### PR TITLE
add USD_INCLUDE_DIR to includes

### DIFF
--- a/plugin/al/CMakeLists.txt
+++ b/plugin/al/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 # to find USD, defined as either Cmake var or env var
 find_package(USD REQUIRED)
 include(${USD_CONFIG_FILE})
+include_directories(${USD_INCLUDE_DIR})
 
 find_package(Maya REQUIRED)
 

--- a/plugin/pxr/CMakeLists.txt
+++ b/plugin/pxr/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(Maya REQUIRED)
 
 find_package(USD REQUIRED)
 include(${USD_CONFIG_FILE})
+include_directories(${USD_INCLUDE_DIR})
 
 pxr_toplevel_prologue()
     add_subdirectory(maya)


### PR DESCRIPTION
So, this may not be necessary / may be due to a problem on my part.  But when I tried to build, it immediately failed, because none of the USD headers could be find.  I couldn't find anywhere in the CMakeLists files that seemed to explicitly add the USD_INCLUDE_DIR to the include path... and when I did, it worked.

However, I assume there must be some other way this is being done for you folks, or else you'd obviously never have been able to build... so maybe I'm missing something?