### PR TITLE
support setting of PXR_USD_LOCATION hint via an env var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ endif()
 
 include(cmake/python.cmake)
 include(cmake/utils.cmake)
+
+find_package(USD REQUIRED)
 include(cmake/usd.cmake)
 
 #==============================================================================

--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -28,7 +28,7 @@ find_library(USD_LIBRARY
     PATH_SUFFIXES
         lib
     DOC
-        "USD Librarires directory"
+        "Main USD library"
 )
 
 get_filename_component(USD_LIBRARY_DIR ${USD_LIBRARY} DIRECTORY)
@@ -54,6 +54,21 @@ find_file(USD_CONFIG_FILE
     DOC "USD cmake configuration file"
 )
 
+# ensure PXR_USD_LOCATION is defined
+if(NOT DEFINED PXR_USD_LOCATION)
+    if(DEFINED ENV{PXR_USD_LOCATION})
+        set(PXR_USD_LOCATION "$ENV{PXR_USD_LOCATION}")
+    else()
+        get_filename_component(PXR_USD_LOCATION "${USD_CONFIG_FILE}" DIRECTORY)
+    endif()
+endif()
+
+# account for possibility that PXR_USD_LOCATION was passed in as a hint-list
+list(LENGTH PXR_USD_LOCATION listlen)
+if(listlen GREATER 1)
+    get_filename_component(PXR_USD_LOCATION "${USD_CONFIG_FILE}" DIRECTORY)
+endif()
+
 if(USD_INCLUDE_DIR AND EXISTS "${USD_INCLUDE_DIR}/pxr/pxr.h")
     foreach(_usd_comp MAJOR MINOR PATCH)
         file(STRINGS
@@ -69,10 +84,11 @@ include(FindPackageHandleStandardArgs)
 
 find_package_handle_standard_args(
     USD
-    REQUIRED_VARS
+REQUIRED_VARS
+    PXR_USD_LOCATION
     USD_INCLUDE_DIR
     USD_LIBRARY_DIR
     USD_GENSCHEMA
     USD_CONFIG_FILE
-    VERSION_VAR
+VERSION_VAR
     USD_VERSION)

--- a/cmake/usd.cmake
+++ b/cmake/usd.cmake
@@ -18,10 +18,6 @@
 
 
 function(init_usd)
-    set(PXR_USD_LOCATION "${PXR_USD_LOCATION}" PARENT_SCOPE)
-    set(PXR_USD_INCLUDE_DIR "${PXR_USD_LOCATION}/include" PARENT_SCOPE)
-    set(PXR_USD_LIB_DIR "${PXR_USD_LOCATION}/lib" PARENT_SCOPE)
-
     # Adjust PYTHONPATH, PATH
     append_path_to_env_var("PYTHONPATH" "${PXR_USD_LOCATION}/lib/python")
     if(WIN32)

--- a/plugin/al/CMakeLists.txt
+++ b/plugin/al/CMakeLists.txt
@@ -23,10 +23,6 @@ else()
     set(CMAKE_WANT_UFE_BUILD ON)
 endif()
 
-# AL_USDMAYA uses pxrConfig.cmake exported targets
-# find_package(USD) can use either ${PXR_USD_LOCATION}, or ${USD_CONFIG_FILE} (which should be ${PXR_USD_LOCATION}/pxrConfig.cmake)
-# to find USD, defined as either Cmake var or env var
-find_package(USD REQUIRED)
 include(${USD_CONFIG_FILE})
 
 find_package(Maya REQUIRED)

--- a/plugin/pxr/CMakeLists.txt
+++ b/plugin/pxr/CMakeLists.txt
@@ -20,7 +20,6 @@ pxr_setup_python()
 #==============================================================================
 find_package(Maya REQUIRED)
 
-find_package(USD REQUIRED)
 include(${USD_CONFIG_FILE})
 
 pxr_toplevel_prologue()


### PR DESCRIPTION
FindUSD.cmake supports using an env var for PXR_USD_LOCATION, but
it never guarantees that the corresponding cmake-var is set... even though other
build files rely on it existing.

This ensures that the cmake-var for PXR_USD_LOCATION is set, which means you can safely use ENV{PXR_USD_LOCATION}.  (Also, ensuring PXR_USD_LOCATION is set before using is a good cmake practice in general.)