### PR TITLE
use std::function instead of boost::function

### DIFF
--- a/lib/fileio/shading/shadingModeImporter.h
+++ b/lib/fileio/shading/shadingModeImporter.h
@@ -33,6 +33,8 @@
 
 #include <maya/MObject.h>
 
+#include <functional>
+
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -145,7 +147,7 @@ private:
     TfToken _volumeShaderPlugName;
     TfToken _displacementShaderPlugName;
 };
-typedef boost::function< MObject (UsdMayaShadingModeImportContext*) > UsdMayaShadingModeImporter;
+typedef std::function< MObject (UsdMayaShadingModeImportContext*) > UsdMayaShadingModeImporter;
 
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
for consistency with rest of code base, fewer dependencies (because project
requires c++11), and because I got a build error becuase boost::function
had only been forward declared