### PR TITLE
Use CMake variables to fully configure mayaUSD.mod

### DIFF
--- a/mayaUSD.mod.template
+++ b/mayaUSD.mod.template
@@ -1,9 +1,9 @@
-+ USD <USD_VERSION> <PATH_TO_PXR_USD_DIR>
++ USD ${USD_VERSION} ${PXR_USD_LOCATION}
 PYTHONPATH+:=lib/python
 PATH+:=bin
 PATH+:=lib
 
-+ PXR_USDMAYA <USD_VERSION> <PATH_TO_PXR_USDMAYA_DIR>
++ PXR_USDMAYA ${USD_VERSION} ${CMAKE_INSTALL_PREFIX}/plugin/pxr
 PYTHONPATH+:=lib/python
 PATH+:=maya/lib
 XBMLANGPATH+:=maya/lib/usd/usdMaya/resources
@@ -11,7 +11,7 @@ MAYA_SCRIPT_PATH+:=maya/lib/usd/usdMaya/resources
 MAYA_PLUG_IN_PATH+:=maya/plugin
 PXR_PLUGINPATH_NAME+:=lib/usd
 
-+ AL_USDMaya <AL_MAYAUSD_VER> <PATH_TO_AL_USDMaya_DIR>
++ AL_USDMaya ${AL_USDMAYA_VERSION} ${CMAKE_INSTALL_PREFIX}/plugin/al
 PYTHONPATH+:=lib/python
 PATH+:=lib
 MAYA_PLUG_IN_PATH+:=plugin

--- a/plugin/al/lib/AL_USDMaya/CMakeLists.txt
+++ b/plugin/al/lib/AL_USDMaya/CMakeLists.txt
@@ -16,6 +16,7 @@ list(APPEND AL_usdmaya_headers
         AL/usdmaya/TypeIDs.h
         AL/usdmaya/ForwardDeclares.h
         AL/usdmaya/Global.h
+        AL/usdmaya/Version.h
 )
 
 list(APPEND AL_usdmaya_source

--- a/plugin/al/lib/AL_USDMaya/CMakeLists.txt
+++ b/plugin/al/lib/AL_USDMaya/CMakeLists.txt
@@ -333,3 +333,14 @@ install( FILES
             ${AL_usdmaya_fileio_translators_headers}
         DESTINATION ${CMAKE_INSTALL_PREFIX}/include/AL/usdmaya/fileio/translators
 )
+
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/AL/usdmaya/Version.h")
+    foreach(_version_comp MAJOR MINOR PATCH)
+        file(STRINGS
+            "${CMAKE_CURRENT_LIST_DIR}/AL/usdmaya/Version.h"
+            _version_comp_def
+            REGEX "#define AL_USDMAYA_VERSION_${_version_comp} .*$")
+        string(REGEX MATCHALL "[0-9]+" AL_USDMAYA_${_version_comp}_VERSION ${_version_comp_def})
+    endforeach()
+    set(AL_USDMAYA_VERSION ${AL_USDMAYA_MAJOR_VERSION}.${AL_USDMAYA_MINOR_VERSION}.${AL_USDMAYA_PATCH_VERSION} CACHE INTERNAL "AL_USDMaya Version String")
+endif()


### PR DESCRIPTION
Hi all,

I'm not sure if you had other plans for this file, but wanted to see what you thought of this.

The two main changes here are extracting the AL_USDMaya version from its Version.h (and including that header in the build), and then using that along with the other existing CMake variables in mayaUSD.mod.template for the fields that needs to be replaced.

With these changes, my builds end up producing a mayaUSD.mod file that looks like this:
```
+ USD 0.19.10 /pixar/ws/trees/mattjohnson/usd_open_source/build/inst
PYTHONPATH+:=lib/python
PATH+:=bin
PATH+:=lib

+ PXR_USDMAYA 0.19.10 /home/mattjohnson/local/open_source_projects/maya-usd/build/install/RelWithDebInfo/plugin/pxr
PYTHONPATH+:=lib/python
PATH+:=maya/lib
XBMLANGPATH+:=maya/lib/usd/usdMaya/resources
MAYA_SCRIPT_PATH+:=maya/lib/usd/usdMaya/resources
MAYA_PLUG_IN_PATH+:=maya/plugin
PXR_PLUGINPATH_NAME+:=lib/usd

+ AL_USDMaya 0.32.15 /home/mattjohnson/local/open_source_projects/maya-usd/build/install/RelWithDebInfo/plugin/al
PYTHONPATH+:=lib/python
PATH+:=lib
MAYA_PLUG_IN_PATH+:=plugin
PXR_PLUGINPATH_NAME+:=lib/usd
```

And I can then launch Maya with the path to the file in my MAYA_MODULE_PATH and load the plugins without having to edit it further.

Let me know what you think! Thanks!