### PR TITLE
Two bug fixes related to viewport selection

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.cpp
@@ -1161,7 +1161,7 @@ MStatus ProxyShapePostSelect::redoIt()
   MSelectionList sl;
   MGlobal::getActiveSelectionList(sl);
   MString command;
-  MFnDependencyNode depNode(m_proxy->thisMObject());
+  MFnDagNode fn(m_proxy->thisMObject());
   for (const auto& path : m_proxy->selectedPaths()) {
     auto obj = m_proxy->findRequiredPath(path);
     if (obj != MObject::kNullObj) {
@@ -1172,7 +1172,7 @@ MStatus ProxyShapePostSelect::redoIt()
         command += "AL_usdmaya_ProxyShapeSelect -i -d -pp \"";
         command += path.GetText();
         command += "\" \"";
-        command += depNode.name();
+        command += fn.fullPathName();
         command += "\";";
       }
     }

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -522,6 +522,8 @@ bool ProxyDrawOverride::userSelect(
 {
   TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyDrawOverride::userSelect\n");
 
+  MString fullSelPath = objPath.fullPathName();
+
   if(!MGlobal::optionVarIntValue("AL_usdmaya_selectionEnabled"))
     return false;
 
@@ -569,6 +571,10 @@ bool ProxyDrawOverride::userSelect(
   auto* proxyShape = static_cast<ProxyShape*>(getShape(objPath));
   auto engine = proxyShape->engine();
   if (!engine) return false;
+
+  // The commands we execute inside this function shouldn't do special
+  // processing of the proxy we are currently handling here if they
+  // should run across it.
   proxyShape->m_pleaseIgnoreSelection = true;
 
   UsdImagingGLRenderParams params;
@@ -630,7 +636,7 @@ bool ProxyDrawOverride::userSelect(
         MDagPath dg;
         dagNode.getPath(dg);
         const double* p = it.second.worldSpaceHitPoint.GetArray();
-        
+
         selectionList.add(dg);
         worldSpaceHitPts.append(MPoint(p[0], p[1], p[2]));
       }
@@ -684,18 +690,16 @@ bool ProxyDrawOverride::userSelect(
         command += "\"";
       }
 
-      MFnDependencyNode fn(proxyShape->thisMObject());
       command += " \"";
-      command += fn.name();
+      command += fullSelPath;
       command += "\"";
       MGlobal::executeCommandOnIdle(command, false);
     }
     else
     {
       MString command = "AL_usdmaya_ProxyShapeSelect -cl ";
-      MFnDependencyNode fn(proxyShape->thisMObject());
       command += " \"";
-      command += fn.name();
+      command += fullSelPath;
       command += "\"";
       MGlobal::executeCommandOnIdle(command, false);
     }
@@ -712,7 +716,7 @@ bool ProxyDrawOverride::userSelect(
         paths.push_back(getHitPath(it));
       };
 
-      // Do to the inaccuracies in the selection method in gl engine
+      // Due to the inaccuracies in the selection method in gl engine
       // we still need to find the closest selection.
       // Around the edges it often selects two or more prims.
       if (selectInfo.singleSelection())
@@ -813,9 +817,8 @@ bool ProxyDrawOverride::userSelect(
         if(!proxyShape->selectedPaths().empty())
         {
           command = "AL_usdmaya_ProxyShapeSelect -i -cl ";
-          MFnDependencyNode fn(proxyShape->thisMObject());
           command += " \"";
-          command += fn.name();
+          command += fullSelPath;
           command += "\";";
         }
 
@@ -828,9 +831,8 @@ bool ProxyDrawOverride::userSelect(
             command += it.GetText();
             command += "\"";
           }
-          MFnDependencyNode fn(proxyShape->thisMObject());
           command += " \"";
-          command += fn.name();
+          command += fullSelPath;
           command += "\"";
 
         }
@@ -855,9 +857,8 @@ bool ProxyDrawOverride::userSelect(
             command += it.GetText();
             command += "\"";
           }
-          MFnDependencyNode fn(proxyShape->thisMObject());
           command += " \"";
-          command += fn.name();
+          command += fullSelPath;
           command += "\"";
         }
 
@@ -880,12 +881,10 @@ bool ProxyDrawOverride::userSelect(
             command += it.GetText();
             command += "\"";
           }
-          MFnDependencyNode fn(proxyShape->thisMObject());
           command += " \"";
-          command += fn.name();
+          command += fullSelPath;
           command += "\"";
           MGlobal::executeCommandOnIdle(command, false);
-          
         }
       }
       break;
@@ -924,12 +923,11 @@ bool ProxyDrawOverride::userSelect(
             hasSelectedItems = true;
           }
         }
-        MFnDependencyNode fn(proxyShape->thisMObject());
         selectcommand += " \"";
-        selectcommand += fn.name();
+        selectcommand += fullSelPath;
         selectcommand += "\"";
         deselectcommand += " \"";
-        deselectcommand += fn.name();
+        deselectcommand += fullSelPath;
         deselectcommand += "\"";
 
         if(hasSelectedItems)
@@ -946,8 +944,7 @@ bool ProxyDrawOverride::userSelect(
       }
 
       MString final_command = "AL_usdmaya_ProxyShapePostSelect \"";
-      MFnDependencyNode fn(proxyShape->thisMObject());
-      final_command += fn.name();
+      final_command += fullSelPath;
       final_command += "\"";
       proxyShape->setChangedSelectionState(true);
       MGlobal::executeCommandOnIdle(final_command, false);
@@ -957,6 +954,10 @@ bool ProxyDrawOverride::userSelect(
   }
 
   ProxyDrawOverrideSelectionHelper::m_paths.clear();
+
+  // We are done executing commands that needed to handle our current
+  // proxy as a special case.  Unset the ignore state on the proxy.
+  proxyShape->m_pleaseIgnoreSelection = false;
   
   return selected;
 }

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeSelection.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeSelection.cpp
@@ -115,13 +115,13 @@ void ProxyShape::onSelectionChanged(void* ptr)
     fnDag.setObject(proxy->thisMObject());
 
     command += " \"";
-    command += fnDag.name().asChar();
+    command += fnDag.fullPathName();
     command += "\"";
 
     if(hasNewItems)
     {
       precommand += " \"";
-      precommand += fnDag.name().asChar();
+      precommand += fnDag.fullPathName();
       precommand += "\";";
       if(!unselectedSet.empty())
       {
@@ -178,7 +178,6 @@ void ProxyShape::onSelectionChanged(void* ptr)
     for(auto selected : proxy->selectedPaths())
     {
       MObject obj = proxy->findRequiredPath(selected);
-      MFnDependencyNode fn(obj);
       if(!hasObject(sl, obj))
       {
         hasItems = true;
@@ -193,7 +192,6 @@ void ProxyShape::onSelectionChanged(void* ptr)
     {
       MObject obj;
       sl.getDependNode(i, obj);
-      MFnDependencyNode fn(obj);
       SdfPath path;
       if(!proxy->isSelectedMObject(obj, path))
       {
@@ -211,12 +209,12 @@ void ProxyShape::onSelectionChanged(void* ptr)
     {
       MFnDagNode fnDag(proxy->thisMObject());
       command += " \"";
-      command += fnDag.name().asChar();
+      command += fnDag.fullPathName();
       command += "\"";
       if(hasNewItems)
       {
         precommand += " \"";
-        precommand += fnDag.name().asChar();
+        precommand += fnDag.fullPathName();
         precommand += "\";";
         command = precommand + command;
       }
@@ -229,7 +227,7 @@ void ProxyShape::onSelectionChanged(void* ptr)
     {
       MFnDagNode fnDag(proxy->thisMObject());
       precommand += " \"";
-      precommand += fnDag.name().asChar();
+      precommand += fnDag.fullPathName();
       precommand += "\";";
       proxy->m_pleaseIgnoreSelection = true;
       MGlobal::executeCommand(precommand, false, true);

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
@@ -454,18 +454,18 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
         command += "\"";
       }
 
-      MFnDependencyNode fn(proxyShape->thisMObject());
+      MFnDagNode fn(proxyShape->thisMObject());
       command += " \"";
-      command += fn.name();
+      command += fn.fullPathName();
       command += "\"";
       MGlobal::executeCommandOnIdle(command, false);
     }
     else
     {
       MString command = "AL_usdmaya_ProxyShapeSelect -cl ";
-      MFnDependencyNode fn(proxyShape->thisMObject());
+      MFnDagNode fn(proxyShape->thisMObject());
       command += " \"";
-      command += fn.name();
+      command += fn.fullPathName();
       command += "\"";
       MGlobal::executeCommandOnIdle(command, false);
     }
@@ -619,9 +619,9 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
         if(!proxyShape->selectedPaths().empty())
         {
           command = "AL_usdmaya_ProxyShapeSelect -i -cl ";
-          MFnDependencyNode fn(proxyShape->thisMObject());
+          MFnDagNode fn(proxyShape->thisMObject());
           command += " \"";
-          command += fn.name();
+          command += fn.fullPathName();
           command += "\";";
         }
 
@@ -634,9 +634,9 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
             command += it.GetText();
             command += "\"";
           }
-          MFnDependencyNode fn(proxyShape->thisMObject());
+          MFnDagNode fn(proxyShape->thisMObject());
           command += " \"";
-          command += fn.name();
+          command += fn.fullPathName();
           command += "\"";
 
         }
@@ -661,9 +661,9 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
             command += it.GetText();
             command += "\"";
           }
-          MFnDependencyNode fn(proxyShape->thisMObject());
+          MFnDagNode fn(proxyShape->thisMObject());
           command += " \"";
-          command += fn.name();
+          command += fn.fullPathName();
           command += "\"";
         }
 
@@ -686,9 +686,9 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
             command += it.GetText();
             command += "\"";
           }
-          MFnDependencyNode fn(proxyShape->thisMObject());
+          MFnDagNode fn(proxyShape->thisMObject());
           command += " \"";
-          command += fn.name();
+          command += fn.fullPathName();
           command += "\"";
           MGlobal::executeCommandOnIdle(command, false);
         }
@@ -729,12 +729,12 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
             hasSelectedItems = true;
           }
         }
-        MFnDependencyNode fn(proxyShape->thisMObject());
+        MFnDagNode fn(proxyShape->thisMObject());
         selectcommand += " \"";
-        selectcommand += fn.name();
+        selectcommand += fn.fullPathName();
         selectcommand += "\"";
         deselectcommand += " \"";
-        deselectcommand += fn.name();
+        deselectcommand += fn.fullPathName();
         deselectcommand += "\"";
 
         if(hasSelectedItems)
@@ -751,8 +751,8 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
     }
 
     MString final_command = "AL_usdmaya_ProxyShapePostSelect \"";
-    MFnDependencyNode fn(proxyShape->thisMObject());
-    final_command += fn.name();
+    MFnDagNode fn(proxyShape->thisMObject());
+    final_command += fn.fullPathName();
     final_command += "\"";
     proxyShape->setChangedSelectionState(true);
     MGlobal::executeCommandOnIdle(final_command, false);


### PR DESCRIPTION
- Viewport selection problems when we have duplicate proxy names
- Sometimes shift-selecting several objects which have duplicate proxy names
  in the viewport, then clicking somewhere else in the viewport, which should
  clear the selection, clears the selection but leaves one or more of the
  objects highlighted in the viewport. (The cause of this was ProxyDrawOverride
  was setting m_pleaseIgnoreSelection - a temporary state - but then neglecting
  to unset it.)