### PR TITLE
'Always' from X.h conflicts with USD when maya/M3dView.h is included

### DIFF
--- a/plugin/pxr/maya/lib/pxrUsdMayaGL/shapeAdapter.h
+++ b/plugin/pxr/maya/lib/pxrUsdMayaGL/shapeAdapter.h
@@ -36,6 +36,7 @@
 #include "pxr/usd/sdf/types.h"
 
 #include <maya/M3dView.h>
+#undef Always // Defined in /usr/lib/X11/X.h (eventually included by M3dView.h) - breaks pxr/usd/lib/usdUtils/registeredVariantSet.h
 #include <maya/MBoundingBox.h>
 #include <maya/MColor.h>
 #include <maya/MDagPath.h>


### PR DESCRIPTION
Requested by @kxl-adsk 