### PR TITLE
some functions weren't returning a value

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/wrapTranslatorBase.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/wrapTranslatorBase.cpp
@@ -128,6 +128,7 @@ public:
             (TfPyCall<bool>(o))(prim, path.fullPathName().asChar());
         return res ? MS::kSuccess : MS::kFailure;
     }
+    return MS::kSuccess;
   }
 
   MStatus postImport(const UsdPrim& prim) override
@@ -136,6 +137,7 @@ public:
         auto res = std::function<bool (const UsdPrim&)>(TfPyCall<bool>(o))(prim);
         return res ? MS::kSuccess : MS::kFailure;
     }
+    return MS::kSuccess;
   }
     
   MStatus preTearDown(UsdPrim& prim) override


### PR DESCRIPTION
Happened to notice a few warnings about functions missing return values.

Longer term, I'd like to get PXR_STRICT_BUILD_MODE (or an equivalent) working, so we can error on all the warnings...