### PR TITLE
replace use of auto with full type name when getting Ufe::HierarchyHandler::Ptr

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -762,7 +762,8 @@ bool ProxyDrawOverride::userSelect(
     if (ArchHasEnv("MAYA_WANT_UFE_SELECTION"))
     {
       // Get the Hierarchy Handler of USD - Id = 2
-      auto handler{ Ufe::RunTimeMgr::instance().hierarchyHandler(2) };
+      Ufe::HierarchyHandler::Ptr handler =
+        Ufe::RunTimeMgr::instance().hierarchyHandler(2);
       if (handler == nullptr)
       {
         MGlobal::displayError("USD Hierarchy handler has not been loaded - Picking is not possible");

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
@@ -541,7 +541,8 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
     }
 #if defined(WANT_UFE_BUILD)
     if (ArchHasEnv("MAYA_WANT_UFE_SELECTION")) {
-        auto handler{ Ufe::RunTimeMgr::instance().hierarchyHandler(USD_UFE_RUNTIME_ID) };
+        Ufe::HierarchyHandler::Ptr handler =
+            Ufe::RunTimeMgr::instance().hierarchyHandler(USD_UFE_RUNTIME_ID);
         if (handler == nullptr) {
             MGlobal::displayError("USD Hierarchy handler has not been loaded - Picking is not possible");
             return false;


### PR DESCRIPTION
This resolves a template deduction/substitution compilation error encountered
when building with gcc 4.8.3 on Linux.