### PR TITLE
[al] TransformMatrix should use xformable, not xform

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
@@ -112,14 +112,14 @@ void TransformationMatrix::setPrim(const UsdPrim& prim, Transform* transformNode
   {
     TF_DEBUG(ALUSDMAYA_TRANSFORM_MATRIX).Msg("TransformationMatrix::setPrim %s\n", prim.GetName().GetText());
     m_prim = prim;
-    UsdGeomXform xform(prim);
+    UsdGeomXformable xform(prim);
     m_xform = xform;
   }
   else
   {
     TF_DEBUG(ALUSDMAYA_TRANSFORM_MATRIX).Msg("TransformationMatrix::setPrim null\n");
     m_prim = UsdPrim();
-    m_xform = UsdGeomXform();
+    m_xform = UsdGeomXformable();
   }
   // Most of these flags are calculated based on reading the usd prim; however, a few are driven
   // "externally" (ie, from attributes on the controlling transform node), and should NOT be reset

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.h
@@ -21,7 +21,7 @@
 #include "maya/MPxTransformationMatrix.h"
 #include "maya/MPxTransform.h"
 
-#include "pxr/usd/usdGeom/xform.h"
+#include "pxr/usd/usdGeom/xformable.h"
 #include "pxr/usd/usdGeom/xformCommonAPI.h"
 
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -40,7 +40,7 @@ class TransformationMatrix
   : public MPxTransformationMatrix
 {
   UsdPrim m_prim;
-  UsdGeomXform m_xform;
+  UsdGeomXformable m_xform;
   UsdTimeCode m_time;
   std::vector<UsdGeomXformOp> m_xformops;
   std::vector<TransformOperation> m_orderedOps;


### PR DESCRIPTION
"collapsed" xforms - ie, a Mesh node with a transform directly applied on it, and no Xform parent - is technically not comatible with UsdGeom.Xform - just UsdGeom.Xformable.

This has mostly gone unnoticed because calls to methods on parent schemas still "work" - however, a check such as `if(m_xform)` will fail.