### PR TITLE
[al] Make AL's cmake confirm that date_time lib is available on windows

### DIFF
--- a/plugin/al/CMakeLists.txt
+++ b/plugin/al/CMakeLists.txt
@@ -53,6 +53,7 @@ set(Boost_FIND_COMPONENTS
 if(WIN32)
     list(APPEND Boost_FIND_COMPONENTS
         chrono
+        date_time
     )
 endif()
 


### PR DESCRIPTION
...since it requires it, better to fail early

Note that I confirmed this change is not in PR91 yet; however, this is obviously low priority.  Just happened to notice this when doing a test build on windows...