### PR TITLE
Fixes issues with PXR_LIB_PREFIX

### DIFF
--- a/cmake/defaults/Options.cmake
+++ b/cmake/defaults/Options.cmake
@@ -56,12 +56,6 @@ set(PXR_OBJECT_LIBS ""
     "Aggregation of all core libraries built as OBJECT libraries."
 )
 
-set(PXR_LIB_PREFIX "lib"
-    CACHE
-    STRING
-    "Prefix for build library name"
-)
-
 option(BUILD_SHARED_LIBS "Build shared libraries." ON)
 option(PXR_BUILD_MONOLITHIC "Build a monolithic library." OFF)
 set(PXR_MONOLITHIC_IMPORT ""

--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -1,5 +1,26 @@
 # Simple module to find USD.
 
+# Note that on Windows with USD <= 0.19.11, USD_LIB_PREFIX should be left at
+# default (or set to empty string), even if PXR_LIB_PREFIX was specified when
+# building core USD, due to a bug.
+
+# On all other platforms / versions, it should match the PXR_LIB_PREFIX used
+# for building USD (and shouldn't need to be touched if PXR_LIB_PREFIX was not
+# used / left at it's default value).
+
+set(USD_LIB_PREFIX ${CMAKE_SHARED_LIBRARY_PREFIX}
+    CACHE STRING "Prefix of USD libraries; generally matches the PXR_LIB_PREFIX used when building core USD")
+
+if (WIN32)
+    # ".lib" on Windows
+    set(USD_LIB_SUFFIX ${CMAKE_STATIC_LIBRARY_SUFFIX}
+        CACHE STRING "Extension of USD libraries")
+else ()
+    # ".so" on Linux, ".dylib" on MacOS
+    set(USD_LIB_SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX}
+        CACHE STRING "Extension of USD libraries")
+endif ()
+
 # On a system with an existing USD /usr/local installation added to the system
 # PATH, use of PATHS in find_path incorrectly causes the existing USD
 # installation to be found.  As per
@@ -21,7 +42,7 @@ find_path(USD_INCLUDE_DIR
 
 find_library(USD_LIBRARY
     NAMES
-        usd
+        ${USD_LIB_PREFIX}usd${USD_LIB_SUFFIX}
     HINTS
         ${PXR_USD_LOCATION}
         $ENV{PXR_USD_LOCATION}

--- a/plugin/pxr/cmake/macros/Public.cmake
+++ b/plugin/pxr/cmake/macros/Public.cmake
@@ -125,7 +125,7 @@ function(pxr_library NAME)
             endif()
         endif()
 
-        set(prefix "${PXR_LIB_PREFIX}")
+        set(prefix "${CMAKE_SHARED_LIBRARY_PREFIX}")
         if(args_TYPE STREQUAL "STATIC")
             set(suffix ${CMAKE_STATIC_LIBRARY_SUFFIX})
         else()
@@ -690,7 +690,6 @@ function(pxr_toplevel_prologue)
             set_target_properties(usd_ms
                 PROPERTIES
                     FOLDER "${folder}"
-                    PREFIX "${PXR_LIB_PREFIX}"
             )
             _get_install_dir("lib" libInstallPrefix)
             install(
@@ -824,7 +823,6 @@ function(pxr_monolithic_epilogue)
         PROPERTIES
             FOLDER "${folder}"
             POSITION_INDEPENDENT_CODE ON
-            PREFIX "${PXR_LIB_PREFIX}"
     )
 
     # Adding $<TARGET_OBJECTS:foo> will not bring along compile


### PR DESCRIPTION
- disable setting of custom output lib prefixes (for maya-usd outputs) via PXR_LIB_PREFIX
- enable finding of USD-core built with a custom PXR_LIB_PREFIX (via USD_LIB_PREFIX)