### PR TITLE
sanitize the proxy's UsdImagingDelegate name before using it to construct the delegateId

### DIFF
--- a/lib/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -18,6 +18,7 @@
 #include "render_delegate.h"
 
 #include "pxr/base/tf/diagnostic.h"
+#include "pxr/base/tf/stringUtils.h"
 #include "pxr/usdImaging/usdImaging/delegate.h"
 #include "pxr/imaging/hdx/renderTask.h"
 #include "pxr/imaging/hdx/selectionTracker.h"
@@ -190,8 +191,16 @@ void ProxyRenderDelegate::_InitRenderDelegate() {
         MProfilingScope subProfilingScope(HdVP2RenderDelegate::sProfilerCategory,
             MProfiler::kColorD_L1, "Allocate SceneDelegate");
 
-        SdfPath delegateID = SdfPath::AbsoluteRootPath().AppendChild(TfToken(TfStringPrintf(
-            "Proxy_%s_%p", usdSubSceneShape->name().asChar(), usdSubSceneShape)));
+        // Make sure the delegate name is a valid identifier, since it may
+        // include colons if the proxy node is in a Maya namespace.
+        const std::string delegateName =
+            TfMakeValidIdentifier(
+                TfStringPrintf(
+                    "Proxy_%s_%p",
+                    usdSubSceneShape->name().asChar(),
+                    usdSubSceneShape));
+        const SdfPath delegateID =
+            SdfPath::AbsoluteRootPath().AppendChild(TfToken(delegateName));
 
         _sceneDelegate = new UsdImagingDelegate(_renderIndex, delegateID);
 


### PR DESCRIPTION
When a proxy node lives inside a Maya namespace (as is the case when a `pxrUsdReferenceAssembly` node is loaded in its `Collapsed` representation), its name will include colon characters which are invalid in identifier names used in prim paths. This change ensures that the delegate name is a valid identifier before we try to create an `SdfPath` from it.

This fixes an issue where `pxrUsdReferenceAssembly` nodes would not draw correctly and Hydra errors would be spewed when `VP2_RENDER_DELEGATE_PROXY` was enabled.