### PR TITLE
misc fixes to paths to get AL pxrUsdTranslators tests running

### DIFF
--- a/plugin/al/translators/pxrUsdTranslators/tests/CMakeLists.txt
+++ b/plugin/al/translators/pxrUsdTranslators/tests/CMakeLists.txt
@@ -6,5 +6,5 @@ add_test(
         ${CMAKE_INSTALL_PREFIX}
         ${USD_LIBRARY_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}
-        ${USD_MAYA_ROOT}
+        ${CMAKE_INSTALL_PREFIX}/../../plugin/pxr
     )

--- a/plugin/al/translators/pxrUsdTranslators/tests/testPxrTranslators.sh
+++ b/plugin/al/translators/pxrUsdTranslators/tests/testPxrTranslators.sh
@@ -2,20 +2,14 @@
 
 export AL_USDMAYA_LOCATION=$1
 export USD_LIBRARY_PATH=$2
-export MAYA_PLUG_IN_PATH=$AL_USDMAYA_LOCATION/plugin:$4/maya/plugin:$MAYA_PLUG_IN_PATH
+export TEST_DIR=$3
+export PXR_USDMAYA_LOCATION=$4
+export MAYA_PLUG_IN_PATH=$AL_USDMAYA_LOCATION/plugin:$PXR_USDMAYA_LOCATION/maya/plugin:$MAYA_PLUG_IN_PATH
 export LD_LIBRARY_PATH=$AL_USDMAYA_LOCATION/lib:$USD_LIBRARY_PATH:$LD_LIBRARY_PATH
-export PYTHONPATH=$AL_USDMAYA_LOCATION/lib/python:$USD_LIBRARY_PATH/python:$3:$PYTHONPATH
+export PYTHONPATH=$AL_USDMAYA_LOCATION/lib/python:$PXR_USDMAYA_LOCATION/lib/python:$USD_LIBRARY_PATH/python:$TEST_DIR:$PYTHONPATH
 export PXR_PLUGINPATH_NAME=$AL_USDMAYA_LOCATION/plugin:$PXR_PLUGINPATH_NAME
 export PATH=$MAYA_LOCATION/bin:$PATH
-export TEST_DIR=$3
 
-# if usd_maya installed in separate location than usd, need to make sure it
-# comes BEFORE usd's python on the path, so it's "pxr" pacakge is picked up
-# first
-if [[ -n "${USD_MAYA_ROOT}" ]]; then
-	export PYTHONPATH="${USD_MAYA_ROOT}/lib/python:${PYTHONPATH}"
-fi
-
-maya -batch -command "python(\"execfile(\\\"$3/testPxrTranslators.py\\\")\")"
+maya -batch -command "python(\"execfile(\\\"$TEST_DIR/testPxrTranslators.py\\\")\")"
 
 exit $?


### PR DESCRIPTION
- $USD_MAYA_ROOT not defined / needed (should always be part of this project)
- made sure that the pixar maya plugin's python dir is added to the
  pythonpath before the main USD python dir; this is necessary because the
  pixar maya plugin also defines a pxr/__init__.py, which needs to come
  before the main USD pxr/__init__.py
- created / used explicit names in place of some $# variables (ie, $3 / $4),
  for clarity