### PR TITLE
only register VP2.0 fragments when in interactive sessions of Maya

### DIFF
--- a/lib/render/vp2ShaderFragments/shaderFragments.cpp
+++ b/lib/render/vp2ShaderFragments/shaderFragments.cpp
@@ -110,6 +110,11 @@ namespace
 // Fragment registration
 MStatus HdVP2ShaderFragments::registerFragments()
 {
+    if (MGlobal::mayaState() != MGlobal::kInteractive) {
+        // Only register fragments in interactive Maya sessions.
+        return MS::kSuccess;
+    }
+
     MHWRender::MRenderer* theRenderer = MHWRender::MRenderer::theRenderer();
     if (!theRenderer) {
         return MS::kFailure;
@@ -176,6 +181,11 @@ MStatus HdVP2ShaderFragments::registerFragments()
 // Fragment deregistration
 MStatus HdVP2ShaderFragments::deregisterFragments()
 {
+    if (MGlobal::mayaState() != MGlobal::kInteractive) {
+        // Only deregister fragments in interactive Maya sessions.
+        return MS::kSuccess;
+    }
+
     MHWRender::MRenderer* theRenderer = MHWRender::MRenderer::theRenderer();
     if (!theRenderer) {
         return MS::kFailure;


### PR DESCRIPTION
Registering the fragments fails when in non-interactive sessions of Maya. This mainly prevents errors from being emitted during tests when plugins are initialized.