### PR TITLE
[al] make pushToPrim default to On

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/PluginRegister.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/PluginRegister.h
@@ -211,7 +211,7 @@ MStatus registerPlugin(AFnPlugin& plugin)
 
   if(!MGlobal::optionVarExists("AL_usdmaya_pushToPrim"))
   {
-    MGlobal::setOptionVarValue("AL_usdmaya_pushToPrim", false);
+    MGlobal::setOptionVarValue("AL_usdmaya_pushToPrim", true);
   }
 
   MStatus status;


### PR DESCRIPTION
...a recent AL change (55e01cf9e52d14069f86763bf447a9c6ee7650a9) added
the ability to control the setting for pushToPrim for newly created
nodes via an optionVar, which is useful, but it also changed the default
from on to off.

In addition to being breaking behavior, this is also highly
non-intuitive for artists, who will be confused when they try to
transform the usd object, and it does nothing.  I would also argue that
the ability to pushToPrim is the primary thing which distinguishes this
plugin from the Pixar plugin, and as such, is probably why most people
are using it in the first place.

NOTE: I haven't yet run the tests for this, as the tests are still not fully functional on the dev branch.  Assuming we agree that this change should be made, we may wish to delay merging it in until the tests work, at which time we can ensure that this modification doesn't require making changes to any tests.