### PR TITLE
Fix #150: Bump minimum required CMake version to 3.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 # =======================================================================
 #
 
-cmake_minimum_required(VERSION 3.1.1)
+cmake_minimum_required(VERSION 3.12.0)
 
 project(maya-usd)
 


### PR DESCRIPTION
This fixes the issue described in #150 by increasing the minimum required CMake version.

_Note: I've just set the version number from the Issue - I haven't tested this myself._

@ryan-seymour could you check whether this captures the older compiler that failed correctly on your end?