### PR TITLE
fix an error on loading plugin, that mayaUsd_ShaderFragments is a folder

### DIFF
--- a/lib/render/vp2ShaderFragments/plugInfo.json
+++ b/lib/render/vp2ShaderFragments/plugInfo.json
@@ -3,10 +3,9 @@
         {
             "Name": "mayaUsd_ShaderFragments", 
             "Info": {}, 
-            "LibraryPath": "../../usd/mayaUsd_ShaderFragments",
             "ResourcePath": "../../usd/mayaUsd_ShaderFragments/resources", 
             "Root": "..", 
-            "Type": "library"
+            "Type": "resource"
         }
     ]
 }


### PR DESCRIPTION
happens because the plugin is marked as a library, instead of a resource,
and specifies a LibraryPath (which it tries to load)