### PR TITLE
make sure stage is set in datablock in ProxyShape::LoadStage

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1484,7 +1484,7 @@ void ProxyShape::loadStage()
           MayaUsdStageData* usdStageData = createData<MayaUsdStageData>(MayaUsdStageData::mayaTypeId, data);
           usdStageData->stage = m_stage;
           usdStageData->primPath = m_path;
-          MStatus status = outputDataValue(dataBlock, outStageData(), usdStageData);
+          outputDataValue(dataBlock, outStageData(), usdStageData);
           
           // Set the edit target to the session layer so any user interaction will wind up there
           m_stage->SetEditTarget(m_stage->GetSessionLayer());

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1479,6 +1479,13 @@ void ProxyShape::loadStage()
           stageId = StageCache::Get().Insert(m_stage);
           outputInt32Value(dataBlock, m_stageCacheId, stageId.ToLongInt());
 
+          // Set the stage in datablock so it's ready in case it needs to be accessed
+          MObject data;
+          MayaUsdStageData* usdStageData = createData<MayaUsdStageData>(MayaUsdStageData::mayaTypeId, data);
+          usdStageData->stage = m_stage;
+          usdStageData->primPath = m_path;
+          MStatus status = outputDataValue(dataBlock, outStageData(), usdStageData);
+          
           // Set the edit target to the session layer so any user interaction will wind up there
           m_stage->SetEditTarget(m_stage->GetSessionLayer());
           // Save the initial edit target


### PR DESCRIPTION
This PR fixes issue #127 

It just makes sure that the stage is set in the data block (in ProxyShape::loadStage()) before sending any notifications or causing side effects.

Inside ProxyShape::loadStage() this call `m_stage->SetEditTarget(m_stage->GetSessionLayer());` causes other events to be triggered. If the stage data is not set in the datablock before this call we experience the error reported in issue #127 