### PR TITLE
Fowlert/ignore vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,13 +4,13 @@
 *.pydevproject
 *.settings/
 *.vs
+*.vscode
 CMakeSettings.json
 CMakeCache.txt
 CMakeLists.txt.user
 CMakeFiles/cmake.check_cache
 *~
 *.orig
-*.vs
 
 *.DS_Store
 *.xcuserstate


### PR DESCRIPTION
There was a duplicate "*.vs" in .gitignore that I believe was supposed to be "*.vscode"