### PR TITLE
Remove old 0.19.05 USD version mention and link to doc/DEVELOPER.md

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -91,7 +91,7 @@ BUILD_PXR_PLUGIN            | Builds the Pixar USD plugin and libraries.        
 
 When building Pixar USD, you need to pass ```--no-maya``` flag to ensure that ```third_party/maya``` plugin doesn't get built since this plugin is now part of maya-usd.
 
-It is important that the version between ```Pixar USD``` and ```Maya USD plugin```match. We are currently using ```v19.05``` for Maya plugin in ```master``` branch and therefore ```Pixar USD``` build should match this version.
+It is important that the version between ```Pixar USD``` and ```Maya USD plugin``` match. See [`doc/DEVELOPER.md`](DEVELOPER.md#source-versions) for the compatible source versions.
 
 ##### Boost:
 


### PR DESCRIPTION
### Issue

The master `/doc/build.md` file still mentioned the build was supposed to run against USD 0.19.05 yet as seen in #189 this actually doesn't work anymore. `/doc/DEVELOPER.md` instead describes the compatible source versions.

_**Warning**: This PR is deliberately set to merge against "master" for #189 to avoid confusion for new users_

This way it'll be more likely for newcomers to actually find the compatible versions to build against.

**Note:**
This same PR should also be cherry-picked for all other branches as it makes sense to have it consistent across the repository. Or, the other way to simplify would be to remove `/doc/DEVELOPER.md` and have the information available in `/doc/build.md`.

### Changes

Remove old 0.19.05 USD version mention in `/doc/build.md` and link to `doc/DEVELOPER.md` instead.