### PR TITLE
add a test to ensure that the AL.usdmaya python lib links correctly

### DIFF
--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/CMakeLists.txt
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/CMakeLists.txt
@@ -20,7 +20,7 @@ separate_argument_list(pythonPath)
 separate_argument_list(mayaPluginPath)
 
 add_test(
-    NAME ${TEST_NAME}
+    NAME TestUSDMayaPython
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND ${MAYA_PY_EXECUTABLE} -c "import sys;from unittest import main;import maya.standalone; \
                                       maya.standalone.initialize(name='python'); \
@@ -35,7 +35,25 @@ add_test(
                                       "
 )
 
-set_property(TEST ${TEST_NAME} APPEND PROPERTY ENVIRONMENT 
+set_property(TEST TestUSDMayaPython APPEND PROPERTY ENVIRONMENT 
+    "PYTHONPATH=${pythonPath}"
+    "PATH=${path}"
+    "MAYA_PLUG_IN_PATH=${mayaPluginPath}"
+    "PXR_PLUGINPATH_NAME=${CMAKE_INSTALL_PREFIX}/lib/usd"
+    "MAYA_NO_STANDALONE_ATEXIT=1"
+)
+
+add_test(
+    NAME TestUSDMayaPythonModuleOnly
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    # Note that, since this test does NOT call maya.standalone.initialize, we can
+    # just let unittest.main call sys.exit "normally"
+    COMMAND ${MAYA_PY_EXECUTABLE} -c "import sys;from unittest import main; \
+                                      import testUSDMayaPythonModuleOnly; testProg = main(module=testUSDMayaPythonModuleOnly); \
+                                      "
+)
+
+set_property(TEST TestUSDMayaPythonModuleOnly APPEND PROPERTY ENVIRONMENT 
     "PYTHONPATH=${pythonPath}"
     "PATH=${path}"
     "MAYA_PLUG_IN_PATH=${mayaPluginPath}"

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/CMakeLists.txt
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(TEST_NAME TestUSDMayaPython)
+set(MAIN_TEST_NAME TestUSDMayaPython)
 
 set(path 
     "${CMAKE_INSTALL_PREFIX}/lib"
@@ -20,7 +20,7 @@ separate_argument_list(pythonPath)
 separate_argument_list(mayaPluginPath)
 
 add_test(
-    NAME TestUSDMayaPython
+    NAME ${MAIN_TEST_NAME}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND ${MAYA_PY_EXECUTABLE} -c "import sys;from unittest import main;import maya.standalone; \
                                       maya.standalone.initialize(name='python'); \
@@ -35,7 +35,7 @@ add_test(
                                       "
 )
 
-set_property(TEST TestUSDMayaPython APPEND PROPERTY ENVIRONMENT 
+set_property(TEST ${MAIN_TEST_NAME} APPEND PROPERTY ENVIRONMENT
     "PYTHONPATH=${pythonPath}"
     "PATH=${path}"
     "MAYA_PLUG_IN_PATH=${mayaPluginPath}"
@@ -43,17 +43,19 @@ set_property(TEST TestUSDMayaPython APPEND PROPERTY ENVIRONMENT
     "MAYA_NO_STANDALONE_ATEXIT=1"
 )
 
+set(MODULE_ONLY_TEST_NAME TestUSDMayaPythonModuleOnly)
+
 add_test(
-    NAME TestUSDMayaPythonModuleOnly
+    NAME ${MODULE_ONLY_TEST_NAME}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     # Note that, since this test does NOT call maya.standalone.initialize, we can
     # just let unittest.main call sys.exit "normally"
     COMMAND ${MAYA_PY_EXECUTABLE} -c "import sys;from unittest import main; \
-                                      import testUSDMayaPythonModuleOnly; testProg = main(module=testUSDMayaPythonModuleOnly); \
+                                      import testUSDMayaPythonModuleOnly; main(module=testUSDMayaPythonModuleOnly); \
                                       "
 )
 
-set_property(TEST TestUSDMayaPythonModuleOnly APPEND PROPERTY ENVIRONMENT 
+set_property(TEST ${MODULE_ONLY_TEST_NAME} APPEND PROPERTY ENVIRONMENT
     "PYTHONPATH=${pythonPath}"
     "PATH=${path}"
     "MAYA_PLUG_IN_PATH=${mayaPluginPath}"

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/examplecubetranslator.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/examplecubetranslator.py
@@ -1,3 +1,19 @@
+#
+# Copyright 2020 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 from AL import usd, usdmaya
 
 from pxr import Tf, UsdGeom, Gf, Vt

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testLayerManager.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testLayerManager.py
@@ -1,3 +1,21 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2020 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import os
 import tempfile
 import unittest

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testProxyShape.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testProxyShape.py
@@ -1,3 +1,21 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2020 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import os
 import tempfile
 import unittest

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testTranslators.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testTranslators.py
@@ -1,3 +1,21 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2020 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import unittest
 import tempfile
 

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testUSDMayaPythonModuleOnly.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testUSDMayaPythonModuleOnly.py
@@ -1,0 +1,48 @@
+'''Test that basic functionality of the python module works without maya.
+'''
+
+# Practically speaking, this test is currently just to check that linking of
+# the python binary is set up correctly, since there's not any real reason
+# to import this module without maya. However, we do at least want it to
+# import without error.
+
+import unittest
+import tempfile
+
+from pxr import Tf, Usd, UsdGeom, Gf
+
+class TestPythonModule(unittest.TestCase):
+
+    def testImport(self):
+        """
+        Test that we can import the AL.usdmaya module, and that it links correctly
+        """
+        import sys
+        self.assertNotIn('maya.standalone', sys.modules)
+        self.assertNotIn('AL', sys.modules)
+        self.assertNotIn('AL.usdmaya', sys.modules)
+        import AL.usdmaya
+        self.assertIn('AL', sys.modules)
+        self.assertIn('AL.usdmaya', sys.modules)
+    
+    def test_ExportFlag(self):
+        """
+        Test ExportFlag enum.
+        """
+        import AL.usdmaya
+        self.assertTrue(hasattr(AL.usdmaya, 'ExportFlag'))
+        self.assertTrue(hasattr(AL.usdmaya.ExportFlag, 'kNotSupported'))
+        self.assertEqual(AL.usdmaya.ExportFlag.values[0],
+                         AL.usdmaya.ExportFlag.kNotSupported)
+        self.assertTrue(hasattr(AL.usdmaya.ExportFlag, 'kFallbackSupport'))
+        self.assertEqual(AL.usdmaya.ExportFlag.values[1],
+                         AL.usdmaya.ExportFlag.kFallbackSupport)
+        self.assertTrue(hasattr(AL.usdmaya.ExportFlag, 'kSupported'))
+        self.assertEqual(AL.usdmaya.ExportFlag.values[2],
+                         AL.usdmaya.ExportFlag.kSupported)
+
+        
+tests = unittest.TestLoader().loadTestsFromTestCase(TestPythonModule)
+result = unittest.TextTestRunner(verbosity=2).run(tests)
+
+exit(not result.wasSuccessful())

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testUSDMayaPythonModuleOnly.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testUSDMayaPythonModuleOnly.py
@@ -1,3 +1,21 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2020 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 '''Test that basic functionality of the python module works without maya.
 '''
 


### PR DESCRIPTION
also added a test to ensure that this module can be imported, even without
loading the plugin or even instantiating maya (mostly just to check that
the linking is set up correctly)