### PR TITLE
[al] set the rpath for testMayaSchemas bin on MacOS / Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,11 @@ if(NOT WIN32)
 endif()
 string(REPLACE ";" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
+if(IS_LINUX)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--enable-new-dtags")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--enable-new-dtags")
+endif()
+
 
 #==============================================================================
 # Tests

--- a/plugin/al/schemas/AL/usd/schemas/maya/tests/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/maya/tests/CMakeLists.txt
@@ -28,6 +28,12 @@ target_link_libraries(testMayaSchemas
     ${Boost_PYTHON_LIBRARY}
     )
 
+if(IS_MACOSX OR IS_LINUX)
+    mayaUsd_init_rpath(rpath "bin")
+    mayaUsd_add_rpath(rpath "../lib")
+    mayaUsd_install_rpath(rpath testMayaSchemas)
+endif()
+
 install(TARGETS testMayaSchemas DESTINATION ${AL_INSTALL_PREFIX}/bin)
 
 

--- a/plugin/al/translators/CMakeLists.txt
+++ b/plugin/al/translators/CMakeLists.txt
@@ -82,8 +82,6 @@ if(IS_MACOSX OR IS_LINUX)
 endif()
 
 if (IS_LINUX)
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--enable-new-dtags" PARENT_SCOPE)
-
   if(WANT_USD_RELATIVE_PATH)
       mayaUsd_add_rpath(rpath "../../../../USD/lib64")
   endif()


### PR DESCRIPTION
...this allows the test to complete successfully.

Also, this change makes sure that RUNPATH is used instead of RPATH for
all shared libs and executables on Linux; RUNPATH is preferrable because
it is overrideable by LD_LIBRARY_PATH.

Note that this was effectively already always used for all AL shared libs,
due to the use of PARENT_SCOPE in al/translators/CMakeLists.txt