### PR TITLE
Disable deprecated warning on windows (matching gcc and clang)

### DIFF
--- a/cmake/defaults/msvcdefaults.cmake
+++ b/cmake/defaults/msvcdefaults.cmake
@@ -56,6 +56,9 @@ _disable_warning("4180")
 # tbb/enumerable_thread_specific.h
 _disable_warning("4334")
 
+# suppress deprecation warning.
+_disable_warning("4996")
+
 # Disable warning C4996 regarding fopen(), strcpy(), etc.
 _add_define("_CRT_SECURE_NO_WARNINGS")
 


### PR DESCRIPTION
This allows us now to build maya-usd in strict mode on all platforms.