### PR TITLE
build mayaUsd Python bindings module consistently with other modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,9 @@ if (BUILD_TESTS)
     fetch_googletest()
 
     enable_testing()
+
+    add_subdirectory(test/lib)
+
     if (UFE_FOUND)
         add_subdirectory(test/lib/ufe)
     endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -665,21 +665,15 @@ if(UFE_FOUND)
 
 endif()
 
-# Python extension library for mayaUsd library bindings.  Capitalize leading
-# character of library name.  Pixar's TF_WRAP_MODULE macro expects the library
-# name to be prefixed with _, but adds an underscore to the package name when
-# creating the Python extension module initialization function (see Pixar's
-# pyModule.h).  Create a package name without the leading underscore, and
-# prefix our library name with a leading underscore, to match this convention.
-string(TOUPPER "${LIBRARY_NAME}" LIBRARY_NAME_CAPS)
-string(SUBSTRING "${LIBRARY_NAME}" 1 -1 LIBRARY_NAME_END)
-string(SUBSTRING "${LIBRARY_NAME_CAPS}" 0 1 LIBRARY_NAME_BEGIN)
-string(CONCAT PACKAGE_NAME "Py" "${LIBRARY_NAME_BEGIN}" "${LIBRARY_NAME_END}")
+# Python extension library for mayaUsd library bindings. Pixar's TF_WRAP_MODULE
+# macro expects the library name to be prefixed with _, but adds an underscore
+# to the package name when creating the Python extension module initialization
+# function (see Pixar's pyModule.h).
 if(IS_WINDOWS AND ${MAYAUSD_DEFINE_BOOST_DEBUG_PYTHON_FLAG})
     # On Windows when compiling with debug python the library must be named with _d.
-    set(PYTHON_LIBRARY_NAME _${PACKAGE_NAME}_d)
+    set(PYTHON_LIBRARY_NAME _${LIBRARY_NAME}_d)
 else()
-    set(PYTHON_LIBRARY_NAME _${PACKAGE_NAME})
+    set(PYTHON_LIBRARY_NAME _${LIBRARY_NAME})
 endif()
 
 add_library(${PYTHON_LIBRARY_NAME}
@@ -706,12 +700,12 @@ endif()
 target_compile_definitions(${PYTHON_LIBRARY_NAME}
     PRIVATE
         ${_macDef}
-        MFB_PACKAGE_NAME=${PACKAGE_NAME}
-        MFB_ALT_PACKAGE_NAME=${PACKAGE_NAME}
-        MFB_PACKAGE_MODULE=${PROJECT_NAME}
+        MFB_PACKAGE_NAME=${LIBRARY_NAME}
+        MFB_ALT_PACKAGE_NAME=${LIBRARY_NAME}
+        MFB_PACKAGE_MODULE=${LIBRARY_NAME}
 )
-set_target_properties(${PYTHON_LIBRARY_NAME} 
-    PROPERTIES 
+set_target_properties(${PYTHON_LIBRARY_NAME}
+    PROPERTIES
         PREFIX ""
 )
 if(IS_WINDOWS)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -122,6 +122,8 @@ list(APPEND mayaUsd_src
     nodes/stageNode.cpp
     nodes/usdPrimProvider.cpp
     #
+    python/moduleDeps.cpp
+    #
     render/px_vp20/glslProgram.cpp
     render/px_vp20/utils.cpp
     render/px_vp20/utils_legacy.cpp

--- a/lib/python/__init__.py
+++ b/lib/python/__init__.py
@@ -1,4 +1,4 @@
-from . import _PyMayaUsd
+from . import _mayaUsd
 from pxr import Tf
-Tf.PrepareModule(_PyMayaUsd, locals())
-del _PyMayaUsd, Tf
+Tf.PrepareModule(_mayaUsd, locals())
+del _mayaUsd, Tf

--- a/lib/python/moduleDeps.cpp
+++ b/lib/python/moduleDeps.cpp
@@ -1,0 +1,52 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "pxr/pxr.h"
+#include "pxr/base/tf/registryManager.h"
+#include "pxr/base/tf/scriptModuleLoader.h"
+#include "pxr/base/tf/token.h"
+
+#include <vector>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_REGISTRY_FUNCTION(TfScriptModuleLoader) {
+    // List of direct dependencies for this library.
+    const std::vector<TfToken> reqs = {
+        TfToken("ar"),
+        TfToken("gf"),
+        TfToken("hd"),
+        TfToken("hdx"),
+        TfToken("js"),
+        TfToken("kind"),
+        TfToken("plug"),
+        TfToken("sdf"),
+        TfToken("tf"),
+        TfToken("usd"),
+        TfToken("usdGeom"),
+        TfToken("usdImaging"),
+        TfToken("usdImagingGL"),
+        TfToken("usdLux"),
+        TfToken("usdRi"),
+        TfToken("usdShade"),
+        TfToken("usdSkel"),
+        TfToken("usdUtils"),
+        TfToken("vt")
+    };
+    TfScriptModuleLoader::GetInstance().
+        RegisterLibrary(TfToken("mayaUsd"), TfToken("mayaUsd.lib"), reqs);
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -1,0 +1,70 @@
+#
+# Copyright 2020 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set(TARGET_NAME MAYAUSD_TEST)
+
+# Unit test scripts.
+set(test_script_files
+    testMayaUsdPythonImport.py
+)
+
+# copy tests to ${CMAKE_CURRENT_BINARY_DIR} and run them from there
+add_custom_target(${TARGET_NAME} ALL)
+
+mayaUsd_copyFiles(${TARGET_NAME}
+    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+    FILES ${test_script_files})
+
+set(path
+    "${CMAKE_INSTALL_PREFIX}/lib"
+    "${MAYA_LOCATION}/bin"
+    "$ENV{PATH}"
+)
+
+set(pythonPath
+    "${CMAKE_INSTALL_PREFIX}/lib/python"
+    "$ENV{PYTHONPATH}"
+)
+
+if(IS_WINDOWS)
+    string(REPLACE ";" "\;" path "${path}")
+    string(REPLACE ";" "\;" pythonPath "${pythonPath}")
+else()
+    separate_arguments(path NATIVE_COMMAND "${path}")
+    separate_arguments(pythonPath NATIVE_COMMAND "${pythonPath}")
+
+    string(REPLACE "\;" ":" path "${path}")
+    string(REPLACE "\;" ":" pythonPath "${pythonPath}")
+endif()
+
+foreach(script ${test_script_files})
+    mayaUsd_get_unittest_target(target ${script})
+    add_test(
+        NAME ${target}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND ${MAYA_PY_EXECUTABLE} -c "from unittest import main; \
+                                          import maya.standalone; \
+                                          maya.standalone.initialize(name='python'); \
+                                          import ${target}; \
+                                          main(module=${target}); \
+                                          maya.standalone.uninitialize()"
+    )
+    set_property(TEST ${target} APPEND PROPERTY ENVIRONMENT
+        "PATH=${path}"
+        "PYTHONPATH=${pythonPath}"
+        "MAYA_NO_STANDALONE_ATEXIT=1"
+    )
+endforeach()

--- a/test/lib/testMayaUsdPythonImport.py
+++ b/test/lib/testMayaUsdPythonImport.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2020 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+
+class MayaUsdPythonImportTestCase(unittest.TestCase):
+    """
+    Verify that the mayaUsd Python module imports correctly.
+    """
+
+    def testImportModule(self):
+        from mayaUsd import lib as mayaUsdLib
+
+        # Test calling a function that depends on USD. This exercises the
+        # script module loader registry function and ensures that loading the
+        # mayaUsd library also loaded its dependencies (i.e. the core USD
+        # libraries). We test the type name as a string to ensure that we're
+        # not causing USD libraries to be loaded any other way.
+        stageCache = mayaUsdLib.StageCache.Get()
+        self.assertEqual(type(stageCache).__name__, 'StageCache')


### PR DESCRIPTION
This changes the name of the Python module shared object for the mayaUsd library to `_mayaUsd.so` to be more consistent with the way other Python modules are built. The capitalization of the first letter in the module name was a carry over from core USD which isn't relevant in maya-usd, and it wasn't even visible from Python anyway, since the module's contents gets imported under the `mayaUsd.lib` package path.

More importantly though, this adds a `TfScriptModuleLoader` registry function that ensures that when the mayaUsd library is loaded as a result of importing its Python module, the core USD libraries that it depends on also get loaded.

Without the changes in this PR, the test that was added fails with an error that looks like this:
```
======================================================================
ERROR: testImportModule (testMayaUsdPythonImport.MayaUsdPythonImportTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "testMayaUsdPythonImport.py", line 35, in testImportModule
    stageCache = mayaUsdLib.StageCache.Get()
TypeError: No Python class registered for C++ class pxrInternal_v0_20__pxrReserved__::UsdStageCache
```