### PR TITLE
build ufe Python bindings module consistently with other modules

### DIFF
--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -25,6 +25,7 @@ target_sources(${PROJECT_NAME}
         UsdUndoDuplicateCommand.cpp
         UsdUndoRenameCommand.cpp
         Utils.cpp
+        moduleDeps.cpp
 )
 
 if(CMAKE_UFE_V2_FEATURES_AVAILABLE)

--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -97,6 +97,8 @@ install(FILES ${headers}
     DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}/ufe
 )
 
+set(UFE_PYTHON_MODULE_NAME ufe)
+
 # -----------------------------------------------------------------------------
 # subdirectories
 # -----------------------------------------------------------------------------
@@ -108,9 +110,9 @@ add_subdirectory(private)
 # UFE Python Bindings
 if(IS_WINDOWS AND MAYAUSD_DEFINE_BOOST_DEBUG_PYTHON_FLAG)
     # On Windows when compiling with debug python the library must be named with _d.
-    set(UFE_PYTHON_TARGET_NAME ufe_d)
+    set(UFE_PYTHON_TARGET_NAME "_${UFE_PYTHON_MODULE_NAME}_d")
 else()
-    set(UFE_PYTHON_TARGET_NAME ufe)
+    set(UFE_PYTHON_TARGET_NAME "_${UFE_PYTHON_MODULE_NAME}")
 endif()
 
 add_library(${UFE_PYTHON_TARGET_NAME} SHARED)
@@ -120,6 +122,7 @@ add_library(${UFE_PYTHON_TARGET_NAME} SHARED)
 # -----------------------------------------------------------------------------
 target_sources(${UFE_PYTHON_TARGET_NAME} 
     PRIVATE
+        module.cpp
         wrapUtils.cpp
 )
 
@@ -128,9 +131,9 @@ target_sources(${UFE_PYTHON_TARGET_NAME}
 # -----------------------------------------------------------------------------
 target_compile_definitions(${UFE_PYTHON_TARGET_NAME}
     PRIVATE
-        MFB_PACKAGE_NAME=${PROJECT_NAME}
-        MFB_ALT_PACKAGE_NAME=${PROJECT_NAME}
-        MFB_PACKAGE_MODULE=ufe
+        MFB_PACKAGE_NAME=${UFE_PYTHON_MODULE_NAME}
+        MFB_ALT_PACKAGE_NAME=${UFE_PYTHON_MODULE_NAME}
+        MFB_PACKAGE_MODULE="${PROJECT_NAME}.${UFE_PYTHON_MODULE_NAME}"
 )
 
 # -----------------------------------------------------------------------------
@@ -151,9 +154,9 @@ set_python_module_property(${UFE_PYTHON_TARGET_NAME})
 # -----------------------------------------------------------------------------
 if(IS_MACOSX OR IS_LINUX)
     mayaUsd_init_rpath(rpath "${PROJECT_NAME}")
-    mayaUsd_add_rpath(rpath "../..")
+    mayaUsd_add_rpath(rpath "../../..")
     if(IS_MACOSX AND DEFINED MAYAUSD_TO_USD_RELATIVE_PATH)
-        mayaUsd_add_rpath(rpath "../../../${MAYAUSD_TO_USD_RELATIVE_PATH}/lib")
+        mayaUsd_add_rpath(rpath "../../../../${MAYAUSD_TO_USD_RELATIVE_PATH}/lib")
     endif()
     mayaUsd_install_rpath(rpath ${UFE_PYTHON_TARGET_NAME})
 endif()
@@ -163,12 +166,16 @@ endif()
 # -----------------------------------------------------------------------------
 install(TARGETS ${UFE_PYTHON_TARGET_NAME}
     LIBRARY
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python/${PROJECT_NAME}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python/${PROJECT_NAME}/${UFE_PYTHON_MODULE_NAME}
     RUNTIME
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python/${PROJECT_NAME}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python/${PROJECT_NAME}/${UFE_PYTHON_MODULE_NAME}
+)
+
+install(FILES __init__.py
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python/${PROJECT_NAME}/${UFE_PYTHON_MODULE_NAME}
 )
 
 if(IS_WINDOWS)
     install(FILES $<TARGET_PDB_FILE:${UFE_PYTHON_TARGET_NAME}> 
-            DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python/${PROJECT_NAME} OPTIONAL)
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python/${PROJECT_NAME}/${UFE_PYTHON_MODULE_NAME} OPTIONAL)
 endif()

--- a/lib/mayaUsd/ufe/__init__.py
+++ b/lib/mayaUsd/ufe/__init__.py
@@ -1,0 +1,19 @@
+#
+# Copyright 2020 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from . import _ufe
+from pxr import Tf
+Tf.PrepareModule(_ufe, locals())
+del _ufe, Tf

--- a/lib/mayaUsd/ufe/module.cpp
+++ b/lib/mayaUsd/ufe/module.cpp
@@ -1,0 +1,23 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "pxr/pxr.h"
+#include "pxr/base/tf/pyModule.h"
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+TF_WRAP_MODULE {
+    TF_WRAP(Utils);
+}

--- a/lib/mayaUsd/ufe/moduleDeps.cpp
+++ b/lib/mayaUsd/ufe/moduleDeps.cpp
@@ -1,0 +1,39 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "pxr/pxr.h"
+#include "pxr/base/tf/registryManager.h"
+#include "pxr/base/tf/scriptModuleLoader.h"
+#include "pxr/base/tf/token.h"
+
+#include <vector>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_REGISTRY_FUNCTION(TfScriptModuleLoader) {
+    // List of direct dependencies for this library.
+    const std::vector<TfToken> reqs = {
+        TfToken("mayaUsd"),
+        TfToken("sdf"),
+        TfToken("tf"),
+        TfToken("usd"),
+        TfToken("usdGeom"),
+        TfToken("vt")
+    };
+    TfScriptModuleLoader::GetInstance().
+        RegisterLibrary(TfToken("ufe"), TfToken("mayaUsd.ufe"), reqs);
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/ufe/wrapUtils.cpp
+++ b/lib/mayaUsd/ufe/wrapUtils.cpp
@@ -103,7 +103,8 @@ UsdPrim ufePathToPrim(const std::string& ufePathString)
     return ufe::ufePathToPrim(path);
 }
 
-BOOST_PYTHON_MODULE(ufe)
+void
+wrapUtils()
 {
     def("getPrimFromRawItem", getPrimFromRawItem);
     

--- a/test/lib/ufe/CMakeLists.txt
+++ b/test/lib/ufe/CMakeLists.txt
@@ -7,6 +7,7 @@ set(test_script_files
     testMatrices.py
     testMayaPickwalk.py
     testRotatePivot.py
+    testUfePythonImport.py
 )
 
 set(test_support_files

--- a/test/lib/ufe/testUfePythonImport.py
+++ b/test/lib/ufe/testUfePythonImport.py
@@ -33,7 +33,10 @@ class UfePythonImportTestCase(unittest.TestCase):
         # libraries). We test the type name as a string to ensure that we're
         # not causing USD libraries to be loaded any other way.
         invalidPrim = mayaUsdUfe.getPrimFromRawItem(0)
-        # XXX: Interestingly, it appears that a default constructed UsdPrim()
-        # in C++ is currently returned to Python as a Usd.Object rather than a
-        # Usd.Prim. Will follow up with core USD...
-        self.assertEqual(type(invalidPrim).__name__, 'Object')
+
+        # Prior to USD version 20.05, a default constructed UsdPrim() in C++
+        # would be returned to Python as a Usd.Object rather than a Usd.Prim.
+        # Since we still want to support earlier versions, make sure it's one
+        # of the two.
+        typeName = type(invalidPrim).__name__
+        self.assertIn(typeName, ['Prim', 'Object'])

--- a/test/lib/ufe/testUfePythonImport.py
+++ b/test/lib/ufe/testUfePythonImport.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2020 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+
+class UfePythonImportTestCase(unittest.TestCase):
+    """
+    Verify that the ufe Python module imports correctly.
+    """
+
+    def testImportModule(self):
+        from mayaUsd import ufe as mayaUsdUfe
+
+        # Test calling a function that depends on USD. This exercises the
+        # script module loader registry function and ensures that loading the
+        # ufe library also loaded its dependencies (i.e. the core USD
+        # libraries). We test the type name as a string to ensure that we're
+        # not causing USD libraries to be loaded any other way.
+        invalidPrim = mayaUsdUfe.getPrimFromRawItem(0)
+        # XXX: Interestingly, it appears that a default constructed UsdPrim()
+        # in C++ is currently returned to Python as a Usd.Object rather than a
+        # Usd.Prim. Will follow up with core USD...
+        self.assertEqual(type(invalidPrim).__name__, 'Object')


### PR DESCRIPTION
This change is similar to #207 but applied to the ufe module. Instead of building the module as `mayaUsd/ufe.so` directly, we instead build it as `mayaUsd/ufe/_ufe.so` and bring its contents into the ufe namespace with an `__init__.py` that uses `Tf.PrepareModule()`.

Also similarly to #207, this adds a `TfScriptModuleLoader` registry function that ensures that when the ufe library is loaded as a result of importing its Python module, the core USD libraries that it depends on also get loaded.

Without the changes in this PR, the test that was added fails with an error that looks like this:
```
======================================================================
ERROR: testImportModule (testUfePythonImport.UfePythonImportTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "testUfePythonImport.py", line 35, in testImportModule
    invalidPrim = mayaUsdUfe.getPrimFromRawItem(0)
TypeError: No to_python (by-value) converter found for C++ type: pxrInternal_v0_20__pxrReserved__::UsdPrim
```