### PR TITLE
MAYA-102918 Adding a basic Export Translator to the MayaUSD plugin

### DIFF
--- a/plugin/adsk/plugin/CMakeLists.txt
+++ b/plugin/adsk/plugin/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 add_library(${PLUGIN_PACKAGE} MODULE
     plugin.cpp
     importTranslator.cpp
+    exportTranslator.cpp
     ProxyShape.cpp
 )
 

--- a/plugin/adsk/plugin/exportTranslator.cpp
+++ b/plugin/adsk/plugin/exportTranslator.cpp
@@ -59,7 +59,7 @@ UsdMayaExportTranslator::writer(const MFileObject &file,
     
     MStringArray filteredTypes;
     // Get the options 
-    if ( optionsString.length() > 0 ) {
+    if (optionsString.length() > 0) {
         MStringArray optionList;
         MStringArray theOption;
         optionsString.split(';', optionList);

--- a/plugin/adsk/plugin/exportTranslator.cpp
+++ b/plugin/adsk/plugin/exportTranslator.cpp
@@ -1,0 +1,211 @@
+//
+// Copyright 2016 Pixar
+// Copyright 2019 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "exportTranslator.h"
+
+#include <mayaUsd/fileio/jobs/jobArgs.h>
+#include <mayaUsd/fileio/shading/shadingModeRegistry.h>
+#include <mayaUsd/fileio/jobs/writeJob.h>
+#include <mayaUsd/fileio/utils/writeUtil.h>
+
+#include <maya/MFileObject.h>
+#include <maya/MGlobal.h>
+#include <maya/MSelectionList.h>
+#include <maya/MString.h>
+
+#include <string>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+MAYAUSD_NS_DEF {
+
+const MString UsdMayaExportTranslator::translatorName("USD Export");
+
+void* UsdMayaExportTranslator::creator() {
+    return new UsdMayaExportTranslator();
+}
+
+UsdMayaExportTranslator::UsdMayaExportTranslator() :
+        MPxFileTranslator() {
+}
+
+UsdMayaExportTranslator::~UsdMayaExportTranslator() {
+}
+
+MStatus
+UsdMayaExportTranslator::writer(const MFileObject &file, 
+                 const MString &optionsString,
+                 MPxFileTranslator::FileAccessMode mode ) {
+
+    std::string fileName(file.fullName().asChar(), file.fullName().length());
+    VtDictionary userArgs;
+    bool exportAnimation = false;
+    GfInterval timeInterval(1.0, 1.0);
+    double frameStride = 1.0;
+    bool append=false;
+    
+    MStringArray filteredTypes;
+    // Get the options 
+    if ( optionsString.length() > 0 ) {
+        MStringArray optionList;
+        MStringArray theOption;
+        optionsString.split(';', optionList);
+        for(int i=0; i<(int)optionList.length(); ++i) {
+            theOption.clear();
+            optionList[i].split('=', theOption);
+            if (theOption.length() != 2) {
+                continue;
+            }
+
+            std::string argName(theOption[0].asChar());
+            if (argName == "animation") {
+                exportAnimation = (theOption[1].asInt() != 0);
+            }
+            else if (argName == "startTime") {
+                timeInterval.SetMin(theOption[1].asDouble());
+            }
+            else if (argName == "endTime") {
+                timeInterval.SetMax(theOption[1].asDouble());
+            }
+            else if (argName == "frameStride") {
+                frameStride = theOption[1].asDouble();
+            }
+            else if (argName == "filterTypes") {
+                theOption[1].split(',', filteredTypes);
+            }
+            else {
+                userArgs[argName] = UsdMayaUtil::ParseArgumentValue(
+                    argName, theOption[1].asChar(),
+                    PXR_NS::UsdMayaJobExportArgs::GetDefaultDictionary());
+            }
+        }
+    }
+
+    // Now resync start and end frame based on export time interval.
+    if (exportAnimation) {
+        if (timeInterval.IsEmpty()) {
+            // If the user accidentally set start > end, resync to the closed
+            // interval with the single start point.
+            timeInterval = GfInterval(timeInterval.GetMin());
+        }
+    }
+    else {
+        // No animation, so empty interval.
+        timeInterval = GfInterval();
+    }
+
+    MSelectionList objSelList;
+    if(mode == MPxFileTranslator::kExportActiveAccessMode) {
+        // Get selected objects
+        MGlobal::getActiveSelectionList(objSelList);
+    } else if(mode == MPxFileTranslator::kExportAccessMode) {
+        // Get all objects at DAG root
+        objSelList.add("|*", true);
+    }
+
+    // Convert selection list to jobArgs dagPaths
+    UsdMayaUtil::MDagPathSet dagPaths;
+    for (unsigned int i=0; i < objSelList.length(); i++) {
+        MDagPath dagPath;
+        if (objSelList.getDagPath(i, dagPath) == MS::kSuccess) {
+            dagPaths.insert(dagPath);
+        }
+    }
+    
+    if (dagPaths.empty()) {
+        TF_WARN("No DAG nodes to export. Skipping.");
+        return MS::kSuccess;
+    }
+
+    const std::vector<double> timeSamples = UsdMayaWriteUtil::GetTimeSamples(
+            timeInterval, std::set<double>(), frameStride);
+    PXR_NS::UsdMayaJobExportArgs jobArgs = PXR_NS::UsdMayaJobExportArgs::CreateFromDictionary(
+            userArgs, dagPaths, timeSamples);
+    for (unsigned int i=0; i < filteredTypes.length(); ++i) {
+        jobArgs.AddFilteredTypeName(filteredTypes[i].asChar());
+    }
+
+    UsdMaya_WriteJob writeJob(jobArgs);
+    if (!writeJob.Write(fileName, append)) {
+        return MS::kFailure;
+    }
+    
+    return MS::kSuccess;
+}
+
+MPxFileTranslator::MFileKind
+UsdMayaExportTranslator::identifyFile(
+        const MFileObject& file,
+        const char*  /*buffer*/,
+        short  /*size*/) const
+{
+    MFileKind retValue = kNotMyFileType;
+    const MString fileName = file.fullName();
+    const int lastIndex = fileName.length() - 1;
+
+    const int periodIndex = fileName.rindex('.');
+    if (periodIndex < 0 || periodIndex >= lastIndex) {
+        return retValue;
+    }
+
+    const MString fileExtension = fileName.substring(periodIndex + 1, lastIndex);
+
+    if (fileExtension ==
+            UsdMayaTranslatorTokens->UsdFileExtensionDefault.GetText() || 
+        fileExtension ==
+            UsdMayaTranslatorTokens->UsdFileExtensionASCII.GetText() || 
+        fileExtension ==
+            UsdMayaTranslatorTokens->UsdFileExtensionCrate.GetText() ||
+        fileExtension ==
+            UsdMayaTranslatorTokens->UsdFileExtensionPackage.GetText()) {
+        retValue = kIsMyFileType;
+    }
+
+    return retValue;
+}
+
+/* static */
+const std::string&
+UsdMayaExportTranslator::GetDefaultOptions()
+{
+    static std::string defaultOptions;
+    static std::once_flag once;
+    std::call_once(once, []() {
+        std::vector<std::string> entries;
+        for (const std::pair<std::string, VtValue> keyValue :
+                PXR_NS::UsdMayaJobExportArgs::GetDefaultDictionary()) {
+            if (keyValue.second.IsHolding<bool>()) {
+                entries.push_back(TfStringPrintf("%s=%d",
+                        keyValue.first.c_str(),
+                        static_cast<int>(keyValue.second.Get<bool>())));
+            }
+            else if (keyValue.second.IsHolding<std::string>()) {
+                entries.push_back(TfStringPrintf("%s=%s",
+                        keyValue.first.c_str(),
+                        keyValue.second.Get<std::string>().c_str()));
+            }
+        }
+        entries.push_back("animation=0");
+        entries.push_back("startTime=1");
+        entries.push_back("endTime=1");
+        entries.push_back("frameStride=1.0");
+        defaultOptions = TfStringJoin(entries, ";");
+    });
+
+    return defaultOptions;
+}
+
+}

--- a/plugin/adsk/plugin/exportTranslator.h
+++ b/plugin/adsk/plugin/exportTranslator.h
@@ -1,0 +1,78 @@
+//
+// Copyright 2016 Pixar
+// Copyright 2019 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include "base/api.h"
+#include <mayaUsd/fileio/jobs/jobArgs.h>
+
+#include "pxr/pxr.h"
+
+#include <maya/MFileObject.h>
+#include <maya/MPxFileTranslator.h>
+#include <maya/MStatus.h>
+#include <maya/MString.h>
+
+MAYAUSD_NS_DEF {
+
+/// File translator for USD files. Handles the USD option in the Export window.
+class UsdMayaExportTranslator : public MPxFileTranslator
+{
+    public:
+        MAYAUSD_PLUGIN_PUBLIC
+        static const MString translatorName;
+
+        /**
+         * method to create UsdMayaExportTranslator file translator
+         */
+        MAYAUSD_PLUGIN_PUBLIC
+        static void* creator();
+
+        MAYAUSD_PLUGIN_PUBLIC
+        MStatus writer(
+                const MFileObject& file, 
+                const MString& optionsString,
+                MPxFileTranslator::FileAccessMode mode) override;
+
+        bool haveReadMethod() const override { return false; }
+        bool haveWriteMethod() const override { return true; }
+
+        MAYAUSD_PLUGIN_PUBLIC
+        MFileKind identifyFile(
+                const MFileObject& file,
+                const char* buffer,
+                short size) const override;
+
+        MString defaultExtension() const override {
+            return PXR_NS::UsdMayaTranslatorTokens->UsdFileExtensionDefault.GetText();
+        }
+        MString filter() const override {
+            return PXR_NS::UsdMayaTranslatorTokens->UsdWritableFileFilter.GetText();
+        }
+
+        MAYAUSD_PLUGIN_PUBLIC
+        static const std::string& GetDefaultOptions();
+
+    private:
+
+        UsdMayaExportTranslator();
+        UsdMayaExportTranslator(const UsdMayaExportTranslator&);
+        ~UsdMayaExportTranslator() override;
+        UsdMayaExportTranslator& operator=(const UsdMayaExportTranslator&);
+};
+
+}
+

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -16,6 +16,7 @@
 
 #include "base/api.h"
 #include "importTranslator.h"
+#include "exportTranslator.h"
 #include "ProxyShape.h"
 
 #include <mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h>
@@ -57,6 +58,17 @@ MStatus initializePlugin(MObject obj)
         false);
     if (!status) {
         status.perror("mayaUsdPlugin: unable to register import translator.");
+    }
+
+    status = plugin.registerFileTranslator(
+        MAYAUSD_NS::UsdMayaExportTranslator::translatorName,
+        "",
+        MAYAUSD_NS::UsdMayaExportTranslator::creator,
+        "mayaUsdTranslatorExport", // options script name
+        const_cast<char*>(MAYAUSD_NS::UsdMayaExportTranslator::GetDefaultOptions().c_str()),
+        false);
+    if (!status) {
+        status.perror("mayaUsdPlugin: unable to register export translator.");
     }
 
     status = MayaUsdProxyShapePlugin::initialize(plugin);
@@ -126,6 +138,11 @@ MStatus uninitializePlugin(MObject obj)
     status = plugin.deregisterFileTranslator("mayaUsdImport");
     if (!status) {
         status.perror("mayaUsdPlugin: unable to deregister import translator.");
+    }
+
+    status = plugin.deregisterFileTranslator(MAYAUSD_NS::UsdMayaExportTranslator::translatorName);
+    if (!status) {
+        status.perror("mayaUsdPlugin: unable to deregister export translator.");
     }
 
     status = plugin.deregisterNode(MayaUsd::ProxyShape::typeId);

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -61,11 +61,11 @@ MStatus initializePlugin(MObject obj)
     }
 
     status = plugin.registerFileTranslator(
-        MAYAUSD_NS::UsdMayaExportTranslator::translatorName,
+        MayaUsd::UsdMayaExportTranslator::translatorName,
         "",
-        MAYAUSD_NS::UsdMayaExportTranslator::creator,
+        MayaUsd::UsdMayaExportTranslator::creator,
         "mayaUsdTranslatorExport", // options script name
-        const_cast<char*>(MAYAUSD_NS::UsdMayaExportTranslator::GetDefaultOptions().c_str()),
+        const_cast<char*>(MayaUsd::UsdMayaExportTranslator::GetDefaultOptions().c_str()),
         false);
     if (!status) {
         status.perror("mayaUsdPlugin: unable to register export translator.");
@@ -140,7 +140,7 @@ MStatus uninitializePlugin(MObject obj)
         status.perror("mayaUsdPlugin: unable to deregister import translator.");
     }
 
-    status = plugin.deregisterFileTranslator(MAYAUSD_NS::UsdMayaExportTranslator::translatorName);
+    status = plugin.deregisterFileTranslator(MayaUsd::UsdMayaExportTranslator::translatorName);
     if (!status) {
         status.perror("mayaUsdPlugin: unable to deregister export translator.");
     }

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -15,20 +15,92 @@
 // limitations under the License.
 //
 
+global proc mayausdTranslatorExport_AnimationCB() {
+    columnLayout -e -visible (`checkBoxGrp -q -v1 animationCheckBox`) animOptsCol;
+}
+
+global proc mayausdTranslatorExport_AnimationRangeCB() {
+    int $startTime = `playbackOptions -q -animationStartTime`;
+    int $endTime = `playbackOptions -q -animationEndTime`;
+    intFieldGrp -e -v1 $startTime -v2 $endTime framRangeFields;
+}
+
+global proc mayausdTranslatorExport_SetCheckbox(string $arg, string $widget) {
+    if ($arg == "0") {
+        checkBoxGrp -e -v1 false $widget;
+    } else {
+        checkBoxGrp -e -v1 true $widget;
+    }
+}
+
+global proc mayausdTranslatorExport_SetTextField(string $arg, string $widget) {
+    textFieldGrp -e -text $arg $widget;
+}
+
+global proc mayausdTranslatorExport_SetOptionMenuByAnnotation(
+        string $ann, string $widget) {
+    int $index = 1; // 1-based indexing.
+    for ($i in `optionMenuGrp -q -itemListLong $widget`) {
+        if (`menuItem -q -ann $i` == $ann) {
+            optionMenuGrp -e -select $index $widget;
+            return;
+        }
+
+        $index++;
+    }
+}
+
+global proc string mayausdTranslatorExport_AppendFromCheckbox(string $currentOptions, string $arg, string $widget) {
+    if (`checkBoxGrp -q -v1 $widget` == 1) {
+        return $currentOptions + ";" + $arg + "=1";
+    } else {
+        return $currentOptions + ";" + $arg + "=0";
+    }
+}
+
+global proc string mayausdTranslatorExport_AppendFromPopup(string $currentOptions, string $arg, string $widget) {
+    int $index = `optionMenuGrp -q -select $widget` - 1;
+    string $allItems[] = `optionMenuGrp -q -itemListLong $widget`;
+    string $item = $allItems[$index];
+    string $annotation = `menuItem -q -ann $item`;
+    return $currentOptions + ";" + $arg + "=" + $annotation;
+}
+
+proc string mayausdTranslatorExport_AppendFrameRange(string $currentOptions) {
+    int $start = `intFieldGrp -q -value1 framRangeFields`;
+    int $end = `intFieldGrp -q -value2 framRangeFields`;
+    return $currentOptions + ";startTime=" + $start + ";endTime=" + $end;
+}
+
+global proc string mayausdTranslatorExport_AppendFromIntField(string $currentOptions, string $arg, string $widget) {
+    string $value = `intFieldGrp -q -value1 $widget`;
+    return $currentOptions + ";" + $arg + "=" + $value;
+}
+
+global proc string mayausdTranslatorExport_AppendFromFloatField(string $currentOptions, string $arg, string $widget) {
+    string $value = `floatFieldGrp -q -value1 $widget`;
+    return $currentOptions + ";" + $arg + "=" + $value;
+}
+
+global proc string mayausdTranslatorExport_AppendFromTextField(string $currentOptions, string $arg, string $widget) {
+    string $value = `textFieldGrp -q -text $widget`;
+    return $currentOptions + ";" + $arg + "=" + $value;
+}
+
 global proc int mayaUsdTranslatorExport (string $parent,
                                      string $action,
                                      string $initialSettings,
                                      string $resultCallback )
 //
 //  Description:
-//    This script posts the mayaUsd export file translator options.
+//    This script posts the USD Export file translator options.
 //    The optionsString is of the form:
 //    varName1=value1;varName2=value2;...
 //
 //  Parameters:
 //    $parent - the elf parent layout for this options layout. It is
 //            always a scrollLayout.
-//    $action - the action that is to be performed with this invocation of this proc.
+//    $action - the action that is to be performed with this invokation of this proc.
 //        Valid options are:
 //        "query" - construct the options string and pass it to the resultCallback.
 //        "post" - post all the elf controls.
@@ -37,20 +109,138 @@ global proc int mayaUsdTranslatorExport (string $parent,
 //            resultCallback ( string $optionsString )
 //
 //    Returns:
-//        1 if successful.
+//        1 if successfull.
 //        0 otherwise.
 //
 {
-    int $bResult = 1;
+    int $bResult;
+    string $currentOptions;
+    string $optionList[];
+    string $optionBreakDown[];
+    int $index;
 
     if ($action == "post") {
         setParent $parent;
 
-		text -label "Maya USD export options to be determined.";
+        columnLayout -adj true usdOptsCol;
+
+        frameLayout -label "Output" -collapsable true -collapse false;
+            separator -style "none";
+
+            textFieldGrp -l "Create USD Parent Scope:" -placeholderText "USD Prim Name" parentScopeField;
+
+            separator -style "none";
+        setParent ..;
+
+        frameLayout -label "Geometry" -collapsable true -collapse false;
+            separator -style "none";
+            optionMenuGrp -l "Default Mesh Scheme:" defaultMeshSchemePopup;
+                menuItem -l "Catmull-Clark" -ann "catmullClark";
+                menuItem -l "Bilinear" -ann "bilinear";
+                menuItem -l "Loop" -ann "loop";
+                menuItem -l "Polygonal Mesh" -ann "none";
+
+            checkBoxGrp -l "Color Sets" exportColorSetsCheckBox;
+
+            checkBoxGrp -l "UV Sets" exportUVsCheckBox;
+            
+            separator -style "none";
+        setParent ..;
+        
+        frameLayout -label "Animation" -collapsable true -collapse false;
+            separator -style "none";
+
+            checkBoxGrp -l "Animation Data: " -cc ("mayausdTranslatorExport_AnimationCB") animationCheckBox;
+
+            columnLayout -width 100 animOptsCol;
+                rowLayout -numberOfColumns 2 -columnAttach 2 "left" 20;
+                    intFieldGrp -l "Frame Range Start/End:" -numberOfFields 2 -v1 1 -v2 200 framRangeFields;
+                    button -l "Use Animation Range" -command ("mayausdTranslatorExport_AnimationRangeCB") animRangeButton;
+                setParent ..;
+
+                floatFieldGrp -l "Frame Step:" -v1 1 frameStrideField;
+
+                checkBoxGrp -l "Euler Filter:" eulerFilterCheckBox;
+            setParent ..;
+
+            separator -style "none";
+        setParent ..;
+
+        frameLayout -label "Advanced" -collapsable true -collapse true;
+            separator -style "none";
+
+            checkBoxGrp -l "Visibility" exportVisibilityCheckBox;
+
+            checkBoxGrp -l "Export Instances" exportInstancesCheckBox;
+
+            checkBoxGrp -l "Merge Transform and Shapes" mergeTransformAndShapeCheckBox;
+
+            checkBoxGrp -l "Strip Namespaces" stripNamespacesCheckBox;
+
+            separator -style "none";
+        setParent ..;
+
+        setParent $parent;
+
+        // Now set to current settings.
+        $currentOptions = $initialSettings;
+        if (size($currentOptions) > 0) {
+            tokenize($currentOptions, ";", $optionList);
+            for ($index = 0; $index < size($optionList); $index++) {
+                tokenize($optionList[$index], "=", $optionBreakDown);
+                if ($optionBreakDown[0] == "exportUVs") {
+                    mayausdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportUVsCheckBox");
+                } else if ($optionBreakDown[0] == "exportColorSets") {
+                    mayausdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportColorSetsCheckBox");
+                } else if ($optionBreakDown[0] == "defaultMeshScheme") {
+                    mayausdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "defaultMeshSchemePopup");
+                } else if ($optionBreakDown[0] == "animation") {
+                    mayausdTranslatorExport_SetCheckbox($optionBreakDown[1], "animationCheckBox");
+                } else if ($optionBreakDown[0] == "eulerFilter") {
+                    mayausdTranslatorExport_SetCheckbox($optionBreakDown[1], "eulerFilterCheckBox");
+                } else if ($optionBreakDown[0] == "startTime") {
+                    int $startTime=$optionBreakDown[1];
+                    intFieldGrp -e -v1 $startTime framRangeFields;
+                } else if ($optionBreakDown[0] == "endTime") {
+                    int $endTime; $endTime=$optionBreakDown[1];
+                    intFieldGrp -e -v2 $endTime framRangeFields;
+                } else if ($optionBreakDown[0] == "frameStride") {
+                    float $frameStride = $optionBreakDown[1];
+                    floatFieldGrp -e -v1 $frameStride frameStrideField;
+                } else if ($optionBreakDown[0] == "parentScope") {
+                    mayausdTranslatorExport_SetTextField($optionBreakDown[1], "parentScopeField");
+                } else if ($optionBreakDown[0] == "exportInstances") {
+                    mayausdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportInstancesCheckBox");                    
+                } else if ($optionBreakDown[0] == "exportVisibility") {
+                    mayausdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportVisibilityCheckBox");
+                } else if ($optionBreakDown[0] == "mergeTransformAndShape") {
+                    mayausdTranslatorExport_SetCheckbox($optionBreakDown[1], "mergeTransformAndShapeCheckBox");                    
+                } else if ($optionBreakDown[0] == "stripNamespaces") {
+                    mayausdTranslatorExport_SetCheckbox($optionBreakDown[1], "stripNamespacesCheckBox");                    
+                }
+            }
+        }
+        // Set visibility for anim widgets
+        mayausdTranslatorExport_AnimationCB();
+
+        $bResult = 1;
+
     } else if ($action == "query") {
-        string $currentOptions = "";
+        $currentOptions = mayausdTranslatorExport_AppendFromCheckbox($currentOptions, "exportUVs", "exportUVsCheckBox");
+        $currentOptions = mayausdTranslatorExport_AppendFromCheckbox($currentOptions, "exportColorSets", "exportColorSetsCheckBox");
+        $currentOptions = mayausdTranslatorExport_AppendFromPopup($currentOptions, "defaultMeshScheme", "defaultMeshSchemePopup");
+        $currentOptions = mayausdTranslatorExport_AppendFromCheckbox($currentOptions, "animation", "animationCheckBox");
+        $currentOptions = mayausdTranslatorExport_AppendFromCheckbox($currentOptions, "eulerFilter", "eulerFilterCheckBox");
+        $currentOptions = mayausdTranslatorExport_AppendFrameRange($currentOptions);
+        $currentOptions = mayausdTranslatorExport_AppendFromFloatField($currentOptions, "frameStride", "frameStrideField");
+        $currentOptions = mayausdTranslatorExport_AppendFromTextField($currentOptions, "parentScope", "parentScopeField");
+        $currentOptions = mayausdTranslatorExport_AppendFromCheckbox($currentOptions, "exportInstances", "exportInstancesCheckBox");
+        $currentOptions = mayausdTranslatorExport_AppendFromCheckbox($currentOptions, "exportVisibility", "exportVisibilityCheckBox");
+        $currentOptions = mayausdTranslatorExport_AppendFromCheckbox($currentOptions, "mergeTransformAndShape", "mergeTransformAndShapeCheckBox");
+        $currentOptions = mayausdTranslatorExport_AppendFromCheckbox($currentOptions, "stripNamespaces", "stripNamespacesCheckBox");
 
         eval($resultCallback+" \""+$currentOptions+"\"");
+        $bResult = 1;
 
     } else {
         $bResult = 0;

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -23,6 +23,14 @@ proc mayaUsdTranslatorExport_SetCheckbox(string $arg, string $widget) {
     }
 }
 
+proc mayaUsdTranslatorExport_SetOppositeCheckbox(string $arg, string $widget) {
+    if ($arg == "0") {
+        checkBoxGrp -e -v1 true $widget;
+    } else {
+        checkBoxGrp -e -v1 false $widget;
+    }
+}
+
 proc mayaUsdTranslatorExport_SetTextField(string $arg, string $widget) {
     textFieldGrp -e -text $arg $widget;
 }
@@ -37,6 +45,27 @@ proc mayaUsdTranslatorExport_SetOptionMenuByAnnotation(
         }
 
         $index++;
+    }
+}
+
+proc mayaUsdTranslatorExport_SetOptionMenuByBool (
+        string $ann, string $widget) {
+    // Mapping between a boolean option and an option menu with two choices.
+    // False maps to the first menu item, which is index 1.
+    // True maps to the second menu item, which is index 2.
+    int $optionAsBool = 1;
+    if ("1" == $ann)
+    {
+        $optionAsBool = 2;
+    }
+    optionMenuGrp -e -select $optionAsBool $widget;
+}
+
+proc string mayaUsdTranslatorExport_AppendOppositeFromCheckbox(string $currentOptions, string $arg, string $widget) {
+    if (`checkBoxGrp -q -v1 $widget` == 1) {
+        return $currentOptions + ";" + $arg + "=0";
+    } else {
+        return $currentOptions + ";" + $arg + "=1";
     }
 }
 
@@ -56,10 +85,20 @@ proc string mayaUsdTranslatorExport_AppendFromPopup(string $currentOptions, stri
     return $currentOptions + ";" + $arg + "=" + $annotation;
 }
 
+proc string mayaUsdTranslatorExport_AppendFromBoolPopup(string $currentOptions, string $arg, string $widget) {
+    int $index = `optionMenuGrp -q -select $widget` - 1;
+    return $currentOptions + ";" + $arg + "=" + $index;
+}
+
 proc string mayaUsdTranslatorExport_AppendFrameRange(string $currentOptions) {
     int $start = `intFieldGrp -q -value1 framRangeFields`;
     int $end = `intFieldGrp -q -value2 framRangeFields`;
     return $currentOptions + ";startTime=" + $start + ";endTime=" + $end;
+}
+
+proc string mayaUsdTranslatorExport_AppendFromIntField(string $currentOptions, string $arg, string $widget) {
+    string $value = `intFieldGrp -q -value1 $widget`;
+    return $currentOptions + ";" + $arg + "=" + $value;
 }
 
 proc string mayaUsdTranslatorExport_AppendFromFloatField(string $currentOptions, string $arg, string $widget) {
@@ -115,6 +154,19 @@ global proc int mayaUsdTranslatorExport (string $parent,
     int $index;
 
     if ($action == "post") {
+        string $parentScopAnn = "Name of the USD scope that is the parent of the exported data.";
+        string $colorSetsAnn = "Exports Maya Color Sets as USD primvars.";
+        string $uvSetsAnn = "Exports Maya UV Sets as USD primvars.";
+        string $animDataAnn = "Exports Maya animation data as USD time samples.";
+        string $frameStepAnn = "Specifies the increment between USD time sample frames during animation export";
+        string $eulerFilterAnn = "Exports the euler angle filtering that was performed in Maya.";
+        string $visibilityAnn = "Exports Maya visibility attributes as USD metadata.";
+        string $mergeShapesAnn = "Merges Maya transform and shape nodes into a single USD prim.";
+        string $namespacesAnn = "By default, namespaces are exported to the USD file in the following format: nameSpaceExample_pPlatonic1";
+        string $instancesAnn = "Exports Maya instances as USD instanceable references.";
+        string $subdMethodAnn = "Exports the selected subdivision method as a USD uniform attribute.";
+        string $frameSamplesAnn = "Specifies the value(s) used to multi-sample time frames during animation export. Multiple values separated by a space (-0.1 0.2) are supported.";
+
         setParent $parent;
 
         columnLayout -adj true usdOptsCol;
@@ -122,22 +174,23 @@ global proc int mayaUsdTranslatorExport (string $parent,
         frameLayout -label "Output" -collapsable true -collapse false;
             separator -style "none";
 
-            textFieldGrp -l "Create USD Parent Scope:" -placeholderText "USD Prim Name" parentScopeField;
+            textFieldGrp -l "Create USD Parent Scope:" -placeholderText "USD Prim Name" 
+                -annotation $parentScopAnn parentScopeField;
 
             separator -style "none";
         setParent ..;
 
         frameLayout -label "Geometry" -collapsable true -collapse false;
             separator -style "none";
-            optionMenuGrp -l "Default Mesh Scheme:" defaultMeshSchemePopup;
+            optionMenuGrp -l "Subdivision Method:" -annotation $subdMethodAnn defaultMeshSchemePopup;
                 menuItem -l "Catmull-Clark" -ann "catmullClark";
                 menuItem -l "Bilinear" -ann "bilinear";
                 menuItem -l "Loop" -ann "loop";
-                menuItem -l "Polygonal Mesh" -ann "none";
+                menuItem -l "None (Polygonal Mesh)" -ann "none";
 
-            checkBoxGrp -l "Color Sets:" exportColorSetsCheckBox;
+            checkBoxGrp -l "Color Sets:" -annotation $colorSetsAnn exportColorSetsCheckBox;
 
-            checkBoxGrp -l "UV Sets:" exportUVsCheckBox;
+            checkBoxGrp -l "UV Sets:" -annotation $uvSetsAnn exportUVsCheckBox;
             
             separator -style "none";
         setParent ..;
@@ -145,7 +198,8 @@ global proc int mayaUsdTranslatorExport (string $parent,
         frameLayout -label "Animation" -collapsable true -collapse false;
             separator -style "none";
 
-            checkBoxGrp -l "Animation Data: " -cc ("mayaUsdTranslatorExport_AnimationCB") animationCheckBox;
+            checkBoxGrp -l "Animation Data: " -cc ("mayaUsdTranslatorExport_AnimationCB") 
+                -annotation $animDataAnn animationCheckBox;
 
             columnLayout -width 100 animOptsCol;
                 rowLayout -numberOfColumns 2 -columnAttach 2 "left" 20;
@@ -153,9 +207,12 @@ global proc int mayaUsdTranslatorExport (string $parent,
                     button -l "Use Animation Range" -command ("mayaUsdTranslatorExport_AnimationRangeCB") animRangeButton;
                 setParent ..;
 
-                floatFieldGrp -l "Frame Step:" -v1 1 -cw 1 175 frameStrideField;
+                floatFieldGrp -l "Frame Step:" -v1 1 -cw 1 175 -annotation $frameStepAnn frameStrideField;
 
-                checkBoxGrp -l "Euler Filter:" -cw 1 175 eulerFilterCheckBox;
+                textFieldGrp -l "Frame Sample:" -cw 1 175 -annotation $frameSamplesAnn frameSampleField;
+
+                checkBoxGrp -l "Euler Filter:" -cw 1 175 
+                    -annotation $eulerFilterAnn eulerFilterCheckBox;
             setParent ..;
 
             separator -style "none";
@@ -164,13 +221,16 @@ global proc int mayaUsdTranslatorExport (string $parent,
         frameLayout -label "Advanced" -collapsable true -collapse true;
             separator -style "none";
 
-            checkBoxGrp -l "Visibility:" exportVisibilityCheckBox;
+            checkBoxGrp -l "Visibility:" -annotation $visibilityAnn exportVisibilityCheckBox;
 
-            checkBoxGrp -l "Export Instances:" exportInstancesCheckBox;
+            optionMenuGrp -l "Instances:" -annotation $instancesAnn exportInstancesPopup;
+                menuItem -l "Flatten";
+                menuItem -l "Convert to USD Instanceable References";
 
-            checkBoxGrp -l "Merge Transform and Shapes:" mergeTransformAndShapeCheckBox;
+            checkBoxGrp -l "Merge Transform and Shape\nNodes:" 
+                -annotation $mergeShapesAnn mergeTransformAndShapeCheckBox;
 
-            checkBoxGrp -l "Strip Namespaces:" stripNamespacesCheckBox;
+            checkBoxGrp -l "Include Namespaces:" -annotation $namespacesAnn includeNamespacesCheckBox;
 
             separator -style "none";
         setParent ..;
@@ -202,16 +262,18 @@ global proc int mayaUsdTranslatorExport (string $parent,
                 } else if ($optionBreakDown[0] == "frameStride") {
                     float $frameStride = $optionBreakDown[1];
                     floatFieldGrp -e -v1 $frameStride frameStrideField;
+                } else if ($optionBreakDown[0] == "frameSample") {
+                    mayaUsdTranslatorExport_SetTextField($optionBreakDown[1], "frameSampleField");
                 } else if ($optionBreakDown[0] == "parentScope") {
                     mayaUsdTranslatorExport_SetTextField($optionBreakDown[1], "parentScopeField");
                 } else if ($optionBreakDown[0] == "exportInstances") {
-                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportInstancesCheckBox");                    
+                    mayaUsdTranslatorExport_SetOptionMenuByBool($optionBreakDown[1], "exportInstancesPopup");
                 } else if ($optionBreakDown[0] == "exportVisibility") {
                     mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportVisibilityCheckBox");
                 } else if ($optionBreakDown[0] == "mergeTransformAndShape") {
-                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "mergeTransformAndShapeCheckBox");                    
+                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "mergeTransformAndShapeCheckBox");
                 } else if ($optionBreakDown[0] == "stripNamespaces") {
-                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "stripNamespacesCheckBox");                    
+                    mayaUsdTranslatorExport_SetOppositeCheckbox($optionBreakDown[1], "includeNamespacesCheckBox");
                 }
             }
         }
@@ -228,11 +290,12 @@ global proc int mayaUsdTranslatorExport (string $parent,
         $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "eulerFilter", "eulerFilterCheckBox");
         $currentOptions = mayaUsdTranslatorExport_AppendFrameRange($currentOptions);
         $currentOptions = mayaUsdTranslatorExport_AppendFromFloatField($currentOptions, "frameStride", "frameStrideField");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromTextField($currentOptions, "frameSample", "frameSampleField");
         $currentOptions = mayaUsdTranslatorExport_AppendFromTextField($currentOptions, "parentScope", "parentScopeField");
-        $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "exportInstances", "exportInstancesCheckBox");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromBoolPopup($currentOptions, "exportInstances", "exportInstancesPopup");
         $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "exportVisibility", "exportVisibilityCheckBox");
         $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "mergeTransformAndShape", "mergeTransformAndShapeCheckBox");
-        $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "stripNamespaces", "stripNamespacesCheckBox");
+        $currentOptions = mayaUsdTranslatorExport_AppendOppositeFromCheckbox($currentOptions, "stripNamespaces", "includeNamespacesCheckBox");
 
         eval($resultCallback+" \""+$currentOptions+"\"");
         $bResult = 1;

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -227,7 +227,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
                 menuItem -l "Flatten";
                 menuItem -l "Convert to USD Instanceable References";
 
-            checkBoxGrp -l "Merge Transform and Shape\nNodes:" 
+            checkBoxGrp -l "Merge Transform and\nShape Nodes:" 
                 -annotation $mergeShapesAnn mergeTransformAndShapeCheckBox;
 
             checkBoxGrp -l "Include Namespaces:" -annotation $namespacesAnn includeNamespacesCheckBox;

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -140,9 +140,9 @@ global proc int mayaUsdTranslatorExport (string $parent,
                 menuItem -l "Loop" -ann "loop";
                 menuItem -l "Polygonal Mesh" -ann "none";
 
-            checkBoxGrp -l "Color Sets" exportColorSetsCheckBox;
+            checkBoxGrp -l "Color Sets:" exportColorSetsCheckBox;
 
-            checkBoxGrp -l "UV Sets" exportUVsCheckBox;
+            checkBoxGrp -l "UV Sets:" exportUVsCheckBox;
             
             separator -style "none";
         setParent ..;
@@ -154,13 +154,13 @@ global proc int mayaUsdTranslatorExport (string $parent,
 
             columnLayout -width 100 animOptsCol;
                 rowLayout -numberOfColumns 2 -columnAttach 2 "left" 20;
-                    intFieldGrp -l "Frame Range Start/End:" -numberOfFields 2 -v1 1 -v2 200 framRangeFields;
+                    intFieldGrp -l "Frame Range Start/End:" -numberOfFields 2 -v1 1 -v2 200 -cw 1 175 framRangeFields;
                     button -l "Use Animation Range" -command ("mayausdTranslatorExport_AnimationRangeCB") animRangeButton;
                 setParent ..;
 
-                floatFieldGrp -l "Frame Step:" -v1 1 frameStrideField;
+                floatFieldGrp -l "Frame Step:" -v1 1 -cw 1 175 frameStrideField;
 
-                checkBoxGrp -l "Euler Filter:" eulerFilterCheckBox;
+                checkBoxGrp -l "Euler Filter:" -cw 1 175 eulerFilterCheckBox;
             setParent ..;
 
             separator -style "none";
@@ -169,13 +169,13 @@ global proc int mayaUsdTranslatorExport (string $parent,
         frameLayout -label "Advanced" -collapsable true -collapse true;
             separator -style "none";
 
-            checkBoxGrp -l "Visibility" exportVisibilityCheckBox;
+            checkBoxGrp -l "Visibility:" exportVisibilityCheckBox;
 
-            checkBoxGrp -l "Export Instances" exportInstancesCheckBox;
+            checkBoxGrp -l "Export Instances:" exportInstancesCheckBox;
 
-            checkBoxGrp -l "Merge Transform and Shapes" mergeTransformAndShapeCheckBox;
+            checkBoxGrp -l "Merge Transform and Shapes:" mergeTransformAndShapeCheckBox;
 
-            checkBoxGrp -l "Strip Namespaces" stripNamespacesCheckBox;
+            checkBoxGrp -l "Strip Namespaces:" stripNamespacesCheckBox;
 
             separator -style "none";
         setParent ..;

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -15,17 +15,7 @@
 // limitations under the License.
 //
 
-global proc mayausdTranslatorExport_AnimationCB() {
-    columnLayout -e -visible (`checkBoxGrp -q -v1 animationCheckBox`) animOptsCol;
-}
-
-global proc mayausdTranslatorExport_AnimationRangeCB() {
-    int $startTime = `playbackOptions -q -animationStartTime`;
-    int $endTime = `playbackOptions -q -animationEndTime`;
-    intFieldGrp -e -v1 $startTime -v2 $endTime framRangeFields;
-}
-
-global proc mayausdTranslatorExport_SetCheckbox(string $arg, string $widget) {
+proc mayaUsdTranslatorExport_SetCheckbox(string $arg, string $widget) {
     if ($arg == "0") {
         checkBoxGrp -e -v1 false $widget;
     } else {
@@ -33,11 +23,11 @@ global proc mayausdTranslatorExport_SetCheckbox(string $arg, string $widget) {
     }
 }
 
-global proc mayausdTranslatorExport_SetTextField(string $arg, string $widget) {
+proc mayaUsdTranslatorExport_SetTextField(string $arg, string $widget) {
     textFieldGrp -e -text $arg $widget;
 }
 
-global proc mayausdTranslatorExport_SetOptionMenuByAnnotation(
+proc mayaUsdTranslatorExport_SetOptionMenuByAnnotation(
         string $ann, string $widget) {
     int $index = 1; // 1-based indexing.
     for ($i in `optionMenuGrp -q -itemListLong $widget`) {
@@ -50,7 +40,7 @@ global proc mayausdTranslatorExport_SetOptionMenuByAnnotation(
     }
 }
 
-global proc string mayausdTranslatorExport_AppendFromCheckbox(string $currentOptions, string $arg, string $widget) {
+proc string mayaUsdTranslatorExport_AppendFromCheckbox(string $currentOptions, string $arg, string $widget) {
     if (`checkBoxGrp -q -v1 $widget` == 1) {
         return $currentOptions + ";" + $arg + "=1";
     } else {
@@ -58,7 +48,7 @@ global proc string mayausdTranslatorExport_AppendFromCheckbox(string $currentOpt
     }
 }
 
-global proc string mayausdTranslatorExport_AppendFromPopup(string $currentOptions, string $arg, string $widget) {
+proc string mayaUsdTranslatorExport_AppendFromPopup(string $currentOptions, string $arg, string $widget) {
     int $index = `optionMenuGrp -q -select $widget` - 1;
     string $allItems[] = `optionMenuGrp -q -itemListLong $widget`;
     string $item = $allItems[$index];
@@ -66,25 +56,30 @@ global proc string mayausdTranslatorExport_AppendFromPopup(string $currentOption
     return $currentOptions + ";" + $arg + "=" + $annotation;
 }
 
-proc string mayausdTranslatorExport_AppendFrameRange(string $currentOptions) {
+proc string mayaUsdTranslatorExport_AppendFrameRange(string $currentOptions) {
     int $start = `intFieldGrp -q -value1 framRangeFields`;
     int $end = `intFieldGrp -q -value2 framRangeFields`;
     return $currentOptions + ";startTime=" + $start + ";endTime=" + $end;
 }
 
-global proc string mayausdTranslatorExport_AppendFromIntField(string $currentOptions, string $arg, string $widget) {
-    string $value = `intFieldGrp -q -value1 $widget`;
-    return $currentOptions + ";" + $arg + "=" + $value;
-}
-
-global proc string mayausdTranslatorExport_AppendFromFloatField(string $currentOptions, string $arg, string $widget) {
+proc string mayaUsdTranslatorExport_AppendFromFloatField(string $currentOptions, string $arg, string $widget) {
     string $value = `floatFieldGrp -q -value1 $widget`;
     return $currentOptions + ";" + $arg + "=" + $value;
 }
 
-global proc string mayausdTranslatorExport_AppendFromTextField(string $currentOptions, string $arg, string $widget) {
+proc string mayaUsdTranslatorExport_AppendFromTextField(string $currentOptions, string $arg, string $widget) {
     string $value = `textFieldGrp -q -text $widget`;
     return $currentOptions + ";" + $arg + "=" + $value;
+}
+
+global proc mayaUsdTranslatorExport_AnimationCB() {
+    columnLayout -e -visible (`checkBoxGrp -q -v1 animationCheckBox`) animOptsCol;
+}
+
+global proc mayaUsdTranslatorExport_AnimationRangeCB() {
+    int $startTime = `playbackOptions -q -animationStartTime`;
+    int $endTime = `playbackOptions -q -animationEndTime`;
+    intFieldGrp -e -v1 $startTime -v2 $endTime framRangeFields;
 }
 
 global proc int mayaUsdTranslatorExport (string $parent,
@@ -100,7 +95,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
 //  Parameters:
 //    $parent - the elf parent layout for this options layout. It is
 //            always a scrollLayout.
-//    $action - the action that is to be performed with this invokation of this proc.
+//    $action - the action that is to be performed with this invocation of this proc.
 //        Valid options are:
 //        "query" - construct the options string and pass it to the resultCallback.
 //        "post" - post all the elf controls.
@@ -109,7 +104,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
 //            resultCallback ( string $optionsString )
 //
 //    Returns:
-//        1 if successfull.
+//        1 if successful.
 //        0 otherwise.
 //
 {
@@ -150,12 +145,12 @@ global proc int mayaUsdTranslatorExport (string $parent,
         frameLayout -label "Animation" -collapsable true -collapse false;
             separator -style "none";
 
-            checkBoxGrp -l "Animation Data: " -cc ("mayausdTranslatorExport_AnimationCB") animationCheckBox;
+            checkBoxGrp -l "Animation Data: " -cc ("mayaUsdTranslatorExport_AnimationCB") animationCheckBox;
 
             columnLayout -width 100 animOptsCol;
                 rowLayout -numberOfColumns 2 -columnAttach 2 "left" 20;
                     intFieldGrp -l "Frame Range Start/End:" -numberOfFields 2 -v1 1 -v2 200 -cw 1 175 framRangeFields;
-                    button -l "Use Animation Range" -command ("mayausdTranslatorExport_AnimationRangeCB") animRangeButton;
+                    button -l "Use Animation Range" -command ("mayaUsdTranslatorExport_AnimationRangeCB") animRangeButton;
                 setParent ..;
 
                 floatFieldGrp -l "Frame Step:" -v1 1 -cw 1 175 frameStrideField;
@@ -189,15 +184,15 @@ global proc int mayaUsdTranslatorExport (string $parent,
             for ($index = 0; $index < size($optionList); $index++) {
                 tokenize($optionList[$index], "=", $optionBreakDown);
                 if ($optionBreakDown[0] == "exportUVs") {
-                    mayausdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportUVsCheckBox");
+                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportUVsCheckBox");
                 } else if ($optionBreakDown[0] == "exportColorSets") {
-                    mayausdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportColorSetsCheckBox");
+                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportColorSetsCheckBox");
                 } else if ($optionBreakDown[0] == "defaultMeshScheme") {
-                    mayausdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "defaultMeshSchemePopup");
+                    mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "defaultMeshSchemePopup");
                 } else if ($optionBreakDown[0] == "animation") {
-                    mayausdTranslatorExport_SetCheckbox($optionBreakDown[1], "animationCheckBox");
+                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "animationCheckBox");
                 } else if ($optionBreakDown[0] == "eulerFilter") {
-                    mayausdTranslatorExport_SetCheckbox($optionBreakDown[1], "eulerFilterCheckBox");
+                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "eulerFilterCheckBox");
                 } else if ($optionBreakDown[0] == "startTime") {
                     int $startTime=$optionBreakDown[1];
                     intFieldGrp -e -v1 $startTime framRangeFields;
@@ -208,36 +203,36 @@ global proc int mayaUsdTranslatorExport (string $parent,
                     float $frameStride = $optionBreakDown[1];
                     floatFieldGrp -e -v1 $frameStride frameStrideField;
                 } else if ($optionBreakDown[0] == "parentScope") {
-                    mayausdTranslatorExport_SetTextField($optionBreakDown[1], "parentScopeField");
+                    mayaUsdTranslatorExport_SetTextField($optionBreakDown[1], "parentScopeField");
                 } else if ($optionBreakDown[0] == "exportInstances") {
-                    mayausdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportInstancesCheckBox");                    
+                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportInstancesCheckBox");                    
                 } else if ($optionBreakDown[0] == "exportVisibility") {
-                    mayausdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportVisibilityCheckBox");
+                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportVisibilityCheckBox");
                 } else if ($optionBreakDown[0] == "mergeTransformAndShape") {
-                    mayausdTranslatorExport_SetCheckbox($optionBreakDown[1], "mergeTransformAndShapeCheckBox");                    
+                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "mergeTransformAndShapeCheckBox");                    
                 } else if ($optionBreakDown[0] == "stripNamespaces") {
-                    mayausdTranslatorExport_SetCheckbox($optionBreakDown[1], "stripNamespacesCheckBox");                    
+                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "stripNamespacesCheckBox");                    
                 }
             }
         }
         // Set visibility for anim widgets
-        mayausdTranslatorExport_AnimationCB();
+        mayaUsdTranslatorExport_AnimationCB();
 
         $bResult = 1;
 
     } else if ($action == "query") {
-        $currentOptions = mayausdTranslatorExport_AppendFromCheckbox($currentOptions, "exportUVs", "exportUVsCheckBox");
-        $currentOptions = mayausdTranslatorExport_AppendFromCheckbox($currentOptions, "exportColorSets", "exportColorSetsCheckBox");
-        $currentOptions = mayausdTranslatorExport_AppendFromPopup($currentOptions, "defaultMeshScheme", "defaultMeshSchemePopup");
-        $currentOptions = mayausdTranslatorExport_AppendFromCheckbox($currentOptions, "animation", "animationCheckBox");
-        $currentOptions = mayausdTranslatorExport_AppendFromCheckbox($currentOptions, "eulerFilter", "eulerFilterCheckBox");
-        $currentOptions = mayausdTranslatorExport_AppendFrameRange($currentOptions);
-        $currentOptions = mayausdTranslatorExport_AppendFromFloatField($currentOptions, "frameStride", "frameStrideField");
-        $currentOptions = mayausdTranslatorExport_AppendFromTextField($currentOptions, "parentScope", "parentScopeField");
-        $currentOptions = mayausdTranslatorExport_AppendFromCheckbox($currentOptions, "exportInstances", "exportInstancesCheckBox");
-        $currentOptions = mayausdTranslatorExport_AppendFromCheckbox($currentOptions, "exportVisibility", "exportVisibilityCheckBox");
-        $currentOptions = mayausdTranslatorExport_AppendFromCheckbox($currentOptions, "mergeTransformAndShape", "mergeTransformAndShapeCheckBox");
-        $currentOptions = mayausdTranslatorExport_AppendFromCheckbox($currentOptions, "stripNamespaces", "stripNamespacesCheckBox");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "exportUVs", "exportUVsCheckBox");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "exportColorSets", "exportColorSetsCheckBox");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromPopup($currentOptions, "defaultMeshScheme", "defaultMeshSchemePopup");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "animation", "animationCheckBox");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "eulerFilter", "eulerFilterCheckBox");
+        $currentOptions = mayaUsdTranslatorExport_AppendFrameRange($currentOptions);
+        $currentOptions = mayaUsdTranslatorExport_AppendFromFloatField($currentOptions, "frameStride", "frameStrideField");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromTextField($currentOptions, "parentScope", "parentScopeField");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "exportInstances", "exportInstancesCheckBox");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "exportVisibility", "exportVisibilityCheckBox");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "mergeTransformAndShape", "mergeTransformAndShapeCheckBox");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "stripNamespaces", "stripNamespacesCheckBox");
 
         eval($resultCallback+" \""+$currentOptions+"\"");
         $bResult = 1;


### PR DESCRIPTION
Adding a new Export Translator for the MayaUSD plugin.  Contains a minimal set of export options plus the UI to set them.  For the most part this is a direct copy of the Pixar options with only minor adjustments to how they show up in the export options window, which was easy enough to do since we have based the current read/write jobs in the core library on the Pixar plugin.