### PR TITLE
apply maya.standalone.uninitialize() fix from #198 to mayaUsd tests

### DIFF
--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -55,12 +55,15 @@ foreach(script ${test_script_files})
     add_test(
         NAME ${target}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        COMMAND ${MAYA_PY_EXECUTABLE} -c "from unittest import main; \
+        COMMAND ${MAYA_PY_EXECUTABLE} -c "import sys; \
+                                          from unittest import main; \
                                           import maya.standalone; \
                                           maya.standalone.initialize(name='python'); \
                                           import ${target}; \
-                                          main(module=${target}); \
-                                          maya.standalone.uninitialize()"
+                                          testProg = main(module=${target}, exit=False); \
+                                          maya.standalone.uninitialize(); \
+                                          sys.exit(not testProg.result.wasSuccessful());
+                                          "
     )
     set_property(TEST ${target} APPEND PROPERTY ENVIRONMENT
         "PATH=${path}"


### PR DESCRIPTION
This prevents `unittest.main()` from exiting on test failures and ensures that `maya.standalone.uninitialize()` gets called before returning success or failure.

@HamedSabri-adsk previously made this fix for the UFE tests in #198.