### PR TITLE
linux/rpath: fix relative path finding for symlinked dirs

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -83,8 +83,10 @@ function(mayaUsd_init_rpath rpathRef origin)
         else()
             set(origin "${CMAKE_INSTALL_PREFIX}/${origin}")
         endif()
-        get_filename_component(origin "${origin}" REALPATH)
     endif()
+    # mayaUsd_add_rpath uses REALPATH, so we must make sure we always
+    # do so here too, to get the right relative path
+    get_filename_component(origin "${origin}" REALPATH)
     set(${rpathRef} "${origin}" PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
This fixes linking issues if you happen to have a symlink as part of your build path.

Previously, mayaUsd_add_rpath would use "realpaths" when comparing to origin, but mayaUsd_init_rpath would ONLY use a realpath if the argument was originally a relative path.  Thus, if you fed in an absolute path with a symlink, you would end up comparing a symlink path to a realpath.