### PR TITLE
[al] make readAnimatedValues default to On

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/PluginRegister.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/PluginRegister.h
@@ -199,7 +199,7 @@ MStatus registerPlugin(AFnPlugin& plugin)
 
   if(!MGlobal::optionVarExists("AL_usdmaya_readAnimatedValues"))
   {
-    MGlobal::setOptionVarValue("AL_usdmaya_readAnimatedValues", false);
+    MGlobal::setOptionVarValue("AL_usdmaya_readAnimatedValues", true);
   }
 
   if(!MGlobal::optionVarExists("AL_usdmaya_selectionEnabled"))


### PR DESCRIPTION
...a recent AL change (97d3ff3e) added the ability to control the setting
for pushToPrim for newly created nodes via an optionVar, which is useful,
but it also changed the default from on to off.

In addition to being breaking behavior, this is also highly
non-intuitive for artists.

This is the sister PR to https://github.com/Autodesk/maya-usd/pull/149 - but I decided to break it into it's own PR, since the performance implications are potentially bigger, so I wanted to give others a chance to object.