### PR TITLE
VP2RenderDelegate support for USD curves

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -197,10 +197,13 @@ list(APPEND mayaUsdShaderFragments_xmls
     render/vp2ShaderFragments/FallbackShader.xml
     render/vp2ShaderFragments/Float4ToFloat3.xml
     render/vp2ShaderFragments/Float4ToFloat4.xml
+    render/vp2ShaderFragments/NwFaceCameraIfNAN.xml
+    render/vp2ShaderFragments/UsdPrimvarReader_color.xml
     render/vp2ShaderFragments/UsdPrimvarReader_float.xml
     render/vp2ShaderFragments/UsdPrimvarReader_float2.xml
     render/vp2ShaderFragments/UsdPrimvarReader_float3.xml
     render/vp2ShaderFragments/UsdPrimvarReader_float4.xml
+    render/vp2ShaderFragments/UsdPrimvarReader_vector.xml
     render/vp2ShaderFragments/UsdUVTexture.xml
     # USD plug info
     render/vp2ShaderFragments/plugInfo.json

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # =======================================================================
-# Copyright 2019 Autodesk
+# Copyright 2020 Autodesk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -144,6 +144,7 @@ list(APPEND mayaUsd_src
     render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
     render/pxrUsdMayaGL/userData.cpp
     #
+    render/vp2RenderDelegate/basisCurves.cpp
     render/vp2RenderDelegate/bboxGeom.cpp
     render/vp2RenderDelegate/debugCodes.cpp
     render/vp2RenderDelegate/draw_item.cpp
@@ -182,6 +183,16 @@ list(APPEND mayaUsdShaderFragments_xmls
     render/vp2ShaderFragments/usdPreviewSurfaceCombiner.xml
     render/vp2ShaderFragments/usdPreviewSurfaceLighting.xml
     # New fragments
+    render/vp2ShaderFragments/BasisCurvesLinearDomain_GLSL.xml
+    render/vp2ShaderFragments/BasisCurvesLinearDomain_HLSL.xml
+    render/vp2ShaderFragments/BasisCurvesLinearDomain_Cg.xml
+    render/vp2ShaderFragments/BasisCurvesLinearFallbackShader.xml
+    render/vp2ShaderFragments/BasisCurvesLinearHull.xml
+    render/vp2ShaderFragments/BasisCurvesCubicDomain_GLSL.xml
+    render/vp2ShaderFragments/BasisCurvesCubicDomain_HLSL.xml
+    render/vp2ShaderFragments/BasisCurvesCubicDomain_Cg.xml
+    render/vp2ShaderFragments/BasisCurvesCubicFallbackShader.xml
+    render/vp2ShaderFragments/BasisCurvesCubicHull.xml
     render/vp2ShaderFragments/FallbackCPVShader.xml
     render/vp2ShaderFragments/FallbackShader.xml
     render/vp2ShaderFragments/Float4ToFloat3.xml

--- a/lib/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/render/vp2RenderDelegate/basisCurves.cpp
@@ -1,0 +1,1674 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "basisCurves.h"
+#include "bboxGeom.h"
+#include "debugCodes.h"
+#include "draw_item.h"
+#include "material.h"
+#include "instancer.h"
+#include "render_delegate.h"
+#include "tokens.h"
+
+#include "pxr/base/gf/matrix4d.h"
+#include "pxr/base/gf/matrix4f.h"
+#include "pxr/base/vt/value.h"
+
+#include "pxr/imaging/hd/repr.h"
+#include "pxr/imaging/hd/sceneDelegate.h"
+#include "pxr/imaging/hd/tokens.h"
+
+#include <maya/MMatrix.h>
+#include <maya/MProfiler.h>
+#include <maya/MSelectionMask.h>
+
+// Conditional compilation due to Maya API gap.
+#if MAYA_API_VERSION >= 20210000
+#define MAYA_ALLOW_PRIMITIVE_TYPE_SWITCH
+#endif
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace {
+
+    //! Required primvars when there is no material binding.
+    const TfTokenVector sFallbackShaderPrimvars = {
+        HdTokens->displayColor,
+        HdTokens->displayOpacity,
+        HdTokens->normals,
+        HdTokens->widths
+    };
+
+    const MColor kSelectionHighlightColor(0.056f, 1.0f, 0.366f, 1.0f); //!< Selection highlight color
+    const MColor kOpaqueGray(.18f, .18f, .18f, 1.0f);                  //!< The default 18% gray color
+    const unsigned int kNumColorChannels = 4;                          //!< The number of color channels
+
+    //! Cached strings for efficiency
+    const MString kPositionsStr("positions");
+    const MString kNormalsStr("normals");
+    const MString kWidthStr("U0_1");
+    const MString kDiffuseColorStr("diffuseColor");
+    const MString kSolidColorStr("solidColor");
+
+    //! A primvar vertex buffer data map indexed by primvar name.
+    using PrimvarBufferDataMap = std::unordered_map<
+        TfToken,
+        void*,
+        TfToken::HashFunctor
+    >;
+
+    //! \brief  Helper struct used to package all the changes into single commit task
+    //!         (such commit task will be executed on main-thread)
+    struct CommitState {
+        HdVP2DrawItem::RenderItemData& _drawItemData;
+
+        //! If valid, new index buffer data to commit
+        int*    _indexBufferData{ nullptr };
+        //! If valid, new color buffer data to commit
+        void*   _colorBufferData{ nullptr };
+        //! If valid, new normals buffer data to commit
+        void*   _normalsBufferData{ nullptr };
+        //! If valid, new primvar buffer data to commit
+        PrimvarBufferDataMap _primvarBufferDataMap;
+
+        //! If valid, world matrix to set on the render item
+        MMatrix* _worldMatrix{ nullptr };
+
+        //! If valid, bounding box to set on the render item
+        MBoundingBox* _boundingBox{ nullptr };
+
+        //! if valid, enable or disable the render item
+        bool* _enabled{ nullptr };
+
+        //! if valid, set the primitive type on the render item
+        MHWRender::MGeometry::Primitive* _primitiveType{ nullptr };
+        //! if valid, set the primitive stride on the render item
+        int* _primitiveStride{ nullptr };
+
+        //! If valid, new shader instance to set
+        MHWRender::MShaderInstance* _shader{ nullptr };
+
+        //! Is this object transparent
+        bool _isTransparent{ false };
+
+        //! Instancing doesn't have dirty bits, every time we do update, we must update instance transforms
+        MMatrixArray _instanceTransforms;
+
+        //! Color array to support per-instance color and selection highlight.
+        MFloatArray _instanceColors;
+
+        //! If true, associate geometric buffers to the render item and trigger consolidation/instancing update
+        bool _geometryDirty{ false };
+
+        //! Construct valid commit state
+        CommitState(HdVP2DrawItem& item) : _drawItemData(item.GetRenderItemData())
+        {}
+
+        //! No default constructor, we need draw item and dirty bits.
+        CommitState() = delete;
+    };
+
+    template <typename T> VtArray<T>
+    InterpolateVarying(
+        size_t numVerts,
+        VtIntArray const & vertexCounts,
+        TfToken wrap,
+        TfToken basis,
+        VtArray<T> const & authoredValues)
+    {
+        VtArray<T> outputValues(numVerts);
+
+        size_t srcIndex = 0;
+        size_t dstIndex = 0;
+
+        if (wrap == HdTokens->periodic) {
+            // XXX : Add support for periodic curves
+            TF_WARN("Varying data is only supported for non-periodic curves.");
+        }
+
+        TF_FOR_ALL(itVertexCount, vertexCounts) {
+            int nVerts = *itVertexCount;
+
+            // Handling for the case of potentially incorrect vertex counts 
+            if(nVerts < 1) {
+                continue;
+            }
+
+            if(basis == HdTokens->catmullRom || basis == HdTokens->bSpline) {
+                // For splines with a vstep of 1, we are doing linear interpolation 
+                // between segments, so all we do here is duplicate the first and 
+                // last outputValues. Since these are never acutally used during 
+                // drawing, it would also work just to set the to 0.
+                outputValues[dstIndex] = authoredValues[srcIndex];
+                ++dstIndex;
+                for (int i = 1; i < nVerts - 2; ++i){
+                    outputValues[dstIndex] = authoredValues[srcIndex];
+                    ++dstIndex; ++srcIndex;
+                }
+                outputValues[dstIndex] = authoredValues[srcIndex];
+                ++dstIndex;
+                outputValues[dstIndex] = authoredValues[srcIndex];
+                ++dstIndex; ++srcIndex;
+            }
+            else if (basis == HdTokens->bezier){
+                // For bezier splines, we map the linear values to cubic values
+                // the begin value gets mapped to the first two vertices and
+                // the end value gets mapped to the last two vertices in a segment.
+                // shaders can choose to access value[1] and value[2] when linearly
+                // interpolating a value, which happens to match up with the
+                // indexing to use for catmullRom and bSpline basis.
+                int vStep = 3;
+                outputValues[dstIndex] = authoredValues[srcIndex];
+                ++dstIndex; // don't increment the srcIndex
+                outputValues[dstIndex] = authoredValues[srcIndex];
+                ++dstIndex; ++ srcIndex;
+
+                // vstep - 1 control points will have an interpolated value
+                for(int i = 2; i < nVerts - 2; i += vStep) {
+                    outputValues[dstIndex] = authoredValues[srcIndex];
+                    ++ dstIndex; // don't increment the srcIndex
+                    outputValues[dstIndex] = authoredValues[srcIndex];
+                    ++ dstIndex; // don't increment the srcIndex
+                    outputValues[dstIndex] = authoredValues[srcIndex];
+                    ++ dstIndex; ++ srcIndex; 
+                }
+                outputValues[dstIndex] = authoredValues[srcIndex];
+                ++dstIndex; // don't increment the srcIndex
+                outputValues[dstIndex] = authoredValues[srcIndex];
+                ++dstIndex; ++ srcIndex;
+            }
+            else {
+                TF_WARN("Unsupported basis: '%s'", basis.GetText());
+            }
+        }
+        TF_VERIFY(srcIndex == authoredValues.size());
+        TF_VERIFY(dstIndex == numVerts);
+    
+        return outputValues;
+    }
+
+    VtValue _BuildCubicIndexArray(const HdBasisCurvesTopology& topology)
+    {
+        /* 
+        Here's a diagram of what's happening in this code:
+
+        For open (non periodic, wrap = false) curves:
+
+          bezier (vStep = 3)
+          0------1------2------3------4------5------6 (vertex index)
+          [======= seg0 =======]
+                               [======= seg1 =======]
+
+
+          bspline / catmullRom (vStep = 1)
+          0------1------2------3------4------5------6 (vertex index)
+          [======= seg0 =======]
+                 [======= seg1 =======]
+                        [======= seg2 =======]
+                               [======= seg3 =======]
+
+
+        For closed (periodic, wrap = true) curves:
+
+           periodic bezier (vStep = 3)
+           0------1------2------3------4------5------0 (vertex index)
+           [======= seg0 =======]
+                                [======= seg1 =======]
+
+
+           periodic bspline / catmullRom (vStep = 1)
+           0------1------2------3------4------5------0------1------2 (vertex index)
+           [======= seg0 =======]
+                  [======= seg1 =======]
+                         [======= seg2 =======]
+                                [======= seg3 =======]
+                                       [======= seg4 =======]
+                                              [======= seg5 =======]
+        */
+        std::vector<GfVec4i> indices;
+
+        const VtArray<int> vertexCounts = topology.GetCurveVertexCounts();
+        bool wrap = topology.GetCurveWrap() == HdTokens->periodic;
+        int vStep;
+        TfToken basis = topology.GetCurveBasis();
+        if(basis == HdTokens->bezier) {
+            vStep = 3;
+        }
+        else {
+            vStep = 1;
+        }
+
+        int vertexIndex = 0;
+        int curveIndex = 0;
+        TF_FOR_ALL(itCounts, vertexCounts) {
+            int count = *itCounts;
+            // The first segment always eats up 4 verts, not just vstep, so to
+            // compensate, we break at count - 3.
+            int numSegs;
+
+            // If we're closing the curve, make sure that we have enough
+            // segments to wrap all the way back to the beginning.
+            if (wrap) {
+                numSegs = count / vStep;
+            } else {
+                numSegs = ((count - 4) / vStep) + 1;
+            }
+
+            for(int i = 0;i < numSegs; ++i) {
+
+                // Set up curve segments based on curve basis
+                GfVec4i seg;
+                int offset = i*vStep;
+                for(int v = 0;v < 4; ++v) {
+                    // If there are not enough verts to round out the segment
+                    // just repeat the last vert.
+                    seg[v] = wrap 
+                        ? vertexIndex + ((offset + v) % count)
+                        : vertexIndex + std::min(offset + v, (count -1));
+                }
+                indices.push_back(seg);
+            }
+            vertexIndex += count;
+            curveIndex++;
+        }
+
+        VtVec4iArray finalIndices(indices.size());
+        VtIntArray const &curveIndices = topology.GetCurveIndices();
+
+        // If have topology has indices set, map the generated indices
+        // with the given indices.
+        if (curveIndices.empty())
+        {
+            std::copy(indices.begin(), indices.end(), finalIndices.begin());
+        }
+        else
+        {
+            size_t lineCount = indices.size();
+            int maxIndex = curveIndices.size() - 1;
+
+            for (size_t lineNum = 0; lineNum < lineCount; ++lineNum)
+            {
+                const GfVec4i &line = indices[lineNum];
+
+                int i0 = std::min(line[0], maxIndex);
+                int i1 = std::min(line[1], maxIndex);
+                int i2 = std::min(line[2], maxIndex);
+                int i3 = std::min(line[3], maxIndex);
+
+                int v0 = curveIndices[i0];
+                int v1 = curveIndices[i1];
+                int v2 = curveIndices[i2];
+                int v3 = curveIndices[i3];
+
+                finalIndices[lineNum].Set(v0, v1, v2, v3);
+            }
+        }
+
+        return VtValue(finalIndices);
+    }
+
+    VtValue _BuildLinesIndexArray(const HdBasisCurvesTopology& topology)
+    {
+        std::vector<GfVec2i> indices;
+        VtArray<int> vertexCounts = topology.GetCurveVertexCounts();
+
+        int vertexIndex = 0;
+        int curveIndex = 0;
+        TF_FOR_ALL(itCounts, vertexCounts) {
+            for(int i = 0; i < *itCounts; i+= 2) {
+                indices.push_back(GfVec2i(vertexIndex, vertexIndex + 1));
+                vertexIndex += 2;
+            }
+            curveIndex++;
+        }
+
+        VtVec2iArray finalIndices(indices.size());
+        VtIntArray const &curveIndices = topology.GetCurveIndices();
+
+        // If have topology has indices set, map the generated indices
+        // with the given indices.
+        if (curveIndices.empty())
+        {
+            std::copy(indices.begin(), indices.end(), finalIndices.begin());
+        }
+        else
+        {
+            size_t lineCount = indices.size();
+            int maxIndex = curveIndices.size() - 1;
+
+            for (size_t lineNum = 0; lineNum < lineCount; ++lineNum)
+            {
+                const GfVec2i &line = indices[lineNum];
+
+                int i0 = std::min(line[0], maxIndex);
+                int i1 = std::min(line[1], maxIndex);
+
+                int v0 = curveIndices[i0];
+                int v1 = curveIndices[i1];
+
+                finalIndices[lineNum].Set(v0, v1);
+            }
+        }
+
+        return VtValue(finalIndices);
+    }
+
+    VtValue _BuildLineSegmentIndexArray(const HdBasisCurvesTopology& topology)
+    {
+        const TfToken basis = topology.GetCurveBasis();
+        const bool skipFirstAndLastSegs = (basis == HdTokens->catmullRom);
+
+        std::vector<GfVec2i> indices;
+        const VtArray<int> vertexCounts = topology.GetCurveVertexCounts();
+        bool wrap = topology.GetCurveWrap() == HdTokens->periodic;
+        int vertexIndex = 0; // Index of next vertex to emit
+        int curveIndex = 0;  // Index of next curve to emit
+        // For each curve
+        TF_FOR_ALL(itCounts, vertexCounts) {
+            int v0 = vertexIndex;
+            int v1;
+            // Store first vert index incase we are wrapping
+            const int firstVert = v0;
+            ++ vertexIndex;
+            for(int i = 1;i < *itCounts; ++i) {
+                v1 = vertexIndex;
+                ++ vertexIndex;
+                if (!skipFirstAndLastSegs || (i > 1 && i < (*itCounts)-1)) {
+                    indices.push_back(GfVec2i(v0, v1));
+                }
+                v0 = v1;
+            }
+            if(wrap) {
+                indices.push_back(GfVec2i(v0, firstVert));
+            }
+            ++curveIndex;
+        }
+
+        VtVec2iArray finalIndices(indices.size());
+        VtIntArray const &curveIndices = topology.GetCurveIndices();
+
+        // If have topology has indices set, map the generated indices
+        // with the given indices.
+        if (curveIndices.empty())
+        {
+            std::copy(indices.begin(), indices.end(), finalIndices.begin());
+        }
+        else
+        {
+            size_t lineCount = indices.size();
+            int maxIndex = curveIndices.size() - 1;
+
+            for (size_t lineNum = 0; lineNum < lineCount; ++lineNum)
+            {
+                const GfVec2i &line = indices[lineNum];
+
+                int i0 = std::min(line[0], maxIndex);
+                int i1 = std::min(line[1], maxIndex);
+
+                int v0 = curveIndices[i0];
+                int v1 = curveIndices[i1];
+
+                finalIndices[lineNum].Set(v0, v1);
+            }
+        }
+
+        return VtValue(finalIndices);
+    }
+
+    VtVec3fArray _BuildInterpolatedArray(
+        const HdBasisCurvesTopology& topology,
+        const VtVec3fArray& authoredData)
+    {
+        // We need to interpolate primvar depending on its type
+        size_t numVerts = topology.CalculateNeededNumberOfControlPoints();
+
+        VtVec3fArray result(numVerts);
+        size_t size = authoredData.size();
+
+        if(size == 1) {
+            // Uniform data
+            const GfVec3f& elem = authoredData[0];
+            for(size_t i = 0; i < numVerts; ++ i) {
+                result[i] = elem;
+            }
+        }
+        else if(size == numVerts) {
+            // Vertex data
+            result = authoredData;
+        }
+        else if(size == topology.CalculateNeededNumberOfVaryingControlPoints()) {
+            // Varying data
+            result = InterpolateVarying<GfVec3f>(numVerts,
+                topology.GetCurveVertexCounts(),
+                topology.GetCurveWrap(),
+                topology.GetCurveBasis(),
+                authoredData);
+        }
+        else {
+            // Fallback
+            const GfVec3f elem(1.0f, 0.0f, 0.0f);
+            for(size_t i = 0; i < numVerts; ++ i) {
+                result[i] = elem;
+            }
+            TF_WARN("Incorrect number of primvar data, using default GfVec3f(0,0,0) for rendering.");
+        }
+
+        return result;
+    }
+
+    VtFloatArray _BuildInterpolatedArray(
+        const HdBasisCurvesTopology& topology,
+        const VtFloatArray& authoredData)
+    {
+        // We need to interpolate primvar depending on its type
+        size_t numVerts = topology.CalculateNeededNumberOfControlPoints();
+
+        VtFloatArray result(numVerts);
+        size_t size = authoredData.size();
+
+        if(size == 1) {
+            // Uniform or missing data
+            float elem = authoredData[0];
+            for(size_t i = 0; i < numVerts; ++ i) {
+                result[i] = elem;
+            }
+        }
+        else if(size == numVerts) {
+            // Vertex data
+            result = authoredData;
+        }
+        else if(size == topology.CalculateNeededNumberOfVaryingControlPoints()) {
+            // Varying data
+            result = InterpolateVarying<float>(numVerts,
+                topology.GetCurveVertexCounts(),
+                topology.GetCurveWrap(),
+                topology.GetCurveBasis(),
+                authoredData);
+        }
+        else {
+            // Fallback
+            for(size_t i = 0; i < numVerts; ++ i) {
+                result[i] = 1.0;
+            }
+            TF_WARN("Incorrect number of primvar data, using default 1.0 for rendering.");
+        }
+
+        return result;
+    }
+
+    //! Helper utility function to adapt Maya API changes.
+    void setWantConsolidation(MHWRender::MRenderItem& renderItem, bool state)
+    {
+#if MAYA_API_VERSION >= 20190000
+        renderItem.setWantConsolidation(state);
+#else
+        renderItem.setWantSubSceneConsolidation(state);
+#endif
+    }
+} // anonymous namespace
+
+//! \brief  Constructor
+HdVP2BasisCurves::HdVP2BasisCurves(
+    HdVP2RenderDelegate *delegate,
+    SdfPath const &id,
+    SdfPath const &instancerId)
+: HdBasisCurves(id, instancerId)
+, _delegate(delegate)
+, _rprimId(id.GetText())
+{
+    const MHWRender::MVertexBufferDescriptor desc(
+        "",
+        MHWRender::MGeometry::kPosition,
+        MHWRender::MGeometry::kFloat,
+        3);
+
+    _curvesSharedData._positionsBuffer.reset(new MHWRender::MVertexBuffer(desc));
+}
+
+//! \brief  Synchronize VP2 state with scene delegate state based on dirty bits and repr
+void HdVP2BasisCurves::Sync(
+    HdSceneDelegate *delegate,
+    HdRenderParam   *renderParam,
+    HdDirtyBits     *dirtyBits,
+    TfToken const   &reprToken)
+{
+    // We don't create a repr for the selection token because this token serves
+    // for selection state update only. Return early to reserve dirty bits so
+    // they can be used to sync regular reprs later.
+    if (reprToken == HdVP2ReprTokens->selection) {
+        return;
+    }
+
+    MProfilingScope profilingScope(HdVP2RenderDelegate::sProfilerCategory,
+        MProfiler::kColorC_L2, _rprimId.asChar(), "HdVP2BasisCurves::Sync");
+
+    const SdfPath& id = GetId();
+
+    if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
+        _SetMaterialId(delegate->GetRenderIndex().GetChangeTracker(),
+            delegate->GetMaterialId(id));
+    }
+
+    if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->normals) ||
+        HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->primvar)) {
+        const HdVP2Material* material = static_cast<const HdVP2Material*>(
+            delegate->GetRenderIndex().GetSprim(
+                HdPrimTypeTokens->material, GetMaterialId())
+        );
+
+        const TfTokenVector& requiredPrimvars =
+            (material && material->GetSurfaceShader()) ?
+            material->GetRequiredPrimvars() : sFallbackShaderPrimvars;
+
+        _UpdatePrimvarSources(delegate, *dirtyBits, requiredPrimvars);
+    }
+
+    if (*dirtyBits & HdChangeTracker::DirtyDisplayStyle) {
+        _curvesSharedData._displayStyle = GetDisplayStyle(delegate);
+    }
+
+    if (HdChangeTracker::IsTopologyDirty(*dirtyBits, id)) {
+        _curvesSharedData._topology = GetBasisCurvesTopology(delegate);
+    }
+
+    // Prepare position buffer. It is shared among all draw items so it should
+    // be updated only once when it gets dirty.
+    if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->points)) {
+        const VtValue value = delegate->Get(id, HdTokens->points);
+        _curvesSharedData._points = value.Get<VtVec3fArray>();
+
+        const size_t numVertices = _curvesSharedData._points.size();
+
+        const HdBasisCurvesTopology& topology = _curvesSharedData._topology;
+        const size_t numControlPoints = topology.CalculateNeededNumberOfControlPoints();
+
+        if (!topology.HasIndices() && numVertices != numControlPoints) {
+            TF_WARN("Topology and vertices do not match for BasisCurve %s",
+                id.GetName().c_str());
+        }
+
+        void* bufferData = _curvesSharedData._positionsBuffer->acquire(numVertices, true);
+        if (bufferData) {
+            const size_t numBytes = sizeof(GfVec3f) * numVertices;
+            memcpy(bufferData, _curvesSharedData._points.cdata(), numBytes);
+
+            // Capture class member for lambda
+            MHWRender::MVertexBuffer* const positionsBuffer =
+                _curvesSharedData._positionsBuffer.get();
+            const MString& rprimId = _rprimId;
+
+            _delegate->GetVP2ResourceRegistry().EnqueueCommit(
+                [positionsBuffer, bufferData, rprimId]() {
+                    MProfilingScope profilingScope(
+                        HdVP2RenderDelegate::sProfilerCategory,
+                        MProfiler::kColorC_L2,
+                        rprimId.asChar(),
+                        "CommitPositions");
+
+                    positionsBuffer->commit(bufferData);
+                }
+            );
+        }
+    }
+
+    if (HdChangeTracker::IsExtentDirty(*dirtyBits, id)) {
+        _sharedData.bounds.SetRange(delegate->GetExtent(id));
+    }
+
+    if (HdChangeTracker::IsTransformDirty(*dirtyBits, id)) {
+        _sharedData.bounds.SetMatrix(delegate->GetTransform(id));
+    }
+
+    if (HdChangeTracker::IsVisibilityDirty(*dirtyBits, id)) {
+        _sharedData.visible = delegate->GetVisible(id);
+    }
+
+    *dirtyBits = HdChangeTracker::Clean;
+
+    // Draw item update is controlled by its own dirty bits.
+    _UpdateRepr(delegate, reprToken);
+}
+
+/*! \brief  Update the draw item
+
+    This call happens on worker threads and results of the change are collected
+    in CommitState and enqueued for Commit on main-thread using CommitTasks
+*/
+void
+HdVP2BasisCurves::_UpdateDrawItem(
+    HdSceneDelegate *sceneDelegate,
+    HdVP2DrawItem *drawItem,
+    HdBasisCurvesReprDesc const &desc)
+{
+    const MHWRender::MRenderItem* renderItem = drawItem->GetRenderItem();
+    if (ARCH_UNLIKELY(!renderItem)) {
+        return;
+    }
+
+    const HdDirtyBits itemDirtyBits = drawItem->GetDirtyBits();
+
+    // We don't need to update the dedicated selection highlight item when there
+    // is no selection highlight change and the prim is not selected. Draw item
+    // has its own dirty bits, so update will be doner when it shows in viewport.
+    const bool isDedicatedSelectionHighlightItem =
+        drawItem->MatchesUsage(HdVP2DrawItem::kSelectionHighlight);
+    if (isDedicatedSelectionHighlightItem &&
+        ((itemDirtyBits & DirtySelectionHighlight) == 0) &&
+        (_selectionState == kUnselected)) {
+        return;
+    }
+
+    CommitState stateToCommit(*drawItem);
+    HdVP2DrawItem::RenderItemData& drawItemData = stateToCommit._drawItemData;
+
+    const SdfPath& id = GetId();
+
+    auto* const param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
+    ProxyRenderDelegate& drawScene = param->GetDrawScene();
+
+    const HdRenderIndex& renderIndex = sceneDelegate->GetRenderIndex();
+
+    const auto& primvarSourceMap = _curvesSharedData._primvarSourceMap;
+
+    const HdBasisCurvesTopology& topology = _curvesSharedData._topology;
+    const VtIntArray& curveVertexCounts = topology.GetCurveVertexCounts();
+    const size_t numCurves = curveVertexCounts.size();
+    const size_t numControlPoints = topology.CalculateNeededNumberOfControlPoints();
+
+    const TfToken type = topology.GetCurveType();
+    const TfToken wrap = topology.GetCurveWrap();
+
+    const MHWRender::MGeometry::DrawMode drawMode = renderItem->drawMode();
+
+    // The bounding box item uses a globally-shared geometry data therefore it
+    // doesn't need to extract index data from the prim.
+    const bool requiresIndexUpdate = (drawMode != MHWRender::MGeometry::kBoundingBox);
+
+    // Prepare index buffer.
+    if (requiresIndexUpdate && (itemDirtyBits & HdChangeTracker::DirtyTopology)) {
+
+        const bool forceLines =
+            (_curvesSharedData._displayStyle.refineLevel <= 0) ||
+            (drawMode == MHWRender::MGeometry::kWireframe);
+
+        VtValue result;
+
+        if (!forceLines && type == HdTokens->cubic) {
+            result = _BuildCubicIndexArray(topology);
+        }
+        else if (wrap == HdTokens->segmented) {
+            result = _BuildLinesIndexArray(topology);
+        }
+        else {
+            result = _BuildLineSegmentIndexArray(topology);
+        }
+
+        const void* indexData = nullptr;
+        unsigned int numIndices = 0;
+
+        if (result.IsHolding<VtVec2iArray>()) {
+            indexData = result.UncheckedGet<VtVec2iArray>().cdata();
+            numIndices = result.GetArraySize() * 2;
+        }
+        else if (result.IsHolding<VtVec4iArray>()) {
+            indexData = result.UncheckedGet<VtVec4iArray>().cdata();
+            numIndices = result.GetArraySize() * 4;
+        }
+
+        if (drawItemData._indexBuffer && numIndices > 0) {
+            stateToCommit._indexBufferData = static_cast<int*>(
+                drawItemData._indexBuffer->acquire(numIndices, true));
+
+            if (indexData != nullptr && stateToCommit._indexBufferData != nullptr) {
+                memcpy(stateToCommit._indexBufferData, indexData,
+                    numIndices * sizeof(int));
+            }
+        }
+    }
+
+    if (desc.geomStyle == HdBasisCurvesGeomStylePatch) {
+        // Prepare normals buffer.
+        if (itemDirtyBits &
+            (HdChangeTracker::DirtyNormals | HdChangeTracker::DirtyDisplayStyle)) {
+            // Using a zero vector to indicate requirement of camera-facing
+            // normals when there is no authored normals.
+            VtVec3fArray normals(1, GfVec3f(0.0f, 0.0f, 0.0f));
+
+            const auto it = primvarSourceMap.find(HdTokens->normals);
+            if (it != primvarSourceMap.end()) {
+                const VtValue& value = it->second.data;
+                if (ARCH_LIKELY(value.IsHolding<VtVec3fArray>())) {
+                    normals = value.UncheckedGet<VtVec3fArray>();
+                }
+            }
+
+            normals = _BuildInterpolatedArray(topology, normals);
+
+            if (!drawItemData._normalsBuffer) {
+                const MHWRender::MVertexBufferDescriptor vbDesc("",
+                    MHWRender::MGeometry::kNormal,
+                    MHWRender::MGeometry::kFloat,
+                    3);
+
+                drawItemData._normalsBuffer.reset(
+                    new MHWRender::MVertexBuffer(vbDesc));
+            }
+
+            unsigned int numNormals = normals.size();
+            if (drawItemData._normalsBuffer && numNormals > 0) {
+                stateToCommit._normalsBufferData =
+                    drawItemData._normalsBuffer->acquire(numNormals, true);
+
+                if (stateToCommit._normalsBufferData != nullptr) {
+                    memcpy(stateToCommit._normalsBufferData, normals.cdata(),
+                        numNormals * sizeof(GfVec3f));
+                }
+            }
+        }
+
+        // Prepare widths buffer.
+        if ((_curvesSharedData._displayStyle.refineLevel > 0) &&
+            (itemDirtyBits & (HdChangeTracker::DirtyPrimvar |
+                              HdChangeTracker::DirtyDisplayStyle))) {
+            VtFloatArray widths(1, 1.0f);
+
+            const auto it = primvarSourceMap.find(HdTokens->widths);
+            if (it != primvarSourceMap.end()) {
+                const VtValue& value = it->second.data;
+                if (value.IsHolding<VtFloatArray>()) {
+                    widths = value.UncheckedGet<VtFloatArray>();
+                }
+            }
+
+            widths = _BuildInterpolatedArray(topology, widths);
+
+            MHWRender::MVertexBuffer* widthsBuffer =
+                drawItemData._primvarBuffers[HdTokens->widths].get();
+
+            if (!widthsBuffer) {
+                const MHWRender::MVertexBufferDescriptor vbDesc("",
+                    MHWRender::MGeometry::kTexture,
+                    MHWRender::MGeometry::kFloat,
+                    1);
+
+                widthsBuffer = new MHWRender::MVertexBuffer(vbDesc);
+                drawItemData._primvarBuffers[HdTokens->widths].reset(widthsBuffer);
+            }
+
+            unsigned int numWidths = widths.size();
+            if (widthsBuffer && numWidths > 0) {
+                void* bufferData = widthsBuffer->acquire(numWidths, true);
+                stateToCommit._primvarBufferDataMap[HdTokens->widths] = bufferData;
+
+                if (bufferData != nullptr) {
+                    memcpy(bufferData, widths.cdata(), numWidths * sizeof(float));
+                }
+            }
+        }
+
+        // Prepare color buffer.
+        if (itemDirtyBits & HdChangeTracker::DirtyMaterialId) {
+            const HdVP2Material* material = static_cast<const HdVP2Material*>(
+                renderIndex.GetSprim(HdPrimTypeTokens->material, GetMaterialId())
+            );
+
+            if (material) {
+                MHWRender::MShaderInstance* shader = material->GetSurfaceShader();
+                if (shader != nullptr && shader != drawItemData._shader) {
+                    drawItemData._shader = shader;
+                    stateToCommit._shader = shader;
+                    stateToCommit._isTransparent = shader->isTransparent();
+                }
+
+                auto primitiveType = MHWRender::MGeometry::kLines;
+                int primitiveStride = 0;
+
+                if (primitiveType != drawItemData._primitiveType ||
+                    primitiveStride != drawItemData._primitiveStride) {
+
+                    drawItemData._primitiveType = primitiveType;
+                    stateToCommit._primitiveType = &drawItemData._primitiveType;
+
+                    drawItemData._primitiveStride = primitiveStride;
+                    stateToCommit._primitiveStride = &drawItemData._primitiveStride;
+                }
+            }
+        }
+
+        if (itemDirtyBits & (HdChangeTracker::DirtyPrimvar |
+                             HdChangeTracker::DirtyDisplayStyle |
+                             DirtySelectionHighlight)) {
+            // If color/opacity is not found, the 18% gray color will be used
+            // to match the default color of Hydra Storm.
+            VtVec3fArray colorArray(1, GfVec3f(0.18f, 0.18f, 0.18f));
+            VtFloatArray alphaArray(1, 1.0f);
+
+            auto itColor = primvarSourceMap.find(HdTokens->displayColor);
+            if (itColor != primvarSourceMap.end()) {
+                const VtValue& value = itColor->second.data;
+                if (value.IsHolding<VtVec3fArray>() && value.GetArraySize() > 0) {
+                    colorArray = value.UncheckedGet<VtVec3fArray>();
+                }
+            }
+
+            auto itOpacity = primvarSourceMap.find(HdTokens->displayOpacity);
+            if (itOpacity != primvarSourceMap.end()) {
+                const VtValue& value = itOpacity->second.data;
+                if (value.IsHolding<VtFloatArray>() && value.GetArraySize() > 0) {
+                    alphaArray = value.UncheckedGet<VtFloatArray>();
+                }
+            }
+
+            if (colorArray.size() == 1 && alphaArray.size() == 1) {
+                // Use fallback shader if there is no material binding or we
+                // failed to create a shader instance from the material.
+                if (!stateToCommit._shader) {
+                    const GfVec3f& color = colorArray[0];
+                    const MColor clr(color[0], color[1], color[2], alphaArray[0]);
+
+                    MHWRender::MShaderInstance* shader = nullptr;
+                    auto primitiveType = MHWRender::MGeometry::kLines;
+                    int primitiveStride = 0;
+
+                    if (_curvesSharedData._displayStyle.refineLevel <= 0) {
+                        shader = _delegate->Get3dSolidShader(clr);
+                    }
+                    else if (type == HdTokens->linear) {
+                        shader = _delegate->GetBasisCurvesLinearFallbackShader(clr);
+                        primitiveType = MHWRender::MGeometry::kPatch;
+                        primitiveStride = 2;
+                    }
+                    else {
+                        shader = _delegate->GetBasisCurvesCubicFallbackShader(clr);
+                        primitiveType = MHWRender::MGeometry::kPatch;
+                        primitiveStride = 4;
+                    }
+
+                    if (shader != nullptr && shader != drawItemData._shader) {
+                        drawItemData._shader = shader;
+                        stateToCommit._shader = shader;
+                    }
+
+                    if (primitiveType != drawItemData._primitiveType ||
+                        primitiveStride != drawItemData._primitiveStride) {
+                        drawItemData._primitiveType = primitiveType;
+                        stateToCommit._primitiveType = &drawItemData._primitiveType;
+
+                        drawItemData._primitiveStride = primitiveStride;
+                        stateToCommit._primitiveStride = &drawItemData._primitiveStride;
+                    }
+                }
+            }
+            else {
+                colorArray = _BuildInterpolatedArray(topology, colorArray);
+                alphaArray = _BuildInterpolatedArray(topology, alphaArray);
+
+                const unsigned int numColors = colorArray.size();
+                const unsigned int numAlphas = alphaArray.size();
+                const unsigned int numVertices =
+                    numColors <= numAlphas ? numColors : numAlphas;
+
+                if (numColors != numAlphas) {
+                    TF_CODING_ERROR("color and opacity do not match for BasisCurve %s",
+                        id.GetName().c_str());
+                }
+
+                // Fill color and opacity into the float4 color stream.
+                if (!drawItemData._colorBuffer) {
+                    const MHWRender::MVertexBufferDescriptor vbDesc("",
+                        MHWRender::MGeometry::kColor,
+                        MHWRender::MGeometry::kFloat,
+                        4);
+
+                    drawItemData._colorBuffer.reset(
+                        new MHWRender::MVertexBuffer(vbDesc));
+                }
+
+                float* bufferData = static_cast<float*>(
+                    drawItemData._colorBuffer->acquire(numVertices, true));
+
+                if (bufferData) {
+                    unsigned int offset = 0;
+                    for (unsigned int v = 0; v < numVertices; v++) {
+                        const GfVec3f& color = colorArray[v];
+                        bufferData[offset++] = color[0];
+                        bufferData[offset++] = color[1];
+                        bufferData[offset++] = color[2];
+
+                        bufferData[offset++] = alphaArray[v];
+                    }
+
+                    stateToCommit._colorBufferData = bufferData;
+                }
+
+                // Use 3d CPV solid-color shader if there is no material binding or
+                // we failed to create a shader instance from the material.
+                if (!stateToCommit._shader) {
+                    MHWRender::MShaderInstance* shader = _delegate->Get3dCPVSolidShader();
+
+                    if (shader != nullptr && shader != drawItemData._shader) {
+                        drawItemData._shader = shader;
+                        stateToCommit._shader = shader;
+                    }
+
+                    auto primitiveType = MHWRender::MGeometry::kLines;
+                    int primitiveStride = 0;
+
+                    if (primitiveType != drawItemData._primitiveType ||
+                        primitiveStride != drawItemData._primitiveStride) {
+
+                        drawItemData._primitiveType = primitiveType;
+                        stateToCommit._primitiveType = &drawItemData._primitiveType;
+
+                        drawItemData._primitiveStride = primitiveStride;
+                        stateToCommit._primitiveStride = &drawItemData._primitiveStride;
+                    }
+                }
+            }
+
+            // It is possible that all elements in the opacity array are 1.
+            // Due to the performance indication about transparency, we have to
+            // traverse the array and enable transparency only when needed.
+            if (!stateToCommit._isTransparent) {
+                const size_t numAlphas = alphaArray.size();
+                for (size_t i = 0; i < numAlphas; i++) {
+                    if (alphaArray[i] < 0.999f) {
+                        stateToCommit._isTransparent = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // Local bounds
+    const GfRange3d& range = _sharedData.bounds.GetRange();
+
+    // Bounds are updated through MPxSubSceneOverride::setGeometryForRenderItem()
+    // which is expensive, so it is updated only when it gets expanded in order
+    // to reduce calling frequence.
+    if (itemDirtyBits & HdChangeTracker::DirtyExtent) {
+        const GfRange3d& rangeToUse =
+            (drawMode == MHWRender::MGeometry::kBoundingBox) ?
+            _delegate->GetSharedBBoxGeom().GetRange() : range;
+
+        bool boundingBoxExpanded = false;
+
+        const GfVec3d& min = rangeToUse.GetMin();
+        const MPoint pntMin(min[0], min[1], min[2]);
+        if (!drawItemData._boundingBox.contains(pntMin)) {
+            drawItemData._boundingBox.expand(pntMin);
+            boundingBoxExpanded = true;
+        }
+
+        const GfVec3d& max = rangeToUse.GetMax();
+        const MPoint pntMax(max[0], max[1], max[2]);
+        if (!drawItemData._boundingBox.contains(pntMax)) {
+            drawItemData._boundingBox.expand(pntMax);
+            boundingBoxExpanded = true;
+        }
+
+        if (boundingBoxExpanded) {
+            stateToCommit._boundingBox = &drawItemData._boundingBox;
+        }
+    }
+
+    // Local-to-world transformation
+    MMatrix& worldMatrix = drawItemData._worldMatrix;
+    _sharedData.bounds.GetMatrix().Get(worldMatrix.matrix);
+
+    // The bounding box draw item uses a globally-shared unit wire cube as the
+    // geometry and transfers scale and offset of the bounds to world matrix.
+    if (drawMode == MHWRender::MGeometry::kBoundingBox) {
+        if ((itemDirtyBits & (HdChangeTracker::DirtyExtent | HdChangeTracker::DirtyTransform)) &&
+            !range.IsEmpty()) {
+            const GfVec3d midpoint = range.GetMidpoint();
+            const GfVec3d size = range.GetSize();
+
+            MTransformationMatrix transformation;
+            transformation.setScale(size.data(), MSpace::kTransform);
+            transformation.setTranslation(midpoint.data(), MSpace::kTransform);
+            worldMatrix = transformation.asMatrix() * worldMatrix;
+            stateToCommit._worldMatrix = &drawItemData._worldMatrix;
+        }
+    }
+    else if (itemDirtyBits & HdChangeTracker::DirtyTransform) {
+        stateToCommit._worldMatrix = &drawItemData._worldMatrix;
+    }
+
+    // If the prim is instanced, create one new instance per transform.
+    // The current instancer invalidation tracking makes it hard for
+    // us to tell whether transforms will be dirty, so this code
+    // pulls them every time something changes.
+    if (!GetInstancerId().IsEmpty()) {
+
+        // Retrieve instance transforms from the instancer.
+        HdInstancer *instancer = renderIndex.GetInstancer(GetInstancerId());
+        VtMatrix4dArray transforms = static_cast<HdVP2Instancer*>(instancer)->
+            ComputeInstanceTransforms(id);
+
+        MMatrix instanceMatrix;
+
+        if (isDedicatedSelectionHighlightItem) {
+            if (_selectionState == kFullySelected) {
+                stateToCommit._instanceTransforms.setLength(transforms.size());
+                for (size_t i = 0; i < transforms.size(); ++i) {
+                    transforms[i].Get(instanceMatrix.matrix);
+                    instanceMatrix = worldMatrix * instanceMatrix;
+                    stateToCommit._instanceTransforms[i] = instanceMatrix;
+                }
+            }
+            else if (auto state = drawScene.GetPrimSelectionState(id)) {
+                for (const auto& indexArray : state->instanceIndices) {
+                    for (const auto index : indexArray) {
+                        transforms[index].Get(instanceMatrix.matrix);
+                        instanceMatrix = worldMatrix * instanceMatrix;
+                        stateToCommit._instanceTransforms.append(instanceMatrix);
+                    }
+                }
+            }
+        }
+        else {
+            const unsigned int instanceCount = transforms.size();
+            stateToCommit._instanceTransforms.setLength(instanceCount);
+            for (size_t i = 0; i < instanceCount; ++i) {
+                transforms[i].Get(instanceMatrix.matrix);
+                instanceMatrix = worldMatrix * instanceMatrix;
+                stateToCommit._instanceTransforms[i] = instanceMatrix;
+            }
+
+            // If the item is used for both regular draw and selection highlight,
+            // it needs to display both wireframe color and selection highlight
+            // with one color vertex buffer.
+            if (drawItem->ContainsUsage(HdVP2DrawItem::kSelectionHighlight)) {
+                const MColor& color = drawScene.GetWireframeColor();
+                unsigned int offset = 0;
+
+                stateToCommit._instanceColors.setLength(instanceCount * kNumColorChannels);
+                for (unsigned int i = 0; i < instanceCount; ++i) {
+                    for (unsigned int j = 0; j < kNumColorChannels; j++) {
+                        stateToCommit._instanceColors[offset++] = color[j];
+                    }
+                }
+
+                if (auto state = drawScene.GetPrimSelectionState(id)) {
+                    for (const auto& indexArray : state->instanceIndices) {
+                        for (const auto i : indexArray) {
+                            offset = i * kNumColorChannels;
+                            for (unsigned int j = 0; j < kNumColorChannels; j++) {
+                                stateToCommit._instanceColors[offset+j] = kSelectionHighlightColor[j];
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    else {
+        // Non-instanced Rprims.
+        if (itemDirtyBits & (DirtySelectionHighlight | HdChangeTracker::DirtyDisplayStyle)) {
+            if (drawItem->ContainsUsage(HdVP2DrawItem::kRegular) &&
+                drawItem->ContainsUsage(HdVP2DrawItem::kSelectionHighlight)) {
+                MHWRender::MShaderInstance* shader = nullptr;
+
+                auto primitiveType = MHWRender::MGeometry::kLines;
+                int primitiveStride = 0;
+
+                if (desc.geomStyle == HdBasisCurvesGeomStylePatch) {
+                    if (_selectionState != kUnselected) {
+                        if (_curvesSharedData._displayStyle.refineLevel <= 0) {
+                            shader = _delegate->Get3dSolidShader(kSelectionHighlightColor);
+                        }
+                        else if (type == HdTokens->linear) {
+                            shader = _delegate->GetBasisCurvesLinearFallbackShader(kSelectionHighlightColor);
+                            primitiveType = MHWRender::MGeometry::kPatch;
+                            primitiveStride = 2;
+                        }
+                        else {
+                            shader = _delegate->GetBasisCurvesCubicFallbackShader(kSelectionHighlightColor);
+                            primitiveType = MHWRender::MGeometry::kPatch;
+                            primitiveStride = 4;
+                        }
+                    }
+                }
+                else {
+                    shader = _delegate->Get3dSolidShader(
+                        (_selectionState != kUnselected) ?
+                        kSelectionHighlightColor :
+                        drawScene.GetWireframeColor()
+                    );
+                }
+
+                if (shader != nullptr && shader != drawItemData._shader) {
+                    drawItemData._shader = shader;
+                    stateToCommit._shader = shader;
+                    stateToCommit._isTransparent = false;
+
+                    if (primitiveType != drawItemData._primitiveType ||
+                        primitiveStride != drawItemData._primitiveStride) {
+                        drawItemData._primitiveType = primitiveType;
+                        stateToCommit._primitiveType = &drawItemData._primitiveType;
+
+                        drawItemData._primitiveStride = primitiveStride;
+                        stateToCommit._primitiveStride = &drawItemData._primitiveStride;
+                    }
+                }
+            }
+        }
+    }
+
+    if (itemDirtyBits & HdChangeTracker::DirtyVisibility) {
+        drawItemData._enabled = drawItem->GetVisible();
+        stateToCommit._enabled = &drawItemData._enabled;
+    }
+
+    if (isDedicatedSelectionHighlightItem) {
+        if (itemDirtyBits & DirtySelectionHighlight) {
+            const bool enable =
+                (_selectionState != kUnselected) && drawItem->GetVisible();
+            if (drawItemData._enabled != enable) {
+                drawItemData._enabled = enable;
+                stateToCommit._enabled = &drawItemData._enabled;
+            }
+        }
+    }
+    else if (drawMode == MHWRender::MGeometry::kBoundingBox) {
+        if (itemDirtyBits & HdChangeTracker::DirtyExtent) {
+            const bool enable = !range.IsEmpty() && drawItem->GetVisible();
+            if (drawItemData._enabled != enable) {
+                drawItemData._enabled = enable;
+                stateToCommit._enabled = &drawItemData._enabled;
+            }
+        }
+    }
+
+    stateToCommit._geometryDirty = (itemDirtyBits & (
+        HdChangeTracker::DirtyPoints |
+        HdChangeTracker::DirtyNormals |
+        HdChangeTracker::DirtyPrimvar |
+        HdChangeTracker::DirtyTopology));
+
+    // Reset dirty bits because we've prepared commit state for this draw item.
+    drawItem->ResetDirtyBits();
+
+    // Capture the valid position buffer and index buffer
+    MHWRender::MVertexBuffer* positionsBuffer = _curvesSharedData._positionsBuffer.get();
+    MHWRender::MIndexBuffer* indexBuffer = drawItemData._indexBuffer.get();
+
+    if (drawMode == MHWRender::MGeometry::kBoundingBox) {
+        const HdVP2BBoxGeom& sharedBBoxGeom = _delegate->GetSharedBBoxGeom();
+        positionsBuffer = const_cast<MHWRender::MVertexBuffer*>(
+            sharedBBoxGeom.GetPositionBuffer());
+        indexBuffer = const_cast<MHWRender::MIndexBuffer*>(
+            sharedBBoxGeom.GetIndexBuffer());
+    }
+
+    _delegate->GetVP2ResourceRegistry().EnqueueCommit(
+        [drawItem, stateToCommit, param, positionsBuffer, indexBuffer]()
+    {
+        MHWRender::MRenderItem* renderItem = drawItem->GetRenderItem();
+        if (ARCH_UNLIKELY(!renderItem))
+            return;
+
+        MProfilingScope profilingScope(HdVP2RenderDelegate::sProfilerCategory,
+            MProfiler::kColorC_L2, drawItem->GetRenderItemName().asChar(), "Commit");
+
+        const HdVP2DrawItem::RenderItemData& drawItemData = stateToCommit._drawItemData;
+
+        MHWRender::MVertexBuffer* colorBuffer = drawItemData._colorBuffer.get();
+        MHWRender::MVertexBuffer* normalsBuffer = drawItemData._normalsBuffer.get();
+
+        const HdVP2DrawItem::PrimvarBufferMap& primvarBuffers = drawItemData._primvarBuffers;
+
+        // If available, something changed
+        if (stateToCommit._colorBufferData)
+            colorBuffer->commit(stateToCommit._colorBufferData);
+
+        // If available, something changed
+        if (stateToCommit._normalsBufferData)
+            normalsBuffer->commit(stateToCommit._normalsBufferData);
+
+        // If available, something changed
+        for (const auto& entry : stateToCommit._primvarBufferDataMap) {
+            const TfToken& primvarName = entry.first;
+            void* primvarBufferData = entry.second;
+            if (primvarBufferData) {
+                const auto it = primvarBuffers.find(primvarName);
+                if (it != primvarBuffers.end()) {
+                    MHWRender::MVertexBuffer* primvarBuffer = it->second.get();
+                    if (primvarBuffer) {
+                        primvarBuffer->commit(primvarBufferData);
+                    }
+                }
+            }
+        }
+
+        // If available, something changed
+        if (stateToCommit._indexBufferData)
+            indexBuffer->commit(stateToCommit._indexBufferData);
+
+        // If available, something changed
+        if (stateToCommit._shader != nullptr) {
+            renderItem->setShader(stateToCommit._shader);
+            renderItem->setTreatAsTransparent(stateToCommit._isTransparent);
+        }
+
+        // If the enable state is changed, then update it.
+        if (stateToCommit._enabled != nullptr) {
+            renderItem->enable(*stateToCommit._enabled);
+        }
+
+#if defined(MAYA_ALLOW_PRIMITIVE_TYPE_SWITCH)
+        // If the primitive type and stride are changed, then update them.
+        if (stateToCommit._primitiveType != nullptr &&
+            stateToCommit._primitiveStride != nullptr) {
+            auto primitive = *stateToCommit._primitiveType;
+            int stride = *stateToCommit._primitiveStride;
+            renderItem->setPrimitive(primitive, stride);
+
+            const bool wantConsolidation =
+                !stateToCommit._drawItemData._usingInstancedDraw &&
+                primitive != MHWRender::MGeometry::kPatch;
+            setWantConsolidation(*renderItem, wantConsolidation);
+        }
+#endif
+
+        ProxyRenderDelegate& drawScene = param->GetDrawScene();
+
+        if (stateToCommit._geometryDirty || stateToCommit._boundingBox) {
+            MHWRender::MVertexBufferArray vertexBuffers;
+            vertexBuffers.addBuffer(kPositionsStr, positionsBuffer);
+
+            if (colorBuffer)
+                vertexBuffers.addBuffer(kDiffuseColorStr, colorBuffer);
+
+            if (normalsBuffer)
+                vertexBuffers.addBuffer(kNormalsStr, normalsBuffer);
+
+            for (auto& entry : primvarBuffers) {
+                const TfToken& primvarName = entry.first;
+                MHWRender::MVertexBuffer* primvarBuffer = entry.second.get();
+                if (primvarBuffer) {
+                    vertexBuffers.addBuffer(primvarName.GetText(), primvarBuffer);
+                }
+            }
+
+            // The API call does three things:
+            // - Associate geometric buffers with the render item.
+            // - Update bounding box.
+            // - Trigger consolidation/instancing update.
+            drawScene.setGeometryForRenderItem(*renderItem,
+                vertexBuffers, *indexBuffer, stateToCommit._boundingBox);
+        }
+
+        // Important, update instance transforms after setting geometry on render items!
+        auto& oldInstanceCount = stateToCommit._drawItemData._instanceCount;
+        auto newInstanceCount = stateToCommit._instanceTransforms.length();
+
+        // GPU instancing has been enabled. We cannot switch to consolidation
+        // without recreating render item, so we keep using GPU instancing.
+        if (stateToCommit._drawItemData._usingInstancedDraw) {
+            if (oldInstanceCount == newInstanceCount) {
+                for (unsigned int i = 0; i < newInstanceCount; i++) {
+                    // VP2 defines instance ID of the first instance to be 1.
+                    drawScene.updateInstanceTransform(*renderItem,
+                        i+1, stateToCommit._instanceTransforms[i]);
+                }
+            } else {
+                drawScene.setInstanceTransformArray(*renderItem,
+                    stateToCommit._instanceTransforms);
+            }
+
+            if (stateToCommit._instanceColors.length() ==
+                newInstanceCount * kNumColorChannels) {
+                drawScene.setExtraInstanceData(*renderItem,
+                    kSolidColorStr, stateToCommit._instanceColors);
+            }
+        }
+        else if (newInstanceCount > 1) {
+            // Turn off consolidation to allow GPU instancing to be used for
+            // multiple instances.
+            setWantConsolidation(*renderItem, false);
+            drawScene.setInstanceTransformArray(*renderItem,
+                stateToCommit._instanceTransforms);
+
+            if (stateToCommit._instanceColors.length() ==
+                newInstanceCount * kNumColorChannels) {
+                drawScene.setExtraInstanceData(*renderItem,
+                    kSolidColorStr, stateToCommit._instanceColors);
+            }
+
+            stateToCommit._drawItemData._usingInstancedDraw = true;
+        }
+        else if (newInstanceCount == 1) {
+            // Special case for single instance prims. We will keep the original
+            // render item to allow consolidation.
+            renderItem->setMatrix(&stateToCommit._instanceTransforms[0]);
+        }
+        else if (stateToCommit._worldMatrix != nullptr) {
+            // Regular non-instanced prims. Consolidation has been turned on by
+            // default and will be kept enabled on this case.
+            renderItem->setMatrix(stateToCommit._worldMatrix);
+        }
+
+        oldInstanceCount = newInstanceCount;
+    });
+}
+
+/*! \brief  Add additional dirty bits
+
+    This callback from Rprim gives the prim an opportunity to set
+    additional dirty bits based on those already set.  This is done
+    before the dirty bits are passed to the scene delegate, so can be
+    used to communicate that extra information is needed by the prim to
+    process the changes.
+
+    The return value is the new set of dirty bits, which replaces the bits
+    passed in.
+
+    See HdRprim::PropagateRprimDirtyBits()
+*/
+HdDirtyBits HdVP2BasisCurves::_PropagateDirtyBits(HdDirtyBits bits) const
+{
+    // Propagate dirty bits to all draw items.
+    for (const std::pair<TfToken, HdReprSharedPtr>& pair : _reprs) {
+        const HdReprSharedPtr& repr = pair.second;
+        const HdRepr::DrawItems& items = repr->GetDrawItems();
+        for (HdDrawItem* item : items) {
+            if (HdVP2DrawItem* drawItem = static_cast<HdVP2DrawItem*>(item)) {
+                drawItem->SetDirtyBits(bits);
+            }
+        }
+    }
+
+    return bits;
+}
+
+/*! \brief  Initialize the given representation of this Rprim.
+
+    This is called prior to syncing the prim, the first time the repr
+    is used.
+
+    \param  reprToken   the name of the repr to initalize.  HdRprim has already
+                        resolved the reprName to its final value.
+
+    \param  dirtyBits   an in/out value.  It is initialized to the dirty bits
+                        from the change tracker.  InitRepr can then set additional
+                        dirty bits if additional data is required from the scene
+                        delegate when this repr is synced.
+
+    InitRepr occurs before dirty bit propagation.
+
+    See HdRprim::InitRepr()
+*/
+void HdVP2BasisCurves::_InitRepr(TfToken const &reprToken, HdDirtyBits *dirtyBits)
+{
+    auto* const param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
+    MSubSceneContainer* subSceneContainer = param->GetContainer();
+    if (ARCH_UNLIKELY(!subSceneContainer))
+        return;
+
+    // We don't create a repr for the selection token because it serves for
+    // selection state update only. Mark DirtySelection bit that will be
+    // automatically propagated to all draw items of the rprim.
+    if (reprToken == HdVP2ReprTokens->selection) {
+        const HdVP2SelectionStatus selectionState =
+            param->GetDrawScene().GetPrimSelectionStatus(GetId());
+        if (_selectionState != selectionState) {
+            _selectionState = selectionState;
+            *dirtyBits |= DirtySelection;
+        }
+        else if (_selectionState == kPartiallySelected) {
+            *dirtyBits |= DirtySelection;
+        }
+        return;
+    }
+
+    // If the repr has any draw item with the DirtySelection bit, mark the
+    // DirtySelectionHighlight bit to invoke the synchronization call.
+    _ReprVector::iterator it = std::find_if(
+        _reprs.begin(), _reprs.end(), _ReprComparator(reprToken));
+    if (it != _reprs.end()) {
+        const HdReprSharedPtr& repr = it->second;
+        const HdRepr::DrawItems& items = repr->GetDrawItems();
+        for (const HdDrawItem* item : items) {
+            const HdVP2DrawItem* drawItem = static_cast<const HdVP2DrawItem*>(item);
+            if (drawItem && (drawItem->GetDirtyBits() & DirtySelection)) {
+                *dirtyBits |= DirtySelectionHighlight;
+                break;
+            }
+        }
+        return;
+    }
+
+    // add new repr
+    _reprs.emplace_back(reprToken, boost::make_shared<HdRepr>());
+    HdReprSharedPtr repr = _reprs.back().second;
+
+    // set dirty bit to say we need to sync a new repr
+    *dirtyBits |= HdChangeTracker::NewRepr;
+
+    _BasisCurvesReprConfig::DescArray descs = _GetReprDesc(reprToken);
+
+    for (size_t descIdx = 0; descIdx < descs.size(); ++descIdx) {
+        const HdBasisCurvesReprDesc& desc = descs[descIdx];
+        if (desc.geomStyle == HdBasisCurvesGeomStyleInvalid) {
+            continue;
+        }
+
+        auto* drawItem = new HdVP2DrawItem(_delegate, &_sharedData);
+        repr->AddDrawItem(drawItem);
+
+        const MString& renderItemName = drawItem->GetRenderItemName();
+
+        MHWRender::MRenderItem* renderItem = nullptr;
+
+        switch (desc.geomStyle) {
+        case HdBasisCurvesGeomStylePatch:
+            renderItem = _CreatePatchRenderItem(renderItemName);
+            drawItem->AddUsage(HdVP2DrawItem::kSelectionHighlight);
+            break;
+        case HdBasisCurvesGeomStyleWire:
+            // The item is used for wireframe display and selection highlight.
+            if (reprToken == HdReprTokens->wire) {
+                renderItem = _CreateWireRenderItem(renderItemName);
+                drawItem->AddUsage(HdVP2DrawItem::kSelectionHighlight);
+            }
+            // The item is used for bbox display and selection highlight.
+            else if (reprToken == HdVP2ReprTokens->bbox) {
+                renderItem = _CreateBBoxRenderItem(renderItemName);
+                drawItem->AddUsage(HdVP2DrawItem::kSelectionHighlight);
+            }
+            break;
+        default:
+            TF_WARN("Unsupported geomStyle");
+            break;
+        }
+
+        if (renderItem) {
+            // Store the render item pointer to avoid expensive lookup in the
+            // subscene container.
+            drawItem->SetRenderItem(renderItem);
+
+            _delegate->GetVP2ResourceRegistry().EnqueueCommit(
+                [subSceneContainer, renderItem]() {
+                    subSceneContainer->add(renderItem);
+                }
+            );
+        }
+    }
+}
+
+/*! \brief  Update the named repr object for this Rprim.
+
+    Repr objects are created to support specific reprName tokens, and contain a list of
+    HdVP2DrawItems and corresponding RenderItems.
+*/
+void HdVP2BasisCurves::_UpdateRepr(
+    HdSceneDelegate *sceneDelegate,
+    TfToken const &reprToken)
+{
+    HdReprSharedPtr const &repr = _GetRepr(reprToken);
+    if (!repr) {
+        return;
+    }
+
+    const _BasisCurvesReprConfig::DescArray &descs = _GetReprDesc(reprToken);
+    const size_t numDescs = descs.size();
+    int drawItemIndex = 0;
+
+    for (size_t i = 0; i < numDescs; ++i) {
+        const HdBasisCurvesReprDesc &desc = descs[i];
+        if (desc.geomStyle != HdBasisCurvesGeomStyleInvalid) {
+            HdVP2DrawItem *drawItem = static_cast<HdVP2DrawItem*>(
+                repr->GetDrawItem(drawItemIndex++));
+            if (drawItem) {
+                _UpdateDrawItem(sceneDelegate, drawItem, desc);
+            }
+        }
+    }
+}
+
+/*! \brief  Returns the minimal set of dirty bits to place in the
+            change tracker for use in the first sync of this prim.
+*/
+HdDirtyBits HdVP2BasisCurves::GetInitialDirtyBitsMask() const
+{
+    constexpr HdDirtyBits bits = 
+        HdChangeTracker::InitRepr |
+        HdChangeTracker::DirtyExtent |
+        HdChangeTracker::DirtyInstanceIndex |
+        HdChangeTracker::DirtyNormals |
+        HdChangeTracker::DirtyPoints |
+        HdChangeTracker::DirtyPrimID |
+        HdChangeTracker::DirtyPrimvar |
+        HdChangeTracker::DirtyDisplayStyle |
+        HdChangeTracker::DirtyRepr |
+        HdChangeTracker::DirtyMaterialId |
+        HdChangeTracker::DirtyTopology |
+        HdChangeTracker::DirtyTransform |
+        HdChangeTracker::DirtyVisibility |
+        HdChangeTracker::DirtyWidths |
+        HdChangeTracker::DirtyComputationPrimvarDesc;
+
+    return bits;
+}
+
+/*! \brief  Update _primvarSourceMap, our local cache of raw primvar data.
+
+    This function pulls data from the scene delegate, but defers processing.
+
+    While iterating primvars, we skip "points" (vertex positions) because
+    the points primvar is processed separately for direct access later. We
+    only call GetPrimvar on primvars that have been marked dirty.
+*/
+void HdVP2BasisCurves::_UpdatePrimvarSources(
+    HdSceneDelegate* sceneDelegate,
+    HdDirtyBits dirtyBits,
+    const TfTokenVector& requiredPrimvars)
+{
+    const SdfPath& id = GetId();
+
+    TfTokenVector::const_iterator begin = requiredPrimvars.cbegin();
+    TfTokenVector::const_iterator end = requiredPrimvars.cend();
+
+    for (size_t i = 0; i < HdInterpolationCount; i++) {
+        const HdInterpolation interp = static_cast<HdInterpolation>(i);
+
+        const HdPrimvarDescriptorVector primvars =
+            GetPrimvarDescriptors(sceneDelegate, interp);
+
+        for (const HdPrimvarDescriptor& pv: primvars) {
+            if (std::find(begin, end, pv.name) == end) {
+                _curvesSharedData._primvarSourceMap.erase(pv.name);
+            }
+            else if (HdChangeTracker::IsPrimvarDirty(dirtyBits, id, pv.name)) {
+                const VtValue value = GetPrimvar(sceneDelegate, pv.name);
+                _curvesSharedData._primvarSourceMap[pv.name] = { value, interp };
+            }
+        }
+    }
+}
+
+/*! \brief  Create render item for wireframe repr.
+*/
+MHWRender::MRenderItem*
+HdVP2BasisCurves::_CreateWireRenderItem(const MString& name) const
+{
+    MHWRender::MRenderItem* const renderItem = MHWRender::MRenderItem::Create(
+        name,
+        MHWRender::MRenderItem::DecorationItem,
+        MHWRender::MGeometry::kLines
+    );
+
+    renderItem->setDrawMode(MHWRender::MGeometry::kWireframe);
+    renderItem->depthPriority(MHWRender::MRenderItem::sDormantWireDepthPriority);
+    renderItem->castsShadows(false);
+    renderItem->receivesShadows(false);
+    renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueGray));
+    renderItem->setSelectionMask(MSelectionMask::kSelectCurves);
+
+    setWantConsolidation(*renderItem, true);
+
+    return renderItem;
+}
+
+/*! \brief  Create render item for bbox repr.
+*/
+MHWRender::MRenderItem*
+HdVP2BasisCurves::_CreateBBoxRenderItem(const MString& name) const
+{
+    MHWRender::MRenderItem* const renderItem = MHWRender::MRenderItem::Create(
+        name,
+        MHWRender::MRenderItem::DecorationItem,
+        MHWRender::MGeometry::kLines
+    );
+
+    renderItem->setDrawMode(MHWRender::MGeometry::kBoundingBox);
+    renderItem->castsShadows(false);
+    renderItem->receivesShadows(false);
+    renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueGray));
+    renderItem->setSelectionMask(MSelectionMask::kSelectCurves);
+
+    setWantConsolidation(*renderItem, true);
+
+    return renderItem;
+}
+
+/*! \brief  Create render item for smoothHull repr.
+*/
+MHWRender::MRenderItem*
+HdVP2BasisCurves::_CreatePatchRenderItem(const MString& name) const
+{
+    MHWRender::MRenderItem* const renderItem = MHWRender::MRenderItem::Create(
+        name,
+        MHWRender::MRenderItem::MaterialSceneItem,
+        MHWRender::MGeometry::kLines
+    );
+
+    renderItem->setDrawMode(static_cast<MHWRender::MGeometry::DrawMode>(
+        MHWRender::MGeometry::kShaded | MHWRender::MGeometry::kTextured));
+    renderItem->castsShadows(false);
+    renderItem->receivesShadows(false);
+    renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueGray));
+    renderItem->setSelectionMask(MSelectionMask::kSelectCurves);
+
+    setWantConsolidation(*renderItem, true);
+
+    return renderItem;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/render/vp2RenderDelegate/basisCurves.cpp
@@ -1489,6 +1489,9 @@ void HdVP2BasisCurves::_InitRepr(TfToken const &reprToken, HdDirtyBits *dirtyBit
                 drawItem->AddUsage(HdVP2DrawItem::kSelectionHighlight);
             }
             break;
+        case HdBasisCurvesGeomStylePoints:
+            renderItem = _CreatePointsRenderItem(renderItemName);
+            break;
         default:
             TF_WARN("Unsupported geomStyle");
             break;
@@ -1661,6 +1664,31 @@ HdVP2BasisCurves::_CreatePatchRenderItem(const MString& name) const
     renderItem->receivesShadows(false);
     renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueGray));
     renderItem->setSelectionMask(MSelectionMask::kSelectCurves);
+
+    setWantConsolidation(*renderItem, true);
+
+    return renderItem;
+}
+
+/*! \brief  Create render item for points repr.
+*/
+MHWRender::MRenderItem*
+HdVP2BasisCurves::_CreatePointsRenderItem(const MString& name) const
+{
+    MHWRender::MRenderItem* const renderItem = MHWRender::MRenderItem::Create(
+        name,
+        MHWRender::MRenderItem::DecorationItem,
+        MHWRender::MGeometry::kPoints
+    );
+
+    renderItem->setDrawMode(MHWRender::MGeometry::kSelectionOnly);
+    renderItem->castsShadows(false);
+    renderItem->receivesShadows(false);
+    renderItem->setShader(_delegate->Get3dFatPointShader());
+
+    MSelectionMask selectionMask(MSelectionMask::kSelectPointsForGravity);
+    selectionMask.addMask(MSelectionMask::kSelectCurves);
+    renderItem->setSelectionMask(selectionMask);
 
     setWantConsolidation(*renderItem, true);
 

--- a/lib/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/render/vp2RenderDelegate/basisCurves.cpp
@@ -679,10 +679,6 @@ HdVP2BasisCurves::_UpdateDrawItem(
     const auto& primvarSourceMap = _curvesSharedData._primvarSourceMap;
 
     const HdBasisCurvesTopology& topology = _curvesSharedData._topology;
-    const VtIntArray& curveVertexCounts = topology.GetCurveVertexCounts();
-    const size_t numCurves = curveVertexCounts.size();
-    const size_t numControlPoints = topology.CalculateNeededNumberOfControlPoints();
-
     const TfToken type = topology.GetCurveType();
     const TfToken wrap = topology.GetCurveWrap();
 

--- a/lib/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/render/vp2RenderDelegate/basisCurves.cpp
@@ -1,4 +1,5 @@
 //
+// Copyright 2018 Pixar
 // Copyright 2020 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/render/vp2RenderDelegate/basisCurves.h
+++ b/lib/render/vp2RenderDelegate/basisCurves.h
@@ -122,6 +122,7 @@ private:
     MHWRender::MRenderItem* _CreatePatchRenderItem(const MString& name) const;
     MHWRender::MRenderItem* _CreateWireRenderItem(const MString& name) const;
     MHWRender::MRenderItem* _CreateBBoxRenderItem(const MString& name) const;
+    MHWRender::MRenderItem* _CreatePointsRenderItem(const MString& name) const;
 
     enum DirtyBits : HdDirtyBits {
         DirtySelection          = HdChangeTracker::CustomBitsBegin,

--- a/lib/render/vp2RenderDelegate/basisCurves.h
+++ b/lib/render/vp2RenderDelegate/basisCurves.h
@@ -1,0 +1,143 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef HDVP2_BASIS_CURVES_H
+#define HDVP2_BASIS_CURVES_H
+
+#include "pxr/pxr.h"
+#include "pxr/base/vt/array.h"
+#include "pxr/imaging/hd/basisCurves.h"
+#include "pxr/imaging/hd/enums.h"
+#include "pxr/usd/sdf/path.h"
+
+#include <maya/MHWGeometry.h>
+
+#include "proxyRenderDelegate.h"
+
+#include <memory>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class HdSceneDelegate;
+class HdVP2DrawItem;
+class HdVP2RenderDelegate;
+
+/*! \brief  HdVP2BasisCurves-specific data shared among all its draw items.
+    \class  HdVP2BasisCurvesSharedData
+
+    A Rprim can have multiple draw items. The shared data are extracted from
+    USD scene delegate during synchronization. Then each draw item can prepare
+    draw data from these shared data as needed.
+*/
+struct HdVP2BasisCurvesSharedData
+{
+    //! Cached scene data. VtArrays are reference counted, so as long as we
+    //! only call const accessors keeping them around doesn't incur a buffer
+    //! copy.
+    HdBasisCurvesTopology _topology;
+
+    //! A local cache of primvar scene data. "data" is a copy-on-write handle to
+    //! the actual primvar buffer, and "interpolation" is the interpolation mode
+    //! to be used.
+    struct PrimvarSource {
+        VtValue data;
+        HdInterpolation interpolation;
+    };
+    TfHashMap<TfToken, PrimvarSource, TfToken::HashFunctor> _primvarSourceMap;
+
+    //! A local cache of points. It is not cached in the above primvar map
+    //! but a separate VtArray for easier access.
+    VtVec3fArray _points;
+
+    //! Position buffer of the Rprim to be shared among all its draw items.
+    std::unique_ptr<MHWRender::MVertexBuffer> _positionsBuffer;
+
+    //! The display style.
+    HdDisplayStyle _displayStyle;
+};
+
+/*! \brief  VP2 representation of basis curves.
+    \class  HdVP2BasisCurves
+
+    The prim object's main function is to bridge the scene description and the
+    renderable representation. The Hydra image generation algorithm will call
+    HdRenderIndex::SyncAll() before any drawing; this, in turn, will call
+    Sync() for each Rprim with new data.
+
+    Sync() is passed a set of dirtyBits, indicating which scene buffers are
+    dirty. It uses these to pull all of the new scene data and constructs
+    updated geometry objects.  Commit of changed buffers to GPU happens
+    in HdVP2RenderDelegate::CommitResources(), which runs on main-thread after
+    all Rprims have been updated.
+*/
+class HdVP2BasisCurves final: public HdBasisCurves
+{
+public:
+    HdVP2BasisCurves(
+        HdVP2RenderDelegate *delegate,
+        const SdfPath &id,
+        const SdfPath &instancerId = SdfPath());
+
+    //! Destructor.
+    ~HdVP2BasisCurves() override = default;
+
+    void Sync(HdSceneDelegate *delegate,
+              HdRenderParam   *renderParam,
+              HdDirtyBits     *dirtyBits,
+              TfToken const   &reprToken) override;
+
+    HdDirtyBits GetInitialDirtyBitsMask() const override;
+
+protected:
+    HdDirtyBits _PropagateDirtyBits(HdDirtyBits bits) const override;
+
+    void _InitRepr(TfToken const &reprToken, HdDirtyBits *dirtyBits) override;
+
+private:
+    void _UpdateRepr(HdSceneDelegate *sceneDelegate,
+                     TfToken const &reprToken);
+
+    void _UpdateDrawItem(HdSceneDelegate *sceneDelegate,
+                         HdVP2DrawItem *drawItem,
+                         HdBasisCurvesReprDesc const &desc);
+
+    void _UpdatePrimvarSources(
+        HdSceneDelegate *sceneDelegate,
+        HdDirtyBits dirtyBits,
+        TfTokenVector const &requiredPrimvars);
+
+    MHWRender::MRenderItem* _CreatePatchRenderItem(const MString& name) const;
+    MHWRender::MRenderItem* _CreateWireRenderItem(const MString& name) const;
+    MHWRender::MRenderItem* _CreateBBoxRenderItem(const MString& name) const;
+
+    enum DirtyBits : HdDirtyBits {
+        DirtySelection          = HdChangeTracker::CustomBitsBegin,
+        DirtySelectionHighlight = (DirtySelection     << 1)
+    };
+
+    HdVP2RenderDelegate* _delegate { nullptr };       //!< VP2 render delegate for which this mesh was created
+    const MString        _rprimId;                    //!< Rprim id cached as a maya string for easier debugging and profiling
+
+    //! Shared data for all draw items of the Rprim
+    HdVP2BasisCurvesSharedData  _curvesSharedData;
+
+    //! Selection status of the Rprim
+    HdVP2SelectionStatus _selectionState { kUnselected };
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDVP2_BASIS_CURVES_H

--- a/lib/render/vp2RenderDelegate/draw_item.cpp
+++ b/lib/render/vp2RenderDelegate/draw_item.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Autodesk
+// Copyright 2020 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,16 +24,12 @@ PXR_NAMESPACE_OPEN_SCOPE
 /*! \brief  Constructor.
 
 Data holder for its corresponding render item to facilitate parallelized evaluation.
-
-Position buffer is held by HdVP2Mesh and shared among its render items.
 */
 HdVP2DrawItem::HdVP2DrawItem(
     HdVP2RenderDelegate* delegate,
-    const HdRprimSharedData* sharedData,
-    const HdMeshReprDesc& desc)
+    const HdRprimSharedData* sharedData)
 : HdDrawItem(sharedData)
 , _delegate(delegate)
-, _reprDesc(desc)
 {
     // In the case of instancing, the ID of a proto has an attribute at the end,
     // we keep this info in _renderItemName so if needed we can extract proto ID
@@ -46,12 +42,6 @@ HdVP2DrawItem::HdVP2DrawItem(
 
     _renderItemData._indexBuffer.reset(
         new MHWRender::MIndexBuffer(MHWRender::MGeometry::kUnsignedInt32));
-
-    if (desc.geomStyle == HdMeshGeomStyleHull) {
-        const MHWRender::MVertexBufferDescriptor desc("",
-            MHWRender::MGeometry::kNormal, MHWRender::MGeometry::kFloat, 3);
-        _renderItemData._normalsBuffer.reset(new MHWRender::MVertexBuffer(desc));
-    }
 }
 
 //! \brief  Destructor.
@@ -63,11 +53,6 @@ HdVP2DrawItem::~HdVP2DrawItem() {
             subSceneContainer->remove(GetRenderItemName());
         }
     }
-}
-
-//! \brief  Get access to render item data.
-HdVP2DrawItem::RenderItemData& HdVP2DrawItem::GetRenderItemData() {
-    return _renderItemData;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/render/vp2RenderDelegate/draw_item.h
+++ b/lib/render/vp2RenderDelegate/draw_item.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Autodesk
+// Copyright 2020 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -67,6 +67,11 @@ public:
         //! Whether or not the render item is enabled
         bool                                        _enabled{ true };
 
+        //! Primitive type of the render item
+        MHWRender::MGeometry::Primitive             _primitiveType{ MHWRender::MGeometry::kInvalidPrimitive };
+        //! Primitive stride of the render item (valid only if the primitive type is kPatch)
+        int                                         _primitiveStride{ 0 };
+
         //! Number of instances currently allocated for render item
         unsigned int                                _instanceCount{ 0 };
 
@@ -83,11 +88,13 @@ public:
     };
 
 public:
-    HdVP2DrawItem(HdVP2RenderDelegate* delegate, const HdRprimSharedData* sharedData, const HdMeshReprDesc& desc);
+    HdVP2DrawItem(HdVP2RenderDelegate* delegate, const HdRprimSharedData* sharedData);
 
     ~HdVP2DrawItem();
 
-    RenderItemData& GetRenderItemData();
+    /*! \brief  Get access to render item data.
+    */
+    RenderItemData& GetRenderItemData() { return _renderItemData; }
 
     /*! \brief  Get render item name
     */
@@ -100,10 +107,6 @@ public:
     /*! \brief  Set pointer of the associated render item
     */
     void SetRenderItem(MHWRender::MRenderItem* item) { _renderItem = item; }
-
-    /*! \brief  Get the repr desc for which the draw item was created.
-    */
-    const HdMeshReprDesc& GetReprDesc() const { return _reprDesc; }
 
     /*! \brief  Set a usage to the render item
     */
@@ -142,7 +145,6 @@ public:
 private:
 
     HdVP2RenderDelegate*    _delegate{ nullptr };   //!< VP2 render delegate for which this draw item was created
-    const HdMeshReprDesc    _reprDesc;              //!< The repr desc for which the draw item was created.
     MString                 _renderItemName;        //!< Unique name for easier debugging and profiling.
     MHWRender::MRenderItem* _renderItem{ nullptr }; //!< Pointer of the render item for fast access. No ownership is held.
     RenderItemData          _renderItemData;        //!< VP2 render item data

--- a/lib/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/render/vp2RenderDelegate/mesh.cpp
@@ -87,17 +87,17 @@ namespace {
         //! if valid, enable or disable the render item
         bool* _enabled{ nullptr };
 
-        //! If valid, new shader instance to set
-        MHWRender::MShaderInstance* _shader{ nullptr };
-
-        //! Is this object transparent
-        bool _isTransparent{ false };
-
         //! Instancing doesn't have dirty bits, every time we do update, we must update instance transforms
         MMatrixArray _instanceTransforms;
 
         //! Color array to support per-instance color and selection highlight.
         MFloatArray _instanceColors;
+
+        //! If valid, new shader instance to set
+        MHWRender::MShaderInstance* _shader{ nullptr };
+
+        //! Is this object transparent
+        bool _isTransparent{ false };
 
         //! If true, associate geometric buffers to the render item and trigger consolidation/instancing update
         bool _geometryDirty{ false };
@@ -925,10 +925,8 @@ void HdVP2Mesh::_UpdateDrawItem(
         if (((itemDirtyBits & HdChangeTracker::DirtyPrimvar) != 0) &&
             (itColor != primvarSourceMap.end() ||
              itOpacity != primvarSourceMap.end())) {
-            // If color/opacity is not found, the 18% gray color will be used
-            // to match the default color of Hydra Storm.
-            VtVec3fArray colorArray(1, GfVec3f(0.18f, 0.18f, 0.18f));
-            VtFloatArray alphaArray(1, 1.0f);
+            VtVec3fArray colorArray;
+            VtFloatArray alphaArray;
 
             HdInterpolation colorInterp = HdInterpolationConstant;
             HdInterpolation alphaInterp = HdInterpolationConstant;
@@ -947,6 +945,18 @@ void HdVP2Mesh::_UpdateDrawItem(
                     alphaArray = value.UncheckedGet<VtFloatArray>();
                     alphaInterp = itOpacity->second.interpolation;
                 }
+            }
+
+            // If color/opacity is not found, the 18% gray color will be used
+            // to match the default color of Hydra Storm.
+            if (colorArray.empty()) {
+                colorArray.push_back(GfVec3f(0.18f, 0.18f, 0.18f));
+                colorInterp = HdInterpolationConstant;
+            }
+
+            if (alphaArray.empty()) {
+                alphaArray.push_back(1.0f);
+                alphaInterp = HdInterpolationConstant;
             }
 
             if (colorInterp == HdInterpolationConstant &&
@@ -1174,10 +1184,15 @@ void HdVP2Mesh::_UpdateDrawItem(
             const GfVec3d midpoint = range.GetMidpoint();
             const GfVec3d size = range.GetSize();
 
-            MTransformationMatrix transformation;
-            transformation.setScale(size.data(), MSpace::kTransform);
-            transformation.setTranslation(midpoint.data(), MSpace::kTransform);
-            worldMatrix = transformation.asMatrix() * worldMatrix;
+            MPoint midp(midpoint[0], midpoint[1], midpoint[2]);
+            midp *= worldMatrix;
+
+            auto& m = worldMatrix.matrix;
+            m[0][0] *= size[0]; m[0][1] *= size[0]; m[0][2] *= size[0]; m[0][3] *= size[0];
+            m[1][0] *= size[1]; m[1][1] *= size[1]; m[1][2] *= size[1]; m[1][3] *= size[1];
+            m[2][0] *= size[2]; m[2][1] *= size[2]; m[2][2] *= size[2]; m[2][3] *= size[2];
+            m[3][0]  = midp[0]; m[3][1]  = midp[1]; m[3][2]  = midp[2]; m[3][3]  = midp[3];
+
             stateToCommit._worldMatrix = &drawItemData._worldMatrix;
         }
     }

--- a/lib/render/vp2RenderDelegate/mesh.h
+++ b/lib/render/vp2RenderDelegate/mesh.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Autodesk
+// Copyright 2020 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ struct HdVP2MeshSharedData {
 
     Sync() is passed a set of dirtyBits, indicating which scene buffers are
     dirty. It uses these to pull all of the new scene data and constructs
-    updated embree geometry objects.  Commit of changed buffers to GPU happens
+    updated geometry objects.  Commit of changed buffers to GPU happens
     in HdVP2RenderDelegate::CommitResources(), which runs on main-thread after
     all prims have been updated.
 */
@@ -100,6 +100,7 @@ private:
 
     void _UpdateDrawItem(
         HdSceneDelegate*, HdVP2DrawItem*,
+        const HdMeshReprDesc& desc,
         bool requireSmoothNormals, bool requireFlatNormals);
 
     void _UpdatePrimvarSources(

--- a/lib/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Autodesk
+// Copyright 2020 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
 #include "pxr/imaging/hdx/renderTask.h"
 #include "pxr/imaging/hdx/selectionTracker.h"
 #include "pxr/imaging/hdx/taskController.h"
+#include "pxr/imaging/hd/basisCurves.h"
 #include "pxr/imaging/hd/enums.h"
 #include "pxr/imaging/hd/mesh.h"
 #include "pxr/imaging/hd/repr.h"
@@ -124,6 +125,15 @@ namespace
         // Special token for selection update and no need to create repr. Adding
         // the empty desc to remove Hydra warning.
         HdMesh::ConfigureRepr(HdVP2ReprTokens->selection, HdMeshReprDesc());
+
+        // Wireframe desc for bbox display.
+        HdBasisCurves::ConfigureRepr(HdVP2ReprTokens->bbox,
+            HdBasisCurvesGeomStyleWire);
+
+        // Special token for selection update and no need to create repr. Adding
+        // the null desc to remove Hydra warning.
+        HdBasisCurves::ConfigureRepr(HdVP2ReprTokens->selection,
+            HdBasisCurvesGeomStyleInvalid);
     }
 
 #if defined(WANT_UFE_BUILD)
@@ -363,6 +373,15 @@ void ProxyRenderDelegate::_UpdateSceneDelegate()
         if (isVisible) {
             SelectionChanged();
         }
+    }
+
+    const int refineLevel = _proxyShape->getComplexity();
+    if (refineLevel != _sceneDelegate->GetRefineLevelFallback())
+    {
+        MProfilingScope subProfilingScope(HdVP2RenderDelegate::sProfilerCategory,
+            MProfiler::kColorC_L1, "SetRefineLevelFallback");
+
+        _sceneDelegate->SetRefineLevelFallback(refineLevel);
     }
 }
 

--- a/lib/render/vp2RenderDelegate/render_delegate.cpp
+++ b/lib/render/vp2RenderDelegate/render_delegate.cpp
@@ -74,8 +74,17 @@ namespace
     const MString _pointSizeParameterName    = "pointSize";       //!< Shader parameter name
     const MString _structOutputName          = "outSurfaceFinal"; //!< Output struct name of the fallback shader
 
-    //! Name of the fallback shaders
-    const MString _fallbackShaderNames[3] =
+    //! Enum class for fallback shader types
+    enum class FallbackShaderType
+    {
+        Common = 0,
+        BasisCurvesLinear,
+        BasisCurvesCubic,
+        Count
+    };
+
+    //! Array of shader fragment names indexed by FallbackShaderType
+    const MString _fallbackShaderNames[FallbackShaderType::Count] =
     {
         "FallbackShader",
         "BasisCurvesLinearFallbackShader",
@@ -220,12 +229,13 @@ namespace
 
             \return A new or existing copy of shader instance with given color
         */
-        MHWRender::MShaderInstance* GetFallbackShader(const MColor& color, unsigned int index)
+        MHWRender::MShaderInstance* GetFallbackShader(const MColor& color, FallbackShaderType type)
         {
-            if (index >= sizeof(_fallbackShaders) / sizeof(_fallbackShaders[0])) {
+            if (type >= FallbackShaderType::Count) {
                 return nullptr;
             }
 
+            const unsigned int index = static_cast<unsigned int>(type);
             auto& shaderMap = _fallbackShaders[index];
 
             // Look for it first with reader lock
@@ -268,8 +278,9 @@ namespace
     private:
         bool                    _isInitialized { false };  //!< Whether the shader cache is initialized
 
-        MShaderMap              _fallbackShaders[3];          //!< Shader registry used by fallback shaders
-        MShaderMap              _3dSolidShaders;              //!< Shader registry used by fallback shaders
+        //! Shader registry used by fallback shaders
+        MShaderMap              _fallbackShaders[FallbackShaderType::Count];
+        MShaderMap              _3dSolidShaders;
 
         MHWRender::MShaderInstance*  _fallbackCPVShader { nullptr }; //!< Fallback shader with CPV support
         MHWRender::MShaderInstance*  _3dFatPointShader { nullptr };  //!< 3d shader for points
@@ -683,7 +694,7 @@ MString HdVP2RenderDelegate::GetLocalNodeName(const MString& name) const {
 MHWRender::MShaderInstance* HdVP2RenderDelegate::GetFallbackShader(
     const MColor& color) const
 {
-    return sShaderCache.GetFallbackShader(color, 0);
+    return sShaderCache.GetFallbackShader(color, FallbackShaderType::Common);
 }
 
 /*! \brief  Returns a fallback shader instance when no material is bound.
@@ -698,7 +709,7 @@ MHWRender::MShaderInstance* HdVP2RenderDelegate::GetFallbackShader(
 MHWRender::MShaderInstance*
 HdVP2RenderDelegate::GetBasisCurvesLinearFallbackShader(const MColor& color) const
 {
-    return sShaderCache.GetFallbackShader(color, 1);
+    return sShaderCache.GetFallbackShader(color, FallbackShaderType::BasisCurvesLinear);
 }
 
 /*! \brief  Returns a fallback shader instance when no material is bound.
@@ -713,7 +724,7 @@ HdVP2RenderDelegate::GetBasisCurvesLinearFallbackShader(const MColor& color) con
 MHWRender::MShaderInstance*
 HdVP2RenderDelegate::GetBasisCurvesCubicFallbackShader(const MColor& color) const
 {
-    return sShaderCache.GetFallbackShader(color, 2);
+    return sShaderCache.GetFallbackShader(color, FallbackShaderType::BasisCurvesCubic);
 }
 
 /*! \brief  Returns a fallback CPV shader instance when no material is bound.

--- a/lib/render/vp2RenderDelegate/render_delegate.cpp
+++ b/lib/render/vp2RenderDelegate/render_delegate.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Autodesk
+// Copyright 2020 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 #include "render_delegate.h"
 
+#include "basisCurves.h"
 #include "bboxGeom.h"
 #include "material.h"
 #include "mesh.h"
@@ -45,8 +46,12 @@ namespace
     /*! \brief List of supported Rprims by VP2 render delegate
     */
     inline const TfTokenVector& _SupportedRprimTypes() {
-        static const TfTokenVector r{ HdPrimTypeTokens->mesh };
-        return r;
+        static const TfTokenVector SUPPORTED_RPRIM_TYPES =
+        {
+            HdPrimTypeTokens->basisCurves,
+            HdPrimTypeTokens->mesh
+        };
+        return SUPPORTED_RPRIM_TYPES;
     }
 
     /*! \brief List of supported Sprims by VP2 render delegate
@@ -67,8 +72,15 @@ namespace
     const MString _diffuseColorParameterName = "diffuseColor";    //!< Shader parameter name
     const MString _solidColorParameterName   = "solidColor";      //!< Shader parameter name
     const MString _pointSizeParameterName    = "pointSize";       //!< Shader parameter name
-    const MString _fallbackShaderName        = "FallbackShader";  //!< Name of the fallback shader
     const MString _structOutputName          = "outSurfaceFinal"; //!< Output struct name of the fallback shader
+
+    //! Name of the fallback shaders
+    const MString _fallbackShaderNames[3] =
+    {
+        "FallbackShader",
+        "BasisCurvesLinearFallbackShader",
+        "BasisCurvesCubicFallbackShader"
+    };
 
     /*! \brief  Color hash helper class, used by shader registry
     */
@@ -119,6 +131,11 @@ namespace
 
             TF_VERIFY(_fallbackCPVShader);
 
+            _3dCPVSolidShader = shaderMgr->getStockShader(
+                MHWRender::MShaderManager::k3dCPVSolidShader);
+
+            TF_VERIFY(_3dCPVSolidShader);
+
             _3dFatPointShader = shaderMgr->getStockShader(
                 MHWRender::MShaderManager::k3dFatPointShader);
 
@@ -145,7 +162,13 @@ namespace
             return _3dFatPointShader;
         }
 
-        /*! \brief  Returns a 3d green shader that can be used for selection highlight.
+        /*! \brief  Returns a 3d CPV solid-color shader instance.
+        */
+        MHWRender::MShaderInstance* Get3dCPVSolidShader() const {
+            return _3dCPVSolidShader;
+        }
+
+        /*! \brief  Returns a 3d solid shader with the specified color.
         */
         MHWRender::MShaderInstance* Get3dSolidShader(const MColor& color)
         {
@@ -192,16 +215,23 @@ namespace
             allowing only one instance per color which enables consolidation of
             draw calls with same shader instance.
 
-            \param color    Color to set on given shader instance
+            \param color   Color to set on given shader instance
+            \param index   Index to the required shader name in _fallbackShaderNames
 
             \return A new or existing copy of shader instance with given color
         */
-        MHWRender::MShaderInstance* GetFallbackShader(const MColor& color)
+        MHWRender::MShaderInstance* GetFallbackShader(const MColor& color, unsigned int index)
         {
+            if (index >= sizeof(_fallbackShaders) / sizeof(_fallbackShaders[0])) {
+                return nullptr;
+            }
+
+            auto& shaderMap = _fallbackShaders[index];
+
             // Look for it first with reader lock
-            tbb::spin_rw_mutex::scoped_lock lock(_fallbackShaders._mutex, false/*write*/);
-            auto it = _fallbackShaders._map.find(color);
-            if (it != _fallbackShaders._map.end()) {
+            tbb::spin_rw_mutex::scoped_lock lock(shaderMap._mutex, false/*write*/);
+            auto it = shaderMap._map.find(color);
+            if (it != shaderMap._map.end()) {
                 return it->second;
             }
 
@@ -209,8 +239,8 @@ namespace
             lock.upgrade_to_writer();
 
             // Double check that it wasn't inserted by another thread
-            it = _fallbackShaders._map.find(color);
-            if (it != _fallbackShaders._map.end()) {
+            it = shaderMap._map.find(color);
+            if (it != shaderMap._map.end()) {
                 return it->second;
             }
 
@@ -220,7 +250,7 @@ namespace
             const MHWRender::MShaderManager* shaderMgr =
                 renderer ? renderer->getShaderManager() : nullptr;
             if (TF_VERIFY(shaderMgr)) {
-                shader = shaderMgr->getFragmentShader(_fallbackShaderName,
+                shader = shaderMgr->getFragmentShader(_fallbackShaderNames[index],
                     _structOutputName, true);
 
                 if (TF_VERIFY(shader)) {
@@ -228,7 +258,7 @@ namespace
                     shader->setParameter(_diffuseColorParameterName, diffuseColor);
 
                     // Insert instance we just created
-                    _fallbackShaders._map[color] = shader;
+                    shaderMap._map[color] = shader;
                 }
             }
 
@@ -238,11 +268,12 @@ namespace
     private:
         bool                    _isInitialized { false };  //!< Whether the shader cache is initialized
 
-        MShaderMap              _fallbackShaders;          //!< Shader registry used by fallback shaders
-        MShaderMap              _3dSolidShaders;           //!< Shader registry used by fallback shaders
+        MShaderMap              _fallbackShaders[3];          //!< Shader registry used by fallback shaders
+        MShaderMap              _3dSolidShaders;              //!< Shader registry used by fallback shaders
 
         MHWRender::MShaderInstance*  _fallbackCPVShader { nullptr }; //!< Fallback shader with CPV support
         MHWRender::MShaderInstance*  _3dFatPointShader { nullptr };  //!< 3d shader for points
+        MHWRender::MShaderInstance*  _3dCPVSolidShader { nullptr };  //!< 3d CPV solid-color shader
     };
 
     MShaderCache sShaderCache;  //!< Global shader cache to minimize the number of unique shaders.
@@ -468,6 +499,9 @@ HdRprim* HdVP2RenderDelegate::CreateRprim(
     if (typeId == HdPrimTypeTokens->mesh) {
         return new HdVP2Mesh(this, rprimId, instancerId);
     }
+    if (typeId == HdPrimTypeTokens->basisCurves) {
+        return new HdVP2BasisCurves(this, rprimId, instancerId);
+    }
     //if (typeId == HdPrimTypeTokens->volume) {
     //    return new HdVP2Volume(this, rprimId, instancerId);
     //}
@@ -649,7 +683,37 @@ MString HdVP2RenderDelegate::GetLocalNodeName(const MString& name) const {
 MHWRender::MShaderInstance* HdVP2RenderDelegate::GetFallbackShader(
     const MColor& color) const
 {
-    return sShaderCache.GetFallbackShader(color);
+    return sShaderCache.GetFallbackShader(color, 0);
+}
+
+/*! \brief  Returns a fallback shader instance when no material is bound.
+
+    This method is keeping registry of all fallback shaders generated, keeping minimal
+    number of shader instances.
+
+    \param color    Color to set on given shader instance
+
+    \return A new or existing copy of shader instance with given color parameter set
+*/
+MHWRender::MShaderInstance*
+HdVP2RenderDelegate::GetBasisCurvesLinearFallbackShader(const MColor& color) const
+{
+    return sShaderCache.GetFallbackShader(color, 1);
+}
+
+/*! \brief  Returns a fallback shader instance when no material is bound.
+
+    This method is keeping registry of all fallback shaders generated, keeping minimal
+    number of shader instances.
+
+    \param color    Color to set on given shader instance
+
+    \return A new or existing copy of shader instance with given color parameter set
+*/
+MHWRender::MShaderInstance*
+HdVP2RenderDelegate::GetBasisCurvesCubicFallbackShader(const MColor& color) const
+{
+    return sShaderCache.GetFallbackShader(color, 2);
 }
 
 /*! \brief  Returns a fallback CPV shader instance when no material is bound.
@@ -659,12 +723,19 @@ MHWRender::MShaderInstance* HdVP2RenderDelegate::GetFallbackCPVShader() const
     return sShaderCache.GetFallbackCPVShader();
 }
 
-/*! \brief  Returns a 3d green shader that can be used for selection highlight.
+/*! \brief  Returns a 3d solid-color shader.
 */
 MHWRender::MShaderInstance* HdVP2RenderDelegate::Get3dSolidShader(
     const MColor& color) const
 {
     return sShaderCache.Get3dSolidShader(color);
+}
+
+/*! \brief  Returns a 3d CPV solid-color shader.
+*/
+MHWRender::MShaderInstance* HdVP2RenderDelegate::Get3dCPVSolidShader() const
+{
+    return sShaderCache.Get3dCPVSolidShader();
 }
 
 /*! \brief  Returns a white 3d fat point shader.

--- a/lib/render/vp2RenderDelegate/render_delegate.cpp
+++ b/lib/render/vp2RenderDelegate/render_delegate.cpp
@@ -77,14 +77,14 @@ namespace
     //! Enum class for fallback shader types
     enum class FallbackShaderType
     {
-        Common = 0,
-        BasisCurvesLinear,
-        BasisCurvesCubic,
-        Count
+        kCommon = 0,
+        kBasisCurvesLinear,
+        kBasisCurvesCubic,
+        kCount
     };
 
     //! Array of shader fragment names indexed by FallbackShaderType
-    const MString _fallbackShaderNames[FallbackShaderType::Count] =
+    const MString _fallbackShaderNames[] =
     {
         "FallbackShader",
         "BasisCurvesLinearFallbackShader",
@@ -231,11 +231,11 @@ namespace
         */
         MHWRender::MShaderInstance* GetFallbackShader(const MColor& color, FallbackShaderType type)
         {
-            if (type >= FallbackShaderType::Count) {
+            if (type >= FallbackShaderType::kCount) {
                 return nullptr;
             }
 
-            const unsigned int index = static_cast<unsigned int>(type);
+            const size_t index = static_cast<size_t>(type);
             auto& shaderMap = _fallbackShaders[index];
 
             // Look for it first with reader lock
@@ -279,7 +279,7 @@ namespace
         bool                    _isInitialized { false };  //!< Whether the shader cache is initialized
 
         //! Shader registry used by fallback shaders
-        MShaderMap              _fallbackShaders[FallbackShaderType::Count];
+        MShaderMap              _fallbackShaders[static_cast<size_t>(FallbackShaderType::kCount)];
         MShaderMap              _3dSolidShaders;
 
         MHWRender::MShaderInstance*  _fallbackCPVShader { nullptr }; //!< Fallback shader with CPV support
@@ -694,7 +694,7 @@ MString HdVP2RenderDelegate::GetLocalNodeName(const MString& name) const {
 MHWRender::MShaderInstance* HdVP2RenderDelegate::GetFallbackShader(
     const MColor& color) const
 {
-    return sShaderCache.GetFallbackShader(color, FallbackShaderType::Common);
+    return sShaderCache.GetFallbackShader(color, FallbackShaderType::kCommon);
 }
 
 /*! \brief  Returns a fallback shader instance when no material is bound.
@@ -709,7 +709,7 @@ MHWRender::MShaderInstance* HdVP2RenderDelegate::GetFallbackShader(
 MHWRender::MShaderInstance*
 HdVP2RenderDelegate::GetBasisCurvesLinearFallbackShader(const MColor& color) const
 {
-    return sShaderCache.GetFallbackShader(color, FallbackShaderType::BasisCurvesLinear);
+    return sShaderCache.GetFallbackShader(color, FallbackShaderType::kBasisCurvesLinear);
 }
 
 /*! \brief  Returns a fallback shader instance when no material is bound.
@@ -724,7 +724,7 @@ HdVP2RenderDelegate::GetBasisCurvesLinearFallbackShader(const MColor& color) con
 MHWRender::MShaderInstance*
 HdVP2RenderDelegate::GetBasisCurvesCubicFallbackShader(const MColor& color) const
 {
-    return sShaderCache.GetFallbackShader(color, FallbackShaderType::BasisCurvesCubic);
+    return sShaderCache.GetFallbackShader(color, FallbackShaderType::kBasisCurvesCubic);
 }
 
 /*! \brief  Returns a fallback CPV shader instance when no material is bound.

--- a/lib/render/vp2RenderDelegate/render_delegate.h
+++ b/lib/render/vp2RenderDelegate/render_delegate.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Autodesk
+// Copyright 2020 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -109,7 +109,11 @@ public:
     MHWRender::MShaderInstance* GetFallbackShader(const MColor& color) const;
     MHWRender::MShaderInstance* GetFallbackCPVShader() const;
     MHWRender::MShaderInstance* Get3dSolidShader(const MColor& color) const;
+    MHWRender::MShaderInstance* Get3dCPVSolidShader() const;
     MHWRender::MShaderInstance* Get3dFatPointShader() const;
+
+    MHWRender::MShaderInstance* GetBasisCurvesLinearFallbackShader(const MColor& color) const;
+    MHWRender::MShaderInstance* GetBasisCurvesCubicFallbackShader(const MColor& color) const;
 
     const MHWRender::MSamplerState* GetSamplerState(
         const MHWRender::MSamplerStateDesc& desc) const;

--- a/lib/render/vp2ShaderFragments/BasisCurvesCubicDomain_Cg.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesCubicDomain_Cg.xml
@@ -1,10 +1,13 @@
 ﻿<!--
 ========================================================================
 Copyright 2020 Autodesk
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/lib/render/vp2ShaderFragments/BasisCurvesCubicDomain_Cg.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesCubicDomain_Cg.xml
@@ -1,0 +1,59 @@
+﻿<!--
+========================================================================
+Copyright 2020 Autodesk
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment uiName="BasisCurvesCubicDomain" name="BasisCurvesCubicDomain" type="domainShader" class="ShadeFragment" version="1.0" feature_level="0">
+    <description>
+        <![CDATA[Domain shader for basisCurves]]>
+    </description>
+    <keyword value="tessellation" />
+    <properties>
+        <undefined  name="GPUStage" semantic="GPUStage" />
+        <float4x4  name="worldView" semantic="worldview" flags="isRequirementOnly" />
+        <float4x4  name="projection" semantic="projection" flags="isRequirementOnly" />
+        <float4x4  name="worldViewIT" semantic="worldviewinversetranspose" flags="isRequirementOnly" />
+        <float4x4  name="worldViewI" semantic="worldviewinverse" flags="isRequirementOnly" />
+        <float4x4  name="worldViewT" semantic="worldviewtranspose" flags="isRequirementOnly" />
+        <float4  name="tessOuterLo" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <float4  name="tessOuterHi" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <struct  name="patchConstants" struct_name="hullConstantsOutS" flags="varyingInputParam" />
+        <struct  name="patch" size="4" struct_name="hullOutS" />
+        <float2  name="domainCoord" semantic="SV_DomainLocation" flags="varyingInputParam" />
+        <int3  name="patchParam" semantic="PATCHPARAM" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="Nm" semantic="NORMAL" flags="isRequirementOnly,varyingInputParam" />
+        <float  name="U0_1" semantic="TEXCOORD0" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="cameraPosition" semantic="worldcameraposition" flags="isRequirementOnly" />
+        <int  name="outputpatchsize" semantic="controlParam" flags="isRequirementOnly" />
+        <string  name="tessprimitives" semantic="controlParam" flags="isRequirementOnly" />
+        <string  name="patchspacing" semantic="controlParam" flags="isRequirementOnly" />
+        <int  name="barriers" semantic="controlParam" flags="isRequirementOnly" />
+    </properties>
+    <values>
+        <int name="outputpatchsize" value="4"/>
+        <string name="tessprimitives" value="quads"/>
+        <string name="patchspacing" value="fractional_odd_spacing"/>
+        <int name="barriers" value="0"/>
+    </values>
+    <outputs>
+        <struct  name="structDomain" size="4" struct_name="structDomain" />
+        <undefined  name="GPUStage" semantic="domainShader" />
+        <float3  name="DS_Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="DS_Nm" semantic="DS_Nm" flags="isRequirementOnly,varyingInputParam" />
+    </outputs>
+    <implementation>
+        <implementation render="OGSRenderer" language="Cg" lang_version="2.1">
+            <function_name val="NOTIMPLEMENTED" />
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/render/vp2ShaderFragments/BasisCurvesCubicDomain_GLSL.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesCubicDomain_GLSL.xml
@@ -20,20 +20,15 @@ limitations under the License.
     <properties>
         <undefined  name="GPUStage" semantic="GPUStage" />
         <float4x4  name="worldView" semantic="worldview" flags="isRequirementOnly" />
-        <float4x4  name="projection" semantic="projection" flags="isRequirementOnly" />
         <float4x4  name="worldViewIT" semantic="worldviewinversetranspose" flags="isRequirementOnly" />
         <float4x4  name="worldViewI" semantic="worldviewinverse" flags="isRequirementOnly" />
         <float4x4  name="worldViewT" semantic="worldviewtranspose" flags="isRequirementOnly" />
         <float4  name="tessOuterLo" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
         <float4  name="tessOuterHi" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
-        <struct  name="patchConstants" struct_name="hullConstantsOutS" flags="varyingInputParam" />
         <struct  name="patch" size="4" struct_name="hullOutS" />
-        <float2  name="domainCoord" semantic="SV_DomainLocation" flags="varyingInputParam" />
-        <int3  name="patchParam" semantic="PATCHPARAM" flags="isRequirementOnly,varyingInputParam" />
         <float3  name="Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
         <float3  name="Nm" semantic="NORMAL" flags="isRequirementOnly,varyingInputParam" />
         <float  name="U0_1" semantic="TEXCOORD0" flags="isRequirementOnly,varyingInputParam" />
-        <float3  name="cameraPosition" semantic="worldcameraposition" flags="isRequirementOnly" />
         <int  name="outputpatchsize" semantic="controlParam" flags="isRequirementOnly" />
         <string  name="tessprimitives" semantic="controlParam" flags="isRequirementOnly" />
         <string  name="patchspacing" semantic="controlParam" flags="isRequirementOnly" />

--- a/lib/render/vp2ShaderFragments/BasisCurvesCubicDomain_GLSL.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesCubicDomain_GLSL.xml
@@ -1,10 +1,14 @@
 ﻿<!--
 ========================================================================
+Copyright 2018 Pixar
 Copyright 2020 Autodesk
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/lib/render/vp2ShaderFragments/BasisCurvesCubicDomain_GLSL.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesCubicDomain_GLSL.xml
@@ -1,0 +1,186 @@
+﻿<!--
+========================================================================
+Copyright 2020 Autodesk
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment uiName="BasisCurvesCubicDomain" name="BasisCurvesCubicDomain" type="domainShader" class="ShadeFragment" version="1.0" feature_level="0">
+    <description>
+        <![CDATA[Domain shader for basisCurves]]>
+    </description>
+    <keyword value="tessellation" />
+    <properties>
+        <undefined  name="GPUStage" semantic="GPUStage" />
+        <float4x4  name="worldView" semantic="worldview" flags="isRequirementOnly" />
+        <float4x4  name="projection" semantic="projection" flags="isRequirementOnly" />
+        <float4x4  name="worldViewIT" semantic="worldviewinversetranspose" flags="isRequirementOnly" />
+        <float4x4  name="worldViewI" semantic="worldviewinverse" flags="isRequirementOnly" />
+        <float4x4  name="worldViewT" semantic="worldviewtranspose" flags="isRequirementOnly" />
+        <float4  name="tessOuterLo" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <float4  name="tessOuterHi" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <struct  name="patchConstants" struct_name="hullConstantsOutS" flags="varyingInputParam" />
+        <struct  name="patch" size="4" struct_name="hullOutS" />
+        <float2  name="domainCoord" semantic="SV_DomainLocation" flags="varyingInputParam" />
+        <int3  name="patchParam" semantic="PATCHPARAM" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="Nm" semantic="NORMAL" flags="isRequirementOnly,varyingInputParam" />
+        <float  name="U0_1" semantic="TEXCOORD0" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="cameraPosition" semantic="worldcameraposition" flags="isRequirementOnly" />
+        <int  name="outputpatchsize" semantic="controlParam" flags="isRequirementOnly" />
+        <string  name="tessprimitives" semantic="controlParam" flags="isRequirementOnly" />
+        <string  name="patchspacing" semantic="controlParam" flags="isRequirementOnly" />
+        <int  name="barriers" semantic="controlParam" flags="isRequirementOnly" />
+    </properties>
+    <values>
+        <int name="outputpatchsize" value="4"/>
+        <string name="tessprimitives" value="quads"/>
+        <string name="patchspacing" value="fractional_odd_spacing"/>
+        <int name="barriers" value="0"/>
+    </values>
+    <outputs>
+        <struct  name="structDomain" size="4" struct_name="structDomain" />
+        <undefined  name="GPUStage" semantic="domainShader" />
+        <float3  name="DS_Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="DS_Nm" semantic="DS_Nm" flags="isRequirementOnly,varyingInputParam" />
+    </outputs>
+    <implementation>
+        <implementation render="OGSRenderer" language="GLSL" lang_version="3.0">
+            <function_name val="BasisCurvesCubicDomain" />
+            <source>
+                <![CDATA[
+struct Coeffs
+{
+    vec4 basis;
+    vec4 tangent_basis;
+};
+
+// line 661 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+float evaluateWidths(vec4 basis, float u)
+{
+    float w0 = DS_IN[0].U0_1;
+    float w1 = DS_IN[1].U0_1;
+    float w2 = DS_IN[2].U0_1;
+    float w3 = DS_IN[3].U0_1;
+    return dot(vec4(w0, w1, w2, w3), basis); 
+}
+
+// line 520 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+vec3 evaluateNormal(vec4 basis, float u)
+{
+    vec4 n0 = worldViewIT * vec4(DS_IN[0].Nm, 1.0f);
+    vec4 n1 = worldViewIT * vec4(DS_IN[1].Nm, 1.0f);
+    vec4 n2 = worldViewIT * vec4(DS_IN[2].Nm, 1.0f);
+    vec4 n3 = worldViewIT * vec4(DS_IN[3].Nm, 1.0f);
+
+    vec3 normal = n0.xyz * basis.x
+                + n1.xyz * basis.y
+                + n2.xyz * basis.z
+                + n3.xyz * basis.w;
+
+    // A zero vector is passed in to indicate requirement of camera-facing normal.
+    if (length(normal) < 0.00001f)
+    {
+        normal = vec3(0.0f, 0.0f, 1.0f);
+    }
+    return normal;
+}
+
+// line 676 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+Coeffs evaluateBasis(float u, float u2, float u3)
+{
+    vec4 basis;
+    basis[0] = u3;
+    basis[1] = -3.0*u3 + 3.0*u2;
+    basis[2] = 3.0*u3 - 6.0*u2 + 3.0*u;
+    basis[3] = -1.0*u3 + 3.0*u2 - 3.0*u + 1.0;
+
+    vec4 tangent_basis;
+    tangent_basis[0] = 3.0*u2;
+    tangent_basis[1] = -9.0*u2 + 6.0*u;
+    tangent_basis[2] = 9.0*u2 - 12.0*u + 3.0;
+    tangent_basis[3] = -3.0*u2 + 6.0*u - 3.0;
+
+    return Coeffs(basis, tangent_basis);
+}
+
+void evaluate(float u, float v, out vec4 position, out vec4 tangent,
+              out float width, out vec3 normal){
+    vec4 p0 = worldView * vec4(DS_IN[0].Pm, 1.0f);
+    vec4 p1 = worldView * vec4(DS_IN[1].Pm, 1.0f);
+    vec4 p2 = worldView * vec4(DS_IN[2].Pm, 1.0f);
+    vec4 p3 = worldView * vec4(DS_IN[3].Pm, 1.0f);
+
+    Coeffs coeffs = evaluateBasis(u, u*u, u*u*u);
+
+    position = coeffs.basis[0] * p0 +
+               coeffs.basis[1] * p1 +
+               coeffs.basis[2] * p2 +
+               coeffs.basis[3] * p3;
+
+    tangent = coeffs.tangent_basis[0] * p0 +
+              coeffs.tangent_basis[1] * p1 +
+              coeffs.tangent_basis[2] * p2 +
+              coeffs.tangent_basis[3] * p3;
+
+    width = evaluateWidths(coeffs.basis, u);
+    normal = normalize(evaluateNormal(coeffs.basis, u));
+    tangent = normalize(tangent);
+}
+
+// it's the responsibility of orient to store Neye, usually with either
+// the computed normal or the tangent (from which the normal will be computed
+// in the fragment shader.)
+vec3 orient(float v, vec4 position, vec4 tangent, vec3 normal)
+{
+    // NOTE: lava/lib/basisCurves currently uses tangent X position instead of
+    // tangent X normal. We should do a more thorough evaluation to see which
+    // is better but to minimize regressions, we're going to keep this as 
+    // tangent X normal for now.
+    return normalize(cross(tangent.xyz, normal)  * (v - 0.5));
+}
+
+structDomain BasisCurvesCubicDomain()
+{
+    float u = gl_TessCoord.y;
+    float v = gl_TessCoord.x;
+
+    Coeffs coeffs = evaluateBasis(u, u*u, u*u*u);
+    vec4 basis = coeffs.basis;
+
+    vec4 position;
+    vec4 tangent;
+    float width;
+    vec3 normal;
+
+    evaluate(u, v, position, tangent, width, normal);
+    vec3 direction = orient(v, position, tangent, normal);
+
+    vec4 scaledDirection = worldView * vec4(direction, 0.0f);
+    vec3 offset = direction * length(scaledDirection.xyz) * width * 0.5f;
+    position.xyz = position.xyz + offset;
+    position.w = 1;
+
+    vec4 Pm = worldViewI * position;
+    vec4 Nm = worldViewT * vec4(normal, 1.0f);
+
+    structDomain outputS;
+    outputS.DS_Pm = Pm.xyz;
+    outputS.DS_Nm = Nm.xyz;
+    return outputS;
+}
+                ]]>
+            </source>
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/render/vp2ShaderFragments/BasisCurvesCubicDomain_HLSL.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesCubicDomain_HLSL.xml
@@ -1,10 +1,14 @@
 ﻿<!--
 ========================================================================
+Copyright 2018 Pixar
 Copyright 2020 Autodesk
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/lib/render/vp2ShaderFragments/BasisCurvesCubicDomain_HLSL.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesCubicDomain_HLSL.xml
@@ -1,0 +1,193 @@
+﻿<!--
+========================================================================
+Copyright 2020 Autodesk
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment uiName="BasisCurvesCubicDomain" name="BasisCurvesCubicDomain" type="domainShader" class="ShadeFragment" version="1.0" feature_level="0">
+    <description>
+        <![CDATA[Domain shader for basisCurves]]>
+    </description>
+    <keyword value="tessellation" />
+    <properties>
+        <undefined  name="GPUStage" semantic="GPUStage" />
+        <float4x4  name="worldView" semantic="worldview" flags="isRequirementOnly" />
+        <float4x4  name="projection" semantic="projection" flags="isRequirementOnly" />
+        <float4x4  name="worldViewIT" semantic="worldviewinversetranspose" flags="isRequirementOnly" />
+        <float4x4  name="worldViewI" semantic="worldviewinverse" flags="isRequirementOnly" />
+        <float4x4  name="worldViewT" semantic="worldviewtranspose" flags="isRequirementOnly" />
+        <float4  name="tessOuterLo" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <float4  name="tessOuterHi" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <struct  name="patchConstants" struct_name="hullConstantsOutS" flags="varyingInputParam" />
+        <struct  name="patch" size="4" struct_name="hullOutS" />
+        <float2  name="domainCoord" semantic="SV_DomainLocation" flags="varyingInputParam" />
+        <int3  name="patchParam" semantic="PATCHPARAM" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="Nm" semantic="NORMAL" flags="isRequirementOnly,varyingInputParam" />
+        <float  name="U0_1" semantic="TEXCOORD0" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="cameraPosition" semantic="worldcameraposition" flags="isRequirementOnly" />
+        <int  name="outputpatchsize" semantic="controlParam" flags="isRequirementOnly" />
+        <string  name="tessprimitives" semantic="controlParam" flags="isRequirementOnly" />
+        <string  name="patchspacing" semantic="controlParam" flags="isRequirementOnly" />
+        <int  name="barriers" semantic="controlParam" flags="isRequirementOnly" />
+    </properties>
+    <values>
+        <int name="outputpatchsize" value="4"/>
+        <string name="tessprimitives" value="quad"/>
+        <string name="patchspacing" value="fractional_odd"/>
+        <int name="barriers" value="0"/>
+    </values>
+    <outputs>
+        <struct  name="structDomain" size="4" struct_name="structDomain" />
+        <undefined  name="GPUStage" semantic="domainShader" />
+        <float3  name="DS_Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="DS_Nm" semantic="DS_Nm" flags="isRequirementOnly,varyingInputParam" />
+    </outputs>
+    <implementation>
+        <implementation render="OGSRenderer" language="HLSL" lang_version="11.0">
+            <function_name val="BasisCurvesCubicDomain" />
+            <source>
+                <![CDATA[
+struct Coeffs
+{
+    float4 basis;
+    float4 tangent_basis;
+};
+
+// line 661 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+float evaluateWidths(hullOutS patch[4], float4 basis, float u)
+{
+    float w0 = patch[0].U0_1;
+    float w1 = patch[1].U0_1;
+    float w2 = patch[2].U0_1;
+    float w3 = patch[3].U0_1;
+    return dot(float4(w0, w1, w2, w3), basis); 
+}
+
+// line 520 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+float3 evaluateNormal(hullOutS patch[4], float4 basis, float u)
+{
+    float4 n0 = mul(float4(patch[0].Nm, 1.0f), worldViewIT);
+    float4 n1 = mul(float4(patch[1].Nm, 1.0f), worldViewIT);
+    float4 n2 = mul(float4(patch[2].Nm, 1.0f), worldViewIT);
+    float4 n3 = mul(float4(patch[3].Nm, 1.0f), worldViewIT);
+
+    float3 normal = n0.xyz * basis.x
+                  + n1.xyz * basis.y
+                  + n2.xyz * basis.z
+                  + n3.xyz * basis.w;
+
+    // A zero vector is passed in to indicate requirement of camera-facing normal.
+    if (length(normal) < 0.00001f)
+    {
+        normal = float3(0.0f, 0.0f, 1.0f);
+    }
+    
+    return normal;
+}
+
+// line 676 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+Coeffs evaluateBasis(float u, float u2, float u3)
+{
+    float4 basis;
+    basis[0] = u3;
+    basis[1] = -3.0*u3 + 3.0*u2;
+    basis[2] = 3.0*u3 - 6.0*u2 + 3.0*u;
+    basis[3] = -1.0*u3 + 3.0*u2 - 3.0*u + 1.0;
+
+    float4 tangent_basis;
+    tangent_basis[0] = 3.0*u2;
+    tangent_basis[1] = -9.0*u2 + 6.0*u;
+    tangent_basis[2] = 9.0*u2 - 12.0*u + 3.0;
+    tangent_basis[3] = -3.0*u2 + 6.0*u - 3.0;
+
+    Coeffs outputS;
+    outputS.basis = basis;
+    outputS.tangent_basis = tangent_basis;
+    return outputS;
+}
+
+void evaluate(hullOutS patch[4], float u, float v, out float4 position, out float4 tangent,
+              out float width, out float3 normal){
+    float4 p0 = mul(float4(patch[0].Pm, 1.0f), worldView);
+    float4 p1 = mul(float4(patch[1].Pm, 1.0f), worldView);
+    float4 p2 = mul(float4(patch[2].Pm, 1.0f), worldView);
+    float4 p3 = mul(float4(patch[3].Pm, 1.0f), worldView);
+
+    Coeffs coeffs = evaluateBasis(u, u*u, u*u*u);
+
+    position = coeffs.basis[0] * p0 +
+               coeffs.basis[1] * p1 +
+               coeffs.basis[2] * p2 +
+               coeffs.basis[3] * p3;
+
+    tangent = coeffs.tangent_basis[0] * p0 +
+              coeffs.tangent_basis[1] * p1 +
+              coeffs.tangent_basis[2] * p2 +
+              coeffs.tangent_basis[3] * p3;
+
+    width = evaluateWidths(patch, coeffs.basis, u);
+    normal = normalize(evaluateNormal(patch, coeffs.basis, u));
+    tangent = normalize(tangent);
+}
+
+// it's the responsibility of orient to store Neye, usually with either
+// the computed normal or the tangent (from which the normal will be computed
+// in the fragment shader.)
+float3 orient(float v, float4 position, float4 tangent, float3 normal)
+{
+    // NOTE: lava/lib/basisCurves currently uses tangent X position instead of
+    // tangent X normal. We should do a more thorough evaluation to see which
+    // is better but to minimize regressions, we're going to keep this as 
+    // tangent X normal for now.
+    return normalize(cross(tangent.xyz, normal)  * (v - 0.5));
+}
+
+structDomain BasisCurvesCubicDomain(
+    hullConstantsOutS patchConstants,
+    hullOutS patch[4],
+    float2 domainCoord)
+{
+    float u = domainCoord.y;
+    float v = domainCoord.x;
+
+    Coeffs coeffs = evaluateBasis(u, u*u, u*u*u);
+    float4 basis = coeffs.basis;
+
+    float4 position;
+    float4 tangent;
+    float width;
+    float3 normal;
+
+    evaluate(patch, u, v, position, tangent, width, normal);
+    float3 direction = orient(v, position, tangent, normal);
+
+    float4 scaledDirection = mul(float4(direction, 0.0f), worldView);
+    float3 offset = direction * length(scaledDirection.xyz) * width * 0.5f;
+    position.xyz = position.xyz + offset;
+    position.w = 1;
+
+    float4 Pm = mul(position, worldViewI);
+    float4 Nm = mul(float4(normal, 1.0f), worldViewT);
+
+    structDomain outputS;
+    outputS.DS_Pm = Pm.xyz;
+    outputS.DS_Nm = Nm.xyz;
+    return outputS;
+}
+                ]]>
+            </source>
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/render/vp2ShaderFragments/BasisCurvesCubicDomain_HLSL.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesCubicDomain_HLSL.xml
@@ -20,20 +20,15 @@ limitations under the License.
     <properties>
         <undefined  name="GPUStage" semantic="GPUStage" />
         <float4x4  name="worldView" semantic="worldview" flags="isRequirementOnly" />
-        <float4x4  name="projection" semantic="projection" flags="isRequirementOnly" />
         <float4x4  name="worldViewIT" semantic="worldviewinversetranspose" flags="isRequirementOnly" />
         <float4x4  name="worldViewI" semantic="worldviewinverse" flags="isRequirementOnly" />
         <float4x4  name="worldViewT" semantic="worldviewtranspose" flags="isRequirementOnly" />
-        <float4  name="tessOuterLo" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
-        <float4  name="tessOuterHi" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
         <struct  name="patchConstants" struct_name="hullConstantsOutS" flags="varyingInputParam" />
         <struct  name="patch" size="4" struct_name="hullOutS" />
         <float2  name="domainCoord" semantic="SV_DomainLocation" flags="varyingInputParam" />
-        <int3  name="patchParam" semantic="PATCHPARAM" flags="isRequirementOnly,varyingInputParam" />
         <float3  name="Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
         <float3  name="Nm" semantic="NORMAL" flags="isRequirementOnly,varyingInputParam" />
         <float  name="U0_1" semantic="TEXCOORD0" flags="isRequirementOnly,varyingInputParam" />
-        <float3  name="cameraPosition" semantic="worldcameraposition" flags="isRequirementOnly" />
         <int  name="outputpatchsize" semantic="controlParam" flags="isRequirementOnly" />
         <string  name="tessprimitives" semantic="controlParam" flags="isRequirementOnly" />
         <string  name="patchspacing" semantic="controlParam" flags="isRequirementOnly" />

--- a/lib/render/vp2ShaderFragments/BasisCurvesCubicFallbackShader.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesCubicFallbackShader.xml
@@ -1,0 +1,106 @@
+<!--
+========================================================================
+Copyright 2020 Autodesk
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment_graph name="BasisCurvesCubicFallbackShader" ref="BasisCurvesCubicFallbackShader" class="FragmentGraph" version="1.0" feature_level="0" >
+    <fragments>
+        <fragment_ref name="mayaBlinnSurface" ref="mayaBlinnSurface" />
+        <fragment_ref name="opacityToTransparency" ref="opacityToTransparency" />
+        <fragment_ref name="Float4ToFloat3" ref="Float4ToFloat3" />
+        <fragment_ref name="Float4ToFloatW" ref="Float4ToFloatW" />
+        <fragment_ref name="Float4ToFloat4" ref="Float4ToFloat4" />
+        <fragment_ref name="BasisCurvesCubicHull" ref="BasisCurvesCubicHull" />
+        <fragment_ref name="BasisCurvesCubicDomain" ref="BasisCurvesCubicDomain" />
+    </fragments>
+    <connections>
+        <connect from="Float4ToFloat3.output" to="mayaBlinnSurface.color" name="color" />
+        <connect from="opacityToTransparency.transparency" to="mayaBlinnSurface.transparency" name="transparency" />
+        <connect from="Float4ToFloatW.output" to="opacityToTransparency.opacity" name="opacity" />
+        <connect from="Float4ToFloat4.output" to="Float4ToFloat3.input" name="rgb" />
+        <connect from="Float4ToFloat4.output" to="Float4ToFloatW.input" name="a" />
+        <connect from="BasisCurvesCubicDomain.GPUStage" to="mayaBlinnSurface.GPUStage" name="DS_to_PS" />
+        <connect from="BasisCurvesCubicHull.GPUStage" to="BasisCurvesCubicDomain.GPUStage" name="HS_to_DS" />
+    </connections>
+    <properties>
+        <undefined name="GPUStage" ref="BasisCurvesCubicHull.GPUStage" semantic="GPUStage" />
+        <float3 name="Nw" ref="mayaBlinnSurface.Nw" flags="varyingInputParam" />
+        <float3 name="Lw" ref="mayaBlinnSurface.Lw" />
+        <float3 name="Vw" ref="mayaBlinnSurface.Vw" flags="varyingInputParam" />
+        <float3 name="HLw" ref="mayaBlinnSurface.HLw" />
+        <float3 name="diffuseI" ref="mayaBlinnSurface.diffuseI" />
+        <float name="diffuse" ref="mayaBlinnSurface.diffuse" />
+        <float name="translucence" ref="mayaBlinnSurface.translucence" />
+        <float name="translucenceDepth" ref="mayaBlinnSurface.translucenceDepth" />
+        <float name="translucenceFocus" ref="mayaBlinnSurface.translucenceFocus" />
+        <float3 name="specularI" ref="mayaBlinnSurface.specularI" />
+        <float3 name="specularColor" ref="mayaBlinnSurface.specularColor" />
+        <float name="eccentricity" ref="mayaBlinnSurface.eccentricity" />
+        <float name="specularRollOff" ref="mayaBlinnSurface.specularRollOff" />
+        <string name="selector" ref="mayaBlinnSurface.selector" />
+        <float3 name="ambientColor" ref="mayaBlinnSurface.ambientColor" />
+        <float3  name="ambientIn" ref="mayaBlinnSurface.ambientIn" />
+        <float3 name="incandescence" ref="mayaBlinnSurface.incandescence" />
+        <float name="reflectivity" ref="mayaBlinnSurface.reflectivity" />
+        <float3 name="reflectedColor" ref="mayaBlinnSurface.reflectedColor" />
+        <float3 name="IrradianceEnv" ref="mayaBlinnSurface.IrradianceEnv" />
+        <float3 name="SpecularEnv" ref="mayaBlinnSurface.SpecularEnv" />
+        <float name="glowIntensity" ref="mayaBlinnSurface.glowIntensity" />
+        <bool name="hideSource" ref="mayaBlinnSurface.hideSource" />
+        <float name="matteOpacity" ref="mayaBlinnSurface.matteOpacity" />
+        <int name="matteOpacityMode" ref="mayaBlinnSurface.matteOpacityMode" />
+        <float name="extraOpacity" ref="mayaBlinnSurface.extraOpacity" />
+        <bool name="fogEnabled" ref="mayaBlinnSurface.fogEnabled" />
+        <float name="fogStart" ref="mayaBlinnSurface.fogStart" />
+        <float name="fogEnd" ref="mayaBlinnSurface.fogEnd" />
+        <int name="fogMode" ref="mayaBlinnSurface.fogMode" />
+        <float name="fogDensity" ref="mayaBlinnSurface.fogDensity" />
+        <float4 name="fogColor" ref="mayaBlinnSurface.fogColor" />
+        <float name="fogMultiplier" ref="mayaBlinnSurface.fogMultiplier" />
+        <float4 name="diffuseColor" ref="Float4ToFloat4.input" />
+    </properties>
+    <values>
+        <float3 name="Lw" value="0.000000,0.000000,0.000000"  />
+        <float3 name="HLw" value="0.000000,0.000000,0.000000"  />
+        <float3 name="diffuseI" value="0.000000,0.000000,0.000000"  />
+        <float name="diffuse" value="0.800000"  />
+        <float name="translucence" value="0.000000"  />
+        <float name="translucenceDepth" value="0.500000"  />
+        <float name="translucenceFocus" value="0.500000"  />
+        <float3 name="specularI" value="0.000000,0.000000,0.000000"  />
+        <float3 name="specularColor" value="0.500000,0.500000,0.500000"  />
+        <float name="eccentricity" value="0.300000"  />
+        <string name="selector" value="mayaLightSelector16"  />
+        <float3 name="ambientColor" value="0.000000,0.000000,0.000000"  />
+        <float3 name="ambientIn" value="0.000000,0.000000,0.000000"  />
+        <float3 name="incandescence" value="0.000000,0.000000,0.000000"  />
+        <float name="reflectivity" value="0.500000"  />
+        <float3 name="reflectedColor" value="0.000000,0.000000,0.000000"  />
+        <float3 name="IrradianceEnv" value="0.000000,0.000000,0.000000"  />
+        <float name="glowIntensity" value="0.000000"  />
+        <bool name="hideSource" value="false"  />
+        <float name="matteOpacity" value="1.000000"  />
+        <int name="matteOpacityMode" value="2"  />
+        <float name="extraOpacity" value="1.000000"  />
+        <bool name="fogEnabled" value="false"  />
+        <float name="fogStart" value="0.000000"  />
+        <float name="fogEnd" value="92.000000"  />
+        <int name="fogMode" value="0"  />
+        <float name="fogDensity" value="0.100000"  />
+        <float4 name="fogColor" value="0.500000,0.500000,0.500000,1.000000"  />
+        <float name="fogMultiplier" value="1.000000"  />
+        <float4 name="diffuseColor" value="0.18,0.18,0.18,1.00" />
+    </values>
+    <outputs>
+        <struct name="mayaSurfaceShaderOutput" ref="mayaBlinnSurface.mayaSurfaceShaderOutput" />
+    </outputs>
+</fragment_graph>

--- a/lib/render/vp2ShaderFragments/BasisCurvesCubicFallbackShader.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesCubicFallbackShader.xml
@@ -1,10 +1,13 @@
 <!--
 ========================================================================
 Copyright 2020 Autodesk
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/lib/render/vp2ShaderFragments/BasisCurvesCubicHull.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesCubicHull.xml
@@ -1,0 +1,201 @@
+﻿<!--
+========================================================================
+Copyright 2020 Autodesk
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment uiName="BasisCurvesCubicHull" name="BasisCurvesCubicHull" type="hullShader" class="ShadeFragment" version="1.0" feature_level="0">
+    <description>
+        <![CDATA[Hull shader for basisCurves]]>
+    </description>
+    <keyword value="tessellation" />
+    <properties>
+        <float4x4  name="world" semantic="world" flags="isRequirementOnly" />
+        <float4x4  name="worldView" semantic="worldview" flags="isRequirementOnly" />
+        <float4x4  name="projection" semantic="projection" flags="isRequirementOnly" />
+        <float4x4  name="worldViewProj" semantic="worldviewprojection" flags="isRequirementOnly" />
+        <float4x4  name="worldInverseTranspose" semantic="worldinversetranspose" flags="isRequirementOnly" />
+        <float2  name="viewportPixelSize" semantic="ViewportPixelSize" flags="isRequirementOnly" />
+        <float  name="tessLevel" semantic="TESSLEVEL" flags="isRequirementOnly" />
+        <struct  name="inputs" semantic="SV_PATCH" size="4" struct_name="vertOutS" flags="varyingInputParam" />
+        <int  name="primitiveID" semantic="SV_PrimitiveID" flags="varyingInputParam" />
+        <int  name="patchID" semantic="SV_OutputControlPointID" flags="varyingInputParam" />
+        <undefined name="GPUStage" semantic="GPUStage" />
+        <float3  name="Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="Nm" semantic="NORMAL" flags="isRequirementOnly,varyingInputParam" />
+        <float  name="U0_1" semantic="TEXCOORD0" flags="isRequirementOnly,varyingInputParam" />
+    </properties>
+    <values>
+    </values>
+    <outputs>
+        <struct  name="outS" size="4" struct_name="hullOutS" />
+        <undefined name="GPUStage" semantic="hullShader" />
+        <float4  name="tessOuterLo" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <float4  name="tessOuterHi" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <int3  name="patchParam" semantic="PATCHPARAM" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="OsdP" semantic="OsdP" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="OsdP1" semantic="OsdP1" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="OsdP2" semantic="OsdP2" flags="isRequirementOnly,varyingInputParam" />
+        <float2  name="vSegments" semantic="vSegments" flags="isRequirementOnly,varyingInputParam" />
+    </outputs>
+    <implementation>
+        <implementation render="OGSRenderer" language="GLSL" lang_version="3.0">
+            <function_name val="BasisCurvesCubicHull" />
+            <source>
+                <![CDATA[
+float GetMaxTess()
+{
+    // Should be replaced with a uniform
+    return 40;
+}
+
+float GetPixelToTessRatio()
+{
+    // Should be replaced with a uniform
+    return 20.0;
+}
+
+vec2 projectToScreen(mat4 wvp, vec3 vertex, vec2 screen_size)
+{
+    vec4 res = wvp * vec4(vertex, 1.0f);
+    res /= res.w;
+    return (clamp(res.xy, -1.3, 1.3) + 1) * (screen_size * 0.5);
+}
+
+// line 185 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+// Use the length of the control points in screen space to determine how many
+// times to subdivide the curve.
+void determineLODSettings()
+{
+    vec2 v0 = projectToScreen(worldViewProj, HS_IN[0].Pm, viewportPixelSize);
+    vec2 v1 = projectToScreen(worldViewProj, HS_IN[1].Pm, viewportPixelSize);
+    vec2 v2 = projectToScreen(worldViewProj, HS_IN[2].Pm, viewportPixelSize);
+    vec2 v3 = projectToScreen(worldViewProj, HS_IN[3].Pm, viewportPixelSize);
+
+    float maxTess = GetMaxTess();
+
+    // Need to handle off screen
+    float dist = distance(v0, v1) + distance(v1, v2) + distance(v2, v3);
+    float level = clamp(dist / GetPixelToTessRatio(), 0, maxTess);
+
+    gl_TessLevelOuter[0] = level;
+    gl_TessLevelOuter[1] = 1;
+    gl_TessLevelOuter[2] = level;
+    gl_TessLevelOuter[3] = 1;
+
+    gl_TessLevelInner[0] = 1;
+    gl_TessLevelInner[1] = level;
+}
+
+// line 154 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+void BasisCurvesCubicHull()
+{
+    if (gl_InvocationID == 0) {
+        determineLODSettings();
+    }
+
+    // U0_1 being used as widths.
+    HS_OUT[gl_InvocationID].U0_1 = HS_IN[gl_InvocationID].U0_1;
+}
+                ]]>
+            </source>
+        </implementation>
+        <implementation render="OGSRenderer" language="HLSL" lang_version="11.0">
+            <function_name val="BasisCurvesCubicHull" />
+            <declaration name="hullConstantsOutS" >
+                <![CDATA[
+struct hullConstantsOutS
+{
+    float tessLevelInner[2] : SV_InsideTessFactor;
+    float tessLevelOuter[4] : SV_TessFactor;
+};
+                ]]>
+            </declaration>
+            <source>
+                <![CDATA[
+float GetMaxTess()
+{
+    // Should be replaced with a uniform
+    return 40;
+}
+
+float GetPixelToTessRatio()
+{
+    // Should be replaced with a uniform
+    return 20.0f;
+}
+
+float2 projectToScreen(float4x4 wvp, float3 vertex, float2 screen_size)
+{
+    float4 res = mul(float4(vertex, 1.0f), wvp);
+    res /= res.w;
+    return (clamp(res.xy, -1.3, 1.3) + 1) * (screen_size * 0.5);
+}
+
+// line 154 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+hullOutS BasisCurvesCubicHull(
+    InputPatch<vertOutS, 4> inputs,
+    uint primitiveID,
+    uint patchID)
+{
+    hullOutS output;
+
+    // U0_1 being used as widths.
+    output.Pm   = inputs[patchID].Pm;
+    output.Nm   = inputs[patchID].Nm;
+    output.U0_1 = inputs[patchID].U0_1;
+
+    return output;
+}
+
+// line 185 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+// Use the length of the control points in screen space to determine how many
+// times to subdivide the curve.
+hullConstantsOutS BasisCurvesCubicHullConstants(
+    InputPatch<vertOutS, 4> inPatch,
+    OutputPatch<hullOutS, 4> outPatch,
+    uint primitiveID : SV_PrimitiveID)
+{
+    float2 v0 = projectToScreen(worldViewProj, inPatch[0].Pm, viewportPixelSize);
+    float2 v1 = projectToScreen(worldViewProj, inPatch[1].Pm, viewportPixelSize);
+    float2 v2 = projectToScreen(worldViewProj, inPatch[2].Pm, viewportPixelSize);
+    float2 v3 = projectToScreen(worldViewProj, inPatch[3].Pm, viewportPixelSize);
+
+    float maxTess = GetMaxTess();
+
+    // Need to handle off screen
+    float dist = distance(v0, v1) + distance(v1, v2) + distance(v2, v3);
+    float level = clamp(dist / GetPixelToTessRatio(), 0, maxTess);
+
+    hullConstantsOutS output;
+
+    output.tessLevelOuter[0] = level;
+    output.tessLevelOuter[1] = 1;
+    output.tessLevelOuter[2] = level;
+    output.tessLevelOuter[3] = 1;
+
+    output.tessLevelInner[0] = 1;
+    output.tessLevelInner[1] = level;
+    
+    return output;
+}
+                ]]>
+            </source>
+        </implementation>
+        <implementation render="OGSRenderer" language="Cg" lang_version="2.1">
+            <function_name val="NOTIMPLEMENTED" />
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/render/vp2ShaderFragments/BasisCurvesCubicHull.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesCubicHull.xml
@@ -18,11 +18,7 @@ limitations under the License.
     </description>
     <keyword value="tessellation" />
     <properties>
-        <float4x4  name="world" semantic="world" flags="isRequirementOnly" />
-        <float4x4  name="worldView" semantic="worldview" flags="isRequirementOnly" />
-        <float4x4  name="projection" semantic="projection" flags="isRequirementOnly" />
         <float4x4  name="worldViewProj" semantic="worldviewprojection" flags="isRequirementOnly" />
-        <float4x4  name="worldInverseTranspose" semantic="worldinversetranspose" flags="isRequirementOnly" />
         <float2  name="viewportPixelSize" semantic="ViewportPixelSize" flags="isRequirementOnly" />
         <float  name="tessLevel" semantic="TESSLEVEL" flags="isRequirementOnly" />
         <struct  name="inputs" semantic="SV_PATCH" size="4" struct_name="vertOutS" flags="varyingInputParam" />
@@ -40,11 +36,6 @@ limitations under the License.
         <undefined name="GPUStage" semantic="hullShader" />
         <float4  name="tessOuterLo" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
         <float4  name="tessOuterHi" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
-        <int3  name="patchParam" semantic="PATCHPARAM" flags="isRequirementOnly,varyingInputParam" />
-        <float3  name="OsdP" semantic="OsdP" flags="isRequirementOnly,varyingInputParam" />
-        <float3  name="OsdP1" semantic="OsdP1" flags="isRequirementOnly,varyingInputParam" />
-        <float3  name="OsdP2" semantic="OsdP2" flags="isRequirementOnly,varyingInputParam" />
-        <float2  name="vSegments" semantic="vSegments" flags="isRequirementOnly,varyingInputParam" />
     </outputs>
     <implementation>
         <implementation render="OGSRenderer" language="GLSL" lang_version="3.0">

--- a/lib/render/vp2ShaderFragments/BasisCurvesLinearDomain_Cg.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesLinearDomain_Cg.xml
@@ -1,0 +1,59 @@
+﻿<!--
+========================================================================
+Copyright 2020 Autodesk
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment uiName="BasisCurvesLinearDomain" name="BasisCurvesLinearDomain" type="domainShader" class="ShadeFragment" version="1.0" feature_level="0">
+    <description>
+        <![CDATA[Domain shader for basisCurves]]>
+    </description>
+    <keyword value="tessellation" />
+    <properties>
+        <undefined  name="GPUStage" semantic="GPUStage" />
+        <float4x4  name="worldView" semantic="worldview" flags="isRequirementOnly" />
+        <float4x4  name="projection" semantic="projection" flags="isRequirementOnly" />
+        <float4x4  name="worldViewIT" semantic="worldviewinversetranspose" flags="isRequirementOnly" />
+        <float4x4  name="worldViewI" semantic="worldviewinverse" flags="isRequirementOnly" />
+        <float4x4  name="worldViewT" semantic="worldviewtranspose" flags="isRequirementOnly" />
+        <float4  name="tessOuterLo" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <float4  name="tessOuterHi" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <struct  name="patchConstants" struct_name="hullConstantsOutS" flags="varyingInputParam" />
+        <struct  name="patch" size="2" struct_name="hullOutS" />
+        <float2  name="domainCoord" semantic="SV_DomainLocation" flags="varyingInputParam" />
+        <int3  name="patchParam" semantic="PATCHPARAM" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="Nm" semantic="NORMAL" flags="isRequirementOnly,varyingInputParam" />
+        <float  name="U0_1" semantic="TEXCOORD0" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="cameraPosition" semantic="worldcameraposition" flags="isRequirementOnly" />
+        <int  name="outputpatchsize" semantic="controlParam" flags="isRequirementOnly" />
+        <string  name="tessprimitives" semantic="controlParam" flags="isRequirementOnly" />
+        <string  name="patchspacing" semantic="controlParam" flags="isRequirementOnly" />
+        <int  name="barriers" semantic="controlParam" flags="isRequirementOnly" />
+    </properties>
+    <values>
+        <int name="outputpatchsize" value="2"/>
+        <string name="tessprimitives" value="quads"/>
+        <string name="patchspacing" value="fractional_odd_spacing"/>
+        <int name="barriers" value="0"/>
+    </values>
+    <outputs>
+        <struct  name="structDomain" size="4" struct_name="structDomain" />
+        <undefined  name="GPUStage" semantic="domainShader" />
+        <float3  name="DS_Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="DS_Nm" semantic="DS_Nm" flags="isRequirementOnly,varyingInputParam" />
+    </outputs>
+    <implementation>
+        <implementation render="OGSRenderer" language="Cg" lang_version="2.1">
+            <function_name val="NOTIMPLEMENTED" />
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/render/vp2ShaderFragments/BasisCurvesLinearDomain_Cg.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesLinearDomain_Cg.xml
@@ -1,10 +1,13 @@
 ﻿<!--
 ========================================================================
 Copyright 2020 Autodesk
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/lib/render/vp2ShaderFragments/BasisCurvesLinearDomain_GLSL.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesLinearDomain_GLSL.xml
@@ -1,10 +1,14 @@
 ﻿<!--
 ========================================================================
+Copyright 2018 Pixar
 Copyright 2020 Autodesk
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/lib/render/vp2ShaderFragments/BasisCurvesLinearDomain_GLSL.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesLinearDomain_GLSL.xml
@@ -20,20 +20,15 @@ limitations under the License.
     <properties>
         <undefined  name="GPUStage" semantic="GPUStage" />
         <float4x4  name="worldView" semantic="worldview" flags="isRequirementOnly" />
-        <float4x4  name="projection" semantic="projection" flags="isRequirementOnly" />
         <float4x4  name="worldViewIT" semantic="worldviewinversetranspose" flags="isRequirementOnly" />
         <float4x4  name="worldViewI" semantic="worldviewinverse" flags="isRequirementOnly" />
         <float4x4  name="worldViewT" semantic="worldviewtranspose" flags="isRequirementOnly" />
         <float4  name="tessOuterLo" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
         <float4  name="tessOuterHi" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
-        <struct  name="patchConstants" struct_name="hullConstantsOutS" flags="varyingInputParam" />
         <struct  name="patch" size="2" struct_name="hullOutS" />
-        <float2  name="domainCoord" semantic="SV_DomainLocation" flags="varyingInputParam" />
-        <int3  name="patchParam" semantic="PATCHPARAM" flags="isRequirementOnly,varyingInputParam" />
         <float3  name="Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
         <float3  name="Nm" semantic="NORMAL" flags="isRequirementOnly,varyingInputParam" />
         <float  name="U0_1" semantic="TEXCOORD0" flags="isRequirementOnly,varyingInputParam" />
-        <float3  name="cameraPosition" semantic="worldcameraposition" flags="isRequirementOnly" />
         <int  name="outputpatchsize" semantic="controlParam" flags="isRequirementOnly" />
         <string  name="tessprimitives" semantic="controlParam" flags="isRequirementOnly" />
         <string  name="patchspacing" semantic="controlParam" flags="isRequirementOnly" />

--- a/lib/render/vp2ShaderFragments/BasisCurvesLinearDomain_GLSL.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesLinearDomain_GLSL.xml
@@ -1,0 +1,162 @@
+﻿<!--
+========================================================================
+Copyright 2020 Autodesk
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment uiName="BasisCurvesLinearDomain" name="BasisCurvesLinearDomain" type="domainShader" class="ShadeFragment" version="1.0" feature_level="0">
+    <description>
+        <![CDATA[Domain shader for basisCurves]]>
+    </description>
+    <keyword value="tessellation" />
+    <properties>
+        <undefined  name="GPUStage" semantic="GPUStage" />
+        <float4x4  name="worldView" semantic="worldview" flags="isRequirementOnly" />
+        <float4x4  name="projection" semantic="projection" flags="isRequirementOnly" />
+        <float4x4  name="worldViewIT" semantic="worldviewinversetranspose" flags="isRequirementOnly" />
+        <float4x4  name="worldViewI" semantic="worldviewinverse" flags="isRequirementOnly" />
+        <float4x4  name="worldViewT" semantic="worldviewtranspose" flags="isRequirementOnly" />
+        <float4  name="tessOuterLo" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <float4  name="tessOuterHi" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <struct  name="patchConstants" struct_name="hullConstantsOutS" flags="varyingInputParam" />
+        <struct  name="patch" size="2" struct_name="hullOutS" />
+        <float2  name="domainCoord" semantic="SV_DomainLocation" flags="varyingInputParam" />
+        <int3  name="patchParam" semantic="PATCHPARAM" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="Nm" semantic="NORMAL" flags="isRequirementOnly,varyingInputParam" />
+        <float  name="U0_1" semantic="TEXCOORD0" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="cameraPosition" semantic="worldcameraposition" flags="isRequirementOnly" />
+        <int  name="outputpatchsize" semantic="controlParam" flags="isRequirementOnly" />
+        <string  name="tessprimitives" semantic="controlParam" flags="isRequirementOnly" />
+        <string  name="patchspacing" semantic="controlParam" flags="isRequirementOnly" />
+        <int  name="barriers" semantic="controlParam" flags="isRequirementOnly" />
+    </properties>
+    <values>
+        <int name="outputpatchsize" value="2"/>
+        <string name="tessprimitives" value="quads"/>
+        <string name="patchspacing" value="fractional_odd_spacing"/>
+        <int name="barriers" value="0"/>
+    </values>
+    <outputs>
+        <struct  name="structDomain" size="4" struct_name="structDomain" />
+        <undefined  name="GPUStage" semantic="domainShader" />
+        <float3  name="DS_Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="DS_Nm" semantic="DS_Nm" flags="isRequirementOnly,varyingInputParam" />
+    </outputs>
+    <implementation>
+        <implementation render="OGSRenderer" language="GLSL" lang_version="3.0">
+            <function_name val="BasisCurvesLinearDomain" />
+            <source>
+                <![CDATA[
+struct Coeffs
+{
+    vec4 basis;
+    vec4 tangent_basis;
+};
+
+// line 520 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+vec3 evaluateNormal(float u)
+{
+    vec4 n0 = worldViewIT * vec4(DS_IN[0].Nm, 1.0f);
+    vec4 n1 = worldViewIT * vec4(DS_IN[1].Nm, 1.0f);
+
+    // XXX: This clamp is a hack to mask some odd orientation flipping issues 
+    u = clamp(u, 1e-3, 1.0 - 1e-3);
+    vec3 normal = mix(n1.xyz, n1.xyz, u);
+
+    // A zero vector is passed in to indicate requirement of camera-facing normal.
+    if (length(normal) < 0.00001f)
+    {
+        normal = vec3(0.0f, 0.0f, 1.0f);
+    }
+    return normal;
+}
+
+// line 676 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+Coeffs evaluateBasis(float u, float u2, float u3)
+{
+    vec4 basis;
+    basis[0] = u3;
+    basis[1] = -3.0*u3 + 3.0*u2;
+    basis[2] = 3.0*u3 - 6.0*u2 + 3.0*u;
+    basis[3] = -1.0*u3 + 3.0*u2 - 3.0*u + 1.0;
+
+    vec4 tangent_basis;
+    tangent_basis[0] = 3.0*u2;
+    tangent_basis[1] = -9.0*u2 + 6.0*u;
+    tangent_basis[2] = 9.0*u2 - 12.0*u + 3.0;
+    tangent_basis[3] = -3.0*u2 + 6.0*u - 3.0;
+
+    return Coeffs(basis, tangent_basis);
+}
+
+void evaluate(float u, float v, out vec4 position, out vec4 tangent,
+              out float width, out vec3 normal){
+    vec4 p0 = worldView * vec4(DS_IN[0].Pm, 1.0f);
+    vec4 p1 = worldView * vec4(DS_IN[1].Pm, 1.0f);
+
+    float w0 = DS_IN[0].U0_1;
+    float w1 = DS_IN[1].U0_1;
+
+    position = mix(p1, p0, u);
+    tangent = normalize(p1 - p0);
+    width = mix(w1, w0, u);
+    normal = normalize(evaluateNormal(u));
+}
+
+// it's the responsibility of orient to store Neye, usually with either
+// the computed normal or the tangent (from which the normal will be computed
+// in the fragment shader.)
+vec3 orient(float v, vec4 position, vec4 tangent, vec3 normal)
+{
+    // NOTE: lava/lib/basisCurves currently uses tangent X position instead of
+    // tangent X normal. We should do a more thorough evaluation to see which
+    // is better but to minimize regressions, we're going to keep this as 
+    // tangent X normal for now.
+    return normalize(cross(tangent.xyz, normal)  * (v - 0.5));
+}
+
+structDomain BasisCurvesLinearDomain()
+{
+    float u = gl_TessCoord.y;
+    float v = gl_TessCoord.x;
+
+    Coeffs coeffs = evaluateBasis(u, u*u, u*u*u);
+    vec4 basis = coeffs.basis;
+
+    vec4 position;
+    vec4 tangent;
+    float width;
+    vec3 normal;
+
+    evaluate(u, v, position, tangent, width, normal);
+    vec3 direction = orient(v, position, tangent, normal);
+
+    vec4 scaledDirection = worldView * vec4(direction, 0.0f);
+    vec3 offset = direction * length(scaledDirection.xyz) * width * 0.5f;
+    position.xyz = position.xyz + offset;
+    position.w = 1;
+
+    vec4 Pm = worldViewI * position;
+    vec4 Nm = worldViewT * vec4(normal, 1.0f);
+
+    structDomain outputS;
+    outputS.DS_Pm = Pm.xyz;
+    outputS.DS_Nm = Nm.xyz;
+    return outputS;
+}
+                ]]>
+            </source>
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/render/vp2ShaderFragments/BasisCurvesLinearDomain_HLSL.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesLinearDomain_HLSL.xml
@@ -20,20 +20,15 @@ limitations under the License.
     <properties>
         <undefined  name="GPUStage" semantic="GPUStage" />
         <float4x4  name="worldView" semantic="worldview" flags="isRequirementOnly" />
-        <float4x4  name="projection" semantic="projection" flags="isRequirementOnly" />
         <float4x4  name="worldViewIT" semantic="worldviewinversetranspose" flags="isRequirementOnly" />
         <float4x4  name="worldViewI" semantic="worldviewinverse" flags="isRequirementOnly" />
         <float4x4  name="worldViewT" semantic="worldviewtranspose" flags="isRequirementOnly" />
-        <float4  name="tessOuterLo" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
-        <float4  name="tessOuterHi" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
         <struct  name="patchConstants" struct_name="hullConstantsOutS" flags="varyingInputParam" />
         <struct  name="patch" size="2" struct_name="hullOutS" />
         <float2  name="domainCoord" semantic="SV_DomainLocation" flags="varyingInputParam" />
-        <int3  name="patchParam" semantic="PATCHPARAM" flags="isRequirementOnly,varyingInputParam" />
         <float3  name="Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
         <float3  name="Nm" semantic="NORMAL" flags="isRequirementOnly,varyingInputParam" />
         <float  name="U0_1" semantic="TEXCOORD0" flags="isRequirementOnly,varyingInputParam" />
-        <float3  name="cameraPosition" semantic="worldcameraposition" flags="isRequirementOnly" />
         <int  name="outputpatchsize" semantic="controlParam" flags="isRequirementOnly" />
         <string  name="tessprimitives" semantic="controlParam" flags="isRequirementOnly" />
         <string  name="patchspacing" semantic="controlParam" flags="isRequirementOnly" />

--- a/lib/render/vp2ShaderFragments/BasisCurvesLinearDomain_HLSL.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesLinearDomain_HLSL.xml
@@ -1,10 +1,14 @@
 ﻿<!--
 ========================================================================
+Copyright 2018 Pixar
 Copyright 2020 Autodesk
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/lib/render/vp2ShaderFragments/BasisCurvesLinearDomain_HLSL.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesLinearDomain_HLSL.xml
@@ -1,0 +1,173 @@
+﻿<!--
+========================================================================
+Copyright 2020 Autodesk
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment uiName="BasisCurvesLinearDomain" name="BasisCurvesLinearDomain" type="domainShader" class="ShadeFragment" version="1.0" feature_level="0">
+    <description>
+        <![CDATA[Domain shader for basisCurves]]>
+    </description>
+    <keyword value="tessellation" />
+    <properties>
+        <undefined  name="GPUStage" semantic="GPUStage" />
+        <float4x4  name="worldView" semantic="worldview" flags="isRequirementOnly" />
+        <float4x4  name="projection" semantic="projection" flags="isRequirementOnly" />
+        <float4x4  name="worldViewIT" semantic="worldviewinversetranspose" flags="isRequirementOnly" />
+        <float4x4  name="worldViewI" semantic="worldviewinverse" flags="isRequirementOnly" />
+        <float4x4  name="worldViewT" semantic="worldviewtranspose" flags="isRequirementOnly" />
+        <float4  name="tessOuterLo" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <float4  name="tessOuterHi" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <struct  name="patchConstants" struct_name="hullConstantsOutS" flags="varyingInputParam" />
+        <struct  name="patch" size="2" struct_name="hullOutS" />
+        <float2  name="domainCoord" semantic="SV_DomainLocation" flags="varyingInputParam" />
+        <int3  name="patchParam" semantic="PATCHPARAM" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="Nm" semantic="NORMAL" flags="isRequirementOnly,varyingInputParam" />
+        <float  name="U0_1" semantic="TEXCOORD0" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="cameraPosition" semantic="worldcameraposition" flags="isRequirementOnly" />
+        <int  name="outputpatchsize" semantic="controlParam" flags="isRequirementOnly" />
+        <string  name="tessprimitives" semantic="controlParam" flags="isRequirementOnly" />
+        <string  name="patchspacing" semantic="controlParam" flags="isRequirementOnly" />
+        <int  name="barriers" semantic="controlParam" flags="isRequirementOnly" />
+    </properties>
+    <values>
+        <int name="outputpatchsize" value="2"/>
+        <string name="tessprimitives" value="quad"/>
+        <string name="patchspacing" value="fractional_odd"/>
+        <int name="barriers" value="0"/>
+    </values>
+    <outputs>
+        <struct  name="structDomain" size="4" struct_name="structDomain" />
+        <undefined  name="GPUStage" semantic="domainShader" />
+        <float3  name="DS_Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="DS_Nm" semantic="DS_Nm" flags="isRequirementOnly,varyingInputParam" />
+    </outputs>
+    <implementation>
+        <implementation render="OGSRenderer" language="HLSL" lang_version="11.0">
+            <function_name val="BasisCurvesLinearDomain" />
+            <source>
+                <![CDATA[
+struct Coeffs
+{
+    float4 basis;
+    float4 tangent_basis;
+};
+
+// line 520 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+float3 evaluateNormal(hullOutS patch[2], float u)
+{
+    float4 n0 = mul(float4(patch[0].Nm, 1.0f), worldViewIT);
+    float4 n1 = mul(float4(patch[1].Nm, 1.0f), worldViewIT);
+
+    // XXX: This clamp is a hack to mask some odd orientation flipping issues 
+    u = clamp(u, 1e-3, 1.0 - 1e-3);
+    float3 normal = lerp(n1.xyz, n0.xyz, u);
+
+    // A zero vector is passed in to indicate requirement of camera-facing normal.
+    if (length(normal) < 0.00001f)
+    {
+        normal = float3(0.0f, 0.0f, 1.0f);
+    }
+
+    return normal;
+}
+
+
+// line 676 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+Coeffs evaluateBasis(float u, float u2, float u3)
+{
+    float4 basis;
+    basis[0] = u3;
+    basis[1] = -3.0*u3 + 3.0*u2;
+    basis[2] = 3.0*u3 - 6.0*u2 + 3.0*u;
+    basis[3] = -1.0*u3 + 3.0*u2 - 3.0*u + 1.0;
+
+    float4 tangent_basis;
+    tangent_basis[0] = 3.0*u2;
+    tangent_basis[1] = -9.0*u2 + 6.0*u;
+    tangent_basis[2] = 9.0*u2 - 12.0*u + 3.0;
+    tangent_basis[3] = -3.0*u2 + 6.0*u - 3.0;
+
+    Coeffs outputS;
+    outputS.basis = basis;
+    outputS.tangent_basis = tangent_basis;
+    return outputS;
+}
+
+void evaluate(hullOutS patch[2],
+    float u, float v, out float4 position, out float4 tangent,
+    out float width, out float3 normal)
+{
+    float4 p0 = mul(float4(patch[0].Pm, 1.0f), worldView);
+    float4 p1 = mul(float4(patch[1].Pm, 1.0f), worldView);
+
+    float w0 = patch[0].U0_1;
+    float w1 = patch[1].U0_1;
+
+    position = lerp(p1, p0, u);
+    tangent = normalize(p1 - p0);
+    width = lerp(w1, w0, u);
+    normal = normalize(evaluateNormal(patch, u));
+}
+
+// it's the responsibility of orient to store Neye, usually with either
+// the computed normal or the tangent (from which the normal will be computed
+// in the fragment shader.)
+float3 orient(float v, float4 position, float4 tangent, float3 normal)
+{
+    // NOTE: lava/lib/basisCurves currently uses tangent X position instead of
+    // tangent X normal. We should do a more thorough evaluation to see which
+    // is better but to minimize regressions, we're going to keep this as 
+    // tangent X normal for now.
+    return normalize(cross(tangent.xyz, normal)  * (v - 0.5));
+}
+
+structDomain BasisCurvesLinearDomain(
+    hullConstantsOutS patchConstants,
+    hullOutS patch[2],
+    float2 domainCoord)
+{
+    structDomain outputS;
+
+    float u = domainCoord.y;
+    float v = domainCoord.x;
+
+    Coeffs coeffs = evaluateBasis(u, u*u, u*u*u);
+    float4 basis = coeffs.basis;
+
+    float4 position;
+    float4 tangent;
+    float width;
+    float3 normal;
+
+    evaluate(patch, u, v, position, tangent, width, normal);
+    float3 direction = orient(v, position, tangent, normal);
+
+    float4 scaledDirection = mul(float4(direction, 0.0f), worldView);
+    float3 offset = direction * length(scaledDirection.xyz) * width * 0.5f;
+    position.xyz = position.xyz + offset;
+    position.w = 1;
+
+    float4 Pm = mul(position, worldViewI);
+    float4 Nm = mul(float4(normal, 1.0f), worldViewT);
+
+    outputS.DS_Pm = Pm.xyz;
+    outputS.DS_Nm = Nm.xyz;
+    return outputS;
+}
+                ]]>
+            </source>
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/render/vp2ShaderFragments/BasisCurvesLinearFallbackShader.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesLinearFallbackShader.xml
@@ -1,0 +1,106 @@
+<!--
+========================================================================
+Copyright 2020 Autodesk
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment_graph name="BasisCurvesLinearFallbackShader" ref="BasisCurvesLinearFallbackShader" class="FragmentGraph" version="1.0" feature_level="0" >
+    <fragments>
+        <fragment_ref name="mayaBlinnSurface" ref="mayaBlinnSurface" />
+        <fragment_ref name="opacityToTransparency" ref="opacityToTransparency" />
+        <fragment_ref name="Float4ToFloat3" ref="Float4ToFloat3" />
+        <fragment_ref name="Float4ToFloatW" ref="Float4ToFloatW" />
+        <fragment_ref name="Float4ToFloat4" ref="Float4ToFloat4" />
+        <fragment_ref name="BasisCurvesLinearHull" ref="BasisCurvesLinearHull" />
+        <fragment_ref name="BasisCurvesLinearDomain" ref="BasisCurvesLinearDomain" />
+    </fragments>
+    <connections>
+        <connect from="Float4ToFloat3.output" to="mayaBlinnSurface.color" name="color" />
+        <connect from="opacityToTransparency.transparency" to="mayaBlinnSurface.transparency" name="transparency" />
+        <connect from="Float4ToFloatW.output" to="opacityToTransparency.opacity" name="opacity" />
+        <connect from="Float4ToFloat4.output" to="Float4ToFloat3.input" name="rgb" />
+        <connect from="Float4ToFloat4.output" to="Float4ToFloatW.input" name="a" />
+        <connect from="BasisCurvesLinearDomain.GPUStage" to="mayaBlinnSurface.GPUStage" name="DS_to_PS" />
+        <connect from="BasisCurvesLinearHull.GPUStage" to="BasisCurvesLinearDomain.GPUStage" name="HS_to_DS" />
+    </connections>
+    <properties>
+        <undefined name="GPUStage" ref="BasisCurvesLinearHull.GPUStage" semantic="GPUStage" />
+        <float3 name="Nw" ref="mayaBlinnSurface.Nw" flags="varyingInputParam" />
+        <float3 name="Lw" ref="mayaBlinnSurface.Lw" />
+        <float3 name="Vw" ref="mayaBlinnSurface.Vw" flags="varyingInputParam" />
+        <float3 name="HLw" ref="mayaBlinnSurface.HLw" />
+        <float3 name="diffuseI" ref="mayaBlinnSurface.diffuseI" />
+        <float name="diffuse" ref="mayaBlinnSurface.diffuse" />
+        <float name="translucence" ref="mayaBlinnSurface.translucence" />
+        <float name="translucenceDepth" ref="mayaBlinnSurface.translucenceDepth" />
+        <float name="translucenceFocus" ref="mayaBlinnSurface.translucenceFocus" />
+        <float3 name="specularI" ref="mayaBlinnSurface.specularI" />
+        <float3 name="specularColor" ref="mayaBlinnSurface.specularColor" />
+        <float name="eccentricity" ref="mayaBlinnSurface.eccentricity" />
+        <float name="specularRollOff" ref="mayaBlinnSurface.specularRollOff" />
+        <string name="selector" ref="mayaBlinnSurface.selector" />
+        <float3 name="ambientColor" ref="mayaBlinnSurface.ambientColor" />
+        <float3  name="ambientIn" ref="mayaBlinnSurface.ambientIn" />
+        <float3 name="incandescence" ref="mayaBlinnSurface.incandescence" />
+        <float name="reflectivity" ref="mayaBlinnSurface.reflectivity" />
+        <float3 name="reflectedColor" ref="mayaBlinnSurface.reflectedColor" />
+        <float3 name="IrradianceEnv" ref="mayaBlinnSurface.IrradianceEnv" />
+        <float3 name="SpecularEnv" ref="mayaBlinnSurface.SpecularEnv" />
+        <float name="glowIntensity" ref="mayaBlinnSurface.glowIntensity" />
+        <bool name="hideSource" ref="mayaBlinnSurface.hideSource" />
+        <float name="matteOpacity" ref="mayaBlinnSurface.matteOpacity" />
+        <int name="matteOpacityMode" ref="mayaBlinnSurface.matteOpacityMode" />
+        <float name="extraOpacity" ref="mayaBlinnSurface.extraOpacity" />
+        <bool name="fogEnabled" ref="mayaBlinnSurface.fogEnabled" />
+        <float name="fogStart" ref="mayaBlinnSurface.fogStart" />
+        <float name="fogEnd" ref="mayaBlinnSurface.fogEnd" />
+        <int name="fogMode" ref="mayaBlinnSurface.fogMode" />
+        <float name="fogDensity" ref="mayaBlinnSurface.fogDensity" />
+        <float4 name="fogColor" ref="mayaBlinnSurface.fogColor" />
+        <float name="fogMultiplier" ref="mayaBlinnSurface.fogMultiplier" />
+        <float4 name="diffuseColor" ref="Float4ToFloat4.input" />
+    </properties>
+    <values>
+        <float3 name="Lw" value="0.000000,0.000000,0.000000"  />
+        <float3 name="HLw" value="0.000000,0.000000,0.000000"  />
+        <float3 name="diffuseI" value="0.000000,0.000000,0.000000"  />
+        <float name="diffuse" value="0.800000"  />
+        <float name="translucence" value="0.000000"  />
+        <float name="translucenceDepth" value="0.500000"  />
+        <float name="translucenceFocus" value="0.500000"  />
+        <float3 name="specularI" value="0.000000,0.000000,0.000000"  />
+        <float3 name="specularColor" value="0.500000,0.500000,0.500000"  />
+        <float name="eccentricity" value="0.300000"  />
+        <string name="selector" value="mayaLightSelector16"  />
+        <float3 name="ambientColor" value="0.000000,0.000000,0.000000"  />
+        <float3 name="ambientIn" value="0.000000,0.000000,0.000000"  />
+        <float3 name="incandescence" value="0.000000,0.000000,0.000000"  />
+        <float name="reflectivity" value="0.500000"  />
+        <float3 name="reflectedColor" value="0.000000,0.000000,0.000000"  />
+        <float3 name="IrradianceEnv" value="0.000000,0.000000,0.000000"  />
+        <float name="glowIntensity" value="0.000000"  />
+        <bool name="hideSource" value="false"  />
+        <float name="matteOpacity" value="1.000000"  />
+        <int name="matteOpacityMode" value="2"  />
+        <float name="extraOpacity" value="1.000000"  />
+        <bool name="fogEnabled" value="false"  />
+        <float name="fogStart" value="0.000000"  />
+        <float name="fogEnd" value="92.000000"  />
+        <int name="fogMode" value="0"  />
+        <float name="fogDensity" value="0.100000"  />
+        <float4 name="fogColor" value="0.500000,0.500000,0.500000,1.000000"  />
+        <float name="fogMultiplier" value="1.000000"  />
+        <float4 name="diffuseColor" value="0.18,0.18,0.18,1.00" />
+    </values>
+    <outputs>
+        <struct name="mayaSurfaceShaderOutput" ref="mayaBlinnSurface.mayaSurfaceShaderOutput" />
+    </outputs>
+</fragment_graph>

--- a/lib/render/vp2ShaderFragments/BasisCurvesLinearFallbackShader.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesLinearFallbackShader.xml
@@ -1,10 +1,13 @@
 <!--
 ========================================================================
 Copyright 2020 Autodesk
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/lib/render/vp2ShaderFragments/BasisCurvesLinearHull.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesLinearHull.xml
@@ -18,11 +18,6 @@ limitations under the License.
     </description>
     <keyword value="tessellation" />
     <properties>
-        <float4x4  name="world" semantic="world" flags="isRequirementOnly" />
-        <float4x4  name="worldView" semantic="worldview" flags="isRequirementOnly" />
-        <float4x4  name="projection" semantic="projection" flags="isRequirementOnly" />
-        <float4x4  name="worldViewProj" semantic="worldviewprojection" flags="isRequirementOnly" />
-        <float4x4  name="worldInverseTranspose" semantic="worldinversetranspose" flags="isRequirementOnly" />
         <float  name="tessLevel" semantic="TESSLEVEL" flags="isRequirementOnly" />
         <struct  name="inputs" semantic="SV_PATCH" size="2" struct_name="vertOutS" flags="varyingInputParam" />
         <int  name="primitiveID" semantic="SV_PrimitiveID" flags="varyingInputParam" />
@@ -39,11 +34,6 @@ limitations under the License.
         <undefined name="GPUStage" semantic="hullShader" />
         <float4  name="tessOuterLo" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
         <float4  name="tessOuterHi" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
-        <int3  name="patchParam" semantic="PATCHPARAM" flags="isRequirementOnly,varyingInputParam" />
-        <float3  name="OsdP" semantic="OsdP" flags="isRequirementOnly,varyingInputParam" />
-        <float3  name="OsdP1" semantic="OsdP1" flags="isRequirementOnly,varyingInputParam" />
-        <float3  name="OsdP2" semantic="OsdP2" flags="isRequirementOnly,varyingInputParam" />
-        <float2  name="vSegments" semantic="vSegments" flags="isRequirementOnly,varyingInputParam" />
     </outputs>
     <implementation>
         <implementation render="OGSRenderer" language="GLSL" lang_version="3.0">

--- a/lib/render/vp2ShaderFragments/BasisCurvesLinearHull.xml
+++ b/lib/render/vp2ShaderFragments/BasisCurvesLinearHull.xml
@@ -1,0 +1,140 @@
+﻿<!--
+========================================================================
+Copyright 2020 Autodesk
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment uiName="BasisCurvesLinearHull" name="BasisCurvesLinearHull" type="hullShader" class="ShadeFragment" version="1.0" feature_level="0">
+    <description>
+        <![CDATA[Hull shader for basisCurves]]>
+    </description>
+    <keyword value="tessellation" />
+    <properties>
+        <float4x4  name="world" semantic="world" flags="isRequirementOnly" />
+        <float4x4  name="worldView" semantic="worldview" flags="isRequirementOnly" />
+        <float4x4  name="projection" semantic="projection" flags="isRequirementOnly" />
+        <float4x4  name="worldViewProj" semantic="worldviewprojection" flags="isRequirementOnly" />
+        <float4x4  name="worldInverseTranspose" semantic="worldinversetranspose" flags="isRequirementOnly" />
+        <float  name="tessLevel" semantic="TESSLEVEL" flags="isRequirementOnly" />
+        <struct  name="inputs" semantic="SV_PATCH" size="2" struct_name="vertOutS" flags="varyingInputParam" />
+        <int  name="primitiveID" semantic="SV_PrimitiveID" flags="varyingInputParam" />
+        <int  name="patchID" semantic="SV_OutputControlPointID" flags="varyingInputParam" />
+        <undefined name="GPUStage" semantic="GPUStage" />
+        <float3  name="Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="Nm" semantic="NORMAL" flags="isRequirementOnly,varyingInputParam" />
+        <float  name="U0_1" semantic="TEXCOORD0" flags="isRequirementOnly,varyingInputParam" />
+    </properties>
+    <values>
+    </values>
+    <outputs>
+        <struct  name="outS" size="2" struct_name="hullOutS" />
+        <undefined name="GPUStage" semantic="hullShader" />
+        <float4  name="tessOuterLo" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <float4  name="tessOuterHi" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <int3  name="patchParam" semantic="PATCHPARAM" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="OsdP" semantic="OsdP" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="OsdP1" semantic="OsdP1" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="OsdP2" semantic="OsdP2" flags="isRequirementOnly,varyingInputParam" />
+        <float2  name="vSegments" semantic="vSegments" flags="isRequirementOnly,varyingInputParam" />
+    </outputs>
+    <implementation>
+        <implementation render="OGSRenderer" language="GLSL" lang_version="3.0">
+            <function_name val="BasisCurvesLinearHull" />
+            <source>
+                <![CDATA[
+// line 185 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+// Use the length of the control points in screen space to determine how many
+// times to subdivide the curve.
+void determineLODSettings()
+{
+    gl_TessLevelOuter[0] = 1;
+    gl_TessLevelOuter[1] = 1;
+    gl_TessLevelOuter[2] = 1;
+    gl_TessLevelOuter[3] = 1;
+
+    gl_TessLevelInner[0] = 1;
+    gl_TessLevelInner[1] = 1;
+}
+
+// line 154 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+void BasisCurvesLinearHull()
+{
+    if (gl_InvocationID == 0) {
+        determineLODSettings();
+    }
+
+    // U0_1 being used as widths.
+    HS_OUT[gl_InvocationID].U0_1 = HS_IN[gl_InvocationID].U0_1;
+}
+                ]]>
+            </source>
+        </implementation>
+        <implementation render="OGSRenderer" language="HLSL" lang_version="11.0">
+            <function_name val="BasisCurvesLinearHull" />
+            <declaration name="hullConstantsOutS" >
+                <![CDATA[
+struct hullConstantsOutS
+{
+    float tessLevelInner[2] : SV_InsideTessFactor;
+    float tessLevelOuter[4] : SV_TessFactor;
+};
+                ]]>
+            </declaration>
+            <source>
+                <![CDATA[
+// line 154 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+hullOutS BasisCurvesLinearHull(
+    InputPatch<vertOutS, 2> inputs,
+    uint primitiveID,
+    uint patchID)
+{
+    hullOutS output;
+
+    // U0_1 being used as widths.
+    output.Pm   = inputs[patchID].Pm;
+    output.Nm   = inputs[patchID].Nm;
+    output.U0_1 = inputs[patchID].U0_1;
+
+    return output;
+}
+
+// line 185 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+// Use the length of the control points in screen space to determine how many
+// times to subdivide the curve.
+hullConstantsOutS BasisCurvesLinearHullConstants(
+    InputPatch<vertOutS, 2> inPatch,
+    OutputPatch<hullOutS, 2> outPatch,
+    uint primitiveID : SV_PrimitiveID)
+{
+    hullConstantsOutS output;
+
+    output.tessLevelOuter[0] = 1;
+    output.tessLevelOuter[1] = 1;
+    output.tessLevelOuter[2] = 1;
+    output.tessLevelOuter[3] = 1;
+
+    output.tessLevelInner[0] = 1;
+    output.tessLevelInner[1] = 1;
+    
+    return output;
+}
+                ]]>
+            </source>
+        </implementation>
+        <implementation render="OGSRenderer" language="Cg" lang_version="2.1">
+            <function_name val="NOTIMPLEMENTED" />
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/render/vp2ShaderFragments/NwFaceCameraIfNAN.xml
+++ b/lib/render/vp2ShaderFragments/NwFaceCameraIfNAN.xml
@@ -1,0 +1,64 @@
+<!--
+========================================================================
+Copyright 2020 Autodesk
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment uiName="NwFaceCameraIfNAN" name="NwFaceCameraIfNAN" type="plumbing" class="ShadeFragment" version="1.0" feature_level="0">
+    <description>
+        <![CDATA[Use camera-facing normal if the authored normal is NAN]]>
+    </description>
+    <properties>
+        <float3 name="Nw" semantic="Nw" flags="varyingInputParam" />
+        <float3 name="Vw" semantic="Vw" flags="varyingInputParam" />
+    </properties>
+    <outputs>
+        <float3 name="output" />
+    </outputs>
+    <implementation>
+        <implementation render="OGSRenderer" language="GLSL" lang_version="3.0">
+            <function_name val="NwFaceCameraIfNAN" />
+            <source>
+                <![CDATA[
+vec3 NwFaceCameraIfNAN(vec3 Nw, vec3 Vw)
+{
+    return any(isnan(Nw)) ? Vw : Nw;
+}
+                ]]>
+            </source>
+        </implementation>
+        <implementation render="OGSRenderer" language="HLSL" lang_version="11.0">
+            <function_name val="NwFaceCameraIfNAN" />
+            <source>
+                <![CDATA[
+float3 NwFaceCameraIfNAN(float3 Nw, float3 Vw)
+{
+    return any(isnan(Nw)) ? Vw : Nw;
+}
+                ]]>
+            </source>
+        </implementation>
+        <implementation render="OGSRenderer" language="Cg" lang_version="2.1">
+            <function_name val="NwFaceCameraIfNAN" />
+            <source>
+                <![CDATA[
+float3 NwFaceCameraIfNAN(float3 Nw, float3 Vw)
+{
+    return any(isnan(Nw)) ? Vw : Nw;
+}
+                ]]>
+            </source>
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/render/vp2ShaderFragments/UsdPreviewSurface.xml
+++ b/lib/render/vp2ShaderFragments/UsdPreviewSurface.xml
@@ -1,6 +1,8 @@
 <!--
 ========================================================================
 Copyright 2018 Pixar
+Copyright 2020 Autodesk
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -21,6 +23,7 @@ limitations under the License.
         <fragment_ref name="mayaShaderGeom" ref="mayaShaderGeom"/>
 
         <!-- Fragments for extracting computed dot products. -->
+        <fragment_ref name="NwFaceCameraIfNAN" ref="NwFaceCameraIfNAN"/>
         <fragment_ref name="mayaShaderGeom_Float4GetX" ref="Float4ToFloatX"/>
         <fragment_ref name="mayaShaderGeom_Float4GetY" ref="Float4ToFloatY"/>
         <fragment_ref name="mayaShaderGeom_Float4GetZ" ref="Float4ToFloatZ"/>
@@ -49,6 +52,7 @@ limitations under the License.
         <!-- mayaShaderGeom packs the dot products into a float4, so we
              extract them individually for use as parameters to the lighting
              fragment. -->
+        <connect from="NwFaceCameraIfNAN.output" to="mayaShaderGeom.Nw" name="Nw"/>
         <connect from="mayaShaderGeom.mayaShaderGeom" to="mayaShaderGeom_Float4GetX.input" name="input"/>
         <connect from="mayaShaderGeom.mayaShaderGeom" to="mayaShaderGeom_Float4GetY.input" name="input"/>
         <connect from="mayaShaderGeom.mayaShaderGeom" to="mayaShaderGeom_Float4GetZ.input" name="input"/>
@@ -91,9 +95,8 @@ limitations under the License.
 
         <!-- Maya Parameters for Lighting -->
         <undefined name="GPUStage" ref="mayaComputeSurfaceFinal.GPUStage" semantic="GPUStage"/>
-        <float3 name="Nw" ref="mayaShaderGeom.Nw" flags="varyingInputParam"/>
+        <float3 name="Nw" ref="NwFaceCameraIfNAN.Nw" flags="varyingInputParam"/>
         <float3 name="Lw" ref="mayaShaderGeom.Lw"/>
-        <float3 name="Vw" ref="mayaShaderGeom.Vw" flags="varyingInputParam"/>
         <float3 name="HLw" ref="mayaHVector.HLw"/>
         <float3 name="diffuseI" ref="usdPreviewSurfaceLighting.diffuseIrradiance"/>
         <float3 name="specularI" ref="usdPreviewSurfaceLighting.specularIrradiance"/>

--- a/lib/render/vp2ShaderFragments/UsdPrimvarReader_color.xml
+++ b/lib/render/vp2ShaderFragments/UsdPrimvarReader_color.xml
@@ -1,0 +1,63 @@
+<!--
+========================================================================
+Copyright 2020 Autodesk
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment uiName="UsdPrimvarReader_color" name="UsdPrimvarReader_color" type="plumbing" class="ShadeFragment" version="1.0" feature_level="0">
+    <description>
+        <![CDATA[VP2 implementation for color/opacity reader]]>
+    </description>
+    <properties>
+        <float4 name="color" semantic="fcolor" flags="varyingInputParam" />
+    </properties>
+    <outputs>
+        <float4 name="output" />
+    </outputs>
+    <implementation>
+        <implementation render="OGSRenderer" language="GLSL" lang_version="3.0">
+            <function_name val="UsdPrimvarReader_color" />
+            <source>
+                <![CDATA[
+vec4 UsdPrimvarReader_color(vec4 input_is_glsl_kw)
+{
+    return input_is_glsl_kw;
+}
+                ]]>
+            </source>
+        </implementation>
+        <implementation render="OGSRenderer" language="HLSL" lang_version="11.0">
+            <function_name val="UsdPrimvarReader_color" />
+            <source>
+                <![CDATA[
+float4 UsdPrimvarReader_color(float4 input)
+{
+    return input;
+}
+                ]]>
+            </source>
+        </implementation>
+        <implementation render="OGSRenderer" language="Cg" lang_version="2.1">
+            <function_name val="UsdPrimvarReader_color" />
+            <source>
+                <![CDATA[
+float4 UsdPrimvarReader_color(float4 input)
+{
+    return input;
+}
+                ]]>
+            </source>
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/render/vp2ShaderFragments/UsdPrimvarReader_vector.xml
+++ b/lib/render/vp2ShaderFragments/UsdPrimvarReader_vector.xml
@@ -1,0 +1,63 @@
+<!--
+========================================================================
+Copyright 2020 Autodesk
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment uiName="UsdPrimvarReader_vector" name="UsdPrimvarReader_vector" type="plumbing" class="ShadeFragment" version="1.0" feature_level="0">
+    <description>
+        <![CDATA[VP2 implementation for primvar reader]]>
+    </description>
+    <properties>
+        <float3 name="primvar" semantic="uvCoord" flags="varyingInputParam" />
+    </properties>
+    <outputs>
+        <float3 name="result" />
+    </outputs>
+    <implementation>
+        <implementation render="OGSRenderer" language="GLSL" lang_version="3.0">
+            <function_name val="UsdPrimvarReader_vector" />
+            <source>
+                <![CDATA[
+vec3 UsdPrimvarReader_vector(vec3 input_is_glsl_kw)
+{
+    return input_is_glsl_kw;
+}
+                ]]>
+            </source>
+        </implementation>
+        <implementation render="OGSRenderer" language="HLSL" lang_version="11.0">
+            <function_name val="UsdPrimvarReader_vector" />
+            <source>
+                <![CDATA[
+float3 UsdPrimvarReader_vector(float3 input)
+{
+    return input;
+}
+                ]]>
+            </source>
+        </implementation>
+        <implementation render="OGSRenderer" language="Cg" lang_version="2.1">
+            <function_name val="UsdPrimvarReader_vector" />
+            <source>
+                <![CDATA[
+float3 UsdPrimvarReader_vector(float3 input)
+{
+    return input;
+}
+                ]]>
+            </source>
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/render/vp2ShaderFragments/shaderFragments.cpp
+++ b/lib/render/vp2ShaderFragments/shaderFragments.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Autodesk
+// Copyright 2020 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,6 +49,8 @@ TF_DEFINE_PRIVATE_TOKENS(
     (Float4ToFloat3)
     (Float4ToFloat4)
 
+    (NwFaceCameraIfNAN)
+
     (lightingContributions)
     (scaledDiffusePassThrough)
     (scaledSpecularPassThrough)
@@ -58,10 +60,12 @@ TF_DEFINE_PRIVATE_TOKENS(
 
     (UsdUVTexture)
 
+    (UsdPrimvarReader_color)
     (UsdPrimvarReader_float)
     (UsdPrimvarReader_float2)
     (UsdPrimvarReader_float3)
     (UsdPrimvarReader_float4)
+    (UsdPrimvarReader_vector)
 
     (UsdPreviewSurface)
 );
@@ -77,10 +81,12 @@ static const TfTokenVector _FragmentNames = {
 
     _tokens->UsdUVTexture,
 
+    _tokens->UsdPrimvarReader_color,
     _tokens->UsdPrimvarReader_float,
     _tokens->UsdPrimvarReader_float2,
     _tokens->UsdPrimvarReader_float3,
     _tokens->UsdPrimvarReader_float4,
+    _tokens->UsdPrimvarReader_vector,
 
     _tokens->Float4ToFloatX,
     _tokens->Float4ToFloatY,
@@ -88,6 +94,8 @@ static const TfTokenVector _FragmentNames = {
     _tokens->Float4ToFloatW,
     _tokens->Float4ToFloat3,
     _tokens->Float4ToFloat4,
+
+    _tokens->NwFaceCameraIfNAN,
 
     _tokens->lightingContributions,
     _tokens->scaledDiffusePassThrough,


### PR DESCRIPTION
This PR implements the VP2RenderDelegate support for USD curves, as well as some derisking work on tessellation shader approach for curve refinements.

* Refinement level 0 is fully implemented to get parity with USDView, which simply shows the curves as line list.
* Refinement level 1 is partially implemented as part of the work to derisk tessellation shader approach for curve refinement. For now it only interpolates widths and normals. The work is currently disabled until the new MRenderItem::setPrimitive() API is shipped.
* Refinement level 2 and 3 are not implemented, which I think is only about more complex algorithm than level 1 and I've already set up the code framework to host new algorithms.

The refactoring change to HdVP2Mesh and HdVP2DrawItem is necessary because the draw item should not be tied with mesh and should be Rprim type agnostic.