### PR TITLE
[fileio] fix a clang warning about default ctor + const member

### DIFF
--- a/lib/fileio/primUpdater.h
+++ b/lib/fileio/primUpdater.h
@@ -37,7 +37,11 @@ public:
     UsdMayaPrimUpdater(const MFnDependencyNode& depNodeFn,
                        const SdfPath& usdPath);
     
-    UsdMayaPrimUpdater() = default;
+    // clang errors if you use "= default" here, due to const SdfPath member
+    //    see: http://open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#253
+    // ...which it seems clang only implements if using newer version + cpp std
+    UsdMayaPrimUpdater() {}
+
     virtual ~UsdMayaPrimUpdater() = default;
 
     enum class Supports {


### PR DESCRIPTION
It seems the strict c++ spec used to state that a const class could only be constructed if it had an explicitly define constructor - even if there was an "obvious" default constructor, that wouldn't leave uninitialized items.

A defect was filed, and later accepted:

http://open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#253

...but it seems clang, as of Apple clang version 11.0.0, still warns if
you're using --std=c++11

(GCC lets this pass.)

The full error message I got when compiling (using OSX catalina, Apple clang version 11.0.0), was:

```
In file included from /System/Volumes/Data/Projects/Dev/USD/maya-usd/src/lib/fileio/primUpdater.cpp:17:
/System/Volumes/Data/Projects/Dev/USD/maya-usd/src/lib/fileio/primUpdater.h:40:5: error: explicitly defaulted default constructor is implicitly deleted [-Werror,-Wdefaulted-function-deleted]
    UsdMayaPrimUpdater() = default;
    ^
/System/Volumes/Data/Projects/Dev/USD/maya-usd/src/lib/fileio/primUpdater.h:113:19: note: default constructor of 'UsdMayaPrimUpdater' is implicitly deleted because field '_usdPath' of const-qualified type 'const pxrInternal_v0_20__pxrReserved__::SdfPath' would not be initialized
    const SdfPath _usdPath;
                  ^
1 error generated.
```

For what it's worth, I only got this when I completely deleted my old build dir, and started a build fresh - perhaps because `PXR_STRICT_BUILD_MODE=OFF` was cached in CMakeCache.txt?

Definitely a big fan of PXR_STRICT_BUILD_MODE being on, though - it's going to make for some things to fixup like this, but definitely worth it in the long run!