### PR TITLE
[al] De-activate usdImaging selection in ProxyDrawOverride (#1008)

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -408,9 +408,6 @@ void ProxyDrawOverride::draw(const MHWRender::MDrawContext& context, const MUser
     combined.insert(combined.end(), paths1.begin(), paths1.end());
     combined.insert(combined.end(), paths2.begin(), paths2.end());
 
-    engine->SetSelected(combined);
-    engine->SetSelectionColor(GfVec4f(1.0f, 2.0f/3.0f, 0.0f, 1.0f));
-
     ptr->m_params.frame = ptr->m_shape->outTimePlug().asMTime().as(MTime::uiUnit());
     engine->Render(ptr->m_rootPrim, ptr->m_params);
 


### PR DESCRIPTION
We noticed when loading our very large sets into Maya that the time taken to select objects in the viewport was taking upto a minute. Running the code through vtune, we identified that the most significant bottleneck was simply a result of the call to UsdImagingEngine::SetSelected. Removing these two calls returned us to an interactive selection speed within the Maya viewport. 