### PR TITLE
[al] added generate unique key method for translators (#1005)

### DIFF
--- a/cmake/plugin/AL_USDMayaTestPlugin/test_data/rig_bindings.usda
+++ b/cmake/plugin/AL_USDMayaTestPlugin/test_data/rig_bindings.usda
@@ -1,0 +1,43 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+)
+
+def "root" (
+    prepend variantSets = "cubes"
+)
+{
+    variantSet "cubes" = {
+        "fourCubes" {
+            def Scope "static_four_cubes" (
+                assettype = "beast_bindings"
+            )
+            {
+                int numCubes = 4
+            }
+            def Scope "dynamic_five_cubes" (
+                assettype = "beast_bindings"
+            )
+            {
+                int numCubes = 5
+            }
+        }
+        "fiveCubes" {
+            def Scope "static_four_cubes" (
+                assettype = "beast_bindings"
+            )
+            {
+                int numCubes = 4
+            }
+            def Scope "dynamic_five_cubes" (
+                assettype = "beast_bindings"
+            )
+            {
+                int numCubes = 5
+            }
+        }
+        "noCubes" {
+        }
+    }
+}
+

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapePostLoadProcess.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapePostLoadProcess.cpp
@@ -351,6 +351,9 @@ void ProxyShapePostLoadProcess::connectSchemaPrims(
           dataPlugin->postImport(prim);
         }
       }
+
+      context->updateUniqueKey(prim);
+
       AL_END_PROFILE_SECTION();
     }
   }

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorBase.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorBase.h
@@ -136,6 +136,20 @@ public:
   virtual MStatus postImport(const UsdPrim& prim)
     { return MS::kSuccess; }
 
+  /// \brief  If your plugin has its own hashing mechanism, your plugin can override this method to return
+  ///         a *meaningful* value as the unique key for the prim, e.g. a md5 hash or uuid string.
+  ///         This method happens just before updating the prim or removing the prim (e.g. when switching variant), then
+  ///         USDMaya checks this hash value to decide if update() / tearDown() / import() are really necessary to be
+  ///         called.
+  ///         Not implementing this method, returning empty string or a false value would indicate this prim is always
+  ///         needed to be updated (or tearDown() and import(), depends on the return value of supportsUpdate()), this
+  ///         is the backward compatible method (prior 0.35.3); returning a constant value would indicate
+  ///         this prim does not need to be updated (or recreated) at all.
+  /// \param  prim the prim to inspect.
+  /// \return unique key string.
+  virtual std::size_t generateUniqueKey(const UsdPrim& prim) const
+    { return 0; }
+
   /// \brief  This method will be called prior to the tear down process taking place. This is the last chance you have
   ///         to do any serialisation whilst all of the existing nodes are available to query.
   /// \param  prim the prim that may be modified or deleted as a result of a variant switch

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.cpp
@@ -19,6 +19,8 @@
 #include "maya/MSelectionList.h"
 #include "maya/MFnDagNode.h"
 
+#include <string>
+
 namespace AL {
 namespace usdmaya {
 namespace fileio {
@@ -390,6 +392,10 @@ MString TranslatorContext::serialise() const
     {
       oss << "," << getNodeName(it.createdNodes()[i].object());
     }
+    if (it.uniqueKey())
+    {
+      oss << ",uniquekey:" << it.uniqueKey();
+    }
     oss << ";";
   }
   return MString(oss.str().c_str());
@@ -419,8 +425,27 @@ void TranslatorContext::deserialise(const MString& string)
 
     PrimLookup lookup(SdfPath(strings2[0].asChar()), strings3[0].asChar(), obj);
 
+    static const MString uniqueKeyPrefix("uniquekey:");
+
     for(uint32_t j = 2; j < strings3.length(); ++j)
     {
+      if (strings3[j].substring(0, 10) == uniqueKeyPrefix)
+      {
+        auto keyStr(strings3[j].substring(10, strings3[j].length()));
+        if (keyStr.length())
+        {
+          try
+          {
+            lookup.setUniqueKey(std::stoul(keyStr.asChar()));
+          }
+          catch (std::logic_error&)
+          {
+            TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("TranslatorContext:deserialise ignored invalid hash value for prim='%s' [hash='%s']\n", lookup.path().GetText(), keyStr.asChar());
+          }
+        }
+        continue;
+      }
+
       MSelectionList sl;
       sl.add(strings3[j].asChar());
       MObject obj;
@@ -532,6 +557,49 @@ void TranslatorContext::removeEntries(const SdfPathVector& itemsToRemove)
   }
   status = modifier.doIt();
   AL_MAYA_CHECK_ERROR2(status, "failed to remove translator prims.");
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+void TranslatorContext::updateUniqueKeys()
+{
+  auto stage = getUsdStage();
+  for (auto& lookup: m_primMapping)
+  {
+    const auto& prim = stage->GetPrimAtPath(lookup.path());
+    if (prim)
+    {
+      std::string translatorId = getTranslatorIdForPath(lookup.path());
+      auto translator = m_proxyShape->translatorManufacture().getTranslatorFromId(translatorId);
+      if(translator)
+      {
+        auto key(translator->generateUniqueKey(prim));
+        TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("TranslatorContext::updateUniqueKeys [generateUniqueKey] prim='%s', uniqueKey='%lu'\n", lookup.path().GetText(), key);
+        lookup.setUniqueKey(key);
+      }
+    }
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+void TranslatorContext::updateUniqueKey(const UsdPrim& prim)
+{
+  TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("TranslatorContext::updateUniqueKey\n");
+
+  const auto path(prim.GetPath());
+  TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("TranslatorContext::updateUniqueKey [generateUniqueKey] updating unique key for prim='%s'\n", path.GetText());
+
+  std::string translatorId = getTranslatorIdForPath(path);
+  auto translator = m_proxyShape->translatorManufacture().getTranslatorFromId(translatorId);
+  if(translator)
+  {
+    auto it = find(path);
+    if(it != m_primMapping.end() && it->path() == path)
+    {
+      auto key(translator->generateUniqueKey(prim));
+      TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("TranslatorContext::updateUniqueKey [generateUniqueKey] prim='%s', uniqueKey='%lu', previousUniqueKey='%lu'\n", path.GetText(), key, it->uniqueKey());
+      it->setUniqueKey(key);
+    }
+  }
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.h
@@ -286,6 +286,28 @@ public:
   AL_USDMAYA_PUBLIC
   void removeEntries(const SdfPathVector& itemsToRemove);
 
+  /// \brief  Get unique key for specified prim path.
+  /// \param  path target prim path
+  /// \return unique key value
+  std::size_t getUniqueKeyForPath(const SdfPath& path)
+  {
+    auto it = find(path);
+    if(it != m_primMapping.end())
+    {
+      return it->uniqueKey();
+    }
+    return 0;
+  }
+
+  /// \brief  Update all unique keys when saving Maya scene.
+  AL_USDMAYA_PUBLIC
+  void updateUniqueKeys();
+
+  /// \brief  Update unique key for a specified prim.
+  /// \param  prim target prim
+  AL_USDMAYA_PUBLIC
+  void updateUniqueKey(const UsdPrim& prim);
+
   /// \brief  An internal structure used to store a mapping between an SdfPath, the type of prim found at that location,
   ///         the maya transform that may have been created (assuming the translator plugin specifies that it needs
   ///         a parent transform), and any nodes that the translator plugin may have created.
@@ -297,7 +319,7 @@ public:
     ///         to call to tear down this prim.
     /// \param  mayaObj the maya transform
     PrimLookup(const SdfPath& path, const std::string& translatorId, MObject mayaObj)
-      : m_path(path), m_translatorId(translatorId), m_object(mayaObj), m_createdNodes() { }
+      : m_path(path), m_translatorId(translatorId), m_uniqueKey(0), m_object(mayaObj), m_createdNodes() { }
 
     /// \brief  dtor
     ~PrimLookup() {}
@@ -322,6 +344,16 @@ public:
     std::string translatorId() const
       { return m_translatorId; }
 
+    /// \brief  get the unique key of the prim
+    /// \return the unique key for this prim
+    const std::size_t uniqueKey() const
+      { return m_uniqueKey; }
+
+    /// \brief  set the unique key for this prim
+    /// \param the unique key for this prim
+    void setUniqueKey(const std::size_t key)
+      { m_uniqueKey = key; }
+
     /// \brief  get the prim type
     /// \return the type stored for this prim
     TfToken type() const
@@ -345,6 +377,7 @@ public:
   private:
     SdfPath m_path;
     std::string m_translatorId;
+    std::size_t m_uniqueKey;
     TfToken m_type;
     MObjectHandle m_object;
     MObjectHandleArray m_createdNodes;

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -82,6 +82,7 @@ void ProxyShape::serialiseTranslatorContext()
 {
   triggerEvent("PreSerialiseContext");
 
+  context()->updateUniqueKeys();
   serializedTrCtxPlug().setValue(context()->serialise());
 
   triggerEvent("PostSerialiseContext");

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -1061,7 +1061,22 @@ private:
   std::string generateTranslatorId(UsdPrim prim) override
    { return m_translatorManufacture.generateTranslatorId(prim); }
 
-
+  bool isPrimDirty(const UsdPrim& prim) override
+  {
+    const SdfPath path(prim.GetPath());
+    auto previous(m_context->getUniqueKeyForPath(path));
+    if (!previous)
+    {
+      return true;
+    }
+    std::string translatorId = m_translatorManufacture.generateTranslatorId(prim);
+    auto translator = m_translatorManufacture.getTranslatorFromId(translatorId);
+    auto current(translator->generateUniqueKey(prim));
+    TF_DEBUG(ALUSDMAYA_EVALUATION).Msg(
+        "ProxyShape:isPrimDirty prim='%s' uniqueKey='%lu', previous='%lu'\n",
+        path.GetText(), current, previous);
+    return !current || current != previous;
+  }
 
 private:
   SdfPathVector m_pathsOrdered;

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/PrimFilter.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/PrimFilter.h
@@ -55,6 +55,11 @@ struct PrimFilterInterface
 
 
   virtual std::string generateTranslatorId(UsdPrim prim) = 0;
+
+  /// \brief  check if a prim is dirty.
+  /// \param  prim the prim to check.
+  /// \return returns true if yes, false otherwise.
+  virtual bool isPrimDirty(const UsdPrim& prim) = 0;
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testTranslators.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testTranslators.py
@@ -413,9 +413,269 @@ class TestPythonTranslators(unittest.TestCase):
         vs.SetVariantSelection("noCubes")
 
 
+class TestTranslatorUniqueKey(usdmaya.TranslatorBase):
+    """
+    Basic Translator for testing unique key
+    """
+    def __init__(self, *args, **kwargs):
+        super(TestTranslatorUniqueKey, self).__init__(*args, **kwargs)
+        self._supportsUpdate = False
+        self.resetCounters()
+        self.primHashValues = dict()
+
+    def initialize(self):
+        return True
+
+    def resetCounters(self):
+        self.preTearDownCount = 0
+        self.tearDownCount = 0
+        self.importObjectCount = 0
+        self.postImportCount = 0
+        self.updateCount = 0
+
+    def setSupportsUpdate(self, state):
+        self._supportsUpdate = state
+
+    def generateUniqueKey(self, prim):
+        return self.primHashValues.get(str(prim.GetPath()))
+
+    def preTearDown(self, prim):
+        self.preTearDownCount += 1
+        return True
+
+    def tearDown(self, path):
+        self.tearDownCount += 1
+        self.removeItems(path)
+        return True
+
+    def canExport(self, mayaObjectName):
+        return False
+
+    def needsTransformParent(self):
+        return True
+
+    def supportsUpdate(self):
+        return self._supportsUpdate
+
+    def importableByDefault(self):
+        return True
+
+    def exportObject(self, stage, path, usdPath, params):
+        return
+
+    def postImport(self, prim):
+        self.postImportCount += 1
+        return True
+
+    def getTranslatedType(self):
+        return Tf.Type.Unknown
+
+    def importObject(self, prim, parent=None):
+        self.importObjectCount += 1
+        numCubesAttr = prim.GetAttribute("numCubes")
+        numCubes = 0
+        if numCubesAttr.IsValid():
+            numCubes = numCubesAttr.Get()
+
+        dgNodes = []
+        for x in range(numCubes):
+            nodes = cmds.polyCube()
+            dgNodes.append(nodes[1])
+            cmds.parent(nodes[0], parent)
+
+        # Only insert the DG nodes. The Dag nodes
+        # created under the parent will be deleted
+        # by AL_USDMaya automatically when the parent
+        # transform is deleted.
+        for n in dgNodes:
+            self.insertItem(prim, n)
+
+        return True
+
+    def update(self, prim):
+        self.updateCount += 1
+        return True
+
+
+class TestPythonTranslatorsUniqueKey(unittest.TestCase):
+
+    def setUp(self):
+        cmds.file(force=True, new=True)
+        cmds.loadPlugin("AL_USDMayaPlugin", quiet=True)
+        self.assertTrue(cmds.pluginInfo("AL_USDMayaPlugin", query=True, loaded=True))
+
+        self.translator = TestTranslatorUniqueKey()
+
+        usdmaya.TranslatorBase.registerTranslator(self.translator, 'beast_bindings')
+
+        self.stage = Usd.Stage.Open('../test_data/rig_bindings.usda')
+        self.rootPrim = self.stage.GetPrimAtPath('/root')
+
+        self.stageCache = UsdUtils.StageCache.Get()
+        self.stageCache.Insert(self.stage)
+        self.stageId = self.stageCache.GetId(self.stage)
+
+    def tearDown(self):
+        UsdUtils.StageCache.Get().Clear()
+        usdmaya.TranslatorBase.clearTranslators()
+        self.translator = None
+        self.stage = None
+        self.stageCache = None
+        self.stageId = None
+
+    def test_withoutSupportsUpdate(self):
+        self.translator.setSupportsUpdate(False)
+
+        # pre-generate hash value for testing only
+        self.translator.primHashValues['/root/static_four_cubes'] = 'static'
+        self.translator.primHashValues['/root/dynamic_five_cubes'] = None
+
+        vs = self.rootPrim.GetVariantSet('cubes')
+        vs.SetVariantSelection('fourCubes')
+
+        cmds.AL_usdmaya_ProxyShapeImport(stageId=self.stageId.ToLongInt(), name='bindings_grp')
+        self.assertEqual(self.translator.preTearDownCount, 0)
+        self.assertEqual(self.translator.tearDownCount, 0)
+        self.assertEqual(self.translator.importObjectCount, 2)
+        self.assertEqual(self.translator.postImportCount, 2)
+        self.assertEqual(self.translator.updateCount, 0)
+        self.assertTrue(cmds.objExists('|bindings_grp|root|static_four_cubes'))
+        self.assertTrue(cmds.objExists('|bindings_grp|root|dynamic_five_cubes'))
+
+        self.translator.resetCounters()
+        # swapping variant set
+        vs.SetVariantSelection('fiveCubes')
+
+        # preTearDownCount happens two times:
+        #  - one for before changing variant set
+        #   "static_four_cubes", "dynamic_five_cubes", +2
+        #  - one for before unloading when re-sync
+        #   "dynamic_five_cubes", +1
+        self.assertEqual(self.translator.preTearDownCount, 3)
+
+        # "dynamic_five_cubes" has no hash, will be removed and recreated (+1)
+        self.assertEqual(self.translator.tearDownCount, 1)
+        self.assertEqual(self.translator.importObjectCount, 1)
+        self.assertEqual(self.translator.postImportCount, 1)
+        self.assertEqual(self.translator.updateCount, 0)
+        self.assertTrue(cmds.objExists('|bindings_grp|root|static_four_cubes'))
+        self.assertTrue(cmds.objExists('|bindings_grp|root|dynamic_five_cubes'))
+
+        ###
+        self.translator.resetCounters()
+
+        # set hash to constant value for both
+        # assuming something changed in Maya and invalided the hash
+        self.translator.primHashValues['/root/static_four_cubes'] = 1242569910549196999 # <= hash(...)
+        self.translator.primHashValues['/root/dynamic_five_cubes'] = -8694302015330580362
+        # switch variant again
+        vs.SetVariantSelection('fourCubes')
+
+        # both of them will be removed and recreated
+        self.assertEqual(self.translator.preTearDownCount, 4)
+        self.assertEqual(self.translator.tearDownCount, 2)
+        self.assertEqual(self.translator.importObjectCount, 2)
+        self.assertEqual(self.translator.postImportCount, 2)
+        self.assertEqual(self.translator.updateCount, 0)
+        self.assertTrue(cmds.objExists('|bindings_grp|root|static_four_cubes'))
+        self.assertTrue(cmds.objExists('|bindings_grp|root|dynamic_five_cubes'))
+
+        ###
+        self.translator.resetCounters()
+
+        # switch variant without changing the hash, no update will happen
+        vs.SetVariantSelection('fiveCubes')
+        # two preTearDown() will be called to update the hash before unloading
+        self.assertEqual(self.translator.preTearDownCount, 2)
+        # no removing nor recreating will happen, the hash are the same
+        self.assertEqual(self.translator.tearDownCount, 0)
+        self.assertEqual(self.translator.importObjectCount, 0)
+        self.assertEqual(self.translator.postImportCount, 0)
+        self.assertEqual(self.translator.updateCount, 0)
+        self.assertTrue(cmds.objExists('|bindings_grp|root|static_four_cubes'))
+        self.assertTrue(cmds.objExists('|bindings_grp|root|dynamic_five_cubes'))
+
+    def test_withSupportsUpdate(self):
+        self.translator.setSupportsUpdate(True)
+
+        # pre-generate hash value for testing only
+        self.translator.primHashValues['/root/static_four_cubes'] = 1242569910549196999
+        self.translator.primHashValues['/root/dynamic_five_cubes'] = None
+
+        vs = self.rootPrim.GetVariantSet('cubes')
+        vs.SetVariantSelection('fourCubes')
+
+        cmds.AL_usdmaya_ProxyShapeImport(stageId=self.stageId.ToLongInt(), name='bindings_grp')
+        self.assertEqual(self.translator.preTearDownCount, 0)
+        self.assertEqual(self.translator.tearDownCount, 0)
+        self.assertEqual(self.translator.importObjectCount, 2)
+        self.assertEqual(self.translator.postImportCount, 2)
+        self.assertEqual(self.translator.updateCount, 0)
+        self.assertTrue(cmds.objExists('|bindings_grp|root|static_four_cubes'))
+        self.assertTrue(cmds.objExists('|bindings_grp|root|dynamic_five_cubes'))
+
+        ###
+        self.translator.resetCounters()
+        # swapping variant set
+        # "static_four_cubes" will not be updated;
+        # "dynamic_five_cubes" will be updated
+        vs.SetVariantSelection('fiveCubes')
+
+        # preTearDownCount happens two times:
+        #  - one for before changing variant set
+        #   "static_four_cubes", "dynamic_five_cubes", +2
+        #  - one for before unloading when re-sync
+        #    (none for this case) +0
+        self.assertEqual(self.translator.preTearDownCount, 2)
+
+        # "dynamic_five_cubes" has no hash, will be updated (+1)
+        self.assertEqual(self.translator.tearDownCount, 0)
+        self.assertEqual(self.translator.importObjectCount, 0)
+        self.assertEqual(self.translator.postImportCount, 1)
+        self.assertEqual(self.translator.updateCount, 1)
+        self.assertTrue(cmds.objExists('|bindings_grp|root|static_four_cubes'))
+        self.assertTrue(cmds.objExists('|bindings_grp|root|dynamic_five_cubes'))
+
+        ###
+        self.translator.resetCounters()
+
+        # set hash to constant value for both
+        # assuming something changed in Maya and invalided the hash
+        self.translator.primHashValues['/root/static_four_cubes'] = '12345'
+        self.translator.primHashValues['/root/dynamic_five_cubes'] = '12345'
+        # switch variant again
+        # both of them will be updated
+        vs.SetVariantSelection('fourCubes')
+
+        # both of them will be removed and recreated
+        self.assertEqual(self.translator.preTearDownCount, 2)
+        self.assertEqual(self.translator.tearDownCount, 0)
+        self.assertEqual(self.translator.importObjectCount, 0)
+        self.assertEqual(self.translator.postImportCount, 2)
+        self.assertEqual(self.translator.updateCount, 2)
+        self.assertTrue(cmds.objExists('|bindings_grp|root|static_four_cubes'))
+        self.assertTrue(cmds.objExists('|bindings_grp|root|dynamic_five_cubes'))
+
+        ###
+        self.translator.resetCounters()
+
+        # switch variant without changing the hash, no update will happen
+        vs.SetVariantSelection('fiveCubes')
+        # two preTearDown() will be called to update the hash before unloading
+        self.assertEqual(self.translator.preTearDownCount, 2)
+        # no removing nor recreating will happen, the hash are the same
+        self.assertEqual(self.translator.tearDownCount, 0)
+        self.assertEqual(self.translator.importObjectCount, 0)
+        self.assertEqual(self.translator.postImportCount, 0)
+        self.assertEqual(self.translator.updateCount, 0)
+        self.assertTrue(cmds.objExists('|bindings_grp|root|static_four_cubes'))
+        self.assertTrue(cmds.objExists('|bindings_grp|root|dynamic_five_cubes'))
+
+
 if __name__ == "__main__":
 
     tests = [unittest.TestLoader().loadTestsFromTestCase(TestPythonTranslators)]
+    tests += [unittest.TestLoader().loadTestsFromTestCase(TestPythonTranslatorsUniqueKey)]
     
     results = [unittest.TextTestRunner(verbosity=2).run(test) for test in tests]
     exitCode = int(not all([result.wasSuccessful() for result in results]))

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/test_data/rig_bindings.usda
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/test_data/rig_bindings.usda
@@ -1,0 +1,43 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+)
+
+def "root" (
+    prepend variantSets = "cubes"
+)
+{
+    variantSet "cubes" = {
+        "fourCubes" {
+            def Scope "static_four_cubes" (
+                assettype = "beast_bindings"
+            )
+            {
+                int numCubes = 4
+            }
+            def Scope "dynamic_five_cubes" (
+                assettype = "beast_bindings"
+            )
+            {
+                int numCubes = 5
+            }
+        }
+        "fiveCubes" {
+            def Scope "static_four_cubes" (
+                assettype = "beast_bindings"
+            )
+            {
+                int numCubes = 4
+            }
+            def Scope "dynamic_five_cubes" (
+                assettype = "beast_bindings"
+            )
+            {
+                int numCubes = 5
+            }
+        }
+        "noCubes" {
+        }
+    }
+}
+


### PR DESCRIPTION
Typically when using a custom translator, the following action occurs on a variant switch:

If a prim that had previously been translated into Maya, remains in the stage after a variant switch, and that prim supports update, then the translator's update method will be called. In some cases this update step may be entirely superfluous _(because none of the data changed)_. 

For some of the translators we use internally, there are cases where the cost of updating can be very large, so this PR adds a way to optionally generate a hash for a translated prim, which can be used again later on to determine whether update should be called or not. 

Within a translator, you would override the generateUniqueKey method, to return a hashed value for a specific prim. 