### PR TITLE
[al] clean up boundary of BasicTransformationMatrix and TransformationMatrix

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/BasicTransformationMatrix.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/BasicTransformationMatrix.cpp
@@ -25,16 +25,14 @@ class Scope;
 
 BasicTransformationMatrix::BasicTransformationMatrix()
   : MPxTransformationMatrix(),
-    m_prim(),
-    m_scope()
+    m_prim()
 {
   TF_DEBUG(ALUSDMAYA_TRANSFORM_MATRIX).Msg("BasicTransformationMatrix::BasicTransformationMatrix\n");
 }
 
 BasicTransformationMatrix::BasicTransformationMatrix(const UsdPrim& prim)
 : MPxTransformationMatrix(),
-  m_prim(prim),
-  m_scope(prim)
+  m_prim(prim)
 {
     TF_DEBUG(ALUSDMAYA_TRANSFORM_MATRIX).Msg("BasicTransformationMatrix::BasicTransformationMatrix\n");
 }
@@ -53,13 +51,11 @@ void BasicTransformationMatrix::setPrim(const UsdPrim& prim, Scope* scopeNode)
     TF_DEBUG(ALUSDMAYA_TRANSFORM_MATRIX).Msg("BasicTransformationMatrix::setPrim %s\n", prim.GetName().GetText());
     m_prim = prim;
     UsdGeomScope scope(prim);
-    m_scope = scope;
   }
   else
   {
     TF_DEBUG(ALUSDMAYA_TRANSFORM_MATRIX).Msg("BasicTransformationMatrix::setPrim null\n");
     m_prim = UsdPrim();
-    m_scope = UsdGeomScope();
   }
 }
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/BasicTransformationMatrix.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/BasicTransformationMatrix.h
@@ -61,7 +61,7 @@ public:
 
   /// \brief  sets the MObject for the transform
   /// \param  object the MObject for the custom transform node
-  virtual void setMObject(const MObject object)
+  void setMObject(const MObject object)
      { m_transformNode = object; }
 
   /// \brief  Is this transform set to write back onto the USD prim, and is it currently possible?
@@ -86,9 +86,6 @@ public:
 
 protected:
   UsdPrim m_prim;
-
-private:
-  UsdGeomScope m_scope;
   MObjectHandle m_transformNode;
 
 };

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Scope.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Scope.h
@@ -76,7 +76,7 @@ public:
 
   /// \brief  returns the transformation matrix for this transform node
   /// \return the transformation matrix
-  virtual BasicTransformationMatrix* transform() const
+  inline BasicTransformationMatrix* transform() const
     { return reinterpret_cast<BasicTransformationMatrix*>(transformationMatrixPtr()); }
 
   virtual const MObject getProxyShape() const

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.h
@@ -50,7 +50,6 @@ class TransformationMatrix
   UsdTimeCode m_time;
   std::vector<UsdGeomXformOp> m_xformops;
   std::vector<TransformOperation> m_orderedOps;
-  MObjectHandle m_transformNode;
 
   // tweak values. These are applied on top of the USD transform values to produce the final result.
   MVector m_scaleTweak;
@@ -354,11 +353,6 @@ class TransformationMatrix
   MMatrix asMatrix(double percent) const override;
 
 public:
-
-  /// \brief  sets the MObject for the transform
-  /// \param  object the MObject for the custom transform node
-  void setMObject(const MObject object) override
-    { m_transformNode = object; }
 
   /// \brief  the type ID of the transformation matrix
   AL_USDMAYA_PUBLIC


### PR DESCRIPTION
Similar to the recent scope fixes (with shadowing of m_prim), I noticed that there were some oddities in the division between BasicTransformationMatrix and TransformationMatrix.

Specifically:

- `m_scope` never seemed to be used anywhere
- `m_transformNode` seemed to be unnecessarily shadowed; unshadowing also meant that `setMObject` didn't need to be virtual / repeated
- there seemed to be no need for `Scope::transform()` to be virtual - it's never overridden, and `Transform::getTransMatrix()` is already defined to get a `TransformationMatrix*`