### PR TITLE
add MProfiler/trace performance tracing when using Pixar's batch renderer

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -462,6 +462,7 @@ target_link_libraries(${LIBRARY_NAME}
     plug
     sdf
     tf
+    trace
     usd
     usdGeom
     usdImaging

--- a/lib/nodes/proxyShapeBase.cpp
+++ b/lib/nodes/proxyShapeBase.cpp
@@ -34,6 +34,7 @@
 #include "pxr/base/tf/staticTokens.h"
 #include "pxr/base/tf/stringUtils.h"
 #include "pxr/base/tf/token.h"
+#include "pxr/base/trace/trace.h"
 
 #include "pxr/usd/ar/resolver.h"
 #include "pxr/usd/sdf/layer.h"
@@ -620,6 +621,8 @@ MayaUsdProxyShapeBase::GetOutputTime(MDataBlock dataBlock) const
 MBoundingBox
 MayaUsdProxyShapeBase::boundingBox() const
 {
+    TRACE_FUNCTION();
+
     MStatus status;
 
     // Make sure outStage is up to date

--- a/lib/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -94,6 +94,14 @@ TF_DEFINE_PRIVATE_TOKENS(
 
 TF_INSTANTIATE_SINGLETON(UsdMayaGLBatchRenderer);
 
+const int UsdMayaGLBatchRenderer::ProfilerCategory = MProfiler::addCategory(
+#if MAYA_API_VERSION >= 20190000
+    "UsdMayaGLBatchRenderer", "UsdMayaGLBatchRenderer"
+#else
+    "UsdMayaGLBatchRenderer"
+#endif
+);
+
 /* static */
 void
 UsdMayaGLBatchRenderer::Init()

--- a/lib/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -39,6 +39,7 @@
 #include "pxr/base/tf/stringUtils.h"
 #include "pxr/base/tf/stl.h"
 #include "pxr/base/tf/token.h"
+#include "pxr/base/trace/trace.h"
 #include "pxr/base/vt/types.h"
 #include "pxr/base/vt/value.h"
 #include "pxr/imaging/glf/contextCaps.h"
@@ -66,6 +67,7 @@
 #include <maya/MMatrix.h>
 #include <maya/MObject.h>
 #include <maya/MObjectHandle.h>
+#include <maya/MProfiler.h>
 #include <maya/MSceneMessage.h>
 #include <maya/MSelectInfo.h>
 #include <maya/MSelectionContext.h>
@@ -138,6 +140,13 @@ UsdMayaGLBatchRenderer::GetDelegatePrefix(const bool isViewport2) const
 bool
 UsdMayaGLBatchRenderer::AddShapeAdapter(PxrMayaHdShapeAdapter* shapeAdapter)
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        ProfilerCategory,
+        MProfiler::kColorE_L3,
+        "Batch Renderer Adding Shape Adapter");
+
     if (!TF_VERIFY(shapeAdapter, "Cannot add invalid shape adapter")) {
         return false;
     }
@@ -245,6 +254,13 @@ UsdMayaGLBatchRenderer::AddShapeAdapter(PxrMayaHdShapeAdapter* shapeAdapter)
 bool
 UsdMayaGLBatchRenderer::RemoveShapeAdapter(PxrMayaHdShapeAdapter* shapeAdapter)
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        ProfilerCategory,
+        MProfiler::kColorE_L3,
+        "Batch Renderer Removing Shape Adapter");
+
     if (!TF_VERIFY(shapeAdapter, "Cannot remove invalid shape adapter")) {
         return false;
     }
@@ -570,6 +586,13 @@ UsdMayaGLBatchRenderer::Draw(const MDrawRequest& request, M3dView& view)
 {
     // Legacy viewport implementation.
 
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        ProfilerCategory,
+        MProfiler::kColorC_L2,
+        "Batch Renderer Draw() (Legacy Viewport)");
+
     MDrawData drawData = request.drawData();
 
     const PxrMayaHdUserData* hdUserData =
@@ -625,6 +648,13 @@ UsdMayaGLBatchRenderer::Draw(
         const MUserData* userData)
 {
     // Viewport 2.0 implementation.
+
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        ProfilerCategory,
+        MProfiler::kColorC_L2,
+        "Batch Renderer Draw() (Viewport 2.0)");
 
     const PxrMayaHdUserData* hdUserData =
         dynamic_cast<const PxrMayaHdUserData*>(userData);
@@ -731,6 +761,13 @@ UsdMayaGLBatchRenderer::TestIntersection(
     // viewport-based selection method, we compute the selection against the
     // Viewport 2.0 shape adapter buckets rather than the legacy buckets, since
     // we want to compute selection against what's actually being rendered.
+
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        ProfilerCategory,
+        MProfiler::kColorE_L3,
+        "Batch Renderer Testing Intersection (Legacy Viewport)");
 
     M3dView view = selectInfo.view();
 
@@ -842,6 +879,13 @@ UsdMayaGLBatchRenderer::TestIntersection(
         const MHWRender::MDrawContext& context)
 {
     // Viewport 2.0 implementation.
+
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        ProfilerCategory,
+        MProfiler::kColorE_L3,
+        "Batch Renderer Testing Intersection (Viewport 2.0)");
 
     // Guard against the user clicking in the viewer before the renderer is
     // setup, or with no shape adapters registered.
@@ -1066,6 +1110,13 @@ UsdMayaGLBatchRenderer::_TestIntersection(
         const bool singleSelection,
         HdxPickHitVector* result)
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        ProfilerCategory,
+        MProfiler::kColorE_L3,
+        "Batch Renderer Testing Intersection");
+
     if (!result) {
         return false;
     }
@@ -1121,6 +1172,13 @@ UsdMayaGLBatchRenderer::_ComputeSelection(
         const GfMatrix4d& projectionMatrix,
         const bool singleSelection)
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        ProfilerCategory,
+        MProfiler::kColorE_L3,
+        "Batch Renderer Computing Selection");
+
     // If depth selection has not been turned on, then we can optimize
     // area/marquee selections by handling collections similarly to a single
     // selection, where we test intersections against the single, viewport
@@ -1218,6 +1276,13 @@ UsdMayaGLBatchRenderer::_Render(
         const GfVec4d& viewport,
         const std::vector<_RenderItem>& items)
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        ProfilerCategory,
+        MProfiler::kColorC_L2,
+        "Batch Renderer Rendering Batch");
+
     _taskDelegate->SetCameraState(worldToViewMatrix,
                                   projectionMatrix,
                                   viewport);
@@ -1296,7 +1361,16 @@ UsdMayaGLBatchRenderer::_Render(
     _hdEngine.SetTaskContextData(HdxTokens->selectionState,
                                  selectionTrackerValue);
 
-    _hdEngine.Execute(_renderIndex.get(), &tasks);
+    {
+        TRACE_SCOPE("Executing Hydra Tasks");
+
+        MProfilingScope hydraProfilingScope(
+            ProfilerCategory,
+            MProfiler::kColorC_L3,
+            "Batch Renderer Executing Hydra Tasks");
+
+        _hdEngine.Execute(_renderIndex.get(), &tasks);
+    }
 
     glDisable(GL_FRAMEBUFFER_SRGB_EXT);
 
@@ -1319,6 +1393,13 @@ UsdMayaGLBatchRenderer::_RenderBatches(
         const GfMatrix4d& projectionMatrix,
         const GfVec4d& viewport)
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        ProfilerCategory,
+        MProfiler::kColorC_L2,
+        "Batch Renderer Rendering Batches");
+
     _ShapeAdapterBucketsMap& bucketsMap = bool(vp2Context) ?
         _shapeAdapterBuckets :
         _legacyShapeAdapterBuckets;

--- a/lib/render/pxrUsdMayaGL/batchRenderer.h
+++ b/lib/render/pxrUsdMayaGL/batchRenderer.h
@@ -89,6 +89,10 @@ class UsdMayaGLBatchRenderer
 {
 public:
 
+    /// Maya profiler category ID
+    MAYAUSD_CORE_PUBLIC
+    static const int ProfilerCategory;
+
     /// Initialize the batch renderer.
     ///
     /// This should be called at least once and it is OK to call it multiple

--- a/lib/render/pxrUsdMayaGL/hdImagingShapeDrawOverride.cpp
+++ b/lib/render/pxrUsdMayaGL/hdImagingShapeDrawOverride.cpp
@@ -26,6 +26,7 @@
 #include "pxr/base/gf/vec2i.h"
 #include "pxr/base/tf/debug.h"
 #include "pxr/base/tf/stringUtils.h"
+#include "pxr/base/trace/trace.h"
 
 #include <maya/MBoundingBox.h>
 #include <maya/MDGContext.h>
@@ -35,6 +36,7 @@
 #include <maya/MFrameContext.h>
 #include <maya/MObject.h>
 #include <maya/MPlug.h>
+#include <maya/MProfiler.h>
 #include <maya/MPxDrawOverride.h>
 #include <maya/MStatus.h>
 #include <maya/MString.h>
@@ -91,6 +93,13 @@ PxrMayaHdImagingShapeDrawOverride::boundingBox(
         const MDagPath& objPath,
         const MDagPath& /* cameraPath */) const
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        UsdMayaGLBatchRenderer::ProfilerCategory,
+        MProfiler::kColorE_L1,
+        "Hydra Imaging Shape Computing Bounding Box (Viewport 2.0)");
+
     const PxrMayaHdImagingShape* imagingShape =
         PxrMayaHdImagingShape::GetShapeAtDagPath(objPath);
     if (!imagingShape) {
@@ -130,6 +139,13 @@ PxrMayaHdImagingShapeDrawOverride::prepareForDraw(
         const MHWRender::MFrameContext& frameContext,
         MUserData* oldData)
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        UsdMayaGLBatchRenderer::ProfilerCategory,
+        MProfiler::kColorE_L2,
+        "Hydra Imaging Shape prepareForDraw() (Viewport 2.0)");
+
     const PxrMayaHdImagingShape* imagingShape =
         PxrMayaHdImagingShape::GetShapeAtDagPath(objPath);
     if (!imagingShape) {
@@ -203,6 +219,13 @@ PxrMayaHdImagingShapeDrawOverride::draw(
         const MHWRender::MDrawContext& context,
         const MUserData* data)
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        UsdMayaGLBatchRenderer::ProfilerCategory,
+        MProfiler::kColorC_L1,
+        "Hydra Imaging Shape draw() (Viewport 2.0)");
+
     TF_DEBUG(PXRUSDMAYAGL_BATCHED_DRAWING).Msg(
         "PxrMayaHdImagingShapeDrawOverride::draw()\n");
 

--- a/lib/render/pxrUsdMayaGL/hdImagingShapeUI.cpp
+++ b/lib/render/pxrUsdMayaGL/hdImagingShapeUI.cpp
@@ -25,6 +25,7 @@
 
 #include "pxr/base/gf/vec2i.h"
 #include "pxr/base/tf/debug.h"
+#include "pxr/base/trace/trace.h"
 
 #include <maya/M3dView.h>
 #include <maya/MDGContext.h>
@@ -35,6 +36,7 @@
 #include <maya/MDrawRequestQueue.h>
 #include <maya/MFnDependencyNode.h>
 #include <maya/MPlug.h>
+#include <maya/MProfiler.h>
 #include <maya/MPxSurfaceShapeUI.h>
 #include <maya/MStatus.h>
 
@@ -57,6 +59,13 @@ PxrMayaHdImagingShapeUI::getDrawRequests(
         bool /* objectAndActiveOnly */,
         MDrawRequestQueue& requests)
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        UsdMayaGLBatchRenderer::ProfilerCategory,
+        MProfiler::kColorE_L2,
+        "Hydra Imaging Shape getDrawRequests() (Legacy Viewport)");
+
     const MDagPath shapeDagPath = drawInfo.multiPath();
     const PxrMayaHdImagingShape* imagingShape =
         PxrMayaHdImagingShape::GetShapeAtDagPath(shapeDagPath);
@@ -133,6 +142,13 @@ PxrMayaHdImagingShapeUI::getDrawRequests(
 void
 PxrMayaHdImagingShapeUI::draw(const MDrawRequest& request, M3dView& view) const
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        UsdMayaGLBatchRenderer::ProfilerCategory,
+        MProfiler::kColorC_L1,
+        "Hydra Imaging Shape draw() (Legacy Viewport)");
+
     TF_DEBUG(PXRUSDMAYAGL_BATCHED_DRAWING).Msg(
         "PxrMayaHdImagingShapeUI::draw()\n");
 

--- a/lib/render/pxrUsdMayaGL/proxyDrawOverride.cpp
+++ b/lib/render/pxrUsdMayaGL/proxyDrawOverride.cpp
@@ -27,6 +27,7 @@
 #include "pxr/base/gf/matrix4d.h"
 #include "pxr/base/gf/vec3f.h"
 #include "pxr/base/tf/stringUtils.h"
+#include "pxr/base/trace/trace.h"
 
 #include <maya/M3dView.h>
 #include <maya/MBoundingBox.h>
@@ -36,6 +37,7 @@
 #include <maya/MMatrix.h>
 #include <maya/MObject.h>
 #include <maya/MPoint.h>
+#include <maya/MProfiler.h>
 #include <maya/MPxDrawOverride.h>
 #include <maya/MSelectionContext.h>
 #include <maya/MSelectionMask.h>
@@ -114,6 +116,13 @@ UsdMayaProxyDrawOverride::boundingBox(
         const MDagPath& objPath,
         const MDagPath& /* cameraPath */) const
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        UsdMayaGLBatchRenderer::ProfilerCategory,
+        MProfiler::kColorE_L1,
+        "USD Proxy Shape Computing Bounding Box (Viewport 2.0)");
+
     // If a proxy shape is connected to a Maya instancer, a draw override will
     // be generated for the proxy shape, but callbacks will get the instancer
     // DAG path instead. Since we properly handle instancers using the
@@ -182,6 +191,13 @@ UsdMayaProxyDrawOverride::prepareForDraw(
         const MHWRender::MFrameContext& frameContext,
         MUserData* oldData)
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        UsdMayaGLBatchRenderer::ProfilerCategory,
+        MProfiler::kColorE_L2,
+        "USD Proxy Shape prepareForDraw() (Viewport 2.0)");
+
     // If a proxy shape is connected to a Maya instancer, a draw override will
     // be generated for the proxy shape, but callbacks will get the instancer
     // DAG path instead. Since we properly handle instancer drawing in this
@@ -246,6 +262,13 @@ UsdMayaProxyDrawOverride::userSelect(
         MPoint& hitPoint,
         const MUserData* data)
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        UsdMayaGLBatchRenderer::ProfilerCategory,
+        MProfiler::kColorE_L2,
+        "USD Proxy Shape userSelect() (Viewport 2.0)");
+
     M3dView view;
     const bool hasView = px_vp20Utils::GetViewFromDrawContext(context, view);
     if (hasView &&
@@ -300,6 +323,13 @@ UsdMayaProxyDrawOverride::draw(
         const MHWRender::MDrawContext& context,
         const MUserData* data)
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        UsdMayaGLBatchRenderer::ProfilerCategory,
+        MProfiler::kColorC_L1,
+        "USD Proxy Shape draw() (Viewport 2.0)");
+
     // Note that this Draw() call is only necessary when we're drawing the
     // bounding box, since that is not yet handled by Hydra and is instead done
     // internally by the batch renderer on a per-shape basis. Otherwise, the

--- a/lib/render/pxrUsdMayaGL/proxyShapeUI.cpp
+++ b/lib/render/pxrUsdMayaGL/proxyShapeUI.cpp
@@ -23,6 +23,7 @@
 
 #include "pxr/base/gf/vec3f.h"
 #include "pxr/base/gf/vec4f.h"
+#include "pxr/base/trace/trace.h"
 #include "pxr/usd/sdf/path.h"
 #include "pxr/usd/usd/prim.h"
 #include "pxr/usd/usd/timeCode.h"
@@ -38,6 +39,7 @@
 #include <maya/MObject.h>
 #include <maya/MPoint.h>
 #include <maya/MPointArray.h>
+#include <maya/MProfiler.h>
 #include <maya/MPxSurfaceShapeUI.h>
 #include <maya/MSelectInfo.h>
 #include <maya/MSelectionList.h>
@@ -63,6 +65,13 @@ UsdMayaProxyShapeUI::getDrawRequests(
         bool /* objectAndActiveOnly */,
         MDrawRequestQueue& requests)
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        UsdMayaGLBatchRenderer::ProfilerCategory,
+        MProfiler::kColorE_L2,
+        "USD Proxy Shape getDrawRequests() (Legacy Viewport)");
+
     const MDagPath shapeDagPath = drawInfo.multiPath();
     MayaUsdProxyShapeBase* shape =
         MayaUsdProxyShapeBase::GetShapeAtDagPath(shapeDagPath);
@@ -107,6 +116,13 @@ UsdMayaProxyShapeUI::getDrawRequests(
 void
 UsdMayaProxyShapeUI::draw(const MDrawRequest& request, M3dView& view) const
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        UsdMayaGLBatchRenderer::ProfilerCategory,
+        MProfiler::kColorC_L1,
+        "USD Proxy Shape draw() (Legacy Viewport)");
+
     if (!view.pluginObjectDisplay(MayaUsdProxyShapeBase::displayFilterName)) {
         return;
     }
@@ -129,6 +145,13 @@ UsdMayaProxyShapeUI::select(
         MSelectionList& selectionList,
         MPointArray& worldSpaceSelectedPoints) const
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        UsdMayaGLBatchRenderer::ProfilerCategory,
+        MProfiler::kColorE_L2,
+        "USD Proxy Shape select() (Legacy Viewport)");
+
     M3dView view = selectInfo.view();
 
     if (!view.pluginObjectDisplay(MayaUsdProxyShapeBase::displayFilterName)) {

--- a/lib/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
+++ b/lib/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
@@ -29,6 +29,7 @@
 #include "pxr/base/tf/diagnostic.h"
 #include "pxr/base/tf/stringUtils.h"
 #include "pxr/base/tf/token.h"
+#include "pxr/base/trace/trace.h"
 #include "pxr/imaging/hd/enums.h"
 #include "pxr/imaging/hd/renderIndex.h"
 #include "pxr/imaging/hd/repr.h"
@@ -48,6 +49,7 @@
 #include <maya/MHWGeometryUtilities.h>
 #include <maya/MMatrix.h>
 #include <maya/MObjectHandle.h>
+#include <maya/MProfiler.h>
 #include <maya/MPxSurfaceShape.h>
 #include <maya/MStatus.h>
 #include <maya/MString.h>
@@ -122,6 +124,13 @@ PxrMayaHdUsdProxyShapeAdapter::_Sync(
         const unsigned int displayStyle,
         const MHWRender::DisplayStatus displayStatus)
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        UsdMayaGLBatchRenderer::ProfilerCategory,
+        MProfiler::kColorE_L2,
+        "USD Proxy Shape Syncing Shape Adapter");
+
     MayaUsdProxyShapeBase* usdProxyShape = 
             MayaUsdProxyShapeBase::GetShapeAtDagPath(shapeDagPath);
     if (!usdProxyShape) {
@@ -281,6 +290,13 @@ PxrMayaHdUsdProxyShapeAdapter::_Sync(
 bool
 PxrMayaHdUsdProxyShapeAdapter::_Init(HdRenderIndex* renderIndex)
 {
+    TRACE_FUNCTION();
+
+    MProfilingScope profilingScope(
+        UsdMayaGLBatchRenderer::ProfilerCategory,
+        MProfiler::kColorE_L2,
+        "USD Proxy Shape Initializing Shape Adapter");
+
     if (!TF_VERIFY(renderIndex,
                    "Cannot initialize shape adapter with invalid HdRenderIndex")) {
         return false;


### PR DESCRIPTION
This takes a cue from recent work in the VP2.0 render delegate and adds some performance tracking to Pixar's batch renderer Hydra integration. This is proving to be helpful as we work to deprecate our usage of the legacy viewport, and also as we look towards eventually adopting the VP2.0 render delegate.

The MProfilerScopes added are good for tracking overall time spent in the batch renderer when using Maya's Profiler. The trace performance tracking is good for looking at the time spent in batch renderer setup and overhead versus the time spent in underlying Hydra and USD libraries, since those are also instrumented using trace.

The one change here that affects users **not** using the batch renderer is the addition of a `TRACE_FUNCTION()` call in `MayaUsdProxyShapeBase::boundingBox()`. A lot of time is currently spent generating bounding boxes (serially) using the batch renderer, so that may also be a current bottleneck for the VP2.0 render delegate.