### PR TITLE
identify Qt 5.12 as the minimum required version for Qt-dependent features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ endif()
 
 if(DEFINED QT_LOCATION)
     set(CMAKE_PREFIX_PATH "${QT_LOCATION}")
-    find_package(Qt5 COMPONENTS Core Gui Widgets REQUIRED)
+    find_package(Qt5 5.12 COMPONENTS Core Gui Widgets REQUIRED)
     if(Qt5_FOUND)
         message(STATUS "Building with Qt features enabled.")
     endif()

--- a/doc/build.md
+++ b/doc/build.md
@@ -17,7 +17,13 @@ Before building the project, consult the following table to ensure you use the r
 |    Python Packages    | PyYAML, PySide, PyOpenGL, Jinja2        | PyYAML, PySide2, PyOpenGL, Jinja2              |      PyYAML, PySide, PyOpenGL, Jinja2             |
 |    Build generator    | Visual Studio, Ninja (Recommended)    |  XCode, Ninja(Recommended)                       |    Ninja(Recommended)       |
 |    Command processor  | Visual Studio X64 2015 or 2017 command prompt  |                     bash                |             bash            |
-| Supported Maya Version|      2018, 2019, 2020           |                      2018, 2019, 2020                  |        2018,2019, 2020      | 
+| Supported Maya Version|      2018, 2019, 2020           |                      2018, 2019, 2020                  |        2018, 2019, 2020     |
+
+|        Optional       | ![](images/windows.png)   |                            ![](images/mac.png)               |   ![](images/linux.png)     |
+|:---------------------:|:-------------------------:|:------------------------------------------------------------:|:---------------------------:|
+|          Qt           |           5.12.6          |                             5.12.6                           |         5.12.6              |
+
+***NOTE:*** The optional Qt features require building with Qt version 5.12.6, which is the version used by Maya 2020. They are not supported with Maya 2018 and 2019 since those versions of Maya use Qt 5.6.1.
 
 ***NOTE:*** We haven't fully tested the plug-ins on ```Catalina``` and it is still at the experimental stage.
 


### PR DESCRIPTION
The newly added import dialog functionality makes use of `QOverload` which was introduced in Qt 5.7, and `QSortFilterProxyModel::setRecursiveFilteringEnabled()` which was introduced in Qt 5.10. Some users may still be using VFX platform 2018 which specifies Qt 5.6.1 as the required version, so they may not be able to build the Qt-dependent features until they switch to VFX platform 2019+ which specifies Qt 5.12 instead.

This change adds CMake enforcement of Qt 5.10+ when building with Qt enabled, and adds a table of version numbers for the optional dependencies, of which Qt is currently the only one.