### PR TITLE
[al] import primvars as colour sets (#1029)

### DIFF
--- a/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
@@ -1694,7 +1694,7 @@ void MeshExportContext::copyColourSetData()
             }
           }
         }
-        UsdGeomPrimvar colourSet = mesh.CreatePrimvar(TfToken(colourSetNames[i].asChar()), SdfValueTypeNames->Float3Array, interpolation);
+        UsdGeomPrimvar colourSet = mesh.CreatePrimvar(TfToken(colourSetNames[i].asChar()), SdfValueTypeNames->Color3fArray, interpolation);
         colourSet.Set(colourValues, m_timeCode);
       }
       if (MFnMesh::kRGBA == representation )
@@ -1764,7 +1764,7 @@ void MeshExportContext::copyColourSetData()
           }
         }
       }
-      UsdGeomPrimvar colourSet = mesh.CreatePrimvar(TfToken(colourSetNames[i].asChar()), SdfValueTypeNames->Float4Array, interpolation);
+      UsdGeomPrimvar colourSet = mesh.CreatePrimvar(TfToken(colourSetNames[i].asChar()), SdfValueTypeNames->Color4fArray, interpolation);
       colourSet.Set(colourValues, m_timeCode);
     }
   }
@@ -1813,7 +1813,7 @@ void MeshExportContext::copyColourSetData()
           }
         }
       }
-      UsdGeomPrimvar colourSet = mesh.CreatePrimvar(TfToken(diff_report[i].setName().asChar()), SdfValueTypeNames->Float3Array, interp);
+      UsdGeomPrimvar colourSet = mesh.CreatePrimvar(TfToken(diff_report[i].setName().asChar()), SdfValueTypeNames->Color3fArray, interp);
       colourSet.Set(colourValues, m_timeCode);
     }
     else
@@ -1844,7 +1844,7 @@ void MeshExportContext::copyColourSetData()
           }
         }
       }
-      UsdGeomPrimvar colourSet = mesh.CreatePrimvar(TfToken(diff_report[i].setName().asChar()), SdfValueTypeNames->Float4Array, interp);
+      UsdGeomPrimvar colourSet = mesh.CreatePrimvar(TfToken(diff_report[i].setName().asChar()), SdfValueTypeNames->Color4fArray, interp);
       colourSet.Set(colourValues, m_timeCode);
     }
   }

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
@@ -771,6 +771,10 @@ void MeshImportContext::applyColourSetData()
     
     primvar.GetDeclarationInfo(&name, &typeName, &interpolation, &elementSize);
 
+    TfToken role = typeName.GetRole();
+    if(role != SdfValueRoleNames->Color)
+      continue;
+
     // early out for channels that are definitely not colourSets
     if (name == prefToken || name == displayOpacityToken)
       continue;


### PR DESCRIPTION
Previously the file import for AL_USDMaya would blindly create any float3/float4 primvar as a colour set. This would mean that any other vector based primvar _(e.g. tangents/binormals)_ would end up being imported as colours. 

This PR changes the exported colour set type to be Color3f/Color4f, and also checks the primvar role to see if the primvar is a Color type. If it is, it will be treated as a colour set.