### PR TITLE
Fix MacOSX build in strict mode:

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -952,9 +952,9 @@ private:
                 << m_selected << ":"
                 << int(m_refCount) << std::endl;
     }
-    uint32_t selected() const { return m_selected; }
-    uint32_t required() const { return m_required; }
-    uint32_t refCount() const { return m_refCount; }
+    uint16_t selected() const { return m_selected; }
+    uint16_t required() const { return m_required; }
+    uint16_t refCount() const { return m_refCount; }
     void prepSelect()
       { m_selectedTemp = m_selected; }
   private:
@@ -963,10 +963,10 @@ private:
     // ref counting values
     struct
     {
-      uint64_t m_required:16;
-      uint64_t m_selectedTemp:16;
-      uint64_t m_selected:16;
-      uint64_t m_refCount:16;
+      uint16_t m_required;
+      uint16_t m_selectedTemp;
+      uint16_t m_selected;
+      uint16_t m_refCount;
     };
   };
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeSelection.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeSelection.cpp
@@ -252,7 +252,7 @@ void ProxyShape::printRefCounts() const
 //----------------------------------------------------------------------------------------------------------------------
 inline bool ProxyShape::TransformReference::decRef(const TransformReason reason)
 {
-  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::decRef %" PRIu32 " %" PRIu32 " %" PRIu32 "\n", m_selected, m_refCount, m_required);
+  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::decRef %" PRIu16 " %" PRIu16 " %" PRIu16 "\n", m_selected, m_refCount, m_required);
   switch(reason)
   {
   case kSelection: assert(m_selected); --m_selected; break;
@@ -263,14 +263,14 @@ inline bool ProxyShape::TransformReference::decRef(const TransformReason reason)
     break;
   }
 
-  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::decRefEnd %" PRIu32 " %" PRIu32 " %" PRIu32 "\n", m_selected, m_refCount, m_required);
+  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::decRefEnd %" PRIu16 " %" PRIu16 " %" PRIu16 "\n", m_selected, m_refCount, m_required);
   return !m_required && !m_selected && !m_refCount;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 inline void ProxyShape::TransformReference::incRef(const TransformReason reason)
 {
-  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::incRef %" PRIu32 " %" PRIu32 " %" PRIu32 "\n", m_selected, m_refCount, m_required);
+  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::incRef %" PRIu16 " %" PRIu16 " %" PRIu16 "\n", m_selected, m_refCount, m_required);
   switch(reason)
   {
   case kSelection: ++m_selected; break;
@@ -279,13 +279,13 @@ inline void ProxyShape::TransformReference::incRef(const TransformReason reason)
   default: assert(0); break;
   }
 
-  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::incRefEnd %" PRIu32 " %" PRIu32 " %" PRIu32 "\n", m_selected, m_refCount, m_required);
+  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::incRefEnd %" PRIu16 " %" PRIu16 " %" PRIu16 "\n", m_selected, m_refCount, m_required);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 inline void ProxyShape::TransformReference::checkIncRef(const TransformReason reason)
 {
-  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::checkIncRef %" PRIu32 " %" PRIu32 " %" PRIu32 "\n", m_selected, m_refCount, m_required);
+  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::checkIncRef %" PRIu16 " %" PRIu16 " %" PRIu16 "\n", m_selected, m_refCount, m_required);
   switch(reason)
   {
   case kSelection: ++m_selectedTemp; break;
@@ -296,7 +296,7 @@ inline void ProxyShape::TransformReference::checkIncRef(const TransformReason re
 //----------------------------------------------------------------------------------------------------------------------
 inline bool ProxyShape::TransformReference::checkRef(const TransformReason reason)
 {
-  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::checkRef %" PRIu32 " : %" PRIu32 " %" PRIu32 " %" PRIu32 "\n", m_selectedTemp, m_selected, m_refCount, m_required);
+  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::checkRef %" PRIu16 " : %" PRIu16 " %" PRIu16 " %" PRIu16 "\n", m_selectedTemp, m_selected, m_refCount, m_required);
   uint32_t sl = m_selected;
   uint32_t rc = m_refCount;
   uint32_t rq = m_required;

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeSelection.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeSelection.cpp
@@ -252,7 +252,7 @@ void ProxyShape::printRefCounts() const
 //----------------------------------------------------------------------------------------------------------------------
 inline bool ProxyShape::TransformReference::decRef(const TransformReason reason)
 {
-  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::decRef %" PRIu64 " %" PRIu64 " %" PRIu64 "\n", m_selected, m_refCount, m_required);
+  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::decRef %" PRIu32 " %" PRIu32 " %" PRIu32 "\n", m_selected, m_refCount, m_required);
   switch(reason)
   {
   case kSelection: assert(m_selected); --m_selected; break;
@@ -263,14 +263,14 @@ inline bool ProxyShape::TransformReference::decRef(const TransformReason reason)
     break;
   }
 
-  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::decRefEnd %" PRIu64 " %" PRIu64 " %" PRIu64 "\n", m_selected, m_refCount, m_required);
+  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::decRefEnd %" PRIu32 " %" PRIu32 " %" PRIu32 "\n", m_selected, m_refCount, m_required);
   return !m_required && !m_selected && !m_refCount;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 inline void ProxyShape::TransformReference::incRef(const TransformReason reason)
 {
-  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::incRef %" PRIu64 " %" PRIu64 " %" PRIu64 "\n", m_selected, m_refCount, m_required);
+  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::incRef %" PRIu32 " %" PRIu32 " %" PRIu32 "\n", m_selected, m_refCount, m_required);
   switch(reason)
   {
   case kSelection: ++m_selected; break;
@@ -279,13 +279,13 @@ inline void ProxyShape::TransformReference::incRef(const TransformReason reason)
   default: assert(0); break;
   }
 
-  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::incRefEnd %" PRIu64 " %" PRIu64 " %" PRIu64 "\n", m_selected, m_refCount, m_required);
+  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::incRefEnd %" PRIu32 " %" PRIu32 " %" PRIu32 "\n", m_selected, m_refCount, m_required);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 inline void ProxyShape::TransformReference::checkIncRef(const TransformReason reason)
 {
-  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::checkIncRef %" PRIu64 " %" PRIu64 " %" PRIu64 "\n", m_selected, m_refCount, m_required);
+  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::checkIncRef %" PRIu32 " %" PRIu32 " %" PRIu32 "\n", m_selected, m_refCount, m_required);
   switch(reason)
   {
   case kSelection: ++m_selectedTemp; break;
@@ -296,7 +296,7 @@ inline void ProxyShape::TransformReference::checkIncRef(const TransformReason re
 //----------------------------------------------------------------------------------------------------------------------
 inline bool ProxyShape::TransformReference::checkRef(const TransformReason reason)
 {
-  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::checkRef %" PRIu64 " : %" PRIu64 " %" PRIu64 " %" PRIu64 "\n", m_selectedTemp, m_selected, m_refCount, m_required);
+  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::checkRef %" PRIu32 " : %" PRIu32 " %" PRIu32 " %" PRIu32 "\n", m_selectedTemp, m_selected, m_refCount, m_required);
   uint32_t sl = m_selected;
   uint32_t rc = m_refCount;
   uint32_t rq = m_required;


### PR DESCRIPTION
**Compiler:** 

`XCode 11.3.1`

**Error:** 
```
format specifies type 'unsigned long long' but the argument has type 'int' [-Werror,-Wformat]
TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyShapeSelection::TransformReference::decRef %" PRIu64 " %" PRIu64 " %" PRIu64 "\n", m_selected, m_refCount, m_required);
.....
```
Hi @murphyeoin, 
I am trying to understand some of the logics in ProxyShape.h related to this issue:
So we have a bit field struct that is a size of 8bytes (16 bits * 4) 
```
    // ref counting values
    struct
    {
      uint64_t m_required:16; 
      uint64_t m_selectedTemp:16;
      uint64_t m_selected:16;
      uint64_t m_refCount:16;
    };
```
but then we have these getters that return them as 4 bytes.  Is there a reason for that? couldn't we return them as uint16_t.
```
   uint32_t selected() const { return m_selected; }
   uint32_t required() const { return m_required; }
   uint32_t refCount() const { return m_refCount; }
```






