### PR TITLE
Use CMake install() instead of touch to install mayaUsd/__init__.py

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -768,9 +768,7 @@ if(IS_WINDOWS)
     install(FILES $<TARGET_PDB_FILE:${PYTHON_LIBRARY_NAME}> DESTINATION ${PYLIB_INSTALL_PREFIX} OPTIONAL)
 endif()
 
-install(CODE
-    "file(TOUCH \"${PYLIB_INSTALL_PREFIX}/../__init__.py\")")
-
+install(FILES ae/__init__.py DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python/${PROJECT_NAME})
 install(FILES python/__init__.py DESTINATION ${PYLIB_INSTALL_PREFIX})
 
 add_subdirectory(usd)


### PR DESCRIPTION
touch fails when using DESTDIR install (non-existent target directory)

During our build process we do an internal staging install using `make DESTDIR=/path/to/staging install'. 

Unfortunately, the hard-coded touch command does not result in generated build files which can be redirected at 'make install' time. Using the CMake install() command creates all the proper boilerplate.

There were several other installations of empty `__init__.py` files in the same CMakeLists.txt file already using install().