### PR TITLE
Switching to release-1.10.0 tag. We were grabbing google-test from ma…

### DIFF
--- a/cmake/CMakeLists_googletest_download.txt.in
+++ b/cmake/CMakeLists_googletest_download.txt.in
@@ -17,7 +17,7 @@ endif()
 
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           release-1.10.0
   SOURCE_DIR        "${GOOGLETEST_BUILD_ROOT}/googletest-src"
   BINARY_DIR        "${GOOGLETEST_BUILD_ROOT}/googletest-build"
   CMAKE_ARGS


### PR DESCRIPTION
…ster but following changes broke the build:

Remove CMAKE_CXX_STANDARD from GoogleTest's CMakeLists.txt

https://github.com/google/googletest/commit/23b2a3b1cf803999fb38175f6e9e038a4495c8a5#diff-af3b638bc2a3e6c650974192a53c7291