### PR TITLE
fix for Pixar testProxyShapeLiveSurface test

### DIFF
--- a/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testProxyShapeLiveSurface.py
+++ b/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testProxyShapeLiveSurface.py
@@ -80,6 +80,13 @@ class testProxyShapeLiveSurface(unittest.TestCase):
                 edit=True, displayAppearance='smoothShaded', rnm='vp2Renderer')
         cmds.showWindow(window)
 
+        # Force all views to re-draw. This causes us to block until the
+        # geometry we're making live has actually been evaluated and is present
+        # in the viewport. Otherwise execution of the test may continue and the
+        # create tool may be invoked before there's any geometry there, in
+        # which case the tool won't create anything.
+        cmds.refresh()
+
         # Get the viewport widget.
         view = OMUI.M3dView()
         OMUI.M3dView.getM3dViewFromModelPanel(panel, view)
@@ -125,6 +132,13 @@ class testProxyShapeLiveSurface(unittest.TestCase):
         cmds.modelEditor(cmds.modelPanel(panel, q=True, modelEditor=True),
                 edit=True, displayAppearance='smoothShaded', rnm='vp2Renderer')
         cmds.showWindow(window)
+
+        # Force all views to re-draw. This causes us to block until the
+        # geometry we're making live has actually been evaluated and is present
+        # in the viewport. Otherwise execution of the test may continue and the
+        # create tool may be invoked before there's any geometry there, in
+        # which case the tool won't create anything.
+        cmds.refresh()
 
         # Get the viewport widget.
         view = OMUI.M3dView()


### PR DESCRIPTION
I don't think anyone other than us is running this test, but this addresses an issue where we were seeing intermittent test failures. Execution of the test would sometimes barrel on through the assembly load and attempt to create new geometry using the proxy as a live surface before the geometry for the proxy was ready.

This adds a cmds.refresh() call immediately after creating the test window/viewport to ensure that the geometry that we're making live is present and will work as a live surface.

Note that this does **not** address #263. When the VP2.0 render delegate is enabled, the live surface functionality seems to be broken and this test fails.