### PR TITLE
Added UFE_PREVIEW_VERSION_NUM pre-processor support.

### DIFF
--- a/cmake/defaults/CXXDefaults.cmake
+++ b/cmake/defaults/CXXDefaults.cmake
@@ -50,6 +50,10 @@ if (DEFINED USD_VERSION_NUM)
     _add_define("USD_VERSION_NUM=${USD_VERSION_NUM}")
 endif()
 
+if (DEFINED UFE_PREVIEW_VERSION_NUM)
+    _add_define("UFE_PREVIEW_VERSION_NUM=${UFE_PREVIEW_VERSION_NUM}")
+endif()
+
 set(_PXR_CXX_FLAGS ${_PXR_CXX_FLAGS} ${_PXR_CXX_WARNING_FLAGS})
 
 # CMake list to string.

--- a/cmake/modules/FindUFE.cmake
+++ b/cmake/modules/FindUFE.cmake
@@ -44,6 +44,10 @@ if(UFE_INCLUDE_DIR AND EXISTS "${UFE_INCLUDE_DIR}/ufe/ufe.h")
     endforeach()
     set(UFE_VERSION ${UFE_MAJOR_VERSION}.${UFE_MINOR_VERSION}.${UFE_PATCH_LEVEL})
 
+    if("${UFE_MAJOR_VERSION}" STREQUAL "0")
+        math(EXPR UFE_PREVIEW_VERSION_NUM "${UFE_MINOR_VERSION} * 1000 + ${UFE_PATCH_LEVEL}")
+    endif()
+
     file(STRINGS
         "${UFE_INCLUDE_DIR}/ufe/ufe.h"
         _ufe_features


### PR DESCRIPTION
This support will allow mayaUsd code to conditionally compile in UFE-dependent code according to the preview version of the UFE library.  UFE preview versions are identified with major version 0.  We intend that conditional compilation directives based on UFE_PREVIEW_VERSION_NUM be removed for the next Maya release, as they will have become obsolete, and since UFE_PREVIEW_VERSION_NUM would be no longer defined, would actually prevent code from being compiled.