### PR TITLE
- Enable C++11 for GoogleTest external project for sake of consistency with the project.

### DIFF
--- a/cmake/CMakeLists_googletest_download.txt.in
+++ b/cmake/CMakeLists_googletest_download.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.12.0)
 
 project(googletest-download NONE)
 
@@ -9,6 +9,10 @@ project(googletest-download NONE)
 # need to force the use of the shared C run-time.
 
 include(ExternalProject)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(FORCE_SHARED_CRT "")
 if(MSVC)
@@ -26,7 +30,9 @@ ExternalProject_Add(googletest
                     "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
                     "-Dgtest_force_shared_crt=ON"
                     "-DBUILD_SHARED_LIBS=ON"
-                    "-DCMAKE_MACOSX_RPATH=ON"
                     "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
                     "${FORCE_SHARED_CRT}"
+                    "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
+                    "-DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}"
+                    "-DCMAKE_CXX_STANDARD_REQUIRED=${CMAKE_CXX_STANDARD_REQUIRED}"
 )

--- a/cmake/CMakeLists_googletest_download.txt.in
+++ b/cmake/CMakeLists_googletest_download.txt.in
@@ -30,6 +30,7 @@ ExternalProject_Add(googletest
                     "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
                     "-Dgtest_force_shared_crt=ON"
                     "-DBUILD_SHARED_LIBS=ON"
+                    "-DCMAKE_MACOSX_RPATH=ON"
                     "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
                     "${FORCE_SHARED_CRT}"
                     "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"

--- a/cmake/CMakeLists_googletest_src.txt.in
+++ b/cmake/CMakeLists_googletest_src.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.12.0)
 
 project(googletest-download NONE)
 
@@ -7,6 +7,10 @@ project(googletest-download NONE)
 # Need to force the use of the shared C run-time.
 
 include(ExternalProject)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(FORCE_SHARED_CRT "")
 if(MSVC)
@@ -24,7 +28,9 @@ ExternalProject_Add(googletest
                     "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
                     "-Dgtest_force_shared_crt=ON"
                     "-DBUILD_SHARED_LIBS=ON"
-                    "-DCMAKE_MACOSX_RPATH=ON"
                     "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
                     "${FORCE_SHARED_CRT}"
+                    "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
+                    "-DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}"
+                    "-DCMAKE_CXX_STANDARD_REQUIRED=${CMAKE_CXX_STANDARD_REQUIRED}"
 )

--- a/cmake/CMakeLists_googletest_src.txt.in
+++ b/cmake/CMakeLists_googletest_src.txt.in
@@ -28,6 +28,7 @@ ExternalProject_Add(googletest
                     "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
                     "-Dgtest_force_shared_crt=ON"
                     "-DBUILD_SHARED_LIBS=ON"
+                    "-DCMAKE_MACOSX_RPATH=ON"
                     "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
                     "${FORCE_SHARED_CRT}"
                     "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"


### PR DESCRIPTION
 I also bumped the CMake Min version to 3.12.0 and removed CMAKE_MACOSX_RPATH flag as is no longer needed.