### PR TITLE
save and restore uniform buffer bindings during batch renderer selection

### DIFF
--- a/lib/render/mayaToHydra/renderOverride.cpp
+++ b/lib/render/mayaToHydra/renderOverride.cpp
@@ -379,7 +379,7 @@ MStatus MtohRenderOverride::Render(const MHWRender::MDrawContext& drawContext) {
         _InitHydraResources();
     }
 
-    UBOBindingsSaver bindingsSaver;
+    GLUniformBufferBindingsSaver bindingsSaver;
 
     _SelectionChanged();
 

--- a/lib/render/mayaToHydra/renderOverride.cpp
+++ b/lib/render/mayaToHydra/renderOverride.cpp
@@ -47,6 +47,7 @@ PXR_NAMESPACE_CLOSE_SCOPE
 #include <chrono>
 #include <exception>
 
+#include "mayaUsd/render/px_vp20/utils.h"
 #include "../../usd/hdMaya/delegates/delegateRegistry.h"
 #include "../../usd/hdMaya/delegates/sceneDelegate.h"
 
@@ -106,48 +107,6 @@ private:
 };
 
 #endif // WANT_UFE_BUILD
-
-/// Simple RAII class to save uniform buffer bindings, to deal with a maya
-/// issue.
-///
-/// As originally explained by Pixar in their usdmaya plugin:
-///
-/// XXX: When Maya is using OpenGL Core Profile as the rendering engine (in
-/// either compatibility or strict mode), batch renders like those done in
-/// the "Render View" window or through the ogsRender command do not
-/// properly track uniform buffer binding state. This was causing issues
-/// where the first batch render performed would look correct, but then all
-/// subsequent renders done in that Maya session would be completely black
-/// (no alpha), even if the frame contained only Maya-native geometry or if
-/// a new scene was created/opened.
-///
-/// To avoid this problem, we need to save and restore Maya's bindings
-/// across Hydra calls. We try not to bog down performance by saving and
-/// restoring *all* GL_MAX_UNIFORM_BUFFER_BINDINGS possible bindings, so
-/// instead we only do just enough to avoid issues. Empirically, the
-/// problematic binding has been the material binding at index 4.
-class UBOBindingsSaver {
-public:
-    static constexpr size_t UNIFORM_BINDINGS_TO_SAVE = 5u;
-
-    UBOBindingsSaver() {
-        for (size_t i = 0u; i < _uniformBufferBindings.size(); ++i) {
-            glGetIntegeri_v(
-                GL_UNIFORM_BUFFER_BINDING, (GLuint)i,
-                &_uniformBufferBindings[i]);
-        }
-    }
-
-    ~UBOBindingsSaver() {
-        for (size_t i = 0u; i < _uniformBufferBindings.size(); ++i) {
-            glBindBufferBase(
-                GL_UNIFORM_BUFFER, (GLuint)i, _uniformBufferBindings[i]);
-        }
-    }
-
-private:
-    std::array<GLint, UNIFORM_BINDINGS_TO_SAVE> _uniformBufferBindings;
-};
 
 } // namespace
 

--- a/lib/render/px_vp20/utils.cpp
+++ b/lib/render/px_vp20/utils.cpp
@@ -27,6 +27,7 @@
 #include "pxr/base/gf/vec3f.h"
 #include "pxr/base/gf/vec4f.h"
 #include "pxr/base/tf/stringUtils.h"
+#include "pxr/imaging/garch/gl.h"
 #include "pxr/imaging/glf/simpleLight.h"
 #include "pxr/imaging/glf/simpleLightingContext.h"
 #include "pxr/imaging/glf/simpleMaterial.h"
@@ -1077,6 +1078,27 @@ px_vp20Utils::OutputDisplayStatusToStream(
         case MHWRender::kNoStatus:
             stream << "kNoStatus";
             break;
+    }
+}
+
+
+UBOBindingsSaver::UBOBindingsSaver()
+{
+    for (size_t i = 0u; i < _uniformBufferBindings.size(); ++i) {
+        glGetIntegeri_v(
+            GL_UNIFORM_BUFFER_BINDING,
+            static_cast<GLuint>(i),
+            &_uniformBufferBindings[i]);
+    }
+}
+
+UBOBindingsSaver::~UBOBindingsSaver()
+{
+    for (size_t i = 0u; i < _uniformBufferBindings.size(); ++i) {
+        glBindBufferBase(
+            GL_UNIFORM_BUFFER,
+            static_cast<GLuint>(i),
+            _uniformBufferBindings[i]);
     }
 }
 

--- a/lib/render/px_vp20/utils.cpp
+++ b/lib/render/px_vp20/utils.cpp
@@ -1082,7 +1082,7 @@ px_vp20Utils::OutputDisplayStatusToStream(
 }
 
 
-UBOBindingsSaver::UBOBindingsSaver()
+GLUniformBufferBindingsSaver::GLUniformBufferBindingsSaver()
 {
     for (size_t i = 0u; i < _uniformBufferBindings.size(); ++i) {
         glGetIntegeri_v(
@@ -1092,7 +1092,7 @@ UBOBindingsSaver::UBOBindingsSaver()
     }
 }
 
-UBOBindingsSaver::~UBOBindingsSaver()
+GLUniformBufferBindingsSaver::~GLUniformBufferBindingsSaver()
 {
     for (size_t i = 0u; i < _uniformBufferBindings.size(); ++i) {
         glBindBufferBase(

--- a/lib/render/px_vp20/utils.h
+++ b/lib/render/px_vp20/utils.h
@@ -24,6 +24,7 @@
 #include "pxr/base/gf/matrix4d.h"
 #include "pxr/base/gf/matrix4f.h"
 #include "pxr/base/gf/vec4f.h"
+#include "pxr/imaging/garch/gl.h"
 #include "pxr/imaging/glf/simpleLightingContext.h"
 
 #include <maya/M3dView.h>
@@ -33,6 +34,7 @@
 #include <maya/MMatrix.h>
 #include <maya/MSelectionContext.h>
 
+#include <array>
 #include <ostream>
 
 
@@ -112,6 +114,40 @@ class px_vp20Utils
     private:
         px_vp20Utils() = delete;
         ~px_vp20Utils() = delete;
+};
+
+
+/// Simple RAII class to save uniform buffer bindings, to deal with a Maya
+/// issue.
+///
+/// XXX: When Maya is using OpenGL Core Profile as the rendering engine (in
+/// either compatibility or strict mode), batch renders like those done in the
+/// "Render View" window or through the ogsRender command do not properly track
+/// uniform buffer binding state. This was causing issues where the first batch
+/// render performed would look correct, but then all subsequent renders done
+/// in that Maya session would be completely black (no alpha), even if the
+/// frame contained only Maya-native geometry or if a new scene was
+/// created/opened.
+///
+/// To avoid this problem, this object can be used to save and restore Maya's
+/// uniform buffer bindings across Hydra/OpenGL calls. We try not to bog down
+/// performance by saving and restoring *all* GL_MAX_UNIFORM_BUFFER_BINDINGS
+/// possible bindings, so instead we only do just enough to avoid issues.
+/// Empirically, the problematic binding has been the material binding at
+/// index 4.
+class UBOBindingsSaver
+{
+    public:
+        static constexpr size_t UNIFORM_BINDINGS_TO_SAVE = 5u;
+
+        MAYAUSD_CORE_PUBLIC
+        UBOBindingsSaver();
+
+        MAYAUSD_CORE_PUBLIC
+        ~UBOBindingsSaver();
+
+    private:
+        std::array<GLint, UNIFORM_BINDINGS_TO_SAVE> _uniformBufferBindings;
 };
 
 

--- a/lib/render/px_vp20/utils.h
+++ b/lib/render/px_vp20/utils.h
@@ -135,16 +135,16 @@ class px_vp20Utils
 /// possible bindings, so instead we only do just enough to avoid issues.
 /// Empirically, the problematic binding has been the material binding at
 /// index 4.
-class UBOBindingsSaver
+class GLUniformBufferBindingsSaver
 {
     public:
         static constexpr size_t UNIFORM_BINDINGS_TO_SAVE = 5u;
 
         MAYAUSD_CORE_PUBLIC
-        UBOBindingsSaver();
+        GLUniformBufferBindingsSaver();
 
         MAYAUSD_CORE_PUBLIC
-        ~UBOBindingsSaver();
+        ~GLUniformBufferBindingsSaver();
 
     private:
         std::array<GLint, UNIFORM_BINDINGS_TO_SAVE> _uniformBufferBindings;

--- a/lib/render/px_vp20/utils.h
+++ b/lib/render/px_vp20/utils.h
@@ -138,8 +138,6 @@ class px_vp20Utils
 class GLUniformBufferBindingsSaver
 {
     public:
-        static constexpr size_t UNIFORM_BINDINGS_TO_SAVE = 5u;
-
         MAYAUSD_CORE_PUBLIC
         GLUniformBufferBindingsSaver();
 
@@ -147,6 +145,8 @@ class GLUniformBufferBindingsSaver
         ~GLUniformBufferBindingsSaver();
 
     private:
+        static constexpr size_t UNIFORM_BINDINGS_TO_SAVE = 5u;
+
         std::array<GLint, UNIFORM_BINDINGS_TO_SAVE> _uniformBufferBindings;
 };
 

--- a/lib/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -993,6 +993,8 @@ UsdMayaGLBatchRenderer::TestIntersectionCustomPrimFilter(
     // Differs from viewport implementations in that it doesn't rely on
     // _ComputeSelection being called first.
 
+    UBOBindingsSaver bindingsSaver;
+
     return _TestIntersection(primFilter.collection,
                              primFilter.renderTags,
                              viewMatrix, projectionMatrix,
@@ -1195,6 +1197,8 @@ UsdMayaGLBatchRenderer::_ComputeSelection(
         primFilters.size());
 
     _selectResults.clear();
+
+    UBOBindingsSaver bindingsSaver;
 
     for (const PxrMayaHdPrimFilter& primFilter : primFilters) {
         TF_DEBUG(PXRUSDMAYAGL_BATCHED_SELECTION).Msg(

--- a/lib/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -22,8 +22,8 @@
 #include "./debugCodes.h"
 #include "./userData.h"
 
-#include "../px_vp20/utils.h"
-#include "../px_vp20/utils_legacy.h"
+#include "mayaUsd/render/px_vp20/utils.h"
+#include "mayaUsd/render/px_vp20/utils_legacy.h"
 
 #include "pxr/base/gf/matrix4d.h"
 #include "pxr/base/gf/vec2i.h"
@@ -1294,27 +1294,7 @@ UsdMayaGLBatchRenderer::_Render(
                  GL_DEPTH_BUFFER_BIT |
                  GL_VIEWPORT_BIT);
 
-    // XXX: When Maya is using OpenGL Core Profile as the rendering engine (in
-    // either compatibility or strict mode), batch renders like those done in
-    // the "Render View" window or through the ogsRender command do not
-    // properly track uniform buffer binding state. This was causing issues
-    // where the first batch render performed would look correct, but then all
-    // subsequent renders done in that Maya session would be completely black
-    // (no alpha), even if the frame contained only Maya-native geometry or if
-    // a new scene was created/opened.
-    //
-    // To avoid this problem, we need to save and restore Maya's bindings
-    // across Hydra calls. We try not to bog down performance by saving and
-    // restoring *all* GL_MAX_UNIFORM_BUFFER_BINDINGS possible bindings, so
-    // instead we only do just enough to avoid issues. Empirically, the
-    // problematic binding has been the material binding at index 4.
-    static constexpr size_t _UNIFORM_BINDINGS_TO_SAVE = 5u;
-    std::vector<GLint> uniformBufferBindings(_UNIFORM_BINDINGS_TO_SAVE, 0);
-    for (size_t i = 0u; i < uniformBufferBindings.size(); ++i) {
-        glGetIntegeri_v(GL_UNIFORM_BUFFER_BINDING,
-                        (GLuint)i,
-                        &uniformBufferBindings[i]);
-    }
+    UBOBindingsSaver bindingsSaver;
 
     // hydra orients all geometry during topological processing so that
     // front faces have ccw winding. We disable culling because culling
@@ -1373,13 +1353,6 @@ UsdMayaGLBatchRenderer::_Render(
     }
 
     glDisable(GL_FRAMEBUFFER_SRGB_EXT);
-
-    // XXX: Restore Maya's uniform buffer binding state. See above for details.
-    for (size_t i = 0u; i < uniformBufferBindings.size(); ++i) {
-        glBindBufferBase(GL_UNIFORM_BUFFER,
-                         (GLuint)i,
-                         uniformBufferBindings[i]);
-    }
 
     glPopAttrib(); // GL_LIGHTING_BIT | GL_ENABLE_BIT | GL_POLYGON_BIT |
                    // GL_DEPTH_BUFFER_BIT | GL_VIEWPORT_BIT

--- a/lib/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -993,7 +993,7 @@ UsdMayaGLBatchRenderer::TestIntersectionCustomPrimFilter(
     // Differs from viewport implementations in that it doesn't rely on
     // _ComputeSelection being called first.
 
-    UBOBindingsSaver bindingsSaver;
+    GLUniformBufferBindingsSaver bindingsSaver;
 
     return _TestIntersection(primFilter.collection,
                              primFilter.renderTags,
@@ -1198,7 +1198,7 @@ UsdMayaGLBatchRenderer::_ComputeSelection(
 
     _selectResults.clear();
 
-    UBOBindingsSaver bindingsSaver;
+    GLUniformBufferBindingsSaver bindingsSaver;
 
     for (const PxrMayaHdPrimFilter& primFilter : primFilters) {
         TF_DEBUG(PXRUSDMAYAGL_BATCHED_SELECTION).Msg(
@@ -1298,7 +1298,7 @@ UsdMayaGLBatchRenderer::_Render(
                  GL_DEPTH_BUFFER_BIT |
                  GL_VIEWPORT_BIT);
 
-    UBOBindingsSaver bindingsSaver;
+    GLUniformBufferBindingsSaver bindingsSaver;
 
     // hydra orients all geometry during topological processing so that
     // front faces have ccw winding. We disable culling because culling


### PR DESCRIPTION
This addresses an issue when running the [testProxyShapeSelectionPerformance](https://github.com/Autodesk/maya-usd/blob/dev/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testProxyShapeSelectionPerformance.py) test where only the first image would be drawn correctly and all images drawn after the first selection operation would be completely black.

This workaround was already being used during rendering, but this change applies it during selection as well.