### PR TITLE
Fix up mtoh initialization to not create entries for invalid delagates.

### DIFF
--- a/lib/render/mayaToHydra/plugin.cpp
+++ b/lib/render/mayaToHydra/plugin.cpp
@@ -60,6 +60,7 @@ PLUGIN_EXPORT MStatus initializePlugin(MObject obj) {
         for (const auto& desc : MtohGetRendererDescriptions()) {
             std::unique_ptr<MtohRenderOverride> mtohRenderer(new MtohRenderOverride(desc));
             renderer->registerOverride(mtohRenderer.get());
+            // registerOverride took the pointer, so release ownership
             mtohRenderer.release();
         }
     }

--- a/lib/render/mayaToHydra/plugin.cpp
+++ b/lib/render/mayaToHydra/plugin.cpp
@@ -56,17 +56,13 @@ PLUGIN_EXPORT MStatus initializePlugin(MObject obj) {
         return ret;
     }
 
-    auto plugins = MtohInitializeRenderPlugins();
     if (auto* renderer = MHWRender::MRenderer::theRenderer()) {
-        for (const auto& desc : plugins.first) {
+        for (const auto& desc : MtohGetRendererDescriptions()) {
             std::unique_ptr<MtohRenderOverride> mtohRenderer(new MtohRenderOverride(desc));
             renderer->registerOverride(mtohRenderer.get());
             mtohRenderer.release();
         }
     }
-
-    // We're done with plugins, move it into render-globals
-    MtohInitializeRenderGlobals(std::move(plugins));
 
     return ret;
 }

--- a/lib/render/mayaToHydra/plugin.cpp
+++ b/lib/render/mayaToHydra/plugin.cpp
@@ -48,14 +48,6 @@ PLUGIN_EXPORT MStatus initializePlugin(MObject obj) {
 
     MFnPlugin plugin(obj, "Luma Pictures", "2018", "Any");
 
-    auto* renderer = MHWRender::MRenderer::theRenderer();
-    if (renderer) {
-        for (const auto& desc : MtohGetRendererDescriptions()) {
-            auto* override = new MtohRenderOverride(desc);
-            renderer->registerOverride(override);
-        }
-    }
-
     if (!plugin.registerCommand(
             MtohViewCmd::name, MtohViewCmd::creator,
             MtohViewCmd::createSyntax)) {
@@ -64,7 +56,17 @@ PLUGIN_EXPORT MStatus initializePlugin(MObject obj) {
         return ret;
     }
 
-    MtohInitializeRenderGlobals();
+    auto plugins = MtohInitializeRenderPlugins();
+    if (auto* renderer = MHWRender::MRenderer::theRenderer()) {
+        for (const auto& desc : plugins.first) {
+            std::unique_ptr<MtohRenderOverride> mtohRenderer(new MtohRenderOverride(desc));
+            renderer->registerOverride(mtohRenderer.get());
+            mtohRenderer.release();
+        }
+    }
+
+    // We're done with plugins, move it into render-globals
+    MtohInitializeRenderGlobals(std::move(plugins));
 
     return ret;
 }

--- a/lib/render/mayaToHydra/renderGlobals.cpp
+++ b/lib/render/mayaToHydra/renderGlobals.cpp
@@ -24,7 +24,6 @@
 #include <maya/MFnNumericAttribute.h>
 #include <maya/MFnStringData.h>
 #include <maya/MFnTypedAttribute.h>
-#include <maya/MGlobal.h>
 #include <maya/MPlug.h>
 #include <maya/MSelectionList.h>
 #include <maya/MStatus.h>
@@ -41,7 +40,6 @@ TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
     (defaultRenderGlobals)
     (mtohTextureMemoryPerTexture)
-    (mtohMaximumShadowMapResolution)
     (mtohColorSelectionHighlight)
     (mtohColorSelectionHighlightColor)
     (mtohColorSelectionHighlightColorA)
@@ -52,9 +50,6 @@ TF_DEFINE_PRIVATE_TOKENS(
 // clang-format on
 
 namespace {
-
-std::unordered_map<TfToken, HdRenderSettingDescriptorList, TfToken::HashFunctor>
-    _rendererAttributes;
 
 void _CreateEnumAttribute(
     MFnDependencyNode& node, const TfToken& attrName,
@@ -239,96 +234,10 @@ void _GetColorAttribute(
     out[3] = plugA.asFloat();
 }
 
-bool _IsSupportedAttribute(const VtValue& v) {
-    return v.IsHolding<bool>() || v.IsHolding<int>() || v.IsHolding<float>() ||
-           v.IsHolding<GfVec4f>() || v.IsHolding<std::string>();
-}
 
-constexpr auto _renderOverrideOptionBoxTemplate = R"mel(
-global proc {{override}}OptionBox() {
-    string $windowName = "{{override}}OptionsWindow";
-    if (`window -exists $windowName`) {
-        showWindow $windowName;
-        return;
-    }
-    string $cc = "mtoh -updateRenderGlobals; refresh -f";
-
-    mtoh -createRenderGlobals;
-
-    window -title "Maya to Hydra Settings" "{{override}}OptionsWindow";
-    scrollLayout;
-    frameLayout -label "Hydra Settings";
-    columnLayout;
-    attrControlGrp -label "Enable Motion Samples" -attribute "defaultRenderGlobals.mtohEnableMotionSamples" -changeCommand $cc;
-    attrControlGrp -label "Texture Memory Per Texture (KB)" -attribute "defaultRenderGlobals.mtohTextureMemoryPerTexture" -changeCommand $cc;
-    attrControlGrp -label "OpenGL Selection Overlay" -attribute "defaultRenderGlobals.mtohSelectionOverlay" -changeCommand $cc;
-    attrControlGrp -label "Show Wireframe on Selected Objects" -attribute "defaultRenderGlobals.mtohWireframeSelectionHighlight" -changeCommand $cc;
-    attrControlGrp -label "Highlight Selected Objects" -attribute "defaultRenderGlobals.mtohColorSelectionHighlight" -changeCommand $cc;
-    attrControlGrp -label "Highlight Color for Selected Objects" -attribute "defaultRenderGlobals.mtohColorSelectionHighlightColor" -changeCommand $cc;
-    setParent ..;
-    setParent ..;
-    {{override}}Options();
-    setParent ..;
-
-    showWindow $windowName;
-}
-)mel";
 } // namespace
 
 MtohRenderGlobals::MtohRenderGlobals() {}
-
-void MtohInitializeRenderGlobals(MtohRendererInitialization validRenderers) {
-    assert(validRenderers.first.size() == validRenderers.second.size() &&  "Unbalanced arguments");
-    for (size_t i = 0, n = validRenderers.first.size(); i < n; ++i) {
-        const auto& rendererDesc = validRenderers.first[i];
-        const auto optionBoxCommand = TfStringReplace(
-            _renderOverrideOptionBoxTemplate, "{{override}}",
-            rendererDesc.overrideName.GetText());
-
-        auto status = MGlobal::executeCommand(optionBoxCommand.c_str());
-        if (!status) {
-            TF_WARN(
-                "Error in render override option box command function: \n%s",
-                status.errorString().asChar());
-        }
-
-        auto& rendererSettingDescriptors = _rendererAttributes[rendererDesc.rendererName];
-        rendererSettingDescriptors = std::move(validRenderers.second[i]);
-
-        std::stringstream ss;
-        ss << "global proc " << rendererDesc.overrideName << "Options() {\n";
-        ss << "\tstring $cc = \"mtoh -updateRenderGlobals; refresh -f\";\n";
-        ss << "\tframeLayout -label \"" << rendererDesc.displayName
-           << "Options\" -collapsable true;\n";
-        ss << "\tcolumnLayout;\n";
-        for (const auto& desc : rendererSettingDescriptors) {
-            if (!_IsSupportedAttribute(desc.defaultValue)) { continue; }
-            const auto attrName = TfStringPrintf(
-                "%s%s", rendererDesc.rendererName.GetText(),
-                desc.key.GetText());
-            ss << "\tattrControlGrp -label \"" << desc.name
-               << "\" -attribute \"defaultRenderGlobals." << attrName
-               << "\" -changeCommand $cc;\n";
-        }
-        if (rendererDesc.rendererName == MtohTokens->HdStormRendererPlugin) {
-            ss << "\tattrControlGrp -label \"Maximum shadow map size"
-               << "\" -attribute \"defaultRenderGlobals."
-               << _tokens->mtohMaximumShadowMapResolution.GetString()
-               << "\" -changeCommand $cc;\n";
-        }
-        ss << "\tsetParent ..;\n";
-        ss << "\tsetParent ..;\n";
-        ss << "}\n";
-
-        const auto optionsCommand = ss.str();
-        status = MGlobal::executeCommand(optionsCommand.c_str());
-        if (!status) {
-            TF_WARN(
-                "Error in render delegate options function: \n%s",
-                status.errorString().asChar());
-        }
-    }
-}
 
 MObject MtohCreateRenderGlobals() {
     MSelectionList slist;
@@ -359,12 +268,12 @@ MObject MtohCreateRenderGlobals() {
             return o;
         });
     _CreateNumericAttribute(
-        node, _tokens->mtohMaximumShadowMapResolution, MFnNumericData::kInt,
+        node, MtohTokens->mtohMaximumShadowMapResolution, MFnNumericData::kInt,
         []() -> MObject {
             MFnNumericAttribute nAttr;
             const auto o = nAttr.create(
-                _tokens->mtohMaximumShadowMapResolution.GetText(),
-                _tokens->mtohMaximumShadowMapResolution.GetText(),
+                MtohTokens->mtohMaximumShadowMapResolution.GetText(),
+                MtohTokens->mtohMaximumShadowMapResolution.GetText(),
                 MFnNumericData::kInt);
             nAttr.setMin(32);
             nAttr.setMax(8192);
@@ -389,7 +298,7 @@ MObject MtohCreateRenderGlobals() {
         defGlobals.colorSelectionHighlightColor);
     // TODO: Move this to an external function and add support for more types,
     //  and improve code quality/reuse.
-    for (const auto& rit : _rendererAttributes) {
+    for (const auto& rit : MtohGetRendererSettings()) {
         const auto rendererName = rit.first;
         for (const auto& attr : rit.second) {
             const TfToken attrName(TfStringPrintf(
@@ -452,7 +361,7 @@ MtohRenderGlobals MtohGetRenderGlobals() {
         node, _tokens->mtohEnableMotionSamples,
         ret.delegateParams.enableMotionSamples);
     _GetAttribute(
-        node, _tokens->mtohMaximumShadowMapResolution,
+        node, MtohTokens->mtohMaximumShadowMapResolution,
         ret.delegateParams.maximumShadowMapResolution);
     _GetEnum(node, _tokens->mtohSelectionOverlay, ret.selectionOverlay);
     _GetAttribute(
@@ -467,7 +376,7 @@ MtohRenderGlobals MtohGetRenderGlobals() {
         ret.colorSelectionHighlightColor);
     // TODO: Move this to an external function and add support for more types,
     //  and improve code quality/reuse.
-    for (const auto& rit : _rendererAttributes) {
+    for (const auto& rit : MtohGetRendererSettings()) {
         const auto rendererName = rit.first;
         auto& settings = ret.rendererSettings[rendererName];
         settings.reserve(rit.second.size());

--- a/lib/render/mayaToHydra/renderGlobals.h
+++ b/lib/render/mayaToHydra/renderGlobals.h
@@ -51,8 +51,6 @@ struct MtohRenderGlobals {
         rendererSettings;
 };
 
-// Reading renderer delegate attributes and generating UI code.
-void MtohInitializeRenderGlobals(MtohRendererInitialization init);
 // Creating render globals attributes on "defaultRenderGlobals"
 MObject MtohCreateRenderGlobals();
 // Returning the settings stored on "defaultRenderGlobals"

--- a/lib/render/mayaToHydra/renderGlobals.h
+++ b/lib/render/mayaToHydra/renderGlobals.h
@@ -25,6 +25,7 @@
 #include <maya/MObject.h>
 
 #include "tokens.h"
+#include "utils.h"
 #include "../../usd/hdMaya/delegates/params.h"
 
 #include <unordered_map>
@@ -51,7 +52,7 @@ struct MtohRenderGlobals {
 };
 
 // Reading renderer delegate attributes and generating UI code.
-void MtohInitializeRenderGlobals();
+void MtohInitializeRenderGlobals(MtohRendererInitialization init);
 // Creating render globals attributes on "defaultRenderGlobals"
 MObject MtohCreateRenderGlobals();
 // Returning the settings stored on "defaultRenderGlobals"

--- a/lib/render/mayaToHydra/tokens.h
+++ b/lib/render/mayaToHydra/tokens.h
@@ -31,7 +31,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 #define MTOH_TOKENS \
     ((HdStormRendererPlugin, HD_STORM_PLUGIN_NAME)) \
     (UseHdSt) \
-                    (UseVp2)
+    (UseVp2)  \
+    (mtohMaximumShadowMapResolution)
 // clang-format on
 
 // This is not an exported API.

--- a/lib/render/mayaToHydra/utils.cpp
+++ b/lib/render/mayaToHydra/utils.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "utils.h"
+#include "tokens.h"
 
 #if USD_VERSION_NUM >= 1911
 #include <pxr/imaging/hd/rendererPlugin.h>
@@ -25,6 +26,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 using HdRendererPluginRegistry = HdxRendererPluginRegistry;
 PXR_NAMESPACE_CLOSE_SCOPE
 #endif
+
+#include <pxr/imaging/glf/contextCaps.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -60,6 +63,10 @@ MtohRendererInitialization MtohInitializeRenderPlugins() {
             if (!plugin)
                 continue;
 
+            // XXX: As of 22.02, this needs to be called for Storm
+            if (pluginDesc.id == MtohTokens->HdStormRendererPlugin)
+                GlfContextCaps::InitInstance();
+
             HdRenderDelegate* delegate = plugin->IsSupported() ?
                 plugin->CreateRenderDelegate() : nullptr;
             if (delegate) {
@@ -69,7 +76,7 @@ MtohRendererInitialization MtohInitializeRenderPlugins() {
                         TfStringPrintf("mtohRenderOverride_%s", renderer.GetText())
                     ),
                     TfToken(
-                        TfStringPrintf("%s (Hydra)", renderer.GetText())
+                        TfStringPrintf("%s (Hydra)", pluginDesc.displayName.c_str())
                     )
                 );
 

--- a/lib/render/mayaToHydra/utils.cpp
+++ b/lib/render/mayaToHydra/utils.cpp
@@ -120,8 +120,8 @@ static void _BuildOptionsMenu(const MtohRendererDescription& rendererDesc,
             "Error in render delegate options function: \n%s",
             status.errorString().asChar());
     }
-
 }
+
 std::pair<const MtohRendererDescriptionVector&, const MtohRendererSettings&>
 MtohInitializeRenderPlugins() {
     using Storage = std::pair<MtohRendererDescriptionVector, MtohRendererSettings>;

--- a/lib/render/mayaToHydra/utils.h
+++ b/lib/render/mayaToHydra/utils.h
@@ -43,7 +43,6 @@ using MtohRendererSettings =
     std::unordered_map<TfToken, HdRenderSettingDescriptorList,
                        TfToken::HashFunctor>;
 
-TfTokenVector MtohGetRendererPlugins();
 std::string MtohGetRendererPluginDisplayName(const TfToken& id);
 TfToken MtohGetDefaultRenderer();
 const MtohRendererDescriptionVector& MtohGetRendererDescriptions();

--- a/lib/render/mayaToHydra/utils.h
+++ b/lib/render/mayaToHydra/utils.h
@@ -19,6 +19,7 @@
 #include <pxr/pxr.h>
 
 #include <pxr/base/tf/token.h>
+#include <pxr/imaging/hd/renderDelegate.h>
 
 #include <string>
 #include <vector>
@@ -36,11 +37,21 @@ struct MtohRendererDescription {
 };
 
 using MtohRendererDescriptionVector = std::vector<MtohRendererDescription>;
+using MtohRendererSettingsVector = std::vector<HdRenderSettingDescriptorList>;
 
 TfTokenVector MtohGetRendererPlugins();
 std::string MtohGetRendererPluginDisplayName(const TfToken& id);
 TfToken MtohGetDefaultRenderer();
 const MtohRendererDescriptionVector& MtohGetRendererDescriptions();
+
+// Initialize the render-delegates list to all known valid delegates.
+// This function should only be called once (on start-up).
+//
+// The second item (MtohRendererSettingsVector) is only valid from that call
+// as continuing initialization may relocate/move the items.
+//
+using MtohRendererInitialization = std::pair<const MtohRendererDescriptionVector&, MtohRendererSettingsVector>;
+MtohRendererInitialization MtohInitializeRenderPlugins();
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/lib/render/mayaToHydra/utils.h
+++ b/lib/render/mayaToHydra/utils.h
@@ -37,21 +37,18 @@ struct MtohRendererDescription {
 };
 
 using MtohRendererDescriptionVector = std::vector<MtohRendererDescription>;
-using MtohRendererSettingsVector = std::vector<HdRenderSettingDescriptorList>;
+
+// Map from MtohRendererDescription::rendererName to it's a HdRenderSettingDescriptorList
+using MtohRendererSettings =
+    std::unordered_map<TfToken, HdRenderSettingDescriptorList,
+                       TfToken::HashFunctor>;
 
 TfTokenVector MtohGetRendererPlugins();
 std::string MtohGetRendererPluginDisplayName(const TfToken& id);
 TfToken MtohGetDefaultRenderer();
 const MtohRendererDescriptionVector& MtohGetRendererDescriptions();
+const MtohRendererSettings& MtohGetRendererSettings();
 
-// Initialize the render-delegates list to all known valid delegates.
-// This function should only be called once (on start-up).
-//
-// The second item (MtohRendererSettingsVector) is only valid from that call
-// as continuing initialization may relocate/move the items.
-//
-using MtohRendererInitialization = std::pair<const MtohRendererDescriptionVector&, MtohRendererSettingsVector>;
-MtohRendererInitialization MtohInitializeRenderPlugins();
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/lib/render/mayaToHydra/viewCommand.cpp
+++ b/lib/render/mayaToHydra/viewCommand.cpp
@@ -141,9 +141,9 @@ MStatus MtohViewCmd::doIt(const MArgList& args) {
     if (!status) { return status; }
 
     if (db.isFlagSet(_listRenderers)) {
-        for (const auto& renderer : MtohGetRendererPlugins()) {
-            appendToResult(renderer.GetText());
-        }
+        for (auto& plugin : MtohGetRendererDescriptions())
+            appendToResult(plugin.rendererName.GetText());
+
         // Want to return an empty list, not None
         if (!isCurrentResultArray()) { setResult(MStringArray()); }
     } else if (db.isFlagSet(_listActiveRenderers)) {


### PR DESCRIPTION
Initialization of the Hydra delegates is a bit awkward and can ultimately lead to invalid entries in the menu. Selecting an -invalid- delegate can wind up crashing depending on what & why they failed.