### PR TITLE
MAYA-103572 Disable a couple warnings

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.h
@@ -30,7 +30,19 @@
 
 #include <map>
 #include <set>
-#include <boost/thread.hpp>
+
+// On Windows, against certain versions of Maya and with strict compiler
+// settings on, we are getting warning-as-error problems with a couple
+// boost includes.  Disabling those warnings for the specific includes
+// for now instead of disabling the strict settings at a higher level.
+#ifdef _MSC_VER
+#pragma warning( push )
+#pragma warning( disable : 4002 )
+#endif
+  #include <boost/thread.hpp>
+#ifdef _MSC_VER
+#pragma warning( pop )
+#endif
 
 PXR_NAMESPACE_USING_DIRECTIVE
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/wrapLayerManager.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/wrapLayerManager.cpp
@@ -17,7 +17,19 @@
 
 #include <boost/python/args.hpp>
 #include <boost/python/def.hpp>
-#include <boost/python.hpp>
+
+// On Windows, against certain versions of Maya and with strict compiler
+// settings on, we are getting warning-as-error problems with a couple
+// boost includes.  Disabling those warnings for the specific includes
+// for now instead of disabling the strict settings at a higher level.
+#ifdef _MSC_VER
+#pragma warning( push )
+#pragma warning( disable : 4275 )
+#endif
+  #include <boost/python.hpp>
+#ifdef _MSC_VER
+#pragma warning( pop )
+#endif
 
 #include <pxr/base/tf/refPtr.h>
 


### PR DESCRIPTION
Disable a couple warnings before including a couple boost headers.  Avoids "warning treated as errors" in a couple specific cases.