### PR TITLE
A piece of PR183 - approximate equality checks

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
@@ -1119,6 +1119,7 @@ void TransformationMatrix::initialiseToPrim(bool readFromPrim, Scope* transformN
             MPlug(transformNode->thisMObject(), MPxTransform::shearXZ).setValue(tempShear.y);
             MPlug(transformNode->thisMObject(), MPxTransform::shearYZ).setValue(tempShear.z);
             m_shearTweak[0] = m_shearTweak[1] = m_shearTweak[2] = 0;
+            m_shearFromUsd = tempShear;
           }
         }
       }
@@ -1329,7 +1330,14 @@ MStatus TransformationMatrix::translateTo(const MVector& vector, MSpace::Space s
     {
       insertTranslateOp();
     }
-    pushTranslateToPrim();
+
+    // Push new value to prim, but only if it's changing, otherwise extra work and unintended
+    // side effects will happen.
+    //
+    if (!vector.isEquivalent(m_translationFromUsd))
+    {
+      pushTranslateToPrim();
+    }
   }
   return status;
 }
@@ -1377,7 +1385,11 @@ MStatus TransformationMatrix::scaleTo(const MVector& scale, MSpace::Space space)
       // rare case: add a new scale op into the prim
       insertScaleOp();
     }
-    pushScaleToPrim();
+    // Push new value to prim, but only if it's changing.
+    if (!scale.isEquivalent(m_scaleFromUsd))
+    {
+      pushScaleToPrim();
+    }
   }
   return status;
 }
@@ -1423,7 +1435,11 @@ MStatus TransformationMatrix::shearTo(const MVector& shear, MSpace::Space space)
       // rare case: add a new scale op into the prim
       insertShearOp();
     }
-    pushShearToPrim();
+    // Push new value to prim, but only if it's changing.
+    if (!shear.isEquivalent(m_shearFromUsd))
+    {
+      pushShearToPrim();
+    }
   }
   return status;
 }
@@ -1468,11 +1484,15 @@ MStatus TransformationMatrix::setScalePivot(const MPoint& sp, MSpace::Space spac
     {
     }
     else
-    if(!pushPrimToMatrix() && sp != MPoint(0.0, 0.0, 0.0, 1.0))
+    if(!pushPrimToMatrix() && sp != MPoint(0.0, 0.0, 0.0))
     {
       insertScalePivotOp();
     }
-    pushScalePivotToPrim();
+    // Push new value to prim, but only if it's changing.
+    if (!sp.isEquivalent(m_scalePivotFromUsd))
+    {
+      pushScalePivotToPrim();
+    }
   }
   return status;
 }
@@ -1512,7 +1532,11 @@ MStatus TransformationMatrix::setScalePivotTranslation(const MVector& sp, MSpace
     {
       insertScalePivotTranslationOp();
     }
-    pushScalePivotTranslateToPrim();
+    // Push new value to prim, but only if it's changing.
+    if (!sp.isEquivalent(m_scalePivotTranslationFromUsd))
+    {
+      pushScalePivotTranslateToPrim();
+    }
   }
   return status;
 }
@@ -1557,11 +1581,15 @@ MStatus TransformationMatrix::setRotatePivot(const MPoint& pivot, MSpace::Space 
     {
     }
     else
-    if(!pushPrimToMatrix() && pivot != MPoint(0.0, 0.0, 0.0, 1.0))
+    if(!pushPrimToMatrix() && pivot != MPoint(0.0, 0.0, 0.0))
     {
       insertRotatePivotOp();
     }
-    pushRotatePivotToPrim();
+    // Push new value to prim, but only if it's changing.
+    if (!pivot.isEquivalent(m_rotatePivotFromUsd))
+    {
+      pushRotatePivotToPrim();
+    }
   }
   return status;
 }
@@ -1597,11 +1625,15 @@ MStatus TransformationMatrix::setRotatePivotTranslation(const MVector &vector, M
     {
     }
     else
-    if(!pushPrimToMatrix() && vector != MPoint(0.0, 0.0, 0.0, 1.0))
+    if(!pushPrimToMatrix() && vector != MVector(0.0, 0.0, 0.0))
     {
       insertRotatePivotTranslationOp();
     }
-    pushRotatePivotTranslateToPrim();
+    // Push new value to prim, but only if it's changing.
+    if (!vector.isEquivalent(m_rotatePivotTranslationFromUsd))
+    {
+      pushRotatePivotTranslateToPrim();
+    }
   }
   return status;
 }
@@ -1680,7 +1712,11 @@ MStatus TransformationMatrix::rotateTo(const MQuaternion &q, MSpace::Space space
     }
     if(m_enableUsdWriteback)
     {
-      pushRotateToPrim();
+      // Push new value to prim, but only if it's changing.
+      if (!MPxTransformationMatrix::rotationValue.isEquivalent(m_rotationFromUsd))
+      {
+        pushRotateToPrim();
+      }
     }
   }
   return status;
@@ -1711,7 +1747,11 @@ MStatus TransformationMatrix::rotateTo(const MEulerRotation &e, MSpace::Space sp
     }
     if(m_enableUsdWriteback)
     {
-      pushRotateToPrim();
+      // Push new value to prim, but only if it's changing.
+      if (!e.isEquivalent(m_rotationFromUsd))
+      {
+        pushRotateToPrim();
+      }
     }
   }
   return status;


### PR DESCRIPTION
Since the full pr/animationMissingAfterMayaFileSaveReopen was too controversial, breaking out some pieces. This piece has the part that everyone agreed was safe to merge in - approximate equality checks of new values against currently set values to determine whether or not new values need to be saved.  Plus a couple of changes that address what looked like small oversights.
(This change alone fixes the problem where we bring in a usd file with a sphere, turn on the Move To manipulator, and then, via python calls, select the sphere, set the sphere's rotateZ to 45 degrees, unselect the sphere, reselect the sphere and the rotation (and usd "over" that sets it) is inexplicably reset to 0,0,0.)