### PR TITLE
Fix copy which becomes illegal in later USD versions.

### DIFF
--- a/lib/fileio/utils/adaptor.cpp
+++ b/lib/fileio/utils/adaptor.cpp
@@ -530,7 +530,7 @@ static TfToken::Set _GetRegisteredSchemas()
     std::set<TfType> derivedTypes;
     TfType::Find<T>().GetAllDerivedTypes(&derivedTypes);
 
-    UsdSchemaRegistry registry = UsdSchemaRegistry::GetInstance();
+    const UsdSchemaRegistry& registry = UsdSchemaRegistry::GetInstance();
     for (const TfType& ty : derivedTypes) {
         SdfPrimSpecHandle primDef = registry.GetPrimDefinition(ty);
         if (!primDef) {


### PR DESCRIPTION
Somewhere in 22.02 or 22.05 with gcc-6.3 this statement becomes un-compilable

@lgritz