### PR TITLE
[hdMaya] remove MtohGetDefaultRenderer

### DIFF
--- a/lib/render/mayaToHydra/utils.cpp
+++ b/lib/render/mayaToHydra/utils.cpp
@@ -201,29 +201,5 @@ const MtohRendererSettings& MtohGetRendererSettings() {
     return MtohInitializeRenderPlugins().second;
 }
 
-TfToken MtohGetDefaultRenderer() {
-    const MtohRendererDescriptionVector& plugins = MtohGetRendererDescriptions();
-    if (plugins.empty())
-        return {};
-
-    const auto* defaultRenderer = getenv(MTOH_DEFAULT_RENDERER_PLUGIN_NAME);
-    if (defaultRenderer == nullptr) {
-        // FIXME: Why have two of these ?
-        // In the case of MTOH_DEFAULT_RENDERER_PLUGIN_NAME, HD_DEFAULT_RENDERER
-        // will still be created once during UsdImagingGL initialization
-        // Give the UsdImagingGL env-variable a try ...
-        defaultRenderer = getenv("HD_DEFAULT_RENDERER");
-        if (defaultRenderer == nullptr)
-            return plugins.front().rendererName;
-    }
-
-    const TfToken defaultRendererToken(defaultRenderer);
-    auto it = std::find_if(plugins.begin(), plugins.end(),
-        [&](const MtohRendererDescription& desc) -> bool {
-            return desc.rendererName == defaultRendererToken;
-        });
-    return it == plugins.end() ? plugins.front().rendererName : defaultRendererToken;
-}
-
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/render/mayaToHydra/utils.cpp
+++ b/lib/render/mayaToHydra/utils.cpp
@@ -34,9 +34,6 @@ PXR_NAMESPACE_CLOSE_SCOPE
 PXR_NAMESPACE_OPEN_SCOPE
 
 namespace {
-constexpr auto MTOH_DEFAULT_RENDERER_PLUGIN_NAME =
-    "MTOH_DEFAULT_RENDERER_PLUGIN";
-
 constexpr auto _renderOverrideOptionBoxTemplate = R"mel(
 global proc {{override}}OptionBox() {
     string $windowName = "{{override}}OptionsWindow";

--- a/lib/render/mayaToHydra/utils.h
+++ b/lib/render/mayaToHydra/utils.h
@@ -44,7 +44,6 @@ using MtohRendererSettings =
                        TfToken::HashFunctor>;
 
 std::string MtohGetRendererPluginDisplayName(const TfToken& id);
-TfToken MtohGetDefaultRenderer();
 const MtohRendererDescriptionVector& MtohGetRendererDescriptions();
 const MtohRendererSettings& MtohGetRendererSettings();
 


### PR DESCRIPTION
wasn't used anywhere - believe it was a holdover when we had a single maya renderOverride, and an option to switch between the various hydra renderDelegates; now that there is a 1-to-1 relationship between renderOverrides and renderDelegates, no need for this

Putting do-not-merge-yet on this, because it will create merge conflicts with https://github.com/Autodesk/maya-usd/pull/292, and I'd like to get that merged first.  I'll resolve conflicts here after that is merged - just wanted to create this now, as a bookmark for myself.