### PR TITLE
MAYA-103651 Enable import of .usdz

### DIFF
--- a/lib/fileio/jobs/jobArgs.h
+++ b/lib/fileio/jobs/jobArgs.h
@@ -45,7 +45,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     ((UsdFileExtensionASCII, "usda")) \
     ((UsdFileExtensionCrate, "usdc")) \
     ((UsdFileExtensionPackage, "usdz")) \
-    ((UsdReadableFileFilter, "*.usd *.usda *.usdc")) \
+    ((UsdReadableFileFilter, "*.usd *.usda *.usdc *.usdz")) \
     ((UsdWritableFileFilter, "*.usd *.usda *.usdc *.usdz"))
 
 TF_DECLARE_PUBLIC_TOKENS(


### PR DESCRIPTION
Adding .usdz extension to the list of formats that can be read