### PR TITLE
add a way for pxrUsdProxyShape to disable subpath selection with the VP2.0 render delegate

### DIFF
--- a/lib/nodes/proxyShapeBase.cpp
+++ b/lib/nodes/proxyShapeBase.cpp
@@ -955,8 +955,9 @@ MayaUsdProxyShapeBase::parentTransform()
     return proxyTransformPath;
 }
 
-MayaUsdProxyShapeBase::MayaUsdProxyShapeBase() :
-    MPxSurfaceShape()
+MayaUsdProxyShapeBase::MayaUsdProxyShapeBase(const bool enableUfeSelection) :
+        MPxSurfaceShape(),
+        _isUfeSelectionEnabled(enableUfeSelection)
 {
     TfRegistryManager::GetInstance().SubscribeTo<MayaUsdProxyShapeBase>();
 }

--- a/lib/nodes/proxyShapeBase.h
+++ b/lib/nodes/proxyShapeBase.h
@@ -218,9 +218,25 @@ class MayaUsdProxyShapeBase : public MPxSurfaceShape,
         Ufe::Path ufePath() const;
 #endif
 
+        /// Returns whether the proxy shape allows subpaths within its
+        /// hierarchy to be selected independently when using the Viewport 2.0
+        /// render delegate.
+        ///
+        /// UFE/subpath selection must be enabled or disabled when constructing
+        /// the proxy shape. This is primarily intended as a mechanism for
+        /// UsdMayaProxyShape to disable UFE/subpath selection. Most of the
+        /// usage of pxrUsdProxyShape nodes is when they are brought in by
+        /// activating the "Collapsed" representation of
+        /// pxrUsdReferenceAssembly nodes. In that case, they are intended to
+        /// be read-only proxies, and any edits to prims within the hierarchy
+        /// should be represented as assembly edits.
+        bool isUfeSelectionEnabled() const {
+            return _isUfeSelectionEnabled;
+        }
+
     protected:
         MAYAUSD_CORE_PUBLIC
-        MayaUsdProxyShapeBase();
+        MayaUsdProxyShapeBase(const bool enableUfeSelection = true);
 
         MAYAUSD_CORE_PUBLIC
         ~MayaUsdProxyShapeBase() override;
@@ -287,6 +303,9 @@ class MayaUsdProxyShapeBase : public MPxSurfaceShape,
         size_t                              _excludePrimPathsVersion{ 1 };
 
         static ClosestPointDelegate _sharedClosestPointDelegate;
+
+        // Whether or not the proxy shape has enabled UFE/subpath selection
+        const bool _isUfeSelectionEnabled;
 };
 
 

--- a/lib/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -506,6 +506,14 @@ bool ProxyRenderDelegate::getInstancedSelectionPath(
     MDagPath& dagPath) const
 {
 #if defined(WANT_UFE_BUILD)
+    if (_proxyShape == nullptr) {
+        return false;
+    }
+
+    if (!_proxyShape->isUfeSelectionEnabled()) {
+        return false;
+    }
+
     // When point snapping, only the point position matters, so return false
     // to use the DAG path from the default implementation and avoid the UFE
     // global selection list to be updated.
@@ -514,9 +522,6 @@ bool ProxyRenderDelegate::getInstancedSelectionPath(
 
     auto handler = Ufe::RunTimeMgr::instance().hierarchyHandler(USD_UFE_RUNTIME_ID);
     if (handler == nullptr)
-        return false;
-
-    if (_proxyShape == nullptr)
         return false;
 
     // Extract id of the owner Rprim. A SdfPath directly created from the render

--- a/plugin/pxr/maya/lib/usdMaya/proxyShape.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/proxyShape.cpp
@@ -282,8 +282,8 @@ UsdMayaProxyShape::getInternalValueInContext(
 }
 
 UsdMayaProxyShape::UsdMayaProxyShape() :
-    MayaUsdProxyShapeBase(),
-    _useFastPlayback(false)
+        MayaUsdProxyShapeBase(/* enableUfeSelection = */ false),
+        _useFastPlayback(false)
 {
     TfRegistryManager::GetInstance().SubscribeTo<UsdMayaProxyShape>();
 }


### PR DESCRIPTION
I wanted to float this change as a possible solution to #262. As we're testing the VP2.0 render delegate internally at Pixar, we're trying to ensure that the selection behavior of our proxy shapes is consistent when switching back and forth with our current batch renderer viewport integration. Our pxrUsdProxyShape node (and pxrUsdReferenceAssembly nodes which are the primary way our proxies are introduced) aren't really designed to support subpatch selection, so workflows aiming to expose more of the guts of a USD stage should favor one of the other proxy shape types.