### PR TITLE
Add missing paths in "PXR_PLUGINPATH_NAME"

### DIFF
--- a/plugin/al/plugin/AL_USDMayaTestPlugin/CMakeLists.txt
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/CMakeLists.txt
@@ -142,9 +142,15 @@ set(mayaPluginPath
     "${CMAKE_INSTALL_PREFIX}/plugin/al/plugin"
 )
 
+set(pxrPluginPath
+    "${CMAKE_INSTALL_PREFIX}/plugin/al/lib/usd"
+    "${CMAKE_INSTALL_PREFIX}/lib/usd"
+)
+
 separate_argument_list(path)
 separate_argument_list(pythonPath)
 separate_argument_list(mayaPluginPath)
+separate_argument_list(pxrPluginPath)
 
 add_test(
     NAME ${TARGET_NAME}
@@ -161,7 +167,7 @@ set_property(TEST ${TARGET_NAME} APPEND PROPERTY ENVIRONMENT
     "PYTHONPATH=${pythonPath}"
     "PATH=${path}"
     "MAYA_PLUG_IN_PATH=${mayaPluginPath}"
-    "PXR_PLUGINPATH_NAME=${CMAKE_INSTALL_PREFIX}/plugin/al/lib/usd"
+    "PXR_PLUGINPATH_NAME=${pxrPluginPath}"
     "MAYA_NO_STANDALONE_ATEXIT=1"
 )
 

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/CMakeLists.txt
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/CMakeLists.txt
@@ -15,9 +15,15 @@ set(mayaPluginPath
     "${CMAKE_INSTALL_PREFIX}/plugin/al/plugin"
 )
 
+set(pxrPluginPath
+    "${CMAKE_INSTALL_PREFIX}/plugin/al/lib/usd"
+    "${CMAKE_INSTALL_PREFIX}/lib/usd"
+)
+
 separate_argument_list(path)
 separate_argument_list(pythonPath)
 separate_argument_list(mayaPluginPath)
+separate_argument_list(pxrPluginPath)
 
 add_test(
     NAME ${MAIN_TEST_NAME}
@@ -39,7 +45,7 @@ set_property(TEST ${MAIN_TEST_NAME} APPEND PROPERTY ENVIRONMENT
     "PYTHONPATH=${pythonPath}"
     "PATH=${path}"
     "MAYA_PLUG_IN_PATH=${mayaPluginPath}"
-    "PXR_PLUGINPATH_NAME=${CMAKE_INSTALL_PREFIX}/lib/usd"
+    "PXR_PLUGINPATH_NAME=${pxrPluginPath}"
     "MAYA_NO_STANDALONE_ATEXIT=1"
 )
 

--- a/plugin/al/translators/pxrUsdTranslators/tests/CMakeLists.txt
+++ b/plugin/al/translators/pxrUsdTranslators/tests/CMakeLists.txt
@@ -19,9 +19,16 @@ set(mayaPluginPath
     "${CMAKE_INSTALL_PREFIX}/plugin/pxr/maya/plugin"
 )
 
+set(pxrPluginPath
+    "${CMAKE_INSTALL_PREFIX}/plugin/al/plugin"
+    "${CMAKE_INSTALL_PREFIX}/lib/usd"
+)
+
+
 separate_argument_list(path)
 separate_argument_list(pythonPath)
 separate_argument_list(mayaPluginPath)
+separate_argument_list(pxrPluginPath)
 
 # unit tests
 add_test(
@@ -40,7 +47,7 @@ set_property(TEST ${TEST_NAME} APPEND PROPERTY ENVIRONMENT
     "PATH=${path}"
     "MAYA_PLUG_IN_PATH=${mayaPluginPath}"
     "MAYA_SCRIPT_PATH=${CMAKE_INSTALL_PREFIX}/plugin/pxr/maya/lib/usd/usdMaya/resources"
-    "PXR_PLUGINPATH_NAME=${CMAKE_INSTALL_PREFIX}/plugin/al/plugin"
+    "PXR_PLUGINPATH_NAME=${pxrPluginPath}"
     "TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}"
     "MAYA_NO_STANDALONE_ATEXIT=1"
 )

--- a/plugin/al/translators/tests/CMakeLists.txt
+++ b/plugin/al/translators/tests/CMakeLists.txt
@@ -15,9 +15,15 @@ set(mayaPluginPath
     "${CMAKE_INSTALL_PREFIX}/plugin/al/plugin"
 )
 
+set(pxrPluginPath 
+    "${CMAKE_INSTALL_PREFIX}/plugin/al/lib/usd"
+    "${CMAKE_INSTALL_PREFIX}/lib/usd"
+)
+
 separate_argument_list(path)
 separate_argument_list(pythonPath)
 separate_argument_list(mayaPluginPath)
+separate_argument_list(pxrPluginPath)
 
 add_test(
     NAME ${TEST_NAME}
@@ -34,7 +40,7 @@ set_property(TEST ${TEST_NAME} APPEND PROPERTY ENVIRONMENT
     "PYTHONPATH=${pythonPath}"
     "PATH=${path}"
     "MAYA_PLUG_IN_PATH=${mayaPluginPath}"
-    "PXR_PLUGINPATH_NAME=${CMAKE_INSTALL_PREFIX}/plugin/al/lib/usd"
+    "PXR_PLUGINPATH_NAME=${pxrPluginPath}"
     "MAYA_NO_STANDALONE_ATEXIT=1"
 )
 

--- a/test/lib/usd/schemas/CMakeLists.txt
+++ b/test/lib/usd/schemas/CMakeLists.txt
@@ -40,16 +40,13 @@ set(pythonPath
     "$ENV{PYTHONPATH}"
 )
 
-if(IS_WINDOWS)
-    string(REPLACE ";" "\;" path "${path}")
-    string(REPLACE ";" "\;" pythonPath "${pythonPath}")
-else()
-    separate_arguments(path NATIVE_COMMAND "${path}")
-    separate_arguments(pythonPath NATIVE_COMMAND "${pythonPath}")
+set(pxrPluginPath 
+    "${CMAKE_INSTALL_PREFIX}/lib/usd"
+)
 
-    string(REPLACE "\;" ":" path "${path}")
-    string(REPLACE "\;" ":" pythonPath "${pythonPath}")
-endif()
+separate_argument_list(path)
+separate_argument_list(pythonPath)
+separate_argument_list(pxrPluginPath)
 
 foreach(script ${test_script_files})
     mayaUsd_get_unittest_target(target ${script})
@@ -66,6 +63,7 @@ foreach(script ${test_script_files})
     set_property(TEST ${target} APPEND PROPERTY ENVIRONMENT
         "PATH=${path}"
         "PYTHONPATH=${pythonPath}"
+        "PXR_PLUGINPATH_NAME=${pxrPluginPath}"
         "MAYA_NO_STANDALONE_ATEXIT=1"
     )
 endforeach()


### PR DESCRIPTION
Added missing paths to `${CMAKE_INSTALL_PREFIX}/lib/usd` and `${CMAKE_INSTALL_PREFIX}/plugin/al/lib/usd` in PXR_PLUGINPATH_NAME which caused some of the unit tests to fail:

```
5 - TestUSDMayaPython (Failed)
8 - TestAdditionalTranslators (Failed)
9 - TestPxrUsdTranslators (Child aborted)
```
These test failures were not visible if the `MAYA_MODULE_PATH` was set to `mayaUSD.mod` location.