### PR TITLE
MAYA-103736 Clear frameSamples set

### DIFF
--- a/plugin/adsk/plugin/exportTranslator.cpp
+++ b/plugin/adsk/plugin/exportTranslator.cpp
@@ -93,6 +93,7 @@ UsdMayaExportTranslator::writer(const MFileObject &file,
                 theOption[1].split(',', filteredTypes);
             }
             else if (argName == "frameSample") {
+                frameSamples.clear();
                 MStringArray samplesStrings;
                 theOption[1].split(' ', samplesStrings);
                 unsigned int nbSams = samplesStrings.length();


### PR DESCRIPTION
Clear frameSamples set so that we don't add in the default value when the flag is used.