### PR TITLE
adapt to UsdImagingDelegate::PopulateSelection param change

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -33,7 +33,7 @@ See Pixar's official github page for instructions on how to build USD: https://g
 
 |               |      ![](images/pxr.png)          |        
 |:------------: |:---------------:                  |
-|  CommitID/Tags | master: [v19.07](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.07) or [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) <br> dev: [40c813](https://github.com/PixarAnimationStudios/USD/commit/40c813421425c47aa84f4572b4798fbb3430984e) | 
+|  CommitID/Tags | master: [v19.07](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.07) or [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) <br> dev: [893c8e4](https://github.com/PixarAnimationStudios/USD/commit/893c8e4cc4d45fb3e7364369d7767602de411120) | 
 
 For additional information on building Pixar USD, see the ***Additional Build Instruction*** section below.
 

--- a/lib/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -621,11 +621,13 @@ void ProxyRenderDelegate::_FilterSelection()
             continue;
         }
 
-        const SdfPath usdPath(segments[1].string());
-        const SdfPath idxPath(_sceneDelegate->ConvertCachePathToIndexPath(usdPath));
+        SdfPath usdPath(segments[1].string());
+#if !defined(USD_IMAGING_API_VERSION) || USD_IMAGING_API_VERSION < 11
+        usdPath = _sceneDelegate->ConvertCachePathToIndexPath(usdPath);
+#endif
 
         _sceneDelegate->PopulateSelection(HdSelection::HighlightModeSelect,
-            idxPath, UsdImagingDelegate::ALL_INSTANCES, _selection);
+            usdPath, UsdImagingDelegate::ALL_INSTANCES, _selection);
     }
 #endif
 }

--- a/lib/usd/hdMaya/adapters/proxyAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/proxyAdapter.cpp
@@ -134,7 +134,11 @@ void HdMayaProxyAdapter::PopulateSelectedPaths(
 
     // First, we check to see if the entire proxy shape is selected
     if (selectedDag.node() == proxyMObj) {
+#if defined(USD_IMAGING_API_VERSION) && USD_IMAGING_API_VERSION >= 11
+        selectedSdfPaths.push_back(sdfPath::AbsoluteRootPath());
+#else
         selectedSdfPaths.push_back(_usdDelegate->GetDelegateID());
+#endif
         _usdDelegate->PopulateSelection(
             HdSelection::HighlightModeSelect, selectedSdfPaths.back(),
             UsdImagingDelegate::ALL_INSTANCES, selection);


### PR DESCRIPTION
With `USD_IMAGING_API_VERSION` 11, `UsdImagingDelegate::PopulateSelection()` expects to be given a USD path instead of a Hydra "index path". This helps to avoid some confusion about
the types of paths being passed around.