### PR TITLE
Fix testPxrUsdPreviewSurfaceExport failure on Windows

### DIFF
--- a/plugin/pxr/maya/plugin/pxrUsdPreviewSurface/CMakeLists.txt
+++ b/plugin/pxr/maya/plugin/pxrUsdPreviewSurface/CMakeLists.txt
@@ -89,7 +89,7 @@ pxr_register_test(testPxrUsdPreviewSurfaceExport
     TESTENV testPxrUsdPreviewSurfaceExport
     ENV
         MAYA_PLUG_IN_PATH=${TEST_INSTALL_PREFIX}/maya/plugin
-        MAYA_SCRIPT_PATH=${TEST_INSTALL_PREFIX}/maya/lib/usd/usdMaya/resources:${TEST_INSTALL_PREFIX}/maya/plugin/pxrUsdPreviewSurface/resources
+        MAYA_SCRIPT_PATH=${TEST_INSTALL_PREFIX}/maya/lib/usd/usdMaya/resources
         MAYA_DISABLE_CIP=1
         MAYA_NO_STANDALONE_ATEXIT=1
         MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile

--- a/plugin/pxr/maya/plugin/pxrUsdPreviewSurface/CMakeLists.txt
+++ b/plugin/pxr/maya/plugin/pxrUsdPreviewSurface/CMakeLists.txt
@@ -83,13 +83,22 @@ pxr_install_test_dir(
 )
 set(TEST_INSTALL_PREFIX "${PXR_INSTALL_PREFIX}")
 
+set(testMayaScriptPath
+    ${TEST_INSTALL_PREFIX}/maya/lib/usd/usdMaya/resources
+    ${TEST_INSTALL_PREFIX}/maya/plugin/pxrUsdPreviewSurface/resources
+)
+
+if (NOT IS_WINDOWS)
+    string(REPLACE ";" ":" testMayaScriptPath "${testMayaScriptPath}")
+endif()
+
 pxr_register_test(testPxrUsdPreviewSurfaceExport
     CUSTOM_PYTHON ${MAYA_PY_EXECUTABLE}
     COMMAND "${TEST_INSTALL_PREFIX}/tests/testPxrUsdPreviewSurfaceExport"
     TESTENV testPxrUsdPreviewSurfaceExport
     ENV
         MAYA_PLUG_IN_PATH=${TEST_INSTALL_PREFIX}/maya/plugin
-        MAYA_SCRIPT_PATH=${TEST_INSTALL_PREFIX}/maya/lib/usd/usdMaya/resources
+        MAYA_SCRIPT_PATH=${testMayaScriptPath}
         MAYA_DISABLE_CIP=1
         MAYA_NO_STANDALONE_ATEXIT=1
         MAYA_APP_DIR=<PXR_TEST_DIR>/maya_profile

--- a/plugin/pxr/maya/plugin/pxrUsdPreviewSurface/CMakeLists.txt
+++ b/plugin/pxr/maya/plugin/pxrUsdPreviewSurface/CMakeLists.txt
@@ -83,14 +83,12 @@ pxr_install_test_dir(
 )
 set(TEST_INSTALL_PREFIX "${PXR_INSTALL_PREFIX}")
 
+# TODO: disabling the second entry since currently testWrapper.py on Windows
+# can't handle the cases where there are multiple value entries. 
 set(testMayaScriptPath
     ${TEST_INSTALL_PREFIX}/maya/lib/usd/usdMaya/resources
-    ${TEST_INSTALL_PREFIX}/maya/plugin/pxrUsdPreviewSurface/resources
+    #${TEST_INSTALL_PREFIX}/maya/plugin/pxrUsdPreviewSurface/resources
 )
-
-if (NOT IS_WINDOWS)
-    string(REPLACE ";" ":" testMayaScriptPath "${testMayaScriptPath}")
-endif()
 
 pxr_register_test(testPxrUsdPreviewSurfaceExport
     CUSTOM_PYTHON ${MAYA_PY_EXECUTABLE}


### PR DESCRIPTION
Hi @mattyjams,

Can you please confirm if `${TEST_INSTALL_PREFIX}/maya/plugin/pxrUsdPreviewSurface/resources` entry is needed ?

The separator for env variables on Windows is ";"  and It doesn't seem that testwrapper.py is currently supporting that?

I removed  `${TEST_INSTALL_PREFIX}/maya/plugin/pxrUsdPreviewSurface/resources` all together and the test passes on Linux.
