### PR TITLE
Fixes for staging dir builds

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -133,7 +133,10 @@ endif()
 
 #install top level plugInfo.json that includes the configured plugInfo.json
 install(CODE
-    "file(WRITE \"${CMAKE_INSTALL_PREFIX}/lib/usd/plugInfo.json\" \"{\n    \\\"Includes\\\": [ \\\"*/resources/\\\" ]\n}\")"
+    "file(WRITE \"${CMAKE_CURRENT_BINARY_DIR}/lib/usd/plugInfo.json\" \"{\n    \\\"Includes\\\": [ \\\"*/resources/\\\" ]\n}\")"
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/usd/plugInfo.json
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/usd
 )
 
 # -----------------------------------------------------------------------------

--- a/lib/usd/translators/CMakeLists.txt
+++ b/lib/usd/translators/CMakeLists.txt
@@ -119,7 +119,10 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/plugInfo.json
 
 #install top level plugInfo.json that includes the configured plugInfo.json
 install(CODE
-    "file(WRITE \"${install_destination}/plugInfo.json\" \"{\n    \\\"Includes\\\": [ \\\"*/resources/\\\" ]\n}\")"
+    "file(WRITE \"${CMAKE_CURRENT_BINARY_DIR}/lib/usd/plugInfo.json\" \"{\n    \\\"Includes\\\": [ \\\"*/resources/\\\" ]\n}\")"
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/usd/plugInfo.json
+    DESTINATION ${install_destination}
 )
 
 install(

--- a/plugin/al/CMakeLists.txt
+++ b/plugin/al/CMakeLists.txt
@@ -83,6 +83,3 @@ endif()
 get_property(LIBRARY_LOCATION GLOBAL PROPERTY GLOBAL_LIBRARY_LOCATION)
 get_property(PYTHON_LIBRARY_LOCATION GLOBAL PROPERTY GLOBAL_PYTHON_LIBRARY_LOCATION)
 configure_file(ALUsdMayaConfig.cmake.in ${PROJECT_BINARY_DIR}/ALUsdMayaConfig.cmake @ONLY)
-
-install(CODE "message(STATUS \"POST INSTALL: Compiling python/pyc for ${AL_INSTALL_PREFIX} ... \")")
-install(CODE "execute_process(COMMAND \"${Python_EXECUTABLE}\" -m compileall \"${AL_INSTALL_PREFIX}\" )")

--- a/plugin/al/lib/AL_USDMaya/CMakeLists.txt
+++ b/plugin/al/lib/AL_USDMaya/CMakeLists.txt
@@ -305,19 +305,30 @@ set_target_properties(${PYTHON_LIBRARY_LOCATION}
 )
 set_property(GLOBAL PROPERTY GLOBAL_PYTHON_LIBRARY_LOCATION ${AL_INSTALL_PREFIX}/lib/python/${arDirPath}/${PYTHON_LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
 
-install(FILES __init__.py
-    DESTINATION ${AL_INSTALL_PREFIX}/lib/python/${arDirPath}
+execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py ${CMAKE_CURRENT_BINARY_DIR}/lib/python/${arDirPath}/__init__.py)
+execute_process(COMMAND ${Python_EXECUTABLE} -m compileall ${CMAKE_CURRENT_BINARY_DIR}/lib/python/${arDirPath}/__init__.py)
+install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/lib/python/${arDirPath}/__init__.py
+        ${CMAKE_CURRENT_BINARY_DIR}/lib/python/${arDirPath}/__init__.pyc
+    DESTINATION
+        ${AL_INSTALL_PREFIX}/lib/python/${arDirPath}
 )
 install(CODE
-    "file(WRITE \"${AL_INSTALL_PREFIX}/lib/python/AL/__init__.py\"
+    "file(WRITE \"${CMAKE_CURRENT_BINARY_DIR}/lib/python/AL/__init__.py\"
     \"try:\n\t__import__('pkg_resources').declare_namespace(__name__)\nexcept:\n\tfrom pkgutil import extend_path\n\t__path__ = extend_path(__path__, __name__)\")"
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/python/AL/__init__.py
+    DESTINATION ${AL_INSTALL_PREFIX}/lib/python/AL
 )
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/plugInfo.json
     DESTINATION ${AL_INSTALL_PREFIX}/lib/usd/${LIBRARY_NAME}/resources
 )
 install(CODE
-    "file(WRITE \"${AL_INSTALL_PREFIX}/lib/usd/plugInfo.json\" \"{\n    \\\"Includes\\\": [ \\\"*/resources/\\\" ]\n}\")"
+    "file(WRITE \"${CMAKE_CURRENT_BINARY_DIR}/lib/usd/plugInfo.json\" \"{\n    \\\"Includes\\\": [ \\\"*/resources/\\\" ]\n}\")"
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/usd/plugInfo.json
+    DESTINATION ${AL_INSTALL_PREFIX}/lib/usd
 )
 
 # install public headers

--- a/plugin/al/schemas/AL/usd/schemas/maya/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/maya/CMakeLists.txt
@@ -16,7 +16,7 @@ set(
 # Bake library name
 configure_file (
     plugInfo.json.in
-    ./plugInfo.json
+    ${CMAKE_CURRENT_BINARY_DIR}/plugInfo.json
     @ONLY
 )
 
@@ -134,7 +134,7 @@ install(TARGETS ${PYTHON_LIBRARY_NAME}
 
 # configure_file has a nice feature where it will copy the __init__ file over when it gets modified, unlike file(COPY ...)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/__init__.py ${CMAKE_BINARY_DIR}/AL/usd/schemas/maya/__init__.py COPYONLY)
-install(CODE "execute_process(COMMAND \"${Python_EXECUTABLE}\" -m compileall \"${CMAKE_BINARY_DIR}/AL/usd/schemas/maya/__init__.py\" )")
+execute_process(COMMAND ${Python_EXECUTABLE} -m compileall ${CMAKE_BINARY_DIR}/AL/usd/schemas/maya/__init__.py)
 
 string(REPLACE "/" ";" folderHierarchy "AL/usd/schemas/maya")
 
@@ -158,6 +158,7 @@ if(${listCount} STRGREATER 1)
         ${CMAKE_BINARY_DIR}/${currentPath}/__init__.py
         "try:\n\t__import__('pkg_resources').declare_namespace(__name__)\nexcept:\n\tfrom pkgutil import extend_path\n\t__path__ = extend_path(__path__, __name__)\n"
       )
+      execute_process(COMMAND ${Python_EXECUTABLE} -m compileall ${CMAKE_BINARY_DIR}/${currentPath}/__init__.py)
     endforeach(i)
 endif()
 
@@ -167,9 +168,6 @@ install(
     DESTINATION
         ${AL_INSTALL_PREFIX}/lib/python
 )
-
-install(CODE "message(STATUS \"POST INSTALL: Compiling python/pyc for ${AL_INSTALL_PREFIX}/lib/python ... \")")
-install(CODE "execute_process(COMMAND \"${Python_EXECUTABLE}\" -m compileall \"${AL_INSTALL_PREFIX}/lib/python\" )")
 
 ####################################################################################################
 # Install public headers
@@ -199,7 +197,7 @@ file(RELATIVE_PATH
 # Bake relative path
 configure_file(
     ${CMAKE_CURRENT_BINARY_DIR}/plugInfo.json
-    .
+    ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 install(

--- a/plugin/al/schemas/AL/usd/schemas/mayatest/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/mayatest/CMakeLists.txt
@@ -16,7 +16,7 @@ set(
 # Bake library name
 configure_file (
     plugInfo.json.in
-    ./plugInfo.json
+    ${CMAKE_CURRENT_BINARY_DIR}/plugInfo.json
     @ONLY
 )
 
@@ -124,7 +124,7 @@ install(TARGETS ${PYTHON_LIBRARY_NAME}
 
 # configure_file has a nice feature where it will copy the __init__ file over when it gets modified, unlike file(COPY ...)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/__init__.py ${CMAKE_BINARY_DIR}/AL/usd/schemas/mayatest/__init__.py COPYONLY)
-install(CODE "execute_process(COMMAND \"${Python_EXECUTABLE}\" -m compileall \"${CMAKE_BINARY_DIR}/AL/usd/schemas/mayatest/__init__.py\" )")
+execute_process(COMMAND ${Python_EXECUTABLE} -m compileall ${CMAKE_BINARY_DIR}/AL/usd/schemas/mayatest/__init__.py)
 
 string(REPLACE "/" ";" folderHierarchy "AL/usd/schemas/mayatest")
 
@@ -148,6 +148,7 @@ if(${listCount} STRGREATER 1)
         ${CMAKE_BINARY_DIR}/${currentPath}/__init__.py
         "try:\n\t__import__('pkg_resources').declare_namespace(__name__)\nexcept:\n\tfrom pkgutil import extend_path\n\t__path__ = extend_path(__path__, __name__)\n"
       )
+      execute_process(COMMAND ${Python_EXECUTABLE} -m compileall ${CMAKE_BINARY_DIR}/${currentPath}/__init__.py)
     endforeach(i)
 endif()
 
@@ -157,9 +158,6 @@ install(
     DESTINATION
         ${AL_INSTALL_PREFIX}/lib/python
 )
-
-install(CODE "message(STATUS \"POST INSTALL: Compiling python/pyc for ${AL_INSTALL_PREFIX}/lib/python ... \")")
-install(CODE "execute_process(COMMAND \"${Python_EXECUTABLE}\" -m compileall \"${AL_INSTALL_PREFIX}/lib/python\" )")
 
 ####################################################################################################
 # Install usd plugin resources
@@ -175,7 +173,7 @@ file(RELATIVE_PATH
 # Bake relative path
 configure_file(
     ${CMAKE_CURRENT_BINARY_DIR}/plugInfo.json
-    .
+    ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 install(

--- a/plugin/al/translators/CMakeLists.txt
+++ b/plugin/al/translators/CMakeLists.txt
@@ -109,7 +109,10 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/plugInfo.json
 
 #install top level plugInfo.json that includes the configured plugInfo.json
 install(CODE
- "file(WRITE \"${AL_INSTALL_PREFIX}/lib/usd/plugInfo.json\" \"{\n    \\\"Includes\\\": [ \\\"*/resources/\\\" ]\n}\")"
+ "file(WRITE \"${CMAKE_CURRENT_BINARY_DIR}/lib/usd/plugInfo.json\" \"{\n    \\\"Includes\\\": [ \\\"*/resources/\\\" ]\n}\")"
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/usd/plugInfo.json
+ DESTINATION ${AL_INSTALL_PREFIX}/lib/usd
 )
 
 # install public headers

--- a/plugin/al/translators/pxrUsdTranslators/CMakeLists.txt
+++ b/plugin/al/translators/pxrUsdTranslators/CMakeLists.txt
@@ -79,7 +79,10 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/plugInfo.json
 
 #install top level plugInfo.json that includes the configured plugInfo.json
 install(CODE
- "file(WRITE \"${AL_INSTALL_PREFIX}/plugin/plugInfo.json\" \"{\n    \\\"Includes\\\": [ \\\"*/resources/\\\" ]\n}\")"
+ "file(WRITE \"${CMAKE_CURRENT_BINARY_DIR}/plugin/plugInfo.json\" \"{\n    \\\"Includes\\\": [ \\\"*/resources/\\\" ]\n}\")"
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/plugin/plugInfo.json
+ DESTINATION ${AL_INSTALL_PREFIX}/plugin
 )
 
 if(NOT SKIP_USDMAYA_TESTS)

--- a/plugin/al/usdtransaction/CMakeLists.txt
+++ b/plugin/al/usdtransaction/CMakeLists.txt
@@ -30,13 +30,21 @@ configure_file(
 # install python module
 foreach(INPUT_FILE ${PY_INIT_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR} ${AL_INSTALL_PREFIX}/lib/python OUTPUT_FILE ${INPUT_FILE})
-  install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E copy \"${INPUT_FILE}\" \"${OUTPUT_FILE}\")")
-  install(CODE "execute_process(COMMAND \"${Python_EXECUTABLE}\" -m compileall \"${OUTPUT_FILE}\" \"${AL_INSTALL_PREFIX}\")")
+  install(CODE "execute_process(COMMAND \"${Python_EXECUTABLE}\" -m compileall \"${INPUT_FILE}\" )")
+  get_filename_component(OUTPUT_PATH ${OUTPUT_FILE} DIRECTORY)
+  install(FILES
+        ${INPUT_FILE}  # .py files
+        ${INPUT_FILE}c # .pyc files
+      DESTINATION ${OUTPUT_PATH}
+  )
 endforeach()
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/plugInfo.json
     DESTINATION ${AL_INSTALL_PREFIX}/lib/usd/${LIBRARY_NAME}/resources
 )
 install(CODE
-    "file(WRITE \"${AL_INSTALL_PREFIX}/lib/usd/plugInfo.json\" \"{\n    \\\"Includes\\\": [ \\\"*/resources/\\\" ]\n}\")"
+    "file(WRITE \"${CMAKE_CURRENT_BINARY_DIR}/lib/usd/plugInfo.json\" \"{\n    \\\"Includes\\\": [ \\\"*/resources/\\\" ]\n}\")"
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/usd/plugInfo.json
+    DESTINATION ${AL_INSTALL_PREFIX}/lib/usd
 )

--- a/plugin/pxr/cmake/macros/Public.cmake
+++ b/plugin/pxr/cmake/macros/Public.cmake
@@ -184,12 +184,15 @@ function(pxr_setup_python)
     # Install a pxr __init__.py in order to have Python 
     # see UsdMaya module inside pxr subdirectory 
     _get_install_dir(lib/python/pxr installPrefix)
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/generated_modules_init.py"
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/__init__.py"
     "try:\n  __import__('pkg_resources').declare_namespace(__name__)\nexcept:\n  from pkgutil import extend_path\n  __path__ = extend_path(__path__, __name__)\n")
+	execute_process(COMMAND ${Python_EXECUTABLE} -m compileall ${CMAKE_CURRENT_BINARY_DIR}/__init__.py)
     install(
-        FILES "${CMAKE_CURRENT_BINARY_DIR}/generated_modules_init.py"
-        DESTINATION ${INSTALL_DIR_SUFFIX}/${installPrefix}
-        RENAME "__init__.py"
+        FILES
+          ${CMAKE_CURRENT_BINARY_DIR}/__init__.py
+          ${CMAKE_CURRENT_BINARY_DIR}/__init__.pyc
+        DESTINATION
+          ${INSTALL_DIR_SUFFIX}/${installPrefix}
     )
 endfunction() # pxr_setup_python
 


### PR DESCRIPTION
Any install(CODE ...) commands operating on CMAKE_INSTALL_PREFIX paths
break the CMake DESTDIR mechanism, and actually cause files to be
immediately created in the final install directory.

This makes it impossible to use a staging dir to receive an install
image via 'make DESTDIR=/path/to/staging/dir install' when using
packaging systems like RPM or rez