### PR TITLE
Tremblp/maya 103295/ufe path string usd

### DIFF
--- a/lib/ufe/Global.cpp
+++ b/lib/ufe/Global.cpp
@@ -33,6 +33,9 @@
 #if UFE_PREVIEW_VERSION_NUM >= 2009
 #include "UsdContextOpsHandler.h"
 #endif
+#if UFE_PREVIEW_VERSION_NUM >= 2011
+#include <ufe/pathString.h>
+#endif
 #else
 #include "UfeVersionCompat.h"
 #endif
@@ -119,6 +122,11 @@ MStatus initialize()
 		return MS::kFailure;
 
 	g_StagesSubject = StagesSubject::create();
+
+    // Register for UFE string to path service using path component separator '/'
+#if UFE_PREVIEW_VERSION_NUM >= 2011
+    UFE_V2(Ufe::PathString::registerPathComponentSeparator(g_USDRtid, '/');)
+#endif
 
 	return MS::kSuccess;
 }

--- a/test/lib/ufe/testDeleteCmd.py
+++ b/test/lib/ufe/testDeleteCmd.py
@@ -23,6 +23,11 @@ import ufe
 
 import unittest
 
+import os
+
+def childrenNames(children):
+    return [str(child.path().back()) for child in children]
+
 class DeleteCmdTestCase(unittest.TestCase):
     '''Verify the Maya delete command, for multiple runtimes.
 
@@ -90,9 +95,6 @@ class DeleteCmdTestCase(unittest.TestCase):
         sphereHierarchy = ufe.Hierarchy.hierarchy(sphereItem)
         propsHierarchy = ufe.Hierarchy.hierarchy(propsItem)
 
-        def childrenNames(children):
-            return [str(child.path().back()) for child in children]
-
         sphereChildren = sphereHierarchy.children()
         propsChildren = propsHierarchy.children()
 
@@ -138,3 +140,100 @@ class DeleteCmdTestCase(unittest.TestCase):
 
         self.assertNotIn(sphereShapeName, sphereChildrenNames)
         self.assertNotIn(ball35Name, propsChildrenNames)
+
+        # undo to restore state to original.
+        cmds.undo()
+
+    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '2011', 'testVisibility only available in UFE preview 2011 and greater')
+    def testDeleteArgs(self):
+        '''Delete Maya and USD objects passed as command arguments.'''
+
+        spherePath = ufe.Path(mayaUtils.createUfePathSegment("|pSphere1"))
+        sphereItem = ufe.Hierarchy.createItem(spherePath)
+        sphereShapePath = ufe.Path(
+            mayaUtils.createUfePathSegment("|pSphere1|pSphereShape1"))
+        sphereShapeItem = ufe.Hierarchy.createItem(sphereShapePath)
+
+        mayaSegment = mayaUtils.createUfePathSegment(
+            "|world|transform1|proxyShape1")
+        ball35Path = ufe.Path(
+            [mayaSegment,
+             usdUtils.createUfePathSegment("/Room_set/Props/Ball_35")])
+        ball35Item = ufe.Hierarchy.createItem(ball35Path)
+        ball34Path = ufe.Path(
+            [mayaSegment,
+             usdUtils.createUfePathSegment("/Room_set/Props/Ball_34")])
+        ball34Item = ufe.Hierarchy.createItem(ball34Path)
+        propsPath = ufe.Path(
+            [mayaSegment, usdUtils.createUfePathSegment("/Room_set/Props")])
+        propsItem = ufe.Hierarchy.createItem(propsPath)
+
+        sphereShapeName = str(sphereShapeItem.path().back())
+        ball35Name = str(ball35Item.path().back())
+        ball34Name = str(ball34Item.path().back())
+
+        # Before delete, each item is a child of its parent.
+        sphereHierarchy = ufe.Hierarchy.hierarchy(sphereItem)
+        propsHierarchy = ufe.Hierarchy.hierarchy(propsItem)
+
+        sphereChildren = sphereHierarchy.children()
+        propsChildren = propsHierarchy.children()
+
+        sphereChildrenNames = childrenNames(sphereChildren)
+        propsChildrenNames = childrenNames(propsChildren)
+
+        self.assertIn(sphereShapeItem, sphereChildren)
+        self.assertIn(ball35Item, propsChildren)
+        self.assertIn(sphereShapeName, sphereChildrenNames)
+        self.assertIn(ball35Name, propsChildrenNames)
+
+        ball34PathString = ufe.PathString.string(ball34Path)
+        self.assertEqual(
+            ball34PathString,
+            "|world|transform1|proxyShape1,/Room_set/Props/Ball_34")
+
+        # Test that "|world" prefix is optional for multi-segment paths.
+        ball35PathString = "|transform1|proxyShape1,/Room_set/Props/Ball_35"
+
+        cmds.delete(
+            ball35PathString, ball34PathString, "|pSphere1|pSphereShape1")
+
+        sphereChildren = sphereHierarchy.children()
+        propsChildren = propsHierarchy.children()
+
+        sphereChildrenNames = childrenNames(sphereChildren)
+        propsChildrenNames = childrenNames(propsChildren)
+
+        self.assertNotIn(sphereShapeName, sphereChildrenNames)
+        self.assertNotIn(ball35Name, propsChildrenNames)
+        self.assertNotIn(ball34Name, propsChildrenNames)
+        self.assertFalse(cmds.ls("|pSphere1|pSphereShape1"))
+
+        cmds.undo()
+
+        sphereChildren = sphereHierarchy.children()
+        propsChildren = propsHierarchy.children()
+
+        sphereChildrenNames = childrenNames(sphereChildren)
+        propsChildrenNames = childrenNames(propsChildren)
+
+        self.assertIn(sphereShapeItem, sphereChildren)
+        self.assertIn(ball35Item, propsChildren)
+        self.assertIn(ball34Item, propsChildren)
+        self.assertIn(sphereShapeName, sphereChildrenNames)
+        self.assertIn(ball35Name, propsChildrenNames)
+        self.assertIn(ball34Name, propsChildrenNames)
+        self.assertTrue(cmds.ls("|pSphere1|pSphereShape1"))
+
+        cmds.redo()
+
+        sphereChildren = sphereHierarchy.children()
+        propsChildren = propsHierarchy.children()
+
+        sphereChildrenNames = childrenNames(sphereChildren)
+        propsChildrenNames = childrenNames(propsChildren)
+
+        self.assertNotIn(sphereShapeName, sphereChildrenNames)
+        self.assertNotIn(ball35Name, propsChildrenNames)
+        self.assertNotIn(ball34Name, propsChildrenNames)
+        self.assertFalse(cmds.ls("|pSphere1|pSphereShape1"))

--- a/test/lib/ufe/testDeleteCmd.py
+++ b/test/lib/ufe/testDeleteCmd.py
@@ -144,7 +144,7 @@ class DeleteCmdTestCase(unittest.TestCase):
         # undo to restore state to original.
         cmds.undo()
 
-    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '2011', 'testVisibility only available in UFE preview 2011 and greater')
+    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '2011', 'testDeleteArgs only available in UFE preview 2011 and greater')
     def testDeleteArgs(self):
         '''Delete Maya and USD objects passed as command arguments.'''
 


### PR DESCRIPTION
This branch adds in support for UFE path strings in the mayaUsd plugin.  Most of the heavy lifting for path strings is done in the UFE library itself; UFE clients simply have to register their path component separator to the UFE library.  From the UFE Doxygen documentation:

In UFE, \ref Ufe::Path "paths" are full-fledged objects that are accessed and used through their object interfaces, in Python and C++.  To support scripting environments where such Python or C++ access is inconvenient or simply not possible, UFE provides an optional \ref Ufe::PathString "path string" service, which converts a parsable UFE path string to a UFE path.  A UFE path string has its segments separated by a path separator string, which by default is the single-character comma string ','.  In this way, UFE paths can be transported and manipulated as strings.  Converting a UFE path to a parsable UFE path string is also provided.  To use the path string service, a run-time registers the path component separator(s) it understands at initialization time, using \ref Ufe::PathString::registerPathComponentSeparator() .

Here is an example UFE path string, taken from the test in this pull request:

"|transform1|proxyShape1,/Room_set/Props/Ball_35"

Essentially, it is just a string representation of the UFE path, with UFE path segments separated by the path segment separator ','.