### PR TITLE
[AL] Ensure UsdGeomXformOp names match Common API

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/Version.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/Version.h
@@ -20,9 +20,9 @@
 #define xstr(a) stringify(a)
 #define stringify(a) #a
 
-#define AL_USDMAYA_VERSION_MAJOR 0
-#define AL_USDMAYA_VERSION_MINOR 39
-#define AL_USDMAYA_VERSION_PATCH 1
+#define AL_USDMAYA_VERSION_MAJOR 1
+#define AL_USDMAYA_VERSION_MINOR 0
+#define AL_USDMAYA_VERSION_PATCH 0
 
 #define AL_USDMAYA_VERSION_STR xstr(AL_USDMAYA_VERSION_MAJOR) "." \
                                xstr(AL_USDMAYA_VERSION_MINOR) "." \

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.cpp
@@ -547,7 +547,7 @@ bool animationCheck(AnimationTranslator* animTranslator, MPlug plug)
 
 //----------------------------------------------------------------------------------------------------------------------
 UsdAttribute addTranslateOp(
-    const UsdGeomXform& xformSchema,
+    const UsdGeomXformable& xformSchema,
     const char* attrName,
     const GfVec3f& currentValue,
     const UsdTimeCode& time)
@@ -558,8 +558,17 @@ UsdAttribute addTranslateOp(
 }
 
 //----------------------------------------------------------------------------------------------------------------------
+UsdAttribute addInverseTranslateOp(
+    const UsdGeomXformable& xformSchema,
+    const char* attrName)
+{
+  UsdGeomXformOp op = xformSchema.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken(attrName), true);
+  return op.GetAttr();
+}
+
+//----------------------------------------------------------------------------------------------------------------------
 UsdAttribute addTranslateOp(
-    const UsdGeomXform& xformSchema,
+    const UsdGeomXformable& xformSchema,
     const char* attrName,
     const GfVec3d& currentValue,
     const UsdTimeCode& time)
@@ -633,7 +642,7 @@ MStatus TransformTranslator::copyAttributes(const MObject& from, UsdPrim& to, co
   static const GfVec3f defaultShear(0.0f);
   static const GfVec3f defaultRotation(0.0f);
   static const GfVec3f defaultRotateAxis(0.0f);
-  static const GfVec3f defaultTranslation(0.0f);
+  static const GfVec3d defaultTranslation(0.0f);
   static const GfVec3f defaultScalePivot(0.0f);
   static const GfVec3f defaultRotatePivot(0.0f);
   static const GfVec3f defaultScalePivotTranslate(0.0f);
@@ -727,8 +736,7 @@ MStatus TransformTranslator::copyAttributes(const MObject& from, UsdPrim& to, co
     plugAnimated = animationCheck(animTranslator, MPlug(from, m_rotatePivot));
     if(plugAnimated || rotatePivot != defaultRotatePivot)
     {
-      UsdAttribute rotatePivotINVAttr = addTranslateOp(xformSchema, "rotatePivotINV", -rotatePivot, params.m_timeCode);
-      if(plugAnimated && animTranslator) animTranslator->forceAddPlug(MPlug(from, m_rotatePivot), rotatePivotINVAttr);
+      addInverseTranslateOp(xformSchema, "rotatePivot");
     }
 
     plugAnimated = animationCheck(animTranslator, MPlug(from, m_scalePivotTranslate));
@@ -767,8 +775,7 @@ MStatus TransformTranslator::copyAttributes(const MObject& from, UsdPrim& to, co
     plugAnimated = animationCheck(animTranslator, MPlug(from, m_scalePivot));
     if(plugAnimated || scalePivot != defaultScalePivot)
     {
-      UsdAttribute scalePivotINVAttr = addTranslateOp(xformSchema, "scalePivotINV", -scalePivot, params.m_timeCode);
-      if(plugAnimated && animTranslator) animTranslator->forceAddPlug(MPlug(from, m_scalePivot), scalePivotINVAttr);
+      addInverseTranslateOp(xformSchema, "scalePivot");
     }
   }
   else

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
@@ -1316,7 +1316,7 @@ void TransformationMatrix::insertTranslateOp()
 {
   TF_DEBUG(ALUSDMAYA_TRANSFORM_MATRIX).Msg("TransformationMatrix::insertTranslateOp\n");
   // generate our translate op, and insert into the correct stack location
-  UsdGeomXformOp op = m_xform.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("translate"));
+  UsdGeomXformOp op = m_xform.AddTranslateOp(UsdGeomXformOp::PrecisionDouble);
   m_xformops.insert(m_xformops.begin(), op);
   m_orderedOps.insert(m_orderedOps.begin(), kTranslate);
   m_xform.SetXformOpOrder(m_xformops, (m_flags & kInheritsTransform) == 0);
@@ -1368,7 +1368,7 @@ void TransformationMatrix::insertScaleOp()
   TF_DEBUG(ALUSDMAYA_TRANSFORM_MATRIX).Msg("TransformationMatrix::insertScaleOp\n");
 
   // generate our translate op, and insert into the correct stack location
-  UsdGeomXformOp op = m_xform.AddScaleOp(UsdGeomXformOp::PrecisionFloat, TfToken("scale"));
+  UsdGeomXformOp op = m_xform.AddScaleOp(UsdGeomXformOp::PrecisionFloat);
 
   auto posInOps = std::lower_bound(m_orderedOps.begin(), m_orderedOps.end(), kScale);
   auto posInXfm = m_xformops.begin() + (posInOps - m_orderedOps.begin());
@@ -1666,32 +1666,32 @@ void TransformationMatrix::insertRotateOp()
   switch(rotationOrder())
   {
   case MTransformationMatrix::kXYZ:
-    op = m_xform.AddRotateXYZOp(UsdGeomXformOp::PrecisionFloat, TfToken("rotate"));
+    op = m_xform.AddRotateXYZOp(UsdGeomXformOp::PrecisionFloat);
     break;
 
   case MTransformationMatrix::kXZY:
-    op = m_xform.AddRotateXZYOp(UsdGeomXformOp::PrecisionFloat, TfToken("rotate"));
+    op = m_xform.AddRotateXZYOp(UsdGeomXformOp::PrecisionFloat);
     break;
 
   case MTransformationMatrix::kYXZ:
-    op = m_xform.AddRotateYXZOp(UsdGeomXformOp::PrecisionFloat, TfToken("rotate"));
+    op = m_xform.AddRotateYXZOp(UsdGeomXformOp::PrecisionFloat);
     break;
 
   case MTransformationMatrix::kYZX:
-    op = m_xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionFloat, TfToken("rotate"));
+    op = m_xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionFloat);
     break;
 
   case MTransformationMatrix::kZXY:
-    op = m_xform.AddRotateZXYOp(UsdGeomXformOp::PrecisionFloat, TfToken("rotate"));
+    op = m_xform.AddRotateZXYOp(UsdGeomXformOp::PrecisionFloat);
     break;
 
   case MTransformationMatrix::kZYX:
-    op = m_xform.AddRotateZYXOp(UsdGeomXformOp::PrecisionFloat, TfToken("rotate"));
+    op = m_xform.AddRotateZYXOp(UsdGeomXformOp::PrecisionFloat);
     break;
 
   default:
     TF_DEBUG(ALUSDMAYA_TRANSFORM_MATRIX).Msg("TransformationMatrix::insertRotateOp - got invalid rotation order; assuming XYZ");
-    op = m_xform.AddRotateXYZOp(UsdGeomXformOp::PrecisionFloat, TfToken("rotate"));
+    op = m_xform.AddRotateXYZOp(UsdGeomXformOp::PrecisionFloat);
     break;
   }
 


### PR DESCRIPTION
Removed the names from the end of the transform op attributes when exporting to usd from the AL plugin. 

Change the geom xform op names from, to.... 
* ```float3 xformOp:translate:translate ```` ---> ```double3 xformOp:translate``` (note type change!)
* ```float3 xformOp:scale:scale ```` ---> ```float3 xformOp:scale```
* ```float3 xformOp:rotate###:rotate ```` ---> ```float3 xformOp:rotate###```
* ```xformOp:translate:rotatePivotINV```` ---> ```!invert!xformOp:translate:rotatePivot``` 
* ```xformOp:translate:scalePivotINV```` ---> ```!invert!xformOp:translate:scalePivot``` 

This now uses the correct way to initialise inverse ops, and the TRS op names now match those found in the common transform API. 