### PR TITLE
upgrade maya-usd project to the C++14 standard

### DIFF
--- a/cmake/defaults/CXXDefaults.cmake
+++ b/cmake/defaults/CXXDefaults.cmake
@@ -17,6 +17,11 @@ include(CXXHelpers)
 include(Version)
 include(Options)
 
+# Require C++14
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 if (CMAKE_COMPILER_IS_GNUCXX)
     include(gccdefaults)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")

--- a/cmake/defaults/gccclangshareddefaults.cmake
+++ b/cmake/defaults/gccclangshareddefaults.cmake
@@ -19,9 +19,6 @@
 # to remain minimal, marking the points where divergence is required.
 include(Options)
 
-# Turn on C++11; pxr won't build without it. 
-set(_PXR_GCC_CLANG_SHARED_CXX_FLAGS "${_PXR_GCC_CLANG_SHARED_CXX_FLAGS} -std=c++11")
-
 # Enable all warnings.
 set(_PXR_GCC_CLANG_SHARED_CXX_FLAGS "${_PXR_GCC_CLANG_SHARED_CXX_FLAGS} -Wall")
 


### PR DESCRIPTION
Conforming to [VFX Reference Platform](http://vfxplatform.com/) CY2018+ and following suit from core USD, this change sets the maya-usd project to use the C++14 standard.

Core USD moved to C++14 with release 20.05 in this commit:
https://github.com/PixarAnimationStudios/USD/commit/afc0d5e3d45eeaf6579b9699250da37cd9149c6f