### PR TITLE
MAYA-104134 Add .usdz extension to the identifyFile function

### DIFF
--- a/plugin/adsk/plugin/importTranslator.cpp
+++ b/plugin/adsk/plugin/importTranslator.cpp
@@ -157,7 +157,8 @@ UsdMayaImportTranslator::identifyFile(
 
     if (fileExtension == UsdMayaTranslatorTokens->UsdFileExtensionDefault.GetText() ||
         fileExtension == UsdMayaTranslatorTokens->UsdFileExtensionASCII.GetText() ||
-        fileExtension == UsdMayaTranslatorTokens->UsdFileExtensionCrate.GetText()) {
+        fileExtension == UsdMayaTranslatorTokens->UsdFileExtensionCrate.GetText() ||
+        fileExtension == UsdMayaTranslatorTokens->UsdFileExtensionPackage.GetText()) {
         retValue = kIsMyFileType;
     }
 

--- a/plugin/pxr/maya/lib/usdMaya/importTranslator.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/importTranslator.cpp
@@ -137,7 +137,8 @@ UsdMayaImportTranslator::identifyFile(
 
     if (fileExtension == UsdMayaTranslatorTokens->UsdFileExtensionDefault.GetText() ||
         fileExtension == UsdMayaTranslatorTokens->UsdFileExtensionASCII.GetText() ||
-        fileExtension == UsdMayaTranslatorTokens->UsdFileExtensionCrate.GetText()) {
+        fileExtension == UsdMayaTranslatorTokens->UsdFileExtensionCrate.GetText() ||
+        fileExtension == UsdMayaTranslatorTokens->UsdFileExtensionPackage.GetText()) {
         retValue = kIsMyFileType;
     }
 


### PR DESCRIPTION
Add .usdz extension to the identifyFile function, which is used to determine if it is a supported file when doing a drag'n drop onto Maya.
