### PR TITLE
add pre-emptive includes of sdf/types.h before M3dView.h for Maya 2019

### DIFF
--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
@@ -22,6 +22,19 @@
 #include <unordered_set>
 #include <utility>
 
+// XXX: With Maya versions up through 2019 on Linux, M3dView.h ends up
+// indirectly including an X11 header that #define's "Bool" as int:
+//   - <maya/M3dView.h> includes <maya/MNativeWindowHdl.h>
+//   - <maya/MNativeWindowHdl.h> includes <X11/Intrinsic.h>
+//   - <X11/Intrinsic.h> includes <X11/Xlib.h>
+//   - <X11/Xlib.h> does: "#define Bool int"
+// This can cause compilation issues if <pxr/usd/sdf/types.h> is included
+// afterwards, so to fix this, we ensure that it gets included first.
+//
+// The X11 include appears to have been removed in Maya 2020+, so this should
+// no longer be an issue with later versions.
+#include <pxr/usd/sdf/types.h>
+
 #include <maya/M3dView.h>
 #include <maya/MDrawContext.h>
 #include <maya/MDrawRequest.h>

--- a/lib/mayaUsd/render/pxrUsdMayaGL/hdImagingShapeUI.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/hdImagingShapeUI.h
@@ -18,10 +18,17 @@
 
 /// \file pxrUsdMayaGL/hdImagingShapeUI.h
 #include <pxr/pxr.h>
-// XXX: On Linux, some Maya headers (notably M3dView.h) end up indirectly
-//      including X11/Xlib.h, which #define's "Bool" as int. This can cause
-//      compilation issues if sdf/types.h is included afterwards, so to fix
-//      this, we ensure that it gets included first.
+// XXX: With Maya versions up through 2019 on Linux, M3dView.h ends up
+// indirectly including an X11 header that #define's "Bool" as int:
+//   - <maya/M3dView.h> includes <maya/MNativeWindowHdl.h>
+//   - <maya/MNativeWindowHdl.h> includes <X11/Intrinsic.h>
+//   - <X11/Intrinsic.h> includes <X11/Xlib.h>
+//   - <X11/Xlib.h> does: "#define Bool int"
+// This can cause compilation issues if <pxr/usd/sdf/types.h> is included
+// afterwards, so to fix this, we ensure that it gets included first.
+//
+// The X11 include appears to have been removed in Maya 2020+, so this should
+// no longer be an issue with later versions.
 #include <pxr/usd/sdf/types.h>
 
 #include <maya/M3dView.h>

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.h
@@ -19,6 +19,19 @@
 /// \file pxrUsdMayaGL/instancerShapeAdapter.h
 #include <memory>
 
+// XXX: With Maya versions up through 2019 on Linux, M3dView.h ends up
+// indirectly including an X11 header that #define's "Bool" as int:
+//   - <maya/M3dView.h> includes <maya/MNativeWindowHdl.h>
+//   - <maya/MNativeWindowHdl.h> includes <X11/Intrinsic.h>
+//   - <X11/Intrinsic.h> includes <X11/Xlib.h>
+//   - <X11/Xlib.h> does: "#define Bool int"
+// This can cause compilation issues if <pxr/usd/sdf/types.h> is included
+// afterwards, so to fix this, we ensure that it gets included first.
+//
+// The X11 include appears to have been removed in Maya 2020+, so this should
+// no longer be an issue with later versions.
+#include <pxr/usd/sdf/types.h>
+
 #include <maya/M3dView.h>
 
 #include <pxr/base/gf/matrix4d.h>

--- a/lib/mayaUsd/render/pxrUsdMayaGL/proxyShapeUI.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/proxyShapeUI.h
@@ -18,6 +18,19 @@
 
 /// \file pxrUsdMayaGL/proxyShapeUI.h
 
+// XXX: With Maya versions up through 2019 on Linux, M3dView.h ends up
+// indirectly including an X11 header that #define's "Bool" as int:
+//   - <maya/M3dView.h> includes <maya/MNativeWindowHdl.h>
+//   - <maya/MNativeWindowHdl.h> includes <X11/Intrinsic.h>
+//   - <X11/Intrinsic.h> includes <X11/Xlib.h>
+//   - <X11/Xlib.h> does: "#define Bool int"
+// This can cause compilation issues if <pxr/usd/sdf/types.h> is included
+// afterwards, so to fix this, we ensure that it gets included first.
+//
+// The X11 include appears to have been removed in Maya 2020+, so this should
+// no longer be an issue with later versions.
+#include <pxr/usd/sdf/types.h>
+
 #include <maya/M3dView.h>
 #include <maya/MDrawInfo.h>
 #include <maya/MDrawRequest.h>

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
@@ -27,10 +27,17 @@
 #include <pxr/imaging/hd/rprimCollection.h>
 #include <pxr/usd/sdf/path.h>
 
-// XXX: On Linux, some Maya headers (notably M3dView.h) end up indirectly
-//      including X11/Xlib.h, which #define's "Bool" as int. This can cause
-//      compilation issues if sdf/types.h is included afterwards, so to fix
-//      this, we ensure that it gets included first.
+// XXX: With Maya versions up through 2019 on Linux, M3dView.h ends up
+// indirectly including an X11 header that #define's "Bool" as int:
+//   - <maya/M3dView.h> includes <maya/MNativeWindowHdl.h>
+//   - <maya/MNativeWindowHdl.h> includes <X11/Intrinsic.h>
+//   - <X11/Intrinsic.h> includes <X11/Xlib.h>
+//   - <X11/Xlib.h> does: "#define Bool int"
+// This can cause compilation issues if <pxr/usd/sdf/types.h> is included
+// afterwards, so to fix this, we ensure that it gets included first.
+//
+// The X11 include appears to have been removed in Maya 2020+, so this should
+// no longer be an issue with later versions.
 #include <pxr/usd/sdf/types.h>
 
 #include <maya/M3dView.h>

--- a/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.h
@@ -20,6 +20,19 @@
 
 #include <memory>
 
+// XXX: With Maya versions up through 2019 on Linux, M3dView.h ends up
+// indirectly including an X11 header that #define's "Bool" as int:
+//   - <maya/M3dView.h> includes <maya/MNativeWindowHdl.h>
+//   - <maya/MNativeWindowHdl.h> includes <X11/Intrinsic.h>
+//   - <X11/Intrinsic.h> includes <X11/Xlib.h>
+//   - <X11/Xlib.h> does: "#define Bool int"
+// This can cause compilation issues if <pxr/usd/sdf/types.h> is included
+// afterwards, so to fix this, we ensure that it gets included first.
+//
+// The X11 include appears to have been removed in Maya 2020+, so this should
+// no longer be an issue with later versions.
+#include <pxr/usd/sdf/types.h>
+
 #include <maya/M3dView.h>
 #include <maya/MHWGeometryUtilities.h>
 #include <maya/MPxSurfaceShape.h>


### PR DESCRIPTION
Following the merge of PRs #388 through #392, the header reorganization created some new sites where `M3dView.h` was being included earlier than `sdf/types.h`.

This change applies an existing pattern of including `sdf/types.h` early to work around this issue and fix compiling for Maya 2019 (and earlier).