### PR TITLE
add one more pre-emptive include of sdf/types.h pxrUsdMayaGL/hdRenderer.h

### DIFF
--- a/lib/mayaUsd/render/pxrUsdMayaGL/hdRenderer.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/hdRenderer.h
@@ -21,6 +21,19 @@
 #include <memory>
 #include <vector>
 
+// XXX: With Maya versions up through 2019 on Linux, M3dView.h ends up
+// indirectly including an X11 header that #define's "Bool" as int:
+//   - <maya/M3dView.h> includes <maya/MNativeWindowHdl.h>
+//   - <maya/MNativeWindowHdl.h> includes <X11/Intrinsic.h>
+//   - <X11/Intrinsic.h> includes <X11/Xlib.h>
+//   - <X11/Xlib.h> does: "#define Bool int"
+// This can cause compilation issues if <pxr/usd/sdf/types.h> is included
+// afterwards, so to fix this, we ensure that it gets included first.
+//
+// The X11 include appears to have been removed in Maya 2020+, so this should
+// no longer be an issue with later versions.
+#include <pxr/usd/sdf/types.h>
+
 #include <maya/M3dView.h>
 #include <maya/MBoundingBox.h>
 #include <maya/MColor.h>


### PR DESCRIPTION
Sorry all, but I missed one spot in #414 and only just now found it as I'm trying to reconcile the recent merges with our internal plugins.