### PR TITLE
[pxrUsdMayaGL] remove unused customBucketName from PxrMayaHdRenderParams

### DIFF
--- a/lib/mayaUsd/render/pxrUsdMayaGL/renderParams.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/renderParams.h
@@ -22,11 +22,10 @@
 
 #include <pxr/pxr.h>
 #include <pxr/base/gf/vec4f.h>
-#include <pxr/base/tf/token.h>
 
-#include <mayaUsd/base/api.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
+
 
 struct PxrMayaHdRenderParams
 {
@@ -38,19 +37,11 @@ struct PxrMayaHdRenderParams
     //
     GfVec4f wireframeColor = GfVec4f(0.0f);
 
-    /// Custom bucketing on top of the regular bucketing based on render params.
-    /// Leave this as the empty token if you want to use the default bucket for
-    /// these params, along with its associated Hydra tasks.
-    /// Set this to a non-empty token if you want to render with separate
-    /// Hydra tasks, since these are allocated on a per-bucket basis.
-    TfToken customBucketName;
-
     /// Helper function to find a batch key for the render params
     size_t Hash() const
     {
         size_t hash = size_t(enableLighting);
         boost::hash_combine(hash, wireframeColor);
-        boost::hash_combine(hash, customBucketName);
 
         return hash;
     }


### PR DESCRIPTION
This field was previously used for supporting custom intersection testing for live surface-type workflows, but it is no longer used or needed.

(Internal change: 2056384)