### PR TITLE
PR II: Pixar Mesh write translator/utilities refactoring

### DIFF
--- a/lib/mayaUsd/fileio/translators/translatorMesh.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMesh.cpp
@@ -38,7 +38,7 @@
 #include <maya/MPointArray.h>
 #include <maya/MString.h>
 
-#include <mayaUsd/fileio/utils/meshUtil.h>
+#include <mayaUsd/fileio/utils/meshReadUtils.h>
 #include <mayaUsd/fileio/utils/readUtil.h>
 #include <mayaUsd/nodes/pointBasedDeformerNode.h>
 #include <mayaUsd/nodes/stageNode.h>
@@ -211,7 +211,7 @@ TranslatorMeshRead::TranslatorMeshRead(const UsdGeomMesh& mesh,
     if (mesh.GetSubdivisionSchemeAttr().Get(&subdScheme) && subdScheme == UsdGeomTokens->none) {
          if (normals.size() == static_cast<size_t>(meshFn.numFaceVertices()) &&
                  mesh.GetNormalsInterpolation() == UsdGeomTokens->faceVarying) {
-             UsdMayaMeshUtil::SetEmitNormalsTag(meshFn, true);
+             UsdMayaMeshUtil::setEmitNormalsTag(meshFn, true);
          }
     } 
     else {

--- a/lib/mayaUsd/fileio/translators/translatorMesh.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMesh.cpp
@@ -211,11 +211,11 @@ TranslatorMeshRead::TranslatorMeshRead(const UsdGeomMesh& mesh,
     if (mesh.GetSubdivisionSchemeAttr().Get(&subdScheme) && subdScheme == UsdGeomTokens->none) {
          if (normals.size() == static_cast<size_t>(meshFn.numFaceVertices()) &&
                  mesh.GetNormalsInterpolation() == UsdGeomTokens->faceVarying) {
-             UsdMayaMeshUtil::setEmitNormalsTag(meshFn, true);
+             UsdMayaMeshReadUtils::setEmitNormalsTag(meshFn, true);
          }
     } 
     else {
-        stat = UsdMayaMeshUtil::assignSubDivTagsToMesh(mesh, m_meshObj, meshFn);
+        stat = UsdMayaMeshReadUtils::assignSubDivTagsToMesh(mesh, m_meshObj, meshFn);
     }
 
     // Copy UsdGeomMesh schema attrs into Maya if they're authored.

--- a/lib/mayaUsd/fileio/utils/CMakeLists.txt
+++ b/lib/mayaUsd/fileio/utils/CMakeLists.txt
@@ -4,7 +4,7 @@
 target_sources(${PROJECT_NAME} 
     PRIVATE
         adaptor.cpp
-        meshUtil.cpp
+        meshReadUtils.cpp
         readUtil.cpp
         roundTripUtil.cpp
         shadingUtil.cpp
@@ -15,7 +15,7 @@ target_sources(${PROJECT_NAME}
 
 set(headers
     adaptor.h
-    meshUtil.h
+    meshReadUtils.h
     readUtil.h
     roundTripUtil.h
     shadingUtil.h

--- a/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
@@ -15,7 +15,7 @@
 //
 // Modifications copyright (C) 2020 Autodesk
 //
-#include "meshUtil.h"
+#include "meshReadUtils.h"
 
 #include <maya/MFloatVector.h>
 #include <maya/MFloatVectorArray.h>
@@ -566,7 +566,7 @@ namespace
 
 // This can be customized for specific pipelines.
 bool
-UsdMayaMeshUtil::GetEmitNormalsTag(const MFnMesh& mesh, bool* value)
+UsdMayaMeshUtil::getEmitNormalsTag(const MFnMesh& mesh, bool* value)
 {
     MPlug plug = mesh.findPlug(MString(_meshTokens->USD_EmitNormals.GetText()));
     if (!plug.isNull()) {
@@ -578,7 +578,7 @@ UsdMayaMeshUtil::GetEmitNormalsTag(const MFnMesh& mesh, bool* value)
 }
 
 void
-UsdMayaMeshUtil::SetEmitNormalsTag(
+UsdMayaMeshUtil::setEmitNormalsTag(
         MFnMesh& meshFn,
         const bool emitNormals)
 {
@@ -596,7 +596,7 @@ UsdMayaMeshUtil::SetEmitNormalsTag(
 }
 
 bool
-UsdMayaMeshUtil::GetMeshNormals(
+UsdMayaMeshUtil::getMeshNormals(
         const MFnMesh& mesh,
         VtArray<GfVec3f>* normalsArray,
         TfToken* interpolation)
@@ -649,7 +649,7 @@ UsdMayaMeshUtil::GetMeshNormals(
 // the RenderMan for Maya int attribute.
 // XXX Maybe we should come up with a OSD centric nomenclature ??
 TfToken
-UsdMayaMeshUtil::GetSubdivScheme(const MFnMesh& mesh)
+UsdMayaMeshUtil::getSubdivScheme(const MFnMesh& mesh)
 {
     // Try grabbing the value via the adaptor first.
     TfToken schemeToken;
@@ -694,7 +694,7 @@ UsdMayaMeshUtil::GetSubdivScheme(const MFnMesh& mesh)
 // We first look for the USD string attribute, and if not present we look for
 // the RenderMan for Maya int attribute.
 // XXX Maybe we should come up with a OSD centric nomenclature ??
-TfToken UsdMayaMeshUtil::GetSubdivInterpBoundary(const MFnMesh& mesh)
+TfToken UsdMayaMeshUtil::getSubdivInterpBoundary(const MFnMesh& mesh)
 {
     // Try grabbing the value via the adaptor first.
     TfToken interpBoundaryToken;
@@ -788,7 +788,7 @@ _GetOsd2FVInterpBoundary(const MFnMesh& mesh)
     return sdFVInterpBound;
 }
 
-TfToken UsdMayaMeshUtil::GetSubdivFVLinearInterpolation(const MFnMesh& mesh)
+TfToken UsdMayaMeshUtil::getSubdivFVLinearInterpolation(const MFnMesh& mesh)
 {
     // Try grabbing the value via the adaptor first.
     TfToken sdFVLinearInterpolation;

--- a/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
@@ -566,7 +566,7 @@ namespace
 
 // This can be customized for specific pipelines.
 bool
-UsdMayaMeshUtil::getEmitNormalsTag(const MFnMesh& mesh, bool* value)
+UsdMayaMeshReadUtils::getEmitNormalsTag(const MFnMesh& mesh, bool* value)
 {
     MPlug plug = mesh.findPlug(MString(_meshTokens->USD_EmitNormals.GetText()));
     if (!plug.isNull()) {
@@ -578,7 +578,7 @@ UsdMayaMeshUtil::getEmitNormalsTag(const MFnMesh& mesh, bool* value)
 }
 
 void
-UsdMayaMeshUtil::setEmitNormalsTag(
+UsdMayaMeshReadUtils::setEmitNormalsTag(
         MFnMesh& meshFn,
         const bool emitNormals)
 {
@@ -596,7 +596,7 @@ UsdMayaMeshUtil::setEmitNormalsTag(
 }
 
 bool
-UsdMayaMeshUtil::getMeshNormals(
+UsdMayaMeshReadUtils::getMeshNormals(
         const MFnMesh& mesh,
         VtArray<GfVec3f>* normalsArray,
         TfToken* interpolation)
@@ -649,7 +649,7 @@ UsdMayaMeshUtil::getMeshNormals(
 // the RenderMan for Maya int attribute.
 // XXX Maybe we should come up with a OSD centric nomenclature ??
 TfToken
-UsdMayaMeshUtil::getSubdivScheme(const MFnMesh& mesh)
+UsdMayaMeshReadUtils::getSubdivScheme(const MFnMesh& mesh)
 {
     // Try grabbing the value via the adaptor first.
     TfToken schemeToken;
@@ -694,7 +694,7 @@ UsdMayaMeshUtil::getSubdivScheme(const MFnMesh& mesh)
 // We first look for the USD string attribute, and if not present we look for
 // the RenderMan for Maya int attribute.
 // XXX Maybe we should come up with a OSD centric nomenclature ??
-TfToken UsdMayaMeshUtil::getSubdivInterpBoundary(const MFnMesh& mesh)
+TfToken UsdMayaMeshReadUtils::getSubdivInterpBoundary(const MFnMesh& mesh)
 {
     // Try grabbing the value via the adaptor first.
     TfToken interpBoundaryToken;
@@ -788,7 +788,7 @@ _GetOsd2FVInterpBoundary(const MFnMesh& mesh)
     return sdFVInterpBound;
 }
 
-TfToken UsdMayaMeshUtil::getSubdivFVLinearInterpolation(const MFnMesh& mesh)
+TfToken UsdMayaMeshReadUtils::getSubdivFVLinearInterpolation(const MFnMesh& mesh)
 {
     // Try grabbing the value via the adaptor first.
     TfToken sdFVLinearInterpolation;
@@ -823,7 +823,7 @@ TfToken UsdMayaMeshUtil::getSubdivFVLinearInterpolation(const MFnMesh& mesh)
 }
 
 void
-UsdMayaMeshUtil::assignPrimvarsToMesh(const UsdGeomMesh& mesh, 
+UsdMayaMeshReadUtils::assignPrimvarsToMesh(const UsdGeomMesh& mesh, 
                                       const MObject& meshObj,
                                       const TfToken::Set& excludePrimvarSet)
 {
@@ -903,7 +903,7 @@ UsdMayaMeshUtil::assignPrimvarsToMesh(const UsdGeomMesh& mesh,
 }
 
 void 
-UsdMayaMeshUtil::assignInvisibleFaces(const UsdGeomMesh& mesh, const MObject& meshObj)
+UsdMayaMeshReadUtils::assignInvisibleFaces(const UsdGeomMesh& mesh, const MObject& meshObj)
 {
     if(meshObj.apiType() != MFn::kMesh){
         return;
@@ -929,7 +929,7 @@ UsdMayaMeshUtil::assignInvisibleFaces(const UsdGeomMesh& mesh, const MObject& me
 }
 
 MStatus
-UsdMayaMeshUtil::assignSubDivTagsToMesh( const UsdGeomMesh& mesh,
+UsdMayaMeshReadUtils::assignSubDivTagsToMesh( const UsdGeomMesh& mesh,
                                          MObject& meshObj,
                                          MFnMesh& meshFn )
 {

--- a/lib/mayaUsd/fileio/utils/meshReadUtils.h
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.h
@@ -46,7 +46,7 @@ TF_DECLARE_PUBLIC_TOKENS(UsdMayaMeshColorSetTokens,
     PXRUSDMAYA_MESH_COLOR_SET_TOKENS);
 
 /// Utilities for dealing with USD and RenderMan for Maya mesh/subdiv tags.
-namespace UsdMayaMeshUtil
+namespace UsdMayaMeshReadUtils
 {
     /// Gets the internal emit-normals tag on the Maya \p mesh, placing it in
     /// \p value. Returns true if the tag exists on the mesh, and false if not.
@@ -85,7 +85,9 @@ namespace UsdMayaMeshUtil
     TfToken getSubdivFVLinearInterpolation(const MFnMesh& mesh);
 
     MAYAUSD_CORE_PUBLIC
-    void assignPrimvarsToMesh(const UsdGeomMesh&, const MObject&, const TfToken::Set&);
+    void assignPrimvarsToMesh(const UsdGeomMesh& mesh, 
+                              const MObject& meshObj, 
+                              const TfToken::Set& excludePrimvarSet);
 
     MAYAUSD_CORE_PUBLIC
     void assignInvisibleFaces(const UsdGeomMesh& mesh, const MObject& meshObj);
@@ -93,7 +95,7 @@ namespace UsdMayaMeshUtil
     MAYAUSD_CORE_PUBLIC
     MStatus assignSubDivTagsToMesh(const UsdGeomMesh&, MObject&, MFnMesh&);
 
-} // namespace UsdMayaMeshUtil
+} // namespace UsdMayaMeshReadUtils
 
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/utils/meshReadUtils.h
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.h
@@ -15,8 +15,8 @@
 //
 // Modifications copyright (C) 2020 Autodesk
 //
-#ifndef PXRUSDMAYA_MESH_UTIL_H
-#define PXRUSDMAYA_MESH_UTIL_H
+#ifndef PXRUSDMAYA_MESH_READ_UTILS_H
+#define PXRUSDMAYA_MESH_READ_UTILS_H
 
 #include <maya/MDagPath.h>
 #include <maya/MFnMesh.h>
@@ -51,39 +51,38 @@ namespace UsdMayaMeshUtil
     /// Gets the internal emit-normals tag on the Maya \p mesh, placing it in
     /// \p value. Returns true if the tag exists on the mesh, and false if not.
     MAYAUSD_CORE_PUBLIC
-    bool GetEmitNormalsTag(const MFnMesh &mesh, bool* value);
+    bool getEmitNormalsTag(const MFnMesh &mesh, bool* value);
 
     /// Sets the internal emit-normals tag on the Maya \p mesh.
     /// This value indicates to the exporter whether it should write out the
     /// normals for the mesh to USD.
     MAYAUSD_CORE_PUBLIC
-    void SetEmitNormalsTag(MFnMesh &meshFn, const bool emitNormals);
+    void setEmitNormalsTag(MFnMesh &meshFn, const bool emitNormals);
 
     /// Helper method for getting Maya mesh normals as a VtVec3fArray.
     MAYAUSD_CORE_PUBLIC
-    bool GetMeshNormals(
-        const MFnMesh& mesh,
-        VtArray<GfVec3f>* normalsArray,
-        TfToken* interpolation);
+    bool getMeshNormals(const MFnMesh& mesh,
+                        VtArray<GfVec3f>* normalsArray, 
+                        TfToken* interpolation);
 
     /// Gets the subdivision scheme tagged for the Maya mesh by consulting the
     /// adaptor for \c UsdGeomMesh.subdivisionSurface, and then falling back to
     /// the RenderMan for Maya attribute.
     MAYAUSD_CORE_PUBLIC
-    TfToken GetSubdivScheme(const MFnMesh &mesh);
+    TfToken getSubdivScheme(const MFnMesh &mesh);
 
     /// Gets the subdivision interpolate boundary tagged for the Maya mesh by
     /// consulting the adaptor for \c UsdGeomMesh.interpolateBoundary, and then
     /// falling back to the RenderMan for Maya attribute.
     MAYAUSD_CORE_PUBLIC
-    TfToken GetSubdivInterpBoundary(const MFnMesh &mesh);
+    TfToken getSubdivInterpBoundary(const MFnMesh &mesh);
 
     /// Gets the subdivision face-varying linear interpolation tagged for the
     /// Maya mesh by consulting the adaptor for
     /// \c UsdGeomMesh.faceVaryingLinearInterpolation, and then falling back to
     /// the OpenSubdiv2-style tagging.
     MAYAUSD_CORE_PUBLIC
-    TfToken GetSubdivFVLinearInterpolation(const MFnMesh& mesh);
+    TfToken getSubdivFVLinearInterpolation(const MFnMesh& mesh);
 
     MAYAUSD_CORE_PUBLIC
     void assignPrimvarsToMesh(const UsdGeomMesh&, const MObject&, const TfToken::Set&);

--- a/lib/mayaUsd/python/CMakeLists.txt
+++ b/lib/mayaUsd/python/CMakeLists.txt
@@ -29,7 +29,7 @@ target_sources(${PYTHON_TARGET_NAME}
         wrapBlockSceneModificationContext.cpp
         wrapColorSpace.cpp
         wrapDiagnosticDelegate.cpp
-        wrapMeshUtil.cpp
+        wrapMeshWriteUtils.cpp
         wrapQuery.cpp
         wrapReadUtil.cpp
         wrapRoundTripUtil.cpp

--- a/lib/mayaUsd/python/module.cpp
+++ b/lib/mayaUsd/python/module.cpp
@@ -24,7 +24,7 @@ TF_WRAP_MODULE {
     TF_WRAP(BlockSceneModificationContext);
     TF_WRAP(ColorSpace);
     TF_WRAP(DiagnosticDelegate);
-    TF_WRAP(MeshUtil);
+    TF_WRAP(MeshWriteUtils);
     TF_WRAP(Query);
     TF_WRAP(ReadUtil);
     TF_WRAP(RoundTripUtil);

--- a/lib/mayaUsd/python/wrapMeshUtil.cpp
+++ b/lib/mayaUsd/python/wrapMeshUtil.cpp
@@ -28,7 +28,7 @@
 #include <pxr/base/tf/token.h>
 #include <pxr/base/vt/array.h>
 
-#include <mayaUsd/fileio/utils/meshUtil.h>
+#include <mayaUsd/fileio/utils/meshReadUtils.h>
 #include <mayaUsd/utils/util.h>
 
 using namespace boost::python;
@@ -59,7 +59,7 @@ _GetMeshNormals(const std::string& meshDagPath)
         return make_tuple(normalsArray, interpolation);
     }
 
-    UsdMayaMeshUtil::GetMeshNormals(meshObj, &normalsArray, &interpolation);
+    UsdMayaMeshUtil::getMeshNormals(meshObj, &normalsArray, &interpolation);
 
     return make_tuple(normalsArray, interpolation);
 }

--- a/lib/mayaUsd/python/wrapMeshWriteUtils.cpp
+++ b/lib/mayaUsd/python/wrapMeshWriteUtils.cpp
@@ -71,7 +71,7 @@ class DummyScopeClass{};
 } // anonymous namespace 
 
 
-void wrapMeshUtil()
+void wrapMeshWriteUtils()
 {
     scope s = class_<DummyScopeClass>("MeshUtil", no_init)
 

--- a/lib/mayaUsd/python/wrapMeshWriteUtils.cpp
+++ b/lib/mayaUsd/python/wrapMeshWriteUtils.cpp
@@ -59,12 +59,12 @@ _GetMeshNormals(const std::string& meshDagPath)
         return make_tuple(normalsArray, interpolation);
     }
 
-    UsdMayaMeshUtil::getMeshNormals(meshObj, &normalsArray, &interpolation);
+    UsdMayaMeshReadUtils::getMeshNormals(meshObj, &normalsArray, &interpolation);
 
     return make_tuple(normalsArray, interpolation);
 }
 
-// Dummy class for putting UsdMayaMeshUtil namespace functions in a Python
+// Dummy class for putting UsdMayaMeshReadUtils namespace functions in a Python
 // MeshUtil namespace.
 class DummyScopeClass{};
 

--- a/lib/usd/translators/meshReader.cpp
+++ b/lib/usd/translators/meshReader.cpp
@@ -139,11 +139,11 @@ MayaUsdPrimReaderMesh::Read(UsdMayaPrimReaderContext* context)
     assignMaterial(mesh, _GetArgs(), meshRead.meshObject(), context);
 
     // assign primvars to mesh
-    UsdMayaMeshUtil::assignPrimvarsToMesh( mesh, 
+    UsdMayaMeshReadUtils::assignPrimvarsToMesh( mesh, 
                                            meshRead.meshObject(),
                                            _GetArgs().GetExcludePrimvarNames());
     // assign invisible faces
-    UsdMayaMeshUtil::assignInvisibleFaces(mesh, meshRead.meshObject());
+    UsdMayaMeshReadUtils::assignInvisibleFaces(mesh, meshRead.meshObject());
 
     return true;
 }

--- a/lib/usd/translators/meshReader.cpp
+++ b/lib/usd/translators/meshReader.cpp
@@ -25,7 +25,7 @@
 #include <mayaUsd/fileio/translators/translatorMaterial.h>
 #include <mayaUsd/fileio/translators/translatorMesh.h>
 #include <mayaUsd/fileio/translators/translatorUtil.h>
-#include <mayaUsd/fileio/utils/meshUtil.h>
+#include <mayaUsd/fileio/utils/meshReadUtils.h>
 #include <mayaUsd/fileio/utils/readUtil.h>
 #include <mayaUsd/nodes/stageNode.h>
 #include <mayaUsd/utils/util.h>

--- a/lib/usd/translators/meshWriter.cpp
+++ b/lib/usd/translators/meshWriter.cpp
@@ -268,7 +268,7 @@ PxrUsdTranslators_MeshWriter::writeMeshAttrs(
 
     // Read subdiv scheme tagging. If not set, we default to defaultMeshScheme
     // flag (this is specified by the job args but defaults to catmullClark).
-    TfToken sdScheme = UsdMayaMeshUtil::getSubdivScheme(finalMesh);
+    TfToken sdScheme = UsdMayaMeshReadUtils::getSubdivScheme(finalMesh);
     if (sdScheme.IsEmpty()) {
         sdScheme = _GetExportArgs().defaultMeshScheme;
     }
@@ -277,12 +277,12 @@ PxrUsdTranslators_MeshWriter::writeMeshAttrs(
     if (sdScheme == UsdGeomTokens->none) {
         // Polygonal mesh - export normals.
         bool emitNormals = true; // Default to emitting normals if no tagging.
-        UsdMayaMeshUtil::getEmitNormalsTag(finalMesh, &emitNormals);
+        UsdMayaMeshReadUtils::getEmitNormalsTag(finalMesh, &emitNormals);
         if (emitNormals) {
             VtArray<GfVec3f> meshNormals;
             TfToken normalInterp;
 
-            if (UsdMayaMeshUtil::getMeshNormals(
+            if (UsdMayaMeshReadUtils::getMeshNormals(
                     geomMeshObj,
                     &meshNormals,
                     &normalInterp)) {
@@ -295,7 +295,7 @@ PxrUsdTranslators_MeshWriter::writeMeshAttrs(
         }
     } else {
         // Subdivision surface - export subdiv-specific attributes.
-        TfToken sdInterpBound = UsdMayaMeshUtil::getSubdivInterpBoundary(
+        TfToken sdInterpBound = UsdMayaMeshReadUtils::getSubdivInterpBoundary(
             finalMesh);
         if (!sdInterpBound.IsEmpty()) {
             _SetAttribute(primSchema.CreateInterpolateBoundaryAttr(),
@@ -303,7 +303,7 @@ PxrUsdTranslators_MeshWriter::writeMeshAttrs(
         }
 
         TfToken sdFVLinearInterpolation =
-            UsdMayaMeshUtil::getSubdivFVLinearInterpolation(finalMesh);
+            UsdMayaMeshReadUtils::getSubdivFVLinearInterpolation(finalMesh);
         if (!sdFVLinearInterpolation.IsEmpty()) {
             _SetAttribute(primSchema.CreateFaceVaryingLinearInterpolationAttr(),
                           sdFVLinearInterpolation);

--- a/lib/usd/translators/meshWriter.cpp
+++ b/lib/usd/translators/meshWriter.cpp
@@ -45,7 +45,7 @@
 #include <mayaUsd/fileio/primWriter.h>
 #include <mayaUsd/fileio/primWriterRegistry.h>
 #include <mayaUsd/fileio/utils/adaptor.h>
-#include <mayaUsd/fileio/utils/meshUtil.h>
+#include <mayaUsd/fileio/utils/meshReadUtils.h>
 #include <mayaUsd/fileio/utils/writeUtil.h>
 #include <mayaUsd/fileio/writeJobContext.h>
 #include <mayaUsd/utils/util.h>
@@ -268,7 +268,7 @@ PxrUsdTranslators_MeshWriter::writeMeshAttrs(
 
     // Read subdiv scheme tagging. If not set, we default to defaultMeshScheme
     // flag (this is specified by the job args but defaults to catmullClark).
-    TfToken sdScheme = UsdMayaMeshUtil::GetSubdivScheme(finalMesh);
+    TfToken sdScheme = UsdMayaMeshUtil::getSubdivScheme(finalMesh);
     if (sdScheme.IsEmpty()) {
         sdScheme = _GetExportArgs().defaultMeshScheme;
     }
@@ -277,12 +277,12 @@ PxrUsdTranslators_MeshWriter::writeMeshAttrs(
     if (sdScheme == UsdGeomTokens->none) {
         // Polygonal mesh - export normals.
         bool emitNormals = true; // Default to emitting normals if no tagging.
-        UsdMayaMeshUtil::GetEmitNormalsTag(finalMesh, &emitNormals);
+        UsdMayaMeshUtil::getEmitNormalsTag(finalMesh, &emitNormals);
         if (emitNormals) {
             VtArray<GfVec3f> meshNormals;
             TfToken normalInterp;
 
-            if (UsdMayaMeshUtil::GetMeshNormals(
+            if (UsdMayaMeshUtil::getMeshNormals(
                     geomMeshObj,
                     &meshNormals,
                     &normalInterp)) {
@@ -295,7 +295,7 @@ PxrUsdTranslators_MeshWriter::writeMeshAttrs(
         }
     } else {
         // Subdivision surface - export subdiv-specific attributes.
-        TfToken sdInterpBound = UsdMayaMeshUtil::GetSubdivInterpBoundary(
+        TfToken sdInterpBound = UsdMayaMeshUtil::getSubdivInterpBoundary(
             finalMesh);
         if (!sdInterpBound.IsEmpty()) {
             _SetAttribute(primSchema.CreateInterpolateBoundaryAttr(),
@@ -303,7 +303,7 @@ PxrUsdTranslators_MeshWriter::writeMeshAttrs(
         }
 
         TfToken sdFVLinearInterpolation =
-            UsdMayaMeshUtil::GetSubdivFVLinearInterpolation(finalMesh);
+            UsdMayaMeshUtil::getSubdivFVLinearInterpolation(finalMesh);
         if (!sdFVLinearInterpolation.IsEmpty()) {
             _SetAttribute(primSchema.CreateFaceVaryingLinearInterpolationAttr(),
                           sdFVLinearInterpolation);


### PR DESCRIPTION
### PART II

- Rename meshUtil(`*.h,*.cpp`) to meshReadUtils(`*.h,*.cpp`).
- Follow coding guideline for function name ( lowerCamelCase ).
