### PR TITLE
PART V: Pixar Mesh write translator/utilities refactoring 

### DIFF
--- a/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
@@ -728,8 +728,8 @@ UsdMayaMeshUtil::assignSubDivTagsToMesh( const UsdGeomMesh& mesh,
     std::unordered_map<float,MSelectionList> elemsPerWeight;
 
     // Vert Creasing
-    VtArray<int>   subdCornerIndices;
-    VtArray<float> subdCornerSharpnesses;
+    VtIntArray   subdCornerIndices;
+    VtFloatArray subdCornerSharpnesses;
     mesh.GetCornerIndicesAttr().Get(&subdCornerIndices); // not animatable
     mesh.GetCornerSharpnessesAttr().Get(&subdCornerSharpnesses); // not animatable
     if (!subdCornerIndices.empty()) {
@@ -789,9 +789,9 @@ UsdMayaMeshUtil::assignSubDivTagsToMesh( const UsdGeomMesh& mesh,
     }
 
     // Edge Creasing
-    VtArray<int>   subdCreaseLengths;
-    VtArray<int>   subdCreaseIndices;
-    VtArray<float> subdCreaseSharpnesses;
+    VtIntArray   subdCreaseLengths;
+    VtIntArray   subdCreaseIndices;
+    VtFloatArray subdCreaseSharpnesses;
     mesh.GetCreaseLengthsAttr().Get(&subdCreaseLengths);
     mesh.GetCreaseIndicesAttr().Get(&subdCreaseIndices);
     mesh.GetCreaseSharpnessesAttr().Get(&subdCreaseSharpnesses);

--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
@@ -483,22 +483,21 @@ UsdMayaMeshWriteUtils::writePointsData(const MFnMesh& meshFn,
     const uint32_t numVertices = meshFn.numVertices();
     VtVec3fArray points(numVertices);
     const float* pointsData = meshFn.getRawPoints(&status);
-    if(status)
-    {
-        // use memcpy() to copy the data. HS April 09, 2020
-        memcpy((GfVec3f*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
 
-        VtVec3fArray extent(2);
-        // Compute the extent using the raw points
-        UsdGeomPointBased::ComputeExtent(points, &extent);
-
-        UsdMayaWriteUtil::SetAttribute(primSchema.GetPointsAttr(), &points, valueWriter, usdTime);
-        UsdMayaWriteUtil::SetAttribute(primSchema.CreateExtentAttr(), &extent, valueWriter,usdTime);
-    }
-    else
-    {
+    if(!status) {
         MGlobal::displayError(MString("Unable to access mesh vertices on mesh: ") + meshFn.fullPathName());
+        return;
     }
+    
+    // use memcpy() to copy the data. HS April 09, 2020
+    memcpy((GfVec3f*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
+
+    VtVec3fArray extent(2);
+    // Compute the extent using the raw points
+    UsdGeomPointBased::ComputeExtent(points, &extent);
+
+    UsdMayaWriteUtil::SetAttribute(primSchema.GetPointsAttr(), &points, valueWriter, usdTime);
+    UsdMayaWriteUtil::SetAttribute(primSchema.CreateExtentAttr(), &extent, valueWriter,usdTime);
 }
 
 void 

--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
@@ -36,6 +36,7 @@
 #include <pxr/base/tf/token.h>
 #include <pxr/base/vt/array.h>
 #include <pxr/usd/usdGeom/mesh.h>
+#include <pxr/usd/usdGeom/pointBased.h>
 #include <pxr/usd/usdGeom/primvar.h>
 #include <pxr/usd/usdGeom/tokens.h>
 #include <pxr/usd/usdUtils/pipeline.h>
@@ -474,6 +475,78 @@ UsdMayaMeshUtil::assignSubDivTagsToUSDPrim(MFnMesh& meshFn,
                 creaseSharpnessesVt.begin());
             UsdMayaWriteUtil::SetAttribute(primSchema.GetCreaseSharpnessesAttr(), &creaseSharpnessesVt, valueWriter);
         }
+    }
+}
+
+void
+UsdMayaMeshUtil::writeVertexData(const MFnMesh& meshFn,
+                                 UsdGeomMesh& primSchema,
+                                 const UsdTimeCode& usdTime,
+                                 UsdUtilsSparseValueWriter& valueWriter)
+{
+    MStatus status{MS::kSuccess};
+
+    const uint32_t numVertices = meshFn.numVertices();
+    VtArray<GfVec3f> points(numVertices);
+    const float* pointsData = meshFn.getRawPoints(&status);
+    if(status)
+    {
+        // use memcpy() to copy the data. HS April 09, 2020
+        memcpy((GfVec3f*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
+
+        VtArray<GfVec3f> extent(2);
+        // Compute the extent using the raw points
+        UsdGeomPointBased::ComputeExtent(points, &extent);
+
+        UsdMayaWriteUtil::SetAttribute(primSchema.GetPointsAttr(), &points, valueWriter, usdTime);
+        UsdMayaWriteUtil::SetAttribute(primSchema.CreateExtentAttr(), &extent, valueWriter,usdTime);
+    }
+    else
+    {
+        MGlobal::displayError(MString("Unable to access mesh vertices on mesh: ") + meshFn.fullPathName());
+    }
+}
+
+void 
+UsdMayaMeshUtil::writeFaceVertexIndicesData(const MFnMesh& meshFn, 
+                                            UsdGeomMesh& primSchema, 
+                                            const UsdTimeCode& usdTime, 
+                                            UsdUtilsSparseValueWriter& valueWriter)
+{
+    const int numFaceVertices = meshFn.numFaceVertices();
+    const int numPolygons = meshFn.numPolygons();
+
+    VtArray<int> faceVertexCounts(numPolygons);
+    VtArray<int> faceVertexIndices(numFaceVertices);
+    MIntArray mayaFaceVertexIndices; // used in loop below
+    unsigned int curFaceVertexIndex = 0;
+    for (int i = 0; i < numPolygons; i++) {
+        meshFn.getPolygonVertices(i, mayaFaceVertexIndices);
+        faceVertexCounts[i] = mayaFaceVertexIndices.length();
+        for (unsigned int j=0; j < mayaFaceVertexIndices.length(); j++) {
+            faceVertexIndices[ curFaceVertexIndex ] = mayaFaceVertexIndices[j]; // push_back
+            curFaceVertexIndex++;
+        }
+    }
+    UsdMayaWriteUtil::SetAttribute(primSchema.GetFaceVertexCountsAttr(), &faceVertexCounts, valueWriter, usdTime);
+    UsdMayaWriteUtil::SetAttribute(primSchema.GetFaceVertexIndicesAttr(), &faceVertexIndices, valueWriter, usdTime);
+}
+
+void 
+UsdMayaMeshUtil::writeInvisibleFacesData(const MFnMesh& meshFn, 
+                                         UsdGeomMesh& primSchema, 
+                                         UsdUtilsSparseValueWriter& valueWriter)
+{
+    MUintArray mayaHoles = meshFn.getInvisibleFaces();
+    const uint32_t count = mayaHoles.length();
+    if (count)
+    {
+        VtArray<int32_t> subdHoles(count);
+        uint32_t* ptr = &mayaHoles[0];
+        // use memcpy() to copy the data. HS April 20, 2019
+        memcpy((int32_t*)subdHoles.data(), ptr, count * sizeof(uint32_t));
+        // not animatable in Maya, so we'll set default only
+        UsdMayaWriteUtil::SetAttribute(primSchema.GetHoleIndicesAttr(), &subdHoles, valueWriter);
     }
 }
 

--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
@@ -149,7 +149,7 @@ namespace
 
 bool
 UsdMayaMeshWriteUtils::getMeshNormals(const MFnMesh& mesh,
-                                      VtArray<GfVec3f>* normalsArray,
+                                      VtVec3fArray* normalsArray,
                                       TfToken* interpolation)
 {
     MStatus status{MS::kSuccess};
@@ -382,7 +382,7 @@ UsdMayaMeshWriteUtils::exportReferenceMesh(UsdGeomMesh& primSchema, MObject obj)
 
     const float* mayaRawPoints = referenceMesh.getRawPoints(&status);
     const int numVertices = referenceMesh.numVertices();
-    VtArray<GfVec3f> points(numVertices);
+    VtVec3fArray points(numVertices);
 
     memcpy(points.data(), mayaRawPoints, numVertices * sizeof(float) * 3);
 
@@ -481,14 +481,14 @@ UsdMayaMeshWriteUtils::writePointsData(const MFnMesh& meshFn,
     MStatus status{MS::kSuccess};
 
     const uint32_t numVertices = meshFn.numVertices();
-    VtArray<GfVec3f> points(numVertices);
+    VtVec3fArray points(numVertices);
     const float* pointsData = meshFn.getRawPoints(&status);
     if(status)
     {
         // use memcpy() to copy the data. HS April 09, 2020
         memcpy((GfVec3f*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
 
-        VtArray<GfVec3f> extent(2);
+        VtVec3fArray extent(2);
         // Compute the extent using the raw points
         UsdGeomPointBased::ComputeExtent(points, &extent);
 
@@ -510,8 +510,8 @@ UsdMayaMeshWriteUtils::writeFaceVertexIndicesData(const MFnMesh& meshFn,
     const int numFaceVertices = meshFn.numFaceVertices();
     const int numPolygons = meshFn.numPolygons();
 
-    VtArray<int> faceVertexCounts(numPolygons);
-    VtArray<int> faceVertexIndices(numFaceVertices);
+    VtIntArray faceVertexCounts(numPolygons);
+    VtIntArray faceVertexIndices(numFaceVertices);
     MIntArray mayaFaceVertexIndices; // used in loop below
     unsigned int curFaceVertexIndex = 0;
     for (int i = 0; i < numPolygons; i++) {
@@ -535,7 +535,7 @@ UsdMayaMeshWriteUtils::writeInvisibleFacesData(const MFnMesh& meshFn,
     const uint32_t count = mayaHoles.length();
     if (count)
     {
-        VtArray<int32_t> subdHoles(count);
+        VtIntArray subdHoles(count);
         uint32_t* ptr = &mayaHoles[0];
         // use memcpy() to copy the data. HS April 20, 2019
         memcpy((int32_t*)subdHoles.data(), ptr, count * sizeof(uint32_t));

--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.h
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.h
@@ -44,7 +44,7 @@ namespace UsdMayaMeshWriteUtils
     /// Helper method for getting Maya mesh normals as a VtVec3fArray.
     MAYAUSD_CORE_PUBLIC
     bool getMeshNormals(const MFnMesh& mesh, 
-                        VtArray<GfVec3f>* normalsArray, 
+                        VtVec3fArray* normalsArray, 
                         TfToken* interpolation);
 
     /// Gets the subdivision scheme tagged for the Maya mesh by consulting the

--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.h
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.h
@@ -39,11 +39,13 @@ PXR_NAMESPACE_OPEN_SCOPE
 class UsdGeomMesh;
 
 // Utilities for dealing with writing USD from Maya mesh/subdiv tags.
-namespace UsdMayaMeshUtil
+namespace UsdMayaMeshWriteUtils
 {
     /// Helper method for getting Maya mesh normals as a VtVec3fArray.
     MAYAUSD_CORE_PUBLIC
-    bool getMeshNormals(const MFnMesh& mesh, VtArray<GfVec3f>* normalsArray, TfToken* interpolation);
+    bool getMeshNormals(const MFnMesh& mesh, 
+                        VtArray<GfVec3f>* normalsArray, 
+                        TfToken* interpolation);
 
     /// Gets the subdivision scheme tagged for the Maya mesh by consulting the
     /// adaptor for \c UsdGeomMesh.subdivisionSurface, and then falling back to
@@ -65,24 +67,34 @@ namespace UsdMayaMeshUtil
     TfToken getSubdivFVLinearInterpolation(const MFnMesh& mesh);
 
     MAYAUSD_CORE_PUBLIC
-    bool isMeshValid(const MDagPath&);
+    bool isMeshValid(const MDagPath& dagPath);
 
     MAYAUSD_CORE_PUBLIC
-    void exportReferenceMesh(UsdGeomMesh&, MObject);
+    void exportReferenceMesh(UsdGeomMesh& primSchema, MObject obj);
 
     MAYAUSD_CORE_PUBLIC
-    void assignSubDivTagsToUSDPrim(MFnMesh&, UsdGeomMesh&, UsdUtilsSparseValueWriter&);
+    void assignSubDivTagsToUSDPrim(MFnMesh& meshFn,
+                                   UsdGeomMesh& primSchema,
+                                   UsdUtilsSparseValueWriter& valueWriter);
 
     MAYAUSD_CORE_PUBLIC
-    void writeVertexData(const MFnMesh&, UsdGeomMesh&, const UsdTimeCode&, UsdUtilsSparseValueWriter&);
+    void writePointsData(const MFnMesh& meshFn,
+                         UsdGeomMesh& primSchema,
+                         const UsdTimeCode& usdTime,
+                         UsdUtilsSparseValueWriter& valueWriter);
 
     MAYAUSD_CORE_PUBLIC
-    void writeFaceVertexIndicesData(const MFnMesh&, UsdGeomMesh&, const UsdTimeCode&, UsdUtilsSparseValueWriter&);
+    void writeFaceVertexIndicesData(const MFnMesh& meshFn,
+                                    UsdGeomMesh& primSchema,
+                                    const UsdTimeCode& usdTime,
+                                    UsdUtilsSparseValueWriter& valueWriter);
 
     MAYAUSD_CORE_PUBLIC
-    void writeInvisibleFacesData(const MFnMesh&, UsdGeomMesh&, UsdUtilsSparseValueWriter&);
+    void writeInvisibleFacesData(const MFnMesh& meshFn,
+                                 UsdGeomMesh& primSchema,
+                                 UsdUtilsSparseValueWriter& valueWriter);
 
-} // namespace UsdMayaMeshUtil
+} // namespace UsdMayaMeshWriteUtils
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.h
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.h
@@ -73,6 +73,15 @@ namespace UsdMayaMeshUtil
     MAYAUSD_CORE_PUBLIC
     void assignSubDivTagsToUSDPrim(MFnMesh&, UsdGeomMesh&, UsdUtilsSparseValueWriter&);
 
+    MAYAUSD_CORE_PUBLIC
+    void writeVertexData(const MFnMesh&, UsdGeomMesh&, const UsdTimeCode&, UsdUtilsSparseValueWriter&);
+
+    MAYAUSD_CORE_PUBLIC
+    void writeFaceVertexIndicesData(const MFnMesh&, UsdGeomMesh&, const UsdTimeCode&, UsdUtilsSparseValueWriter&);
+
+    MAYAUSD_CORE_PUBLIC
+    void writeInvisibleFacesData(const MFnMesh&, UsdGeomMesh&, UsdUtilsSparseValueWriter&);
+
 } // namespace UsdMayaMeshUtil
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/utils/writeUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/writeUtil.cpp
@@ -1211,7 +1211,7 @@ UsdMayaWriteUtil::WriteArrayAttrsToInstancer(
                 "objectIndex", &status);
         CHECK_MSTATUS_AND_RETURN(status, false);
 
-        VtArray<int> vtArray = _MapMayaToVtArray<MDoubleArray, double, int>(
+        VtIntArray vtArray = _MapMayaToVtArray<MDoubleArray, double, int>(
             objectIndex,
             [numPrototypes](double x) {
                 if (x < numPrototypes) {
@@ -1226,7 +1226,7 @@ UsdMayaWriteUtil::WriteArrayAttrsToInstancer(
                       usdTime, valueWriter);
     }
     else {
-        VtArray<int> vtArray;
+        VtIntArray vtArray;
         vtArray.assign(numInstances, 0);
         _SetAttribute(instancer.CreateProtoIndicesAttr(),
                       vtArray, usdTime, valueWriter);

--- a/lib/usd/translators/meshWriter.cpp
+++ b/lib/usd/translators/meshWriter.cpp
@@ -160,44 +160,12 @@ PxrUsdTranslators_MeshWriter::writeMeshAttrs(
         return true;
     }
 
-    unsigned int numVertices = geomMesh.numVertices();
-    unsigned int numPolygons = geomMesh.numPolygons();
-
     // Set mesh attrs ==========
-    // Get points
-    // TODO: Use memcpy()
-    const float* mayaRawPoints = geomMesh.getRawPoints(&status);
-    VtArray<GfVec3f> points(numVertices);
-    for (unsigned int i = 0; i < numVertices; i++) {
-        unsigned int floatIndex = i*3;
-        points[i].Set(mayaRawPoints[floatIndex],
-                      mayaRawPoints[floatIndex+1],
-                      mayaRawPoints[floatIndex+2]);
-    }
+    // Write points
+    UsdMayaMeshUtil::writeVertexData(geomMesh, primSchema, usdTime, *_GetSparseValueWriter());
 
-    VtArray<GfVec3f> extent(2);
-    // Compute the extent using the raw points
-    UsdGeomPointBased::ComputeExtent(points, &extent);
-
-    _SetAttribute(primSchema.GetPointsAttr(), &points, usdTime);
-    _SetAttribute(primSchema.CreateExtentAttr(), &extent, usdTime);
-
-    // Get faceVertexIndices
-    unsigned int numFaceVertices = geomMesh.numFaceVertices(&status);
-    VtArray<int>     faceVertexCounts(numPolygons);
-    VtArray<int>     faceVertexIndices(numFaceVertices);
-    MIntArray mayaFaceVertexIndices; // used in loop below
-    unsigned int curFaceVertexIndex = 0;
-    for (unsigned int i = 0; i < numPolygons; i++) {
-        geomMesh.getPolygonVertices(i, mayaFaceVertexIndices);
-        faceVertexCounts[i] = mayaFaceVertexIndices.length();
-        for (unsigned int j=0; j < mayaFaceVertexIndices.length(); j++) {
-            faceVertexIndices[ curFaceVertexIndex ] = mayaFaceVertexIndices[j]; // push_back
-            curFaceVertexIndex++;
-        }
-    }
-    _SetAttribute(primSchema.GetFaceVertexCountsAttr(), &faceVertexCounts, usdTime);
-    _SetAttribute(primSchema.GetFaceVertexIndicesAttr(), &faceVertexIndices, usdTime);
+    // Write faceVertexIndices
+    UsdMayaMeshUtil::writeFaceVertexIndicesData(geomMesh, primSchema, usdTime, *_GetSparseValueWriter());
 
     // Read subdiv scheme tagging. If not set, we default to defaultMeshScheme
     // flag (this is specified by the job args but defaults to catmullClark).


### PR DESCRIPTION
### PART V
Created 3 utility functions for writing Maya mesh data to USD:

- vertex positions
- face/vertex indices
- invisible faces

Removed the "TODO: Use memcpy()" and used memcpy to copy the data directly.