### PR TITLE
MAYA-103876 - Update expected failing tests

### DIFF
--- a/test/lib/ufe/testMoveCmd.py
+++ b/test/lib/ufe/testMoveCmd.py
@@ -175,6 +175,19 @@ class MoveCmdTestCase(testTRSBase.TRSTestCaseBase):
 
         self.runTestMove(expected)
 
+    # MAYA-96058: unfortunately, the move command currently requires a move
+    # manipulator to be created to update the UFE object, but such a
+    # manipulator cannot be created in batch mode, thus the move command will
+    # not work properly  
+    #
+    # This test is expected to fail until the underlying issue can be addressed
+    #
+    # The first test cases fails because the initial translation is not the same
+    # as the default translation, and since all translations are applied to the
+    # default translation, they do not compound because of MAYA-96058.
+    # test cases will fail.
+    #
+    @unittest.expectedFailure
     def testMoveUSD(self):
         '''Move USD object, read through the Transform3d interface.'''
 

--- a/test/lib/ufe/testRotateCmd.py
+++ b/test/lib/ufe/testRotateCmd.py
@@ -180,6 +180,10 @@ class RotateCmdTestCase(testTRSBase.TRSTestCaseBase):
     # Note: marked as expected failure as sometimes it passes and sometimes it fails
     #       with something like:
     #       AssertionError: -0.5235987755982988 != -0.4220828456501826 within 7 places
+    # The first test cases passes because the initial rotation is the same as
+    # the default rotation, but subsequent rotations are applied to the default
+    # rotation, and thus do not compound because of MAYA-96058.
+    #
     @unittest.expectedFailure
     def testRotateUSD(self):
         '''Rotate USD object, read through the Transform3d interface.'''
@@ -217,7 +221,11 @@ class RotateCmdTestCase(testTRSBase.TRSTestCaseBase):
         expected = ball35Rotation()
 
         # MAYA-96058: unfortunately, rotate command currently requires a rotate
-        # manipulator to be created to update the UFE object.
+        # manipulator to be created to update the UFE object, but such a
+        # manipulator cannot be created in batch mode, thus the rotate command
+        # will not work properly. This test is expected to fail until the
+        # underlying issue can be addressed.
+        #
         manipCtx = cmds.manipRotateContext()
         cmds.setToolTo(manipCtx)
 

--- a/test/lib/ufe/testScaleCmd.py
+++ b/test/lib/ufe/testScaleCmd.py
@@ -173,6 +173,11 @@ class ScaleCmdTestCase(testTRSBase.TRSTestCaseBase):
 
     # Note: marking as expected failure for now as sometimes it passes and
     #       sometimes it fails with: AssertionError: 0.5 != 2.0 within 7 places
+    #
+    # The first test cases passes because the initial scale is the same as
+    # the default scale, but subsequent scales are applied to the default
+    # scale, and thus do not compound because of MAYA-96058.
+    #
     @unittest.expectedFailure
     def testScaleUSD(self):
         '''Scale USD object, read through the Transform3d interface.'''
@@ -209,7 +214,11 @@ class ScaleCmdTestCase(testTRSBase.TRSTestCaseBase):
         expected = ball35Scale()
 
         # MAYA-96058: unfortunately, scale command currently requires a scale
-        # manipulator to be created to update the UFE object.
+        # manipulator to be created to update the UFE object, but such a
+        # manipulator cannot be created in batch mode, thus the scale command
+        # will not work properly. This test is expected to fail until the
+        # underlying issue can be addressed.
+        #
         manipCtx = cmds.manipScaleContext()
         cmds.setToolTo(manipCtx)
 


### PR DESCRIPTION
The workaround added to testScaleCmd.py and testRotateCmd.py
cannot work in batch mode, because manipulators can only be
created in GUI mode. Added further comments, and marked testMoveUsd in
testMoveCmd.py as an expected failure, due to an upcoming fix in the
underlying Maya code.