### PR TITLE
Failure to create shader instance when running command-line render

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapePlugin.cpp
+++ b/lib/mayaUsd/nodes/proxyShapePlugin.cpp
@@ -121,9 +121,6 @@ MayaUsdProxyShapePlugin::initialize(MFnPlugin& plugin)
         CHECK_MSTATUS(status);
     }
 
-    status = HdVP2ShaderFragments::registerFragments();
-    CHECK_MSTATUS(status);
-
     return status;
 }
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
@@ -127,6 +127,9 @@ namespace
         */
         void Initialize()
         {
+            if (_isInitialized)
+                return;
+
             MHWRender::MRenderer* renderer = MHWRender::MRenderer::theRenderer();
             const MHWRender::MShaderManager* shaderMgr =
                 renderer ? renderer->getShaderManager() : nullptr;
@@ -153,6 +156,8 @@ namespace
                 _3dFatPointShader->setParameter(_solidColorParameterName, white);
                 _3dFatPointShader->setParameter(_pointSizeParameterName, size);
             }
+
+            _isInitialized = true;
         }
 
         /*! \brief  Returns a fallback CPV shader instance when no material is bound.
@@ -281,6 +286,8 @@ namespace
         }
 
     private:
+        bool                    _isInitialized { false };  //!< Whether the shader cache is initialized
+
         //! Shader registry used by fallback shaders
         MShaderMap              _fallbackShaders[static_cast<size_t>(FallbackShaderType::kCount)];
         MShaderMap              _3dSolidShaders;
@@ -289,6 +296,8 @@ namespace
         MHWRender::MShaderInstance*  _3dFatPointShader { nullptr };  //!< 3d shader for points
         MHWRender::MShaderInstance*  _3dCPVSolidShader { nullptr };  //!< 3d CPV solid-color shader
     };
+
+    MShaderCache sShaderCache;  //!< Global shader cache to minimize the number of unique shaders.
 
     /*! \brief  Sampler state desc hash helper class, used by sampler state cache.
     */
@@ -354,25 +363,7 @@ namespace
     MSamplerStateCache sSamplerStates;  //!< Sampler state cache
     tbb::spin_rw_mutex sSamplerRWMutex; //!< Synchronization used to protect concurrent read from serial writes
 
-    MShaderCache sShaderCache;                      //!< Global shader cache to minimize the number of unique shaders.
     const HdVP2BBoxGeom* sSharedBBoxGeom = nullptr; //!< Shared geometry for all Rprims to display bounding box
-    std::once_flag sInitializeVP2ResourcesCalled;   //!< Whether or not InitializeVP2Resources() has been called.
-
-    void InitializeVP2Resources()
-    {
-        // Shader fragments can only be registered until VP2 has been initialized, thus the function
-        // cannot be called when loading plugin (which can happen before VP2 initialization for
-        // command-line render). The fragments will be deregistered when plugin is unloaded.
-        HdVP2ShaderFragments::registerFragments();
-
-        // The shader cache should be initialized after registering shader fragments.
-        sShaderCache.Initialize();
-
-        // HdVP2BBoxGeom can only be instantiated from main thread until VP2 has been initialized.
-        if (TF_VERIFY(sSharedBBoxGeom == nullptr)) {
-            sSharedBBoxGeom = new HdVP2BBoxGeom();
-        }
-    }
 
 } // namespace
 
@@ -396,11 +387,25 @@ HdVP2RenderDelegate::HdVP2RenderDelegate(ProxyRenderDelegate& drawScene) {
     std::lock_guard<std::mutex> guard(_renderDelegateMutex);
     if (_renderDelegateCounter.fetch_add(1) == 0) {
         _resourceRegistry.reset(new HdResourceRegistry());
+
+        // HdVP2BBoxGeom can only be instantiated during the lifetime of VP2
+        // renderer from main thread. HdVP2RenderDelegate is created from main
+        // thread currently, if we need to make its creation parallel in the
+        // future we should move this code out.
+        if (TF_VERIFY(sSharedBBoxGeom == nullptr)) {
+            sSharedBBoxGeom = new HdVP2BBoxGeom();
+        }
     }
 
-    std::call_once(sInitializeVP2ResourcesCalled, InitializeVP2Resources);
-
     _renderParam.reset(new HdVP2RenderParam(drawScene));
+
+    // Shader fragments can only be registered after VP2 initialization, thus the function cannot
+    // be called when loading plugin (which can happen before VP2 initialization in the case of
+    // command-line rendering). The fragments will be deregistered when plugin is unloaded.
+    HdVP2ShaderFragments::registerFragments();
+
+    // The shader cache should be initialized after registration of shader fragments.
+    sShaderCache.Initialize();
 }
 
 /*! \brief  Destructor.

--- a/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.cpp
+++ b/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.cpp
@@ -130,22 +130,24 @@ namespace
     }
 }
 
-// Fragment registration
+bool HdVP2ShaderFragments::_registered = false;
+
+// Fragment registration should be done until VP2 has been initialized, to avoid any errors from
+// headless configurations or command-line renders.
 MStatus HdVP2ShaderFragments::registerFragments()
 {
-    // We do not force the renderer to initialize in case we're running in a
-    // headless context. If we cannot get a handle to the renderer or the
-    // fragment manager, we assume that's the case and simply return success.
-    MHWRender::MRenderer* theRenderer =
-        MHWRender::MRenderer::theRenderer(/* initializeRenderer = */ false);
-    if (!theRenderer) {
+    if (_registered)
         return MS::kSuccess;
+
+    MHWRender::MRenderer* theRenderer = MHWRender::MRenderer::theRenderer();
+    if (!theRenderer) {
+        return MS::kFailure;
     }
 
     MHWRender::MFragmentManager* fragmentManager =
         theRenderer->getFragmentManager();
     if (!fragmentManager) {
-        return MS::kSuccess;
+        return MS::kFailure;
     }
 
     std::string language;
@@ -237,20 +239,18 @@ MStatus HdVP2ShaderFragments::registerFragments()
 // Fragment deregistration
 MStatus HdVP2ShaderFragments::deregisterFragments()
 {
-    // Similar to registration, we do not force the renderer to initialize in
-    // case we're running in a headless context. If we cannot get a handle to
-    // the renderer or the fragment manager, we assume that's the case and
-    // simply return success.
-    MHWRender::MRenderer* theRenderer =
-        MHWRender::MRenderer::theRenderer(/* initializeRenderer = */ false);
-    if (!theRenderer) {
+    if (!_registered)
         return MS::kSuccess;
+
+    MHWRender::MRenderer* theRenderer = MHWRender::MRenderer::theRenderer();
+    if (!theRenderer) {
+        return MS::kFailure;
     }
 
     MHWRender::MFragmentManager* fragmentManager =
         theRenderer->getFragmentManager();
     if (!fragmentManager) {
-        return MS::kSuccess;
+        return MS::kFailure;
     }
 
     // De-register all fragment graphs.

--- a/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.cpp
+++ b/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.cpp
@@ -132,7 +132,7 @@ namespace
 
 bool HdVP2ShaderFragments::_registered = false;
 
-// Fragment registration should be done until VP2 has been initialized, to avoid any errors from
+// Fragment registration should be done after VP2 has been initialized, to avoid any errors from
 // headless configurations or command-line renders.
 MStatus HdVP2ShaderFragments::registerFragments()
 {
@@ -233,6 +233,8 @@ MStatus HdVP2ShaderFragments::registerFragments()
         }
     }
 
+    _registered = true;
+
     return MS::kSuccess;
 }
 
@@ -276,6 +278,8 @@ MStatus HdVP2ShaderFragments::deregisterFragments()
             return MS::kFailure;
         }
     }
+
+    _registered = false;
 
 #if MAYA_API_VERSION >= 201700
     // Clear the shader manager's effect cache as well so that any changes to

--- a/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.h
+++ b/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.h
@@ -22,17 +22,21 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-/*! \brief  
+/*! \brief  Registration/deregistration of HdVP2 shader fragments.
     \class  HdVP2ShaderFragments
 */
 class HdVP2ShaderFragments
 {
 public:
-    // Loads all fragments into VP2
+    //! Register all HdVP2 fragments
     static MStatus registerFragments();
 
-    // Unload all fragments from VP2
+    //! Deregister all HdVP2 fragments
     static MStatus deregisterFragments();
+
+private:
+    //! Whether or not fragments have been registered.
+    static bool _registered;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
The failure to create shader instance when running command-line render was a regression caused by #130 and a block for us to deploy automated render tests.

When running command-line render, plugin loading happens before VP2 is initialized. Because fragment registration relies on the access to the fragment manager which is created during VP2 initialization, we will have to delay the fragment registration until when it is needed instead of doing it at plugin loading.

PS: The last time I tested #130 and the command-line render worked because there was some other plugin forcing VP2 initialization to be done earlier. We don't want to force initialization of VP2 during plugin load, for compatibility with headless config used by other partners.