### PR TITLE
MAYA-101454 Clear stage cach on file new/open.

### DIFF
--- a/lib/mayaUsd/listeners/notice.cpp
+++ b/lib/mayaUsd/listeners/notice.cpp
@@ -24,7 +24,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 namespace {
 
-// Siple ref count for how many plugins have initialized the callback.
+// Simple ref count for how many plugins have initialized the callback.
 // Used to keep the listener around until the last plugin asks for it
 // to be removed.
 static int _newOrOpenRegistrationCount = 0;

--- a/lib/mayaUsd/listeners/notice.cpp
+++ b/lib/mayaUsd/listeners/notice.cpp
@@ -24,6 +24,11 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 namespace {
 
+// Siple ref count for how many plugins have initialized the callback.
+// Used to keep the listener around until the last plugin asks for it
+// to be removed.
+static int _newOrOpenRegistrationCount = 0;
+
 static
 void
 _OnMayaNewOrOpenSceneCallback(void* /*clientData*/)
@@ -53,6 +58,10 @@ UsdMayaSceneResetNotice::UsdMayaSceneResetNotice()
 void
 UsdMayaSceneResetNotice::InstallListener()
 {
+    if (_newOrOpenRegistrationCount++ > 0) {
+        return;
+    }
+
     // Send scene reset notices when changing scenes (either by switching
     // to a new empty scene or by opening a different scene). We do not listen
     // for kSceneUpdate messages since those are also emitted after a SaveAs
@@ -79,6 +88,10 @@ UsdMayaSceneResetNotice::InstallListener()
 void
 UsdMayaSceneResetNotice::RemoveListener()
 {
+    if (_newOrOpenRegistrationCount-- > 1) {
+        return;
+    }
+    
     if (_afterNewCallbackId != 0) {
         MMessage::removeCallback(_afterNewCallbackId);
     }

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -23,6 +23,7 @@
 #include <pxr/base/plug/plugin.h>
 #include <pxr/base/plug/registry.h>
 
+#include <mayaUsd/listeners/notice.h>
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/nodes/proxyShapePlugin.h>
@@ -134,6 +135,8 @@ MStatus initializePlugin(MObject obj)
         }
     }
 
+    UsdMayaSceneResetNotice::InstallListener();
+
     return status;
 }
 
@@ -180,5 +183,7 @@ MStatus uninitializePlugin(MObject obj)
     CHECK_MSTATUS(status);
 #endif
 
+    UsdMayaSceneResetNotice::RemoveListener();
+    
     return status;
 }


### PR DESCRIPTION
This is a small change that reuses existing code that will reset the stage cache on New or Open, fixing some logged issues.  It is not a complete fix for how we deal with the cache though, e.g. deleting the proxy shape and re-importing the same USD file will still show you the cached version which is probably unexpected.  The listener here is only called on File -> New and Open.

We do plan on looking at how the Animal Logic plugin deals with this kind of thing and will most likely refactor some of that into the core lib to be shared by all plugins, but for right now this is an easy change that should help in a couple obvious workflows.