### PR TITLE
upgrade maya-usd project to the C++14 standard

### DIFF
--- a/cmake/defaults/CXXDefaults.cmake
+++ b/cmake/defaults/CXXDefaults.cmake
@@ -20,8 +20,7 @@ include(Options)
 # Require C++14 if we're either building for Maya 2019 or later, or if we're
 # building against USD 20.05 or later. Otherwise require C++11.
 if ((MAYA_APP_VERSION VERSION_GREATER_EQUAL 2019) OR
-        ((DEFINED USD_VERSION_NUM) AND
-         (USD_VERSION_NUM VERSION_GREATER_EQUAL 2005)))
+        (USD_VERSION_NUM VERSION_GREATER_EQUAL 2005))
     set(CMAKE_CXX_STANDARD 14)
 else()
     set(CMAKE_CXX_STANDARD 11)
@@ -59,9 +58,7 @@ if (PXR_OVERRIDE_PLUGINPATH_NAME)
     _add_define("PXR_PLUGINPATH_NAME=${PXR_OVERRIDE_PLUGINPATH_NAME}")
 endif()
 
-if (DEFINED USD_VERSION_NUM)
-    _add_define("USD_VERSION_NUM=${USD_VERSION_NUM}")
-endif()
+_add_define("USD_VERSION_NUM=${USD_VERSION_NUM}")
 
 if (DEFINED UFE_PREVIEW_VERSION_NUM)
     _add_define("UFE_PREVIEW_VERSION_NUM=${UFE_PREVIEW_VERSION_NUM}")

--- a/cmake/defaults/CXXDefaults.cmake
+++ b/cmake/defaults/CXXDefaults.cmake
@@ -17,6 +17,19 @@ include(CXXHelpers)
 include(Version)
 include(Options)
 
+# Require C++14 if we're either building for Maya 2019 or later, or if we're
+# building against USD 20.05 or later. Otherwise require C++11.
+if ((MAYA_APP_VERSION VERSION_GREATER_EQUAL 2019) OR
+        ((DEFINED USD_VERSION_NUM) AND
+         (USD_VERSION_NUM VERSION_GREATER_EQUAL 2005)))
+    set(CMAKE_CXX_STANDARD 14)
+else()
+    set(CMAKE_CXX_STANDARD 11)
+endif()
+
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 if (CMAKE_COMPILER_IS_GNUCXX)
     include(gccdefaults)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")

--- a/cmake/defaults/gccclangshareddefaults.cmake
+++ b/cmake/defaults/gccclangshareddefaults.cmake
@@ -19,9 +19,6 @@
 # to remain minimal, marking the points where divergence is required.
 include(Options)
 
-# Turn on C++11; pxr won't build without it. 
-set(_PXR_GCC_CLANG_SHARED_CXX_FLAGS "${_PXR_GCC_CLANG_SHARED_CXX_FLAGS} -std=c++11")
-
 # Enable all warnings.
 set(_PXR_GCC_CLANG_SHARED_CXX_FLAGS "${_PXR_GCC_CLANG_SHARED_CXX_FLAGS} -Wall")
 

--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -115,6 +115,8 @@ find_package_handle_standard_args(USD
         USD_LIBRARY_DIR
         USD_GENSCHEMA
         USD_CONFIG_FILE
+        USD_VERSION
+        USD_VERSION_NUM
     VERSION_VAR
         USD_VERSION
 )


### PR DESCRIPTION
Re-opening this from the original #395 pull request...

Conforming to VFX Reference Platform CY2018+ and following suit from core USD, this change sets the maya-usd project to use the C++14 standard if we're either building for Maya 2019 or later, or if we're building against USD 20.05 or later.

Core USD moved to C++14 with release 20.05 in this commit:
https://github.com/PixarAnimationStudios/USD/commit/afc0d5e3d45eeaf6579b9699250da37cd9149c6f