### PR TITLE
Fix compilation error on gcc 9.1

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -164,7 +164,8 @@ namespace {
                 }
 
                 if (channelOffset == 0 && sizeof(DEST_TYPE) == sizeof(SRC_TYPE)) {
-                    memcpy(vertexBuffer, primvarData.cdata(), sizeof(DEST_TYPE) * numVertices);
+                    const void* source = static_cast<const void*>(primvarData.cdata());
+                    memcpy(vertexBuffer, source, sizeof(DEST_TYPE) * numVertices);
                 }
                 else {
                     for (size_t v = 0; v < numVertices; v++) {
@@ -244,7 +245,8 @@ namespace {
                     }
 
                     if (channelOffset == 0 && sizeof(DEST_TYPE) == sizeof(SRC_TYPE)) {
-                        memcpy(vertexBuffer, primvarData.cdata(), sizeof(DEST_TYPE) * numVertices);
+                        const void* source = static_cast<const void*>(primvarData.cdata());
+                        memcpy(vertexBuffer, source, sizeof(DEST_TYPE) * numVertices);
                     }
                     else {
                         for (size_t v = 0; v < numVertices; v++) {


### PR DESCRIPTION
This commit is to fix the following compilation error with gcc 9.1:

‘void* memcpy(void*, const void*, size_t)’ copying an object
of type ‘class pxrInternal_v0_20__pxrReserved__::GfVec4f’ with
‘private’ member ‘pxrInternal_v0_20__pxrReserved__::GfVec4f::_data’
from an array of ‘const class pxrInternal_v0_20__pxrReserved__::GfVec3f’;
use assignment or copy-initialization instead [-Werror=class-memaccess]