### PR TITLE
plugin/pxr is now adopting mayaUsd_compile_config routine

### DIFF
--- a/plugin/pxr/CMakeLists.txt
+++ b/plugin/pxr/CMakeLists.txt
@@ -9,31 +9,10 @@ set(PXR_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}/${INSTALL_DIR_SUFFIX})
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
     ${PROJECT_SOURCE_DIR}/cmake/modules
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/macros
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/defaults
 )
 
-include(Version)
-include(Options)
 include(Public)
 pxr_setup_python()
-
-#------------------------------------------------------------------------------
-# compiler configuration
-#------------------------------------------------------------------------------
-# CXXDefaults will set a variety of variables for the project.
-# Consume them here. This is an effort to keep the most common
-# build files readable.
-include(CXXDefaults)
-add_definitions(${_PXR_CXX_DEFINITIONS} -DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE)
-set(CMAKE_CXX_FLAGS "${_PXR_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
-
-if(NOT WIN32)
-    set(CMAKE_CXX_FLAGS
-        -msse3
-        "${CMAKE_CXX_FLAGS} ${_PXR_CXX_FLAGS}"
-    )
-endif()
-string(REPLACE ";" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
 #==============================================================================
 # subdirectory

--- a/plugin/pxr/cmake/macros/Private.cmake
+++ b/plugin/pxr/cmake/macros/Private.cmake
@@ -854,6 +854,10 @@ function(_pxr_python_module NAME)
         SHARED
         ${args_CPPFILES}
     )
+
+    # compiler configuration
+    mayaUsd_compile_config(${LIBRARY_NAME})
+
     add_dependencies(python ${LIBRARY_NAME})
     if(args_PYTHON_FILES)
         add_dependencies(${LIBRARY_NAME} ${LIBRARY_NAME}_pythonfiles)
@@ -1072,6 +1076,9 @@ function(_pxr_library NAME)
             ${args_PRIVATE_HEADERS}
         )
     endif()
+
+    # compiler configuration
+    mayaUsd_compile_config(${NAME})
 
     #
     # Compute names and paths.

--- a/plugin/pxr/cmake/macros/Public.cmake
+++ b/plugin/pxr/cmake/macros/Public.cmake
@@ -262,6 +262,9 @@ function(pxr_build_test_shared_lib LIBRARY_NAME)
                 FOLDER "${folder}"
         )
 
+        # compiler configuration
+        mayaUsd_compile_config(${LIBRARY_NAME})
+
         # Find libraries under the install prefix, which has the core USD
         # libraries.
         mayaUsd_init_rpath(rpath "tests/lib")
@@ -820,6 +823,9 @@ function(pxr_monolithic_epilogue)
         COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/usd_m.cpp"
     )
     add_library(usd_m STATIC "${CMAKE_CURRENT_BINARY_DIR}/usd_m.cpp" ${objects})
+
+    # compiler configuration
+    mayaUsd_compile_config(usd_m)
 
     _get_folder("" folder)
     set_target_properties(usd_m


### PR DESCRIPTION
Following PR #412, plugin/pxr is now getting the compiler configuration by using `mayaUsd_compile_config`. 

I didn't delete `defaults` sub-directory and left it there by itself for now.