### PR TITLE
plugin/al is now adopting mayaUsd_compile_config routine

### DIFF
--- a/plugin/al/CMakeLists.txt
+++ b/plugin/al/CMakeLists.txt
@@ -56,27 +56,6 @@ set(AL_USDMAYA_LOCATION_NAME
     "Name of the environment variable used to store AL_USDMaya installation location"
 )
 
-#------------------------------------------------------------------------------
-# compiler configuration
-#------------------------------------------------------------------------------
-# CXXDefaults will set a variety of variables for the project.
-# Consume them here. This is an effort to keep the most common
-# build files readable.
-list(APPEND CMAKE_MODULE_PATH
-    ${PROJECT_SOURCE_DIR}/../pxr/cmake/defaults
-)
-include(CXXDefaults)
-add_definitions(${_PXR_CXX_DEFINITIONS} -DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE)
-set(CMAKE_CXX_FLAGS "${_PXR_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
-
-if(NOT WIN32)
-    set(CMAKE_CXX_FLAGS
-        -msse3
-        "${CMAKE_CXX_FLAGS} ${_PXR_CXX_FLAGS}"
-    )
-endif()
-string(REPLACE ";" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-
 # Build all the utils
 set(EVENTS_INCLUDE_LOCATION ${CMAKE_CURRENT_LIST_DIR}/utils)
 set(MAYAUTILS_INCLUDE_LOCATION ${CMAKE_CURRENT_LIST_DIR}/mayautils)

--- a/plugin/al/lib/AL_USDMaya/CMakeLists.txt
+++ b/plugin/al/lib/AL_USDMaya/CMakeLists.txt
@@ -160,13 +160,12 @@ add_library(${LIBRARY_NAME}
         ${AL_usdmaya_nodes_source}
 )
 
-if(IS_MACOSX)
-    set(_macDef OSMac_)
-endif()
+# compiler configuration
+mayaUsd_compile_config(${LIBRARY_NAME})
 
 target_compile_definitions(${LIBRARY_NAME}
     PRIVATE
-        ${_macDef}
+        $<$<BOOL:${IS_MACOSX}>:OSMac_>
         AL_MAYA_MACROS_EXPORT
         AL_USDMAYA_EXPORT
         AL_USDMAYA_LOCATION_NAME="${AL_USDMAYA_LOCATION_NAME}"
@@ -244,13 +243,12 @@ add_library(${PYTHON_LIBRARY_NAME}
     AL/usdmaya/fileio/translators/wrapTranslatorContext.cpp
 )
 
-if(IS_MACOSX)
-    set(_macDef OSMac_)
-endif()
+# compiler configuration
+mayaUsd_compile_config(${PYTHON_LIBRARY_NAME})
 
 target_compile_definitions(${PYTHON_LIBRARY_NAME}
     PRIVATE
-        ${_macDef}
+        $<$<BOOL:${IS_MACOSX}>:OSMac_>
         MFB_PACKAGE_NAME=${LIBRARY_NAME}
         MFB_ALT_PACKAGE_NAME=${LIBRARY_NAME}
         MFB_PACKAGE_MODULE=usdmaya

--- a/plugin/al/mayatest/AL/maya/test/CMakeLists.txt
+++ b/plugin/al/mayatest/AL/maya/test/CMakeLists.txt
@@ -18,6 +18,9 @@ target_sources(${MAYA_TEST_LIBRARY_NAME}
     testHarness.cpp
 )
 
+# compiler configuration
+mayaUsd_compile_config(${MAYA_TEST_LIBRARY_NAME})
+
 target_compile_definitions(${MAYA_TEST_LIBRARY_NAME}
   PRIVATE
     $<$<BOOL:${IS_MACOSX}>:OSMac_>

--- a/plugin/al/mayautils/AL/maya/CMakeLists.txt
+++ b/plugin/al/mayautils/AL/maya/CMakeLists.txt
@@ -45,13 +45,12 @@ add_library(${MAYAUTILS_LIBRARY_NAME}
         ${maya_source}
 )
 
-if(IS_MACOSX)
-    set(_macDef OSMac_)
-endif()
+# compiler configuration
+mayaUsd_compile_config(${MAYAUTILS_LIBRARY_NAME})
 
 target_compile_definitions(${MAYAUTILS_LIBRARY_NAME}
     PRIVATE
-        ${_macDef}
+        $<$<BOOL:${IS_MACOSX}>:OSMac_>
         AL_MAYA_EVENTS_EXPORT
         AL_MAYA_UTILS_EXPORT
         AL_MAYA_MACROS_EXPORT

--- a/plugin/al/mayautils/AL/maya/tests/mayaplugintest/CMakeLists.txt
+++ b/plugin/al/mayautils/AL/maya/tests/mayaplugintest/CMakeLists.txt
@@ -23,6 +23,9 @@ elseif(IS_LINUX)
     set_target_properties(${TARGET_NAME} PROPERTIES PREFIX "")
 endif()
 
+# compiler configuration
+mayaUsd_compile_config(${TARGET_NAME})
+
 target_compile_definitions(${TARGET_NAME}
     PRIVATE
         $<$<BOOL:${IS_MACOSX}>:OSMac_>

--- a/plugin/al/plugin/AL_USDMayaPlugin/CMakeLists.txt
+++ b/plugin/al/plugin/AL_USDMayaPlugin/CMakeLists.txt
@@ -5,6 +5,9 @@ add_library(
     plugin.cpp
 )
 
+# compiler configuration
+mayaUsd_compile_config(${PXR_PACKAGE})
+
 target_compile_definitions(${PXR_PACKAGE}
     PRIVATE
         AL_USDMAYA_PLUGIN_EXPORT

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/CMakeLists.txt
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/CMakeLists.txt
@@ -62,6 +62,9 @@ elseif(IS_LINUX)
     set_target_properties(${TARGET_NAME} PROPERTIES PREFIX "")
 endif()
 
+# compiler configuration
+mayaUsd_compile_config(${TARGET_NAME})
+
 target_compile_definitions(${TARGET_NAME}
     PRIVATE
         AL_USDMAYA_UNITTEST

--- a/plugin/al/schemas/AL/usd/schemas/maya/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/maya/CMakeLists.txt
@@ -61,6 +61,9 @@ add_library(AL_USDMayaSchemas
     ModuleDeps.cpp
 )
 
+# compiler configuration
+mayaUsd_compile_config(AL_USDMayaSchemas)
+
 target_compile_definitions(AL_USDMayaSchemas
     PRIVATE
         AL_USDMAYASCHEMAS_EXPORTS
@@ -109,6 +112,9 @@ add_library(${PYTHON_LIBRARY_NAME}
     wrapTokens.cpp
     wrapFrameRange.cpp
 )
+
+# compiler configuration
+mayaUsd_compile_config(${PYTHON_LIBRARY_NAME})
 
 target_compile_definitions(${PYTHON_LIBRARY_NAME}
     PRIVATE

--- a/plugin/al/schemas/AL/usd/schemas/maya/tests/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/maya/tests/CMakeLists.txt
@@ -4,6 +4,9 @@ find_package(GTest REQUIRED)
 
 add_executable(${TARGET_NAME})
 
+# compiler configuration
+mayaUsd_compile_config(${TARGET_NAME})
+
 target_sources(${TARGET_NAME}
     PRIVATE
         main.cpp

--- a/plugin/al/schemas/AL/usd/schemas/mayatest/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/mayatest/CMakeLists.txt
@@ -60,6 +60,9 @@ add_library(AL_USDMayaSchemasTest
     ${CMAKE_CURRENT_BINARY_DIR}/tokens.cpp
 )
 
+# compiler configuration
+mayaUsd_compile_config(AL_USDMayaSchemasTest)
+
 target_compile_definitions(AL_USDMayaSchemasTest
     PRIVATE
         AL_USDMAYASCHEMASTEST_EXPORTS
@@ -99,6 +102,9 @@ add_library(${PYTHON_LIBRARY_NAME}
     wrapTokens.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/wrapExamplePolyCubeNode.cpp
 )
+
+# compiler configuration
+mayaUsd_compile_config(${PYTHON_LIBRARY_NAME})
 
 target_compile_definitions(${PYTHON_LIBRARY_NAME}
     PRIVATE

--- a/plugin/al/translators/CMakeLists.txt
+++ b/plugin/al/translators/CMakeLists.txt
@@ -24,6 +24,9 @@ add_library(${TRANSLATORS_PACKAGE}
     DirectionalLight.cpp
 )
 
+# compiler configuration
+mayaUsd_compile_config(${TRANSLATORS_PACKAGE})
+
 if(IS_MACOSX)
     set(_macDef OSMac_)
 endif()

--- a/plugin/al/translators/pxrUsdTranslators/CMakeLists.txt
+++ b/plugin/al/translators/pxrUsdTranslators/CMakeLists.txt
@@ -30,6 +30,9 @@ add_library(${PXR_TRANSLATORS_PACKAGE}
   plugin.cpp
 )
 
+# compiler configuration
+mayaUsd_compile_config(${PXR_TRANSLATORS_PACKAGE})
+
 maya_set_plugin_properties(${PXR_TRANSLATORS_PACKAGE})
 
 # handle run-time search paths

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/CMakeLists.txt
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/CMakeLists.txt
@@ -37,13 +37,12 @@ add_library(${USDMAYA_UTILS_LIBRARY_NAME}
         ${usdmaya_utils_source}
 )
 
-if(IS_MACOSX)
-    set(_macDef OSMac_)
-endif()
+# compiler configuration
+mayaUsd_compile_config(${USDMAYA_UTILS_LIBRARY_NAME})
 
 target_compile_definitions(${USDMAYA_UTILS_LIBRARY_NAME}
     PRIVATE
-        ${_macDef}
+        $<$<BOOL:${IS_MACOSX}>:OSMac_>
         AL_USDMAYA_UTILS_EXPORT
 )
 

--- a/plugin/al/usdtransaction/AL/usd/transaction/CMakeLists.txt
+++ b/plugin/al/usdtransaction/AL/usd/transaction/CMakeLists.txt
@@ -38,6 +38,9 @@ add_library(${USDTRANSACTION_LIBRARY_NAME}
     ${usdtransaction_source}
 )
 
+# compiler configuration
+mayaUsd_compile_config(${USDTRANSACTION_LIBRARY_NAME})
+
 target_compile_definitions(${USDTRANSACTION_LIBRARY_NAME}
     PRIVATE
         AL_USD_TRANSACTION_EXPORT
@@ -67,6 +70,9 @@ add_library(${USDTRANSACTION_PYTHON_LIBRARY_NAME}
   SHARED
     ${usdtransaction_python_source}
 )
+
+# compiler configuration
+mayaUsd_compile_config(${USDTRANSACTION_PYTHON_LIBRARY_NAME})
 
 target_compile_definitions(${USDTRANSACTION_PYTHON_LIBRARY_NAME}
   PRIVATE

--- a/plugin/al/usdtransaction/AL/usd/transaction/tests/CMakeLists.txt
+++ b/plugin/al/usdtransaction/AL/usd/transaction/tests/CMakeLists.txt
@@ -6,6 +6,9 @@ set(USDTRANSACTION_PYTHON_TEST_NAME Python:AL_USDTransactionTests)
 
 add_executable(${USDTRANSACTION_TEST_EXECUTABLE_NAME})
 
+# compiler configuration
+mayaUsd_compile_config(${USDTRANSACTION_TEST_EXECUTABLE_NAME})
+
 target_sources(${USDTRANSACTION_TEST_EXECUTABLE_NAME}
   PRIVATE
     testMain.cpp

--- a/plugin/al/utils/AL/CMakeLists.txt
+++ b/plugin/al/utils/AL/CMakeLists.txt
@@ -25,6 +25,9 @@ add_library(${EVENTS_LIBRARY_NAME}
         ${utils_source}
 )
 
+# compiler configuration
+mayaUsd_compile_config(${EVENTS_LIBRARY_NAME})
+
 target_compile_definitions(${EVENTS_LIBRARY_NAME}
     PRIVATE
         AL_EVENT_EXPORT


### PR DESCRIPTION
Following PR #412, plugin/al is now getting the compiler configuration by using mayaUsd_compile_config.