### PR TITLE
updates from Hdx de-boostification and Hd reorganization

### DIFF
--- a/lib/usd/hdMaya/adapters/lightAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/lightAdapter.cpp
@@ -33,6 +33,12 @@
 #include <hdMaya/adapters/constantShadowMatrix.h>
 #include <hdMaya/adapters/mayaAttrs.h>
 
+#if HDX_API_VERSION < 7
+#include <boost/shared_ptr.hpp>
+#include <boost/make_shared.hpp>
+#endif
+
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 TF_REGISTRY_FUNCTION(TfType) {
@@ -272,10 +278,16 @@ void HdMayaLightAdapter::_CalculateShadowParams(
             : std::min(
                   GetDelegate()->GetParams().maximumShadowMapResolution,
                   dmapResolutionPlug.asInt());
+
     params.shadowMatrix =
+#if HDX_API_VERSION >= 7
+        std::make_shared<HdMayaConstantShadowMatrix>(
+            GetTransform() * _shadowProjectionMatrix);
+#else
         boost::static_pointer_cast<HdxShadowMatrixComputation>(
             boost::make_shared<HdMayaConstantShadowMatrix>(
                 GetTransform() * _shadowProjectionMatrix));
+#endif
     params.bias = dmapBiasPlug.isNull() ? -0.001 : -dmapBiasPlug.asFloat();
     params.blur = dmapFilterSizePlug.isNull()
                       ? 0.0

--- a/lib/usd/hdMaya/utils.h
+++ b/lib/usd/hdMaya/utils.h
@@ -36,6 +36,7 @@
 #include <pxr/base/gf/matrix4d.h>
 #include <pxr/base/tf/token.h>
 #include <pxr/imaging/hd/textureResource.h>
+#include <pxr/imaging/hd/types.h>
 
 #include <hdMaya/api.h>
 #include <hdMaya/adapters/mayaAttrs.h>


### PR DESCRIPTION
Two recent post-20.05 commits in core USD made some Hdx pointer types use std::shared_ptr instead of boost::shared_ptr, and a third commit moved some Hd enum values from hd/enums.h to hd/types.h.

The changes here update the maya-usd code to account for these core USD commits.