### PR TITLE
remove virtual dispatch for PxrMayaHdShapeAdapter::IsViewport2()

### DIFF
--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerImager.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerImager.cpp
@@ -99,7 +99,8 @@ UsdMayaGL_InstancerImager::_SyncShapeAdapters(
             std::unique_ptr<UsdMayaGL_InstancerShapeAdapter>& adapter =
                     entry.adapterVp2;
             if (!adapter) {
-                adapter.reset(CreateInstancerShapeAdapter());
+                adapter.reset(
+                    CreateInstancerShapeAdapter(/* isViewport2 = */ true));
             }
 
             if (adapter->Sync(
@@ -114,7 +115,8 @@ UsdMayaGL_InstancerImager::_SyncShapeAdapters(
             std::unique_ptr<UsdMayaGL_InstancerShapeAdapter>& adapter =
                     entry.adapterLegacy;
             if (!adapter) {
-                adapter.reset(CreateInstancerShapeAdapter());
+                adapter.reset(
+                    CreateInstancerShapeAdapter(/* isViewport2 = */ false));
             }
 
             if (adapter->Sync(
@@ -440,12 +442,12 @@ void UsdMayaGL_InstancerImager::SetInstancerShapeAdapterFactory(
 }
 
 UsdMayaGL_InstancerShapeAdapter*
-UsdMayaGL_InstancerImager::CreateInstancerShapeAdapter()
+UsdMayaGL_InstancerImager::CreateInstancerShapeAdapter(const bool isViewport2)
 {
     if (!_instancerShapeAdapterFactory) {
-        return new UsdMayaGL_InstancerShapeAdapter();
+        return new UsdMayaGL_InstancerShapeAdapter(isViewport2);
     }
-    return _instancerShapeAdapterFactory();
+    return _instancerShapeAdapterFactory(isViewport2);
 }
 
 UsdMayaGL_InstancerImager::_InstancerEntry::~_InstancerEntry()

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerImager.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerImager.cpp
@@ -442,7 +442,7 @@ void UsdMayaGL_InstancerImager::SetInstancerShapeAdapterFactory(
 }
 
 UsdMayaGL_InstancerShapeAdapter*
-UsdMayaGL_InstancerImager::CreateInstancerShapeAdapter(const bool isViewport2)
+UsdMayaGL_InstancerImager::CreateInstancerShapeAdapter(bool isViewport2)
 {
     if (!_instancerShapeAdapterFactory) {
         return new UsdMayaGL_InstancerShapeAdapter(isViewport2);

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerImager.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerImager.h
@@ -72,7 +72,9 @@ public:
         ContinueTrackingOnDisconnectDelegate delegate);
 
     /// Factory function for creating instancer shape adapters.
-    typedef std::function<UsdMayaGL_InstancerShapeAdapter*()> InstancerShapeAdapterFactory;
+    using InstancerShapeAdapterFactory =
+        std::function<UsdMayaGL_InstancerShapeAdapter*(
+            const bool /* isViewport2 */)>;
 
     /// Set the factory function for creating instancer shape adapters.
     MAYAUSD_CORE_PUBLIC
@@ -177,7 +179,8 @@ private:
     /// no factory has been set, returns a UsdMayaGL_InstancerShapeAdapter base
     /// class object.  The caller must manage the lifescope of the returned
     /// object.
-    static UsdMayaGL_InstancerShapeAdapter* CreateInstancerShapeAdapter();
+    static UsdMayaGL_InstancerShapeAdapter* CreateInstancerShapeAdapter(
+            const bool isViewport2);
 
     UsdMayaGL_InstancerImager();
     ~UsdMayaGL_InstancerImager();

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerImager.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerImager.h
@@ -73,8 +73,7 @@ public:
 
     /// Factory function for creating instancer shape adapters.
     using InstancerShapeAdapterFactory =
-        std::function<UsdMayaGL_InstancerShapeAdapter*(
-            const bool /* isViewport2 */)>;
+        std::function<UsdMayaGL_InstancerShapeAdapter*(bool /* isViewport2 */)>;
 
     /// Set the factory function for creating instancer shape adapters.
     MAYAUSD_CORE_PUBLIC
@@ -179,8 +178,7 @@ private:
     /// no factory has been set, returns a UsdMayaGL_InstancerShapeAdapter base
     /// class object.  The caller must manage the lifescope of the returned
     /// object.
-    static UsdMayaGL_InstancerShapeAdapter* CreateInstancerShapeAdapter(
-            const bool isViewport2);
+    static UsdMayaGL_InstancerShapeAdapter* CreateInstancerShapeAdapter(bool isViewport2);
 
     UsdMayaGL_InstancerImager();
     ~UsdMayaGL_InstancerImager();

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.cpp
@@ -403,7 +403,7 @@ void UsdMayaGL_InstancerShapeAdapter::SyncInstancerPerPrototypePostHook(
 }
 
 UsdMayaGL_InstancerShapeAdapter::UsdMayaGL_InstancerShapeAdapter(
-        const bool isViewport2) :
+        bool isViewport2) :
     PxrMayaHdShapeAdapter(isViewport2)
 {
     TF_DEBUG(PXRUSDMAYAGL_SHAPE_ADAPTER_LIFECYCLE).Msg(

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.cpp
@@ -402,7 +402,9 @@ void UsdMayaGL_InstancerShapeAdapter::SyncInstancerPerPrototypePostHook(
     prototypeRefs.ClearReferences();
 }
 
-UsdMayaGL_InstancerShapeAdapter::UsdMayaGL_InstancerShapeAdapter()
+UsdMayaGL_InstancerShapeAdapter::UsdMayaGL_InstancerShapeAdapter(
+        const bool isViewport2) :
+    PxrMayaHdShapeAdapter(isViewport2)
 {
     TF_DEBUG(PXRUSDMAYAGL_SHAPE_ADAPTER_LIFECYCLE).Msg(
         "Constructing UsdMayaGL_InstancerShapeAdapter: %p\n",

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.h
@@ -109,7 +109,7 @@ class UsdMayaGL_InstancerShapeAdapter : public PxrMayaHdShapeAdapter
         /// Note that only friends of this class are able to construct
         /// instances of this class.
         MAYAUSD_CORE_PUBLIC
-        UsdMayaGL_InstancerShapeAdapter(const bool isViewport2);
+        UsdMayaGL_InstancerShapeAdapter(bool isViewport2);
 
         // Derived class hook to allow derived classes to augment
         // _SyncInstancerPrototypes(), for each prototype.  The implementation

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.h
@@ -109,7 +109,7 @@ class UsdMayaGL_InstancerShapeAdapter : public PxrMayaHdShapeAdapter
         /// Note that only friends of this class are able to construct
         /// instances of this class.
         MAYAUSD_CORE_PUBLIC
-        UsdMayaGL_InstancerShapeAdapter();
+        UsdMayaGL_InstancerShapeAdapter(const bool isViewport2);
 
         // Derived class hook to allow derived classes to augment
         // _SyncInstancerPrototypes(), for each prototype.  The implementation

--- a/lib/mayaUsd/render/pxrUsdMayaGL/proxyDrawOverride.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/proxyDrawOverride.cpp
@@ -64,10 +64,11 @@ UsdMayaProxyDrawOverride::UsdMayaProxyDrawOverride(const MObject& obj) :
         MHWRender::MPxDrawOverride(obj,
                                    UsdMayaProxyDrawOverride::draw
 #if MAYA_API_VERSION >= 201651
-                                   , /* isAlwaysDirty = */ false)
+                                   , /* isAlwaysDirty = */ false),
 #else
-                                   )
+                                   ),
 #endif
+        _shapeAdapter(/* isViewport2 = */ true)
 {
 }
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/proxyShapeUI.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/proxyShapeUI.cpp
@@ -216,7 +216,9 @@ UsdMayaProxyShapeUI::select(
     return true;
 }
 
-UsdMayaProxyShapeUI::UsdMayaProxyShapeUI() : MPxSurfaceShapeUI()
+UsdMayaProxyShapeUI::UsdMayaProxyShapeUI() :
+        MPxSurfaceShapeUI(),
+        _shapeAdapter(/* isViewport2 = */ false)
 {
     MStatus status;
     _onNodeRemovedCallbackId = MDGMessage::addNodeRemovedCallback(

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
@@ -538,7 +538,7 @@ PxrMayaHdShapeAdapter::_GetVisibility(
     return true;
 }
 
-PxrMayaHdShapeAdapter::PxrMayaHdShapeAdapter(const bool isViewport2) :
+PxrMayaHdShapeAdapter::PxrMayaHdShapeAdapter(bool isViewport2) :
         _isViewport2(isViewport2)
 {
     TF_DEBUG(PXRUSDMAYAGL_SHAPE_ADAPTER_LIFECYCLE).Msg(

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
@@ -122,7 +122,6 @@ PxrMayaHdShapeAdapter::Sync(
         const M3dView::DisplayStatus legacyDisplayStatus)
 {
     // Legacy viewport implementation.
-    _isViewport2 = false;
 
     UsdMayaGLBatchRenderer::GetInstance().StartBatchingFrameDiagnostics();
 
@@ -165,7 +164,6 @@ PxrMayaHdShapeAdapter::Sync(
         const MHWRender::DisplayStatus displayStatus)
 {
     // Viewport 2.0 implementation.
-    _isViewport2 = true;
 
     UsdMayaGLBatchRenderer::GetInstance().StartBatchingFrameDiagnostics();
 
@@ -405,13 +403,6 @@ PxrMayaHdShapeAdapter::GetDagPath() const
 }
 
 /* virtual */
-bool
-PxrMayaHdShapeAdapter::IsViewport2() const
-{
-    return _isViewport2;
-}
-
-/* virtual */
 TfToken
 PxrMayaHdShapeAdapter::_GetRprimCollectionName() const
 {
@@ -547,7 +538,8 @@ PxrMayaHdShapeAdapter::_GetVisibility(
     return true;
 }
 
-PxrMayaHdShapeAdapter::PxrMayaHdShapeAdapter()
+PxrMayaHdShapeAdapter::PxrMayaHdShapeAdapter(const bool isViewport2) :
+        _isViewport2(isViewport2)
 {
     TF_DEBUG(PXRUSDMAYAGL_SHAPE_ADAPTER_LIFECYCLE).Msg(
         "Constructing PxrMayaHdShapeAdapter: %p\n",

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
@@ -201,14 +201,15 @@ class PxrMayaHdShapeAdapter
 
         /// Get whether this shape adapter is for use with Viewport 2.0.
         ///
-        /// The shape adapter gets its viewport renderer affiliation from the
-        /// version of Sync() that is used to populate it.
+        /// The shape adapter's viewport renderer affiliation must be specified
+        /// when it is constructed.
         ///
         /// Returns true if the shape adapter should be used for batched
         /// drawing/selection in Viewport 2.0, or false if it should be used
         /// in the legacy viewport.
-        MAYAUSD_CORE_PUBLIC
-        virtual bool IsViewport2() const;
+        bool IsViewport2() const {
+            return _isViewport2;
+        }
 
     protected:
 
@@ -277,7 +278,7 @@ class PxrMayaHdShapeAdapter
 
         /// Construct a new uninitialized PxrMayaHdShapeAdapter.
         MAYAUSD_CORE_PUBLIC
-        PxrMayaHdShapeAdapter();
+        PxrMayaHdShapeAdapter(const bool isViewport2);
 
         MAYAUSD_CORE_PUBLIC
         virtual ~PxrMayaHdShapeAdapter();
@@ -293,7 +294,7 @@ class PxrMayaHdShapeAdapter
 
         GfMatrix4d _rootXform;
 
-        bool _isViewport2;
+        const bool _isViewport2;
 };
 
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
@@ -278,7 +278,7 @@ class PxrMayaHdShapeAdapter
 
         /// Construct a new uninitialized PxrMayaHdShapeAdapter.
         MAYAUSD_CORE_PUBLIC
-        PxrMayaHdShapeAdapter(const bool isViewport2);
+        PxrMayaHdShapeAdapter(bool isViewport2);
 
         MAYAUSD_CORE_PUBLIC
         virtual ~PxrMayaHdShapeAdapter();

--- a/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
@@ -385,8 +385,7 @@ PxrMayaHdUsdProxyShapeAdapter::_Init(HdRenderIndex* renderIndex)
     return true;
 }
 
-PxrMayaHdUsdProxyShapeAdapter::PxrMayaHdUsdProxyShapeAdapter(
-        const bool isViewport2) :
+PxrMayaHdUsdProxyShapeAdapter::PxrMayaHdUsdProxyShapeAdapter(bool isViewport2) :
     PxrMayaHdShapeAdapter(isViewport2)
 {
     TF_DEBUG(PXRUSDMAYAGL_SHAPE_ADAPTER_LIFECYCLE).Msg(

--- a/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
@@ -385,7 +385,9 @@ PxrMayaHdUsdProxyShapeAdapter::_Init(HdRenderIndex* renderIndex)
     return true;
 }
 
-PxrMayaHdUsdProxyShapeAdapter::PxrMayaHdUsdProxyShapeAdapter()
+PxrMayaHdUsdProxyShapeAdapter::PxrMayaHdUsdProxyShapeAdapter(
+        const bool isViewport2) :
+    PxrMayaHdShapeAdapter(isViewport2)
 {
     TF_DEBUG(PXRUSDMAYAGL_SHAPE_ADAPTER_LIFECYCLE).Msg(
         "Constructing PxrMayaHdUsdProxyShapeAdapter: %p\n",

--- a/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.h
@@ -111,7 +111,7 @@ class PxrMayaHdUsdProxyShapeAdapter : public PxrMayaHdShapeAdapter
         /// Note that only friends of this class are able to construct
         /// instances of this class.
         MAYAUSD_CORE_PUBLIC
-        PxrMayaHdUsdProxyShapeAdapter(const bool isViewport2);
+        PxrMayaHdUsdProxyShapeAdapter(bool isViewport2);
 
         MAYAUSD_CORE_PUBLIC
         ~PxrMayaHdUsdProxyShapeAdapter() override;

--- a/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.h
@@ -111,7 +111,7 @@ class PxrMayaHdUsdProxyShapeAdapter : public PxrMayaHdShapeAdapter
         /// Note that only friends of this class are able to construct
         /// instances of this class.
         MAYAUSD_CORE_PUBLIC
-        PxrMayaHdUsdProxyShapeAdapter();
+        PxrMayaHdUsdProxyShapeAdapter(const bool isViewport2);
 
         MAYAUSD_CORE_PUBLIC
         ~PxrMayaHdUsdProxyShapeAdapter() override;

--- a/plugin/pxr/maya/lib/usdMaya/instancerShapeAdapterWithSceneAssembly.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/instancerShapeAdapterWithSceneAssembly.cpp
@@ -26,7 +26,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 UsdMayaGL_InstancerShapeAdapterWithSceneAssembly::UsdMayaGL_InstancerShapeAdapterWithSceneAssembly(
-        const bool isViewport2) :
+        bool isViewport2) :
     UsdMayaGL_InstancerShapeAdapter(isViewport2)
 {
     TF_DEBUG(PXRUSDMAYAGL_SHAPE_ADAPTER_LIFECYCLE).Msg(

--- a/plugin/pxr/maya/lib/usdMaya/instancerShapeAdapterWithSceneAssembly.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/instancerShapeAdapterWithSceneAssembly.cpp
@@ -25,7 +25,9 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-UsdMayaGL_InstancerShapeAdapterWithSceneAssembly::UsdMayaGL_InstancerShapeAdapterWithSceneAssembly()
+UsdMayaGL_InstancerShapeAdapterWithSceneAssembly::UsdMayaGL_InstancerShapeAdapterWithSceneAssembly(
+        const bool isViewport2) :
+    UsdMayaGL_InstancerShapeAdapter(isViewport2)
 {
     TF_DEBUG(PXRUSDMAYAGL_SHAPE_ADAPTER_LIFECYCLE).Msg(
         "Constructing UsdMayaGL_InstancerShapeAdapterWithSceneAssembly: %p\n",

--- a/plugin/pxr/maya/lib/usdMaya/instancerShapeAdapterWithSceneAssembly.h
+++ b/plugin/pxr/maya/lib/usdMaya/instancerShapeAdapterWithSceneAssembly.h
@@ -34,8 +34,7 @@ class UsdMayaGL_InstancerShapeAdapterWithSceneAssembly : public UsdMayaGL_Instan
         ~UsdMayaGL_InstancerShapeAdapterWithSceneAssembly() override;
 
         /// Construct a new uninitialized UsdMayaGL_InstancerShapeAdapterWithSceneAssembly.
-        UsdMayaGL_InstancerShapeAdapterWithSceneAssembly(
-                const bool isViewport2);
+        UsdMayaGL_InstancerShapeAdapterWithSceneAssembly(bool isViewport2);
 
     private:
 

--- a/plugin/pxr/maya/lib/usdMaya/instancerShapeAdapterWithSceneAssembly.h
+++ b/plugin/pxr/maya/lib/usdMaya/instancerShapeAdapterWithSceneAssembly.h
@@ -34,7 +34,8 @@ class UsdMayaGL_InstancerShapeAdapterWithSceneAssembly : public UsdMayaGL_Instan
         ~UsdMayaGL_InstancerShapeAdapterWithSceneAssembly() override;
 
         /// Construct a new uninitialized UsdMayaGL_InstancerShapeAdapterWithSceneAssembly.
-        UsdMayaGL_InstancerShapeAdapterWithSceneAssembly();
+        UsdMayaGL_InstancerShapeAdapterWithSceneAssembly(
+                const bool isViewport2);
 
     private:
 

--- a/plugin/pxr/maya/lib/usdMaya/referenceAssembly.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/referenceAssembly.cpp
@@ -1577,9 +1577,9 @@ bool UsdMayaGL_InstancerImager_ContinueTrackingOnDisconnect(
 }
 
 UsdMayaGL_InstancerShapeAdapter*
-UsdMayaGL_InstancerImager_InstancerShapeAdapterFactory()
+UsdMayaGL_InstancerImager_InstancerShapeAdapterFactory(const bool isViewport2)
 {
-    return new UsdMayaGL_InstancerShapeAdapterWithSceneAssembly();
+    return new UsdMayaGL_InstancerShapeAdapterWithSceneAssembly(isViewport2);
 }
 
 TF_REGISTRY_FUNCTION(UsdMayaReferenceAssembly)

--- a/plugin/pxr/maya/lib/usdMaya/referenceAssembly.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/referenceAssembly.cpp
@@ -1577,7 +1577,7 @@ bool UsdMayaGL_InstancerImager_ContinueTrackingOnDisconnect(
 }
 
 UsdMayaGL_InstancerShapeAdapter*
-UsdMayaGL_InstancerImager_InstancerShapeAdapterFactory(const bool isViewport2)
+UsdMayaGL_InstancerImager_InstancerShapeAdapterFactory(bool isViewport2)
 {
     return new UsdMayaGL_InstancerShapeAdapterWithSceneAssembly(isViewport2);
 }


### PR DESCRIPTION
Following on from #450, we want to start being more explicit about the division between the legacy viewport and Viewport 2.0 so that it's easier to tear out the legacy stuff a little bit at a time.

There might also be a slight performance improvement here with `PxrMayaHdShapeAdapter::IsViewport2()` no longer dispatching virtually.