### PR TITLE
[al] When updating a transform via a quat, test for equivalence in quat space

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.h
@@ -489,6 +489,7 @@ public:
   void pushRotatePivotTranslateToPrim();
   void pushRotatePivotToPrim();
   void pushRotateToPrim();
+  void pushRotateQuatToPrim();
   void pushRotateAxisToPrim();
   void pushScalePivotTranslateToPrim();
   void pushScalePivotToPrim();


### PR DESCRIPTION
If you have a transform that is a +270 rotation around the x axis, If this gets set as a quat the euler equivalents would be a -90 degree rotation in x. Previously the code would test to see if the rotations had changed by comparing euler values. This was leading to some pointless rotations being written as overs into the usd stage. By comparing the values as quats instead, the equivalence check now works correctly, and the pointless overs no longer get generated.