### PR TITLE
Enable exception handling for VS compiler

### DIFF
--- a/cmake/compiler_config.cmake
+++ b/cmake/compiler_config.cmake
@@ -24,6 +24,8 @@ set(msvc_flags
     /Zc:rvalueCast
     # enable multiprocessor builds.
     /MP
+    # enable exception handling.
+    /EHsc
     # disable warnings
     /wd4244
     /wd4267

--- a/lib/mayaUsd/CMakeLists.txt
+++ b/lib/mayaUsd/CMakeLists.txt
@@ -49,6 +49,9 @@ target_compile_definitions(${PROJECT_NAME}
         $<$<BOOL:${IS_LINUX}>:LINUX>
         $<$<BOOL:${IS_LINUX}>:GL_GLEXT_PROTOTYPES>
         $<$<BOOL:${IS_LINUX}>:GLX_GLXEXT_PROTOTYPES>
+
+        # this flag is needed when building maya-usd in Maya
+        $<$<BOOL:${IS_WINDOWS}>:WIN32>
 )
 
 if(DEFINED UFE_PREVIEW_VERSION_NUM)


### PR DESCRIPTION
Full compiler support for the Standard C++exception handling model that safely unwinds stack objects requires /EHsc (recommended)