### PR TITLE
Fix leak of UsdImagingDelegate

### DIFF
--- a/lib/usd/hdMaya/adapters/proxyAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/proxyAdapter.cpp
@@ -143,13 +143,13 @@ void HdMayaProxyAdapter::PopulateSelectedPaths(
 }
 
 void HdMayaProxyAdapter::CreateUsdImagingDelegate() {
-    // Why do this release when we do a reset right below? Because we want
+    // Why do this reset when we do another right below? Because we want
     // to make sure we delete the old delegate before creating a new one
     // (the reset statement below will first create a new one, THEN delete
     // the old one). Why do we care? In case they have the same _renderIndex
     // - if so, the delete may clear out items from the renderIndex that the
     // constructor potentially adds
-    _usdDelegate.release();
+    _usdDelegate.reset();
     _usdDelegate.reset(new HdMayaProxyUsdImagingDelegate(
         &GetDelegate()->GetRenderIndex(),
         _id.AppendChild(TfToken(TfStringPrintf(


### PR DESCRIPTION
There's an issue with the following, when a viewport triggers a display before the second command is run:
```
string $proxy = `createNode mayaUsdProxyShape`;
setAttr ($proxy + ".filePath") <path>
```