### PR TITLE
Teach the import cmd ui how to import usd-assets and apply to proxy-shapes

### DIFF
--- a/lib/usd/ui/USDImportDialogCmd.cpp
+++ b/lib/usd/ui/USDImportDialogCmd.cpp
@@ -15,6 +15,9 @@
 //
 #include "USDImportDialogCmd.h"
 
+#include <pxr/usd/ar/resolver.h>
+#include <pxr/usd/usd/variantSets.h>
+
 #include <maya/MArgParser.h>
 #include <maya/MFileObject.h>
 #include <maya/MQtUtil.h>
@@ -22,12 +25,17 @@
 #include <maya/MString.h>
 #include <maya/MStringArray.h>
 #include <maya/MSyntax.h>
+#include <maya/MDagPath.h>
+#include <maya/MSelectionList.h>
+#include <maya/MFnDependencyNode.h>
+#include <maya/MFnStringData.h>
 
 // This is added to prevent multiple definitions of the MApiVersion string.
 #define MNoVersionString
 #include <maya/MFnPlugin.h>
 
 #include <mayaUsd/fileio/importData.h>
+#include <mayaUsd/nodes/proxyShapeBase.h>
 
 #include <mayaUsdUI/ui/USDImportDialog.h>
 #include <mayaUsdUI/ui/USDQtUtil.h>
@@ -42,6 +50,8 @@ constexpr auto kPrimPathFlag = "-pp";
 constexpr auto kPrimPathFlagLong = "-primPath";
 constexpr auto kClearDataFlag = "-cd";
 constexpr auto kClearDataFlagLong = "-clearData";
+constexpr auto kApplyToProxyFlag = "-ap";
+constexpr auto kApplyToProxyFlagLong = "-applyToProxy";
 
 }
 
@@ -64,6 +74,69 @@ MStatus USDImportDialogCmd::finalize(MFnPlugin& plugin)
 void* USDImportDialogCmd::creator()
 {
 	return new USDImportDialogCmd();
+}
+
+MStatus USDImportDialogCmd::applyToProxy(const MString& proxyPath)
+{
+	MDagPath proxyShapeDagPath;
+	MSelectionList selection;
+	selection.add(proxyPath);
+	MStatus status = selection.getDagPath(0, proxyShapeDagPath);
+	if (status.error())
+		return status;
+
+	MObject proxyShapeObj = proxyShapeDagPath.node(&status);
+	CHECK_MSTATUS_AND_RETURN(status, status);
+	if (status.error())
+		return status;
+
+    MFnDependencyNode fn(proxyShapeObj, &status);
+	if (status.error())
+		return status;
+
+	if (fn.typeName() != MString("mayaUsdProxyShape"))
+		return MS::kInvalidParameter;
+
+    MayaUsdProxyShapeBase* proxyShape = dynamic_cast<MayaUsdProxyShapeBase*>(fn.userNode());
+	if (!proxyShape)
+		return MS::kInvalidParameter;
+
+	MPlug primPath = fn.findPlug("primPath", &status);
+	if (status.error())
+		return status;
+	MPlug filePath = fn.findPlug("filePath", &status);
+	if (status.error())
+		return status;
+
+	ImportData& importData = ImportData::instance();
+	primPath.setValue(MString(importData.rootPrimPath().c_str()));
+	if (status.error())
+		return status;
+
+	filePath.setValue(MString(importData.filename().c_str()));
+	if (status.error())
+		return status;
+
+	auto rootPrim = proxyShape->usdPrim();
+	if (!rootPrim)
+		return MS::kNotFound;
+
+	auto stage = rootPrim.GetStage();
+	if (!stage)
+		return MS::kNotFound;
+
+	for (auto& primVariant : importData.primVariantSelections()) {
+		auto prim = stage->GetPrimAtPath(primVariant.first);
+		if (!prim || !prim.HasVariantSets())
+			return MS::kNotFound;
+
+		for (auto& variant : primVariant.second) {
+			auto variantSet = prim.GetVariantSet(variant.first);
+			if (variantSet)
+				variantSet.SetVariantSelection(variant.second);
+		}
+	}
+    return MS::kSuccess;
 }
 
 MStatus USDImportDialogCmd::doIt(const MArgList& args)
@@ -93,30 +166,55 @@ MStatus USDImportDialogCmd::doIt(const MArgList& args)
 		return MS::kSuccess;
 	}
 
+	if(argData.isFlagSet(kApplyToProxyFlag))
+	{
+		MStringArray proxyArray;
+		st = argData.getObjects(proxyArray);
+		if (!st || proxyArray.length() != 1)
+			return MS::kInvalidParameter;
+
+		return applyToProxy(proxyArray[0]);
+	}
+
 	MStringArray filenameArray;
 	st = argData.getObjects(filenameArray);
 	if (st && (filenameArray.length() > 0))
 	{
 		// We only use the first one.
 		MFileObject fo;
+		MString assetPath;
 		fo.setRawFullName(filenameArray[0]);
-		if (fo.exists())
+		bool validTarget = fo.exists();
+		if (!validTarget) {
+			// Give the default usd-asset-resolver a chance
+			if (const char* cStr = filenameArray[0].asChar()) {
+				validTarget = !ArGetResolver().Resolve(cStr).empty();
+				if (validTarget)
+					assetPath = filenameArray[0];
+			}
+		} else
+			assetPath = fo.resolvedFullName();
+
+		if (validTarget)
 		{
 			USDQtUtil usdQtUtil;
 			ImportData& importData = ImportData::instance();
-			MString usdFile = fo.resolvedFullName();
-			std::unique_ptr<IUSDImportView> usdImportDialog(new USDImportDialog(usdFile.asChar(), &importData, usdQtUtil, MQtUtil::mainWindow()));
-			if (usdImportDialog->execute())
-			{
-				// The user clicked 'Apply' so copy the info from the dialog to the import data instance.
-				importData.setFilename(usdImportDialog->filename());
-				importData.setStageInitialLoadSet(usdImportDialog->stageInitialLoadSet());
-				importData.setRootPrimPath(usdImportDialog->rootPrimPath());
-				// Don't set the stage pop mask until we solve how to use it together with
-				// the root prim path.
-				//importData.setStagePopulationMask(usdImportDialog->stagePopulationMask());
-				importData.setPrimVariantSelections(usdImportDialog->primVariantSelections());
-			}
+			std::unique_ptr<IUSDImportView> usdImportDialog(
+				new USDImportDialog(assetPath.asChar(), &importData,
+					                usdQtUtil, MQtUtil::mainWindow()));
+			if (!usdImportDialog->execute())
+				return MS::kFailure;
+
+			// The user clicked 'Apply' so copy the info from the dialog to the import data instance.
+			importData.setFilename(usdImportDialog->filename());
+			importData.setStageInitialLoadSet(usdImportDialog->stageInitialLoadSet());
+			importData.setRootPrimPath(usdImportDialog->rootPrimPath());
+			// Don't set the stage pop mask until we solve how to use it together with
+			// the root prim path.
+			//importData.setStagePopulationMask(usdImportDialog->stagePopulationMask());
+			importData.setPrimVariantSelections(usdImportDialog->primVariantSelections());
+
+			setResult(assetPath);
 			return MS::kSuccess;
 		}
 	}
@@ -131,7 +229,8 @@ MSyntax USDImportDialogCmd::createSyntax()
 	syntax.enableEdit(false);
 	syntax.addFlag(kPrimPathFlag, kPrimPathFlagLong);
 	syntax.addFlag(kClearDataFlag, kClearDataFlagLong);
-	syntax.setObjectType(MSyntax::kStringObjects, 1, 1);
+	syntax.addFlag(kApplyToProxyFlag, kApplyToProxyFlagLong);
+	syntax.setObjectType(MSyntax::kStringObjects, 0, 1);
 	return syntax;
 }
 

--- a/lib/usd/ui/USDImportDialogCmd.h
+++ b/lib/usd/ui/USDImportDialogCmd.h
@@ -25,6 +25,8 @@
 MAYAUSD_NS_DEF {
 
 class MAYAUSD_UI_PUBLIC USDImportDialogCmd : public MPxCommand {
+    MStatus applyToProxy(const MString& proxyPath);
+
 public:
 	USDImportDialogCmd() = default;
 	~USDImportDialogCmd() override = default;

--- a/lib/usd/ui/USDImportDialogCmd.h
+++ b/lib/usd/ui/USDImportDialogCmd.h
@@ -25,8 +25,6 @@
 MAYAUSD_NS_DEF {
 
 class MAYAUSD_UI_PUBLIC USDImportDialogCmd : public MPxCommand {
-    MStatus applyToProxy(const MString& proxyPath);
-
 public:
 	USDImportDialogCmd() = default;
 	~USDImportDialogCmd() override = default;
@@ -40,6 +38,9 @@ public:
 	static MSyntax createSyntax();
 
 	MStatus doIt(const MArgList& args) override;
+
+private:
+    MStatus applyToProxy(const MString& proxyPath);
 };
 
 } // namespace MayaUsd

--- a/plugin/adsk/scripts/CMakeLists.txt
+++ b/plugin/adsk/scripts/CMakeLists.txt
@@ -4,6 +4,7 @@ list(APPEND scripts_src
     AEmayaUsdProxyShapeTemplate.mel
     mayaUsdMenu.mel
     mayaUsd_createStageFromFile.mel
+    mayaUsd_createStageFromAsset.mel
 )
 
 install(FILES ${scripts_src}

--- a/plugin/adsk/scripts/mayaUsd_createStageFromAsset.mel
+++ b/plugin/adsk/scripts/mayaUsd_createStageFromAsset.mel
@@ -1,0 +1,30 @@
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+
+global proc string mayaUsd_createStageFromAsset(string $assetPath, string $name) {
+    $assetPath = `usdImportDialog $assetPath`;
+    string $shapeNode = "";
+    if (size($assetPath) != 0)
+    {
+        $shapeNode = `createNode "mayaUsdProxyShape" -skipSelect -name $name`;
+        usdImportDialog -applyToProxy $shapeNode;
+
+        connectAttr time1.outTime ($shapeNode+".time");
+        select -r $shapeNode;
+    }
+    usdImportDialog -clearData;
+    return $shapeNode;
+}


### PR DESCRIPTION
Current code assumes an on-disk 'usd' file, which blocks possible ArAssetResolver from running.
Adds another `mayaUsd_createStageFromAsset` mel procedure to open the UI and apply settings to a proxy.