### PR TITLE
[al] flip translator order

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorBase.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorBase.cpp
@@ -141,6 +141,11 @@ TranslatorManufacture::RefPtr TranslatorManufacture::getTranslatorByAssetTypeMet
 //----------------------------------------------------------------------------------------------------------------------
 TranslatorRefPtr TranslatorManufacture::getTranslatorBySchemaType(const TfToken type_name)
 {
+  if(TranslatorRefPtr py = getPythonTranslatorBySchemaType(type_name))
+  {
+    return py;
+  }
+
   TfType type = TfType::FindDerivedByName<UsdSchemaBase>(type_name);
   std::string typeName(type.GetTypeName());
   TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("TranslatorManufacture::getTranslatorBySchemaType:: found schema %s\n",typeName.c_str());
@@ -155,7 +160,7 @@ TranslatorRefPtr TranslatorManufacture::getTranslatorBySchemaType(const TfToken 
       return it->second;
     }
   }
-  return getPythonTranslatorBySchemaType(type_name);
+  return TranslatorRefPtr();
 }
 
 
@@ -164,6 +169,12 @@ TranslatorRefPtr TranslatorManufacture::get(const MObject& mayaObject)
 {
   TranslatorRefPtr base;
   TranslatorManufacture::RefPtr derived;
+
+  if(auto py = TranslatorManufacture::getPythonTranslator(mayaObject))
+  {
+    return py;
+  }
+  
   for(auto& it : m_translatorsMap)
   {
     if(it.second->active())
@@ -182,11 +193,7 @@ TranslatorRefPtr TranslatorManufacture::get(const MObject& mayaObject)
   if(derived) {
     return derived;
   }
-  else if(base) {
-    return base;
-  }
-  auto py = TranslatorManufacture::getPythonTranslator(mayaObject);
-  return py;
+  return base;
 }
 
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorBase.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorBase.cpp
@@ -141,7 +141,7 @@ TranslatorManufacture::RefPtr TranslatorManufacture::getTranslatorByAssetTypeMet
 //----------------------------------------------------------------------------------------------------------------------
 TranslatorRefPtr TranslatorManufacture::getTranslatorBySchemaType(const TfToken type_name)
 {
-  if(TranslatorRefPtr py = getPythonTranslatorBySchemaType(type_name))
+  if(auto py = getPythonTranslatorBySchemaType(type_name))
   {
     return py;
   }


### PR DESCRIPTION
Previously the AL translator plugin code would first check to see if there was a C++ translator, and would then later check for a python translator. In order to allow the python translators to override the C++ translators, the order has been reversed.