### PR TITLE
MAYA-104213 - add a new USD stage to an empty scene

### DIFF
--- a/lib/mayaUsd/listeners/proxyShapeNotice.cpp
+++ b/lib/mayaUsd/listeners/proxyShapeNotice.cpp
@@ -19,17 +19,19 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_INSTANTIATE_TYPE(UsdMayaProxyStageSetNotice,
+TF_INSTANTIATE_TYPE(MayaUsdProxyStageSetNotice,
+                    TfType::CONCRETE, TF_1_PARENT(TfNotice));
+TF_INSTANTIATE_TYPE(MayaUsdProxyStageInvalidateNotice,
                     TfType::CONCRETE, TF_1_PARENT(TfNotice));
 
-UsdMayaProxyStageSetNotice::UsdMayaProxyStageSetNotice(
+MayaUsdProxyStageBaseNotice::MayaUsdProxyStageBaseNotice(
         const MayaUsdProxyShapeBase& proxy)
         : _proxy(proxy)
 {
 }
 
 const MayaUsdProxyShapeBase&
-UsdMayaProxyStageSetNotice::GetProxyShape() const
+MayaUsdProxyStageBaseNotice::GetProxyShape() const
 {
     return _proxy;
 }

--- a/lib/mayaUsd/listeners/proxyShapeNotice.h
+++ b/lib/mayaUsd/listeners/proxyShapeNotice.h
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#ifndef USDMAYA_PROXYSTAGE_NOTICE_H
-#define USDMAYA_PROXYSTAGE_NOTICE_H
+#ifndef MAYAUSD_PROXYSTAGE_NOTICE_H
+#define MAYAUSD_PROXYSTAGE_NOTICE_H
 
 #include <maya/MObject.h>
 
@@ -27,11 +27,11 @@ PXR_NAMESPACE_OPEN_SCOPE
 class MayaUsdProxyShapeBase;
 
 /// Notice sent when the ProxyShape loads a new stage
-class UsdMayaProxyStageSetNotice : public TfNotice
+class MayaUsdProxyStageBaseNotice : public TfNotice
 {
 public:
     MAYAUSD_CORE_PUBLIC
-    UsdMayaProxyStageSetNotice(const MayaUsdProxyShapeBase& proxy);
+    MayaUsdProxyStageBaseNotice(const MayaUsdProxyShapeBase& proxy);
 
     /// Get proxy shape which had stage set
     MAYAUSD_CORE_PUBLIC
@@ -39,6 +39,18 @@ public:
 
 private:
     const MayaUsdProxyShapeBase& _proxy;
+};
+
+class MayaUsdProxyStageSetNotice : public MayaUsdProxyStageBaseNotice
+{
+public:
+    using MayaUsdProxyStageBaseNotice::MayaUsdProxyStageBaseNotice;
+};
+
+class MayaUsdProxyStageInvalidateNotice : public MayaUsdProxyStageBaseNotice
+{
+public:
+    using MayaUsdProxyStageBaseNotice::MayaUsdProxyStageBaseNotice;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -496,6 +496,11 @@ MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
 
             usdStage->SetEditTarget(usdStage->GetSessionLayer());
         }
+        else if (!usdStage) {
+            // Create a new stage in memory with an anonymous root layer.
+            UsdStageCacheContext ctx(UsdMayaStageCache::Get());
+            usdStage = UsdStage::CreateInMemory("", loadSet);
+        }
 
         if (usdStage) {
             primPath = usdStage->GetPseudoRoot().GetPath();
@@ -621,7 +626,7 @@ MayaUsdProxyShapeBase::computeOutStageData(MDataBlock& dataBlock)
                   this,
                   std::placeholders::_1));
 
-    UsdMayaProxyStageSetNotice(*this).Send();
+    MayaUsdProxyStageSetNotice(*this).Send();
 
     return MS::kSuccess;
 }
@@ -797,6 +802,7 @@ MayaUsdProxyShapeBase::setDependentsDirty(const MPlug& plug, MPlugArray& plugArr
         plug == loadPayloadsAttr ||
         plug == inStageDataAttr) {
         _IncreaseUsdStageVersion();
+        MayaUsdProxyStageInvalidateNotice(*this).Send();
     }
 
     return MPxSurfaceShape::setDependentsDirty(plug, plugArray);

--- a/lib/mayaUsd/ufe/StagesSubject.h
+++ b/lib/mayaUsd/ufe/StagesSubject.h
@@ -76,7 +76,10 @@ private:
 
 private:
 	// Notice listener method for proxy stage set
-	void onStageSet(const UsdMayaProxyStageSetNotice& notice);
+	void onStageSet(const MayaUsdProxyStageSetNotice& notice);
+
+	// Notice listener method for proxy stage invalidate.
+	void onStageInvalidate(const MayaUsdProxyStageInvalidateNotice& notice);
 
 	// Map of per-stage listeners, indexed by stage.
 	typedef TfHashMap<UsdStageWeakPtr, TfNotice::Key, TfHash> StageListenerMap;

--- a/lib/mayaUsd/ufe/UsdStageMap.cpp
+++ b/lib/mayaUsd/ufe/UsdStageMap.cpp
@@ -19,6 +19,7 @@
 
 #include <maya/MFnDagNode.h>
 
+#include <mayaUsd/ufe/ProxyShapeHandler.h>
 #include <mayaUsd/ufe/Utils.h>
 
 namespace {
@@ -92,8 +93,10 @@ void UsdStageMap::addItem(const Ufe::Path& path, UsdStageWeakPtr stage)
 	fStageToObject[stage] = proxyShape;
 }
 
-UsdStageWeakPtr UsdStageMap::stage(const Ufe::Path& path) const
+UsdStageWeakPtr UsdStageMap::stage(const Ufe::Path& path)
 {
+	rebuildIfDirty();
+
 	auto proxyShape = proxyShapeHandle(path);
 	if (!proxyShape.isValid()) {
 		return nullptr;
@@ -106,8 +109,10 @@ UsdStageWeakPtr UsdStageMap::stage(const Ufe::Path& path) const
 	return nullptr;
 }
 
-Ufe::Path UsdStageMap::path(UsdStageWeakPtr stage) const
+Ufe::Path UsdStageMap::path(UsdStageWeakPtr stage)
 {
+	rebuildIfDirty();
+
 	// A stage is bound to a single Dag proxy shape.
 	auto iter = fStageToObject.find(stage);
 	if (iter != std::end(fStageToObject))
@@ -115,10 +120,26 @@ Ufe::Path UsdStageMap::path(UsdStageWeakPtr stage) const
 	return Ufe::Path();
 }
 
-void UsdStageMap::clear()
+void UsdStageMap::setDirty()
 {
 	fObjectToStage.clear();
 	fStageToObject.clear();
+	fDirty = true;
+}
+
+void UsdStageMap::rebuildIfDirty()
+{
+	if (!fDirty) return;
+
+	auto proxyShapeNames = ProxyShapeHandler::getAllNames();
+	for (const auto& psn : proxyShapeNames)
+	{
+		MDagPath dag = nameToDagPath(psn);
+		Ufe::Path ufePath = dagPathToUfe(dag);
+		auto stage = ProxyShapeHandler::dagPathToStage(psn);
+		addItem(ufePath, stage);
+	}
+	fDirty = false;
 }
 
 } // namespace ufe

--- a/lib/mayaUsd/ufe/UsdStageMap.h
+++ b/lib/mayaUsd/ufe/UsdStageMap.h
@@ -66,16 +66,22 @@ public:
 	UsdStageMap(UsdStageMap&&) = delete;
 	UsdStageMap& operator=(UsdStageMap&&) = delete;
 
-	//!Add the input Ufe path and USD Stage to the map.
-	void addItem(const Ufe::Path& path, UsdStageWeakPtr stage);
-
 	//! Get USD stage corresponding to argument Maya Dag path.
-	UsdStageWeakPtr stage(const Ufe::Path& path) const;
+	UsdStageWeakPtr stage(const Ufe::Path& path);
 
 	//! Return the ProxyShape node UFE path for the argument stage.
-	Ufe::Path path(UsdStageWeakPtr stage) const;
+	Ufe::Path path(UsdStageWeakPtr stage);
 
-	void clear();
+	//! Set the stage map as dirty. It will be cleared immediately, but
+	//! only repopulated when stage info is requested.
+	void setDirty();
+
+	//! Returns true if the stage map is dirty (meaning it needs to be filled in).
+	bool isDirty() const { return fDirty; }
+
+private:
+	void addItem(const Ufe::Path& path, UsdStageWeakPtr stage);
+	void rebuildIfDirty();
 
 private:
 	// We keep two maps for fast lookup when there are many proxy shapes.
@@ -83,6 +89,7 @@ private:
 	using StageToObject = TfHashMap<UsdStageWeakPtr, MObjectHandle, TfHash>;
 	ObjectToStage fObjectToStage;
 	StageToObject fStageToObject;
+	bool fDirty{true};
 
 }; // UsdStageMap
 

--- a/lib/usd/hdMaya/adapters/proxyAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/proxyAdapter.cpp
@@ -165,7 +165,7 @@ void HdMayaProxyAdapter::PreFrame() {
     _usdDelegate->PostSyncCleanup();
 }
 
-void HdMayaProxyAdapter::_OnStageSet(const UsdMayaProxyStageSetNotice& notice)
+void HdMayaProxyAdapter::_OnStageSet(const MayaUsdProxyStageSetNotice& notice)
 {
     if(&notice.GetProxyShape() == _proxy)
     {

--- a/lib/usd/hdMaya/adapters/proxyAdapter.h
+++ b/lib/usd/hdMaya/adapters/proxyAdapter.h
@@ -68,7 +68,7 @@ public:
 
 private:
     /// Notice listener method for proxy stage set
-    void _OnStageSet(const UsdMayaProxyStageSetNotice& notice);
+    void _OnStageSet(const MayaUsdProxyStageSetNotice& notice);
 
     MayaUsdProxyShapeBase* _proxy{ nullptr };
     std::unique_ptr<HdMayaProxyUsdImagingDelegate> _usdDelegate;

--- a/plugin/adsk/scripts/CMakeLists.txt
+++ b/plugin/adsk/scripts/CMakeLists.txt
@@ -4,6 +4,7 @@ list(APPEND scripts_src
     AEmayaUsdProxyShapeTemplate.mel
     mayaUsdMenu.mel
     mayaUsd_createStageFromFile.mel
+    mayaUsd_createStageWithNewLayer.py
 )
 
 install(FILES ${scripts_src}

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -58,6 +58,15 @@ proc removeMenuCallback(string $menuName, string $cmd) {
 // initRuntimeCommands
 // create all the runtime commands we'll use and the user can map to hotkeys
 proc initRuntimeCommands() {
+    if (!`runTimeCommand -exists mayaUsdCreateStageWithNewLayer`) {
+        runTimeCommand -default true
+            -label "Stage with New Layer"
+            -annotation "Create a new, empty USD Stage"
+            -category "Menu items.Maya USD"
+            -command "python(\"import mayaUsd_createStageWithNewLayer; mayaUsd_createStageWithNewLayer.createStageWithNewLayer()\")"
+            mayaUsdCreateStageWithNewLayer;
+    }
+
     if (!`runTimeCommand -exists mayaUsdCreateStageFromFile`) {
         runTimeCommand -default true
             -label "Stage From File..."
@@ -103,6 +112,7 @@ global proc mayaUsdMenu_createMenuCallback() {
                 -label "Universal Scene Description (USD)" 
                 -annotation "Create a USD stage" 
                 -version $mayaVersion`;
+            menuItem -runTimeCommand mayaUsdCreateStageWithNewLayer;
             menuItem -runTimeCommand mayaUsdCreateStageFromFile;
             menuItem -runTimeCommand mayaUsdCreateStageFromFileOptions -optionBox true;
         } else {

--- a/plugin/adsk/scripts/mayaUsd_createStageWithNewLayer.py
+++ b/plugin/adsk/scripts/mayaUsd_createStageWithNewLayer.py
@@ -1,0 +1,32 @@
+# Copyright 2020 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import maya.cmds as cmds
+
+def createStageWithNewLayer():
+    """For use in aggregating USD (Assembly) and creating layer structures (Layout)
+    users need to be able to create a new empty stage.
+
+    Executing this command should produce the following:
+    - Proxyshape
+    - Stage
+    - Session Layer
+    - Anonymous Root Layer (this is set as the target layer)
+    """
+
+    # Simply create a proxy shape. Since it does not have a USD file associated
+    # (in the .filePath attribute), the proxy shape base will create an empty
+    # stage in memory. This will create the session and root layer as well.
+    shapeNode = cmds.createNode('mayaUsdProxyShape', name='stageShape')

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -398,6 +398,18 @@ MStatus ProxyShape::setDependentsDirty(const MPlug& plugBeingDirtied, MPlugArray
   {
     MHWRender::MRenderer::setGeometryDrawDirty(thisMObject(), true);
   }
+
+  if (plugBeingDirtied == outStageData() ||
+    // All the plugs that affect outStageDataAttr
+    plugBeingDirtied == filePath() ||
+    plugBeingDirtied == primPath() ||
+    plugBeingDirtied == m_populationMaskIncludePaths ||
+    plugBeingDirtied == m_stageDataDirty ||
+    plugBeingDirtied == m_assetResolverConfig)
+  {
+    MayaUsdProxyStageInvalidateNotice(*this).Send();
+  }
+
   return MPxSurfaceShape::setDependentsDirty(plugBeingDirtied, plugs);
 }
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1432,7 +1432,7 @@ MStatus ProxyShape::computeOutStageData(const MPlug& plug, MDataBlock& dataBlock
     return MS::kFailure;
   }
 
-  UsdMayaProxyStageSetNotice(*this).Send();
+  MayaUsdProxyStageSetNotice(*this).Send();
 
   return status;
 }

--- a/test/lib/ufe/testObject3d.py
+++ b/test/lib/ufe/testObject3d.py
@@ -220,19 +220,14 @@ class Object3dTestCase(unittest.TestCase):
         self.assertFalse(object3d.visibility())
 
         # We should have got 'one' notification.
-        # USD Attribute Notification doubling problem:
-        # Note: because we are using set on the usd attribute (just above)
-        #       directly we we receive TWO notifs in our transform3d observer.
-        #       See UsdAttribute.cpp function setUsdAttr() for details.
-        self.assertEqual(visObs.notifications(), 2)
+        self.assertEqual(visObs.notifications(), 1)
 
         # Make it visible.
         object3d.setVisibility(True)
         self.assertTrue(object3d.visibility())
 
         # We should have got one more notification.
-        # Note: same double notif as above.
-        self.assertEqual(visObs.notifications(), 4)
+        self.assertEqual(visObs.notifications(), 2)
 
         # Remove the observer.
         ufe.Object3d.removeObserver(visObs)

--- a/test/lib/ufe/testTransform3dTranslate.py
+++ b/test/lib/ufe/testTransform3dTranslate.py
@@ -234,8 +234,4 @@ class Transform3dTranslateTestCase(unittest.TestCase):
             Gf.Vec3d(10, 20, 30))
 
         # Notified.
-        # USD Attribute Notification doubling problem:
-        # Note: because we are using set on the usd attribute (just above)
-        #       directly we we receive TWO notifs in our transform3d observer.
-        #       See UsdAttribute.cpp function setUsdAttr() for details.
-        self.assertEqual(t3dObs.notifications(), 2)
+        self.assertEqual(t3dObs.notifications(), 1)


### PR DESCRIPTION
#### MAYA-104213 - As a user, I'd like to add a new USD stage to an empty scene

* New USD notice type for stage invalidate. Send this notice when certain attributes (like filepath) are changed. From the StagesSubject receiver of this notice we also send the new Ufe::ObjectInvalidate() notification.
* When proxy shape compute is called if no filepath was attached, we create an in memory stage.
* Added dirty state to UsdStageMap. When dirty it will rebuild when a new request for stage info is made.
* Cleanup: renamed "UsdMayaProxyStageSetNotice" -> "MayaUsdProxyStageSetNotice".
* Added new menu item "Stage with New Layer".