### PR TITLE
remove use of HdxTaskController::SetColorizeQuantizationEnabled() after USD 20.05

### DIFF
--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
@@ -457,7 +457,7 @@ MStatus MtohRenderOverride::Render(const MHWRender::MDrawContext& drawContext) {
     } else
         _taskController->SetSelectionEnableOutline(false);
 #endif
-#if USD_VERSION_NUM > 1911
+#if USD_VERSION_NUM > 1911 && USD_VERSION_NUM <= 2005
     _taskController->SetColorizeQuantizationEnabled(_globals.enableColorQuantization);
 #endif
 


### PR DESCRIPTION
Following up on #469, the questionable `HdxTaskController::SetColorizeQuantizationEnabled()` was actually removed fairly soon after the release of core USD 20.05 in this commit:
https://github.com/PixarAnimationStudios/USD/commit/584c27d495047aa9a7231df64eec9e22396e5651

The change here ensures we stop using it for USD versions after 20.05.