### PR TITLE
When the stage data changes clear the cache so that the contents of

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -760,6 +760,7 @@ MayaUsdProxyShapeBase::preEvaluation(const MDGContext& context, const MEvaluatio
         evaluationNode.dirtyPlugExists(loadPayloadsAttr) ||
         evaluationNode.dirtyPlugExists(inStageDataAttr)) {
         _IncreaseUsdStageVersion();
+        UsdMayaStageCache::Clear();
     }
 
     return MStatus::kSuccess;
@@ -797,6 +798,7 @@ MayaUsdProxyShapeBase::setDependentsDirty(const MPlug& plug, MPlugArray& plugArr
         plug == loadPayloadsAttr ||
         plug == inStageDataAttr) {
         _IncreaseUsdStageVersion();
+        UsdMayaStageCache::Clear();
     }
 
     return MPxSurfaceShape::setDependentsDirty(plug, plugArray);


### PR DESCRIPTION
out stage data reflect the current state of the proxy shape.