### PR TITLE
remove unused PxrUsdMayaGLBatchRenderer::GetInstancerIndexForHit()

### DIFF
--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -974,24 +974,6 @@ UsdMayaGLBatchRenderer::TestIntersectionCustomPrimFilter(
                              true, outResult);
 }
 
-int
-UsdMayaGLBatchRenderer::GetInstancerIndexForHit(
-        const HdxPickHit& hit) const
-{
-#if defined(HD_API_VERSION) && HD_API_VERSION >= 33
-    return hit.instanceIndex;
-#else
-    int ret = -1;
-    if (auto delegate = _renderIndex->GetSceneDelegateForRprim(hit.objectId)) {
-        delegate->GetPathForInstanceIndex(
-            hit.objectId,
-            hit.instanceIndex,
-            &ret);
-    }
-    return ret;
-#endif
-}
-
 /* static */
 const HdxPickHit*
 UsdMayaGLBatchRenderer::GetNearestHit(

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
@@ -264,12 +264,6 @@ public:
     static const HdxPickHit* GetNearestHit(
             const HdxPickHitVector* hitSet);
 
-    /// Returns the index within the point instancer for \c hit.
-    ///
-    /// Returns -1 if unable to get the instanceIndex.
-    MAYAUSD_CORE_PUBLIC
-    int GetInstancerIndexForHit(const HdxPickHit& hit) const;
-
     /// Returns whether soft selection for proxy shapes is currently enabled.
     MAYAUSD_CORE_PUBLIC
     inline bool GetObjectSoftSelectEnabled()


### PR DESCRIPTION
This was previously used only by a Pixar-internal plugin, but the equivalent functionality is available using `HdSceneDelegate::GetScenePrimPath()`.

(Internal change: 2068351)