### PR TITLE
MAYA-104677 Update MayaUSD to use the new version of the prototype API.

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
@@ -272,6 +272,9 @@ namespace
                 if (TF_VERIFY(shaderMgr)) {
                     shader = shaderMgr->getFragmentShader(
                         _fallbackShaderNames[index], _structOutputName, true);
+#if MAYA_API_VERSION >= 20210000
+                    shader->setWantDiffuseColorMultiDrawConsolidation(true);
+#endif
                 }
             }
 


### PR DESCRIPTION
This change replaces the changes in https://github.com/Autodesk/maya-usd/pull/468 to use an updated prototype API in Maya.