### PR TITLE
MAYA-104401 Add/Clear Reference menu op's

### DIFF
--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -180,30 +180,30 @@ public:
     AddReferenceUndoableCommand(
         const UsdPrim& prim,
         const std::string& filePath
-    ) : fPrim(prim),
-        fSdfRef(),
-        fFilePath(filePath)
+    ) : _prim(prim),
+        _sdfRef(),
+        _filePath(filePath)
     {}
 
     void undo() override { 
-        if (fPrim.IsValid()) {
-            UsdReferences primRefs = fPrim.GetReferences();
-            primRefs.RemoveReference(fSdfRef);
+        if (_prim.IsValid()) {
+            UsdReferences primRefs = _prim.GetReferences();
+            primRefs.RemoveReference(_sdfRef);
         }
     }
 
     void redo() override { 
-        if (fPrim.IsValid()) {
-            fSdfRef = SdfReference(fFilePath);
-            UsdReferences primRefs = fPrim.GetReferences();
-            primRefs.AddReference(fSdfRef);
+        if (_prim.IsValid()) {
+            _sdfRef = SdfReference(_filePath);
+            UsdReferences primRefs = _prim.GetReferences();
+            primRefs.AddReference(_sdfRef);
         }
     }
 
 private:
-    UsdPrim fPrim;
-    SdfReference fSdfRef;
-    const std::string fFilePath;
+    UsdPrim _prim;
+    SdfReference _sdfRef;
+    const std::string _filePath;
 };
 const std::string AddReferenceUndoableCommand::commandName("Add Reference...");
 
@@ -215,7 +215,7 @@ public:
 
     ClearAllReferencesUndoableCommand(
         const UsdPrim& prim
-    ) : fPrim(prim)
+    ) : _prim(prim)
     {}
 
     void undo() override { 
@@ -223,14 +223,14 @@ public:
     }
 
     void redo() override { 
-        if (fPrim.IsValid()) {
-            UsdReferences primRefs = fPrim.GetReferences();
+        if (_prim.IsValid()) {
+            UsdReferences primRefs = _prim.GetReferences();
             primRefs.ClearReferences();
         }
     }
 
 private:
-    UsdPrim fPrim;
+    UsdPrim _prim;
 };
 const std::string ClearAllReferencesUndoableCommand::commandName("Clear All References");
 const MString ClearAllReferencesUndoableCommand::cancelRemoval("No");

--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -23,9 +23,13 @@
 #include <ufe/attribute.h>
 #include <ufe/path.h>
 
+#include <pxr/usd/sdf/reference.h>
+#include <pxr/usd/usd/references.h>
 #include <pxr/usd/usd/variantSets.h>
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/usd/usdGeom/tokens.h>
+
+#include <mayaUsd/utils/util.h>
 
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/ufe/UsdSceneItem.h>
@@ -140,6 +144,97 @@ private:
     PXR_NS::TfToken _primToken;
 };
 
+const char* selectUSDFileScript = R"(
+global proc string SelectUSDFileForAddReference()
+{
+    string $result[] = `fileDialog2 
+        -fileMode 1
+        -caption "Add Reference to USD Prim"
+        -fileFilter "USD Files (*.usd *.usda *.usdc);;*.usd;;*.usda;;*.usdc"`;
+
+    if (0 == size($result))
+        return "";
+    else
+        return $result[0];
+}
+SelectUSDFileForAddReference();
+)";
+
+const char* clearAllReferencesConfirmScript = R"(
+global proc string ClearAllUSDReferencesConfirm()
+{
+    return `confirmDialog -title "Remove All References" 
+        -message "Removing all references from USD prim.  Are you sure?"
+        -button "Yes" -button "No" -defaultButton "Yes"
+        -cancelButton "No" -dismissString "No"`;
+
+}
+ClearAllUSDReferencesConfirm();
+)";
+
+class AddReferenceUndoableCommand : public Ufe::UndoableCommand
+{
+public:
+    static const std::string commandName;
+
+    AddReferenceUndoableCommand(
+        const UsdPrim& prim,
+        const std::string& filePath
+    ) : fPrim(prim),
+        fSdfRef(),
+        fFilePath(filePath)
+    {}
+
+    void undo() override { 
+        if (fPrim.IsValid()) {
+            UsdReferences primRefs = fPrim.GetReferences();
+            primRefs.RemoveReference(fSdfRef);
+        }
+    }
+
+    void redo() override { 
+        if (fPrim.IsValid()) {
+            fSdfRef = SdfReference(fFilePath);
+            UsdReferences primRefs = fPrim.GetReferences();
+            primRefs.AddReference(fSdfRef);
+        }
+    }
+
+private:
+    UsdPrim fPrim;
+    SdfReference fSdfRef;
+    const std::string fFilePath;
+};
+const std::string AddReferenceUndoableCommand::commandName("Add Reference...");
+
+class ClearAllReferencesUndoableCommand : public Ufe::UndoableCommand
+{
+public:
+    static const std::string commandName;
+    static const MString cancelRemoval;
+
+    ClearAllReferencesUndoableCommand(
+        const UsdPrim& prim
+    ) : fPrim(prim)
+    {}
+
+    void undo() override { 
+
+    }
+
+    void redo() override { 
+        if (fPrim.IsValid()) {
+            UsdReferences primRefs = fPrim.GetReferences();
+            primRefs.ClearReferences();
+        }
+    }
+
+private:
+    UsdPrim fPrim;
+};
+const std::string ClearAllReferencesUndoableCommand::commandName("Clear All References");
+const MString ClearAllReferencesUndoableCommand::cancelRemoval("No");
+
 }
 
 MAYAUSD_NS_DEF {
@@ -220,6 +315,11 @@ Ufe::ContextOps::Items UsdContextOps::getItems(
         // Top level item - Add New Prim (for all context op types).
         items.emplace_back(
             kUSDAddNewPrimItem, kUSDAddNewPrimLabel, Ufe::ContextItem::kHasChildren);
+
+        items.emplace_back(AddReferenceUndoableCommand::commandName,
+                            AddReferenceUndoableCommand::commandName);
+        items.emplace_back(ClearAllReferencesUndoableCommand::commandName,
+                            ClearAllReferencesUndoableCommand::commandName);
     }
     else {
         if (itemPath[0] == kUSDVariantSetsItem) {
@@ -314,6 +414,24 @@ Ufe::UndoableCommand::Ptr UsdContextOps::doOpCmd(const ItemPath& itemPath)
         // Just open the editor directly and return null so we don't have undo.
         MGlobal::executeCommand("UsdLayerEditor");
         return nullptr;
+    }
+    else if (itemPath[0] == AddReferenceUndoableCommand::commandName) {
+        MString fileRef = MGlobal::executeCommandStringResult(selectUSDFileScript);
+
+        std::string path = UsdMayaUtil::convert(fileRef);
+        if (path.empty())
+            return nullptr;
+
+        return std::make_shared<AddReferenceUndoableCommand>(
+            fPrim, path);        
+    }
+    else if (itemPath[0] == ClearAllReferencesUndoableCommand::commandName) {
+        MString confirmation = MGlobal::executeCommandStringResult(clearAllReferencesConfirmScript);
+        if (ClearAllReferencesUndoableCommand::cancelRemoval == confirmation)
+            return nullptr;
+
+        return std::make_shared<ClearAllReferencesUndoableCommand>(fPrim);
+        
     }
 
     return nullptr;


### PR DESCRIPTION
Added "Add Reference" and "Clear All References" menu items to the Outliner popup menu for UFE objects.  This is just a quick initial implementation, a separate Issue will be logged by Design to cover a more complete/advanced workflow.

