### PR TITLE
remove unused method warning: _CreateFloatAttribute 

### DIFF
--- a/lib/mayaUsd/render/mayaToHydra/renderGlobals.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderGlobals.cpp
@@ -177,10 +177,12 @@ void _CreateBoolAttribute(
     _CreateNumericAttribute<bool>(node, attrName, MFnNumericData::kBoolean, defValue);
 }
 
+#if USD_VERSION_NUM >= 2005
 void _CreateFloatAttribute(
     MFnDependencyNode& node, const TfToken& attrName, float defValue) {
     _CreateNumericAttribute<float>(node, attrName, MFnNumericData::kFloat, defValue);
 }
+#endif
 
 void _CreateStringAttribute(
     MFnDependencyNode& node, const TfToken& attrName,


### PR DESCRIPTION
The usage of _CreateFloatAttribute is conditionally compiled. When using older versions of usd (e.g. 20.2), a compiler warning is generated for the unused method. Conditionally compile the method as well to remove the warning.