### PR TITLE
Add override flag for setting WORKING_DIRECTORY

### DIFF
--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -15,6 +15,7 @@ endfunction()
 #   PYTHON_COMMAND     - Python code to execute; should call sys.exit
 #                        with an appropriate exitcode to indicate success
 #                        or failure.
+#   WORKING_DIRECTORY  - Directory from which the test executable will be called.
 #   COMMAND            - Command line to execute as a test
 #   NO_STANDALONE_INIT - Only allowable with PYTHON_MODULE or
 #                        PYTHON_COMMAND. With those modes, this
@@ -49,9 +50,9 @@ function(mayaUsd_add_test test_name)
     # -----------------
 
     cmake_parse_arguments(PREFIX
-        "NO_STANDALONE_INIT"            # options
-        "PYTHON_MODULE;PYTHON_COMMAND"  # one_value keywords
-        "COMMAND;ENV"                   # multi_value keywords
+        "NO_STANDALONE_INIT"                              # options
+        "PYTHON_MODULE;PYTHON_COMMAND;WORKING_DIRECTORY"  # one_value keywords
+        "COMMAND;ENV"                                     # multi_value keywords
         ${ARGN}
     )
 
@@ -72,6 +73,13 @@ function(mayaUsd_add_test test_name)
                                           OR PREFIX_PYTHON_COMMAND))
         message(FATAL_ERROR "mayaUsd_add_test: NO_STANDALONE_INIT may only be "
             "used with PYTHON_MODULE or PYTHON_COMMAND")
+    endif()
+
+    # set the working_dir
+    if(PREFIX_WORKING_DIRECTORY)
+        set(working_dir ${PREFIX_WORKING_DIRECTORY})
+    else()
+        set(working_dir ${CMAKE_CURRENT_SOURCE_DIR})
     endif()
 
     # --------------
@@ -116,7 +124,7 @@ finally:
 
     add_test(
         NAME "${test_name}"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        WORKING_DIRECTORY ${working_dir}
         COMMAND ${command}
     )
 

--- a/test/lib/ufe/CMakeLists.txt
+++ b/test/lib/ufe/CMakeLists.txt
@@ -56,6 +56,7 @@ mayaUsd_copyFiles(${TARGET_NAME} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
 foreach(script ${test_script_files})
     mayaUsd_get_unittest_target(target ${script})
     mayaUsd_add_test(${target}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         PYTHON_MODULE ${target}
         ENV
             "MAYA_PLUG_IN_PATH=${CMAKE_CURRENT_BINARY_DIR}/ufeTestPlugins"


### PR DESCRIPTION
Added a new flag to allow overriding `WORKING_DIRECTORY`. If this flag is not set, ${CMAKE_CURRENT_SOURCE_DIR} is used hence the default behavior. 

UFE tests are supposed to run from build directory. We already copy all the python tests and resource to build directory and therefore WORKING_DIRECTORY needs to be set to ${CMAKE_CURRENT_BINARY_DIR}