### PR TITLE
[al] Added '.variantFallbacks' attribute

### DIFF
--- a/plugin/al/docs/proxyShape.md
+++ b/plugin/al/docs/proxyShape.md
@@ -18,6 +18,30 @@ The only addition to default Hydra rendering AL_USDMaya currently adds is suppor
 ## The Node
 see [code docs](https://animallogic.github.io/AL_USDMaya/classAL_1_1usdmaya_1_1nodes_1_1ProxyShape.html) for documentation on the attributes of the node.
 
+**Additional note on variant fallbacks**
+
+Departments might have different variant fallbacks request for different workflow, they might add overrides of global variant fallbacks before loading a stage then restore the global fallbacks later, this information is not stored anywhere, thus will be lost if Maya scene saved and reopened, resulting in inconsistent stage hierarchy.
+
+ProxyShape provides an attribute ".variantFallbacks" to store the variant fallbacks:
++ Before stage is loaded, check if the attribute ".variantFallbacks" has variant fallbacks, use that to override global variant fallbacks if found;
++ If "stageCacheId" is specified when loading an existing stage (see [AL_usdmaya_ProxyShapeImport](proxyShape.md#Importing with AL_usdmaya_ProxyShapeImport)), check if the session layer has any "variant_fallbacks" metadata, save that data value to ".variantFallbacks" attribute if found.
+
+Both of the key and value types for "variant_fallbacks" should be string type, the value string is a serialised string form of JSON format.
+
+```
+# Python example:
+>>> variantFallbacks = {'geo': ['proxy', 'render']}
+>>> customLayerData = stage.GetSessionLayer().customLayerData
+>>> customLayerData['variant_fallbacks'] = json.dumps(variantFallbacks)
+>>> stage.GetSessionLayer().customLayerData = customLayerData
+>>> print(stage.GetSessionLayer().ExportToString())
+#sdf 1.4.32
+(
+    customLayerData = {
+        string variant_fallbacks = '{"geo": ["proxy", "render"]}'
+    }
+)
+```
 
 ## Importing with AL_usdmaya_ProxyShapeImport
 + loads the USD stage into memory

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -126,6 +126,7 @@ MObject ProxyShape::m_transformScale = MObject::kNullObj;
 MObject ProxyShape::m_stageDataDirty = MObject::kNullObj;
 MObject ProxyShape::m_stageCacheId = MObject::kNullObj;
 MObject ProxyShape::m_assetResolverConfig = MObject::kNullObj;
+MObject ProxyShape::m_variantFallbacks = MObject::kNullObj;
 MObject ProxyShape::m_visibleInReflections = MObject::kNullObj;
 MObject ProxyShape::m_visibleInRefractions = MObject::kNullObj;
 
@@ -595,6 +596,7 @@ MStatus ProxyShape::initialise()
     m_stageCacheId = addInt32Attr("stageCacheId", "stcid", -1, kCached | kConnectable | kReadable | kInternal );
 
     m_assetResolverConfig = addStringAttr("assetResolverConfig", "arc", kReadable | kWritable | kConnectable | kStorable | kAffectsAppearance | kInternal);
+    m_variantFallbacks = addStringAttr("variantFallbacks", "vfs", kReadable | kWritable | kConnectable | kStorable | kAffectsAppearance | kInternal);
 
     AL_MAYA_CHECK_ERROR(attributeAffects(time(), m_outTime), errorString);
     AL_MAYA_CHECK_ERROR(attributeAffects(m_timeOffset, m_outTime), errorString);
@@ -604,6 +606,7 @@ MStatus ProxyShape::initialise()
     AL_MAYA_CHECK_ERROR(attributeAffects(m_populationMaskIncludePaths, outStageData()), errorString);
     AL_MAYA_CHECK_ERROR(attributeAffects(m_stageDataDirty, outStageData()), errorString);
     AL_MAYA_CHECK_ERROR(attributeAffects(m_assetResolverConfig, outStageData()), errorString);
+    AL_MAYA_CHECK_ERROR(attributeAffects(m_variantFallbacks, outStageData()), errorString);
   }
   catch (const MStatus& status)
   {
@@ -1168,6 +1171,12 @@ void ProxyShape::loadStage()
       MGlobal::displayError(MString("ProxyShape::loadStage called with non-existent stageCacheId ") + stageId.ToString().c_str());
       stageId = UsdStageCache::Id();
     }
+
+    // Save variant fallbacks from session layer to Maya node attribute
+    if (m_stage)
+    {
+      saveVariantFallbacks(getVariantFallbacksFromLayer(m_stage->GetSessionLayer()), dataBlock);
+    }
   }
   else
   {
@@ -1268,6 +1277,11 @@ void ProxyShape::loadStage()
         }
         AL_END_PROFILE_SECTION();
 
+        AL_BEGIN_PROFILE_SECTION(UpdateGlobalVariantFallbacks);
+        PcpVariantFallbackMap defaultVariantFallbacks;
+        PcpVariantFallbackMap fallbacks(updateVariantFallbacks(defaultVariantFallbacks, dataBlock));
+        AL_END_PROFILE_SECTION();
+
         AL_BEGIN_PROFILE_SECTION(UsdStageOpen);
         {
           UsdStageCacheContext ctx(StageCache::Get());
@@ -1305,6 +1319,17 @@ void ProxyShape::loadStage()
           trackEditTargetLayer();
         }
         AL_END_PROFILE_SECTION();
+
+        AL_BEGIN_PROFILE_SECTION(ResetGlobalVariantFallbacks);
+        // reset only if the global variant fallbacks has been modified
+        if (!fallbacks.empty())
+        {
+          saveVariantFallbacks(convertVariantFallbacksToStr(fallbacks), dataBlock);
+          // restore default value
+          UsdStage::SetGlobalVariantFallbacks(defaultVariantFallbacks);
+        }
+        AL_END_PROFILE_SECTION();
+
       AL_END_PROFILE_SECTION();
     }
     else if (!fileString.empty())
@@ -1526,18 +1551,18 @@ bool ProxyShape::setInternalValue(const MPlug& plug, const MDataHandle& dataHand
   // the datablock for us, but this would be too late for these subfunctions
   TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("ProxyShape::setInternalValue %s\n", plug.name().asChar());
 
-  if(plug == filePath() || plug == m_assetResolverConfig || plug == m_stageCacheId)
+  if(plug == filePath() || plug == m_assetResolverConfig || plug == m_stageCacheId || plug == m_variantFallbacks)
   {
     m_filePathDirty = true;
     
     // can't use dataHandle.datablock(), as this is a temporary datahandle
     MDataBlock datablock = forceCache();
 
-    if (plug == filePath() || plug == m_assetResolverConfig)
+    if (plug == filePath() || plug == m_assetResolverConfig || plug == m_variantFallbacks)
     {
       AL_MAYA_CHECK_ERROR_RETURN_VAL(outputStringValue(datablock, plug, dataHandle.asString()),
                                      false,
-                                     "ProxyShape::setInternalValue - error setting filePath or assetResolverConfig");
+                                     "ProxyShape::setInternalValue - error setting filePath, assetResolverConfig or variantFallbacks");
     }
     else
     {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -345,6 +345,9 @@ public:
   /// A place to put a custom assetResolver Config string that's passed to the Resolver Context when stage is opened
   AL_DECL_ATTRIBUTE(assetResolverConfig);
 
+  /// Variant fallbacks if stage was opened and/reopened a Maya scene with custom variants fallbacks
+  AL_DECL_ATTRIBUTE(variantFallbacks);
+
   //--------------------------------------------------------------------------------------------------------------------
   /// \name   Output Attributes
   //--------------------------------------------------------------------------------------------------------------------
@@ -983,6 +986,32 @@ private:
   UsdPrim getUsdPrim(MDataBlock& dataBlock) const;
   SdfPathVector getExcludePrimPaths() const override;
   UsdStagePopulationMask constructStagePopulationMask(const MString &paths) const;
+
+  /// \brief  Convert variant fallbacks from string (attribute value)
+  /// \param  fallbacksStr attribute value
+  /// \return PcpVariantFallbackMap type of variant fallbacks
+  PcpVariantFallbackMap convertVariantFallbackFromStr(const MString& fallbacksStr) const;
+
+  /// \brief  Convert variant fallbacks to string
+  /// \param  fallbacks variant fallbacks map
+  /// \return MString string form of variant fallbacks
+  MString convertVariantFallbacksToStr(const PcpVariantFallbackMap& fallbacks) const;
+
+  /// \brief  Get variant fallbacks from session layer
+  /// \param  layer session layer pointer
+  /// \return MString string form of variant fallbacks JSON data
+  MString getVariantFallbacksFromLayer(const SdfLayerRefPtr& layer) const;
+
+  /// \brief  Set global variant fallbacks if found from attribute ".variantFallbacks"
+  /// \param  defaultVariantFallbacks default global variant fallbacks before updating
+  /// \param  dataBlock attribute data block
+  /// \return PcpVariantFallbackMap variant fallbacks that applied to global variant fallbacks, would be empty if nothing applied
+  PcpVariantFallbackMap updateVariantFallbacks(PcpVariantFallbackMap& defaultVariantFallbacks, MDataBlock& dataBlock) const;
+
+  /// \brief  Save variant fallbacks from session layer customLayerData to attribute
+  /// \param  fallbacksStr string format of variant fallbacks to save to the node attribute
+  /// \param  dataBlock attribute data block
+  void saveVariantFallbacks(const MString& fallbacksStr, MDataBlock& dataBlock) const;
 
   bool isStageValid() const;
   bool initPrim(const uint32_t index, MDGContext& ctx);

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/ProxyShapeVariantFallbacks.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/ProxyShapeVariantFallbacks.cpp
@@ -1,0 +1,140 @@
+//
+// Copyright 2017 Animal Logic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "AL/usdmaya/nodes/ProxyShape.h"
+
+#include "pxr/base/js/json.h"
+#include "pxr/usd/pcp/types.h"
+
+namespace AL {
+namespace usdmaya {
+namespace nodes {
+
+
+//----------------------------------------------------------------------------------------------------------------------
+PcpVariantFallbackMap ProxyShape::convertVariantFallbackFromStr(const MString& fallbacksStr) const
+{
+  if (!fallbacksStr.length())
+  {
+    return {};
+  }
+
+  JsParseError parseError;
+  JsValue jsValue(JsParseString(fallbacksStr.asChar(), &parseError));
+  if (parseError.line || !jsValue.IsObject())
+  {
+    MGlobal::displayError(MString(parseError.reason.c_str()));
+    MGlobal::displayError(
+      MString("ProxyShape attribute \"") + name() + ".variantFallbacks\" "
+      "contains incorrect variant fallbacks, value must be a string form of JSON data.");
+    return {};
+  }
+
+  JsObject jsObject(jsValue.GetJsObject());
+  PcpVariantFallbackMap result;
+  for (const auto& variantSet: jsObject)
+  {
+    const std::string& variantName = variantSet.first;
+    if (!variantSet.second.IsArray())
+    {
+      MGlobal::displayError(
+        MString("ProxyShape attribute \"") + name() + ".variantFallbacks\" "
+        "contains unexpected data: variant value for \"" + variantName.c_str() + "\" must be an array.");
+      continue;
+    }
+    result[variantName] = variantSet.second.GetArrayOf<std::string>();
+  }
+  return result;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MString ProxyShape::convertVariantFallbacksToStr(const PcpVariantFallbackMap& fallbacks) const
+{
+  if (fallbacks.empty())
+  {
+    return {};
+  }
+
+  JsObject jsObject;
+  for (const auto& variantSet: fallbacks)
+  {
+    jsObject[variantSet.first] = JsArray(variantSet.second.cbegin(), variantSet.second.cend());
+  }
+
+  return JsWriteToString(jsObject).c_str();
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MString ProxyShape::getVariantFallbacksFromLayer(const SdfLayerRefPtr& layer) const
+{
+  if (!layer)
+  {
+    return {};
+  }
+
+  static const std::string kVariantFallbacksToken = "variant_fallbacks";
+  const VtDictionary& data(layer->GetCustomLayerData());
+  const auto& valIt(data.find(kVariantFallbacksToken));
+  if (valIt == data.end())
+  {
+    return {};
+  }
+
+  const VtValue& customFallbacksVal(valIt->second);
+  if (!customFallbacksVal.IsHolding<std::string>())
+  {
+    TF_WARN(
+        "Session layer has wrong \"%s\" data type, value must be a string.",
+        kVariantFallbacksToken.c_str());
+    return {};
+  }
+  auto result = customFallbacksVal.Get<std::string>();
+  if (result.empty())
+  {
+    return {};
+  }
+  return result.c_str();
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+PcpVariantFallbackMap ProxyShape::updateVariantFallbacks(PcpVariantFallbackMap& defaultVariantFallbacks, MDataBlock& dataBlock) const
+{
+  auto fallbacks(convertVariantFallbackFromStr(inputStringValue(dataBlock, m_variantFallbacks)));
+  if (!fallbacks.empty())
+  {
+    defaultVariantFallbacks = UsdStage::GetGlobalVariantFallbacks();
+    TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("Setting global variant fallback");
+    UsdStage::SetGlobalVariantFallbacks(fallbacks);
+    return fallbacks;
+  }
+  return {};
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+void ProxyShape::saveVariantFallbacks(const MString& fallbacksStr, MDataBlock& dataBlock) const
+{
+  if (fallbacksStr != inputStringValue(dataBlock, m_variantFallbacks))
+  {
+    TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("Saving global variant fallbacks: \n\"%s\"\n", fallbacksStr.asChar());
+    outputStringValue(dataBlock, m_variantFallbacks, fallbacksStr);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+} // nodes
+} // usdmaya
+} // AL
+//----------------------------------------------------------------------------------------------------------------------

--- a/plugin/al/lib/AL_USDMaya/CMakeLists.txt
+++ b/plugin/al/lib/AL_USDMaya/CMakeLists.txt
@@ -140,6 +140,7 @@ list(APPEND AL_usdmaya_nodes_source
         AL/usdmaya/nodes/proxy/LockManager.cpp
         AL/usdmaya/nodes/proxy/PrimFilter.cpp
         AL/usdmaya/nodes/proxy/ProxyShapeMetaData.cpp
+        AL/usdmaya/nodes/proxy/ProxyShapeVariantFallbacks.cpp
 )
 
 list(APPEND AL_usdmaya_public_headers

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_VariantFallbacks.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_VariantFallbacks.cpp
@@ -1,0 +1,227 @@
+//
+// Copyright 2017 Animal Logic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "test_usdmaya.h"
+
+#include "AL/usdmaya/nodes/ProxyShape.h"
+
+#include "pxr/usd/usd/stage.h"
+#include "pxr/usd/usdUtils/stageCache.h"
+
+#include "maya/MSelectionList.h"
+#include "maya/MGlobal.h"
+#include "maya/MDagPath.h"
+#include "maya/MFnDagNode.h"
+#include "maya/MFileIO.h"
+
+namespace
+{
+  //! create a ProxyShape node from file path
+  AL::usdmaya::nodes::ProxyShape* createProxy(const MString& path)
+  {
+    MString importCommand = "AL_usdmaya_ProxyShapeImport -f \"" + path +"\"";
+    MStringArray cmdResults;
+    MGlobal::executeCommand(importCommand, cmdResults, true);
+    MString proxyName = cmdResults[0];
+
+    MSelectionList sel;
+    sel.add(proxyName);
+    MDagPath proxyDagPath;
+    sel.getDagPath(0, proxyDagPath);
+    MFnDagNode proxyMFn(proxyDagPath);
+    return dynamic_cast<AL::usdmaya::nodes::ProxyShape*>(proxyMFn.userNode());
+  }
+
+  //! create a ProxyShape node without any file path
+  AL::usdmaya::nodes::ProxyShape* createProxy()
+  {
+    MFnDagNode fn;
+    MObject xform = fn.create("transform");
+    MObject shape = fn.create("AL_usdmaya_ProxyShape", xform);
+    return dynamic_cast<AL::usdmaya::nodes::ProxyShape*>(fn.userNode());
+  }
+
+  //! create a ProxyShape node with specified name and stage cache id
+  AL::usdmaya::nodes::ProxyShape* createProxy(const MString& name, long stageCacheId)
+  {
+    MString importCommand =
+      MString("AL_usdmaya_ProxyShapeImport  ")
+      + "-name \"" + name + "\" " + "-stageId " + stageCacheId;
+    MStringArray cmdResults;
+    MGlobal::executeCommand(importCommand, cmdResults, true);
+    MString proxyName = cmdResults[0];
+
+    MSelectionList sel;
+    sel.add(proxyName);
+    MDagPath proxyDagPath;
+    sel.getDagPath(0, proxyDagPath);
+    MFnDagNode proxyMFn(proxyDagPath);
+    return dynamic_cast<AL::usdmaya::nodes::ProxyShape*>(proxyMFn.userNode());
+  }
+}
+
+// Test variant fallback config from global setting, the attribute
+// ".variantFallbacks" should have no change (compatible with previous
+// behaviour).
+TEST(VariantFallbacks, fromGlobal)
+{
+  MString filePath = MString(AL_USDMAYA_TEST_DATA) + "/variant_fallbacks.usda";
+  MFileIO::newFile(true);
+
+  PXR_NS::PcpVariantFallbackMap defaultVariantFallbacks(PXR_NS::UsdStage::GetGlobalVariantFallbacks());
+  // set global variant fallback to custom value
+  PXR_NS::PcpVariantFallbackMap fallbacks;
+  fallbacks["geo"] = {{"plane"}};
+  PXR_NS::UsdStage::SetGlobalVariantFallbacks(fallbacks);
+
+  auto proxy = createProxy(filePath);
+  PXR_NS::SdfPath primPath("/root/GEO/plane1/planeShape1");
+  EXPECT_TRUE(proxy->getUsdStage()->GetPrimAtPath(primPath).IsValid());
+  // the attribute should be empty because no custom variant provided
+  EXPECT_TRUE(proxy->variantFallbacksPlug().asString().length() == 0);
+
+  // restore to default
+  PXR_NS::UsdStage::SetGlobalVariantFallbacks(defaultVariantFallbacks);
+}
+
+// Test variant fallback from ".variantFallbacks" attribute.
+// This is to cover the case when user reopen a Maya scene file with a
+// predefined variant fallback setting; global variant fallback should remain
+// the same.
+TEST(VariantFallbacks, fromAttribute)
+{
+  MString filePath = MString(AL_USDMAYA_TEST_DATA) + "/variant_fallbacks.usda";
+  MFileIO::newFile(true);
+
+  PXR_NS::PcpVariantFallbackMap defaultVariantFallbacks(PXR_NS::UsdStage::GetGlobalVariantFallbacks());
+
+  auto proxy = createProxy();
+  // Note: MString below is a pre-formatted JSON data
+  MString variantAttrVal("{\n    \"geo\": [\"non_exist_variant\", \"cube\"]\n}");
+  // set the variant fallback config
+  proxy->variantFallbacksPlug().setString(variantAttrVal);
+  // trigger stage loading, the "cube" variant should be picked
+  proxy->filePathPlug().setString(filePath);
+
+  // verify loaded prim
+  PXR_NS::SdfPath primPath("/root/GEO/cube1/cubeShape1");
+  EXPECT_TRUE(proxy->getUsdStage()->GetPrimAtPath(primPath).IsValid());
+  // proxy node should have saved the config to ".variantFallbacks"
+  EXPECT_EQ(proxy->variantFallbacksPlug().asString(), variantAttrVal);
+  // default global variant should not be changed
+  EXPECT_EQ(PXR_NS::UsdStage::GetGlobalVariantFallbacks(), defaultVariantFallbacks);
+}
+
+// Test variant fallback from ".variantFallbacks" attribute with invalid
+// format.
+TEST(VariantFallbacks, invalidAttributeFormat)
+{
+  MString filePath = MString(AL_USDMAYA_TEST_DATA) + "/variant_fallbacks.usda";
+  MFileIO::newFile(true);
+
+  PXR_NS::PcpVariantFallbackMap defaultVariantFallbacks(PXR_NS::UsdStage::GetGlobalVariantFallbacks());
+
+  auto proxy = createProxy();
+  MString variantAttrVal("<invalid json format>");
+  // set the variant fallback config
+  proxy->variantFallbacksPlug().setString(variantAttrVal);
+  // trigger stage loading, the "cube" variant should be picked
+  proxy->filePathPlug().setString(filePath);
+  // ".variantFallbacks" attribute should have no change
+  EXPECT_EQ(proxy->variantFallbacksPlug().asString(), variantAttrVal);
+  // default global variant should have no change
+  EXPECT_EQ(PXR_NS::UsdStage::GetGlobalVariantFallbacks(), defaultVariantFallbacks);
+}
+
+// Test variant fallback from ".variantFallbacks" attribute with invalid
+// type.
+TEST(VariantFallbacks, incorrectVariantType)
+{
+  MString filePath = MString(AL_USDMAYA_TEST_DATA) + "/variant_fallbacks.usda";
+  MFileIO::newFile(true);
+
+  PXR_NS::PcpVariantFallbackMap defaultVariantFallbacks(PXR_NS::UsdStage::GetGlobalVariantFallbacks());
+
+  auto proxy = createProxy();
+  // Note: MString below is a pre-formatted JSON data
+  MString variantAttrVal("{\n    \"geo\": \"incorrect type\"\n}");
+  // set the variant fallback config
+  proxy->variantFallbacksPlug().setString(variantAttrVal);
+  // trigger stage loading, the "cube" variant should be picked
+  proxy->filePathPlug().setString(filePath);
+  // ".variantFallbacks" attribute should have no change
+  EXPECT_EQ(proxy->variantFallbacksPlug().asString(), variantAttrVal);
+  // default global variant should have no change
+  EXPECT_EQ(PXR_NS::UsdStage::GetGlobalVariantFallbacks(), defaultVariantFallbacks);
+}
+
+// Test variant fallback from session layer.
+// This is to cover the case where department workflow / etc. apps that had
+// variant fallback overrides saved on session layer, the ".variantFallbacks"
+// attribute should save that overrides value
+TEST(VariantFallbacks, fromSessionLayer)
+{
+  std::string filePath = std::string(AL_USDMAYA_TEST_DATA) + "/variant_fallbacks.usda";
+  MFileIO::newFile(true);
+
+  PXR_NS::PcpVariantFallbackMap defaultVariantFallbacks(PXR_NS::UsdStage::GetGlobalVariantFallbacks());
+  PXR_NS::UsdStageCache::Id stageCacheId;
+  {
+    // simulate the workflow that Forge2 would do, which set the variants
+    // before loading then restore to default
+    // set variant fallback globally
+    PXR_NS::PcpVariantFallbackMap fallbacks;
+    fallbacks["geo"] = {"non_exist_variant", "sphere"};
+    PXR_NS::UsdStage::SetGlobalVariantFallbacks(fallbacks);
+
+    // open a stage and put it to stage cache
+    auto stage = PXR_NS::UsdStage::Open(filePath);
+    stageCacheId = PXR_NS::UsdUtilsStageCache::Get().Insert(stage);
+    EXPECT_TRUE(stageCacheId.IsValid());
+    // set the same variant fallbacks on session layer
+    auto sessionLayer = stage->GetSessionLayer();
+    PXR_NS::VtDictionary layerData;
+    // NOTE: the value is a pre-formatted string form of JSON data
+    layerData["variant_fallbacks"] = PXR_NS::VtValue("{\n    \"geo\": [\"non_exist_variant\", \"sphere\"]\n}");
+    sessionLayer->SetCustomLayerData(layerData);
+
+    // restore to default
+    PXR_NS::UsdStage::SetGlobalVariantFallbacks(defaultVariantFallbacks);
+  }
+
+  auto proxy = createProxy("testProxy", stageCacheId.ToLongInt());
+  // verify loaded prim
+  PXR_NS::SdfPath primPath("/root/GEO/sphere1/sphereShape1");
+  EXPECT_TRUE(proxy->getUsdStage()->GetPrimAtPath(primPath).IsValid());
+  // Note: MString below is a pre-formatted JSON data
+  MString variantAttrVal("{\n    \"geo\": [\"non_exist_variant\", \"sphere\"]\n}");
+  EXPECT_EQ(proxy->variantFallbacksPlug().asString(), variantAttrVal);
+
+  // verify Maya node existence via selection
+  MString translateCommand =
+    MString("AL_usdmaya_TranslatePrim -importPaths \"/root/GEO/sphere1/sphereShape1\" -forceImport -pushToPrim 0 ")
+    + "-proxy \"" + proxy->name() + "\"";
+  EXPECT_TRUE(MGlobal::executeCommand(translateCommand, true, false) == MStatus::kSuccess);
+  MString spherePath("|testProxy|root|GEO|sphere1|sphereShape1");
+  MDagPath meshDagPath;
+  {
+    MSelectionList sel;
+    sel.add(spherePath);
+    sel.getDagPath(0, meshDagPath);
+  }
+  EXPECT_EQ(meshDagPath.fullPathName(), spherePath);
+  // verify default global variant fallback
+  EXPECT_EQ(PXR_NS::UsdStage::GetGlobalVariantFallbacks(), defaultVariantFallbacks);
+}

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/CMakeLists.txt
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(${TARGET_NAME}
         AL/usdmaya/nodes/test_TransformMatrix.cpp
         AL/usdmaya/nodes/test_ScopeMatrix.cpp
         AL/usdmaya/nodes/test_TranslatorContext.cpp
+        AL/usdmaya/nodes/test_VariantFallbacks.cpp
         AL/usdmaya/test_DiffGeom.cpp
         AL/usdmaya/test_DiffPrimVar.cpp
         AL/usdmaya/test_SelectabilityDB.cpp

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testProxyShape.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testProxyShape.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+import json
 import os
 import tempfile
 import unittest
@@ -316,10 +317,53 @@ class TestProxyShapeGetMayaPathFromUsdPrim(unittest.TestCase):
         os.remove(_file.name)
         
 
+class TestProxyShapeVariantFallbacks(unittest.TestCase):
+    def setUp(self):
+        cmds.file(new=True, force=True)
+        cmds.loadPlugin("AL_USDMayaPlugin", quiet=True)
+
+    def tearDown(self):
+        pxr.UsdUtils.StageCache.Get().Clear()
+        cmds.file(force=True, new=True)
+        cmds.unloadPlugin("AL_USDMayaPlugin", force=True)
+
+    def _prepSessionLayer(self, customVariantFallbacks):
+        defaultGlobalVariantFallbacks = pxr.Usd.Stage.GetGlobalVariantFallbacks()
+        pxr.Usd.Stage.SetGlobalVariantFallbacks(customVariantFallbacks)
+        usdFile = '../test_data/variant_fallbacks.usda'
+
+        stage = pxr.Usd.Stage.Open(usdFile)
+        stageCacheId = pxr.UsdUtils.StageCache.Get().Insert(stage)
+        sessionLayer = stage.GetSessionLayer()
+        sessionLayer.customLayerData = {'variant_fallbacks': json.dumps(customVariantFallbacks)}
+        # restore default
+        pxr.Usd.Stage.SetGlobalVariantFallbacks(defaultGlobalVariantFallbacks)
+
+        # create the proxy node with stage cache id
+        proxyName = cmds.AL_usdmaya_ProxyShapeImport(stageId=stageCacheId.ToLongInt())[0]
+        proxyShape = AL.usdmaya.ProxyShape.getByName(proxyName)
+        return proxyShape, proxyName
+
+    def test_fromSessionLayer(self):
+        # this will create a C++ type of: std::vector<VtValue>
+        custom = {'geo': ['sphere']}
+        proxyShape, proxyName = self._prepSessionLayer(custom)
+
+        # the "sphere" variant prim should be loaded
+        prim = proxyShape.getUsdStage().GetPrimAtPath('/root/GEO/sphere1/sphereShape1')
+        self.assertTrue(prim.IsValid())
+
+        # the custom variant fallback should be saved to the attribute
+        savedAttrValue = cmds.getAttr(proxyName + '.variantFallbacks')
+        self.assertEqual(savedAttrValue, json.dumps(custom))
+
+
 if __name__ == "__main__":
 
     tests = [unittest.TestLoader().loadTestsFromTestCase(TestProxyShapeGetUsdPrimFromMayaPath),
-             unittest.TestLoader().loadTestsFromTestCase(TestProxyShapeGetMayaPathFromUsdPrim)
+             unittest.TestLoader().loadTestsFromTestCase(TestProxyShapeGetMayaPathFromUsdPrim),
+             unittest.TestLoader().loadTestsFromTestCase(TestProxyShapeAnonymousLayer),
+             unittest.TestLoader().loadTestsFromTestCase(TestProxyShapeVariantFallbacks)
               ]
     results = [unittest.TextTestRunner(verbosity=2).run(test) for test in tests]
     exitCode = int(not all([result.wasSuccessful() for result in results]))

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/test_data/variant_fallbacks.usda
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/test_data/variant_fallbacks.usda
@@ -1,0 +1,87 @@
+#usda 1.0
+
+def "root" (
+    prepend variantSets = "geo"
+)
+{
+    def "GEO"
+    {
+    }
+    variantSet "geo" = {
+        "cube" {
+            def Scope "GEO" (
+            )
+            {
+                def Xform "cube1"
+                {
+                    def Mesh "cubeShape1"
+                    {
+                        int[] faceVertexCounts = [4, 4, 4, 4]
+                        int[] faceVertexIndices = [0, 1, 4, 3, 1, 2, 5, 4, 3, 4, 7, 6, 4, 5, 8, 7]
+                        point3f[] points = [(-0.5, 0, 0.5), (0, 0, 0.5), (0.5, 0, 0.5), (-0.5, 0, 0), (0, 0, 0), (0.5, 0, 0), (-0.5, 0, -0.5), (0, 0, -0.5), (0.5, 0, -0.5)]
+                    }
+                }
+            }
+        }
+        "plane" {
+            def Scope "GEO" (
+            )
+            {
+                def Xform "plane1"
+                {
+                    def Mesh "planeShape1"
+                    {
+                        int[] faceVertexCounts = [4, 4, 4, 4]
+                        int[] faceVertexIndices = [0, 1, 4, 3, 1, 2, 5, 4, 3, 4, 7, 6, 4, 5, 8, 7]
+                        point3f[] points = [(-0.5, 0, 0.5), (0, 0, 0.5), (0.5, 0, 0.5), (-0.5, 0, 0), (0, 0, 0), (0.5, 0, 0), (-0.5, 0, -0.5), (0, 0, -0.5), (0.5, 0, -0.5)]
+                    }
+                }
+            }
+        }
+        "sphere" {
+            def Scope "GEO" (
+            )
+            {
+                def Xform "sphere1"
+                {
+                    def Mesh "sphereShape1"
+                    {
+                        int[] faceVertexCounts = [4, 4, 4, 4]
+                        int[] faceVertexIndices = [0, 1, 4, 3, 1, 2, 5, 4, 3, 4, 7, 6, 4, 5, 8, 7]
+                        point3f[] points = [(-0.5, 0, 0.5), (0, 0, 0.5), (0.5, 0, 0.5), (-0.5, 0, 0), (0, 0, 0), (0.5, 0, 0), (-0.5, 0, -0.5), (0, 0, -0.5), (0.5, 0, -0.5)]
+                    }
+                }
+            }
+        }
+        "render_high" {
+            def Scope "GEO" (
+            )
+            {
+                def Xform "render_xform1"
+                {
+                    def Mesh "render_mesh1"
+                    {
+                        int[] faceVertexCounts = [4, 4, 4, 4]
+                        int[] faceVertexIndices = [0, 1, 4, 3, 1, 2, 5, 4, 3, 4, 7, 6, 4, 5, 8, 7]
+                        point3f[] points = [(-0.5, 0, 0.5), (0, 0, 0.5), (0.5, 0, 0.5), (-0.5, 0, 0), (0, 0, 0), (0.5, 0, 0), (-0.5, 0, -0.5), (0, 0, -0.5), (0.5, 0, -0.5)]
+                    }
+                }
+            }
+        }
+        "display_high" {
+            def Scope "GEO" (
+            )
+            {
+                def Xform "display_xform1"
+                {
+                    def Mesh "display_mesh1"
+                    {
+                        int[] faceVertexCounts = [4, 4, 4, 4]
+                        int[] faceVertexIndices = [0, 1, 4, 3, 1, 2, 5, 4, 3, 4, 7, 6, 4, 5, 8, 7]
+                        point3f[] points = [(-0.5, 0, 0.5), (0, 0, 0.5), (0.5, 0, 0.5), (-0.5, 0, 0), (0, 0, 0), (0.5, 0, 0), (-0.5, 0, -0.5), (0, 0, -0.5), (0.5, 0, -0.5)]
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
  Added '.variantFallbacks' attribute to store custom fallbacksThis PR is to add support of storing custom variant fallbacks inot ".variantFallbacks" ProxyShape node attribute.

Department might have different variant fallbacks request for different department / workflow apps, they can add overrides of global variant fallbacks before loading a stage then restore the global fallbacks after stage loaded, but previously there was no way to store this information, thus if user saves the Maya scene and reopen the scene file without using previous app, the variant fallbacks would be lost.

The proposed solution is to:

Before stage is loaded, check if the attribute ".variantFallbacks" has stored settings, use that as the fallbacks if foud;
If stageCacheId is provided, check if the session layer has any "variant_fallbacks" metadata, use that as fallbacks if found.
Both of the key and value types for "variant_fallbacks" should be string type, the value string is a serialised string form of JSON format.