### PR TITLE
[al] Handle anonymous layer in ProxyShape

### DIFF
--- a/plugin/al/docs/layers.md
+++ b/plugin/al/docs/layers.md
@@ -16,7 +16,25 @@ Normally, the default Edit Target in USD will be the Root Layer of the scene, bu
 ###### Modifications for exisiting layers
 After doing in-memory edits to our USD scene changes(typically via Maya) we then translate our USD scene, which is a filepath to the root layer and the serialised content of all the modified in-memory layers that are tracked by the LayerManager, into our renderers scene description for rendering. 
 
-#### Commands 
+###### Serialised anonymous layers
+An anonymous root layer can be imported into the ProxyShape by passing the `stageId` into the AL_usdmaya_ProxyShapeImport command. This way the layer manager serialises changes that are made in the root layer without any backing `.usda` or `.usdc` file. As an example this follow script sets up a scene with a single sphere in an anonymous layer, and import that into a ProxyShape.
+
+```python
+from pxr import Usd, UsdUtils, UsdGeom
+from maya import cmds
+
+stageCache = UsdUtils.StageCache.Get()
+with Usd.StageCacheContext(stageCache):
+    stage = Usd.Stage.CreateInMemory()
+    with Usd.EditContext(stage, Usd.EditContext(stage.GetRootLayer())):
+        UsdGeom.Sphere.Define(stage, "/sphere").GetRadiusAttr().Set(1.0)
+
+cmds.AL_usdmaya_ProxyShapeImport(
+    stageId=stageCache.GetId(stage).ToLongInt(),
+    name='anonymousShape'
+```
+
+#### Commands
 There are a number of layer-related commands available, all are available via MEL, and some from the USD->Layers dropdow in the UI.
 + AL_usdmaya_LayerSave
 + AL_usdmaya_LayerCreateLayer

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -749,7 +749,21 @@ void ProxyShape::serialize(UsdStageRefPtr stage, LayerManager* layerManager)
         // ...make sure for the old Maya scene, we clear the sessionLayerName plug so there is no
         // complaint when we open it.
         sessionLayerNamePlug().setValue("");
-      }      
+      }
+
+      auto rootLayer = stage->GetRootLayer();
+      if (rootLayer->IsAnonymous())
+      {
+        // For an anonymous root layer we need to update the file path to match the new
+        // identifier the layer manager may have associated the layer with.
+        MPlug filePathPlug = this->filePathPlug();
+        const std::string currentRootLayerId = AL::maya::utils::convert(filePathPlug.asString());
+        const std::string &newRootLayerId = rootLayer->GetIdentifier();
+        if (currentRootLayerId != newRootLayerId)
+        {
+          filePathPlug.setString(AL::maya::utils::convert(newRootLayerId));
+        }
+      }
 
       // Then add in the current edit target
       trackEditTargetLayer(layerManager);
@@ -1180,30 +1194,67 @@ void ProxyShape::loadStage()
 
     TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("ProxyShape::reloadStage original USD file path is %s\n", fileString.c_str());
 
-    boost::filesystem::path filestringPath(fileString);
-    if (filestringPath.is_absolute())
+    SdfLayerRefPtr rootLayer;
+    if (SdfLayer::IsAnonymousLayerIdentifier(fileString))
     {
-      fileString = UsdMayaUtilFileSystem::resolvePath(fileString);
-      TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("ProxyShape::reloadStage resolved the USD file path to %s\n",
-                                          fileString.c_str());
+      // For anonymous root layer we must explicitly ask for from the layer manager.
+      // This is because USD does not allow us to create a new anonymous SdfLayer
+      // with the exact same identifier. The best we can do is to ask the layer manager
+      // to create the anonymous layer, and let it manage the identifier mappings.
+      if (auto layerManager = LayerManager::findManager())
+      {
+        rootLayer = layerManager->findLayer(fileString);
+      }
+
+      if (rootLayer)
+      {
+        TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg(
+          "ProxyShape::reloadStage found anonymous layer %s from layer manager\n",
+          fileString.c_str()
+        );
+      }
+      else
+      {
+        const std::string tag = SdfLayer::GetDisplayNameFromIdentifier(fileString);
+        rootLayer = SdfLayer::CreateAnonymous(tag);
+        if (rootLayer)
+        {
+          TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg(
+            "ProxyShape::reloadStage created anonymous layer %s (renamed to %s)\n",
+            fileString.c_str(),
+            rootLayer->GetIdentifier().c_str()
+          );
+        }
+      }
     }
     else
     {
-      fileString = UsdMayaUtilFileSystem::resolveRelativePathWithinMayaContext(thisMObject(), fileString);
-      TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("ProxyShape::reloadStage resolved the relative USD file path to %s\n",
-                                          fileString.c_str());
+      boost::filesystem::path filestringPath(fileString);
+      if (filestringPath.is_absolute())
+      {
+        fileString = UsdMayaUtilFileSystem::resolvePath(fileString);
+        TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("ProxyShape::reloadStage resolved the USD file path to %s\n",
+                                            fileString.c_str());
+      }
+      else
+      {
+        fileString = UsdMayaUtilFileSystem::resolveRelativePathWithinMayaContext(thisMObject(), fileString);
+        TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("ProxyShape::reloadStage resolved the relative USD file path to %s\n",
+                                            fileString.c_str());
+      }
+
+      // Fall back on providing the path "as is" to USD
+      if (fileString.empty())
+      {
+        fileString.assign(file.asChar(), file.length());
+      }
+
+      TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("ProxyShape::loadStage called for the usd file: %s\n", fileString.c_str());
+      rootLayer = SdfLayer::FindOrOpen(fileString);
     }
 
-    // Fall back on providing the path "as is" to USD
-    if (fileString.empty())
-    {
-      fileString.assign(file.asChar(), file.length());
-    }
-
-    TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("ProxyShape::loadStage called for the usd file: %s\n", fileString.c_str());
-
-    // Only try to create a stage for layers that can be opened.
-    if (SdfLayerRefPtr rootLayer = SdfLayer::FindOrOpen(fileString))
+     // Only try to create a stage for layers that can be opened.
+    if (rootLayer)
     {
       MStatus status;
       SdfLayerRefPtr sessionLayer;

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testProxyShape.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testProxyShape.py
@@ -18,13 +18,16 @@
 
 import os
 import tempfile
+import shutil
 import unittest
 
 import AL
 
 import pxr
+from pxr import Usd, UsdUtils
 
 from maya import cmds
+from maya.api import OpenMaya as om2
 
 
 class TestProxyShapeGetUsdPrimFromMayaPath(unittest.TestCase):
@@ -314,12 +317,76 @@ class TestProxyShapeGetMayaPathFromUsdPrim(unittest.TestCase):
 
         # Cleanup
         os.remove(_file.name)
-        
+
+
+class TestProxyShapeAnonymousLayer(unittest.TestCase):
+    workingDir = None
+    fileName = 'foo.ma'
+    SC = pxr.UsdUtils.StageCache.Get()
+
+    def setUp(self):
+        unittest.TestCase.setUp(self)
+        self.workingDir = tempfile.mkdtemp()
+        cmds.file(new=True, save=False, force=True)
+        cmds.loadPlugin("AL_USDMayaPlugin", quiet=True)
+        self.assertTrue(cmds.pluginInfo("AL_USDMayaPlugin", query=True, loaded=True))
+
+        with pxr.Usd.StageCacheContext(self.SC):
+            stage = pxr.Usd.Stage.CreateInMemory()
+            with pxr.Usd.EditContext(stage, pxr.Usd.EditTarget(stage.GetRootLayer())):
+                pxr.UsdGeom.Xform.Define(stage, '/root/GEO/sphere_hrc').AddTranslateOp().Set((0.0, 1.0, 0.0))
+                pxr.UsdGeom.Sphere.Define(stage, '/root/GEO/sphere_hrc/sphere').GetRadiusAttr().Set(5.0)
+
+        cmds.AL_usdmaya_ProxyShapeImport(
+            stageId=self.SC.GetId(stage).ToLongInt(),
+            name='anonymousShape'
+        )
+        cmds.file(rename=self.serialisationPath())
+        cmds.file(type='mayaAscii')
+        cmds.file(save=True)
+        cmds.file(new=True, save=False, force=True)
+        self.SC.Clear()
+
+    def tearDown(self):
+        if os.path.isdir(self.workingDir):
+            shutil.rmtree(self.workingDir)
+
+        self.SC.Clear()
+        unittest.TestCase.tearDown(self)
+
+    def serialisationPath(self):
+        return os.path.join(self.workingDir, self.fileName)
+
+    def test_anonymousLayerRoundTrip(self):
+        cmds.file(self.serialisationPath(), open=True, save=False, force=True)
+        proxyShape = AL.usdmaya.ProxyShape.getByName('anonymousShape')
+        self.assertIsNotNone(proxyShape)
+        stage = proxyShape.getUsdStage()
+        self.assertIsInstance(stage, pxr.Usd.Stage)
+
+        hrc = stage.GetPrimAtPath('/root/GEO/sphere_hrc')
+        self.assertTrue(hrc.IsValid())
+        self.assertTrue(hrc.IsDefined())
+        self.assertTrue(hrc.IsA(pxr.UsdGeom.Xform))
+        hrcXformableApi = pxr.UsdGeom.XformCommonAPI(hrc)
+        t, r, s, p, _ = hrcXformableApi.GetXformVectors(pxr.Usd.TimeCode.Default())
+        self.assertEqual(tuple(t), (0.0, 1.0, 0.0))
+        self.assertEqual(tuple(r), (0.0, 0.0, 0.0))
+        self.assertEqual(tuple(s), (1.0, 1.0, 1.0))
+        self.assertEqual(tuple(p), (0.0, 0.0, 0.0))
+
+        sphere = stage.GetPrimAtPath('/root/GEO/sphere_hrc/sphere')
+        self.assertTrue(sphere.IsValid())
+        self.assertTrue(sphere.IsDefined())
+        self.assertTrue(sphere.IsA(pxr.UsdGeom.Sphere))
+        self.assertEqual(pxr.UsdGeom.Sphere(sphere).GetRadiusAttr().Get(), 5.0)
+
 
 if __name__ == "__main__":
 
     tests = [unittest.TestLoader().loadTestsFromTestCase(TestProxyShapeGetUsdPrimFromMayaPath),
-             unittest.TestLoader().loadTestsFromTestCase(TestProxyShapeGetMayaPathFromUsdPrim)
+             unittest.TestLoader().loadTestsFromTestCase(TestProxyShapeGetMayaPathFromUsdPrim),
+             unittest.TestLoader().loadTestsFromTestCase(TestProxyShapeAnonymousLayer),
               ]
     results = [unittest.TextTestRunner(verbosity=2).run(test) for test in tests]
     exitCode = int(not all([result.wasSuccessful() for result in results]))


### PR DESCRIPTION
Summary
This change allows ProxyShape to correctly load an anonymous root layer if the file path is set to an anonymous layer id. The anonymous root layer is serialised by the layer manager.

Note on file path
Note that the filePath on the ProxyShape is subject to change when an anonymous layer is used. This is necessary because an anonymous layer cannot be re-created with the same exact anon identitifier. This prevents the ProxyShape's file path from deviating from the layer manager serialisation records, and by doing so guarantees fetching the right layer when the Maya scene is reloaded.

Tests
A couple of Python tests are provided to verify this feature.