### PR TITLE
[al] Viewport Framing Fix

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Scope.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Scope.cpp
@@ -174,9 +174,21 @@ MBoundingBox Scope::boundingBox() const
   UsdPrim prim = transform()->prim();
   if(prim)
   {
+    // Get purpose draw states
+    bool drawRenderPurpose = false;
+    bool drawProxyPurpose = false;
+    bool drawGuidePurpose = false;
+    CHECK_MSTATUS(MPlug(getProxyShape(), ProxyShape::drawRenderPurposeAttr).getValue(drawRenderPurpose));
+    CHECK_MSTATUS(MPlug(getProxyShape(), ProxyShape::drawProxyPurposeAttr).getValue(drawProxyPurpose));
+    CHECK_MSTATUS(MPlug(getProxyShape(), ProxyShape::drawGuidePurposeAttr).getValue(drawGuidePurpose));
+    const TfToken purpose1 = UsdGeomTokens->default_;
+    const TfToken purpose2 = drawRenderPurpose ? UsdGeomTokens->render : TfToken();
+    const TfToken purpose3 = drawProxyPurpose ? UsdGeomTokens->proxy : TfToken();
+    const TfToken purpose4 = drawGuidePurpose ? UsdGeomTokens->guide : TfToken();
+  
+    // Compute bounding box
     UsdGeomImageable imageable(prim);
-    const TfToken token("default");
-    const GfBBox3d box = imageable.ComputeLocalBound(usdTime, token);
+    const GfBBox3d box = imageable.ComputeLocalBound(usdTime, purpose1, purpose2, purpose3, purpose4);
     const GfRange3d range = box.GetRange();
     const GfVec3d minMin = range.GetMin();
     const GfVec3d minMax = range.GetMax();

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Scope.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Scope.cpp
@@ -171,6 +171,9 @@ MBoundingBox Scope::boundingBox() const
     usdTime = UsdTimeCode(outTime.as(MTime::uiUnit()));
   }
 
+  // Compute Maya bounding box first. Some nodes can contain both Maya and USD boundable descendants.
+  MBoundingBox bbox = MPxTransform::boundingBox();
+  
   UsdPrim prim = transform()->prim();
   if(prim)
   {
@@ -185,23 +188,22 @@ MBoundingBox Scope::boundingBox() const
     const TfToken purpose2 = drawRenderPurpose ? UsdGeomTokens->render : TfToken();
     const TfToken purpose3 = drawProxyPurpose ? UsdGeomTokens->proxy : TfToken();
     const TfToken purpose4 = drawGuidePurpose ? UsdGeomTokens->guide : TfToken();
-  
+    
     // Compute bounding box
     UsdGeomImageable imageable(prim);
     const GfBBox3d box = imageable.ComputeLocalBound(usdTime, purpose1, purpose2, purpose3, purpose4);
     const GfRange3d range = box.GetRange();
-    const GfVec3d minMin = range.GetMin();
-    const GfVec3d minMax = range.GetMax();
-    const MVector minBound(minMin[0], minMin[1], minMin[2]);
-    const MVector maxBound(minMax[0], minMax[1], minMax[2]);
-    MBoundingBox bbox(minBound, maxBound);
+    const GfVec3d usdMin = range.IsEmpty() ? GfVec3d(0.0, 0.0, 0.0) : range.GetMin();
+    const GfVec3d usdMax = range.IsEmpty() ? GfVec3d(0.0, 0.0, 0.0) : range.GetMax();
+    bbox.expand(MPoint(usdMin[0], usdMin[1], usdMin[2]));
+    bbox.expand(MPoint(usdMax[0], usdMax[1], usdMax[2]));
     MMatrix mayaMx;
     const double* matrixArray = box.GetMatrix().GetArray();
     std::copy(matrixArray, matrixArray+16, mayaMx[0]);
     bbox.transformUsing(mayaMx);
-    return bbox;
   }
-  return MPxTransform::boundingBox();
+  
+  return bbox;
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Scope.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Scope.h
@@ -81,6 +81,8 @@ public:
 
   virtual const MObject getProxyShape() const
     { return proxyShapeHandle.object(); }
+  
+  MBoundingBox boundingBox() const override;
 
 protected:
 
@@ -96,7 +98,6 @@ private:
   MStatus validateAndSetValue(const MPlug& plug, const MDataHandle& handle, const MDGContext& context) override;
   MPxTransformationMatrix* createTransformationMatrix() override;
   void postConstructor() override;
-  MBoundingBox boundingBox() const override;
   MStatus connectionMade(const MPlug& plug, const MPlug& otherPlug, bool asSrc) override;
   MStatus connectionBroken(const MPlug& plug, const MPlug& otherPlug, bool asSrc) override;
   bool isBounded() const override

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Transform.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Transform.cpp
@@ -296,37 +296,6 @@ void Transform::updateTransform(MDataBlock& dataBlock)
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-MBoundingBox Transform::boundingBox() const
-{
-  TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("Transform::boundingBox\n");
-  MTime theTime;
-  outTimePlug().getValue(theTime);
-  UsdTimeCode usdTime(theTime.as(MTime::uiUnit()));
-
-  // grab prim from the dataBlock
-  UsdPrim prim  = transform()->prim();
-
-  if(prim && (prim.IsA<UsdGeomImageable>()))
-  {
-    UsdGeomImageable imageable(prim);
-    const TfToken token("default");
-    const GfBBox3d box = imageable.ComputeLocalBound(usdTime, token);
-    const GfRange3d range = box.GetRange();
-    const GfVec3d minMin = range.GetMin();
-    const GfVec3d minMax = range.GetMax();
-    const MVector minBound(minMin[0], minMin[1], minMin[2]);
-    const MVector maxBound(minMax[0], minMax[1], minMax[2]);
-    MBoundingBox bbox(minBound, maxBound);
-    MMatrix mayaMx;
-    const double* matrixArray = box.GetMatrix().GetArray();
-    std::copy(matrixArray, matrixArray+16, mayaMx[0]);
-    bbox.transformUsing(mayaMx);
-    return bbox;
-  }
-  return MPxTransform::boundingBox();
-}
-
-//----------------------------------------------------------------------------------------------------------------------
 MStatus Transform::connectionMade(const MPlug& plug, const MPlug& otherPlug, bool asSrc)
 {
   if(!asSrc && plug == m_inStageData)

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Transform.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Transform.h
@@ -136,7 +136,6 @@ private:
   MPxTransformationMatrix* createTransformationMatrix() override;
   MStatus compute(const MPlug &plug, MDataBlock &datablock) override;
   void postConstructor() override;
-  MBoundingBox boundingBox() const override;
   MStatus connectionMade(const MPlug& plug, const MPlug& otherPlug, bool asSrc) override;
   MStatus connectionBroken(const MPlug& plug, const MPlug& otherPlug, bool asSrc) override;
   bool setInternalValue(const MPlug& plug, const MDataHandle& dataHandle) override;


### PR DESCRIPTION
Fix for including purposes during bounding box computations of USD data represented as Transform/Scope nodes. Viewport framing should work again.

Transform now delegates bounding box computations to parent Scope class
Scope now checks proxy shapes purpose draw state attributes before computing bounding boxes
Promoted Scope::boundingBox() virtual method from private to public.