### PR TITLE
[al] Ensure excluded prim changed are correctly handled

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -281,18 +281,7 @@ void ProxyRenderDelegate::_InitRenderDelegate(MSubSceneContainer& container) {
         MProfilingScope subProfilingScope(HdVP2RenderDelegate::sProfilerCategory,
             MProfiler::kColorD_L1, "Allocate SceneDelegate");
 
-        // Make sure the delegate name is a valid identifier, since it may
-        // include colons if the proxy node is in a Maya namespace.
-        const std::string delegateName =
-            TfMakeValidIdentifier(
-                TfStringPrintf(
-                    "Proxy_%s_%p",
-                    _proxyShapeData->ProxyShape()->name().asChar(),
-                    _proxyShapeData->ProxyShape()));
-        const SdfPath delegateID =
-            SdfPath::AbsoluteRootPath().AppendChild(TfToken(delegateName));
-
-        _sceneDelegate.reset(new UsdImagingDelegate(_renderIndex.get(), delegateID));
+        const SdfPath delegateID =_ResetSceneDelegate();
 
         _taskController.reset(new HdxTaskController(_renderIndex.get(),
             delegateID.AppendChild(TfToken(TfStringPrintf("_UsdImaging_VP2_%p", this))) ));
@@ -345,17 +334,7 @@ bool ProxyRenderDelegate::_Populate() {
         // if previously populated, destroy the old delegate to be able to populate the new excluded paths
         if(_isPopulated)
         {
-            delete _sceneDelegate; 
-            const std::string delegateName =
-                TfMakeValidIdentifier(
-                    TfStringPrintf(
-                        "Proxy_%s_%p",
-                        _proxyShape->name().asChar(),
-                        _proxyShape));
-            const SdfPath delegateID =
-                SdfPath::AbsoluteRootPath().AppendChild(TfToken(delegateName));
-
-            _sceneDelegate = new UsdImagingDelegate(_renderIndex, delegateID);   
+            _ResetSceneDelegate();
         }
 
         // It might have been already populated, clear it if so.
@@ -743,6 +722,24 @@ ProxyRenderDelegate::GetPrimSelectionStatus(const SdfPath& path) const
 const MColor& ProxyRenderDelegate::GetWireframeColor() const
 {
     return _wireframeColor;
+}
+
+SdfPath ProxyRenderDelegate::_ResetSceneDelegate()
+{
+    // Make sure the delegate name is a valid identifier, since it may
+    // include colons if the proxy node is in a Maya namespace.
+    const std::string delegateName =
+        TfMakeValidIdentifier(
+            TfStringPrintf(
+                "Proxy_%s_%p",
+                _proxyShapeData->ProxyShape()->name().asChar(),
+                _proxyShapeData->ProxyShape()));
+    const SdfPath delegateID =
+        SdfPath::AbsoluteRootPath().AppendChild(TfToken(delegateName));
+
+    _sceneDelegate.reset(new UsdImagingDelegate(_renderIndex.get(), delegateID));
+
+    return delegateID;
 }
 
 // ProxyShapeData

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -342,6 +342,22 @@ bool ProxyRenderDelegate::_Populate() {
         MProfilingScope subProfilingScope(HdVP2RenderDelegate::sProfilerCategory,
             MProfiler::kColorD_L1, "Populate");
 
+        // if previously populated, destroy the old delegate to be able to populate the new excluded paths
+        if(_isPopulated)
+        {
+            delete _sceneDelegate; 
+            const std::string delegateName =
+                TfMakeValidIdentifier(
+                    TfStringPrintf(
+                        "Proxy_%s_%p",
+                        _proxyShape->name().asChar(),
+                        _proxyShape));
+            const SdfPath delegateID =
+                SdfPath::AbsoluteRootPath().AppendChild(TfToken(delegateName));
+
+            _sceneDelegate = new UsdImagingDelegate(_renderIndex, delegateID);   
+        }
+
         // It might have been already populated, clear it if so.
         SdfPathVector excludePrimPaths = _proxyShapeData->ProxyShape()->getExcludePrimPaths();
         for (auto& excludePrim : excludePrimPaths) {

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -127,9 +127,9 @@ private:
     ProxyRenderDelegate& operator=(const ProxyRenderDelegate&) = delete;
 
     void _InitRenderDelegate(MSubSceneContainer& container);
+    SdfPath _InitSceneDelegate();
     void _ClearRenderDelegate();
     bool _Populate();
-    SdfPath _ResetSceneDelegate();
     void _UpdateSceneDelegate();
     void _Execute(const MHWRender::MFrameContext& frameContext);
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -129,6 +129,7 @@ private:
     void _InitRenderDelegate(MSubSceneContainer& container);
     void _ClearRenderDelegate();
     bool _Populate();
+    SdfPath _ResetSceneDelegate();
     void _UpdateSceneDelegate();
     void _Execute(const MHWRender::MFrameContext& frameContext);
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -998,7 +998,7 @@ void ProxyShape::processChangedObjects(const SdfPathVector& resyncedPaths, const
   if(isLockPrimFeatureActive())
   {
     processChangedMetaData(resyncedPaths, changedOnlyPaths);
-  }
+  }  
 
   // These paths are subtree-roots representing entire subtrees that may have
   // changed. In this case, we must dump all cached data below these points

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/ProxyShapeMetaData.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/ProxyShapeMetaData.cpp
@@ -162,7 +162,6 @@ void ProxyShape::processChangedMetaData(const SdfPathVector& resyncedPaths, cons
           }
           else
           {
-            //std::cout << " > excl2 " << prim.GetPath().GetString() << ' ' << excludeGeo << '\n';
             // if we aren't excluding the geom, but have an existing entry, remove it.
             const auto last = m_excludedTaggedGeometry.begin() + lastTaggedPrim;
             const auto it = std::lower_bound(m_excludedTaggedGeometry.begin(), last, path);


### PR DESCRIPTION
1. Ensure the tagged excluded prims are updated correctly when a meta data value is changed.
2. Rebuild the UsdImagingDelegate used within the VP2 render delegate when the excluded prim paths change. Previous implementation assumed re-populating the delegate would be enough (it actually needs to be rebuilt)