### PR TITLE
Fixing the crash when loading USDSkel

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -888,10 +888,11 @@ void HdVP2Mesh::_UpdateDrawItem(
                 adjacency->GetSharedAdjacencyBuilderComputation(&topology);
             adjacencyComputation->Resolve(); // IS the adjacency updated now?
 
-            // The topology doesn't have to reference all of the points, thus
-            // we compute the number of normals as required by the topology.
+            // Only the points referenced by the topology are used to compute
+            // smooth normals.
             normals = Hd_SmoothNormals::ComputeSmoothNormals(
-                adjacency.get(), topology.GetNumPoints(),
+                adjacency.get(),
+                _meshSharedData._points.size(),
                 _meshSharedData._points.cdata());
 
             interp = HdInterpolationVertex;


### PR DESCRIPTION
**Issue**
Described in #430 

**Cause**
The crash occurred because it tried to compute smooth normals
from an empty point array due to missing support of USDSkel.

**Solution**
The change will fix the crash itself, and the real support
for USDSkel will be implemented at some other time.