### PR TITLE
Use separate UsdStageCache's for stages that loadAll or loadNone. 

### DIFF
--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -101,16 +101,17 @@ UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
                                                                 varSelsVec);
 
     // Layer and Stage used to Read in the USD file
-    UsdStageCacheContext stageCacheContext(UsdMayaStageCache::Get());
     UsdStageRefPtr stage;
     if (mImportData.hasPopulationMask())
     {
+        // OpenMasked doesn't use the UsdStageCache, so don't create a UsdStageCacheContext
         stage = UsdStage::OpenMasked(rootLayer, sessionLayer,
                                      mImportData.stagePopulationMask(),
                                      mImportData.stageInitialLoadSet());
     }
     else
     {
+        UsdStageCacheContext stageCacheContext(UsdMayaStageCache::Get(mImportData.stageInitialLoadSet() == UsdStage::InitialLoadSet::LoadAll));
         stage = UsdStage::Open(rootLayer, sessionLayer,
                                mImportData.stageInitialLoadSet());
     }

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -481,7 +481,7 @@ MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
         }
 
         if (SdfLayerRefPtr rootLayer = SdfLayer::FindOrOpen(fileString)) {
-            UsdStageCacheContext ctx(UsdMayaStageCache::Get());
+            UsdStageCacheContext ctx(UsdMayaStageCache::Get(loadSet == UsdStage::InitialLoadSet::LoadAll));
             SdfLayerRefPtr sessionLayer = computeSessionLayer(dataBlock);
             if (sessionLayer) {
                 usdStage = UsdStage::Open(rootLayer,
@@ -498,7 +498,7 @@ MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
         }
         else if (!usdStage) {
             // Create a new stage in memory with an anonymous root layer.
-            UsdStageCacheContext ctx(UsdMayaStageCache::Get());
+            UsdStageCacheContext ctx(UsdMayaStageCache::Get(loadSet == UsdStage::InitialLoadSet::LoadAll));
             usdStage = UsdStage::CreateInMemory("", loadSet);
         }
 
@@ -755,6 +755,8 @@ MayaUsdProxyShapeBase::isStageValid() const
 MStatus
 MayaUsdProxyShapeBase::preEvaluation(const MDGContext& context, const MEvaluationNode& evaluationNode)
 {
+    // Any logic here should have an equivalent implementation in MayaUsdProxyShapeBase::setDependentsDirty().
+
     if (evaluationNode.dirtyPlugExists(excludePrimPathsAttr)) {
         _IncreaseExcludePrimPathsVersion();
     }
@@ -765,6 +767,7 @@ MayaUsdProxyShapeBase::preEvaluation(const MDGContext& context, const MEvaluatio
         evaluationNode.dirtyPlugExists(loadPayloadsAttr) ||
         evaluationNode.dirtyPlugExists(inStageDataAttr)) {
         _IncreaseUsdStageVersion();
+        MayaUsdProxyStageInvalidateNotice(*this).Send();
     }
 
     return MStatus::kSuccess;
@@ -786,6 +789,8 @@ MayaUsdProxyShapeBase::postEvaluation(const  MDGContext& context, const MEvaluat
 MStatus
 MayaUsdProxyShapeBase::setDependentsDirty(const MPlug& plug, MPlugArray& plugArray)
 {
+    // Any logic here should have an equivalent implementation in MayaUsdProxyShapeBase::preEvaluation() or postEvaluation().
+
     // If/when the MPxDrawOverride for the proxy shape specifies
     // isAlwaysDirty=false to improve performance, we must be sure to notify
     // the Maya renderer that the geometry is dirty and needs to be redrawn

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -496,9 +496,8 @@ MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
 
             usdStage->SetEditTarget(usdStage->GetSessionLayer());
         }
-        else if (!usdStage) {
+        else {
             // Create a new stage in memory with an anonymous root layer.
-            UsdStageCacheContext ctx(UsdMayaStageCache::Get(loadSet == UsdStage::InitialLoadSet::LoadAll));
             usdStage = UsdStage::CreateInMemory("", loadSet);
         }
 

--- a/lib/mayaUsd/nodes/stageData.h
+++ b/lib/mayaUsd/nodes/stageData.h
@@ -104,6 +104,8 @@ class MayaUsdStageData : public MPxGeometryData
         // weak_ptr worked around this issue. Basically if we use a shared
         // pointer here, the only way to reload a scene, would be to restart
         // Maya."
+        //
+        // Logged as https://github.com/Autodesk/maya-usd/issues/528
 
         UsdStageWeakPtr stage;
         SdfPath primPath;

--- a/lib/mayaUsd/nodes/stageNode.cpp
+++ b/lib/mayaUsd/nodes/stageNode.cpp
@@ -123,7 +123,8 @@ UsdMayaStageNode::compute(const MPlug& plug, MDataBlock& dataBlock)
         UsdStageRefPtr usdStage;
 
         if (SdfLayerRefPtr rootLayer = SdfLayer::FindOrOpen(usdFile)) {
-            UsdStageCacheContext ctx(UsdMayaStageCache::Get());
+            const bool loadAll = true;
+            UsdStageCacheContext ctx(UsdMayaStageCache::Get(loadAll));
             usdStage = UsdStage::Open(rootLayer,
                                       ArGetResolver().GetCurrentContext());
 

--- a/lib/mayaUsd/python/wrapStageCache.cpp
+++ b/lib/mayaUsd/python/wrapStageCache.cpp
@@ -33,7 +33,7 @@ void wrapStageCache()
     class_<UsdMayaStageCache>("StageCache")
 
         .def("Get", &UsdMayaStageCache::Get,
-             (args("forcePopulate") = true),
+             args("loadAll"),
              return_value_policy<reference_existing_object>())
         .staticmethod("Get")
         .def("Clear", &UsdMayaStageCache::Clear)

--- a/lib/mayaUsd/utils/stageCache.cpp
+++ b/lib/mayaUsd/utils/stageCache.cpp
@@ -61,13 +61,13 @@ struct _OnSceneResetListener : public TfWeakBase {
 
 /* static */
 UsdStageCache&
-UsdMayaStageCache::Get(const bool forcePopulate)
+UsdMayaStageCache::Get(const bool loadAll)
 {
-    static UsdStageCache theCacheForcePopulate;
-    static UsdStageCache theCache;
+    static UsdStageCache theCacheLoadAll;  // used when UsdStage::Open() will be called with UsdStage::InitialLoadSet::LoadAll
+    static UsdStageCache theCache;         // used when UsdStage::Open() will be called with UsdStage::InitialLoadSet::LoadNode
     static _OnSceneResetListener onSceneResetListener;
 
-    return forcePopulate ? theCacheForcePopulate : theCache;
+    return loadAll ? theCacheLoadAll : theCache;
 }
 
 /* static */

--- a/lib/mayaUsd/utils/stageCache.h
+++ b/lib/mayaUsd/utils/stageCache.h
@@ -31,8 +31,9 @@ class UsdMayaStageCache
 public:
 
     /// Return the singleton stage cache for use by all USD clients within Maya.
-    /// 2 stage caches are maintained; 1 for stages that have been
-    /// force-populated, and 1 for stages that have not been force-populated.
+    /// 2 stage caches are maintained; 1 for stages that have been opened with
+    /// UsdStage::InitialLoadSet::LoadAll, and 1 for stages that have been 
+    /// opened with UsdStage::InitialLoadSet::LoadNode.
     MAYAUSD_CORE_PUBLIC
     static UsdStageCache& Get(const bool loadAll);
 

--- a/lib/mayaUsd/utils/stageCache.h
+++ b/lib/mayaUsd/utils/stageCache.h
@@ -34,7 +34,7 @@ public:
     /// 2 stage caches are maintained; 1 for stages that have been
     /// force-populated, and 1 for stages that have not been force-populated.
     MAYAUSD_CORE_PUBLIC
-    static UsdStageCache& Get(const bool forcePopulate=true);
+    static UsdStageCache& Get(const bool loadAll);
 
     /// Clear the cache
     MAYAUSD_CORE_PUBLIC

--- a/plugin/pxr/maya/lib/usdMaya/referenceAssembly.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/referenceAssembly.cpp
@@ -732,7 +732,8 @@ UsdMayaReferenceAssembly::computeInStageDataCached(MDataBlock& dataBlock)
                 sessionLayer = unsharedSessionLayer;
             }
 
-            UsdStageCacheContext ctx(UsdMayaStageCache::Get());
+            const bool loadAll = true;
+            UsdStageCacheContext ctx(UsdMayaStageCache::Get(loadAll));
             usdStage = UsdStage::Open(rootLayer,
                                       sessionLayer,
                                       ArGetResolver().GetCurrentContext());
@@ -899,7 +900,8 @@ UsdMayaReferenceAssembly::computeOutStageData(MDataBlock& dataBlock)
             sessionLayer->TransferContent(oldLayer);
             sessionLayer->TransferContent(newLayer);
 
-            UsdStageCacheContext ctx(UsdMayaStageCache::Get());
+            const bool loadAll = true;
+            UsdStageCacheContext ctx(UsdMayaStageCache::Get(loadAll));
             usdStage = UsdStage::Open(usdPrim.GetStage()->GetRootLayer(),
                                       sessionLayer,
                                       ArGetResolver().GetCurrentContext());

--- a/plugin/pxr/maya/lib/usdMaya/translatorModelAssembly.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/translatorModelAssembly.cpp
@@ -375,7 +375,8 @@ UsdMayaTranslatorModelAssembly::Read(
         return false;
     }
 
-    UsdStageCacheContext stageCacheContext(UsdMayaStageCache::Get());
+    const bool loadAll = true;
+    UsdStageCacheContext stageCacheContext(UsdMayaStageCache::Get(loadAll));
     UsdStageRefPtr usdStage = UsdStage::Open(assetIdentifier);
     if (!usdStage) {
         TF_RUNTIME_ERROR("Cannot open USD file %s", assetIdentifier.c_str());

--- a/test/lib/testMayaUsdPythonImport.py
+++ b/test/lib/testMayaUsdPythonImport.py
@@ -32,5 +32,5 @@ class MayaUsdPythonImportTestCase(unittest.TestCase):
         # mayaUsd library also loaded its dependencies (i.e. the core USD
         # libraries). We test the type name as a string to ensure that we're
         # not causing USD libraries to be loaded any other way.
-        stageCache = mayaUsdLib.StageCache.Get()
+        stageCache = mayaUsdLib.StageCache.Get(True)
         self.assertEqual(type(stageCache).__name__, 'StageCache')


### PR DESCRIPTION
Rename forcePopulate to loadAll to match the enum name. Remove the default parameter value for loadAll so future callers have to make a choice, they will be more likely to choose correctly.

The stage cache does know about different session layers and so it won't hit the cache if the session layers don't match. The interesting code is at https://github.com/PixarAnimationStudios/USD/blob/master/pxr/usd/usd/stage.cpp#L975.

There you can see the call to the cache to FindOneMatching takes all the arguments except for the InitialLoadSet.