### PR TITLE
Selection highlight disappears when switching variant

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1438,10 +1438,9 @@ void HdVP2BasisCurves::_InitRepr(TfToken const &reprToken, HdDirtyBits *dirtyBit
     if (ARCH_UNLIKELY(!subSceneContainer))
         return;
 
-    // We don't create a repr for the selection token because it serves for
-    // selection state update only. Mark DirtySelection bit that will be
-    // automatically propagated to all draw items of the rprim.
-    if (reprToken == HdVP2ReprTokens->selection) {
+    // Update selection state on demand or when it is a new Rprim. DirtySelection
+    // will be propagated to all draw items, to trigger sync for each repr.
+    if (reprToken == HdVP2ReprTokens->selection || _reprs.empty()) {
         const HdVP2SelectionStatus selectionState =
             param->GetDrawScene().GetPrimSelectionStatus(GetId());
         if (_selectionState != selectionState) {
@@ -1451,7 +1450,11 @@ void HdVP2BasisCurves::_InitRepr(TfToken const &reprToken, HdDirtyBits *dirtyBit
         else if (_selectionState == kPartiallySelected) {
             *dirtyBits |= DirtySelection;
         }
-        return;
+
+        // We don't create a repr for the selection token because it serves for
+        // selection state update only. Return from here.
+        if (reprToken == HdVP2ReprTokens->selection)
+            return;
     }
 
     // If the repr has any draw item with the DirtySelection bit, mark the

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -607,10 +607,9 @@ void HdVP2Mesh::_InitRepr(const TfToken& reprToken, HdDirtyBits* dirtyBits) {
     if (ARCH_UNLIKELY(!subSceneContainer))
         return;
 
-    // We don't create a repr for the selection token because it serves for
-    // selection state update only. Mark DirtySelection bit that will be
-    // automatically propagated to all draw items of the rprim.
-    if (reprToken == HdVP2ReprTokens->selection) {
+    // Update selection state on demand or when it is a new Rprim. DirtySelection
+    // will be propagated to all draw items, to trigger sync for each repr.
+    if (reprToken == HdVP2ReprTokens->selection || _reprs.empty()) {
         const HdVP2SelectionStatus selectionState =
             param->GetDrawScene().GetPrimSelectionStatus(GetId());
         if (_selectionState != selectionState) {
@@ -620,7 +619,11 @@ void HdVP2Mesh::_InitRepr(const TfToken& reprToken, HdDirtyBits* dirtyBits) {
         else if (_selectionState == kPartiallySelected) {
             *dirtyBits |= DirtySelection;
         }
-        return;
+
+        // We don't create a repr for the selection token because it serves for
+        // selection state update only. Return from here.
+        if (reprToken == HdVP2ReprTokens->selection)
+            return;
     }
 
     // If the repr has any draw item with the DirtySelection bit, mark the


### PR DESCRIPTION
**Problem**

Selection highlight will disappear when switching variant

**Cause**

When switching variant, a new Rprim will be created to replace
the original one, but the selection state of the new Rprim is
not set.