### PR TITLE
clarify that HdRepr owns the draw items by using std::unique_ptr

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -26,6 +26,7 @@
 #include <pxr/imaging/hd/sceneDelegate.h>
 #include <pxr/imaging/hd/smoothNormals.h>
 #include <pxr/imaging/hd/vertexAdjacency.h>
+#include <pxr/imaging/hd/version.h>
 
 #include "bboxGeom.h"
 #include "debugCodes.h"
@@ -573,9 +574,16 @@ HdDirtyBits HdVP2Mesh::_PropagateDirtyBits(HdDirtyBits bits) const {
     // Propagate dirty bits to all draw items.
     for (const std::pair<TfToken, HdReprSharedPtr>& pair : _reprs) {
         const HdReprSharedPtr& repr = pair.second;
+#if HD_API_VERSION < 35
         const HdRepr::DrawItems& items = repr->GetDrawItems();
         for (HdDrawItem* item : items) {
             if (HdVP2DrawItem* drawItem = static_cast<HdVP2DrawItem*>(item)) {
+#else
+        const HdRepr::DrawItemUniquePtrVector &items = repr->GetDrawItems();
+        for (const HdRepr::DrawItemUniquePtr &item : items) {
+            if (HdVP2DrawItem* const drawItem =
+                        static_cast<HdVP2DrawItem*>(item.get())) {
+#endif
                 drawItem->SetDirtyBits(bits);
             }
         }
@@ -632,9 +640,16 @@ void HdVP2Mesh::_InitRepr(const TfToken& reprToken, HdDirtyBits* dirtyBits) {
         _reprs.begin(), _reprs.end(), _ReprComparator(reprToken));
     if (it != _reprs.end()) {
         const HdReprSharedPtr& repr = it->second;
+#if HD_API_VERSION < 35
         const HdRepr::DrawItems& items = repr->GetDrawItems();
         for (const HdDrawItem* item : items) {
             const HdVP2DrawItem* drawItem = static_cast<const HdVP2DrawItem*>(item);
+#else
+        const HdRepr::DrawItemUniquePtrVector &items = repr->GetDrawItems();
+        for (const HdRepr::DrawItemUniquePtr &item : items) {
+            const HdVP2DrawItem* const drawItem =
+                static_cast<HdVP2DrawItem*>(item.get());
+#endif
             if (drawItem && (drawItem->GetDirtyBits() & DirtySelection)) {
                 *dirtyBits |= DirtySelectionHighlight;
                 break;
@@ -661,8 +676,12 @@ void HdVP2Mesh::_InitRepr(const TfToken& reprToken, HdDirtyBits* dirtyBits) {
             continue;
         }
 
+#if HD_API_VERSION < 35
         auto* drawItem = new HdVP2DrawItem(_delegate, &_sharedData);
-        repr->AddDrawItem(drawItem);
+#else
+        std::unique_ptr<HdVP2DrawItem> drawItem =
+            std::make_unique<HdVP2DrawItem>(_delegate, &_sharedData);
+#endif
 
         const MString& renderItemName = drawItem->GetRenderItemName();
 
@@ -724,6 +743,12 @@ void HdVP2Mesh::_InitRepr(const TfToken& reprToken, HdDirtyBits* dirtyBits) {
                 }
             }
         }
+
+#if HD_API_VERSION < 35
+        repr->AddDrawItem(drawItem);
+#else
+        repr->AddDrawItem(std::move(drawItem));
+#endif
     }
 }
 


### PR DESCRIPTION
This change corresponds to core USD commit https://github.com/PixarAnimationStudios/USD/commit/8a8ab0b274dccfe335737dff611593dadbfb6a40