### PR TITLE
MAYA-104776 send a notice that a newly created proxy shape is dirty

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -372,6 +372,7 @@ void
 MayaUsdProxyShapeBase::postConstructor()
 {
     setRenderable(true);
+    MayaUsdProxyStageInvalidateNotice(*this).Send();
 }
 
 /* virtual */


### PR DESCRIPTION
The workflow that shows the problem here:
1. Create a new proxy shape.
2. Right click on the proxy shape and you will see the UFE/USD menu items, e.g. "Add new prim".
3. Create another new proxy shape.  Not from file, an empty one.
4. Right click the new proxy shape and you will not see the UFE/USD menu items.

This happens because we maintain a map of proxy shapes <-> USD stages that gets updated only when dirty.  The map currently only gets dirtied when the file path attribute on the proxy shape changes, which worked fine until we added a command to create a new empty stage + proxy shape.  In this case we were not notifying anyone that there was a new/dirty item so the map was not dirtied and we do not update the popup menu.

