### PR TITLE
MAYA-103697 selection update on new objects

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -142,10 +142,10 @@ namespace
     }
 
 #if defined(WANT_UFE_BUILD)
-    class UfeSelectionObserver : public Ufe::Observer
+    class UfeObserver : public Ufe::Observer
     {
     public:
-        UfeSelectionObserver(ProxyRenderDelegate& proxyRenderDelegate)
+        UfeObserver(ProxyRenderDelegate& proxyRenderDelegate)
             : Ufe::Observer()
             , _proxyRenderDelegate(proxyRenderDelegate)
         {
@@ -361,15 +361,15 @@ void ProxyRenderDelegate::_InitRenderDelegate(MSubSceneContainer& container) {
         _selection.reset(new HdSelection);
 
 #if defined(WANT_UFE_BUILD)
-        if (!_ufeSelectionObserver) {
-            _ufeSelectionObserver = std::make_shared<UfeSelectionObserver>(*this);
+        if (!_observer) {
+            _observer = std::make_shared<UfeObserver>(*this);
 
             auto globalSelection = Ufe::GlobalSelection::get();
             if (globalSelection) {
-                globalSelection->addObserver(_ufeSelectionObserver);
+                globalSelection->addObserver(_observer);
             }
 
-            Ufe::Scene::instance().addObjectAddObserver(_ufeSelectionObserver);
+            Ufe::Scene::instance().addObjectAddObserver(_observer);
         }
 #else
         // Without UFE, support basic selection highlight at proxy shape level.

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -365,7 +365,7 @@ void ProxyRenderDelegate::_InitRenderDelegate(MSubSceneContainer& container) {
             _observer = std::make_shared<UfeObserver>(*this);
 
             auto globalSelection = Ufe::GlobalSelection::get();
-            if (globalSelection) {
+            if (TF_VERIFY(globalSelection)) {
                 globalSelection->addObserver(_observer);
             }
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -197,10 +197,10 @@ private:
     HdSelectionSharedPtr               _selection;
 
 #if defined(WANT_UFE_BUILD)
-    //! Observer for UFE global selection change
-    Ufe::Observer::Ptr  _ufeSelectionObserver;
+    //! Observer to listen to UFE changes
+    Ufe::Observer::Ptr  _observer;
 #else
-    //! Support proxy selection highlight when UFE is not available.
+    //! Minimum support for proxy selection when UFE is not available.
     MCallbackId         _mayaSelectionCallbackId{ 0 };
 #endif
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -186,7 +186,7 @@ private:
     std::unique_ptr<UsdImagingDelegate> _sceneDelegate; //!< USD scene delegate
 
     bool                    _isPopulated{ false };      //!< If false, scene delegate wasn't populated yet within render index
-    bool                    _selectionChanged{ false }; //!< Whether there is any selection change or not
+    bool                    _selectionChanged{ true };  //!< Whether there is any selection change or not
     bool                    _isProxySelected{ false };  //!< Whether the proxy shape is selected
     MColor                  _wireframeColor;            //!< Wireframe color assigned to the proxy shape
 


### PR DESCRIPTION
When a prim switches modeling variant, the children of the prim can probably be changed to a different set of prims, with different hierarchy and paths. Thus the UFE selection observer will need to also listen to `Ufe::ObjectAdd` notification for Hydra selection update.

The other part of the commit will update the Hydra selection with respect to the UFE global selection  when creating a new stage or a new prim.
