### PR TITLE
MAYA-101853 Changes necessary for UDIM texture support.

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -430,12 +430,6 @@ MHWRender::MTexture* _LoadTexture(
         return _LoadUdimTexture(path, isColorSpaceSRGB, uvScaleOffset);
 #endif
 
-    // set a default uv scale of (1.0, 1.0) and an offset of (0.0f, 0.0f);
-    uvScaleOffset.append(1.0f);
-    uvScaleOffset.append(1.0f);
-    uvScaleOffset.append(0.0f);
-    uvScaleOffset.append(0.0f);
-
     MHWRender::MRenderer* const renderer = MHWRender::MRenderer::theRenderer();
     MHWRender::MTextureManager* const textureMgr =
         renderer ? renderer->getTextureManager() : nullptr;
@@ -975,8 +969,16 @@ HdVP2Material::_AcquireTexture(const std::string& path)
     HdVP2TextureInfo& info = _textureMap[path];
     info._texture.reset(texture);
     info._isColorSpaceSRGB = isSRGB;
-    info._stScale.Set(uvScaleOffset[0], uvScaleOffset[1]); // The first 2 elements are the scale, the 2nd two elements are the offset.
-    info._stOffset.Set(uvScaleOffset[2], uvScaleOffset[3]);
+    if (uvScaleOffset.length() > 0) {
+        TF_VERIFY(uvScaleOffset.length() == 4);
+        info._stScale.Set(uvScaleOffset[0], uvScaleOffset[1]); // The first 2 elements are the scale
+        info._stOffset.Set(uvScaleOffset[2], uvScaleOffset[3]);// The next two elements are the offset
+    }
+    else {
+        // set a default uv scale of (1.0, 1.0) and an offset of (0.0f, 0.0f);
+        info._stScale.Set(1.0f, 1.0f);
+        info._stOffset.Set(0.0f, 0.0f);
+    }
     return info;
 }
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -412,7 +412,7 @@ MHWRender::MTexture* _LoadUdimTexture(
 
     return texture;
 #else
-    #return nullptr;
+    return nullptr;
 #endif
 }
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -37,11 +37,13 @@
 #include <pxr/base/gf/vec4f.h>
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/imaging/glf/image.h>
+#include <pxr/imaging/glf/udimTexture.h>
 #include <pxr/imaging/hd/sceneDelegate.h>
 #include <pxr/usd/ar/packageUtils.h>
 #include <pxr/usd/sdf/assetPath.h>
 #include <pxr/usd/usdHydra/tokens.h>
 #include <pxr/usdImaging/usdImaging/tokens.h>
+#include <pxr/usdImaging/usdImaging/textureUtils.h>
 
 #include "debugCodes.h"
 #include "render_delegate.h"
@@ -291,12 +293,101 @@ MHWRender::MSamplerStateDesc _GetSamplerStateDesc(const HdMaterialNode& node)
     return desc;
 }
 
+MHWRender::MTexture* _LoadUdimTexture(
+    const std::string& path, bool& isColorSpaceSRGB, MFloatArray& uvScaleOffset)
+{
+    /*
+        For this method to work path needs to be an absolute file path, not an asset path.
+        That means that this function depends on the changes in 4e426565 to materialAdapther.cpp
+        to work. As of my writing this 4e426565 is not in the USD that MayaUSD normally builds
+        against so this code will fail, because UsdImaging_GetUdimTiles won't file the tiles
+        because we don't know where on disk to look for them.
+
+        https://github.com/PixarAnimationStudios/USD/commit/4e42656543f4e3a313ce31a81c27477d4dcb64b9
+    */
+
+    // test for a UDIM texture
+    if (!GlfIsSupportedUdimTexture(path))
+        return nullptr;
+    
+    /*
+        Maya's tiled texture support is implemented quite differently from Usd's UDIM support.
+        In Maya the texture tiles get combined into a single big texture, downscaling each tile
+        if necessary, and filling in empty regions of a non-square tile with the undefined color.
+
+        In USD the UDIM textures are stored in a texture array that the shader uses to draw.
+    */
+
+    MHWRender::MRenderer* const renderer = MHWRender::MRenderer::theRenderer();
+    MHWRender::MTextureManager* const textureMgr =
+        renderer ? renderer->getTextureManager() : nullptr;
+    if (!TF_VERIFY(textureMgr)) {
+        return nullptr;
+    }
+
+    MString textureName(path.c_str()); // used for caching, using the string with <UDIM> in it is fine
+    MStringArray tilePaths;
+    MFloatArray tilePositions;
+    // HdSt sets the tile limit to the max number of textures in an array of 2d textures. We don't
+    // want to set it too high because UsdImaging_GetUdimTiles will search for every one on disk.
+    int tileLimit = 100;
+    std::vector<std::tuple<int, TfToken>> tiles = UsdImaging_GetUdimTiles(path, tileLimit);
+    
+    for(auto& tile : tiles)
+    {
+        tilePaths.append(MString(std::get<1>(tile).GetText()));
+        // The image labeled 1001 will have id 0, 1002 will have id 1, 1011 will have id 10.
+        // image 1001 starts with UV (0.0f, 0.0f), 1002 is (1.0f, 0.0f) and 1011 is (0.0f, 1.0f)
+        int tileId = std::get<0>(tile);
+        float u = (float)(tileId % 10);
+        float v = (float)((tileId - u) / 10);
+        tilePositions.append(u);
+        tilePositions.append(v);
+    }
+
+    MColor undefinedColor(0.0f, 1.0f, 0.0f, 1.0f);
+    // 16384x16384 is the max 2d texture resolution on my NVidia K5000, I think some cards do
+    // support 32k x 32k. I don't think there is a downside to setting a very high limit.
+    // Maya will clamp the texture size to the VP2 texture clamp resolution and the hardware's
+    // max texture size. And Maya doesn't make the tiled texture unnecessarily large. When I 
+    // try loading two 1k textures I end up with a tiled texture that is 2k x 1k.
+    unsigned int maxWidth = 32768;
+    unsigned int maxHeight = 32768;
+    MStringArray failedTilePaths;
+    MHWRender::MTexture* texture = textureMgr->acquireTiledTexture(
+        textureName,
+        tilePaths,
+        tilePositions,
+        undefinedColor,
+        maxWidth, maxHeight,
+        failedTilePaths,
+        uvScaleOffset
+    );
+
+    for(unsigned int i=0; i<failedTilePaths.length(); i++)
+    {
+        TF_WARN("Failed to load <UDIM> texture tile %s", failedTilePaths[i].asChar());
+    }
+
+    return texture;
+}
+
 //! Load texture from the specified path
 MHWRender::MTexture* _LoadTexture(
     const std::string& path,
-    bool& isColorSpaceSRGB)
+    bool& isColorSpaceSRGB, MFloatArray& uvScaleOffset)
 {
     isColorSpaceSRGB = false;
+
+    // If it is a UDIM texture we need to modify the path before calling OpenForReading
+    if (GlfIsSupportedUdimTexture(path))
+        return _LoadUdimTexture(path, isColorSpaceSRGB, uvScaleOffset);
+
+    // set a default uv scale of (1.0, 1.0) and an offset of (0.0f, 0.0f);
+    uvScaleOffset.append(1.0f);
+    uvScaleOffset.append(1.0f);
+    uvScaleOffset.append(0.0f);
+    uvScaleOffset.append(0.0f);
 
     MHWRender::MRenderer* const renderer = MHWRender::MRenderer::theRenderer();
     MHWRender::MTextureManager* const textureMgr =
@@ -783,6 +874,16 @@ void HdVP2Material::_UpdateShaderInstance(const HdMaterialNetwork& mat)
                         status = _surfaceShader->setParameter(paramName,
                             info._isColorSpaceSRGB);
                     }
+                    if (status) {
+                        paramName = nodeName + "stScale";
+                        const float* val = &(info._stScale[0]);
+                        status = _surfaceShader->setParameter(paramName, val);
+                    }
+                    if (status) {
+                        paramName = nodeName + "stOffset";
+                        const float* val = &(info._stOffset[0]);
+                        status = _surfaceShader->setParameter(paramName, val);
+                    }
                 }
             }
             else if (value.IsHolding<int>()) {
@@ -823,11 +924,16 @@ HdVP2Material::_AcquireTexture(const std::string& path)
     }
 
     bool isSRGB = false;
-    MHWRender::MTexture* texture = _LoadTexture(path, isSRGB);
+    MFloatArray          uvScaleOffset;
+    MHWRender::MTexture* texture = _LoadTexture(path, isSRGB, uvScaleOffset);
 
     HdVP2TextureInfo& info = _textureMap[path];
     info._texture.reset(texture);
     info._isColorSpaceSRGB = isSRGB;
+    info._stScale[0] = uvScaleOffset[0]; // The first 2 elements are the scale, the 2nd two elements are the offset.
+    info._stScale[1] = uvScaleOffset[1];
+    info._stOffset[0] = uvScaleOffset[2];
+    info._stOffset[1] = uvScaleOffset[3];
     return info;
 }
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -37,14 +37,17 @@
 #include <pxr/base/gf/vec4f.h>
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/imaging/glf/image.h>
+#if USD_VERSION_NUM >= 2002
 #include <pxr/imaging/glf/udimTexture.h>
+#endif
 #include <pxr/imaging/hd/sceneDelegate.h>
 #include <pxr/usd/ar/packageUtils.h>
 #include <pxr/usd/sdf/assetPath.h>
 #include <pxr/usd/usdHydra/tokens.h>
 #include <pxr/usdImaging/usdImaging/tokens.h>
+#if USD_VERSION_NUM >= 2002
 #include <pxr/usdImaging/usdImaging/textureUtils.h>
-
+#endif
 #include "debugCodes.h"
 #include "render_delegate.h"
 
@@ -296,6 +299,7 @@ MHWRender::MSamplerStateDesc _GetSamplerStateDesc(const HdMaterialNode& node)
 MHWRender::MTexture* _LoadUdimTexture(
     const std::string& path, bool& isColorSpaceSRGB, MFloatArray& uvScaleOffset)
 {
+#if USD_VERSION_NUM >= 2002
     /*
         For this method to work path needs to be an absolute file path, not an asset path.
         That means that this function depends on the changes in 4e426565 to materialAdapther.cpp
@@ -370,6 +374,9 @@ MHWRender::MTexture* _LoadUdimTexture(
     }
 
     return texture;
+#else
+    #return nullptr;
+#endif
 }
 
 //! Load texture from the specified path
@@ -379,9 +386,11 @@ MHWRender::MTexture* _LoadTexture(
 {
     isColorSpaceSRGB = false;
 
+#if USD_VERSION_NUM >= 2002
     // If it is a UDIM texture we need to modify the path before calling OpenForReading
     if (GlfIsSupportedUdimTexture(path))
         return _LoadUdimTexture(path, isColorSpaceSRGB, uvScaleOffset);
+#endif
 
     // set a default uv scale of (1.0, 1.0) and an offset of (0.0f, 0.0f);
     uvScaleOffset.append(1.0f);

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -422,8 +422,6 @@ MHWRender::MTexture* _LoadTexture(
     bool& isColorSpaceSRGB,
     MFloatArray& uvScaleOffset)
 {
-    isColorSpaceSRGB = false;
-
 #if USD_VERSION_NUM >= 2002
     // If it is a UDIM texture we need to modify the path before calling OpenForReading
     if (GlfIsSupportedUdimTexture(path))
@@ -973,11 +971,6 @@ HdVP2Material::_AcquireTexture(const std::string& path)
         TF_VERIFY(uvScaleOffset.length() == 4);
         info._stScale.Set(uvScaleOffset[0], uvScaleOffset[1]); // The first 2 elements are the scale
         info._stOffset.Set(uvScaleOffset[2], uvScaleOffset[3]);// The next two elements are the offset
-    }
-    else {
-        // set a default uv scale of (1.0, 1.0) and an offset of (0.0f, 0.0f);
-        info._stScale.Set(1.0f, 1.0f);
-        info._stOffset.Set(0.0f, 0.0f);
     }
     return info;
 }

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.h
@@ -22,6 +22,7 @@
 
 #include <pxr/pxr.h>
 #include <pxr/imaging/hd/material.h>
+#include<pxr/base/gf/vec2f.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -61,8 +62,8 @@ using HdVP2TextureUniquePtr = std::unique_ptr<
 struct HdVP2TextureInfo
 {
     HdVP2TextureUniquePtr  _texture;          //!< Unique pointer of the texture
-    float                  _stScale[2];       //!< UV scale for tiled textures
-    float                  _stOffset[2];      //!< UV offset for tiled textures
+    GfVec2f                _stScale;       //!< UV scale for tiled textures
+    GfVec2f                _stOffset;      //!< UV offset for tiled textures
     bool                   _isColorSpaceSRGB; //!< Whether sRGB linearization is needed
 };
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.h
@@ -61,10 +61,10 @@ using HdVP2TextureUniquePtr = std::unique_ptr<
 */
 struct HdVP2TextureInfo
 {
-    HdVP2TextureUniquePtr  _texture;          //!< Unique pointer of the texture
-    GfVec2f                _stScale;       //!< UV scale for tiled textures
-    GfVec2f                _stOffset;      //!< UV offset for tiled textures
-    bool                   _isColorSpaceSRGB; //!< Whether sRGB linearization is needed
+    HdVP2TextureUniquePtr  _texture;                //!< Unique pointer of the texture
+    GfVec2f                _stScale{1.0f,1.0f};     //!< UV scale for tiled textures
+    GfVec2f                _stOffset{0.0f, 0.0f};   //!< UV offset for tiled textures
+    bool                   _isColorSpaceSRGB{false};//!< Whether sRGB linearization is needed
 };
 
 /*! \brief  An unordered string-indexed map to cache texture information.

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.h
@@ -61,6 +61,8 @@ using HdVP2TextureUniquePtr = std::unique_ptr<
 struct HdVP2TextureInfo
 {
     HdVP2TextureUniquePtr  _texture;          //!< Unique pointer of the texture
+    float                  _stScale[2];       //!< UV scale for tiled textures
+    float                  _stOffset[2];      //!< UV offset for tiled textures
     bool                   _isColorSpaceSRGB; //!< Whether sRGB linearization is needed
 };
 

--- a/lib/mayaUsd/render/vp2ShaderFragments/UsdUVTexture.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/UsdUVTexture.xml
@@ -23,6 +23,8 @@ limitations under the License.
         <texture2 name="file" />
         <sampler name="fileSampler" />
         <float2 name="st" />
+        <float2 name="stScale" />
+        <float2 name="stOffset" />
         <bool name="isColorSpaceSRGB" />
         <float4 name="fallback" />
         <float4 name="scale" />
@@ -30,6 +32,8 @@ limitations under the License.
     </properties>
     <values>
         <float2 name="st" value="0.0,0.0" />
+        <float2 name="stScale" value="1.0,1.0" />
+        <float2 name="stOffset" value="0.0,0.0" />
         <bool name="isColorSpaceSRGB" value="true" />
         <float4 name="fallback" value="0.0,0.0,0.0,1.0" />
         <float4 name="scale" value="1.0,1.0,1.0,1.0" />
@@ -46,12 +50,15 @@ limitations under the License.
 vec4 UsdUVTexture(
     sampler2D fileSampler,
     vec2 st,
+    vec2 stScale,
+    vec2 stOffset,
     bool isColorSpaceSRGB,
     vec4 fallback,
     vec4 scale,
     vec4 bias)
 {
-    vec2 stFlipped = st * vec2(1, -1) + vec2(0, 1);
+    vec2 stScaleOffset = (st + stOffset) * stScale;
+    vec2 stFlipped = stScaleOffset * vec2(1, -1) + vec2(0, 1);
     vec4 outColor = texture(fileSampler, stFlipped);
     if (isColorSpaceSRGB) {
         vec4 breakPnt = vec4(0.03928571566939354, 0.03928571566939354, 0.03928571566939354, 1.);
@@ -77,12 +84,15 @@ float4 UsdUVTexture(
     Texture2D file,
     sampler fileSampler,
     float2 st,
+    float2 stScale,
+    float2 stOffset,
     bool isColorSpaceSRGB,
     float4 fallback,
     float4 scale,
     float4 bias)
 {
-    float2 stFlipped = st * float2(1, -1) + float2(0, 1);
+    float2 stScaleOffset = (st + stOffset) * stScale;
+    float2 stFlipped = stScaleOffset * float2(1, -1) + float2(0, 1);
     float4 outColor = file.Sample(fileSampler, stFlipped);
     if (isColorSpaceSRGB) {
         float4 breakPnt = float4(0.03928571566939354, 0.03928571566939354, 0.03928571566939354, 1.);
@@ -108,12 +118,15 @@ float4 UsdUVTexture(
     texture2D file,
     sampler2D fileSampler,
     float2 st,
+    float2 stScale,
+    float2 stOffset,
     bool isColorSpaceSRGB,
     float4 fallback,
     float4 scale,
     float4 bias)
 {
-    float2 stFlipped = st * float2(1, -1) + float2(0, 1);
+    float2 stScaleOffset = (st + stOffset) * stScale;
+    float2 stFlipped = stScaleOffset * float2(1, -1) + float2(0, 1);
     float4 outColor = tex2D(fileSampler, stFlipped);
     if (isColorSpaceSRGB) {
         float4 breakPnt = float4(0.03928571566939354, 0.03928571566939354, 0.03928571566939354, 1.);


### PR DESCRIPTION
This change depends on a change in USD, commit [4e426565](https://github.com/PixarAnimationStudios/USD/commit/4e42656543f4e3a313ce31a81c27477d4dcb64b9), which isn't merged into the standard version of USD that we build against, so it won't actually work yet. But the source itself can compile fine without that change and the behavior isn't any worse, so I will commit the changes anyway.

This commit + 4e426565 fixes issue #89 