### PR TITLE
remove hard-coded "pxr" namespace in favor of PXR_NS in baseExportCommand

### DIFF
--- a/lib/mayaUsd/commands/baseExportCommand.cpp
+++ b/lib/mayaUsd/commands/baseExportCommand.cpp
@@ -172,7 +172,7 @@ void* MayaUSDExportCommand::creator()
 }
 
 /* virtual */
-std::unique_ptr<UsdMaya_WriteJob> MayaUSDExportCommand::initializeWriteJob(const pxr::UsdMayaJobExportArgs & args)
+std::unique_ptr<UsdMaya_WriteJob> MayaUSDExportCommand::initializeWriteJob(const PXR_NS::UsdMayaJobExportArgs & args)
 {
     return std::unique_ptr<UsdMaya_WriteJob>(new UsdMaya_WriteJob(args));
 }

--- a/lib/mayaUsd/commands/baseExportCommand.h
+++ b/lib/mayaUsd/commands/baseExportCommand.h
@@ -19,6 +19,8 @@
 
 #include <mayaUsd/base/api.h>
 
+#include <pxr/pxr.h>
+
 #include <memory>
 
 #include <maya/MPxCommand.h>
@@ -97,7 +99,7 @@ class MAYAUSD_CORE_PUBLIC MayaUSDExportCommand : public MPxCommand
     static void* creator();
 
   protected:
-    virtual std::unique_ptr<pxr::UsdMaya_WriteJob> initializeWriteJob(const pxr::UsdMayaJobExportArgs &);
+    virtual std::unique_ptr<PXR_NS::UsdMaya_WriteJob> initializeWriteJob(const PXR_NS::UsdMayaJobExportArgs &);
 
 };
 


### PR DESCRIPTION
This is a small follow-up fix to #398 and accounts for the case when PXR_USE_NAMESPACES is disabled (which is how Pixar currently builds internally) or when USD is built with anything other than "pxr" as the namespace.