### PR TITLE
expanded the name collision search to choose nonconflciting names for…

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
@@ -59,7 +59,7 @@ void UsdUndoDuplicateCommand::primInfo(const UsdPrim& srcPrim, SdfPath& usdDstPa
 {
 	auto parent = srcPrim.GetParent();
 	TfToken::HashSet childrenNames;
-	for(auto child : parent.GetChildren())
+	for(auto child : parent.GetFilteredChildren(UsdPrimIsDefined && !UsdPrimIsAbstract))
 	{
 		childrenNames.insert(child.GetName());
 	}

--- a/test/lib/ufe/testDuplicateCmd.py
+++ b/test/lib/ufe/testDuplicateCmd.py
@@ -48,10 +48,6 @@ class DuplicateCmdTestCase(unittest.TestCase):
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
 
-    @classmethod    
-    def childrenNames(children):
-        return [str(child.path().back()) for child in children]
-
     def setUp(self):
         ''' Called initially to set up the Maya test environment '''
         # Load plugins
@@ -146,7 +142,8 @@ class DuplicateCmdTestCase(unittest.TestCase):
         self.assertNotIn(ball35DupName, propsChildrenNames)
 
         # MAYA-92264: because of USD bug, redo doesn't work.
-        """return
+        """
+        return
         cmds.redo()
 
         snIter = iter(ufe.GlobalSelection.get())
@@ -166,12 +163,12 @@ class DuplicateCmdTestCase(unittest.TestCase):
         self.assertIn(sphereDupItem, worldChildren)
         self.assertIn(ball35DupItem, propsChildren)
         """
-    
-        # The duplicated items should not be assigned to the name of a 
+
+        # The duplicated items should not be assigned to the name of a
         # deactivated USD item.
-        
+
         cmds.select(clear=True)
-        
+
         # Delete the even numbered props:
         evenPropsChildrenPre = propsChildrenPre[0:35:2]
         for propChild in evenPropsChildrenPre:
@@ -186,7 +183,7 @@ class DuplicateCmdTestCase(unittest.TestCase):
 
         # Duplicate Ball_1
         ufe.GlobalSelection.get().append(propsChildrenPostDel[0])
-        
+
         cmds.duplicate()
 
         snIter = iter(ufe.GlobalSelection.get())
@@ -196,6 +193,6 @@ class DuplicateCmdTestCase(unittest.TestCase):
         self.assertNotIn(ballDupItem, propsChildrenPostDel)
         self.assertNotIn(ballDupName, propsChildrenNames)
         self.assertEqual(ballDupName, "Ball_36")
-        
+
         cmds.undo() # undo duplication
-        cmds.undo() # undo deletion        
+        cmds.undo() # undo deletion

--- a/test/lib/ufe/testDuplicateCmd.py
+++ b/test/lib/ufe/testDuplicateCmd.py
@@ -47,7 +47,11 @@ class DuplicateCmdTestCase(unittest.TestCase):
     def setUpClass(cls):
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
-    
+
+    @classmethod    
+    def childrenNames(children):
+        return [str(child.path().back()) for child in children]
+
     def setUp(self):
         ''' Called initially to set up the Maya test environment '''
         # Load plugins
@@ -142,8 +146,7 @@ class DuplicateCmdTestCase(unittest.TestCase):
         self.assertNotIn(ball35DupName, propsChildrenNames)
 
         # MAYA-92264: because of USD bug, redo doesn't work.
-        """
-        return
+        """return
         cmds.redo()
 
         snIter = iter(ufe.GlobalSelection.get())
@@ -163,12 +166,12 @@ class DuplicateCmdTestCase(unittest.TestCase):
         self.assertIn(sphereDupItem, worldChildren)
         self.assertIn(ball35DupItem, propsChildren)
         """
-
-        # The duplicated items should not be assigned to the name of a
+    
+        # The duplicated items should not be assigned to the name of a 
         # deactivated USD item.
-
+        
         cmds.select(clear=True)
-
+        
         # Delete the even numbered props:
         evenPropsChildrenPre = propsChildrenPre[0:35:2]
         for propChild in evenPropsChildrenPre:
@@ -181,9 +184,9 @@ class DuplicateCmdTestCase(unittest.TestCase):
         propsChildren = propsHierarchy.children()
         propsChildrenPostDel = propsHierarchy.children()
 
-        # Duplicate Ball_1, which should create Ball_36, not Ball_2
+        # Duplicate Ball_1
         ufe.GlobalSelection.get().append(propsChildrenPostDel[0])
-
+        
         cmds.duplicate()
 
         snIter = iter(ufe.GlobalSelection.get())
@@ -192,6 +195,7 @@ class DuplicateCmdTestCase(unittest.TestCase):
 
         self.assertNotIn(ballDupItem, propsChildrenPostDel)
         self.assertNotIn(ballDupName, propsChildrenNames)
-
+        self.assertEqual(ballDupName, "Ball_36")
+        
         cmds.undo() # undo duplication
-        cmds.undo() # undo deletion
+        cmds.undo() # undo deletion        

--- a/test/lib/ufe/testDuplicateCmd.py
+++ b/test/lib/ufe/testDuplicateCmd.py
@@ -142,6 +142,7 @@ class DuplicateCmdTestCase(unittest.TestCase):
         self.assertNotIn(ball35DupName, propsChildrenNames)
 
         # MAYA-92264: because of USD bug, redo doesn't work.
+        """
         return
         cmds.redo()
 
@@ -161,3 +162,36 @@ class DuplicateCmdTestCase(unittest.TestCase):
 
         self.assertIn(sphereDupItem, worldChildren)
         self.assertIn(ball35DupItem, propsChildren)
+        """
+
+        # The duplicated items should not be assigned to the name of a
+        # deactivated USD item.
+
+        cmds.select(clear=True)
+
+        # Delete the even numbered props:
+        evenPropsChildrenPre = propsChildrenPre[0:35:2]
+        for propChild in evenPropsChildrenPre:
+            ufe.GlobalSelection.get().append(propChild)
+        cmds.delete()
+
+        worldHierarchy = ufe.Hierarchy.hierarchy(worldItem)
+        worldChildren = worldHierarchy.children()
+        propsHierarchy = ufe.Hierarchy.hierarchy(propsItem)
+        propsChildren = propsHierarchy.children()
+        propsChildrenPostDel = propsHierarchy.children()
+
+        # Duplicate Ball_1, which should create Ball_36, not Ball_2
+        ufe.GlobalSelection.get().append(propsChildrenPostDel[0])
+
+        cmds.duplicate()
+
+        snIter = iter(ufe.GlobalSelection.get())
+        ballDupItem = next(snIter)
+        ballDupName = str(ballDupItem.path().back())
+
+        self.assertNotIn(ballDupItem, propsChildrenPostDel)
+        self.assertNotIn(ballDupName, propsChildrenNames)
+
+        cmds.undo() # undo duplication
+        cmds.undo() # undo deletion


### PR DESCRIPTION
… duplicated items


When building a list of item names that would cause collisions in new items, include inactive and unloaded items.  (Otherwise new items will be subject to the opinions about the inactive and unloaded items, which is incorrect.)

getChildren() is equivalent to getFilteredChildren(UsdPrimDefaultPredicate);
UsdPrimDefaultPredicate is equivalent to:
UsdPrimIsDefined && UsdPrimIsLoaded && !UsdPrimIsAbstract && UsdPrimIsActive;

So the change here is to stop filtering the unloaded and inactive items from this list of reserved names that is getting built.

This matches usdview's use of unloaded and inactive items in its listing of items inside appController.py => _computeDisplayPredicate(...)