### PR TITLE
Remove the call to the old multidraw API, and use the new xml based 

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
@@ -272,9 +272,6 @@ namespace
                 if (TF_VERIFY(shaderMgr)) {
                     shader = shaderMgr->getFragmentShader(
                         _fallbackShaderNames[index], _structOutputName, true);
-#if MAYA_API_VERSION >= 20210000
-                    shader->setWantMultiDrawConsolidation(_diffuseColorParameterName, true);
-#endif
                 }
             }
 

--- a/lib/mayaUsd/render/vp2ShaderFragments/FallbackShader.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/FallbackShader.xml
@@ -65,7 +65,7 @@ limitations under the License.
         <float name="fogDensity" ref="mayaBlinnSurface.fogDensity" />
         <float4 name="fogColor" ref="mayaBlinnSurface.fogColor" />
         <float name="fogMultiplier" ref="mayaBlinnSurface.fogMultiplier" />
-        <float4 name="diffuseColor" ref="Float4ToFloat4.input" />
+        <float4 name="diffuseColor" ref="Float4ToFloat4.input" flags="multiDraw" />
     </properties>
     <values>
         <float3 name="Lw" value="0.000000,0.000000,0.000000"  />


### PR DESCRIPTION
api to enable multidraw consolidation.

The "API" (the XML attribute name) is still being finalized but I wanted this up to show an example of how it is used.