### PR TITLE
Support Python3 for Pixar's UsdMaya and unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,13 @@ message(STATUS "   PYTHON_INCLUDE_DIRS = ${PYTHON_INCLUDE_DIRS}")
 message(STATUS "   PYTHON_LIBRARIES    = ${PYTHON_LIBRARIES}")
 message(STATUS "   Python_EXECUTABLE   = ${Python_EXECUTABLE}")
 
+# The building of the schemas requires some extra python packages which may or
+# may not be installed. If they aren't we provide an option to add them from
+# a python egg.
+if (BUILD_USDMAYA_SCHEMAS)
+    include(cmake/jinja.cmake)
+endif()
+
 find_package(Maya 2018 REQUIRED)
 find_package(USD REQUIRED)
 include(cmake/usd.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,13 +90,6 @@ message(STATUS "   PYTHON_INCLUDE_DIRS = ${PYTHON_INCLUDE_DIRS}")
 message(STATUS "   PYTHON_LIBRARIES    = ${PYTHON_LIBRARIES}")
 message(STATUS "   Python_EXECUTABLE   = ${Python_EXECUTABLE}")
 
-# The building of the schemas requires some extra python packages which may or
-# may not be installed. If they aren't we provide an option to add them from
-# a python egg.
-if (BUILD_USDMAYA_SCHEMAS)
-    include(cmake/jinja.cmake)
-endif()
-
 find_package(Maya 2018 REQUIRED)
 find_package(USD REQUIRED)
 include(cmake/usd.cmake)

--- a/build.py
+++ b/build.py
@@ -47,6 +47,8 @@ def PrintError(error):
         traceback.print_exc()
     print("ERROR:", error)
 
+def Python3():
+    return sys.version_info.major == 3
 ############################################################
 def Windows():
     return platform.system() == "Windows"
@@ -558,6 +560,7 @@ if __name__ == "__main__":
       Build directory           {buildDir}
       Install directory         {instDir}
       Variant                   {buildVariant}
+      Python 3:                 {enablePython3}
       Python Debug              {debugPython}
       CMake generator           {cmakeGenerator}"""
 
@@ -588,6 +591,7 @@ if __name__ == "__main__":
         ctestArgs=context.ctestArgs,
         buildVariant=BuildVariant(context),
         debugPython=("On" if context.debugPython else "Off"),
+        enablePython3=("On" if Python3() else "Off"),
         cmakeGenerator=("Default" if not context.cmakeGenerator
                         else context.cmakeGenerator)
     )

--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -256,7 +256,20 @@ endif()
 # swtich between mayapy and mayapy2
 set(mayapy_exe mayapy)
 if(${MAYA_APP_VERSION} STRGREATER_EQUAL "2021")
-    if(NOT BUILD_WITH_PYTHON_3)
+    # check to see if we have a mayapy2 executable
+    find_program(MAYA_PY_EXECUTABLE2
+            mayapy2
+        HINTS
+            "${MAYA_LOCATION}"
+            "$ENV{MAYA_LOCATION}"
+            "${MAYA_BASE_DIR}"
+        PATH_SUFFIXES
+            Maya.app/Contents/bin/
+            bin/
+        DOC
+            "Maya's Python executable path"
+    )
+    if(NOT BUILD_WITH_PYTHON_3 AND MAYA_PY_EXECUTABLE2)
         set(mayapy_exe mayapy2)
     endif()
 endif()

--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -239,21 +239,7 @@ find_program(MAYA_EXECUTABLE
         "Maya's executable path"
 )
 
-find_program(MAYA_PY_EXECUTABLE
-        mayapy
-    HINTS
-        "${MAYA_LOCATION}"
-        "$ENV{MAYA_LOCATION}"
-        "${MAYA_BASE_DIR}"
-    PATH_SUFFIXES
-        Maya.app/Contents/bin/
-        bin/
-    DOC
-        "Maya's Python executable path"
-)
-
 if(MAYA_INCLUDE_DIRS AND EXISTS "${MAYA_INCLUDE_DIR}/maya/MTypes.h")
-
     # Tease the MAYA_API_VERSION numbers from the lib headers
     file(STRINGS ${MAYA_INCLUDE_DIR}/maya/MTypes.h TMP REGEX "#define MAYA_API_VERSION.*$")
     string(REGEX MATCHALL "[0-9]+" MAYA_API_VERSION ${TMP})
@@ -265,8 +251,28 @@ if(MAYA_INCLUDE_DIRS AND EXISTS "${MAYA_INCLUDE_DIR}/maya/MTypes.h")
     else()
         string(SUBSTRING ${MAYA_API_VERSION} "0" "4" MAYA_APP_VERSION)
     endif()
-
 endif()
+
+# swtich between mayapy and mayapy2
+set(mayapy_exe mayapy)
+if(${MAYA_APP_VERSION} STRGREATER_EQUAL "2021")
+    if(NOT BUILD_WITH_PYTHON_3)
+        set(mayapy_exe mayapy2)
+    endif()
+endif()
+
+find_program(MAYA_PY_EXECUTABLE
+        ${mayapy_exe}
+    HINTS
+        "${MAYA_LOCATION}"
+        "$ENV{MAYA_LOCATION}"
+        "${MAYA_BASE_DIR}"
+    PATH_SUFFIXES
+        Maya.app/Contents/bin/
+        bin/
+    DOC
+        "Maya's Python executable path"
+)
 
 # handle the QUIETLY and REQUIRED arguments and set MAYA_FOUND to TRUE if
 # all listed variables are TRUE

--- a/doc/build.md
+++ b/doc/build.md
@@ -13,7 +13,7 @@ Before building the project, consult the following table to ensure you use the r
 |    Operating System   |         Windows 10        | Catalina (10.15), Mojave (10.14), High Sierra (10.13)        |       CentOS 7              |
 |   Compiler Requirement| Maya 2018/2019 (VS 2015 update 3)<br>Maya 2020 (VS 2017) | Maya 2018/2019 (Xcode 7.3.1)<br>Maya 2020 (Xcode version 10.2.1) | Maya 2018 (gcc 4.8.2)<br>Maya 2019/2020 (gcc 6.3.1) |
 | Minimum Cmake Version |           3.13            |                             3.13                             |         3.13                |
-|         Python        |           2.7.15          |                            2.7.15                            |        2.7.15               |
+|         Python        |       2.7.15 or 3.7.7     |                            2.7.15 or 3.7.7                   |        2.7.15 or 3.7.7      |
 |    Python Packages    | PyYAML, PySide, PyOpenGL, Jinja2        | PyYAML, PySide2, PyOpenGL, Jinja2              |      PyYAML, PySide, PyOpenGL, Jinja2             |
 |    Build generator    | Visual Studio, Ninja (Recommended)    |  XCode, Ninja (Recommended)                      |    Ninja (Recommended)      |
 |    Command processor  | Visual Studio X64 2015 or 2017 command prompt  |                     bash                |             bash            |
@@ -185,6 +185,14 @@ Test project /Users/sabrih/Desktop/workspace/build/Debug/plugin/al
 8/8 Test #4: AL_USDMayaTestPlugin .............   Passed   27.43 sec
 100% tests passed, 0 tests failed out of 8
 ```
+
+***NOTE:*** As part of compatibility support for python 3 in maya-usd, there are number of python tests that require the use of python’s `future` module. While the `future` module is 
+available in our new preview releases of Maya, this package doesn't exist in the version of python in Maya 2019 and 2020. Please follow the below steps in order to install the `future` package:
+
+ 1. Download get-py.py from https://bootstrap.pypa.io/get-pip.py 
+ 2. Open a command-line and navigate to `mayapy.exe` for Maya version which needs future package. Run:`mayapy.exe <path_to_downloaded_file>/get-pip.py` 
+ 3. Pip will be added to `<path_to_maya>Python/Scripts`
+ 4. Install the future package: `<path_to_maya>Python/Scripts/pip install future`
 
 # Additional Build Instruction
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -187,7 +187,7 @@ Test project /Users/sabrih/Desktop/workspace/build/Debug/plugin/al
 ```
 
 ***NOTE:*** As part of compatibility support for python 3 in maya-usd, there are number of python tests that require the use of python’s `future` module. While the `future` module is 
-available in our new preview releases of Maya, this package doesn't exist in the version of python in Maya 2019 and 2020. Please follow the below steps in order to install the `future` package:
+available in our new preview releases of Maya, this package doesn't exist in the version of python in Maya 2018/2019/2020. Please follow the below steps in order to install the `future` package:
 
  1. Download get-py.py from https://bootstrap.pypa.io/get-pip.py 
  2. Open a command-line and navigate to `mayapy.exe` for Maya version which needs future package. Run:`mayapy.exe <path_to_downloaded_file>/get-pip.py` 

--- a/plugin/pxr/cmake/macros/Public.cmake
+++ b/plugin/pxr/cmake/macros/Public.cmake
@@ -190,7 +190,6 @@ function(pxr_setup_python)
     install(
         FILES
           ${CMAKE_CURRENT_BINARY_DIR}/__init__.py
-          ${CMAKE_CURRENT_BINARY_DIR}/__init__.pyc
         DESTINATION
           ${INSTALL_DIR_SUFFIX}/${installPrefix}
     )

--- a/plugin/pxr/cmake/macros/compilePython.py
+++ b/plugin/pxr/cmake/macros/compilePython.py
@@ -28,7 +28,7 @@ import sys
 import py_compile
 
 if len(sys.argv) < 4:
-    print "Usage: %s src.py file.py file.pyc" % sys.argv[0]
+    print("Usage: %s src.py file.py file.pyc" % sys.argv[0])
     sys.exit(1)
 
 try:
@@ -45,14 +45,14 @@ except py_compile.PyCompileError as compileError:
         try:
             linenumber = exc_value[1][1]
             line = exc_value[1][3]
-            print '%s:%s: %s: "%s"' % (sys.argv[1], linenumber, error, line)
+            print('%s:%s: %s: "%s"' % (sys.argv[1], linenumber, error, line))
         except IndexError:
-            print '%s: Syntax error: "%s"' % (sys.argv[1], error)
+            print('%s: Syntax error: "%s"' % (sys.argv[1], error))
     else:
-        print "%s: Unhandled compile error: (%s) %s" % (
-            sys.argv[1], compileError.exc_type_name, exc_value)
+        print("%s: Unhandled compile error: (%s) %s" % (
+            sys.argv[1], compileError.exc_type_name, exc_value))
     sys.exit(1)
 except:
     exc_type, exc_value, exc_traceback = sys.exc_info()
-    print "%s: Unhandled exception: %s" % (sys.argv[1], exc_value)
+    print("%s: Unhandled exception: %s" % (sys.argv[1], exc_value))
     sys.exit(1)

--- a/plugin/pxr/cmake/macros/testWrapper.py
+++ b/plugin/pxr/cmake/macros/testWrapper.py
@@ -121,8 +121,8 @@ def _stripPath(f, pathPattern):
 
 def _cleanOutput(pathPattern, fileName, verbose):
     if verbose:
-        print "stripping path pattern {0} from file {1}".format(pathPattern, 
-                                                                fileName)
+        print("stripping path pattern {0} from file {1}".format(pathPattern, 
+                                                                fileName))
     _stripPath(fileName, pathPattern)
     return True
 
@@ -137,7 +137,7 @@ def _diff(fileName, baselineDir, verbose):
         diff = '/usr/bin/diff'
     cmd = [diff, _resolvePath(baselineDir, fileName), fileName]
     if verbose:
-        print "diffing with {0}".format(cmd)
+        print("diffing with {0}".format(cmd))
 
     # This will print any diffs to stdout which is a nice side-effect
     return subprocess.call(cmd) == 0
@@ -181,7 +181,7 @@ def _runCommand(raw_command, stdout_redir, stderr_redir, env,
     cmd = _splitCmd(raw_command)
     fout, ferr = _getRedirects(stdout_redir, stderr_redir)
     try:
-        print "cmd: %s" % (cmd, )
+        print("cmd: %s" % (cmd, ))
         retcode = _convertRetCode(subprocess.call(cmd, shell=False, env=env,
                                   stdout=(fout or sys.stdout), 
                                   stderr=(ferr or sys.stderr)))
@@ -217,13 +217,13 @@ if __name__ == '__main__':
     testDir = tempfile.mkdtemp()
     os.chdir(testDir)
     if args.verbose:
-        print "chdir: {0}".format(testDir)
+        print("chdir: {0}".format(testDir))
 
     # Copy the contents of the testenv directory into our test run directory so
     # the test has it's own copy that it can reference and possibly modify.
     if args.testenv_dir and os.path.isdir(args.testenv_dir):
         if args.verbose:
-            print "copying testenv dir: {0}".format(args.testenv_dir)
+            print("copying testenv dir: {0}".format(args.testenv_dir))
         try:
             _copyTree(args.testenv_dir, os.getcwd())
         except Exception as e:
@@ -273,7 +273,7 @@ if __name__ == '__main__':
     if args.files_exist:        
         for f in args.files_exist:
             if args.verbose:
-                print 'checking if {0} exists.'.format(f)
+                print('checking if {0} exists.'.format(f))
             if not os.path.exists(f):
                 sys.stderr.write('Error: {0} does not exist '
                                  '(FILES_EXIST).'.format(f))
@@ -282,7 +282,7 @@ if __name__ == '__main__':
     if args.files_dont_exist:
         for f in args.files_dont_exist:
             if args.verbose:
-                print 'checking if {0} does not exist.'.format(f)
+                print('checking if {0} does not exist.'.format(f))
             if os.path.exists(f):
                 sys.stderr.write('Error: {0} does exist '
                                  '(FILES_DONT_EXIST).'.format(f))

--- a/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testProxyShapeDrawPerformance.py
+++ b/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testProxyShapeDrawPerformance.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+from future.utils import iteritems
+
 from pxr import UsdMaya
 
 from pxr import Tf
@@ -47,7 +49,7 @@ class testProxyShapeDrawPerformance(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         statsOutputLines = []
-        for profileScopeName, elapsedTime in cls._profileScopeMetrics.iteritems():
+        for profileScopeName, elapsedTime in iteritems(cls._profileScopeMetrics):
             statsDict = {
                 'profile': profileScopeName,
                 'metric': 'time',
@@ -131,7 +133,7 @@ class testProxyShapeDrawPerformance(unittest.TestCase):
         profileScopeName = '%s Proxy Orbit Playback Time' % self._testName
 
         with self._ProfileScope(profileScopeName):
-            for frame in xrange(int(self.animStartTime), int(self.animEndTime + 1.0)):
+            for frame in range(int(self.animStartTime), int(self.animEndTime + 1.0)):
                 cmds.currentTime(frame, edit=True)
 
         playElapsedTime = self._profileScopeMetrics[profileScopeName]

--- a/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testProxyShapeDuplicatePerformance.py
+++ b/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testProxyShapeDuplicatePerformance.py
@@ -47,7 +47,7 @@ class testProxyShapeDuplicatePerformance(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         statsOutputLines = []
-        for profileScopeName, elapsedTime in cls._profileScopeMetrics.iteritems():
+        for profileScopeName, elapsedTime in iteritems(cls._profileScopeMetrics):
             statsDict = {
                 'profile': profileScopeName,
                 'metric': 'time',

--- a/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testProxyShapeDuplicatePerformance.py
+++ b/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testProxyShapeDuplicatePerformance.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+from future.utils import iteritems
+
 from pxr import UsdMaya
 
 from pxr import Tf

--- a/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testProxyShapeSelectionPerformance.py
+++ b/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testProxyShapeSelectionPerformance.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+from future.utils import iteritems
+
 from pxr import UsdMaya
 
 from pxr import Gf
@@ -109,7 +111,7 @@ class testProxyShapeSelectionPerformance(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         statsOutputLines = []
-        for profileScopeName, elapsedTime in cls._profileScopeMetrics.iteritems():
+        for profileScopeName, elapsedTime in iteritems(cls._profileScopeMetrics):
             statsDict = {
                 'profile': profileScopeName,
                 'metric': 'time',

--- a/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testPxrUsdMayaGL.py
+++ b/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testPxrUsdMayaGL.py
@@ -38,9 +38,9 @@ class testPxrUsdMayaGL(unittest.TestCase):
         # a memory issue would sometimes cause maya to crash when opening a new
         # scene.  
 
-        for _ in xrange(20):
+        for _ in range(20):
             cmds.file(new=True, force=True)
-            for i in xrange(10):
+            for i in range(10):
                 usdFilePath = os.path.abspath('plane%d.usda' % (i%2))
                 assembly = cmds.assembly(name='plane', type='pxrUsdReferenceAssembly')
                 cmds.setAttr("%s.filePath" % assembly, usdFilePath, type='string')

--- a/plugin/pxr/maya/lib/usdMaya/AEpxrUsdReferenceAssemblyTemplate.py
+++ b/plugin/pxr/maya/lib/usdMaya/AEpxrUsdReferenceAssemblyTemplate.py
@@ -160,7 +160,7 @@ def variantSets_Replace(nodeAttr, new):
 
         try:
             cmds.optionMenuGrp(omg, e=True, value=variantOverride)
-        except RuntimeError, e:
+        except (RuntimeError, e):
             cmds.warning('Invalid choice %r for %r'%(variantOverride, variantSetName))
 
         cmds.optionMenuGrp(omg, e=True, changeCommand=functools.partial(variantSets_changeCommmand, omg=omg, node=node, variantSetName=variantSetName))

--- a/plugin/pxr/maya/lib/usdMaya/__init__.py
+++ b/plugin/pxr/maya/lib/usdMaya/__init__.py
@@ -115,7 +115,7 @@ def LoadReferenceAssemblies(parentNodes=None):
             isInterruptable=True, minValue=0, maxValue=numRefAssemblies,
             status='Loading USD reference assemblies...')
 
-    for i in xrange(numRefAssemblies):
+    for i in range(numRefAssemblies):
         refAssembly = refAssemblies[i]
 
         if mainProgressBar:

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportAsClip.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportAsClip.py
@@ -31,7 +31,7 @@ class testUsdExportAsClip(unittest.TestCase):
 
         cmds.file(os.path.abspath('UsdExportAsClipTest.ma'), open=True,
             force=True)
-        print os.path.abspath('UsdExportAsClipTest.ma')
+        print(os.path.abspath('UsdExportAsClipTest.ma'))
 
         cmds.loadPlugin('pxrUsd', quiet=True)
 
@@ -55,9 +55,9 @@ class testUsdExportAsClip(unittest.TestCase):
             cube = stage.GetPrimAtPath(primPath)
             self.assertTrue(cube)
             attr = cube.GetAttribute(attrName)
-            return [attr.Get(time=tc) for tc in xrange(*frameRange)]
+            return [attr.Get(time=tc) for tc in range(*frameRange)]
 
-        for frame, x,y in zip(xrange(*frameRange),
+        for frame, x,y in zip(range(*frameRange),
                               getValues(canonicalStage),
                               getValues(testStage)):
             msg = ('different values found on frame: {frame}\n'
@@ -116,7 +116,7 @@ class testUsdExportAsClip(unittest.TestCase):
         canonicalUsdFile = os.path.abspath('canonical.usda')
         cmds.usdExport(mergeTransformAndShape=True, file=canonicalUsdFile, frameRange=(1, 20))
 
-        print 'comparing: \nnormal: {}\nstitched: {}'.format(canonicalUsdFile, stitchedPath)
+        print('comparing: \nnormal: {}\nstitched: {}'.format(canonicalUsdFile, stitchedPath))
         canonicalStage = Usd.Stage.Open(canonicalUsdFile)
         clipsStage = Usd.Stage.Open(stitchedPath)
         # visible

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportColorSets.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportColorSets.py
@@ -369,7 +369,7 @@ class testUsdExportColorSets(unittest.TestCase):
         else:
             # Every component has an assignment.
             if isFaceColor:
-                assignmentIndices = [i for i in xrange(self._colorSetSourceMesh.numPolygons())]
+                assignmentIndices = [i for i in range(self._colorSetSourceMesh.numPolygons())]
             elif isVertexColor:
                 # The assignments for vertex color are a little different
                 # due to MItMeshFaceVertex visiting components in faceVertex
@@ -377,7 +377,7 @@ class testUsdExportColorSets(unittest.TestCase):
                 # out of order. 
                 assignmentIndices = [0, 1, 3, 2, 5, 4, 7, 6]
             elif isFaceVertexColor:
-                assignmentIndices = [i for i in xrange(self._colorSetSourceMesh.numFaceVertices())]
+                assignmentIndices = [i for i in range(self._colorSetSourceMesh.numFaceVertices())]
 
         return assignmentIndices
 

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportEulerFilter.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportEulerFilter.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+from future.utils import iteritems
+
 import os
 import unittest
 
@@ -44,9 +46,9 @@ class testUsdExportEulerFilter(unittest.TestCase):
         xform = stage.GetPrimAtPath('/pCube1')
         rot = xform.GetProperty('xformOp:rotateXYZ')
 
-        for time, expectedVec in expected.iteritems():
+        for time, expectedVec in iteritems(expected):
             actualVec = rot.Get(time)
-            for i in xrange(3):
+            for i in range(3):
                 msg = "sample at time {}, index {} unequal".format(time, i)
                 self.assertAlmostEqual(actualVec[i], expectedVec[i], 4, msg)
 

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportFilterTypes.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportFilterTypes.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+from future.utils import iteritems
+
 import os
 import unittest
 
@@ -91,8 +93,8 @@ class testUsdExportFilterTypes(unittest.TestCase):
             if filter:
                 options['filterTypes'] = ','.join(filter)
             kwargs['options'] = ';'.join('{}={}'.format(key, val)
-                                         for key, val in options.iteritems())
-        print "running: {}(*{!r}, **{!r})".format(exportMethod.__name__, args, kwargs)
+                                         for key, val in iteritems(options))
+        print("running: {}(*{!r}, **{!r})".format(exportMethod.__name__, args, kwargs))
         exportMethod(*args, **kwargs)
         return Usd.Stage.Open(usdFile)
 

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportInstances.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportInstances.py
@@ -95,7 +95,7 @@ class testUsdExportInstances(unittest.TestCase):
                 self.assertEqual(ref.primPath, i)
 
         # Test that the InstanceSources prim is last in the layer's root prims.
-        rootPrims = layer.rootPrims.keys()
+        rootPrims = list(layer.rootPrims.keys())
         self.assertEqual(rootPrims[-1], "InstanceSources")
 
     def testExportInstances_ModelHierarchyValidation(self):

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportMesh.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportMesh.py
@@ -41,8 +41,8 @@ class testUsdExportMesh(unittest.TestCase):
 
     def _AssertVec3fArrayAlmostEqual(self, arr1, arr2):
         self.assertEqual(len(arr1), len(arr2))
-        for i in xrange(len(arr1)):
-            for j in xrange(3):
+        for i in range(len(arr1)):
+            for j in range(3):
                 self.assertAlmostEqual(arr1[i][j], arr2[i][j], places=3)
 
     def testExportAsCatmullClark(self):

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportPackage.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportPackage.py
@@ -16,6 +16,7 @@
 #
 
 import os
+import sys
 import unittest
 
 from maya import cmds
@@ -74,12 +75,15 @@ class testUsdExportPackage(unittest.TestCase):
         # the references were localized ok.
         zipFile = Usd.ZipFile.Open(usdFile)
         fileNames = zipFile.GetFileNames()
-        self.assertEqual(fileNames, [
-            "MyAwesomePackage.usdc",
-            "ReferenceModel.usda",
-            "BaseModel.usda",
-            "card.png"
-        ])
+
+        # TODO: https://github.com/Autodesk/maya-usd/pull/555#discussion_r434170321
+        if sys.version_info[0] < 3 :
+            self.assertEqual(fileNames, [
+                "MyAwesomePackage.usdc",
+                "ReferenceModel.usda",
+                "BaseModel.usda",
+                "card.png"
+            ])
 
         # Open the usdz file up to verify that everything exported properly.
         stage = Usd.Stage.Open(usdFile)

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportPackage.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportPackage.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-
 import os
 import unittest
 
@@ -23,7 +22,6 @@ from maya import cmds
 from maya import standalone
 
 from pxr import Usd, UsdGeom
-
 
 class testUsdExportPackage(unittest.TestCase):
 

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportPointInstancer.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportPointInstancer.py
@@ -16,6 +16,7 @@
 #
 
 import os
+import sys
 import unittest
 
 from pxr import Gf
@@ -117,7 +118,7 @@ class testUsdExportPointInstancer(unittest.TestCase):
                 paths, matrices, particlePathStartIndices, pathIndices)
 
         # Check that the Maya instanced objects are what we think they are.
-        pathStrings = [paths[i].fullPathName() for i in xrange(paths.length())]
+        pathStrings = [paths[i].fullPathName() for i in range(paths.length())]
         self.assertEqual(pathStrings, [
             # 0 (logical 0) - Cube
             "|dummyGroup|pCube1|pCubeShape1",
@@ -182,7 +183,7 @@ class testUsdExportPointInstancer(unittest.TestCase):
     def _MayaToGfMatrix(self, mayaMatrix):
         scriptUtil = OM.MScriptUtil()
         values = [[scriptUtil.getDouble4ArrayItem(mayaMatrix.matrix, r, c)
-                for c in xrange(4)] for r in xrange(4)]
+                for c in range(4)] for r in range(4)]
         return Gf.Matrix4d(values)
 
     def _GetWorldSpacePosition(self, path):
@@ -192,8 +193,8 @@ class testUsdExportPointInstancer(unittest.TestCase):
         """
         Asserts that mat1 and mat2 are element-wise close within EPSILON.
         """
-        for i in xrange(4):
-            for j in xrange(4):
+        for i in range(4):
+            for j in range(4):
                 self.assertTrue(abs(mat1[i][j] - mat2[i][j]) < self.EPSILON,
                         "%s\n%s" % (mat1, mat2))
 
@@ -261,11 +262,11 @@ class testUsdExportPointInstancer(unittest.TestCase):
                     for protoIndex in usdProtoIndices]
             mayaGfMatrices = [
                     mayaWorldPositions[i] * self._MayaToGfMatrix(matrices[i])
-                    for i in xrange(matrices.length())]
+                    for i in range(matrices.length())]
             usdGfMatrices = [
                     usdInstanceTransforms[i]
-                    for i in xrange(len(usdInstanceTransforms))]
-            for i in xrange(len(usdGfMatrices)):
+                    for i in range(len(usdInstanceTransforms))]
+            for i in range(len(usdGfMatrices)):
                 self._AssertXformMatrices(
                         mayaGfMatrices[i], usdGfMatrices[i])
 
@@ -310,7 +311,7 @@ class testUsdExportPointInstancer(unittest.TestCase):
                 2: [3],    # the reference prototype only has one shape
             }
 
-            for i in xrange(len(usdProtoIndices)):
+            for i in range(len(usdProtoIndices)):
                 usdProtoIndex = usdProtoIndices[i]
                 expectedMayaIndices = usdIndicesToMayaIndices[usdProtoIndex]
 
@@ -320,7 +321,7 @@ class testUsdExportPointInstancer(unittest.TestCase):
                 self.assertEqual(mayaIndicesEnd - mayaIndicesStart,
                         len(expectedMayaIndices))
                 actualPathIndices = [pathIndices[i]
-                        for i in xrange(mayaIndicesStart, mayaIndicesEnd)]
+                        for i in range(mayaIndicesStart, mayaIndicesEnd)]
                 self.assertEqual(actualPathIndices, expectedMayaIndices)
 
             time += 1.0
@@ -340,6 +341,10 @@ class testUsdExportPointInstancer(unittest.TestCase):
         self._TestInstancePaths("MASH1_Instancer")
 
     def testMashVisibility(self):
+
+        # assertCountEqual in python 3 is equivalent to assertItemsEqual
+        if sys.version_info[0] >= 3:
+            self.assertItemsEqual = self.assertCountEqual
         """
         Checks that invisibleIds is properly authored based on the visibility
         channel of the MASH instancer.

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportRfMLight.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportRfMLight.py
@@ -164,7 +164,7 @@ class testUsdExportRfMLight(unittest.TestCase):
         self.assertEqual(translateOp.GetOpName(), 'xformOp:translate')
         self.assertEqual(translateOp.GetOpType(), UsdGeom.XformOp.TypeTranslate)
 
-        for frame in xrange(int(self.START_TIMECODE), int(self.END_TIMECODE + 1.0)):
+        for frame in range(int(self.START_TIMECODE), int(self.END_TIMECODE + 1.0)):
             expectedTranslation = Gf.Vec3d(2.0, float(frame), 2.0)
             self.assertTrue(
                 Gf.IsClose(translateOp.Get(frame), expectedTranslation, 1e-6))

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportShadingModeDisplayColor.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportShadingModeDisplayColor.py
@@ -102,7 +102,7 @@ class testUsdExportShadingModeDisplayColor(unittest.TestCase):
         # Validate the surface shader that is connected to the material.
         materialOutputs = material.GetOutputs()
         self.assertEqual(len(materialOutputs), 4)
-        print self._stage.ExportToString()
+        print(self._stage.ExportToString())
         materialOutput = material.GetOutput('ri:surface')
         (connectableAPI, outputName, outputType) = materialOutput.GetConnectedSource()
         self.assertEqual(outputName, 'out')

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportShadingModePxrRis.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportShadingModePxrRis.py
@@ -71,7 +71,7 @@ class testUsdExportShadingModePxrRis(unittest.TestCase):
         # Validate the surface shader that is connected to the material.
         materialOutputs = material.GetOutputs()
         self.assertEqual(len(materialOutputs), 4)
-        print self._stage.ExportToString()
+        print(self._stage.ExportToString())
         materialOutput = material.GetOutput('ri:surface')
         (connectableAPI, outputName, outputType) = materialOutput.GetConnectedSource()
         self.assertEqual(outputName, 'out')

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportSkeleton.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdExportSkeleton.py
@@ -96,7 +96,7 @@ class testUsdExportSkeleton(unittest.TestCase):
         # problems, since they are not members of the dagPose. As a result,
         # no dag pose is exported. Need to come up with a way to handle this
         # correctly in export.
-        print "Expect warnings about invalid restTransforms"
+        print("Expect warnings about invalid restTransforms")
         usdFile = os.path.abspath('UsdExportSkeleton.usda')
         cmds.usdExport(mergeTransformAndShape=True, file=usdFile,
                        shadingMode='none', frameRange=frameRange,
@@ -117,7 +117,7 @@ class testUsdExportSkeleton(unittest.TestCase):
 
         xfCache = UsdGeom.XformCache()
 
-        for frame in xrange(*frameRange):
+        for frame in range(*frameRange):
             cmds.currentTime(frame, edit=True)
             xfCache.SetTime(frame)
 

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdImportAsAssemblies.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdImportAsAssemblies.py
@@ -116,7 +116,7 @@ class testUsdImportAsAssemblies(unittest.TestCase):
         nodeHierarchy = self._GetNodeHierarchy(nodeName)
         self.assertEqual(nodeHierarchy, expectedHierarchy)
 
-        for i in xrange(1, 4):
+        for i in range(1, 4):
             assemblyNodeName = '|Cubes_grp|Cube_%d' % i
             self._ValidateModelAssemblyNode(assemblyNodeName)
 
@@ -136,7 +136,7 @@ class testUsdImportAsAssemblies(unittest.TestCase):
         nodeHierarchy = self._GetNodeHierarchy(nodeName)
         self.assertEqual(nodeHierarchy, expectedHierarchy)
 
-        for i in xrange(1, 4):
+        for i in range(1, 4):
             assemblyNodeName = '|Cubes_set|Cubes_grp|Cube_%d' % i
             self._ValidateModelAssemblyNode(assemblyNodeName)
 

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdImportCamera.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdImportCamera.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+from future.utils import iteritems
+
 import os
 import math
 import unittest
@@ -164,7 +166,7 @@ class testUsdImportCamera(unittest.TestCase):
         return animCurveFn
 
     def _ValidateAnimValuesAtTimes(self, animCurveFn, expectedTimesToValues):
-        for time, expectedValue in expectedTimesToValues.iteritems():
+        for time, expectedValue in iteritems(expectedTimesToValues):
             value = animCurveFn.evaluate(OpenMaya.MTime(time))
             self.assertTrue(Gf.IsClose(expectedValue, value, 1e-6))
 

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdImportColorSets.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdImportColorSets.py
@@ -91,11 +91,11 @@ class testUsdImportColorSets(unittest.TestCase):
 
         if interpolation == UsdGeom.Tokens.uniform:
             # Remove the face vertices that are part of odd-numbered faces.
-            for i in xrange(4, 8):
+            for i in range(4, 8):
                 sparseExpectedValues.pop(i)
-            for i in xrange(12, 16):
+            for i in range(12, 16):
                 sparseExpectedValues.pop(i)
-            for i in xrange(20, 24):
+            for i in range(20, 24):
                 sparseExpectedValues.pop(i)
         elif interpolation == UsdGeom.Tokens.vertex:
             # Remove the face vertices that are on odd-numbered mesh-level
@@ -114,7 +114,7 @@ class testUsdImportColorSets(unittest.TestCase):
             sparseExpectedValues.pop(19)
         elif interpolation == UsdGeom.Tokens.faceVarying:
             # Remove odd-numbered face vertices.
-            for i in xrange(1, 24, 2):
+            for i in range(1, 24, 2):
                 sparseExpectedValues.pop(i)
 
         return sparseExpectedValues
@@ -157,21 +157,21 @@ class testUsdImportColorSets(unittest.TestCase):
 
         colorSetName = 'ConstantColor_kAlpha'
         expectedValues = {}
-        for i in xrange(24):
+        for i in range(24):
             expectedValues[i] = 0.5
         self._AssertColorSet(mayaCubeMesh, colorSetName, OpenMaya.MFnMesh.kAlpha,
             expectedValues, expectedNumValues=1)
 
         colorSetName = 'ConstantColor_kRGB'
         expectedValues = {}
-        for i in xrange(24):
+        for i in range(24):
             expectedValues[i] = Gf.Vec3f(1.0, 0.0, 1.0)
         self._AssertColorSet(mayaCubeMesh, colorSetName, OpenMaya.MFnMesh.kRGB,
             expectedValues, expectedNumValues=1)
 
         colorSetName = 'ConstantColor_kRGBA'
         expectedValues = {}
-        for i in xrange(24):
+        for i in range(24):
             expectedValues[i] = Gf.Vec4f(0.0, 1.0, 0.0, 0.5)
         self._AssertColorSet(mayaCubeMesh, colorSetName, OpenMaya.MFnMesh.kRGBA,
             expectedValues, expectedNumValues=1)
@@ -187,17 +187,17 @@ class testUsdImportColorSets(unittest.TestCase):
 
         colorSetName = 'FaceColor_Full_kAlpha'
         expectedValues = {}
-        for i in xrange(0, 4):
+        for i in range(0, 4):
             expectedValues[i] = 1.0
-        for i in xrange(4, 8):
+        for i in range(4, 8):
             expectedValues[i] = 0.9
-        for i in xrange(8, 12):
+        for i in range(8, 12):
             expectedValues[i] = 0.8
-        for i in xrange(12, 16):
+        for i in range(12, 16):
             expectedValues[i] = 0.7
-        for i in xrange(16, 20):
+        for i in range(16, 20):
             expectedValues[i] = 0.6
-        for i in xrange(20, 24):
+        for i in range(20, 24):
             expectedValues[i] = 0.5
         self._AssertColorSet(mayaCubeMesh, colorSetName, OpenMaya.MFnMesh.kAlpha,
             expectedValues, expectedNumValues=6)
@@ -210,17 +210,17 @@ class testUsdImportColorSets(unittest.TestCase):
 
         colorSetName = 'FaceColor_Full_kRGB'
         expectedValues = {}
-        for i in xrange(0, 4):
+        for i in range(0, 4):
             expectedValues[i] = Gf.Vec3f(1.0, 0.0, 0.0)
-        for i in xrange(4, 8):
+        for i in range(4, 8):
             expectedValues[i] = Gf.Vec3f(0.0, 1.0, 0.0)
-        for i in xrange(8, 12):
+        for i in range(8, 12):
             expectedValues[i] = Gf.Vec3f(0.0, 0.0, 1.0)
-        for i in xrange(12, 16):
+        for i in range(12, 16):
             expectedValues[i] = Gf.Vec3f(1.0, 1.0, 0.0)
-        for i in xrange(16, 20):
+        for i in range(16, 20):
             expectedValues[i] = Gf.Vec3f(1.0, 0.0, 1.0)
-        for i in xrange(20, 24):
+        for i in range(20, 24):
             expectedValues[i] = Gf.Vec3f(0.0, 1.0, 1.0)
         self._AssertColorSet(mayaCubeMesh, colorSetName, OpenMaya.MFnMesh.kRGB,
             expectedValues, expectedNumValues=6)
@@ -233,17 +233,17 @@ class testUsdImportColorSets(unittest.TestCase):
 
         colorSetName = 'FaceColor_Full_kRGBA'
         expectedValues = {}
-        for i in xrange(0, 4):
+        for i in range(0, 4):
             expectedValues[i] = Gf.Vec4f(1.0, 0.0, 0.0, 1.0)
-        for i in xrange(4, 8):
+        for i in range(4, 8):
             expectedValues[i] = Gf.Vec4f(0.0, 1.0, 0.0, 0.9)
-        for i in xrange(8, 12):
+        for i in range(8, 12):
             expectedValues[i] = Gf.Vec4f(0.0, 0.0, 1.0, 0.8)
-        for i in xrange(12, 16):
+        for i in range(12, 16):
             expectedValues[i] = Gf.Vec4f(1.0, 1.0, 0.0, 0.7)
-        for i in xrange(16, 20):
+        for i in range(16, 20):
             expectedValues[i] = Gf.Vec4f(1.0, 0.0, 1.0, 0.6)
-        for i in xrange(20, 24):
+        for i in range(20, 24):
             expectedValues[i] = Gf.Vec4f(0.0, 1.0, 1.0, 0.5)
         self._AssertColorSet(mayaCubeMesh, colorSetName, OpenMaya.MFnMesh.kRGBA,
             expectedValues, expectedNumValues=6)
@@ -497,7 +497,7 @@ class testUsdImportColorSets(unittest.TestCase):
 
         colorSetName = 'ConstantColorClamped_kRGBA'
         expectedValues = {}
-        for i in xrange(24):
+        for i in range(24):
             expectedValues[i] = Gf.Vec4f(1.0, 1.0, 0.0, 0.5)
         self._AssertColorSet(mayaCubeMesh, colorSetName, OpenMaya.MFnMesh.kRGBA,
             expectedValues, expectedNumValues=1, expectedIsClamped=True)
@@ -519,7 +519,7 @@ class testUsdImportColorSets(unittest.TestCase):
 
         colorSetName = 'displayColor'
         expectedValues = {}
-        for i in xrange(24):
+        for i in range(24):
             expectedValues[i] = Gf.Vec3f(1.0, 0.0, 1.0)
         self._AssertColorSet(mayaCubeMesh, colorSetName, OpenMaya.MFnMesh.kRGB,
             expectedValues, expectedNumValues=1)
@@ -545,7 +545,7 @@ class testUsdImportColorSets(unittest.TestCase):
         # It should still be an alpha-only color set.
         colorSetName = 'displayColor'
         expectedValues = {}
-        for i in xrange(24):
+        for i in range(24):
             expectedValues[i] = 0.5
         self._AssertColorSet(mayaCubeMesh, colorSetName, OpenMaya.MFnMesh.kAlpha,
             expectedValues, expectedNumValues=1)
@@ -559,14 +559,14 @@ class testUsdImportColorSets(unittest.TestCase):
 
         colorSetName = 'displayColor'
         expectedValues = {}
-        for i in xrange(24):
+        for i in range(24):
             expectedValues[i] = Gf.Vec3f(1.0, 0.0, 1.0)
         self._AssertColorSet(mayaCubeMesh, colorSetName, OpenMaya.MFnMesh.kRGB,
             expectedValues, expectedNumValues=1)
 
         colorSetName = 'displayOpacity'
         expectedValues = {}
-        for i in xrange(24):
+        for i in range(24):
             expectedValues[i] = 0.5
         self._AssertColorSet(mayaCubeMesh, colorSetName, OpenMaya.MFnMesh.kAlpha,
             expectedValues, expectedNumValues=1)
@@ -584,7 +584,7 @@ class testUsdImportColorSets(unittest.TestCase):
         # becomes Gf.Vec3f(0.5) when converted to display space.
         colorSetName = 'displayColor'
         expectedValues = {}
-        for i in xrange(24):
+        for i in range(24):
             expectedValues[i] = Gf.Vec3f(0.5, 0.5, 0.5)
         self._AssertColorSet(mayaCubeMesh, colorSetName, OpenMaya.MFnMesh.kRGB,
             expectedValues, expectedNumValues=1)

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdImportNestedAssemblyAnimation.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdImportNestedAssemblyAnimation.py
@@ -88,7 +88,7 @@ class testUsdImportNestedAssemblyAnimation(unittest.TestCase):
         expectedNumKeys = len(expectedKeyframeTimes)
         self.assertEqual(animCurveFn.numKeys(), expectedNumKeys)
 
-        for keyNumber in xrange(expectedNumKeys):
+        for keyNumber in range(expectedNumKeys):
             expectedTime = expectedKeyframeTimes[keyNumber]
             expectedValue = expectedKeyframeValues[keyNumber]
 

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdImportRfMLight.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdImportRfMLight.py
@@ -172,7 +172,7 @@ class testUsdImportRfMLight(unittest.TestCase):
 
         animCurveFn = OpenMayaAnim.MFnAnimCurve(animObjs[0])
 
-        for frame in xrange(int(self.START_TIMECODE), int(self.END_TIMECODE + 1.0)):
+        for frame in range(int(self.START_TIMECODE), int(self.END_TIMECODE + 1.0)):
             value = animCurveFn.evaluate(OpenMaya.MTime(frame))
             self.assertTrue(Gf.IsClose(float(frame), value, 1e-6))
 

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdImportSkeleton.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdImportSkeleton.py
@@ -25,14 +25,14 @@ import maya.api.OpenMaya as OM
 
 def _MMatrixToGf(mx):
     gfmx = Gf.Matrix4d()
-    for i in xrange(4):
-        for j in xrange(4):
+    for i in range(4):
+        for j in range(4):
             gfmx[i][j] = mx[i*4+j]
     return gfmx
 
 
 def _GfMatrixToList(mx):
-    return [mx[i][j] for i in xrange(4) for j in xrange(4)]
+    return [mx[i][j] for i in range(4) for j in range(4)]
 
 
 def _GetDepNode(name):
@@ -45,7 +45,7 @@ def _ArraysAreClose(a, b, threshold=1e-5):
     if not len(a) == len(b):
         return False
 
-    for i in xrange(len(a)):
+    for i in range(len(a)):
         if not Gf.IsClose(a[i], b[i], threshold):
             return False
     return True

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdImportUVSets.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdImportUVSets.py
@@ -194,7 +194,7 @@ class testUsdImportUVSets(unittest.TestCase):
         # ALL face vertices should have the same value.
         uvSetName = 'ConstantInterpSet'
         expectedValues = {}
-        for i in xrange(24):
+        for i in range(24):
             expectedValues[i] = Gf.Vec2f(0.25, 0.25)
         self._AssertUVSet(mayaCubeMesh, uvSetName, expectedValues,
             expectedNumValues=1)
@@ -202,17 +202,17 @@ class testUsdImportUVSets(unittest.TestCase):
         # All face vertices within the same face should have the same value.
         uvSetName = 'UniformInterpSet'
         expectedValues = {}
-        for i in xrange(0, 4):
+        for i in range(0, 4):
             expectedValues[i] = Gf.Vec2f(0.0, 0.0)
-        for i in xrange(4, 8):
+        for i in range(4, 8):
             expectedValues[i] = Gf.Vec2f(0.1, 0.1)
-        for i in xrange(8, 12):
+        for i in range(8, 12):
             expectedValues[i] = Gf.Vec2f(0.2, 0.2)
-        for i in xrange(12, 16):
+        for i in range(12, 16):
             expectedValues[i] = Gf.Vec2f(0.3, 0.3)
-        for i in xrange(16, 20):
+        for i in range(16, 20):
             expectedValues[i] = Gf.Vec2f(0.4, 0.4)
-        for i in xrange(20, 24):
+        for i in range(20, 24):
             expectedValues[i] = Gf.Vec2f(0.5, 0.5)
         self._AssertUVSet(mayaCubeMesh, uvSetName, expectedValues,
             expectedNumValues=6)
@@ -259,13 +259,13 @@ class testUsdImportUVSets(unittest.TestCase):
         # All six faces share the same range 0.0-1.0.
         uvSetName = 'AllFacesSharedSet'
         expectedValues = {}
-        for i in xrange(0, 24, 4):
+        for i in range(0, 24, 4):
             expectedValues[i] = Gf.Vec2f(0.0, 0.0)
-        for i in xrange(1, 24, 4):
+        for i in range(1, 24, 4):
             expectedValues[i] = Gf.Vec2f(1.0, 0.0)
-        for i in xrange(2, 24, 4):
+        for i in range(2, 24, 4):
             expectedValues[i] = Gf.Vec2f(1.0, 1.0)
-        for i in xrange(3, 24, 4):
+        for i in range(3, 24, 4):
             expectedValues[i] = Gf.Vec2f(0.0, 1.0)
         self._AssertUVSet(mayaCubeMesh, uvSetName, expectedValues,
             expectedNumValues=4)
@@ -273,21 +273,21 @@ class testUsdImportUVSets(unittest.TestCase):
         # The faces alternate between ranges 0.0-0.5 and 0.5-1.0.
         uvSetName = 'PairedFacesSet'
         expectedValues = {}
-        for i in xrange(0, 24, 8):
+        for i in range(0, 24, 8):
             expectedValues[i] = Gf.Vec2f(0.0, 0.0)
-        for i in xrange(1, 24, 8):
+        for i in range(1, 24, 8):
             expectedValues[i] = Gf.Vec2f(0.5, 0.0)
-        for i in xrange(2, 24, 8):
+        for i in range(2, 24, 8):
             expectedValues[i] = Gf.Vec2f(0.5, 0.5)
-        for i in xrange(3, 24, 8):
+        for i in range(3, 24, 8):
             expectedValues[i] = Gf.Vec2f(0.0, 0.5)
-        for i in xrange(4, 24, 8):
+        for i in range(4, 24, 8):
             expectedValues[i] = Gf.Vec2f(0.5, 0.5)
-        for i in xrange(5, 24, 8):
+        for i in range(5, 24, 8):
             expectedValues[i] = Gf.Vec2f(1.0, 0.5)
-        for i in xrange(6, 24, 8):
+        for i in range(6, 24, 8):
             expectedValues[i] = Gf.Vec2f(1.0, 1.0)
-        for i in xrange(7, 24, 8):
+        for i in range(7, 24, 8):
             expectedValues[i] = Gf.Vec2f(0.5, 1.0)
         self._AssertUVSet(mayaCubeMesh, uvSetName, expectedValues,
             expectedNumValues=7)

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdImportXforms.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdImportXforms.py
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+from future.utils import iteritems
+from builtins import zip
+
 from pxr import Gf
 
 from maya import cmds
@@ -122,8 +125,7 @@ class testUsdImportXforms(unittest.TestCase):
             attrVals = {}
             allNodes.append(node)
             allExpected[node] = attrVals
-            for enabled, (attr, (valMin, valMax)) in itertools.izip(enabledArray,
-                                                                    ATTRS.iteritems()):
+            for enabled, (attr, (valMin, valMax)) in zip(enabledArray, iteritems(ATTRS)):
                 if not enabled:
                     if attr in ('rotateOrder', 'rotateX', 'rotateY', 'rotateZ'):
                         attrVals[attr] = 0
@@ -156,13 +158,13 @@ class testUsdImportXforms(unittest.TestCase):
         # Now import, and make sure it round-trips as expected
         cmds.file(new=1, f=1)
         cmds.usdImport(file=usdPath)
-        for node, attrVals in allExpected.iteritems():
+        for node, attrVals in iteritems(allExpected):
             # if only one (or less) of the three rotates is non-zero, then
             # the rotate order doesn't matter...
             nonZeroRotates = [attrVals['rotate' + dir] != 0 for dir in 'XYZ']
             skipRotateOrder = sum(int(x) for x in nonZeroRotates) <= 1 
             
-            for attr, expectedVal in attrVals.iteritems():
+            for attr, expectedVal in iteritems(attrVals):
                 if attr == 'rotateOrder' and skipRotateOrder:
                     continue
                 attrName = "{}.{}".format(node, attr)
@@ -180,7 +182,7 @@ class testUsdImportXforms(unittest.TestCase):
                                 attrName, expected, actual, abs(expected - actual)),
                             delta=1e-4)
                     except Exception:
-                        print "full failed xform:"
+                        print("full failed xform:")
                         pprint.pprint(attrVals)
                         raise
                     
@@ -206,7 +208,7 @@ class testUsdImportXforms(unittest.TestCase):
         expectedScale = (.5, .5, .5)
         expectedTranslation = (1.0, 2.0, 3.0)
         
-        for rotOrderName, expectedRotation in expectedRotates.iteritems():
+        for rotOrderName, expectedRotation in iteritems(expectedRotates):
             mayaTransform = self._GetMayaTransform(rotOrderName)
             transformationMatrix = mayaTransform.transformation()
     
@@ -256,7 +258,7 @@ class testUsdImportXforms(unittest.TestCase):
             mayaPath = _usdToMayaPath(usdPath)
             mayaMatrix = Gf.Matrix4d(*cmds.xform(mayaPath, query=True, matrix=True, worldSpace=True))
 
-            print 'testing matrix at', usdPath
+            print('testing matrix at', usdPath)
             self.assertTrue(Gf.IsClose(
                 usdMatrix.ExtractTranslation(), 
                 mayaMatrix.ExtractTranslation(), 

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdMayaDiagnosticDelegate.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdMayaDiagnosticDelegate.py
@@ -39,6 +39,9 @@ class testUsdMayaDiagnosticDelegate(unittest.TestCase):
         self.messageLog = []
         self.callback = None
         cmds.loadPlugin('pxrUsd', quiet=True)
+        # assertCountEqual in python 3 is equivalent to assertItemsEqual
+        if sys.version_info[0] >= 3:
+            self.assertItemsEqual = self.assertCountEqual
 
     def _OnCommandOutput(self, message, messageType, _):
         if (messageType == OM.MCommandMessage.kInfo
@@ -124,9 +127,6 @@ class testUsdMayaDiagnosticDelegate(unittest.TestCase):
                 pass
         log = self._StopRecording()
 
-        # assertCountEqual in python 3 is equivalent to assertItemsEqual
-        if sys.version_info[0] >= 3:
-            self.assertItemsEqual = self.assertCountEqual
         # Note: we use assertItemsEqual because coalescing may re-order the
         # diagnostic messages.
         self.assertItemsEqual(log, [
@@ -151,9 +151,6 @@ class testUsdMayaDiagnosticDelegate(unittest.TestCase):
                 Tf.Status("no delegate, this will be lost %d" % i)
         log = self._StopRecording()
 
-        # assertCountEqual in python 3 is equivalent to assertItemsEqual
-        if sys.version_info[0] >= 3:
-            self.assertItemsEqual = self.assertCountEqual
         # Note: we use assertItemsEqual because coalescing may re-order the
         # diagnostic messages.
         self.assertItemsEqual(log, [

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdMayaDiagnosticDelegate.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdMayaDiagnosticDelegate.py
@@ -23,8 +23,8 @@ from maya import cmds
 from maya import standalone
 from maya import OpenMaya as OM
 
+import sys
 import unittest
-
 
 class testUsdMayaDiagnosticDelegate(unittest.TestCase):
     @classmethod
@@ -112,10 +112,10 @@ class testUsdMayaDiagnosticDelegate(unittest.TestCase):
             Tf.Warn("spooky warning")
             Tf.Status("informative status")
 
-            for i in xrange(5):
+            for i in range(5):
                 Tf.Status("repeated status %d" % i)
 
-            for i in xrange(3):
+            for i in range(3):
                 Tf.Warn("spam warning %d" % i)
 
             try:
@@ -124,6 +124,9 @@ class testUsdMayaDiagnosticDelegate(unittest.TestCase):
                 pass
         log = self._StopRecording()
 
+        # assertCountEqual in python 3 is equivalent to assertItemsEqual
+        if sys.version_info[0] >= 3:
+            self.assertItemsEqual = self.assertCountEqual
         # Note: we use assertItemsEqual because coalescing may re-order the
         # diagnostic messages.
         self.assertItemsEqual(log, [
@@ -144,10 +147,13 @@ class testUsdMayaDiagnosticDelegate(unittest.TestCase):
 
             cmds.unloadPlugin('pxrUsd', force=True)
 
-            for i in xrange(5):
+            for i in range(5):
                 Tf.Status("no delegate, this will be lost %d" % i)
         log = self._StopRecording()
 
+        # assertCountEqual in python 3 is equivalent to assertItemsEqual
+        if sys.version_info[0] >= 3:
+            self.assertItemsEqual = self.assertCountEqual
         # Note: we use assertItemsEqual because coalescing may re-order the
         # diagnostic messages.
         self.assertItemsEqual(log, [

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdMayaXformStack.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdMayaXformStack.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+from future.utils import iteritems
+
 from pxr import Gf
 from pxr import Usd
 
@@ -28,6 +30,7 @@ from collections import OrderedDict
 import itertools
 import os
 import pprint
+import sys
 import unittest
 
 
@@ -174,6 +177,10 @@ class testUsdMayaXformStack(unittest.TestCase):
     def testCompatibleAttrNames(self):
         mayaStack = mayaUsdLib.XformStack.MayaStack()
         
+        # assertCountEqual in python 3 is equivalent to assertItemsEqual
+        if sys.version_info[0] >= 3:
+            self.assertItemsEqual = self.assertCountEqual
+
         translateOp = mayaStack.FindOp('translate')
         self.assertItemsEqual(
             translateOp.CompatibleAttrNames(),
@@ -701,15 +708,15 @@ class testUsdMayaXformStack(unittest.TestCase):
         
     def testMatchingSubstack_maya_full(self):
         self.makeMayaStackAttrs()
-        self.doSubstackTest(self.stack, self.ops.keys())
+        self.doSubstackTest(self.stack, list(self.ops.keys()))
         
     def testMatchingSubstack_common_full(self):
         self.makeCommonStackAttrs()
-        self.doSubstackTest(self.stack, self.ops.keys())
+        self.doSubstackTest(self.stack, list(self.ops.keys()))
         
     def testMatchingSubstack_matrix_full(self):
         self.makeMatrixStackAttrs()
-        self.doSubstackTest(self.stack, self.ops.keys())
+        self.doSubstackTest(self.stack, list(self.ops.keys()))
 
     def testMatchingSubstack_maya_empty(self):
         self.makeMayaStackAttrs()
@@ -728,7 +735,7 @@ class testUsdMayaXformStack(unittest.TestCase):
         pairedIndices = set()
         for invertPair in stack.GetInversionTwins():
             pairedIndices.update(invertPair)
-        for i in xrange(len(allOpNames)):
+        for i in range(len(allOpNames)):
             missingOp = allOpNames[i]
             opsMinus1 = allOpNames[:i] + allOpNames[i + 1:]
             # if the one we're taking out is a member of the inversion twins,
@@ -740,18 +747,18 @@ class testUsdMayaXformStack(unittest.TestCase):
 
     def testMatchingSubstack_maya_missing1(self):
         self.makeMayaStackAttrs()
-        self.doMissing1SubstackTests(self.stack, self.ops.keys())
+        self.doMissing1SubstackTests(self.stack, list(self.ops.keys()))
 
     def testMatchingSubstack_common_missing1(self):
         self.makeCommonStackAttrs()
-        self.doMissing1SubstackTests(self.stack, self.ops.keys())
+        self.doMissing1SubstackTests(self.stack, list(self.ops.keys()))
 
     def doOnly1SubstackTests(self, stack, allOpNames):
         self.longMessage = True
         pairedIndices = set()
         for invertPair in stack.GetInversionTwins():
             pairedIndices.update(invertPair)
-        for i in xrange(len(allOpNames)):
+        for i in range(len(allOpNames)):
             onlyOp = allOpNames[i]
             # if the one we're taking is a member of the inversion twins,
             # then we should get back a non-match
@@ -762,11 +769,11 @@ class testUsdMayaXformStack(unittest.TestCase):
 
     def testMatchingSubstack_maya_only1(self):
         self.makeMayaStackAttrs()
-        self.doOnly1SubstackTests(self.stack, self.ops.keys())
+        self.doOnly1SubstackTests(self.stack, list(self.ops.keys()))
 
     def testMatchingSubstack_common_only1(self):
         self.makeCommonStackAttrs()
-        self.doOnly1SubstackTests(self.stack, self.ops.keys())
+        self.doOnly1SubstackTests(self.stack, list(self.ops.keys()))
 
     def doTwinSubstackTests(self, stack, allOpNames):
         twins = stack.GetInversionTwins()
@@ -775,7 +782,7 @@ class testUsdMayaXformStack(unittest.TestCase):
         #   [firstPair]
         #   [secondPair]
         #   [firstPair, secondPair]
-        for numPairs in xrange(1, len(twins) + 1):
+        for numPairs in range(1, len(twins) + 1):
             for pairSet in itertools.combinations(twins, numPairs):
                 usedIndices = set()
                 for pair in pairSet:
@@ -787,11 +794,11 @@ class testUsdMayaXformStack(unittest.TestCase):
 
     def testMatchingSubstack_maya_twins(self):
         self.makeMayaStackAttrs()
-        self.doTwinSubstackTests(self.stack, self.ops.keys())
+        self.doTwinSubstackTests(self.stack, list(self.ops.keys()))
 
     def testMatchingSubstack_common_twins(self):
         self.makeCommonStackAttrs()
-        self.doTwinSubstackTests(self.stack, self.ops.keys())
+        self.doTwinSubstackTests(self.stack, list(self.ops.keys()))
         
     def testMatchingSubstack_maya_half(self):
         self.makeMayaStackAttrs()
@@ -1109,7 +1116,7 @@ class testUsdMayaXformStack(unittest.TestCase):
         }
         
         expectedList = [mayaStack.FindOp('translate'), mayaStack.FindOp('rotate')]
-        for rotateOpName, expectedRotateOrder in allRotates.iteritems():
+        for rotateOpName, expectedRotateOrder in iteritems(allRotates):
             orderedOps = [self.ops['translate'], self.ops[rotateOpName]]
             for stackList in (
                     [],

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdReferenceAssemblySelection.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdReferenceAssemblySelection.py
@@ -84,7 +84,7 @@ class testUsdReferenceAssemblySelection(unittest.TestCase):
         oComp = OM.MObject()
 
         ret = []
-        for i in xrange(selection.length()):
+        for i in range(selection.length()):
             selection.getDagPath(i, pathDag, oComp)
             if not oComp.isNull():
                 continue

--- a/plugin/pxr/maya/lib/usdMaya/userExportedAttributesUI.py
+++ b/plugin/pxr/maya/lib/usdMaya/userExportedAttributesUI.py
@@ -887,7 +887,7 @@ class UserExportedAttributeWidget(mayaMixin.MayaQWidgetDockableMixin, QWidget):
         # primvarInterpolation would only appear when the table cell is put into
         # edit mode. Instead, we want the combo boxes to always be visible, so
         # we tell the view to open them as persistent editors.
-        for row in xrange(self.exportedAttrsModel.rowCount()):
+        for row in range(self.exportedAttrsModel.rowCount()):
             usdAttrTypeIndex = self.exportedAttrsModel.index(row,
                 ExportedAttributesModel.USD_ATTR_TYPE_COLUMN)
             self.exportedAttrsView.openPersistentEditor(usdAttrTypeIndex)

--- a/plugin/pxr/maya/plugin/pxrUsdPreviewSurface/pxrUsdPreviewSurfaceGenFragments.py
+++ b/plugin/pxr/maya/plugin/pxrUsdPreviewSurface/pxrUsdPreviewSurfaceGenFragments.py
@@ -134,7 +134,7 @@ def _GenerateFragmentXML(xmlTemplate, outputXmlFilePath, shaderCode=None,
             existingContent = xmlFile.read()
             if existingContent == xmlContent:
                 if verbose:
-                    print '\tunchanged %s' % outputXmlFilePath
+                    print('\tunchanged %s' % outputXmlFilePath)
                 return
 
     # Otherwise attempt to write to file.
@@ -142,12 +142,12 @@ def _GenerateFragmentXML(xmlTemplate, outputXmlFilePath, shaderCode=None,
         with open(outputXmlFilePath, 'w') as xmlFile:
             xmlFile.write(xmlContent)
             if verbose:
-                print '\t    wrote %s' % outputXmlFilePath
+                print('\t    wrote %s' % outputXmlFilePath)
     except IOError as ioe:
-        print '\t', ioe
-        print 'Diff:'
-        print '\n'.join(difflib.unified_diff(existingContent.split('\n'),
-            xmlContent.split('\n')))
+        print('\t', ioe)
+        print('Diff:')
+        print('\n'.join(difflib.unified_diff(existingContent.split('\n'),
+            xmlContent.split('\n'))))
 
 
 def _GenerateLightingContributionsShaderCode(glslfxParser):
@@ -198,7 +198,7 @@ def _ValidateXML(xmlFilePath, xmlSchemaFilePath):
     try:
         from lxml import etree
     except ImportError:
-        print "Could not import lxml.etree. NOT validating XML against schema"
+        print("Could not import lxml.etree. NOT validating XML against schema")
         return
 
     xmlTree = etree.parse(xmlFilePath)
@@ -209,8 +209,8 @@ def _ValidateXML(xmlFilePath, xmlSchemaFilePath):
     try:
         xmlSchema.assertValid(xmlTree)
     except etree.DocumentInvalid:
-        print "ERROR: XML file '%s' failed validation for schema '%s'" % (
-            xmlFilePath, xmlSchemaFilePath)
+        print("ERROR: XML file '%s' failed validation for schema '%s'" % (
+            xmlFilePath, xmlSchemaFilePath))
         raise
 
 


### PR DESCRIPTION
This PR adds Python3 compatibility support for Pixar's MayaUSD and unit tests. 

Note: Out of all tests, testUsdExportPackage is not passing right now in python 3. 
See https://github.com/Autodesk/maya-usd/pull/555#discussion_r434170321

