### PR TITLE
MAYA-104981 Disable all degenerated render items.

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
@@ -66,6 +66,9 @@ struct HdVP2BasisCurvesSharedData
 
     //! The display style.
     HdDisplayStyle _displayStyle;
+
+    //! Render tag of the Rprim.
+    TfToken _renderTag;
 };
 
 /*! \brief  VP2 representation of basis curves.

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
@@ -59,8 +59,11 @@ struct HdVP2MeshSharedData {
     //! but a separate VtArray for easier access.
     VtVec3fArray _points;
 
-    //!< Position buffer of the Rprim to be shared among all its draw items.
+    //! Position buffer of the Rprim to be shared among all its draw items.
     std::unique_ptr<MHWRender::MVertexBuffer> _positionsBuffer;
+
+    //! Render tag of the Rprim.
+    TfToken _renderTag;
 };
 
 /*! \brief  VP2 representation of poly-mesh object.


### PR DESCRIPTION
Currently due to missing support for UsdSkel, the mesh will have no points data, but it still has the topology data which will reference the points. This could cause corrupted geometry in the viewport.

The commit will disable all degenerated render items.

Along with the fix I clean up the code that determines the enable/disable state of the render item.