### PR TITLE
add Trace profiling to pxr interactive performance tests

### DIFF
--- a/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testProxyShapeDrawPerformance.py
+++ b/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testProxyShapeDrawPerformance.py
@@ -18,6 +18,7 @@
 from pxr import UsdMaya
 
 from pxr import Tf
+from pxr import Trace
 
 from maya import cmds
 
@@ -75,15 +76,26 @@ class testProxyShapeDrawPerformance(unittest.TestCase):
         exit and stores the elapsed time in the class' metrics dictionary.
         """
         stopwatch = Tf.Stopwatch()
+        collector = Trace.Collector()
 
         try:
             stopwatch.Start()
+            collector.enabled = True
+            collector.BeginEvent(profileScopeName)
             yield
         finally:
+            collector.EndEvent(profileScopeName)
+            collector.enabled = False
             stopwatch.Stop()
             elapsedTime = stopwatch.seconds
             self._profileScopeMetrics[profileScopeName] = elapsedTime
-            Tf.Status("%s: %f" % (profileScopeName, elapsedTime))
+            Tf.Status('%s: %f' % (profileScopeName, elapsedTime))
+
+            traceFilePath = '%s/%s.trace' % (
+                self._testDir, profileScopeName)
+            Trace.Reporter.globalReporter.Report(traceFilePath)
+            collector.Clear()
+            Trace.Reporter.globalReporter.ClearTree()
 
     def _RunLoadTest(self):
         profileScopeName = '%s Assemblies Load Time' % self._testName

--- a/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testProxyShapeSelectionPerformance.py
+++ b/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testProxyShapeSelectionPerformance.py
@@ -19,6 +19,7 @@ from pxr import UsdMaya
 
 from pxr import Gf
 from pxr import Tf
+from pxr import Trace
 
 from maya import cmds
 from maya.api import OpenMayaUI as OMUI
@@ -191,15 +192,26 @@ class testProxyShapeSelectionPerformance(unittest.TestCase):
         exit and stores the elapsed time in the class' metrics dictionary.
         """
         stopwatch = Tf.Stopwatch()
+        collector = Trace.Collector()
 
         try:
             stopwatch.Start()
+            collector.enabled = True
+            collector.BeginEvent(profileScopeName)
             yield
         finally:
+            collector.EndEvent(profileScopeName)
+            collector.enabled = False
             stopwatch.Stop()
             elapsedTime = stopwatch.seconds
             self._profileScopeMetrics[profileScopeName] = elapsedTime
-            Tf.Status("%s: %f" % (profileScopeName, elapsedTime))
+            Tf.Status('%s: %f' % (profileScopeName, elapsedTime))
+
+            traceFilePath = '%s/%s.trace' % (
+                self._testDir, profileScopeName)
+            Trace.Reporter.globalReporter.Report(traceFilePath)
+            collector.Clear()
+            Trace.Reporter.globalReporter.ClearTree()
 
     def _TestSelectCenterSingle(self):
         """


### PR DESCRIPTION
These tests are still not being run through CMake/CTest, but we've been running them internally in our SCons-based build. This change makes them drop performance metrics generated using the Trace library to better determine where the time is being spent.