### PR TITLE
MAYA-105122 trigger only on assignment to ecp-maya-devops-adsk

### DIFF
--- a/.github/workflows/maya-usd-preflight-launcher.yml
+++ b/.github/workflows/maya-usd-preflight-launcher.yml
@@ -4,55 +4,48 @@ name: Pre-flight build on pull request
 # https://help.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   pull_request:
-    branches: [ dev ]
+    branches: [dev]
     types:    [assigned]
 
 jobs:
 
   build:
+      timeout-minutes: 180
+      runs-on: ubuntu-latest
+      if: contains(toJson(github.event.pull_request.assignee), 'ecp-maya-devops-adsk')
+      steps:
 
-    timeout-minutes: 180
+        # Build logs and results will be committed here when the remote build is complete
+        - name: Setup transfer repo
+          uses: actions/checkout@v2
+          with:
+            repository: ecp-maya-devops-adsk/log-transfer
+            ref: transfer
+            path: transfer
 
-    # The type of runners that the job will run on.
-    # In this case only a linux system is required.
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-18.04]
+        # Echo the file name - it's hard to find the run_id in the UI
+        - name: Echo the expected result file name
+          run: "echo ${{ github.run_id }}_${{ github.run_number }}_result.txt"
 
-    steps:
+        # Wait for remote build to finish and commit results to git
+        - name: Wait until build results are available
+          shell: bash
+          run: "cd transfer ; while ! [ -f ${{ github.run_id }}_${{ github.run_number }}_result.txt ] ; do git pull --quiet ; sleep 10 ; done"
 
-    # Build logs and results will be committed here when the remote build is complete
-    - name: Setup transfer repo
-      uses: actions/checkout@v2
-      with:
-        repository: ecp-maya-devops-adsk/log-transfer
-        ref: transfer
-        path: transfer
+        # List files related to this build
+        - name: List files in transfer directory
+          shell: bash
+          run: "ls -lap transfer/${{ github.run_id }}_${{ github.run_number }}_*"
 
-    # Echo the file name - it's hard to find the run_id in the UI
-    - name: Echo the expected result file name
-      run: "echo ${{ github.run_id }}_${{ github.run_number }}_result.txt"
+        # Upload files related to this build
+        - name: Upload files in transfer directory as artifacts
+          uses: actions/upload-artifact@v2
+          with:
+            name: build logs
+            path: "transfer/${{ github.run_id }}_${{ github.run_number }}_*"
 
-    # Wait for remote build to finish and commit results to git
-    - name: Wait until build results are available
-      shell: bash
-      run: "cd transfer ; while ! [ -f ${{ github.run_id }}_${{ github.run_number }}_result.txt ] ; do git pull --quiet ; sleep 10 ; done"
-
-    # List files related to this build
-    - name: List files in transfer directory
-      shell: bash
-      run: "ls -lap transfer/${{ github.run_id }}_${{ github.run_number }}_*"
-
-    # Upload files related to this build
-    - name: Upload files in transfer directory as artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: build logs
-        path: "transfer/${{ github.run_id }}_${{ github.run_number }}_*"
-
-    # Grep the results file to show failures
-    - name: Exit with error if a build failed
-      # Default shell includes "-o pipefail" and "-e". Specify a different shell
-      shell: bash --noprofile --norc {0}
-      run: "if grep -i failed transfer/${{ github.run_id }}_${{ github.run_number }}_result.txt; then exit 1; else exit 0; fi"
+        # Grep the results file to show failures
+        - name: Exit with error if a build failed
+          # Default shell includes "-o pipefail" and "-e". Specify a different shell
+          shell: bash --noprofile --norc {0}
+          run: "if grep -i failed transfer/${{ github.run_id }}_${{ github.run_number }}_result.txt; then exit 1; else exit 0; fi"


### PR DESCRIPTION
The diff looks bad. The real change is only 2 lines:

` runs-on: ubuntu-latest`
`if: contains(toJson(github.event.pull_request.assignee), 'ecp-maya-devops-adsk')`

I took out the runs-on matrix for simplicity.
The if: condition makes the GitHub Actions build show as "skipped" instead of "failed", which is nice. You can see an example here: https://github.com/smithw-adsk/maya-usd/pull/16