### PR TITLE
MAYA-105120 Hide MRenderItems created for instancers with zero instances.

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1075,6 +1075,9 @@ HdVP2BasisCurves::_UpdateDrawItem(
     // The current instancer invalidation tracking makes it hard for
     // us to tell whether transforms will be dirty, so this code
     // pulls them every time something changes.
+    // If the mesh is instanced but has 0 instance transforms remember that
+    // so the render item can be hidden.
+    bool instancerWithNoInstances = false;
     if (!GetInstancerId().IsEmpty()) {
 
         // Retrieve instance transforms from the instancer.
@@ -1083,10 +1086,14 @@ HdVP2BasisCurves::_UpdateDrawItem(
             ComputeInstanceTransforms(id);
 
         MMatrix instanceMatrix;
+        const unsigned int instanceCount = transforms.size();
 
-        if (isDedicatedSelectionHighlightItem) {
+        if (0 == instanceCount) {
+            instancerWithNoInstances = true;
+        }
+        else if (isDedicatedSelectionHighlightItem) {
             if (_selectionState == kFullySelected) {
-                stateToCommit._instanceTransforms.setLength(transforms.size());
+                stateToCommit._instanceTransforms.setLength(instanceCount);
                 for (size_t i = 0; i < transforms.size(); ++i) {
                     transforms[i].Get(instanceMatrix.matrix);
                     instanceMatrix = worldMatrix * instanceMatrix;
@@ -1104,7 +1111,6 @@ HdVP2BasisCurves::_UpdateDrawItem(
             }
         }
         else {
-            const unsigned int instanceCount = transforms.size();
             stateToCommit._instanceTransforms.setLength(instanceCount);
             for (size_t i = 0; i < instanceCount; ++i) {
                 transforms[i].Get(instanceMatrix.matrix);
@@ -1193,12 +1199,13 @@ HdVP2BasisCurves::_UpdateDrawItem(
     }
 
     // Determine if the render item should be enabled or not.
-    if (itemDirtyBits & (HdChangeTracker::DirtyVisibility |
+    if ((itemDirtyBits & (HdChangeTracker::DirtyVisibility |
                          HdChangeTracker::DirtyRenderTag |
                          HdChangeTracker::DirtyPoints |
                          HdChangeTracker::DirtyExtent |
-                         DirtySelectionHighlight)) {
-        bool enable = drawItem->GetVisible() && !_curvesSharedData._points.empty();
+                         DirtySelectionHighlight)) ||
+                         !GetInstancerId().IsEmpty()) {
+        bool enable = drawItem->GetVisible() && !_curvesSharedData._points.empty() && !instancerWithNoInstances;
 
         if (isDedicatedSelectionHighlightItem) {
             enable = enable && (_selectionState != kUnselected);

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1358,11 +1358,11 @@ void HdVP2Mesh::_UpdateDrawItem(
     }
 
     // Determine if the render item should be enabled or not.
-    if (itemDirtyBits & (HdChangeTracker::DirtyVisibility |
+    if ((itemDirtyBits & (HdChangeTracker::DirtyVisibility |
                          HdChangeTracker::DirtyRenderTag |
                          HdChangeTracker::DirtyPoints |
                          HdChangeTracker::DirtyExtent |
-                         DirtySelectionHighlight) ||
+                         DirtySelectionHighlight)) ||
         instancerWithNoInstances) {
         bool enable = drawItem->GetVisible() && !_meshSharedData._points.empty() && !instancerWithNoInstances;
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1267,7 +1267,7 @@ void HdVP2Mesh::_UpdateDrawItem(
     // The current instancer invalidation tracking makes it hard for
     // us to tell whether transforms will be dirty, so this code
     // pulls them every time something changes.
-    // If the mesh is instanced but have 0 instance transforms remember that
+    // If the mesh is instanced but has 0 instance transforms remember that
     // so the render item can be hidden.
     bool instancerWithNoInstances = false;
     if (!GetInstancerId().IsEmpty()) {
@@ -1363,7 +1363,7 @@ void HdVP2Mesh::_UpdateDrawItem(
                          HdChangeTracker::DirtyPoints |
                          HdChangeTracker::DirtyExtent |
                          DirtySelectionHighlight)) ||
-        instancerWithNoInstances) {
+                        !GetInstancerId().IsEmpty()) {
         bool enable = drawItem->GetVisible() && !_meshSharedData._points.empty() && !instancerWithNoInstances;
 
         if (isDedicatedSelectionHighlightItem) {


### PR DESCRIPTION
As a part of setting up an instanced MRenderItem in Vp2RenderDelegate we'd set the prototype geometry on the item. At this point the MRenderItem looks to Maya like any other drawable item (with an identity transform matrix). Then we set the instance transforms and the MRenderItem changes to an instanced item and we handle the drawing differently.

The problem is when there is a USD instances with no instances we never do that second step, so the item stays a regular Maya item and we draw it normally, which is not what we want to happen.

The solution is detect that there is an instancer with zero instance transforms and hide the MRenderItem in those cases.

#404 #522