### PR TITLE
Demonstrate fix for Maya selection undo / redo.

### DIFF
--- a/test/lib/ufe/ufeTestUtils/mayaUtils.py
+++ b/test/lib/ufe/ufeTestUtils/mayaUtils.py
@@ -151,13 +151,23 @@ def openTreeRefScene():
 def previewReleaseVersion():
     '''Return the Maya Preview Release version.
 
-    If the version of Maya is not a Preview Release, returns sys.maxsize (a very
-    large number).  If the environment variable
+    If the version of Maya is 2019, returns 98.
+
+    If the version of Maya is 2020, returns 110.
+
+    If the version of Maya is current and is not a Preview Release, returns
+    sys.maxsize (a very large number).  If the environment variable
     MAYA_PREVIEW_RELEASE_VERSION_OVERRIDE is defined, return its value instead.
     '''
 
     if 'MAYA_PREVIEW_RELEASE_VERSION_OVERRIDE' in os.environ:
         return int(os.environ['MAYA_PREVIEW_RELEASE_VERSION_OVERRIDE'])
+
+    majorVersion = int(cmds.about(majorVersion=True))
+    if majorVersion == 2019:
+        return 98
+    elif majorVersion == 2020:
+        return 110
 
     match = prRe.match(cmds.about(v=True))
 


### PR DESCRIPTION
This pull request updates the selection test to demonstrate a fix to the Maya selection undo / redo behavior.  The previous version of the test did not trigger the bug; this one does, and therefore demonstrates the fix, which will be in the next Maya preview release.  This pull request should not be merged before the corresponding Maya bug fix is merged.

The bug occurs when the select command replaces a non-Maya UFE selection.  On undo, the select command must restore the previous non-Maya UFE selection.  This test ensures it does.