### PR TITLE
Pixar batch renderer refactoring and performance improvements

### DIFF
--- a/lib/mayaUsd/render/px_vp20/utils.cpp
+++ b/lib/mayaUsd/render/px_vp20/utils.cpp
@@ -763,8 +763,8 @@ px_vp20Utils::RenderBoundingBox(
     bboxTransformMatrix.setScale(scales, MSpace::kTransform);
     return RenderWireCubes(
             { GfMatrix4f(bboxTransformMatrix.asMatrix().matrix) },
-            color, 
-            GfMatrix4d(worldViewMat.matrix), 
+            color,
+            GfMatrix4d(worldViewMat.matrix),
             GfMatrix4d(projectionMat.matrix));
 }
 
@@ -875,7 +875,7 @@ void main()
     // Populate the shader variables.
     GfMatrix4f vpMatrix(worldViewMat * projectionMat);
     GLuint vpMatrixLoc = glGetUniformLocation(renderBoundsProgramId, "vpMatrix");
-    glUniformMatrix4fv(vpMatrixLoc, 1, 
+    glUniformMatrix4fv(vpMatrixLoc, 1,
             GL_TRUE, // transpose
             vpMatrix.data());
 
@@ -891,12 +891,12 @@ void main()
     // since we're copying these directly from GfMatrix4f, we need to
     // transpose() them in the shader.
     const GLuint cubeXformLoc = glGetAttribLocation(renderBoundsProgramId, "cubeXformT");
-    glBufferData(GL_ARRAY_BUFFER, 
+    glBufferData(GL_ARRAY_BUFFER,
             sizeof(GfMatrix4f) * numCubes, cubeXforms.data(), GL_DYNAMIC_DRAW);
     for (size_t r = 0; r < 4; r++) {
         GLuint loc = cubeXformLoc + r;
         glEnableVertexAttribArray(loc);
-        glVertexAttribPointer(loc, 4, GL_FLOAT, GL_FALSE, sizeof(GfMatrix4f), 
+        glVertexAttribPointer(loc, 4, GL_FLOAT, GL_FALSE, sizeof(GfMatrix4f),
                 (char*)(sizeof(float)*4*r));
         glVertexAttribDivisor(loc, 1);
     }

--- a/lib/mayaUsd/render/px_vp20/utils.h
+++ b/lib/mayaUsd/render/px_vp20/utils.h
@@ -25,6 +25,7 @@
 #include <maya/MBoundingBox.h>
 #include <maya/MDrawContext.h>
 #include <maya/MHWGeometryUtilities.h>
+#include <maya/MFrameContext.h>
 #include <maya/MMatrix.h>
 #include <maya/MSelectionContext.h>
 
@@ -63,6 +64,14 @@ class px_vp20Utils
         static bool GetViewFromDrawContext(
                 const MHWRender::MDrawContext& context,
                 M3dView& view);
+
+        /// Returns true if the given Maya display style indicates that a
+        /// bounding box should be rendered.
+        static bool ShouldRenderBoundingBox(unsigned int displayStyle) {
+            const bool boundingBoxStyle =
+                displayStyle & MHWRender::MFrameContext::DisplayStyle::kBoundingBox;
+            return boundingBoxStyle;
+        }
 
         /// Renders the given bounding box in the given \p color via OpenGL.
         MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/render/px_vp20/utils.h
+++ b/lib/mayaUsd/render/px_vp20/utils.h
@@ -83,7 +83,7 @@ class px_vp20Utils
 
         /// Helper to draw multiple wireframe boxes, where \p cubeXforms is a
         /// list of transforms to apply to the unit cube centered around the
-        /// origin.  Those transforms will all be concatenated with the 
+        /// origin.  Those transforms will all be concatenated with the
         /// \p worldViewMat and \p projectionMat.
         MAYAUSD_CORE_PUBLIC
         static bool RenderWireCubes(

--- a/lib/mayaUsd/render/px_vp20/utils_legacy.h
+++ b/lib/mayaUsd/render/px_vp20/utils_legacy.h
@@ -89,6 +89,13 @@ class px_LegacyViewportUtils
             return displayStyle;
         }
 
+        /// Returns true if the given Maya display style indicates that a
+        /// bounding box should be rendered.
+        static bool ShouldRenderBoundingBox(
+                M3dView::DisplayStyle legacyDisplayStyle) {
+            return (legacyDisplayStyle == M3dView::kBoundingBox);
+        }
+
     private:
         px_LegacyViewportUtils() = delete;
         ~px_LegacyViewportUtils() = delete;

--- a/lib/mayaUsd/render/px_vp20/utils_legacy.h
+++ b/lib/mayaUsd/render/px_vp20/utils_legacy.h
@@ -18,9 +18,24 @@
 
 /// \file px_vp20/utils_legacy.h
 
+// XXX: With Maya versions up through 2019 on Linux, M3dView.h ends up
+// indirectly including an X11 header that #define's "Bool" as int:
+//   - <maya/M3dView.h> includes <maya/MNativeWindowHdl.h>
+//   - <maya/MNativeWindowHdl.h> includes <X11/Intrinsic.h>
+//   - <X11/Intrinsic.h> includes <X11/Xlib.h>
+//   - <X11/Xlib.h> does: "#define Bool int"
+// This can cause compilation issues if <pxr/usd/sdf/types.h> is included
+// afterwards, so to fix this, we ensure that it gets included first.
+//
+// The X11 include appears to have been removed in Maya 2020+, so this should
+// no longer be an issue with later versions.
+#include <pxr/usd/sdf/types.h>
+
 #include <pxr/pxr.h>
 #include <pxr/base/gf/matrix4d.h>
 
+#include <maya/M3dView.h>
+#include <maya/MFrameContext.h>
 #include <maya/MSelectInfo.h>
 
 #include <mayaUsd/base/api.h>
@@ -39,6 +54,40 @@ class px_LegacyViewportUtils
                 MSelectInfo& selectInfo,
                 GfMatrix4d& viewMatrix,
                 GfMatrix4d& projectionMatrix);
+
+        /// Helper function that converts M3dView::DisplayStyle from the legacy
+        /// viewport into MHWRender::MFrameContext::DisplayStyle for Viewport
+        /// 2.0.
+        ///
+        /// In the legacy viewport, the M3dView can be in exactly one
+        /// displayStyle whereas Viewport 2.0's displayStyle is a bitmask of
+        /// potentially multiple styles. To translate from the legacy viewport
+        /// to Viewport 2.0, we simply bitwise-OR the single legacy viewport
+        /// displayStyle into an empty mask.
+        static unsigned int GetMFrameContextDisplayStyle(
+                M3dView::DisplayStyle legacyDisplayStyle) {
+            unsigned int displayStyle = 0u;
+
+            switch (legacyDisplayStyle) {
+                case M3dView::kBoundingBox:
+                    displayStyle |= MHWRender::MFrameContext::DisplayStyle::kBoundingBox;
+                    break;
+                case M3dView::kFlatShaded:
+                    displayStyle |= MHWRender::MFrameContext::DisplayStyle::kFlatShaded;
+                    break;
+                case M3dView::kGouraudShaded:
+                    displayStyle |= MHWRender::MFrameContext::DisplayStyle::kGouraudShaded;
+                    break;
+                case M3dView::kWireFrame:
+                    displayStyle |= MHWRender::MFrameContext::DisplayStyle::kWireFrame;
+                    break;
+                case M3dView::kPoints:
+                    // Not supported.
+                    break;
+            }
+
+            return displayStyle;
+        }
 
     private:
         px_LegacyViewportUtils() = delete;

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -160,8 +160,7 @@ UsdMayaGLBatchRenderer::AddShapeAdapter(PxrMayaHdShapeAdapter* shapeAdapter)
         _shapeAdapterBuckets :
         _legacyShapeAdapterBuckets;
 
-    const PxrMayaHdRenderParams renderParams =
-        shapeAdapter->GetRenderParams(nullptr, nullptr);
+    const PxrMayaHdRenderParams& renderParams = shapeAdapter->GetRenderParams();
     const size_t renderParamsHash = renderParams.Hash();
 
     TF_DEBUG(PXRUSDMAYAGL_SHAPE_ADAPTER_BUCKETING).Msg(

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -1090,6 +1090,7 @@ UsdMayaGLBatchRenderer::_GetIntersectionPrimFilters(
 
             primFilters.push_back(
                     PxrMayaHdPrimFilter {
+                        nullptr,
                         rprimCollection,
                         renderTags
                     });
@@ -1104,6 +1105,7 @@ UsdMayaGLBatchRenderer::_GetIntersectionPrimFilters(
 
         primFilters.push_back(
             PxrMayaHdPrimFilter {
+                nullptr,
                 collection,
                 TfTokenVector{
 #if USD_VERSION_NUM >= 1911
@@ -1466,6 +1468,7 @@ UsdMayaGLBatchRenderer::_RenderBatches(
             itemsVisible |= shapeAdapter->IsVisible();
 
             primFilters.push_back(PxrMayaHdPrimFilter {
+                nullptr,
                 shapeAdapter->GetRprimCollection(),
                 shapeAdapter->GetRenderTags()
             });

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -1097,11 +1097,11 @@ UsdMayaGLBatchRenderer::_GetIntersectionPrimFilters(
             const TfTokenVector &renderTags = shapeAdapter->GetRenderTags();
 
             primFilters.push_back(
-                    PxrMayaHdPrimFilter {
-                        shapeAdapter,
-                        rprimCollection,
-                        renderTags
-                    });
+                PxrMayaHdPrimFilter {
+                    shapeAdapter,
+                    rprimCollection,
+                    renderTags
+                });
         }
     }
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -62,6 +62,7 @@
 #include <pxr/base/vt/types.h>
 #include <pxr/base/vt/value.h>
 #include <pxr/imaging/glf/contextCaps.h>
+#include <pxr/imaging/hd/changeTracker.h>
 #include <pxr/imaging/hd/renderIndex.h>
 #include <pxr/imaging/hd/rprimCollection.h>
 #include <pxr/imaging/hd/task.h>

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
@@ -318,6 +318,7 @@ private:
             const GfMatrix4d& worldToViewMatrix,
             const GfMatrix4d& projectionMatrix,
             const GfVec4d& viewport,
+            unsigned int displayStyle,
             const std::vector<_RenderItem>& items);
 
     /// Call to render all queued batches. May be called safely without

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
@@ -93,8 +93,10 @@ using HgiUniquePtr = std::unique_ptr<class Hgi>;
 /// A user data object should also be created/obtained for the shape by calling
 /// the shape adapter's GetMayaUserData() method.
 ///
-/// In the draw stage, Draw() must be called for each draw request to complete
-/// the render.
+/// Typically, all Hydra-imaged shapes will be drawn automatically as a single
+/// batch by the pxrHdImagingShape. However, bounding boxes are not drawn by
+/// Hydra, so each draw override should invoke DrawBoundingBox() to do that if
+/// necessary.
 ///
 /// Draw/selection management objects should be sure to call
 /// RemoveShapeAdapter() (usually in the destructor) when they no longer wish

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
@@ -188,6 +188,16 @@ public:
             const MHWRender::MDrawContext& context,
             const MUserData* userData);
 
+    /// Render bounding box in the legacy viewport based on \p request
+    MAYAUSD_CORE_PUBLIC
+    void DrawBoundingBox(const MDrawRequest& request, M3dView& view);
+
+    /// Render bounding box in Viewport 2.0 based on \p userData
+    MAYAUSD_CORE_PUBLIC
+    void DrawBoundingBox(
+            const MHWRender::MDrawContext& context,
+            const MUserData* userData);
+
     /// Gets the resolution of the draw target used for computing selections.
     ///
     /// The resolution is specified as (width, height).

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
@@ -51,6 +51,7 @@
 #include <pxr/base/gf/vec3f.h>
 #include <pxr/base/gf/vec4d.h>
 #include <pxr/base/tf/singleton.h>
+#include <pxr/base/tf/token.h>
 #include <pxr/base/tf/weakBase.h>
 #include <pxr/imaging/hd/engine.h>
 #include <pxr/imaging/hd/renderIndex.h>

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
@@ -180,11 +180,11 @@ public:
             const MDagPath& dagPath,
             PxrMayaHdPrimFilter& primFilter);
 
-    /// Render batch or bounding box in the legacy viewport based on \p request
+    /// Render batch in the legacy viewport based on \p request
     MAYAUSD_CORE_PUBLIC
     void Draw(const MDrawRequest& request, M3dView& view);
 
-    /// Render batch or bounding box in Viewport 2.0 based on \p userData
+    /// Render batch in Viewport 2.0 based on \p userData
     MAYAUSD_CORE_PUBLIC
     void Draw(
             const MHWRender::MDrawContext& context,

--- a/lib/mayaUsd/render/pxrUsdMayaGL/hdImagingShapeDrawOverride.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/hdImagingShapeDrawOverride.cpp
@@ -193,8 +193,6 @@ PxrMayaHdImagingShapeDrawOverride::prepareForDraw(
         newData = new PxrMayaHdUserData();
     }
 
-    newData->drawShape = true;
-
     return newData;
 }
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/hdImagingShapeUI.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/hdImagingShapeUI.cpp
@@ -116,7 +116,6 @@ PxrMayaHdImagingShapeUI::getDrawRequests(
     // renderer deletes the MUserData object at the end of a legacy viewport
     // Draw() call.
     PxrMayaHdUserData* userData = new PxrMayaHdUserData();
-    userData->drawShape = true;
 
     MDrawData drawData;
     getDrawData(userData, drawData);

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerImager.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerImager.cpp
@@ -92,7 +92,7 @@ UsdMayaGL_InstancerImager::_SyncShapeAdapters(
 
         const MDagPath firstInstancePath =
                 MDagPath::getAPathTo(handle.object());
-    
+
         // Create the adapter if it doesn't exist yet.
         _InstancerEntry& entry = iter->second;
         if (vp2) {

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.cpp
@@ -72,7 +72,7 @@ bool
 UsdMayaGL_InstancerShapeAdapter::UpdateVisibility(const M3dView* view)
 {
     bool isVisible;
-    if (!_GetVisibility(_shapeDagPath, view, &isVisible)) {
+    if (!_GetVisibility(GetDagPath(), view, &isVisible)) {
         return false;
     }
 
@@ -224,7 +224,7 @@ UsdMayaGL_InstancerShapeAdapter::_Sync(
     // require us to re-initialize the shape adapter.
     HdRenderIndex* renderIndex =
         UsdMayaGLBatchRenderer::GetInstance().GetRenderIndex();
-    if (!(shapeDagPath == _shapeDagPath) ||
+    if (!(shapeDagPath == GetDagPath()) ||
             !_delegate ||
             renderIndex != &_delegate->GetRenderIndex()) {
         _SetDagPath(shapeDagPath);
@@ -237,7 +237,7 @@ UsdMayaGL_InstancerShapeAdapter::_Sync(
     // Reset _renderParams to the defaults.
     _renderParams = PxrMayaHdRenderParams();
 
-    const MMatrix transform = _shapeDagPath.inclusiveMatrix(&status);
+    const MMatrix transform = GetDagPath().inclusiveMatrix(&status);
     if (status == MS::kSuccess) {
         _rootXform = GfMatrix4d(transform.matrix);
         _delegate->SetRootTransform(_rootXform);
@@ -309,14 +309,14 @@ UsdMayaGL_InstancerShapeAdapter::_Init(HdRenderIndex* renderIndex)
         "    shape identifier: %s\n"
         "    delegateId      : %s\n",
         this,
-        _shapeDagPath.fullPathName().asChar(),
+        GetDagPath().fullPathName().asChar(),
         _shapeIdentifier.GetText(),
         _delegateId.GetText());
 
     _delegate.reset(new UsdImagingDelegate(renderIndex, _delegateId));
     if (!TF_VERIFY(_delegate,
                   "Failed to create shape adapter delegate for shape %s",
-                  _shapeDagPath.fullPathName().asChar())) {
+                  GetDagPath().fullPathName().asChar())) {
         return false;
     }
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.cpp
@@ -40,7 +40,6 @@
 #include <pxr/imaging/hd/enums.h>
 #include <pxr/imaging/hd/renderIndex.h>
 #include <pxr/imaging/hd/repr.h>
-#include <pxr/imaging/hd/rprimCollection.h>
 #include <pxr/imaging/hd/tokens.h>
 #include <pxr/usd/kind/registry.h>
 #include <pxr/usd/sdf/path.h>
@@ -271,19 +270,6 @@ UsdMayaGL_InstancerShapeAdapter::_Sync(
         _delegate->SetRootVisibility(_drawShape);
     }
 
-    if (_rprimCollection.GetReprSelector() != reprSelector) {
-        _rprimCollection.SetReprSelector(reprSelector);
-
-        TF_DEBUG(PXRUSDMAYAGL_SHAPE_ADAPTER_LIFECYCLE).Msg(
-                "    Repr selector changed: %s\n"
-                "        Marking collection dirty: %s\n",
-                reprSelector.GetText(),
-                _rprimCollection.GetName().GetText());
-
-        _delegate->GetRenderIndex().GetChangeTracker().MarkCollectionDirty(
-            _rprimCollection.GetName());
-    }
-
     HdCullStyle cullStyle = HdCullStyleNothing;
     if (displayStyle & MHWRender::MFrameContext::DisplayStyle::kBackfaceCulling) {
         cullStyle = HdCullStyleBackUnlessDoubleSided;
@@ -322,15 +308,6 @@ UsdMayaGL_InstancerShapeAdapter::_Init(HdRenderIndex* renderIndex)
 
     UsdPrim usdPrim = _instancerStage->GetDefaultPrim();
     _delegate->Populate(usdPrim, SdfPathVector());
-
-    if (collectionName != _rprimCollection.GetName()) {
-        _rprimCollection.SetName(collectionName);
-        renderIndex->GetChangeTracker().AddCollection(
-                _rprimCollection.GetName());
-    }
-
-    _rprimCollection.SetReprSelector(HdReprSelector(HdReprTokens->refined));
-    _rprimCollection.SetRootPath(delegateId);
 
     return true;
 }

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.cpp
@@ -258,16 +258,9 @@ UsdMayaGL_InstancerShapeAdapter::_Sync(
     // lighting.
     const HdReprSelector reprSelector =
         GetReprSelectorForDisplayStyle(displayStyle);
-
-    _drawShape = reprSelector.AnyActiveRepr();
-
     if (reprSelector.Contains(HdReprTokens->wire) ||
             reprSelector.Contains(HdReprTokens->refinedWire)) {
         _renderParams.enableLighting = false;
-    }
-
-    if (_delegate->GetRootVisibility() != _drawShape) {
-        _delegate->SetRootVisibility(_drawShape);
     }
 
     HdCullStyle cullStyle = HdCullStyleNothing;

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.cpp
@@ -309,7 +309,7 @@ UsdMayaGL_InstancerShapeAdapter::_Init(HdRenderIndex* renderIndex)
 void UsdMayaGL_InstancerShapeAdapter::SyncInstancerPerPrototypePostHook(
     const MPlug&              ,
     UsdPrim&                  prototypePrim,
-    std::vector<std::string>& 
+    std::vector<std::string>&
 )
 {
     UsdReferences prototypeRefs = prototypePrim.GetReferences();

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.cpp
@@ -276,12 +276,6 @@ UsdMayaGL_InstancerShapeAdapter::_Sync(
 
     _drawShape = reprSelector.AnyActiveRepr();
 
-    // We won't ever draw the bounding box here because the native Maya
-    // instancer already draws a bounding box, and we don't want to draw two.
-    // XXX: The native Maya instancer's bounding box will only cover the native
-    // geometry, though; is there any way to "teach" it about our bounds?
-    _drawBoundingBox = false;
-
     if (reprSelector.Contains(HdReprTokens->wire) ||
             reprSelector.Contains(HdReprTokens->refinedWire)) {
         _renderParams.enableLighting = false;

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.h
@@ -123,9 +123,10 @@ class UsdMayaGL_InstancerShapeAdapter : public PxrMayaHdShapeAdapter
         /// Initialize the shape adapter using the given \p renderIndex.
         ///
         /// This method is called automatically during Sync() when the shape
-        /// adapter's "identity" changes. This happens when the delegateId or
-        /// the rprim collection name computed from the shape adapter's shape
-        /// is different than what is currently stored in the shape adapter.
+        /// adapter's "identity" changes. This can happen when the shape
+        /// managed by this adapter is changed by setting a new DAG path, or
+        /// otherwise when there is some other fundamental change to the shape
+        /// or to the delegate or render index.
         /// The shape adapter will then query the batch renderer for its render
         /// index and use that to re-create its delegate and re-add its rprim
         /// collection, if necessary.

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.h
@@ -75,7 +75,7 @@ class UsdMayaGL_InstancerShapeAdapter : public PxrMayaHdShapeAdapter
         /// Gets whether the shape adapter's shape is visible.
         ///
         /// This should be called after a call to UpdateVisibility() to ensure
-        /// that the returned value is correct. 
+        /// that the returned value is correct.
         MAYAUSD_CORE_PUBLIC
         bool IsVisible() const override;
 
@@ -83,7 +83,7 @@ class UsdMayaGL_InstancerShapeAdapter : public PxrMayaHdShapeAdapter
         void SetRootXform(const GfMatrix4d& transform) override;
 
         MAYAUSD_CORE_PUBLIC
-            ~UsdMayaGL_InstancerShapeAdapter() override;
+        ~UsdMayaGL_InstancerShapeAdapter() override;
 
     protected:
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.h
@@ -83,9 +83,6 @@ class UsdMayaGL_InstancerShapeAdapter : public PxrMayaHdShapeAdapter
         void SetRootXform(const GfMatrix4d& transform) override;
 
         MAYAUSD_CORE_PUBLIC
-        const SdfPath& GetDelegateID() const override;
-
-        MAYAUSD_CORE_PUBLIC
             ~UsdMayaGL_InstancerShapeAdapter() override;
 
     protected:

--- a/lib/mayaUsd/render/pxrUsdMayaGL/proxyDrawOverride.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/proxyDrawOverride.cpp
@@ -208,24 +208,9 @@ UsdMayaProxyDrawOverride::prepareForDraw(
 
     UsdMayaGLBatchRenderer::GetInstance().AddShapeAdapter(&_shapeAdapter);
 
-    bool drawShape;
-    bool drawBoundingBox;
-    _shapeAdapter.GetRenderParams(&drawShape, &drawBoundingBox);
+    const MBoundingBox boundingBox = shape->boundingBox();
 
-    if (!drawBoundingBox && !drawShape) {
-        // We weren't asked to do anything.
-        return nullptr;
-    }
-
-    MBoundingBox boundingBox;
-    MBoundingBox* boundingBoxPtr = nullptr;
-    if (drawBoundingBox) {
-        // Only query for the bounding box if we're drawing it.
-        boundingBox = shape->boundingBox();
-        boundingBoxPtr = &boundingBox;
-    }
-
-    return _shapeAdapter.GetMayaUserData(oldData, boundingBoxPtr);
+    return _shapeAdapter.GetMayaUserData(oldData, &boundingBox);
 }
 
 /* virtual */

--- a/lib/mayaUsd/render/pxrUsdMayaGL/proxyDrawOverride.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/proxyDrawOverride.cpp
@@ -299,11 +299,12 @@ UsdMayaProxyDrawOverride::draw(
         MProfiler::kColorC_L1,
         "USD Proxy Shape draw() (Viewport 2.0)");
 
-    // Note that this Draw() call is only necessary when we're drawing the
-    // bounding box, since that is not yet handled by Hydra and is instead done
-    // internally by the batch renderer on a per-shape basis. Otherwise, the
-    // pxrHdImagingShape is what will invoke Hydra to draw the shape.
-    UsdMayaGLBatchRenderer::GetInstance().Draw(context, data);
+    const unsigned int displayStyle = context.getDisplayStyle();
+    if (!px_vp20Utils::ShouldRenderBoundingBox(displayStyle)) {
+        return;
+    }
+
+    UsdMayaGLBatchRenderer::GetInstance().DrawBoundingBox(context, data);
 }
 
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/proxyDrawOverride.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/proxyDrawOverride.cpp
@@ -254,7 +254,7 @@ UsdMayaProxyDrawOverride::userSelect(
 
     const unsigned int displayStyle = context.getDisplayStyle();
     const MHWRender::DisplayStatus displayStatus =
-        MHWRender::MGeometryUtilities::displayStatus(_shapeAdapter._shapeDagPath);
+        MHWRender::MGeometryUtilities::displayStatus(_shapeAdapter.GetDagPath());
 
     // At this point, we expect the shape to have already been drawn and our
     // shape adapter to have been added to the batch renderer, but just in
@@ -263,7 +263,7 @@ UsdMayaProxyDrawOverride::userSelect(
     // must have already been done to have caused the shape to be drawn and
     // become eligible for selection.
     if (!_shapeAdapter.Sync(
-            _shapeAdapter._shapeDagPath, displayStyle, displayStatus)) {
+            _shapeAdapter.GetDagPath(), displayStyle, displayStatus)) {
         return false;
     }
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/proxyShapeDelegate.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/proxyShapeDelegate.cpp
@@ -35,8 +35,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 static PxrMayaHdPrimFilter _sharedPrimFilter = {
         nullptr,
         HdRprimCollection(
-                TfToken("UsdMayaGL_ClosestPointOnProxyShape"),
-                HdReprSelector(HdReprTokens->refined)
+            TfToken("UsdMayaGL_ClosestPointOnProxyShape"),
+            HdReprSelector(HdReprTokens->refined)
         ),
         TfTokenVector()  // Render Tags
 };

--- a/lib/mayaUsd/render/pxrUsdMayaGL/proxyShapeDelegate.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/proxyShapeDelegate.cpp
@@ -33,6 +33,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 static PxrMayaHdPrimFilter _sharedPrimFilter = {
+        nullptr,
         HdRprimCollection(
                 TfToken("UsdMayaGL_ClosestPointOnProxyShape"),
                 HdReprSelector(HdReprTokens->refined)

--- a/lib/mayaUsd/render/pxrUsdMayaGL/proxyShapeUI.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/proxyShapeUI.cpp
@@ -85,26 +85,11 @@ UsdMayaProxyShapeUI::getDrawRequests(
 
     UsdMayaGLBatchRenderer::GetInstance().AddShapeAdapter(&_shapeAdapter);
 
-    bool drawShape;
-    bool drawBoundingBox;
-    _shapeAdapter.GetRenderParams(&drawShape, &drawBoundingBox);
-
-    if (!drawBoundingBox && !drawShape) {
-        // We weren't asked to do anything.
-        return;
-    }
-
-    MBoundingBox boundingBox;
-    MBoundingBox* boundingBoxPtr = nullptr;
-    if (drawBoundingBox) {
-        // Only query for the bounding box if we're drawing it.
-        boundingBox = shape->boundingBox();
-        boundingBoxPtr = &boundingBox;
-    }
+    const MBoundingBox boundingBox = shape->boundingBox();
 
     MDrawRequest request = drawInfo.getPrototype(*this);
 
-    _shapeAdapter.GetMayaUserData(this, request, boundingBoxPtr);
+    _shapeAdapter.GetMayaUserData(this, request, &boundingBox);
 
     // Add the request to the queue.
     requests.add(request);

--- a/lib/mayaUsd/render/pxrUsdMayaGL/proxyShapeUI.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/proxyShapeUI.cpp
@@ -42,6 +42,7 @@
 #include <pxr/usd/usd/timeCode.h>
 
 #include <mayaUsd/nodes/proxyShapeBase.h>
+#include <mayaUsd/render/px_vp20/utils_legacy.h>
 #include <mayaUsd/render/pxrUsdMayaGL/batchRenderer.h>
 #include <mayaUsd/render/pxrUsdMayaGL/renderParams.h>
 #include <mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.h>
@@ -106,17 +107,18 @@ UsdMayaProxyShapeUI::draw(const MDrawRequest& request, M3dView& view) const
         MProfiler::kColorC_L1,
         "USD Proxy Shape draw() (Legacy Viewport)");
 
+    const M3dView::DisplayStyle legacyDisplayStyle = view.displayStyle();
+    if (!px_LegacyViewportUtils::ShouldRenderBoundingBox(legacyDisplayStyle)) {
+        return;
+    }
+
     if (!view.pluginObjectDisplay(MayaUsdProxyShapeBase::displayFilterName)) {
         return;
     }
 
-    // Note that this Draw() call is only necessary when we're drawing the
-    // bounding box, since that is not yet handled by Hydra and is instead done
-    // internally by the batch renderer on a per-shape basis. Otherwise, the
-    // pxrHdImagingShape is what will invoke Hydra to draw the shape.
     view.beginGL();
 
-    UsdMayaGLBatchRenderer::GetInstance().Draw(request, view);
+    UsdMayaGLBatchRenderer::GetInstance().DrawBoundingBox(request, view);
 
     view.endGL();
 }

--- a/lib/mayaUsd/render/pxrUsdMayaGL/renderParams.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/renderParams.h
@@ -35,12 +35,14 @@ struct PxrMayaHdRenderParams
 
     // Color Params
     //
+    bool useWireframe = false;
     GfVec4f wireframeColor = GfVec4f(0.0f);
 
     /// Helper function to find a batch key for the render params
     size_t Hash() const
     {
         size_t hash = size_t(enableLighting);
+        boost::hash_combine(hash, useWireframe);
         boost::hash_combine(hash, wireframeColor);
 
         return hash;

--- a/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
@@ -438,6 +438,7 @@ HdTaskSharedPtrVector
 PxrMayaHdSceneDelegate::GetRenderTasks(
         const size_t hash,
         const PxrMayaHdRenderParams& renderParams,
+        unsigned int /* displayStyle */,
         const PxrMayaHdPrimFilterVector& primFilters)
 {
     HdTaskSharedPtrVector taskList;

--- a/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
@@ -441,7 +441,7 @@ PxrMayaHdSceneDelegate::GetRenderTasks(
         const PxrMayaHdPrimFilterVector& primFilters)
 {
     HdTaskSharedPtrVector taskList;
-    HdRenderIndex &renderIndex = GetRenderIndex();
+    HdRenderIndex& renderIndex = GetRenderIndex();
 
     // Task List Consist of:
     //  Render Setup Task
@@ -502,7 +502,7 @@ PxrMayaHdSceneDelegate::GetRenderTasks(
                                        key.hash,
                                        key.collectionName.GetText())));
 
-            GetRenderIndex().InsertTask<HdxRenderTask>(this, renderTaskId);
+            renderIndex.InsertTask<HdxRenderTask>(this, renderTaskId);
 
             // Note that the render task has no params of its own. All of the
             // render params are on the render setup task instead.
@@ -519,8 +519,8 @@ PxrMayaHdSceneDelegate::GetRenderTasks(
 
             if (currentRenderTags != primFilter.renderTags) {
                 _SetValue(renderTaskId, HdTokens->renderTags, primFilter.renderTags);
-                GetRenderIndex().GetChangeTracker().MarkTaskDirty(
-                        renderTaskId,
+                renderIndex.GetChangeTracker().MarkTaskDirty(
+                    renderTaskId,
                     HdChangeTracker::DirtyRenderTags);
             }
         }
@@ -530,7 +530,7 @@ PxrMayaHdSceneDelegate::GetRenderTasks(
         // Update the collections on the render task and mark them dirty.
         // XXX: Should only mark collection dirty if collection has changed
         _SetValue(renderTaskId, HdTokens->collection, primFilter.collection);
-        GetRenderIndex().GetChangeTracker().MarkTaskDirty(
+        renderIndex.GetChangeTracker().MarkTaskDirty(
             renderTaskId,
             HdChangeTracker::DirtyCollection);
     }
@@ -543,7 +543,7 @@ PxrMayaHdSceneDelegate::GetRenderTasks(
                                    _tokens->selectionTask.GetText(),
                                    hash)));
 
-        GetRenderIndex().InsertTask<HdxSelectionTask>(this, selectionTaskId);
+        renderIndex.InsertTask<HdxSelectionTask>(this, selectionTaskId);
         HdxSelectionTaskParams selectionTaskParams;
         selectionTaskParams.enableSelection = true;
 
@@ -612,7 +612,7 @@ PxrMayaHdSceneDelegate::GetRenderTasks(
         // Store the updated render setup task params back in the cache and
         // mark them dirty.
         _SetValue(renderSetupTaskId, HdTokens->params, renderSetupTaskParams);
-        GetRenderIndex().GetChangeTracker().MarkTaskDirty(
+        renderIndex.GetChangeTracker().MarkTaskDirty(
             renderSetupTaskId,
             HdChangeTracker::DirtyParams);
     }

--- a/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
@@ -579,19 +579,9 @@ PxrMayaHdSceneDelegate::GetRenderTasks(
     // With Hydra, changing the contents of a collection can be
     // an expensive operation as it causes draw batches to be rebuilt.
     //
-    // The Maya-Hydra Plugin is currently reusing the same collection
-    // name for all collections within a frame.
-    // (This stems from a time when collection name had a significant meaning
-    // rather than id'ing a collection).
-    //
     // The plugin should also track deltas to the contents of a collection
     // and set Hydra's dirty state when prims get added and removed from
     // the collection.
-    //
-    // Another possible change that can be made to this code is HdxRenderTask
-    // now takes an array of collections, so it is possible to support different
-    // reprs using the same task.  Therefore, this code should be modified to
-    // only add one task that is provided with the active set of collections.
     //
     // However, a further improvement to the code could be made using
     // UsdDelegate's fallback repr feature instead of using multiple

--- a/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
@@ -62,7 +62,6 @@ TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
     (selectionTask)
-    (renderTags)
 );
 
 
@@ -163,7 +162,7 @@ PxrMayaHdSceneDelegate::PxrMayaHdSceneDelegate(
         taskParams.camera = _cameraId;
         taskParams.viewport = _viewport;
         cache[HdTokens->params] = VtValue(taskParams);
-        cache[_tokens->renderTags] = VtValue(defaultShadowRenderTags);
+        cache[HdTokens->renderTags] = VtValue(defaultShadowRenderTags);
     }
 
     // Picking task.
@@ -178,7 +177,7 @@ PxrMayaHdSceneDelegate::PxrMayaHdSceneDelegate(
         // on first use, but this ensures we don't need
         // to special case first time vs others for comparing
         // to current render tags
-        cache[_tokens->renderTags] = VtValue(TfTokenVector());
+        cache[HdTokens->renderTags] = VtValue(TfTokenVector());
     }
 }
 
@@ -211,7 +210,7 @@ PxrMayaHdSceneDelegate::GetCameraParamValue(
 TfTokenVector
 PxrMayaHdSceneDelegate::GetTaskRenderTags(SdfPath const& taskId)
 {
-    VtValue value = Get(taskId, _tokens->renderTags);
+    VtValue value = Get(taskId, HdTokens->renderTags);
 
     return value.Get<TfTokenVector>();
 }
@@ -441,10 +440,10 @@ PxrMayaHdSceneDelegate::GetPickingTasks(
 {
     // Update tasks render tags to match those specified in the parameter.
     const TfTokenVector &currentRenderTags =
-        _GetValue<TfTokenVector>(_pickingTaskId, _tokens->renderTags);
+        _GetValue<TfTokenVector>(_pickingTaskId, HdTokens->renderTags);
 
     if (currentRenderTags != renderTags) {
-        _SetValue(_pickingTaskId, _tokens->renderTags, renderTags);
+        _SetValue(_pickingTaskId, HdTokens->renderTags, renderTags);
         GetRenderIndex().GetChangeTracker().MarkTaskDirty(
             _pickingTaskId,
             HdChangeTracker::DirtyRenderTags);
@@ -532,16 +531,16 @@ PxrMayaHdSceneDelegate::GetRenderTasks(
             _ValueCache& cache = _valueCacheMap[renderTaskId];
             cache[HdTokens->params] = VtValue();
             cache[HdTokens->collection] = VtValue(primFilter.collection);
-            cache[_tokens->renderTags] = VtValue(primFilter.renderTags);
+            cache[HdTokens->renderTags] = VtValue(primFilter.renderTags);
 
             _renderTaskIdMap[key] = renderTaskId;
         } else {
             // Update task's render tags
             const TfTokenVector &currentRenderTags =
-                _GetValue<TfTokenVector>(renderTaskId, _tokens->renderTags);
+                _GetValue<TfTokenVector>(renderTaskId, HdTokens->renderTags);
 
             if (currentRenderTags != primFilter.renderTags) {
-                _SetValue(renderTaskId, _tokens->renderTags, primFilter.renderTags);
+                _SetValue(renderTaskId, HdTokens->renderTags, primFilter.renderTags);
                 GetRenderIndex().GetChangeTracker().MarkTaskDirty(
                         renderTaskId,
                     HdChangeTracker::DirtyRenderTags);

--- a/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
@@ -35,6 +35,7 @@
 #include <pxr/imaging/glf/simpleLight.h>
 #include <pxr/imaging/glf/simpleLightingContext.h>
 #include <pxr/imaging/hd/camera.h>
+#include <pxr/imaging/hd/changeTracker.h>
 #include <pxr/imaging/hd/renderIndex.h>
 #include <pxr/imaging/hd/repr.h>
 #include <pxr/imaging/hd/rprimCollection.h>

--- a/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
@@ -435,28 +435,6 @@ PxrMayaHdSceneDelegate::GetSetupTasks()
 }
 
 HdTaskSharedPtrVector
-PxrMayaHdSceneDelegate::GetPickingTasks(
-        const TfTokenVector& renderTags)
-{
-    // Update tasks render tags to match those specified in the parameter.
-    const TfTokenVector &currentRenderTags =
-        _GetValue<TfTokenVector>(_pickingTaskId, HdTokens->renderTags);
-
-    if (currentRenderTags != renderTags) {
-        _SetValue(_pickingTaskId, HdTokens->renderTags, renderTags);
-        GetRenderIndex().GetChangeTracker().MarkTaskDirty(
-            _pickingTaskId,
-            HdChangeTracker::DirtyRenderTags);
-    }
-
-    HdTaskSharedPtrVector tasks;
-
-    tasks.push_back(GetRenderIndex().GetTask(_pickingTaskId));
-
-    return tasks;
-}
-
-HdTaskSharedPtrVector
 PxrMayaHdSceneDelegate::GetRenderTasks(
         const size_t hash,
         const PxrMayaHdRenderParams& renderParams,
@@ -640,6 +618,28 @@ PxrMayaHdSceneDelegate::GetRenderTasks(
     }
 
     return taskList;
+}
+
+HdTaskSharedPtrVector
+PxrMayaHdSceneDelegate::GetPickingTasks(
+        const TfTokenVector& renderTags)
+{
+    // Update tasks render tags to match those specified in the parameter.
+    const TfTokenVector &currentRenderTags =
+        _GetValue<TfTokenVector>(_pickingTaskId, HdTokens->renderTags);
+
+    if (currentRenderTags != renderTags) {
+        _SetValue(_pickingTaskId, HdTokens->renderTags, renderTags);
+        GetRenderIndex().GetChangeTracker().MarkTaskDirty(
+            _pickingTaskId,
+            HdChangeTracker::DirtyRenderTags);
+    }
+
+    HdTaskSharedPtrVector tasks;
+
+    tasks.push_back(GetRenderIndex().GetTask(_pickingTaskId));
+
+    return tasks;
 }
 
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
@@ -509,6 +509,10 @@ PxrMayaHdSceneDelegate::GetRenderTasks(
                 primFilter.shapeAdapter->GetReprSelectorForDisplayStyle(
                     displayStyle);
 
+            if (!repr.AnyActiveRepr()) {
+                continue;
+            }
+
             renderTaskId = primFilter.shapeAdapter->GetRenderTaskId(repr);
             rprimCollection = primFilter.shapeAdapter->GetRprimCollection(repr);
             renderTags = primFilter.shapeAdapter->GetRenderTags();

--- a/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.h
@@ -94,6 +94,7 @@ class PxrMayaHdSceneDelegate : public HdSceneDelegate
         HdTaskSharedPtrVector GetRenderTasks(
                 const size_t hash,
                 const PxrMayaHdRenderParams& renderParams,
+                unsigned int displayStyle,
                 const PxrMayaHdPrimFilterVector& primFilters);
 
         MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.h
@@ -134,32 +134,18 @@ class PxrMayaHdSceneDelegate : public HdSceneDelegate
 
         SdfPath _shadowTaskId;
 
-        // XXX: While this is correct, that we are using
-        // hash in forming the task id, so the map is valid.
-        // It is possible for the hash to collide, so the id
-        // formed from the combination of hash and collection name is not
-        // necessarily unique.
-        struct _RenderTaskIdMapKey
-        {
-            size_t                hash;
-            TfToken               collectionName;
+        // Currently, there is a one-to-one mapping between rprim collections
+        // managed by shape adapters and Hydra render tasks. The shape adapters
+        // ensure that their collections have a unique name, so we index into
+        // the map of Hydra render tasks using that name to find the render
+        // task for that collection.
+        using _RenderTaskIdMap =
+            std::unordered_map<TfToken, SdfPath, TfToken::HashFunctor>;
 
-            struct HashFunctor {
-                size_t operator()(const  _RenderTaskIdMapKey& value) const;
-            };
+        // For render setup tasks, there is one task per unique set of render
+        // params, which are hashed to generate a key.
+        using _RenderParamTaskIdMap = std::unordered_map<size_t, SdfPath>;
 
-            bool operator==(const  _RenderTaskIdMapKey& other) const;
-        };
-
-        typedef std::unordered_map<
-                _RenderTaskIdMapKey,
-                SdfPath,
-                _RenderTaskIdMapKey::HashFunctor> _RenderTaskIdMap;
-
-        typedef std::unordered_map<size_t, SdfPath> _RenderParamTaskIdMap;
-
-
-       
         _RenderParamTaskIdMap _renderSetupTaskIdMap;
         _RenderTaskIdMap      _renderTaskIdMap;
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.h
@@ -162,9 +162,9 @@ class PxrMayaHdSceneDelegate : public HdSceneDelegate
        
         _RenderParamTaskIdMap _renderSetupTaskIdMap;
         _RenderTaskIdMap      _renderTaskIdMap;
-        _RenderParamTaskIdMap _selectionTaskIdMap;
 
 		SdfPath _pickingTaskId;
+        SdfPath _selectionTaskId;
 
         typedef TfHashMap<TfToken, VtValue, TfToken::HashFunctor> _ValueCache;
         typedef TfHashMap<SdfPath, _ValueCache, SdfPath::Hash> _ValueCacheMap;

--- a/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.h
@@ -163,7 +163,7 @@ class PxrMayaHdSceneDelegate : public HdSceneDelegate
         _RenderParamTaskIdMap _renderSetupTaskIdMap;
         _RenderTaskIdMap      _renderTaskIdMap;
 
-		SdfPath _pickingTaskId;
+        SdfPath _pickingTaskId;
         SdfPath _selectionTaskId;
 
         typedef TfHashMap<TfToken, VtValue, TfToken::HashFunctor> _ValueCache;

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
@@ -223,11 +223,9 @@ PxrMayaHdShapeAdapter::GetMayaUserData(
     return newData;
 }
 
-/* virtual */
 HdReprSelector
-PxrMayaHdShapeAdapter::GetReprSelectorForDisplayState(
-        const unsigned int displayStyle,
-        const MHWRender::DisplayStatus displayStatus) const
+PxrMayaHdShapeAdapter::GetReprSelectorForDisplayStyle(
+        unsigned int displayStyle) const
 {
     HdReprSelector reprSelector;
 
@@ -245,13 +243,17 @@ PxrMayaHdShapeAdapter::GetReprSelectorForDisplayState(
         return reprSelector;
     }
 
+    const MHWRender::DisplayStatus displayStatus =
+        MHWRender::MGeometryUtilities::displayStatus(_shapeDagPath);
+
     const bool isActive = _IsActiveDisplayStatus(displayStatus);
 
     const bool shadeActiveOnlyStyle =
         displayStyle & MHWRender::MFrameContext::DisplayStyle::kShadeActiveOnly;
 
     const bool wireframeStyle =
-        displayStyle & MHWRender::MFrameContext::DisplayStyle::kWireFrame;
+        (displayStyle & MHWRender::MFrameContext::DisplayStyle::kWireFrame) ||
+        _renderParams.useWireframe;
 
     const bool flatShadedStyle =
         displayStyle & MHWRender::MFrameContext::DisplayStyle::kFlatShaded;

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
@@ -209,7 +209,6 @@ PxrMayaHdShapeAdapter::GetMayaUserData(
     // of batching up the drawing of all of the shapes, so we specify in the
     // Maya user data that the shape should *not* draw by default. The
     // pxrHdImagingShape bypasses this and sets drawShape to true.
-    // We handle this similarly in GetRenderParams() below.
     newData->drawShape = false;
 
     if (boundingBox) {
@@ -294,30 +293,6 @@ PxrMayaHdShapeAdapter::GetReprSelectorForDisplayStyle(
     }
 
     return reprSelector;
-}
-
-/* virtual */
-PxrMayaHdRenderParams
-PxrMayaHdShapeAdapter::GetRenderParams(
-        bool* drawShape,
-        bool* drawBoundingBox) const
-{
-    if (drawShape) {
-        // Internally, the shape adapter keeps track of whether its shape is
-        // being drawn for managing visibility, but otherwise most Hydra-imaged
-        // shapes should not be drawing themselves. The pxrHdImagingShape will
-        // take care of batching up the drawing of all of the shapes, so for
-        // the purposes of render params, we set drawShape to false by default.
-        // The pxrHdImagingShape bypasses this and sets drawShape to true.
-        // We handle this similarly in GetMayaUserData() above.
-        *drawShape = false;
-    }
-
-    if (drawBoundingBox) {
-        *drawBoundingBox = _drawBoundingBox;
-    }
-
-    return _renderParams;
 }
 
 /* virtual */

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
@@ -43,6 +43,7 @@
 #include <pxr/usd/sdf/path.h>
 
 #include <mayaUsd/base/api.h>
+#include <mayaUsd/render/px_vp20/utils_legacy.h>
 #include <mayaUsd/render/pxrUsdMayaGL/batchRenderer.h>
 #include <mayaUsd/render/pxrUsdMayaGL/debugCodes.h>
 #include <mayaUsd/render/pxrUsdMayaGL/renderParams.h>
@@ -50,40 +51,6 @@
 #include <mayaUsd/render/pxrUsdMayaGL/userData.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
-
-// Helper function that converts M3dView::DisplayStyle (legacy viewport) into
-// MHWRender::MFrameContext::DisplayStyle (Viewport 2.0).
-//
-// In the legacy viewport, the M3dView can be in exactly one displayStyle
-// whereas Viewport 2.0's displayStyle is a bitmask of potentially multiple
-// styles. To translate from the legacy viewport to Viewport 2.0, we simply
-// bitwise-OR the single legacy viewport displayStyle into an empty mask.
-static inline
-unsigned int
-_ToMFrameContextDisplayStyle(const M3dView::DisplayStyle legacyDisplayStyle)
-{
-    unsigned int displayStyle = 0u;
-
-    switch (legacyDisplayStyle) {
-        case M3dView::kBoundingBox:
-            displayStyle |= MHWRender::MFrameContext::DisplayStyle::kBoundingBox;
-            break;
-        case M3dView::kFlatShaded:
-            displayStyle |= MHWRender::MFrameContext::DisplayStyle::kFlatShaded;
-            break;
-        case M3dView::kGouraudShaded:
-            displayStyle |= MHWRender::MFrameContext::DisplayStyle::kGouraudShaded;
-            break;
-        case M3dView::kWireFrame:
-            displayStyle |= MHWRender::MFrameContext::DisplayStyle::kWireFrame;
-            break;
-        case M3dView::kPoints:
-            // Not supported.
-            break;
-    }
-
-    return displayStyle;
-}
 
 // Helper function that converts M3dView::DisplayStatus (legacy viewport) into
 // MHWRender::DisplayStatus (Viewport 2.0).
@@ -122,7 +89,8 @@ PxrMayaHdShapeAdapter::Sync(
     UsdMayaGLBatchRenderer::GetInstance().StartBatchingFrameDiagnostics();
 
     const unsigned int displayStyle =
-        _ToMFrameContextDisplayStyle(legacyDisplayStyle);
+        px_LegacyViewportUtils::GetMFrameContextDisplayStyle(
+            legacyDisplayStyle);
     const MHWRender::DisplayStatus displayStatus =
         _ToMHWRenderDisplayStatus(legacyDisplayStatus);
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
@@ -77,6 +77,18 @@ _ToMHWRenderDisplayStatus(const M3dView::DisplayStatus legacyDisplayStatus)
     return MHWRender::DisplayStatus((int)legacyDisplayStatus);
 }
 
+static inline
+bool
+_IsActiveDisplayStatus(MHWRender::DisplayStatus displayStatus)
+{
+    return
+        (displayStatus == MHWRender::DisplayStatus::kActive) ||
+        (displayStatus == MHWRender::DisplayStatus::kHilite) ||
+        (displayStatus == MHWRender::DisplayStatus::kActiveTemplate) ||
+        (displayStatus == MHWRender::DisplayStatus::kActiveComponent) ||
+        (displayStatus == MHWRender::DisplayStatus::kLead);
+}
+
 /* virtual */
 bool
 PxrMayaHdShapeAdapter::Sync(
@@ -233,15 +245,10 @@ PxrMayaHdShapeAdapter::GetReprSelectorForDisplayState(
         return reprSelector;
     }
 
+    const bool isActive = _IsActiveDisplayStatus(displayStatus);
+
     const bool shadeActiveOnlyStyle =
         displayStyle & MHWRender::MFrameContext::DisplayStyle::kShadeActiveOnly;
-
-    const bool isActive =
-        (displayStatus == MHWRender::DisplayStatus::kActive) ||
-        (displayStatus == MHWRender::DisplayStatus::kHilite) ||
-        (displayStatus == MHWRender::DisplayStatus::kActiveTemplate) ||
-        (displayStatus == MHWRender::DisplayStatus::kActiveComponent) ||
-        (displayStatus == MHWRender::DisplayStatus::kLead);
 
     const bool wireframeStyle =
         displayStyle & MHWRender::MFrameContext::DisplayStyle::kWireFrame;
@@ -403,12 +410,7 @@ PxrMayaHdShapeAdapter::_GetWireframeColor(
 
     const bool wireframeStyle = (displayStyle & wireframeDisplayStyles);
 
-    const bool isActive =
-        (displayStatus == MHWRender::DisplayStatus::kActive) ||
-        (displayStatus == MHWRender::DisplayStatus::kHilite) ||
-        (displayStatus == MHWRender::DisplayStatus::kActiveTemplate) ||
-        (displayStatus == MHWRender::DisplayStatus::kActiveComponent) ||
-        (displayStatus == MHWRender::DisplayStatus::kLead);
+    const bool isActive = _IsActiveDisplayStatus(displayStatus);
 
     if (wireframeStyle || isActive) {
         useWireframeColor = true;

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
@@ -203,14 +203,6 @@ PxrMayaHdShapeAdapter::GetMayaUserData(
         newData = new PxrMayaHdUserData();
     }
 
-    // Internally, the shape adapter keeps track of whether its shape is being
-    // drawn for managing visibility, but otherwise most Hydra-imaged shapes
-    // should not be drawing themselves. The pxrHdImagingShape will take care
-    // of batching up the drawing of all of the shapes, so we specify in the
-    // Maya user data that the shape should *not* draw by default. The
-    // pxrHdImagingShape bypasses this and sets drawShape to true.
-    newData->drawShape = false;
-
     if (boundingBox) {
         newData->boundingBox.reset(new MBoundingBox(*boundingBox));
         newData->wireframeColor.reset(new GfVec4f(_renderParams.wireframeColor));

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
@@ -288,46 +288,10 @@ PxrMayaHdShapeAdapter::GetReprSelectorForDisplayStyle(
 }
 
 /* virtual */
-const HdRprimCollection&
-PxrMayaHdShapeAdapter::GetRprimCollection() const
-{
-    return _rprimCollection;
-}
-
-/* virtual */
-const TfTokenVector&
-PxrMayaHdShapeAdapter::GetRenderTags() const
-{
-    return _renderTags;
-}
-
-
-/* virtual */
-const GfMatrix4d&
-PxrMayaHdShapeAdapter::GetRootXform() const
-{
-    return _rootXform;
-}
-
-/* virtual */
-void
-PxrMayaHdShapeAdapter::SetRootXform(const GfMatrix4d& transform)
-{
-    _rootXform = transform;
-}
-
-/* virtual */
 const SdfPath&
 PxrMayaHdShapeAdapter::GetDelegateID() const
 {
     return SdfPath::EmptyPath();
-}
-
-/* virtual */
-const MDagPath&
-PxrMayaHdShapeAdapter::GetDagPath() const
-{
-    return _shapeDagPath;
 }
 
 /* virtual */

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
@@ -182,16 +182,9 @@ PxrMayaHdShapeAdapter::GetMayaUserData(
     // Viewport 2.0 implementation (also called by legacy viewport
     // implementation).
     //
-    // Our PxrMayaHdUserData can be used to signify whether we are requesting a
-    // shape to be rendered, a bounding box, both, or neither.
-    //
     // In the Viewport 2.0 prepareForDraw() usage, any MUserData object passed
     // into the function will be deleted by Maya. In the legacy viewport usage,
     // the object gets deleted at the end of a legacy viewport Draw() call.
-
-    if (!_drawShape && !boundingBox) {
-        return nullptr;
-    }
 
     PxrMayaHdUserData* newData = dynamic_cast<PxrMayaHdUserData*>(oldData);
     if (!newData) {

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
@@ -44,6 +44,7 @@
 #include <pxr/imaging/hd/repr.h>
 #include <pxr/imaging/hd/rprimCollection.h>
 #include <pxr/imaging/hd/tokens.h>
+#include <pxr/imaging/hd/types.h>
 #include <pxr/imaging/hdx/tokens.h>
 #include <pxr/usd/sdf/path.h>
 
@@ -377,6 +378,23 @@ PxrMayaHdShapeAdapter::_SetDagPath(const MDagPath& dagPath)
     }
 
     return status;
+}
+
+void
+PxrMayaHdShapeAdapter::_MarkRenderTasksDirty(HdDirtyBits dirtyBits)
+{
+    HdRenderIndex* renderIndex =
+        UsdMayaGLBatchRenderer::GetInstance().GetRenderIndex();
+
+    for (const auto& iter : _renderTaskIdMap) {
+        // The render tasks represented by the IDs in this map are instantiated
+        // lazily, so check that the task exists before attempting to dirty it.
+        if (renderIndex->HasTask(iter.second)) {
+            renderIndex->GetChangeTracker().MarkTaskDirty(
+                iter.second,
+                dirtyBits);
+        }
+    }
 }
 
 /* static */

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
@@ -89,7 +89,6 @@ _IsActiveDisplayStatus(MHWRender::DisplayStatus displayStatus)
         (displayStatus == MHWRender::DisplayStatus::kLead);
 }
 
-/* virtual */
 bool
 PxrMayaHdShapeAdapter::Sync(
         const MDagPath& shapeDagPath,
@@ -132,7 +131,6 @@ PxrMayaHdShapeAdapter::Sync(
     return success;
 }
 
-/* virtual */
 bool
 PxrMayaHdShapeAdapter::Sync(
         const MDagPath& shapeDagPath,

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
@@ -164,14 +164,10 @@ class PxrMayaHdShapeAdapter
         HdReprSelector GetReprSelectorForDisplayStyle(
                 unsigned int displayStyle) const;
 
-        /// Get a set of render params from the shape adapter's current state.
-        ///
-        /// Sets \p drawShape and \p drawBoundingBox depending on whether shape
-        /// and/or bounding box rendering is indicated from the state.
-        MAYAUSD_CORE_PUBLIC
-        virtual PxrMayaHdRenderParams GetRenderParams(
-                bool* drawShape,
-                bool* drawBoundingBox) const;
+        /// Get the render params for the shape adapter's current state.
+        const PxrMayaHdRenderParams& GetRenderParams() const {
+            return _renderParams;
+        }
 
         MAYAUSD_CORE_PUBLIC
         virtual const HdRprimCollection& GetRprimCollection() const;

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
@@ -297,7 +297,6 @@ class PxrMayaHdShapeAdapter
         MAYAUSD_CORE_PUBLIC
         virtual ~PxrMayaHdShapeAdapter();
 
-        MDagPath _shapeDagPath;
         TfToken _shapeIdentifier;
         SdfPath _delegateId;
 
@@ -310,6 +309,10 @@ class PxrMayaHdShapeAdapter
         GfMatrix4d _rootXform;
 
         const bool _isViewport2;
+
+    private:
+
+        MDagPath _shapeDagPath;
 };
 
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
@@ -25,8 +25,10 @@
 #include <pxr/base/gf/matrix4d.h>
 #include <pxr/base/gf/vec4f.h>
 #include <pxr/base/tf/token.h>
+#include <pxr/imaging/hd/changeTracker.h>
 #include <pxr/imaging/hd/repr.h>
 #include <pxr/imaging/hd/rprimCollection.h>
+#include <pxr/imaging/hd/types.h>
 #include <pxr/usd/sdf/path.h>
 
 // XXX: With Maya versions up through 2019 on Linux, M3dView.h ends up
@@ -278,6 +280,16 @@ class PxrMayaHdShapeAdapter
         /// error, which can be detected from the returned MStatus.
         MAYAUSD_CORE_PUBLIC
         MStatus _SetDagPath(const MDagPath& dagPath);
+
+        /// Mark the render tasks for this shape dirty.
+        ///
+        /// The batch renderer currently creates a render task for each shape's
+        /// HdRprimCollection, but it has no knowledge of when the collection
+        /// is changed, for example. This method should be called to notify the
+        /// batch renderer when such a change is made.
+        MAYAUSD_CORE_PUBLIC
+        void _MarkRenderTasksDirty(
+                HdDirtyBits dirtyBits = HdChangeTracker::AllDirty);
 
         /// Helper for getting the wireframe color of the shape.
         ///

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
@@ -66,7 +66,7 @@ class PxrMayaHdShapeAdapter
         /// Update the shape adapter's state from the shape with the given
         /// \p shapeDagPath and the legacy viewport display state.
         MAYAUSD_CORE_PUBLIC
-        virtual bool Sync(
+        bool Sync(
                 const MDagPath& shapeDagPath,
                 const M3dView::DisplayStyle legacyDisplayStyle,
                 const M3dView::DisplayStatus legacyDisplayStatus);
@@ -74,7 +74,7 @@ class PxrMayaHdShapeAdapter
         /// Update the shape adapter's state from the shape with the given
         /// \p shapeDagPath and the Viewport 2.0 display state.
         MAYAUSD_CORE_PUBLIC
-        virtual bool Sync(
+        bool Sync(
                 const MDagPath& shapeDagPath,
                 const unsigned int displayStyle,
                 const MHWRender::DisplayStatus displayStatus);

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
@@ -195,8 +195,9 @@ class PxrMayaHdShapeAdapter
             _rootXform = transform;
         }
 
-        MAYAUSD_CORE_PUBLIC
-        virtual const SdfPath& GetDelegateID() const;
+        const SdfPath& GetDelegateID() const {
+            return _delegateId;
+        }
 
         const MDagPath& GetDagPath() const {
             return _shapeDagPath;
@@ -230,19 +231,21 @@ class PxrMayaHdShapeAdapter
                 const unsigned int displayStyle,
                 const MHWRender::DisplayStatus displayStatus) = 0;
 
-        /// Helper for computing the name of the shape's HdRprimCollection.
+        /// Sets the shape adapter's DAG path.
         ///
-        /// The batch renderer currently creates a render task for each shape's
+        /// This re-computes the "identifier" for the shape, which is used to
+        /// compute the name of the shape's HdRprimCollection. The batch
+        /// renderer currently creates a render task for each shape's
         /// HdRprimCollection, and those render tasks are identified by an
         /// SdfPath constructed using the collection's name. We therefore need
         /// the collection to have a name that is unique to the shape it
         /// represents and also sanitized for use in SdfPaths.
         ///
-        /// Returns a TfToken collection name that is unique to the shape and
-        /// is a valid SdfPath identifier, or an empty TfToken is there is an
-        /// error.
+        /// The identifier will be a TfToken that is unique to the shape and is
+        /// a valid SdfPath identifier, or an empty TfToken if there is an
+        /// error, which can be detected from the returned MStatus.
         MAYAUSD_CORE_PUBLIC
-        virtual TfToken _GetRprimCollectionName() const;
+        MStatus _SetDagPath(const MDagPath& dagPath);
 
         /// Helper for getting the wireframe color of the shape.
         ///
@@ -295,6 +298,8 @@ class PxrMayaHdShapeAdapter
         virtual ~PxrMayaHdShapeAdapter();
 
         MDagPath _shapeDagPath;
+        TfToken _shapeIdentifier;
+        SdfPath _delegateId;
 
         PxrMayaHdRenderParams _renderParams;
         bool _drawShape;

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
@@ -143,7 +143,7 @@ class PxrMayaHdShapeAdapter
                 const MBoundingBox* boundingBox = nullptr);
 
         /// Gets the HdReprSelector that corresponds to the given Maya display
-        /// state.
+        /// style.
         ///
         /// \p displayStyle should be a bitwise combination of
         /// MHWRender::MFrameContext::DisplayStyle values, typically either
@@ -152,18 +152,17 @@ class PxrMayaHdShapeAdapter
         /// obtained using MHWRender::MFrameContext::getDisplayStyle() for
         /// Viewport 2.0.
         ///
-        /// \p displayStatus is typically either up-converted from
-        /// a M3dView::DisplayStatus value obtained using
-        /// MDrawInfo::displayStatus() for the legacy viewport, or obtained
-        /// using MHWRender::MGeometryUtilities::displayStatus() for Viewport
-        /// 2.0.
+        /// The HdReprSelector chosen is also dependent on the display status
+        /// (active/selected vs. inactive) which Maya is queried for, as well
+        /// as whether or not the render params specify that we are using the
+        /// shape's wireframe, which is influenced by both the display status
+        /// and whether or not the shape is involved in a soft selection.
         ///
         /// If there is no corresponding HdReprSelector for the given display
-        /// state, an empty HdReprSelector is returned.
+        /// style, an empty HdReprSelector is returned.
         MAYAUSD_CORE_PUBLIC
-        virtual HdReprSelector GetReprSelectorForDisplayState(
-                const unsigned int displayStyle,
-                const MHWRender::DisplayStatus displayStatus) const;
+        HdReprSelector GetReprSelectorForDisplayStyle(
+                unsigned int displayStyle) const;
 
         /// Get a set of render params from the shape adapter's current state.
         ///

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
@@ -282,7 +282,6 @@ class PxrMayaHdShapeAdapter
 
         PxrMayaHdRenderParams _renderParams;
         bool _drawShape;
-        bool _drawBoundingBox;
 
         HdRprimCollection _rprimCollection;
         TfTokenVector     _renderTags;

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
@@ -22,6 +22,7 @@
 
 #include <pxr/pxr.h>
 #include <pxr/base/gf/matrix4d.h>
+#include <pxr/base/gf/vec4f.h>
 #include <pxr/base/tf/token.h>
 #include <pxr/imaging/hd/repr.h>
 #include <pxr/imaging/hd/rprimCollection.h>
@@ -43,7 +44,6 @@
 #include <maya/M3dView.h>
 #undef Always // Defined in /usr/lib/X11/X.h (eventually included by M3dView.h) - breaks pxr/usd/lib/usdUtils/registeredVariantSet.h
 #include <maya/MBoundingBox.h>
-#include <maya/MColor.h>
 #include <maya/MDagPath.h>
 #include <maya/MDrawRequest.h>
 #include <maya/MHWGeometryUtilities.h>
@@ -244,18 +244,26 @@ class PxrMayaHdShapeAdapter
         /// access the soft selection info.
         ///
         /// Returns true if the wireframe color should be used, that is if the
-        /// object and/or its component(s) are involved in a selection, or if
-        /// the displayStyle indicates that a wireframe style is being drawn
-        /// (either kWireFrame or kBoundingBox). Otherwise returns false.
+        /// object and/or its component(s) are involved in a selection.
+        /// Otherwise returns false.
         ///
-        /// The wireframe color will always be returned in \p mayaWireColor (if
-        /// it is not nullptr) in case the caller wants to use other criteria
-        /// for determining whether to use it.
+        /// Note that we do not factor in the viewport's displayStyle, which
+        /// may indicate that a wireframe style is being drawn (either
+        /// kWireFrame or kBoundingBox). The displayStyle can be changed
+        /// without triggering a re-Sync(), so we want to make sure that shape
+        /// adapters don't inadvertently "bake in" whether to use the wireframe
+        /// into their render params based on it. We only want to know whether
+        /// we need to use the wireframe for a reason *other* than the
+        /// displayStyle.
+        ///
+        /// The wireframe color will always be returned in \p wireframeColor
+        /// (if it is not nullptr) in case the caller wants to use other
+        /// criteria for determining whether to use it (e.g. for bounding
+        /// boxes).
         static bool _GetWireframeColor(
-                const unsigned int displayStyle,
-                const MHWRender::DisplayStatus displayStatus,
+                MHWRender::DisplayStatus displayStatus,
                 const MDagPath& shapeDagPath,
-                MColor* mayaWireColor);
+                GfVec4f* wireframeColor);
 
         /// Helper for computing the viewport visibility of the shape.
         ///

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
@@ -333,7 +333,6 @@ class PxrMayaHdShapeAdapter
         SdfPath _delegateId;
 
         PxrMayaHdRenderParams _renderParams;
-        bool _drawShape;
 
         struct _ReprHashFunctor {
             size_t operator()(const HdReprSelector& repr) const {

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
@@ -169,30 +169,38 @@ class PxrMayaHdShapeAdapter
             return _renderParams;
         }
 
-        MAYAUSD_CORE_PUBLIC
-        virtual const HdRprimCollection& GetRprimCollection() const;
+        const HdRprimCollection& GetRprimCollection() const {
+            return _rprimCollection;
+        }
 
-        /// Retrieves the render tags for this shape.  I.e. which
-        /// prim purposes should be drawn (such as geomerty, proxy, guides
-        /// and/or render).
-        /// This function just returns the _renderTags attribute and it
-        /// is expected each subclass update the attribute in _Sync() or
-        /// overrides this function if it needs special processing.
-        MAYAUSD_CORE_PUBLIC
-        virtual const TfTokenVector& GetRenderTags() const;
+        /// Retrieves the render tags for this shape (i.e. which prim purposes
+        /// should be drawn, such as geometry, proxy, guide and/or render).
+        ///
+        /// This function just returns the _renderTags attribute and it is
+        /// expected that subclasses update the attribute in _Sync().
+        const TfTokenVector& GetRenderTags() const {
+            return _renderTags;
+        }
 
+        const GfMatrix4d& GetRootXform() const {
+            return _rootXform;
+        }
 
-        MAYAUSD_CORE_PUBLIC
-        virtual const GfMatrix4d& GetRootXform() const;
-
-        MAYAUSD_CORE_PUBLIC
-        virtual void SetRootXform(const GfMatrix4d& transform);
+        /// Sets the root transform for the shape adapter.
+        ///
+        /// This function is virtual in case the shape adapter needs to update
+        /// other state in response to a change in the root transform (e.g.
+        /// updating an HdSceneDelegate).
+        virtual void SetRootXform(const GfMatrix4d& transform) {
+            _rootXform = transform;
+        }
 
         MAYAUSD_CORE_PUBLIC
         virtual const SdfPath& GetDelegateID() const;
 
-        MAYAUSD_CORE_PUBLIC
-        virtual const MDagPath& GetDagPath() const;
+        const MDagPath& GetDagPath() const {
+            return _shapeDagPath;
+        }
 
         /// Get whether this shape adapter is for use with Viewport 2.0.
         ///

--- a/lib/mayaUsd/render/pxrUsdMayaGL/softSelectHelper.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/softSelectHelper.cpp
@@ -53,7 +53,7 @@ UsdMayaGLSoftSelectHelper::Populate()
     _populated = true;
 }
 
-void 
+void
 UsdMayaGLSoftSelectHelper::_PopulateWeights()
 {
     // we don't want to fallback to the active selection if there is no sot

--- a/lib/mayaUsd/render/pxrUsdMayaGL/softSelectHelper.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/softSelectHelper.h
@@ -44,7 +44,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// While this class doesn't have anything particular to rendering, it is only
 /// used by the render and is therefore here.  We can move this to usdMaya if
 /// we'd like to use it outside of the rendering.
-class UsdMayaGLSoftSelectHelper 
+class UsdMayaGLSoftSelectHelper
 {
 public:
     MAYAUSD_CORE_PUBLIC
@@ -59,7 +59,7 @@ public:
     void Populate();
 
     /// \brief Returns true if \p dagPath is in the softSelection.  Also returns
-    /// the \p weight.  
+    /// the \p weight.
     ///
     /// NOTE: until MAYA-73448 (and MAYA-73513) is fixed, the \p weight value is
     /// arbitrary.

--- a/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
@@ -37,7 +37,6 @@
 #include <pxr/imaging/hd/enums.h>
 #include <pxr/imaging/hd/renderIndex.h>
 #include <pxr/imaging/hd/repr.h>
-#include <pxr/imaging/hd/rprimCollection.h>
 #include <pxr/imaging/hd/tokens.h>
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/prim.h>
@@ -231,19 +230,6 @@ PxrMayaHdUsdProxyShapeAdapter::_Sync(
         _delegate->SetRootVisibility(_drawShape);
     }
 
-    if (_rprimCollection.GetReprSelector() != reprSelector) {
-        _rprimCollection.SetReprSelector(reprSelector);
-
-        TF_DEBUG(PXRUSDMAYAGL_SHAPE_ADAPTER_LIFECYCLE).Msg(
-                "    Repr selector changed: %s\n"
-                "        Marking collection dirty: %s\n",
-                reprSelector.GetText(),
-                _rprimCollection.GetName().GetText());
-
-        _delegate->GetRenderIndex().GetChangeTracker().MarkCollectionDirty(
-            _rprimCollection.GetName());
-    }
-
     HdCullStyle cullStyle = HdCullStyleNothing;
     if (displayStyle & MHWRender::MFrameContext::DisplayStyle::kBackfaceCulling) {
         cullStyle = HdCullStyleBackUnlessDoubleSided;
@@ -302,14 +288,6 @@ PxrMayaHdUsdProxyShapeAdapter::_Init(HdRenderIndex* renderIndex)
     }
 
     _delegate->Populate(_rootPrim, _excludedPrimPaths, SdfPathVector());
-
-    if (collectionName != _rprimCollection.GetName()) {
-        _rprimCollection.SetName(collectionName);
-        renderIndex->GetChangeTracker().AddCollection(_rprimCollection.GetName());
-    }
-
-    _rprimCollection.SetReprSelector(HdReprSelector(HdReprTokens->refined));
-    _rprimCollection.SetRootPath(delegateId);
 
     return true;
 }

--- a/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
@@ -246,8 +246,6 @@ PxrMayaHdUsdProxyShapeAdapter::_Sync(
         GetReprSelectorForDisplayStyle(displayStyle);
 
     _drawShape = reprSelector.AnyActiveRepr();
-    _drawBoundingBox =
-        (displayStyle & MHWRender::MFrameContext::DisplayStyle::kBoundingBox);
 
     if (reprSelector.Contains(HdReprTokens->wire) ||
             reprSelector.Contains(HdReprTokens->refinedWire)) {

--- a/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
@@ -20,7 +20,6 @@
 #include <boost/functional/hash.hpp>
 
 #include <maya/M3dView.h>
-#include <maya/MColor.h>
 #include <maya/MDagPath.h>
 #include <maya/MFnDagNode.h>
 #include <maya/MFrameContext.h>
@@ -34,7 +33,6 @@
 
 #include <pxr/pxr.h>
 #include <pxr/base/gf/matrix4d.h>
-#include <pxr/base/gf/vec4f.h>
 #include <pxr/base/tf/debug.h>
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/base/tf/stringUtils.h>
@@ -219,19 +217,11 @@ PxrMayaHdUsdProxyShapeAdapter::_Sync(
     // Will only react if time actually changes.
     _delegate->SetTime(timeCode);
 
-    MColor mayaWireframeColor;
     _renderParams.useWireframe =
         _GetWireframeColor(
-            displayStyle,
             displayStatus,
             _shapeDagPath,
-            &mayaWireframeColor);
-    if (_renderParams.useWireframe) {
-        _renderParams.wireframeColor = GfVec4f(mayaWireframeColor.r,
-                                               mayaWireframeColor.g,
-                                               mayaWireframeColor.b,
-                                               mayaWireframeColor.a);
-    }
+            &_renderParams.wireframeColor);
 
     // XXX: This is not technically correct. Since the display style can vary
     // per viewport, this decision of whether or not to enable lighting should

--- a/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
@@ -69,7 +69,7 @@ PxrMayaHdUsdProxyShapeAdapter::UpdateVisibility(const M3dView* view)
         // USD proxy shapes are being filtered from this view, so don't bother
         // checking any other visibility state.
         isVisible = false;
-    } else if (!_GetVisibility(_shapeDagPath, view, &isVisible)) {
+    } else if (!_GetVisibility(GetDagPath(), view, &isVisible)) {
         return false;
     }
 
@@ -146,7 +146,7 @@ PxrMayaHdUsdProxyShapeAdapter::_Sync(
     // require us to re-initialize the shape adapter.
     HdRenderIndex* renderIndex =
         UsdMayaGLBatchRenderer::GetInstance().GetRenderIndex();
-    if (!(shapeDagPath == _shapeDagPath) ||
+    if (!(shapeDagPath == GetDagPath()) ||
             usdPrim != _rootPrim ||
             excludedPrimPaths != _excludedPrimPaths ||
             !_delegate ||
@@ -191,7 +191,7 @@ PxrMayaHdUsdProxyShapeAdapter::_Sync(
 #endif
 
     MStatus status;
-    const MMatrix transform = _shapeDagPath.inclusiveMatrix(&status);
+    const MMatrix transform = GetDagPath().inclusiveMatrix(&status);
     if (status == MS::kSuccess) {
         _rootXform = GfMatrix4d(transform.matrix);
         _delegate->SetRootTransform(_rootXform);
@@ -205,7 +205,7 @@ PxrMayaHdUsdProxyShapeAdapter::_Sync(
     _renderParams.useWireframe =
         _GetWireframeColor(
             displayStatus,
-            _shapeDagPath,
+            GetDagPath(),
             &_renderParams.wireframeColor);
 
     // XXX: This is not technically correct. Since the display style can vary
@@ -276,14 +276,14 @@ PxrMayaHdUsdProxyShapeAdapter::_Init(HdRenderIndex* renderIndex)
         "    shape identifier: %s\n"
         "    delegateId      : %s\n",
         this,
-        _shapeDagPath.fullPathName().asChar(),
+        GetDagPath().fullPathName().asChar(),
         _shapeIdentifier.GetText(),
         _delegateId.GetText());
 
     _delegate.reset(new UsdImagingDelegate(renderIndex, _delegateId));
     if (!TF_VERIFY(_delegate,
                   "Failed to create shape adapter delegate for shape %s",
-                  _shapeDagPath.fullPathName().asChar())) {
+                  GetDagPath().fullPathName().asChar())) {
         return false;
     }
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
@@ -218,16 +218,9 @@ PxrMayaHdUsdProxyShapeAdapter::_Sync(
     // determine the repr, so be sure to do this *after* that has been set.
     const HdReprSelector reprSelector =
         GetReprSelectorForDisplayStyle(displayStyle);
-
-    _drawShape = reprSelector.AnyActiveRepr();
-
     if (reprSelector.Contains(HdReprTokens->wire) ||
             reprSelector.Contains(HdReprTokens->refinedWire)) {
         _renderParams.enableLighting = false;
-    }
-
-    if (_delegate->GetRootVisibility() != _drawShape) {
-        _delegate->SetRootVisibility(_drawShape);
     }
 
     HdCullStyle cullStyle = HdCullStyleNothing;

--- a/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
@@ -222,13 +222,13 @@ PxrMayaHdUsdProxyShapeAdapter::_Sync(
     unsigned int reprDisplayStyle = displayStyle;
 
     MColor mayaWireframeColor;
-    const bool useWireframeColor =
+    _renderParams.useWireframe =
         _GetWireframeColor(
             displayStyle,
             displayStatus,
             _shapeDagPath,
             &mayaWireframeColor);
-    if (useWireframeColor) {
+    if (_renderParams.useWireframe) {
         _renderParams.wireframeColor = GfVec4f(mayaWireframeColor.r,
                                                mayaWireframeColor.g,
                                                mayaWireframeColor.b,

--- a/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.cpp
@@ -112,7 +112,7 @@ PxrMayaHdUsdProxyShapeAdapter::_Sync(
         MProfiler::kColorE_L2,
         "USD Proxy Shape Syncing Shape Adapter");
 
-    MayaUsdProxyShapeBase* usdProxyShape = 
+    MayaUsdProxyShapeBase* usdProxyShape =
             MayaUsdProxyShapeBase::GetShapeAtDagPath(shapeDagPath);
     if (!usdProxyShape) {
         TF_DEBUG(PXRUSDMAYAGL_SHAPE_ADAPTER_LIFECYCLE).Msg(

--- a/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.h
@@ -87,9 +87,6 @@ class PxrMayaHdUsdProxyShapeAdapter : public PxrMayaHdShapeAdapter
         MAYAUSD_CORE_PUBLIC
         void SetRootXform(const GfMatrix4d& transform) override;
 
-        MAYAUSD_CORE_PUBLIC
-        const SdfPath& GetDelegateID() const override;
-
     protected:
 
         /// Update the shape adapter's state from the shape with the given

--- a/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.h
@@ -118,9 +118,10 @@ class PxrMayaHdUsdProxyShapeAdapter : public PxrMayaHdShapeAdapter
         /// Initialize the shape adapter using the given \p renderIndex.
         ///
         /// This method is called automatically during Sync() when the shape
-        /// adapter's "identity" changes. This happens when the delegateId or
-        /// the rprim collection name computed from the shape adapter's shape
-        /// is different than what is currently stored in the shape adapter.
+        /// adapter's "identity" changes. This can happen when the shape
+        /// managed by this adapter is changed by setting a new DAG path, or
+        /// otherwise when there is some other fundamental change to the shape
+        /// or to the delegate or render index.
         /// The shape adapter will then query the batch renderer for its render
         /// index and use that to re-create its delegate and re-add its rprim
         /// collection, if necessary.

--- a/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.h
@@ -80,7 +80,7 @@ class PxrMayaHdUsdProxyShapeAdapter : public PxrMayaHdShapeAdapter
         /// Gets whether the shape adapter's shape is visible.
         ///
         /// This should be called after a call to UpdateVisibility() to ensure
-        /// that the returned value is correct. 
+        /// that the returned value is correct.
         MAYAUSD_CORE_PUBLIC
         bool IsVisible() const override;
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/userData.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/userData.cpp
@@ -24,12 +24,8 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// Note that we set deleteAfterUse=false when calling the MUserData
 /// constructor. This ensures that the draw data survives across multiple draw
 /// passes in Viewport 2.0 (e.g. a shadow pass and a color pass).
-///
-/// drawShape is initialized to false, since we expect that the
-/// pxrHdImagingShape will be the only one to set it to true.
 PxrMayaHdUserData::PxrMayaHdUserData() :
-    MUserData(/* deleteAfterUse = */ false),
-    drawShape(false)
+    MUserData(/* deleteAfterUse = */ false)
 {
 }
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/userData.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/userData.h
@@ -41,7 +41,6 @@ class PxrMayaHdUserData : public MUserData
 {
     public:
 
-        bool drawShape;
         std::unique_ptr<MBoundingBox> boundingBox;
         std::unique_ptr<GfVec4f> wireframeColor;
 


### PR DESCRIPTION
To buy us some time with our production artists while we tackle adopting the VP2.0 render delegate, I took one final pass at improving and optimizing the Pixar batch renderer.

The biggest benefit for them here is a fix for a long-standing issue where the displayStyle of the viewport was only being considered at `prepareForDraw()` time. This caused draw issues when changing the style of a viewport where the display wouldn't update until another `prepareForDraw()` was issued (for example by performing a selection).

There is some marginal performance improvement here as well though as a result of avoiding ever dirtying the rprim collection or the repr for a given render task. The shape adapters now manage a collection for each repr that might be used by the Maya viewport, and a render task ID for each of those collections. The batch renderer itself still instantiates the actual tasks lazily.

I tried to narrate the process as best I could in the commit history, but let me know if anything seems unclear.

And just to reiterate, I still wouldn't recommend that anyone introduce new usage of the Pixar batch renderer. We ourselves are aiming to adopt the VP2.0 render delegate over the next few months and don't intend to put any additional effort into improving the batch renderer. This pass was solely to provide some relief to production while we pursue that adoption.