### PR TITLE
do not hard-code the number of jobs to 1 when running ctest

### DIFF
--- a/build.py
+++ b/build.py
@@ -287,19 +287,15 @@ def RunCMake(context, extraArgs=None, stages=None):
 def RunCTest(context, extraArgs=None):
     buildDir = context.buildDir
     variant = BuildVariant(context)
-    #TODO we can't currently run tests in parallel, something to revisit.
-    numJobs = 1
 
     with CurrentWorkingDirectory(buildDir):
         Run(context,
             'ctest '
             '--output-on-failure ' 
             '--timeout 300 '
-            '-j {numJobs} '
             '-C {variant} '
             '{extraArgs} '
-            .format(numJobs=numJobs,
-                    variant=variant,
+            .format(variant=variant,
                     extraArgs=(" ".join(extraArgs) if extraArgs else "")))
 
 def RunMakeZipArchive(context):


### PR DESCRIPTION
I'm not sure what previously required the tests to be run serially, but I don't seem to be having any issues running them in parallel on Linux.

Was there something else we needed to follow up on here before we switched multiprocessing back on?