### PR TITLE
Fixed path string test.

### DIFF
--- a/test/lib/ufe/testDeleteCmd.py
+++ b/test/lib/ufe/testDeleteCmd.py
@@ -190,6 +190,8 @@ class DeleteCmdTestCase(unittest.TestCase):
         ball34PathString = ufe.PathString.string(ball34Path)
         self.assertEqual(
             ball34PathString,
+            "|transform1|proxyShape1,/Room_set/Props/Ball_34" if \
+            mayaUtils.previewReleaseVersion() >= 116 else \
             "|world|transform1|proxyShape1,/Room_set/Props/Ball_34")
 
         # Test that "|world" prefix is optional for multi-segment paths.


### PR DESCRIPTION
Maya has been changed (for the next preview release) to customize UFE path string output (path object to string) to avoid the leading "|world" prefix.  For single-segment Maya objects, having this prefix in the path is legal syntax, but does not match any objects when passed to Maya commands, and this was causing bugs when invoking Maya commands directly with UFE path string output as arguments (e.g. the parent command).  Changed the path string test to reflect this.

As before, the "|world" prefix on UFE path string input (string to path object) is optional, and can be omitted --- this is customization that Maya already does, and is unchanged.