### PR TITLE
fix up header includes using "./" and "../" and other misc. clean-up

### DIFF
--- a/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
+++ b/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
@@ -15,8 +15,8 @@
 //
 #pragma once
 
-#include "../base/api.h"
-#include "UsdSceneItem.h"
+#include "mayaUsd/base/api.h"
+#include "mayaUsd/ufe/UsdSceneItem.h"
 
 #include <ufe/transform3dUndoableCommands.h>
 #include <ufe/observer.h>

--- a/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
+++ b/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
@@ -15,8 +15,8 @@
 //
 #pragma once
 
-#include "mayaUsd/base/api.h"
-#include "mayaUsd/ufe/UsdSceneItem.h"
+#include <mayaUsd/base/api.h>
+#include <mayaUsd/ufe/UsdSceneItem.h>
 
 #include <ufe/transform3dUndoableCommands.h>
 #include <ufe/observer.h>

--- a/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
+++ b/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
@@ -18,10 +18,10 @@
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/ufe/UsdSceneItem.h>
 
-#include <ufe/transform3dUndoableCommands.h>
-#include <ufe/observer.h>
-
 #include <pxr/usd/usd/attribute.h>
+
+#include <ufe/observer.h>
+#include <ufe/transform3dUndoableCommands.h>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
@@ -15,8 +15,8 @@
 //
 #pragma once
 
-#include "mayaUsd/base/api.h"
-#include "mayaUsd/ufe/UsdSceneItem.h"
+#include <mayaUsd/base/api.h>
+#include <mayaUsd/ufe/UsdSceneItem.h>
 
 #include <ufe/undoableCommand.h>
 

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
@@ -18,9 +18,9 @@
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/ufe/UsdSceneItem.h>
 
-#include <ufe/undoableCommand.h>
-
 #include <pxr/usd/usd/prim.h>
+
+#include <ufe/undoableCommand.h>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
@@ -15,9 +15,8 @@
 //
 #pragma once
 
-#include "../base/api.h"
-
-#include "UsdSceneItem.h"
+#include "mayaUsd/base/api.h"
+#include "mayaUsd/ufe/UsdSceneItem.h"
 
 #include <ufe/undoableCommand.h>
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/DebugCommands.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/DebugCommands.h
@@ -15,12 +15,12 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
+#include <AL/usdmaya/Api.h>
 
 #include <maya/MPxCommand.h>
 
-#include "AL/maya/utils/Api.h"
-#include "AL/maya/utils/MayaHelperMacros.h"
+#include <AL/maya/utils/Api.h>
+#include <AL/maya/utils/MayaHelperMacros.h>
 
 
 namespace AL {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/DebugCommands.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/DebugCommands.h
@@ -15,12 +15,11 @@
 //
 #pragma once
 
+#include <AL/maya/utils/Api.h>
+#include <AL/maya/utils/MayaHelperMacros.h>
 #include <AL/usdmaya/Api.h>
 
 #include <maya/MPxCommand.h>
-
-#include <AL/maya/utils/Api.h>
-#include <AL/maya/utils/MayaHelperMacros.h>
 
 
 namespace AL {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/DebugCommands.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/DebugCommands.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../Api.h"
+#include "AL/usdmaya/Api.h"
 
 #include <maya/MPxCommand.h>
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/LayerCommands.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/LayerCommands.h
@@ -15,15 +15,15 @@
 //
 #pragma once
 
-#include <AL/usdmaya/Api.h>
-
-#include <AL/usdmaya/ForwardDeclares.h>
 #include <AL/maya/utils/Api.h>
 #include <AL/maya/utils/MayaHelperMacros.h>
-#include <maya/MDGModifier.h>
-#include <maya/MPxCommand.h>
+#include <AL/usdmaya/Api.h>
+#include <AL/usdmaya/ForwardDeclares.h>
 
 #include <pxr/usd/usd/stage.h>
+
+#include <maya/MDGModifier.h>
+#include <maya/MPxCommand.h>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/LayerCommands.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/LayerCommands.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../Api.h"
+#include "AL/usdmaya/Api.h"
 
 #include "AL/usdmaya/ForwardDeclares.h"
 #include "AL/maya/utils/Api.h"

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/LayerCommands.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/LayerCommands.h
@@ -15,11 +15,11 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
+#include <AL/usdmaya/Api.h>
 
-#include "AL/usdmaya/ForwardDeclares.h"
-#include "AL/maya/utils/Api.h"
-#include "AL/maya/utils/MayaHelperMacros.h"
+#include <AL/usdmaya/ForwardDeclares.h>
+#include <AL/maya/utils/Api.h>
+#include <AL/maya/utils/MayaHelperMacros.h>
 #include <maya/MDGModifier.h>
 #include <maya/MPxCommand.h>
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ListTranslators.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ListTranslators.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../Api.h"
+#include "AL/usdmaya/Api.h"
 
 #include "AL/maya/utils/MayaHelperMacros.h"
 #include <maya/MPxCommand.h>

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ListTranslators.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ListTranslators.h
@@ -15,9 +15,9 @@
 //
 #pragma once
 
+#include <AL/maya/utils/MayaHelperMacros.h>
 #include <AL/usdmaya/Api.h>
 
-#include <AL/maya/utils/MayaHelperMacros.h>
 #include <maya/MPxCommand.h>
 
 namespace AL {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ListTranslators.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ListTranslators.h
@@ -15,9 +15,9 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
+#include <AL/usdmaya/Api.h>
 
-#include "AL/maya/utils/MayaHelperMacros.h"
+#include <AL/maya/utils/MayaHelperMacros.h>
 #include <maya/MPxCommand.h>
 
 namespace AL {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../Api.h"
+#include "AL/usdmaya/Api.h"
 
 #include <maya/MDagModifier.h>
 #include <maya/MObjectArray.h>

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.h
@@ -16,16 +16,15 @@
 #pragma once
 
 #include <AL/usdmaya/Api.h>
+#include <AL/usdmaya/StageCache.h>
+#include <AL/usdmaya/fileio/ImportParams.h>
+#include <AL/usdmaya/nodes/ProxyShape.h>
+
+#include <pxr/usd/usd/stage.h>
 
 #include <maya/MDagModifier.h>
 #include <maya/MObjectArray.h>
 #include <maya/MPxCommand.h>
-
-#include <AL/usdmaya/fileio/ImportParams.h>
-#include <AL/usdmaya/nodes/ProxyShape.h>
-#include <AL/usdmaya/StageCache.h>
-
-#include <pxr/usd/usd/stage.h>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.h
@@ -15,15 +15,15 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
+#include <AL/usdmaya/Api.h>
 
 #include <maya/MDagModifier.h>
 #include <maya/MObjectArray.h>
 #include <maya/MPxCommand.h>
 
-#include "AL/usdmaya/fileio/ImportParams.h"
-#include "AL/usdmaya/nodes/ProxyShape.h"
-#include "AL/usdmaya/StageCache.h"
+#include <AL/usdmaya/fileio/ImportParams.h>
+#include <AL/usdmaya/nodes/ProxyShape.h>
+#include <AL/usdmaya/StageCache.h>
 
 #include <pxr/usd/usd/stage.h>
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/RendererCommands.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/RendererCommands.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../Api.h"
+#include "AL/usdmaya/Api.h"
 
 #include "AL/maya/utils/MayaHelperMacros.h"
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/RendererCommands.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/RendererCommands.h
@@ -15,9 +15,9 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
+#include <AL/usdmaya/Api.h>
 
-#include "AL/maya/utils/MayaHelperMacros.h"
+#include <AL/maya/utils/MayaHelperMacros.h>
 
 #include <maya/MPxCommand.h>
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/RendererCommands.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/RendererCommands.h
@@ -15,9 +15,8 @@
 //
 #pragma once
 
-#include <AL/usdmaya/Api.h>
-
 #include <AL/maya/utils/MayaHelperMacros.h>
+#include <AL/usdmaya/Api.h>
 
 #include <maya/MPxCommand.h>
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/SyncFileIOGui.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/SyncFileIOGui.h
@@ -15,11 +15,11 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
+#include <AL/usdmaya/Api.h>
 
 #include <maya/MPxCommand.h>
 
-#include "AL/maya/utils/MayaHelperMacros.h"
+#include <AL/maya/utils/MayaHelperMacros.h>
 
 namespace AL {
 namespace usdmaya {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/SyncFileIOGui.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/SyncFileIOGui.h
@@ -15,11 +15,10 @@
 //
 #pragma once
 
+#include <AL/maya/utils/MayaHelperMacros.h>
 #include <AL/usdmaya/Api.h>
 
 #include <maya/MPxCommand.h>
-
-#include <AL/maya/utils/MayaHelperMacros.h>
 
 namespace AL {
 namespace usdmaya {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/SyncFileIOGui.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/SyncFileIOGui.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../Api.h"
+#include "AL/usdmaya/Api.h"
 
 #include <maya/MPxCommand.h>
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/AnimationTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/AnimationTranslator.h
@@ -15,12 +15,12 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
+#include <AL/usdmaya/Api.h>
 
-#include "AL/maya/utils/Utils.h"
+#include <AL/maya/utils/Utils.h>
 
-#include "AL/usdmaya/utils/AnimationTranslator.h"
-#include "AL/usdmaya/fileio/translators/TranslatorBase.h"
+#include <AL/usdmaya/utils/AnimationTranslator.h>
+#include <AL/usdmaya/fileio/translators/TranslatorBase.h>
 
 #include <pxr/usd/usd/attribute.h>
 PXR_NAMESPACE_USING_DIRECTIVE

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/AnimationTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/AnimationTranslator.h
@@ -15,14 +15,13 @@
 //
 #pragma once
 
-#include <AL/usdmaya/Api.h>
-
 #include <AL/maya/utils/Utils.h>
-
-#include <AL/usdmaya/utils/AnimationTranslator.h>
+#include <AL/usdmaya/Api.h>
 #include <AL/usdmaya/fileio/translators/TranslatorBase.h>
+#include <AL/usdmaya/utils/AnimationTranslator.h>
 
 #include <pxr/usd/usd/attribute.h>
+
 PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace AL {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/AnimationTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/AnimationTranslator.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../Api.h"
+#include "AL/usdmaya/Api.h"
 
 #include "AL/maya/utils/Utils.h"
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportTranslator.h
@@ -15,10 +15,10 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
+#include <AL/usdmaya/Api.h>
 
-#include "AL/maya/utils/FileTranslatorBase.h"
-#include "AL/maya/utils/PluginTranslatorOptions.h"
+#include <AL/maya/utils/FileTranslatorBase.h>
+#include <AL/maya/utils/PluginTranslatorOptions.h>
 
 namespace AL {
 namespace usdmaya {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportTranslator.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../Api.h"
+#include "AL/usdmaya/Api.h"
 
 #include "AL/maya/utils/FileTranslatorBase.h"
 #include "AL/maya/utils/PluginTranslatorOptions.h"

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportTranslator.h
@@ -15,10 +15,9 @@
 //
 #pragma once
 
-#include <AL/usdmaya/Api.h>
-
 #include <AL/maya/utils/FileTranslatorBase.h>
 #include <AL/maya/utils/PluginTranslatorOptions.h>
+#include <AL/usdmaya/Api.h>
 
 namespace AL {
 namespace usdmaya {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ImportTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ImportTranslator.h
@@ -15,11 +15,11 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
+#include <AL/usdmaya/Api.h>
 
-#include "AL/maya/utils/FileTranslatorBase.h"
-#include "AL/usdmaya/fileio/ImportParams.h"
-#include "AL/maya/utils/PluginTranslatorOptions.h"
+#include <AL/maya/utils/FileTranslatorBase.h>
+#include <AL/usdmaya/fileio/ImportParams.h>
+#include <AL/maya/utils/PluginTranslatorOptions.h>
 
 namespace AL {
 namespace usdmaya {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ImportTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ImportTranslator.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../Api.h"
+#include "AL/usdmaya/Api.h"
 
 #include "AL/maya/utils/FileTranslatorBase.h"
 #include "AL/usdmaya/fileio/ImportParams.h"

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ImportTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ImportTranslator.h
@@ -15,11 +15,10 @@
 //
 #pragma once
 
-#include <AL/usdmaya/Api.h>
-
 #include <AL/maya/utils/FileTranslatorBase.h>
-#include <AL/usdmaya/fileio/ImportParams.h>
 #include <AL/maya/utils/PluginTranslatorOptions.h>
+#include <AL/usdmaya/Api.h>
+#include <AL/usdmaya/fileio/ImportParams.h>
 
 namespace AL {
 namespace usdmaya {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/DagNodeTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/DagNodeTranslator.h
@@ -15,10 +15,10 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
+#include <AL/usdmaya/Api.h>
 
 #include <AL/usdmaya/ForwardDeclares.h>
-#include "AL/usdmaya/fileio/translators/DgNodeTranslator.h"
+#include <AL/usdmaya/fileio/translators/DgNodeTranslator.h>
 #include <maya/MObject.h>
 #include <pxr/base/tf/token.h>
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/DagNodeTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/DagNodeTranslator.h
@@ -16,11 +16,12 @@
 #pragma once
 
 #include <AL/usdmaya/Api.h>
-
 #include <AL/usdmaya/ForwardDeclares.h>
 #include <AL/usdmaya/fileio/translators/DgNodeTranslator.h>
-#include <maya/MObject.h>
+
 #include <pxr/base/tf/token.h>
+
+#include <maya/MObject.h>
 
 namespace AL {
 namespace usdmaya {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/DagNodeTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/DagNodeTranslator.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../../Api.h"
+#include "AL/usdmaya/Api.h"
 
 #include <AL/usdmaya/ForwardDeclares.h>
 #include "AL/usdmaya/fileio/translators/DgNodeTranslator.h"

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/DgNodeTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/DgNodeTranslator.h
@@ -15,13 +15,13 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
+#include <AL/usdmaya/Api.h>
 
 #include <AL/usdmaya/ForwardDeclares.h>
-#include "AL/usdmaya/utils/AttributeType.h"
-#include "AL/usdmaya/utils/DgNodeHelper.h"
-#include "AL/usdmaya/utils/ForwardDeclares.h"
-#include "AL/maya/utils/MayaHelperMacros.h"
+#include <AL/usdmaya/utils/AttributeType.h>
+#include <AL/usdmaya/utils/DgNodeHelper.h>
+#include <AL/usdmaya/utils/ForwardDeclares.h>
+#include <AL/maya/utils/MayaHelperMacros.h>
 
 #include <maya/MPlug.h>
 #include <maya/MAngle.h>

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/DgNodeTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/DgNodeTranslator.h
@@ -15,24 +15,22 @@
 //
 #pragma once
 
+#include <AL/maya/utils/MayaHelperMacros.h>
 #include <AL/usdmaya/Api.h>
-
 #include <AL/usdmaya/ForwardDeclares.h>
 #include <AL/usdmaya/utils/AttributeType.h>
 #include <AL/usdmaya/utils/DgNodeHelper.h>
 #include <AL/usdmaya/utils/ForwardDeclares.h>
-#include <AL/maya/utils/MayaHelperMacros.h>
-
-#include <maya/MPlug.h>
-#include <maya/MAngle.h>
-#include <maya/MDistance.h>
-#include <maya/MTime.h>
-
-#include <maya/MGlobal.h>
-#include <maya/MStatus.h>
 
 #include <pxr/base/gf/half.h>
 #include <pxr/usd/usd/attribute.h>
+
+#include <maya/MAngle.h>
+#include <maya/MDistance.h>
+#include <maya/MGlobal.h>
+#include <maya/MPlug.h>
+#include <maya/MStatus.h>
+#include <maya/MTime.h>
 
 #include <string>
 #include <vector>

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/DgNodeTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/DgNodeTranslator.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../../Api.h"
+#include "AL/usdmaya/Api.h"
 
 #include <AL/usdmaya/ForwardDeclares.h>
 #include "AL/usdmaya/utils/AttributeType.h"

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/ExtraDataPlugin.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/ExtraDataPlugin.h
@@ -15,8 +15,8 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
-#include "AL/maya/utils/Api.h"
+#include <AL/usdmaya/Api.h>
+#include <AL/maya/utils/Api.h>
 
 #include <maya/MDagPath.h>
 
@@ -26,8 +26,8 @@
 #include <pxr/base/tf/registryManager.h>
 #include <pxr/usd/usd/prim.h>
 
-#include "AL/usdmaya/fileio/translators/TranslatorContext.h"
-#include "AL/usdmaya/fileio/ExportParams.h"
+#include <AL/usdmaya/fileio/translators/TranslatorContext.h>
+#include <AL/usdmaya/fileio/ExportParams.h>
 
 namespace AL {
 namespace usdmaya {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/ExtraDataPlugin.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/ExtraDataPlugin.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../../Api.h"
+#include "AL/usdmaya/Api.h"
 #include "AL/maya/utils/Api.h"
 
 #include <maya/MDagPath.h>

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/ExtraDataPlugin.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/ExtraDataPlugin.h
@@ -15,19 +15,18 @@
 //
 #pragma once
 
-#include <AL/usdmaya/Api.h>
 #include <AL/maya/utils/Api.h>
-
-#include <maya/MDagPath.h>
+#include <AL/usdmaya/Api.h>
+#include <AL/usdmaya/fileio/ExportParams.h>
+#include <AL/usdmaya/fileio/translators/TranslatorContext.h>
 
 #include <pxr/base/tf/refBase.h>
+#include <pxr/base/tf/registryManager.h>
 #include <pxr/base/tf/type.h>
 #include <pxr/base/tf/weakBase.h>
-#include <pxr/base/tf/registryManager.h>
 #include <pxr/usd/usd/prim.h>
 
-#include <AL/usdmaya/fileio/translators/TranslatorContext.h>
-#include <AL/usdmaya/fileio/ExportParams.h>
+#include <maya/MDagPath.h>
 
 namespace AL {
 namespace usdmaya {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TestExtraDataPlugin.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TestExtraDataPlugin.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../../Api.h"
+#include "AL/usdmaya/Api.h"
 #include "AL/maya/utils/Api.h"
 
 #include <maya/MDagPath.h>

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TestExtraDataPlugin.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TestExtraDataPlugin.h
@@ -15,8 +15,8 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
-#include "AL/maya/utils/Api.h"
+#include <AL/usdmaya/Api.h>
+#include <AL/maya/utils/Api.h>
 
 #include <maya/MDagPath.h>
 
@@ -27,9 +27,9 @@
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/attribute.h>
 
-#include "AL/usdmaya/fileio/translators/TranslatorContext.h"
-#include "AL/usdmaya/fileio/translators/ExtraDataPlugin.h"
-#include "AL/usdmaya/fileio/ExportParams.h"
+#include <AL/usdmaya/fileio/translators/TranslatorContext.h>
+#include <AL/usdmaya/fileio/translators/ExtraDataPlugin.h>
+#include <AL/usdmaya/fileio/ExportParams.h>
 
 namespace AL {
 namespace usdmaya {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TestExtraDataPlugin.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TestExtraDataPlugin.h
@@ -15,21 +15,20 @@
 //
 #pragma once
 
-#include <AL/usdmaya/Api.h>
 #include <AL/maya/utils/Api.h>
-
-#include <maya/MDagPath.h>
+#include <AL/usdmaya/Api.h>
+#include <AL/usdmaya/fileio/ExportParams.h>
+#include <AL/usdmaya/fileio/translators/ExtraDataPlugin.h>
+#include <AL/usdmaya/fileio/translators/TranslatorContext.h>
 
 #include <pxr/base/tf/refBase.h>
+#include <pxr/base/tf/registryManager.h>
 #include <pxr/base/tf/type.h>
 #include <pxr/base/tf/weakBase.h>
-#include <pxr/base/tf/registryManager.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/attribute.h>
 
-#include <AL/usdmaya/fileio/translators/TranslatorContext.h>
-#include <AL/usdmaya/fileio/translators/ExtraDataPlugin.h>
-#include <AL/usdmaya/fileio/ExportParams.h>
+#include <maya/MDagPath.h>
 
 namespace AL {
 namespace usdmaya {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.h
@@ -15,11 +15,11 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
+#include <AL/usdmaya/Api.h>
 
 #include <AL/usdmaya/ForwardDeclares.h>
-#include "AL/usdmaya/TransformOperation.h"
-#include "AL/usdmaya/fileio/translators/DagNodeTranslator.h"
+#include <AL/usdmaya/TransformOperation.h>
+#include <AL/usdmaya/fileio/translators/DagNodeTranslator.h>
 
 #include <pxr/usd/usd/attribute.h>
 #include <pxr/usd/usdGeom/xform.h>

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../../Api.h"
+#include "AL/usdmaya/Api.h"
 
 #include <AL/usdmaya/ForwardDeclares.h>
 #include "AL/usdmaya/TransformOperation.h"

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <AL/usdmaya/Api.h>
-
 #include <AL/usdmaya/ForwardDeclares.h>
 #include <AL/usdmaya/TransformOperation.h>
 #include <AL/usdmaya/fileio/translators/DagNodeTranslator.h>

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorBase.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorBase.h
@@ -15,8 +15,8 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
-#include "AL/maya/utils/Api.h"
+#include <AL/usdmaya/Api.h>
+#include <AL/maya/utils/Api.h>
 
 #include <maya/MDagPath.h>
 
@@ -29,9 +29,9 @@
 #include <iostream>
 #include <unordered_map>
 #include <functional>
-#include "AL/usdmaya/fileio/translators/TranslatorContext.h"
-#include "AL/usdmaya/fileio/translators/ExtraDataPlugin.h"
-#include "AL/usdmaya/fileio/ExportParams.h"
+#include <AL/usdmaya/fileio/translators/TranslatorContext.h>
+#include <AL/usdmaya/fileio/translators/ExtraDataPlugin.h>
+#include <AL/usdmaya/fileio/ExportParams.h>
 
 namespace AL {
 namespace usdmaya {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorBase.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorBase.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../../Api.h"
+#include "AL/usdmaya/Api.h"
 #include "AL/maya/utils/Api.h"
 
 #include <maya/MDagPath.h>

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorBase.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorBase.h
@@ -15,23 +15,23 @@
 //
 #pragma once
 
-#include <AL/usdmaya/Api.h>
 #include <AL/maya/utils/Api.h>
+#include <AL/usdmaya/Api.h>
+#include <AL/usdmaya/fileio/ExportParams.h>
+#include <AL/usdmaya/fileio/translators/ExtraDataPlugin.h>
+#include <AL/usdmaya/fileio/translators/TranslatorContext.h>
+
+#include <pxr/base/tf/refBase.h>
+#include <pxr/base/tf/registryManager.h>
+#include <pxr/base/tf/type.h>
+#include <pxr/base/tf/weakBase.h>
+#include <pxr/usd/usd/prim.h>
 
 #include <maya/MDagPath.h>
 
-#include <pxr/base/tf/refBase.h>
-#include <pxr/base/tf/type.h>
-#include <pxr/base/tf/weakBase.h>
-#include <pxr/base/tf/registryManager.h>
-#include <pxr/usd/usd/prim.h>
-
+#include <functional>
 #include <iostream>
 #include <unordered_map>
-#include <functional>
-#include <AL/usdmaya/fileio/translators/TranslatorContext.h>
-#include <AL/usdmaya/fileio/translators/ExtraDataPlugin.h>
-#include <AL/usdmaya/fileio/ExportParams.h>
 
 namespace AL {
 namespace usdmaya {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../../Api.h"
+#include "AL/usdmaya/Api.h"
 
 #include <AL/usdmaya/ForwardDeclares.h>
 #include <maya/MPxData.h>

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
+#include <AL/usdmaya/Api.h>
 
 #include <AL/usdmaya/ForwardDeclares.h>
 #include <maya/MPxData.h>
@@ -28,7 +28,7 @@
 #include <pxr/base/tf/refPtr.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/base/tf/debug.h>
-#include "AL/usdmaya/DebugCodes.h"
+#include <AL/usdmaya/DebugCodes.h>
 
 #include <vector>
 #include <string>

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.h
@@ -16,23 +16,24 @@
 #pragma once
 
 #include <AL/usdmaya/Api.h>
-
+#include <AL/usdmaya/DebugCodes.h>
 #include <AL/usdmaya/ForwardDeclares.h>
-#include <maya/MPxData.h>
+#include <mayaUsdUtils/ForwardDeclares.h>
+
+#include <pxr/base/tf/debug.h>
+#include <pxr/base/tf/refPtr.h>
+#include <pxr/pxr.h>
+#include <pxr/usd/usd/prim.h>
+
+#include <maya/MDGModifier.h>
 #include <maya/MGlobal.h>
 #include <maya/MObject.h>
-#include <maya/MObjectHandle.h>
 #include <maya/MObjectArray.h>
-#include <maya/MDGModifier.h>
-#include <pxr/pxr.h>
-#include <pxr/base/tf/refPtr.h>
-#include <pxr/usd/usd/prim.h>
-#include <pxr/base/tf/debug.h>
-#include <AL/usdmaya/DebugCodes.h>
+#include <maya/MObjectHandle.h>
+#include <maya/MPxData.h>
 
-#include <vector>
 #include <string>
-#include <mayaUsdUtils/ForwardDeclares.h>
+#include <vector>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorTestType.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorTestType.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../../Api.h"
+#include "AL/usdmaya/Api.h"
 
 #include <pxr/pxr.h>
 #include <pxr/usd/usd/typed.h>

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorTestType.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorTestType.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
+#include <AL/usdmaya/Api.h>
 
 #include <pxr/pxr.h>
 #include <pxr/usd/usd/typed.h>

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorTestType.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorTestType.h
@@ -18,11 +18,11 @@
 #include <AL/usdmaya/Api.h>
 
 #include <pxr/pxr.h>
-#include <pxr/usd/usd/typed.h>
-#include <pxr/usd/usd/prim.h>
-#include <pxr/usd/usd/stage.h>
 #include <pxr/base/tf/token.h>
 #include <pxr/base/tf/type.h>
+#include <pxr/usd/usd/prim.h>
+#include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usd/typed.h>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/LockManager.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/LockManager.h
@@ -15,9 +15,9 @@
 //
 #pragma once
 
-#include <pxr/usd/sdf/path.h>
-
 #include <AL/usdmaya/Api.h>
+
+#include <pxr/usd/sdf/path.h>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/LockManager.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/LockManager.h
@@ -17,7 +17,7 @@
 
 #include <pxr/usd/sdf/path.h>
 
-#include "AL/usdmaya/Api.h"
+#include <AL/usdmaya/Api.h>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/LockManager.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/LockManager.h
@@ -17,7 +17,7 @@
 
 #include <pxr/usd/sdf/path.h>
 
-#include "../../Api.h"
+#include "AL/usdmaya/Api.h"
 
 PXR_NAMESPACE_USING_DIRECTIVE
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/PrimFilter.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/PrimFilter.h
@@ -16,12 +16,12 @@
 #pragma once
 
 #include <AL/usdmaya/Api.h>
+#include <mayaUsdUtils/ForwardDeclares.h>
+
+#include <pxr/usd/sdf/path.h>
+#include <pxr/usd/usd/prim.h>
 
 #include <vector>
-#include <pxr/usd/usd/prim.h>
-#include <pxr/usd/sdf/path.h>
-
-#include <mayaUsdUtils/ForwardDeclares.h>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/PrimFilter.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/PrimFilter.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "AL/usdmaya/Api.h"
+#include <AL/usdmaya/Api.h>
 
 #include <vector>
 #include <pxr/usd/usd/prim.h>

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/PrimFilter.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/PrimFilter.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include "../../Api.h"
+#include "AL/usdmaya/Api.h"
 
 #include <vector>
 #include <pxr/usd/usd/prim.h>

--- a/plugin/al/plugin/AL_USDMayaPlugin/plugin.cpp
+++ b/plugin/al/plugin/AL_USDMayaPlugin/plugin.cpp
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-#include "./Api.h"
+#include "Api.h"
 
 #include <maya/MFnPlugin.h>
 

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/plugin.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/plugin.cpp
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-#include "./Api.h"
+#include "Api.h"
 
 #include <maya/MFnPlugin.h>
 #include <maya/MGlobal.h>

--- a/plugin/al/schemas/AL/usd/schemas/maya/FrameRange.cpp
+++ b/plugin/al/schemas/AL/usd/schemas/maya/FrameRange.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "FrameRange.h"
+
 #include <pxr/usd/usd/schemaRegistry.h>
 #include <pxr/usd/usd/typed.h>
 

--- a/plugin/al/schemas/AL/usd/schemas/maya/FrameRange.cpp
+++ b/plugin/al/schemas/AL/usd/schemas/maya/FrameRange.cpp
@@ -15,11 +15,10 @@
 //
 #include "FrameRange.h"
 
+#include <pxr/usd/sdf/assetPath.h>
+#include <pxr/usd/sdf/types.h>
 #include <pxr/usd/usd/schemaRegistry.h>
 #include <pxr/usd/usd/typed.h>
-
-#include <pxr/usd/sdf/types.h>
-#include <pxr/usd/sdf/assetPath.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/plugin/al/schemas/AL/usd/schemas/maya/FrameRange.cpp
+++ b/plugin/al/schemas/AL/usd/schemas/maya/FrameRange.cpp
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "./FrameRange.h"
+#include "FrameRange.h"
 #include <pxr/usd/usd/schemaRegistry.h>
 #include <pxr/usd/usd/typed.h>
 

--- a/plugin/al/schemas/AL/usd/schemas/maya/FrameRange.h
+++ b/plugin/al/schemas/AL/usd/schemas/maya/FrameRange.h
@@ -18,12 +18,13 @@
 
 /// \file AL_USDMayaSchemas/FrameRange.h
 
-#include <pxr/pxr.h>
 #include "api.h"
+#include "tokens.h"
+
+#include <pxr/pxr.h>
 #include <pxr/usd/usd/typed.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
-#include "tokens.h"
 
 #include <pxr/base/vt/value.h>
 

--- a/plugin/al/schemas/AL/usd/schemas/maya/FrameRange.h
+++ b/plugin/al/schemas/AL/usd/schemas/maya/FrameRange.h
@@ -19,11 +19,11 @@
 /// \file AL_USDMayaSchemas/FrameRange.h
 
 #include <pxr/pxr.h>
-#include "./api.h"
+#include "api.h"
 #include <pxr/usd/usd/typed.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
-#include "./tokens.h"
+#include "tokens.h"
 
 #include <pxr/base/vt/value.h>
 

--- a/plugin/al/schemas/AL/usd/schemas/maya/FrameRange.h
+++ b/plugin/al/schemas/AL/usd/schemas/maya/FrameRange.h
@@ -21,19 +21,16 @@
 #include "api.h"
 #include "tokens.h"
 
-#include <pxr/pxr.h>
-#include <pxr/usd/usd/typed.h>
-#include <pxr/usd/usd/prim.h>
-#include <pxr/usd/usd/stage.h>
-
-#include <pxr/base/vt/value.h>
-
+#include <pxr/base/gf/matrix4d.h>
 #include <pxr/base/gf/vec3d.h>
 #include <pxr/base/gf/vec3f.h>
-#include <pxr/base/gf/matrix4d.h>
-
 #include <pxr/base/tf/token.h>
 #include <pxr/base/tf/type.h>
+#include <pxr/base/vt/value.h>
+#include <pxr/pxr.h>
+#include <pxr/usd/usd/prim.h>
+#include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usd/typed.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/plugin/al/schemas/AL/usd/schemas/maya/ModelAPI.cpp
+++ b/plugin/al/schemas/AL/usd/schemas/maya/ModelAPI.cpp
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "./ModelAPI.h"
+#include "ModelAPI.h"
 #include <pxr/usd/usd/schemaRegistry.h>
 #include <pxr/usd/usd/typed.h>
 #include <pxr/usd/usd/tokens.h>

--- a/plugin/al/schemas/AL/usd/schemas/maya/ModelAPI.cpp
+++ b/plugin/al/schemas/AL/usd/schemas/maya/ModelAPI.cpp
@@ -15,12 +15,11 @@
 //
 #include "ModelAPI.h"
 
-#include <pxr/usd/usd/schemaRegistry.h>
-#include <pxr/usd/usd/typed.h>
-#include <pxr/usd/usd/tokens.h>
-
-#include <pxr/usd/sdf/types.h>
 #include <pxr/usd/sdf/assetPath.h>
+#include <pxr/usd/sdf/types.h>
+#include <pxr/usd/usd/schemaRegistry.h>
+#include <pxr/usd/usd/tokens.h>
+#include <pxr/usd/usd/typed.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/plugin/al/schemas/AL/usd/schemas/maya/ModelAPI.cpp
+++ b/plugin/al/schemas/AL/usd/schemas/maya/ModelAPI.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "ModelAPI.h"
+
 #include <pxr/usd/usd/schemaRegistry.h>
 #include <pxr/usd/usd/typed.h>
 #include <pxr/usd/usd/tokens.h>

--- a/plugin/al/schemas/AL/usd/schemas/maya/ModelAPI.h
+++ b/plugin/al/schemas/AL/usd/schemas/maya/ModelAPI.h
@@ -19,12 +19,12 @@
 /// \file AL_USDMayaSchemas/ModelAPI.h
 
 #include <pxr/pxr.h>
-#include "./api.h"
+#include "api.h"
 #include <pxr/usd/usd/modelAPI.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
 
-#include "./tokens.h"
+#include "tokens.h"
 
 
 #include <pxr/base/vt/value.h>

--- a/plugin/al/schemas/AL/usd/schemas/maya/ModelAPI.h
+++ b/plugin/al/schemas/AL/usd/schemas/maya/ModelAPI.h
@@ -21,20 +21,16 @@
 #include "api.h"
 #include "tokens.h"
 
+#include <pxr/base/gf/matrix4d.h>
+#include <pxr/base/gf/vec3d.h>
+#include <pxr/base/gf/vec3f.h>
+#include <pxr/base/tf/token.h>
+#include <pxr/base/tf/type.h>
+#include <pxr/base/vt/value.h>
 #include <pxr/pxr.h>
 #include <pxr/usd/usd/modelAPI.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
-
-
-#include <pxr/base/vt/value.h>
-
-#include <pxr/base/gf/vec3d.h>
-#include <pxr/base/gf/vec3f.h>
-#include <pxr/base/gf/matrix4d.h>
-
-#include <pxr/base/tf/token.h>
-#include <pxr/base/tf/type.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/plugin/al/schemas/AL/usd/schemas/maya/ModelAPI.h
+++ b/plugin/al/schemas/AL/usd/schemas/maya/ModelAPI.h
@@ -18,13 +18,13 @@
 
 /// \file AL_USDMayaSchemas/ModelAPI.h
 
-#include <pxr/pxr.h>
 #include "api.h"
+#include "tokens.h"
+
+#include <pxr/pxr.h>
 #include <pxr/usd/usd/modelAPI.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
-
-#include "tokens.h"
 
 
 #include <pxr/base/vt/value.h>

--- a/plugin/al/schemas/AL/usd/schemas/maya/schema.usda.in
+++ b/plugin/al/schemas/AL/usd/schemas/maya/schema.usda.in
@@ -75,7 +75,7 @@ doc = "Data used to import a maya reference."
         string className = "ModelAPI"
         string fileName = "ModelAPI"
         string extraIncludes = """
-#include "./tokens.h"
+#include "tokens.h"
 """
       }
 )

--- a/plugin/al/schemas/AL/usd/schemas/maya/tokens.cpp
+++ b/plugin/al/schemas/AL/usd/schemas/maya/tokens.cpp
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "./tokens.h"
+#include "tokens.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/plugin/al/schemas/AL/usd/schemas/maya/tokens.h
+++ b/plugin/al/schemas/AL/usd/schemas/maya/tokens.h
@@ -26,7 +26,7 @@
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 #include <pxr/pxr.h>
-#include "./api.h"
+#include "api.h"
 #include <pxr/base/tf/staticData.h>
 #include <pxr/base/tf/token.h>
 #include <vector>

--- a/plugin/al/schemas/AL/usd/schemas/maya/tokens.h
+++ b/plugin/al/schemas/AL/usd/schemas/maya/tokens.h
@@ -27,9 +27,10 @@
 
 #include "api.h"
 
-#include <pxr/pxr.h>
 #include <pxr/base/tf/staticData.h>
 #include <pxr/base/tf/token.h>
+#include <pxr/pxr.h>
+
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/plugin/al/schemas/AL/usd/schemas/maya/tokens.h
+++ b/plugin/al/schemas/AL/usd/schemas/maya/tokens.h
@@ -25,8 +25,9 @@
 // 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-#include <pxr/pxr.h>
 #include "api.h"
+
+#include <pxr/pxr.h>
 #include <pxr/base/tf/staticData.h>
 #include <pxr/base/tf/token.h>
 #include <vector>

--- a/plugin/al/schemas/AL/usd/schemas/maya/wrapFrameRange.cpp
+++ b/plugin/al/schemas/AL/usd/schemas/maya/wrapFrameRange.cpp
@@ -15,15 +15,13 @@
 //
 #include "FrameRange.h"
 
-#include <pxr/usd/usd/schemaBase.h>
-
-#include <pxr/usd/sdf/primSpec.h>
-
-#include <pxr/usd/usd/pyConversions.h>
 #include <pxr/base/tf/pyContainerConversions.h>
 #include <pxr/base/tf/pyResultConversions.h>
 #include <pxr/base/tf/pyUtils.h>
 #include <pxr/base/tf/wrapTypeHelpers.h>
+#include <pxr/usd/sdf/primSpec.h>
+#include <pxr/usd/usd/pyConversions.h>
+#include <pxr/usd/usd/schemaBase.h>
 
 #include <boost/python.hpp>
 

--- a/plugin/al/schemas/AL/usd/schemas/maya/wrapFrameRange.cpp
+++ b/plugin/al/schemas/AL/usd/schemas/maya/wrapFrameRange.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "FrameRange.h"
+
 #include <pxr/usd/usd/schemaBase.h>
 
 #include <pxr/usd/sdf/primSpec.h>

--- a/plugin/al/schemas/AL/usd/schemas/maya/wrapFrameRange.cpp
+++ b/plugin/al/schemas/AL/usd/schemas/maya/wrapFrameRange.cpp
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "./FrameRange.h"
+#include "FrameRange.h"
 #include <pxr/usd/usd/schemaBase.h>
 
 #include <pxr/usd/sdf/primSpec.h>

--- a/plugin/al/schemas/AL/usd/schemas/maya/wrapModelAPI.cpp
+++ b/plugin/al/schemas/AL/usd/schemas/maya/wrapModelAPI.cpp
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "./ModelAPI.h"
+#include "ModelAPI.h"
 #include <pxr/usd/usd/schemaBase.h>
 
 #include <pxr/usd/sdf/primSpec.h>

--- a/plugin/al/schemas/AL/usd/schemas/maya/wrapModelAPI.cpp
+++ b/plugin/al/schemas/AL/usd/schemas/maya/wrapModelAPI.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "ModelAPI.h"
+
 #include <pxr/usd/usd/schemaBase.h>
 
 #include <pxr/usd/sdf/primSpec.h>

--- a/plugin/al/schemas/AL/usd/schemas/maya/wrapModelAPI.cpp
+++ b/plugin/al/schemas/AL/usd/schemas/maya/wrapModelAPI.cpp
@@ -15,15 +15,13 @@
 //
 #include "ModelAPI.h"
 
-#include <pxr/usd/usd/schemaBase.h>
-
-#include <pxr/usd/sdf/primSpec.h>
-
-#include <pxr/usd/usd/pyConversions.h>
 #include <pxr/base/tf/pyContainerConversions.h>
 #include <pxr/base/tf/pyResultConversions.h>
 #include <pxr/base/tf/pyUtils.h>
 #include <pxr/base/tf/wrapTypeHelpers.h>
+#include <pxr/usd/sdf/primSpec.h>
+#include <pxr/usd/usd/pyConversions.h>
+#include <pxr/usd/usd/schemaBase.h>
 
 #include <boost/python.hpp>
 

--- a/plugin/al/schemas/AL/usd/schemas/maya/wrapTokens.cpp
+++ b/plugin/al/schemas/AL/usd/schemas/maya/wrapTokens.cpp
@@ -14,8 +14,9 @@
 // limitations under the License.
 //
 // GENERATED FILE.  DO NOT EDIT.
-#include <boost/python/class.hpp>
 #include "tokens.h"
+
+#include <boost/python/class.hpp>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 

--- a/plugin/al/schemas/AL/usd/schemas/maya/wrapTokens.cpp
+++ b/plugin/al/schemas/AL/usd/schemas/maya/wrapTokens.cpp
@@ -15,7 +15,7 @@
 //
 // GENERATED FILE.  DO NOT EDIT.
 #include <boost/python/class.hpp>
-#include "./tokens.h"
+#include "tokens.h"
 
 PXR_NAMESPACE_USING_DIRECTIVE
 

--- a/plugin/al/schemas/AL/usd/schemas/mayatest/ExamplePolyCubeNode.h
+++ b/plugin/al/schemas/AL/usd/schemas/mayatest/ExamplePolyCubeNode.h
@@ -27,11 +27,11 @@
 /// \file AL_USDMayaSchemasTest/ExamplePolyCubeNode.h
 
 #include <pxr/pxr.h>
-#include "./api.h"
+#include "api.h"
 #include <pxr/usd/usd/typed.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
-#include "./tokens.h"
+#include "tokens.h"
 
 #include <pxr/base/vt/value.h>
 

--- a/plugin/al/schemas/AL/usd/schemas/mayatest/ExamplePolyCubeNode.h
+++ b/plugin/al/schemas/AL/usd/schemas/mayatest/ExamplePolyCubeNode.h
@@ -26,12 +26,13 @@
 
 /// \file AL_USDMayaSchemasTest/ExamplePolyCubeNode.h
 
-#include <pxr/pxr.h>
 #include "api.h"
+#include "tokens.h"
+
+#include <pxr/pxr.h>
 #include <pxr/usd/usd/typed.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
-#include "tokens.h"
 
 #include <pxr/base/vt/value.h>
 

--- a/plugin/al/schemas/AL/usd/schemas/mayatest/ExamplePolyCubeNode.h
+++ b/plugin/al/schemas/AL/usd/schemas/mayatest/ExamplePolyCubeNode.h
@@ -29,19 +29,16 @@
 #include "api.h"
 #include "tokens.h"
 
-#include <pxr/pxr.h>
-#include <pxr/usd/usd/typed.h>
-#include <pxr/usd/usd/prim.h>
-#include <pxr/usd/usd/stage.h>
-
-#include <pxr/base/vt/value.h>
-
+#include <pxr/base/gf/matrix4d.h>
 #include <pxr/base/gf/vec3d.h>
 #include <pxr/base/gf/vec3f.h>
-#include <pxr/base/gf/matrix4d.h>
-
 #include <pxr/base/tf/token.h>
 #include <pxr/base/tf/type.h>
+#include <pxr/base/vt/value.h>
+#include <pxr/pxr.h>
+#include <pxr/usd/usd/prim.h>
+#include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usd/typed.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/plugin/al/schemas/AL/usd/schemas/mayatest/tokens.h
+++ b/plugin/al/schemas/AL/usd/schemas/mayatest/tokens.h
@@ -33,8 +33,9 @@
 // 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-#include <pxr/pxr.h>
 #include "api.h"
+
+#include <pxr/pxr.h>
 #include <pxr/base/tf/staticData.h>
 #include <pxr/base/tf/token.h>
 #include <vector>

--- a/plugin/al/schemas/AL/usd/schemas/mayatest/tokens.h
+++ b/plugin/al/schemas/AL/usd/schemas/mayatest/tokens.h
@@ -35,9 +35,10 @@
 
 #include "api.h"
 
-#include <pxr/pxr.h>
 #include <pxr/base/tf/staticData.h>
 #include <pxr/base/tf/token.h>
+#include <pxr/pxr.h>
+
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/plugin/al/schemas/AL/usd/schemas/mayatest/tokens.h
+++ b/plugin/al/schemas/AL/usd/schemas/mayatest/tokens.h
@@ -34,7 +34,7 @@
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 #include <pxr/pxr.h>
-#include "./api.h"
+#include "api.h"
 #include <pxr/base/tf/staticData.h>
 #include <pxr/base/tf/token.h>
 #include <vector>


### PR DESCRIPTION
This fixes up the remaining instances where headers were being included with a path using `./` or `../`. While I was in there, I also addressed a few other coding guidelines issues for the header includes in those files.