### PR TITLE
MAYA-103556 Display a wait cursor when building the hierarchy view

### DIFF
--- a/lib/usd/ui/USDImportDialogCmd.cpp
+++ b/lib/usd/ui/USDImportDialogCmd.cpp
@@ -40,6 +40,10 @@
 #include <mayaUsdUI/ui/USDImportDialog.h>
 #include <mayaUsdUI/ui/USDQtUtil.h>
 
+#include <QtGui/QCursor>
+#include <QtWidgets/QApplication>
+
+
 MAYAUSD_NS_DEF {
 
 const MString USDImportDialogCmd::fsName("usdImportDialog");
@@ -194,7 +198,14 @@ MStatus USDImportDialogCmd::doIt(const MArgList& args)
 		{
 			USDQtUtil usdQtUtil;
 			ImportData& importData = ImportData::instance();
+
+			// Creating the View can pause Maya, usually only briefly but it's noticable, so we'll toggle the wait cursor to show that it's working.
+			QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
+
 			std::unique_ptr<IUSDImportView> usdImportDialog(new USDImportDialog(assetPath.asChar(), &importData, usdQtUtil, MQtUtil::mainWindow()));
+
+			QApplication::restoreOverrideCursor();
+
 			if (usdImportDialog->execute())
 			{
 				// The user clicked 'Apply' so copy the info from the dialog to the import data instance.


### PR DESCRIPTION
There can be a pause while building the hierarchy view dialog when importing a larger usd file, so here I add a wait cursor while building it.

The QApplication calls I'm making here are basically what the Maya waitCursor command does, so just calling them directly instead of bothering with a call to the command from c++.

Also thought about putting the calls right in the dialog itself, but I think the slower code in there is partly in the initializer list so it wasn't a good fit there.