### PR TITLE
Do not install shadingModePxrRis_rfm_map.h header publicly

### DIFF
--- a/lib/mayaUsd/fileio/shading/CMakeLists.txt
+++ b/lib/mayaUsd/fileio/shading/CMakeLists.txt
@@ -16,7 +16,6 @@ set(headers
     shadingModeExporter.h
     shadingModeExporterContext.h
     shadingModeImporter.h
-    shadingModePxrRis_rfm_map.h
     shadingModeRegistry.h
 )
 

--- a/lib/mayaUsd/fileio/shading/shadingModePxrRis.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModePxrRis.cpp
@@ -13,6 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
+// Defines the RenderMan for Maya mapping between Pxr objects and Maya internal nodes
+#include "shadingModePxrRis_rfm_map.h"
+
 #include <vector>
 
 #include <maya/MFnAttribute.h>
@@ -46,9 +50,6 @@
 #include <mayaUsd/fileio/shading/shadingModeExporter.h>
 #include <mayaUsd/fileio/shading/shadingModeExporterContext.h>
 #include <mayaUsd/fileio/shading/shadingModeImporter.h>
-
-// Defines the RenderMan for Maya mapping between Pxr objects and Maya internal nodes
-#include <mayaUsd/fileio/shading/shadingModePxrRis_rfm_map.h>
 
 #include <mayaUsd/fileio/shading/shadingModeRegistry.h>
 #include <mayaUsd/fileio/translators/translatorUtil.h>

--- a/lib/mayaUsd/fileio/shading/shadingModePxrRis.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModePxrRis.cpp
@@ -17,16 +17,15 @@
 // Defines the RenderMan for Maya mapping between Pxr objects and Maya internal nodes
 #include "shadingModePxrRis_rfm_map.h"
 
-#include <vector>
-
-#include <maya/MFnAttribute.h>
-#include <maya/MFnDependencyNode.h>
-#include <maya/MFnSet.h>
-#include <maya/MGlobal.h>
-#include <maya/MObject.h>
-#include <maya/MPlug.h>
-#include <maya/MStatus.h>
-#include <maya/MString.h>
+#include <mayaUsd/fileio/shading/shadingModeExporter.h>
+#include <mayaUsd/fileio/shading/shadingModeExporterContext.h>
+#include <mayaUsd/fileio/shading/shadingModeImporter.h>
+#include <mayaUsd/fileio/shading/shadingModeRegistry.h>
+#include <mayaUsd/fileio/translators/translatorUtil.h>
+#include <mayaUsd/fileio/utils/roundTripUtil.h>
+#include <mayaUsd/fileio/utils/writeUtil.h>
+#include <mayaUsd/utils/converter.h>
+#include <mayaUsd/utils/util.h>
 
 #include <pxr/pxr.h>
 #include <pxr/base/tf/diagnostic.h>
@@ -47,16 +46,16 @@
 #include <pxr/usd/usdShade/shader.h>
 #include <pxr/usd/usdShade/tokens.h>
 
-#include <mayaUsd/fileio/shading/shadingModeExporter.h>
-#include <mayaUsd/fileio/shading/shadingModeExporterContext.h>
-#include <mayaUsd/fileio/shading/shadingModeImporter.h>
+#include <maya/MFnAttribute.h>
+#include <maya/MFnDependencyNode.h>
+#include <maya/MFnSet.h>
+#include <maya/MGlobal.h>
+#include <maya/MObject.h>
+#include <maya/MPlug.h>
+#include <maya/MStatus.h>
+#include <maya/MString.h>
 
-#include <mayaUsd/fileio/shading/shadingModeRegistry.h>
-#include <mayaUsd/fileio/translators/translatorUtil.h>
-#include <mayaUsd/fileio/utils/roundTripUtil.h>
-#include <mayaUsd/fileio/utils/writeUtil.h>
-#include <mayaUsd/utils/converter.h>
-#include <mayaUsd/utils/util.h>
+#include <vector>
 
 using namespace MAYAUSD_NS;
 


### PR DESCRIPTION
I also organized the header includes in shadingModePxrRis.cpp while I was at it.