### PR TITLE
MAYA-105538 minor fix for column width of some text.

### DIFF
--- a/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
@@ -59,7 +59,7 @@ global proc int mayaUsdTranslatorImport (string $parent,
                     -sbm "Select a USD file and click Hierarchy View to open the Hierarchy View window. This window lets you toggle prim checkboxes and non-destructively switch between variants to build the scope of your import."
                     -ann "Select a USD file and click <strong>Hierarchy View</strong> to build the scope of your import and switch variants.<br><br><strong>Scope</strong>: A USD file consists of prims, the primary container object in USD. Prims can contain any scene element, like meshes, lights, cameras, etc. Use the checkboxes in the <strong>Hierarchy View</strong> to select and deselect prims to build the scope of your import.<br><br><strong>Variant</strong>: A variant is a single, named variation of a variant set. Each variant set is a package of alternatives that users can switch between non-destructively. A variant set has no limits to what it can store. Variants can be used to swap out a material or change the entire hierarchy of an asset. A single prim can have many variants and variant sets, but only one variant from each variant set can be selected for import into Maya."
                 ;
-                textField -ed false -nbg true -text "Please select a file to enable this option" -w $cw2 mayaUsdTranslator_SelectFileField;
+                textField -ed false -nbg true -text "Please select a file to enable this option" -w $cw1 mayaUsdTranslator_SelectFileField;
                 button -label "Hierarchy View" -c "string $usdFile = currentFileDialogSelection(); usdImportDialog $usdFile;" mayaUsdTranslator_ViewHierBtn;
 
                 // Hide the button by default.
@@ -171,7 +171,7 @@ global proc int mayaUsdTranslatorImport (string $parent,
             else
             {
                 // Show the field and hide the button.
-                textField -e -vis true -w $cw2 mayaUsdTranslator_SelectFileField;
+                textField -e -vis true -w $cw1 mayaUsdTranslator_SelectFileField;
             }
         }
 


### PR DESCRIPTION
Minor change to adjust the column width of some text in the Import UI.  The chosen width is important for the animation details below the Hierarchy View button, but the text that is displayed when the button is invisible doesn't need the extra width.  The current width can effect other parts of the UI, minor problem but can be annoying.