### PR TITLE
do not bypass the mayaUsdPlugin load in the testUsdImportRfMLight test

### DIFF
--- a/test/lib/usd/translators/testUsdImportRfMLight.py
+++ b/test/lib/usd/translators/testUsdImportRfMLight.py
@@ -35,7 +35,7 @@ class testUsdImportRfMLight(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        inputPath = fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+        inputPath = fixturesUtils.readOnlySetUpClass(__file__)
         cmds.file(new=True, force=True)
 
         cmds.loadPlugin('RenderMan_for_Maya', quiet=True)


### PR DESCRIPTION
`fixturesUtils._setUpClass()` monkey patches the `cmds.usdExport` and `cmds.usdImport` names to `cmds.mayaUSDExport` and `cmds.mayaUSDImport`, respectively, so if we don't load `mayaUsdPlugin`, those commands will not exist.

This change fixes the `testUsdImportRfMLight` test, but `fixturesUtils` may need some reconsideration if we really want to support bypassing loading any plugins.