### PR TITLE
Updates to support core USD release 20.08

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -31,7 +31,7 @@ See Pixar's official github page for instructions on how to build USD: https://g
 
 |               |      ![](images/pxr.png)          |        
 |:------------: |:---------------:                  |
-|  CommitID/Tags | master: [v19.07](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.07) or [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) <br> dev: [e7ff8e8](https://github.com/PixarAnimationStudios/USD/commit/e7ff8e85b422b04a6d685908a32e4b394ef04504) |
+|  CommitID/Tags | release: [v19.07](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.07) or [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) <br> dev: [238d0f4](https://github.com/PixarAnimationStudios/USD/commit/238d0f4b09d595955d3b5819db427e270756cc24) |
 
 For additional information on building Pixar USD, see the ***Additional Build Instruction*** section below.
 
@@ -79,13 +79,13 @@ There are four arguments that must be passed to the script:
 
 ```
 Linux:
-➜ maya-usd python build.py --maya-location /usr/autodesk/maya2020 --pxrusd-location /usr/local/USD-Master --devkit-location /usr/local/devkitBase /usr/local/workspace
+➜ maya-usd python build.py --maya-location /usr/autodesk/maya2020 --pxrusd-location /usr/local/USD-Release --devkit-location /usr/local/devkitBase /usr/local/workspace
 
 MacOSX:
-➜ maya-usd python build.py --maya-location /Applications/Autodesk/maya2020 --pxrusd-location /opt/local/USD-Master --devkit-location /opt/local/devkitBase /opt/local/workspace
+➜ maya-usd python build.py --maya-location /Applications/Autodesk/maya2020 --pxrusd-location /opt/local/USD-Release --devkit-location /opt/local/devkitBase /opt/local/workspace
 
 Windows:
-c:\maya-usd> python build.py --maya-location "C:\Program Files\Autodesk\Maya2020" --pxrusd-location C:\USD-Master --devkit-location C:\devkitBase C:\workspace
+c:\maya-usd> python build.py --maya-location "C:\Program Files\Autodesk\Maya2020" --pxrusd-location C:\USD-Release --devkit-location C:\devkitBase C:\workspace
 ```
 
 ##### Build Arguments

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp
@@ -31,6 +31,7 @@
 #include <vector>
 #include "AL/usdmaya/nodes/Engine.h"
 
+#include <pxr/imaging/hd/engine.h>
 #include <pxr/imaging/hdx/pickTask.h>
 #include <pxr/imaging/hdx/taskController.h>
 #include <pxr/usdImaging/usdImaging/delegate.h>
@@ -78,9 +79,15 @@ bool Engine::TestIntersectionBatch(
   pickParams.outHits = &allHits;
   VtValue vtPickParams(pickParams);
 
-  _engine.SetTaskContextData(HdxPickTokens->pickParams, vtPickParams);
+#if defined(USDIMAGINGGL_API_VERSION) && USDIMAGINGGL_API_VERSION >= 6
+  HdEngine* hdEngine = _GetHdEngine();
+#else
+  HdEngine* hdEngine = &_engine;
+#endif
+
+  hdEngine->SetTaskContextData(HdxPickTokens->pickParams, vtPickParams);
   auto pickingTasks = _taskController->GetPickingTasks();
-  _engine.Execute(_taskController->GetRenderIndex(), &pickingTasks);
+  hdEngine->Execute(_taskController->GetRenderIndex(), &pickingTasks);
 
   if (allHits.size() == 0) {
     return false;

--- a/test/lib/usd/translators/testUsdExportAsClip.py
+++ b/test/lib/usd/translators/testUsdExportAsClip.py
@@ -108,7 +108,20 @@ class testUsdExportAsClip(unittest.TestCase):
 
         stitchedPath = os.path.abspath('result.usda')
         stitchedLayer = Sdf.Layer.CreateNew(stitchedPath)
-        self.assertTrue(UsdUtils.StitchClips(stitchedLayer, clipFiles, '/world', 1, 20, 'default'))
+
+        # Clip stitching behavior changed significantly between core USD 20.05
+        # and 20.08. Beginning with 20.08, we need to pass an additional option
+        # to ensure that authored time samples are held across gaps in value
+        # clips.
+        if Usd.GetVersion() > (0, 20, 5):
+            self.assertTrue(
+                UsdUtils.StitchClips(stitchedLayer, clipFiles, '/world',
+                    startFrame=1, endFrame=20,
+                    interpolateMissingClipValues=True, clipSet='default'))
+        else:
+            self.assertTrue(
+                UsdUtils.StitchClips(stitchedLayer, clipFiles, '/world',
+                    startFrame=1, endFrame=20, clipSet='default'))
 
         # export a non clip version for comparison
         canonicalUsdFile = os.path.abspath('canonical.usda')


### PR DESCRIPTION
The `_engine` property was made private starting with `USDIMAGINGGL_API_VERSION` 6 in core USD commit https://github.com/PixarAnimationStudios/USD/commit/c03508ba9850bccabcd4b84e217533bd909352a7. It can still be accessed using the protected `_GetHdEngine()` accessor.

These changes should continue to work before and after that version.