### PR TITLE
initialize Maya standalone mode when the testUsdExportRenderLayerMode module is loaded

### DIFF
--- a/test/lib/usd/translators/testUsdExportRenderLayerMode.py
+++ b/test/lib/usd/translators/testUsdExportRenderLayerMode.py
@@ -29,6 +29,11 @@ from maya import OpenMayaRender as OMR
 
 import fixturesUtils
 
+# Initialize Maya standalone mode early, since we call cmds.mayaHasRenderSetup()
+# in a decorator on the test class, which will be evaluated *before*
+# setUpClass() is called.
+standalone.initialize('usd')
+
 @unittest.skipIf(cmds.mayaHasRenderSetup(), "USD render layer functionality can only be tested with Maya set to legacy render layer mode.")
 class testUsdExportRenderLayerMode(unittest.TestCase):
 


### PR DESCRIPTION
Since we call `cmds.mayaHasRenderSetup()` in a decorator on the test class, we have to make sure that we call `maya.standalone.initialize()` *before* the class is defined, since `setUpClass()` when it would normally be called executes after that. Otherwise, the method called in the decorator will fail.

This is somewhat similar to #609 where because we're running this test outside of the usual CMake harness, we don't get the extra standalone initialization code injected.