### PR TITLE
MAYA-103187 Add option to save .usd files as binary or ascii

### DIFF
--- a/lib/mayaUsd/commands/baseExportCommand.cpp
+++ b/lib/mayaUsd/commands/baseExportCommand.cpp
@@ -87,6 +87,9 @@ MSyntax MayaUSDExportCommand::createSyntax()
     syntax.addFlag(kDefaultMeshSchemeFlag,
                    UsdMayaJobExportArgsTokens->defaultMeshScheme.GetText(),
                    MSyntax::kString);
+    syntax.addFlag(kDefaultUSDFormatFlag,
+                   UsdMayaJobExportArgsTokens->defaultUSDFormat.GetText(),
+                   MSyntax::kString);                   
     syntax.addFlag(kExportVisibilityFlag,
                    UsdMayaJobExportArgsTokens->exportVisibility.GetText(),
                    MSyntax::kBoolean);

--- a/lib/mayaUsd/commands/baseExportCommand.h
+++ b/lib/mayaUsd/commands/baseExportCommand.h
@@ -44,6 +44,7 @@ class MAYAUSD_CORE_PUBLIC MayaUSDExportCommand : public MPxCommand
     //
     // The list of short forms of flags defined as Arg Tokens:
     static constexpr auto kDefaultMeshSchemeFlag = "dms";
+    static constexpr auto kDefaultUSDFormatFlag = "duf";
     static constexpr auto kExportColorSetsFlag = "cls";
     static constexpr auto kExportUVsFlag = "uvs";
     static constexpr auto kEulerFilterFlag = "ef";

--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -32,6 +32,8 @@
 #include <pxr/usd/sdf/schema.h>
 #include <pxr/usd/usdGeom/tokens.h>
 #include <pxr/usd/usdUtils/pipeline.h>
+#include <pxr/usd/usd/usdaFileFormat.h>
+#include <pxr/usd/usd/usdcFileFormat.h>
 
 #include <mayaUsd/fileio/registryHelper.h>
 #include <mayaUsd/fileio/shading/shadingModeRegistry.h>
@@ -250,6 +252,13 @@ UsdMayaJobExportArgs::UsdMayaJobExportArgs(
                     UsdGeomTokens->bilinear,
                     UsdGeomTokens->none
                 })),
+        defaultUSDFormat(
+            _Token(userArgs,
+                UsdMayaJobExportArgsTokens->defaultUSDFormat,
+                UsdUsdcFileFormatTokens->Id,
+                {
+                    UsdUsdaFileFormatTokens->Id
+                })),                 
         eulerFilter(
             _Boolean(userArgs, UsdMayaJobExportArgsTokens->eulerFilter)),
         excludeInvisible(
@@ -356,6 +365,7 @@ operator <<(std::ostream& out, const UsdMayaJobExportArgs& exportArgs)
 {
     out << "compatibility: " << exportArgs.compatibility << std::endl
         << "defaultMeshScheme: " << exportArgs.defaultMeshScheme << std::endl
+        << "defaultUSDFormat: " << exportArgs.defaultUSDFormat << std::endl
         << "eulerFilter: " << TfStringify(exportArgs.eulerFilter) << std::endl
         << "excludeInvisible: " << TfStringify(exportArgs.excludeInvisible) << std::endl
         << "exportCollectionBasedBindings: " << TfStringify(exportArgs.exportCollectionBasedBindings) << std::endl
@@ -444,6 +454,8 @@ UsdMayaJobExportArgs::GetDefaultDictionary()
         d[UsdMayaJobExportArgsTokens->defaultCameras] = false;
         d[UsdMayaJobExportArgsTokens->defaultMeshScheme] = 
                 UsdGeomTokens->catmullClark.GetString();
+        d[UsdMayaJobExportArgsTokens->defaultUSDFormat] = 
+                UsdUsdcFileFormatTokens->Id.GetString();
         d[UsdMayaJobExportArgsTokens->eulerFilter] = false;
         d[UsdMayaJobExportArgsTokens->exportCollectionBasedBindings] = false;
         d[UsdMayaJobExportArgsTokens->exportColorSets] = true;

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -54,6 +54,7 @@ TF_DECLARE_PUBLIC_TOKENS(
     (compatibility) \
     (defaultCameras) \
     (defaultMeshScheme) \
+    (defaultUSDFormat) \
     (eulerFilter) \
     (exportCollectionBasedBindings) \
     (exportColorSets) \
@@ -122,6 +123,7 @@ struct UsdMayaJobExportArgs
 {
     const TfToken compatibility;
     const TfToken defaultMeshScheme;
+    const TfToken defaultUSDFormat;
     const bool eulerFilter;
     const bool excludeInvisible;
 

--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -54,6 +54,7 @@
 #include <mayaUsd/utils/stageCache.h>
 #include <mayaUsd/utils/util.h>
 
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 UsdMaya_ReadJob::UsdMaya_ReadJob(

--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -46,6 +46,7 @@
 #include <pxr/usd/usd/timeCode.h>
 #include <pxr/usd/usdGeom/scope.h>
 #include <pxr/usd/usdGeom/xform.h>
+#include <pxr/usd/usd/usdFileFormat.h>
 
 #include <mayaUsd/fileio/instancedNodeWriter.h>
 #include <mayaUsd/fileio/jobs/jobArgs.h>
@@ -388,7 +389,9 @@ UsdMayaWriteJobContext::_OpenFile(const std::string& filename, bool append)
             layer = existingLayer;
         }
         else {
-            layer = SdfLayer::CreateNew(filename);
+            SdfLayer::FileFormatArguments args;
+            args[UsdUsdFileFormatTokens->FormatArg] = mArgs.defaultUSDFormat.GetString();            
+            layer = SdfLayer::CreateNew(filename, "",  args);
         }
         if (!layer) {
             TF_RUNTIME_ERROR(

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -166,12 +166,20 @@ global proc int mayaUsdTranslatorExport (string $parent,
         string $instancesAnn = "Exports Maya instances as USD instanceable references.";
         string $subdMethodAnn = "Exports the selected subdivision method as a USD uniform attribute.";
         string $frameSamplesAnn = "Specifies the value(s) used to multi-sample time frames during animation export. Multiple values separated by a space (-0.1 0.2) are supported.";
+        string $defaultFormatAnn = "Select whether the .usd file is written out in binary or ASCII";
+        string $defaultFormatStatus = "Select whether the .usd file is written out in binary or ASCII. You can save a file in .usdc (binary), or .usda (ASCII) format. Manually entering a file name with an extension overrides the selection in this drop-down menu.";
 
         setParent $parent;
 
         columnLayout -adj true usdOptsCol;
 
         frameLayout -label "Output" -collapsable true -collapse false;
+            separator -style "none";
+
+            optionMenuGrp -l ".usd File Format:" -annotation $defaultFormatAnn -statusBarMessage $defaultFormatStatus defaultUSDFormatPopup;
+                menuItem -l "Binary" -ann "usdc";
+                menuItem -l "ASCII" -ann "usda";
+
             separator -style "none";
 
             textFieldGrp -l "Create USD Parent Scope:" -placeholderText "USD Prim Name" 
@@ -269,6 +277,8 @@ global proc int mayaUsdTranslatorExport (string $parent,
                     mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportColorSetsCheckBox");
                 } else if ($optionBreakDown[0] == "defaultMeshScheme") {
                     mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "defaultMeshSchemePopup");
+                } else if ($optionBreakDown[0] == "defaultUSDFormat") {
+                    mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "defaultUSDFormatPopup");                    
                 } else if ($optionBreakDown[0] == "animation") {
                     mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "animationCheckBox");
                 } else if ($optionBreakDown[0] == "eulerFilter") {
@@ -308,6 +318,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
         $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "exportUVs", "exportUVsCheckBox");
         $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "exportColorSets", "exportColorSetsCheckBox");
         $currentOptions = mayaUsdTranslatorExport_AppendFromPopup($currentOptions, "defaultMeshScheme", "defaultMeshSchemePopup");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromPopup($currentOptions, "defaultUSDFormat", "defaultUSDFormatPopup");
         $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "animation", "animationCheckBox");
         $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "eulerFilter", "eulerFilterCheckBox");
         $currentOptions = mayaUsdTranslatorExport_AppendFrameRange($currentOptions);

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -7,6 +7,7 @@ set(test_script_files
     testUsdExportConnected.py
     testUsdExportDisplayColor.py
     testUsdExportEulerFilter.py
+    testUsdExportFileFormat.py
     testUsdExportFilterTypes.py
     testUsdExportFrameOffset.py
     testUsdExportInstances.py

--- a/test/lib/usd/translators/testUsdExportFileFormat.py
+++ b/test/lib/usd/translators/testUsdExportFileFormat.py
@@ -1,0 +1,143 @@
+#!/pxrpythonsubst
+#
+# Copyright 2020 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import unittest
+
+from maya import cmds
+from maya import standalone
+
+from pxr import Usd
+from pxr import Sdf
+
+import fixturesUtils
+
+class testUsdExportFileFormat(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        fixturesUtils.setUpClass(__file__)
+        cmds.polySphere()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def GetUnderlyingUsdFileFormat(self, layer):
+        if Sdf.FileFormat.FindById('usda').CanRead(layer.identifier):
+            return 'usda'
+        elif Sdf.FileFormat.FindById('usdc').CanRead(layer.identifier):
+            return 'usdc'
+        return ''
+        
+    def testUsdExportFileFormat_cmd_default(self):
+        name = 'default.usd'
+        usdFile = os.path.abspath(name)
+
+        args = ()
+        kwargs = {
+            'file': usdFile,
+        }
+        cmds.mayaUSDExport(*args, **kwargs)
+
+        layer = Sdf.Layer.FindOrOpen(usdFile)
+        format = self.GetUnderlyingUsdFileFormat(layer)
+        self.assertEqual(format, 'usdc')
+
+    def testUsdExportFileFormat_cmd_usdc(self):
+        name = 'crate.usd'
+        usdFile = os.path.abspath(name)
+
+        args = ()
+        kwargs = {
+            'file': usdFile,
+            'defaultUSDFormat': 'usdc'
+        }
+        cmds.mayaUSDExport(*args, **kwargs)
+
+        layer = Sdf.Layer.FindOrOpen(usdFile)
+        format = self.GetUnderlyingUsdFileFormat(layer)
+        self.assertEqual(format, 'usdc')
+
+    def testUsdExportFileFormat_cmd_usda(self):
+        name = 'ascii.usd'
+        usdFile = os.path.abspath(name)
+
+        args = ()
+        kwargs = {
+            'file': usdFile,
+            'defaultUSDFormat': 'usda'
+        }
+        cmds.mayaUSDExport(*args, **kwargs)
+
+        layer = Sdf.Layer.FindOrOpen(usdFile)
+        format = self.GetUnderlyingUsdFileFormat(layer)
+        self.assertEqual(format, 'usda')
+
+    def testUsdExportFileFormat_file_cmd_default(self):
+        name = 'default.usd'
+        usdFile = os.path.abspath(name)
+
+        args = (usdFile,)
+        kwargs = {
+            'force': True,
+            'ea': True,
+            'typ': 'USD Export',
+            'options': ';defaultUSDFormat=usdc;'
+        }
+        cmds.file(*args, **kwargs)
+
+        layer = Sdf.Layer.FindOrOpen(usdFile)
+        format = self.GetUnderlyingUsdFileFormat(layer)
+        self.assertEqual(format, 'usdc')
+
+    def testUsdExportFileFormat_file_cmd_usdc(self):
+        name = 'crate.usd'
+        usdFile = os.path.abspath(name)
+
+        args = (usdFile,)
+        kwargs = {
+            'force': True,
+            'ea': True,
+            'typ': 'USD Export',
+            'options': ';defaultUSDFormat=usdc;'
+        }
+        cmds.file(*args, **kwargs)
+
+        layer = Sdf.Layer.FindOrOpen(usdFile)
+        format = self.GetUnderlyingUsdFileFormat(layer)
+        self.assertEqual(format, 'usdc')
+
+    def testUsdExportFileFormat_file_cmd_usda(self):
+        name = 'ascii.usd'
+        usdFile = os.path.abspath(name)
+
+        args = (usdFile,)
+        kwargs = {
+            'force': True,
+            'ea': True,
+            'typ': 'USD Export',
+            'options': ';defaultUSDFormat=usda;'
+        }
+        cmds.file(*args, **kwargs)
+
+        layer = Sdf.Layer.FindOrOpen(usdFile)
+        format = self.GetUnderlyingUsdFileFormat(layer)
+        self.assertEqual(format, 'usda')
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This branch is everything from https://github.com/Autodesk/maya-usd/pull/591 including some requested changes to use the file format id's, and a test added, but redone on the latest dev branch.  I had set this aside while there was some ongoing work on the tests and when coming back to it after everything else went in I ended up just cherry picking in the original changes I had into a new branch.