### PR TITLE
Add menu in Hierarchy View to reset the model and variant selections

### DIFF
--- a/lib/usd/ui/TreeModel.cpp
+++ b/lib/usd/ui/TreeModel.cpp
@@ -55,24 +55,24 @@ TreeItem* findTreeItem(TreeModel* treeModel, const QModelIndex& parent, std::fun
 
 void resetVariantToPrimSelection(TreeItem* variantItem)
 {
-	if (variantItem) {
-		UsdPrim prim = variantItem->prim();
-		assert(prim.IsValid() && prim.HasVariantSets());
+	assert(variantItem);
 
-		UsdVariantSets varSets = prim.GetVariantSets();
+	UsdPrim prim = variantItem->prim();
+	assert(prim.IsValid() && prim.HasVariantSets());
 
-		std::vector<std::string> usdVarSetNames;
-		varSets.GetNames(&usdVarSetNames);
+	UsdVariantSets varSets = prim.GetVariantSets();
 
-		QStringList qtVarNames;
-		for (auto it=usdVarSetNames.crbegin(); it != usdVarSetNames.crend(); it++)
-		{
-			UsdVariantSet varSet1 = varSets.GetVariantSet(*it);
-			qtVarNames.push_back(QString::fromStdString(varSet1.GetVariantSelection()));
-		}
+	std::vector<std::string> usdVarSetNames;
+	varSets.GetNames(&usdVarSetNames);
 
-		variantItem->setData(qtVarNames, ItemDelegate::kVariantSelectionRole);
+	QStringList qtVarNames;
+	for (auto it=usdVarSetNames.crbegin(); it != usdVarSetNames.crend(); it++)
+	{
+		UsdVariantSet varSet1 = varSets.GetVariantSet(*it);
+		qtVarNames.push_back(QString::fromStdString(varSet1.GetVariantSelection()));
 	}
+
+	variantItem->setData(qtVarNames, ItemDelegate::kVariantSelectionRole);
 }
 
 void resetAllVariants(TreeModel* treeModel, const QModelIndex& parent)
@@ -81,9 +81,8 @@ void resetAllVariants(TreeModel* treeModel, const QModelIndex& parent)
 	{
 		QModelIndex variantIndex = treeModel->index(r, TreeModel::kTreeColumn_Variants, parent);
 		TreeItem* variantItem = static_cast<TreeItem*>(treeModel->itemFromIndex(variantIndex));
-		assert(variantItem);
 
-		if (variantItem->variantSelectionModified()) 
+		if (nullptr != variantItem && variantItem->variantSelectionModified()) 
 		{
 			resetVariantToPrimSelection(variantItem);
 		}

--- a/lib/usd/ui/TreeModel.h
+++ b/lib/usd/ui/TreeModel.h
@@ -80,6 +80,8 @@ public:
 
 	void onItemClicked(TreeItem* item);
 
+	void resetVariants();
+	
 private:
 	void uncheckEnableTree();
 	void checkEnableItem(TreeItem* item);

--- a/lib/usd/ui/USDImportDialog.cpp
+++ b/lib/usd/ui/USDImportDialog.cpp
@@ -175,7 +175,7 @@ void USDImportDialog::onItemClicked(const QModelIndex& index)
 
 void USDImportDialog::onResetFileTriggered()
 {
-	if (fTreeModel)
+	if (nullptr != fTreeModel)
 	{
 		fTreeModel->resetVariants();
 		fTreeModel->setRootPrimPath("/");

--- a/lib/usd/ui/USDImportDialog.cpp
+++ b/lib/usd/ui/USDImportDialog.cpp
@@ -71,6 +71,7 @@ USDImportDialog::USDImportDialog(const std::string& filename, const ImportData* 
 	fUI->treeView->setAlternatingRowColors(true);
 	fUI->treeView->setSelectionMode(QAbstractItemView::SingleSelection);
 	QObject::connect(fUI->treeView, SIGNAL(clicked(const QModelIndex&)), this, SLOT(onItemClicked(const QModelIndex&)));
+	QObject::connect(fUI->actionReset_File, SIGNAL(triggered(bool)), this, SLOT(onResetFileTriggered()));
 
 	QHeaderView* header = fUI->treeView->header();
 
@@ -169,6 +170,15 @@ void USDImportDialog::onItemClicked(const QModelIndex& index)
 			if (item->checkState() == TreeItem::CheckState::kChecked)
 				fUI->treeView->expand(index);
 		}
+	}
+}
+
+void USDImportDialog::onResetFileTriggered()
+{
+	if (fTreeModel)
+	{
+		fTreeModel->resetVariants();
+		fTreeModel->setRootPrimPath("/");
 	}
 }
 

--- a/lib/usd/ui/USDImportDialog.h
+++ b/lib/usd/ui/USDImportDialog.h
@@ -69,6 +69,7 @@ public:
 
 private Q_SLOTS:
 	void onItemClicked(const QModelIndex&);
+	void onResetFileTriggered();
 
 protected:
 	// Reference to the Qt UI View of the dialog:

--- a/lib/usd/ui/USDImportDialog.ui
+++ b/lib/usd/ui/USDImportDialog.ui
@@ -23,7 +23,75 @@
    <bool>false</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QMenuBar" name="menuBar">
+     <widget class="QMenu" name="menuEdit">
+      <property name="title">
+       <string>Edit</string>
+      </property>
+      <addaction name="actionReset_File"/>
+     </widget>
+     <addaction name="menuEdit"/>
+    </widget>
+   </item>   
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <property name="topMargin">
+      <number>7</number>
+     </property>
+     <property name="bottomMargin">
+      <number>7</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="autoFillBackground">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>USD File Path:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="usdFilePath">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="selectPrims">
+     <property name="text">
+      <string>Select the prim(s) you'd like to import. Switch variants accordingly.</string>
+     </property>
+    </widget>
+   </item>   
    <item row="3" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QTreeView" name="treeView">
+       <property name="autoFillBackground">
+        <bool>true</bool>
+       </property>
+       <property name="editTriggers">
+        <set>QAbstractItemView::NoEditTriggers</set>
+       </property>
+       <property name="selectionMode">
+        <enum>QAbstractItemView::ExtendedSelection</enum>
+       </property>
+       <property name="uniformRowHeights">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="topMargin">
       <number>7</number>
@@ -78,64 +146,17 @@
      </item>
     </layout>
    </item>
-   <item row="0" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <property name="topMargin">
-      <number>7</number>
-     </property>
-     <property name="bottomMargin">
-      <number>7</number>
-     </property>
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="autoFillBackground">
-        <bool>true</bool>
-       </property>
-       <property name="text">
-        <string>USD File Path:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="usdFilePath">
-        <property name="readOnly">
-          <bool>true</bool>
-        </property>
-        <property name="enabled">
-          <bool>false</bool>
-        </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <widget class="QTreeView" name="treeView">
-       <property name="autoFillBackground">
-        <bool>true</bool>
-       </property>
-       <property name="editTriggers">
-        <set>QAbstractItemView::NoEditTriggers</set>
-       </property>
-       <property name="selectionMode">
-        <enum>QAbstractItemView::ExtendedSelection</enum>
-       </property>
-       <property name="uniformRowHeights">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="selectPrims">
-     <property name="text">
-      <string>Select the prim(s) you'd like to import. Switch variants accordingly.</string>
-     </property>
-    </widget>
-   </item>
   </layout>
+  <action name="actionEdit">
+   <property name="text">
+    <string>Edit</string>
+   </property>
+  </action>
+  <action name="actionReset_File">
+   <property name="text">
+    <string>Reset File</string>
+   </property>
+  </action>
  </widget>
  <resources/>
  <connections>


### PR DESCRIPTION
New menu item in the Hierarchy View dialog that will reset all of the edited variant sets back to what is in the usd file, and sets the checked state back to the root selection