### PR TITLE
Selection by kind

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -108,10 +108,11 @@ namespace
 
     //! \brief  Query the Kind to be selected from viewport.
     //! \return A Kind token (https://graphics.pixar.com/usd/docs/api/kind_page_front.html). If the
-    //!         token is empty, the exact prim that gets picked from viewport will be selected.
+    //!         token is empty or non-existing in the hierarchy, the exact prim that gets picked
+    //!         in the viewport will be selected.
     TfToken GetSelectionKind()
     {
-        static const MString kOptionVarName("usdSelectionKind");
+        static const MString kOptionVarName("UsdSelectionKind");
 
         if (MGlobal::optionVarExists(kOptionVarName)) {
             MString optionVarValue = MGlobal::optionVarStringValue(kOptionVarName);

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -226,6 +226,9 @@ private:
 #if defined(WANT_UFE_BUILD) && defined(MAYA_ENABLE_UPDATE_FOR_SELECTION)
     //! Adjustment mode for global selection list: ADD, REMOVE, REPLACE, XOR
     MGlobal::ListAdjustment _globalListAdjustment;
+
+    //! Token of the Kind to be selected from viewport. If it empty, select the exact prims.
+    TfToken                 _selectionKind;
 #endif
 };
 


### PR DESCRIPTION
The pull request is to add a "UsdSelectionKind" option var to override selection
behavior (GUI support is coming separately).

The default behavior is to select the exact prim which is picked in the viewport.

If the option var is assigned with a non-empty string to indicate a Kind token,
the nearest ancestor that is assigned with that Kind or a subcategory of that
Kind will be selected when a prim is picked in the viewport. If the prim doesn't
have any qualified ancester, it falls back to the default behavior (but it can be
slower due to the cost of walking the scene hierarchy).

If the option var is undefined or empty, the default behavior will be used to
select the exact prim.

For details about Kind, please refer to [Kind : Extensible Categorization](https://graphics.pixar.com/usd/docs/api/kind_page_front.html).

Examples:

// Select the nearing ancester which is a model or its subcategory.
optionVar -sv "UsdSelectionKind" "model";

// Select the nearing ancester which is a group or its subcategory.
optionVar -sv "UsdSelectionKind" "group";

// Select the nearing ancester which is a user-defined kind or its subcategory.
optionVar -sv "UsdSelectionKind" "user-defined";

// Select the exact prim that is picked in the viewport.
optionVar -sv "UsdSelectionKind" "";