### PR TITLE
[mtoh] Draw all the things that mtoh will not in the post-render pass.

### DIFF
--- a/lib/mayaUsd/render/mayaToHydra/renderGlobals.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderGlobals.cpp
@@ -299,8 +299,6 @@ MObject MtohCreateRenderGlobals() {
                 defGlobals.delegateParams.maximumShadowMapResolution);
             return o;
         });
-    static const TfTokenVector selectionOverlays{MtohTokens->UseHdSt,
-                                                 MtohTokens->UseVp2};
     _CreateBoolAttribute(
         node, _tokens->mtohWireframeSelectionHighlight,
         defGlobals.wireframeSelectionHighlight);

--- a/lib/mayaUsd/render/mayaToHydra/renderGlobals.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderGlobals.cpp
@@ -44,7 +44,6 @@ TF_DEFINE_PRIVATE_TOKENS(
     (mtohColorSelectionHighlightColor)
     (mtohColorSelectionHighlightColorA)
     (mtohWireframeSelectionHighlight)
-    (mtohSelectionOverlay)
     (mtohColorQuantization)
     (mtohSelectionOutline)
     (mtohEnableMotionSamples)
@@ -201,16 +200,6 @@ void _CreateStringAttribute(
         });
 }
 
-void _GetEnum(
-    const MFnDependencyNode& node, const TfToken& attrName, TfToken& out) {
-    const auto plug = node.findPlug(attrName.GetText(), true);
-    if (plug.isNull()) { return; }
-    MStatus status;
-    MFnEnumAttribute eAttr(plug.attribute(), &status);
-    if (!status) { return; }
-    out = TfToken(eAttr.fieldName(plug.asShort()).asChar());
-}
-
 template <typename T>
 void _GetFromPlug(const MPlug& plug, T& out) {
     assert(false);
@@ -312,9 +301,6 @@ MObject MtohCreateRenderGlobals() {
         });
     static const TfTokenVector selectionOverlays{MtohTokens->UseHdSt,
                                                  MtohTokens->UseVp2};
-    _CreateEnumAttribute(
-        node, _tokens->mtohSelectionOverlay, selectionOverlays,
-        defGlobals.selectionOverlay);
     _CreateBoolAttribute(
         node, _tokens->mtohWireframeSelectionHighlight,
         defGlobals.wireframeSelectionHighlight);
@@ -406,7 +392,6 @@ MtohRenderGlobals MtohGetRenderGlobals() {
     _GetAttribute(
         node, MtohTokens->mtohMaximumShadowMapResolution,
         ret.delegateParams.maximumShadowMapResolution);
-    _GetEnum(node, _tokens->mtohSelectionOverlay, ret.selectionOverlay);
     _GetAttribute(
         node, _tokens->mtohWireframeSelectionHighlight,
         ret.wireframeSelectionHighlight);

--- a/lib/mayaUsd/render/mayaToHydra/renderGlobals.h
+++ b/lib/mayaUsd/render/mayaToHydra/renderGlobals.h
@@ -38,7 +38,6 @@ struct MtohRenderGlobals {
     ~MtohRenderGlobals() = default;
     HdMayaParams delegateParams;
     GfVec4f colorSelectionHighlightColor = GfVec4f(1.0f, 1.0f, 0.0f, 0.5f);
-    TfToken selectionOverlay = MtohTokens->UseVp2;
 #if USD_VERSION_NUM >= 2005
     float outlineSelectionWidth = 4.f;
 #endif

--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
@@ -323,14 +323,6 @@ void MtohRenderOverride::_UpdateRenderGlobals() {
     _renderGlobalsHaveChanged = false;
     _globals = MtohGetRenderGlobals();
     _UpdateRenderDelegateOptions();
-    if (_isUsingHdSt && !_operations.empty()) {
-        const auto vp2Overlay = _globals.selectionOverlay == MtohTokens->UseVp2;
-        auto* mayaRender = reinterpret_cast<HdMayaSceneRender*>(_operations[0]);
-        if (mayaRender->_drawSelectionOverlay != vp2Overlay) {
-            mayaRender->_drawSelectionOverlay = vp2Overlay;
-            MGlobal::executeCommandOnIdle("refresh -f;");
-        }
-    }
 }
 
 void MtohRenderOverride::_UpdateRenderDelegateOptions() {
@@ -527,14 +519,11 @@ MStatus MtohRenderOverride::Render(const MHWRender::MDrawContext& drawContext) {
 
         // This causes issues with the embree delegate and potentially others.
         // (i.e. rendering a wireframe via collections isn't supported by other delegates)
-        if (_globals.wireframeSelectionHighlight &&
-            _globals.selectionOverlay == MtohTokens->UseHdSt && _isUsingHdSt) {
-            if (!_selectionCollection.GetRootPaths().empty()) {
-                _taskController->SetCollection(_selectionCollection);
-                renderFrame();
-                // XXX: This call isn't 'free' and will be done again on the next MtohRenderOverride::Render call anyway
-                _taskController->SetCollection(_renderCollection);
-            }
+        if (_globals.wireframeSelectionHighlight && !_selectionCollection.GetRootPaths().empty()) {
+            _taskController->SetCollection(_selectionCollection);
+            renderFrame();
+            // XXX: This call isn't 'free' and will be done again on the next MtohRenderOverride::Render call anyway
+            _taskController->SetCollection(_renderCollection);
         }
     } else {
         renderFrame(true);
@@ -739,20 +728,17 @@ MStatus MtohRenderOverride::setup(const MString& destination) {
     if (renderer == nullptr) { return MStatus::kFailure; }
 
     if (_operations.empty()) {
-        // Draw Misc UI elements (cameras, CVs, grid, etc), as well as
-        // possibly selection (depending on if we're using HdSt, and the
-        // selection overlay mode)
-        _operations.push_back(new HdMayaSceneRender(
-            "HydraRenderOverride_Scene",
-            !_isUsingHdSt || _globals.selectionOverlay == MtohTokens->UseVp2));
+        // Clear and draw the grid
+        _operations.push_back(
+            new HdMayaPreRender("HydraRenderOverride_PreScene"));
 
         // The main hydra render
         _operations.push_back(
             new HdMayaRender("HydraRenderOverride_Hydra", this));
 
-        // Draw maniuplators
+        // Draw scene elements (cameras, CVs, grid, shapes not pushed into hydra)
         _operations.push_back(
-            new HdMayaManipulatorRender("HydraRenderOverride_Manipulator"));
+            new HdMayaPostRender("HydraRenderOverride_PostScene"));
 
         // Draw HUD elements
         _operations.push_back(new MHWRender::MHUDRender());

--- a/lib/mayaUsd/render/mayaToHydra/tokens.h
+++ b/lib/mayaUsd/render/mayaToHydra/tokens.h
@@ -30,8 +30,6 @@ PXR_NAMESPACE_OPEN_SCOPE
 // clang-format off
 #define MTOH_TOKENS \
     ((HdStormRendererPlugin, HD_STORM_PLUGIN_NAME)) \
-    (UseHdSt) \
-    (UseVp2)  \
     (mtohMaximumShadowMapResolution)
 // clang-format on
 

--- a/lib/mayaUsd/render/mayaToHydra/utils.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/utils.cpp
@@ -52,7 +52,6 @@ global proc {{override}}OptionBox() {
     columnLayout;
     attrControlGrp -label "Enable Motion Samples" -attribute "defaultRenderGlobals.mtohEnableMotionSamples" -changeCommand $cc;
     attrControlGrp -label "Texture Memory Per Texture (KB)" -attribute "defaultRenderGlobals.mtohTextureMemoryPerTexture" -changeCommand $cc;
-    attrControlGrp -label "OpenGL Selection Overlay" -attribute "defaultRenderGlobals.mtohSelectionOverlay" -changeCommand $cc;
     attrControlGrp -label "Show Wireframe on Selected Objects" -attribute "defaultRenderGlobals.mtohWireframeSelectionHighlight" -changeCommand $cc;
     attrControlGrp -label "Highlight Selected Objects" -attribute "defaultRenderGlobals.mtohColorSelectionHighlight" -changeCommand $cc;
     attrControlGrp -label "Highlight Color for Selected Objects" -attribute "defaultRenderGlobals.mtohColorSelectionHighlightColor" -changeCommand $cc;


### PR DESCRIPTION
There still seems to be a lot of things not drawn when in mtoh (Nurbs, SubdivSurf, GreasePencils).
This may or may not have been introduced in aeb87c46, but this simplifies the Pre & Post render passes to just not draw Meshes & PluginShapes (for UsdProxies) in the _PostRender_.

Additionally the HdSt menu for selection is removed, as I seem to be able to accomplish this with the other two checkboxes for wireframe & overlay.  And I haven't been able to get the menu to show what it's purpose is. (perhaps @pmolodo can shed some light on what it does or if the original intent is still valid).