### PR TITLE
[mtoh] Support USD enableSceneMaterials better.

### DIFF
--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
@@ -449,7 +449,7 @@ MStatus MtohRenderOverride::Render(const MHWRender::MDrawContext& drawContext) {
 
     HdxRenderTaskParams params;
     params.enableLighting = true;
-    params.enableSceneMaterials = true;
+    params.enableSceneMaterials = !(drawContext.getDisplayStyle() & MHWRender::MFrameContext::kDefaultMaterial);
 
     /* TODO: Find replacement
      * if (displayStyle & MHWRender::MFrameContext::kBoundingBox) {

--- a/lib/usd/hdMaya/adapters/proxyAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/proxyAdapter.cpp
@@ -158,7 +158,8 @@ void HdMayaProxyAdapter::CreateUsdImagingDelegate() {
     _isPopulated = false;
 }
 
-void HdMayaProxyAdapter::PreFrame() {
+void HdMayaProxyAdapter::PreFrame(const MHWRender::MDrawContext& context) {
+    _usdDelegate->SetSceneMaterialsEnabled(!(context.getDisplayStyle() & MHWRender::MFrameContext::kDefaultMaterial));
     _usdDelegate->ApplyPendingUpdates();
     // TODO: set this only when time is actually changed
     _usdDelegate->SetTime(_proxy->getTime());

--- a/lib/usd/hdMaya/adapters/proxyAdapter.h
+++ b/lib/usd/hdMaya/adapters/proxyAdapter.h
@@ -37,7 +37,7 @@ public:
 
     void CreateUsdImagingDelegate();
 
-    void PreFrame();
+    void PreFrame(const MHWRender::MDrawContext& context);
 
     MayaUsdProxyShapeBase* GetProxy() { return _proxy; }
 

--- a/lib/usd/hdMaya/delegates/proxyDelegate.cpp
+++ b/lib/usd/hdMaya/delegates/proxyDelegate.cpp
@@ -189,7 +189,7 @@ void HdMayaProxyDelegate::Populate() {
 
 void HdMayaProxyDelegate::PreFrame(const MHWRender::MDrawContext& context) {
     std::lock_guard<std::mutex> lock(_allAdaptersMutex);
-    for (auto adapter : _allAdapters) { adapter->PreFrame(); }
+    for (auto adapter : _allAdapters) { adapter->PreFrame(context); }
 }
 
 #if WANT_UFE_BUILD

--- a/lib/usd/hdMaya/delegates/sceneDelegate.h
+++ b/lib/usd/hdMaya/delegates/sceneDelegate.h
@@ -251,6 +251,7 @@ private:
     std::vector<SdfPath> _materialTagsChanged;
 
     SdfPath _fallbackMaterial;
+    bool _enableMaterials = false;
 };
 
 typedef std::shared_ptr<HdMayaSceneDelegate> MayaSceneDelegateSharedPtr;


### PR DESCRIPTION
This pushes Maya's "Use default material" toggle into Hydra.  Quick toggle to ignore all shaders is useful (particularly fo Storm and textures)