### PR TITLE
[mtoh] Remove explicit call to HdChangeTracker::RprimInserted.

### DIFF
--- a/lib/usd/hdMaya/adapters/meshAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/meshAdapter.cpp
@@ -74,8 +74,7 @@ public:
     void Populate() override {
         if (_isPopulated) { return; }
         GetDelegate()->InsertRprim(
-            HdPrimTypeTokens->mesh, GetID(), HdChangeTracker::AllDirty,
-            GetInstancerID());
+            HdPrimTypeTokens->mesh, GetID(), GetInstancerID());
         _isPopulated = true;
     }
 

--- a/lib/usd/hdMaya/adapters/nurbsCurveAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/nurbsCurveAdapter.cpp
@@ -60,7 +60,7 @@ public:
 
     void Populate() override {
         GetDelegate()->InsertRprim(
-            HdPrimTypeTokens->basisCurves, GetID(), HdChangeTracker::AllDirty);
+            HdPrimTypeTokens->basisCurves, GetID());
     }
 
     void CreateCallbacks() override {

--- a/lib/usd/hdMaya/delegates/delegateCtx.cpp
+++ b/lib/usd/hdMaya/delegates/delegateCtx.cpp
@@ -69,14 +69,12 @@ HdMayaDelegateCtx::HdMayaDelegateCtx(const InitData& initData)
 }
 
 void HdMayaDelegateCtx::InsertRprim(
-    const TfToken& typeId, const SdfPath& id, HdDirtyBits initialBits,
-    const SdfPath& instancerId) {
+    const TfToken& typeId, const SdfPath& id, const SdfPath& instancerId) {
     if (!instancerId.IsEmpty()) {
         GetRenderIndex().InsertInstancer(this, instancerId);
         GetChangeTracker().InstancerInserted(id);
     }
     GetRenderIndex().InsertRprim(typeId, this, id, instancerId);
-    GetChangeTracker().RprimInserted(id, initialBits);
 }
 
 void HdMayaDelegateCtx::InsertSprim(

--- a/lib/usd/hdMaya/delegates/delegateCtx.h
+++ b/lib/usd/hdMaya/delegates/delegateCtx.h
@@ -45,7 +45,7 @@ public:
 
     HDMAYA_API
     void InsertRprim(
-        const TfToken& typeId, const SdfPath& id, HdDirtyBits initialBits,
+        const TfToken& typeId, const SdfPath& id,
         const SdfPath& instancerId = {});
     HDMAYA_API
     void InsertSprim(


### PR DESCRIPTION
HdRenderIndex::InsertRprim will do this using HdRprim::GetInitialDirtyBitsMask().
Additionally, the previous use of HdChangeTracker::AllDirty could cause over-invalidation:
 If the delegate doesn't have knowledge of those bits,  it won't necessarily clear them leading to `HdRprim::Sync` called on every `engine.Execute` invocation.