### PR TITLE
[mtoh] Fix stage-repopulation.

### DIFF
--- a/lib/usd/hdMaya/adapters/proxyAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/proxyAdapter.cpp
@@ -176,7 +176,13 @@ void HdMayaProxyAdapter::_OnStageSet(const MayaUsdProxyStageSetNotice& notice)
                 "(ProxyShape: "
                 "%s)\n",
                 GetDagPath().partialPathName().asChar());
+
         CreateUsdImagingDelegate();
+        auto stage = _proxy->getUsdStage();
+        if (_usdDelegate && stage) {
+            _usdDelegate->Populate(stage->GetPseudoRoot());
+            _isPopulated = true;
+        }
     }
 }
 


### PR DESCRIPTION
When rendering via **mtoh**, changes to **UsdProxy.filepath** aren't working.
(If not always, at least when **VP_RENDER_DELEGATE=0**)