### PR TITLE
Convenience function for printing the list of queried composition arcs in order

### DIFF
--- a/lib/usd/utils/util.cpp
+++ b/lib/usd/utils/util.cpp
@@ -23,7 +23,6 @@
 #include <pxr/usd/usd/stage.h>
 
 #include <set>
-#include <iostream>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -186,23 +185,25 @@ hasSpecs(const UsdPrim& prim)
     return found;
 }
 
-
 void
-printCompositionQuery(const UsdPrim& prim)
+printCompositionQuery(const UsdPrim& prim, std::ostream& os)
 {
     UsdPrimCompositionQuery query(prim);
-    std::cout << "[\n";
-    // the composition arcs are always returned in order from strongest
+
+    os << "[\n";
+
+    // the composition arcs are always returned in order from strongest 
     // to weakest regardless of the filter.
     for (const auto& arc : query.GetCompositionArcs()) {
         const auto& arcDic = getDict(arc);
-        std::cout << "{\n";
-        std::for_each(arcDic.begin(), arcDic.end(), [&](const auto& it) {
-            std::cout << it.first << ": " << it.second << '\n';
+        os << "{\n";
+        std::for_each(arcDic.begin(),arcDic.end(), [&](const auto& it) {
+            os << it.first << ": " << it.second << '\n';
         });
-        std::cout << "}\n";
+        os << "}\n";
     }
-    std::cout << "]\n\n";
+
+    os << "]\n\n";
 }
 
 } // MayaUsdUtils

--- a/lib/usd/utils/util.h
+++ b/lib/usd/utils/util.h
@@ -55,7 +55,7 @@ namespace MayaUsdUtils {
 
     //! Convenience function for printing the list of queried composition arcs in order. 
     MAYA_USD_UTILS_PUBLIC
-    void printCompositionQuery(const UsdPrim&);
+    void printCompositionQuery(const UsdPrim&, std::ostream&);
 
 } // namespace MayaUsdUtils
 

--- a/lib/usd/utils/util.h
+++ b/lib/usd/utils/util.h
@@ -53,6 +53,10 @@ namespace MayaUsdUtils {
     MAYA_USD_UTILS_PUBLIC
     bool hasSpecs(const UsdPrim&);
 
+    //! Convenience function for printing the list of queried composition arcs in order. 
+    MAYA_USD_UTILS_PUBLIC
+    void printCompositionQuery(const UsdPrim&);
+
 } // namespace MayaUsdUtils
 
 #endif // MAYAUSDUTILS_UTIL_H


### PR DESCRIPTION
Often time I need to debug the queried composition arcs in C++ and this function helps to pretty-print them.

Same thing can also be achieved in python. See testUsdPrimCompositionQuery here :

https://github.com/PixarAnimationStudios/USD/blob/ebac0a8b6703f4fa1c27115f1f013bb9819662f4/pxr/usd/usd/testenv/testUsdPrimCompositionQuery.py#L28