### PR TITLE
Added implementation for new UFE unparent interface (MAYA-105276)

### DIFF
--- a/lib/mayaUsd/ufe/Global.cpp
+++ b/lib/mayaUsd/ufe/Global.cpp
@@ -174,5 +174,10 @@ Ufe::Rtid getUsdRunTimeId()
     return g_USDRtid;
 }
 
+Ufe::Rtid getMayaRunTimeId()
+{
+    return g_MayaRtid;
+}
+
 } // namespace ufe
 } // namespace MayaUsd

--- a/lib/mayaUsd/ufe/Global.h
+++ b/lib/mayaUsd/ufe/Global.h
@@ -38,5 +38,9 @@ MStatus finalize();
 MAYAUSD_CORE_PUBLIC
 Ufe::Rtid getUsdRunTimeId();
 
+//! Return the run-time ID allocated to Maya.
+MAYAUSD_CORE_PUBLIC
+Ufe::Rtid getMayaRunTimeId();
+
 } // namespace ufe
 } // namespace MayaUsd

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
@@ -25,6 +25,7 @@
 #include <pxr/usd/usd/stage.h>
 
 #include <mayaUsd/ufe/Utils.h>
+#include <mayaUsd/ufe/Global.h>
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 #if UFE_PREVIEW_VERSION_NUM >= 2013
@@ -153,10 +154,12 @@ Ufe::SceneItem::Ptr ProxyShapeHierarchy::parent() const
 	return fMayaHierarchy->parent();
 }
 
+#if UFE_PREVIEW_VERSION_NUM < 2018
 Ufe::AppendedChild ProxyShapeHierarchy::appendChild(const Ufe::SceneItem::Ptr& child)
 {
 	throw std::runtime_error("ProxyShapeHierarchy::appendChild() not implemented");
 }
+#endif
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 #if UFE_PREVIEW_VERSION_NUM >= 2013
@@ -210,6 +213,30 @@ Ufe::UndoableCommand::Ptr ProxyShapeHierarchy::createGroupCmd(const Ufe::Selecti
 }
 
 #endif // UFE_PREVIEW_VERSION_NUM
+
+#if UFE_PREVIEW_VERSION_NUM >= 2018
+
+Ufe::SceneItem::Ptr ProxyShapeHierarchy::defaultParent() const
+{
+    // Default parent for Maya nodes is "|world".
+    return createItem(Ufe::Path(Ufe::PathSegment(Ufe::PathComponent("world"), 
+                                                 getMayaRunTimeId(), '|')));
+}
+
+Ufe::SceneItem::Ptr ProxyShapeHierarchy::insertChild(
+        const Ufe::SceneItem::Ptr& ,
+        const Ufe::SceneItem::Ptr& 
+)
+{
+    // Should be possible to implement trivially when support for returning the
+    // result of the parent command (MAYA-105278) is implemented.  For now,
+    // Ufe::Hierarchy::insertChildCmd() returns a base class
+    // Ufe::UndoableCommand::Ptr object, from which we can't retrieve the added
+    // child.  PPT, 13-Jul-2020.
+    return nullptr;
+}
+
+#endif
 
 #endif // UFE_V2_FEATURES_AVAILABLE
 

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
@@ -218,9 +218,8 @@ Ufe::UndoableCommand::Ptr ProxyShapeHierarchy::createGroupCmd(const Ufe::Selecti
 
 Ufe::SceneItem::Ptr ProxyShapeHierarchy::defaultParent() const
 {
-    // Default parent for Maya nodes is "|world".
-    return createItem(Ufe::Path(Ufe::PathSegment(Ufe::PathComponent("world"), 
-                                                 getMayaRunTimeId(), '|')));
+    // Maya shape nodes cannot be unparented.
+    return nullptr;
 }
 
 Ufe::SceneItem::Ptr ProxyShapeHierarchy::insertChild(

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
@@ -177,6 +177,23 @@ Ufe::UndoableCommand::Ptr ProxyShapeHierarchy::insertChildCmd(
 }
 #endif
 
+#if UFE_PREVIEW_VERSION_NUM >= 2018
+
+Ufe::SceneItem::Ptr ProxyShapeHierarchy::insertChild(
+        const Ufe::SceneItem::Ptr& ,
+        const Ufe::SceneItem::Ptr& 
+)
+{
+    // Should be possible to implement trivially when support for returning the
+    // result of the parent command (MAYA-105278) is implemented.  For now,
+    // Ufe::Hierarchy::insertChildCmd() returns a base class
+    // Ufe::UndoableCommand::Ptr object, from which we can't retrieve the added
+    // child.  PPT, 13-Jul-2020.
+    return nullptr;
+}
+
+#endif
+
 #if UFE_PREVIEW_VERSION_NUM < 2017
 
 Ufe::SceneItem::Ptr ProxyShapeHierarchy::createGroup(const Ufe::PathComponent& name) const
@@ -219,19 +236,6 @@ Ufe::UndoableCommand::Ptr ProxyShapeHierarchy::createGroupCmd(const Ufe::Selecti
 Ufe::SceneItem::Ptr ProxyShapeHierarchy::defaultParent() const
 {
     // Maya shape nodes cannot be unparented.
-    return nullptr;
-}
-
-Ufe::SceneItem::Ptr ProxyShapeHierarchy::insertChild(
-        const Ufe::SceneItem::Ptr& ,
-        const Ufe::SceneItem::Ptr& 
-)
-{
-    // Should be possible to implement trivially when support for returning the
-    // result of the parent command (MAYA-105278) is implemented.  For now,
-    // Ufe::Hierarchy::insertChildCmd() returns a base class
-    // Ufe::UndoableCommand::Ptr object, from which we can't retrieve the added
-    // child.  PPT, 13-Jul-2020.
     return nullptr;
 }
 

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
@@ -61,7 +61,9 @@ public:
 	bool hasChildren() const override;
 	Ufe::SceneItemList children() const override;
 	Ufe::SceneItem::Ptr parent() const override;
+#if UFE_PREVIEW_VERSION_NUM < 2018
 	Ufe::AppendedChild appendChild(const Ufe::SceneItem::Ptr& child) override;
+#endif
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 #if UFE_PREVIEW_VERSION_NUM >= 2013
@@ -79,6 +81,13 @@ public:
 	Ufe::UndoableCommand::Ptr createGroupCmd(const Ufe::Selection& selection, const Ufe::PathComponent& name) const override;
 #endif
 
+#if UFE_PREVIEW_VERSION_NUM >= 2018
+    Ufe::SceneItem::Ptr defaultParent() const override;
+    Ufe::SceneItem::Ptr insertChild(
+        const Ufe::SceneItem::Ptr& child,
+        const Ufe::SceneItem::Ptr& pos
+    ) override;
+#endif
 #endif
 
 private:

--- a/lib/mayaUsd/ufe/UsdHierarchy.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchy.cpp
@@ -180,6 +180,23 @@ Ufe::UndoableCommand::Ptr UsdHierarchy::insertChildCmd(
 }
 #endif
 
+#if UFE_PREVIEW_VERSION_NUM >= 2018
+
+Ufe::SceneItem::Ptr UsdHierarchy::insertChild(
+        const Ufe::SceneItem::Ptr& ,
+        const Ufe::SceneItem::Ptr& 
+)
+{
+    // Should be possible to implement trivially when support for returning the
+    // result of the parent command (MAYA-105278) is implemented.  For now,
+    // Ufe::Hierarchy::insertChildCmd() returns a base class
+    // Ufe::UndoableCommand::Ptr object, from which we can't retrieve the added
+    // child.  PPT, 13-Jul-2020.
+    return nullptr;
+}
+
+#endif // UFE_PREVIEW_VERSION_NUM
+
 #if UFE_PREVIEW_VERSION_NUM < 2017
 // Create a transform.
 Ufe::SceneItem::Ptr UsdHierarchy::createGroup(const Ufe::PathComponent& name) const
@@ -242,6 +259,7 @@ Ufe::UndoableCommand::Ptr UsdHierarchy::createGroupCmd(const Ufe::Selection& sel
 #endif // UFE_PREVIEW_VERSION_NUM
 
 #if UFE_PREVIEW_VERSION_NUM >= 2018
+
 Ufe::SceneItem::Ptr UsdHierarchy::defaultParent() const
 {
     // Default parent for USD nodes is the pseudo-root of their stage, which is
@@ -252,19 +270,6 @@ Ufe::SceneItem::Ptr UsdHierarchy::defaultParent() const
 #endif
     auto proxyShapePath = path.popSegment();
     return createItem(proxyShapePath);
-}
-
-Ufe::SceneItem::Ptr UsdHierarchy::insertChild(
-        const Ufe::SceneItem::Ptr& ,
-        const Ufe::SceneItem::Ptr& 
-)
-{
-    // Should be possible to implement trivially when support for returning the
-    // result of the parent command (MAYA-105278) is implemented.  For now,
-    // Ufe::Hierarchy::insertChildCmd() returns a base class
-    // Ufe::UndoableCommand::Ptr object, from which we can't retrieve the added
-    // child.  PPT, 13-Jul-2020.
-    return nullptr;
 }
 
 #endif // UFE_PREVIEW_VERSION_NUM

--- a/lib/mayaUsd/ufe/UsdHierarchy.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchy.cpp
@@ -122,6 +122,7 @@ Ufe::SceneItem::Ptr UsdHierarchy::parent() const
 	return UsdSceneItem::create(fItem->path().pop(), fPrim.GetParent());
 }
 
+#if UFE_PREVIEW_VERSION_NUM < 2018
 Ufe::AppendedChild UsdHierarchy::appendChild(const Ufe::SceneItem::Ptr& child)
 {
 	auto usdChild = std::dynamic_pointer_cast<UsdSceneItem>(child);
@@ -165,6 +166,7 @@ Ufe::AppendedChild UsdHierarchy::appendChild(const Ufe::SceneItem::Ptr& child)
 	// FIXME  No idea how to get the child prim index yet.  PPT, 16-Aug-2018.
 	return Ufe::AppendedChild(ufeDstItem, ufeSrcPath, 0);
 }
+#endif
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 #if UFE_PREVIEW_VERSION_NUM >= 2013
@@ -235,6 +237,34 @@ Ufe::SceneItem::Ptr UsdHierarchy::createGroup(const Ufe::Selection& selection, c
 Ufe::UndoableCommand::Ptr UsdHierarchy::createGroupCmd(const Ufe::Selection& selection, const Ufe::PathComponent& name) const
 {
 	return UsdUndoCreateGroupCommand::create(fItem, selection, name.string());
+}
+
+#endif // UFE_PREVIEW_VERSION_NUM
+
+#if UFE_PREVIEW_VERSION_NUM >= 2018
+Ufe::SceneItem::Ptr UsdHierarchy::defaultParent() const
+{
+    // Default parent for USD nodes is the pseudo-root of their stage, which is
+    // represented by the proxy shape.
+    auto path = fItem->path(); 
+#if !defined(NDEBUG)
+	assert(path.nbSegments() == 2);
+#endif
+    auto proxyShapePath = path.popSegment();
+    return createItem(proxyShapePath);
+}
+
+Ufe::SceneItem::Ptr UsdHierarchy::insertChild(
+        const Ufe::SceneItem::Ptr& ,
+        const Ufe::SceneItem::Ptr& 
+)
+{
+    // Should be possible to implement trivially when support for returning the
+    // result of the parent command (MAYA-105278) is implemented.  For now,
+    // Ufe::Hierarchy::insertChildCmd() returns a base class
+    // Ufe::UndoableCommand::Ptr object, from which we can't retrieve the added
+    // child.  PPT, 13-Jul-2020.
+    return nullptr;
 }
 
 #endif // UFE_PREVIEW_VERSION_NUM

--- a/lib/mayaUsd/ufe/UsdHierarchy.h
+++ b/lib/mayaUsd/ufe/UsdHierarchy.h
@@ -57,7 +57,9 @@ public:
 	bool hasChildren() const override;
 	Ufe::SceneItemList children() const override;
 	Ufe::SceneItem::Ptr parent() const override;
+#if UFE_PREVIEW_VERSION_NUM < 2018
 	Ufe::AppendedChild appendChild(const Ufe::SceneItem::Ptr& child) override;
+#endif
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 #if UFE_PREVIEW_VERSION_NUM >= 2013
@@ -73,6 +75,13 @@ public:
 #else
 	Ufe::SceneItem::Ptr createGroup(const Ufe::Selection& selection, const Ufe::PathComponent& name) const override;
 	Ufe::UndoableCommand::Ptr createGroupCmd(const Ufe::Selection& selection, const Ufe::PathComponent& name) const override;
+#endif
+#if UFE_PREVIEW_VERSION_NUM >= 2018
+    Ufe::SceneItem::Ptr defaultParent() const override;
+    Ufe::SceneItem::Ptr insertChild(
+        const Ufe::SceneItem::Ptr& child,
+        const Ufe::SceneItem::Ptr& pos
+    ) override;
 #endif
 #endif
 

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
@@ -106,6 +106,10 @@ UsdUndoInsertChildCommand::Ptr UsdUndoInsertChildCommand::create(
     const UsdSceneItem::Ptr& pos
 )
 {
+    if (!parent || !child) {
+        return nullptr;
+    }
+
     // Error if requested parent is currently a child of requested child.
     if (parent->path().startsWith(child->path())) {
         return nullptr;

--- a/test/lib/ufe/testParentCmd.py
+++ b/test/lib/ufe/testParentCmd.py
@@ -360,3 +360,94 @@ class ParentCmdTestCase(unittest.TestCase):
             self.assertEqual(len(childrenPre)+1, len(children))
             self.assertIn("pSphere1", childrenNames(children))
             self.assertIn("pCylinderShape1", childrenNames(children))
+
+    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '2018', 'testUnparentUSD only available in UFE preview version 0.2.18 and greater')
+    def testUnparentUSD(self):
+        '''Unparent USD node.'''
+
+        with OpenFileCtx("simpleHierarchy.ma"):
+            # Unparent a USD node
+            cubePathStr =  '|mayaUsdProxy1|mayaUsdProxyShape1,/pCylinder1/pCube1'
+            cubePath = ufe.PathString.path(cubePathStr)
+            cylinderItem = ufe.Hierarchy.createItem(ufe.PathString.path(
+                '|mayaUsdProxy1|mayaUsdProxyShape1,/pCylinder1'))
+            proxyShapeItem = ufe.Hierarchy.createItem(
+                ufe.PathString.path('|mayaUsdProxy1|mayaUsdProxyShape1'))
+            proxyShape = ufe.Hierarchy.hierarchy(proxyShapeItem)
+            cylinder = ufe.Hierarchy.hierarchy(cylinderItem)
+
+            def checkUnparent(done):
+                proxyShapeChildren = proxyShape.children()
+                cylinderChildren = cylinder.children()
+                self.assertEqual(
+                    'pCube1' in childrenNames(proxyShapeChildren), done)
+                self.assertEqual(
+                    'pCube1' in childrenNames(cylinderChildren), not done)
+
+            checkUnparent(done=False)
+
+            cmds.parent(cubePathStr, world=True)
+            checkUnparent(done=True)
+            
+            cmds.undo()
+            checkUnparent(done=False)
+
+            cmds.redo()
+            checkUnparent(done=True)
+
+    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '2018', 'testUnparentMixed only available in UFE preview version 0.2.18 and greater')
+    def testUnparentMultiStage(self):
+        '''Unparent USD nodes in more than one stage.'''
+
+        with OpenFileCtx("simpleHierarchy.ma"):
+            # An early version of this test imported the same file into the
+            # opened file.  Layers are then shared between the stages, because
+            # they come from the same USD file, causing changes done below one
+            # proxy shape to be seen in the other.  Import from another file.
+            filePath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test-samples", "parentCmd", "simpleSceneUSD_TRS.ma")
+            cmds.file(filePath, i=True)
+
+            # Unparent a USD node in each stage.  Unparenting Lambert node is
+            # nonsensical, but demonstrates the functionality.
+            cubePathStr1 = '|mayaUsdProxy1|mayaUsdProxyShape1,/pCylinder1/pCube1'
+            lambertPathStr2 = '|simpleSceneUSD_TRS_mayaUsdProxy1|simpleSceneUSD_TRS_mayaUsdProxyShape1,/initialShadingGroup/initialShadingGroup_lambert'
+
+            cylinderItem1 = ufe.Hierarchy.createItem(ufe.PathString.path(
+                '|mayaUsdProxy1|mayaUsdProxyShape1,/pCylinder1'))
+            shadingGroupItem2 = ufe.Hierarchy.createItem(
+                ufe.PathString.path('|simpleSceneUSD_TRS_mayaUsdProxy1|simpleSceneUSD_TRS_mayaUsdProxyShape1,/initialShadingGroup'))
+            proxyShapeItem1 = ufe.Hierarchy.createItem(ufe.PathString.path(
+                '|mayaUsdProxy1|mayaUsdProxyShape1'))
+            proxyShapeItem2 = ufe.Hierarchy.createItem(ufe.PathString.path(
+                '|simpleSceneUSD_TRS_mayaUsdProxy1|simpleSceneUSD_TRS_mayaUsdProxyShape1'))
+            cylinder1 = ufe.Hierarchy.hierarchy(cylinderItem1)
+            shadingGroup2 = ufe.Hierarchy.hierarchy(shadingGroupItem2)
+            proxyShape1 = ufe.Hierarchy.hierarchy(proxyShapeItem1)
+            proxyShape2 = ufe.Hierarchy.hierarchy(proxyShapeItem2)
+
+            def checkUnparent(done):
+                proxyShape1Children   = proxyShape1.children()
+                proxyShape2Children   = proxyShape2.children()
+                cylinder1Children     = cylinder1.children()
+                shadingGroup2Children = shadingGroup2.children()
+                self.assertEqual(
+                    'pCube1' in childrenNames(proxyShape1Children), done)
+                self.assertEqual(
+                    'pCube1' in childrenNames(cylinder1Children), not done)
+                self.assertEqual(
+                    'initialShadingGroup_lambert' in childrenNames(proxyShape2Children), done)
+                self.assertEqual(
+                    'initialShadingGroup_lambert' in childrenNames(shadingGroup2Children), not done)
+
+            checkUnparent(done=False)
+
+            # Use relative parenting, else trying to keep absolute world
+            # position of Lambert node fails (of course).
+            cmds.parent(cubePathStr1, lambertPathStr2, w=True, r=True)
+            checkUnparent(done=True)
+            
+            cmds.undo()
+            checkUnparent(done=False)
+
+            cmds.redo()
+            checkUnparent(done=True)


### PR DESCRIPTION
This pull request implements the Ufe::Hierarchy::defaultParent() method.  This is used when unparenting, a.k.a parent -world.  In this implementation, the default parent of USD nodes is their proxy shape, so that calling parent -w on them will place them as a child of the corresponding USD stage pseudo-root.
