### PR TITLE
MAYA-105732 Activate displayColors on mesh only if one imported colorSets is displayable

### DIFF
--- a/test/lib/usd/translators/UsdImportColorSetsTest/UsdImportColorSetsTest.usda
+++ b/test/lib/usd/translators/UsdImportColorSetsTest/UsdImportColorSetsTest.usda
@@ -57,10 +57,10 @@ def Xform "UsdImportColorSetsTest" (
                 float[] primvars:FaceColor_Full_kAlpha = [1, 0.9, 0.8, 0.7, 0.6, 0.5] (
                     interpolation = "uniform"
                 )
-                float[] primvars:ExcludeMe = [.5] (
+                float[] primvars:ExcludeMeEvenIfOpacity = [.5] (
                     interpolation = "constant"
                 )
-                float[] primvars:ExcludeMeNot = [.5] (
+                float[] primvars:ExcludeMeNotBecauseOpacity = [.5] (
                     interpolation = "constant"
                 )
                 int[] primvars:FaceColor_Full_kAlpha:indices = [0, 1, 2, 3, 4, 5]

--- a/test/lib/usd/translators/UsdImportColorSetsTest/UsdImportColorSetsTest.usda
+++ b/test/lib/usd/translators/UsdImportColorSetsTest/UsdImportColorSetsTest.usda
@@ -57,10 +57,10 @@ def Xform "UsdImportColorSetsTest" (
                 float[] primvars:FaceColor_Full_kAlpha = [1, 0.9, 0.8, 0.7, 0.6, 0.5] (
                     interpolation = "uniform"
                 )
-                float[] primvars:ExcludeMeEvenIfOpacity = [.5] (
+                float[] primvars:ExcludeMe = [.5] (
                     interpolation = "constant"
                 )
-                float[] primvars:ExcludeMeNotBecauseOpacity = [.5] (
+                float[] primvars:ExcludeMeNot = [.5] (
                     interpolation = "constant"
                 )
                 int[] primvars:FaceColor_Full_kAlpha:indices = [0, 1, 2, 3, 4, 5]
@@ -145,6 +145,39 @@ def Xform "UsdImportColorSetsTest" (
                     unauthoredValuesIndex = 4
                 )
                 int[] primvars:VertexColor_Sparse_kRGBA:indices = [0, 4, 1, 4, 2, 4, 3, 4]
+                float3 xformOp:translate:pivot = (0, 0, 5)
+                uniform token[] xformOpOrder = ["xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]
+            }
+
+            def Mesh "NonColorSetsCube"
+            {
+                float3[] extent = [(-5, -5, 0), (5, 5, 10)]
+                int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+                int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+                point3f[] points = [(-5, -5, 10), (5, -5, 10), (-5, 5, 10), (5, 5, 10), (-5, 5, 0), (5, 5, 0), (-5, -5, 0), (5, -5, 0)]
+                float[] primvars:ExcludeMe = [.5] (
+                    interpolation = "constant"
+                )
+                float[] primvars:ExcludeMeNot = [.5] (
+                    interpolation = "constant"
+                )
+                texCoord2f[] primvars:st = [(0.375, 0), (0.625, 0), (0.625, 0.25), (0.375, 0.25), (0.625, 0.5), (0.375, 0.5), (0.625, 0.75), (0.375, 0.75), (0.625, 1), (0.375, 1), (0.875, 0), (0.875, 0.25), (0.125, 0), (0.125, 0.25)] (
+                    interpolation = "faceVarying"
+                )
+                int[] primvars:st:indices = [0, 1, 2, 3, 3, 2, 4, 5, 5, 4, 6, 7, 7, 6, 8, 9, 1, 10, 11, 2, 12, 0, 3, 13]
+                float3[] primvars:CustomFloat3Stream = [(1, 0, 0), (0, 1, 0), (1, 1, 0), (0, 0, 1), (0, 1, 1), (1, 0, 1), (1, 1, 1), (0, 0, 0)] (
+                    interpolation = "vertex"
+                )
+                int[] primvars:CustomFloat3Stream:indices = [0, 1, 3, 2, 5, 4, 7, 6]
+                float4[] primvars:CustomFloat4Stream = [(1, 0, 0, 1), (0, 1, 0, 0.9), (1, 1, 0, 0.7), (0, 0, 1, 0.8), (0, 1, 1, 0.5), (1, 0, 1, 0.6), (1, 1, 1, 0.3), (0, 0, 0, 0.4)] (
+                    interpolation = "vertex"
+                )
+                int[] primvars:CustomFloat4Stream:indices = [0, 1, 3, 2, 5, 4, 7, 6]
+                float[] primvars:CustomFloatStream = [1, 0.8, 0.6, 0.4, 1] (
+                    interpolation = "vertex"
+                    unauthoredValuesIndex = 4
+                )
+                int[] primvars:CustomFloatStream:indices = [0, 4, 1, 4, 2, 4, 3, 4]
                 float3 xformOp:translate:pivot = (0, 0, 5)
                 uniform token[] xformOpOrder = ["xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]
             }

--- a/test/lib/usd/translators/testUsdImportColorSets.py
+++ b/test/lib/usd/translators/testUsdImportColorSets.py
@@ -130,7 +130,7 @@ class testUsdImportColorSets(unittest.TestCase):
         inputPath = fixturesUtils.readOnlySetUpClass(__file__)
 
         usdFile = os.path.join(inputPath, "UsdImportColorSetsTest", "UsdImportColorSetsTest.usda")
-        cmds.usdImport(file=usdFile, shadingMode='none', excludePrimvar='ExcludeMe')
+        cmds.usdImport(file=usdFile, shadingMode='none', excludePrimvar='ExcludeMeEvenIfOpacity')
 
     def _GetMayaMesh(self, meshName):
         selectionList = OpenMaya.MSelectionList()
@@ -592,8 +592,8 @@ class testUsdImportColorSets(unittest.TestCase):
         """Tests excluding primvars when importing color sets."""
         mayaCubeMesh = self._GetMayaMesh('ColorSetsCubeShape')
         colorSets = mayaCubeMesh.getColorSetNames()
-        self.assertNotIn("ExcludeMe", colorSets)
-        self.assertIn("ExcludeMeNot", colorSets)
+        self.assertNotIn("ExcludeMeEvenIfOpacity", colorSets)
+        self.assertIn("ExcludeMeNotBecauseOpacity", colorSets)
 
 
 if __name__ == '__main__':

--- a/test/lib/usd/translators/testUsdImportColorSets.py
+++ b/test/lib/usd/translators/testUsdImportColorSets.py
@@ -130,7 +130,7 @@ class testUsdImportColorSets(unittest.TestCase):
         inputPath = fixturesUtils.readOnlySetUpClass(__file__)
 
         usdFile = os.path.join(inputPath, "UsdImportColorSetsTest", "UsdImportColorSetsTest.usda")
-        cmds.usdImport(file=usdFile, shadingMode='none', excludePrimvar='ExcludeMeEvenIfOpacity')
+        cmds.usdImport(file=usdFile, shadingMode='none', excludePrimvar='ExcludeMe')
 
     def _GetMayaMesh(self, meshName):
         selectionList = OpenMaya.MSelectionList()
@@ -592,9 +592,22 @@ class testUsdImportColorSets(unittest.TestCase):
         """Tests excluding primvars when importing color sets."""
         mayaCubeMesh = self._GetMayaMesh('ColorSetsCubeShape')
         colorSets = mayaCubeMesh.getColorSetNames()
-        self.assertNotIn("ExcludeMeEvenIfOpacity", colorSets)
-        self.assertIn("ExcludeMeNotBecauseOpacity", colorSets)
+        self.assertNotIn("ExcludeMe", colorSets)
+        self.assertIn("ExcludeMeNot", colorSets)
+        # Plenty of colors to show:
+        self.assertTrue(mayaCubeMesh.displayColors)
 
+    def testOnlyCustomData(self):
+        """Test with a mesh containing non-color custom data."""
+        mayaCubeMesh = self._GetMayaMesh('NonColorSetsCubeShape')
+        colorSets = mayaCubeMesh.getColorSetNames()
+        self.assertNotIn("ExcludeMe", colorSets)
+        self.assertIn("ExcludeMeNot", colorSets)
+        self.assertIn("CustomFloatStream", colorSets)
+        self.assertIn("CustomFloat3Stream", colorSets)
+        self.assertIn("CustomFloat4Stream", colorSets)
+        # Not a single "color" to show:
+        self.assertFalse(mayaCubeMesh.displayColors)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Only turn on the displayColors attribute on the mesh if the loaded color set looks like a color.

This means that loading the Kitchen_set scene will still result in having these colorSets: 
    float[] primvars:__faceindex = [...]
    float3[] primvars:PreMenvPosingRefPose = [...]
But the will not cause the objects to be shown as black in the viewport.