### PR TITLE
MAYA-105743 Use the correct type when creating a new group

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
@@ -64,7 +64,7 @@ UsdUndoAddNewPrimCommand::UsdUndoAddNewPrimCommand(const UsdSceneItem::Ptr& usdS
 
         // The type of prim we were asked to create.
         // Note: "Def" means create typeless prim.
-        _primToken = (type.empty() || type == "Def") ? TfToken() : TfToken(name);
+        _primToken = (type.empty() || type == "Def") ? TfToken() : TfToken(type);
     }
 }
 

--- a/test/lib/ufe/testGroupCmd.py
+++ b/test/lib/ufe/testGroupCmd.py
@@ -92,6 +92,12 @@ class GroupCmdTestCase(unittest.TestCase):
         # convention in Maya.
         newGroupPath = parentPath + ufe.PathComponent("newGroup1")
 
+        # Make sure the new group item has the correct Usd type
+        newGroupItem = ufe.Hierarchy.createItem(newGroupPath)
+        newGroupPrim = usdUtils.getPrimFromSceneItem(newGroupItem)
+        newGroupType = newGroupPrim.GetTypeName()
+        self.assertEqual(newGroupType, 'Xform')
+
         childPaths = set([child.path() for child in parentChildrenPost])
 
         self.assertTrue(newGroupPath in childPaths)


### PR DESCRIPTION
Made a typo in my group command change.  Problem was that I used the variable for the name of the new object when defining the prim type.  Fixed that and added to the group test to make sure it's correct.

