### PR TITLE
MAYA-102330 Add UI to display the number of selected prims and changed variants

### DIFF
--- a/lib/mayaUsd/fileio/importData.cpp
+++ b/lib/mayaUsd/fileio/importData.cpp
@@ -28,6 +28,8 @@ constexpr const char* kRootPrimPath = "/";
 ImportData::ImportData()
 	: fLoadSet(UsdStage::InitialLoadSet::LoadAll)
 	, fRootPrimPath(kRootPrimPath)
+	, fPrimsInScopeCount(0)
+	, fSwitchedVariantCount(0)
 {
 }
 
@@ -35,6 +37,8 @@ ImportData::ImportData(const std::string& f)
 	: fLoadSet(UsdStage::InitialLoadSet::LoadAll)
 	, fRootPrimPath(kRootPrimPath)
 	, fFilename(f)
+	, fPrimsInScopeCount(0)
+	, fSwitchedVariantCount(0)	
 {
 }
 
@@ -60,6 +64,8 @@ void ImportData::clearData()
 	fPrimVariants.clear();
 	fFilename.clear();
 	fRootPrimPath = kRootPrimPath;
+	fPrimsInScopeCount = 0;
+	fSwitchedVariantCount =0;	
 }
 
 bool ImportData::empty() const
@@ -124,7 +130,7 @@ void ImportData::setStageInitialLoadSet(UsdStage::InitialLoadSet loadSet)
 
 bool ImportData::hasVariantSelections() const
 {
-	return !(fRootVariants.empty() || fPrimVariants.empty());
+	return !(fRootVariants.empty() && fPrimVariants.empty());
 }
 
 const SdfVariantSelectionMap& ImportData::rootVariantSelections() const
@@ -155,6 +161,26 @@ void ImportData::setPrimVariantSelections(const PrimVariantSelections& vars)
 void ImportData::setPrimVariantSelections(PrimVariantSelections&& vars)
 {
 	fPrimVariants = std::move(vars);
+}
+
+void ImportData::setPrimsInScopeCount(int count)
+{
+	fPrimsInScopeCount = count;
+}
+
+void ImportData::switchedVariantCount(int count)
+{
+	fSwitchedVariantCount = count;
+}
+
+int ImportData::primsInScopeCount() const
+{
+	return fPrimsInScopeCount;
+}
+
+int ImportData::switchedVariantCount() const
+{
+	return fSwitchedVariantCount;
 }
 
 } // namespace MayaUsd

--- a/lib/mayaUsd/fileio/importData.cpp
+++ b/lib/mayaUsd/fileio/importData.cpp
@@ -168,7 +168,7 @@ void ImportData::setPrimsInScopeCount(int count)
 	fPrimsInScopeCount = count;
 }
 
-void ImportData::switchedVariantCount(int count)
+void ImportData::setSwitchedVariantCount(int count)
 {
 	fSwitchedVariantCount = count;
 }

--- a/lib/mayaUsd/fileio/importData.h
+++ b/lib/mayaUsd/fileio/importData.h
@@ -115,6 +115,11 @@ public:
 	void setPrimVariantSelections(const PrimVariantSelections& vars);
 	void setPrimVariantSelections(PrimVariantSelections&& vars);
 
+	void setPrimsInScopeCount(int count);
+	void switchedVariantCount(int count);
+	int primsInScopeCount() const;
+	int switchedVariantCount() const;
+
 private:
 	UsdStagePopulationMask		fPopMask;
 	UsdStage::InitialLoadSet	fLoadSet;
@@ -122,6 +127,9 @@ private:
 	PrimVariantSelections		fPrimVariants;
 	std::string					fRootPrimPath;
 	std::string					fFilename;
+
+	int							fPrimsInScopeCount;
+	int							fSwitchedVariantCount;
 };
 
 } // namespace MayaUsd

--- a/lib/mayaUsd/fileio/importData.h
+++ b/lib/mayaUsd/fileio/importData.h
@@ -115,10 +115,16 @@ public:
 	void setPrimVariantSelections(const PrimVariantSelections& vars);
 	void setPrimVariantSelections(PrimVariantSelections&& vars);
 
+	//@{
+	//! Set and get the number of prims to be imported and the number of prims within that scope
+	//! that had a variant changed from what is currently set in the USD file.
+	//! These values are stored here as a way of communicating choices made between the various
+	//! Import options UI, and are used for display purposes only.
 	void setPrimsInScopeCount(int count);
-	void switchedVariantCount(int count);
+	void setSwitchedVariantCount(int count);
 	int primsInScopeCount() const;
 	int switchedVariantCount() const;
+	//@}
 
 private:
 	UsdStagePopulationMask		fPopMask;

--- a/lib/usd/ui/ItemDelegate.cpp
+++ b/lib/usd/ui/ItemDelegate.cpp
@@ -118,6 +118,7 @@ void ItemDelegate::setModelData(QWidget* editor, QAbstractItemModel* model, cons
 		if (nullptr != treeItem)
 		{
 			treeItem->setVariantSelectionModified();
+			Q_EMIT variantModified();
 		}
 	}
 

--- a/lib/usd/ui/ItemDelegate.h
+++ b/lib/usd/ui/ItemDelegate.h
@@ -79,6 +79,9 @@ public:
 	QSize sizeHint(const QStyleOptionViewItem&, const QModelIndex&) const override;
 	void updateEditorGeometry(QWidget*, const QStyleOptionViewItem&, const QModelIndex&) const override;
 
+Q_SIGNALS:
+	void variantModified() const;
+
 public Q_SLOTS:
 	void commitVariantSelection(VariantsEditorWidget* editor);
 

--- a/lib/usd/ui/TreeItem.h
+++ b/lib/usd/ui/TreeItem.h
@@ -97,6 +97,8 @@ public:
 	//! Only valid for kVariants type.
 	void setVariantSelectionModified();
 
+	//! Reset the flag that is set to track if the variant selection has been modified.
+	//! Only valid for kVariants type.
 	void resetVariantSelectionModified() { fVariantSelectionModified = false; }
 
 private:

--- a/lib/usd/ui/TreeItem.h
+++ b/lib/usd/ui/TreeItem.h
@@ -97,6 +97,8 @@ public:
 	//! Only valid for kVariants type.
 	void setVariantSelectionModified();
 
+	void resetVariantSelectionModified() { fVariantSelectionModified = false; }
+
 private:
 	void initializeItem();
 

--- a/lib/usd/ui/TreeModel.cpp
+++ b/lib/usd/ui/TreeModel.cpp
@@ -339,7 +339,6 @@ void TreeModel::updateCheckedItemCount() const
 
 void TreeModel::countCheckedItems(const QModelIndex &parent, int& nbChecked, int& nbVariantsModified) const
 {
-	int count = 0;
 	for (int r=0; r<rowCount(parent); ++r)
 	{
 		TreeItem* item;

--- a/lib/usd/ui/TreeModel.h
+++ b/lib/usd/ui/TreeModel.h
@@ -86,8 +86,18 @@ private:
 	void uncheckEnableTree();
 	void checkEnableItem(TreeItem* item);
 
+	void updateCheckedItemCount() const;
+	void countCheckedItems(const QModelIndex &parent, int& nbChecked, int& nbVariantsModified) const;
+
 	void setParentsCheckState(const QModelIndex &child, TreeItem::CheckState state);
 	void setChildCheckState(const QModelIndex &parent, TreeItem::CheckState state);
+
+Q_SIGNALS:
+	void checkedStateChanged(int nbChecked) const;
+	void modifiedVariantCountChanged(int nbModified) const;
+
+public Q_SLOTS:
+	void updateModifiedVariantCount() const;
 
 private:
 	// Extra import data, if any to set the initial state of dialog from.

--- a/lib/usd/ui/USDImportDialog.h
+++ b/lib/usd/ui/USDImportDialog.h
@@ -28,6 +28,7 @@
 #include <mayaUsdUI/ui/api.h>
 #include <mayaUsdUI/ui/IUSDImportView.h>
 #include <mayaUsdUI/ui/TreeModel.h>
+#include <mayaUsdUI/ui/ItemDelegate.h>
 
 namespace Ui {
 	class ImportDialog;
@@ -67,9 +68,15 @@ public:
 	ImportData::PrimVariantSelections primVariantSelections() const override;
 	bool execute() override;
 
+	int primsInScopeCount() const;
+	int switchedVariantCount() const;
+
 private Q_SLOTS:
 	void onItemClicked(const QModelIndex&);
 	void onResetFileTriggered();
+	void onHierarchyViewHelpTriggered();
+	void onCheckedStateChanged(int);
+	void onModifiedVariantsChanged(int);
 
 protected:
 	// Reference to the Qt UI View of the dialog:
@@ -79,6 +86,8 @@ protected:
 	std::unique_ptr<TreeModel> fTreeModel;
 	// Reference to the Proxy Model used to sort and filter the USD file hierarchy:
 	std::unique_ptr<QSortFilterProxyModel> fProxyModel;
+	// Reference to the delegate we set on the tree view:
+	std::unique_ptr<ItemDelegate> fItemDelegate;
 
 	// Reference to the USD Stage holding the list of Prims which could be imported:
 	UsdStageRefPtr fStage;

--- a/lib/usd/ui/USDImportDialog.ui
+++ b/lib/usd/ui/USDImportDialog.ui
@@ -23,17 +23,6 @@
    <bool>false</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QMenuBar" name="menuBar">
-     <widget class="QMenu" name="menuEdit">
-      <property name="title">
-       <string>Edit</string>
-      </property>
-      <addaction name="actionReset_File"/>
-     </widget>
-     <addaction name="menuEdit"/>
-    </widget>
-   </item>   
    <item row="1" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <property name="topMargin">
@@ -64,34 +53,7 @@
      </item>
     </layout>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="selectPrims">
-     <property name="text">
-      <string>Select the prim(s) you'd like to import. Switch variants accordingly.</string>
-     </property>
-    </widget>
-   </item>   
-   <item row="3" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <widget class="QTreeView" name="treeView">
-       <property name="autoFillBackground">
-        <bool>true</bool>
-       </property>
-       <property name="editTriggers">
-        <set>QAbstractItemView::NoEditTriggers</set>
-       </property>
-       <property name="selectionMode">
-        <enum>QAbstractItemView::ExtendedSelection</enum>
-       </property>
-       <property name="uniformRowHeights">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="4" column="0">
+   <item row="6" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="topMargin">
       <number>7</number>
@@ -146,6 +108,113 @@
      </item>
     </layout>
    </item>
+   <item row="3" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QTreeView" name="treeView">
+       <property name="autoFillBackground">
+        <bool>true</bool>
+       </property>
+       <property name="editTriggers">
+        <set>QAbstractItemView::NoEditTriggers</set>
+       </property>
+       <property name="selectionMode">
+        <enum>QAbstractItemView::ExtendedSelection</enum>
+       </property>
+       <property name="uniformRowHeights">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Total Number of Prims in Scope:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="nbPrimsInScopeLabel">
+       <property name="text">
+        <string>123</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="0">
+    <widget class="QMenuBar" name="menuBar">
+     <widget class="QMenu" name="menuEdit">
+      <property name="title">
+       <string>Edit</string>
+      </property>
+      <addaction name="actionReset_File"/>
+     </widget>
+     <widget class="QMenu" name="menuHelp">
+      <property name="title">
+       <string>Help</string>
+      </property>
+      <addaction name="actionHelp_on_Hierarchy_View"/>
+     </widget>
+     <addaction name="menuEdit"/>
+     <addaction name="menuHelp"/>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="selectPrims">
+     <property name="text">
+      <string>Select the prim(s) you'd like to import. Switch variants accordingly.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Variants Switched in Scope:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="nbVariantsChangedLabel">
+       <property name="text">
+        <string>12</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
   </layout>
   <action name="actionEdit">
    <property name="text">
@@ -155,6 +224,11 @@
   <action name="actionReset_File">
    <property name="text">
     <string>Reset File</string>
+   </property>
+  </action>
+  <action name="actionHelp_on_Hierarchy_View">
+   <property name="text">
+    <string>Help on Hierarchy View</string>
    </property>
   </action>
  </widget>

--- a/lib/usd/ui/USDImportDialogCmd.cpp
+++ b/lib/usd/ui/USDImportDialogCmd.cpp
@@ -237,7 +237,7 @@ MStatus USDImportDialogCmd::doIt(const MArgList& args)
 				importData.setPrimVariantSelections(usdImportDialog->primVariantSelections());
 				
 				importData.setPrimsInScopeCount(usdImportDialog->primsInScopeCount());
-				importData.switchedVariantCount(usdImportDialog->switchedVariantCount());
+				importData.setSwitchedVariantCount(usdImportDialog->switchedVariantCount());
 
 				setResult(assetPath);
 			}

--- a/lib/usd/ui/USDImportDialogCmd.cpp
+++ b/lib/usd/ui/USDImportDialogCmd.cpp
@@ -36,13 +36,13 @@
 
 #include <mayaUsd/fileio/importData.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
+#include <mayaUsd/utils/util.h>
 
 #include <mayaUsdUI/ui/USDImportDialog.h>
 #include <mayaUsdUI/ui/USDQtUtil.h>
 
 #include <QtGui/QCursor>
 #include <QtWidgets/QApplication>
-
 
 MAYAUSD_NS_DEF {
 
@@ -56,6 +56,11 @@ constexpr auto kClearDataFlag = "-cd";
 constexpr auto kClearDataFlagLong = "-clearData";
 constexpr auto kApplyToProxyFlag = "-ap";
 constexpr auto kApplyToProxyFlagLong = "-applyToProxy";
+
+constexpr auto kPrimCountFlag = "-pc";
+constexpr auto kPrimCountFlagLong = "-primCount";
+constexpr auto kSwitchedVariantCountFlag = "-swc";
+constexpr auto kSwitchedVariantCountFlagLong = "-switchedVariantCount";
 
 }
 
@@ -153,6 +158,20 @@ MStatus USDImportDialogCmd::doIt(const MArgList& args)
 			return MS::kSuccess;
 		}
 
+		if (argData.isFlagSet(kPrimCountFlag))
+		{
+			const ImportData& importData = ImportData::cinstance();
+			setResult(importData.primsInScopeCount());
+			return MS::kSuccess;
+		}
+
+		if (argData.isFlagSet(kSwitchedVariantCountFlag))
+		{
+			const ImportData& importData = ImportData::cinstance();
+			setResult(importData.switchedVariantCount());
+			return MS::kSuccess;
+		}
+
 		return MS::kInvalidParameter;
 	}
 
@@ -202,7 +221,7 @@ MStatus USDImportDialogCmd::doIt(const MArgList& args)
 			// Creating the View can pause Maya, usually only briefly but it's noticable, so we'll toggle the wait cursor to show that it's working.
 			QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
 
-			std::unique_ptr<IUSDImportView> usdImportDialog(new USDImportDialog(assetPath.asChar(), &importData, usdQtUtil, MQtUtil::mainWindow()));
+			std::unique_ptr<USDImportDialog> usdImportDialog(new USDImportDialog(assetPath.asChar(), &importData, usdQtUtil, MQtUtil::mainWindow()));
 
 			QApplication::restoreOverrideCursor();
 
@@ -216,6 +235,9 @@ MStatus USDImportDialogCmd::doIt(const MArgList& args)
 				// the root prim path.
 				//importData.setStagePopulationMask(usdImportDialog->stagePopulationMask());
 				importData.setPrimVariantSelections(usdImportDialog->primVariantSelections());
+				
+				importData.setPrimsInScopeCount(usdImportDialog->primsInScopeCount());
+				importData.switchedVariantCount(usdImportDialog->switchedVariantCount());
 
 				setResult(assetPath);
 			}
@@ -234,6 +256,9 @@ MSyntax USDImportDialogCmd::createSyntax()
 	syntax.addFlag(kPrimPathFlag, kPrimPathFlagLong);
 	syntax.addFlag(kClearDataFlag, kClearDataFlagLong);
 	syntax.addFlag(kApplyToProxyFlag, kApplyToProxyFlagLong);
+	syntax.addFlag(kPrimCountFlag, kPrimCountFlagLong);
+	syntax.addFlag(kSwitchedVariantCountFlag, kSwitchedVariantCountFlagLong);
+
 	syntax.setObjectType(MSyntax::kStringObjects, 0, 1);
 	return syntax;
 }

--- a/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
@@ -28,6 +28,20 @@ proc mayaUsdTranslatorImport_hideInfo()
     }
 }
 
+proc mayaUsdTranslatorImport_showInfo()
+{
+    if (`rowLayout -exists mayaUsd_NBPrimsInScopeRL`) 
+    {
+        int $pc = `usdImportDialog -q -primCount`;
+        int $swc = `usdImportDialog -q -switchedVariantCount`;
+
+        text -edit -label $pc mayaUsd_NBPrimsInScopeLabel;
+        text -edit -label $swc mayaUsd_NBSwitchedVariantsLabel;
+
+        rowLayout -edit -visible true mayaUsd_NBPrimsInScopeRL;
+        rowLayout -edit -visible true mayaUsd_NBSwitchedVariantsRL;
+    }
+}
 
 global proc int mayaUsdTranslatorImport (string $parent,
                                  string $action,
@@ -275,14 +289,7 @@ global proc mayaUsdTranslatorImport_ViewHierCB()
     string $result = `usdImportDialog $usdFile`;
     if ("" != $result)
     {
-        int $pc = `usdImportDialog -q -primCount`;
-        int $swc = `usdImportDialog -q -switchedVariantCount`;
-
-        text -edit -label $pc mayaUsd_NBPrimsInScopeLabel;
-        text -edit -label $swc mayaUsd_NBSwitchedVariantsLabel;
-
-        rowLayout -edit -visible true mayaUsd_NBPrimsInScopeRL;
-        rowLayout -edit -visible true mayaUsd_NBSwitchedVariantsRL;
+        mayaUsdTranslatorImport_showInfo();
     }
 
     // If the dialog was cancelled then we will not get a result, but

--- a/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
@@ -15,6 +15,20 @@
 // limitations under the License.
 //
 
+
+proc mayaUsdTranslatorImport_hideInfo()
+{
+    if (`rowLayout -exists mayaUsd_NBPrimsInScopeRL`) 
+    {
+        rowLayout -edit -visible false mayaUsd_NBPrimsInScopeRL;
+        rowLayout -edit -visible false mayaUsd_NBSwitchedVariantsRL;
+
+        text -edit -label "---" mayaUsd_NBPrimsInScopeLabel;
+        text -edit -label "---" mayaUsd_NBSwitchedVariantsLabel;
+    }
+}
+
+
 global proc int mayaUsdTranslatorImport (string $parent,
                                  string $action,
                                  string $initialSettings,
@@ -54,18 +68,38 @@ global proc int mayaUsdTranslatorImport (string $parent,
 
         if (`exists usdImportDialog`)
         {
-            rowLayout -numberOfColumns 3 -cw 1 $cw1 -cat 1 "right" 0;
+            rowLayout -numberOfColumns 4 -cw 1 $cw1 -cat 1 "right" 0;
                 text -label "Scope and Variants: "
                     -al "right"
                     -sbm "Select a USD file and click Hierarchy View to open the Hierarchy View window. This window lets you toggle prim checkboxes and non-destructively switch between variants to build the scope of your import."
                     -ann "Select a USD file and click <strong>Hierarchy View</strong> to build the scope of your import and switch variants.<br><br><strong>Scope</strong>: A USD file consists of prims, the primary container object in USD. Prims can contain any scene element, like meshes, lights, cameras, etc. Use the checkboxes in the <strong>Hierarchy View</strong> to select and deselect prims to build the scope of your import.<br><br><strong>Variant</strong>: A variant is a single, named variation of a variant set. Each variant set is a package of alternatives that users can switch between non-destructively. A variant set has no limits to what it can store. Variants can be used to swap out a material or change the entire hierarchy of an asset. A single prim can have many variants and variant sets, but only one variant from each variant set can be selected for import into Maya."
                 ;
                 textField -ed false -nbg true -text "Please select a file to enable this option" -w $cw2 mayaUsdTranslator_SelectFileField;
-                button -label "Hierarchy View" -c "{string $usdFile = currentFileDialogSelection(); usdImportDialog $usdFile;}" mayaUsdTranslator_ViewHierBtn;
+                button -label "Hierarchy View" -c "mayaUsdTranslatorImport_ViewHierCB" mayaUsdTranslator_ViewHierBtn;
+                iconTextButton -w 32 -h 32 -command ("mayaUsdTranslatorImport_ClearImportData;") -
+                    style "iconAndTextVertical" -image1 "refresh.png" -label "" mayaUsdTranslator_ResetBtn;
+
+                string $nbPrimsInScopeLabel = "Total Number of Prims in Scope:";
+                string $nbModifiedVariantsLabel = "Variants Switched in Scope:";
 
                 // Hide the button by default.
                 button -e -visible false -w 1 mayaUsdTranslator_ViewHierBtn;
+                iconTextButton -e -visible false mayaUsdTranslator_ResetBtn;
             setParent ..;
+
+            rowLayout -numberOfColumns 3 -cw 1 $cw1 -cat 1 "right" 0 -cal 1 "right" mayaUsd_NBPrimsInScopeRL;
+                text -label "";
+                text -label $nbPrimsInScopeLabel;
+                text -label "---" mayaUsd_NBPrimsInScopeLabel;
+            setParent ..;
+            rowLayout -numberOfColumns 3 -cw 1 $cw1 -cat 1 "right" 0 -cal 1 "right" mayaUsd_NBSwitchedVariantsRL;
+                text -label "";
+                text -label $nbModifiedVariantsLabel;
+                text -label "---" mayaUsd_NBSwitchedVariantsLabel;
+            setParent ..;
+            // We'll start off with the info UI hidden and only make it visible when we come out of 
+            // the Hierarchy View the first time.
+            mayaUsdTranslatorImport_hideInfo();
         }
 //        checkBoxGrp -label "Load Payloads: " -cw 1 $cw1 mayaUsdTranslator_LoadPayloadsCheckBox;
 //
@@ -145,7 +179,7 @@ global proc int mayaUsdTranslatorImport (string $parent,
         if (`exists usdImportDialog`)
         {
             // Clear out the import data since we have a new selection.
-            usdImportDialog -clearData "";
+            mayaUsdTranslatorImport_ClearImportData;
         }
 
         // Test the currently selected file in the import dialog to see if it is
@@ -169,12 +203,14 @@ global proc int mayaUsdTranslatorImport (string $parent,
                 // Hide the field (and shrink it) and show the button (which will align with label).
                 textField -e -vis false -w 1 mayaUsdTranslator_SelectFileField;
                 button -e -visible true -w $bw mayaUsdTranslator_ViewHierBtn;
+                iconTextButton -e -visible true -w 32 mayaUsdTranslator_ResetBtn;
             }
             else
             {
                 // Show the field and hide the button.
                 textField -e -vis true -w $cw2 mayaUsdTranslator_SelectFileField;
                 button -e -visible false -w 1 mayaUsdTranslator_ViewHierBtn;
+                iconTextButton -e -visible false -w 1 mayaUsdTranslator_ResetBtn;
             }
         }
 
@@ -231,4 +267,30 @@ global proc string mayaUsdTranslatorImport_AppendFromDialog(string $currentOptio
             return $currentOptions + ";" + $arg + "=" + $value;
         }
     }
+}
+
+global proc mayaUsdTranslatorImport_ViewHierCB()
+{
+    string $usdFile = currentFileDialogSelection(); 
+    string $result = `usdImportDialog $usdFile`;
+    if ("" != $result)
+    {
+        int $pc = `usdImportDialog -q -primCount`;
+        int $swc = `usdImportDialog -q -switchedVariantCount`;
+
+        text -edit -label $pc mayaUsd_NBPrimsInScopeLabel;
+        text -edit -label $swc mayaUsd_NBSwitchedVariantsLabel;
+
+        rowLayout -edit -visible true mayaUsd_NBPrimsInScopeRL;
+        rowLayout -edit -visible true mayaUsd_NBSwitchedVariantsRL;
+    }
+
+    // If the dialog was cancelled then we will not get a result, but
+    // don't clear out the info since nothing should be changed.
+}
+
+global proc mayaUsdTranslatorImport_ClearImportData()
+{
+    usdImportDialog -clearData "";
+    mayaUsdTranslatorImport_hideInfo();
 }


### PR DESCRIPTION
1. Help menu in the Hierarchy View dialog.

2. Might not be called from anywhere, but noticed a typo in ImportData::hasVariantSelections that I fixed.

3. I think we were leaking every ItemDelegate we created.  Qt docs say that QAbstractItemView::setItemDelegate does not take ownership of the delegate you pass to it but we were calling it like it would.

4. Made the checkbox column not resizable. 

5. Main part:
Adding UI to display a couple counts as information to the user.  One is the total number of prims that are checked, and the other is the number of variants that have been modified and are checked.  This info is displayed both in the Hierarchy View and also the file dialog import options after exiting the HV.

In the file dialog import options we also added a button to reset the import data.

The model is responsible for doing all of the counting.
The model sends signals to the dialog when it has updated the counts and the dialog will update the labels that display the info.
The delegate is where the editing of the variants happens so I connect it to the model with a signal/slot so that updating a variant will trigger the model to update the count.

The file dialog options UI just needs to display the same #’s that the Hierarchy View was displaying, so I store those two #’s in the ImportData and then added a couple query flags to the command so the options UI can get at it.
