### PR TITLE
added code to manipulate xform stacks in any coordinate frame

### DIFF
--- a/lib/usd/utils/TransformOpTools.cpp
+++ b/lib/usd/utils/TransformOpTools.cpp
@@ -1,0 +1,2812 @@
+//
+// Copyright 2017 Animal Logic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "TransformOpTools.h"
+#include "SIMD.h"
+
+#include <pxr/usd/usdGeom/xform.h>
+#include <pxr/base/gf/rotation.h>
+#include <iostream>
+
+namespace MayaUsdUtils {
+
+namespace 
+{
+
+//---------------------------------------------------------------------------------------------
+// Note: If needed, it's possible to sneak a bit more performance from this code. I stopped 
+// short of adding a vectorised sincos() implementation, but that would be possible....
+//---------------------------------------------------------------------------------------------
+inline d256 Quat_from_EulerXYZ(const d256 half_angles)
+{
+  alignas(32) double h[4];
+  store4d(h, half_angles);
+  const double sx = std::sin(h[0]);
+  const double cx = std::cos(h[0]);
+  const double sy = std::sin(h[1]);
+  const double cy = std::cos(h[1]);
+  const double sz = std::sin(h[2]);
+  const double cz = std::cos(h[2]);
+  const double czcy = cz * cy;
+  const double czsy = cz * sy;
+  const double szsy = sz * sy;
+  const double szcy = sz * cy;
+  return set4d(
+     (czcy * sx) - (szsy * cx),
+     (czsy * cx) + (szcy * sx),
+    -(czsy * sx) + (szcy * cx),
+     (czcy * cx) + (szsy * sx)
+  );
+}
+
+inline d256 Quat_from_EulerXZY(const d256 half_angles)
+{
+  alignas(32) double h[4];
+  store4d(h, half_angles);
+  const double sx = std::sin(h[0]);
+  const double cx = std::cos(h[0]);
+  const double sy = std::sin(h[1]);
+  const double cy = std::cos(h[1]);
+  const double sz = std::sin(h[2]);
+  const double cz = std::cos(h[2]);
+  const double cycz = cy * cz;
+  const double cysz = cy * sz;
+  const double sycz = sy * cz;
+  const double sysz = sy * sz;
+  return set4d(
+    (cycz * sx) + (sysz * cx),
+    (cysz * sx) + (sycz * cx),
+    (cysz * cx) - (sycz * sx),
+    (cycz * cx) - (sysz * sx)
+  );
+}
+
+inline d256 Quat_from_EulerYXZ(const d256 half_angles)
+{
+  alignas(32) double h[4];
+  store4d(h, half_angles);
+  const double sx = std::sin(h[0]);
+  const double cx = std::cos(h[0]);
+  const double sy = std::sin(h[1]);
+  const double cy = std::cos(h[1]);
+  const double sz = std::sin(h[2]);
+  const double cz = std::cos(h[2]);
+  const double czsx = cz * sx;
+  const double czcx = cz * cx;
+  const double szsx = sz * sx;
+  const double szcx = sz * cx;
+  return set4d(
+    (czsx * cy) - (szcx * sy),
+    (czcx * sy) + (szsx * cy),
+    (czsx * sy) + (szcx * cy),
+    (czcx * cy) - (szsx * sy)
+  );
+}
+
+inline d256 Quat_from_EulerYZX(const d256 half_angles)
+{
+  alignas(32) double h[4];
+  store4d(h, half_angles);
+  const double sx = std::sin(h[0]);
+  const double cx = std::cos(h[0]);
+  const double sy = std::sin(h[1]);
+  const double cy = std::cos(h[1]);
+  const double sz = std::sin(h[2]);
+  const double cz = std::cos(h[2]);
+  const double cxsz = cx * sz;
+  const double cxcz = cx * cz;
+  const double sxsz = sx * sz;
+  const double sxcz = sx * cz;
+  return set4d(
+    -(cxsz * sy) + (sxcz * cy),
+     (cxcz * sy) - (sxsz * cy),
+     (cxsz * cy) + (sxcz * sy),
+     (cxcz * cy) + (sxsz * sy)
+  );
+}
+
+inline d256 Quat_from_EulerZYX(const d256 half_angles)
+{
+  alignas(32) double h[4];
+  store4d(h, half_angles);
+  const double sx = std::sin(h[0]);
+  const double cx = std::cos(h[0]);
+  const double sy = std::sin(h[1]);
+  const double cy = std::cos(h[1]);
+  const double sz = std::sin(h[2]);
+  const double cz = std::cos(h[2]); 
+  const double cxsy = cx * sy;
+  const double cxcy = cx * cy;
+  const double sxsy = sx * sy;
+  const double sxcy = sx * cy;
+  return set4d(
+    (cxsy * sz) + (sxcy * cz),
+    (cxsy * cz) - (sxcy * sz),
+    (cxcy * sz) + (sxsy * cz),
+    (cxcy * cz) - (sxsy * sz)
+  );
+}
+
+inline d256 Quat_from_EulerZXY(const d256 half_angles)
+{
+  alignas(32) double h[4];
+  store4d(h, half_angles);
+  const double sx = std::sin(h[0]);
+  const double cx = std::cos(h[0]);
+  const double sy = std::sin(h[1]);
+  const double cy = std::cos(h[1]);
+  const double sz = std::sin(h[2]);
+  const double cz = std::cos(h[2]); 
+  const double cysx = cy * sx;
+  const double cycx = cy * cx;
+  const double sysx = sy * sx;
+  const double sycx = sy * cx;
+  return set4d(
+     (cysx * cz) + (sycx * sz),
+    -(cysx * sz) + (sycx * cz),
+     (cycx * sz) - (sysx * cz),
+     (cycx * cz) + (sysx * sz)
+  );
+}
+
+
+//-------------------------------------------------------------------------------------------
+// /Autogenerated code.
+//-------------------------------------------------------------------------------------------
+
+//-------------------------------------------------------------------------------------------
+enum class RotationOrder
+{
+  kXYZ, 
+  kYZX, 
+  kZXY, 
+  kXZY, 
+  kYXZ, 
+  kZYX
+};
+
+inline d256 multiplyQuat(const d256 parent, const d256 child)
+{
+  const d256 negw = set4d(0, 0, 0, -0.0);
+  const d256 pWWWW = permute4d<3, 3, 3, 3>(parent);
+  const d256 pXYZX = xor4d(permute4d<0, 1, 2, 0>(parent), negw);
+  const d256 pZXYY = permute4d<2, 0, 1, 1>(parent);
+  const d256 pYZXZ = xor4d(permute4d<1, 2, 0, 2>(parent), negw);
+  const d256 cXYZW = permute4d<0, 1, 2, 3>(child);
+  const d256 cWWWX = permute4d<3, 3, 3, 0>(child);
+  const d256 cYZXY = permute4d<1, 2, 0, 1>(child);
+  const d256 cZXYZ = permute4d<2, 0, 1, 2>(child);
+  d256 rr = fmadd4d(pXYZX, cWWWX, mul4d(pWWWW, cXYZW));
+  rr = fnmadd4d(pZXYY, cYZXY, rr);
+  return fmadd4d(pYZXZ, cZXYZ, rr);
+}
+
+inline d256 cross(d256 b, d256 c)
+{
+  const d256 B1 = permute4d<1, 2, 0, 3>(b);
+  const d256 C1 = permute4d<2, 0, 1, 3>(c);
+  const d256 B2 = permute4d<2, 0, 1, 3>(b);
+  const d256 C2 = permute4d<1, 2, 0, 3>(c);
+
+	// (a)[0] = (b)[1] * (c)[2] - (c)[1] * (b)[2];
+	// (a)[1] = (b)[2] * (c)[0] - (c)[2] * (b)[0];
+	// (a)[2] = (b)[0] * (c)[1] - (c)[0] * (b)[1];
+
+  return fmadd4d(B1, C1, mul4d(B2, C2));
+}
+
+inline void extractEuler(const d256 mat[4], RotationOrder rotOrder, GfVec3f& rot)
+{
+  const int mod3[6] = {0, 1, 2, 0, 1, 2};
+  const int k1 = int(rotOrder) > 2 ? 2 : 1;
+  const int k2 = 3 - k1;
+  const int row = mod3[int(rotOrder)];
+  const int col = mod3[k2 + row];
+  const int colCos = mod3[col + k1];
+  const int colSin = mod3[col + k2];
+  const int rowSin = mod3[row + k1];
+  const int rowCos = mod3[row + k2];
+  const double s  = int(rotOrder) < 3 ? -1.0 : 1.0;
+
+  const double epsilon = std::numeric_limits<double>::epsilon();
+  if (std::fabs(mat[row][col] - 1) < epsilon)
+  {
+    rot[row] = std::atan2(s*mat[rowSin][colCos], mat[rowSin][colSin]);
+    rot[rowSin] = s*M_PI/2;
+    rot[rowCos] = 0;
+  }
+  else
+  if (std::fabs(mat[row][col] + 1) < epsilon)
+  {    
+    rot[row] = std::atan2(-s*mat[rowSin][colCos], mat[rowSin][colSin]);
+    rot[rowSin] = -s*M_PI/2;
+    rot[rowCos] = 0;
+  }
+  else
+  {
+    rot[row] = std::atan2(-s*mat[rowSin][col], mat[rowCos][col] );
+    rot[rowSin] = std::asin ( s*mat[row][col] );
+    rot[rowCos] = std::atan2(-s*mat[row][colSin], mat[row][colCos] );
+  }
+}
+
+inline d256 quatInvert(d256 quat)
+{
+  return xor4d(quat, set4d(-0.0, -0.0, -0.0, 0.0));
+}
+
+void quatToMatrix(d256 quat, d256 matrix[4])
+{
+  // the standard Quatd to matrix follows this approach:
+  // 
+  //   1 - 2yy - 2zz,      2xy + 2wz,      2xz - 2wy
+  //       2xy - 2wz,  1 - 2xx - 2zz,      2yz + 2wx
+  //       2xz + 2wy,      2yz - 2wx,  1 - 2xx - 2yy
+  // 
+  // Pretty much every term needs to be multiplied by 2, so let's cheat instead! Define the following:
+  // 
+  //   X = x * sqrt(2);
+  //   Y = y * sqrt(2);
+  //   Z = z * sqrt(2);
+  //   W = w * sqrt(2);
+  //
+  // and now we can simplify the equation to:
+  // 
+  //   1 - YY - ZZ,      XY + ZW,      XZ - YW
+  //       XY - ZW,  1 - XX - ZZ,      YZ + XW
+  //       XZ + YW,      YZ - XW,  1 - XX - YY
+  //
+  // Whilst there are lots of common terms here, I'm only going to pre-calculate XY, XZ, and YZ. 
+  // All of the other terms I will calculate using FMA instructions. This does mean I'll be 
+  // duplicating some computations, however fmadd has a higher throughput that add or sub, so it's 
+  // actually just quicker to duplicate those computations! (somewhat counter intuitively!)
+  // 
+  const d256 root2 = splat4d(1.4142135623730950488016887242097);
+  //const d256 one = splat4d(1.0);
+  const d256 XYZW = mul4d(quat, root2);
+
+  d256 X;
+  d256 Y;
+  d256 Z;
+  {
+    auto YXX = permute4d<1, 0, 0, 3>(XYZW);
+    auto YYZ = permute4d<1, 1, 2, 3>(XYZW);
+    auto ZZY = permute4d<2, 2, 1, 3>(XYZW);
+    auto ZWW = permute4d<2, 3, 3, 3>(XYZW);
+    X = mul4d(YXX, YYZ);
+    ZZY = xor4d(ZZY, set4d(0, 0, -0.0, 0));
+    X = fmadd4d(ZZY, ZWW, X);
+    X = xor4d(X, set4d(-0.0, 0, 0, 0));
+    X = add4d(X, set4d(1.0, 0, 0, 0));
+  }
+  {
+    auto XXY = permute4d<0, 0, 1, 3>(XYZW);
+    auto YXZ = permute4d<1, 0, 2, 3>(XYZW);
+    auto ZZX = permute4d<2, 2, 0, 3>(XYZW);
+    auto WZW = permute4d<3, 2, 3, 3>(XYZW);
+    Y = mul4d(XXY, YXZ);
+    ZZX = xor4d(ZZX, set4d(-0.0, 0, 0, 0));
+    Y = fmadd4d(ZZX, WZW, Y);
+    Y = xor4d(Y, set4d(0, -0.0, 0, 0));
+    Y = add4d(Y, set4d(0, 1.0, 0, 0));
+  }
+  {
+    auto XYX = permute4d<0, 1, 0, 3>(XYZW);
+    auto ZZX = permute4d<2, 2, 0, 3>(XYZW);
+    auto YXY = permute4d<1, 0, 1, 3>(XYZW);
+    auto WWY = permute4d<3, 3, 1, 3>(XYZW);
+    Z = mul4d(XYX, ZZX);
+    YXY = xor4d(YXY, set4d(0, -0.0, 0, 0));
+    Z = fmadd4d(YXY, WWY, Z);
+    Z = xor4d(Z, set4d(0, 0, -0.0, 0));
+    Z = add4d(Z, set4d(0, 0, 1.0, 0));
+  }
+  matrix[0] = select4d<1, 1, 1, 0>(X, zero4d());
+  matrix[1] = select4d<1, 1, 1, 0>(Y, zero4d());
+  matrix[2] = select4d<1, 1, 1, 0>(Z, zero4d());
+  matrix[3] = set4d(0, 0, 0, 1.0);
+}
+
+/// there is room for improvement here!
+void extractEuler(const d256 q, RotationOrder rotOrder, GfVec3f& rot)
+{
+  d256 matrix[4];
+  quatToMatrix(q, matrix);
+  extractEuler(matrix, rotOrder, rot);
+}
+
+// rotate an offset vector by the coordinate frame
+inline d256 rotate(const d256 offset, const d256 frame[4])
+{
+  const d256 xxx = permute4d<0, 0, 0, 0>(offset);
+  const d256 yyy = permute4d<1, 1, 1, 1>(offset);
+  const d256 zzz = permute4d<2, 2, 2, 2>(offset);
+  return fmadd4d(zzz, frame[2], fmadd4d(yyy, frame[1], mul4d(xxx, frame[0])));
+}
+
+inline double dot3(d256 a, d256 b)
+{
+  d256 ab = mul4d(a, b);
+  return ab[0] + ab[1] + ab[2];
+}
+
+// rotate an offset vector by the coordinate frame
+inline d256 fastInverseRotate(const d256 offset, const d256 frame[4])
+{
+  return set4d(dot3(offset, frame[0]), dot3(offset, frame[1]), dot3(offset, frame[2]), 0);
+}
+
+// rotate an offset vector by the coordinate frame
+inline d256 inverseRotate(const d256 offset, const d256 frame[4])
+{
+  d256 len2 = set4d(dot3(frame[0], frame[0]), dot3(frame[1], frame[1]), dot3(frame[2], frame[2]), 0.0);
+  return div4d(set4d(dot3(offset, frame[0]), dot3(offset, frame[1]), dot3(offset, frame[2]), 0), len2);
+}
+
+// transform a point by the coordinate frame
+inline d256 transform(const d256 offset, const d256 frame[4])
+{
+  return add4d(frame[3], rotate(offset, frame));
+}
+
+// transform a point by the inverse coordinate frame
+inline d256 inverseTransform(d256 offset, const d256 frame[4])
+{
+  offset = sub4d(offset, frame[3]);
+  auto r = inverseRotate(offset, frame);
+  return r;
+}
+
+
+// frame *= childTransform
+inline void multiply(d256 frame[4], const d256 childTransform[4])
+{
+  const d256 mx = rotate(childTransform[0], frame);
+  const d256 my = rotate(childTransform[1], frame);
+  const d256 mz = rotate(childTransform[2], frame);
+  frame[3] = transform(childTransform[3], frame);
+  frame[0] = mx;
+  frame[1] = my;
+  frame[2] = mz;
+}
+
+// rotate an offset vector by the coordinate frame
+inline d256 transform4d(const d256 offset, const d256 frame[4])
+{
+  const d256 xxx = permute4d<0, 0, 0, 0>(offset);
+  const d256 yyy = permute4d<1, 1, 1, 1>(offset);
+  const d256 zzz = permute4d<2, 2, 2, 2>(offset);
+  const d256 www = permute4d<3, 3, 3, 3>(offset);
+  return fmadd4d(www, frame[3], fmadd4d(zzz, frame[2], fmadd4d(yyy, frame[1], mul4d(xxx, frame[0]))));
+}
+
+// frame *= childTransform
+inline void multiply4x4(d256 frame[4], const d256 childTransform[4])
+{
+  const d256 mx = transform4d(childTransform[0], frame);
+  const d256 my = transform4d(childTransform[1], frame);
+  const d256 mz = transform4d(childTransform[2], frame);
+  frame[3] = transform4d(childTransform[3], frame);
+  frame[0] = mx;
+  frame[1] = my;
+  frame[2] = mz;
+}
+// frame *= childTransform
+inline void multiply4x4(d256 output[4], const d256 childTransform[4], const d256 parentTransform[4])
+{
+  const d256 mx = transform4d(childTransform[0], parentTransform);
+  const d256 my = transform4d(childTransform[1], parentTransform);
+  const d256 mz = transform4d(childTransform[2], parentTransform);
+  output[3] = transform4d(childTransform[3], parentTransform);
+  output[0] = mx;
+  output[1] = my;
+  output[2] = mz;
+}
+// frame *= childTransform
+inline void multiply(d256 output[4], const d256 childTransform[4], const d256 parentTransform[4])
+{
+  const d256 mx = rotate(childTransform[0], parentTransform);
+  const d256 my = rotate(childTransform[1], parentTransform);
+  const d256 mz = rotate(childTransform[2], parentTransform);
+  output[3] = transform(childTransform[3], parentTransform);
+  output[0] = mx;
+  output[1] = my;
+  output[2] = mz;
+}
+
+inline d256 matrixToQuat(const d256 iframe[4])
+{
+  d256 frame[3];
+
+  // orthogonalise matrix
+  double lx = std::sqrt(dot3(iframe[0], iframe[0]));
+  double lz = std::sqrt(dot3(iframe[2], iframe[2]));
+  frame[0] = div4d(iframe[0], splat4d(lx));
+  frame[2] = div4d(iframe[2], splat4d(lz));
+  frame[1] = cross(iframe[2], iframe[0]);
+  frame[2] = cross(iframe[0], iframe[1]);
+
+  double W = 1.0 + frame[0][0] + frame[1][1] + frame[2][2];
+  W = std::sqrt(W);
+  const double qx = (frame[1][2] - frame[2][1]);
+  const double qy = (frame[2][0] - frame[0][2]);
+  const double s = (0.5 / W);
+  const double qz = (frame[0][1] - frame[1][0]);
+  return set4d(qx * s, qy * s, qz * s, W * 0.5);
+}
+
+} // end anon
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+MAYA_USD_UTILS_PUBLIC
+TransformOpProcessor::TransformOpProcessor(const UsdPrim prim, const TfToken opName, const TransformOpProcessor::ManipulatorMode mode, const UsdTimeCode& tc)
+  : _prim(prim)
+{
+  _ops = UsdGeomXformable(prim).GetOrderedXformOps(&_resetsXformStack);
+  const auto count = _ops.size();
+  for(_opIndex = 0; _opIndex < count; ++_opIndex)
+  {
+    if(_ops[_opIndex].GetOpName() == opName)
+      break;
+  }
+  if(_opIndex == count)
+  {
+    throw std::runtime_error(std::string("unable to find xform op on prim: ") + opName.GetString());
+  }
+  UpdateToTime(tc, mode);
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+MAYA_USD_UTILS_PUBLIC
+TransformOpProcessor::TransformOpProcessor(const UsdPrim prim, const uint32_t opIndex, const TransformOpProcessor::ManipulatorMode mode, const UsdTimeCode& tc)
+  : _opIndex(opIndex), _prim(prim)
+{
+  _ops = UsdGeomXformable(prim).GetOrderedXformOps(&_resetsXformStack);
+  if(_opIndex >= _ops.size())
+  {
+    throw std::range_error(std::string("invalid op index"));
+  }
+  UpdateToTime(tc, mode);
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+TransformOpProcessor::ManipulatorMode TransformOpProcessor::ManipMode() const
+{
+  return _manipMode; 
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+MAYA_USD_UTILS_PUBLIC
+bool TransformOpProcessor::CanRotate() const
+{
+  if(const auto xop = op())
+  {
+    switch(xop.GetOpType())
+    {
+    case UsdGeomXformOp::TypeTranslate:
+    case UsdGeomXformOp::TypeScale:
+    case UsdGeomXformOp::TypeInvalid:
+      return false;
+    default:
+      break;
+    }
+    return true;
+  }
+  return false;
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+MAYA_USD_UTILS_PUBLIC
+bool TransformOpProcessor::CanTranslate() const
+{
+  if(const auto xop = op())
+  {
+    switch(xop.GetOpType())
+    {
+    case UsdGeomXformOp::TypeTransform:
+    case UsdGeomXformOp::TypeTranslate:
+      return true;
+    default:
+      break;
+    }
+  }
+  return false;
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+MAYA_USD_UTILS_PUBLIC
+bool TransformOpProcessor::CanScale() const
+{
+  if(const auto xop = op())
+  {
+    switch(xop.GetOpType())
+    {
+    case UsdGeomXformOp::TypeTransform:
+    case UsdGeomXformOp::TypeScale:
+      return true;
+    default:
+      break;
+    }
+  }
+  return false;
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+MAYA_USD_UTILS_PUBLIC
+void TransformOpProcessor::UpdateToTime(const UsdTimeCode& tc, UsdGeomXformCache& cache, const TransformOpProcessor::ManipulatorMode mode)
+{
+  _manipMode = mode;
+  _timeCode = tc;
+
+  // grab type of op 
+  auto xop = op();
+  auto opType = xop.GetOpType();
+
+  // if we are to guess the manipulator mode in use...
+  if(_manipMode == kGuess)
+  {
+    // if the type is a translation (or a matrix - default to possibly wrong here!)
+    if(opType == UsdGeomXformOp::TypeTransform || 
+       opType == UsdGeomXformOp::TypeTranslate)
+    {
+      _manipMode = kTranslate;
+    }
+    else
+    // if the op type is a scale
+    if(opType == UsdGeomXformOp::TypeScale)
+    {
+      _manipMode = kScale;
+    }
+    else
+    // otherwise assume a rotation
+    {
+      _manipMode = kRotate;
+    }
+  }
+
+  // evaluate the initial guess for the coordinate frame 
+  _coordFrame = EvaluateCoordinateFrameForIndex(_ops, _opIndex, _timeCode);
+
+  // If we have a matrix transformation, depending on the type of manip used, 
+  // we may have to offset the coordinate frame slightly
+  if(opType == UsdGeomXformOp::TypeTransform)
+  {
+    switch(_manipMode)
+    {
+    default:
+    case kTranslate:
+      /* nothing to do. Translation frame will be correct */
+      break;
+
+    case kRotate:
+      /* we need to offset the coordinate frame by the translation */
+      {
+        alignas(32) GfMatrix4d matrix;
+        if(xop.Get(&matrix, _timeCode))
+        {
+          // transform offset by coordinate frame, and apply to coordinate frame
+          GfVec4d offset(matrix[3][0], matrix[3][1], matrix[3][2], 0.0);
+          offset = offset * _coordFrame;
+          _coordFrame[3][0] += offset[0];
+          _coordFrame[3][1] += offset[1];
+          _coordFrame[3][2] += offset[2];
+        }
+      }
+      break;
+
+    case kScale:
+      /* we need to offset the coordinate frame by the translation & rotation */
+      {
+        d256 matrix[4];
+        if(xop.Get((GfMatrix4d*)matrix, _timeCode))
+        {
+          // orthogonalise matrix to remove scaling
+          auto sx = splat4d(std::sqrt(dot3(matrix[0], matrix[0])));
+          auto sy = splat4d(std::sqrt(dot3(matrix[1], matrix[1])));
+          auto sz = splat4d(std::sqrt(dot3(matrix[2], matrix[2])));
+          matrix[0] = div4d(matrix[0], sx);
+          matrix[1] = div4d(matrix[1], sy);
+          matrix[2] = div4d(matrix[2], sz);
+          // offset the coordinate frame
+          multiply4x4((d256*)&_coordFrame, matrix, (const d256*)&_coordFrame);
+        }
+      }
+      break;
+    }
+  }
+
+  switch(_manipMode)
+  {
+  default:
+  case kTranslate:
+    if(!CanTranslate())
+    {
+      throw std::runtime_error(std::string("Cannot translate transform op: ") + xop.GetName().GetString());
+    }
+    break;
+  case kRotate:
+    if(!CanRotate())
+    {
+      throw std::runtime_error(std::string("Cannot rotate transform op: ") + xop.GetName().GetString());
+    }
+    break;
+  case kScale:
+    if(!CanScale())
+    {
+      throw std::runtime_error(std::string("Cannot scale transform op: ") + xop.GetName().GetString());
+    }
+    break;
+  }
+
+  if(!_resetsXformStack)
+  {
+    alignas(32) auto _parentFrame = cache.GetParentToWorldTransform(_prim);
+    multiply4x4((d256*)&_worldFrame, (const d256*)&_coordFrame, (const d256*)&_parentFrame);
+    _invWorldFrame = _worldFrame.GetInverse();
+    _invCoordFrame = _coordFrame.GetInverse();
+    _qcoordFrame = matrixToQuat((const d256*)&_coordFrame);
+    _qworldFrame = matrixToQuat((const d256*)&_worldFrame);
+  }
+  else
+  {
+    // set to identity
+    const d256 x = set4d(1.0, 0.0, 0.0, 0.0);
+    const d256 y = set4d(0.0, 1.0, 0.0, 0.0);
+    const d256 z = set4d(0.0, 0.0, 1.0, 0.0);
+    const d256 w = set4d(0.0, 0.0, 0.0, 1.0);
+    store4d(_worldFrame[0], x);
+    store4d(_invWorldFrame[0], x);
+    store4d(_worldFrame[1], y);
+    store4d(_invWorldFrame[1], y);
+    store4d(_worldFrame[2], z);
+    store4d(_invWorldFrame[2], z);
+    store4d(_worldFrame[3], w);
+    store4d(_invWorldFrame[3], w);
+    _qworldFrame = w;
+    _invCoordFrame = _coordFrame.GetInverse();
+    _qcoordFrame = matrixToQuat((const d256*)&_coordFrame);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+MAYA_USD_UTILS_PUBLIC
+bool TransformOpProcessor::Translate(const GfVec3d& translateChange, const Space space)
+{
+  auto xformOp = op();
+  // check to make sure this transform op can be translated!
+  if(_manipMode != kTranslate)
+  {
+    if(xformOp.GetOpType() == UsdGeomXformOp::TypeTransform)
+    {
+      // update to time can convert the coordinate frame in this case
+      UpdateToTime(_timeCode, kTranslate);
+    }
+    else
+    {
+      return false;
+    }
+  }
+
+  d256 temp = set4d(translateChange[0], translateChange[1], translateChange[2], 0);
+  switch(space)
+  {
+  case kTransform: break;
+  case kWorld: temp = transform4d(temp, (const d256*)&_invWorldFrame); break;
+  case kParent: temp = transform4d(temp, (const d256*)&_invCoordFrame); break;
+  }
+
+  // if the change is close to zero, ignore it. 
+  {
+    const auto atemp = abs4d(temp);
+    const auto eps = splat4d(1e-6);
+    if( (movemask4d(cmpgt4d(atemp, eps)) & 0x7) == 0 )
+    {
+      // technically not a failure. It just doesn't seem worth applying the change...
+      return true;
+    }
+  }
+
+  if(xformOp.GetOpType() == UsdGeomXformOp::TypeTranslate)
+  {
+    // grab the current value from USD
+    d256 original = zero4d();
+    const auto precision = op().GetPrecision();
+    switch(precision)
+    {
+    case UsdGeomXformOp::PrecisionDouble:
+      {
+        xformOp.Get((GfVec3d*)&original, _timeCode);
+      }
+      break;
+
+    case UsdGeomXformOp::PrecisionFloat:
+      {
+        f128 v;
+        xformOp.Get((GfVec3f*)&v, _timeCode);
+        original = cvt4f_to_4d(v);
+      }
+      break;
+
+    case UsdGeomXformOp::PrecisionHalf:
+      {
+        i128 v;
+        xformOp.Get((GfVec3h*)&v, _timeCode);
+        original = cvt4f_to_4d(cvtph4(v));
+      }
+      break;
+    }
+
+    // sum offset
+    temp = add4d(temp, original);
+    // write back into USD
+    switch(precision)
+    {
+    case UsdGeomXformOp::PrecisionDouble:
+      {
+        void* ptr = &temp;
+        xformOp.Set(*(GfVec3d*)ptr, _timeCode);
+      }
+      break;
+
+    case UsdGeomXformOp::PrecisionFloat:
+      {
+        f128 v = cvt4d_to_4f(temp);
+        void* ptr = &v;
+        xformOp.Set(*(GfVec3f*)ptr, _timeCode);
+      }
+      break;
+
+    case UsdGeomXformOp::PrecisionHalf:
+      {
+        i128 v = cvtph4(cvt4d_to_4f(temp));
+        void* ptr = &v;
+        xformOp.Set(*(GfVec3h*)ptr, _timeCode);
+      }
+      break;
+    }
+  }
+  else
+  if(xformOp.GetOpType() == UsdGeomXformOp::TypeTransform)
+  {
+    d256 matrix[4] = {
+      set4d(1.0, 0.0, 0.0, 0.0),
+      set4d(0.0, 1.0, 0.0, 0.0),
+      set4d(0.0, 0.0, 1.0, 0.0),
+      set4d(0.0, 0.0, 0.0, 1.0)
+    };
+    xformOp.Get((GfMatrix4d*)matrix, _timeCode);
+    matrix[3] = add4d(temp, matrix[3]);
+    xformOp.Set(*(GfMatrix4d*)matrix, _timeCode);
+  }
+  else
+  {
+    return false;
+  }
+  return true;
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+static inline bool isClose(const double a, const double b)
+{
+  return std::abs(a - b) < 1e-6f;
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+MAYA_USD_UTILS_PUBLIC
+bool TransformOpProcessor::Scale(const GfVec3d& scaleChange, const Space space)
+{
+  // when in strange coordinate frames, scaling can only be safely applied if the XYZ values are uniform
+  switch(space)
+  {
+  case kTransform: break;
+  case kWorld:
+  case kParent:
+    {
+      if(!isClose(scaleChange[0], scaleChange[1]) || 
+         !isClose(scaleChange[0], scaleChange[2]))
+      {
+        return false;
+      }
+    }
+    break;
+  }
+
+  auto xformOp = op();
+  // check to make sure this transform op can be translated!
+  if(_manipMode != kScale)
+  {
+    if(xformOp.GetOpType() == UsdGeomXformOp::TypeTransform)
+    {
+      // update to time can convert the coordinate frame in this case
+      UpdateToTime(_timeCode, kScale);
+    }
+    else
+    {
+      return false;
+    }
+  }
+
+  d256 temp = set4d(scaleChange[0], scaleChange[1], scaleChange[2], 0.0);
+
+  // if the change is close to one, ignore it. 
+  {
+    const auto abstemp = abs4d(sub4d(temp, splat4d(1.0)));
+    const auto eps = splat4d(1e-6);
+    if( (movemask4d(cmpgt4d(abstemp, eps)) & 0x7) == 0 )
+    {
+      // technically not a failure. It just doesn't seem worth applying the change...
+      return true;
+    }
+  }
+
+  if(xformOp.GetOpType() == UsdGeomXformOp::TypeScale)
+  {
+    // grab the current value from USD
+    d256 original = set4d(1.0, 1.0, 1.0, 0.0);
+    const auto precision = xformOp.GetPrecision();
+    switch(precision)
+    {
+    case UsdGeomXformOp::PrecisionDouble:
+      {
+        xformOp.Get((GfVec3d*)&original, _timeCode);
+      }
+      break;
+
+    case UsdGeomXformOp::PrecisionFloat:
+      {
+        f128 v;
+        xformOp.Get((GfVec3f*)&v, _timeCode);
+        original = cvt4f_to_4d(v);
+      }
+      break;
+
+    case UsdGeomXformOp::PrecisionHalf:
+      {
+        i128 v;
+        xformOp.Get((GfVec3h*)&v, _timeCode);
+        original = cvt4f_to_4d(cvtph4(v));
+      }
+      break;
+    }
+
+    // multiply scaling
+    temp = mul4d(temp, original);
+
+    // write back into USD
+    switch(precision)
+    {
+    case UsdGeomXformOp::PrecisionDouble:
+      {
+        xformOp.Set(*(GfVec3d*)&temp, _timeCode);
+      }
+      break;
+
+    case UsdGeomXformOp::PrecisionFloat:
+      {
+        f128 v = cvt4d_to_4f(temp);
+        void* ptr = &v;
+        xformOp.Set(*(GfVec3f*)ptr, _timeCode);
+      }
+      break;
+
+    case UsdGeomXformOp::PrecisionHalf:
+      {
+        i128 v = cvtph4(cvt4d_to_4f(temp));
+        void* ptr = &v;
+        xformOp.Set(*(GfVec3h*)ptr, _timeCode);
+      }
+      break;
+    }
+  }
+  else
+  if(xformOp.GetOpType() == UsdGeomXformOp::TypeTransform)
+  {
+    d256 matrix[4] = {
+      set4d(1.0, 0.0, 0.0, 0.0),
+      set4d(0.0, 1.0, 0.0, 0.0),
+      set4d(0.0, 0.0, 1.0, 0.0),
+      set4d(0.0, 0.0, 0.0, 1.0)
+    };
+    xformOp.Get((GfMatrix4d*)matrix, _timeCode);
+    matrix[0] = mul4d(permute4d<0,0,0,0>(temp), matrix[0]);
+    matrix[1] = mul4d(permute4d<1,1,1,1>(temp), matrix[1]);
+    matrix[2] = mul4d(permute4d<2,2,2,2>(temp), matrix[2]);
+    xformOp.Set(*(GfMatrix4d*)matrix, _timeCode);
+  }
+  else
+  {
+    return false;
+  }
+  return true;
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+MAYA_USD_UTILS_PUBLIC
+bool TransformOpProcessor::Rotate(const GfQuatd& quatChange, Space space)
+{
+  d256 temp = set4d(quatChange.GetImaginary()[0], quatChange.GetImaginary()[1], quatChange.GetImaginary()[2], quatChange.GetReal());
+
+  // if the change is close to zero, ignore it. 
+  {
+    const auto atemp = abs4d(sub4d(temp, set4d(0.0, 0.0, 0.0, 1.0)));
+    const auto eps = splat4d(1e-6);
+    if(!movemask4d(cmpgt4d(atemp, eps)))
+    {
+      // technically not a failure. It just doesn't seem worth applying an identity rotation
+      return true;
+    }
+  }
+
+  auto xformOp = op();
+  // check to make sure this transform op can be rotated!
+  if(_manipMode != kRotate)
+  {
+    if(xformOp.GetOpType() == UsdGeomXformOp::TypeTransform)
+    {
+      // update to time can convert the coordinate frame in this case
+      UpdateToTime(_timeCode, kRotate);
+    }
+    else
+    {
+      return false;
+    }
+  }
+
+  // a utility method that applies an rotational offset to the original rotation quaternion, 
+  // in the correct coordinate frame (e.g. local, parent, world), and returns the resulting
+  // euler angle triplet
+  auto processMatrixRotation = [this] (d256 offset, const Space space)
+  {
+    switch(space)
+    {
+    default:
+      {
+        // grab original matrix
+        d256 matrix[4] = {
+          set4d(1.0, 0.0, 0.0, 0.0),
+          set4d(0.0, 1.0, 0.0, 0.0),
+          set4d(0.0, 0.0, 1.0, 0.0),
+          set4d(0.0, 0.0, 0.0, 1.0)
+        };
+        op().Get((GfMatrix4d*)matrix, _timeCode);
+        d256 rmatrix[4];
+        quatToMatrix(offset, rmatrix);
+        matrix[0] = rotate(matrix[0], rmatrix);
+        matrix[1] = rotate(matrix[1], rmatrix);
+        matrix[2] = rotate(matrix[2], rmatrix);
+        op().Set(*(GfMatrix4d*)matrix, _timeCode);
+      }
+      break;
+    case kWorld:
+      {
+        // grab original matrix
+        d256 omatrix[4] = {
+          set4d(1.0, 0.0, 0.0, 0.0),
+          set4d(0.0, 1.0, 0.0, 0.0),
+          set4d(0.0, 0.0, 1.0, 0.0),
+          set4d(0.0, 0.0, 0.0, 1.0)
+        };
+        op().Get((GfMatrix4d*)omatrix, _timeCode);
+
+        d256 rotateMatrix[4], rmatrix[4] = {load4d(_worldFrame[0]), load4d(_worldFrame[1]), load4d(_worldFrame[2]), zero4d()};
+        quatToMatrix(offset, rotateMatrix);
+        d256 translateToAddBackIn = omatrix[3];
+        rotateMatrix[3] = omatrix[3] = zero4d();
+        multiply(rmatrix, omatrix, rmatrix);
+        // remove translation
+        rmatrix[3] = zero4d();
+        multiply(rotateMatrix, rmatrix, rotateMatrix);
+        // add translation back in here
+        rotateMatrix[3] = load4d(_worldFrame[3]);
+        // bang into local space
+        multiply4x4(rmatrix, rotateMatrix, (d256*)&_invWorldFrame);
+        rmatrix[3] = translateToAddBackIn;
+        op().Set(*(GfMatrix4d*)rmatrix, _timeCode);
+      }
+      break;
+    case kParent:
+      {
+        // grab original matrix
+        d256 omatrix[4] = {
+          set4d(1.0, 0.0, 0.0, 0.0),
+          set4d(0.0, 1.0, 0.0, 0.0),
+          set4d(0.0, 0.0, 1.0, 0.0),
+          set4d(0.0, 0.0, 0.0, 1.0)
+        };
+        op().Get((GfMatrix4d*)omatrix, _timeCode);
+
+        d256 rotateMatrix[4], rmatrix[4] = {load4d(_coordFrame[0]), load4d(_coordFrame[1]), load4d(_coordFrame[2]), zero4d()};
+        quatToMatrix(offset, rotateMatrix);
+        d256 translateToAddBackIn = omatrix[3];
+        rotateMatrix[3] = omatrix[3] = zero4d();
+        multiply(rmatrix, omatrix, rmatrix);
+        // remove translation
+        rmatrix[3] = zero4d();
+        multiply(rotateMatrix, rmatrix, rotateMatrix);
+        // add translation back in here
+        rotateMatrix[3] = load4d(_coordFrame[3]);
+        // bang into local space
+        multiply4x4(rmatrix, rotateMatrix, (d256*)&_invWorldFrame);
+        rmatrix[3] = translateToAddBackIn;
+        op().Set(*(GfMatrix4d*)rmatrix, _timeCode);
+      }
+      break;
+      
+    }
+  };
+  
+  // a utility method that applies an rotational offset to the original rotation quaternion, 
+  // in the correct coordinate frame (e.g. local, parent, world), and returns the resulting
+  // euler angle triplet
+  auto process3AxisRotation = [this] (d256 original, d256 offset, const Space space, const RotationOrder order)
+  {
+    GfVec3f rot(0);
+    switch(space)
+    {
+    default:
+      {
+        d256 new_rotation = multiplyQuat(original, offset);
+        extractEuler(new_rotation, order, rot);
+      }
+      break;
+    case kWorld:
+      {
+        d256 rotateMatrix[4], rmatrix[4] = {load4d(_worldFrame[0]), load4d(_worldFrame[1]), load4d(_worldFrame[2]), zero4d()}, omatrix[4];
+        quatToMatrix(offset, rotateMatrix);
+        quatToMatrix(original, omatrix);
+        rotateMatrix[3] = omatrix[3] = zero4d();
+        multiply(rmatrix, omatrix, rmatrix);
+        // remove translation
+        rmatrix[3] = zero4d();
+        multiply(rotateMatrix, rmatrix, rotateMatrix);
+        // add translation back in here
+        rotateMatrix[3] = load4d(_worldFrame[3]);
+        multiply4x4(rmatrix, rotateMatrix, (d256*)&_invWorldFrame);
+        d256 ctest = cross(rmatrix[0], rmatrix[1]);
+        if(dot3(ctest, rmatrix[2]) < 0)
+          rmatrix[2] = sub4d(zero4d(), rmatrix[2]);
+        extractEuler(rmatrix, order , rot);
+      }
+      break;
+    case kParent:
+      {
+        d256 rotateMatrix[4], rmatrix[4] = {load4d(_coordFrame[0]), load4d(_coordFrame[1]), load4d(_coordFrame[2]), zero4d()}, omatrix[4];
+        quatToMatrix(offset, rotateMatrix);
+        quatToMatrix(original, omatrix);
+        rotateMatrix[3] = omatrix[3] = zero4d();
+        multiply(rmatrix, omatrix, rmatrix);
+        // remove translation
+        rmatrix[3] = zero4d();
+        multiply(rotateMatrix, rmatrix, rotateMatrix);
+        rotateMatrix[3] = load4d(_worldFrame[3]);
+        multiply4x4(rmatrix, rotateMatrix, (d256*)&_invCoordFrame);
+        d256 ctest = cross(rmatrix[0], rmatrix[1]);
+        if(dot3(ctest, rmatrix[2]) < 0)
+          rmatrix[2] = sub4d(zero4d(), rmatrix[2]);
+        extractEuler(rmatrix, order , rot);
+      }
+      break;
+      
+    }
+    // convert back to degrees
+    return rot * (180.0f / M_PI);
+  };
+
+  // a utility method that applies an rotational offset to the original rotation quaternion, 
+  // in the correct coordinate frame (e.g. local, parent, world), and returns the new rotation 
+  // as a quaternion
+  auto process1AxisRotation = [this] (const d256 original, d256 offset, const Space space)
+  {
+    d256 new_rotation;
+    // convert rotation offset into the correct coordinate frame for the transformation
+    switch(space)
+    {
+    default:
+    case kTransform:
+      new_rotation = multiplyQuat(original, offset);
+      break;
+    case kWorld:
+      new_rotation = multiplyQuat(_qworldFrame, original);
+      new_rotation = multiplyQuat(offset, new_rotation);
+      new_rotation = multiplyQuat(quatInvert(_qworldFrame), new_rotation);
+      break;
+    case kParent:
+      new_rotation = multiplyQuat(_qcoordFrame, original);
+      new_rotation = multiplyQuat(offset, new_rotation);
+      new_rotation = multiplyQuat(quatInvert(_qcoordFrame), original);
+      break;
+    }
+    return new_rotation;
+  };
+
+  const auto precision = xformOp.GetPrecision();
+  switch(xformOp.GetOpType())
+  {
+  case UsdGeomXformOp::TypeTransform:
+    {
+      processMatrixRotation(temp, space);
+    }
+    break;
+
+  case UsdGeomXformOp::TypeRotateX:
+    {
+      double original = 0;
+      switch(precision)
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        {
+          xformOp.Get(&original, _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        {
+          float foriginal = 0;
+          xformOp.Get(&foriginal, _timeCode);
+          original = double(foriginal);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        {
+          GfHalf foriginal = 0;
+          xformOp.Get(&foriginal, _timeCode);
+          original = double(float(foriginal));
+        }
+        break;
+      }
+      // convert to half angle radians
+      auto half_angle = original * (M_PI / 360.0);
+      auto orig_quat = set4d(std::sin(half_angle), 0, 0, std::cos(half_angle));
+      auto new_rotation = process1AxisRotation(orig_quat, temp, space);
+      
+      // and back to degrees
+      const double xrotate = std::atan2(new_rotation[0], new_rotation[3]) * (360.0 / M_PI);
+      original = xrotate;
+
+      switch(precision)
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        xformOp.Set(original, _timeCode);
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        xformOp.Set(float(original), _timeCode);
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        xformOp.Set(GfHalf(float(original)), _timeCode);
+        break;
+      }
+    }
+    break;
+
+  case UsdGeomXformOp::TypeRotateY:
+    {
+      double original = 0;
+      switch(precision)
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        {
+          xformOp.Get(&original, _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        {
+          float foriginal = 0;
+          xformOp.Get(&foriginal, _timeCode);
+          original = double(foriginal);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        {
+          GfHalf foriginal = 0;
+          xformOp.Get(&foriginal, _timeCode);
+          original = double(float(foriginal));
+        }
+        break;
+      }
+      // convert to half angle radians
+      auto half_angle = original * (M_PI / 360.0);
+      auto orig_quat = set4d(0, std::sin(half_angle), 0, std::cos(half_angle));
+      auto new_rotation = process1AxisRotation(orig_quat, temp, space);
+      
+      // and back to degrees
+      const double yrotate = std::atan2(new_rotation[1], new_rotation[3]) * (360.0 / M_PI);
+      original = yrotate;
+
+      switch(precision)
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        xformOp.Set(original, _timeCode);
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        xformOp.Set(float(original), _timeCode);
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        xformOp.Set(GfHalf(float(original)), _timeCode);
+        break;
+      }
+    }
+    break;
+
+  case UsdGeomXformOp::TypeRotateZ:
+    {
+      double original = 0;
+      switch(precision)
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        {
+          xformOp.Get(&original, _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        {
+          float foriginal = 0;
+          xformOp.Get(&foriginal, _timeCode);
+          original = double(foriginal);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        {
+          GfHalf foriginal = 0;
+          xformOp.Get(&foriginal, _timeCode);
+          original = double(float(foriginal));
+        }
+        break;
+      }
+      // convert to half angle radians
+      auto half_angle = original * (M_PI / 360.0);
+      auto orig_quat = set4d(0, 0, std::sin(half_angle), std::cos(half_angle));
+      auto new_rotation = process1AxisRotation(orig_quat, temp, space);
+      
+      // and back to degrees
+      const double zrotate = std::atan2(new_rotation[2], new_rotation[3]) * (360.0 / M_PI);
+      original = zrotate;
+
+      switch(precision)
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        xformOp.Set(original, _timeCode);
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        xformOp.Set(float(original), _timeCode);
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        xformOp.Set(GfHalf(float(original)), _timeCode);
+        break;
+      }
+    }
+    break;
+
+  case UsdGeomXformOp::TypeRotateXYZ:
+    {
+      switch(precision)
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        {
+          d256 original = zero4d();
+          xformOp.Get((GfVec3d*)&original, _timeCode);
+          original = Quat_from_EulerXYZ(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kXYZ);
+          xformOp.Set(GfVec3d(rot), _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        {
+          f128 forig = zero4f();
+          xformOp.Get((GfVec3f*)&forig, _timeCode);
+          d256 original = cvt4f_to_4d(forig);
+          original = Quat_from_EulerXYZ(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kXYZ);
+          xformOp.Set(GfVec3f(rot), _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        {
+          i128 forig = zero4i();
+          xformOp.Get((GfVec3h*)&forig, _timeCode);
+          d256 original = cvt4f_to_4d(cvtph4(forig));
+          original = Quat_from_EulerXYZ(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kXYZ);
+          xformOp.Set(GfVec3h(rot), _timeCode);
+        }
+        break;
+      }
+    }
+    break;
+
+  case UsdGeomXformOp::TypeRotateXZY:
+    {
+      switch(precision)
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        {
+          d256 original = zero4d();
+          xformOp.Get((GfVec3d*)&original, _timeCode);
+          original = Quat_from_EulerXZY(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kXZY);
+          xformOp.Set(GfVec3d(rot), _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        {
+          f128 forig = zero4f();
+          xformOp.Get((GfVec3f*)&forig, _timeCode);
+          d256 original = cvt4f_to_4d(forig);
+          original = Quat_from_EulerXZY(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kXZY);
+          xformOp.Set(rot, _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        {
+          i128 forig = zero4i();
+          xformOp.Get((GfVec3h*)&forig, _timeCode);
+          d256 original = cvt4f_to_4d(cvtph4(forig));
+          original = Quat_from_EulerXZY(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kXZY);
+          xformOp.Set(GfVec3h(rot), _timeCode);
+        }
+        break;
+      }
+    }
+    break;
+
+  case UsdGeomXformOp::TypeRotateYXZ:
+    {
+      switch(precision)
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        {
+          d256 original = zero4d();
+          xformOp.Get((GfVec3d*)&original, _timeCode);
+          original = Quat_from_EulerYXZ(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kYXZ);
+          xformOp.Set(GfVec3d(rot), _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        {
+          f128 forig = zero4f();
+          xformOp.Get((GfVec3f*)&forig, _timeCode);
+          d256 original = cvt4f_to_4d(forig);
+          original = Quat_from_EulerYXZ(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kYXZ);
+          xformOp.Set(rot, _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        {
+          i128 forig = zero4i();
+          xformOp.Get((GfVec3h*)&forig, _timeCode);
+          d256 original = cvt4f_to_4d(cvtph4(forig));
+          original = Quat_from_EulerYXZ(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kYXZ);
+          xformOp.Set(GfVec3h(rot), _timeCode);
+        }
+        break;
+      }
+    }
+    break;
+
+  case UsdGeomXformOp::TypeRotateYZX:
+    {
+      switch(precision)
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        {
+          d256 original = zero4d();
+          xformOp.Get((GfVec3d*)&original, _timeCode);
+          original = Quat_from_EulerYZX(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kYZX);
+          xformOp.Set(GfVec3d(rot), _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        {
+          f128 forig = zero4f();
+          xformOp.Get((GfVec3f*)&forig, _timeCode);
+          d256 original = cvt4f_to_4d(forig);
+          original = Quat_from_EulerYZX(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kYZX);
+          xformOp.Set(rot, _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        {
+          i128 forig = zero4i();
+          xformOp.Get((GfVec3h*)&forig, _timeCode);
+          d256 original = cvt4f_to_4d(cvtph4(forig));
+          original = Quat_from_EulerYZX(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kYZX);
+          xformOp.Set(GfVec3h(rot), _timeCode);
+        }
+        break;
+      }
+    }
+    break;
+
+  case UsdGeomXformOp::TypeRotateZXY:
+    {
+      switch(precision)
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        {
+          d256 original = zero4d();
+          xformOp.Get((GfVec3d*)&original, _timeCode);
+          original = Quat_from_EulerZXY(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kZXY);
+          xformOp.Set(GfVec3d(rot), _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        {
+          f128 forig = zero4f();
+          xformOp.Get((GfVec3f*)&forig, _timeCode);
+          d256 original = cvt4f_to_4d(forig);
+          original = Quat_from_EulerZXY(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kZXY);
+          xformOp.Set(rot, _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        {
+          i128 forig = zero4i();
+          xformOp.Get((GfVec3h*)&forig, _timeCode);
+          d256 original = cvt4f_to_4d(cvtph4(forig));
+          original = Quat_from_EulerZXY(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kZXY);
+          xformOp.Set(GfVec3h(rot), _timeCode);
+        }
+        break;
+      }
+    }
+    break;
+
+  case UsdGeomXformOp::TypeRotateZYX:
+    {
+      switch(precision)
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        {
+          d256 original = zero4d();
+          xformOp.Get((GfVec3d*)&original, _timeCode);
+          original = Quat_from_EulerZYX(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kZYX);
+          xformOp.Set(GfVec3d(rot), _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        {
+          f128 forig = zero4f();
+          xformOp.Get((GfVec3f*)&forig, _timeCode);
+          d256 original = cvt4f_to_4d(forig);
+          original = Quat_from_EulerZYX(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kZYX);
+          xformOp.Set(rot, _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        {
+          i128 forig = zero4i();
+          xformOp.Get((GfVec3h*)&forig, _timeCode);
+          d256 original = cvt4f_to_4d(cvtph4(forig));
+          original = Quat_from_EulerZYX(mul4d(original, splat4d(M_PI / 360.0)));
+          auto rot = process3AxisRotation(original, temp, space, RotationOrder::kZYX);
+          xformOp.Set(GfVec3h(rot), _timeCode);
+        }
+        break;
+      }
+    }
+    break;
+
+  case UsdGeomXformOp::TypeOrient:
+    {
+      switch(precision)
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        {
+          d256 original = set4d(0, 0, 0, 1.0);
+          xformOp.Get((GfQuatd*)&original, _timeCode);
+          original = multiplyQuat(original, temp);
+          xformOp.Set(*(GfQuatd*)&original, _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        {
+          f128 original = set4f(0, 0, 0, 1.0f);
+          xformOp.Get((GfQuatf*)&original, _timeCode);
+          original = cvt4d_to_4f(multiplyQuat(cvt4f_to_4d(original), temp));
+          xformOp.Set(*(GfQuatf*)&original, _timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        {
+          i128 original = zero4i();
+          xformOp.Get((GfQuath*)&original, _timeCode);
+          original = cvtph4(cvt4d_to_4f(multiplyQuat(cvt4f_to_4d(cvtph4(original)), temp)));
+          void* ptr = &original;
+          xformOp.Set(*(GfQuath*)ptr, _timeCode);
+        }
+        break;
+      }
+    }
+    break;
+    
+  // unsupported transform op type
+  default:
+    return false;
+  }
+  return true;
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+MAYA_USD_UTILS_PUBLIC
+bool TransformOpProcessor::RotateX(const double radianChange, Space space)
+{
+  if(space == kTransform)
+  {
+    auto xformOp = op();
+    const auto precision = xformOp.GetPrecision();
+    switch(xformOp.GetOpType())
+    {
+    case UsdGeomXformOp::TypeRotateX:
+      {
+        switch(precision)
+        {
+        case UsdGeomXformOp::PrecisionDouble:
+          {
+            double original = 0;
+            xformOp.Get(&original, _timeCode);
+            original += radianChange * (180.0 / M_PI);
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionFloat:
+          {
+            float original = 0;
+            xformOp.Get(&original, _timeCode);
+            original += radianChange * float(180.0 / M_PI);
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionHalf:
+          {
+            GfHalf original = 0;
+            xformOp.Get(&original, _timeCode);
+            original += radianChange * float(180.0 / M_PI);
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+        }
+        return true;
+      }
+
+    // directly modifying the x value only ever works when the rotation order begins with X
+    case UsdGeomXformOp::TypeRotateXYZ:
+    case UsdGeomXformOp::TypeRotateXZY:
+      {
+        switch(precision)
+        {
+        case UsdGeomXformOp::PrecisionDouble:
+          {
+            GfVec3d original(0);
+            xformOp.Get(&original, _timeCode);
+            original[0] += radianChange * (180.0 / M_PI);
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionFloat:
+          {
+            GfVec3f original(0);
+            xformOp.Get(&original, _timeCode);
+            original[0] += radianChange * (180.0 / M_PI);
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionHalf:
+          {
+            GfVec3h original(0);
+            xformOp.Get(&original, _timeCode);
+            original[0] += radianChange * (180.0 / M_PI);
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+        }
+        return true;
+      }
+
+    case UsdGeomXformOp::TypeRotateYZX:
+    case UsdGeomXformOp::TypeRotateZYX:
+    case UsdGeomXformOp::TypeRotateYXZ:
+    case UsdGeomXformOp::TypeRotateZXY:
+    case UsdGeomXformOp::TypeTransform:
+    case UsdGeomXformOp::TypeOrient:
+      /* These have to be handled via quats sadly :( */
+      break;
+
+    // unsupported op type
+    case UsdGeomXformOp::TypeRotateY:
+    case UsdGeomXformOp::TypeRotateZ:
+    default:
+      return false;
+    }
+  }
+  const double sr = std::sin(radianChange * 0.5f);
+  const double cr = std::cos(radianChange * 0.5f);
+  return Rotate(GfQuatd(cr, sr, 0, 0), space);
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+MAYA_USD_UTILS_PUBLIC
+bool TransformOpProcessor::RotateY(const double radianChange, Space space)
+{
+  if(space == kTransform)
+  {
+    auto xformOp = op();
+    const auto precision = xformOp.GetPrecision();
+    switch(xformOp.GetOpType())
+    {
+    case UsdGeomXformOp::TypeRotateY:
+      {
+        switch(precision)
+        {
+        case UsdGeomXformOp::PrecisionDouble:
+          {
+            double original = 0;
+            xformOp.Get(&original, _timeCode);
+            original += radianChange * (180.0 / M_PI);
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionFloat:
+          {
+            float original = 0;
+            xformOp.Get(&original, _timeCode);
+            original += float(radianChange * (180.0 / M_PI));
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionHalf:
+          {
+            GfHalf original = 0;
+            xformOp.Get(&original, _timeCode);
+            original += float(radianChange * (180.0 / M_PI));
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+        }
+        return true;
+      }
+
+    // directly modifying the y value only ever works when the rotation order begins with Y
+    case UsdGeomXformOp::TypeRotateYXZ:
+    case UsdGeomXformOp::TypeRotateYZX:
+      {
+        switch(precision)
+        {
+        case UsdGeomXformOp::PrecisionDouble:
+          {
+            GfVec3d original(0);
+            xformOp.Get(&original, _timeCode);
+            original[1] += radianChange * (180.0 / M_PI);
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionFloat:
+          {
+            GfVec3f original(0);
+            xformOp.Get(&original, _timeCode);
+            original[1] += radianChange * (180.0 / M_PI);
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionHalf:
+          {
+            GfVec3h original(0);
+            xformOp.Get(&original, _timeCode);
+            original[1] += radianChange * (180.0 / M_PI);
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+        }
+        return true;
+      }
+
+    case UsdGeomXformOp::TypeRotateXYZ:
+    case UsdGeomXformOp::TypeRotateXZY:
+    case UsdGeomXformOp::TypeRotateZXY:
+    case UsdGeomXformOp::TypeRotateZYX:
+    case UsdGeomXformOp::TypeTransform:
+    case UsdGeomXformOp::TypeOrient:
+      /* These have to be handled via quats sadly :( */
+      break;
+      
+    // unsupported transform op type
+    case UsdGeomXformOp::TypeRotateX:
+    case UsdGeomXformOp::TypeRotateZ:
+    default:
+      return false;
+    }
+  }
+  const double sr = std::sin(radianChange * 0.5f);
+  const double cr = std::cos(radianChange * 0.5f);
+  return Rotate(GfQuatd(cr, 0, sr, 0), space);
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+MAYA_USD_UTILS_PUBLIC
+bool TransformOpProcessor::RotateZ(const double radianChange, Space space)
+{
+  if(space == kTransform)
+  {
+    auto xformOp = op();
+    const auto precision = xformOp.GetPrecision();
+    switch(xformOp.GetOpType())
+    {
+    case UsdGeomXformOp::TypeRotateZ:
+      {
+        switch(precision)
+        {
+        case UsdGeomXformOp::PrecisionDouble:
+          {
+            double original = 0;
+            xformOp.Get(&original, _timeCode);
+            original += radianChange * (180.0 / M_PI);
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionFloat:
+          {
+            float original = 0;
+            xformOp.Get(&original, _timeCode);
+            original += float(radianChange * (180.0 / M_PI));
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionHalf:
+          {
+            GfHalf original = 0;
+            xformOp.Get(&original, _timeCode);
+            original += float(radianChange * (180.0 / M_PI));
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+        }
+        return true;
+      }
+
+    // directly modifying the Z value only ever works when the rotation order begins with Z
+    case UsdGeomXformOp::TypeRotateZXY:
+    case UsdGeomXformOp::TypeRotateZYX:
+      {
+        switch(precision)
+        {
+        case UsdGeomXformOp::PrecisionDouble:
+          {
+            GfVec3d original(0);
+            xformOp.Get(&original, _timeCode);
+            original[2] += radianChange * (180.0 / M_PI);
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionFloat:
+          {
+            GfVec3f original(0);
+            xformOp.Get(&original, _timeCode);
+            original[2] += radianChange * (180.0 / M_PI);
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionHalf:
+          {
+            GfVec3h original(0);
+            xformOp.Get(&original, _timeCode);
+            original[2] += radianChange * (180.0 / M_PI);
+            xformOp.Set(original, _timeCode);
+          }
+          break;
+        }
+        return true;
+      }
+
+    case UsdGeomXformOp::TypeRotateXYZ:
+    case UsdGeomXformOp::TypeRotateXZY:
+    case UsdGeomXformOp::TypeRotateYXZ:
+    case UsdGeomXformOp::TypeRotateYZX:
+    case UsdGeomXformOp::TypeTransform:
+    case UsdGeomXformOp::TypeOrient:
+      /* These have to be handled via quats sadly :( */
+      break;
+      
+    // unsupported transform op type
+    case UsdGeomXformOp::TypeRotateX:
+    case UsdGeomXformOp::TypeRotateY:
+    default:
+      return false;
+    }
+  }
+  const double sr = std::sin(radianChange * 0.5f);
+  const double cr = std::cos(radianChange * 0.5f);
+  return Rotate(GfQuatd(cr, 0, 0, sr), space);
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+/// \brief  given an ordered set of XformOps, this method will evaluate the coordinate frame for a specifici xform op. 
+///         By and large it will do this by concatonating operations of the same type, e.g. 
+///          - successive translations will be grouped into 1 translation
+///          - successive scales will be grouped into 1 scale
+///          - successive rotations will be grouped into 1 quaternion
+///         This will then be evaluated 
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+GfMatrix4d TransformOpProcessor::EvaluateCoordinateFrameForIndex(const std::vector<UsdGeomXformOp>& ops, uint32_t index, const UsdTimeCode& timeCode)
+{
+  auto iter = ops.begin();
+  auto last = ops.begin() + index;
+  if(last > ops.end()) 
+    throw;
+
+  // the computed coordinate frame - initially the identity
+  d256 frame[4] = {
+    set4d(1.0, 0.0, 0.0, 0.0),
+    set4d(0.0, 1.0, 0.0, 0.0),
+    set4d(0.0, 0.0, 1.0, 0.0),
+    set4d(0.0, 0.0, 0.0, 1.0)
+  };
+
+  UsdGeomXformOp::Type lastType = UsdGeomXformOp::TypeInvalid;
+  while(iter < last)
+  {
+    switch (iter->GetOpType())
+    {
+    //-------------------------------------------------------------------------------------
+    // accumulate any translations into a single offset value, which we can apply to the 
+    // matrix at the end. 
+    // Note: During this accumulation of the offset, the 'w' value will be garbage. This is
+    // removed prior to applying to the matrix. 
+    //-------------------------------------------------------------------------------------
+    case UsdGeomXformOp::TypeTranslate:
+      {
+        d256 offset = zero4d();
+        do
+        {
+          offset = add4d(offset, _Translation(*iter, timeCode));
+          ++iter;
+        }
+        while(iter != last && iter->GetOpType() == UsdGeomXformOp::TypeTranslate);
+
+        // the 'w' value in offset is nonsense at this point. Replace it with 1.0. 
+        offset = select4d<1, 1, 1, 0>(offset, splat4d(1.0));
+
+        // if these translations are the very first in the stack, 
+        // just assign the resulting translation directly, rather 
+        // than trying to pointlessly rotate it (and accumulate error in the process).
+        // typically Translate, RotatePivot, and RotatePivotTranslate could be 
+        // evaluated in this way. 
+        if(lastType == UsdGeomXformOp::TypeInvalid)
+        {
+          frame[3] = offset;
+        }
+        else
+        {
+          // If however this translation is in the middle of the transform stack, 
+          // we need to re-orient the offset by the current coordinate frame before
+          // applying the translation.
+          frame[3] = add4d(frame[3], rotate(offset, frame));
+        }
+        lastType = UsdGeomXformOp::TypeTranslate;
+      }
+      break;
+
+    //-------------------------------------------------------------------------------------
+    // starting with a scaling of (1,1,1), successively multiply each scaling value we find
+    // until we end up with a single scaling op to apply. It's unlikely there will be
+    // multiple scales applied in succession, but might as well follow the same pattern.
+    //-------------------------------------------------------------------------------------
+    case UsdGeomXformOp::TypeScale:
+      {
+        d256 scaling = splat4d(1.0);
+        do
+        {
+          scaling = mul4d(scaling, _Scale(*iter, timeCode));
+          ++iter;
+        }
+        while(iter != last && iter->GetOpType() == UsdGeomXformOp::TypeScale);
+
+        // apply scaling to each axis
+        frame[0] = mul4d(permute4d<0, 0, 0, 0>(scaling), frame[0]);
+        frame[1] = mul4d(permute4d<1, 1, 1, 1>(scaling), frame[1]);
+        frame[2] = mul4d(permute4d<2, 2, 2, 2>(scaling), frame[2]);
+
+        lastType = UsdGeomXformOp::TypeScale;
+      }
+      break;
+
+    //-------------------------------------------------------------------------------------
+    // for transforms, just multiply our frame with them and move on. There is no benefit
+    // accumulating transforms in this case. 
+    //-------------------------------------------------------------------------------------
+    case UsdGeomXformOp::TypeTransform:
+      {
+        d256 dmatrix[4];
+        switch(iter->GetPrecision())
+        {
+        case UsdGeomXformOp::PrecisionDouble:
+          {
+            // just grab matrix
+            iter->Get((GfMatrix4d*)dmatrix, timeCode);
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionFloat:
+          {
+            // USD doesn't appear to support the GfMatrix4f type ?
+            #if 0
+            // grab as float
+            f128 matrix[4];
+            iter->Get((GfMatrix4f*)matrix, timeCode);
+
+            // convert to double
+            dmatrix[0] = cvt4f_to_4d(matrix[0]);
+            dmatrix[1] = cvt4f_to_4d(matrix[1]);
+            dmatrix[2] = cvt4f_to_4d(matrix[2]);
+            dmatrix[3] = cvt4f_to_4d(matrix[3]);
+            #endif
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionHalf:
+          {
+            // USD doesn't appear to have a GfMatrix4h ?
+            #if 0
+            // grab as half
+            i128 matrix[2];
+            iter->Get((GfMatrix4h*)matrix, timeCode);
+
+            // convert to float
+            f256 fmatrix[2] = {
+              cvtph8(matrix[0]),
+              cvtph8(matrix[1])
+            };
+
+            // convert to double
+            dmatrix[0] = cvt4f_to_4d(extract4f(fmatrix[0], 0));
+            dmatrix[1] = cvt4f_to_4d(extract4f(fmatrix[0], 1));
+            dmatrix[2] = cvt4f_to_4d(extract4f(fmatrix[1], 0));
+            dmatrix[3] = cvt4f_to_4d(extract4f(fmatrix[1], 1));
+            #endif
+          }
+          break;
+        }
+
+        multiply4x4(frame, dmatrix);
+        lastType = UsdGeomXformOp::TypeTransform;
+      }
+      break;
+
+    //-------------------------------------------------------------------------------------
+    // No op. Only handling this case so I can lazily use the default case for rotation.
+    //-------------------------------------------------------------------------------------
+    case UsdGeomXformOp::TypeInvalid:
+      break;
+
+    //-------------------------------------------------------------------------------------
+    // The default case is used to handle all rotation types. Successive rotations are 
+    // accumulated as a quaternion, which is then converted to a matrix, before being 
+    // multiplied with our frame.
+    // Quats have a few advantages here, and possibly some disadvantages. 
+    // 
+    // Pros:
+    // + Pretty trivial to generate a quat from an euler angle triplet directly. 
+    // + Inverting a quat is extremely fast
+    // Cons:
+    // - People seem to be scared of them :)
+    // - Quat mult can end up being slower than a 4x4 matrix mult 
+    // - rotating a vector by a quat is more expensive that rotating by a matrix
+    //
+    // Looking through the various options here, accumulating eulers would be downright daft, 
+    // accumulating as matrices seems very much like overkill, so I went down the quat route.
+    //-------------------------------------------------------------------------------------
+    default:
+      {
+        // util to identify whether an op is a rotation or not.
+        auto isRotation = [](const UsdGeomXformOp& op) {
+          switch(op.GetOpType())
+          {
+          case UsdGeomXformOp::TypeInvalid:
+          case UsdGeomXformOp::TypeTranslate:
+          case UsdGeomXformOp::TypeScale:
+          case UsdGeomXformOp::TypeTransform:
+            return false;
+          default:
+            break;
+          }
+          return true;
+        };
+
+        // grab first rotation as a quat
+        d256 rotation = _Rotation(*iter, timeCode);
+        ++iter;
+
+        // accumulate any additional rotations
+        while(iter != last && isRotation(*iter))
+        {
+          rotation = multiplyQuat(rotation, _Rotation(*iter, timeCode));
+          ++iter;
+        }
+
+        // convert final quat to matrix
+        d256 rotateMatrix[4];
+        quatToMatrix(rotation, rotateMatrix);
+
+        // and transform coordinate frame
+        multiply(frame, rotateMatrix);
+
+        // a bit naughty, but make sure we tag it as something a bit rotationy
+        lastType = UsdGeomXformOp::TypeOrient;
+      }
+      break;
+    }
+  }
+  GfMatrix4d r;
+  store4d(r[0], frame[0]);
+  store4d(r[1], frame[1]);
+  store4d(r[2], frame[2]);
+  store4d(r[3], frame[3]);
+  return r;
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+d256 TransformOpProcessor::_Rotation(const UsdGeomXformOp& op, const UsdTimeCode& timeCode)
+{
+  d256 result = set4d(0, 0, 0, 1.0);
+
+  const bool isInverse = op.IsInverseOp();
+  switch (op.GetOpType())
+  {
+  //-------------------------------------------------------------------------------------
+  // error
+  //-------------------------------------------------------------------------------------
+  case UsdGeomXformOp::TypeTranslate:
+    break;
+
+  //-------------------------------------------------------------------------------------
+  // error
+  //-------------------------------------------------------------------------------------
+  case UsdGeomXformOp::TypeScale:
+    break;
+
+  //-------------------------------------------------------------------------------------
+  // for transforms, just multiply our frame with them and move on. There is no benefit
+  // accumulating transforms in this case. 
+  //-------------------------------------------------------------------------------------
+  case UsdGeomXformOp::TypeTransform:
+    {
+      d256 dmatrix[4] = {
+        set4d(1.0, 0.0, 0.0, 0.0),
+        set4d(0.0, 1.0, 0.0, 0.0),
+        set4d(0.0, 0.0, 1.0, 0.0),
+        set4d(0.0, 0.0, 0.0, 1.0)
+      };
+      switch(op.GetPrecision())
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        {
+          // just grab matrix
+          op.Get((GfMatrix4d*)dmatrix, timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        {
+          // USD doesn't appear to support the GfMatrix4f type ?
+          #if 0
+          // grab as float
+          f128 matrix[4];
+          op.Get((GfMatrix4f*)matrix, timeCode);
+
+          // convert to double
+          dmatrix[0] = cvt4f_to_4d(matrix[0]);
+          dmatrix[1] = cvt4f_to_4d(matrix[1]);
+          dmatrix[2] = cvt4f_to_4d(matrix[2]);
+          dmatrix[3] = cvt4f_to_4d(matrix[3]);
+          #endif
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        {
+          // USD doesn't appear to have a GfMatrix4h ?
+          #if 0
+          // grab as half
+          i128 matrix[2];
+          op.Get((GfMatrix4h*)matrix, timeCode);
+
+          // convert to float
+          f256 fmatrix[2] = {
+            cvtph8(matrix[0]),
+            cvtph8(matrix[1])
+          };
+
+          // convert to double
+          dmatrix[0] = cvt4f_to_4d(extract4f(fmatrix[0], 0));
+          dmatrix[1] = cvt4f_to_4d(extract4f(fmatrix[0], 1));
+          dmatrix[2] = cvt4f_to_4d(extract4f(fmatrix[1], 0));
+          dmatrix[3] = cvt4f_to_4d(extract4f(fmatrix[1], 1));
+          #endif
+        }
+        break;
+      }
+      result = matrixToQuat(dmatrix);
+    }
+    break;
+
+  //-------------------------------------------------------------------------------------
+  // No op. Only handling this case so I can lazily use the default case for rotation.
+  //-------------------------------------------------------------------------------------
+  case UsdGeomXformOp::TypeInvalid:
+    break;
+
+  //-------------------------------------------------------------------------------------
+  // The default case is used to handle all rotation types. Successive rotations are 
+  // accumulated as a quaternion, which is then converted to a matrix, before being 
+  // multiplied with our frame.
+  // Quats have a few advantages here, and possibly some disadvantages. 
+  // 
+  // Pros:
+  // + Pretty trivial to generate a quat from an euler angle triplet directly. 
+  // + Inverting a quat is extremely fast
+  // Cons:
+  // - People seem to be scared of them :)
+  // - Quat mult can end up being slower than a 4x4 matrix mult 
+  // - rotating a vector by a quat is more expensive that rotating by a matrix
+  //
+  // Looking through the various options here, accumulating eulers would be downright daft, 
+  // accumulating as matrices seems very much like overkill, so I went down the quat route.
+  //-------------------------------------------------------------------------------------
+  default:
+    {
+      // extract an angle value in degrees, and convert it into (radians / 2)
+      auto getDouble = [timeCode, op]()
+      {
+        switch(op.GetPrecision())
+        {
+        case UsdGeomXformOp::PrecisionDouble:
+          {
+            double v;
+            op.Get(&v, timeCode);
+            return v * (M_PI / 180.0) * 0.5;
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionFloat:
+          {
+            float v;
+            op.Get(&v, timeCode);
+            return v * (M_PI / 180.0) * 0.5;
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionHalf:
+          {
+            GfHalf v;
+            op.Get(&v, timeCode);
+            return _cvtsh_ss(v.bits()) * (M_PI / 180.0) * 0.5;
+          }
+          break;
+        }
+        return 0.0;
+      };
+
+      // extract an trio of angle values in degrees, and convert to: (radians / 2)
+      auto getXYZ = [timeCode, op]()
+      {
+        switch(op.GetPrecision())
+        {
+        case UsdGeomXformOp::PrecisionDouble:
+          {
+            d256 v;
+            op.Get((GfVec3d*)&v, timeCode);
+            return mul4d(v, splat4d(M_PI / 360.0));
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionFloat:
+          {
+            f128 v;
+            op.Get((GfVec3f*)&v, timeCode);
+            return mul4d(cvt4f_to_4d(v), splat4d(M_PI / 360.0));
+          }
+          break;
+
+        case UsdGeomXformOp::PrecisionHalf:
+          {
+            i128 v;
+            op.Get((GfVec3h*)&v, timeCode);
+            return mul4d(cvt4f_to_4d(cvtph4(v)), splat4d(M_PI / 360.0));
+          }
+          break;
+        }
+        return zero4d();
+      };
+
+      // given the various 
+      auto getQuat = [timeCode, getXYZ, getDouble, op]()
+      {
+        auto opType = op.GetOpType();
+        switch(opType)
+        {
+        // splat straight into quat form
+        case UsdGeomXformOp::TypeRotateX: 
+          {
+            const double half_angle = getDouble();
+            const double sa = std::sin(half_angle);
+            const double ca = std::cos(half_angle);
+            return set4d(sa, 0, 0, ca);
+          }
+          break;
+
+        case UsdGeomXformOp::TypeRotateY:
+          {
+            const double half_angle = getDouble();
+            const double sa = std::sin(half_angle);
+            const double ca = std::cos(half_angle);
+            return set4d(0, sa, 0, ca);
+          }
+          break;
+
+        case UsdGeomXformOp::TypeRotateZ:
+          {
+            const double half_angle = getDouble();
+            const double sa = std::sin(half_angle);
+            const double ca = std::cos(half_angle);
+            return set4d(0, 0, sa, ca);
+          }
+          break;
+
+        case UsdGeomXformOp::TypeRotateXYZ: 
+          {
+            const d256 half_angle = getXYZ();
+            return Quat_from_EulerXYZ(half_angle);
+          }
+          break;
+
+        case UsdGeomXformOp::TypeRotateXZY: 
+          {
+            const d256 half_angle = getXYZ();
+            return Quat_from_EulerXZY(half_angle);
+          }
+          break;
+
+        case UsdGeomXformOp::TypeRotateYXZ: 
+          {
+            const d256 half_angle = getXYZ();
+            return Quat_from_EulerYXZ(half_angle);
+          }
+          break;
+
+        case UsdGeomXformOp::TypeRotateYZX: 
+          {
+            const d256 half_angle = getXYZ();
+            return Quat_from_EulerYZX(half_angle);
+          }
+          break;
+
+        case UsdGeomXformOp::TypeRotateZYX: 
+          {
+            const d256 half_angle = getXYZ();
+            return Quat_from_EulerZYX(half_angle);
+          }
+          break;
+
+        case UsdGeomXformOp::TypeRotateZXY: 
+          {
+            const d256 half_angle = getXYZ();
+            return Quat_from_EulerZXY(half_angle);
+          }
+          break;
+
+        // splat straight into quat 
+        case UsdGeomXformOp::TypeOrient: 
+          {
+            switch(op.GetPrecision())
+            {
+            case UsdGeomXformOp::PrecisionDouble:
+              {
+                d256 v;
+                op.Get((GfQuatd*)&v, timeCode);
+                return v;
+              }
+              break;
+
+            case UsdGeomXformOp::PrecisionFloat:
+              {
+                f128 v;
+                op.Get((GfQuatf*)&v, timeCode);
+                return cvt4f_to_4d(v);
+              }
+              break;
+
+            case UsdGeomXformOp::PrecisionHalf:
+              {
+                i128 v;
+                op.Get((GfQuath*)&v, timeCode);
+                auto temp = cvtph4(v);
+                return cvt4f_to_4d(temp);
+              }
+              break;
+            }
+          }
+          break;
+
+        default:
+          break; 
+        }
+        return set4d(0.0, 0.0, 0.0, 1.0);
+      };
+
+      // grab first rotation as a quat
+      result = getQuat();
+    }
+    break;
+  }
+  if(isInverse)
+    result = xor4d(result, set4d(-0.0, -0.0, -0.0, 0));
+  return result;
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+d256 TransformOpProcessor::_Translation(const UsdGeomXformOp& op, const UsdTimeCode& timeCode)
+{
+  d256 result = set4d(0.0, 0.0, 0.0, 0.0);
+  const bool isInverse = op.IsInverseOp();
+  switch (op.GetOpType())
+  {
+  //-------------------------------------------------------------------------------------
+  // error
+  //-------------------------------------------------------------------------------------
+  case UsdGeomXformOp::TypeTranslate:
+    {
+      switch(op.GetPrecision())
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        {
+          op.Get((GfVec3d*)&result, timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        {
+          f128 v;
+          op.Get((GfVec3f*)&v, timeCode);
+          result = cvt4f_to_4d(v);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        {
+          i128 v;
+          op.Get((GfVec3h*)&v, timeCode);
+          auto temp = cvtph4(v);
+          result = cvt4f_to_4d(temp);
+        }
+        break;
+      }
+    }
+    break;
+
+  //-------------------------------------------------------------------------------------
+  // for transforms, just multiply our frame with them and move on. There is no benefit
+  // accumulating transforms in this case. 
+  //-------------------------------------------------------------------------------------
+  case UsdGeomXformOp::TypeTransform:
+    {
+      d256 dmatrix[4] = {
+        set4d(1.0, 0.0, 0.0, 0.0),
+        set4d(0.0, 1.0, 0.0, 0.0),
+        set4d(0.0, 0.0, 1.0, 0.0),
+        set4d(0.0, 0.0, 0.0, 1.0)
+      };
+      switch(op.GetPrecision())
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        {
+          // just grab matrix
+          op.Get((GfMatrix4d*)dmatrix, timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        {
+          // USD doesn't appear to support the GfMatrix4f type ?
+          #if 0
+          // grab as float
+          f128 matrix[4];
+          op.Get((GfMatrix4f*)matrix, timeCode);
+
+          // convert to double
+          dmatrix[0] = cvt4f_to_4d(matrix[0]);
+          dmatrix[1] = cvt4f_to_4d(matrix[1]);
+          dmatrix[2] = cvt4f_to_4d(matrix[2]);
+          dmatrix[3] = cvt4f_to_4d(matrix[3]);
+          #endif
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        {
+          // USD doesn't appear to have a GfMatrix4h ?
+          #if 0
+          // grab as half
+          i128 matrix[2];
+          op.Get((GfMatrix4h*)matrix, timeCode);
+
+          // convert to float
+          f256 fmatrix[2] = {
+            cvtph8(matrix[0]),
+            cvtph8(matrix[1])
+          };
+
+          // convert to double
+          dmatrix[0] = cvt4f_to_4d(extract4f(fmatrix[0], 0));
+          dmatrix[1] = cvt4f_to_4d(extract4f(fmatrix[0], 1));
+          dmatrix[2] = cvt4f_to_4d(extract4f(fmatrix[1], 0));
+          dmatrix[3] = cvt4f_to_4d(extract4f(fmatrix[1], 1));
+          #endif
+        }
+        break;
+      }
+      // extract translation from matrix
+      result = select4d<1, 1, 1, 0>(dmatrix[3], result);
+    }
+    break;
+
+  //-------------------------------------------------------------------------------------
+  // error
+  //-------------------------------------------------------------------------------------
+  default:
+    break;
+  }
+
+  // negate if inverse op
+  if(isInverse)
+  {
+    result = xor4d(result, set4d(-0.0, -0.0, -0.0, 0.0));
+  }
+  return result;
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+d256 TransformOpProcessor::_Scale(const UsdGeomXformOp& op, const UsdTimeCode& timeCode)
+{
+  d256 result = set4d(1.0, 1.0, 1.0, 0.0);
+  const bool isInverse = op.IsInverseOp();
+  switch (op.GetOpType())
+  {
+  //-------------------------------------------------------------------------------------
+  // error
+  //-------------------------------------------------------------------------------------
+  case UsdGeomXformOp::TypeScale:
+    {
+      switch(op.GetPrecision())
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        {
+          op.Get((GfVec3d*)&result, timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        {
+          f128 v;
+          op.Get((GfVec3f*)&v, timeCode);
+          result = cvt4f_to_4d(v);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        {
+          i128 v;
+          op.Get((GfVec3h*)&v, timeCode);
+          auto temp = cvtph4(v);
+          result = cvt4f_to_4d(temp);
+        }
+        break;
+      }
+    }
+    break;
+
+  //-------------------------------------------------------------------------------------
+  // for transforms, just multiply our frame with them and move on. There is no benefit
+  // accumulating transforms in this case. 
+  //-------------------------------------------------------------------------------------
+  case UsdGeomXformOp::TypeTransform:
+    {
+      d256 dmatrix[4] = {
+        set4d(1.0, 0.0, 0.0, 0.0),
+        set4d(0.0, 1.0, 0.0, 0.0),
+        set4d(0.0, 0.0, 1.0, 0.0),
+        set4d(0.0, 0.0, 0.0, 1.0)
+      };
+      switch(op.GetPrecision())
+      {
+      case UsdGeomXformOp::PrecisionDouble:
+        {
+          // just grab matrix
+          op.Get((GfMatrix4d*)dmatrix, timeCode);
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionFloat:
+        {
+          // USD doesn't appear to support the GfMatrix4f type ?
+          #if 0
+          // grab as float
+          f128 matrix[4];
+          op.Get((GfMatrix4f*)matrix, timeCode);
+
+          // convert to double
+          dmatrix[0] = cvt4f_to_4d(matrix[0]);
+          dmatrix[1] = cvt4f_to_4d(matrix[1]);
+          dmatrix[2] = cvt4f_to_4d(matrix[2]);
+          dmatrix[3] = cvt4f_to_4d(matrix[3]);
+          #endif
+        }
+        break;
+
+      case UsdGeomXformOp::PrecisionHalf:
+        {
+          // USD doesn't appear to have a GfMatrix4h ?
+          #if 0
+          // grab as half
+          i128 matrix[2];
+          op.Get((GfMatrix4h*)matrix, timeCode);
+
+          // convert to float
+          f256 fmatrix[2] = {
+            cvtph8(matrix[0]),
+            cvtph8(matrix[1])
+          };
+
+          // convert to double
+          dmatrix[0] = cvt4f_to_4d(extract4f(fmatrix[0], 0));
+          dmatrix[1] = cvt4f_to_4d(extract4f(fmatrix[0], 1));
+          dmatrix[2] = cvt4f_to_4d(extract4f(fmatrix[1], 0));
+          dmatrix[3] = cvt4f_to_4d(extract4f(fmatrix[1], 1));
+          #endif
+        }
+        break;
+      }
+
+      d256 testz = cross(dmatrix[0], dmatrix[1]);
+      double sx = dot3(dmatrix[0], dmatrix[0]);
+      double sy = dot3(dmatrix[1], dmatrix[1]);
+      double sz = dot3(dmatrix[2], dmatrix[2]);
+      if(dot3(testz, dmatrix[2]) < 0)
+        sz = -sz;
+      result = sqrt4d(set4d(sx, sy, sz, 0.0));
+    }
+    break;
+
+  //-------------------------------------------------------------------------------------
+  // error
+  //-------------------------------------------------------------------------------------
+  default:
+    break;
+  }
+
+  // negate if inverse op
+  if(isInverse)
+  {
+    result = div4d(splat4d(1.0), result);
+  }
+  return result;
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+GfQuatd TransformOpProcessor::Rotation() const
+{
+  if(CanRotate())
+  {
+    GfQuatd rotate;
+    store4d(&rotate, _Rotation(op(), _timeCode));
+    return rotate;
+  }
+  return GfQuatd(1.0, 0.0, 0.0, 0.0);
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+GfVec3d TransformOpProcessor::Translation() const
+{
+  if(CanTranslate())
+  {
+    const d256 translate = _Translation(op(), _timeCode);
+    return GfVec3d(translate[0], translate[1], translate[2]);
+  }
+  return GfVec3d(0.0);
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+GfVec3d TransformOpProcessor::Scale() const
+{
+  if(CanScale())
+  {
+    const d256 scale = _Scale(op(), _timeCode);
+    return GfVec3d(scale[0], scale[1], scale[2]);
+  }
+  return GfVec3d(1.0);
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+bool TransformOpProcessorEx::SetTranslate(const GfVec3d& position, Space space)
+{
+  if(CanTranslate())
+  {
+    d256 translate = _Translation(op(), _timeCode);
+    if(space == kTransform)
+    {
+      d256 offset = sub4d(set4d(position[0], position[1], position[2], 0), translate);
+      return TransformOpProcessor::Translate(GfVec3d(offset[0], offset[1], offset[2]), space);
+    }
+    if(space == kWorld)
+    {
+      d256* pworldFrame = (d256*)&_worldFrame;
+      d256 worldPos = transform(translate, pworldFrame);
+      d256 world_offset = sub4d(set4d(position[0], position[1], position[2], 1.0), worldPos); 
+      return TransformOpProcessor::Translate(GfVec3d(world_offset[0], world_offset[1], world_offset[2]), kWorld);
+    }
+    if(space == kParent)
+    {
+      d256* pcoordFrame = (d256*)&_coordFrame;
+      d256 worldPos = transform(translate, pcoordFrame);
+      d256 parent_offset = sub4d(set4d(position[0], position[1], position[2], 1.0), worldPos); 
+      return TransformOpProcessor::Translate(GfVec3d(parent_offset[0], parent_offset[1], parent_offset[2]), kParent);
+    }
+  }
+  return false;
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+bool TransformOpProcessorEx::SetScale(const GfVec3d& scale, Space space)
+{
+  if(CanScale())
+  {
+    d256 original = _Scale(op(), _timeCode);
+    d256 offset = div4d(set4d(scale[0], scale[1], scale[2], 0.0), original); 
+    return TransformOpProcessor::Scale(GfVec3d(offset[0], offset[1], offset[2]), kWorld);
+  }
+  return false;
+}
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+bool TransformOpProcessorEx::SetRotate(const GfQuatd& orientation, Space space)
+{
+  if(CanRotate())
+  {
+    d256 final_orient = load4d(&orientation);
+    d256 rotate = _Rotation(op(), _timeCode);
+    if(space == kTransform)
+    {
+      d256 offset = multiplyQuat(rotate, quatInvert(final_orient));
+      return TransformOpProcessor::Rotate(GfQuatd(offset[0], offset[1], offset[2], offset[3]), space);
+    }
+    if(space == kWorld)
+    {
+      d256 world_rotate = multiplyQuat(rotate, _qworldFrame);
+      d256 world_offset = multiplyQuat(world_rotate, quatInvert(final_orient));
+      return TransformOpProcessor::Rotate(GfQuatd(world_offset[0], world_offset[1], world_offset[2], world_offset[3]), space);
+    }
+    if(space == kParent)
+    {
+      d256 world_rotate = multiplyQuat(rotate, _qcoordFrame);
+      d256 world_offset = multiplyQuat(world_rotate, quatInvert(final_orient));
+      return TransformOpProcessor::Rotate(GfQuatd(world_offset[0], world_offset[1], world_offset[2], world_offset[3]), space);
+    }
+  }
+  return false;
+}
+
+bool TransformOpProcessorEx::Translate(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const GfVec3d& translateChange, Space space)
+{
+  TransformOpProcessorEx proc(prim, rotateAttr, TransformOpProcessorEx::kTranslate, timeCode);
+  return proc.Translate(translateChange, space);
+}
+
+bool TransformOpProcessorEx::Scale(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const GfVec3d& scaleChange, Space space)
+{
+  TransformOpProcessorEx proc(prim, rotateAttr, TransformOpProcessorEx::kScale, timeCode);
+  return proc.Scale(scaleChange, space);
+}
+
+bool TransformOpProcessorEx::RotateX(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const double radianChange, Space space)
+{
+  TransformOpProcessorEx proc(prim, rotateAttr, TransformOpProcessorEx::kTranslate, timeCode);
+  return proc.RotateX(radianChange, space);
+}
+
+bool TransformOpProcessorEx::RotateY(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const double radianChange, Space space)
+{
+  TransformOpProcessorEx proc(prim, rotateAttr, TransformOpProcessorEx::kTranslate, timeCode);
+  return proc.RotateY(radianChange, space);
+}
+
+bool TransformOpProcessorEx::RotateZ(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const double radianChange, Space space)
+{
+  TransformOpProcessorEx proc(prim, rotateAttr, TransformOpProcessorEx::kTranslate, timeCode);
+  return proc.RotateZ(radianChange, space);
+}
+
+bool TransformOpProcessorEx::Rotate(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const GfQuatd& quatChange, Space space)
+{
+  TransformOpProcessorEx proc(prim, rotateAttr, TransformOpProcessorEx::kTranslate, timeCode);
+  return proc.Rotate(quatChange, space);
+}
+
+bool TransformOpProcessorEx::SetTranslate(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const GfVec3d& position, Space space)
+{
+  TransformOpProcessorEx proc(prim, rotateAttr, TransformOpProcessorEx::kTranslate, timeCode);
+  return proc.SetTranslate(position, space);
+}
+
+bool TransformOpProcessorEx::SetScale(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const GfVec3d& scale, Space space)
+{
+  TransformOpProcessorEx proc(prim, rotateAttr, TransformOpProcessorEx::kTranslate, timeCode);
+  return proc.SetScale(scale, space);
+}
+
+bool TransformOpProcessorEx::SetRotate(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const GfQuatd& orientation, Space space)
+{
+  TransformOpProcessorEx proc(prim, rotateAttr, TransformOpProcessorEx::kTranslate, timeCode);
+  return proc.SetRotate(orientation, space);
+}
+
+
+} // MayaUsdUtils

--- a/lib/usd/utils/TransformOpTools.h
+++ b/lib/usd/utils/TransformOpTools.h
@@ -1,0 +1,312 @@
+//
+// Copyright 2017 Animal Logic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include "Api.h"
+#include <pxr/base/gf/vec3f.h>
+#include <pxr/base/gf/vec3d.h>
+#include <pxr/base/gf/matrix4d.h>
+#include <pxr/base/tf/token.h>
+
+#include <pxr/usd/usd/prim.h>
+#include <pxr/usd/usdGeom/xformable.h>
+#include <pxr/usd/usdGeom/xformCache.h>
+#include <immintrin.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace MayaUsdUtils {
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+class alignas(32) TransformOpProcessor
+{
+public:
+
+  // when processing matrix transform ops, the coordinate frame for the manipulator will change 
+  // depending on whether we are setting up for scale, rotatation, or translation
+  enum ManipulatorMode
+  {
+    kTranslate, 
+    kRotate, 
+    kScale,
+    kGuess //< for most ops, this will just work. For matrix ops, you'll need to be more specific
+  };
+  enum Space
+  {
+    kTransform,
+    kWorld,
+    kParent
+  };
+
+  MAYA_USD_UTILS_PUBLIC
+  TransformOpProcessor(const UsdPrim prim, const TfToken opName, ManipulatorMode mode = kGuess, const UsdTimeCode& tc = UsdTimeCode::Default());
+
+  MAYA_USD_UTILS_PUBLIC
+  TransformOpProcessor(const UsdPrim prim, const uint32_t opIndex, ManipulatorMode mode = kGuess, const UsdTimeCode& tc = UsdTimeCode::Default());
+
+  /// re-evaluate the internal coordinate frames on time change
+  MAYA_USD_UTILS_PUBLIC
+  void UpdateToTime(const UsdTimeCode& tc, UsdGeomXformCache& cache, ManipulatorMode mode = kGuess);
+  void UpdateToTime(const UsdTimeCode& tc, ManipulatorMode mode = kGuess) { UsdGeomXformCache cache; UpdateToTime(tc, cache, mode); }
+
+  //--------------------------------------------------------------------------------------------------------------------------------------------------------
+  // given the xform op currently assigned to this processor, can we scale, rotate, and/or translate the op? (In some cases, e.g. matrices, all may be supported)
+  //--------------------------------------------------------------------------------------------------------------------------------------------------------
+
+  /// returns true if the current xfrom op can be rotated
+  MAYA_USD_UTILS_PUBLIC
+  bool CanRotate() const;
+
+  /// returns true if the current xfrom op can be rotated in the local x axis
+  bool CanRotateX() const
+    { return CanRotate() && op().GetOpType() != UsdGeomXformOp::TypeRotateY && op().GetOpType() != UsdGeomXformOp::TypeRotateZ; }
+
+  /// returns true if the current xfrom op can be rotated in the local y axis
+  bool CanRotateY() const
+    { return CanRotate() && op().GetOpType() != UsdGeomXformOp::TypeRotateX && op().GetOpType() != UsdGeomXformOp::TypeRotateZ; }
+
+  /// returns true if the current xfrom op can be rotated in the local z axis
+  bool CanRotateZ() const
+    { return CanRotate() && op().GetOpType() != UsdGeomXformOp::TypeRotateX && op().GetOpType() != UsdGeomXformOp::TypeRotateY; }
+
+  /// returns true if the current xfrom op can be translated
+  MAYA_USD_UTILS_PUBLIC
+  bool CanTranslate() const;
+
+  /// returns true if the current xfrom op can be scaled
+  MAYA_USD_UTILS_PUBLIC
+  bool CanScale() const;
+
+  //--------------------------------------------------------------------------------------------------------------------------------------------------------
+  // Compute the current transform op value - all values in local space
+  //--------------------------------------------------------------------------------------------------------------------------------------------------------
+
+  /// returns the current orientation as a quat (If CanRotate() returns false, the identity quat is returned)
+  MAYA_USD_UTILS_PUBLIC
+  GfQuatd Rotation() const;
+
+  /// returns the current translation as a vec3 (If CanTranslate() returns false, [0,0,0] is returned)
+  MAYA_USD_UTILS_PUBLIC
+  GfVec3d Translation() const;
+
+  /// returns the current scale as a vec3 (If CanScale() returns false, [1,1,1] is returned)
+  MAYA_USD_UTILS_PUBLIC
+  GfVec3d Scale() const;
+
+  //--------------------------------------------------------------------------------------------------------------------------------------------------------
+  // Compute the current transform op value. 
+  //--------------------------------------------------------------------------------------------------------------------------------------------------------
+
+  /// returns the coordinate frame for this manipulator where the transformation is the identity (e.g. the local origin)
+  inline const GfMatrix4d& ManipulatorFrame() const
+    { return _coordFrame; }
+
+  /// returns the inclusive matrix of the manipulator frame, and the transformation of the xform op applied 
+  inline GfMatrix4d ManipulatorMatrix() const
+    { return EvaluateCoordinateFrameForIndex(_ops, _opIndex + 1, _timeCode); }
+
+  /// returns the current manipulator mode
+  MAYA_USD_UTILS_PUBLIC
+  ManipulatorMode ManipMode() const;
+
+  //--------------------------------------------------------------------------------------------------------------------------------------------------------
+  // Apply relative transformations to the Transform Op
+  //--------------------------------------------------------------------------------------------------------------------------------------------------------
+
+  /// apply a translation offset to the xform op
+  MAYA_USD_UTILS_PUBLIC
+  bool Translate(const GfVec3d& translateChange, Space space = kTransform);
+
+  /// apply a scale offset to the xform op
+  MAYA_USD_UTILS_PUBLIC
+  bool Scale(const GfVec3d& scaleChange, Space space = kTransform);
+
+  /// apply a rotational offset to the X axis
+  MAYA_USD_UTILS_PUBLIC
+  bool RotateX(const double radianChange, Space space = kTransform);
+
+  /// apply a rotational offset to the Y axis
+  MAYA_USD_UTILS_PUBLIC
+  bool RotateY(const double radianChange, Space space = kTransform);
+
+  /// apply a rotational offset to the Z axis
+  MAYA_USD_UTILS_PUBLIC
+  bool RotateZ(const double radianChange, Space space = kTransform);
+
+  /// apply a rotational offset to the xform op. 
+  /// NOTE: This is primarily useful for rotating objects via the sphere (rather than axis rings of the rotate manip)
+  /// It's likely that using this method won't result in 'nice' eulers afterwards. 
+  /// If you want 'nice' eulers (as much as is possible with a rotate tool), then prefer to use the axis rotation 
+  /// methods, RotateX etc. 
+  /// It should also be noted that this method may end up being called by the RotateX/RotateY/RotateZ methods if 
+  /// either the rotation is not a simple one - i.e. a simple RotateX xform op 
+  MAYA_USD_UTILS_PUBLIC
+  bool Rotate(const GfQuatd& quatChange, Space space);
+
+  //--------------------------------------------------------------------------------------------------------------------------------------------------------
+  // Coordinate frames for manipulators
+  //--------------------------------------------------------------------------------------------------------------------------------------------------------
+
+  /// return the coordinate frame for the transform op - i.e. the 'origin' for the manipulator
+  const GfMatrix4d& WorldFrame() const 
+    { return _worldFrame; }
+
+  /// return the coordinate frame for the transform op - i.e. the 'origin' for the manipulator
+  const GfMatrix4d& CoordinateFrame() const 
+    { return _coordFrame; }
+
+  /// given some list of UsdGeomXformOp's, evaluate the coordinate frame needed for the op at the given index. 
+  /// This does not evaluate the xform op at that index (i.e. If the first op in ops is a translate, then requesting
+  /// index zero will return the identity)
+  /// I should really extract this method and pass to Pixar. The code is more performant than UsdGeomXformable::GetLocalTransformation.
+  MAYA_USD_UTILS_PUBLIC
+  static GfMatrix4d EvaluateCoordinateFrameForIndex(const std::vector<UsdGeomXformOp>& ops, uint32_t index, const UsdTimeCode& timeCode);
+
+protected:
+  // helper methods to extract scale/rotation/translation from the transform op
+  static __m256d _Scale(const UsdGeomXformOp& op, const UsdTimeCode& timeCode);
+  static __m256d _Rotation(const UsdGeomXformOp& op, const UsdTimeCode& timeCode);
+  static __m256d _Translation(const UsdGeomXformOp& op, const UsdTimeCode& timeCode);
+  GfMatrix4d _coordFrame;
+  GfMatrix4d _worldFrame;
+  GfMatrix4d _invCoordFrame;
+  GfMatrix4d _invWorldFrame;
+  __m256d _qcoordFrame;
+  __m256d _qworldFrame;
+  __m256d _qparentFrame;
+  std::vector<UsdGeomXformOp> _ops;
+  uint32_t _opIndex;
+  UsdTimeCode _timeCode = UsdTimeCode::Default();
+  UsdPrim _prim;
+  ManipulatorMode _manipMode;
+  bool _resetsXformStack = false;
+  UsdGeomXformOp op() const { return _ops[_opIndex]; }
+};
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+/// All methods in TransformOpProcessor deal with relative offsets. This class extends the base and adds support to set xform ops to specific positions
+/// and orientations. All methods in this class are implemented using methods from the base class.  
+//----------------------------------------------------------------------------------------------------------------------------------------------------------
+class TransformOpProcessorEx : public TransformOpProcessor
+{
+public:
+
+  TransformOpProcessorEx(const UsdPrim prim, const TfToken opName, ManipulatorMode mode = kGuess, const UsdTimeCode& tc = UsdTimeCode::Default())
+    : TransformOpProcessor(prim, opName, mode, tc) {}
+
+  TransformOpProcessorEx(const UsdPrim prim, const uint32_t opIndex, ManipulatorMode mode = kGuess, const UsdTimeCode& tc = UsdTimeCode::Default())
+    : TransformOpProcessor(prim, opIndex, mode, tc) {}
+
+  /// set the translate value on the translate op xform op
+  MAYA_USD_UTILS_PUBLIC
+  bool SetTranslate(const GfVec3d& position, Space space = kTransform);
+
+  /// set the scale value on the xform op
+  MAYA_USD_UTILS_PUBLIC
+  bool SetScale(const GfVec3d& scale, Space space = kTransform);
+
+  /// set transform op to world space orientation
+  MAYA_USD_UTILS_PUBLIC
+  bool SetRotate(const GfQuatd& orientation, Space space = kTransform);
+
+  //--------------------------------------------------------------------------------------------------------------------------------------------------------
+  // static 'one-hit' versions
+  //--------------------------------------------------------------------------------------------------------------------------------------------------------
+
+  /// apply a translation offset to the xform op
+  MAYA_USD_UTILS_PUBLIC
+  static bool Translate(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const GfVec3d& translateChange, Space space = kTransform);
+
+  /// apply a scale offset to the xform op
+  MAYA_USD_UTILS_PUBLIC
+  static bool Scale(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const GfVec3d& scaleChange, Space space = kTransform);
+
+  /// apply a rotational offset to the X axis
+  MAYA_USD_UTILS_PUBLIC
+  static bool RotateX(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const double radianChange, Space space = kTransform);
+
+  /// apply a rotational offset to the Y axis
+  MAYA_USD_UTILS_PUBLIC
+  static bool RotateY(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const double radianChange, Space space = kTransform);
+
+  /// apply a rotational offset to the Z axis
+  MAYA_USD_UTILS_PUBLIC
+  static bool RotateZ(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const double radianChange, Space space = kTransform);
+
+  /// apply a rotational offset to the xform op. 
+  /// NOTE: This is primarily useful for rotating objects via the sphere (rather than axis rings of the rotate manip)
+  /// It's likely that using this method won't result in 'nice' eulers afterwards. 
+  /// If you want 'nice' eulers (as much as is possible with a rotate tool), then prefer to use the axis rotation 
+  /// methods, RotateX etc. 
+  /// It should also be noted that this method may end up being called by the RotateX/RotateY/RotateZ methods if 
+  /// either the rotation is not a simple one - i.e. a simple RotateX xform op 
+  MAYA_USD_UTILS_PUBLIC
+  static bool Rotate(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const GfQuatd& quatChange, Space space);
+
+  /// set the translate value on the translate op xform op
+  MAYA_USD_UTILS_PUBLIC
+  static bool SetTranslate(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const GfVec3d& position, Space space = kTransform);
+
+  /// set the scale value on the xform op
+  MAYA_USD_UTILS_PUBLIC
+  static bool SetScale(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const GfVec3d& scale, Space space = kTransform);
+
+  /// set transform op to world space orientation
+  MAYA_USD_UTILS_PUBLIC
+  static bool SetRotate(UsdPrim prim, TfToken rotateAttr, UsdTimeCode timeCode, const GfQuatd& orientation, Space space = kTransform);
+
+  //--------------------------------------------------------------------------------------------------------------------------------------------------------
+  // The static version of Rotate/Translate etc, end up hiding the base class implementations. inline them here. 
+  //--------------------------------------------------------------------------------------------------------------------------------------------------------
+
+  /// apply a translation offset to the xform op
+  inline
+  bool Translate(const GfVec3d& translateChange, Space space = kTransform)
+    { return TransformOpProcessor::Translate(translateChange, space); }
+
+  /// apply a scale offset to the xform op
+  inline
+  bool Scale(const GfVec3d& scaleChange, Space space = kTransform)
+    { return TransformOpProcessor::Scale(scaleChange, space); }
+
+  /// apply a rotational offset to the X axis
+  inline
+  bool RotateX(const double radianChange, Space space = kTransform)
+    { return TransformOpProcessor::RotateX(radianChange, space); }
+
+  /// apply a rotational offset to the Y axis
+  inline
+  bool RotateY(const double radianChange, Space space = kTransform)
+    { return TransformOpProcessor::RotateY(radianChange, space); }
+
+  /// apply a rotational offset to the Z axis
+  inline
+  bool RotateZ(const double radianChange, Space space = kTransform)
+    { return TransformOpProcessor::RotateZ(radianChange, space); }
+
+  /// apply a rotational offset to the xform op. 
+  /// NOTE: This is primarily useful for rotating objects via the sphere (rather than axis rings of the rotate manip)
+  /// It's likely that using this method won't result in 'nice' eulers afterwards. 
+  /// If you want 'nice' eulers (as much as is possible with a rotate tool), then prefer to use the axis rotation 
+  /// methods, RotateX etc. 
+  /// It should also be noted that this method may end up being called by the RotateX/RotateY/RotateZ methods if 
+  /// either the rotation is not a simple one - i.e. a simple RotateX xform op 
+  inline
+  bool Rotate(const GfQuatd& quatChange, Space space)
+    { return TransformOpProcessor::Rotate(quatChange, space); }
+};
+
+} // MayaUsdUtils

--- a/test/lib/usd/utils/test_TransformOpTools.cpp
+++ b/test/lib/usd/utils/test_TransformOpTools.cpp
@@ -1,0 +1,5913 @@
+//
+// Copyright 2017 Animal Logic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include <mayaUsdUtils/TransformOpTools.h>
+
+#include <pxr/usd/usdGeom/xform.h>
+
+#include <gtest/gtest.h>
+#include <fstream>
+
+using namespace MayaUsdUtils;
+
+#define COMPARE_MAT4(A, B, eps) \
+ EXPECT_NEAR(A[0][0], B[0][0], eps); \
+ EXPECT_NEAR(A[0][1], B[0][1], eps); \
+ EXPECT_NEAR(A[0][2], B[0][2], eps); \
+ EXPECT_NEAR(A[0][3], B[0][3], eps); \
+ EXPECT_NEAR(A[1][0], B[1][0], eps); \
+ EXPECT_NEAR(A[1][1], B[1][1], eps); \
+ EXPECT_NEAR(A[1][2], B[1][2], eps); \
+ EXPECT_NEAR(A[1][3], B[1][3], eps); \
+ EXPECT_NEAR(A[2][0], B[2][0], eps); \
+ EXPECT_NEAR(A[2][1], B[2][1], eps); \
+ EXPECT_NEAR(A[2][2], B[2][2], eps); \
+ EXPECT_NEAR(A[2][3], B[2][3], eps); \
+ EXPECT_NEAR(A[3][0], B[3][0], eps); \
+ EXPECT_NEAR(A[3][1], B[3][1], eps); \
+ EXPECT_NEAR(A[3][2], B[3][2], eps); \
+ EXPECT_NEAR(A[3][3], B[3][3], eps); 
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that up to 3 translations in a row evaluate correctly using double precision
+// The code should concatonate these into a single vec3 and simply assign the resulting translation. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, translate_d)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+  first.Set(GfVec3d(1.0, 2.0, 3.0));
+  GfMatrix4d first_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+
+  UsdGeomXformOp second = xform.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("second"));
+  second.Set(GfVec3d(0.1, 0.2, 0.3));
+  GfMatrix4d second_result(1.0, 0.0, 0.0, 0.0,
+                           0.0, 1.0, 0.0, 0.0,
+                           0.0, 0.0, 1.0, 0.0,
+                           1.0, 2.0, 3.0, 1.0);
+
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+
+  UsdGeomXformOp third = xform.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("third"));
+  third.Set(GfVec3d(0.01, 0.02, 0.03));
+  GfMatrix4d third_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          1.1, 2.2, 3.3, 1.0);
+  GfMatrix4d final_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          1.11, 2.22, 3.33, 1.0);
+
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+  COMPARE_MAT4(result, third_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+  COMPARE_MAT4(result, final_result, 1e-5f);
+
+  // sanity check - make sure our matrices match USD
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, final_result, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that up to 3 translations in a row evaluate correctly using float precision
+// The code should concatonate these into a single vec3 and simply assign the resulting translation. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, translate_f)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+
+  UsdGeomXformOp first = xform.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+  first.Set(GfVec3f(1.0f, 2.0f, 3.0f));
+  GfMatrix4d first_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+
+  UsdGeomXformOp second = xform.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("second"));
+  second.Set(GfVec3f(0.1f, 0.2f, 0.3f));
+  GfMatrix4d second_result(1.0, 0.0, 0.0, 0.0,
+                           0.0, 1.0, 0.0, 0.0,
+                           0.0, 0.0, 1.0, 0.0,
+                           1.0, 2.0, 3.0, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+
+  UsdGeomXformOp third = xform.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("third"));
+  third.Set(GfVec3f(0.01f, 0.02f, 0.03f));
+  GfMatrix4d third_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          1.1, 2.2, 3.3, 1.0);
+  GfMatrix4d final_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          1.11, 2.22, 3.33, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+  COMPARE_MAT4(result, third_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+  COMPARE_MAT4(result, final_result, 1e-5f);
+
+  // sanity check - make sure our matrices match USD
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, final_result, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that up to 3 translations in a row evaluate correctly using float precision
+// The code should concatonate these into a single vec3 and simply assign the resulting translation. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, translate_h)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+
+  UsdGeomXformOp first = xform.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+  first.Set(GfVec3h(1.0f, 2.0f, 3.0f));
+  GfMatrix4d first_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+
+  UsdGeomXformOp second = xform.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("second"));
+  second.Set(GfVec3h(0.1f, 0.2f, 0.3f));
+  GfMatrix4d second_result(1.0, 0.0, 0.0, 0.0,
+                           0.0, 1.0, 0.0, 0.0,
+                           0.0, 0.0, 1.0, 0.0,
+                           1.0, 2.0, 3.0, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+
+  UsdGeomXformOp third = xform.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("third"));
+  third.Set(GfVec3h(0.01f, 0.02f, 0.03f));
+  GfMatrix4d third_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          1.1, 2.2, 3.3, 1.0);
+  GfMatrix4d final_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          1.11, 2.22, 3.33, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-4f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-4f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+  COMPARE_MAT4(result, third_result, 1e-4f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+  COMPARE_MAT4(result, final_result, 1e-4f);
+
+  // sanity check - make sure our matrices match USD
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, final_result, 1e-4f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that up to 3 translations in a row evaluate correctly using a mix of precision
+// The code should concatonate these into a single vec3 and simply assign the resulting translation. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, translate_dfh)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+
+  UsdGeomXformOp first = xform.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+  first.Set(GfVec3d(1.0, 2.0, 3.0));
+  GfMatrix4d first_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+
+  UsdGeomXformOp second = xform.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("second"));
+  second.Set(GfVec3f(0.1f, 0.2f, 0.3f));
+  GfMatrix4d second_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          1.0, 2.0, 3.0, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+
+  UsdGeomXformOp third = xform.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("third"));
+  third.Set(GfVec3h(0.01f, 0.02f, 0.03f));
+  GfMatrix4d third_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          1.1, 2.2, 3.3, 1.0);
+  GfMatrix4d final_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          1.11, 2.22, 3.33, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+  COMPARE_MAT4(result, third_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+  COMPARE_MAT4(result, final_result, 1e-5f);
+
+  // sanity check - make sure our matrices match USD
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, final_result, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that up to 3 translations in a row evaluate correctly using double precision
+// The code should concatonate these into a single vec3 and then transform by the prior evaluated matrix 
+// (which will be a scaling matrix)
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, scale_translate_d)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp scale = xform.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("scale"));
+  scale.Set(GfVec3d(1.0, 10.0, 100.0));
+  GfMatrix4d scale_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+
+
+  UsdGeomXformOp first = xform.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+  first.Set(GfVec3d(1.0, 2.0, 3.0));
+  GfMatrix4d first_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 10.0, 0.0, 0.0,
+                          0.0, 0.0, 100.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, scale_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+
+  UsdGeomXformOp second = xform.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("second"));
+  second.Set(GfVec3d(0.1, 0.2, 0.3));
+  GfMatrix4d second_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 10.0, 0.0, 0.0,
+                          0.0, 0.0, 100.0, 0.0,
+                          1.0, 20.0, 300.0, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, scale_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+
+  UsdGeomXformOp third = xform.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("third"));
+  third.Set(GfVec3d(0.01, 0.02, 0.03));
+  GfMatrix4d third_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 10.0, 0.0, 0.0,
+                          0.0, 0.0, 100.0, 0.0,
+                          1.1, 22, 330, 1.0);
+  GfMatrix4d final_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 10.0, 0.0, 0.0,
+                          0.0, 0.0, 100.0, 0.0,
+                          1.11, 22.2, 333, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, scale_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+  COMPARE_MAT4(result, third_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 4, UsdTimeCode::Default());
+  COMPARE_MAT4(result, final_result, 1e-5f);
+
+  // sanity check - make sure our matrices match USD
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, final_result, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that up to 3 translations in a row evaluate correctly using float precision
+// The code should concatonate these into a single vec3 and then transform by the prior evaluated matrix 
+// (which will be a scaling matrix)
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, scale_translate_f)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp scale = xform.AddScaleOp(UsdGeomXformOp::PrecisionFloat, TfToken("scale"));
+  scale.Set(GfVec3f(1.0f, 10.0f, 100.0f));
+  GfMatrix4d scale_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+
+
+  UsdGeomXformOp first = xform.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+  first.Set(GfVec3f(1.0f, 2.0f, 3.0f));
+  GfMatrix4d first_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 10.0, 0.0, 0.0,
+                          0.0, 0.0, 100.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, scale_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+
+  UsdGeomXformOp second = xform.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("second"));
+  second.Set(GfVec3f(0.1f, 0.2f, 0.3f));
+  GfMatrix4d second_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 10.0, 0.0, 0.0,
+                          0.0, 0.0, 100.0, 0.0,
+                          1.0, 20.0, 300.0, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, scale_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+
+  UsdGeomXformOp third = xform.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("third"));
+  third.Set(GfVec3f(0.01f, 0.02f, 0.03f));
+  GfMatrix4d third_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 10.0, 0.0, 0.0,
+                          0.0, 0.0, 100.0, 0.0,
+                          1.1, 22, 330, 1.0);
+  GfMatrix4d final_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 10.0, 0.0, 0.0,
+                          0.0, 0.0, 100.0, 0.0,
+                          1.11, 22.2, 333, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, scale_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+  COMPARE_MAT4(result, third_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 4, UsdTimeCode::Default());
+  COMPARE_MAT4(result, final_result, 1e-5f);
+
+
+  // sanity check - make sure our matrices match USD
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, final_result, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that up to 3 translations in a row evaluate correctly using float precision
+// The code should concatonate these into a single vec3 and then transform by the prior evaluated matrix 
+// (which will be a scaling matrix)
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, scale_translate_h)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp scale = xform.AddScaleOp(UsdGeomXformOp::PrecisionHalf, TfToken("scale"));
+  scale.Set(GfVec3h(1.0f, 10.0f, 100.0f));
+  GfMatrix4d scale_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+
+
+  UsdGeomXformOp first = xform.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+  first.Set(GfVec3h(1.0f, 2.0f, 3.0f));
+  GfMatrix4d first_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 10.0, 0.0, 0.0,
+                          0.0, 0.0, 100.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, scale_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+
+  UsdGeomXformOp second = xform.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("second"));
+  second.Set(GfVec3h(0.1f, 0.2f, 0.3f));
+  GfMatrix4d second_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 10.0, 0.0, 0.0,
+                          0.0, 0.0, 100.0, 0.0,
+                          1.0, 20.0, 300.0, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, scale_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+
+  UsdGeomXformOp third = xform.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("third"));
+  third.Set(GfVec3h(0.01f, 0.02f, 0.03f));
+  GfMatrix4d third_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 10.0, 0.0, 0.0,
+                          0.0, 0.0, 100.0, 0.0,
+                          1.1, 22, 330, 1.0);
+  GfMatrix4d final_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 10.0, 0.0, 0.0,
+                          0.0, 0.0, 100.0, 0.0,
+                          1.11, 22.2, 333, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, scale_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+  COMPARE_MAT4(result, third_result, 5e-3f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 4, UsdTimeCode::Default());
+  COMPARE_MAT4(result, final_result, 5e-3f);
+
+  // sanity check - make sure our matrices match USD
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, final_result, 5e-3f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that up to 3 translations in a row evaluate correctly using double precision
+// The code should concatonate these into a single vec3 and simply assign the resulting translation. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, scale_d)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+
+  UsdGeomXformOp first = xform.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+  first.Set(GfVec3d(1.0, 2.0, 3.0));
+  GfMatrix4d first_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+
+  UsdGeomXformOp second = xform.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("second"));
+  second.Set(GfVec3d(0.1, 0.2, 0.3));
+  GfMatrix4d second_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 2.0, 0.0, 0.0,
+                          0.0, 0.0, 3.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+
+  UsdGeomXformOp third = xform.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("third"));
+  third.Set(GfVec3d(0.01, 0.02, 0.03));
+  GfMatrix4d third_result(1.0 * 0.1, 0.0, 0.0, 0.0,
+                          0.0, 2.0 * 0.2, 0.0, 0.0,
+                          0.0, 0.0, 3.0 * 0.3, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+  GfMatrix4d final_result(1.0 * 0.1 * 0.01, 0.0, 0.0, 0.0,
+                          0.0, 2.0 * 0.2 * 0.02, 0.0, 0.0,
+                          0.0, 0.0, 3.0 * 0.3 * 0.03, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+  COMPARE_MAT4(result, third_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+  COMPARE_MAT4(result, final_result, 1e-5f);
+
+  // sanity check - make sure our matrices match USD
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, final_result, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that up to 3 translations in a row evaluate correctly using float precision
+// The code should concatonate these into a single vec3 and simply assign the resulting translation. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, scale_f)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+
+  UsdGeomXformOp first = xform.AddScaleOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+  first.Set(GfVec3f(1.0f, 2.0f, 3.0f));
+  GfMatrix4d first_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+
+  UsdGeomXformOp second = xform.AddScaleOp(UsdGeomXformOp::PrecisionFloat, TfToken("second"));
+  second.Set(GfVec3f(0.1f, 0.2f, 0.3f));
+  GfMatrix4d second_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 2.0, 0.0, 0.0,
+                          0.0, 0.0, 3.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+
+  UsdGeomXformOp third = xform.AddScaleOp(UsdGeomXformOp::PrecisionFloat, TfToken("third"));
+  third.Set(GfVec3f(0.01f, 0.02f, 0.03f));
+  GfMatrix4d third_result(1.0 * 0.1, 0.0, 0.0, 0.0,
+                          0.0, 2.0 * 0.2, 0.0, 0.0,
+                          0.0, 0.0, 3.0 * 0.3, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+  GfMatrix4d final_result(1.0 * 0.1 * 0.01, 0.0, 0.0, 0.0,
+                          0.0, 2.0 * 0.2 * 0.02, 0.0, 0.0,
+                          0.0, 0.0, 3.0 * 0.3 * 0.03, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+  COMPARE_MAT4(result, third_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+  COMPARE_MAT4(result, final_result, 1e-5f);
+
+  // sanity check - make sure our matrices match USD
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, final_result, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that up to 3 translations in a row evaluate correctly using float precision
+// The code should concatonate these into a single vec3 and simply assign the resulting translation. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, scale_h)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+
+  UsdGeomXformOp first = xform.AddScaleOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+  first.Set(GfVec3h(1.0f, 2.0f, 3.0f));
+  GfMatrix4d first_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+
+  UsdGeomXformOp second = xform.AddScaleOp(UsdGeomXformOp::PrecisionHalf, TfToken("second"));
+  second.Set(GfVec3h(0.1f, 0.2f, 0.3f));
+  GfMatrix4d second_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 2.0, 0.0, 0.0,
+                          0.0, 0.0, 3.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+
+  UsdGeomXformOp third = xform.AddScaleOp(UsdGeomXformOp::PrecisionHalf, TfToken("third"));
+  third.Set(GfVec3h(0.01f, 0.02f, 0.03f));
+  GfMatrix4d third_result(1.0 * 0.1, 0.0, 0.0, 0.0,
+                          0.0, 2.0 * 0.2, 0.0, 0.0,
+                          0.0, 0.0, 3.0 * 0.3, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+  GfMatrix4d final_result(1.0 * 0.1 * 0.01, 0.0, 0.0, 0.0,
+                          0.0, 2.0 * 0.2 * 0.02, 0.0, 0.0,
+                          0.0, 0.0, 3.0 * 0.3 * 0.03, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-4f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+  COMPARE_MAT4(result, third_result, 1e-3f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+  COMPARE_MAT4(result, final_result, 1e-3f);
+
+  // sanity check - make sure our matrices match USD
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, final_result, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that up to 3 translations in a row evaluate correctly using a mix of precision
+// The code should concatonate these into a single vec3 and simply assign the resulting translation. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, scale_dfh)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+
+  UsdGeomXformOp first = xform.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+  first.Set(GfVec3d(1.0, 2.0, 3.0));
+  GfMatrix4d first_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 1.0, 0.0, 0.0,
+                          0.0, 0.0, 1.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+
+  UsdGeomXformOp second = xform.AddScaleOp(UsdGeomXformOp::PrecisionFloat, TfToken("second"));
+  second.Set(GfVec3f(0.1f, 0.2f, 0.3f));
+  GfMatrix4d second_result(1.0, 0.0, 0.0, 0.0,
+                          0.0, 2.0, 0.0, 0.0,
+                          0.0, 0.0, 3.0, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+
+  UsdGeomXformOp third = xform.AddScaleOp(UsdGeomXformOp::PrecisionHalf, TfToken("third"));
+  third.Set(GfVec3h(0.01f, 0.02f, 0.03f));
+  GfMatrix4d third_result(1.0 * 0.1, 0.0, 0.0, 0.0,
+                          0.0, 2.0 * 0.2, 0.0, 0.0,
+                          0.0, 0.0, 3.0 * 0.3, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+  GfMatrix4d final_result(1.0 * 0.1 * 0.01, 0.0, 0.0, 0.0,
+                          0.0, 2.0 * 0.2 * 0.02, 0.0, 0.0,
+                          0.0, 0.0, 3.0 * 0.3 * 0.03, 0.0,
+                          0.0, 0.0, 0.0, 1.0);
+                          
+  ops = xform.GetOrderedXformOps(&resetsXformStack);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 0, UsdTimeCode::Default());
+  COMPARE_MAT4(result, first_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+  COMPARE_MAT4(result, second_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+  COMPARE_MAT4(result, third_result, 1e-5f);
+  result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+  COMPARE_MAT4(result, final_result, 1e-5f);
+
+  // sanity check - make sure our matrices match USD
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, final_result, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that single-axis rotations are correctly evaluated with differing precision
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotate_x)
+{
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateXOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+    first.Set(23.0);
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateXOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+    first.Set(23.0f);
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateXOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+    first.Set(GfHalf(23.0f));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, rotate_y)
+{
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateYOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+    first.Set(23.0);
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateYOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+    first.Set(23.0f);
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateYOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+    first.Set(GfHalf(23.0f));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, rotate_z)
+{
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateZOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+    first.Set(23.0);
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateZOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+    first.Set(23.0f);
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateZOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+    first.Set(GfHalf(23.0f));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that three-axis rotations are correctly evaluated with differing precision
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotate_xyz)
+{
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+    first.Set(GfVec3d(23.0, 31.0, -22.9));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateXYZOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+    first.Set(GfVec3f(23.0, 31.0, -22.9));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateXYZOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+    first.Set(GfVec3h(23.0f, 31.0f, -22.9f));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, rotate_xzy)
+{
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateXZYOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+    first.Set(GfVec3d(23.0, 31.0, -22.9));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateXZYOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+    first.Set(GfVec3f(23.0, 31.0, -22.9));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateXZYOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+    first.Set(GfVec3h(23.0f, 31.0f, -22.9f));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, rotate_yxz)
+{
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateYXZOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+    first.Set(GfVec3d(23.0, 31.0, -22.9));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateYXZOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+    first.Set(GfVec3f(23.0, 31.0, -22.9));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateYXZOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+    first.Set(GfVec3h(23.0f, 31.0f, -22.9f));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, rotate_yzx)
+{
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+    first.Set(GfVec3d(23.0, 31.0, -22.9));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+    first.Set(GfVec3f(23.0, 31.0, -22.9));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+    first.Set(GfVec3h(23.0f, 31.0f, -22.9f));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, rotate_zxy)
+{
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateZXYOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+    first.Set(GfVec3d(23.0, 31.0, -22.9));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateZXYOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+    first.Set(GfVec3f(23.0, 31.0, -22.9));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateZXYOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+    first.Set(GfVec3h(23.0f, 31.0f, -22.9f));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, rotate_zyx)
+{
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateZYXOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+    first.Set(GfVec3d(23.0, 31.0, -22.9));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateZYXOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+    first.Set(GfVec3f(23.0, 31.0, -22.9));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateZYXOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+    first.Set(GfVec3h(23.0f, 31.0f, -22.9f));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, combined_rotation)
+{
+  auto randf = []()
+  {
+    return -180.0f + 360.0f*(rand()/float(RAND_MAX));
+  };
+
+  for(int k = 0; k < 1; ++k)
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddRotateZYXOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+    first.Set(GfVec3d(randf(), randf(), randf()));
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+
+    UsdGeomXformOp second = xform.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("second"));
+    second.Set(GfVec3d(randf(), randf(), randf()));
+
+    ops = xform.GetOrderedXformOps(&resetsXformStack);
+    final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+    
+    UsdGeomXformOp third = xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionDouble, TfToken("third"));
+    third.Set(GfVec3d(randf(), randf(), randf()));
+
+    ops = xform.GetOrderedXformOps(&resetsXformStack);
+    final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, orient)
+{
+  auto randf = []()
+  {
+    return -1.0f + 2.0f*(rand()/float(RAND_MAX));
+  };
+  
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddOrientOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+    GfQuatd q(randf(), randf(), randf(), randf());
+    q.Normalize();
+    first.Set(q);
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddOrientOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+    GfQuatf q(randf(), randf(), randf(), randf());
+    q.Normalize();
+    first.Set(q);
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 1e-5f);
+  }
+
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    ASSERT_TRUE(stage);
+    UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+    UsdGeomXformOp first = xform.AddOrientOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+    GfQuath q(randf(), randf(), randf(), randf());
+    q.Normalize();
+    first.Set(q);
+
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d final_result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default()), result;
+    EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+    COMPARE_MAT4(result, final_result, 2.6e-3f);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that inverse scale ops evaluate correctly
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, inverse_scaled)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+  first.Set(GfVec3d(1.0, 2.0, 3.0));
+
+  UsdGeomXformOp second = xform.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("second"));
+  second.Set(GfVec3d(3.2, 2.2, 1.2));
+
+  UsdGeomXformOp third = xform.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"), true);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d evaluated = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default()), result;
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, evaluated, 1e-5f);
+}
+
+TEST(TransformOpProcessor, inverse_scalef)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddScaleOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+  first.Set(GfVec3f(1.0, 2.0, 3.0));
+
+  UsdGeomXformOp second = xform.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("second"));
+  second.Set(GfVec3d(3.2, 2.2, 1.2));
+
+  UsdGeomXformOp third = xform.AddScaleOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"), true);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d evaluated = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default()), result;
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, evaluated, 1e-5f);
+}
+
+TEST(TransformOpProcessor, inverse_scaleh)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddScaleOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+  first.Set(GfVec3h(1.0, 2.0, 3.0));
+
+  UsdGeomXformOp second = xform.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("second"));
+  second.Set(GfVec3d(3.2, 2.2, 1.2));
+
+  UsdGeomXformOp third = xform.AddScaleOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"), true);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d evaluated = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default()), result;
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, evaluated, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that inverse translate ops evaluate correctly
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, inverse_translated)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+  first.Set(GfVec3d(1.0, 2.0, 3.0));
+
+  UsdGeomXformOp second = xform.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("second"));
+  second.Set(GfVec3d(3.2, 2.2, 1.2));
+
+  UsdGeomXformOp third = xform.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"), true);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d evaluated = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default()), result;
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, evaluated, 1e-5f);
+}
+
+TEST(TransformOpProcessor, inverse_translatef)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+  first.Set(GfVec3f(1.0f, 2.0f, 3.0f));
+
+  UsdGeomXformOp second = xform.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("second"));
+  second.Set(GfVec3d(3.2f, 2.2f, 1.2f));
+
+  UsdGeomXformOp third = xform.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"), true);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d evaluated = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default()), result;
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, evaluated, 1e-5f);
+}
+
+TEST(TransformOpProcessor, inverse_translateh)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+  first.Set(GfVec3h(1.0f, 2.0f, 3.0f));
+
+  UsdGeomXformOp second = xform.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("second"));
+  second.Set(GfVec3d(3.2f, 2.2f, 1.2f));
+
+  UsdGeomXformOp third = xform.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"), true);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d evaluated = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default()), result;
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, evaluated, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that inverse rotate ops evaluate correctly
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, inverse_rotated)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateZYXOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+  first.Set(GfVec3d(1.0, 2.0, 3.0));
+
+  UsdGeomXformOp second = xform.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("second"));
+  second.Set(GfVec3d(3.2, 2.2, 1.2));
+
+  UsdGeomXformOp third = xform.AddRotateZYXOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"), true);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d evaluated = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default()), result;
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, evaluated, 1e-5f);
+}
+
+TEST(TransformOpProcessor, inverse_rotatef)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+  first.Set(GfVec3f(1.0, 2.0, 3.0));
+
+  UsdGeomXformOp second = xform.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("second"));
+  second.Set(GfVec3d(3.2, 2.2, 1.2));
+
+  UsdGeomXformOp third = xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"), true);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d evaluated = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default()), result;
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, evaluated, 1e-5f);
+}
+
+TEST(TransformOpProcessor, inverse_rotateh)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXZYOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+  first.Set(GfVec3h(1.0, 2.0, 3.0));
+
+  UsdGeomXformOp second = xform.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("second"));
+  second.Set(GfVec3d(3.2, 2.2, 1.2));
+
+  UsdGeomXformOp third = xform.AddRotateXZYOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"), true);
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+  GfMatrix4d evaluated = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default()), result;
+  EXPECT_TRUE(xform.GetLocalTransformation(&result, ops, UsdTimeCode::Default()));
+  COMPARE_MAT4(result, evaluated, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that ops that have no value set don't accumulate any garbage as a result
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, no_scale_value)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), first.GetOpName());
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kScale, processor.ManipMode());
+  EXPECT_TRUE(processor.Scale(GfVec3d(2.0, 0.5, 0.3), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3d scale;
+  first.Get(&scale);
+  EXPECT_NEAR(2.0, scale[0], 1e-5f);
+  EXPECT_NEAR(0.5, scale[1], 1e-5f);
+  EXPECT_NEAR(0.3, scale[2], 1e-5f);
+
+  EXPECT_TRUE(processor.Scale(GfVec3d(2.0, 0.5, 0.3), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  first.Get(&scale);
+  EXPECT_NEAR(2.0 * 2.0, scale[0], 1e-5f);
+  EXPECT_NEAR(0.5 * 0.5, scale[1], 1e-5f);
+  EXPECT_NEAR(0.3 * 0.3, scale[2], 1e-5f);
+}
+
+TEST(TransformOpProcessor, no_translate_value)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), first.GetOpName());
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+  EXPECT_TRUE(processor.Translate(GfVec3d(2.0, 0.5, 0.3), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3d translate;
+  first.Get(&translate);
+  EXPECT_NEAR(2.0, translate[0], 1e-5f);
+  EXPECT_NEAR(0.5, translate[1], 1e-5f);
+  EXPECT_NEAR(0.3, translate[2], 1e-5f);
+
+  EXPECT_TRUE(processor.Translate(GfVec3d(2.0, 0.5, 0.3), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  first.Get(&translate);
+  EXPECT_NEAR(4.0, translate[0], 1e-5f);
+  EXPECT_NEAR(1.0, translate[1], 1e-5f);
+  EXPECT_NEAR(0.6, translate[2], 1e-5f);
+}
+
+TEST(TransformOpProcessor, no_rotate_value)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  double sx = std::sin( (45.0f * (M_PI / 360.0) ) );
+  double cx = std::cos( (45.0f * (M_PI / 360.0) ) );
+  GfQuatd Q(cx, sx, 0, 0);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3d rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(45.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(0.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(0.0, rotate[2], 1e-5f);
+
+  // 45 degrees around X
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  first.Get(&rotate);
+  EXPECT_NEAR(90.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(0.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(0.0, rotate[2], 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Make sure we can rotate single axis rotations (double)
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotateXd)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  double sx = std::sin( (45.0 * (M_PI / 360.0) ) );
+  double cx = std::cos( (45.0 * (M_PI / 360.0) ) );
+  GfQuatd Q(cx, sx, 0, 0);
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), first.GetOpName());
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  double rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(45.0, rotate, 1e-5);
+
+  // 45 degrees around X
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  first.Get(&rotate);
+  EXPECT_NEAR(90.0, rotate, 1e-5);
+}
+
+TEST(TransformOpProcessor, rotateYd)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateYOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+
+  double sx = std::sin( (45.0 * (M_PI / 360.0) ) );
+  double cx = std::cos( (45.0 * (M_PI / 360.0) ) );
+  GfQuatd Q(cx, 0, sx, 0);
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), first.GetOpName());
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around Y
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  double rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(45.0, rotate, 1e-5);
+
+  // 45 degrees around Y
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  first.Get(&rotate);
+  EXPECT_NEAR(90.0, rotate, 1e-5);
+}
+
+TEST(TransformOpProcessor, rotateZd)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateZOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  double sx = std::sin( (45.0 * (M_PI / 360.0) ) );
+  double cx = std::cos( (45.0 * (M_PI / 360.0) ) );
+  GfQuatd Q(cx, 0, 0, sx);
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), first.GetOpName());
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around Z
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  double rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(45.0, rotate, 1e-5);
+
+  // 45 degrees around Z
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  first.Get(&rotate);
+  EXPECT_NEAR(90.0, rotate, 1e-5);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Make sure we can rotate three axis rotations (float)
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotateXf)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  double sx = std::sin( (45.0 * (M_PI / 360.0) ) );
+  double cx = std::cos( (45.0 * (M_PI / 360.0) ) );
+  GfQuatd Q(cx, sx, 0, 0);
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), first.GetOpName());
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  float rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(45.0, rotate, 1e-5f);
+
+  // 45 degrees around X
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  first.Get(&rotate);
+  EXPECT_NEAR(90.0, rotate, 1e-5f);
+}
+
+TEST(TransformOpProcessor, rotateYf)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateYOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  double sx = std::sin( (45.0 * (M_PI / 360.0) ) );
+  double cx = std::cos( (45.0 * (M_PI / 360.0) ) );
+  GfQuatd Q(cx, 0, sx, 0);
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), first.GetOpName());
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  float rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(45.0, rotate, 1e-5f);
+
+  // 45 degrees around X
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  first.Get(&rotate);
+  EXPECT_NEAR(90.0, rotate, 1e-5f);
+}
+
+TEST(TransformOpProcessor, rotateZf)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateZOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  double sx = std::sin( (45.0 * (M_PI / 360.0) ) );
+  double cx = std::cos( (45.0 * (M_PI / 360.0) ) );
+  GfQuatd Q(cx, 0, 0, sx);
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), first.GetOpName());
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  float rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(45.0, rotate, 1e-5f);
+
+  // 45 degrees around X
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  first.Get(&rotate);
+  EXPECT_NEAR(90.0, rotate, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Make sure we can rotate three axis rotations (half)
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotateXh)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  double sx = std::sin( (45.0 * (M_PI / 360.0) ) );
+  double cx = std::cos( (45.0 * (M_PI / 360.0) ) );
+  GfQuatd Q(cx, sx, 0, 0);
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), first.GetOpName());
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfHalf rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(45.0, rotate, 1e-5f);
+
+  // 45 degrees around X
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  first.Get(&rotate);
+  EXPECT_NEAR(90.0, rotate, 1e-5f);
+}
+
+TEST(TransformOpProcessor, rotateYh)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateYOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  double sx = std::sin( (45.0 * (M_PI / 360.0) ) );
+  double cx = std::cos( (45.0 * (M_PI / 360.0) ) );
+  GfQuatd Q(cx, 0, sx, 0);
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), first.GetOpName());
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfHalf rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(45.0, rotate, 1e-5f);
+
+  // 45 degrees around X
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  first.Get(&rotate);
+  EXPECT_NEAR(90.0, rotate, 1e-5f);
+}
+
+TEST(TransformOpProcessor, rotateZh)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateZOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  double sx = std::sin( (45.0 * (M_PI / 360.0) ) );
+  double cx = std::cos( (45.0 * (M_PI / 360.0) ) );
+  GfQuatd Q(cx, 0, 0, sx);
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), first.GetOpName());
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfHalf rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(45.0, rotate, 1e-5f);
+
+  // 45 degrees around X
+  EXPECT_TRUE(processor.Rotate(Q, MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  first.Get(&rotate);
+  EXPECT_NEAR(90.0, rotate, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// When modifying the 'X' angle in an XYZ rotation, we can go down an optimised path that simply sets the 'X' value
+// directly.
+//----------------------------------------------------------------------------------------------------------------------
+
+TEST(TransformOpProcessor, rotateXYZd_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+  first.Set(GfVec3d(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateX(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3d rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(15.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(18.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(42.0, rotate[2], 1e-5f);
+}
+TEST(TransformOpProcessor, rotateXYZf_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXYZOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+  first.Set(GfVec3f(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateX(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3f rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(15.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(18.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(42.0, rotate[2], 1e-5f);
+}
+TEST(TransformOpProcessor, rotateXYZh_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXYZOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+  first.Set(GfVec3h(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateX(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3h rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(15.0, rotate[0], 1e-3f);
+  EXPECT_NEAR(18.0, rotate[1], 1e-3f);
+  EXPECT_NEAR(42.0, rotate[2], 1e-3f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// When modifying the 'X' angle in an XZY rotation, we can go down an optimised path that simply sets the 'X' value
+// directly.
+//----------------------------------------------------------------------------------------------------------------------
+
+TEST(TransformOpProcessor, rotateXZYd_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXZYOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+  first.Set(GfVec3d(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateX(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3d rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(15.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(18.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(42.0, rotate[2], 1e-5f);
+}
+TEST(TransformOpProcessor, rotateXZYf_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXZYOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+  first.Set(GfVec3f(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateX(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3f rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(15.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(18.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(42.0, rotate[2], 1e-5f);
+}
+TEST(TransformOpProcessor, rotateXZYh_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXZYOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+  first.Set(GfVec3h(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateX(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3h rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(15.0, rotate[0], 1e-3f);
+  EXPECT_NEAR(18.0, rotate[1], 1e-3f);
+  EXPECT_NEAR(42.0, rotate[2], 1e-3f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// When modifying the 'Y' angle in an YXZ rotation, we can go down an optimised path that simply sets the 'Y' value
+// directly.
+//----------------------------------------------------------------------------------------------------------------------
+
+TEST(TransformOpProcessor, rotateYXZd_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+  first.Set(GfVec3d(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3d rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(10.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(23.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(42.0, rotate[2], 1e-5f);
+}
+TEST(TransformOpProcessor, rotateYXZf_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+  first.Set(GfVec3f(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3f rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(10.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(23.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(42.0, rotate[2], 1e-5f);
+}
+TEST(TransformOpProcessor, rotateYXZh_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+  first.Set(GfVec3h(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3h rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(10.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(23.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(42.0, rotate[2], 1e-3f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// When modifying the 'Y' angle in an YZX rotation, we can go down an optimised path that simply sets the 'Y' value
+// directly.
+//----------------------------------------------------------------------------------------------------------------------
+
+TEST(TransformOpProcessor, rotateYZXd_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+  first.Set(GfVec3d(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3d rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(10.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(23.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(42.0, rotate[2], 1e-5f);
+}
+TEST(TransformOpProcessor, rotateYZXf_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+  first.Set(GfVec3f(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3f rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(10.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(23.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(42.0, rotate[2], 1e-5f);
+}
+TEST(TransformOpProcessor, rotateYZXh_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+  first.Set(GfVec3h(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  EXPECT_TRUE(processor.RotateY(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3h rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(10.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(23.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(42.0, rotate[2], 1e-3f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// When modifying the 'Y' angle in an YXZ rotation, we can go down an optimised path that simply sets the 'Y' value
+// directly.
+//----------------------------------------------------------------------------------------------------------------------
+
+TEST(TransformOpProcessor, rotateZXYd_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateZXYOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+  first.Set(GfVec3d(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateZ(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3d rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(10.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(18.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(47.0, rotate[2], 1e-5f);
+}
+TEST(TransformOpProcessor, rotateZXYf_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateZXYOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+  first.Set(GfVec3f(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateZ(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3f rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(10.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(18.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(47.0, rotate[2], 1e-5f);
+}
+TEST(TransformOpProcessor, rotateZXYh_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateZXYOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+  first.Set(GfVec3h(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateZ(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3h rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(10.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(18.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(47.0, rotate[2], 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// When modifying the 'Z' angle in an ZYX rotation, we can go down an optimised path that simply sets the 'Z' value
+// directly.
+//----------------------------------------------------------------------------------------------------------------------
+
+TEST(TransformOpProcessor, rotateZYXd_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateZYXOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+  first.Set(GfVec3d(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateZ(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3d rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(10.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(18.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(47.0, rotate[2], 1e-5f);
+}
+TEST(TransformOpProcessor, rotateZYXf_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateZYXOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+  first.Set(GfVec3f(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateZ(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3f rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(10.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(18.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(47.0, rotate[2], 1e-5f);
+}
+TEST(TransformOpProcessor, rotateZYXh_rotate_first)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateZYXOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+  first.Set(GfVec3h(10, 18, 42));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  EXPECT_TRUE(processor.RotateZ(5.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3h rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(10.0, rotate[0], 1e-5f);
+  EXPECT_NEAR(18.0, rotate[1], 1e-5f);
+  EXPECT_NEAR(47.0, rotate[2], 1e-5f);
+}
+
+
+//----------------------------------------------------------------------------------------------------------------------
+// Using an XYZ rotation order, replicate some rotations that may occur with the Maya rotate tool, and check we end up 
+// with the same result. The Y and Z rotations will utilise quaternions.
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotateXYZd)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3d rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(19.390714, rotate[0], 1e-5f);
+  EXPECT_NEAR(-52.266911, rotate[1], 1e-5f);
+  EXPECT_NEAR(32.255846, rotate[2], 1e-5f);
+}
+
+TEST(TransformOpProcessor, rotateXYZf)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXYZOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3f rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(19.390714, rotate[0], 1e-5f);
+  EXPECT_NEAR(-52.266911, rotate[1], 1e-5f);
+  EXPECT_NEAR(32.255846, rotate[2], 1e-5f);
+}
+
+TEST(TransformOpProcessor, rotateXYZh)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXYZOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3h rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(19.390714, rotate[0], 1e-1f);
+  EXPECT_NEAR(-52.266911, rotate[1], 1e-1f);
+  EXPECT_NEAR(32.255846, rotate[2], 1e-1f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Using an XZY rotation order, replicate some rotations that may occur with the Maya rotate tool, and check we end up 
+// with the same result. The Y and Z rotations will utilise quaternions.
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotateXZYd)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXZYOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3d rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(45.915175, rotate[0], 1e-5f);
+  EXPECT_NEAR(-56.79962, rotate[1], 1e-5f);
+  EXPECT_NEAR(19.063526, rotate[2], 1e-5f);
+}
+
+TEST(TransformOpProcessor, rotateXZYf)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXZYOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3f rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(45.915175, rotate[0], 1e-5f);
+  EXPECT_NEAR(-56.79962, rotate[1], 1e-5f);
+  EXPECT_NEAR(19.063526, rotate[2], 1e-5f);
+}
+
+TEST(TransformOpProcessor, rotateXZYh)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateXZYOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3h rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(45.915175, rotate[0], 1e-1f);
+  EXPECT_NEAR(-56.79962, rotate[1], 1e-1f);
+  EXPECT_NEAR(19.063526, rotate[2], 1e-1f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Using an YXZ rotation order, replicate some rotations that may occur with the Maya rotate tool, and check we end up 
+// with the same result. The Y and Z rotations will utilise quaternions.
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotateYXZd)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateYXZOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3d rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(11.723195, rotate[0], 1e-5f);
+  EXPECT_NEAR(-53.873641, rotate[1], 1e-5f);
+  EXPECT_NEAR(47.811204, rotate[2], 1e-5f);
+}
+
+TEST(TransformOpProcessor, rotateYXZf)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateYXZOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3f rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(11.723195, rotate[0], 1e-5f);
+  EXPECT_NEAR(-53.873641, rotate[1], 1e-5f);
+  EXPECT_NEAR(47.811204, rotate[2], 1e-5f);
+}
+
+TEST(TransformOpProcessor, rotateYXZh)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateYXZOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3h rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(11.723195, rotate[0], 1e-1f);
+  EXPECT_NEAR(-53.873641, rotate[1], 1e-1f);
+  EXPECT_NEAR(47.811204, rotate[2], 1e-1f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Using an YZX rotation order, replicate some rotations that may occur with the Maya rotate tool, and check we end up 
+// with the same result. The Y and Z rotations will utilise quaternions.
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotateYZXd)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3d rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(17.170789, rotate[0], 1e-5f);
+  EXPECT_NEAR(-41.238612, rotate[1], 1e-5f);
+  EXPECT_NEAR(46.508833, rotate[2], 1e-5f);
+}
+
+TEST(TransformOpProcessor, rotateYZXf)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3f rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(17.170789, rotate[0], 1e-5f);
+  EXPECT_NEAR(-41.238612, rotate[1], 1e-5f);
+  EXPECT_NEAR(46.508833, rotate[2], 1e-5f);
+}
+
+TEST(TransformOpProcessor, rotateYZXh)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateYZXOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3h rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(17.170789, rotate[0], 1e-1f);
+  EXPECT_NEAR(-41.238612, rotate[1], 1e-1f);
+  EXPECT_NEAR(46.508833, rotate[2], 1e-1f);
+}
+
+
+//----------------------------------------------------------------------------------------------------------------------
+// Using an ZYX rotation order, replicate some rotations that may occur with the Maya rotate tool, and check we end up 
+// with the same result. The Y and Z rotations will utilise quaternions.
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotateZXYd)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateZXYOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3d rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(42.759017, rotate[0], 1e-5f);
+  EXPECT_NEAR(-38.164457, rotate[1], 1e-5f);
+  EXPECT_NEAR(26.413781, rotate[2], 1e-5f);
+}
+
+TEST(TransformOpProcessor, rotateZXYf)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateZXYOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3f rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(42.759017, rotate[0], 1e-5f);
+  EXPECT_NEAR(-38.164457, rotate[1], 1e-5f);
+  EXPECT_NEAR(26.413781, rotate[2], 1e-5f);
+}
+
+TEST(TransformOpProcessor, rotateZXYh)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateZXYOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3h rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(42.759017, rotate[0], 1e-1f);
+  EXPECT_NEAR(-38.164457, rotate[1], 1e-1f);
+  EXPECT_NEAR(26.413781, rotate[2], 1e-1f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Using an ZYX rotation order, replicate some rotations that may occur with the Maya rotate tool, and check we end up 
+// with the same result. The Y and Z rotations will utilise quaternions.
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotateZYXd)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateZYXOp(UsdGeomXformOp::PrecisionDouble, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3d rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(49.6261, rotate[0], 1e-5f);
+  EXPECT_NEAR(-26.980493, rotate[1], 1e-5f);
+  EXPECT_NEAR(54.49695, rotate[2], 1e-5f);
+}
+
+TEST(TransformOpProcessor, rotateZYXf)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateZYXOp(UsdGeomXformOp::PrecisionFloat, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3f rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(49.6261, rotate[0], 1e-5f);
+  EXPECT_NEAR(-26.980493, rotate[1], 1e-5f);
+  EXPECT_NEAR(54.49695, rotate[2], 1e-5f);
+}
+
+TEST(TransformOpProcessor, rotateZYXh)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+  UsdGeomXform xform = UsdGeomXform::Define(stage, SdfPath("/xform"));
+
+  UsdGeomXformOp first = xform.AddRotateZYXOp(UsdGeomXformOp::PrecisionHalf, TfToken("first"));
+
+  bool resetsXformStack = false;
+  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
+
+  MayaUsdUtils::TransformOpProcessor processor(xform.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  // 45 degrees around X
+  EXPECT_TRUE(processor.RotateY(-38.164457 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateX(42.759017 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+  EXPECT_TRUE(processor.RotateZ(26.413781 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+  GfVec3h rotate;
+  first.Get(&rotate);
+  EXPECT_NEAR(49.6261, rotate[0], 1e-1f);
+  EXPECT_NEAR(-26.980493, rotate[1], 1e-1f);
+  EXPECT_NEAR(54.49695, rotate[2], 1e-1f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Using an XYZ rotation order, replicate some rotations that may occur with the Maya rotate tool, and check we end up 
+// with the same result. The Y and Z rotations will utilise quaternions.
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotate_world_space_d_no_scale)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+
+  parent_translate.Set(GfVec3d(-2.0, 3.0, 1.0));
+  parent_rotate.Set(GfVec3d(-11.0, -21.0, 22.0));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(0.865601,0.349725,0.358368,0,-0.304323,0.935764,-0.178136,0,-0.397646,0.0451345,0.916428,0,-2,3,1,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  child_translate.Set(GfVec3d(2.0, 1.0, 2.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1,0,0,0,0,1,0,0,0,0,1,0,2,1,2,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  {
+    const GfMatrix4d expected(0.865601,0.349725,0.358368,0,-0.304323,0.935764,-0.178136,0,-0.397646,0.0451345,0.916428,0,-1.368415,4.725484,3.371456,1);
+    COMPARE_MAT4(expected, processor.WorldFrame(), 1e-5f);
+  }
+
+  // rotate 15 degrees around X in world space
+  {
+    GfVec3d rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_TRUE(processor.RotateX(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(13.218885, rotate[0], 1e-5f);
+    EXPECT_NEAR(-3.843776, rotate[1], 1e-5f);
+    EXPECT_NEAR(-6.439076, rotate[2], 1e-5f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.RotateY(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(16.968949, rotate[0], 1e-5f);
+    EXPECT_NEAR(10.668345, rotate[1], 1e-5f);
+    EXPECT_NEAR(-5.533085, rotate[2], 1e-5f);
+  }
+
+  // rotate 15 degrees around Z in world space
+  {
+    EXPECT_TRUE(processor.RotateZ(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(22.315417, rotate[0], 1e-5f);
+    EXPECT_NEAR(7.835664, rotate[1], 1e-5f);
+    EXPECT_NEAR(9.086346, rotate[2], 1e-5f);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Apply a world space translation on a simple set up
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, translate_world_space_d)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-3.0, -2.0, -1.0));
+  parent_rotate.Set(GfVec3d(10.0, 15.0, 20.0));
+  parent_scale.Set(GfVec3d(1.1, 1.2, 1.3));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(0.998441,0.363403,-0.284701,0,-0.353509,1.128946,0.201278,0,0.388579,-0.0987992,1.236627,0,-3,-2,-1,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  child_translate.Set(GfVec3d(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1,0,0,0,0,1,0,0,0,0,1,0,3,4,5,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(6.810837, translate[0], 1e-5f);
+    EXPECT_NEAR(7.022931, translate[1], 1e-5f);
+    EXPECT_NEAR(9.024255, translate[2], 1e-5f);
+  }
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(10.621674, translate[0], 1e-5f);
+    EXPECT_NEAR(10.045862, translate[1], 1e-5f);
+    EXPECT_NEAR(13.04851, translate[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space_f)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-3.0, -2.0, -1.0));
+  parent_rotate.Set(GfVec3d(10.0, 15.0, 20.0));
+  parent_scale.Set(GfVec3d(1.1, 1.2, 1.3));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(0.998441,0.363403,-0.284701,0,-0.353509,1.128946,0.201278,0,0.388579,-0.0987992,1.236627,0,-3,-2,-1,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("child_translate"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  child_translate.Set(GfVec3f(3.0f, 4.0f, 5.0f));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1,0,0,0,0,1,0,0,0,0,1,0,3,4,5,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  // rotate 15 degrees around X in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(6.810837, translate[0], 1e-5f);
+    EXPECT_NEAR(7.022931, translate[1], 1e-5f);
+    EXPECT_NEAR(9.024255, translate[2], 1e-5f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(10.621674, translate[0], 1e-5f);
+    EXPECT_NEAR(10.045862, translate[1], 1e-5f);
+    EXPECT_NEAR(13.04851, translate[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space_h)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-3.0, -2.0, -1.0));
+  parent_rotate.Set(GfVec3d(10.0, 15.0, 20.0));
+  parent_scale.Set(GfVec3d(1.1, 1.2, 1.3));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(0.998441,0.363403,-0.284701,0,-0.353509,1.128946,0.201278,0,0.388579,-0.0987992,1.236627,0,-3,-2,-1,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("child_translate"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  child_translate.Set(GfVec3h(3.0f, 4.0f, 5.0f));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1,0,0,0,0,1,0,0,0,0,1,0,3,4,5,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  // rotate 15 degrees around X in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(6.810837, translate[0], 1e-2f);
+    EXPECT_NEAR(7.022931, translate[1], 1e-2f);
+    EXPECT_NEAR(9.024255, translate[2], 1e-2f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(10.621674, translate[0], 1e-2f);
+    EXPECT_NEAR(10.045862, translate[1], 1e-2f);
+    EXPECT_NEAR(13.04851, translate[2], 1e-2f);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test world space translations against the results given by Maya (double precision).
+// Tested with a varying number of xform operations of different types
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, translate_parent_space1_d)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-3.0, -2.0, -1.0));
+  parent_rotate.Set(GfVec3d(10.0, 15.0, 20.0));
+  parent_scale.Set(GfVec3d(1.1, 1.2, 1.3));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(0.998441,0.363403,-0.284701,0,-0.353509,1.128946,0.201278,0,0.388579,-0.0987992,1.236627,0,-3,-2,-1,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  child_translate.Set(GfVec3d(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1,0,0,0,0,1,0,0,0,0,1,0,3,4,5,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  // translate in parent space - this should be the same as a simple local space transform in this case
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kParent));
+    GfVec3d translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(7.3, translate[0], 1e-5f);
+    EXPECT_NEAR(8.4, translate[1], 1e-5f);
+    EXPECT_NEAR(9.5, translate[2], 1e-5f);
+  }
+
+  // translate in parent space - this should be the same as a simple local space transform in this case
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kParent));
+    GfVec3d translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(11.6, translate[0], 1e-5f);
+    EXPECT_NEAR(12.8, translate[1], 1e-5f);
+    EXPECT_NEAR(14.0, translate[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space2_d)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+
+  parent_rotate.Set(GfVec3d(22.0, 33.0, 44.0));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,0,0,0,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  child_translate.Set(GfVec3d(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1,0,0,0, 0,1,0,0, 0,0,1,0, 3,4,5,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  // rotate 15 degrees around X in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(5.706661, translate[0], 1e-5f);
+    EXPECT_NEAR(6.833556, translate[1], 1e-5f);
+    EXPECT_NEAR(11.537962, translate[2], 1e-5f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(8.413323, translate[0], 1e-5f);
+    EXPECT_NEAR(9.667113, translate[1], 1e-5f);
+    EXPECT_NEAR(18.075923, translate[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space3_d)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+
+  parent_rotate.Set(GfVec3d(22.0, 33.0, 44.0));
+  parent_translate.Set(GfVec3d(3.0, 4.0, 5.0));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,0,0,0,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(parent.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  // rotate 15 degrees around X in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d translate(0);
+    parent_translate.Get(&translate);
+
+    EXPECT_NEAR(5.706661, translate[0], 1e-5f);
+    EXPECT_NEAR(6.833556, translate[1], 1e-5f);
+    EXPECT_NEAR(11.537962, translate[2], 1e-5f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d translate(0);
+    parent_translate.Get(&translate);
+    EXPECT_NEAR(8.413323, translate[0], 1e-5f);
+    EXPECT_NEAR(9.667113, translate[1], 1e-5f);
+    EXPECT_NEAR(18.075923, translate[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space4_d)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+  parent_scale.Set(GfVec3d(2, 2, 2));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d parent_matrix(2, 0, 0,0,  0, 2, 0, 0,  0, 0, 2, 0, 0, 0, 0, 1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+  
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  child_rotate.Set(GfVec3d(22.0, 33.0, 44.0));
+  child_translate.Set(GfVec3d(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,2.937999,5.389119,3.510778,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d presult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(parent.GetOrderedXformOps(&resetsXformStack), 1, UsdTimeCode::Default());
+    GfMatrix4d cresult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(child.GetOrderedXformOps(&resetsXformStack), 2, UsdTimeCode::Default());
+    GfMatrix4d result = cresult * presult;
+    GfMatrix4d expected(1.206578,1.165179,-1.089278,0,-0.994625,1.617376,0.628343,0,1.246952,0.162639,1.555204,0,5.875997,10.778238,7.021556,1);
+    COMPARE_MAT4(result, expected, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  // rotate 15 degrees around X in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(4.353331, translate[0], 1e-5f);
+    EXPECT_NEAR(5.416778, translate[1], 1e-5f);
+    EXPECT_NEAR(8.268981, translate[2], 1e-5f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(5.706661, translate[0], 1e-5f);
+    EXPECT_NEAR(6.833556, translate[1], 1e-5f);
+    EXPECT_NEAR(11.537962, translate[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space5_d)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+  parent_scale.Set(GfVec3d(2, 2, 2));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d parent_matrix(2, 0, 0,0,  0, 2, 0, 0,  0, 0, 2, 0, 0, 0, 0, 1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+  
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  child_translate.Set(GfVec3d(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1, 0, 0, 0,  0, 1, 0, 0,  0, 0, 1, 0, 3, 4, 5, 1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(5.150, translate[0], 1e-5f);
+    EXPECT_NEAR(6.200, translate[1], 1e-5f);
+    EXPECT_NEAR(7.250, translate[2], 1e-5f);
+  }
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(7.3, translate[0], 1e-5f);
+    EXPECT_NEAR(8.4, translate[1], 1e-5f);
+    EXPECT_NEAR(9.5, translate[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space6_d)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  child_rotate.Set(GfVec3d(22.0, 33.0, 44.0));
+  child_translate.Set(GfVec3d(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,0,0,0,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+    
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(5.706661, translate[0], 1e-5f);
+    EXPECT_NEAR(6.833556, translate[1], 1e-5f);
+    EXPECT_NEAR(11.537962, translate[2], 1e-5f);
+  }
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(8.413323, translate[0], 1e-5f);
+    EXPECT_NEAR(9.667113, translate[1], 1e-5f);
+    EXPECT_NEAR(18.075923, translate[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space7_d)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+  parent_scale.Set(GfVec3d(2, 2, 2));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d parent_matrix(2, 0, 0,0,  0, 2, 0, 0,  0, 0, 2, 0, 0, 0, 0, 1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+  
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  child_rotate.Set(GfVec3d(22.0, 33.0, 44.0));
+  child_translate.Set(GfVec3d(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,2.937999,5.389119,3.510778,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d presult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(parent.GetOrderedXformOps(&resetsXformStack), 1, UsdTimeCode::Default());
+    GfMatrix4d cresult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(child.GetOrderedXformOps(&resetsXformStack), 2, UsdTimeCode::Default());
+    GfMatrix4d result = cresult * presult;
+    GfMatrix4d expected(1.206578,1.165179,-1.089278,0,-0.994625,1.617376,0.628343,0,1.246952,0.162639,1.555204,0,5.875997,10.778238,7.021556,1);
+    COMPARE_MAT4(result, expected, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(4.353331, translate[0], 1e-5f);
+    EXPECT_NEAR(5.416778, translate[1], 1e-5f);
+    EXPECT_NEAR(8.268981, translate[2], 1e-5f);
+  }
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(5.706661, translate[0], 1e-5f);
+    EXPECT_NEAR(6.833556, translate[1], 1e-5f);
+    EXPECT_NEAR(11.537962, translate[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space8_d)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-3.0, -2.0, -1.0));
+  parent_rotate.Set(GfVec3d(10.0, 15.0, 20.0));
+  parent_scale.Set(GfVec3d(1.1, 1.2, 1.3));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(0.998441,0.363403,-0.284701,0,-0.353509,1.128946,0.201278,0,0.388579,-0.0987992,1.236627,0,-3,-2,-1,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  child_rotate.Set(GfVec3d(22, 33, 44));
+  child_translate.Set(GfVec3d(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,2.937999,5.389119,3.510778,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+
+  {
+    bool resetsXformStack = false;
+    GfMatrix4d presult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(parent.GetOrderedXformOps(&resetsXformStack), 3, UsdTimeCode::Default());
+    GfMatrix4d cresult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(child.GetOrderedXformOps(&resetsXformStack), 2, UsdTimeCode::Default());
+    const GfMatrix4d expected(0.184763,0.930759,-0.72801,0,-0.660335,0.701201,0.692869,0,0.895916,0.241552,0.800467,0,-0.607473,4.804837,3.589779,1);
+    GfMatrix4d result = cresult * presult;
+    COMPARE_MAT4(result, expected, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  {
+    const GfMatrix4d expected(0.184763,0.930759,-0.72801,0,-0.660335,0.701201,0.692869,0,0.895916,0.241552,0.800467,0,-3,-2,-1,1);
+    COMPARE_MAT4(expected, processor.WorldFrame(), 1e-5f);
+  }
+  
+  // rotate 15 degrees around X in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(4.868398, translate[0], 1e-5f);
+    EXPECT_NEAR(5.813738, translate[1], 1e-5f);
+    EXPECT_NEAR(10.751057, translate[2], 1e-5f);
+  }
+    {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d presult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(parent.GetOrderedXformOps(&resetsXformStack), 3, UsdTimeCode::Default());
+    GfMatrix4d cresult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(child.GetOrderedXformOps(&resetsXformStack), 2, UsdTimeCode::Default());
+    const GfMatrix4d expected(0.184763,0.930759,-0.72801,0,-0.660335,0.701201,0.692869,0,0.895916,0.241552,0.800467,0,3.692527,9.204837,8.089779,1);
+    GfMatrix4d result = cresult * presult;
+    COMPARE_MAT4(result, expected, 1e-5f);
+  }
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(6.736796, translate[0], 1e-5f);
+    EXPECT_NEAR(7.627476, translate[1], 1e-5f);
+    EXPECT_NEAR(16.502115, translate[2], 1e-5f);
+  }
+    {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d presult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(parent.GetOrderedXformOps(&resetsXformStack), 3, UsdTimeCode::Default());
+    GfMatrix4d cresult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(child.GetOrderedXformOps(&resetsXformStack), 2, UsdTimeCode::Default());
+    const GfMatrix4d expected(0.184763,0.930759,-0.72801,0,-0.660335,0.701201,0.692869,0,0.895916,0.241552,0.800467,0,-0.607473 + 4.3 + 4.3,4.4 + 4.4 +4.804837,4.5 + 4.5 + 3.589779,1);
+    GfMatrix4d result = cresult * presult;
+    COMPARE_MAT4(result, expected, 1e-5f);
+  }
+}
+
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test world space translations against the results given by Maya (double precision).
+// Tested with a varying number of xform operations of different types
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, translate_parent_space1_f)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-3.0, -2.0, -1.0));
+  parent_rotate.Set(GfVec3d(10.0, 15.0, 20.0));
+  parent_scale.Set(GfVec3d(1.1, 1.2, 1.3));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(0.998441,0.363403,-0.284701,0,-0.353509,1.128946,0.201278,0,0.388579,-0.0987992,1.236627,0,-3,-2,-1,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("child_translate"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  child_translate.Set(GfVec3f(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1,0,0,0,0,1,0,0,0,0,1,0,3,4,5,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  // translate in parent space - this should be the same as a simple local space transform in this case
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kParent));
+    GfVec3f translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(7.3, translate[0], 1e-5f);
+    EXPECT_NEAR(8.4, translate[1], 1e-5f);
+    EXPECT_NEAR(9.5, translate[2], 1e-5f);
+  }
+
+  // translate in parent space - this should be the same as a simple local space transform in this case
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kParent));
+    GfVec3f translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(11.6, translate[0], 1e-5f);
+    EXPECT_NEAR(12.8, translate[1], 1e-5f);
+    EXPECT_NEAR(14.0, translate[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space2_f)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+
+  parent_rotate.Set(GfVec3d(22.0, 33.0, 44.0));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,0,0,0,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("child_translate"));
+  child_translate.Set(GfVec3f(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1,0,0,0, 0,1,0,0, 0,0,1,0, 3,4,5,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  // rotate 15 degrees around X in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(5.706661, translate[0], 1e-5f);
+    EXPECT_NEAR(6.833556, translate[1], 1e-5f);
+    EXPECT_NEAR(11.537962, translate[2], 1e-5f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(8.413323, translate[0], 1e-5f);
+    EXPECT_NEAR(9.667113, translate[1], 1e-5f);
+    EXPECT_NEAR(18.075923, translate[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space3_f)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("parent_translate"));
+
+  parent_rotate.Set(GfVec3d(22.0, 33.0, 44.0));
+  parent_translate.Set(GfVec3f(3.0, 4.0, 5.0));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,0,0,0,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(parent.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  // rotate 15 degrees around X in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f translate(0);
+    parent_translate.Get(&translate);
+
+    EXPECT_NEAR(5.706661, translate[0], 1e-5f);
+    EXPECT_NEAR(6.833556, translate[1], 1e-5f);
+    EXPECT_NEAR(11.537962, translate[2], 1e-5f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f translate(0);
+    parent_translate.Get(&translate);
+    EXPECT_NEAR(8.413323, translate[0], 1e-5f);
+    EXPECT_NEAR(9.667113, translate[1], 1e-5f);
+    EXPECT_NEAR(18.075923, translate[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space4_f)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+  parent_scale.Set(GfVec3d(2, 2, 2));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d parent_matrix(2, 0, 0,0,  0, 2, 0, 0,  0, 0, 2, 0, 0, 0, 0, 1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+  
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("child_translate"));
+  child_rotate.Set(GfVec3d(22.0, 33.0, 44.0));
+  child_translate.Set(GfVec3f(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,2.937999,5.389119,3.510778,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d presult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(parent.GetOrderedXformOps(&resetsXformStack), 1, UsdTimeCode::Default());
+    GfMatrix4d cresult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(child.GetOrderedXformOps(&resetsXformStack), 2, UsdTimeCode::Default());
+    GfMatrix4d result = cresult * presult;
+    GfMatrix4d expected(1.206578,1.165179,-1.089278,0,-0.994625,1.617376,0.628343,0,1.246952,0.162639,1.555204,0,5.875997,10.778238,7.021556,1);
+    COMPARE_MAT4(result, expected, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  // rotate 15 degrees around X in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(4.353331, translate[0], 1e-5f);
+    EXPECT_NEAR(5.416778, translate[1], 1e-5f);
+    EXPECT_NEAR(8.268981, translate[2], 1e-5f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(5.706661, translate[0], 1e-5f);
+    EXPECT_NEAR(6.833556, translate[1], 1e-5f);
+    EXPECT_NEAR(11.537962, translate[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space5_f)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+  parent_scale.Set(GfVec3d(2, 2, 2));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d parent_matrix(2, 0, 0,0,  0, 2, 0, 0,  0, 0, 2, 0, 0, 0, 0, 1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+  
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("child_translate"));
+  child_translate.Set(GfVec3f(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1, 0, 0, 0,  0, 1, 0, 0,  0, 0, 1, 0, 3, 4, 5, 1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(5.150, translate[0], 1e-5f);
+    EXPECT_NEAR(6.200, translate[1], 1e-5f);
+    EXPECT_NEAR(7.250, translate[2], 1e-5f);
+  }
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(7.3, translate[0], 1e-5f);
+    EXPECT_NEAR(8.4, translate[1], 1e-5f);
+    EXPECT_NEAR(9.5, translate[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space6_f)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("child_translate"));
+  child_rotate.Set(GfVec3d(22.0, 33.0, 44.0));
+  child_translate.Set(GfVec3f(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,0,0,0,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+    
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(5.706661, translate[0], 1e-5f);
+    EXPECT_NEAR(6.833556, translate[1], 1e-5f);
+    EXPECT_NEAR(11.537962, translate[2], 1e-5f);
+  }
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(8.413323, translate[0], 1e-5f);
+    EXPECT_NEAR(9.667113, translate[1], 1e-5f);
+    EXPECT_NEAR(18.075923, translate[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space7_f)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+  parent_scale.Set(GfVec3d(2, 2, 2));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d parent_matrix(2, 0, 0,0,  0, 2, 0, 0,  0, 0, 2, 0, 0, 0, 0, 1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+  
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("child_translate"));
+  child_rotate.Set(GfVec3d(22.0, 33.0, 44.0));
+  child_translate.Set(GfVec3f(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,2.937999,5.389119,3.510778,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d presult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(parent.GetOrderedXformOps(&resetsXformStack), 1, UsdTimeCode::Default());
+    GfMatrix4d cresult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(child.GetOrderedXformOps(&resetsXformStack), 2, UsdTimeCode::Default());
+    GfMatrix4d result = cresult * presult;
+    GfMatrix4d expected(1.206578,1.165179,-1.089278,0,-0.994625,1.617376,0.628343,0,1.246952,0.162639,1.555204,0,5.875997,10.778238,7.021556,1);
+    COMPARE_MAT4(result, expected, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(4.353331, translate[0], 1e-5f);
+    EXPECT_NEAR(5.416778, translate[1], 1e-5f);
+    EXPECT_NEAR(8.268981, translate[2], 1e-5f);
+  }
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(5.706661, translate[0], 1e-5f);
+    EXPECT_NEAR(6.833556, translate[1], 1e-5f);
+    EXPECT_NEAR(11.537962, translate[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space8_f)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-3.0, -2.0, -1.0));
+  parent_rotate.Set(GfVec3d(10.0, 15.0, 20.0));
+  parent_scale.Set(GfVec3d(1.1, 1.2, 1.3));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(0.998441,0.363403,-0.284701,0,-0.353509,1.128946,0.201278,0,0.388579,-0.0987992,1.236627,0,-3,-2,-1,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, TfToken("child_translate"));
+  child_rotate.Set(GfVec3d(22, 33, 44));
+  child_translate.Set(GfVec3f(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,2.937999,5.389119,3.510778,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+
+  {
+    bool resetsXformStack = false;
+    GfMatrix4d presult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(parent.GetOrderedXformOps(&resetsXformStack), 3, UsdTimeCode::Default());
+    GfMatrix4d cresult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(child.GetOrderedXformOps(&resetsXformStack), 2, UsdTimeCode::Default());
+    const GfMatrix4d expected(0.184763,0.930759,-0.72801,0,-0.660335,0.701201,0.692869,0,0.895916,0.241552,0.800467,0,-0.607473,4.804837,3.589779,1);
+    GfMatrix4d result = cresult * presult;
+    COMPARE_MAT4(result, expected, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  {
+    const GfMatrix4d expected(0.184763,0.930759,-0.72801,0,-0.660335,0.701201,0.692869,0,0.895916,0.241552,0.800467,0,-3,-2,-1,1);
+    COMPARE_MAT4(expected, processor.WorldFrame(), 1e-5f);
+  }
+  
+  // rotate 15 degrees around X in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(4.868398, translate[0], 1e-5f);
+    EXPECT_NEAR(5.813738, translate[1], 1e-5f);
+    EXPECT_NEAR(10.751057, translate[2], 1e-5f);
+  }
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d presult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(parent.GetOrderedXformOps(&resetsXformStack), 3, UsdTimeCode::Default());
+    GfMatrix4d cresult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(child.GetOrderedXformOps(&resetsXformStack), 2, UsdTimeCode::Default());
+    const GfMatrix4d expected(0.184763,0.930759,-0.72801,0,-0.660335,0.701201,0.692869,0,0.895916,0.241552,0.800467,0,3.692527,9.204837,8.089779,1);
+    GfMatrix4d result = cresult * presult;
+    COMPARE_MAT4(result, expected, 1e-5f);
+  }
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(6.736796, translate[0], 1e-5f);
+    EXPECT_NEAR(7.627476, translate[1], 1e-5f);
+    EXPECT_NEAR(16.502115, translate[2], 1e-5f);
+  }
+    {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d presult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(parent.GetOrderedXformOps(&resetsXformStack), 3, UsdTimeCode::Default());
+    GfMatrix4d cresult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(child.GetOrderedXformOps(&resetsXformStack), 2, UsdTimeCode::Default());
+    const GfMatrix4d expected(0.184763,0.930759,-0.72801,0,-0.660335,0.701201,0.692869,0,0.895916,0.241552,0.800467,0,-0.607473 + 4.3 + 4.3,4.4 + 4.4 +4.804837,4.5 + 4.5 + 3.589779,1);
+    GfMatrix4d result = cresult * presult;
+    COMPARE_MAT4(result, expected, 1e-5f);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test world space translations against the results given by Maya (half precision).
+// Tested with a varying number of xform operations of different types
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, translate_parent_space1_h)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-3.0, -2.0, -1.0));
+  parent_rotate.Set(GfVec3d(10.0, 15.0, 20.0));
+  parent_scale.Set(GfVec3d(1.1, 1.2, 1.3));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(0.998441,0.363403,-0.284701,0,-0.353509,1.128946,0.201278,0,0.388579,-0.0987992,1.236627,0,-3,-2,-1,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("child_translate"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  child_translate.Set(GfVec3h(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1,0,0,0,0,1,0,0,0,0,1,0,3,4,5,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  // translate in parent space - this should be the same as a simple local space transform in this case
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kParent));
+    GfVec3h translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(7.3, translate[0], 2e-3f);
+    EXPECT_NEAR(8.4, translate[1], 3.2e-3f);
+    EXPECT_NEAR(9.5, translate[2], 2e-3f);
+  }
+
+  // translate in parent space - this should be the same as a simple local space transform in this case
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kParent));
+    GfVec3h translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(11.6, translate[0], 2e-3f);
+    EXPECT_NEAR(12.8, translate[1], 3.2e-3f);
+    EXPECT_NEAR(14.0, translate[2], 2.3e-3f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space2_h)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+
+  parent_rotate.Set(GfVec3d(22.0, 33.0, 44.0));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,0,0,0,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("child_translate"));
+  child_translate.Set(GfVec3h(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1,0,0,0, 0,1,0,0, 0,0,1,0, 3,4,5,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  // rotate 15 degrees around X in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(5.706661, translate[0], 2e-3f);
+    EXPECT_NEAR(6.833556, translate[1], 2e-3f);
+    EXPECT_NEAR(11.537962, translate[2], 2e-3f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(8.413323, translate[0], 2e-3f);
+    EXPECT_NEAR(9.667113, translate[1], 3.1e-3f);
+    EXPECT_NEAR(18.075923, translate[2], 2.3e-3f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space3_h)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("parent_translate"));
+
+  parent_rotate.Set(GfVec3d(22.0, 33.0, 44.0));
+  parent_translate.Set(GfVec3h(3.0, 4.0, 5.0));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,0,0,0,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(parent.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  // rotate 15 degrees around X in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h translate(0);
+    parent_translate.Get(&translate);
+
+    EXPECT_NEAR(5.706661, translate[0], 2e-3f);
+    EXPECT_NEAR(6.833556, translate[1], 2e-3f);
+    EXPECT_NEAR(11.537962, translate[2], 2e-3f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h translate(0);
+    parent_translate.Get(&translate);
+    EXPECT_NEAR(8.413323, translate[0], 2e-3f);
+    EXPECT_NEAR(9.667113, translate[1], 3.1e-3f);
+    EXPECT_NEAR(18.075923, translate[2], 2.3e-3f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space4_h)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+  parent_scale.Set(GfVec3d(2, 2, 2));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d parent_matrix(2, 0, 0,0,  0, 2, 0, 0,  0, 0, 2, 0, 0, 0, 0, 1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+  
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("child_translate"));
+  child_rotate.Set(GfVec3d(22.0, 33.0, 44.0));
+  child_translate.Set(GfVec3h(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,2.937999,5.389119,3.510778,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d presult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(parent.GetOrderedXformOps(&resetsXformStack), 1, UsdTimeCode::Default());
+    GfMatrix4d cresult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(child.GetOrderedXformOps(&resetsXformStack), 2, UsdTimeCode::Default());
+    GfMatrix4d result = cresult * presult;
+    GfMatrix4d expected(1.206578,1.165179,-1.089278,0,-0.994625,1.617376,0.628343,0,1.246952,0.162639,1.555204,0,5.875997,10.778238,7.021556,1);
+    COMPARE_MAT4(result, expected, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  // rotate 15 degrees around X in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(4.353331, translate[0], 2e-3f);
+    EXPECT_NEAR(5.416778, translate[1], 2e-3f);
+    EXPECT_NEAR(8.268981, translate[2], 3.4e-3f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(5.706661, translate[0], 3.6e-3f);
+    EXPECT_NEAR(6.833556, translate[1], 2.4e-3f);
+    EXPECT_NEAR(11.537962, translate[2], 6.8e-3f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space5_h)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+  parent_scale.Set(GfVec3d(2, 2, 2));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d parent_matrix(2, 0, 0,0,  0, 2, 0, 0,  0, 0, 2, 0, 0, 0, 0, 1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+  
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("child_translate"));
+  child_translate.Set(GfVec3h(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1, 0, 0, 0,  0, 1, 0, 0,  0, 0, 1, 0, 3, 4, 5, 1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(5.150, translate[0], 2e-3f);
+    EXPECT_NEAR(6.200, translate[1], 2e-3f);
+    EXPECT_NEAR(7.250, translate[2], 2e-3f);
+  }
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(7.3, translate[0], 3.2e-3f);
+    EXPECT_NEAR(8.4, translate[1], 2e-3f);
+    EXPECT_NEAR(9.5, translate[2], 2e-3f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space6_h)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("child_translate"));
+  child_rotate.Set(GfVec3d(22.0, 33.0, 44.0));
+  child_translate.Set(GfVec3h(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,0,0,0,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+    
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(5.706661, translate[0], 2e-3f);
+    EXPECT_NEAR(6.833556, translate[1], 2e-3f);
+    EXPECT_NEAR(11.537962, translate[2], 2e-3f);
+  }
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(8.413323, translate[0], 2e-3f);
+    EXPECT_NEAR(9.667113, translate[1], 3.1e-3f);
+    EXPECT_NEAR(18.075923, translate[2], 2.3e-3f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space7_h)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+  parent_scale.Set(GfVec3d(2, 2, 2));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d parent_matrix(2, 0, 0,0,  0, 2, 0, 0,  0, 0, 2, 0, 0, 0, 0, 1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+  
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("child_translate"));
+  child_rotate.Set(GfVec3d(22.0, 33.0, 44.0));
+  child_translate.Set(GfVec3h(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,2.937999,5.389119,3.510778,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+  
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d presult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(parent.GetOrderedXformOps(&resetsXformStack), 1, UsdTimeCode::Default());
+    GfMatrix4d cresult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(child.GetOrderedXformOps(&resetsXformStack), 2, UsdTimeCode::Default());
+    GfMatrix4d result = cresult * presult;
+    GfMatrix4d expected(1.206578,1.165179,-1.089278,0,-0.994625,1.617376,0.628343,0,1.246952,0.162639,1.555204,0,5.875997,10.778238,7.021556,1);
+    COMPARE_MAT4(result, expected, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  {
+    processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld);
+    GfVec3h translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(4.353331, translate[0], 2e-3f);
+    EXPECT_NEAR(5.416778, translate[1], 2e-3f);
+    EXPECT_NEAR(8.268981, translate[2], 3.4e-3f);
+  }
+
+  {
+    processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld);
+    GfVec3h translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(5.706661, translate[0], 3.6e-3f);
+    EXPECT_NEAR(6.833556, translate[1], 2.4e-3f);
+    EXPECT_NEAR(11.537962, translate[2], 6.8e-3f);
+  }
+}
+
+TEST(TransformOpProcessor, translate_world_space8_h)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-3.0, -2.0, -1.0));
+  parent_rotate.Set(GfVec3d(10.0, 15.0, 20.0));
+  parent_scale.Set(GfVec3d(1.1, 1.2, 1.3));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(0.998441,0.363403,-0.284701,0,-0.353509,1.128946,0.201278,0,0.388579,-0.0987992,1.236627,0,-3,-2,-1,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionHalf, TfToken("child_translate"));
+  child_rotate.Set(GfVec3d(22, 33, 44));
+  child_translate.Set(GfVec3h(3.0, 4.0, 5.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(0.603289,0.58259,-0.544639,0,-0.497312,0.808688,0.314172,0,0.623476,0.0813195,0.777602,0,2.937999,5.389119,3.510778,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 2, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+
+  {
+    bool resetsXformStack = false;
+    GfMatrix4d presult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(parent.GetOrderedXformOps(&resetsXformStack), 3, UsdTimeCode::Default());
+    GfMatrix4d cresult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(child.GetOrderedXformOps(&resetsXformStack), 2, UsdTimeCode::Default());
+    const GfMatrix4d expected(0.184763,0.930759,-0.72801,0,-0.660335,0.701201,0.692869,0,0.895916,0.241552,0.800467,0,-0.607473,4.804837,3.589779,1);
+    GfMatrix4d result = cresult * presult;
+    COMPARE_MAT4(result, expected, 1e-5f);
+  }
+  
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  {
+    const GfMatrix4d expected(0.184763,0.930759,-0.72801,0,-0.660335,0.701201,0.692869,0,0.895916,0.241552,0.800467,0,-3,-2,-1,1);
+    COMPARE_MAT4(expected, processor.WorldFrame(), 1e-5f);
+  }
+  
+  // rotate 15 degrees around X in world space
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h translate(0);
+    child_translate.Get(&translate);
+
+    EXPECT_NEAR(4.868398, translate[0], 2e-3f);
+    EXPECT_NEAR(5.813738, translate[1], 2e-3f);
+    EXPECT_NEAR(10.751057, translate[2], 2e-3f);
+  }
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d presult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(parent.GetOrderedXformOps(&resetsXformStack), 3, UsdTimeCode::Default());
+    GfMatrix4d cresult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(child.GetOrderedXformOps(&resetsXformStack), 2, UsdTimeCode::Default());
+    const GfMatrix4d expected(0.184763,0.930759,-0.72801,0,-0.660335,0.701201,0.692869,0,0.895916,0.241552,0.800467,0,3.692527,9.204837,8.089779,1);
+    GfMatrix4d result = cresult * presult;
+    COMPARE_MAT4(result, expected, 2.5e-3f);
+  }
+
+  {
+    EXPECT_TRUE(processor.Translate(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h translate(0);
+    child_translate.Get(&translate);
+    EXPECT_NEAR(6.736796, translate[0], 2.5e-3f);
+    EXPECT_NEAR(7.627476, translate[1], 2.5e-3f);
+    EXPECT_NEAR(16.502115, translate[2], 2.2e-3f);
+  }
+    {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d presult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(parent.GetOrderedXformOps(&resetsXformStack), 3, UsdTimeCode::Default());
+    GfMatrix4d cresult = TransformOpProcessor::EvaluateCoordinateFrameForIndex(child.GetOrderedXformOps(&resetsXformStack), 2, UsdTimeCode::Default());
+    const GfMatrix4d expected(0.184763,0.930759,-0.72801,0,-0.660335,0.701201,0.692869,0,0.895916,0.241552,0.800467,0,-0.607473 + 4.3 + 4.3,4.4 + 4.4 +4.804837,4.5 + 4.5 + 3.589779,1);
+    GfMatrix4d result = cresult * presult;
+    COMPARE_MAT4(result, expected, 4.5e-2f);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Scaling in world space is only valid if the scale is uniform. Non uniform scales are rejected.
+//----------------------------------------------------------------------------------------------------------------------
+
+TEST(TransformOpProcessor, scale_world_space_d)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-3.0, -2.0, -1.0));
+  parent_rotate.Set(GfVec3d(10.0, 15.0, 20.0));
+  parent_scale.Set(GfVec3d(1.1, 1.2, 1.3));
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  UsdGeomXformOp child_scale = child.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_scale"));
+  child_rotate.Set(GfVec3d(22, 33, 44));
+  child_translate.Set(GfVec3d(3.0, 4.0, 5.0));
+  child_scale.Set(GfVec3d(-2.0, 5.0, 3.0));
+
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 2);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kScale, processor.ManipMode());
+  
+  {
+    // non-uniform scales are ignored in world space
+    EXPECT_FALSE(processor.Scale(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d scale(0);
+    child_scale.Get(&scale);
+
+    // should be the same as the original
+    EXPECT_NEAR(-2.0, scale[0], 1e-5f);
+    EXPECT_NEAR(5.0, scale[1], 1e-5f);
+    EXPECT_NEAR(3.0, scale[2], 1e-5f);
+  }
+  {
+    // uniform scales are handled in world space
+    EXPECT_TRUE(processor.Scale(GfVec3d(4.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d scale(0);
+    child_scale.Get(&scale);
+
+    // should be the same as the original * 4.0
+    EXPECT_NEAR(-8.0, scale[0], 1e-5f);
+    EXPECT_NEAR(20.0, scale[1], 1e-5f);
+    EXPECT_NEAR(12.0, scale[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, scale_world_space_f)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-3.0, -2.0, -1.0));
+  parent_rotate.Set(GfVec3d(10.0, 15.0, 20.0));
+  parent_scale.Set(GfVec3d(1.1, 1.2, 1.3));
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  UsdGeomXformOp child_scale = child.AddScaleOp(UsdGeomXformOp::PrecisionFloat, TfToken("child_scale"));
+  child_rotate.Set(GfVec3d(22, 33, 44));
+  child_translate.Set(GfVec3d(3.0, 4.0, 5.0));
+  child_scale.Set(GfVec3f(-2.0, 5.0, 3.0));
+
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 2);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kScale, processor.ManipMode());
+  
+  {
+    // non-uniform scales are ignored in world space
+    EXPECT_FALSE(processor.Scale(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f scale(0);
+    child_scale.Get(&scale);
+
+    // should be the same as the original
+    EXPECT_NEAR(-2.0, scale[0], 1e-5f);
+    EXPECT_NEAR(5.0, scale[1], 1e-5f);
+    EXPECT_NEAR(3.0, scale[2], 1e-5f);
+  }
+  {
+    // uniform scales are handled in world space
+    EXPECT_TRUE(processor.Scale(GfVec3d(4.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f scale(0);
+    child_scale.Get(&scale);
+
+    // should be the same as the original * 4.0
+    EXPECT_NEAR(-8.0, scale[0], 1e-5f);
+    EXPECT_NEAR(20.0, scale[1], 1e-5f);
+    EXPECT_NEAR(12.0, scale[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, scale_world_space_h)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-3.0, -2.0, -1.0));
+  parent_rotate.Set(GfVec3d(10.0, 15.0, 20.0));
+  parent_scale.Set(GfVec3d(1.1, 1.2, 1.3));
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  UsdGeomXformOp child_scale = child.AddScaleOp(UsdGeomXformOp::PrecisionHalf, TfToken("child_scale"));
+  child_rotate.Set(GfVec3d(22, 33, 44));
+  child_translate.Set(GfVec3d(3.0, 4.0, 5.0));
+  child_scale.Set(GfVec3h(-2.0, 5.0, 3.0));
+
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 2);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kScale, processor.ManipMode());
+  
+  {
+    // non-uniform scales are ignored in world space
+    EXPECT_FALSE(processor.Scale(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h scale(0);
+    child_scale.Get(&scale);
+
+    // should be the same as the original
+    EXPECT_NEAR(-2.0, scale[0], 1e-5f);
+    EXPECT_NEAR(5.0, scale[1], 1e-5f);
+    EXPECT_NEAR(3.0, scale[2], 1e-5f);
+  }
+  {
+    // uniform scales are handled in world space
+    EXPECT_TRUE(processor.Scale(GfVec3d(4.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h scale(0);
+    child_scale.Get(&scale);
+
+    // should be the same as the original * 4.0
+    EXPECT_NEAR(-8.0, scale[0], 1e-5f);
+    EXPECT_NEAR(20.0, scale[1], 1e-5f);
+    EXPECT_NEAR(12.0, scale[2], 1e-5f);
+  }
+}
+
+
+//----------------------------------------------------------------------------------------------------------------------
+// Scaling in world space is only valid if the scale is uniform. Non uniform scales are rejected.
+//----------------------------------------------------------------------------------------------------------------------
+
+TEST(TransformOpProcessor, scale_parent_space_d)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-3.0, -2.0, -1.0));
+  parent_rotate.Set(GfVec3d(10.0, 15.0, 20.0));
+  parent_scale.Set(GfVec3d(1.1, 1.2, 1.3));
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  UsdGeomXformOp child_scale = child.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_scale"));
+  child_rotate.Set(GfVec3d(22, 33, 44));
+  child_translate.Set(GfVec3d(3.0, 4.0, 5.0));
+  child_scale.Set(GfVec3d(-2.0, 5.0, 3.0));
+
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 2);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kScale, processor.ManipMode());
+  
+  {
+    // non-uniform scales are ignored in world space
+    EXPECT_FALSE(processor.Scale(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kParent));
+    GfVec3d scale(0);
+    child_scale.Get(&scale);
+
+    // should be the same as the original
+    EXPECT_NEAR(-2.0, scale[0], 1e-5f);
+    EXPECT_NEAR(5.0, scale[1], 1e-5f);
+    EXPECT_NEAR(3.0, scale[2], 1e-5f);
+  }
+  {
+    // uniform scales are handled in world space
+    EXPECT_TRUE(processor.Scale(GfVec3d(4.0), MayaUsdUtils::TransformOpProcessor::kParent));
+    GfVec3d scale(0);
+    child_scale.Get(&scale);
+
+    // should be the same as the original * 4.0
+    EXPECT_NEAR(-8.0, scale[0], 1e-5f);
+    EXPECT_NEAR(20.0, scale[1], 1e-5f);
+    EXPECT_NEAR(12.0, scale[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, scale_parent_space_f)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-3.0, -2.0, -1.0));
+  parent_rotate.Set(GfVec3d(10.0, 15.0, 20.0));
+  parent_scale.Set(GfVec3d(1.1, 1.2, 1.3));
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  UsdGeomXformOp child_scale = child.AddScaleOp(UsdGeomXformOp::PrecisionFloat, TfToken("child_scale"));
+  child_rotate.Set(GfVec3d(22, 33, 44));
+  child_translate.Set(GfVec3d(3.0, 4.0, 5.0));
+  child_scale.Set(GfVec3f(-2.0, 5.0, 3.0));
+
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 2);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kScale, processor.ManipMode());
+  
+  {
+    // non-uniform scales are ignored in world space
+    EXPECT_FALSE(processor.Scale(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kParent));
+    GfVec3f scale(0);
+    child_scale.Get(&scale);
+
+    // should be the same as the original
+    EXPECT_NEAR(-2.0, scale[0], 1e-5f);
+    EXPECT_NEAR(5.0, scale[1], 1e-5f);
+    EXPECT_NEAR(3.0, scale[2], 1e-5f);
+  }
+  {
+    // uniform scales are handled in world space
+    EXPECT_TRUE(processor.Scale(GfVec3d(4.0), MayaUsdUtils::TransformOpProcessor::kParent));
+    GfVec3f scale(0);
+    child_scale.Get(&scale);
+
+    // should be the same as the original * 4.0
+    EXPECT_NEAR(-8.0, scale[0], 1e-5f);
+    EXPECT_NEAR(20.0, scale[1], 1e-5f);
+    EXPECT_NEAR(12.0, scale[2], 1e-5f);
+  }
+}
+
+TEST(TransformOpProcessor, scale_parent_space_h)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-3.0, -2.0, -1.0));
+  parent_rotate.Set(GfVec3d(10.0, 15.0, 20.0));
+  parent_scale.Set(GfVec3d(1.1, 1.2, 1.3));
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  UsdGeomXformOp child_scale = child.AddScaleOp(UsdGeomXformOp::PrecisionHalf, TfToken("child_scale"));
+  child_rotate.Set(GfVec3d(22, 33, 44));
+  child_translate.Set(GfVec3d(3.0, 4.0, 5.0));
+  child_scale.Set(GfVec3h(-2.0, 5.0, 3.0));
+
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 2);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kScale, processor.ManipMode());
+  
+  {
+    // non-uniform scales are ignored in world space
+    EXPECT_FALSE(processor.Scale(GfVec3d(4.3, 4.4, 4.5), MayaUsdUtils::TransformOpProcessor::kParent));
+    GfVec3h scale(0);
+    child_scale.Get(&scale);
+
+    // should be the same as the original
+    EXPECT_NEAR(-2.0, scale[0], 1e-5f);
+    EXPECT_NEAR(5.0, scale[1], 1e-5f);
+    EXPECT_NEAR(3.0, scale[2], 1e-5f);
+  }
+  {
+    // uniform scales are handled in world space
+    EXPECT_TRUE(processor.Scale(GfVec3d(4.0), MayaUsdUtils::TransformOpProcessor::kParent));
+    GfVec3h scale(0);
+    child_scale.Get(&scale);
+
+    // should be the same as the original * 4.0
+    EXPECT_NEAR(-8.0, scale[0], 1e-5f);
+    EXPECT_NEAR(20.0, scale[1], 1e-5f);
+    EXPECT_NEAR(12.0, scale[2], 1e-5f);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Using an XYZ rotation order, replicate some rotations that may occur with the Maya rotate tool, and check we end up 
+// with the same result. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotate_world_space_with_uniform_scale_d)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-2.0, 3.0, 1.0));
+  parent_rotate.Set(GfVec3d(-11.0, -21.0, 22.0));
+  parent_scale.Set(GfVec3d(2,2,2));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(1.731201,0.699451,0.716736,0,-0.608647,1.871529,-0.356271,0,-0.795293,0.090269,1.832856,0,-2,3,1,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  child_translate.Set(GfVec3d(2.0, 1.0, 2.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1,0,0,0,0,1,0,0,0,0,1,0,2,1,2,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  {
+    const GfMatrix4d expected(1.731201,0.699451,0.716736,0,-0.608647,1.871529,-0.356271,0,-0.795293,0.090269,1.832856,0,-0.73683,6.450968,5.742912,1);
+    COMPARE_MAT4(expected, processor.WorldFrame(), 1e-5f);
+  }
+
+  // rotate 15 degrees around X in world space
+  {
+    GfVec3d rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_TRUE(processor.RotateX(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(13.218885, rotate[0], 1e-5f);
+    EXPECT_NEAR(-3.843776, rotate[1], 1e-5f);
+    EXPECT_NEAR(-6.439076, rotate[2], 1e-5f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.RotateY(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(16.968949, rotate[0], 1e-5f);
+    EXPECT_NEAR(10.668345, rotate[1], 1e-5f);
+    EXPECT_NEAR(-5.533085, rotate[2], 1e-5f);
+  }
+
+  // rotate 15 degrees around Z in world space
+  {
+    EXPECT_TRUE(processor.RotateZ(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(22.315417, rotate[0], 1e-5f);
+    EXPECT_NEAR(7.835664, rotate[1], 1e-5f);
+    EXPECT_NEAR(9.086346, rotate[2], 1e-5f);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Using an XYZ rotation order, replicate some rotations that may occur with the Maya rotate tool, and check we end up 
+// with the same result. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotate_world_space_with_uniform_scale_f)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-2.0, 3.0, 1.0));
+  parent_rotate.Set(GfVec3d(-11.0, -21.0, 22.0));
+  parent_scale.Set(GfVec3d(2,2,2));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(1.731201,0.699451,0.716736,0,-0.608647,1.871529,-0.356271,0,-0.795293,0.090269,1.832856,0,-2,3,1,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionFloat, TfToken("child_rotate"));
+  child_translate.Set(GfVec3d(2.0, 1.0, 2.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1,0,0,0,0,1,0,0,0,0,1,0,2,1,2,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  {
+    const GfMatrix4d expected(1.731201,0.699451,0.716736,0,-0.608647,1.871529,-0.356271,0,-0.795293,0.090269,1.832856,0,-0.73683,6.450968,5.742912,1);
+    COMPARE_MAT4(expected, processor.WorldFrame(), 1e-5f);
+  }
+
+  // rotate 15 degrees around X in world space
+  {
+    EXPECT_TRUE(processor.RotateX(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(13.218885, rotate[0], 1e-5f);
+    EXPECT_NEAR(-3.843776, rotate[1], 1e-5f);
+    EXPECT_NEAR(-6.439076, rotate[2], 1e-5f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.RotateY(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(16.968949, rotate[0], 1e-5f);
+    EXPECT_NEAR(10.668345, rotate[1], 1e-5f);
+    EXPECT_NEAR(-5.533085, rotate[2], 1e-5f);
+  }
+
+  // rotate 15 degrees around Z in world space
+  {
+    EXPECT_TRUE(processor.RotateZ(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(22.315417, rotate[0], 1e-5f);
+    EXPECT_NEAR(7.835664, rotate[1], 1e-5f);
+    EXPECT_NEAR(9.086346, rotate[2], 1e-5f);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Using an XYZ rotation order, replicate some rotations that may occur with the Maya rotate tool, and check we end up 
+// with the same result. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotate_world_space_with_uniform_scale_h)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-2.0, 3.0, 1.0));
+  parent_rotate.Set(GfVec3d(-11.0, -21.0, 22.0));
+  parent_scale.Set(GfVec3d(2,2,2));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(1.731201,0.699451,0.716736,0,-0.608647,1.871529,-0.356271,0,-0.795293,0.090269,1.832856,0,-2,3,1,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionHalf, TfToken("child_rotate"));
+  child_translate.Set(GfVec3d(2.0, 1.0, 2.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1,0,0,0,0,1,0,0,0,0,1,0,2,1,2,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  {
+    const GfMatrix4d expected(1.731201,0.699451,0.716736,0,-0.608647,1.871529,-0.356271,0,-0.795293,0.090269,1.832856,0,-0.73683,6.450968,5.742912,1);
+    COMPARE_MAT4(expected, processor.WorldFrame(), 1e-5f);
+  }
+
+  // rotate 15 degrees around X in world space
+  {
+    EXPECT_TRUE(processor.RotateX(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(13.218885, rotate[0], 1.4e-3f);
+    EXPECT_NEAR(-3.843776, rotate[1], 2.7e-5f);
+    EXPECT_NEAR(-6.439076, rotate[2], 1.6e-2f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.RotateY(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(16.968949, rotate[0], 2e-3f);
+    EXPECT_NEAR(10.668345, rotate[1], 3.6e-2f);
+    EXPECT_NEAR(-5.533085, rotate[2], 2e-2f);
+  }
+
+  // rotate 15 degrees around Z in world space
+  {
+    EXPECT_TRUE(processor.RotateZ(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(22.315417, rotate[0], 3e-2f);
+    EXPECT_NEAR(7.835664, rotate[1], 4.2e-2f);
+    EXPECT_NEAR(9.086346, rotate[2], 4.1e-2f);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Using an XYZ rotation order, replicate some rotations that may occur with the Maya rotate tool, and check we end up 
+// with the same result. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotate_world_space_with_non_uniform_scale_d)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-2.0, 3.0, 1.0));
+  parent_rotate.Set(GfVec3d(-11.0, -21.0, 22.0));
+  parent_scale.Set(GfVec3d(2,3,4));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(1.731201,0.699451,0.716736,0,-0.91297,2.807293,-0.534407,0,-1.590586,0.180538,3.665712,0,-2,3,1,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_rotate"));
+  child_translate.Set(GfVec3d(2.0, 1.0, 2.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1,0,0,0,0,1,0,0,0,0,1,0,2,1,2,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  {
+    const GfMatrix4d expected(1.731201,0.699451,0.716736,0,-0.91297,2.807293,-0.534407,0,-1.590586,0.180538,3.665712,0,-2.631739,7.567271,9.230489,1);
+    COMPARE_MAT4(expected, processor.WorldFrame(), 1e-5f);
+  }
+
+  // rotate 15 degrees around X in world space
+  {
+    GfVec3d rotate(0);
+    EXPECT_TRUE(processor.RotateX(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(9.991373, rotate[0], 1e-5f);
+    EXPECT_NEAR(-1.930805, rotate[1], 1e-2f);
+    EXPECT_NEAR(-4.302774, rotate[2], 1e-5f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.RotateY(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(13.515801, rotate[0], 1e-3f);
+    EXPECT_NEAR(5.457887, rotate[1], 0.11);   //< Fairly high difference - shearing effects?
+    EXPECT_NEAR(-3.5485, rotate[2], 0.146);   //< Fairly high difference - shearing effects?
+  }
+
+  // rotate 15 degrees around Z in world space
+  {
+    EXPECT_TRUE(processor.RotateZ(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3d rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(17.381871, rotate[0], 1e-3f);
+    EXPECT_NEAR(4.011838, rotate[1], 0.088);   //< Fairly high difference - shearing effects?
+    EXPECT_NEAR(5.998051, rotate[2], 0.083);   //< Fairly high difference - shearing effects?
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Using an XYZ rotation order, replicate some rotations that may occur with the Maya rotate tool, and check we end up 
+// with the same result. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotate_world_space_with_non_uniform_scale_f)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-2.0, 3.0, 1.0));
+  parent_rotate.Set(GfVec3d(-11.0, -21.0, 22.0));
+  parent_scale.Set(GfVec3d(2,3,4));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(1.731201,0.699451,0.716736,0,-0.91297,2.807293,-0.534407,0,-1.590586,0.180538,3.665712,0,-2,3,1,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionFloat, TfToken("child_rotate"));
+  child_translate.Set(GfVec3d(2.0, 1.0, 2.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1,0,0,0,0,1,0,0,0,0,1,0,2,1,2,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  {
+    const GfMatrix4d expected(1.731201,0.699451,0.716736,0,-0.91297,2.807293,-0.534407,0,-1.590586,0.180538,3.665712,0,-2.631739,7.567271,9.230489,1);
+    COMPARE_MAT4(expected, processor.WorldFrame(), 1e-5f);
+  }
+
+  // rotate 15 degrees around X in world space
+  {
+    GfVec3f rotate(0);
+    EXPECT_TRUE(processor.RotateX(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(9.991373, rotate[0], 1e-5f);
+    EXPECT_NEAR(-1.930805, rotate[1], 1e-2f);
+    EXPECT_NEAR(-4.302774, rotate[2], 1e-5f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.RotateY(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(13.515801, rotate[0], 1e-3f);
+    EXPECT_NEAR(5.457887, rotate[1], 0.11);   //< Fairly high difference - shearing effects?
+    EXPECT_NEAR(-3.5485, rotate[2], 0.146);   //< Fairly high difference - shearing effects?
+  }
+
+  // rotate 15 degrees around Z in world space
+  {
+    EXPECT_TRUE(processor.RotateZ(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3f rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(17.381871, rotate[0], 1e-3f);
+    EXPECT_NEAR(4.011838, rotate[1], 0.088);   //< Fairly high difference - shearing effects?
+    EXPECT_NEAR(5.998051, rotate[2], 0.083);   //< Fairly high difference - shearing effects?
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Using an XYZ rotation order, replicate some rotations that may occur with the Maya rotate tool, and check we end up 
+// with the same result. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, rotate_world_space_with_non_uniform_scale_h)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_translate = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_translate"));
+  UsdGeomXformOp parent_rotate = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_rotate"));
+  UsdGeomXformOp parent_scale = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_scale"));
+
+  parent_translate.Set(GfVec3d(-2.0, 3.0, 1.0));
+  parent_rotate.Set(GfVec3d(-11.0, -21.0, 22.0));
+  parent_scale.Set(GfVec3d(2,3,4));
+
+  // sanity check parent matrix matches result from maya 
+  const GfMatrix4d parent_matrix(1.731201,0.699451,0.716736,0,-0.91297,2.807293,-0.534407,0,-1.590586,0.180538,3.665712,0,-2,3,1,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = parent.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 3, UsdTimeCode::Default());
+    COMPARE_MAT4(result, parent_matrix, 1e-5f);
+  }
+
+  // now specify a child transform with a rotation
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_translate = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_translate"));
+  UsdGeomXformOp child_rotate = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionHalf, TfToken("child_rotate"));
+  child_translate.Set(GfVec3d(2.0, 1.0, 2.0));
+
+  // sanity check starting matrix against maya result
+  const GfMatrix4d child_matrix(1,0,0,0,0,1,0,0,0,0,1,0,2,1,2,1);
+  {
+    bool resetsXformStack = false;
+    std::vector<UsdGeomXformOp> ops = child.GetOrderedXformOps(&resetsXformStack);
+    GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, 1, UsdTimeCode::Default());
+    COMPARE_MAT4(result, child_matrix, 1e-5f);
+  }
+
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+  {
+    const GfMatrix4d expected(1.731201,0.699451,0.716736,0,-0.91297,2.807293,-0.534407,0,-1.590586,0.180538,3.665712,0,-2.631739,7.567271,9.230489,1);
+    COMPARE_MAT4(expected, processor.WorldFrame(), 1e-5f);
+  }
+
+  // rotate 15 degrees around X in world space
+  {
+    GfVec3h rotate(0);
+    EXPECT_TRUE(processor.RotateX(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(9.991373, rotate[0], 8.2e-3f);
+    EXPECT_NEAR(-1.930805, rotate[1], 2e-2f);
+    EXPECT_NEAR(-4.302774, rotate[2], 2e-2f);
+  }
+
+  // rotate 15 degrees around Y in world space
+  {
+    EXPECT_TRUE(processor.RotateY(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(13.515801, rotate[0], 1e-3f);
+    EXPECT_NEAR(5.457887, rotate[1], 0.12);   //< Fairly high difference - shearing effects?
+    EXPECT_NEAR(-3.5485, rotate[2], 0.147);   //< Fairly high difference - shearing effects?
+  }
+
+  // rotate 15 degrees around Z in world space
+  {
+    EXPECT_TRUE(processor.RotateZ(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+    GfVec3h rotate(0);
+    child_rotate.Get(&rotate);
+    EXPECT_NEAR(17.381871, rotate[0], 8.8e-2f);
+    EXPECT_NEAR(4.011838, rotate[1], 0.089);   //< Fairly high difference - shearing effects?
+    EXPECT_NEAR(5.998051, rotate[2], 0.083);   //< Fairly high difference - shearing effects?
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// When using a xform op of type TypeTransform, ensure that when kRotate mode is requested, the correct coordinate
+// frame is computed
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, matrix_transform_op_correct_frame_translate)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_transform = parent.AddTransformOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_transform"));
+  const GfMatrix4d matrixTransform(4,0,0,0,0,3.535534,3.535534,0,0,-4.242641,4.242641,0,1,2,3,1);
+  parent_transform.Set(matrixTransform);
+
+  MayaUsdUtils::TransformOpProcessor processor(parent.GetPrim(), 0);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  const GfMatrix4d expectedFrame(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1);
+  COMPARE_MAT4(expectedFrame, processor.ManipulatorFrame(), 1e-5f);
+  COMPARE_MAT4(expectedFrame, processor.WorldFrame(), 1e-5f);
+
+  EXPECT_TRUE(processor.Translate(GfVec3d(2, 3, 4)));
+  const GfMatrix4d expectedResult(4,0,0,0,0,3.535534,3.535534,0,0,-4.242641,4.242641,0,3,5,7,1);
+  GfMatrix4d evaluated;
+  parent_transform.Get(&evaluated);
+  COMPARE_MAT4(expectedResult, evaluated, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// When using a xform op of type TypeTransform, ensure that when kRotate mode is requested, the correct coordinate
+// frame is computed
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, matrix_transform_op_correct_frame_rotate)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_transform = parent.AddTransformOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_transform"));
+  const GfMatrix4d matrixTransform(4,0,0,0,0,3.535534,3.535534,0,0,-4.242641,4.242641,0,1,2,3,1);
+  parent_transform.Set(matrixTransform);
+
+  MayaUsdUtils::TransformOpProcessor processor(parent.GetPrim(), 0, MayaUsdUtils::TransformOpProcessor::kRotate);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+
+  const GfMatrix4d expectedFrame(1,0,0,0, 0,1,0,0, 0,0,1,0, 1,2,3,1);
+  COMPARE_MAT4(expectedFrame, processor.ManipulatorFrame(), 1e-5f);
+  COMPARE_MAT4(expectedFrame, processor.WorldFrame(), 1e-5f);
+
+  EXPECT_TRUE(processor.RotateX(45.0 * M_PI / 180.0));
+  const GfMatrix4d expectedResult(4,0,0,0,0,0,5,0,0,-6,0,0,1,2,3,1);
+  GfMatrix4d evaluated;
+  parent_transform.Get(&evaluated);
+  COMPARE_MAT4(expectedResult, evaluated, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// When using a xform op of type TypeTransform, ensure that when kRotate mode is requested, the correct coordinate
+// frame is computed
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, matrix_transform_op_correct_frame_rotate2)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_transform = parent.AddTransformOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_transform"));
+  const GfMatrix4d matrixTransform(4,0,0,0,0,3.535534,3.535534,0,0,-4.242641,4.242641,0,1,2,3,1);
+  parent_transform.Set(matrixTransform);
+
+  MayaUsdUtils::TransformOpProcessor processor(parent.GetPrim(), 0, MayaUsdUtils::TransformOpProcessor::kRotate);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+
+  const GfMatrix4d expectedFrame(1,0,0,0, 0,1,0,0, 0,0,1,0, 1,2,3,1);
+  COMPARE_MAT4(expectedFrame, processor.ManipulatorFrame(), 1e-5f);
+  COMPARE_MAT4(expectedFrame, processor.WorldFrame(), 1e-5f);
+
+  EXPECT_TRUE(processor.RotateY(15.0 * M_PI / 180.0));
+  const GfMatrix4d expectedResult(3.863703,0,-1.035276,0,0.915064,3.535534,3.415064,0,1.098076,-4.242641,4.098076,0,1,2,3,1);
+  GfMatrix4d evaluated;
+  parent_transform.Get(&evaluated);
+  COMPARE_MAT4(expectedResult, evaluated, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// When using a xform op of type TypeTransform, ensure that when kScale mode is requested, the correct coordinate
+// frame is computed
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, matrix_transform_op_correct_frame_scale)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp parent_transform = parent.AddTransformOp(UsdGeomXformOp::PrecisionDouble, TfToken("parent_transform"));
+  const GfMatrix4d matrixTransform(4,0,0,0,0,3.535534,3.535534,0,0,-4.242641,4.242641,0,1,2,3,1);
+  parent_transform.Set(matrixTransform);
+
+  MayaUsdUtils::TransformOpProcessor processor(parent.GetPrim(), 0, MayaUsdUtils::TransformOpProcessor::kScale);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kScale, processor.ManipMode());
+
+  const GfMatrix4d expectedFrame(1,0,0,0,0,0.707107,0.707107,0,0,-0.707107,0.707107,0, 1,2,3,1);
+  COMPARE_MAT4(expectedFrame, processor.ManipulatorFrame(), 1e-5f);
+  COMPARE_MAT4(expectedFrame, processor.WorldFrame(), 1e-5f);
+
+  EXPECT_TRUE(processor.Scale(GfVec3d(2, 1, 3)));
+  const GfMatrix4d expectedResult(8,0,0,0,0,3.535534,3.535534,0,0,-12.727922,12.727922,0,1,2,3,1);
+  GfMatrix4d evaluated;
+  parent_transform.Get(&evaluated);
+  COMPARE_MAT4(expectedResult, evaluated, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that we can rotate a matrix op in world space
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, matrix_transform_op_world_rotate)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble).Set(GfVec3d(1, 2, 3));
+  parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble).Set(GfVec3d(15, 30, 45));
+
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_transform = child.AddTransformOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_transform"));
+
+  const GfMatrix4d matrixTransform(4,0,0,0,0,3.535534,3.535534,0,0,-4.242641,4.242641,0,1,2,3,1);
+  child_transform.Set(matrixTransform);
+
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0, MayaUsdUtils::TransformOpProcessor::kRotate);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+
+  EXPECT_TRUE(processor.RotateX(15.0 * M_PI / 180.0, MayaUsdUtils::TransformOpProcessor::kWorld));
+
+  const GfMatrix4d expectedResult(3.914815,0.493652,0.656151,0,-1.026176,2.859477,3.97119,0,0.0252416,-4.86594,3.51027,0,1,2,3,1);
+  GfMatrix4d evaluated;
+  child_transform.Get(&evaluated);
+  COMPARE_MAT4(expectedResult, evaluated, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that we can rotate a matrix op in parent space
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, matrix_transform_op_parent_rotate)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble).Set(GfVec3d(1, 2, 3));
+  parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble).Set(GfVec3d(15, 30, 45));
+  UsdGeomXformOp child_transform = parent.AddTransformOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_transform"));
+
+  const GfMatrix4d matrixTransform(4,0,0,0,0,3.535534,3.535534,0,0,-4.242641,4.242641,0,1,2,3,1);
+  child_transform.Set(matrixTransform);
+
+  MayaUsdUtils::TransformOpProcessor processor(parent.GetPrim(), 2, MayaUsdUtils::TransformOpProcessor::kRotate);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+
+  EXPECT_TRUE(processor.RotateX(15.0 * M_PI / 180.0, MayaUsdUtils::TransformOpProcessor::kParent));
+
+  const GfMatrix4d expectedResult(3.914815,0.493652,0.656151,0,-1.026176,2.859477,3.97119,0,0.0252416,-4.86594,3.51027,0,1,2,3,1);
+  GfMatrix4d evaluated;
+  child_transform.Get(&evaluated);
+  COMPARE_MAT4(expectedResult, evaluated, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that we can rotate a matrix op in world space
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, matrix_transform_op_world_translate)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble).Set(GfVec3d(1, 2, 3));
+  parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble).Set(GfVec3d(15, 30, 45));
+
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp child_transform = child.AddTransformOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_transform"));
+
+  const GfMatrix4d matrixTransform(4,0,0,0,0,3.535534,3.535534,0,0,-4.242641,4.242641,0,1,2,3,1);
+  child_transform.Set(matrixTransform);
+
+  MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0, MayaUsdUtils::TransformOpProcessor::kTranslate);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+
+  EXPECT_TRUE(processor.Translate(GfVec3d(-2.0, 3.0, 1.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+
+  const GfMatrix4d expectedResult(4,0,0,0,0,3.535534,3.535534,0,0,-4.242641,4.242641,0,1.112372,5.730714,3.262959,1);
+  GfMatrix4d evaluated;
+  child_transform.Get(&evaluated);
+  COMPARE_MAT4(expectedResult, evaluated, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Test that we can rotate a matrix op in parent space
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, matrix_transform_op_parent_translate)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble).Set(GfVec3d(1, 2, 3));
+  parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble).Set(GfVec3d(15, 30, 45));
+  UsdGeomXformOp child_transform = parent.AddTransformOp(UsdGeomXformOp::PrecisionDouble, TfToken("child_transform"));
+
+  const GfMatrix4d matrixTransform(4,0,0,0,0,3.535534,3.535534,0,0,-4.242641,4.242641,0,1,2,3,1);
+  child_transform.Set(matrixTransform);
+
+  MayaUsdUtils::TransformOpProcessor processor(parent.GetPrim(), 2, MayaUsdUtils::TransformOpProcessor::kRotate);
+  EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+
+  EXPECT_TRUE(processor.Translate(GfVec3d(-2.0, 3.0, 1.0), MayaUsdUtils::TransformOpProcessor::kParent));
+
+  const GfMatrix4d expectedResult(4,0,0,0,0,3.535534,3.535534,0,0,-4.242641,4.242641,0,1.112372,5.730714,3.262959,1);
+  GfMatrix4d evaluated;
+  child_transform.Get(&evaluated);
+  COMPARE_MAT4(expectedResult, evaluated, 1e-5f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Simplest negative scale case. This shouldn't need to apply any special negative scale handling, so it should just work
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, negative_scale_and_translate_local)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  // initialise a parent transform
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp T = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("T"));
+  UsdGeomXformOp R = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("R"));
+  UsdGeomXformOp S = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("S"));
+  T.Set(GfVec3d(2.0, 3.0, 1.0));
+  R.Set(GfVec3d(15.0, 30.0, 45.0));
+  S.Set(GfVec3d(-2.2, 3.3, 1.1));
+
+  // make a small translation modification
+  {
+    MayaUsdUtils::TransformOpProcessor processor(parent.GetPrim(), 0, MayaUsdUtils::TransformOpProcessor::kTranslate);
+    EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+    EXPECT_TRUE(processor.Translate(GfVec3d(-1, -2, -4), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+    GfVec3d result;
+    T.Get(&result);
+
+    EXPECT_NEAR(2.0 - 1.0, result[0], 1e-5f);
+    EXPECT_NEAR(3.0 - 2.0, result[1], 1e-5f);
+    EXPECT_NEAR(1.0 - 4.0, result[2], 1e-5f);
+  }
+
+  // make a small rotation modification
+  {
+    MayaUsdUtils::TransformOpProcessor processor(parent.GetPrim(), 1, MayaUsdUtils::TransformOpProcessor::kRotate);
+    EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+    EXPECT_TRUE(processor.RotateX(45.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+    GfVec3d result;
+    R.Get(&result);
+
+    EXPECT_NEAR(60.0, result[0], 1e-5f);
+    EXPECT_NEAR(30.0, result[1], 1e-5f);
+    EXPECT_NEAR(45.0, result[2], 1e-5f);
+  }
+
+  // make a small scale modification
+  {
+    MayaUsdUtils::TransformOpProcessor processor(parent.GetPrim(), 2, MayaUsdUtils::TransformOpProcessor::kScale);
+    EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kScale, processor.ManipMode());
+    EXPECT_TRUE(processor.Scale(GfVec3d(10.0, 20.0, 30.0), MayaUsdUtils::TransformOpProcessor::kTransform));
+
+    GfVec3d result;
+    S.Get(&result);
+
+    EXPECT_NEAR(-22.0, result[0], 1e-5f);
+    EXPECT_NEAR(66.0, result[1], 1e-5f);
+    EXPECT_NEAR(33.0, result[2], 1e-5f);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Simplest negative scale case. This shouldn't need to apply any special negative scale handling. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, uniform_negative_scale_and_transform_world)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp T = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("T"));
+  UsdGeomXformOp R = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("R"));
+  UsdGeomXformOp S = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("S"));
+  T.Set(GfVec3d(0.0, 0.0, 0.0));
+  R.Set(GfVec3d(0.0, 0.0, 0.0));
+  S.Set(GfVec3d(-2.2, -2.2, -2.2));
+
+  // initialise a parent transform
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp Tc = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("T"));
+  UsdGeomXformOp Rc = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("R"));
+  UsdGeomXformOp Sc = child.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("S"));
+  Tc.Set(GfVec3d(2.0, 3.0, 1.0));
+  Rc.Set(GfVec3d(15.0, 30.0, 45.0));
+  Sc.Set(GfVec3d(2.2, -3.3, 1.1));
+
+  // make a small translation modification
+  {
+    MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0, MayaUsdUtils::TransformOpProcessor::kTranslate);
+    EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+    EXPECT_TRUE(processor.Translate(GfVec3d(-1, -2, -4), MayaUsdUtils::TransformOpProcessor::kWorld));
+
+    GfVec3d result;
+    Tc.Get(&result);
+
+    EXPECT_NEAR(2.454545, result[0], 1e-5f);
+    EXPECT_NEAR(3.909091, result[1], 1e-5f);
+    EXPECT_NEAR(2.818182, result[2], 1e-5f);
+  }
+
+  // make a small rotation modification
+  {
+    MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1, MayaUsdUtils::TransformOpProcessor::kRotate);
+    EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+    EXPECT_TRUE(processor.RotateX(15.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+
+    GfVec3d result;
+    Rc.Get(&result);
+
+    EXPECT_NEAR(26.155986, result[0], 1e-5f);
+    EXPECT_NEAR(18.933424, result[1], 1e-5f);
+    EXPECT_NEAR(49.654204, result[2], 1e-5f);
+  }
+
+  // make a small scale modification
+  {
+    MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 2, MayaUsdUtils::TransformOpProcessor::kScale);
+    EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kScale, processor.ManipMode());
+    EXPECT_TRUE(processor.Scale(GfVec3d(-3, -3, -3), MayaUsdUtils::TransformOpProcessor::kWorld));
+
+    GfVec3d result;
+    Sc.Get(&result);
+
+    EXPECT_NEAR(2.2 * -3.0, result[0], 1e-5f);
+    EXPECT_NEAR(-3.3 * -3.0, result[1], 1e-5f);
+    EXPECT_NEAR(1.1 * -3.0, result[2], 1e-5f);
+  }
+}
+
+#if 0
+// 
+// I've disabled these tests for now. 
+// 
+// I'm a little unsure how Maya is handling the case where the parent matrix has a negative non-uniform scale in 1 or 3 axes, 
+// and we're applying a world space rotation to the child transform. 
+// 
+// The results are always going to be *wrong* when you do this (since we have to account for shear), so in that regard, 
+// my approach is no less wrong than Maya's, however it would be nice to make this final edge case match the result of Maya :(
+//
+
+//----------------------------------------------------------------------------------------------------------------------
+// Simplest negative scale case. This shouldn't need to apply any special negative scale handling. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, negative_non_uniform_scale_and_translate_world1)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp T = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("T"));
+  UsdGeomXformOp R = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("R"));
+  UsdGeomXformOp S = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("S"));
+  T.Set(GfVec3d(0.0, 0.0, 0.0));
+  R.Set(GfVec3d(0.0, 0.0, 0.0));
+  S.Set(GfVec3d(-2.2, 3.3, 1.1));
+
+  // initialise a parent transform
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp Tc = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("T"));
+  UsdGeomXformOp Rc = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("R"));
+  UsdGeomXformOp Sc = child.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("S"));
+  Tc.Set(GfVec3d(2.0, 3.0, 1.0));
+  Rc.Set(GfVec3d(15.0, 30.0, 45.0));
+  Sc.Set(GfVec3d(2.2, -3.3, 1.1));
+
+  // make a small translation modification
+  {
+    MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0, MayaUsdUtils::TransformOpProcessor::kTranslate);
+    EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+    EXPECT_TRUE(processor.Translate(GfVec3d(-1, -2, -4), MayaUsdUtils::TransformOpProcessor::kWorld));
+
+    GfVec3d result;
+    Tc.Get(&result);
+
+    EXPECT_NEAR(2.454545, result[0], 1e-5f);
+    EXPECT_NEAR(2.393939, result[1], 1e-5f);
+    EXPECT_NEAR(-2.636364, result[2], 1e-5f);
+  }
+
+  // make a small rotation modification
+  {
+    MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1, MayaUsdUtils::TransformOpProcessor::kRotate);
+    EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+    EXPECT_TRUE(processor.RotateX(45.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+
+    GfVec3d result;
+    Rc.Get(&result);
+
+    EXPECT_NEAR(62.752755, result[0], 1e-5f);
+    EXPECT_NEAR(-25.013615, result[1], 1e-5f);
+    EXPECT_NEAR(47.487338, result[2], 1e-5f);
+  }
+
+  // make a small scale modification
+  {
+    MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 2, MayaUsdUtils::TransformOpProcessor::kScale);
+    EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kScale, processor.ManipMode());
+    EXPECT_TRUE(processor.Scale(GfVec3d(-3, -3, -3), MayaUsdUtils::TransformOpProcessor::kWorld));
+
+    GfVec3d result;
+    Sc.Get(&result);
+
+    EXPECT_NEAR(2.2 * -3.0, result[0], 1e-5f);
+    EXPECT_NEAR(-3.3 * -3.0, result[1], 1e-5f);
+    EXPECT_NEAR(1.1 * -3.0, result[2], 1e-5f);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Simplest negative scale case. This shouldn't need to apply any special negative scale handling. 
+//----------------------------------------------------------------------------------------------------------------------
+TEST(TransformOpProcessor, negative_non_uniform_scale_and_translate_world2)
+{
+  UsdStageRefPtr stage = UsdStage::CreateInMemory();
+  ASSERT_TRUE(stage);
+
+  UsdGeomXform parent = UsdGeomXform::Define(stage, SdfPath("/xform"));
+  UsdGeomXformOp T = parent.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("T"));
+  UsdGeomXformOp R = parent.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("R"));
+  UsdGeomXformOp S = parent.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("S"));
+  T.Set(GfVec3d(2.0, 3.0, 1.0));
+  R.Set(GfVec3d(15.0, 30.0, 45.0));
+  S.Set(GfVec3d(-2.2, 3.3, 1.1));
+
+  // initialise a parent transform
+  UsdGeomXform child = UsdGeomXform::Define(stage, SdfPath("/xform/child"));
+  UsdGeomXformOp Tc = child.AddTranslateOp(UsdGeomXformOp::PrecisionDouble, TfToken("T"));
+  UsdGeomXformOp Rc = child.AddRotateXYZOp(UsdGeomXformOp::PrecisionDouble, TfToken("R"));
+  UsdGeomXformOp Sc = child.AddScaleOp(UsdGeomXformOp::PrecisionDouble, TfToken("S"));
+  Tc.Set(GfVec3d(2.0, 3.0, 1.0));
+  Rc.Set(GfVec3d(15.0, 30.0, 45.0));
+  Sc.Set(GfVec3d(2.2, -3.3, 1.1));
+
+  // make a small translation modification
+  {
+    MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 0, MayaUsdUtils::TransformOpProcessor::kTranslate);
+    EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kTranslate, processor.ManipMode());
+    EXPECT_TRUE(processor.Translate(GfVec3d(-1, -2, -4), MayaUsdUtils::TransformOpProcessor::kWorld));
+
+    GfVec3d result;
+    Tc.Get(&result);
+
+    EXPECT_NEAR(1.925962, result[0], 1e-5f);
+    EXPECT_NEAR(2.438149, result[1], 1e-5f);
+    EXPECT_NEAR(-2.806883, result[2], 1e-5f);
+  }
+
+  // make a small rotation modification
+  {
+    MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 1, MayaUsdUtils::TransformOpProcessor::kRotate);
+    EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kRotate, processor.ManipMode());
+    EXPECT_TRUE(processor.RotateX(45.0 * (M_PI / 180.0), MayaUsdUtils::TransformOpProcessor::kWorld));
+
+    GfVec3d result;
+    Rc.Get(&result);
+
+    EXPECT_NEAR(90.312074, result[0], 1e-5f);
+    EXPECT_NEAR(21.092268, result[1], 1e-5f);
+    EXPECT_NEAR(43.367621, result[2], 1e-5f);
+  }
+
+  // make a small scale modification
+  {
+    MayaUsdUtils::TransformOpProcessor processor(child.GetPrim(), 2, MayaUsdUtils::TransformOpProcessor::kScale);
+    EXPECT_EQ(MayaUsdUtils::TransformOpProcessor::kScale, processor.ManipMode());
+    EXPECT_TRUE(processor.Scale(GfVec3d(-3, -3, -3), MayaUsdUtils::TransformOpProcessor::kWorld));
+
+    GfVec3d result;
+    Sc.Get(&result);
+
+    EXPECT_NEAR(2.2 * -3.0, result[0], 1e-5f);
+    EXPECT_NEAR(-3.3 * -3.0, result[1], 1e-5f);
+    EXPECT_NEAR(1.1 * -3.0, result[2], 1e-5f);
+  }
+}
+#endif


### PR DESCRIPTION
Added code to provide an API to manipulate USD xform OPs in various coordinate frames. 
One thing the code provides is a far more efficient transform evaluation than the one available in UsdGeom, so to compute the local space matrix of a transform:
```c++
  UsdGeomXformable xform(somePrim);
  bool resetsXformStack = false;
  std::vector<UsdGeomXformOp> ops = xform.GetOrderedXformOps(&resetsXformStack);
  GfMatrix4d result = TransformOpProcessor::EvaluateCoordinateFrameForIndex(ops, ops.size(), UsdTimeCode::Default());
```
The code within USD blindly evaluates each transform op as a matrix, and multiplies them out. This code evaluates like terms (e.g. it'll combine a series of translations into 1 translation, or combine a series of rotations into a single quat) and then applies that single transformation as a direct modification of the matrix being evaluated. 

**Evaluating individual coordinate frames for transforms**

This method can also be used to compute coordinate frames for invidiual UsdXformOp's, so let's assume we have some xformable prim which has some named translation attribute named we wish to modify....

```c++
  // initialise processor to work on the xformOp 'translate'. If not found, an exception is thrown.
  MayaUsdUtils::TransformOpProcessor processor(_somePrim, TfToken("xformOp:translate"));
```
We can now query the processor to see which transform manipulations are supported:

```c++
if(processor.CanRotate())
{
  if(processor.CanRotateX())
  {
  }
  if(processor.CanRotateY())
  {
  }
  if(processor.CanRotateZ())
  {
  }
}
if(processor.CanTranslate())
{
  // should get here hopefully!
}
if(processor.CanScale())
{
}
```
This step is required since matrices can manipulate translate scale and rotate.

You can then query two matrices _(in local space, so transform by prim parent matrix!)_. The ManipulatorFrame() returns the origin for the transform op, as if the transform was the identity _(e.g. [1,1,1] for scale, [0,0,0] for translate, [0,0,0] for rotate)_. Those should be the only matrices you need to implement your own scale/translate/rotate tools.  
```c++
auto local_origin = processor.ManipulatorFrame();
auto current_transform = processor.ManipulatorMatrix();
 ```
So at this point, you can simply translate the xform op in one of 3 coordinate frames (e.g. local, world, parent)
```c++
  if(!processor.Translate(GfVec3d(2.0, 0.5, 0.3), MayaUsdUtils::TransformOpProcessor::kWorld))
  {
    // apply a world space translation offset of [2.0, 0.5, 0.3]
  }
```
The transformation is automatically converted to the correct coordinate frame,  and the translation is applied as a local space offset. 

**A word about rotations....**

When using this class prefer the RotateX / RotateY / RotateZ methods over calling Rotate. The latter should only really be used when implemented the ball-based rotation when clicking on the sphere of the rotation manip. Rotations around a specific axis should really be passed to RotateX etc, for more accurate results. 

**A word about matrices....**

Matrices are a little bit of an oddball in that they are the only xformOp that supports scale, translation, and rotation. That also leads to a mild annoyance in that the coordinate frame for the manipulator will change depending on what you are edition, e.g. translate uses the identity frame, rotate applies translation to its frame, and scale will apply both rotate & translate. As a result of this behaviour, the class has to track which manip type is in use (and modify the manipulator frame accordingly).  

For the most part the code will guess what it is you are doing, and only allow valid manipulations (updating the internal frames if needed). For a slightly nicer user experience (i.e. avoid manipulators jumping about in space when modifying matrices), it's a good idea to specify the type of manipulator you want upfront (e.g. kTranslate, kScale, kRotate). 

```c++
  MayaUsdUtils::TransformOpProcessor processor(
      _somePrim,
      TfToken("xformOp:translate"),
      MayaUsdUtils::TransformOpProcessor::kTranslate);  //< use translate manip type
```

**A word about time....**
If you want to specify the timeCode used to evaluate the coordinate frame, you can do so in the constructor (default is DefaultTIme()):

```c++
  MayaUsdUtils::TransformOpProcessor processor(
      _somePrim,
      TfToken("xformOp:translate"),
      MayaUsdUtils::TransformOpProcessor::kTranslate,
      UsdTimeCode(1001));  //< use frame 1001
```
The UpdateToTime method will re-evaluate all coordinates frames for the given time code (and can also be used to switch manip modes from rotate to scale, etc)
```c++
  processor.UpdateToTime(
      UsdTimeCode(1002),
      MayaUsdUtils::TransformOpProcessor::kTranslate); 
```

**A word about compiling the code....**

The code requires the following instrinsics enabled: ```-mavx2 -mfma -mf16c```. This is the base spec of our CPUs, so that's what I'm targeting here. 

**Things that don't work....**

* The TypeRotateX / TypeRotateY / TypeRotateZ are mostly correct when manipulating in world or parent space, however I'm not sure how my maths would fair with non-uniform scaling thrown in the mix. It's always going to end up being 'wrong', but if needed I could make it less wrong.
* If a parent transform has negative-non-uniform scaling, then the approach I take to handle shear when applying world and parent space rotation results in differing rotations. I'm not entirely sure how maya is handling this case?
* There are no checks for non-invertable transformations. For example, if you have a zero scaling in the transform stack, there's a good chance the transformation code will end up creating NAN's and INF's. 
* No support for float or half precision matrices (this is a limitation of USDGeom)

**Things That do work...**

The following Types are fully implemented:
* TypeTranslate - works in all cases
* TypeScale - copies mayas approach. Allow local scaling changes, but only allow world/parent scaling changes if the change is uniform in X, Y, and Z 
* TypeOrient - works in all cases
* TypeRotateXYZ, TypeRotateXZY, etc, etc - works in all cases _(although won't match Maya when the parent TM has a non-uniform scaling with a negative value in 1 or 3 axes)_. 
* TypeTransform - works in all cases

The following precision's are supported:
* kHalf - _note: GfMatrix4h is not a valid type for UsdGeomXformOp_
* kFloat - _note: GfMatrix4f is not a valid type for UsdGeomXformOp_
* kDouble 

**Things that this PR does not do...**

* No read-only checks
* It wont create transform ops for you. 
* I'm not bothering to add any cmake stuff. 

**Final thoughts...**
Yes this code is not portable. Yes the implementation could be cleaner. Yes there is an edge case to fix. Trees, Wood, and all that.... 