### PR TITLE
MAYA-105608 Non-UFE selection code path couldn't work with instances

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -607,7 +607,7 @@ void ProxyRenderDelegate::updateSelectionGranularity(
     }
 }
 
-//! \brief  UFE-based selection for both instanced and non-instanced cases.
+//! \brief  Selection for both instanced and non-instanced cases.
 bool ProxyRenderDelegate::getInstancedSelectionPath(
     const MHWRender::MRenderItem& renderItem,
     const MHWRender::MIntersection& intersection,
@@ -729,11 +729,11 @@ bool ProxyRenderDelegate::getInstancedSelectionPath(
         TF_WARN("Unexpected MGlobal::ListAdjustment enum for selection.");
         break;
     }
+#else
+    dagPath = _proxyShapeData->ProxyDagPath();
+#endif
 
     return true;
-#else
-    return false;
-#endif
 }
 
 //! \brief  Notify of selection change.


### PR DESCRIPTION
When picking instances from viewport, the non-UFE selection code path
wasn't able to select the proxy DAG path as expected because the default
VP2 selection logic cannot handle selection for non-DAG instances.

Thus in the plugin side we need to determine the selected DAG path to
avoid relying on the default VP2 selection logic.

Note: This fix is for Maya 2018 only. Besides, in the maya side we are fixing
a selection issue for transparent instances for all relevant Maya versions.