### PR TITLE
MAYA-105977: Update restriction error reports based on latest design.

### DIFF
--- a/lib/mayaUsd/ufe/private/Utils.cpp
+++ b/lib/mayaUsd/ufe/private/Utils.cpp
@@ -36,95 +36,95 @@ namespace ufe {
 
 UsdGeomXformCommonAPI convertToCompatibleCommonAPI(const UsdPrim& prim)
 {
-	// As we are using USD's XformCommonAPI which supports only the following xformOps :
-	//    ["xformOp:translate", "xformOp:translate:pivot", "xformOp:rotateXYZ", "xformOp:scale", "!invert!xformOp:translate:pivot"]
-	// We are extending the supported xform Operations with :
-	//    ["xformOp:rotateX", "xformOp:rotateY", "xformOp:rotateZ"]
-	// Where we convert these into xformOp:rotateXYZ.
+    // As we are using USD's XformCommonAPI which supports only the following xformOps :
+    //    ["xformOp:translate", "xformOp:translate:pivot", "xformOp:rotateXYZ", "xformOp:scale", "!invert!xformOp:translate:pivot"]
+    // We are extending the supported xform Operations with :
+    //    ["xformOp:rotateX", "xformOp:rotateY", "xformOp:rotateZ"]
+    // Where we convert these into xformOp:rotateXYZ.
 
-	static TfToken rotX("xformOp:rotateX");
-	static TfToken rotY("xformOp:rotateY");
-	static TfToken rotZ("xformOp:rotateZ");
-	static TfToken rotXYZ("xformOp:rotateXYZ");
-	static TfToken scale("xformOp:scale");
-	static TfToken trans("xformOp:translate");
-	static TfToken pivot("xformOp:translate:pivot");
-	static TfToken notPivot("!invert!xformOp:translate:pivot");
+    static TfToken rotX("xformOp:rotateX");
+    static TfToken rotY("xformOp:rotateY");
+    static TfToken rotZ("xformOp:rotateZ");
+    static TfToken rotXYZ("xformOp:rotateXYZ");
+    static TfToken scale("xformOp:scale");
+    static TfToken trans("xformOp:translate");
+    static TfToken pivot("xformOp:translate:pivot");
+    static TfToken notPivot("!invert!xformOp:translate:pivot");
 
-	auto xformable = UsdGeomXformable(prim);
-	bool resetsXformStack;
-	auto xformOps = xformable.GetOrderedXformOps(&resetsXformStack);
-	xformable.ClearXformOpOrder();
-	auto primXform = UsdGeomXformCommonAPI(prim);
-	for (const auto& op : xformOps)
-	{
-		auto opName = op.GetOpName();
+    auto xformable = UsdGeomXformable(prim);
+    bool resetsXformStack;
+    auto xformOps = xformable.GetOrderedXformOps(&resetsXformStack);
+    xformable.ClearXformOpOrder();
+    auto primXform = UsdGeomXformCommonAPI(prim);
+    for (const auto& op : xformOps)
+    {
+        auto opName = op.GetOpName();
 
-		// RotateX, RotateY, RotateZ
-		if ((opName == rotX) || (opName == rotY) || (opName == rotZ))
-		{
-			float retValue;
-			if (op.Get<float>(&retValue))
-			{
-				if (opName == rotX)
-					primXform.SetRotate(GfVec3f(retValue, 0, 0));
-				else if (opName == rotY)
-					primXform.SetRotate(GfVec3f(0, retValue, 0));
-				else if (opName == rotZ)
-					primXform.SetRotate(GfVec3f(0, 0, retValue));
-			}
-		}
-		// RotateXYZ
-		else if (opName == rotXYZ)
-		{
-			GfVec3f retValue;
-			if (op.Get<GfVec3f>(&retValue))
-			{
-				primXform.SetRotate(retValue);
-			}
-		}
-		// Scale
-		else if (opName == scale)
-		{
-			GfVec3f retValue;
-			if (op.Get<GfVec3f>(&retValue))
-			{
-				primXform.SetScale(retValue);
-			}
-		}
-		// Translate
-		else if (opName == trans)
-		{
-			GfVec3d retValue;
-			if (op.Get<GfVec3d>(&retValue))
-			{
-				primXform.SetTranslate(retValue);
-			}
-		}
-		// Scale / rotate pivot
-		else if (opName == pivot)
-		{
-			GfVec3f retValue;
-			if (op.Get<GfVec3f>(&retValue))
-			{
-				primXform.SetPivot(retValue);
-			}
-		}
-		// Scale / rotate pivot inverse
-		else if (opName == notPivot)
-		{
-			// automatically added, nothing to do.
-		}
-		// Not compatible
-		else
-		{
-			// Restore old
-			xformable.SetXformOpOrder(xformOps);
-			std::string err = TfStringPrintf("Incompatible xform op %s:", op.GetOpName().GetString().c_str());
-			throw std::runtime_error(err.c_str());
-		}
-	}
-	return primXform;
+        // RotateX, RotateY, RotateZ
+        if ((opName == rotX) || (opName == rotY) || (opName == rotZ))
+        {
+            float retValue;
+            if (op.Get<float>(&retValue))
+            {
+                if (opName == rotX)
+                    primXform.SetRotate(GfVec3f(retValue, 0, 0));
+                else if (opName == rotY)
+                    primXform.SetRotate(GfVec3f(0, retValue, 0));
+                else if (opName == rotZ)
+                    primXform.SetRotate(GfVec3f(0, 0, retValue));
+            }
+        }
+        // RotateXYZ
+        else if (opName == rotXYZ)
+        {
+            GfVec3f retValue;
+            if (op.Get<GfVec3f>(&retValue))
+            {
+                primXform.SetRotate(retValue);
+            }
+        }
+        // Scale
+        else if (opName == scale)
+        {
+            GfVec3f retValue;
+            if (op.Get<GfVec3f>(&retValue))
+            {
+                primXform.SetScale(retValue);
+            }
+        }
+        // Translate
+        else if (opName == trans)
+        {
+            GfVec3d retValue;
+            if (op.Get<GfVec3d>(&retValue))
+            {
+                primXform.SetTranslate(retValue);
+            }
+        }
+        // Scale / rotate pivot
+        else if (opName == pivot)
+        {
+            GfVec3f retValue;
+            if (op.Get<GfVec3f>(&retValue))
+            {
+                primXform.SetPivot(retValue);
+            }
+        }
+        // Scale / rotate pivot inverse
+        else if (opName == notPivot)
+        {
+            // automatically added, nothing to do.
+        }
+        // Not compatible
+        else
+        {
+            // Restore old
+            xformable.SetXformOpOrder(xformOps);
+            std::string err = TfStringPrintf("Incompatible xform op %s:", op.GetOpName().GetString().c_str());
+            throw std::runtime_error(err.c_str());
+        }
+    }
+    return primXform;
 }
 
 void applyCommandRestriction(const UsdPrim& prim, const std::string& commandName)
@@ -132,17 +132,25 @@ void applyCommandRestriction(const UsdPrim& prim, const std::string& commandName
     // early check to see if a particular node has any specs to contribute
     // to the final composed prim. e.g (a node in payload)
     if(!MayaUsdUtils::hasSpecs(prim)){
-        std::string err = TfStringPrintf("Cannot %s [%s] because it doesn't have any specs to contribute to the composed prim.",
-                                          commandName.c_str(),
-                                          prim.GetName().GetString().c_str());
+
+        auto layers = MayaUsdUtils::layerInCompositionArcsWithSpec(prim);
+        std::string layerDisplayNames;
+        for (auto layer : layers) {
+            layerDisplayNames.append("[" + layer->GetDisplayName() + "]" + ",");
+        }
+        layerDisplayNames.pop_back();
+        std::string err = TfStringPrintf("Cannot %s [%s]. It does not make any contributions in the current layer "
+                                         "because its specs are in an external composition arc. Please open %s to make direct edits.",
+                                         commandName.c_str(),
+                                         prim.GetName().GetString().c_str(), 
+                                         layerDisplayNames.c_str());
         throw std::runtime_error(err.c_str());
     }
 
     // if the current layer doesn't have any contributions
     if (!MayaUsdUtils::doesEditTargetLayerContribute(prim)) {
         auto strongestContributingLayer = MayaUsdUtils::strongestContributingLayer(prim);
-        std::string err = TfStringPrintf("Cannot %s [%s] defined on another layer. " 
-                                         "Please set [%s] as the target layer to proceed", 
+        std::string err = TfStringPrintf("Cannot %s [%s]. It is defined on another layer. Please set [%s] as the target layer to proceed.", 
                                          commandName.c_str(),
                                          prim.GetName().GetString().c_str(),
                                          strongestContributingLayer->GetDisplayName().c_str());
@@ -158,8 +166,7 @@ void applyCommandRestriction(const UsdPrim& prim, const std::string& commandName
                 layerDisplayNames.append("[" + layer->GetDisplayName() + "]" + ",");
             }
             layerDisplayNames.pop_back();
-            std::string err = TfStringPrintf("Cannot %s [%s] with definitions or opinions on other layers. "
-                                             "Opinions exist in %s",
+            std::string err = TfStringPrintf("Cannot %s [%s]. It has definitions or opinions on other layers. Opinions exist in %s",
                                              commandName.c_str(),
                                              prim.GetName().GetString().c_str(), 
                                              layerDisplayNames.c_str());
@@ -174,82 +181,82 @@ void applyCommandRestriction(const UsdPrim& prim, const std::string& commandName
 
 void translateOp(const UsdPrim& prim, const Ufe::Path& path, double x, double y, double z)
 {
-	auto primXform = UsdGeomXformCommonAPI(prim);
-	if (!primXform.SetTranslate(GfVec3d(x, y, z)))
-	{
-		// This could mean that we have an incompatible xformOp in the stack
-		try {
-			primXform = convertToCompatibleCommonAPI(prim);
-			if (!primXform.SetTranslate(GfVec3d(x,y,z)))
-				throw std::runtime_error("Unable to SetTranslate after conversion to CommonAPI.");
-		}
-		catch (const std::exception& e) {
-			std::string err = TfStringPrintf("Failed to translate prim %s - %s",
-				path.string().c_str(), e.what());
-			UFE_LOG(err.c_str());
-			throw;
-		}
-	}
+    auto primXform = UsdGeomXformCommonAPI(prim);
+    if (!primXform.SetTranslate(GfVec3d(x, y, z)))
+    {
+        // This could mean that we have an incompatible xformOp in the stack
+        try {
+            primXform = convertToCompatibleCommonAPI(prim);
+            if (!primXform.SetTranslate(GfVec3d(x,y,z)))
+                throw std::runtime_error("Unable to SetTranslate after conversion to CommonAPI.");
+        }
+        catch (const std::exception& e) {
+            std::string err = TfStringPrintf("Failed to translate prim %s - %s",
+                path.string().c_str(), e.what());
+            UFE_LOG(err.c_str());
+            throw;
+        }
+    }
 }
 
 void rotateOp(const UsdPrim& prim, const Ufe::Path& path, double x, double y, double z)
 {
-	auto primXform = UsdGeomXformCommonAPI(prim);
-	if (!primXform.SetRotate(GfVec3f(x, y, z)))
-	{
-		// This could mean that we have an incompatible xformOp in the stack
-		try {
-			primXform = convertToCompatibleCommonAPI(prim);
-			if (!primXform.SetRotate(GfVec3f(x, y, z)))
-				throw std::runtime_error("Unable to SetRotate after conversion to CommonAPI.");
-		}
-		catch (const std::exception& e) {
-			std::string err = TfStringPrintf("Failed to rotate prim %s - %s",
-				path.string().c_str(), e.what());
-			UFE_LOG(err.c_str());
-			throw;
-		}
-	}
+    auto primXform = UsdGeomXformCommonAPI(prim);
+    if (!primXform.SetRotate(GfVec3f(x, y, z)))
+    {
+        // This could mean that we have an incompatible xformOp in the stack
+        try {
+            primXform = convertToCompatibleCommonAPI(prim);
+            if (!primXform.SetRotate(GfVec3f(x, y, z)))
+                throw std::runtime_error("Unable to SetRotate after conversion to CommonAPI.");
+        }
+        catch (const std::exception& e) {
+            std::string err = TfStringPrintf("Failed to rotate prim %s - %s",
+                path.string().c_str(), e.what());
+            UFE_LOG(err.c_str());
+            throw;
+        }
+    }
 }
 
 void scaleOp(const UsdPrim& prim, const Ufe::Path& path, double x, double y, double z)
 {
-	auto primXform = UsdGeomXformCommonAPI(prim);
-	if (!primXform.SetScale(GfVec3f(x, y, z)))
-	{
-		// This could mean that we have an incompatible xformOp in the stack
-		try {
-			primXform = convertToCompatibleCommonAPI(prim);
-			if (!primXform.SetScale(GfVec3f(x, y, z)))
-				throw std::runtime_error("Unable to SetScale after conversion to CommonAPI.");
-		}
-		catch (const std::exception& e) {
-			std::string err = TfStringPrintf("Failed to scale prim %s - %s",
-				path.string().c_str(), e.what());
-			UFE_LOG(err.c_str());
-			throw;
-		}
-	}
+    auto primXform = UsdGeomXformCommonAPI(prim);
+    if (!primXform.SetScale(GfVec3f(x, y, z)))
+    {
+        // This could mean that we have an incompatible xformOp in the stack
+        try {
+            primXform = convertToCompatibleCommonAPI(prim);
+            if (!primXform.SetScale(GfVec3f(x, y, z)))
+                throw std::runtime_error("Unable to SetScale after conversion to CommonAPI.");
+        }
+        catch (const std::exception& e) {
+            std::string err = TfStringPrintf("Failed to scale prim %s - %s",
+                path.string().c_str(), e.what());
+            UFE_LOG(err.c_str());
+            throw;
+        }
+    }
 }
 
 void rotatePivotTranslateOp(const UsdPrim& prim, const Ufe::Path& path, double x, double y, double z)
 {
-	auto primXform = UsdGeomXformCommonAPI(prim);
-	if (!primXform.SetPivot(GfVec3f(x, y, z)))
-	{
-		// This could mean that we have an incompatible xformOp in the stack
-		try {
-			primXform = convertToCompatibleCommonAPI(prim);
-			if (!primXform.SetPivot(GfVec3f(x, y, z)))
-				throw std::runtime_error("Unable to SetPivot after conversion to CommonAPI.");
-		}
-		catch (const std::exception& e) {
-			std::string err = TfStringPrintf("Failed to set pivot for prim %s - %s",
-				path.string().c_str(), e.what());
-			UFE_LOG(err.c_str());
-			throw;
-		}
-	}
+    auto primXform = UsdGeomXformCommonAPI(prim);
+    if (!primXform.SetPivot(GfVec3f(x, y, z)))
+    {
+        // This could mean that we have an incompatible xformOp in the stack
+        try {
+            primXform = convertToCompatibleCommonAPI(prim);
+            if (!primXform.SetPivot(GfVec3f(x, y, z)))
+                throw std::runtime_error("Unable to SetPivot after conversion to CommonAPI.");
+        }
+        catch (const std::exception& e) {
+            std::string err = TfStringPrintf("Failed to set pivot for prim %s - %s",
+                path.string().c_str(), e.what());
+            UFE_LOG(err.c_str());
+            throw;
+        }
+    }
 }
 
 } // namespace ufe

--- a/lib/usd/utils/util.cpp
+++ b/lib/usd/utils/util.cpp
@@ -185,6 +185,23 @@ hasSpecs(const UsdPrim& prim)
     return found;
 }
 
+std::vector<SdfLayerHandle>
+layerInCompositionArcsWithSpec(const UsdPrim& prim)
+{
+    UsdPrimCompositionQuery query(prim);
+
+    std::vector<SdfLayerHandle> layersWithContribution;
+
+    for (const auto& compQueryArc : query.GetCompositionArcs()) {
+        if (compQueryArc.GetTargetNode().HasSpecs()) {
+            layersWithContribution.emplace_back(
+                compQueryArc.GetTargetNode().GetLayerStack()->GetIdentifier().rootLayer);
+        }
+    }
+
+    return layersWithContribution;
+}
+
 void
 printCompositionQuery(const UsdPrim& prim, std::ostream& os)
 {

--- a/lib/usd/utils/util.h
+++ b/lib/usd/utils/util.h
@@ -53,6 +53,10 @@ namespace MayaUsdUtils {
     MAYA_USD_UTILS_PUBLIC
     bool hasSpecs(const UsdPrim&);
 
+    //! Returns the layer in composition arc where HasSpecs is set to true
+    MAYA_USD_UTILS_PUBLIC
+    std::vector<SdfLayerHandle> layerInCompositionArcsWithSpec(const UsdPrim& prim);
+
     //! Convenience function for printing the list of queried composition arcs in order. 
     MAYA_USD_UTILS_PUBLIC
     void printCompositionQuery(const UsdPrim&, std::ostream&);


### PR DESCRIPTION
Updated the strings for re-parent/rename restriction rules. There are currently 3 rules in place:

**1.** Check if a particular node has any specs to contribute to the final composed prim. 

`Error Message: Cannot [reparent/rename] [prim_name]. It does not make any contributions in the current layer because its specs are in an external composition arc. Please open [filename.usd] to make direct edits.`

 **2.** Check if we are in the correct edit target to make an edit.

`Error Message:  Cannot [reparent/rename] [prim_name]. It is defined on another layer. Please set [layername] as the target layer to proceed.
`

 **3.** Check if we have more than 2 layers that contribute to the final composed prim. 

`Error Message: Cannot [reparent/rename] [prim_name]. It has definitions or opinions on other layers. Opinions exist in [layer name 1], [layer name 2], [layer name 3], [layer name 4].`
