### PR TITLE
MAYA-105442 - Add reference is not updated in the Outliner

### DIFF
--- a/lib/mayaUsd/ufe/Global.cpp
+++ b/lib/mayaUsd/ufe/Global.cpp
@@ -28,7 +28,7 @@
 #include <mayaUsd/ufe/UsdSceneItemOpsHandler.h>
 #include <mayaUsd/ufe/UsdTransform3dHandler.h>
 
-#include "private/InPathChange.h"
+#include "private/UfeNotifGuard.h"
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 // Note: must come after include of ufe files so we have the define.
@@ -82,7 +82,8 @@ Ufe::ContextOpsHandler::Ptr g_MayaContextOpsHandler;
 // Subject singleton for observation of all USD stages.
 StagesSubject::Ptr g_StagesSubject;
 
-bool InPathChange::fInPathChange = false;
+bool InPathChange::inGuard = false;
+bool InAddOrRemoveReference::inGuard = false;
 
 //------------------------------------------------------------------------------
 // Functions

--- a/lib/mayaUsd/ufe/StagesSubject.cpp
+++ b/lib/mayaUsd/ufe/StagesSubject.cpp
@@ -28,7 +28,7 @@
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
 
-#include "private/InPathChange.h"
+#include "private/UfeNotifGuard.h"
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 #include <ufe/attributes.h>
@@ -221,8 +221,20 @@ void StagesSubject::stageChanged(UsdNotice::ObjectsChanged const& notice, UsdSta
 
 			if (prim.IsActive())
 			{
-				auto notification = Ufe::ObjectAdd(sceneItem);
-				Ufe::Scene::notifyObjectAdd(notification);
+				if (InAddOrRemoveReference::inAddOrRemoveReference())
+				{
+#if UFE_PREVIEW_VERSION_NUM >= 2014
+					// When we are in an add or remove reference we send the
+					// UFE subtree invalidate notif instead.
+					auto notification = Ufe::SubtreeInvalidate(sceneItem);
+					Ufe::Scene::notifySubtreeInvalidate(notification);
+#endif
+				}
+				else
+				{
+					auto notification = Ufe::ObjectAdd(sceneItem);
+					Ufe::Scene::notifyObjectAdd(notification);
+				}
 			}
 			else
 			{

--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -35,6 +35,8 @@
 #include <mayaUsd/ufe/UsdSceneItem.h>
 #include <mayaUsd/ufe/UsdUndoAddNewPrimCommand.h>
 
+#include "private/UfeNotifGuard.h"
+
 namespace {
 
 // Ufe::ContextItem strings
@@ -133,6 +135,7 @@ public:
 
     void undo() override { 
         if (_prim.IsValid()) {
+            MayaUsd::ufe::InAddOrRemoveReference ar;
             UsdReferences primRefs = _prim.GetReferences();
             primRefs.RemoveReference(_sdfRef);
         }
@@ -140,6 +143,7 @@ public:
 
     void redo() override { 
         if (_prim.IsValid()) {
+            MayaUsd::ufe::InAddOrRemoveReference ar;
             _sdfRef = SdfReference(_filePath);
             UsdReferences primRefs = _prim.GetReferences();
             primRefs.AddReference(_sdfRef);
@@ -170,6 +174,7 @@ public:
 
     void redo() override { 
         if (_prim.IsValid()) {
+            MayaUsd::ufe::InAddOrRemoveReference ar;
             UsdReferences primRefs = _prim.GetReferences();
             primRefs.ClearReferences();
         }
@@ -267,7 +272,7 @@ Ufe::ContextOps::Items UsdContextOps::getItems(
             items.emplace_back(AddReferenceUndoableCommand::commandName,
                                 AddReferenceUndoableCommand::commandName);
             items.emplace_back(ClearAllReferencesUndoableCommand::commandName,
-                                ClearAllReferencesUndoableCommand::commandName);            
+                                ClearAllReferencesUndoableCommand::commandName);
         }
     }
     else {
@@ -372,7 +377,7 @@ Ufe::UndoableCommand::Ptr UsdContextOps::doOpCmd(const ItemPath& itemPath)
             return nullptr;
 
         return std::make_shared<AddReferenceUndoableCommand>(
-            fPrim, path);        
+            fPrim, path);
     }
     else if (itemPath[0] == ClearAllReferencesUndoableCommand::commandName) {
         MString confirmation = MGlobal::executeCommandStringResult(clearAllReferencesConfirmScript);
@@ -380,7 +385,6 @@ Ufe::UndoableCommand::Ptr UsdContextOps::doOpCmd(const ItemPath& itemPath)
             return nullptr;
 
         return std::make_shared<ClearAllReferencesUndoableCommand>(fPrim);
-        
     }
 
     return nullptr;

--- a/lib/mayaUsd/ufe/UsdHierarchy.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchy.cpp
@@ -32,7 +32,7 @@
 
 #include <mayaUsdUtils/util.h>
 
-#include "private/InPathChange.h"
+#include "private/UfeNotifGuard.h"
 #include "private/Utils.h"
 
 #ifdef UFE_V2_FEATURES_AVAILABLE

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
@@ -15,7 +15,7 @@
 //
 
 #include "UsdUndoInsertChildCommand.h"
-#include "private/InPathChange.h"
+#include "private/UfeNotifGuard.h"
 #include "private/Utils.h"
 #include "Utils.h"
 

--- a/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
@@ -31,7 +31,7 @@
 
 #include <mayaUsdUtils/util.h>
 
-#include "private/InPathChange.h"
+#include "private/UfeNotifGuard.h"
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 #define UFE_ENABLE_ASSERTS

--- a/lib/mayaUsd/ufe/private/UfeNotifGuard.h
+++ b/lib/mayaUsd/ufe/private/UfeNotifGuard.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef UFENOTIFGUARD_H
+#define UFENOTIFGUARD_H
 
 #include <mayaUsd/base/api.h>
 
@@ -24,8 +25,8 @@ namespace ufe {
 class InPathChange
 {
 public:
-	InPathChange() { fInPathChange = true; }
-	~InPathChange() { fInPathChange = false; }
+	InPathChange() { inGuard = true; }
+	~InPathChange() { inGuard = false; }
 
 	// Delete the copy/move constructors assignment operators.
 	InPathChange(const InPathChange&) = delete;
@@ -33,11 +34,33 @@ public:
 	InPathChange(InPathChange&&) = delete;
 	InPathChange& operator=(InPathChange&&) = delete;
 
-	static bool inPathChange() { return fInPathChange; }
+	static bool inPathChange() { return inGuard; }
 
 private:
-	static bool fInPathChange;
+	static bool inGuard;
 };
+
+//! \brief Helper class to scope when we are in an add or remove reference operation.
+class InAddOrRemoveReference
+{
+public:
+	InAddOrRemoveReference() { inGuard = true; }
+	~InAddOrRemoveReference() { inGuard = false; }
+
+	// Delete the copy/move constructors assignment operators.
+	InAddOrRemoveReference(const InAddOrRemoveReference&) = delete;
+	InAddOrRemoveReference& operator=(const InAddOrRemoveReference&) = delete;
+	InAddOrRemoveReference(InAddOrRemoveReference&&) = delete;
+	InAddOrRemoveReference& operator=(InAddOrRemoveReference&&) = delete;
+
+	static bool inAddOrRemoveReference() { return inGuard; }
+
+private:
+	static bool inGuard;
+};
+
 
 } // namespace ufe
 } // namespace MayaUsd
+
+#endif // UFENOTIFGUARD_H


### PR DESCRIPTION
#### MAYA-105442 - Add reference is not updated in the Outliner
* New helper class to know when we are in an add or remove reference operation. Send UFE subtree invaliate notif for USD ObjectsChanged when we are in add/remove reference.