### PR TITLE
MAYA-104967 mel commands for Undo/Redo USD target change and sublayer edits

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from __future__ import print_function
 
 from distutils.spawn import find_executable

--- a/lib/mayaUsd/commands/CMakeLists.txt
+++ b/lib/mayaUsd/commands/CMakeLists.txt
@@ -6,12 +6,16 @@ target_sources(${PROJECT_NAME}
         baseExportCommand.cpp
         baseImportCommand.cpp
         baseListShadingModesCommand.cpp
+        editTargetCommand.cpp
+        layerEditorCommand.cpp
 )
 
 set(HEADERS
         baseExportCommand.h
         baseImportCommand.h
         baseListShadingModesCommand.h
+        editTargetCommand.h
+        layerEditorCommand.h
 )
 
 # -----------------------------------------------------------------------------

--- a/lib/mayaUsd/commands/editTargetCommand.cpp
+++ b/lib/mayaUsd/commands/editTargetCommand.cpp
@@ -1,0 +1,198 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//ı
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "editTargetCommand.h"
+
+#include <mayaUsd/utils/query.h>
+
+#include <pxr/usd/usd/prim.h>
+#include <pxr/usd/usd/stage.h>
+
+#include <maya/MArgParser.h>
+#include <maya/MGlobal.h>
+#include <maya/MStringArray.h>
+#include <maya/MSyntax.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace {
+const char kTargetFlag[] = "et";
+const char kTargetFlagL[] = "editTarget";
+
+void reportError(const MString& errorString) { MGlobal::displayError(errorString); }
+
+} // namespace
+
+namespace MAYAUSD_NS {
+
+namespace Impl {
+class SetEditTarget {
+public:
+    bool doIt(UsdStagePtr stage)
+    {
+        auto layerHandle = SdfLayer::Find(_newTarget);
+        if (!layerHandle) {
+            return false;
+        }
+
+        auto currentTarget = stage->GetEditTarget().GetLayer();
+        if (currentTarget) {
+            _oldTarget = currentTarget->GetIdentifier();
+        }
+
+        stage->SetEditTarget(layerHandle);
+        return true;
+    }
+    void undoIt(UsdStagePtr stage)
+    {
+        SdfLayerHandle layerToSet = stage->GetRootLayer();
+        if (!_oldTarget.empty()) {
+            auto oldLayer = SdfLayer::Find(_oldTarget);
+            if (oldLayer) {
+                layerToSet = oldLayer;
+            }
+        }
+        stage->SetEditTarget(layerToSet);
+    }
+
+    std::string _newTarget;
+    std::string _oldTarget;
+};
+} // namespace Impl
+
+const char EditTargetCommand::commandName[] = "mayaUsdEditTarget";
+
+// plug-in callback to create the command object
+void* EditTargetCommand::creator()
+{
+    return static_cast<MPxCommand*>(new EditTargetCommand());
+}
+
+// plug-in callback to register the command syntax
+MSyntax EditTargetCommand::createSyntax()
+{
+    MSyntax syntax;
+
+    syntax.enableQuery(true);
+    syntax.enableEdit(true);
+
+    // proxy shape name
+    syntax.setObjectType(MSyntax::kStringObjects, 1, 1);
+
+    syntax.addFlag(kTargetFlag, kTargetFlagL, MSyntax::kString);
+
+    return syntax;
+}
+
+// private argument parsing helper
+MStatus EditTargetCommand::parseArgs(const MArgList& argList)
+{
+    setCommandString(commandName);
+
+    MStatus    status;
+    MArgParser argParser(syntax(), argList, &status);
+    if (status != MS::kSuccess) {
+        return MS::kInvalidParameter;
+    }
+    if (argParser.isQuery()) {
+        _cmdMode = Mode::kQuery;
+    } else if (argParser.isEdit()) {
+        _cmdMode = Mode::kEdit;
+    } else {
+        _cmdMode = Mode::kCreate;
+    }
+
+    MStringArray objects;
+    argParser.getObjects(objects);
+    _proxyShapePath = objects[0];
+
+    auto prim = UsdMayaQuery::GetPrim(_proxyShapePath.asChar());
+    if (prim == UsdPrim()) {
+        reportError(MString("Invalid proxy shape \"") + MString(_proxyShapePath.asChar()) + "\"");
+        return MS::kInvalidParameter;
+    }
+
+    if (isQuery()) {
+        MStringArray results;
+        if (argParser.isFlagSet(kTargetFlag)) {
+            auto stage = prim.GetStage();
+            auto target = stage->GetEditTarget();
+            auto layer = target.GetLayer();
+            layer->GetIdentifier();
+            results.append(layer->GetIdentifier().c_str());
+        }
+
+        setResult(results);
+    } else {
+        if (argParser.isFlagSet(kTargetFlag)) {
+            _setEditTarget = std::make_unique<Impl::SetEditTarget>();
+            _setEditTarget->_newTarget = argParser.flagArgumentString(kTargetFlag, 0).asChar();
+        }
+    }
+
+    return MS::kSuccess;
+}
+
+// MPxCommand undo ability callback
+bool EditTargetCommand::isUndoable() const { return !isQuery(); }
+
+// main MPxCommand execution point
+MStatus EditTargetCommand::doIt(const MArgList& argList)
+{
+    MStatus status(MS::kSuccess);
+    clearResult();
+
+    status = parseArgs(argList);
+    if (status != MS::kSuccess)
+        return status;
+
+    return redoIt();
+}
+
+// main MPxCommand execution point
+MStatus EditTargetCommand::redoIt()
+{
+    auto prim = UsdMayaQuery::GetPrim(_proxyShapePath.asChar());
+    auto stage = prim.GetStage();
+    if (!stage) {
+        return MS::kInvalidParameter;
+    }
+
+    if (_setEditTarget) {
+        if (!_setEditTarget->doIt(stage))
+            return MS::kFailure;
+    }
+
+    return MS::kSuccess;
+}
+
+// main MPxCommand execution point
+MStatus EditTargetCommand::undoIt()
+{
+    auto prim = UsdMayaQuery::GetPrim(_proxyShapePath.asChar());
+    auto stage = prim.GetStage();
+    if (!stage) {
+        return MS::kInvalidParameter;
+    }
+
+    if (_setEditTarget) {
+        _setEditTarget->undoIt(stage);
+    }
+
+    return MS::kSuccess;
+}
+
+} //  namespace MAYAUSD_NS

--- a/lib/mayaUsd/commands/editTargetCommand.h
+++ b/lib/mayaUsd/commands/editTargetCommand.h
@@ -1,0 +1,55 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <mayaUsd/mayaUsd.h>
+
+#include <maya/MPxCommand.h>
+#include <maya/MString.h>
+
+#include <memory>
+#include <string>
+
+namespace MAYAUSD_NS {
+
+namespace Impl {
+class SetEditTarget;
+}
+
+class EditTargetCommand : public MPxCommand {
+public:
+    // plugin registration requirements
+    static const char commandName[];
+    static void*      creator();
+    static MSyntax    createSyntax();
+
+    // MPxCommand callbacks
+    MStatus doIt(const MArgList& argList) override;
+    MStatus undoIt() override;
+    MStatus redoIt() override;
+    bool    isUndoable() const override;
+
+private:
+    MStatus parseArgs(const MArgList& argList);
+
+    enum class Mode { kCreate, kEdit, kQuery } _cmdMode = Mode::kCreate;
+    bool isEdit() const { return _cmdMode == Mode::kEdit; }
+    bool isQuery() const { return _cmdMode == Mode::kQuery; }
+
+    MString                              _proxyShapePath;
+    std::unique_ptr<Impl::SetEditTarget> _setEditTarget;
+};
+
+} // namespace MAYAUSD_NS

--- a/lib/mayaUsd/commands/editTargetCommand.h
+++ b/lib/mayaUsd/commands/editTargetCommand.h
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+#include <mayaUsd/base/api.h>
 #include <mayaUsd/mayaUsd.h>
 
 #include <maya/MPxCommand.h>
@@ -28,7 +29,7 @@ namespace Impl {
 class SetEditTarget;
 }
 
-class EditTargetCommand : public MPxCommand {
+class MAYAUSD_CORE_PUBLIC EditTargetCommand : public MPxCommand {
 public:
     // plugin registration requirements
     static const char commandName[];

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -106,17 +106,17 @@ public:
     {
         if (_cmdId == CmdId::kInsert || _cmdId == CmdId::kAddAnonLayer) {
             if (_index == -1) {
-                _index = layer->GetNumSubLayerPaths();
+                _index = (int)layer->GetNumSubLayerPaths();
             }
             if (_index != 0) {
-                if (_index < 0 || _index >= layer->GetNumSubLayerPaths()) {
+                if (_index < 0 || _index >= (int)layer->GetNumSubLayerPaths()) {
                     return false;
                 }
             }
             layer->InsertSubLayerPath(_subPath, _index);
             TF_VERIFY(layer->GetSubLayerPaths()[_index] == _subPath);
         } else {
-            if (_index < 0 || _index >= layer->GetNumSubLayerPaths()) {
+            if (_index < 0 || _index >= (int)layer->GetNumSubLayerPaths()) {
                 return false;
             }
             _subPath = layer->GetSubLayerPaths()[_index];
@@ -167,7 +167,7 @@ public:
     bool doIt(SdfLayerHandle layer) override
     {
         auto proxy = layer->GetSubLayerPaths();
-        if (proxy.Find(_oldPath) == -1) {
+        if (proxy.Find(_oldPath) == size_t(-1)) {
             std::string message = std::string("path ") + _oldPath
                 + std::string(" not found on layer ") + layer->GetIdentifier();
             MGlobal::displayError(message.c_str());

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -329,7 +329,7 @@ MStatus LayerEditorCommand::parseArgs(const MArgList& argList)
         if (argParser.isFlagSet(kInsertSubPathFlag)) {
             auto count = argParser.numberOfFlagUses(kInsertSubPathFlag);
             for (unsigned i = 0; i < count; i++) {
-                auto cmd = std::make_unique<Impl::InsertSubPath>();
+                auto cmd = std::make_shared<Impl::InsertSubPath>();
 
                 MArgList listOfArgs;
                 argParser.getFlagArgumentList(kInsertSubPathFlag, i, listOfArgs);
@@ -342,7 +342,7 @@ MStatus LayerEditorCommand::parseArgs(const MArgList& argList)
         if (argParser.isFlagSet(kRemoveSubPathFlag)) {
             auto count = argParser.numberOfFlagUses(kRemoveSubPathFlag);
             for (unsigned i = 0; i < count; i++) {
-                auto cmd = std::make_unique<Impl::RemoveSubPath>();
+                auto cmd = std::make_shared<Impl::RemoveSubPath>();
 
                 MArgList listOfArgs;
                 argParser.getFlagArgumentList(kRemoveSubPathFlag, i, listOfArgs);
@@ -354,7 +354,7 @@ MStatus LayerEditorCommand::parseArgs(const MArgList& argList)
         if (argParser.isFlagSet(kReplaceSubPathFlag)) {
             auto count = argParser.numberOfFlagUses(kReplaceSubPathFlag);
             for (unsigned i = 0; i < count; i++) {
-                auto cmd = std::make_unique<Impl::ReplaceSubPath>();
+                auto cmd = std::make_shared<Impl::ReplaceSubPath>();
 
                 MArgList listOfArgs;
                 argParser.getFlagArgumentList(kReplaceSubPathFlag, i, listOfArgs);
@@ -365,19 +365,19 @@ MStatus LayerEditorCommand::parseArgs(const MArgList& argList)
         }
 
         if (argParser.isFlagSet(kDiscardEditsFlag)) {
-            auto cmd = std::make_unique<Impl::DiscardEdit>();
+            auto cmd = std::make_shared<Impl::DiscardEdit>();
             _subCommands.push_back(std::move(cmd));
         }
 
         if (argParser.isFlagSet(kClearLayerFlag)) {
-            auto cmd = std::make_unique<Impl::ClearLayer>();
+            auto cmd = std::make_shared<Impl::ClearLayer>();
             _subCommands.push_back(std::move(cmd));
         }
 
         if (argParser.isFlagSet(kAddAnonSublayerFlag)) {
             auto count = argParser.numberOfFlagUses(kAddAnonSublayerFlag);
             for (unsigned i = 0; i < count; i++) {
-                auto cmd = std::make_unique<Impl::AddAnonSubLayer>();
+                auto cmd = std::make_shared<Impl::AddAnonSubLayer>();
 
                 MArgList listOfArgs;
                 argParser.getFlagArgumentList(kAddAnonSublayerFlag, i, listOfArgs);

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -1,0 +1,449 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//ı
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "layerEditorCommand.h"
+
+#include <mayaUsd/utils/query.h>
+
+#include <maya/MArgList.h>
+#include <maya/MArgParser.h>
+#include <maya/MGlobal.h>
+#include <maya/MStringArray.h>
+#include <maya/MSyntax.h>
+
+#include <pxr/base/tf/diagnostic.h>
+
+#include <cstddef>
+#include <string>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace {
+const char kInsertSubPathFlag[] = "is";
+const char kInsertSubPathFlagL[] = "insertSubPath";
+const char kRemoveSubPathFlag[] = "rs";
+const char kRemoveSubPathFlagL[] = "removeSubPath";
+const char kReplaceSubPathFlag[] = "rp";
+const char kReplaceSubPathFlagL[] = "replaceSubPath";
+const char kDiscardEditsFlag[] = "de";
+const char kDiscardEditsFlagL[] = "discardEdits";
+const char kClearLayerFlag[] = "cl";
+const char kClearLayerFlagL[] = "clear";
+const char kAddAnonSublayerFlag[] = "aa";
+const char kAddAnonSublayerFlagL[] = "addAnonymous";
+
+} // namespace
+
+namespace MAYAUSD_NS {
+
+namespace Impl {
+
+enum class CmdId { kInsert, kRemove, kReplace, kDiscardEdit, kClearLayer, kAddAnonLayer };
+
+class BaseCmd {
+public:
+    BaseCmd(CmdId id)
+        : _cmdId(id)
+    {
+    }
+    virtual ~BaseCmd() { }
+    virtual bool doIt(SdfLayerHandle layer) = 0;
+    virtual void undoIt(SdfLayerHandle layer) = 0;
+
+    std::string _cmdResult; // set if the command returns something
+
+protected:
+    CmdId _cmdId;
+    // we need to hold on to dirty sublayers if we remove them
+    std::vector<PXR_NS::SdfLayerRefPtr> _subLayersRefs;
+    void                                holdOntoSubLayers(SdfLayerHandle layer);
+    void                                releaseSubLayers() { _subLayersRefs.clear(); }
+    void                                holdOnPathIfDirty(SdfLayerHandle layer, std::string path);
+};
+
+void BaseCmd::holdOnPathIfDirty(SdfLayerHandle layer, std::string path)
+{
+    auto subLayerHandle = SdfLayer::FindRelativeToLayer(layer, path);
+    if (subLayerHandle != nullptr) {
+        if (subLayerHandle->IsDirty() || subLayerHandle->IsAnonymous()) {
+            _subLayersRefs.push_back(subLayerHandle);
+            holdOntoSubLayers(subLayerHandle); // we'll need to hold onto children as well
+        }
+    }
+}
+
+// hold references to any anon or dirty sublayer
+void BaseCmd::holdOntoSubLayers(SdfLayerHandle layer)
+{
+    const std::vector<std::string>& sublayers = layer->GetSubLayerPaths();
+    for (auto path : sublayers) { holdOnPathIfDirty(layer, path); }
+}
+
+class InsertRemoveSubPathBase : public BaseCmd {
+public:
+    int         _index = -1;
+    std::string _subPath;
+
+    InsertRemoveSubPathBase(CmdId id)
+        : BaseCmd(id)
+    {
+    }
+
+    bool doIt(SdfLayerHandle layer) override
+    {
+        if (_cmdId == CmdId::kInsert || _cmdId == CmdId::kAddAnonLayer) {
+            if (_index == -1) {
+                _index = layer->GetNumSubLayerPaths();
+            }
+            if (_index != 0) {
+                if (_index < 0 || _index >= layer->GetNumSubLayerPaths()) {
+                    return false;
+                }
+            }
+            layer->InsertSubLayerPath(_subPath, _index);
+            TF_VERIFY(layer->GetSubLayerPaths()[_index] == _subPath);
+        } else {
+            if (_index < 0 || _index >= layer->GetNumSubLayerPaths()) {
+                return false;
+            }
+            _subPath = layer->GetSubLayerPaths()[_index];
+            holdOnPathIfDirty(layer, _subPath);
+            layer->RemoveSubLayerPath(_index);
+        }
+        return true;
+    }
+    void undoIt(SdfLayerHandle layer) override
+    {
+        if (_cmdId == CmdId::kInsert || _cmdId == CmdId::kAddAnonLayer) {
+            auto index = _index;
+            if (index == -1) {
+                index = static_cast<int>(layer->GetNumSubLayerPaths() - 1);
+            }
+            TF_VERIFY(layer->GetSubLayerPaths()[index] == _subPath);
+            layer->RemoveSubLayerPath(index);
+        } else {
+            TF_VERIFY(_index != -1);
+            layer->InsertSubLayerPath(_subPath, _index);
+        }
+    }
+};
+
+class InsertSubPath : public InsertRemoveSubPathBase {
+public:
+    InsertSubPath()
+        : InsertRemoveSubPathBase(CmdId::kInsert)
+    {
+    }
+};
+
+class RemoveSubPath : public InsertRemoveSubPathBase {
+public:
+    RemoveSubPath()
+        : InsertRemoveSubPathBase(CmdId::kRemove)
+    {
+    }
+};
+
+class ReplaceSubPath : public BaseCmd {
+public:
+    ReplaceSubPath()
+        : BaseCmd(CmdId::kReplace)
+    {
+    }
+
+    bool doIt(SdfLayerHandle layer) override
+    {
+        auto proxy = layer->GetSubLayerPaths();
+        if (proxy.Find(_oldPath) == -1) {
+            std::string message = std::string("path ") + _oldPath
+                + std::string(" not found on layer ") + layer->GetIdentifier();
+            MGlobal::displayError(message.c_str());
+            return false;
+        }
+
+        holdOnPathIfDirty(layer, _oldPath);
+        proxy.Replace(_oldPath, _newPath);
+        return true;
+    }
+
+    void undoIt(SdfLayerHandle layer) override
+    {
+        auto proxy = layer->GetSubLayerPaths();
+        proxy.Replace(_newPath, _oldPath);
+        releaseSubLayers();
+        holdOnPathIfDirty(layer, _newPath);
+    }
+
+    std::string _oldPath, _newPath;
+};
+
+class AddAnonSubLayer : public InsertRemoveSubPathBase {
+public:
+    AddAnonSubLayer()
+        : InsertRemoveSubPathBase(CmdId::kAddAnonLayer) {};
+
+    bool doIt(SdfLayerHandle layer) override
+    {
+        _anonLayer = SdfLayer::CreateAnonymous(_anonName);
+        _subPath = _anonLayer->GetIdentifier();
+        _index = 0;
+        _cmdResult = _subPath;
+        return InsertRemoveSubPathBase::doIt(layer);
+    }
+
+    void undoIt(SdfLayerHandle layer) override
+    {
+        InsertRemoveSubPathBase::undoIt(layer);
+        _anonLayer = nullptr;
+    }
+
+    std::string _anonName;
+
+protected:
+    PXR_NS::SdfLayerRefPtr _anonLayer;
+};
+
+class BackupLayerBase : public BaseCmd {
+    // commands that need to backup the whole layer for undo
+public:
+    BackupLayerBase(CmdId id)
+        : BaseCmd(id)
+    {
+    }
+
+    bool doIt(SdfLayerHandle layer) override
+    {
+        // using reload will correctly reset the dirty bit
+        if (layer->IsDirty()) {
+            _backupLayer = SdfLayer::CreateAnonymous();
+            _backupLayer->TransferContent(layer);
+        }
+        holdOntoSubLayers(layer);
+
+        if (_cmdId == CmdId::kDiscardEdit) {
+            layer->Reload();
+        } else if (_cmdId == CmdId::kClearLayer) {
+            layer->Clear();
+        }
+        return true;
+    }
+    void undoIt(SdfLayerHandle layer) override
+    {
+        if (_backupLayer == nullptr) {
+            layer->Reload();
+        } else {
+            layer->TransferContent(_backupLayer);
+            _backupLayer = nullptr;
+            releaseSubLayers();
+        }
+    }
+
+    // we need to hold onto the layer if we dirty it
+    PXR_NS::SdfLayerRefPtr _backupLayer;
+};
+
+class DiscardEdit : public BackupLayerBase {
+public:
+    DiscardEdit()
+        : BackupLayerBase(CmdId::kDiscardEdit)
+    {
+    }
+};
+
+class ClearLayer : public BackupLayerBase {
+public:
+    ClearLayer()
+        : BackupLayerBase(CmdId::kClearLayer)
+    {
+    }
+};
+
+} // namespace Impl
+
+const char LayerEditorCommand::commandName[] = "mayaUsdLayerEditor";
+
+// plug-in callback to create the command object
+void* LayerEditorCommand::creator() { return static_cast<MPxCommand*>(new LayerEditorCommand()); }
+
+// plug-in callback to register the command syntax
+MSyntax LayerEditorCommand::createSyntax()
+{
+    MSyntax syntax;
+
+    // syntax.enableQuery(true);
+    syntax.enableEdit(true);
+
+    // layer id
+    syntax.setObjectType(MSyntax::kStringObjects, 1, 1);
+
+    syntax.addFlag(kInsertSubPathFlag, kInsertSubPathFlagL, MSyntax::kLong, MSyntax::kString);
+    syntax.makeFlagMultiUse(kInsertSubPathFlag);
+    syntax.addFlag(kRemoveSubPathFlag, kRemoveSubPathFlagL, MSyntax::kLong);
+    syntax.makeFlagMultiUse(kRemoveSubPathFlag);
+    syntax.addFlag(kReplaceSubPathFlag, kReplaceSubPathFlagL, MSyntax::kString, MSyntax::kString);
+    syntax.makeFlagMultiUse(kReplaceSubPathFlag);
+    syntax.addFlag(kDiscardEditsFlag, kDiscardEditsFlagL);
+    syntax.addFlag(kClearLayerFlag, kClearLayerFlagL);
+    syntax.addFlag(kAddAnonSublayerFlag, kAddAnonSublayerFlagL, MSyntax::kString);
+    syntax.makeFlagMultiUse(kAddAnonSublayerFlag);
+
+    return syntax;
+}
+
+// private argument parsing helper
+MStatus LayerEditorCommand::parseArgs(const MArgList& argList)
+{
+    setCommandString(commandName);
+
+    MStatus    status;
+    MArgParser argParser(syntax(), argList, &status);
+    if (status != MS::kSuccess) {
+        return MS::kInvalidParameter;
+    }
+    if (argParser.isQuery()) {
+        _cmdMode = Mode::Query;
+    } else if (argParser.isEdit()) {
+        _cmdMode = Mode::Edit;
+    } else {
+        _cmdMode = Mode::Create;
+    }
+
+    MStringArray objects;
+    argParser.getObjects(objects);
+    _layerIdentifier = objects[0].asChar();
+
+    if (!isQuery()) {
+        if (argParser.isFlagSet(kInsertSubPathFlag)) {
+            auto count = argParser.numberOfFlagUses(kInsertSubPathFlag);
+            for (unsigned i = 0; i < count; i++) {
+                auto cmd = std::make_unique<Impl::InsertSubPath>();
+
+                MArgList listOfArgs;
+                argParser.getFlagArgumentList(kInsertSubPathFlag, i, listOfArgs);
+                cmd->_index = listOfArgs.asInt(0);
+                cmd->_subPath = listOfArgs.asString(1).asUTF8();
+                _subCommands.push_back(std::move(cmd));
+            }
+        }
+
+        if (argParser.isFlagSet(kRemoveSubPathFlag)) {
+            auto count = argParser.numberOfFlagUses(kRemoveSubPathFlag);
+            for (unsigned i = 0; i < count; i++) {
+                auto cmd = std::make_unique<Impl::RemoveSubPath>();
+
+                MArgList listOfArgs;
+                argParser.getFlagArgumentList(kRemoveSubPathFlag, i, listOfArgs);
+                cmd->_index = listOfArgs.asInt(0);
+                _subCommands.push_back(std::move(cmd));
+            }
+        }
+
+        if (argParser.isFlagSet(kReplaceSubPathFlag)) {
+            auto count = argParser.numberOfFlagUses(kReplaceSubPathFlag);
+            for (unsigned i = 0; i < count; i++) {
+                auto cmd = std::make_unique<Impl::ReplaceSubPath>();
+
+                MArgList listOfArgs;
+                argParser.getFlagArgumentList(kReplaceSubPathFlag, i, listOfArgs);
+                cmd->_oldPath = listOfArgs.asString(0).asUTF8();
+                cmd->_newPath = listOfArgs.asString(1).asUTF8();
+                _subCommands.push_back(std::move(cmd));
+            }
+        }
+
+        if (argParser.isFlagSet(kDiscardEditsFlag)) {
+            auto cmd = std::make_unique<Impl::DiscardEdit>();
+            _subCommands.push_back(std::move(cmd));
+        }
+
+        if (argParser.isFlagSet(kClearLayerFlag)) {
+            auto cmd = std::make_unique<Impl::ClearLayer>();
+            _subCommands.push_back(std::move(cmd));
+        }
+
+        if (argParser.isFlagSet(kAddAnonSublayerFlag)) {
+            auto count = argParser.numberOfFlagUses(kAddAnonSublayerFlag);
+            for (unsigned i = 0; i < count; i++) {
+                auto cmd = std::make_unique<Impl::AddAnonSubLayer>();
+
+                MArgList listOfArgs;
+                argParser.getFlagArgumentList(kAddAnonSublayerFlag, i, listOfArgs);
+                cmd->_anonName = listOfArgs.asString(0).asUTF8();
+                _subCommands.push_back(std::move(cmd));
+            }
+        }
+    }
+
+    return MS::kSuccess;
+}
+
+// MPxCommand undo ability callback
+bool LayerEditorCommand::isUndoable() const { return !isQuery(); }
+
+// main MPxCommand execution point
+MStatus LayerEditorCommand::doIt(const MArgList& argList)
+{
+    MStatus status(MS::kSuccess);
+    clearResult();
+
+    status = parseArgs(argList);
+    if (status != MS::kSuccess)
+        return status;
+
+    return redoIt();
+}
+
+// main MPxCommand execution point
+MStatus LayerEditorCommand::redoIt()
+{
+
+    auto layer = SdfLayer::FindOrOpen(_layerIdentifier);
+    if (!layer) {
+        return MS::kInvalidParameter;
+    }
+
+    for (auto it = _subCommands.begin(); it != _subCommands.end(); ++it) {
+        if (!(*it)->doIt(layer)) {
+            return MS::kFailure;
+        }
+        const auto& result = (*it)->_cmdResult;
+        if (!result.empty()) {
+            appendToResult(result.c_str());
+        }
+    }
+
+    return MS::kSuccess;
+}
+
+// main MPxCommand execution point
+MStatus LayerEditorCommand::undoIt()
+{
+
+    auto layer = SdfLayer::FindOrOpen(_layerIdentifier);
+    if (!layer) {
+        return MS::kInvalidParameter;
+    }
+
+    // clang-format off
+    for (auto it = _subCommands.rbegin(); it != _subCommands.rend(); ++it) { 
+        (*it)->undoIt(layer); 
+    }
+
+    // clang-format on
+    return MS::kSuccess;
+}
+
+} // namespace MAYAUSD_NS

--- a/lib/mayaUsd/commands/layerEditorCommand.h
+++ b/lib/mayaUsd/commands/layerEditorCommand.h
@@ -53,7 +53,7 @@ private:
     bool isQuery() const { return _cmdMode == Mode::Query; }
 
     std::string                                 _layerIdentifier;
-    std::vector<std::unique_ptr<Impl::BaseCmd>> _subCommands;
+    std::vector<std::shared_ptr<Impl::BaseCmd>> _subCommands;
 };
 
 } // namespace MAYAUSD_NS

--- a/lib/mayaUsd/commands/layerEditorCommand.h
+++ b/lib/mayaUsd/commands/layerEditorCommand.h
@@ -1,0 +1,58 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <mayaUsd/mayaUsd.h>
+
+#include <maya/MPxCommand.h>
+#include <maya/MString.h>
+
+#include <pxr/usd/sdf/layer.h>
+
+#include <memory>
+#include <vector>
+#include <string>
+
+namespace MAYAUSD_NS {
+
+namespace Impl {
+class BaseCmd;
+}
+
+class LayerEditorCommand : public MPxCommand {
+public:
+    // plugin registration requirements
+    static const char commandName[];
+    static void*      creator();
+    static MSyntax    createSyntax();
+
+    // MPxCommand callbacks
+    MStatus doIt(const MArgList& argList) override;
+    MStatus undoIt() override;
+    MStatus redoIt() override;
+    bool    isUndoable() const override;
+
+private:
+    MStatus parseArgs(const MArgList& argList);
+
+    enum class Mode { Create, Edit, Query } _cmdMode = Mode::Create;
+    bool isEdit() const { return _cmdMode == Mode::Edit; }
+    bool isQuery() const { return _cmdMode == Mode::Query; }
+
+    std::string          _layerIdentifier;
+    std::vector<std::unique_ptr<Impl::BaseCmd>> _subCommands;
+};
+
+} // namespace MAYAUSD_NS

--- a/lib/mayaUsd/commands/layerEditorCommand.h
+++ b/lib/mayaUsd/commands/layerEditorCommand.h
@@ -14,16 +14,17 @@
 // limitations under the License.
 //
 
+#include <mayaUsd/base/api.h>
 #include <mayaUsd/mayaUsd.h>
+
+#include <pxr/usd/sdf/layer.h>
 
 #include <maya/MPxCommand.h>
 #include <maya/MString.h>
 
-#include <pxr/usd/sdf/layer.h>
-
 #include <memory>
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace MAYAUSD_NS {
 
@@ -31,7 +32,7 @@ namespace Impl {
 class BaseCmd;
 }
 
-class LayerEditorCommand : public MPxCommand {
+class MAYAUSD_CORE_PUBLIC LayerEditorCommand : public MPxCommand {
 public:
     // plugin registration requirements
     static const char commandName[];
@@ -51,7 +52,7 @@ private:
     bool isEdit() const { return _cmdMode == Mode::Edit; }
     bool isQuery() const { return _cmdMode == Mode::Query; }
 
-    std::string          _layerIdentifier;
+    std::string                                 _layerIdentifier;
     std::vector<std::unique_ptr<Impl::BaseCmd>> _subCommands;
 };
 

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -4,6 +4,7 @@ set(TARGET_NAME MAYAUSD_TEST)
 set(TEST_SCRIPT_FILES
     testMayaUsdConverter.py
     testMayaUsdPythonImport.py
+    testMayaUsdLayerEditorCommands.py
 )
 
 if (MAYA_APP_VERSION VERSION_GREATER 2020)

--- a/test/lib/testMayaUsdLayerEditorCommands.py
+++ b/test/lib/testMayaUsdLayerEditorCommands.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2020 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+from maya import cmds
+import mayaUsd_createStageWithNewLayer
+import mayaUsd
+from pxr import Sdf, Usd
+
+CLEAR = "-clear"
+DISCARD = "-discardEdits"
+PROXY_NODE_TYPE = "mayaUsdProxyShapeBase"
+
+DUMMY_FILE_TEXT = \
+"""#usda 1.0
+def Sphere "ball"
+    {
+        custom string Winner = "shotFX"
+    }
+"""
+
+def getCleanMayaStage():
+    """ gets a stage that only has an anon layer """
+
+    cmds.file(new=True, force=True)
+    mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+
+    proxyShapes = cmds.ls(type=PROXY_NODE_TYPE, long=True)
+    shapePath = proxyShapes[0]
+    stage = mayaUsd.lib.GetPrim(shapePath).GetStage()
+    return shapePath, stage
+
+class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
+    """ test mel commands intended for the layer editor """
+
+    @classmethod
+    def setUpClass(cls):
+        cmds.loadPlugin('mayaUsdPlugin')
+
+
+    def testEditTarget(self):
+        """ tests 'mayaUsdEditTarget' command, but also touches on adding anon layers """
+        shapePath, stage = getCleanMayaStage()
+
+        # original target is the root anonymous layer
+        originalTargetID = stage.GetEditTarget().GetLayer().identifier
+        rootLayer = stage.GetRootLayer()
+        self.assertEqual(originalTargetID, rootLayer.identifier)
+
+        currentTargetID = cmds.mayaUsdEditTarget(shapePath, query=True, editTarget=True)[0]
+        self.assertEqual(originalTargetID, currentTargetID)
+
+        # add two sub layers
+        redLayerId = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="redLayer")[0]
+        greenLayerId = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="greenLayer")[0]
+        self.assertEqual(len(rootLayer.subLayerPaths), 2)
+
+        cmds.mayaUsdEditTarget(shapePath, edit=True, editTarget=greenLayerId)
+        self.assertEqual(stage.GetEditTarget().GetLayer().identifier, greenLayerId)
+        # do we return that new target?
+        self.assertEqual(stage.GetEditTarget().GetLayer().identifier, cmds.mayaUsdEditTarget(shapePath, query=True, editTarget=True)[0])
+        undoStepTwo = greenLayerId
+
+        cmds.mayaUsdEditTarget(shapePath, edit=True, editTarget=redLayerId)
+        self.assertEqual(stage.GetEditTarget().GetLayer().identifier, redLayerId)
+        undoStepOne = redLayerId
+
+        # can we set the target back to the root?
+        rootLayerID = rootLayer.identifier
+        cmds.mayaUsdEditTarget(shapePath, edit=True, editTarget=rootLayerID)
+        self.assertEqual(stage.GetEditTarget().GetLayer().identifier, rootLayerID)
+
+        # undo
+        cmds.undo()
+        self.assertEqual(stage.GetEditTarget().GetLayer().identifier, undoStepOne)
+        cmds.undo()
+        self.assertEqual(stage.GetEditTarget().GetLayer().identifier, undoStepTwo)
+
+        # test bad input
+        with self.assertRaises(RuntimeError):
+            cmds.mayaUsdEditTarget("bogusShape", query=True, editTarget=True)
+
+        with self.assertRaises(RuntimeError):
+            cmds.mayaUsdEditTarget("bogusShape", edit=True, editTarget=greenLayerId)
+
+        with self.assertRaises(RuntimeError):
+            cmds.mayaUsdEditTarget(shapePath, edit=True, editTarget="bogusLayer")
+
+    def testSubLayerEditing(self):
+        """ test 'mayaUsdLayerEditor' command """
+        _shapePath, stage = getCleanMayaStage()
+        rootLayer = stage.GetRootLayer()
+
+        # -addAnonymous
+
+        # add three layers. Note: these are always added at the top
+        layer3Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer1")[0]
+        layer2Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer2")[0]
+        layer1Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer3")[0]
+
+        # check that they were added
+        addedLayers = [layer1Id, layer2Id, layer3Id]
+        self.assertEqual(rootLayer.subLayerPaths, addedLayers)
+
+        # -removeSubPath
+
+        # remove second sublayer
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, removeSubPath=1)
+        afterDeletion = [layer1Id, layer3Id]
+        self.assertEqual(rootLayer.subLayerPaths, afterDeletion)
+
+        # remove second sublayer again to leave only one
+        afterDeletion = [layer1Id, layer3Id]
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, removeSubPath=1)
+        self.assertEqual(rootLayer.subLayerPaths, [layer1Id])
+
+        # remove second sublayer  -- this time it's out of bounds
+        with self.assertRaises(RuntimeError):
+            cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, removeSubPath=1)
+
+        # undo twice to get back to three layers
+        cmds.undo()
+        cmds.undo()
+        self.assertEqual(rootLayer.subLayerPaths, addedLayers)
+        # redo deletion of second layer
+        cmds.redo()
+        self.assertEqual(rootLayer.subLayerPaths, afterDeletion)
+        cmds.undo()
+
+        # put a sub layer and a sub-sub layer on the top layer.
+        childLayerId = cmds.mayaUsdLayerEditor(layer1Id, edit=True, addAnonymous="ChildLayer")[0]
+        grandChildLayerId = cmds.mayaUsdLayerEditor(childLayerId, edit=True, addAnonymous="GrandChild")[0]
+
+        # delete the top layer.  See if it comes back after redo.
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, removeSubPath=0)
+        # check layer1 was deleted
+        self.assertEqual(rootLayer.subLayerPaths, [layer2Id, layer3Id])
+        # bring it back
+        cmds.undo()
+        firstLayer = Sdf.Layer.Find(layer1Id)
+        self.assertIsNotNone(firstLayer)
+
+        # check the children were not deleted
+        self.assertEqual(firstLayer.subLayerPaths[0], childLayerId)
+        childLayer = Sdf.Layer.Find(childLayerId)
+        self.assertEqual(childLayer.subLayerPaths[0], grandChildLayerId)
+
+        # -insertSubPath
+
+        # insert two layers
+        rootLayer.subLayerPaths.clear()
+        second = "second.usda"
+        first = "first.usda"
+        newName = "david.usda"
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[0, second])
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[0, first])
+        self.assertEqual(rootLayer.subLayerPaths, [first, second])
+
+        # bad index
+        with self.assertRaises(RuntimeError):
+            cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[-2, "bogus"])
+        with self.assertRaises(RuntimeError):
+            cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[2, "bogus"])
+
+        # -replaceSubPath
+
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, replaceSubPath=[first, newName])
+        self.assertEqual(rootLayer.subLayerPaths, [newName, second])
+        # bad replace path
+        with self.assertRaises(RuntimeError):
+            cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, replaceSubPath=["notfound", newName])
+
+        # -clear
+        # -discardEdits
+
+        testPasses = [CLEAR, DISCARD]
+        for testPass in testPasses:
+
+            if testPass == CLEAR:
+                # get a clear stage
+                rootLayer.subLayerPaths.clear()
+            if testPass == DISCARD:
+                # save and load a stage
+                filePath = "dummy.usda"
+                with open(filePath, "w") as testFile:
+                    testFile.write(DUMMY_FILE_TEXT)
+
+                newStage = Usd.Stage.Open(filePath)
+                rootLayer = newStage.GetRootLayer()
+                self.assertEqual(len(rootLayer.subLayerPaths), 0)
+
+            childLayerId = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Child")[0]
+            grandChildLayerId = cmds.mayaUsdLayerEditor(childLayerId, edit=True, addAnonymous="GrandChild")[0]
+
+            if testPass == CLEAR:
+                cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, clear=True)
+            if testPass == DISCARD:
+                cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, discardEdits=True)
+
+            # test everything is gone
+            self.assertEqual(len(rootLayer.subLayerPaths), 0)
+
+            cmds.undo() # layers are back
+            self.assertEqual(len(rootLayer.subLayerPaths), 1)
+            self.assertEqual(rootLayer.subLayerPaths[0], childLayerId)
+            cmds.redo() # cleared/discarded again
+            self.assertEqual(len(rootLayer.subLayerPaths), 0)
+            cmds.undo() # layers are back
+            self.assertEqual(rootLayer.subLayerPaths[0], childLayerId)
+            childLayer = Sdf.Layer.Find(childLayerId)
+            self.assertEqual(childLayer.subLayerPaths[0], grandChildLayerId)

--- a/test/lib/testMayaUsdLayerEditorCommands.py
+++ b/test/lib/testMayaUsdLayerEditorCommands.py
@@ -17,6 +17,7 @@
 #
 
 import unittest
+import tempfile
 from maya import cmds
 import mayaUsd_createStageWithNewLayer
 import mayaUsd
@@ -169,6 +170,8 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
         newName = "david.usda"
         cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[0, second])
         cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[0, first])
+        # message for anyone looking at the test log:
+        # It's normal for stage.cpp to print the error that it can't find second.usa and first.usda, they do not exist"
         self.assertEqual(rootLayer.subLayerPaths, [first, second])
 
         # bad index
@@ -196,11 +199,11 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
                 rootLayer.subLayerPaths.clear()
             if testPass == DISCARD:
                 # save and load a stage
-                filePath = "dummy.usda"
-                with open(filePath, "w") as testFile:
-                    testFile.write(DUMMY_FILE_TEXT)
+                testUsdFile = tempfile.NamedTemporaryFile(suffix=".usda", prefix="dummy", delete=False)
+                testUsdFile.write(DUMMY_FILE_TEXT)
+                testUsdFile.close()
 
-                newStage = Usd.Stage.Open(filePath)
+                newStage = Usd.Stage.Open(testUsdFile.name)
                 rootLayer = newStage.GetRootLayer()
                 self.assertEqual(len(rootLayer.subLayerPaths), 0)
 


### PR DESCRIPTION
MAYA-104967 Undo/Redo USD target change and sublayer edits for Maya USD Layer Editor
New MEL commands
```
Synopsis: mayaUsdEditTarget [flags] String 
Flags:
   -e -edit
   -q -query
  -et -editTarget  String
Synopsis: mayaUsdLayerEditor [flags] String 
Flags:
   -e -edit
  -aa -addAnonymous    String (multi-use)
  -cl -clear          
  -de -discardEdits   
  -is -insertSubPath   Int String (multi-use)
  -rp -replaceSubPath  String String (multi-use)
  -rs -removeSubPath   Int (multi-use)
```