### PR TITLE
MAYA-104770: Naming of stage and shape at creation are not inline with naming in Maya

### DIFF
--- a/plugin/adsk/scripts/mayaUsd_createStageWithNewLayer.py
+++ b/plugin/adsk/scripts/mayaUsd_createStageWithNewLayer.py
@@ -29,4 +29,4 @@ def createStageWithNewLayer():
     # Simply create a proxy shape. Since it does not have a USD file associated
     # (in the .filePath attribute), the proxy shape base will create an empty
     # stage in memory. This will create the session and root layer as well.
-    shapeNode = cmds.createNode('mayaUsdProxyShape', name='stageShape')
+    shapeNode = cmds.createNode('mayaUsdProxyShape', name='stageShape1')

--- a/test/lib/ufe/testContextOps.py
+++ b/test/lib/ufe/testContextOps.py
@@ -159,7 +159,7 @@ class ContextOpsTestCase(unittest.TestCase):
     @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '2015', 'testAddNewPrim only available in UFE preview version 0.2.15 and greater')
     def testAddNewPrim(self):
         # Create a ContextOps interface for the proxy shape.
-        proxyShapePath = ufe.Path([mayaUtils.createUfePathSegment("|world|stage|stageShape")])
+        proxyShapePath = ufe.Path([mayaUtils.createUfePathSegment("|world|stage1|stageShape1")])
         proxyShapeItem = ufe.Hierarchy.createItem(proxyShapePath)
         contextOps = ufe.ContextOps.contextOps(proxyShapeItem)
 


### PR DESCRIPTION
MAYA-104770: When a new stage is created, it is named "stage" instead of "stage1" and the shape is named "stageShape" instead of "stageShape1" if multiple stages are created subsequent ones contain a number for instance the next one would be "stage1" which is correct however the shape is named "stage1Shape" instead of "stageShape1"