### PR TITLE
MAYA-105764: Fix cruft in data model after re-parenting on undo/redo.

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
@@ -66,13 +66,14 @@ private:
     UsdSceneItem::Ptr _ufeSrcItem;
     UsdSceneItem::Ptr _ufeDstItem;
 
+    Ufe::Path _ufeSrcPath;
+    Ufe::Path _ufeDstPath;
+
     SdfPath _usdSrcPath;
     SdfPath _usdDstPath;
 
     SdfLayerHandle _childLayer;
     SdfLayerHandle _parentLayer;
-
-    Ufe::Path _ufeDstPath;
 
 }; // UsdUndoInsertChildCommand
 

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
@@ -61,8 +61,6 @@ private:
     bool insertChildRedo();
     bool insertChildUndo();
 
-    UsdStageWeakPtr _stage;
-
     UsdSceneItem::Ptr _ufeSrcItem;
     UsdSceneItem::Ptr _ufeDstItem;
 


### PR DESCRIPTION
## Description of the problem
Re-parenting creates cruft in the generated USD data model. This is mainly caused by the SetActive mechanism on undo/redo.

## How the new mechanism work
New mechanics doesn't use SetActive. Here are the steps during the undo/redo:

Redo:

1. Copy spec data at **srcPath** in **srcLayer** into **destPath** in **destLayer**
2. Remove **srcPath** in **srcLayer** by using "Stage::RemovePrim" 
3. Re-create **Ufe::SceneItem** and send data model change notification

Undo:

1. Copy spec data at **destPath** in **destLayer** into **srcPath** in **srcLayer**
2. Remove **destPath** in **destLayer** by using "Stage::RemovePrim" 
3. Re-create **Ufe::SceneItem** and send data model change notification

## Features

1. clean USD data model
2. undo/redo support
3. re-parenting support between multiple stages.



