### PR TITLE
Fix build script and test failures with python3 build

### DIFF
--- a/build.py
+++ b/build.py
@@ -146,7 +146,7 @@ def Run(context, cmd):
                 if l != "":
                     # Avoid "UnicodeEncodeError: 'ascii' codec can't encode 
                     # character" errors by serializing utf8 byte strings.
-                    logfile.write(l.encode("utf8"))
+                    logfile.write(str(l.encode("utf8")))
                     PrintCommandOutput(l)
                 elif p.poll() is not None:
                     break

--- a/test/lib/testMayaUsdLayerEditorCommands.py
+++ b/test/lib/testMayaUsdLayerEditorCommands.py
@@ -199,7 +199,7 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
                 rootLayer.subLayerPaths.clear()
             if testPass == DISCARD:
                 # save and load a stage
-                testUsdFile = tempfile.NamedTemporaryFile(suffix=".usda", prefix="dummy", delete=False)
+                testUsdFile = tempfile.NamedTemporaryFile(suffix=".usda", prefix="dummy", delete=False, mode="w")
                 testUsdFile.write(DUMMY_FILE_TEXT)
                 testUsdFile.close()
 


### PR DESCRIPTION
Build script was failing to run when executed with python3:
```
Traceback (most recent call last):
  File "build.py", line 602, in <module>
    BuildAndInstall(context, context.buildArgs, context.stagesArgs)
  File "build.py", line 369, in BuildAndInstall
    RunCMake(context, extraArgs, stagesArgs)
  File "build.py", line 275, in RunCMake
    extraArgs=(" ".join(extraArgs) if extraArgs else "")))
  File "build.py", line 148, in Run
    logfile.write(l.encode("utf8"))
TypeError: write() argument must be str, not bytes
```

Similarly, a new regression test `testMayaUsdLayerEditorCommands.MayaUsdLayerEditorCommandsTestCase` was failing: 
 ```
3: ======================================================================
3: ERROR: testSubLayerEditing (testMayaUsdLayerEditorCommands.MayaUsdLayerEditorCommandsTestCase)
3: test 'mayaUsdLayerEditor' command
3: ----------------------------------------------------------------------
3: Traceback (most recent call last):
3:   File "/Users/ligenzk/Dev/usd/_workspace/Maya_USD/build/RelWithDebInfo/test/lib/testMayaUsdLayerEditorCommands.py", line 203, in testSubLayerEditing
3:     testUsdFile.write(str(DUMMY_FILE_TEXT))
3:   File "/Users/ligenzk/Dev/maya/builds/main/maya/build/RelWithDebInfo/runTime/Maya.app/Contents/Frameworks/Python.framework/Versions/Current/lib/python37.zip/tempfile.py", line 481, in func_wrapper
3:     return func(*args, **kwargs)
3: TypeError: a bytes-like object is required, not 'str'
3: 
3: ----------------------------------------------------------------------
```

In both cases, we either open the stream in wrong mode or pass bytes when expecting a string. 