### PR TITLE
Fix windows build when compiling for Maya 2018 or without UFE

### DIFF
--- a/lib/mayaUsd/commands/editTargetCommand.h
+++ b/lib/mayaUsd/commands/editTargetCommand.h
@@ -29,17 +29,29 @@ namespace Impl {
 class SetEditTarget;
 }
 
-class MAYAUSD_CORE_PUBLIC EditTargetCommand : public MPxCommand {
+class EditTargetCommand : public MPxCommand {
 public:
     // plugin registration requirements
+    MAYAUSD_CORE_PUBLIC
     static const char commandName[];
+    
+    MAYAUSD_CORE_PUBLIC
     static void*      creator();
+    
+    MAYAUSD_CORE_PUBLIC
     static MSyntax    createSyntax();
 
     // MPxCommand callbacks
+    MAYAUSD_CORE_PUBLIC
     MStatus doIt(const MArgList& argList) override;
+    
+    MAYAUSD_CORE_PUBLIC
     MStatus undoIt() override;
+    
+    MAYAUSD_CORE_PUBLIC
     MStatus redoIt() override;
+    
+    MAYAUSD_CORE_PUBLIC
     bool    isUndoable() const override;
 
 private:


### PR DESCRIPTION
The compiler generates following warning as an error when building on windows for Maya 2018 (or without UFE):
```
e:\maya-usd_pr\lib\mayausd\commands\editTargetCommand.h(53): error C2220: warning treated as error - no 'object' file generated
e:\maya-usd_pr\lib\mayausd\commands\editTargetCommand.h(53): warning C4251: 'MayaUsd::EditTargetCommand::_setEditTarget': class 'std::unique_ptr<MayaUsd::Impl::SetEditTarget,std::default_delete<_Ty>>' needs to have dll-interface to be used by clients of class 'MayaUsd::EditTargetCommand'
        with
        [
            _Ty=MayaUsd::Impl::SetEditTarget
        ]
e:\maya-usd_pr\lib\mayausd\commands\editTargetCommand.h(53): note: see declaration of 'std::unique_ptr<MayaUsd::Impl::SetEditTarget,std::default_delete<_Ty>>'
        with
        [
            _Ty=MayaUsd::Impl::SetEditTarget
        ]
```

There can't be any clients of _setEditTarget, so a simple solution to this problem is to export only what's needed. 