### PR TITLE
MAYA-105732 Do not auto turn on displayColors

### DIFF
--- a/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
@@ -526,15 +526,14 @@ namespace
                     if (csRep == MFnMesh::kRGB || csRep == MFnMesh::kRGBA) 
                     {
                         meshFn.setCurrentColorSetName(colorSetName);
+                        MPlug plg = meshFn.findPlug("displayColors");
+                        if (!plg.isNull()) {
+                            plg.setBool(true);
+                        }
                     }
                     break;
                 }
             }
-
-            // It is tempting to enable "displayColors" here on the mesh to display the imported
-            // vertex colors. This would be fine if those streams were only vertex colors, but they
-            // are very frequently used to store custom per vertex values which would not display
-            // properly. Let the user turn that on manually.
         }
 
         return true;

--- a/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
@@ -531,10 +531,10 @@ namespace
                 }
             }
 
-            MPlug plg = meshFn.findPlug("displayColors");
-            if (!plg.isNull()) {
-                plg.setBool(true);
-            }
+            // It is tempting to enable "displayColors" here on the mesh to display the imported
+            // vertex colors. This would be fine if those streams were only vertex colors, but they
+            // are very frequently used to store custom per vertex values which would not display
+            // properly. Let the user turn that on manually.
         }
 
         return true;


### PR DESCRIPTION
The vertex color streams are sometimes hijacked to store custom
attribute values that are not representable as colors. This is the case
in the Kitchen_Set scene with pose information that show as black when
displayColors is turned on. Let the user manually turn that feature on
if he knows for sure there are colors to display.