### PR TITLE
remove Reload() override from HdVP2Material for core USD 20.11+

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -31,7 +31,7 @@ See Pixar's official github page for instructions on how to build USD: https://g
 
 |               |      ![](images/pxr.png)          |        
 |:------------: |:---------------:                  |
-|  CommitID/Tags | release: [v19.07](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.07) or [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) <br> dev: [238d0f4](https://github.com/PixarAnimationStudios/USD/commit/238d0f4b09d595955d3b5819db427e270756cc24) |
+|  CommitID/Tags | release: [v19.07](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.07) or [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) <br> dev: [5814e68](https://github.com/PixarAnimationStudios/USD/commit/5814e68c62dbb82c366933f72566f34d35da4774) |
 
 For additional information on building Pixar USD, see the ***Additional Build Instruction*** section below.
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -624,11 +624,6 @@ void HdVP2Material::Sync(
     *dirtyBits = HdMaterial::Clean;
 }
 
-/*! \brief  Reload the shader
-*/
-void HdVP2Material::Reload() {
-}
-
 /*! \brief  Returns the minimal set of dirty bits to place in the
 change tracker for use in the first sync of this prim.
 */

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.h
@@ -86,7 +86,10 @@ public:
     void Sync(HdSceneDelegate*, HdRenderParam*, HdDirtyBits*) override;
 
     HdDirtyBits GetInitialDirtyBitsMask() const override;
-    void Reload() override;
+
+#if USD_VERSION_NUM < 2011
+    void Reload() override {};
+#endif
 
     //! Get the surface shader instance.
     MHWRender::MShaderInstance* GetSurfaceShader() const {


### PR DESCRIPTION
This virtual function was removed from `HdMaterial` in core USD commit https://github.com/PixarAnimationStudios/USD/commit/5814e68c62dbb82c366933f72566f34d35da4774

The removed override didn't actually do anything and was only invoked indirectly by HdEngine, but it was a pure virtual function, so we continue to define it for earlier versions of USD.