### PR TITLE
adjust verification of texture path relative-ness in testUsdExportImportRoundtripPreviewSurface

### DIFF
--- a/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
+++ b/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
@@ -138,12 +138,17 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
         self.assertEqual(cmds.getAttr("place2dTexture.wrapU"), 0)
         self.assertEqual(cmds.getAttr("place2dTexture.wrapV"), 1)
 
-        # Make sure paths are relative in the USD file:
+        # Make sure paths are relative in the USD file. Joining the directory
+        # that the USD file lives in with the texture path should point us at
+        # a file that exists.
         stage = Usd.Stage.Open(usd_path)
-        file_texture = stage.GetPrimAtPath(
+        texture_prim = stage.GetPrimAtPath(
             "/pSphere1/Looks/pxrUsdPreviewSurface1SG/file1")
-        file_path = file_texture.GetAttribute('inputs:file').Get().path
-        self.assertTrue(file_path.startswith(".."))
+        rel_texture_path = texture_prim.GetAttribute('inputs:file').Get().path
+
+        usd_dir = os.path.dirname(usd_path)
+        full_texture_path = os.path.join(usd_dir, rel_texture_path)
+        self.assertTrue(os.path.isfile(full_texture_path))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When I brought the changes from #686 down internally and attempted to run the tests, I was seeing the `testUsdExportImportRoundtripPreviewSurface` test fail on the final assertion that checks to make sure the texture file path in USD begins with a `..`:
https://github.com/Autodesk/maya-usd/blob/e15890ca2e4ddecfff7da95e4caf6bb9c425cca4/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py#L146

Since we run the tests through a completely different infrastructure, it just so happened that the test run directory and the test data files are arranged on disk such that we end up with a relative file path authored that does **not** involve `..`.

I adjusted this final assertion to be more robust to this by verifying that when we join the directory that the USD file lives in with the relative path we pull off of the texture prim, the resulting full path should point to a valid file on disk (the texture file). This should still be validating the same assumption as before, but allows the test run directory and the test files to move relative to each other.