### PR TITLE
Do not test unparent functionality until Maya with UFE 0.2.20.

### DIFF
--- a/test/lib/ufe/testParentCmd.py
+++ b/test/lib/ufe/testParentCmd.py
@@ -385,7 +385,7 @@ class ParentCmdTestCase(unittest.TestCase):
             self.assertIn("pSphere1", childrenNames(children))
             self.assertIn("pCylinderShape1", childrenNames(children))
 
-    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '2018', 'testUnparentUSD only available in UFE preview version 0.2.18 and greater')
+    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '2020', 'testUnparentUSD only available in Maya with UFE preview version 0.2.20 and greater')
     def testUnparentUSD(self):
         '''Unparent USD node.'''
 
@@ -419,7 +419,7 @@ class ParentCmdTestCase(unittest.TestCase):
             cmds.redo()
             checkUnparent(done=True)
 
-    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '2018', 'testUnparentMixed only available in UFE preview version 0.2.18 and greater')
+    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '2020', 'testUnparentMixed only available in Maya with UFE preview version 0.2.20 and greater')
     def testUnparentMultiStage(self):
         '''Unparent USD nodes in more than one stage.'''
 


### PR DESCRIPTION
Unparent functionality was initially planned to go into Maya with UFE 0.2.18.  Because of a change in priorities, it will go into Maya with UFE 0.2.20.  Disable the unparent test until that version of Maya.
