### PR TITLE
updates for building with latest post-20.08 commits of core USD

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -31,7 +31,7 @@ See Pixar's official github page for instructions on how to build USD: https://g
 
 |               |      ![](images/pxr.png)          |        
 |:------------: |:---------------:                  |
-|  CommitID/Tags | release: [v19.07](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.07) or [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) <br> dev: [238d0f4](https://github.com/PixarAnimationStudios/USD/commit/238d0f4b09d595955d3b5819db427e270756cc24) |
+|  CommitID/Tags | release: [v19.07](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.07) or [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) <br> dev: [8a13d20](https://github.com/PixarAnimationStudios/USD/commit/8a13d20062d14d486b7e130d252c4652aab0263e) |
 
 For additional information on building Pixar USD, see the ***Additional Build Instruction*** section below.
 

--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -390,8 +390,12 @@ UsdMayaWriteJobContext::_OpenFile(const std::string& filename, bool append)
         }
         else {
             SdfLayer::FileFormatArguments args;
-            args[UsdUsdFileFormatTokens->FormatArg] = mArgs.defaultUSDFormat.GetString();            
-            layer = SdfLayer::CreateNew(filename, "",  args);
+            args[UsdUsdFileFormatTokens->FormatArg] = mArgs.defaultUSDFormat.GetString();
+#if USD_VERSION_NUM > 2008
+            layer = SdfLayer::CreateNew(filename, args);
+#else
+            layer = SdfLayer::CreateNew(filename, "", args);
+#endif
         }
         if (!layer) {
             TF_RUNTIME_ERROR(

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -624,11 +624,6 @@ void HdVP2Material::Sync(
     *dirtyBits = HdMaterial::Clean;
 }
 
-/*! \brief  Reload the shader
-*/
-void HdVP2Material::Reload() {
-}
-
 /*! \brief  Returns the minimal set of dirty bits to place in the
 change tracker for use in the first sync of this prim.
 */

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.h
@@ -86,7 +86,10 @@ public:
     void Sync(HdSceneDelegate*, HdRenderParam*, HdDirtyBits*) override;
 
     HdDirtyBits GetInitialDirtyBitsMask() const override;
-    void Reload() override;
+
+#if USD_VERSION_NUM < 2011
+    void Reload() override {};
+#endif
 
     //! Get the surface shader instance.
     MHWRender::MShaderInstance* GetSurfaceShader() const {

--- a/lib/usd/translators/skelReader.cpp
+++ b/lib/usd/translators/skelReader.cpp
@@ -161,12 +161,24 @@ UsdMayaPrimReaderSkelRoot::PostReadSubtree(
     // We do this in a post-subtree stage to ensure that any skinnable
     // prims we produce skin clusters for have been processed first.
 
+    std::vector<UsdSkelBinding> bindings;
+
+#if USD_VERSION_NUM > 2008
+    _cache.Populate(skelRoot, UsdTraverseInstanceProxies());
+
+    if (!_cache.ComputeSkelBindings(
+            skelRoot,
+            &bindings,
+            UsdTraverseInstanceProxies())) {
+        return;
+    }
+#else
     _cache.Populate(skelRoot);
 
-    std::vector<UsdSkelBinding> bindings;
     if (!_cache.ComputeSkelBindings(skelRoot, &bindings)) {
         return;
     }
+#endif
 
     for (const UsdSkelBinding& binding : bindings) {
         if (binding.GetSkinningTargets().empty())

--- a/test/lib/usd/translators/testUsdExportSkeleton.py
+++ b/test/lib/usd/translators/testUsdExportSkeleton.py
@@ -108,7 +108,11 @@ class testUsdExportSkeleton(unittest.TestCase):
         self.assertTrue(root)
 
         skelCache = UsdSkel.Cache()
-        skelCache.Populate(root)
+
+        if Usd.GetVersion() > (0, 20, 8):
+            skelCache.Populate(root, Usd.PrimDefaultPredicate)
+        else:
+            skelCache.Populate(root)
 
         skel = UsdSkel.Skeleton.Get(stage, '/SkelChar/Hips')
         self.assertTrue(skel)

--- a/test/lib/usd/translators/testUsdImportSkeleton.py
+++ b/test/lib/usd/translators/testUsdImportSkeleton.py
@@ -238,8 +238,12 @@ class testUsdImportSkeleton(unittest.TestCase):
         
         bindingSitePrim = stage.GetPrimAtPath("/Root")
         self.assertTrue(bindingSitePrim.IsA(UsdSkel.Root))
-        
-        skelCache.Populate(UsdSkel.Root(bindingSitePrim))
+
+        if Usd.GetVersion() > (0, 20, 8):
+            skelCache.Populate(UsdSkel.Root(bindingSitePrim),
+                Usd.PrimDefaultPredicate)
+        else:
+            skelCache.Populate(UsdSkel.Root(bindingSitePrim))
 
         skel = UsdSkel.Skeleton.Get(stage, "/Root/Skeleton")
         self.assertTrue(skel)


### PR DESCRIPTION
A handful of commits were pushed recently to core USD that require version-gated changes in maya-usd. This includes the `HdMaterial` change previously presented as #704 and replaces that PR.

With the changes here, maya-usd will continue to build against supported core USD releases 20.08 and earlier. For core USD at commits beyond the 20.08 release, commit https://github.com/PixarAnimationStudios/USD/commit/8a13d20062d14d486b7e130d252c4652aab0263e or later must be used. The build.md was updated accordingly.