### PR TITLE
MAYA-103701 - UFE: Maya crashes after switching variant

### DIFF
--- a/lib/mayaUsd/ufe/Global.cpp
+++ b/lib/mayaUsd/ufe/Global.cpp
@@ -83,7 +83,7 @@ Ufe::ContextOpsHandler::Ptr g_MayaContextOpsHandler;
 StagesSubject::Ptr g_StagesSubject;
 
 bool InPathChange::inGuard = false;
-bool InAddOrRemoveReference::inGuard = false;
+bool InAddOrDeleteOperation::inGuard = false;
 
 //------------------------------------------------------------------------------
 // Functions

--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -35,8 +35,6 @@
 #include <mayaUsd/ufe/UsdSceneItem.h>
 #include <mayaUsd/ufe/UsdUndoAddNewPrimCommand.h>
 
-#include "private/UfeNotifGuard.h"
-
 namespace {
 
 // Ufe::ContextItem strings
@@ -135,7 +133,6 @@ public:
 
     void undo() override { 
         if (_prim.IsValid()) {
-            MayaUsd::ufe::InAddOrRemoveReference ar;
             UsdReferences primRefs = _prim.GetReferences();
             primRefs.RemoveReference(_sdfRef);
         }
@@ -143,7 +140,6 @@ public:
 
     void redo() override { 
         if (_prim.IsValid()) {
-            MayaUsd::ufe::InAddOrRemoveReference ar;
             _sdfRef = SdfReference(_filePath);
             UsdReferences primRefs = _prim.GetReferences();
             primRefs.AddReference(_sdfRef);
@@ -174,7 +170,6 @@ public:
 
     void redo() override { 
         if (_prim.IsValid()) {
-            MayaUsd::ufe::InAddOrRemoveReference ar;
             UsdReferences primRefs = _prim.GetReferences();
             primRefs.ClearReferences();
         }

--- a/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
@@ -18,6 +18,8 @@
 #include <mayaUsd/ufe/Global.h>
 #include <mayaUsd/ufe/Utils.h>
 
+#include "private/UfeNotifGuard.h"
+
 namespace {
 
 Ufe::Path appendToPath(const Ufe::Path& path, const std::string& name)
@@ -71,6 +73,7 @@ UsdUndoAddNewPrimCommand::UsdUndoAddNewPrimCommand(const UsdSceneItem::Ptr& usdS
 void UsdUndoAddNewPrimCommand::undo()
 {
     if (_stage) {
+        MayaUsd::ufe::InAddOrDeleteOperation ad;
         _stage->RemovePrim(_primPath);
     }
 }
@@ -78,6 +81,7 @@ void UsdUndoAddNewPrimCommand::undo()
 void UsdUndoAddNewPrimCommand::redo()
 {
     if (_stage) {
+        MayaUsd::ufe::InAddOrDeleteOperation ad;
         auto prim = _stage->DefinePrim(_primPath, _primToken);
         if (!prim.IsValid())
             TF_RUNTIME_ERROR("Failed to create new prim type: %s", _primToken.GetText());

--- a/lib/mayaUsd/ufe/UsdUndoDeleteCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDeleteCommand.cpp
@@ -15,6 +15,8 @@
 //
 #include "UsdUndoDeleteCommand.h"
 
+#include "private/UfeNotifGuard.h"
+
 MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -36,6 +38,7 @@ UsdUndoDeleteCommand::Ptr UsdUndoDeleteCommand::create(const UsdPrim& prim)
 
 void UsdUndoDeleteCommand::perform(bool state)
 {
+	MayaUsd::ufe::InAddOrDeleteOperation ad;
 	fPrim.SetActive(state);
 }
 

--- a/lib/mayaUsd/ufe/private/UfeNotifGuard.h
+++ b/lib/mayaUsd/ufe/private/UfeNotifGuard.h
@@ -40,20 +40,20 @@ private:
 	static bool inGuard;
 };
 
-//! \brief Helper class to scope when we are in an add or remove reference operation.
-class InAddOrRemoveReference
+//! \brief Helper class to scope when we are in an add or delete operation.
+class InAddOrDeleteOperation
 {
 public:
-	InAddOrRemoveReference() { inGuard = true; }
-	~InAddOrRemoveReference() { inGuard = false; }
+	InAddOrDeleteOperation() { inGuard = true; }
+	~InAddOrDeleteOperation() { inGuard = false; }
 
 	// Delete the copy/move constructors assignment operators.
-	InAddOrRemoveReference(const InAddOrRemoveReference&) = delete;
-	InAddOrRemoveReference& operator=(const InAddOrRemoveReference&) = delete;
-	InAddOrRemoveReference(InAddOrRemoveReference&&) = delete;
-	InAddOrRemoveReference& operator=(InAddOrRemoveReference&&) = delete;
+	InAddOrDeleteOperation(const InAddOrDeleteOperation&) = delete;
+	InAddOrDeleteOperation& operator=(const InAddOrDeleteOperation&) = delete;
+	InAddOrDeleteOperation(InAddOrDeleteOperation&&) = delete;
+	InAddOrDeleteOperation& operator=(InAddOrDeleteOperation&&) = delete;
 
-	static bool inAddOrRemoveReference() { return inGuard; }
+	static bool inAddOrDeleteOperation() { return inGuard; }
 
 private:
 	static bool inGuard;

--- a/test/lib/ufe/testContextOps.py
+++ b/test/lib/ufe/testContextOps.py
@@ -27,6 +27,28 @@ import ufe
 import unittest
 import os
 
+class TestAddPrimObserver(ufe.Observer):
+    def __init__(self):
+        super(TestAddPrimObserver, self).__init__()
+        self.deleteNotif = 0
+        self.addNotif = 0
+
+    def __call__(self, notification):
+        if isinstance(notification, ufe.ObjectDelete):
+            self.deleteNotif += 1
+        if isinstance(notification, ufe.ObjectAdd):
+            self.addNotif += 1
+
+    def nbDeleteNotif(self):
+        return self.deleteNotif
+
+    def nbAddNotif(self):
+        return self.addNotif
+
+    def reset(self):
+        self.addNotif = 0
+        self.deleteNotif = 0
+
 class ContextOpsTestCase(unittest.TestCase):
     '''Verify the ContextOps interface for the USD runtime.'''
 
@@ -41,13 +63,13 @@ class ContextOpsTestCase(unittest.TestCase):
         ''' Called initially to set up the maya test environment '''
         # Load plugins
         self.assertTrue(self.pluginsLoaded)
-        
+
+        # This test requires no additional setup.
+        if self._testMethodName == 'testAddNewPrim':
+            return
+
         # Open top_layer.ma scene in test-samples
         mayaUtils.openTopLayerScene()
-
-        # Create a proxy shape with empty stage to start with.
-        import mayaUsd_createStageWithNewLayer
-        mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
 
         # Clear selection to start off.
         ufe.GlobalSelection.get().clear()
@@ -158,6 +180,16 @@ class ContextOpsTestCase(unittest.TestCase):
 
     @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '2015', 'testAddNewPrim only available in UFE preview version 0.2.15 and greater')
     def testAddNewPrim(self):
+
+        # Create a proxy shape with empty stage to start with.
+        import mayaUsd_createStageWithNewLayer
+        mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+
+        # Create our UFE notification observer
+        ufeObs = TestAddPrimObserver()
+        ufe.Scene.addObjectDeleteObserver(ufeObs)
+        ufe.Scene.addObjectAddObserver(ufeObs)
+
         # Create a ContextOps interface for the proxy shape.
         proxyShapePath = ufe.Path([mayaUtils.createUfePathSegment("|world|stage1|stageShape1")])
         proxyShapeItem = ufe.Hierarchy.createItem(proxyShapePath)
@@ -166,7 +198,12 @@ class ContextOpsTestCase(unittest.TestCase):
         # Add a new prim.
         cmd = contextOps.doOpCmd(['Add New Prim', 'Xform'])
         self.assertIsNotNone(cmd)
+        ufeObs.reset()
         ufeCmd.execute(cmd)
+
+        # Ensure we got the correct UFE notifs.
+        self.assertEqual(ufeObs.nbAddNotif(), 1)
+        self.assertEqual(ufeObs.nbDeleteNotif(), 0)
 
         # The proxy shape should now have a single UFE child item.
         proxyShapehier = ufe.Hierarchy.hierarchy(proxyShapeItem)
@@ -186,7 +223,12 @@ class ContextOpsTestCase(unittest.TestCase):
         # Add a new prim.
         cmd = contextOps.doOpCmd(['Add New Prim', 'Xform'])
         self.assertIsNotNone(cmd)
+        ufeObs.reset()
         ufeCmd.execute(cmd)
+
+        # Ensure we got the correct UFE notifs.
+        self.assertEqual(ufeObs.nbAddNotif(), 1)
+        self.assertEqual(ufeObs.nbDeleteNotif(), 0)
 
         # The xform prim should now have a single UFE child item.
         xformHier = ufe.Hierarchy.hierarchy(xformItem)
@@ -196,25 +238,47 @@ class ContextOpsTestCase(unittest.TestCase):
         # Add another prim
         cmd = contextOps.doOpCmd(['Add New Prim', 'Capsule'])
         self.assertIsNotNone(cmd)
+        ufeObs.reset()
         ufeCmd.execute(cmd)
+
+        # Ensure we got the correct UFE notifs.
+        self.assertEqual(ufeObs.nbAddNotif(), 1)
+        self.assertEqual(ufeObs.nbDeleteNotif(), 0)
 
         # The xform prim should now have two UFE child items.
         self.assertTrue(xformHier.hasChildren())
         self.assertEqual(len(xformHier.children()), 2)
 
         # Undo will remove the new prim, meaning one less child.
+        ufeObs.reset()
         cmds.undo()
         self.assertTrue(xformHier.hasChildren())
         self.assertEqual(len(xformHier.children()), 1)
+
+        # Ensure we got the correct UFE notifs.
+        self.assertEqual(ufeObs.nbAddNotif(), 0)
+        self.assertEqual(ufeObs.nbDeleteNotif(), 1)
 
         # Undo again will remove the first added prim, meaning no children.
         cmds.undo()
         self.assertFalse(xformHier.hasChildren())
 
+        # Ensure we got the correct UFE notifs.
+        self.assertEqual(ufeObs.nbAddNotif(), 0)
+        self.assertEqual(ufeObs.nbDeleteNotif(), 2)
+
         cmds.redo()
         self.assertTrue(xformHier.hasChildren())
         self.assertEqual(len(xformHier.children()), 1)
 
+        # Ensure we got the correct UFE notifs.
+        self.assertEqual(ufeObs.nbAddNotif(), 1)
+        self.assertEqual(ufeObs.nbDeleteNotif(), 2)
+
         cmds.redo()
         self.assertTrue(xformHier.hasChildren())
         self.assertEqual(len(xformHier.children()), 2)
+
+        # Ensure we got the correct UFE notifs.
+        self.assertEqual(ufeObs.nbAddNotif(), 2)
+        self.assertEqual(ufeObs.nbDeleteNotif(), 2)


### PR DESCRIPTION
#### MAYA-103701 - UFE: Maya crashes when selecting a new object after switching variant

* Removed special case for add/remove reference and instead created special case for add or delete operations. In these cases we send the UFE add/delete notifs. Otherwise we fallback and send the UFE subtree invalidate notif.
* In the tests that add new prims and test delete, added a UFE observer to make sure we are getting the correct notifs.