### PR TITLE
Proof of concept for USD matrix transform op editing.

### DIFF
--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -20,6 +20,8 @@ target_sources(${PROJECT_NAME}
         UsdStageMap.cpp
         UsdTRSUndoableCommandBase.cpp
         UsdTransform3d.cpp
+        UsdTransform3dBase.cpp
+        UsdTransform3dMatrixOp.cpp
         UsdTransform3dHandler.cpp
         UsdTranslateUndoableCommand.cpp
         UsdUndoDeleteCommand.cpp
@@ -74,6 +76,8 @@ set(HEADERS
     UsdStageMap.h
     UsdTRSUndoableCommandBase.h
     UsdTransform3d.h
+    UsdTransform3dBase.h
+    UsdTransform3dMatrixOp.h
     UsdTransform3dHandler.h
     UsdTranslateUndoableCommand.h
     UsdUndoDeleteCommand.h

--- a/lib/mayaUsd/ufe/StagesSubject.cpp
+++ b/lib/mayaUsd/ufe/StagesSubject.cpp
@@ -280,9 +280,7 @@ void StagesSubject::stageChanged(UsdNotice::ObjectsChanged const& notice, UsdSta
 #endif
 #endif
 
-		// We need to determine if the change is a Transform3d change.
-		// We must at least pick up xformOp:translate, xformOp:rotateXYZ, 
-		// and xformOp:scale.
+		// Is the change a Transform3d change?
 		const TfToken nameToken = changedPath.GetNameToken();
 		if(nameToken == UsdGeomTokens->xformOpOrder || UsdGeomXformOp::IsXformOp(nameToken))
 		{

--- a/lib/mayaUsd/ufe/UsdTransform3d.h
+++ b/lib/mayaUsd/ufe/UsdTransform3d.h
@@ -54,6 +54,9 @@ public:
 	const Ufe::Path& path() const override;
 	Ufe::SceneItem::Ptr sceneItem() const override;
 
+	inline UsdSceneItem::Ptr usdSceneItem() const { return fItem; }
+	inline UsdPrim prim() const { return fPrim; }
+
     // When the current Maya preview release has UFE 0.2.13, this conditional
     // compilation can be converted to:
     // #ifdef UFE_V2_FEATURES_AVAILABLE

--- a/lib/mayaUsd/ufe/UsdTransform3d.md
+++ b/lib/mayaUsd/ufe/UsdTransform3d.md
@@ -1,0 +1,205 @@
+# Editing USD Transformable Objects with maya-usd
+
+Draft version 0.3, 19-Aug-2020, 4:52 P.M.
+
+## Background
+
+Transformable USD prims are derived fom [UsdGeomXformable](https://graphics.pixar.com/usd/docs/api/class_usd_geom_xformable.html#details), which supports
+arbitrary sequences of component affine transformations.  These transform
+operations, or transform ops, are implemented in 
+[UsdGeomXformOp](https://graphics.pixar.com/usd/docs/api/class_usd_geom_xform_op.html#details),
+a schema wrapper on a UsdAttribute to read and write transform operations.
+
+Because the list of transform operations is arbitrary, it can be authored in
+different ways by different producers of USD data.  The existing maya-usd
+implementation for the UFE Transform3d API, which requires conversion to the
+very restrictive USD common transform API
+[UsdGeomXformCommonAPI](https://graphics.pixar.com/usd/docs/api/class_usd_geom_xform_common_a_p_i.html#details)
+is inadequate and destructive.
+
+## Requirements
+
+In discussions with partners, Autodesk has identified a set of requirements for
+editing USD transformable prim transform stacks.  We focus on two requirements
+here, identified as per the discussion documents:
+- 2 Manipulation code will use an interface that takes care of transformation
+operations management. Pipelines may choose to change this interface at runtime
+to improve interop between DCCs.
+
+- 6 UFE API should provide UFE-USD plugin with an interface to handle the
+in-place editing of any arbitrary transformation stacks, i.e. target any
+transformation op.
+
+## Assumptions
+
+Autodesk is making a proposal to meet these requirements under the following
+assumptions.
+- Users of maya-usd want to direct editing of transformable prims with an
+arbitrary stack of transform ops to one or more of these transform ops which
+are relevant for their workflow.
+- It must be possible for a plugin to completely override what Autodesk
+proposes as the default maya-usd transform editing capability.
+- Transform ops can be conceptually seen as transformable objects in their own
+right, and therefore can be targeted as the destination of 3D transform edits
+through viewport manipulation.
+
+## Existing Interfaces
+
+Three UFE interfaces are involved when dealing with reading or writing to
+transformable USD objects, which must all be implemented by the UFE run-time.
+- The Ufe::Transform3dHandler: this is the factory object that creates
+Ufe::Transform3d interfaces.  This factory object can be replaced at run-time.
+- The Ufe::Transform3d: this is the interface object that is used to read the
+transform data.  When writing, either the write is done without undo capability
+directly through the Transform3d interface, or the Transform3d interface is
+asked to create an undoable command (see below)
+- The Ufe::TranslateUndoableCommand, Ufe::RotateUndoableCommand, and
+UfeScaleUndoableCommand: these deal with the complete interactive manipulation,
+and obviously undo / redo.  During manipulation, they are repeatedly updated
+with the latest value of the attribute being changed.
+
+## Proposal
+
+### Targeting TRS Edits Inside the Transform Stack
+
+The `Transform3dHandler::transform3d()` call must be used to create an
+interface object to read or write the complete object's local transform.
+Reading is done for example when transforming the UFE Object3d interface object
+space bounding box.  Writing is done for example when performing the Maya
+`parent -absolute` command, where the object's world space transformation must
+not change, and therefore the object's complete local transform must be
+changed.  This conflicts with the requirement to edit an individual transform
+op.
+
+To solve this, a key is the realization that the Transform3d interface is
+appropriate for editing arbitrary transform ops inside a USD transformable
+prim.  The Transform3d interface applies to an object, whatever the implementer
+of the interface decides that object to be.  Therefore, we can apply the
+Transform3d interface **to USD transform ops**.  In that case, we can implement
+the `Transform3d::segmentExclusiveMatrix()` and 
+`Transform3d::segmentInclusiveMatrix()` to return values appropriate to a USD
+transform op.  The stack of transform ops is then treated as representing
+objects to be manipulated using a Transform3d interface.
+
+What is needed is a way for the implementer of the UFE run-time to
+return an interface object that appropriately targets a single transform op, or
+a logical group of transform ops (e.g. the ops in the USD common transform API,
+or the ops in the Maya transform API).  This **replaces the need for a
+dedicated coordinate frame interface**: interpreting one or more transform ops
+as a logical "local transform", the coordinate frame is that of the transform
+op (or group of transform ops), and we can re-use the existing Transform3d
+interface.
+
+We implement this by adding a new virtual to the Ufe::Transform3dHandler
+factory interface.  Its signature and documentation are the following:
+```C++
+    /*! Return an interface to be used to edit the 3D transformation of the
+        object.  By default, returns the normal Transform3d interface.  The
+        edit transform object may have a different local transformation and a
+        different \ref Ufe::Transform3d::segmentInclusiveMatrix() and
+        \ref Ufe::Transform3d::segmentExclusiveMatrix() than the normal
+        Transform3d interface associated with a scene item.  All changes made
+        through the edit transform 3D object will be visible through the normal
+        \ref Ufe::Transform3d::transform3d() interface.
+        \param item SceneItem to use to retrieve its Transform3d interface.
+        \return Transform3d interface of given SceneItem. Returns a null
+        pointer if no Transform3d interface can be created for the item.
+    */
+    virtual Transform3d::Ptr editTransform3d(const SceneItem::Ptr& item) const {
+        return transform3d(item);
+    }
+```
+The rest of the Transform3dHandler, and the Transform3d interface, are
+unchanged.  The Maya move, rotate and scale commands call `editTransform3d`,
+not `transform3d`, when performing move, rotate, or scale manipulation.  The
+implementer can then return an interface object that is appropriate for editing
+a transform op, or group of transform ops.
+
+### Using Transform3dHandler Customization Capability
+
+Plugins can replace the USD run-time
+Transform3dHandler (the factory object) with a custom factory.  A plugin is
+therefore free to completely replace the Autodesk Transform3dHandler at
+run-time with its own Transform3dHandler.  This allows the creation of
+Transform3d interface objects created by the plugin.  This does not require any
+change to maya-usd core code, or any derivation from core code, only derivation
+from the UFE base classes.  Plugin-created Transform3dHandler classes can
+therefore be created and live side by side with Autodesk core
+Transform3dHandler classes, avoiding conflicting updates.
+
+Autodesk uses to capability in the prototype
+transform edit code to set up a [chain of
+responsibility](https://en.wikipedia.org/wiki/Chain-of-responsibility_pattern)
+with multiple Transform3dHandler objects, each capable of recognizing whether
+the transformable prim can be edited by its associated Transform3d interface.
+If it can handle the transformable prim, it creates the Transform3d interface
+object, and if cannot, it delegates to the next Transform3dHandler in the chain.
+
+In the prototype code for example, there is a matrix op handler that inspects
+whether the transformable prim has a single matrix op, and the fallback
+Transform3Handler, which is the existing forced conversion to the USD common
+transform API.  More Transform3dHandler's can be devised, for example to
+support the Autodesk Maya Transform API, or by plugin writers to support their
+own transform API.  The transform handlers in the prototype code may or may not
+survive the transition to production code, but the fundamental idea is that
+these handlers can support focused code that is easier to mix and match and
+maintain, through clear separation of concerns.
+
+### Using Transform Command Customization Capability
+
+By implementing a Transform3d interface class, the USD run-time undoable
+commands can be customized.  The Transform3d interface is accessed by the Maya
+move, rotate and scale commands by being asked to create commands for the
+translation, rotation, and scale.  From that point on the Transform3d interface
+plays no part in setting the translation, rotation, and scale: the commands
+perform all the work.
+```C++
+    //! Create an undoable translate command.  The command is not executed.
+    //! \param x X-axis translation.
+    //! \param y Y-axis translation.
+    //! \param z Z-axis translation.
+    //! \return Undoable command whose undo restores the original translation.
+    virtual TranslateUndoableCommand::Ptr translateCmd(
+        double x, double y, double z) = 0;
+
+    //! Create an undoable rotate command.  The command is not executed.
+    //! \param x value to rotate on the X-axis, in degrees.
+    //! \param y value to rotate on the Y-axis, in degrees.
+    //! \param z value to rotate on the Z-axis, in degrees.
+    //! \return Undoable command whose undo restores the original rotation.
+    virtual RotateUndoableCommand::Ptr rotateCmd(
+        double x, double y, double z) = 0;
+
+    //! Create an undoable scale command.  The command is not executed.
+    //! \param x value to scale on the X-axis.
+    //! \param y value to scale on the Y-axis.
+    //! \param z value to scale on the Z-axis.
+    //! \return Undoable command whose undo restores the scale's value
+    virtual ScaleUndoableCommand::Ptr scaleCmd(
+        double x, double y, double z) = 0;
+```
+This is a clear way by which Maya indicates what is under manipulation: when
+the Transform3d interface object is asked to create a translate command, the
+plugin knows that the object's translation will be edited, and so on.
+
+## Analysis
+
+Autodesk believes that the proposed Transform3dHandler addition above, and the
+use of existing facilities, allows moving forward in meeting the requirements:
+- 2 *Manipulation code will use an interface that takes care of transformation
+operations management. Pipelines may choose to change this interface at runtime
+to improve interop between DCCs.*  This is met by the existing customizable
+Transform3dHandler system, which can create custom Transform3d interfaces.
+Pipelines can leverage this mechanism to introduce studio-specific overrides
+without modifying the default implementation or having to maintain and resolve
+conflicts when the default implementation changes. In other words, the default
+implementation and studio overrides will be leveraging a stable common
+interface.
+- 6 *UFE API should provide UFE-USD plugin with an interface to handle the
+in-place editing of any arbitrary transformation stacks, i.e. target any
+transformation op.*  The foundations for meeting this requirement is the
+addition of the `Transform3dHandler::editTransform3d()` method.  As presented
+in the proof of concept MatrixOp handler implementation, this allows writing
+custom Transform3d interfaces targeting specific transform ops.  We are open to
+feedback to identify potential other UFE API gaps when it comes to
+requirement 6.

--- a/lib/mayaUsd/ufe/UsdTransform3dBase.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dBase.cpp
@@ -1,0 +1,207 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "UsdTransform3dBase.h"
+
+#include <mayaUsd/ufe/Utils.h>
+
+#include <pxr/usd/usdGeom/xformCache.h>
+#include <pxr/usd/usdGeom/xformCommonAPI.h>
+
+namespace {
+const char* const kLocalTransformFailed = "Obtaining local transform failed for object %s";
+const char* const kReadOnly = "Illegal %s call on read-only interface UsdTransform3dBase for object %s";
+}
+
+MAYAUSD_NS_DEF {
+namespace ufe {
+
+UsdTransform3dBase::UsdTransform3dBase(const UsdSceneItem::Ptr& item)
+    : Transform3d(), fItem(item), fPrim(item->prim())
+{}
+
+/* static */
+UsdTransform3dBase::Ptr UsdTransform3dBase::create(const UsdSceneItem::Ptr& item)
+{
+    return std::make_shared<UsdTransform3dBase>(item);
+}
+
+const Ufe::Path& UsdTransform3dBase::path() const
+{
+    return fItem->path();
+}
+
+Ufe::SceneItem::Ptr UsdTransform3dBase::sceneItem() const
+{
+    return fItem;
+}
+
+Ufe::TranslateUndoableCommand::Ptr UsdTransform3dBase::translateCmd(
+    double /* x */, double /* y */, double /* z */)
+{
+    return nullptr;
+}
+
+void UsdTransform3dBase::translate(double /* x */, double /* y */, double /* z */)
+{
+    TF_CODING_ERROR(kReadOnly, "translate()", pathCStr());
+}
+
+Ufe::Vector3d UsdTransform3dBase::translation() const
+{
+    UsdGeomXformable xformable(prim());
+    GfMatrix4d m;
+    bool unused;
+    if (!xformable.GetLocalTransformation(&m, &unused, getTime(path()))) {
+        TF_WARN(kLocalTransformFailed, pathCStr());
+        return Ufe::Vector3d(0, 0, 0);
+    }
+    return toUfe(m.ExtractTranslation());
+}
+
+Ufe::Vector3d UsdTransform3dBase::rotation() const
+{
+    UsdGeomXformable xformable(prim());
+    GfMatrix4d m;
+    bool unused;
+    if (!xformable.GetLocalTransformation(&m, &unused, getTime(path()))) {
+        TF_WARN(kLocalTransformFailed, pathCStr());
+        return Ufe::Vector3d(0, 0, 0);
+    }
+    return toUfe(m.DecomposeRotation(GfVec3d::XAxis(), GfVec3d::YAxis(), GfVec3d::ZAxis()));
+}
+
+Ufe::Vector3d UsdTransform3dBase::scale() const
+{
+    UsdGeomXformable xformable(prim());
+    GfMatrix4d m;
+    bool unused;
+    if (!xformable.GetLocalTransformation(&m, &unused, getTime(path()))) {
+        TF_WARN(kLocalTransformFailed, pathCStr());
+        return Ufe::Vector3d(1, 1, 1);
+    }
+    GfMatrix4d unusedR, unusedP, unusedU;
+    GfVec3d    s, unusedT;
+    if (!m.Factor(&unusedR, &s, &unusedU, &unusedT, &unusedP)) {
+        TF_WARN("Cannot decompose local transform for %s", pathCStr());
+        return Ufe::Vector3d(1, 1, 1);
+    }
+    
+    return toUfe(s);
+}
+
+Ufe::RotateUndoableCommand::Ptr UsdTransform3dBase::rotateCmd(
+    double /* x */, double /* y */, double /* z */
+)
+{
+    return nullptr;
+}
+
+void UsdTransform3dBase::rotate(double /* x */, double /* y */, double /* z */)
+{
+    TF_CODING_ERROR(kReadOnly, "rotate()", pathCStr());
+}
+
+Ufe::ScaleUndoableCommand::Ptr UsdTransform3dBase::scaleCmd(
+    double /* x */, double /* y */, double /* z */
+)
+{
+    return nullptr;
+}
+
+void UsdTransform3dBase::scale(double /* x */, double /* y */, double /* z */)
+{
+    TF_CODING_ERROR(kReadOnly, "scale()", pathCStr());
+}
+
+Ufe::TranslateUndoableCommand::Ptr UsdTransform3dBase::rotatePivotTranslateCmd()
+{
+    return nullptr;
+}
+
+void UsdTransform3dBase::rotatePivotTranslate(
+    double /* x */, double /* y */, double /* z */
+)
+{
+    TF_CODING_ERROR(kReadOnly, "rotatePivotTranslate()", pathCStr());
+}
+
+Ufe::Vector3d UsdTransform3dBase::rotatePivot() const
+{
+    // Called by Maya during transform editing.
+    return Ufe::Vector3d(0, 0, 0);
+}
+
+Ufe::TranslateUndoableCommand::Ptr UsdTransform3dBase::scalePivotTranslateCmd()
+{
+    return nullptr;
+}
+
+void UsdTransform3dBase::scalePivotTranslate(double x, double y, double z)
+{
+    TF_CODING_ERROR(kReadOnly, "scalePivotTranslate()", pathCStr());
+}
+
+Ufe::Vector3d UsdTransform3dBase::scalePivot() const
+{
+    // Called by Maya during transform editing.
+    return Ufe::Vector3d(0, 0, 0);
+}
+
+Ufe::Matrix4d UsdTransform3dBase::segmentInclusiveMatrix() const
+{
+    UsdGeomXformCache xformCache(getTime(path()));
+    return toUfe(xformCache.GetLocalToWorldTransform(fPrim));
+}
+ 
+Ufe::Matrix4d UsdTransform3dBase::segmentExclusiveMatrix() const
+{
+    UsdGeomXformCache xformCache(getTime(path()));
+    return toUfe(xformCache.GetParentToWorldTransform(fPrim));
+}
+
+const char* UsdTransform3dBase::pathCStr() const
+{
+    return sceneItem()->path().string().c_str();
+}
+
+//------------------------------------------------------------------------------
+// UsdTransform3dBaseHandler
+//------------------------------------------------------------------------------
+
+UsdTransform3dBaseHandler::UsdTransform3dBaseHandler() 
+  : Ufe::Transform3dHandler()
+{}
+
+/*static*/
+UsdTransform3dBaseHandler::Ptr UsdTransform3dBaseHandler::create()
+{
+    return std::make_shared<UsdTransform3dBaseHandler>();
+}
+
+Ufe::Transform3d::Ptr UsdTransform3dBaseHandler::transform3d(
+    const Ufe::SceneItem::Ptr& item
+) const
+{
+    UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
+#if !defined(NDEBUG)
+    assert(usdItem);
+#endif
+
+    return UsdTransform3dBase::create(usdItem);
+}
+
+} // namespace ufe
+} // namespace MayaUsd

--- a/lib/mayaUsd/ufe/UsdTransform3dBase.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dBase.h
@@ -1,0 +1,122 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <ufe/transform3d.h>
+#include <ufe/transform3dHandler.h>
+
+#include <pxr/usd/usd/prim.h>
+
+#include <mayaUsd/base/api.h>
+#include <mayaUsd/ufe/UsdSceneItem.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+MAYAUSD_NS_DEF {
+namespace ufe {
+
+//! \brief Read-only implementation for USD object 3D transform information.
+// 
+// Methods in the interface which return a command to change the object's 3D
+// transformation return a null pointer.
+//
+// Methods in the interface which change the object directly raise an exception.
+//
+// Note that all calls to specify time use the default time, but this
+// could be changed to use the current time, using getTime(path()).
+
+class MAYAUSD_CORE_PUBLIC UsdTransform3dBase : public Ufe::Transform3d
+{
+public:
+    typedef std::shared_ptr<UsdTransform3dBase> Ptr;
+
+    UsdTransform3dBase(const UsdSceneItem::Ptr& item);
+    ~UsdTransform3dBase() override = default;
+
+    // Delete the copy/move constructors assignment operators.
+    UsdTransform3dBase(const UsdTransform3dBase&) = delete;
+    UsdTransform3dBase& operator=(const UsdTransform3dBase&) = delete;
+    UsdTransform3dBase(UsdTransform3dBase&&) = delete;
+    UsdTransform3dBase& operator=(UsdTransform3dBase&&) = delete;
+
+    //! Create a UsdTransform3dBase.
+    static UsdTransform3dBase::Ptr create(const UsdSceneItem::Ptr& item);
+
+    // Ufe::Transform3d overrides
+    const Ufe::Path& path() const override;
+    Ufe::SceneItem::Ptr sceneItem() const override;
+
+    inline UsdSceneItem::Ptr usdSceneItem() const { return fItem; }
+    inline UsdPrim prim() const { return fPrim; }
+
+    Ufe::Vector3d translation() const override;
+    Ufe::Vector3d rotation() const override;
+    Ufe::Vector3d scale() const override;
+
+    Ufe::TranslateUndoableCommand::Ptr translateCmd(double x, double y, double z) override;
+    Ufe::RotateUndoableCommand::Ptr rotateCmd(double x, double y, double z) override;
+    Ufe::ScaleUndoableCommand::Ptr scaleCmd(double x, double y, double z) override;
+    void translate(double x, double y, double z) override;
+    void rotate(double x, double y, double z) override;
+    void scale(double x, double y, double z) override;
+
+    Ufe::TranslateUndoableCommand::Ptr rotatePivotTranslateCmd() override;
+    void rotatePivotTranslate(double x, double y, double z) override;
+    Ufe::Vector3d rotatePivot() const override;
+
+    Ufe::TranslateUndoableCommand::Ptr scalePivotTranslateCmd() override;
+    void scalePivotTranslate(double x, double y, double z) override;
+    Ufe::Vector3d scalePivot() const override;
+
+    Ufe::Matrix4d segmentInclusiveMatrix() const override;
+    Ufe::Matrix4d segmentExclusiveMatrix() const override;
+
+protected:
+    const char* pathCStr() const;
+
+private:
+
+    UsdSceneItem::Ptr fItem;
+    UsdPrim fPrim;
+
+}; // UsdTransform3dBase
+
+//! \brief Factory to create a UsdTransform3dBase interface object.
+//
+// 
+class MAYAUSD_CORE_PUBLIC UsdTransform3dBaseHandler : public Ufe::Transform3dHandler
+{
+public:
+    typedef std::shared_ptr<UsdTransform3dBaseHandler> Ptr;
+
+    UsdTransform3dBaseHandler();
+
+    // Delete the copy/move constructors assignment operators.
+    UsdTransform3dBaseHandler(const UsdTransform3dBaseHandler&) = delete;
+    UsdTransform3dBaseHandler& operator=(const UsdTransform3dBaseHandler&) = delete;
+    UsdTransform3dBaseHandler(UsdTransform3dBaseHandler&&) = delete;
+    UsdTransform3dBaseHandler& operator=(UsdTransform3dBaseHandler&&) = delete;
+
+    //! Create a UsdTransform3dBaseHandler.
+    static Ptr create();
+
+    // Ufe::Transform3dHandler overrides
+    Ufe::Transform3d::Ptr transform3d(const Ufe::SceneItem::Ptr& item) const override;
+
+}; // UsdTransform3dBaseHandler
+
+} // namespace ufe
+} // namespace MayaUsd

--- a/lib/mayaUsd/ufe/UsdTransform3dHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dHandler.cpp
@@ -17,6 +17,8 @@
 
 #include <mayaUsd/ufe/UsdSceneItem.h>
 
+#include <mayaUsd/ufe/UsdTransform3d.h>
+
 MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -30,7 +32,7 @@ UsdTransform3dHandler::~UsdTransform3dHandler()
 /*static*/
 UsdTransform3dHandler::Ptr UsdTransform3dHandler::create()
 {
-	return std::make_shared<UsdTransform3dHandler>();
+    return std::make_shared<UsdTransform3dHandler>();
 }
 
 //------------------------------------------------------------------------------
@@ -39,11 +41,12 @@ UsdTransform3dHandler::Ptr UsdTransform3dHandler::create()
 
 Ufe::Transform3d::Ptr UsdTransform3dHandler::transform3d(const Ufe::SceneItem::Ptr& item) const
 {
-	UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
+    UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
 #if !defined(NDEBUG)
-	assert(usdItem);
+    assert(usdItem);
 #endif
-	return UsdTransform3d::create(usdItem);
+
+    return UsdTransform3d::create(usdItem);
 }
 
 } // namespace ufe

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -96,7 +96,7 @@ public:
     void redo() { fOp.GetAttr().Set(fNewOpValue,  fTime); }
 
     UsdGeomXformOp          fOp;
-    const UsdTimeCode       fTime;
+    const UsdTimeCode       fTime; // Authoring time
     const VtValue           fPrevOpValue;
     VtValue                 fNewOpValue;
 };
@@ -112,7 +112,8 @@ public:
         const UsdTimeCode&       time
     ) : Ufe::TranslateUndoableCommand(item), UsdTRSUndoableCmdBase(op, time)
     {
-        fOpTransform = op.GetOpTransform(time);
+        // We always read from proxy shape time.
+        fOpTransform = op.GetOpTransform(getTime(item->path()));
     }
 
     void undo() override { UsdTRSUndoableCmdBase::undo(); }
@@ -142,7 +143,8 @@ public:
         const UsdTimeCode&       time
     ) : Ufe::RotateUndoableCommand(item), UsdTRSUndoableCmdBase(op, time)
     {
-        GfMatrix4d opTransform = op.GetOpTransform(time);
+        // We always read from proxy shape time.
+        GfMatrix4d opTransform = op.GetOpTransform(getTime(item->path()));
 
         // Other matrix decomposition code from AL:
         // from https://github.com/AnimalLogic/maya-usd/blob/8852bdbb1fc904ac80543cd6103489097fa00154/lib/usd/utils/MayaTransformAPI.cpp#L979-L1055
@@ -190,7 +192,8 @@ public:
         const UsdTimeCode&       time
     ) : Ufe::ScaleUndoableCommand(item), UsdTRSUndoableCmdBase(op, time)
     {
-        GfMatrix4d opTransform = op.GetOpTransform(time);
+        // We always read from proxy shape time.
+        GfMatrix4d opTransform = op.GetOpTransform(getTime(item->path()));
 
         // Other matrix decomposition code from AL:
         // from https://github.com/AnimalLogic/maya-usd/blob/8852bdbb1fc904ac80543cd6103489097fa00154/lib/usd/utils/MayaTransformAPI.cpp#L979-L1055

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -1,0 +1,375 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "UsdTransform3dMatrixOp.h"
+
+#include <mayaUsd/ufe/UsdSceneItem.h>
+#include <mayaUsd/ufe/Utils.h>
+
+#include <ufe/transform3dUndoableCommands.h>
+
+#include <pxr/usd/usdGeom/xformOp.h>
+#include <pxr/usd/usdGeom/xformable.h>
+#include <pxr/usd/usdGeom/xformCache.h>
+
+#include <pxr/base/gf/rotation.h>
+#include <pxr/base/gf/transform.h>
+
+#include <algorithm>
+
+namespace {
+
+using namespace MayaUsd::ufe;
+
+VtValue getValue(const UsdAttribute& attr, const UsdTimeCode& time)
+{
+    VtValue value;
+    attr.Get(&value, time);
+    return value;
+}
+
+const char* getMatrixOp()
+{
+    return std::getenv("MAYA_USD_MATRIX_XFORM_OP_NAME");
+}
+
+template<bool INCLUSIVE>
+GfMatrix4d computeLocalTransform(
+    const UsdPrim&        prim,                          
+    const UsdGeomXformOp& op,
+    const UsdTimeCode&    time
+)
+{
+    UsdGeomXformable xformable(prim);
+    bool unused;
+    auto ops = xformable.GetOrderedXformOps(&unused);
+
+    // FIXME  Searching for transform op in vector is awkward, as we've likely
+    // already done this to create the UsdTransform3dMatrixOp object itself.
+    // PPT, 10-Aug-2020.
+    auto i = std::find(ops.begin(), ops.end(), op);
+
+    if (i == ops.end()) {
+        TF_FATAL_ERROR("Matrix op %s not found in transform ops.", op.GetOpName().GetText());
+    }
+    // If we want the op to be included, increment i.
+    if (INCLUSIVE) {
+        ++i;
+    }
+    std::vector<UsdGeomXformOp> cfOps(std::distance(ops.begin(), i));
+    cfOps.assign(ops.begin(), i);
+
+    GfMatrix4d m(1);
+    if (!UsdGeomXformable::GetLocalTransformation(&m, cfOps, time)) {
+        TF_FATAL_ERROR("Local transformation computation for prim %s failed.", prim.GetPath().GetText());
+    }
+
+    return m;
+}
+
+auto computeLocalInclusiveTransform = computeLocalTransform<true>;
+auto computeLocalExclusiveTransform = computeLocalTransform<false>;
+
+// Helper class to factor out common code for translate, rotate, scale
+// undoable commands.
+class UsdTRSUndoableCmdBase {
+public:
+    UsdTRSUndoableCmdBase(
+        const UsdGeomXformOp&    op, 
+        const UsdTimeCode&       time
+    ) : fOp(op), fTime(time), fPrevOpValue(getValue(op.GetAttr(), time)), 
+        fNewOpValue(fPrevOpValue) {}
+        
+    void undo() { fOp.GetAttr().Set(fPrevOpValue, fTime); }
+    void redo() { fOp.GetAttr().Set(fNewOpValue,  fTime); }
+
+    UsdGeomXformOp          fOp;
+    const UsdTimeCode       fTime;
+    const VtValue           fPrevOpValue;
+    VtValue                 fNewOpValue;
+};
+
+// Command to set the translation on a scene item by setting a matrix transform
+// op at an arbitrary position in the transform op stack.
+class UsdTranslateUndoableCmd : public Ufe::TranslateUndoableCommand,
+    public UsdTRSUndoableCmdBase {
+public:
+    UsdTranslateUndoableCmd(
+        const UsdSceneItem::Ptr& item,
+        const UsdGeomXformOp&    op, 
+        const UsdTimeCode&       time
+    ) : Ufe::TranslateUndoableCommand(item), UsdTRSUndoableCmdBase(op, time)
+    {
+        fOpTransform = op.GetOpTransform(time);
+    }
+
+    void undo() override { UsdTRSUndoableCmdBase::undo(); }
+    void redo() override { UsdTRSUndoableCmdBase::redo(); }
+
+    // Executes the command by setting the translation onto the transform op.
+    bool translate(double x, double y, double z) override
+    {
+        fOpTransform.SetTranslateOnly(GfVec3d(x, y, z));
+        fNewOpValue = fOpTransform;
+        
+        redo();
+        return true;
+    }
+
+private:
+    GfMatrix4d fOpTransform;
+};
+
+class UsdRotateUndoableCmd : public Ufe::RotateUndoableCommand,
+    public UsdTRSUndoableCmdBase {
+
+public:
+    UsdRotateUndoableCmd(
+        const UsdSceneItem::Ptr& item,
+        const UsdGeomXformOp&    op, 
+        const UsdTimeCode&       time
+    ) : Ufe::RotateUndoableCommand(item), UsdTRSUndoableCmdBase(op, time)
+    {
+        GfMatrix4d opTransform = op.GetOpTransform(time);
+
+        // Other matrix decomposition code from AL:
+        // from https://github.com/AnimalLogic/maya-usd/blob/8852bdbb1fc904ac80543cd6103489097fa00154/lib/usd/utils/MayaTransformAPI.cpp#L979-L1055
+        GfMatrix4d unusedR, unusedP;
+        GfVec3d    s;
+        if (!opTransform.Factor(&unusedR, &s, &fU, &fT, &unusedP)) {
+            TF_FATAL_ERROR("Cannot decompose transform for op %s", op.GetOpName().GetText());
+        }
+        
+        fS = GfMatrix4d(GfVec4d(s[0], s[1], s[2], 1.0));
+    }
+
+    void undo() override { UsdTRSUndoableCmdBase::undo(); }
+    void redo() override { UsdTRSUndoableCmdBase::redo(); }
+
+    // Executes the command by setting the rotation onto the transform op.
+    bool rotate(double x, double y, double z) override
+    {
+        // Expect XYZ Euler angles in degrees.
+        GfMatrix3d r(GfRotation(GfVec3d::XAxis(),x) *
+                    GfRotation(GfVec3d::YAxis(),y) *
+                    GfRotation(GfVec3d::ZAxis(),z));
+
+        fU.SetRotate(r);
+      
+        GfMatrix4d opTransform = (fS * fU).SetTranslateOnly(fT);
+        fNewOpValue = opTransform;
+
+        redo();
+        return true;
+    }
+
+private:
+    GfVec3d    fT;
+    GfMatrix4d fS, fU;
+};
+
+class UsdScaleUndoableCmd : public Ufe::ScaleUndoableCommand,
+    public UsdTRSUndoableCmdBase {
+
+public:
+    UsdScaleUndoableCmd(
+        const UsdSceneItem::Ptr& item,
+        const UsdGeomXformOp&    op, 
+        const UsdTimeCode&       time
+    ) : Ufe::ScaleUndoableCommand(item), UsdTRSUndoableCmdBase(op, time)
+    {
+        GfMatrix4d opTransform = op.GetOpTransform(time);
+
+        // Other matrix decomposition code from AL:
+        // from https://github.com/AnimalLogic/maya-usd/blob/8852bdbb1fc904ac80543cd6103489097fa00154/lib/usd/utils/MayaTransformAPI.cpp#L979-L1055
+        GfMatrix4d unusedR, unusedP;
+        GfVec3d    unusedS;
+        if (!opTransform.Factor(&unusedR, &unusedS, &fU, &fT, &unusedP)) {
+            TF_FATAL_ERROR("Cannot decompose transform for op %s", op.GetOpName().GetText());
+        }
+    }
+
+    void undo() override { UsdTRSUndoableCmdBase::undo(); }
+    void redo() override { UsdTRSUndoableCmdBase::redo(); }
+
+    // Executes the command by setting the rotation onto the transform op.
+    bool scale(double x, double y, double z) override
+    {
+        GfMatrix4d opTransform = (GfMatrix4d(GfVec4d(x, y, z, 1.0)) * fU).SetTranslateOnly(fT);
+        fNewOpValue = opTransform;
+
+        redo();
+        return true;
+    }
+
+private:
+    GfVec3d    fT;
+    GfMatrix4d fU;
+};
+
+}
+
+MAYAUSD_NS_DEF {
+namespace ufe {
+
+UsdTransform3dMatrixOp::UsdTransform3dMatrixOp(
+    const UsdSceneItem::Ptr& item,
+    const UsdGeomXformOp&    op
+)
+    : UsdTransform3dBase(item), _op(op)
+{}
+
+/* static */
+UsdTransform3dMatrixOp::Ptr UsdTransform3dMatrixOp::create(
+    const UsdSceneItem::Ptr& item,
+    const UsdGeomXformOp&    op
+)
+{
+    return std::make_shared<UsdTransform3dMatrixOp>(item, op);
+}
+
+Ufe::Vector3d UsdTransform3dMatrixOp::translation() const
+{
+    auto local = computeLocalInclusiveTransform(prim(), _op, getTime(path()));
+    return toUfe(local.ExtractTranslation());
+}
+
+Ufe::Vector3d UsdTransform3dMatrixOp::rotation() const
+{
+    auto local = computeLocalInclusiveTransform(prim(), _op, getTime(path()));
+    return toUfe(local.DecomposeRotation(GfVec3d::XAxis(), GfVec3d::YAxis(), GfVec3d::ZAxis()));
+}
+
+Ufe::Vector3d UsdTransform3dMatrixOp::scale() const
+{
+    auto local = computeLocalInclusiveTransform(prim(), _op, getTime(path()));
+    GfMatrix4d unusedR, unusedP, unusedU;
+    GfVec3d    s, unusedT;
+    if (!local.Factor(&unusedR, &s, &unusedU, &unusedT, &unusedP)) {
+            TF_WARN("Cannot decompose local transform for %s", pathCStr());
+            return Ufe::Vector3d(1, 1, 1);
+    }
+    
+    return toUfe(s);
+}
+
+Ufe::TranslateUndoableCommand::Ptr UsdTransform3dMatrixOp::translateCmd(double x, double y, double z)
+{
+    return std::make_shared<UsdTranslateUndoableCmd>(
+        usdSceneItem(), _op, UsdTimeCode::Default());
+}
+
+Ufe::RotateUndoableCommand::Ptr UsdTransform3dMatrixOp::rotateCmd(
+    double x, double y, double z
+)
+{
+    return std::make_shared<UsdRotateUndoableCmd>(
+        usdSceneItem(), _op, UsdTimeCode::Default());
+}
+
+Ufe::ScaleUndoableCommand::Ptr UsdTransform3dMatrixOp::scaleCmd(
+    double x, double y, double z
+)
+{
+    return std::make_shared<UsdScaleUndoableCmd>(
+        usdSceneItem(), _op, UsdTimeCode::Default());
+}
+
+Ufe::Matrix4d UsdTransform3dMatrixOp::segmentInclusiveMatrix() const
+{
+    // Get the parent transform plus all ops including the requested one.
+    auto time = getTime(path());
+    UsdGeomXformCache xformCache(time);
+    auto parent = xformCache.GetParentToWorldTransform(prim());
+    auto local = computeLocalInclusiveTransform(prim(), _op, time);
+    return toUfe(local * parent);
+}
+ 
+Ufe::Matrix4d UsdTransform3dMatrixOp::segmentExclusiveMatrix() const
+{
+    // Get the parent transform plus all ops excluding the requested one.
+    auto time = getTime(path());
+    UsdGeomXformCache xformCache(time);
+    auto parent = xformCache.GetParentToWorldTransform(prim());
+    auto local = computeLocalExclusiveTransform(prim(), _op, time);
+    return toUfe(local * parent);
+}
+
+//------------------------------------------------------------------------------
+// UsdTransform3dMatrixOpHandler
+//------------------------------------------------------------------------------
+
+UsdTransform3dMatrixOpHandler::UsdTransform3dMatrixOpHandler(
+    const Ufe::Transform3dHandler::Ptr& nextHandler
+) : UsdTransform3dBaseHandler(), _nextHandler(nextHandler)
+{}
+
+/*static*/
+UsdTransform3dMatrixOpHandler::Ptr UsdTransform3dMatrixOpHandler::create(
+    const Ufe::Transform3dHandler::Ptr& nextHandler
+)
+{
+    return std::make_shared<UsdTransform3dMatrixOpHandler>(nextHandler);
+}
+
+Ufe::Transform3d::Ptr UsdTransform3dMatrixOpHandler::transform3d(
+    const Ufe::SceneItem::Ptr& item
+) const
+{
+    // This method can be used to edit the 3D transform of the argument, but at
+    // time of writing this is not implemented in UsdTransform3dMatrixOp, and
+    // our UsdTransform3dBaseHandler base class does not know how to edit the
+    // argument either.  Simply delegate to the next handler in the list.
+    return _nextHandler->transform3d(item);
+}
+
+Ufe::Transform3d::Ptr UsdTransform3dMatrixOpHandler::editTransform3d(
+    const Ufe::SceneItem::Ptr& item
+) const
+{
+    UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
+#if !defined(NDEBUG)
+    assert(usdItem);
+#endif
+
+    // Beware: the default UsdGeomXformOp constructor
+    // https://github.com/PixarAnimationStudios/USD/blob/71b4baace2044ea4400ba802e91667f9ebe342f0/pxr/usd/usdGeom/xformOp.h#L148    
+    // leaves the _opType enum data member uninitialized, which as per
+    // https://stackoverflow.com/questions/6842799/enum-variable-default-value/6842821
+    // is undefined behavior, so a default constructed UsdGeomXformOp cannot be
+    // used as a UsdGeomXformOp::TypeInvalid sentinel value.  PPT, 10-Aug-20.
+
+    // We try to edit a matrix op in the prim's transform op stack.  If a
+    // matrix op has been specified, it will be used if found.  If a matrix op
+    // has not been specified, we edit the first matrix op in the stack.  If
+    // the matrix op is not found, or there is no matrix op in the stack, let
+    // the next Transform3d handler in the chain handle the request.
+    auto opName = getMatrixOp();
+    UsdGeomXformable xformable(usdItem->prim());
+    bool unused;
+    auto xformOps = xformable.GetOrderedXformOps(&unused);
+    auto i = std::find_if(xformOps.begin(), xformOps.end(), 
+        [opName](const UsdGeomXformOp& op) {
+            return (op.GetOpType() == UsdGeomXformOp::TypeTransform) &&
+                (!opName || std::string(opName) == op.GetOpName());
+    });
+    bool foundMatrix = (i != xformOps.end());
+
+    return foundMatrix ? UsdTransform3dMatrixOp::create(usdItem, *i) :
+        _nextHandler->editTransform3d(item);
+}
+
+} // namespace ufe
+} // namespace MayaUsd

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.h
@@ -1,0 +1,109 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <mayaUsd/ufe/UsdTransform3dBase.h>
+
+#include <pxr/usd/usdGeom/xformOp.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+MAYAUSD_NS_DEF {
+namespace ufe {
+
+//! \brief Interface to transform objects in 3D.
+//
+// The UsdTransform3dMatrixOp class implements the Transform3d interface for a
+// single UsdGeomXformOp matrix transform op in a UsdGeomXformable prim.  It
+// allows reading and editing the local transformation of that single transform
+// op.  The parent transformation of the transform op is the concatenation of
+// the scene item's parent transformation and the combined transformation of
+// all transform ops preceding this one.
+//
+// This is a departure from the standard Transform3d interface, which allows
+// reading and editing the local transformation of the prim as a whole.  Having
+// the interface target a single transform op allows for fine-grained control
+// and editing of individual transform ops.  To read the local transformation
+// of the prim as a whole, use UsdTransform3dBase.
+//
+// Note that all calls to specify time use the default time, but this
+// could be changed to use the current time, using getTime(path()).
+
+class MAYAUSD_CORE_PUBLIC UsdTransform3dMatrixOp : public UsdTransform3dBase
+{
+public:
+    typedef std::shared_ptr<UsdTransform3dMatrixOp> Ptr;
+
+    UsdTransform3dMatrixOp(
+        const UsdSceneItem::Ptr& item,
+        const UsdGeomXformOp&    op
+    );
+    ~UsdTransform3dMatrixOp() override = default;
+
+    //! Create a UsdTransform3dMatrixOp.
+    static UsdTransform3dMatrixOp::Ptr create(
+        const UsdSceneItem::Ptr& item,
+        const UsdGeomXformOp&    op
+    );
+
+    Ufe::Vector3d translation() const override;
+    Ufe::Vector3d rotation() const override;
+    Ufe::Vector3d scale() const override;
+
+    /* FIXME  Implement.  PPT, 10-Aug-2020.
+    void translate(double x, double y, double z) override;
+    void rotate(double x, double y, double z) override;
+    void scale(double x, double y, double z) override;
+    */
+
+    Ufe::TranslateUndoableCommand::Ptr translateCmd(double x, double y, double z) override;
+    Ufe::RotateUndoableCommand::Ptr rotateCmd(double x, double y, double z) override;
+    Ufe::ScaleUndoableCommand::Ptr scaleCmd(double x, double y, double z) override;
+
+    Ufe::Matrix4d segmentInclusiveMatrix() const override;
+    Ufe::Matrix4d segmentExclusiveMatrix() const override;
+
+private:
+
+    const UsdGeomXformOp _op;
+
+}; // UsdTransform3dMatrixOp
+
+//! \brief Factory to create a UsdTransform3dMatrixOp interface object.
+//
+// 
+class MAYAUSD_CORE_PUBLIC UsdTransform3dMatrixOpHandler : 
+    public UsdTransform3dBaseHandler
+{
+public:
+    typedef std::shared_ptr<UsdTransform3dMatrixOpHandler> Ptr;
+
+    UsdTransform3dMatrixOpHandler(const Ufe::Transform3dHandler::Ptr& nextHandler);
+
+    //! Create a UsdTransform3dMatrixOpHandler.
+    static Ptr create(const Ufe::Transform3dHandler::Ptr& nextHandler);
+
+    // Ufe::Transform3dHandler overrides
+    Ufe::Transform3d::Ptr transform3d(const Ufe::SceneItem::Ptr& item) const override;
+    Ufe::Transform3d::Ptr editTransform3d(const Ufe::SceneItem::Ptr& item) const override;
+
+private:
+    Ufe::Transform3dHandler::Ptr _nextHandler;
+
+}; // UsdTransform3dMatrixOpHandler
+
+} // namespace ufe
+} // namespace MayaUsd

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -35,6 +35,8 @@
 #include <mayaUsd/ufe/UsdStageMap.h>
 #include <mayaUsd/utils/util.h>
 
+#include <ufe/pathSegment.h>
+
 #include "private/Utils.h"
 
 PXR_NAMESPACE_USING_DIRECTIVE

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -16,8 +16,8 @@
 #pragma once
 
 #include <ufe/path.h>
-#include <ufe/pathSegment.h>
 #include <ufe/scene.h>
+#include <ufe/types.h>
 
 #include <maya/MDagPath.h>
 
@@ -29,7 +29,13 @@
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/ufe/UsdSceneItem.h>
 
+#include <cstring>		// memcpy
+
 PXR_NAMESPACE_USING_DIRECTIVE
+
+UFE_NS_DEF {
+class PathSegment;
+}
 
 MAYAUSD_NS_DEF {
 namespace ufe {
@@ -92,6 +98,20 @@ void sendNotification(const Ufe::SceneItem::Ptr& item, const Ufe::Path& previous
 inline
 UsdSceneItem::Ptr downcast(const Ufe::SceneItem::Ptr& item) {
     return std::dynamic_pointer_cast<UsdSceneItem>(item);
+}
+
+//! Copy the argument matrix into the return matrix.
+inline Ufe::Matrix4d toUfe(const GfMatrix4d& src)
+{
+    Ufe::Matrix4d dst;
+    std::memcpy(&dst.matrix[0][0], src.GetArray(), sizeof(double) * 16);
+    return dst;
+}
+
+//! Copy the argument vector into the return vector.
+inline Ufe::Vector3d toUfe(const GfVec3d& src)
+{
+  return Ufe::Vector3d(src[0], src[1], src[2]);
 }
 
 } // namespace ufe


### PR DESCRIPTION
# Editing Matrix Transform Op Proof of Concept

This branch is a proof of concept for editing USD matrix transform ops
with maya-usd.  A more detailed architectural overview is given in
lib/mayaUsd/ufe/UsdTransform3d.md .

## Relevant Requirements 

As per lib/mayaUsd/ufe/UsdTransform3d.md , the following two
requirements are the focus of this branch:
- 2 *Manipulation code will use an interface that takes care of transformation
operations management. Pipelines may choose to change this interface at runtime
to improve interop between DCCs.*  This is met by the existing customizable
Transform3dHandler system, which can create custom Transform3d interfaces.
Pipelines can leverage this mechanism to introduce studio-specific overrides
without modifying the default implementation or having to maintain and resolve
conflicts when the default implementation changes. In other words, the default
implementation and studio overrides will be leveraging a stable common
interface.
- 6 *UFE API should provide UFE-USD plugin with an interface to handle the
in-place editing of any arbitrary transformation stacks, i.e. target any
transformation op.*  The foundations for meeting this requirement is the
addition of the `Transform3dHandler::editTransform3d()` method.  As presented
in the proof of concept MatrixOp handler implementation, this allows writing
custom Transform3d interfaces targeting specific transform ops.  We are open to
feedback to identify potential other UFE API gaps when it comes to
requirement 6.

## Files of Interest

An important demonstration in this branch is the capability to
entirely replace at run-time the factory that creates Transform3d
interface objects, the Transform3dHandler.  This allows a plugin to
develop its own Transform3dHandler and its own Transform3d, without
changing maya-usd core code, and to be able to have UFE use it.

For the Autodesk plugin, we replace the default Transform3dHandler
with a new one in file plugin/adsk/plugin/plugin.cpp .  The new
Transform3dHandler sets up a chain of responsibility, with the new
UsdTransform3dMatrixOpHandler being given the existing
Transform3dHandler as an argument, so it can later delegate to it.
Please note that *this chain of responsibility software structure is
entirely optional!* The main point is that you can replace the
Transform3dHandler for your plugin with your own Transform3dHandler,
which can be a single, monolithic handler, or a chain of more granular
handlers, or any implementation of the Transform3dHandler interface
you choose.

File lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp is where most of the
new code is.  It has the UsdTransform3dMatrixOp implementation of the
Ufe::Transform3d interface, which targets an individual matrix
transform op.  It also has the UsdTransform3dMatrixOpHandler, which
shows how to set up the Transform3dHandler chain of responsibility.
The handler is given an item for which to create a Transform3d
interface.  If it can, it creates and returns a UsdTransform3dMatrixOp
interface.  If it cannot, it passes on to the next handler in the
chain, which in the case of the Autodesk plugin is the existing
UsdTransform3dHandler.

## Use in Maya

To use this branch in Maya to edit a given matrix transform op, the
transform op's name must be given to maya-usd.  This branch provides
no real workflow around the support, so a simple environment variable
is used.  The following Python script can be used to set the transform
op's name for the selected prim to be
"xformOp:transform:relative:_1:RIG",
"xformOp:transform:relative:_2:WORLD", or
"xformOp:transform:relative:_3:DIRECTION", respectively.  Notifying of
a transform change through UFE updates the Maya manipulator.  If no
matrix transform op name is given, the first matrix transform op will
be edited.  If a non-existent matrix transform op name is given, no
editing will be done.  If no matrix transform op exists, the current
maya-usd Transform3dHandler will be used.
```Python
from __future__ import print_function
import os
import ufe

def setMatrixOp(name):
    os.environ['MAYA_USD_MATRIX_XFORM_OP_NAME'] = name
    sn = ufe.GlobalSelection.get()
    if not sn:
        print("Empty selection, cannot notify Transform3d observers.")
        return
    ufe.Transform3d.notify(sn.front().path())

setMatrixOp("xformOp:transform:relative:_1:RIG")
setMatrixOp("xformOp:transform:relative:_2:WORLD")
setMatrixOp("xformOp:transform:relative:_3:DIRECTION")
```
