### PR TITLE
Eliminate any std::bind in favor of lambda

### DIFF
--- a/lib/mayaUsd/fileio/functorPrimReader.cpp
+++ b/lib/mayaUsd/fileio/functorPrimReader.cpp
@@ -45,10 +45,9 @@ UsdMayaPrimReaderRegistry::ReaderFactoryFn
 UsdMaya_FunctorPrimReader::CreateFactory(
     UsdMayaPrimReaderRegistry::ReaderFn readerFn)
 {
-    return std::bind(
-            Create,
-            std::placeholders::_1,
-            readerFn);
+    return [=](const UsdMayaPrimReaderArgs& args) { 
+        return Create(args, readerFn); 
+    };
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/functorPrimWriter.cpp
+++ b/lib/mayaUsd/fileio/functorPrimWriter.cpp
@@ -107,12 +107,11 @@ UsdMayaPrimWriterRegistry::WriterFactoryFn
 UsdMaya_FunctorPrimWriter::CreateFactory(
         UsdMayaPrimWriterRegistry::WriterFn fn)
 {
-    return std::bind(
-            Create,
-            std::placeholders::_1,
-            std::placeholders::_2,
-            std::placeholders::_3,
-            fn);
+    return [=](const MFnDependencyNode& depNodeFn, 
+               const SdfPath& usdPath, 
+               UsdMayaWriteJobContext& jobCtx) { 
+        return Create(depNodeFn, usdPath, jobCtx, fn); 
+    };
 }
 
 


### PR DESCRIPTION
Favour lambda over std::bind to avoid the unnecessary overheads that comes with std::bind 