### PR TITLE
adapt to refactoring in core USD of registry handling of prim specs versus prim definitions

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -31,7 +31,7 @@ See Pixar's official github page for instructions on how to build USD: https://g
 
 |               |      ![](images/pxr.png)          |        
 |:------------: |:---------------:                  |
-|  CommitID/Tags | release: [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) <br> dev: [8a13d20](https://github.com/PixarAnimationStudios/USD/commit/8a13d20062d14d486b7e130d252c4652aab0263e) |
+|  CommitID/Tags | release: [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) <br> dev: [5d1771d](https://github.com/PixarAnimationStudios/USD/commit/5d1771d23b935740bcd5bfb985a92a6652e070c0) |
 
 For additional information on building Pixar USD, see the ***Additional Build Instruction*** section below.
 

--- a/lib/mayaUsd/fileio/utils/adaptor.cpp
+++ b/lib/mayaUsd/fileio/utils/adaptor.cpp
@@ -183,10 +183,10 @@ UsdMayaAdaptor::GetSchemaByName(const TfToken& schemaName) const
         return SchemaAdaptor();
     }
 
+#if USD_VERSION_NUM > 2002
     // Get the schema definition. If it's registered, there should be a def.
     SdfPrimSpecHandle primSpec;
 
-#if USD_VERSION_NUM > 2002
     // Is this an API schema?
     const UsdSchemaRegistry &schemaReg = UsdSchemaRegistry::GetInstance();
     if (const UsdPrimDefinition *primDef =
@@ -217,7 +217,14 @@ UsdMayaAdaptor::GetSchemaByName(const TfToken& schemaName) const
             return SchemaAdaptor();
         }
     }
+
+    if (primSpec) {
+        return SchemaAdaptor(_handle.object(), primSpec);
+    }
 #else
+    // Get the schema definition. If it's registered, there should be a def.
+    SdfPrimSpecHandle primSpec;
+
     // Get the schema's TfType; its name should be registered as an alias.
     const TfType schemaType =
             TfType::Find<UsdSchemaBase>().FindDerivedByName(schemaName);
@@ -251,11 +258,11 @@ UsdMayaAdaptor::GetSchemaByName(const TfToken& schemaName) const
             return SchemaAdaptor();
         }
     }
-#endif
 
     if (primSpec) {
         return SchemaAdaptor(_handle.object(), primSpec);
     }
+#endif
 
     // We shouldn't be able to reach this (everything is either typed or API).
     TF_CODING_ERROR("'%s' isn't a known API or typed schema",
@@ -344,6 +351,24 @@ UsdMayaAdaptor::ApplySchemaByName(
     }
 
     SdfPrimSpecHandle primSpec = primDef->GetSchemaPrimSpec();
+    if (!primSpec) {
+        TF_CODING_ERROR("Can't find schema definition for name '%s'",
+                schemaName.GetText());
+        return SchemaAdaptor();
+    }
+
+    // Add to schema list (if not yet present).
+    TfTokenVector currentSchemas = GetAppliedSchemas();
+    if (std::find(currentSchemas.begin(), currentSchemas.end(), schemaName) ==
+            currentSchemas.end()) {
+        currentSchemas.push_back(schemaName);
+        SetMetadata(
+                UsdTokens->apiSchemas,
+                _GetListOpForTokenVector(currentSchemas),
+                modifier);
+    }
+
+    return SchemaAdaptor(_handle.object(), primSpec);
 #else 
     // Get the schema's TfType; its name should be registered as an alias.
     const TfType schemaType =
@@ -366,8 +391,6 @@ UsdMayaAdaptor::ApplySchemaByName(
     // Get the schema definition. If it's registered, there should be a def.
     SdfPrimSpecHandle primSpec =
         UsdSchemaRegistry::GetInstance().GetPrimDefinition(schemaName);
-#endif
-
     if (!primSpec) {
         TF_CODING_ERROR("Can't find schema definition for name '%s'",
                 schemaName.GetText());
@@ -386,6 +409,7 @@ UsdMayaAdaptor::ApplySchemaByName(
     }
 
     return SchemaAdaptor(_handle.object(), primSpec);
+#endif
 }
 
 void
@@ -715,7 +739,9 @@ UsdMayaAdaptor::SchemaAdaptor::SchemaAdaptor()
 
 UsdMayaAdaptor::SchemaAdaptor::SchemaAdaptor(
     const MObjectHandle& handle, SdfPrimSpecHandle schemaDef)
-    : _handle(handle), _schemaDef(schemaDef)
+    : _handle(handle)
+    , _schemaDef(schemaDef)
+    , _schemaName(schemaDef->GetNameToken())
 {
 }
 
@@ -732,7 +758,7 @@ UsdMayaAdaptor::SchemaAdaptor::operator bool() const
 
 std::string
 UsdMayaAdaptor::SchemaAdaptor::_GetMayaAttrNameOrAlias(
-    const SdfAttributeSpecHandle& attrSpec) const
+    const TfToken& name) const
 {
     if (!*this) {
         TF_CODING_ERROR("Schema adaptor is not valid");
@@ -745,7 +771,6 @@ UsdMayaAdaptor::SchemaAdaptor::_GetMayaAttrNameOrAlias(
     MFnDependencyNode depNode(thisObject);
 
     // If the generated name exists, it is the most preferred name,
-    const TfToken name = attrSpec->GetNameToken();
     const std::string genName = _GetMayaAttrNameForAttrName(name);
     if (depNode.hasAttribute(genName.c_str())) {
         return genName;
@@ -784,7 +809,14 @@ UsdMayaAdaptor::SchemaAdaptor::GetName() const
         return TfToken();
     }
 
-    return _schemaDef->GetNameToken();
+    return _schemaName;
+}
+
+static 
+SdfAttributeSpecHandle
+_GetAttributeSpec(const SdfPrimSpecHandle &primSpec, const TfToken &attrName) 
+{
+    return primSpec->GetAttributes()[attrName];
 }
 
 UsdMayaAdaptor::AttributeAdaptor
@@ -794,14 +826,14 @@ UsdMayaAdaptor::SchemaAdaptor::GetAttribute(const TfToken& attrName) const
         return AttributeAdaptor();
     }
 
-    SdfAttributeSpecHandle attrDef = _schemaDef->GetAttributes()[attrName];
+    SdfAttributeSpecHandle attrDef = _GetAttributeSpec(_schemaDef, attrName);
     if (!attrDef) {
         TF_CODING_ERROR("Attribute '%s' doesn't exist on schema '%s'",
-                attrName.GetText(), _schemaDef->GetName().c_str());
+                attrName.GetText(), _schemaName.GetText());
         return AttributeAdaptor();
     }
 
-    std::string mayaAttrName = _GetMayaAttrNameOrAlias(attrDef);
+    std::string mayaAttrName = _GetMayaAttrNameOrAlias(attrName);
     MFnDependencyNode node(_handle.object());
     MPlug plug = node.findPlug(mayaAttrName.c_str());
     if (plug.isNull()) {
@@ -827,14 +859,14 @@ UsdMayaAdaptor::SchemaAdaptor::CreateAttribute(
         return AttributeAdaptor();
     }
 
-    SdfAttributeSpecHandle attrDef = _schemaDef->GetAttributes()[attrName];
+    SdfAttributeSpecHandle attrDef = _GetAttributeSpec(_schemaDef, attrName);
     if (!attrDef) {
         TF_CODING_ERROR("Attribute '%s' doesn't exist on schema '%s'",
-                attrName.GetText(), _schemaDef->GetName().c_str());
+                attrName.GetText(), _schemaName.GetText());
         return AttributeAdaptor();
     }
 
-    std::string mayaAttrName = _GetMayaAttrNameOrAlias(attrDef);
+    std::string mayaAttrName = _GetMayaAttrNameOrAlias(attrName);
     std::string mayaNiceAttrName = attrDef->GetName();
     MFnDependencyNode node(_handle.object());
 
@@ -874,14 +906,14 @@ UsdMayaAdaptor::SchemaAdaptor::RemoveAttribute(
         return;
     }
 
-    SdfAttributeSpecHandle attrDef = _schemaDef->GetAttributes()[attrName];
+    SdfAttributeSpecHandle attrDef = _GetAttributeSpec(_schemaDef, attrName);
     if (!attrDef) {
         TF_CODING_ERROR("Attribute '%s' doesn't exist on schema '%s'",
-                attrName.GetText(), _schemaDef->GetName().c_str());
+                attrName.GetText(), _schemaName.GetText());
         return;
     }
 
-    std::string mayaAttrName = _GetMayaAttrNameOrAlias(attrDef);
+    std::string mayaAttrName = _GetMayaAttrNameOrAlias(attrName);
     MFnDependencyNode node(_handle.object());
     if (node.hasAttribute(mayaAttrName.c_str())) {
         MObject attr = node.attribute(mayaAttrName.c_str());
@@ -900,7 +932,7 @@ UsdMayaAdaptor::SchemaAdaptor::GetAuthoredAttributeNames() const
     MFnDependencyNode node(_handle.object());
     TfTokenVector result;
     for (const SdfAttributeSpecHandle& attr : _schemaDef->GetAttributes()) {
-        std::string mayaAttrName = _GetMayaAttrNameOrAlias(attr);
+        std::string mayaAttrName = _GetMayaAttrNameOrAlias(attr->GetNameToken());
         if (node.hasAttribute(mayaAttrName.c_str())) {
             result.push_back(attr->GetNameToken());
         }

--- a/lib/mayaUsd/fileio/utils/adaptor.h
+++ b/lib/mayaUsd/fileio/utils/adaptor.h
@@ -217,15 +217,26 @@ public:
     /// import.
     class SchemaAdaptor {
         MObjectHandle _handle;
+#if USD_VERSION_NUM > 2002
+        const UsdPrimDefinition *_schemaDef;
+#else
         SdfPrimSpecHandle _schemaDef;
+#endif
         TfToken _schemaName;
 
     public:
         MAYAUSD_CORE_PUBLIC
         SchemaAdaptor();
 
+#if USD_VERSION_NUM > 2002
+        MAYAUSD_CORE_PUBLIC
+        SchemaAdaptor(const MObjectHandle& object, 
+                      const TfToken &schemaName,
+                      const UsdPrimDefinition *schemaPrimDef);
+#else
         MAYAUSD_CORE_PUBLIC
         SchemaAdaptor(const MObjectHandle& object, SdfPrimSpecHandle schemaDef);
+#endif
 
         MAYAUSD_CORE_PUBLIC
         explicit operator bool() const;
@@ -303,10 +314,17 @@ public:
         MAYAUSD_CORE_PUBLIC
         TfTokenVector GetAttributeNames() const;
 
+#if USD_VERSION_NUM > 2002
+        /// Gets the prim definition for this schema from the schema registry.
+        /// Returns a null pointer if this schema adaptor is invalid.
+        MAYAUSD_CORE_PUBLIC
+        const UsdPrimDefinition *GetSchemaDefinition() const;
+#else 
         /// Gets the prim spec for this schema from the schema registry.
         /// Returns a null handle if this schema adaptor is invalid.
         MAYAUSD_CORE_PUBLIC
         const SdfPrimSpecHandle GetSchemaDefinition() const;
+#endif
 
     private:
         /// Gets the name of the adapted Maya attribute for the given attribute

--- a/lib/mayaUsd/fileio/utils/adaptor.h
+++ b/lib/mayaUsd/fileio/utils/adaptor.h
@@ -218,6 +218,7 @@ public:
     class SchemaAdaptor {
         MObjectHandle _handle;
         SdfPrimSpecHandle _schemaDef;
+        TfToken _schemaName;
 
     public:
         MAYAUSD_CORE_PUBLIC
@@ -309,10 +310,9 @@ public:
 
     private:
         /// Gets the name of the adapted Maya attribute for the given attribute
-        /// definition. The name may come from the registered aliases if one
+        /// name. The name may come from the registered aliases if one
         /// exists and is already present on the node.
-        std::string _GetMayaAttrNameOrAlias(
-                const SdfAttributeSpecHandle& attrSpec) const;
+        std::string _GetMayaAttrNameOrAlias(const TfToken& attrName) const;
     };
 
     MAYAUSD_CORE_PUBLIC


### PR DESCRIPTION
These changes were made by the core USD team to allow some refactoring in the schema registry. They make use of API added in core USD version 20.05 so older APIs can be removed for later versions of USD. Support for older versions of USD is maintained as well.

The changes here are required to build against core USD at commit https://github.com/PixarAnimationStudios/USD/commit/0e3171a02b5b854c36d58c4ca74c7a8fa3ac2b8a or later.