### PR TITLE
apply UsdGeomModelAPI schema to test assets that exercise the drawMode adapter

### DIFF
--- a/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/InstancerDrawTest/CubeModel.usda
+++ b/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/InstancerDrawTest/CubeModel.usda
@@ -14,6 +14,7 @@ def Xform "CubeModel" (
     variants = {
         string shadingVariant = "Default"
     }
+    prepend apiSchemas = ["GeomModelAPI"]
 )
 {
     uniform token model:cardGeometry = "cross"

--- a/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/RefAssemblyDrawRepresentationsTest/CubeModel.usda
+++ b/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/RefAssemblyDrawRepresentationsTest/CubeModel.usda
@@ -14,6 +14,7 @@ def Xform "CubeModel" (
     variants = {
         string shadingVariant = "Default"
     }
+    prepend apiSchemas = ["GeomModelAPI"]
 )
 {
     uniform token model:cardGeometry = "cross"


### PR DESCRIPTION
In core USD, the test to determine whether a draw mode is used for a particular prim was updated to require that that prim has had the UsdGeomModelAPI schema applied to it. Most "modern" assets should have this already if they used the API schema to author draw mode, but these are some old test assets that were authored before the API schema applied itself when authoring the drawMode.

This change corresponds to core USD commit
https://github.com/PixarAnimationStudios/USD/commit/ccf9a3ddc8cdaf8ec9d5867418ebc947ca00d799