### PR TITLE
MAYA-105604 Handle empty relative path

### DIFF
--- a/lib/usd/translators/shading/usdFileTextureWriter.cpp
+++ b/lib/usd/translators/shading/usdFileTextureWriter.cpp
@@ -218,7 +218,7 @@ PxrUsdTranslators_FileTextureWriter::Write(const UsdTimeCode& usdTime)
     usdDir = usdDir.parent_path();
     boost::system::error_code ec;
     boost::filesystem::path relativePath = boost::filesystem::relative(fileTextureName, usdDir, ec);
-    if (!ec) {
+    if (!ec && !relativePath.empty()) {
         fileTextureName = relativePath.generic_string();
     }
 


### PR DESCRIPTION
Boost filesystem will return an empty path when it can not find a
relative one. This will happen when the USD file and the textures are
not on the same Windows drive, or with UNC paths.