### PR TITLE
Reset version ids and dirty information when the USD stage is cleared.

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -365,6 +365,12 @@ void ProxyRenderDelegate::_ClearRenderDelegate()
     _taskController.reset();
     _renderIndex.reset();
     _renderDelegate.reset();
+
+    // reset any version ids or dirty information that doesn't make sense if we clear
+    // the render index.
+    _renderTagVersion = 0;
+    _visibilityVersion = 0;
+    _taskRenderTagsValid = false;
 }
 
 //! \brief  One time initialization of this drawing routine


### PR DESCRIPTION
When the USD stage is set on proxyRenderDelegate we clear the change tracker and render index. At the same time we need to reset the dirty information that we use to track the state of the render index. Once the render index is cleared that old dirty information is meaningless, and sometimes causes us to do the wrong thing when the stage is replaced.