### PR TITLE
[mayaUsdUI] replace #pragma once with #ifndef include guards

### DIFF
--- a/lib/usd/ui/IMayaMQtUtil.h
+++ b/lib/usd/ui/IMayaMQtUtil.h
@@ -14,7 +14,9 @@
 // limitations under the License.
 //
 
-#pragma once
+#ifndef MAYAUSDUI_I_MAYA_MQT_UTIL_H
+#define MAYAUSDUI_I_MAYA_MQT_UTIL_H
+
 
 #include <string>
 
@@ -44,3 +46,6 @@ public:
 };
 
 } // namespace MayaUsd
+
+
+#endif

--- a/lib/usd/ui/IUSDImportView.h
+++ b/lib/usd/ui/IUSDImportView.h
@@ -14,7 +14,9 @@
 // limitations under the License.
 //
 
-#pragma once
+#ifndef MAYAUSDUI_I_USD_IMPORT_VIEW_H
+#define MAYAUSDUI_I_USD_IMPORT_VIEW_H
+
 
 #include <pxr/usd/usd/stage.h>
 
@@ -61,3 +63,6 @@ public:
 };
 
 } // namespace MayaUsd
+
+
+#endif

--- a/lib/usd/ui/ItemDelegate.h
+++ b/lib/usd/ui/ItemDelegate.h
@@ -14,7 +14,9 @@
 // limitations under the License.
 //
 
-#pragma once
+#ifndef MAYAUSDUI_ITEM_DELEGATE_H
+#define MAYAUSDUI_ITEM_DELEGATE_H
+
 
 #include <QtCore/QList>
 #include <QtCore/QStringList>
@@ -118,3 +120,6 @@ private:
 }; // VariantsEditorWidget
 
 } // namespace MayaUsd
+
+
+#endif

--- a/lib/usd/ui/TreeItem.h
+++ b/lib/usd/ui/TreeItem.h
@@ -14,7 +14,9 @@
 // limitations under the License.
 //
 
-#pragma once
+#ifndef MAYAUSDUI_TREE_ITEM_H
+#define MAYAUSDUI_TREE_ITEM_H
+
 
 #include <QtGui/QStandardItem>
 #include <QtGui/QPixmap>
@@ -124,3 +126,6 @@ protected:
 };
 
 } // namespace MayaUsd
+
+
+#endif

--- a/lib/usd/ui/TreeModel.h
+++ b/lib/usd/ui/TreeModel.h
@@ -14,7 +14,9 @@
 // limitations under the License.
 //
 
-#pragma once
+#ifndef MAYAUSDUI_TREE_MODEL_H
+#define MAYAUSDUI_TREE_MODEL_H
+
 
 #include <QtGui/QStandardItemModel>
 
@@ -108,3 +110,6 @@ private:
 };
 
 } // namespace MayaUsd
+
+
+#endif

--- a/lib/usd/ui/TreeModelFactory.h
+++ b/lib/usd/ui/TreeModelFactory.h
@@ -14,7 +14,9 @@
 // limitations under the License.
 //
 
-#pragma once
+#ifndef MAYAUSDUI_TREE_MODEL_FACTORY_H
+#define MAYAUSDUI_TREE_MODEL_FACTORY_H
+
 
 #include <memory>
 #include <unordered_set>
@@ -102,3 +104,6 @@ protected:
 };
 
 } // namespace MayaUsd
+
+
+#endif

--- a/lib/usd/ui/USDImportDialog.h
+++ b/lib/usd/ui/USDImportDialog.h
@@ -14,7 +14,9 @@
 // limitations under the License.
 //
 
-#pragma once
+#ifndef MAYAUSDUI_USD_IMPORT_DIALOG_H
+#define MAYAUSDUI_USD_IMPORT_DIALOG_H
+
 
 #include <memory>
 
@@ -100,3 +102,6 @@ protected:
 };
 
 } // namespace MayaUsd
+
+
+#endif

--- a/lib/usd/ui/USDImportDialogCmd.h
+++ b/lib/usd/ui/USDImportDialogCmd.h
@@ -14,7 +14,9 @@
 // limitations under the License.
 //
 
-#pragma once
+#ifndef MAYAUSDUI_USD_IMPORT_DIALOG_CMD_H
+#define MAYAUSDUI_USD_IMPORT_DIALOG_CMD_H
+
 
 #include <maya/MPxCommand.h>
 
@@ -44,3 +46,6 @@ private:
 };
 
 } // namespace MayaUsd
+
+
+#endif

--- a/lib/usd/ui/USDQtUtil.h
+++ b/lib/usd/ui/USDQtUtil.h
@@ -14,7 +14,9 @@
 // limitations under the License.
 //
 
-#pragma once
+#ifndef MAYAUSDUI_USD_QT_UTIL_H
+#define MAYAUSDUI_USD_QT_UTIL_H
+
 
 #include <mayaUsd/mayaUsd.h>
 
@@ -34,3 +36,6 @@ public:
 };
 
 } // namespace MayaUsd
+
+
+#endif


### PR DESCRIPTION
We're finally getting our VFX platform 2019 and Maya 2020+ builds into a place where we're able to build the UI components of maya-usd, but I ended up tripping over the `#pragma once` directives being used there. I'm not sure exactly what the specific difference in setup is between our build internally and the CMake build, but since we landed on include guards being preferred to `#pragma once` in the coding guidelines, I just converted all of the headers in mayaUsdUI.