### PR TITLE
use the un-linearized lambert transparency to author displayOpacity when using displayColors shading mode

### DIFF
--- a/lib/mayaUsd/fileio/shading/shadingModeDisplayColor.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeDisplayColor.cpp
@@ -99,6 +99,13 @@ private:
 
         GfVec3f color;
         GfVec3f transparency;
+
+        // We might use the Maya shading node's transparency to author a scalar
+        // displayOpacity value on the UsdGeomGprim, as well as an input on the
+        // shader prim. How we compute that value will depend on which Maya
+        // shading node we're working with.
+        float transparencyAvg;
+
         const MFnLambertShader lambertFn(ssDepNode.object(), &status);
         if (status == MS::kSuccess) {
             const MColor mayaColor = lambertFn.color();
@@ -108,6 +115,11 @@ private:
                 diffuseCoeff*GfVec3f(mayaColor[0], mayaColor[1], mayaColor[2]));
             transparency = UsdMayaColorSpace::ConvertMayaToLinear(
                 GfVec3f(mayaTransparency[0], mayaTransparency[1], mayaTransparency[2]));
+            // Compute the average transparency using the un-linearized Maya
+            // value.
+            transparencyAvg = (mayaTransparency[0] +
+                               mayaTransparency[1] +
+                               mayaTransparency[2]) / 3.0f;
         } else {
 #if MAYA_API_VERSION >= 20200000
             const MFnStandardSurfaceShader surfaceFn(ssDepNode.object(), &status);
@@ -120,6 +132,9 @@ private:
                 base*GfVec3f(mayaColor[0], mayaColor[1], mayaColor[2]));
             const float mayaTransparency = surfaceFn.transmission();
             transparency = GfVec3f(mayaTransparency, mayaTransparency, mayaTransparency);
+            // We can directly use the scalar transmission value as the
+            // "average".
+            transparencyAvg = mayaTransparency;
 #else
             return;
 #endif
@@ -128,15 +143,7 @@ private:
         VtVec3fArray displayColorAry;
         displayColorAry.push_back(color);
 
-        // The simple UsdGeomGprim display shading schema only allows for a
-        // scalar opacity.  We compute it as the unweighted average of the
-        // components since it would be ridiculous to apply the inverse weighting
-        // (of the common graycale conversion) on re-import
-        // The average is compute from the Maya color as is
         VtFloatArray displayOpacityAry;
-        const float transparencyAvg = (transparency[0] +
-                                       transparency[1] +
-                                       transparency[2]) / 3.0f;
         if (transparencyAvg > 0.0f) {
             displayOpacityAry.push_back(1.0f - transparencyAvg);
         }

--- a/lib/mayaUsd/fileio/shading/shadingModeDisplayColor.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeDisplayColor.cpp
@@ -97,7 +97,6 @@ private:
             return;
         }
 
-        const UsdStageRefPtr& stage = context.GetUsdStage();
         GfVec3f color;
         GfVec3f transparency;
         const MFnLambertShader lambertFn(ssDepNode.object(), &status);
@@ -141,6 +140,8 @@ private:
         if (transparencyAvg > 0.0f) {
             displayOpacityAry.push_back(1.0f - transparencyAvg);
         }
+
+        const UsdStageRefPtr& stage = context.GetUsdStage();
 
         TF_FOR_ALL(iter, assignments) {
             const SdfPath& boundPrimPath = iter->first;


### PR DESCRIPTION
Prior to PR #707, the un-linearized transparency value was being used to compute a transparency "average", which was then used to author `displayOpacity` on the bound gprim if it did not already have an authored `displayOpacity`, as well as a `displayOpacity` input on the shader prim. It looks like an unintended side effect of #707 was that it was made to use the linearized transparency for this purpose instead. Note the use of the linearized `transparency` instead of the previously un-linearized `mayaTransparency` here:
https://github.com/Autodesk/maya-usd/pull/707/files#diff-5fe2e05011c04068f0f7249a36061532R138

Both of these behaviors seem somewhat dubious. It doesn't really seem like the shading mode exporter should be authoring `displayOpacity` of the bound gprim, since that is more a property of the geometry than the material. It also doesn't appear as if the `displayOpacity` input being authored on the shader prim is used for anything.

Ignoring those two oddities for now, the changes here should address the "regression" introduced by #707. We can revisit the behavior of the displayColors shading mode (or better yet work towards removing it!) in follow-up commits.