### PR TITLE
Undo support for multiple parented items in outliner

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -445,7 +445,7 @@ void ProxyRenderDelegate::_InitRenderDelegate(MSubSceneContainer& container) {
                 globalSelection->addObserver(_observer);
             }
 
-            Ufe::Scene::instance().addObjectAddObserver(_observer);
+            Ufe::Scene::instance().addObserver(_observer);
         }
 #else
         // Without UFE, support basic selection highlight at proxy shape level.

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -446,9 +446,9 @@ void ProxyRenderDelegate::_InitRenderDelegate(MSubSceneContainer& container) {
             }
 
             #if UFE_PREVIEW_VERSION_NUM >= 2021
-                Ufe::Scene::instance().addObserver(_observer);
+            Ufe::Scene::instance().addObserver(_observer);
             #else
-                Ufe::Scene::instance().addObjectAddObserver(_observer);
+            Ufe::Scene::instance().addObjectAddObserver(_observer);
             #endif
         }
 #else

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -445,7 +445,11 @@ void ProxyRenderDelegate::_InitRenderDelegate(MSubSceneContainer& container) {
                 globalSelection->addObserver(_observer);
             }
 
-            Ufe::Scene::instance().addObserver(_observer);
+            #if UFE_PREVIEW_VERSION_NUM >= 2021
+                Ufe::Scene::instance().addObserver(_observer);
+            #else
+                Ufe::Scene::instance().addObjectAddObserver(_observer);
+            #endif
         }
 #else
         // Without UFE, support basic selection highlight at proxy shape level.

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
@@ -158,10 +158,18 @@ Ufe::AppendedChild ProxyShapeHierarchy::appendChild(const Ufe::SceneItem::Ptr& c
 #endif
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
+
+#if UFE_PREVIEW_VERSION_NUM >= 2021
 Ufe::InsertChildCommand::Ptr ProxyShapeHierarchy::insertChildCmd(
     const Ufe::SceneItem::Ptr& child,
     const Ufe::SceneItem::Ptr& pos
 )
+#else
+Ufe::UndoableCommand::Ptr ProxyShapeHierarchy::insertChildCmd(
+    const Ufe::SceneItem::Ptr& child,
+    const Ufe::SceneItem::Ptr& pos
+)
+#endif
 {
     // UsdUndoInsertChildCommand expects a UsdSceneItem which wraps a prim, so
     // create one using the pseudo-root and our own path.

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
@@ -158,7 +158,7 @@ Ufe::AppendedChild ProxyShapeHierarchy::appendChild(const Ufe::SceneItem::Ptr& c
 #endif
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
-Ufe::UndoableCommand::Ptr ProxyShapeHierarchy::insertChildCmd(
+Ufe::InsertChildCommand::Ptr ProxyShapeHierarchy::insertChildCmd(
     const Ufe::SceneItem::Ptr& child,
     const Ufe::SceneItem::Ptr& pos
 )

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
@@ -66,7 +66,7 @@ public:
 #endif
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
-    Ufe::UndoableCommand::Ptr insertChildCmd(
+    Ufe::InsertChildCommand::Ptr insertChildCmd(
         const Ufe::SceneItem::Ptr& child,
         const Ufe::SceneItem::Ptr& pos
     ) override;

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
@@ -67,9 +67,9 @@ public:
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 	#if UFE_PREVIEW_VERSION_NUM >= 2021
-    	Ufe::InsertChildCommand::Ptr insertChildCmd(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
+    Ufe::InsertChildCommand::Ptr insertChildCmd(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
     #else
-    	Ufe::UndoableCommand::Ptr insertChildCmd(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
+    Ufe::UndoableCommand::Ptr insertChildCmd(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
     #endif
 
 	Ufe::SceneItem::Ptr createGroup(const Ufe::Selection& selection, const Ufe::PathComponent& name) const override;

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
@@ -66,10 +66,11 @@ public:
 #endif
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
-    Ufe::InsertChildCommand::Ptr insertChildCmd(
-        const Ufe::SceneItem::Ptr& child,
-        const Ufe::SceneItem::Ptr& pos
-    ) override;
+	#if UFE_PREVIEW_VERSION_NUM >= 2021
+    	Ufe::InsertChildCommand::Ptr insertChildCmd(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
+    #else
+    	Ufe::UndoableCommand::Ptr insertChildCmd(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
+    #endif
 
 	Ufe::SceneItem::Ptr createGroup(const Ufe::Selection& selection, const Ufe::PathComponent& name) const override;
 	Ufe::UndoableCommand::Ptr createGroupCmd(const Ufe::Selection& selection, const Ufe::PathComponent& name) const override;

--- a/lib/mayaUsd/ufe/StagesSubject.cpp
+++ b/lib/mayaUsd/ufe/StagesSubject.cpp
@@ -224,19 +224,19 @@ void StagesSubject::stageChanged(UsdNotice::ObjectsChanged const& notice, UsdSta
 				if (prim.IsActive())
 				{
 					#if UFE_PREVIEW_VERSION_NUM >= 2021
-						Ufe::Scene::instance().notify(Ufe::ObjectAdd(sceneItem));
+					Ufe::Scene::instance().notify(Ufe::ObjectAdd(sceneItem));
 					#else
-						auto notification = Ufe::ObjectAdd(sceneItem);
-						Ufe::Scene::notifyObjectAdd(notification);
+					auto notification = Ufe::ObjectAdd(sceneItem);
+					Ufe::Scene::notifyObjectAdd(notification);
 					#endif
 				}
 				else
 				{
 					#if UFE_PREVIEW_VERSION_NUM >= 2021
-						Ufe::Scene::instance().notify(Ufe::ObjectPostDelete(sceneItem));
+					Ufe::Scene::instance().notify(Ufe::ObjectPostDelete(sceneItem));
 					#else
-						auto notification = Ufe::ObjectPostDelete(sceneItem);
-						Ufe::Scene::notifyObjectDelete(notification);
+					auto notification = Ufe::ObjectPostDelete(sceneItem);
+					Ufe::Scene::notifyObjectDelete(notification);
 					#endif
 				}
 			}
@@ -247,10 +247,10 @@ void StagesSubject::stageChanged(UsdNotice::ObjectsChanged const& notice, UsdSta
 				// - Resyncs imply entire subtree invalidation of all descendant prims and properties.
 				// So we send the UFE subtree invalidate notif.
 				#if UFE_PREVIEW_VERSION_NUM >= 2021
-					Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
+				Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
 				#else
-					auto notification = Ufe::SubtreeInvalidate(sceneItem);
-					Ufe::Scene::notifySubtreeInvalidate(notification);
+				auto notification = Ufe::SubtreeInvalidate(sceneItem);
+				Ufe::Scene::notifySubtreeInvalidate(notification);
 				#endif
 			}
 #endif
@@ -261,21 +261,21 @@ void StagesSubject::stageChanged(UsdNotice::ObjectsChanged const& notice, UsdSta
 			if (InAddOrDeleteOperation::inAddOrDeleteOperation())
 			{
 				#if UFE_PREVIEW_VERSION_NUM >= 2021
-					Ufe::Scene::instance().notify(Ufe::ObjectDestroyed(ufePath));
+				Ufe::Scene::instance().notify(Ufe::ObjectDestroyed(ufePath));
 				#else
-					auto notification = Ufe::ObjectDestroyed(ufePath);
-					Ufe::Scene::notifyObjectDelete(notification);
+				auto notification = Ufe::ObjectDestroyed(ufePath);
+				Ufe::Scene::notifyObjectDelete(notification);
 				#endif
 			}
 			else
 			{
 				#if UFE_PREVIEW_VERSION_NUM >= 2021
-					auto sceneItem = Ufe::Hierarchy::createItem(ufePath);
-					Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
+				auto sceneItem = Ufe::Hierarchy::createItem(ufePath);
+				Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
 				#else
-					auto sceneItem = Ufe::Hierarchy::createItem(ufePath);
-					auto notification = Ufe::SubtreeInvalidate(sceneItem);
-					Ufe::Scene::notifySubtreeInvalidate(notification);
+				auto sceneItem = Ufe::Hierarchy::createItem(ufePath);
+				auto notification = Ufe::SubtreeInvalidate(sceneItem);
+				Ufe::Scene::notifySubtreeInvalidate(notification);
 				#endif
 			}
 		}
@@ -341,10 +341,10 @@ void StagesSubject::onStageInvalidate(const MayaUsdProxyStageInvalidateNotice& n
 #ifdef UFE_V2_FEATURES_AVAILABLE
 	Ufe::SceneItem::Ptr sceneItem = Ufe::Hierarchy::createItem(notice.GetProxyShape().ufePath());
 	#if UFE_PREVIEW_VERSION_NUM >= 2021
-		Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
+	Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
 	#else
-		auto notification = Ufe::SubtreeInvalidate(sceneItem);
-		Ufe::Scene::notifySubtreeInvalidate(notification);
+	auto notification = Ufe::SubtreeInvalidate(sceneItem);
+	Ufe::Scene::notifySubtreeInvalidate(notification);
 	#endif
 #endif
 }

--- a/lib/mayaUsd/ufe/StagesSubject.cpp
+++ b/lib/mayaUsd/ufe/StagesSubject.cpp
@@ -223,11 +223,21 @@ void StagesSubject::stageChanged(UsdNotice::ObjectsChanged const& notice, UsdSta
 			{
 				if (prim.IsActive())
 				{
-					Ufe::Scene::instance().notify(Ufe::ObjectAdd(sceneItem));
+					#if UFE_PREVIEW_VERSION_NUM >= 2021
+						Ufe::Scene::instance().notify(Ufe::ObjectAdd(sceneItem));
+					#else
+						auto notification = Ufe::ObjectAdd(sceneItem);
+						Ufe::Scene::notifyObjectAdd(notification);
+					#endif
 				}
 				else
 				{
-					Ufe::Scene::instance().notify(Ufe::ObjectPostDelete(sceneItem));
+					#if UFE_PREVIEW_VERSION_NUM >= 2021
+						Ufe::Scene::instance().notify(Ufe::ObjectPostDelete(sceneItem));
+					#else
+						auto notification = Ufe::ObjectPostDelete(sceneItem);
+						Ufe::Scene::notifyObjectDelete(notification);
+					#endif
 				}
 			}
 #ifdef UFE_V2_FEATURES_AVAILABLE
@@ -236,7 +246,12 @@ void StagesSubject::stageChanged(UsdNotice::ObjectsChanged const& notice, UsdSta
 				// According to USD docs for GetResyncedPaths():
 				// - Resyncs imply entire subtree invalidation of all descendant prims and properties.
 				// So we send the UFE subtree invalidate notif.
-				Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
+				#if UFE_PREVIEW_VERSION_NUM >= 2021
+					Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
+				#else
+					auto notification = Ufe::SubtreeInvalidate(sceneItem);
+					Ufe::Scene::notifySubtreeInvalidate(notification);
+				#endif
 			}
 #endif
 		}
@@ -245,12 +260,23 @@ void StagesSubject::stageChanged(UsdNotice::ObjectsChanged const& notice, UsdSta
 		{
 			if (InAddOrDeleteOperation::inAddOrDeleteOperation())
 			{
-				Ufe::Scene::instance().notify(Ufe::ObjectDestroyed(ufePath));
+				#if UFE_PREVIEW_VERSION_NUM >= 2021
+					Ufe::Scene::instance().notify(Ufe::ObjectDestroyed(ufePath));
+				#else
+					auto notification = Ufe::ObjectDestroyed(ufePath);
+					Ufe::Scene::notifyObjectDelete(notification);
+				#endif
 			}
 			else
 			{
-				auto sceneItem = Ufe::Hierarchy::createItem(ufePath);
-				Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
+				#if UFE_PREVIEW_VERSION_NUM >= 2021
+					auto sceneItem = Ufe::Hierarchy::createItem(ufePath);
+					Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
+				#else
+					auto sceneItem = Ufe::Hierarchy::createItem(ufePath);
+					auto notification = Ufe::SubtreeInvalidate(sceneItem);
+					Ufe::Scene::notifySubtreeInvalidate(notification);
+				#endif
 			}
 		}
 #endif
@@ -314,7 +340,12 @@ void StagesSubject::onStageInvalidate(const MayaUsdProxyStageInvalidateNotice& n
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 	Ufe::SceneItem::Ptr sceneItem = Ufe::Hierarchy::createItem(notice.GetProxyShape().ufePath());
-	Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
+	#if UFE_PREVIEW_VERSION_NUM >= 2021
+		Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
+	#else
+		auto notification = Ufe::SubtreeInvalidate(sceneItem);
+		Ufe::Scene::notifySubtreeInvalidate(notification);
+	#endif
 #endif
 }
 

--- a/lib/mayaUsd/ufe/StagesSubject.cpp
+++ b/lib/mayaUsd/ufe/StagesSubject.cpp
@@ -223,13 +223,11 @@ void StagesSubject::stageChanged(UsdNotice::ObjectsChanged const& notice, UsdSta
 			{
 				if (prim.IsActive())
 				{
-					auto notification = Ufe::ObjectAdd(sceneItem);
-					Ufe::Scene::notifyObjectAdd(notification);
+					Ufe::Scene::instance().notify(Ufe::ObjectAdd(sceneItem));
 				}
 				else
 				{
-					auto notification = Ufe::ObjectPostDelete(sceneItem);
-					Ufe::Scene::notifyObjectDelete(notification);
+					Ufe::Scene::instance().notify(Ufe::ObjectPostDelete(sceneItem));
 				}
 			}
 #ifdef UFE_V2_FEATURES_AVAILABLE
@@ -238,8 +236,7 @@ void StagesSubject::stageChanged(UsdNotice::ObjectsChanged const& notice, UsdSta
 				// According to USD docs for GetResyncedPaths():
 				// - Resyncs imply entire subtree invalidation of all descendant prims and properties.
 				// So we send the UFE subtree invalidate notif.
-				auto notification = Ufe::SubtreeInvalidate(sceneItem);
-				Ufe::Scene::notifySubtreeInvalidate(notification);
+				Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
 			}
 #endif
 		}
@@ -248,14 +245,12 @@ void StagesSubject::stageChanged(UsdNotice::ObjectsChanged const& notice, UsdSta
 		{
 			if (InAddOrDeleteOperation::inAddOrDeleteOperation())
 			{
-				auto notification = Ufe::ObjectDestroyed(ufePath);
-				Ufe::Scene::notifyObjectDelete(notification);
+				Ufe::Scene::instance().notify(Ufe::ObjectDestroyed(ufePath));
 			}
 			else
 			{
 				auto sceneItem = Ufe::Hierarchy::createItem(ufePath);
-				auto notification = Ufe::SubtreeInvalidate(sceneItem);
-				Ufe::Scene::notifySubtreeInvalidate(notification);
+				Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
 			}
 		}
 #endif
@@ -319,8 +314,7 @@ void StagesSubject::onStageInvalidate(const MayaUsdProxyStageInvalidateNotice& n
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 	Ufe::SceneItem::Ptr sceneItem = Ufe::Hierarchy::createItem(notice.GetProxyShape().ufePath());
-	auto notification = Ufe::SubtreeInvalidate(sceneItem);
-	Ufe::Scene::notifySubtreeInvalidate(notification);
+	Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
 #endif
 }
 

--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -187,7 +187,8 @@ MAYAUSD_NS_DEF {
 namespace ufe {
 
 UsdContextOps::UsdContextOps(const UsdSceneItem::Ptr& item)
-	: Ufe::ContextOps(), fItem(item), fPrim(item->prim())
+	: Ufe::ContextOps()
+    , fItem(item)
 {
 }
 
@@ -203,7 +204,6 @@ UsdContextOps::Ptr UsdContextOps::create(const UsdSceneItem::Ptr& item)
 
 void UsdContextOps::setItem(const UsdSceneItem::Ptr& item)
 {
-	fPrim = item->prim();
 	fItem = item;
 }
 
@@ -237,7 +237,7 @@ Ufe::ContextOps::Items UsdContextOps::getItems(
 
         // Top-level items.  Variant sets and visibility. Do not add for gateway type node.
         if (!fIsAGatewayType) {
-            if (fPrim.HasVariantSets()) {
+            if (prim().HasVariantSets()) {
                 items.emplace_back(
                     kUSDVariantSetsItem, kUSDVariantSetsLabel, Ufe::ContextItem::kHasChildren);
             }
@@ -270,7 +270,7 @@ Ufe::ContextOps::Items UsdContextOps::getItems(
     }
     else {
         if (itemPath[0] == kUSDVariantSetsItem) {
-            UsdVariantSets varSets = fPrim.GetVariantSets();
+            UsdVariantSets varSets = prim().GetVariantSets();
             std::vector<std::string> varSetsNames;
             varSets.GetNames(&varSetsNames);
 
@@ -332,7 +332,7 @@ Ufe::UndoableCommand::Ptr UsdContextOps::doOpCmd(const ItemPath& itemPath)
         // At this point we know we have enough arguments to execute the
         // operation.
         return std::make_shared<SetVariantSelectionUndoableCommand>(
-            fPrim, itemPath);
+            prim(), itemPath);
     } // Variant sets
     else if (itemPath[0] == kUSDToggleVisibilityItem) {
         auto attributes = Ufe::Attributes::attributes(sceneItem());
@@ -368,14 +368,14 @@ Ufe::UndoableCommand::Ptr UsdContextOps::doOpCmd(const ItemPath& itemPath)
             return nullptr;
 
         return std::make_shared<AddReferenceUndoableCommand>(
-            fPrim, path);
+            prim(), path);
     }
     else if (itemPath[0] == ClearAllReferencesUndoableCommand::commandName) {
         MString confirmation = MGlobal::executeCommandStringResult(clearAllReferencesConfirmScript);
         if (ClearAllReferencesUndoableCommand::cancelRemoval == confirmation)
             return nullptr;
 
-        return std::make_shared<ClearAllReferencesUndoableCommand>(fPrim);
+        return std::make_shared<ClearAllReferencesUndoableCommand>(prim());
     }
 
     return nullptr;

--- a/lib/mayaUsd/ufe/UsdContextOps.h
+++ b/lib/mayaUsd/ufe/UsdContextOps.h
@@ -56,6 +56,7 @@ public:
 
 	void setItem(const UsdSceneItem::Ptr& item);
 	const Ufe::Path& path() const;
+	inline UsdPrim prim() const { TF_AXIOM(fItem != nullptr); return fItem->prim(); }
 
 	// When we are created from the ProxyShapeContextOpsHandler we do not have the proper
 	// Maya UFE scene item. So it won't return the correct node type. Therefore we set
@@ -70,7 +71,6 @@ public:
 
 private:
 	UsdSceneItem::Ptr fItem;
-	UsdPrim fPrim;
 	bool fIsAGatewayType{false};
 
 }; // UsdContextOps

--- a/lib/mayaUsd/ufe/UsdHierarchy.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchy.cpp
@@ -133,13 +133,13 @@ Ufe::AppendedChild UsdHierarchy::appendChild(const Ufe::SceneItem::Ptr& child)
 	std::string childName = uniqueChildName(fItem, child->path());
 
 	// Set up all paths to perform the reparent.
-	auto prim = usdChild->prim();
-	auto stage = prim.GetStage();
+	auto childPrim = usdChild->prim();
+	auto stage = childPrim.GetStage();
 	auto ufeSrcPath = usdChild->path();
-	auto usdSrcPath = prim.GetPath();
+	auto usdSrcPath = childPrim.GetPath();
 	auto ufeDstPath = fItem->path() + childName;
 	auto usdDstPath = prim().GetPath().AppendChild(TfToken(childName));
-	SdfLayerHandle layer = MayaUsdUtils::defPrimSpecLayer(prim);
+	SdfLayerHandle layer = MayaUsdUtils::defPrimSpecLayer(childPrim);
 	if (!layer) {
 		std::string err = TfStringPrintf("No prim found at %s", usdSrcPath.GetString().c_str());
 		throw std::runtime_error(err.c_str());

--- a/lib/mayaUsd/ufe/UsdHierarchy.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchy.cpp
@@ -168,8 +168,11 @@ Ufe::AppendedChild UsdHierarchy::appendChild(const Ufe::SceneItem::Ptr& child)
 #endif
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
-
+#if UFE_PREVIEW_VERSION_NUM >= 2021
 Ufe::InsertChildCommand::Ptr UsdHierarchy::insertChildCmd(
+#else
+Ufe::UndoableCommand::Ptr UsdHierarchy::insertChildCmd(
+#endif
     const Ufe::SceneItem::Ptr& child,
     const Ufe::SceneItem::Ptr& pos
 )

--- a/lib/mayaUsd/ufe/UsdHierarchy.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchy.cpp
@@ -60,7 +60,8 @@ MAYAUSD_NS_DEF {
 namespace ufe {
 
 UsdHierarchy::UsdHierarchy(const UsdSceneItem::Ptr& item)
-	: Ufe::Hierarchy(), fItem(item), fPrim(item->prim())
+	: Ufe::Hierarchy()
+    , fItem(item)
 {
 }
 
@@ -76,7 +77,6 @@ UsdHierarchy::Ptr UsdHierarchy::create(const UsdSceneItem::Ptr& item)
 
 void UsdHierarchy::setItem(const UsdSceneItem::Ptr& item)
 {
-	fPrim = item->prim();
 	fItem = item;
 }
 
@@ -101,14 +101,14 @@ Ufe::SceneItem::Ptr UsdHierarchy::sceneItem() const
 
 bool UsdHierarchy::hasChildren() const
 {
-	return !filteredChildren(fPrim).empty();
+	return !filteredChildren(prim()).empty();
 }
 
 Ufe::SceneItemList UsdHierarchy::children() const
 {
 	// Return USD children only, i.e. children within this run-time.
 	Ufe::SceneItemList children;
-	for (auto child : filteredChildren(fPrim))
+	for (auto child : filteredChildren(prim()))
 	{
 		children.emplace_back(UsdSceneItem::create(fItem->path() + child.GetName(), child));
 	}
@@ -117,7 +117,7 @@ Ufe::SceneItemList UsdHierarchy::children() const
 
 Ufe::SceneItem::Ptr UsdHierarchy::parent() const
 {
-	return UsdSceneItem::create(fItem->path().pop(), fPrim.GetParent());
+	return UsdSceneItem::create(fItem->path().pop(), prim().GetParent());
 }
 
 #ifndef UFE_V2_FEATURES_AVAILABLE
@@ -138,7 +138,7 @@ Ufe::AppendedChild UsdHierarchy::appendChild(const Ufe::SceneItem::Ptr& child)
 	auto ufeSrcPath = usdChild->path();
 	auto usdSrcPath = prim.GetPath();
 	auto ufeDstPath = fItem->path() + childName;
-	auto usdDstPath = fPrim.GetPath().AppendChild(TfToken(childName));
+	auto usdDstPath = prim().GetPath().AppendChild(TfToken(childName));
 	SdfLayerHandle layer = MayaUsdUtils::defPrimSpecLayer(prim);
 	if (!layer) {
 		std::string err = TfStringPrintf("No prim found at %s", usdSrcPath.GetString().c_str());
@@ -169,7 +169,7 @@ Ufe::AppendedChild UsdHierarchy::appendChild(const Ufe::SceneItem::Ptr& child)
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 
-Ufe::UndoableCommand::Ptr UsdHierarchy::insertChildCmd(
+Ufe::InsertChildCommand::Ptr UsdHierarchy::insertChildCmd(
     const Ufe::SceneItem::Ptr& child,
     const Ufe::SceneItem::Ptr& pos
 )

--- a/lib/mayaUsd/ufe/UsdHierarchy.h
+++ b/lib/mayaUsd/ufe/UsdHierarchy.h
@@ -49,6 +49,7 @@ public:
 
 	void setItem(const UsdSceneItem::Ptr& item);
 	const Ufe::Path& path() const;
+	inline UsdPrim prim() const { TF_AXIOM(fItem != nullptr); return fItem->prim(); }
 
 	UsdSceneItem::Ptr usdSceneItem() const;
 
@@ -62,7 +63,7 @@ public:
 #endif
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
-    Ufe::UndoableCommand::Ptr insertChildCmd(
+    Ufe::InsertChildCommand::Ptr insertChildCmd(
         const Ufe::SceneItem::Ptr& child,
         const Ufe::SceneItem::Ptr& pos
     ) override;
@@ -78,7 +79,6 @@ public:
 
 private:
 	UsdSceneItem::Ptr fItem;
-	UsdPrim fPrim;
 
 }; // UsdHierarchy
 

--- a/lib/mayaUsd/ufe/UsdHierarchy.h
+++ b/lib/mayaUsd/ufe/UsdHierarchy.h
@@ -63,10 +63,11 @@ public:
 #endif
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
-    Ufe::InsertChildCommand::Ptr insertChildCmd(
-        const Ufe::SceneItem::Ptr& child,
-        const Ufe::SceneItem::Ptr& pos
-    ) override;
+	#if UFE_PREVIEW_VERSION_NUM >= 2021
+    Ufe::InsertChildCommand::Ptr insertChildCmd(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
+    #else
+    Ufe::UndoableCommand::Ptr insertChildCmd(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
+    #endif
 
 	Ufe::SceneItem::Ptr createGroup(const Ufe::Selection& selection, const Ufe::PathComponent& name) const override;
 	Ufe::UndoableCommand::Ptr createGroupCmd(const Ufe::Selection& selection, const Ufe::PathComponent& name) const override;

--- a/lib/mayaUsd/ufe/UsdRotatePivotTranslateUndoableCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdRotatePivotTranslateUndoableCommand.cpp
@@ -20,24 +20,47 @@
 MAYAUSD_NS_DEF {
 namespace ufe {
 
+#if UFE_PREVIEW_VERSION_NUM >= 2021
 UsdRotatePivotTranslateUndoableCommand::UsdRotatePivotTranslateUndoableCommand(const Ufe::Path& path)
     : Ufe::TranslateUndoableCommand(path)
     , fPath(path)
     , fNoPivotOp(false)
+#else
+UsdRotatePivotTranslateUndoableCommand::UsdRotatePivotTranslateUndoableCommand(const UsdPrim& prim, const Ufe::Path& path, const Ufe::SceneItem::Ptr& item)
+    : Ufe::TranslateUndoableCommand(item)
+    , fPrim(prim)
+    , fPath(path)
+    , fNoPivotOp(false)
+#endif
 {
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     // create a sceneItem on first access
     sceneItem();
+    #endif
 
     // Prim does not have a pivot translate attribute
     const TfToken xpivot("xformOp:translate:pivot");
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     if (!prim().HasAttribute(xpivot))
+    #else
+    if (!fPrim.HasAttribute(xpivot))
+    #endif
     {
         fNoPivotOp = true;
         // Add an empty pivot translate.
+        #if UFE_PREVIEW_VERSION_NUM >= 2021
         rotatePivotTranslateOp(prim(), fPath, 0, 0, 0);
+        #else
+        rotatePivotTranslateOp(fPrim, fPath, 0, 0, 0);
+        #endif
     }
 
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     fPivotAttrib = prim().GetAttribute(xpivot);
+    #else
+    fPivotAttrib = fPrim.GetAttribute(xpivot);
+    #endif
+
     fPivotAttrib.Get<GfVec3f>(&fPrevPivotValue);
 }
 
@@ -45,6 +68,7 @@ UsdRotatePivotTranslateUndoableCommand::~UsdRotatePivotTranslateUndoableCommand(
 {
 }
 
+#if UFE_PREVIEW_VERSION_NUM >= 2021
 UsdSceneItem::Ptr
 UsdRotatePivotTranslateUndoableCommand::sceneItem() const {
     if (!fItem) {
@@ -52,12 +76,20 @@ UsdRotatePivotTranslateUndoableCommand::sceneItem() const {
     }
     return fItem;
 }
+#endif
 
 /*static*/
+#if UFE_PREVIEW_VERSION_NUM >= 2021
 UsdRotatePivotTranslateUndoableCommand::Ptr UsdRotatePivotTranslateUndoableCommand::create(const Ufe::Path& path)
 {
     return std::make_shared<UsdRotatePivotTranslateUndoableCommand>(path);
 }
+#else
+UsdRotatePivotTranslateUndoableCommand::Ptr UsdRotatePivotTranslateUndoableCommand::create(const UsdPrim& prim, const Ufe::Path& ufePath, const Ufe::SceneItem::Ptr& item)
+{
+    return std::make_shared<UsdRotatePivotTranslateUndoableCommand>(prim, ufePath, item);
+}
+#endif
 
 void UsdRotatePivotTranslateUndoableCommand::undo()
 {
@@ -79,7 +111,12 @@ void UsdRotatePivotTranslateUndoableCommand::redo()
 
 bool UsdRotatePivotTranslateUndoableCommand::translate(double x, double y, double z)
 {
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     rotatePivotTranslateOp(prim(), fPath, x, y, z);
+    #else
+    rotatePivotTranslateOp(fPrim, fPath, x, y, z);
+    #endif
+    
     return true;
 }
 

--- a/lib/mayaUsd/ufe/UsdRotatePivotTranslateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdRotatePivotTranslateUndoableCommand.h
@@ -20,6 +20,7 @@
 #include <pxr/usd/usd/attribute.h>
 
 #include <mayaUsd/base/api.h>
+#include <mayaUsd/ufe/UsdSceneItem.h>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -28,36 +29,41 @@ namespace ufe {
 
 //! \brief Absolute translation command of the given prim's rotate pivot.
 /*!
-	Ability to perform undo to restore the original pivot value.
+    Ability to perform undo to restore the original pivot value.
  */
 class MAYAUSD_CORE_PUBLIC UsdRotatePivotTranslateUndoableCommand : public Ufe::TranslateUndoableCommand
 {
 public:
-	typedef std::shared_ptr<UsdRotatePivotTranslateUndoableCommand> Ptr;
+    typedef std::shared_ptr<UsdRotatePivotTranslateUndoableCommand> Ptr;
 
-	UsdRotatePivotTranslateUndoableCommand(const UsdPrim& prim, const Ufe::Path& ufePath, const Ufe::SceneItem::Ptr& item);
-	~UsdRotatePivotTranslateUndoableCommand() override;
+    UsdRotatePivotTranslateUndoableCommand(const Ufe::Path& path);
+    ~UsdRotatePivotTranslateUndoableCommand() override;
 
-	// Delete the copy/move constructors assignment operators.
-	UsdRotatePivotTranslateUndoableCommand(const UsdRotatePivotTranslateUndoableCommand&) = delete;
-	UsdRotatePivotTranslateUndoableCommand& operator=(const UsdRotatePivotTranslateUndoableCommand&) = delete;
-	UsdRotatePivotTranslateUndoableCommand(UsdRotatePivotTranslateUndoableCommand&&) = delete;
-	UsdRotatePivotTranslateUndoableCommand& operator=(UsdRotatePivotTranslateUndoableCommand&&) = delete;
+    // Delete the copy/move constructors assignment operators.
+    UsdRotatePivotTranslateUndoableCommand(const UsdRotatePivotTranslateUndoableCommand&) = delete;
+    UsdRotatePivotTranslateUndoableCommand& operator=(const UsdRotatePivotTranslateUndoableCommand&) = delete;
+    UsdRotatePivotTranslateUndoableCommand(UsdRotatePivotTranslateUndoableCommand&&) = delete;
+    UsdRotatePivotTranslateUndoableCommand& operator=(UsdRotatePivotTranslateUndoableCommand&&) = delete;
 
-	//! Create a UsdRotatePivotTranslateUndoableCommand from a USD prim, UFE path and UFE scene item.
-	static UsdRotatePivotTranslateUndoableCommand::Ptr create(const UsdPrim& prim, const Ufe::Path& ufePath, const Ufe::SceneItem::Ptr& item);
+    //! Create a UsdRotatePivotTranslateUndoableCommand from a USD prim, UFE path and UFE scene item.
+    static UsdRotatePivotTranslateUndoableCommand::Ptr create(const Ufe::Path& path);
 
-	// Ufe::TranslateUndoableCommand overrides
-	void undo() override;
-	void redo() override;
-	bool translate(double x, double y, double z) override;
+    // Ufe::TranslateUndoableCommand overrides
+    void undo() override;
+    void redo() override;
+    bool translate(double x, double y, double z) override;
+
+    inline UsdPrim prim() const { TF_AXIOM(fItem != nullptr); return fItem->prim(); }
 
 private:
-	UsdPrim fPrim;
-	UsdAttribute fPivotAttrib;
-	GfVec3f fPrevPivotValue;
-	Ufe::Path fPath;
-	bool fNoPivotOp;
+    UsdSceneItem::Ptr sceneItem() const;
+
+private:
+    Ufe::Path fPath;
+    mutable UsdSceneItem::Ptr fItem{nullptr};
+    UsdAttribute fPivotAttrib;
+    GfVec3f fPrevPivotValue;
+    bool fNoPivotOp;
 
 }; // UsdRotatePivotTranslateUndoableCommand
 

--- a/lib/mayaUsd/ufe/UsdRotatePivotTranslateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdRotatePivotTranslateUndoableCommand.h
@@ -36,7 +36,12 @@ class MAYAUSD_CORE_PUBLIC UsdRotatePivotTranslateUndoableCommand : public Ufe::T
 public:
     typedef std::shared_ptr<UsdRotatePivotTranslateUndoableCommand> Ptr;
 
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     UsdRotatePivotTranslateUndoableCommand(const Ufe::Path& path);
+    #else
+    UsdRotatePivotTranslateUndoableCommand(const UsdPrim& prim, const Ufe::Path& ufePath, const Ufe::SceneItem::Ptr& item);
+    #endif
+
     ~UsdRotatePivotTranslateUndoableCommand() override;
 
     // Delete the copy/move constructors assignment operators.
@@ -46,7 +51,11 @@ public:
     UsdRotatePivotTranslateUndoableCommand& operator=(UsdRotatePivotTranslateUndoableCommand&&) = delete;
 
     //! Create a UsdRotatePivotTranslateUndoableCommand from a USD prim, UFE path and UFE scene item.
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     static UsdRotatePivotTranslateUndoableCommand::Ptr create(const Ufe::Path& path);
+    #else
+    static UsdRotatePivotTranslateUndoableCommand::Ptr create(const UsdPrim& prim, const Ufe::Path& ufePath, const Ufe::SceneItem::Ptr& item);
+    #endif
 
     // Ufe::TranslateUndoableCommand overrides
     void undo() override;
@@ -56,9 +65,14 @@ public:
     inline UsdPrim prim() const { TF_AXIOM(fItem != nullptr); return fItem->prim(); }
 
 private:
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     UsdSceneItem::Ptr sceneItem() const;
+    #endif
 
 private:
+    #if UFE_PREVIEW_VERSION_NUM < 2021
+    UsdPrim fPrim;
+    #endif
     Ufe::Path fPath;
     mutable UsdSceneItem::Ptr fItem{nullptr};
     UsdAttribute fPivotAttrib;

--- a/lib/mayaUsd/ufe/UsdRotateUndoableCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdRotateUndoableCommand.cpp
@@ -23,9 +23,9 @@ namespace ufe {
 TfToken UsdRotateUndoableCommand::rotXYZ("xformOp:rotateXYZ");
 
 UsdRotateUndoableCommand::UsdRotateUndoableCommand(
-    const UsdSceneItem::Ptr& item, double x, double y, double z)
-	: Ufe::RotateUndoableCommand(item),
-      UsdTRSUndoableCommandBase(item, x, y, z)
+    const Ufe::Path& path, double x, double y, double z)
+	: Ufe::RotateUndoableCommand(path),
+      UsdTRSUndoableCommandBase(x, y, z)
 {
 	// Since we want to change xformOp:rotateXYZ, and we need to store the
 	// prevRotate for undo purposes, we need to make sure we convert it to
@@ -46,10 +46,10 @@ UsdRotateUndoableCommand::~UsdRotateUndoableCommand()
 
 /*static*/
 UsdRotateUndoableCommand::Ptr UsdRotateUndoableCommand::create(
-    const UsdSceneItem::Ptr& item, double x, double y, double z)
+    const Ufe::Path& path, double x, double y, double z)
 {
 	auto cmd = std::make_shared<MakeSharedEnabler<UsdRotateUndoableCommand>>(
-        item, x, y, z);
+        path, x, y, z);
     cmd->initialize();
     return cmd;
 }

--- a/lib/mayaUsd/ufe/UsdRotateUndoableCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdRotateUndoableCommand.cpp
@@ -22,10 +22,17 @@ namespace ufe {
 
 TfToken UsdRotateUndoableCommand::rotXYZ("xformOp:rotateXYZ");
 
+#if UFE_PREVIEW_VERSION_NUM >= 2021
 UsdRotateUndoableCommand::UsdRotateUndoableCommand(
     const Ufe::Path& path, double x, double y, double z)
 	: Ufe::RotateUndoableCommand(path),
       UsdTRSUndoableCommandBase(x, y, z)
+#else
+UsdRotateUndoableCommand::UsdRotateUndoableCommand(
+    const UsdSceneItem::Ptr& item, double x, double y, double z)
+	: Ufe::RotateUndoableCommand(item),
+      UsdTRSUndoableCommandBase(item, x, y, z)
+#endif
 {
 	// Since we want to change xformOp:rotateXYZ, and we need to store the
 	// prevRotate for undo purposes, we need to make sure we convert it to
@@ -45,6 +52,7 @@ UsdRotateUndoableCommand::~UsdRotateUndoableCommand()
 {}
 
 /*static*/
+#if UFE_PREVIEW_VERSION_NUM >= 2021
 UsdRotateUndoableCommand::Ptr UsdRotateUndoableCommand::create(
     const Ufe::Path& path, double x, double y, double z)
 {
@@ -53,6 +61,17 @@ UsdRotateUndoableCommand::Ptr UsdRotateUndoableCommand::create(
     cmd->initialize();
     return cmd;
 }
+#else
+UsdRotateUndoableCommand::Ptr UsdRotateUndoableCommand::create(
+    const UsdSceneItem::Ptr& item, double x, double y, double z)
+{
+	auto cmd = std::make_shared<MakeSharedEnabler<UsdRotateUndoableCommand>>(
+        item, x, y, z);
+    cmd->initialize();
+    return cmd;
+}
+#endif
+
 
 void UsdRotateUndoableCommand::undo()
 {

--- a/lib/mayaUsd/ufe/UsdRotateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdRotateUndoableCommand.h
@@ -46,7 +46,7 @@ public:
 	//! Create a UsdRotateUndoableCommand from a UFE scene item.  The
 	//! command is not executed.
 	static UsdRotateUndoableCommand::Ptr create(
-        const UsdSceneItem::Ptr& item, double x, double y, double z);
+        const Ufe::Path& path, double x, double y, double z);
 
 	// Ufe::RotateUndoableCommand overrides.  rotate() sets the command's
 	// rotation value and executes the command.
@@ -54,10 +54,12 @@ public:
 	void redo() override;
 	bool rotate(double x, double y, double z) override;
 
+	Ufe::Path getPath() const override { return path(); }
+
 protected:
 
     //! Construct a UsdRotateUndoableCommand.  The command is not executed.
-	UsdRotateUndoableCommand(const UsdSceneItem::Ptr& item, double x, double y, double z);
+	UsdRotateUndoableCommand(const Ufe::Path& path, double x, double y, double z);
 	~UsdRotateUndoableCommand() override;
 
 private:

--- a/lib/mayaUsd/ufe/UsdRotateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdRotateUndoableCommand.h
@@ -43,10 +43,17 @@ public:
 	UsdRotateUndoableCommand(UsdRotateUndoableCommand&&) = delete;
 	UsdRotateUndoableCommand& operator=(UsdRotateUndoableCommand&&) = delete;
 
-	//! Create a UsdRotateUndoableCommand from a UFE scene item.  The
-	//! command is not executed.
+	#if UFE_PREVIEW_VERSION_NUM >= 2021
+	//! Create a UsdRotateUndoableCommand from a UFE scene path.  The command is
+    //! not executed.
 	static UsdRotateUndoableCommand::Ptr create(
         const Ufe::Path& path, double x, double y, double z);
+	#else
+	//! Create a UsdRotateUndoableCommand from a UFE scene item.  The command is
+    //! not executed.
+	static UsdRotateUndoableCommand::Ptr create(
+        const UsdSceneItem::Ptr& item, double x, double y, double z);
+	#endif
 
 	// Ufe::RotateUndoableCommand overrides.  rotate() sets the command's
 	// rotation value and executes the command.
@@ -54,12 +61,18 @@ public:
 	void redo() override;
 	bool rotate(double x, double y, double z) override;
 
+	#if UFE_PREVIEW_VERSION_NUM >= 2021
 	Ufe::Path getPath() const override { return path(); }
+	#endif
 
 protected:
 
     //! Construct a UsdRotateUndoableCommand.  The command is not executed.
+	#if UFE_PREVIEW_VERSION_NUM >= 2021
 	UsdRotateUndoableCommand(const Ufe::Path& path, double x, double y, double z);
+	#else
+	UsdRotateUndoableCommand(const UsdSceneItem::Ptr& item, double x, double y, double z);
+	#endif
 	~UsdRotateUndoableCommand() override;
 
 private:

--- a/lib/mayaUsd/ufe/UsdScaleUndoableCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdScaleUndoableCommand.cpp
@@ -22,26 +22,47 @@ namespace ufe {
 
 TfToken UsdScaleUndoableCommand::scaleTok("xformOp:scale");
 
+#if UFE_PREVIEW_VERSION_NUM >= 2021
 UsdScaleUndoableCommand::UsdScaleUndoableCommand(
     const Ufe::Path& path, double x, double y, double z
 ) : Ufe::ScaleUndoableCommand(path),
     UsdTRSUndoableCommandBase(x, y, z)
 {}
+#else
+UsdScaleUndoableCommand::UsdScaleUndoableCommand(
+    const UsdSceneItem::Ptr& item, double x, double y, double z
+) : Ufe::ScaleUndoableCommand(item),
+    UsdTRSUndoableCommandBase(item, x, y, z)
+{}
+#endif
 
 UsdScaleUndoableCommand::~UsdScaleUndoableCommand()
 {}
 
 /*static*/
+#if UFE_PREVIEW_VERSION_NUM >= 2021
 UsdScaleUndoableCommand::Ptr UsdScaleUndoableCommand::create(
     const Ufe::Path& path, double x, double y, double z
 )
 {
-	auto cmd = std::make_shared<MakeSharedEnabler<UsdScaleUndoableCommand>>(
+    auto cmd = std::make_shared<MakeSharedEnabler<UsdScaleUndoableCommand>>(
         path, x, y, z);
     cmd->initialize();
     return cmd;
 
 }
+#else
+UsdScaleUndoableCommand::Ptr UsdScaleUndoableCommand::create(
+    const UsdSceneItem::Ptr& item, double x, double y, double z
+)
+{
+    auto cmd = std::make_shared<MakeSharedEnabler<UsdScaleUndoableCommand>>(
+        item, x, y, z);
+    cmd->initialize();
+    return cmd;
+
+}
+#endif
 
 void UsdScaleUndoableCommand::undo()
 {

--- a/lib/mayaUsd/ufe/UsdScaleUndoableCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdScaleUndoableCommand.cpp
@@ -23,9 +23,9 @@ namespace ufe {
 TfToken UsdScaleUndoableCommand::scaleTok("xformOp:scale");
 
 UsdScaleUndoableCommand::UsdScaleUndoableCommand(
-    const UsdSceneItem::Ptr& item, double x, double y, double z
-) : Ufe::ScaleUndoableCommand(item),
-    UsdTRSUndoableCommandBase(item, x, y, z)
+    const Ufe::Path& path, double x, double y, double z
+) : Ufe::ScaleUndoableCommand(path),
+    UsdTRSUndoableCommandBase(x, y, z)
 {}
 
 UsdScaleUndoableCommand::~UsdScaleUndoableCommand()
@@ -33,11 +33,11 @@ UsdScaleUndoableCommand::~UsdScaleUndoableCommand()
 
 /*static*/
 UsdScaleUndoableCommand::Ptr UsdScaleUndoableCommand::create(
-    const UsdSceneItem::Ptr& item, double x, double y, double z
+    const Ufe::Path& path, double x, double y, double z
 )
 {
 	auto cmd = std::make_shared<MakeSharedEnabler<UsdScaleUndoableCommand>>(
-        item, x, y, z);
+        path, x, y, z);
     cmd->initialize();
     return cmd;
 

--- a/lib/mayaUsd/ufe/UsdScaleUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdScaleUndoableCommand.h
@@ -41,22 +41,36 @@ public:
 	UsdScaleUndoableCommand(UsdScaleUndoableCommand&&) = delete;
 	UsdScaleUndoableCommand& operator=(UsdScaleUndoableCommand&&) = delete;
 
-	//! Create a UsdScaleUndoableCommand from a UFE scene item.  The command is
+	#if UFE_PREVIEW_VERSION_NUM >= 2021
+	//! Create a UsdScaleUndoableCommand from a UFE scene path.  The command is
     //! not executed.
 	static UsdScaleUndoableCommand::Ptr create(
         const Ufe::Path& path, double x, double y, double z);
+	#else
+	//! Create a UsdScaleUndoableCommand from a UFE scene item.  The command is
+    //! not executed.
+	static UsdScaleUndoableCommand::Ptr create(
+        const UsdSceneItem::Ptr& item, double x, double y, double z);
+	#endif
 
 	// Ufe::ScaleUndoableCommand overrides
 	void undo() override;
 	void redo() override;
 	bool scale(double x, double y, double z) override;
 
+	#if UFE_PREVIEW_VERSION_NUM >= 2021
 	Ufe::Path getPath() const override { return path(); }
+	#endif
 
 protected:
 
     //! Construct a UsdScaleUndoableCommand.  The command is not executed.
+	#if UFE_PREVIEW_VERSION_NUM >= 2021
 	UsdScaleUndoableCommand(const Ufe::Path& path, double x, double y, double z);
+	#else
+	UsdScaleUndoableCommand(const UsdSceneItem::Ptr& item, double x, double y, double z);
+	#endif
+
 	~UsdScaleUndoableCommand() override;
 
 private:

--- a/lib/mayaUsd/ufe/UsdScaleUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdScaleUndoableCommand.h
@@ -44,17 +44,19 @@ public:
 	//! Create a UsdScaleUndoableCommand from a UFE scene item.  The command is
     //! not executed.
 	static UsdScaleUndoableCommand::Ptr create(
-        const UsdSceneItem::Ptr& item, double x, double y, double z);
+        const Ufe::Path& path, double x, double y, double z);
 
 	// Ufe::ScaleUndoableCommand overrides
 	void undo() override;
 	void redo() override;
 	bool scale(double x, double y, double z) override;
 
+	Ufe::Path getPath() const override { return path(); }
+
 protected:
 
     //! Construct a UsdScaleUndoableCommand.  The command is not executed.
-	UsdScaleUndoableCommand(const UsdSceneItem::Ptr& item, double x, double y, double z);
+	UsdScaleUndoableCommand(const Ufe::Path& path, double x, double y, double z);
 	~UsdScaleUndoableCommand() override;
 
 private:

--- a/lib/mayaUsd/ufe/UsdSceneItem.cpp
+++ b/lib/mayaUsd/ufe/UsdSceneItem.cpp
@@ -53,7 +53,13 @@ std::string UsdSceneItem::nodeType() const
 std::vector<std::string> UsdSceneItem::ancestorNodeTypes() const
 {
 	std::vector<std::string> strAncestorTypes;
-
+	
+	// during drag/drop in outliner UsdPrim can become invalidated which
+	// should never happens.
+	// MAYA-106644: HS August 31,2020 investigate the invalidation.
+	if (!fPrim.IsValid()) {
+		return {};
+	}
 #if USD_VERSION_NUM < 2005
 	static const TfType schemaBaseType = TfType::Find<UsdSchemaBase>();
 	const TfType schemaType = schemaBaseType.FindDerivedByName(fPrim.GetTypeName().GetString());

--- a/lib/mayaUsd/ufe/UsdSceneItem.cpp
+++ b/lib/mayaUsd/ufe/UsdSceneItem.cpp
@@ -53,13 +53,7 @@ std::string UsdSceneItem::nodeType() const
 std::vector<std::string> UsdSceneItem::ancestorNodeTypes() const
 {
 	std::vector<std::string> strAncestorTypes;
-	
-	// during drag/drop in outliner UsdPrim can become invalidated which
-	// should never happens.
-	// MAYA-106644: HS August 31,2020 investigate the invalidation.
-	if (!fPrim.IsValid()) {
-		return {};
-	}
+
 #if USD_VERSION_NUM < 2005
 	static const TfType schemaBaseType = TfType::Find<UsdSchemaBase>();
 	const TfType schemaType = schemaBaseType.FindDerivedByName(fPrim.GetTypeName().GetString());

--- a/lib/mayaUsd/ufe/UsdSceneItemOps.cpp
+++ b/lib/mayaUsd/ufe/UsdSceneItemOps.cpp
@@ -24,7 +24,8 @@ MAYAUSD_NS_DEF {
 namespace ufe {
 
 UsdSceneItemOps::UsdSceneItemOps(const UsdSceneItem::Ptr& item)
-	: Ufe::SceneItemOps(), fItem(item), fPrim(item->prim())
+	: Ufe::SceneItemOps()
+    , fItem(item)
 {
 }
 
@@ -40,7 +41,6 @@ UsdSceneItemOps::Ptr UsdSceneItemOps::create(const UsdSceneItem::Ptr& item)
 
 void UsdSceneItemOps::setItem(const UsdSceneItem::Ptr& item)
 {
-	fPrim = item->prim();
 	fItem = item;
 }
 
@@ -60,19 +60,19 @@ Ufe::SceneItem::Ptr UsdSceneItemOps::sceneItem() const
 
 Ufe::UndoableCommand::Ptr UsdSceneItemOps::deleteItemCmd()
 {
-	auto deleteCmd = UsdUndoDeleteCommand::create(fPrim);
+	auto deleteCmd = UsdUndoDeleteCommand::create(prim());
 	deleteCmd->execute();
 	return deleteCmd;
 }
 
 bool UsdSceneItemOps::deleteItem()
 {
-	return fPrim.SetActive(false);
+	return prim().SetActive(false);
 }
 
 Ufe::Duplicate UsdSceneItemOps::duplicateItemCmd()
 {
-	auto duplicateCmd = UsdUndoDuplicateCommand::create(fPrim, fItem->path());
+	auto duplicateCmd = UsdUndoDuplicateCommand::create(prim(), fItem->path());
 	duplicateCmd->execute();
 	auto item = createSiblingSceneItem(path(), duplicateCmd->usdDstPath().GetElementString());
 	return Ufe::Duplicate(item, duplicateCmd);
@@ -82,8 +82,8 @@ Ufe::SceneItem::Ptr UsdSceneItemOps::duplicateItem()
 {
 	SdfPath usdDstPath;
 	SdfLayerHandle layer;
-	UsdUndoDuplicateCommand::primInfo(fPrim, usdDstPath, layer);
-	bool status = UsdUndoDuplicateCommand::duplicate(layer, fPrim.GetPath(), usdDstPath);
+	UsdUndoDuplicateCommand::primInfo(prim(), usdDstPath, layer);
+	bool status = UsdUndoDuplicateCommand::duplicate(layer, prim().GetPath(), usdDstPath);
 
 	// The duplicate is a sibling of the source.
 	if (status)

--- a/lib/mayaUsd/ufe/UsdSceneItemOps.h
+++ b/lib/mayaUsd/ufe/UsdSceneItemOps.h
@@ -48,6 +48,7 @@ public:
 
 	void setItem(const UsdSceneItem::Ptr& item);
 	const Ufe::Path& path() const;
+	inline UsdPrim prim() const { TF_AXIOM(fItem != nullptr); return fItem->prim(); }
 
 	// Ufe::SceneItemOps overrides
 	Ufe::SceneItem::Ptr sceneItem() const override;
@@ -60,7 +61,6 @@ public:
 
 private:
 	UsdSceneItem::Ptr fItem;
-	UsdPrim fPrim;
 
 }; // UsdSceneItemOps
 

--- a/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.cpp
+++ b/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.cpp
@@ -24,11 +24,18 @@ MAYAUSD_NS_DEF {
 namespace ufe {
 
 template<class V>
+#if UFE_PREVIEW_VERSION_NUM >= 2021
 UsdTRSUndoableCommandBase<V>::UsdTRSUndoableCommandBase(double x, double y, double z)
     : fNewValue(x, y, z)
+#else
+UsdTRSUndoableCommandBase<V>::UsdTRSUndoableCommandBase(
+    const UsdSceneItem::Ptr& item, double x, double y, double z
+) : fItem(item), fNewValue(x, y, z)
+#endif
 {
 }
 
+#if UFE_PREVIEW_VERSION_NUM >= 2021
 template<class V>
 void UsdTRSUndoableCommandBase<V>::updateItem() const
 {
@@ -37,6 +44,7 @@ void UsdTRSUndoableCommandBase<V>::updateItem() const
         fItem = std::dynamic_pointer_cast<UsdSceneItem>(ufeSceneItemPtr);
     }
 }
+#endif
 
 template<class V>
 void UsdTRSUndoableCommandBase<V>::initialize()
@@ -53,11 +61,31 @@ void UsdTRSUndoableCommandBase<V>::initialize()
     }
 
     attribute().Get(&fPrevValue);
+
+    #if UFE_PREVIEW_VERSION_NUM < 2021
+    Ufe::Scene::instance().addObjectPathChangeObserver(this->shared_from_this());
+    #endif
 }
+
+#if UFE_PREVIEW_VERSION_NUM < 2021
+template<class V>
+void UsdTRSUndoableCommandBase<V>::operator()(
+    const Ufe::Notification& n
+)
+{
+    if (auto renamed = dynamic_cast<const Ufe::ObjectRename*>(&n)) {
+        checkNotification(renamed);
+    }
+    else if (auto reparented = dynamic_cast<const Ufe::ObjectReparent*>(&n)) {
+        checkNotification(reparented);
+    }
+}
+#endif
 
 template<class V>
 void UsdTRSUndoableCommandBase<V>::undoImp()
 {
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     // Set fItem to nullptr because the command does not know what can go on with the prim inside
     // its item after their own undo() or redo(). Setting it back to nullptr is safer because it means 
     // that the next time the command is used, it will be forced to create a new item from the path, 
@@ -65,6 +93,7 @@ void UsdTRSUndoableCommandBase<V>::undoImp()
     fItem = nullptr;
 
     updateItem();
+    #endif
 
     attribute().Set(fPrevValue);
     // Todo : We would want to remove the xformOp
@@ -74,6 +103,7 @@ void UsdTRSUndoableCommandBase<V>::undoImp()
 template<class V>
 void UsdTRSUndoableCommandBase<V>::redoImp()
 {
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     // Set fItem to nullptr because the command does not know what can go on with the prim inside
     // its item after their own undo() or redo(). Setting it back to nullptr is safer because it means 
     // that the next time the command is used, it will be forced to create a new item from the path, 
@@ -81,6 +111,7 @@ void UsdTRSUndoableCommandBase<V>::redoImp()
     fItem = nullptr;
 
     updateItem();
+    #endif
 
     // We must go through conversion to the common transform API by calling
     // perform(), otherwise we get "Empty typeName" USD assertions for rotate
@@ -92,6 +123,17 @@ void UsdTRSUndoableCommandBase<V>::redoImp()
 
     perform(fNewValue[0], fNewValue[1], fNewValue[2]);
 }
+
+#if UFE_PREVIEW_VERSION_NUM < 2021
+template<class V>
+template<class N>
+void UsdTRSUndoableCommandBase<V>::checkNotification(const N* notification)
+{
+    if (notification->previousPath() == path()) {
+        fItem = std::dynamic_pointer_cast<UsdSceneItem>(notification->item());
+    }
+}
+#endif
 
 template<class V>
 void UsdTRSUndoableCommandBase<V>::perform(double x, double y, double z)

--- a/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.cpp
+++ b/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.cpp
@@ -24,10 +24,19 @@ MAYAUSD_NS_DEF {
 namespace ufe {
 
 template<class V>
-UsdTRSUndoableCommandBase<V>::UsdTRSUndoableCommandBase(
-    const UsdSceneItem::Ptr& item, double x, double y, double z
-) : fItem(item), fNewValue(x, y, z)
-{}
+UsdTRSUndoableCommandBase<V>::UsdTRSUndoableCommandBase(double x, double y, double z)
+    : fNewValue(x, y, z)
+{
+}
+
+template<class V>
+void UsdTRSUndoableCommandBase<V>::updateItem() const
+{
+    if(!fItem) {
+        auto ufeSceneItemPtr = Ufe::Hierarchy::createItem(getPath());
+        fItem = std::dynamic_pointer_cast<UsdSceneItem>(ufeSceneItemPtr);
+    }
+}
 
 template<class V>
 void UsdTRSUndoableCommandBase<V>::initialize()
@@ -43,29 +52,20 @@ void UsdTRSUndoableCommandBase<V>::initialize()
         addEmptyAttribute();
     }
 
-    // See
-    // https://stackoverflow.com/questions/17853212/using-shared-from-this-in-templated-classes
-    // for explanation of this->shared_from_this() in templated class.
     attribute().Get(&fPrevValue);
-    Ufe::Scene::instance().addObjectPathChangeObserver(this->shared_from_this());
-}
-
-template<class V>
-void UsdTRSUndoableCommandBase<V>::operator()(
-    const Ufe::Notification& n
-)
-{
-    if (auto renamed = dynamic_cast<const Ufe::ObjectRename*>(&n)) {
-        checkNotification(renamed);
-    }
-    else if (auto reparented = dynamic_cast<const Ufe::ObjectReparent*>(&n)) {
-        checkNotification(reparented);
-    }
 }
 
 template<class V>
 void UsdTRSUndoableCommandBase<V>::undoImp()
 {
+    // Set fItem to nullptr because the command does not know what can go on with the prim inside
+    // its item after their own undo() or redo(). Setting it back to nullptr is safer because it means 
+    // that the next time the command is used, it will be forced to create a new item from the path, 
+    // or the command will crash on a null pointer.
+    fItem = nullptr;
+
+    updateItem();
+
     attribute().Set(fPrevValue);
     // Todo : We would want to remove the xformOp
     // (SD-06/07/2018) Haven't found a clean way to do it - would need to investigate
@@ -74,6 +74,14 @@ void UsdTRSUndoableCommandBase<V>::undoImp()
 template<class V>
 void UsdTRSUndoableCommandBase<V>::redoImp()
 {
+    // Set fItem to nullptr because the command does not know what can go on with the prim inside
+    // its item after their own undo() or redo(). Setting it back to nullptr is safer because it means 
+    // that the next time the command is used, it will be forced to create a new item from the path, 
+    // or the command will crash on a null pointer.
+    fItem = nullptr;
+
+    updateItem();
+
     // We must go through conversion to the common transform API by calling
     // perform(), otherwise we get "Empty typeName" USD assertions for rotate
     // and scale.  Once that is done, we can simply set the attribute directly.
@@ -83,15 +91,6 @@ void UsdTRSUndoableCommandBase<V>::redoImp()
     }
 
     perform(fNewValue[0], fNewValue[1], fNewValue[2]);
-}
-
-template<class V>
-template<class N>
-void UsdTRSUndoableCommandBase<V>::checkNotification(const N* notification)
-{
-    if (notification->previousPath() == path()) {
-        fItem = std::dynamic_pointer_cast<UsdSceneItem>(notification->item());
-    }
 }
 
 template<class V>

--- a/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
+++ b/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
@@ -47,12 +47,22 @@ namespace ufe {
 //   becomes stale, and the prim in the updated scene item should be used.
 //
 template<class V>
+#if UFE_PREVIEW_VERSION_NUM >= 2021
 class MAYAUSD_CORE_PUBLIC UsdTRSUndoableCommandBase 
     : public std::enable_shared_from_this<UsdTRSUndoableCommandBase<V>>
+#else
+class MAYAUSD_CORE_PUBLIC UsdTRSUndoableCommandBase : public Ufe::Observer,
+        public std::enable_shared_from_this<UsdTRSUndoableCommandBase<V> >
+#endif
 {
 protected:
-
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     UsdTRSUndoableCommandBase(double x, double y, double z);
+    #else
+    UsdTRSUndoableCommandBase(
+        const UsdSceneItem::Ptr& item, double x, double y, double z);
+    #endif
+
     ~UsdTRSUndoableCommandBase() = default;
 
     // Initialize the command.
@@ -68,7 +78,13 @@ protected:
     // UFE item (and its USD prim) may change after creation time (e.g.
     // parenting change caused by undo / redo of other commands in the undo
     // stack), so always return current data.
+
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     inline UsdPrim prim() const { updateItem(); return fItem->prim(); };
+    #else
+    inline UsdPrim prim() const { return fItem->prim(); }
+    inline Ufe::Path path() const { return fItem->path(); }
+    #endif
 
     // Hooks to be implemented by the derived class: name of the attribute set
     // by the command, implementation of perform(), and add empty attribute.
@@ -78,13 +94,23 @@ protected:
     virtual void addEmptyAttribute() = 0;
     virtual bool cannotInit() const;
 
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     // Conditionally create a UsdSceneItem::Ptr from the Ufe::Path, if null.
     void updateItem() const;
 
     // Returns the new Ufe::Path overriden by derived classes (e.g TRS)
     virtual Ufe::Path getPath() const = 0;
+    #endif
 
 private:
+
+    #if UFE_PREVIEW_VERSION_NUM < 2021
+    // Overridden from Ufe::Observer
+    void operator()(const Ufe::Notification& notification) override;
+
+    template<class N> void checkNotification(const N* notification);
+    #endif
+
     inline UsdAttribute attribute() const {
         return prim().GetAttribute(attributeName());
     }
@@ -101,9 +127,14 @@ private:
 template<class T>
 struct MakeSharedEnabler : public T {
     MakeSharedEnabler(
+#if UFE_PREVIEW_VERSION_NUM >= 2021
         const Ufe::Path& path, double x, double y, double z)
         : T(path, x, y, z) {}
 };
-
+#else
+        const UsdSceneItem::Ptr& item, double x, double y, double z)
+        : T(item, x, y, z) {}
+};
+#endif
 } // namespace ufe
 } // namespace MayaUsd

--- a/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
+++ b/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
@@ -78,7 +78,7 @@ protected:
     virtual void addEmptyAttribute() = 0;
     virtual bool cannotInit() const;
 
-    // Create a UsdSceneItem::Ptr conditionaly in the first access from Ufe::Path.
+    // Conditionally create a UsdSceneItem::Ptr from the Ufe::Path, if null.
     void updateItem() const;
 
     // Returns the new Ufe::Path overriden by derived classes (e.g TRS)

--- a/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
+++ b/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
@@ -47,13 +47,12 @@ namespace ufe {
 //   becomes stale, and the prim in the updated scene item should be used.
 //
 template<class V>
-class MAYAUSD_CORE_PUBLIC UsdTRSUndoableCommandBase : public Ufe::Observer,
-        public std::enable_shared_from_this<UsdTRSUndoableCommandBase<V> >
+class MAYAUSD_CORE_PUBLIC UsdTRSUndoableCommandBase 
+    : public std::enable_shared_from_this<UsdTRSUndoableCommandBase<V>>
 {
 protected:
 
-    UsdTRSUndoableCommandBase(
-        const UsdSceneItem::Ptr& item, double x, double y, double z);
+    UsdTRSUndoableCommandBase(double x, double y, double z);
     ~UsdTRSUndoableCommandBase() = default;
 
     // Initialize the command.
@@ -69,8 +68,7 @@ protected:
     // UFE item (and its USD prim) may change after creation time (e.g.
     // parenting change caused by undo / redo of other commands in the undo
     // stack), so always return current data.
-    inline UsdPrim prim() const { return fItem->prim(); }
-    inline Ufe::Path path() const { return fItem->path(); }
+    inline UsdPrim prim() const { updateItem(); return fItem->prim(); };
 
     // Hooks to be implemented by the derived class: name of the attribute set
     // by the command, implementation of perform(), and add empty attribute.
@@ -80,30 +78,31 @@ protected:
     virtual void addEmptyAttribute() = 0;
     virtual bool cannotInit() const;
 
+    // Create a UsdSceneItem::Ptr conditionaly in the first access from Ufe::Path.
+    void updateItem() const;
+
+    // Returns the new Ufe::Path overriden by derived classes (e.g TRS)
+    virtual Ufe::Path getPath() const = 0;
+
 private:
-
-    // Overridden from Ufe::Observer
-    void operator()(const Ufe::Notification& notification) override;
-
-    template<class N> void checkNotification(const N* notification);
-
     inline UsdAttribute attribute() const {
-      return prim().GetAttribute(attributeName());
+        return prim().GetAttribute(attributeName());
     }
 
-    UsdSceneItem::Ptr fItem;
-    V                 fPrevValue;
-    V                 fNewValue;
-    bool              fOpAdded{false};
-    bool              fDoneOnce{false};
+    mutable UsdSceneItem::Ptr fItem{nullptr};
+    V                         fPrevValue;
+    V                         fNewValue;
+    bool                      fOpAdded{false};
+    bool                      fDoneOnce{false};
+
 }; // UsdTRSUndoableCommandBase
 
 // shared_ptr requires public ctor, dtor, so derive a class for it.
 template<class T>
 struct MakeSharedEnabler : public T {
     MakeSharedEnabler(
-        const UsdSceneItem::Ptr& item, double x, double y, double z)
-        : T(item, x, y, z) {}
+        const Ufe::Path& path, double x, double y, double z)
+        : T(path, x, y, z) {}
 };
 
 } // namespace ufe

--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -230,7 +230,7 @@ Ufe::SetMatrixUndoableCommand::Ptr UsdTransform3d::setMatrixCmd(const Ufe::Matri
 Ufe::Matrix4d UsdTransform3d::matrix() const
 {
     // TODO: HS Aug25,2020 dummy code to pass the compiler errors
-    Ufe::Matrix4d m;
+    Ufe::Matrix4d m{};
     return m;
 }
 #endif

--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -29,35 +29,35 @@ MAYAUSD_NS_DEF {
 namespace ufe {
 
 namespace {
-	Ufe::Matrix4d convertFromUsd(const GfMatrix4d& matrix)
-	{
-		// Even though memory layout of Ufe::Matrix4d and double[4][4] are identical
-		// we need to return a copy of the matrix so we cannot cast.
-		double m[4][4];
-		matrix.Get(m);
-		Ufe::Matrix4d uMat;
-		uMat.matrix = {{	{{m[0][0], m[0][1], m[0][2], m[0][3]}},
-							{{m[1][0], m[1][1], m[1][2], m[1][3]}},
-							{{m[2][0], m[2][1], m[2][2], m[2][3]}},
-							{{m[3][0], m[3][1], m[3][2], m[3][3]}} }};
-		return uMat;
-	}
+    Ufe::Matrix4d convertFromUsd(const GfMatrix4d& matrix)
+    {
+        // Even though memory layout of Ufe::Matrix4d and double[4][4] are identical
+        // we need to return a copy of the matrix so we cannot cast.
+        double m[4][4];
+        matrix.Get(m);
+        Ufe::Matrix4d uMat;
+        uMat.matrix = {{    {{m[0][0], m[0][1], m[0][2], m[0][3]}},
+                            {{m[1][0], m[1][1], m[1][2], m[1][3]}},
+                            {{m[2][0], m[2][1], m[2][2], m[2][3]}},
+                            {{m[3][0], m[3][1], m[3][2], m[3][3]}} }};
+        return uMat;
+    }
 
-	Ufe::Matrix4d primToUfeXform(const UsdPrim& prim, const UsdTimeCode& time)
-	{
-		UsdGeomXformCache xformCache(time);
-		GfMatrix4d usdMatrix = xformCache.GetLocalToWorldTransform(prim);
-		Ufe::Matrix4d xform = convertFromUsd(usdMatrix);
-		return xform;
-	}
+    Ufe::Matrix4d primToUfeXform(const UsdPrim& prim, const UsdTimeCode& time)
+    {
+        UsdGeomXformCache xformCache(time);
+        GfMatrix4d usdMatrix = xformCache.GetLocalToWorldTransform(prim);
+        Ufe::Matrix4d xform = convertFromUsd(usdMatrix);
+        return xform;
+    }
 
-	Ufe::Matrix4d primToUfeExclusiveXform(const UsdPrim& prim, const UsdTimeCode& time)
-	{
-		UsdGeomXformCache xformCache(time);
-		GfMatrix4d usdMatrix = xformCache.GetParentToWorldTransform(prim);
-		Ufe::Matrix4d xform = convertFromUsd(usdMatrix);
-		return xform;
-	}
+    Ufe::Matrix4d primToUfeExclusiveXform(const UsdPrim& prim, const UsdTimeCode& time)
+    {
+        UsdGeomXformCache xformCache(time);
+        GfMatrix4d usdMatrix = xformCache.GetParentToWorldTransform(prim);
+        Ufe::Matrix4d xform = convertFromUsd(usdMatrix);
+        return xform;
+    }
 }
 
 UsdTransform3d::UsdTransform3d() : Transform3d()
@@ -65,13 +65,14 @@ UsdTransform3d::UsdTransform3d() : Transform3d()
 }
 
 UsdTransform3d::UsdTransform3d(const UsdSceneItem::Ptr& item)
-    : Transform3d(), fItem(item), fPrim(item->prim())
+    : Transform3d()
+    , fItem(item)
 {}
 
 /*static*/
 UsdTransform3d::Ptr UsdTransform3d::create()
 {
-	return std::make_shared<UsdTransform3d>();
+    return std::make_shared<UsdTransform3d>();
 }
 
 /* static */
@@ -82,8 +83,7 @@ UsdTransform3d::Ptr UsdTransform3d::create(const UsdSceneItem::Ptr& item)
 
 void UsdTransform3d::setItem(const UsdSceneItem::Ptr& item)
 {
-	fPrim = item->prim();
-	fItem = item;
+    fItem = item;
 }
 
 //------------------------------------------------------------------------------
@@ -92,165 +92,179 @@ void UsdTransform3d::setItem(const UsdSceneItem::Ptr& item)
 
 const Ufe::Path& UsdTransform3d::path() const
 {
-	return fItem->path();
+    return fItem->path();
 }
 
 Ufe::SceneItem::Ptr UsdTransform3d::sceneItem() const
 {
-	return fItem;
+    return fItem;
 }
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd(double x, double y, double z)
 {
-	return UsdTranslateUndoableCommand::create(fItem, x, y, z);
+    return UsdTranslateUndoableCommand::create(path(), x, y, z);
 }
 #endif
 
 void UsdTransform3d::translate(double x, double y, double z)
 {
-	translateOp(fPrim, fItem->path(), x, y, z);
+    translateOp(prim(), fItem->path(), x, y, z);
 }
 
 Ufe::Vector3d UsdTransform3d::translation() const
 {
-	double x{0}, y{0}, z{0};
-	const TfToken xlate("xformOp:translate");
-	if (fPrim.HasAttribute(xlate))
-	{
-		// Initially, attribute can be created, but have no value.
-		GfVec3d v;
-		if (fPrim.GetAttribute(xlate).Get<GfVec3d>(&v,getTime(path())))
-		{
-			x = v[0]; y = v[1]; z = v[2];
-		}
-	}
-	return Ufe::Vector3d(x, y, z);
+    double x{0}, y{0}, z{0};
+    const TfToken xlate("xformOp:translate");
+    if (prim().HasAttribute(xlate))
+    {
+        // Initially, attribute can be created, but have no value.
+        GfVec3d v;
+        if (prim().GetAttribute(xlate).Get<GfVec3d>(&v,getTime(path())))
+        {
+            x = v[0]; y = v[1]; z = v[2];
+        }
+    }
+    return Ufe::Vector3d(x, y, z);
 }
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::Vector3d UsdTransform3d::rotation() const
 {
-	double x{0}, y{0}, z{0};
-	const TfToken rotXYZ("xformOp:rotateXYZ");
-	if (fPrim.HasAttribute(rotXYZ))
-	{
-		// Initially, attribute can be created, but have no value.
-		GfVec3f v;
-		if (fPrim.GetAttribute(rotXYZ).Get<GfVec3f>(&v,getTime(path())))
-		{
-			x = v[0]; y = v[1]; z = v[2];
-		}
-	}
-	return Ufe::Vector3d(x, y, z);
+    double x{0}, y{0}, z{0};
+    const TfToken rotXYZ("xformOp:rotateXYZ");
+    if (prim().HasAttribute(rotXYZ))
+    {
+        // Initially, attribute can be created, but have no value.
+        GfVec3f v;
+        if (prim().GetAttribute(rotXYZ).Get<GfVec3f>(&v,getTime(path())))
+        {
+            x = v[0]; y = v[1]; z = v[2];
+        }
+    }
+    return Ufe::Vector3d(x, y, z);
 }
 
 Ufe::Vector3d UsdTransform3d::scale() const
 {
-	double x{0}, y{0}, z{0};
-	const TfToken scaleTok("xformOp:scale");
-	if (fPrim.HasAttribute(scaleTok))
-	{
-		// Initially, attribute can be created, but have no value.
-		GfVec3f v;
-		if (fPrim.GetAttribute(scaleTok).Get<GfVec3f>(&v,getTime(path())))
-		{
-			x = v[0]; y = v[1]; z = v[2];
-		}
-	}
-	return Ufe::Vector3d(x, y, z);
+    double x{0}, y{0}, z{0};
+    const TfToken scaleTok("xformOp:scale");
+    if (prim().HasAttribute(scaleTok))
+    {
+        // Initially, attribute can be created, but have no value.
+        GfVec3f v;
+        if (prim().GetAttribute(scaleTok).Get<GfVec3f>(&v,getTime(path())))
+        {
+            x = v[0]; y = v[1]; z = v[2];
+        }
+    }
+    return Ufe::Vector3d(x, y, z);
 }
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd(double x, double y, double z)
 {
-	return UsdRotateUndoableCommand::create(fItem, x, y, z);
+    return UsdRotateUndoableCommand::create(path(), x, y, z);
 }
 #endif
 
 void UsdTransform3d::rotate(double x, double y, double z)
 {
-	rotateOp(fPrim, fItem->path(), x, y, z);
+    rotateOp(prim(), fItem->path(), x, y, z);
 }
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd(double x, double y, double z)
 {
-	return UsdScaleUndoableCommand::create(fItem, x, y, z);
+    return UsdScaleUndoableCommand::create(path(), x, y, z);
 }
 
 #else
 
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd()
 {
-	return UsdTranslateUndoableCommand::create(fItem, 0, 0, 0);
+    return UsdTranslateUndoableCommand::create(path(), 0, 0, 0);
 }
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd()
 {
-	return UsdRotateUndoableCommand::create(fItem, 0, 0, 0);
+    return UsdRotateUndoableCommand::create(path(), 0, 0, 0);
 }
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd()
 {
-	return UsdScaleUndoableCommand::create(fItem, 1, 1, 1);
+    return UsdScaleUndoableCommand::create(path(), 1, 1, 1);
+}
+#endif
+
+#if UFE_PREVIEW_VERSION_NUM >= 2021
+Ufe::SetMatrixUndoableCommand::Ptr UsdTransform3d::setMatrixCmd(const Ufe::Matrix4d& m)
+{
+    // TODO: HS Aug25,2020 dummy code to pass the compiler errors
+    return nullptr;
+}
+
+Ufe::Matrix4d UsdTransform3d::matrix() const
+{
+    // TODO: HS Aug25,2020 dummy code to pass the compiler errors
+    Ufe::Matrix4d m{0};
+    return m;
 }
 #endif
 
 void UsdTransform3d::scale(double x, double y, double z)
 {
-	scaleOp(fPrim, fItem->path(), x, y, z);
+    scaleOp(prim(), fItem->path(), x, y, z);
 }
 
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::rotatePivotTranslateCmd()
 {
-	auto translateCmd = UsdRotatePivotTranslateUndoableCommand::create(fPrim, fItem->path(), fItem);
-	return translateCmd;
+    return UsdRotatePivotTranslateUndoableCommand::create(fItem->path());
 }
 
 void UsdTransform3d::rotatePivotTranslate(double x, double y, double z)
 {
-	rotatePivotTranslateOp(fPrim, fItem->path(), x, y, z);
+    rotatePivotTranslateOp(prim(), path(), x, y, z);
 }
 
 Ufe::Vector3d UsdTransform3d::rotatePivot() const
 {
-	double x{0}, y{0}, z{0};
-	const TfToken xpivot("xformOp:translate:pivot");
-	if (fPrim.HasAttribute(xpivot))
-	{
-		// Initially, attribute can be created, but have no value.
-		GfVec3f v;
-		if (fPrim.GetAttribute(xpivot).Get<GfVec3f>(&v,getTime(path())))
-		{
-			x = v[0]; y = v[1]; z = v[2];
-		}
-	}
-	return Ufe::Vector3d(x, y, z);
+    double x{0}, y{0}, z{0};
+    const TfToken xpivot("xformOp:translate:pivot");
+    if (prim().HasAttribute(xpivot))
+    {
+        // Initially, attribute can be created, but have no value.
+        GfVec3f v;
+        if (prim().GetAttribute(xpivot).Get<GfVec3f>(&v,getTime(path())))
+        {
+            x = v[0]; y = v[1]; z = v[2];
+        }
+    }
+    return Ufe::Vector3d(x, y, z);
 }
 
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::scalePivotTranslateCmd()
 {
-	throw std::runtime_error("UsdTransform3d::scalePivotTranslateCmd() not implemented");
+    throw std::runtime_error("UsdTransform3d::scalePivotTranslateCmd() not implemented");
 }
 
 void UsdTransform3d::scalePivotTranslate(double x, double y, double z)
 {
-	return rotatePivotTranslate(x, y, z);
+    return rotatePivotTranslate(x, y, z);
 }
 
 Ufe::Vector3d UsdTransform3d::scalePivot() const
 {
-	return rotatePivot();
+    return rotatePivot();
 }
 
 Ufe::Matrix4d UsdTransform3d::segmentInclusiveMatrix() const
 {
-	return primToUfeXform(fPrim,getTime(path()));
+    return primToUfeXform(prim(),getTime(path()));
 }
  
 Ufe::Matrix4d UsdTransform3d::segmentExclusiveMatrix() const
 {
-	return primToUfeExclusiveXform(fPrim,getTime(path()));
+    return primToUfeExclusiveXform(prim(),getTime(path()));
 }
 
 } // namespace ufe

--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -103,7 +103,11 @@ Ufe::SceneItem::Ptr UsdTransform3d::sceneItem() const
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd(double x, double y, double z)
 {
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     return UsdTranslateUndoableCommand::create(path(), x, y, z);
+    #else
+    return UsdTranslateUndoableCommand::create(fItem, x, y, z);
+    #endif
 }
 #endif
 
@@ -163,7 +167,11 @@ Ufe::Vector3d UsdTransform3d::scale() const
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd(double x, double y, double z)
 {
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     return UsdRotateUndoableCommand::create(path(), x, y, z);
+    #else
+    return UsdRotateUndoableCommand::create(fItem, x, y, z);
+    #endif
 }
 #endif
 
@@ -175,24 +183,40 @@ void UsdTransform3d::rotate(double x, double y, double z)
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd(double x, double y, double z)
 {
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     return UsdScaleUndoableCommand::create(path(), x, y, z);
+    #else
+    return UsdScaleUndoableCommand::create(fItem, x, y, z);
+    #endif
 }
 
 #else
 
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd()
 {
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     return UsdTranslateUndoableCommand::create(path(), 0, 0, 0);
+    #else
+    return UsdTranslateUndoableCommand::create(fItem, 0, 0, 0);
+    #endif
 }
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd()
 {
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     return UsdRotateUndoableCommand::create(path(), 0, 0, 0);
+    #else
+    return UsdRotateUndoableCommand::create(fItem, 0, 0, 0);
+    #endif
 }
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd()
 {
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     return UsdScaleUndoableCommand::create(path(), 1, 1, 1);
+    #else
+    return UsdScaleUndoableCommand::create(fItem, 1, 1, 1);
+    #endif
 }
 #endif
 
@@ -218,7 +242,12 @@ void UsdTransform3d::scale(double x, double y, double z)
 
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::rotatePivotTranslateCmd()
 {
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     return UsdRotatePivotTranslateUndoableCommand::create(fItem->path());
+    #else
+    auto translateCmd = UsdRotatePivotTranslateUndoableCommand::create(prim(), fItem->path(), fItem);
+    return translateCmd;
+    #endif
 }
 
 void UsdTransform3d::rotatePivotTranslate(double x, double y, double z)

--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -230,7 +230,7 @@ Ufe::SetMatrixUndoableCommand::Ptr UsdTransform3d::setMatrixCmd(const Ufe::Matri
 Ufe::Matrix4d UsdTransform3d::matrix() const
 {
     // TODO: HS Aug25,2020 dummy code to pass the compiler errors
-    Ufe::Matrix4d m{0};
+    Ufe::Matrix4d m;
     return m;
 }
 #endif

--- a/lib/mayaUsd/ufe/UsdTransform3d.h
+++ b/lib/mayaUsd/ufe/UsdTransform3d.h
@@ -53,6 +53,7 @@ public:
 	// Ufe::Transform3d overrides
 	const Ufe::Path& path() const override;
 	Ufe::SceneItem::Ptr sceneItem() const override;
+	inline UsdPrim prim() const { TF_AXIOM(fItem != nullptr); return fItem->prim(); }
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 	Ufe::TranslateUndoableCommand::Ptr translateCmd(double x, double y, double z) override;
@@ -64,6 +65,11 @@ public:
 	Ufe::TranslateUndoableCommand::Ptr translateCmd() override;
 	Ufe::RotateUndoableCommand::Ptr rotateCmd() override;
 	Ufe::ScaleUndoableCommand::Ptr scaleCmd() override;
+#endif
+
+#if UFE_PREVIEW_VERSION_NUM >= 2021
+	Ufe::SetMatrixUndoableCommand::Ptr setMatrixCmd(const Ufe::Matrix4d& m) override;
+	Ufe::Matrix4d matrix() const override;
 #endif
 
 	void translate(double x, double y, double z) override;
@@ -81,7 +87,6 @@ public:
 
 private:
 	UsdSceneItem::Ptr fItem;
-	UsdPrim fPrim;
 
 }; // UsdTransform3d
 

--- a/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.cpp
@@ -22,10 +22,9 @@ namespace ufe {
 
 TfToken UsdTranslateUndoableCommand::xlate("xformOp:translate");
 
-UsdTranslateUndoableCommand::UsdTranslateUndoableCommand(
-    const UsdSceneItem::Ptr& item, double x, double y, double z
-) : Ufe::TranslateUndoableCommand(item),
-    UsdTRSUndoableCommandBase(item, x, y, z)
+UsdTranslateUndoableCommand::UsdTranslateUndoableCommand(const Ufe::Path& path, double x, double y, double z) 
+    : Ufe::TranslateUndoableCommand(path)
+    , UsdTRSUndoableCommandBase(x, y, z)
 {}
 
 UsdTranslateUndoableCommand::~UsdTranslateUndoableCommand()
@@ -33,11 +32,11 @@ UsdTranslateUndoableCommand::~UsdTranslateUndoableCommand()
 
 /*static*/
 UsdTranslateUndoableCommand::Ptr UsdTranslateUndoableCommand::create(
-    const UsdSceneItem::Ptr& item, double x, double y, double z
+    const Ufe::Path& path, double x, double y, double z
 )
 {
     auto cmd = std::make_shared<MakeSharedEnabler<UsdTranslateUndoableCommand>>(
-        item, x, y, z);
+        path, x, y, z);
     cmd->initialize();
     return cmd;
 }

--- a/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.cpp
@@ -22,15 +22,24 @@ namespace ufe {
 
 TfToken UsdTranslateUndoableCommand::xlate("xformOp:translate");
 
+#if UFE_PREVIEW_VERSION_NUM >= 2021
 UsdTranslateUndoableCommand::UsdTranslateUndoableCommand(const Ufe::Path& path, double x, double y, double z) 
     : Ufe::TranslateUndoableCommand(path)
     , UsdTRSUndoableCommandBase(x, y, z)
 {}
+#else
+UsdTranslateUndoableCommand::UsdTranslateUndoableCommand(
+    const UsdSceneItem::Ptr& item, double x, double y, double z
+) : Ufe::TranslateUndoableCommand(item),
+    UsdTRSUndoableCommandBase(item, x, y, z)
+{}
+#endif
 
 UsdTranslateUndoableCommand::~UsdTranslateUndoableCommand()
 {}
 
 /*static*/
+#if UFE_PREVIEW_VERSION_NUM >= 2021
 UsdTranslateUndoableCommand::Ptr UsdTranslateUndoableCommand::create(
     const Ufe::Path& path, double x, double y, double z
 )
@@ -40,6 +49,17 @@ UsdTranslateUndoableCommand::Ptr UsdTranslateUndoableCommand::create(
     cmd->initialize();
     return cmd;
 }
+#else
+UsdTranslateUndoableCommand::Ptr UsdTranslateUndoableCommand::create(
+    const UsdSceneItem::Ptr& item, double x, double y, double z
+)
+{
+    auto cmd = std::make_shared<MakeSharedEnabler<UsdTranslateUndoableCommand>>(
+        item, x, y, z);
+    cmd->initialize();
+    return cmd;
+}
+#endif
 
 void UsdTranslateUndoableCommand::undo()
 {

--- a/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.h
@@ -41,10 +41,10 @@ public:
 	UsdTranslateUndoableCommand(UsdTranslateUndoableCommand&&) = delete;
 	UsdTranslateUndoableCommand& operator=(UsdTranslateUndoableCommand&&) = delete;
 
-	//! Create a UsdTranslateUndoableCommand from a UFE scene item.  The
+	//! Create a UsdTranslateUndoableCommand from a UFE scene path. The
 	//! command is not executed.
 	static UsdTranslateUndoableCommand::Ptr create(
-        const UsdSceneItem::Ptr& item, double x, double y, double z);
+        const Ufe::Path& path, double x, double y, double z);
 
 	// Ufe::TranslateUndoableCommand overrides.  translate() sets the command's
 	// translation value and executes the command.
@@ -52,10 +52,12 @@ public:
 	void redo() override;
 	bool translate(double x, double y, double z) override;
 
+	Ufe::Path getPath() const override { return path(); }
+
 protected:
 
     //! Construct a UsdTranslateUndoableCommand.  The command is not executed.
-	UsdTranslateUndoableCommand(const UsdSceneItem::Ptr& item, double x, double y, double z);
+	UsdTranslateUndoableCommand(const Ufe::Path& path, double x, double y, double z);
 	~UsdTranslateUndoableCommand() override;
 
 private:

--- a/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.h
@@ -41,10 +41,17 @@ public:
 	UsdTranslateUndoableCommand(UsdTranslateUndoableCommand&&) = delete;
 	UsdTranslateUndoableCommand& operator=(UsdTranslateUndoableCommand&&) = delete;
 
+	#if UFE_PREVIEW_VERSION_NUM >= 2021
 	//! Create a UsdTranslateUndoableCommand from a UFE scene path. The
 	//! command is not executed.
 	static UsdTranslateUndoableCommand::Ptr create(
         const Ufe::Path& path, double x, double y, double z);
+	#else
+	//! Create a UsdTranslateUndoableCommand from a UFE scene item.  The
+	//! command is not executed.
+	static UsdTranslateUndoableCommand::Ptr create(
+        const UsdSceneItem::Ptr& item, double x, double y, double z);
+	#endif
 
 	// Ufe::TranslateUndoableCommand overrides.  translate() sets the command's
 	// translation value and executes the command.
@@ -52,12 +59,19 @@ public:
 	void redo() override;
 	bool translate(double x, double y, double z) override;
 
+	#if UFE_PREVIEW_VERSION_NUM >= 2021
 	Ufe::Path getPath() const override { return path(); }
+	#endif
 
 protected:
 
     //! Construct a UsdTranslateUndoableCommand.  The command is not executed.
+	#if UFE_PREVIEW_VERSION_NUM >= 2021
 	UsdTranslateUndoableCommand(const Ufe::Path& path, double x, double y, double z);
+	#else
+	UsdTranslateUndoableCommand(const UsdSceneItem::Ptr& item, double x, double y, double z);
+	#endif
+
 	~UsdTranslateUndoableCommand() override;
 
 private:

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
@@ -106,9 +106,9 @@ void UsdUndoDuplicateCommand::undo()
 										fUfeSrcPath, fUsdDstPath.GetElementString()));
 
 	#if UFE_PREVIEW_VERSION_NUM >= 2021
-		Ufe::Scene::instance().notify(notification);
+	Ufe::Scene::instance().notify(notification);
 	#else
-		Ufe::Scene::notifyObjectDelete(notification);
+	Ufe::Scene::notifyObjectDelete(notification);
 	#endif
 
 	fStage->RemovePrim(fUsdDstPath);

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
@@ -104,7 +104,7 @@ void UsdUndoDuplicateCommand::undo()
 	// the notification is sent, we send a pre delete notification here.
 	Ufe::ObjectPreDelete notification(createSiblingSceneItem(
 										fUfeSrcPath, fUsdDstPath.GetElementString()));
-	Ufe::Scene::notifyObjectDelete(notification);
+	Ufe::Scene::instance().notify(notification);
 
 	fStage->RemovePrim(fUsdDstPath);
 }

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
@@ -104,7 +104,12 @@ void UsdUndoDuplicateCommand::undo()
 	// the notification is sent, we send a pre delete notification here.
 	Ufe::ObjectPreDelete notification(createSiblingSceneItem(
 										fUfeSrcPath, fUsdDstPath.GetElementString()));
-	Ufe::Scene::instance().notify(notification);
+
+	#if UFE_PREVIEW_VERSION_NUM >= 2021
+		Ufe::Scene::instance().notify(notification);
+	#else
+		Ufe::Scene::notifyObjectDelete(notification);
+	#endif
 
 	fStage->RemovePrim(fUsdDstPath);
 }

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
@@ -54,8 +54,12 @@ namespace ufe {
 
 UsdUndoInsertChildCommand::UsdUndoInsertChildCommand(const UsdSceneItem::Ptr& parent,
                                                      const UsdSceneItem::Ptr& child,
-                                                     const UsdSceneItem::Ptr& /* pos */) 
+                                                     const UsdSceneItem::Ptr& /* pos */)
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     : Ufe::InsertChildCommand()
+    #else
+    : Ufe::UndoableCommand()
+    #endif
     , _ufeSrcItem(child)
     , _ufeDstItem(nullptr)
     , _ufeSrcPath(child->path())

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
@@ -55,7 +55,7 @@ namespace ufe {
 UsdUndoInsertChildCommand::UsdUndoInsertChildCommand(const UsdSceneItem::Ptr& parent,
                                                      const UsdSceneItem::Ptr& child,
                                                      const UsdSceneItem::Ptr& /* pos */) 
-    : Ufe::UndoableCommand()
+    : Ufe::InsertChildCommand()
     , _ufeSrcItem(child)
     , _ufeDstItem(nullptr)
     , _ufeSrcPath(child->path())

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 
-#include <ufe/undoableCommand.h>
+#include <ufe/hierarchy.h>
 
 #include <pxr/usd/usd/prim.h>
 
@@ -28,7 +28,7 @@ MAYAUSD_NS_DEF {
 namespace ufe {
 
 //! \brief UsdUndoInsertChildCommand
-class MAYAUSD_CORE_PUBLIC UsdUndoInsertChildCommand : public Ufe::UndoableCommand
+class MAYAUSD_CORE_PUBLIC UsdUndoInsertChildCommand : public Ufe::InsertChildCommand
 {
 public:
     using Ptr = std::shared_ptr<UsdUndoInsertChildCommand>;
@@ -46,6 +46,8 @@ public:
     static UsdUndoInsertChildCommand::Ptr create(const UsdSceneItem::Ptr& parent,
                                                  const UsdSceneItem::Ptr& child,
                                                  const UsdSceneItem::Ptr& pos);
+
+    Ufe::SceneItem::Ptr insertedChild() const override {return _ufeDstItem;}
 
 protected:
     //! Construct a UsdUndoInsertChildCommand.  Note that as of 4-May-2020 the

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
@@ -15,7 +15,11 @@
 //
 #pragma once
 
+#if UFE_PREVIEW_VERSION_NUM >= 2021
 #include <ufe/hierarchy.h>
+#else
+#include <ufe/undoableCommand.h>
+#endif
 
 #include <pxr/usd/usd/prim.h>
 
@@ -28,7 +32,11 @@ MAYAUSD_NS_DEF {
 namespace ufe {
 
 //! \brief UsdUndoInsertChildCommand
+#if UFE_PREVIEW_VERSION_NUM >= 2021
 class MAYAUSD_CORE_PUBLIC UsdUndoInsertChildCommand : public Ufe::InsertChildCommand
+#else
+class MAYAUSD_CORE_PUBLIC UsdUndoInsertChildCommand : public Ufe::UndoableCommand
+#endif
 {
 public:
     using Ptr = std::shared_ptr<UsdUndoInsertChildCommand>;
@@ -47,7 +55,9 @@ public:
                                                  const UsdSceneItem::Ptr& child,
                                                  const UsdSceneItem::Ptr& pos);
 
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     Ufe::SceneItem::Ptr insertedChild() const override {return _ufeDstItem;}
+    #endif
 
 protected:
     //! Construct a UsdUndoInsertChildCommand.  Note that as of 4-May-2020 the

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -85,7 +85,7 @@ template <class T>
 void sendNotification(const Ufe::SceneItem::Ptr& item, const Ufe::Path& previousPath)
 {
     T notification(item, previousPath);
-    Ufe::Scene::notifyObjectPathChange(notification);
+    Ufe::Scene::instance().notify(notification);
 }
 
 //! Readability function to downcast a SceneItem::Ptr to a UsdSceneItem::Ptr.

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -85,7 +85,11 @@ template <class T>
 void sendNotification(const Ufe::SceneItem::Ptr& item, const Ufe::Path& previousPath)
 {
     T notification(item, previousPath);
+    #if UFE_PREVIEW_VERSION_NUM >= 2021
     Ufe::Scene::instance().notify(notification);
+    #else
+    Ufe::Scene::notifyObjectPathChange(notification);
+    #endif
 }
 
 //! Readability function to downcast a SceneItem::Ptr to a UsdSceneItem::Ptr.

--- a/test/lib/ufe/CMakeLists.txt
+++ b/test/lib/ufe/CMakeLists.txt
@@ -31,6 +31,7 @@ if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
         testScaleCmd.py
         testSceneItem.py
         testTransform3dTranslate.py
+        testObservableScene.py
     )
 endif()
 

--- a/test/lib/ufe/testContextOps.py
+++ b/test/lib/ufe/testContextOps.py
@@ -187,8 +187,11 @@ class ContextOpsTestCase(unittest.TestCase):
 
         # Create our UFE notification observer
         ufeObs = TestAddPrimObserver()
-        ufe.Scene.addObjectDeleteObserver(ufeObs)
-        ufe.Scene.addObjectAddObserver(ufeObs)
+        if(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '2021'):
+            ufe.Scene.addObjectDeleteObserver(ufeObs)
+            ufe.Scene.addObjectAddObserver(ufeObs)
+        else:
+            ufe.Scene.addObserver(ufeObs)
 
         # Create a ContextOps interface for the proxy shape.
         proxyShapePath = ufe.Path([mayaUtils.createUfePathSegment("|world|stage1|stageShape1")])

--- a/test/lib/ufe/testDeleteCmd.py
+++ b/test/lib/ufe/testDeleteCmd.py
@@ -22,6 +22,7 @@ from ufeTestUtils import ufeUtils, usdUtils, mayaUtils
 import ufe
 
 import unittest
+import os
 
 def childrenNames(children):
     return [str(child.path().back()) for child in children]
@@ -90,8 +91,12 @@ class DeleteCmdTestCase(unittest.TestCase):
 
         # Create our UFE notification observer
         ufeObs = TestObserver()
-        ufe.Scene.addObjectDeleteObserver(ufeObs)
-        ufe.Scene.addObjectAddObserver(ufeObs)
+
+        if(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '2021'):
+            ufe.Scene.addObjectDeleteObserver(ufeObs)
+            ufe.Scene.addObjectAddObserver(ufeObs)
+        else:
+            ufe.Scene.addObserver(ufeObs)
 
         # Select two objects, one Maya, one USD.
         spherePath = ufe.Path(mayaUtils.createUfePathSegment("|pSphere1"))
@@ -192,8 +197,11 @@ class DeleteCmdTestCase(unittest.TestCase):
 
         # Create our UFE notification observer
         ufeObs = TestObserver()
-        ufe.Scene.addObjectDeleteObserver(ufeObs)
-        ufe.Scene.addObjectAddObserver(ufeObs)
+        if(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '2021'):
+            ufe.Scene.addObjectDeleteObserver(ufeObs)
+            ufe.Scene.addObjectAddObserver(ufeObs)
+        else:
+            ufe.Scene.addObserver(ufeObs)
 
         spherePath = ufe.Path(mayaUtils.createUfePathSegment("|pSphere1"))
         sphereItem = ufe.Hierarchy.createItem(spherePath)

--- a/test/lib/ufe/testObservableScene.py
+++ b/test/lib/ufe/testObservableScene.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2020 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os
+import sys
+import unittest
+
+import ufe
+
+class TestObserver(ufe.Observer):
+    def __init__(self):
+        self.add = 0
+        self.delete = 0
+        self.pathChange = 0
+        self.subtreeInvalidate = 0
+        self.composite = 0
+        super(TestObserver, self).__init__()
+
+    def __call__(self, notification):
+        if isinstance(notification, ufe.ObjectAdd):
+            self.add += 1
+        if isinstance(notification, ufe.ObjectDelete):
+            self.delete += 1
+        if isinstance(notification, ufe.ObjectPathChange):
+            self.pathChange += 1
+        if isinstance(notification, ufe.SubtreeInvalidate):
+            self.subtreeInvalidate += 1
+        if isinstance(notification, ufe.SceneCompositeNotification):
+            self.composite += 1
+
+    def notifications(self):
+        return [self.add, self.delete, self.pathChange, self.subtreeInvalidate, self.composite]
+
+class UFEObservableSceneTest(unittest.TestCase):
+
+    def checkNotifications(self, testObserver, listNotifications):
+        self.assertTrue(testObserver.add == listNotifications[0])
+        self.assertTrue(testObserver.delete == listNotifications[1])
+        self.assertTrue(testObserver.pathChange == listNotifications[2])
+        self.assertTrue(testObserver.subtreeInvalidate == listNotifications[3])
+        self.assertTrue(testObserver.composite == listNotifications[4])
+
+    def testObservableSelection(self):
+        # Setup
+        ca = ufe.PathComponent("a")
+        cb = ufe.PathComponent("b")
+        cc = ufe.PathComponent("c")
+
+        sa = ufe.PathSegment([ca], 3, '/')
+        sab = ufe.PathSegment([ca, cb], 1, '|')
+        sc = ufe.PathSegment([cc], 2, '/')
+
+        a = ufe.Path(sa)
+        b = ufe.Path(sab)
+        c = ufe.Path([sab, sc])
+
+        itemA = ufe.SceneItem(a)
+        itemB = ufe.SceneItem(b)
+        itemC = ufe.SceneItem(c)
+        # End Setup
+
+        # No observers yet.
+        self.assertEqual(ufe.Scene.nbObservers(), 0)
+
+        snObs = TestObserver()
+
+        # Add observer to the scene.
+        ufe.Scene.addObserver(snObs)
+
+        # Order of expected notifications. No notifications yet.
+        self.checkNotifications(snObs, [0,0,0,0,0,0])
+
+        self.assertEqual(ufe.Scene.nbObservers(), 1)
+        self.assertTrue(ufe.Scene.hasObserver(snObs))
+
+        ufe.Scene.notify(ufe.ObjectAdd(itemA))
+
+        # we should now have an ObjectAdd notification
+        self.checkNotifications(snObs, [1,0,0,0,0,0])
+
+        # HS 2020: can't pass ufe.scene to NotificationGuard??
+        
+        # Composite notifications with guard.
+        # with ufe.NotificationGuard(ufe.Scene):
+        #     ufe.Scene.notify(ufe.ObjectAdd(itemB))
+        #     ufe.Scene.notify(ufe.ObjectAdd(itemC))

--- a/test/lib/ufe/testObservableScene.py
+++ b/test/lib/ufe/testObservableScene.py
@@ -47,7 +47,7 @@ class TestObserver(ufe.Observer):
     def notifications(self):
         return [self.add, self.delete, self.pathChange, self.subtreeInvalidate, self.composite]
 
-@unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') >= '2021', 'testObservableScene is only available in Maya with UFE preview version 0.2.21 and greater')
+@unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '2021', 'testObservableScene is only available in Maya with UFE preview version 0.2.21 and greater')
 class UFEObservableSceneTest(unittest.TestCase):
 
     def checkNotifications(self, testObserver, listNotifications):

--- a/test/lib/ufe/testObservableScene.py
+++ b/test/lib/ufe/testObservableScene.py
@@ -47,6 +47,7 @@ class TestObserver(ufe.Observer):
     def notifications(self):
         return [self.add, self.delete, self.pathChange, self.subtreeInvalidate, self.composite]
 
+@unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') >= '2021', 'testObservableScene is only available in Maya with UFE preview version 0.2.21 and greater')
 class UFEObservableSceneTest(unittest.TestCase):
 
     def checkNotifications(self, testObserver, listNotifications):

--- a/test/lib/ufe/testObservableScene.py
+++ b/test/lib/ufe/testObservableScene.py
@@ -56,7 +56,7 @@ class UFEObservableSceneTest(unittest.TestCase):
         self.assertTrue(testObserver.subtreeInvalidate == listNotifications[3])
         self.assertTrue(testObserver.composite == listNotifications[4])
 
-    def testObservableSelection(self):
+    def testObservableScene(self):
         # Setup
         ca = ufe.PathComponent("a")
         cb = ufe.PathComponent("b")

--- a/test/lib/ufe/testRename.py
+++ b/test/lib/ufe/testRename.py
@@ -420,14 +420,10 @@ class RenameTestCase(unittest.TestCase):
         ufeObs = TestObserver()
 
         # We start off with no observers
-        self.assertFalse(ufe.Scene.hasObjectAddObserver(ufeObs))
-        self.assertFalse(ufe.Scene.hasObjectDeleteObserver(ufeObs))
-        self.assertFalse(ufe.Scene.hasObjectPathChangeObserver(ufeObs))
+        self.assertFalse(ufe.Scene.hasObserver(ufeObs))
 
-        # Add the UFE observers we want to test
-        ufe.Scene.addObjectAddObserver(ufeObs)
-        ufe.Scene.addObjectDeleteObserver(ufeObs)
-        ufe.Scene.addObjectPathChangeObserver(ufeObs)
+        # Add the UFE observer we want to test
+        ufe.Scene.addObserver(ufeObs)
 
         # rename
         newName = 'pCylinder1_Renamed'

--- a/test/lib/ufe/testRename.py
+++ b/test/lib/ufe/testRename.py
@@ -24,6 +24,7 @@ import mayaUsd.ufe
 
 import unittest
 import re
+import os
 
 class TestObserver(ufe.Observer):
     def __init__(self):
@@ -419,11 +420,22 @@ class RenameTestCase(unittest.TestCase):
         # Create our UFE notification observer
         ufeObs = TestObserver()
 
-        # We start off with no observers
-        self.assertFalse(ufe.Scene.hasObserver(ufeObs))
+        if(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '2021'):
+            # We start off with no observers
+            self.assertFalse(ufe.Scene.hasObjectAddObserver(ufeObs))
+            self.assertFalse(ufe.Scene.hasObjectDeleteObserver(ufeObs))
+            self.assertFalse(ufe.Scene.hasObjectPathChangeObserver(ufeObs))
 
-        # Add the UFE observer we want to test
-        ufe.Scene.addObserver(ufeObs)
+            # Add the UFE observers we want to test
+            ufe.Scene.addObjectAddObserver(ufeObs)
+            ufe.Scene.addObjectDeleteObserver(ufeObs)
+            ufe.Scene.addObjectPathChangeObserver(ufeObs)
+        else:
+            # We start off with no observers
+            self.assertFalse(ufe.Scene.hasObserver(ufeObs))
+
+            # Add the UFE observer we want to test
+            ufe.Scene.addObserver(ufeObs)
 
         # rename
         newName = 'pCylinder1_Renamed'


### PR DESCRIPTION
Summary of changes:

* Adopt to new UFE changes: (**Ufe::Scene**, **Ufe::SceneCompositeNotfication**, **Ufe::hierarchy**)
* Translate/Rotate/Scale/RotatePivotTranslate commands now rely on Ufe::Path.
* Added a new testObservableScene.py 