### PR TITLE
[mtoh] Add option to schedule updates through Qt instead of Maya.

### DIFF
--- a/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -2,6 +2,17 @@ set(TARGET_NAME mtoh)
 
 add_library(${TARGET_NAME} SHARED)
 
+
+# -----------------------------------------------------------------------------
+# options
+# -----------------------------------------------------------------------------
+option(MTOH_QT_UPDATES "Use Qt to ensure viewport updates" ON)
+
+if (MTOH_QT_UPDATES AND NOT QT_LOCATION)
+  set(MTOH_QT_UPDATES OFF)
+  message("Disabling Qt updates because build does not have Qt enabled")
+endif()
+
 # -----------------------------------------------------------------------------
 # sources
 # -----------------------------------------------------------------------------
@@ -29,6 +40,7 @@ target_compile_definitions(${TARGET_NAME}
         $<$<BOOL:${IS_LINUX}>:LINUX>
         # Not sure if msvcc sets this automatically, but won't hurt to redefine
         $<$<BOOL:${IS_WINDOWS}>:_WIN32>
+        $<$<BOOL:${MTOH_QT_UPDATES}>:MTOH_QT_UPDATES>
 )
 
 mayaUsd_compile_config(${TARGET_NAME})
@@ -38,7 +50,8 @@ mayaUsd_compile_config(${TARGET_NAME})
 # -----------------------------------------------------------------------------
 target_link_libraries(${TARGET_NAME} 
     PRIVATE 
-        hdMaya 
+        hdMaya
+        $<$<BOOL:${MTOH_QT_UPDATES}>:Qt5::Core>
 )
 
 # -----------------------------------------------------------------------------

--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.h
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.h
@@ -125,7 +125,6 @@ private:
 
     // Callbacks
     static void _ClearHydraCallback(void* data);
-    static void _TimerCallback(float, float, void* data);
     static void _PlayblastingChanged(bool state, void*);
     static void _SelectionChangedCallback(void* data);
     static void _PanelDeletedCallback(const MString& panelName, void* data);
@@ -136,16 +135,16 @@ private:
         const MString& panelName, const MString& oldOverride,
         const MString& newOverride, void* data);
 
+    class AsynchronousUpdate;
+    std::unique_ptr<AsynchronousUpdate> _asyncUpdater;
+
     MtohRendererDescription _rendererDesc;
 
     std::vector<MHWRender::MRenderOperation*> _operations;
     std::vector<MCallbackId> _callbacks;
-    MCallbackId _timerCallback = 0;
     PanelCallbacksList _renderPanelCallbacks;
     MtohRenderGlobals _globals;
 
-    std::mutex _lastRenderTimeMutex;
-    std::chrono::system_clock::time_point _lastRenderTime;
     std::atomic<bool> _playBlasting = {false};
     std::atomic<bool> _isConverged = {false};
     std::atomic<bool> _needsClear = {false};


### PR DESCRIPTION
This PR addresses two outstanding issues:
  - The refresh on idle callback being done for every delegate separately, and incurring a bit of a penalty to get the update.
  - There's an outstanding issue in Maya where a user holding the mouse down button will block all updates....We'd like to think our users are going to be actively using their cursor and would still like visual feedback in those cases.

From offline conversations it seems 2 is in your court to solve, but this provides a work-around until then.
I does introduce Qt as a dependency into **mtoh** (which I think no-one really wants) but we need to get around the issue at hand.

**-DMTOH_QT_UPDATES=OFF** can be used to make **mtoh** use a modified version of the old code-path (using an MTimer callback, but that version moves away from `MGlobal::executeOnIdle('refresh -f')` in favor of `M3dView::scheduleRefreshAllViews()`