### PR TITLE
Add test for setting rotate pivot through move command.

### DIFF
--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -204,6 +204,8 @@ finally:
          "${CMAKE_INSTALL_PREFIX}/plugin/adsk/plugin")
     list(APPEND MAYAUSD_VARNAME_PYTHONPATH
          "${CMAKE_INSTALL_PREFIX}/plugin/adsk/scripts")
+    list(APPEND MAYAUSD_VARNAME_MAYA_SCRIPT_PATH
+         "${CMAKE_INSTALL_PREFIX}/plugin/adsk/scripts")
 
     # pxr
     list(APPEND MAYAUSD_VARNAME_PYTHONPATH

--- a/test/lib/ufe/CMakeLists.txt
+++ b/test/lib/ufe/CMakeLists.txt
@@ -6,8 +6,7 @@ set(TEST_SCRIPT_FILES
     testDeleteCmd.py
     testMatrices.py
     testMayaPickwalk.py
-    testRotatePivot.py
-	testSelection.py
+    testSelection.py
     testUfePythonImport.py
 )
 
@@ -27,6 +26,7 @@ if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
         testRename.py
 		testParentCmd.py
         testRotateCmd.py
+        testRotatePivot.py
         testScaleCmd.py
         testSceneItem.py
         testTransform3dTranslate.py


### PR DESCRIPTION
Add an automated test for setting the UFE rotate pivot through the Maya move command.