### PR TITLE
remove test dependencies on Python future past, and builtin.zip

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -184,14 +184,6 @@ Test project /Users/sabrih/Desktop/workspace/build/Debug/plugin/al
 100% tests passed, 0 tests failed out of 8
 ```
 
-***NOTE:*** As part of compatibility support for python 3 in maya-usd, there are number of python tests that require the use of python’s `future` module. While the `future` module is 
-available in our new preview releases of Maya, this package doesn't exist in the version of python in Maya 2018/2019/2020. Please follow the below steps in order to install the `future` package:
-
- 1. Download get-py.py from https://bootstrap.pypa.io/get-pip.py 
- 2. Open a command-line and navigate to `mayapy` executable for Maya version which needs future package.
- 3. Install pip: `mayapy <path_to_downloaded_file>/get-pip.py` 
- 3. Install the future package: `mayapy -m pip install future`
-
 # Additional Build Instruction
 
 ##### Boost:

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/test_translators_PythonBindings.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/test_translators_PythonBindings.cpp
@@ -40,12 +40,17 @@ TEST(translators_PythonBindings, import)
   prim.GetDepthAttr().Set(3.4f);
   stage->Save();
 
-  auto pythonscript = MString("\"") + AL_USDMAYA_TEST_DATA +
-                      MString("/../py/examplecubetranslator.py\"");
+  auto pythonscript = MString("'") + AL_USDMAYA_TEST_DATA +
+                      MString("/../py/examplecubetranslator.py'");
 
-  auto status = MGlobal::executePythonCommand(
-      MString {"from past.builtins import execfile; execfile("} + pythonscript + ")\n"
-  );
+  MString pyExecCmd;
+  pyExecCmd.format(
+    "file = ^1s;\n"
+    "globals = {'__file__': ^1s, '__name__': '__main__'};\n"
+    "exec(compile(open(file, 'rb').read(), file, 'exec'), globals);\n",
+    pythonscript);
+
+  auto status = MGlobal::executePythonCommand(pyExecCmd);
   ASSERT_TRUE(status);
 
   MFnDagNode fnd;
@@ -72,12 +77,17 @@ TEST(translators_PythonBindings, import)
 
 TEST(translators_PythonBindings, unknownType)
 {
-  auto pythonscript = MString("\"") + AL_USDMAYA_TEST_DATA +
-                      MString("/unknowntypetranslator.py\"");
+  auto pythonscript = MString("'") + AL_USDMAYA_TEST_DATA +
+                      MString("/unknowntypetranslator.py'");
 
-  auto status = MGlobal::executePythonCommand(
-      MString {"from past.builtins import execfile; execfile("} + pythonscript + ")\n"
-  );
+  MString pyExecCmd;
+  pyExecCmd.format(
+    "file = ^1s;\n"
+    "globals = {'__file__': ^1s, '__name__': '__main__'};\n"
+    "exec(compile(open(file, 'rb').read(), file, 'exec'), globals);\n",
+    pythonscript);
+
+  auto status = MGlobal::executePythonCommand(pyExecCmd);
   ASSERT_TRUE(status);
 
   auto pythonTranslators = TranslatorManufacture::getPythonTranslators();

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdMayaXformStack.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdMayaXformStack.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-from future.utils import iteritems
-
 from pxr import Gf
 from pxr import Usd
 
@@ -1116,7 +1114,8 @@ class testUsdMayaXformStack(unittest.TestCase):
         }
         
         expectedList = [mayaStack.FindOp('translate'), mayaStack.FindOp('rotate')]
-        for rotateOpName, expectedRotateOrder in iteritems(allRotates):
+        for rotateOpName in allRotates.keys():
+            expectedRotateOrder = allRotates[rotateOpName]
             orderedOps = [self.ops['translate'], self.ops[rotateOpName]]
             for stackList in (
                     [],

--- a/test/lib/usd/translators/testUsdExportEulerFilter.py
+++ b/test/lib/usd/translators/testUsdExportEulerFilter.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-from future.utils import iteritems
-
 import os
 import unittest
 
@@ -48,7 +46,8 @@ class testUsdExportEulerFilter(unittest.TestCase):
         xform = stage.GetPrimAtPath('/pCube1')
         rot = xform.GetProperty('xformOp:rotateXYZ')
 
-        for time, expectedVec in iteritems(expected):
+        for time in expected.keys():
+            expectedVec = expected[time]
             actualVec = rot.Get(time)
             for i in range(3):
                 msg = "sample at time {}, index {} unequal".format(time, i)

--- a/test/lib/usd/translators/testUsdExportFilterTypes.py
+++ b/test/lib/usd/translators/testUsdExportFilterTypes.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-from future.utils import iteritems
-
 import os
 import unittest
 
@@ -92,8 +90,8 @@ class testUsdExportFilterTypes(unittest.TestCase):
             }
             if filter:
                 options['filterTypes'] = ','.join(filter)
-            kwargs['options'] = ';'.join('{}={}'.format(key, val)
-                                         for key, val in iteritems(options))
+            kwargs['options'] = ';'.join('{}={}'.format(key, options[key])
+                                         for key in options.keys())
         print("running: {}(*{!r}, **{!r})".format(exportMethod.__name__, args, kwargs))
         exportMethod(*args, **kwargs)
         return Usd.Stage.Open(usdFile)

--- a/test/lib/usd/translators/testUsdImportCamera.py
+++ b/test/lib/usd/translators/testUsdImportCamera.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-from future.utils import iteritems
-
 import os
 import math
 import unittest
@@ -166,7 +164,8 @@ class testUsdImportCamera(unittest.TestCase):
         return animCurveFn
 
     def _ValidateAnimValuesAtTimes(self, animCurveFn, expectedTimesToValues):
-        for time, expectedValue in iteritems(expectedTimesToValues):
+        for time in expectedTimesToValues.keys():
+            expectedValue = expectedTimesToValues[time]
             value = animCurveFn.evaluate(OpenMaya.MTime(time))
             self.assertTrue(Gf.IsClose(expectedValue, value, 1e-6))
 


### PR DESCRIPTION
This removes the usage of `future`, `past`, and `builtin.zip` in tests. This simplifies the Python environment setup when attempting to run tests on currently released versions of Maya with Python 2, but should still support Python 3 as well.

Note that this is only part of the `future` removal. The other part of it takes place in #761 for the `pxrUsdMayaGL` tests.

No future. No past. Only now. :)