### PR TITLE
Use MFnMatrixData when storing/retriving MMatrix from data block

### DIFF
--- a/lib/mayaUsd/utils/converter.cpp
+++ b/lib/mayaUsd/utils/converter.cpp
@@ -291,9 +291,21 @@ MAYAUSD_NS_DEF
 
         static void set(FnType& data, const Type& value) { data.set(value); }
 
-        static void get(const MDataHandle& handle, Type& value) { value = handle.asMatrix(); }
+        static void get(const MDataHandle& handle, Type& value)
+        {
+            MObject dataObj = const_cast<MDataHandle&>(handle).data();
+            FnType  dataFn(dataObj);
+            get(dataFn, value);
+        }
 
-        static void set(MDataHandle& handle, const Type& value) { handle.set(value); }
+        static void set(MDataHandle& handle, const Type& value)
+        {
+            FnType  dataFn;
+            MObject dataObj = create(dataFn);
+            set(dataFn, value);
+
+            handle.setMObject(dataObj);
+        }
     };
 
     //! \brief  Type trait for Maya's float3 type providing get and set methods for data handle and

--- a/test/lib/testMayaUsdProxyAccessor.py
+++ b/test/lib/testMayaUsdProxyAccessor.py
@@ -1335,7 +1335,7 @@ class MayaUsdProxyAccessorTestCase(unittest.TestCase):
     def testMatrixOp_Caching(self):
         """
         Validate that accessor works correctly with matrix ops
-        Cached playback is disabled in this test.
+        Cached playback is ENABLED in this test.
         """
         cmds.file(new=True, force=True)
         with CachingScope(self) as thisScope:


### PR DESCRIPTION
Matrix is stored as shared data, we have to use an appropriate function interface to allocate and maintain the lifetime of matrix objects when stored in the data block.

Added regression test to validate the fix and prevent regressions. Normally it would require a test only for the converter, but data block is not something we have easy access to from python.