### PR TITLE
Fix build script with python 3 where each line starting with 'b and ends with \n' making it hard to read the log.

### DIFF
--- a/build.py
+++ b/build.py
@@ -5,6 +5,7 @@ from distutils.spawn import find_executable
 
 import argparse
 import contextlib
+import codecs
 import datetime
 import distutils
 import multiprocessing
@@ -124,7 +125,7 @@ def Run(context, cmd):
     """Run the specified command in a subprocess."""
     PrintInfo('Running "{cmd}"'.format(cmd=cmd))
 
-    with open(context.logFileLocation, "a") as logfile:
+    with codecs.open(context.logFileLocation, "a", "utf-8") as logfile:
         logfile.write("#####################################################################################" + "\n")
         logfile.write("log date: " + datetime.datetime.now().strftime("%Y-%m-%d %H:%M") + "\n")
         commitID,commitData = GetGitHeadInfo(context)
@@ -146,7 +147,7 @@ def Run(context, cmd):
                 if l != "":
                     # Avoid "UnicodeEncodeError: 'ascii' codec can't encode 
                     # character" errors by serializing utf8 byte strings.
-                    logfile.write(str(l.encode("utf8")))
+                    logfile.write(l)
                     PrintCommandOutput(l)
                 elif p.poll() is not None:
                     break


### PR DESCRIPTION
When running build.py with python3, each line starts with 'b and ends with \n' making it hard to read the log.

Using codec module fixes the problem: https://docs.python.org/3/library/codecs.html

It appears the same fix was also introduced in USD's build_usd.py few months ago:

```
Commit 4f0a1640
by sunyab, 25/03/2020 04:43 PM
committed by pixar-oss
parent 7f64522e
child a9c9786e
```

