### PR TITLE
Clean up setting _ufeDstItem in renameUndo() 

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
@@ -172,8 +172,6 @@ bool UsdUndoRenameCommand::renameUndo()
         _stage->SetDefaultPrim(_ufeSrcItem->prim());
     }
 
-    _ufeDstItem = nullptr;
-
     return true;
 }
 


### PR DESCRIPTION
Minor clean up for the purpose of code readability.  No need to set _ufeDstItem to nullptr at the end of renameUndo(). I already set _ufeDstItem to nullptr in the initializer list.