### PR TITLE
MAYA-106376: fix undo/redo re-parenting crash due to accessing a stale prim.

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
@@ -124,16 +124,20 @@ bool UsdUndoInsertChildCommand::insertChildRedo()
     bool status = SdfCopySpec(_childLayer, _usdSrcPath, _parentLayer, _usdDstPath);
     if (status)
     {
+        // we shouldn't rely on UsdSceneItem to access the UsdPrim since 
+        // it could be stale. Instead we should get the USDPrim from the Ufe::Path
+        const auto& desPrimUsd = ufePathToPrim(_ufeDstPath);
+
         // remove all scene description for the given path and 
         // its subtree in the current UsdEditTarget 
         {
-            auto stage = _ufeSrcItem->prim().GetStage();
+            auto stage = desPrimUsd.GetStage();
             UsdEditContext ctx(stage, _childLayer);
             status = stage->RemovePrim(_usdSrcPath);
         }
 
         if (status) {
-            _ufeDstItem = UsdSceneItem::create(_ufeDstPath, ufePathToPrim(_ufeDstPath));
+            _ufeDstItem = UsdSceneItem::create(_ufeDstPath, desPrimUsd);
             sendNotification<Ufe::ObjectReparent>(_ufeDstItem, _ufeSrcPath);
         }
     }
@@ -150,16 +154,20 @@ bool UsdUndoInsertChildCommand::insertChildUndo()
     bool status = SdfCopySpec(_parentLayer, _usdDstPath, _childLayer, _usdSrcPath);
     if (status)
     {
+        // we shouldn't rely on UsdSceneItem to access the UsdPrim since 
+        // it could be stale. Instead we should get the USDPrim from the Ufe::Path
+        const auto& srcPrimUsd = ufePathToPrim(_ufeSrcPath);
+
         // remove all scene description for the given path and 
         // its subtree in the current UsdEditTarget
         {
-            auto stage = _ufeDstItem->prim().GetStage();
+            auto stage = srcPrimUsd.GetStage();
             UsdEditContext ctx(stage, _parentLayer);
             status = stage->RemovePrim(_usdDstPath);
         }
 
         if (status) {
-            _ufeSrcItem = UsdSceneItem::create(_ufeSrcPath, ufePathToPrim(_ufeSrcPath));
+            _ufeSrcItem = UsdSceneItem::create(_ufeSrcPath, srcPrimUsd);
             sendNotification<Ufe::ObjectReparent>(_ufeSrcItem, _ufeDstPath);
         }
     }

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
@@ -124,20 +124,20 @@ bool UsdUndoInsertChildCommand::insertChildRedo()
     bool status = SdfCopySpec(_childLayer, _usdSrcPath, _parentLayer, _usdDstPath);
     if (status)
     {
-        // we shouldn't rely on UsdSceneItem to access the UsdPrim since 
-        // it could be stale. Instead we should get the USDPrim from the Ufe::Path
-        const auto& desPrimUsd = ufePathToPrim(_ufeDstPath);
-
         // remove all scene description for the given path and 
         // its subtree in the current UsdEditTarget 
         {
-            auto stage = desPrimUsd.GetStage();
+            // we shouldn't rely on UsdSceneItem to access the UsdPrim since 
+            // it could be stale. Instead we should get the USDPrim from the Ufe::Path
+            const auto& usdSrcPrim = ufePathToPrim(_ufeSrcPath);
+
+            auto stage = usdSrcPrim.GetStage();
             UsdEditContext ctx(stage, _childLayer);
             status = stage->RemovePrim(_usdSrcPath);
         }
 
         if (status) {
-            _ufeDstItem = UsdSceneItem::create(_ufeDstPath, desPrimUsd);
+            _ufeDstItem = UsdSceneItem::create(_ufeDstPath, ufePathToPrim(_ufeDstPath));
             sendNotification<Ufe::ObjectReparent>(_ufeDstItem, _ufeSrcPath);
         }
     }
@@ -154,20 +154,21 @@ bool UsdUndoInsertChildCommand::insertChildUndo()
     bool status = SdfCopySpec(_parentLayer, _usdDstPath, _childLayer, _usdSrcPath);
     if (status)
     {
-        // we shouldn't rely on UsdSceneItem to access the UsdPrim since 
-        // it could be stale. Instead we should get the USDPrim from the Ufe::Path
-        const auto& srcPrimUsd = ufePathToPrim(_ufeSrcPath);
 
         // remove all scene description for the given path and 
         // its subtree in the current UsdEditTarget
         {
-            auto stage = srcPrimUsd.GetStage();
+            // we shouldn't rely on UsdSceneItem to access the UsdPrim since 
+            // it could be stale. Instead we should get the USDPrim from the Ufe::Path
+            const auto& usdDstPrim = ufePathToPrim(_ufeDstPath);
+
+            auto stage = usdDstPrim.GetStage();
             UsdEditContext ctx(stage, _parentLayer);
             status = stage->RemovePrim(_usdDstPath);
         }
 
         if (status) {
-            _ufeSrcItem = UsdSceneItem::create(_ufeSrcPath, srcPrimUsd);
+            _ufeSrcItem = UsdSceneItem::create(_ufeSrcPath, ufePathToPrim(_ufeSrcPath));
             sendNotification<Ufe::ObjectReparent>(_ufeSrcItem, _ufeDstPath);
         }
     }

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
@@ -60,7 +60,6 @@ UsdUndoInsertChildCommand::UsdUndoInsertChildCommand(const UsdSceneItem::Ptr& pa
     #else
     : Ufe::UndoableCommand()
     #endif
-    , _ufeSrcItem(child)
     , _ufeDstItem(nullptr)
     , _ufeSrcPath(child->path())
     , _usdSrcPath(child->prim().GetPath())
@@ -154,7 +153,6 @@ bool UsdUndoInsertChildCommand::insertChildUndo()
     bool status = SdfCopySpec(_parentLayer, _usdDstPath, _childLayer, _usdSrcPath);
     if (status)
     {
-
         // remove all scene description for the given path and 
         // its subtree in the current UsdEditTarget
         {
@@ -168,8 +166,8 @@ bool UsdUndoInsertChildCommand::insertChildUndo()
         }
 
         if (status) {
-            _ufeSrcItem = UsdSceneItem::create(_ufeSrcPath, ufePathToPrim(_ufeSrcPath));
-            sendNotification<Ufe::ObjectReparent>(_ufeSrcItem, _ufeDstPath);
+            auto ufeSrcItem = UsdSceneItem::create(_ufeSrcPath, ufePathToPrim(_ufeSrcPath));
+            sendNotification<Ufe::ObjectReparent>(ufeSrcItem, _ufeDstPath);
         }
     }
     else {

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
@@ -73,7 +73,6 @@ private:
     bool insertChildRedo();
     bool insertChildUndo();
 
-    UsdSceneItem::Ptr _ufeSrcItem;
     UsdSceneItem::Ptr _ufeDstItem;
 
     Ufe::Path _ufeSrcPath;


### PR DESCRIPTION
This PR addresses the random undo/redo crash after performing multiple re-parenting operations.
