### PR TITLE
[plugin/al] remove call to UsdImagingGLEngine::InvalidateBuffers()

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -31,7 +31,7 @@ See Pixar's official github page for instructions on how to build USD: https://g
 
 |               |      ![](images/pxr.png)          |        
 |:------------: |:---------------:                  |
-|  CommitID/Tags | release: [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) <br> dev: [5d1771d](https://github.com/PixarAnimationStudios/USD/commit/5d1771d23b935740bcd5bfb985a92a6652e070c0) |
+|  CommitID/Tags | release: [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) <br> dev: [ac8f6d4](https://github.com/PixarAnimationStudios/USD/commit/ac8f6d4be9bc20e7ff6ad98843d93e7a1cefca0b) |
 
 For additional information on building Pixar USD, see the ***Additional Build Instruction*** section below.
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -310,7 +310,6 @@ void ProxyShape::destroyGLImagingEngine()
   if(m_engine)
   {
     triggerEvent("DestroyGLEngine");
-    m_engine->InvalidateBuffers();
     delete m_engine;
     m_engine = nullptr;
   }


### PR DESCRIPTION
This function was a vestige of the legacy Hydra implementation and now no
longer does anything. It was removed in core USD commit https://github.com/PixarAnimationStudios/USD/commit/0c5c150e70c646226b9e6ffbb932c5187600efad.

`InvalidateBuffers()` hasn't done anything (for non-legacy Hydra) since at least USD 19.07, so this change should build against all supported earlier release of core USD as well. It is required for building with the current tip of the dev branch, https://github.com/PixarAnimationStudios/USD/commit/ac8f6d4be9bc20e7ff6ad98843d93e7a1cefca0b.