### PR TITLE
MAYA-106222 - Fix registry errors for preview surface readers and wri…

### DIFF
--- a/lib/usd/pxrUsdPreviewSurface/usdPreviewSurfacePlugin.h
+++ b/lib/usd/pxrUsdPreviewSurface/usdPreviewSurfacePlugin.h
@@ -56,6 +56,12 @@ public:
 
     PXRUSDPREVIEWSURFACE_API
     static MStatus deregisterFragments();
+
+    PXRUSDPREVIEWSURFACE_API
+    static void RegisterPreviewSurfaceReader(const MString& typeName);
+
+    PXRUSDPREVIEWSURFACE_API
+    static void RegisterPreviewSurfaceWriter(const MString& typeName);
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -31,6 +31,8 @@
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/commands/editTargetCommand.h>
 #include <mayaUsd/commands/layerEditorCommand.h>
+#include <mayaUsd/fileio/shaderReaderRegistry.h>
+#include <mayaUsd/fileio/shaderWriterRegistry.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/nodes/proxyShapePlugin.h>
 #include <mayaUsd/nodes/stageData.h>
@@ -84,6 +86,11 @@ template <typename T> void deregisterCommandCheck(MFnPlugin& plugin)
     }
 }
 } // namespace
+
+TF_REGISTRY_FUNCTION(UsdMayaShaderReaderRegistry)
+{ PxrMayaUsdPreviewSurfacePlugin::RegisterPreviewSurfaceReader(MayaUsdPreviewSurface_typeName); };
+TF_REGISTRY_FUNCTION(UsdMayaShaderWriterRegistry)
+{ PxrMayaUsdPreviewSurfacePlugin::RegisterPreviewSurfaceWriter(MayaUsdPreviewSurface_typeName); };
 
 MAYAUSD_PLUGIN_PUBLIC
 MStatus initializePlugin(MObject obj)

--- a/plugin/pxr/maya/plugin/pxrUsdPreviewSurface/CMakeLists.txt
+++ b/plugin/pxr/maya/plugin/pxrUsdPreviewSurface/CMakeLists.txt
@@ -6,6 +6,7 @@ pxr_plugin(${PXR_PACKAGE}
     LIBRARIES
         arch
         basePxrUsdPreviewSurface
+        mayaUsd
         ${MAYA_Foundation_LIBRARY}
         ${MAYA_OpenMaya_LIBRARY}
 

--- a/plugin/pxr/maya/plugin/pxrUsdPreviewSurface/plugin.cpp
+++ b/plugin/pxr/maya/plugin/pxrUsdPreviewSurface/plugin.cpp
@@ -15,6 +15,9 @@
 //
 #include <basePxrUsdPreviewSurface/usdPreviewSurfacePlugin.h>
 
+#include <mayaUsd/fileio/shaderReaderRegistry.h>
+#include <mayaUsd/fileio/shaderWriterRegistry.h>
+
 #include <maya/MFnPlugin.h>
 #include <maya/MString.h>
 
@@ -27,6 +30,11 @@ const MString PxrUsdPreviewSurface_typeName("pxrUsdPreviewSurface");
 const MTypeId PxrUsdPreviewSurface_typeId(0x00126403);
 const MString& PxrUsdPreviewSurface_registrantId = PxrUsdPreviewSurface_typeName;
 }
+
+TF_REGISTRY_FUNCTION(UsdMayaShaderReaderRegistry)
+{ PxrMayaUsdPreviewSurfacePlugin::RegisterPreviewSurfaceReader(PxrUsdPreviewSurface_typeName); };
+TF_REGISTRY_FUNCTION(UsdMayaShaderWriterRegistry)
+{ PxrMayaUsdPreviewSurfacePlugin::RegisterPreviewSurfaceWriter(PxrUsdPreviewSurface_typeName); };
 
 PXRUSDPREVIEWSURFACE_API
 MStatus


### PR DESCRIPTION
…ters

Fixes the registration of the UsdPreviewSurface reader and writer. The registration needs to be done in a Tf registry context in order for the automatic removal of the reader/writer to be correctly done when the plugins are unloaded.
The directly visible impact is that this will fix the following coding error message that appeared with PR 744:
`Coding Error: in AddUnloader at line 301 of C:\mayaUsd\fileio\registryHelper.cpp -- Couldn't add unload function (was this function called from outside a TF_REGISTRY_FUNCTION block?)`