### PR TITLE
use fixturesUtils for pxrUsdMayaGL tests

### DIFF
--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawAndTransform.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawAndTransform.py
@@ -23,6 +23,8 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
+
 
 class testProxyShapeDrawAndTransform(unittest.TestCase):
 
@@ -32,8 +34,11 @@ class testProxyShapeDrawAndTransform(unittest.TestCase):
         # that way too.
         cmds.upAxis(axis='z')
 
+        inputPath = fixturesUtils.setUpClass(__file__,
+            initializeStandalone=False, loadPlugin=False)
+
         cls._testName = 'ProxyShapeDrawAndTransformTest'
-        cls._inputDir = os.path.abspath(cls._testName)
+        cls._inputDir = os.path.join(inputPath, cls._testName)
 
         cls._testDir = os.path.abspath('.')
 

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawColorAccuracy.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawColorAccuracy.py
@@ -21,6 +21,8 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
+
 
 class testProxyShapeDrawColorAccuracy(unittest.TestCase):
 
@@ -30,8 +32,11 @@ class testProxyShapeDrawColorAccuracy(unittest.TestCase):
         # that way too.
         cmds.upAxis(axis='z')
 
+        inputPath = fixturesUtils.setUpClass(__file__,
+            initializeStandalone=False, loadPlugin=False)
+
         cls._testName = 'ProxyShapeDrawColorAccuracyTest'
-        cls._inputDir = os.path.abspath(cls._testName)
+        cls._inputDir = os.path.join(inputPath, cls._testName)
 
         cls._testDir = os.path.abspath('.')
 

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawColors.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawColors.py
@@ -21,6 +21,8 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
+
 
 class testProxyShapeDrawColors(unittest.TestCase):
 
@@ -30,10 +32,11 @@ class testProxyShapeDrawColors(unittest.TestCase):
         # that way too.
         cmds.upAxis(axis='z')
 
-        cmds.loadPlugin('mayaUsdPlugin')
+        inputPath = fixturesUtils.setUpClass(__file__,
+            initializeStandalone=False)
 
         cls._testName = 'ProxyShapeDrawColorsTest'
-        cls._inputDir = os.path.abspath(cls._testName)
+        cls._inputDir = os.path.join(inputPath, cls._testName)
 
         cls._testDir = os.path.abspath('.')
 

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawLighting.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawLighting.py
@@ -21,6 +21,8 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
+
 
 class testProxyShapeDrawLighting(unittest.TestCase):
 
@@ -30,18 +32,21 @@ class testProxyShapeDrawLighting(unittest.TestCase):
         # that way too.
         cmds.upAxis(axis='z')
 
+        inputPath = fixturesUtils.setUpClass(__file__,
+            initializeStandalone=False, loadPlugin=False)
+
         cls._testDir = os.path.abspath('.')
 
-        cls._testRootNodeName = 'ProxyShapeDrawLightingTest'
-        cls._testSceneName = '%s.ma' % cls._testRootNodeName
-        cls._testSceneFullPath = os.path.abspath(
-            os.path.join('ProxyShapeDrawLightingTest', cls._testSceneName))
+        cls._testName = 'ProxyShapeDrawLightingTest'
+        cls._testSceneName = '%s.ma' % cls._testName
+        cls._testSceneFullPath = os.path.join(inputPath, cls._testName,
+            cls._testSceneName)
 
-        cls._nativeNodePathName = '|%s|Native' % cls._testRootNodeName
+        cls._nativeNodePathName = '|%s|Native' % cls._testName
         cls._nativeTorusPathName = '%s|Torus' % cls._nativeNodePathName
         cls._nativePlanePathName = '%s|Plane' % cls._nativeNodePathName
 
-        cls._hydraNodePathName = '|%s|Hydra' % cls._testRootNodeName
+        cls._hydraNodePathName = '|%s|Hydra' % cls._testName
         cls._hydraTorusPathName = '%s|Torus' % cls._hydraNodePathName
         cls._hydraPlanePathName = '%s|Plane' % cls._hydraNodePathName
 

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawPerformance.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawPerformance.py
@@ -26,6 +26,8 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
+
 
 class testProxyShapeDrawPerformance(unittest.TestCase):
 
@@ -35,7 +37,11 @@ class testProxyShapeDrawPerformance(unittest.TestCase):
         # that way too.
         cmds.upAxis(axis='z')
 
-        cls._inputDir = os.path.abspath('ProxyShapeDrawPerformanceTest')
+        inputPath = fixturesUtils.setUpClass(__file__,
+            initializeStandalone=False, loadPlugin=False)
+
+        cls._inputDir = os.path.join(inputPath,
+            'ProxyShapeDrawPerformanceTest')
 
         cls._testDir = os.path.abspath('.')
 

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawPurpose.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawPurpose.py
@@ -21,6 +21,8 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
+
 
 class testProxyShapeDrawPurpose(unittest.TestCase):
 
@@ -29,6 +31,12 @@ class testProxyShapeDrawPurpose(unittest.TestCase):
         # The test USD data is authored Z-up, so make sure Maya is configured
         # that way too.
         cmds.upAxis(axis='z')
+
+        inputPath = fixturesUtils.setUpClass(__file__,
+            initializeStandalone=False, loadPlugin=False)
+
+        cls._testName = 'ProxyShapeDrawPurposeTest'
+        cls._inputDir = os.path.join(inputPath, cls._testName)
 
         cls._testDir = os.path.abspath('.')
 
@@ -72,11 +80,8 @@ class testProxyShapeDrawPurpose(unittest.TestCase):
         Tests drawing USD proxy shapes while changing their purpose-based draw
         attributes.
         """
-        self._testName = 'ProxyShapeDrawPurposeTest'
-
         mayaSceneFile = '%s.ma' % self._testName
-        mayaSceneFullPath = os.path.abspath(
-            os.path.join('ProxyShapeDrawPurposeTest', mayaSceneFile))
+        mayaSceneFullPath = os.path.join(self._inputDir, mayaSceneFile)
         cmds.file(mayaSceneFullPath, open=True, force=True)
 
         # Force an initial draw to complete by switching frames.

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawTimeSampled.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawTimeSampled.py
@@ -21,6 +21,8 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
+
 
 class testProxyShapeDrawTimeSampled(unittest.TestCase):
 
@@ -30,8 +32,11 @@ class testProxyShapeDrawTimeSampled(unittest.TestCase):
         # that way too.
         cmds.upAxis(axis='z')
 
+        inputPath = fixturesUtils.setUpClass(__file__,
+            initializeStandalone=False, loadPlugin=False)
+
         cls._testName = 'ProxyShapeDrawTimeSampledTest'
-        cls._inputDir = os.path.abspath(cls._testName)
+        cls._inputDir = os.path.join(inputPath, cls._testName)
 
         cls._testDir = os.path.abspath('.')
 

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawUsdChangeProcessing.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawUsdChangeProcessing.py
@@ -23,6 +23,8 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
+
 
 class testProxyShapeDrawUsdChangeProcessing(unittest.TestCase):
 
@@ -32,8 +34,11 @@ class testProxyShapeDrawUsdChangeProcessing(unittest.TestCase):
         # that way too.
         cmds.upAxis(axis='z')
 
+        inputPath = fixturesUtils.setUpClass(__file__,
+            initializeStandalone=False, loadPlugin=False)
+
         cls._testName = 'ProxyShapeDrawUsdChangeProcessingTest'
-        cls._inputDir = os.path.abspath(cls._testName)
+        cls._inputDir = os.path.join(inputPath, cls._testName)
 
         cls._testDir = os.path.abspath('.')
 

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawVisibility.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawVisibility.py
@@ -21,6 +21,8 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
+
 
 class testProxyShapeDrawVisibility(unittest.TestCase):
 
@@ -30,8 +32,11 @@ class testProxyShapeDrawVisibility(unittest.TestCase):
         # that way too.
         cmds.upAxis(axis='z')
 
+        inputPath = fixturesUtils.setUpClass(__file__,
+            initializeStandalone=False, loadPlugin=False)
+
         cls._testName = 'ProxyShapeDrawVisibilityTest'
-        cls._inputDir = os.path.abspath(cls._testName)
+        cls._inputDir = os.path.join(inputPath, cls._testName)
 
         cls._testDir = os.path.abspath('.')
 

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDuplicatePerformance.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDuplicatePerformance.py
@@ -26,6 +26,8 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
+
 
 class testProxyShapeDuplicatePerformance(unittest.TestCase):
 
@@ -35,7 +37,11 @@ class testProxyShapeDuplicatePerformance(unittest.TestCase):
         # that way too.
         cmds.upAxis(axis='z')
 
-        cls._inputDir = os.path.abspath('ProxyShapeDuplicatePerformanceTest')
+        inputPath = fixturesUtils.setUpClass(__file__,
+            initializeStandalone=False, loadPlugin=False)
+
+        cls._inputDir = os.path.join(inputPath,
+            'ProxyShapeDuplicatePerformanceTest')
 
         cls._testDir = os.path.abspath('.')
 

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeLiveSurface.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeLiveSurface.py
@@ -30,6 +30,8 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
+
 
 class testProxyShapeLiveSurface(unittest.TestCase):
 
@@ -39,8 +41,11 @@ class testProxyShapeLiveSurface(unittest.TestCase):
         # that way too.
         cmds.upAxis(axis='z')
 
+        inputPath = fixturesUtils.readOnlySetUpClass(__file__,
+            initializeStandalone=False, loadPlugin=False)
+
         cls._testName = 'ProxyShapeLiveSurfaceTest'
-        cls._inputDir = os.path.abspath(cls._testName)
+        cls._inputDir = os.path.join(inputPath, cls._testName)
 
     def setUp(self):
         mayaSceneFile = '%s.ma' % self._testName

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeRendererSceneMessages.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeRendererSceneMessages.py
@@ -23,6 +23,8 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
+
 
 class testProxyShapeRendererSceneMessages(unittest.TestCase):
 
@@ -32,8 +34,11 @@ class testProxyShapeRendererSceneMessages(unittest.TestCase):
         # that way too.
         cmds.upAxis(axis='z')
 
+        inputPath = fixturesUtils.setUpClass(__file__,
+            initializeStandalone=False, loadPlugin=False)
+
         cls._testName = 'ProxyShapeRendererSceneMessagesTest'
-        cls._inputDir = os.path.abspath(cls._testName)
+        cls._inputDir = os.path.join(inputPath, cls._testName)
 
     def setUp(self):
         cmds.file(new=True, force=True)

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeSelectionPerformance.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeSelectionPerformance.py
@@ -36,6 +36,8 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
+
 
 class testProxyShapeSelectionPerformance(unittest.TestCase):
 
@@ -70,7 +72,11 @@ class testProxyShapeSelectionPerformance(unittest.TestCase):
         # that way too.
         cmds.upAxis(axis='z')
 
-        cls._inputDir = os.path.abspath('ProxyShapeSelectionPerformanceTest')
+        inputPath = fixturesUtils.setUpClass(__file__,
+            initializeStandalone=False, loadPlugin=False)
+
+        cls._inputDir = os.path.join(inputPath,
+            'ProxyShapeSelectionPerformanceTest')
 
         cls._testDir = os.path.abspath('.')
 

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testPxrUsdMayaGL.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testPxrUsdMayaGL.py
@@ -21,6 +21,8 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
+
 
 class testPxrUsdMayaGL(unittest.TestCase):
 
@@ -30,10 +32,11 @@ class testPxrUsdMayaGL(unittest.TestCase):
         # that way too.
         cmds.upAxis(axis='z')
 
-        cmds.loadPlugin('mayaUsdPlugin')
+        inputPath = fixturesUtils.readOnlySetUpClass(__file__,
+            initializeStandalone=False)
 
         cls._testName = 'PxrUsdMayaGLTest'
-        cls._inputDir = os.path.abspath(cls._testName)
+        cls._inputDir = os.path.join(inputPath, cls._testName)
 
     def testEmptySceneDraws(self):
         cmds.file(new=True, force=True)

--- a/test/testUtils/fixturesUtils.py
+++ b/test/testUtils/fixturesUtils.py
@@ -15,16 +15,19 @@
 #
 
 from maya import cmds
-from maya import standalone
 
 import os
 import shutil
 
 _exportTranslatorName = "USD Export"
 
-def _setUpClass(modulePathName, loadPlugin):
-    '''Common code for setUpClass() and readOnlySetUpClass()'''
-    standalone.initialize('usd')
+def _setUpClass(modulePathName, initializeStandalone, loadPlugin):
+    '''
+    Common code for setUpClass() and readOnlySetUpClass()
+    '''
+    if initializeStandalone:
+        from maya import standalone
+        standalone.initialize('usd')
 
     if loadPlugin:
         cmds.loadPlugin('mayaUsdPlugin', quiet=True)
@@ -41,17 +44,20 @@ def _setUpClass(modulePathName, loadPlugin):
 def exportTranslatorName():
     return _exportTranslatorName
 
-def setUpClass(modulePathName, suffix='', loadPlugin=True):
-    '''Test class setup.
+def setUpClass(modulePathName, suffix='', initializeStandalone=True,
+        loadPlugin=True):
+    '''
+    Test class setup.
 
     This function:
-    - Initializes Maya standalone use.
+    - (Optionally) Initializes Maya standalone use.
     - Creates (or empties) a test output directory based on the argument.
     - Changes the current working directory to the test output directory.
-    - Loads the plugin
+    - (Optionally) Loads the plugin
     - Returns the original directory from the argument.
     '''
-    (testDir, testFile) = _setUpClass(modulePathName, loadPlugin)
+    (testDir, testFile) = _setUpClass(modulePathName, initializeStandalone,
+        loadPlugin)
     outputName = os.path.splitext(testFile)[0]+suffix+'Output'
 
     outputPath = os.path.join(testDir, outputName)
@@ -64,14 +70,17 @@ def setUpClass(modulePathName, suffix='', loadPlugin=True):
 
     return testDir
 
-def readOnlySetUpClass(modulePathName, loadPlugin=True):
-    '''Test class import setup for tests that do not write to the file system.
+def readOnlySetUpClass(modulePathName, initializeStandalone=True,
+        loadPlugin=True):
+    '''
+    Test class import setup for tests that do not write to the file system.
 
     This function:
-    - Initializes Maya standalone use.
-    - Loads the plugin
+    - (Optionally) Initializes Maya standalone use.
+    - (Optionally) Loads the plugin
     - Returns the original directory from the argument.
     '''
-    (testDir, testFile) = _setUpClass(modulePathName, loadPlugin)
+    (testDir, testFile) = _setUpClass(modulePathName, initializeStandalone,
+        loadPlugin)
 
     return testDir


### PR DESCRIPTION
I realized that the interactive tests I added were all dumping their output into the same directory where the tests live.

This change modifies `fixturesUtils` a bit so that the standalone initialization can be turned off, and then all of the pxrUsdMayaGL tests were updated to use `fixtureUtils`.