### PR TITLE
[CMake] Use PROJECT_SOURCE_DIR for nested projects.

### DIFF
--- a/plugin/adsk/scripts/CMakeLists.txt
+++ b/plugin/adsk/scripts/CMakeLists.txt
@@ -18,7 +18,7 @@ install(FILES ${scripts_src}
 
 set(PREVIEWSURFACE_MAYA_TYPE_NAME "usdPreviewSurface")
 
-configure_file("${CMAKE_SOURCE_DIR}/lib/usd/pxrUsdPreviewSurface/AEusdPreviewSurfaceTemplate.mel"
+configure_file("${PROJECT_SOURCE_DIR}/lib/usd/pxrUsdPreviewSurface/AEusdPreviewSurfaceTemplate.mel"
                "${CMAKE_CURRENT_BINARY_DIR}/AEusdPreviewSurfaceTemplate.mel"
 )
 

--- a/plugin/pxr/maya/plugin/pxrUsdPreviewSurface/CMakeLists.txt
+++ b/plugin/pxr/maya/plugin/pxrUsdPreviewSurface/CMakeLists.txt
@@ -23,7 +23,7 @@ pxr_plugin(${PXR_PACKAGE}
 
 set(PREVIEWSURFACE_MAYA_TYPE_NAME "pxrUsdPreviewSurface")
 
-configure_file("${CMAKE_SOURCE_DIR}/lib/usd/pxrUsdPreviewSurface/AEusdPreviewSurfaceTemplate.mel"
+configure_file("${PROJECT_SOURCE_DIR}/lib/usd/pxrUsdPreviewSurface/AEusdPreviewSurfaceTemplate.mel"
                "${CMAKE_CURRENT_BINARY_DIR}/AEpxrUsdPreviewSurfaceTemplate.mel"
 )
 


### PR DESCRIPTION
Using CMAKE_SOURCE_DIR here breaks when the **maya-usd** project is included in another parent project