### PR TITLE
Fix Python 3 warnings

### DIFF
--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdMayaDiagnosticDelegate.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdMayaDiagnosticDelegate.py
@@ -31,6 +31,12 @@ class testUsdMayaDiagnosticDelegate(unittest.TestCase):
     def setUpClass(cls):
         standalone.initialize('usd')
 
+        # Deprecated since version 3.2: assertRegexpMatches and assertRaisesRegexp
+        # have been renamed to assertRegex() and assertRaisesRegex()
+        if sys.version_info.major < 3 or sys.version_info.minor < 2:
+            cls.assertRegex = cls.assertRegexpMatches
+            cls.assertRaisesRegex = cls.assertRaisesRegexp
+
     @classmethod
     def tearDownClass(cls):
         standalone.uninitialize()

--- a/plugin/pxr/maya/lib/usdMaya/testenv/testUsdMayaDiagnosticDelegate.py
+++ b/plugin/pxr/maya/lib/usdMaya/testenv/testUsdMayaDiagnosticDelegate.py
@@ -96,7 +96,7 @@ class testUsdMayaDiagnosticDelegate(unittest.TestCase):
         log = self._StopRecording()
         self.assertEqual(len(log), 1)
         logText, logCode = log[0]
-        self.assertRegexpMatches(logText,
+        self.assertRegex(logText,
                 "^Python coding error: blah -- Coding Error in "
                 "__main__\.testError at line [0-9]+ of ")
         self.assertEqual(logCode, OM.MCommandMessage.kError)

--- a/test/lib/usd/translators/testUsdExportStripNamespaces.py
+++ b/test/lib/usd/translators/testUsdExportStripNamespaces.py
@@ -17,6 +17,7 @@
 
 
 import os
+import sys
 import unittest
 
 from maya import cmds
@@ -31,6 +32,12 @@ class testUsdExportStripNamespaces(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         fixturesUtils.setUpClass(__file__)
+
+        # Deprecated since version 3.2: assertRegexpMatches and assertRaisesRegexp
+        # have been renamed to assertRegex() and assertRaisesRegex()
+        if sys.version_info.major < 3 or sys.version_info.minor < 2:
+            cls.assertRegex = cls.assertRegexpMatches
+            cls.assertRaisesRegex = cls.assertRaisesRegexp
 
     @classmethod
     def tearDownClass(cls):

--- a/test/lib/usd/translators/testUsdExportStripNamespaces.py
+++ b/test/lib/usd/translators/testUsdExportStripNamespaces.py
@@ -64,14 +64,14 @@ class testUsdExportStripNamespaces(unittest.TestCase):
         #     ".+|cube1 - |foo:cube1.*"
         errorRegexp = 'Maya command error'
 
-        with self.assertRaisesRegexp(RuntimeError, errorRegexp) as cm:
+        with self.assertRaisesRegex(RuntimeError, errorRegexp) as cm:
             cmds.usdExport(mergeTransformAndShape=True,
                            selection=False,
                            stripNamespaces=True,
                            file=usdFilePath,
                            shadingMode='none')
 
-        with self.assertRaisesRegexp(RuntimeError,errorRegexp) as cm:
+        with self.assertRaisesRegex(RuntimeError,errorRegexp) as cm:
             cmds.usdExport(mergeTransformAndShape=False,
                            selection=False,
                            stripNamespaces=True,


### PR DESCRIPTION
Fix Python 3 warnings (also works in Python 2).
See https://docs.python.org/3.3/library/unittest.html#deprecated-aliases