### PR TITLE
MAYA-106755: Support automatic updating of internal references when the path they are referencing has changed.

### DIFF
--- a/lib/mayaUsd/ufe/UsdHierarchy.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchy.cpp
@@ -153,7 +153,7 @@ Ufe::AppendedChild UsdHierarchy::appendChild(const Ufe::SceneItem::Ptr& child)
 #endif
 
 	// First, check if we need to rename the child.
-	std::string childName = uniqueChildName(fItem->prim(), child->nodeName());
+	std::string childName = uniqueChildName(fItem->prim(), child->path().back().string());
 
 	// Set up all paths to perform the reparent.
 	auto childPrim = usdChild->prim();

--- a/lib/mayaUsd/ufe/UsdHierarchy.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchy.cpp
@@ -153,7 +153,7 @@ Ufe::AppendedChild UsdHierarchy::appendChild(const Ufe::SceneItem::Ptr& child)
 #endif
 
 	// First, check if we need to rename the child.
-	std::string childName = uniqueChildName(fItem, child->path());
+	std::string childName = uniqueChildName(fItem->prim(), child->nodeName());
 
 	// Set up all paths to perform the reparent.
 	auto childPrim = usdChild->prim();

--- a/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
@@ -53,7 +53,7 @@ UsdUndoAddNewPrimCommand::UsdUndoAddNewPrimCommand(const UsdSceneItem::Ptr& usdS
         _newUfePath = appendToPath(ufePath, name + '1');
 
         // Ensure the requested name is unique.
-        auto newPrimName = uniqueChildName(usdSceneItem, _newUfePath);
+        auto newPrimName = uniqueChildName(usdSceneItem->prim(), _newUfePath.back().string());
 
         // If the name had to change then we need to update the full ufe path.
         if (name != newPrimName) {

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
@@ -72,7 +72,7 @@ UsdUndoInsertChildCommand::UsdUndoInsertChildCommand(const UsdSceneItem::Ptr& pa
     ufe::applyCommandRestriction(parentPrim, "reparent");
 
     // First, check if we need to rename the child.
-    const auto& childName = uniqueChildName(parent, child->path());
+    const auto childName = uniqueChildName(parent->prim(), child->nodeName());
 
     // Create a new segment if parent and child are in different run-times.
     // parenting a USD node to the proxy shape node implies two different run-times

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
@@ -72,7 +72,7 @@ UsdUndoInsertChildCommand::UsdUndoInsertChildCommand(const UsdSceneItem::Ptr& pa
     ufe::applyCommandRestriction(parentPrim, "reparent");
 
     // First, check if we need to rename the child.
-    const auto childName = uniqueChildName(parent->prim(), child->nodeName());
+    const auto childName = uniqueChildName(parent->prim(), child->path().back().string());
 
     // Create a new segment if parent and child are in different run-times.
     // parenting a USD node to the proxy shape node implies two different run-times

--- a/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
@@ -62,20 +62,13 @@ UsdUndoRenameCommand::UsdUndoRenameCommand(const UsdSceneItem::Ptr& srcItem, con
     , _ufeSrcItem(srcItem)
     , _ufeDstItem(nullptr)
     , _stage(_ufeSrcItem->prim().GetStage())
-    , _newName(newName.string())
 {
     const UsdPrim& prim = _stage->GetPrimAtPath(_ufeSrcItem->prim().GetPath());
 
     ufe::applyCommandRestriction(prim, "rename");
 
     // handle unique name for _newName
-    TfToken::HashSet childrenNames;
-    for (auto child : prim.GetParent().GetChildren()){
-        childrenNames.insert(child.GetName());
-    }
-    if (childrenNames.find(TfToken(_newName)) != childrenNames.end()){
-        _newName = uniqueName(childrenNames, _newName);
-    }
+    _newName = uniqueChildName(prim.GetParent(), newName.string());
 
     // names are not allowed to start to digit numbers
     if(std::isdigit(_newName.at(0))){

--- a/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
@@ -136,6 +136,12 @@ bool UsdUndoRenameCommand::renameRedo()
         _stage->SetDefaultPrim(_ufeDstItem->prim());
     }
 
+    // update internal references
+    status = MayaUsdUtils::updateInternalReferences(prim, _ufeDstItem->prim());
+    if (!status) {
+        return false;
+    }
+
     return true;
 }
 
@@ -172,7 +178,11 @@ bool UsdUndoRenameCommand::renameUndo()
         _stage->SetDefaultPrim(_ufeSrcItem->prim());
     }
 
-    _ufeDstItem = nullptr;
+    // update internal references
+    status = MayaUsdUtils::updateInternalReferences(prim, _ufeSrcItem->prim());
+    if (!status) {
+        return false;
+    }
 
     return true;
 }

--- a/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
@@ -110,15 +110,16 @@ bool UsdUndoRenameCommand::renameRedo()
 
     // 1- open a changeblock to delay sending notifications.
     // 2- update the Internal References paths (if any) first
-    // 3- set the new name 
+    // 3- set the new name
+    // Note: during the changeBlock scope we are still working with old items/paths/prims.
+    // it's only after the scope ends that we start working with new items/paths/prims
     {
         SdfChangeBlock changeBlock;
 
         const UsdPrim& prim = _stage->GetPrimAtPath(_ufeSrcItem->prim().GetPath());
 
-        auto newSceneItem = createSiblingSceneItem(_ufeSrcItem->path(), _newName);
-        auto newUfePath = Ufe::Path(newSceneItem->path().getSegments()[1]);
-        bool status = MayaUsdUtils::updateInternalReferencesPath(prim, SdfPath(newUfePath.string()));
+        auto ufeSiblingPath = _ufeSrcItem->path().sibling(Ufe::PathComponent(_newName));
+        bool status = MayaUsdUtils::updateInternalReferencesPath(prim, SdfPath(ufeSiblingPath.getSegments()[1].string()));
         if (!status) {
             return false;
         }
@@ -152,15 +153,16 @@ bool UsdUndoRenameCommand::renameUndo()
 
     // 1- open a changeblock to delay sending notifications.
     // 2- update the Internal References paths (if any) first
-    // 3- set the new name 
+    // 3- set the new name
+    // Note: during the changeBlock scope we are still working with old items/paths/prims.
+    // it's only after the scope ends that we start working with new items/paths/prims
     {
         SdfChangeBlock changeBlock;
 
         const UsdPrim& prim = _stage->GetPrimAtPath(_ufeDstItem->prim().GetPath());
 
-        auto newSceneItem = createSiblingSceneItem(_ufeSrcItem->path(), _ufeSrcItem->prim().GetName());
-        auto newUfePath = Ufe::Path(newSceneItem->path().getSegments()[1]);
-        bool status = MayaUsdUtils::updateInternalReferencesPath(prim, SdfPath(newUfePath.string()));
+        auto ufeSiblingPath = _ufeSrcItem->path().sibling(Ufe::PathComponent(_ufeSrcItem->prim().GetName()));
+        bool status = MayaUsdUtils::updateInternalReferencesPath(prim, SdfPath(ufeSiblingPath.getSegments()[1].string()));
         if (!status) {
             return false;
         }

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -130,9 +130,9 @@ std::string uniqueName(const TfToken::HashSet& existingNames, std::string srcNam
 	return dstName;
 }
 
-std::string uniqueChildName(const UsdSceneItem::Ptr& usdParent, const Ufe::Path& childPath)
+std::string uniqueChildName(const UsdPrim& usdParent, const std::string& name)
 {
-	if (!usdParent) return std::string();
+	if (!usdParent.IsValid()) return std::string();
 
 	TfToken::HashSet childrenNames;
 
@@ -147,11 +147,11 @@ std::string uniqueChildName(const UsdSceneItem::Ptr& usdParent, const Ufe::Path&
 	//		 use loaded either in _computeDisplayPredicate().
 	//
 	// Note: our UsdHierarchy uses instance proxies, so we also use them here.
-	for (auto child : usdParent->prim().GetFilteredChildren(UsdTraverseInstanceProxies(UsdPrimIsDefined && !UsdPrimIsAbstract)))
+	for (auto child : usdParent.GetFilteredChildren(UsdTraverseInstanceProxies(UsdPrimIsDefined && !UsdPrimIsAbstract)))
 	{
 		childrenNames.insert(child.GetName());
 	}
-	std::string childName = childPath.back().string();
+	std::string childName{name};
 	if (childrenNames.find(TfToken(childName)) != childrenNames.end())
 	{
 		childName = uniqueName(childrenNames, childName);

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -63,7 +63,7 @@ std::string uniqueName(const TfToken::HashSet& existingNames, std::string srcNam
 
 //! Return a unique child name.
 MAYAUSD_CORE_PUBLIC
-std::string uniqueChildName(const UsdSceneItem::Ptr& parent, const Ufe::Path& childPath);
+std::string uniqueChildName(const UsdPrim& parent, const std::string& name);
 
 //! Return if a Maya node type is derived from the gateway node type.
 MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/ufe/private/Utils.cpp
+++ b/lib/mayaUsd/ufe/private/Utils.cpp
@@ -25,8 +25,6 @@
 
 #include <mayaUsdUtils/util.h>
 
-#include <iostream>
-
 PXR_NAMESPACE_USING_DIRECTIVE
 
 MAYAUSD_NS_DEF {

--- a/lib/usd/utils/ForwardDeclares.h
+++ b/lib/usd/utils/ForwardDeclares.h
@@ -32,6 +32,7 @@ class UsdGeomCamera;
 class UsdLuxDistantLight;
 class UsdPrimCompositionQuery;
 class UsdPrimCompositionQueryArc;
+class UsdReferences;
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/lib/usd/utils/util.cpp
+++ b/lib/usd/utils/util.cpp
@@ -93,7 +93,7 @@ namespace
         // the Replace() method to replace them with updated SdfReference items.
         for (const SdfReference &ref : listProxy)
         {
-            if (ref.IsInternal())
+            if (MayaUsdUtils::isInternalReference(ref))
             {
                 SdfPath finalPath;
                 if(oldPrim.GetPath() == ref.GetPrimPath()) {
@@ -138,29 +138,11 @@ defPrimSpecLayer(const UsdPrim& prim)
     return defLayer;
 }
 
-
 SdfPrimSpecHandle 
 getPrimSpecAtEditTarget(const UsdPrim& prim)
 {
     auto stage = prim.GetStage();
     return stage->GetEditTarget().GetPrimSpecForScenePath(prim.GetPath());
-}
-
-bool
-isInternalReference(const SdfPrimSpecHandle& primSpec)
-{
-    bool isInternalRef{false};
-
-    for (const SdfReference& ref : primSpec->GetReferenceList().GetAddedOrExplicitItems()) {
-        // GetAssetPath returns the asset path to the root layer of the referenced layer
-        // this will be empty in the case of an internal reference.
-        if (ref.GetAssetPath().empty()) {
-            isInternalRef = true;
-            break;
-        }
-    }
-
-    return isInternalRef;
 }
 
 void
@@ -205,6 +187,16 @@ updateInternalReferencesPath(const UsdPrim& oldPrim, const SdfPath& newPath)
     }
 
     return true;
+}
+
+bool
+isInternalReference(const SdfReference& ref)
+{
+    #if USD_VERSION_NUM >= 2008
+    return ref.IsInternal();
+    #else
+    return ref.GetAssetPath().empty();
+    #endif
 }
 
 } // MayaUsdUtils

--- a/lib/usd/utils/util.cpp
+++ b/lib/usd/utils/util.cpp
@@ -77,21 +77,21 @@ namespace
                                const SdfReferencesProxy& referencesList,
                                SdfListOpType op)
     {
-        // set the itemVector based on the SdfListOpType
-        auto itemVector = referencesList.GetAppendedItems();
+        // set the listProxy based on the SdfListOpType
+        SdfReferencesProxy::ListProxy listProxy = referencesList.GetAppendedItems();
         if (op == SdfListOpTypePrepended) {
-            itemVector = referencesList.GetPrependedItems();
+            listProxy = referencesList.GetPrependedItems();
         } else if (op == SdfListOpTypeOrdered) {
-            itemVector = referencesList.GetOrderedItems();
+            listProxy = referencesList.GetOrderedItems();
         } else if (op == SdfListOpTypeAdded) {
-            itemVector = referencesList.GetAddedItems();
+            listProxy = referencesList.GetAddedItems();
         } else if (op == SdfListOpTypeDeleted) {
-            itemVector = referencesList.GetDeletedItems();
+            listProxy = referencesList.GetDeletedItems();
         }
 
         // fetching the existing SdfReference items and using 
         // the Replace() method to replace them with updated SdfReference items.
-        for (const SdfReference &ref : itemVector)
+        for (const SdfReference &ref : listProxy)
         {
             if (ref.IsInternal())
             {
@@ -110,7 +110,7 @@ namespace
                 // replace the old reference with new one
                 SdfReference newRef;
                 newRef.SetPrimPath(finalPath);
-                itemVector.Replace(ref, newRef);
+                listProxy.Replace(ref, newRef);
             }
         }
     }

--- a/lib/usd/utils/util.h
+++ b/lib/usd/utils/util.h
@@ -33,10 +33,6 @@ namespace MayaUsdUtils {
     MAYA_USD_UTILS_PUBLIC
     SdfPrimSpecHandle getPrimSpecAtEditTarget(const UsdPrim& prim);
 
-    //! Returns true if the prim spec has an internal reference.
-    MAYA_USD_UTILS_PUBLIC
-    bool isInternalReference(const SdfPrimSpecHandle& primSpec);
-
     //! Convenience function for printing the list of queried composition arcs in order. 
     MAYA_USD_UTILS_PUBLIC
     void printCompositionQuery(const UsdPrim& prim, std::ostream& os);
@@ -45,6 +41,10 @@ namespace MayaUsdUtils {
     //  the path that it has referenced is changed.
     MAYA_USD_UTILS_PUBLIC
     bool updateInternalReferencesPath(const UsdPrim& oldPrim, const SdfPath& newPath);
+
+    //! Returns true if reference is internal.
+    MAYA_USD_UTILS_PUBLIC
+    bool isInternalReference(const SdfReference&);
 
 } // namespace MayaUsdUtils
 

--- a/lib/usd/utils/util.h
+++ b/lib/usd/utils/util.h
@@ -42,10 +42,11 @@ namespace MayaUsdUtils {
     void printCompositionQuery(const UsdPrim& prim, std::ostream& os);
 
     //! This function automatically updates the internal refrences path if 
-    //  the path that it references to has changed.
+    //  the path that it has referenced is changed.
     MAYA_USD_UTILS_PUBLIC
-    bool updateInternalReferences(const UsdPrim& oldPrim, const UsdPrim& newPrim);
+    bool updateInternalReferencesPath(const UsdPrim& oldPrim, const SdfPath& newPath);
 
 } // namespace MayaUsdUtils
 
 #endif // MAYAUSDUTILS_UTIL_H
+

--- a/lib/usd/utils/util.h
+++ b/lib/usd/utils/util.h
@@ -27,19 +27,24 @@ namespace MayaUsdUtils {
 
     //! Return the highest-priority layer where the prim has a def primSpec.
     MAYA_USD_UTILS_PUBLIC
-    SdfLayerHandle defPrimSpecLayer(const UsdPrim&);
+    SdfLayerHandle defPrimSpecLayer(const UsdPrim& prim);
 
     //! Return a PrimSpec for the argument prim in the layer containing the stage's current edit target.
     MAYA_USD_UTILS_PUBLIC
-    SdfPrimSpecHandle getPrimSpecAtEditTarget(const UsdPrim&);
+    SdfPrimSpecHandle getPrimSpecAtEditTarget(const UsdPrim& prim);
 
     //! Returns true if the prim spec has an internal reference.
     MAYA_USD_UTILS_PUBLIC
-    bool isInternalReference(const SdfPrimSpecHandle&);
+    bool isInternalReference(const SdfPrimSpecHandle& primSpec);
 
     //! Convenience function for printing the list of queried composition arcs in order. 
     MAYA_USD_UTILS_PUBLIC
-    void printCompositionQuery(const UsdPrim&, std::ostream&);
+    void printCompositionQuery(const UsdPrim& prim, std::ostream& os);
+
+    //! This function automatically updates the internal refrences path if 
+    //  the path that it references to has changed.
+    MAYA_USD_UTILS_PUBLIC
+    bool updateInternalReferences(const UsdPrim& oldPrim, const UsdPrim& newPrim);
 
 } // namespace MayaUsdUtils
 


### PR DESCRIPTION
### Description
The goal of this PR is to allow clients to be able to rename prims that are **internally referenced** by other prims and not worry about breaking them. The same workflow can also later be applied to other composition arcs ( e.g inherits or specializes ).