### PR TITLE
[CMake/CTest] Use -pythonver argument for testsuite.

### DIFF
--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -122,7 +122,7 @@ compileMode = \\\"exec\\\"\\\; \
 globals = {\\\"__file__\\\": file, \\\"__name__\\\": \\\"__main__\\\"}\\\; \
 exec(compile(open(file, openMode).read(), file, compileMode), globals)\
 \")")
-            set(COMMAND_CALL ${MAYA_EXECUTABLE} -c ${MEL_PY_EXEC_COMMAND})
+            set(COMMAND_CALL ${MAYA_EXECUTABLE} -pythonver ${Python_VERSION_MAJOR} -c ${MEL_PY_EXEC_COMMAND})
         else()
             set(COMMAND_CALL ${MAYA_PY_EXECUTABLE} ${PREFIX_PYTHON_SCRIPT})
         endif()


### PR DESCRIPTION
We're running into issues where running tests on the python-2 builds are invoking the python-3 version of Maya.