### PR TITLE
fix Python version handling for interactive tests

### DIFF
--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -253,9 +253,12 @@ if(MAYA_INCLUDE_DIRS AND EXISTS "${MAYA_INCLUDE_DIR}/maya/MTypes.h")
     endif()
 endif()
 
-# swtich between mayapy and mayapy2
+# Determine the Python version and switch between mayapy and mayapy2.
 set(MAYAPY_EXE mayapy)
+set(MAYA_PY_VERSION 2)
 if(${MAYA_APP_VERSION} STRGREATER_EQUAL "2021")
+    set(MAYA_PY_VERSION 3)
+
     # check to see if we have a mayapy2 executable
     find_program(MAYA_PY_EXECUTABLE2
             mayapy2
@@ -271,6 +274,7 @@ if(${MAYA_APP_VERSION} STRGREATER_EQUAL "2021")
     )
     if(NOT BUILD_WITH_PYTHON_3 AND MAYA_PY_EXECUTABLE2)
         set(MAYAPY_EXE mayapy2)
+        set(MAYA_PY_VERSION 2)
     endif()
 endif()
 
@@ -295,6 +299,7 @@ find_package_handle_standard_args(Maya
     REQUIRED_VARS
         MAYA_EXECUTABLE
         MAYA_PY_EXECUTABLE
+        MAYA_PY_VERSION
         MAYA_INCLUDE_DIRS
         MAYA_LIBRARIES
         MAYA_API_VERSION

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -302,11 +302,14 @@ finally:
             "${pathvar}=${MAYAUSD_VARNAME_${pathvar}}")
     endforeach()
 
+    # Set the Python major version in MAYA_PYTHON_VERSION. Maya 2020 and
+    # earlier that are Python 2 only will simply ignore it.
     # without "MAYA_NO_STANDALONE_ATEXIT=1", standalone.uninitialize() will
     # set exitcode to 0
     # MAYA_DISABLE_CIP=1  Avoid fatal crash on start-up.
     # MAYA_DISABLE_CER=1  Customer Error Reporting.
     set_property(TEST "${test_name}" APPEND PROPERTY ENVIRONMENT
+        "MAYA_PYTHON_VERSION=${MAYA_PY_VERSION}"
         "MAYA_NO_STANDALONE_ATEXIT=1"
         "MAYA_DISABLE_CIP=1"
         "MAYA_DISABLE_CER=1")


### PR DESCRIPTION
This should address the issue raised in #805. Since the interactive tests launch the `maya` binary rather than `mayapy` or `mayapy2`, they were always running using Python 3 in Maya 2021/preview releases.

In addition to setting `MAYA_PY_EXECUTABLE` to either `mayapy` or `mayapy2` in `FindMaya.cmake`, we now also set `MAYA_PY_VERSION` to either `2` or `3` as appropriate. We then use that CMake variable to set `MAYA_PYTHON_VERSION` when setting up the environment for running the tests. Maya 2020 and earlier will simply ignore that environment variable.

I've verified that the interactive tests pass running Maya PR 119 and Python 2 on Linux. I'm not actually setup to build against Python 3 yet, so if someone is able to verify that configuration for me, that would be great. These tests get skipped by the preflight builds, so any issues likely would not show up there.