### PR TITLE
Necessary fixes required before we can apply clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -25,6 +25,7 @@ IncludeBlocks: Regroup
 IncludeCategories:
 
   # Desired final ordering:
+  # 0. Glew must be included before any other GL header
   # 1. Related header
   # 2. All private headers
   # 3. All public headers from this repository (maya-usd)
@@ -35,6 +36,11 @@ IncludeCategories:
   # 8. C system headers
   # 9. Conditional includes
 
+  # 0. Glew must be included before any other GL header
+  # Negative priority puts it above the default IncludeIsMainRegex
+  - Regex:           '<pxr/imaging/glf/glew.h>'
+    Priority:        -1
+  
   # 1. Related header
   #    Handled  by the default IncludeIsMainRegex regex, and auto-assigned
   #    Priority 0

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportTranslator.h
@@ -18,6 +18,7 @@
 #include <AL/maya/utils/FileTranslatorBase.h>
 #include <AL/maya/utils/PluginTranslatorOptions.h>
 #include <AL/usdmaya/Api.h>
+#include <AL/usdmaya/fileio/ExportParams.h>
 
 namespace AL {
 namespace usdmaya {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.h
@@ -28,6 +28,8 @@ namespace AL {
 namespace usdmaya {
 namespace nodes {
 
+class ProxyShape;
+
 //----------------------------------------------------------------------------------------------------------------------
 /// \brief  This class provides the draw override for the USD proxy shape node.
 /// \ingroup nodes

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Scope.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Scope.h
@@ -15,7 +15,9 @@
 //
 #pragma once
 
+#include "AL/maya/utils/MayaHelperMacros.h"
 #include "AL/maya/utils/NodeHelper.h"
+#include "AL/usdmaya/TypeIDs.h"
 
 #include <maya/MObjectHandle.h>
 #include <maya/MPxTransform.h>

--- a/plugin/al/translators/Mesh.h
+++ b/plugin/al/translators/Mesh.h
@@ -24,47 +24,46 @@ class UsdGeomMesh;
 
 PXR_NAMESPACE_CLOSE_SCOPE
 
-namespace AL {
-namespace usdmaya {
-namespace fileio {
-namespace translators {
+namespace AL{
+namespace usdmaya{
+namespace fileio{
+namespace translators{
 
 //----------------------------------------------------------------------------------------------------------------------
 /// \brief Class to translate a mesh in and out of maya.
 //----------------------------------------------------------------------------------------------------------------------
-class Mesh : public TranslatorBase {
+class Mesh : public TranslatorBase
+{
 public:
-    AL_USDMAYA_DECLARE_TRANSLATOR(Mesh);
+  AL_USDMAYA_DECLARE_TRANSLATOR(Mesh);
+private:
+  MStatus initialize() override;
+  MStatus import(const UsdPrim& prim, MObject& parent, MObject& createdObj) override;
+  UsdPrim exportObject(UsdStageRefPtr stage, MDagPath dagPath, const SdfPath& usdPath,
+                       const ExporterParams& params) override;
+  MStatus tearDown(const SdfPath& path) override;
+  MStatus update(const UsdPrim& path) override;
+  MStatus preTearDown(UsdPrim& prim) override;
+
+  bool supportsUpdate() const override
+    { return false; } // Turned off supportsUpdate to get tearDown working correctly
+  bool importableByDefault() const override
+    { return false; }
+
+  ExportFlag canExport(const MObject& obj) override
+    { return obj.hasFn(MFn::kMesh) ? ExportFlag::kFallbackSupport : ExportFlag::kNotSupported; }
+  bool canBeOverridden() override
+    { return true; }
 
 private:
-    MStatus initialize() override;
-    MStatus import(const UsdPrim& prim, MObject& parent, MObject& createdObj) override;
-    UsdPrim exportObject(
-        UsdStageRefPtr        stage,
-        MDagPath              dagPath,
-        const SdfPath&        usdPath,
-        const ExporterParams& params) override;
-    MStatus tearDown(const SdfPath& path) override;
-    MStatus update(const UsdPrim& path) override;
-    MStatus preTearDown(UsdPrim& prim) override;
+  enum WriteOptions
+  {
+    kPerformDiff = 1 << 0,
+    kDynamicAttributes = 1 << 1
+  };
+  void writeEdits(MDagPath& dagPath, PXR_NS::UsdGeomMesh& geomPrim, uint32_t options = kDynamicAttributes);
+  static MObject m_visible;
 
-    bool supportsUpdate() const override
-    {
-        return false;
-    } // Turned off supportsUpdate to get tearDown working correctly
-    bool importableByDefault() const override { return false; }
-
-    ExportFlag canExport(const MObject& obj) override
-    {
-        return obj.hasFn(MFn::kMesh) ? ExportFlag::kFallbackSupport : ExportFlag::kNotSupported;
-    }
-    bool canBeOverridden() override { return true; }
-
-private:
-    enum WriteOptions { kPerformDiff = 1 << 0, kDynamicAttributes = 1 << 1 };
-    void
-                   writeEdits(MDagPath& dagPath, PXR_NS::UsdGeomMesh& geomPrim, uint32_t options = kDynamicAttributes);
-    static MObject m_visible;
 };
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -73,3 +72,4 @@ private:
 } // namespace usdmaya
 } // namespace AL
 //----------------------------------------------------------------------------------------------------------------------
+

--- a/plugin/al/translators/Mesh.h
+++ b/plugin/al/translators/Mesh.h
@@ -17,47 +17,54 @@
 #pragma once
 #include "AL/usdmaya/fileio/translators/TranslatorBase.h"
 
+PXR_NAMESPACE_OPEN_SCOPE
 
-namespace AL{
-namespace usdmaya{
-namespace fileio{
-namespace translators{
+// forward declare usd types
+class UsdGeomMesh;
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+namespace AL {
+namespace usdmaya {
+namespace fileio {
+namespace translators {
 
 //----------------------------------------------------------------------------------------------------------------------
 /// \brief Class to translate a mesh in and out of maya.
 //----------------------------------------------------------------------------------------------------------------------
-class Mesh : public TranslatorBase
-{
+class Mesh : public TranslatorBase {
 public:
-  AL_USDMAYA_DECLARE_TRANSLATOR(Mesh);
-private:
-  MStatus initialize() override;
-  MStatus import(const UsdPrim& prim, MObject& parent, MObject& createdObj) override;
-  UsdPrim exportObject(UsdStageRefPtr stage, MDagPath dagPath, const SdfPath& usdPath,
-                       const ExporterParams& params) override;
-  MStatus tearDown(const SdfPath& path) override;
-  MStatus update(const UsdPrim& path) override;
-  MStatus preTearDown(UsdPrim& prim) override;
-
-  bool supportsUpdate() const override
-    { return false; } // Turned off supportsUpdate to get tearDown working correctly
-  bool importableByDefault() const override
-    { return false; }
-
-  ExportFlag canExport(const MObject& obj) override
-    { return obj.hasFn(MFn::kMesh) ? ExportFlag::kFallbackSupport : ExportFlag::kNotSupported; }
-  bool canBeOverridden() override
-    { return true; }
+    AL_USDMAYA_DECLARE_TRANSLATOR(Mesh);
 
 private:
-  enum WriteOptions
-  {
-    kPerformDiff = 1 << 0,
-    kDynamicAttributes = 1 << 1
-  };
-  void writeEdits(MDagPath& dagPath, UsdGeomMesh& geomPrim, uint32_t options = kDynamicAttributes);
-  static MObject m_visible;
+    MStatus initialize() override;
+    MStatus import(const UsdPrim& prim, MObject& parent, MObject& createdObj) override;
+    UsdPrim exportObject(
+        UsdStageRefPtr        stage,
+        MDagPath              dagPath,
+        const SdfPath&        usdPath,
+        const ExporterParams& params) override;
+    MStatus tearDown(const SdfPath& path) override;
+    MStatus update(const UsdPrim& path) override;
+    MStatus preTearDown(UsdPrim& prim) override;
 
+    bool supportsUpdate() const override
+    {
+        return false;
+    } // Turned off supportsUpdate to get tearDown working correctly
+    bool importableByDefault() const override { return false; }
+
+    ExportFlag canExport(const MObject& obj) override
+    {
+        return obj.hasFn(MFn::kMesh) ? ExportFlag::kFallbackSupport : ExportFlag::kNotSupported;
+    }
+    bool canBeOverridden() override { return true; }
+
+private:
+    enum WriteOptions { kPerformDiff = 1 << 0, kDynamicAttributes = 1 << 1 };
+    void
+                   writeEdits(MDagPath& dagPath, PXR_NS::UsdGeomMesh& geomPrim, uint32_t options = kDynamicAttributes);
+    static MObject m_visible;
 };
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -66,4 +73,3 @@ private:
 } // namespace usdmaya
 } // namespace AL
 //----------------------------------------------------------------------------------------------------------------------
-

--- a/plugin/al/translators/NurbsCurve.h
+++ b/plugin/al/translators/NurbsCurve.h
@@ -17,6 +17,13 @@
 #pragma once
 #include "AL/usdmaya/fileio/translators/TranslatorBase.h"
 
+PXR_NAMESPACE_OPEN_SCOPE
+
+// forward declare usd types
+class UsdGeomNurbsCurves;
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
 namespace AL {
 namespace usdmaya {
 namespace fileio {
@@ -49,7 +56,7 @@ private:
     { return true; }
 
 private:
-  void writeEdits(UsdGeomNurbsCurves& nurbsCurvesPrim, MFnNurbsCurve& fnCurve, bool writeAll);
+  void writeEdits(PXR_NS::UsdGeomNurbsCurves& nurbsCurvesPrim, MFnNurbsCurve& fnCurve, bool writeAll);
 
   static MObject m_visible;
 };


### PR DESCRIPTION
Draft #690 applied clang-format for the entire repository. What we found out was that we no longer can build maya-usd. This PR makes necessary fixes to address it.