### PR TITLE
remove unused hitMode field from HdxPickTaskContextParams

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -31,7 +31,7 @@ See Pixar's official github page for instructions on how to build USD: https://g
 
 |               |      ![](images/pxr.png)          |        
 |:------------: |:---------------:                  |
-|  CommitID/Tags | release: [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) <br> dev: [533030f](https://github.com/PixarAnimationStudios/USD/commit/533030f94bab9e4b2df5e8896b867b3379bfeafc) |
+|  CommitID/Tags | release: [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) <br> dev: [66f59e9](https://github.com/PixarAnimationStudios/USD/commit/66f59e903f9b454b59ecdf514d3c61d59f5bde10) |
 
 For additional information on building Pixar USD, see the ***Additional Build Instruction*** section below.
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp
@@ -70,7 +70,6 @@ bool Engine::TestIntersectionBatch(
 
   HdxPickTaskContextParams pickParams;
   pickParams.resolution = GfVec2i(pickResolution, pickResolution);
-  pickParams.hitMode = HdxPickTokens->hitAll;
   pickParams.resolveMode = HdxPickTokens->resolveUnique;
   pickParams.viewMatrix = worldToLocalSpace * viewMatrix;
   pickParams.projectionMatrix = projectionMatrix;


### PR DESCRIPTION
This parameter was not actually being used by Hydra, so it should be fully compatible with older releases of USD. This change is *required* to build against the current tip of core USD dev branch.

This change corresponds to core USD commit https://github.com/PixarAnimationStudios/USD/commit/722bbab50b900ea2c1f9a75e975564cd16fb06c4.