### PR TITLE
MAYA-105537 Add CPV support and curveBasis support for basiscurves complexity level 1

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -36,11 +36,9 @@
 #include "render_delegate.h"
 #include "tokens.h"
 
-// MRenderItem supports primitive type switch on these Maya versions.
-#if ((MAYA_API_VERSION >= 20200100) || \
-    ((MAYA_API_VERSION >= 20190300) && (MAYA_API_VERSION < 20200000)) || \
-    ((MAYA_API_VERSION >= 20180700) && (MAYA_API_VERSION < 20190000)))
-#define MAYA_ALLOW_PRIMITIVE_TYPE_SWITCH
+// Complete tessellation shader support is avaiable for basisCurves complexity levels
+#if MAYA_API_VERSION >= 20210000
+#define HDVP2_ENABLE_BASISCURVES_TESSELLATION
 #endif
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -702,7 +700,7 @@ HdVP2BasisCurves::_UpdateDrawItem(
     const TfToken wrap = topology.GetCurveWrap();
     const TfToken basis = topology.GetCurveBasis();
 
-#if defined(MAYA_ALLOW_PRIMITIVE_TYPE_SWITCH)
+#if defined(HDVP2_ENABLE_BASISCURVES_TESSELLATION)
     const int refineLevel = _curvesSharedData._displayStyle.refineLevel;
 #else
     const int refineLevel = 0;
@@ -1311,7 +1309,7 @@ HdVP2BasisCurves::_UpdateDrawItem(
             renderItem->enable(*stateToCommit._enabled);
         }
 
-#if defined(MAYA_ALLOW_PRIMITIVE_TYPE_SWITCH)
+#if defined(HDVP2_ENABLE_BASISCURVES_TESSELLATION)
         // If the primitive type and stride are changed, then update them.
         if (stateToCommit._primitiveType != nullptr &&
             stateToCommit._primitiveStride != nullptr) {

--- a/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
@@ -353,7 +353,7 @@ namespace
         MShaderMap              _3dSolidShaders;
 
         //!< Fallback shaders with CPV support
-        MHWRender::MShaderInstance* _fallbackCPVShaders[FallbackShaderTypeCount];
+        MHWRender::MShaderInstance* _fallbackCPVShaders[FallbackShaderTypeCount] { nullptr };
 
         MHWRender::MShaderInstance* _3dFatPointShader { nullptr }; //!< 3d shader for points
         MHWRender::MShaderInstance* _3dCPVSolidShader { nullptr }; //!< 3d CPV solid-color shader

--- a/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
@@ -73,24 +73,62 @@ namespace
     const MString _diffuseColorParameterName = "diffuseColor";    //!< Shader parameter name
     const MString _solidColorParameterName   = "solidColor";      //!< Shader parameter name
     const MString _pointSizeParameterName    = "pointSize";       //!< Shader parameter name
+    const MString _curveBasisParameterName   = "curveBasis";      //!< Shader parameter name
     const MString _structOutputName          = "outSurfaceFinal"; //!< Output struct name of the fallback shader
 
     //! Enum class for fallback shader types
-    enum class FallbackShaderType
-    {
+    enum class FallbackShaderType {
         kCommon = 0,
         kBasisCurvesLinear,
-        kBasisCurvesCubic,
+        kBasisCurvesCubicBezier,
+        kBasisCurvesCubicBSpline,
+        kBasisCurvesCubicCatmullRom,
         kCount
     };
 
-    //! Array of shader fragment names indexed by FallbackShaderType
-    const MString _fallbackShaderNames[] =
+    //! Total number of fallback shader types
+    constexpr size_t FallbackShaderTypeCount = static_cast<size_t>(FallbackShaderType::kCount);
+
+    //! Array of constant-color shader fragment names indexed by FallbackShaderType
+    const MString _fallbackShaderNames[] = { "FallbackShader",
+                                             "BasisCurvesLinearFallbackShader",
+                                             "BasisCurvesCubicFallbackShader",
+                                             "BasisCurvesCubicFallbackShader",
+                                             "BasisCurvesCubicFallbackShader" };
+
+    //! Array of varying-color shader fragment names indexed by FallbackShaderType
+    const MString _cpvFallbackShaderNames[] = { "FallbackCPVShader",
+                                                "BasisCurvesLinearCPVShader",
+                                                "BasisCurvesCubicCPVShader",
+                                                "BasisCurvesCubicCPVShader",
+                                                "BasisCurvesCubicCPVShader" };
+
+    //! "curveBasis" parameter values for three different cubic curves
+    const std::unordered_map<FallbackShaderType, int> _curveBasisParameterValueMapping
+        = { { FallbackShaderType::kBasisCurvesCubicBezier, 0 },
+            { FallbackShaderType::kBasisCurvesCubicBSpline, 1 },
+            { FallbackShaderType::kBasisCurvesCubicCatmullRom, 2 } };
+
+    //! Get the shader type needed by the given curveType and curveBasis
+    FallbackShaderType
+    GetBasisCurvesShaderType(const TfToken& curveType, const TfToken& curveBasis)
     {
-        "FallbackShader",
-        "BasisCurvesLinearFallbackShader",
-        "BasisCurvesCubicFallbackShader"
-    };
+        FallbackShaderType type = FallbackShaderType::kCount;
+
+        if (curveType == HdTokens->linear) {
+            type = FallbackShaderType::kBasisCurvesLinear;
+        } else if (curveType == HdTokens->cubic) {
+            if (curveBasis == HdTokens->bezier) {
+                type = FallbackShaderType::kBasisCurvesCubicBezier;
+            } else if (curveBasis == HdTokens->bSpline) {
+                type = FallbackShaderType::kBasisCurvesCubicBSpline;
+            } else if (curveBasis == HdTokens->catmullRom) {
+                type = FallbackShaderType::kBasisCurvesCubicCatmullRom;
+            }
+        }
+
+        return type;
+    }
 
     /*! \brief  Color hash helper class, used by shader registry
     */
@@ -136,11 +174,6 @@ namespace
             if (!TF_VERIFY(shaderMgr))
                 return;
 
-            _fallbackCPVShader = shaderMgr->getFragmentShader(
-                "FallbackCPVShader", _structOutputName, true);
-
-            TF_VERIFY(_fallbackCPVShader);
-
             _3dCPVSolidShader = shaderMgr->getStockShader(
                 MHWRender::MShaderManager::k3dCPVSolidShader);
 
@@ -157,13 +190,33 @@ namespace
                 _3dFatPointShader->setParameter(_pointSizeParameterName, size);
             }
 
+            for (size_t i = 0; i < FallbackShaderTypeCount; i++) {
+                MHWRender::MShaderInstance* shader = shaderMgr->getFragmentShader(
+                    _cpvFallbackShaderNames[i], _structOutputName, true);
+
+                if (TF_VERIFY(shader)) {
+                    FallbackShaderType type = static_cast<FallbackShaderType>(i);
+                    const auto it = _curveBasisParameterValueMapping.find(type);
+                    if (it != _curveBasisParameterValueMapping.end()) {
+                        shader->setParameter(_curveBasisParameterName, it->second);
+                    }
+                }
+
+                _fallbackCPVShaders[i] = shader;
+            }
+
             _isInitialized = true;
         }
 
         /*! \brief  Returns a fallback CPV shader instance when no material is bound.
         */
-        MHWRender::MShaderInstance* GetFallbackCPVShader() const {
-            return _fallbackCPVShader;
+        MHWRender::MShaderInstance* GetFallbackCPVShader(FallbackShaderType type) const {
+            if (type >= FallbackShaderType::kCount) {
+                return nullptr;
+            }
+
+            const size_t index = static_cast<size_t>(type);
+            return _fallbackCPVShaders[index];
         }
 
         /*! \brief  Returns a white 3d fat point shader.
@@ -272,6 +325,13 @@ namespace
                 if (TF_VERIFY(shaderMgr)) {
                     shader = shaderMgr->getFragmentShader(
                         _fallbackShaderNames[index], _structOutputName, true);
+
+                    if (TF_VERIFY(shader)) {
+                        const auto it = _curveBasisParameterValueMapping.find(type);
+                        if (it != _curveBasisParameterValueMapping.end()) {
+                            shader->setParameter(_curveBasisParameterName, it->second);
+                        }
+                    }
                 }
             }
 
@@ -289,12 +349,14 @@ namespace
         bool                    _isInitialized { false };  //!< Whether the shader cache is initialized
 
         //! Shader registry used by fallback shaders
-        MShaderMap              _fallbackShaders[static_cast<size_t>(FallbackShaderType::kCount)];
+        MShaderMap              _fallbackShaders[FallbackShaderTypeCount];
         MShaderMap              _3dSolidShaders;
 
-        MHWRender::MShaderInstance*  _fallbackCPVShader { nullptr }; //!< Fallback shader with CPV support
-        MHWRender::MShaderInstance*  _3dFatPointShader { nullptr };  //!< 3d shader for points
-        MHWRender::MShaderInstance*  _3dCPVSolidShader { nullptr };  //!< 3d CPV solid-color shader
+        //!< Fallback shaders with CPV support
+        MHWRender::MShaderInstance* _fallbackCPVShaders[FallbackShaderTypeCount];
+
+        MHWRender::MShaderInstance* _3dFatPointShader { nullptr }; //!< 3d shader for points
+        MHWRender::MShaderInstance* _3dCPVSolidShader { nullptr }; //!< 3d CPV solid-color shader
     };
 
     MShaderCache sShaderCache;  //!< Global shader cache to minimize the number of unique shaders.
@@ -712,41 +774,51 @@ MHWRender::MShaderInstance* HdVP2RenderDelegate::GetFallbackShader(
     return sShaderCache.GetFallbackShader(color, FallbackShaderType::kCommon);
 }
 
-/*! \brief  Returns a fallback shader instance when no material is bound.
+/*! \brief  Returns a constant-color fallback shader instance for basisCurves when no material is
+   bound.
 
-    This method is keeping registry of all fallback shaders generated, keeping minimal
-    number of shader instances.
+    This method is keeping registry of all fallback shaders generated, keeping minimal number of
+    shader instances.
 
-    \param color    Color to set on given shader instance
+    \param curveType    The curve type
+    \param curveBasis   The curve basis
+    \param color        Color to set on given shader instance
 
     \return A new or existing copy of shader instance with given color parameter set
 */
-MHWRender::MShaderInstance*
-HdVP2RenderDelegate::GetBasisCurvesLinearFallbackShader(const MColor& color) const
+MHWRender::MShaderInstance* HdVP2RenderDelegate::GetBasisCurvesFallbackShader(
+    const TfToken& curveType,
+    const TfToken& curveBasis,
+    const MColor&  color) const
 {
-    return sShaderCache.GetFallbackShader(color, FallbackShaderType::kBasisCurvesLinear);
+    FallbackShaderType type = GetBasisCurvesShaderType(curveType, curveBasis);
+    return sShaderCache.GetFallbackShader(color, type);
 }
 
-/*! \brief  Returns a fallback shader instance when no material is bound.
+/*! \brief  Returns a varying-color fallback shader instance for basisCurves when no material is
+   bound.
 
-    This method is keeping registry of all fallback shaders generated, keeping minimal
-    number of shader instances.
+    This method is keeping registry of all fallback shaders generated, keeping minimal number of
+    shader instances.
 
-    \param color    Color to set on given shader instance
+    \param curveType    The curve type
+    \param curveBasis   The curve basis
 
     \return A new or existing copy of shader instance with given color parameter set
 */
-MHWRender::MShaderInstance*
-HdVP2RenderDelegate::GetBasisCurvesCubicFallbackShader(const MColor& color) const
+MHWRender::MShaderInstance* HdVP2RenderDelegate::GetBasisCurvesCPVShader(
+    const TfToken& curveType,
+    const TfToken& curveBasis) const
 {
-    return sShaderCache.GetFallbackShader(color, FallbackShaderType::kBasisCurvesCubic);
+    FallbackShaderType type = GetBasisCurvesShaderType(curveType, curveBasis);
+    return sShaderCache.GetFallbackCPVShader(type);
 }
 
 /*! \brief  Returns a fallback CPV shader instance when no material is bound.
 */
 MHWRender::MShaderInstance* HdVP2RenderDelegate::GetFallbackCPVShader() const
 {
-    return sShaderCache.GetFallbackCPVShader();
+    return sShaderCache.GetFallbackCPVShader(FallbackShaderType::kCommon);
 }
 
 /*! \brief  Returns a 3d solid-color shader.

--- a/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.h
@@ -111,8 +111,13 @@ public:
     MHWRender::MShaderInstance* Get3dCPVSolidShader() const;
     MHWRender::MShaderInstance* Get3dFatPointShader() const;
 
-    MHWRender::MShaderInstance* GetBasisCurvesLinearFallbackShader(const MColor& color) const;
-    MHWRender::MShaderInstance* GetBasisCurvesCubicFallbackShader(const MColor& color) const;
+    MHWRender::MShaderInstance* GetBasisCurvesFallbackShader(
+        const TfToken& curveType,
+        const TfToken& curveBasis,
+        const MColor&  color) const;
+
+    MHWRender::MShaderInstance*
+    GetBasisCurvesCPVShader(const TfToken& curveType, const TfToken& curveBasis) const;
 
     const MHWRender::MSamplerState* GetSamplerState(
         const MHWRender::MSamplerStateDesc& desc) const;

--- a/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesCubicCPVHull.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesCubicCPVHull.xml
@@ -1,0 +1,193 @@
+﻿<!--
+========================================================================
+Copyright 2020 Autodesk
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment uiName="BasisCurvesCubicCPVHull" name="BasisCurvesCubicCPVHull" type="hullShader" class="ShadeFragment" version="1.0" feature_level="0">
+    <description>
+        <![CDATA[Hull shader for basisCurves]]>
+    </description>
+    <keyword value="tessellation" />
+    <properties>
+        <float4x4  name="worldViewProj" semantic="worldviewprojection" flags="isRequirementOnly" />
+        <float2  name="viewportPixelSize" semantic="ViewportPixelSize" flags="isRequirementOnly" />
+        <float  name="tessLevel" semantic="TESSLEVEL" flags="isRequirementOnly" />
+        <struct  name="inputs" semantic="SV_PATCH" size="4" struct_name="vertOutS" flags="varyingInputParam" />
+        <int  name="primitiveID" semantic="SV_PrimitiveID" flags="varyingInputParam" />
+        <int  name="patchID" semantic="SV_OutputControlPointID" flags="varyingInputParam" />
+        <undefined name="GPUStage" semantic="GPUStage" />
+        <float3  name="Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="Nm" semantic="NORMAL" flags="isRequirementOnly,varyingInputParam" />
+        <float  name="U0_1" semantic="TEXCOORD0" flags="isRequirementOnly,varyingInputParam" />
+        <float4  name="UsdPrimvarColor" semantic="COLOR0" flags="isRequirementOnly,varyingInputParam" />
+    </properties>
+    <values>
+    </values>
+    <outputs>
+        <struct  name="outS" size="4" struct_name="hullOutS" />
+        <undefined name="GPUStage" semantic="hullShader" />
+        <float4  name="tessOuterLo" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <float4  name="tessOuterHi" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+    </outputs>
+    <implementation>
+        <implementation render="OGSRenderer" language="GLSL" lang_version="3.0">
+            <function_name val="BasisCurvesCubicCPVHull" />
+            <source>
+                <![CDATA[
+float GetMaxTess()
+{
+    // Should be replaced with a uniform
+    return 40;
+}
+
+float GetPixelToTessRatio()
+{
+    // Should be replaced with a uniform
+    return 20.0;
+}
+
+vec2 projectToScreen(mat4 wvp, vec3 vertex, vec2 screen_size)
+{
+    vec4 res = wvp * vec4(vertex, 1.0f);
+    res /= res.w;
+    return (clamp(res.xy, -1.3, 1.3) + 1) * (screen_size * 0.5);
+}
+
+// line 185 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+// Use the length of the control points in screen space to determine how many
+// times to subdivide the curve.
+void determineLODSettings()
+{
+    vec2 v0 = projectToScreen(worldViewProj, HS_IN[0].Pm, viewportPixelSize);
+    vec2 v1 = projectToScreen(worldViewProj, HS_IN[1].Pm, viewportPixelSize);
+    vec2 v2 = projectToScreen(worldViewProj, HS_IN[2].Pm, viewportPixelSize);
+    vec2 v3 = projectToScreen(worldViewProj, HS_IN[3].Pm, viewportPixelSize);
+
+    float maxTess = GetMaxTess();
+
+    // Need to handle off screen
+    float dist = distance(v0, v1) + distance(v1, v2) + distance(v2, v3);
+    float level = clamp(dist / GetPixelToTessRatio(), 0, maxTess);
+
+    gl_TessLevelOuter[0] = level;
+    gl_TessLevelOuter[1] = 1;
+    gl_TessLevelOuter[2] = level;
+    gl_TessLevelOuter[3] = 1;
+
+    gl_TessLevelInner[0] = 1;
+    gl_TessLevelInner[1] = level;
+}
+
+// line 154 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+void BasisCurvesCubicCPVHull()
+{
+    if (gl_InvocationID == 0) {
+        determineLODSettings();
+    }
+
+    HS_OUT[gl_InvocationID].U0_1 = HS_IN[gl_InvocationID].U0_1; // U0_1 being used as widths.
+    HS_OUT[gl_InvocationID].UsdPrimvarColor = HS_IN[gl_InvocationID].UsdPrimvarColor;
+}
+                ]]>
+            </source>
+        </implementation>
+        <implementation render="OGSRenderer" language="HLSL" lang_version="11.0">
+            <function_name val="BasisCurvesCubicCPVHull" />
+            <declaration name="hullConstantsOutS" >
+                <![CDATA[
+struct hullConstantsOutS
+{
+    float tessLevelInner[2] : SV_InsideTessFactor;
+    float tessLevelOuter[4] : SV_TessFactor;
+};
+                ]]>
+            </declaration>
+            <source>
+                <![CDATA[
+float GetMaxTess()
+{
+    // Should be replaced with a uniform
+    return 40;
+}
+
+float GetPixelToTessRatio()
+{
+    // Should be replaced with a uniform
+    return 20.0f;
+}
+
+float2 projectToScreen(float4x4 wvp, float3 vertex, float2 screen_size)
+{
+    float4 res = mul(float4(vertex, 1.0f), wvp);
+    res /= res.w;
+    return (clamp(res.xy, -1.3, 1.3) + 1) * (screen_size * 0.5);
+}
+
+// line 154 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+hullOutS BasisCurvesCubicCPVHull(
+    InputPatch<vertOutS, 4> inputs,
+    uint primitiveID,
+    uint patchID)
+{
+    hullOutS output;
+
+    output.Pm   = inputs[patchID].Pm;
+    output.Nm   = inputs[patchID].Nm;
+    output.U0_1 = inputs[patchID].U0_1; // U0_1 being used as widths.
+    output.UsdPrimvarColor = inputs[patchID].UsdPrimvarColor;
+
+    return output;
+}
+
+// line 185 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+// Use the length of the control points in screen space to determine how many
+// times to subdivide the curve.
+hullConstantsOutS BasisCurvesCubicCPVHullConstants(
+    InputPatch<vertOutS, 4> inPatch,
+    OutputPatch<hullOutS, 4> outPatch,
+    uint primitiveID : SV_PrimitiveID)
+{
+    float2 v0 = projectToScreen(worldViewProj, inPatch[0].Pm, viewportPixelSize);
+    float2 v1 = projectToScreen(worldViewProj, inPatch[1].Pm, viewportPixelSize);
+    float2 v2 = projectToScreen(worldViewProj, inPatch[2].Pm, viewportPixelSize);
+    float2 v3 = projectToScreen(worldViewProj, inPatch[3].Pm, viewportPixelSize);
+
+    float maxTess = GetMaxTess();
+
+    // Need to handle off screen
+    float dist = distance(v0, v1) + distance(v1, v2) + distance(v2, v3);
+    float level = clamp(dist / GetPixelToTessRatio(), 0, maxTess);
+
+    hullConstantsOutS output;
+
+    output.tessLevelOuter[0] = level;
+    output.tessLevelOuter[1] = 1;
+    output.tessLevelOuter[2] = level;
+    output.tessLevelOuter[3] = 1;
+
+    output.tessLevelInner[0] = 1;
+    output.tessLevelInner[1] = level;
+    
+    return output;
+}
+                ]]>
+            </source>
+        </implementation>
+        <implementation render="OGSRenderer" language="Cg" lang_version="2.1">
+            <function_name val="NOTIMPLEMENTED" />
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesCubicCPVPassing.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesCubicCPVPassing.xml
@@ -1,0 +1,68 @@
+<!--
+========================================================================
+Copyright 2020 Autodesk
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment  uiName="BasisCurvesCubicCPVPassing" name="BasisCurvesCubicCPVPassing" type="interpolant" class="ShadeFragment" version="1.0" feature_level="0" >
+    <description>
+        <![CDATA[Pass primvars:displayColor and primvars::displayOpacity through shader stages]]>
+    </description>
+    <properties>
+        <float4 name="colorIn" semantic="fcolor" flags="varyingInputParam" />
+    </properties>
+    <outputs>
+        <float4 name="BasisCurvesCubicColor" />
+    </outputs>
+    <implementation  >
+        <implementation  render="OGSRenderer" language="GLSL" lang_version="3.000000" >
+            <function_name val="BasisCurvesCubicCPVPassing" />
+            <source>
+                <![CDATA[
+vec4 BasisCurvesCubicCPVPassing(vec4 inColor)
+{
+    return inColor;
+}
+                ]]>
+            </source>
+            <vertex_source>
+                <![CDATA[
+vec4 iBasisCurvesCubicCPVPassing(vec4 inColor)
+{
+    return inColor;
+}
+                ]]>
+            </vertex_source>
+        </implementation>
+        <implementation  render="OGSRenderer" language="HLSL" lang_version="11.000000" >
+            <function_name val="BasisCurvesCubicCPVPassing" />
+            <source>
+                <![CDATA[
+float4 BasisCurvesCubicCPVPassing(float4 inColor)
+{
+    return inColor;
+}
+                ]]>
+            </source>
+            <vertex_source>
+                <![CDATA[
+float4 iBasisCurvesCubicCPVPassing(float4 inColor)
+{
+    return inColor;
+}
+                ]]>
+            </vertex_source>
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesCubicCPVShader.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesCubicCPVShader.xml
@@ -15,27 +15,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ========================================================================
 -->
-<fragment_graph name="BasisCurvesCubicFallbackShader" ref="BasisCurvesCubicFallbackShader" class="FragmentGraph" version="1.0" feature_level="0" >
+<fragment_graph name="BasisCurvesCubicCPVShader" ref="BasisCurvesCubicCPVShader" class="FragmentGraph" version="1.0" feature_level="0" >
     <fragments>
         <fragment_ref name="mayaBlinnSurface" ref="mayaBlinnSurface" />
         <fragment_ref name="opacityToTransparency" ref="opacityToTransparency" />
         <fragment_ref name="Float4ToFloat3" ref="Float4ToFloat3" />
         <fragment_ref name="Float4ToFloatW" ref="Float4ToFloatW" />
-        <fragment_ref name="Float4ToFloat4" ref="Float4ToFloat4" />
-        <fragment_ref name="BasisCurvesCubicHull" ref="BasisCurvesCubicHull" />
+        <fragment_ref name="BasisCurvesCubicCPVPassing" ref="BasisCurvesCubicCPVPassing" />
+        <fragment_ref name="BasisCurvesCubicCPVHull" ref="BasisCurvesCubicCPVHull" />
         <fragment_ref name="BasisCurvesCubicDomain" ref="BasisCurvesCubicDomain" />
     </fragments>
     <connections>
         <connect from="Float4ToFloat3.output" to="mayaBlinnSurface.color" name="color" />
         <connect from="opacityToTransparency.transparency" to="mayaBlinnSurface.transparency" name="transparency" />
         <connect from="Float4ToFloatW.output" to="opacityToTransparency.opacity" name="opacity" />
-        <connect from="Float4ToFloat4.output" to="Float4ToFloat3.input" name="rgb" />
-        <connect from="Float4ToFloat4.output" to="Float4ToFloatW.input" name="a" />
+        <connect from="BasisCurvesCubicCPVPassing.BasisCurvesCubicColor" to="Float4ToFloat3.input" name="rgb" />
+        <connect from="BasisCurvesCubicCPVPassing.BasisCurvesCubicColor" to="Float4ToFloatW.input" name="a" />
         <connect from="BasisCurvesCubicDomain.GPUStage" to="mayaBlinnSurface.GPUStage" name="DS_to_PS" />
-        <connect from="BasisCurvesCubicHull.GPUStage" to="BasisCurvesCubicDomain.GPUStage" name="HS_to_DS" />
+        <connect from="BasisCurvesCubicCPVHull.GPUStage" to="BasisCurvesCubicDomain.GPUStage" name="HS_to_DS" />
     </connections>
     <properties>
-        <undefined name="GPUStage" ref="BasisCurvesCubicHull.GPUStage" semantic="GPUStage" />
+        <undefined name="GPUStage" ref="BasisCurvesCubicCPVHull.GPUStage" semantic="GPUStage" />
         <float3 name="Nw" ref="mayaBlinnSurface.Nw" flags="varyingInputParam" />
         <float3 name="Lw" ref="mayaBlinnSurface.Lw" />
         <float3 name="Vw" ref="mayaBlinnSurface.Vw" flags="varyingInputParam" />
@@ -69,7 +69,7 @@ limitations under the License.
         <float name="fogDensity" ref="mayaBlinnSurface.fogDensity" />
         <float4 name="fogColor" ref="mayaBlinnSurface.fogColor" />
         <float name="fogMultiplier" ref="mayaBlinnSurface.fogMultiplier" />
-        <float4 name="diffuseColor" ref="Float4ToFloat4.input" />
+        <float4 name="diffuseColor" ref="BasisCurvesCubicCPVPassing.colorIn" flags="varyingInputParam" />
         <int name="curveBasis" ref="BasisCurvesCubicDomain.curveBasis" />
     </properties>
     <values>

--- a/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesCubicColorDomain.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesCubicColorDomain.xml
@@ -1,0 +1,84 @@
+<!--
+========================================================================
+Copyright 2020 Autodesk
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment  uiName="BasisCurvesCubicColorDomain" name="BasisCurvesCubicColorDomain" type="plumbing" class="ShadeFragment" version="1.0" feature_level="50" >
+    <description>
+        <![CDATA[Tessellation evaluation for varying color]]>
+    </description>
+    <keyword value="input" />
+    <properties>
+        <struct name="patchConstants" struct_name="hullConstantsOutS" flags="varyingInputParam" />
+        <struct name="patch" size="4" struct_name="hullOutS" />
+        <float2 name="domainCoord" semantic="SV_DomainLocation" flags="varyingInputParam" />
+        <float4 name="UsdPrimvarColor" semantic="COLOR0" flags="isRequirementOnly,varyingInputParam" />
+        <int name="curveBasis" />
+    </properties>
+    <values>
+        <int name="curveBasis" value="0"/>
+    </values>
+    <outputs>
+        <float4 name="BasisCurvesCubicColorDomain" />
+    </outputs>
+    <implementation  >
+        <implementation  render="OGSRenderer" language="GLSL" lang_version="3.000000" >
+            <function_name val="BasisCurvesCubicColorDomain" />
+            <source>
+                <![CDATA[
+vec4 BasisCurvesCubicColorDomain(int curveBasis)
+{
+    float u = gl_TessCoord.y;
+    float v = gl_TessCoord.x;
+
+    Coeffs coeffs = evaluateBasis(curveBasis, u, u*u, u*u*u);
+
+    vec4 c0 = DS_IN[0].UsdPrimvarColor;
+    vec4 c1 = DS_IN[1].UsdPrimvarColor;
+    vec4 c2 = DS_IN[2].UsdPrimvarColor;
+    vec4 c3 = DS_IN[3].UsdPrimvarColor;
+
+    return mat4(c0, c1, c2, c3) * coeffs.basis;
+}
+            ]]>
+            </source>
+        </implementation>
+        <implementation  render="OGSRenderer" language="HLSL" lang_version="11.000000" >
+            <function_name val="BasisCurvesCubicColorDomain" />
+            <source>
+                <![CDATA[
+float4 BasisCurvesCubicColorDomain(
+    hullConstantsOutS patchConstants,
+    hullOutS patch[4],
+    float2 domainCoord,
+    int curveBasis)
+{
+    float u = domainCoord.y;
+    float v = domainCoord.x;
+
+    Coeffs coeffs = evaluateBasis(curveBasis, u, u*u, u*u*u);
+
+    float4 c0 = patch[0].UsdPrimvarColor;
+    float4 c1 = patch[1].UsdPrimvarColor;
+    float4 c2 = patch[2].UsdPrimvarColor;
+    float4 c3 = patch[3].UsdPrimvarColor;
+
+    return mul(coeffs.basis, float4x4(c0, c1, c2, c3));
+}
+                ]]>
+            </source>
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesCubicDomain_GLSL.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesCubicDomain_GLSL.xml
@@ -37,12 +37,14 @@ limitations under the License.
         <string  name="tessprimitives" semantic="controlParam" flags="isRequirementOnly" />
         <string  name="patchspacing" semantic="controlParam" flags="isRequirementOnly" />
         <int  name="barriers" semantic="controlParam" flags="isRequirementOnly" />
+        <int  name="curveBasis" />
     </properties>
     <values>
         <int name="outputpatchsize" value="4"/>
         <string name="tessprimitives" value="quads"/>
         <string name="patchspacing" value="fractional_odd_spacing"/>
         <int name="barriers" value="0"/>
+        <int name="curveBasis" value="0"/>
     </values>
     <outputs>
         <struct  name="structDomain" size="4" struct_name="structDomain" />
@@ -81,10 +83,7 @@ vec3 evaluateNormal(vec4 basis, float u)
     vec4 n2 = worldViewIT * vec4(DS_IN[2].Nm, 1.0f);
     vec4 n3 = worldViewIT * vec4(DS_IN[3].Nm, 1.0f);
 
-    vec3 normal = n0.xyz * basis.x
-                + n1.xyz * basis.y
-                + n2.xyz * basis.z
-                + n3.xyz * basis.w;
+    vec3 normal = (mat4(n0, n1, n2, n3) * basis).xyz;
 
     // A zero vector is passed in to indicate requirement of camera-facing normal.
     if (length(normal) < 0.00001f)
@@ -96,41 +95,69 @@ vec3 evaluateNormal(vec4 basis, float u)
 
 // line 676 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
 
-Coeffs evaluateBasis(float u, float u2, float u3)
+Coeffs evaluateBasis(int curveBasis, float u, float u2, float u3)
 {
-    vec4 basis;
-    basis[0] = u3;
-    basis[1] = -3.0*u3 + 3.0*u2;
-    basis[2] = 3.0*u3 - 6.0*u2 + 3.0*u;
-    basis[3] = -1.0*u3 + 3.0*u2 - 3.0*u + 1.0;
+    Coeffs result;
 
-    vec4 tangent_basis;
-    tangent_basis[0] = 3.0*u2;
-    tangent_basis[1] = -9.0*u2 + 6.0*u;
-    tangent_basis[2] = 9.0*u2 - 12.0*u + 3.0;
-    tangent_basis[3] = -3.0*u2 + 6.0*u - 3.0;
+    if (curveBasis == 0) // Curves.BezierBasis
+    {
+        result.basis = vec4(u3,
+                            -3.0*u3 + 3.0*u2,
+                            3.0*u3 - 6.0*u2 + 3.0*u,
+                            -1.0*u3 + 3.0*u2 - 3.0*u + 1.0);
 
-    return Coeffs(basis, tangent_basis);
+        result.tangent_basis = vec4(3.0*u2,
+                                    -9.0*u2 + 6.0*u,
+                                    9.0*u2 - 12.0*u + 3.0,
+                                    -3.0*u2 + 6.0*u - 3.0);
+    }
+    else if (curveBasis == 1) // Curves.BsplineBasis
+    {
+        result.basis = vec4((1.0/6.0)*u3,
+                            -0.5*u3 + 0.5*u2 + 0.5*u + (1.0/6.0),
+                            0.5*u3 - u2 + (2.0/3.0),
+                            -(1.0/6.0)*u3 + 0.5*u2 - 0.5*u + (1.0/6.0));
+
+        result.tangent_basis = vec4(0.5*u2,
+                                    -1.5*u2 + u + 0.5,
+                                    1.5*u2 - 2.0*u,
+                                    -0.5*u2 + u - 0.5);
+    }
+    else if (curveBasis == 2) // Curves.CatmullRomBasis
+    {
+        result.basis = vec4(0.5*u3 - 0.5*u2,
+                            -1.5*u3 + 2.0*u2 + 0.5*u,
+                            1.5*u3 - 2.5*u2 + 1.0,
+                            -0.5*u3 + u2 - 0.5*u);
+
+        result.tangent_basis = vec4(1.5*u2 - u,
+                                    -4.5*u2 + 4.0*u + 0.5,
+                                    4.5*u2 - 5.0*u,
+                                    -1.5*u2 + 2.0*u - 0.5);
+    }
+    else // Unexpected value
+    {
+        result.basis = vec4(0.0, 0.0, 0.0, 0.0);
+
+        result.tangent_basis = vec4(0.0, 0.0, 0.0, 0.0);
+    }
+
+    return result;
 }
 
-void evaluate(float u, float v, out vec4 position, out vec4 tangent,
-              out float width, out vec3 normal){
+void evaluate(int curveBasis, float u, float v, out vec4 position, out vec4 tangent,
+              out float width, out vec3 normal)
+{
     vec4 p0 = worldView * vec4(DS_IN[0].Pm, 1.0f);
     vec4 p1 = worldView * vec4(DS_IN[1].Pm, 1.0f);
     vec4 p2 = worldView * vec4(DS_IN[2].Pm, 1.0f);
     vec4 p3 = worldView * vec4(DS_IN[3].Pm, 1.0f);
 
-    Coeffs coeffs = evaluateBasis(u, u*u, u*u*u);
+    Coeffs coeffs = evaluateBasis(curveBasis, u, u*u, u*u*u);
 
-    position = coeffs.basis[0] * p0 +
-               coeffs.basis[1] * p1 +
-               coeffs.basis[2] * p2 +
-               coeffs.basis[3] * p3;
-
-    tangent = coeffs.tangent_basis[0] * p0 +
-              coeffs.tangent_basis[1] * p1 +
-              coeffs.tangent_basis[2] * p2 +
-              coeffs.tangent_basis[3] * p3;
+    mat4 pmat = mat4(p0, p1, p2, p3);
+    position = pmat * coeffs.basis;
+    tangent = pmat * coeffs.tangent_basis;
 
     width = evaluateWidths(coeffs.basis, u);
     normal = normalize(evaluateNormal(coeffs.basis, u));
@@ -149,20 +176,17 @@ vec3 orient(float v, vec4 position, vec4 tangent, vec3 normal)
     return normalize(cross(tangent.xyz, normal)  * (v - 0.5));
 }
 
-structDomain BasisCurvesCubicDomain()
+structDomain BasisCurvesCubicDomain(int curveBasis)
 {
     float u = gl_TessCoord.y;
     float v = gl_TessCoord.x;
-
-    Coeffs coeffs = evaluateBasis(u, u*u, u*u*u);
-    vec4 basis = coeffs.basis;
 
     vec4 position;
     vec4 tangent;
     float width;
     vec3 normal;
 
-    evaluate(u, v, position, tangent, width, normal);
+    evaluate(curveBasis, u, v, position, tangent, width, normal);
     vec3 direction = orient(v, position, tangent, normal);
 
     vec4 scaledDirection = worldView * vec4(direction, 0.0f);

--- a/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesCubicDomain_HLSL.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesCubicDomain_HLSL.xml
@@ -37,12 +37,14 @@ limitations under the License.
         <string  name="tessprimitives" semantic="controlParam" flags="isRequirementOnly" />
         <string  name="patchspacing" semantic="controlParam" flags="isRequirementOnly" />
         <int  name="barriers" semantic="controlParam" flags="isRequirementOnly" />
+        <int  name="curveBasis" />
     </properties>
     <values>
         <int name="outputpatchsize" value="4"/>
         <string name="tessprimitives" value="quad"/>
         <string name="patchspacing" value="fractional_odd"/>
         <int name="barriers" value="0"/>
+        <int name="curveBasis" value="0"/>
     </values>
     <outputs>
         <struct  name="structDomain" size="4" struct_name="structDomain" />
@@ -81,10 +83,7 @@ float3 evaluateNormal(hullOutS patch[4], float4 basis, float u)
     float4 n2 = mul(float4(patch[2].Nm, 1.0f), worldViewIT);
     float4 n3 = mul(float4(patch[3].Nm, 1.0f), worldViewIT);
 
-    float3 normal = n0.xyz * basis.x
-                  + n1.xyz * basis.y
-                  + n2.xyz * basis.z
-                  + n3.xyz * basis.w;
+    float3 normal = mul(basis, float4x4(n0, n1, n2, n3)).xyz;
 
     // A zero vector is passed in to indicate requirement of camera-facing normal.
     if (length(normal) < 0.00001f)
@@ -97,44 +96,68 @@ float3 evaluateNormal(hullOutS patch[4], float4 basis, float u)
 
 // line 676 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
 
-Coeffs evaluateBasis(float u, float u2, float u3)
+Coeffs evaluateBasis(int curveBasis, float u, float u2, float u3)
 {
-    float4 basis;
-    basis[0] = u3;
-    basis[1] = -3.0*u3 + 3.0*u2;
-    basis[2] = 3.0*u3 - 6.0*u2 + 3.0*u;
-    basis[3] = -1.0*u3 + 3.0*u2 - 3.0*u + 1.0;
+    Coeffs result;
 
-    float4 tangent_basis;
-    tangent_basis[0] = 3.0*u2;
-    tangent_basis[1] = -9.0*u2 + 6.0*u;
-    tangent_basis[2] = 9.0*u2 - 12.0*u + 3.0;
-    tangent_basis[3] = -3.0*u2 + 6.0*u - 3.0;
+    if (curveBasis == 0) // Curves.BezierBasis
+    {
+        result.basis = float4(u3,
+                              -3.0*u3 + 3.0*u2,
+                              3.0*u3 - 6.0*u2 + 3.0*u,
+                              -1.0*u3 + 3.0*u2 - 3.0*u + 1.0);
 
-    Coeffs outputS;
-    outputS.basis = basis;
-    outputS.tangent_basis = tangent_basis;
-    return outputS;
+        result.tangent_basis = float4(3.0*u2,
+                                      -9.0*u2 + 6.0*u,
+                                      9.0*u2 - 12.0*u + 3.0,
+                                      -3.0*u2 + 6.0*u - 3.0);
+    }
+    else if (curveBasis == 1) // Curves.BsplineBasis
+    {
+        result.basis = float4((1.0/6.0)*u3,
+                              -0.5*u3 + 0.5*u2 + 0.5*u + (1.0/6.0),
+                              0.5*u3 - u2 + (2.0/3.0),
+                              -(1.0/6.0)*u3 + 0.5*u2 - 0.5*u + (1.0/6.0));
+
+        result.tangent_basis = float4(0.5*u2,
+                                      -1.5*u2 + u + 0.5,
+                                      1.5*u2 - 2.0*u,
+                                      -0.5*u2 + u - 0.5);
+    }
+    else if (curveBasis == 2) // Curves.CatmullRomBasis
+    {
+        result.basis = float4(0.5*u3 - 0.5*u2,
+                              -1.5*u3 + 2.0*u2 + 0.5*u,
+                              1.5*u3 - 2.5*u2 + 1.0,
+                              -0.5*u3 + u2 - 0.5*u);
+
+        result.tangent_basis = float4(1.5*u2 - u,
+                                      -4.5*u2 + 4.0*u + 0.5,
+                                      4.5*u2 - 5.0*u,
+                                      -1.5*u2 + 2.0*u - 0.5);
+    }
+    else // Unexpected value
+    {
+        result.basis = float4(0.0, 0.0, 0.0, 0.0);
+
+        result.tangent_basis = float4(0.0, 0.0, 0.0, 0.0);
+    }
+    
+    return result;
 }
 
-void evaluate(hullOutS patch[4], float u, float v, out float4 position, out float4 tangent,
+void evaluate(hullOutS patch[4], int curveBasis, float u, float v, out float4 position, out float4 tangent,
               out float width, out float3 normal){
     float4 p0 = mul(float4(patch[0].Pm, 1.0f), worldView);
     float4 p1 = mul(float4(patch[1].Pm, 1.0f), worldView);
     float4 p2 = mul(float4(patch[2].Pm, 1.0f), worldView);
     float4 p3 = mul(float4(patch[3].Pm, 1.0f), worldView);
 
-    Coeffs coeffs = evaluateBasis(u, u*u, u*u*u);
+    Coeffs coeffs = evaluateBasis(curveBasis, u, u*u, u*u*u);
 
-    position = coeffs.basis[0] * p0 +
-               coeffs.basis[1] * p1 +
-               coeffs.basis[2] * p2 +
-               coeffs.basis[3] * p3;
-
-    tangent = coeffs.tangent_basis[0] * p0 +
-              coeffs.tangent_basis[1] * p1 +
-              coeffs.tangent_basis[2] * p2 +
-              coeffs.tangent_basis[3] * p3;
+    float4x4 pmat = float4x4(p0, p1, p2, p3);
+    position = mul(coeffs.basis, pmat);
+    tangent = mul(coeffs.tangent_basis, pmat);
 
     width = evaluateWidths(patch, coeffs.basis, u);
     normal = normalize(evaluateNormal(patch, coeffs.basis, u));
@@ -156,20 +179,18 @@ float3 orient(float v, float4 position, float4 tangent, float3 normal)
 structDomain BasisCurvesCubicDomain(
     hullConstantsOutS patchConstants,
     hullOutS patch[4],
-    float2 domainCoord)
+    float2 domainCoord,
+    int curveBasis)
 {
     float u = domainCoord.y;
     float v = domainCoord.x;
-
-    Coeffs coeffs = evaluateBasis(u, u*u, u*u*u);
-    float4 basis = coeffs.basis;
 
     float4 position;
     float4 tangent;
     float width;
     float3 normal;
 
-    evaluate(patch, u, v, position, tangent, width, normal);
+    evaluate(patch, curveBasis, u, v, position, tangent, width, normal);
     float3 direction = orient(v, position, tangent, normal);
 
     float4 scaledDirection = mul(float4(direction, 0.0f), worldView);

--- a/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesLinearCPVHull.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesLinearCPVHull.xml
@@ -1,0 +1,131 @@
+﻿<!--
+========================================================================
+Copyright 2020 Autodesk
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment uiName="BasisCurvesLinearCPVHull" name="BasisCurvesLinearCPVHull" type="hullShader" class="ShadeFragment" version="1.0" feature_level="0">
+    <description>
+        <![CDATA[Hull shader for basisCurves]]>
+    </description>
+    <keyword value="tessellation" />
+    <properties>
+        <float  name="tessLevel" semantic="TESSLEVEL" flags="isRequirementOnly" />
+        <struct  name="inputs" semantic="SV_PATCH" size="2" struct_name="vertOutS" flags="varyingInputParam" />
+        <int  name="primitiveID" semantic="SV_PrimitiveID" flags="varyingInputParam" />
+        <int  name="patchID" semantic="SV_OutputControlPointID" flags="varyingInputParam" />
+        <undefined name="GPUStage" semantic="GPUStage" />
+        <float3  name="Pm" semantic="POSITION" flags="isRequirementOnly,varyingInputParam" />
+        <float3  name="Nm" semantic="NORMAL" flags="isRequirementOnly,varyingInputParam" />
+        <float  name="U0_1" semantic="TEXCOORD0" flags="isRequirementOnly,varyingInputParam" />
+        <float4  name="UsdPrimvarColor" semantic="COLOR0" flags="isRequirementOnly,varyingInputParam" />
+    </properties>
+    <values>
+    </values>
+    <outputs>
+        <struct  name="outS" size="2" struct_name="hullOutS" />
+        <undefined name="GPUStage" semantic="hullShader" />
+        <float4  name="tessOuterLo" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+        <float4  name="tessOuterHi" semantic="patchConstantParam" flags="isRequirementOnly,varyingInputParam" />
+    </outputs>
+    <implementation>
+        <implementation render="OGSRenderer" language="GLSL" lang_version="3.0">
+            <function_name val="BasisCurvesLinearCPVHull" />
+            <source>
+                <![CDATA[
+// line 185 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+// Use the length of the control points in screen space to determine how many
+// times to subdivide the curve.
+void determineLODSettings()
+{
+    gl_TessLevelOuter[0] = 1;
+    gl_TessLevelOuter[1] = 1;
+    gl_TessLevelOuter[2] = 1;
+    gl_TessLevelOuter[3] = 1;
+
+    gl_TessLevelInner[0] = 1;
+    gl_TessLevelInner[1] = 1;
+}
+
+// line 154 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+void BasisCurvesLinearCPVHull()
+{
+    if (gl_InvocationID == 0) {
+        determineLODSettings();
+    }
+
+    HS_OUT[gl_InvocationID].U0_1 = HS_IN[gl_InvocationID].U0_1; // U0_1 being used as widths.
+    HS_OUT[gl_InvocationID].UsdPrimvarColor = HS_IN[gl_InvocationID].UsdPrimvarColor;
+}
+                ]]>
+            </source>
+        </implementation>
+        <implementation render="OGSRenderer" language="HLSL" lang_version="11.0">
+            <function_name val="BasisCurvesLinearCPVHull" />
+            <declaration name="hullConstantsOutS" >
+                <![CDATA[
+struct hullConstantsOutS
+{
+    float tessLevelInner[2] : SV_InsideTessFactor;
+    float tessLevelOuter[4] : SV_TessFactor;
+};
+                ]]>
+            </declaration>
+            <source>
+                <![CDATA[
+// line 154 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+hullOutS BasisCurvesLinearCPVHull(
+    InputPatch<vertOutS, 2> inputs,
+    uint primitiveID,
+    uint patchID)
+{
+    hullOutS output;
+
+    output.Pm   = inputs[patchID].Pm;
+    output.Nm   = inputs[patchID].Nm;
+    output.U0_1 = inputs[patchID].U0_1; // U0_1 being used as widths.
+    output.UsdPrimvarColor = inputs[patchID].UsdPrimvarColor;
+
+    return output;
+}
+
+// line 185 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
+
+// Use the length of the control points in screen space to determine how many
+// times to subdivide the curve.
+hullConstantsOutS BasisCurvesLinearCPVHullConstants(
+    InputPatch<vertOutS, 2> inPatch,
+    OutputPatch<hullOutS, 2> outPatch,
+    uint primitiveID : SV_PrimitiveID)
+{
+    hullConstantsOutS output;
+
+    output.tessLevelOuter[0] = 1;
+    output.tessLevelOuter[1] = 1;
+    output.tessLevelOuter[2] = 1;
+    output.tessLevelOuter[3] = 1;
+
+    output.tessLevelInner[0] = 1;
+    output.tessLevelInner[1] = 1;
+    
+    return output;
+}
+                ]]>
+            </source>
+        </implementation>
+        <implementation render="OGSRenderer" language="Cg" lang_version="2.1">
+            <function_name val="NOTIMPLEMENTED" />
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesLinearCPVPassing.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesLinearCPVPassing.xml
@@ -1,0 +1,68 @@
+<!--
+========================================================================
+Copyright 2020 Autodesk
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment  uiName="BasisCurvesLinearCPVPassing" name="BasisCurvesLinearCPVPassing" type="interpolant" class="ShadeFragment" version="1.0" feature_level="0" >
+    <description>
+        <![CDATA[Pass primvars:displayColor and primvars::displayOpacity through shader stages]]>
+    </description>
+    <properties>
+        <float4 name="colorIn" semantic="fcolor" flags="varyingInputParam" />
+    </properties>
+    <outputs>
+        <float4 name="BasisCurvesLinearColor" />
+    </outputs>
+    <implementation  >
+        <implementation  render="OGSRenderer" language="GLSL" lang_version="3.000000" >
+            <function_name val="BasisCurvesLinearCPVPassing" />
+            <source>
+                <![CDATA[
+vec4 BasisCurvesLinearCPVPassing(vec4 inColor)
+{
+    return inColor;
+}
+                ]]>
+            </source>
+            <vertex_source>
+                <![CDATA[
+vec4 iBasisCurvesLinearCPVPassing(vec4 inColor)
+{
+    return inColor;
+}
+                ]]>
+            </vertex_source>
+        </implementation>
+        <implementation  render="OGSRenderer" language="HLSL" lang_version="11.000000" >
+            <function_name val="BasisCurvesLinearCPVPassing" />
+            <source>
+                <![CDATA[
+float4 BasisCurvesLinearCPVPassing(float4 inColor)
+{
+    return inColor;
+}
+                ]]>
+            </source>
+            <vertex_source>
+                <![CDATA[
+float4 iBasisCurvesLinearCPVPassing(float4 inColor)
+{
+    return inColor;
+}
+                ]]>
+            </vertex_source>
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesLinearCPVShader.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesLinearCPVShader.xml
@@ -15,27 +15,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ========================================================================
 -->
-<fragment_graph name="BasisCurvesCubicFallbackShader" ref="BasisCurvesCubicFallbackShader" class="FragmentGraph" version="1.0" feature_level="0" >
+<fragment_graph name="BasisCurvesLinearCPVShader" ref="BasisCurvesLinearCPVShader" class="FragmentGraph" version="1.0" feature_level="0" >
     <fragments>
         <fragment_ref name="mayaBlinnSurface" ref="mayaBlinnSurface" />
         <fragment_ref name="opacityToTransparency" ref="opacityToTransparency" />
         <fragment_ref name="Float4ToFloat3" ref="Float4ToFloat3" />
         <fragment_ref name="Float4ToFloatW" ref="Float4ToFloatW" />
-        <fragment_ref name="Float4ToFloat4" ref="Float4ToFloat4" />
-        <fragment_ref name="BasisCurvesCubicHull" ref="BasisCurvesCubicHull" />
-        <fragment_ref name="BasisCurvesCubicDomain" ref="BasisCurvesCubicDomain" />
+        <fragment_ref name="BasisCurvesLinearCPVPassing" ref="BasisCurvesLinearCPVPassing" />
+        <fragment_ref name="BasisCurvesLinearCPVHull" ref="BasisCurvesLinearCPVHull" />
+        <fragment_ref name="BasisCurvesLinearDomain" ref="BasisCurvesLinearDomain" />
     </fragments>
     <connections>
         <connect from="Float4ToFloat3.output" to="mayaBlinnSurface.color" name="color" />
         <connect from="opacityToTransparency.transparency" to="mayaBlinnSurface.transparency" name="transparency" />
         <connect from="Float4ToFloatW.output" to="opacityToTransparency.opacity" name="opacity" />
-        <connect from="Float4ToFloat4.output" to="Float4ToFloat3.input" name="rgb" />
-        <connect from="Float4ToFloat4.output" to="Float4ToFloatW.input" name="a" />
-        <connect from="BasisCurvesCubicDomain.GPUStage" to="mayaBlinnSurface.GPUStage" name="DS_to_PS" />
-        <connect from="BasisCurvesCubicHull.GPUStage" to="BasisCurvesCubicDomain.GPUStage" name="HS_to_DS" />
+        <connect from="BasisCurvesLinearCPVPassing.BasisCurvesLinearColor" to="Float4ToFloat3.input" name="rgb" />
+        <connect from="BasisCurvesLinearCPVPassing.BasisCurvesLinearColor" to="Float4ToFloatW.input" name="a" />
+        <connect from="BasisCurvesLinearDomain.GPUStage" to="mayaBlinnSurface.GPUStage" name="DS_to_PS" />
+        <connect from="BasisCurvesLinearCPVHull.GPUStage" to="BasisCurvesLinearDomain.GPUStage" name="HS_to_DS" />
     </connections>
     <properties>
-        <undefined name="GPUStage" ref="BasisCurvesCubicHull.GPUStage" semantic="GPUStage" />
+        <undefined name="GPUStage" ref="BasisCurvesLinearCPVHull.GPUStage" semantic="GPUStage" />
         <float3 name="Nw" ref="mayaBlinnSurface.Nw" flags="varyingInputParam" />
         <float3 name="Lw" ref="mayaBlinnSurface.Lw" />
         <float3 name="Vw" ref="mayaBlinnSurface.Vw" flags="varyingInputParam" />
@@ -69,8 +69,7 @@ limitations under the License.
         <float name="fogDensity" ref="mayaBlinnSurface.fogDensity" />
         <float4 name="fogColor" ref="mayaBlinnSurface.fogColor" />
         <float name="fogMultiplier" ref="mayaBlinnSurface.fogMultiplier" />
-        <float4 name="diffuseColor" ref="Float4ToFloat4.input" />
-        <int name="curveBasis" ref="BasisCurvesCubicDomain.curveBasis" />
+        <float4 name="diffuseColor" ref="BasisCurvesLinearCPVPassing.colorIn" flags="varyingInputParam" />
     </properties>
     <values>
         <float3 name="Lw" value="0.000000,0.000000,0.000000"  />

--- a/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesLinearColorDomain.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesLinearColorDomain.xml
@@ -1,0 +1,71 @@
+<!--
+========================================================================
+Copyright 2020 Autodesk
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment  uiName="BasisCurvesLinearColorDomain" name="BasisCurvesLinearColorDomain" type="plumbing" class="ShadeFragment" version="1.0" feature_level="50" >
+    <description>
+        <![CDATA[Tessellation evaluation for varying color]]>
+    </description>
+    <keyword value="input" />
+    <properties>
+        <struct name="patchConstants" struct_name="hullConstantsOutS" flags="varyingInputParam" />
+        <struct name="patch" size="2" struct_name="hullOutS" />
+        <float2 name="domainCoord" semantic="SV_DomainLocation" flags="varyingInputParam" />
+        <float4 name="UsdPrimvarColor" semantic="COLOR0" flags="isRequirementOnly,varyingInputParam" />
+    </properties>
+    <outputs>
+        <float4 name="BasisCurvesLinearColorDomain" />
+    </outputs>
+    <implementation  >
+        <implementation  render="OGSRenderer" language="GLSL" lang_version="3.000000" >
+            <function_name val="BasisCurvesLinearColorDomain" />
+            <source>
+                <![CDATA[
+vec4 BasisCurvesLinearColorDomain()
+{
+    float u = gl_TessCoord.y;
+    float v = gl_TessCoord.x;
+
+    vec4 c0 = DS_IN[0].UsdPrimvarColor;
+    vec4 c1 = DS_IN[1].UsdPrimvarColor;
+
+    return mix(c1, c0, u);
+}
+            ]]>
+            </source>
+        </implementation>
+        <implementation  render="OGSRenderer" language="HLSL" lang_version="11.000000" >
+            <function_name val="BasisCurvesLinearColorDomain" />
+            <source>
+                <![CDATA[
+float4 BasisCurvesLinearColorDomain(
+    hullConstantsOutS patchConstants,
+    hullOutS patch[4],
+    float2 domainCoord)
+{
+    float u = domainCoord.y;
+    float v = domainCoord.x;
+
+    float4 c0 = patch[0].UsdPrimvarColor;
+    float4 c1 = patch[1].UsdPrimvarColor;
+
+    return lerp(c1, c0, u);
+}
+                ]]>
+            </source>
+        </implementation>
+    </implementation>
+</fragment>

--- a/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesLinearDomain_GLSL.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesLinearDomain_GLSL.xml
@@ -55,12 +55,6 @@ limitations under the License.
             <function_name val="BasisCurvesLinearDomain" />
             <source>
                 <![CDATA[
-struct Coeffs
-{
-    vec4 basis;
-    vec4 tangent_basis;
-};
-
 // line 520 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
 
 vec3 evaluateNormal(float u)
@@ -78,25 +72,6 @@ vec3 evaluateNormal(float u)
         normal = vec3(0.0f, 0.0f, 1.0f);
     }
     return normal;
-}
-
-// line 676 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
-
-Coeffs evaluateBasis(float u, float u2, float u3)
-{
-    vec4 basis;
-    basis[0] = u3;
-    basis[1] = -3.0*u3 + 3.0*u2;
-    basis[2] = 3.0*u3 - 6.0*u2 + 3.0*u;
-    basis[3] = -1.0*u3 + 3.0*u2 - 3.0*u + 1.0;
-
-    vec4 tangent_basis;
-    tangent_basis[0] = 3.0*u2;
-    tangent_basis[1] = -9.0*u2 + 6.0*u;
-    tangent_basis[2] = 9.0*u2 - 12.0*u + 3.0;
-    tangent_basis[3] = -3.0*u2 + 6.0*u - 3.0;
-
-    return Coeffs(basis, tangent_basis);
 }
 
 void evaluate(float u, float v, out vec4 position, out vec4 tangent,
@@ -129,9 +104,6 @@ structDomain BasisCurvesLinearDomain()
 {
     float u = gl_TessCoord.y;
     float v = gl_TessCoord.x;
-
-    Coeffs coeffs = evaluateBasis(u, u*u, u*u*u);
-    vec4 basis = coeffs.basis;
 
     vec4 position;
     vec4 tangent;

--- a/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesLinearDomain_HLSL.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/BasisCurvesLinearDomain_HLSL.xml
@@ -55,12 +55,6 @@ limitations under the License.
             <function_name val="BasisCurvesLinearDomain" />
             <source>
                 <![CDATA[
-struct Coeffs
-{
-    float4 basis;
-    float4 tangent_basis;
-};
-
 // line 520 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
 
 float3 evaluateNormal(hullOutS patch[2], float u)
@@ -79,29 +73,6 @@ float3 evaluateNormal(hullOutS patch[2], float u)
     }
 
     return normal;
-}
-
-
-// line 676 ".../lib/usd/hdSt/resources/shaders/basisCurves.glslfx"
-
-Coeffs evaluateBasis(float u, float u2, float u3)
-{
-    float4 basis;
-    basis[0] = u3;
-    basis[1] = -3.0*u3 + 3.0*u2;
-    basis[2] = 3.0*u3 - 6.0*u2 + 3.0*u;
-    basis[3] = -1.0*u3 + 3.0*u2 - 3.0*u + 1.0;
-
-    float4 tangent_basis;
-    tangent_basis[0] = 3.0*u2;
-    tangent_basis[1] = -9.0*u2 + 6.0*u;
-    tangent_basis[2] = 9.0*u2 - 12.0*u + 3.0;
-    tangent_basis[3] = -3.0*u2 + 6.0*u - 3.0;
-
-    Coeffs outputS;
-    outputS.basis = basis;
-    outputS.tangent_basis = tangent_basis;
-    return outputS;
 }
 
 void evaluate(hullOutS patch[2],
@@ -141,9 +112,6 @@ structDomain BasisCurvesLinearDomain(
 
     float u = domainCoord.y;
     float v = domainCoord.x;
-
-    Coeffs coeffs = evaluateBasis(u, u*u, u*u*u);
-    float4 basis = coeffs.basis;
 
     float4 position;
     float4 tangent;

--- a/lib/mayaUsd/render/vp2ShaderFragments/CMakeLists.txt
+++ b/lib/mayaUsd/render/vp2ShaderFragments/CMakeLists.txt
@@ -24,21 +24,30 @@ list(APPEND SHADERFRAGMENTS_XMLS
     usdPreviewSurfaceCombiner.xml
     usdPreviewSurfaceLighting.xml
     # New fragments
-    BasisCurvesLinearDomain_GLSL.xml
-    BasisCurvesLinearDomain_HLSL.xml
-    BasisCurvesLinearDomain_Cg.xml
-    BasisCurvesLinearFallbackShader.xml
-    BasisCurvesLinearHull.xml
+    BasisCurvesCubicColorDomain.xml
+    BasisCurvesCubicCPVHull.xml
+    BasisCurvesCubicCPVPassing.xml
+    BasisCurvesCubicCPVShader.xml
     BasisCurvesCubicDomain_GLSL.xml
     BasisCurvesCubicDomain_HLSL.xml
     BasisCurvesCubicDomain_Cg.xml
     BasisCurvesCubicFallbackShader.xml
     BasisCurvesCubicHull.xml
+    BasisCurvesLinearColorDomain.xml
+    BasisCurvesLinearCPVHull.xml
+    BasisCurvesLinearCPVPassing.xml
+    BasisCurvesLinearCPVShader.xml
+    BasisCurvesLinearDomain_GLSL.xml
+    BasisCurvesLinearDomain_HLSL.xml
+    BasisCurvesLinearDomain_Cg.xml
+    BasisCurvesLinearFallbackShader.xml
+    BasisCurvesLinearHull.xml
     FallbackCPVShader.xml
     FallbackShader.xml
     Float4ToFloat3.xml
     Float4ToFloat4.xml
     NwFaceCameraIfNAN.xml
+    UsdPrimvarColor.xml
     UsdPrimvarReader_color.xml
     UsdPrimvarReader_float.xml
     UsdPrimvarReader_float2.xml

--- a/lib/mayaUsd/render/vp2ShaderFragments/UsdPrimvarColor.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/UsdPrimvarColor.xml
@@ -1,0 +1,87 @@
+<!--
+========================================================================
+Copyright 2020 Autodesk
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+========================================================================
+-->
+<fragment  uiName="UsdPrimvarColor" name="UsdPrimvarColor" type="interpolant" class="ShadeFragment" version="1.0" feature_level="0" >
+    <description>
+        <![CDATA[Interpolant fragment for USD primvars:displayColor and primvars:displayOpacity]]>
+    </description>
+    <properties>
+        <float4 name="UsdPrimvarColor" semantic="fcolor" flags="varyingInputParam" />
+    </properties>
+    <outputs>
+        <float4 name="UsdPrimvarColor" />
+    </outputs>
+    <implementation  >
+        <implementation  render="OGSRenderer" language="GLSL" lang_version="3.000000" >
+            <function_name val="UsdPrimvarColor" />
+            <source>
+                <![CDATA[
+vec4 UsdPrimvarColor(vec4 inColor)
+{
+    return inColor;
+}
+                ]]>
+            </source>
+            <vertex_source>
+                <![CDATA[
+vec4 iUsdPrimvarColor(vec4 inColor)
+{
+    return inColor;
+}
+                ]]>
+            </vertex_source>
+        </implementation>
+        <implementation  render="OGSRenderer" language="HLSL" lang_version="11.000000" >
+            <function_name val="UsdPrimvarColor" />
+            <source>
+                <![CDATA[
+float4 UsdPrimvarColor(float4 inColor)
+{
+    return inColor;
+}
+                ]]>
+            </source>
+            <vertex_source>
+                <![CDATA[
+float4 iUsdPrimvarColor(float4 inColor)
+{
+    return inColor;
+}
+                ]]>
+            </vertex_source>
+        </implementation>
+        <implementation  render="OGSRenderer" language="Cg" lang_version="2.100000" >
+            <function_name val="UsdPrimvarColor" />
+            <source>
+                <![CDATA[
+float4 UsdPrimvarColor(float4 inColor)
+{
+    return inColor;
+}
+                ]]>
+            </source>
+            <vertex_source>
+                <![CDATA[
+float4 iUsdPrimvarColor(float4 inColor)
+{
+    return inColor;
+}
+                ]]>
+            </vertex_source>
+        </implementation>
+    </implementation>
+</fragment>


### PR DESCRIPTION
* Supported CPV for basisCurves complexity level 1
* Supported curve basis functions (including Bezier, BSpline and CatmullRom) for cubic basisCurves complexity level 1.
* Disabled complexity level 1 drawing for basisCurves on Maya 2018/2019/2020 because the necessary Maya API to allow plug-ins to build a complete tessellation shader graphs are not included in those releases.
