### PR TITLE
disable shadows on the directionalLight in the Maya scene for the testProxyShapeDrawColorAccuracy test

### DIFF
--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/ProxyShapeDrawColorAccuracyTest/ProxyShapeDrawColorAccuracyTest.ma
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/ProxyShapeDrawColorAccuracyTest/ProxyShapeDrawColorAccuracyTest.ma
@@ -105,6 +105,7 @@ createNode transform -n "directionalLight1";
 createNode directionalLight -n "directionalLightShape1" -p "directionalLight1";
 	rename -uid "6A99C900-0000-28A9-5AB9-7ECF00000267";
 	setAttr -k off ".v";
+	setAttr ".urs" no;
 createNode lightLinker -s -n "lightLinker1";
 	rename -uid "24A938C0-0000-731D-5A94-5B170000022C";
 	setAttr -s 2 ".lnk";


### PR DESCRIPTION
This is intended to address #265.

The Storm-based Pixar batch renderer (poorly) supports depth map shadows but not ray-traced shadows, while the Viewport 2.0 render delegate supports both. The `directionalLight` in the Maya scene for the `testProxyShapeDrawColorAccuracy` test was set to use ray-traced shadows (which is the default). This meant that the "all_lights" image written by the test would not include shadows when run with the Pixar batch renderer, but it would include a very noisy shadow when run with the Viewport 2.0 render delegate, since the geometry is just a very simple cube.

Shadows are not important in the functionality being exercised by this test, so this change simply disables shadows on the `directionalLight`.