### PR TITLE
update baseline USD file for testUsdExportSkeleton test following #822

### DIFF
--- a/test/lib/usd/translators/UsdExportSkeletonTest/baseline/UsdExportSkeletonWithoutBindPose.usda
+++ b/test/lib/usd/translators/UsdExportSkeletonTest/baseline/UsdExportSkeletonWithoutBindPose.usda
@@ -36,16 +36,6 @@ def SkelRoot "cubeRig" (
                 4: [(3.25, 3.25, 0.5), (4.25, 3.25, 0.5), (3.25, 4.25, 0.5), (4.25, 4.25, 0.5), (3.25, 4.25, -0.5), (4.25, 4.25, -0.5), (3.25, 3.25, -0.5), (4.25, 3.25, -0.5)],
                 5: [(4.5, 4.5, 0.5), (5.5, 4.5, 0.5), (4.5, 5.5, 0.5), (5.5, 5.5, 0.5), (4.5, 5.5, -0.5), (5.5, 5.5, -0.5), (4.5, 4.5, -0.5), (5.5, 4.5, -0.5)],
             }
-            color3f[] primvars:displayColor (
-                customData = {
-                    dictionary Maya = {
-                        bool generated = 1
-                    }
-                }
-            )
-            color3f[] primvars:displayColor.timeSamples = {
-                1: [(0.13320851, 0.13320851, 0.13320851)],
-            }
             texCoord2f[] primvars:st (
                 interpolation = "faceVarying"
             )


### PR DESCRIPTION
Internally, we have a post-process to the `testUsdExportSkeleton` test that diffs the generated USD against this baseline. Following the merge of PR #822, the test began to fail since `displayColor` was no longer being exported with `shadingMode=none`.