### PR TITLE
enable exportDisplayColor in testUsdExportRenderLayerMode test following #822

### DIFF
--- a/test/lib/usd/translators/testUsdExportRenderLayerMode.py
+++ b/test/lib/usd/translators/testUsdExportRenderLayerMode.py
@@ -70,7 +70,8 @@ class testUsdExportRenderLayerMode(unittest.TestCase):
 
         # Export to USD.
         cmds.usdExport(mergeTransformAndShape=True, file=usdFilePath,
-            shadingMode='none', renderLayerMode=renderLayerMode, **kwargs)
+            shadingMode='none', exportDisplayColor=True,
+            renderLayerMode=renderLayerMode, **kwargs)
 
         stage = Usd.Stage.Open(usdFilePath)
         self.assertTrue(stage)


### PR DESCRIPTION
Internally, we still run the `testUsdExportRenderLayerMode` test with `MAYA_ENABLE_LEGACY_RENDER_LAYERS` turned on. The test began failing following the merge of PR #822 since `displayColor` was no longer being exported. This change gets the test passing again by turning on the `exportDisplayColor` when calling `cmds.usdExport()`.