### PR TITLE
enable exportDisplayColor in testProxyShapeDrawColors test following #822

### DIFF
--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawColors.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawColors.py
@@ -72,7 +72,8 @@ class testProxyShapeDrawColors(unittest.TestCase):
         x = self._PlaneWithColor((0.55, 0.55, 0.55))
         cmds.select(x)
         usdFile = os.path.join(self._testDir, 'plane.usd')
-        cmds.mayaUSDExport(file=usdFile, selection=True, shadingMode='displayColor')
+        cmds.mayaUSDExport(file=usdFile, selection=True, shadingMode='none',
+            exportDisplayColor=True)
         proxyShape = cmds.createNode('mayaUsdProxyShape', name='usdProxyShape')
         proxyTransform = cmds.listRelatives(proxyShape, parent=True,
             fullPath=True)[0]


### PR DESCRIPTION
Internally, we have a post-process to the `testProxyShapeDrawColors` test that diffs a render generated from the viewport against a baseline. Following the merge of PR #822, the test began to fail since `displayColor` was no longer being exported, so the color represented in the image was different. This change turns on the `exportDisplayColor` option to `cmds.usdExport()` so that `displayColor` is present in the exported USD, and the rendered image matches the baseline again.