### PR TITLE
Absence of scale pivot support is not an error.

### DIFF
--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -269,7 +269,7 @@ Ufe::Vector3d UsdTransform3d::rotatePivot() const
 //#ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::scalePivotCmd(double, double, double)
 {
-    throw std::runtime_error("UsdTransform3d::scalePivotCmd() not implemented");
+    return nullptr;
 }
 
 void UsdTransform3d::scalePivot(double x, double y, double z)


### PR DESCRIPTION
Previously, attempting to create an undoable command to set the scale pivot was an error, as Maya would never ask for such a capability.  With UFE 0.2.25 support, it does, and run-times that don't support a separate scale pivot must return a null command.