### PR TITLE
add translation support between lambert transparency and UsdPreviewSurface opacity

### DIFF
--- a/lib/usd/translators/shading/usdLambertReader.cpp
+++ b/lib/usd/translators/shading/usdLambertReader.cpp
@@ -22,6 +22,7 @@
 #include <mayaUsd/fileio/utils/readUtil.h>
 #include <mayaUsd/utils/util.h>
 
+#include <pxr/base/gf/vec3f.h>
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/base/tf/staticTokens.h>
 #include <pxr/base/tf/token.h>
@@ -53,6 +54,7 @@ TF_DEFINE_PRIVATE_TOKENS(
 
     // Maya material nodes attribute names
     (color)
+    (transparency)
     (incandescence)
     (normalCamera)
 );
@@ -95,6 +97,21 @@ void PxrUsdTranslators_LambertReader::_OnBeforeReadAttribute(
     }
 }
 
+/* override */
+void
+PxrUsdTranslators_LambertReader::_ConvertToMaya(
+        const TfToken& mayaAttrName,
+        VtValue& usdValue) const
+{
+    if (mayaAttrName == _tokens->transparency && usdValue.IsHolding<float>()) {
+        const float opacity = usdValue.UncheckedGet<float>();
+        usdValue = GfVec3f(1.0f - opacity);
+        return;
+    }
+
+    PxrUsdTranslators_MaterialReader::_ConvertToMaya(mayaAttrName, usdValue);
+}
+
 /* virtual */
 TfToken PxrUsdTranslators_LambertReader::GetMayaNameForUsdAttrName(const TfToken& usdAttrName) const
 {
@@ -105,6 +122,8 @@ TfToken PxrUsdTranslators_LambertReader::GetMayaNameForUsdAttrName(const TfToken
     if (attrType == UsdShadeAttributeType::Input) {
         if (usdInputName == PxrMayaUsdPreviewSurfaceTokens->DiffuseColorAttrName) {
             return _tokens->color;
+        } else if (usdInputName == PxrMayaUsdPreviewSurfaceTokens->OpacityAttrName) {
+            return _tokens->transparency;
         } else if (usdInputName == PxrMayaUsdPreviewSurfaceTokens->EmissiveColorAttrName) {
             return _tokens->incandescence;
         } else if (usdInputName == PxrMayaUsdPreviewSurfaceTokens->NormalAttrName) {

--- a/lib/usd/translators/shading/usdLambertReader.h
+++ b/lib/usd/translators/shading/usdLambertReader.h
@@ -20,6 +20,8 @@
 
 #include "usdMaterialReader.h"
 
+#include <pxr/base/tf/token.h>
+#include <pxr/base/vt/value.h>
 #include <pxr/pxr.h>
 
 #include <maya/MFnDependencyNode.h>
@@ -47,6 +49,10 @@ protected:
     /// setting back values in \p shaderFn that were lost during the export phase.
     void
     _OnBeforeReadAttribute(const TfToken& mayaAttrName, MFnDependencyNode& shaderFn) const override;
+
+    /// Convert the value in \p usdValue from USD back to Maya following rules
+    /// for attribute \p mayaAttrName
+    void _ConvertToMaya(const TfToken& mayaAttrName, VtValue& usdValue) const override;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
We have some internal test cases that were previously using the `displayColor` shadingMode, and in switching them over to use the new round robin-style shadingMode handling from #822 instead, I noticed that `lambert` shaders were not having their `transparency` attribute properly round-tripped out to USD as `opacity` and then back.

We could definitely use some better unit testing in this area, but I wanted to get the fix for this up sooner than later.