### PR TITLE
fix import of "useSpecularWorkflow" input on UsdPreviewSurface shaders

### DIFF
--- a/lib/usd/pxrUsdPreviewSurface/usdPreviewSurfaceReader.cpp
+++ b/lib/usd/pxrUsdPreviewSurface/usdPreviewSurfaceReader.cpp
@@ -95,7 +95,28 @@ bool PxrMayaUsdPreviewSurface_Reader::Read(UsdMayaPrimReaderContext* context)
         if (status != MS::kSuccess) {
             continue;
         }
-        UsdMayaReadUtil::SetMayaAttr(mayaAttr, input, /*unlinearizeColors*/ false);
+
+        VtValue inputVal;
+        if (!input.GetAttr().Get(&inputVal)) {
+            continue;
+        }
+
+        // "useSpecularWorkflow" is an int in USD, but a boolean in Maya.
+        if (baseName == PxrMayaUsdPreviewSurfaceTokens->UseSpecularWorkflowAttrName &&
+                inputVal.IsHolding<int>()) {
+            inputVal = (inputVal.UncheckedGet<int>() == 0) ?
+                false :
+                true;
+        }
+
+        if (UsdMayaReadUtil::SetMayaAttr(
+                mayaAttr,
+                inputVal,
+                /* unlinearizeColors = */ false)) {
+            UsdMayaReadUtil::SetMayaAttrKeyableState(
+                mayaAttr,
+                input.GetAttr().GetVariability());
+        }
     }
 
     return true;

--- a/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
+++ b/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
@@ -67,6 +67,7 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
         cmds.setAttr(material_node + ".roughness", 0.25)
         cmds.setAttr(material_node + ".specularColor", 0.125, 0.25, 0.75,
                      type="double3")
+        cmds.setAttr(material_node + ".useSpecularWorkflow", True)
 
         file_node = cmds.shadingNode("file", asTexture=True,
                                      isColorManaged=True)
@@ -131,6 +132,7 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
                                0.25)
         self.assertEqual(cmds.getAttr("usdPreviewSurface2.specularColor"),
                          [(0.125, 0.25, 0.75)])
+        self.assertTrue(cmds.getAttr("usdPreviewSurface2.useSpecularWorkflow"))
         self.assertEqual(cmds.getAttr("file2.defaultColor"),
                          [(0.5, 0.25, 0.125)])
         original_path = cmds.getAttr(file_node+".fileTextureName")


### PR DESCRIPTION
`useSpecularWorkflow` is an int-typed input attribute in USD, but it's a boolean attribute in Maya, so the value needs to be type-converted during import. The conversion was already being done for export.