### PR TITLE
Devtoolset-9 fixes

### DIFF
--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
@@ -579,7 +579,7 @@ UsdMayaMeshWriteUtils::exportReferenceMesh(UsdGeomMesh& primSchema, MObject obj)
     const int numVertices = referenceMesh.numVertices();
     VtVec3fArray points(numVertices);
 
-    memcpy(points.data(), mayaRawPoints, numVertices * sizeof(float) * 3);
+    memcpy((void*)points.data(), mayaRawPoints, numVertices * sizeof(float) * 3);
 
     UsdGeomPrimvar primVar = primSchema.CreatePrimvar(
         UsdUtilsGetPrefName(),
@@ -687,7 +687,7 @@ UsdMayaMeshWriteUtils::writePointsData(const MFnMesh& meshFn,
     }
 
     // use memcpy() to copy the data. HS April 09, 2020
-    memcpy((GfVec3f*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
+    memcpy((void*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
 
     VtVec3fArray extent(2);
     // Compute the extent using the raw points

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/test_translators_NurbsCurveTranslator.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/test_translators_NurbsCurveTranslator.cpp
@@ -54,28 +54,15 @@ MObject createNurbStage(bool useSingleWidth=false)
   VtArray<int32_t> curveVertextCounts;
   curveVertextCounts.push_back(5);
 
-  std::array<double, 7> knotsa = {0., 0., 0., 1., 2., 2., 2.};
-  VtDoubleArray knots = VtDoubleArray(7);
-  memcpy(knots.data(), &knotsa, sizeof(double)*7);
+  VtDoubleArray knots = VtDoubleArray{0., 0., 0., 1., 2., 2., 2.};
 
-  std::vector<std::array<float, 3>> pointsa = { {-1.5079714f, 44.28195f, 5.781988f},
+  VtVec3fArray points = VtVec3fArray{ {-1.5079714f, 44.28195f, 5.781988f},
                             {-1.5784601f, 44.300205f, 5.813314f},
                             {-2.4803247f, 44.201904f, 6.2143235f},
                             {-3.9173129f, 43.33975f, 6.475575f},
                             {-5.2281976f, 42.145287f, 6.6371536f} };
-  VtVec3fArray points = VtVec3fArray(5);
-  for(uint32_t i = 0 ; i< pointsa.size(); ++i)
-  {
-    memcpy((void*)&points[i], &pointsa[i], 3*sizeof(float));
-  }
 
-  std::vector<std::array<double,2> > rangesa = {{0.,2.}};
-  VtVec2dArray ranges = VtVec2dArray(2);
-
-  for(uint32_t i = 0 ; i< rangesa.size(); ++i)
-  {
-    memcpy((void*)&ranges[i], &rangesa[i], 2*sizeof(double));
-  }
+  VtVec2dArray ranges = VtVec2dArray{{0.,2.}};
 
   if(useSingleWidth)
   {

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/test_translators_NurbsCurveTranslator.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/test_translators_NurbsCurveTranslator.cpp
@@ -66,7 +66,7 @@ MObject createNurbStage(bool useSingleWidth=false)
   VtVec3fArray points = VtVec3fArray(5);
   for(uint32_t i = 0 ; i< pointsa.size(); ++i)
   {
-    memcpy(&points[i], &pointsa[i], 3*sizeof(float));
+    memcpy((void*)&points[i], &pointsa[i], 3*sizeof(float));
   }
 
   std::vector<std::array<double,2> > rangesa = {{0.,2.}};
@@ -74,7 +74,7 @@ MObject createNurbStage(bool useSingleWidth=false)
 
   for(uint32_t i = 0 ; i< rangesa.size(); ++i)
   {
-    memcpy(&ranges[i], &rangesa[i], 2*sizeof(double));
+    memcpy((void*)&ranges[i], &rangesa[i], 2*sizeof(double));
   }
 
   if(useSingleWidth)

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/DgNodeHelper.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/DgNodeHelper.cpp
@@ -705,7 +705,7 @@ MStatus DgNodeHelper::setMatrix4x4Array(MObject node, MObject attribute, const d
     MStatus status;
     MMatrixArray arrayData;
     arrayData.setLength(count);
-    memcpy((void*)&arrayData[0], values, sizeof(MMatrix) * count);
+    memcpy(arrayData[0][0], values, sizeof(MMatrix) * count);
 
     MFnMatrixArrayData fn;
     MObject data = fn.create(arrayData, &status);

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/DgNodeHelper.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/DgNodeHelper.cpp
@@ -705,7 +705,7 @@ MStatus DgNodeHelper::setMatrix4x4Array(MObject node, MObject attribute, const d
     MStatus status;
     MMatrixArray arrayData;
     arrayData.setLength(count);
-    memcpy(&arrayData[0], values, sizeof(MMatrix) * count);
+    memcpy((void*)&arrayData[0], values, sizeof(MMatrix) * count);
 
     MFnMatrixArrayData fn;
     MObject data = fn.create(arrayData, &status);

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/DiffPrimVar.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/DiffPrimVar.cpp
@@ -64,7 +64,7 @@ uint32_t diffGeom(UsdGeomPointBased& geom, MFnMesh& mesh, UsdTimeCode timeCode, 
     {
       const uint32_t numVertices = mesh.numVertices();
       VtArray<GfVec3f> points(numVertices);
-      memcpy((GfVec3f*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
+      memcpy((void*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
 
       VtArray<GfVec3f> mayaExtent(2);
       UsdGeomPointBased::ComputeExtent(points, &mayaExtent);

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/DiffPrimVar.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/DiffPrimVar.cpp
@@ -63,8 +63,8 @@ uint32_t diffGeom(UsdGeomPointBased& geom, MFnMesh& mesh, UsdTimeCode timeCode, 
     if(status)
     {
       const uint32_t numVertices = mesh.numVertices();
-      VtArray<GfVec3f> points(numVertices);
-      memcpy((void*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
+      const GfVec3f* vecData = reinterpret_cast<const GfVec3f*>(pointsData);
+      VtArray<GfVec3f> points(vecData, vecData + numVertices);
 
       VtArray<GfVec3f> mayaExtent(2);
       UsdGeomPointBased::ComputeExtent(points, &mayaExtent);

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
@@ -844,7 +844,7 @@ void MeshImportContext::applyColourSetData()
           {
             const VtArray<GfVec4f> rawVal = vtValue.UncheckedGet<VtArray<GfVec4f> >();
             colours.setLength(rawVal.size());
-            memcpy((void*)&colours[0], (const float*) rawVal.cdata(), sizeof(float) * 4 * rawVal.size());
+            memcpy(&colours[0][0], (const float*) rawVal.cdata(), sizeof(float) * 4 * rawVal.size());
             representation = MFnMesh::kRGBA;
           }
         
@@ -1986,12 +1986,11 @@ void MeshExportContext::copyVertexData(UsdTimeCode time)
     {
       MStatus status;
       const uint32_t numVertices = fnMesh.numVertices();
-      VtArray<GfVec3f> points(numVertices);
       const float* pointsData = fnMesh.getRawPoints(&status);
       if(status)
       {
-        memcpy((void*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
-
+        const GfVec3f* vecData = reinterpret_cast<const GfVec3f*>(pointsData);
+        VtArray<GfVec3f> points(vecData, vecData + numVertices);
         pointsAttr.Set(points, time);
       }
       else
@@ -2013,9 +2012,9 @@ void MeshExportContext::copyExtentData(UsdTimeCode time)
       const float* pointsData = fnMesh.getRawPoints(&status);
       if(status)
       {
+        const GfVec3f* vecData = reinterpret_cast<const GfVec3f*>(pointsData);
         const uint32_t numVertices = fnMesh.numVertices();
-        VtArray<GfVec3f> points(numVertices);
-        memcpy((void*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
+        VtArray<GfVec3f> points(vecData, vecData + numVertices);
 
         VtArray<GfVec3f> extent(2);
         UsdGeomPointBased::ComputeExtent(points, &extent);
@@ -2044,11 +2043,11 @@ void MeshExportContext::copyBindPoseData(UsdTimeCode time)
     {
       MStatus status;
       const uint32_t numVertices = fnMesh.numVertices();
-      VtArray<GfVec3f> points(numVertices);
       const float* pointsData = fnMesh.getRawPoints(&status);
       if(status)
       {
-        memcpy((void*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
+        const GfVec3f* vecData = reinterpret_cast<const GfVec3f*>(pointsData);
+        VtArray<GfVec3f> points(vecData, vecData + numVertices);
 
         pRefPrimVarAttr.Set(points, time);
       }
@@ -2084,6 +2083,7 @@ void MeshExportContext::copyNormalData(UsdTimeCode time, bool copyAsPrimvar)
       MStatus status;
       const uint32_t numNormals = fnMesh.numNormals();
       const float* normalsData = fnMesh.getRawNormals(&status);
+      const GfVec3f* vecData = reinterpret_cast<const GfVec3f*>(normalsData);
       if(status && numNormals)
       {
         MIntArray normalCounts, normalIndices;
@@ -2111,7 +2111,6 @@ void MeshExportContext::copyNormalData(UsdTimeCode time, bool copyAsPrimvar)
         {
           if(MayaUsdUtils::compareArray(&normalIndices[0], &faceConnects[0], normalIndices.length(), faceConnects.length()))
           {
-            VtArray<GfVec3f> normals(numNormals);
             if(copyAsPrimvar)
             {
               primvar.SetInterpolation(UsdGeomTokens->vertex);
@@ -2121,7 +2120,7 @@ void MeshExportContext::copyNormalData(UsdTimeCode time, bool copyAsPrimvar)
               mesh.SetNormalsInterpolation(UsdGeomTokens->vertex);
             }
 
-            memcpy((void*)normals.data(), normalsData, sizeof(float) * 3 * numNormals);
+            VtArray<GfVec3f> normals(vecData, vecData + numNormals);
             normalsAttr.Set(normals, time);
           }
           else
@@ -2147,8 +2146,7 @@ void MeshExportContext::copyNormalData(UsdTimeCode time, bool copyAsPrimvar)
 
             if(isPerVertex)
             {
-              VtArray<GfVec3f> normals(numNormals);
-              memcpy((void*)normals.data(), normalsData, sizeof(float) * 3 * numNormals);
+              VtArray<GfVec3f> normals(vecData, vecData + numNormals);
               for(auto& c : missing)
               {
                 const uint32_t orig = c.first;
@@ -2219,8 +2217,7 @@ void MeshExportContext::copyNormalData(UsdTimeCode time, bool copyAsPrimvar)
             {
               mesh.SetNormalsInterpolation(UsdGeomTokens->faceVarying);
             }
-            VtArray<GfVec3f> normals(numNormals);
-            memcpy((void*)normals.data(), normalsData, sizeof(float) * 3 * numNormals);
+            VtArray<GfVec3f> normals(vecData, vecData + numNormals);
             normalsAttr.Set(normals, time);
           }
           else

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
@@ -844,7 +844,7 @@ void MeshImportContext::applyColourSetData()
           {
             const VtArray<GfVec4f> rawVal = vtValue.UncheckedGet<VtArray<GfVec4f> >();
             colours.setLength(rawVal.size());
-            memcpy(&colours[0], (const float*) rawVal.cdata(), sizeof(float) * 4 * rawVal.size());
+            memcpy((void*)&colours[0], (const float*) rawVal.cdata(), sizeof(float) * 4 * rawVal.size());
             representation = MFnMesh::kRGBA;
           }
         
@@ -1990,7 +1990,7 @@ void MeshExportContext::copyVertexData(UsdTimeCode time)
       const float* pointsData = fnMesh.getRawPoints(&status);
       if(status)
       {
-        memcpy((GfVec3f*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
+        memcpy((void*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
 
         pointsAttr.Set(points, time);
       }
@@ -2015,7 +2015,7 @@ void MeshExportContext::copyExtentData(UsdTimeCode time)
       {
         const uint32_t numVertices = fnMesh.numVertices();
         VtArray<GfVec3f> points(numVertices);
-        memcpy((GfVec3f*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
+        memcpy((void*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
 
         VtArray<GfVec3f> extent(2);
         UsdGeomPointBased::ComputeExtent(points, &extent);
@@ -2048,7 +2048,7 @@ void MeshExportContext::copyBindPoseData(UsdTimeCode time)
       const float* pointsData = fnMesh.getRawPoints(&status);
       if(status)
       {
-        memcpy((GfVec3f*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
+        memcpy((void*)points.data(), pointsData, sizeof(float) * 3 * numVertices);
 
         pRefPrimVarAttr.Set(points, time);
       }
@@ -2121,7 +2121,7 @@ void MeshExportContext::copyNormalData(UsdTimeCode time, bool copyAsPrimvar)
               mesh.SetNormalsInterpolation(UsdGeomTokens->vertex);
             }
 
-            memcpy((GfVec3f*)normals.data(), normalsData, sizeof(float) * 3 * numNormals);
+            memcpy((void*)normals.data(), normalsData, sizeof(float) * 3 * numNormals);
             normalsAttr.Set(normals, time);
           }
           else
@@ -2148,7 +2148,7 @@ void MeshExportContext::copyNormalData(UsdTimeCode time, bool copyAsPrimvar)
             if(isPerVertex)
             {
               VtArray<GfVec3f> normals(numNormals);
-              memcpy((GfVec3f*)normals.data(), normalsData, sizeof(float) * 3 * numNormals);
+              memcpy((void*)normals.data(), normalsData, sizeof(float) * 3 * numNormals);
               for(auto& c : missing)
               {
                 const uint32_t orig = c.first;
@@ -2220,7 +2220,7 @@ void MeshExportContext::copyNormalData(UsdTimeCode time, bool copyAsPrimvar)
               mesh.SetNormalsInterpolation(UsdGeomTokens->faceVarying);
             }
             VtArray<GfVec3f> normals(numNormals);
-            memcpy((GfVec3f*)normals.data(), normalsData, sizeof(float) * 3 * numNormals);
+            memcpy((void*)normals.data(), normalsData, sizeof(float) * 3 * numNormals);
             normalsAttr.Set(normals, time);
           }
           else


### PR DESCRIPTION
GCC 9 will warn if using memcopy to overwrite the memory area of a non-POD class. The warning is correct, but in these cases, we know that these classes are POD so we can proceed and indicate the intent with a void* cast.