### PR TITLE
author UsdPreviewSurface "normal" input using Normal3f type name

### DIFF
--- a/lib/usd/translators/shading/usdLambertWriter.cpp
+++ b/lib/usd/translators/shading/usdLambertWriter.cpp
@@ -23,6 +23,7 @@
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/base/tf/staticTokens.h>
 #include <pxr/base/tf/token.h>
+#include <pxr/usd/sdf/valueTypeName.h>
 #include <pxr/usd/usdShade/shader.h>
 #include <pxr/usd/usdShade/tokens.h>
 
@@ -123,7 +124,8 @@ void PxrUsdTranslators_LambertWriter::Write(const UsdTimeCode& usdTime)
         _tokens->normalCamera,
         shaderSchema,
         PxrMayaUsdPreviewSurfaceTokens->NormalAttrName,
-        usdTime);
+        usdTime,
+        /* inputTypeName = */ SdfValueTypeNames->Normal3f);
 
     WriteSpecular(usdTime);
 }

--- a/lib/usd/translators/shading/usdMaterialWriter.cpp
+++ b/lib/usd/translators/shading/usdMaterialWriter.cpp
@@ -109,11 +109,17 @@ PxrUsdTranslators_MaterialWriter::AuthorShaderInputFromShadingNodeAttr(
         const TfToken& shadingNodeAttrName,
         UsdShadeShader& shaderSchema,
         const TfToken& shaderInputName,
-        const UsdTimeCode usdTime)
+        const UsdTimeCode usdTime,
+        const SdfValueTypeName& inputTypeName)
 {
     return AuthorShaderInputFromScaledShadingNodeAttr(
-        depNodeFn, shadingNodeAttrName, shaderSchema, shaderInputName,
-        usdTime, TfToken());
+        depNodeFn,
+        shadingNodeAttrName,
+        shaderSchema,
+        shaderInputName,
+        usdTime,
+        TfToken(),
+        inputTypeName);
 }
 
 bool
@@ -123,7 +129,8 @@ PxrUsdTranslators_MaterialWriter::AuthorShaderInputFromScaledShadingNodeAttr(
         UsdShadeShader& shaderSchema,
         const TfToken& shaderInputName,
         const UsdTimeCode usdTime,
-        const TfToken& scalingAttrName)
+        const TfToken& scalingAttrName,
+        const SdfValueTypeName& inputTypeName)
 {
     MStatus status;
 
@@ -141,7 +148,10 @@ PxrUsdTranslators_MaterialWriter::AuthorShaderInputFromScaledShadingNodeAttr(
         return false;
     }
 
-    auto shaderInputTypeName = Converter::getUsdTypeName(shadingNodePlug);
+    const SdfValueTypeName shaderInputTypeName =
+        bool(inputTypeName) ?
+            inputTypeName :
+            Converter::getUsdTypeName(shadingNodePlug);
 
     // Are color values are all linear on the shader?
     // Do we need to re-linearize them?

--- a/lib/usd/translators/shading/usdMaterialWriter.h
+++ b/lib/usd/translators/shading/usdMaterialWriter.h
@@ -21,6 +21,7 @@
 #include <mayaUsd/fileio/shaderWriter.h>
 
 #include <pxr/pxr.h>
+#include <pxr/usd/sdf/valueTypeName.h>
 
 #include <maya/MFnDependencyNode.h>
 
@@ -50,12 +51,20 @@ class PxrUsdTranslators_MaterialWriter : public UsdMayaShaderWriter
         /// Maya attribute \p shadingNodeAttrName in dependency node \p depNodeFn has been modified
         /// or has an incoming connection at \p usdTime.
         ///
+        /// If a specific SdfValueTypeName is desired for the created
+        /// UsdShadeInput, it can be provided with the optional
+        /// \p inputTypeName parameter. This is useful in cases where the role
+        /// of the value type name may not be discoverable strictly from
+        /// inspecting the Maya attribute plug (for example, determining that
+        /// the "normalCamera" attributes of Maya shaders should be exported as
+        /// Normal3f rather than just Float3).
         bool AuthorShaderInputFromShadingNodeAttr(
                 const MFnDependencyNode& depNodeFn,
                 const TfToken& shadingNodeAttrName,
                 UsdShadeShader& shaderSchema,
                 const TfToken& shaderInputName,
-                const UsdTimeCode usdTime);
+                const UsdTimeCode usdTime,
+                const SdfValueTypeName& inputTypeName = SdfValueTypeName());
 
         /// Same as AuthorShaderInputFromShadingNodeAttr, but allows scaling the value using a float
         /// value found in the attribute \p scalingAttrName of the dependency node \p depNodeFn.
@@ -66,7 +75,8 @@ class PxrUsdTranslators_MaterialWriter : public UsdMayaShaderWriter
                 UsdShadeShader& shaderSchema,
                 const TfToken& shaderInputName,
                 const UsdTimeCode usdTime,
-                const TfToken& scalingAttrName);
+                const TfToken& scalingAttrName,
+                const SdfValueTypeName& inputTypeName = SdfValueTypeName());
 
 };
 

--- a/lib/usd/translators/shading/usdStandardSurfaceWriter.cpp
+++ b/lib/usd/translators/shading/usdStandardSurfaceWriter.cpp
@@ -196,7 +196,8 @@ void PxrUsdTranslators_StandardSurfaceWriter::Write(const UsdTimeCode& usdTime)
         _tokens->normalCamera,
         shaderSchema,
         PxrMayaUsdPreviewSurfaceTokens->NormalAttrName,
-        usdTime);
+        usdTime,
+        /* inputTypeName = */ SdfValueTypeNames->Normal3f);
 }
 
 /* virtual */


### PR DESCRIPTION
These changes ensure that the `normal` shader input written by the lambert and standardSurface (and descendant) shader writers use the `Normal3f` type name when creating and authoring the input rather than just `Float3`. The existing call to `Converter::getUsdTypeName()` is not able to determine the role aspect of the type name from simply inspecting the Maya attribute plug, so an optional `inputTypeName` parameter was added to `AuthorShaderInputFromShadingNodeAttr()` and `AuthorShaderInputFromScaledShadingNodeAttr()` to handle cases like that.