### PR TITLE
export lambert and descendants more sparsely

### DIFF
--- a/lib/usd/translators/shading/usdLambertWriter.cpp
+++ b/lib/usd/translators/shading/usdLambertWriter.cpp
@@ -28,6 +28,7 @@
 #include <pxr/usd/usdShade/tokens.h>
 
 #include <maya/MFnDependencyNode.h>
+#include <maya/MPlug.h>
 #include <maya/MStatus.h>
 
 #include <basePxrUsdPreviewSurface/usdPreviewSurface.h>
@@ -111,12 +112,15 @@ void PxrUsdTranslators_LambertWriter::Write(const UsdTimeCode& usdTime)
         }
     }
 
+    // Since incandescence in Maya and emissiveColor in UsdPreviewSurface are
+    // both black by default, only author it in USD if it is authored in Maya.
     AuthorShaderInputFromShadingNodeAttr(
         depNodeFn,
         _tokens->incandescence,
         shaderSchema,
         PxrMayaUsdPreviewSurfaceTokens->EmissiveColorAttrName,
-        usdTime);
+        usdTime,
+        /* ignoreIfUnauthored = */ true);
 
     // Exported, but unsupported in hdStorm.
     AuthorShaderInputFromShadingNodeAttr(

--- a/lib/usd/translators/shading/usdLambertWriter.cpp
+++ b/lib/usd/translators/shading/usdLambertWriter.cpp
@@ -125,6 +125,7 @@ void PxrUsdTranslators_LambertWriter::Write(const UsdTimeCode& usdTime)
         shaderSchema,
         PxrMayaUsdPreviewSurfaceTokens->NormalAttrName,
         usdTime,
+        /* ignoreIfUnauthored = */ false,
         /* inputTypeName = */ SdfValueTypeNames->Normal3f);
 
     WriteSpecular(usdTime);

--- a/lib/usd/translators/shading/usdLambertWriter.cpp
+++ b/lib/usd/translators/shading/usdLambertWriter.cpp
@@ -140,16 +140,12 @@ void PxrUsdTranslators_LambertWriter::WriteSpecular(const UsdTimeCode& usdTime)
         .CreateInput(PxrMayaUsdPreviewSurfaceTokens->RoughnessAttrName, SdfValueTypeNames->Float)
         .Set(1.0f, usdTime);
 
-    // Using specular workflow, but enforced black specular color.
+    // Using specular workflow. There is no need to author the specular color
+    // since UsdPreviewSurface uses black as a fallback value.
     shaderSchema
         .CreateInput(
             PxrMayaUsdPreviewSurfaceTokens->UseSpecularWorkflowAttrName, SdfValueTypeNames->Int)
         .Set(1, usdTime);
-
-    shaderSchema
-        .CreateInput(PxrMayaUsdPreviewSurfaceTokens->SpecularColorAttrName, SdfValueTypeNames->Color3f)
-        .Set(GfVec3f(0.0f, 0.0f, 0.0f), usdTime);
-
 }
 
 /* virtual */

--- a/lib/usd/translators/shading/usdMaterialWriter.cpp
+++ b/lib/usd/translators/shading/usdMaterialWriter.cpp
@@ -110,6 +110,7 @@ PxrUsdTranslators_MaterialWriter::AuthorShaderInputFromShadingNodeAttr(
         UsdShadeShader& shaderSchema,
         const TfToken& shaderInputName,
         const UsdTimeCode usdTime,
+        bool ignoreIfUnauthored,
         const SdfValueTypeName& inputTypeName)
 {
     return AuthorShaderInputFromScaledShadingNodeAttr(
@@ -119,6 +120,7 @@ PxrUsdTranslators_MaterialWriter::AuthorShaderInputFromShadingNodeAttr(
         shaderInputName,
         usdTime,
         TfToken(),
+        ignoreIfUnauthored,
         inputTypeName);
 }
 
@@ -130,6 +132,7 @@ PxrUsdTranslators_MaterialWriter::AuthorShaderInputFromScaledShadingNodeAttr(
         const TfToken& shaderInputName,
         const UsdTimeCode usdTime,
         const TfToken& scalingAttrName,
+        bool ignoreIfUnauthored,
         const SdfValueTypeName& inputTypeName)
 {
     MStatus status;
@@ -141,6 +144,11 @@ PxrUsdTranslators_MaterialWriter::AuthorShaderInputFromScaledShadingNodeAttr(
             &status);
     if (status != MS::kSuccess) {
         return false;
+    }
+
+    if (ignoreIfUnauthored && !UsdMayaUtil::IsAuthored(shadingNodePlug)) {
+        // Ignore this unauthored Maya attribute and return success.
+        return true;
     }
 
     const bool isDestination = shadingNodePlug.isDestination(&status);

--- a/lib/usd/translators/shading/usdMaterialWriter.h
+++ b/lib/usd/translators/shading/usdMaterialWriter.h
@@ -51,6 +51,15 @@ class PxrUsdTranslators_MaterialWriter : public UsdMayaShaderWriter
         /// Maya attribute \p shadingNodeAttrName in dependency node \p depNodeFn has been modified
         /// or has an incoming connection at \p usdTime.
         ///
+        /// By default, the shader input will be created and authored
+        /// regardless of whether the Maya attribute is authored or connected.
+        /// If instead the shader input should only be authored if the Maya
+        /// attribute is authored, the optional \p ignoreIfUnauthored parameter
+        /// can be set to true. This may be appropriate for cases where the
+        /// Maya attribute and the shader input share the same default value
+        /// (for example, "incandescence" in Maya and "emissiveColor" in
+        /// UsdPreviewSurface are both black by default).
+        ///
         /// If a specific SdfValueTypeName is desired for the created
         /// UsdShadeInput, it can be provided with the optional
         /// \p inputTypeName parameter. This is useful in cases where the role
@@ -64,6 +73,7 @@ class PxrUsdTranslators_MaterialWriter : public UsdMayaShaderWriter
                 UsdShadeShader& shaderSchema,
                 const TfToken& shaderInputName,
                 const UsdTimeCode usdTime,
+                bool ignoreIfUnauthored = false,
                 const SdfValueTypeName& inputTypeName = SdfValueTypeName());
 
         /// Same as AuthorShaderInputFromShadingNodeAttr, but allows scaling the value using a float
@@ -76,6 +86,7 @@ class PxrUsdTranslators_MaterialWriter : public UsdMayaShaderWriter
                 const TfToken& shaderInputName,
                 const UsdTimeCode usdTime,
                 const TfToken& scalingAttrName,
+                bool ignoreIfUnauthored = false,
                 const SdfValueTypeName& inputTypeName = SdfValueTypeName());
 
 };

--- a/lib/usd/translators/shading/usdStandardSurfaceWriter.cpp
+++ b/lib/usd/translators/shading/usdStandardSurfaceWriter.cpp
@@ -30,6 +30,7 @@
 #include <pxr/usd/usdShade/tokens.h>
 
 #include <maya/MFnDependencyNode.h>
+#include <maya/MPlug.h>
 #include <maya/MStatus.h>
 
 #include <basePxrUsdPreviewSurface/usdPreviewSurface.h>
@@ -197,6 +198,7 @@ void PxrUsdTranslators_StandardSurfaceWriter::Write(const UsdTimeCode& usdTime)
         shaderSchema,
         PxrMayaUsdPreviewSurfaceTokens->NormalAttrName,
         usdTime,
+        /* ignoreIfUnauthored = */ false,
         /* inputTypeName = */ SdfValueTypeNames->Normal3f);
 }
 


### PR DESCRIPTION
This addresses some test failures we started seeing when adapting them to use the new cascading `shadingMode` setup. The tests do straight USD file diffs of an initial export from Maya versus a re-import and re-export of that initial export. Because the initial export uses the lambert shader writer, `emissiveColor` and `specularColor` were both getting exported as black, which is unnecessary since that's the default value for those inputs anyway:
https://github.com/PixarAnimationStudios/USD/blob/d8a405a1344480f859f025c4f97085143efacb53/pxr/usdImaging/plugin/usdShaders/shaders/shaderDefs.usda#L34

When re-imported, those shaders became usdPreviewSurface nodes in Maya instead of lambert nodes. The reader sets those attributes using the default values which has no effect. When the usdPreviewSurface writer then runs during the second export, it does **not** author `emissiveColor` or `specularColor` since they are not authored in Maya.

The diff of the two USD files would then show `emissiveColor` and `specularColor` present in the first export but absent in the second export. The default-authored values aren't needed in the first export, so these changes just avoid authoring them.