### PR TITLE
disable shading import in UsdMayaTranslatorCamera::ReadToCamera()

### DIFF
--- a/lib/mayaUsd/fileio/translators/translatorCamera.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorCamera.cpp
@@ -27,6 +27,8 @@
 #include <pxr/base/gf/vec2f.h>
 #include <pxr/base/tf/token.h>
 #include <pxr/base/tf/type.h>
+#include <pxr/base/vt/dictionary.h>
+#include <pxr/base/vt/value.h>
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/timeCode.h>
@@ -36,6 +38,7 @@
 #include <mayaUsd/fileio/jobs/jobArgs.h>
 #include <mayaUsd/fileio/primReaderArgs.h>
 #include <mayaUsd/fileio/primReaderContext.h>
+#include <mayaUsd/fileio/shading/shadingModeRegistry.h>
 #include <mayaUsd/fileio/translators/translatorUtil.h>
 #include <mayaUsd/utils/util.h>
 
@@ -379,10 +382,18 @@ UsdMayaTranslatorCamera::ReadToCamera(
         const UsdGeomCamera& usdCamera,
         MFnCamera& cameraObject)
 {
-    UsdMayaJobImportArgs defaultJobArgs =
-            UsdMayaJobImportArgs::CreateFromDictionary(
-                UsdMayaJobImportArgs::GetDefaultDictionary());
-    UsdMayaPrimReaderArgs args(usdCamera.GetPrim(), defaultJobArgs);
+    VtDictionary userArgsDict;
+
+    // Disable shading import since we're only interested in the camera.
+    userArgsDict[UsdMayaJobImportArgsTokens->shadingMode] =
+        std::vector<VtValue> { VtValue(
+            std::vector<VtValue> {
+                VtValue(UsdMayaShadingModeTokens->none.GetString()),
+                VtValue(std::string("default")) }) };
+
+    UsdMayaJobImportArgs importArgs =
+        UsdMayaJobImportArgs::CreateFromDictionary(userArgsDict);
+    UsdMayaPrimReaderArgs args(usdCamera.GetPrim(), importArgs);
     return _ReadToCamera(usdCamera, cameraObject, args, nullptr);
 }
 


### PR DESCRIPTION
Some additional fallout following #822. This is a workaround specific to `ReadToCamera()`, but we may want to reconsider how/when the `UsdPreviewSurface` shading mode conversion is registered to fix this for all potential cases.

Code that links against mayaUsd but otherwise does not load any Maya plugins currently encounters an error that looks like this when it calls `ReadToCamera()`:

```
Error in '_shadingModesImportArgs' at line 244 in file ext/mayapkg/maya_open_source/maya-usd/lib/mayaUsd/fileio/jobs/jobArgs.cpp : 'Unknown material conversion 'UsdPreviewSurface''```
```

The issue is that the `UsdPreviewSurface` shading conversion is specified as the default in the default args dictionary in the mayaUsd core, but that conversion is only registered when one of the `mayaUsdPlugin`, `usdPreviewSurface`, or `pxrUsdPreviewSurface` plugins are loaded.

Since in this case we're only interested in importing cameras, we can work around that issue for now by overriding `shadingMode` in the default args dictionary and disabling shading import.