### PR TITLE
MAYA-106892 - Export and import color space information on file nodes

### DIFF
--- a/lib/usd/translators/shading/usdFileTextureWriter.cpp
+++ b/lib/usd/translators/shading/usdFileTextureWriter.cpp
@@ -223,11 +223,6 @@ PxrUsdTranslators_FileTextureWriter::Write(const UsdTimeCode& usdTime)
         return;
     }
 
-    MString colorRuleCmd;
-    colorRuleCmd.format(
-        "colorManagementFileRules -evaluate \"^1s\";", fileTextureNamePlug.asString());
-    const MString colorSpaceByRule = MGlobal::executeCommandStringResult(colorRuleCmd);
-
     // WARNING: This extremely minimal attempt at making the file path relative
     //          to the USD stage is a stopgap measure intended to provide
     //          minimal interop. It will be replaced by proper use of Maya and
@@ -245,6 +240,10 @@ PxrUsdTranslators_FileTextureWriter::Write(const UsdTimeCode& usdTime)
 
     MPlug colorSpacePlug = depNodeFn.findPlug(_tokens->colorSpace.GetText(), true, &status);
     if (status == MS::kSuccess) {
+        MString colorRuleCmd;
+        colorRuleCmd.format(
+            "colorManagementFileRules -evaluate \"^1s\";", fileTextureNamePlug.asString());
+        const MString colorSpaceByRule(MGlobal::executeCommandStringResult(colorRuleCmd));
         const MString colorSpace(colorSpacePlug.asString(&status));
         if (status == MS::kSuccess && colorSpace != colorSpaceByRule) {
             fileInput.GetAttr().SetColorSpace(TfToken(colorSpace.asChar()));

--- a/lib/usd/translators/shading/usdUVTextureReader.cpp
+++ b/lib/usd/translators/shading/usdUVTextureReader.cpp
@@ -60,6 +60,7 @@ TF_DEFINE_PRIVATE_TOKENS(
     (alphaOffset)
     (colorGain)
     (colorOffset)
+    (colorSpace)
     (defaultColor)
     (fileTextureName)
     (outAlpha)
@@ -189,6 +190,15 @@ bool PxrMayaUsdUVTexture_Reader::Read(UsdMayaPrimReaderContext* context)
         mayaAttr = depFn.findPlug(_tokens->fileTextureName.GetText(), true, &status);
         if (status == MS::kSuccess) {
             UsdMayaReadUtil::SetMayaAttr(mayaAttr, val);
+        }
+
+        // colorSpace:
+        if (usdInput.GetAttr().HasColorSpace()) {
+            MString colorSpace = usdInput.GetAttr().GetColorSpace().GetText();
+            mayaAttr = depFn.findPlug(_tokens->colorSpace.GetText(), true, &status);
+            if (status == MS::kSuccess) {
+                mayaAttr.setString(colorSpace);
+            }
         }
     }
 

--- a/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
+++ b/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
@@ -86,6 +86,7 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
         txfile = os.path.join("UsdExportImportRoundtripPreviewSurface",
                               "Brazilian_rosewood_pxr128.png")
         cmds.setAttr(file_node+".fileTextureName", txfile, type="string")
+        cmds.setAttr(file_node+".colorSpace", "ACEScg", type="string")
         cmds.setAttr(file_node + ".defaultColor", 0.5, 0.25, 0.125,
                      type="double3")
 
@@ -135,6 +136,7 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
         self.assertTrue(cmds.getAttr("usdPreviewSurface2.useSpecularWorkflow"))
         self.assertEqual(cmds.getAttr("file2.defaultColor"),
                          [(0.5, 0.25, 0.125)])
+        self.assertEqual(cmds.getAttr(file_node+".colorSpace"), "ACEScg")
         original_path = cmds.getAttr(file_node+".fileTextureName")
         imported_path = cmds.getAttr("file2.fileTextureName")
         # imported path will be absolute:


### PR DESCRIPTION
On export, if the color space of a file node was set (differs from the global rule) then we export it as a colorSpace metadata on the file UsdShadeInput.
On import, if there is a colorSpace on the USD file input, we set it in the Maya file node.