### PR TITLE
MAYA-107591: Subtree invalidation support on StageProxy ( a.k.a pseudo-root ).

### DIFF
--- a/lib/mayaUsd/ufe/StagesSubject.cpp
+++ b/lib/mayaUsd/ufe/StagesSubject.cpp
@@ -203,7 +203,7 @@ void StagesSubject::stageChanged(UsdNotice::ObjectsChanged const& notice, UsdSta
 		// each Maya Dag path instancing the proxy shape / stage.
 		Ufe::Path ufePath;
 		UsdPrim prim;
-		if (changedPath.GetString() == "/")
+		if (changedPath.IsAbsoluteRootPath())
 		{
 			ufePath = stagePath(sender);
 			prim = stage->GetPseudoRoot();

--- a/lib/mayaUsd/ufe/StagesSubject.cpp
+++ b/lib/mayaUsd/ufe/StagesSubject.cpp
@@ -203,7 +203,7 @@ void StagesSubject::stageChanged(UsdNotice::ObjectsChanged const& notice, UsdSta
 		// each Maya Dag path instancing the proxy shape / stage.
 		Ufe::Path ufePath;
 		UsdPrim prim;
-		if (changedPath.IsAbsoluteRootPath())
+		if (changedPath == SdfPath::AbsoluteRootPath())
 		{
 			ufePath = stagePath(sender);
 			prim = stage->GetPseudoRoot();


### PR DESCRIPTION
This PR fixes the cases where subtree invalidation doesn't occur in the outliner where all the children are the descendant of stage proxy shape ( a.k.a pseudo-root).

This issue became obvious during the current ongoing work on reordering support where outliner stopped to refresh.