### PR TITLE
[CMake] Add mayaUtils.openTestScene and mayaUtils.getTestScene

### DIFF
--- a/test/lib/ufe/testParentCmd.py
+++ b/test/lib/ufe/testParentCmd.py
@@ -42,8 +42,7 @@ class OpenFileCtx(object):
         self._fileName = fileName
 
     def __enter__(self):
-        filePath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../..", "testSamples", "parentCmd", self._fileName)
-        cmds.file(filePath, force=True, open=True)
+        mayaUtils.openTestScene("parentCmd", self._fileName)
 
     def __exit__(self, type, value, traceback):
         # Close the file.
@@ -69,8 +68,7 @@ class ParentCmdTestCase(unittest.TestCase):
 
         # Load a file that has the same scene in both the Maya Dag
         # hierarchy and the USD hierarchy.
-        filePath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../..", "testSamples", "parentCmd", "simpleSceneMayaPlusUSD_TRS.ma" )
-        cmds.file(filePath, force=True, open=True)
+        mayaUtils.openTestScene("parentCmd", "simpleSceneMayaPlusUSD_TRS.ma" )
 
         # Clear selection to start off
         cmds.select(clear=True)
@@ -426,7 +424,7 @@ class ParentCmdTestCase(unittest.TestCase):
             # opened file.  Layers are then shared between the stages, because
             # they come from the same USD file, causing changes done below one
             # proxy shape to be seen in the other.  Import from another file.
-            filePath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../..", "testSamples", "parentCmd", "simpleSceneUSD_TRS.ma")
+            filePath = mayaUtils.getTestScene("parentCmd", "simpleSceneUSD_TRS.ma")
             cmds.file(filePath, i=True)
 
             # Unparent a USD node in each stage.  Unparenting Lambert node is

--- a/test/lib/ufe/testSelection.py
+++ b/test/lib/ufe/testSelection.py
@@ -51,8 +51,7 @@ class SelectTestCase(unittest.TestCase):
 
         # Load a file that has the same scene in both the Maya Dag
         # hierarchy and the USD hierarchy.
-        filePath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../..", "testSamples", "parentCmd", "simpleSceneMayaPlusUSD_TRS.ma" )
-        cmds.file(filePath, force=True, open=True)
+        mayaUtils.openTestScene("parentCmd", "simpleSceneMayaPlusUSD_TRS.ma")
 
         # Clear selection to start off
         cmds.select(clear=True)

--- a/test/testUtils/mayaUtils.py
+++ b/test/testUtils/mayaUtils.py
@@ -117,6 +117,13 @@ def getMayaSelectionList():
     else:
         return [x for x in cmds.ls(sl=True)]
 
+def getTestScene(*args):
+    return os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "testSamples", *args)
+
+def openTestScene(*args):
+    filePath = getTestScene(*args)
+    cmds.file(filePath, force=True, open=True)
+
 def openTopLayerScene():
     '''
         The test scene hierarchy is represented as :
@@ -133,36 +140,28 @@ def openTopLayerScene():
                                     /Ball_35
     '''
     # Open top_layer file which contains the USD scene
-    filePath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "testSamples", "ballset", "StandaloneScene", "top_layer.ma" )
-    cmds.file(filePath, force=True, open=True)
+    return openTestScene("ballset", "StandaloneScene", "top_layer.ma" )
 
 def openCylinderScene():
-    filePath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "testSamples", "cylinder", "usdCylinder.ma" )
-    cmds.file(filePath, force=True, open=True)
+    return openTestScene("cylinder", "usdCylinder.ma" )
 
 def openTwoSpheresScene():
-    filePath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "testSamples", "twoSpheres", "twoSpheres.ma" )
-    cmds.file(filePath, force=True, open=True)
+    return openTestScene("twoSpheres", "twoSpheres.ma" )
 
 def openSphereAnimatedRadiusScene():
-    filePath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "testSamples", "sphereAnimatedRadius", "sphereAnimatedRadiusProxyShape.ma" )
-    cmds.file(filePath, force=True, open=True)
+    return openTestScene("sphereAnimatedRadius", "sphereAnimatedRadiusProxyShape.ma" )
 
 def openTreeScene():
-    filePath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "testSamples", "tree", "tree.ma" )
-    cmds.file(filePath, force=True, open=True)
+    return openTestScene("tree", "tree.ma" )
 
 def openTreeRefScene():
-    filePath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "testSamples", "tree", "treeRef.ma" )
-    cmds.file(filePath, force=True, open=True)
+    return openTestScene("tree", "treeRef.ma" )
 
 def openAppleBiteScene():
-    filePath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "testSamples", "appleBite", "appleBite.ma" )
-    cmds.file(filePath, force=True, open=True)
+    return openTestScene("appleBite", "appleBite.ma" )
 
 def openGroupBallsScene():
-    filePath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "testSamples", "groupBalls", "ballset.ma" )
-    cmds.file(filePath, force=True, open=True)
+    return openTestScene("groupBalls", "ballset.ma" )
 
 def createProxyAndStage():
     """


### PR DESCRIPTION
Fixes relative paths to test-scenes copied to **${CMAKE_BINARY_DIR}** when compiled as a sub-project.
  * testParentCmd.py, testSelection.py

Refactor duplicate **os.path.join** and **cmds.file** across other tests scenes into one place
  * other tests