### PR TITLE
wrap UFE runtime ID getters for Maya and USD to Python

### DIFF
--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -134,6 +134,7 @@ add_library(${UFE_PYTHON_TARGET_NAME} SHARED)
 target_sources(${UFE_PYTHON_TARGET_NAME} 
     PRIVATE
         module.cpp
+        wrapGlobal.cpp
         wrapUtils.cpp
         wrapNotice.cpp
 )

--- a/lib/mayaUsd/ufe/wrapGlobal.cpp
+++ b/lib/mayaUsd/ufe/wrapGlobal.cpp
@@ -13,13 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include <pxr/pxr.h>
-#include <pxr/base/tf/pyModule.h>
+#include <mayaUsd/ufe/Global.h>
 
-PXR_NAMESPACE_USING_DIRECTIVE
+#include <boost/python.hpp>
 
-TF_WRAP_MODULE {
-    TF_WRAP(Global);
-    TF_WRAP(Utils);
-    TF_WRAP(Notice);
+using namespace MayaUsd;
+using namespace boost::python;
+
+
+void
+wrapGlobal()
+{
+    def("getMayaRunTimeId", ufe::getMayaRunTimeId);
+
+    def("getUsdRunTimeId", ufe::getUsdRunTimeId);
 }

--- a/test/testUtils/mayaUtils.py
+++ b/test/testUtils/mayaUtils.py
@@ -19,16 +19,21 @@
 """
     Helper functions regarding Maya that will be used throughout the test.
 """
-import maya.cmds as cmds
-import sys, os
-import re
+
+from mayaUsd import lib as mayaUsdLib
+from mayaUsd import ufe as mayaUsdUfe
+
+from pxr import Usd
+from pxr import UsdGeom
+
+from maya import cmds
 
 import ufe
 
-from mayaUsd import lib as mayaUsdLib
-from pxr import Usd, UsdGeom
+import os
+import re
+import sys
 
-mayaRuntimeID = 1
 mayaSeparator = "|"
 
 prRe = re.compile('Preview Release ([0-9]+)')
@@ -100,7 +105,8 @@ def createUfePathSegment(mayaPath):
     """
     if not mayaPath.startswith("|world"):
         mayaPath = "|world" + mayaPath
-    return ufe.PathSegment(mayaPath, mayaRuntimeID, mayaSeparator)
+    return ufe.PathSegment(mayaPath, mayaUsdUfe.getMayaRunTimeId(),
+        mayaSeparator)
 
     
 def getMayaSelectionList():

--- a/test/testUtils/usdUtils.py
+++ b/test/testUtils/usdUtils.py
@@ -20,10 +20,12 @@
     Helper functions regarding USD that will be used throughout the test.
 """
 
-usdSeparator = '/'
-usdRuntimeID = 2
-import ufe
 import mayaUsd.ufe
+
+import ufe
+
+usdSeparator = '/'
+
 
 def createUfePathSegment(usdPath):
     """
@@ -33,7 +35,7 @@ def createUfePathSegment(usdPath):
         Returns :
             PathSegment of the given usdPath
     """
-    return ufe.PathSegment(usdPath, usdRuntimeID, usdSeparator)
+    return ufe.PathSegment(usdPath, mayaUsd.ufe.getUsdRunTimeId(), usdSeparator)
 
 def getPrimFromSceneItem(item):
     rawItem = item.getRawAddress()


### PR DESCRIPTION
We're starting to work more UFE awareness into some of our internal pipeline tools and having the UFE runtime IDs more readily accessible to client code would be handy.