### PR TITLE
Tremblp/maya 106087/maya xform stack 01

### DIFF
--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(${PROJECT_NAME}
         UsdTransform3d.cpp
         UsdTransform3dBase.cpp
         UsdTransform3dMatrixOp.cpp
+        UsdTransform3dMayaXformStack.cpp
         UsdTransform3dHandler.cpp
         UsdTranslateUndoableCommand.cpp
         UsdUndoDeleteCommand.cpp
@@ -74,6 +75,7 @@ set(HEADERS
     UsdTransform3d.h
     UsdTransform3dBase.h
     UsdTransform3dMatrixOp.h
+    UsdTransform3dMayaXformStack.h
     UsdTransform3dHandler.h
     UsdTranslateUndoableCommand.h
     UsdUndoDeleteCommand.h

--- a/lib/mayaUsd/ufe/StagesSubject.cpp
+++ b/lib/mayaUsd/ufe/StagesSubject.cpp
@@ -303,11 +303,13 @@ void StagesSubject::stageChanged(UsdNotice::ObjectsChanged const& notice, UsdSta
 		}
 #endif
 
-		// Is the change a Transform3d change?
-		const TfToken nameToken = changedPath.GetNameToken();
-		if(nameToken == UsdGeomTokens->xformOpOrder || UsdGeomXformOp::IsXformOp(nameToken))
-		{
-			Ufe::Transform3d::notify(ufePath);
+		if (!InTransform3dChange::inTransform3dChange()) {
+			// Is the change a Transform3d change?
+			const TfToken nameToken = changedPath.GetNameToken();
+			if(nameToken == UsdGeomTokens->xformOpOrder || UsdGeomXformOp::IsXformOp(nameToken))
+			{
+				Ufe::Transform3d::notify(ufePath);
+			}
 		}
 	}
 }

--- a/lib/mayaUsd/ufe/UsdRotateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdRotateUndoableCommand.h
@@ -55,7 +55,7 @@ public:
         const UsdSceneItem::Ptr& item, double x, double y, double z);
 	#endif
 
-	// Ufe::RotateUndoableCommand overrides.  rotate() sets the command's
+	// Ufe::RotateUndoableCommand overrides.  set() sets the command's
 	// rotation value and executes the command.
 	void undo() override;
 	void redo() override;

--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -243,7 +243,7 @@ Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::rotatePivotTranslateCmd()
     #endif
 }
 
-void UsdTransform3d::rotatePivotTranslate(double x, double y, double z)
+void UsdTransform3d::rotatePivot(double x, double y, double z)
 {
     rotatePivotTranslateOp(prim(), path(), x, y, z);
 }
@@ -282,15 +282,41 @@ Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::scalePivotTranslateCmd()
     throw std::runtime_error("UsdTransform3d::scalePivotTranslateCmd() not implemented");
 }
 
-void UsdTransform3d::scalePivotTranslate(double x, double y, double z)
+void UsdTransform3d::scalePivot(double x, double y, double z)
 {
-    return rotatePivotTranslate(x, y, z);
+    throw std::runtime_error("UsdTransform3d::scalePivot() not implemented");
 }
 #endif
 
 Ufe::Vector3d UsdTransform3d::scalePivot() const
 {
     return rotatePivot();
+}
+
+Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateRotatePivotCmd(
+    double, double, double)
+{
+	// USD common transform API does not support rotate pivot correction.
+	return nullptr;
+}
+
+Ufe::Vector3d UsdTransform3d::rotatePivotTranslation() const
+{
+	// USD common transform API does not support rotate pivot correction.
+	return Ufe::Vector3d(0, 0, 0);
+}
+
+Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateScalePivotCmd(
+    double, double, double)
+{
+	// USD common transform API does not support scale pivot correction.
+	return nullptr;
+}
+
+Ufe::Vector3d UsdTransform3d::scalePivotTranslation() const
+{
+	// USD common transform API does not support scale pivot correction.
+	return Ufe::Vector3d(0, 0, 0);
 }
 
 Ufe::Matrix4d UsdTransform3d::segmentInclusiveMatrix() const

--- a/lib/mayaUsd/ufe/UsdTransform3d.h
+++ b/lib/mayaUsd/ufe/UsdTransform3d.h
@@ -96,6 +96,14 @@ public:
 #endif
 	Ufe::Vector3d rotatePivot() const override;
 	Ufe::Vector3d scalePivot() const override;
+	
+	Ufe::TranslateUndoableCommand::Ptr translateRotatePivotCmd(
+		double x, double y, double z) override;
+	Ufe::Vector3d rotatePivotTranslation() const override;
+	Ufe::TranslateUndoableCommand::Ptr translateScalePivotCmd(
+		double x, double y, double z) override;
+	Ufe::Vector3d scalePivotTranslation() const override;
+
 	Ufe::Matrix4d segmentInclusiveMatrix() const override;
 	Ufe::Matrix4d segmentExclusiveMatrix() const override;
 

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
@@ -446,6 +446,8 @@ Ufe::RotateUndoableCommand::Ptr UsdTransform3dMayaXformStack::rotateCmd(double x
     GfVec3f v(x, y, z);
     CvtRotXYZToAttrFn cvt = toXYZ; // No conversion is default.
     if (!hasOp(NdxRotate)) {
+        // Use notification guard, otherwise will generate one notification for
+        // the xform op add, and another for the reorder.
         InTransform3dChange guard(path());
         r = _xformable.AddRotateXYZOp();
         if (!TF_VERIFY(r)) {

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
@@ -1,0 +1,706 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "UsdTransform3dMayaXformStack.h"
+
+#include <mayaUsd/ufe/Utils.h>
+
+#include <mayaUsd/fileio/utils/xformStack.h>
+
+#include "private/UfeNotifGuard.h"
+
+#include <maya/MEulerRotation.h>
+
+#include <map>
+
+namespace {
+
+using namespace MayaUsd::ufe;
+
+// Type traits for GfVec precision.
+template<class V>
+struct OpPrecision {
+    static UsdGeomXformOp::Precision precision;
+};
+
+template<>
+UsdGeomXformOp::Precision OpPrecision<GfVec3f>::precision = 
+    UsdGeomXformOp::PrecisionFloat;
+
+template<>
+UsdGeomXformOp::Precision OpPrecision<GfVec3d>::precision = 
+    UsdGeomXformOp::PrecisionDouble;
+
+inline double TO_DEG(double a) { return a * 180.0 / 3.141592654; }
+inline double TO_RAD(double a) { return a * 3.141592654 / 180.0; }
+
+VtValue getValue(const UsdAttribute& attr, const UsdTimeCode& time)
+{
+    VtValue value;
+    attr.Get(&value, time);
+    return value;
+}
+
+// UsdMayaXformStack::FindOpIndex() requires an inconvenient isInvertedTwin
+// argument, various rotate transform op equivalences in a separate
+// UsdMayaXformStack::IsCompatibleType().  Just roll our own op name to
+// Maya transform stack index position.
+const std::unordered_map<std::string, UsdTransform3dMayaXformStack::OpNdx> opNameToNdx{
+    {"xformOp:translate",           UsdTransform3dMayaXformStack::NdxTranslate},
+    {"xformOp:translate:rotatePivotTranslate", UsdTransform3dMayaXformStack::NdxRotatePivotTranslate},
+    {"xformOp:translate:rotatePivot", UsdTransform3dMayaXformStack::NdxRotatePivot},
+    {"xformOp:rotateX",             UsdTransform3dMayaXformStack::NdxRotate},
+    {"xformOp:rotateY",             UsdTransform3dMayaXformStack::NdxRotate},
+    {"xformOp:rotateZ",             UsdTransform3dMayaXformStack::NdxRotate},
+    {"xformOp:rotateXYZ",           UsdTransform3dMayaXformStack::NdxRotate},
+    {"xformOp:rotateXZY",           UsdTransform3dMayaXformStack::NdxRotate},
+    {"xformOp:rotateYXZ",           UsdTransform3dMayaXformStack::NdxRotate},
+    {"xformOp:rotateYZX",           UsdTransform3dMayaXformStack::NdxRotate},
+    {"xformOp:rotateZXY",           UsdTransform3dMayaXformStack::NdxRotate},
+    {"xformOp:rotateZYX",           UsdTransform3dMayaXformStack::NdxRotate},
+    {"xformOp:orient",              UsdTransform3dMayaXformStack::NdxRotate},
+    {"xformOp:rotateXYZ:rotateAxis", UsdTransform3dMayaXformStack::NdxRotateAxis},
+    {"!invert!xformOp:translate:rotatePivot", UsdTransform3dMayaXformStack::NdxRotatePivotInverse},
+    {"xformOp:translate:scalePivotTranslate", UsdTransform3dMayaXformStack::NdxScalePivotTranslate},
+    {"xformOp:translate:scalePivot", UsdTransform3dMayaXformStack::NdxScalePivot},
+    {"xformOp:shear",               UsdTransform3dMayaXformStack::NdxShear},
+    {"xformOp:scale",               UsdTransform3dMayaXformStack::NdxScale},
+    {"!invert!xformOp:translate:scalePivot", UsdTransform3dMayaXformStack::NdxScalePivotInverse}};
+
+//----------------------------------------------------------------------
+// Conversion functions from RotXYZ to all supported rotation attributes.
+//----------------------------------------------------------------------
+
+typedef VtValue (*CvtRotXYZToAttrFn)(double x, double y, double z);
+
+VtValue toXYZ(double x, double y, double z) {
+    // No rotation order conversion
+    VtValue v;
+    v = GfVec3f(x, y, z);
+    return v;
+}
+
+// Reorder argument RotXYZ rotation.
+template<MEulerRotation::RotationOrder DST_ROT_ORDER>
+VtValue to(double x, double y, double z) {
+    MEulerRotation eulerRot(TO_RAD(x), TO_RAD(y), TO_RAD(z), MEulerRotation::kXYZ);
+    eulerRot.reorderIt(DST_ROT_ORDER);
+    VtValue v;
+    v = GfVec3f(TO_DEG(eulerRot.x), TO_DEG(eulerRot.y), TO_DEG(eulerRot.z));
+    return v;
+}
+
+auto toXZY = to<MEulerRotation::kXZY>;
+auto toYXZ = to<MEulerRotation::kYXZ>;
+auto toYZX = to<MEulerRotation::kYZX>;
+auto toZXY = to<MEulerRotation::kZXY>;
+auto toZYX = to<MEulerRotation::kZYX>;
+
+VtValue toX(double x, double, double) {
+    VtValue v;
+    v = float(x);
+    return v;
+}
+
+VtValue toY(double, double y, double) {
+    VtValue v;
+    v = float(y);
+    return v;
+}
+
+VtValue toZ(double, double, double z) {
+    VtValue v;
+    v = float(z);
+    return v;
+}
+
+CvtRotXYZToAttrFn getCvtRotXYZToAttrFn(const TfToken& opName)
+{
+    // Can't get std::unordered_map<TfToken, CvtRotXYZToAttrFn> to instantiate.
+    static std::map<TfToken, CvtRotXYZToAttrFn> cvt = {
+        {TfToken("xformOp:rotateX"),   toX},
+        {TfToken("xformOp:rotateY"),   toY},
+        {TfToken("xformOp:rotateZ"),   toZ},
+        {TfToken("xformOp:rotateXYZ"), toXYZ},
+        {TfToken("xformOp:rotateXZY"), toXZY},
+        {TfToken("xformOp:rotateYXZ"), toYXZ},
+        {TfToken("xformOp:rotateYZX"), toYZX},
+        {TfToken("xformOp:rotateZXY"), toZXY},
+        {TfToken("xformOp:rotateZYX"), toZYX},
+        {TfToken("xformOp:orient"),    nullptr}}; // FIXME, unsupported.
+
+    return cvt.at(opName);
+}
+
+//----------------------------------------------------------------------
+// Conversion functions from all supported rotation attributes to RotXYZ.
+//----------------------------------------------------------------------
+
+typedef Ufe::Vector3d (*CvtRotXYZFromAttrFn)(const VtValue& value);
+
+Ufe::Vector3d fromXYZ(const VtValue& value) {
+    // No rotation order conversion
+    auto v = value.Get<GfVec3f>();
+    return Ufe::Vector3d(v[0], v[1], v[2]);
+}
+
+template<MEulerRotation::RotationOrder SRC_ROT_ORDER>
+Ufe::Vector3d from(const VtValue& value) {
+    auto v = value.Get<GfVec3f>();
+
+    MEulerRotation eulerRot(TO_RAD(v[0]), TO_RAD(v[1]), TO_RAD(v[2]), SRC_ROT_ORDER);
+    eulerRot.reorderIt(MEulerRotation::kXYZ);
+    return Ufe::Vector3d(TO_DEG(eulerRot.x), TO_DEG(eulerRot.y), TO_DEG(eulerRot.z));
+}
+
+auto fromXZY = from<MEulerRotation::kXZY>;
+auto fromYXZ = from<MEulerRotation::kYXZ>;
+auto fromYZX = from<MEulerRotation::kYZX>;
+auto fromZXY = from<MEulerRotation::kZXY>;
+auto fromZYX = from<MEulerRotation::kZYX>;
+
+Ufe::Vector3d fromX(const VtValue& value) {
+    return Ufe::Vector3d(value.Get<float>(), 0, 0);
+}
+
+Ufe::Vector3d fromY(const VtValue& value) {
+    return Ufe::Vector3d(0, value.Get<float>(), 0);
+}
+
+Ufe::Vector3d fromZ(const VtValue& value) {
+    return Ufe::Vector3d(0, 0, value.Get<float>());
+}
+
+CvtRotXYZFromAttrFn getCvtRotXYZFromAttrFn(const TfToken& opName)
+{
+    static std::map<TfToken, CvtRotXYZFromAttrFn> cvt = {
+        {TfToken("xformOp:rotateX"),   fromX},
+        {TfToken("xformOp:rotateY"),   fromY},
+        {TfToken("xformOp:rotateZ"),   fromZ},
+        {TfToken("xformOp:rotateXYZ"), fromXYZ},
+        {TfToken("xformOp:rotateXZY"), fromXZY},
+        {TfToken("xformOp:rotateYXZ"), fromYXZ},
+        {TfToken("xformOp:rotateYZX"), fromYZX},
+        {TfToken("xformOp:rotateZXY"), fromZXY},
+        {TfToken("xformOp:rotateZYX"), fromZYX},
+        {TfToken("xformOp:orient"),    nullptr}}; // FIXME, unsupported.
+
+    return cvt.at(opName);
+}
+
+}
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+namespace {
+
+inline Ufe::Transform3d::Ptr nextTransform3d(
+    const Ufe::Transform3dHandler::Ptr& nextHandler,
+    const Ufe::SceneItem::Ptr&          item
+) {
+    return nextHandler->transform3d(item);
+}
+
+inline Ufe::Transform3d::Ptr nextEditTransform3d(
+    const Ufe::Transform3dHandler::Ptr& nextHandler,
+    const Ufe::SceneItem::Ptr&          item
+) {
+    return nextHandler->editTransform3d(item);
+}
+
+typedef Ufe::Transform3d::Ptr (*NextTransform3dFn)(
+    const Ufe::Transform3dHandler::Ptr& nextHandler,
+    const Ufe::SceneItem::Ptr&          item
+);
+
+Ufe::Transform3d::Ptr createTransform3d(
+    const Ufe::Transform3dHandler::Ptr& nextHandler,
+    const Ufe::SceneItem::Ptr&          item,
+    NextTransform3dFn                   nextTransform3dFn
+)
+{
+    UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
+#if !defined(NDEBUG)
+    assert(usdItem);
+#endif
+
+    // If the prim isn't transformable, can't create a Transform3d interface
+    // for it.
+    UsdGeomXformable xformSchema(usdItem->prim());
+    if (!xformSchema) {
+        return nullptr;
+    }
+    bool resetsXformStack = false;
+    auto xformOps = xformSchema.GetOrderedXformOps(&resetsXformStack);
+
+    // Early out: if there are no transform ops yet, it's a match.
+    if (xformOps.empty()) {
+        return UsdTransform3dMayaXformStack::create(usdItem);
+    }
+
+    // If the prim supports the Maya transform stack, create a Maya transform
+    // stack interface for it, otherwise delegate to the next handler in the
+    // chain of responsibility.
+    auto stackOps = UsdMayaXformStack::MayaStack().MatchingSubstack(xformOps);
+
+    return stackOps.empty() ? nextTransform3dFn(nextHandler, item) :
+        UsdTransform3dMayaXformStack::create(usdItem);
+}
+
+// Helper class to factor out common code for translate, rotate, scale
+// undoable commands.
+class UsdTRSUndoableCmdBase : public Ufe::SetVector3dUndoableCommand {
+private:
+    UsdGeomXformOp    fOp;
+    const UsdTimeCode fReadTime;
+    const UsdTimeCode fWriteTime;
+    const VtValue     fPrevOpValue;
+    const TfToken     fAttrName;
+
+public:
+    UsdTRSUndoableCmdBase(
+        const VtValue&        newOpValue,
+        const Ufe::Path&      path,
+        const UsdGeomXformOp& op,
+        const UsdTimeCode&    writeTime_
+    ) : Ufe::SetVector3dUndoableCommand(path), fOp(op),
+        // Always read from proxy shape time.
+        fReadTime(getTime(path)),
+        fWriteTime(writeTime_),
+        fPrevOpValue(getValue(op.GetAttr(), readTime())),
+        fNewOpValue(newOpValue),
+        fAttrName(op.GetOpName())
+    {}
+
+    // Have separate execute override which is value-only, as default execute()
+    // calls redo, and undo / redo will eventually not be value only and will
+    // support propertySpec / primSpec management.
+    void execute() override { setValue(fNewOpValue); }
+
+    void recreateOp() {
+        auto sceneItem = std::dynamic_pointer_cast<UsdSceneItem>(
+            Ufe::Hierarchy::createItem(path())); TF_AXIOM(sceneItem);
+        auto prim = sceneItem->prim(); TF_AXIOM(prim);
+        auto attr = prim.GetAttribute(fAttrName); TF_AXIOM(attr);
+        fOp       = UsdGeomXformOp(attr);
+    }
+
+    void undo() override {
+        // Re-create the XformOp, as the underlying prim may have been
+        // invalidated by later commands.
+        recreateOp();
+        setValue(fPrevOpValue);
+    }
+    void redo() override {
+        // Re-create the XformOp, as the underlying prim may have been
+        // invalidated by earlier commands.
+        recreateOp();
+        setValue(fNewOpValue);
+    }
+
+    void setValue(const VtValue& v) { fOp.GetAttr().Set(v, fWriteTime); }
+
+    UsdTimeCode readTime() const { return fReadTime; }
+    UsdTimeCode writeTime() const { return fWriteTime; }
+
+protected:
+    VtValue fNewOpValue;
+};
+
+// UsdRotatePivotTranslateUndoableCmd uses hard-coded USD common transform API
+// single pivot attribute name, not reusable.
+template<class V>
+class UsdVecOpUndoableCmd : public UsdTRSUndoableCmdBase {
+public:
+    UsdVecOpUndoableCmd(
+        const V&              v,
+        const Ufe::Path&      path,
+        const UsdGeomXformOp& op,
+        const UsdTimeCode&    writeTime
+    ) : UsdTRSUndoableCmdBase(VtValue(v), path, op, writeTime)
+    {}
+
+    // Executes the command by setting the translation onto the transform op.
+    bool set(double x, double y, double z) override
+    {
+        fNewOpValue = V(x, y, z);
+
+        setValue(fNewOpValue);
+        return true;
+    }
+};
+
+class UsdRotateOpUndoableCmd : public UsdTRSUndoableCmdBase {
+public:
+    UsdRotateOpUndoableCmd(
+        const GfVec3f&        r,
+        const Ufe::Path&      path,
+        const UsdGeomXformOp& op,
+        CvtRotXYZToAttrFn     cvt,
+        const UsdTimeCode&    writeTime
+    ) : UsdTRSUndoableCmdBase(VtValue(r), path, op, writeTime), 
+        _cvtRotXYZToAttr(cvt)
+    {}
+
+    // Executes the command by setting the rotation onto the transform op.
+    bool set(double x, double y, double z) override
+    {
+        fNewOpValue = _cvtRotXYZToAttr(x, y, z);
+
+        setValue(fNewOpValue);
+        return true;
+    }
+
+private:
+
+    // Convert from UFE RotXYZ rotation to a value for the transform op.
+    CvtRotXYZToAttrFn _cvtRotXYZToAttr;
+};
+
+}
+
+UsdTransform3dMayaXformStack::UsdTransform3dMayaXformStack(
+    const UsdSceneItem::Ptr& item
+)
+    : UsdTransform3dBase(item), _xformable(prim())
+{
+    TF_AXIOM(_xformable);
+
+    // *** FIXME ***  Consider receiving the ordered transform ops as a ctor
+    // argument, as we're already asking for them.
+
+    // *** FIXME ***  We ask for ordered transform ops, but the prim may have
+    // other transform ops that are not in the ordered list.  However, those
+    // transform ops are not contributing to the final local transform.
+    bool resetsXformStack = false;
+    auto xformOps = _xformable.GetOrderedXformOps(&resetsXformStack);
+    for (const auto& op : xformOps) {
+        std::string opName = op.GetOpName();
+        auto ndx = opNameToNdx.at(opName);
+        _orderedOps[ndx] = op;
+    }
+}
+
+/* static */
+UsdTransform3dMayaXformStack::Ptr UsdTransform3dMayaXformStack::create(
+    const UsdSceneItem::Ptr& item
+)
+{
+    return std::make_shared<UsdTransform3dMayaXformStack>(item);
+}
+
+Ufe::Vector3d UsdTransform3dMayaXformStack::translation() const
+{
+    return getVector3d<GfVec3d>(UsdGeomXformOp::GetOpName(
+        UsdGeomXformOp::TypeTranslate));
+}
+
+Ufe::Vector3d UsdTransform3dMayaXformStack::rotation() const
+{
+    if (!hasOp(NdxRotate)) {
+        return Ufe::Vector3d(0, 0, 0);
+    }
+    UsdGeomXformOp r = getOp(NdxRotate);
+    TF_AXIOM(r);
+
+    CvtRotXYZFromAttrFn cvt = getCvtRotXYZFromAttrFn(r.GetOpName());
+    return cvt(getValue(r.GetAttr(), getTime(path())));
+}
+
+Ufe::Vector3d UsdTransform3dMayaXformStack::scale() const
+{
+    if (!hasOp(NdxRotate)) {
+        return Ufe::Vector3d(1, 1, 1);
+    }
+    UsdGeomXformOp s = getOp(NdxScale);
+    TF_AXIOM(s);
+
+    GfVec3f v;
+    s.Get(&v, getTime(path()));
+    return toUfe(v);
+}
+
+Ufe::TranslateUndoableCommand::Ptr UsdTransform3dMayaXformStack::translateCmd(double x, double y, double z)
+{
+    return setVector3dCmd(GfVec3d(x, y, z),
+        UsdGeomXformOp::GetOpName(UsdGeomXformOp::TypeTranslate));
+}
+
+Ufe::RotateUndoableCommand::Ptr UsdTransform3dMayaXformStack::rotateCmd(double x, double y, double z)
+{
+    // If there is no rotate transform op yet, create it.
+    UsdGeomXformOp r;
+    GfVec3f v(x, y, z);
+    CvtRotXYZToAttrFn cvt = toXYZ; // No conversion is default.
+    if (!hasOp(NdxRotate)) {
+        InTransform3dChange guard(path());
+        r = _xformable.AddRotateXYZOp();
+        if (!TF_VERIFY(r)) {
+            return nullptr;
+        }
+        r.Set(v);
+        setXformOpOrder();
+    }
+    else {
+        r = getOp(NdxRotate);
+        cvt = getCvtRotXYZToAttrFn(r.GetOpName());
+    }
+
+    return std::make_shared<UsdRotateOpUndoableCmd>(
+        v, path(), r, cvt, UsdTimeCode::Default());
+}
+
+Ufe::ScaleUndoableCommand::Ptr UsdTransform3dMayaXformStack::scaleCmd(double x, double y, double z)
+{
+    // If there is no scale transform op yet, create it.
+    UsdGeomXformOp s;
+    GfVec3f v(x, y, z);
+    if (!hasOp(NdxScale)) {
+        InTransform3dChange guard(path());
+        s = _xformable.AddScaleOp();
+        if (!TF_VERIFY(s)) {
+            return nullptr;
+        }
+        s.Set(v);
+        setXformOpOrder();
+    }
+    else {
+        s = getOp(NdxScale);
+    }
+
+    return std::make_shared<UsdVecOpUndoableCmd<GfVec3f>>(
+        v, path(), s, UsdTimeCode::Default());
+}
+
+Ufe::TranslateUndoableCommand::Ptr
+UsdTransform3dMayaXformStack::rotatePivotCmd(double x, double y, double z)
+{
+    return pivotCmd(UsdMayaXformStackTokens->rotatePivot, x, y, z);
+}
+
+Ufe::Vector3d UsdTransform3dMayaXformStack::rotatePivot() const
+{
+    return getVector3d<GfVec3f>(UsdGeomXformOp::GetOpName(
+        UsdGeomXformOp::TypeTranslate, UsdMayaXformStackTokens->rotatePivot));
+}
+
+Ufe::TranslateUndoableCommand::Ptr
+UsdTransform3dMayaXformStack::scalePivotCmd(double x, double y, double z)
+{
+    return pivotCmd(UsdMayaXformStackTokens->scalePivot, x, y, z);
+}
+
+Ufe::Vector3d UsdTransform3dMayaXformStack::scalePivot() const
+{
+    return getVector3d<GfVec3f>(UsdGeomXformOp::GetOpName(
+        UsdGeomXformOp::TypeTranslate, UsdMayaXformStackTokens->scalePivot));
+}
+
+Ufe::TranslateUndoableCommand::Ptr
+UsdTransform3dMayaXformStack::translateRotatePivotCmd(
+    double x, double y, double z)
+{
+    auto opSuffix = UsdMayaXformStackTokens->rotatePivotTranslate;
+    auto attrName = UsdGeomXformOp::GetOpName(
+        UsdGeomXformOp::TypeTranslate, opSuffix);
+    return setVector3dCmd(GfVec3f(x, y, z), attrName, opSuffix);
+}
+
+Ufe::Vector3d UsdTransform3dMayaXformStack::rotatePivotTranslation() const
+{
+    return getVector3d<GfVec3f>(UsdGeomXformOp::GetOpName(
+        UsdGeomXformOp::TypeTranslate,
+        UsdMayaXformStackTokens->rotatePivotTranslate));
+}
+
+Ufe::TranslateUndoableCommand::Ptr
+UsdTransform3dMayaXformStack::translateScalePivotCmd(
+    double x, double y, double z)
+{
+    auto opSuffix = UsdMayaXformStackTokens->scalePivotTranslate;
+    auto attrName = UsdGeomXformOp::GetOpName(
+        UsdGeomXformOp::TypeTranslate, opSuffix);
+    return setVector3dCmd(GfVec3f(x, y, z), attrName, opSuffix);
+}
+
+Ufe::Vector3d UsdTransform3dMayaXformStack::scalePivotTranslation() const
+{
+    return getVector3d<GfVec3f>(UsdGeomXformOp::GetOpName(
+        UsdGeomXformOp::TypeTranslate,
+        UsdMayaXformStackTokens->scalePivotTranslate));
+}
+
+template<class V>
+Ufe::Vector3d UsdTransform3dMayaXformStack::getVector3d(
+    const TfToken& attrName
+) const
+{
+    // If the attribute doesn't exist yet, return a zero vector.
+    auto attr = prim().GetAttribute(attrName);
+    if (!attr) {
+        return Ufe::Vector3d(0, 0, 0);
+    }
+
+    UsdGeomXformOp op(attr);
+    TF_AXIOM(op);
+
+    V v;
+    op.Get(&v, getTime(path()));
+    return toUfe(v);
+}
+
+template<class V>
+Ufe::SetVector3dUndoableCommand::Ptr
+UsdTransform3dMayaXformStack::setVector3dCmd(
+    const V& v, const TfToken& attrName, const TfToken& opSuffix
+)
+{
+    UsdGeomXformOp op;
+
+    // If the attribute doesn't exist yet, create it.
+    auto attr = prim().GetAttribute(attrName);
+    if (!attr) {
+        InTransform3dChange guard(path());
+        op = _xformable.AddTranslateOp(OpPrecision<V>::precision, opSuffix);
+        if (!TF_VERIFY(op)) {
+            return nullptr;
+        }
+        op.Set(v);
+        setXformOpOrder();
+    }
+    else {
+        op = UsdGeomXformOp(attr);
+        TF_AXIOM(op);
+    }
+
+    return std::make_shared<UsdVecOpUndoableCmd<V>>(
+        v, path(), op, UsdTimeCode::Default());
+}
+
+Ufe::TranslateUndoableCommand::Ptr UsdTransform3dMayaXformStack::pivotCmd(
+    const TfToken& pvtOpSuffix,
+    double x, double y, double z
+)
+{
+    auto pvtAttrName = UsdGeomXformOp::GetOpName(
+        UsdGeomXformOp::TypeTranslate, pvtOpSuffix);
+    UsdGeomXformOp p;
+
+    // If the pivot attribute pair doesn't exist yet, create it.
+    auto attr = prim().GetAttribute(pvtAttrName);
+    GfVec3f v(x, y, z);
+    if (!attr) {
+        // Without a notification guard each operation (each transform op
+        // addition, setting the attribute value, and setting the transform op
+        // order) will notify.  Observers would see an object in an inconsistent
+        // state, especially after pivot is added but before its inverse is
+        // added --- this does not match the Maya transform stack.  Use of
+        // SdfChangeBlock is discouraged when calling USD APIs above Sdf, so
+        // use our own guard.
+        InTransform3dChange guard(path());
+        p = _xformable.AddTranslateOp(UsdGeomXformOp::PrecisionFloat,
+                                     pvtOpSuffix);
+        auto pInv = _xformable.AddTranslateOp(UsdGeomXformOp::PrecisionFloat,
+            pvtOpSuffix, /* isInverseOp */ true);
+        if (!TF_VERIFY(p && pInv)) {
+            return nullptr;
+        }
+        p.Set(v);
+        setXformOpOrder();
+    }
+    else {
+        p = UsdGeomXformOp(attr);
+        TF_AXIOM(p);
+    }
+
+    return std::make_shared<UsdVecOpUndoableCmd<GfVec3f>>(
+        v, path(), p, UsdTimeCode::Default());
+}
+
+void UsdTransform3dMayaXformStack::setXformOpOrder()
+{
+    // Simply adding a transform op appends to the op order vector.  Therefore,
+    // after addition, we must sort the ops to preserve Maya transform stack
+    // ordering.  Use the Maya transform stack indices to add to a map, then
+    // simply traverse the map to obtain the transform ops in order.
+    std::map<int, UsdGeomXformOp> orderedOps;
+    bool resetsXformStack = false;
+    auto oldOrder = _xformable.GetOrderedXformOps(&resetsXformStack);
+    for (const auto& op : oldOrder) {
+        std::string opName = op.GetOpName();
+        auto ndx = opNameToNdx.at(opName);
+        orderedOps[ndx] = op;
+    }
+
+    // Set the transform op order attribute, and rebuild our indexed cache.
+    _orderedOps.clear();
+    std::vector<UsdGeomXformOp> newOrder;
+    newOrder.reserve(oldOrder.size());
+    for (const auto& orderedOp : orderedOps) {
+        const auto& op = orderedOp.second;
+        newOrder.emplace_back(op);
+        std::string opName = op.GetOpName();
+        auto ndx = opNameToNdx.at(opName);
+        _orderedOps[ndx] = op;
+    }
+
+    _xformable.SetXformOpOrder(newOrder, resetsXformStack);
+}
+
+bool UsdTransform3dMayaXformStack::hasOp(OpNdx ndx) const
+{
+    return _orderedOps.find(ndx) != _orderedOps.end();
+}
+
+UsdGeomXformOp UsdTransform3dMayaXformStack::getOp(OpNdx ndx) const
+{
+    return _orderedOps.at(ndx);
+}
+
+//------------------------------------------------------------------------------
+// UsdTransform3dMayaXformStackHandler
+//------------------------------------------------------------------------------
+
+UsdTransform3dMayaXformStackHandler::UsdTransform3dMayaXformStackHandler(
+    const Ufe::Transform3dHandler::Ptr& nextHandler
+) : Ufe::Transform3dHandler(), _nextHandler(nextHandler)
+{}
+
+/*static*/
+UsdTransform3dMayaXformStackHandler::Ptr UsdTransform3dMayaXformStackHandler::create(
+    const Ufe::Transform3dHandler::Ptr& nextHandler
+)
+{
+    return std::make_shared<UsdTransform3dMayaXformStackHandler>(nextHandler);
+}
+
+Ufe::Transform3d::Ptr UsdTransform3dMayaXformStackHandler::transform3d(
+    const Ufe::SceneItem::Ptr& item
+) const
+{
+    return createTransform3d(_nextHandler, item, nextTransform3d);
+}
+
+Ufe::Transform3d::Ptr UsdTransform3dMayaXformStackHandler::editTransform3d(
+    const Ufe::SceneItem::Ptr& item
+) const
+{
+    return createTransform3d(_nextHandler, item, nextEditTransform3d);
+}
+
+} // namespace ufe
+} // namespace MayaUsd
+

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
@@ -108,6 +108,7 @@ auto toYZX = to<MEulerRotation::kYZX>;
 auto toZXY = to<MEulerRotation::kZXY>;
 auto toZYX = to<MEulerRotation::kZYX>;
 
+// Scalar float is the proper type for single-axis rotations.
 VtValue toX(double x, double, double) {
     VtValue v;
     v = float(x);
@@ -422,7 +423,7 @@ Ufe::Vector3d UsdTransform3dMayaXformStack::rotation() const
 
 Ufe::Vector3d UsdTransform3dMayaXformStack::scale() const
 {
-    if (!hasOp(NdxRotate)) {
+    if (!hasOp(NdxScale)) {
         return Ufe::Vector3d(1, 1, 1);
     }
     UsdGeomXformOp s = getOp(NdxScale);

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
@@ -1,0 +1,133 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <mayaUsd/ufe/UsdTransform3dBase.h>
+
+#include <mayaUsd/fileio/utils/xformStack.h>
+
+#include <pxr/usd/usdGeom/xformable.h>
+
+#include <unordered_map>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+//! \brief Transform USD objects in 3D using the Maya transform stack.
+// 
+// The Maya transform stack is described here:
+// http://help.autodesk.com/view/MAYAUL/2018/ENU/?guid=__cpp_ref_class_m_fn_transform_html
+//
+// The Maya transform stack represents a local matrix transformation as a fixed
+// list of transform ops of a prescribed type and semantics.  This class allows
+// for UFE transformation of objects that use this local matrix representation.
+//
+class MAYAUSD_CORE_PUBLIC UsdTransform3dMayaXformStack : public UsdTransform3dBase
+{
+public:
+    enum OpNdx {NdxTranslate = 0, NdxRotatePivotTranslate, NdxRotatePivot, 
+                NdxRotate, NdxRotateAxis, NdxRotatePivotInverse, 
+                NdxScalePivotTranslate, NdxScalePivot, NdxShear, NdxScale, 
+                NdxScalePivotInverse, NbOpNdx};
+
+    typedef std::shared_ptr<UsdTransform3dMayaXformStack> Ptr;
+
+    UsdTransform3dMayaXformStack(const UsdSceneItem::Ptr& item);
+    ~UsdTransform3dMayaXformStack() override = default;
+
+    //! Create a UsdTransform3dMayaXformStack.
+    static UsdTransform3dMayaXformStack::Ptr create(
+        const UsdSceneItem::Ptr& item
+    );
+
+    Ufe::Vector3d translation() const override;
+    Ufe::Vector3d rotation() const override;
+    Ufe::Vector3d scale() const override;
+
+    Ufe::TranslateUndoableCommand::Ptr translateCmd(double x, double y, double z) override;
+    Ufe::RotateUndoableCommand::Ptr rotateCmd(double x, double y, double z) override;
+    Ufe::ScaleUndoableCommand::Ptr scaleCmd(double x, double y, double z) override;
+
+    Ufe::TranslateUndoableCommand::Ptr rotatePivotCmd(double x, double y, double z) override;
+    Ufe::Vector3d rotatePivot() const override;
+
+    Ufe::TranslateUndoableCommand::Ptr scalePivotCmd(double x, double y, double z) override;
+    Ufe::Vector3d scalePivot() const override;
+
+    Ufe::TranslateUndoableCommand::Ptr translateRotatePivotCmd(
+        double x, double y, double z) override;
+
+    Ufe::Vector3d rotatePivotTranslation() const override;
+
+    Ufe::TranslateUndoableCommand::Ptr translateScalePivotCmd(
+        double x, double y, double z) override;
+
+    Ufe::Vector3d scalePivotTranslation() const override;
+
+private:
+
+    bool           hasOp(OpNdx ndx) const;
+    UsdGeomXformOp getOp(OpNdx ndx) const;
+
+    Ufe::TranslateUndoableCommand::Ptr pivotCmd(
+        const TfToken& pvtOpSuffix,
+        double x, double y, double z
+    );
+    template<class V>
+    Ufe::Vector3d getVector3d(const TfToken& attrName) const;
+    template<class V>
+    Ufe::SetVector3dUndoableCommand::Ptr setVector3dCmd(
+        const V& v, const TfToken& attrName, const TfToken& opSuffix = TfToken()
+    );
+
+    void setXformOpOrder();
+    
+    // Cache of ops in the ordered ops vector, indexed by position.
+    std::unordered_map<OpNdx, UsdGeomXformOp> _orderedOps;
+
+    UsdGeomXformable _xformable;
+
+}; // UsdTransform3dMayaXformStack
+
+//! \brief Factory to create a UsdTransform3dMayaXformStack interface object.
+//
+// Note that all calls to specify time use the default time, but this
+// could be changed to use the current time, using getTime(path()).
+
+class MAYAUSD_CORE_PUBLIC UsdTransform3dMayaXformStackHandler
+  : public Ufe::Transform3dHandler
+{
+public:
+    typedef std::shared_ptr<UsdTransform3dMayaXformStackHandler> Ptr;
+
+    UsdTransform3dMayaXformStackHandler(const Ufe::Transform3dHandler::Ptr& nextHandler);
+
+    //! Create a UsdTransform3dMayaXformStackHandler.
+    static Ptr create(const Ufe::Transform3dHandler::Ptr& nextHandler);
+
+    // Ufe::Transform3dHandler overrides
+    Ufe::Transform3d::Ptr transform3d(const Ufe::SceneItem::Ptr& item) const override;
+    Ufe::Transform3d::Ptr editTransform3d(const Ufe::SceneItem::Ptr& item) const override;
+
+private:
+    Ufe::Transform3dHandler::Ptr _nextHandler;
+
+}; // UsdTransform3dMayaXformStackHandler
+
+} // namespace ufe
+} // namespace MayaUsd

--- a/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.h
@@ -53,7 +53,7 @@ public:
         const UsdSceneItem::Ptr& item, double x, double y, double z);
 	#endif
 
-	// Ufe::TranslateUndoableCommand overrides.  translate() sets the command's
+	// Ufe::TranslateUndoableCommand overrides.  set() sets the command's
 	// translation value and executes the command.
 	void undo() override;
 	void redo() override;

--- a/lib/mayaUsd/ufe/private/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/private/CMakeLists.txt
@@ -3,5 +3,6 @@
 # -----------------------------------------------------------------------------
 target_sources(${PROJECT_NAME} 
     PRIVATE
+        UfeNotifGuard.cpp
         Utils.cpp
 )

--- a/lib/mayaUsd/ufe/private/UfeNotifGuard.cpp
+++ b/lib/mayaUsd/ufe/private/UfeNotifGuard.cpp
@@ -1,0 +1,46 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "UfeNotifGuard.h"
+
+#include <ufe/transform3d.h>
+#include <ufe/path.h>
+
+namespace {
+    Ufe::Path transform3dPath;
+}
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+InTransform3dChange::InTransform3dChange(const Ufe::Path& path)
+{
+    transform3dPath = path;
+}
+
+InTransform3dChange::~InTransform3dChange()
+{
+    Ufe::Transform3d::notify(transform3dPath);
+    transform3dPath = Ufe::Path();
+}
+
+/* static */
+bool InTransform3dChange::inTransform3dChange()
+{
+    return !transform3dPath.empty();
+}
+
+} // namespace ufe
+} // namespace MayaUsd

--- a/lib/mayaUsd/ufe/private/UfeNotifGuard.h
+++ b/lib/mayaUsd/ufe/private/UfeNotifGuard.h
@@ -18,10 +18,19 @@
 
 #include <mayaUsd/base/api.h>
 
+#include <ufe/ufe.h>
+
+UFE_NS_DEF {
+class Path;
+}
+
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
 //! \brief Helper class to scope when we are in a path change operation.
+//
+// This simple guard class can be used within a single scope, but does not have
+// recursive scope capability.
 class InPathChange
 {
 public:
@@ -41,6 +50,9 @@ private:
 };
 
 //! \brief Helper class to scope when we are in an add or delete operation.
+//
+// This simple guard class can be used within a single scope, but does not have
+// recursive scope capability.
 class InAddOrDeleteOperation
 {
 public:
@@ -59,6 +71,26 @@ private:
 	static bool inGuard;
 };
 
+
+//! \brief Helper class to scope when we are in a Transform3d change operation.
+//
+// This simple guard class can be used within a single scope, but does not have
+// recursive scope capability.  On guard exit, will send a Transform3d
+// notification.
+class InTransform3dChange
+{
+public:
+	InTransform3dChange(const Ufe::Path& path);
+	~InTransform3dChange();
+
+	// Delete the copy/move constructors assignment operators.
+	InTransform3dChange(const InTransform3dChange&) = delete;
+	InTransform3dChange& operator=(const InTransform3dChange&) = delete;
+	InTransform3dChange(InTransform3dChange&&) = delete;
+	InTransform3dChange& operator=(InTransform3dChange&&) = delete;
+
+	static bool inTransform3dChange();
+};
 
 } // namespace ufe
 } // namespace MayaUsd

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -54,6 +54,7 @@
 #if defined(WANT_UFE_BUILD)
 #include <mayaUsd/ufe/Global.h>
 #include <mayaUsd/ufe/UsdTransform3dMatrixOp.h>
+#include <mayaUsd/ufe/UsdTransform3dMayaXformStack.h>
 
 #include <ufe/runTimeMgr.h>
 #endif
@@ -152,7 +153,8 @@ MStatus initializePlugin(MObject obj)
     g_Transform3dHandler = runTimeMgr.transform3dHandler(usdRtid);
 	auto matrixHandler = MAYAUSD_NS::ufe::UsdTransform3dMatrixOpHandler::create(
 		g_Transform3dHandler);
-	runTimeMgr.setTransform3dHandler(usdRtid, matrixHandler);
+	auto mayaStackHandler = MAYAUSD_NS::ufe::UsdTransform3dMayaXformStackHandler::create(matrixHandler);
+	runTimeMgr.setTransform3dHandler(usdRtid, mayaStackHandler);
 #endif
 
     status = plugin.registerShape(

--- a/test/lib/ufe/testComboCmd.py
+++ b/test/lib/ufe/testComboCmd.py
@@ -514,6 +514,12 @@ class ComboCmdTestCase(testTRSBase.TRSTestCaseBase):
         sphereItem = ufe.Hierarchy.createItem(spherePath)
         usdSphereT3d = ufe.Transform3d.transform3d(sphereItem)
         
+        # If the Transform3d interface can't handle rotate or scale pivot
+        # compensation, skip this test.
+        if usdSphereT3d.translateRotatePivotCmd() is None or \
+           usdSphereT3d.translateScalePivotCmd() is None:
+            raise unittest.SkipTest("Rotate or scale pivot compensation unsupported.")
+
         # Maya object and its exported USD object twin should have the
         # same pivots and pivot compensations.
         checkPivotsAndCompensations(self, "pSphere1", usdSphereT3d)


### PR DESCRIPTION
This pull request provides an initial implementation of the Maya transform stack in maya-usd.  As previously, creation of Ufe::Transform3d is structured as a chain of responsibility: in this pull request, creation of a Maya transform stack is the first link in the chain, and therefore will be considered first to determine a match.

The implementation is incomplete: undo / redo does not remove added transform ops in the ordered ops vector, single-axis rotations are buggy and move along two axes (!), and the rotate axis and shear components are unimplemented, though the UFE interface exists.  Additionally, a fair amount of undoable command code could be shared with the UsdTransform3dMatrixOp class, but this is not addressed in this pull request.

The core files in the review are UsdTransform3dMayaXformStack.{h,cpp}.