### PR TITLE
fix call to non-existent function in pxrUsd plugin's usdTranslatorImport

### DIFF
--- a/plugin/pxr/maya/lib/usdMaya/usdTranslatorImport.mel
+++ b/plugin/pxr/maya/lib/usdMaya/usdTranslatorImport.mel
@@ -160,7 +160,7 @@ global proc int usdTranslatorImport (string $parent,
             for ($index = 0; $index < size($optionList); $index++) {
                 tokenize($optionList[$index], "=", $optionBreakDown);
                 if ($optionBreakDown[0] == "shadingMode") {
-                    usdTranslatorImport_SetShadingOptionMenuByAnnotation($optionBreakDown[1], "shadingModePopup");
+                    usdTranslatorImport_SetOptionMenuByAnnotation($optionBreakDown[1], "shadingModePopup");
                 } else if ($optionBreakDown[0] == "readAnimData") {
                     usdTranslatorImport_SetCheckbox($optionBreakDown[1], "readAnimDataCheckBox");
                 } else if ($optionBreakDown[0] == "useAsAnimationCache") {


### PR DESCRIPTION
The existing call to `usdTranslatorImport_SetOptionMenuByAnnotation()` was replaced with a call to `usdTranslatorImport_SetShadingOptionMenuByAnnotation()` in #865, but the latter does not exist anywhere. This reverts that change.