### PR TITLE
wrap token definitions in clang-format off/clang-format on

### DIFF
--- a/lib/mayaUsd/commands/baseListShadingModesCommand.cpp
+++ b/lib/mayaUsd/commands/baseListShadingModesCommand.cpp
@@ -30,14 +30,18 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace MAYAUSD_NS_DEF {
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
-    ((NoneOption,
-      "none"))((NoneNiceName, "None"))((NoneExportDescription, "No material data gets exported."))(
-        (NoneImportDescription,
-         "Stop the search for materials. Can signal that no materials are to be"
-         " imported when used alone.")));
+    ((NoneOption, "none"))
+    ((NoneNiceName, "None"))
+    ((NoneExportDescription, "No material data gets exported."))
+    ((NoneImportDescription,
+        "Stop the search for materials. Can signal that no materials are to be"
+        " imported when used alone."))
+);
+// clang-format on
 
 namespace {
 std::pair<TfToken, TfToken> _GetOptions(const MString& niceName, bool isExport)

--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -47,15 +47,23 @@ TF_DEFINE_PUBLIC_TOKENS(UsdMayaJobExportArgsTokens, PXRUSDMAYA_JOB_EXPORT_ARGS_T
 
 TF_DEFINE_PUBLIC_TOKENS(UsdMayaJobImportArgsTokens, PXRUSDMAYA_JOB_IMPORT_ARGS_TOKENS);
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _usdExportInfoScope,
 
-    (UsdMaya)(UsdExport));
+    (UsdMaya)
+        (UsdExport)
+);
+// clang-format on
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _usdImportInfoScope,
 
-    (UsdMaya)(UsdImport));
+    (UsdMaya)
+        (UsdImport)
+);
+// clang-format on
 
 /// Extracts a bool at \p key from \p userArgs, or false if it can't extract.
 static bool _Boolean(const VtDictionary& userArgs, const TfToken& key)

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -34,42 +34,93 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define PXRUSDMAYA_TRANSLATOR_TOKENS                                         \
-    ((UsdFileExtensionDefault, "usd"))((UsdFileExtensionASCII, "usda"))(     \
-        (UsdFileExtensionCrate, "usdc"))((UsdFileExtensionPackage, "usdz"))( \
-        (UsdReadableFileFilter, "*.usd *.usda *.usdc *.usdz"))(              \
-        (UsdWritableFileFilter, "*.usd *.usda *.usdc *.usdz"))
+// clang-format off
+#define PXRUSDMAYA_TRANSLATOR_TOKENS \
+    ((UsdFileExtensionDefault, "usd")) \
+    ((UsdFileExtensionASCII, "usda")) \
+    ((UsdFileExtensionCrate, "usdc")) \
+    ((UsdFileExtensionPackage, "usdz")) \
+    ((UsdReadableFileFilter, "*.usd *.usda *.usdc *.usdz")) \
+    ((UsdWritableFileFilter, "*.usd *.usda *.usdc *.usdz"))
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
     UsdMayaTranslatorTokens,
     MAYAUSD_CORE_PUBLIC,
     PXRUSDMAYA_TRANSLATOR_TOKENS);
 
-#define PXRUSDMAYA_JOB_EXPORT_ARGS_TOKENS                                                      \
-    /* Dictionary keys */                                                                      \
-    (chaser)(chaserArgs)(compatibility)(defaultCameras)(defaultMeshScheme)(defaultUSDFormat)(  \
-        eulerFilter)(exportCollectionBasedBindings)(exportColorSets)(exportDisplayColor)(      \
-        exportInstances)(exportMaterialCollections)(exportReferenceObjects)(                   \
-        exportRefsAsInstanceable)(exportSkels)(exportSkin)(exportUVs)(exportVisibility)(kind)( \
-        materialCollectionsPath)(materialsScopeName)(melPerFrameCallback)(melPostCallback)(    \
-        mergeTransformAndShape)(normalizeNurbs)(parentScope)(pythonPerFrameCallback)(          \
-        pythonPostCallback)(renderableOnly)(renderLayerMode)(shadingMode)(convertMaterialsTo)( \
-        stripNamespaces)(verbose)                     /* Special "none" token */               \
-        (none)                                        /* renderLayerMode values */             \
-        (defaultLayer)(currentLayer)(modelingVariant) /* exportSkels/exportSkin values */      \
-        ((auto_, "auto"))((explicit_, "explicit"))    /* compatibility values */               \
-        (appleArKit)
+// clang-format off
+#define PXRUSDMAYA_JOB_EXPORT_ARGS_TOKENS \
+    /* Dictionary keys */ \
+    (chaser) \
+    (chaserArgs) \
+    (compatibility) \
+    (defaultCameras) \
+    (defaultMeshScheme) \
+    (defaultUSDFormat) \
+    (eulerFilter) \
+    (exportCollectionBasedBindings) \
+    (exportColorSets) \
+    (exportDisplayColor) \
+    (exportInstances) \
+    (exportMaterialCollections) \
+    (exportReferenceObjects) \
+    (exportRefsAsInstanceable) \
+    (exportSkels) \
+    (exportSkin) \
+    (exportUVs) \
+    (exportVisibility) \
+    (kind) \
+    (materialCollectionsPath) \
+    (materialsScopeName) \
+    (melPerFrameCallback) \
+    (melPostCallback) \
+    (mergeTransformAndShape) \
+    (normalizeNurbs) \
+    (parentScope) \
+    (pythonPerFrameCallback) \
+    (pythonPostCallback) \
+    (renderableOnly) \
+    (renderLayerMode) \
+    (shadingMode) \
+    (convertMaterialsTo) \
+    (stripNamespaces) \
+    (verbose) \
+    /* Special "none" token */ \
+    (none) \
+    /* renderLayerMode values */ \
+    (defaultLayer) \
+    (currentLayer) \
+    (modelingVariant) \
+    /* exportSkels/exportSkin values */ \
+    ((auto_, "auto")) \
+    ((explicit_, "explicit")) \
+    /* compatibility values */ \
+    (appleArKit)
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
     UsdMayaJobExportArgsTokens,
     MAYAUSD_CORE_PUBLIC,
     PXRUSDMAYA_JOB_EXPORT_ARGS_TOKENS);
 
-#define PXRUSDMAYA_JOB_IMPORT_ARGS_TOKENS                                               \
-    /* Dictionary keys */                                                               \
-    (apiSchema)(assemblyRep)(excludePrimvar)(metadata)(shadingMode)(preferredMaterial)( \
-        useAsAnimationCache)(importInstances) /* assemblyRep values */                  \
-        (Collapsed)(Full)(Import)((Unloaded, ""))
+// clang-format off
+#define PXRUSDMAYA_JOB_IMPORT_ARGS_TOKENS \
+    /* Dictionary keys */ \
+    (apiSchema) \
+    (assemblyRep) \
+    (excludePrimvar) \
+    (metadata) \
+    (shadingMode) \
+    (preferredMaterial) \
+    (useAsAnimationCache) \
+    (importInstances) \
+    /* assemblyRep values */ \
+    (Collapsed) \
+    (Full) \
+    (Import) \
+    ((Unloaded, ""))
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
     UsdMayaJobImportArgsTokens,

--- a/lib/mayaUsd/fileio/primReaderRegistry.cpp
+++ b/lib/mayaUsd/fileio/primReaderRegistry.cpp
@@ -34,7 +34,14 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_DEFINE_PRIVATE_TOKENS(_tokens, (UsdMaya)(PrimReader));
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(
+    _tokens,
+
+    (UsdMaya)
+    (PrimReader)
+);
+// clang-format on
 
 typedef std::map<TfToken, UsdMayaPrimReaderRegistry::ReaderFactoryFn> _Registry;
 static _Registry                                                      _reg;

--- a/lib/mayaUsd/fileio/primUpdaterRegistry.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterRegistry.cpp
@@ -35,7 +35,14 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_DEFINE_PRIVATE_TOKENS(_tokens, (UsdMaya)(PrimUpdater));
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(
+    _tokens,
+
+    (UsdMaya)
+        (PrimUpdater)
+);
+// clang-format on
 
 typedef std::map<TfToken, UsdMayaPrimUpdaterRegistry::RegisterItem> _Registry;
 static _Registry                                                    _reg;

--- a/lib/mayaUsd/fileio/primWriter.cpp
+++ b/lib/mayaUsd/fileio/primWriter.cpp
@@ -51,10 +51,13 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 PXRUSDMAYA_REGISTER_ADAPTOR_ATTRIBUTE_ALIAS(UsdGeomTokens->purpose, "USD_purpose");
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
-    (USD_inheritClassNames));
+    (USD_inheritClassNames)
+);
+// clang-format on
 
 static bool _IsAnimated(const UsdMayaJobExportArgs& args, const MObject& obj)
 {

--- a/lib/mayaUsd/fileio/primWriterRegistry.cpp
+++ b/lib/mayaUsd/fileio/primWriterRegistry.cpp
@@ -33,7 +33,14 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_DEFINE_PRIVATE_TOKENS(_tokens, (UsdMaya)(PrimWriter));
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(
+    _tokens,
+
+    (UsdMaya)
+        (PrimWriter)
+);
+// clang-format on
 
 typedef std::map<std::string, UsdMayaPrimWriterRegistry::WriterFactoryFn> _Registry;
 static _Registry                                                          _reg;

--- a/lib/mayaUsd/fileio/registryHelper.cpp
+++ b/lib/mayaUsd/fileio/registryHelper.cpp
@@ -32,7 +32,16 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_DEFINE_PRIVATE_TOKENS(_tokens, (mayaPlugin)(providesTranslator)(UsdMaya)(ShadingModePlugin));
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(
+    _tokens,
+
+    (mayaPlugin)
+    (providesTranslator)
+    (UsdMaya)
+    (ShadingModePlugin)
+);
+// clang-format on
 
 template <typename T> bool _GetData(const JsValue& any, T* val)
 {

--- a/lib/mayaUsd/fileio/shaderReaderRegistry.cpp
+++ b/lib/mayaUsd/fileio/shaderReaderRegistry.cpp
@@ -34,7 +34,14 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_DEFINE_PRIVATE_TOKENS(_tokens, (UsdMaya)(ShaderReader));
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(
+    _tokens,
+
+    (UsdMaya)
+        (ShaderReader)
+);
+// clang-format on
 
 namespace {
 struct _RegistryEntry

--- a/lib/mayaUsd/fileio/shaderWriterRegistry.cpp
+++ b/lib/mayaUsd/fileio/shaderWriterRegistry.cpp
@@ -33,10 +33,14 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
-    (UsdMaya)(ShaderWriter));
+    (UsdMaya)
+        (ShaderWriter)
+);
+// clang-format on
 
 namespace {
 struct _RegistryEntry

--- a/lib/mayaUsd/fileio/shading/shadingModeDisplayColor.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeDisplayColor.cpp
@@ -60,14 +60,19 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
-    (diffuseColor)(opacity)
 
-        ((NiceName, "Display Colors"))(
-            (ImportDescription,
-             "Imports the displayColor primvar on the USD mesh as a Maya"
-             " surface shader.")));
+    (diffuseColor)
+    (opacity)
+
+    ((NiceName, "Display Colors"))
+    ((ImportDescription,
+        "Imports the displayColor primvar on the USD mesh as a Maya"
+        " surface shader."))
+);
+// clang-format on
 
 DEFINE_SHADING_MODE_IMPORTER_WITH_JOB_ARGUMENTS(
     displayColor,

--- a/lib/mayaUsd/fileio/shading/shadingModeExporter.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporter.cpp
@@ -41,7 +41,13 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_DEFINE_PRIVATE_TOKENS(_tokens, ((materialNamespace, "material:")));
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(
+    _tokens,
+
+    ((materialNamespace, "material:"))
+);
+// clang-format on
 
 UsdMayaShadingModeExporter::UsdMayaShadingModeExporter() { }
 

--- a/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
@@ -58,7 +58,17 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_DEFINE_PRIVATE_TOKENS(_tokens, (surfaceShader)(volumeShader)(displacementShader)(varname)(map1));
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(
+    _tokens,
+
+    (surfaceShader)
+    (volumeShader)
+    (displacementShader)
+    (varname)
+    (map1)
+);
+// clang-format on
 
 UsdMayaShadingModeExportContext::UsdMayaShadingModeExportContext(
     const MObject&                           shadingEngine,

--- a/lib/mayaUsd/fileio/shading/shadingModeImporter.h
+++ b/lib/mayaUsd/fileio/shading/shadingModeImporter.h
@@ -34,7 +34,10 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define PXRUSDMAYA_SHADING_MODE_IMPORTER_TOKENS ((MayaMaterialNamespace, "USD_Materials"))
+// clang-format off
+#define PXRUSDMAYA_SHADING_MODE_IMPORTER_TOKENS \
+    ((MayaMaterialNamespace, "USD_Materials"))
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
     UsdMayaShadingModeImporterTokens,

--- a/lib/mayaUsd/fileio/shading/shadingModePxrRis.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModePxrRis.cpp
@@ -60,14 +60,19 @@ using namespace MAYAUSD_NS_DEF;
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
-    ((PxrShaderPrefix, "Pxr"))((DefaultShaderOutputName, "out"))((MayaShaderOutputName, "outColor"))
+    ((PxrShaderPrefix, "Pxr"))
+    ((DefaultShaderOutputName, "out"))
+    ((MayaShaderOutputName, "outColor"))
 
-        ((RmanPlugPreferenceName, "rfmShadingEngineUseRmanPlugs"))
+    ((RmanPlugPreferenceName, "rfmShadingEngineUseRmanPlugs"))
 
-            ((RmanVolumeShaderPlugName, "volumeShader")));
+    ((RmanVolumeShaderPlugName, "volumeShader"))
+);
+// clang-format on
 
 namespace {
 

--- a/lib/mayaUsd/fileio/shading/shadingModeRegistry.h
+++ b/lib/mayaUsd/fileio/shading/shadingModeRegistry.h
@@ -34,15 +34,27 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define PXRUSDMAYA_SHADINGMODE_TOKENS (none)(displayColor)(useRegistry)
+// clang-format off
+#define PXRUSDMAYA_SHADINGMODE_TOKENS \
+    (none) \
+    (displayColor) \
+    (useRegistry)
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
     UsdMayaShadingModeTokens,
     MAYAUSD_CORE_PUBLIC,
     PXRUSDMAYA_SHADINGMODE_TOKENS);
 
+// clang-format off
 #define PXRUSDMAYA_SHADINGCONVERSION_TOKENS \
-    (none)(lambert)(standardSurface)(usdPreviewSurface)(blinn)(phong)
+    (none) \
+    (lambert) \
+    (standardSurface) \
+    (usdPreviewSurface) \
+    (blinn) \
+    (phong)
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
     UsdMayaPreferredMaterialTokens,

--- a/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
@@ -56,15 +56,20 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 namespace {
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
-    ((ArgName, "useRegistry"))((NiceName, "Use Registry"))(
-        (ExportDescription,
+
+    ((ArgName, "useRegistry"))
+    ((NiceName, "Use Registry"))
+    ((ExportDescription,
+        "Use a registry based mechanism, complemented with material conversions,"
+         " to export to a UsdShade network"))
+    ((ImportDescription,
          "Use a registry based mechanism, complemented with material conversions,"
-         " to export to a UsdShade network"))(
-        (ImportDescription,
-         "Use a registry based mechanism, complemented with material conversions,"
-         " to import from a UsdShade network")));
+         " to import from a UsdShade network"))
+);
+// clang-format on
 
 using _NodeHandleToShaderWriterMap
     = UsdMayaUtil::MObjectHandleUnorderedMap<UsdMayaShaderWriterSharedPtr>;

--- a/lib/mayaUsd/fileio/shading/symmetricShaderReader.cpp
+++ b/lib/mayaUsd/fileio/shading/symmetricShaderReader.cpp
@@ -50,10 +50,13 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
-    ((MayaShaderOutputName, "outColor")));
+    ((MayaShaderOutputName, "outColor"))
+);
+// clang-format on
 
 /* static */
 void UsdMayaSymmetricShaderReader::RegisterReader(

--- a/lib/mayaUsd/fileio/translators/translatorCamera.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorCamera.cpp
@@ -50,19 +50,25 @@ static bool _ReadToCamera(
     const UsdMayaPrimReaderArgs& args,
     UsdMayaPrimReaderContext*    context);
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
-    ((MayaCameraTypeName, "camera"))((MayaCameraShapeNameSuffix, "Shape"))
 
-        ((MayaCameraAttrNameHorizontalAperture,
-          "horizontalFilmAperture"))((MayaCameraAttrNameVerticalAperture, "verticalFilmAperture"))(
-            (MayaCameraAttrNameHorizontalApertureOffset, "horizontalFilmOffset"))(
-            (MayaCameraAttrNameVerticalApertureOffset,
-             "verticalFilmOffset"))((MayaCameraAttrNameOrthographicWidth, "orthographicWidth"))(
-            (MayaCameraAttrNameFocalLength, "focalLength"))(
-            (MayaCameraAttrNameFocusDistance, "focusDistance"))((MayaCameraAttrNameFStop, "fStop"))(
-            (MayaCameraAttrNameNearClippingPlane,
-             "nearClipPlane"))((MayaCameraAttrNameFarClippingPlane, "farClipPlane")));
+    ((MayaCameraTypeName, "camera"))
+    ((MayaCameraShapeNameSuffix, "Shape"))
+
+    ((MayaCameraAttrNameHorizontalAperture, "horizontalFilmAperture"))
+    ((MayaCameraAttrNameVerticalAperture, "verticalFilmAperture"))
+    ((MayaCameraAttrNameHorizontalApertureOffset, "horizontalFilmOffset"))
+    ((MayaCameraAttrNameVerticalApertureOffset, "verticalFilmOffset"))
+    ((MayaCameraAttrNameOrthographicWidth, "orthographicWidth"))
+    ((MayaCameraAttrNameFocalLength, "focalLength"))
+    ((MayaCameraAttrNameFocusDistance, "focusDistance"))
+    ((MayaCameraAttrNameFStop, "fStop"))
+    ((MayaCameraAttrNameNearClippingPlane, "nearClipPlane"))
+    ((MayaCameraAttrNameFarClippingPlane, "farClipPlane"))
+);
+// clang-format on
 
 static bool _CheckUsdTypeAndResizeArrays(
     const UsdAttribute&  usdAttr,

--- a/lib/mayaUsd/fileio/translators/translatorRfMLight.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorRfMLight.cpp
@@ -58,47 +58,75 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
     // RenderMan for Maya light types.
-    ((AovLightMayaTypeName, "PxrAovLight"))((CylinderLightMayaTypeName, "PxrCylinderLight"))(
-        (DiskLightMayaTypeName, "PxrDiskLight"))((DistantLightMayaTypeName, "PxrDistantLight"))(
-        (DomeLightMayaTypeName, "PxrDomeLight"))((EnvDayLightMayaTypeName, "PxrEnvDayLight"))(
-        (GeometryLightMayaTypeName, "PxrMeshLight"))((RectLightMayaTypeName, "PxrRectLight"))(
-        (SphereLightMayaTypeName, "PxrSphereLight"))
+    ((AovLightMayaTypeName, "PxrAovLight"))
+    ((CylinderLightMayaTypeName, "PxrCylinderLight"))
+    ((DiskLightMayaTypeName, "PxrDiskLight"))
+    ((DistantLightMayaTypeName, "PxrDistantLight"))
+    ((DomeLightMayaTypeName, "PxrDomeLight"))
+    ((EnvDayLightMayaTypeName, "PxrEnvDayLight"))
+    ((GeometryLightMayaTypeName, "PxrMeshLight"))
+    ((RectLightMayaTypeName, "PxrRectLight"))
+    ((SphereLightMayaTypeName, "PxrSphereLight"))
 
     // Light plug names.
-    ((IntensityPlugName, "intensity"))((ExposurePlugName, "exposure"))(
-        (DiffuseAmountPlugName, "diffuse"))((SpecularAmountPlugName, "specular"))(
-        (NormalizePowerPlugName, "areaNormalize"))((ColorPlugName, "lightColor"))(
-        (EnableTemperaturePlugName, "enableTemperature"))((TemperaturePlugName, "temperature"))
+    ((IntensityPlugName, "intensity"))
+    ((ExposurePlugName, "exposure"))
+    ((DiffuseAmountPlugName, "diffuse"))
+    ((SpecularAmountPlugName, "specular"))
+    ((NormalizePowerPlugName, "areaNormalize"))
+    ((ColorPlugName, "lightColor"))
+    ((EnableTemperaturePlugName, "enableTemperature"))
+    ((TemperaturePlugName, "temperature"))
 
     // Type-specific Light plug names.
-    ((DistantLightAnglePlugName, "angleExtent"))((TextureFilePlugName, "lightColorMap"))
+    ((DistantLightAnglePlugName, "angleExtent"))
+    ((TextureFilePlugName, "lightColorMap"))
 
     // PxrAovLight plug names.
-    ((AovNamePlugName, "aovName"))((InPrimaryHitPlugName, "inPrimaryHit"))(
-        (InReflectionPlugName, "inReflection"))((InRefractionPlugName, "inRefraction"))(
-        (InvertPlugName, "invert"))((OnVolumeBoundariesPlugName, "onVolumeBoundaries"))(
-        (UseColorPlugName, "useColor"))((UseThroughputPlugName, "useThroughput"))
+    ((AovNamePlugName, "aovName"))
+    ((InPrimaryHitPlugName, "inPrimaryHit"))
+    ((InReflectionPlugName, "inReflection"))
+    ((InRefractionPlugName, "inRefraction"))
+    ((InvertPlugName, "invert"))
+    ((OnVolumeBoundariesPlugName, "onVolumeBoundaries"))
+    ((UseColorPlugName, "useColor"))
+    ((UseThroughputPlugName, "useThroughput"))
 
     // PxrEnvDayLight plug names.
-    ((DayPlugName, "day"))((HazinessPlugName, "haziness"))((HourPlugName, "hour"))(
-        (LatitudePlugName, "latitude"))((LongitudePlugName, "longitude"))((MonthPlugName, "month"))(
-        (SkyTintPlugName,
-         "skyTint"))((SunDirectionPlugName, "sunDirection"))((SunSizePlugName, "sunSize"))(
-        (SunTintPlugName, "sunTint"))((YearPlugName, "year"))((ZonePlugName, "zone"))
+    ((DayPlugName, "day"))
+    ((HazinessPlugName, "haziness"))
+    ((HourPlugName, "hour"))
+    ((LatitudePlugName, "latitude"))
+    ((LongitudePlugName, "longitude"))
+    ((MonthPlugName, "month"))
+    ((SkyTintPlugName, "skyTint"))
+    ((SunDirectionPlugName, "sunDirection"))
+    ((SunSizePlugName, "sunSize"))
+    ((SunTintPlugName, "sunTint"))
+    ((YearPlugName, "year"))
+    ((ZonePlugName, "zone"))
 
     // ShapingAPI plug names.
-    ((FocusPlugName, "emissionFocus"))((FocusTintPlugName, "emissionFocusTint"))(
-        (ConeAnglePlugName, "coneAngle"))((ConeSoftnessPlugName, "coneSoftness"))(
-        (ProfileFilePlugName, "iesProfile"))((ProfileScalePlugName, "iesProfileScale"))
+    ((FocusPlugName, "emissionFocus"))
+    ((FocusTintPlugName, "emissionFocusTint"))
+    ((ConeAnglePlugName, "coneAngle"))
+    ((ConeSoftnessPlugName, "coneSoftness"))
+    ((ProfileFilePlugName, "iesProfile"))
+    ((ProfileScalePlugName, "iesProfileScale"))
 
     // ShadowAPI plug names.
-    ((EnableShadowsPlugName, "enableShadows"))((ShadowColorPlugName, "shadowColor"))(
-        (ShadowDistancePlugName, "shadowDistance"))((ShadowFalloffPlugName, "shadowFalloff"))(
-        (ShadowFalloffGammaPlugName, "shadowFalloffGamma")));
+    ((EnableShadowsPlugName, "enableShadows"))
+    ((ShadowColorPlugName, "shadowColor"))
+    ((ShadowDistancePlugName, "shadowDistance"))
+    ((ShadowFalloffPlugName, "shadowFalloff"))
+    ((ShadowFalloffGammaPlugName, "shadowFalloffGamma"))
+);
+// clang-format on
 
 static bool _ReportError(const std::string& msg, const SdfPath& primPath = SdfPath())
 {

--- a/lib/mayaUsd/fileio/translators/translatorSkel.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorSkel.cpp
@@ -107,7 +107,17 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 namespace {
 
-TF_DEFINE_PRIVATE_TOKENS(_tokens, (Animation)(bindPose)(Maya)(generated)(Skeleton));
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(
+    _tokens,
+
+    (Animation)
+    (bindPose)
+    (Maya)
+    (generated)
+    (Skeleton)
+);
+// clang-format on
 
 struct _MayaTokensData
 {

--- a/lib/mayaUsd/fileio/utils/jointWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/jointWriteUtils.cpp
@@ -57,7 +57,14 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_DEFINE_PRIVATE_TOKENS(_tokens, (Animation)(Skeleton));
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(
+    _tokens,
+
+    (Animation)
+    (Skeleton)
+);
+// clang-format on
 
 SdfPath UsdMayaJointUtil::getAnimationPath(const SdfPath& skelPath)
 {

--- a/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
@@ -54,6 +54,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 TF_DEFINE_PUBLIC_TOKENS(UsdMayaMeshPrimvarTokens, PXRUSDMAYA_MESH_PRIMVAR_TOKENS);
 
 // These tokens are supported Maya attributes used for Mesh surfaces
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _meshTokens,
 
@@ -67,7 +68,9 @@ TF_DEFINE_PRIVATE_TOKENS(
     // This token is deprecated as it is from OpenSubdiv 2 and the USD
     // schema now conforms to OpenSubdiv 3, but we continue to look for it
     // and translate to the equivalent new value for backwards compatibility.
-    (USD_faceVaryingInterpolateBoundary));
+    (USD_faceVaryingInterpolateBoundary)
+);
+// clang-format on
 
 PXRUSDMAYA_REGISTER_ADAPTOR_ATTRIBUTE_ALIAS(
     UsdGeomTokens->subdivisionScheme,

--- a/lib/mayaUsd/fileio/utils/meshReadUtils.h
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.h
@@ -37,9 +37,12 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class UsdGeomMesh;
 
-#define PXRUSDMAYA_MESH_PRIMVAR_TOKENS                                                            \
-    ((DisplayColorColorSetName, "displayColor"))((DisplayOpacityColorSetName, "displayOpacity"))( \
-        (DefaultMayaTexcoordName, "map1"))
+// clang-format off
+#define PXRUSDMAYA_MESH_PRIMVAR_TOKENS \
+    ((DisplayColorColorSetName, "displayColor")) \
+    ((DisplayOpacityColorSetName, "displayOpacity")) \
+    ((DefaultMayaTexcoordName, "map1"))
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
     UsdMayaMeshPrimvarTokens,

--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
@@ -48,6 +48,7 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 // These tokens are supported Maya attributes used for Mesh surfaces
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _meshTokens,
 
@@ -61,7 +62,9 @@ TF_DEFINE_PRIVATE_TOKENS(
     // This token is deprecated as it is from OpenSubdiv 2 and the USD
     // schema now conforms to OpenSubdiv 3, but we continue to look for it
     // and translate to the equivalent new value for backwards compatibility.
-    (USD_faceVaryingInterpolateBoundary));
+    (USD_faceVaryingInterpolateBoundary)
+);
+// clang-format on
 
 namespace {
 /// Default value to use when collecting UVs from a UV set and a component

--- a/lib/mayaUsd/fileio/utils/roundTripUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/roundTripUtil.cpp
@@ -26,6 +26,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
@@ -36,12 +37,14 @@ TF_DEFINE_PRIVATE_TOKENS(
     // re-imported into Maya when trying to "roundtrip" data.
     (generated)
 
-        (clamped)
+    (clamped)
 
     // This annotates if the attribute used to be a maya array.  The index
     // of the array is likely encoded in the attribute name though we could
     // extend this to store the name and index.
-    (arrayIndex));
+    (arrayIndex)
+);
+// clang-format on
 
 template <typename T>
 static bool _GetMayaDictValue(const UsdAttribute& attr, const TfToken& key, T* outVal)

--- a/lib/mayaUsd/fileio/utils/userTaggedAttribute.cpp
+++ b/lib/mayaUsd/fileio/utils/userTaggedAttribute.cpp
@@ -38,10 +38,17 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 TF_DEFINE_PUBLIC_TOKENS(UsdMayaUserTaggedAttributeTokens, PXRUSDMAYA_ATTR_TOKENS);
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
-    (USD_UserExportedAttributesJson)(usdAttrName)(usdAttrType)(
-        translateMayaDoubleToUsdSinglePrecision)((UserPropertiesNamespace, "userProperties:")));
+
+    (USD_UserExportedAttributesJson)
+    (usdAttrName)
+    (usdAttrType)
+    (translateMayaDoubleToUsdSinglePrecision)
+    ((UserPropertiesNamespace, "userProperties:"))
+);
+// clang-format on
 
 UsdMayaUserTaggedAttribute::UsdMayaUserTaggedAttribute(
     const MPlug&       plug,

--- a/lib/mayaUsd/fileio/utils/userTaggedAttribute.h
+++ b/lib/mayaUsd/fileio/utils/userTaggedAttribute.h
@@ -32,7 +32,11 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define PXRUSDMAYA_ATTR_TOKENS ((USDAttrTypePrimvar, "primvar"))((USDAttrTypeUsdRi, "usdRi"))
+// clang-format off
+#define PXRUSDMAYA_ATTR_TOKENS \
+    ((USDAttrTypePrimvar, "primvar")) \
+    ((USDAttrTypeUsdRi, "usdRi"))
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
     UsdMayaUserTaggedAttributeTokens,

--- a/lib/mayaUsd/fileio/utils/xformStack.h
+++ b/lib/mayaUsd/fileio/utils/xformStack.h
@@ -35,10 +35,22 @@ PXR_NAMESPACE_OPEN_SCOPE
 // at present, but there was some support for reading it, thus
 // why it's here
 
+// clang-format off
 /// \hideinitializer
-#define PXRUSDMAYA_XFORM_STACK_TOKENS                                                        \
-    (translate)(rotatePivotTranslate)(rotatePivot)(rotate)(rotateAxis)(scalePivotTranslate)( \
-        scalePivot)(shear)(scale)(pivot)(pivotTranslate)(transform)
+#define PXRUSDMAYA_XFORM_STACK_TOKENS \
+    (translate) \
+    (rotatePivotTranslate) \
+    (rotatePivot) \
+    (rotate) \
+    (rotateAxis) \
+    (scalePivotTranslate) \
+    (scalePivot) \
+    (shear) \
+    (scale) \
+    (pivot) \
+    (pivotTranslate) \
+    (transform)
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
     UsdMayaXformStackTokens,

--- a/lib/mayaUsd/nodes/hdImagingShape.h
+++ b/lib/mayaUsd/nodes/hdImagingShape.h
@@ -36,7 +36,10 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define PXRUSDMAYA_HD_IMAGING_SHAPE_TOKENS ((MayaTypeName, "pxrHdImagingShape"))
+// clang-format off
+#define PXRUSDMAYA_HD_IMAGING_SHAPE_TOKENS \
+    ((MayaTypeName, "pxrHdImagingShape"))
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
     PxrMayaHdImagingShapeTokens,

--- a/lib/mayaUsd/nodes/pointBasedDeformerNode.h
+++ b/lib/mayaUsd/nodes/pointBasedDeformerNode.h
@@ -32,7 +32,10 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define PXRUSDMAYA_POINT_BASED_DEFORMER_NODE_TOKENS ((MayaTypeName, "pxrUsdPointBasedDeformerNode"))
+// clang-format off
+#define PXRUSDMAYA_POINT_BASED_DEFORMER_NODE_TOKENS \
+    ((MayaTypeName, "pxrUsdPointBasedDeformerNode"))
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
     UsdMayaPointBasedDeformerNodeTokens,

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -60,7 +60,10 @@ constexpr char USD_UFE_SEPARATOR = '/';
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define MAYAUSD_PROXY_SHAPE_BASE_TOKENS ((MayaTypeName, "mayaUsdProxyShapeBase"))
+// clang-format off
+#define MAYAUSD_PROXY_SHAPE_BASE_TOKENS \
+    ((MayaTypeName, "mayaUsdProxyShapeBase"))
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
     MayaUsdProxyShapeBaseTokens,

--- a/lib/mayaUsd/nodes/stageData.h
+++ b/lib/mayaUsd/nodes/stageData.h
@@ -31,7 +31,10 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define PXRMAYAUSD_STAGE_DATA_TOKENS ((MayaTypeName, "pxrUsdStageData"))
+// clang-format off
+#define PXRMAYAUSD_STAGE_DATA_TOKENS \
+    ((MayaTypeName, "pxrUsdStageData"))
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(MayaUsdStageDataTokens, MAYAUSD_CORE_PUBLIC, PXRMAYAUSD_STAGE_DATA_TOKENS);
 

--- a/lib/mayaUsd/nodes/stageNode.h
+++ b/lib/mayaUsd/nodes/stageNode.h
@@ -31,7 +31,10 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define PXRUSDMAYA_STAGE_NODE_TOKENS ((MayaTypeName, "pxrUsdStageNode"))
+// clang-format off
+#define PXRUSDMAYA_STAGE_NODE_TOKENS \
+    ((MayaTypeName, "pxrUsdStageNode"))
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(UsdMayaStageNodeTokens, MAYAUSD_CORE_PUBLIC, PXRUSDMAYA_STAGE_NODE_TOKENS);
 

--- a/lib/mayaUsd/render/mayaToHydra/renderGlobals.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderGlobals.cpp
@@ -40,6 +40,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 // clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
+
     (defaultRenderGlobals)
     (mtohTextureMemoryPerTexture)
     (mtohColorSelectionHighlight)

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -83,11 +83,16 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
-    ((BatchRendererRootName, "MayaHdBatchRenderer"))((LegacyViewport, "LegacyViewport"))(
-        (Viewport2, "Viewport2"))((MayaEndRenderNotificationName, "UsdMayaEndRenderNotification")));
+    ((BatchRendererRootName, "MayaHdBatchRenderer"))
+    ((LegacyViewport, "LegacyViewport"))
+    ((Viewport2, "Viewport2"))
+    ((MayaEndRenderNotificationName, "UsdMayaEndRenderNotification"))
+);
+// clang-format on
 
 TF_INSTANTIATE_SINGLETON(UsdMayaGLBatchRenderer);
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.cpp
@@ -58,9 +58,16 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
-    ((NativeInstancerType, "instancer"))(Instancer)(Prototypes)(EmptyPrim));
+
+    ((NativeInstancerType, "instancer"))
+    (Instancer)
+    (Prototypes)
+    (EmptyPrim)
+);
+// clang-format on
 
 /* virtual */
 bool UsdMayaGL_InstancerShapeAdapter::UpdateVisibility(const M3dView* view)

--- a/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
@@ -61,10 +61,13 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
-    (selectionTask));
+    (selectionTask)
+);
+// clang-format on
 
 namespace {
 class PxrMayaHdShadowMatrix : public HdxShadowMatrixComputation

--- a/lib/mayaUsd/render/vp2RenderDelegate/instancer.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/instancer.cpp
@@ -34,7 +34,16 @@ PXR_NAMESPACE_OPEN_SCOPE
 // Define local tokens for the names of the primvars the instancer
 // consumes.
 // XXX: These should be hydra tokens...
-TF_DEFINE_PRIVATE_TOKENS(_tokens, (instanceTransform)(rotate)(scale)(translate));
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(
+    _tokens,
+
+    (instanceTransform)
+    (rotate)
+    (scale)
+    (translate)
+);
+// clang-format on
 
 /*! \brief  Constructor.
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -55,20 +55,40 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 namespace {
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
-    (file)(opacity)(st)(varname)
+    (file)
+    (opacity)
+    (st)
+    (varname)
 
-        (input)(output)
+    (input)
+    (output)
 
-            (rgb)(r)(g)(b)(a)
+    (rgb)
+    (r)
+    (g)
+    (b)
+    (a)
 
-                (xyz)(x)(y)(z)(w)
+    (xyz)
+    (x)
+    (y)
+    (z)
+    (w)
 
-                    (Float4ToFloatX)(Float4ToFloatY)(Float4ToFloatZ)(Float4ToFloatW)(Float4ToFloat3)
+    (Float4ToFloatX)
+    (Float4ToFloatY)
+    (Float4ToFloatZ)
+    (Float4ToFloatW)
+    (Float4ToFloat3)
 
-                        (UsdPrimvarReader_color)(UsdPrimvarReader_vector));
+    (UsdPrimvarReader_color)
+    (UsdPrimvarReader_vector)
+);
+// clang-format on
 
 //! Helper utility function to test whether a node is a UsdShade primvar reader.
 bool _IsUsdPrimvarReader(const HdMaterialNode& node)

--- a/lib/mayaUsd/render/vp2RenderDelegate/tokens.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/tokens.h
@@ -21,7 +21,11 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define HDVP2_REPR_TOKENS (bbox)(selection)
+// clang-format off
+#define HDVP2_REPR_TOKENS \
+    (bbox) \
+    (selection)
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(HdVP2ReprTokens, , HDVP2_REPR_TOKENS);
 

--- a/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.cpp
+++ b/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.cpp
@@ -32,32 +32,56 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 TF_DEFINE_PUBLIC_TOKENS(HdVP2ShaderFragmentsTokens, MAYAUSD_CORE_PUBLIC_USD_PREVIEW_SURFACE_TOKENS);
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
-    (BasisCurvesCubicColorDomain)(BasisCurvesCubicCPVHull)(BasisCurvesCubicCPVPassing)(
-        BasisCurvesCubicCPVShader)(BasisCurvesCubicDomain)(BasisCurvesCubicFallbackShader)(
-        BasisCurvesCubicHull)(BasisCurvesLinearColorDomain)(BasisCurvesLinearCPVHull)(
-        BasisCurvesLinearCPVPassing)(BasisCurvesLinearCPVShader)(BasisCurvesLinearDomain)(
-        BasisCurvesLinearFallbackShader)(BasisCurvesLinearHull)
+    (BasisCurvesCubicColorDomain)
+    (BasisCurvesCubicCPVHull)
+    (BasisCurvesCubicCPVPassing)
+    (BasisCurvesCubicCPVShader)
+    (BasisCurvesCubicDomain)
+    (BasisCurvesCubicFallbackShader)
+    (BasisCurvesCubicHull)
+    (BasisCurvesLinearColorDomain)
+    (BasisCurvesLinearCPVHull)
+    (BasisCurvesLinearCPVPassing)
+    (BasisCurvesLinearCPVShader)
+    (BasisCurvesLinearDomain)
+    (BasisCurvesLinearFallbackShader)
+    (BasisCurvesLinearHull)
 
-        (FallbackCPVShader)(FallbackShader)
+    (FallbackCPVShader)
+    (FallbackShader)
 
-            (Float4ToFloatX)(Float4ToFloatY)(Float4ToFloatZ)(Float4ToFloatW)(Float4ToFloat3)(
-                Float4ToFloat4)
+    (Float4ToFloatX)
+    (Float4ToFloatY)
+    (Float4ToFloatZ)
+    (Float4ToFloatW)
+    (Float4ToFloat3)
+    (Float4ToFloat4)
 
-                (NwFaceCameraIfNAN)
+    (NwFaceCameraIfNAN)
 
-                    (lightingContributions)(scaledDiffusePassThrough)(scaledSpecularPassThrough)(
-                        opacityToTransparency)(usdPreviewSurfaceLighting)(usdPreviewSurfaceCombiner)
+    (lightingContributions)
+    (scaledDiffusePassThrough)
+    (scaledSpecularPassThrough)
+    (opacityToTransparency)
+    (usdPreviewSurfaceLighting)
+    (usdPreviewSurfaceCombiner)
 
-                        (UsdPrimvarColor)
+    (UsdPrimvarColor)
 
-                            (UsdUVTexture)
+    (UsdUVTexture)
 
-                                (UsdPrimvarReader_color)(UsdPrimvarReader_float)(
-                                    UsdPrimvarReader_float2)(UsdPrimvarReader_float3)(
-                                    UsdPrimvarReader_float4)(UsdPrimvarReader_vector));
+    (UsdPrimvarReader_color)
+    (UsdPrimvarReader_float)
+    (UsdPrimvarReader_float2)
+    (UsdPrimvarReader_float3)
+    (UsdPrimvarReader_float4)
+    (UsdPrimvarReader_vector)
+);
+// clang-format on
 
 static const TfTokenVector _LanguageSpecificFragmentNames
     = { _tokens->BasisCurvesLinearDomain, _tokens->BasisCurvesCubicDomain };

--- a/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.h
+++ b/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.h
@@ -25,9 +25,11 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define MAYAUSD_CORE_PUBLIC_USD_PREVIEW_SURFACE_TOKENS  \
-    ((CoreFragmentGraphName, "UsdPreviewSurfaceCore"))( \
-        (SurfaceFragmentGraphName, "UsdPreviewSurface"))
+// clang-format off
+#define MAYAUSD_CORE_PUBLIC_USD_PREVIEW_SURFACE_TOKENS \
+    ((CoreFragmentGraphName, "UsdPreviewSurfaceCore")) \
+    ((SurfaceFragmentGraphName, "UsdPreviewSurface"))
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
     HdVP2ShaderFragmentsTokens,

--- a/lib/usd/hdMaya/delegates/proxyDelegate.cpp
+++ b/lib/usd/hdMaya/delegates/proxyDelegate.cpp
@@ -45,7 +45,13 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-TF_DEFINE_PRIVATE_TOKENS(_tokens, (HdMayaProxyDelegate));
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(
+    _tokens,
+
+    (HdMayaProxyDelegate)
+);
+// clang-format off
 
 TF_REGISTRY_FUNCTION(TfType)
 {

--- a/lib/usd/hdMaya/delegates/sceneDelegate.cpp
+++ b/lib/usd/hdMaya/delegates/sceneDelegate.cpp
@@ -167,9 +167,14 @@ inline void _MapAdapter(F f, const M0& m0, const M&... m)
 
 } // namespace
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
-    (HdMayaSceneDelegate)((FallbackMaterial, "__fallback_material__")));
+
+    (HdMayaSceneDelegate)
+    ((FallbackMaterial, "__fallback_material__"))
+);
+// clang-format on
 
 TF_REGISTRY_FUNCTION(TfType)
 {

--- a/lib/usd/hdMaya/delegates/testDelegate.cpp
+++ b/lib/usd/hdMaya/delegates/testDelegate.cpp
@@ -23,7 +23,13 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 TF_DEFINE_ENV_SETTING(HDMAYA_TEST_DELEGATE_FILE, "", "Path for HdMayaTestDelegate to load");
 
-TF_DEFINE_PRIVATE_TOKENS(_tokens, (HdMayaTestDelegate));
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(
+    _tokens,
+
+    (HdMayaTestDelegate)
+);
+// clang-format on
 
 TF_REGISTRY_FUNCTION_WITH_TAG(HdMayaDelegateRegistry, HdMayaTestDelegate)
 {

--- a/lib/usd/pxrUsdPreviewSurface/usdPreviewSurface.h
+++ b/lib/usd/pxrUsdPreviewSurface/usdPreviewSurface.h
@@ -33,18 +33,27 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define PXRUSDPREVIEWSURFACE_USD_PREVIEW_SURFACE_TOKENS                                        \
-    ((ClearcoatAttrName, "clearcoat"))((ClearcoatRoughnessAttrName, "clearcoatRoughness"))(    \
-        (DiffuseColorAttrName, "diffuseColor"))((DisplacementAttrName, "displacement"))(       \
-        (EmissiveColorAttrName, "emissiveColor"))((IorAttrName, "ior"))(                       \
-        (MetallicAttrName, "metallic"))((NormalAttrName, "normal"))(                           \
-        (OcclusionAttrName, "occlusion"))((OpacityAttrName, "opacity"))(                       \
-        (RoughnessAttrName, "roughness"))((SpecularColorAttrName, "specularColor"))(           \
-        (UseSpecularWorkflowAttrName, "useSpecularWorkflow"))((OutColorAttrName, "outColor"))( \
-        (OutTransparencyAttrName, "outTransparency"))((niceName, "USD Preview Surface"))(      \
-        (exportDescription,                                                                    \
-         "Exports the bound shader as a USD preview surface UsdShade network."))(              \
-        (importDescription, "Search for a USD preview surface UsdShade network to import."))
+// clang-format off
+#define PXRUSDPREVIEWSURFACE_USD_PREVIEW_SURFACE_TOKENS \
+    ((ClearcoatAttrName, "clearcoat")) \
+    ((ClearcoatRoughnessAttrName, "clearcoatRoughness")) \
+    ((DiffuseColorAttrName, "diffuseColor")) \
+    ((DisplacementAttrName, "displacement")) \
+    ((EmissiveColorAttrName, "emissiveColor")) \
+    ((IorAttrName, "ior")) \
+    ((MetallicAttrName, "metallic")) \
+    ((NormalAttrName, "normal")) \
+    ((OcclusionAttrName, "occlusion")) \
+    ((OpacityAttrName, "opacity")) \
+    ((RoughnessAttrName, "roughness")) \
+    ((SpecularColorAttrName, "specularColor")) \
+    ((UseSpecularWorkflowAttrName, "useSpecularWorkflow")) \
+    ((OutColorAttrName, "outColor")) \
+    ((OutTransparencyAttrName, "outTransparency")) \
+    ((niceName, "USD Preview Surface")) \
+    ((exportDescription, "Exports the bound shader as a USD preview surface UsdShade network.")) \
+    ((importDescription, "Search for a USD preview surface UsdShade network to import."))
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
     PxrMayaUsdPreviewSurfaceTokens,

--- a/lib/usd/translators/instancerWriter.cpp
+++ b/lib/usd/translators/instancerWriter.cpp
@@ -46,7 +46,14 @@ PXR_NAMESPACE_OPEN_SCOPE
 PXRUSDMAYA_REGISTER_WRITER(instancer, PxrUsdTranslators_InstancerWriter);
 PXRUSDMAYA_REGISTER_ADAPTOR_SCHEMA(instancer, UsdGeomPointInstancer);
 
-TF_DEFINE_PRIVATE_TOKENS(_tokens, (Prototypes)(instancerTranslate));
+// clang-format off
+TF_DEFINE_PRIVATE_TOKENS(
+    _tokens,
+
+    (Prototypes)
+    (instancerTranslate)
+);
+// clang-format on
 
 namespace {
 

--- a/lib/usd/translators/meshWriter.cpp
+++ b/lib/usd/translators/meshWriter.cpp
@@ -59,10 +59,15 @@ PXR_NAMESPACE_OPEN_SCOPE
 PXRUSDMAYA_REGISTER_WRITER(mesh, PxrUsdTranslators_MeshWriter);
 PXRUSDMAYA_REGISTER_ADAPTOR_SCHEMA(mesh, UsdGeomMesh);
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
-    ((skelJointIndices, "skel:jointIndices"))((skelJointWeights, "skel:jointWeights"))(
-        (skelGeomBindTransform, "skel:geomBindTransform")));
+
+    ((skelJointIndices, "skel:jointIndices"))
+    ((skelJointWeights, "skel:jointWeights"))
+    ((skelGeomBindTransform, "skel:geomBindTransform"))
+);
+// clang-format on
 
 PxrUsdTranslators_MeshWriter::PxrUsdTranslators_MeshWriter(
     const MFnDependencyNode& depNodeFn,

--- a/lib/usd/translators/shading/rfmShaderTranslation.cpp
+++ b/lib/usd/translators/shading/rfmShaderTranslation.cpp
@@ -27,12 +27,17 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
-    ((conversionName, "rendermanForMaya"))((renderContext, "ri"))((niceName, "RenderMan for Maya"))(
-        (exportDescription, "Exports bound shaders as a RenderMan for Maya UsdShade network."))(
-        (importDescription, "Imports a RenderMan UsdShade network.")));
+    ((conversionName, "rendermanForMaya"))
+    ((renderContext, "ri"))
+    ((niceName, "RenderMan for Maya"))
+    ((exportDescription, "Exports bound shaders as a RenderMan for Maya UsdShade network."))
+    ((importDescription, "Imports a RenderMan UsdShade network."))
+);
+// clang-format on
 
 REGISTER_SHADING_MODE_EXPORT_MATERIAL_CONVERSION(
     _tokens->conversionName,

--- a/lib/usd/translators/shading/usdBlinnWriter.cpp
+++ b/lib/usd/translators/shading/usdBlinnWriter.cpp
@@ -55,11 +55,16 @@ protected:
 
 PXRUSDMAYA_REGISTER_SHADER_WRITER(blinn, PxrUsdTranslators_BlinnWriter);
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
     // Maya material nodes attribute names
-    (eccentricity)(specularColor)(specularRollOff));
+    (eccentricity)
+    (specularColor)
+    (specularRollOff)
+);
+// clang-format on
 
 PxrUsdTranslators_BlinnWriter::PxrUsdTranslators_BlinnWriter(
     const MFnDependencyNode& depNodeFn,

--- a/lib/usd/translators/shading/usdDisplacementShaderWriter.cpp
+++ b/lib/usd/translators/shading/usdDisplacementShaderWriter.cpp
@@ -58,11 +58,14 @@ public:
 
 PXRUSDMAYA_REGISTER_SHADER_WRITER(displacementShader, PxrUsdTranslators_DisplacementShaderWriter);
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
     // Maya material nodes attribute names
-    (displacement));
+    (displacement)
+);
+// clang-format on
 
 PxrUsdTranslators_DisplacementShaderWriter::PxrUsdTranslators_DisplacementShaderWriter(
     const MFnDependencyNode& depNodeFn,

--- a/lib/usd/translators/shading/usdFileTextureWriter.cpp
+++ b/lib/usd/translators/shading/usdFileTextureWriter.cpp
@@ -68,22 +68,40 @@ public:
 
 PXRUSDMAYA_REGISTER_SHADER_WRITER(file, PxrUsdTranslators_FileTextureWriter);
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
     // Maya "file" node attribute names
-    (alphaGain)(alphaOffset)(colorGain)(colorOffset)(colorSpace)(defaultColor)(fileTextureName)(
-        outAlpha)(outColor)(outColorR)(outColorG)(outColorB)(outTransparency)(outTransparencyR)(
-        outTransparencyG)(outTransparencyB)(wrapU)(wrapV)
+    (alphaGain)
+    (alphaOffset)
+    (colorGain)
+    (colorOffset)
+    (colorSpace)
+    (defaultColor)
+    (fileTextureName)
+    (outAlpha)
+    (outColor)
+    (outColorR)
+    (outColorG)
+    (outColorB)
+    (outTransparency)
+    (outTransparencyR)
+    (outTransparencyG)
+    (outTransparencyB)
+    (wrapU)
+    (wrapV)
 
     // UDIM handling:
-    (uvTilingMode)((UDIMTag, "<UDIM>"))
+    (uvTilingMode)
+    ((UDIMTag, "<UDIM>"))
 
     // XXX: We duplicate these tokens here rather than create a dependency on
     // usdImaging in case the plugin is being built with imaging disabled.
     // If/when they move out of usdImaging to a place that is always available,
     // they should be pulled from there instead.
-    (UsdUVTexture)(UsdPrimvarReader_float2)
+    (UsdUVTexture)
+    (UsdPrimvarReader_float2)
 
     // UsdPrimvarReader_float2 Prim Name
     ((PrimvarReaderShaderName, "TexCoordReader"))
@@ -95,14 +113,26 @@ TF_DEFINE_PRIVATE_TOKENS(
     (result)
 
     // UsdUVTexture Input Names
-    (bias)(fallback)(file)(scale)(st)(wrapS)(wrapT)
+    (bias)
+    (fallback)
+    (file)
+    (scale)
+    (st)
+    (wrapS)
+    (wrapT)
 
     // Values for wrapS and wrapT
-    (black)(repeat)
+    (black)
+    (repeat)
 
     // UsdUVTexture Output Names
-    ((RGBOutputName, "rgb"))((RedOutputName, "r"))((GreenOutputName, "g"))((BlueOutputName, "b"))(
-        (AlphaOutputName, "a")));
+    ((RGBOutputName, "rgb"))
+    ((RedOutputName, "r"))
+    ((GreenOutputName, "g"))
+    ((BlueOutputName, "b"))
+    ((AlphaOutputName, "a"))
+);
+// clang-format on
 
 UsdMayaShaderWriter::ContextSupport
 PxrUsdTranslators_FileTextureWriter::CanExport(const UsdMayaJobExportArgs& exportArgs)

--- a/lib/usd/translators/shading/usdLambertWriter.cpp
+++ b/lib/usd/translators/shading/usdLambertWriter.cpp
@@ -39,11 +39,18 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 PXRUSDMAYA_REGISTER_SHADER_WRITER(lambert, PxrUsdTranslators_LambertWriter);
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
     // Maya material nodes attribute names
-    (color)(transparency)(diffuse)(incandescence)(normalCamera));
+    (color)
+    (transparency)
+    (diffuse)
+    (incandescence)
+    (normalCamera)
+);
+// clang-format on
 
 PxrUsdTranslators_LambertWriter::PxrUsdTranslators_LambertWriter(
     const MFnDependencyNode& depNodeFn,

--- a/lib/usd/translators/shading/usdMaterialWriter.cpp
+++ b/lib/usd/translators/shading/usdMaterialWriter.cpp
@@ -51,11 +51,14 @@ using namespace MAYAUSD_NS_DEF;
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
     // Maya material nodes attribute names
-    (outColor));
+    (outColor)
+);
+// clang-format on
 
 UsdMayaShaderWriter::ContextSupport
 PxrUsdTranslators_MaterialWriter::CanExport(const UsdMayaJobExportArgs& exportArgs)

--- a/lib/usd/translators/shading/usdPhongEWriter.cpp
+++ b/lib/usd/translators/shading/usdPhongEWriter.cpp
@@ -52,11 +52,14 @@ public:
 
 PXRUSDMAYA_REGISTER_SHADER_WRITER(phongE, PxrUsdTranslators_PhongEWriter);
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
     // Maya
-    (roughness));
+    (roughness)
+);
+// clang-format on
 
 PxrUsdTranslators_PhongEWriter::PxrUsdTranslators_PhongEWriter(
     const MFnDependencyNode& depNodeFn,

--- a/lib/usd/translators/shading/usdPhongWriter.cpp
+++ b/lib/usd/translators/shading/usdPhongWriter.cpp
@@ -54,11 +54,14 @@ public:
 
 PXRUSDMAYA_REGISTER_SHADER_WRITER(phong, PxrUsdTranslators_PhongWriter);
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
     // Maya material nodes attribute names
-    (cosinePower));
+    (cosinePower)
+);
+// clang-format on
 
 PxrUsdTranslators_PhongWriter::PxrUsdTranslators_PhongWriter(
     const MFnDependencyNode& depNodeFn,

--- a/lib/usd/translators/shading/usdReflectWriter.cpp
+++ b/lib/usd/translators/shading/usdReflectWriter.cpp
@@ -28,11 +28,14 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
     // Maya material nodes attribute names
-    (specularColor));
+    (specularColor)
+);
+// clang-format on
 
 PxrUsdTranslators_ReflectWriter::PxrUsdTranslators_ReflectWriter(
     const MFnDependencyNode& depNodeFn,

--- a/lib/usd/translators/shading/usdStandardSurfaceWriter.cpp
+++ b/lib/usd/translators/shading/usdStandardSurfaceWriter.cpp
@@ -56,12 +56,26 @@ public:
 
 PXRUSDMAYA_REGISTER_SHADER_WRITER(standardSurface, PxrUsdTranslators_StandardSurfaceWriter);
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
     // Maya material nodes attribute names
-    (base)(baseColor)(emission)(emissionColor)(metalness)(specular)(specularColor)(specularIOR)(
-        specularRoughness)(coat)(coatRoughness)(transmission)(normalCamera));
+    (base)
+    (baseColor)
+    (emission)
+    (emissionColor)
+    (metalness)
+    (specular)
+    (specularColor)
+    (specularIOR)
+    (specularRoughness)
+    (coat)
+    (coatRoughness)
+    (transmission)
+    (normalCamera)
+);
+// clang-format on
 
 PxrUsdTranslators_StandardSurfaceWriter::PxrUsdTranslators_StandardSurfaceWriter(
     const MFnDependencyNode& depNodeFn,

--- a/lib/usd/translators/shading/usdUVTextureReader.cpp
+++ b/lib/usd/translators/shading/usdUVTextureReader.cpp
@@ -55,27 +55,65 @@ public:
 
 PXRUSDMAYA_REGISTER_SHADER_READER(UsdUVTexture, PxrMayaUsdUVTexture_Reader)
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
     // Maya "file" node attribute names
-    (file)(alphaGain)(alphaOffset)(colorGain)(colorOffset)(colorSpace)(defaultColor)(
-        fileTextureName)(outAlpha)(outColor)(outColorR)(outColorG)(outColorB)(place2dTexture)(
-        coverage)(translateFrame)(rotateFrame)(mirrorU)(mirrorV)(stagger)(wrapU)(wrapV)(repeatUV)(
-        offset)(rotateUV)(noiseUV)(vertexUvOne)(vertexUvTwo)(vertexUvThree)(vertexCameraOne)
+    (file)
+    (alphaGain)
+    (alphaOffset)
+    (colorGain)
+    (colorOffset)
+    (colorSpace)
+    (defaultColor)
+    (fileTextureName)
+    (outAlpha)
+    (outColor)
+    (outColorR)
+    (outColorG)
+    (outColorB)
+    (place2dTexture)
+    (coverage)
+    (translateFrame)
+    (rotateFrame)
+    (mirrorU)
+    (mirrorV)
+    (stagger)
+    (wrapU)
+    (wrapV)
+    (repeatUV)
+    (offset)
+    (rotateUV)
+    (noiseUV)
+    (vertexUvOne)
+    (vertexUvTwo)
+    (vertexUvThree)
+    (vertexCameraOne)
 
     // UsdUVTexture Input Names
-    (bias)(fallback)(scale)(wrapS)(wrapT)
+    (bias)
+    (fallback)
+    (scale)
+    (wrapS)
+    (wrapT)
 
     // Values for wrapS and wrapT
-    (black)(repeat)
+    (black)
+    (repeat)
 
     // UsdUVTexture Output Names
-    ((RGBOutputName, "rgb"))((RedOutputName, "r"))((GreenOutputName, "g"))((BlueOutputName, "b"))(
-        (AlphaOutputName, "a"))
+    ((RGBOutputName, "rgb"))
+    ((RedOutputName, "r"))
+    ((GreenOutputName, "g"))
+    ((BlueOutputName, "b"))
+    ((AlphaOutputName, "a"))
 
     // UDIM detection
-    ((UDIMTag, "<UDIM>"))(uvTilingMode));
+    ((UDIMTag, "<UDIM>"))
+    (uvTilingMode)
+);
+// clang-format on
 
 static const TfTokenVector _Place2dTextureConnections = {
     _tokens->coverage,    _tokens->translateFrame, _tokens->rotateFrame,   _tokens->mirrorU,

--- a/plugin/al/schemas/codegenTemplates/tokens.h
+++ b/plugin/al/schemas/codegenTemplates/tokens.h
@@ -35,12 +35,14 @@
 {{ namespaceOpen }}
 
 {% endif %}
+// clang-format off
 /// \hideinitializer
 #define {{ Upper(tokensPrefix) }}_TOKENS \
 {% for token in tokens %}
     {% if token.id == token.value -%}({{ token.id }})
     {%- else -%}                     (({{ token.id }}, "{{ token.value}}"))
     {%- endif -%}{% if not loop.last %} \{% endif %}
+// clang-format on
 
 {% endfor %}
 

--- a/plugin/pxr/maya/lib/usdMaya/proxyShape.h
+++ b/plugin/pxr/maya/lib/usdMaya/proxyShape.h
@@ -48,7 +48,10 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define PXRUSDMAYA_PROXY_SHAPE_TOKENS ((MayaTypeName, "pxrUsdProxyShape"))
+// clang-format off
+#define PXRUSDMAYA_PROXY_SHAPE_TOKENS \
+    ((MayaTypeName, "pxrUsdProxyShape"))
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(UsdMayaProxyShapeTokens, PXRUSDMAYA_API, PXRUSDMAYA_PROXY_SHAPE_TOKENS);
 

--- a/plugin/pxr/maya/lib/usdMaya/readJob_ImportWithProxies.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/readJob_ImportWithProxies.cpp
@@ -48,12 +48,18 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
-    ((PointInstancerTypeName, "PxPointInstancer"))((XformTypeName, "Xform"))(
-        (GeomRootName, "Geom"))((ScopePrimTypeName, "Scope"))
 
-        ((MayaProxyShapeNodeName, "GeomProxy"))((ExcludePrimPathsPlugName, "excludePrimPaths")));
+    ((PointInstancerTypeName, "PxPointInstancer"))
+    ((XformTypeName, "Xform"))
+    ((GeomRootName, "Geom"))
+    ((ScopePrimTypeName, "Scope"))
+    ((MayaProxyShapeNodeName, "GeomProxy"))
+    ((ExcludePrimPathsPlugName, "excludePrimPaths"))
+);
+// clang-format on
 
 /*******************************************************************************
  *                                                                              *

--- a/plugin/pxr/maya/lib/usdMaya/referenceAssembly.h
+++ b/plugin/pxr/maya/lib/usdMaya/referenceAssembly.h
@@ -42,14 +42,20 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#define PXRUSDMAYA_REFERENCE_ASSEMBLY_TOKENS ((MayaTypeName, "pxrUsdReferenceAssembly"))
+// clang-format off
+#define PXRUSDMAYA_REFERENCE_ASSEMBLY_TOKENS \
+    ((MayaTypeName, "pxrUsdReferenceAssembly"))
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
     UsdMayaReferenceAssemblyTokens,
     PXRUSDMAYA_API,
     PXRUSDMAYA_REFERENCE_ASSEMBLY_TOKENS);
 
-#define PXRUSDMAYA_VARIANT_SET_TOKENS ((PlugNamePrefix, "usdVariantSet_"))
+// clang-format off
+#define PXRUSDMAYA_VARIANT_SET_TOKENS \
+    ((PlugNamePrefix, "usdVariantSet_"))
+// clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(UsdMayaVariantSetTokens, PXRUSDMAYA_API, PXRUSDMAYA_VARIANT_SET_TOKENS);
 

--- a/plugin/pxr/maya/lib/usdMaya/translatorModelAssembly.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/translatorModelAssembly.cpp
@@ -64,15 +64,21 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
-    ((FilePathPlugName, "filePath"))((PrimPathPlugName, "primPath"))((KindPlugName, "kind"))
 
-        ((MayaProxyShapeNameSuffix, "Proxy"))
+    ((FilePathPlugName, "filePath"))
+    ((PrimPathPlugName, "primPath"))
+    ((KindPlugName, "kind"))
+    ((MayaProxyShapeNameSuffix, "Proxy"))
 
     // XXX: These should eventually be replaced/removed when the proxy shape
     // node supports all variantSets and not just modelingVariant.
-    (variantKey)(modelingVariant));
+    (variantKey)
+    (modelingVariant)
+);
+// clang-format on
 
 /* static */
 bool UsdMayaTranslatorModelAssembly::Create(

--- a/plugin/pxr/maya/plugin/pxrUsd/alembicChaser.cpp
+++ b/plugin/pxr/maya/plugin/pxrUsd/alembicChaser.cpp
@@ -41,13 +41,18 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
-    ((abcTypeSuffix, "_AbcType"))((abcGeomScopeSuffix, "_AbcGeomScope"))(
-        (abcGeomScopeFaceVarying, "fvr"))((abcGeomScopeUniform, "uni"))((abcGeomScopeVertex, "vtx"))
-
-        ((userProperties, "userProperties:")));
+    ((abcTypeSuffix, "_AbcType"))
+    ((abcGeomScopeSuffix, "_AbcGeomScope"))
+    ((abcGeomScopeFaceVarying, "fvr"))
+    ((abcGeomScopeUniform, "uni"))
+    ((abcGeomScopeVertex, "vtx"))
+    ((userProperties, "userProperties:"))
+);
+// clang-format on
 
 struct _AttributeEntry
 {

--- a/test/lib/usd/plugin/mayaShaderTranslation.cpp
+++ b/test/lib/usd/plugin/mayaShaderTranslation.cpp
@@ -33,14 +33,20 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
 
-    ((conversionName, "maya"))((renderContext, "maya"))((niceName, "Maya Shaders"))(
-        (exportDescription,
+    ((conversionName, "maya"))
+    ((renderContext, "maya"))
+    ((niceName, "Maya Shaders"))
+    ((exportDescription,
          "Dumps the bound shader in a Maya UsdShade network that can only be "
-         "used for import. Will not render in the Maya viewport or usdView."))(
-        (importDescription, "Fetches back a Maya shader network dumped as UsdShade")));
+         "used for import. Will not render in the Maya viewport or usdView."))
+    ((importDescription,
+        "Fetches back a Maya shader network dumped as UsdShade"))
+);
+// clang-format on
 
 REGISTER_SHADING_MODE_EXPORT_MATERIAL_CONVERSION(
     _tokens->conversionName,


### PR DESCRIPTION
It looks like `clang-format` is pretty seriously mangling some of the code that defines public and private tokens, so this change wraps many of these in `// clang-format off` and `// clang-format on`.