### PR TITLE
MAYA-103547 Use the common utility function to check error conditions

### DIFF
--- a/lib/mayaUsd/ufe/UsdSceneItemOps.cpp
+++ b/lib/mayaUsd/ufe/UsdSceneItemOps.cpp
@@ -87,24 +87,15 @@ bool UsdSceneItemOps::deleteItem()
 
 Ufe::Duplicate UsdSceneItemOps::duplicateItemCmd()
 {
-    auto duplicateCmd = UsdUndoDuplicateCommand::create(prim(), fItem->path());
+    auto duplicateCmd = UsdUndoDuplicateCommand::create(fItem);
     duplicateCmd->execute();
-    auto item = createSiblingSceneItem(path(), duplicateCmd->usdDstPath().GetElementString());
-    return Ufe::Duplicate(item, duplicateCmd);
+    return Ufe::Duplicate(duplicateCmd->duplicatedItem(), duplicateCmd);
 }
 
 Ufe::SceneItem::Ptr UsdSceneItemOps::duplicateItem()
 {
-    SdfPath        usdDstPath;
-    SdfLayerHandle layer;
-    UsdUndoDuplicateCommand::primInfo(prim(), usdDstPath, layer);
-    bool status = UsdUndoDuplicateCommand::duplicate(layer, prim().GetPath(), usdDstPath);
-
-    // The duplicate is a sibling of the source.
-    if (status)
-        return createSiblingSceneItem(path(), usdDstPath.GetElementString());
-
-    return nullptr;
+    auto duplicate = duplicateItemCmd();
+    return duplicate.item;
 }
 
 Ufe::SceneItem::Ptr UsdSceneItemOps::renameItem(const Ufe::PathComponent& newName)

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
@@ -72,6 +72,13 @@ void UsdUndoDuplicateCommand::primInfo(
     // has a numerical suffix, increment it, otherwise append "1" to it.
     auto dstName = uniqueName(childrenNames, srcPrim.GetName());
     usdDstPath = parent.GetPath().AppendChild(TfToken(dstName));
+
+    srcLayer = MayaUsdUtils::defPrimSpecLayer(srcPrim);
+    if (!srcLayer) {
+        std::string err
+            = TfStringPrintf("No prim found at %s", srcPrim.GetPath().GetString().c_str());
+        throw std::runtime_error(err.c_str());
+    }
 }
 
 /*static*/

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include <mayaUsd/base/api.h>
-#include <mayaUsd/ufe/UsdSceneItem.h>
 
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/prim.h>
@@ -57,19 +56,15 @@ public:
     static bool
     duplicate(const SdfLayerHandle& layer, const SdfPath& usdSrcPath, const SdfPath& usdDstPath);
 
-    //! Return the USD destination path and layer.
-    static void primInfo();
-
     // UsdUndoDuplicateCommand overrides
     void undo() override;
     void redo() override;
 
 private:
-    UsdPrim         fSrcPrim;
-    UsdStageWeakPtr fStage;
-    SdfLayerHandle  fLayer;
-    Ufe::Path       fUfeSrcPath;
-    SdfPath         fUsdDstPath;
+    UsdPrim        _srcPrim;
+    SdfLayerHandle _layer;
+    Ufe::Path      _ufeSrcPath;
+    SdfPath        _usdDstPath;
 
 }; // UsdUndoDuplicateCommand
 

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.h
@@ -16,9 +16,9 @@
 #pragma once
 
 #include <mayaUsd/base/api.h>
+#include <mayaUsd/ufe/UsdSceneItem.h>
 
 #include <pxr/usd/sdf/path.h>
-#include <pxr/usd/usd/prim.h>
 
 #include <ufe/path.h>
 #include <ufe/undoableCommand.h>
@@ -34,7 +34,7 @@ class MAYAUSD_CORE_PUBLIC UsdUndoDuplicateCommand : public Ufe::UndoableCommand
 public:
     typedef std::shared_ptr<UsdUndoDuplicateCommand> Ptr;
 
-    UsdUndoDuplicateCommand(const UsdPrim& srcPrim, const Ufe::Path& ufeSrcPath);
+    UsdUndoDuplicateCommand(const UsdSceneItem::Ptr& srcItem);
     ~UsdUndoDuplicateCommand() override;
 
     // Delete the copy/move constructors assignment operators.
@@ -44,28 +44,20 @@ public:
     UsdUndoDuplicateCommand& operator=(UsdUndoDuplicateCommand&&) = delete;
 
     //! Create a UsdUndoDuplicateCommand from a USD prim and UFE path.
-    static UsdUndoDuplicateCommand::Ptr create(const UsdPrim& srcPrim, const Ufe::Path& ufeSrcPath);
+    static UsdUndoDuplicateCommand::Ptr create(const UsdSceneItem::Ptr& srcItem);
 
-    const SdfPath& usdDstPath() const;
-
-    //! Return the USD destination path and layer.
-    static void primInfo(const UsdPrim& srcPrim, SdfPath& usdDstPath, SdfLayerHandle& srcLayer);
-
-    //! Duplicate the prim hierarchy at usdSrcPath.
-    //! \return True for success.
-    static bool
-    duplicate(const SdfLayerHandle& layer, const SdfPath& usdSrcPath, const SdfPath& usdDstPath);
+    UsdSceneItem::Ptr duplicatedItem() const;
 
     // UsdUndoDuplicateCommand overrides
     void undo() override;
     void redo() override;
 
 private:
-    UsdPrim        _srcPrim;
-    SdfLayerHandle _layer;
-    Ufe::Path      _ufeSrcPath;
-    SdfPath        _usdDstPath;
+    bool duplicateUndo();
+    bool duplicateRedo();
 
+    Ufe::Path _ufeSrcPath;
+    SdfPath   _usdDstPath;
 }; // UsdUndoDuplicateCommand
 
 } // namespace ufe

--- a/test/lib/ufe/testDuplicateCmd.py
+++ b/test/lib/ufe/testDuplicateCmd.py
@@ -135,9 +135,7 @@ class DuplicateCmdTestCase(unittest.TestCase):
         self.assertNotIn(sphereDupName, worldChildrenNames)
         self.assertNotIn(ball35DupName, propsChildrenNames)
 
-        # MAYA-92264: because of USD bug, redo doesn't work.
-        """
-        return
+        # The duplicated items shoudl reappear after a redo
         cmds.redo()
 
         snIter = iter(ufe.GlobalSelection.get())
@@ -152,7 +150,8 @@ class DuplicateCmdTestCase(unittest.TestCase):
 
         self.assertIn(sphereDupItem, worldChildren)
         self.assertIn(ball35DupItem, propsChildren)
-        """
+
+        cmds.undo()
 
         # The duplicated items should not be assigned to the name of a
         # deactivated USD item.


### PR DESCRIPTION
There is a utility function in Utils that can be shared between some of the commands (e.g. duplicate and rename).  Using it to get the correct logic and proper error message.

There is still a question about what the exact logic/message should be for the commands, but if we want to change it then that will happen in a separate PR.