### PR TITLE
Add support for Boost_NO_BOOST_CMAKE=ON for Boost::python

### DIFF
--- a/plugin/al/CMakeLists.txt
+++ b/plugin/al/CMakeLists.txt
@@ -25,7 +25,6 @@ option(SKIP_USDMAYA_TESTS "Build tests" OFF)
 # Adding specific components forces calls to _Boost_find_library, which
 # is the rationale for listing them here.
 set(Boost_FIND_COMPONENTS
-     python
      thread
 )
 if(NEED_BOOST_FILESYSTEM)
@@ -42,6 +41,35 @@ if(WIN32)
     if(MAYAUSD_DEFINE_BOOST_DEBUG_PYTHON_FLAG)
         set(Boost_USE_DEBUG_PYTHON ON)
     endif()
+endif()
+
+find_package(Boost REQUIRED)
+
+# As of boost 1.67 the boost_python component name includes the
+# associated Python version (e.g. python27, python36). After boost 1.70
+# the built-in cmake files will deal with this. If we are using boost
+# that does not have working cmake files, or we are using a new boost
+# and not using cmake's boost files, we need to do the below.
+# https://cmake.org/cmake/help/latest/module/FindBoost.html
+# Find the component under the versioned name and then set the generic
+# Boost_PYTHON_LIBRARY variable so that we don't have to duplicate this
+# logic in each library's CMakeLists.txt.
+set(boost_version_string "${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION}")
+if (((${boost_version_string} VERSION_GREATER_EQUAL "1.67") AND
+    (${boost_version_string} VERSION_LESS "1.70")) OR
+    ((${boost_version_string} VERSION_GREATER_EQUAL "1.70") AND
+    Boost_NO_BOOST_CMAKE))
+
+    set(python_version_nodot "${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
+    list(APPEND Boost_FIND_COMPONENTS
+        python${python_version_nodot}
+    )
+
+    set(Boost_PYTHON_LIBRARY "${Boost_PYTHON${python_version_nodot}_LIBRARY}")
+else()
+    list(APPEND Boost_FIND_COMPONENTS
+        python
+    )
 endif()
 
 find_package(Boost COMPONENTS

--- a/plugin/al/lib/AL_USDMaya/CMakeLists.txt
+++ b/plugin/al/lib/AL_USDMaya/CMakeLists.txt
@@ -208,7 +208,7 @@ target_link_libraries(${LIBRARY_NAME}
     usdImaging
     usdImagingGL
     vt
-    Boost::python
+    ${Boost_PYTHON_LIBRARY}
     $<IF:$<VERSION_GREATER_EQUAL:${Boost_VERSION},${boost_1_70_0_ver_string}>,Boost::thread,${Boost_THREAD_LIBRARY}>
     $<$<BOOL:${IS_WINDOWS}>:Boost::chrono>
     $<$<BOOL:${IS_WINDOWS}>:Boost::date_time>

--- a/plugin/al/schemas/AL/usd/schemas/maya/tests/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/maya/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries(${TARGET_NAME}
     tf
     vt
     plug
-    Boost::python
+    ${Boost_PYTHON_LIBRARY}
 )
 
 # install

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/CMakeLists.txt
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/CMakeLists.txt
@@ -63,7 +63,7 @@ target_link_libraries(${USDMAYA_UTILS_LIBRARY_NAME}
   usdGeom
   usdUtils
   vt
-  Boost::python
+  ${Boost_PYTHON_LIBRARY}
   ${PYTHON_LIBRARIES}
   ${MAYA_Foundation_LIBRARY}
   ${MAYA_OpenMaya_LIBRARY}


### PR DESCRIPTION
This PR is a reflection of our internal changes to support Boost_NO_BOOST_CMAKE=ON for using boost::python along custom paths. 

For a set of Boost Versions, the CMake setup made it difficult to use your own Boost library paths.
Prior to Boost 1.70, certain versions of CMake failed to find Boosts Python library due to the addition of version suffixes.
From Boost 1.70 onwards, it is possible for Boost to optionally support CMake files, but can also be problematic if you want to sub in your own paths. Occasionally without Boost_NO_BOOST_CMAKE, CMake will resolve to other versions of boost even if you specify an explicit boost root path. Hence the need for Boost_NO_BOOST_CMAKE.
See https://stackoverflow.com/a/63094072 for more details.

This doesn't appear to affect any other of the Boost requirements for Maya USD, and so we only manage that one specific library here.