### PR TITLE
Add FPS metadata to exported usd files if non static

### DIFF
--- a/lib/mayaUsd/fileio/jobs/writeJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/writeJob.cpp
@@ -244,6 +244,8 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
     if (!mJobCtx.mArgs.timeSamples.empty()) {
         mJobCtx.mStage->SetStartTimeCode(mJobCtx.mArgs.timeSamples.front());
         mJobCtx.mStage->SetEndTimeCode(mJobCtx.mArgs.timeSamples.back());
+        mJobCtx.mStage->SetTimeCodesPerSecond(UsdMayaUtil::GetSceneMTimeUnitAsFloat());
+        mJobCtx.mStage->SetFramesPerSecond(UsdMayaUtil::GetSceneMTimeUnitAsFloat());
     }
 
     // Setup the requested render layer mode:

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -2078,3 +2078,172 @@ void UsdMayaUtil::GetFilteredSelectionToExport(
             dagPaths.emplace(pIter);
     }
 }
+
+float UsdMayaUtil::ConvertMTimeUnitToFloat(const MTime::Unit& unit)
+{
+    float ret = 0.f;
+    switch (unit) {
+    case MTime::k2FPS: {
+        ret = 2.f;
+    } break;
+    case MTime::k3FPS: {
+        ret = 3.f;
+    } break;
+    case MTime::k4FPS: {
+        ret = 4.f;
+    } break;
+    case MTime::k5FPS: {
+        ret = 5.f;
+    } break;
+    case MTime::k6FPS: {
+        ret = 6.f;
+    } break;
+    case MTime::k8FPS: {
+        ret = 8.f;
+    } break;
+    case MTime::k10FPS: {
+        ret = 10.f;
+    } break;
+    case MTime::k12FPS: {
+        ret = 12.f;
+    } break;
+    case MTime::k15FPS: {
+        ret = 15.f;
+    } break;
+    case MTime::k16FPS: {
+        ret = 16.f;
+    } break;
+    case MTime::k20FPS: {
+        ret = 20.f;
+    } break;
+    case MTime::k23_976FPS: {
+        ret = 23.976f;
+    } break;
+    case MTime::k24FPS: {
+        ret = 24.f;
+    } break;
+    case MTime::k25FPS: {
+        ret = 25.f;
+    } break;
+    case MTime::k29_97FPS: {
+        ret = 29.97f;
+    } break;
+    case MTime::k29_97DF: {
+        ret = 29.97f;
+    } break;
+    case MTime::k30FPS: {
+        ret = 30.f;
+    } break;
+    case MTime::k40FPS: {
+        ret = 40.f;
+    } break;
+    case MTime::k47_952FPS: {
+        ret = 47.952f;
+    } break;
+    case MTime::k48FPS: {
+        ret = 48.f;
+    } break;
+    case MTime::k50FPS: {
+        ret = 50.f;
+    } break;
+    case MTime::k59_94FPS: {
+        ret = 59.94f;
+    } break;
+    case MTime::k60FPS: {
+        ret = 60.f;
+    } break;
+    case MTime::k75FPS: {
+        ret = 75.f;
+    } break;
+    case MTime::k80FPS: {
+        ret = 80.f;
+    } break;
+#if MAYA_API_VERSION >= 20200000
+    case MTime::k90FPS: {
+        ret = 90.f;
+    } break;
+#endif
+    case MTime::k100FPS: {
+        ret = 100.f;
+    } break;
+    case MTime::k120FPS: {
+        ret = 120.f;
+    } break;
+    case MTime::k125FPS: {
+        ret = 125.f;
+    } break;
+    case MTime::k150FPS: {
+        ret = 150.f;
+    } break;
+    case MTime::k200FPS: {
+        ret = 200.f;
+    } break;
+    case MTime::k240FPS: {
+        ret = 240.f;
+    } break;
+    case MTime::k250FPS: {
+        ret = 250.f;
+    } break;
+    case MTime::k300FPS: {
+        ret = 300.f;
+    } break;
+    case MTime::k375FPS: {
+        ret = 375.f;
+    } break;
+    case MTime::k400FPS: {
+        ret = 400.f;
+    } break;
+    case MTime::k500FPS: {
+        ret = 500.f;
+    } break;
+    case MTime::k600FPS: {
+        ret = 600.f;
+    } break;
+    case MTime::k750FPS: {
+        ret = 750.f;
+    } break;
+    case MTime::k1200FPS: {
+        ret = 1200.f;
+    } break;
+    case MTime::k1500FPS: {
+        ret = 1500.f;
+    } break;
+    case MTime::k2000FPS: {
+        ret = 2000.f;
+    } break;
+    case MTime::k3000FPS: {
+        ret = 3000.f;
+    } break;
+    case MTime::k6000FPS: {
+        ret = 6000.f;
+    } break;
+    case MTime::k44100FPS: {
+        ret = 44100.f;
+    } break;
+    case MTime::k48000FPS: {
+        ret = 48000.f;
+    } break;
+    case MTime::kHours: {
+        ret = (1.f / 3600.f);
+    } break;
+    case MTime::kMinutes: {
+        ret = (1.f / 60.f);
+    } break;
+    case MTime::kSeconds: {
+        ret = 1.0f;
+    } break;
+    case MTime::kMilliseconds: {
+        ret = 1000.f;
+    } break;
+    default: {
+        ret = 0.0f;
+    } break;
+    }
+    return ret;
+}
+
+float UsdMayaUtil::GetSceneMTimeUnitAsFloat()
+{
+    const MTime::Unit sceneUnit = MTime::uiUnit();
+    return UsdMayaUtil::ConvertMTimeUnitToFloat(sceneUnit);
+}

--- a/lib/mayaUsd/utils/util.h
+++ b/lib/mayaUsd/utils/util.h
@@ -48,6 +48,7 @@
 #include <maya/MSelectionList.h>
 #include <maya/MStatus.h>
 #include <maya/MString.h>
+#include <maya/MTime.h>
 
 #include <map>
 #include <set>
@@ -568,6 +569,16 @@ void GetFilteredSelectionToExport(
     bool                      exportSelected,
     MSelectionList&           objectList,
     UsdMayaUtil::MDagPathSet& dagPaths);
+
+/// Coverts a given \pMTime::\pUnit enum to a \pfloat value of samples per second
+/// Returns 0.0f if the result is invalid.
+MAYAUSD_CORE_PUBLIC
+float ConvertMTimeUnitToFloat(const MTime::Unit& unit);
+
+/// Get's the scene's \pMTime::\pUnit as a \pfloat value of samples per second
+/// Returns 0.0f if the result is invalid.
+MAYAUSD_CORE_PUBLIC
+float GetSceneMTimeUnitAsFloat();
 
 } // namespace UsdMayaUtil
 

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_SCRIPT_FILES
     testUsdExportFrameOffset.py
     testUsdExportGeomSubset.py
     testUsdExportInstances.py
+    testUsdExportLayerAttributes.py
     testUsdExportLocator.py
     testUsdExportMayaInstancer.py
     testUsdExportMesh.py

--- a/test/lib/usd/translators/testUsdExportLayerAttributes.py
+++ b/test/lib/usd/translators/testUsdExportLayerAttributes.py
@@ -1,0 +1,62 @@
+#!/pxrpythonsubst
+
+
+#
+# Copyright 2020 Apple
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import unittest
+
+import fixturesUtils
+from maya import cmds
+from maya import standalone
+from pxr import Usd
+
+
+class testMayaUsdExportLayerAttributes(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = fixturesUtils.setUpClass(__file__)
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def test_fps_30(self):
+        fps_map = {
+            "ntsc": 30,
+            "game": 15,
+            "film": 24,
+            "pal": 25,
+            "show": 48,
+            "palf": 50,
+            "ntscf": 60
+
+        }
+
+        for name, fps in fps_map.items():
+            cmds.currentUnit(time=name)
+            temp_file = os.path.join(self.temp_dir, 'test_{}.usda'.format(name))
+            cmds.mayaUSDExport(f=temp_file, frameRange=(1, 5))
+
+            stage = Usd.Stage.Open(temp_file)
+            self.assertEqual(stage.GetTimeCodesPerSecond(), fps)
+            self.assertEqual(stage.GetFramesPerSecond(), fps)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The current exporter behavior writes out frames as if the USD is a the current scenes uiUnits, but does not actually set the fps attributes in the exported layer. This causes downstream readers to treat it as 24fps as is default.

This change adds both TimeCodesPerSecond and FramesPerSecond, if the exporter is exporting animation. This will allow downstream readers to playback at the correct timing.

As a side note...it is surprising that MTimeUnit doesn't have an API method to convert to float values. Would be great in the future if that was exposed, rather than resorting to a hardcoded mapping here.