### PR TITLE
Add opacity threshold to USD Preview Surface Shader

### DIFF
--- a/lib/usd/pxrUsdPreviewSurface/AEusdPreviewSurfaceTemplate.mel
+++ b/lib/usd/pxrUsdPreviewSurface/AEusdPreviewSurfaceTemplate.mel
@@ -41,6 +41,7 @@ global proc AE${PREVIEWSURFACE_MAYA_TYPE_NAME}Template(string $nodeName)
     editorTemplate -addControl "emissiveColor";
     editorTemplate -addControl "occlusion";
     editorTemplate -addControl "opacity";
+    editorTemplate -addControl "opacityThreshold";
 
     editorTemplate -beginLayout "Specular" -collapse false;
         editorTemplate -addControl "useSpecularWorkflow"

--- a/lib/usd/pxrUsdPreviewSurface/usdPreviewSurface.h
+++ b/lib/usd/pxrUsdPreviewSurface/usdPreviewSurface.h
@@ -45,6 +45,7 @@ PXR_NAMESPACE_OPEN_SCOPE
     ((NormalAttrName, "normal"))                                                                 \
     ((OcclusionAttrName, "occlusion"))                                                           \
     ((OpacityAttrName, "opacity"))                                                               \
+    ((OpacityThresholdAttrName, "opacityThreshold"))                                             \
     ((RoughnessAttrName, "roughness"))                                                           \
     ((SpecularColorAttrName, "specularColor"))                                                   \
     ((UseSpecularWorkflowAttrName, "useSpecularWorkflow"))                                       \

--- a/lib/usd/pxrUsdPreviewSurface/usdPreviewSurfaceReader.cpp
+++ b/lib/usd/pxrUsdPreviewSurface/usdPreviewSurfaceReader.cpp
@@ -137,6 +137,7 @@ TfToken PxrMayaUsdPreviewSurface_Reader::GetMayaNameForUsdAttrName(const TfToken
             || baseName == PxrMayaUsdPreviewSurfaceTokens->NormalAttrName
             || baseName == PxrMayaUsdPreviewSurfaceTokens->OcclusionAttrName
             || baseName == PxrMayaUsdPreviewSurfaceTokens->OpacityAttrName
+            || baseName == PxrMayaUsdPreviewSurfaceTokens->OpacityThresholdAttrName
             || baseName == PxrMayaUsdPreviewSurfaceTokens->RoughnessAttrName
             || baseName == PxrMayaUsdPreviewSurfaceTokens->SpecularColorAttrName
             || baseName == PxrMayaUsdPreviewSurfaceTokens->UseSpecularWorkflowAttrName) {

--- a/lib/usd/pxrUsdPreviewSurface/usdPreviewSurfaceWriter.cpp
+++ b/lib/usd/pxrUsdPreviewSurface/usdPreviewSurfaceWriter.cpp
@@ -253,6 +253,14 @@ void PxrMayaUsdPreviewSurface_Writer::Write(const UsdTimeCode& usdTime)
         SdfValueTypeNames->Float,
         usdTime);
 
+    // Opacity Threshold
+    _AuthorShaderInputFromShadingNodeAttr(
+        depNodeFn,
+        shaderSchema,
+        PxrMayaUsdPreviewSurfaceTokens->OpacityThresholdAttrName,
+        SdfValueTypeNames->Float,
+        usdTime);
+
     // Roughness
     _AuthorShaderInputFromShadingNodeAttr(
         depNodeFn,
@@ -306,6 +314,7 @@ PxrMayaUsdPreviewSurface_Writer::GetShadingAttributeNameForMayaAttrName(const Tf
         || mayaAttrName == PxrMayaUsdPreviewSurfaceTokens->NormalAttrName
         || mayaAttrName == PxrMayaUsdPreviewSurfaceTokens->OcclusionAttrName
         || mayaAttrName == PxrMayaUsdPreviewSurfaceTokens->OpacityAttrName
+        || mayaAttrName == PxrMayaUsdPreviewSurfaceTokens->OpacityThresholdAttrName
         || mayaAttrName == PxrMayaUsdPreviewSurfaceTokens->RoughnessAttrName
         || mayaAttrName == PxrMayaUsdPreviewSurfaceTokens->SpecularColorAttrName
         || mayaAttrName == PxrMayaUsdPreviewSurfaceTokens->UseSpecularWorkflowAttrName) {

--- a/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
+++ b/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
@@ -68,6 +68,7 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
         cmds.setAttr(material_node + ".specularColor", 0.125, 0.25, 0.75,
                      type="double3")
         cmds.setAttr(material_node + ".useSpecularWorkflow", True)
+        cmds.setAttr(material_node + ".opacityThreshold", 0.5)
 
         file_node = cmds.shadingNode("file", asTexture=True,
                                      isColorManaged=True)
@@ -131,6 +132,8 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
         # Check values:
         self.assertAlmostEqual(cmds.getAttr("usdPreviewSurface2.roughness"),
                                0.25)
+        self.assertAlmostEqual(cmds.getAttr("usdPreviewSurface2.opacityThreshold"),
+                               0.5)
         self.assertEqual(cmds.getAttr("usdPreviewSurface2.specularColor"),
                          [(0.125, 0.25, 0.75)])
         self.assertTrue(cmds.getAttr("usdPreviewSurface2.useSpecularWorkflow"))


### PR DESCRIPTION
Opacity Threshold is an attribute on the USD preview surface shader that wasn't previously exposed to Maya, however is useful for artists to define the cutoff level for their opacity maps.

This exposes it in the attribute editor, makes sure it serializes properly to USD and that it clips the opacity accordingly. 

There's a very minimal test included here that we used to check after merging upstream commits, but I hope we can add more material serialization tests in the future so I'm including it here.