### PR TITLE
Apply clang-format two more times to make sure we have everything formatted

### DIFF
--- a/lib/mayaUsd/ufe/UsdAttributes.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributes.cpp
@@ -127,85 +127,17 @@ UsdAttributes::getUfeTypeForAttribute(const PXR_NS::UsdAttribute& usdAttr) const
 {
     // Map the USD type into UFE type.
     static const std::unordered_map<size_t, Ufe::Attribute::Type> sUsdTypeToUfe {
-        { SdfValueTypeNames->Bool.GetHash(), Ufe::Attribute::kBool }, // bool
-        //		{SdfValueTypeNames->UChar.GetHash(), Ufe::Attribute::kUnknown},
-        //// uint8_t
-        { SdfValueTypeNames->Int.GetHash(), Ufe::Attribute::kInt }, // int32_t
-        //		{SdfValueTypeNames->UInt.GetHash(), Ufe::Attribute::kUnknown},
-        //// uint32_t
-        //		{SdfValueTypeNames->Int64.GetHash(), Ufe::Attribute::kInt},
-        //// int64_t 		{SdfValueTypeNames->UInt64.GetHash(),
-        /// Ufe::Attribute::kUnknown}, / uint64_t
-        //		{SdfValueTypeNames->Half.GetHash(), Ufe::Attribute::kUnknown},
-        //// GfHalf
-        { SdfValueTypeNames->Float.GetHash(), Ufe::Attribute::kFloat },      // float
-        { SdfValueTypeNames->Double.GetHash(), Ufe::Attribute::kDouble },    // double
-        { SdfValueTypeNames->String.GetHash(), Ufe::Attribute::kString },    // std::string
-        { SdfValueTypeNames->Token.GetHash(), Ufe::Attribute::kEnumString }, // TfToken
-        //		{SdfValueTypeNames->Asset.GetHash(), Ufe::Attribute::kUnknown},
-        //// SdfAssetPath 		{SdfValueTypeNames->Int2.GetHash(), Ufe::Attribute::kInt2},
-        //// GfVec2i 		{SdfValueTypeNames->Half2.GetHash(),
-        /// Ufe::Attribute::kUnknown}, / GfVec2h {SdfValueTypeNames->Float2.GetHash(),
-        /// Ufe::Attribute::kFloat2}, / GfVec2f {SdfValueTypeNames->Double2.GetHash(),
-        /// Ufe::Attribute::kDouble2}, / GfVec2d
-        { SdfValueTypeNames->Int3.GetHash(), Ufe::Attribute::kInt3 }, // GfVec3i
-        //		{SdfValueTypeNames->Half3.GetHash(), Ufe::Attribute::kUnknown},
-        //// GfVec3h
-        { SdfValueTypeNames->Float3.GetHash(), Ufe::Attribute::kFloat3 },   // GfVec3f
-        { SdfValueTypeNames->Double3.GetHash(), Ufe::Attribute::kDouble3 }, // GfVec3d
-        //		{SdfValueTypeNames->Int4.GetHash(), Ufe::Attribute::kInt4},
-        //// GfVec4i 		{SdfValueTypeNames->Half4.GetHash(),
-        /// Ufe::Attribute::kUnknown}, / GfVec4h {SdfValueTypeNames->Float4.GetHash(),
-        /// Ufe::Attribute::kFloat4}, / GfVec4f {SdfValueTypeNames->Double4.GetHash(),
-        /// Ufe::Attribute::kDouble4}, / GfVec4d {SdfValueTypeNames->Point3h.GetHash(),
-        /// Ufe::Attribute::kUnknown}, / GfVec3h {SdfValueTypeNames->Point3f.GetHash(),
-        /// Ufe::Attribute::kUnknown}, / GfVec3f {SdfValueTypeNames->Point3d.GetHash(),
-        /// Ufe::Attribute::kUnknown}, / GfVec3d
-        ///{SdfValueTypeNames->Vector3h.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3h
-        ///{SdfValueTypeNames->Vector3f.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3f
-        ///{SdfValueTypeNames->Vector3d.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3d
-        ///{SdfValueTypeNames->Normal3h.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3h
-        ///{SdfValueTypeNames->Normal3f.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3f
-        ///{SdfValueTypeNames->Normal3d.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3d
-        ///{SdfValueTypeNames->Color3h.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3h
+        { SdfValueTypeNames->Bool.GetHash(), Ufe::Attribute::kBool },           // bool
+        { SdfValueTypeNames->Int.GetHash(), Ufe::Attribute::kInt },             // int32_t
+        { SdfValueTypeNames->Float.GetHash(), Ufe::Attribute::kFloat },         // float
+        { SdfValueTypeNames->Double.GetHash(), Ufe::Attribute::kDouble },       // double
+        { SdfValueTypeNames->String.GetHash(), Ufe::Attribute::kString },       // std::string
+        { SdfValueTypeNames->Token.GetHash(), Ufe::Attribute::kEnumString },    // TfToken
+        { SdfValueTypeNames->Int3.GetHash(), Ufe::Attribute::kInt3 },           // GfVec3i
+        { SdfValueTypeNames->Float3.GetHash(), Ufe::Attribute::kFloat3 },       // GfVec3f
+        { SdfValueTypeNames->Double3.GetHash(), Ufe::Attribute::kDouble3 },     // GfVec3d
         { SdfValueTypeNames->Color3f.GetHash(), Ufe::Attribute::kColorFloat3 }, // GfVec3f
         { SdfValueTypeNames->Color3d.GetHash(), Ufe::Attribute::kColorFloat3 }, // GfVec3d
-        //		{SdfValueTypeNames->Color4h.GetHash(), Ufe::Attribute::kUnknown},
-        //// GfVec4h 		{SdfValueTypeNames->Color4f.GetHash(),
-        /// Ufe::Attribute::kUnknown}, / GfVec4f {SdfValueTypeNames->Color4d.GetHash(),
-        /// Ufe::Attribute::kUnknown}, / GfVec4d 		{SdfValueTypeNames->Quath.GetHash(),
-        /// Ufe::Attribute::kUnknown}, / GfQuath 		{SdfValueTypeNames->Quatf.GetHash(),
-        /// Ufe::Attribute::kUnknown}, / GfQuatf 		{SdfValueTypeNames->Quatd.GetHash(),
-        /// Ufe::Attribute::kUnknown}, / GfQuatd
-        ///{SdfValueTypeNames->Matrix2d.GetHash(), Ufe::Attribute::kUnknown}, / GfMatrix2d
-        ///{SdfValueTypeNames->Matrix3d.GetHash(), Ufe::Attribute::kUnknown}, / GfMatrix3d
-        ///{SdfValueTypeNames->Matrix4d.GetHash(), Ufe::Attribute::kUnknown}, / GfMatrix4d
-        ///{SdfValueTypeNames->Frame4d.GetHash(), Ufe::Attribute::kUnknown}, / GfMatrix4d
-        ///{SdfValueTypeNames->TexCoord2f.GetHash(), Ufe::Attribute::kUnknown}, / GfVec2f
-        ///{SdfValueTypeNames->TexCoord2d.GetHash(), Ufe::Attribute::kUnknown}, / GfVec2d
-        ///{SdfValueTypeNames->TexCoord2h.GetHash(), Ufe::Attribute::kUnknown}, / GfVec2h
-        ///{SdfValueTypeNames->TexCoord3f.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3f
-        ///{SdfValueTypeNames->TexCoord3d.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3d
-        ///{SdfValueTypeNames->TexCoord3h.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3h
-        // To add?
-        // SdfValueTypeName BoolArray;
-        // SdfValueTypeName UCharArray, IntArray, UIntArray, Int64Array, UInt64Array;
-        // SdfValueTypeName HalfArray, FloatArray, DoubleArray;
-        // SdfValueTypeName StringArray, TokenArray, AssetArray;
-        // SdfValueTypeName Int2Array,     Int3Array,     Int4Array;
-        // SdfValueTypeName Half2Array,    Half3Array,    Half4Array;
-        // SdfValueTypeName Float2Array,   Float3Array,   Float4Array;
-        // SdfValueTypeName Double2Array,  Double3Array,  Double4Array;
-        // SdfValueTypeName Point3hArray,  Point3fArray,  Point3dArray;
-        // SdfValueTypeName Vector3hArray, Vector3fArray, Vector3dArray;
-        // SdfValueTypeName Normal3hArray, Normal3fArray, Normal3dArray;
-        // SdfValueTypeName Color3hArray,  Color3fArray,  Color3dArray;
-        // SdfValueTypeName Color4hArray,  Color4fArray,  Color4dArray;
-        // SdfValueTypeName QuathArray,    QuatfArray,    QuatdArray;
-        // SdfValueTypeName Matrix2dArray, Matrix3dArray, Matrix4dArray;
-        // SdfValueTypeName Frame4dArray;
-        // SdfValueTypeName TexCoord2hArray, TexCoord2fArray, TexCoord2dArray;
-        // SdfValueTypeName TexCoord3hArray, TexCoord3fArray, TexCoord3dArray;
     };
 
     if (usdAttr.IsValid()) {

--- a/lib/mayaUsd/ufe/UsdAttributes.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributes.cpp
@@ -126,89 +126,87 @@ Ufe::Attribute::Type
 UsdAttributes::getUfeTypeForAttribute(const PXR_NS::UsdAttribute& usdAttr) const
 {
     // Map the USD type into UFE type.
-    static const std::
-        unordered_map<size_t, Ufe::Attribute::Type>
-            sUsdTypeToUfe {
-                { SdfValueTypeNames->Bool.GetHash(), Ufe::Attribute::kBool }, // bool
-                //		{SdfValueTypeNames->UChar.GetHash(), Ufe::Attribute::kUnknown},
-                //// uint8_t
-                { SdfValueTypeNames->Int.GetHash(), Ufe::Attribute::kInt }, // int32_t
-                //		{SdfValueTypeNames->UInt.GetHash(), Ufe::Attribute::kUnknown},
-                //// uint32_t
-                //		{SdfValueTypeNames->Int64.GetHash(), Ufe::Attribute::kInt},
-                //// int64_t 		{SdfValueTypeNames->UInt64.GetHash(), Ufe::Attribute::kUnknown},
-                //// uint64_t
-                //		{SdfValueTypeNames->Half.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfHalf
-                { SdfValueTypeNames->Float.GetHash(), Ufe::Attribute::kFloat },      // float
-                { SdfValueTypeNames->Double.GetHash(), Ufe::Attribute::kDouble },    // double
-                { SdfValueTypeNames->String.GetHash(), Ufe::Attribute::kString },    // std::string
-                { SdfValueTypeNames->Token.GetHash(), Ufe::Attribute::kEnumString }, // TfToken
-                //		{SdfValueTypeNames->Asset.GetHash(), Ufe::Attribute::kUnknown},
-                //// SdfAssetPath 		{SdfValueTypeNames->Int2.GetHash(), Ufe::Attribute::kInt2},
-                //// GfVec2i 		{SdfValueTypeNames->Half2.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec2h 		{SdfValueTypeNames->Float2.GetHash(), Ufe::Attribute::kFloat2},
-                //// GfVec2f 		{SdfValueTypeNames->Double2.GetHash(), Ufe::Attribute::kDouble2},
-                //// GfVec2d
-                { SdfValueTypeNames->Int3.GetHash(), Ufe::Attribute::kInt3 }, // GfVec3i
-                //		{SdfValueTypeNames->Half3.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec3h
-                { SdfValueTypeNames->Float3.GetHash(), Ufe::Attribute::kFloat3 },   // GfVec3f
-                { SdfValueTypeNames->Double3.GetHash(), Ufe::Attribute::kDouble3 }, // GfVec3d
-                //		{SdfValueTypeNames->Int4.GetHash(), Ufe::Attribute::kInt4},
-                //// GfVec4i 		{SdfValueTypeNames->Half4.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec4h 		{SdfValueTypeNames->Float4.GetHash(), Ufe::Attribute::kFloat4},
-                //// GfVec4f 		{SdfValueTypeNames->Double4.GetHash(), Ufe::Attribute::kDouble4},
-                //// GfVec4d 		{SdfValueTypeNames->Point3h.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec3h 		{SdfValueTypeNames->Point3f.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec3f 		{SdfValueTypeNames->Point3d.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec3d 		{SdfValueTypeNames->Vector3h.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec3h 		{SdfValueTypeNames->Vector3f.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec3f 		{SdfValueTypeNames->Vector3d.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec3d 		{SdfValueTypeNames->Normal3h.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec3h 		{SdfValueTypeNames->Normal3f.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec3f 		{SdfValueTypeNames->Normal3d.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec3d 		{SdfValueTypeNames->Color3h.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec3h
-                { SdfValueTypeNames->Color3f.GetHash(), Ufe::Attribute::kColorFloat3 }, // GfVec3f
-                { SdfValueTypeNames->Color3d.GetHash(), Ufe::Attribute::kColorFloat3 }, // GfVec3d
-                //		{SdfValueTypeNames->Color4h.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec4h 		{SdfValueTypeNames->Color4f.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec4f 		{SdfValueTypeNames->Color4d.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec4d 		{SdfValueTypeNames->Quath.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfQuath 		{SdfValueTypeNames->Quatf.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfQuatf 		{SdfValueTypeNames->Quatd.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfQuatd 		{SdfValueTypeNames->Matrix2d.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfMatrix2d 		{SdfValueTypeNames->Matrix3d.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfMatrix3d 		{SdfValueTypeNames->Matrix4d.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfMatrix4d 		{SdfValueTypeNames->Frame4d.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfMatrix4d 		{SdfValueTypeNames->TexCoord2f.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec2f 		{SdfValueTypeNames->TexCoord2d.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec2d 		{SdfValueTypeNames->TexCoord2h.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec2h 		{SdfValueTypeNames->TexCoord3f.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec3f 		{SdfValueTypeNames->TexCoord3d.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec3d 		{SdfValueTypeNames->TexCoord3h.GetHash(), Ufe::Attribute::kUnknown},
-                //// GfVec3h
-                // To add?
-                // SdfValueTypeName BoolArray;
-                // SdfValueTypeName UCharArray, IntArray, UIntArray, Int64Array, UInt64Array;
-                // SdfValueTypeName HalfArray, FloatArray, DoubleArray;
-                // SdfValueTypeName StringArray, TokenArray, AssetArray;
-                // SdfValueTypeName Int2Array,     Int3Array,     Int4Array;
-                // SdfValueTypeName Half2Array,    Half3Array,    Half4Array;
-                // SdfValueTypeName Float2Array,   Float3Array,   Float4Array;
-                // SdfValueTypeName Double2Array,  Double3Array,  Double4Array;
-                // SdfValueTypeName Point3hArray,  Point3fArray,  Point3dArray;
-                // SdfValueTypeName Vector3hArray, Vector3fArray, Vector3dArray;
-                // SdfValueTypeName Normal3hArray, Normal3fArray, Normal3dArray;
-                // SdfValueTypeName Color3hArray,  Color3fArray,  Color3dArray;
-                // SdfValueTypeName Color4hArray,  Color4fArray,  Color4dArray;
-                // SdfValueTypeName QuathArray,    QuatfArray,    QuatdArray;
-                // SdfValueTypeName Matrix2dArray, Matrix3dArray, Matrix4dArray;
-                // SdfValueTypeName Frame4dArray;
-                // SdfValueTypeName TexCoord2hArray, TexCoord2fArray, TexCoord2dArray;
-                // SdfValueTypeName TexCoord3hArray, TexCoord3fArray, TexCoord3dArray;
-            };
+    static const std::unordered_map<size_t, Ufe::Attribute::Type> sUsdTypeToUfe {
+        { SdfValueTypeNames->Bool.GetHash(), Ufe::Attribute::kBool }, // bool
+        //		{SdfValueTypeNames->UChar.GetHash(), Ufe::Attribute::kUnknown},
+        //// uint8_t
+        { SdfValueTypeNames->Int.GetHash(), Ufe::Attribute::kInt }, // int32_t
+        //		{SdfValueTypeNames->UInt.GetHash(), Ufe::Attribute::kUnknown},
+        //// uint32_t
+        //		{SdfValueTypeNames->Int64.GetHash(), Ufe::Attribute::kInt},
+        //// int64_t 		{SdfValueTypeNames->UInt64.GetHash(),
+        /// Ufe::Attribute::kUnknown}, / uint64_t
+        //		{SdfValueTypeNames->Half.GetHash(), Ufe::Attribute::kUnknown},
+        //// GfHalf
+        { SdfValueTypeNames->Float.GetHash(), Ufe::Attribute::kFloat },      // float
+        { SdfValueTypeNames->Double.GetHash(), Ufe::Attribute::kDouble },    // double
+        { SdfValueTypeNames->String.GetHash(), Ufe::Attribute::kString },    // std::string
+        { SdfValueTypeNames->Token.GetHash(), Ufe::Attribute::kEnumString }, // TfToken
+        //		{SdfValueTypeNames->Asset.GetHash(), Ufe::Attribute::kUnknown},
+        //// SdfAssetPath 		{SdfValueTypeNames->Int2.GetHash(), Ufe::Attribute::kInt2},
+        //// GfVec2i 		{SdfValueTypeNames->Half2.GetHash(),
+        /// Ufe::Attribute::kUnknown}, / GfVec2h {SdfValueTypeNames->Float2.GetHash(),
+        /// Ufe::Attribute::kFloat2}, / GfVec2f {SdfValueTypeNames->Double2.GetHash(),
+        /// Ufe::Attribute::kDouble2}, / GfVec2d
+        { SdfValueTypeNames->Int3.GetHash(), Ufe::Attribute::kInt3 }, // GfVec3i
+        //		{SdfValueTypeNames->Half3.GetHash(), Ufe::Attribute::kUnknown},
+        //// GfVec3h
+        { SdfValueTypeNames->Float3.GetHash(), Ufe::Attribute::kFloat3 },   // GfVec3f
+        { SdfValueTypeNames->Double3.GetHash(), Ufe::Attribute::kDouble3 }, // GfVec3d
+        //		{SdfValueTypeNames->Int4.GetHash(), Ufe::Attribute::kInt4},
+        //// GfVec4i 		{SdfValueTypeNames->Half4.GetHash(),
+        /// Ufe::Attribute::kUnknown}, / GfVec4h {SdfValueTypeNames->Float4.GetHash(),
+        /// Ufe::Attribute::kFloat4}, / GfVec4f {SdfValueTypeNames->Double4.GetHash(),
+        /// Ufe::Attribute::kDouble4}, / GfVec4d {SdfValueTypeNames->Point3h.GetHash(),
+        /// Ufe::Attribute::kUnknown}, / GfVec3h {SdfValueTypeNames->Point3f.GetHash(),
+        /// Ufe::Attribute::kUnknown}, / GfVec3f {SdfValueTypeNames->Point3d.GetHash(),
+        /// Ufe::Attribute::kUnknown}, / GfVec3d
+        ///{SdfValueTypeNames->Vector3h.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3h
+        ///{SdfValueTypeNames->Vector3f.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3f
+        ///{SdfValueTypeNames->Vector3d.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3d
+        ///{SdfValueTypeNames->Normal3h.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3h
+        ///{SdfValueTypeNames->Normal3f.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3f
+        ///{SdfValueTypeNames->Normal3d.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3d
+        ///{SdfValueTypeNames->Color3h.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3h
+        { SdfValueTypeNames->Color3f.GetHash(), Ufe::Attribute::kColorFloat3 }, // GfVec3f
+        { SdfValueTypeNames->Color3d.GetHash(), Ufe::Attribute::kColorFloat3 }, // GfVec3d
+        //		{SdfValueTypeNames->Color4h.GetHash(), Ufe::Attribute::kUnknown},
+        //// GfVec4h 		{SdfValueTypeNames->Color4f.GetHash(),
+        /// Ufe::Attribute::kUnknown}, / GfVec4f {SdfValueTypeNames->Color4d.GetHash(),
+        /// Ufe::Attribute::kUnknown}, / GfVec4d 		{SdfValueTypeNames->Quath.GetHash(),
+        /// Ufe::Attribute::kUnknown}, / GfQuath 		{SdfValueTypeNames->Quatf.GetHash(),
+        /// Ufe::Attribute::kUnknown}, / GfQuatf 		{SdfValueTypeNames->Quatd.GetHash(),
+        /// Ufe::Attribute::kUnknown}, / GfQuatd
+        ///{SdfValueTypeNames->Matrix2d.GetHash(), Ufe::Attribute::kUnknown}, / GfMatrix2d
+        ///{SdfValueTypeNames->Matrix3d.GetHash(), Ufe::Attribute::kUnknown}, / GfMatrix3d
+        ///{SdfValueTypeNames->Matrix4d.GetHash(), Ufe::Attribute::kUnknown}, / GfMatrix4d
+        ///{SdfValueTypeNames->Frame4d.GetHash(), Ufe::Attribute::kUnknown}, / GfMatrix4d
+        ///{SdfValueTypeNames->TexCoord2f.GetHash(), Ufe::Attribute::kUnknown}, / GfVec2f
+        ///{SdfValueTypeNames->TexCoord2d.GetHash(), Ufe::Attribute::kUnknown}, / GfVec2d
+        ///{SdfValueTypeNames->TexCoord2h.GetHash(), Ufe::Attribute::kUnknown}, / GfVec2h
+        ///{SdfValueTypeNames->TexCoord3f.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3f
+        ///{SdfValueTypeNames->TexCoord3d.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3d
+        ///{SdfValueTypeNames->TexCoord3h.GetHash(), Ufe::Attribute::kUnknown}, / GfVec3h
+        // To add?
+        // SdfValueTypeName BoolArray;
+        // SdfValueTypeName UCharArray, IntArray, UIntArray, Int64Array, UInt64Array;
+        // SdfValueTypeName HalfArray, FloatArray, DoubleArray;
+        // SdfValueTypeName StringArray, TokenArray, AssetArray;
+        // SdfValueTypeName Int2Array,     Int3Array,     Int4Array;
+        // SdfValueTypeName Half2Array,    Half3Array,    Half4Array;
+        // SdfValueTypeName Float2Array,   Float3Array,   Float4Array;
+        // SdfValueTypeName Double2Array,  Double3Array,  Double4Array;
+        // SdfValueTypeName Point3hArray,  Point3fArray,  Point3dArray;
+        // SdfValueTypeName Vector3hArray, Vector3fArray, Vector3dArray;
+        // SdfValueTypeName Normal3hArray, Normal3fArray, Normal3dArray;
+        // SdfValueTypeName Color3hArray,  Color3fArray,  Color3dArray;
+        // SdfValueTypeName Color4hArray,  Color4fArray,  Color4dArray;
+        // SdfValueTypeName QuathArray,    QuatfArray,    QuatdArray;
+        // SdfValueTypeName Matrix2dArray, Matrix3dArray, Matrix4dArray;
+        // SdfValueTypeName Frame4dArray;
+        // SdfValueTypeName TexCoord2hArray, TexCoord2fArray, TexCoord2dArray;
+        // SdfValueTypeName TexCoord3hArray, TexCoord3fArray, TexCoord3dArray;
+    };
 
     if (usdAttr.IsValid()) {
         const PXR_NS::SdfValueTypeName typeName = usdAttr.GetTypeName();

--- a/plugin/al/mayautils/AL/maya/event/MayaEventManager.cpp
+++ b/plugin/al/mayautils/AL/maya/event/MayaEventManager.cpp
@@ -878,37 +878,42 @@ void MayaEventHandler::initDagMessage(MayaCallbackInfo& cbi)
     case DagMessage::kParentAdded:
         cbi.mayaCallback = MDagMessage::addParentAddedCallback(bindParentChildFunction, &cbi);
         break;
-    case DagMessage::kParentAddedDagPath: /* cbi.mayaCallback =
-                                             MDagMessage::addParentAddedDagPathCallback(bindNodeStringBoolFunc,
-                                             &cbi); */
+    case DagMessage::
+        kParentAddedDagPath: /* cbi.mayaCallback =
+                                MDagMessage::addParentAddedDagPathCallback(bindNodeStringBoolFunc,
+                                &cbi); */
         break;
     case DagMessage::kParentRemoved:
         cbi.mayaCallback = MDagMessage::addParentRemovedCallback(bindParentChildFunction, &cbi);
         break;
-    case DagMessage::kParentRemovedDagPath: /* cbi.mayaCallback =
-                                               MDagMessage::addParentRemovedDagPathCallback(bindNodeStringBoolFunc,
-                                               &cbi); */
+    case DagMessage::
+        kParentRemovedDagPath: /* cbi.mayaCallback =
+                                  MDagMessage::addParentRemovedDagPathCallback(bindNodeStringBoolFunc,
+                                  &cbi); */
         break;
     case DagMessage::kChildAdded:
         cbi.mayaCallback = MDagMessage::addChildAddedCallback(bindParentChildFunction, &cbi);
         break;
-    case DagMessage::kChildAddedDagPath: /* cbi.mayaCallback =
-                                            MContainerMessage::addChildAddedDagPathCallback(bindNodeStringBoolFunc,
-                                            &cbi); */
+    case DagMessage::
+        kChildAddedDagPath: /* cbi.mayaCallback =
+                               MContainerMessage::addChildAddedDagPathCallback(bindNodeStringBoolFunc,
+                               &cbi); */
         break;
     case DagMessage::kChildRemoved:
         cbi.mayaCallback = MDagMessage::addChildRemovedCallback(bindParentChildFunction, &cbi);
         break;
-    case DagMessage::kChildRemovedDagPath: /* cbi.mayaCallback =
-                                              MDagMessage::addChildRemovedDagPathCallback(bindNodeStringBoolFunc,
-                                              &cbi); */
+    case DagMessage::
+        kChildRemovedDagPath: /* cbi.mayaCallback =
+                                 MDagMessage::addChildRemovedDagPathCallback(bindNodeStringBoolFunc,
+                                 &cbi); */
         break;
     case DagMessage::kChildReordered:
         cbi.mayaCallback = MDagMessage::addChildReorderedCallback(bindParentChildFunction, &cbi);
         break;
-    case DagMessage::kChildReorderedDagPath: /* cbi.mayaCallback =
-                                                MDagMessage::addChildReorderedDagPathCallback(bindNodeStringBoolFunc,
-                                                &cbi); */
+    case DagMessage::
+        kChildReorderedDagPath: /* cbi.mayaCallback =
+                                   MDagMessage::addChildReorderedDagPathCallback(bindNodeStringBoolFunc,
+                                   &cbi); */
         break;
     case DagMessage::kDag: /* cbi.mayaCallback =
                               MDagMessage::addDagCallback(bindMessageParentChildFunction, &cbi); */
@@ -921,27 +926,31 @@ void MayaEventHandler::initDagMessage(MayaCallbackInfo& cbi)
         cbi.mayaCallback
             = MDagMessage::addAllDagChangesCallback(bindMessageParentChildFunction, &cbi);
         break;
-    case DagMessage::kAllDagChangesDagPath: /* cbi.mayaCallback =
-                                               MDagMessage::addAllDagChangesDagPathCallback(bindNodeStringBoolFunc,
-                                               &cbi); */
+    case DagMessage::
+        kAllDagChangesDagPath: /* cbi.mayaCallback =
+                                  MDagMessage::addAllDagChangesDagPathCallback(bindNodeStringBoolFunc,
+                                  &cbi); */
         break;
     case DagMessage::kInstanceAdded:
         cbi.mayaCallback = MDagMessage::addInstanceAddedCallback(bindParentChildFunction, &cbi);
         break;
-    case DagMessage::kInstanceAddedDagPath: /* cbi.mayaCallback =
-                                               MDagMessage::addInstanceAddedDagPathCallback(bindNodeStringBoolFunc,
-                                               &cbi); */
+    case DagMessage::
+        kInstanceAddedDagPath: /* cbi.mayaCallback =
+                                  MDagMessage::addInstanceAddedDagPathCallback(bindNodeStringBoolFunc,
+                                  &cbi); */
         break;
     case DagMessage::kInstanceRemoved:
         cbi.mayaCallback = MDagMessage::addInstanceRemovedCallback(bindParentChildFunction, &cbi);
         break;
-    case DagMessage::kInstanceRemovedDagPath: /* cbi.mayaCallback =
-                                                 MDagMessage::addInstanceRemovedDagPathCallback(bindNodeStringBoolFunc,
-                                                 &cbi); */
+    case DagMessage::
+        kInstanceRemovedDagPath: /* cbi.mayaCallback =
+                                    MDagMessage::addInstanceRemovedDagPathCallback(bindNodeStringBoolFunc,
+                                    &cbi); */
         break;
-    case DagMessage::kWorldMatrixModified: /* cbi.mayaCallback =
-                                              MDagMessage::addWorldMatrixModifiedCallback(bindNodeStringBoolFunc,
-                                              &cbi); */
+    case DagMessage::
+        kWorldMatrixModified: /* cbi.mayaCallback =
+                                 MDagMessage::addWorldMatrixModifiedCallback(bindNodeStringBoolFunc,
+                                 &cbi); */
         break;
     default: break;
     }
@@ -1143,13 +1152,15 @@ void MayaEventHandler::initModelMessage(MayaCallbackInfo& cbi)
     case ModelMessage::kAfterDuplicate:
         cbi.mayaCallback = MModelMessage::addAfterDuplicateCallback(bindBasicFunction, &cbi);
         break;
-    case ModelMessage::kNodeAddedToModel: /* cbi.mayaCallback =
-                                             MModelMessage::addNodeAddedToModelCallback(bindTimeFunction,
-                                             &cbi); */
+    case ModelMessage::
+        kNodeAddedToModel: /* cbi.mayaCallback =
+                              MModelMessage::addNodeAddedToModelCallback(bindTimeFunction,
+                              &cbi); */
         break;
-    case ModelMessage::kNodeRemovedFromModel: /* cbi.mayaCallback =
-                                                 MModelMessage::addNodeRemovedFromModelCallback(bindTimeFunction,
-                                                 &cbi); */
+    case ModelMessage::
+        kNodeRemovedFromModel: /* cbi.mayaCallback =
+                                  MModelMessage::addNodeRemovedFromModelCallback(bindTimeFunction,
+                                  &cbi); */
         break;
     default: break;
     }

--- a/plugin/al/mayautils/AL/maya/event/MayaEventManager.h
+++ b/plugin/al/mayautils/AL/maya/event/MayaEventManager.h
@@ -174,8 +174,8 @@ enum class MayaCallbackType
                               ///< referenceNode, MFileObject& file, void* userData); \endcode
     kRenderTileFunction,      ///< \brief describes the maya callback type \b
                               ///< MMessage::MRenderTileFunction \code typedef void
-                         ///< (*MRenderTileFunction) (int originX, int originY, int tileMaxX, int
-                         ///< tileMaxY, void* userData); \endcode
+    ///< (*MRenderTileFunction) (int originX, int originY, int tileMaxX, int
+    ///< tileMaxY, void* userData); \endcode
     kMessageFunction, ///< \brief describes the maya callback type \b MMessage::MMessageFunction
                       ///< \code typedef void (*MMessageFunction) (const MString& message,
                       ///< MCommandMessage::MessageType messageType, void* userData); \endcode
@@ -197,8 +197,8 @@ enum class MayaCallbackType
     kWorldMatrixModifiedFunction    ///< \brief describes the maya callback type \b
                                     ///< MMessage::MWorldMatrixModifiedFunction \code typedef void
                                     ///< (*MWorldMatrixModifiedFunction) (MObject& transformNode,
-                                 ///< MDagMessage::MatrixModifiedFlags& modified, void* userData);
-                                 ///< \endcode
+    ///< MDagMessage::MatrixModifiedFlags& modified, void* userData);
+    ///< \endcode
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/plugin/al/mayautils/AL/maya/utils/FileTranslatorOptions.cpp
+++ b/plugin/al/mayautils/AL/maya/utils/FileTranslatorOptions.cpp
@@ -607,7 +607,7 @@ FileTranslatorOptions::generateScript(OptionsParser& optionParser, MString& defa
               "  string $optionBreakDown[];\n"
               "  int $index;\n"
               "  if ($action == \"post\")\n  {\n" //< start of the 'post' section of the script (set
-                                                  //control values from option string)
+                                                  // control values from option string)
               "    setParent $parent;\n"
               "    columnLayout -adj true;\n"
               "    AL_usdmaya_SyncFileIOGui \""
@@ -650,8 +650,8 @@ FileTranslatorOptions::generateScript(OptionsParser& optionParser, MString& defa
         + "($optionBreakDown[0], $optionBreakDown[1]);\n        }\n"
           "      }\n    }\n"
           "  }\n  else\n  if ($action == \"query\")\n  {\n"; //< start of 'query' section - return
-                                                             //all control values as key-value pairs
-                                                             //in an option string.
+                                                             // all control values as key-value
+                                                             // pairs in an option string.
 
     itf = m_frames.begin();
     for (; itf != endf; ++itf) {


### PR DESCRIPTION
After PR #890 we still had few files that weren't fully formatted by clang-format
```
	modified:   lib/mayaUsd/ufe/UsdAttributes.cpp
	modified:   plugin/al/mayautils/AL/maya/event/MayaEventManager.cpp
	modified:   plugin/al/mayautils/AL/maya/event/MayaEventManager.h
	modified:   plugin/al/mayautils/AL/maya/utils/FileTranslatorOptions.cpp
```

For some reason, clang-format required to be applied twice to the above files (and to be precise, three times for lib/mayaUsd/ufe/UsdAttributes.cpp).

It's not something I was aware of, but luckily it's only these 4 files we missed.