### PR TITLE
Fixed current compiler warnings

### DIFF
--- a/cmake/compiler_config.cmake
+++ b/cmake/compiler_config.cmake
@@ -13,6 +13,12 @@ set(GNU_CLANG_FLAGS
     -Wno-unused-local-typedefs
 )
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    list(APPEND GNU_CLANG_FLAGS
+            -Wrange-loop-analysis
+        )
+endif()
+
 set(MSVC_FLAGS
     # we want to be as strict as possible
     /W3

--- a/lib/mayaUsd/commands/baseListShadingModesCommand.cpp
+++ b/lib/mayaUsd/commands/baseListShadingModesCommand.cpp
@@ -114,7 +114,7 @@ MStatus MayaUSDListShadingModesCommand::doIt(const MArgList& args)
         // This is to be used when importing via the dialog. Finer grained import is available at
         // the command level.
         //
-        for (const auto c : UsdMayaShadingModeRegistry::ListMaterialConversions()) {
+        for (const auto &c : UsdMayaShadingModeRegistry::ListMaterialConversions()) {
             if (c != UsdImagingTokens->UsdPreviewSurface) {
                 auto const& info = UsdMayaShadingModeRegistry::GetMaterialConversionInfo(c);
                 if (info.hasImporter) {
@@ -122,7 +122,7 @@ MStatus MayaUSDListShadingModesCommand::doIt(const MArgList& args)
                 }
             }
         }
-        for (const auto s : UsdMayaShadingModeRegistry::ListImporters()) {
+        for (const auto &s : UsdMayaShadingModeRegistry::ListImporters()) {
             if (s != UsdMayaShadingModeTokens->useRegistry
                 && s != UsdMayaShadingModeTokens->displayColor) {
                 appendToResult(UsdMayaShadingModeRegistry::GetImporterNiceName(s).c_str());

--- a/lib/mayaUsd/fileio/instancedNodeWriter.cpp
+++ b/lib/mayaUsd/fileio/instancedNodeWriter.cpp
@@ -168,7 +168,7 @@ UsdMaya_InstancedNodeWriter::UsdMaya_InstancedNodeWriter(
             // Replace prefixes to obtain DAG-USD path mapping.
             const UsdMayaUtil::MDagPathMap<SdfPath>& writerMapping
                 = writer->GetDagToUsdPathMapping();
-            for (const std::pair<MDagPath, SdfPath>& pair : writerMapping) {
+            for (const auto& pair : writerMapping) {
                 const MDagPath& dagPathInMaster = pair.first;
                 const SdfPath&  usdPathInMaster = pair.second;
 

--- a/lib/mayaUsd/fileio/registryHelper.cpp
+++ b/lib/mayaUsd/fileio/registryHelper.cpp
@@ -238,7 +238,7 @@ VtDictionary UsdMaya_RegistryHelper::GetComposedInfoDictionary(const std::vector
         if (_ReadNestedDict(plugin->GetMetadata(), scope, &curJsDict)) {
             const VtValue curValue = JsConvertToContainerType<VtValue, VtDictionary>(curJsDict);
             if (curValue.IsHolding<VtDictionary>()) {
-                for (const std::pair<std::string, VtValue>& pair :
+                for (const std::pair<std::string, VtValue> pair :
                      curValue.UncheckedGet<VtDictionary>()) {
                     result[pair.first] = pair.second;
                     keyDefinitionSites[pair.first].push_back(plugin->GetName());
@@ -254,7 +254,7 @@ VtDictionary UsdMaya_RegistryHelper::GetComposedInfoDictionary(const std::vector
     }
 
     // Validate that keys are only defined once globally.
-    for (const std::pair<std::string, std::vector<std::string>>& pair : keyDefinitionSites) {
+    for (const auto& pair : keyDefinitionSites) {
         if (pair.second.size() != 1) {
             TF_RUNTIME_ERROR(
                 "Key '%s' is defined in multiple plugins (%s). "

--- a/lib/mayaUsd/fileio/utils/readUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/readUtil.cpp
@@ -643,7 +643,7 @@ bool UsdMayaReadUtil::SetMayaAttr(
         if (Converter::hasAttrType(attrPlug, MFnData::kVectorArray)) {
             VtVec3fArray arr = newValue.Get<VtVec3fArray>();
             MVectorArray mayaArr;
-            for (const GfVec3d& v : arr) {
+            for (const GfVec3d v : arr) {
                 mayaArr.append(MVector(v[0], v[1], v[2]));
             }
             MFnVectorArrayData data;
@@ -654,7 +654,7 @@ bool UsdMayaReadUtil::SetMayaAttr(
         } else if (Converter::hasAttrType(attrPlug, MFnData::kPointArray)) {
             VtVec3fArray arr = newValue.Get<VtVec3fArray>();
             MPointArray  mayaArr;
-            for (const GfVec3d& v : arr) {
+            for (const GfVec3d v : arr) {
                 mayaArr.append(MPoint(v[0], v[1], v[2]));
             }
             MFnPointArrayData data;

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -1682,7 +1682,7 @@ VtDictionary UsdMayaUtil::GetDictionaryFromArgDatabase(
     //     Python command API. If single arg per flag, make it a vector of
     //     strings. Multi arg per flag, vector of vector of strings.
     VtDictionary args;
-    for (const std::pair<std::string, VtValue>& entry : guideDict) {
+    for (const auto& entry : guideDict) {
         const std::string& key = entry.first;
         const VtValue&     guideValue = entry.second;
         if (!argData.isFlagSet(key.c_str())) {

--- a/lib/usd/hdMaya/adapters/materialNetworkConverter.cpp
+++ b/lib/usd/hdMaya/adapters/materialNetworkConverter.cpp
@@ -140,7 +140,7 @@ TfToken GetOutputName(const HdMaterialNode& material, SdfValueTypeName type)
         // Then see if any preferred names are found
         if (!validOutputs.empty()) {
             const auto& preferredNames = GetPreferredOutputNames(type);
-            for (const auto preferredName : preferredNames) {
+            for (const auto& preferredName : preferredNames) {
                 if (std::find(validOutputs.begin(), validOutputs.end(), preferredName)
                     != validOutputs.end()) {
                     TF_DEBUG(HDMAYA_ADAPTER_MATERIALS)

--- a/lib/usd/utils/util.cpp
+++ b/lib/usd/utils/util.cpp
@@ -82,7 +82,7 @@ void replaceReferenceItems(
 
     // fetching the existing SdfReference items and using
     // the Replace() method to replace them with updated SdfReference items.
-    for (const SdfReference& ref : listProxy) {
+    for (const SdfReference ref : listProxy) {
         if (MayaUsdUtils::isInternalReference(ref)) {
             SdfPath finalPath;
             if (oldPrim.GetPath() == ref.GetPrimPath()) {


### PR DESCRIPTION
There were several small warnings that were tripping up our compilation when trying to compile with -Wall

They're all errors like this:

```
/Users/dhruvgovil/Projects/maya-usd/lib/mayaUsd/commands/baseListShadingModesCommand.cpp:117:25: warning: loop variable 'c' of type 'const pxrInternal_v0_20__pxrReserved__::TfToken' creates a copy from type 'const pxrInternal_v0_20__pxrReserved__::TfToken' [-Wrange-loop-analysis]
        for (const auto c : UsdMayaShadingModeRegistry::ListMaterialConversions()) {
```