### PR TITLE
MAYA-106722 Maya check callback to see if there are any unsaved edits

### DIFF
--- a/plugin/adsk/plugin/CMakeLists.txt
+++ b/plugin/adsk/plugin/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(${TARGET_NAME}
         importTranslator.cpp
         exportTranslator.cpp
         ProxyShape.cpp
+        sceneResetCheck.cpp
 )
 
 # -----------------------------------------------------------------------------

--- a/plugin/adsk/plugin/base/api.h
+++ b/plugin/adsk/plugin/base/api.h
@@ -42,3 +42,7 @@
 #define MAYAUSD_PLUGIN_LOCAL
 #endif
 #endif
+
+// Convenience symbol versioning include: because api.h is widely
+// included, this reduces the need to explicitly include mayaUsd.h.
+#include <mayaUsd/mayaUsd.h>

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -20,6 +20,7 @@
 #include "base/api.h"
 #include "exportTranslator.h"
 #include "importTranslator.h"
+#include "sceneResetCheck.h"
 
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/commands/editTargetCommand.h>
@@ -201,6 +202,8 @@ MStatus initializePlugin(MObject obj)
 
     UsdMayaSceneResetNotice::InstallListener();
 
+    MayaUsd::SceneResetCheck::registerSceneResetCheckCallback();
+
     return status;
 }
 
@@ -258,6 +261,8 @@ MStatus uninitializePlugin(MObject obj)
 #endif
 
     UsdMayaSceneResetNotice::RemoveListener();
+
+    MayaUsd::SceneResetCheck::deregisterSceneResetCheckCallback();
 
     return status;
 }

--- a/plugin/adsk/plugin/sceneResetCheck.cpp
+++ b/plugin/adsk/plugin/sceneResetCheck.cpp
@@ -64,11 +64,11 @@ static void _OnMayaNewOrOpenSceneCheckCallback(bool* retCode, void*)
                 continue;
             }
 
-            std::string          temp;
             SdfLayerHandleVector allLayers = stage->GetLayerStack(true);
             for (auto layer : allLayers) {
                 if (layer->IsDirty()) {
                     atLeastOneDirty = true;
+                    break;
                 }
             }
         }

--- a/plugin/adsk/plugin/sceneResetCheck.cpp
+++ b/plugin/adsk/plugin/sceneResetCheck.cpp
@@ -1,0 +1,109 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "sceneResetCheck.h"
+
+#include "ProxyShape.h"
+
+#include <maya/MFnDependencyNode.h>
+#include <maya/MGlobal.h>
+#include <maya/MItDependencyNodes.h>
+#include <maya/MMessage.h>
+#include <maya/MSceneMessage.h>
+
+namespace {
+MCallbackId _beforeNewCheckCallbackId = 0;
+MCallbackId _beforeOpenCheckCallbackId = 0;
+
+const char* ignoreDirtyLayersConfirmScript = R"(
+global proc string MayaUsdIgnoreDirtyLayersConfirm()
+{
+    return `confirmDialog -title "Warning: USD Edits Not Saved" 
+        -message "USD edits are not saved.  Are you sure you want to leave?"
+        -button "Yes" -button "No" -defaultButton "No"
+        -cancelButton "No" -dismissString "No"`;
+
+}
+MayaUsdIgnoreDirtyLayersConfirm();
+)";
+
+static void _OnMayaNewOrOpenSceneCheckCallback(bool* retCode, void*)
+{
+    *retCode = true;
+
+    bool atLeastOneDirty = false;
+
+    MFnDependencyNode  fn;
+    MItDependencyNodes iter(MFn::kPluginDependNode);
+
+    for (; !iter.isDone() && !atLeastOneDirty; iter.next()) {
+        MObject mobj = iter.item();
+        fn.setObject(mobj);
+        if (MayaUsd::ProxyShape::typeId == fn.typeId()) {
+            MayaUsdProxyShapeBase* pShape = static_cast<MayaUsdProxyShapeBase*>(fn.userNode());
+            UsdStageRefPtr         stage = pShape ? pShape->getUsdStage() : nullptr;
+            if (!stage) {
+                continue;
+            }
+
+            std::string          temp;
+            SdfLayerHandleVector allLayers = stage->GetLayerStack(true);
+            for (auto layer : allLayers) {
+                if (layer->IsDirty()) {
+                    atLeastOneDirty = true;
+                }
+            }
+        }
+    }
+
+    if (atLeastOneDirty) {
+        MString allowExit = MGlobal::executeCommandStringResult(ignoreDirtyLayersConfirmScript);
+        if (MString("No") == allowExit) {
+            *retCode = false;
+        }
+    }
+}
+
+} // namespace
+
+namespace MAYAUSD_NS_DEF {
+
+void SceneResetCheck::registerSceneResetCheckCallback()
+{
+    if (_beforeNewCheckCallbackId == 0) {
+        _beforeNewCheckCallbackId = MSceneMessage::addCheckCallback(
+            MSceneMessage::kBeforeNewCheck, _OnMayaNewOrOpenSceneCheckCallback);
+    }
+
+    if (_beforeOpenCheckCallbackId == 0) {
+        _beforeOpenCheckCallbackId = MSceneMessage::addCheckCallback(
+            MSceneMessage::kBeforeOpenCheck, _OnMayaNewOrOpenSceneCheckCallback);
+    }
+}
+
+void SceneResetCheck::deregisterSceneResetCheckCallback()
+{
+    if (_beforeNewCheckCallbackId != 0) {
+        MMessage::removeCallback(_beforeNewCheckCallbackId);
+        _beforeNewCheckCallbackId = 0;
+    }
+
+    if (_beforeOpenCheckCallbackId != 0) {
+        MMessage::removeCallback(_beforeOpenCheckCallbackId);
+        _beforeOpenCheckCallbackId = 0;
+    }
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/plugin/adsk/plugin/sceneResetCheck.cpp
+++ b/plugin/adsk/plugin/sceneResetCheck.cpp
@@ -36,9 +36,9 @@ MCallbackId _beforeOpenCheckCallbackId = 0;
 const char* ignoreDirtyLayersConfirmScript = R"(
 global proc string MayaUsdIgnoreDirtyLayersConfirm()
 {
-    return `confirmDialog -title "Warning: USD Edits Not Saved" 
-        -message "USD edits are not saved.  Are you sure you want to leave?"
-        -button "Yes" -button "No" -defaultButton "No"
+    return `confirmDialog -title "Discard USD Edits" 
+        -message "Are you sure you want to exit this session?\n\nAll edits on your USD layer(s) will be discarded."
+        -button "Yes" -button "No" -defaultButton "No" -icon "warning"
         -cancelButton "No" -dismissString "No"`;
 
 }

--- a/plugin/adsk/plugin/sceneResetCheck.cpp
+++ b/plugin/adsk/plugin/sceneResetCheck.cpp
@@ -17,11 +17,17 @@
 
 #include "ProxyShape.h"
 
+#include <pxr/pxr.h>
+#include <pxr/usd/usd/common.h>
+#include <pxr/usd/usd/stage.h>
+
 #include <maya/MFnDependencyNode.h>
 #include <maya/MGlobal.h>
 #include <maya/MItDependencyNodes.h>
 #include <maya/MMessage.h>
 #include <maya/MSceneMessage.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace {
 MCallbackId _beforeNewCheckCallbackId = 0;

--- a/plugin/adsk/plugin/sceneResetCheck.h
+++ b/plugin/adsk/plugin/sceneResetCheck.h
@@ -1,0 +1,35 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef ADSK_MAYA_SCENE_RESET_CHECK_H
+#define ADSK_MAYA_SCENE_RESET_CHECK_H
+
+#include "base/api.h"
+
+namespace MAYAUSD_NS_DEF {
+
+class SceneResetCheck
+{
+public:
+    MAYAUSD_PLUGIN_PUBLIC
+    static void registerSceneResetCheckCallback();
+
+    MAYAUSD_PLUGIN_PUBLIC
+    static void deregisterSceneResetCheckCallback();
+};
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif


### PR DESCRIPTION
This adds a file new and open check callback so we can warn the user that they have USD edits that are not saved.  The "check" callbacks from Maya pass a bool variable that you can set to false in order to block the file IO operation.  Meaning, before Maya actually opens another file or creates a new scene we can cancel it and stay in the current scene.

We are still iterating on the entire workflow of warning the user and then helping them to quick save the edits, so at the moment this is only in the ADSK plugin.  Once we finalize the workflow we can look at what might be useful down in the shared lib.
