### PR TITLE
MAYA-105322 - No undo support for viewport selections of USD objects

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -49,6 +49,9 @@
 #include <mayaUsd/ufe/UsdSceneItem.h>
 
 #include <ufe/globalSelection.h>
+#if UFE_PREVIEW_VERSION_NUM >= 2027 // #ifdef UFE_V2_FEATURES_AVAILABLE
+#include <ufe/namedSelection.h>
+#endif
 #include <ufe/observableSelection.h>
 #include <ufe/runTimeMgr.h>
 #include <ufe/scene.h>
@@ -755,7 +758,9 @@ bool ProxyRenderDelegate::getInstancedSelectionPath(
     // each intersection.
 #if defined(MAYA_ENABLE_UPDATE_FOR_SELECTION)
     const TfToken&                 selectionKind = _selectionKind;
+#if UFE_PREVIEW_VERSION_NUM < 2027 // #ifndef UFE_V2_FEATURES_AVAILABLE
     const MGlobal::ListAdjustment& listAdjustment = _globalListAdjustment;
+#endif
 #else
     const TfToken selectionKind = GetSelectionKind();
     const MGlobal::ListAdjustment listAdjustment = GetListAdjustment();
@@ -783,6 +788,10 @@ bool ProxyRenderDelegate::getInstancedSelectionPath(
         return false;
     }
 
+#if UFE_PREVIEW_VERSION_NUM >= 2027 // #ifdef UFE_V2_FEATURES_AVAILABLE
+    auto ufeSel = Ufe::NamedSelection::get("MayaSelectTool");
+    ufeSel->append(si);
+#else
     auto globalSelection = Ufe::GlobalSelection::get();
 
     switch (listAdjustment) {
@@ -802,6 +811,7 @@ bool ProxyRenderDelegate::getInstancedSelectionPath(
         break;
     default: TF_WARN("Unexpected MGlobal::ListAdjustment enum for selection."); break;
     }
+#endif
 #else
     dagPath = _proxyShapeData->ProxyDagPath();
 #endif
@@ -812,7 +822,7 @@ bool ProxyRenderDelegate::getInstancedSelectionPath(
 //! \brief  Notify of selection change.
 void ProxyRenderDelegate::SelectionChanged() { _selectionChanged = true; }
 
-//! \brief  Polulate lead and active selection for Rprims under the proxy shape.
+//! \brief  Populate lead and active selection for Rprims under the proxy shape.
 void ProxyRenderDelegate::_PopulateSelection()
 {
 #if defined(WANT_UFE_BUILD)

--- a/lib/mayaUsd/ufe/UsdStageMap.cpp
+++ b/lib/mayaUsd/ufe/UsdStageMap.cpp
@@ -70,7 +70,7 @@ void UsdStageMap::addItem(const Ufe::Path& path, UsdStageWeakPtr stage)
 {
     // We expect a path to the proxy shape node, therefore a single segment.
     auto nbSegments =
-#ifdef UFE_V0_2_6_FEATURES_AVAILABLE
+#if UFE_PREVIEW_VERSION_NUM >= 2006
         path.nbSegments();
 #else
         path.getSegments().size();

--- a/lib/usd/hdMaya/delegates/proxyDelegate.cpp
+++ b/lib/usd/hdMaya/delegates/proxyDelegate.cpp
@@ -38,6 +38,9 @@
 
 #if WANT_UFE_BUILD
 #include <ufe/globalSelection.h>
+#if UFE_PREVIEW_VERSION_NUM >= 2027
+#include <ufe/namedSelection.h>
+#endif
 #include <ufe/observableSelection.h>
 #include <ufe/rtid.h>
 #include <ufe/runTimeMgr.h>
@@ -373,7 +376,11 @@ void HdMayaProxyDelegate::PopulateSelectionList(
     if (handler == nullptr)
         return;
 
+#if UFE_PREVIEW_VERSION_NUM >= 2027 // #ifdef UFE_V2_FEATURES_AVAILABLE
+    auto ufeSel = Ufe::NamedSelection::get("MayaSelectTool");
+#else
     const MGlobal::ListAdjustment listAdjustment = GetListAdjustment();
+#endif
 
     std::lock_guard<std::mutex> lock(_allAdaptersMutex);
 
@@ -410,6 +417,9 @@ void HdMayaProxyDelegate::PopulateSelectionList(
                 break;
             }
 
+#if UFE_PREVIEW_VERSION_NUM >= 2027 // #ifdef UFE_V2_FEATURES_AVAILABLE
+            ufeSel->append(si);
+#else
             auto globalSelection = Ufe::GlobalSelection::get();
 
             switch (listAdjustment) {
@@ -429,6 +439,7 @@ void HdMayaProxyDelegate::PopulateSelectionList(
                 break;
             default: TF_WARN("Unexpected MGlobal::ListAdjustment enum for selection."); break;
             }
+#endif
 
             break;
         }

--- a/lib/usd/hdMaya/delegates/proxyDelegate.cpp
+++ b/lib/usd/hdMaya/delegates/proxyDelegate.cpp
@@ -142,7 +142,7 @@ void SetupPluginCallbacks()
     TF_VERIFY(status, "Could not set pluginUnloaded callback");
 }
 
-#if MAYA_API_VERSION >= 20210000 && WANT_UFE_BUILD
+#if (MAYA_API_VERSION >= 20210000) && WANT_UFE_BUILD && (UFE_PREVIEW_VERSION_NUM < 2027)
 MGlobal::ListAdjustment GetListAdjustment()
 {
     // Keyboard modifiers can be queried from QApplication::keyboardModifiers()

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -35,6 +35,9 @@
 #include "AL/usdmaya/TypeIDs.h"
 #include "ufe/globalSelection.h"
 #include "ufe/log.h"
+#if UFE_PREVIEW_VERSION_NUM >= 2027
+#include <ufe/namedSelection.h>
+#endif
 #include "ufe/observableSelection.h"
 #include "ufe/runTimeMgr.h"
 #include "ufe/sceneItem.h"
@@ -691,7 +694,11 @@ bool ProxyDrawOverride::userSelect(
             }
 
             if (paths.size()) {
+#if UFE_PREVIEW_VERSION_NUM >= 2027 // #ifdef UFE_V2_FEATURES_AVAILABLE
+                auto ufeSel = Ufe::NamedSelection::get("MayaSelectTool");
+#else
                 auto globalSelection = Ufe::GlobalSelection::get();
+#endif
 
                 for (const auto& it : paths) {
                     // Build a path segment of the USD picked object
@@ -701,6 +708,9 @@ bool ProxyDrawOverride::userSelect(
                     const Ufe::SceneItem::Ptr& si { handler->createItem(
                         proxyShape->ufePath() + ps_usd) };
 
+#if UFE_PREVIEW_VERSION_NUM >= 2027 // #ifdef UFE_V2_FEATURES_AVAILABLE
+                    ufeSel->append(si);
+#else
                     switch (listAdjustment) {
                     case MGlobal::kReplaceList:
                         // The list has been cleared before viewport selection runs, so we
@@ -721,6 +731,7 @@ bool ProxyDrawOverride::userSelect(
                         UFE_LOG("UFE does not support prepend to selection.");
                         break;
                     }
+#endif
                 }
             }
         } else {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
@@ -33,6 +33,9 @@
 #include "ufe/globalSelection.h"
 #include "ufe/hierarchyHandler.h"
 #include "ufe/log.h"
+#if UFE_PREVIEW_VERSION_NUM >= 2027
+#include <ufe/namedSelection.h>
+#endif
 #include "ufe/observableSelection.h"
 #include "ufe/runTimeMgr.h"
 #include "ufe/sceneItem.h"
@@ -509,8 +512,12 @@ bool ProxyShapeUI::select(
                 return false;
             }
 
+#if UFE_PREVIEW_VERSION_NUM >= 2027 // #ifdef UFE_V2_FEATURES_AVAILABLE
+            auto ufeSel = Ufe::NamedSelection::get("MayaSelectTool");
+#else
             Ufe::Selection dstSelection; // Only used for kReplaceList
                                          // Get the paths
+#endif
             if (paths.size()) {
                 for (const auto& it : paths) {
                     // Build a path segment of the USD picked object
@@ -520,6 +527,9 @@ bool ProxyShapeUI::select(
                     const Ufe::SceneItem::Ptr& si { handler->createItem(
                         proxyShape->ufePath() + ps_usd) };
 
+#if UFE_PREVIEW_VERSION_NUM >= 2027 // #ifdef UFE_V2_FEATURES_AVAILABLE
+                    ufeSel->append(si);
+#else
                     auto globalSelection = Ufe::GlobalSelection::get();
 
                     switch (mode) {
@@ -545,12 +555,15 @@ bool ProxyShapeUI::select(
                         UFE_LOG("UFE does not support prepend to selection.");
                     } break;
                     }
+#endif
                 }
 
+#if UFE_PREVIEW_VERSION_NUM < 2027 // #ifndef UFE_V2_FEATURES_AVAILABLE
                 if (mode == MGlobal::kReplaceList) {
                     // Add to Global selection
                     Ufe::GlobalSelection::get()->replaceWith(dstSelection);
                 }
+#endif
             }
         } else {
 #endif


### PR DESCRIPTION
#### MAYA-105322 - No undo support for viewport selections of USD objects
* Use new Ufe::NamedSelection "MayaSelectTool" for viewport selection, rather than modifying UFE global selection directly.