### PR TITLE
Proxy Shape AE Template - Part 2

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -90,6 +90,9 @@
 
 #if defined(WANT_UFE_BUILD)
 #include <ufe/path.h>
+#ifdef UFE_V2_FEATURES_AVAILABLE
+#include <ufe/pathString.h>
+#endif
 #endif
 
 using namespace MAYAUSD_NS_DEF;
@@ -1219,10 +1222,14 @@ Ufe::Path MayaUsdProxyShapeBase::ufePath() const
     MDagPath thisPath;
     MDagPath::getAPathTo(thisMObject(), thisPath);
 
+#ifdef UFE_V2_FEATURES_AVAILABLE
+    return Ufe::PathString::path(thisPath.fullPathName().asChar());
+#else
     // MDagPath does not include |world to its full path name
     MString fullpath = "|world" + thisPath.fullPathName();
 
     return Ufe::Path(Ufe::PathSegment(fullpath.asChar(), MAYA_UFE_RUNTIME_ID, MAYA_UFE_SEPARATOR));
+#endif
 }
 #endif
 

--- a/lib/mayaUsd/ufe/StagesSubject.cpp
+++ b/lib/mayaUsd/ufe/StagesSubject.cpp
@@ -316,8 +316,13 @@ void StagesSubject::onStageInvalidate(const MayaUsdProxyStageInvalidateNotice& n
     afterOpen();
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
-    Ufe::SceneItem::Ptr sceneItem = Ufe::Hierarchy::createItem(notice.GetProxyShape().ufePath());
-    Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
+    auto p = notice.GetProxyShape().ufePath();
+    if (!p.empty()) {
+        Ufe::SceneItem::Ptr sceneItem = Ufe::Hierarchy::createItem(p);
+        if (sceneItem) {
+            Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
+        }
+    }
 #endif
 }
 

--- a/lib/mayaUsd/ufe/wrapUtils.cpp
+++ b/lib/mayaUsd/ufe/wrapUtils.cpp
@@ -21,6 +21,9 @@
 
 #include <ufe/rtid.h>
 #include <ufe/runTimeMgr.h>
+#ifdef UFE_V2_FEATURES_AVAILABLE
+#include <ufe/pathString.h>
+#endif
 
 #include <boost/python.hpp>
 
@@ -61,10 +64,14 @@ std::string getNodeTypeFromRawItem(uint64_t rawItem)
 
 UsdStageWeakPtr getStage(const std::string& ufePathString)
 {
+#ifdef UFE_V2_FEATURES_AVAILABLE
+    return ufe::getStage(Ufe::PathString::path(ufePathString));
+#else
     // This function works on a single-segment path, i.e. the Maya Dag path
     // segment to the proxy shape.  We know the Maya run-time ID is 1,
     // separator is '|'.
     return ufe::getStage(Ufe::Path(Ufe::PathSegment(ufePathString, 1, '|')));
+#endif
 }
 
 std::string stagePath(UsdStageWeakPtr stage)

--- a/plugin/adsk/scripts/AETemplateHelpers.py
+++ b/plugin/adsk/scripts/AETemplateHelpers.py
@@ -2,8 +2,6 @@ import ufe
 import mayaUsd.ufe
 
 def GetDefaultPrimName(proxyShape):
-    if not proxyShape.startswith('|world'):
-        proxyShape = '|world' + proxyShape
     try:
         proxyStage = mayaUsd.ufe.getStage(proxyShape)
         if proxyStage:
@@ -15,8 +13,6 @@ def GetDefaultPrimName(proxyShape):
     return ''
 
 def GetRootLayerName(proxyShape):
-    if not proxyShape.startswith('|world'):
-        proxyShape = '|world' + proxyShape
     try:
         proxyStage = mayaUsd.ufe.getStage(proxyShape)
         if proxyStage:

--- a/plugin/adsk/scripts/AETemplateHelpers.py
+++ b/plugin/adsk/scripts/AETemplateHelpers.py
@@ -1,0 +1,28 @@
+import ufe
+import mayaUsd.ufe
+
+def GetDefaultPrimName(proxyShape):
+    if not proxyShape.startswith('|world'):
+        proxyShape = '|world' + proxyShape
+    try:
+        proxyStage = mayaUsd.ufe.getStage(proxyShape)
+        if proxyStage:
+            defPrim = proxyStage.GetDefaultPrim()
+            if defPrim:
+                return defPrim.GetName()
+    except:
+        pass
+    return ''
+
+def GetRootLayerName(proxyShape):
+    if not proxyShape.startswith('|world'):
+        proxyShape = '|world' + proxyShape
+    try:
+        proxyStage = mayaUsd.ufe.getStage(proxyShape)
+        if proxyStage:
+            rootLayer = proxyStage.GetRootLayer()
+            if rootLayer:
+                return rootLayer.GetDisplayName() if rootLayer.anonymous else rootLayer.realPath
+    except:
+        pass
+    return ''

--- a/plugin/adsk/scripts/AEmayaUsdProxyShapeTemplate.mel
+++ b/plugin/adsk/scripts/AEmayaUsdProxyShapeTemplate.mel
@@ -1,6 +1,65 @@
+global proc AEmayaUsdProxyShapeInfoNew(string $input)
+{
+    textFieldGrp -label "Root Layer" -editable 0
+                 -ann "Identifies the root layer of a stage. If a file path is shown in this field, the root layer is a file on disk. If a layerName is shown in this field, the root layer is an anonymous layer."
+                 mayaUsdProxyShapeRootLayer;
+
+    textFieldGrp -label "Default Prim" -editable 0
+                 -ann "As part of its metadata, each stage can identify a default prim. This is the primitive that is referenced in if you reference in a file."
+                 mayaUsdProxyShapeDefaultPrim;
+
+    AEmayaUsdProxyShapeInfoReplace($input);
+}
+
+global proc AEmayaUsdProxyShapeInfoReplace(string $input)
+{
+    // From the input attribute we simply want the node name.
+    string $nodeName = plugNode($input);
+    string $res[] = `ls -l $nodeName`;
+    string $fullNodeName = $res[0];
+
+    // Call python helpers to get the info we want to display.
+    string $rootLayer   = `python("import AETemplateHelpers; AETemplateHelpers.GetRootLayerName('" + $fullNodeName + "')")`;
+    string $defaultPrim = `python("import AETemplateHelpers; AETemplateHelpers.GetDefaultPrimName('" + $fullNodeName + "')")`;
+
+    textFieldGrp -edit -text $rootLayer mayaUsdProxyShapeRootLayer;
+    textFieldGrp -edit -text $defaultPrim mayaUsdProxyShapeDefaultPrim;
+}
+
 global proc AEmayaUsdProxyShapeTemplate( string $nodeName )
 {
     editorTemplate -beginScrollLayout;
+
+        //
+        // Proxy Shape specific attributes
+        //
+        editorTemplate -suppress "complexity";
+        editorTemplate -suppress "inStageData";
+        editorTemplate -suppress "stageCacheId";
+        editorTemplate -suppress "outStageCacheId";
+
+        editorTemplate -beginLayout "Stage" -collapse 0;
+            // We aren't displaying the "inStageData" attribute in the ProxyShapeInfo. We simply
+            // pass it in order to get the current nodename. Cannot use the input one here as it
+            // changes based on which proxy shape the AE is viewing.
+            editorTemplate -callCustom "AEmayaUsdProxyShapeInfoNew" "AEmayaUsdProxyShapeInfoReplace" inStageData;
+            editorTemplate -addControl "loadPayloads";
+        editorTemplate -endLayout;
+
+        editorTemplate -beginLayout "Stage Source" -collapse 0;
+            editorTemplate -addControl "filePath";
+        editorTemplate -endLayout;
+
+        editorTemplate -beginLayout "Stage Display" -collapse 0;
+            editorTemplate -ann "Edits the current time value of a stage, which corresponds to the animation frame drawn in the viewport. By default, this value connects to Maya’s global time node."
+                           -addControl "time";
+            editorTemplate -addControl "drawGuidePurpose";
+            editorTemplate -addControl "drawProxyPurpose";
+            editorTemplate -addControl "drawRenderPurpose";
+            editorTemplate -addControl "primPath";
+            editorTemplate -addControl "excludePrimPaths";
+        editorTemplate -endLayout;
+
 
         // Object Display (from AEdagNodeCommon.mel):
         editorTemplate -beginLayout (uiRes("m_AEshapeTemplate.kObjectDisplay"));
@@ -29,24 +88,6 @@ global proc AEmayaUsdProxyShapeTemplate( string $nodeName )
         editorTemplate -beginLayout (uiRes("m_AEdependNodeTemplate.kUUID"));
             editorTemplate -suppress "nodeState";
             editorTemplate -callCustom "AEdependNodeUUIDNew" "AEdependNodeUUIDReplace" "nodeState";
-        editorTemplate -endLayout;
-
-        // Proxy Shape specific attributes
-        editorTemplate -beginLayout "Stage" -collapse 0;
-            editorTemplate -beginNoOptimize;
-                editorTemplate -suppress "complexity";
-                editorTemplate -suppress "inStageData";
-                editorTemplate -addControl "filePath";
-                editorTemplate -addControl "primPath";
-                editorTemplate -addControl "excludePrimPaths";
-                editorTemplate -addControl "loadPayloads";
-                editorTemplate -addControl "time";
-                editorTemplate -addControl "stageCacheId";
-                editorTemplate -addControl "drawRenderPurpose";
-                editorTemplate -addControl "drawProxyPurpose";
-                editorTemplate -addControl "drawGuidePurpose";
-                editorTemplate -addControl "outStageCacheId";
-            editorTemplate -endNoOptimize;
         editorTemplate -endLayout;
 
         // Displacement Map (completely remove):

--- a/plugin/adsk/scripts/AEmayaUsdProxyShapeTemplate.mel
+++ b/plugin/adsk/scripts/AEmayaUsdProxyShapeTemplate.mel
@@ -51,7 +51,7 @@ global proc AEmayaUsdProxyShapeTemplate( string $nodeName )
         editorTemplate -endLayout;
 
         editorTemplate -beginLayout "Stage Display" -collapse 0;
-            editorTemplate -ann "Edits the current time value of a stage, which corresponds to the animation frame drawn in the viewport. By default, this value connects to Maya’s global time node."
+            editorTemplate -ann "Edits the current time value of a stage, which corresponds to the animation frame drawn in the viewport. By default, this value connects to Maya's global time node."
                            -addControl "time";
             editorTemplate -addControl "drawGuidePurpose";
             editorTemplate -addControl "drawProxyPurpose";

--- a/plugin/adsk/scripts/CMakeLists.txt
+++ b/plugin/adsk/scripts/CMakeLists.txt
@@ -2,6 +2,7 @@ list(APPEND scripts_src
     mayaUsdTranslatorImport.mel
     mayaUsdTranslatorExport.mel
     AEmayaUsdProxyShapeTemplate.mel
+    AETemplateHelpers.py
     mayaUsdMenu.mel
     mayaUsd_createStageFromFile.mel
     mayaUsd_createStageWithNewLayer.py

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -396,7 +396,7 @@ void ProxyDrawOverride::draw(const MHWRender::MDrawContext& context, const MUser
             SdfPathVector ufePaths;
             auto          ufeSelList = Ufe::GlobalSelection::get();
 
-            Ufe::PathSegment proxyUfePath = ptr->m_shape->ufePathSegment();
+            Ufe::PathSegment proxyUfePath = ptr->m_shape->ufePath().getSegments()[0];
             for (const auto& sceneItem : *ufeSelList) {
                 if (sceneItem->runTimeId() == USD_UFE_RUNTIME_ID) {
                     const Ufe::Path&        itemPath = sceneItem->path();

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1905,23 +1905,6 @@ MSelectionMask ProxyShape::getShapeSelectionMask() const
     return MSelectionMask(selType);
 }
 
-#if defined(WANT_UFE_BUILD)
-//----------------------------------------------------------------------------------------------------------------------
-Ufe::PathSegment ProxyShape::ufePathSegment() const
-{
-    // Build a path segment to proxyShape
-    MDagPath thisPath;
-    MDagPath::getAPathTo(thisMObject(), thisPath);
-
-    // MDagPath does not include |world to its full path naem
-    MString fullpath = "|world" + thisPath.fullPathName();
-
-    return Ufe::PathSegment(fullpath.asChar(), MAYA_UFE_RUNTIME_ID, MAYA_UFE_SEPARATOR);
-}
-
-Ufe::Path ProxyShape::ufePath() const { return Ufe::Path(ProxyShape::ufePathSegment()); }
-#endif
-
 //----------------------------------------------------------------------------------------------------------------------
 } // namespace nodes
 } // namespace usdmaya

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -833,18 +833,6 @@ public:
     AL_USDMAYA_PUBLIC
     SdfPathVector getPrimPathsFromCommaJoinedString(const MString& paths) const;
 
-#if defined(WANT_UFE_BUILD)
-    /// \brief Get the UFE path of the maya proxy shape
-    /// \return An UFE path containing the path to the proxy shape
-    AL_USDMAYA_PUBLIC
-    Ufe::Path ufePath() const;
-
-    /// \brief Get the UFE path segment of the maya proxy shape
-    /// \return An UFE path segment containing the maya path to the proxy shape
-    AL_USDMAYA_PUBLIC
-    Ufe::PathSegment ufePathSegment() const;
-#endif
-
     /// \brief  Returns the selection mask of the shape
     AL_USDMAYA_PUBLIC
     MSelectionMask getShapeSelectionMask() const override;

--- a/test/lib/ufe/testAttribute.py
+++ b/test/lib/ufe/testAttribute.py
@@ -96,7 +96,7 @@ class AttributeTestCase(unittest.TestCase):
 
         # Get a UFE scene item the input path in the scene.
         itemPath = ufe.Path([
-            mayaUtils.createUfePathSegment("|world|transform1|proxyShape1"), 
+            mayaUtils.createUfePathSegment("|transform1|proxyShape1"), 
             usdUtils.createUfePathSegment(path)])
         ufeItem = ufe.Hierarchy.createItem(itemPath)
 
@@ -420,7 +420,7 @@ class AttributeTestCase(unittest.TestCase):
         # Create three observers, one for global attribute observation, and two
         # on different UFE items.
         proxyShapePathSegment = mayaUtils.createUfePathSegment(
-            "|world|transform1|proxyShape1")
+            "|transform1|proxyShape1")
         path = ufe.Path([
             proxyShapePathSegment, 
             usdUtils.createUfePathSegment('/Room_set/Props/Ball_34')])

--- a/test/lib/ufe/testAttributes.py
+++ b/test/lib/ufe/testAttributes.py
@@ -45,7 +45,7 @@ class AttributesTestCase(unittest.TestCase):
 
         # Get a UFE scene item for one of the balls in the scene.
         ball35Path = ufe.Path([
-            mayaUtils.createUfePathSegment("|world|transform1|proxyShape1"), 
+            mayaUtils.createUfePathSegment("|transform1|proxyShape1"), 
             usdUtils.createUfePathSegment("/Room_set/Props/Ball_35")])
         ball35Item = ufe.Hierarchy.createItem(ball35Path)
 

--- a/test/lib/ufe/testComboCmd.py
+++ b/test/lib/ufe/testComboCmd.py
@@ -332,7 +332,7 @@ class ComboCmdTestCase(testTRSBase.TRSTestCaseBase):
 
         # Select Ball_35 to move, rotate, and scale it.
         ball35Path = ufe.Path([
-            mayaUtils.createUfePathSegment("|world|transform1|proxyShape1"), 
+            mayaUtils.createUfePathSegment("|transform1|proxyShape1"), 
             usdUtils.createUfePathSegment("/Room_set/Props/Ball_35")])
         ball35Item = ufe.Hierarchy.createItem(ball35Path)
 

--- a/test/lib/ufe/testContextOps.py
+++ b/test/lib/ufe/testContextOps.py
@@ -76,7 +76,7 @@ class ContextOpsTestCase(unittest.TestCase):
         
         # Select Ball_35.
         ball35Path = ufe.Path([
-            mayaUtils.createUfePathSegment("|world|transform1|proxyShape1"), 
+            mayaUtils.createUfePathSegment("|transform1|proxyShape1"), 
             usdUtils.createUfePathSegment("/Room_set/Props/Ball_35")])
         self.ball35Item = ufe.Hierarchy.createItem(ball35Path)
         self.ball35Prim = usdUtils.getPrimFromSceneItem(self.ball35Item)
@@ -218,7 +218,7 @@ class ContextOpsTestCase(unittest.TestCase):
             ufe.Scene.addObserver(ufeObs)
 
         # Create a ContextOps interface for the proxy shape.
-        proxyShapePath = ufe.Path([mayaUtils.createUfePathSegment("|world|stage1|stageShape1")])
+        proxyShapePath = ufe.Path([mayaUtils.createUfePathSegment("|stage1|stageShape1")])
         proxyShapeItem = ufe.Hierarchy.createItem(proxyShapePath)
         contextOps = ufe.ContextOps.contextOps(proxyShapeItem)
 
@@ -319,7 +319,7 @@ class ContextOpsTestCase(unittest.TestCase):
         mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
 
         # Create a ContextOps interface for the proxy shape.
-        proxyShapePath = ufe.Path([mayaUtils.createUfePathSegment("|world|stage1|stageShape1")])
+        proxyShapePath = ufe.Path([mayaUtils.createUfePathSegment("|stage1|stageShape1")])
         proxyShapeItem = ufe.Hierarchy.createItem(proxyShapePath)
         contextOps = ufe.ContextOps.contextOps(proxyShapeItem)
 
@@ -358,7 +358,7 @@ class ContextOpsTestCase(unittest.TestCase):
         Descendants", and "Unload".
         '''
         proxyShapePathSegment = mayaUtils.createUfePathSegment(
-            '|world|transform1|proxyShape1')
+            '|transform1|proxyShape1')
 
         propsPath = ufe.Path([
             proxyShapePathSegment,

--- a/test/lib/ufe/testDeleteCmd.py
+++ b/test/lib/ufe/testDeleteCmd.py
@@ -106,7 +106,7 @@ class DeleteCmdTestCase(unittest.TestCase):
         sphereShapeItem = ufe.Hierarchy.createItem(sphereShapePath)
 
         mayaSegment = mayaUtils.createUfePathSegment(
-            "|world|transform1|proxyShape1")
+            "|transform1|proxyShape1")
         ball35Path = ufe.Path(
             [mayaSegment,
              usdUtils.createUfePathSegment("/Room_set/Props/Ball_35")])
@@ -210,7 +210,7 @@ class DeleteCmdTestCase(unittest.TestCase):
         sphereShapeItem = ufe.Hierarchy.createItem(sphereShapePath)
 
         mayaSegment = mayaUtils.createUfePathSegment(
-            "|world|transform1|proxyShape1")
+            "|transform1|proxyShape1")
         ball35Path = ufe.Path(
             [mayaSegment,
              usdUtils.createUfePathSegment("/Room_set/Props/Ball_35")])

--- a/test/lib/ufe/testDuplicateCmd.py
+++ b/test/lib/ufe/testDuplicateCmd.py
@@ -74,7 +74,7 @@ class DuplicateCmdTestCase(unittest.TestCase):
 
         ball35Path = ufe.Path([
             mayaUtils.createUfePathSegment(
-                "|world|transform1|proxyShape1"),
+                "|transform1|proxyShape1"),
             usdUtils.createUfePathSegment("/Room_set/Props/Ball_35")])
         ball35Item = ufe.Hierarchy.createItem(ball35Path)
         ball35Hierarchy = ufe.Hierarchy.hierarchy(ball35Item)

--- a/test/lib/ufe/testGroupCmd.py
+++ b/test/lib/ufe/testGroupCmd.py
@@ -58,7 +58,7 @@ class GroupCmdTestCase(unittest.TestCase):
         '''Creation of USD group objects.'''
 
         mayaPathSegment = mayaUtils.createUfePathSegment(
-            "|world|transform1|proxyShape1")
+            "|transform1|proxyShape1")
 
         usdSegmentBall5 = usdUtils.createUfePathSegment(
             "/Ball_set/Props/Ball_5")

--- a/test/lib/ufe/testMatrices.py
+++ b/test/lib/ufe/testMatrices.py
@@ -91,7 +91,7 @@ class Transform3dMatricesTestCase(unittest.TestCase):
 
         # Next, rotate the USD object by another 30 degrees around X.  To
         # do so, select it first.
-        mayaPathSegment = mayaUtils.createUfePathSegment('|world|mayaUsdTransform|shape')
+        mayaPathSegment = mayaUtils.createUfePathSegment('|mayaUsdTransform|shape')
         usdPathSegment = usdUtils.createUfePathSegment('/pCylinder1')
         cylinderPath = ufe.Path([mayaPathSegment, usdPathSegment])
         cylinderItem = ufe.Hierarchy.createItem(cylinderPath)
@@ -118,7 +118,7 @@ class Transform3dMatricesTestCase(unittest.TestCase):
 
         # Get a Transform3d interface for the proxy shape's transform, and
         # get its transforms.
-        xformPath = ufe.Path(mayaUtils.createUfePathSegment('|world|mayaUsdTransform'))
+        xformPath = ufe.Path(mayaUtils.createUfePathSegment('|mayaUsdTransform'))
         xformItem = ufe.Hierarchy.createItem(xformPath)
         t3d = ufe.Transform3d.transform3d(xformItem)
 

--- a/test/lib/ufe/testMayaPickwalk.py
+++ b/test/lib/ufe/testMayaPickwalk.py
@@ -185,14 +185,14 @@ class MayaUFEPickWalkTesting(unittest.TestCase):
         # Pickwalk on Non-Mixed Maya items is already tested in Maya regression tests
         # Pickwalk on Non-Mixed USD items
         ufeUtils.selectPath(ufe.Path([ \
-                               mayaUtils.createUfePathSegment("|world|transform1|proxyShape1"), \
+                               mayaUtils.createUfePathSegment("|transform1|proxyShape1"), \
                                usdUtils.createUfePathSegment("/Room_set/Props/Ball_1") \
                                 ]), True)
         self.snapShotAndTest(([], ['Ball_1']))
         
         
         ufeUtils.selectPath(ufe.Path([ \
-                               mayaUtils.createUfePathSegment("|world|transform1|proxyShape1"), \
+                               mayaUtils.createUfePathSegment("|transform1|proxyShape1"), \
                                usdUtils.createUfePathSegment("/Room_set/Props/Ball_2") \
                                 ]))
         self.snapShotAndTest(([], ['Ball_1', 'Ball_2']))
@@ -202,7 +202,7 @@ class MayaUFEPickWalkTesting(unittest.TestCase):
         
         # Pickwalk on mixed items
         ufeUtils.selectPath(ufe.Path([ \
-                               mayaUtils.createUfePathSegment("|world|transform1|proxyShape1"), \
+                               mayaUtils.createUfePathSegment("|transform1|proxyShape1"), \
                                usdUtils.createUfePathSegment("/Room_set/Props/Ball_1") \
                                 ]), True)
         self.snapShotAndTest(([], ['Ball_1']))

--- a/test/lib/ufe/testMoveCmd.py
+++ b/test/lib/ufe/testMoveCmd.py
@@ -180,7 +180,7 @@ class MoveCmdTestCase(testTRSBase.TRSTestCaseBase):
 
         # Select Ball_35 to move it.
         ball35Path = ufe.Path([
-            mayaUtils.createUfePathSegment("|world|transform1|proxyShape1"), 
+            mayaUtils.createUfePathSegment("|transform1|proxyShape1"), 
             usdUtils.createUfePathSegment("/Room_set/Props/Ball_35")])
         ball35Item = ufe.Hierarchy.createItem(ball35Path)
 
@@ -215,7 +215,7 @@ class MoveCmdTestCase(testTRSBase.TRSTestCaseBase):
 
         # Select multiple balls to move them.
         proxyShapePathSegment = mayaUtils.createUfePathSegment(
-            "|world|transform1|proxyShape1")
+            "|transform1|proxyShape1")
 
         balls = ['Ball_33', 'Ball_34']
         ballPaths = [

--- a/test/lib/ufe/testObject3d.py
+++ b/test/lib/ufe/testObject3d.py
@@ -157,7 +157,7 @@ class Object3dTestCase(unittest.TestCase):
 
         # Create an Object3d interface for USD sphere.
         mayaPathSegment = mayaUtils.createUfePathSegment(
-            '|world|transform1|proxyShape1')
+            '|transform1|proxyShape1')
         usdPathSegment = usdUtils.createUfePathSegment('/pSphere1')
 
         spherePath = ufe.Path([mayaPathSegment, usdPathSegment])
@@ -186,7 +186,7 @@ class Object3dTestCase(unittest.TestCase):
 
         # Get a scene item for Ball_35.
         ball35Path = ufe.Path([
-            mayaUtils.createUfePathSegment("|world|transform1|proxyShape1"), 
+            mayaUtils.createUfePathSegment("|transform1|proxyShape1"), 
             usdUtils.createUfePathSegment("/Room_set/Props/Ball_35")])
         ball35Item = ufe.Hierarchy.createItem(ball35Path)
 

--- a/test/lib/ufe/testParentCmd.py
+++ b/test/lib/ufe/testParentCmd.py
@@ -76,7 +76,7 @@ class ParentCmdTestCase(unittest.TestCase):
     def testParentRelative(self):
         # Create scene items for the cube and the cylinder.
         shapeSegment = mayaUtils.createUfePathSegment(
-            "|world|mayaUsdProxy1|mayaUsdProxyShape1")
+            "|mayaUsdProxy1|mayaUsdProxyShape1")
         cubePath = ufe.Path(
             [shapeSegment, usdUtils.createUfePathSegment("/cubeXform")])
         cubeItem = ufe.Hierarchy.createItem(cubePath)
@@ -166,7 +166,7 @@ class ParentCmdTestCase(unittest.TestCase):
     def testParentAbsolute(self):
         # Create scene items for the cube and the cylinder.
         shapeSegment = mayaUtils.createUfePathSegment(
-            "|world|mayaUsdProxy1|mayaUsdProxyShape1")
+            "|mayaUsdProxy1|mayaUsdProxyShape1")
         cubePath = ufe.Path(
             [shapeSegment, usdUtils.createUfePathSegment("/cubeXform")])
         cubeItem = ufe.Hierarchy.createItem(cubePath)
@@ -251,7 +251,7 @@ class ParentCmdTestCase(unittest.TestCase):
 
             # Create scene items for the proxy shape and the sphere.
             shapeSegment = mayaUtils.createUfePathSegment(
-                "|world|mayaUsdProxy1|mayaUsdProxyShape1")
+                "|mayaUsdProxy1|mayaUsdProxyShape1")
             shapePath = ufe.Path([shapeSegment])
             shapeItem = ufe.Hierarchy.createItem(shapePath)
 
@@ -326,7 +326,7 @@ class ParentCmdTestCase(unittest.TestCase):
 
         with OpenFileCtx("simpleHierarchy.ma"):
             shapeSegment = mayaUtils.createUfePathSegment(
-                "|world|mayaUsdProxy1|mayaUsdProxyShape1")
+                "|mayaUsdProxy1|mayaUsdProxyShape1")
             spherePath = ufe.Path(
                 [shapeSegment,
                  usdUtils.createUfePathSegment("/pCylinder1/pCube1/pSphere1")])

--- a/test/lib/ufe/testRename.py
+++ b/test/lib/ufe/testRename.py
@@ -76,7 +76,7 @@ class RenameTestCase(unittest.TestCase):
         '''Rename proxy shape, UFE lookup should succeed.'''
 
         mayaSegment = mayaUtils.createUfePathSegment(
-            "|world|transform1|proxyShape1")
+            "|transform1|proxyShape1")
         usdSegment = usdUtils.createUfePathSegment("/Room_set/Props/Ball_35")
 
         ball35Path = ufe.Path([mayaSegment, usdSegment])
@@ -105,7 +105,7 @@ class RenameTestCase(unittest.TestCase):
         # Rename the proxy shape node itself.  Stage and prim access should
         # still be valid, with the new path.
         mayaSegment = mayaUtils.createUfePathSegment(
-            "|world|transform1|potato")
+            "|transform1|potato")
         cmds.rename('|transform1|proxyShape1', 'potato')
         self.assertEqual(len(cmds.ls('potato')), 1)
 
@@ -123,7 +123,7 @@ class RenameTestCase(unittest.TestCase):
         cmds.select(clear=True)
 
         # select a USD object.
-        mayaPathSegment = mayaUtils.createUfePathSegment('|world|Tree_usd|Tree_usdShape')
+        mayaPathSegment = mayaUtils.createUfePathSegment('|Tree_usd|Tree_usdShape')
         usdPathSegment = usdUtils.createUfePathSegment('/TreeBase')
         treebasePath = ufe.Path([mayaPathSegment, usdPathSegment])
         treebaseItem = ufe.Hierarchy.createItem(treebasePath)
@@ -183,7 +183,7 @@ class RenameTestCase(unittest.TestCase):
         cmds.select(clear=True)
 
         # select a USD object.
-        mayaPathSegment = mayaUtils.createUfePathSegment('|world|mayaUsdTransform|shape')
+        mayaPathSegment = mayaUtils.createUfePathSegment('|mayaUsdTransform|shape')
         usdPathSegment = usdUtils.createUfePathSegment('/pCylinder1')
         cylinderPath = ufe.Path([mayaPathSegment, usdPathSegment])
         cylinderItem = ufe.Hierarchy.createItem(cylinderPath)
@@ -251,7 +251,7 @@ class RenameTestCase(unittest.TestCase):
         '''Restrict renaming USD node. Cannot rename a prim defined on another layer.'''
 
         # select a USD object.
-        mayaPathSegment = mayaUtils.createUfePathSegment('|world|transform1|proxyShape1')
+        mayaPathSegment = mayaUtils.createUfePathSegment('|transform1|proxyShape1')
         usdPathSegment = usdUtils.createUfePathSegment('/Room_set/Props/Ball_35')
         ball35Path = ufe.Path([mayaPathSegment, usdPathSegment])
         ball35Item = ufe.Hierarchy.createItem(ball35Path)
@@ -280,7 +280,7 @@ class RenameTestCase(unittest.TestCase):
         cmds.select(clear=True)
 
         # select a USD object.
-        mayaPathSegment = mayaUtils.createUfePathSegment('|world|Asset_flattened_instancing_and_class_removed_usd|Asset_flattened_instancing_and_class_removed_usdShape')
+        mayaPathSegment = mayaUtils.createUfePathSegment('|Asset_flattened_instancing_and_class_removed_usd|Asset_flattened_instancing_and_class_removed_usdShape')
         usdPathSegment = usdUtils.createUfePathSegment('/apple/payload/geo')
         geoPath = ufe.Path([mayaPathSegment, usdPathSegment])
         geoItem = ufe.Hierarchy.createItem(geoPath)
@@ -303,7 +303,7 @@ class RenameTestCase(unittest.TestCase):
         cmds.select(clear=True)
 
         # select a USD object.
-        mayaPathSegment = mayaUtils.createUfePathSegment('|world|Tree_usd|Tree_usdShape')
+        mayaPathSegment = mayaUtils.createUfePathSegment('|Tree_usd|Tree_usdShape')
         usdPathSegment = usdUtils.createUfePathSegment('/TreeBase/trunk')
         trunkPath = ufe.Path([mayaPathSegment, usdPathSegment])
         trunkItem = ufe.Hierarchy.createItem(trunkPath)
@@ -338,7 +338,7 @@ class RenameTestCase(unittest.TestCase):
         cmds.select(clear=True)
 
         # select a USD object.
-        mayaPathSegment = mayaUtils.createUfePathSegment('|world|usdSphereParent|usdSphereParentShape')
+        mayaPathSegment = mayaUtils.createUfePathSegment('|usdSphereParent|usdSphereParentShape')
         usdPathSegment = usdUtils.createUfePathSegment('/sphereXform/sphere')
         basePath = ufe.Path([mayaPathSegment, usdPathSegment])
         usdSphereItem = ufe.Hierarchy.createItem(basePath)
@@ -380,7 +380,7 @@ class RenameTestCase(unittest.TestCase):
         cmds.select(clear=True)
 
         # select a USD object.
-        mayaPathSegment = mayaUtils.createUfePathSegment('|world|mayaUsdTransform|shape')
+        mayaPathSegment = mayaUtils.createUfePathSegment('|mayaUsdTransform|shape')
         usdPathSegment = usdUtils.createUfePathSegment('/pCylinder1')
         cylinderPath = ufe.Path([mayaPathSegment, usdPathSegment])
         cylinderItem = ufe.Hierarchy.createItem(cylinderPath)

--- a/test/lib/ufe/testRotateCmd.py
+++ b/test/lib/ufe/testRotateCmd.py
@@ -181,7 +181,7 @@ class RotateCmdTestCase(testTRSBase.TRSTestCaseBase):
 
         # Select Ball_35 to rotate it.
         ball35Path = ufe.Path([
-            mayaUtils.createUfePathSegment("|world|transform1|proxyShape1"), 
+            mayaUtils.createUfePathSegment("|transform1|proxyShape1"), 
             usdUtils.createUfePathSegment("/Room_set/Props/Ball_35")])
         ball35Item = ufe.Hierarchy.createItem(ball35Path)
 
@@ -218,7 +218,7 @@ class RotateCmdTestCase(testTRSBase.TRSTestCaseBase):
 
         # Select multiple balls to rotate them.
         proxyShapePathSegment = mayaUtils.createUfePathSegment(
-            "|world|transform1|proxyShape1")
+            "|transform1|proxyShape1")
 
         balls = ['Ball_33', 'Ball_34']
         ballPaths = [

--- a/test/lib/ufe/testScaleCmd.py
+++ b/test/lib/ufe/testScaleCmd.py
@@ -176,7 +176,7 @@ class ScaleCmdTestCase(testTRSBase.TRSTestCaseBase):
 
         # Select Ball_35 to scale it.
         ball35Path = ufe.Path([
-            mayaUtils.createUfePathSegment("|world|transform1|proxyShape1"), 
+            mayaUtils.createUfePathSegment("|transform1|proxyShape1"), 
             usdUtils.createUfePathSegment("/Room_set/Props/Ball_35")])
         ball35Item = ufe.Hierarchy.createItem(ball35Path)
 
@@ -212,7 +212,7 @@ class ScaleCmdTestCase(testTRSBase.TRSTestCaseBase):
 
         # Select multiple balls to scale them.
         proxyShapePathSegment = mayaUtils.createUfePathSegment(
-            "|world|transform1|proxyShape1")
+            "|transform1|proxyShape1")
 
         # Test passes for a single item.
         # balls = ['Ball_33']

--- a/test/lib/ufe/testSceneItem.py
+++ b/test/lib/ufe/testSceneItem.py
@@ -48,7 +48,7 @@ class SceneItemTestCase(unittest.TestCase):
 
         # Get a UFE scene item for one of the balls in the scene.
         ball35Path = ufe.Path([
-            mayaUtils.createUfePathSegment("|world|transform1|proxyShape1"), 
+            mayaUtils.createUfePathSegment("|transform1|proxyShape1"), 
             usdUtils.createUfePathSegment("/Room_set/Props/Ball_35")])
         ball35Item = ufe.Hierarchy.createItem(ball35Path)
 

--- a/test/lib/ufe/testTransform3dTranslate.py
+++ b/test/lib/ufe/testTransform3dTranslate.py
@@ -158,7 +158,7 @@ class Transform3dTranslateTestCase(unittest.TestCase):
 
         # Select Ball_35 to move it.
         ball35Path = ufe.Path([
-            mayaUtils.createUfePathSegment("|world|transform1|proxyShape1"), 
+            mayaUtils.createUfePathSegment("|transform1|proxyShape1"), 
             usdUtils.createUfePathSegment("/Room_set/Props/Ball_35")])
         ball35Item = ufe.Hierarchy.createItem(ball35Path)
 
@@ -199,7 +199,7 @@ class Transform3dTranslateTestCase(unittest.TestCase):
 
         # Select Ball_35 to move it.
         ball35Path = ufe.Path([
-            mayaUtils.createUfePathSegment("|world|transform1|proxyShape1"), 
+            mayaUtils.createUfePathSegment("|transform1|proxyShape1"), 
             usdUtils.createUfePathSegment("/Room_set/Props/Ball_35")])
         ball35Item = ufe.Hierarchy.createItem(ball35Path)
 

--- a/test/testUtils/mayaUtils.py
+++ b/test/testUtils/mayaUtils.py
@@ -29,6 +29,7 @@ from pxr import UsdGeom
 from maya import cmds
 
 import ufe
+import ufeUtils
 
 import os
 import re
@@ -95,20 +96,20 @@ def isMayaUsdPluginLoaded():
 
 def createUfePathSegment(mayaPath):
     """
-        Create an UFE path from a given maya path.
-        Make sure that it starts with |world. We are currently 
-        supporting Maya nodes being at the top of UFE Paths (03/26/2018)
+        Create a UFE path from a given maya path and return the first segment.
         Args:
             mayaPath (str): The maya path to use
         Returns :
             PathSegment of the given mayaPath
     """
-    if not mayaPath.startswith("|world"):
-        mayaPath = "|world" + mayaPath
-    return ufe.PathSegment(mayaPath, mayaUsdUfe.getMayaRunTimeId(),
-        mayaSeparator)
+    if ufeUtils.ufeFeatureSetVersion() >= 2:
+        return ufe.PathString.path(mayaPath).segments[0]
+    else:
+        if not mayaPath.startswith("|world"):
+            mayaPath = "|world" + mayaPath
+        return ufe.PathSegment(mayaPath, mayaUsdUfe.getMayaRunTimeId(),
+            mayaSeparator)
 
-    
 def getMayaSelectionList():
     """ 
         Returns the current Maya selection in a list


### PR DESCRIPTION
#### JIRA items:
MAYA-107386 As a user, on the stage AE template I'd like to connect to time
MAYA-107350 As a user, on the stage AE template I'd like to see what my default prim is
MAYA-107338 As a user, on the stage AE template I'd like to see what my Root Layer is
MAYA-107273 As a user, on the stage AE template I'd like to toggle Purpose=Default

* Create new AETemplatesHelpers.py file which is used by the MEL templates to query USD (thru python API).
* Organized proxy shape template in sections: "Stage", "Stage Source" and "Stage Display".
* Suppressed 'Stage Cache ID' and 'Out Stage Cache ID'.
* Added new non-editable text fields (for display purposes only) for "Root Layer" and "Default Prim".
* Added tooltips to some controls.