### PR TITLE
Reuse shader effect for duplicate material networks.

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
+++ b/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(${PROJECT_NAME}
         render_delegate.cpp
         render_param.cpp
         sampler.cpp
+        shader.cpp
         tokens.cpp
 )
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -503,7 +503,7 @@ _LoadTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& uvSca
 #if USD_VERSION_NUM >= 2102
     HioImageSharedPtr image = HioImage::OpenForReading(path);
 #else
-    GlfImageSharedPtr image = GlfImage::OpenForReading(path);
+    GlfImageSharedPtr     image = GlfImage::OpenForReading(path);
 #endif
     if (!TF_VERIFY(image)) {
         return nullptr;

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.h
@@ -16,6 +16,8 @@
 #ifndef HD_VP2_MATERIAL
 #define HD_VP2_MATERIAL
 
+#include "shader.h"
+
 #include <pxr/base/gf/vec2f.h>
 #include <pxr/imaging/hd/material.h>
 #include <pxr/pxr.h>
@@ -28,17 +30,6 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 class HdSceneDelegate;
 class HdVP2RenderDelegate;
-
-/*! \brief  A deleter for MShaderInstance, for use with smart pointers.
- */
-struct HdVP2ShaderDeleter
-{
-    void operator()(MHWRender::MShaderInstance*);
-};
-
-/*! \brief  A MShaderInstance owned by a std unique pointer.
- */
-using HdVP2ShaderUniquePtr = std::unique_ptr<MHWRender::MShaderInstance, HdVP2ShaderDeleter>;
 
 /*! \brief  A deleter for MTexture, for use with smart pointers.
  */

--- a/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.h
@@ -159,8 +159,8 @@ private:
         _resourceRegistry; //!< Shared and unused by VP2 resource registry
 
     std::unique_ptr<HdVP2RenderParam>
-        _renderParam; //!< Render param used to provided access to VP2 during prim synchronization
-    SdfPath _id;      //!< Render delegate ID
+            _renderParam; //!< Render param used to provided access to VP2 during prim synchronization
+    SdfPath _id;          //!< Render delegate ID
     HdVP2ResourceRegistry
         _resourceRegistryVP2; //!< VP2 resource registry used for enqueue and execution of commits
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.h
@@ -18,6 +18,7 @@
 
 #include "render_param.h"
 #include "resource_registry.h"
+#include "shader.h"
 
 #include <pxr/imaging/hd/renderDelegate.h>
 #include <pxr/imaging/hd/resourceRegistry.h>
@@ -136,6 +137,9 @@ public:
     MHWRender::MShaderInstance*
     GetBasisCurvesCPVShader(const TfToken& curveType, const TfToken& curveBasis) const;
 
+    MHWRender::MShaderInstance* GetShaderFromCache(const TfToken& id);
+    bool AddShaderToCache(const TfToken& id, const MHWRender::MShaderInstance& shader);
+
     const MHWRender::MSamplerState* GetSamplerState(const MHWRender::MSamplerStateDesc& desc) const;
 
     const HdVP2BBoxGeom& GetSharedBBoxGeom() const;
@@ -155,10 +159,12 @@ private:
         _resourceRegistry; //!< Shared and unused by VP2 resource registry
 
     std::unique_ptr<HdVP2RenderParam>
-            _renderParam; //!< Render param used to provided access to VP2 during prim synchronization
-    SdfPath _id;          //!< Render delegate IDs
+        _renderParam; //!< Render param used to provided access to VP2 during prim synchronization
+    SdfPath _id;      //!< Render delegate ID
     HdVP2ResourceRegistry
         _resourceRegistryVP2; //!< VP2 resource registry used for enqueue and execution of commits
+
+    HdVP2ShaderCache _shaderCache; //!< A thread-safe cache of named shaders.
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/render/vp2RenderDelegate/shader.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/shader.cpp
@@ -1,0 +1,34 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "shader.h"
+
+#include <pxr/base/tf/diagnostic.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/*! \brief  Releases the reference to the shader owned by a smart pointer.
+ */
+void HdVP2ShaderDeleter::operator()(MHWRender::MShaderInstance* shader)
+{
+    MRenderer* const renderer = MRenderer::theRenderer();
+
+    const MShaderManager* const shaderMgr = renderer ? renderer->getShaderManager() : nullptr;
+    if (TF_VERIFY(shaderMgr)) {
+        shaderMgr->releaseShader(shader);
+    }
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/render/vp2RenderDelegate/shader.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/shader.h
@@ -1,0 +1,55 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef HD_VP2_SHADER
+#define HD_VP2_SHADER
+
+#include <pxr/base/tf/token.h>
+#include <pxr/pxr.h>
+
+#include <maya/MShaderManager.h>
+
+#include <tbb/spin_rw_mutex.h>
+
+#include <memory>
+#include <unordered_map>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/*! \brief  A deleter for MShaderInstance, for use with smart pointers.
+ */
+struct HdVP2ShaderDeleter
+{
+    void operator()(MHWRender::MShaderInstance*);
+};
+
+/*! \brief  A MShaderInstance owned by a std::unique_ptr.
+ */
+using HdVP2ShaderUniquePtr = std::unique_ptr<MHWRender::MShaderInstance, HdVP2ShaderDeleter>;
+
+/*! \brief  Thread-safe cache of named shaders.
+ */
+struct HdVP2ShaderCache
+{
+    //! Shader registry
+    std::unordered_map<TfToken, HdVP2ShaderUniquePtr, TfToken::HashFunctor> _map;
+
+    //! Synchronization used to protect concurrent read from serial writes
+    tbb::spin_rw_mutex _mutex;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HD_VP2_SHADER


### PR DESCRIPTION
Implemented a shader instance cache to allow reuse of shader effect for duplicate material networks.
* This avoids repetitive compilation of the same shader effect, and thus reduces the load time.
* This removes a blocker for material consolidation, and thus will reduce the playback time. Maya has some other blockers for material consolidation that should be fixed separately.
