### PR TITLE
Added Blendshape export functionality

### DIFF
--- a/lib/mayaUsd/commands/baseExportCommand.cpp
+++ b/lib/mayaUsd/commands/baseExportCommand.cpp
@@ -115,6 +115,10 @@ MSyntax MayaUSDExportCommand::createSyntax()
     syntax.addFlag(
         kExportSkinFlag, UsdMayaJobExportArgsTokens->exportSkin.GetText(), MSyntax::kString);
     syntax.addFlag(
+        kExportBlendShapesFlag,
+        UsdMayaJobExportArgsTokens->exportBlendShapes.GetText(),
+        MSyntax::kBoolean);
+    syntax.addFlag(
         kParentScopeFlag, UsdMayaJobExportArgsTokens->parentScope.GetText(), MSyntax::kString);
     syntax.addFlag(
         kRenderableOnlyFlag, UsdMayaJobExportArgsTokens->renderableOnly.GetText(), MSyntax::kNoArg);

--- a/lib/mayaUsd/commands/baseExportCommand.cpp
+++ b/lib/mayaUsd/commands/baseExportCommand.cpp
@@ -107,6 +107,10 @@ MSyntax MayaUSDExportCommand::createSyntax()
         UsdMayaJobExportArgsTokens->exportVisibility.GetText(),
         MSyntax::kBoolean);
     syntax.addFlag(
+        kIgnoreWarningsFlag,
+        UsdMayaJobExportArgsTokens->ignoreWarnings.GetText(),
+        MSyntax::kBoolean);
+    syntax.addFlag(
         kExportReferenceObjectsFlag,
         UsdMayaJobExportArgsTokens->exportReferenceObjects.GetText(),
         MSyntax::kBoolean);

--- a/lib/mayaUsd/commands/baseExportCommand.h
+++ b/lib/mayaUsd/commands/baseExportCommand.h
@@ -48,6 +48,7 @@ public:
     static constexpr auto kExportUVsFlag = "uvs";
     static constexpr auto kEulerFilterFlag = "ef";
     static constexpr auto kExportVisibilityFlag = "vis";
+    static constexpr auto kIgnoreWarningsFlag = "ign";
     static constexpr auto kExportInstancesFlag = "ein";
     static constexpr auto kMergeTransformAndShapeFlag = "mt";
     static constexpr auto kStripNamespacesFlag = "sn";

--- a/lib/mayaUsd/commands/baseExportCommand.h
+++ b/lib/mayaUsd/commands/baseExportCommand.h
@@ -63,6 +63,7 @@ public:
     static constexpr auto kExportReferenceObjectsFlag = "ero";
     static constexpr auto kExportSkelsFlag = "skl";
     static constexpr auto kExportSkinFlag = "skn";
+    static constexpr auto kExportBlendShapesFlag = "ebs";
     static constexpr auto kParentScopeFlag = "psc";
     static constexpr auto kRenderableOnlyFlag = "ro";
     static constexpr auto kDefaultCamerasFlag = "dc";

--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -320,6 +320,7 @@ UsdMayaJobExportArgs::UsdMayaJobExportArgs(
           UsdMayaJobExportArgsTokens->exportSkin,
           UsdMayaJobExportArgsTokens->none,
           { UsdMayaJobExportArgsTokens->auto_, UsdMayaJobExportArgsTokens->explicit_ }))
+    , exportBlendShapes(_Boolean(userArgs, UsdMayaJobExportArgsTokens->exportBlendShapes))
     , exportVisibility(_Boolean(userArgs, UsdMayaJobExportArgsTokens->exportVisibility))
     , materialCollectionsPath(
           _AbsolutePath(userArgs, UsdMayaJobExportArgsTokens->materialCollectionsPath))
@@ -385,6 +386,7 @@ std::ostream& operator<<(std::ostream& out, const UsdMayaJobExportArgs& exportAr
         << std::endl
         << "exportSkels: " << TfStringify(exportArgs.exportSkels) << std::endl
         << "exportSkin: " << TfStringify(exportArgs.exportSkin) << std::endl
+        << "exportBlendShapes: " << TfStringify(exportArgs.exportBlendShapes) << std::endl
         << "exportVisibility: " << TfStringify(exportArgs.exportVisibility) << std::endl
         << "materialCollectionsPath: " << exportArgs.materialCollectionsPath << std::endl
         << "materialsScopeName: " << exportArgs.materialsScopeName << std::endl
@@ -466,6 +468,7 @@ const VtDictionary& UsdMayaJobExportArgs::GetDefaultDictionary()
         d[UsdMayaJobExportArgsTokens->exportRefsAsInstanceable] = false;
         d[UsdMayaJobExportArgsTokens->exportSkin] = UsdMayaJobExportArgsTokens->none.GetString();
         d[UsdMayaJobExportArgsTokens->exportSkels] = UsdMayaJobExportArgsTokens->none.GetString();
+        d[UsdMayaJobExportArgsTokens->exportBlendShapes] = false;
         d[UsdMayaJobExportArgsTokens->exportUVs] = true;
         d[UsdMayaJobExportArgsTokens->exportVisibility] = true;
         d[UsdMayaJobExportArgsTokens->kind] = std::string();

--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -322,6 +322,7 @@ UsdMayaJobExportArgs::UsdMayaJobExportArgs(
           { UsdMayaJobExportArgsTokens->auto_, UsdMayaJobExportArgsTokens->explicit_ }))
     , exportBlendShapes(_Boolean(userArgs, UsdMayaJobExportArgsTokens->exportBlendShapes))
     , exportVisibility(_Boolean(userArgs, UsdMayaJobExportArgsTokens->exportVisibility))
+    , ignoreWarnings(_Boolean(userArgs, UsdMayaJobExportArgsTokens->ignoreWarnings))
     , materialCollectionsPath(
           _AbsolutePath(userArgs, UsdMayaJobExportArgsTokens->materialCollectionsPath))
     , materialsScopeName(
@@ -388,6 +389,7 @@ std::ostream& operator<<(std::ostream& out, const UsdMayaJobExportArgs& exportAr
         << "exportSkin: " << TfStringify(exportArgs.exportSkin) << std::endl
         << "exportBlendShapes: " << TfStringify(exportArgs.exportBlendShapes) << std::endl
         << "exportVisibility: " << TfStringify(exportArgs.exportVisibility) << std::endl
+        << "ignoreWarnings: " << TfStringify(exportArgs.ignoreWarnings) << std::endl
         << "materialCollectionsPath: " << exportArgs.materialCollectionsPath << std::endl
         << "materialsScopeName: " << exportArgs.materialsScopeName << std::endl
         << "mergeTransformAndShape: " << TfStringify(exportArgs.mergeTransformAndShape) << std::endl
@@ -471,6 +473,7 @@ const VtDictionary& UsdMayaJobExportArgs::GetDefaultDictionary()
         d[UsdMayaJobExportArgsTokens->exportBlendShapes] = false;
         d[UsdMayaJobExportArgsTokens->exportUVs] = true;
         d[UsdMayaJobExportArgsTokens->exportVisibility] = true;
+        d[UsdMayaJobExportArgsTokens->ignoreWarnings] = false;
         d[UsdMayaJobExportArgsTokens->kind] = std::string();
         d[UsdMayaJobExportArgsTokens->materialCollectionsPath] = std::string();
         d[UsdMayaJobExportArgsTokens->materialsScopeName]

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -59,6 +59,7 @@ TF_DECLARE_PUBLIC_TOKENS(
     (defaultMeshScheme) \
     (defaultUSDFormat) \
     (eulerFilter) \
+    (exportBlendShapes) \
     (exportCollectionBasedBindings) \
     (exportColorSets) \
     (exportDisplayColor) \
@@ -68,7 +69,6 @@ TF_DECLARE_PUBLIC_TOKENS(
     (exportRefsAsInstanceable) \
     (exportSkels) \
     (exportSkin) \
-    (exportBlendShapes) \
     (exportUVs) \
     (exportVisibility) \
     (ignoreWarnings) \

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -71,6 +71,7 @@ TF_DECLARE_PUBLIC_TOKENS(
     (exportBlendShapes) \
     (exportUVs) \
     (exportVisibility) \
+    (ignoreWarnings) \
     (kind) \
     (materialCollectionsPath) \
     (materialsScopeName) \
@@ -155,6 +156,7 @@ struct UsdMayaJobExportArgs
     const TfToken exportSkin;
     const bool    exportBlendShapes;
     const bool    exportVisibility;
+    const bool    ignoreWarnings;
 
     /// If this is not empty, then a set of collections are exported on the
     /// prim pointed to by the path, each representing the collection of

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -68,6 +68,7 @@ TF_DECLARE_PUBLIC_TOKENS(
     (exportRefsAsInstanceable) \
     (exportSkels) \
     (exportSkin) \
+    (exportBlendShapes) \
     (exportUVs) \
     (exportVisibility) \
     (kind) \
@@ -152,6 +153,7 @@ struct UsdMayaJobExportArgs
     const bool    exportRefsAsInstanceable;
     const TfToken exportSkels;
     const TfToken exportSkin;
+    const bool    exportBlendShapes;
     const bool    exportVisibility;
 
     /// If this is not empty, then a set of collections are exported on the

--- a/lib/mayaUsd/fileio/primWriter.h
+++ b/lib/mayaUsd/fileio/primWriter.h
@@ -16,15 +16,9 @@
 #ifndef PXRUSDMAYA_PRIM_WRITER_H
 #define PXRUSDMAYA_PRIM_WRITER_H
 
-#include <memory>
-
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/fileio/jobs/jobArgs.h>
 #include <mayaUsd/utils/util.h>
-#include <maya/MBoundingBox.h>
-#include <maya/MDagPath.h>
-#include <maya/MFnDependencyNode.h>
-#include <maya/MObject.h>
 
 #include <pxr/base/vt/value.h>
 #include <pxr/pxr.h>
@@ -35,6 +29,7 @@
 #include <pxr/usd/usd/timeCode.h>
 #include <pxr/usd/usdUtils/sparseValueWriter.h>
 
+#include <maya/MBoundingBox.h>
 #include <maya/MDagPath.h>
 #include <maya/MFnDependencyNode.h>
 #include <maya/MObject.h>

--- a/lib/mayaUsd/fileio/primWriter.h
+++ b/lib/mayaUsd/fileio/primWriter.h
@@ -16,9 +16,15 @@
 #ifndef PXRUSDMAYA_PRIM_WRITER_H
 #define PXRUSDMAYA_PRIM_WRITER_H
 
+#include <memory>
+
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/fileio/jobs/jobArgs.h>
 #include <mayaUsd/utils/util.h>
+#include <maya/MBoundingBox.h>
+#include <maya/MDagPath.h>
+#include <maya/MFnDependencyNode.h>
+#include <maya/MObject.h>
 
 #include <pxr/base/vt/value.h>
 #include <pxr/pxr.h>

--- a/lib/mayaUsd/fileio/translators/skelBindingsProcessor.h
+++ b/lib/mayaUsd/fileio/translators/skelBindingsProcessor.h
@@ -50,6 +50,12 @@ public:
     /// Performs final processing for skel bindings.
     bool PostProcessSkelBindings(const UsdStagePtr& stage) const;
 
+    /// Updates the SkelRoots with a given extent value and time sample.
+    bool UpdateSkelRootsWithExtent(
+        const UsdStagePtr&  stage,
+        const VtVec3fArray& bbox,
+        const UsdTimeCode&  timeSample);
+
 private:
     bool _VerifyOrMakeSkelRoots(const UsdStagePtr& stage) const;
 

--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
@@ -36,14 +36,178 @@
 #include <pxr/usd/usdGeom/tokens.h>
 #include <pxr/usd/usdUtils/pipeline.h>
 
+#include <maya/MBoundingBox.h>
+#include <maya/MFnAttribute.h>
+#include <maya/MFnMesh.h>
 #include <maya/MFnSet.h>
 #include <maya/MGlobal.h>
 #include <maya/MIntArray.h>
+#include <maya/MItDependencyGraph.h>
 #include <maya/MItMeshFaceVertex.h>
 #include <maya/MPlug.h>
 #include <maya/MPlugArray.h>
+#include <maya/MPoint.h>
 #include <maya/MStatus.h>
 #include <maya/MUintArray.h>
+#include <maya/MVector.h>
+
+#define MAYA_ATTR_NAME_INMESH "inMesh"
+
+MString mayaGetUniqueNameOfDAGNode(const MObject& node)
+{
+    assert(!node.isNull());
+    assert(node.hasFn(MFn::kDagNode));
+    MStatus    stat;
+    MFnDagNode fnNode(node, &stat);
+    CHECK_MSTATUS_AND_RETURN(stat, MString());
+    MString nodeName = fnNode.partialPathName(&stat);
+    return nodeName;
+}
+
+MPlug mayaFindChildPlugWithName(const MPlug& parent, const MString& name)
+{
+    MPlug sentinel;
+    if (!parent.isCompound() || parent.isNull()) {
+        return sentinel;
+    }
+    MStatus      stat;
+    unsigned int numChildren = parent.numChildren(&stat);
+    CHECK_MSTATUS_AND_RETURN(stat, sentinel);
+    if (numChildren == 0) {
+        return sentinel;
+    }
+
+    MFnAttribute fnAttr;
+
+    // TODO: (yliangsiew) for a certain threshold of child plugs, might want to
+    //       binary search instead.
+    for (unsigned int i = 0; i < numChildren; ++i) {
+        MPlug plgChild = parent.child(i, &stat);
+        CHECK_MSTATUS_AND_RETURN(stat, sentinel);
+        MObject attrChild = plgChild.attribute(&stat);
+        CHECK_MSTATUS_AND_RETURN(stat, sentinel);
+        stat = fnAttr.setObject(attrChild);
+        CHECK_MSTATUS_AND_RETURN(stat, sentinel);
+        const MString attrName = fnAttr.name();
+        if (attrName == name) {
+            return plgChild;
+        }
+    }
+
+    return sentinel;
+}
+
+MStatus mayaGetSkinClusterConnectedToMesh(const MObject& mesh, MObject& skinCluster)
+{
+    // TODO: (yliangsiew) Do we care about multiple skinCluster layers? How do we even want
+    //        to deal with that, if at all?
+    MStatus stat;
+    if (!mesh.hasFn(MFn::kMesh)) {
+        return MStatus::kInvalidParameter;
+    }
+
+    MFnDependencyNode fnNode(mesh, &stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+    MPlug inMeshPlug = fnNode.findPlug(MAYA_ATTR_NAME_INMESH, false, &stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+    bool isDest = inMeshPlug.isDestination(&stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+    if (!isDest) {
+        return MStatus::kFailure;
+    }
+    MPlug srcPlug = inMeshPlug.source(&stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+    if (srcPlug.isNull()) {
+        return MStatus::kFailure;
+    }
+
+    skinCluster = srcPlug.node(&stat);
+
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+    if (!skinCluster.hasFn(MFn::kSkinClusterFilter)) {
+        return MStatus::kFailure;
+    }
+
+    return stat;
+}
+
+MStatus mayaGetSkinClustersUpstreamOfMesh(const MObject& mesh, MObjectArray& skinClusters)
+{
+    MStatus stat;
+    if (!mesh.hasFn(MFn::kMesh)) {
+        return MStatus::kInvalidParameter;
+    }
+
+    skinClusters.clear();
+    MObject            searchObj = MObject(mesh);
+    MItDependencyGraph itDg(
+        searchObj,
+        MFn::kInvalid,
+        MItDependencyGraph::kUpstream,
+        MItDependencyGraph::kDepthFirst,
+        MItDependencyGraph::kNodeLevel,
+        &stat);
+    while (!itDg.isDone()) {
+        MObject curNode = itDg.currentItem();
+        if (curNode.hasFn(MFn::kSkinClusterFilter)) {
+            skinClusters.append(curNode);
+        }
+        itDg.next();
+    }
+
+    return stat;
+}
+
+bool mayaSearchMIntArray(const int a, const MIntArray& array, unsigned int* idx)
+{
+    for (unsigned int i = 0; i < array.length(); ++i) {
+        if (array[i] == a) {
+            if (idx != NULL) {
+                *idx = i;
+            }
+            return true;
+        }
+    }
+    if (idx != NULL) {
+        *idx = -1;
+    }
+    return false;
+}
+
+MBoundingBox mayaCalcBBoxOfMeshes(const MObjectArray& meshes)
+{
+    unsigned int numMeshes = meshes.length();
+    MFnMesh      fnMesh;
+    MStatus      stat;
+    MVector      a;
+    MVector      b;
+    for (unsigned int i = 0; i < numMeshes; ++i) {
+        MObject curMesh = meshes[i];
+        assert(curMesh.hasFn(MFn::kMesh));
+        fnMesh.setObject(curMesh);
+        unsigned int numVertices = fnMesh.numVertices();
+        const float* meshPts = fnMesh.getRawPoints(&stat);
+        for (unsigned int j = 0; j < numVertices; ++j) {
+            float x = meshPts[j * 3];
+            float y = meshPts[(j * 3) + 1];
+            float z = meshPts[(j * 3) + 2];
+
+            a.x = x < a.x ? x : a.x;
+            b.x = x > b.x ? x : b.x;
+
+            a.y = y < a.y ? y : a.y;
+            b.y = y > b.y ? y : b.y;
+
+            a.z = z < a.z ? z : a.z;
+            b.z = z > b.z ? z : b.z;
+        }
+    }
+
+    MBoundingBox result = MBoundingBox(MPoint(a), MPoint(b));
+    return result;
+}
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
@@ -386,7 +386,7 @@ MStatus UsdMayaMeshWriteUtils::getSkinClustersUpstreamOfMesh(
     MObjectArray&  skinClusters)
 {
     MStatus stat;
-    if (!mesh.hasFn(MFn::kMesh)) {
+    if (mesh.isNull() || !mesh.hasFn(MFn::kMesh)) {
         return MStatus::kInvalidParameter;
     }
 

--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.h
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.h
@@ -35,25 +35,12 @@
 #include <maya/MObject.h>
 #include <maya/MString.h>
 
-/**
- * Gets the minimum unique name of a DAG node.
- *
- * @param node  The node to find the name of.
- *
- * @return      The name as a Maya string.
- */
-MString mayaGetUniqueNameOfDAGNode(const MObject& node);
+PXR_NAMESPACE_OPEN_SCOPE
 
-/**
- * Finds a child plug with the given `name`.
- *
- * @param parent    The parent plug to start the search from.
- * @param name      The name of the child plug to find. This should be the short name.
- *
- * @return          The plug if it can be found, or a null `MPlug` otherwise.
- */
-MPlug mayaFindChildPlugWithName(const MPlug& parent, const MString& name);
+class UsdGeomMesh;
 
+// Utilities for dealing with writing USD from Maya mesh/subdiv tags.
+namespace UsdMayaMeshWriteUtils {
 /**
  * Finds a skinCluster directly connected upstream in the DG to the given mesh.
  *
@@ -63,10 +50,11 @@ MPlug mayaFindChildPlugWithName(const MPlug& parent, const MString& name);
  *
  * @return                  `MStatus::kSuccess` if the operation completed successfully.
  */
-MStatus mayaGetSkinClusterConnectedToMesh(const MObject& mesh, MObject& skinCluster);
+MAYAUSD_CORE_PUBLIC
+MStatus getSkinClusterConnectedToMesh(const MObject& mesh, MObject& skinCluster);
 
 /**
- * Similar to `mayaGetSkinClusterConnectedToMesh`, except that instead of finding a
+ * Similar to `getSkinClusterConnectedToMesh`, except that instead of finding a
  * directly-connected skinCluster, it searches the DG upstream of the mesh for any
  * other skinClusters as well.
  *
@@ -75,19 +63,8 @@ MStatus mayaGetSkinClusterConnectedToMesh(const MObject& mesh, MObject& skinClus
  *
  * @return                  `MStatus::kSuccess` if the operation completed successfully.
  */
-MStatus mayaGetSkinClustersUpstreamOfMesh(const MObject& mesh, MObjectArray& skinClusters);
-
-/**
- * Searches the given array for an element.
- *
- * @param a         The element to search for.
- * @param array     The array to search within.
- * @param idx       Storage for the index of the element within the array if it exists.
- *                  If it does not exist, this will be undefined.
- *
- * @return          Returns ``true`` if the element exists in the array, ``false`` otherwise.
- */
-bool mayaSearchMIntArray(const int a, const MIntArray& array, unsigned int* idx);
+MAYAUSD_CORE_PUBLIC
+MStatus getSkinClustersUpstreamOfMesh(const MObject& mesh, MObjectArray& skinClusters);
 
 /**
  * Calculates the union bounding box of a given array of meshes.
@@ -96,14 +73,9 @@ bool mayaSearchMIntArray(const int a, const MIntArray& array, unsigned int* idx)
  *
  * @return          The union bounding box.
  */
-MBoundingBox mayaCalcBBoxOfMeshes(const MObjectArray& meshes);
+MAYAUSD_CORE_PUBLIC
+MBoundingBox calcBBoxOfMeshes(const MObjectArray& meshes);
 
-PXR_NAMESPACE_OPEN_SCOPE
-
-class UsdGeomMesh;
-
-// Utilities for dealing with writing USD from Maya mesh/subdiv tags.
-namespace UsdMayaMeshWriteUtils {
 /// Helper method for getting Maya mesh normals as a VtVec3fArray.
 MAYAUSD_CORE_PUBLIC
 bool getMeshNormals(const MFnMesh& mesh, VtVec3fArray* normalsArray, TfToken* interpolation);

--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.h
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.h
@@ -29,10 +29,74 @@
 #include <pxr/usd/usdGeom/mesh.h>
 #include <pxr/usd/usdUtils/sparseValueWriter.h>
 
+#include <maya/MBoundingBox.h>
 #include <maya/MDagPath.h>
 #include <maya/MFnMesh.h>
 #include <maya/MObject.h>
 #include <maya/MString.h>
+
+/**
+ * Gets the minimum unique name of a DAG node.
+ *
+ * @param node  The node to find the name of.
+ *
+ * @return      The name as a Maya string.
+ */
+MString mayaGetUniqueNameOfDAGNode(const MObject& node);
+
+/**
+ * Finds a child plug with the given `name`.
+ *
+ * @param parent    The parent plug to start the search from.
+ * @param name      The name of the child plug to find. This should be the short name.
+ *
+ * @return          The plug if it can be found, or a null `MPlug` otherwise.
+ */
+MPlug mayaFindChildPlugWithName(const MPlug& parent, const MString& name);
+
+/**
+ * Finds a skinCluster directly connected upstream in the DG to the given mesh.
+ *
+ * @param mesh              The mesh to search from.
+ * @param skinCluster       Storage for the result. If no skinCluster can be found,
+ *                          this will be a null `MObject`.
+ *
+ * @return                  `MStatus::kSuccess` if the operation completed successfully.
+ */
+MStatus mayaGetSkinClusterConnectedToMesh(const MObject& mesh, MObject& skinCluster);
+
+/**
+ * Similar to `mayaGetSkinClusterConnectedToMesh`, except that instead of finding a
+ * directly-connected skinCluster, it searches the DG upstream of the mesh for any
+ * other skinClusters as well.
+ *
+ * @param mesh              The mesh to start the search from.
+ * @param skinClusters      Storage for the result.
+ *
+ * @return                  `MStatus::kSuccess` if the operation completed successfully.
+ */
+MStatus mayaGetSkinClustersUpstreamOfMesh(const MObject& mesh, MObjectArray& skinClusters);
+
+/**
+ * Searches the given array for an element.
+ *
+ * @param a         The element to search for.
+ * @param array     The array to search within.
+ * @param idx       Storage for the index of the element within the array if it exists.
+ *                  If it does not exist, this will be undefined.
+ *
+ * @return          Returns ``true`` if the element exists in the array, ``false`` otherwise.
+ */
+bool mayaSearchMIntArray(const int a, const MIntArray& array, unsigned int* idx);
+
+/**
+ * Calculates the union bounding box of a given array of meshes.
+ *
+ * @param meshes    The meshes to calculate the union bounding box of.
+ *
+ * @return          The union bounding box.
+ */
+MBoundingBox mayaCalcBBoxOfMeshes(const MObjectArray& meshes);
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -590,4 +590,13 @@ void UsdMayaWriteJobContext::MarkSkelBindings(
     _skelBindingsProcessor->MarkBindings(path, skelPath, config);
 }
 
+bool UsdMayaWriteJobContext::UpdateSkelBindingsWithExtent(
+    const UsdStagePtr&  stage,
+    const VtVec3fArray& bbox,
+    const UsdTimeCode&  timeSample)
+{
+    bool bStat = _skelBindingsProcessor->UpdateSkelRootsWithExtent(stage, bbox, timeSample);
+    return bStat;
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -595,8 +595,7 @@ bool UsdMayaWriteJobContext::UpdateSkelBindingsWithExtent(
     const VtVec3fArray& bbox,
     const UsdTimeCode&  timeSample)
 {
-    bool bStat = _skelBindingsProcessor->UpdateSkelRootsWithExtent(stage, bbox, timeSample);
-    return bStat;
+    return _skelBindingsProcessor->UpdateSkelRootsWithExtent(stage, bbox, timeSample);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/writeJobContext.h
+++ b/lib/mayaUsd/fileio/writeJobContext.h
@@ -29,6 +29,7 @@
 #include <maya/MObjectHandle.h>
 
 #include <memory>
+#include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -126,6 +127,12 @@ public:
     /// mark an invalid binding.
     MAYAUSD_CORE_PUBLIC
     void MarkSkelBindings(const SdfPath& path, const SdfPath& skelPath, const TfToken& config);
+
+    MAYAUSD_CORE_PUBLIC
+    bool UpdateSkelBindingsWithExtent(
+        const UsdStagePtr&  stage,
+        const VtVec3fArray& bbox,
+        const UsdTimeCode&  timeSample);
 
 protected:
     /// Opens the stage with the given \p filename for writing.

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -2310,9 +2310,9 @@ bool UsdMayaUtil::mayaSearchMIntArray(const int a, const MIntArray& array, unsig
     return false;
 }
 
-MStatus UsdMayaUtil::GetAllIndicesFromComponentListDataPlug(const MPlug &plg, MIntArray &indices)
+MStatus UsdMayaUtil::GetAllIndicesFromComponentListDataPlug(const MPlug& plg, MIntArray& indices)
 {
-    MStatus status;
+    MStatus     status;
     MDataHandle dh = plg.asMDataHandle(&status);
     CHECK_MSTATUS_AND_RETURN_IT(status);
     MObject indicesData = dh.data();

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -2310,7 +2310,6 @@ bool UsdMayaUtil::mayaSearchMIntArray(const int a, const MIntArray& array, unsig
     return false;
 }
 
-
 MStatus UsdMayaUtil::GetAllIndicesFromComponentListDataPlug(const MPlug &plg, MIntArray &indices)
 {
     MStatus status;

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -189,8 +189,9 @@ std::string UsdMayaUtil::GetMayaNodeName(const MObject& mayaNode)
 
 MString UsdMayaUtil::GetUniqueNameOfDAGNode(const MObject& node)
 {
-    TF_VERIFY(!node.isNull());
-    TF_VERIFY(node.hasFn(MFn::kDagNode));
+    if (!TF_VERIFY(!node.isNull() && node.hasFn(MFn::kDagNode))) {
+        return MString();
+    }
     MStatus    stat;
     MFnDagNode fnNode(node, &stat);
     CHECK_MSTATUS_AND_RETURN(stat, MString());

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -185,6 +185,17 @@ std::string UsdMayaUtil::GetMayaNodeName(const MObject& mayaNode)
     return nodeName.asChar();
 }
 
+MString UsdMayaUtil::GetUniqueNameOfDAGNode(const MObject& node)
+{
+    TF_VERIFY(!node.isNull());
+    TF_VERIFY(node.hasFn(MFn::kDagNode));
+    MStatus    stat;
+    MFnDagNode fnNode(node, &stat);
+    CHECK_MSTATUS_AND_RETURN(stat, MString());
+    MString nodeName = fnNode.partialPathName(&stat);
+    return nodeName;
+}
+
 MStatus UsdMayaUtil::GetMObjectByName(const std::string& nodeName, MObject& mObj)
 {
     MSelectionList selectionList;
@@ -237,6 +248,39 @@ MStatus UsdMayaUtil::GetPlugByName(const std::string& attrPath, MPlug& plug)
 
     plug = tmpPlug;
     return status;
+}
+
+MPlug UsdMayaUtil::FindChildPlugWithName(const MPlug& parent, const MString& name)
+{
+    MPlug sentinel;
+    if (parent.isNull() || !parent.isCompound()) {
+        return sentinel;
+    }
+    MStatus      stat;
+    unsigned int numChildren = parent.numChildren(&stat);
+    CHECK_MSTATUS_AND_RETURN(stat, sentinel);
+    if (numChildren == 0) {
+        return sentinel;
+    }
+
+    MFnAttribute fnAttr;
+
+    // TODO: (yliangsiew) for a certain threshold of child plugs, might want to
+    //       binary search instead.
+    for (unsigned int i = 0; i < numChildren; ++i) {
+        MPlug plgChild = parent.child(i, &stat);
+        CHECK_MSTATUS_AND_RETURN(stat, sentinel);
+        MObject attrChild = plgChild.attribute(&stat);
+        CHECK_MSTATUS_AND_RETURN(stat, sentinel);
+        stat = fnAttr.setObject(attrChild);
+        CHECK_MSTATUS_AND_RETURN(stat, sentinel);
+        const MString attrName = fnAttr.name();
+        if (attrName == name) {
+            return plgChild;
+        }
+    }
+
+    return sentinel;
 }
 
 MPlug UsdMayaUtil::GetMayaTimePlug()
@@ -2246,4 +2290,20 @@ float UsdMayaUtil::GetSceneMTimeUnitAsFloat()
 {
     const MTime::Unit sceneUnit = MTime::uiUnit();
     return UsdMayaUtil::ConvertMTimeUnitToFloat(sceneUnit);
+}
+
+bool UsdMayaUtil::mayaSearchMIntArray(const int a, const MIntArray& array, unsigned int* idx)
+{
+    for (unsigned int i = 0; i < array.length(); ++i) {
+        if (array[i] == a) {
+            if (idx != nullptr) {
+                *idx = i;
+            }
+            return true;
+        }
+    }
+    if (idx != nullptr) {
+        *idx = -1;
+    }
+    return false;
 }

--- a/lib/mayaUsd/utils/util.h
+++ b/lib/mayaUsd/utils/util.h
@@ -160,6 +160,16 @@ MDistance::Unit ConvertUsdGeomLinearUnitToMDistanceUnit(const double linearUnit)
 MAYAUSD_CORE_PUBLIC
 std::string GetMayaNodeName(const MObject& mayaNode);
 
+/**
+ * Gets the minimum unique name of a DAG node.
+ *
+ * @param node  The node to find the name of.
+ *
+ * @return      The name as a Maya string.
+ */
+MAYAUSD_CORE_PUBLIC
+MString GetUniqueNameOfDAGNode(const MObject& node);
+
 /// Gets the Maya MObject for the node named \p nodeName.
 MAYAUSD_CORE_PUBLIC
 MStatus GetMObjectByName(const std::string& nodeName, MObject& mObj);
@@ -173,6 +183,17 @@ MStatus GetDagPathByName(const std::string& nodeName, MDagPath& dagPath);
 /// used by MEL).
 MAYAUSD_CORE_PUBLIC
 MStatus GetPlugByName(const std::string& attrPath, MPlug& plug);
+
+/**
+ * Finds a child plug with the given `name`.
+ *
+ * @param parent    The parent plug to start the search from.
+ * @param name      The name of the child plug to find. This should be the short name.
+ *
+ * @return          The plug if it can be found, or a null `MPlug` otherwise.
+ */
+MAYAUSD_CORE_PUBLIC
+MPlug FindChildPlugWithName(const MPlug& parent, const MString& name);
 
 /// Get the MPlug for the output time attribute of Maya's global time object
 ///
@@ -579,6 +600,19 @@ float ConvertMTimeUnitToFloat(const MTime::Unit& unit);
 /// Returns 0.0f if the result is invalid.
 MAYAUSD_CORE_PUBLIC
 float GetSceneMTimeUnitAsFloat();
+
+/**
+ * Searches the given array for an element.
+ *
+ * @param a         The element to search for.
+ * @param array     The array to search within.
+ * @param idx       Storage for the index of the element within the array if it exists.
+ *                  If it does not exist, this will be undefined.
+ *
+ * @return          Returns ``true`` if the element exists in the array, ``false`` otherwise.
+ */
+MAYAUSD_CORE_PUBLIC
+bool mayaSearchMIntArray(const int a, const MIntArray& array, unsigned int* idx);
 
 } // namespace UsdMayaUtil
 

--- a/lib/mayaUsd/utils/util.h
+++ b/lib/mayaUsd/utils/util.h
@@ -614,6 +614,9 @@ float GetSceneMTimeUnitAsFloat();
 MAYAUSD_CORE_PUBLIC
 bool mayaSearchMIntArray(const int a, const MIntArray& array, unsigned int* idx);
 
+MAYAUSD_CORE_PUBLIC
+MStatus GetAllIndicesFromComponentListDataPlug(const MPlug &plg, MIntArray &indices);
+
 } // namespace UsdMayaUtil
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/utils/util.h
+++ b/lib/mayaUsd/utils/util.h
@@ -615,7 +615,7 @@ MAYAUSD_CORE_PUBLIC
 bool mayaSearchMIntArray(const int a, const MIntArray& array, unsigned int* idx);
 
 MAYAUSD_CORE_PUBLIC
-MStatus GetAllIndicesFromComponentListDataPlug(const MPlug &plg, MIntArray &indices);
+MStatus GetAllIndicesFromComponentListDataPlug(const MPlug& plg, MIntArray& indices);
 
 } // namespace UsdMayaUtil
 

--- a/lib/usd/translators/CMakeLists.txt
+++ b/lib/usd/translators/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(Boost COMPONENTS filesystem system REQUIRED)
 # -----------------------------------------------------------------------------
 # sources
 # -----------------------------------------------------------------------------
-target_sources(${TARGET_NAME} 
+target_sources(${TARGET_NAME}
     PRIVATE
         cameraReader.cpp
         cameraWriter.cpp
@@ -35,6 +35,7 @@ target_sources(${TARGET_NAME}
         mayaReferenceUpdater.cpp
         meshReader.cpp
         meshWriter.cpp
+        meshWriter_BlendShapes.cpp
         nurbsCurvesReader.cpp
         nurbsCurveWriter.cpp
         nurbsPatchReader.cpp
@@ -51,7 +52,7 @@ add_subdirectory(shading)
 # -----------------------------------------------------------------------------
 # compiler configuration
 # -----------------------------------------------------------------------------
-target_compile_definitions(${TARGET_NAME} 
+target_compile_definitions(${TARGET_NAME}
     PRIVATE
         $<$<BOOL:${IS_MACOSX}>:OSMac_>
 )
@@ -70,8 +71,8 @@ target_include_directories(${TARGET_NAME}
 # -----------------------------------------------------------------------------
 # link libraries
 # -----------------------------------------------------------------------------
-target_link_libraries(${TARGET_NAME} 
-    PRIVATE 
+target_link_libraries(${TARGET_NAME}
+    PRIVATE
         arch
         gf
         kind
@@ -135,11 +136,11 @@ install(
 )
 
 if(IS_WINDOWS)
-    install(FILES $<TARGET_PDB_FILE:${TARGET_NAME}> 
+    install(FILES $<TARGET_PDB_FILE:${TARGET_NAME}>
         DESTINATION ${LIBRARY_INSTALL_PATH} OPTIONAL
     )
 endif()
- 
+
 install(FILES ${HEADERS}
     DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${TARGET_NAME}
 )

--- a/lib/usd/translators/meshWriter.cpp
+++ b/lib/usd/translators/meshWriter.cpp
@@ -26,6 +26,7 @@
 #include <mayaUsd/fileio/writeJobContext.h>
 #include <mayaUsd/utils/util.h>
 
+#include "pxr/base/tf/diagnostic.h"
 #include <pxr/base/gf/vec2f.h>
 #include <pxr/base/gf/vec3f.h>
 #include <pxr/base/gf/vec4f.h>
@@ -41,9 +42,12 @@
 #include <pxr/usd/usdSkel/root.h>
 #include <pxr/usd/usdUtils/pipeline.h>
 
+#include <maya/MFnBlendShapeDeformer.h>
 #include <maya/MFnDependencyNode.h>
+#include <maya/MFnGeometryFilter.h>
 #include <maya/MFnMesh.h>
 #include <maya/MIntArray.h>
+#include <maya/MItDependencyGraph.h>
 #include <maya/MPlug.h>
 #include <maya/MPlugArray.h>
 #include <maya/MString.h>
@@ -53,6 +57,57 @@
 #include <set>
 #include <string>
 #include <vector>
+
+MObject mayaFindUpstreamOrigMesh(const MObject& mesh)
+{
+    MStatus stat;
+
+    // NOTE: (yliangsiew) If there's a skinCluster, find that first since that
+    // will be the intermediate to the blendShape node. If not, just search for any
+    // blendshape deformers upstream of the mesh.
+    MObject searchObject;
+    MObject skinCluster;
+    stat = mayaGetSkinClusterConnectedToMesh(mesh, skinCluster);
+    if (stat) {
+        searchObject = MObject(skinCluster);
+    } else {
+        searchObject = MObject(mesh);
+    }
+
+    // TODO: (yliangsiew) Problem: if there are _intermediate deformers between blendshapes,
+    // then what do we do? Like blendshape1 -> wrap -> blendshape2. This won't find
+    // that correctly...
+    MFnGeometryFilter     fnGeoFilter;
+    MFnBlendShapeDeformer fnBlendShape;
+    MItDependencyGraph    itDg(
+        searchObject,
+        MFn::kBlendShape,
+        MItDependencyGraph::kUpstream,
+        MItDependencyGraph::kDepthFirst,
+        MItDependencyGraph::kPlugLevel,
+        &stat);
+    MFnDependencyNode fnNode;
+    for (; !itDg.isDone(); itDg.next()) {
+        MObject curBlendShape = itDg.currentItem();
+        assert(curBlendShape.hasFn(MFn::kBlendShape));
+
+        MPlug outputGeomPlug = itDg.thisPlug();
+        assert(outputGeomPlug.isElement() == true);
+        unsigned int outputGeomPlugIdx = outputGeomPlug.logicalIndex();
+
+        // NOTE: (yliangsiew) Because we can have multiple output
+        // deformed meshes from a single blendshape deformer, we have
+        // to walk back up the graph using the connected index to find
+        // out what the _actual_ base mesh was.
+        fnGeoFilter.setObject(curBlendShape);
+        MObject inputGeo = fnGeoFilter.inputShapeAtIndex(outputGeomPlugIdx, &stat);
+        if (inputGeo.hasFn(MFn::kMesh)) {
+            return inputGeo;
+        }
+    }
+
+    return mesh;
+}
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -87,6 +142,35 @@ PxrUsdTranslators_MeshWriter::PxrUsdTranslators_MeshWriter(
 
 void PxrUsdTranslators_MeshWriter::PostExport() { cleanupPrimvars(); }
 
+bool PxrUsdTranslators_MeshWriter::writeAnimatedMeshExtents(
+    const MObject&     deformedMesh,
+    const UsdTimeCode& usdTime)
+{
+    // NOTE: (yliangsiew) We also cache the animated extents out here; this
+    // will be written at the SkelRoot level later on.
+    assert(!deformedMesh.isNull());
+    assert(deformedMesh.hasFn(MFn::kMesh));
+    MStatus stat;
+    MFnMesh fnMesh(deformedMesh, &stat);
+    CHECK_MSTATUS_AND_RETURN(stat, false);
+    unsigned int numVertices = fnMesh.numVertices();
+    const float* meshPts = fnMesh.getRawPoints(&stat);
+    CHECK_MSTATUS_AND_RETURN(stat, false);
+
+    const GfVec3f* pVtMeshPts = reinterpret_cast<const GfVec3f*>(meshPts);
+    VtVec3fArray   vtMeshPts(pVtMeshPts, pVtMeshPts + numVertices);
+    VtVec3fArray   meshBBox(2);
+    UsdGeomPointBased::ComputeExtent(vtMeshPts, &meshBBox);
+    bool bStat = true;
+    if (meshBBox != this->_prevMeshExtentsSample) {
+        bStat = this->_writeJobCtx.UpdateSkelBindingsWithExtent(
+            this->GetUsdStage(), meshBBox, usdTime);
+    }
+    this->_prevMeshExtentsSample = meshBBox;
+
+    return bStat;
+}
+
 void PxrUsdTranslators_MeshWriter::Write(const UsdTimeCode& usdTime)
 {
     UsdMayaPrimWriter::Write(usdTime);
@@ -101,8 +185,10 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
 {
     MStatus status { MS::kSuccess };
 
+    const UsdMayaJobExportArgs& exportArgs = _GetExportArgs();
+
     // Exporting reference object only once
-    if (usdTime.IsDefault() && _GetExportArgs().exportReferenceObjects) {
+    if (usdTime.IsDefault() && exportArgs.exportReferenceObjects) {
         UsdMayaMeshWriteUtils::exportReferenceMesh(primSchema, GetMayaObject());
     }
 
@@ -110,7 +196,7 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
     // determine whether we use the "input" or "final" mesh when exporting
     // mesh geometry. This should only be run once at default time.
     if (usdTime.IsDefault()) {
-        const TfToken& exportSkin = _GetExportArgs().exportSkin;
+        const TfToken& exportSkin = exportArgs.exportSkin;
         if (exportSkin != UsdMayaJobExportArgsTokens->auto_
             && exportSkin != UsdMayaJobExportArgsTokens->explicit_) {
 
@@ -130,7 +216,7 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
                 GetUsdPath(),
                 GetDagPath(),
                 skelPath,
-                _GetExportArgs().stripNamespaces,
+                exportArgs.stripNamespaces,
                 _GetSparseValueWriter());
 
             if (!_skelInputMesh.isNull()) {
@@ -163,10 +249,47 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
     MObject geomMeshObj = _skelInputMesh.isNull() ? finalMesh.object() : _skelInputMesh;
     // do not pass these to functions that need access to geomMeshObj!
     // geomMesh.object() returns nil for meshes of type kMeshData.
+
+    // NOTE: (yliangsiew) Because we need to write out the _actual_ base mesh,
+    // not the deformed mesh as as result of blendshapes, if there is a blendshape
+    // in the deform stack here, we walk past it to the original shape instead.
+    if (exportArgs.exportBlendShapes) {
+        geomMeshObj = mayaFindUpstreamOrigMesh(geomMeshObj);
+    }
     MFnMesh geomMesh(geomMeshObj, &status);
     if (!status) {
         TF_RUNTIME_ERROR(
             "Failed to get geom mesh at DAG path: %s", GetDagPath().fullPathName().asChar());
+        return false;
+    }
+
+    // Write UsdSkelBlendShape data next. This also expands the _unionBBox member as
+    // needed to encompass all the target blendshapes and writes it to the SkelRoot.
+    bool bStat;
+    if (exportArgs.exportBlendShapes) {
+        if (usdTime.IsDefault()) {
+            _skelInputMesh = this->writeBlendShapeData(primSchema);
+            if (_skelInputMesh.isNull()) {
+                TF_WARN("Failed to write out initial blendshape data.");
+                return false;
+            }
+        } else {
+            // NOTE: (yliangsiew) This is going to get called once for each time sampled.
+            if (!_skelInputMesh.isNull()) {
+                bStat = this->writeBlendShapeAnimation(usdTime);
+                if (!bStat) {
+                    TF_RUNTIME_ERROR("Failed to write out blendshape animation.");
+                    return bStat;
+                }
+            }
+        }
+    }
+
+    // NOTE: (yliangsiew) Write out the final deformed mesh extents for each frame here.
+    MDagPath deformedMeshDagPath = this->GetDagPath();
+    MObject  deformedMesh = deformedMeshDagPath.node();
+    bStat = this->writeAnimatedMeshExtents(deformedMesh, usdTime);
+    if (!bStat) {
         return false;
     }
 
@@ -190,7 +313,7 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
     // flag (this is specified by the job args but defaults to catmullClark).
     TfToken sdScheme = UsdMayaMeshWriteUtils::getSubdivScheme(finalMesh);
     if (sdScheme.IsEmpty()) {
-        sdScheme = _GetExportArgs().defaultMeshScheme;
+        sdScheme = exportArgs.defaultMeshScheme;
     }
     primSchema.CreateSubdivisionSchemeAttr(VtValue(sdScheme), true);
 
@@ -218,14 +341,14 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
     UsdMayaMeshWriteUtils::writeInvisibleFacesData(finalMesh, primSchema, _GetSparseValueWriter());
 
     // == Write UVSets as Vec2f Primvars
-    if (_GetExportArgs().exportMeshUVs) {
+    if (exportArgs.exportMeshUVs) {
         UsdMayaMeshWriteUtils::writeUVSetsAsVec2fPrimvars(
             finalMesh, primSchema, usdTime, _GetSparseValueWriter());
     }
 
     // == Gather ColorSets
     std::vector<std::string> colorSetNames;
-    if (_GetExportArgs().exportColorSets) {
+    if (exportArgs.exportColorSets) {
         MStringArray mayaColorSetNames;
         status = finalMesh.getColorSetNames(mayaColorSetNames);
         colorSetNames.reserve(mayaColorSetNames.length());
@@ -245,7 +368,7 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
     // opacities from the shaders assigned to the mesh and/or its faces.
     // If we find a displayColor color set, the shader colors and opacities
     // will be used to fill in unauthored/unpainted faces in the color set.
-    if (_GetExportArgs().exportDisplayColor || !colorSetNames.empty()) {
+    if (exportArgs.exportDisplayColor || !colorSetNames.empty()) {
         UsdMayaUtil::GetLinearShaderColor(
             finalMesh,
             &shadersRGBData,
@@ -262,7 +385,7 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
         bool isDisplayColor = false;
 
         if (colorSetName == UsdMayaMeshPrimvarTokens->DisplayColorColorSetName.GetString()) {
-            if (!_GetExportArgs().exportDisplayColor) {
+            if (!exportArgs.exportDisplayColor) {
                 continue;
             }
             isDisplayColor = true;
@@ -372,7 +495,7 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
     // UsdMayaMeshWriteUtils::addDisplayPrimvars() will only author displayColor and displayOpacity
     // if no authored opinions exist, so the code below only has an effect if
     // we did NOT find a displayColor color set above.
-    if (_GetExportArgs().exportDisplayColor) {
+    if (exportArgs.exportDisplayColor) {
         // Using the shader default values (an alpha of zero, in particular)
         // results in Gprims rendering the same way in usdview as they do in
         // Maya (i.e. unassigned components are invisible).

--- a/lib/usd/translators/meshWriter.cpp
+++ b/lib/usd/translators/meshWriter.cpp
@@ -337,17 +337,13 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
                                         if (fabs(vertexComponent - 0.0f) > FLT_EPSILON) {
                                             MFnDependencyNode fnNode(curIntermediate, &status);
                                             CHECK_MSTATUS_AND_RETURN(status, false);
-                                            MGlobal::displayError(
-                                                "Could not determine the original blendshape "
-                                                "source mesh due to the tweak node: "
-                                                + fnNode.name()
-                                                + ". Please either bake it down or remove the "
-                                                  "edits and attempt the export process again, or "
-                                                  "specify -ignoreWarnings.");
                                             TF_RUNTIME_ERROR(
                                                 "Could not determine the original blendshape "
-                                                "source mesh due to a non-empty tweak node, "
-                                                "aborting export.");
+                                                "source mesh due to a non-empty tweak node: %s. "
+                                                "Please either bake it down or remove the "
+                                                "edits and attempt the export process again, or "
+                                                "specify -ignoreWarnings.",
+                                                fnNode.name().asChar());
                                             return false;
                                         }
                                     }
@@ -357,10 +353,6 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
                         continue; // NOTE: (yliangsiew) If the tweak node has no effect, go check
                                   // the next intermediate.
                     }
-                    MGlobal::displayError(
-                        "USDSkelBlendShape does not support animated blend shapes. Please bake "
-                        "down deformer history before attempting an export, or specify "
-                        "-ignoreWarnings during the export process.");
                     TF_RUNTIME_ERROR(
                         "USDSkelBlendShape does not support animated blend shapes. Please bake "
                         "down deformer history before attempting an export, or specify "
@@ -380,14 +372,11 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
                         for (unsigned int k = 0; k < plgPnt.numChildren(); ++k) {
                             float tweakValue = plgPnt.child(k).asFloat();
                             if (fabs(tweakValue - 0.0f) > FLT_EPSILON) {
-                                MGlobal::displayError(
-                                    "The mesh: " + fnNode.name()
-                                    + " has local tweak data on its .pnts attribute. Please remove "
-                                      "it before attempting an export, or specify -ignoreWarnings "
-                                      "during the export process.");
                                 TF_RUNTIME_ERROR(
-                                    "Could not reliably verify the points of the original source "
-                                    "mesh for the blendshape export, aborting export.");
+                                    "The mesh: %s has local tweak data on its .pnts attribute. "
+                                    "Please remove it before attempting an export, or specify "
+                                    "-ignoreWarnings during the export process.",
+                                    fnNode.name().asChar());
                                 return false;
                             }
                         }
@@ -396,11 +385,6 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
                 } else {
                     MFnDependencyNode fnNode(curIntermediate, &status);
                     CHECK_MSTATUS_AND_RETURN(status, false);
-                    MGlobal::displayError(
-                        "Unrecognized node encountered in blendshape deformation chain: "
-                        + fnNode.name()
-                        + "Please bake down deformer history before attempting an export, or "
-                          "specify -ignoreWarnings during the export process.");
                     TF_RUNTIME_ERROR(
                         "Unrecognized node encountered in blendshape deformation chain: %s. Please "
                         "bake down deformer history before attempting an export, or specify "

--- a/lib/usd/translators/meshWriter.cpp
+++ b/lib/usd/translators/meshWriter.cpp
@@ -122,8 +122,16 @@ MObject mayaFindOrigMeshFromBlendShapeTarget(const MObject& mesh, MObjectArray* 
                 MItDependencyGraph::kPlugLevel,
                 &stat);
             for (; !itDgBS.isDone(); itDgBS.next()) {
-                MItDependencyGraph itDgBS(curBlendShape, MFn::kInvalid, MItDependencyGraph::kUpstream, MItDependencyGraph::kDepthFirst, MItDependencyGraph::kNodeLevel, &stat);
-                for (itDgBS.next(); !itDgBS.isDone(); itDgBS.next()) {  // NOTE: (yliangsiew) Skip the first node which starts at the root, which is the blendshape deformer itself.
+                MItDependencyGraph itDgBS(
+                    curBlendShape,
+                    MFn::kInvalid,
+                    MItDependencyGraph::kUpstream,
+                    MItDependencyGraph::kDepthFirst,
+                    MItDependencyGraph::kNodeLevel,
+                    &stat);
+                for (itDgBS.next(); !itDgBS.isDone();
+                     itDgBS.next()) { // NOTE: (yliangsiew) Skip the first node which starts at the
+                                      // root, which is the blendshape deformer itself.
                     MObject curNode = itDgBS.thisNode();
                     if (curNode.hasFn(MFn::kMesh)) {
                         return curNode;
@@ -134,7 +142,6 @@ MObject mayaFindOrigMeshFromBlendShapeTarget(const MObject& mesh, MObjectArray* 
         }
     }
     return mesh;
-
 }
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -331,15 +338,25 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
                                         if (fabs(vertexComponent - 0.0f) > FLT_EPSILON) {
                                             MFnDependencyNode fnNode(curIntermediate, &status);
                                             CHECK_MSTATUS_AND_RETURN(status, false);
-                                            MGlobal::displayError("Could not determine the original blendshape source mesh due to the tweak node: " + fnNode.name() + ". Please either bake it down or remove the edits and attempt the export process again, or specify -ignoreWarnings.");
-                                            TF_RUNTIME_ERROR("Could not determine the original blendshape source mesh due to a non-empty tweak node, aborting export.");
+                                            MGlobal::displayError(
+                                                "Could not determine the original blendshape "
+                                                "source mesh due to the tweak node: "
+                                                + fnNode.name()
+                                                + ". Please either bake it down or remove the "
+                                                  "edits and attempt the export process again, or "
+                                                  "specify -ignoreWarnings.");
+                                            TF_RUNTIME_ERROR(
+                                                "Could not determine the original blendshape "
+                                                "source mesh due to a non-empty tweak node, "
+                                                "aborting export.");
                                             return false;
                                         }
                                     }
                                 }
                             }
                         }
-                        continue; // NOTE: (yliangsiew) If the tweak node has no effect, go check the next intermediate.
+                        continue; // NOTE: (yliangsiew) If the tweak node has no effect, go check
+                                  // the next intermediate.
                     }
                     MGlobal::displayError(
                         "USDSkelBlendShape does not support animated blend shapes. Please bake "
@@ -352,19 +369,26 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
                     return false;
 
                 } else if (curIntermediate.hasFn(MFn::kMesh)) {
-                    // NOTE: (yliangsiew) Need to check that the mesh itself does not include any tweaks.
+                    // NOTE: (yliangsiew) Need to check that the mesh itself does not include any
+                    // tweaks.
                     MFnDependencyNode fnNode(curIntermediate, &status);
                     CHECK_MSTATUS_AND_RETURN(status, false);
                     MPlug plgPnts = fnNode.findPlug("pnts");
                     assert(plgPnts.isArray());
-                    for (unsigned int j=0; j < plgPnts.numElements(); ++j) {
+                    for (unsigned int j = 0; j < plgPnts.numElements(); ++j) {
                         MPlug plgPnt = plgPnts.elementByPhysicalIndex(j);
                         assert(plgPnt.isCompound());
-                        for (unsigned int k=0; k < plgPnt.numChildren(); ++k) {
+                        for (unsigned int k = 0; k < plgPnt.numChildren(); ++k) {
                             float tweakValue = plgPnt.child(k).asFloat();
                             if (fabs(tweakValue - 0.0f) > FLT_EPSILON) {
-                                MGlobal::displayError("The mesh: " + fnNode.name() + " has local tweak data on its .pnts attribute. Please remove it before attempting an export, or specify -ignoreWarnings during the export process.");
-                                TF_RUNTIME_ERROR("Could not reliably verify the points of the original source mesh for the blendshape export, aborting export.");
+                                MGlobal::displayError(
+                                    "The mesh: " + fnNode.name()
+                                    + " has local tweak data on its .pnts attribute. Please remove "
+                                      "it before attempting an export, or specify -ignoreWarnings "
+                                      "during the export process.");
+                                TF_RUNTIME_ERROR(
+                                    "Could not reliably verify the points of the original source "
+                                    "mesh for the blendshape export, aborting export.");
                                 return false;
                             }
                         }

--- a/lib/usd/translators/meshWriter.cpp
+++ b/lib/usd/translators/meshWriter.cpp
@@ -15,6 +15,8 @@
 //
 #include "meshWriter.h"
 
+#include "pxr/base/tf/diagnostic.h"
+
 #include <mayaUsd/fileio/primWriter.h>
 #include <mayaUsd/fileio/primWriterRegistry.h>
 #include <mayaUsd/fileio/translators/translatorMesh.h>
@@ -26,7 +28,6 @@
 #include <mayaUsd/fileio/writeJobContext.h>
 #include <mayaUsd/utils/util.h>
 
-#include "pxr/base/tf/diagnostic.h"
 #include <pxr/base/gf/vec2f.h>
 #include <pxr/base/gf/vec3f.h>
 #include <pxr/base/gf/vec4f.h>

--- a/lib/usd/translators/meshWriter.cpp
+++ b/lib/usd/translators/meshWriter.cpp
@@ -65,7 +65,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 MObject mayaFindOrigMeshFromBlendShapeTarget(const MObject& mesh, MObjectArray* intermediates)
 {
-    assert(mesh.hasFn(MFn::kMesh));
+    TF_VERIFY(mesh.hasFn(MFn::kMesh));
     MStatus stat;
 
     // NOTE: (yliangsiew) If there's a skinCluster, find that first since that
@@ -106,7 +106,7 @@ MObject mayaFindOrigMeshFromBlendShapeTarget(const MObject& mesh, MObjectArray* 
         // deformed meshes from a single blendshape deformer, we have
         // to walk back up the graph using the connected index to find
         // out what the _actual_ base mesh was.
-        if (intermediates == NULL) {
+        if (intermediates == nullptr) {
             MFnGeometryFilter fnGeoFilter;
             fnGeoFilter.setObject(curBlendShape);
             MObject inputGeo = fnGeoFilter.inputShapeAtIndex(outputGeomPlugIdx, &stat);
@@ -292,7 +292,7 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
     // assignments to materials.)
     if (exportArgs.exportBlendShapes && geomMeshObj.hasFn(MFn::kDependencyNode)) {
         if (exportArgs.ignoreWarnings) {
-            geomMeshObj = mayaFindOrigMeshFromBlendShapeTarget(geomMeshObj, NULL);
+            geomMeshObj = mayaFindOrigMeshFromBlendShapeTarget(geomMeshObj, nullptr);
         } else {
             MObjectArray intermediates;
             geomMeshObj = mayaFindOrigMeshFromBlendShapeTarget(geomMeshObj, &intermediates);

--- a/lib/usd/translators/meshWriter.h
+++ b/lib/usd/translators/meshWriter.h
@@ -71,18 +71,20 @@ private:
     /// skinCluster is applied but we don't support that right now.
     bool isMeshAnimated() const;
 
-    /// Input mesh before any skeletal deformations, cached between iterations.
-    MObject _skelInputMesh;
-
-    // The animated plugs of any blendshape nodes involved in mesh deformation.
-    MPlugArray _animBlendShapeWeightPlugs;
-
-    VtVec3fArray _prevMeshExtentsSample;
-
-    UsdSkelAnimation _skelAnim;
     MObject          writeBlendShapeData(UsdGeomMesh& primSchema);
     bool             writeBlendShapeAnimation(const UsdTimeCode& usdTime);
     bool writeAnimatedMeshExtents(const MObject& deformedMesh, const UsdTimeCode& usdTime);
+
+    /// Input mesh before any skeletal deformations, cached between iterations.
+    MObject _skelInputMesh;
+
+    /// The animated plugs of any blendshape nodes involved in mesh deformation.
+    MPlugArray _animBlendShapeWeightPlugs;
+
+    /// The previous sample for the mesh extents. Cached between iterations.
+    VtVec3fArray _prevMeshExtentsSample;
+
+    UsdSkelAnimation _skelAnim;
 
     /// Set of color sets that should be excluded.
     /// Intermediate processes may alter this set prior to writeMeshAttrs().

--- a/lib/usd/translators/meshWriter.h
+++ b/lib/usd/translators/meshWriter.h
@@ -32,9 +32,12 @@
 #include <pxr/usd/usdGeom/gprim.h>
 #include <pxr/usd/usdGeom/mesh.h>
 #include <pxr/usd/usdGeom/primvar.h>
+#include <pxr/usd/usdSkel/animation.h>
 
+#include <maya/MBoundingBox.h>
 #include <maya/MFnDependencyNode.h>
 #include <maya/MFnMesh.h>
+#include <maya/MPlugArray.h>
 #include <maya/MString.h>
 
 #include <set>
@@ -70,6 +73,16 @@ private:
 
     /// Input mesh before any skeletal deformations, cached between iterations.
     MObject _skelInputMesh;
+
+    // The animated plugs of any blendshape nodes involved in mesh deformation.
+    MPlugArray _animBlendShapeWeightPlugs;
+
+    VtVec3fArray _prevMeshExtentsSample;
+
+    UsdSkelAnimation _skelAnim;
+    MObject          writeBlendShapeData(UsdGeomMesh& primSchema);
+    bool             writeBlendShapeAnimation(const UsdTimeCode& usdTime);
+    bool writeAnimatedMeshExtents(const MObject& deformedMesh, const UsdTimeCode& usdTime);
 
     /// Set of color sets that should be excluded.
     /// Intermediate processes may alter this set prior to writeMeshAttrs().

--- a/lib/usd/translators/meshWriter_BlendShapes.cpp
+++ b/lib/usd/translators/meshWriter_BlendShapes.cpp
@@ -62,7 +62,6 @@ constexpr char kMayaAttrNameBlendShapeInGeomTgt[] = "inputGeomTarget";
 constexpr char kMayaAttrNameBlendShapeInCompsTgt[] = "inputComponentsTarget";
 constexpr char kMayaAttrNameBlendShapeInPtsTgt[] = "inputPointsTarget";
 
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 /// The information about a single blendshape target.
@@ -344,7 +343,8 @@ MStatus mayaGetBlendShapeInfosForMesh(
         // The logical index of the weight plug should match that of the
         // inputTargetGroup that is being driven by said weight. (Confirmed by @williamkrick from
         // ADSK).
-        MPlug plgInTgtGrps = UsdMayaUtil::FindChildPlugWithName(plgInTgt, kMayaAttrNameBlendShapeInTgtGrp);
+        MPlug plgInTgtGrps
+            = UsdMayaUtil::FindChildPlugWithName(plgInTgt, kMayaAttrNameBlendShapeInTgtGrp);
         TF_VERIFY(!plgInTgtGrps.isNull());
 
         // NOTE: (yliangsiew) Problem: looks like there's a maya bug where you have to twiddle the
@@ -379,14 +379,14 @@ MStatus mayaGetBlendShapeInfosForMesh(
             for (unsigned int k = 0; k < weightInfo.targetItemIndices.length(); ++k) {
                 MPlug plgInTgtItem
                     = plgInTgtItems.elementByLogicalIndex(weightInfo.targetItemIndices[k]);
-                MPlug plgInGeomTgt
-                    = UsdMayaUtil::FindChildPlugWithName(plgInTgtItem, kMayaAttrNameBlendShapeInGeomTgt);
+                MPlug plgInGeomTgt = UsdMayaUtil::FindChildPlugWithName(
+                    plgInTgtItem, kMayaAttrNameBlendShapeInGeomTgt);
                 TF_VERIFY(!plgInGeomTgt.isNull());
 
                 // NOTE: (yliangsiew) Get the indices first so that we know which
                 // components to calculate the offsets for.
-                MPlug plgInComponentsTgt
-                    = UsdMayaUtil::FindChildPlugWithName(plgInTgtItem, kMayaAttrNameBlendShapeInCompsTgt);
+                MPlug plgInComponentsTgt = UsdMayaUtil::FindChildPlugWithName(
+                    plgInTgtItem, kMayaAttrNameBlendShapeInCompsTgt);
                 TF_VERIFY(!plgInComponentsTgt.isNull());
 
                 MayaBlendShapeTargetDatum meshTargetDatum = {};
@@ -433,8 +433,8 @@ MStatus mayaGetBlendShapeInfosForMesh(
                     // case we need to compute the deltas manually for the points.
                     meshTargetDatum.normalOffsets.resize(
                         numComponentIndices); // NOTE: (yliangsiew) Zeroed out normal offsets.
-                    MPlug plgInPtsTgt
-                        = UsdMayaUtil::FindChildPlugWithName(plgInTgtItem, kMayaAttrNameBlendShapeInPtsTgt);
+                    MPlug plgInPtsTgt = UsdMayaUtil::FindChildPlugWithName(
+                        plgInTgtItem, kMayaAttrNameBlendShapeInPtsTgt);
                     TF_VERIFY(!plgInPtsTgt.isNull());
                     MObject inPtsTgtData = plgInPtsTgt.asMObject(&stat);
                     CHECK_MSTATUS_AND_RETURN_IT(stat);
@@ -833,8 +833,7 @@ MObject PxrUsdTranslators_MeshWriter::writeBlendShapeData(UsdGeomMesh& primSchem
                             TF_VERIFY(blendShapeNode.hasFn(MFn::kBlendShape));
                             MFnDependencyNode fnNode(blendShapeNode, &stat);
                             CHECK_MSTATUS_AND_RETURN(stat, MObject::kNullObj);
-                            MPlug weightsPlug
-                                = fnNode.findPlug(kMayaAttrNameWeight, false, &stat);
+                            MPlug weightsPlug = fnNode.findPlug(kMayaAttrNameWeight, false, &stat);
                             CHECK_MSTATUS_AND_RETURN(stat, MObject::kNullObj);
                             TF_VERIFY(weightsPlug.isArray());
                             MPlug weightPlug = weightsPlug.elementByLogicalIndex(weightIndex);

--- a/lib/usd/translators/meshWriter_BlendShapes.cpp
+++ b/lib/usd/translators/meshWriter_BlendShapes.cpp
@@ -60,7 +60,7 @@ struct MayaBlendShapeWeightDatum
     MObjectArray targetMeshes; // The target shape(s) to hit. (i.e. multiple shapes would be using
                                // Maya's "in-betweens" feature.)
     MIntArray
-        inputTargetGroupIndices; // The input group indices at which each target is connected under.
+              inputTargetGroupIndices; // The input group indices at which each target is connected under.
     MIntArray inputTargetIndices; // The input indices at which each target is connected under.
     MIntArray targetItemIndices;  // The Maya blendshape weight indices for the resulting deformed
                                   // mesh shape.

--- a/lib/usd/translators/meshWriter_BlendShapes.cpp
+++ b/lib/usd/translators/meshWriter_BlendShapes.cpp
@@ -1,0 +1,931 @@
+//
+// Copyright 2020 Apple
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "jointWriter.h"
+#include "meshWriter.h"
+
+#include <mayaUsd/fileio/primWriter.h>
+#include <mayaUsd/fileio/translators/translatorUtil.h>
+#include <mayaUsd/fileio/utils/meshWriteUtils.h>
+#include <mayaUsd/fileio/utils/writeUtil.h>
+
+#include <pxr/base/tf/diagnostic.h>
+#include <pxr/base/tf/stringUtils.h>
+#include <pxr/base/vt/types.h>
+#include <pxr/usd/sdf/path.h>
+#include <pxr/usd/usdGeom/pointBased.h>
+#include <pxr/usd/usdSkel/bindingAPI.h>
+#include <pxr/usd/usdSkel/blendShape.h>
+
+#include <maya/MApiNamespace.h>
+#include <maya/MFloatArray.h>
+#include <maya/MFloatPointArray.h>
+#include <maya/MFnAttribute.h>
+#include <maya/MFnBlendShapeDeformer.h>
+#include <maya/MFnComponentListData.h>
+#include <maya/MFnGeometryFilter.h>
+#include <maya/MFnPointArrayData.h>
+#include <maya/MFnSingleIndexedComponent.h>
+#include <maya/MGlobal.h>
+#include <maya/MItDependencyGraph.h>
+#include <maya/MObject.h>
+#include <maya/MPointArray.h>
+#include <maya/MStatus.h>
+
+#include <algorithm>
+#include <complex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#define MAYA_BLENDSHAPE_EVAL_HOTFIX 1
+
+#define MAYA_ATTR_NAME_WEIGHT "weight"
+
+struct MayaBlendShapeWeightDatum
+{
+    MObjectArray targetMeshes; // The target shape(s) to hit. (i.e. multiple shapes would be using
+                               // Maya's "in-betweens" feature.)
+    MIntArray
+        inputTargetGroupIndices; // The input group indices at which each target is connected under.
+    MIntArray inputTargetIndices; // The input indices at which each target is connected under.
+    MIntArray targetItemIndices;  // The Maya blendshape weight indices for the resulting deformed
+                                  // mesh shape.
+    unsigned int weightIndex; // The logical index of the weight attribute on the blendshape node.
+};
+
+struct MayaBlendShapeDatum
+{
+    MObject deformedMesh;       // The resulting deformed mesh shape (i.e. deformation + weight +
+                                // envelope) Maya calls this a base object.
+    MObject baseMesh;           // The original base mesh shape (i.e. no deformation)
+    MObject blendShapeDeformer; // The blendshape deformer node itself.
+    std::vector<MayaBlendShapeWeightDatum> weightDatas;
+    unsigned int                           numWeights;
+    unsigned int outputGeomIndex; // The logical index at which the deformed mesh is ultimately
+                                  // connected downstream from the blendshape deformer.
+};
+
+float mayaGetBlendShapeTargetWeightFromIndex(const unsigned int index)
+{
+    float targetWeight = (static_cast<float>(index) - 5000.0f) * 0.001f;
+    return targetWeight;
+}
+
+/**
+ * Gets information about available blend shapes for a given deformed mesh (i.e. final result)
+ *
+ * @param mesh        The deformed mesh to find the blendshape info(s) for.
+ * @param outInfos    Storage for the result.
+ *
+ * @return            A status code.
+ */
+MStatus mayaGetBlendShapeInfosForMesh(
+    const MObject&                    deformedMesh,
+    std::vector<MayaBlendShapeDatum>& outInfos)
+{
+    // TODO: (yliangsiew) Eh, find a way to avoid incremental allocations like these and just
+    // allocate upfront. But hard to do with the iterative search functions of the DG...
+    MStatus stat;
+
+    // NOTE: (yliangsiew) If there's a skinCluster, find that first since that
+    // will be the intermediate to the blendShape node. If not, just search for any
+    // blendshape deformers upstream of the mesh.
+    MObject      searchObject;
+    MObjectArray skinClusters;
+    stat = mayaGetSkinClustersUpstreamOfMesh(deformedMesh, skinClusters);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+    unsigned int numSkinClusters = skinClusters.length();
+    switch (numSkinClusters) {
+    case 0: searchObject = MObject(deformedMesh); break;
+    case 1: searchObject = MObject(skinClusters[0]); break;
+    default:
+        MGlobal::displayWarning("More than one skinCluster was found; only the first one will be "
+                                "considered during the search!");
+        searchObject = MObject(skinClusters[0]);
+        break;
+    }
+
+    // TODO: (yliangsiew) Problem: if there are _intermediate deformers between blendshapes,
+    // then oh-no: what do we do? Like blendshape1 -> wrap -> blendshape2. We can't possibliy
+    // export that into current USD file format and expect predictable behaviour.
+    // Houston, we have a problem...
+    MFnGeometryFilter     fnGeoFilter;
+    MFnBlendShapeDeformer fnBlendShape;
+    MItDependencyGraph    itDg(
+        searchObject,
+        MFn::kBlendShape,
+        MItDependencyGraph::kUpstream,
+        MItDependencyGraph::kDepthFirst,
+        MItDependencyGraph::kPlugLevel,
+        &stat);
+    MFnDependencyNode fnNode;
+    for (; !itDg.isDone(); itDg.next()) {
+        MObject curBlendShape = itDg.currentItem();
+        assert(curBlendShape.hasFn(MFn::kBlendShape));
+
+        MPlug outputGeomPlug = itDg.thisPlug();
+        assert(outputGeomPlug.isElement() == true);
+        unsigned int outputGeomPlugIdx = outputGeomPlug.logicalIndex();
+
+        // NOTE: (yliangsiew) Because we can have multiple output
+        // deformed meshes from a single blendshape deformer, we have
+        // to walk back up the graph using the connected index to find
+        // out what the _actual_ base mesh was.
+        MayaBlendShapeDatum info = {};
+        info.blendShapeDeformer = curBlendShape;
+        info.outputGeomIndex = outputGeomPlugIdx;
+        fnGeoFilter.setObject(curBlendShape);
+        MObject inputGeo = fnGeoFilter.inputShapeAtIndex(outputGeomPlugIdx, &stat);
+        CHECK_MSTATUS_AND_RETURN_IT(stat);
+        info.baseMesh = inputGeo;
+        info.deformedMesh = deformedMesh;
+
+        fnBlendShape.setObject(curBlendShape);
+        info.numWeights = fnBlendShape.numWeights();
+        MIntArray weightIndices;
+        stat = fnBlendShape.weightIndexList(weightIndices);
+        CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+        for (unsigned int i = 0; i < weightIndices.length(); ++i) {
+            MayaBlendShapeWeightDatum weightInfo = {};
+            weightInfo.weightIndex = weightIndices[i];
+            stat = fnBlendShape.getTargets(
+                deformedMesh, weightInfo.weightIndex, weightInfo.targetMeshes);
+            CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+            for (unsigned int j = 0; j < weightInfo.targetMeshes.length(); ++j) {
+                MObject targetMesh = weightInfo.targetMeshes[j];
+                stat = fnNode.setObject(targetMesh);
+                CHECK_MSTATUS_AND_RETURN_IT(stat);
+                MPlug plgWorldMeshes = fnNode.findPlug("worldMesh", false, &stat);
+                CHECK_MSTATUS_AND_RETURN_IT(stat);
+                unsigned int numWorldMeshesConnected = plgWorldMeshes.numElements();
+                if (numWorldMeshesConnected != 1) {
+                    return MStatus::kFailure;
+                }
+                MPlug plgWorldMesh = plgWorldMeshes.elementByPhysicalIndex(0, &stat);
+                CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+                if (!plgWorldMesh.isSource()) {
+                    return MStatus::kFailure;
+                }
+                MPlugArray destPlugs;
+                plgWorldMesh.destinations(destPlugs);
+                for (unsigned int k = 0; k < destPlugs.length(); ++k) {
+                    MPlug   destPlug = destPlugs[k];
+                    MObject blendShape = destPlug.node();
+                    MPlug   inputTargetGroupPlug;
+                    MPlug   inputTargetPlug;
+                    if (blendShape == curBlendShape) {
+                        MPlug inputTargetItemPlug = destPlug.parent();
+                        MPlug inputTargetItemsPlug = inputTargetItemPlug.array();
+                        inputTargetGroupPlug = inputTargetItemsPlug.parent();
+                        weightInfo.inputTargetGroupIndices.append(
+                            inputTargetGroupPlug.logicalIndex());
+
+                        MPlug inputTargetGroupsPlug = inputTargetGroupPlug.array();
+                        inputTargetPlug = inputTargetGroupsPlug.parent();
+                        weightInfo.inputTargetIndices.append(inputTargetPlug.logicalIndex());
+                    }
+                }
+            }
+
+            // NOTE: (yliangsiew) If the target mesh has "in-between" weights, in
+            // Maya they are stored as an array of sparse ints, where the formula is:
+            // index = fullWeight * 1000 + 5000.
+            // Thus fullWeight values of 0.5, 1.0 and 2.0, they will be connected to
+            // inputTargetItem array indices 5500, 6000 and 7000, respectively.
+            // Refer to the docs for MFnBlendShape::targetItemIndexList for more info.
+            stat = fnBlendShape.targetItemIndexList(
+                weightInfo.weightIndex, deformedMesh, weightInfo.targetItemIndices);
+            CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+            info.weightDatas.push_back(weightInfo);
+        }
+        outInfos.push_back(info);
+    }
+    return stat;
+}
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+VtIntArray getUnionOfVtIntArrays(const VtIntArray* const arrays, const size_t count)
+{
+    std::unordered_map<int, int> visitedMap = {};
+    for (size_t i = 0; i < count; ++i) {
+        const VtIntArray array = arrays[i];
+        for (size_t j = 0; j < array.size(); ++j) {
+            ++(visitedMap[array[j]]);
+        }
+    }
+
+    VtIntArray result;
+    for (auto it = visitedMap.begin(); it != visitedMap.end(); ++it) {
+        if (it->second != 0) {
+            result.push_back(it->first);
+        }
+    }
+
+    return result;
+}
+
+MStatus findNormalOffsetsBetweenMeshes(
+    const MObject&   target,
+    const MObject&   base,
+    const MIntArray& indices,
+    VtVec3fArray&    offsets)
+{
+    assert(target.hasFn(MFn::kMesh));
+    assert(base.hasFn(MFn::kMesh));
+
+    MStatus stat;
+    MFnMesh fnMesh(target, &stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+    unsigned int numNormalsTarget = fnMesh.numNormals(&stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+    const float* targetNormals = fnMesh.getRawNormals(&stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+    const GfVec3f* pVtTargetNormals = reinterpret_cast<const GfVec3f*>(targetNormals);
+    VtVec3fArray   vtTargetNormals(pVtTargetNormals, pVtTargetNormals + numNormalsTarget);
+
+    fnMesh.setObject(base);
+    unsigned int numNormalsBase = fnMesh.numNormals(&stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+    if (numNormalsTarget != numNormalsBase) {
+        return MStatus::kFailure;
+    }
+
+    const float* baseNormals = fnMesh.getRawNormals(&stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+    const GfVec3f* pVtBaseNormals = reinterpret_cast<const GfVec3f*>(baseNormals);
+    VtVec3fArray   vtBaseNormals(pVtBaseNormals, pVtBaseNormals + numNormalsBase);
+
+    unsigned int numIndices = indices.length();
+    offsets.resize(numIndices);
+    for (unsigned int i = 0; i < numIndices; ++i) {
+        int componentIdx = indices[i];
+        offsets[i] = vtTargetNormals[componentIdx] - vtBaseNormals[componentIdx];
+    }
+
+    return stat;
+}
+
+/**
+ * Reads data for a target from a blendshape node.
+ *
+ * @param blendShapeNode        The blendshape deformer.
+ * @param inputTargetIndex      The input target sparse index.
+ * @param targetGroupIndex      The input target group sparse index.
+ * @param targetWeightIndex     The input target item sparse index that also acts as the "weight" of
+ * the target.
+ * @param outputGeomIndex       The output geometry sparse index.
+ * @param targetOffsetIndices   Storage for the indices of the components being affected.
+ * @param targetOffsets         Storage for the vertex offsets of the components being affected.
+ * @param targetNormalOffsets   Storage for the normal offsets of the components being affected.
+ *
+ * @return                      A status code.
+ */
+MStatus readBlendShapeTargetData(
+    const MObject& blendShapeNode,
+    const int      inputTargetIndex,
+    const int      targetGroupIndex,
+    const int      targetWeightIndex,
+    const int      outputGeomIndex,
+    VtIntArray&    targetOffsetIndices,
+    VtVec3fArray&  targetOffsets,
+    VtVec3fArray&  targetNormalOffsets)
+{
+    MStatus stat;
+    assert(blendShapeNode.hasFn(MFn::kBlendShape));
+    MFnDependencyNode fnNode(blendShapeNode, &stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+    MPlug plgInputTargets = fnNode.findPlug("inputTarget", false, &stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+    assert(plgInputTargets.isArray());
+    MPlug plgInputTarget = plgInputTargets.elementByPhysicalIndex(inputTargetIndex, &stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+    MPlug plgInputTargetGrps = mayaFindChildPlugWithName(plgInputTarget, "inputTargetGroup");
+    assert(!plgInputTargetGrps.isNull());
+    assert(plgInputTargetGrps.isArray());
+
+    unsigned int numInputTargetGrps = plgInputTargetGrps.numElements();
+    assert(static_cast<int>(numInputTargetGrps) > targetGroupIndex);
+    MPlug plgInputTargetGrp = plgInputTargetGrps.elementByPhysicalIndex(targetGroupIndex, &stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+    MPlug plgInputTargetItems = mayaFindChildPlugWithName(plgInputTargetGrp, "inputTargetItem");
+    assert(!plgInputTargetItems.isNull());
+    assert(plgInputTargetItems.isArray());
+
+#if _DEBUG // TODO: (yliangsiew) Need to find a good macro that I can rely on for this.
+    MIntArray plgInputTargetItemLogicalIndices;
+    plgInputTargetItems.getExistingArrayAttributeIndices(plgInputTargetItemLogicalIndices, &stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+    assert(mayaSearchMIntArray(weightIndex, plgInputTargetItemLogicalIndices) == true);
+#endif
+
+    MPlug plgInputTargetItem = plgInputTargetItems.elementByLogicalIndex(targetWeightIndex, &stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+    MPlug plgInputComponentsTarget
+        = mayaFindChildPlugWithName(plgInputTargetItem, "inputComponentsTarget");
+    assert(!plgInputComponentsTarget.isNull());
+
+    // NOTE: (yliangsiew) Problem: looks like there's a maya bug where you have to twiddle the
+    // blendshape weight directly before these kComponentListData-type plugs get evaluated.
+#if MAYA_BLENDSHAPE_EVAL_HOTFIX
+    MPlug plgBlendShapeWeights = fnNode.findPlug("weight", false, &stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+    assert(plgBlendShapeWeights.isArray());
+
+    MFnBlendShapeDeformer fnBS(blendShapeNode, &stat);
+    MFloatArray           origWeightVals; // Storage for the original weight values.
+    MIntArray             indicesChanged;
+    MIntArray             targetItemIndexList;
+    MIntArray             bsWeightIndices;
+    stat = fnBS.weightIndexList(bsWeightIndices);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+    // NOTE: (yliangsiew) Need to force the other kComponentListData plugs to
+    // be dirtied and recalculated.
+    MObjectArray baseObjs;
+    stat = fnBS.getBaseObjects(baseObjs);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+    for (unsigned int i = 0; i < bsWeightIndices.length(); ++i) {
+        int weightIndex = bsWeightIndices[i];
+        for (unsigned int j = 0; j < baseObjs.length(); ++j) {
+            MObject baseObj = baseObjs[j];
+            targetItemIndexList.clear();
+            stat = fnBS.targetItemIndexList(weightIndex, baseObj, targetItemIndexList);
+            CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+            for (unsigned int k = 0; k < targetItemIndexList.length(); ++k) {
+                float curWeight = fnBS.weight(weightIndex, &stat);
+                CHECK_MSTATUS_AND_RETURN_IT(stat);
+                origWeightVals.append(curWeight);
+                // NOTE: (yliangsiew) For in-between shapes, need to trigger at _all_
+                // full weight values of each target so as to populate the components
+                // list for each of the targets. Yea, this is dumb.
+                float targetWeight = mayaGetBlendShapeTargetWeightFromIndex(targetItemIndexList[k]);
+                fnBS.setWeight(i, targetWeight);
+                indicesChanged.append(i);
+
+                // NOTE: (yliangsiew) We also just force an evaluation
+                // of the mesh at each time we set the blendshape
+                // weight value in the scene to force the components
+                // list to update.
+                MFnMesh fnMesh;
+                for (unsigned int i = 0; i < baseObjs.length(); ++i) {
+                    stat = fnMesh.setObject(baseObjs[i]);
+                    CHECK_MSTATUS_AND_RETURN_IT(stat);
+                    const float* meshPts = fnMesh.getRawPoints(&stat);
+                    CHECK_MSTATUS_AND_RETURN_IT(stat);
+                    (void)meshPts;
+                }
+            }
+        }
+    }
+
+    // NOTE: (yliangsiew) Restore the weight changes that we were doing above.
+    for (unsigned int i = 0; i < indicesChanged.length(); ++i) {
+        stat = fnBS.setWeight(indicesChanged[i], origWeightVals[i]);
+        CHECK_MSTATUS_AND_RETURN_IT(stat);
+    }
+#endif
+
+    MDataHandle dhInputComponentsTarget = plgInputComponentsTarget.asMDataHandle(&stat);
+
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+    MObject inputComponentsTargetIndices = dhInputComponentsTarget.data();
+    if (inputComponentsTargetIndices.isNull()
+        || !inputComponentsTargetIndices.hasFn(MFn::kComponentListData)) {
+        return MStatus::kFailure;
+    }
+    MFnComponentListData fnComponentListData(inputComponentsTargetIndices, &stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+    unsigned int numIndices = fnComponentListData.length();
+    if (numIndices == 0) {
+        return MStatus::kFailure;
+    }
+
+    targetOffsetIndices.clear();
+    MIntArray indices;
+    for (unsigned int i = 0; i < numIndices; ++i) {
+        MObject                   curComponent = fnComponentListData[i];
+        MFnSingleIndexedComponent fnSingleIndexedComponent(curComponent, &stat);
+        CHECK_MSTATUS_AND_RETURN_IT(stat);
+        stat = fnSingleIndexedComponent.getElements(indices);
+        CHECK_MSTATUS_AND_RETURN_IT(stat);
+        for (unsigned int j = 0; j < indices.length(); ++j) {
+            targetOffsetIndices.push_back(indices[j]);
+        }
+    }
+
+    MPlug plgInputPointsTarget = mayaFindChildPlugWithName(plgInputTargetItem, "inputPointsTarget");
+    MDataHandle dhInputPointsTarget = plgInputPointsTarget.asMDataHandle(&stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+    MObject inputPointsTarget = dhInputPointsTarget.data();
+    assert(inputPointsTarget.hasFn(MFn::kPointArrayData));
+
+    MFnPointArrayData fnPtArrayData(inputPointsTarget, &stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+    MPointArray  mptTargetOffsets = fnPtArrayData.array();
+    unsigned int numOffsets = mptTargetOffsets.length();
+    if (numOffsets == 0) { // NOTE: (yliangsiew) There cannot possibly be _no_ offsets in the
+                           // blendshape, since we have indices for the offsets.
+        return MStatus::kFailure;
+    }
+    targetOffsets.resize(numOffsets);
+    for (unsigned int i = 0; i < numOffsets; ++i) {
+        MPoint curPt = mptTargetOffsets[i];
+        targetOffsets[i] = GfVec3f(curPt.x, curPt.y, curPt.z);
+    }
+
+    MPlug plgTargetGeom = mayaFindChildPlugWithName(plgInputTargetItem, "inputGeomTarget");
+    if (plgTargetGeom.isNull()) {
+        return MStatus::kFailure;
+    }
+    MObject targetGeom = plgTargetGeom.asMObject();
+    assert(targetGeom.hasFn(MFn::kMesh));
+
+    MPlug plgOutputGeoms = fnNode.findPlug("outputGeometry", false, &stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+    assert(plgOutputGeoms.isArray());
+
+    MPlug plgOutputGeom = plgOutputGeoms.elementByPhysicalIndex(outputGeomIndex, &stat);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+    MObject outputGeom = plgOutputGeom.asMObject();
+    assert(outputGeom.hasFn(MFn::kMesh));
+
+    stat = findNormalOffsetsBetweenMeshes(targetGeom, outputGeom, indices, targetNormalOffsets);
+    CHECK_MSTATUS_AND_RETURN_IT(stat);
+
+    return stat;
+}
+
+void findUnionAndProcessArrays(
+    const std::vector<VtIntArray>&   indicesArrays,
+    const std::vector<VtVec3fArray>& offsetsArrays,
+    const std::vector<VtVec3fArray>& normalsArrays,
+    VtIntArray&                      unionIndices,
+    std::vector<VtVec3fArray>&       unionOffsetsArrays,
+    std::vector<VtVec3fArray>&       unionNormalsArrays)
+{
+    // NOTE: (yliangsiew) Because according to the USD blendshape schema, the pointIndices
+    // mapping applies to all in-between shapes, we need to calculate the union of the indices here:
+    std::unordered_map<int, int> visitedIndicesMap = {};
+    size_t                       numArrays = indicesArrays.size();
+    for (size_t i = 0; i < numArrays; ++i) {
+        const VtIntArray& array = indicesArrays[i];
+        for (size_t j = 0; j < array.size(); ++j) {
+            ++(visitedIndicesMap[array[j]]);
+        }
+    }
+
+    unionIndices.clear();
+    for (const auto& it : visitedIndicesMap) {
+        if (it.second != 0) {
+            unionIndices.push_back(it.first);
+        }
+    }
+
+    std::sort(unionIndices.begin(), unionIndices.end());
+
+    size_t numUnionIndices = unionIndices.size();
+    unionOffsetsArrays.clear();
+    unionOffsetsArrays.resize(offsetsArrays.size());
+    unionNormalsArrays.clear();
+    unionNormalsArrays.resize(normalsArrays.size());
+    for (size_t i = 0; i < numArrays; ++i) {
+        const VtVec3fArray& origOffsetsArray = offsetsArrays[i];
+        const size_t        numOrigOffsets = origOffsetsArray.size();
+        assert(numOrigOffsets != 0);
+        VtVec3fArray& newOffsetsArray = unionOffsetsArrays[i];
+        newOffsetsArray.assign(numUnionIndices, GfVec3f(0.0f));
+
+        const VtVec3fArray& origNormalsArray = normalsArrays[i];
+        const size_t        numOrigNormals = origNormalsArray.size();
+        assert(numOrigOffsets == numOrigNormals);
+        VtVec3fArray& newNormalsArray = unionNormalsArrays[i];
+        newNormalsArray.assign(numUnionIndices, GfVec3f(0.0f));
+
+        const VtIntArray& origIndicesArray = indicesArrays[i];
+        for (size_t j = 0, k = 0; j < numUnionIndices; ++j) {
+            int index = unionIndices[j];
+            int origIndex = origIndicesArray[k];
+            if (index != origIndex || k > numOrigOffsets - 1) {
+                GfVec3f sentinel(0.0f);
+                newOffsetsArray[j] = sentinel;
+                newNormalsArray[j] = sentinel;
+            } else {
+                newOffsetsArray[j] = origOffsetsArray[k];
+                newNormalsArray[j] = origNormalsArray[k];
+                ++k;
+            }
+        }
+    }
+
+    return;
+}
+
+// NOTE: (yliangsiew) This gets called once for each shape being exported
+// under a single transform.
+MObject PxrUsdTranslators_MeshWriter::writeBlendShapeData(UsdGeomMesh& primSchema)
+{
+    MStatus                    stat;
+    const UsdMayaJobExportArgs exportArgs = this->_GetExportArgs();
+
+    MDagPath deformedMeshDagPath = this->GetDagPath();
+    MObject  deformedMesh = deformedMeshDagPath.node();
+    assert(deformedMesh.hasFn(MFn::kMesh) == true);
+
+    MObjectArray blendShapeDeformers;
+    MIntArray    blendShapeCxnIndices;
+
+    // TODO: (yliangsiew) Figure out if this can be isolated. It's kind of hard
+    // because we want to avoid repeated walks through the DG.
+    std::vector<MayaBlendShapeDatum> blendShapeDeformerInfos;
+    stat = mayaGetBlendShapeInfosForMesh(deformedMesh, blendShapeDeformerInfos);
+    if (stat != MStatus::kSuccess) {
+        TF_WARN("Cannot find any blendshape deformers for the mesh.");
+        return MObject::kNullObj;
+    }
+
+    size_t numOfBlendShapeDeformers = blendShapeDeformerInfos.size();
+    switch (numOfBlendShapeDeformers) {
+    case 0: TF_WARN("Cannot find any blendshape deformers for the mesh."); return MObject::kNullObj;
+    case 1: break;
+    default:
+        // TODO: (yliangsiew) For multiple blend shape deformers, what do we do?
+        // Do we collapse the shapes from multiple blend targets together, or just
+        // write out only the "closest" blendshape deformer's targets? Or just write all
+        // of them and print this warning to end-users?
+        TF_WARN("Multiple blendshape deformers were found; while your shapes will still be saved, "
+                "since USDSkelBlendShape does not support a deformation stack, results may be "
+                "unpredictable on import.");
+        break;
+    }
+
+    bool exportAnim = !(exportArgs.timeSamples.empty());
+
+    SdfPathVector  usdBlendShapePaths;
+    VtTokenArray   usdBlendShapeNames;
+    const SdfPath& primSchemaPath = primSchema.GetPrim().GetPath();
+    for (size_t i = 0; i < numOfBlendShapeDeformers; ++i) {
+        MayaBlendShapeDatum blendShapeInfo = blendShapeDeformerInfos[i];
+        // NOTE: (yliangsiew) Each of the weights here we iterate over is equivalent
+        // to each individual weight that you are able to toggle on a blendshape node
+        // in the Attribute Editor within Maya.
+        for (unsigned int j = 0; j < blendShapeInfo.numWeights; ++j) {
+            MayaBlendShapeWeightDatum weightInfo = blendShapeInfo.weightDatas[j];
+            unsigned int              numTargetItemIndices = weightInfo.targetItemIndices.length();
+            switch (numTargetItemIndices) {
+            case 0:
+                TF_RUNTIME_ERROR("No target indices for the blendshape target could be found. "
+                                 "Check that the blendshape was set up correctly.");
+                return MObject::kNullObj;
+            case 1: { // NOTE: (yliangsiew) Means no inbetweens possible.
+                unsigned int numOfTargets = weightInfo.targetMeshes.length();
+                for (unsigned int k = 0; k < numOfTargets; ++k) {
+                    MObject targetMesh = weightInfo.targetMeshes[k];
+                    MString curTargetMeshNameMStr = mayaGetUniqueNameOfDAGNode(targetMesh);
+                    assert(curTargetMeshNameMStr.length() != 0);
+                    std::string curTargetMeshName
+                        = TfMakeValidIdentifier(std::string(curTargetMeshNameMStr.asChar()));
+                    SdfPath usdBlendShapePath
+                        = primSchemaPath.AppendChild(TfToken(curTargetMeshName));
+                    UsdSkelBlendShape usdBlendShape
+                        = UsdSkelBlendShape::Define(this->GetUsdStage(), usdBlendShapePath);
+                    if (!usdBlendShape) {
+                        TF_RUNTIME_ERROR(
+                            "Could not create blendshape primitive: <%s>",
+                            usdBlendShapePath.GetText());
+                        return MObject::kNullObj;
+                    }
+
+                    unsigned int inputTargetIndex = weightInfo.inputTargetIndices[k];
+                    unsigned int inputTargetGroupIndex = weightInfo.inputTargetGroupIndices[k];
+                    unsigned int targetWeightIndex = weightInfo.targetItemIndices[0];
+
+                    VtIntArray   targetIndices;
+                    VtVec3fArray targetOffsets;
+                    VtVec3fArray targetNormalOffsets;
+                    stat = readBlendShapeTargetData(
+                        blendShapeInfo.blendShapeDeformer,
+                        inputTargetIndex,
+                        inputTargetGroupIndex,
+                        targetWeightIndex,
+                        blendShapeInfo.outputGeomIndex,
+                        targetIndices,
+                        targetOffsets,
+                        targetNormalOffsets);
+                    if (stat != MStatus::kSuccess) {
+                        TF_RUNTIME_ERROR("Error occurred while attempting to read offset data for "
+                                         "the blendshape.");
+                        return MObject::kNullObj;
+                    }
+
+                    usdBlendShape.CreatePointIndicesAttr(VtValue(targetIndices));
+                    usdBlendShape.CreateOffsetsAttr(VtValue(targetOffsets));
+                    usdBlendShape.CreateNormalOffsetsAttr(VtValue(targetNormalOffsets));
+
+                    usdBlendShapePaths.emplace_back(usdBlendShapePath);
+                    usdBlendShapeNames.push_back(TfToken(curTargetMeshName));
+
+                    // NOTE: (yliangsiew) Because animation export is deferred until subsequent
+                    // calls in meshWriter.cpp, we just store the plugs to retrieve the samples from
+                    // first, until the time comes to sample them.
+                    if (exportAnim) {
+                        unsigned int weightIndex = weightInfo.weightIndex;
+                        MObject      blendShapeNode = blendShapeInfo.blendShapeDeformer;
+                        assert(blendShapeNode.hasFn(MFn::kBlendShape));
+                        MFnDependencyNode fnNode(blendShapeNode, &stat);
+                        CHECK_MSTATUS_AND_RETURN(stat, MObject::kNullObj);
+                        MPlug weightsPlug = fnNode.findPlug(MAYA_ATTR_NAME_WEIGHT, false, &stat);
+                        CHECK_MSTATUS_AND_RETURN(stat, MObject::kNullObj);
+                        assert(weightsPlug.isArray());
+                        MPlug weightPlug = weightsPlug.elementByLogicalIndex(weightIndex);
+                        this->_animBlendShapeWeightPlugs.append(weightPlug);
+                    }
+                }
+                break;
+            }
+            default: {
+                // NOTE: (yliangsiew) If there _are_ in-betweens, we just write out the additional
+                // in-between shapes and format names for them ourselves based on the weight that
+                // they're supposed to activate at.
+                unsigned int numOfTargets = weightInfo.targetMeshes.length();
+                // NOTE: (yliangsiew) Because of just how USD works; need to create
+                // the base shape first before we create the inbetween shapes.
+                // For this, we will use the name of the plug at the corresponding weight index.
+                MFnDependencyNode fnNode(blendShapeInfo.blendShapeDeformer, &stat);
+                if (stat != MStatus::kSuccess) {
+                    TF_RUNTIME_ERROR(
+                        "Error occurred while attempting to read name for the blendshape.");
+                    return MObject::kNullObj;
+                }
+                MPlug plgBlendShapeWeights = fnNode.findPlug(MAYA_ATTR_NAME_WEIGHT, false, &stat);
+                if (stat != MStatus::kSuccess) {
+                    TF_RUNTIME_ERROR(
+                        "Error occurred while attempting to read name for the blendshape.");
+                    return MObject::kNullObj;
+                }
+
+                MPlug plgBlendShapeWeight
+                    = plgBlendShapeWeights.elementByLogicalIndex(weightInfo.weightIndex);
+                MString weightTargetName = plgBlendShapeWeight.partialName(
+                    false, false, false, true, false, true, &stat);
+                if (stat != MStatus::kSuccess) {
+                    TF_RUNTIME_ERROR(
+                        "Error occurred while attempting to read name for the blendshape.");
+                    return MObject::kNullObj;
+                }
+
+                SdfPath usdBlendShapePath
+                    = primSchemaPath.AppendChild(TfToken(weightTargetName.asChar()));
+                UsdSkelBlendShape usdBlendShape
+                    = UsdSkelBlendShape::Define(this->GetUsdStage(), usdBlendShapePath);
+                if (!usdBlendShape) {
+                    TF_RUNTIME_ERROR(
+                        "Could not create blendshape primitive: <%s>", usdBlendShapePath.GetText());
+                    return MObject::kNullObj;
+                }
+
+                // NOTE: (yliangsiew) Because according to the USD blendshape schema, the
+                // pointIndices mapping applies to all in-between shapes, we need to calculate the
+                // union of the indices here:
+                std::vector<VtIntArray>   indicesArrays(numOfTargets);
+                std::vector<VtVec3fArray> targetsOffsetsArrays(numOfTargets);
+                std::vector<VtVec3fArray> targetsNormalOffsetsArrays(numOfTargets);
+
+                for (unsigned int k = 0; k < numOfTargets; ++k) {
+                    unsigned int inputTargetIndex = weightInfo.inputTargetIndices[k];
+                    unsigned int inputTargetGroupIndex = weightInfo.inputTargetGroupIndices[k];
+                    unsigned int targetWeightIndex = weightInfo.targetItemIndices[k];
+                    VtIntArray   targetIndices;
+                    VtVec3fArray targetOffsets;
+                    VtVec3fArray targetNormalOffsets;
+                    stat = readBlendShapeTargetData(
+                        blendShapeInfo.blendShapeDeformer,
+                        inputTargetIndex,
+                        inputTargetGroupIndex,
+                        targetWeightIndex,
+                        blendShapeInfo.outputGeomIndex,
+                        targetIndices,
+                        targetOffsets,
+                        targetNormalOffsets);
+                    if (stat != MStatus::kSuccess) {
+                        TF_RUNTIME_ERROR("Error occurred while attempting to read offset data for "
+                                         "the blendshape.");
+                        return MObject::kNullObj;
+                    }
+                    indicesArrays[k] = targetIndices;
+                    targetsOffsetsArrays[k] = targetOffsets;
+                    targetsNormalOffsetsArrays[k] = targetNormalOffsets;
+                }
+
+                VtIntArray                unionIndices;
+                std::vector<VtVec3fArray> processedOffsetsArrays;
+                std::vector<VtVec3fArray> processedNormalsOffsetsArrays;
+                findUnionAndProcessArrays(
+                    indicesArrays,
+                    targetsOffsetsArrays,
+                    targetsNormalOffsetsArrays,
+                    unionIndices,
+                    processedOffsetsArrays,
+                    processedNormalsOffsetsArrays);
+
+                for (unsigned int k = 0; k < numOfTargets; ++k) {
+                    MObject     targetMesh = weightInfo.targetMeshes[k];
+                    MString     curTargetMeshNameMStr = mayaGetUniqueNameOfDAGNode(targetMesh);
+                    std::string curTargetMeshName
+                        = TfMakeValidIdentifier(std::string(curTargetMeshNameMStr.asChar()));
+                    unsigned int targetWeightIndex = weightInfo.targetItemIndices[k];
+                    if (targetWeightIndex == 6000) { // NOTE: (yliangsiew) For default fullweight,
+                                                     // we don't append the weight name.
+                        usdBlendShape.CreatePointIndicesAttr(VtValue(unionIndices));
+                        usdBlendShape.CreateOffsetsAttr(VtValue(processedOffsetsArrays[k]));
+                        usdBlendShape.CreateNormalOffsetsAttr(
+                            VtValue(processedNormalsOffsetsArrays[k]));
+                        usdBlendShapePaths.emplace_back(usdBlendShapePath);
+                        usdBlendShapeNames.push_back(TfToken(curTargetMeshName));
+
+                        // NOTE: (yliangsiew) Because animation export is deferred until subsequent
+                        // calls in meshWriter.cpp, we just store the plugs to retrieve the samples
+                        // from first, until the time comes to sample them.
+                        if (exportAnim) {
+                            unsigned int weightIndex = weightInfo.weightIndex;
+                            MObject      blendShapeNode = blendShapeInfo.blendShapeDeformer;
+                            assert(blendShapeNode.hasFn(MFn::kBlendShape));
+                            MFnDependencyNode fnNode(blendShapeNode, &stat);
+                            CHECK_MSTATUS_AND_RETURN(stat, MObject::kNullObj);
+                            MPlug weightsPlug
+                                = fnNode.findPlug(MAYA_ATTR_NAME_WEIGHT, false, &stat);
+                            CHECK_MSTATUS_AND_RETURN(stat, MObject::kNullObj);
+                            assert(weightsPlug.isArray());
+                            MPlug weightPlug = weightsPlug.elementByLogicalIndex(weightIndex);
+                            this->_animBlendShapeWeightPlugs.append(weightPlug);
+                        }
+                    } else {
+                        float weightValue
+                            = mayaGetBlendShapeTargetWeightFromIndex(targetWeightIndex);
+                        int     representedWeight = static_cast<int>(weightValue * 100.0f);
+                        TfToken usdInbetweenName = TfToken(
+                            std::string(curTargetMeshName) + std::string("_")
+                            + std::to_string(representedWeight));
+                        UsdSkelInbetweenShape usdInbetween
+                            = usdBlendShape.CreateInbetween(usdInbetweenName);
+                        if (!usdInbetween.IsDefined()) {
+                            TF_RUNTIME_ERROR("Error occurred while attempting to define the "
+                                             "in-between blendshape.");
+                            return MObject::kNullObj;
+                        }
+                        usdInbetween.SetWeight(weightValue);
+                        usdInbetween.SetOffsets(processedOffsetsArrays[k]);
+                        usdInbetween.SetNormalOffsets(processedNormalsOffsetsArrays[k]);
+                    }
+                }
+            } break;
+            }
+        }
+    }
+
+    const UsdSkelBindingAPI bindingAPI = UsdSkelBindingAPI::Apply(primSchema.GetPrim());
+    UsdAttribute            blendShapesAttr = bindingAPI.CreateBlendShapesAttr();
+    blendShapesAttr.Set(VtValue(usdBlendShapeNames));
+
+    UsdRelationship targetsRel = bindingAPI.CreateBlendShapeTargetsRel();
+    targetsRel.SetTargets(usdBlendShapePaths);
+
+    SdfPath       blendShapeAnimPath;
+    SdfPathVector skelTargets;
+    bindingAPI.GetSkeletonRel().GetTargets(&skelTargets);
+    size_t numSkelTargets = skelTargets.size();
+
+    if (numSkelTargets > 0) {
+        if (exportAnim) {
+            blendShapeAnimPath = skelTargets[0].AppendPath(SdfPath("Animation"));
+            UsdRelationship animSourceRel = bindingAPI.GetAnimationSourceRel();
+            if (!animSourceRel) {
+                animSourceRel = bindingAPI.CreateAnimationSourceRel();
+            }
+            animSourceRel.SetTargets({ blendShapeAnimPath });
+        }
+    } else {
+        // NOTE: (yliangsiew) Do blendshapes _require_ that an empty skeleton be created?
+        // Looks like the answer is "yes".
+        SdfPath         skelPath;
+        UsdSkelSkeleton skel
+            = UsdSkelSkeleton::Get(this->GetUsdStage(), primSchemaPath.GetParentPath());
+        if (skel) {
+            skelPath = skel.GetPath();
+        } else {
+            skelPath = primSchemaPath.GetParentPath().AppendPath(
+                SdfPath(primSchema.GetPrim().GetName().GetString() + "_Skeleton"));
+            skel = UsdSkelSkeleton::Define(this->GetUsdStage(), skelPath);
+        }
+        if (!skel) {
+            TF_RUNTIME_ERROR("Could not create skeleton primitive: <%s>", skelPath.GetText());
+            return MObject::kNullObj;
+        }
+
+        _writeJobCtx.MarkSkelBindings(skelPath, skelPath, exportArgs.exportSkels);
+        UsdRelationship skelRel = bindingAPI.CreateSkeletonRel();
+        skelRel.SetTargets({ skelPath });
+
+        const UsdSkelBindingAPI skelBindingAPI
+            = UsdMayaTranslatorUtil::GetAPISchemaForAuthoring<UsdSkelBindingAPI>(skel.GetPrim());
+        if (exportAnim) {
+            blendShapeAnimPath = skelPath.AppendPath(SdfPath("Animation"));
+            UsdRelationship animSourceRel = skelBindingAPI.GetAnimationSourceRel();
+            if (!animSourceRel) {
+                animSourceRel = skelBindingAPI.CreateAnimationSourceRel();
+            }
+            animSourceRel.SetTargets({ blendShapeAnimPath });
+        }
+    }
+
+    if (!exportAnim) {
+        return deformedMesh;
+    }
+
+    _skelAnim = UsdSkelAnimation::Get(this->GetUsdStage(), blendShapeAnimPath);
+    if (!_skelAnim) {
+        _skelAnim = UsdSkelAnimation::Define(this->GetUsdStage(), blendShapeAnimPath);
+        if (!_skelAnim) {
+            TF_RUNTIME_ERROR(
+                "Could not create animation primitive: <%s>", blendShapeAnimPath.GetText());
+            return MObject::kNullObj;
+        }
+    }
+
+    VtTokenArray existingBlendShapeNames;
+    UsdAttribute skelAnimBlendShapesAttr = _skelAnim.GetBlendShapesAttr();
+    if (skelAnimBlendShapesAttr.HasAuthoredValue()) {
+        skelAnimBlendShapesAttr.Get(&existingBlendShapeNames);
+    } else {
+        skelAnimBlendShapesAttr = _skelAnim.CreateBlendShapesAttr();
+    }
+
+    skelAnimBlendShapesAttr.Set(usdBlendShapeNames);
+
+    return deformedMesh;
+}
+
+bool PxrUsdTranslators_MeshWriter::writeBlendShapeAnimation(const UsdTimeCode& usdTime)
+{
+    VtTokenArray existingBlendShapeNames;
+    UsdAttribute blendShapesAttr = this->_skelAnim.GetBlendShapesAttr();
+    if (!blendShapesAttr) {
+        TF_RUNTIME_ERROR("No blendshapes attribute could be found.");
+        return false;
+    }
+    blendShapesAttr.Get(&existingBlendShapeNames);
+    size_t       numExistingBlendShapes = existingBlendShapeNames.size();
+    VtFloatArray usdWeights(numExistingBlendShapes);
+    UsdAttribute blendShapeWeightsAttr = this->_skelAnim.GetBlendShapeWeightsAttr();
+    if (blendShapeWeightsAttr.HasAuthoredValue()) {
+        blendShapeWeightsAttr.Get(&usdWeights, usdTime);
+    } else {
+        blendShapeWeightsAttr = this->_skelAnim.CreateBlendShapeWeightsAttr();
+    }
+
+    unsigned int numWeightPlugs = this->_animBlendShapeWeightPlugs.length();
+    if (numExistingBlendShapes != numWeightPlugs) {
+        return false;
+    }
+
+    for (size_t i = 0; i < usdWeights.size(); ++i) {
+        MPlug weightPlug = this->_animBlendShapeWeightPlugs[i];
+        usdWeights[i] = weightPlug.asFloat();
+    }
+
+    bool result = blendShapeWeightsAttr.Set(VtValue(usdWeights), usdTime);
+
+    return result;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/usd/translators/meshWriter_BlendShapes.cpp
+++ b/lib/usd/translators/meshWriter_BlendShapes.cpp
@@ -173,11 +173,11 @@ MStatus mayaFindPtAndNormalOffsetsBetweenMeshes(
         const int     componentIdx = indices[i];
         const GfVec3f ptA = pVtPtsA[componentIdx];
         const GfVec3f ptB = pVtPtsB[componentIdx];
-        ptOffsets[i] = ptA - ptB;
+        ptOffsets[i] = ptB - ptA;
 
         const GfVec3f nrmA = pVtNrmsA[componentIdx];
         const GfVec3f nrmB = pVtNrmsB[componentIdx];
-        nrmOffsets[i] = nrmA - nrmB;
+        nrmOffsets[i] = nrmB - nrmA;
     }
 
     return status;

--- a/lib/usd/translators/meshWriter_BlendShapes.cpp
+++ b/lib/usd/translators/meshWriter_BlendShapes.cpp
@@ -325,9 +325,7 @@ MStatus mayaGetBlendShapeInfosForMesh(
         // NOTE: (yliangsiew) So after we call targetItemIndexList which associates a given weight
         // index and a base object, we can infer that the inputTarget group logical index matches
         // that of the outputGeometry logical index (i.e. the base object).
-        // TODO: (yliangsiew) BUG: each weightdatum is reading _all_ the targets instead of just the
-        // one it is associated with.
-        // TODO: (yliangsiew) The logical index of the weight plug should match that of the
+        // The logical index of the weight plug should match that of the
         // inputTargetGroup that is being driven by said weight. (Confirmed by @williamkrick from ADSK).
         MPlug plgInTgtGrps = UsdMayaUtil::FindChildPlugWithName(plgInTgt, "inputTargetGroup");
         assert(!plgInTgtGrps.isNull());
@@ -720,7 +718,7 @@ MObject PxrUsdTranslators_MeshWriter::writeBlendShapeData(UsdGeomMesh& primSchem
                 for (size_t k = 0; k < numOfTargets; ++k) {
                     MayaBlendShapeTargetDatum targetDatum = weightInfo.targets[k];
                     MObject targetMesh = targetDatum.targetMesh;
-                    // TODO: (yliangsiew) If mesh is already baked in, format name differently.
+                    // NOTE: (yliangsiew) If mesh is already baked in, format name differently.
                     MString curTargetNameMStr;
                     if (!targetMesh.isNull()) {
                         // NOTE: (yliangsiew) Because UsdSkelBlendShape does not

--- a/lib/usd/translators/meshWriter_BlendShapes.cpp
+++ b/lib/usd/translators/meshWriter_BlendShapes.cpp
@@ -528,8 +528,10 @@ void findUnionAndProcessArrays(
         newOffsetsArray.assign(numUnionIndices, GfVec3f(0.0f));
 
         const VtVec3fArray& origNormalsArray = normalsArrays[i];
+#ifdef _DEBUG
         const size_t        numOrigNormals = origNormalsArray.size();
         assert(numOrigOffsets == numOrigNormals);
+#endif
         VtVec3fArray& newNormalsArray = unionNormalsArrays[i];
         newNormalsArray.assign(numUnionIndices, GfVec3f(0.0f));
 

--- a/lib/usd/translators/meshWriter_BlendShapes.cpp
+++ b/lib/usd/translators/meshWriter_BlendShapes.cpp
@@ -30,8 +30,8 @@
 #include <pxr/usd/usdSkel/bindingAPI.h>
 #include <pxr/usd/usdSkel/blendShape.h>
 
-#include <maya/MApiNamespace.h>
 #include <maya/MAnimUtil.h>
+#include <maya/MApiNamespace.h>
 #include <maya/MFloatArray.h>
 #include <maya/MFloatPointArray.h>
 #include <maya/MFnAttribute.h>
@@ -617,7 +617,9 @@ MObject PxrUsdTranslators_MeshWriter::writeBlendShapeData(UsdGeomMesh& primSchem
                     // `offsets` attributes are defined as uniforms), we cannot
                     // fully support it in the exporter either.
                     if (MAnimUtil::isAnimated(targetMesh)) {
-                        TF_RUNTIME_ERROR("Animated blendshapes are not supported in USD. Please bake down deformer history and remove existing connections first before attempting to export.");
+                        TF_RUNTIME_ERROR("Animated blendshapes are not supported in USD. Please "
+                                         "bake down deformer history and remove existing "
+                                         "connections first before attempting to export.");
                         return MObject::kNullObj;
                     }
 
@@ -693,10 +695,12 @@ MObject PxrUsdTranslators_MeshWriter::writeBlendShapeData(UsdGeomMesh& primSchem
                 // animated targets (the `normalOffsets` and `offsets`
                 // attributes are defined as uniforms), we cannot fully support
                 // it in the exporter either.
-                for (unsigned int k=0; k < numOfTargets; ++k) {
+                for (unsigned int k = 0; k < numOfTargets; ++k) {
                     MObject targetMesh = weightInfo.targetMeshes[k];
                     if (MAnimUtil::isAnimated(targetMesh)) {
-                        TF_RUNTIME_ERROR("Animated blendshapes are not supported in USD. Please bake down deformer history and remove existing connections first before attempting to export.");
+                        TF_RUNTIME_ERROR("Animated blendshapes are not supported in USD. Please "
+                                         "bake down deformer history and remove existing "
+                                         "connections first before attempting to export.");
                         return MObject::kNullObj;
                     }
                 }

--- a/lib/usd/translators/meshWriter_BlendShapes.cpp
+++ b/lib/usd/translators/meshWriter_BlendShapes.cpp
@@ -278,8 +278,8 @@ MStatus mayaGetBlendShapeInfosForMesh(
     case 0: searchObject = MObject(deformedMesh); break;
     case 1: searchObject = MObject(skinClusters[0]); break;
     default:
-        MGlobal::displayWarning("More than one skinCluster was found; only the first one will be "
-                                "considered during the search!");
+        TF_WARN("More than one skinCluster was found; only the first one will be "
+                "considered during the search!");
         searchObject = MObject(skinClusters[0]);
         break;
     }

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -208,6 +208,9 @@ global proc int mayaUsdTranslatorExport (string $parent,
         string $parentScopAnn = "Name of the USD scope that is the parent of the exported data.";
         string $colorSetsAnn = "Exports Maya Color Sets as USD primvars.";
         string $uvSetsAnn = "Exports Maya UV Sets as USD primvars.";
+        string $skelsAnn = "Exports Maya joints as part of a USD skeleton.";
+        string $skinClustersAnn = "Exports Maya skin clusters as part of a USD skeleton.";
+        string $blendShapesAnn = "Exports Maya Blend Shapes as USD blendshapes. Requires skeletons to be exported as well.";
         string $materialsAnn = "Controls whether shading data is exported from the Maya scene and how it is created in USD.";
         string $animDataAnn = "Exports Maya animation data as USD time samples.";
         string $frameStepAnn = "Specifies the increment between USD time sample frames during animation export";
@@ -235,7 +238,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
 
             separator -style "none";
 
-            textFieldGrp -l "Create USD Parent Scope:" -placeholderText "USD Prim Name" 
+            textFieldGrp -l "Create USD Parent Scope:" -placeholderText "USD Prim Name"
                 -annotation $parentScopAnn parentScopeField;
 
             separator -style "none";
@@ -253,6 +256,18 @@ global proc int mayaUsdTranslatorExport (string $parent,
 
             checkBoxGrp -l "UV Sets:" -annotation $uvSetsAnn exportUVsCheckBox;
 
+            optionMenuGrp -l "Skeletons:" -annotation $skelsAnn skelsPopup;
+                menuItem -l "None" -ann "none";
+                menuItem -l "All (Automatically Create SkelRoots)" -ann "auto";
+                menuItem -l "Only under SkelRoots" -ann "explicit";
+
+            optionMenuGrp -l "Skin Clusters" -annotation $skinClustersAnn skinClustersPopup;
+                menuItem -l "None" -ann "none";
+                menuItem -l "All (Automatically Create SkelRoots)" -ann "auto";
+                menuItem -l "Only Under SkelRoots" -ann "explicit";
+
+            checkBoxGrp -l "Blend Shapes:" -annotation $blendShapesAnn exportBlendShapesCheckBox;
+
             string $exporters[] = `mayaUSDListShadingModes -export`;
             optionMenuGrp -l "Materials:" -ann $materialsAnn shadingModePopup;
             for ($exporter in $exporters) {
@@ -266,11 +281,11 @@ global proc int mayaUsdTranslatorExport (string $parent,
 
             separator -style "none";
         setParent ..;
-        
+
         frameLayout -label "Animation" -collapsable true -collapse false;
             separator -style "none";
 
-            checkBoxGrp -l "Animation Data: " -cc ("mayaUsdTranslatorExport_AnimationCB") 
+            checkBoxGrp -l "Animation Data: " -cc ("mayaUsdTranslatorExport_AnimationCB")
                 -annotation $animDataAnn animationCheckBox;
 
             columnLayout -width 100 animOptsCol;
@@ -283,7 +298,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
 
                 textFieldGrp -l "Frame Sample:" -cw 1 175 -annotation $frameSamplesAnn frameSampleField;
 
-                checkBoxGrp -l "Euler Filter:" -cw 1 175 
+                checkBoxGrp -l "Euler Filter:" -cw 1 175
                     -annotation $eulerFilterAnn eulerFilterCheckBox;
             setParent ..;
 
@@ -299,7 +314,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
                 menuItem -l "Flatten";
                 menuItem -l "Convert to USD Instanceable References";
 
-            checkBoxGrp -l "Merge Transform and\nShape Nodes:" 
+            checkBoxGrp -l "Merge Transform and\nShape Nodes:"
                 -annotation $mergeShapesAnn mergeTransformAndShapeCheckBox;
 
             checkBoxGrp -l "Include Namespaces:" -annotation $namespacesAnn includeNamespacesCheckBox;
@@ -317,12 +332,18 @@ global proc int mayaUsdTranslatorExport (string $parent,
                 tokenize($optionList[$index], "=", $optionBreakDown);
                 if ($optionBreakDown[0] == "exportUVs") {
                     mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportUVsCheckBox");
+                } else if ($optionBreakDown[0] == "exportSkels") {
+                    mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "skelsPopup");
+                } else if ($optionBreakDown[0] == "exportSkin") {
+                    mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "skinClustersPopup");
+                } else if ($optionBreakDown[0] == "exportBlendShapes") {
+                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportBlendShapesCheckBox");
                 } else if ($optionBreakDown[0] == "exportColorSets") {
                     mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportColorSetsCheckBox");
                 } else if ($optionBreakDown[0] == "defaultMeshScheme") {
                     mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "defaultMeshSchemePopup");
                 } else if ($optionBreakDown[0] == "defaultUSDFormat") {
-                    mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "defaultUSDFormatPopup");                    
+                    mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "defaultUSDFormatPopup");
                 } else if ($optionBreakDown[0] == "animation") {
                     mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "animationCheckBox");
                 } else if ($optionBreakDown[0] == "eulerFilter") {
@@ -387,6 +408,9 @@ global proc int mayaUsdTranslatorExport (string $parent,
 
     } else if ($action == "query") {
         $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "exportUVs", "exportUVsCheckBox");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromPopup($currentOptions, "exportSkels", "skelsPopup");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromPopup($currentOptions, "exportSkin", "skinClustersPopup");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "exportBlendShapes", "exportBlendShapesCheckBox");
         $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "exportColorSets", "exportColorSetsCheckBox");
         $currentOptions = mayaUsdTranslatorExport_AppendFromPopup($currentOptions, "defaultMeshScheme", "defaultMeshSchemePopup");
         $currentOptions = mayaUsdTranslatorExport_AppendFromPopup($currentOptions, "defaultUSDFormat", "defaultUSDFormatPopup");

--- a/plugin/pxr/maya/lib/usdMaya/usdTranslatorExport.mel
+++ b/plugin/pxr/maya/lib/usdMaya/usdTranslatorExport.mel
@@ -198,6 +198,8 @@ global proc int usdTranslatorExport (string $parent,
             menuItem -l "All (Automatically Create SkelRoots)" -ann "auto";
             menuItem -l "Only Under SkelRoots" -ann "explicit";
 
+        checkBox -l "Export Blend Shapes:" exportBlendShapesCheckBox;
+
         checkBox -l "Export Animation" -cc ("usdTranslatorExport_AnimationCB") animationCheckBox;
 
         checkBox -l "Apply Euler Filter" eulerFilterCheckBox;
@@ -254,6 +256,8 @@ global proc int usdTranslatorExport (string $parent,
                     usdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "exportSkelsPopup");
                 } else if ($optionBreakDown[0] == "exportSkin") {
                     usdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "exportSkinClustersPopup");
+                } else if ($optionBreakDown[0] == "exportBlendShapes") {
+                    usdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportBlendShapesCheckBox");
                 } else if ($optionBreakDown[0] == "exportVisibility") {
                     usdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportVisibilityCheckBox");
                 } else if ($optionBreakDown[0] == "stripNamespaces") {
@@ -304,6 +308,7 @@ global proc int usdTranslatorExport (string $parent,
         $currentOptions = usdTranslatorExport_AppendFromPopup($currentOptions, "defaultMeshScheme", "defaultMeshSchemePopup");
         $currentOptions = usdTranslatorExport_AppendFromPopup($currentOptions, "exportSkels", "exportSkelsPopup");
         $currentOptions = usdTranslatorExport_AppendFromPopup($currentOptions, "exportSkin", "exportSkinClustersPopup");
+        $currentOptions = usdTranslatorExport_AppendFromCheckbox($currentOptions, "exportBlendShapes", "exportBlendShapesCheckBox");
         $currentOptions = usdTranslatorExport_AppendFromCheckbox($currentOptions, "exportVisibility", "exportVisibilityCheckBox");
         $currentOptions = usdTranslatorExport_AppendFromCheckbox($currentOptions, "stripNamespaces", "stripNamespacesCheckBox");
         $currentOptions = usdTranslatorExport_AppendFromCheckbox($currentOptions, "animation", "animationCheckBox");

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TARGET_NAME IMPORT_EXPORT_TEST)
 
 set(TEST_SCRIPT_FILES
     testUsdExportAsClip.py
+    testUsdExportBlendshapes.py
     testUsdExportCamera.py
     testUsdExportColorSets.py
     testUsdExportConnected.py

--- a/test/lib/usd/translators/testUsdExportBlendshapes.py
+++ b/test/lib/usd/translators/testUsdExportBlendshapes.py
@@ -1,0 +1,76 @@
+#!/pxrpythonsubst
+#
+# Copyright 2020 Apple
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import unittest
+
+import fixturesUtils
+from maya import cmds
+from maya import standalone
+from pxr import Usd
+
+
+class TestUsdExportBlendshapes(unittest.TestCase):
+    """
+    Verify that exporting blend shapes from Maya works.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = fixturesUtils.setUpClass(__file__)
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def testBlendShapesExport(self):
+        cmds.file(new=True, force=True)
+        parent = cmds.group(name="root", empty=True)
+        base, _ = cmds.polyCube(name="base")
+        cmds.parent(base, parent)
+        target, _ = cmds.polyCube(name="blend")
+        cmds.parent(target, parent)
+        cmds.polyMoveVertex('{}.vtx[0:2]'.format(target), s=(1.0, 1.5, 1.0))
+
+        cmds.blendShape(target, base, automatic=True)
+
+        cmds.select(base, replace=True)
+        temp_file = os.path.join(self.temp_dir, 'blendshape.usda')
+        cmds.mayaUSDExport(f=temp_file, v=True, sl=True, ebs=True, skl="auto")
+
+        stage = Usd.Stage.Open(temp_file)
+        prim = stage.GetPrimAtPath("/root/base/blendShape")
+        offsets = prim.GetAttribute("offsets").Get()
+
+        for i, coords in enumerate(offsets):
+            coords = list(coords)  # convert from GfVec3
+            self.assertEqual(coords, [0, -0.25 if i < 2 else 0.25, 0])
+
+        """
+        Sample BlendShape prim:
+        
+        def BlendShape "blendShape"
+        {
+            uniform vector3f[] normalOffsets = [(0, 0, 0), (0, 0, 0), (0, 0, 0)]
+            uniform vector3f[] offsets = [(0, -0.25, 0), (0, -0.25, 0), (0, 0.25, 0)]
+            uniform int[] pointIndices = [0, 1, 2]
+        }
+        """
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Hi all:

This PR adds support for exporting blendshapes out of Maya in line with the `UsdSkelBlendShape` schema for a variety of scenarios, including single base - single target, single base - multiple targets (incl. inbetween), multiple base - multiple targets, writing out combined extents, and writing out animation. Some limitations include:

- Currently no support for "chained" blendshape deformations or other intermediate deformers in the deform stack.
- "Layered" blendshape deformers will end up having individual shapes baked out individually.
- Combined extents only take blendshapes into account and no other deformers.

I ran into an issue while implementing this, which can be summarized by the following:

Maya does not evaluate certain plugs on a blendshape node until evaluation of the node is forced. This is a problem because certain information like the indices of components on a blendshape cannot be determined _unless_ the blendshape node itself is evaluated.

Steps to  Reproduce:

1. Create a cube and a blendshape for it with one vertex moved.
2. Run the following code:

```
import maya.OpenMaya as om
sl = om.MSelectionList()
p = om.MPlug()
sl.add('blendShape1.inputTarget[0].inputTargetGroup[0].inputTargetItem[6000].inputComponentsTarget')
sl.getPlug(0, p)

dh = p.asMDataHandle()
d= dh.data()
fn = om.MFnComponentListData(d)
print fn.length()
```

3. You should have gotten an error when attempting to attach the function set. Now twiddle the weight on the blendshape deformer and twiddle it back and then run the same code again.
4. The code suddenly works without any other modifications to the scene or its data.

We're currently working around this by basically twiddling the blendshape node's weights through OpenMaya prior to export, which is not ideal since that could potentially be expensive for denser meshes. Hopefully someone from ADSK could help advise here on any possible remedies.

Please review and raise any concerns.
