### PR TITLE
remove dependencies on old Hydra texture system from hdMaya for USD releases after 20.11

### DIFF
--- a/lib/usd/hdMaya/adapters/aiSkydomeLightAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/aiSkydomeLightAdapter.cpp
@@ -97,7 +97,7 @@ public:
                 file.findPlug(MayaAttrs::file::fileTextureName, true).asString().asChar()));
         } else if (paramName == HdLightTokens->enableColorTemperature) {
             return VtValue(false);
-#if USD_VERSION_NUM >= 1910
+#if USD_VERSION_NUM >= 1910 && USD_VERSION_NUM < 2011
         } else if (paramName == HdLightTokens->textureResource) {
             auto fileObj = GetConnectedFileNode(GetNode(), HdMayaAdapterTokens->color);
             // TODO: Return a default, white texture?
@@ -110,7 +110,7 @@ public:
                 fileObj,
                 GetFileTexturePath(MFnDependencyNode(fileObj)),
                 GetDelegate()->GetParams().textureMemoryPerTexture) };
-#endif // USD_VERSION_NUM >= 1910
+#endif // USD_VERSION_NUM >= 1910 && USD_VERSION_NUM < 2011
         }
         return {};
     }

--- a/lib/usd/hdMaya/adapters/materialAdapter.h
+++ b/lib/usd/hdMaya/adapters/materialAdapter.h
@@ -43,7 +43,14 @@ public:
     HDMAYA_API
     void Populate() override;
 
-#if USD_VERSION_NUM <= 1911
+#if USD_VERSION_NUM > 1911 && USD_VERSION_NUM < 2011
+
+    HDMAYA_API
+    virtual HdTextureResourceSharedPtr GetTextureResource(const SdfPath& textureShaderId);
+    HDMAYA_API
+    virtual HdTextureResource::ID GetTextureResourceID(const TfToken& paramName);
+
+#elif USD_VERSION_NUM <= 1911
 
     HDMAYA_API
     virtual std::string GetSurfaceShaderSource();
@@ -69,16 +76,11 @@ public:
     static const VtValue& GetPreviewMaterialParamValue(const TfToken& paramName);
     HDMAYA_API
     virtual HdTextureResourceSharedPtr GetTextureResource(const TfToken& paramName);
-
-#else // USD_VERSION_NUM > 1911
-
     HDMAYA_API
-    virtual HdTextureResourceSharedPtr GetTextureResource(const SdfPath& textureShaderId);
+    virtual HdTextureResource::ID GetTextureResourceID(const TfToken& paramName);
 
 #endif // USD_VERSION_NUM <= 1911
 
-    HDMAYA_API
-    virtual HdTextureResource::ID GetTextureResourceID(const TfToken& paramName);
     HDMAYA_API
     virtual VtValue GetMaterialResource();
 

--- a/lib/usd/hdMaya/delegates/delegateDebugCodes.cpp
+++ b/lib/usd/hdMaya/delegates/delegateDebugCodes.cpp
@@ -82,15 +82,6 @@ TF_REGISTRY_FUNCTION(TfDebug)
         "Print information about 'GetSubdivTags' calls to the delegates.");
 
     TF_DEBUG_ENVIRONMENT_SYMBOL(
-        HDMAYA_DELEGATE_GET_TEXTURE_RESOURCE,
-        "Print information about 'GetTextureResource' calls to the delegates.");
-
-    TF_DEBUG_ENVIRONMENT_SYMBOL(
-        HDMAYA_DELEGATE_GET_TEXTURE_RESOURCE_ID,
-        "Print information about 'GetTextureResourceID' calls to the "
-        "delegates.");
-
-    TF_DEBUG_ENVIRONMENT_SYMBOL(
         HDMAYA_DELEGATE_GET_TRANSFORM,
         "Print information about 'GetTransform' calls to the delegates.");
 
@@ -121,6 +112,19 @@ TF_REGISTRY_FUNCTION(TfDebug)
 
     TF_DEBUG_ENVIRONMENT_SYMBOL(
         HDMAYA_DELEGATE_SELECTION, "Print information about hdMaya delegate selection.");
+
+#if USD_VERSION_NUM < 2011
+
+    TF_DEBUG_ENVIRONMENT_SYMBOL(
+        HDMAYA_DELEGATE_GET_TEXTURE_RESOURCE,
+        "Print information about 'GetTextureResource' calls to the delegates.");
+
+    TF_DEBUG_ENVIRONMENT_SYMBOL(
+        HDMAYA_DELEGATE_GET_TEXTURE_RESOURCE_ID,
+        "Print information about 'GetTextureResourceID' calls to the "
+        "delegates.");
+
+#endif // USD_VERSION_NUM < 2011
 
 #if USD_VERSION_NUM <= 1911
 

--- a/lib/usd/hdMaya/delegates/delegateDebugCodes.h
+++ b/lib/usd/hdMaya/delegates/delegateDebugCodes.h
@@ -38,8 +38,6 @@ TF_DEBUG_CODES(
     HDMAYA_DELEGATE_GET_PRIMVAR_DESCRIPTORS,
     HDMAYA_DELEGATE_GET_RENDER_TAG,
     HDMAYA_DELEGATE_GET_SUBDIV_TAGS,
-    HDMAYA_DELEGATE_GET_TEXTURE_RESOURCE,
-    HDMAYA_DELEGATE_GET_TEXTURE_RESOURCE_ID,
     HDMAYA_DELEGATE_GET_TRANSFORM,
     HDMAYA_DELEGATE_GET_VISIBLE,
     HDMAYA_DELEGATE_INSERTDAG,
@@ -50,6 +48,18 @@ TF_DEBUG_CODES(
     HDMAYA_DELEGATE_SAMPLE_TRANSFORM,
     HDMAYA_DELEGATE_SELECTION);
 // clang-format on
+
+// Debug codes for Hydra API that was deprecated with USD 20.11.
+// These are declared in a separate block to avoid using a preprocessor
+// directive inside the TF_DEBUG_CODES() macro invocation, which breaks
+// compilation on Windows.
+#if USD_VERSION_NUM < 2011
+// clang-format off
+TF_DEBUG_CODES(
+    HDMAYA_DELEGATE_GET_TEXTURE_RESOURCE,
+    HDMAYA_DELEGATE_GET_TEXTURE_RESOURCE_ID);
+// clang-format on
+#endif // USD_VERSION_NUM < 2011
 
 // Debug codes for Hydra API that was deprecated after USD 19.11.
 // These are declared in a separate block to avoid using a preprocessor

--- a/lib/usd/hdMaya/delegates/sceneDelegate.cpp
+++ b/lib/usd/hdMaya/delegates/sceneDelegate.cpp
@@ -30,9 +30,7 @@
 #include <pxr/imaging/hd/mesh.h>
 #include <pxr/imaging/hd/rprim.h>
 #include <pxr/imaging/hd/tokens.h>
-#include <pxr/imaging/hdx/renderSetupTask.h>
-#include <pxr/imaging/hdx/renderTask.h>
-#include <pxr/imaging/hdx/tokens.h>
+#include <pxr/imaging/hdx/pickTask.h>
 #include <pxr/usd/sdf/assetPath.h>
 #include <pxr/usd/usdGeom/tokens.h>
 
@@ -126,12 +124,16 @@ inline bool _RemoveAdapter(const SdfPath& id, F f, M0& m0, M&... m)
 
 template <typename R> inline R _GetDefaultValue() { return {}; }
 
+#if USD_VERSION_NUM < 2011
+
 // Default return value for HdTextureResource::ID, if not found, should be
 // -1, not {} - which would be 0
 template <> inline HdTextureResource::ID _GetDefaultValue<HdTextureResource::ID>()
 {
     return HdTextureResource::ID(-1);
 }
+
+#endif // USD_VERSION_NUM < 2011
 
 // This will be nicer to use with automatic parameter deduction for lambdas in
 // C++14.
@@ -1130,6 +1132,8 @@ VtValue HdMayaSceneDelegate::GetMaterialResource(const SdfPath& id)
     return ret.IsEmpty() ? HdMayaMaterialAdapter::GetPreviewMaterialResource(id) : ret;
 }
 
+#if USD_VERSION_NUM < 2011
+
 HdTextureResource::ID HdMayaSceneDelegate::GetTextureResourceID(const SdfPath& textureId)
 {
     TF_DEBUG(HDMAYA_DELEGATE_GET_TEXTURE_RESOURCE_ID)
@@ -1188,6 +1192,8 @@ HdTextureResourceSharedPtr HdMayaSceneDelegate::GetTextureResource(const SdfPath
 
 #endif // USD_VERSION_NUM <= 1911
 }
+
+#endif // USD_VERSION_NUM < 2011
 
 bool HdMayaSceneDelegate::_CreateMaterial(const SdfPath& id, const MObject& obj)
 {

--- a/lib/usd/hdMaya/delegates/sceneDelegate.h
+++ b/lib/usd/hdMaya/delegates/sceneDelegate.h
@@ -243,11 +243,13 @@ protected:
     HDMAYA_API
     VtValue GetMaterialResource(const SdfPath& id) override;
 
+#if USD_VERSION_NUM < 2011
     HDMAYA_API
     HdTextureResource::ID GetTextureResourceID(const SdfPath& textureId) override;
 
     HDMAYA_API
     HdTextureResourceSharedPtr GetTextureResource(const SdfPath& textureId) override;
+#endif // USD_VERSION_NUM < 2011
 
 private:
     bool _CreateMaterial(const SdfPath& id, const MObject& obj);

--- a/lib/usd/hdMaya/utils.h
+++ b/lib/usd/hdMaya/utils.h
@@ -24,8 +24,6 @@
 
 #include <pxr/base/gf/matrix4d.h>
 #include <pxr/base/tf/token.h>
-#include <pxr/imaging/hd/textureResource.h>
-#include <pxr/imaging/hd/types.h>
 #include <pxr/pxr.h>
 
 #include <maya/MDagPath.h>
@@ -38,8 +36,12 @@
 #include <maya/MRenderUtil.h>
 #include <maya/MSelectionList.h>
 
-#include <functional>
+#if USD_VERSION_NUM < 2011
+#include <pxr/imaging/hd/textureResource.h>
+#include <pxr/imaging/hd/types.h>
+
 #include <tuple>
+#endif // USD_VERSION_NUM < 2011
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -80,6 +82,8 @@ MObject GetConnectedFileNode(const MFnDependencyNode& node, const TfToken& param
 HDMAYA_API
 TfToken GetFileTexturePath(const MFnDependencyNode& fileNode);
 
+#if USD_VERSION_NUM < 2011
+
 /// \brief Returns the texture resource from a "file" shader node.
 /// \param fileObj "file" shader object.
 /// \param filePath Path to the texture file held by "file" shader node.
@@ -100,6 +104,8 @@ HdTextureResourceSharedPtr GetFileTextureResource(
 ///  for s and t axis.
 HDMAYA_API
 std::tuple<HdWrap, HdWrap> GetFileTextureWrappingParams(const MObject& fileObj);
+
+#endif // USD_VERSION_NUM < 2011
 
 /// \brief Runs a function on all recursive descendents of a selection list
 ///  May optionally filter by node type. The items in the list are also included


### PR DESCRIPTION
Our Hydra team is working on removing parts of the old Hydra texture system for the next core USD release.

With Luma's recent work, it looks like all of the necessary support for the newer material network-based system is already in place, so the changes here mostly just pre-process the old code away for USD releases after 20.11.