### PR TITLE
MAYA-108545: Prevent the crash when authoring edits to instance proxies.

### DIFF
--- a/lib/mayaUsd/ufe/UsdTransform3dHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dHandler.cpp
@@ -17,6 +17,8 @@
 
 #include <mayaUsd/ufe/UsdSceneItem.h>
 
+#include <maya/MGlobal.h>
+
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -43,6 +45,14 @@ Ufe::Transform3d::Ptr UsdTransform3dHandler::transform3d(const Ufe::SceneItem::P
 #if !defined(NDEBUG)
     assert(usdItem);
 #endif
+
+    // According to USD docs, editing scene description via instance proxies and their properties is
+    // not allowed.
+    // https://graphics.pixar.com/usd/docs/api/_usd__page__scenegraph_instancing.html#Usd_ScenegraphInstancing_InstanceProxies
+    if (usdItem->prim().IsInstanceProxy()) {
+        MGlobal::displayError("Authoring to an instance proxy is not allowed.");
+        return nullptr;
+    }
 
     return UsdTransform3d::create(usdItem);
 }

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
@@ -24,6 +24,7 @@
 #include <mayaUsd/undo/UsdUndoableItem.h>
 
 #include <maya/MEulerRotation.h>
+#include <maya/MGlobal.h>
 
 #include <functional>
 #include <map>
@@ -129,6 +130,14 @@ createTransform3d(const Ufe::SceneItem::Ptr& item, NextTransform3dFn nextTransfo
             "Could not create Maya transform stack Transform3d interface for null item.");
     }
 #endif
+
+    // According to USD docs, editing scene description via instance proxies and their properties is
+    // not allowed.
+    // https://graphics.pixar.com/usd/docs/api/_usd__page__scenegraph_instancing.html#Usd_ScenegraphInstancing_InstanceProxies
+    if (usdItem->prim().IsInstanceProxy()) {
+        MGlobal::displayError("Authoring to an instance proxy is not allowed.");
+        return nullptr;
+    }
 
     // If the prim isn't transformable, can't create a Transform3d interface
     // for it.


### PR DESCRIPTION
According to USD docs, editing scene description via instance proxies and their properties is not allowed.