### PR TITLE
Use RUNPATH instead of RPATH for linux plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,10 +52,11 @@ set(CMAKE_MODULE_PATH
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules
 )
 
-# Use RUNPATH instead of RPATH for all shared libs and executables on Linux
+# Use RUNPATH instead of RPATH for all shared libs, executables and modules on Linux
 if(IS_LINUX)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--enable-new-dtags")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--enable-new-dtags")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--enable-new-dtags")
 endif()
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This bakes runtime paths using RUNPATH instead of RPATH for linux plugins (i.e. modules) as well.