### PR TITLE
Fixed incorrect Transform3d fallback assertion.

### DIFF
--- a/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.cpp
@@ -291,8 +291,9 @@ UsdTransform3dFallbackMayaXformStack::getOrderedOps() const
 {
     bool resetsXformStack = false;
     auto ops = _xformable.GetOrderedXformOps(&resetsXformStack);
+    // On initial fallback op addition there is no existing fallback
+    // op, so the return iterator may be ops.end().
     auto i = findFirstFallbackOp(ops);
-    TF_AXIOM(i != ops.end());
 
     // Sort from the start of the Maya sub-stack.  Use the Maya transform stack
     // indices to add to a map, then simply traverse the map to obtain the


### PR DESCRIPTION
Assertion in Maya fallback Transform3d interface was incorrect.

Fix was done using Test Driven Development (TDD).  Test was written, it failed, fix was done, test passes.
