### PR TITLE
Added staticSingleSample flag, and optimize mesh attributes by default

### DIFF
--- a/lib/mayaUsd/commands/baseExportCommand.cpp
+++ b/lib/mayaUsd/commands/baseExportCommand.cpp
@@ -156,6 +156,10 @@ MSyntax MayaUSDExportCommand::createSyntax()
         UsdMayaJobExportArgsTokens->pythonPostCallback.GetText(),
         MSyntax::kString);
     syntax.addFlag(kVerboseFlag, UsdMayaJobExportArgsTokens->verbose.GetText(), MSyntax::kNoArg);
+    syntax.addFlag(
+        kStaticSingleSample,
+        UsdMayaJobExportArgsTokens->staticSingleSample.GetText(),
+        MSyntax::kBoolean);
 
     // These are additional flags under our control.
     syntax.addFlag(kFrameRangeFlag, kFrameRangeFlagLong, MSyntax::kDouble, MSyntax::kDouble);

--- a/lib/mayaUsd/commands/baseExportCommand.h
+++ b/lib/mayaUsd/commands/baseExportCommand.h
@@ -76,6 +76,7 @@ public:
     static constexpr auto kPythonPerFrameCallbackFlag = "pfc";
     static constexpr auto kPythonPostCallbackFlag = "ppc";
     static constexpr auto kVerboseFlag = "v";
+    static constexpr auto kStaticSingleSample = "sss";
 
     // Short and Long forms of flags defined by this command itself:
     static constexpr auto kAppendFlag = "a";

--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -347,6 +347,7 @@ UsdMayaJobExportArgs::UsdMayaJobExportArgs(
           UsdImagingTokens->UsdPreviewSurface,
           UsdMayaShadingModeRegistry::ListMaterialConversions()))
     , verbose(_Boolean(userArgs, UsdMayaJobExportArgsTokens->verbose))
+    , staticSingleSample(_Boolean(userArgs, UsdMayaJobExportArgsTokens->staticSingleSample))
     ,
 
     chaserNames(_Vector<std::string>(userArgs, UsdMayaJobExportArgsTokens->chaser))
@@ -397,6 +398,7 @@ std::ostream& operator<<(std::ostream& out, const UsdMayaJobExportArgs& exportAr
         << "convertMaterialsTo: " << exportArgs.convertMaterialsTo << std::endl
         << "stripNamespaces: " << TfStringify(exportArgs.stripNamespaces) << std::endl
         << "timeSamples: " << exportArgs.timeSamples.size() << " sample(s)" << std::endl
+        << "staticSingleSample: " << TfStringify(exportArgs.staticSingleSample) << std::endl
         << "usdModelRootOverridePath: " << exportArgs.usdModelRootOverridePath << std::endl;
 
     out << "melPerFrameCallback: " << exportArgs.melPerFrameCallback << std::endl
@@ -488,6 +490,7 @@ const VtDictionary& UsdMayaJobExportArgs::GetDefaultDictionary()
             = UsdImagingTokens->UsdPreviewSurface.GetString();
         d[UsdMayaJobExportArgsTokens->stripNamespaces] = false;
         d[UsdMayaJobExportArgsTokens->verbose] = false;
+        d[UsdMayaJobExportArgsTokens->staticSingleSample] = false;
 
         // plugInfo.json site defaults.
         // The defaults dict should be correctly-typed, so enable

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -86,6 +86,7 @@ TF_DECLARE_PUBLIC_TOKENS(
     (convertMaterialsTo) \
     (stripNamespaces) \
     (verbose) \
+    (staticSingleSample) \
     /* Special "none" token */ \
     (none) \
     /* renderLayerMode values */ \
@@ -177,6 +178,7 @@ struct UsdMayaJobExportArgs
     const TfToken shadingMode;
     const TfToken convertMaterialsTo;
     const bool    verbose;
+    const bool    staticSingleSample;
 
     typedef std::map<std::string, std::string> ChaserArgs;
     const std::vector<std::string>             chaserNames;

--- a/lib/mayaUsd/fileio/primWriter.h
+++ b/lib/mayaUsd/fileio/primWriter.h
@@ -76,7 +76,7 @@ public:
 
     /// Post export function that runs before saving the stage.
     ///
-    /// Base implementation does nothing.
+    /// Base implementation handles optional optimization of data.
     MAYAUSD_CORE_PUBLIC
     virtual void PostExport();
 
@@ -159,6 +159,15 @@ public:
     /// Gets the USD stage that we're writing to.
     MAYAUSD_CORE_PUBLIC
     const UsdStageRefPtr& GetUsdStage() const;
+
+    /// Modify all primvars on this prim with single time samples to be static instead.
+    MAYAUSD_CORE_PUBLIC
+    void MakeSingleSamplesStatic();
+
+    /// Modify a specific primvar attribute with single time samples
+    /// to be static.
+    MAYAUSD_CORE_PUBLIC
+    void MakeSingleSamplesStatic(UsdAttribute attr);
 
 protected:
     /// Helper function for determining whether the current node has input

--- a/lib/usd/translators/meshWriter.cpp
+++ b/lib/usd/translators/meshWriter.cpp
@@ -486,6 +486,10 @@ void PxrUsdTranslators_MeshWriter::cleanupPrimvars()
             }
         }
     }
+
+    // The function checks within itself if it is required to be called, so no conditional check
+    // here
+    MakeSingleSamplesStatic();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -212,6 +212,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
         string $animDataAnn = "Exports Maya animation data as USD time samples.";
         string $frameStepAnn = "Specifies the increment between USD time sample frames during animation export";
         string $eulerFilterAnn = "Exports the euler angle filtering that was performed in Maya.";
+        string $staticSingleSampleAnn = "Converts animated values with a single time sample to be static instead.";
         string $visibilityAnn = "Exports Maya visibility attributes as USD metadata.";
         string $mergeShapesAnn = "Merges Maya transform and shape nodes into a single USD prim.";
         string $namespacesAnn = "By default, namespaces are exported to the USD file in the following format: nameSpaceExample_pPlatonic1";
@@ -285,8 +286,11 @@ global proc int mayaUsdTranslatorExport (string $parent,
 
                 checkBoxGrp -l "Euler Filter:" -cw 1 175 
                     -annotation $eulerFilterAnn eulerFilterCheckBox;
-            setParent ..;
 
+                checkBoxGrp -l "Static Single Sample:" -annotation $staticSingleSampleAnn -v1 0 staticSingleSampleCheckBox;
+
+            setParent ..;
+            
             separator -style "none";
         setParent ..;
 
@@ -327,6 +331,8 @@ global proc int mayaUsdTranslatorExport (string $parent,
                     mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "animationCheckBox");
                 } else if ($optionBreakDown[0] == "eulerFilter") {
                     mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "eulerFilterCheckBox");
+                } else if ($optionBreakDown[0] == "staticSingleSample") {
+                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "staticSingleSampleCheckBox");
                 } else if ($optionBreakDown[0] == "startTime") {
                     int $startTime=$optionBreakDown[1];
                     intFieldGrp -e -v1 $startTime framRangeFields;
@@ -392,6 +398,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
         $currentOptions = mayaUsdTranslatorExport_AppendFromPopup($currentOptions, "defaultUSDFormat", "defaultUSDFormatPopup");
         $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "animation", "animationCheckBox");
         $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "eulerFilter", "eulerFilterCheckBox");
+        $currentOptions = mayaUsdTranslatorExport_AppendFromCheckbox($currentOptions, "staticSingleSample", "staticSingleSampleCheckBox");
         $currentOptions = mayaUsdTranslatorExport_AppendFrameRange($currentOptions);
         $currentOptions = mayaUsdTranslatorExport_AppendFromFloatField($currentOptions, "frameStride", "frameStrideField");
         $currentOptions = mayaUsdTranslatorExport_AppendFromTextField($currentOptions, "frameSample", "frameSampleField");

--- a/plugin/pxr/maya/lib/usdMaya/usdTranslatorExport.mel
+++ b/plugin/pxr/maya/lib/usdMaya/usdTranslatorExport.mel
@@ -202,6 +202,8 @@ global proc int usdTranslatorExport (string $parent,
 
         checkBox -l "Apply Euler Filter" eulerFilterCheckBox;
 
+        checkBox -l "Static Single Sample" staticSingleSampleCheckBox;
+
         columnLayout -width 100 animOptsCol;
         intFieldGrp -l "Start Time:" -v1 1 startTimeField;
         intFieldGrp -l "End Time:" -v1 1 endTimeField;
@@ -262,6 +264,8 @@ global proc int usdTranslatorExport (string $parent,
                     usdTranslatorExport_SetCheckbox($optionBreakDown[1], "animationCheckBox");
                 } else if ($optionBreakDown[0] == "eulerFilter") {
                     usdTranslatorExport_SetCheckbox($optionBreakDown[1], "eulerFilterCheckBox");
+                } else if ($optionBreakDown[0] == "staticSingleSample") {
+                    usdTranslatorExport_SetCheckbox($optionBreakDown[1], "staticSingleSampleCheckBox");
                 } else if ($optionBreakDown[0] == "startTime") {
                     int $startTime=$optionBreakDown[1];
                     intFieldGrp -e -v1 $startTime startTimeField;
@@ -308,6 +312,7 @@ global proc int usdTranslatorExport (string $parent,
         $currentOptions = usdTranslatorExport_AppendFromCheckbox($currentOptions, "stripNamespaces", "stripNamespacesCheckBox");
         $currentOptions = usdTranslatorExport_AppendFromCheckbox($currentOptions, "animation", "animationCheckBox");
         $currentOptions = usdTranslatorExport_AppendFromCheckbox($currentOptions, "eulerFilter", "eulerFilterCheckBox");
+        $currentOptions = usdTranslatorExport_AppendFromCheckbox($currentOptions, "staticSingleSample", "staticSingleSampleCheckBox");
         $currentOptions = usdTranslatorExport_AppendFromIntField($currentOptions, "startTime", "startTimeField");
         $currentOptions = usdTranslatorExport_AppendFromIntField($currentOptions, "endTime", "endTimeField");
         $currentOptions = usdTranslatorExport_AppendFromFloatField($currentOptions, "frameStride", "frameStrideField");

--- a/test/lib/usd/translators/testUsdExportAnimation.py
+++ b/test/lib/usd/translators/testUsdExportAnimation.py
@@ -1,0 +1,64 @@
+#!/pxrpythonsubst
+#
+# Copyright 2020 Apple
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os
+import unittest
+
+import fixturesUtils
+from maya import cmds
+from maya import standalone
+from pxr import Usd
+
+
+class testUsdExportAnimation(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = fixturesUtils.setUpClass(__file__)
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def testExportStaticSingleSampleOn(self):
+        for state in (True, False):
+            # Set up the scene in here to prevent having to maintain a Maya file
+            cmds.file(new=True, force=True)
+            root = cmds.group(empty=True, name="root")
+            cube, _ = cmds.polyCube(name="Cube")
+            joint = cmds.joint()
+            cmds.parent(cube, joint, root)
+            cmds.skinCluster(joint, cube)
+
+
+            cmds.setKeyframe(joint, v=0, at='translateY', time=1)
+            cmds.setKeyframe(root, v=0, at='translateY', time=1)
+            cmds.setKeyframe(joint, v=0, at='translateY', time=10)
+
+            # Okay now do the export
+            path = os.path.join(self.temp_dir, "staticSingleFrame{}.usda".format("On" if state else "Off"))
+
+            cmds.mayaUSDExport(f=path, exportSkels="auto", frameRange=(1, 10), sss=state)
+
+            stage = Usd.Stage.Open(path)
+
+            # Check to see if the flag is working
+            prim = stage.GetPrimAtPath("/root")
+            attr = prim.GetAttribute("xformOp:translate")
+            num_samples = attr.GetNumTimeSamples()
+            self.assertEqual(num_samples, int(not state))

--- a/test/lib/usd/translators/testUsdExportAsClip.py
+++ b/test/lib/usd/translators/testUsdExportAsClip.py
@@ -80,14 +80,14 @@ class testUsdExportAsClip(unittest.TestCase):
         # first 5 frames have no animation
         usdFile = os.path.abspath('UsdExportAsClip_cube.001.usda')
         clipFiles.append(usdFile)
-        cmds.usdExport(mergeTransformAndShape=True, file=usdFile, frameRange=(1, 5))
+        cmds.usdExport(mergeTransformAndShape=True, file=usdFile, frameRange=(1, 5), sss=False)
         stage = Usd.Stage.Open(usdFile)
         self._ValidateNumSamples(stage,'/world/pCube1', 'points',  1)
 
         # next 5 frames have no animation
         usdFile = os.path.abspath('UsdExportAsClip_cube.005.usda')
         clipFiles.append(usdFile)
-        cmds.usdExport(mergeTransformAndShape=True, file=usdFile, frameRange=(5, 10))
+        cmds.usdExport(mergeTransformAndShape=True, file=usdFile, frameRange=(5, 10), sss=False)
         stage = Usd.Stage.Open(usdFile)
         self._ValidateNumSamples(stage, '/world/pCube1', 'points', 1)
 
@@ -95,14 +95,14 @@ class testUsdExportAsClip(unittest.TestCase):
         usdFile = os.path.abspath('UsdExportAsClip_cube.010.usda')
         clipFiles.append(usdFile)
         frames = (10, 15)
-        cmds.usdExport(mergeTransformAndShape=True, file=usdFile, frameRange=frames)
+        cmds.usdExport(mergeTransformAndShape=True, file=usdFile, frameRange=frames, sss=False)
         stage = Usd.Stage.Open(usdFile)
         self._ValidateNumSamples(stage, '/world/pCube1', 'points', frames[1] + 1 - frames[0])
 
         # next 5 frames have no animation
         usdFile = os.path.abspath('UsdExportAsClip_cube.015.usda')
         clipFiles.append(usdFile)
-        cmds.usdExport(mergeTransformAndShape=True, file=usdFile, frameRange=(15, 20))
+        cmds.usdExport(mergeTransformAndShape=True, file=usdFile, frameRange=(15, 20), sss=False)
         stage = Usd.Stage.Open(usdFile)
         self._ValidateNumSamples(stage, '/world/pCube1', 'points', 1)
 
@@ -125,7 +125,7 @@ class testUsdExportAsClip(unittest.TestCase):
 
         # export a non clip version for comparison
         canonicalUsdFile = os.path.abspath('canonical.usda')
-        cmds.usdExport(mergeTransformAndShape=True, file=canonicalUsdFile, frameRange=(1, 20))
+        cmds.usdExport(mergeTransformAndShape=True, file=canonicalUsdFile, frameRange=(1, 20), sss=False)
 
         print('comparing: \nnormal: {}\nstitched: {}'.format(canonicalUsdFile, stitchedPath))
         canonicalStage = Usd.Stage.Open(canonicalUsdFile)


### PR DESCRIPTION
This is a PR that adds an export optimization to convert attributes with single time samples to static values.

This is run by default for common mesh attributes as they have the benefit of reducing the complexity of the USD, especially for USD readers. For example, this will benefit round tripping USD files into maya since point cached meshes will be able to import their UVs if they're static.

For all other prim attributes, this is gated behind a new flag called staticSingleSamples. This is off by default to prevent any unwanted surprises if someone was expecting a single keyframe to persist through.

We find, with even the files generated by the included test, that a single attribute results in a 32 byte savings for usda file , and a 67 byte savings for a usdc file due to empty padding in usdc. This scales somewhat linearly with the complexity of the file, so could result in reasonable size reductions overall. As we generate lots of usdz files for distribution over the web, this flag is beneficial to us, and we think it would be beneficial for third parties as well.