### PR TITLE
MAYA-107449 Layer disappears when moved under last layer.

### DIFF
--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -123,7 +123,7 @@ public:
                 _index = (int)layer->GetNumSubLayerPaths();
             }
             if (_index != 0) {
-                if (!validateAndReportIndex(layer, _index)) {
+                if (!validateAndReportIndex(layer, _index, (int)layer->GetNumSubLayerPaths() + 1)) {
                     return false;
                 }
             }
@@ -131,7 +131,7 @@ public:
             TF_VERIFY(layer->GetSubLayerPaths()[_index] == _subPath);
         } else {
             TF_VERIFY(_cmdId == CmdId::kRemove);
-            if (!validateAndReportIndex(layer, _index)) {
+            if (!validateAndReportIndex(layer, _index, (int)layer->GetNumSubLayerPaths())) {
                 return false;
             }
             _subPath = layer->GetSubLayerPaths()[_index];
@@ -168,9 +168,9 @@ public:
         return !(index < 0 || index > (int)layer->GetNumSubLayerPaths());
     }
 
-    static bool validateAndReportIndex(SdfLayerHandle layer, int index)
+    static bool validateAndReportIndex(SdfLayerHandle layer, int index, int maxIndex)
     {
-        if (index < 0 || index > (int)layer->GetNumSubLayerPaths()) {
+        if (index < 0 || index >= maxIndex) {
             std::string message = std::string("Index ") + std::to_string(index)
                 + std::string(" out-of-bound for ") + layer->GetIdentifier();
             MPxCommand::displayError(message.c_str());

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -170,7 +170,7 @@ public:
 
     static bool validateAndReportIndex(SdfLayerHandle layer, int index)
     {
-        if (index < 0 || index >= (int)layer->GetNumSubLayerPaths()) {
+        if (index < 0 || index > (int)layer->GetNumSubLayerPaths()) {
             std::string message = std::string("Index ") + std::to_string(index)
                 + std::string(" out-of-bound for ") + layer->GetIdentifier();
             MPxCommand::displayError(message.c_str());

--- a/test/lib/testMayaUsdLayerEditorCommands.py
+++ b/test/lib/testMayaUsdLayerEditorCommands.py
@@ -198,7 +198,7 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[-2, "bogus"])
         with self.assertRaises(RuntimeError):
-            cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[2, "bogus"])
+            cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[3, "bogus"])
 
         # -replaceSubPath
 


### PR DESCRIPTION
When a layer in the Layer Editor is moved (drag & drop) under the last layer in a hierarchy it will disappear.

drag & drop a layer is a two steps operation. 
 1- Removed the layer from it's original index position
 2- Adding the layer to is new index location. 

The problem is we can't add a layer at the end of the layer list because of a wrong comparaison.
So, the layer is removed but never added at the new location.
  