### PR TITLE
use the PXR_NS macro instead of pxr in the layer editor

### DIFF
--- a/lib/usd/ui/layerEditor/abstractCommandHook.h
+++ b/lib/usd/ui/layerEditor/abstractCommandHook.h
@@ -27,8 +27,8 @@
 
 namespace UsdLayerEditor {
 
-typedef pxr::SdfLayerRefPtr UsdLayer;
-typedef pxr::UsdStageRefPtr UsdStage;
+typedef PXR_NS::SdfLayerRefPtr UsdLayer;
+typedef PXR_NS::UsdStageRefPtr UsdStage;
 
 class SessionState;
 

--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -116,7 +116,7 @@ LayerItemVector LayerTreeItem::childrenVector() const
 }
 
 // recursively update the target layer data member. Meant to be called from invisibleRoot
-void LayerTreeItem::updateTargetLayerRecursive(const pxr::SdfLayerRefPtr& newTargetLayer)
+void LayerTreeItem::updateTargetLayerRecursive(const PXR_NS::SdfLayerRefPtr& newTargetLayer)
 {
     if (!_layer)
         return;
@@ -174,7 +174,7 @@ AbstractCommandHook* LayerTreeItem::commandHook() const
     return parentModel()->sessionState()->commandHook();
 }
 
-pxr::UsdStageRefPtr const& LayerTreeItem::stage() const
+PXR_NS::UsdStageRefPtr const& LayerTreeItem::stage() const
 {
     return parentModel()->sessionState()->stage();
 }
@@ -308,7 +308,7 @@ void LayerTreeItem::addAnonymousSublayer()
     addAnonymousSublayerAndReturn();
 }
 
-pxr::SdfLayerRefPtr LayerTreeItem::addAnonymousSublayerAndReturn()
+PXR_NS::SdfLayerRefPtr LayerTreeItem::addAnonymousSublayerAndReturn()
 {
     auto model = parentModel();
     auto newLayer

--- a/lib/usd/ui/layerEditor/layerTreeItem.h
+++ b/lib/usd/ui/layerEditor/layerTreeItem.h
@@ -68,10 +68,10 @@ class LayerTreeItem : public QStandardItem
 {
 public:
     LayerTreeItem(
-        pxr::SdfLayerRefPtr in_usdLayer,
-        LayerType           in_layerType = LayerType::SubLayer,
-        std::string         in_subLayerPath = "",
-        RecursionDetector*  in_recursionDetector = nullptr);
+        PXR_NS::SdfLayerRefPtr in_usdLayer,
+        LayerType              in_layerType = LayerType::SubLayer,
+        std::string            in_subLayerPath = "",
+        RecursionDetector*     in_recursionDetector = nullptr);
 
     // refresh our data from the USD Layer
     void fetchData(RebuildChildren in_rebuild, RecursionDetector* in_recursionDetector = nullptr);
@@ -90,7 +90,7 @@ public:
     // if a sublayer, get the path we were saved with in the parent
     const std::string& subLayerPath() const { return _subLayerPath; }
     // shortcut to get stage from model
-    pxr::UsdStageRefPtr const& stage() const;
+    PXR_NS::UsdStageRefPtr const& stage() const;
 
     // is the layer muted at the stage level?
     bool isMuted() const;
@@ -108,15 +108,15 @@ public:
     // is this sublayer with a path that doesn't load?
     bool isInvalidLayer() const { return !_layer; }
     // update the target layer flags -- meant to be called from invisible root
-    void updateTargetLayerRecursive(const pxr::SdfLayerRefPtr& newTargetLayer);
+    void updateTargetLayerRecursive(const PXR_NS::SdfLayerRefPtr& newTargetLayer);
 
     // USD Layer type query
-    bool                isSessionLayer() const { return _layerType == LayerType::SessionLayer; }
-    bool                isSublayer() const { return _layerType == LayerType::SubLayer; }
-    bool                isTargetLayer() const { return _isTargetLayer; }
-    bool                isAnonymous() const { return _layer ? _layer->IsAnonymous() : false; }
-    bool                isRootLayer() const { return _layerType == LayerType::RootLayer; }
-    pxr::SdfLayerRefPtr layer() const { return _layer; }
+    bool                   isSessionLayer() const { return _layerType == LayerType::SessionLayer; }
+    bool                   isSublayer() const { return _layerType == LayerType::SubLayer; }
+    bool                   isTargetLayer() const { return _isTargetLayer; }
+    bool                   isAnonymous() const { return _layer ? _layer->IsAnonymous() : false; }
+    bool                   isRootLayer() const { return _layerType == LayerType::RootLayer; }
+    PXR_NS::SdfLayerRefPtr layer() const { return _layer; }
 
     // allows c++ iteration of children
     LayerItemVector childrenVector() const;
@@ -127,11 +127,11 @@ public:
     void discardEdits();
 
     // there are two addAnonymousSubLayer , because the menu needs all method to be void
-    void                addAnonymousSublayer();
-    pxr::SdfLayerRefPtr addAnonymousSublayerAndReturn();
-    void                loadSubLayers(QWidget* in_parent);
-    void                printLayer();
-    void                clearLayer();
+    void                   addAnonymousSublayer();
+    PXR_NS::SdfLayerRefPtr addAnonymousSublayerAndReturn();
+    void                   loadSubLayers(QWidget* in_parent);
+    void                   printLayer();
+    void                   clearLayer();
 
     // delegate Action API for command buttons
     int getActionButtonCount() const { return (isSublayer() && !isInvalidLayer()) ? 1 : 0; }
@@ -140,11 +140,11 @@ public:
     static const std::vector<LayerActionInfo>& actionButtonsDefinition();
 
 protected:
-    pxr::SdfLayerRefPtr _layer;
-    std::string         _displayName;
-    bool                _isTargetLayer = false;
-    LayerType           _layerType = LayerType::SubLayer;
-    std::string         _subLayerPath; // name of the layer as it was found in the parent's stack
+    PXR_NS::SdfLayerRefPtr _layer;
+    std::string            _displayName;
+    bool                   _isTargetLayer = false;
+    LayerType              _layerType = LayerType::SubLayer;
+    std::string            _subLayerPath; // name of the layer as it was found in the parent's stack
 
     static std::vector<LayerActionInfo> _actionButtons;
 

--- a/lib/usd/ui/layerEditor/layerTreeModel.h
+++ b/lib/usd/ui/layerEditor/layerTreeModel.h
@@ -48,7 +48,7 @@ enum class InRebuildModel
  */
 class LayerTreeModel
     : public QStandardItemModel
-    , public pxr::TfWeakBase
+    , public PXR_NS::TfWeakBase
 {
     Q_OBJECT
 public:
@@ -87,7 +87,7 @@ public:
     void toggleMuteLayer(LayerTreeItem* item, bool* forcedState = nullptr);
 
     // ask to select a layer in the near future
-    void selectUsdLayerOnIdle(const pxr::SdfLayerRefPtr& usdLayer);
+    void selectUsdLayerOnIdle(const PXR_NS::SdfLayerRefPtr& usdLayer);
 
     // drag and drop support
     Qt::ItemFlags   flags(const QModelIndex& index) const override;
@@ -116,14 +116,14 @@ protected:
     SessionState* _sessionState = nullptr;
 
     void registerUsdNotifications(bool in_register);
-    void usd_layerChanged(pxr::SdfNotice::LayersDidChangeSentPerLayer const& notice);
-    void usd_editTargetChanged(pxr::UsdNotice::StageEditTargetChanged const& notice);
+    void usd_layerChanged(PXR_NS::SdfNotice::LayersDidChangeSentPerLayer const& notice);
+    void usd_editTargetChanged(PXR_NS::UsdNotice::StageEditTargetChanged const& notice);
     void usd_layerDirtinessChanged(
-        pxr::SdfNotice::LayerDirtinessChanged const& notice,
-        const pxr::TfWeakPtr<pxr::SdfLayer>&         layer);
+        PXR_NS::SdfNotice::LayerDirtinessChanged const& notice,
+        const PXR_NS::TfWeakPtr<PXR_NS::SdfLayer>&      layer);
 
-    pxr::TfNotice::Keys _noticeKeys;
-    static bool         _blockUsdNotices;
+    PXR_NS::TfNotice::Keys _noticeKeys;
+    static bool            _blockUsdNotices;
     ;
 
     mutable int _lastAskedAnonLayerNameSinceRebuild = 0;
@@ -134,7 +134,7 @@ protected:
 
     void updateTargetLayer(InRebuildModel inRebuild);
 
-    LayerTreeItem* findUSDLayerItem(const pxr::SdfLayerRefPtr& usdLayer) const;
+    LayerTreeItem* findUSDLayerItem(const PXR_NS::SdfLayerRefPtr& usdLayer) const;
 };
 
 } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/layerTreeView.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeView.cpp
@@ -169,8 +169,8 @@ void LayerTreeView::onAddParentLayer(const QString& undoName) const
     for (auto item : *params.selection) {
         auto oldParent = item->parentLayerItem()->layer();
         // create an anon layer as the new parent
-        auto anonLayer
-            = pxr::SdfLayer::CreateAnonymous(item->parentModel()->findNameForNewAnonymousLayer());
+        auto anonLayer = PXR_NS::SdfLayer::CreateAnonymous(
+            item->parentModel()->findNameForNewAnonymousLayer());
         // insert this selected item under it
         anonLayer->InsertSubLayerPath(item->layer()->GetIdentifier());
         // replace this selected item in its parent with the anon layer

--- a/lib/usd/ui/layerEditor/mayaCommandHook.cpp
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.cpp
@@ -144,7 +144,7 @@ UsdLayer MayaCommandHook::addAnonymousSubLayer(UsdLayer usdLayer, std::string ne
     cmd += quote(newName);
     cmd += quote(usdLayer->GetIdentifier());
     std::string result = executeMel(cmd).asChar();
-    return pxr::SdfLayer::FindOrOpen(result);
+    return PXR_NS::SdfLayer::FindOrOpen(result);
 }
 
 // mute or unmute the given layer

--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -59,7 +59,7 @@ MayaSessionState::~MayaSessionState()
     //
 }
 
-void MayaSessionState::setStage(pxr::UsdStageRefPtr const& in_stage)
+void MayaSessionState::setStage(PXR_NS::UsdStageRefPtr const& in_stage)
 {
     PARENT_CLASS::setStage(in_stage);
     if (in_stage) {
@@ -356,7 +356,7 @@ void MayaSessionState::setAutoHideSessionLayer(bool hideIt)
     PARENT_CLASS::setAutoHideSessionLayer(hideIt);
 }
 
-void MayaSessionState::printLayer(const pxr::SdfLayerRefPtr& layer) const
+void MayaSessionState::printLayer(const PXR_NS::SdfLayerRefPtr& layer) const
 {
     MString result, temp;
 

--- a/lib/usd/ui/layerEditor/mayaSessionState.h
+++ b/lib/usd/ui/layerEditor/mayaSessionState.h
@@ -39,7 +39,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
  */
 class MayaSessionState
     : public SessionState
-    , public pxr::TfWeakBase
+    , public PXR_NS::TfWeakBase
 
 {
     Q_OBJECT
@@ -50,7 +50,7 @@ public:
     ~MayaSessionState();
 
     // API implementation
-    void                    setStage(pxr::UsdStageRefPtr const& in_stage) override;
+    void                    setStage(PXR_NS::UsdStageRefPtr const& in_stage) override;
     void                    setAutoHideSessionLayer(bool hide) override;
     AbstractCommandHook*    commandHook() override;
     std::vector<StageEntry> allStages() const override;
@@ -62,7 +62,7 @@ public:
     // ui to save a layer. returns the path and the file format (ex: "usda")
     bool saveLayerUI(QWidget* in_parent, std::string* out_filePath, std::string* out_pFormat)
         const override;
-    void printLayer(const pxr::SdfLayerRefPtr& layer) const override;
+    void printLayer(const PXR_NS::SdfLayerRefPtr& layer) const override;
 
     // main API
     void setupCreateMenu(QMenu* in_menu) override;

--- a/lib/usd/ui/layerEditor/pathChecker.cpp
+++ b/lib/usd/ui/layerEditor/pathChecker.cpp
@@ -32,8 +32,8 @@
 namespace {
 using namespace UsdLayerEditor;
 
-typedef pxr::SdfLayerRefPtr   UsdLayer;
-typedef std::vector<UsdLayer> UsdLayerVector;
+typedef PXR_NS::SdfLayerRefPtr UsdLayer;
+typedef std::vector<UsdLayer>  UsdLayerVector;
 
 // helper for checkIfPathIsSafeToAdd
 UsdLayerVector getAllParentHandles(LayerTreeItem* parentItem)
@@ -79,7 +79,7 @@ bool checkPathRecursive(
         return false;
     }
 
-    auto& resolver = pxr::ArGetResolver();
+    auto& resolver = PXR_NS::ArGetResolver();
     auto  anchor = toForwardSlashes(testLayer->GetRealPath());
 
     // now check all children of the testLayer recursivly down for conflicts with any of the parents
@@ -89,7 +89,7 @@ bool checkPathRecursive(
     for (const auto path : proxy) {
         auto actualpath = computePathToLoadSublayer(path, anchor, resolver);
 
-        auto childLayer = pxr::SdfLayer::FindOrOpen(actualpath);
+        auto childLayer = PXR_NS::SdfLayer::FindOrOpen(actualpath);
         if (childLayer != nullptr) {
             if (!checkPathRecursive(
                     in_errorTitle,
@@ -121,7 +121,7 @@ bool checkIfPathIsSafeToAdd(
     // checking if the handles were already loaded
 
     auto  parentLayer = in_parentItem->layer();
-    auto& resolver = pxr::ArGetResolver();
+    auto& resolver = PXR_NS::ArGetResolver();
 
     // first check if the path is already in the stack
     auto proxy = parentLayer->GetSubLayerPaths();
@@ -133,7 +133,7 @@ bool checkIfPathIsSafeToAdd(
         // now we're going to check if the layer is already in the stack, through
         // another path
         bool foundLayerInStack = false;
-        auto subLayer = pxr::SdfLayer::FindOrOpen(pathToAdd);
+        auto subLayer = PXR_NS::SdfLayer::FindOrOpen(pathToAdd);
         if (subLayer == nullptr) {
             return true; // always safe to add a bad path, unless it's already in the stack
         } else {
@@ -141,7 +141,7 @@ bool checkIfPathIsSafeToAdd(
             for (const auto path : proxy) {
                 std::string actualpath = computePathToLoadSublayer(path, anchor, resolver);
 
-                auto childLayer = pxr::SdfLayer::FindOrOpen(actualpath);
+                auto childLayer = PXR_NS::SdfLayer::FindOrOpen(actualpath);
                 if (childLayer == subLayer) {
                     foundLayerInStack = true;
                     break;
@@ -164,11 +164,11 @@ bool checkIfPathIsSafeToAdd(
 }
 
 bool saveSubLayer(
-    const QString&      in_errorTitle,
-    LayerTreeItem*      in_parentItem,
-    pxr::SdfLayerRefPtr in_layer,
-    const std::string&  in_absolutePath,
-    const std::string&  in_formatTag)
+    const QString&         in_errorTitle,
+    LayerTreeItem*         in_parentItem,
+    PXR_NS::SdfLayerRefPtr in_layer,
+    const std::string&     in_absolutePath,
+    const std::string&     in_formatTag)
 {
     std::string backupFileName;
     QFileInfo   fileInfo(QString::fromStdString(in_absolutePath));
@@ -184,7 +184,7 @@ bool saveSubLayer(
     }
 
     if (!fileError) {
-        pxr::SdfFileFormat::FileFormatArguments formatArgs;
+        PXR_NS::SdfFileFormat::FileFormatArguments formatArgs;
         formatArgs["format"] = in_formatTag;
 
         if (!in_layer->Export(in_absolutePath, "", formatArgs)) {

--- a/lib/usd/ui/layerEditor/pathChecker.h
+++ b/lib/usd/ui/layerEditor/pathChecker.h
@@ -45,11 +45,11 @@ bool checkIfPathIsSafeToAdd(
 // if that fails, delete the file we created.
 // for now, assumes an absolute input path
 bool saveSubLayer(
-    const QString&      in_errorTitle,
-    LayerTreeItem*      in_parentItem,
-    pxr::SdfLayerRefPtr in_layer,
-    const std::string&  in_absolutePath,
-    const std::string&  in_formatTag);
+    const QString&         in_errorTitle,
+    LayerTreeItem*         in_parentItem,
+    PXR_NS::SdfLayerRefPtr in_layer,
+    const std::string&     in_absolutePath,
+    const std::string&     in_formatTag);
 
 // convert path string to use forward slashes
 inline std::string toForwardSlashes(const std::string& in_path)
@@ -64,13 +64,13 @@ inline std::string toForwardSlashes(const std::string& in_path)
 // from a sublayerpath.
 // this path could be absolute, relative, or be an anon layer
 inline std::string computePathToLoadSublayer(
-    const std::string& subLayerPath,
-    const std::string& anchor,
-    pxr::ArResolver&   resolver)
+    const std::string&  subLayerPath,
+    const std::string&  anchor,
+    PXR_NS::ArResolver& resolver)
 {
     std::string actualPath = subLayerPath;
     if (resolver.IsRelativePath(subLayerPath)) {
-        auto subLayer = pxr::SdfLayer::Find(subLayerPath); // note: finds in the cache
+        auto subLayer = PXR_NS::SdfLayer::Find(subLayerPath); // note: finds in the cache
         if (subLayer) {
             if (!resolver.IsRelativePath(subLayer->GetIdentifier())) {
                 actualPath = toForwardSlashes(subLayer->GetRealPath());

--- a/lib/usd/ui/layerEditor/saveLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.cpp
@@ -333,7 +333,7 @@ void SaveLayersDialog::onSaveAll()
 
         QString path = row->pathToSaveAs();
         if (!path.isEmpty()) {
-            pxr::SdfFileFormat::FileFormatArguments formatArgs;
+            PXR_NS::SdfFileFormat::FileFormatArguments formatArgs;
             formatArgs["format"] = row->usdFormatTag().toStdString();
 
             auto sessionState = item->parentModel()->sessionState();

--- a/lib/usd/ui/layerEditor/sessionState.cpp
+++ b/lib/usd/ui/layerEditor/sessionState.cpp
@@ -23,7 +23,7 @@ void SessionState::setAutoHideSessionLayer(bool hideIt)
     Q_EMIT autoHideSessionLayerSignal(_autoHideSessionLayer);
 }
 
-void SessionState::setStage(pxr::UsdStageRefPtr const& in_stage)
+void SessionState::setStage(PXR_NS::UsdStageRefPtr const& in_stage)
 {
     if (in_stage != _stage) {
         _stage = in_stage;
@@ -31,7 +31,7 @@ void SessionState::setStage(pxr::UsdStageRefPtr const& in_stage)
     }
 }
 
-pxr::SdfLayerRefPtr SessionState::targetLayer() const
+PXR_NS::SdfLayerRefPtr SessionState::targetLayer() const
 {
     if (_stage != nullptr) {
         const auto& target = _stage->GetEditTarget();

--- a/lib/usd/ui/layerEditor/sessionState.h
+++ b/lib/usd/ui/layerEditor/sessionState.h
@@ -45,17 +45,17 @@ public:
 
     struct StageEntry
     {
-        pxr::UsdStageRefPtr _stage;
-        std::string         _displayName;
-        std::string         _proxyShapePath;
+        PXR_NS::UsdStageRefPtr _stage;
+        std::string            _displayName;
+        std::string            _proxyShapePath;
     };
 
     // properties
     virtual bool                    autoHideSessionLayer() const { return _autoHideSessionLayer; }
     virtual void                    setAutoHideSessionLayer(bool hide);
-    pxr::UsdStageRefPtr const&      stage() const { return _stage; }
-    pxr::SdfLayerRefPtr             targetLayer() const;
-    virtual void                    setStage(pxr::UsdStageRefPtr const& in_stage);
+    PXR_NS::UsdStageRefPtr const&   stage() const { return _stage; }
+    PXR_NS::SdfLayerRefPtr          targetLayer() const;
+    virtual void                    setStage(PXR_NS::UsdStageRefPtr const& in_stage);
     virtual AbstractCommandHook*    commandHook() = 0;
     virtual std::vector<StageEntry> allStages() const = 0;
     // path to default load layer dialogs to
@@ -66,7 +66,7 @@ public:
     // ui to save a layer. returns the path and the file format (ex: "usda")
     virtual bool
                  saveLayerUI(QWidget* in_parent, std::string* out_filePath, std::string* out_pFormat) const = 0;
-    virtual void printLayer(const pxr::SdfLayerRefPtr& layer) const = 0;
+    virtual void printLayer(const PXR_NS::SdfLayerRefPtr& layer) const = 0;
 
     // main API
     virtual void setupCreateMenu(QMenu* in_menu) = 0;
@@ -78,13 +78,13 @@ public:
 
 Q_SIGNALS:
     void currentStageChangedSignal();
-    void stageListChangedSignal(pxr::UsdStageRefPtr const& toSelect = pxr::UsdStageRefPtr());
-    void stageRenamedSignal(std::string const& name, pxr::UsdStageRefPtr const& stage);
+    void stageListChangedSignal(PXR_NS::UsdStageRefPtr const& toSelect = PXR_NS::UsdStageRefPtr());
+    void stageRenamedSignal(std::string const& name, PXR_NS::UsdStageRefPtr const& stage);
     void autoHideSessionLayerSignal(bool hideIt);
 
 protected:
-    pxr::UsdStageRefPtr _stage;
-    bool                _autoHideSessionLayer = true;
+    PXR_NS::UsdStageRefPtr _stage;
+    bool                   _autoHideSessionLayer = true;
 };
 
 } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
@@ -24,7 +24,7 @@
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QLabel>
 
-Q_DECLARE_METATYPE(pxr::UsdStageRefPtr);
+Q_DECLARE_METATYPE(PXR_NS::UsdStageRefPtr);
 
 namespace UsdLayerEditor {
 
@@ -69,17 +69,17 @@ void StageSelectorWidget::setSessionState(SessionState* in_sessionState)
     updateFromSessionState();
 }
 
-pxr::UsdStageRefPtr StageSelectorWidget::selectedStage()
+PXR_NS::UsdStageRefPtr StageSelectorWidget::selectedStage()
 {
     if (_dropDown->currentIndex() != -1) {
         auto const& data = _dropDown->currentData();
-        return data.value<pxr::UsdStageRefPtr>();
+        return data.value<PXR_NS::UsdStageRefPtr>();
     }
 
-    return pxr::UsdStageRefPtr();
+    return PXR_NS::UsdStageRefPtr();
 }
 // repopulates the combo based on the session stage list
-void StageSelectorWidget::updateFromSessionState(pxr::UsdStageRefPtr const& stageToSelect)
+void StageSelectorWidget::updateFromSessionState(PXR_NS::UsdStageRefPtr const& stageToSelect)
 {
     QSignalBlocker blocker(_dropDown);
     _dropDown->clear();
@@ -118,7 +118,7 @@ void StageSelectorWidget::sessionStageChanged()
     }
 }
 
-void StageSelectorWidget::stageRenamed(std::string const& name, pxr::UsdStageRefPtr const& stage)
+void StageSelectorWidget::stageRenamed(std::string const& name, PXR_NS::UsdStageRefPtr const& stage)
 {
     auto index = _dropDown->findData(QVariant::fromValue(stage));
     if (index != -1) {

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.h
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.h
@@ -39,12 +39,13 @@ public:
     StageSelectorWidget(SessionState* in_sessionState, QWidget* in_parent);
 
 protected:
-    void                setSessionState(SessionState* in_sessionState);
-    pxr::UsdStageRefPtr selectedStage();
+    void                   setSessionState(SessionState* in_sessionState);
+    PXR_NS::UsdStageRefPtr selectedStage();
 
     // slot:
-    void updateFromSessionState(pxr::UsdStageRefPtr const& stageToSelect = pxr::UsdStageRefPtr());
-    void stageRenamed(std::string const& name, pxr::UsdStageRefPtr const& stage);
+    void
+         updateFromSessionState(PXR_NS::UsdStageRefPtr const& stageToSelect = PXR_NS::UsdStageRefPtr());
+    void stageRenamed(std::string const& name, PXR_NS::UsdStageRefPtr const& stage);
     void sessionStageChanged();
     void selectedIndexChanged(int index);
 


### PR DESCRIPTION
Just a small follow-up from the merge of the layer editor work from #988:

The `PXR_NS` macro should be used rather than hard-coding `pxr` as the namespace when referring to symbols in USD in case the core USD build is configured to use a different namespace (or in our case, no namespace with `PXR_USE_NAMESPACES=0`).