### PR TITLE
install and remove UsdMayaDiagnosticDelegate for adsk plugin load and unload

### DIFF
--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -34,6 +34,7 @@
 #include <mayaUsd/render/pxrUsdMayaGL/proxyShapeUI.h>
 #include <mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h>
 #include <mayaUsd/undo/UsdUndoBlock.h>
+#include <mayaUsd/utils/diagnosticDelegate.h>
 #include <mayaUsd/utils/undoHelperCommand.h>
 
 #include <pxr/base/plug/plugin.h>
@@ -313,6 +314,7 @@ MStatus initializePlugin(MObject obj)
     }
 
     UsdMayaSceneResetNotice::InstallListener();
+    UsdMayaDiagnosticDelegate::InstallDelegate();
 
     return status;
 }
@@ -394,6 +396,7 @@ MStatus uninitializePlugin(MObject obj)
 #endif
 
     UsdMayaSceneResetNotice::RemoveListener();
+    UsdMayaDiagnosticDelegate::RemoveDelegate();
 
     return status;
 }

--- a/test/lib/usd/translators/testUsdExportStripNamespaces.py
+++ b/test/lib/usd/translators/testUsdExportStripNamespaces.py
@@ -55,21 +55,8 @@ class testUsdExportStripNamespaces(unittest.TestCase):
 
         usdFilePath = os.path.abspath('UsdExportStripNamespaces_EXPORTED.usda')
 
-        # https://github.com/Autodesk/maya-usd/blob/dev/lib/mayaUsd/fileio/jobs/writeJob.cpp#L814
-        # does indeed generate the proper TF_RUNTIME_ERROR originally tested
-        # below, and
-        # http://graphics.pixar.com/usd/docs/api/group__group__tf___diagnostic.html#ga4abf7754e5dbf161d2a5a4160fd3b891
-        # describes that "Generally, an error handling delegate will take action
-        # to turn this error into a python exception [...]".
-        #
-        # Unfortunately, at time of writing, this is not happening correctly,
-        # as the Python exception is generated, but the detailed error string
-        # is lost.  We are left with the generic 'Maya command error'
-        # string, which is far weaker.  PPT, 16-Jun-20.
-        #
-        # errorRegexp = "Multiple dag nodes map to the same prim path" \
-        #     ".+|cube1 - |foo:cube1.*"
-        errorRegexp = 'Maya command error'
+        errorRegexp = "Multiple dag nodes map to the same prim path" \
+            ".+|cube1 - |foo:cube1.*"
 
         with self.assertRaisesRegex(RuntimeError, errorRegexp) as cm:
             cmds.usdExport(mergeTransformAndShape=True,


### PR DESCRIPTION
These changes make `mayaUsdPlugin` use `UsdMayaDiagnosticDelegate` in the same way that the `pxrUsd` plugin currently does. The delegate's install and remove functions were modified slightly to make this work, using a pattern similar to the one used for `MayaUsdProxyShapePlugin`.

The diagnostic delegate takes care of intercepting messages emitted by the `Tf` library in core USD and relaying them to the appropriate `MGlobal` functions (e.g. `displayWarning()`, `displayError()`, etc.).

This should address an issue @ysiewappl ran into in #952 where it was necessary to explicitly call both diagnostic functions with the same message:
https://github.com/Autodesk/maya-usd/pull/952/files#r539582025

It also turns out that this fixes an issue @ppt-adsk ran into where the full error message in Python exceptions was not making it through in the `testUsdExportStripNamespaces` test.