### PR TITLE
ensure that GL is initialized when mtoh creates the Storm render delegate

### DIFF
--- a/lib/mayaUsd/render/mayaToHydra/utils.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/utils.cpp
@@ -13,6 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
+// GLEW must be included early (for core USD < 21.02), but we need pxr.h first
+// so that USD_VERSION_NUM has the correct value.
+// We also disable clang-format for this block, since otherwise v10.0.0 fails
+// to recognize that "utils.h" is the related header.
+// clang-format off
+#include <pxr/pxr.h>
+#if USD_VERSION_NUM < 2102
+#include <pxr/imaging/glf/glew.h>
+#endif
+// clang-format on
+
 #include "utils.h"
 
 #include "renderGlobals.h"
@@ -23,6 +35,10 @@
 #include <pxr/imaging/hd/rendererPluginRegistry.h>
 
 #include <maya/MGlobal.h>
+
+#if USD_VERSION_NUM >= 2102
+#include <pxr/imaging/garch/glApi.h>
+#endif
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -51,8 +67,14 @@ MtohInitializeRenderPlugins()
             }
 
             // XXX: As of 22.02, this needs to be called for Storm
-            if (pluginDesc.id == MtohTokens->HdStormRendererPlugin)
+            if (pluginDesc.id == MtohTokens->HdStormRendererPlugin) {
+#if USD_VERSION_NUM >= 2102
+                GarchGLApiLoad();
+#else
+                GlfGlewInit();
+#endif
                 GlfContextCaps::InitInstance();
+            }
 
             HdRenderDelegate* delegate
                 = plugin->IsSupported() ? plugin->CreateRenderDelegate() : nullptr;


### PR DESCRIPTION
I'm not sure how others aren't running into this, but we're seeing all of the newly added `mtoh` tests crashing because GL/GLEW isn't fully initialized at the point where it discovers the Storm renderer plugin and tries to call `GlfContextCaps::InitInstance()`.

Prior to core USD 21.02, this was handled by calling `GlfGlewInit()`, but from 21.02 on, the GLEW dependency has been removed, and `GarchGLApiLoad()` is  used instead.

The same pattern of calling `GlfGlewInit()`/`GarchGLApiLoad()` before calling `GlfContextCaps::InitInstance()` can be seen in some of the unit tests in core USD, for example:
https://github.com/PixarAnimationStudios/USD/blob/e9172af0ccea9896990f5ac093c3d6063ac7cab5/pxr/imaging/hdSt/unitTestGLDrawing.cpp#L94