### PR TITLE
MAYA-108814 Support viewport display filtering for meshes and basisCurves

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -32,6 +32,7 @@
 #include <pxr/imaging/hd/tokens.h>
 #include <pxr/imaging/hd/version.h>
 
+#include <maya/MFrameContext.h>
 #include <maya/MMatrix.h>
 #include <maya/MProfiler.h>
 #include <maya/MSelectionMask.h>
@@ -1666,6 +1667,10 @@ MHWRender::MRenderItem* HdVP2BasisCurves::_CreateWireRenderItem(const MString& n
     renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueGray));
     renderItem->setSelectionMask(MSelectionMask::kSelectCurves);
 
+#if MAYA_API_VERSION >= 20210000
+    renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeNurbsCurves);
+#endif
+
     setWantConsolidation(*renderItem, true);
 
     return renderItem;
@@ -1683,6 +1688,10 @@ MHWRender::MRenderItem* HdVP2BasisCurves::_CreateBBoxRenderItem(const MString& n
     renderItem->receivesShadows(false);
     renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueGray));
     renderItem->setSelectionMask(MSelectionMask::kSelectCurves);
+
+#if MAYA_API_VERSION >= 20210000
+    renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeNurbsCurves);
+#endif
 
     setWantConsolidation(*renderItem, true);
 
@@ -1702,6 +1711,10 @@ MHWRender::MRenderItem* HdVP2BasisCurves::_CreatePatchRenderItem(const MString& 
     renderItem->receivesShadows(false);
     renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueGray));
     renderItem->setSelectionMask(MSelectionMask::kSelectCurves);
+
+#if MAYA_API_VERSION >= 20210000
+    renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeNurbsCurves);
+#endif
 
     setWantConsolidation(*renderItem, true);
 
@@ -1723,6 +1736,10 @@ MHWRender::MRenderItem* HdVP2BasisCurves::_CreatePointsRenderItem(const MString&
     MSelectionMask selectionMask(MSelectionMask::kSelectPointsForGravity);
     selectionMask.addMask(MSelectionMask::kSelectCurves);
     renderItem->setSelectionMask(selectionMask);
+
+#if MAYA_API_VERSION >= 20210000
+    renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeNurbsCurves);
+#endif
 
     setWantConsolidation(*renderItem, true);
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -33,6 +33,7 @@
 #include <pxr/imaging/hd/version.h>
 #include <pxr/imaging/hd/vertexAdjacency.h>
 
+#include <maya/MFrameContext.h>
 #include <maya/MMatrix.h>
 #include <maya/MProfiler.h>
 #include <maya/MSelectionMask.h>
@@ -1662,6 +1663,10 @@ MHWRender::MRenderItem* HdVP2Mesh::_CreatePointsRenderItem(const MString& name) 
     selectionMask.addMask(MSelectionMask::kSelectMeshVerts);
     renderItem->setSelectionMask(selectionMask);
 
+#if MAYA_API_VERSION >= 20210000
+    renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeMeshes);
+#endif
+
     setWantConsolidation(*renderItem, true);
 
     return renderItem;
@@ -1681,6 +1686,10 @@ MHWRender::MRenderItem* HdVP2Mesh::_CreateWireframeRenderItem(const MString& nam
     renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueBlue));
     renderItem->setSelectionMask(MSelectionMask::kSelectMeshes);
 
+#if MAYA_API_VERSION >= 20210000
+    renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeMeshes);
+#endif
+
     setWantConsolidation(*renderItem, true);
 
     return renderItem;
@@ -1698,6 +1707,10 @@ MHWRender::MRenderItem* HdVP2Mesh::_CreateBoundingBoxRenderItem(const MString& n
     renderItem->receivesShadows(false);
     renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueBlue));
     renderItem->setSelectionMask(MSelectionMask::kSelectMeshes);
+
+#if MAYA_API_VERSION >= 20210000
+    renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeMeshes);
+#endif
 
     setWantConsolidation(*renderItem, true);
 
@@ -1720,6 +1733,10 @@ MHWRender::MRenderItem* HdVP2Mesh::_CreateSmoothHullRenderItem(const MString& na
     renderItem->setShader(_delegate->GetFallbackShader(kOpaqueGray));
     renderItem->setSelectionMask(MSelectionMask::kSelectMeshes);
 
+#if MAYA_API_VERSION >= 20210000
+    renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeMeshes);
+#endif
+
     setWantConsolidation(*renderItem, true);
 
     return renderItem;
@@ -1740,6 +1757,10 @@ MHWRender::MRenderItem* HdVP2Mesh::_CreateSelectionHighlightRenderItem(const MSt
     renderItem->receivesShadows(false);
     renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueBlue));
     renderItem->setSelectionMask(MSelectionMask());
+
+#if MAYA_API_VERSION >= 20210000
+    renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeMeshes);
+#endif
 
     setWantConsolidation(*renderItem, true);
 


### PR DESCRIPTION
* If polygons are excluded from display, USD meshes will be filtered out.
* If NURBS curves are excluded from display, USD curves will be filtered out.
* If plugin shapes are excluded from display, all USD objects will be filtered out.