### PR TITLE
[tests] interactive tests ensure output streams are flushed before quitting

### DIFF
--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testLayerManager.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testLayerManager.py
@@ -23,6 +23,8 @@ import unittest
 from maya import cmds
 from AL.usdmaya import ProxyShape
 
+import fixturesUtils
+
 class TestLayerManagerSerialisation(unittest.TestCase):
     """Test cases for layer manager serialisation and deserialisation"""
 
@@ -76,7 +78,7 @@ class TestLayerManagerSerialisation(unittest.TestCase):
         self._stage.DefinePrim(newPrimPath, "xform")
         self._stage.SetEditTarget(self._stage.GetSessionLayer())
 
-        _tmpMayafile = tempfile.NamedTemporaryFile(delete=True, suffix=".ma") 
+        _tmpMayafile = tempfile.NamedTemporaryFile(delete=True, suffix=".ma")
         _tmpMayafile.close()
 
         cmds.file(rename=_tmpMayafile.name)
@@ -97,7 +99,7 @@ class TestLayerManagerSerialisation(unittest.TestCase):
     def test_sessionLayerSerialisation(self):
         """ A clean session layer should not be serialised on Maya scene save, nor we get
             any complain form usdMaya on Maya scene reopen.
-            A dirty session layer should be serialised correctly on Maya scene save, and 
+            A dirty session layer should be serialised correctly on Maya scene save, and
             we should get it deserialised on Maya scene reopen. We should also be able to
             reload on session layer to clear it.
         """
@@ -141,10 +143,5 @@ class TestLayerManagerSerialisation(unittest.TestCase):
         os.remove(_tmpMayafile.name)
 
 
-
-if __name__ == "__main__":
-
-    tests = [unittest.TestLoader().loadTestsFromTestCase(TestLayerManagerSerialisation),]
-    results = [unittest.TextTestRunner(verbosity=2).run(test) for test in tests]
-    exitCode = int(not all([result.wasSuccessful() for result in results]))
-    cmds.quit(exitCode=(exitCode))
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals())

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testProxyShape.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testProxyShape.py
@@ -30,6 +30,8 @@ from pxr import Usd, UsdUtils
 from maya import cmds
 from maya.api import OpenMaya as om2
 
+import fixturesUtils
+
 
 class TestProxyShapeGetUsdPrimFromMayaPath(unittest.TestCase):
     """Test cases for static function: AL.usdmaya.ProxyShape.getUsdPrimFromMayaPath"""
@@ -424,13 +426,5 @@ class TestProxyShapeVariantFallbacks(unittest.TestCase):
         self.assertEqual(savedAttrValue, json.dumps(custom))
 
 
-if __name__ == "__main__":
-
-    tests = [unittest.TestLoader().loadTestsFromTestCase(TestProxyShapeGetUsdPrimFromMayaPath),
-             unittest.TestLoader().loadTestsFromTestCase(TestProxyShapeGetMayaPathFromUsdPrim),
-             unittest.TestLoader().loadTestsFromTestCase(TestProxyShapeAnonymousLayer),
-             unittest.TestLoader().loadTestsFromTestCase(TestProxyShapeVariantFallbacks)
-              ]
-    results = [unittest.TextTestRunner(verbosity=2).run(test) for test in tests]
-    exitCode = int(not all([result.wasSuccessful() for result in results]))
-    cmds.quit(exitCode=(exitCode))
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals())

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testTranslators.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testTranslators.py
@@ -27,6 +27,8 @@ from AL import usdmaya
 
 from pxr import Usd, UsdUtils, Tf
 
+import fixturesUtils
+
 class CubeGenerator(usdmaya.TranslatorBase):
     '''
     Basic Translator which doesn't support update
@@ -38,7 +40,7 @@ class CubeGenerator(usdmaya.TranslatorBase):
     importObjectCount = 0
     updateCount = 0
     importObjectMObjects = []
-    
+
     @classmethod
     def resetState(cls):
         cls.initializeCount = 0
@@ -48,12 +50,12 @@ class CubeGenerator(usdmaya.TranslatorBase):
         cls.importObjectCount = 0
         cls.updateCount = 0
         cls.importObjectMObjects = []
-        
+
     @classmethod
     def getState(cls):
-        return {"initializeCount": cls.initializeCount, 
-                "preTearDownCount": cls.preTearDownCount, 
-                "tearDownCount": cls.tearDownCount, 
+        return {"initializeCount": cls.initializeCount,
+                "preTearDownCount": cls.preTearDownCount,
+                "tearDownCount": cls.tearDownCount,
                 "postImportCount":cls.postImportCount,
                 "importObjectCount":cls.importObjectCount,
                 "updateCount":cls.updateCount,
@@ -61,37 +63,37 @@ class CubeGenerator(usdmaya.TranslatorBase):
 
     def initialize(self):
         return True
-    
+
     def preTearDown(self, prim):
         self.__class__.preTearDownCount +=1
         return True
-    
+
     def tearDown(self, path):
         self.__class__.tearDownCount +=1
         self.removeItems(path)
         return True
-    
+
     def canExport(self, mayaObjectName):
         return False
-    
+
     def needsTransformParent(self):
         return True
-    
+
     def supportsUpdate(self):
         return False
-    
+
     def importableByDefault(self):
         return True
-    
+
     def exportObject(self, stage, path, usdPath, params):
         return
-    
+
     def postImport(self, prim):
         return True
 
     def getTranslatedType(self):
         return Tf.Type.Unknown
-       
+
 
     def importObject(self, prim, parent=None):
         self.__class__.importObjectCount +=1
@@ -115,7 +117,7 @@ class CubeGenerator(usdmaya.TranslatorBase):
 
         self.__class__.importObjectMObjects = self.context().getMObjectsPath(prim)
         return True
-    
+
 
     def update(self, prim):
         self.__class__.updateCount +=1
@@ -181,18 +183,18 @@ class DeleteParentNodeOnPostImport(usdmaya.TranslatorBase):
 
 
 class TestPythonTranslators(unittest.TestCase):
-    
+
     def setUp(self):
         cmds.file(force=True, new=True)
         cmds.loadPlugin("AL_USDMayaPlugin", quiet=True)
         self.assertTrue(cmds.pluginInfo("AL_USDMayaPlugin", query=True, loaded=True))
-        
-        
+
+
     def tearDown(self):
         CubeGenerator.resetState()
         UsdUtils.StageCache.Get().Clear()
         usdmaya.TranslatorBase.clearTranslators()
-    
+
     def test_registration(self):
         import examplecubetranslator  #This registers the translator
 
@@ -675,11 +677,5 @@ class TestPythonTranslatorsUniqueKey(unittest.TestCase):
         self.assertTrue(cmds.objExists('|bindings_grp|root|dynamic_five_cubes'))
 
 
-if __name__ == "__main__":
-
-    tests = [unittest.TestLoader().loadTestsFromTestCase(TestPythonTranslators)]
-    tests += [unittest.TestLoader().loadTestsFromTestCase(TestPythonTranslatorsUniqueKey)]
-    
-    results = [unittest.TextTestRunner(verbosity=2).run(test) for test in tests]
-    exitCode = int(not all([result.wasSuccessful() for result in results]))
-    cmds.quit(force=True, exitCode=(exitCode))
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals())

--- a/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testBatchRendererIsolateSelection.py
+++ b/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testBatchRendererIsolateSelection.py
@@ -23,6 +23,8 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
+
 
 class testBatchRendererIsolateSelection(unittest.TestCase):
 
@@ -152,15 +154,4 @@ class testBatchRendererIsolateSelection(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(
-            testBatchRendererIsolateSelection)
-
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())

--- a/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testPxrUsdMayaGLInstancerDraw.py
+++ b/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testPxrUsdMayaGLInstancerDraw.py
@@ -20,6 +20,8 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
+
 
 class testPxrUsdMayaGLInstancerDraw(unittest.TestCase):
 
@@ -99,16 +101,6 @@ class testPxrUsdMayaGLInstancerDraw(unittest.TestCase):
         self._SetModelPanelsToViewport2()
         self._WriteViewportImage("InstancerTest", "reload")
 
-if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(
-            testPxrUsdMayaGLInstancerDraw)
 
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals())

--- a/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testRefAssemblyDrawRepresentations.py
+++ b/plugin/pxr/maya/lib/pxrUsdMayaGL/testenv/testRefAssemblyDrawRepresentations.py
@@ -23,6 +23,7 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
 
 class testRefAssemblyDrawRepresentations(unittest.TestCase):
 
@@ -91,15 +92,4 @@ class testRefAssemblyDrawRepresentations(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(
-            testRefAssemblyDrawRepresentations)
-
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawAndTransform.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawAndTransform.py
@@ -103,14 +103,4 @@ class testProxyShapeDrawAndTransform(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(testProxyShapeDrawAndTransform)
-
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawColorAccuracy.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawColorAccuracy.py
@@ -105,15 +105,4 @@ class testProxyShapeDrawColorAccuracy(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(
-        testProxyShapeDrawColorAccuracy)
-
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawColors.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawColors.py
@@ -119,15 +119,4 @@ class testProxyShapeDrawColors(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(
-        testProxyShapeDrawColors)
-
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawLighting.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawLighting.py
@@ -191,15 +191,4 @@ class testProxyShapeDrawLighting(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(
-        testProxyShapeDrawLighting)
-
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawPerformance.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawPerformance.py
@@ -204,15 +204,4 @@ class testProxyShapeDrawPerformance(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(
-        testProxyShapeDrawPerformance)
-
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawPurpose.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawPurpose.py
@@ -118,14 +118,4 @@ class testProxyShapeDrawPurpose(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(testProxyShapeDrawPurpose)
-
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawTimeSampled.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawTimeSampled.py
@@ -99,15 +99,4 @@ class testProxyShapeDrawTimeSampled(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(
-        testProxyShapeDrawTimeSampled)
-
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawUsdChangeProcessing.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawUsdChangeProcessing.py
@@ -106,15 +106,4 @@ class testProxyShapeDrawUsdChangeProcessing(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(
-        testProxyShapeDrawUsdChangeProcessing)
-
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawVisibility.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawVisibility.py
@@ -108,15 +108,4 @@ class testProxyShapeDrawVisibility(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(
-        testProxyShapeDrawVisibility)
-
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDuplicatePerformance.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDuplicatePerformance.py
@@ -161,15 +161,4 @@ class testProxyShapeDuplicatePerformance(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(
-        testProxyShapeDuplicatePerformance)
-
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeLiveSurface.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeLiveSurface.py
@@ -147,15 +147,4 @@ class testProxyShapeLiveSurface(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(
-        testProxyShapeLiveSurface)
-
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeRendererSceneMessages.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeRendererSceneMessages.py
@@ -174,14 +174,4 @@ class testProxyShapeRendererSceneMessages(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(testProxyShapeRendererSceneMessages)
-
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeSelectionPerformance.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeSelectionPerformance.py
@@ -438,15 +438,4 @@ class testProxyShapeSelectionPerformance(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(
-        testProxyShapeSelectionPerformance)
-
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testPxrUsdMayaGL.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testPxrUsdMayaGL.py
@@ -64,13 +64,4 @@ class testPxrUsdMayaGL(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(testPxrUsdMayaGL)
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # maya running interactively often absorbs all the output.  comment out the
-    # following to prevent maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())

--- a/test/lib/usd/pxrUsdPreviewSurface/testPxrUsdPreviewSurfaceDraw.py
+++ b/test/lib/usd/pxrUsdPreviewSurface/testPxrUsdPreviewSurfaceDraw.py
@@ -22,6 +22,7 @@ import os
 import sys
 import unittest
 
+import fixturesUtils
 
 class testPxrUsdPreviewSurfaceDraw(unittest.TestCase):
 
@@ -86,14 +87,4 @@ class testPxrUsdPreviewSurfaceDraw(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    suite = unittest.TestLoader().loadTestsFromTestCase(testPxrUsdPreviewSurfaceDraw)
-
-    results = unittest.TextTestRunner(stream=sys.__stderr__).run(suite)
-    if results.wasSuccessful():
-        exitCode = 0
-    else:
-        exitCode = 1
-    # Maya running interactively often absorbs all the output. Comment out the
-    # following to prevent Maya from exiting and open the script editor to look
-    # at failures.
-    cmds.quit(abort=True, exitCode=exitCode)
+    fixturesUtils.runTests(globals())


### PR DESCRIPTION
When developing #915, we uncovered an issue where [output streams weren't being flushing before interactive maya tests quit](https://github.com/Autodesk/maya-usd/pull/915#issuecomment-738472429). 

This applies the fix developed in that PR to all interactive maya tests, so we can be sure to see all their output on stdout.