### PR TITLE
Add testUsdExportAnimation for staticSingleSamples flag to CMakeList

### DIFF
--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TARGET_NAME IMPORT_EXPORT_TEST)
 
 set(TEST_SCRIPT_FILES
+    testUsdExportAnimation.py
     testUsdExportAsClip.py
     testUsdExportCamera.py
     testUsdExportColorSets.py


### PR DESCRIPTION
Thanks again for @mattyjams for catching the missing test in the CMakeLists in https://github.com/Autodesk/maya-usd/pull/989/files#r544716374. 