### PR TITLE
MAYA-106310 - Crash when querying target layer and nothing is assigne…

### DIFF
--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -110,6 +110,7 @@ class InsertRemoveSubPathBase : public BaseCmd
 public:
     int         _index = -1;
     std::string _subPath;
+    std::string _proxyShapePath;
 
     InsertRemoveSubPathBase(CmdId id)
         : BaseCmd(id)
@@ -136,6 +137,18 @@ public:
             }
             _subPath = layer->GetSubLayerPaths()[_index];
             holdOnPathIfDirty(layer, _subPath);
+
+            // if the layer to remove is the current edit target,
+            // set the root layer as the current edit target
+            auto subLayerHandle = SdfLayer::FindRelativeToLayer(layer, _subPath);
+            auto stage = getStage();
+            auto currentTarget = stage->GetEditTarget().GetLayer();
+            if (currentTarget
+                && currentTarget->GetIdentifier() == subLayerHandle->GetIdentifier()) {
+                _isEditTarget = true;
+                stage->SetEditTarget(stage->GetRootLayer());
+            }
+
             layer->RemoveSubLayerPath(_index);
         }
         return true;
@@ -157,6 +170,14 @@ public:
             TF_VERIFY(_index != -1);
             if (validateUndoIndex(layer, _index)) {
                 layer->InsertSubLayerPath(_subPath, _index);
+
+                // if the removed layer was the edit target,
+                // set it back to the current edit target
+                if (_isEditTarget) {
+                    auto stage = getStage();
+                    auto subLayerHandle = SdfLayer::FindRelativeToLayer(layer, _subPath);
+                    stage->SetEditTarget(subLayerHandle);
+                }
             } else {
                 return false;
             }
@@ -178,6 +199,16 @@ public:
         } else {
             return true;
         }
+    }
+
+protected:
+    bool _isEditTarget = false;
+
+    UsdStageWeakPtr getStage()
+    {
+        auto prim = UsdMayaQuery::GetPrim(_proxyShapePath.c_str());
+        auto stage = prim.GetStage();
+        return stage;
     }
 };
 
@@ -397,7 +428,7 @@ MSyntax LayerEditorCommand::createSyntax()
 
     syntax.addFlag(kInsertSubPathFlag, kInsertSubPathFlagL, MSyntax::kLong, MSyntax::kString);
     syntax.makeFlagMultiUse(kInsertSubPathFlag);
-    syntax.addFlag(kRemoveSubPathFlag, kRemoveSubPathFlagL, MSyntax::kLong);
+    syntax.addFlag(kRemoveSubPathFlag, kRemoveSubPathFlagL, MSyntax::kLong, MSyntax::kString);
     syntax.makeFlagMultiUse(kRemoveSubPathFlag);
     syntax.addFlag(kReplaceSubPathFlag, kReplaceSubPathFlagL, MSyntax::kString, MSyntax::kString);
     syntax.makeFlagMultiUse(kReplaceSubPathFlag);
@@ -451,11 +482,22 @@ MStatus LayerEditorCommand::parseArgs(const MArgList& argList)
         if (argParser.isFlagSet(kRemoveSubPathFlag)) {
             auto count = argParser.numberOfFlagUses(kRemoveSubPathFlag);
             for (unsigned i = 0; i < count; i++) {
-                auto cmd = std::make_shared<Impl::RemoveSubPath>();
 
                 MArgList listOfArgs;
                 argParser.getFlagArgumentList(kRemoveSubPathFlag, i, listOfArgs);
-                cmd->_index = listOfArgs.asInt(0);
+
+                auto index = listOfArgs.asInt(0);
+                auto shapePath = listOfArgs.asString(1);
+                auto prim = UsdMayaQuery::GetPrim(shapePath.asChar());
+                if (prim == UsdPrim()) {
+                    displayError(
+                        MString("Invalid proxy shape \"") + shapePath.asChar() + "\"");
+                    return MS::kInvalidParameter;
+                }
+
+                auto cmd = std::make_shared<Impl::RemoveSubPath>();
+                cmd->_index = index;
+                cmd->_proxyShapePath = shapePath.asChar();
                 _subCommands.push_back(std::move(cmd));
             }
         }

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -490,8 +490,7 @@ MStatus LayerEditorCommand::parseArgs(const MArgList& argList)
                 auto shapePath = listOfArgs.asString(1);
                 auto prim = UsdMayaQuery::GetPrim(shapePath.asChar());
                 if (prim == UsdPrim()) {
-                    displayError(
-                        MString("Invalid proxy shape \"") + shapePath.asChar() + "\"");
+                    displayError(MString("Invalid proxy shape \"") + shapePath.asChar() + "\"");
                     return MS::kInvalidParameter;
                 }
 

--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -225,9 +225,6 @@ void LayerTreeItem::getActionButton(int index, LayerActionInfo* out_info) const
 void LayerTreeItem::removeSubLayer()
 {
     if (isSublayer()) { // can't remove session or root layer
-        if (_isTargetLayer) {
-            commandHook()->setEditTarget(stage()->GetRootLayer());
-        }
         commandHook()->removeSubLayerPath(parentLayerItem()->layer(), subLayerPath());
     }
 }

--- a/lib/usd/ui/layerEditor/mayaCommandHook.cpp
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.cpp
@@ -102,7 +102,8 @@ void MayaCommandHook::removeSubLayerPath(UsdLayer usdLayer, Path path)
     assert(index != static_cast<size_t>(-1));
     std::string cmd;
     cmd = "mayaUsdLayerEditor -edit -removeSubPath ";
-    cmd += std::to_string(index);
+    cmd += std::to_string(index);   
+    cmd += quote(proxyShapePath());
     cmd += quote(usdLayer->GetIdentifier());
     executeMel(cmd);
 }

--- a/lib/usd/ui/layerEditor/mayaCommandHook.cpp
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.cpp
@@ -102,7 +102,7 @@ void MayaCommandHook::removeSubLayerPath(UsdLayer usdLayer, Path path)
     assert(index != static_cast<size_t>(-1));
     std::string cmd;
     cmd = "mayaUsdLayerEditor -edit -removeSubPath ";
-    cmd += std::to_string(index);   
+    cmd += std::to_string(index);
     cmd += quote(proxyShapePath());
     cmd += quote(usdLayer->GetIdentifier());
     executeMel(cmd);

--- a/test/lib/testMayaUsdLayerEditorCommands.py
+++ b/test/lib/testMayaUsdLayerEditorCommands.py
@@ -94,6 +94,21 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
         cmds.undo()
         self.assertEqual(stage.GetEditTarget().GetLayer().identifier, undoStepTwo)
 
+        # test removing the edit target
+        self.assertEqual(stage.GetEditTarget().GetLayer().identifier, greenLayerId)
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, removeSubPath=[0,shapePath])
+        self.assertEqual(stage.GetEditTarget().GetLayer().identifier, rootLayerID)
+        cmds.undo()
+        self.assertEqual(stage.GetEditTarget().GetLayer().identifier, greenLayerId)
+
+        cmds.mayaUsdEditTarget(shapePath, edit=True, editTarget=redLayerId)
+
+        self.assertEqual(stage.GetEditTarget().GetLayer().identifier, redLayerId)
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, removeSubPath=[1,shapePath])
+        self.assertEqual(stage.GetEditTarget().GetLayer().identifier, rootLayerID)
+        cmds.undo()
+        self.assertEqual(stage.GetEditTarget().GetLayer().identifier, redLayerId)
+
         # test bad input
         with self.assertRaises(RuntimeError):
             cmds.mayaUsdEditTarget("bogusShape", query=True, editTarget=True)
@@ -141,18 +156,18 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
 
         # -removeSubPath
         # remove second sublayer
-        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, removeSubPath=1)
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, removeSubPath=[1,_shapePath])
         afterDeletion = [layer1Id, layer3Id]
         self.assertEqual(rootLayer.subLayerPaths, afterDeletion)
 
         # remove second sublayer again to leave only one
         afterDeletion = [layer1Id, layer3Id]
-        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, removeSubPath=1)
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, removeSubPath=[1,_shapePath])
         self.assertEqual(rootLayer.subLayerPaths, [layer1Id])
 
         # remove second sublayer  -- this time it's out of bounds
         with self.assertRaises(RuntimeError):
-            cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, removeSubPath=1)
+            cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, removeSubPath=[1,_shapePath])
 
         # undo twice to get back to three layers
         cmds.undo()
@@ -168,7 +183,7 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
         grandChildLayerId = cmds.mayaUsdLayerEditor(childLayerId, edit=True, addAnonymous="GrandChild")[0]
 
         # delete the top layer.  See if it comes back after redo.
-        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, removeSubPath=0)
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, removeSubPath=[0,_shapePath])
         # check layer1 was deleted
         self.assertEqual(rootLayer.subLayerPaths, [layer2Id, layer3Id])
         # bring it back


### PR DESCRIPTION
…d the target

- Update the mayaUsdLayerEditor cmd to set the root layer as the edit target when the command is used the remove a layer and this layer is the edit target