### PR TITLE
updates for building with latest post-20.11 dev branch of core USD

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -43,9 +43,9 @@ IncludeCategories:
   # 8. C system headers
   # 9. Conditional includes
 
-  # 0. Glew must be included before any other GL header
+  # 0. GL loaders must be included before any other GL header
   # Negative priority puts it above the default IncludeIsMainRegex
-  - Regex:           '<pxr/imaging/glf/glew.h>'
+  - Regex:           '<pxr/imaging/(garch/glApi.h|glf/glew.h)>'
     Priority:        -1
 
   # 1. Related header

--- a/doc/build.md
+++ b/doc/build.md
@@ -31,7 +31,7 @@ See Pixar's official github page for instructions on how to build USD: https://g
 
 |               |      ![](images/pxr.png)          |        
 |:------------: |:---------------:                  |
-|  CommitID/Tags | release: [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) or [v20.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.11) <br> dev: [fc74bea](https://github.com/PixarAnimationStudios/USD/commit/fc74bea71029e278d7956822a13b220764ccd32d) |
+|  CommitID/Tags | release: [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) or [v20.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.11) <br> dev: [5904885](https://github.com/PixarAnimationStudios/USD/commit/590488516d285de4352c96bd5a542f5c6a5829be) |
 
 For additional information on building Pixar USD, see the ***Additional Build Instruction*** section below.
 

--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
@@ -657,7 +657,9 @@ void MtohRenderOverride::_InitHydraResources()
 {
     TF_DEBUG(HDMAYA_RENDEROVERRIDE_RESOURCES)
         .Msg("MtohRenderOverride::_InitHydraResources(%s)\n", _rendererDesc.rendererName.GetText());
+#if USD_VERSION_NUM < 2102
     GlfGlewInit();
+#endif
     GlfContextCaps::InitInstance();
     _rendererPlugin
         = HdRendererPluginRegistry::GetInstance().GetRendererPlugin(_rendererDesc.rendererName);

--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.h
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.h
@@ -16,10 +16,12 @@
 #ifndef MTOH_VIEW_OVERRIDE_H
 #define MTOH_VIEW_OVERRIDE_H
 
+#include <pxr/pxr.h>
+#if USD_VERSION_NUM < 2102
 #include <pxr/imaging/glf/glew.h>
+#endif
 
 #include <pxr/base/tf/singleton.h>
-#include <pxr/pxr.h>
 
 #include <maya/MCallbackIdArray.h>
 #include <maya/MMessage.h>

--- a/lib/mayaUsd/render/mayaToHydra/utils.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/utils.cpp
@@ -36,10 +36,6 @@
 
 #include <maya/MGlobal.h>
 
-#if USD_VERSION_NUM >= 2102
-#include <pxr/imaging/garch/glApi.h>
-#endif
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 namespace {
@@ -68,9 +64,7 @@ MtohInitializeRenderPlugins()
 
             // XXX: As of 22.02, this needs to be called for Storm
             if (pluginDesc.id == MtohTokens->HdStormRendererPlugin) {
-#if USD_VERSION_NUM >= 2102
-                GarchGLApiLoad();
-#else
+#if USD_VERSION_NUM < 2102
                 GlfGlewInit();
 #endif
                 GlfContextCaps::InitInstance();

--- a/lib/mayaUsd/render/px_vp20/glslProgram.cpp
+++ b/lib/mayaUsd/render/px_vp20/glslProgram.cpp
@@ -14,8 +14,13 @@
 // limitations under the License.
 //
 
-// glew must be included before any other GL header.
+// GL loading library needs to be included before any other OpenGL headers.
+#include <pxr/pxr.h>
+#if USD_VERSION_NUM < 2102
 #include <pxr/imaging/glf/glew.h>
+#else
+#include <pxr/imaging/garch/glApi.h>
+#endif
 
 #include "glslProgram.h"
 

--- a/lib/mayaUsd/render/px_vp20/utils.cpp
+++ b/lib/mayaUsd/render/px_vp20/utils.cpp
@@ -14,8 +14,13 @@
 // limitations under the License.
 //
 
-// glew must be included before any other GL header.
+// GL loading library needs to be included before any other OpenGL headers.
+#include <pxr/pxr.h>
+#if USD_VERSION_NUM < 2102
 #include <pxr/imaging/glf/glew.h>
+#else
+#include <pxr/imaging/garch/glApi.h>
+#endif
 
 #include "utils.h"
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -14,8 +14,13 @@
 // limitations under the License.
 //
 
-// glew needs to be included before any other OpenGL headers.
+// GL loading library needs to be included before any other OpenGL headers.
+#include <pxr/pxr.h>
+#if USD_VERSION_NUM < 2102
 #include <pxr/imaging/glf/glew.h>
+#else
+#include <pxr/imaging/garch/glApi.h>
+#endif
 
 #include "batchRenderer.h"
 
@@ -48,7 +53,6 @@
 #include <pxr/imaging/hd/tokens.h>
 #include <pxr/imaging/hdx/selectionTracker.h>
 #include <pxr/imaging/hdx/tokens.h>
-#include <pxr/pxr.h>
 #include <pxr/usd/sdf/path.h>
 
 #include <maya/M3dView.h>
@@ -108,7 +112,9 @@ const int UsdMayaGLBatchRenderer::ProfilerCategory = MProfiler::addCategory(
 /* static */
 void UsdMayaGLBatchRenderer::Init()
 {
+#if USD_VERSION_NUM < 2102
     GlfGlewInit();
+#endif
     GlfContextCaps::InitInstance();
 
     GetInstance();

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
@@ -114,7 +114,7 @@ public:
     /// Initialize the batch renderer.
     ///
     /// This should be called at least once and it is OK to call it multiple
-    /// times. This handles things like initializing OpenGL/Glew.
+    /// times. This handles things like initializing OpenGL Loading Library.
     MAYAUSD_CORE_PUBLIC
     static void Init();
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/proxyShapeDelegate.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/proxyShapeDelegate.cpp
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include <pxr/imaging/glf/glew.h> // This header must absolutely come first.
 
 #include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/render/pxrUsdMayaGL/batchRenderer.h>
@@ -25,8 +24,6 @@
 #include <pxr/base/gf/rotation.h>
 #include <pxr/base/gf/vec3d.h>
 #include <pxr/base/tf/registryManager.h>
-#include <pxr/imaging/glf/drawTarget.h>
-#include <pxr/imaging/glf/glContext.h>
 
 #include <maya/MFnDagNode.h>
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/instancer.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/instancer.cpp
@@ -15,8 +15,6 @@
 //
 // Modifications copyright (C) 2019 Autodesk
 //
-#include <pxr/imaging/glf/glew.h>
-
 #include "instancer.h"
 
 #include "sampler.h"

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -46,8 +46,13 @@
 #include <string>
 
 #if USD_VERSION_NUM >= 2002
-#include <pxr/imaging/glf/udimTexture.h>
 #include <pxr/usdImaging/usdImaging/textureUtils.h>
+#endif
+
+#if USD_VERSION_NUM >= 2102
+#include <pxr/imaging/hdSt/udimTextureObject.h>
+#elif USD_VERSION_NUM >= 2002
+#include <pxr/imaging/glf/udimTexture.h>
 #endif
 
 #if USD_VERSION_NUM >= 2102
@@ -371,8 +376,13 @@ _LoadUdimTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& u
     */
 
     // test for a UDIM texture
+#if USD_VERSION_NUM >= 2102
+    if (!HdStIsSupportedUdimTexture(path))
+        return nullptr;
+#else
     if (!GlfIsSupportedUdimTexture(path))
         return nullptr;
+#endif
 
     /*
         Maya's tiled texture support is implemented quite differently from Usd's UDIM support.
@@ -489,8 +499,13 @@ _LoadTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& uvSca
 {
 #if USD_VERSION_NUM >= 2002
     // If it is a UDIM texture we need to modify the path before calling OpenForReading
+#if USD_VERSION_NUM >= 2102
+    if (HdStIsSupportedUdimTexture(path))
+        return _LoadUdimTexture(path, isColorSpaceSRGB, uvScaleOffset);
+#else
     if (GlfIsSupportedUdimTexture(path))
         return _LoadUdimTexture(path, isColorSpaceSRGB, uvScaleOffset);
+#endif
 #endif
 
     MHWRender::MRenderer* const       renderer = MHWRender::MRenderer::theRenderer();

--- a/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.cpp
@@ -765,7 +765,14 @@ bool MeshViewportCompute::hasOpenGL()
     return nullptr != glBindBufferBase;
 }
 
-void MeshViewportCompute::initializeOpenGL() { glewInit(); }
+void MeshViewportCompute::initializeOpenGL()
+{
+#if USD_VERSION_NUM < 2102
+    GlfGlewInit();
+#else
+    GarchGLApiLoad();
+#endif
+}
 
 void MeshViewportCompute::compileNormalsProgram()
 {

--- a/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.h
@@ -85,8 +85,12 @@
 // clang-format wants to re-order these two includes but they must be done in this order or
 // the code will not compile.
 // clang-format off
-#include "pxr/imaging/glf/glew.h"   // needs to be included before anything else includes gl.h
-#include "../px_vp20/glslProgram.h" // this includes gl.h and not glew.
+#if USD_VERSION_NUM < 2102
+#include <pxr/imaging/glf/glew.h> // needs to be included before anything else includes gl.h
+#else
+#include <pxr/imaging/garch/glApi.h>
+#endif
+#include <mayaUsd/render/px_vp20/glslProgram.h> // this includes gl.h and no GL loader.
 //clang-format on
 #endif
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/sampler.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/sampler.h
@@ -18,8 +18,6 @@
 #ifndef HD_VP2_SAMPLER_H
 #define HD_VP2_SAMPLER_H
 
-#include <pxr/imaging/glf/glew.h>
-
 #include <pxr/base/gf/matrix4d.h>
 #include <pxr/base/gf/matrix4f.h>
 #include <pxr/base/gf/vec2d.h>

--- a/lib/usd/hdMaya/delegates/delegate.h
+++ b/lib/usd/hdMaya/delegates/delegate.h
@@ -16,8 +16,6 @@
 #ifndef HDMAYA_DELEGATE_H
 #define HDMAYA_DELEGATE_H
 
-#include <pxr/imaging/glf/glew.h>
-
 #include <hdMaya/api.h>
 #include <hdMaya/delegates/params.h>
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/PluginRegister.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/PluginRegister.h
@@ -14,7 +14,12 @@
 // limitations under the License.
 //
 #pragma once
+#include <pxr/pxr.h>
+#if USD_VERSION_NUM < 2102
 #include <pxr/imaging/glf/glew.h>
+#else
+#include <pxr/imaging/garch/glApi.h>
+#endif
 
 #include "AL/maya/utils/CommandGuiHelper.h"
 #include "AL/maya/utils/MenuBuilder.h"
@@ -51,7 +56,6 @@
 #include <pxr/base/plug/registry.h>
 #include <pxr/imaging/glf/contextCaps.h>
 #include <pxr/imaging/glf/glContext.h>
-#include <pxr/pxr.h>
 
 #include <maya/MDrawRegistry.h>
 #include <maya/MGlobal.h>
@@ -171,7 +175,11 @@ global proc AL_usdmaya_meshAnimImport()
 //----------------------------------------------------------------------------------------------------------------------
 template <typename AFnPlugin> MStatus registerPlugin(AFnPlugin& plugin)
 {
+#if USD_VERSION_NUM < 2102
     GlfGlewInit();
+#else
+    GarchGLApiLoad();
+#endif
 
     // We may be in a non-gui maya... if so,
     // GlfContextCaps::InitInstance() will error

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -13,7 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+
+// GL loading library needs to be included before any other OpenGL headers.
+// We also disable clang-format for this block, since otherwise v10.0.0 fails
+// to recognize that "ProxyDrawOverride.h" is the related header.
+// clang-format off
+#include <pxr/pxr.h>
+#if USD_VERSION_NUM < 2102
 #include <pxr/imaging/glf/glew.h>
+#else
+#include <pxr/imaging/garch/glApi.h>
+#endif
+// clang-format on
 
 #include "AL/usdmaya/nodes/ProxyDrawOverride.h"
 


### PR DESCRIPTION
A few small changes here adapting to recent updates in `garch`, `glf`, and `hdSt` in core USD.

With core USD 21.02, the pxr imaging code no longer has a dependency on GLEW and instead uses its own GL loader in the `garch` library. Where code for USD prior to 21.02 would have called `GlfGlewInit()`, for 21.02 and later it should now call `GarchGLApiLoad()` instead. `GlfContextCaps::InitInstance()` calls `GarchGLApiLoad()` itself, so any calls of `GlfContextCaps::InitInstance()` do not need an additional load call.

Though it's not a strict requirement for `garch/glApi.h` to be included before any other GL header like it was for `glew.h`, our Hydra team tells me it's probably still good practice, so it was added to the highest priority group in the `clang-format` config.

Some UDIM texture utilities also moved from `glf` to `hdSt`, so the usage of that utility in `vp2RenderDelegate/material.cpp` was updated accordingly.