### PR TITLE
MAYA-106780  Layer Editor "Any Edits" query flag

### DIFF
--- a/lib/mayaUsd/commands/layerEditorCommand.h
+++ b/lib/mayaUsd/commands/layerEditorCommand.h
@@ -21,6 +21,7 @@
 
 #include <maya/MPxCommand.h>
 #include <maya/MString.h>
+#include <maya/MTypeId.h>
 
 #include <memory>
 #include <string>
@@ -45,6 +46,13 @@ public:
     MStatus undoIt() override;
     MStatus redoIt() override;
     bool    isUndoable() const override;
+
+    // Maya will query the Layer Editor to see if there are any unsaved changes
+    // before resetting the scene.  Plugins can register the MTypeId of the proxy
+    // shape node that they want to have the Layer Editor check for unsaved changes.
+    //
+    static void registerSceneResetCheckCallback(MTypeId nodeId);
+    static void deregisterSceneResetCheckCallback(MTypeId nodeId);
 
 private:
     MStatus parseArgs(const MArgList& argList);

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -316,6 +316,8 @@ MStatus initializePlugin(MObject obj)
     UsdMayaSceneResetNotice::InstallListener();
     UsdMayaDiagnosticDelegate::InstallDelegate();
 
+    MayaUsd::LayerEditorCommand::registerSceneResetCheckCallback(MayaUsd::ProxyShape::typeId);
+
     return status;
 }
 
@@ -397,6 +399,8 @@ MStatus uninitializePlugin(MObject obj)
 
     UsdMayaSceneResetNotice::RemoveListener();
     UsdMayaDiagnosticDelegate::RemoveDelegate();
+
+    MayaUsd::LayerEditorCommand::deregisterSceneResetCheckCallback(MayaUsd::ProxyShape::typeId);
 
     return status;
 }


### PR DESCRIPTION
Adding ability to register node id's with the Layer Editor so that Maya can determine that there are unsaved changes
Added a new flag on the Layer Editor command that Maya can query and then warn a user before resetting the scene.