### PR TITLE
MAYA-107303 - UFE: crash (debug only) with multiple UFE items in single string

### DIFF
--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -51,7 +51,7 @@ template <> struct iterator_traits<MStringArray::Iterator>
 #endif
 
 namespace {
-    static constexpr auto kIllegalUSDPath = "Illegal USD run-time path %s.";
+constexpr auto kIllegalUSDPath = "Illegal USD run-time path %s.";
 }
 
 namespace MAYAUSD_NS_DEF {

--- a/lib/mayaUsd/ufe/private/Utils.h
+++ b/lib/mayaUsd/ufe/private/Utils.h
@@ -29,22 +29,6 @@ namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
 //------------------------------------------------------------------------------
-// Private globals and macros
-//------------------------------------------------------------------------------
-const std::string kIllegalUSDPath = "Illegal USD run-time path %s.";
-
-#if !defined(NDEBUG)
-#define TEST_USD_PATH(SEG, PATH) \
-    assert(SEG.size() == 2);     \
-    if (SEG.size() != 2)         \
-        TF_WARN(kIllegalUSDPath.c_str(), PATH.string().c_str());
-#else
-#define TEST_USD_PATH(SEG, PATH) \
-    if (SEG.size() != 2)         \
-        TF_WARN(kIllegalUSDPath.c_str(), PATH.string().c_str());
-#endif
-
-//------------------------------------------------------------------------------
 // Private helper functions
 //------------------------------------------------------------------------------
 

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -41,7 +41,6 @@ set(TEST_SCRIPT_FILES
     testUsdExportSkeleton.py
     testUsdExportStripNamespaces.py
     testUsdExportStroke.py
-    testUsdExportUVTransforms.py
     testUsdExportVisibilityDefault.py
     testUsdImportCamera.py
     testUsdImportColorSets.py
@@ -71,6 +70,15 @@ set(TEST_SCRIPT_FILES
     testUsdMayaAdaptorMetadata.py
     testUsdMayaAdaptorUndoRedo.py
 )
+
+if(BUILD_PXR_PLUGIN)
+    # This test uses the file "UsdExportUVTransforms.ma" which
+    # requires the plugin "pxrUsdPreviewSurface" that is built by the
+    # Pixar plugin.
+    list(APPEND TEST_SCRIPT_FILES
+        testUsdExportUVTransforms.py
+    )
+endif()
 
 if (BUILD_RFM_TRANSLATORS)
     list(APPEND TEST_SCRIPT_FILES


### PR DESCRIPTION
#### MAYA-107303 - UFE: crash (debug only) in MEL parser with multiple UFE items in single string

* When asking for UsdPrim from Ufe Path we cannot assume the path is valid and therefore should not assert.