### PR TITLE
MAYA-95543: implement the local affine transformation matrix 

### DIFF
--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -201,6 +201,8 @@ Ufe::Matrix4d UsdTransform3d::matrix() const
     // Note: Gf matrices are row-major.
     // https://graphics.pixar.com/usd/docs/api/class_gf_matrix4d.html
     GfMatrix4d m(1);
+
+    // 4x4 local affine transformation matrix. 4th column of matrix is [0 0 0 1]
     if (!UsdGeomXformable::GetLocalTransformation(&m, ops, getTime(path()))) {
         TF_FATAL_ERROR(
             "Local transformation computation for prim %s failed.", prim().GetPath().GetText());

--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -198,6 +198,8 @@ Ufe::Matrix4d UsdTransform3d::matrix() const
     bool             unused;
     auto             ops = xformable.GetOrderedXformOps(&unused);
 
+    // Note: Gf matrices are row-major.
+    // https://graphics.pixar.com/usd/docs/api/class_gf_matrix4d.html
     GfMatrix4d m(1);
     if (!UsdGeomXformable::GetLocalTransformation(&m, ops, getTime(path()))) {
         TF_FATAL_ERROR(

--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -194,9 +194,17 @@ Ufe::SetMatrix4dUndoableCommand::Ptr UsdTransform3d::setMatrixCmd(const Ufe::Mat
 
 Ufe::Matrix4d UsdTransform3d::matrix() const
 {
-    // TODO: HS Aug25,2020 dummy code to pass the compiler errors
-    Ufe::Matrix4d m {};
-    return m;
+    UsdGeomXformable xformable(prim());
+    bool             unused;
+    auto             ops = xformable.GetOrderedXformOps(&unused);
+
+    GfMatrix4d m(1);
+    if (!UsdGeomXformable::GetLocalTransformation(&m, ops, getTime(path()))) {
+        TF_FATAL_ERROR(
+            "Local transformation computation for prim %s failed.", prim().GetPath().GetText());
+    }
+
+    return convertFromUsd(m);
 }
 #endif
 


### PR DESCRIPTION
Implement the 4x4 local affine transformation matrix for UsdTransform3d::matrix() accessor.