### PR TITLE
fix regex in testDiagnosticDelegate to handle varying ways of executing the test

### DIFF
--- a/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
+++ b/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
@@ -107,9 +107,20 @@ class testDiagnosticDelegate(unittest.TestCase):
         log = self._StopRecording()
         self.assertEqual(len(log), 1)
         logText, logCode = log[0]
+
+        # When this test is executed as a result of the unittest.main() call at
+        # the bottom of this file (e.g. when this script is executed directly
+        # via the shebang, when the script file is passed to a Python
+        # interpreter on the command-line, or when the script file's contents
+        # is read and executed through compile() and exec(), the module will be
+        # reported as "__main__". Otherwise, when this file is imported as a
+        # module and then executed using unittest.main(module=<module name>),
+        # the module name will match the file name and be reported as
+        # "testDiagnosticDelegate". We make the regex here recognize both
+        # cases.
         self.assertRegex(logText,
             "^Python coding error: blah -- Coding Error in "
-            "testDiagnosticDelegate\.testError at line [0-9]+ of ")
+            "(__main__|testDiagnosticDelegate)\.testError at line [0-9]+ of ")
         self.assertEqual(logCode, OM.MCommandMessage.kError)
 
     def testError_Python(self):


### PR DESCRIPTION
This is a follow-up fix to a change I made in #1042 that replaced the `__main__` module name included as part of a coding error message with `testDiagnosticDelegate` instead. While this is correct for the way the test is run using the mayaUsd CMake testing infrastructure, it is not correct in all cases.

When the test is executed as a result of the `unittest.main()` call at the bottom of the file (e.g. when the script is executed directly via its shebang, when the script file is passed to a Python interpreter on the command-line, or when the script file's contents is read and executed through `compile()` and `exec()`, the module will be reported as `__main__`. Otherwise, when the file is imported as a module and then executed using `unittest.main(module=<module name>)`, the module name will match the file name and be reported as `testDiagnosticDelegate`.

To preserve the extra detail in the test, the regex used to match against the exception message was updated to recognize both cases.