### PR TITLE
Fix issue where referenced scenes have incorrect UV set attribute name written out.

### DIFF
--- a/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
@@ -443,7 +443,9 @@ public:
 
             switch (splitName.size()) {
             case 3: _nodesWithUVInput.push_back(TfToken(splitName[1])); break;
-            default:  // NOTE: (yliangsiew) Means that we have a Maya node with a namespace/multiple namespaces.
+            default
+                : // NOTE: (yliangsiew) Means that we have a Maya node with a namespace/multiple
+                  // namespaces.
             {
                 std::string mayaNodeName = splitName[1];
                 for (size_t i = 2; i < splitName.size() - 1; ++i) {

--- a/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
@@ -443,13 +443,15 @@ public:
 
             switch (splitName.size()) {
             case 3: _nodesWithUVInput.push_back(TfToken(splitName[1])); break;
-            case 4: // NOTE: (yliangsiew) Means we have a Maya node already with a namespace.
+            default:  // NOTE: (yliangsiew) Means that we have a Maya node with a namespace/multiple namespaces.
             {
-                std::string nodeName = splitName[1] + ":" + splitName[2];
-                _nodesWithUVInput.push_back(TfToken(nodeName));
+                std::string mayaNodeName = splitName[1];
+                for (size_t i = 2; i < splitName.size() - 1; ++i) {
+                    mayaNodeName += ":" + splitName[i];
+                }
+                _nodesWithUVInput.push_back(TfToken(mayaNodeName));
                 break;
             }
-            default: break;
             }
         }
 

--- a/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
@@ -437,10 +437,20 @@ public:
         for (const UsdShadeInput& input : material.GetInputs()) {
             const UsdAttribute&      usdAttr = input.GetAttr();
             std::vector<std::string> splitName = usdAttr.SplitName();
-            if (splitName.size() != 3 || splitName[2] != _tokens->varname.GetString()) {
+            if (splitName.back() != _tokens->varname.GetString()) {
                 continue;
             }
-            _nodesWithUVInput.push_back(TfToken(splitName[1]));
+
+            switch (splitName.size()) {
+            case 3: _nodesWithUVInput.push_back(TfToken(splitName[1])); break;
+            case 4: // NOTE: (yliangsiew) Means we have a Maya node already with a namespace.
+            {
+                std::string nodeName = splitName[1] + ":" + splitName[2];
+                _nodesWithUVInput.push_back(TfToken(nodeName));
+                break;
+            }
+            default: break;
+            }
         }
 
         if (_nodesWithUVInput.empty()) {


### PR DESCRIPTION
Hi: 

This fixes an issue related to referenced Maya scenes being written out with the incorrect varname attribute for the UV set, as it is being determined incorrectly. You can reproduce the issue by attempting to export the cube in the Maya scene with the reference in it and looking at the resulting USDA (the correct file should have `map1` as its attribute name.)

Example:

```
        def Material "usdPreviewSurface1SG"
        {
            token inputs:usd_scene_orig:file1:varname = "map1"
            token outputs:surface.connect = </usd_scene_orig_pCube1/Looks/usdPreviewSurface1SG/usd_scene_orig_usdPreviewSurface1.outputs:surface>
```

This issue can be demonstrated with the following two scenes, which essentially amount to a single cube with a texture assigned, and then referenced in another scene:

[scenes.zip](https://github.com/Autodesk/maya-usd/files/5799217/scenes.zip)

If you then export the cube in the referenced scene, you get the following without this fix, and even if you have `MAYAUSD_EXPORT_MAP1_AS_PRIMARY_UV_SET` set appropriately:

```
        def Material "usdPreviewSurface1SG"
        {
            token inputs:usd_scene_orig:file1:varname = "st"
            token outputs:surface.connect = </usd_scene_orig_pCube1/Looks/usdPreviewSurface1SG/usd_scene_orig_usdPreviewSurface1.outputs:surface>
```

This is incorrect, and causes USDView to fail to resolve the texture and display it appropriately.

This fix brings up the issue of "how do we determine which is the correct UV set name to write out"? Since we can imagine a scenario like the following, where a shadingEngine could be assigned to multiple meshes; different meshes could then potentially have different data for their `currentUVset` plug; how would the exporter know which one to then use for writing out the `varname` attribute for the file node?

![image](https://user-images.githubusercontent.com/74624210/104257651-c9763f80-5432-11eb-905c-804ec452237b.png)

For now, however, we're fixing the most common case, where a single shadingEngine is associated with a single mesh and single usdPreviewSurface material.
