### PR TITLE
Custom layer data export

### DIFF
--- a/lib/mayaUsd/commands/baseExportCommand.cpp
+++ b/lib/mayaUsd/commands/baseExportCommand.cpp
@@ -161,6 +161,14 @@ MSyntax MayaUSDExportCommand::createSyntax()
         UsdMayaJobExportArgsTokens->staticSingleSample.GetText(),
         MSyntax::kBoolean);
 
+    syntax.addFlag(
+        kCustomLayerData,
+        UsdMayaJobExportArgsTokens->customLayerData.GetText(),
+        MSyntax::kString,
+        MSyntax::kString,
+        MSyntax::kString);
+    syntax.makeFlagMultiUse(UsdMayaJobExportArgsTokens->customLayerData.GetText());
+
     // These are additional flags under our control.
     syntax.addFlag(kFrameRangeFlag, kFrameRangeFlagLong, MSyntax::kDouble, MSyntax::kDouble);
     syntax.addFlag(kFrameStrideFlag, kFrameStrideFlagLong, MSyntax::kDouble);

--- a/lib/mayaUsd/commands/baseExportCommand.h
+++ b/lib/mayaUsd/commands/baseExportCommand.h
@@ -77,6 +77,7 @@ public:
     static constexpr auto kPythonPostCallbackFlag = "ppc";
     static constexpr auto kVerboseFlag = "v";
     static constexpr auto kStaticSingleSample = "sss";
+    static constexpr auto kCustomLayerData = "cld";
 
     // Short and Long forms of flags defined by this command itself:
     static constexpr auto kAppendFlag = "a";

--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -255,10 +255,21 @@ static VtDictionary _CustomLayerData(const VtDictionary& userArgs, const TfToken
                 TF_WARN("Could not parse '%s' as double", raw_value.c_str());
                 continue;
             }
+        } else if (type == "bool") {
+            m_value = m_value.toLowerCase();
+            if (m_value == "1" || m_value == "true") {
+                val = true;
+            } else if (m_value == "0" || m_value == "false"){
+                val = false;
+            } else {
+                TF_WARN("Could not parse '%s' as bool", raw_value.c_str());
+                continue;
+            }
         } else {
-            TF_WARN("Unsupported customLayerData type '%s' for '%s'", type.c_str(), key.c_str());
-            continue;
+                TF_WARN("Unsupported customLayerData type '%s' for '%s'", type.c_str(), key.c_str());
+                continue;
         }
+
 
         data[key] = val;
     }

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -88,6 +88,7 @@ TF_DECLARE_PUBLIC_TOKENS(
     (stripNamespaces) \
     (verbose) \
     (staticSingleSample) \
+    (customLayerData) \
     /* Special "none" token */ \
     (none) \
     /* renderLayerMode values */ \
@@ -185,6 +186,7 @@ struct UsdMayaJobExportArgs
     typedef std::map<std::string, std::string> ChaserArgs;
     const std::vector<std::string>             chaserNames;
     const std::map<std::string, ChaserArgs>    allChaserArgs;
+    const VtDictionary                         customLayerData;
 
     const std::string melPerFrameCallback;
     const std::string melPostCallback;

--- a/lib/mayaUsd/fileio/jobs/writeJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/writeJob.cpp
@@ -248,6 +248,11 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
         mJobCtx.mStage->SetFramesPerSecond(UsdMayaUtil::GetSceneMTimeUnitAsDouble());
     }
 
+    // Set the customLayerData on the layer
+    if (!mJobCtx.mArgs.customLayerData.empty()) {
+        mJobCtx.mStage->GetRootLayer()->SetCustomLayerData(mJobCtx.mArgs.customLayerData);
+    }
+
     // Setup the requested render layer mode:
     //     defaultLayer    - Switch to the default render layer before exporting,
     //                       then switch back afterwards (no layer switching if

--- a/test/lib/usd/translators/testUsdExportLayerAttributes.py
+++ b/test/lib/usd/translators/testUsdExportLayerAttributes.py
@@ -67,11 +67,14 @@ class testMayaUsdExportLayerAttributes(unittest.TestCase):
                                ["age", 10, "int"],
                                ["floaty", 0.1, "float"],
                                ["pi", math.pi, "double"],
+                               ["works", 1, "bool"],
+                               ["fail", False, "bool"],
                                # These should fail but continue
                                ["a", "0", "unknown"],
                                ["b", "b", "int"],
                                ["c", "c", "float"],
-                               ["d", "d", "double"]
+                               ["d", "d", "double"],
+                               ["e", "e", "bool"]
                            ])
 
         stage = Usd.Stage.Open(temp_file)
@@ -81,8 +84,10 @@ class testMayaUsdExportLayerAttributes(unittest.TestCase):
         self.assertEqual(data['age'], 10)
         self.assertAlmostEqual(data['floaty'], 0.1)
         self.assertAlmostEqual(data['pi'], math.pi)
+        self.assertTrue(data['works'])
+        self.assertFalse(data['fail'])
 
-        invalid = ('a', 'b', 'c', 'd')
+        invalid = ('a', 'b', 'c', 'd', 'e')
         for i in invalid:
             self.assertNotIn(i, data)
 

--- a/test/lib/usd/translators/testUsdExportLayerAttributes.py
+++ b/test/lib/usd/translators/testUsdExportLayerAttributes.py
@@ -57,6 +57,14 @@ class testMayaUsdExportLayerAttributes(unittest.TestCase):
             self.assertEqual(stage.GetTimeCodesPerSecond(), fps)
             self.assertEqual(stage.GetFramesPerSecond(), fps)
 
+    def test_customLayerData(self):
+        temp_file = os.path.join(self.temp_dir, 'test_customLayerData.usda')
+        cmds.mayaUSDExport(f=temp_file,
+                           customLayerData=[
+                               ["foo", "spam", "string"],
+                               ["eggs", "green", "string"]
+                           ])
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/usd/translators/testUsdExportLayerAttributes.py
+++ b/test/lib/usd/translators/testUsdExportLayerAttributes.py
@@ -19,6 +19,7 @@
 
 import os
 import unittest
+import math
 
 import fixturesUtils
 from maya import cmds
@@ -61,9 +62,29 @@ class testMayaUsdExportLayerAttributes(unittest.TestCase):
         temp_file = os.path.join(self.temp_dir, 'test_customLayerData.usda')
         cmds.mayaUSDExport(f=temp_file,
                            customLayerData=[
+                               # These should be successful
                                ["foo", "spam", "string"],
-                               ["eggs", "green", "string"]
+                               ["age", 10, "int"],
+                               ["floaty", 0.1, "float"],
+                               ["pi", math.pi, "double"],
+                               # These should fail but continue
+                               ["a", "0", "unknown"],
+                               ["b", "b", "int"],
+                               ["c", "c", "float"],
+                               ["d", "d", "double"]
                            ])
+
+        stage = Usd.Stage.Open(temp_file)
+        data = stage.GetRootLayer().customLayerData
+
+        self.assertEqual(data['foo'], 'spam')
+        self.assertEqual(data['age'], 10)
+        self.assertAlmostEqual(data['floaty'], 0.1)
+        self.assertAlmostEqual(data['pi'], math.pi)
+
+        invalid = ('a', 'b', 'c', 'd')
+        for i in invalid:
+            self.assertNotIn(i, data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Draft PR to aid this discussion https://github.com/Autodesk/maya-usd/discussions/896#discussioncomment-284792
Adds the ability for users to specify an array of triplets to be exported as customLayerData on the root layer.
Supports basic types like string, bool, int, float and double for now.