### PR TITLE
Added usdRender dependency.

### DIFF
--- a/lib/mayaUsd/CMakeLists.txt
+++ b/lib/mayaUsd/CMakeLists.txt
@@ -110,6 +110,7 @@ target_link_libraries(${PROJECT_NAME}
         usdImaging
         usdImagingGL
         usdLux
+        usdRender
         usdRi
         usdShade
         usdSkel


### PR DESCRIPTION
Adding dependency to usdRender. This change is mainly for Arnold team that rely on mayaUsd plugin to link against USD libraries. 