### PR TITLE
author kind=group on the UsdPrim created by the group command when its parent is in the model hierarchy

### DIFF
--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -50,6 +50,7 @@ if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
             UsdUndoCreateGroupCommand.cpp
             UsdUndoInsertChildCommand.cpp
             UsdUndoReorderCommand.cpp
+            UsdUndoSetKindCommand.cpp
             UsdUndoVisibleCommand.cpp
     )
     if(UFE_PREVIEW_VERSION_NUM GREATER_EQUAL 2022)
@@ -115,6 +116,7 @@ if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
         UsdUndoCreateGroupCommand.h
         UsdUndoInsertChildCommand.h
         UsdUndoReorderCommand.h
+        UsdUndoSetKindCommand.h
         UsdUndoVisibleCommand.h
     )
     # Why no if for UsdUIInfoHandler.h ?

--- a/lib/mayaUsd/ufe/UsdUndoSetKindCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoSetKindCommand.cpp
@@ -1,0 +1,62 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "UsdUndoSetKindCommand.h"
+
+#include <mayaUsd/undo/UsdUndoBlock.h>
+
+#include <pxr/base/tf/token.h>
+#include <pxr/usd/usd/modelAPI.h>
+#include <pxr/usd/usd/prim.h>
+
+#include <ufe/undoableCommand.h>
+
+#include <memory>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+UsdUndoSetKindCommand::UsdUndoSetKindCommand(
+    const PXR_NS::UsdPrim& prim,
+    const PXR_NS::TfToken& kind)
+    : Ufe::UndoableCommand()
+    , _prim(prim)
+    , _kind(kind)
+{
+}
+
+UsdUndoSetKindCommand::Ptr
+UsdUndoSetKindCommand::create(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& kind)
+{
+    if (!prim) {
+        return nullptr;
+    }
+
+    return std::make_shared<UsdUndoSetKindCommand>(prim, kind);
+}
+
+void UsdUndoSetKindCommand::execute()
+{
+    UsdUndoBlock undoBlock(&_undoableItem);
+
+    UsdModelAPI(_prim).SetKind(_kind);
+}
+
+void UsdUndoSetKindCommand::redo() { _undoableItem.redo(); }
+
+void UsdUndoSetKindCommand::undo() { _undoableItem.undo(); }
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdUndoSetKindCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoSetKindCommand.h
@@ -1,0 +1,66 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_UFE_USD_UNDO_SET_KIND_COMMAND_H
+#define MAYAUSD_UFE_USD_UNDO_SET_KIND_COMMAND_H
+
+#include <mayaUsd/base/api.h>
+#include <mayaUsd/undo/UsdUndoableItem.h>
+
+#include <pxr/base/tf/token.h>
+#include <pxr/usd/usd/prim.h>
+
+#include <ufe/undoableCommand.h>
+
+#include <memory>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+//! Undoable command for setting the kind metadata of a UsdPrim.
+class MAYAUSD_CORE_PUBLIC UsdUndoSetKindCommand : public Ufe::UndoableCommand
+{
+public:
+    using Ptr = std::shared_ptr<UsdUndoSetKindCommand>;
+
+    UsdUndoSetKindCommand(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& kind);
+    ~UsdUndoSetKindCommand() override = default;
+
+    UsdUndoSetKindCommand(const UsdUndoSetKindCommand&) = delete;
+    UsdUndoSetKindCommand& operator=(const UsdUndoSetKindCommand&) = delete;
+    UsdUndoSetKindCommand(UsdUndoSetKindCommand&&) = delete;
+    UsdUndoSetKindCommand& operator=(UsdUndoSetKindCommand&&) = delete;
+
+    //! Create a UsdUndoSetKindCommand object
+    static UsdUndoSetKindCommand::Ptr
+    create(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& kind);
+
+    void execute() override;
+    void undo() override;
+    void redo() override;
+
+private:
+    UsdPrim _prim;
+
+    TfToken _kind;
+
+    UsdUndoableItem _undoableItem;
+
+}; // UsdUndoSetKindCommand
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF
+
+#endif


### PR DESCRIPTION
Authoring the kind metadata on the group `Xform` prim ensures that the model hierarchy remains contiguous between the parent and children of the new group prim. Prims underneath the group prim may still be in the model hierarchy if they also have kind authored.

If the parent prim of the group prim is not part of the model hierarchy, no kind is authored on the group prim.

More info about model hierarchy can be found here:
https://graphics.pixar.com/usd/docs/USD-Glossary.html#USDGlossary-ModelHierarchy