### PR TITLE
re-add testUsdExportCamera translator test back to CMakeLists.txt

### DIFF
--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_SCRIPT_FILES
     testUsdExportAsClip.py
     testUsdExportBindTransform.py
     testUsdExportBlendshapes.py
+    testUsdExportCamera.py
     testUsdExportColorSets.py
     testUsdExportConnected.py
     testUsdExportDisplacement.py


### PR DESCRIPTION
This repairs some minor damage from the merge of PR #1016 where the new `testUsdExportBlendshapes` test replaced `testUsdExportCamera` rather than just being added:

https://github.com/Autodesk/maya-usd/commit/138c4f99dce5388f0e0a10e4dd18d14ed0149fb6#diff-59ba898f87ae0237808269ee377b8b6cfd9adec3bc66f81455b72ab6b31cc33d