### PR TITLE
Fix for Maya 2020 and compilation fixes for VS2015 when building without Qt

### DIFF
--- a/lib/mayaUsd/fileio/shading/shadingModeRegistry.h
+++ b/lib/mayaUsd/fileio/shading/shadingModeRegistry.h
@@ -178,6 +178,17 @@ public:
         TfToken importDescription;
         bool    hasExporter = false;
         bool    hasImporter = false;
+
+        ConversionInfo() = default;
+        ConversionInfo(TfToken rc, TfToken nn, TfToken ed, TfToken id, bool he, bool hi)
+            : renderContext(rc)
+            , niceName(nn)
+            , exportDescription(ed)
+            , importDescription(id)
+            , hasExporter(he)
+            , hasImporter(hi)
+        {
+        }
     };
 
     /// Gets the conversion information associated with \p materialConversion on export and import

--- a/lib/mayaUsd/render/mayaToHydra/renderGlobals.h
+++ b/lib/mayaUsd/render/mayaToHydra/renderGlobals.h
@@ -47,6 +47,14 @@ public:
         // If creating the attribute for the first time, immediately set to a user default
         const bool fallbackToUserDefaults = true;
         // TODO: Extend this and mtoh with a setting to ignore scene settings
+
+        GlobalParams() = default;
+        GlobalParams(const TfToken f, bool fir, bool ftud)
+            : filter(f)
+            , filterIsRenderer(fir)
+            , fallbackToUserDefaults(ftud)
+        {
+        }
     };
 
     // Creating render globals attributes on "defaultRenderGlobals"

--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -282,7 +282,8 @@ MayaSessionState::loadLayersUI(const QString& in_title, const std::string& in_de
         return std::vector<std::string>();
     else {
         std::vector<std::string> results;
-        for (const auto& file : files) {
+        for (uint32_t i = 0; i < files.length(); i++) {
+            const auto& file = files[i];
             results.push_back(file.asChar());
         }
         return results;

--- a/plugin/al/mayautils/AL/maya/utils/PluginTranslatorOptions.cpp
+++ b/plugin/al/mayautils/AL/maya/utils/PluginTranslatorOptions.cpp
@@ -258,7 +258,7 @@ void PluginTranslatorOptionsInstance::parse(MString key, const MString& value)
             if (opt->name == key) {
                 auto& optData = set.m_options[i];
                 switch (opt->type) {
-                case OptionType::kBool: optData.m_bool = value.asInt(); break;
+                case OptionType::kBool: optData.m_bool = (value.asInt() > 0); break;
                 case OptionType::kInt: optData.m_int = value.asInt(); break;
                 case OptionType::kEnum: optData.m_int = value.asInt(); break;
                 case OptionType::kFloat: optData.m_float = value.asFloat(); break;


### PR DESCRIPTION
We discovered that VS2015 wasn't well supported as part of https://github.com/Autodesk/maya-usd/issues/1087. This PR fixes the compilation error for Maya 2018 and some of the compilation errors when building with VS2015. The remaining compilation errors with VS2015 are related to `error C2872: 'uchar': ambiguous symbol` caused by:
```
\qt\5.6.1\14f946f\include\QtCore/qglobal.h(204): note: could be 'unsigned char uchar'
\Pixar_USD_VS2015\include\pxr/base/arch/inttypes.h(58): note: or       'pxrInternal_v0_21__pxrReserved__::uchar'
```