### PR TITLE
updates for building with latest post-21.02 dev branch commit of core USD

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -31,7 +31,7 @@ See Pixar's official github page for instructions on how to build USD: https://g
 
 |               |      ![](images/pxr.png)          |        
 |:------------: |:---------------:                  |
-|  CommitID/Tags | release: [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) or [v20.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.11) <br> dev: [5904885](https://github.com/PixarAnimationStudios/USD/commit/590488516d285de4352c96bd5a542f5c6a5829be) |
+|  CommitID/Tags | release: [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) or [v20.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.11) or [v21.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v21.02)<br> dev: [3378c5d](https://github.com/PixarAnimationStudios/USD/commit/3378c5dc17b24162db3d2fc05fe98ddacc475a6f) |
 
 For additional information on building Pixar USD, see the ***Additional Build Instruction*** section below.
 

--- a/lib/mayaUsd/fileio/shading/shadingModePxrRis.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModePxrRis.cpp
@@ -251,7 +251,7 @@ private:
                 = _ExportShadingNodeHelper(materialPrim, connectedDepFn, context, processedPaths)) {
                 UsdShadeConnectableAPI::ConnectToSource(
                     input,
-                    UsdShadeShader(cPrim),
+                    UsdShadeConnectableAPI(cPrim),
                     TfToken(UsdMayaShadingUtil::GetStandardAttrName(connectedPlug, false)));
             }
         }

--- a/lib/mayaUsd/fileio/utils/adaptor.cpp
+++ b/lib/mayaUsd/fileio/utils/adaptor.cpp
@@ -230,8 +230,6 @@ UsdMayaAdaptor::SchemaAdaptor UsdMayaAdaptor::GetSchemaByName(const TfToken& sch
     }
 #endif
 
-    // We shouldn't be able to reach this (everything is either typed or API).
-    TF_CODING_ERROR("'%s' isn't a known API or typed schema", schemaName.GetText());
     return SchemaAdaptor();
 }
 

--- a/lib/mayaUsd/render/mayaToHydra/shadingModeExporter.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/shadingModeExporter.cpp
@@ -118,7 +118,7 @@ protected:
             return UsdShadeConnectableAPI::ConnectToSource(input, output);
         }
         return UsdShadeConnectableAPI::ConnectToSource(
-            input, outputShader, relationship.inputName,
+            input, outputShader.ConnectableAPI(), relationship.inputName,
             UsdShadeAttributeType::Output, typeName);
     }
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -564,7 +564,11 @@ void HdVP2BasisCurves::Sync(
     const SdfPath& id = GetId();
 
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
+#if HD_API_VERSION < 37
         _SetMaterialId(delegate->GetRenderIndex().GetChangeTracker(), delegate->GetMaterialId(id));
+#else
+        SetMaterialId(delegate->GetMaterialId(id));
+#endif
     }
 
     if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->normals)

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -406,7 +406,11 @@ void HdVP2Mesh::Sync(
     const SdfPath& id = GetId();
 
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
+#if HD_API_VERSION < 37
         _SetMaterialId(delegate->GetRenderIndex().GetChangeTracker(), delegate->GetMaterialId(id));
+#else
+        SetMaterialId(delegate->GetMaterialId(id));
+#endif
     }
 
     if (HdChangeTracker::IsPrimvarDirty(*dirtyBits, id, HdTokens->normals)

--- a/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
@@ -63,7 +63,7 @@ inline const TfTokenVector& _SupportedSprimTypes()
  */
 inline const TfTokenVector& _SupportedBprimTypes()
 {
-    static const TfTokenVector r { HdPrimTypeTokens->texture };
+    static const TfTokenVector r {};
     return r;
 }
 
@@ -710,9 +710,6 @@ void HdVP2RenderDelegate::DestroySprim(HdSprim* sPrim) { delete sPrim; }
 HdBprim* HdVP2RenderDelegate::CreateBprim(const TfToken& typeId, const SdfPath& bprimId)
 {
     /*
-    if (typeId == HdPrimTypeTokens->texture) {
-        return new HdVP2Texture(this, bprimId);
-    }
     if (typeId == HdPrimTypeTokens->renderBuffer) {
         return new HdVP2RenderBuffer(bprimId);
     }
@@ -736,9 +733,6 @@ HdBprim* HdVP2RenderDelegate::CreateBprim(const TfToken& typeId, const SdfPath& 
 HdBprim* HdVP2RenderDelegate::CreateFallbackBprim(const TfToken& typeId)
 {
     /*
-    if (typeId == HdPrimTypeTokens->texture) {
-        return new HdVP2Texture(this, SdfPath::EmptyPath());
-    }
     if (typeId == HdPrimTypeTokens->renderBuffer) {
         return new HdVP2RenderBuffer(SdfPath::EmptyPath());
     }


### PR DESCRIPTION
Just a handful of small changes to conform to recent, post-21.02 changes in core USD. These should all be backwards compatible with all previous releases of core USD supported by maya-usd.

This is the first such update since the release of 21.02, so I also took this opportunity to add it to `doc/build.md`, along with updating the dev branch commit SHA.