### PR TITLE
fix typo in test - "mtoh" not "moth"

### DIFF
--- a/test/lib/mayaUsd/render/mayaToHydra/testMtohCommand.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/testMtohCommand.py
@@ -68,7 +68,7 @@ class TestCommand(unittest.TestCase):
     def test_getRendererDisplayName(self):
         # needs at least one arg
         self.assertRaises(RuntimeError, mel.eval,
-                          "moth -getRendererDisplayName")
+                          "mtoh -getRendererDisplayName")
 
         displayName = cmds.mtoh(renderer=mtohUtils.HD_STORM,
                                 getRendererDisplayName=True)


### PR DESCRIPTION
...never noticed because it was in a command that's SUPPOSED to error