### PR TITLE
[maya] error if unrecognized shadingMode on export

### DIFF
--- a/lib/mayaUsd/commands/baseExportCommand.cpp
+++ b/lib/mayaUsd/commands/baseExportCommand.cpp
@@ -17,6 +17,7 @@
 #include "baseExportCommand.h"
 
 #include <mayaUsd/fileio/jobs/jobArgs.h>
+#include <mayaUsd/fileio/shading/shadingModeRegistry.h>
 #include <mayaUsd/fileio/utils/writeUtil.h>
 
 #include <pxr/pxr.h>
@@ -210,6 +211,20 @@ MStatus MayaUSDExportCommand::doIt(const MArgList& args)
         // Check that all flags were valid
         if (status != MS::kSuccess) {
             return status;
+        }
+
+        if (argData.isFlagSet("shadingMode")) {
+            MString stringVal;
+            argData.getFlagArgument("shadingMode", 0, stringVal);
+            TfToken shadingMode(stringVal.asChar());
+
+            if (!shadingMode.IsEmpty()
+                && UsdMayaShadingModeRegistry::GetInstance().GetExporter(shadingMode) == nullptr
+                && shadingMode != UsdMayaShadingModeTokens->none) {
+                MGlobal::displayError(
+                    TfStringPrintf("No shadingMode '%s' found.", shadingMode.GetText()).c_str());
+                return MS::kFailure;
+            }
         }
 
         // Read all of the dictionary args first.

--- a/plugin/adsk/plugin/exportTranslator.cpp
+++ b/plugin/adsk/plugin/exportTranslator.cpp
@@ -101,6 +101,19 @@ MStatus UsdMayaExportTranslator::writer(
                     }
                 }
             } else {
+                if (argName == "shadingMode") {
+                    TfToken shadingMode(theOption[1].asChar());
+                    if (!shadingMode.IsEmpty()
+                        && UsdMayaShadingModeRegistry::GetInstance().GetExporter(shadingMode)
+                            == nullptr
+                        && shadingMode != UsdMayaShadingModeTokens->none) {
+
+                        MGlobal::displayError(
+                            TfStringPrintf("No shadingMode '%s' found.", shadingMode.GetText())
+                                .c_str());
+                        return MS::kFailure;
+                    }
+                }
                 userArgs[argName] = UsdMayaUtil::ParseArgumentValue(
                     argName,
                     theOption[1].asChar(),

--- a/plugin/pxr/maya/lib/usdMaya/exportTranslator.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/exportTranslator.cpp
@@ -76,6 +76,19 @@ MStatus UsdMayaExportTranslator::writer(
             } else if (argName == "filterTypes") {
                 theOption[1].split(',', filteredTypes);
             } else {
+                if (argName == "shadingMode") {
+                    TfToken shadingMode(theOption[1].asChar());
+                    if (!shadingMode.IsEmpty()
+                        && UsdMayaShadingModeRegistry::GetInstance().GetExporter(shadingMode)
+                            == nullptr
+                        && shadingMode != UsdMayaShadingModeTokens->none) {
+
+                        MGlobal::displayError(
+                            TfStringPrintf("No shadingMode '%s' found.", shadingMode.GetText())
+                                .c_str());
+                        return MS::kFailure;
+                    }
+                }
                 userArgs[argName] = UsdMayaUtil::ParseArgumentValue(
                     argName, theOption[1].asChar(), UsdMayaJobExportArgs::GetDefaultDictionary());
             }


### PR DESCRIPTION
We had a situation where shader exports were failing, but not being picked up as such, due to a mistyped shadingMode.

This will make the command error / fail if a bad shadingMode is requested