### PR TITLE
[usdMaya] add a root arg to usdExport

### DIFF
--- a/lib/mayaUsd/commands/baseExportCommand.cpp
+++ b/lib/mayaUsd/commands/baseExportCommand.cpp
@@ -115,6 +115,7 @@ MSyntax MayaUSDExportCommand::createSyntax()
         kExportReferenceObjectsFlag,
         UsdMayaJobExportArgsTokens->exportReferenceObjects.GetText(),
         MSyntax::kBoolean);
+    syntax.addFlag(kExportRootFlag, UsdMayaJobExportArgsTokens->root.GetText(), MSyntax::kString);
     syntax.addFlag(
         kExportSkelsFlag, UsdMayaJobExportArgsTokens->exportSkels.GetText(), MSyntax::kString);
     syntax.addFlag(
@@ -232,6 +233,22 @@ MStatus MayaUSDExportCommand::doIt(const MArgList& args)
             argData, UsdMayaJobExportArgs::GetDefaultDictionary());
 
         // Now read all of the other args that are specific to this command.
+        if (argData.isFlagSet("root")) {
+            MString stringVal;
+            argData.getFlagArgument("root", 0, stringVal);
+            std::string rootPath = stringVal.asChar();
+
+            if (!rootPath.empty()) {
+                MDagPath rootDagPath;
+                UsdMayaUtil::GetDagPathByName(rootPath, rootDagPath);
+                if (!rootDagPath.isValid()) {
+                    MGlobal::displayError(
+                        MString("Invalid dag path provided for root: ") + stringVal);
+                    return MS::kFailure;
+                }
+            }
+        }
+
         bool        append = false;
         std::string fileName;
 

--- a/lib/mayaUsd/commands/baseExportCommand.h
+++ b/lib/mayaUsd/commands/baseExportCommand.h
@@ -53,6 +53,7 @@ public:
     static constexpr auto kMergeTransformAndShapeFlag = "mt";
     static constexpr auto kStripNamespacesFlag = "sn";
     static constexpr auto kExportRefsAsInstanceableFlag = "eri";
+    static constexpr auto kExportRootFlag = "rt";
     static constexpr auto kExportDisplayColorFlag = "dsp";
     static constexpr auto kShadingModeFlag = "shd";
     static constexpr auto kConvertMaterialsToFlag = "cmt";

--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -314,6 +314,7 @@ UsdMayaJobExportArgs::UsdMayaJobExportArgs(
     , exportReferenceObjects(_Boolean(userArgs, UsdMayaJobExportArgsTokens->exportReferenceObjects))
     , exportRefsAsInstanceable(
           _Boolean(userArgs, UsdMayaJobExportArgsTokens->exportRefsAsInstanceable))
+    , exportRootPath(_String(userArgs, UsdMayaJobExportArgsTokens->root))
     , exportSkels(_Token(
           userArgs,
           UsdMayaJobExportArgsTokens->exportSkels,
@@ -391,6 +392,7 @@ std::ostream& operator<<(std::ostream& out, const UsdMayaJobExportArgs& exportAr
         << "exportNurbsExplicitUV: " << TfStringify(exportArgs.exportNurbsExplicitUV) << std::endl
         << "exportRefsAsInstanceable: " << TfStringify(exportArgs.exportRefsAsInstanceable)
         << std::endl
+        << "exportRootPath: " << exportArgs.exportRootPath << std::endl
         << "exportSkels: " << TfStringify(exportArgs.exportSkels) << std::endl
         << "exportSkin: " << TfStringify(exportArgs.exportSkin) << std::endl
         << "exportBlendShapes: " << TfStringify(exportArgs.exportBlendShapes) << std::endl
@@ -476,6 +478,7 @@ const VtDictionary& UsdMayaJobExportArgs::GetDefaultDictionary()
         d[UsdMayaJobExportArgsTokens->exportMaterialCollections] = false;
         d[UsdMayaJobExportArgsTokens->exportReferenceObjects] = false;
         d[UsdMayaJobExportArgsTokens->exportRefsAsInstanceable] = false;
+        d[UsdMayaJobExportArgsTokens->root] = std::string();
         d[UsdMayaJobExportArgsTokens->exportSkin] = UsdMayaJobExportArgsTokens->none.GetString();
         d[UsdMayaJobExportArgsTokens->exportSkels] = UsdMayaJobExportArgsTokens->none.GetString();
         d[UsdMayaJobExportArgsTokens->exportBlendShapes] = false;

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -85,6 +85,7 @@ TF_DECLARE_PUBLIC_TOKENS(
     (pythonPostCallback) \
     (renderableOnly) \
     (renderLayerMode) \
+    (root) \
     (shadingMode) \
     (convertMaterialsTo) \
     (stripNamespaces) \
@@ -148,16 +149,21 @@ struct UsdMayaJobExportArgs
     /// material-collections are created and bindings are made to the
     /// collections at \p materialCollectionsPath, instead of direct
     /// per-gprim bindings.
-    const bool        exportCollectionBasedBindings;
-    const bool        exportColorSets;
-    const bool        exportDefaultCameras;
-    const bool        exportDisplayColor;
-    const bool        exportInstances;
-    const bool        exportMaterialCollections;
-    const bool        exportMeshUVs;
-    const bool        exportNurbsExplicitUV;
-    const bool        exportReferenceObjects;
-    const bool        exportRefsAsInstanceable;
+    const bool exportCollectionBasedBindings;
+    const bool exportColorSets;
+    const bool exportDefaultCameras;
+    const bool exportDisplayColor;
+    const bool exportInstances;
+    const bool exportMaterialCollections;
+    const bool exportMeshUVs;
+    const bool exportNurbsExplicitUV;
+    const bool exportReferenceObjects;
+    const bool exportRefsAsInstanceable;
+
+    // Optionally specified path to use as top level prim in
+    // place of the scene root.
+    std::string exportRootPath;
+
     const TfToken     exportSkels;
     const TfToken     exportSkin;
     const bool        exportBlendShapes;

--- a/lib/mayaUsd/fileio/jobs/writeJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/writeJob.cpp
@@ -275,6 +275,12 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
             false);
     }
 
+    MDagPath curLeafDagPath;
+    MDagPath rootDagPath;
+    if (!mJobCtx._exportRootSdfPath.IsEmpty()) {
+        UsdMayaUtil::GetDagPathByName(mJobCtx.mArgs.exportRootPath, rootDagPath);
+    }
+
     // Pre-process the argument dagPath path names into two sets. One set
     // contains just the arg dagPaths, and the other contains all parents of
     // arg dagPaths all the way up to the world root. Partial path names are
@@ -295,6 +301,23 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
         std::string curDagPathStr(curDagPath.partialPathName(&status).asChar());
         if (status != MS::kSuccess) {
             continue;
+        }
+
+        // If we have an export root, check if this arg is either a parent or
+        // child of the root - if it's not, we ignore it
+        if (rootDagPath.isValid()) {
+            // If it's a parent of the exportRoot, we not only keep this node, we set
+            // it to be the curLeafDagPath - normally, we would set this while iterating
+            // through the dag tree, with itDag below, but if we have an export root,
+            // we might skip beneath all the mArgs.dagPaths... but we still
+            // need to set curLeafDagPath so we know we're underneath a
+            // requested path
+            if (MFnDagNode(rootDagPath).hasParent(curDagPath.node())) {
+                curLeafDagPath = curDagPath;
+            } else if (!(rootDagPath == curDagPath
+                         || MFnDagNode(curDagPath).hasParent(rootDagPath.node()))) {
+                continue;
+            }
         }
 
         argDagPaths.insert(curDagPathStr);
@@ -327,8 +350,24 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
 
     // Now do a depth-first traversal of the Maya DAG from the world root.
     // We keep a reference to arg dagPaths as we encounter them.
-    MDagPath curLeafDagPath;
-    for (MItDag itDag(MItDag::kDepthFirst, MFn::kInvalid); !itDag.isDone(); itDag.next()) {
+    MItDag itDag(MItDag::kDepthFirst, MFn::kInvalid);
+
+    if (rootDagPath.isValid()) {
+        // Check if there was no intersection between the given arg paths
+        // and the root dag path, and error if they don't overlap at all
+        if (argDagPaths.size() == 0) {
+            MGlobal::displayError("Given export root was neither a parent or child of"
+                                  " any of the items to export; export aborting");
+            return false;
+        }
+
+        // If a root is specified, start iteration there
+        MDagPath rootDagPath;
+        UsdMayaUtil::GetDagPathByName(mJobCtx.mArgs.exportRootPath, rootDagPath);
+        itDag.reset(rootDagPath, MItDag::kDepthFirst, MFn::kInvalid);
+    }
+
+    for (; !itDag.isDone(); itDag.next()) {
         MDagPath curDagPath;
         itDag.getPath(curDagPath);
         std::string curDagPathStr(curDagPath.partialPathName().asChar());
@@ -337,6 +376,16 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
             // This dagPath is a parent of one of the arg dagPaths. It should
             // be included in the export, but not necessarily all of its
             // children should be, so we continue to traverse down.
+            if (rootDagPath.isValid() && curDagPath.length() > 0) {
+                // However if an export root is specified, we skip any dag
+                // parents that are above that root.
+                SdfPath sdfDagPath = SdfPath(UsdMayaUtil::MDagPathToUsdPath(
+                    curDagPath, false, mJobCtx.mArgs.stripNamespaces));
+                if (mJobCtx._exportRootSdfPath.GetCommonPrefix(sdfDagPath)
+                    != mJobCtx._exportRootSdfPath) {
+                    continue;
+                }
+            }
         } else if (argDagPaths.find(curDagPathStr) != argDagPaths.end()) {
             // This dagPath IS one of the arg dagPaths. It AND all of its
             // children should be included in the export.

--- a/lib/mayaUsd/fileio/writeJobContext.h
+++ b/lib/mayaUsd/fileio/writeJobContext.h
@@ -219,6 +219,9 @@ private:
     // resolved in this map).
     std::map<std::string, UsdMayaPrimWriterRegistry::WriterFactoryFn> mWriterFactoryCache;
 
+    // Cache the conversion from string to SdfPath here
+    SdfPath _exportRootSdfPath;
+
     // UsdMaya_InstancedNodeWriter is in a separate file, but functions as
     // an internal helper for UsdMayaWriteJobContext.
     friend class UsdMaya_InstancedNodeWriter;

--- a/plugin/adsk/plugin/exportTranslator.cpp
+++ b/plugin/adsk/plugin/exportTranslator.cpp
@@ -100,6 +100,18 @@ MStatus UsdMayaExportTranslator::writer(
                         frameSamples.insert(samplesStrings[sam].asDouble());
                     }
                 }
+            } else if (argName == "root") {
+                std::string exportRootPath = theOption[1].asChar();
+                userArgs[argName] = VtValue(exportRootPath);
+                if (!exportRootPath.empty()) {
+                    MDagPath rootDagPath;
+                    UsdMayaUtil::GetDagPathByName(exportRootPath, rootDagPath);
+                    if (!rootDagPath.isValid()) {
+                        MGlobal::displayError(
+                            MString("Invalid dag path provided for root: ") + theOption[1]);
+                        return MS::kFailure;
+                    }
+                }
             } else {
                 if (argName == "shadingMode") {
                     TfToken shadingMode(theOption[1].asChar());

--- a/plugin/pxr/maya/lib/usdMaya/exportTranslator.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/exportTranslator.cpp
@@ -75,6 +75,18 @@ MStatus UsdMayaExportTranslator::writer(
                 frameStride = theOption[1].asDouble();
             } else if (argName == "filterTypes") {
                 theOption[1].split(',', filteredTypes);
+            } else if (argName == "root") {
+                std::string exportRootPath = theOption[1].asChar();
+                userArgs[argName] = VtValue(exportRootPath);
+                if (!exportRootPath.empty()) {
+                    MDagPath rootDagPath;
+                    UsdMayaUtil::GetDagPathByName(exportRootPath, rootDagPath);
+                    if (!rootDagPath.isValid()) {
+                        MGlobal::displayError(
+                            MString("Invalid dag path provided for root: ") + theOption[1]);
+                        return MS::kFailure;
+                    }
+                }
             } else {
                 if (argName == "shadingMode") {
                     TfToken shadingMode(theOption[1].asChar());

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TEST_SCRIPT_FILES
     # To avoid skipping and run in legacy render layer mode,
     # export MAYA_ENABLE_LEGACY_RENDER_LAYERS=1
     testUsdExportRenderLayerMode.py
+    testUsdExportRoot.py
     ## XXX: This test is disabled by default since it requires the RenderMan for Maya plugin.
     # testUsdExportRfMLight.py
     testUsdExportSelection.py

--- a/test/lib/usd/translators/UsdExportRootTest/UsdExportRootTest.ma
+++ b/test/lib/usd/translators/UsdExportRootTest/UsdExportRootTest.ma
@@ -1,0 +1,39 @@
+//Maya ASCII 2018 scene
+//Name: UsdExportRootTest.ma
+//Last modified: Fri, Apr 20, 2018 02:26:40 PM
+//Codeset: UTF-8
+requires maya "2018";
+currentUnit -l centimeter -a degree -t film;
+fileInfo "application" "maya";
+fileInfo "product" "Maya 2018";
+fileInfo "version" "2018";
+fileInfo "cutIdentifier" "201708311015-002f4fe637";
+fileInfo "osv" "Linux 3.10.0-514.6.1.el7.x86_64 #1 SMP Wed Jan 18 13:06:36 UTC 2017 x86_64";
+createNode transform -n "Top";
+	rename -uid "D0BBC940-0000-4EBB-5AD5-491C00000255";
+createNode transform -n "Mid" -p "Top";
+	rename -uid "D0BBC940-0000-4EBB-5AD5-491B00000254";
+createNode transform -n "Cube" -p "Mid";
+	rename -uid "D0BBC940-0000-4EBB-5AD5-491A00000253";
+createNode mesh -n "CubeShape" -p "Cube";
+	rename -uid "D0BBC940-0000-4EBB-5AD5-491A00000252";
+	setAttr -k off ".v";
+	setAttr ".vir" yes;
+	setAttr ".vif" yes;
+	setAttr ".uvst[0].uvsn" -type "string" "map1";
+	setAttr ".cuvs" -type "string" "map1";
+	setAttr ".dcc" -type "string" "Ambient+Diffuse";
+	setAttr ".covm[0]"  0 1 1;
+	setAttr ".cdvm[0]"  0 1 1;
+createNode transform -n "OtherLowest" -p "Mid";
+	rename -uid "BDCE9940-0000-7302-5ADA-417700000269";
+createNode transform -n "OtherMid" -p "Top";
+	rename -uid "BDCE9940-0000-7302-5ADA-416500000268";
+createNode transform -n "OtherTop";
+	rename -uid "BDCE9940-0000-7302-5ADA-3FAD00000267";
+createNode polyCube -n "polyCube1";
+	rename -uid "D0BBC940-0000-4EBB-5AD5-491A00000251";
+	setAttr ".cuv" 4;
+connectAttr "polyCube1.out" "CubeShape.i";
+connectAttr "CubeShape.iog" ":initialShadingGroup.dsm" -na;
+// End of UsdExportRootTest.ma

--- a/test/lib/usd/translators/testUsdExportRoot.py
+++ b/test/lib/usd/translators/testUsdExportRoot.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env mayapy
+#
+# Copyright 2018 Pixar
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import unittest
+
+from maya import cmds
+from maya import standalone
+
+from pxr import Usd
+from pxr import UsdGeom
+from pxr import Vt
+from pxr import Gf
+
+import fixturesUtils
+
+class testUsdExportRoot(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        inputPath = fixturesUtils.setUpClass(__file__)
+
+        filePath = os.path.join(inputPath, "UsdExportRootTest", "UsdExportRootTest.ma")
+        cmds.file(filePath, force=True, open=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+        
+    def doExportImportOneMethod(self, method, shouldError=False, root=None, selection=None):
+        name = 'UsdExportRoot_root-{root}_sel-{sel}'.format(root=root, sel=selection)
+        if method == 'cmd':
+            name += '.usda'
+        elif method == 'translator':
+            # the translator seems to be only able to export .usd - or at least,
+            # I couldn't find an option to do .usda instead...
+            name += '.usd'
+        usdFile = os.path.abspath(name)
+        
+        if method == 'cmd':
+            exportMethod = cmds.usdExport
+            args = ()
+            kwargs = {
+                'file': usdFile,
+                'mergeTransformAndShape': True,
+                'shadingMode': 'none',
+            }
+            if root:
+                kwargs['root'] = root
+            if selection:
+                kwargs['selection'] = 1
+                cmds.select(selection)
+        else:
+            exportMethod = cmds.file
+            args = (usdFile,)
+            kwargs = {
+                'type': 'USD Export',
+                'f': 1,
+            }
+            if root:
+                kwargs['options'] = 'root={}'.format(root)
+            if selection:
+                kwargs['exportSelected'] = 1
+            else:
+                kwargs['exportAll'] = 1
+
+        if shouldError:
+            self.assertRaises(RuntimeError, exportMethod, *args, **kwargs)
+            return
+        exportMethod(*args, **kwargs)
+        return Usd.Stage.Open(usdFile)
+        
+    def doExportImportTest(self, validator, shouldError=False, root=None, selection=None):
+        stage = self.doExportImportOneMethod('cmd', shouldError=shouldError,
+                                             root=root, selection=selection)
+        validator(stage)
+        stage = self.doExportImportOneMethod('translator', shouldError=shouldError,
+                                             root=root, selection=selection)
+        validator(stage)
+
+    def assertPrim(self, stage, path, type):
+        prim = stage.GetPrimAtPath(path)
+        self.assertTrue(prim.IsValid())
+        self.assertEqual(prim.GetTypeName(), type)
+
+    def assertNotPrim(self, stage, path):
+        self.assertFalse(stage.GetPrimAtPath(path).IsValid())
+
+    def testNonOverlappingSelectionRoot(self):
+        # test that the command errors if we give it a root + selection that
+        # have no intersection
+        def validator(stage):
+            pass
+        self.doExportImportTest(validator, shouldError=True, root='Mid', selection='OtherTop')
+
+    def testExportRoot_rootTop_selNone(self):
+        def validator(stage):
+            self.assertPrim(stage, '/Top/Mid/Cube', 'Mesh')
+            self.assertNotPrim(stage, '/OtherTop')
+            self.assertPrim(stage, '/Top/OtherMid', 'Xform')
+            self.assertPrim(stage, '/Top/Mid/OtherLowest', 'Xform')
+        self.doExportImportTest(validator, root='Top')
+
+    def testExportRoot_rootTop_selTop(self):
+        def validator(stage):
+            self.assertPrim(stage, '/Top/Mid/Cube', 'Mesh')
+            self.assertNotPrim(stage, '/OtherTop')
+            self.assertPrim(stage, '/Top/OtherMid', 'Xform')
+            self.assertPrim(stage, '/Top/Mid/OtherLowest', 'Xform')
+        self.doExportImportTest(validator, root='Top', selection='Top')
+
+    def testExportRoot_rootTop_selMid(self):
+        def validator(stage):
+            self.assertPrim(stage, '/Top/Mid/Cube', 'Mesh')
+            self.assertNotPrim(stage, '/OtherTop')
+            self.assertNotPrim(stage, '/Top/OtherMid')
+            self.assertPrim(stage, '/Top/Mid/OtherLowest', 'Xform')
+        self.doExportImportTest(validator, root='Top', selection='Mid')
+
+    def testExportRoot_rootTop_selCube(self):
+        def validator(stage):
+            self.assertPrim(stage, '/Top/Mid/Cube', 'Mesh')
+            self.assertNotPrim(stage, '/OtherTop')
+            self.assertNotPrim(stage, '/Top/OtherMid')
+            self.assertNotPrim(stage, '/Top/Mid/OtherLowest')
+        self.doExportImportTest(validator, root='Top', selection='Cube')
+
+    def testExportRoot_rootMid_selNone(self):
+        def validator(stage):
+            self.assertPrim(stage, '/Mid/Cube', 'Mesh')
+            self.assertNotPrim(stage, '/Top')
+            self.assertNotPrim(stage, '/OtherTop')
+            self.assertNotPrim(stage, '/OtherMid')
+            self.assertPrim(stage, '/Mid/OtherLowest', 'Xform')
+        self.doExportImportTest(validator, root='Mid')
+
+    def testExportRoot_rootMid_selTop(self):
+        def validator(stage):
+            self.assertPrim(stage, '/Mid/Cube', 'Mesh')
+            self.assertNotPrim(stage, '/Top')
+            self.assertNotPrim(stage, '/OtherTop')
+            self.assertNotPrim(stage, '/OtherMid')
+            self.assertPrim(stage, '/Mid/OtherLowest', 'Xform')
+        self.doExportImportTest(validator, root='Mid', selection='Top')
+
+    def testExportRoot_rootMid_selMid(self):
+        def validator(stage):
+            self.assertPrim(stage, '/Mid/Cube', 'Mesh')
+            self.assertNotPrim(stage, '/Top')
+            self.assertNotPrim(stage, '/OtherTop')
+            self.assertNotPrim(stage, '/OtherMid')
+            self.assertPrim(stage, '/Mid/OtherLowest', 'Xform')
+        self.doExportImportTest(validator, root='Mid', selection='Mid')
+
+    def testExportRoot_rootMid_selCube(self):
+        def validator(stage):
+            self.assertPrim(stage, '/Mid/Cube', 'Mesh')
+            self.assertNotPrim(stage, '/Top')
+            self.assertNotPrim(stage, '/OtherTop')
+            self.assertNotPrim(stage, '/OtherMid')
+            self.assertNotPrim(stage, '/Mid/OtherLowest')
+        self.doExportImportTest(validator, root='Mid', selection='Cube')
+
+    def testExportRoot_rootCube_selNone(self):
+        def validator(stage):
+            self.assertPrim(stage, '/Cube', 'Mesh')
+            self.assertNotPrim(stage, '/Top')
+            self.assertNotPrim(stage, '/Mid')
+            self.assertNotPrim(stage, '/OtherTop')
+            self.assertNotPrim(stage, '/OtherMid')
+            self.assertNotPrim(stage, '/OtherLowest')
+        self.doExportImportTest(validator, root='Cube')
+
+    def testExportRoot_rootCube_selTop(self):
+        def validator(stage):
+            self.assertPrim(stage, '/Cube', 'Mesh')
+            self.assertNotPrim(stage, '/Top')
+            self.assertNotPrim(stage, '/Mid')
+            self.assertNotPrim(stage, '/OtherTop')
+            self.assertNotPrim(stage, '/OtherMid')
+            self.assertNotPrim(stage, '/OtherLowest')
+        self.doExportImportTest(validator, root='Cube', selection='Top')
+
+    def testExportRoot_rootCube_selMid(self):
+        def validator(stage):
+            self.assertPrim(stage, '/Cube', 'Mesh')
+            self.assertNotPrim(stage, '/Top')
+            self.assertNotPrim(stage, '/Mid')
+            self.assertNotPrim(stage, '/OtherTop')
+            self.assertNotPrim(stage, '/OtherMid')
+            self.assertNotPrim(stage, '/OtherLowest')
+        self.doExportImportTest(validator, root='Cube', selection='Mid')
+
+    def testExportRoot_rootCube_selCube(self):
+        def validator(stage):
+            self.assertPrim(stage, '/Cube', 'Mesh')
+            self.assertNotPrim(stage, '/Top')
+            self.assertNotPrim(stage, '/Mid')
+            self.assertNotPrim(stage, '/OtherTop')
+            self.assertNotPrim(stage, '/OtherMid')
+            self.assertNotPrim(stage, '/OtherLowest')
+        self.doExportImportTest(validator, root='Cube', selection='Cube')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The root arg enables exporting sub trees of the maya scene without also including all the parent nodes.

ie, if you have this Maya path:

```
|top|mid|plant
```

...and wish to export starting at `plant`, so we end up with just

```
/plant
```

in USD, then you would set `root="|top|mid|plant"` at export.