### PR TITLE
MAYA-107554 - As a user, I'd like to see 'Revert to File' instead of …

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -285,12 +285,12 @@ void LayerTreeItem::discardEdits()
     } else {
         MString title;
         title.format(
-            StringResources::getAsMString(StringResources::kDiscardEditsTitle),
+            StringResources::getAsMString(StringResources::kRevertToFileTitle),
             MQtUtil::toMString(text()));
 
         MString desc;
         desc.format(
-            StringResources::getAsMString(StringResources::kDiscardEditsMsg),
+            StringResources::getAsMString(StringResources::kRevertToFileMsg),
             MQtUtil::toMString(text()));
 
         if (confirmDialog(MQtUtil::toQString(title), MQtUtil::toQString(desc))) {

--- a/lib/usd/ui/layerEditor/stringResources.h
+++ b/lib/usd/ui/layerEditor/stringResources.h
@@ -58,9 +58,9 @@ const auto kClearLayerConfirmMessage { create("kClearLayerConfirmMessage",
                                               " \"^1s\"  will remain in the Layer Editor"
                                               " but all contents will be cleared, including sublayer paths.") };
 const auto kCreate                   { create("kCreate", "Create") };
-const auto kDiscardEditsTitle        { create("kDiscardEditsTitle", "Discard Edits \"^1s\"") };
-const auto kDiscardEditsMsg          { create("kDiscardEditsMsg", "Are you sure you want to revert these edits?"
-                                                                  " \"^1s\" will revert to its state on disk") };
+const auto kRevertToFileTitle        { create("kRevertToFileTitle", "Revert to File \"^1s\"") };
+const auto kRevertToFileMsg          { create("kRevertToFileMsg", "Are you sure you want to revert \"^1s\" to its "
+                                               "state on disk? All edits will be discarded.") };
 const auto kHelp                     { create("kHelp", "Help") };
 const auto kHelpOnUSDLayerEditor     { create("kHelpOnUSDLayerEditor", "Help on USD Layer Editor") };
 const auto kLoadExistingLayer        { create("kLoadExistingLayer", "Load an Existing Layer") };

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
@@ -37,7 +37,7 @@ global proc mayaUSDRegisterStrings() {
     register("kMenuAddSublayer", "Add Sublayer");
     register("kMenuAddParentLayer", "Add Parent Layer");
     register("kMenuClear", "Clear");
-    register("kMenuDiscardEdits", "Discard Edits");
+    register("kMenuRevertToFile", "Revert to File");
     register("kMenuLoadSublayers", "Load Sublayers...");
     register("kMenuMute", "Mute");
     register("kMenuPrintToScriptEditor", "Print to Script Editor");

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -248,8 +248,7 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
     int $isSessionLayer = `mayaUsdLayerEditorWindow -q -isSessionLayer $panelName`;
     int $isAnonymousLayer = `mayaUsdLayerEditorWindow -q -isAnonymousLayer $panelName`;
     int $needsSaving = `mayaUsdLayerEditorWindow -q -layerNeedsSaving $panelName`;
-    int $singleSelect = `mayaUsdLayerEditorWindow -q -selectionLength $panelName` == 1;
-    int $isDirty = `mayaUsdLayerEditorWindow -q -isLayerDirty $panelName`;    
+    int $singleSelect = `mayaUsdLayerEditorWindow -q -selectionLength $panelName` == 1;  
     int $appearsMuted = `mayaUsdLayerEditorWindow -q -layerAppearsMuted $panelName`;
     int $isSubLayer = `mayaUsdLayerEditorWindow -q -isSubLayer $panelName`;
     int $isMuted = `mayaUsdLayerEditorWindow -q -layerIsMuted $panelName`;
@@ -269,11 +268,12 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
 
     }
 
-    $label = getMayaUsdString("kMenuDiscardEdits");
-    $cmd = makeCommand($panelName, "discardEdits");
-    $enabled = $isDirty;
-    menuItem -label $label -enable $enabled -c $cmd;
-    
+    if (!$isAnonymousLayer) {
+        $label = getMayaUsdString("kMenuRevertToFile");
+        $cmd = makeCommand($panelName, "discardEdits");
+        menuItem -label $label -c $cmd;
+    }    
+
     menuItem -divider 1;
 
     $label = getMayaUsdString("kMenuAddSublayer");
@@ -327,11 +327,9 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
     }
 
 
-    if (!$isAnonymousLayer) {
-        $label = getMayaUsdString("kMenuClear");
-        $cmd = makeCommand($panelName, "clearLayer");
-        $enabled = 1;
-        menuItem -label $label -enable $enabled -c $cmd;
-    }
+    $label = getMayaUsdString("kMenuClear");
+    $cmd = makeCommand($panelName, "clearLayer");
+    $enabled = 1;
+    menuItem -label $label -enable $enabled -c $cmd;
 }
 


### PR DESCRIPTION
…'Discard Edits'

- Rename context menu  'Discard Edits' to 'Revert to File'
- 'Revert to File' menu always enable for layer on disc no matter is the layer has edit or not.
- 'Revert to File' menu not available for anonynous layer.
- Make 'Clear' option available to for anonynous layer