### PR TITLE
Fixed crash caused by out of date stage map

### DIFF
--- a/lib/mayaUsd/ufe/StagesSubject.cpp
+++ b/lib/mayaUsd/ufe/StagesSubject.cpp
@@ -392,9 +392,9 @@ void StagesSubject::onStageSet(const MayaUsdProxyStageSetNotice& notice)
                 Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
             }
         }
+#endif
 
         fInvalidStages.clear();
-#endif
 
         stageSetGuardCount = false;
     }
@@ -404,14 +404,12 @@ void StagesSubject::onStageInvalidate(const MayaUsdProxyStageInvalidateNotice& n
 {
     afterOpen();
 
-#ifdef UFE_V2_FEATURES_AVAILABLE
     auto p = notice.GetProxyShape().ufePath();
     if (!p.empty()) {
         // We can't send notification to clients from dirty propagation.
         // Delay it till the new stage is actually set during compute.
         fInvalidStages.insert(p);
     }
-#endif
 }
 
 #ifdef UFE_V2_FEATURES_AVAILABLE

--- a/lib/mayaUsd/ufe/StagesSubject.cpp
+++ b/lib/mayaUsd/ufe/StagesSubject.cpp
@@ -120,7 +120,11 @@ StagesSubject::Ptr StagesSubject::create() { return TfCreateWeakPtr(new StagesSu
 
 bool StagesSubject::beforeNewCallback() const { return fBeforeNewCallback; }
 
-void StagesSubject::beforeNewCallback(bool b) { fBeforeNewCallback = b; }
+void StagesSubject::beforeNewCallback(bool b)
+{
+    fBeforeNewCallback = b;
+    fInvalidStages.clear();
+}
 
 /*static*/
 void StagesSubject::beforeNewCallback(void* clientData)
@@ -380,6 +384,18 @@ void StagesSubject::onStageSet(const MayaUsdProxyStageSetNotice& notice)
             fStageListeners[stage] = noticeKeys;
         }
 
+#ifdef UFE_V2_FEATURES_AVAILABLE
+        // Now we can send the notifications about stage change.
+        for (auto& path : fInvalidStages) {
+            Ufe::SceneItem::Ptr sceneItem = Ufe::Hierarchy::createItem(path);
+            if (sceneItem) {
+                Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
+            }
+        }
+
+        fInvalidStages.clear();
+#endif
+
         stageSetGuardCount = false;
     }
 }
@@ -391,10 +407,9 @@ void StagesSubject::onStageInvalidate(const MayaUsdProxyStageInvalidateNotice& n
 #ifdef UFE_V2_FEATURES_AVAILABLE
     auto p = notice.GetProxyShape().ufePath();
     if (!p.empty()) {
-        Ufe::SceneItem::Ptr sceneItem = Ufe::Hierarchy::createItem(p);
-        if (sceneItem) {
-            Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(sceneItem));
-        }
+        // We can't send notification to clients from dirty propagation.
+        // Delay it till the new stage is actually set during compute.
+        fInvalidStages.insert(p);
     }
 #endif
 }

--- a/lib/mayaUsd/ufe/StagesSubject.h
+++ b/lib/mayaUsd/ufe/StagesSubject.h
@@ -25,7 +25,10 @@
 #include <pxr/usd/usd/stage.h>
 
 #include <maya/MCallbackIdArray.h>
+#include <ufe/path.h>
 #include <ufe/ufe.h> // For UFE_V2_FEATURES_AVAILABLE
+
+#include <unordered_set>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -97,6 +100,15 @@ private:
     // Map of per-stage listeners, indexed by stage.
     typedef TfHashMap<UsdStageWeakPtr, NoticeKeys, TfHash> StageListenerMap;
     StageListenerMap                                       fStageListeners;
+
+    /*! \brief  Store invalidated ufe paths during dirty propagation.
+
+       We need to delay notification till stage changes, but at that time it could be too costly to
+       discover what changed in the stage map. Instead, we store all gateway notes that changed
+       during dirty propagation and send invalidation from compute, when the new stage is set. This
+       cache is only useful between onStageInvalidate and onStageSet notifications.
+    */
+    std::unordered_set<Ufe::Path> fInvalidStages;
 
     bool fBeforeNewCallback = false;
 


### PR DESCRIPTION
When using the `onStageInvalidate` notification, extra care has to be taken to NOT trigger any notification that would result in pulling on stage map. This notification is sent during dirty propagation, and we can't trigger compute from it (number one DG rule).
We didn't fully follow this rule and started to send `Ufe::SubtreeInvalidate`. One of the listeners, i.e. Outliner, was trying to refresh the tree by pulling on the list of stages. This caused a lack of refresh and what's more important, the potential use of released memory in future calls.

The fix is to delay this notification till later when we know the stage map has been already populated.