### PR TITLE
MAYA-109483 - Crash when removing an invalid layer

### DIFF
--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -143,7 +143,7 @@ public:
             auto subLayerHandle = SdfLayer::FindRelativeToLayer(layer, _subPath);
             auto stage = getStage();
             auto currentTarget = stage->GetEditTarget().GetLayer();
-            if (currentTarget
+            if (currentTarget && subLayerHandle
                 && currentTarget->GetIdentifier() == subLayerHandle->GetIdentifier()) {
                 _isEditTarget = true;
                 stage->SetEditTarget(stage->GetRootLayer());


### PR DESCRIPTION
Add a check for null pointer to avoid crash when removing invalid layer