### PR TITLE
Fixes related to export of skeleton rest-xforms

### DIFF
--- a/lib/usd/translators/jointWriter.cpp
+++ b/lib/usd/translators/jointWriter.cpp
@@ -259,6 +259,18 @@ bool _GetLocalTransformForDagPoseMember(
     MStatus status;
 
     MPlug xformMatrixPlug = dagPoseDep.findPlug("xformMatrix");
+    if (TfDebug::IsEnabled(PXRUSDMAYA_TRANSLATORS)) {
+        // As an extra debug sanity check, make sure that the logicalIndex
+        // already exists
+        MIntArray allIndices;
+        xformMatrixPlug.getExistingArrayAttributeIndices(allIndices);
+        if (std::find(allIndices.cbegin(), allIndices.cend(), logicalIndex) == allIndices.cend()) {
+            TfDebug::Helper().Msg(
+                "Warning - attempting to retrieve %s[%u], but that index did not exist yet",
+                xformMatrixPlug.name().asChar(),
+                logicalIndex);
+        }
+    }
     MPlug xformPlug = xformMatrixPlug.elementByLogicalIndex(logicalIndex, &status);
     CHECK_MSTATUS_AND_RETURN(status, false);
 

--- a/lib/usd/translators/jointWriter.cpp
+++ b/lib/usd/translators/jointWriter.cpp
@@ -241,10 +241,9 @@ static bool _FindDagPoseMembers(
     for (size_t i = 0; i < visitedIndices.size(); ++i) {
         uint8_t visited = visitedIndices[i];
         if (visited != 1) {
-            unsigned int index = (*indices)[i];
             TF_WARN(
                 "Node '%s' is not a member of dagPose '%s'.",
-                MFnDependencyNode(dagPaths[index].node()).name().asChar(),
+                MFnDependencyNode(dagPaths[i].node()).name().asChar(),
                 dagPoseDep.name().asChar());
             return false;
         }

--- a/lib/usd/translators/jointWriter.cpp
+++ b/lib/usd/translators/jointWriter.cpp
@@ -317,14 +317,13 @@ static bool _GetJointLocalRestTransformsFromDagPose(
     for (size_t i = 0; i < xforms->size(); ++i) {
         if (!_GetLocalTransformForDagPoseMember(
                 bindPoseDep, memberIndices[i], xforms->data() + i)) {
-            TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
-                .Msg(
-                    "%s -- Failed retrieving the local transform of joint '%s' "
-                    "from dagPose '%s': The Skeleton's 'restTransforms' "
-                    "property will be calculated from the 'bindTransforms'.",
-                    skelPath.GetText(),
-                    jointDagPaths[i].fullPathName().asChar(),
-                    bindPoseDep.name().asChar());
+            TF_WARN(
+                "%s -- Failed retrieving the local transform of joint '%s' "
+                "from dagPose '%s': The Skeleton's 'restTransforms' "
+                "property will be calculated from the 'bindTransforms'.",
+                skelPath.GetText(),
+                jointDagPaths[i].fullPathName().asChar(),
+                bindPoseDep.name().asChar());
             return false;
         }
     }

--- a/test/lib/usd/translators/UsdExportSkeletonTest/UsdExportSkeletonBindPoseMissingJoints.ma
+++ b/test/lib/usd/translators/UsdExportSkeletonTest/UsdExportSkeletonBindPoseMissingJoints.ma
@@ -1,0 +1,78 @@
+//Maya ASCII 2020 scene
+//Name: UsdExportSkeletonBindPoseMissingJoints.ma
+//Last modified: Wed, Jan 27, 2021 02:16:36 PM
+//Codeset: UTF-8
+requires maya "2020";
+requires "stereoCamera" "10.0";
+requires "stereoCamera" "10.0";
+currentUnit -l centimeter -a degree -t film;
+fileInfo "application" "maya";
+fileInfo "product" "Maya 2020";
+fileInfo "version" "2020";
+fileInfo "cutIdentifier" "202011110415-b1e20b88e2";
+fileInfo "osv" "Linux 3.10.0-1062.18.1.el7.x86_64 #1 SMP Tue Mar 17 23:49:17 UTC 2020 x86_64";
+fileInfo "UUID" "CA508C80-0000-5159-6011-E644000002A4";
+createNode transform -n "joint_grp";
+	rename -uid "716A8C80-0000-676C-6011-C976000006DF";
+createNode joint -n "joint1" -p "joint_grp";
+	rename -uid "716A8C80-0000-676C-6011-C839000006BD";
+	setAttr ".t" -type "double3" -0.13387224879650539 0.21395404220941927 0 ;
+	setAttr ".mnrl" -type "double3" -360 -360 -360 ;
+	setAttr ".mxrl" -type "double3" 360 360 360 ;
+	setAttr ".jo" -type "double3" 0 0 2.5352931362020645 ;
+	setAttr ".radi" 0.66868990097983616;
+createNode joint -n "joint2" -p "joint1";
+	rename -uid "716A8C80-0000-676C-6011-C83A000006BE";
+	setAttr ".t" -type "double3" 4.2613380856101655 8.8262730457699945e-15 0 ;
+	setAttr ".mnrl" -type "double3" -360 -360 -360 ;
+	setAttr ".mxrl" -type "double3" 360 360 360 ;
+	setAttr ".jo" -type "double3" 0 0 -50.479340742609303 ;
+	setAttr ".radi" 0.60456769613120953;
+createNode joint -n "joint3" -p "joint2";
+	rename -uid "716A8C80-0000-676C-6011-C83A000006BF";
+	setAttr ".t" -type "double3" 3.0216421252033836 6.6613381477509392e-16 0 ;
+	setAttr ".mnrl" -type "double3" -360 -360 -360 ;
+	setAttr ".mxrl" -type "double3" 360 360 360 ;
+	setAttr ".jo" -type "double3" 0 0 47.94404760640726 ;
+	setAttr ".radi" 0.60456769613120953;
+createNode joint -n "joint4" -p "joint2";
+	rename -uid "716A8C80-0000-676C-6011-C857000006C2";
+	setAttr ".t" -type "double3" 3.0216421252033836 1.7763568394002505e-15 0 ;
+	setAttr ".mnrl" -type "double3" -360 -360 -360 ;
+	setAttr ".mxrl" -type "double3" 360 360 360 ;
+	setAttr ".jo" -type "double3" 0 0 47.944047606407246 ;
+	setAttr ".radi" 0.60456769613120953;
+createNode dagPose -n "dagPose1";
+	rename -uid "716A8C80-0000-676C-6011-C87A000006C4";
+	setAttr -s 3 ".wm";
+	setAttr ".wm[0]" -type "matrix" 0.99902116331496138 0.044234774203348912 0 0 -0.044234774203348912 0.99902116331496138 0 0
+		 0 0 1 0 -0.13387224879650539 0.21395404220941927 0 1;
+	setAttr ".wm[1]" -type "matrix" 0.66985600785788646 -0.74249102939813039 0 0 0.74249102939813039 0.66985600785788646 0 0
+		 0 0 1 0 4.1232946827681127 0.40245337023052485 0 1;
+	setAttr ".wm[2]" -type "matrix" 1.0000000000000002 2.7755575615628914e-16 0 0 -2.7755575615628914e-16 1.0000000000000002 0 0
+		 0 0 1 0 6.1473598139320718 -1.8410888017844895 0 1;
+	setAttr -s 3 ".xm";
+	setAttr ".xm[0]" -type "matrix" "xform" 1 1 1 0 0 0 0 -0.13387224879650539
+		 0.21395404220941927 0 0 0 0 0 0 0 0 0 0 0
+		 0 0 0 0 0 0 0 0 1 0 0 0.022122801416622397 0.9997552608801219 1
+		 1 1 yes;
+	setAttr ".xm[1]" -type "matrix" "xform" 1 1 1 0 0 0 0 4.2613380856101655
+		 8.8262730457699945e-15 0 0 0 0 0 0 0 0 0 0 0
+		 0 0 0 0 0 0 0 0 1 0 0 -0.42640567234133786 0.90453203514034353 1
+		 1 1 yes;
+	setAttr ".xm[2]" -type "matrix" "xform" 1 1 1 0 0 0 0 3.0216421252033836
+		 6.6613381477509392e-16 0 0 0 0 0 0 0 0 0 0 0
+		 0 0 0 0 0 0 0 0 1 0 0 0.40629053160399503 0.91374394877829046 1
+		 1 1 yes;
+	setAttr -s 3 ".m";
+	setAttr -s 3 ".p";
+connectAttr "joint1.s" "joint2.is";
+connectAttr "joint2.s" "joint3.is";
+connectAttr "joint2.s" "joint4.is";
+connectAttr "joint1.msg" "dagPose1.m[0]";
+connectAttr "joint2.msg" "dagPose1.m[1]";
+connectAttr "joint3.msg" "dagPose1.m[2]";
+connectAttr "dagPose1.w" "dagPose1.p[0]";
+connectAttr "dagPose1.m[0]" "dagPose1.p[1]";
+connectAttr "dagPose1.m[1]" "dagPose1.p[2]";
+// End of UsdExportSkeletonBindPoseMissingJoints.ma

--- a/test/lib/usd/translators/UsdExportSkeletonTest/UsdExportSkeletonBindPoseSparseIndices.ma
+++ b/test/lib/usd/translators/UsdExportSkeletonTest/UsdExportSkeletonBindPoseSparseIndices.ma
@@ -1,0 +1,74 @@
+//Maya ASCII 2020 scene
+//Name: UsdExportSkeletonBindPoseSparseIndicesTest.ma
+//Last modified: Wed, Jan 27, 2021 02:16:36 PM
+//Codeset: UTF-8
+requires maya "2020";
+requires "stereoCamera" "10.0";
+requires "stereoCamera" "10.0";
+currentUnit -l centimeter -a degree -t film;
+fileInfo "application" "maya";
+fileInfo "product" "Maya 2020";
+fileInfo "version" "2020";
+fileInfo "cutIdentifier" "202011110415-b1e20b88e2";
+fileInfo "osv" "Linux 3.10.0-1062.18.1.el7.x86_64 #1 SMP Tue Mar 17 23:49:17 UTC 2020 x86_64";
+fileInfo "UUID" "CA508C80-0000-5159-6011-E644000002A4";
+createNode transform -n "joint_grp";
+	rename -uid "716A8C80-0000-676C-6011-C976000006DF";
+createNode joint -n "joint1" -p "joint_grp";
+	rename -uid "716A8C80-0000-676C-6011-C839000006BD";
+	setAttr ".t" -type "double3" -0.13387224879650539 0.21395404220941927 0 ;
+	setAttr ".mnrl" -type "double3" -360 -360 -360 ;
+	setAttr ".mxrl" -type "double3" 360 360 360 ;
+	setAttr ".jo" -type "double3" 0 0 2.5352931362020645 ;
+	setAttr ".radi" 0.66868990097983616;
+createNode joint -n "joint2" -p "joint1";
+	rename -uid "716A8C80-0000-676C-6011-C83A000006BE";
+	setAttr ".t" -type "double3" 4.2613380856101655 8.8262730457699945e-15 0 ;
+	setAttr ".mnrl" -type "double3" -360 -360 -360 ;
+	setAttr ".mxrl" -type "double3" 360 360 360 ;
+	setAttr ".jo" -type "double3" 0 0 -50.479340742609303 ;
+	setAttr ".radi" 0.60456769613120953;
+createNode joint -n "joint3" -p "joint2";
+	rename -uid "716A8C80-0000-676C-6011-C83A000006BF";
+	setAttr ".t" -type "double3" 3.0216421252033836 6.6613381477509392e-16 0 ;
+	setAttr ".mnrl" -type "double3" -360 -360 -360 ;
+	setAttr ".mxrl" -type "double3" 360 360 360 ;
+	setAttr ".jo" -type "double3" 0 0 47.94404760640726 ;
+	setAttr ".radi" 0.60456769613120953;
+createNode dagPose -n "dagPose1";
+	rename -uid "075DCC80-0000-2CD0-6011-F36F000002EA";
+	setAttr -s 3 ".wm";
+	setAttr ".wm[120]" -type "matrix" 1 0 0 0 0 1 0 0
+		 0 0 1 0 0 0 2 1;
+	setAttr ".wm[480]" -type "matrix" 1 0 0 0 0 1 0 0
+		 0 0 1 0 0 3 2 1;
+	setAttr ".wm[801]" -type "matrix" 1 0 0 0 0 1 0 0
+		 0 0 1 0 5 3 2 1;
+	setAttr -s 4 ".xm";
+	setAttr ".xm[0]" -type "matrix" "xform" 1 1 1 0 0 0 0 777
+		 888 999 0 0 0 0 0 0 0 0 0 0
+		 0 0 0 0 0 0 0 0 1 0 0 0 1 1
+		 1 1 yes;
+	setAttr ".xm[120]" -type "matrix" "xform" 1 1 1 0 0 0 0 0
+		 0 2 0 0 0 0 0 0 0 0 0 0
+		 0 0 0 0 0 0 0 0 1 0 0 0 1 1
+		 1 1 yes;
+	setAttr ".xm[480]" -type "matrix" "xform" 1 1 1 0 0 0 0 0
+		 3 0 0 0 0 0 0 0 0 0 0 0
+		 0 0 0 0 0 0 0 0 1 0 0 0 1 1
+		 1 1 yes;
+	setAttr ".xm[801]" -type "matrix" "xform" 1 1 1 0 0 0 0 5
+		 0 0 0 0 0 0 0 0 0 0 0 0
+		 0 0 0 0 0 0 0 0 1 0 0 0 1 1
+		 1 1 yes;
+	setAttr -s 3 ".m";
+	setAttr -s 3 ".p";
+connectAttr "joint1.s" "joint2.is";
+connectAttr "joint2.s" "joint3.is";
+connectAttr "joint1.msg" "dagPose1.m[120]";
+connectAttr "joint2.msg" "dagPose1.m[480]";
+connectAttr "joint3.msg" "dagPose1.m[801]";
+connectAttr "dagPose1.w" "dagPose1.p[120]";
+connectAttr "dagPose1.m[120]" "dagPose1.p[480]";
+connectAttr "dagPose1.m[480]" "dagPose1.p[801]";
+// End of UsdExportSkeletonBindPoseSparseIndicesTest.ma

--- a/test/lib/usd/translators/UsdExportSkeletonTest/UsdExportSkeletonNoDagPose.ma
+++ b/test/lib/usd/translators/UsdExportSkeletonTest/UsdExportSkeletonNoDagPose.ma
@@ -1,0 +1,47 @@
+//Maya ASCII 2020 scene
+//Name: UsdExportSkeletonNoDagPose.ma
+//Last modified: Wed, Jan 27, 2021 05:20:36 PM
+//Codeset: UTF-8
+requires maya "2020";
+requires "stereoCamera" "10.0";
+currentUnit -l centimeter -a degree -t film;
+fileInfo "application" "maya";
+fileInfo "product" "Maya 2020";
+fileInfo "version" "2020";
+fileInfo "cutIdentifier" "202011110415-b1e20b88e2";
+fileInfo "osv" "Linux 3.10.0-1062.18.1.el7.x86_64 #1 SMP Tue Mar 17 23:49:17 UTC 2020 x86_64";
+fileInfo "UUID" "075DCC80-0000-2CD0-6012-11640000043B";
+createNode transform -n "skel_root";
+	rename -uid "075DCC80-0000-2CD0-6012-11480000043A";
+createNode joint -n "joint1" -p "skel_root";
+	rename -uid "075DCC80-0000-2CD0-6012-0D7900000396";
+	addAttr -ci true -sn "liw" -ln "lockInfluenceWeights" -min 0 -max 1 -at "bool";
+	setAttr ".t" -type "double3" -8 1 7 ;
+	setAttr ".r" -type "double3" 0 60 0 ;
+	setAttr ".bps" -type "matrix" -1 0 0 0 0 1 0 0
+		 0 0 -1 0 0 0 0 1;
+createNode joint -n "joint2" -p "joint1";
+	rename -uid "075DCC80-0000-2CD0-6012-0D7E00000397";
+	addAttr -ci true -sn "liw" -ln "lockInfluenceWeights" -min 0 -max 1 -at "bool";
+	setAttr ".t" -type "double3" -3 0 1.23 ;
+	setAttr ".r" -type "double3" 30 0 0 ;
+	setAttr ".bps" -type "matrix" 0 -1 0 0 -1 0 0 0
+		 0 0 -1 0 3 0 0 1;
+createNode joint -n "joint3" -p "joint2";
+	rename -uid "075DCC80-0000-2CD0-6012-0D94000003A6";
+	addAttr -ci true -sn "liw" -ln "lockInfluenceWeights" -min 0 -max 1 -at "bool";
+	setAttr ".t" -type "double3" -5 5 13 ;
+	setAttr ".r" -type "double3" 45 0 45 ;
+	setAttr ".bps" -type "matrix" 0 -1 0 0 0 0 -1 0
+		 1 0 0 0 3 0 -2 1;
+createNode joint -n "joint4" -p "joint3";
+	rename -uid "075DCC80-0000-2CD0-6012-0E6A000003FD";
+	addAttr -ci true -sn "liw" -ln "lockInfluenceWeights" -min 0 -max 1 -at "bool";
+	setAttr ".t" -type "double3" 0 1.9999999999999998 4.4408920985006262e-16 ;
+	setAttr ".r" -type "double3" 90 0 0 ;
+	setAttr ".bps" -type "matrix" 0 -1 0 0 1 0 0 0
+		 0 0 1 0 3 0 -4 1;
+connectAttr "joint1.s" "joint2.is";
+connectAttr "joint2.s" "joint3.is";
+connectAttr "joint3.s" "joint4.is";
+// End of UsdExportSkeletonNoDagPose.ma

--- a/test/lib/usd/translators/UsdExportSkeletonTest/UsdExportSkeletonWithIdentityBindPose.ma
+++ b/test/lib/usd/translators/UsdExportSkeletonTest/UsdExportSkeletonWithIdentityBindPose.ma
@@ -1,5 +1,5 @@
 //Maya ASCII 2018ff08 scene
-//Name: UsdExportSkeletonWithoutBindPose.ma
+//Name: UsdExportSkeletonWithIdentityBindPose.ma
 //Last modified: Wed, Dec 19, 2018 05:34:34 PM
 //Codeset: UTF-8
 requires maya "2018ff08";
@@ -366,4 +366,4 @@ connectAttr "bindPose1.m[1]" "bindPose1.p[2]";
 connectAttr "joint1.bps" "bindPose1.wm[2]";
 connectAttr "defaultRenderLayer.msg" ":defaultRenderingList1.r" -na;
 connectAttr "pCubeShape1.iog" ":initialShadingGroup.dsm" -na;
-// End of UsdExportSkeletonWithoutBindPose.ma
+// End of UsdExportSkeletonWithIdentityBindPose.ma

--- a/test/lib/usd/translators/testUsdExportSkeleton.py
+++ b/test/lib/usd/translators/testUsdExportSkeleton.py
@@ -209,7 +209,7 @@ class testUsdExportSkeleton(unittest.TestCase):
 
     def testSkelRestXformsWithNoDagPose(self):
         """
-        Tests export of of rest xforms when there is no dagPose node at all.
+        Tests export of rest xforms when there is no dagPose node at all.
         """
         mayaFile = os.path.join(self.inputPath, "UsdExportSkeletonTest",
             "UsdExportSkeletonNoDagPose.ma")

--- a/test/lib/usd/translators/testUsdExportSkeleton.py
+++ b/test/lib/usd/translators/testUsdExportSkeleton.py
@@ -21,7 +21,7 @@ from maya import cmds
 from maya import standalone
 from maya.api import OpenMaya as OM
 
-from pxr import Gf, Sdf, Usd, UsdGeom, UsdSkel, Vt
+from pxr import Gf, Sdf, Tf, Usd, UsdGeom, UsdSkel, UsdUtils, Vt
 
 import fixturesUtils
 
@@ -235,7 +235,34 @@ class testUsdExportSkeleton(unittest.TestCase):
         for _ in range(5):
             cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFile,
                          shadingMode='none', exportSkels='auto', selection=True)
+            
+    def testSkelMissingJointFromDagPose(self):
+        """
+        Check that dagPoses that don't contain all desired joints issue an
+        appropriate warning
+        """
+        mayaFile = os.path.join(self.inputPath, "UsdExportSkeletonTest", "UsdExportSkeletonBindPoseMissingJoints.ma")
+        cmds.file(mayaFile, force=True, open=True)
 
+        usdFile = os.path.abspath('UsdExportBindPoseMissingJointsTest.usda')
+
+        joints = cmds.listRelatives('joint_grp', allDescendents=True, type='joint')
+        bindMembers = cmds.dagPose('dagPose1', q=1, members=1)
+        nonBindJoints = [j for j in joints if j not in bindMembers]
+        self.assertEqual(nonBindJoints, [u'joint4'])
+
+        delegate = UsdUtils.CoalescingDiagnosticDelegate()
+
+        cmds.select('joint_grp')
+        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFile, shadingMode='none',
+                           exportSkels='auto', selection=True)
+
+        messages = delegate.TakeUncoalescedDiagnostics()
+        warnings = [x.commentary for x in messages if x.diagnosticCode == Tf.TF_DIAGNOSTIC_WARNING_TYPE]
+        missingJointWarnings = [x for x in warnings if 'is not a member of dagPose' in x]
+        self.assertEqual(len(missingJointWarnings), 1)
+        self.assertIn("Node 'joint4' is not a member of dagPose 'dagPose1'",
+                      missingJointWarnings[0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some bugfixes for edge cases, and made it so that we export restXforms whenever we export bindXforms (ie, the restXforms are calculated from the bindXforms if present).

We were getting some errors in other tools if rest xforms weren't present (as well as an annoying warning/error from usdview, IIRC).