### PR TITLE
Use data model undo framework for attribute undo.

### DIFF
--- a/lib/mayaUsd/ufe/UsdAttribute.h
+++ b/lib/mayaUsd/ufe/UsdAttribute.h
@@ -92,9 +92,10 @@ public:
     UFE_ATTRIBUTE_OVERRIDES
 
     // Ufe::AttributeEnumString overrides
-    std::string get() const override;
-    void        set(const std::string& value) override;
-    EnumValues  getEnumValues() const override;
+    std::string               get() const override;
+    void                      set(const std::string& value) override;
+    Ufe::UndoableCommand::Ptr setCmd(const std::string& value) override;
+    EnumValues                getEnumValues() const override;
 }; // UsdAttributeEnumString
 
 //! \brief Internal helper template class to implement the get/set methods from Ufe::TypeAttribute.
@@ -110,8 +111,9 @@ public:
     UFE_ATTRIBUTE_OVERRIDES
 
     // Ufe::TypedAttribute overrides
-    T    get() const override;
-    void set(const T& value) override;
+    T                         get() const override;
+    void                      set(const T& value) override;
+    Ufe::UndoableCommand::Ptr setCmd(const T& value) override;
 }; // TypedUsdAttribute
 
 //! \brief Interface for USD bool attributes.


### PR DESCRIPTION
UsdAttribute derived classes were not overriding the Ufe::Attribute::setCmd() virtual.  This meant that we were using the implementation from UFE, rather than our new, data model correct undo system.  This was bad in two ways:
- The UFE implementation only does value undo, not data model undo
- It uses the Ufe::Attribute to set the previous value, and in our implementation this Ufe::Attribute stores a UsdPrim that can become stale, as per the Autodesk MAYA-109522 internal bug.
Now fixed, with an automated test to validate the fix.