### PR TITLE
MAYA-104490 Geom subset support for meshes.

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1262,7 +1262,7 @@ void HdVP2BasisCurves::_UpdateDrawItem(
         MProfilingScope profilingScope(
             HdVP2RenderDelegate::sProfilerCategory,
             MProfiler::kColorC_L2,
-            drawItem->GetRenderItemName().asChar(),
+            drawItem->GetDrawItemName().asChar(),
             "Commit");
 
         const HdVP2DrawItem::RenderItemData& drawItemData = stateToCommit._drawItemData;
@@ -1560,7 +1560,7 @@ void HdVP2BasisCurves::_InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBit
             = std::make_unique<HdVP2DrawItem>(_delegate, &_sharedData);
 #endif
 
-        const MString& renderItemName = drawItem->GetRenderItemName();
+        const MString& renderItemName = drawItem->GetDrawItemName();
 
         MHWRender::MRenderItem* renderItem = nullptr;
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/draw_item.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/draw_item.cpp
@@ -25,21 +25,20 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 Data holder for its corresponding render item to facilitate parallelized evaluation.
 */
-HdVP2DrawItem::HdVP2DrawItem(HdVP2RenderDelegate* delegate, const HdRprimSharedData* sharedData)
+HdVP2DrawItem::HdVP2DrawItem(
+    HdVP2RenderDelegate*     delegate,
+    const HdRprimSharedData* sharedData)
     : HdDrawItem(sharedData)
     , _delegate(delegate)
 {
     // In the case of instancing, the ID of a proto has an attribute at the end,
-    // we keep this info in _renderItemName so if needed we can extract proto ID
+    // we keep this info in _drawItemName so if needed we can extract proto ID
     // and use it to figure out Rprim path for each instance. For example:
     //
     //   "/Proxy/TreePatch/Tree_1.proto_leaves_id0"
     //
-    _renderItemName = GetRprimID().GetText();
-    _renderItemName += TfStringPrintf("/DrawItem_%p", this).c_str();
-
-    _renderItemData._indexBuffer.reset(
-        new MHWRender::MIndexBuffer(MHWRender::MGeometry::kUnsignedInt32));
+    _drawItemName = GetRprimID().GetText();
+    _drawItemName += TfStringPrintf("/DrawItem_%p", this).c_str();
 }
 
 //! \brief  Destructor.
@@ -52,6 +51,25 @@ HdVP2DrawItem::~HdVP2DrawItem()
             subSceneContainer->remove(GetRenderItemName());
         }
     }
+}
+
+void HdVP2DrawItem::AddRenderItem(
+    MHWRender::MRenderItem* item,
+    const HdGeomSubset*     geomSubset)
+{
+    _renderItems.push_back(RenderItemData());
+    RenderItemData& renderItemData = _renderItems.back();
+
+    renderItemData._renderItem = item;
+    renderItemData._renderItemName = _drawItemName;
+    if (geomSubset)
+    {
+        renderItemData._geomSubset = *geomSubset;
+        renderItemData._renderItemName += geomSubset->id.GetString().c_str();
+    }
+
+    renderItemData._indexBuffer.reset(
+        new MHWRender::MIndexBuffer(MHWRender::MGeometry::kUnsignedInt32));
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
@@ -16,6 +16,7 @@
 #ifndef HD_VP2_MESH
 #define HD_VP2_MESH
 
+#include "draw_item.h"
 #include "meshViewportCompute.h"
 
 #include <mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h>
@@ -59,6 +60,12 @@ struct HdVP2MeshSharedData
     //! for efficient GPU rendering.
     HdMeshTopology _renderingTopology;
 
+    //! triangulation of the _renderingTopology
+    VtVec3iArray _trianglesFaceVertexIndices;
+
+    //! triangleId to faceId of _trianglesFaceVertexIndices
+    VtIntArray _primitiveParam;
+
     //! An array to store original scene face vertex index of each rendering
     //! face vertex index.
     VtIntArray _renderingToSceneFaceVtxIds;
@@ -69,6 +76,10 @@ struct HdVP2MeshSharedData
     //! An array to store a rendering face vertex index for each original scene
     //! face vertex index.
     std::vector<int> _sceneToRenderingFaceVtxIds;
+
+    //! Map from the original topology faceId to the void* pointer to the MRenderItem
+    //! that face is a part of
+    std::vector<void *> _faceIdToRenderItem;
 
     //! A local cache of primvar scene data. "data" is a copy-on-write handle to
     //! the actual primvar buffer, and "interpolation" is the interpolation mode
@@ -136,6 +147,7 @@ private:
     void _UpdateDrawItem(
         HdSceneDelegate*,
         HdVP2DrawItem*,
+        HdVP2DrawItem::RenderItemData&,
         const HdMeshReprDesc& desc,
         bool                  requireSmoothNormals,
         bool                  requireFlatNormals);
@@ -146,6 +158,8 @@ private:
         HdSceneDelegate*     sceneDelegate,
         HdDirtyBits          dirtyBits,
         const TfTokenVector& requiredPrimvars);
+
+    void _CreateSmoothHullRenderItems(HdVP2DrawItem& drawItem);
 
     MHWRender::MRenderItem* _CreateSelectionHighlightRenderItem(const MString& name) const;
     MHWRender::MRenderItem* _CreateSmoothHullRenderItem(const MString& name) const;


### PR DESCRIPTION
This represents a pretty fundamental shift in how HdDrawItem maps to MRenderItem, so I'm expecting a lengthy review.

I'm still having trouble with Apple ARkit stratocaster.usdz, investigation of that is still ongoing. Other scenes with simpler materials work fine, and instancing + geom subsets works.

The performance of this version is not great. Each geom subset material binding causes every geometry stream which is not positions to get duplicated. So If you have a mesh with 100 materials on it, you'll have 100 copies of the full MVertexBuffer for the positions. It is 100% possible to re-use buffers between the items, but it requires a pretty significant refactor of HdVP2Mesh::_UpdateRepr and _UpdateDrawItem which is not going to fit in the time I have remaining for this issue.

Once the data is created in the VP2RenderDelegate the performance is the same as what we'd expect in the future.