### PR TITLE
move minimum core usd version to v20.02

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ include(cmake/utils.cmake)
 include(cmake/jinja.cmake)
 
 find_package(Maya 2018 REQUIRED)
-find_package(USD REQUIRED)
+find_package(USD 0.20.02 REQUIRED)
 include(cmake/usd.cmake)
 include(${USD_CONFIG_FILE})
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -31,7 +31,7 @@ See Pixar's official github page for instructions on how to build USD: https://g
 
 |               |      ![](images/pxr.png)          |        
 |:------------: |:---------------:                  |
-|  CommitID/Tags | release: [v19.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v19.11) or [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) or [v20.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.11) or [v21.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v21.02)<br> dev: [3378c5d](https://github.com/PixarAnimationStudios/USD/commit/3378c5dc17b24162db3d2fc05fe98ddacc475a6f) |
+|  CommitID/Tags | release: [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) or [v20.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.11) or [v21.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v21.02)<br> dev: [3378c5d](https://github.com/PixarAnimationStudios/USD/commit/3378c5dc17b24162db3d2fc05fe98ddacc475a6f) |
 
 For additional information on building Pixar USD, see the ***Additional Build Instruction*** section below.
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -31,7 +31,7 @@ See Pixar's official github page for instructions on how to build USD: https://g
 
 |               |      ![](images/pxr.png)          |        
 |:------------: |:---------------:                  |
-|  CommitID/Tags | release: [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) or [v20.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.11) or [v21.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v21.02)<br> dev: [3378c5d](https://github.com/PixarAnimationStudios/USD/commit/3378c5dc17b24162db3d2fc05fe98ddacc475a6f) |
+|  CommitID/Tags | release: [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) or [v20.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.11) or [v21.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v21.02)<br> dev: [82dd40a](https://github.com/PixarAnimationStudios/USD/commit/82dd40ad31bcdecfb18c2f23e39a3ddf68ef10d4) |
 
 For additional information on building Pixar USD, see the ***Additional Build Instruction*** section below.
 

--- a/lib/mayaUsd/render/mayaToHydra/renderGlobals.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderGlobals.cpp
@@ -83,7 +83,7 @@ global proc mtohRenderOverride_AddMTOHAttributes(int $fromAE) {
     mtohRenderOverride_AddAttribute("mtoh", "Highlight outline (in pixels, 0 to disable)", "mtohSelectionOutline", $fromAE);
 )mel"
 #endif
-#if USD_VERSION_NUM > 1911 && USD_VERSION_NUM <= 2005
+#if USD_VERSION_NUM <= 2005
                                           R"mel(
     mtohRenderOverride_AddAttribute("mtoh", "Enable color quantization", "mtohColorQuantization", $fromAE);
 )mel"
@@ -859,7 +859,7 @@ MObject MtohRenderGlobals::CreateAttributes(const GlobalParams& params)
             node, filter.mayaString(), defGlobals.outlineSelectionWidth, userDefaults);
     }
 #endif
-#if USD_VERSION_NUM > 1911 && USD_VERSION_NUM <= 2005
+#if USD_VERSION_NUM <= 2005
     if (filter(_tokens->mtohColorQuantization)) {
         _CreateBoolAttribute(
             node, filter.mayaString(), defGlobals.enableColorQuantization, userDefaults);
@@ -1021,7 +1021,7 @@ MtohRenderGlobals::GetInstance(const GlobalParams& params, bool storeUserSetting
         }
     }
 #endif
-#if USD_VERSION_NUM > 1911 && USD_VERSION_NUM <= 2005
+#if USD_VERSION_NUM <= 2005
     if (filter(_tokens->mtohColorQuantization)) {
         _GetAttribute(node, filter.mayaString(), globals.enableColorQuantization, storeUserSetting);
         if (filter.attributeFilter()) {

--- a/lib/mayaUsd/render/mayaToHydra/renderGlobals.h
+++ b/lib/mayaUsd/render/mayaToHydra/renderGlobals.h
@@ -100,7 +100,7 @@ public:
 #if USD_VERSION_NUM >= 2005
     float outlineSelectionWidth = 4.f;
 #endif
-#if USD_VERSION_NUM > 1911 && USD_VERSION_NUM <= 2005
+#if USD_VERSION_NUM <= 2005
     float enableColorQuantization = false;
 #endif
 };

--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
@@ -969,7 +969,8 @@ bool MtohRenderOverride::select(
 
     // Execute picking tasks.
     HdTaskSharedPtrVector pickingTasks = _taskController->GetPickingTasks();
-    _engine.SetTaskContextData(HdxPickTokens->pickParams, VtValue(pickParams));
+    VtValue               pickParamsValue(pickParams);
+    _engine.SetTaskContextData(HdxPickTokens->pickParams, pickParamsValue);
     _engine.Execute(_taskController->GetRenderIndex(), &pickingTasks);
 
     if (pointSnappingActive) {

--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
@@ -467,18 +467,10 @@ MStatus MtohRenderOverride::Render(const MHWRender::MDrawContext& drawContext)
         drawContext.getRenderTargetSize(width, height);
 
         GfVec4d viewport(originX, originY, width, height);
-#if USD_VERSION_NUM >= 1910
         _taskController->SetFreeCameraMatrices(
-#else
-        _taskController->SetCameraMatrices(
-#endif // USD_VERSION_NUM >= 1910
             GetGfMatrixFromMaya(drawContext.getMatrix(MHWRender::MFrameContext::kViewMtx)),
             GetGfMatrixFromMaya(drawContext.getMatrix(MHWRender::MFrameContext::kProjectionMtx)));
-#if USD_VERSION_NUM >= 1910
         _taskController->SetRenderViewport(viewport);
-#else
-        _taskController->SetCameraViewport(viewport);
-#endif // USD_VERSION_NUM >= 1910
 
         HdTaskSharedPtrVector tasks = _taskController->GetRenderingTasks();
 
@@ -588,7 +580,7 @@ MStatus MtohRenderOverride::Render(const MHWRender::MDrawContext& drawContext)
     } else
         _taskController->SetSelectionEnableOutline(false);
 #endif
-#if USD_VERSION_NUM > 1911 && USD_VERSION_NUM <= 2005
+#if USD_VERSION_NUM <= 2005
     _taskController->SetColorizeQuantizationEnabled(_globals.enableColorQuantization);
 #endif
 

--- a/lib/mayaUsd/render/mayaToHydra/tokens.h
+++ b/lib/mayaUsd/render/mayaToHydra/tokens.h
@@ -21,15 +21,9 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#if USD_VERSION_NUM >= 1910
-#define HD_STORM_PLUGIN_NAME "HdStormRendererPlugin"
-#else
-#define HD_STORM_PLUGIN_NAME "HdStreamRendererPlugin"
-#endif
-
 // clang-format off
 #define MTOH_TOKENS \
-    ((HdStormRendererPlugin, HD_STORM_PLUGIN_NAME)) \
+    (HdStormRendererPlugin) \
     (mtohMaximumShadowMapResolution)
 // clang-format on
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -792,7 +792,6 @@ const HdxPickHitVector* UsdMayaGLBatchRenderer::TestIntersection(
         for (const HdxPickHit& hit : *hitSet) {
             TF_DEBUG(PXRUSDMAYAGL_BATCHED_SELECTION)
                 .Msg(
-#if USD_VERSION_NUM > 1911
                     "        HIT:\n"
                     "            delegateId      : %s\n"
                     "            objectId        : %s\n"
@@ -800,15 +799,6 @@ const HdxPickHitVector* UsdMayaGLBatchRenderer::TestIntersection(
                     hit.delegateId.GetText(),
                     hit.objectId.GetText(),
                     hit.normalizedDepth);
-#else
-                    "        HIT:\n"
-                    "            delegateId: %s\n"
-                    "            objectId  : %s\n"
-                    "            ndcDepth  : %f\n",
-                    hit.delegateId.GetText(),
-                    hit.objectId.GetText(),
-                    hit.ndcDepth);
-#endif
         }
     }
 
@@ -898,7 +888,6 @@ const HdxPickHitVector* UsdMayaGLBatchRenderer::TestIntersection(
         for (const HdxPickHit& hit : *hitSet) {
             TF_DEBUG(PXRUSDMAYAGL_BATCHED_SELECTION)
                 .Msg(
-#if USD_VERSION_NUM > 1911
                     "        HIT:\n"
                     "            delegateId      : %s\n"
                     "            objectId        : %s\n"
@@ -906,15 +895,6 @@ const HdxPickHitVector* UsdMayaGLBatchRenderer::TestIntersection(
                     hit.delegateId.GetText(),
                     hit.objectId.GetText(),
                     hit.normalizedDepth);
-#else
-                    "        HIT:\n"
-                    "            delegateId: %s\n"
-                    "            objectId  : %s\n"
-                    "            ndcDepth  : %f\n",
-                    hit.delegateId.GetText(),
-                    hit.objectId.GetText(),
-                    hit.ndcDepth);
-#endif
         }
     }
 
@@ -1145,7 +1125,6 @@ void UsdMayaGLBatchRenderer::_ComputeSelection(
         for (const HdxPickHit& hit : hitSet) {
             TF_DEBUG(PXRUSDMAYAGL_BATCHED_SELECTION)
                 .Msg(
-#if USD_VERSION_NUM > 1911
                     "    NEW HIT\n"
                     "        delegateId      : %s\n"
                     "        objectId        : %s\n"
@@ -1155,17 +1134,6 @@ void UsdMayaGLBatchRenderer::_ComputeSelection(
                     hit.objectId.GetText(),
                     hit.instanceIndex,
                     hit.normalizedDepth);
-#else
-                    "    NEW HIT\n"
-                    "        delegateId   : %s\n"
-                    "        objectId     : %s\n"
-                    "        instanceIndex: %d\n"
-                    "        ndcDepth     : %f\n",
-                    hit.delegateId.GetText(),
-                    hit.objectId.GetText(),
-                    hit.instanceIndex,
-                    hit.ndcDepth);
-#endif
 
             if (!hit.instancerId.IsEmpty()) {
                 const VtIntArray instanceIndices(1, hit.instanceIndex);

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -28,6 +28,7 @@
 #include <pxr/usd/ar/packageUtils.h>
 #include <pxr/usd/sdf/assetPath.h>
 #include <pxr/usd/usdHydra/tokens.h>
+#include <pxr/usdImaging/usdImaging/textureUtils.h>
 #include <pxr/usdImaging/usdImaging/tokens.h>
 
 #include <maya/MFragmentManager.h>
@@ -45,13 +46,9 @@
 #include <iostream>
 #include <string>
 
-#if USD_VERSION_NUM >= 2002
-#include <pxr/usdImaging/usdImaging/textureUtils.h>
-#endif
-
 #if USD_VERSION_NUM >= 2102
 #include <pxr/imaging/hdSt/udimTextureObject.h>
-#elif USD_VERSION_NUM >= 2002
+#else
 #include <pxr/imaging/glf/udimTexture.h>
 #endif
 
@@ -264,7 +261,6 @@ MHWRender::MSamplerStateDesc _GetSamplerStateDesc(const HdMaterialNode& node)
     return desc;
 }
 
-#if USD_VERSION_NUM >= 2002
 MHWRender::MTexture*
 _LoadUdimTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& uvScaleOffset)
 {
@@ -394,7 +390,6 @@ _LoadUdimTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& u
 
     return texture;
 }
-#endif
 
 //! Load texture from the specified path
 MHWRender::MTexture*
@@ -403,7 +398,6 @@ _LoadTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& uvSca
     MProfilingScope profilingScope(
         HdVP2RenderDelegate::sProfilerCategory, MProfiler::kColorD_L2, "LoadTexture", path.c_str());
 
-#if USD_VERSION_NUM >= 2002
     // If it is a UDIM texture we need to modify the path before calling OpenForReading
 #if USD_VERSION_NUM >= 2102
     if (HdStIsSupportedUdimTexture(path))
@@ -411,7 +405,6 @@ _LoadTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& uvSca
 #else
     if (GlfIsSupportedUdimTexture(path))
         return _LoadUdimTexture(path, isColorSpaceSRGB, uvScaleOffset);
-#endif
 #endif
 
     MHWRender::MRenderer* const       renderer = MHWRender::MRenderer::theRenderer();

--- a/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.cpp
@@ -22,6 +22,8 @@
 #include <mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h>
 
 #include <pxr/imaging/hd/vertexAdjacency.h>
+#include <pxr/imaging/pxOsd/refinerFactory.h>
+#include <pxr/imaging/pxOsd/tokens.h>
 
 #include <maya/MProfiler.h>
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.h
@@ -106,9 +106,6 @@
 #include <pxr/base/tf/diagnostic.h>
 
 #ifdef HDVP2_ENABLE_GPU_OSD
-#include <pxr/imaging/pxOsd/refinerFactory.h>
-#include <pxr/imaging/pxOsd/tokens.h>
-
 #include <opensubdiv/far/_patchTable.h>
 #include <opensubdiv/far/patchTableFactory.h>
 #include <opensubdiv/far/stencilTable.h>

--- a/lib/usd/hdMaya/adapters/aiSkydomeLightAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/aiSkydomeLightAdapter.cpp
@@ -97,7 +97,7 @@ public:
                 file.findPlug(MayaAttrs::file::fileTextureName, true).asString().asChar()));
         } else if (paramName == HdLightTokens->enableColorTemperature) {
             return VtValue(false);
-#if USD_VERSION_NUM >= 1910 && USD_VERSION_NUM < 2011
+#if USD_VERSION_NUM < 2011
         } else if (paramName == HdLightTokens->textureResource) {
             auto fileObj = GetConnectedFileNode(GetNode(), HdMayaAdapterTokens->color);
             // TODO: Return a default, white texture?
@@ -110,7 +110,7 @@ public:
                 fileObj,
                 GetFileTexturePath(MFnDependencyNode(fileObj)),
                 GetDelegate()->GetParams().textureMemoryPerTexture) };
-#endif // USD_VERSION_NUM >= 1910 && USD_VERSION_NUM < 2011
+#endif // USD_VERSION_NUM < 2011
         }
         return {};
     }

--- a/lib/usd/hdMaya/adapters/materialAdapter.h
+++ b/lib/usd/hdMaya/adapters/materialAdapter.h
@@ -43,43 +43,14 @@ public:
     HDMAYA_API
     void Populate() override;
 
-#if USD_VERSION_NUM > 1911 && USD_VERSION_NUM < 2011
+#if USD_VERSION_NUM < 2011
 
     HDMAYA_API
     virtual HdTextureResourceSharedPtr GetTextureResource(const SdfPath& textureShaderId);
     HDMAYA_API
     virtual HdTextureResource::ID GetTextureResourceID(const TfToken& paramName);
 
-#elif USD_VERSION_NUM <= 1911
-
-    HDMAYA_API
-    virtual std::string GetSurfaceShaderSource();
-    HDMAYA_API
-    virtual std::string GetDisplacementShaderSource();
-    HDMAYA_API
-    virtual VtValue GetMaterialParamValue(const TfToken& paramName);
-    HDMAYA_API
-    virtual HdMaterialParamVector GetMaterialParams();
-    /// \brief Gets the Metadata for the Material.
-    ///
-    /// \return Dictionary holding the metadata.
-    HDMAYA_API
-    virtual VtDictionary GetMaterialMetadata();
-
-    HDMAYA_API
-    static const HdMaterialParamVector& GetPreviewMaterialParams();
-    HDMAYA_API
-    static const std::string& GetPreviewSurfaceSource();
-    HDMAYA_API
-    static const std::string& GetPreviewDisplacementSource();
-    HDMAYA_API
-    static const VtValue& GetPreviewMaterialParamValue(const TfToken& paramName);
-    HDMAYA_API
-    virtual HdTextureResourceSharedPtr GetTextureResource(const TfToken& paramName);
-    HDMAYA_API
-    virtual HdTextureResource::ID GetTextureResourceID(const TfToken& paramName);
-
-#endif // USD_VERSION_NUM <= 1911
+#endif // USD_VERSION_NUM < 2011
 
     HDMAYA_API
     virtual VtValue GetMaterialResource();

--- a/lib/usd/hdMaya/adapters/materialNetworkConverter.cpp
+++ b/lib/usd/hdMaya/adapters/materialNetworkConverter.cpp
@@ -890,32 +890,4 @@ const HdMayaShaderParams& HdMayaMaterialNetworkConverter::GetPreviewShaderParams
     return _previewShaderParams;
 }
 
-#if USD_VERSION_NUM <= 1911
-
-// This is required quite often, so we precalc.
-std::mutex            _previewMaterialParamVector_mutex;
-bool                  _previewMaterialParamVector_initialized = false;
-HdMaterialParamVector _previewMaterialParamVector;
-
-const HdMaterialParamVector& HdMayaMaterialNetworkConverter::GetPreviewMaterialParamVector()
-{
-    if (!_previewMaterialParamVector_initialized) {
-        std::lock_guard<std::mutex> lock(_previewMaterialParamVector_mutex);
-        // Once we have the lock, recheck to make sure it's still
-        // uninitialized...
-        if (!_previewMaterialParamVector_initialized) {
-            auto& shaderParams = HdMayaMaterialNetworkConverter::GetPreviewShaderParams();
-            _previewMaterialParamVector.reserve(shaderParams.size());
-            for (const auto& it : shaderParams) {
-                _previewMaterialParamVector.emplace_back(
-                    HdMaterialParam::ParamTypeFallback, it.name, it.fallbackValue);
-            }
-            _previewMaterialParamVector_initialized = true;
-        }
-    }
-    return _previewMaterialParamVector;
-}
-
-#endif // USD_VERSION_NUM <= 1911
-
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/usd/hdMaya/adapters/materialNetworkConverter.h
+++ b/lib/usd/hdMaya/adapters/materialNetworkConverter.h
@@ -168,13 +168,6 @@ public:
     HDMAYA_API
     static const HdMayaShaderParams& GetPreviewShaderParams();
 
-#if USD_VERSION_NUM <= 1911
-
-    HDMAYA_API
-    static const HdMaterialParamVector& GetPreviewMaterialParamVector();
-
-#endif // USD_VERSION_NUM <= 1911
-
 private:
     HdMaterialNetwork& _network;
     const SdfPath&     _prefix;

--- a/lib/usd/hdMaya/adapters/nurbsCurveAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/nurbsCurveAdapter.cpp
@@ -156,14 +156,7 @@ public:
         return {};
     }
 
-    TfToken GetRenderTag() const override
-    {
-#if USD_VERSION_NUM >= 1910
-        return HdRenderTagTokens->guide;
-#else
-        return HdTokens->guide;
-#endif
-    }
+    TfToken GetRenderTag() const override { return HdRenderTagTokens->guide; }
 
 private:
     static void NodeDirtiedCallback(MObject& node, MPlug& plug, void* clientData)

--- a/lib/usd/hdMaya/delegates/delegateDebugCodes.cpp
+++ b/lib/usd/hdMaya/delegates/delegateDebugCodes.cpp
@@ -125,34 +125,6 @@ TF_REGISTRY_FUNCTION(TfDebug)
         "delegates.");
 
 #endif // USD_VERSION_NUM < 2011
-
-#if USD_VERSION_NUM <= 1911
-
-    TF_DEBUG_ENVIRONMENT_SYMBOL(
-        HDMAYA_DELEGATE_GET_DISPLACEMENT_SHADER_SOURCE,
-        "Print information about 'GetDisplacementShaderSource' calls to the "
-        "delegates.");
-
-    TF_DEBUG_ENVIRONMENT_SYMBOL(
-        HDMAYA_DELEGATE_GET_MATERIAL_METADATA,
-        "Print information about 'GetMaterialMetadata' calls to the "
-        "delegates.");
-
-    TF_DEBUG_ENVIRONMENT_SYMBOL(
-        HDMAYA_DELEGATE_GET_MATERIAL_PARAM_VALUE,
-        "Print information about 'GetMaterialParamValue' calls to the "
-        "delegates.");
-
-    TF_DEBUG_ENVIRONMENT_SYMBOL(
-        HDMAYA_DELEGATE_GET_MATERIAL_PARAMS,
-        "Print information about 'GetMaterialParams' calls to the delegates.");
-
-    TF_DEBUG_ENVIRONMENT_SYMBOL(
-        HDMAYA_DELEGATE_GET_SURFACE_SHADER_SOURCE,
-        "Print information about 'GetSurfaceShaderSource' calls to the "
-        "delegates.");
-
-#endif // USD_VERSION_NUM <= 1911
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/usd/hdMaya/delegates/delegateDebugCodes.h
+++ b/lib/usd/hdMaya/delegates/delegateDebugCodes.h
@@ -61,21 +61,6 @@ TF_DEBUG_CODES(
 // clang-format on
 #endif // USD_VERSION_NUM < 2011
 
-// Debug codes for Hydra API that was deprecated after USD 19.11.
-// These are declared in a separate block to avoid using a preprocessor
-// directive inside the TF_DEBUG_CODES() macro invocation, which breaks
-// compilation on Windows.
-#if USD_VERSION_NUM <= 1911
-// clang-format off
-TF_DEBUG_CODES(
-    HDMAYA_DELEGATE_GET_DISPLACEMENT_SHADER_SOURCE,
-    HDMAYA_DELEGATE_GET_MATERIAL_METADATA,
-    HDMAYA_DELEGATE_GET_MATERIAL_PARAM_VALUE,
-    HDMAYA_DELEGATE_GET_MATERIAL_PARAMS,
-    HDMAYA_DELEGATE_GET_SURFACE_SHADER_SOURCE);
-// clang-format on
-#endif // USD_VERSION_NUM <= 1911
-
 PXR_NAMESPACE_CLOSE_SCOPE
 
 #endif // HDMAYA_DELEGATE_DEBUG_CODES_H

--- a/lib/usd/hdMaya/delegates/sceneDelegate.cpp
+++ b/lib/usd/hdMaya/delegates/sceneDelegate.cpp
@@ -1025,77 +1025,6 @@ HdDisplayStyle HdMayaSceneDelegate::GetDisplayStyle(const SdfPath& id)
         _shapeAdapters);
 }
 
-#if USD_VERSION_NUM <= 1911
-
-std::string HdMayaSceneDelegate::GetSurfaceShaderSource(const SdfPath& id)
-{
-    TF_DEBUG(HDMAYA_DELEGATE_GET_SURFACE_SHADER_SOURCE)
-        .Msg("HdMayaSceneDelegate::GetSurfaceShaderSource(%s)\n", id.GetText());
-    if (id == _fallbackMaterial) {
-        return HdMayaMaterialAdapter::GetPreviewSurfaceSource();
-    }
-    return _GetValue<HdMayaMaterialAdapter, std::string>(
-        id,
-        [](HdMayaMaterialAdapter* a) -> std::string { return a->GetSurfaceShaderSource(); },
-        _materialAdapters);
-}
-
-std::string HdMayaSceneDelegate::GetDisplacementShaderSource(const SdfPath& id)
-{
-    TF_DEBUG(HDMAYA_DELEGATE_GET_DISPLACEMENT_SHADER_SOURCE)
-        .Msg("HdMayaSceneDelegate::GetDisplacementShaderSource(%s)\n", id.GetText());
-    if (id == _fallbackMaterial) {
-        return HdMayaMaterialAdapter::GetPreviewDisplacementSource();
-    }
-    return _GetValue<HdMayaMaterialAdapter, std::string>(
-        id,
-        [](HdMayaMaterialAdapter* a) -> std::string { return a->GetDisplacementShaderSource(); },
-        _materialAdapters);
-}
-
-VtValue HdMayaSceneDelegate::GetMaterialParamValue(const SdfPath& id, const TfToken& paramName)
-{
-    TF_DEBUG(HDMAYA_DELEGATE_GET_MATERIAL_PARAM_VALUE)
-        .Msg(
-            "HdMayaSceneDelegate::GetMaterialParamValue(%s, %s)\n",
-            id.GetText(),
-            paramName.GetText());
-    if (id == _fallbackMaterial) {
-        return HdMayaMaterialAdapter::GetPreviewMaterialParamValue(paramName);
-    }
-    return _GetValue<HdMayaMaterialAdapter, VtValue>(
-        id,
-        [&paramName](HdMayaMaterialAdapter* a) -> VtValue {
-            return a->GetMaterialParamValue(paramName);
-        },
-        _materialAdapters);
-}
-
-HdMaterialParamVector HdMayaSceneDelegate::GetMaterialParams(const SdfPath& id)
-{
-    TF_DEBUG(HDMAYA_DELEGATE_GET_MATERIAL_PARAMS)
-        .Msg("HdMayaSceneDelegate::GetMaterialParams(%s)\n", id.GetText());
-    if (id == _fallbackMaterial) {
-        return HdMayaMaterialAdapter::GetPreviewMaterialParams();
-    }
-    return _GetValue<HdMayaMaterialAdapter, HdMaterialParamVector>(
-        id,
-        [](HdMayaMaterialAdapter* a) -> HdMaterialParamVector { return a->GetMaterialParams(); },
-        _materialAdapters);
-}
-
-VtDictionary HdMayaSceneDelegate::GetMaterialMetadata(const SdfPath& materialId)
-{
-    TF_DEBUG(HDMAYA_DELEGATE_GET_MATERIAL_METADATA)
-        .Msg("HdMayaSceneDelegate::GetMaterialMetadata(%s)\n", materialId.GetText());
-    return _GetValue<HdMayaMaterialAdapter, VtDictionary>(
-        materialId,
-        [](HdMayaMaterialAdapter* a) -> VtDictionary { return a->GetMaterialMetadata(); },
-        _materialAdapters);
-}
-
-#endif // USD_VERSION_NUM <= 1911
-
 SdfPath HdMayaSceneDelegate::GetMaterialId(const SdfPath& id)
 {
     TF_DEBUG(HDMAYA_DELEGATE_GET_MATERIAL_ID)
@@ -1151,17 +1080,6 @@ HdTextureResourceSharedPtr HdMayaSceneDelegate::GetTextureResource(const SdfPath
     TF_DEBUG(HDMAYA_DELEGATE_GET_TEXTURE_RESOURCE)
         .Msg("HdMayaSceneDelegate::GetTextureResource(%s)\n", textureId.GetText());
 
-#if USD_VERSION_NUM <= 1911
-
-    return _GetValue<HdMayaMaterialAdapter, HdTextureResourceSharedPtr>(
-        textureId.GetPrimPath(),
-        [&textureId](HdMayaMaterialAdapter* a) -> HdTextureResourceSharedPtr {
-            return a->GetTextureResource(textureId.GetNameToken());
-        },
-        _materialAdapters);
-
-#else // USD_VERSION_NUM > 1911
-
     auto* adapterPtr = TfMapLookupPtr(_materialAdapters, textureId);
 
     if (!adapterPtr) {
@@ -1188,9 +1106,8 @@ HdTextureResourceSharedPtr HdMayaSceneDelegate::GetTextureResource(const SdfPath
     if (adapterPtr) {
         return adapterPtr->get()->GetTextureResource(textureId);
     }
-    return nullptr;
 
-#endif // USD_VERSION_NUM <= 1911
+    return nullptr;
 }
 
 #endif // USD_VERSION_NUM < 2011

--- a/lib/usd/hdMaya/delegates/sceneDelegate.h
+++ b/lib/usd/hdMaya/delegates/sceneDelegate.h
@@ -212,31 +212,6 @@ protected:
         SdfPathVector* instanceContext) override;
 #endif
 
-#if USD_VERSION_NUM <= 1911
-
-    HDMAYA_API
-    std::string GetSurfaceShaderSource(const SdfPath& id) override;
-
-    HDMAYA_API
-    std::string GetDisplacementShaderSource(const SdfPath& id) override;
-
-    HDMAYA_API
-    VtValue GetMaterialParamValue(const SdfPath& id, const TfToken& paramName) override;
-
-    HDMAYA_API
-    HdMaterialParamVector GetMaterialParams(const SdfPath& id) override;
-
-    /// \brief Gets the metadata from a material.
-    ///
-    /// For now we are only returning the materialTag for translucency.
-    ///
-    /// \param materialId Path to the material.
-    /// \return Dictionary storing the metadata.
-    HDMAYA_API
-    VtDictionary GetMaterialMetadata(const SdfPath& materialId) override;
-
-#endif // USD_VERSION_NUM <= 1911
-
     HDMAYA_API
     SdfPath GetMaterialId(const SdfPath& id) override;
 

--- a/lib/usd/hdMaya/utils.cpp
+++ b/lib/usd/hdMaya/utils.cpp
@@ -169,9 +169,7 @@ GetFileTextureResource(const MObject& fileObj, const TfToken& filePath, int maxT
         textureType,
         std::get<0>(wrapping),
         std::get<1>(wrapping),
-#if USD_VERSION_NUM >= 1910
         HdWrapClamp,
-#endif
         HdMinFilterLinearMipmapLinear,
         HdMagFilterLinear,
         maxTextureMemory));

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1109,11 +1109,7 @@ void ProxyShape::variantSelectionListener(SdfNotice::LayersDidChange const& noti
 
     const SdfLayerHandleVector stack = m_stage->GetLayerStack();
 
-#if USD_VERSION_NUM > 1911
     TF_FOR_ALL(itr, notice.GetChangeListVec())
-#else
-    TF_FOR_ALL(itr, notice.GetChangeListMap())
-#endif
     {
         if (std::find(stack.begin(), stack.end(), itr->first) == stack.end())
             continue;

--- a/test/lib/mayaUsd/render/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/CMakeLists.txt
@@ -1,10 +1,5 @@
 add_subdirectory(pxrUsdMayaGL)
 
 if(BUILD_HDMAYA)
-    # skip tests for usd<=19.11, as these do image diffs, and it seems like
-    # something having to do with colorspaces (or perhaps default lighting?)
-    # changed in 20.02
-    if(USD_VERSION_NUM GREATER 1911)
-        add_subdirectory(mayaToHydra)
-    endif()
+    add_subdirectory(mayaToHydra)
 endif()


### PR DESCRIPTION
Following up on #1101, these changes set core USD version 20.02 as the minimum supported version of core USD. This version is specified as the minimum in the `find_package()` call in the top-level `CMakeLists.txt` so that the build will quickly bail out on any attempt to use an older USD version.

All conditionally compiled code that was active for versions of USD prior to 20.02 was removed. The bulk of the removed code was in `hdMaya`/`mayaToHydra`.

Our environment has moved on such that I can't actually build core USD 20.02 anymore, but I was able to verify this against 20.05 on Linux using Maya PR 121. A few minor adjustments were needed though (see 1281cbb374daba6ab96c38e7bdd6cd574e5ef045).

I also took this opportunity to mark the current USD dev branch commit (https://github.com/PixarAnimationStudios/USD/commit/82dd40ad31bcdecfb18c2f23e39a3ddf68ef10d4) as supported in `doc/build.md` as well (c6625f1abf80dda0d4a27ad760e47af58676abfd).