### PR TITLE
MAYA-105623 better support for USD leftHanded mesh.

### DIFF
--- a/lib/mayaUsd/fileio/translators/translatorGprim.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorGprim.cpp
@@ -28,11 +28,6 @@ void UsdMayaTranslatorGprim::Read(
 {
     MFnDagNode fnGprim(mayaNode);
 
-    TfToken orientation;
-    if (gprim.GetOrientationAttr().Get(&orientation)) {
-        UsdMayaUtil::setPlugValue(fnGprim, "opposite", (orientation == UsdGeomTokens->leftHanded));
-    }
-
     bool doubleSided;
     if (gprim.GetDoubleSidedAttr().Get(&doubleSided)) {
         UsdMayaUtil::setPlugValue(fnGprim, "doubleSided", doubleSided);

--- a/lib/mayaUsd/fileio/translators/translatorMesh.h
+++ b/lib/mayaUsd/fileio/translators/translatorMesh.h
@@ -65,6 +65,8 @@ public:
 private:
     MStatus setPointBasedDeformerForMayaNode(const MObject&, const MObject&, const UsdPrim&);
 
+    static bool isPrimitiveLeftHanded(const UsdGeomGprim& prim);
+
 private:
     MObject m_meshObj;
     MObject m_meshBlendObj;

--- a/lib/mayaUsd/fileio/translators/translatorNurbsPatch.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorNurbsPatch.cpp
@@ -211,7 +211,8 @@ bool UsdMayaTranslatorNurbsPatch::Read(
     //       order to be right-handed when imported.
     TfToken orientation;
     if (usdNurbsPatch.GetOrientationAttr().Get(&orientation)) {
-        UsdMayaUtil::setPlugValue(surfaceObj, "opposite", (orientation == UsdGeomTokens->leftHanded));
+        UsdMayaUtil::setPlugValue(
+            surfaceObj, "opposite", (orientation == UsdGeomTokens->leftHanded));
     }
 
     // == Animate points ==

--- a/lib/mayaUsd/fileio/translators/translatorNurbsPatch.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorNurbsPatch.cpp
@@ -204,6 +204,16 @@ bool UsdMayaTranslatorNurbsPatch::Read(
     // NurbsSurface is a shape, so read Gprim properties
     UsdMayaTranslatorGprim::Read(usdNurbsPatch, surfaceObj, context);
 
+    // Note: the USD leftHanded orientation makes both the vertices order of faces left-handed
+    //       and the face normals be left-handed. On the other hand, the Maya 'opposite' flag
+    //       only flips faces, not normals. So, this may need further work. For example, the
+    //       mesh translator does not set the 'opposite' flag but merely changes the vertices
+    //       order to be right-handed when imported.
+    TfToken orientation;
+    if (usdNurbsPatch.GetOrientationAttr().Get(&orientation)) {
+        UsdMayaUtil::setPlugValue(surfaceObj, "opposite", (orientation == UsdGeomTokens->leftHanded));
+    }
+
     // == Animate points ==
     //   Use blendShapeDeformer so that all the points for a frame are contained in a single node
     //   Almost identical code as used with MayaMeshReader.cpp

--- a/test/lib/usd/translators/UsdImportMeshTest/Mesh.usda
+++ b/test/lib/usd/translators/UsdImportMeshTest/Mesh.usda
@@ -31,18 +31,69 @@ def Xform "World"
         int[] primvars:st:indices = [0, 1, 2, 3, 3, 2, 4, 5, 5, 4, 6, 7, 7, 6, 8, 9, 1, 10, 11, 2, 12, 0, 3, 13]
     }
 
+    def Mesh "LeftHandedSubdivMesh" (
+        kind = "component"
+    )
+    {
+        uniform token orientation = "leftHanded"
+        float3[] extent = [(0.5, 0.5, 0.5), (1.5, 1.5, 1.5)]
+        token faceVaryingLinearInterpolation = "all"
+        int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+        int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+        token interpolateBoundary = "edgeOnly"
+        point3f[] points = [(0.5, 0.5, 1.5), (1.5, 0.5, 1.5), (0.5, 1.5, 1.5), (1.5, 1.5, 1.5), (0.5, 1.5, 0.5), (1.5, 1.5, 0.5), (0.5, 0.5, 0.5), (1.5, 0.5, 0.5)]
+        color3f[] primvars:displayColor = [(0.13320851, 0.13320851, 0.13320851)] (
+            customData = {
+                dictionary Maya = {
+                    bool generated = 1
+                }
+            }
+        )
+        texCoord2f[] primvars:st = [(0.375, 0), (0.625, 0), (0.625, 0.25), (0.375, 0.25), (0.625, 0.5), (0.375, 0.5), (0.625, 0.75), (0.375, 0.75), (0.625, 1), (0.375, 1), (0.875, 0), (0.875, 0.25), (0.125, 0), (0.125, 0.25)] (
+            interpolation = "faceVarying"
+        )
+        int[] primvars:st:indices = [0, 1, 2, 3, 3, 2, 4, 5, 5, 4, 6, 7, 7, 6, 8, 9, 1, 10, 11, 2, 12, 0, 3, 13]
+    }
+
     def Mesh "PolyMesh" (
         kind = "component"
     )
     {
-        float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+        float3[] extent = [(1.5, 1.5, 1.5), (2.5, 2.5, 2.5)]
         int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
         int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
         token interpolateBoundary = "none"
         normal3f[] normals = [(0, 0, 1), (0, 0, 1), (0, 0, 1), (0, 0, 1), (0, 1, 0), (0, 1, 0), (0, 1, 0), (0, 1, 0), (0, 0, -1), (0, 0, -1), (0, 0, -1), (0, 0, -1), (0, -1, 0), (0, -1, 0), (0, -1, 0), (0, -1, 0), (1, 0, 0), (1, 0, 0), (1, 0, 0), (1, 0, 0), (-1, 0, 0), (-1, 0, 0), (-1, 0, 0), (-1, 0, 0)] (
             interpolation = "faceVarying"
         )
-        point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5)]
+        point3f[] points = [(1.5, 1.5, 2.5), (2.5, 1.5, 2.5), (1.5, 2.5, 2.5), (2.5, 2.5, 2.5), (1.5, 2.5, 1.5), (2.5, 2.5, 1.5), (1.5, 1.5, 1.5), (2.5, 1.5, 1.5)]
+        color3f[] primvars:displayColor = [(0.13320851, 0.13320851, 0.13320851)] (
+            customData = {
+                dictionary Maya = {
+                    bool generated = 1
+                }
+            }
+        )
+        texCoord2f[] primvars:st = [(0.375, 0), (0.625, 0), (0.625, 0.25), (0.375, 0.25), (0.625, 0.5), (0.375, 0.5), (0.625, 0.75), (0.375, 0.75), (0.625, 1), (0.375, 1), (0.875, 0), (0.875, 0.25), (0.125, 0), (0.125, 0.25)] (
+            interpolation = "faceVarying"
+        )
+        int[] primvars:st:indices = [0, 1, 2, 3, 3, 2, 4, 5, 5, 4, 6, 7, 7, 6, 8, 9, 1, 10, 11, 2, 12, 0, 3, 13]
+        uniform token subdivisionScheme = "none"
+    }
+
+    def Mesh "LeftHandedPolyMesh" (
+        kind = "component"
+    )
+    {
+        uniform token orientation = "leftHanded"
+        float3[] extent = [(3.5, 3.5, 3.5), (4.5, 4.5, 4.5)]
+        int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+        int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+        token interpolateBoundary = "none"
+        normal3f[] normals = [(0, 0, -1), (0, 0, -1), (0, 0, -1), (0, 0, -1), (0, -1, 0), (0, -1, 0), (0, -1, 0), (0, -1, 0), (0, 0, 1), (0, 0, 1), (0, 0, 1), (0, 0, 1), (0, 1, 0), (0, 1, 0), (0, 1, 0), (0, 1, 0), (-1, 0, 0), (-1, 0, 0), (-1, 0, 0), (-1, 0, 0), (1, 0, 0), (1, 0, 0), (1, 0, 0), (1, 0, 0)] (
+            interpolation = "faceVarying"
+        )
+        point3f[] points = [(3.5, 3.5, 4.5), (4.5, 3.5, 4.5), (3.5, 4.5, 4.5), (4.5, 4.5, 4.5), (3.5, 4.5, 3.5), (4.5, 4.5, 3.5), (3.5, 3.5, 3.5), (4.5, 3.5, 3.5)]
         color3f[] primvars:displayColor = [(0.13320851, 0.13320851, 0.13320851)] (
             customData = {
                 dictionary Maya = {

--- a/test/lib/usd/translators/testUsdImportMesh.py
+++ b/test/lib/usd/translators/testUsdImportMesh.py
@@ -40,8 +40,7 @@ class testUsdImportMesh(unittest.TestCase):
     def tearDownClass(cls):
         standalone.uninitialize()
 
-    def testImportPoly(self):
-        mesh = 'PolyMeshShape'
+    def verifyPolyMeshCommonAttributes(self, mesh):
         self.assertTrue(cmds.objExists(mesh))
 
         schema = mayaUsdLib.Adaptor(mesh).GetSchema(UsdGeom.Mesh)
@@ -60,8 +59,13 @@ class testUsdImportMesh(unittest.TestCase):
         self.assertTrue(
                 cmds.attributeQuery("USD_EmitNormals", node=mesh, exists=True))
 
-    def testImportSubdiv(self):
-        mesh = 'SubdivMeshShape'
+    def testImportPoly(self):
+        self.verifyPolyMeshCommonAttributes('PolyMeshShape')
+
+    def testImportLeftHandedPoly(self):
+        self.verifyPolyMeshCommonAttributes('LeftHandedPolyMeshShape')
+
+    def verifySubdivCommonAttributes(self, mesh):
         self.assertTrue(cmds.objExists(mesh))
 
         schema = mayaUsdLib.Adaptor(mesh).GetSchema(UsdGeom.Mesh)
@@ -79,6 +83,12 @@ class testUsdImportMesh(unittest.TestCase):
 
         self.assertFalse(
                 cmds.attributeQuery("USD_EmitNormals", node=mesh, exists=True))
+
+    def testImportSubdiv(self):
+        self.verifySubdivCommonAttributes('SubdivMeshShape')
+
+    def testImportLeftHandedSubdiv(self):
+        self.verifySubdivCommonAttributes('LeftHandedSubdivMeshShape')
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
The  main problem is that the 'leftHanded' orientation is USD changes the interpretation of the vertices order of faces *and* the direction of generated normals.

On the other hand, the 'opposite' flag in Maya flips the faces directions, but does not flip the normals.

So the behaviour differs. To better suport USD import of externally-generated USD files, we will no longer set the 'opposite' flag when importing ledftHanded USD files. We will instead change the vertices orders to be right-handed.

Note that we will still export 'opposite' geometries from Maya as by setting the 'leftHanded' flag. This is done for two reasons: first, to keep the code change minimal, second because USD does not support different handedness for faces and normasl anyway.