### PR TITLE
use accurate MAYA_API_VERSION in guard for MRenderItem::setObjectTypeExclusionFlag()

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1728,7 +1728,7 @@ MHWRender::MRenderItem* HdVP2BasisCurves::_CreateWireRenderItem(const MString& n
     renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueGray));
     renderItem->setSelectionMask(MSelectionMask::kSelectCurves);
 
-#if MAYA_API_VERSION >= 20210000
+#if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeNurbsCurves);
 #endif
 
@@ -1750,7 +1750,7 @@ MHWRender::MRenderItem* HdVP2BasisCurves::_CreateBBoxRenderItem(const MString& n
     renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueGray));
     renderItem->setSelectionMask(MSelectionMask::kSelectCurves);
 
-#if MAYA_API_VERSION >= 20210000
+#if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeNurbsCurves);
 #endif
 
@@ -1773,7 +1773,7 @@ MHWRender::MRenderItem* HdVP2BasisCurves::_CreatePatchRenderItem(const MString& 
     renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueGray));
     renderItem->setSelectionMask(MSelectionMask::kSelectCurves);
 
-#if MAYA_API_VERSION >= 20210000
+#if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeNurbsCurves);
 #endif
 
@@ -1798,7 +1798,7 @@ MHWRender::MRenderItem* HdVP2BasisCurves::_CreatePointsRenderItem(const MString&
     selectionMask.addMask(MSelectionMask::kSelectCurves);
     renderItem->setSelectionMask(selectionMask);
 
-#if MAYA_API_VERSION >= 20210000
+#if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeNurbsCurves);
 #endif
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1942,7 +1942,7 @@ MHWRender::MRenderItem* HdVP2Mesh::_CreatePointsRenderItem(const MString& name) 
     selectionMask.addMask(MSelectionMask::kSelectMeshVerts);
     renderItem->setSelectionMask(selectionMask);
 
-#if MAYA_API_VERSION >= 20210000
+#if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeMeshes);
 #endif
 
@@ -1965,7 +1965,7 @@ MHWRender::MRenderItem* HdVP2Mesh::_CreateWireframeRenderItem(const MString& nam
     renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueBlue));
     renderItem->setSelectionMask(MSelectionMask::kSelectMeshes);
 
-#if MAYA_API_VERSION >= 20210000
+#if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeMeshes);
 #endif
 
@@ -1987,7 +1987,7 @@ MHWRender::MRenderItem* HdVP2Mesh::_CreateBoundingBoxRenderItem(const MString& n
     renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueBlue));
     renderItem->setSelectionMask(MSelectionMask::kSelectMeshes);
 
-#if MAYA_API_VERSION >= 20210000
+#if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeMeshes);
 #endif
 
@@ -2012,7 +2012,7 @@ MHWRender::MRenderItem* HdVP2Mesh::_CreateSmoothHullRenderItem(const MString& na
     renderItem->setShader(_delegate->GetFallbackShader(kOpaqueGray));
     renderItem->setSelectionMask(MSelectionMask::kSelectMeshes);
 
-#if MAYA_API_VERSION >= 20210000
+#if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeMeshes);
 #endif
 
@@ -2037,7 +2037,7 @@ MHWRender::MRenderItem* HdVP2Mesh::_CreateSelectionHighlightRenderItem(const MSt
     renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueBlue));
     renderItem->setSelectionMask(MSelectionMask());
 
-#if MAYA_API_VERSION >= 20210000
+#if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeMeshes);
 #endif
 


### PR DESCRIPTION
Maya PR 121 reports its API version as 20210000 while PR 122 reports its API version as 20220000. The newly added `MRenderItem::setObjectTypeExclusionFlag()` function whose use was added in pull request #1008 is only available in PR 122, not in PR 121. This means that compilation against PR 121 fails because the API version check guarding the function's usage is incorrect.

While I concede that we don't intend to support all previous preview/beta releases of Maya, this has been causing sufficient headache for us as we try to get PR 122 licensed that I was hoping taking these changes would be acceptable. The updated `MAYA_API_VERSION` also more accurately reflects the version in which the new API was added.