### PR TITLE
make tests in test/lib/ufe directly runnable and use fixturesUtils

### DIFF
--- a/test/lib/ufe/testAttribute.py
+++ b/test/lib/ufe/testAttribute.py
@@ -16,17 +16,23 @@
 # limitations under the License.
 #
 
-import os
+import fixturesUtils
+import mayaUtils
+import testUtils
+import usdUtils
 
-import usdUtils, mayaUtils, testUtils
-import ufe
 from pxr import UsdGeom
+
+from maya import cmds
+from maya import standalone
+from maya.internal.ufeSupport import ufeCmdWrapper as ufeCmd
+
+import ufe
+
+import os
 import random
-
-import maya.cmds as cmds
-import maya.internal.ufeSupport.ufeCmdWrapper as ufeCmd
-
 import unittest
+
 
 class TestObserver(ufe.Observer):
     def __init__(self):
@@ -53,6 +59,8 @@ class AttributeTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
 
@@ -65,6 +73,8 @@ class AttributeTestCase(unittest.TestCase):
     def tearDownClass(cls):
         # See comments in MayaUFEPickWalkTesting.tearDownClass
         cmds.file(new=True, force=True)
+
+        standalone.uninitialize()
 
     def setUp(self):
         '''Called initially to set up the maya test environment'''
@@ -604,3 +614,7 @@ class AttributeTestCase(unittest.TestCase):
         radiusAttr = attrs.attribute('radius')
         
         self.assertEqual(radiusAttr.get(), newRadius)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testAttributes.py
+++ b/test/lib/ufe/testAttributes.py
@@ -16,11 +16,18 @@
 # limitations under the License.
 #
 
-import usdUtils, mayaUtils
-import ufe
+import fixturesUtils
+import mayaUtils
+import usdUtils
+
 from pxr import UsdGeom
 
+from maya import standalone
+
+import ufe
+
 import unittest
+
 
 class AttributesTestCase(unittest.TestCase):
     '''Verify the Attributes UFE interface, for multiple runtimes.
@@ -30,8 +37,14 @@ class AttributesTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
 
     def setUp(self):
         ''' Called initially to set up the maya test environment '''
@@ -67,3 +80,7 @@ class AttributesTestCase(unittest.TestCase):
 
         # Visibility should be in this list.
         self.assertIn(UsdGeom.Tokens.visibility, ball35AttrNames)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testChildFilter.py
+++ b/test/lib/ufe/testChildFilter.py
@@ -16,14 +16,17 @@
 # limitations under the License.
 #
 
-import os
-
-import maya.cmds as cmds
-
+import fixturesUtils
 import mayaUtils
+
+from maya import cmds
+from maya import standalone
+
 import ufe
 
+import os
 import unittest
+
 
 class ChildFilterTestCase(unittest.TestCase):
     '''Verify the ChildFilter USD implementation.
@@ -33,8 +36,14 @@ class ChildFilterTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
 
     def setUp(self):
         ''' Called initially to set up the Maya test environment '''
@@ -80,3 +89,7 @@ class ChildFilterTestCase(unittest.TestCase):
         children = propsHier.filteredChildren(cf)
         self.assertEqual(6, len(children))
         self.assertIn(ball3Hier, children)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testComboCmd.py
+++ b/test/lib/ufe/testComboCmd.py
@@ -16,24 +16,31 @@
 # limitations under the License.
 #
 
-import maya.api.OpenMaya as om
-import maya.cmds as cmds
-from math import radians, degrees
+import fixturesUtils
+import mayaUtils
+from testUtils import assertVectorAlmostEqual
+import testTRSBase
+import ufeUtils
+import usdUtils
 
 import mayaUsd.ufe
 import mayaUsd.lib
 
-import usdUtils, mayaUtils, ufeUtils
-from testUtils import assertVectorAlmostEqual
-import testTRSBase
+from pxr import UsdGeom
+from pxr import Vt
+
+from maya import cmds
+from maya import standalone
+from maya.api import OpenMaya as om
+
 import ufe
 
-from pxr import UsdGeom, Vt
-
-import unittest
-import os
-
 from functools import partial
+from math import degrees
+from math import radians
+import os
+import unittest
+
 
 def transform3dScale(transform3d):
     matrix = om.MMatrix(transform3d.inclusiveMatrix().matrix)
@@ -133,8 +140,14 @@ class ComboCmdTestCase(testTRSBase.TRSTestCaseBase):
     
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.setUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
     
     def setUp(self):
         ''' Called initially to set up the maya test environment '''
@@ -794,3 +807,7 @@ class ComboCmdTestCase(testTRSBase.TRSTestCaseBase):
 
         checkPivotsAndCompensations(self, mayaObj, usdSphere3d)
         checkPivotsAndCompensations(self, mayaObj, usdFallbackSphere3d)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testContextOps.py
+++ b/test/lib/ufe/testContextOps.py
@@ -16,16 +16,21 @@
 # limitations under the License.
 #
 
-import maya.cmds as cmds
-import maya.internal.ufeSupport.ufeCmdWrapper as ufeCmd
+import fixturesUtils
+import mayaUtils
+import usdUtils
 
 from pxr import UsdGeom
 
-import usdUtils, mayaUtils
+from maya import cmds
+from maya import standalone
+from maya.internal.ufeSupport import ufeCmdWrapper as ufeCmd
+
 import ufe
 
-import unittest
 import os
+import unittest
+
 
 class TestAddPrimObserver(ufe.Observer):
     def __init__(self):
@@ -56,9 +61,15 @@ class ContextOpsTestCase(unittest.TestCase):
     
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
-    
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
     def setUp(self):
         ''' Called initially to set up the maya test environment '''
         # Load plugins
@@ -461,3 +472,7 @@ class ContextOpsTestCase(unittest.TestCase):
         _validateLoadAndUnloadItems(propsItem, ['Load with Descendants'])
         _validateLoadAndUnloadItems(ball1Item, ['Load', 'Load with Descendants'])
         _validateLoadAndUnloadItems(ball15Item, ['Load', 'Load with Descendants'])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testDeleteCmd.py
+++ b/test/lib/ufe/testDeleteCmd.py
@@ -16,13 +16,19 @@
 # limitations under the License.
 #
 
-import maya.cmds as cmds
+import fixturesUtils
+import mayaUtils
+import ufeUtils
+import usdUtils
 
-import ufeUtils, usdUtils, mayaUtils
+from maya import cmds
+from maya import standalone
+
 import ufe
 
-import unittest
 import os
+import unittest
+
 
 def childrenNames(children):
     return [str(child.path().back()) for child in children]
@@ -69,9 +75,15 @@ class DeleteCmdTestCase(unittest.TestCase):
     
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
-    
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
     def setUp(self):
         ''' Called initially to set up the Maya test environment '''
         # Load plugins
@@ -301,3 +313,7 @@ class DeleteCmdTestCase(unittest.TestCase):
         self.assertNotIn(ball35Name, propsChildrenNames)
         self.assertNotIn(ball34Name, propsChildrenNames)
         self.assertFalse(cmds.objExists("|pSphere1|pSphereShape1"))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testDuplicateCmd.py
+++ b/test/lib/ufe/testDuplicateCmd.py
@@ -16,9 +16,15 @@
 # limitations under the License.
 #
 
-import maya.cmds as cmds
+import fixturesUtils
+import mayaUtils
+import testUtils
+import ufeUtils
+import usdUtils
 
-import usdUtils, mayaUtils, ufeUtils, testUtils
+from maya import cmds
+from maya import standalone
+
 import ufe
 
 import unittest
@@ -44,8 +50,14 @@ class DuplicateCmdTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
 
     def setUp(self):
         ''' Called initially to set up the Maya test environment '''
@@ -205,3 +217,7 @@ class DuplicateCmdTestCase(unittest.TestCase):
         correctResult = [20, 0, 0, 1]
 
         self.assertEqual(correctResult, transVector)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testGroupCmd.py
+++ b/test/lib/ufe/testGroupCmd.py
@@ -16,14 +16,20 @@
 # limitations under the License.
 #
 
+import fixturesUtils
+import mayaUtils
+import testUtils
+import ufeUtils
+import usdUtils
+
 import mayaUsd.ufe
 
 from pxr import Kind
 from pxr import Usd
 
-import maya.cmds as cmds
+from maya import cmds
+from maya import standalone
 
-import usdUtils, mayaUtils, ufeUtils, testUtils
 import ufe
 
 import os
@@ -41,8 +47,14 @@ class GroupCmdTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
 
     def setUp(self):
         ''' Called initially to set up the Maya test environment '''
@@ -216,3 +228,7 @@ class GroupCmdTestCase(unittest.TestCase):
         # authored either.
         self.assertEqual(Usd.ModelAPI(newGroupPrim).GetKind(), "")
         self.assertFalse(newGroupPrim.IsModel())
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testMatrices.py
+++ b/test/lib/ufe/testMatrices.py
@@ -16,17 +16,22 @@
 # limitations under the License.
 #
 
-import usdUtils, mayaUtils
+import fixturesUtils
+import mayaUtils
+import usdUtils
+
+from maya import cmds
+from maya import standalone
+from maya.api import OpenMaya as om
 
 import ufe
 
-import maya.api.OpenMaya as om
-import maya.cmds as cmds
-
-from math import radians, sin, cos
+from math import cos
+from math import radians
+from math import sin
 import os
-
 import unittest
+
 
 # AX = |  1    0    0    0 |
 #      |  0    cx   sx   0 |
@@ -54,8 +59,14 @@ class Transform3dMatricesTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
 
     def setUp(self):
         ''' Called initially to set up the maya test environment '''
@@ -149,3 +160,7 @@ class Transform3dMatricesTestCase(unittest.TestCase):
         self.assertMatrixAlmostEqual(
             cylInclMat.matrix, [[1, 0, 0, 0], [0, cx60, sx60, 0],
                                 [0, -sx60, cx60, 0], [0, 10, 0, 1]])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testMayaPickwalk.py
+++ b/test/lib/ufe/testMayaPickwalk.py
@@ -16,13 +16,20 @@
 # limitations under the License.
 #
 
+import fixturesUtils
+import mayaUtils
+import ufeUtils
+import usdUtils
+
+from maya import cmds
+from maya import standalone
+
+import ufe
+
+import os
+import sys
 import unittest
 
-import maya.cmds as cmds
-import sys, os
-
-import usdUtils, mayaUtils, ufeUtils
-import ufe
 
 class MayaUFEPickWalkTesting(unittest.TestCase):
     '''
@@ -49,9 +56,11 @@ class MayaUFEPickWalkTesting(unittest.TestCase):
     '''
     
     pluginsLoaded = False
-    
+
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
     
@@ -61,6 +70,8 @@ class MayaUFEPickWalkTesting(unittest.TestCase):
         # exit while cleaning out the undo stack, because the Python commands 
         # we use in this test are destroyed after the Python interpreter exits.
         cmds.file(new=True, force=True)
+
+        standalone.uninitialize()
 
     def setUp(self):
         ''' Called initially to set up the maya test environment '''
@@ -220,3 +231,7 @@ class MayaUFEPickWalkTesting(unittest.TestCase):
         self.rewindMemento()
         self.fforwardMemento()
         '''
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testMoveCmd.py
+++ b/test/lib/ufe/testMoveCmd.py
@@ -16,17 +16,22 @@
 # limitations under the License.
 #
 
-import maya.api.OpenMaya as om
-import maya.cmds as cmds
-
-import usdUtils, mayaUtils, ufeUtils
-from testUtils import assertVectorAlmostEqual
+import fixturesUtils
+import mayaUtils
 import testTRSBase
+from testUtils import assertVectorAlmostEqual
+import ufeUtils
+import usdUtils
+
+from maya import cmds
+from maya import standalone
+from maya.api import OpenMaya as om
+
 import ufe
 
+from functools import partial
 import unittest
 
-from functools import partial
 
 def matrix4dTranslation(matrix4d):
     translation = matrix4d.matrix[-1]
@@ -69,8 +74,14 @@ class MoveCmdTestCase(testTRSBase.TRSTestCaseBase):
     
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
     
     def setUp(self):
         ''' Called initially to set up the maya test environment '''
@@ -264,3 +275,7 @@ class MoveCmdTestCase(testTRSBase.TRSTestCaseBase):
         expected = [usdSceneItemTranslation(ballItem) for ballItem in ballItems]
 
         self.runMultiSelectTestMove(ballItems, expected)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testObject3d.py
+++ b/test/lib/ufe/testObject3d.py
@@ -16,20 +16,26 @@
 # limitations under the License.
 #
 
-import mayaUtils, usdUtils
-from testUtils import assertVectorAlmostEqual, assertVectorEqual
-
-import ufe
-
-from pxr import Usd, UsdGeom
+import fixturesUtils
+import mayaUtils
+from testUtils import assertVectorAlmostEqual
+from testUtils import assertVectorEqual
+import usdUtils
 
 import mayaUsd.ufe
 
-import maya.cmds as cmds
-import maya.api.OpenMaya as OpenMaya
+from pxr import Usd
+from pxr import UsdGeom
 
-import unittest
+from maya import cmds
+from maya import standalone
+from maya.api import OpenMaya as OpenMaya
+
+import ufe
+
 import os
+import unittest
+
 
 def nameToPlug(nodeName):
     selection = OpenMaya.MSelectionList()
@@ -56,8 +62,14 @@ class Object3dTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
 
     def setUp(self):
         ''' Called initially to set up the Maya test environment '''
@@ -402,3 +414,7 @@ class Object3dTestCase(unittest.TestCase):
         # visibility "token" must exists now in the USD data model
         self.assertTrue(bool(primSpecCapsule and UsdGeom.Tokens.visibility in primSpecCapsule.attributes))
         self.assertTrue(bool(primSpecCylinder and UsdGeom.Tokens.visibility in primSpecCylinder.attributes))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testObservableScene.py
+++ b/test/lib/ufe/testObservableScene.py
@@ -16,12 +16,16 @@
 # limitations under the License.
 #
 
+import fixturesUtils
+
+from maya import standalone
+
+import ufe
 
 import os
 import sys
 import unittest
 
-import ufe
 
 class TestObserver(ufe.Observer):
     def __init__(self):
@@ -48,6 +52,14 @@ class TestObserver(ufe.Observer):
         return [self.add, self.delete, self.pathChange, self.subtreeInvalidate, self.composite]
 
 class UFEObservableSceneTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
 
     def checkNotifications(self, testObserver, listNotifications):
         self.assertTrue(testObserver.add == listNotifications[0])
@@ -100,3 +112,7 @@ class UFEObservableSceneTest(unittest.TestCase):
         # with ufe.NotificationGuard(ufe.Scene):
         #     ufe.Scene.notify(ufe.ObjectAdd(itemB))
         #     ufe.Scene.notify(ufe.ObjectAdd(itemC))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testParentCmd.py
+++ b/test/lib/ufe/testParentCmd.py
@@ -16,17 +16,24 @@
 # limitations under the License.
 #
 
-import mayaUtils, usdUtils, testUtils
+import fixturesUtils
+import mayaUtils
+import testUtils
 from testUtils import assertVectorAlmostEqual
+import usdUtils
+
+import mayaUsd.ufe
 
 from pxr import UsdGeom
 
-import ufe
-import mayaUsd.ufe
-import maya.cmds as cmds
+from maya import cmds
+from maya import standalone
 
-import unittest
+import ufe
+
 import os
+import unittest
+
 
 def childrenNames(children):
     return [str(child.path().back()) for child in children]
@@ -55,12 +62,16 @@ class ParentCmdTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
 
     @classmethod
     def tearDownClass(cls):
         cmds.file(new=True, force=True)
+
+        standalone.uninitialize()
 
     def setUp(self):
         # Load plugins
@@ -479,4 +490,7 @@ class ParentCmdTestCase(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             cmds.parent("|Tree_usd|Tree_usdShape,/TreeBase/trunk",
                         "|Tree_usd|Tree_usdShape,/TreeBase/leavesXform/leaves")
-        
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testPointInstances.py
+++ b/test/lib/ufe/testPointInstances.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import fixturesUtils
 import mayaUtils
 import usdUtils
 
@@ -23,6 +24,7 @@ from mayaUsd import ufe as mayaUsdUfe
 from pxr import UsdGeom
 
 from maya import cmds
+from maya import standalone
 
 import ufe
 
@@ -39,6 +41,8 @@ class PointInstancesTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls._pluginsLoaded:
             cls._pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
 
@@ -46,6 +50,10 @@ class PointInstancesTestCase(unittest.TestCase):
         self.assertTrue(self._pluginsLoaded)
 
         mayaUtils.openPointInstancesGrid14Scene()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
 
     def testPointInstances(self):
         # Create a UFE path to a PointInstancer prim with an instanceIndex on
@@ -138,3 +146,7 @@ class PointInstancesTestCase(unittest.TestCase):
         self.assertEqual(
             ufePathString,
             '|UsdProxy|UsdProxyShape,/PointInstancerGrid/PointInstancer')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testPythonWrappers.py
+++ b/test/lib/ufe/testPythonWrappers.py
@@ -16,13 +16,19 @@
 # limitations under the License.
 #
 
-import unittest
+import fixturesUtils
+import mayaUtils
+import ufeUtils
+import usdUtils
 
-import mayaUtils, ufeUtils, usdUtils
 import mayaUsd
+
+from maya import cmds
+from maya import standalone
+
 import ufe
 
-import maya.cmds as cmds
+import unittest
 
 
 class PythonWrappersTestCase(unittest.TestCase):
@@ -33,8 +39,14 @@ class PythonWrappersTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
 
     def setUp(self):
         ''' Called initially to set up the Maya test environment '''
@@ -99,3 +111,7 @@ class PythonWrappersTestCase(unittest.TestCase):
         self.assertTrue(mayaRtid > 0)
         self.assertTrue(usdRtid > 0)
         self.assertNotEqual(mayaRtid, usdRtid)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testRename.py
+++ b/test/lib/ufe/testRename.py
@@ -16,19 +16,24 @@
 # limitations under the License.
 #
 
-import maya.cmds as cmds
+import fixturesUtils
+import mayaUtils
+import usdUtils
+
+import mayaUsd.ufe
 
 from pxr import Usd
 
-import collections
+from maya import cmds
+from maya import standalone
 
-import usdUtils, mayaUtils
 import ufe
-import mayaUsd.ufe
 
-import unittest
-import re
+import collections
 import os
+import re
+import unittest
+
 
 # This class is used for composition arcs query.
 class CompositionQuery(object):
@@ -77,12 +82,16 @@ class RenameTestCase(unittest.TestCase):
     
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
     
     @classmethod
     def tearDownClass(cls):
         cmds.file(new=True, force=True)
+
+        standalone.uninitialize()
 
     def setUp(self):
         ''' Called initially to set up the Maya test environment '''
@@ -571,3 +580,7 @@ class RenameTestCase(unittest.TestCase):
 
         compQueryPrimC = CompositionQuery(stage.GetPrimAtPath('/objects_eggplant/geos_cucumber/cube_C'))
         self.assertTrue(list(compQueryPrimC.getData()[1].values()), ['specialize', '/objects_eggplant/geos_cucumber/cube_banana'])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testReorderCmd.py
+++ b/test/lib/ufe/testReorderCmd.py
@@ -16,15 +16,21 @@
 # limitations under the License.
 #
 
-import usdUtils, mayaUtils
+import fixturesUtils
+import mayaUtils
+import usdUtils
+
+import mayaUsd.ufe
+
+from maya import cmds
+from maya import standalone
 
 import ufe
-import mayaUsd.ufe
-import maya.cmds as cmds
 
-import unittest
-import re
 import os
+import re
+import unittest
+
 
 def findIndex(childItem):
     hier = ufe.Hierarchy.hierarchy(childItem)
@@ -39,12 +45,16 @@ class ReorderCmdTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
 
     @classmethod
     def tearDownClass(cls):
         cmds.file(new=True, force=True)
+
+        standalone.uninitialize()
 
     def setUp(self):
         # load plugins
@@ -143,3 +153,7 @@ class ReorderCmdTestCase(unittest.TestCase):
         self.assertEqual(findIndex(capsuleItem), 1)
         self.assertEqual(findIndex(coneItem),    2) 
         self.assertEqual(findIndex(cubeItem),    3)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testRotateCmd.py
+++ b/test/lib/ufe/testRotateCmd.py
@@ -16,18 +16,23 @@
 # limitations under the License.
 #
 
-import maya.api.OpenMaya as om
-import maya.cmds as cmds
-from math import radians
-
-import usdUtils, mayaUtils, ufeUtils
-from testUtils import assertVectorAlmostEqual
+import fixturesUtils
+import mayaUtils
 import testTRSBase
+from testUtils import assertVectorAlmostEqual
+import ufeUtils
+import usdUtils
+
+from maya import cmds
+from maya import standalone
+from maya.api import OpenMaya as om
+
 import ufe
 
+from functools import partial
+from math import radians
 import unittest
 
-from functools import partial
 
 def transform3dRotation(transform3d):
     matrix = om.MMatrix(transform3d.inclusiveMatrix().matrix)
@@ -69,8 +74,14 @@ class RotateCmdTestCase(testTRSBase.TRSTestCaseBase):
     
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
     
     def setUp(self):
         ''' Called initially to set up the maya test environment '''
@@ -267,3 +278,6 @@ class RotateCmdTestCase(testTRSBase.TRSTestCaseBase):
 
         self.runMultiSelectTestRotate(ballItems, expected)
         
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testRotatePivot.py
+++ b/test/lib/ufe/testRotatePivot.py
@@ -16,17 +16,22 @@
 # limitations under the License.
 #
 
-import usdUtils, mayaUtils
+import fixturesUtils
+import mayaUtils
+import usdUtils
+
+from maya import cmds
+from maya import standalone
+from maya.api import OpenMaya as om
 
 import ufe
 
-import maya.api.OpenMaya as om
-import maya.cmds as cmds
-
-from math import radians, degrees, sin
+from math import degrees
+from math import radians
+from math import sin
 import os
-
 import unittest
+
 
 def v3dToMPoint(v):
     return om.MPoint(v.x(), v.y(), v.z())
@@ -58,8 +63,14 @@ class RotatePivotTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
 
     def setUp(self):
         ''' Called initially to set up the maya test environment '''
@@ -183,3 +194,7 @@ class RotatePivotTestCase(unittest.TestCase):
         cmds.rotate(degrees(rot[0]), degrees(rot[1]), degrees(rot[2]))
         sphereMatrix = om.MMatrix(t3d.inclusiveMatrix().matrix)
         self.checkPos(sphereMatrix, [xyWorldValue, xyWorldValue, 0])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testScaleCmd.py
+++ b/test/lib/ufe/testScaleCmd.py
@@ -15,17 +15,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import maya.api.OpenMaya as om
-import maya.cmds as cmds
 
-import usdUtils, mayaUtils, ufeUtils
-from testUtils import assertVectorAlmostEqual
+import fixturesUtils
+import mayaUtils
 import testTRSBase
+from testUtils import assertVectorAlmostEqual
+import ufeUtils
+import usdUtils
+
+from maya import cmds
+from maya import standalone
+from maya.api import OpenMaya as om
+
 import ufe
 
+from functools import partial
 import unittest
 
-from functools import partial
 
 def transform3dScale(transform3d):
     matrix = om.MMatrix(transform3d.inclusiveMatrix().matrix)
@@ -65,9 +71,15 @@ class ScaleCmdTestCase(testTRSBase.TRSTestCaseBase):
     
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
-    
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
     def setUp(self):
         ''' Called initially to set up the maya test environment '''
         # Load plugins
@@ -260,3 +272,7 @@ class ScaleCmdTestCase(testTRSBase.TRSTestCaseBase):
         expected = [usdSceneItemScale(ballItem) for ballItem in ballItems]
 
         self.runMultiSelectTestScale(ballItems, expected, places=6)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testSceneItem.py
+++ b/test/lib/ufe/testSceneItem.py
@@ -16,13 +16,18 @@
 # limitations under the License.
 #
 
-import maya.cmds as cmds
+import fixturesUtils
+import mayaUtils
+import usdUtils
 
-import usdUtils, mayaUtils
+from maya import cmds
+from maya import standalone
+
 import ufe
 
-import unittest
 import os
+import unittest
+
 
 class SceneItemTestCase(unittest.TestCase):
     '''Verify the SceneItem UFE interface.
@@ -32,8 +37,14 @@ class SceneItemTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
 
     def setUp(self):
         ''' Called initially to set up the maya test environment '''
@@ -60,3 +71,7 @@ class SceneItemTestCase(unittest.TestCase):
         ball35AncestorNodeTypes = ball35Item.ancestorNodeTypes()
         self.assertEqual(ball35NodeType, ball35AncestorNodeTypes[0])
         self.assertTrue(len(ball35AncestorNodeTypes) > 1)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testSelection.py
+++ b/test/lib/ufe/testSelection.py
@@ -16,11 +16,15 @@
 # limitations under the License.
 #
 
-import mayaUtils, usdUtils, ufeUtils
+import fixturesUtils
+import mayaUtils
+import ufeUtils
+import usdUtils
+
+from maya import cmds
+from maya import standalone
 
 import ufe
-
-import maya.cmds as cmds
 
 try:
     from maya.internal.ufeSupport import ufeSelectCmd
@@ -28,22 +32,27 @@ except ImportError:
     # Maya 2019 and 2020 don't have ufeSupport plugin, so use fallback.
     from ufeScripts import ufeSelectCmd
 
-import unittest
 import os
+import unittest
+
 
 class SelectTestCase(unittest.TestCase):
     '''Verify UFE selection on a USD scene.'''
 
     pluginsLoaded = False
-    
+
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
     
     @classmethod
     def tearDownClass(cls):
         cmds.file(new=True, force=True)
+
+        standalone.uninitialize()
 
     def setUp(self):
         # Load plugins
@@ -264,3 +273,7 @@ class SelectTestCase(unittest.TestCase):
         cmds.select(ufe.PathString.string(first.path()), add=True)
         self.assertTrue(globalSn.contains(first.path()))
         self.assertEqual(globalSn.back(), first)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testTransform3dChainOfResponsibility.py
+++ b/test/lib/ufe/testTransform3dChainOfResponsibility.py
@@ -16,16 +16,21 @@
 # limitations under the License.
 #
 
-import maya.cmds as cmds
+import fixturesUtils
+import mayaUtils
 
 import mayaUsd.ufe
 
-import mayaUtils
+from pxr import UsdGeom
+from pxr import Vt
+
+from maya import cmds
+from maya import standalone
+
 import ufe
 
-from pxr import UsdGeom, Vt
-
 import unittest
+
 
 class Transform3dChainOfResponsibilityTestCase(unittest.TestCase):
     '''Verify the Transform3d chain of responsibility for USD.'''
@@ -34,9 +39,15 @@ class Transform3dChainOfResponsibilityTestCase(unittest.TestCase):
     
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
-    
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
     def testXformCommonAPI(self):
         '''The Maya transform API is preferred to the USD common API.'''
 
@@ -144,3 +155,7 @@ class Transform3dChainOfResponsibilityTestCase(unittest.TestCase):
             Vt.TokenArray(("xformOp:translate:pivot", "xformOp:rotateXYZ",
                            "!invert!xformOp:translate:pivot")))
         self.assertTrue(UsdGeom.XformCommonAPI(cubeXformable))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testTransform3dTranslate.py
+++ b/test/lib/ufe/testTransform3dTranslate.py
@@ -16,18 +16,23 @@
 # limitations under the License.
 #
 
-import maya.api.OpenMaya as om
-import maya.cmds as cmds
-
-import usdUtils, mayaUtils, ufeUtils
+import fixturesUtils
+import mayaUtils
 from testUtils import assertVectorAlmostEqual
-import ufe
-
-import unittest
-
-from functools import partial
+import ufeUtils
+import usdUtils
 
 from pxr import Gf
+
+from maya import cmds
+from maya import standalone
+from maya.api import OpenMaya as om
+
+import ufe
+
+from functools import partial
+import unittest
+
 
 def matrix4dTranslation(matrix4d):
     translation = matrix4d.matrix[-1]
@@ -80,9 +85,15 @@ class Transform3dTranslateTestCase(unittest.TestCase):
     
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
-    
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
     def setUp(self):
         ''' Called initially to set up the maya test environment '''
         # Load plugins
@@ -235,3 +246,7 @@ class Transform3dTranslateTestCase(unittest.TestCase):
 
         # Notified.
         self.assertEqual(t3dObs.notifications(), 1)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testUIInfoHandler.py
+++ b/test/lib/ufe/testUIInfoHandler.py
@@ -16,14 +16,17 @@
 # limitations under the License.
 #
 
-import os
-
-import maya.cmds as cmds
-
+import fixturesUtils
 import mayaUtils
+
+from maya import cmds
+from maya import standalone
+
 import ufe
 
+import os
 import unittest
+
 
 class UIInfoHandlerTestCase(unittest.TestCase):
     '''Verify the UIInfoHandler USD implementation.
@@ -33,8 +36,14 @@ class UIInfoHandlerTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
         if not cls.pluginsLoaded:
             cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
 
     def setUp(self):
         ''' Called initially to set up the Maya test environment '''
@@ -79,3 +88,7 @@ class UIInfoHandlerTestCase(unittest.TestCase):
         icon = ufeUIInfo.treeViewIcon(ball3Hier)
         self.assertEqual(icon.baseIcon, "out_USD_Sphere.png")
         self.assertFalse(icon.badgeIcon)    # empty string
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testUfePythonImport.py
+++ b/test/lib/ufe/testUfePythonImport.py
@@ -16,6 +16,10 @@
 # limitations under the License.
 #
 
+import fixturesUtils
+
+from maya import standalone
+
 import unittest
 
 
@@ -23,6 +27,14 @@ class UfePythonImportTestCase(unittest.TestCase):
     """
     Verify that the ufe Python module imports correctly.
     """
+
+    @classmethod
+    def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
 
     def testImportModule(self):
         from mayaUsd import ufe as mayaUsdUfe
@@ -46,3 +58,7 @@ class UfePythonImportTestCase(unittest.TestCase):
         # of the two.
         typeName = type(invalidPrim).__name__
         self.assertIn(typeName, ['Prim', 'Object'])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This change syncs the tests in `test/lib/ufe` with tests elsewhere in the source tree so that the script files are directly runnable (with the addition of a `__name__ == "__main__"` block at the bottom) rather than only as a module. They also now use `fixturesUtils` to ensure that Maya standalone is initialized and uninitialized in that case.

I also cleaned up and reordered the module imports at the top of each test script.