### PR TITLE
perrauo/MAYA-109675/fix-crash-after-load-unload-and-loading-new

### DIFF
--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
@@ -264,11 +264,13 @@ MtohRenderOverride::MtohRenderOverride(const MtohRendererDescription& desc)
 
 MtohRenderOverride::~MtohRenderOverride()
 {
+#if WANT_UFE_BUILD
     const Ufe::GlobalSelection::Ptr& ufeSelection = Ufe::GlobalSelection::get();
     if (ufeSelection) {
         ufeSelection->removeObserver(_ufeSelectionObserver);
         _ufeSelectionObserver = nullptr;
     }
+#endif // WANT_UFE_BUILD
 
     TF_DEBUG(HDMAYA_RENDEROVERRIDE_RESOURCES)
         .Msg(


### PR DESCRIPTION
* Remove lingering Ufe::GlobalSelection callback observer when the renderOverride is destroyed.