### PR TITLE
We will need to adopt new OCIOv2 in mtoh tests, but for now switch it off

### DIFF
--- a/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -30,6 +30,10 @@ foreach(script ${TEST_SCRIPT_FILES})
             # Maya uses a very old version of GLEW, so we need support for
             # pre-loading a newer version from elsewhere.
             "LD_PRELOAD=${ADDITIONAL_LD_PRELOAD}"
+
+            # Fallback to old color management. We will have to investigate
+            # and introduce OCIOv2 compatible version of these tests.
+            "MAYA_COLOR_MANAGEMENT_SYNCOLOR=1"
     )
 
     # Assign a CTest label to these tests for easy filtering.

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
@@ -36,6 +36,10 @@ foreach(script ${TEST_SCRIPT_FILES})
             # Maya uses a very old version of GLEW, so we need support for
             # pre-loading a newer version from elsewhere.
             "LD_PRELOAD=${ADDITIONAL_LD_PRELOAD}"
+
+            # Fallback to old color management. We will have to investigate
+            # and introduce OCIOv2 compatible version of these tests.
+            "MAYA_COLOR_MANAGEMENT_SYNCOLOR=1"
     )
 
     # Assign a CTest label to these tests for easy filtering.


### PR DESCRIPTION
We will have to detect if OCIOv2 is running and set it up differently. The CM default settings have changed, including the default render color space (instead of "scene-linear Rec 709/sRGB"), and the former view transform "sRGB gamma" is now a pair "ACES 1.0 SDR-video (sRGB). The end result is to see the viewport is a little bit darker.

Also, the outputTransformName "Raw" was renamed to "Raw (sRGB)".

Above will require changes, including new base images. For now, we switch back to legacy mode.