### PR TITLE
fix build breakage from PR #1119 due to missing Hydra API in USD 20.05

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -804,7 +804,7 @@ bool ProxyRenderDelegate::getInstancedSelectionPath(
     SdfPath topLevelPath;
     int     topLevelInstanceIndex = UsdImagingDelegate::ALL_INSTANCES;
 
-#if defined(USD_IMAGING_API_VERSION) && USD_IMAGING_API_VERSION >= 13
+#if defined(USD_IMAGING_API_VERSION) && USD_IMAGING_API_VERSION >= 14
     HdInstancerContext instancerContext;
     SdfPath usdPath = _sceneDelegate->GetScenePrimPath(rprimId, instanceIndex, &instancerContext);
 
@@ -815,6 +815,8 @@ bool ProxyRenderDelegate::getInstancedSelectionPath(
         topLevelPath = instancerContext.front().first;
         topLevelInstanceIndex = instancerContext.front().second;
     }
+#elif defined(USD_IMAGING_API_VERSION) && USD_IMAGING_API_VERSION >= 13
+    SdfPath usdPath = _sceneDelegate->GetScenePrimPath(rprimId, instanceIndex);
 #else
     SdfPath indexPath;
     if (drawInstID > 0) {
@@ -834,7 +836,7 @@ bool ProxyRenderDelegate::getInstancedSelectionPath(
     }
 
     // The "Instances" point instances pick mode is not supported for
-    // USD_IMAGING_API_VERSION < 13 (core USD versions earlier than 20.05), so
+    // USD_IMAGING_API_VERSION < 14 (core USD versions earlier than 20.08), so
     // no setting of topLevelPath or topLevelInstanceIndex here.
 #endif
 

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
@@ -3,9 +3,9 @@ set(TARGET_NAME VP2_RENDER_DELEGATE_TEST)
 # Unit test scripts.
 set(TEST_SCRIPT_FILES "")
 
-if (CMAKE_UFE_V2_FEATURES_AVAILABLE AND USD_VERSION_NUM GREATER_EQUAL 2005)
-    # The point instance selection tests requires UsdImaging API version 13 or
-    # later, which is only provided by core USD 20.05 or later.
+if (CMAKE_UFE_V2_FEATURES_AVAILABLE AND USD_VERSION_NUM GREATER_EQUAL 2008)
+    # The point instance selection tests requires UsdImaging API version 14 or
+    # later, which is only provided by core USD 20.08 or later.
     list(APPEND TEST_SCRIPT_FILES
         testVP2RenderDelegatePointInstanceSelection.py
         testVP2RenderDelegatePointInstancesPickMode.py


### PR DESCRIPTION
Point instance selection depends on getting the `HdInstancerContext` from Hydra which was only exposed in `USD_IMAGING_API_VERSION` version 14. As a result, we can only support point instance selection for core USD 20.08, not 20.05 as previously thought.