### PR TITLE
remove irrelevant setting of VP2_RENDER_DELEGATE_PROXY in vp2RenderDelegate tests

### DIFF
--- a/test/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
@@ -28,8 +28,6 @@ foreach(script ${TEST_SCRIPT_FILES})
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         PYTHON_SCRIPT ${script}
         ENV
-            "VP2_RENDER_DELEGATE_PROXY=1"
-
             "MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/lib/maya"
             "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
 


### PR DESCRIPTION
This was accidentally introduced by #1119 since that work spanned the transition from using `VP2_RENDER_DELEGATE_PROXY` to `MAYAUSD_DISABLE_VP2_RENDER_DELEGATE`.