### PR TITLE
Cleanup + simplify some of the selection logic in the AL plugin

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp
@@ -54,7 +54,6 @@ bool Engine::TestIntersectionBatch(
     UsdImagingGLRenderParams params,
     const TfToken&           resolveMode,
     unsigned int             pickResolution,
-    PathTranslatorCallback   pathTranslator,
     HitBatch*                outHit)
 {
     if (ARCH_UNLIKELY(_legacyImpl)) {
@@ -124,7 +123,7 @@ bool Engine::TestIntersectionBatch(
         }
 #endif
 
-        HitInfo& info = (*outHit)[pathTranslator(primPath, instancerPath, instanceIndex)];
+        HitInfo& info = (*outHit)[primPath];
 
         info.worldSpaceHitPoint = GfVec3d(
             hit.worldSpaceHitPoint[0], hit.worldSpaceHitPoint[1], hit.worldSpaceHitPoint[2]);

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp
@@ -32,7 +32,6 @@
 
 #include <pxr/imaging/hd/engine.h>
 #include <pxr/imaging/hdx/pickTask.h>
-#include <pxr/imaging/hdx/taskController.h>
 #include <pxr/usdImaging/usdImaging/delegate.h>
 
 #include <vector>
@@ -100,20 +99,14 @@ bool Engine::TestIntersectionBatch(
 
     for (const auto& hit : allHits) {
         SdfPath primPath = hit.objectId;
-        SdfPath instancerPath = hit.instancerId;
         int     instanceIndex = hit.instanceIndex;
 
 #if defined(USDIMAGINGGL_API_VERSION) && USDIMAGINGGL_API_VERSION >= 5
         // See similar code in usdImagingGL/engine.cpp...
         primPath = _GetSceneDelegate()->GetScenePrimPath(primPath, instanceIndex);
-        instancerPath = _GetSceneDelegate()
-                            ->ConvertIndexPathToCachePath(instancerPath)
-                            .GetAbsoluteRootOrPrimPath();
 #elif defined(USDIMAGINGGL_API_VERSION) && USDIMAGINGGL_API_VERSION >= 3
         // See similar code in usdImagingGL/engine.cpp...
         primPath = _delegate->GetScenePrimPath(primPath, instanceIndex);
-        instancerPath
-            = _delegate->ConvertIndexPathToCachePath(instancerPath).GetAbsoluteRootOrPrimPath();
 #else
         SdfPath resolvedPath = GetPrimPathFromInstanceIndex(primPath, instanceIndex);
         if (!resolvedPath.IsEmpty()) {
@@ -123,11 +116,7 @@ bool Engine::TestIntersectionBatch(
         }
 #endif
 
-        HitInfo& info = (*outHit)[primPath];
-
-        info.worldSpaceHitPoint = GfVec3d(
-            hit.worldSpaceHitPoint[0], hit.worldSpaceHitPoint[1], hit.worldSpaceHitPoint[2]);
-        info.hitInstanceIndex = instanceIndex;
+        (*outHit)[primPath] = hit.worldSpaceHitPoint;
     }
 
     return true;

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp
@@ -52,6 +52,7 @@ bool Engine::TestIntersectionBatch(
     const GfMatrix4d&        worldToLocalSpace,
     const SdfPathVector&     paths,
     UsdImagingGLRenderParams params,
+    const TfToken&           resolveMode,
     unsigned int             pickResolution,
     PathTranslatorCallback   pathTranslator,
     HitBatch*                outHit)
@@ -59,7 +60,6 @@ bool Engine::TestIntersectionBatch(
     if (ARCH_UNLIKELY(_legacyImpl)) {
         return false;
     }
-
     _UpdateHydraCollection(&_intersectCollection, paths, params);
 
     TfTokenVector renderTags;
@@ -73,7 +73,7 @@ bool Engine::TestIntersectionBatch(
 
     HdxPickTaskContextParams pickParams;
     pickParams.resolution = GfVec2i(pickResolution, pickResolution);
-    pickParams.resolveMode = HdxPickTokens->resolveUnique;
+    pickParams.resolveMode = resolveMode;
     pickParams.viewMatrix = worldToLocalSpace * viewMatrix;
     pickParams.projectionMatrix = projectionMatrix;
     pickParams.clipPlanes = params.clipPlanes;

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.h
@@ -45,6 +45,7 @@ public:
         const GfMatrix4d&        worldToLocalSpace,
         const SdfPathVector&     paths,
         UsdImagingGLRenderParams params,
+        const TfToken&           resolveMode,
         unsigned int             pickResolution,
         PathTranslatorCallback   pathTranslator,
         HitBatch*                outHit);

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.h
@@ -47,7 +47,6 @@ public:
         UsdImagingGLRenderParams params,
         const TfToken&           resolveMode,
         unsigned int             pickResolution,
-        PathTranslatorCallback   pathTranslator,
         HitBatch*                outHit);
 };
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.h
@@ -15,6 +15,7 @@
 //
 #pragma once
 
+#include <pxr/imaging/hdx/taskController.h>
 #include <pxr/usdImaging/usdImagingGL/engine.h>
 #include <pxr/usdImaging/usdImagingGL/renderParams.h>
 
@@ -29,12 +30,7 @@ class Engine : public UsdImagingGLEngine
 public:
     Engine(const SdfPath& rootPath, const SdfPathVector& excludedPaths);
 
-    struct HitInfo
-    {
-        GfVec3d worldSpaceHitPoint;
-        int     hitInstanceIndex;
-    };
-    typedef TfHashMap<SdfPath, HitInfo, SdfPath::Hash> HitBatch;
+    typedef TfHashMap<SdfPath, GfVec3d, SdfPath::Hash> HitBatch;
 
     typedef std::function<SdfPath(const SdfPath&, const SdfPath&, const int)>
         PathTranslatorCallback;

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -468,19 +468,6 @@ ProxyShape* ProxyDrawOverride::getShape(const MDagPath& objPath)
     return static_cast<ProxyShape*>(dnNode.userNode());
 }
 
-//----------------------------------------------------------------------------------------------------------------------
-class ProxyDrawOverrideSelectionHelper
-{
-public:
-    static SdfPath path_ting(const SdfPath& a, const SdfPath& b, const int c)
-    {
-        m_paths.push_back(a);
-        return a;
-    }
-    static SdfPathVector m_paths;
-};
-SdfPathVector ProxyDrawOverrideSelectionHelper::m_paths;
-
 #if MAYA_API_VERSION >= 20180600
 //----------------------------------------------------------------------------------------------------------------------
 bool ProxyDrawOverride::userSelect(
@@ -578,7 +565,6 @@ bool ProxyDrawOverride::userSelect(
         params,
         resolveMode,
         resolution,
-        ProxyDrawOverrideSelectionHelper::path_ting,
         &hitBatch);
 
     auto selected = false;
@@ -636,9 +622,8 @@ bool ProxyDrawOverride::userSelect(
             }
 
             for (const auto& it : hitBatch) {
-                auto path = it.first;
                 command += " -pp \"";
-                command += path.GetText();
+                command += it.first.GetText();
                 command += "\"";
             }
 
@@ -831,8 +816,6 @@ bool ProxyDrawOverride::userSelect(
         } // else MAYA_WANT_UFE_SELECTION
 #endif
     }
-
-    ProxyDrawOverrideSelectionHelper::m_paths.clear();
 
     // We are done executing commands that needed to handle our current
     // proxy as a special case.  Unset the ignore state on the proxy.

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -582,7 +582,7 @@ bool ProxyDrawOverride::userSelect(
                 MFnDagNode dagNode(obj);
                 MDagPath   dg;
                 dagNode.getPath(dg);
-                const double* p = it.second.worldSpaceHitPoint.GetArray();
+                const double* p = it.second.GetArray();
 
                 selectionList.add(dg);
                 worldSpaceHitPts.append(MPoint(p[0], p[1], p[2]));

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -567,12 +567,16 @@ bool ProxyDrawOverride::userSelect(
         resolution = 1024;
     }
 
+    TfToken resolveMode = selectInfo.singleSelection() ? HdxPickTokens->resolveNearestToCamera
+                                                       : HdxPickTokens->resolveUnique;
+
     bool hitSelected = engine->TestIntersectionBatch(
         GfMatrix4d(worldViewMatrix.matrix),
         GfMatrix4d(projectionMatrix.matrix),
         worldToLocalSpace,
         rootPath,
         params,
+        resolveMode,
         resolution,
         ProxyDrawOverrideSelectionHelper::path_ting,
         &hitBatch);
@@ -653,44 +657,8 @@ bool ProxyDrawOverride::userSelect(
         SdfPathVector paths;
         if (!hitBatch.empty()) {
             paths.reserve(hitBatch.size());
-
-            auto addHit
-                = [&paths](Engine::HitBatch::const_reference& it) { paths.push_back(it.first); };
-
-            // Due to the inaccuracies in the selection method in gl engine
-            // we still need to find the closest selection.
-            // Around the edges it often selects two or more prims.
-            if (selectInfo.singleSelection()) {
-                auto closestHit = hitBatch.cbegin();
-
-                if (hitBatch.size() > 1) {
-                    MDagPath cameraPath;
-                    M3dView::active3dView().getCamera(cameraPath);
-                    const auto cameraPoint
-                        = cameraPath.inclusiveMatrix() * MPoint(0.0, 0.0, 0.0, 1.0);
-                    auto distanceToCameraSq
-                        = [&cameraPoint](Engine::HitBatch::const_reference& it) -> double {
-                        const auto dx = cameraPoint.x - it.second.worldSpaceHitPoint[0];
-                        const auto dy = cameraPoint.y - it.second.worldSpaceHitPoint[1];
-                        const auto dz = cameraPoint.z - it.second.worldSpaceHitPoint[2];
-                        return dx * dx + dy * dy + dz * dz;
-                    };
-
-                    auto closestDistance = distanceToCameraSq(*closestHit);
-                    for (auto it = ++hitBatch.cbegin(), itEnd = hitBatch.cend(); it != itEnd;
-                         ++it) {
-                        const auto currentDistance = distanceToCameraSq(*it);
-                        if (currentDistance < closestDistance) {
-                            closestDistance = currentDistance;
-                            closestHit = it;
-                        }
-                    }
-                }
-                addHit(*closestHit);
-            } else {
-                for (const auto& it : hitBatch) {
-                    addHit(it);
-                }
+            for (const auto& it : hitBatch) {
+                paths.push_back(it.first);
             }
         }
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -32,6 +32,8 @@
 #include "AL/usdmaya/nodes/Engine.h"
 #include "AL/usdmaya/nodes/ProxyShape.h"
 
+#include <pxr/imaging/hdx/pickTask.h>
+
 #include <maya/M3dView.h>
 #include <maya/MDrawContext.h>
 #include <maya/MFnDagNode.h>

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
@@ -56,6 +56,7 @@
 #include <pxr/base/arch/env.h>
 #endif
 
+#include <pxr/imaging/hdx/pickTask.h>
 #include <pxr/usd/kind/registry.h>
 #include <pxr/usd/usd/modelAPI.h>
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
@@ -386,7 +386,7 @@ bool ProxyShapeUI::select(
                 MDagPath       dg;
                 dagNode.getPath(dg);
                 sl.add(dg);
-                const double* d = it.second.worldSpaceHitPoint.GetArray();
+                const double* d = it.second.GetArray();
                 selectInfo.addSelection(
                     sl,
                     MPoint(d[0], d[1], d[2], 1.0),

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
@@ -280,19 +280,6 @@ void ProxyShapeUI::draw(const MDrawRequest& request, M3dView& view) const
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-class ProxyShapeSelectionHelper
-{
-public:
-    static SdfPath path_ting(const SdfPath& a, const SdfPath& b, const int c)
-    {
-        m_paths.push_back(a);
-        return a;
-    }
-    static SdfPathVector m_paths;
-};
-SdfPathVector ProxyShapeSelectionHelper::m_paths;
-
-//----------------------------------------------------------------------------------------------------------------------
 bool ProxyShapeUI::select(
     MSelectInfo&    selectInfo,
     MSelectionList& selectionList,
@@ -363,7 +350,6 @@ bool ProxyShapeUI::select(
         params,
         resolveMode,
         resolution,
-        ProxyShapeSelectionHelper::path_ting,
         &hitBatch);
 
     auto selected = false;
@@ -442,9 +428,8 @@ bool ProxyShapeUI::select(
             }
 
             for (const auto& it : hitBatch) {
-                auto path = it.first;
                 command += " -pp \"";
-                command += path.GetText();
+                command += it.first.GetText();
                 command += "\"";
             }
 
@@ -681,8 +666,6 @@ bool ProxyShapeUI::select(
         } // else MAYA_WANT_UFE_SELECTION
 #endif
     }
-
-    ProxyShapeSelectionHelper::m_paths.clear();
 
     // restore clear colour
     glClearColor(clearCol[0], clearCol[1], clearCol[2], clearCol[3]);


### PR DESCRIPTION
I noticed that some bits of the AL selection code can be simplified / removed, some of which led to cascades of other bits being removed. In particular:

- I removed the custom code for getting nearest hit to camera, and instead rely on built-in resolveNearestToCamera
- Removed the need for `*SelectionHelper`, since we no longer use the hits we tracked with it
- Removed the need for custom `HitInfo` struct, as we never we no longer used the instanceIndex info, just the world space position