### PR TITLE
maintain UV connectivity across export and re-import round trips

### DIFF
--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
@@ -30,6 +30,7 @@
 #include <pxr/base/tf/staticTokens.h>
 #include <pxr/base/tf/token.h>
 #include <pxr/base/vt/array.h>
+#include <pxr/pxr.h>
 #include <pxr/usd/usdGeom/mesh.h>
 #include <pxr/usd/usdGeom/pointBased.h>
 #include <pxr/usd/usdGeom/primvar.h>
@@ -873,7 +874,12 @@ bool UsdMayaMeshWriteUtils::getMeshUVSetData(
     uvArray->clear();
     uvArray->reserve(static_cast<size_t>(uArray.length()));
     for (unsigned int uvId = 0u; uvId < uArray.length(); ++uvId) {
+#if PXR_VERSION >= 2011
         uvArray->emplace_back(uArray[uvId], vArray[uvId]);
+#else
+        GfVec2f value(uArray[uvId], vArray[uvId]);
+        uvArray->push_back(value);
+#endif
     }
 
     // Now iterate through all the face vertices and fill in the faceVarying

--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
@@ -846,39 +846,46 @@ bool UsdMayaMeshWriteUtils::getMeshUVSetData(
     TfToken*       interpolation,
     VtIntArray*    assignmentIndices)
 {
-    MStatus status { MS::kSuccess };
-
-    // Sanity check first to make sure this UV set even has assigned values
-    // before we attempt to do anything with the data.
+    // Check first to make sure this UV set even has assigned values before we
+    // attempt to do anything with the data. We cannot directly use this data
+    // otherwise though since we need a uvId for every face vertex, and the
+    // returned uvIds MIntArray may be shorter than that if there are unmapped
+    // faces.
     MIntArray uvCounts, uvIds;
-    status = mesh.getAssignedUVs(uvCounts, uvIds, &uvSetName);
-    if (status != MS::kSuccess) {
-        return false;
-    }
-    if (uvCounts.length() == 0 || uvIds.length() == 0) {
+    MStatus   status = mesh.getAssignedUVs(uvCounts, uvIds, &uvSetName);
+    CHECK_MSTATUS_AND_RETURN(status, false);
+
+    if (uvCounts.length() == 0u || uvIds.length() == 0u) {
         return false;
     }
 
-    // using itFV.getUV() does not always give us the right answer, so
-    // instead, we have to use itFV.getUVIndex() and use that to index into the
-    // UV set.
+    // Transfer the UV values directly to USD, in the same order as they are in
+    // the Maya mesh.
     MFloatArray uArray;
     MFloatArray vArray;
-    mesh.getUVs(uArray, vArray, &uvSetName);
+    status = mesh.getUVs(uArray, vArray, &uvSetName);
+    CHECK_MSTATUS_AND_RETURN(status, false);
+
     if (uArray.length() != vArray.length()) {
         return false;
     }
 
-    // We'll populate the assignment indices for every face vertex, but we'll
-    // only push values into the data if the face vertex has a value. All face
-    // vertices are initially unassigned/unauthored.
-    const unsigned int numFaceVertices = mesh.numFaceVertices(&status);
     uvArray->clear();
-    assignmentIndices->assign((size_t)numFaceVertices, -1);
+    uvArray->reserve(static_cast<size_t>(uArray.length()));
+    for (unsigned int uvId = 0u; uvId < uArray.length(); ++uvId) {
+        uvArray->emplace_back(uArray[uvId], vArray[uvId]);
+    }
+
+    // Now iterate through all the face vertices and fill in the faceVarying
+    // assignmentIndices array, again in the same order as in the Maya mesh.
+    const unsigned int numFaceVertices = mesh.numFaceVertices(&status);
+    CHECK_MSTATUS_AND_RETURN(status, false);
+
+    assignmentIndices->assign(static_cast<size_t>(numFaceVertices), -1);
     *interpolation = UsdGeomTokens->faceVarying;
 
     MItMeshFaceVertex itFV(mesh.object());
-    unsigned int      fvi = 0;
+    unsigned int      fvi = 0u;
     for (itFV.reset(); !itFV.isDone(); itFV.next(), ++fvi) {
         if (!itFV.hasUVs(uvSetName)) {
             // No UVs for this faceVertex, so leave it unassigned.
@@ -887,17 +894,16 @@ bool UsdMayaMeshWriteUtils::getMeshUVSetData(
 
         int uvIndex;
         itFV.getUVIndex(uvIndex, &uvSetName);
-        if (uvIndex < 0 || static_cast<size_t>(uvIndex) >= uArray.length()) {
+        if (uvIndex < 0 || static_cast<unsigned int>(uvIndex) >= uArray.length()) {
             return false;
         }
 
-        GfVec2f value(uArray[uvIndex], vArray[uvIndex]);
-        uvArray->push_back(value);
-        (*assignmentIndices)[fvi] = uvArray->size() - 1;
+        (*assignmentIndices)[fvi] = uvIndex;
     }
 
-    UsdMayaUtil::MergeEquivalentIndexedValues(uvArray, assignmentIndices);
-    UsdMayaUtil::CompressFaceVaryingPrimvarIndices(mesh, interpolation, assignmentIndices);
+    // We do not merge indexed values or compress indices here in an effort to
+    // maintain the same UV shells and connectivity across export/import
+    // round-trips.
 
     return true;
 }

--- a/test/lib/usd/translators/UsdExportUVSetsFloatTest/UsdExportUVSetsTest_Float.ma
+++ b/test/lib/usd/translators/UsdExportUVSetsFloatTest/UsdExportUVSetsTest_Float.ma
@@ -352,12 +352,10 @@ createNode mesh -n "SharedFacesCubeShape" -p "SharedFacesCube";
 	setAttr -s 3 ".uvst";
 	setAttr ".uvst[0].uvsn" -type "string" "map1";
 	setAttr ".uvst[1].uvsn" -type "string" "PairedFacesSet";
-	setAttr -s 23 ".uvst[1].uvsp[0:22]" -type "float2" 0 0 0.5 0 0.5 0.5
-		 0 0.5 0.5 0.5 1 0.5 1 1 0.5 1 0 0 0.5 0 0.5 0.5 0 0.5 0.5 0.5 1 0.5 1 1 0.5 1 0 0
-		 0.5 0 0.5 0.5 0 0.5 0.5 0.5 1 0.5 1 1;
+	setAttr -s 7 ".uvst[1].uvsp[0:6]" -type "float2" 0 0 0.5 0 0.5 0.5
+		 0 0.5 1 0.5 1 1 0.5 1;
 	setAttr ".uvst[2].uvsn" -type "string" "AllFacesSharedSet";
-	setAttr -s 24 ".uvst[2].uvsp[0:23]" -type "float2" 0 0 1 0 1 1 0 1 0
-		 0 1 0 1 1 0 1 0 0 1 0 1 1 0 1 0 0 1 0 1 1 0 1 0 0 1 0 1 1 0 1 0 0 1 0 1 1 0 1;
+	setAttr -s 4 ".uvst[2].uvsp[0:3]" -type "float2" 0 0 1 0 1 1 0 1;
 	setAttr ".cuvs" -type "string" "PairedFacesSet";
 	setAttr ".dcc" -type "string" "Ambient+Diffuse";
 	setAttr ".ds" no;
@@ -372,20 +370,20 @@ createNode mesh -n "SharedFacesCubeShape" -p "SharedFacesCube";
 		mu 1 4 0 1 2 3
 		mu 2 4 0 1 2 3
 		f 4 1 7 -3 -7
-		mu 1 4 4 5 6 7
-		mu 2 4 4 5 6 7
+		mu 1 4 2 4 5 6
+		mu 2 4 0 1 2 3
 		f 4 2 9 -4 -9
-		mu 1 4 8 9 10 11
-		mu 2 4 8 9 10 11
+		mu 1 4 0 1 2 3
+		mu 2 4 0 1 2 3
 		f 4 3 11 -1 -11
-		mu 1 4 12 13 14 15
-		mu 2 4 12 13 14 15
+		mu 1 4 2 4 5 6
+		mu 2 4 0 1 2 3
 		f 4 -12 -10 -8 -6
-		mu 1 4 16 17 18 19
-		mu 2 4 16 17 18 19
+		mu 1 4 0 1 2 3
+		mu 2 4 0 1 2 3
 		f 4 10 4 6 8
-		mu 1 4 20 21 22 7
-		mu 2 4 20 21 22 23;
+		mu 1 4 2 4 5 6
+		mu 2 4 0 1 2 3;
 	setAttr ".cd" -type "dataPolyComponent" Index_Data Edge 0 ;
 	setAttr ".cvd" -type "dataPolyComponent" Index_Data Vertex 0 ;
 	setAttr -s 3 ".pd";

--- a/test/lib/usd/translators/UsdExportUVSetsFloatTest/UsdExportUVSetsTest_Float.ma
+++ b/test/lib/usd/translators/UsdExportUVSetsFloatTest/UsdExportUVSetsTest_Float.ma
@@ -326,90 +326,6 @@ createNode mesh -n "polySurfaceShape2" -p "OneAssignedFaceCube";
 	setAttr ".hfd" -type "dataPolyComponent" Index_Data Face 0 ;
 	setAttr ".mgi" -type "string" "ID_41632452-941c-445a-8955-d85daaf8813f";
 	setAttr ".allowPerFaceDisplayColors" yes;
-createNode transform -n "CompressibleUVSetsCube" -p "CubeMeshes";
-	rename -uid "6BB5D8C0-0000-562B-57BB-88050000027F";
-	addAttr -ci true -sn "allowPerFaceDisplayColors" -ln "allowPerFaceDisplayColors" 
-		-min 0 -max 1 -at "bool";
-	setAttr ".t" -type "double3" -20 0 0 ;
-	setAttr ".rp" -type "double3" 0 0 5 ;
-	setAttr ".sp" -type "double3" 0 0 5 ;
-	setAttr ".allowPerFaceDisplayColors" yes;
-createNode mesh -n "CompressibleUVSetsCubeShape" -p "CompressibleUVSetsCube";
-	rename -uid "6BB5D8C0-0000-562B-57BB-880500000280";
-	addAttr -ci true -sn "mgi" -ln "mayaGprimID" -dt "string";
-	addAttr -ci true -sn "allowPerFaceDisplayColors" -ln "allowPerFaceDisplayColors" 
-		-min 0 -max 1 -at "bool";
-	setAttr -k off ".v";
-	setAttr -s 6 ".iog[0].og";
-	setAttr ".iog[0].og[0].gcl" -type "componentList" 1 "f[2]";
-	setAttr ".iog[0].og[1].gcl" -type "componentList" 1 "f[3]";
-	setAttr ".iog[0].og[2].gcl" -type "componentList" 1 "f[4]";
-	setAttr ".iog[0].og[3].gcl" -type "componentList" 1 "f[1]";
-	setAttr ".iog[0].og[4].gcl" -type "componentList" 1 "f[5]";
-	setAttr ".iog[0].og[5].gcl" -type "componentList" 1 "f[0]";
-	setAttr ".vir" yes;
-	setAttr ".vif" yes;
-	setAttr -s 4 ".uvst";
-	setAttr ".uvst[0].uvsn" -type "string" "map1";
-	setAttr ".uvst[1].uvsn" -type "string" "ConstantInterpSet";
-	setAttr -s 22 ".uvst[1].uvsp[0:21]" -type "float2" 0.25 0.25 0.25 0.25
-		 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25
-		 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25
-		 0.25 0.25 0.25 0.25 0.25 0.25;
-	setAttr ".uvst[2].uvsn" -type "string" "UniformInterpSet";
-	setAttr -s 24 ".uvst[2].uvsp[0:23]" -type "float2" 0 0 0.1 0.1 0.2 0.2
-		 0.30000001 0.30000001 0.40000001 0.40000001 0.5 0.5 0 0 0 0 0 0 0.1 0.1 0.1 0.1 0.1
-		 0.1 0.2 0.2 0.2 0.2 0.2 0.2 0.30000001 0.30000001 0.30000001 0.30000001 0.30000001
-		 0.30000001 0.40000001 0.40000001 0.40000001 0.40000001 0.40000001 0.40000001 0.5
-		 0.5 0.5 0.5 0.5 0.5;
-	setAttr ".uvst[3].uvsn" -type "string" "VertexInterpSet";
-	setAttr -s 8 ".uvst[3].uvsp[0:7]" -type "float2" 0 0 0.1 0.1 0.2 0.2
-		 0.30000001 0.30000001 0.40000001 0.40000001 0.5 0.5 0.60000002 0.60000002 0.69999999
-		 0.69999999;
-	setAttr ".cuvs" -type "string" "VertexInterpSet";
-	setAttr ".dcc" -type "string" "Ambient+Diffuse";
-	setAttr ".ds" no;
-	setAttr ".covm[0]"  0 1 1;
-	setAttr ".cdvm[0]"  0 1 1;
-	setAttr -s 8 ".vt[0:7]"  -5 -5 10 5 -5 10 -5 5 10 5 5 10 -5 5 0 5 5 0
-		 -5 -5 0 5 -5 0;
-	setAttr -s 12 ".ed[0:11]"  0 1 0 2 3 0 4 5 0 6 7 0 0 2 0 1 3 0 2 4 0
-		 3 5 0 4 6 0 5 7 0 6 0 0 7 1 0;
-	setAttr -s 6 -ch 24 ".fc[0:5]" -type "polyFaces" 
-		f 4 0 5 -2 -5
-		mu 1 4 0 1 2 3
-		mu 2 4 0 6 7 8
-		mu 3 4 0 1 3 2
-		f 4 1 7 -3 -7
-		mu 1 4 4 5 6 7
-		mu 2 4 1 9 10 11
-		mu 3 4 2 3 5 4
-		f 4 2 9 -4 -9
-		mu 1 4 8 9 10 11
-		mu 2 4 2 12 13 14
-		mu 3 4 4 5 7 6
-		f 4 3 11 -1 -11
-		mu 1 4 12 13 14 0
-		mu 2 4 3 15 16 17
-		mu 3 4 6 7 1 0
-		f 4 -12 -10 -8 -6
-		mu 1 4 15 16 17 18
-		mu 2 4 4 18 19 20
-		mu 3 4 1 7 5 3
-		f 4 10 4 6 8
-		mu 1 4 19 0 20 21
-		mu 2 4 5 21 22 23
-		mu 3 4 6 0 2 4;
-	setAttr ".cd" -type "dataPolyComponent" Index_Data Edge 0 ;
-	setAttr ".cvd" -type "dataPolyComponent" Index_Data Vertex 0 ;
-	setAttr -s 4 ".pd";
-	setAttr ".pd[0]" -type "dataPolyComponent" Index_Data UV 0 ;
-	setAttr ".pd[1]" -type "dataPolyComponent" Index_Data UV 0 ;
-	setAttr ".pd[2]" -type "dataPolyComponent" Index_Data UV 0 ;
-	setAttr ".pd[3]" -type "dataPolyComponent" Index_Data UV 0 ;
-	setAttr ".hfd" -type "dataPolyComponent" Index_Data Face 0 ;
-	setAttr ".mgi" -type "string" "ID_a46bf4f0-e7ae-46d4-8a18-42305fb119fe";
-	setAttr ".allowPerFaceDisplayColors" yes;
 createNode transform -n "SharedFacesCube" -p "CubeMeshes";
 	rename -uid "6BB5D8C0-0000-562B-57BB-96820000028B";
 	addAttr -ci true -sn "allowPerFaceDisplayColors" -ln "allowPerFaceDisplayColors" 
@@ -1747,7 +1663,6 @@ connectAttr "DefaultUVSetCubeShape.iog" "lambert2SG.dsm" -na;
 connectAttr "EmptyDefaultUVSetCubeShape.iog" "lambert2SG.dsm" -na;
 connectAttr "OneMissingFaceCubeShape.iog" "lambert2SG.dsm" -na;
 connectAttr "OneAssignedFaceCubeShape.iog" "lambert2SG.dsm" -na;
-connectAttr "CompressibleUVSetsCubeShape.iog" "lambert2SG.dsm" -na;
 connectAttr "SharedFacesCubeShape.iog" "lambert2SG.dsm" -na;
 connectAttr "lambert2SG.msg" "materialInfo1.sg";
 connectAttr "Red.msg" "materialInfo1.m";

--- a/test/lib/usd/translators/UsdExportUVSetsFloatTest/UsdExportUVSetsTest_Float.ma
+++ b/test/lib/usd/translators/UsdExportUVSetsFloatTest/UsdExportUVSetsTest_Float.ma
@@ -199,30 +199,6 @@ createNode mesh -n "OneMissingFaceCubeShape" -p "OneMissingFaceCube";
 	setAttr ".vir" yes;
 	setAttr ".vif" yes;
 	setAttr ".uvst[0].uvsn" -type "string" "map1";
-	setAttr ".cuvs" -type "string" "map1";
-	setAttr ".dcc" -type "string" "Ambient+Diffuse";
-	setAttr ".ds" no;
-	setAttr ".covm[0]"  0 1 1;
-	setAttr ".cdvm[0]"  0 1 1;
-	setAttr ".mgi" -type "string" "ID_00dcb39c-ae2c-4239-b0d8-945f9db8e612";
-	setAttr ".allowPerFaceDisplayColors" yes;
-createNode mesh -n "polySurfaceShape1" -p "OneMissingFaceCube";
-	rename -uid "415B68C0-0000-16E9-57B7-9C390000027F";
-	addAttr -ci true -sn "mgi" -ln "mayaGprimID" -dt "string";
-	addAttr -ci true -sn "allowPerFaceDisplayColors" -ln "allowPerFaceDisplayColors" 
-		-min 0 -max 1 -at "bool";
-	setAttr -k off ".v";
-	setAttr ".io" yes;
-	setAttr -s 6 ".iog[0].og";
-	setAttr ".iog[0].og[0].gcl" -type "componentList" 1 "f[2]";
-	setAttr ".iog[0].og[1].gcl" -type "componentList" 1 "f[3]";
-	setAttr ".iog[0].og[2].gcl" -type "componentList" 1 "f[4]";
-	setAttr ".iog[0].og[3].gcl" -type "componentList" 1 "f[1]";
-	setAttr ".iog[0].og[4].gcl" -type "componentList" 1 "f[5]";
-	setAttr ".iog[0].og[5].gcl" -type "componentList" 1 "f[0]";
-	setAttr ".vir" yes;
-	setAttr ".vif" yes;
-	setAttr ".uvst[0].uvsn" -type "string" "map1";
 	setAttr -s 14 ".uvst[0].uvsp[0:13]" -type "float2" 0.375 0 0.625 0 0.375
 		 0.25 0.625 0.25 0.375 0.5 0.625 0.5 0.375 0.75 0.625 0.75 0.375 1 0.625 1 0.875 0
 		 0.875 0.25 0.125 0 0.125 0.25;
@@ -241,7 +217,6 @@ createNode mesh -n "polySurfaceShape1" -p "OneMissingFaceCube";
 		f 4 1 7 -3 -7
 		mu 0 4 2 3 5 4
 		f 4 2 9 -4 -9
-		mu 0 4 4 5 7 6
 		f 4 3 11 -1 -11
 		mu 0 4 6 7 9 8
 		f 4 -12 -10 -8 -6
@@ -271,33 +246,8 @@ createNode mesh -n "OneAssignedFaceCubeShape" -p "OneAssignedFaceCube";
 	setAttr ".vir" yes;
 	setAttr ".vif" yes;
 	setAttr ".uvst[0].uvsn" -type "string" "map1";
-	setAttr ".cuvs" -type "string" "map1";
-	setAttr ".dcc" -type "string" "Ambient+Diffuse";
-	setAttr ".ds" no;
-	setAttr ".covm[0]"  0 1 1;
-	setAttr ".cdvm[0]"  0 1 1;
-	setAttr ".mgi" -type "string" "ID_f8c2d19a-0a4f-48e1-b29c-dc491b67c152";
-	setAttr ".allowPerFaceDisplayColors" yes;
-createNode mesh -n "polySurfaceShape2" -p "OneAssignedFaceCube";
-	rename -uid "415B68C0-0000-16E9-57B7-9CCB00000286";
-	addAttr -ci true -sn "mgi" -ln "mayaGprimID" -dt "string";
-	addAttr -ci true -sn "allowPerFaceDisplayColors" -ln "allowPerFaceDisplayColors" 
-		-min 0 -max 1 -at "bool";
-	setAttr -k off ".v";
-	setAttr ".io" yes;
-	setAttr -s 6 ".iog[0].og";
-	setAttr ".iog[0].og[0].gcl" -type "componentList" 1 "f[2]";
-	setAttr ".iog[0].og[1].gcl" -type "componentList" 1 "f[3]";
-	setAttr ".iog[0].og[2].gcl" -type "componentList" 1 "f[4]";
-	setAttr ".iog[0].og[3].gcl" -type "componentList" 1 "f[1]";
-	setAttr ".iog[0].og[4].gcl" -type "componentList" 1 "f[5]";
-	setAttr ".iog[0].og[5].gcl" -type "componentList" 1 "f[0]";
-	setAttr ".vir" yes;
-	setAttr ".vif" yes;
-	setAttr ".uvst[0].uvsn" -type "string" "map1";
-	setAttr -s 14 ".uvst[0].uvsp[0:13]" -type "float2" 0.375 0 0.625 0 0.375
-		 0.25 0.625 0.25 0.375 0.5 0.625 0.5 0.375 0.75 0.625 0.75 0.375 1 0.625 1 0.875 0
-		 0.875 0.25 0.125 0 0.125 0.25;
+	setAttr -s 4 ".uvst[0].uvsp[0:3]" -type "float2" 0.375 0.5 0.625 0.5
+		 0.375 0.75 0.625 0.75;
 	setAttr ".cuvs" -type "string" "map1";
 	setAttr ".dcc" -type "string" "Ambient+Diffuse";
 	setAttr ".ds" no;
@@ -309,17 +259,12 @@ createNode mesh -n "polySurfaceShape2" -p "OneAssignedFaceCube";
 		 3 5 0 4 6 0 5 7 0 6 0 0 7 1 0;
 	setAttr -s 6 -ch 24 ".fc[0:5]" -type "polyFaces" 
 		f 4 0 5 -2 -5
-		mu 0 4 0 1 3 2
 		f 4 1 7 -3 -7
-		mu 0 4 2 3 5 4
 		f 4 2 9 -4 -9
-		mu 0 4 4 5 7 6
+		mu 0 4 0 1 3 2
 		f 4 3 11 -1 -11
-		mu 0 4 6 7 9 8
 		f 4 -12 -10 -8 -6
-		mu 0 4 1 10 11 3
-		f 4 10 4 6 8
-		mu 0 4 12 0 2 13;
+		f 4 10 4 6 8;
 	setAttr ".cd" -type "dataPolyComponent" Index_Data Edge 0 ;
 	setAttr ".cvd" -type "dataPolyComponent" Index_Data Vertex 0 ;
 	setAttr ".pd[0]" -type "dataPolyComponent" Index_Data UV 0 ;
@@ -1312,7 +1257,7 @@ createNode lambert -n "Red";
 createNode shadingEngine -n "lambert2SG";
 	rename -uid "109AE860-0000-148A-5708-3FF300000264";
 	setAttr ".ihi" 0;
-	setAttr -s 6 ".dsm";
+	setAttr -s 5 ".dsm";
 	setAttr ".ro" yes;
 createNode materialInfo -n "materialInfo1";
 	rename -uid "109AE860-0000-148A-5708-3FF300000265";
@@ -1380,14 +1325,6 @@ createNode nodeGraphEditorInfo -n "hyperShadePrimaryNodeEditorSavedTabsInfo";
 	setAttr ".tgi[0].tn" -type "string" "Untitled_1";
 	setAttr ".tgi[0].vl" -type "double2" -113.09523360123723 -455.97199742362869 ;
 	setAttr ".tgi[0].vh" -type "double2" 571.428548722041 205.97200735773578 ;
-createNode polyMapDel -n "polyMapDel1";
-	rename -uid "415B68C0-0000-16E9-57B7-9C390000027E";
-	setAttr ".uopa" yes;
-	setAttr ".ics" -type "componentList" 1 "f[2]";
-createNode polyMapDel -n "polyMapDel2";
-	rename -uid "415B68C0-0000-16E9-57B7-9CCB00000285";
-	setAttr ".uopa" yes;
-	setAttr ".ics" -type "componentList" 2 "f[0:1]" "f[3:5]";
 createNode expression -n "BrokenUVs_C3d__HiddenInfoNode";
 	rename -uid "0D9708C0-0000-66E1-59DF-C01C0000028F";
 	addAttr -ci true -h true -sn "__pxSimNodeEmulate" -ln "__pxSimNodeEmulate" -min 
@@ -1632,8 +1569,6 @@ select -ne :defaultColorMgtGlobals;
 select -ne :hardwareRenderGlobals;
 	setAttr ".ctrs" 256;
 	setAttr ".btrs" 512;
-connectAttr "polyMapDel1.out" "OneMissingFaceCubeShape.i";
-connectAttr "polyMapDel2.out" "OneAssignedFaceCubeShape.i";
 relationship "link" ":lightLinker1" ":initialShadingGroup.message" ":defaultLightSet.message";
 relationship "link" ":lightLinker1" ":initialParticleSE.message" ":defaultLightSet.message";
 relationship "link" ":lightLinker1" "lambert2SG.message" ":defaultLightSet.message";
@@ -1679,8 +1614,6 @@ connectAttr "Magenta.msg" "materialInfo5.m";
 connectAttr "Cyan.oc" "lambert7SG.ss";
 connectAttr "lambert7SG.msg" "materialInfo6.sg";
 connectAttr "Cyan.msg" "materialInfo6.m";
-connectAttr "polySurfaceShape1.o" "polyMapDel1.ip";
-connectAttr "polySurfaceShape2.o" "polyMapDel2.ip";
 connectAttr ":time1.o" "BrokenUVs_C3d__HiddenInfoNode.tim";
 connectAttr "layerManager.dli[4]" "BrokenUVs_Decimated.id";
 connectAttr "layerManager.dli[5]" "BrokenUVs_Simulation.id";

--- a/test/lib/usd/translators/UsdExportUVSetsTest/UsdExportUVSetsTest.ma
+++ b/test/lib/usd/translators/UsdExportUVSetsTest/UsdExportUVSetsTest.ma
@@ -352,12 +352,10 @@ createNode mesh -n "SharedFacesCubeShape" -p "SharedFacesCube";
 	setAttr -s 3 ".uvst";
 	setAttr ".uvst[0].uvsn" -type "string" "map1";
 	setAttr ".uvst[1].uvsn" -type "string" "PairedFacesSet";
-	setAttr -s 23 ".uvst[1].uvsp[0:22]" -type "float2" 0 0 0.5 0 0.5 0.5
-		 0 0.5 0.5 0.5 1 0.5 1 1 0.5 1 0 0 0.5 0 0.5 0.5 0 0.5 0.5 0.5 1 0.5 1 1 0.5 1 0 0
-		 0.5 0 0.5 0.5 0 0.5 0.5 0.5 1 0.5 1 1;
+	setAttr -s 7 ".uvst[1].uvsp[0:6]" -type "float2" 0 0 0.5 0 0.5 0.5
+		 0 0.5 1 0.5 1 1 0.5 1;
 	setAttr ".uvst[2].uvsn" -type "string" "AllFacesSharedSet";
-	setAttr -s 24 ".uvst[2].uvsp[0:23]" -type "float2" 0 0 1 0 1 1 0 1 0
-		 0 1 0 1 1 0 1 0 0 1 0 1 1 0 1 0 0 1 0 1 1 0 1 0 0 1 0 1 1 0 1 0 0 1 0 1 1 0 1;
+	setAttr -s 4 ".uvst[2].uvsp[0:3]" -type "float2" 0 0 1 0 1 1 0 1;
 	setAttr ".cuvs" -type "string" "PairedFacesSet";
 	setAttr ".dcc" -type "string" "Ambient+Diffuse";
 	setAttr ".ds" no;
@@ -372,20 +370,20 @@ createNode mesh -n "SharedFacesCubeShape" -p "SharedFacesCube";
 		mu 1 4 0 1 2 3
 		mu 2 4 0 1 2 3
 		f 4 1 7 -3 -7
-		mu 1 4 4 5 6 7
-		mu 2 4 4 5 6 7
+		mu 1 4 2 4 5 6
+		mu 2 4 0 1 2 3
 		f 4 2 9 -4 -9
-		mu 1 4 8 9 10 11
-		mu 2 4 8 9 10 11
+		mu 1 4 0 1 2 3
+		mu 2 4 0 1 2 3
 		f 4 3 11 -1 -11
-		mu 1 4 12 13 14 15
-		mu 2 4 12 13 14 15
+		mu 1 4 2 4 5 6
+		mu 2 4 0 1 2 3
 		f 4 -12 -10 -8 -6
-		mu 1 4 16 17 18 19
-		mu 2 4 16 17 18 19
+		mu 1 4 0 1 2 3
+		mu 2 4 0 1 2 3
 		f 4 10 4 6 8
-		mu 1 4 20 21 22 7
-		mu 2 4 20 21 22 23;
+		mu 1 4 2 4 5 6
+		mu 2 4 0 1 2 3;
 	setAttr ".cd" -type "dataPolyComponent" Index_Data Edge 0 ;
 	setAttr ".cvd" -type "dataPolyComponent" Index_Data Vertex 0 ;
 	setAttr -s 3 ".pd";

--- a/test/lib/usd/translators/UsdExportUVSetsTest/UsdExportUVSetsTest.ma
+++ b/test/lib/usd/translators/UsdExportUVSetsTest/UsdExportUVSetsTest.ma
@@ -326,90 +326,6 @@ createNode mesh -n "polySurfaceShape2" -p "OneAssignedFaceCube";
 	setAttr ".hfd" -type "dataPolyComponent" Index_Data Face 0 ;
 	setAttr ".mgi" -type "string" "ID_41632452-941c-445a-8955-d85daaf8813f";
 	setAttr ".allowPerFaceDisplayColors" yes;
-createNode transform -n "CompressibleUVSetsCube" -p "CubeMeshes";
-	rename -uid "6BB5D8C0-0000-562B-57BB-88050000027F";
-	addAttr -ci true -sn "allowPerFaceDisplayColors" -ln "allowPerFaceDisplayColors" 
-		-min 0 -max 1 -at "bool";
-	setAttr ".t" -type "double3" -20 0 0 ;
-	setAttr ".rp" -type "double3" 0 0 5 ;
-	setAttr ".sp" -type "double3" 0 0 5 ;
-	setAttr ".allowPerFaceDisplayColors" yes;
-createNode mesh -n "CompressibleUVSetsCubeShape" -p "CompressibleUVSetsCube";
-	rename -uid "6BB5D8C0-0000-562B-57BB-880500000280";
-	addAttr -ci true -sn "mgi" -ln "mayaGprimID" -dt "string";
-	addAttr -ci true -sn "allowPerFaceDisplayColors" -ln "allowPerFaceDisplayColors" 
-		-min 0 -max 1 -at "bool";
-	setAttr -k off ".v";
-	setAttr -s 6 ".iog[0].og";
-	setAttr ".iog[0].og[0].gcl" -type "componentList" 1 "f[2]";
-	setAttr ".iog[0].og[1].gcl" -type "componentList" 1 "f[3]";
-	setAttr ".iog[0].og[2].gcl" -type "componentList" 1 "f[4]";
-	setAttr ".iog[0].og[3].gcl" -type "componentList" 1 "f[1]";
-	setAttr ".iog[0].og[4].gcl" -type "componentList" 1 "f[5]";
-	setAttr ".iog[0].og[5].gcl" -type "componentList" 1 "f[0]";
-	setAttr ".vir" yes;
-	setAttr ".vif" yes;
-	setAttr -s 4 ".uvst";
-	setAttr ".uvst[0].uvsn" -type "string" "map1";
-	setAttr ".uvst[1].uvsn" -type "string" "ConstantInterpSet";
-	setAttr -s 22 ".uvst[1].uvsp[0:21]" -type "float2" 0.25 0.25 0.25 0.25
-		 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25
-		 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25 0.25
-		 0.25 0.25 0.25 0.25 0.25 0.25;
-	setAttr ".uvst[2].uvsn" -type "string" "UniformInterpSet";
-	setAttr -s 24 ".uvst[2].uvsp[0:23]" -type "float2" 0 0 0.1 0.1 0.2 0.2
-		 0.30000001 0.30000001 0.40000001 0.40000001 0.5 0.5 0 0 0 0 0 0 0.1 0.1 0.1 0.1 0.1
-		 0.1 0.2 0.2 0.2 0.2 0.2 0.2 0.30000001 0.30000001 0.30000001 0.30000001 0.30000001
-		 0.30000001 0.40000001 0.40000001 0.40000001 0.40000001 0.40000001 0.40000001 0.5
-		 0.5 0.5 0.5 0.5 0.5;
-	setAttr ".uvst[3].uvsn" -type "string" "VertexInterpSet";
-	setAttr -s 8 ".uvst[3].uvsp[0:7]" -type "float2" 0 0 0.1 0.1 0.2 0.2
-		 0.30000001 0.30000001 0.40000001 0.40000001 0.5 0.5 0.60000002 0.60000002 0.69999999
-		 0.69999999;
-	setAttr ".cuvs" -type "string" "VertexInterpSet";
-	setAttr ".dcc" -type "string" "Ambient+Diffuse";
-	setAttr ".ds" no;
-	setAttr ".covm[0]"  0 1 1;
-	setAttr ".cdvm[0]"  0 1 1;
-	setAttr -s 8 ".vt[0:7]"  -5 -5 10 5 -5 10 -5 5 10 5 5 10 -5 5 0 5 5 0
-		 -5 -5 0 5 -5 0;
-	setAttr -s 12 ".ed[0:11]"  0 1 0 2 3 0 4 5 0 6 7 0 0 2 0 1 3 0 2 4 0
-		 3 5 0 4 6 0 5 7 0 6 0 0 7 1 0;
-	setAttr -s 6 -ch 24 ".fc[0:5]" -type "polyFaces" 
-		f 4 0 5 -2 -5
-		mu 1 4 0 1 2 3
-		mu 2 4 0 6 7 8
-		mu 3 4 0 1 3 2
-		f 4 1 7 -3 -7
-		mu 1 4 4 5 6 7
-		mu 2 4 1 9 10 11
-		mu 3 4 2 3 5 4
-		f 4 2 9 -4 -9
-		mu 1 4 8 9 10 11
-		mu 2 4 2 12 13 14
-		mu 3 4 4 5 7 6
-		f 4 3 11 -1 -11
-		mu 1 4 12 13 14 0
-		mu 2 4 3 15 16 17
-		mu 3 4 6 7 1 0
-		f 4 -12 -10 -8 -6
-		mu 1 4 15 16 17 18
-		mu 2 4 4 18 19 20
-		mu 3 4 1 7 5 3
-		f 4 10 4 6 8
-		mu 1 4 19 0 20 21
-		mu 2 4 5 21 22 23
-		mu 3 4 6 0 2 4;
-	setAttr ".cd" -type "dataPolyComponent" Index_Data Edge 0 ;
-	setAttr ".cvd" -type "dataPolyComponent" Index_Data Vertex 0 ;
-	setAttr -s 4 ".pd";
-	setAttr ".pd[0]" -type "dataPolyComponent" Index_Data UV 0 ;
-	setAttr ".pd[1]" -type "dataPolyComponent" Index_Data UV 0 ;
-	setAttr ".pd[2]" -type "dataPolyComponent" Index_Data UV 0 ;
-	setAttr ".pd[3]" -type "dataPolyComponent" Index_Data UV 0 ;
-	setAttr ".hfd" -type "dataPolyComponent" Index_Data Face 0 ;
-	setAttr ".mgi" -type "string" "ID_a46bf4f0-e7ae-46d4-8a18-42305fb119fe";
-	setAttr ".allowPerFaceDisplayColors" yes;
 createNode transform -n "SharedFacesCube" -p "CubeMeshes";
 	rename -uid "6BB5D8C0-0000-562B-57BB-96820000028B";
 	addAttr -ci true -sn "allowPerFaceDisplayColors" -ln "allowPerFaceDisplayColors" 
@@ -1747,7 +1663,6 @@ connectAttr "DefaultUVSetCubeShape.iog" "lambert2SG.dsm" -na;
 connectAttr "EmptyDefaultUVSetCubeShape.iog" "lambert2SG.dsm" -na;
 connectAttr "OneMissingFaceCubeShape.iog" "lambert2SG.dsm" -na;
 connectAttr "OneAssignedFaceCubeShape.iog" "lambert2SG.dsm" -na;
-connectAttr "CompressibleUVSetsCubeShape.iog" "lambert2SG.dsm" -na;
 connectAttr "SharedFacesCubeShape.iog" "lambert2SG.dsm" -na;
 connectAttr "lambert2SG.msg" "materialInfo1.sg";
 connectAttr "Red.msg" "materialInfo1.m";

--- a/test/lib/usd/translators/UsdExportUVSetsTest/UsdExportUVSetsTest.ma
+++ b/test/lib/usd/translators/UsdExportUVSetsTest/UsdExportUVSetsTest.ma
@@ -199,30 +199,6 @@ createNode mesh -n "OneMissingFaceCubeShape" -p "OneMissingFaceCube";
 	setAttr ".vir" yes;
 	setAttr ".vif" yes;
 	setAttr ".uvst[0].uvsn" -type "string" "map1";
-	setAttr ".cuvs" -type "string" "map1";
-	setAttr ".dcc" -type "string" "Ambient+Diffuse";
-	setAttr ".ds" no;
-	setAttr ".covm[0]"  0 1 1;
-	setAttr ".cdvm[0]"  0 1 1;
-	setAttr ".mgi" -type "string" "ID_00dcb39c-ae2c-4239-b0d8-945f9db8e612";
-	setAttr ".allowPerFaceDisplayColors" yes;
-createNode mesh -n "polySurfaceShape1" -p "OneMissingFaceCube";
-	rename -uid "415B68C0-0000-16E9-57B7-9C390000027F";
-	addAttr -ci true -sn "mgi" -ln "mayaGprimID" -dt "string";
-	addAttr -ci true -sn "allowPerFaceDisplayColors" -ln "allowPerFaceDisplayColors" 
-		-min 0 -max 1 -at "bool";
-	setAttr -k off ".v";
-	setAttr ".io" yes;
-	setAttr -s 6 ".iog[0].og";
-	setAttr ".iog[0].og[0].gcl" -type "componentList" 1 "f[2]";
-	setAttr ".iog[0].og[1].gcl" -type "componentList" 1 "f[3]";
-	setAttr ".iog[0].og[2].gcl" -type "componentList" 1 "f[4]";
-	setAttr ".iog[0].og[3].gcl" -type "componentList" 1 "f[1]";
-	setAttr ".iog[0].og[4].gcl" -type "componentList" 1 "f[5]";
-	setAttr ".iog[0].og[5].gcl" -type "componentList" 1 "f[0]";
-	setAttr ".vir" yes;
-	setAttr ".vif" yes;
-	setAttr ".uvst[0].uvsn" -type "string" "map1";
 	setAttr -s 14 ".uvst[0].uvsp[0:13]" -type "float2" 0.375 0 0.625 0 0.375
 		 0.25 0.625 0.25 0.375 0.5 0.625 0.5 0.375 0.75 0.625 0.75 0.375 1 0.625 1 0.875 0
 		 0.875 0.25 0.125 0 0.125 0.25;
@@ -241,7 +217,6 @@ createNode mesh -n "polySurfaceShape1" -p "OneMissingFaceCube";
 		f 4 1 7 -3 -7
 		mu 0 4 2 3 5 4
 		f 4 2 9 -4 -9
-		mu 0 4 4 5 7 6
 		f 4 3 11 -1 -11
 		mu 0 4 6 7 9 8
 		f 4 -12 -10 -8 -6
@@ -271,33 +246,8 @@ createNode mesh -n "OneAssignedFaceCubeShape" -p "OneAssignedFaceCube";
 	setAttr ".vir" yes;
 	setAttr ".vif" yes;
 	setAttr ".uvst[0].uvsn" -type "string" "map1";
-	setAttr ".cuvs" -type "string" "map1";
-	setAttr ".dcc" -type "string" "Ambient+Diffuse";
-	setAttr ".ds" no;
-	setAttr ".covm[0]"  0 1 1;
-	setAttr ".cdvm[0]"  0 1 1;
-	setAttr ".mgi" -type "string" "ID_f8c2d19a-0a4f-48e1-b29c-dc491b67c152";
-	setAttr ".allowPerFaceDisplayColors" yes;
-createNode mesh -n "polySurfaceShape2" -p "OneAssignedFaceCube";
-	rename -uid "415B68C0-0000-16E9-57B7-9CCB00000286";
-	addAttr -ci true -sn "mgi" -ln "mayaGprimID" -dt "string";
-	addAttr -ci true -sn "allowPerFaceDisplayColors" -ln "allowPerFaceDisplayColors" 
-		-min 0 -max 1 -at "bool";
-	setAttr -k off ".v";
-	setAttr ".io" yes;
-	setAttr -s 6 ".iog[0].og";
-	setAttr ".iog[0].og[0].gcl" -type "componentList" 1 "f[2]";
-	setAttr ".iog[0].og[1].gcl" -type "componentList" 1 "f[3]";
-	setAttr ".iog[0].og[2].gcl" -type "componentList" 1 "f[4]";
-	setAttr ".iog[0].og[3].gcl" -type "componentList" 1 "f[1]";
-	setAttr ".iog[0].og[4].gcl" -type "componentList" 1 "f[5]";
-	setAttr ".iog[0].og[5].gcl" -type "componentList" 1 "f[0]";
-	setAttr ".vir" yes;
-	setAttr ".vif" yes;
-	setAttr ".uvst[0].uvsn" -type "string" "map1";
-	setAttr -s 14 ".uvst[0].uvsp[0:13]" -type "float2" 0.375 0 0.625 0 0.375
-		 0.25 0.625 0.25 0.375 0.5 0.625 0.5 0.375 0.75 0.625 0.75 0.375 1 0.625 1 0.875 0
-		 0.875 0.25 0.125 0 0.125 0.25;
+	setAttr -s 4 ".uvst[0].uvsp[0:3]" -type "float2" 0.375 0.5 0.625 0.5
+		 0.375 0.75 0.625 0.75;
 	setAttr ".cuvs" -type "string" "map1";
 	setAttr ".dcc" -type "string" "Ambient+Diffuse";
 	setAttr ".ds" no;
@@ -309,17 +259,12 @@ createNode mesh -n "polySurfaceShape2" -p "OneAssignedFaceCube";
 		 3 5 0 4 6 0 5 7 0 6 0 0 7 1 0;
 	setAttr -s 6 -ch 24 ".fc[0:5]" -type "polyFaces" 
 		f 4 0 5 -2 -5
-		mu 0 4 0 1 3 2
 		f 4 1 7 -3 -7
-		mu 0 4 2 3 5 4
 		f 4 2 9 -4 -9
-		mu 0 4 4 5 7 6
+		mu 0 4 0 1 3 2
 		f 4 3 11 -1 -11
-		mu 0 4 6 7 9 8
 		f 4 -12 -10 -8 -6
-		mu 0 4 1 10 11 3
-		f 4 10 4 6 8
-		mu 0 4 12 0 2 13;
+		f 4 10 4 6 8;
 	setAttr ".cd" -type "dataPolyComponent" Index_Data Edge 0 ;
 	setAttr ".cvd" -type "dataPolyComponent" Index_Data Vertex 0 ;
 	setAttr ".pd[0]" -type "dataPolyComponent" Index_Data UV 0 ;
@@ -1312,7 +1257,7 @@ createNode lambert -n "Red";
 createNode shadingEngine -n "lambert2SG";
 	rename -uid "109AE860-0000-148A-5708-3FF300000264";
 	setAttr ".ihi" 0;
-	setAttr -s 6 ".dsm";
+	setAttr -s 5 ".dsm";
 	setAttr ".ro" yes;
 createNode materialInfo -n "materialInfo1";
 	rename -uid "109AE860-0000-148A-5708-3FF300000265";
@@ -1380,14 +1325,6 @@ createNode nodeGraphEditorInfo -n "hyperShadePrimaryNodeEditorSavedTabsInfo";
 	setAttr ".tgi[0].tn" -type "string" "Untitled_1";
 	setAttr ".tgi[0].vl" -type "double2" -113.09523360123723 -455.97199742362869 ;
 	setAttr ".tgi[0].vh" -type "double2" 571.428548722041 205.97200735773578 ;
-createNode polyMapDel -n "polyMapDel1";
-	rename -uid "415B68C0-0000-16E9-57B7-9C390000027E";
-	setAttr ".uopa" yes;
-	setAttr ".ics" -type "componentList" 1 "f[2]";
-createNode polyMapDel -n "polyMapDel2";
-	rename -uid "415B68C0-0000-16E9-57B7-9CCB00000285";
-	setAttr ".uopa" yes;
-	setAttr ".ics" -type "componentList" 2 "f[0:1]" "f[3:5]";
 createNode expression -n "BrokenUVs_C3d__HiddenInfoNode";
 	rename -uid "0D9708C0-0000-66E1-59DF-C01C0000028F";
 	addAttr -ci true -h true -sn "__pxSimNodeEmulate" -ln "__pxSimNodeEmulate" -min 
@@ -1632,8 +1569,6 @@ select -ne :defaultColorMgtGlobals;
 select -ne :hardwareRenderGlobals;
 	setAttr ".ctrs" 256;
 	setAttr ".btrs" 512;
-connectAttr "polyMapDel1.out" "OneMissingFaceCubeShape.i";
-connectAttr "polyMapDel2.out" "OneAssignedFaceCubeShape.i";
 relationship "link" ":lightLinker1" ":initialShadingGroup.message" ":defaultLightSet.message";
 relationship "link" ":lightLinker1" ":initialParticleSE.message" ":defaultLightSet.message";
 relationship "link" ":lightLinker1" "lambert2SG.message" ":defaultLightSet.message";
@@ -1679,8 +1614,6 @@ connectAttr "Magenta.msg" "materialInfo5.m";
 connectAttr "Cyan.oc" "lambert7SG.ss";
 connectAttr "lambert7SG.msg" "materialInfo6.sg";
 connectAttr "Cyan.msg" "materialInfo6.m";
-connectAttr "polySurfaceShape1.o" "polyMapDel1.ip";
-connectAttr "polySurfaceShape2.o" "polyMapDel2.ip";
 connectAttr ":time1.o" "BrokenUVs_C3d__HiddenInfoNode.tim";
 connectAttr "layerManager.dli[4]" "BrokenUVs_Decimated.id";
 connectAttr "layerManager.dli[5]" "BrokenUVs_Simulation.id";

--- a/test/lib/usd/translators/UsdImportUVSetsFloatTest/UsdImportUVSetsTest_Float.usda
+++ b/test/lib/usd/translators/UsdImportUVSetsFloatTest/UsdImportUVSetsTest_Float.usda
@@ -84,7 +84,7 @@ def Xform "UsdImportUVSetsTest" (
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]
             }
 
-            def Mesh "CompressibleUVSetsCube"
+            def Mesh "CompressedUVSetsCube"
             {
                 float3[] extent = [(-5, -5, 0), (5, 5, 10)]
                 int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]

--- a/test/lib/usd/translators/UsdImportUVSetsFloatTest/UsdImportUVSetsTest_Float.usda
+++ b/test/lib/usd/translators/UsdImportUVSetsFloatTest/UsdImportUVSetsTest_Float.usda
@@ -28,10 +28,10 @@ def Xform "UsdImportUVSetsTest" (
                 int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
                 int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
                 point3f[] points = [(-5, -5, 10), (5, -5, 10), (-5, 5, 10), (5, 5, 10), (-5, 5, 0), (5, 5, 0), (-5, -5, 0), (5, -5, 0)]
-                texCoord2f[] primvars:st = [(0.375, 0), (0.625, 0), (0.625, 0.25), (0.375, 0.25), (0.625, 0.5), (0.375, 0.5), (0.625, 0.75), (0.375, 0.75), (0.625, 1), (0.375, 1), (0.875, 0), (0.875, 0.25), (0.125, 0), (0.125, 0.25)] (
+                texCoord2f[] primvars:st = [(0.375, 0), (0.625, 0), (0.375, 0.25), (0.625, 0.25), (0.375, 0.5), (0.625, 0.5), (0.375, 0.75), (0.625, 0.75), (0.375, 1), (0.625, 1), (0.875, 0), (0.875, 0.25), (0.125, 0), (0.125, 0.25)] (
                     interpolation = "faceVarying"
                 )
-                int[] primvars:st:indices = [0, 1, 2, 3, 3, 2, 4, 5, 5, 4, 6, 7, 7, 6, 8, 9, 1, 10, 11, 2, 12, 0, 3, 13]
+                int[] primvars:st:indices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 9, 8, 1, 10, 11, 3, 12, 0, 2, 13]
                 double3 xformOp:translate = (0, 20, 0)
                 float3 xformOp:translate:pivot = (0, 0, 5)
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]
@@ -43,10 +43,10 @@ def Xform "UsdImportUVSetsTest" (
                 int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
                 int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
                 point3f[] points = [(-5, -5, 10), (5, -5, 10), (-5, 5, 10), (5, 5, 10), (-5, 5, 0), (5, 5, 0), (-5, -5, 0), (5, -5, 0)]
-                texCoord2f[] primvars:map1 = [(0.375, 0), (0.625, 0), (0.625, 0.25), (0.375, 0.25), (0.625, 0.5), (0.375, 0.5), (0.625, 0.75), (0.375, 0.75), (0.625, 1), (0.375, 1), (0.875, 0), (0.875, 0.25), (0.125, 0), (0.125, 0.25)] (
+                texCoord2f[] primvars:map1 = [(0.375, 0), (0.625, 0), (0.375, 0.25), (0.625, 0.25), (0.375, 0.5), (0.625, 0.5), (0.375, 0.75), (0.625, 0.75), (0.375, 1), (0.625, 1), (0.875, 0), (0.875, 0.25), (0.125, 0), (0.125, 0.25)] (
                     interpolation = "faceVarying"
                 )
-                int[] primvars:map1:indices = [0, 1, 2, 3, 3, 2, 4, 5, 5, 4, 6, 7, 7, 6, 8, 9, 1, 10, 11, 2, 12, 0, 3, 13]
+                int[] primvars:map1:indices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 9, 8, 1, 10, 11, 3, 12, 0, 2, 13]
                 double3 xformOp:translate = (0, 20, 0)
                 float3 xformOp:translate:pivot = (0, 0, 5)
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]
@@ -58,11 +58,11 @@ def Xform "UsdImportUVSetsTest" (
                 int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
                 int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
                 point3f[] points = [(-5, -5, 10), (5, -5, 10), (-5, 5, 10), (5, 5, 10), (-5, 5, 0), (5, 5, 0), (-5, -5, 0), (5, -5, 0)]
-                texCoord2f[] primvars:st = [(0.375, 0), (0.625, 0), (0.625, 0.25), (0.375, 0.25), (0.625, 0.5), (0.375, 0.5), (0.375, 0.75), (0.625, 0.75), (0.625, 1), (0.375, 1), (0.875, 0), (0.875, 0.25), (0.125, 0), (0.125, 0.25), (-1e+30, -1e+30)] (
+                texCoord2f[] primvars:st = [(0, 0), (0.375, 0), (0.625, 0), (0.375, 0.25), (0.625, 0.25), (0.375, 0.5), (0.625, 0.5), (0.375, 0.75), (0.625, 0.75), (0.375, 1), (0.625, 1), (0.875, 0), (0.875, 0.25), (0.125, 0), (0.125, 0.25)] (
                     interpolation = "faceVarying"
-                    unauthoredValuesIndex = 14
+                    unauthoredValuesIndex = 0
                 )
-                int[] primvars:st:indices = [0, 1, 2, 3, 3, 2, 4, 5, 14, 14, 14, 14, 6, 7, 8, 9, 1, 10, 11, 2, 12, 0, 3, 13]
+                int[] primvars:st:indices = [1, 2, 4, 3, 3, 4, 6, 5, 0, 0, 0, 0, 7, 8, 10, 9, 2, 11, 12, 4, 13, 1, 3, 14]
                 double3 xformOp:translate = (0, 40, 0)
                 float3 xformOp:translate:pivot = (0, 0, 5)
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]
@@ -74,11 +74,11 @@ def Xform "UsdImportUVSetsTest" (
                 int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
                 int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
                 point3f[] points = [(-5, -5, 10), (5, -5, 10), (-5, 5, 10), (5, 5, 10), (-5, 5, 0), (5, 5, 0), (-5, -5, 0), (5, -5, 0)]
-                texCoord2f[] primvars:st = [(0.375, 0.5), (0.625, 0.5), (0.625, 0.75), (0.375, 0.75), (-1e+30, -1e+30)] (
+                texCoord2f[] primvars:st = [(0, 0), (0.375, 0.5), (0.625, 0.5), (0.375, 0.75), (0.625, 0.75)] (
                     interpolation = "faceVarying"
-                    unauthoredValuesIndex = 4
+                    unauthoredValuesIndex = 0
                 )
-                int[] primvars:st:indices = [4, 4, 4, 4, 4, 4, 4, 4, 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]
+                int[] primvars:st:indices = [0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                 double3 xformOp:translate = (0, 60, 0)
                 float3 xformOp:translate:pivot = (0, 0, 5)
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]

--- a/test/lib/usd/translators/UsdImportUVSetsTest/UsdImportUVSetsTest.usda
+++ b/test/lib/usd/translators/UsdImportUVSetsTest/UsdImportUVSetsTest.usda
@@ -84,7 +84,7 @@ def Xform "UsdImportUVSetsTest" (
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]
             }
 
-            def Mesh "CompressibleUVSetsCube"
+            def Mesh "CompressedUVSetsCube"
             {
                 float3[] extent = [(-5, -5, 0), (5, 5, 10)]
                 int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]

--- a/test/lib/usd/translators/UsdImportUVSetsTest/UsdImportUVSetsTest.usda
+++ b/test/lib/usd/translators/UsdImportUVSetsTest/UsdImportUVSetsTest.usda
@@ -28,10 +28,10 @@ def Xform "UsdImportUVSetsTest" (
                 int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
                 int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
                 point3f[] points = [(-5, -5, 10), (5, -5, 10), (-5, 5, 10), (5, 5, 10), (-5, 5, 0), (5, 5, 0), (-5, -5, 0), (5, -5, 0)]
-                texCoord2f[] primvars:st = [(0.375, 0), (0.625, 0), (0.625, 0.25), (0.375, 0.25), (0.625, 0.5), (0.375, 0.5), (0.625, 0.75), (0.375, 0.75), (0.625, 1), (0.375, 1), (0.875, 0), (0.875, 0.25), (0.125, 0), (0.125, 0.25)] (
+                texCoord2f[] primvars:st = [(0.375, 0), (0.625, 0), (0.375, 0.25), (0.625, 0.25), (0.375, 0.5), (0.625, 0.5), (0.375, 0.75), (0.625, 0.75), (0.375, 1), (0.625, 1), (0.875, 0), (0.875, 0.25), (0.125, 0), (0.125, 0.25)] (
                     interpolation = "faceVarying"
                 )
-                int[] primvars:st:indices = [0, 1, 2, 3, 3, 2, 4, 5, 5, 4, 6, 7, 7, 6, 8, 9, 1, 10, 11, 2, 12, 0, 3, 13]
+                int[] primvars:st:indices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 9, 8, 1, 10, 11, 3, 12, 0, 2, 13]
                 double3 xformOp:translate = (0, 20, 0)
                 float3 xformOp:translate:pivot = (0, 0, 5)
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]
@@ -43,10 +43,10 @@ def Xform "UsdImportUVSetsTest" (
                 int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
                 int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
                 point3f[] points = [(-5, -5, 10), (5, -5, 10), (-5, 5, 10), (5, 5, 10), (-5, 5, 0), (5, 5, 0), (-5, -5, 0), (5, -5, 0)]
-                texCoord2f[] primvars:map1 = [(0.375, 0), (0.625, 0), (0.625, 0.25), (0.375, 0.25), (0.625, 0.5), (0.375, 0.5), (0.625, 0.75), (0.375, 0.75), (0.625, 1), (0.375, 1), (0.875, 0), (0.875, 0.25), (0.125, 0), (0.125, 0.25)] (
+                texCoord2f[] primvars:map1 = [(0.375, 0), (0.625, 0), (0.375, 0.25), (0.625, 0.25), (0.375, 0.5), (0.625, 0.5), (0.375, 0.75), (0.625, 0.75), (0.375, 1), (0.625, 1), (0.875, 0), (0.875, 0.25), (0.125, 0), (0.125, 0.25)] (
                     interpolation = "faceVarying"
                 )
-                int[] primvars:map1:indices = [0, 1, 2, 3, 3, 2, 4, 5, 5, 4, 6, 7, 7, 6, 8, 9, 1, 10, 11, 2, 12, 0, 3, 13]
+                int[] primvars:map1:indices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 9, 8, 1, 10, 11, 3, 12, 0, 2, 13]
                 double3 xformOp:translate = (0, 20, 0)
                 float3 xformOp:translate:pivot = (0, 0, 5)
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]
@@ -58,11 +58,11 @@ def Xform "UsdImportUVSetsTest" (
                 int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
                 int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
                 point3f[] points = [(-5, -5, 10), (5, -5, 10), (-5, 5, 10), (5, 5, 10), (-5, 5, 0), (5, 5, 0), (-5, -5, 0), (5, -5, 0)]
-                texCoord2f[] primvars:st = [(0.375, 0), (0.625, 0), (0.625, 0.25), (0.375, 0.25), (0.625, 0.5), (0.375, 0.5), (0.375, 0.75), (0.625, 0.75), (0.625, 1), (0.375, 1), (0.875, 0), (0.875, 0.25), (0.125, 0), (0.125, 0.25), (-1e+30, -1e+30)] (
+                texCoord2f[] primvars:st = [(0, 0), (0.375, 0), (0.625, 0), (0.375, 0.25), (0.625, 0.25), (0.375, 0.5), (0.625, 0.5), (0.375, 0.75), (0.625, 0.75), (0.375, 1), (0.625, 1), (0.875, 0), (0.875, 0.25), (0.125, 0), (0.125, 0.25)] (
                     interpolation = "faceVarying"
-                    unauthoredValuesIndex = 14
+                    unauthoredValuesIndex = 0
                 )
-                int[] primvars:st:indices = [0, 1, 2, 3, 3, 2, 4, 5, 14, 14, 14, 14, 6, 7, 8, 9, 1, 10, 11, 2, 12, 0, 3, 13]
+                int[] primvars:st:indices = [1, 2, 4, 3, 3, 4, 6, 5, 0, 0, 0, 0, 7, 8, 10, 9, 2, 11, 12, 4, 13, 1, 3, 14]
                 double3 xformOp:translate = (0, 40, 0)
                 float3 xformOp:translate:pivot = (0, 0, 5)
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]
@@ -74,11 +74,11 @@ def Xform "UsdImportUVSetsTest" (
                 int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
                 int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
                 point3f[] points = [(-5, -5, 10), (5, -5, 10), (-5, 5, 10), (5, 5, 10), (-5, 5, 0), (5, 5, 0), (-5, -5, 0), (5, -5, 0)]
-                texCoord2f[] primvars:st = [(0.375, 0.5), (0.625, 0.5), (0.625, 0.75), (0.375, 0.75), (-1e+30, -1e+30)] (
+                texCoord2f[] primvars:st = [(0, 0), (0.375, 0.5), (0.625, 0.5), (0.375, 0.75), (0.625, 0.75)] (
                     interpolation = "faceVarying"
-                    unauthoredValuesIndex = 4
+                    unauthoredValuesIndex = 0
                 )
-                int[] primvars:st:indices = [4, 4, 4, 4, 4, 4, 4, 4, 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4]
+                int[] primvars:st:indices = [0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                 double3 xformOp:translate = (0, 60, 0)
                 float3 xformOp:translate:pivot = (0, 0, 5)
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]

--- a/test/lib/usd/translators/testUsdExportUVSets.py
+++ b/test/lib/usd/translators/testUsdExportUVSets.py
@@ -129,8 +129,7 @@ class testUsdExportUVSets(unittest.TestCase):
         # These are the default UV values and indices that are exported for a
         # regular Maya polycube. If you just created a new cube and then
         # exported it to USD, these are the values and indices you would see
-        # for the default UV set 'map1'. The data here has already been
-        # merged/compressed.
+        # for the default UV set 'map1'.
         expectedValues = [
             Gf.Vec2f(0.375, 0),
             Gf.Vec2f(0.625, 0),
@@ -250,68 +249,6 @@ class testUsdExportUVSets(unittest.TestCase):
             expectedInterpolation=expectedInterpolation,
             expectedIndices=expectedIndices,
             expectedUnauthoredValuesIndex=expectedUnauthoredValuesIndex)
-
-    def testExportCompressibleUVSets(self):
-        """
-        Tests that UV sets on a cube mesh that can be compressed to constant,
-        uniform and vertex interpolations get exported correctly.
-
-        Note that the actual values here don't really make sense as UV sets.
-        """
-        usdCubeMesh = self._GetCubeUsdMesh('CompressibleUVSetsCube')
-
-        uvSetName = 'ConstantInterpSet'
-        expectedValues = [
-            Gf.Vec2f(0.25, 0.25)
-        ]
-        expectedIndices = [0]
-        expectedInterpolation = UsdGeom.Tokens.constant
-
-        primvar = usdCubeMesh.GetPrimvar(uvSetName)
-        self._AssertUVPrimvar(primvar,
-            expectedValues=expectedValues,
-            expectedInterpolation=expectedInterpolation,
-            expectedIndices=expectedIndices)
-
-        uvSetName = 'UniformInterpSet'
-        expectedValues = [
-            Gf.Vec2f(0.0, 0.0),
-            Gf.Vec2f(0.1, 0.1),
-            Gf.Vec2f(0.2, 0.2),
-            Gf.Vec2f(0.3, 0.3),
-            Gf.Vec2f(0.4, 0.4),
-            Gf.Vec2f(0.5, 0.5)
-        ]
-        expectedIndices = [0, 1, 2, 3, 4, 5]
-        expectedInterpolation = UsdGeom.Tokens.uniform
-
-        primvar = usdCubeMesh.GetPrimvar(uvSetName)
-        self._AssertUVPrimvar(primvar,
-            expectedValues=expectedValues,
-            expectedInterpolation=expectedInterpolation,
-            expectedIndices=expectedIndices)
-
-        # The values here end up in a somewhat odd order because of how
-        # MItMeshFaceVertex visits vertices.
-        uvSetName = 'VertexInterpSet'
-        expectedValues = [
-            Gf.Vec2f(0.0, 0.0),
-            Gf.Vec2f(0.1, 0.1),
-            Gf.Vec2f(0.3, 0.3),
-            Gf.Vec2f(0.2, 0.2),
-            Gf.Vec2f(0.5, 0.5),
-            Gf.Vec2f(0.4, 0.4),
-            Gf.Vec2f(0.7, 0.7),
-            Gf.Vec2f(0.6, 0.6)
-        ]
-        expectedIndices = [0, 1, 3, 2, 5, 4, 7, 6]
-        expectedInterpolation = UsdGeom.Tokens.vertex
-
-        primvar = usdCubeMesh.GetPrimvar(uvSetName)
-        self._AssertUVPrimvar(primvar,
-            expectedValues=expectedValues,
-            expectedInterpolation=expectedInterpolation,
-            expectedIndices=expectedIndices)
 
     def testExportSharedFacesUVSets(self):
         """

--- a/test/lib/usd/translators/testUsdExportUVSets.py
+++ b/test/lib/usd/translators/testUsdExportUVSets.py
@@ -56,11 +56,6 @@ class testUsdExportUVSets(unittest.TestCase):
             expectedUnauthoredValuesIndex)
         self.assertEqual(primvar.GetInterpolation(), expectedInterpolation)
 
-
-    @classmethod
-    def tearDownClass(cls):
-        standalone.uninitialize()
-
     @classmethod
     def setUpClass(cls):
         asFloat2 = mayaUsdLib.WriteUtil.WriteUVAsFloat2()
@@ -93,6 +88,10 @@ class testUsdExportUVSets(unittest.TestCase):
             exportUVs=True)
 
         cls._stage = Usd.Stage.Open(usdFilePath)
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
 
     def testStageOpens(self):
         self.assertTrue(self._stage)

--- a/test/lib/usd/translators/testUsdExportUVSets.py
+++ b/test/lib/usd/translators/testUsdExportUVSets.py
@@ -185,26 +185,26 @@ class testUsdExportUVSets(unittest.TestCase):
         expectedValues = [
             Gf.Vec2f(0.375, 0),
             Gf.Vec2f(0.625, 0),
-            Gf.Vec2f(0.625, 0.25),
             Gf.Vec2f(0.375, 0.25),
-            Gf.Vec2f(0.625, 0.5),
+            Gf.Vec2f(0.625, 0.25),
             Gf.Vec2f(0.375, 0.5),
-            Gf.Vec2f(0.625, 0.75),
+            Gf.Vec2f(0.625, 0.5),
             Gf.Vec2f(0.375, 0.75),
-            Gf.Vec2f(0.625, 1),
+            Gf.Vec2f(0.625, 0.75),
             Gf.Vec2f(0.375, 1),
+            Gf.Vec2f(0.625, 1),
             Gf.Vec2f(0.875, 0),
             Gf.Vec2f(0.875, 0.25),
             Gf.Vec2f(0.125, 0),
             Gf.Vec2f(0.125, 0.25)
         ]
         expectedIndices = [
-            0, 1, 2, 3,
-            3, 2, 4, 5,
-            5, 4, 6, 7,
-            7, 6, 8, 9,
-            1, 10, 11, 2,
-            12, 0, 3, 13]
+            0, 1, 3, 2,
+            2, 3, 5, 4,
+            4, 5, 7, 6,
+            6, 7, 9, 8,
+            1, 10, 11, 3,
+            12, 0, 2, 13]
 
         expectedInterpolation = UsdGeom.Tokens.faceVarying
 
@@ -226,29 +226,29 @@ class testUsdExportUVSets(unittest.TestCase):
         usdCubeMesh = self._GetCubeUsdMesh('OneMissingFaceCube')
 
         expectedValues = [
-            Gf.Vec2f(0.0, 0.0),
+            Gf.Vec2f(0, 0),
             Gf.Vec2f(0.375, 0),
             Gf.Vec2f(0.625, 0),
-            Gf.Vec2f(0.625, 0.25),
             Gf.Vec2f(0.375, 0.25),
-            Gf.Vec2f(0.625, 0.5),
+            Gf.Vec2f(0.625, 0.25),
             Gf.Vec2f(0.375, 0.5),
+            Gf.Vec2f(0.625, 0.5),
             Gf.Vec2f(0.375, 0.75),
             Gf.Vec2f(0.625, 0.75),
-            Gf.Vec2f(0.625, 1),
             Gf.Vec2f(0.375, 1),
+            Gf.Vec2f(0.625, 1),
             Gf.Vec2f(0.875, 0),
             Gf.Vec2f(0.875, 0.25),
             Gf.Vec2f(0.125, 0),
             Gf.Vec2f(0.125, 0.25)
         ]
         expectedIndices = [
-            1, 2, 3, 4,
-            4, 3, 5, 6,
+            1, 2, 4, 3,
+            3, 4, 6, 5,
             0, 0, 0, 0,
-            7, 8, 9, 10,
-            2, 11, 12, 3,
-            13, 1, 4, 14
+            7, 8, 10, 9,
+            2, 11, 12, 4,
+            13, 1, 3, 14
         ]
         expectedUnauthoredValuesIndex = 0
 
@@ -273,16 +273,16 @@ class testUsdExportUVSets(unittest.TestCase):
         usdCubeMesh = self._GetCubeUsdMesh('OneAssignedFaceCube')
 
         expectedValues = [
-            Gf.Vec2f(0.0, 0.0),
+            Gf.Vec2f(0, 0),
             Gf.Vec2f(0.375, 0.5),
             Gf.Vec2f(0.625, 0.5),
-            Gf.Vec2f(0.625, 0.75),
-            Gf.Vec2f(0.375, 0.75)
+            Gf.Vec2f(0.375, 0.75),
+            Gf.Vec2f(0.625, 0.75)
         ]
         expectedIndices = [
             0, 0, 0, 0,
             0, 0, 0, 0,
-            1, 2, 3, 4,
+            1, 2, 4, 3,
             0, 0, 0, 0,
             0, 0, 0, 0,
             0, 0, 0, 0
@@ -363,7 +363,8 @@ class testUsdExportUVSets(unittest.TestCase):
         else:
             stPrimvar = brokenBoxMesh.GetPrimvar("map1").ComputeFlattened()
 
-        self.assertEqual(stPrimvar[0], Gf.Vec2f(1.0, 1.0))
+        self.assertEqual(stPrimvar[0], Gf.Vec2f(1.0, 2.0))
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/usd/translators/testUsdImportUVSets.py
+++ b/test/lib/usd/translators/testUsdImportUVSets.py
@@ -64,10 +64,6 @@ class testUsdImportUVSets(unittest.TestCase):
             fvi += 1
 
     @classmethod
-    def tearDownClass(cls):
-        standalone.uninitialize()
-
-    @classmethod
     def setUpClass(cls):
         cls.asFloat2 = mayaUsdLib.ReadUtil.ReadFloat2AsUV()
         cls.defaultUVName = "st"
@@ -82,6 +78,10 @@ class testUsdImportUVSets(unittest.TestCase):
             usdFile = os.path.join(cls.inputPath, "UsdImportUVSetsTest", "UsdImportUVSetsTest.usda")
 
         cmds.usdImport(file=usdFile, shadingMode=[["none", "default"], ])
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
 
     def _GetMayaMesh(self, meshName):
         selectionList = OM.MSelectionList()

--- a/test/lib/usd/translators/testUsdImportUVSets.py
+++ b/test/lib/usd/translators/testUsdImportUVSets.py
@@ -31,7 +31,8 @@ import fixturesUtils
 
 class testUsdImportUVSets(unittest.TestCase):
 
-    def _AssertUVSet(self, mesh, uvSetName, expectedValues, expectedNumValues=None):
+    def _AssertUVSet(self, mesh, uvSetName, expectedValues,
+            expectedNumValues=None, expectedNumUVShells=None):
         """
         Verifies that the UV values for the uv set named uvSetName on the
         MFnMesh mesh match the values in expectedValues. expectedValues should
@@ -62,6 +63,10 @@ class testUsdImportUVSets(unittest.TestCase):
 
             itMeshFV.next()
             fvi += 1
+
+        if expectedNumUVShells is not None:
+            (numUVShells, shellIndices) = mesh.getUvShellsIds(uvSetName)
+            self.assertEqual(expectedNumUVShells, numUVShells)
 
     @classmethod
     def setUpClass(cls):
@@ -135,7 +140,7 @@ class testUsdImportUVSets(unittest.TestCase):
         }
 
         self._AssertUVSet(mayaCubeMesh, self.defaultUVName, expectedValues,
-            expectedNumValues=14)
+            expectedNumValues=14, expectedNumUVShells=1)
 
     def testImportMap1UVSet(self):
         """
@@ -173,7 +178,7 @@ class testUsdImportUVSets(unittest.TestCase):
         }
 
         self._AssertUVSet(mayaCubeMesh, "map1", expectedValues,
-            expectedNumValues=14)
+            expectedNumValues=14, expectedNumUVShells=1)
 
     def testImportOneMissingFaceUVSet(self):
         """
@@ -206,7 +211,7 @@ class testUsdImportUVSets(unittest.TestCase):
         }
 
         self._AssertUVSet(mayaCubeMesh, self.defaultUVName, expectedValues,
-            expectedNumValues=14)
+            expectedNumValues=14, expectedNumUVShells=2)
 
     def testImportOneAssignedFaceUVSet(self):
         """
@@ -223,7 +228,7 @@ class testUsdImportUVSets(unittest.TestCase):
         }
 
         self._AssertUVSet(mayaCubeMesh, self.defaultUVName, expectedValues,
-            expectedNumValues=4)
+            expectedNumValues=4, expectedNumUVShells=1)
 
     def testImportCompressedUVSets(self):
         """
@@ -245,7 +250,7 @@ class testUsdImportUVSets(unittest.TestCase):
         for i in range(24):
             expectedValues[i] = Gf.Vec2f(0.25, 0.25)
         self._AssertUVSet(mayaCubeMesh, uvSetName, expectedValues,
-            expectedNumValues=1)
+            expectedNumValues=1, expectedNumUVShells=1)
 
         # All face vertices within the same face should have the same value.
         uvSetName = 'UniformInterpSet'
@@ -263,7 +268,7 @@ class testUsdImportUVSets(unittest.TestCase):
         for i in range(20, 24):
             expectedValues[i] = Gf.Vec2f(0.5, 0.5)
         self._AssertUVSet(mayaCubeMesh, uvSetName, expectedValues,
-            expectedNumValues=6)
+            expectedNumValues=6, expectedNumUVShells=6)
 
         # All face vertices on the same mesh vertex (indices 0-7 for a cube)
         # should have the same value.
@@ -295,7 +300,7 @@ class testUsdImportUVSets(unittest.TestCase):
             23 : Gf.Vec2f(0.4, 0.4)
         }
         self._AssertUVSet(mayaCubeMesh, uvSetName, expectedValues,
-            expectedNumValues=8)
+            expectedNumValues=8, expectedNumUVShells=1)
 
     def testImportSharedFacesUVSets(self):
         """
@@ -316,7 +321,7 @@ class testUsdImportUVSets(unittest.TestCase):
         for i in range(3, 24, 4):
             expectedValues[i] = Gf.Vec2f(0.0, 1.0)
         self._AssertUVSet(mayaCubeMesh, uvSetName, expectedValues,
-            expectedNumValues=4)
+            expectedNumValues=4, expectedNumUVShells=1)
 
         # The faces alternate between ranges 0.0-0.5 and 0.5-1.0.
         uvSetName = 'PairedFacesSet'
@@ -338,7 +343,7 @@ class testUsdImportUVSets(unittest.TestCase):
         for i in range(7, 24, 8):
             expectedValues[i] = Gf.Vec2f(0.5, 1.0)
         self._AssertUVSet(mayaCubeMesh, uvSetName, expectedValues,
-            expectedNumValues=7)
+            expectedNumValues=7, expectedNumUVShells=2)
     
     def testImportUVSetForMeshWithCreases(self):
         """

--- a/test/lib/usd/translators/testUsdImportUVSets.py
+++ b/test/lib/usd/translators/testUsdImportUVSets.py
@@ -83,11 +83,11 @@ class testUsdImportUVSets(unittest.TestCase):
     def tearDownClass(cls):
         standalone.uninitialize()
 
-    def _GetMayaMesh(self, meshName):
+    @staticmethod
+    def _GetMayaMesh(meshNodePath):
         selectionList = OM.MSelectionList()
-        selectionList.add(meshName)
+        selectionList.add(meshNodePath)
         mObj = selectionList.getDependNode(0)
-
         return OM.MFnMesh(mObj)
 
     def testImportNoUVSets(self):
@@ -95,7 +95,7 @@ class testUsdImportUVSets(unittest.TestCase):
         Tests that importing a USD cube mesh with no UV set primvars results in
         the default 'map1' UV set on the Maya mesh being empty.
         """
-        mayaCubeMesh = self._GetMayaMesh('NoUVSetsCubeShape')
+        mayaCubeMesh = testUsdImportUVSets._GetMayaMesh('NoUVSetsCubeShape')
         expectedValues = {}
         self._AssertUVSet(mayaCubeMesh, 'map1', expectedValues)
 
@@ -104,7 +104,7 @@ class testUsdImportUVSets(unittest.TestCase):
         Tests that a USD cube mesh with the Maya default values for the default
         UV set (named 'st' in USD) gets imported correctly.
         """
-        mayaCubeMesh = self._GetMayaMesh('DefaultUVSetCubeShape')
+        mayaCubeMesh = testUsdImportUVSets._GetMayaMesh('DefaultUVSetCubeShape')
 
         # These are the default UV values for a regular Maya polycube.
         expectedValues = {
@@ -142,7 +142,7 @@ class testUsdImportUVSets(unittest.TestCase):
         Tests that a USD cube mesh with the Maya default values for the default
         UV set (map1) gets imported correctly.
         """
-        mayaCubeMesh = self._GetMayaMesh('Map1UVSetCubeShape')
+        mayaCubeMesh = testUsdImportUVSets._GetMayaMesh('Map1UVSetCubeShape')
 
         # These are the default UV values for a regular Maya polycube.
         expectedValues = {
@@ -180,7 +180,7 @@ class testUsdImportUVSets(unittest.TestCase):
         Tests that a USD cube mesh with values for all but one face in the
         default UV set (named 'st' in USD) gets imported correctly.
         """
-        mayaCubeMesh = self._GetMayaMesh('OneMissingFaceCubeShape')
+        mayaCubeMesh = testUsdImportUVSets._GetMayaMesh('OneMissingFaceCubeShape')
 
         expectedValues = {
             0: Gf.Vec2f(0.375, 0),
@@ -213,7 +213,7 @@ class testUsdImportUVSets(unittest.TestCase):
         Tests that a USD cube mesh with values for only one face in the default
         UV set (named 'st' in USD) gets imported correctly.
         """
-        mayaCubeMesh = self._GetMayaMesh('OneAssignedFaceCubeShape')
+        mayaCubeMesh = testUsdImportUVSets._GetMayaMesh('OneAssignedFaceCubeShape')
 
         expectedValues = {
             8: Gf.Vec2f(0.375, 0.5),
@@ -234,7 +234,7 @@ class testUsdImportUVSets(unittest.TestCase):
         We also do not perform any compression when exporting from Maya, so UV
         sets like this would have to come from some other source.
         """
-        mayaCubeMesh = self._GetMayaMesh('CompressedUVSetsCubeShape')
+        mayaCubeMesh = testUsdImportUVSets._GetMayaMesh('CompressedUVSetsCubeShape')
 
         # We should not see the default "map1" UV set:
         self.assertNotIn("map1", mayaCubeMesh.getUVSetNames())
@@ -302,7 +302,7 @@ class testUsdImportUVSets(unittest.TestCase):
         Tests that UV sets on a USD cube mesh that use the same UV ranges for
         multiple faces are imported correctly.
         """
-        mayaCubeMesh = self._GetMayaMesh('SharedFacesCubeShape')
+        mayaCubeMesh = testUsdImportUVSets._GetMayaMesh('SharedFacesCubeShape')
 
         # All six faces share the same range 0.0-1.0.
         uvSetName = 'AllFacesSharedSet'
@@ -358,7 +358,7 @@ class testUsdImportUVSets(unittest.TestCase):
         # translator caused a crash.
         cmds.file(usdFile, i=True)
 
-        mayaCubeMesh = self._GetMayaMesh('CreasedCubeShape')
+        mayaCubeMesh = testUsdImportUVSets._GetMayaMesh('CreasedCubeShape')
 
         # These are the default UV values for a regular Maya polycube.
         expectedValues = {
@@ -390,6 +390,7 @@ class testUsdImportUVSets(unittest.TestCase):
 
         self._AssertUVSet(mayaCubeMesh, self.defaultUVName, expectedValues,
             expectedNumValues=14)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/usd/translators/testUsdImportUVSets.py
+++ b/test/lib/usd/translators/testUsdImportUVSets.py
@@ -225,14 +225,16 @@ class testUsdImportUVSets(unittest.TestCase):
         self._AssertUVSet(mayaCubeMesh, self.defaultUVName, expectedValues,
             expectedNumValues=4)
 
-    def testImportCompressibleUVSets(self):
+    def testImportCompressedUVSets(self):
         """
         Tests that UV sets on a USD cube mesh that were compressed to constant,
         uniform, and vertex interpolations are imported correctly.
 
         Note that the actual values here don't really make sense as UV sets.
+        We also do not perform any compression when exporting from Maya, so UV
+        sets like this would have to come from some other source.
         """
-        mayaCubeMesh = self._GetMayaMesh('CompressibleUVSetsCubeShape')
+        mayaCubeMesh = self._GetMayaMesh('CompressedUVSetsCubeShape')
 
         # We should not see the default "map1" UV set:
         self.assertNotIn("map1", mayaCubeMesh.getUVSetNames())


### PR DESCRIPTION
Some of our artists have discovered that the re-indexing and compression that we're doing when we export UV sets is actually messing with the connectivity information that Maya computes from the values and indices arrays. The result is that when they export Maya meshes to USD and then re-import them back into Maya, they're ending up with disconnected and hard to work with UV sets.

With the changes here, we now translate the Maya mesh's UV values and assignment indices more or less directly, and we no longer apply any compression. This offers the best chance of maintaining the UV set's connectivity across round-trips. The net result in USD is the same (i.e. the array of UVs produced by doing `primvar.ComputeFlattened()` is the same as before), but the array values for the UV set primvar and its accompanying indices attribute may be different.

The real meat of the changes are in 82ae536ae6617b306ed9f8199c52a27777f60b64 while the other commits are from clean-up, simplification, and testing.