### PR TITLE
replace usage of USD_VERSION_NUM with PXR_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ find_package(USD 0.20.02 REQUIRED)
 include(cmake/usd.cmake)
 include(${USD_CONFIG_FILE})
 
-if( MAYA_APP_VERSION LESS 2020 AND USD_VERSION_NUM GREATER 2005 AND USD_VERSION_NUM LESS 2102 )
+if( MAYA_APP_VERSION LESS 2020 AND PXR_VERSION GREATER 2005 AND PXR_VERSION LESS 2102 )
     # Default to OFF if maya==2019 AND USD==(20.08||20.11)
     #   Due to a problem with glew - if you force on with these versions, you
     #   will probably need to LD_PRELOAD your glew lib.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,6 @@ include(cmake/jinja.cmake)
 find_package(Maya 2018 REQUIRED)
 find_package(USD 0.20.02 REQUIRED)
 include(cmake/usd.cmake)
-include(${USD_CONFIG_FILE})
 
 if( MAYA_APP_VERSION LESS 2020 AND PXR_VERSION GREATER 2005 AND PXR_VERSION LESS 2102 )
     # Default to OFF if maya==2019 AND USD==(20.08||20.11)

--- a/cmake/compiler_config.cmake
+++ b/cmake/compiler_config.cmake
@@ -81,7 +81,7 @@ function(mayaUsd_compile_config TARGET)
     # required compiler feature
     # Require C++14 if we're either building for Maya 2019 or later, or if we're building against 
     # USD 20.05 or later. Otherwise require C++11.
-    if ((MAYA_APP_VERSION VERSION_GREATER_EQUAL 2019) OR (USD_VERSION_NUM VERSION_GREATER_EQUAL 2005))
+    if ((MAYA_APP_VERSION VERSION_GREATER_EQUAL 2019) OR (PXR_VERSION VERSION_GREATER_EQUAL 2005))
         target_compile_features(${TARGET} 
             PRIVATE
                 cxx_std_14

--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -92,7 +92,14 @@ if(listlen GREATER 1)
     get_filename_component(PXR_USD_LOCATION "${USD_CONFIG_FILE}" DIRECTORY)
 endif()
 
-if(USD_INCLUDE_DIR AND EXISTS "${USD_INCLUDE_DIR}/pxr/pxr.h")
+if(DEFINED PXR_VERSION)
+    # Starting in core USD 21.05, pxrConfig.cmake provides the various USD
+    # version numbers as CMake variables, in which case PXR_VERSION should have
+    # been defined, along with the major, minor, and patch version numbers, so
+    # there is no need to extract them from the pxr/pxr.h header file anymore.
+    # The only thing we need to do is assemble the USD_VERSION version string.
+    set(USD_VERSION ${PXR_MAJOR_VERSION}.${PXR_MINOR_VERSION}.${PXR_PATCH_VERSION})
+elseif(USD_INCLUDE_DIR AND EXISTS "${USD_INCLUDE_DIR}/pxr/pxr.h")
     foreach(_usd_comp MAJOR MINOR PATCH)
         file(STRINGS
             "${USD_INCLUDE_DIR}/pxr/pxr.h"

--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -75,6 +75,8 @@ find_file(USD_CONFIG_FILE
     DOC "USD cmake configuration file"
 )
 
+include(${USD_CONFIG_FILE})
+
 # ensure PXR_USD_LOCATION is defined
 if(NOT DEFINED PXR_USD_LOCATION)
     if(DEFINED ENV{PXR_USD_LOCATION})

--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -99,7 +99,7 @@ if(USD_INCLUDE_DIR AND EXISTS "${USD_INCLUDE_DIR}/pxr/pxr.h")
         string(REGEX MATCHALL "[0-9]+" USD_${_usd_comp}_VERSION ${_usd_tmp})
     endforeach()
     set(USD_VERSION ${USD_MAJOR_VERSION}.${USD_MINOR_VERSION}.${USD_PATCH_VERSION})
-    math(EXPR USD_VERSION_NUM "${USD_MAJOR_VERSION} * 10000 + ${USD_MINOR_VERSION} * 100 + ${USD_PATCH_VERSION}")
+    math(EXPR PXR_VERSION "${USD_MAJOR_VERSION} * 10000 + ${USD_MINOR_VERSION} * 100 + ${USD_PATCH_VERSION}")
 endif()
 
 message(STATUS "USD include dir: ${USD_INCLUDE_DIR}")
@@ -116,7 +116,7 @@ find_package_handle_standard_args(USD
         USD_GENSCHEMA
         USD_CONFIG_FILE
         USD_VERSION
-        USD_VERSION_NUM
+        PXR_VERSION
     VERSION_VAR
         USD_VERSION
 )

--- a/doc/codingGuidelines.md
+++ b/doc/codingGuidelines.md
@@ -213,7 +213,7 @@ Headers should be included in the following order, with each section separated b
 	* `WANT_UFE_BUILD` equals 1 if UFE is found and it should be used for conditional compilation on codes depending on UFE.
 
 **USD**
-	* `USD_VERSION_NUM` is the macro to test USD version (`USD_MAJOR_VERSION` * 10000 + `USD_MINOR_VERSION` * 100 + `USD_PATCH_VERSION`)
+	* `PXR_VERSION` is the macro to test USD version (`PXR_MAJOR_VERSION` * 10000 + `PXR_MINOR_VERSION` * 100 + `PXR_PATCH_VERSION`)
 
 Respect the minimum supported version for Maya and USD stated in [build.md](https://github.com/Autodesk/maya-usd/blob/dev/doc/build.md) .
 

--- a/lib/mayaUsd/CMakeLists.txt
+++ b/lib/mayaUsd/CMakeLists.txt
@@ -33,7 +33,6 @@ find_package(Boost COMPONENTS filesystem system REQUIRED)
 # -----------------------------------------------------------------------------
 target_compile_definitions(${PROJECT_NAME}
     PUBLIC
-        USD_VERSION_NUM=${USD_VERSION_NUM}
         PXR_PLUGINPATH_NAME=${PXR_OVERRIDE_PLUGINPATH_NAME}
         $<$<STREQUAL:${CMAKE_BUILD_TYPE},Debug>:TBB_USE_DEBUG>
         $<$<STREQUAL:${CMAKE_BUILD_TYPE},Debug>:BOOST_DEBUG_PYTHON>

--- a/lib/mayaUsd/fileio/utils/adaptor.cpp
+++ b/lib/mayaUsd/fileio/utils/adaptor.cpp
@@ -21,6 +21,7 @@
 #include <mayaUsd/fileio/utils/writeUtil.h>
 #include <mayaUsd/utils/util.h>
 
+#include <pxr/pxr.h>
 #include <pxr/usd/sdf/schema.h>
 #include <pxr/usd/usd/apiSchemaBase.h>
 #include <pxr/usd/usd/schemaBase.h>
@@ -90,7 +91,7 @@ TfToken UsdMayaAdaptor::GetUsdTypeName() const
     }
 
     const TfType ty = GetUsdType();
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     return UsdSchemaRegistry::GetInstance().GetSchemaTypeName(ty);
 #else
     const SdfPrimSpecHandle primDef = UsdSchemaRegistry::GetInstance().GetPrimDefinition(ty);
@@ -143,7 +144,7 @@ TfTokenVector UsdMayaAdaptor::GetAppliedSchemas() const
 
 UsdMayaAdaptor::SchemaAdaptor UsdMayaAdaptor::GetSchema(const TfType& ty) const
 {
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     const TfToken usdTypeName = UsdSchemaRegistry::GetInstance().GetSchemaTypeName(ty);
 #else
     const SdfPrimSpecHandle primDef = UsdSchemaRegistry::GetInstance().GetPrimDefinition(ty);
@@ -163,7 +164,7 @@ UsdMayaAdaptor::SchemaAdaptor UsdMayaAdaptor::GetSchemaByName(const TfToken& sch
         return SchemaAdaptor();
     }
 
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     // Is this an API schema?
     const UsdSchemaRegistry& schemaReg = UsdSchemaRegistry::GetInstance();
     if (const UsdPrimDefinition* primDef = schemaReg.FindAppliedAPIPrimDefinition(schemaName)) {
@@ -261,7 +262,7 @@ UsdMayaAdaptor::SchemaAdaptor UsdMayaAdaptor::ApplySchema(const TfType& ty)
 
 UsdMayaAdaptor::SchemaAdaptor UsdMayaAdaptor::ApplySchema(const TfType& ty, MDGModifier& modifier)
 {
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     const TfToken usdTypeName = UsdSchemaRegistry::GetInstance().GetSchemaTypeName(ty);
 #else
     const SdfPrimSpecHandle primDef = UsdSchemaRegistry::GetInstance().GetPrimDefinition(ty);
@@ -290,7 +291,7 @@ UsdMayaAdaptor::ApplySchemaByName(const TfToken& schemaName, MDGModifier& modifi
         return SchemaAdaptor();
     }
 
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     // Get the "apply" schema definition. If it's registered, there should be a
     // def.
     const UsdPrimDefinition* primDef
@@ -353,7 +354,7 @@ void UsdMayaAdaptor::UnapplySchema(const TfType& ty)
 
 void UsdMayaAdaptor::UnapplySchema(const TfType& ty, MDGModifier& modifier)
 {
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     const TfToken usdTypeName = UsdSchemaRegistry::GetInstance().GetSchemaTypeName(ty);
 #else
     const SdfPrimSpecHandle primDef = UsdSchemaRegistry::GetInstance().GetPrimDefinition(ty);
@@ -537,7 +538,7 @@ template <typename T> static TfToken::Set _GetRegisteredSchemas()
 
     const UsdSchemaRegistry& registry = UsdSchemaRegistry::GetInstance();
     for (const TfType& ty : derivedTypes) {
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
         const TfToken usdTypeName = registry.GetSchemaTypeName(ty);
 #else
         const SdfPrimSpecHandle primDef = registry.GetPrimDefinition(ty);
@@ -624,7 +625,7 @@ UsdMayaAdaptor::SchemaAdaptor::SchemaAdaptor()
 {
 }
 
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
 UsdMayaAdaptor::SchemaAdaptor::SchemaAdaptor(
     const MObjectHandle&     handle,
     const TfToken&           schemaName,
@@ -708,7 +709,7 @@ TfToken UsdMayaAdaptor::SchemaAdaptor::GetName() const
     return _schemaName;
 }
 
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
 static SdfAttributeSpecHandle
 _GetAttributeSpec(const UsdPrimDefinition* primDef, const TfToken& attrName)
 {
@@ -838,7 +839,7 @@ TfTokenVector UsdMayaAdaptor::SchemaAdaptor::GetAuthoredAttributeNames() const
 
     MFnDependencyNode node(_handle.object());
     TfTokenVector     result;
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     for (const TfToken& propName : _schemaDef->GetPropertyNames()) {
         if (_schemaDef->GetSpecType(propName) == SdfSpecTypeAttribute) {
             std::string mayaAttrName = _GetMayaAttrNameOrAlias(propName);
@@ -866,7 +867,7 @@ TfTokenVector UsdMayaAdaptor::SchemaAdaptor::GetAttributeNames() const
     }
 
     TfTokenVector attrNames;
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     for (const TfToken& propName : _schemaDef->GetPropertyNames()) {
         if (_schemaDef->GetSpecType(propName) == SdfSpecTypeAttribute) {
             attrNames.push_back(propName);
@@ -881,7 +882,7 @@ TfTokenVector UsdMayaAdaptor::SchemaAdaptor::GetAttributeNames() const
     return attrNames;
 }
 
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
 const UsdPrimDefinition* UsdMayaAdaptor::SchemaAdaptor::GetSchemaDefinition() const
 {
     return _schemaDef;

--- a/lib/mayaUsd/fileio/utils/adaptor.h
+++ b/lib/mayaUsd/fileio/utils/adaptor.h
@@ -220,7 +220,7 @@ public:
     class SchemaAdaptor
     {
         MObjectHandle _handle;
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
         const UsdPrimDefinition* _schemaDef;
 #else
         SdfPrimSpecHandle _schemaDef;
@@ -231,7 +231,7 @@ public:
         MAYAUSD_CORE_PUBLIC
         SchemaAdaptor();
 
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
         MAYAUSD_CORE_PUBLIC
         SchemaAdaptor(
             const MObjectHandle&     object,
@@ -316,7 +316,7 @@ public:
         MAYAUSD_CORE_PUBLIC
         TfTokenVector GetAttributeNames() const;
 
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
         /// Gets the prim definition for this schema from the schema registry.
         /// Returns a null pointer if this schema adaptor is invalid.
         MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -362,7 +362,7 @@ bool UsdMayaWriteJobContext::_OpenFile(const std::string& filename, bool append)
         } else {
             SdfLayer::FileFormatArguments args;
             args[UsdUsdFileFormatTokens->FormatArg] = mArgs.defaultUSDFormat.GetString();
-#if USD_VERSION_NUM > 2008
+#if PXR_VERSION > 2008
             layer = SdfLayer::CreateNew(filename, args);
 #else
             layer = SdfLayer::CreateNew(filename, "", args);

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -37,6 +37,7 @@
 #include <pxr/base/tf/stringUtils.h>
 #include <pxr/base/tf/token.h>
 #include <pxr/base/trace/trace.h>
+#include <pxr/pxr.h>
 #include <pxr/usd/ar/resolver.h>
 #include <pxr/usd/sdf/attributeSpec.h>
 #include <pxr/usd/sdf/layer.h>
@@ -1441,7 +1442,7 @@ void MayaUsdProxyShapeBase::_OnStageObjectsChanged(const UsdNotice::ObjectsChang
         }
 
         // If the attribute is not part of the primitive schema, it does not affect extents
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
         auto attrDefn
             = changedPrim.GetPrimDefinition().GetSchemaAttributeSpec(changedPropertyToken);
 #else

--- a/lib/mayaUsd/render/mayaToHydra/renderGlobals.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderGlobals.cpp
@@ -21,6 +21,7 @@
 #include <pxr/imaging/hd/renderDelegate.h>
 #include <pxr/imaging/hd/rendererPlugin.h>
 #include <pxr/imaging/hd/rendererPluginRegistry.h>
+#include <pxr/pxr.h>
 
 #include <maya/MFnDependencyNode.h>
 #include <maya/MFnEnumAttribute.h>
@@ -78,12 +79,12 @@ global proc mtohRenderOverride_AddMTOHAttributes(int $fromAE) {
     mtohRenderOverride_AddAttribute("mtoh", "Highlight Selected Objects", "mtohColorSelectionHighlight", $fromAE);
     mtohRenderOverride_AddAttribute("mtoh", "Highlight Color for Selected Objects", "mtohColorSelectionHighlightColor", $fromAE);
 )mel"
-#if USD_VERSION_NUM >= 2005
+#if PXR_VERSION >= 2005
                                           R"mel(
     mtohRenderOverride_AddAttribute("mtoh", "Highlight outline (in pixels, 0 to disable)", "mtohSelectionOutline", $fromAE);
 )mel"
 #endif
-#if USD_VERSION_NUM <= 2005
+#if PXR_VERSION <= 2005
                                           R"mel(
     mtohRenderOverride_AddAttribute("mtoh", "Enable color quantization", "mtohColorQuantization", $fromAE);
 )mel"
@@ -853,13 +854,13 @@ MObject MtohRenderGlobals::CreateAttributes(const GlobalParams& params)
             return mayaObject;
         }
     }
-#if USD_VERSION_NUM >= 2005
+#if PXR_VERSION >= 2005
     if (filter(_tokens->mtohSelectionOutline)) {
         _CreateFloatAttribute(
             node, filter.mayaString(), defGlobals.outlineSelectionWidth, userDefaults);
     }
 #endif
-#if USD_VERSION_NUM <= 2005
+#if PXR_VERSION <= 2005
     if (filter(_tokens->mtohColorQuantization)) {
         _CreateBoolAttribute(
             node, filter.mayaString(), defGlobals.enableColorQuantization, userDefaults);
@@ -1013,7 +1014,7 @@ MtohRenderGlobals::GetInstance(const GlobalParams& params, bool storeUserSetting
             return globals;
         }
     }
-#if USD_VERSION_NUM >= 2005
+#if PXR_VERSION >= 2005
     if (filter(_tokens->mtohSelectionOutline)) {
         _GetAttribute(node, filter.mayaString(), globals.outlineSelectionWidth, storeUserSetting);
         if (filter.attributeFilter()) {
@@ -1021,7 +1022,7 @@ MtohRenderGlobals::GetInstance(const GlobalParams& params, bool storeUserSetting
         }
     }
 #endif
-#if USD_VERSION_NUM <= 2005
+#if PXR_VERSION <= 2005
     if (filter(_tokens->mtohColorQuantization)) {
         _GetAttribute(node, filter.mayaString(), globals.enableColorQuantization, storeUserSetting);
         if (filter.attributeFilter()) {

--- a/lib/mayaUsd/render/mayaToHydra/renderGlobals.h
+++ b/lib/mayaUsd/render/mayaToHydra/renderGlobals.h
@@ -97,10 +97,10 @@ public:
     GfVec4f      colorSelectionHighlightColor = GfVec4f(1.0f, 1.0f, 0.0f, 0.5f);
     bool         colorSelectionHighlight = true;
     bool         wireframeSelectionHighlight = true;
-#if USD_VERSION_NUM >= 2005
+#if PXR_VERSION >= 2005
     float outlineSelectionWidth = 4.f;
 #endif
-#if USD_VERSION_NUM <= 2005
+#if PXR_VERSION <= 2005
     float enableColorQuantization = false;
 #endif
 };

--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
@@ -34,6 +34,7 @@
 #include <pxr/imaging/hdx/pickTask.h>
 #include <pxr/imaging/hdx/renderTask.h>
 #include <pxr/imaging/hdx/tokens.h>
+#include <pxr/pxr.h>
 
 #include <maya/M3dView.h>
 #include <maya/MConditionMessage.h>
@@ -53,7 +54,7 @@
 #include <exception>
 #include <limits>
 
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
 #include <pxr/imaging/hgi/hgi.h>
 #include <pxr/imaging/hgi/tokens.h>
 #endif
@@ -196,8 +197,8 @@ MtohRenderOverride::MtohRenderOverride(const MtohRendererDescription& desc)
     , _rendererDesc(desc)
     , _globals(MtohRenderGlobals::GetInstance())
     ,
-#if USD_VERSION_NUM > 2002
-#if USD_VERSION_NUM > 2005
+#if PXR_VERSION > 2002
+#if PXR_VERSION > 2005
     _hgi(Hgi::CreatePlatformDefaultHgi())
     ,
 #else
@@ -494,7 +495,7 @@ MStatus MtohRenderOverride::Render(const MHWRender::MDrawContext& drawContext)
         if (_playBlasting && !_isUsingHdSt && !tasks.empty()) {
             // XXX: Is this better as user-configurable ?
             constexpr auto msWait = std::chrono::duration<float, std::milli>(100);
-#if USD_VERSION_NUM >= 2005
+#if PXR_VERSION >= 2005
             std::shared_ptr<HdxRenderTask> renderTask
                 = std::dynamic_pointer_cast<HdxRenderTask>(tasks.front());
 #else
@@ -581,14 +582,14 @@ MStatus MtohRenderOverride::Render(const MHWRender::MDrawContext& drawContext)
     _taskController->SetSelectionColor(_globals.colorSelectionHighlightColor);
     _taskController->SetEnableSelection(_globals.colorSelectionHighlight);
 
-#if USD_VERSION_NUM >= 2005
+#if PXR_VERSION >= 2005
     if (_globals.outlineSelectionWidth != 0.f) {
         _taskController->SetSelectionOutlineRadius(_globals.outlineSelectionWidth);
         _taskController->SetSelectionEnableOutline(true);
     } else
         _taskController->SetSelectionEnableOutline(false);
 #endif
-#if USD_VERSION_NUM <= 2005
+#if PXR_VERSION <= 2005
     _taskController->SetColorizeQuantizationEnabled(_globals.enableColorQuantization);
 #endif
 
@@ -657,14 +658,14 @@ void MtohRenderOverride::_InitHydraResources()
 {
     TF_DEBUG(HDMAYA_RENDEROVERRIDE_RESOURCES)
         .Msg("MtohRenderOverride::_InitHydraResources(%s)\n", _rendererDesc.rendererName.GetText());
-#if USD_VERSION_NUM < 2102
+#if PXR_VERSION < 2102
     GlfGlewInit();
 #endif
     GlfContextCaps::InitInstance();
     _rendererPlugin
         = HdRendererPluginRegistry::GetInstance().GetRendererPlugin(_rendererDesc.rendererName);
     auto* renderDelegate = _rendererPlugin->CreateRenderDelegate();
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     _renderIndex = HdRenderIndex::New(renderDelegate, { &_hgiDriver });
 #else
     _renderIndex = HdRenderIndex::New(renderDelegate);
@@ -797,11 +798,11 @@ void MtohRenderOverride::_SelectionChanged()
         return;
     }
     SdfPathVector selectedPaths;
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     auto selection = std::make_shared<HdSelection>();
 #else
     auto selection = boost::make_shared<HdSelection>();
-#endif // USD_VERSION_NUM > 2002
+#endif // PXR_VERSION > 2002
 
 #if WANT_UFE_BUILD
     const UFE_NS::GlobalSelection::Ptr& ufeSelection = UFE_NS::GlobalSelection::get();

--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.h
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.h
@@ -17,7 +17,7 @@
 #define MTOH_VIEW_OVERRIDE_H
 
 #include <pxr/pxr.h>
-#if USD_VERSION_NUM < 2102
+#if PXR_VERSION < 2102
 #include <pxr/imaging/glf/glew.h>
 #endif
 
@@ -33,7 +33,7 @@
 #include <memory>
 #include <mutex>
 
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
 #include <pxr/imaging/hd/driver.h>
 #endif
 #include <pxr/imaging/hd/engine.h>
@@ -162,7 +162,7 @@ private:
     std::atomic<bool>                     _isConverged = { false };
     std::atomic<bool>                     _needsClear = { false };
 
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     /// Hgi and HdDriver should be constructed before HdEngine to ensure they
     /// are destructed last. Hgi may be used during engine/delegate destruction.
     HgiUniquePtr _hgi;

--- a/lib/mayaUsd/render/mayaToHydra/utils.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/utils.cpp
@@ -15,12 +15,12 @@
 //
 
 // GLEW must be included early (for core USD < 21.02), but we need pxr.h first
-// so that USD_VERSION_NUM has the correct value.
+// so that PXR_VERSION has the correct value.
 // We also disable clang-format for this block, since otherwise v10.0.0 fails
 // to recognize that "utils.h" is the related header.
 // clang-format off
 #include <pxr/pxr.h>
-#if USD_VERSION_NUM < 2102
+#if PXR_VERSION < 2102
 #include <pxr/imaging/glf/glew.h>
 #endif
 // clang-format on
@@ -64,7 +64,7 @@ MtohInitializeRenderPlugins()
 
             // XXX: As of 22.02, this needs to be called for Storm
             if (pluginDesc.id == MtohTokens->HdStormRendererPlugin) {
-#if USD_VERSION_NUM < 2102
+#if PXR_VERSION < 2102
                 GlfGlewInit();
 #endif
                 GlfContextCaps::InitInstance();

--- a/lib/mayaUsd/render/px_vp20/glslProgram.cpp
+++ b/lib/mayaUsd/render/px_vp20/glslProgram.cpp
@@ -16,7 +16,7 @@
 
 // GL loading library needs to be included before any other OpenGL headers.
 #include <pxr/pxr.h>
-#if USD_VERSION_NUM < 2102
+#if PXR_VERSION < 2102
 #include <pxr/imaging/glf/glew.h>
 #else
 #include <pxr/imaging/garch/glApi.h>

--- a/lib/mayaUsd/render/px_vp20/utils.cpp
+++ b/lib/mayaUsd/render/px_vp20/utils.cpp
@@ -16,7 +16,7 @@
 
 // GL loading library needs to be included before any other OpenGL headers.
 #include <pxr/pxr.h>
-#if USD_VERSION_NUM < 2102
+#if PXR_VERSION < 2102
 #include <pxr/imaging/glf/glew.h>
 #else
 #include <pxr/imaging/garch/glApi.h>

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -16,7 +16,7 @@
 
 // GL loading library needs to be included before any other OpenGL headers.
 #include <pxr/pxr.h>
-#if USD_VERSION_NUM < 2102
+#if PXR_VERSION < 2102
 #include <pxr/imaging/glf/glew.h>
 #else
 #include <pxr/imaging/garch/glApi.h>
@@ -80,7 +80,7 @@
 #include <utility>
 #include <vector>
 
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
 #include <pxr/imaging/hgi/hgi.h>
 #include <pxr/imaging/hgi/tokens.h>
 #endif
@@ -112,7 +112,7 @@ const int UsdMayaGLBatchRenderer::ProfilerCategory = MProfiler::addCategory(
 /* static */
 void UsdMayaGLBatchRenderer::Init()
 {
-#if USD_VERSION_NUM < 2102
+#if PXR_VERSION < 2102
     GlfGlewInit();
 #endif
     GlfContextCaps::InitInstance();
@@ -399,8 +399,8 @@ UsdMayaGLBatchRenderer::UsdMayaGLBatchRenderer()
     , _softSelectOptionsCallbackId(0)
     , _selectResultsKey(GfMatrix4d(0.0), GfMatrix4d(0.0), false)
     ,
-#if USD_VERSION_NUM > 2002
-#if USD_VERSION_NUM > 2005
+#if PXR_VERSION > 2002
+#if PXR_VERSION > 2005
     _hgi(Hgi::CreatePlatformDefaultHgi())
     ,
 #else
@@ -417,7 +417,7 @@ UsdMayaGLBatchRenderer::UsdMayaGLBatchRenderer()
     _legacyViewportPrefix = _rootId.AppendChild(_tokens->LegacyViewport);
     _viewport2Prefix = _rootId.AppendChild(_tokens->Viewport2);
 
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     _renderIndex.reset(HdRenderIndex::New(&_renderDelegate, { &_hgiDriver }));
 #else
     _renderIndex.reset(HdRenderIndex::New(&_renderDelegate));

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
@@ -69,7 +69,7 @@
 #include <maya/MTypes.h>
 #include <maya/MUserData.h>
 
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
 #include <pxr/imaging/hd/driver.h>
 #endif
 
@@ -454,7 +454,7 @@ private:
     /// *after* the render index. We enforce that ordering by declaring the
     /// render delegate *before* the render index, since class members are
     /// destructed in reverse declaration order.
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     /// Hgi and HdDriver should be constructed before HdEngine to ensure they
     /// are destructed last. Hgi may be used during engine/delegate destruction.
     HgiUniquePtr _hgi;

--- a/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
@@ -235,7 +235,7 @@ void PxrMayaHdSceneDelegate::SetCameraState(
 
     // Provide other keys so that pulling on those in HdCamera::Sync doesn't
     // trigger coding errors.
-#if USD_VERSION_NUM >= 2102
+#if PXR_VERSION >= 2102
     cache[HdCameraTokens->projection] = VtValue();
 #endif
     cache[HdCameraTokens->horizontalAperture] = VtValue();
@@ -249,7 +249,7 @@ void PxrMayaHdSceneDelegate::SetCameraState(
     cache[HdCameraTokens->focusDistance] = VtValue();
     cache[HdCameraTokens->shutterOpen] = VtValue();
     cache[HdCameraTokens->shutterClose] = VtValue();
-#if USD_VERSION_NUM >= 2011
+#if PXR_VERSION >= 2011
     cache[HdCameraTokens->exposure] = VtValue();
 #endif
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -31,6 +31,7 @@
 #include <pxr/imaging/hd/sceneDelegate.h>
 #include <pxr/imaging/hd/tokens.h>
 #include <pxr/imaging/hd/version.h>
+#include <pxr/pxr.h>
 
 #include <maya/MFrameContext.h>
 #include <maya/MMatrix.h>
@@ -1535,7 +1536,7 @@ void HdVP2BasisCurves::_InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBit
     }
 
     // add new repr
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     _reprs.emplace_back(reprToken, std::make_shared<HdRepr>());
 #else
     _reprs.emplace_back(reprToken, boost::make_shared<HdRepr>());

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -25,6 +25,7 @@
 #include <pxr/base/gf/vec4f.h>
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/imaging/hd/sceneDelegate.h>
+#include <pxr/pxr.h>
 #include <pxr/usd/ar/packageUtils.h>
 #include <pxr/usd/sdf/assetPath.h>
 #include <pxr/usd/usdHydra/tokens.h>
@@ -46,13 +47,13 @@
 #include <iostream>
 #include <string>
 
-#if USD_VERSION_NUM >= 2102
+#if PXR_VERSION >= 2102
 #include <pxr/imaging/hdSt/udimTextureObject.h>
 #else
 #include <pxr/imaging/glf/udimTexture.h>
 #endif
 
-#if USD_VERSION_NUM >= 2102
+#if PXR_VERSION >= 2102
 #include <pxr/imaging/hio/image.h>
 #else
 #include <pxr/imaging/glf/image.h>
@@ -275,7 +276,7 @@ _LoadUdimTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& u
     */
 
     // test for a UDIM texture
-#if USD_VERSION_NUM >= 2102
+#if PXR_VERSION >= 2102
     if (!HdStIsSupportedUdimTexture(path))
         return nullptr;
 #else
@@ -319,7 +320,7 @@ _LoadUdimTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& u
     // resolution, warn the user if Maya's tiled texture implementation is going to result in
     // a loss of texture data.
     {
-#if USD_VERSION_NUM >= 2102
+#if PXR_VERSION >= 2102
         HioImageSharedPtr image = HioImage::OpenForReading(std::get<1>(tiles[0]).GetString());
 #else
         GlfImageSharedPtr image = GlfImage::OpenForReading(std::get<1>(tiles[0]).GetString());
@@ -348,7 +349,7 @@ _LoadUdimTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& u
     for (auto& tile : tiles) {
         tilePaths.append(MString(std::get<1>(tile).GetText()));
 
-#if USD_VERSION_NUM >= 2102
+#if PXR_VERSION >= 2102
         HioImageSharedPtr image = HioImage::OpenForReading(std::get<1>(tile).GetString());
 #else
         GlfImageSharedPtr image = GlfImage::OpenForReading(std::get<1>(tile).GetString());
@@ -399,7 +400,7 @@ _LoadTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& uvSca
         HdVP2RenderDelegate::sProfilerCategory, MProfiler::kColorD_L2, "LoadTexture", path.c_str());
 
     // If it is a UDIM texture we need to modify the path before calling OpenForReading
-#if USD_VERSION_NUM >= 2102
+#if PXR_VERSION >= 2102
     if (HdStIsSupportedUdimTexture(path))
         return _LoadUdimTexture(path, isColorSpaceSRGB, uvScaleOffset);
 #else
@@ -414,7 +415,7 @@ _LoadTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& uvSca
         return nullptr;
     }
 
-#if USD_VERSION_NUM >= 2102
+#if PXR_VERSION >= 2102
     HioImageSharedPtr image = HioImage::OpenForReading(path);
 #else
     GlfImageSharedPtr     image = GlfImage::OpenForReading(path);
@@ -426,7 +427,7 @@ _LoadTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& uvSca
     // This image is used for loading pixel data from usdz only and should
     // not trigger any OpenGL call. VP2RenderDelegate will transfer the
     // texels to GPU memory with VP2 API which is 3D API agnostic.
-#if USD_VERSION_NUM >= 2102
+#if PXR_VERSION >= 2102
     HioImage::StorageSpec spec;
 #else
     GlfImage::StorageSpec spec;
@@ -434,9 +435,9 @@ _LoadTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& uvSca
     spec.width = image->GetWidth();
     spec.height = image->GetHeight();
     spec.depth = 1;
-#if USD_VERSION_NUM >= 2102
+#if PXR_VERSION >= 2102
     spec.format = image->GetFormat();
-#elif USD_VERSION_NUM > 2008
+#elif PXR_VERSION > 2008
     spec.hioFormat = image->GetHioFormat();
 #else
     spec.format = image->GetFormat();
@@ -464,8 +465,8 @@ _LoadTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& uvSca
     desc.fBytesPerRow = bytesPerRow;
     desc.fBytesPerSlice = bytesPerSlice;
 
-#if USD_VERSION_NUM > 2008
-#if USD_VERSION_NUM >= 2102
+#if PXR_VERSION > 2008
+#if PXR_VERSION >= 2102
     switch (spec.format) {
 #else
     switch (spec.hioFormat) {

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.h
@@ -31,7 +31,7 @@
 // Workaround for a material consolidation update issue in VP2. Before USD 0.20.11, a Rprim will be
 // recreated if its material has any change, so everything gets refreshed and the update issue gets
 // masked. Once the update issue is fixed in VP2 we will disable this workaround.
-#if USD_VERSION_NUM >= 2011 && MAYA_API_VERSION >= 20210000
+#if PXR_VERSION >= 2011 && MAYA_API_VERSION >= 20210000
 #define HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
 #endif
 
@@ -82,7 +82,7 @@ public:
 
     HdDirtyBits GetInitialDirtyBitsMask() const override;
 
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
     void Reload() override {};
 #endif
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -33,6 +33,7 @@
 #include <pxr/imaging/hd/smoothNormals.h>
 #include <pxr/imaging/hd/version.h>
 #include <pxr/imaging/hd/vertexAdjacency.h>
+#include <pxr/pxr.h>
 
 #include <maya/MFrameContext.h>
 #include <maya/MMatrix.h>
@@ -787,7 +788,7 @@ void HdVP2Mesh::_InitRepr(const TfToken& reprToken, HdDirtyBits* dirtyBits)
         return;
     }
 
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     _reprs.emplace_back(reprToken, std::make_shared<HdRepr>());
 #else
     _reprs.emplace_back(reprToken, boost::make_shared<HdRepr>());

--- a/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.cpp
@@ -24,6 +24,7 @@
 #include <pxr/imaging/hd/vertexAdjacency.h>
 #include <pxr/imaging/pxOsd/refinerFactory.h>
 #include <pxr/imaging/pxOsd/tokens.h>
+#include <pxr/pxr.h>
 
 #include <maya/MProfiler.h>
 
@@ -769,7 +770,7 @@ bool MeshViewportCompute::hasOpenGL()
 
 void MeshViewportCompute::initializeOpenGL()
 {
-#if USD_VERSION_NUM < 2102
+#if PXR_VERSION < 2102
     GlfGlewInit();
 #else
     GarchGLApiLoad();

--- a/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.h
@@ -16,6 +16,8 @@
 #ifndef HD_VP2_MESHVIEWPORTCOMPUTE
 #define HD_VP2_MESHVIEWPORTCOMPUTE
 
+#include <pxr/pxr.h> // for PXR_VERSION
+
 #include <maya/MTypes.h> // for MAYA_API_VERSION
 
 /*
@@ -43,7 +45,7 @@
 // Maya 2020 is missing API necessary for compute support
 // OSX doesn't have OpenGL 4.3 support necessary for compute
 // USD before 20.08 doesn't include some OSD commits we rely on
-#if MAYA_API_VERSION >= 20210000 && !defined(OSMac_) && USD_VERSION_NUM > 2002
+#if MAYA_API_VERSION >= 20210000 && !defined(OSMac_) && PXR_VERSION > 2002
 #define HDVP2_ENABLE_GPU_COMPUTE
 #endif
 
@@ -58,7 +60,6 @@
 #endif
 
 #include <pxr/imaging/hd/mesh.h>
-#include <pxr/pxr.h>
 
 #include <maya/MHWGeometry.h>
 #include <maya/MSharedPtr.h>
@@ -85,7 +86,7 @@
 // clang-format wants to re-order these two includes but they must be done in this order or
 // the code will not compile.
 // clang-format off
-#if USD_VERSION_NUM < 2102
+#if PXR_VERSION < 2102
 #include <pxr/imaging/glf/glew.h> // needs to be included before anything else includes gl.h
 #else
 #include <pxr/imaging/garch/glApi.h>

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -37,6 +37,7 @@
 #include <pxr/imaging/hdx/renderTask.h>
 #include <pxr/imaging/hdx/selectionTracker.h>
 #include <pxr/imaging/hdx/taskController.h>
+#include <pxr/pxr.h>
 #include <pxr/usd/kind/registry.h>
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/modelAPI.h>
@@ -484,7 +485,7 @@ void ProxyRenderDelegate::_InitRenderDelegate()
     if (!_renderIndex) {
         MProfilingScope subProfilingScope(
             HdVP2RenderDelegate::sProfilerCategory, MProfiler::kColorD_L1, "Allocate RenderIndex");
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
         _renderIndex.reset(HdRenderIndex::New(_renderDelegate.get(), HdDriverVector()));
 #else
         _renderIndex.reset(HdRenderIndex::New(_renderDelegate.get()));

--- a/lib/mayaUsd/ufe/UsdAttribute.cpp
+++ b/lib/mayaUsd/ufe/UsdAttribute.cpp
@@ -20,6 +20,7 @@
 
 #include <pxr/base/tf/token.h>
 #include <pxr/base/vt/value.h>
+#include <pxr/pxr.h>
 #include <pxr/usd/sdf/attributeSpec.h>
 #include <pxr/usd/usd/schemaRegistry.h>
 
@@ -286,7 +287,7 @@ Ufe::UndoableCommand::Ptr UsdAttributeEnumString::setCmd(const std::string& valu
 Ufe::AttributeEnumString::EnumValues UsdAttributeEnumString::getEnumValues() const
 {
     PXR_NS::TfToken tk(name());
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     auto attrDefn = fPrim.GetPrimDefinition().GetSchemaAttributeSpec(tk);
 #else
     auto attrDefn = PXR_NS::UsdSchemaRegistry::GetAttributeDefinition(fPrim.GetTypeName(), tk);

--- a/lib/mayaUsd/ufe/UsdAttributes.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributes.cpp
@@ -16,6 +16,7 @@
 #include "UsdAttributes.h"
 
 #include <pxr/base/tf/token.h>
+#include <pxr/pxr.h>
 #include <pxr/usd/sdf/attributeSpec.h>
 #include <pxr/usd/usd/schemaRegistry.h>
 
@@ -151,7 +152,7 @@ UsdAttributes::getUfeTypeForAttribute(const PXR_NS::UsdAttribute& usdAttr) const
             // Special case for TfToken -> Enum. If it doesn't have any allowed
             // tokens, then use String instead.
             if (iter->second == Ufe::Attribute::kEnumString) {
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
                 auto attrDefn = fPrim.GetPrimDefinition().GetSchemaAttributeSpec(usdAttr.GetName());
 #else
                 auto attrDefn = PXR_NS::UsdSchemaRegistry::GetAttributeDefinition(

--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -26,6 +26,7 @@
 #include <mayaUsd/utils/util.h>
 
 #include <pxr/base/tf/diagnostic.h>
+#include <pxr/pxr.h>
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usd/sdf/reference.h>
 #include <pxr/usd/usd/common.h>
@@ -354,7 +355,7 @@ _computeLoadAndUnloadItems(const UsdPrim& prim)
     std::vector<std::pair<const char* const, const char* const>> itemLabelPairs;
 
     const bool isInPrototype =
-#if USD_VERSION_NUM >= 2011
+#if PXR_VERSION >= 2011
         prim.IsInPrototype();
 #else
         prim.IsInMaster();

--- a/lib/mayaUsd/ufe/UsdSceneItem.cpp
+++ b/lib/mayaUsd/ufe/UsdSceneItem.cpp
@@ -16,7 +16,8 @@
 #include "UsdSceneItem.h"
 
 #include <pxr/base/tf/type.h>
-#if USD_VERSION_NUM < 2008
+#include <pxr/pxr.h>
+#if PXR_VERSION < 2008
 #include <pxr/usd/usd/schemaBase.h>
 #else
 #include <pxr/usd/usd/primTypeInfo.h>
@@ -51,7 +52,7 @@ std::vector<std::string> UsdSceneItem::ancestorNodeTypes() const
 {
     std::vector<std::string> strAncestorTypes;
 
-#if USD_VERSION_NUM < 2008
+#if PXR_VERSION < 2008
     static const TfType schemaBaseType = TfType::Find<UsdSchemaBase>();
     const TfType schemaType = schemaBaseType.FindDerivedByName(fPrim.GetTypeName().GetString());
 #else
@@ -76,7 +77,7 @@ std::vector<std::string> UsdSceneItem::ancestorNodeTypes() const
     for (const TfType& ty : tfAncestorTypes) {
         // If there is a concrete schema type name, we'll return that since it is what
         // is used/shown in the UI (ex: 'Xform' vs 'UsdGeomXform').
-#if USD_VERSION_NUM >= 2005
+#if PXR_VERSION >= 2005
         strAncestorTypes.emplace_back(
             schemaReg.IsConcrete(ty) ? schemaReg.GetSchemaTypeName(ty) : ty.GetTypeName());
 #else

--- a/lib/usd/hdMaya/adapters/aiSkydomeLightAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/aiSkydomeLightAdapter.cpp
@@ -65,7 +65,7 @@ public:
             return VtValue(light.findPlug("aiExposure", true).asFloat());
         } else if (paramName == HdLightTokens->normalize) {
             return VtValue(light.findPlug("aiNormalize", true).asBool());
-#if USD_VERSION_NUM >= 2102
+#if PXR_VERSION >= 2102
         } else if (paramName == HdLightTokens->textureFormat) {
 #else
         } else if (paramName == UsdLuxTokens->textureFormat) {
@@ -97,7 +97,7 @@ public:
                 file.findPlug(MayaAttrs::file::fileTextureName, true).asString().asChar()));
         } else if (paramName == HdLightTokens->enableColorTemperature) {
             return VtValue(false);
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
         } else if (paramName == HdLightTokens->textureResource) {
             auto fileObj = GetConnectedFileNode(GetNode(), HdMayaAdapterTokens->color);
             // TODO: Return a default, white texture?
@@ -110,7 +110,7 @@ public:
                 fileObj,
                 GetFileTexturePath(MFnDependencyNode(fileObj)),
                 GetDelegate()->GetParams().textureMemoryPerTexture) };
-#endif // USD_VERSION_NUM < 2011
+#endif // PXR_VERSION < 2011
         }
         return {};
     }

--- a/lib/usd/hdMaya/adapters/materialAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/materialAdapter.cpp
@@ -25,6 +25,7 @@
 #include <pxr/base/tf/token.h>
 #include <pxr/base/tf/type.h>
 #include <pxr/imaging/hd/material.h>
+#include <pxr/pxr.h>
 #include <pxr/usd/sdf/types.h>
 #include <pxr/usdImaging/usdImaging/tokens.h>
 
@@ -32,9 +33,9 @@
 #include <maya/MPlug.h>
 #include <maya/MPlugArray.h>
 
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
 #include <pxr/imaging/hdSt/textureResourceHandle.h>
-#endif // USD_VERSION_NUM < 2011
+#endif // PXR_VERSION < 2011
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -89,7 +90,7 @@ void HdMayaMaterialAdapter::Populate()
     _isPopulated = true;
 }
 
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
 
 HdTextureResource::ID HdMayaMaterialAdapter::GetTextureResourceID(const TfToken& paramName)
 {
@@ -101,7 +102,7 @@ HdTextureResourceSharedPtr HdMayaMaterialAdapter::GetTextureResource(const SdfPa
     return {};
 }
 
-#endif // USD_VERSION_NUM < 2011
+#endif // PXR_VERSION < 2011
 
 VtValue HdMayaMaterialAdapter::GetMaterialResource()
 {
@@ -212,7 +213,7 @@ private:
         }
     }
 
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
 
     HdTextureResourceSharedPtr GetTextureResource(const SdfPath& textureShaderId) override
     {
@@ -234,7 +235,7 @@ private:
         return {};
     }
 
-#endif // USD_VERSION_NUM < 2011
+#endif // PXR_VERSION < 2011
 
     void _CreateSurfaceMaterialCallback()
     {
@@ -250,7 +251,7 @@ private:
         }
     }
 
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
 
     inline HdTextureResource::ID
     _GetTextureResourceID(const MObject& fileObj, const TfToken& filePath)
@@ -263,7 +264,7 @@ private:
         return HdTextureResource::ID(hash);
     }
 
-#endif // USD_VERSION_NUM < 2011
+#endif // PXR_VERSION < 2011
 
     VtValue GetMaterialResource() override
     {
@@ -319,12 +320,12 @@ private:
     TfToken _surfaceShaderType;
     // So they live long enough
 
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
 
     std::unordered_map<TfToken, HdStTextureResourceHandleSharedPtr, TfToken::HashFunctor>
         _textureResourceHandles;
 
-#endif // USD_VERSION_NUM < 2011
+#endif // PXR_VERSION < 2011
 
     MCallbackId _surfaceShaderCallback;
 #ifdef HDMAYA_OIT_ENABLED

--- a/lib/usd/hdMaya/adapters/materialAdapter.h
+++ b/lib/usd/hdMaya/adapters/materialAdapter.h
@@ -43,14 +43,14 @@ public:
     HDMAYA_API
     void Populate() override;
 
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
 
     HDMAYA_API
     virtual HdTextureResourceSharedPtr GetTextureResource(const SdfPath& textureShaderId);
     HDMAYA_API
     virtual HdTextureResource::ID GetTextureResourceID(const TfToken& paramName);
 
-#endif // USD_VERSION_NUM < 2011
+#endif // PXR_VERSION < 2011
 
     HDMAYA_API
     virtual VtValue GetMaterialResource();

--- a/lib/usd/hdMaya/delegates/delegateDebugCodes.cpp
+++ b/lib/usd/hdMaya/delegates/delegateDebugCodes.cpp
@@ -16,6 +16,7 @@
 #include "delegateDebugCodes.h"
 
 #include <pxr/base/tf/registryManager.h>
+#include <pxr/pxr.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -113,7 +114,7 @@ TF_REGISTRY_FUNCTION(TfDebug)
     TF_DEBUG_ENVIRONMENT_SYMBOL(
         HDMAYA_DELEGATE_SELECTION, "Print information about hdMaya delegate selection.");
 
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
 
     TF_DEBUG_ENVIRONMENT_SYMBOL(
         HDMAYA_DELEGATE_GET_TEXTURE_RESOURCE,
@@ -124,7 +125,7 @@ TF_REGISTRY_FUNCTION(TfDebug)
         "Print information about 'GetTextureResourceID' calls to the "
         "delegates.");
 
-#endif // USD_VERSION_NUM < 2011
+#endif // PXR_VERSION < 2011
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/usd/hdMaya/delegates/delegateDebugCodes.h
+++ b/lib/usd/hdMaya/delegates/delegateDebugCodes.h
@@ -53,13 +53,13 @@ TF_DEBUG_CODES(
 // These are declared in a separate block to avoid using a preprocessor
 // directive inside the TF_DEBUG_CODES() macro invocation, which breaks
 // compilation on Windows.
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
 // clang-format off
 TF_DEBUG_CODES(
     HDMAYA_DELEGATE_GET_TEXTURE_RESOURCE,
     HDMAYA_DELEGATE_GET_TEXTURE_RESOURCE_ID);
 // clang-format on
-#endif // USD_VERSION_NUM < 2011
+#endif // PXR_VERSION < 2011
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/lib/usd/hdMaya/delegates/sceneDelegate.cpp
+++ b/lib/usd/hdMaya/delegates/sceneDelegate.cpp
@@ -31,6 +31,7 @@
 #include <pxr/imaging/hd/rprim.h>
 #include <pxr/imaging/hd/tokens.h>
 #include <pxr/imaging/hdx/pickTask.h>
+#include <pxr/pxr.h>
 #include <pxr/usd/sdf/assetPath.h>
 #include <pxr/usd/usdGeom/tokens.h>
 
@@ -124,7 +125,7 @@ inline bool _RemoveAdapter(const SdfPath& id, F f, M0& m0, M&... m)
 
 template <typename R> inline R _GetDefaultValue() { return {}; }
 
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
 
 // Default return value for HdTextureResource::ID, if not found, should be
 // -1, not {} - which would be 0
@@ -133,7 +134,7 @@ template <> inline HdTextureResource::ID _GetDefaultValue<HdTextureResource::ID>
     return HdTextureResource::ID(-1);
 }
 
-#endif // USD_VERSION_NUM < 2011
+#endif // PXR_VERSION < 2011
 
 // This will be nicer to use with automatic parameter deduction for lambdas in
 // C++14.
@@ -1061,7 +1062,7 @@ VtValue HdMayaSceneDelegate::GetMaterialResource(const SdfPath& id)
     return ret.IsEmpty() ? HdMayaMaterialAdapter::GetPreviewMaterialResource(id) : ret;
 }
 
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
 
 HdTextureResource::ID HdMayaSceneDelegate::GetTextureResourceID(const SdfPath& textureId)
 {
@@ -1110,7 +1111,7 @@ HdTextureResourceSharedPtr HdMayaSceneDelegate::GetTextureResource(const SdfPath
     return nullptr;
 }
 
-#endif // USD_VERSION_NUM < 2011
+#endif // PXR_VERSION < 2011
 
 bool HdMayaSceneDelegate::_CreateMaterial(const SdfPath& id, const MObject& obj)
 {

--- a/lib/usd/hdMaya/delegates/sceneDelegate.h
+++ b/lib/usd/hdMaya/delegates/sceneDelegate.h
@@ -218,13 +218,13 @@ protected:
     HDMAYA_API
     VtValue GetMaterialResource(const SdfPath& id) override;
 
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
     HDMAYA_API
     HdTextureResource::ID GetTextureResourceID(const SdfPath& textureId) override;
 
     HDMAYA_API
     HdTextureResourceSharedPtr GetTextureResource(const SdfPath& textureId) override;
-#endif // USD_VERSION_NUM < 2011
+#endif // PXR_VERSION < 2011
 
 private:
     bool _CreateMaterial(const SdfPath& id, const MObject& obj);

--- a/lib/usd/hdMaya/utils.cpp
+++ b/lib/usd/hdMaya/utils.cpp
@@ -16,13 +16,14 @@
 #include "utils.h"
 
 #include <pxr/base/tf/token.h>
+#include <pxr/pxr.h>
 
 #include <maya/MFnDependencyNode.h>
 #include <maya/MObject.h>
 #include <maya/MPlugArray.h>
 #include <maya/MStatus.h>
 
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
 #include <pxr/base/tf/fileUtils.h>
 #include <pxr/imaging/glf/contextCaps.h>
 #include <pxr/imaging/glf/image.h>
@@ -37,7 +38,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
 
 namespace {
 
@@ -65,7 +66,7 @@ public:
 
 } // namespace
 
-#endif // USD_VERSION_NUM < 2011
+#endif // PXR_VERSION < 2011
 
 MObject GetConnectedFileNode(const MObject& obj, const TfToken& paramName)
 {
@@ -111,7 +112,7 @@ TfToken GetFileTexturePath(const MFnDependencyNode& fileNode)
     }
 }
 
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
 
 std::tuple<HdWrap, HdWrap> GetFileTextureWrappingParams(const MObject& fileObj)
 {
@@ -175,6 +176,6 @@ GetFileTextureResource(const MObject& fileObj, const TfToken& filePath, int maxT
         maxTextureMemory));
 }
 
-#endif // USD_VERSION_NUM < 2011
+#endif // PXR_VERSION < 2011
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/usd/hdMaya/utils.h
+++ b/lib/usd/hdMaya/utils.h
@@ -36,12 +36,12 @@
 #include <maya/MRenderUtil.h>
 #include <maya/MSelectionList.h>
 
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
 #include <pxr/imaging/hd/textureResource.h>
 #include <pxr/imaging/hd/types.h>
 
 #include <tuple>
-#endif // USD_VERSION_NUM < 2011
+#endif // PXR_VERSION < 2011
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -82,7 +82,7 @@ MObject GetConnectedFileNode(const MFnDependencyNode& node, const TfToken& param
 HDMAYA_API
 TfToken GetFileTexturePath(const MFnDependencyNode& fileNode);
 
-#if USD_VERSION_NUM < 2011
+#if PXR_VERSION < 2011
 
 /// \brief Returns the texture resource from a "file" shader node.
 /// \param fileObj "file" shader object.
@@ -105,7 +105,7 @@ HdTextureResourceSharedPtr GetFileTextureResource(
 HDMAYA_API
 std::tuple<HdWrap, HdWrap> GetFileTextureWrappingParams(const MObject& fileObj);
 
-#endif // USD_VERSION_NUM < 2011
+#endif // PXR_VERSION < 2011
 
 /// \brief Runs a function on all recursive descendents of a selection list
 ///  May optionally filter by node type. The items in the list are also included

--- a/lib/usd/translators/skelReader.cpp
+++ b/lib/usd/translators/skelReader.cpp
@@ -150,7 +150,7 @@ void UsdMayaPrimReaderSkelRoot::PostReadSubtree(UsdMayaPrimReaderContext* contex
 
     std::vector<UsdSkelBinding> bindings;
 
-#if USD_VERSION_NUM > 2008
+#if PXR_VERSION > 2008
     _cache.Populate(skelRoot, UsdTraverseInstanceProxies());
 
     if (!_cache.ComputeSkelBindings(skelRoot, &bindings, UsdTraverseInstanceProxies())) {

--- a/lib/usd/utils/util.cpp
+++ b/lib/usd/utils/util.cpp
@@ -16,6 +16,7 @@
 
 #include "util.h"
 
+#include <pxr/pxr.h>
 #include <pxr/usd/pcp/layerStack.h>
 #include <pxr/usd/sdf/layer.h>
 #include <pxr/usd/usd/inherits.h>
@@ -238,7 +239,7 @@ bool updateReferencedPath(const UsdPrim& oldPrim, const SdfPath& newPath)
 
 bool isInternalReference(const SdfReference& ref)
 {
-#if USD_VERSION_NUM >= 2008
+#if PXR_VERSION >= 2008
     return ref.IsInternal();
 #else
     return ref.GetAssetPath().empty();

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/PluginRegister.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/PluginRegister.h
@@ -15,7 +15,7 @@
 //
 #pragma once
 #include <pxr/pxr.h>
-#if USD_VERSION_NUM < 2102
+#if PXR_VERSION < 2102
 #include <pxr/imaging/glf/glew.h>
 #else
 #include <pxr/imaging/garch/glApi.h>
@@ -175,7 +175,7 @@ global proc AL_usdmaya_meshAnimImport()
 //----------------------------------------------------------------------------------------------------------------------
 template <typename AFnPlugin> MStatus registerPlugin(AFnPlugin& plugin)
 {
-#if USD_VERSION_NUM < 2102
+#if PXR_VERSION < 2102
     GlfGlewInit();
 #else
     GarchGLApiLoad();

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -19,7 +19,7 @@
 // to recognize that "ProxyDrawOverride.h" is the related header.
 // clang-format off
 #include <pxr/pxr.h>
-#if USD_VERSION_NUM < 2102
+#if PXR_VERSION < 2102
 #include <pxr/imaging/glf/glew.h>
 #else
 #include <pxr/imaging/garch/glApi.h>

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
@@ -3,7 +3,7 @@ set(TARGET_NAME VP2_RENDER_DELEGATE_TEST)
 # Unit test scripts.
 set(TEST_SCRIPT_FILES "")
 
-if (CMAKE_UFE_V2_FEATURES_AVAILABLE AND USD_VERSION_NUM GREATER_EQUAL 2008)
+if (CMAKE_UFE_V2_FEATURES_AVAILABLE AND PXR_VERSION GREATER_EQUAL 2008)
     # The point instance selection tests requires UsdImaging API version 14 or
     # later, which is only provided by core USD 20.08 or later.
     list(APPEND TEST_SCRIPT_FILES


### PR DESCRIPTION
maya-usd currently recomputes the `PXR_VERSION` provided by core USD as `USD_VERSION_NUM`. With the minimum USD version now set at 20.02, all supported versions of core USD provide the `PXR_VERSION` symbol in `pxr/pxr.h`, so we no longer need to recompute its value.

All usages of `USD_VERSION_NUM` in C++ were replaced with `PXR_VERSION`, and `#include`s of `pxr/pxr.h` were added where it was used.

For versions of core USD before 21.05, we still need to recompute `USD_VERSION_NUM` as a CMake variable, but we now use the `PXR_VERSION` name for consistency with C++. Starting with core USD 21.05, `PXR_VERSION` along with `PXR_MAJOR_VERSION`, `PXR_MINOR_VERSION`, and `PXR_PATCH_VERSION` will all be set as CMake variables in `pxrConfig.cmake` (see https://github.com/PixarAnimationStudios/USD/commit/30df5e9c8af0a3b3afd1a393adf92363b4042ab9). We'll then no longer need to extract them from the `pxr/pxr.h` header.