### PR TITLE
Remove the old formatTag option and anything that might still call it

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -307,7 +307,7 @@ void LayerTreeItem::saveAnonymousLayer()
     if (sessionState->saveLayerUI(nullptr, &fileName)) {
         // the path we has is an absolute path
         const QString dialogTitle = StringResources::getAsQString(StringResources::kSaveLayer);
-        std::string formatTag = UsdMayaSerialization::usdFormatArgOption();
+        std::string   formatTag = UsdMayaSerialization::usdFormatArgOption();
         if (saveSubLayer(dialogTitle, parentLayerItem(), layer(), fileName, formatTag)) {
             printf("USD Layer written to %s\n", fileName.c_str());
 

--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -9,6 +9,8 @@
 #include "stringResources.h"
 #include "warningDialogs.h"
 
+#include <mayaUsd/utils/utilSerialization.h>
+
 #include <pxr/usd/ar/resolver.h>
 #include <pxr/usd/sdf/fileFormat.h>
 #include <pxr/usd/sdf/layer.h>
@@ -301,10 +303,11 @@ void LayerTreeItem::saveAnonymousLayer()
 {
     auto sessionState = parentModel()->sessionState();
 
-    std::string fileName, formatTag;
-    if (sessionState->saveLayerUI(nullptr, &fileName, &formatTag)) {
+    std::string fileName;
+    if (sessionState->saveLayerUI(nullptr, &fileName)) {
         // the path we has is an absolute path
         const QString dialogTitle = StringResources::getAsQString(StringResources::kSaveLayer);
+        std::string formatTag = UsdMayaSerialization::usdFormatArgOption();
         if (saveSubLayer(dialogTitle, parentLayerItem(), layer(), fileName, formatTag)) {
             printf("USD Layer written to %s\n", fileName.c_str());
 

--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -226,9 +226,7 @@ void MayaSessionState::sceneClosingCB(void* clientData)
     Q_EMIT THIS->clearUIOnSceneResetSignal();
 }
 
-bool MayaSessionState::saveLayerUI(
-    QWidget*     in_parent,
-    std::string* out_filePath) const
+bool MayaSessionState::saveLayerUI(QWidget* in_parent, std::string* out_filePath) const
 {
     return SaveLayersDialog::saveLayerFilePathUI(*out_filePath);
 }

--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -228,10 +228,9 @@ void MayaSessionState::sceneClosingCB(void* clientData)
 
 bool MayaSessionState::saveLayerUI(
     QWidget*     in_parent,
-    std::string* out_filePath,
-    std::string* out_pFormat) const
+    std::string* out_filePath) const
 {
-    return SaveLayersDialog::saveLayerFilePathUI(*out_filePath, *out_pFormat);
+    return SaveLayersDialog::saveLayerFilePathUI(*out_filePath);
 }
 
 std::vector<std::string>

--- a/lib/usd/ui/layerEditor/mayaSessionState.h
+++ b/lib/usd/ui/layerEditor/mayaSessionState.h
@@ -59,9 +59,8 @@ public:
     // ui that returns a list of paths to load
     std::vector<std::string>
     loadLayersUI(const QString& title, const std::string& default_path) const override;
-    // ui to save a layer. returns the path 
-    bool saveLayerUI(QWidget* in_parent, std::string* out_filePath)
-        const override;
+    // ui to save a layer. returns the path
+    bool saveLayerUI(QWidget* in_parent, std::string* out_filePath) const override;
     void printLayer(const PXR_NS::SdfLayerRefPtr& layer) const override;
 
     // main API

--- a/lib/usd/ui/layerEditor/mayaSessionState.h
+++ b/lib/usd/ui/layerEditor/mayaSessionState.h
@@ -59,8 +59,8 @@ public:
     // ui that returns a list of paths to load
     std::vector<std::string>
     loadLayersUI(const QString& title, const std::string& default_path) const override;
-    // ui to save a layer. returns the path and the file format (ex: "usda")
-    bool saveLayerUI(QWidget* in_parent, std::string* out_filePath, std::string* out_pFormat)
+    // ui to save a layer. returns the path 
+    bool saveLayerUI(QWidget* in_parent, std::string* out_filePath)
         const override;
     void printLayer(const PXR_NS::SdfLayerRefPtr& layer) const override;
 

--- a/lib/usd/ui/layerEditor/saveLayersDialog.h
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.h
@@ -36,8 +36,8 @@ public:
     ~SaveLayersDialog();
 
     // UI to get a file path to save a layer.
-    // As output returns the path and the file format (ex: "usda").
-    static bool saveLayerFilePathUI(std::string& out_filePath, std::string& out_format);
+    // As output returns the path.
+    static bool saveLayerFilePathUI(std::string& out_filePath);
 
 protected:
     void onSaveAll();

--- a/lib/usd/ui/layerEditor/sessionState.h
+++ b/lib/usd/ui/layerEditor/sessionState.h
@@ -63,9 +63,8 @@ public:
     // ui that returns a list of paths to load
     virtual std::vector<std::string>
     loadLayersUI(const QString& title, const std::string& default_path) const = 0;
-    // ui to save a layer. returns the path 
-    virtual bool
-                 saveLayerUI(QWidget* in_parent, std::string* out_filePath) const = 0;
+    // ui to save a layer. returns the path
+    virtual bool saveLayerUI(QWidget* in_parent, std::string* out_filePath) const = 0;
     virtual void printLayer(const PXR_NS::SdfLayerRefPtr& layer) const = 0;
 
     // main API

--- a/lib/usd/ui/layerEditor/sessionState.h
+++ b/lib/usd/ui/layerEditor/sessionState.h
@@ -63,9 +63,9 @@ public:
     // ui that returns a list of paths to load
     virtual std::vector<std::string>
     loadLayersUI(const QString& title, const std::string& default_path) const = 0;
-    // ui to save a layer. returns the path and the file format (ex: "usda")
+    // ui to save a layer. returns the path 
     virtual bool
-                 saveLayerUI(QWidget* in_parent, std::string* out_filePath, std::string* out_pFormat) const = 0;
+                 saveLayerUI(QWidget* in_parent, std::string* out_filePath) const = 0;
     virtual void printLayer(const PXR_NS::SdfLayerRefPtr& layer) const = 0;
 
     // main API


### PR DESCRIPTION
There was still one function call we were making that looked at the old binary/ascii option.  Fixing that was a one-liner, to just leave the function parameter as an empty string which gets the utils function to check the optionVar for us, but I went ahead and removed the member variable in the SaveLayerPathRow class that tracked the old option and any use of it.

All code should now use the option that is in the Layer Editor menu for ascii or binary when saving to a .usd file.