### PR TITLE
When some instances are hidden there is a difference between the Scene

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1130,11 +1130,22 @@ void HdVP2BasisCurves::_UpdateDrawItem(
                 // Assign with the index to the dormant wireframe color by default.
                 colorIndices.resize(instanceCount, 0);
 
+                // The active & lead selection information tells us the scene delegate instance
+                // Id. We need to convert that to the Vp2 instance id used in the colorIndices
+                // vector.
+                VtIntArray delegateToVp2Map = static_cast<HdVP2Instancer*>(instancer)
+                                                  ->ComputeInstanceIdToVp2InstanceIdArray(id);
+
                 // Assign with the index to the active selection highlight color.
                 if (auto state = drawScene.GetActiveSelectionState(id)) {
                     for (const auto& indexArray : state->instanceIndices) {
                         for (const auto index : indexArray) {
-                            colorIndices[index] = 1;
+                            if (index < delegateToVp2Map.size()) {
+                                int vp2InstanceIndex = delegateToVp2Map[index];
+                                if (vp2InstanceIndex >= 0) {
+                                    colorIndices[vp2InstanceIndex] = 1;
+                                }
+                            }
                         }
                     }
                 }
@@ -1143,7 +1154,12 @@ void HdVP2BasisCurves::_UpdateDrawItem(
                 if (auto state = drawScene.GetLeadSelectionState(id)) {
                     for (const auto& indexArray : state->instanceIndices) {
                         for (const auto index : indexArray) {
-                            colorIndices[index] = 2;
+                            if (index < delegateToVp2Map.size()) {
+                                int vp2InstanceIndex = delegateToVp2Map[index];
+                                if (vp2InstanceIndex >= 0) {
+                                    colorIndices[vp2InstanceIndex] = 2;
+                                }
+                            }
                         }
                     }
                 }

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1140,7 +1140,8 @@ void HdVP2BasisCurves::_UpdateDrawItem(
                 if (auto state = drawScene.GetActiveSelectionState(id)) {
                     for (const auto& indexArray : state->instanceIndices) {
                         for (const auto index : indexArray) {
-                            if (index < delegateToVp2Map.size()) {
+                            TF_VERIFY(index >= 0);
+                            if (static_cast<size_t>(index) < delegateToVp2Map.size()) {
                                 int vp2InstanceIndex = delegateToVp2Map[index];
                                 if (vp2InstanceIndex >= 0) {
                                     colorIndices[vp2InstanceIndex] = 1;
@@ -1154,7 +1155,8 @@ void HdVP2BasisCurves::_UpdateDrawItem(
                 if (auto state = drawScene.GetLeadSelectionState(id)) {
                     for (const auto& indexArray : state->instanceIndices) {
                         for (const auto index : indexArray) {
-                            if (index < delegateToVp2Map.size()) {
+                            TF_VERIFY(index >= 0);
+                            if (static_cast<size_t>(index) < delegateToVp2Map.size()) {
                                 int vp2InstanceIndex = delegateToVp2Map[index];
                                 if (vp2InstanceIndex >= 0) {
                                     colorIndices[vp2InstanceIndex] = 2;

--- a/lib/mayaUsd/render/vp2RenderDelegate/instancer.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/instancer.h
@@ -47,6 +47,7 @@ public:
     ~HdVP2Instancer();
 
     VtMatrix4dArray ComputeInstanceTransforms(SdfPath const& prototypeId);
+    VtIntArray      ComputeInstanceIdToVp2InstanceIdArray(SdfPath const& prototypeId);
 
 private:
     void _SyncPrimvars();

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1501,7 +1501,8 @@ void HdVP2Mesh::_UpdateDrawItem(
             if (const auto state = drawScene.GetActiveSelectionState(id)) {
                 for (const auto& indexArray : state->instanceIndices) {
                     for (const auto index : indexArray) {
-                        if (index < delegateToVp2Map.size()) {
+                        TF_VERIFY(index >= 0);
+                        if (static_cast<size_t>(index) < delegateToVp2Map.size()) {
                             int vp2InstanceIndex = delegateToVp2Map[index];
                             if (vp2InstanceIndex >= 0) {
                                 visibleInstance = true;
@@ -1516,7 +1517,8 @@ void HdVP2Mesh::_UpdateDrawItem(
             if (const auto state = drawScene.GetLeadSelectionState(id)) {
                 for (const auto& indexArray : state->instanceIndices) {
                     for (const auto index : indexArray) {
-                        if (index < delegateToVp2Map.size()) {
+                        TF_VERIFY(index >= 0);
+                        if (static_cast<size_t>(index) < delegateToVp2Map.size()) {
                             int vp2InstanceIndex = delegateToVp2Map[index];
                             if (vp2InstanceIndex >= 0) {
                                 visibleInstance = true;

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1488,7 +1488,9 @@ void HdVP2Mesh::_UpdateDrawItem(
             // Assign with the index to the dormant wireframe color by default.
             colorIndices.resize(instanceCount, 0);
 
-            //
+            // The active & lead selection information tells us the scene delegate instance
+            // Id. We need to convert that to the Vp2 instance id used in the colorIndices
+            // vector.
             VtIntArray delegateToVp2Map
                 = static_cast<HdVP2Instancer*>(instancer)->ComputeInstanceIdToVp2InstanceIdArray(
                     id);


### PR DESCRIPTION
Delegate instance Id and the Maya instance Id. Store a mapping buffer from the Scene Delegate Id to the Maya Id so we can correctly draw selection highlights.