### PR TITLE
Uvset names not written

### DIFF
--- a/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
@@ -39,6 +39,7 @@
 #include <pxr/usd/usdShade/shader.h>
 #include <pxr/usd/usdUtils/pipeline.h>
 
+#include <maya/MCommandResult.h>
 #include <maya/MDGContext.h>
 #include <maya/MDagPath.h>
 #include <maya/MDagPathArray.h>
@@ -479,8 +480,34 @@ public:
                 }
                 MString getAttrCmd;
                 getAttrCmd.format("getAttr \"^1s\";", uvSetRef.c_str());
-                TfToken getAttrResult(MGlobal::executeCommandStringResult(getAttrCmd).asChar());
-
+                MCommandResult mayaCmdResult;
+                TfToken getAttrResult;
+                MGlobal::executeCommand(getAttrCmd, mayaCmdResult, false, false);
+                // NOTE: (yliangsiew) We do this because if you have a mesh shape in Maya named the same as its
+                // parent transform, you get back the result `map1 map1` instead of just `map1`. Why?
+                // Refer to the issue here: https://github.com/Autodesk/maya-usd/issues/1079
+                switch (mayaCmdResult.resultType()) {
+                case MCommandResult::kStringArray:
+                {
+                    MStringArray cmdResult;
+                    mayaCmdResult.getResult(cmdResult);
+                    if (cmdResult.length() == 0) {
+                        TF_RUNTIME_ERROR("No valid UV set names could be determined! The command run was: %s", getAttrCmd.asChar());
+                        continue;
+                    }
+                    getAttrResult = TfToken(cmdResult[0].asChar());
+                    break;
+                }
+                case MCommandResult::kString:
+                {
+                    MString cmdResult;
+                    mayaCmdResult.getResult(cmdResult);
+                    getAttrResult = TfToken(cmdResult.asChar());
+                    break;
+                }
+                default:
+                    break;
+                }
                 // Check if map1 should export as st:
                 if (getAttrResult == _tokens->map1 && UsdMayaWriteUtil::WriteMap1AsST()) {
                     getAttrResult = UsdUtilsGetPrimaryUVSetName();

--- a/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
@@ -481,32 +481,32 @@ public:
                 MString getAttrCmd;
                 getAttrCmd.format("getAttr \"^1s\";", uvSetRef.c_str());
                 MCommandResult mayaCmdResult;
-                TfToken getAttrResult;
+                TfToken        getAttrResult;
                 MGlobal::executeCommand(getAttrCmd, mayaCmdResult, false, false);
-                // NOTE: (yliangsiew) We do this because if you have a mesh shape in Maya named the same as its
-                // parent transform, you get back the result `map1 map1` instead of just `map1`. Why?
-                // Refer to the issue here: https://github.com/Autodesk/maya-usd/issues/1079
+                // NOTE: (yliangsiew) We do this because if you have a mesh shape in Maya named the
+                // same as its parent transform, you get back the result `map1 map1` instead of just
+                // `map1`. Why? Refer to the issue here:
+                // https://github.com/Autodesk/maya-usd/issues/1079
                 switch (mayaCmdResult.resultType()) {
-                case MCommandResult::kStringArray:
-                {
+                case MCommandResult::kStringArray: {
                     MStringArray cmdResult;
                     mayaCmdResult.getResult(cmdResult);
                     if (cmdResult.length() == 0) {
-                        TF_RUNTIME_ERROR("No valid UV set names could be determined! The command run was: %s", getAttrCmd.asChar());
+                        TF_RUNTIME_ERROR(
+                            "No valid UV set names could be determined! The command run was: %s",
+                            getAttrCmd.asChar());
                         continue;
                     }
                     getAttrResult = TfToken(cmdResult[0].asChar());
                     break;
                 }
-                case MCommandResult::kString:
-                {
+                case MCommandResult::kString: {
                     MString cmdResult;
                     mayaCmdResult.getResult(cmdResult);
                     getAttrResult = TfToken(cmdResult.asChar());
                     break;
                 }
-                default:
-                    break;
+                default: break;
                 }
                 // Check if map1 should export as st:
                 if (getAttrResult == _tokens->map1 && UsdMayaWriteUtil::WriteMap1AsST()) {

--- a/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
@@ -506,7 +506,12 @@ public:
                     getAttrResult = TfToken(cmdResult.asChar());
                     break;
                 }
-                default: break;
+                default:
+                    TF_RUNTIME_ERROR(
+                        "The UV set name could not be determined; the result was of an "
+                        "unrecognized type! The command run was: %s",
+                        getAttrCmd.asChar());
+                    continue;
                 }
                 // Check if map1 should export as st:
                 if (getAttrResult == _tokens->map1 && UsdMayaWriteUtil::WriteMap1AsST()) {


### PR DESCRIPTION
Hi:

This PR accounts for the Maya behaviour described in https://github.com/Autodesk/maya-usd/issues/1079, where the UV set name is not correctly written out when there is a shape node that shares the exact same name as its parent transform. 

Please review and raise any concerns.