### PR TITLE
al: notifyProxyShapeOfRedraw: fix for check if xform has changed

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
@@ -1703,7 +1703,7 @@ MStatus TransformationMatrix::setRotateOrientation(
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-void TransformationMatrix::notifyProxyShapeOfRedraw()
+void TransformationMatrix::notifyProxyShapeOfRedraw(GfMatrix4d& oldMatrix, bool oldResetsStack)
 {
     // Anytime we update the xform, we need to tell the proxy shape that it
     // needs to redraw itself
@@ -1717,10 +1717,6 @@ void TransformationMatrix::notifyProxyShapeOfRedraw()
             if (!proxyObj.isNull()) {
                 MFnDependencyNode proxyMfn(proxyObj);
                 if (proxyMfn.typeId() == ProxyShape::kTypeId) {
-                    GfMatrix4d oldMatrix;
-                    bool       oldResetsStack;
-                    m_xform.GetLocalTransformation(&oldMatrix, &oldResetsStack, getTimeCode());
-
                     // We check that the matrix actually HAS changed, as this function will be
                     // called when, ie, pushToPrim is toggled, which often happens on node
                     // creation, when nothing has actually changed
@@ -2153,7 +2149,7 @@ void TransformationMatrix::pushToPrim()
         } break;
         }
     }
-    notifyProxyShapeOfRedraw();
+    notifyProxyShapeOfRedraw(oldMatrix, oldResetsStack);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.h
@@ -367,7 +367,7 @@ class TransformationMatrix : public BasicTransformationMatrix
     /// \brief  pushes any modifications on the matrix back onto the UsdPrim
     void pushToPrim();
 
-    void notifyProxyShapeOfRedraw();
+    void notifyProxyShapeOfRedraw(GfMatrix4d& oldMatrix, bool oldResetsStack);
 
     /// \brief  sets the SRT values from a matrix
     void setFromMatrix(MObject thisNode, const MMatrix& m);


### PR DESCRIPTION
Bugfix - in [line 2065](https://github.com/Autodesk/maya-usd/blob/21d410cf9cfcce4231b554cf715a5124f54c4b06/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp#L2065) we get the old transform, but then never use it... then when actually comparing the value, we [used to get the current value twice](https://github.com/Autodesk/maya-usd/pull/1192/files#diff-4918577650a36d85c51a468a604f5b99cf93dcd92521951e7dae78aeda422155L1722), and compare against each other (which is always equal).