### PR TITLE
AL: fix proxy shape time-scalar export

### DIFF
--- a/plugin/al/translators/pxrUsdTranslators/ProxyShapeTranslator.cpp
+++ b/plugin/al/translators/pxrUsdTranslators/ProxyShapeTranslator.cpp
@@ -126,7 +126,11 @@ bool AL_USDMayaTranslatorProxyShape::Create(
             auto           timeOffsetPlug = proxyShape->timeOffsetPlug();
             auto           timeScalarPlug = proxyShape->timeScalarPlug();
             SdfLayerOffset offset(
-                timeOffsetPlug.asMTime().as(MTime::uiUnit()), timeScalarPlug.asDouble());
+                timeOffsetPlug.asMTime().as(MTime::uiUnit()),
+                // AL_USDMaya interprets the scalar such that 2.0 means
+                // fast-forward / play back twice as fast, while the usd spec
+                // interprets that as play in slow-motion / half-speed
+                1.0 / timeScalarPlug.asDouble());
 
             if (refPrimPathStr.empty()) {
                 refs.AddReference(refAssetPath, offset);

--- a/plugin/al/translators/pxrUsdTranslators/tests/sphere2.usda
+++ b/plugin/al/translators/pxrUsdTranslators/tests/sphere2.usda
@@ -15,6 +15,11 @@ def Xform "pSphere1" (
         texCoord2f[] primvars:st = [(0, 0), (1, 0), (0, 1), (1, 1)] (
             interpolation = "vertex"
         )
+        float xformOp:rotateZ.timeSamples = {
+            0: 0,
+            4: 360,
+        }
+        uniform token[] xformOpOrder = ["xformOp:rotateZ"]
     }
 
     def Mesh "pSphereShape2"


### PR DESCRIPTION
If exporting a ProxyShape as a reference, make sure we export the timeScalar settings we've changed.

NOTE - the interpretation of the timeScalar is OPPOSITE that as used by USD.  Not sure if this was intentional, but I invert the values on export, to make it work in USD as it did in Maya.