### PR TITLE
new signal/slot to reset a stage/proxy in the Layer Editor

### DIFF
--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -156,9 +156,23 @@ void MayaSessionState::unregisterNotifications()
 void MayaSessionState::mayaUsdStageReset(const MayaUsdProxyStageSetNotice& notice)
 {
     auto shapePath = notice.GetShapePath();
+    auto stage = notice.GetStage();
     if (shapePath == _currentProxyShapePath) {
-        auto stage = notice.GetStage();
         QTimer::singleShot(0, this, [this, stage]() { setStage(stage); });
+    } else {
+        auto shapePath = notice.GetShapePath();
+        QTimer::singleShot(
+            0, this, [this, shapePath, stage]() { mayaUsdStageResetCBOnIdle(shapePath, stage); });
+    }
+}
+
+void MayaSessionState::mayaUsdStageResetCBOnIdle(
+    const std::string&            shapePath,
+    PXR_NS::UsdStageRefPtr const& stage)
+{
+    StageEntry entry;
+    if (getStageEntry(&entry, shapePath.c_str())) {
+        Q_EMIT stageResetSignal(entry._proxyShapePath, stage);
     }
 }
 

--- a/lib/usd/ui/layerEditor/mayaSessionState.h
+++ b/lib/usd/ui/layerEditor/mayaSessionState.h
@@ -94,6 +94,7 @@ protected:
 
     // Notice listener method for proxy stage set
     void mayaUsdStageReset(const MayaUsdProxyStageSetNotice& notice);
+    void mayaUsdStageResetCBOnIdle(const std::string& shapePath, UsdStageRefPtr const& stage);
 
     std::vector<MCallbackId> _callbackIds;
     TfNotice::Key            _stageResetNoticeKey;

--- a/lib/usd/ui/layerEditor/sessionState.h
+++ b/lib/usd/ui/layerEditor/sessionState.h
@@ -81,6 +81,7 @@ Q_SIGNALS:
     void stageListChangedSignal(PXR_NS::UsdStageRefPtr const& toSelect = PXR_NS::UsdStageRefPtr());
     void stageRenamedSignal(std::string const& name, PXR_NS::UsdStageRefPtr const& stage);
     void autoHideSessionLayerSignal(bool hideIt);
+    void stageResetSignal(const std::string& proxyPath, PXR_NS::UsdStageRefPtr const& stage);
 
 protected:
     PXR_NS::UsdStageRefPtr _stage;

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
@@ -25,9 +25,7 @@
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QLabel>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
-Q_DECLARE_METATYPE(UsdStageRefPtr);
+Q_DECLARE_METATYPE(PXR_NS::UsdStageRefPtr);
 
 namespace UsdLayerEditor {
 
@@ -73,17 +71,17 @@ void StageSelectorWidget::setSessionState(SessionState* in_sessionState)
     updateFromSessionState();
 }
 
-UsdStageRefPtr StageSelectorWidget::selectedStage()
+PXR_NS::UsdStageRefPtr StageSelectorWidget::selectedStage()
 {
     if (_dropDown->currentIndex() != -1) {
         auto const& data = _dropDown->currentData();
-        return data.value<UsdStageRefPtr>();
+        return data.value<PXR_NS::UsdStageRefPtr>();
     }
 
-    return UsdStageRefPtr();
+    return PXR_NS::UsdStageRefPtr();
 }
 // repopulates the combo based on the session stage list
-void StageSelectorWidget::updateFromSessionState(UsdStageRefPtr const& stageToSelect)
+void StageSelectorWidget::updateFromSessionState(PXR_NS::UsdStageRefPtr const& stageToSelect)
 {
     QSignalBlocker blocker(_dropDown);
     _dropDown->clear();
@@ -122,7 +120,7 @@ void StageSelectorWidget::sessionStageChanged()
     }
 }
 
-void StageSelectorWidget::stageRenamed(std::string const& name, UsdStageRefPtr const& stage)
+void StageSelectorWidget::stageRenamed(std::string const& name, PXR_NS::UsdStageRefPtr const& stage)
 {
     auto index = _dropDown->findData(QVariant::fromValue(stage));
     if (index != -1) {
@@ -130,7 +128,9 @@ void StageSelectorWidget::stageRenamed(std::string const& name, UsdStageRefPtr c
     }
 }
 
-void StageSelectorWidget::stageReset(const std::string& proxyPath, UsdStageRefPtr const& stage)
+void StageSelectorWidget::stageReset(
+    const std::string&            proxyPath,
+    PXR_NS::UsdStageRefPtr const& stage)
 {
     // Individual combo box entries have a short display name and a reference to a stage,
     // which is not a unique combination.  By construction the combo box indices do line

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.h
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.h
@@ -46,6 +46,7 @@ protected:
     void
          updateFromSessionState(PXR_NS::UsdStageRefPtr const& stageToSelect = PXR_NS::UsdStageRefPtr());
     void stageRenamed(std::string const& name, PXR_NS::UsdStageRefPtr const& stage);
+    void stageReset(const std::string& proxyPath, PXR_NS::UsdStageRefPtr const& stage);
     void sessionStageChanged();
     void selectedIndexChanged(int index);
 


### PR DESCRIPTION
I have some other changes to how we handle anonymous root layers, but this fixes an issue that showed up in a demo last week where a proxy that has a new stage set still has the old stage visible in the Layer Editor if it wasn't the visible proxy when the reset happens.

The easiest way to test this right now is to copy/paste in a path to a new .usd file for the filePath attribute of a proxy that is not being displayed in the Layer Editor.  Switching to that proxy after making the change to filePath will still show the old stage.  This defect can also be hit as part of File -> Save, but this change only deals with the Layer Editor.  Follow up changes are going to improve how we handle anonymous root layers as part of saving.