### PR TITLE
[mtoh] if using the VP2 MPxSubSceneOverride, don't update if we're also using mtoh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,10 @@ else()
     option(BUILD_HDMAYA "Build the Maya-To-Hydra plugin and scene delegate." ON)
 endif()
 
+if (BUILD_HDMAYA)
+    add_definitions(-DBUILD_HDMAYA)
+endif()
+
 if(${MAYA_APP_VERSION} STRLESS "2019" AND CMAKE_WANT_UFE_BUILD)
     set(CMAKE_WANT_UFE_BUILD OFF)
     message(AUTHOR_WARNING "========================================================================================= \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,10 +111,6 @@ else()
     option(BUILD_HDMAYA "Build the Maya-To-Hydra plugin and scene delegate." ON)
 endif()
 
-if (BUILD_HDMAYA)
-    add_definitions(-DBUILD_HDMAYA)
-endif()
-
 if(${MAYA_APP_VERSION} STRLESS "2019" AND CMAKE_WANT_UFE_BUILD)
     set(CMAKE_WANT_UFE_BUILD OFF)
     message(AUTHOR_WARNING "========================================================================================= \

--- a/lib/mayaUsd/CMakeLists.txt
+++ b/lib/mayaUsd/CMakeLists.txt
@@ -50,6 +50,7 @@ target_compile_definitions(${PROJECT_NAME}
         $<$<BOOL:${IS_LINUX}>:GL_GLEXT_PROTOTYPES>
         $<$<BOOL:${IS_LINUX}>:GLX_GLXEXT_PROTOTYPES>
         $<$<BOOL:${Qt5_FOUND}>:WANT_QT_BUILD>
+        $<$<BOOL:${BUILD_HDMAYA}>:BUILD_HDMAYA>
 
         # this flag is needed when building maya-usd in Maya
         $<$<BOOL:${IS_WINDOWS}>:WIN32>

--- a/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
+++ b/lib/mayaUsd/render/mayaToHydra/CMakeLists.txt
@@ -18,6 +18,15 @@ target_sources(${TARGET_NAME}
         viewCommand.cpp
 )
 
+set(HEADERS
+    utils.h
+)
+
+# -----------------------------------------------------------------------------
+# promoted headers
+# -----------------------------------------------------------------------------
+mayaUsd_promoteHeaderList(HEADERS ${HEADERS} SUBDIR render/mayaToHydra)
+
 # -----------------------------------------------------------------------------
 # compiler configuration
 # -----------------------------------------------------------------------------
@@ -78,6 +87,10 @@ endif()
 # -----------------------------------------------------------------------------
 install(TARGETS ${TARGET_NAME}
         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/maya)
+
+install(FILES ${HEADERS}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}/render/mayaToHydra
+)
 
 if(IS_WINDOWS)
     install(FILES $<TARGET_PDB_FILE:${TARGET_NAME}> 

--- a/lib/mayaUsd/render/mayaToHydra/utils.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/utils.cpp
@@ -89,7 +89,7 @@ MtohInitializeRenderPlugins()
 
             store.first.emplace_back(
                 renderer,
-                TfToken(TfStringPrintf("mtohRenderOverride_%s", renderer.GetText())),
+                TfToken(TfStringPrintf("%s%s", MTOH_RENDER_OVERRIDE_PREFIX, renderer.GetText())),
                 TfToken(TfStringPrintf("%s (Hydra)", pluginDesc.displayName.c_str())));
             MtohRenderGlobals::BuildOptionsMenu(store.first.back(), rendererSettingDescriptors);
         }

--- a/lib/mayaUsd/render/mayaToHydra/utils.h
+++ b/lib/mayaUsd/render/mayaToHydra/utils.h
@@ -54,7 +54,7 @@ using MtohRendererSettings
 inline bool IsMtohRenderOverrideName(const MString& overrideName)
 {
     // See if the override is an mtoh one - ie, it starts with the right prefix
-    
+
     // VS2017 msvc didn't accept this as a constexpr
     const auto prefixLen = strlen(MTOH_RENDER_OVERRIDE_PREFIX);
     if (overrideName.length() < prefixLen) {

--- a/lib/mayaUsd/render/mayaToHydra/utils.h
+++ b/lib/mayaUsd/render/mayaToHydra/utils.h
@@ -55,12 +55,6 @@ inline bool IsMtohRenderOverrideName(const MString& overrideName)
 {
     // See if the override is an mtoh one - ie, it starts with the right prefix
     constexpr auto prefixLen = strlen(MTOH_RENDER_OVERRIDE_PREFIX);
-
-    TF_WARN(
-        "%s: %s an mtoh renderer",
-        overrideName.asChar(),
-        overrideName.substring(0, prefixLen - 1) == MTOH_RENDER_OVERRIDE_PREFIX ? "is" : "is not");
-
     if (overrideName.length() < prefixLen) {
         return false;
     }

--- a/lib/mayaUsd/render/mayaToHydra/utils.h
+++ b/lib/mayaUsd/render/mayaToHydra/utils.h
@@ -50,7 +50,7 @@ using MtohRendererDescriptionVector = std::vector<MtohRendererDescription>;
 using MtohRendererSettings
     = std::unordered_map<TfToken, HdRenderSettingDescriptorList, TfToken::HashFunctor>;
 
-// Defining these in header so don't need to link to use... template is
+// Defining these in header so don't need to link to use
 inline bool IsMtohRenderOverrideName(const MString& overrideName)
 {
     // See if the override is an mtoh one - ie, it starts with the right prefix

--- a/lib/mayaUsd/render/mayaToHydra/utils.h
+++ b/lib/mayaUsd/render/mayaToHydra/utils.h
@@ -20,10 +20,15 @@
 #include <pxr/imaging/hd/renderDelegate.h>
 #include <pxr/pxr.h>
 
+#include <maya/MFrameContext.h>
+#include <maya/MString.h>
+
 #include <string>
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
+
+constexpr auto MTOH_RENDER_OVERRIDE_PREFIX = "mtohRenderOverride_";
 
 struct MtohRendererDescription
 {
@@ -44,6 +49,31 @@ using MtohRendererDescriptionVector = std::vector<MtohRendererDescription>;
 // Map from MtohRendererDescription::rendererName to it's a HdRenderSettingDescriptorList
 using MtohRendererSettings
     = std::unordered_map<TfToken, HdRenderSettingDescriptorList, TfToken::HashFunctor>;
+
+// Defining these in header so don't need to link to use... template is
+inline bool IsMtohRenderOverrideName(const MString& overrideName)
+{
+    // See if the override is an mtoh one - ie, it starts with the right prefix
+    constexpr auto prefixLen = strlen(MTOH_RENDER_OVERRIDE_PREFIX);
+
+    TF_WARN(
+        "%s: %s an mtoh renderer",
+        overrideName.asChar(),
+        overrideName.substring(0, prefixLen - 1) == MTOH_RENDER_OVERRIDE_PREFIX ? "is" : "is not");
+
+    if (overrideName.length() < prefixLen) {
+        return false;
+    }
+
+    return overrideName.substring(0, prefixLen - 1) == MTOH_RENDER_OVERRIDE_PREFIX;
+}
+
+inline bool IsMtohRenderOverride(const MHWRender::MFrameContext& frameContext)
+{
+    MHWRender::MFrameContext::RenderOverrideInformation overrideInfo;
+    frameContext.getRenderOverrideInformation(overrideInfo);
+    return IsMtohRenderOverrideName(overrideInfo.overrideName);
+}
 
 std::string                          MtohGetRendererPluginDisplayName(const TfToken& id);
 const MtohRendererDescriptionVector& MtohGetRendererDescriptions();

--- a/lib/mayaUsd/render/mayaToHydra/utils.h
+++ b/lib/mayaUsd/render/mayaToHydra/utils.h
@@ -54,7 +54,9 @@ using MtohRendererSettings
 inline bool IsMtohRenderOverrideName(const MString& overrideName)
 {
     // See if the override is an mtoh one - ie, it starts with the right prefix
-    constexpr auto prefixLen = strlen(MTOH_RENDER_OVERRIDE_PREFIX);
+    
+    // VS2017 msvc didn't accept this as a constexpr
+    const auto prefixLen = strlen(MTOH_RENDER_OVERRIDE_PREFIX);
     if (overrideName.length() < prefixLen) {
         return false;
     }

--- a/lib/mayaUsd/render/pxrUsdMayaGL/proxyDrawOverride.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/proxyDrawOverride.cpp
@@ -44,6 +44,10 @@
 #include <maya/MUserData.h>
 #include <maya/MViewport2Renderer.h>
 
+#if defined(BUILD_HDMAYA)
+#include <mayaUsd/render/mayaToHydra/utils.h>
+#endif
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 const MString UsdMayaProxyDrawOverride::drawDbClassification(
@@ -186,6 +190,15 @@ MUserData* UsdMayaProxyDrawOverride::prepareForDraw(
     if (objPath.apiType() == MFn::kInstancer) {
         return nullptr;
     }
+
+#if defined(BUILD_HDMAYA)
+    // If the current viewport renderer is an mtoh one, skip this update, as
+    // mtoh already has special handling for proxy shapes, and we don't want to
+    // build out a render index we don't need
+    if (IsMtohRenderOverride(frameContext)) {
+        return nullptr;
+    }
+#endif
 
     MayaUsdProxyShapeBase* shape = MayaUsdProxyShapeBase::GetShapeAtDagPath(objPath);
     if (!shape) {

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -358,16 +358,12 @@ bool ProxyRenderDelegate::requiresUpdate(
     const MFrameContext&      frameContext) const
 {
 #if defined(BUILD_HDMAYA)
-    std::cout << "ProxyRenderDelegate::update - BUILD_HDMAYA - checking if IsMtohRenderOverride"
-              << std::endl;
-
     // If the current viewport renderer is an mtoh one, skip this update, as
     // mtoh already has special handling for proxy shapes, and we don't want to
     // build out a render index we don't need
     if (IsMtohRenderOverride(frameContext)) {
         return false;
     }
-    std::cout << "ProxyRenderDelegate::requiresSpdate - was not mtoh" << std::endl;
 #endif
     return true;
 }

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -60,6 +60,10 @@
 #include <ufe/selectionNotification.h>
 #endif
 
+#if defined(BUILD_HDMAYA)
+#include <mayaUsd/render/mayaToHydra/utils.h>
+#endif
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 namespace {
@@ -348,11 +352,23 @@ bool ProxyRenderDelegate::enableUpdateForSelection() const { return true; }
 #endif
 
 //! \brief  Always requires update since changes are tracked by Hydraw change tracker and it will
-//! guarantee minimal update
+//! guarantee minimal update; only exception is if rendering through Maya-to-Hydra
 bool ProxyRenderDelegate::requiresUpdate(
     const MSubSceneContainer& container,
     const MFrameContext&      frameContext) const
 {
+#if defined(BUILD_HDMAYA)
+    std::cout << "ProxyRenderDelegate::update - BUILD_HDMAYA - checking if IsMtohRenderOverride"
+              << std::endl;
+
+    // If the current viewport renderer is an mtoh one, skip this update, as
+    // mtoh already has special handling for proxy shapes, and we don't want to
+    // build out a render index we don't need
+    if (IsMtohRenderOverride(frameContext)) {
+        return false;
+    }
+    std::cout << "ProxyRenderDelegate::requiresSpdate - was not mtoh" << std::endl;
+#endif
     return true;
 }
 


### PR DESCRIPTION
These apparently still get called even when using MtoH's RenderOverride;
however, since MtoH has it's own proxyShape handling, they're unneeded, but
were still populating their own renderIndex.  Skip this to save time + memory.