### PR TITLE
MAYA-108709 refactor the undo/redo for transform commands

### DIFF
--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -115,6 +115,8 @@ if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
         UsdUndoReorderCommand.h
         UsdUndoSetKindCommand.h
         UsdUndoVisibleCommand.h
+        UsdValueUndoableCommandBase.h
+        UsdXformOpUndoableCommandBase.h
         XformOpUtils.h
     )
     # Why no if for UsdUIInfoHandler.h ?

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -139,7 +139,7 @@ GfMatrix4d xformInv(
 }
 
 // Class for setMatrixCmd() implementation.
-class UsdSetMatrix4dUndoableCmd : public UsdUndoableCommandBase<Ufe::SetMatrix4dUndoableCommand>
+class UsdSetMatrix4dUndoableCmd : public UsdValueUndoableCommandBase<Ufe::SetMatrix4dUndoableCommand>
 {
 public:
     UsdSetMatrix4dUndoableCmd(
@@ -168,7 +168,8 @@ public:
         // transform3d() returns a whole-object interface, which may include
         // other transform ops.
         auto t3d = Ufe::Transform3d::editTransform3d(sceneItem());
-        t3d->setMatrix(_newM);
+        const auto& matrix = v.Get<Ufe::Matrix4d>();
+        t3d->setMatrix(matrix);
     }
 };
 

--- a/lib/mayaUsd/ufe/UsdUndoableCommandBase.h
+++ b/lib/mayaUsd/ufe/UsdUndoableCommandBase.h
@@ -79,7 +79,7 @@ protected:
     // Actual implementation of the execution of the command,
     // executed "within" a UsdUndoBlock to capture undo data,
     // to be implemented by the sub-class.
-    virtual void executeImpl() = 0;
+    virtual void executeImpl(State prevState, State newState) = 0;
 
 private:
     UsdUndoableItem _undoableItem;
@@ -108,10 +108,11 @@ template <typename Cmd> inline void UsdUndoableCommandBase<Cmd>::execute()
 
     // Note: set new state before call in case setting the value causes feedback
     //       that end-up calling this again.
+    const State prevState = _state;
     _state = State::Done;
 
     UsdUndoBlock undoBlock(&_undoableItem);
-    executeImpl();
+    executeImpl(prevState, _state);
 }
 template <typename Cmd> inline void UsdUndoableCommandBase<Cmd>::undo()
 {

--- a/lib/mayaUsd/ufe/UsdValueUndoableCommandBase.h
+++ b/lib/mayaUsd/ufe/UsdValueUndoableCommandBase.h
@@ -1,0 +1,117 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include "UsdUndoableCommandBase.h"
+
+#include <pxr/base/vt/value.h>
+#include <pxr/usd/usdGeom/xformOp.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+// Templated helper class to factor out common code for setting USD values.
+//
+// Implement the execute, undo and redo of the UFE command interfaces, with
+// common code protecting against early undo/redo preceeding the initial
+// execution and declaring the UsdUndoBlock during the execution.
+//
+// Sub-classes should *not* have to override execute(), undo() nor redo().
+//
+// Sub-classes only need to implement the handleSet() function.
+//
+// Sub-classes can override set() if the command support interactive
+// manipulations. Since each set() in specific to the specific Cmd base
+// class, we cannot provide a generic implementation in this template.
+//
+// A typical set() implementation should call setNewValue() with the
+// new value and then execute() to actually set the value on the USD
+// attribute.
+template <typename Cmd> class UsdValueUndoableCommandBase : public UsdUndoableCommandBase<Cmd>
+{
+public:
+    using BaseClass = UsdUndoableCommandBase<Cmd>;
+
+    UsdValueUndoableCommandBase(
+        const VtValue&     newOpValue,
+        const Ufe::Path&   path,
+        const UsdTimeCode& writeTime_);
+
+    UsdTimeCode readTime() const;
+    UsdTimeCode writeTime() const;
+
+protected:
+    // Update the new value that will be set by execute().
+    void setNewValue(const VtValue& v);
+
+    // Concrete implementation of execute, undo and redo.
+    //
+    // Execute creates an undo block with the undoable item and calls handleSet().
+    void executeImpl(State previousState, State newState) override;
+
+    // Overridable method for derived classes to actually set the value on
+    // the USD attribute. The handleSet() call will be within a USD undo block
+    // as necessary. You don't need to declare such a block.
+    //
+    // We provide the previous and new state in case they need to take special
+    // actions on a given transition.
+    virtual void handleSet(State prevState, State newState, const VtValue& v) = 0;
+
+private:
+    const UsdTimeCode _readTime;
+    const UsdTimeCode _writeTime;
+    VtValue           _newValue;
+};
+
+// Implementation of the command base class.
+
+template <typename Cmd>
+inline UsdValueUndoableCommandBase<Cmd>::UsdValueUndoableCommandBase(
+    const VtValue&     newOpValue,
+    const Ufe::Path&   path,
+    const UsdTimeCode& writeTime_)
+    : BaseClass(path)
+    // Always read from proxy shape time.
+    , _readTime(getTime(path))
+    , _writeTime(writeTime_)
+    , _newValue(newOpValue)
+{
+}
+
+template <typename Cmd> inline void UsdValueUndoableCommandBase<Cmd>::executeImpl(State prevState, State newState)
+{
+    handleSet(prevState, newState, _newValue);
+}
+
+template <typename Cmd> inline void UsdValueUndoableCommandBase<Cmd>::setNewValue(const VtValue& v)
+{
+    _newValue = v;
+}
+
+template <typename Cmd> inline UsdTimeCode UsdValueUndoableCommandBase<Cmd>::readTime() const
+{
+    return _readTime;
+}
+
+template <typename Cmd> inline UsdTimeCode UsdValueUndoableCommandBase<Cmd>::writeTime() const
+{
+    return _writeTime;
+}
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdXformOpUndoableCommandBase.h
+++ b/lib/mayaUsd/ufe/UsdXformOpUndoableCommandBase.h
@@ -1,0 +1,108 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include "UsdValueUndoableCommandBase.h"
+
+#include <mayaUsd/base/api.h>
+#include <mayaUsd/undo/UsdUndoableItem.h>
+
+#include <pxr/base/vt/value.h>
+#include <pxr/usd/usdGeom/xformOp.h>
+
+#include <ufe/path.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+// Templated helper class to factor out common code for setting USD values.
+// Supports repeated calls to the set() method, invoked during direct
+// manipulation.
+template <typename Cmd>
+class UsdXformOpUndoableCommandBase : public UsdValueUndoableCommandBase<Cmd>
+{
+public:
+#if UFE_PREVIEW_VERSION_NUM >= 2031
+    using BaseUndoableCommand = Ufe::BaseUndoableCommand;
+#else
+    using BaseUndoableCommand = Ufe::BaseTransformUndoableCommand;
+#endif
+    using OpFunc = std::function<UsdGeomXformOp(const BaseUndoableCommand&)>;
+
+    UsdXformOpUndoableCommandBase(
+        const VtValue&     newOpValue,
+        const Ufe::Path&   path,
+        OpFunc             opFunc,
+        const UsdTimeCode& writeTime);
+
+    UsdXformOpUndoableCommandBase(
+        const VtValue&        newOpValue,
+        const Ufe::Path&      path,
+        const UsdGeomXformOp& op,
+        const UsdTimeCode&    writeTime);
+
+protected:
+    using State = typename UsdValueUndoableCommandBase<Cmd>::State;
+
+    // Engine method for derived classes implementing their set() method.
+    void handleSet(State previousState, State newState, const VtValue& v) override;
+
+private:
+    UsdGeomXformOp _op;
+    OpFunc         _opFunc;
+};
+
+// Implementation of the set-value command base class.
+
+template <typename Cmd>
+inline UsdXformOpUndoableCommandBase<Cmd>::UsdXformOpUndoableCommandBase(
+    const VtValue&        newOpValue,
+    const Ufe::Path&      path,
+    const UsdGeomXformOp& op,
+    const UsdTimeCode&    writeTime)
+    : UsdValueUndoableCommandBase<Cmd>(newOpValue, path, writeTime)
+    , _op(op)
+    , _opFunc()
+{
+}
+
+template <typename Cmd>
+inline UsdXformOpUndoableCommandBase<Cmd>::UsdXformOpUndoableCommandBase(
+    const VtValue&     newOpValue,
+    const Ufe::Path&   path,
+    OpFunc             opFunc,
+    const UsdTimeCode& writeTime)
+    : UsdValueUndoableCommandBase<Cmd>(newOpValue, path, writeTime)
+    , _op()
+    , _opFunc(std::move(opFunc))
+{
+}
+
+template <typename Cmd>
+inline void
+UsdXformOpUndoableCommandBase<Cmd>::handleSet(State previousState, State newState, const VtValue& v)
+{
+    // Only need to initialize the transform operation on the first execution.
+    if (previousState == State::Initial && _opFunc)
+        _op = _opFunc(*this);
+
+    _op.GetAttr().Set(v, writeTime());
+}
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF


### PR DESCRIPTION
- Implemented two additional template undo/redo base classes for transforms.
- UsdValueUndoableCommandBase is used to handle the case where a value is set on an attribute.
- UsdXformOpUndoableCommandBase is used to handle the case where the attribute is on a UsdGeomXformOp.
- Refactor UsdTransform3dMatrixOp, UsdTransform3dCommonAPI and UsdTransform3dMayaXformStack to use these classes.
- This is done to minimize the code duplication and undo/redo logic duplication.