### PR TITLE
Fix crash on failure to initialize a renderer, and only try once.

### DIFF
--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.h
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.h
@@ -206,7 +206,8 @@ private:
     int _currentOperation = -1;
 
     const bool _isUsingHdSt = false;
-    bool       _initializedViewport = false;
+    bool       _initializationAttempted = false;
+    bool       _initializationSucceeded = false;
     bool       _hasDefaultLighting = false;
     bool       _selectionChanged = true;
 


### PR DESCRIPTION
If a render-delegate fails to initialize itself **mtoh** will crash.
The checks here are a bit overly-cautious, but the function is called once (after switching renderers) so shouldn't affect perf.