### PR TITLE
MAYA-107424 - On stage AE template load/reload a file as stage source

### DIFF
--- a/plugin/adsk/scripts/AETemplateHelpers.py
+++ b/plugin/adsk/scripts/AETemplateHelpers.py
@@ -1,6 +1,14 @@
+import os.path
+import maya.cmds as cmds
 import ufe
 import mayaUsd.ufe
 import maya.internal.ufeSupport.ufeCmdWrapper as ufeCmd
+import maya.mel as mel
+
+def debugMessage(msg):
+    DEBUG = False
+    if DEBUG:
+        print(msg)
 
 def GetDefaultPrimName(proxyShape):
     try:
@@ -9,7 +17,8 @@ def GetDefaultPrimName(proxyShape):
             defPrim = proxyStage.GetDefaultPrim()
             if defPrim:
                 return defPrim.GetName()
-    except:
+    except Exception as e:
+        debugMessage('GetDefaultPrimName() - Error: %s' % str(e))
         pass
     return ''
 
@@ -20,7 +29,8 @@ def GetRootLayerName(proxyShape):
             rootLayer = proxyStage.GetRootLayer()
             if rootLayer:
                 return rootLayer.GetDisplayName() if rootLayer.anonymous else rootLayer.realPath
-    except:
+    except Exception as e:
+        debugMessage('GetRootLayerName() - Error: %s' % str(e))
         pass
     return ''
 
@@ -35,4 +45,162 @@ def ProxyShapePayloads(proxyShape, loadAll):
                 cmd = contextOps.doOpCmd([cmdStr])
                 ufeCmd.execute(cmd)
     except:
+        debugMessage('ProxyShapePayloads() - error during function')
+        pass
+
+def IsProxyShapeLayerStackDirty(proxyStage):
+    # Helper method which returns True if any layer (skipping SessionLayer)
+    # in the layer stack is dirty.
+    if proxyStage:
+        # Is any layer in the layerstack dirty?
+        for layer in proxyStage.GetLayerStack(includeSessionLayers=False):
+            debugMessage('  Proessing layer: %s' % layer.GetDisplayName())
+            if layer.dirty:
+                debugMessage('    Found dirty layer')
+                return True
+    return False
+
+def GetStageFromProxyShapeAttr(attr):
+    # Helper method which returns the proxy shape name and Usd stage
+    # from the input attribute on the proxy shape.
+
+    # First get the stage name from the input attribute.
+    stageName = mel.eval('plugNode("%s")' % attr)
+
+    # Convert that into a long Maya path so we can get the USD stage.
+    res = cmds.ls(stageName, l=True)
+    fullStageName = res[0]
+    proxyStage = mayaUsd.ufe.getStage(fullStageName)
+
+    return(stageName, proxyStage)
+
+def ProxyShapeFilePathChanged(filePathAttr, newFilePath=None):
+    # Function called from the MayaUsd Proxy Shape template when the file path
+    # text field of the file path attibute custom control is modified or interacted with.
+    #
+    # Arguments:
+    # - filePathAttr: string representing the file path attribute.
+    # - newFilePath : If None, the user clicked the file browser button.
+    #                 - In this case a file dialog will be opened to allow user to pick USD file.
+    #                 Otherwise when a string, the user entered a filename directly in the field.
+    #                 - In this case simply try and load the file.
+    #
+    # Return Value:
+    # - True:  The input file path attribute was updated with a new value.
+    # - False: No update to file path attribute was done.
+    #
+    debugMessage('ProxyShapeFilePathChanged(%s, %s)' % (filePathAttr, newFilePath))
+    try:
+        stageName, proxyStage = GetStageFromProxyShapeAttr(filePathAttr)
+
+        # Does the filepath attribute contain a valid file?
+        currFilePath = cmds.getAttr(filePathAttr)
+        dirtyStack = False
+        openFileDialog = False
+        if currFilePath:
+            # We have a current file path, so check if any layer in the layerstack is dirty?
+            dirtyStack = IsProxyShapeLayerStackDirty(proxyStage)
+            if not dirtyStack:
+                openFileDialog = True
+        else:
+            # No current file path, so do we just have an empty stage or was something added to
+            # this anon layer?
+            rootLayer = proxyStage.GetRootLayer()
+            if rootLayer and not rootLayer.empty:
+                dirtyStack = True
+            elif newFilePath is None:
+                debugMessage('  Empty stage, opening file dialog...')
+                openFileDialog = True
+
+        # If we have a dirty layer stack, display dialog to confirm new loading.
+        if dirtyStack:
+            kTitleFormat = mel.eval('getMayaUsdString("kDiscardStageEditsTitle")')
+            kMsgFormat = mel.eval('getMayaUsdString("kDiscardStageEditsLoadMsg")')
+            kYes = mel.eval('getMayaUsdString("kButtonYes")')
+            kNo = mel.eval('getMayaUsdString("kButtonNo")')
+            kTitle = cmds.format(kTitleFormat, stringArg=stageName)
+            # Our title is a little long, and the confirmDialog command is not making the
+            # dialog wide enough to show it all. So by telling the message string to not
+            # word-wrap, the dialog is forced wider.
+            kMsg = "<p style='white-space:pre'>" + cmds.format(kMsgFormat, stringArg=stageName)
+            res = cmds.confirmDialog(title=kTitle,
+                                     message=kMsg, messageAlign='left', 
+                                     button=[kYes, kNo], defaultButton=kYes, cancelButton=kNo, dismissString=kNo,
+                                     icon='warning')
+            if res == kYes:
+                debugMessage('  User confirmed load action, opening file dialog...')
+                openFileDialog = True
+            else:
+                # User said NO to update, so don't proceed any farther.
+                return False
+
+        if openFileDialog and newFilePath is None:
+            # Pop the file open dialog for user to load new usd file.
+            title = mel.eval('getMayaUsdString("kLoadUSDFile")')
+            okCaption = mel.eval('getMayaUsdString("kLoad")')
+            fileFilter = mel.eval('getMayaUsdString("kAllUsdFiles")') + ' (*.usd *.usda *.usdc *.usdz );;*.usd;;*.usda;;*.usdc;;*.usdz';
+            res = cmds.fileDialog2(caption=title, fileMode=1, ff=fileFilter, okc=okCaption)
+            if res and len(res) == 1:
+                debugMessage('    User picked USD file, setting file path attribute')
+                # Simply set the file path attribute. The proxy shape will load the file.
+                usdFileToLoad = res[0]
+                cmds.setAttr(filePathAttr, usdFileToLoad, type='string')
+                return True
+        elif newFilePath is not None:
+            # Instead of opening a file dialog to get the USD file, simply
+            # use the one provided as input.
+            # Note: it is important to check "not None" since the new file path can be
+            #       an empty string.
+            debugMessage('  New file to load provided, setting filepath="%s"' % newFilePath)
+            cmds.setAttr(filePathAttr, newFilePath, type='string')
+            return True
+    except Exception as e:
+        debugMessage('ProxyShapeFilePathChanged() - Error: %s' % str(e))
+        pass
+    return False
+
+def ProxyShapeFilePathRefresh(filePathAttr):
+    # Function called from the MayaUsd Proxy Shape template when the refresh
+    # button of the file path attribute custom control is clicked.
+    #
+    # Arguments:
+    # - filePathAttr: string representing the file path attribute.
+    #
+    # Return Value:
+    # - None
+    #
+    debugMessage('ProxyShapeFilePathRefresh(%s)' % filePathAttr)
+    try:
+        stageName, proxyStage = GetStageFromProxyShapeAttr(filePathAttr)
+
+        # Is any layer in the layerstack dirty?
+        # - If nothing is dirty, we simply reload.
+        # - If any layer is dirty pop a confirmation dialog to reload.
+        # Note: since we are file-backed, this will reload based on the file
+        #       which could have changed on disk.
+        if not IsProxyShapeLayerStackDirty(proxyStage):
+            debugMessage('  No dirty layers, calling UsdStage.Reload()')
+            proxyStage.Reload()
+        else:
+            kTitleFormat = mel.eval('getMayaUsdString("kDiscardStageEditsTitle")')
+            kMsgFormat = mel.eval('getMayaUsdString("kDiscardStageEditsReloadMsg")')
+            kYes = mel.eval('getMayaUsdString("kButtonYes")')
+            kNo = mel.eval('getMayaUsdString("kButtonNo")')
+            kTitle = cmds.format(kTitleFormat, stringArg=stageName)
+            # Our title is a little long, and the confirmDialog command is not making the
+            # dialog wide enough to show it all. So by telling the message string to not
+            # word-wrap, the dialog is forced wider.
+            filepath = cmds.getAttr(filePathAttr)
+            if filepath:
+                filename = os.path.basename(filepath)
+                kMsg = "<p style='white-space:pre'>" + cmds.format(kMsgFormat, stringArg=(filename, stageName))
+                res = cmds.confirmDialog(title=kTitle,
+                                         message=kMsg, messageAlign='left', 
+                                         button=[kYes, kNo], defaultButton=kYes, cancelButton=kNo, dismissString=kNo,
+                                         icon='warning')
+                if res == kYes:
+                    debugMessage('  User confirmed reload action, calling UsdStage.Reload()')
+                    proxyStage.Reload()
+    except Exception as e:
+        debugMessage('ProxyShapeFilePathRefresh() - Error: %s' % str(e))
         pass

--- a/plugin/adsk/scripts/AETemplateHelpers.py
+++ b/plugin/adsk/scripts/AETemplateHelpers.py
@@ -3,7 +3,7 @@ import maya.cmds as cmds
 import ufe
 import mayaUsd.ufe
 import maya.internal.ufeSupport.ufeCmdWrapper as ufeCmd
-import maya.mel as mel
+from mayaUSDRegisterStrings import getMayaUsdString
 
 def debugMessage(msg):
     DEBUG = False
@@ -54,7 +54,7 @@ def IsProxyShapeLayerStackDirty(proxyStage):
     if proxyStage:
         # Is any layer in the layerstack dirty?
         for layer in proxyStage.GetLayerStack(includeSessionLayers=False):
-            debugMessage('  Proessing layer: %s' % layer.GetDisplayName())
+            debugMessage('  Processing layer: %s' % layer.GetDisplayName())
             if layer.dirty:
                 debugMessage('    Found dirty layer')
                 return True
@@ -65,7 +65,7 @@ def GetStageFromProxyShapeAttr(attr):
     # from the input attribute on the proxy shape.
 
     # First get the stage name from the input attribute.
-    stageName = mel.eval('plugNode("%s")' % attr)
+    stageName = attr.split('.')[0]
 
     # Convert that into a long Maya path so we can get the USD stage.
     res = cmds.ls(stageName, l=True)
@@ -114,10 +114,10 @@ def ProxyShapeFilePathChanged(filePathAttr, newFilePath=None):
 
         # If we have a dirty layer stack, display dialog to confirm new loading.
         if dirtyStack:
-            kTitleFormat = mel.eval('getMayaUsdString("kDiscardStageEditsTitle")')
-            kMsgFormat = mel.eval('getMayaUsdString("kDiscardStageEditsLoadMsg")')
-            kYes = mel.eval('getMayaUsdString("kButtonYes")')
-            kNo = mel.eval('getMayaUsdString("kButtonNo")')
+            kTitleFormat = getMayaUsdString("kDiscardStageEditsTitle")
+            kMsgFormat = getMayaUsdString("kDiscardStageEditsLoadMsg")
+            kYes = getMayaUsdString("kButtonYes")
+            kNo = getMayaUsdString("kButtonNo")
             kTitle = cmds.format(kTitleFormat, stringArg=stageName)
             # Our title is a little long, and the confirmDialog command is not making the
             # dialog wide enough to show it all. So by telling the message string to not
@@ -136,9 +136,9 @@ def ProxyShapeFilePathChanged(filePathAttr, newFilePath=None):
 
         if openFileDialog and newFilePath is None:
             # Pop the file open dialog for user to load new usd file.
-            title = mel.eval('getMayaUsdString("kLoadUSDFile")')
-            okCaption = mel.eval('getMayaUsdString("kLoad")')
-            fileFilter = mel.eval('getMayaUsdString("kAllUsdFiles")') + ' (*.usd *.usda *.usdc *.usdz );;*.usd;;*.usda;;*.usdc;;*.usdz';
+            title = getMayaUsdString("kLoadUSDFile")
+            okCaption = getMayaUsdString("kLoad")
+            fileFilter = getMayaUsdString("kAllUsdFiles") + ' (*.usd *.usda *.usdc *.usdz );;*.usd;;*.usda;;*.usdc;;*.usdz';
             res = cmds.fileDialog2(caption=title, fileMode=1, ff=fileFilter, okc=okCaption)
             if res and len(res) == 1:
                 debugMessage('    User picked USD file, setting file path attribute')
@@ -182,10 +182,10 @@ def ProxyShapeFilePathRefresh(filePathAttr):
             debugMessage('  No dirty layers, calling UsdStage.Reload()')
             proxyStage.Reload()
         else:
-            kTitleFormat = mel.eval('getMayaUsdString("kDiscardStageEditsTitle")')
-            kMsgFormat = mel.eval('getMayaUsdString("kDiscardStageEditsReloadMsg")')
-            kYes = mel.eval('getMayaUsdString("kButtonYes")')
-            kNo = mel.eval('getMayaUsdString("kButtonNo")')
+            kTitleFormat = getMayaUsdString("kDiscardStageEditsTitle")
+            kMsgFormat = getMayaUsdString("kDiscardStageEditsReloadMsg")
+            kYes = getMayaUsdString("kButtonYes")
+            kNo = getMayaUsdString("kButtonNo")
             kTitle = cmds.format(kTitleFormat, stringArg=stageName)
             # Our title is a little long, and the confirmDialog command is not making the
             # dialog wide enough to show it all. So by telling the message string to not

--- a/plugin/adsk/scripts/AEmayaUsdProxyShapeBaseTemplate.mel
+++ b/plugin/adsk/scripts/AEmayaUsdProxyShapeBaseTemplate.mel
@@ -56,6 +56,75 @@ global proc AEmayaUsdProxyShapePayloadsReplace(string $loadPayloads)
     button -e -c ("AEMayaUsdProxyShapePayloadsCmd(\"" + $fullNodeName + "\", 0)") payloadsUnloadAllBtn;
 }
 
+global proc AEmayaUsdProxyShapeFilePathNew(string $filePathAttr)
+{
+    setUITemplate -pst attributeEditorTemplate;
+    columnLayout -adj true;
+        rowLayout -nc 4 -adj 2;
+            text -label `uiRes("m_scriptEditorPanel.kFile")` -ann `getMayaUsdString("kFileAnn")`;
+            textField mayaUsdProxyShapeFilePath;
+            symbolButton -image "navButtonBrowse.png" mayaUsdProxyShapeFilePathBrowser;
+            symbolButton -image "refresh.png" mayaUsdProxyShapeFilePathRefresh;
+        setParent ..;
+    setUITemplate -ppt;
+
+    AEmayaUsdProxyShapeFilePathReplace($filePathAttr);
+}
+
+global proc AEmayaUsdProxyShapeFilePathReplace(string $filePathAttr)
+{
+    // We don't want to connect FilePath control to the filePath attribute because we
+    // want to perform special validation on input before loading any new file.
+    // So do NOT use "connectControl" command.
+
+    string $currFilePath = `getAttr $filePathAttr`;
+    textField -e -fileName $currFilePath -changeCommand ("AEmayaUsdProxyShapeFilePathField(\"" + $filePathAttr + "\"\, \"" + $currFilePath + "\")") mayaUsdProxyShapeFilePath;
+    symbolButton -e -c ("AEmayaUsdProxyShapeFilePathBrowser(\"" + $filePathAttr + "\")") mayaUsdProxyShapeFilePathBrowser;
+    symbolButton -e -c ("AEmayaUsdProxyShapeFilePathRefresh(\"" + $filePathAttr + "\")") -enable `size($currFilePath)` mayaUsdProxyShapeFilePathRefresh;
+
+    // Add a script job on the filepath attribute so we can update the AE control
+    // if the attribute changes from the outside.
+    global int $mayaUsdProxyShapeFilePathScriptJobId = -1;
+    if (`scriptJob -exists $mayaUsdProxyShapeFilePathScriptJobId`)
+        scriptJob -kill $mayaUsdProxyShapeFilePathScriptJobId;
+    string $cmd = "AEmayaUsdProxyShapeFilePathChanged(\"" + $filePathAttr + "\")";
+    $mayaUsdProxyShapeFilePathScriptJobId = `scriptJob -parent mayaUsdProxyShapeFilePath -attributeChange $filePathAttr $cmd`;
+}
+
+// Called with file path attribute text field changes.
+global proc AEmayaUsdProxyShapeFilePathField(string $filePathAttr, string $currFilePath)
+{
+    string $newFilePath = `textField -q -fileName mayaUsdProxyShapeFilePath`;
+    int $result = python("import AETemplateHelpers; AETemplateHelpers.ProxyShapeFilePathChanged('" + $filePathAttr + "', newFilePath='" + $newFilePath + "')");
+    if ($result == 0) {
+        // The proxy shape file path update was rejected (no setAttr was done).
+        // Reset the field back to its original value.
+        textField -e -fileName $currFilePath mayaUsdProxyShapeFilePath;
+    }
+}
+
+// Called when user clicks the file path browser button.
+global proc AEmayaUsdProxyShapeFilePathBrowser(string $filePathAttr)
+{
+    python("import AETemplateHelpers; AETemplateHelpers.ProxyShapeFilePathChanged('" + $filePathAttr + "')");
+}
+
+// Called when the user clicks the file path refresh button.
+global proc AEmayaUsdProxyShapeFilePathRefresh(string $filePathAttr)
+{
+    python("import AETemplateHelpers; AETemplateHelpers.ProxyShapeFilePathRefresh('" + $filePathAttr + "')");
+}
+
+// Called in response to attributeChange notif on filePath attribute.
+global proc AEmayaUsdProxyShapeFilePathChanged(string $filePathAttr)
+{
+    // The Proxy Shape file path attribute was changed outside so we need to set
+    // the new value in our field and enable/disable the refresh button.
+    string $filePath = `getAttr $filePathAttr`;
+    textField -edit -fileName $filePath mayaUsdProxyShapeFilePath;
+    symbolButton -edit -enable `size($filePath)` mayaUsdProxyShapeFilePathRefresh;
+}
+
 // Callback used from editorTemplate -callCustom
 global proc AEmayaUsdProxyShapePurposeNew(string $drawGuidePurposeAttr, string $drawProxyPurposeAttr, string $drawRenderPurposeAttr)
 {
@@ -127,7 +196,7 @@ global proc AEmayaUsdProxyShapeBaseTemplate( string $nodeName )
         editorTemplate -endLayout;
 
         editorTemplate -beginLayout `getMayaUsdString("kLabelStageSource")` -collapse 0;
-            editorTemplate -addControl "filePath";
+            editorTemplate -callCustom "AEmayaUsdProxyShapeFilePathNew" "AEmayaUsdProxyShapeFilePathReplace" "filePath";
         editorTemplate -endLayout;
 
         editorTemplate -beginLayout `getMayaUsdString("kLabelStageDisplay")` -collapse 0;

--- a/plugin/adsk/scripts/CMakeLists.txt
+++ b/plugin/adsk/scripts/CMakeLists.txt
@@ -2,6 +2,7 @@ list(APPEND scripts_src
     mayaUsdTranslatorImport.mel
     mayaUsdTranslatorExport.mel
     mayaUSDRegisterStrings.mel
+    mayaUSDRegisterStrings.py
     AEmayaUsdProxyShapeBaseTemplate.mel
     AEmayaUsdProxyShapeTemplate.mel
     AETemplateHelpers.py

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
@@ -26,14 +26,20 @@ global proc mayaUSDRegisterStrings() {
     register("kAllUsdFiles", "All USD Files");
     register("kButtonSave", "Save");
     register("kButtonCancel", "Cancel");
+    register("kButtonYes", "Yes");
+    register("kButtonNo", "No");
     register("kCreateUsdStageFromFile", "Create USD Stage from File");
     register("kCreateUsdStageFromFileOptions", "Create USD Stage from File Options");
     register("kCreateStageFromFile", "Create Stage from File");
     register("kDefaultPrim", "Default Prim");
     register("kDefaultPrimAnn", "As part of its metadata, each stage can identify a default prim. This is the primitive that is referenced in if you reference in a file.");
+    register("kDiscardStageEditsTitle", "Discard Edits on ^1s's Layers");
+    register("kDiscardStageEditsLoadMsg", "Are you sure you want to load in a new file as the stage source?\n\nAll edits on your layers in ^1s will be discarded.");
+    register("kDiscardStageEditsReloadMsg", "Are you sure you want to reload ^1s as the stage source?\n\nAll edits on your layers (except the session layer) in ^2s will be discarded.");
     register("kExcludePrimPaths", "Exclude Prim Paths:");
     register("kExcludePrimPathsAnn", "Specify the path of a prim to exclude it from the viewport display. Multiple prim paths must be separated by a comma.");
     register("kExcludePrimPathsSbm", "Specify the path of a prim to exclude it from the viewport display.");
+    register("kFileAnn", "Load in a file as the stage source.");
     register("kLabelStage", "Stage");
     register("kLabelStageSource", "Stage Source");
     register("kLabelStageDisplay", "Stage Display");
@@ -42,6 +48,7 @@ global proc mayaUSDRegisterStrings() {
     register("kLoadPayloads", "Load Payloads:");
     register("kLoadPayloadsAnn", "When on, loads all prims marked as payloads. When off, all prims marked as payloads and their children are not loaded.");
     register("kLoadPayloadsSbm", "Loads prims marked as payloads");
+    register("kLoadUSDFile", "Load USD File");
     register("kMenuAddSublayer", "Add Sublayer");
     register("kMenuAddParentLayer", "Add Parent Layer");
     register("kMenuClear", "Clear");

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
@@ -26,16 +26,11 @@ global proc mayaUSDRegisterStrings() {
     register("kAllUsdFiles", "All USD Files");
     register("kButtonSave", "Save");
     register("kButtonCancel", "Cancel");
-    register("kButtonYes", "Yes");
-    register("kButtonNo", "No");
     register("kCreateUsdStageFromFile", "Create USD Stage from File");
     register("kCreateUsdStageFromFileOptions", "Create USD Stage from File Options");
     register("kCreateStageFromFile", "Create Stage from File");
     register("kDefaultPrim", "Default Prim");
     register("kDefaultPrimAnn", "As part of its metadata, each stage can identify a default prim. This is the primitive that is referenced in if you reference in a file.");
-    register("kDiscardStageEditsTitle", "Discard Edits on ^1s's Layers");
-    register("kDiscardStageEditsLoadMsg", "Are you sure you want to load in a new file as the stage source?\n\nAll edits on your layers in ^1s will be discarded.");
-    register("kDiscardStageEditsReloadMsg", "Are you sure you want to reload ^1s as the stage source?\n\nAll edits on your layers (except the session layer) in ^2s will be discarded.");
     register("kExcludePrimPaths", "Exclude Prim Paths:");
     register("kExcludePrimPathsAnn", "Specify the path of a prim to exclude it from the viewport display. Multiple prim paths must be separated by a comma.");
     register("kExcludePrimPathsSbm", "Specify the path of a prim to exclude it from the viewport display.");
@@ -48,7 +43,6 @@ global proc mayaUSDRegisterStrings() {
     register("kLoadPayloads", "Load Payloads:");
     register("kLoadPayloadsAnn", "When on, loads all prims marked as payloads. When off, all prims marked as payloads and their children are not loaded.");
     register("kLoadPayloadsSbm", "Loads prims marked as payloads");
-    register("kLoadUSDFile", "Load USD File");
     register("kMenuAddSublayer", "Add Sublayer");
     register("kMenuAddParentLayer", "Add Parent Layer");
     register("kMenuClear", "Clear");
@@ -102,6 +96,12 @@ global proc mayaUSDRegisterStrings() {
     register("kUsdFileOptions", "USD File Options");
     register("kUsdOptionsFrameLabel", "Universal Scene Description (USD) Options");
     register("kSaveOption2GBWarning", "<b>Important</b>: per layer, any data exceeding the limit of 2GB will not be saved.");
+
+    // Register the strings from the python equivalent register function.
+    // Note: the strings from both the MEL and python register can be loaded
+    //       by either MEL or python. They all get registered together under
+    //       the 'mayaUsdPlugin' plugin.
+    python("import mayaUSDRegisterStrings; mayaUSDRegisterStrings.mayaUSDRegisterStrings()");
 
     // load any localized resources
     loadPluginLanguageResources("mayaUsdPlugin", "mayaUsdPlugin.pres.mel");

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.py
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.py
@@ -1,0 +1,70 @@
+# Copyright 2021 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import maya.cmds as cmds
+import maya.mel as mel
+
+def register(key, value):
+    registerPluginResource('mayaUsdPlugin', key, value)
+
+def getMayaUsdString(key):
+    return getPluginResource('mayaUsdPlugin', key)
+
+def mayaUSDRegisterStrings():
+    # This function is called from the equivalent MEL proc
+    # with the same name. The strings registered here and all the
+    # ones registered from the MEL proc can be used in either
+    # MEL or python.
+    register("kButtonYes", "Yes")
+    register("kButtonNo", "No")
+    register("kDiscardStageEditsTitle", "Discard Edits on ^1s's Layers")
+    register("kDiscardStageEditsLoadMsg", "Are you sure you want to load in a new file as the stage source?\n\nAll edits on your layers in ^1s will be discarded.")
+    register("kDiscardStageEditsReloadMsg", "Are you sure you want to reload ^1s as the stage source?\n\nAll edits on your layers (except the session layer) in ^2s will be discarded.")
+    register("kLoadUSDFile", "Load USD File")
+
+def registerPluginResource(pluginId, stringId, resourceStr):
+    '''See registerPluginResource.mel in Maya.
+
+    Unfortunately there is no equivalent python version of this MEL proc
+    so we created our own version of it here.'''
+
+    fullId = 'p_%s.%s' % (pluginId, stringId)
+    if cmds.displayString(fullId, exists=True):
+        # Issue warning if the string is already registered.
+        msgFormat = mel.eval('uiRes("m_registerPluginResource.kNotRegistered")')
+        msg = cmds.format(msgFormat, stringArg=(pluginId, stringId))
+        cmds.warning(msg)
+        # Replace the string's value
+        cmds.displayString(fullId, replace=True, value=resourceStr)
+    else:
+        # Set the string's default value.
+        cmds.displayString(fullId, value=resourceStr)
+
+def getPluginResource(pluginId, stringId):
+    '''See getPluginResource.mel in Maya.
+
+    Unfortunately there is no equivalent python version of this MEL proc
+    so we created our own version of it here.'''
+
+    # Form full id string.
+    # Plugin string id's are prefixed with "p_".
+    fullId = 'p_%s.%s' % (pluginId, stringId)
+    if cmds.displayString(fullId, exists=True):
+        dispStr = cmds.displayString(fullId, query=True, value=True)
+        return dispStr
+    else:
+        msgFormat = mel.eval('uiRes("m_getPluginResource.kLookupFailed")')
+        msg = cmds.format(msgFormat, stringArg=(pluginId, stringId))
+        cmds.error(msg)


### PR DESCRIPTION
MAYA-107424 - On the stage AE template I'd like to load/reload a file as the stage source

* Added debugging messages to template helpers (controlled from var).
* New template helper method to deal with file path being changed from text field and file browser button.
* New template helper method to refresh file path attribute.
* Replace file path attribute with custom control containing: label, text field (for path), file browser button, file refresh button.