### PR TITLE
MAYA-110155: consistent namespace across the project - Part 1

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -171,7 +171,7 @@ void convertAnonymousLayersRecursive(
             convertAnonymousLayersRecursive(subL, basename, stage);
 
             if (subL->IsAnonymous()) {
-                auto newLayer = UsdMayaSerialization::saveAnonymousLayer(subL, layer, basename);
+                auto newLayer = MayaUsd::utils::saveAnonymousLayer(subL, layer, basename);
                 if (subL == currentTarget) {
                     stage->SetEditTarget(newLayer);
                 }
@@ -377,15 +377,15 @@ bool LayerDatabase::saveUsd()
 {
     bool result = true;
 
-    auto opt = UsdMayaSerialization::serializeUsdEditsLocationOption();
+    auto opt = MayaUsd::utils::serializeUsdEditsLocationOption();
 
-    if (UsdMayaSerialization::kIgnoreUSDEdits != opt) {
+    if (MayaUsd::utils::kIgnoreUSDEdits != opt) {
         if (_batchSaveDelegate) {
             result = _batchSaveDelegate(_stagesToSave);
         }
 
         if (result) {
-            if (UsdMayaSerialization::kSaveToUSDFiles == opt) {
+            if (MayaUsd::utils::kSaveToUSDFiles == opt) {
                 result = saveUsdToUsdFiles();
             } else {
                 result = saveUsdToMayaFile();
@@ -523,8 +523,8 @@ void LayerDatabase::convertAnonymousLayers(MayaUsdProxyShapeBase* pShape, UsdSta
 
     if (root->IsAnonymous()) {
         PXR_NS::SdfFileFormat::FileFormatArguments args;
-        args["format"] = UsdMayaSerialization::usdFormatArgOption();
-        std::string newFileName = UsdMayaSerialization::generateUniqueFileName(proxyName);
+        args["format"] = MayaUsd::utils::usdFormatArgOption();
+        std::string newFileName = MayaUsd::utils::generateUniqueFileName(proxyName);
         root->Export(newFileName, "", args);
 
         setNewProxyPath(pShape->name(), UsdMayaUtil::convert(newFileName));

--- a/lib/mayaUsd/utils/utilSerialization.h
+++ b/lib/mayaUsd/utils/utilSerialization.h
@@ -13,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+#ifndef MAYAUSD_UTILS_UTILSERIALIZATION_H
+#define MAYAUSD_UTILS_UTILSERIALIZATION_H
+
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
 
@@ -20,10 +23,9 @@
 #include <pxr/usd/sdf/fileFormat.h>
 #include <pxr/usd/sdf/layer.h>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 /// General utility functions used when serializing Usd edits during a save operation
-namespace UsdMayaSerialization {
+namespace MAYAUSD_NS_DEF {
+namespace utils {
 
 /*! \brief Helps suggest a folder to export anonymous layers to.  Checks in order:
     1. File-backed root layer folder.
@@ -31,7 +33,7 @@ namespace UsdMayaSerialization {
     3. Current Maya workspace scenes folder.
  */
 MAYAUSD_CORE_PUBLIC
-std::string suggestedStartFolder(UsdStageRefPtr stage);
+std::string suggestedStartFolder(PXR_NS::UsdStageRefPtr stage);
 
 /*! \brief Queries Maya for the current workspace "scenes" folder.
  */
@@ -63,32 +65,35 @@ USDUnsavedEditsOption serializeUsdEditsLocationOption();
     in the parent layer.
  */
 MAYAUSD_CORE_PUBLIC
-SdfLayerRefPtr saveAnonymousLayer(
-    SdfLayerRefPtr     anonLayer,
-    SdfLayerRefPtr     parentLayer,
-    const std::string& basename,
-    std::string        formatArg = "");
+PXR_NS::SdfLayerRefPtr saveAnonymousLayer(
+    PXR_NS::SdfLayerRefPtr anonLayer,
+    PXR_NS::SdfLayerRefPtr parentLayer,
+    const std::string&     basename,
+    std::string            formatArg = "");
 
 /*! \brief Save an anonymous layer to disk and update the sublayer path array
     in the parent layer.
  */
 MAYAUSD_CORE_PUBLIC
-SdfLayerRefPtr saveAnonymousLayer(
-    SdfLayerRefPtr     anonLayer,
-    const std::string& path,
-    SdfLayerRefPtr     parentLayer,
-    std::string        formatArg = "");
+PXR_NS::SdfLayerRefPtr saveAnonymousLayer(
+    PXR_NS::SdfLayerRefPtr anonLayer,
+    const std::string&     path,
+    PXR_NS::SdfLayerRefPtr parentLayer,
+    std::string            formatArg = "");
 
 struct stageLayersToSave
 {
-    std::vector<std::pair<SdfLayerRefPtr, SdfLayerRefPtr>> anonLayers;
-    std::vector<SdfLayerRefPtr>                            dirtyFileBackedLayers;
+    std::vector<std::pair<PXR_NS::SdfLayerRefPtr, PXR_NS::SdfLayerRefPtr>> anonLayers;
+    std::vector<PXR_NS::SdfLayerRefPtr>                                    dirtyFileBackedLayers;
 };
 
 /*! \brief Check the sublayer stack of the stage looking for any anonymnous
     layers that will need to be saved.
  */
 MAYAUSD_CORE_PUBLIC
-void getLayersToSaveFromProxy(UsdStageRefPtr stage, stageLayersToSave& layersInfo);
+void getLayersToSaveFromProxy(PXR_NS::UsdStageRefPtr stage, stageLayersToSave& layersInfo);
 
-} // namespace UsdMayaSerialization
+} // namespace utils
+} // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_UTILS_UTILSERIALIZATION_H

--- a/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.cpp
+++ b/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.cpp
@@ -34,8 +34,8 @@ void UsdLayerEditor::initialize()
 bool UsdLayerEditor::batchSaveLayersUIDelegate(const std::vector<UsdStageRefPtr>& stages)
 {
     if (MGlobal::kInteractive == MGlobal::mayaState()) {
-        auto opt = UsdMayaSerialization::serializeUsdEditsLocationOption();
-        if (UsdMayaSerialization::kSaveToUSDFiles == opt) {
+        auto opt = MayaUsd::utils::serializeUsdEditsLocationOption();
+        if (MayaUsd::utils::kSaveToUSDFiles == opt) {
             UsdLayerEditor::SaveLayersDialog dlg(nullptr, stages);
             if (QDialog::Accepted != dlg.exec()) {
                 return false;

--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -307,7 +307,7 @@ void LayerTreeItem::saveAnonymousLayer()
     if (sessionState->saveLayerUI(nullptr, &fileName)) {
         // the path we has is an absolute path
         const QString dialogTitle = StringResources::getAsQString(StringResources::kSaveLayer);
-        std::string   formatTag = UsdMayaSerialization::usdFormatArgOption();
+        std::string   formatTag = MayaUsd::utils::usdFormatArgOption();
         if (saveSubLayer(dialogTitle, parentLayerItem(), layer(), fileName, formatTag)) {
             printf("USD Layer written to %s\n", fileName.c_str());
 

--- a/lib/usd/ui/layerEditor/saveLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.cpp
@@ -144,8 +144,8 @@ SaveLayerPathRow::SaveLayerPathRow(
     _label->setToolTip(in_parent->buildTooltipForLayer(_layerPair.first));
     gridLayout->addWidget(_label, 0, 0);
 
-    _initialStartFolder = UsdMayaSerialization::getSceneFolder().c_str();
-    _absolutePath = UsdMayaSerialization::generateUniqueFileName(stageName).c_str();
+    _initialStartFolder = MayaUsd::utils::getSceneFolder().c_str();
+    _absolutePath = MayaUsd::utils::generateUniqueFileName(stageName).c_str();
 
     QFileInfo fileInfo(_absolutePath);
     QString   suggestedFullPath = fileInfo.absoluteFilePath();
@@ -301,8 +301,8 @@ SaveLayersDialog ::~SaveLayersDialog() { QApplication::restoreOverrideCursor(); 
 void SaveLayersDialog::getLayersToSave(UsdStageRefPtr stage, const std::string& stageName)
 {
     // Get the layers to save for this stage.
-    UsdMayaSerialization::stageLayersToSave stageLayersToSave;
-    UsdMayaSerialization::getLayersToSaveFromProxy(stage, stageLayersToSave);
+    MayaUsd::utils::stageLayersToSave stageLayersToSave;
+    MayaUsd::utils::getLayersToSaveFromProxy(stage, stageLayersToSave);
 
     // Keep track of all the layers for this particular stage.
     for (const auto& layerPairs : stageLayersToSave.anonLayers) {
@@ -496,7 +496,7 @@ void SaveLayersDialog::onSaveAll()
                 auto sFileName = qFileName.toStdString();
 
                 auto newLayer
-                    = UsdMayaSerialization::saveAnonymousLayer(sdfLayer, sFileName, parentLayer);
+                    = MayaUsd::utils::saveAnonymousLayer(sdfLayer, sFileName, parentLayer);
 
                 if (!parentLayer) {
                     newRoot = sFileName;


### PR DESCRIPTION
We currently don't have a consistent namespace under "lib/mayaUsd" and in many places we are not respecting the namespaces at all making it hard to read and write code logic. This PR is the first of many to do this cleanup.