### PR TITLE
adapt tests to UsdShade GetInputs() and GetOutputs() API update with USD 21.05

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -31,7 +31,7 @@ See Pixar's official github page for instructions on how to build USD: https://g
 
 |               |      ![](images/pxr.png)          |        
 |:------------: |:---------------:                  |
-|  CommitID/Tags | release: [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) or [v20.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.11) or [v21.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v21.02)<br> dev: [09ff5b7](https://github.com/PixarAnimationStudios/USD/commit/09ff5b7d6d0ae9e92142781322daf6d79e058e2e) |
+|  CommitID/Tags | release: [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) or [v20.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.11) or [v21.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v21.02)<br> dev: [07d13fe](https://github.com/PixarAnimationStudios/USD/commit/07d13fe1ac2cd35ca0b8f1952f8b5dfb0b6ff052) |
 
 For additional information on building Pixar USD, see the ***Additional Build Instruction*** section below.
 

--- a/test/lib/usd/translators/testUsdExportRfMShaders.py
+++ b/test/lib/usd/translators/testUsdExportRfMShaders.py
@@ -71,12 +71,22 @@ class testUsdExportRfMShaders(unittest.TestCase):
         materialPath = material.GetPath().pathString
         self.assertEqual(materialPath, '/MarbleCube/Materials/MarbleCubeSG')
 
-        # We expect four outputs on the material, the three built-in terminals
-        # for the universal renderContext, and a fourth for the "surface"
-        # terminal in the "ri" renderContext that the export should have
-        # authored.
+        if Usd.GetVersion() >= (0, 21, 5):
+            # For USD 21.05 and later, GetInputs() and GetOutputs() take an
+            # "onlyAuthored" argument that is True by default, so in that case
+            # we expect only one output on the material for the "surface"
+            # terminal in the "ri" renderContext that the export should have
+            # authored.
+            expectedNumOutputs = 1
+        else:
+            # Otherwise prior to USD 21.05, GetInputs() and GetOutputs() did
+            # not take any arguments and always included the built-in
+            # terminals for the universal renderContext as well as any other
+            # authored terminals.
+            expectedNumOutputs = 4
+
         materialOutputs = material.GetOutputs()
-        self.assertEqual(len(materialOutputs), 4)
+        self.assertEqual(len(materialOutputs), expectedNumOutputs)
 
         # Validate the lambert surface shader that is connected to the material.
         materialOutput = material.GetOutput('ri:surface')

--- a/test/lib/usd/translators/testUsdExportShadingModePxrRis.py
+++ b/test/lib/usd/translators/testUsdExportShadingModePxrRis.py
@@ -68,9 +68,23 @@ class testUsdExportShadingModePxrRis(unittest.TestCase):
         materialPath = material.GetPath().pathString
         self.assertEqual(materialPath, '/MarbleCube/Materials/MarbleCubeSG')
 
+        if Usd.GetVersion() >= (0, 21, 5):
+            # For USD 21.05 and later, GetInputs() and GetOutputs() take an
+            # "onlyAuthored" argument that is True by default, so in that case
+            # we expect only one output on the material for the "surface"
+            # terminal in the "ri" renderContext that the export should have
+            # authored.
+            expectedNumOutputs = 1
+        else:
+            # Otherwise prior to USD 21.05, GetInputs() and GetOutputs() did
+            # not take any arguments and always included the built-in
+            # terminals for the universal renderContext as well as any other
+            # authored terminals.
+            expectedNumOutputs = 4
+
         # Validate the surface shader that is connected to the material.
         materialOutputs = material.GetOutputs()
-        self.assertEqual(len(materialOutputs), 4)
+        self.assertEqual(len(materialOutputs), expectedNumOutputs)
         print(self._stage.ExportToString())
         materialOutput = material.GetOutput('ri:surface')
         (connectableAPI, outputName, outputType) = materialOutput.GetConnectedSource()


### PR DESCRIPTION
Just one small tests-only change to go along with the most recently pushed core USD dev branch commits.

Starting with core USD 21.05, `GetInputs()` and `GetOutputs()` take an optional `onlyAuthored` argument that is `True` by default, which means that calling those functions without arguments will only return the authored terminals. For earlier USD releases, we still expect them to always return the built-in terminals for the universal renderContext in addition to any other authored terminals. See https://github.com/PixarAnimationStudios/USD/commit/53757699be3069a72842bf6b9781dfba017cd240 for more detail.

I also took the opportunity to update the `doc/build.md`.