### PR TITLE
Fix Maya 2018 compilation

### DIFF
--- a/lib/usd/translators/jointWriter.cpp
+++ b/lib/usd/translators/jointWriter.cpp
@@ -259,6 +259,7 @@ bool _GetLocalTransformForDagPoseMember(
     MStatus status;
 
     MPlug xformMatrixPlug = dagPoseDep.findPlug("xformMatrix");
+#if MAYA_API_VERSION >= 20190000
     if (TfDebug::IsEnabled(PXRUSDMAYA_TRANSLATORS)) {
         // As an extra debug sanity check, make sure that the logicalIndex
         // already exists
@@ -271,6 +272,7 @@ bool _GetLocalTransformForDagPoseMember(
                 logicalIndex);
         }
     }
+#endif
     MPlug xformPlug = xformMatrixPlug.elementByLogicalIndex(logicalIndex, &status);
     CHECK_MSTATUS_AND_RETURN(status, false);
 


### PR DESCRIPTION
We are going to drop support for Maya 2018 as mentioned in https://github.com/Autodesk/maya-usd/discussions/1217. This PR fixes compilation before we officially remove the support from the https://github.com/Autodesk/maya-usd/blob/dev/doc/build.md documentation.