### PR TITLE
MAYA-110196 - Multiple ProxyShapes with Same Stage (InStageData) Bug

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeModel.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeModel.cpp
@@ -233,7 +233,7 @@ void LayerTreeModel::setSessionState(SessionState* in_sessionState)
         in_sessionState,
         &SessionState::autoHideSessionLayerSignal,
         this,
-        &LayerTreeModel::sessionStageChanged);
+        &LayerTreeModel::autoHideSessionLayerChanged);
 }
 
 void LayerTreeModel::rebuildModelOnIdle()

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
@@ -44,7 +44,7 @@ class LayerEditorWindowCreator : public AbstractLayerEditorCreator
 {
 public:
     LayerEditorWindowCreator() { ; };
-    virtual ~LayerEditorWindowCreator() {}
+    virtual ~LayerEditorWindowCreator() { }
 
     AbstractLayerEditorWindow* createWindow(const char* panelName) override;
     AbstractLayerEditorWindow* getWindow(const char* panelName) const override;

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
@@ -44,7 +44,7 @@ class LayerEditorWindowCreator : public AbstractLayerEditorCreator
 {
 public:
     LayerEditorWindowCreator() { ; };
-    virtual ~LayerEditorWindowCreator() { }
+    virtual ~LayerEditorWindowCreator() {}
 
     AbstractLayerEditorWindow* createWindow(const char* panelName) override;
     AbstractLayerEditorWindow* getWindow(const char* panelName) const override;
@@ -232,11 +232,10 @@ void MayaLayerEditorWindow::selectPrimsWithSpec()
 
 void MayaLayerEditorWindow::selectProxyShape(const char* shapePath)
 {
-    auto prim = UsdMayaQuery::GetPrim(shapePath);
-    if (prim) {
-        auto stage = prim.GetStage();
-        if (stage != nullptr) {
-            _sessionState.setStage(stage);
+    SessionState::StageEntry entry;
+    if (_sessionState.getStageEntry(&entry, shapePath)) {
+        if (entry._stage != nullptr) {
+            _sessionState.setStageEntry(entry);
         }
     }
 }

--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -32,7 +32,6 @@
 #include <QtCore/QTimer>
 #include <QtWidgets/QMenu>
 
-
 #ifdef THIS
 #undef THIS
 #endif
@@ -226,7 +225,7 @@ void MayaSessionState::nodeRenamedCBOnIdle(std::string const& oldName, const MOb
                 _currentStageEntry = entry;
             }
 
-            Q_EMIT stageRenamedSignal(oldName, entry);
+            Q_EMIT stageRenamedSignal(entry);
         }
     }
 }

--- a/lib/usd/ui/layerEditor/mayaSessionState.h
+++ b/lib/usd/ui/layerEditor/mayaSessionState.h
@@ -50,7 +50,7 @@ public:
     ~MayaSessionState();
 
     // API implementation
-    void                    setStage(PXR_NS::UsdStageRefPtr const& in_stage) override;
+    void                    setStageEntry(StageEntry const& in_entry) override;
     void                    setAutoHideSessionLayer(bool hide) override;
     AbstractCommandHook*    commandHook() override;
     std::vector<StageEntry> allStages() const override;
@@ -69,7 +69,7 @@ public:
     // in this case, the stage needs to be re-created on the new file
     void rootLayerPathChanged(std::string const& in_path) override;
 
-    std::string proxyShapePath() { return _currentProxyShapePath; }
+    std::string proxyShapePath() { return _currentStageEntry._proxyShapePath; }
 
 Q_SIGNALS:
     void clearUIOnSceneResetSignal();
@@ -78,10 +78,10 @@ public:
     void registerNotifications();
     void unregisterNotifications();
 
-protected:
     // get the stage and proxy name for a path
     static bool getStageEntry(StageEntry* out_stageEntry, const MString& shapePath);
 
+protected:
     // maya callback handers
     static void proxyShapeAddedCB(MObject& node, void* clientData);
     static void proxyShapeRemovedCB(MObject& node, void* clientData);
@@ -89,15 +89,14 @@ protected:
     static void sceneClosingCB(void* clientData);
 
     void proxyShapeAddedCBOnIdle(const MObject& node);
-    void nodeRenamedCBOnIdle(const MObject& obj);
+    void nodeRenamedCBOnIdle(std::string const& oldName, const MObject& obj);
 
     // Notice listener method for proxy stage set
     void mayaUsdStageReset(const MayaUsdProxyStageSetNotice& notice);
-    void mayaUsdStageResetCBOnIdle(const std::string& shapePath, UsdStageRefPtr const& stage);
+    void mayaUsdStageResetCBOnIdle(StageEntry const& entry);
 
     std::vector<MCallbackId> _callbackIds;
     TfNotice::Key            _stageResetNoticeKey;
-    std::string              _currentProxyShapePath;
     MayaCommandHook          _mayaCommandHook;
 };
 

--- a/lib/usd/ui/layerEditor/saveLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.cpp
@@ -275,19 +275,11 @@ SaveLayersDialog::SaveLayersDialog(SessionState* in_sessionState, QWidget* in_pa
     MString msg;
     QString dialogTitle = StringResources::getAsQString(StringResources::kSaveStage);
     if (TF_VERIFY(nullptr != _sessionState)) {
-        auto stage = _sessionState->stage();
-
-        auto stageList = _sessionState->allStages();
-        for (auto const& entry : stageList) {
-            if (entry._stage == stage) {
-                std::string stageName = entry._displayName;
-                msg.format(
-                    StringResources::getAsMString(StringResources::kSaveName), stageName.c_str());
-                dialogTitle = MQtUtil::toQString(msg);
-                getLayersToSave(stage, stageName);
-                break;
-            }
-        }
+        auto        stageEntry = _sessionState->stageEntry();
+        std::string stageName = stageEntry._displayName;
+        msg.format(StringResources::getAsMString(StringResources::kSaveName), stageName.c_str());
+        dialogTitle = MQtUtil::toQString(msg);
+        getLayersToSave(stageEntry._stage, stageName);
     }
     setWindowTitle(dialogTitle);
 

--- a/lib/usd/ui/layerEditor/sessionState.cpp
+++ b/lib/usd/ui/layerEditor/sessionState.cpp
@@ -23,18 +23,19 @@ void SessionState::setAutoHideSessionLayer(bool hideIt)
     Q_EMIT autoHideSessionLayerSignal(_autoHideSessionLayer);
 }
 
-void SessionState::setStage(PXR_NS::UsdStageRefPtr const& in_stage)
+void SessionState::setStageEntry(StageEntry const& in_entry)
 {
-    if (in_stage != _stage) {
-        _stage = in_stage;
+    if (_currentStageEntry != in_entry) {
+        auto oldEntry = _currentStageEntry;
+        _currentStageEntry = in_entry;
         Q_EMIT currentStageChangedSignal();
     }
 }
 
 PXR_NS::SdfLayerRefPtr SessionState::targetLayer() const
 {
-    if (_stage != nullptr) {
-        const auto& target = _stage->GetEditTarget();
+    if (_currentStageEntry._stage != nullptr) {
+        const auto& target = _currentStageEntry._stage->GetEditTarget();
         return target.GetLayer();
     } else {
         return nullptr;

--- a/lib/usd/ui/layerEditor/sessionState.h
+++ b/lib/usd/ui/layerEditor/sessionState.h
@@ -56,23 +56,6 @@ public:
             _proxyShapePath = "";
         }
 
-        StageEntry(
-            PXR_NS::UsdStageRefPtr const& stage,
-            std::string const&            displayName,
-            std::string const&            proxyShapePath)
-        {
-            _stage = stage;
-            _displayName = displayName;
-            _proxyShapePath = proxyShapePath;
-        }
-
-        StageEntry(const StageEntry& entry)
-        {
-            _stage = entry._stage;
-            _displayName = entry._displayName;
-            _proxyShapePath = entry._proxyShapePath;
-        }
-
         bool operator==(const StageEntry& entry) const
         {
             return (
@@ -130,7 +113,7 @@ public:
 Q_SIGNALS:
     void currentStageChangedSignal();
     void stageListChangedSignal(StageEntry const& toSelect = StageEntry());
-    void stageRenamedSignal(std::string const& oldName, StageEntry const& renamedEntry);
+    void stageRenamedSignal(StageEntry const& renamedEntry);
     void autoHideSessionLayerSignal(bool hideIt);
     void stageResetSignal(StageEntry const& entry);
 

--- a/lib/usd/ui/layerEditor/sessionState.h
+++ b/lib/usd/ui/layerEditor/sessionState.h
@@ -45,12 +45,14 @@ public:
 
     struct StageEntry
     {
+        std::string            _id;
         PXR_NS::UsdStageRefPtr _stage;
         std::string            _displayName;
         std::string            _proxyShapePath;
 
         StageEntry()
         {
+            _id = "";
             _stage = PXR_NS::UsdStageRefPtr();
             _displayName = "";
             _proxyShapePath = "";
@@ -59,19 +61,11 @@ public:
         bool operator==(const StageEntry& entry) const
         {
             return (
-                _stage == entry._stage && _displayName == entry._displayName
+                _id == entry._id && _stage == entry._stage && _displayName == entry._displayName
                 && _proxyShapePath == entry._proxyShapePath);
         }
 
         bool operator!=(const StageEntry& entry) const { return !(*this == entry); }
-
-        StageEntry& operator=(const StageEntry& entry)
-        {
-            _stage = entry._stage;
-            _displayName = entry._displayName;
-            _proxyShapePath = entry._proxyShapePath;
-            return *this;
-        }
 
         void clear()
         {

--- a/lib/usd/ui/layerEditor/sessionState.h
+++ b/lib/usd/ui/layerEditor/sessionState.h
@@ -41,7 +41,7 @@ class SessionState : public QObject
 {
     Q_OBJECT
 public:
-    virtual ~SessionState() {}
+    virtual ~SessionState() { }
 
     struct StageEntry
     {

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
@@ -26,16 +26,17 @@
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QLabel>
 
+
 Q_DECLARE_METATYPE(UsdLayerEditor::SessionState::StageEntry);
 
 namespace {
-int getEntryIndexByProxyPath(
+int getEntryIndexById(
     UsdLayerEditor::SessionState::StageEntry const&              entry,
     std::vector<UsdLayerEditor::SessionState::StageEntry> const& stages)
 {
     auto it = std::find_if(
         stages.begin(), stages.end(), [entry](UsdLayerEditor::SessionState::StageEntry stageEntry) {
-            return (entry._proxyShapePath == stageEntry._proxyShapePath);
+            return (entry._id == stageEntry._id);
         });
 
     if (it != stages.end()) {
@@ -130,8 +131,7 @@ void StageSelectorWidget::selectedIndexChanged(int index)
 void StageSelectorWidget::sessionStageChanged()
 {
     if (!_internalChange) {
-        auto index
-            = getEntryIndexByProxyPath(_sessionState->stageEntry(), _sessionState->allStages());
+        auto index = getEntryIndexById(_sessionState->stageEntry(), _sessionState->allStages());
         if (index != -1) {
             QSignalBlocker blocker(_dropDown);
             _dropDown->setCurrentIndex(index);
@@ -141,7 +141,7 @@ void StageSelectorWidget::sessionStageChanged()
 
 void StageSelectorWidget::stageRenamed(SessionState::StageEntry const& renamedEntry)
 {
-    auto index = getEntryIndexByProxyPath(renamedEntry, _sessionState->allStages());
+    auto index = getEntryIndexById(renamedEntry, _sessionState->allStages());
     if (index != -1) {
         _dropDown->setItemText(index, renamedEntry._displayName.c_str());
         _dropDown->setItemData(index, QVariant::fromValue(renamedEntry));
@@ -160,7 +160,7 @@ void StageSelectorWidget::stageReset(SessionState::StageEntry const& entry)
         return;
     }
 
-    auto index = getEntryIndexByProxyPath(entry, _sessionState->allStages());
+    auto index = getEntryIndexById(entry, _sessionState->allStages());
     if (index >= 0 && index < count) {
         _dropDown->setItemData(index, QVariant::fromValue(entry));
     }

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
@@ -26,7 +26,6 @@
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QLabel>
 
-
 Q_DECLARE_METATYPE(UsdLayerEditor::SessionState::StageEntry);
 
 namespace {

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.h
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.h
@@ -26,8 +26,6 @@
 
 namespace UsdLayerEditor {
 
-class SessionState;
-
 /**
  * @brief Drop down list that allows selecting a stage. Owned by the LayerEditorWidget
  *
@@ -39,14 +37,14 @@ public:
     StageSelectorWidget(SessionState* in_sessionState, QWidget* in_parent);
 
 protected:
-    void                   setSessionState(SessionState* in_sessionState);
-    PXR_NS::UsdStageRefPtr selectedStage();
+    void                           setSessionState(SessionState* in_sessionState);
+    SessionState::StageEntry const selectedStage();
 
     // slot:
-    void
-         updateFromSessionState(PXR_NS::UsdStageRefPtr const& stageToSelect = PXR_NS::UsdStageRefPtr());
-    void stageRenamed(std::string const& name, PXR_NS::UsdStageRefPtr const& stage);
-    void stageReset(const std::string& proxyPath, PXR_NS::UsdStageRefPtr const& stage);
+    void updateFromSessionState(
+        SessionState::StageEntry const& entryToSelect = SessionState::StageEntry());
+    void stageRenamed(std::string const& oldName, SessionState::StageEntry const& renamedEntry);
+    void stageReset(SessionState::StageEntry const& entry);
     void sessionStageChanged();
     void selectedIndexChanged(int index);
 

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.h
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.h
@@ -43,7 +43,7 @@ protected:
     // slot:
     void updateFromSessionState(
         SessionState::StageEntry const& entryToSelect = SessionState::StageEntry());
-    void stageRenamed(std::string const& oldName, SessionState::StageEntry const& renamedEntry);
+    void stageRenamed(SessionState::StageEntry const& renamedEntry);
     void stageReset(SessionState::StageEntry const& entry);
     void sessionStageChanged();
     void selectedIndexChanged(int index);


### PR DESCRIPTION
We can have a situation where we have multiple proxy shapes that point to the same exact stage, using the InStageData port. Unfortunately this causes an issue in the layer editor since the combo-box is keeping track of the stage only, so two entries with the same stage is ambiguous. 

The fix was to move away from storing the Pixar Stage Reference as the data in the combo box and move to the StageEntry which encapsulates both stage and the proxy shape path.