### PR TITLE
PXR_NAMESPACE_USING_DIRECTIVE removal from lib/mayaUsd/ufe.

### DIFF
--- a/lib/mayaUsd/ufe/ProxyShapeContextOpsHandler.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeContextOpsHandler.cpp
@@ -49,7 +49,7 @@ Ufe::ContextOps::Ptr ProxyShapeContextOpsHandler::contextOps(const Ufe::SceneIte
     if (isAGatewayType(item->nodeType())) {
         // UsdContextOps expects a UsdSceneItem which wraps a prim, so
         // create one using the pseudo-root and our own path.
-        UsdStageWeakPtr stage = getStage(item->path());
+        PXR_NS::UsdStageWeakPtr stage = getStage(item->path());
         if (stage) {
             auto               usdItem = UsdSceneItem::create(item->path(), stage->GetPseudoRoot());
             auto               usdContextOpsHandler = UsdContextOpsHandler::create();

--- a/lib/mayaUsd/ufe/ProxyShapeHandler.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHandler.cpp
@@ -71,7 +71,7 @@ std::vector<PXR_NS::UsdStageRefPtr> ProxyShapeHandler::getAllStages()
     // Maya, so it requires the AL proxy shape inheritance from
     // MayaUsdProxyShapeBase.  PPT, 12-Apr-2019.
     std::vector<PXR_NS::UsdStageRefPtr> stages;
-    auto                        allNames = getAllNames();
+    auto                                allNames = getAllNames();
     stages.reserve(allNames.size());
     for (const auto& name : allNames) {
         PXR_NS::UsdStageWeakPtr stage = dagPathToStage(name);

--- a/lib/mayaUsd/ufe/ProxyShapeHandler.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHandler.cpp
@@ -53,14 +53,14 @@ std::vector<std::string> ProxyShapeHandler::getAllNames()
 }
 
 /*static*/
-UsdStageWeakPtr ProxyShapeHandler::dagPathToStage(const std::string& dagPath)
+PXR_NS::UsdStageWeakPtr ProxyShapeHandler::dagPathToStage(const std::string& dagPath)
 {
-    auto prim = UsdMayaQuery::GetPrim(dagPath);
+    auto prim = PXR_NS::UsdMayaQuery::GetPrim(dagPath);
     return prim ? prim.GetStage() : nullptr;
 }
 
 /*static*/
-std::vector<UsdStageRefPtr> ProxyShapeHandler::getAllStages()
+std::vector<PXR_NS::UsdStageRefPtr> ProxyShapeHandler::getAllStages()
 {
     // According to Pixar, the following should work:
     //   return UsdMayaStageCache::Get().GetAllStages();
@@ -70,11 +70,11 @@ std::vector<UsdStageRefPtr> ProxyShapeHandler::getAllStages()
     // When using an unmodified AL plugin, the following line crashes
     // Maya, so it requires the AL proxy shape inheritance from
     // MayaUsdProxyShapeBase.  PPT, 12-Apr-2019.
-    std::vector<UsdStageRefPtr> stages;
+    std::vector<PXR_NS::UsdStageRefPtr> stages;
     auto                        allNames = getAllNames();
     stages.reserve(allNames.size());
     for (const auto& name : allNames) {
-        UsdStageWeakPtr stage = dagPathToStage(name);
+        PXR_NS::UsdStageWeakPtr stage = dagPathToStage(name);
         if (stage) {
             stages.push_back(stage);
         }

--- a/lib/mayaUsd/ufe/ProxyShapeHandler.h
+++ b/lib/mayaUsd/ufe/ProxyShapeHandler.h
@@ -23,8 +23,6 @@
 #include <string>
 #include <vector>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -49,9 +47,9 @@ public:
 
     static std::vector<std::string> getAllNames();
 
-    static UsdStageWeakPtr dagPathToStage(const std::string& dagPath);
+    static PXR_NS::UsdStageWeakPtr dagPathToStage(const std::string& dagPath);
 
-    static std::vector<UsdStageRefPtr> getAllStages();
+    static std::vector<PXR_NS::UsdStageRefPtr> getAllStages();
 
 private:
     static const std::string fMayaUsdGatewayNodeType;

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
@@ -34,6 +34,8 @@
 #include <mayaUsd/ufe/UsdUndoReorderCommand.h>
 #endif
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace {
 UsdPrimSiblingRange getUSDFilteredChildren(
     const UsdPrim&               prim,

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
@@ -23,8 +23,6 @@
 #include <ufe/hierarchyHandler.h>
 #include <ufe/selection.h>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -82,8 +80,8 @@ public:
 #endif
 
 private:
-    const UsdPrim&     getUsdRootPrim() const;
-    Ufe::SceneItemList createUFEChildList(const UsdPrimSiblingRange& range) const;
+    const PXR_NS::UsdPrim& getUsdRootPrim() const;
+    Ufe::SceneItemList     createUFEChildList(const PXR_NS::UsdPrimSiblingRange& range) const;
 
 private:
     Ufe::SceneItem::Ptr        fItem;
@@ -91,7 +89,7 @@ private:
     Ufe::HierarchyHandler::Ptr fMayaHierarchyHandler;
 
     // The root prim is initialized on first use and therefore mutable.
-    mutable UsdPrim fUsdRootPrim;
+    mutable PXR_NS::UsdPrim fUsdRootPrim;
 }; // ProxyShapeHierarchy
 
 } // namespace ufe

--- a/lib/mayaUsd/ufe/RotationUtils.cpp
+++ b/lib/mayaUsd/ufe/RotationUtils.cpp
@@ -26,35 +26,37 @@ inline double TO_RAD(double a) { return a * 3.141592654 / 180.0; }
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
-template <MEulerRotation::RotationOrder SRC_ROT_ORDER> Ufe::Vector3d fromRot(const VtValue& value)
+template <MEulerRotation::RotationOrder SRC_ROT_ORDER>
+Ufe::Vector3d fromRot(const PXR_NS::VtValue& value)
 {
-    auto v = value.Get<GfVec3f>();
+    auto v = value.Get<PXR_NS::GfVec3f>();
 
     MEulerRotation eulerRot(TO_RAD(v[0]), TO_RAD(v[1]), TO_RAD(v[2]), SRC_ROT_ORDER);
     eulerRot.reorderIt(MEulerRotation::kXYZ);
     return Ufe::Vector3d(TO_DEG(eulerRot.x), TO_DEG(eulerRot.y), TO_DEG(eulerRot.z));
 }
 
-template <MEulerRotation::RotationOrder DST_ROT_ORDER> VtValue toRot(double x, double y, double z)
+template <MEulerRotation::RotationOrder DST_ROT_ORDER>
+PXR_NS::VtValue toRot(double x, double y, double z)
 {
     MEulerRotation eulerRot(TO_RAD(x), TO_RAD(y), TO_RAD(z), MEulerRotation::kXYZ);
     eulerRot.reorderIt(DST_ROT_ORDER);
-    VtValue v;
-    v = GfVec3f(TO_DEG(eulerRot.x), TO_DEG(eulerRot.y), TO_DEG(eulerRot.z));
+    PXR_NS::VtValue v;
+    v = PXR_NS::GfVec3f(TO_DEG(eulerRot.x), TO_DEG(eulerRot.y), TO_DEG(eulerRot.z));
     return v;
 }
 
-template Ufe::Vector3d fromRot<MEulerRotation::kXZY>(const VtValue&);
-template Ufe::Vector3d fromRot<MEulerRotation::kYXZ>(const VtValue&);
-template Ufe::Vector3d fromRot<MEulerRotation::kYZX>(const VtValue&);
-template Ufe::Vector3d fromRot<MEulerRotation::kZXY>(const VtValue&);
-template Ufe::Vector3d fromRot<MEulerRotation::kZYX>(const VtValue&);
+template Ufe::Vector3d fromRot<MEulerRotation::kXZY>(const PXR_NS::VtValue&);
+template Ufe::Vector3d fromRot<MEulerRotation::kYXZ>(const PXR_NS::VtValue&);
+template Ufe::Vector3d fromRot<MEulerRotation::kYZX>(const PXR_NS::VtValue&);
+template Ufe::Vector3d fromRot<MEulerRotation::kZXY>(const PXR_NS::VtValue&);
+template Ufe::Vector3d fromRot<MEulerRotation::kZYX>(const PXR_NS::VtValue&);
 
-template VtValue toRot<MEulerRotation::kXZY>(double, double, double);
-template VtValue toRot<MEulerRotation::kYXZ>(double, double, double);
-template VtValue toRot<MEulerRotation::kYZX>(double, double, double);
-template VtValue toRot<MEulerRotation::kZXY>(double, double, double);
-template VtValue toRot<MEulerRotation::kZYX>(double, double, double);
+template PXR_NS::VtValue toRot<MEulerRotation::kXZY>(double, double, double);
+template PXR_NS::VtValue toRot<MEulerRotation::kYXZ>(double, double, double);
+template PXR_NS::VtValue toRot<MEulerRotation::kYZX>(double, double, double);
+template PXR_NS::VtValue toRot<MEulerRotation::kZXY>(double, double, double);
+template PXR_NS::VtValue toRot<MEulerRotation::kZYX>(double, double, double);
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/RotationUtils.h
+++ b/lib/mayaUsd/ufe/RotationUtils.h
@@ -23,8 +23,6 @@
 #include <maya/MEulerRotation.h>
 #include <ufe/types.h>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -32,16 +30,17 @@ namespace ufe {
 // Conversion functions from RotXYZ to all supported rotation attributes.
 //----------------------------------------------------------------------
 
-inline VtValue toXYZ(double x, double y, double z)
+inline PXR_NS::VtValue toXYZ(double x, double y, double z)
 {
     // No rotation order conversion
-    VtValue v;
-    v = GfVec3f(x, y, z);
+    PXR_NS::VtValue v;
+    v = PXR_NS::GfVec3f(x, y, z);
     return v;
 }
 
 // Reorder argument RotXYZ rotation.
-template <MEulerRotation::RotationOrder DST_ROT_ORDER> VtValue toRot(double x, double y, double z);
+template <MEulerRotation::RotationOrder DST_ROT_ORDER>
+PXR_NS::VtValue toRot(double x, double y, double z);
 
 constexpr auto toXZY = toRot<MEulerRotation::kXZY>;
 constexpr auto toYXZ = toRot<MEulerRotation::kYXZ>;
@@ -50,23 +49,23 @@ constexpr auto toZXY = toRot<MEulerRotation::kZXY>;
 constexpr auto toZYX = toRot<MEulerRotation::kZYX>;
 
 // Scalar float is the proper type for single-axis rotations.
-inline VtValue toX(double x, double, double)
+inline PXR_NS::VtValue toX(double x, double, double)
 {
-    VtValue v;
+    PXR_NS::VtValue v;
     v = float(x);
     return v;
 }
 
-inline VtValue toY(double, double y, double)
+inline PXR_NS::VtValue toY(double, double y, double)
 {
-    VtValue v;
+    PXR_NS::VtValue v;
     v = float(y);
     return v;
 }
 
-inline VtValue toZ(double, double, double z)
+inline PXR_NS::VtValue toZ(double, double, double z)
 {
-    VtValue v;
+    PXR_NS::VtValue v;
     v = float(z);
     return v;
 }
@@ -75,14 +74,15 @@ inline VtValue toZ(double, double, double z)
 // Conversion functions from all supported rotation attributes to RotXYZ.
 //----------------------------------------------------------------------
 
-inline Ufe::Vector3d fromXYZ(const VtValue& value)
+inline Ufe::Vector3d fromXYZ(const PXR_NS::VtValue& value)
 {
     // No rotation order conversion
-    auto v = value.Get<GfVec3f>();
+    auto v = value.Get<PXR_NS::GfVec3f>();
     return Ufe::Vector3d(v[0], v[1], v[2]);
 }
 
-template <MEulerRotation::RotationOrder SRC_ROT_ORDER> Ufe::Vector3d fromRot(const VtValue& value);
+template <MEulerRotation::RotationOrder SRC_ROT_ORDER>
+Ufe::Vector3d fromRot(const PXR_NS::VtValue& value);
 
 constexpr auto fromXZY = fromRot<MEulerRotation::kXZY>;
 constexpr auto fromYXZ = fromRot<MEulerRotation::kYXZ>;
@@ -90,11 +90,20 @@ constexpr auto fromYZX = fromRot<MEulerRotation::kYZX>;
 constexpr auto fromZXY = fromRot<MEulerRotation::kZXY>;
 constexpr auto fromZYX = fromRot<MEulerRotation::kZYX>;
 
-inline Ufe::Vector3d fromX(const VtValue& value) { return Ufe::Vector3d(value.Get<float>(), 0, 0); }
+inline Ufe::Vector3d fromX(const PXR_NS::VtValue& value)
+{
+    return Ufe::Vector3d(value.Get<float>(), 0, 0);
+}
 
-inline Ufe::Vector3d fromY(const VtValue& value) { return Ufe::Vector3d(0, value.Get<float>(), 0); }
+inline Ufe::Vector3d fromY(const PXR_NS::VtValue& value)
+{
+    return Ufe::Vector3d(0, value.Get<float>(), 0);
+}
 
-inline Ufe::Vector3d fromZ(const VtValue& value) { return Ufe::Vector3d(0, 0, value.Get<float>()); }
+inline Ufe::Vector3d fromZ(const PXR_NS::VtValue& value)
+{
+    return Ufe::Vector3d(0, 0, value.Get<float>());
+}
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/StagesSubject.cpp
+++ b/lib/mayaUsd/ufe/StagesSubject.cpp
@@ -48,6 +48,8 @@
 #include <unordered_map>
 #endif
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace {
 
 // Prevent re-entrant stage set.

--- a/lib/mayaUsd/ufe/StagesSubject.h
+++ b/lib/mayaUsd/ufe/StagesSubject.h
@@ -30,8 +30,6 @@
 
 #include <unordered_set>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -41,10 +39,10 @@ namespace ufe {
         stage the Maya scene contains.  This USD observer translates USD
         notifications into UFE notifications.
  */
-class MAYAUSD_CORE_PUBLIC StagesSubject : public TfWeakBase
+class MAYAUSD_CORE_PUBLIC StagesSubject : public PXR_NS::TfWeakBase
 {
 public:
-    typedef TfWeakPtr<StagesSubject> Ptr;
+    typedef PXR_NS::TfWeakPtr<StagesSubject> Ptr;
 
     //! Constructor
     StagesSubject();
@@ -74,31 +72,33 @@ private:
     static void afterOpenCallback(void* clientData);
 
     //! Call the stageChanged() methods on stage observers.
-    void stageChanged(UsdNotice::ObjectsChanged const& notice, UsdStageWeakPtr const& sender);
+    void stageChanged(
+        PXR_NS::UsdNotice::ObjectsChanged const& notice,
+        PXR_NS::UsdStageWeakPtr const&           sender);
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
     //! Call the stageEditTargetChanged() methods on stage observers.
     void stageEditTargetChanged(
-        UsdNotice::StageEditTargetChanged const& notice,
-        UsdStageWeakPtr const&                   sender);
+        PXR_NS::UsdNotice::StageEditTargetChanged const& notice,
+        PXR_NS::UsdStageWeakPtr const&                   sender);
 #endif
 
 private:
     // Notice listener method for proxy stage set
-    void onStageSet(const MayaUsdProxyStageSetNotice& notice);
+    void onStageSet(const PXR_NS::MayaUsdProxyStageSetNotice& notice);
 
     // Notice listener method for proxy stage invalidate.
-    void onStageInvalidate(const MayaUsdProxyStageInvalidateNotice& notice);
+    void onStageInvalidate(const PXR_NS::MayaUsdProxyStageInvalidateNotice& notice);
 
     // Array of Notice::Key for registered listener
 #ifdef UFE_V2_FEATURES_AVAILABLE
-    using NoticeKeys = std::array<TfNotice::Key, 2>;
+    using NoticeKeys = std::array<PXR_NS::TfNotice::Key, 2>;
 #else
-    using NoticeKeys = std::array<TfNotice::Key, 1>;
+    using NoticeKeys = std::array<PXR_NS::TfNotice::Key, 1>;
 #endif
 
     // Map of per-stage listeners, indexed by stage.
-    typedef TfHashMap<UsdStageWeakPtr, NoticeKeys, TfHash> StageListenerMap;
+    typedef PXR_NS::TfHashMap<PXR_NS::UsdStageWeakPtr, NoticeKeys, PXR_NS::TfHash> StageListenerMap;
     StageListenerMap                                       fStageListeners;
 
     /*! \brief  Store invalidated ufe paths during dirty propagation.

--- a/lib/mayaUsd/ufe/StagesSubject.h
+++ b/lib/mayaUsd/ufe/StagesSubject.h
@@ -99,7 +99,7 @@ private:
 
     // Map of per-stage listeners, indexed by stage.
     typedef PXR_NS::TfHashMap<PXR_NS::UsdStageWeakPtr, NoticeKeys, PXR_NS::TfHash> StageListenerMap;
-    StageListenerMap                                       fStageListeners;
+    StageListenerMap                                                               fStageListeners;
 
     /*! \brief  Store invalidated ufe paths during dirty propagation.
 

--- a/lib/mayaUsd/ufe/UsdAttributes.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributes.cpp
@@ -119,7 +119,7 @@ std::vector<std::string> UsdAttributes::attributeNames() const
 
 bool UsdAttributes::hasAttribute(const std::string& name) const
 {
-    TfToken tkName(name);
+    PXR_NS::TfToken tkName(name);
     return fPrim.HasAttribute(tkName);
 }
 
@@ -128,17 +128,17 @@ UsdAttributes::getUfeTypeForAttribute(const PXR_NS::UsdAttribute& usdAttr) const
 {
     // Map the USD type into UFE type.
     static const std::unordered_map<size_t, Ufe::Attribute::Type> sUsdTypeToUfe {
-        { SdfValueTypeNames->Bool.GetHash(), Ufe::Attribute::kBool },           // bool
-        { SdfValueTypeNames->Int.GetHash(), Ufe::Attribute::kInt },             // int32_t
-        { SdfValueTypeNames->Float.GetHash(), Ufe::Attribute::kFloat },         // float
-        { SdfValueTypeNames->Double.GetHash(), Ufe::Attribute::kDouble },       // double
-        { SdfValueTypeNames->String.GetHash(), Ufe::Attribute::kString },       // std::string
-        { SdfValueTypeNames->Token.GetHash(), Ufe::Attribute::kEnumString },    // TfToken
-        { SdfValueTypeNames->Int3.GetHash(), Ufe::Attribute::kInt3 },           // GfVec3i
-        { SdfValueTypeNames->Float3.GetHash(), Ufe::Attribute::kFloat3 },       // GfVec3f
-        { SdfValueTypeNames->Double3.GetHash(), Ufe::Attribute::kDouble3 },     // GfVec3d
-        { SdfValueTypeNames->Color3f.GetHash(), Ufe::Attribute::kColorFloat3 }, // GfVec3f
-        { SdfValueTypeNames->Color3d.GetHash(), Ufe::Attribute::kColorFloat3 }, // GfVec3d
+        { PXR_NS::SdfValueTypeNames->Bool.GetHash(), Ufe::Attribute::kBool },        // bool
+        { PXR_NS::SdfValueTypeNames->Int.GetHash(), Ufe::Attribute::kInt },          // int32_t
+        { PXR_NS::SdfValueTypeNames->Float.GetHash(), Ufe::Attribute::kFloat },      // float
+        { PXR_NS::SdfValueTypeNames->Double.GetHash(), Ufe::Attribute::kDouble },    // double
+        { PXR_NS::SdfValueTypeNames->String.GetHash(), Ufe::Attribute::kString },    // std::string
+        { PXR_NS::SdfValueTypeNames->Token.GetHash(), Ufe::Attribute::kEnumString }, // TfToken
+        { PXR_NS::SdfValueTypeNames->Int3.GetHash(), Ufe::Attribute::kInt3 },        // GfVec3i
+        { PXR_NS::SdfValueTypeNames->Float3.GetHash(), Ufe::Attribute::kFloat3 },    // GfVec3f
+        { PXR_NS::SdfValueTypeNames->Double3.GetHash(), Ufe::Attribute::kDouble3 },  // GfVec3d
+        { PXR_NS::SdfValueTypeNames->Color3f.GetHash(), Ufe::Attribute::kColorFloat3 }, // GfVec3f
+        { PXR_NS::SdfValueTypeNames->Color3d.GetHash(), Ufe::Attribute::kColorFloat3 }, // GfVec3d
     };
 
     if (usdAttr.IsValid()) {

--- a/lib/mayaUsd/ufe/UsdCamera.h
+++ b/lib/mayaUsd/ufe/UsdCamera.h
@@ -23,8 +23,6 @@
 #include <ufe/camera.h>
 #include <ufe/path.h>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -47,8 +45,9 @@ public:
     //! Create a UsdCamera.
     static UsdCamera::Ptr create(const UsdSceneItem::Ptr& item);
 
-    inline UsdPrim prim() const
+    inline PXR_NS::UsdPrim prim() const
     {
+        PXR_NAMESPACE_USING_DIRECTIVE
         TF_AXIOM(fItem != nullptr);
         return fItem->prim();
     }

--- a/lib/mayaUsd/ufe/UsdCameraHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdCameraHandler.cpp
@@ -45,7 +45,7 @@ Ufe::Camera::Ptr UsdCameraHandler::camera(const Ufe::SceneItem::Ptr& item) const
 
     // Test if this item is a camera. If not, then we cannot create a camera
     // interface for it, which is a valid case (such as for a mesh node type).
-    UsdGeomCamera primSchema(usdItem->prim());
+    PXR_NS::UsdGeomCamera primSchema(usdItem->prim());
     if (!primSchema)
         return nullptr;
 

--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -51,6 +51,8 @@
 #include <utility>
 #include <vector>
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace {
 
 // Ufe::ContextItem strings

--- a/lib/mayaUsd/ufe/UsdContextOps.h
+++ b/lib/mayaUsd/ufe/UsdContextOps.h
@@ -52,8 +52,8 @@ public:
     //! Create a UsdContextOps.
     static UsdContextOps::Ptr create(const UsdSceneItem::Ptr& item);
 
-    void             setItem(const UsdSceneItem::Ptr& item);
-    const Ufe::Path& path() const;
+    void                   setItem(const UsdSceneItem::Ptr& item);
+    const Ufe::Path&       path() const;
     inline PXR_NS::UsdPrim prim() const
     {
         PXR_NAMESPACE_USING_DIRECTIVE

--- a/lib/mayaUsd/ufe/UsdContextOps.h
+++ b/lib/mayaUsd/ufe/UsdContextOps.h
@@ -23,8 +23,6 @@
 #include <ufe/contextOps.h>
 #include <ufe/path.h>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -56,8 +54,9 @@ public:
 
     void             setItem(const UsdSceneItem::Ptr& item);
     const Ufe::Path& path() const;
-    inline UsdPrim   prim() const
+    inline PXR_NS::UsdPrim prim() const
     {
+        PXR_NAMESPACE_USING_DIRECTIVE
         TF_AXIOM(fItem != nullptr);
         return fItem->prim();
     }

--- a/lib/mayaUsd/ufe/UsdContextOpsHandler.h
+++ b/lib/mayaUsd/ufe/UsdContextOpsHandler.h
@@ -20,8 +20,6 @@
 
 #include <ufe/contextOpsHandler.h>
 
-// PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 

--- a/lib/mayaUsd/ufe/UsdHierarchy.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchy.cpp
@@ -44,6 +44,8 @@
 #include <mayaUsd/ufe/UsdUndoReorderCommand.h>
 #endif
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace {
 UsdPrimSiblingRange getUSDFilteredChildren(
     const MayaUsd::ufe::UsdSceneItem::Ptr usdSceneItem,

--- a/lib/mayaUsd/ufe/UsdHierarchy.h
+++ b/lib/mayaUsd/ufe/UsdHierarchy.h
@@ -48,8 +48,8 @@ public:
     //! Create a UsdHierarchy.
     static UsdHierarchy::Ptr create(const UsdSceneItem::Ptr& item);
 
-    void             setItem(const UsdSceneItem::Ptr& item);
-    const Ufe::Path& path() const;
+    void                   setItem(const UsdSceneItem::Ptr& item);
+    const Ufe::Path&       path() const;
     inline PXR_NS::UsdPrim prim() const
     {
         PXR_NAMESPACE_USING_DIRECTIVE

--- a/lib/mayaUsd/ufe/UsdHierarchy.h
+++ b/lib/mayaUsd/ufe/UsdHierarchy.h
@@ -50,8 +50,9 @@ public:
 
     void             setItem(const UsdSceneItem::Ptr& item);
     const Ufe::Path& path() const;
-    inline UsdPrim   prim() const
+    inline PXR_NS::UsdPrim prim() const
     {
+        PXR_NAMESPACE_USING_DIRECTIVE
         TF_AXIOM(fItem != nullptr);
         return fItem->prim();
     }
@@ -85,7 +86,7 @@ public:
 #endif
 
 private:
-    Ufe::SceneItemList createUFEChildList(const UsdPrimSiblingRange& range) const;
+    Ufe::SceneItemList createUFEChildList(const PXR_NS::UsdPrimSiblingRange& range) const;
 
 private:
     UsdSceneItem::Ptr fItem;

--- a/lib/mayaUsd/ufe/UsdHierarchyHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchyHandler.cpp
@@ -48,7 +48,7 @@ Ufe::Hierarchy::Ptr UsdHierarchyHandler::hierarchy(const Ufe::SceneItem::Ptr& it
 Ufe::SceneItem::Ptr UsdHierarchyHandler::createItem(const Ufe::Path& path) const
 {
     const PXR_NS::UsdPrim prim = ufePathToPrim(path);
-    const int     instanceIndex = ufePathToInstanceIndex(path);
+    const int             instanceIndex = ufePathToInstanceIndex(path);
     return prim.IsValid() ? UsdSceneItem::create(path, prim, instanceIndex) : nullptr;
 }
 

--- a/lib/mayaUsd/ufe/UsdHierarchyHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchyHandler.cpp
@@ -47,7 +47,7 @@ Ufe::Hierarchy::Ptr UsdHierarchyHandler::hierarchy(const Ufe::SceneItem::Ptr& it
 
 Ufe::SceneItem::Ptr UsdHierarchyHandler::createItem(const Ufe::Path& path) const
 {
-    const UsdPrim prim = ufePathToPrim(path);
+    const PXR_NS::UsdPrim prim = ufePathToPrim(path);
     const int     instanceIndex = ufePathToInstanceIndex(path);
     return prim.IsValid() ? UsdSceneItem::create(path, prim, instanceIndex) : nullptr;
 }

--- a/lib/mayaUsd/ufe/UsdHierarchyHandler.h
+++ b/lib/mayaUsd/ufe/UsdHierarchyHandler.h
@@ -22,8 +22,6 @@
 
 #include <ufe/hierarchyHandler.h>
 
-// PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 

--- a/lib/mayaUsd/ufe/UsdObject3d.cpp
+++ b/lib/mayaUsd/ufe/UsdObject3d.cpp
@@ -30,6 +30,8 @@
 
 #include <stdexcept>
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace {
 Ufe::Vector3d toVector3d(const GfVec3d& v) { return Ufe::Vector3d(v[0], v[1], v[2]); }
 } // namespace

--- a/lib/mayaUsd/ufe/UsdObject3d.h
+++ b/lib/mayaUsd/ufe/UsdObject3d.h
@@ -48,7 +48,7 @@ public:
 
 private:
     UsdSceneItem::Ptr fItem;
-    UsdPrim           fPrim;
+    PXR_NS::UsdPrim   fPrim;
 
 }; // UsdObject3d
 

--- a/lib/mayaUsd/ufe/UsdObject3dHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdObject3dHandler.cpp
@@ -41,7 +41,7 @@ Ufe::Object3d::Ptr UsdObject3dHandler::object3d(const Ufe::SceneItem::Ptr& item)
 
     // Test if this item is imageable. If not, then we cannot create an object3d
     // interface for it, which is a valid case (such as for a material node type).
-    UsdGeomImageable primSchema(usdItem->prim());
+    PXR_NS::UsdGeomImageable primSchema(usdItem->prim());
     if (!primSchema)
         return nullptr;
 

--- a/lib/mayaUsd/ufe/UsdRootChildHierarchy.cpp
+++ b/lib/mayaUsd/ufe/UsdRootChildHierarchy.cpp
@@ -19,6 +19,8 @@
 
 #include <cassert>
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 

--- a/lib/mayaUsd/ufe/UsdRootChildHierarchy.h
+++ b/lib/mayaUsd/ufe/UsdRootChildHierarchy.h
@@ -18,8 +18,6 @@
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/ufe/UsdHierarchy.h>
 
-// PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 

--- a/lib/mayaUsd/ufe/UsdRotatePivotTranslateUndoableCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdRotatePivotTranslateUndoableCommand.cpp
@@ -17,6 +17,8 @@
 
 #include "private/Utils.h"
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 

--- a/lib/mayaUsd/ufe/UsdRotatePivotTranslateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdRotatePivotTranslateUndoableCommand.h
@@ -23,8 +23,6 @@
 
 #include <ufe/transform3dUndoableCommands.h>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -42,7 +40,7 @@ public:
     UsdRotatePivotTranslateUndoableCommand(const Ufe::Path& path);
 #else
     UsdRotatePivotTranslateUndoableCommand(
-        const UsdPrim&             prim,
+        const PXR_NS::UsdPrim&     prim,
         const Ufe::Path&           ufePath,
         const Ufe::SceneItem::Ptr& item);
 #endif
@@ -74,8 +72,9 @@ public:
     bool translate(double x, double y, double z) override;
 #endif
 
-    inline UsdPrim prim() const
+    inline PXR_NS::UsdPrim prim() const
     {
+        PXR_NAMESPACE_USING_DIRECTIVE
         TF_AXIOM(fItem != nullptr);
         return fItem->prim();
     }
@@ -85,12 +84,12 @@ private:
 
 private:
 #ifndef UFE_V2_FEATURES_AVAILABLE
-    UsdPrim fPrim;
+    PXR_NS::UsdPrim fPrim;
 #endif
     Ufe::Path                 fPath;
     mutable UsdSceneItem::Ptr fItem { nullptr };
-    UsdAttribute              fPivotAttrib;
-    GfVec3f                   fPrevPivotValue;
+    PXR_NS::UsdAttribute      fPivotAttrib;
+    PXR_NS::GfVec3f           fPrevPivotValue;
     bool                      fNoPivotOp;
 
 }; // UsdRotatePivotTranslateUndoableCommand

--- a/lib/mayaUsd/ufe/UsdRotatePivotTranslateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdRotatePivotTranslateUndoableCommand.h
@@ -60,7 +60,7 @@ public:
     static UsdRotatePivotTranslateUndoableCommand::Ptr create(const Ufe::Path& path);
 #else
     static UsdRotatePivotTranslateUndoableCommand::Ptr
-         create(const UsdPrim& prim, const Ufe::Path& ufePath, const Ufe::SceneItem::Ptr& item);
+         create(const PXR_NS::UsdPrim& prim, const Ufe::Path& ufePath, const Ufe::SceneItem::Ptr& item);
 #endif
 
     // Ufe::TranslateUndoableCommand overrides

--- a/lib/mayaUsd/ufe/UsdRotateUndoableCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdRotateUndoableCommand.cpp
@@ -20,7 +20,7 @@
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
-TfToken UsdRotateUndoableCommand::rotXYZ("xformOp:rotateXYZ");
+PXR_NS::TfToken UsdRotateUndoableCommand::rotXYZ("xformOp:rotateXYZ");
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 UsdRotateUndoableCommand::UsdRotateUndoableCommand(

--- a/lib/mayaUsd/ufe/UsdRotateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdRotateUndoableCommand.h
@@ -82,9 +82,9 @@ private:
     static PXR_NS::TfToken rotXYZ;
 
     PXR_NS::TfToken attributeName() const override { return rotXYZ; }
-    void    performImp(double x, double y, double z) override;
-    void    addEmptyAttribute() override;
-    bool    cannotInit() const override { return bool(fFailedInit); }
+    void            performImp(double x, double y, double z) override;
+    void            addEmptyAttribute() override;
+    bool            cannotInit() const override { return bool(fFailedInit); }
 
     std::exception_ptr fFailedInit;
 

--- a/lib/mayaUsd/ufe/UsdRotateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdRotateUndoableCommand.h
@@ -24,8 +24,6 @@
 
 #include <exception>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -35,7 +33,7 @@ namespace ufe {
  */
 class MAYAUSD_CORE_PUBLIC UsdRotateUndoableCommand
     : public Ufe::RotateUndoableCommand
-    , public UsdTRSUndoableCommandBase<GfVec3f>
+    , public UsdTRSUndoableCommandBase<PXR_NS::GfVec3f>
 {
 public:
     typedef std::shared_ptr<UsdRotateUndoableCommand> Ptr;
@@ -81,9 +79,9 @@ protected:
     ~UsdRotateUndoableCommand() override;
 
 private:
-    static TfToken rotXYZ;
+    static PXR_NS::TfToken rotXYZ;
 
-    TfToken attributeName() const override { return rotXYZ; }
+    PXR_NS::TfToken attributeName() const override { return rotXYZ; }
     void    performImp(double x, double y, double z) override;
     void    addEmptyAttribute() override;
     bool    cannotInit() const override { return bool(fFailedInit); }

--- a/lib/mayaUsd/ufe/UsdScaleUndoableCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdScaleUndoableCommand.cpp
@@ -20,7 +20,7 @@
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
-TfToken UsdScaleUndoableCommand::scaleTok("xformOp:scale");
+PXR_NS::TfToken UsdScaleUndoableCommand::scaleTok("xformOp:scale");
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 UsdScaleUndoableCommand::UsdScaleUndoableCommand(

--- a/lib/mayaUsd/ufe/UsdScaleUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdScaleUndoableCommand.h
@@ -79,8 +79,8 @@ private:
     static PXR_NS::TfToken scaleTok;
 
     PXR_NS::TfToken attributeName() const override { return scaleTok; }
-    void    performImp(double x, double y, double z) override;
-    void    addEmptyAttribute() override;
+    void            performImp(double x, double y, double z) override;
+    void            addEmptyAttribute() override;
 
 }; // UsdScaleUndoableCommand
 

--- a/lib/mayaUsd/ufe/UsdScaleUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdScaleUndoableCommand.h
@@ -22,8 +22,6 @@
 
 #include <ufe/transform3dUndoableCommands.h>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -33,7 +31,7 @@ namespace ufe {
  */
 class MAYAUSD_CORE_PUBLIC UsdScaleUndoableCommand
     : public Ufe::ScaleUndoableCommand
-    , public UsdTRSUndoableCommandBase<GfVec3f>
+    , public UsdTRSUndoableCommandBase<PXR_NS::GfVec3f>
 {
 public:
     typedef std::shared_ptr<UsdScaleUndoableCommand> Ptr;
@@ -78,9 +76,9 @@ protected:
     ~UsdScaleUndoableCommand() override;
 
 private:
-    static TfToken scaleTok;
+    static PXR_NS::TfToken scaleTok;
 
-    TfToken attributeName() const override { return scaleTok; }
+    PXR_NS::TfToken attributeName() const override { return scaleTok; }
     void    performImp(double x, double y, double z) override;
     void    addEmptyAttribute() override;
 

--- a/lib/mayaUsd/ufe/UsdSceneItem.cpp
+++ b/lib/mayaUsd/ufe/UsdSceneItem.cpp
@@ -24,6 +24,8 @@
 #endif
 #include <pxr/usd/usd/schemaRegistry.h>
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 

--- a/lib/mayaUsd/ufe/UsdSceneItem.h
+++ b/lib/mayaUsd/ufe/UsdSceneItem.h
@@ -24,8 +24,6 @@
 #include <ufe/path.h>
 #include <ufe/sceneItem.h>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -85,9 +83,9 @@ public:
     typedef std::shared_ptr<UsdSceneItem> Ptr;
 
     UsdSceneItem(
-        const Ufe::Path& path,
-        const UsdPrim&   prim,
-        int              instanceIndex = UsdImagingDelegate::ALL_INSTANCES);
+        const Ufe::Path&       path,
+        const PXR_NS::UsdPrim& prim,
+        int                    instanceIndex = PXR_NS::UsdImagingDelegate::ALL_INSTANCES);
     ~UsdSceneItem() override = default;
 
     // Delete the copy/move constructors assignment operators.
@@ -101,11 +99,11 @@ public:
     // A non-negative instanceIndex should be provided if the scene item is
     // intended to represent an individual instance of a PointInstancer.
     static UsdSceneItem::Ptr create(
-        const Ufe::Path& path,
-        const UsdPrim&   prim,
-        int              instanceIndex = UsdImagingDelegate::ALL_INSTANCES);
+        const Ufe::Path&       path,
+        const PXR_NS::UsdPrim& prim,
+        int                    instanceIndex = PXR_NS::UsdImagingDelegate::ALL_INSTANCES);
 
-    const UsdPrim& prim() const { return fPrim; }
+    const PXR_NS::UsdPrim& prim() const { return fPrim; }
 
     int instanceIndex() const { return _instanceIndex; }
 
@@ -115,7 +113,7 @@ public:
     // PointInstancer and its instanceIndex is non-negative.
     bool isPointInstance() const
     {
-        return (fPrim && fPrim.IsA<UsdGeomPointInstancer>() && _instanceIndex >= 0);
+        return (fPrim && fPrim.IsA<PXR_NS::UsdGeomPointInstancer>() && _instanceIndex >= 0);
     }
 
     // Ufe::SceneItem overrides
@@ -125,7 +123,7 @@ public:
 #endif
 
 private:
-    UsdPrim   fPrim;
+    PXR_NS::UsdPrim fPrim;
     const int _instanceIndex;
 }; // UsdSceneItem
 

--- a/lib/mayaUsd/ufe/UsdSceneItem.h
+++ b/lib/mayaUsd/ufe/UsdSceneItem.h
@@ -124,7 +124,7 @@ public:
 
 private:
     PXR_NS::UsdPrim fPrim;
-    const int _instanceIndex;
+    const int       _instanceIndex;
 }; // UsdSceneItem
 
 } // namespace ufe

--- a/lib/mayaUsd/ufe/UsdSceneItemOps.cpp
+++ b/lib/mayaUsd/ufe/UsdSceneItemOps.cpp
@@ -27,7 +27,7 @@ namespace {
 static constexpr char kWarningCannotDeactivePrim[]
     = "Cannot deactivate \"^1s\" because it is already inactive.";
 
-void displayWarning(const UsdPrim& prim, const MString& fmt)
+void displayWarning(const PXR_NS::UsdPrim& prim, const MString& fmt)
 {
     MString msg, primArg(prim.GetName().GetText());
     msg.format(fmt, primArg);

--- a/lib/mayaUsd/ufe/UsdSceneItemOps.h
+++ b/lib/mayaUsd/ufe/UsdSceneItemOps.h
@@ -23,8 +23,6 @@
 #include <ufe/path.h>
 #include <ufe/sceneItemOps.h>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -48,8 +46,9 @@ public:
 
     void             setItem(const UsdSceneItem::Ptr& item);
     const Ufe::Path& path() const;
-    inline UsdPrim   prim() const
+    inline PXR_NS::UsdPrim prim() const
     {
+        PXR_NAMESPACE_USING_DIRECTIVE
         TF_AXIOM(fItem != nullptr);
         return fItem->prim();
     }

--- a/lib/mayaUsd/ufe/UsdSceneItemOps.h
+++ b/lib/mayaUsd/ufe/UsdSceneItemOps.h
@@ -44,8 +44,8 @@ public:
     //! Create a UsdSceneItemOps.
     static UsdSceneItemOps::Ptr create(const UsdSceneItem::Ptr& item);
 
-    void             setItem(const UsdSceneItem::Ptr& item);
-    const Ufe::Path& path() const;
+    void                   setItem(const UsdSceneItem::Ptr& item);
+    const Ufe::Path&       path() const;
     inline PXR_NS::UsdPrim prim() const
     {
         PXR_NAMESPACE_USING_DIRECTIVE

--- a/lib/mayaUsd/ufe/UsdSceneItemOpsHandler.h
+++ b/lib/mayaUsd/ufe/UsdSceneItemOpsHandler.h
@@ -20,8 +20,6 @@
 
 #include <ufe/sceneItemOpsHandler.h>
 
-// PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 

--- a/lib/mayaUsd/ufe/UsdStageMap.cpp
+++ b/lib/mayaUsd/ufe/UsdStageMap.cpp
@@ -23,6 +23,8 @@
 
 #include <cassert>
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace {
 
 MObjectHandle proxyShapeHandle(const Ufe::Path& path)

--- a/lib/mayaUsd/ufe/UsdStageMap.h
+++ b/lib/mayaUsd/ufe/UsdStageMap.h
@@ -38,8 +38,6 @@ template <> struct hash<MObjectHandle>
 };
 } // namespace std
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -60,7 +58,7 @@ namespace ufe {
 class MAYAUSD_CORE_PUBLIC UsdStageMap
 {
 public:
-    typedef TfHashSet<UsdStageWeakPtr, TfHash> StageSet;
+    typedef PXR_NS::TfHashSet<PXR_NS::UsdStageWeakPtr, PXR_NS::TfHash> StageSet;
 
     UsdStageMap() = default;
     ~UsdStageMap() = default;
@@ -72,10 +70,10 @@ public:
     UsdStageMap& operator=(UsdStageMap&&) = delete;
 
     //! Get USD stage corresponding to argument Maya Dag path.
-    UsdStageWeakPtr stage(const Ufe::Path& path);
+    PXR_NS::UsdStageWeakPtr stage(const Ufe::Path& path);
 
     //! Return the ProxyShape node UFE path for the argument stage.
-    Ufe::Path path(UsdStageWeakPtr stage);
+    Ufe::Path path(PXR_NS::UsdStageWeakPtr stage);
 
     //! Return all the USD stages.
     StageSet allStages();
@@ -88,13 +86,13 @@ public:
     bool isDirty() const { return fDirty; }
 
 private:
-    void addItem(const Ufe::Path& path, UsdStageWeakPtr stage);
+    void addItem(const Ufe::Path& path, PXR_NS::UsdStageWeakPtr stage);
     void rebuildIfDirty();
 
 private:
     // We keep two maps for fast lookup when there are many proxy shapes.
-    using ObjectToStage = std::unordered_map<MObjectHandle, UsdStageWeakPtr>;
-    using StageToObject = TfHashMap<UsdStageWeakPtr, MObjectHandle, TfHash>;
+    using ObjectToStage = std::unordered_map<MObjectHandle, PXR_NS::UsdStageWeakPtr>;
+    using StageToObject = PXR_NS::TfHashMap<PXR_NS::UsdStageWeakPtr, MObjectHandle, PXR_NS::TfHash>;
     ObjectToStage fObjectToStage;
     StageToObject fStageToObject;
     bool          fDirty { true };

--- a/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
+++ b/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
@@ -23,8 +23,6 @@
 #include <ufe/observer.h>
 #include <ufe/transform3dUndoableCommands.h>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -80,20 +78,20 @@ protected:
     // stack), so always return current data.
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
-    inline UsdPrim prim() const
+    inline PXR_NS::UsdPrim prim() const
     {
         updateItem();
         return fItem->prim();
     };
 #else
-    inline UsdPrim   prim() const { return fItem->prim(); }
+    inline PXR_NS::UsdPrim prim() const { return fItem->prim(); }
     inline Ufe::Path path() const { return fItem->path(); }
 #endif
 
     // Hooks to be implemented by the derived class: name of the attribute set
     // by the command, implementation of perform(), and add empty attribute.
     // Implementation of cannotInit() in this class returns false.
-    virtual TfToken attributeName() const = 0;
+    virtual PXR_NS::TfToken attributeName() const = 0;
     virtual void    performImp(double x, double y, double z) = 0;
     virtual void    addEmptyAttribute() = 0;
     virtual bool    cannotInit() const;
@@ -114,7 +112,7 @@ private:
     template <class N> void checkNotification(const N* notification);
 #endif
 
-    inline UsdAttribute attribute() const { return prim().GetAttribute(attributeName()); }
+    inline PXR_NS::UsdAttribute attribute() const { return prim().GetAttribute(attributeName()); }
 
     mutable UsdSceneItem::Ptr fItem { nullptr };
     V                         fPrevValue;

--- a/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
+++ b/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
@@ -85,16 +85,16 @@ protected:
     };
 #else
     inline PXR_NS::UsdPrim prim() const { return fItem->prim(); }
-    inline Ufe::Path path() const { return fItem->path(); }
+    inline Ufe::Path       path() const { return fItem->path(); }
 #endif
 
     // Hooks to be implemented by the derived class: name of the attribute set
     // by the command, implementation of perform(), and add empty attribute.
     // Implementation of cannotInit() in this class returns false.
     virtual PXR_NS::TfToken attributeName() const = 0;
-    virtual void    performImp(double x, double y, double z) = 0;
-    virtual void    addEmptyAttribute() = 0;
-    virtual bool    cannotInit() const;
+    virtual void            performImp(double x, double y, double z) = 0;
+    virtual void            addEmptyAttribute() = 0;
+    virtual bool            cannotInit() const;
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
     // Conditionally create a UsdSceneItem::Ptr from the Ufe::Path, if null.

--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -25,6 +25,8 @@
 
 #include <pxr/usd/usdGeom/xformCache.h>
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 

--- a/lib/mayaUsd/ufe/UsdTransform3d.h
+++ b/lib/mayaUsd/ufe/UsdTransform3d.h
@@ -51,8 +51,9 @@ public:
     // Ufe::Transform3d overrides
     const Ufe::Path&    path() const override;
     Ufe::SceneItem::Ptr sceneItem() const override;
-    inline UsdPrim      prim() const
+    inline PXR_NS::UsdPrim prim() const
     {
+        PXR_NAMESPACE_USING_DIRECTIVE
         TF_AXIOM(fItem != nullptr);
         return fItem->prim();
     }

--- a/lib/mayaUsd/ufe/UsdTransform3d.h
+++ b/lib/mayaUsd/ufe/UsdTransform3d.h
@@ -49,8 +49,8 @@ public:
     void setItem(const UsdSceneItem::Ptr& item);
 
     // Ufe::Transform3d overrides
-    const Ufe::Path&    path() const override;
-    Ufe::SceneItem::Ptr sceneItem() const override;
+    const Ufe::Path&       path() const override;
+    Ufe::SceneItem::Ptr    sceneItem() const override;
     inline PXR_NS::UsdPrim prim() const
     {
         PXR_NAMESPACE_USING_DIRECTIVE

--- a/lib/mayaUsd/ufe/UsdTransform3dBase.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dBase.cpp
@@ -20,6 +20,8 @@
 #include <pxr/usd/usdGeom/xformCache.h>
 #include <pxr/usd/usdGeom/xformCommonAPI.h>
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 

--- a/lib/mayaUsd/ufe/UsdTransform3dBase.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dBase.h
@@ -53,7 +53,7 @@ public:
     Ufe::SceneItem::Ptr sceneItem() const override;
 
     inline UsdSceneItem::Ptr usdSceneItem() const { return fItem; }
-    inline UsdPrim           prim() const { return fPrim; }
+    inline PXR_NS::UsdPrim   prim() const { return fPrim; }
 
     Ufe::TranslateUndoableCommand::Ptr translateCmd(double x, double y, double z) override;
     Ufe::RotateUndoableCommand::Ptr    rotateCmd(double x, double y, double z) override;
@@ -82,7 +82,7 @@ public:
 
 private:
     UsdSceneItem::Ptr fItem;
-    UsdPrim           fPrim;
+    PXR_NS::UsdPrim   fPrim;
 
 }; // UsdTransform3dBase
 

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
@@ -19,6 +19,8 @@
 
 #include <pxr/usd/usdGeom/xformCache.h>
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.h
@@ -63,7 +63,7 @@ public:
     Ufe::Vector3d                      rotatePivot() const override;
 
 private:
-    UsdGeomXformCommonAPI _commonAPI;
+    PXR_NS::UsdGeomXformCommonAPI _commonAPI;
 
 }; // UsdTransform3dCommonAPI
 

--- a/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.cpp
@@ -22,6 +22,8 @@
 
 #include <pxr/usd/usdGeom/xformCache.h>
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace {
 
 using namespace MayaUsd::ufe;

--- a/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.h
@@ -78,9 +78,9 @@ public:
     Ufe::Matrix4d segmentExclusiveMatrix() const override;
 
 private:
-    SetXformOpOrderFn               getXformOpOrderFn() const override;
-    PXR_NS::TfToken                 getOpSuffix(OpNdx ndx) const override;
-    PXR_NS::TfToken                 getTRSOpSuffix() const override;
+    SetXformOpOrderFn   getXformOpOrderFn() const override;
+    PXR_NS::TfToken     getOpSuffix(OpNdx ndx) const override;
+    PXR_NS::TfToken     getTRSOpSuffix() const override;
     CvtRotXYZFromAttrFn getCvtRotXYZFromAttrFn(const PXR_NS::TfToken& opName) const override;
     CvtRotXYZToAttrFn   getCvtRotXYZToAttrFn(const PXR_NS::TfToken& opName) const override;
     std::map<OpNdx, PXR_NS::UsdGeomXformOp> getOrderedOps() const override;

--- a/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.h
@@ -79,11 +79,11 @@ public:
 
 private:
     SetXformOpOrderFn               getXformOpOrderFn() const override;
-    TfToken                         getOpSuffix(OpNdx ndx) const override;
-    TfToken                         getTRSOpSuffix() const override;
-    CvtRotXYZFromAttrFn             getCvtRotXYZFromAttrFn(const TfToken& opName) const override;
-    CvtRotXYZToAttrFn               getCvtRotXYZToAttrFn(const TfToken& opName) const override;
-    std::map<OpNdx, UsdGeomXformOp> getOrderedOps() const override;
+    PXR_NS::TfToken                 getOpSuffix(OpNdx ndx) const override;
+    PXR_NS::TfToken                 getTRSOpSuffix() const override;
+    CvtRotXYZFromAttrFn getCvtRotXYZFromAttrFn(const PXR_NS::TfToken& opName) const override;
+    CvtRotXYZToAttrFn   getCvtRotXYZToAttrFn(const PXR_NS::TfToken& opName) const override;
+    std::map<OpNdx, PXR_NS::UsdGeomXformOp> getOrderedOps() const override;
 
 }; // UsdTransform3dFallbackMayaXformStack
 

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -32,6 +32,8 @@
 
 #include <algorithm>
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace {
 
 using namespace MayaUsd;

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.h
@@ -46,12 +46,12 @@ class MAYAUSD_CORE_PUBLIC UsdTransform3dMatrixOp : public UsdTransform3dBase
 public:
     typedef std::shared_ptr<UsdTransform3dMatrixOp> Ptr;
 
-    UsdTransform3dMatrixOp(const UsdSceneItem::Ptr& item, const UsdGeomXformOp& op);
+    UsdTransform3dMatrixOp(const UsdSceneItem::Ptr& item, const PXR_NS::UsdGeomXformOp& op);
     ~UsdTransform3dMatrixOp() override = default;
 
     //! Create a UsdTransform3dMatrixOp.
     static UsdTransform3dMatrixOp::Ptr
-    create(const UsdSceneItem::Ptr& item, const UsdGeomXformOp& op);
+    create(const UsdSceneItem::Ptr& item, const PXR_NS::UsdGeomXformOp& op);
 
     Ufe::Vector3d translation() const override;
     Ufe::Vector3d rotation() const override;
@@ -69,7 +69,7 @@ public:
     Ufe::Matrix4d segmentExclusiveMatrix() const override;
 
 private:
-    const UsdGeomXformOp _op;
+    const PXR_NS::UsdGeomXformOp _op;
 
 }; // UsdTransform3dMatrixOp
 

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
@@ -33,6 +33,8 @@
 #include <functional>
 #include <map>
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace {
 
 #if UFE_PREVIEW_VERSION_NUM >= 2031

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
@@ -91,11 +91,11 @@ public:
     Ufe::SetMatrix4dUndoableCommand::Ptr setMatrixCmd(const Ufe::Matrix4d& m) override;
 
 protected:
-    bool                                    hasOp(OpNdx ndx) const;
-    PXR_NS::UsdGeomXformOp                  getOp(OpNdx ndx) const;
-    virtual SetXformOpOrderFn               getXformOpOrderFn() const;
-    virtual PXR_NS::TfToken                 getOpSuffix(OpNdx ndx) const;
-    virtual PXR_NS::TfToken                 getTRSOpSuffix() const;
+    bool                        hasOp(OpNdx ndx) const;
+    PXR_NS::UsdGeomXformOp      getOp(OpNdx ndx) const;
+    virtual SetXformOpOrderFn   getXformOpOrderFn() const;
+    virtual PXR_NS::TfToken     getOpSuffix(OpNdx ndx) const;
+    virtual PXR_NS::TfToken     getTRSOpSuffix() const;
     virtual CvtRotXYZFromAttrFn getCvtRotXYZFromAttrFn(const PXR_NS::TfToken& opName) const;
     virtual CvtRotXYZToAttrFn   getCvtRotXYZToAttrFn(const PXR_NS::TfToken& opName) const;
     virtual std::map<OpNdx, PXR_NS::UsdGeomXformOp> getOrderedOps() const;

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
@@ -54,9 +54,9 @@ public:
     };
 
     typedef std::shared_ptr<UsdTransform3dMayaXformStack> Ptr;
-    typedef Ufe::Vector3d (*CvtRotXYZFromAttrFn)(const VtValue& value);
-    typedef VtValue (*CvtRotXYZToAttrFn)(double x, double y, double z);
-    typedef void (*SetXformOpOrderFn)(const UsdGeomXformable&);
+    typedef Ufe::Vector3d (*CvtRotXYZFromAttrFn)(const PXR_NS::VtValue& value);
+    typedef PXR_NS::VtValue (*CvtRotXYZToAttrFn)(double x, double y, double z);
+    typedef void (*SetXformOpOrderFn)(const PXR_NS::UsdGeomXformable&);
 
     UsdTransform3dMayaXformStack(const UsdSceneItem::Ptr& item);
     ~UsdTransform3dMayaXformStack() override = default;
@@ -92,25 +92,27 @@ public:
 
 protected:
     bool                                    hasOp(OpNdx ndx) const;
-    UsdGeomXformOp                          getOp(OpNdx ndx) const;
+    PXR_NS::UsdGeomXformOp                  getOp(OpNdx ndx) const;
     virtual SetXformOpOrderFn               getXformOpOrderFn() const;
-    virtual TfToken                         getOpSuffix(OpNdx ndx) const;
-    virtual TfToken                         getTRSOpSuffix() const;
-    virtual CvtRotXYZFromAttrFn             getCvtRotXYZFromAttrFn(const TfToken& opName) const;
-    virtual CvtRotXYZToAttrFn               getCvtRotXYZToAttrFn(const TfToken& opName) const;
-    virtual std::map<OpNdx, UsdGeomXformOp> getOrderedOps() const;
+    virtual PXR_NS::TfToken                 getOpSuffix(OpNdx ndx) const;
+    virtual PXR_NS::TfToken                 getTRSOpSuffix() const;
+    virtual CvtRotXYZFromAttrFn getCvtRotXYZFromAttrFn(const PXR_NS::TfToken& opName) const;
+    virtual CvtRotXYZToAttrFn   getCvtRotXYZToAttrFn(const PXR_NS::TfToken& opName) const;
+    virtual std::map<OpNdx, PXR_NS::UsdGeomXformOp> getOrderedOps() const;
 
-    template <class V> Ufe::Vector3d getVector3d(const TfToken& attrName) const;
+    template <class V> Ufe::Vector3d getVector3d(const PXR_NS::TfToken& attrName) const;
 
     template <class V>
-    Ufe::SetVector3dUndoableCommand::Ptr
-    setVector3dCmd(const V& v, const TfToken& attrName, const TfToken& opSuffix = TfToken());
+    Ufe::SetVector3dUndoableCommand::Ptr setVector3dCmd(
+        const V&               v,
+        const PXR_NS::TfToken& attrName,
+        const PXR_NS::TfToken& opSuffix = PXR_NS::TfToken());
 
-    UsdGeomXformable _xformable;
+    PXR_NS::UsdGeomXformable _xformable;
 
 private:
     Ufe::TranslateUndoableCommand::Ptr
-    pivotCmd(const TfToken& pvtOpSuffix, double x, double y, double z);
+    pivotCmd(const PXR_NS::TfToken& pvtOpSuffix, double x, double y, double z);
 }; // UsdTransform3dMayaXformStack
 
 //! \brief Factory to create a UsdTransform3dMayaXformStack interface object.

--- a/lib/mayaUsd/ufe/UsdTransform3dSetObjectMatrix.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dSetObjectMatrix.cpp
@@ -23,8 +23,8 @@ namespace ufe {
 
 UsdTransform3dSetObjectMatrix::UsdTransform3dSetObjectMatrix(
     const Ufe::Transform3d::Ptr& wrapped,
-    const GfMatrix4d&            mlInv,
-    const GfMatrix4d&            mrInv)
+    const PXR_NS::GfMatrix4d&    mlInv,
+    const PXR_NS::GfMatrix4d&    mrInv)
     : UsdTransform3dBase(std::dynamic_pointer_cast<UsdSceneItem>(wrapped->sceneItem()))
     , _wrapped(wrapped)
     , _mlInv(mlInv)
@@ -35,26 +35,29 @@ UsdTransform3dSetObjectMatrix::UsdTransform3dSetObjectMatrix(
 /* static */
 UsdTransform3dSetObjectMatrix::Ptr UsdTransform3dSetObjectMatrix::create(
     const Ufe::Transform3d::Ptr& wrapped,
-    const GfMatrix4d&            mlInv,
-    const GfMatrix4d&            mrInv)
+    const PXR_NS::GfMatrix4d&    mlInv,
+    const PXR_NS::GfMatrix4d&    mrInv)
 {
     return std::make_shared<UsdTransform3dSetObjectMatrix>(wrapped, mlInv, mrInv);
 }
 
 Ufe::Vector3d UsdTransform3dSetObjectMatrix::translation() const
 {
+    PXR_NAMESPACE_USING_DIRECTIVE
     TF_CODING_ERROR("Illegal call to unimplemented UsdTransform3dSetObjectMatrix::translation()");
     return Ufe::Vector3d(0, 0, 0);
 }
 
 Ufe::Vector3d UsdTransform3dSetObjectMatrix::rotation() const
 {
+    PXR_NAMESPACE_USING_DIRECTIVE
     TF_CODING_ERROR("Illegal call to unimplemented UsdTransform3dSetObjectMatrix::rotation()");
     return Ufe::Vector3d(0, 0, 0);
 }
 
 Ufe::Vector3d UsdTransform3dSetObjectMatrix::scale() const
 {
+    PXR_NAMESPACE_USING_DIRECTIVE
     TF_CODING_ERROR("Illegal call to unimplemented UsdTransform3dSetObjectMatrix::scale()");
     return Ufe::Vector3d(1, 1, 1);
 }

--- a/lib/mayaUsd/ufe/UsdTransform3dSetObjectMatrix.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dSetObjectMatrix.cpp
@@ -18,6 +18,8 @@
 
 #include <mayaUsd/ufe/Utils.h>
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -43,21 +45,18 @@ UsdTransform3dSetObjectMatrix::Ptr UsdTransform3dSetObjectMatrix::create(
 
 Ufe::Vector3d UsdTransform3dSetObjectMatrix::translation() const
 {
-    PXR_NAMESPACE_USING_DIRECTIVE
     TF_CODING_ERROR("Illegal call to unimplemented UsdTransform3dSetObjectMatrix::translation()");
     return Ufe::Vector3d(0, 0, 0);
 }
 
 Ufe::Vector3d UsdTransform3dSetObjectMatrix::rotation() const
 {
-    PXR_NAMESPACE_USING_DIRECTIVE
     TF_CODING_ERROR("Illegal call to unimplemented UsdTransform3dSetObjectMatrix::rotation()");
     return Ufe::Vector3d(0, 0, 0);
 }
 
 Ufe::Vector3d UsdTransform3dSetObjectMatrix::scale() const
 {
-    PXR_NAMESPACE_USING_DIRECTIVE
     TF_CODING_ERROR("Illegal call to unimplemented UsdTransform3dSetObjectMatrix::scale()");
     return Ufe::Vector3d(1, 1, 1);
 }

--- a/lib/mayaUsd/ufe/UsdTransform3dSetObjectMatrix.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dSetObjectMatrix.h
@@ -94,13 +94,15 @@ public:
 
     UsdTransform3dSetObjectMatrix(
         const Ufe::Transform3d::Ptr& wrapped,
-        const GfMatrix4d&            mlInv,
-        const GfMatrix4d&            mrInv);
+        const PXR_NS::GfMatrix4d&    mlInv,
+        const PXR_NS::GfMatrix4d&    mrInv);
     ~UsdTransform3dSetObjectMatrix() override = default;
 
     //! Create a UsdTransform3dSetObjectMatrix.
-    static UsdTransform3dSetObjectMatrix::Ptr
-    create(const Ufe::Transform3d::Ptr& wrapped, const GfMatrix4d& mlInv, const GfMatrix4d& mrInv);
+    static UsdTransform3dSetObjectMatrix::Ptr create(
+        const Ufe::Transform3d::Ptr& wrapped,
+        const PXR_NS::GfMatrix4d&    mlInv,
+        const PXR_NS::GfMatrix4d&    mrInv);
 
     // Implementation for base class pure virtuals (illegal calls).
     Ufe::Vector3d translation() const override;
@@ -114,8 +116,8 @@ private:
     Ufe::Matrix4d mw(const Ufe::Matrix4d& m) const;
 
     Ufe::Transform3d::Ptr _wrapped;
-    const GfMatrix4d      _mlInv { 1 };
-    const GfMatrix4d      _mrInv { 1 };
+    const PXR_NS::GfMatrix4d _mlInv { 1 };
+    const PXR_NS::GfMatrix4d _mrInv { 1 };
 
 }; // UsdTransform3dSetObjectMatrix
 

--- a/lib/mayaUsd/ufe/UsdTransform3dSetObjectMatrix.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dSetObjectMatrix.h
@@ -115,7 +115,7 @@ public:
 private:
     Ufe::Matrix4d mw(const Ufe::Matrix4d& m) const;
 
-    Ufe::Transform3d::Ptr _wrapped;
+    Ufe::Transform3d::Ptr    _wrapped;
     const PXR_NS::GfMatrix4d _mlInv { 1 };
     const PXR_NS::GfMatrix4d _mrInv { 1 };
 

--- a/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.cpp
@@ -20,7 +20,7 @@
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
-TfToken UsdTranslateUndoableCommand::xlate("xformOp:translate");
+PXR_NS::TfToken UsdTranslateUndoableCommand::xlate("xformOp:translate");
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 UsdTranslateUndoableCommand::UsdTranslateUndoableCommand(

--- a/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.h
@@ -22,8 +22,6 @@
 
 #include <ufe/transform3dUndoableCommands.h>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -33,7 +31,7 @@ namespace ufe {
  */
 class MAYAUSD_CORE_PUBLIC UsdTranslateUndoableCommand
     : public Ufe::TranslateUndoableCommand
-    , public UsdTRSUndoableCommandBase<GfVec3d>
+    , public UsdTRSUndoableCommandBase<PXR_NS::GfVec3d>
 {
 public:
     typedef std::shared_ptr<UsdTranslateUndoableCommand> Ptr;
@@ -80,9 +78,9 @@ protected:
     ~UsdTranslateUndoableCommand() override;
 
 private:
-    static TfToken xlate;
+    static PXR_NS::TfToken xlate;
 
-    TfToken attributeName() const override { return xlate; }
+    PXR_NS::TfToken attributeName() const override { return xlate; }
     void    performImp(double x, double y, double z) override;
     void    addEmptyAttribute() override;
 

--- a/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.h
@@ -81,8 +81,8 @@ private:
     static PXR_NS::TfToken xlate;
 
     PXR_NS::TfToken attributeName() const override { return xlate; }
-    void    performImp(double x, double y, double z) override;
-    void    addEmptyAttribute() override;
+    void            performImp(double x, double y, double z) override;
+    void            addEmptyAttribute() override;
 
 }; // UsdTranslateUndoableCommand
 

--- a/lib/mayaUsd/ufe/UsdUIInfoHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdUIInfoHandler.cpp
@@ -165,10 +165,11 @@ Ufe::UIInfoHandler::Icon UsdUIInfoHandler::treeViewIcon(const Ufe::SceneItem::Pt
             icon.pos = Ufe::UIInfoHandler::LowerRight;
         } else {
             // Composition related metadata.
-            static const std::vector<PXR_NS::TfToken> compKeys = { PXR_NS::SdfFieldKeys->References,
-                                                                   SdfFieldKeys->Payload,
-                                                                   SdfFieldKeys->InheritPaths,
-                                                                   SdfFieldKeys->Specializes };
+            static const std::vector<PXR_NS::TfToken> compKeys
+                = { PXR_NS::SdfFieldKeys->References,
+                    PXR_NS::SdfFieldKeys->Payload,
+                    PXR_NS::SdfFieldKeys->InheritPaths,
+                    PXR_NS::SdfFieldKeys->Specializes };
             for (const auto& k : compKeys) {
                 if (usdItem->prim().HasMetadata(k)) {
                     icon.badgeIcon = "out_USD_CompArcBadge.png";

--- a/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.h
@@ -42,7 +42,7 @@ public:
     void redo() override;
 
     const Ufe::Path& newUfePath() const;
-    UsdPrim          newPrim() const;
+    PXR_NS::UsdPrim  newPrim() const;
 
     static UsdUndoAddNewPrimCommand::Ptr
     create(const UsdSceneItem::Ptr& usdSceneItem, const std::string& name, const std::string& type);

--- a/lib/mayaUsd/ufe/UsdUndoCreateGroupCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoCreateGroupCommand.cpp
@@ -68,7 +68,7 @@ void UsdUndoCreateGroupCommand::execute()
     // newly created group prim to make sure that the model hierarchy remains
     // contiguous.
     const PXR_NS::UsdPrim& parentPrim = _parentItem->prim();
-    if (UsdModelAPI(parentPrim).IsModel()) {
+    if (PXR_NS::UsdModelAPI(parentPrim).IsModel()) {
         const PXR_NS::UsdPrim& groupPrim = _group->prim();
         auto setKindCmd = UsdUndoSetKindCommand::create(groupPrim, PXR_NS::KindTokens->group);
         append(setKindCmd);

--- a/lib/mayaUsd/ufe/UsdUndoDeleteCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDeleteCommand.cpp
@@ -24,7 +24,7 @@
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
-UsdUndoDeleteCommand::UsdUndoDeleteCommand(const UsdPrim& prim)
+UsdUndoDeleteCommand::UsdUndoDeleteCommand(const PXR_NS::UsdPrim& prim)
     : Ufe::UndoableCommand()
     , _prim(prim)
 {
@@ -32,7 +32,7 @@ UsdUndoDeleteCommand::UsdUndoDeleteCommand(const UsdPrim& prim)
 
 UsdUndoDeleteCommand::~UsdUndoDeleteCommand() { }
 
-UsdUndoDeleteCommand::Ptr UsdUndoDeleteCommand::create(const UsdPrim& prim)
+UsdUndoDeleteCommand::Ptr UsdUndoDeleteCommand::create(const PXR_NS::UsdPrim& prim)
 {
     return std::make_shared<UsdUndoDeleteCommand>(prim);
 }

--- a/lib/mayaUsd/ufe/UsdUndoDeleteCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoDeleteCommand.h
@@ -36,7 +36,7 @@ class MAYAUSD_CORE_PUBLIC UsdUndoDeleteCommand : public Ufe::UndoableCommand
 public:
     typedef std::shared_ptr<UsdUndoDeleteCommand> Ptr;
 
-    UsdUndoDeleteCommand(const UsdPrim& prim);
+    UsdUndoDeleteCommand(const PXR_NS::UsdPrim& prim);
     ~UsdUndoDeleteCommand() override;
 
     // Delete the copy/move constructors assignment operators.
@@ -46,14 +46,14 @@ public:
     UsdUndoDeleteCommand& operator=(UsdUndoDeleteCommand&&) = delete;
 
     //! Create a UsdUndoDeleteCommand from a USD prim.
-    static UsdUndoDeleteCommand::Ptr create(const UsdPrim& prim);
+    static UsdUndoDeleteCommand::Ptr create(const PXR_NS::UsdPrim& prim);
 
     UFE_V2(void execute() override;)
     void undo() override;
     void redo() override;
 
 private:
-    UsdPrim _prim;
+    PXR_NS::UsdPrim _prim;
     UFE_V2(UsdUndoableItem _undoableItem;)
 
 #ifndef UFE_V2_FEATURES_AVAILABLE

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
@@ -71,7 +71,7 @@ void UsdUndoDuplicateCommand::execute()
 
     auto prim = ufePathToPrim(_ufeSrcPath);
     auto layer = prim.GetStage()->GetEditTarget().GetLayer();
-    SdfCopySpec(layer, prim.GetPath(), layer, _usdDstPath);
+    PXR_NS::SdfCopySpec(layer, prim.GetPath(), layer, _usdDstPath);
 }
 
 void UsdUndoDuplicateCommand::undo()

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.h
@@ -63,7 +63,7 @@ private:
     bool duplicateRedo();
 #endif
 
-    Ufe::Path _ufeSrcPath;
+    Ufe::Path       _ufeSrcPath;
     PXR_NS::SdfPath _usdDstPath;
 
 }; // UsdUndoDuplicateCommand

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.h
@@ -64,7 +64,7 @@ private:
 #endif
 
     Ufe::Path _ufeSrcPath;
-    SdfPath   _usdDstPath;
+    PXR_NS::SdfPath _usdDstPath;
 
 }; // UsdUndoDuplicateCommand
 

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
@@ -68,11 +68,11 @@ private:
     Ufe::Path _ufeSrcPath;
     Ufe::Path _ufeDstPath;
 
-    SdfPath _usdSrcPath;
-    SdfPath _usdDstPath;
+    PXR_NS::SdfPath _usdSrcPath;
+    PXR_NS::SdfPath _usdDstPath;
 
-    SdfLayerHandle _childLayer;
-    SdfLayerHandle _parentLayer;
+    PXR_NS::SdfLayerHandle _childLayer;
+    PXR_NS::SdfLayerHandle _parentLayer;
 
 }; // UsdUndoInsertChildCommand
 

--- a/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
@@ -42,6 +42,8 @@
 
 #include <cctype>
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 

--- a/lib/mayaUsd/ufe/UsdUndoRenameCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoRenameCommand.h
@@ -57,7 +57,7 @@ private:
     UsdSceneItem::Ptr _ufeDstItem;
 
     PXR_NS::UsdStageWeakPtr _stage;
-    std::string     _newName;
+    std::string             _newName;
 
 }; // UsdUndoRenameCommand
 

--- a/lib/mayaUsd/ufe/UsdUndoRenameCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoRenameCommand.h
@@ -56,7 +56,7 @@ private:
     UsdSceneItem::Ptr _ufeSrcItem;
     UsdSceneItem::Ptr _ufeDstItem;
 
-    UsdStageWeakPtr _stage;
+    PXR_NS::UsdStageWeakPtr _stage;
     std::string     _newName;
 
 }; // UsdUndoRenameCommand

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -37,8 +37,6 @@
 
 #include <cstring> // memcpy
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 UFE_NS_DEF
 {
     class PathSegment;
@@ -54,23 +52,23 @@ namespace ufe {
 
 //! Get USD stage corresponding to argument Maya Dag path.
 MAYAUSD_CORE_PUBLIC
-UsdStageWeakPtr getStage(const Ufe::Path& path);
+PXR_NS::UsdStageWeakPtr getStage(const Ufe::Path& path);
 
 //! Return the ProxyShape node UFE path for the argument stage.
 MAYAUSD_CORE_PUBLIC
-Ufe::Path stagePath(UsdStageWeakPtr stage);
+Ufe::Path stagePath(PXR_NS::UsdStageWeakPtr stage);
 
 //! Return all the USD stages.
 MAYAUSD_CORE_PUBLIC
-TfHashSet<UsdStageWeakPtr, TfHash> getAllStages();
+PXR_NS::TfHashSet<PXR_NS::UsdStageWeakPtr, PXR_NS::TfHash> getAllStages();
 
 //! Get the UFE path segment corresponding to the argument USD path.
 //! If an instanceIndex is provided, the path segment for a point instance with
 //! that USD path and index is returned.
 MAYAUSD_CORE_PUBLIC
 Ufe::PathSegment usdPathToUfePathSegment(
-    const SdfPath& usdPath,
-    int            instanceIndex = UsdImagingDelegate::ALL_INSTANCES);
+    const PXR_NS::SdfPath& usdPath,
+    int                    instanceIndex = PXR_NS::UsdImagingDelegate::ALL_INSTANCES);
 
 //! Get the UFE path representing just the USD prim for the argument UFE path.
 //! Any instance index component at the tail of the given path is removed from
@@ -80,7 +78,7 @@ Ufe::Path stripInstanceIndexFromUfePath(const Ufe::Path& path);
 
 //! Return the USD prim corresponding to the argument UFE path.
 MAYAUSD_CORE_PUBLIC
-UsdPrim ufePathToPrim(const Ufe::Path& path);
+PXR_NS::UsdPrim ufePathToPrim(const Ufe::Path& path);
 
 //! Return the instance index corresponding to the argument UFE path if it
 //! represents a point instance.
@@ -99,11 +97,11 @@ createSiblingSceneItem(const Ufe::Path& ufeSrcPath, const std::string& siblingNa
 //! Split the source name into a base name and a numerical suffix (set to
 //! 1 if absent).  Increment the numerical suffix until name is unique.
 MAYAUSD_CORE_PUBLIC
-std::string uniqueName(const TfToken::HashSet& existingNames, std::string srcName);
+std::string uniqueName(const PXR_NS::TfToken::HashSet& existingNames, std::string srcName);
 
 //! Return a unique child name.
 MAYAUSD_CORE_PUBLIC
-std::string uniqueChildName(const UsdPrim& parent, const std::string& name);
+std::string uniqueChildName(const PXR_NS::UsdPrim& parent, const std::string& name);
 
 //! Return if a Maya node type is derived from the gateway node type.
 MAYAUSD_CORE_PUBLIC
@@ -118,13 +116,13 @@ Ufe::PathSegment dagPathToPathSegment(const MDagPath& dagPath);
 //! Get the time along the argument path.  A gateway node (i.e. proxy shape)
 //! along the path can transform Maya's time (e.g. with scale and offset).
 MAYAUSD_CORE_PUBLIC
-UsdTimeCode getTime(const Ufe::Path& path);
+PXR_NS::UsdTimeCode getTime(const Ufe::Path& path);
 
 //! Return the non-default purposes of the gateway node (i.e. proxy shape)
 //! along the argument path.  Only those purposes that are true are returned.
 //! The default purpose is not returned, and is considered implicit.
 MAYAUSD_CORE_PUBLIC
-TfTokenVector getProxyShapePurposes(const Ufe::Path& path);
+PXR_NS::TfTokenVector getProxyShapePurposes(const Ufe::Path& path);
 
 //! Send notification for data model changes
 template <class T>
@@ -145,7 +143,7 @@ inline UsdSceneItem::Ptr downcast(const Ufe::SceneItem::Ptr& item)
 }
 
 //! Copy the argument matrix into the return matrix.
-inline Ufe::Matrix4d toUfe(const GfMatrix4d& src)
+inline Ufe::Matrix4d toUfe(const PXR_NS::GfMatrix4d& src)
 {
     Ufe::Matrix4d dst;
     std::memcpy(&dst.matrix[0][0], src.GetArray(), sizeof(double) * 16);
@@ -153,15 +151,18 @@ inline Ufe::Matrix4d toUfe(const GfMatrix4d& src)
 }
 
 //! Copy the argument matrix into the return matrix.
-inline GfMatrix4d toUsd(const Ufe::Matrix4d& src)
+inline PXR_NS::GfMatrix4d toUsd(const Ufe::Matrix4d& src)
 {
-    GfMatrix4d dst;
+    PXR_NS::GfMatrix4d dst;
     std::memcpy(dst.GetArray(), &src.matrix[0][0], sizeof(double) * 16);
     return dst;
 }
 
 //! Copy the argument vector into the return vector.
-inline Ufe::Vector3d toUfe(const GfVec3d& src) { return Ufe::Vector3d(src[0], src[1], src[2]); }
+inline Ufe::Vector3d toUfe(const PXR_NS::GfVec3d& src)
+{
+    return Ufe::Vector3d(src[0], src[1], src[2]);
+}
 
 //! Filter a source selection by removing descendants of filterPath.
 Ufe::Selection removeDescendants(const Ufe::Selection& src, const Ufe::Path& filterPath);

--- a/lib/mayaUsd/ufe/XformOpUtils.cpp
+++ b/lib/mayaUsd/ufe/XformOpUtils.cpp
@@ -18,6 +18,8 @@
 
 #include <pxr/usd/usdGeom/xformable.h>
 
+PXR_NAMESPACE_USING_DIRECTIVE
+
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 

--- a/lib/mayaUsd/ufe/XformOpUtils.h
+++ b/lib/mayaUsd/ufe/XformOpUtils.h
@@ -23,32 +23,30 @@
 
 #include <vector>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
-GfMatrix4d computeLocalInclusiveTransform(
-    const std::vector<UsdGeomXformOp>&          ops,
-    std::vector<UsdGeomXformOp>::const_iterator endOp,
-    const UsdTimeCode&                          time);
+PXR_NS::GfMatrix4d computeLocalInclusiveTransform(
+    const std::vector<PXR_NS::UsdGeomXformOp>&          ops,
+    std::vector<PXR_NS::UsdGeomXformOp>::const_iterator endOp,
+    const PXR_NS::UsdTimeCode&                          time);
 
-GfMatrix4d computeLocalInclusiveTransform(
-    const UsdPrim&        prim,
-    const UsdGeomXformOp& op,
-    const UsdTimeCode&    time);
+PXR_NS::GfMatrix4d computeLocalInclusiveTransform(
+    const PXR_NS::UsdPrim&        prim,
+    const PXR_NS::UsdGeomXformOp& op,
+    const PXR_NS::UsdTimeCode&    time);
 
-GfMatrix4d computeLocalExclusiveTransform(
-    const std::vector<UsdGeomXformOp>&          ops,
-    std::vector<UsdGeomXformOp>::const_iterator endOp,
-    const UsdTimeCode&                          time);
+PXR_NS::GfMatrix4d computeLocalExclusiveTransform(
+    const std::vector<PXR_NS::UsdGeomXformOp>&          ops,
+    std::vector<PXR_NS::UsdGeomXformOp>::const_iterator endOp,
+    const PXR_NS::UsdTimeCode&                          time);
 
-GfMatrix4d computeLocalExclusiveTransform(
-    const UsdPrim&        prim,
-    const UsdGeomXformOp& op,
-    const UsdTimeCode&    time);
+PXR_NS::GfMatrix4d computeLocalExclusiveTransform(
+    const PXR_NS::UsdPrim&        prim,
+    const PXR_NS::UsdGeomXformOp& op,
+    const PXR_NS::UsdTimeCode&    time);
 
-std::vector<UsdGeomXformOp> getOrderedXformOps(const UsdPrim& prim);
+std::vector<PXR_NS::UsdGeomXformOp> getOrderedXformOps(const PXR_NS::UsdPrim& prim);
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/wrapUtils.cpp
+++ b/lib/mayaUsd/ufe/wrapUtils.cpp
@@ -187,7 +187,7 @@ int ufePathToInstanceIndex(const std::string& ufePathString)
     // If there are fewer than two segments, there cannot be a USD segment, so
     // return ALL_INSTANCES.
     if (path.getSegments().size() < 2u) {
-        return UsdImagingDelegate::ALL_INSTANCES;
+        return PXR_NS::UsdImagingDelegate::ALL_INSTANCES;
     }
 
     return ufe::ufePathToInstanceIndex(path);

--- a/lib/mayaUsd/ufe/wrapUtils.cpp
+++ b/lib/mayaUsd/ufe/wrapUtils.cpp
@@ -38,14 +38,14 @@ using namespace MayaUsd;
 using namespace boost::python;
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
-UsdPrim getPrimFromRawItem(uint64_t rawItem)
+PXR_NS::UsdPrim getPrimFromRawItem(uint64_t rawItem)
 {
     Ufe::SceneItem*    item = reinterpret_cast<Ufe::SceneItem*>(rawItem);
     ufe::UsdSceneItem* usdItem = dynamic_cast<ufe::UsdSceneItem*>(item);
     if (nullptr != usdItem) {
         return usdItem->prim();
     }
-    return UsdPrim();
+    return PXR_NS::UsdPrim();
 }
 
 std::string getNodeNameFromRawItem(uint64_t rawItem)
@@ -69,7 +69,7 @@ std::string getNodeTypeFromRawItem(uint64_t rawItem)
 }
 #endif
 
-UsdStageWeakPtr getStage(const std::string& ufePathString)
+PXR_NS::UsdStageWeakPtr getStage(const std::string& ufePathString)
 {
 #ifdef UFE_V2_FEATURES_AVAILABLE
     return ufe::getStage(Ufe::PathString::path(ufePathString));
@@ -90,7 +90,7 @@ UsdStageWeakPtr getStage(const std::string& ufePathString)
 #endif
 }
 
-std::string stagePath(UsdStageWeakPtr stage)
+std::string stagePath(PXR_NS::UsdStageWeakPtr stage)
 {
     // Proxy shape node's UFE path is a single segment, so no need to separate
     // segments with commas.
@@ -98,8 +98,8 @@ std::string stagePath(UsdStageWeakPtr stage)
 }
 
 std::string usdPathToUfePathSegment(
-    const SdfPath& usdPath,
-    int            instanceIndex = UsdImagingDelegate::ALL_INSTANCES)
+    const PXR_NS::SdfPath& usdPath,
+    int                    instanceIndex = PXR_NS::UsdImagingDelegate::ALL_INSTANCES)
 {
     return ufe::usdPathToUfePathSegment(usdPath, instanceIndex).string();
 }
@@ -113,7 +113,7 @@ static Ufe::Path _UfeV1StringToUsdPath(const std::string& ufePathString)
 
     // The path string is a list of segment strings separated by ',' comma
     // separator.
-    auto segmentStrings = TfStringTokenize(ufePathString, ",");
+    auto segmentStrings = PXR_NS::TfStringTokenize(ufePathString, ",");
 
     // If there are fewer than two segments, there cannot be a USD segment, so
     // return an invalid path.
@@ -137,7 +137,7 @@ static Ufe::Path _UfeV1StringToUsdPath(const std::string& ufePathString)
 }
 #endif
 
-UsdTimeCode getTime(const std::string& pathStr)
+PXR_NS::UsdTimeCode getTime(const std::string& pathStr)
 {
     const Ufe::Path path =
 #ifdef UFE_V2_FEATURES_AVAILABLE
@@ -160,7 +160,7 @@ std::string stripInstanceIndexFromUfePath(const std::string& ufePathString)
 #endif
 }
 
-UsdPrim ufePathToPrim(const std::string& ufePathString)
+PXR_NS::UsdPrim ufePathToPrim(const std::string& ufePathString)
 {
 #ifdef UFE_V2_FEATURES_AVAILABLE
     return ufe::ufePathToPrim(Ufe::PathString::path(ufePathString));
@@ -170,7 +170,7 @@ UsdPrim ufePathToPrim(const std::string& ufePathString)
     // If there are fewer than two segments, there cannot be a USD segment, so
     // return an invalid UsdPrim.
     if (path.getSegments().size() < 2u) {
-        return UsdPrim();
+        return PXR_NS::UsdPrim();
     }
 
     return ufe::ufePathToPrim(path);
@@ -194,7 +194,7 @@ int ufePathToInstanceIndex(const std::string& ufePathString)
 #endif
 }
 
-TfTokenVector getProxyShapePurposes(const std::string& ufePathString)
+PXR_NS::TfTokenVector getProxyShapePurposes(const std::string& ufePathString)
 {
     auto path =
 #ifdef UFE_V2_FEATURES_AVAILABLE
@@ -224,7 +224,7 @@ void wrapUtils()
     def("stagePath", stagePath);
     def("usdPathToUfePathSegment",
         usdPathToUfePathSegment,
-        (arg("usdPath"), arg("instanceIndex") = UsdImagingDelegate::ALL_INSTANCES));
+        (arg("usdPath"), arg("instanceIndex") = PXR_NS::UsdImagingDelegate::ALL_INSTANCES));
     def("getTime", getTime);
     def("stripInstanceIndexFromUfePath", stripInstanceIndexFromUfePath, (arg("ufePathString")));
     def("ufePathToPrim", ufePathToPrim);


### PR DESCRIPTION
This pull request removes PXR_NAMESPACE_USING_DIRECTIVE statements from all files in lib/mayaUsd/ufe, in favor of using the explicit PXR_NS namespace for Pixar USD data types.  This ensures that headers don't propagate the using directive where they are themselves included.