### PR TITLE
move import of ufeSelectCmd inside selectPath() function in ufeUtils

### DIFF
--- a/test/testUtils/ufeUtils.py
+++ b/test/testUtils/ufeUtils.py
@@ -21,11 +21,7 @@
 """
 
 import ufe
-try:
-    from maya.internal.ufeSupport import ufeSelectCmd
-except ImportError:
-    # Maya 2019 and 2020 don't have ufeSupport plugin, so use fallback.
-    from ufeScripts import ufeSelectCmd
+
 
 def getUfeGlobalSelectionList():
     """ 
@@ -46,6 +42,15 @@ def selectPath(path, replace=False):
             replace (bool=False): Replace the selection with
                                     given UFE path
     """
+    # Do this import inside this function rather than at the top of the file
+    # so that the module can be imported and ufeFeatureSetVersion() can be
+    # called prior to maya.standalone.initialize().
+    try:
+        from maya.internal.ufeSupport import ufeSelectCmd
+    except ImportError:
+        # Maya 2019 and 2020 don't have ufeSupport plugin, so use fallback.
+        from ufeScripts import ufeSelectCmd
+
     sceneItem = ufe.Hierarchy.createItem(path)
     if replace:
         selection = ufe.Selection()


### PR DESCRIPTION
Attempting to import `ufeSelectCmd` before `maya.standalone.initialize()` has been called will raise an `ImportError` and cause tests to fail. For example, this would be the case for test cases that are decorated with the `unittest.skipUnless()` decorator and use `ufeUtils.ufeFeatureSetVersion()`, since the decorator will be executed before `setUpClass` has a chance to run and initialize `maya.standalone`.

This change addresses that by pushing the import of `ufeSelectCmd` into the `selectPath()` function where it is used rather than having it at the top of the file. This ensures that the `ufeUtils` module can be imported and `ufeUtils.ufeFeatureSetVersion()` can be called safely before `maya.standalone.initialize()`.

Note that this does not currently manifest as an issue when running the unit tests using the CMake infrastructure in this repo since we inject the Maya standalone initialization early in every test:
https://github.com/Autodesk/maya-usd/blob/d1fe7cd81434fde47119a2f90fac5c7065c94937/cmake/test.cmake#L154

We do not do that in our internal test infrastructure, which is why this is problematic for us. Ultimately, it seems like it would be preferable not do to that in CMake either and make sure that every test script can run successfully on its own without requiring additional patching from the test harness. There are likely other changes along the lines of this one needed to make that a reality, but this is hopefully one more small step in that direction.