### PR TITLE
Remove use of unnecessary pxr namespace

### DIFF
--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -71,7 +71,7 @@ void MayaSessionState::setStageEntry(StageEntry const& inEntry)
 
 bool MayaSessionState::getStageEntry(StageEntry* out_stageEntry, const MString& shapePath)
 {
-    pxr::UsdPrim prim;
+    UsdPrim prim;
 
     MObject shapeObj;
     MStatus status = UsdMayaUtil::GetMObjectByName(shapePath.asChar(), shapeObj);


### PR DESCRIPTION
With the addition of PXR_NAMESPACE_USING_DIRECTIVE there is no need to
specify the pxr namespace for USD types.