### PR TITLE
Minimize name-based lookup of proxy shape nodes.

### DIFF
--- a/lib/mayaUsd/ufe/UsdStageMap.cpp
+++ b/lib/mayaUsd/ufe/UsdStageMap.cpp
@@ -23,10 +23,6 @@
 
 #include <maya/MFnDagNode.h>
 
-#ifdef UFE_V2_FEATURES_AVAILABLE
-#include <ufe/pathString.h>
-#endif
-
 #include <cassert>
 
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -195,11 +191,7 @@ void UsdStageMap::rebuildIfDirty()
 
     for (const auto& psn : ProxyShapeHandler::getAllNames()) {
         addItem(
-#ifdef UFE_V2_FEATURES_AVAILABLE
-            Ufe::PathString::path(psn));
-#else
             Ufe::Path(Ufe::PathSegment("|world" + psn, getMayaRunTimeId(), '|')));
-#endif
     }
     fDirty = false;
 }

--- a/lib/mayaUsd/ufe/UsdStageMap.cpp
+++ b/lib/mayaUsd/ufe/UsdStageMap.cpp
@@ -190,8 +190,7 @@ void UsdStageMap::rebuildIfDirty()
         return;
 
     for (const auto& psn : ProxyShapeHandler::getAllNames()) {
-        addItem(
-            Ufe::Path(Ufe::PathSegment("|world" + psn, getMayaRunTimeId(), '|')));
+        addItem(Ufe::Path(Ufe::PathSegment("|world" + psn, getMayaRunTimeId(), '|')));
     }
     fDirty = false;
 }

--- a/lib/mayaUsd/ufe/UsdStageMap.cpp
+++ b/lib/mayaUsd/ufe/UsdStageMap.cpp
@@ -112,16 +112,22 @@ void UsdStageMap::addItem(const Ufe::Path& path)
         return;
     }
 
-    // We've just done a name-based lookup of the proxy shape, so the stage
-    // cannot be null.
-    auto stage = objToStage(proxyShape.object());
+    // Non-const MObject& requires an lvalue.  We've just done a name-based
+    // lookup of the proxy shape, so the stage cannot be null.
+    auto obj = proxyShape.object();
+    auto stage = objToStage(obj);
     TF_AXIOM(stage);
 
     fPathToObject[path] = proxyShape;
     fStageToObject[stage] = proxyShape;
 }
 
-UsdStageWeakPtr UsdStageMap::stage(const Ufe::Path& path) { return objToStage(proxyShape(path)); }
+UsdStageWeakPtr UsdStageMap::stage(const Ufe::Path& path)
+{
+    // Non-const MObject& requires an lvalue.
+    auto obj = proxyShape(path);
+    return objToStage(obj);
+}
 
 MObject UsdStageMap::proxyShape(const Ufe::Path& path)
 {

--- a/lib/mayaUsd/ufe/UsdStageMap.cpp
+++ b/lib/mayaUsd/ufe/UsdStageMap.cpp
@@ -15,11 +15,17 @@
 //
 #include "UsdStageMap.h"
 
+#include <mayaUsd/nodes/proxyShapeBase.h>
+#include <mayaUsd/ufe/Global.h>
 #include <mayaUsd/ufe/ProxyShapeHandler.h>
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/utils/util.h>
 
 #include <maya/MFnDagNode.h>
+
+#ifdef UFE_V2_FEATURES_AVAILABLE
+#include <ufe/pathString.h>
+#endif
 
 #include <cassert>
 
@@ -27,9 +33,9 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace {
 
-MObjectHandle proxyShapeHandle(const Ufe::Path& path)
+MObjectHandle nameLookup(const Ufe::Path& path)
 {
-    // Get the MObjectHandle from the tail of the MDagPath.	 Remove the leading
+    // Get the MObjectHandle from the tail of the MDagPath.  Remove the leading
     // '|world' component.
     auto          noWorld = path.popHead().string();
     auto          dagPath = UsdMayaUtil::nameToDagPath(noWorld);
@@ -53,6 +59,30 @@ Ufe::Path firstPath(const MObjectHandle& handle)
     return MayaUsd::ufe::dagPathToUfe(dagPath);
 }
 
+UsdStageWeakPtr objToStage(MObject& obj)
+{
+    if (obj.isNull()) {
+        return nullptr;
+    }
+
+    // Get the stage from the proxy shape.
+    MFnDependencyNode fn(obj);
+    auto              ps = dynamic_cast<MayaUsdProxyShapeBase*>(fn.userNode());
+    TF_VERIFY(ps);
+
+    return ps->getUsdStage();
+}
+
+inline Ufe::Path::Segments::size_type nbPathSegments(const Ufe::Path& path)
+{
+    return
+#ifdef UFE_V2_FEATURES_AVAILABLE
+        path.nbSegments();
+#else
+        path.getSegments().size();
+#endif
+}
+
 } // namespace
 
 namespace MAYAUSD_NS_DEF {
@@ -68,15 +98,10 @@ UsdStageMap g_StageMap;
 // UsdStageMap
 //------------------------------------------------------------------------------
 
-void UsdStageMap::addItem(const Ufe::Path& path, UsdStageWeakPtr stage)
+void UsdStageMap::addItem(const Ufe::Path& path)
 {
     // We expect a path to the proxy shape node, therefore a single segment.
-    auto nbSegments =
-#ifdef UFE_V2_FEATURES_AVAILABLE
-        path.nbSegments();
-#else
-        path.getSegments().size();
-#endif
+    auto nbSegments = nbPathSegments(path);
     if (nbSegments != 1) {
         TF_CODING_ERROR(
             "A proxy shape node path can have only one segment, path '%s' has %lu",
@@ -85,32 +110,53 @@ void UsdStageMap::addItem(const Ufe::Path& path, UsdStageWeakPtr stage)
         return;
     }
 
-    // Convert the tail of the UFE path to an MObjectHandle.
-    auto proxyShape = proxyShapeHandle(path);
+    // Convert the UFE path to an MObjectHandle.
+    auto proxyShape = nameLookup(path);
     if (!proxyShape.isValid()) {
         return;
     }
 
-    // Could get the stage from the proxy shape object in the stage() method,
-    // but since it's given here, simply store it.
-    fObjectToStage[proxyShape] = stage;
+    // We've just done a name-based lookup of the proxy shape, so the stage
+    // cannot be null.
+    auto stage = objToStage(proxyShape.object());
+    TF_AXIOM(stage);
+
+    fPathToObject[path] = proxyShape;
     fStageToObject[stage] = proxyShape;
 }
 
-UsdStageWeakPtr UsdStageMap::stage(const Ufe::Path& path)
+UsdStageWeakPtr UsdStageMap::stage(const Ufe::Path& path) { return objToStage(proxyShape(path)); }
+
+MObject UsdStageMap::proxyShape(const Ufe::Path& path)
 {
+    const auto& singleSegmentPath
+        = nbPathSegments(path) == 1 ? path : Ufe::Path(path.getSegments()[0]);
+
+    auto iter = fPathToObject.find(singleSegmentPath);
+    if (iter != std::end(fPathToObject)) {
+        return iter->second.object();
+    }
+
+    // Did not find object in cache, either because the cache is stale, or
+    // because the object does not exist.  Rebuild the cache and try again.
+    setDirty();
     rebuildIfDirty();
 
-    auto proxyShape = proxyShapeHandle(path);
-    if (!proxyShape.isValid()) {
+    // At this point the cache is rebuilt, so lookup failure means the object
+    // doesn't exist.
+    iter = fPathToObject.find(singleSegmentPath);
+    return iter == std::end(fPathToObject) ? MObject() : iter->second.object();
+}
+
+MayaUsdProxyShapeBase* UsdStageMap::proxyShapeNode(const Ufe::Path& path)
+{
+    auto obj = proxyShape(path);
+    if (obj.isNull()) {
         return nullptr;
     }
 
-    // A stage is bound to a single Dag proxy shape.
-    auto iter = fObjectToStage.find(proxyShape);
-    if (iter != std::end(fObjectToStage))
-        return iter->second;
-    return nullptr;
+    MFnDependencyNode fn(obj);
+    return dynamic_cast<MayaUsdProxyShapeBase*>(fn.userNode());
 }
 
 Ufe::Path UsdStageMap::path(UsdStageWeakPtr stage)
@@ -129,15 +175,15 @@ UsdStageMap::StageSet UsdStageMap::allStages()
     rebuildIfDirty();
 
     StageSet stages;
-    for (const auto& pair : fObjectToStage) {
-        stages.insert(pair.second);
+    for (const auto& pair : fPathToObject) {
+        stages.insert(stage(pair.first));
     }
     return stages;
 }
 
 void UsdStageMap::setDirty()
 {
-    fObjectToStage.clear();
+    fPathToObject.clear();
     fStageToObject.clear();
     fDirty = true;
 }
@@ -147,12 +193,13 @@ void UsdStageMap::rebuildIfDirty()
     if (!fDirty)
         return;
 
-    auto proxyShapeNames = ProxyShapeHandler::getAllNames();
-    for (const auto& psn : proxyShapeNames) {
-        MDagPath  dag = UsdMayaUtil::nameToDagPath(psn);
-        Ufe::Path ufePath = dagPathToUfe(dag);
-        auto      stage = ProxyShapeHandler::dagPathToStage(psn);
-        addItem(ufePath, stage);
+    for (const auto& psn : ProxyShapeHandler::getAllNames()) {
+        addItem(
+#ifdef UFE_V2_FEATURES_AVAILABLE
+            Ufe::PathString::path(psn));
+#else
+            Ufe::Path(Ufe::PathSegment("|world" + psn, getMayaRunTimeId(), '|')));
+#endif
     }
     fDirty = false;
 }

--- a/lib/mayaUsd/ufe/UsdStageMap.h
+++ b/lib/mayaUsd/ufe/UsdStageMap.h
@@ -27,33 +27,31 @@
 
 #include <unordered_map>
 
-// Allow for use of MObjectHandle with std::unordered_map.
-namespace std {
-template <> struct hash<MObjectHandle>
-{
-    std::size_t operator()(const MObjectHandle& handle) const
-    {
-        return static_cast<std::size_t>(handle.hashCode());
-    }
-};
-} // namespace std
+// Pending rework of mayaUsd namespaces, MayaUsdProxyShapeBase is in the Pixar
+// namespace.  PPT, 9-Mar-2021.
+PXR_NAMESPACE_OPEN_SCOPE
+class MayaUsdProxyShapeBase;
+PXR_NAMESPACE_CLOSE_SCOPE
 
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
 //! \brief USD Stage Map
 /*!
-        Two-way map of proxy shape UFE path to corresponding stage.
+    Two-way map of proxy shape UFE path to corresponding stage.
 
-        We will assume that	a USD proxy shape will not be instanced (even though
-        nothing in the data model prevents it).  To support renaming and repathing,
-        we store an MObjectHandle in the maps, which is invariant to renaming and
-        repathing, and compute the path on access.  This is slower than a scheme
-        where we cache using the Ufe::Path, but such a cache must be refreshed on
-        rename and repath, which is non-trivial, since there is no guarantee on the
-        order of notification of Ufe observers.  An earlier implementation with
-        rename observation had the Maya Outliner (which observes rename) access the
-        UsdStageMap on rename before the UsdStageMap had been updated.
+    We will assume that	a USD proxy shape will not be instanced (even though
+    nothing in the data model prevents it).  To generalized access to the
+    underlying node, we store an MObjectHandle in the maps.
+
+    The cache is refreshed on access to a stage given a path which cannot be
+    found.  In this way, the cache does not need to observe the Maya data
+    model, and we avoid order of notification problems where one observer would
+    need to access the cache before it is refreshed, since there is no
+    guarantee on the order of notification of Ufe observers.  An earlier
+    implementation with rename observation had the Maya Outliner (which
+    observes rename) access the UsdStageMap on rename before the UsdStageMap
+    had been updated.
 */
 class MAYAUSD_CORE_PUBLIC UsdStageMap
 {
@@ -69,8 +67,16 @@ public:
     UsdStageMap(UsdStageMap&&) = delete;
     UsdStageMap& operator=(UsdStageMap&&) = delete;
 
-    //! Get USD stage corresponding to argument Maya Dag path.
+    //! Get USD stage for the first segment of the argument path.
     PXR_NS::UsdStageWeakPtr stage(const Ufe::Path& path);
+
+    //! Return the ProxyShape object for the first segment of the argument
+    //! path.  If no such proxy shape exists, returns a null MObject.
+    MObject proxyShape(const Ufe::Path& path);
+
+    //! Return the ProxyShape node for the first segment of the argument path.
+    //! If no such proxy shape node exists, returns a null pointer.
+    PXR_NS::MayaUsdProxyShapeBase* proxyShapeNode(const Ufe::Path& path);
 
     //! Return the ProxyShape node UFE path for the argument stage.
     Ufe::Path path(PXR_NS::UsdStageWeakPtr stage);
@@ -86,14 +92,14 @@ public:
     bool isDirty() const { return fDirty; }
 
 private:
-    void addItem(const Ufe::Path& path, PXR_NS::UsdStageWeakPtr stage);
+    void addItem(const Ufe::Path& path);
     void rebuildIfDirty();
 
 private:
     // We keep two maps for fast lookup when there are many proxy shapes.
-    using ObjectToStage = std::unordered_map<MObjectHandle, PXR_NS::UsdStageWeakPtr>;
+    using PathToObject = std::unordered_map<Ufe::Path, MObjectHandle>;
     using StageToObject = PXR_NS::TfHashMap<PXR_NS::UsdStageWeakPtr, MObjectHandle, PXR_NS::TfHash>;
-    ObjectToStage fObjectToStage;
+    PathToObject  fPathToObject;
     StageToObject fStageToObject;
     bool          fDirty { true };
 


### PR DESCRIPTION
The UsdStageMap was performing name-based lookup of proxy shape nodes on every access.  This has been replaced with a scheme that uses an unordered map index by Ufe::Path, which are hashable.