### PR TITLE
guard against past-end iterator invalidation

### DIFF
--- a/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
@@ -393,7 +393,7 @@ UsdPrim UsdMayaShadingModeExportContext::MakeStandardMaterialPrim(
             return ret;
         }
         MString seName = seDepNode.name();
-        materialName = MNamespace::stripNamespaceFromName(seName).asChar();
+        materialName = seName.asChar();
     }
 
     materialName = UsdMayaUtil::SanitizeName(materialName);
@@ -545,20 +545,12 @@ public:
         if (largestSize) {
             TfTokenVector::const_iterator itNode = _nodesWithUVInput.cbegin();
             TfTokenVector::const_iterator itName = largestSet.cbegin();
-            for (; itNode != _nodesWithUVInput.cend(); ++itNode) {
+            for (; itNode != _nodesWithUVInput.cend(); ++itNode, ++itName) {
                 TfToken inputName(
                     TfStringPrintf("%s:%s", itNode->GetText(), _tokens->varname.GetText()));
                 UsdShadeInput materialInput = material.GetInput(inputName);
-                // NOTE: (yliangsiew) If we have a mismatch in array sizes, we default to assigning
-                // the most common mapping to the materials that don't have inputs.
-                if (itName != largestSet.cend()) {
-                    materialInput.Set(*itName);
-                    ++itName;
-                } else {
-                    --itName;
-                    materialInput.Set(*itName);
-                    ++itName;
-                }
+                TF_VERIFY(itName != largestSet.cend());
+                materialInput.Set(*itName);
             }
             _uvNamesToMaterial[largestSet] = material;
         }

--- a/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
@@ -545,11 +545,20 @@ public:
         if (largestSize) {
             TfTokenVector::const_iterator itNode = _nodesWithUVInput.cbegin();
             TfTokenVector::const_iterator itName = largestSet.cbegin();
-            for (; itNode != _nodesWithUVInput.cend() && itName != largestSet.cend(); ++itNode, ++itName) {
+            for (; itNode != _nodesWithUVInput.cend(); ++itNode) {
                 TfToken inputName(
                     TfStringPrintf("%s:%s", itNode->GetText(), _tokens->varname.GetText()));
                 UsdShadeInput materialInput = material.GetInput(inputName);
-                materialInput.Set(*itName);
+                // NOTE: (yliangsiew) If we have a mismatch in array sizes, we default to assigning
+                // the most common mapping to the materials that don't have inputs.
+                if (itName != largestSet.cend()) {
+                    materialInput.Set(*itName);
+                    ++itName;
+                } else {
+                    --itName;
+                    materialInput.Set(*itName);
+                    ++itName;
+                }
             }
             _uvNamesToMaterial[largestSet] = material;
         }

--- a/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
@@ -545,7 +545,7 @@ public:
         if (largestSize) {
             TfTokenVector::const_iterator itNode = _nodesWithUVInput.cbegin();
             TfTokenVector::const_iterator itName = largestSet.cbegin();
-            for (; itNode != _nodesWithUVInput.cend(); ++itNode, ++itName) {
+            for (; itNode != _nodesWithUVInput.cend() && itName != largestSet.cend(); ++itNode, ++itName) {
                 TfToken inputName(
                     TfStringPrintf("%s:%s", itNode->GetText(), _tokens->varname.GetText()));
                 UsdShadeInput materialInput = material.GetInput(inputName);

--- a/lib/usd/translators/shading/usdFileTextureWriter.cpp
+++ b/lib/usd/translators/shading/usdFileTextureWriter.cpp
@@ -213,11 +213,8 @@ PxrUsdTranslators_FileTextureWriter::PxrUsdTranslators_FileTextureWriter(
     }
 
     if (materialSchema) {
-        MString       absoluteName = depNodeFn.absoluteName();
-        TfToken       inputName(TfStringPrintf(
-            "%s:%s",
-            absoluteName.substring(1, absoluteName.length() - 1).asChar(),
-            _tokens->varname.GetText()));
+        TfToken inputName(
+            TfStringPrintf("%s:%s", depNodeFn.name().asChar(), _tokens->varname.GetText()));
         UsdShadeInput materialInput
             = materialSchema.CreateInput(inputName, SdfValueTypeNames->Token);
         materialInput.Set(UsdUtilsGetPrimaryUVSetName());

--- a/lib/usd/translators/shading/usdFileTextureWriter.cpp
+++ b/lib/usd/translators/shading/usdFileTextureWriter.cpp
@@ -213,8 +213,11 @@ PxrUsdTranslators_FileTextureWriter::PxrUsdTranslators_FileTextureWriter(
     }
 
     if (materialSchema) {
-        TfToken inputName(
-            TfStringPrintf("%s:%s", depNodeFn.name().asChar(), _tokens->varname.GetText()));
+        MString       absoluteName = depNodeFn.absoluteName();
+        TfToken       inputName(TfStringPrintf(
+            "%s:%s",
+            absoluteName.substring(1, absoluteName.length() - 1).asChar(),
+            _tokens->varname.GetText()));
         UsdShadeInput materialInput
             = materialSchema.CreateInput(inputName, SdfValueTypeNames->Token);
         materialInput.Set(UsdUtilsGetPrimaryUVSetName());


### PR DESCRIPTION
Hi:

This PR fixes a crash we're seeing on some exports where layered shaders are involved, leading to a mistaken assumption in array sizes and resulting in past-the-end-iterator invalidation.

Please review and raise any concerns.