### PR TITLE
MAYA-106484 add single-channel half-float EXR support.

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -483,6 +483,10 @@ _LoadTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& uvSca
         desc.fFormat = MHWRender::kR32_FLOAT;
         texture = textureMgr->acquireTexture(path.c_str(), desc, spec.data);
         break;
+    case HioFormatFloat16:
+        desc.fFormat = MHWRender::kR16_FLOAT;
+        texture = textureMgr->acquireTexture(path.c_str(), desc, spec.data);
+        break;
     case HioFormatUNorm8:
         desc.fFormat = MHWRender::kR8_UNORM;
         texture = textureMgr->acquireTexture(path.c_str(), desc, spec.data);


### PR DESCRIPTION
Handle teh case where we receive a single-channel half-float texture. The support in Maya already existeed, only the correspondence in the switch/case was missing.