### PR TITLE
Explicitly case Ar path string to ArResolvedPath

### DIFF
--- a/lib/usd/translators/shading/usdUVTextureReader.cpp
+++ b/lib/usd/translators/shading/usdUVTextureReader.cpp
@@ -266,7 +266,8 @@ bool PxrMayaUsdUVTexture_Reader::Read(UsdMayaPrimReaderContext* context)
             && !filePath.empty() && ArIsPackageRelativePath(filePath)) {
             // NOTE: (yliangsiew) Package-relatve path means that we are inside of a USDZ file.
             ArResolver& arResolver = ArGetResolver(); // NOTE: (yliangsiew) This is cached.
-            std::shared_ptr<ArAsset> assetPtr = arResolver.OpenAsset(filePath);
+            std::shared_ptr<ArAsset> assetPtr = arResolver.OpenAsset(
+                ArResolvedPath(filePath));
             if (assetPtr == nullptr) {
                 TF_WARN(
                     "The file: %s could not be found within the USDZ archive for extraction.",

--- a/lib/usd/translators/shading/usdUVTextureReader.cpp
+++ b/lib/usd/translators/shading/usdUVTextureReader.cpp
@@ -266,8 +266,7 @@ bool PxrMayaUsdUVTexture_Reader::Read(UsdMayaPrimReaderContext* context)
             && !filePath.empty() && ArIsPackageRelativePath(filePath)) {
             // NOTE: (yliangsiew) Package-relatve path means that we are inside of a USDZ file.
             ArResolver& arResolver = ArGetResolver(); // NOTE: (yliangsiew) This is cached.
-            std::shared_ptr<ArAsset> assetPtr = arResolver.OpenAsset(
-                ArResolvedPath(filePath));
+            std::shared_ptr<ArAsset> assetPtr = arResolver.OpenAsset(ArResolvedPath(filePath));
             if (assetPtr == nullptr) {
                 TF_WARN(
                     "The file: %s could not be found within the USDZ archive for extraction.",

--- a/lib/usd/translators/shading/usdUVTextureReader.cpp
+++ b/lib/usd/translators/shading/usdUVTextureReader.cpp
@@ -266,7 +266,12 @@ bool PxrMayaUsdUVTexture_Reader::Read(UsdMayaPrimReaderContext* context)
             && !filePath.empty() && ArIsPackageRelativePath(filePath)) {
             // NOTE: (yliangsiew) Package-relatve path means that we are inside of a USDZ file.
             ArResolver& arResolver = ArGetResolver(); // NOTE: (yliangsiew) This is cached.
+#if PXR_VERSION > 2011
             std::shared_ptr<ArAsset> assetPtr = arResolver.OpenAsset(ArResolvedPath(filePath));
+#else
+            std::shared_ptr<ArAsset> assetPtr = arResolver.OpenAsset(filePath);
+#endif
+
             if (assetPtr == nullptr) {
                 TF_WARN(
                     "The file: %s could not be found within the USDZ archive for extraction.",


### PR DESCRIPTION
Passing a path string to ArResolver::OpenAsset throws an error when built against the latest version of USD. This parameter is explicitly cast to ArResolvedPath elsewhere in the USD code, so updating this callsite to follow that pattern.