### PR TITLE
Add "/permissive-" flag for VS compiler

### DIFF
--- a/cmake/compiler_config.cmake
+++ b/cmake/compiler_config.cmake
@@ -24,7 +24,7 @@ set(MSVC_FLAGS
     /W3
     $<$<BOOL:${BUILD_STRICT_MODE}>:/WX>
     # enable two-phase name lookup and other strict checks (binding a non-const reference to a temporary, etc..)
-    /permissive-
+    $<$<BOOL:$<VERSION_GREATER:${PXR_VERSION},2002>>:/permissive->
     # enable pdb generation.
     /Zi
     # standards compliant.

--- a/cmake/compiler_config.cmake
+++ b/cmake/compiler_config.cmake
@@ -23,6 +23,8 @@ set(MSVC_FLAGS
     # we want to be as strict as possible
     /W3
     $<$<BOOL:${BUILD_STRICT_MODE}>:/WX>
+    # enable two-phase name lookup and other strict checks (binding a non-const reference to a temporary, etc..)
+    /permissive-
     # enable pdb generation.
     /Zi
     # standards compliant.

--- a/cmake/compiler_config.cmake
+++ b/cmake/compiler_config.cmake
@@ -24,7 +24,7 @@ set(MSVC_FLAGS
     /W3
     $<$<BOOL:${BUILD_STRICT_MODE}>:/WX>
     # enable two-phase name lookup and other strict checks (binding a non-const reference to a temporary, etc..)
-    $<$<BOOL:$<VERSION_GREATER:${PXR_VERSION},2002>>:/permissive->
+    $<$<BOOL:$<VERSION_GREATER:${USD_BOOST_VERSION},106600>>:/permissive->
     # enable pdb generation.
     /Zi
     # standards compliant.

--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -101,9 +101,29 @@ elseif(USD_INCLUDE_DIR AND EXISTS "${USD_INCLUDE_DIR}/pxr/pxr.h")
     math(EXPR PXR_VERSION "${USD_MAJOR_VERSION} * 10000 + ${USD_MINOR_VERSION} * 100 + ${USD_PATCH_VERSION}")
 endif()
 
+# Get the boost version from the one built with USD
+if(USD_INCLUDE_DIR)
+    file(GLOB _USD_VERSION_HPP_FILE "${USD_INCLUDE_DIR}/boost-*/boost/version.hpp")
+    list(LENGTH _USD_VERSION_HPP_FILE found_one)
+    if(${found_one} STREQUAL "1")
+        list(GET _USD_VERSION_HPP_FILE 0 USD_VERSION_HPP)
+        file(STRINGS
+            "${USD_VERSION_HPP}"
+            _usd_tmp
+            REGEX "#define BOOST_VERSION .*$")
+        string(REGEX MATCH "[0-9]+" USD_BOOST_VERSION ${_usd_tmp})
+        unset(_usd_tmp)
+        unset(_USD_VERSION_HPP_FILE)
+        unset(USD_VERSION_HPP)
+    endif()
+endif()
+
 message(STATUS "USD include dir: ${USD_INCLUDE_DIR}")
 message(STATUS "USD library dir: ${USD_LIBRARY_DIR}")
 message(STATUS "USD version: ${USD_VERSION}")
+if(DEFINED USD_BOOST_VERSION)
+    message(STATUS "USD Boost::boost version: ${USD_BOOST_VERSION}")
+endif()
 
 include(FindPackageHandleStandardArgs)
 


### PR DESCRIPTION
This PR, enables `/permissive-` flag for Visual Studio compiler. Read more here:

https://docs.microsoft.com/en-us/cpp/build/reference/permissive-standards-conformance?view=msvc-160

I recently wrote a code where I bind a non-const reference to a temporary which was rightfully detected as error with GCC but surprisingly not with either VS compiler 2017/2019.

```
void foo(std::string* errMsg)
{
    std::string message{"potato_message"};
    *errMsg = message;
}

int main()
{
    // bad code: I am binding a temporary to a reference and by doing 
    // so I am creating a reference to an object that will be 
    // destroyed at the end of the expression.
    foo(&std::string());
}
```
godbolt pseudo-code:

https://godbolt.org/z/3KzhnM

The "/permissive-" option is supported in Visual Studio 2017 and later and it would be great to have it ON to detect cases like:

- two-phase name lookup
- binding a non-const reference to a temporary
- allowing multiple user-defined conversions in initialization
- treating copy init as direct init

You can read on "Two-phase name lookup support comes to MSVC" here:

https://devblogs.microsoft.com/cppblog/two-phase-name-lookup-support-comes-to-msvc/


