### PR TITLE
Spinell/maya 110157/clearing mutiple layer crash

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -396,19 +396,7 @@ void LayerTreeItem::printLayer()
 
 void LayerTreeItem::clearLayer()
 {
-    MString title;
-    title.format(
-        StringResources::getAsMString(StringResources::kClearLayerTitle),
-        MQtUtil::toMString(text()));
-
-    MString desc;
-    desc.format(
-        StringResources::getAsMString(StringResources::kClearLayerConfirmMessage),
-        MQtUtil::toMString(text()));
-
-    if (confirmDialog(MQtUtil::toQString(title), MQtUtil::toQString(desc))) {
-        commandHook()->clearLayer(layer());
-    }
+    commandHook()->clearLayer(layer());
 }
 
 } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -394,9 +394,6 @@ void LayerTreeItem::printLayer()
     }
 }
 
-void LayerTreeItem::clearLayer()
-{
-    commandHook()->clearLayer(layer());
-}
+void LayerTreeItem::clearLayer() { commandHook()->clearLayer(layer()); }
 
 } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
@@ -218,8 +218,21 @@ void MayaLayerEditorWindow::printLayer()
 
 void MayaLayerEditorWindow::clearLayer()
 {
+    // Suspend usd notification while clearing and force a refresh after
+    // all layers are cleared. This is required because callMethodOnSelection()
+    // will loop on all selected layers and clear them one by one, If a refresh
+    // happen before callMethodOnSelection() finish to loop over the selected item,
+    // maya will crash because of a dangling pointer (All layer item are deleted
+    // during the refresh).
+    LayerTreeModel::suspendUsdNotices(true);
+
     QString name = "Clear";
     treeView()->callMethodOnSelection(name, &LayerTreeItem::clearLayer);
+
+    LayerTreeModel::suspendUsdNotices(false);
+
+    LayerTreeModel* model = treeView()->layerTreeModel();
+    model->forceRefresh();
 }
 
 void MayaLayerEditorWindow::selectPrimsWithSpec()

--- a/lib/usd/ui/layerEditor/stringResources.h
+++ b/lib/usd/ui/layerEditor/stringResources.h
@@ -54,11 +54,6 @@ const auto kAutoHideSessionLayer     { create("kAutoHideSessionLayer", "Auto-Hid
 const auto kBinary                   { create("kBinary", "Binary") };
 const auto kConvertToRelativePath    { create("kConvertToRelativePath", "Convert to Relative Path") };
 const auto kCancel                   { create("kCancel", "Cancel") };
-const auto kClearLayerTitle          { create("kclearLayerTitle", "Clear \"^1s\"") };
-const auto kClearLayerConfirmMessage { create("kClearLayerConfirmMessage",
-                                              "Are you sure you want to clear this layer?"
-                                              " \"^1s\"  will remain in the Layer Editor"
-                                              " but all contents will be cleared, including sublayer paths.") };
 const auto kCreate                   { create("kCreate", "Create") };
 const auto kRevertToFileTitle        { create("kRevertToFileTitle", "Revert to File \"^1s\"") };
 const auto kRevertToFileMsg          { create("kRevertToFileMsg", "Are you sure you want to revert \"^1s\" to its "


### PR DESCRIPTION
- Remove warning comfirmation dialog box when clearing a layer. (That cause the Layer editor to refresh when clearing multiple layer which can cause a dangling pointer and crash)
- Suspend Usd Notices until all layers are cleared.

When clearing multiple layer at the same time, maya crash because of a dangling pointer. This happen when in the selected layers, there is a sub layer of another layer. When clearing layers, we are first getting a list of all selected layers than loop over the list and clear layer one by one (Same pattern as remove layer). The problem here is after the first clear, we are notified by USD that a layer changed and we are queuing a Layer Editor refresh on idle. On the next loop iteration, items can become a dangling pointer to an object that have been deleted if the Layer Editor refresh already happen (During the refresh all the items are deleted are recreated). 

Let suppose you have the fallowing hierarchy:
&nbsp; layer1
&nbsp;&nbsp; layer2
&nbsp;&nbsp;&nbsp; layer3
&nbsp;&nbsp;&nbsp;&nbsp; layer4 

If all layers are selected and layer1 is cleared first, sub layer2 is removed from layer1 and a Layer Editor refresh callback is set on idle. If the refresh happen before we finish to iterate on the selected items, the selection list will contains dangling pointer.

To be sure the Layer Editor is not refreshing before we finish to clear all layers, I'm disabling USD notification and I'm forcing a refresh after all layer are cleared.

Note : 
Before clearing each layer, a warning dialog box is displayed and maya become idle so the Layer Editor get refresh and the selection list become invalidate. I spoke with Natalia and we conclude that displayed a warning dialog box when clearing a layer does not really make sense because this operation is undo-able and we don't display a warning when removing a layer. So I removed the confirmation box. 