### PR TITLE
MAYA-110623: Fix visibility attribute not blocked via outliner

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoVisibleCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoVisibleCommand.cpp
@@ -15,6 +15,7 @@
 //
 #include "UsdUndoVisibleCommand.h"
 
+#include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/undo/UsdUndoBlock.h>
 
 #include <pxr/usd/usdGeom/imageable.h>
@@ -43,7 +44,15 @@ void UsdUndoVisibleCommand::execute()
 {
     UsdUndoBlock undoBlock(&_undoableItem);
 
-    _visible ? UsdGeomImageable(_prim).MakeVisible() : UsdGeomImageable(_prim).MakeInvisible();
+    UsdGeomImageable primImageAble(_prim);
+
+    std::string errMsg;
+    if (!MayaUsd::ufe::isAttributeEditAllowed(primImageAble.GetVisibilityAttr(), &errMsg)) {
+        MGlobal::displayError(errMsg.c_str());
+        return;
+    }
+
+    _visible ? primImageAble.MakeVisible() : primImageAble.MakeInvisible();
 }
 
 void UsdUndoVisibleCommand::redo() { _undoableItem.redo(); }

--- a/lib/mayaUsd/ufe/UsdUndoVisibleCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoVisibleCommand.cpp
@@ -42,17 +42,17 @@ UsdUndoVisibleCommand::Ptr UsdUndoVisibleCommand::create(const UsdPrim& prim, bo
 
 void UsdUndoVisibleCommand::execute()
 {
-    UsdUndoBlock undoBlock(&_undoableItem);
-
-    UsdGeomImageable primImageAble(_prim);
+    UsdGeomImageable primImageable(_prim);
 
     std::string errMsg;
-    if (!MayaUsd::ufe::isAttributeEditAllowed(primImageAble.GetVisibilityAttr(), &errMsg)) {
+    if (!MayaUsd::ufe::isAttributeEditAllowed(primImageable.GetVisibilityAttr(), &errMsg)) {
         MGlobal::displayError(errMsg.c_str());
         return;
     }
 
-    _visible ? primImageAble.MakeVisible() : primImageAble.MakeInvisible();
+    UsdUndoBlock undoBlock(&_undoableItem);
+
+    _visible ? primImageable.MakeVisible() : primImageable.MakeInvisible();
 }
 
 void UsdUndoVisibleCommand::redo() { _undoableItem.redo(); }


### PR DESCRIPTION
This PR fixes visibility attribute not getting blocked when changed via outliner. I found this bug while testing some workflows.


