### PR TITLE
Fix spurious warning being raised about USDZ texture import and allow for user-defined sourceImages path

### DIFF
--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -682,8 +682,16 @@ const std::string UsdMayaJobImportArgs::GetImportUSDZTexturesFilePath(const std:
             // `sourceimages` folder under a Maya project root folder.
             importTexturesRootDirPath.assign(
                 currentMayaWorkspacePath.asChar(), currentMayaWorkspacePath.length());
-            bool bStat
-                = UsdMayaUtilFileSystem::pathAppendPath(importTexturesRootDirPath, "sourceimages");
+            MString sourceImagesDirBaseName
+                = MGlobal::executeCommandStringResult("workspace -fre \"sourceImages\"");
+            if (sourceImagesDirBaseName.length() == 0) {
+                TF_RUNTIME_ERROR(
+                    "Unable to determine the sourceImages fileRule for the Maya project: %s.",
+                    currentMayaWorkspacePath.asChar());
+                return "";
+            }
+            bool bStat = UsdMayaUtilFileSystem::pathAppendPath(
+                importTexturesRootDirPath, sourceImagesDirBaseName.asChar());
             if (!bStat) {
                 TF_RUNTIME_ERROR(
                     "Unable to determine the texture directory for the Maya project: %s.",

--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -690,10 +690,6 @@ const std::string UsdMayaJobImportArgs::GetImportUSDZTexturesFilePath(const std:
                     currentMayaWorkspacePath.asChar());
                 return "";
             }
-            TF_WARN(
-                "Because -importUSDZTexturesFilePath was not explicitly specified, textures "
-                "will be imported to the workspace folder: %s.",
-                currentMayaWorkspacePath.asChar());
         }
     } else {
         importTexturesRootDirPath.assign(userArg);

--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -271,6 +271,7 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
         }
 
         if (this->mArgs.importUSDZTexturesFilePath.length() == 0) {
+            MString currentMayaWorkspacePath = UsdMayaUtil::GetCurrentMayaWorkspacePath();
             TF_WARN(
                 "Because -importUSDZTexturesFilePath was not explicitly specified, textures "
                 "will be imported to the workspace folder: %s.",

--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -269,6 +269,13 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
                 stage->GetRootLayer()->GetRealPath().c_str());
             return MStatus::kFailure;
         }
+
+        if (this->mArgs.importUSDZTexturesFilePath.length() == 0) {
+            TF_WARN(
+                "Because -importUSDZTexturesFilePath was not explicitly specified, textures "
+                "will be imported to the workspace folder: %s.",
+                currentMayaWorkspacePath.asChar());
+        }
     }
 
     DoImport(range, usdRootPrim);


### PR DESCRIPTION
Hi:

This PR fixes #1273 and only shows the warning when the relevant `importUSDZTextures` flag is actually specified.

Update: I've also updated this PR to also fix #1272 as well since the code changes are minimal and they both relate to the same functionality.

Please review and raise any concerns.