### PR TITLE
[mtoh] Fix Hydra prim invalidation for hidden lights that are never population

### DIFF
--- a/lib/usd/hdMaya/adapters/lightAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/lightAdapter.cpp
@@ -117,7 +117,7 @@ void HdMayaLightAdapter::Populate()
 
 void HdMayaLightAdapter::MarkDirty(HdDirtyBits dirtyBits)
 {
-    if (dirtyBits != 0) {
+    if (_isPopulated && dirtyBits != 0) {
         GetDelegate()->GetChangeTracker().MarkSprimDirty(GetID(), dirtyBits);
     }
 }


### PR DESCRIPTION
Lights translation/population doesn't occur when the light is invisible, so subsequent attempt to invalidate the prim issue errors as it doesn't exists.