### PR TITLE
[mtoh] Add camera adapter to support physical camera parameters and configurable motion blur and depth-of-field.

### DIFF
--- a/lib/mayaUsd/render/mayaToHydra/renderGlobals.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderGlobals.cpp
@@ -49,7 +49,8 @@ TF_DEFINE_PRIVATE_TOKENS(
     (mtohWireframeSelectionHighlight)
     (mtohColorQuantization)
     (mtohSelectionOutline)
-    (mtohEnableMotionSamples)
+    (mtohMotionSampleStart)
+    (mtohMotionSampleEnd)
 );
 // clang-format on
 
@@ -73,7 +74,8 @@ global proc mtohRenderOverride_AddAttribute(string $renderer, string $label, str
     }
 }
 global proc mtohRenderOverride_AddMTOHAttributes(int $fromAE) {
-    mtohRenderOverride_AddAttribute("mtoh", "Enable Motion Samples", "mtohEnableMotionSamples", $fromAE);
+    mtohRenderOverride_AddAttribute("mtoh", "Motion Sample Start", "mtohMotionSampleStart", $fromAE);
+    mtohRenderOverride_AddAttribute("mtoh", "Motion Samples End", "mtohMotionSampleEnd", $fromAE);
     mtohRenderOverride_AddAttribute("mtoh", "Texture Memory Per Texture (KB)", "mtohTextureMemoryPerTexture", $fromAE);
     mtohRenderOverride_AddAttribute("mtoh", "Show Wireframe on Selected Objects", "mtohWireframeSelectionHighlight", $fromAE);
     mtohRenderOverride_AddAttribute("mtoh", "Highlight Selected Objects", "mtohColorSelectionHighlight", $fromAE);
@@ -796,9 +798,16 @@ MObject MtohRenderGlobals::CreateAttributes(const GlobalParams& params)
     MtohSettingFilter filter(params);
     const bool        userDefaults = params.fallbackToUserDefaults;
 
-    if (filter(_tokens->mtohEnableMotionSamples)) {
-        _CreateBoolAttribute(
-            node, filter.mayaString(), defGlobals.delegateParams.enableMotionSamples, userDefaults);
+    if (filter(_tokens->mtohMotionSampleStart)) {
+        _CreateFloatAttribute(
+            node, filter.mayaString(), defGlobals.delegateParams.motionSampleStart, userDefaults);
+        if (filter.attributeFilter()) {
+            return mayaObject;
+        }
+    }
+    if (filter(_tokens->mtohMotionSampleEnd)) {
+        _CreateFloatAttribute(
+            node, filter.mayaString(), defGlobals.delegateParams.motionSampleEnd, userDefaults);
         if (filter.attributeFilter()) {
             return mayaObject;
         }
@@ -974,12 +983,16 @@ MtohRenderGlobals::GetInstance(const GlobalParams& params, bool storeUserSetting
             return globals;
         }
     }
-    if (filter(_tokens->mtohEnableMotionSamples)) {
+    if (filter(_tokens->mtohMotionSampleStart)) {
         _GetAttribute(
-            node,
-            filter.mayaString(),
-            globals.delegateParams.enableMotionSamples,
-            storeUserSetting);
+            node, filter.mayaString(), globals.delegateParams.motionSampleStart, storeUserSetting);
+        if (filter.attributeFilter()) {
+            return globals;
+        }
+    }
+    if (filter(_tokens->mtohMotionSampleEnd)) {
+        _GetAttribute(
+            node, filter.mayaString(), globals.delegateParams.motionSampleEnd, storeUserSetting);
         if (filter.attributeFilter()) {
             return globals;
         }

--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.h
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.h
@@ -203,6 +203,8 @@ private:
 
     SdfPath _ID;
 
+    GfVec4d _viewport;
+
     int _currentOperation = -1;
 
     const bool _isUsingHdSt = false;

--- a/lib/usd/hdMaya/adapters/CMakeLists.txt
+++ b/lib/usd/hdMaya/adapters/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(${TARGET_NAME}
         adapterRegistry.cpp
         aiSkydomeLightAdapter.cpp
         areaLightAdapter.cpp
+        cameraAdapter.cpp
         dagAdapter.cpp
         directionalLightAdapter.cpp
         lightAdapter.cpp
@@ -27,6 +28,7 @@ set(HEADERS
     adapter.h
     adapterDebugCodes.h
     adapterRegistry.h
+    cameraAdapter.h
     constantShadowMatrix.h
     dagAdapter.h
     lightAdapter.h

--- a/lib/usd/hdMaya/adapters/adapterRegistry.cpp
+++ b/lib/usd/hdMaya/adapters/adapterRegistry.cpp
@@ -75,6 +75,20 @@ HdMayaAdapterRegistry::GetLightAdapterCreator(const MDagPath& dag)
     return ret;
 }
 
+void HdMayaAdapterRegistry::RegisterCameraAdapter(const TfToken& type, CameraAdapterCreator creator)
+{
+    GetInstance()._cameraAdapters.insert({ type, creator });
+}
+
+HdMayaAdapterRegistry::CameraAdapterCreator
+HdMayaAdapterRegistry::GetCameraAdapterCreator(const MDagPath& dag)
+{
+    MFnDependencyNode    depNode(dag.node());
+    CameraAdapterCreator ret = nullptr;
+    TfMapLookup(GetInstance()._cameraAdapters, TfToken(depNode.typeName().asChar()), &ret);
+    return ret;
+}
+
 void HdMayaAdapterRegistry::RegisterMaterialAdapter(
     const TfToken&         type,
     MaterialAdapterCreator creator)

--- a/lib/usd/hdMaya/adapters/adapterRegistry.h
+++ b/lib/usd/hdMaya/adapters/adapterRegistry.h
@@ -16,6 +16,7 @@
 #ifndef HDMAYA_ADAPTER_REGISTRY_H
 #define HDMAYA_ADAPTER_REGISTRY_H
 
+#include <hdMaya/adapters/cameraAdapter.h>
 #include <hdMaya/adapters/lightAdapter.h>
 #include <hdMaya/adapters/materialAdapter.h>
 #include <hdMaya/adapters/shapeAdapter.h>
@@ -63,6 +64,14 @@ public:
     HDMAYA_API
     static MaterialAdapterCreator GetMaterialAdapterCreator(const MObject& node);
 
+    using CameraAdapterCreator
+        = std::function<HdMayaCameraAdapterPtr(HdMayaDelegateCtx*, const MDagPath&)>;
+    HDMAYA_API
+    static void RegisterCameraAdapter(const TfToken& type, CameraAdapterCreator creator);
+
+    HDMAYA_API
+    static CameraAdapterCreator GetCameraAdapterCreator(const MDagPath& dag);
+
     // Find all HdMayaAdapter plugins, and load them all
     HDMAYA_API
     static void LoadAllPlugin();
@@ -71,6 +80,7 @@ private:
     std::unordered_map<TfToken, ShapeAdapterCreator, TfToken::HashFunctor>    _dagAdapters;
     std::unordered_map<TfToken, LightAdapterCreator, TfToken::HashFunctor>    _lightAdapters;
     std::unordered_map<TfToken, MaterialAdapterCreator, TfToken::HashFunctor> _materialAdapters;
+    std::unordered_map<TfToken, CameraAdapterCreator, TfToken::HashFunctor>   _cameraAdapters;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/usd/hdMaya/adapters/cameraAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/cameraAdapter.cpp
@@ -178,8 +178,9 @@ VtValue HdMayaCameraAdapter::GetCameraParamValue(const TfToken& paramName)
 
     auto projectionMatrix
         = [&](const MFnCamera& camera, bool isOrtho, const GfVec4d* viewport) -> GfMatrix4d {
-        double left, right, bottom, top, near = camera.nearClippingPlane(),
-                                         far = camera.farClippingPlane(), farMinusNear = far - near,
+        double left, right, bottom, top, cameraNear = camera.nearClippingPlane(),
+                                         cameraFar = camera.farClippingPlane(),
+                                         cameraFarMinusNear = cameraFar - cameraNear,
                                          aspectRatio = viewport
             ? (((*viewport)[2] - (*viewport)[0]) / ((*viewport)[3] - (*viewport)[1]))
             : camera.aspectRatio();
@@ -200,11 +201,11 @@ VtValue HdMayaCameraAdapter::GetCameraParamValue(const TfToken& paramName)
                     0,
                     0,
                     0,
-                    -2.0 / farMinusNear,
+                    -2.0 / cameraFarMinusNear,
                     0,
                     0,
                     0,
-                    -(far + near) / farMinusNear,
+                    -(cameraFar + cameraNear) / cameraFarMinusNear,
                     1);
 
             return GfMatrix4d(
@@ -218,50 +219,50 @@ VtValue HdMayaCameraAdapter::GetCameraParamValue(const TfToken& paramName)
                 0,
                 0,
                 0,
-                -2.0 / farMinusNear,
+                -2.0 / cameraFarMinusNear,
                 0,
                 -(right + left) / (right - left),
                 -(top + bottom) / (top - bottom),
-                -(far + near) / farMinusNear,
+                -(cameraFar + cameraNear) / cameraFarMinusNear,
                 1);
         }
 
         // Skip over extraneous double-precision math in the common symmetric case
         if (right == -left && top == -bottom)
             return GfMatrix4d(
-                near / right,
+                cameraNear / right,
                 0,
                 0,
                 0,
                 0,
-                near / top,
+                cameraNear / top,
                 0,
                 0,
                 0,
                 0,
-                -(far + near) / farMinusNear,
+                -(cameraFar + cameraNear) / cameraFarMinusNear,
                 -1,
                 0,
                 0,
-                (-2.0 * far * near) / farMinusNear,
+                (-2.0 * cameraFar * cameraNear) / cameraFarMinusNear,
                 0);
 
         return GfMatrix4d(
-            (2.0 * near) / (right - left),
+            (2.0 * cameraNear) / (right - left),
             0,
             0,
             0,
             0,
-            (2.0 * near) / (top - bottom),
+            (2.0 * cameraNear) / (top - bottom),
             0,
             0,
             (right + left) / (right - left),
             (top + bottom) / (top - bottom),
-            -(far + near) / farMinusNear,
+            -(cameraFar + cameraNear) / cameraFarMinusNear,
             -1,
             0,
             0,
-            (2.0 * near * -far) / farMinusNear,
+            (2.0 * cameraNear * -cameraFar) / cameraFarMinusNear,
             0);
     };
 

--- a/lib/usd/hdMaya/adapters/cameraAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/cameraAdapter.cpp
@@ -1,0 +1,387 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "cameraAdapter.h"
+
+#include <hdMaya/adapters/adapterDebugCodes.h>
+#include <hdMaya/adapters/adapterRegistry.h>
+#include <hdMaya/adapters/mayaAttrs.h>
+
+#include <pxr/base/gf/interval.h>
+#include <pxr/imaging/hd/camera.h>
+
+#include <maya/MDagMessage.h>
+#include <maya/MFnCamera.h>
+#include <maya/MNodeMessage.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace {
+
+TF_REGISTRY_FUNCTION(TfType)
+{
+    TfType::Define<HdMayaCameraAdapter, TfType::Bases<HdMayaShapeAdapter>>();
+}
+
+TF_REGISTRY_FUNCTION_WITH_TAG(HdMayaAdapterRegistry, camera)
+{
+    HdMayaAdapterRegistry::RegisterCameraAdapter(
+        HdPrimTypeTokens->camera,
+        [](HdMayaDelegateCtx* delegate, const MDagPath& dag) -> HdMayaCameraAdapterPtr {
+            return HdMayaCameraAdapterPtr(new HdMayaCameraAdapter(delegate, dag));
+        });
+}
+
+} // namespace
+
+HdMayaCameraAdapter::HdMayaCameraAdapter(HdMayaDelegateCtx* delegate, const MDagPath& dag)
+    : HdMayaShapeAdapter(delegate->GetPrimPath(dag, true), delegate, dag)
+{
+}
+
+HdMayaCameraAdapter::~HdMayaCameraAdapter() { }
+
+TfToken HdMayaCameraAdapter::CameraType() { return HdPrimTypeTokens->camera; }
+
+bool HdMayaCameraAdapter::IsSupported() const
+{
+    return GetDelegate()->GetRenderIndex().IsSprimTypeSupported(CameraType());
+}
+
+void HdMayaCameraAdapter::Populate()
+{
+    if (_isPopulated) {
+        return;
+    }
+    GetDelegate()->InsertSprim(CameraType(), GetID(), HdCamera::AllDirty);
+    _isPopulated = true;
+}
+
+void HdMayaCameraAdapter::MarkDirty(HdDirtyBits dirtyBits)
+{
+    if (_isPopulated && dirtyBits != 0) {
+        if (dirtyBits & HdChangeTracker::DirtyTransform) {
+            dirtyBits |= HdCamera::DirtyViewMatrix;
+        }
+        dirtyBits = dirtyBits & HdCamera::AllDirty;
+        GetDelegate()->GetChangeTracker().MarkSprimDirty(GetID(), dirtyBits);
+    }
+}
+
+void HdMayaCameraAdapter::CreateCallbacks()
+{
+    MStatus status;
+    auto    dag = GetDagPath();
+    auto    obj = dag.node();
+
+    auto paramsChanged = MNodeMessage::addNodeDirtyCallback(
+        obj,
+        +[](MObject& obj, void* clientData) {
+            auto* adapter = reinterpret_cast<HdMayaCameraAdapter*>(clientData);
+            // Dirty everything rather than track complex param and fit to projection dependencies.
+            adapter->MarkDirty(
+                HdCamera::DirtyParams | HdCamera::DirtyProjMatrix | HdCamera::DirtyWindowPolicy);
+        },
+        reinterpret_cast<void*>(this),
+        &status);
+    if (status) {
+        AddCallback(paramsChanged);
+    }
+
+    auto xformChanged = MDagMessage::addWorldMatrixModifiedCallback(
+        dag,
+        +[](MObject& transformNode, MDagMessage::MatrixModifiedFlags& modified, void* clientData) {
+            auto* adapter = reinterpret_cast<HdMayaCameraAdapter*>(clientData);
+            adapter->MarkDirty(HdCamera::DirtyViewMatrix);
+            adapter->InvalidateTransform();
+        },
+        reinterpret_cast<void*>(this),
+        &status);
+    if (status) {
+        AddCallback(xformChanged);
+    }
+
+    // Skip over HdMayaShapeAdapter's CreateCallbacks
+    HdMayaAdapter::CreateCallbacks();
+}
+
+void HdMayaCameraAdapter::RemovePrim()
+{
+    if (!_isPopulated) {
+        return;
+    }
+    GetDelegate()->RemoveSprim(CameraType(), GetID());
+    _isPopulated = false;
+}
+
+bool HdMayaCameraAdapter::HasType(const TfToken& typeId) const { return typeId == CameraType(); }
+
+VtValue HdMayaCameraAdapter::Get(const TfToken& key) { return HdMayaShapeAdapter::Get(key); }
+
+VtValue HdMayaCameraAdapter::GetCameraParamValue(const TfToken& paramName)
+{
+    constexpr double mayaInchToHydraCentimeter = 0.254;
+    constexpr double mayaInchToHydraMillimeter = 0.0254;
+    constexpr double mayaFocaLenToHydra = 0.01;
+
+    MStatus status;
+
+    auto convertFit = [&](const MFnCamera& camera) -> CameraUtilConformWindowPolicy {
+        const auto mayaFit = camera.filmFit(&status);
+        if (mayaFit == MFnCamera::kHorizontalFilmFit)
+            return CameraUtilConformWindowPolicy::CameraUtilMatchHorizontally;
+        if (mayaFit == MFnCamera::kVerticalFilmFit)
+            return CameraUtilConformWindowPolicy::CameraUtilMatchVertically;
+
+        const auto fitMatcher = camera.horizontalFilmAperture() > camera.verticalFilmAperture()
+            ? MFnCamera::kOverscanFilmFit
+            : MFnCamera::kFillFilmFit;
+        return mayaFit == fitMatcher ? CameraUtilConformWindowPolicy::CameraUtilMatchHorizontally
+                                     : CameraUtilConformWindowPolicy::CameraUtilMatchVertically;
+    };
+
+    auto apertureConvert = [&](const MFnCamera& camera, double glApertureX, double glApertureY) {
+        const auto   usdFit = convertFit(camera);
+        const double aperture = usdFit == CameraUtilConformWindowPolicy::CameraUtilMatchHorizontally
+            ? camera.horizontalFilmAperture()
+            : camera.verticalFilmAperture();
+        const double glAperture
+            = usdFit == CameraUtilConformWindowPolicy::CameraUtilMatchHorizontally ? glApertureX
+                                                                                   : glApertureY;
+        return (0.02 / aperture) * (aperture / glAperture);
+    };
+
+    auto viewParameters = [&](const MFnCamera& camera,
+                              const GfVec4d*   viewport,
+                              double&          apertureX,
+                              double&          apertureY,
+                              double&          offsetX,
+                              double&          offsetY) -> MStatus {
+        double aspectRatio = viewport
+            ? ((*viewport)[2] - (*viewport)[0]) / ((*viewport)[3] - (*viewport)[1])
+            : camera.aspectRatio();
+        return camera.getViewParameters(
+            aspectRatio, apertureX, apertureY, offsetX, offsetY, true, false, true);
+    };
+
+    auto projectionMatrix
+        = [&](const MFnCamera& camera, bool isOrtho, const GfVec4d* viewport) -> GfMatrix4d {
+        double left, right, bottom, top, near = camera.nearClippingPlane(),
+                                         far = camera.farClippingPlane(), farMinusNear = far - near,
+                                         aspectRatio = viewport
+            ? (((*viewport)[2] - (*viewport)[0]) / ((*viewport)[3] - (*viewport)[1]))
+            : camera.aspectRatio();
+
+        status = camera.getViewingFrustum(aspectRatio, left, right, bottom, top, true, false, true);
+
+        if (isOrtho) {
+            // Skip over extraneous double-precision math in the common symmetric case
+            if (right == -left && top == -bottom)
+                return GfMatrix4d(
+                    1.0 / right,
+                    0,
+                    0,
+                    0,
+                    0,
+                    1.0 / top,
+                    0,
+                    0,
+                    0,
+                    0,
+                    -2.0 / farMinusNear,
+                    0,
+                    0,
+                    0,
+                    -(far + near) / farMinusNear,
+                    1);
+
+            return GfMatrix4d(
+                2.0 / (right - left),
+                0,
+                0,
+                0,
+                0,
+                2.0 / (top - bottom),
+                0,
+                0,
+                0,
+                0,
+                -2.0 / farMinusNear,
+                0,
+                -(right + left) / (right - left),
+                -(top + bottom) / (top - bottom),
+                -(far + near) / farMinusNear,
+                1);
+        }
+
+        // Skip over extraneous double-precision math in the common symmetric case
+        if (right == -left && top == -bottom)
+            return GfMatrix4d(
+                near / right,
+                0,
+                0,
+                0,
+                0,
+                near / top,
+                0,
+                0,
+                0,
+                0,
+                -(far + near) / farMinusNear,
+                -1,
+                0,
+                0,
+                (-2.0 * far * near) / farMinusNear,
+                0);
+
+        return GfMatrix4d(
+            (2.0 * near) / (right - left),
+            0,
+            0,
+            0,
+            0,
+            (2.0 * near) / (top - bottom),
+            0,
+            0,
+            (right + left) / (right - left),
+            (top + bottom) / (top - bottom),
+            -(far + near) / farMinusNear,
+            -1,
+            0,
+            0,
+            (2.0 * near * -far) / farMinusNear,
+            0);
+    };
+
+    auto hadError = [&](MStatus& status) -> bool {
+        if (ARCH_LIKELY(status))
+            return false;
+        TF_WARN(
+            "Error in HdMayaCameraAdapter::GetCameraParamValue(%s): %s",
+            paramName.GetText(),
+            status.errorString().asChar());
+        return false;
+    };
+
+    MFnCamera camera(GetDagPath(), &status);
+    if (hadError(status))
+        return {};
+
+    const bool isOrtho = camera.isOrtho(&status);
+    if (hadError(status)) {
+        return {};
+    }
+
+    if (paramName == HdCameraTokens->projectionMatrix) {
+        const auto projMatrix = projectionMatrix(camera, isOrtho, _viewport.get());
+        if (hadError(status))
+            return {};
+        return VtValue(projMatrix);
+    }
+    if (paramName == HdCameraTokens->worldToViewMatrix) {
+        return VtValue(GetTransform().GetInverse());
+    }
+    if (paramName == HdCameraTokens->shutterOpen) {
+        // No motion samples, instantaneous shutter
+        if (!GetDelegate()->GetParams().motionSamplesEnabled())
+            return VtValue(double(0));
+        return VtValue(double(GetDelegate()->GetCurrentTimeSamplingInterval().GetMin()));
+    }
+    if (paramName == HdCameraTokens->shutterClose) {
+        // No motion samples, instantaneous shutter
+        if (!GetDelegate()->GetParams().motionSamplesEnabled())
+            return VtValue(double(0));
+        const auto shutterAngle = camera.shutterAngle(&status);
+        if (hadError(status))
+            return {};
+        auto constexpr maxRadians = M_PI * 2.0;
+        auto shutterClose = std::min(std::max(0.0, shutterAngle), maxRadians) / maxRadians;
+        auto interval = GetDelegate()->GetCurrentTimeSamplingInterval();
+        return VtValue(double(interval.GetMin() + interval.GetSize() * shutterClose));
+    }
+
+    // Don't bother with anything else for orthographic cameras
+    if (isOrtho) {
+        return {};
+    }
+    if (paramName == HdCameraTokens->focusDistance) {
+        auto focusDistance = camera.focusDistance(&status);
+        if (hadError(status))
+            return {};
+        return VtValue(float(focusDistance * mayaInchToHydraCentimeter));
+    }
+    if (paramName == HdCameraTokens->focalLength) {
+        GfMatrix4d glProjMatrix = projectionMatrix(camera, isOrtho, _viewport.get());
+        const int  index
+            = convertFit(camera) == CameraUtilConformWindowPolicy::CameraUtilMatchVertically;
+        const auto focalLen = glProjMatrix[index][index];
+        return VtValue(float(focalLen * mayaFocaLenToHydra));
+    }
+    if (paramName == HdCameraTokens->fStop) {
+        // For USD/Hydra fStop=0 should disable depthOfField
+        if (!camera.isDepthOfField())
+            return VtValue(0.f);
+        const auto fStop = camera.fStop(&status);
+        if (hadError(status))
+            return {};
+        return VtValue(float(fStop));
+    }
+    if (paramName == HdCameraTokens->horizontalAperture) {
+        double apertureX, apertureY, offsetX, offsetY;
+        status = viewParameters(camera, _viewport.get(), apertureX, apertureY, offsetX, offsetY);
+        if (hadError(status))
+            return {};
+        return VtValue(float(apertureX * apertureConvert(camera, apertureX, apertureY)));
+    }
+    if (paramName == HdCameraTokens->verticalAperture) {
+        double apertureX, apertureY, offsetX, offsetY;
+        status = viewParameters(camera, _viewport.get(), apertureX, apertureY, offsetX, offsetY);
+        if (hadError(status))
+            return {};
+        return VtValue(float(apertureY * apertureConvert(camera, apertureX, apertureY)));
+    }
+    if (paramName == HdCameraTokens->horizontalApertureOffset) {
+        double apertureX, apertureY, offsetX, offsetY;
+        status = viewParameters(camera, _viewport.get(), apertureX, apertureY, offsetX, offsetY);
+        if (hadError(status))
+            return {};
+        return VtValue(float(offsetX * mayaInchToHydraMillimeter));
+    }
+    if (paramName == HdCameraTokens->verticalApertureOffset) {
+        double apertureX, apertureY, offsetX, offsetY;
+        status = viewParameters(camera, _viewport.get(), apertureX, apertureY, offsetX, offsetY);
+        if (hadError(status))
+            return {};
+        return VtValue(float(offsetY * mayaInchToHydraMillimeter));
+    }
+    if (paramName == HdCameraTokens->windowPolicy) {
+        const auto windowPolicy = convertFit(camera);
+        if (hadError(status))
+            return {};
+        return VtValue(windowPolicy);
+    }
+
+    return {};
+}
+
+void HdMayaCameraAdapter::SetViewport(const GfVec4d& viewport)
+{
+    if (!_viewport) {
+        _viewport.reset(new GfVec4d);
+    }
+    *_viewport = viewport;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/usd/hdMaya/adapters/cameraAdapter.h
+++ b/lib/usd/hdMaya/adapters/cameraAdapter.h
@@ -1,0 +1,76 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef HDMAYA_CAMERA_ADAPTER_H
+#define HDMAYA_CAMERA_ADAPTER_H
+
+#include <hdMaya/adapters/dagAdapter.h>
+#include <hdMaya/adapters/shapeAdapter.h>
+
+#include <pxr/pxr.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class HdMayaCameraAdapter : public HdMayaShapeAdapter
+{
+public:
+    HDMAYA_API
+    HdMayaCameraAdapter(HdMayaDelegateCtx* delegate, const MDagPath& dag);
+
+    HDMAYA_API
+    virtual ~HdMayaCameraAdapter();
+
+    HDMAYA_API
+    bool IsSupported() const override;
+
+    HDMAYA_API
+    void MarkDirty(HdDirtyBits dirtyBits) override;
+
+    HDMAYA_API
+    void Populate() override;
+
+    HDMAYA_API
+    void RemovePrim() override;
+
+    HDMAYA_API
+    bool HasType(const TfToken& typeId) const override;
+
+    HDMAYA_API
+    VtValue Get(const TfToken& key) override;
+
+    HDMAYA_API
+    VtValue GetCameraParamValue(const TfToken& paramName);
+
+    HDMAYA_API
+    void CreateCallbacks() override;
+
+    HDMAYA_API
+    void SetViewport(const GfVec4d& viewport);
+
+protected:
+    static TfToken CameraType();
+
+    // The use of a pointer here helps us track whether this camera is (or has ever been)
+    // the active viewport camera.  NOTE: it's possile that _viewport will be out of date
+    // after switching to a new camera and resizing the viewport, but _viewport will eventually
+    // be re-synched before any output/pixels of the stale size is requested.
+    std::unique_ptr<GfVec4d> _viewport;
+};
+
+using HdMayaCameraAdapterPtr = std::shared_ptr<HdMayaCameraAdapter>;
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // HDMAYA_CAMERA_ADAPTER_H

--- a/lib/usd/hdMaya/adapters/dagAdapter.h
+++ b/lib/usd/hdMaya/adapters/dagAdapter.h
@@ -57,7 +57,7 @@ public:
     HDMAYA_API
     virtual void RemovePrim() override;
     HDMAYA_API
-    const GfMatrix4d& GetTransform();
+    GfMatrix4d GetTransform();
     HDMAYA_API
     size_t SampleTransform(size_t maxSampleCount, float* times, GfMatrix4d* samples);
     HDMAYA_API
@@ -77,15 +77,13 @@ public:
 
 protected:
     HDMAYA_API
-    void _CalculateTransform();
-    HDMAYA_API
     void _AddHierarchyChangedCallbacks(MDagPath& dag);
     HDMAYA_API
     virtual bool _GetVisibility() const;
 
 private:
     MDagPath   _dagPath;
-    GfMatrix4d _transform[2];
+    GfMatrix4d _transform;
     bool       _isVisible = true;
     bool       _visibilityDirty = true;
     bool       _invalidTransform = true;

--- a/lib/usd/hdMaya/adapters/meshAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/meshAdapter.cpp
@@ -19,16 +19,14 @@
 #include <hdMaya/adapters/shapeAdapter.h>
 #include <hdMaya/adapters/tokens.h>
 
+#include <pxr/base/gf/interval.h>
 #include <pxr/base/tf/type.h>
 #include <pxr/imaging/hd/tokens.h>
 #include <pxr/imaging/pxOsd/tokens.h>
 #include <pxr/pxr.h>
 #include <pxr/usd/usdGeom/tokens.h>
 
-#include <maya/MAnimControl.h>
 #include <maya/MCallbackIdArray.h>
-#include <maya/MDGContext.h>
-#include <maya/MDGContextGuard.h>
 #include <maya/MFloatArray.h>
 #include <maya/MFnMesh.h>
 #include <maya/MIntArray.h>
@@ -207,16 +205,8 @@ public:
             if (ARCH_UNLIKELY(!status)) {
                 return 0;
             }
-            times[0] = 0.0f;
-            samples[0] = GetPoints(mesh);
-            if (maxSampleCount == 1 || !GetDelegate()->GetParams().enableMotionSamples) {
-                return 1;
-            }
-            times[1] = 1.0f;
-            MDGContextGuard guard(MAnimControl::currentTime() + 1.0);
-            samples[1] = GetPoints(mesh);
-            // FIXME: should we do this or in the render delegate?
-            return samples[1] == samples[0] ? 1 : 2;
+            return GetDelegate()->SampleValues(
+                maxSampleCount, times, samples, [&]() -> VtValue { return GetPoints(mesh); });
         } else if (key == HdMayaAdapterTokens->st) {
             times[0] = 0.0f;
             samples[0] = GetUVs();

--- a/lib/usd/hdMaya/delegates/delegate.cpp
+++ b/lib/usd/hdMaya/delegates/delegate.cpp
@@ -15,6 +15,7 @@
 //
 #include "delegate.h"
 
+#include <pxr/base/gf/interval.h>
 #include <pxr/base/tf/type.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -31,5 +32,12 @@ HdMayaDelegate::HdMayaDelegate(const InitData& initData)
 }
 
 void HdMayaDelegate::SetParams(const HdMayaParams& params) { _params = params; }
+
+void HdMayaDelegate::SetCameraForSampling(SdfPath const& camID) { _cameraPathForSampling = camID; }
+
+GfInterval HdMayaDelegate::GetCurrentTimeSamplingInterval() const
+{
+    return GfInterval(_params.motionSampleStart, _params.motionSampleEnd);
+}
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/usd/hdMaya/delegates/delegate.h
+++ b/lib/usd/hdMaya/delegates/delegate.h
@@ -141,7 +141,7 @@ public:
 
     /// Common function to return templated sample types
     template <typename T, typename Getter>
-    HDMAYA_API size_t SampleValues(size_t maxSampleCount, float* times, T* samples, Getter getValue)
+    size_t SampleValues(size_t maxSampleCount, float* times, T* samples, Getter getValue)
     {
         if (ARCH_UNLIKELY(maxSampleCount == 0)) {
             return 0;

--- a/lib/usd/hdMaya/delegates/delegateCtx.cpp
+++ b/lib/usd/hdMaya/delegates/delegateCtx.cpp
@@ -111,9 +111,9 @@ void HdMayaDelegateCtx::RemoveSprim(const TfToken& typeId, const SdfPath& id)
 
 void HdMayaDelegateCtx::RemoveInstancer(const SdfPath& id) { GetRenderIndex().RemoveInstancer(id); }
 
-SdfPath HdMayaDelegateCtx::GetPrimPath(const MDagPath& dg, bool isLight)
+SdfPath HdMayaDelegateCtx::GetPrimPath(const MDagPath& dg, bool isSprim)
 {
-    if (isLight) {
+    if (isSprim) {
         return _GetPrimPath(_sprimPath, dg);
     } else {
         return _GetPrimPath(_rprimPath, dg);

--- a/lib/usd/hdMaya/delegates/delegateCtx.h
+++ b/lib/usd/hdMaya/delegates/delegateCtx.h
@@ -64,7 +64,7 @@ public:
     /// \param id Id of the Material that changed its tag.
     virtual void MaterialTagChanged(const SdfPath& id) { }
     HDMAYA_API
-    SdfPath GetPrimPath(const MDagPath& dg, bool isLight);
+    SdfPath GetPrimPath(const MDagPath& dg, bool isSprim);
     HDMAYA_API
     SdfPath GetMaterialPath(const MObject& obj);
 

--- a/lib/usd/hdMaya/delegates/params.h
+++ b/lib/usd/hdMaya/delegates/params.h
@@ -24,10 +24,13 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 struct HdMayaParams
 {
-    int  textureMemoryPerTexture = 4 * 1024 * 1024;
-    int  maximumShadowMapResolution = 2048;
-    bool displaySmoothMeshes = true;
-    bool enableMotionSamples = false;
+    int   textureMemoryPerTexture = 4 * 1024 * 1024;
+    int   maximumShadowMapResolution = 2048;
+    float motionSampleStart = 0;
+    float motionSampleEnd = 0;
+    bool  displaySmoothMeshes = true;
+
+    bool motionSamplesEnabled() const { return motionSampleStart != 0 || motionSampleEnd != 0; }
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/usd/hdMaya/delegates/sceneDelegate.h
+++ b/lib/usd/hdMaya/delegates/sceneDelegate.h
@@ -16,6 +16,7 @@
 #ifndef HDMAYA_SCENE_DELEGATE_H
 #define HDMAYA_SCENE_DELEGATE_H
 
+#include <hdMaya/adapters/cameraAdapter.h>
 #include <hdMaya/adapters/lightAdapter.h>
 #include <hdMaya/adapters/materialAdapter.h>
 #include <hdMaya/adapters/shapeAdapter.h>
@@ -111,6 +112,9 @@ public:
     void SetParams(const HdMayaParams& params) override;
 
     HDMAYA_API
+    SdfPath SetCameraViewport(const MDagPath& camPath, const GfVec4d& viewport);
+
+    HDMAYA_API
     void PopulateSelectedPaths(
         const MSelectionList&       mayaSelection,
         SdfPathVector&              selectedSdfPaths,
@@ -185,6 +189,9 @@ protected:
     VtValue GetLightParamValue(const SdfPath& id, const TfToken& paramName) override;
 
     HDMAYA_API
+    VtValue GetCameraParamValue(const SdfPath& cameraId, const TfToken& paramName) override;
+
+    HDMAYA_API
     VtIntArray GetInstanceIndices(const SdfPath& instancerId, const SdfPath& prototypeId) override;
 
 #if defined(HD_API_VERSION) && HD_API_VERSION >= 36
@@ -227,6 +234,13 @@ protected:
 #endif // PXR_VERSION < 2011
 
 private:
+    template <typename AdapterPtr, typename Map>
+    AdapterPtr Create(
+        const MDagPath&                                                       dag,
+        const std::function<AdapterPtr(HdMayaDelegateCtx*, const MDagPath&)>& adapterCreator,
+        Map&                                                                  adapterMap,
+        bool                                                                  isSprim = false);
+
     bool _CreateMaterial(const SdfPath& id, const MObject& obj);
 
     template <typename T> using AdapterMap = std::unordered_map<SdfPath, T, SdfPath::Hash>;
@@ -234,6 +248,8 @@ private:
     AdapterMap<HdMayaShapeAdapterPtr> _shapeAdapters;
     /// \brief Unordered Map storing the light adapters.
     AdapterMap<HdMayaLightAdapterPtr> _lightAdapters;
+    /// \brief Unordered Map storing the camera adapters.
+    AdapterMap<HdMayaCameraAdapterPtr> _cameraAdapters;
     /// \brief Unordered Map storing the material adapters.
     AdapterMap<HdMayaMaterialAdapterPtr>       _materialAdapters;
     std::vector<MCallbackId>                   _callbacks;

--- a/lib/usd/hdMaya/plugInfo.json
+++ b/lib/usd/hdMaya/plugInfo.json
@@ -65,6 +65,12 @@
                         ],
                         "displayName": "Shapes in Hydra for Maya."
                     },
+                    "HdMayaCameraAdapter": {
+                        "bases": [
+                            "HdMayaShapeAdapter"
+                        ],
+                        "displayName": "Cameras in Hydra for Maya."
+                    },
                     "HdMayaMeshAdapter": {
                         "bases": [
                             "HdMayaShapeAdapter"

--- a/lib/usd/hdMaya/utils.h
+++ b/lib/usd/hdMaya/utils.h
@@ -28,6 +28,7 @@
 
 #include <maya/MDagPath.h>
 #include <maya/MDagPathArray.h>
+#include <maya/MFloatMatrix.h>
 #include <maya/MFnDependencyNode.h>
 #include <maya/MItDag.h>
 #include <maya/MItSelectionList.h>
@@ -52,6 +53,19 @@ inline GfMatrix4d GetGfMatrixFromMaya(const MMatrix& mayaMat)
 {
     GfMatrix4d mat;
     memcpy(mat.GetArray(), mayaMat[0], sizeof(double) * 16);
+    return mat;
+}
+
+/// \brief Converts a Maya float matrix to a double precision GfMatrix.
+/// \param mayaMat Maya `MFloatMatrix` to be converted.
+/// \return `GfMatrix4d` equal to \p mayaMat.
+inline GfMatrix4d GetGfMatrixFromMaya(const MFloatMatrix& mayaMat)
+{
+    GfMatrix4d mat;
+    for (unsigned i = 0; i < 4; ++i) {
+        for (unsigned j = 0; j < 4; ++j)
+            mat[i][j] = mayaMat(i, j);
+    }
     return mat;
 }
 

--- a/test/lib/mayaUsd/render/mayaToHydra/testMtohCommand.py
+++ b/test/lib/mayaUsd/render/mayaToHydra/testMtohCommand.py
@@ -91,12 +91,12 @@ class TestCommand(unittest.TestCase):
         for flag in ("createRenderGlobals", "crg"):
             cmds.file(f=1, new=1)
             self.assertFalse(cmds.objExists(
-                "defaultRenderGlobals.mtohEnableMotionSamples"))
+                "defaultRenderGlobals.mtohMotionSampleStart"))
             cmds.mtoh(**{flag: 1})
             self.assertTrue(cmds.objExists(
-                "defaultRenderGlobals.mtohEnableMotionSamples"))
+                "defaultRenderGlobals.mtohMotionSampleStart"))
             self.assertFalse(cmds.getAttr(
-                "defaultRenderGlobals.mtohEnableMotionSamples"))
+                "defaultRenderGlobals.mtohMotionSampleStart"))
 
     # TODO: test_updateRenderGlobals
 


### PR DESCRIPTION
_Running the test-suite locally to verify nothing has been broken, but as the change-set is quite large posting it now_

Currently mtoh does motion-blur with two hard-coded samples **t=frame** and **t=frame+1**. We'd like this to be configurable, as these values/ranges are rarely used by our camera's, which are usually centered around the current frame.  Additionally, reliance in the Hydra-projection matrix only for the camera means depth-of-field isn't currently supported.

These changes shouldn't affect Storm or other delegates that only use the Hydra render-pass view matrix.
 
- Removes **mtohEnableMotionSamples**, in favor of explicit shutter start and end settings. Setting **start=0**, **end=1** with a camera's **shutterAngle=360** is the equivalent of the old hard-coded mode.
- **HdMayaSceneDelegate::InsertDag** is refactored and templatized for the common pattern in adapter creation.
- **HdMayaMeshAdapter::SamplePrimvar** and **HdMayaDagAdapter::SampleTransform** call through to a templatized  **HdMayaDelegate::SampleValues** method.
- Hydra **HdCameraTokens->windowPolicy** is exported as **CameraUtilMatchHorizontally** or **CameraUtilMatchVertically** to avoid any potential conversion issues with Maya's **Fill** or **Overscan** modes leaking out to HdRenderDelagtes.
- **HdMayaDagAdapter** matrix cache is reduced from two matrices to one.

**TODO:** Need a way to use the Maya viewport camera in a UsdProxyShape.  Waiting until we can actually get the USD camera path when selected in the viewport to see what else can be done....The only way I can think of doing this right now is to build up a camera in the UsdProxyShape's stage, which has some downsides.