### PR TITLE
Fix referenced material non-default attributes not getting exported to USD

### DIFF
--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -1211,7 +1211,7 @@ bool UsdMayaUtil::IsPlugDefaultValue(const MPlug& plug)
     // the source of a connection or is not connected at all, it's
     // authored-ness only depends on its own value, which is checked below.
     if (plug.isDestination(&status)) {
-        return true;
+        return false;
     }
 
     if (plug.isDefaultValue(true, &status)) {

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -1198,6 +1198,29 @@ bool UsdMayaUtil::IsAuthored(const MPlug& plug)
     return false;
 }
 
+bool UsdMayaUtil::IsPlugDefaultValue(const MPlug& plug)
+{
+    MStatus status;
+
+    if (plug.isNull(&status) || status != MS::kSuccess) {
+        return false;
+    }
+
+    // Plugs that are the destination of a connection are considered authored,
+    // since their value comes from an upstream dependency. If the plug is only
+    // the source of a connection or is not connected at all, it's
+    // authored-ness only depends on its own value, which is checked below.
+    if (plug.isDestination(&status)) {
+        return true;
+    }
+
+    if (plug.isDefaultValue(true, &status)) {
+        return true;
+    }
+    CHECK_MSTATUS(status);
+    return false;
+}
+
 MPlug UsdMayaUtil::GetConnected(const MPlug& plug)
 {
     MStatus    status = MS::kFailure;

--- a/lib/mayaUsd/utils/util.h
+++ b/lib/mayaUsd/utils/util.h
@@ -374,6 +374,9 @@ MAYAUSD_CORE_PUBLIC
 bool IsAuthored(const MPlug& plug);
 
 MAYAUSD_CORE_PUBLIC
+bool IsPlugDefaultValue(const MPlug& plug);
+
+MAYAUSD_CORE_PUBLIC
 MPlug GetConnected(const MPlug& plug);
 
 MAYAUSD_CORE_PUBLIC

--- a/lib/usd/pxrUsdPreviewSurface/usdPreviewSurfaceWriter.cpp
+++ b/lib/usd/pxrUsdPreviewSurface/usdPreviewSurfaceWriter.cpp
@@ -118,7 +118,7 @@ static bool _AuthorShaderInputFromShadingNodeAttr(
         return false;
     }
 
-    if (UsdMayaUtil::IsAuthored(shadingNodePlug)) {
+    if (!UsdMayaUtil::IsPlugDefaultValue(shadingNodePlug)) {
         // Color values are all linear on the shader, so do not re-linearize
         // them.
         VtValue value = UsdMayaWriteUtil::GetVtValue(


### PR DESCRIPTION
Hi:

This PR fixes #796, where referenced material attributes at non-default values were not getting exported to USD, causing a discrepancy in what was shown in Maya compared to what was getting exported.

Please review and raise any concerns.