### PR TITLE
MAYA-110731:  Support Building Gulark library locally

### DIFF
--- a/cmake/gulark.cmake
+++ b/cmake/gulark.cmake
@@ -14,16 +14,35 @@
 # limitations under the License.
 #
 
+set(CONTENT_NAME gulark)
+
 include(FetchContent)
 
 set(FETCHCONTENT_QUIET OFF)
 
-FetchContent_Declare(
-    gulark
-    GIT_REPOSITORY https://github.com/gulrak/filesystem.git
-    GIT_TAG        v1.5.0
-    USES_TERMINAL_DOWNLOAD TRUE
-    GIT_CONFIG     advice.detachedHead=false
-)
+# GULARK_SOURCE_DIR : Set this to the directory where you have cloned gulark filesystem repo, 
+#                     if you would like to bypass pulling from Github repository via Internet.
+if(DEFINED GULARK_SOURCE_DIR)
+    message(STATUS "**** Building Gulark From " ${GULARK_SOURCE_DIR} )
 
-FetchContent_MakeAvailable(gulark)
+    FetchContent_Declare(
+        ${CONTENT_NAME}
+        URL ${GULARK_SOURCE_DIR}
+    ) 
+
+    string(TOUPPER ${CONTENT_NAME} UPPERGULARK)
+    mark_as_advanced(FETCHCONTENT_SOURCE_DIR_${UPPERGULARK})
+    mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_${UPPERGULARK})
+
+else()
+    message(STATUS "**** Building Gulark From Github Repository.")
+    FetchContent_Declare(
+        ${CONTENT_NAME}
+        GIT_REPOSITORY https://github.com/gulrak/filesystem.git
+        GIT_TAG        v1.5.0
+        USES_TERMINAL_DOWNLOAD TRUE
+        GIT_CONFIG     advice.detachedHead=false
+    )
+endif()
+
+FetchContent_MakeAvailable(${CONTENT_NAME})

--- a/cmake/gulark.cmake
+++ b/cmake/gulark.cmake
@@ -14,21 +14,20 @@
 # limitations under the License.
 #
 
-set(CONTENT_NAME gulark)
-
 include(FetchContent)
+
+set(CONTENT_NAME gulark)
 
 set(FETCHCONTENT_QUIET OFF)
 
 # GULARK_SOURCE_DIR : Set this to the directory where you have cloned gulark filesystem repo, 
 #                     if you would like to bypass pulling from Github repository via Internet.
 if(DEFINED GULARK_SOURCE_DIR)
-    message(STATUS "**** Building Gulark From " ${GULARK_SOURCE_DIR} )
-
+    message(STATUS "**** Building Gulark From " ${GULARK_SOURCE_DIR})
     FetchContent_Declare(
         ${CONTENT_NAME}
         URL ${GULARK_SOURCE_DIR}
-    ) 
+    )
 
     string(TOUPPER ${CONTENT_NAME} UPPERGULARK)
     mark_as_advanced(FETCHCONTENT_SOURCE_DIR_${UPPERGULARK})

--- a/cmake/gulark.cmake
+++ b/cmake/gulark.cmake
@@ -38,7 +38,7 @@ else()
     FetchContent_Declare(
         ${CONTENT_NAME}
         GIT_REPOSITORY https://github.com/gulrak/filesystem.git
-        GIT_TAG        v1.5.0
+        GIT_TAG        3d3c02ce35dcc68b5ebb34f21cb1fc507be9a66e
         USES_TERMINAL_DOWNLOAD TRUE
         GIT_CONFIG     advice.detachedHead=false
     )


### PR DESCRIPTION
This PR adds support for building Gulark via local source to avoid the need to pull directly from an external repo which requires an internet connectivity.

**Instruction:**

Set `GULARK_SOURCE_DIR` to the local directory where you have cloned gulark repo:
e.g

`--build-args=-DGULARK_SOURCE_DIR="path_to_your_gulark_local_source_directory"
`

Further discussion: https://github.com/Autodesk/maya-usd/discussions/1286 , 
