### PR TITLE
MAYA-110596 MAYA-110576 faster point snapping

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -709,7 +709,7 @@ void HdVP2BasisCurves::_UpdateDrawItem(
     HdVP2DrawItem*               drawItem,
     HdBasisCurvesReprDesc const& desc)
 {
-    const MHWRender::MRenderItem* renderItem = drawItem->GetRenderItem();
+    MHWRender::MRenderItem* renderItem = drawItem->GetRenderItem();
     if (ARCH_UNLIKELY(!renderItem)) {
         return;
     }
@@ -745,7 +745,13 @@ void HdVP2BasisCurves::_UpdateDrawItem(
     // doesn't need to extract index data from topology. Points use non-indexed
     // draw.
     const bool isBoundingBoxItem = (drawMode == MHWRender::MGeometry::kBoundingBox);
+
+#ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
+    constexpr bool isPointSnappingItem = false;
+#else
     const bool isPointSnappingItem = (renderItem->primitive() == MHWRender::MGeometry::kPoints);
+#endif
+
     const bool requiresIndexUpdate = !isBoundingBoxItem && !isPointSnappingItem;
 
     // Prepare index buffer.
@@ -1298,6 +1304,20 @@ void HdVP2BasisCurves::_UpdateDrawItem(
               | HdChangeTracker::DirtyPrimvar | HdChangeTracker::DirtyTopology
               | DirtySelectionHighlight));
 
+#ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
+    if ((itemDirtyBits & DirtySelectionHighlight) && !isBoundingBoxItem) {
+        MSelectionMask selectionMask(MSelectionMask::kSelectNurbsCurves);
+
+        // Only unselected Rprims can be used for point snapping.
+        if (_selectionStatus == kUnselected) {
+            selectionMask.addMask(MSelectionMask::kSelectPointsForGravity);
+        }
+
+        // The function is thread-safe, thus called in place to keep simple.
+        renderItem->setSelectionMask(selectionMask);
+    }
+#endif
+
     // Reset dirty bits because we've prepared commit state for this draw item.
     drawItem->ResetDirtyBits();
 
@@ -1637,9 +1657,11 @@ void HdVP2BasisCurves::_InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBit
                 drawItem->AddUsage(HdVP2DrawItem::kSelectionHighlight);
             }
             break;
+#ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
         case HdBasisCurvesGeomStylePoints:
             renderItem = _CreatePointsRenderItem(renderItemName);
             break;
+#endif
         default: TF_WARN("Unsupported geomStyle"); break;
         }
 
@@ -1802,7 +1824,14 @@ MHWRender::MRenderItem* HdVP2BasisCurves::_CreateWireRenderItem(const MString& n
     renderItem->castsShadows(false);
     renderItem->receivesShadows(false);
     renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueGray));
+
+#ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
+    MSelectionMask selectionMask(MSelectionMask::kSelectNurbsCurves);
+    selectionMask.addMask(MSelectionMask::kSelectPointsForGravity);
+    renderItem->setSelectionMask(selectionMask);
+#else
     renderItem->setSelectionMask(MSelectionMask::kSelectNurbsCurves);
+#endif
 
 #if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeNurbsCurves);
@@ -1847,7 +1876,14 @@ MHWRender::MRenderItem* HdVP2BasisCurves::_CreatePatchRenderItem(const MString& 
     renderItem->castsShadows(false);
     renderItem->receivesShadows(false);
     renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueGray));
+
+#ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
+    MSelectionMask selectionMask(MSelectionMask::kSelectNurbsCurves);
+    selectionMask.addMask(MSelectionMask::kSelectPointsForGravity);
+    renderItem->setSelectionMask(selectionMask);
+#else
     renderItem->setSelectionMask(MSelectionMask::kSelectNurbsCurves);
+#endif
 
 #if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeNurbsCurves);
@@ -1858,6 +1894,7 @@ MHWRender::MRenderItem* HdVP2BasisCurves::_CreatePatchRenderItem(const MString& 
     return renderItem;
 }
 
+#ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
 /*! \brief  Create render item for points repr.
  */
 MHWRender::MRenderItem* HdVP2BasisCurves::_CreatePointsRenderItem(const MString& name) const
@@ -1882,5 +1919,6 @@ MHWRender::MRenderItem* HdVP2BasisCurves::_CreatePointsRenderItem(const MString&
 
     return renderItem;
 }
+#endif
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
@@ -147,7 +147,10 @@ private:
     MHWRender::MRenderItem* _CreatePatchRenderItem(const MString& name) const;
     MHWRender::MRenderItem* _CreateWireRenderItem(const MString& name) const;
     MHWRender::MRenderItem* _CreateBBoxRenderItem(const MString& name) const;
+
+#ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
     MHWRender::MRenderItem* _CreatePointsRenderItem(const MString& name) const;
+#endif
 
     enum DirtyBits : HdDirtyBits
     {

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1301,9 +1301,7 @@ void HdVP2Mesh::_InitRepr(const TfToken& reprToken, HdDirtyBits* dirtyBits)
             }
             break;
 #ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
-        case HdMeshGeomStylePoints:
-            renderItem = _CreatePointsRenderItem(renderItemName);
-            break;
+        case HdMeshGeomStylePoints: renderItem = _CreatePointsRenderItem(renderItemName); break;
 #endif
         default: TF_WARN("Unsupported geomStyle"); break;
         }
@@ -1876,8 +1874,8 @@ void HdVP2Mesh::_UpdateDrawItem(
               | HdChangeTracker::DirtyPrimvar | HdChangeTracker::DirtyTopology));
 
 #ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
-    if ((itemDirtyBits & DirtySelectionHighlight) &&
-        !isBBoxItem && !isDedicatedSelectionHighlightItem) {
+    if (!isBBoxItem && !isDedicatedSelectionHighlightItem
+        && (itemDirtyBits & DirtySelectionHighlight)) {
         MSelectionMask selectionMask(MSelectionMask::kSelectMeshes);
 
         // Only unselected Rprims can be used for point snapping.

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
@@ -157,8 +157,11 @@ private:
     MHWRender::MRenderItem* _CreateSelectionHighlightRenderItem(const MString& name) const;
     MHWRender::MRenderItem* _CreateSmoothHullRenderItem(const MString& name) const;
     MHWRender::MRenderItem* _CreateWireframeRenderItem(const MString& name) const;
-    MHWRender::MRenderItem* _CreatePointsRenderItem(const MString& name) const;
     MHWRender::MRenderItem* _CreateBoundingBoxRenderItem(const MString& name) const;
+
+#ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
+    MHWRender::MRenderItem* _CreatePointsRenderItem(const MString& name) const;
+#endif
 
     static void _InitGPUCompute();
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -782,12 +782,11 @@ void ProxyRenderDelegate::updateSelectionGranularity(
     const MDagPath&               path,
     MHWRender::MSelectionContext& selectionContext)
 {
-    // The component level is coarse-grain, causing Maya to produce selection hits with undesired
-    // selection levels, i.e. face/edge selection hits, as well as vertex selection hits that are
-    // required by point snapping. Switch to the new vertex selection level if available in order
-    // to produce vertex selection hits only.
+    // The component level is coarse-grain, causing Maya to produce undesired face/edge selection
+    // hits, as well as vertex selection hits that are required for point snapping. Switch to the
+    // new vertex selection level if available in order to produce vertex selection hits only.
     if (pointSnappingActive()) {
-#if MAYA_API_VERSION >= 20230000 // HDC_TODO: 20230000 -> 20220100
+#if MAYA_API_VERSION >= 20220100
         selectionContext.setSelectionLevel(MHWRender::MSelectionContext::kVertex);
 #else
         selectionContext.setSelectionLevel(MHWRender::MSelectionContext::kComponent);

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -694,7 +694,12 @@ void ProxyRenderDelegate::_Execute(const MHWRender::MFrameContext& frameContext)
 #endif // defined(WANT_UFE_BUILD)
 
 #else  // !defined(MAYA_ENABLE_UPDATE_FOR_SELECTION)
+
+#ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
+    HdReprSelector reprSelector;
+#else
     HdReprSelector reprSelector = kPointsReprSelector;
+#endif
 
     constexpr bool inSelectionPass = false;
     constexpr bool inPointSnapping = false;

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -777,13 +777,21 @@ void ProxyRenderDelegate::update(MSubSceneContainer& container, const MFrameCont
     param->EndUpdate();
 }
 
-//! \brief  Switch to component-level selection for point snapping.
+//! \brief  Update selection granularity for point snapping.
 void ProxyRenderDelegate::updateSelectionGranularity(
     const MDagPath&               path,
     MHWRender::MSelectionContext& selectionContext)
 {
+    // The component level is coarse-grain, causing Maya to produce selection hits with undesired
+    // selection levels, i.e. face/edge selection hits, as well as vertex selection hits that are
+    // required by point snapping. Switch to the new vertex selection level if available in order
+    // to produce vertex selection hits only.
     if (pointSnappingActive()) {
+#if MAYA_API_VERSION >= 20230000 // HDC_TODO: 20230000 -> 20220100
+        selectionContext.setSelectionLevel(MHWRender::MSelectionContext::kVertex);
+#else
         selectionContext.setSelectionLevel(MHWRender::MSelectionContext::kComponent);
+#endif
     }
 }
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -693,7 +693,7 @@ void ProxyRenderDelegate::_Execute(const MHWRender::MFrameContext& frameContext)
     }
 #endif // defined(WANT_UFE_BUILD)
 
-#else // !defined(MAYA_ENABLE_UPDATE_FOR_SELECTION)
+#else  // !defined(MAYA_ENABLE_UPDATE_FOR_SELECTION)
     HdReprSelector reprSelector = kPointsReprSelector;
 
     constexpr bool inSelectionPass = false;
@@ -885,7 +885,7 @@ bool ProxyRenderDelegate::getInstancedSelectionPath(
 #if defined(MAYA_ENABLE_UPDATE_FOR_SELECTION)
     const TfToken&                   selectionKind = _selectionKind;
     const UsdPointInstancesPickMode& pointInstancesPickMode = _pointInstancesPickMode;
-    const MGlobal::ListAdjustment& listAdjustment = _globalListAdjustment;
+    const MGlobal::ListAdjustment&   listAdjustment = _globalListAdjustment;
 #else
     const TfToken selectionKind = GetSelectionKind();
     const UsdPointInstancesPickMode pointInstancesPickMode = GetPointInstancesPickMode();

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -693,7 +693,7 @@ void ProxyRenderDelegate::_Execute(const MHWRender::MFrameContext& frameContext)
     }
 #endif // defined(WANT_UFE_BUILD)
 
-#else  // !defined(MAYA_ENABLE_UPDATE_FOR_SELECTION)
+#else // !defined(MAYA_ENABLE_UPDATE_FOR_SELECTION)
 
 #ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
     HdReprSelector reprSelector;

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -888,12 +888,14 @@ bool ProxyRenderDelegate::getInstancedSelectionPath(
     const TfToken&                   selectionKind = _selectionKind;
     const UsdPointInstancesPickMode& pointInstancesPickMode = _pointInstancesPickMode;
 #ifndef UFE_V2_FEATURES_AVAILABLE
-    const MGlobal::ListAdjustment& listAdjustment = _globalListAdjustment;
+    const MGlobal::ListAdjustment listAdjustment = _globalListAdjustment;
 #endif
 #else
     const TfToken selectionKind = GetSelectionKind();
     const UsdPointInstancesPickMode pointInstancesPickMode = GetPointInstancesPickMode();
+#ifndef UFE_V2_FEATURES_AVAILABLE
     const MGlobal::ListAdjustment listAdjustment = GetListAdjustment();
+#endif
 #endif
 
     UsdPrim       prim = _proxyShapeData->UsdStage()->GetPrimAtPath(usdPath);

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -40,8 +40,13 @@
 #include <ufe/observer.h>
 #endif
 
+// The new Maya point snapping support doesn't require point snapping items any more.
+#if MAYA_API_VERSION >= 20230000 // HDC_TODO: 20230000 -> 20220200
+#define MAYA_NEW_POINT_SNAPPING_SUPPORT
+#endif
+
 // Conditional compilation due to Maya API gap.
-#if MAYA_API_VERSION >= 20200000
+#if MAYA_API_VERSION >= 20200000 && !defined(MAYA_NEW_POINT_SNAPPING_SUPPORT)
 #define MAYA_ENABLE_UPDATE_FOR_SELECTION
 #endif
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -41,7 +41,7 @@
 #endif
 
 // The new Maya point snapping support doesn't require point snapping items any more.
-#if MAYA_API_VERSION >= 20230000 // HDC_TODO: 20230000 -> 20220200
+#if MAYA_API_VERSION >= 20230000
 #define MAYA_NEW_POINT_SNAPPING_SUPPORT
 #endif
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -46,7 +46,7 @@
 #endif
 
 // Conditional compilation due to Maya API gap.
-#if MAYA_API_VERSION >= 20200000 && !defined(MAYA_NEW_POINT_SNAPPING_SUPPORT)
+#if MAYA_API_VERSION >= 20200000
 #define MAYA_ENABLE_UPDATE_FOR_SELECTION
 #endif
 


### PR DESCRIPTION
The component level is coarse-grain, causing Maya to produce selection hits with undesired selection levels, i.e. face/edge selection hits, as well as vertex selection hits that are required by point snapping. Switch to the new vertex selection level if available in order to produce vertex selection hits only.