### PR TITLE
MAYA-110670: block attribute authoring in weaker layers in legacy transform3d

### DIFF
--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -25,6 +25,8 @@
 
 #include <pxr/usd/usdGeom/xformCache.h>
 
+#include <maya/MGlobal.h>
+
 PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace MAYAUSD_NS_DEF {
@@ -60,6 +62,26 @@ Ufe::Matrix4d primToUfeExclusiveXform(const UsdPrim& prim, const UsdTimeCode& ti
     Ufe::Matrix4d     xform = convertFromUsd(usdMatrix);
     return xform;
 }
+
+std::string isAttributeEditAllowed(const PXR_NS::UsdPrim& prim, const std::string& tokenName)
+{
+    std::string errMsg;
+
+    // check for xformOp:tokenName in XformOpOrderAttr first
+    UsdGeomXformable xformable(prim);
+    if (!MayaUsd::ufe::isAttributeEditAllowed(xformable.GetXformOpOrderAttr(), &errMsg)) {
+        MGlobal::displayError(errMsg.c_str());
+    } else {
+        // check for xformOp:tokenName
+        const TfToken xlate(tokenName);
+        if (!MayaUsd::ufe::isAttributeEditAllowed(prim.GetAttribute(xlate), &errMsg)) {
+            MGlobal::displayError(errMsg.c_str());
+        }
+    }
+
+    return errMsg;
+}
+
 } // namespace
 
 UsdTransform3d::UsdTransform3d()
@@ -95,6 +117,10 @@ Ufe::SceneItem::Ptr UsdTransform3d::sceneItem() const { return fItem; }
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd(double x, double y, double z)
 {
+    if (!isAttributeEditAllowed(prim(), "xformOp:translate").empty()) {
+        return nullptr;
+    }
+
     return UsdTranslateUndoableCommand::create(path(), x, y, z);
 }
 #endif
@@ -155,6 +181,10 @@ Ufe::Vector3d UsdTransform3d::scale() const
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd(double x, double y, double z)
 {
+    if (!isAttributeEditAllowed(prim(), "xformOp:rotateXYZ").empty()) {
+        return nullptr;
+    }
+
     return UsdRotateUndoableCommand::create(path(), x, y, z);
 }
 #endif
@@ -167,22 +197,38 @@ void UsdTransform3d::rotate(double x, double y, double z)
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd(double x, double y, double z)
 {
+    if (!isAttributeEditAllowed(prim(), "xformOp:scale").empty()) {
+        return nullptr;
+    }
+
     return UsdScaleUndoableCommand::create(path(), x, y, z);
 }
 
 #else
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd()
 {
+    if (!isAttributeEditAllowed(prim(), "xformOp:translate").empty()) {
+        return nullptr;
+    }
+
     return UsdTranslateUndoableCommand::create(fItem, 0, 0, 0);
 }
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd()
 {
+    if (!isAttributeEditAllowed(prim(), "xformOp:rotateXYZ").empty()) {
+        return nullptr;
+    }
+
     return UsdRotateUndoableCommand::create(fItem, 0, 0, 0);
 }
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd()
 {
+    if (!isAttributeEditAllowed(prim(), "xformOp:scale").empty()) {
+        return nullptr;
+    }
+
     return UsdScaleUndoableCommand::create(fItem, 1, 1, 1);
 }
 #endif
@@ -226,6 +272,10 @@ UsdTransform3d::rotatePivotCmd(double, double, double)
 UsdTransform3d::rotatePivotTranslateCmd()
 #endif
 {
+    if (!isAttributeEditAllowed(prim(), "xformOp:translate:pivot").empty()) {
+        return nullptr;
+    }
+
     // As of 12-Oct-2020, setting rotate pivot on command creation
     // unsupported.  Use translate() method on returned command.
     return UsdRotatePivotTranslateUndoableCommand::create(

--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -63,7 +63,7 @@ Ufe::Matrix4d primToUfeExclusiveXform(const UsdPrim& prim, const UsdTimeCode& ti
     return xform;
 }
 
-std::string isAttributeEditAllowed(const PXR_NS::UsdPrim& prim, const std::string& tokenName)
+bool isAttributeEditAllowed(const PXR_NS::UsdPrim& prim, const std::string& tokenName)
 {
     std::string errMsg;
 
@@ -71,15 +71,17 @@ std::string isAttributeEditAllowed(const PXR_NS::UsdPrim& prim, const std::strin
     UsdGeomXformable xformable(prim);
     if (!MayaUsd::ufe::isAttributeEditAllowed(xformable.GetXformOpOrderAttr(), &errMsg)) {
         MGlobal::displayError(errMsg.c_str());
+        return false;
     } else {
         // check for xformOp:tokenName
         const TfToken xlate(tokenName);
         if (!MayaUsd::ufe::isAttributeEditAllowed(prim.GetAttribute(xlate), &errMsg)) {
             MGlobal::displayError(errMsg.c_str());
+            return false;
         }
     }
 
-    return errMsg;
+    return true;
 }
 
 } // namespace
@@ -117,7 +119,7 @@ Ufe::SceneItem::Ptr UsdTransform3d::sceneItem() const { return fItem; }
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:translate").empty()) {
+    if (!isAttributeEditAllowed(prim(), "xformOp:translate")) {
         return nullptr;
     }
 
@@ -181,7 +183,7 @@ Ufe::Vector3d UsdTransform3d::scale() const
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:rotateXYZ").empty()) {
+    if (!isAttributeEditAllowed(prim(), "xformOp:rotateXYZ")) {
         return nullptr;
     }
 
@@ -197,7 +199,7 @@ void UsdTransform3d::rotate(double x, double y, double z)
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:scale").empty()) {
+    if (!isAttributeEditAllowed(prim(), "xformOp:scale")) {
         return nullptr;
     }
 
@@ -207,7 +209,7 @@ Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd(double x, double y, doub
 #else
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd()
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:translate").empty()) {
+    if (!isAttributeEditAllowed(prim(), "xformOp:translate")) {
         return nullptr;
     }
 
@@ -216,7 +218,7 @@ Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd()
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd()
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:rotateXYZ").empty()) {
+    if (!isAttributeEditAllowed(prim(), "xformOp:rotateXYZ")) {
         return nullptr;
     }
 
@@ -225,7 +227,7 @@ Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd()
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd()
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:scale").empty()) {
+    if (!isAttributeEditAllowed(prim(), "xformOp:scale")) {
         return nullptr;
     }
 
@@ -272,7 +274,7 @@ UsdTransform3d::rotatePivotCmd(double, double, double)
 UsdTransform3d::rotatePivotTranslateCmd()
 #endif
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:translate:pivot").empty()) {
+    if (!isAttributeEditAllowed(prim(), "xformOp:translate:pivot")) {
         return nullptr;
     }
 

--- a/test/lib/ufe/CMakeLists.txt
+++ b/test/lib/ufe/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_SCRIPT_FILES
     testPythonWrappers.py
     testSelection.py
     testUfePythonImport.py
+    testAttributeBlock.py
 )
 
 set(TEST_SUPPORT_FILES

--- a/test/lib/ufe/testAttributeBlock.py
+++ b/test/lib/ufe/testAttributeBlock.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2021 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import fixturesUtils
+import mayaUtils
+import ufeUtils
+import usdUtils
+
+from pxr import UsdGeom, Vt, Gf
+
+from maya import cmds
+from maya import standalone
+
+import mayaUsd
+from mayaUsd import ufe as mayaUsdUfe
+
+import ufe
+import os
+import unittest
+
+class AttributeBlockTestCase(unittest.TestCase):
+
+    pluginsLoaded = False
+   
+    @classmethod
+    def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
+        if not cls.pluginsLoaded:
+            cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def setUp(self):
+        ''' Called initially to set up the Maya test environment '''
+        # Load plugins
+        self.assertTrue(self.pluginsLoaded)
+
+        # Clear selection to start off
+        cmds.select(clear=True)
+
+    def testSingleAttributeBlocking(self):
+        ''' Authoring attribute(s) in weaker layer(s) are not permitted if there exist opinion(s) in stronger layer(s).'''
+
+        # create new stage
+        cmds.file(new=True, force=True)
+
+        # Open usdCylinder.ma scene in testSamples
+        mayaUtils.openCylinderScene()
+
+        # get the stage
+        proxyShapes = cmds.ls(type="mayaUsdProxyShapeBase", long=True)
+        proxyShapePath = proxyShapes[0]
+        stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
+
+        # cylinder prim
+        cylinderPrim = stage.GetPrimAtPath('/pCylinder1')
+        self.assertIsNotNone(cylinderPrim)
+
+        # author a new radius value
+        self.assertTrue(cylinderPrim.HasAttribute('doubleSided'))
+        doubleSidedAttr = cylinderPrim.GetAttribute('doubleSided')
+
+        # authoring new attribute edit is expected to be allowed.
+        self.assertTrue(mayaUsdUfe.isAttributeEditAllowed(doubleSidedAttr))
+        doubleSidedAttr.Set(0)
+
+        # create a sub-layer.
+        rootLayer = stage.GetRootLayer()
+        subLayerA = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="LayerA")[0]
+
+        # check to see the if the sublayers was added
+        addedLayers = [subLayerA]
+        self.assertEqual(rootLayer.subLayerPaths, addedLayers)
+
+        # set the edit target to LayerA.
+        cmds.mayaUsdEditTarget(proxyShapePath, edit=True, editTarget=subLayerA)
+
+        # doubleSidedAttr is not allowed to change since there is an opinion in a stronger layer
+        self.assertFalse(mayaUsdUfe.isAttributeEditAllowed(doubleSidedAttr))
+
+    def testTransformationAttributeBlocking(self):
+        '''Authoring transformation attribute(s) in weaker layer(s) are not permitted if there exist opinion(s) in stronger layer(s).'''
+
+        # create new stage
+        cmds.file(new=True, force=True)
+
+        # Open usdCylinder.ma scene in testSamples
+        mayaUtils.openCylinderScene()
+
+        # get the stage
+        proxyShapes = cmds.ls(type="mayaUsdProxyShapeBase", long=True)
+        proxyShapePath = proxyShapes[0]
+        stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
+
+        # cylinder prim
+        cylinderPrim = stage.GetPrimAtPath('/pCylinder1')
+        self.assertIsNotNone(cylinderPrim)
+
+         # create 3 sub-layers ( LayerA, LayerB, LayerC ) and set the edit target to LayerB.
+        rootLayer = stage.GetRootLayer()
+        subLayerC = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="SubLayerC")[0]
+        subLayerB = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="SubLayerB")[0]
+        subLayerA = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="SubLayerA")[0]
+
+        # check to see the sublayers added
+        addedLayers = [subLayerA, subLayerB, subLayerC]
+        self.assertEqual(rootLayer.subLayerPaths, addedLayers)
+
+        # set the edit target to LayerB
+        cmds.mayaUsdEditTarget(proxyShapePath, edit=True, editTarget=subLayerB)
+
+        # create a transform3d
+        cylinderPath = ufe.Path([
+                     mayaUtils.createUfePathSegment("|mayaUsdTransform|shape"), 
+                     usdUtils.createUfePathSegment("/pCylinder1")])
+        cylinderItem = ufe.Hierarchy.createItem(cylinderPath)
+
+        cylinderT3d = ufe.Transform3d.transform3d(cylinderItem)
+
+        # create a xformable
+        cylinderXformable = UsdGeom.Xformable(cylinderPrim)
+
+        # writing to "transform op order" is expected to be allowed.
+        self.assertTrue(mayaUsdUfe.isAttributeEditAllowed(cylinderXformable.GetXformOpOrderAttr()))
+
+        # do any transform editing.
+        cylinderT3d = ufe.Transform3d.transform3d(cylinderItem)
+        cylinderT3d.scale(2.5, 2.5, 2.5)
+        cylinderT3d.translate(4.0, 2.0, 3.0)
+
+        # check the "transform op order" stack.
+        self.assertEqual(cylinderXformable.GetXformOpOrderAttr().Get(), Vt.TokenArray(('xformOp:translate', 'xformOp:scale')))
+
+        # check if translate attribute is editable
+        translateAttr = cylinderPrim.GetAttribute('xformOp:translate')
+        self.assertIsNotNone(translateAttr)
+
+        # authoring new transformation edit is expected to be allowed.
+        self.assertTrue(mayaUsdUfe.isAttributeEditAllowed(translateAttr))
+        cylinderT3d.translate(5.0, 6.0, 7.0)
+        self.assertEqual(translateAttr.Get(), Gf.Vec3d(5.0, 6.0, 7.0))
+
+        # set the edit target to a weaker layer (LayerC)
+        cmds.mayaUsdEditTarget(proxyShapePath, edit=True, editTarget=subLayerC)
+
+        # authoring new transformation edit is not allowed.
+        self.assertFalse(mayaUsdUfe.isAttributeEditAllowed(translateAttr))
+
+        # set the edit target to a stronger layer (LayerA)
+        cmds.mayaUsdEditTarget(proxyShapePath, edit=True, editTarget=subLayerA)
+
+        # authoring new transformation edit is allowed.
+        self.assertTrue(mayaUsdUfe.isAttributeEditAllowed(translateAttr))
+        cylinderT3d.rotate(0.0, 90.0, 0.0)
+
+        # check the "transform op order" stack.
+        self.assertEqual(cylinderXformable.GetXformOpOrderAttr().Get(), Vt.TokenArray(('xformOp:translate','xformOp:rotateXYZ', 'xformOp:scale')))
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This PR adds support for blocking attribute authoring in weaker layer in "legacy transform3d" via UFE1.0 && 2.0