### PR TITLE
MAYA-110706: Block attribute edits for the remaining transformation stacks (UsdTransform3dCommonAPI, UsdTransform3dMatrixOp)

### DIFF
--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -25,8 +25,6 @@
 
 #include <pxr/usd/usdGeom/xformCache.h>
 
-#include <maya/MGlobal.h>
-
 PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace MAYAUSD_NS_DEF {

--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -63,27 +63,6 @@ Ufe::Matrix4d primToUfeExclusiveXform(const UsdPrim& prim, const UsdTimeCode& ti
     return xform;
 }
 
-bool isAttributeEditAllowed(const PXR_NS::UsdPrim& prim, const std::string& tokenName)
-{
-    std::string errMsg;
-
-    // check for xformOp:tokenName in XformOpOrderAttr first
-    UsdGeomXformable xformable(prim);
-    if (!MayaUsd::ufe::isAttributeEditAllowed(xformable.GetXformOpOrderAttr(), &errMsg)) {
-        MGlobal::displayError(errMsg.c_str());
-        return false;
-    } else {
-        // check for xformOp:tokenName
-        const TfToken xlate(tokenName);
-        if (!MayaUsd::ufe::isAttributeEditAllowed(prim.GetAttribute(xlate), &errMsg)) {
-            MGlobal::displayError(errMsg.c_str());
-            return false;
-        }
-    }
-
-    return true;
-}
-
 } // namespace
 
 UsdTransform3d::UsdTransform3d()

--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -98,7 +98,7 @@ Ufe::SceneItem::Ptr UsdTransform3d::sceneItem() const { return fItem; }
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:translate")) {
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
         return nullptr;
     }
 
@@ -162,7 +162,7 @@ Ufe::Vector3d UsdTransform3d::scale() const
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:rotateXYZ")) {
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
         return nullptr;
     }
 
@@ -178,7 +178,7 @@ void UsdTransform3d::rotate(double x, double y, double z)
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:scale")) {
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
         return nullptr;
     }
 
@@ -188,7 +188,7 @@ Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd(double x, double y, doub
 #else
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd()
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:translate")) {
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
         return nullptr;
     }
 
@@ -197,7 +197,7 @@ Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd()
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd()
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:rotateXYZ")) {
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
         return nullptr;
     }
 
@@ -206,7 +206,7 @@ Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd()
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd()
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:scale")) {
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
         return nullptr;
     }
 
@@ -253,7 +253,7 @@ UsdTransform3d::rotatePivotCmd(double, double, double)
 UsdTransform3d::rotatePivotTranslateCmd()
 #endif
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:translate:pivot")) {
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate:pivot"))) {
         return nullptr;
     }
 

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
@@ -19,6 +19,8 @@
 
 #include <pxr/usd/usdGeom/xformCache.h>
 
+#include <maya/MGlobal.h>
+
 PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace MAYAUSD_NS_DEF {
@@ -264,22 +266,38 @@ void UsdTransform3dCommonAPI::scale(double x, double y, double z)
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dCommonAPI::translateCmd(double x, double y, double z)
 {
+    if (!isAttributeEditAllowed(prim(), "xformOp:translate")) {
+        return nullptr;
+    }
+
     return std::make_shared<UsdTranslateUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3dCommonAPI::rotateCmd(double x, double y, double z)
 {
+    if (!isAttributeEditAllowed(prim(), "xformOp:rotateXYZ")) {
+        return nullptr;
+    }
+
     return std::make_shared<UsdRotateUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3dCommonAPI::scaleCmd(double x, double y, double z)
 {
+    if (!isAttributeEditAllowed(prim(), "xformOp:scale")) {
+        return nullptr;
+    }
+
     return std::make_shared<UsdScaleUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dCommonAPI::rotatePivotCmd(double x, double y, double z)
 {
+    if (!isAttributeEditAllowed(prim(), "xformOp:translate:pivot")) {
+        return nullptr;
+    }
+
     return std::make_shared<UsdTranslatePivotUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
@@ -19,8 +19,6 @@
 
 #include <pxr/usd/usdGeom/xformCache.h>
 
-#include <maya/MGlobal.h>
-
 PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace MAYAUSD_NS_DEF {

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
@@ -266,7 +266,7 @@ void UsdTransform3dCommonAPI::scale(double x, double y, double z)
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dCommonAPI::translateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:translate")) {
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
         return nullptr;
     }
 
@@ -275,7 +275,7 @@ UsdTransform3dCommonAPI::translateCmd(double x, double y, double z)
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3dCommonAPI::rotateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:rotateXYZ")) {
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
         return nullptr;
     }
 
@@ -284,7 +284,7 @@ Ufe::RotateUndoableCommand::Ptr UsdTransform3dCommonAPI::rotateCmd(double x, dou
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3dCommonAPI::scaleCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:scale")) {
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
         return nullptr;
     }
 
@@ -294,7 +294,7 @@ Ufe::ScaleUndoableCommand::Ptr UsdTransform3dCommonAPI::scaleCmd(double x, doubl
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dCommonAPI::rotatePivotCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:translate:pivot")) {
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate:pivot"))) {
         return nullptr;
     }
 

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -29,6 +29,7 @@
 #include <pxr/usd/usdGeom/xformOp.h>
 #include <pxr/usd/usdGeom/xformable.h>
 
+#include <maya/MGlobal.h>
 #include <ufe/transform3dUndoableCommands.h>
 
 #include <algorithm>
@@ -367,6 +368,10 @@ Ufe::Vector3d UsdTransform3dMatrixOp::scale() const
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dMatrixOp::translateCmd(double x, double y, double z)
 {
+    if (!::isAttributeEditAllowed(prim(), "xformOp:translate")) {
+        return nullptr;
+    }
+
     return std::make_shared<UsdTranslateUndoableCmd>(
 #ifdef UFE_V2_FEATURES_AVAILABLE
         path(),
@@ -379,6 +384,10 @@ UsdTransform3dMatrixOp::translateCmd(double x, double y, double z)
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3dMatrixOp::rotateCmd(double x, double y, double z)
 {
+    if (!::isAttributeEditAllowed(prim(), "xformOp:rotateXYZ")) {
+        return nullptr;
+    }
+
     return std::make_shared<UsdRotateUndoableCmd>(
 #ifdef UFE_V2_FEATURES_AVAILABLE
         path(),
@@ -391,6 +400,10 @@ Ufe::RotateUndoableCommand::Ptr UsdTransform3dMatrixOp::rotateCmd(double x, doub
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3dMatrixOp::scaleCmd(double x, double y, double z)
 {
+    if (!::isAttributeEditAllowed(prim(), "xformOp:scale")) {
+        return nullptr;
+    }
+
     return std::make_shared<UsdScaleUndoableCmd>(
 #ifdef UFE_V2_FEATURES_AVAILABLE
         path(),

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -29,7 +29,6 @@
 #include <pxr/usd/usdGeom/xformOp.h>
 #include <pxr/usd/usdGeom/xformable.h>
 
-#include <maya/MGlobal.h>
 #include <ufe/transform3dUndoableCommands.h>
 
 #include <algorithm>

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -368,7 +368,7 @@ Ufe::Vector3d UsdTransform3dMatrixOp::scale() const
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dMatrixOp::translateCmd(double x, double y, double z)
 {
-    if (!::isAttributeEditAllowed(prim(), "xformOp:translate")) {
+    if (!isAttributeEditAllowed(prim(), "xformOp:translate")) {
         return nullptr;
     }
 
@@ -384,7 +384,7 @@ UsdTransform3dMatrixOp::translateCmd(double x, double y, double z)
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3dMatrixOp::rotateCmd(double x, double y, double z)
 {
-    if (!::isAttributeEditAllowed(prim(), "xformOp:rotateXYZ")) {
+    if (!isAttributeEditAllowed(prim(), "xformOp:rotateXYZ")) {
         return nullptr;
     }
 
@@ -400,7 +400,7 @@ Ufe::RotateUndoableCommand::Ptr UsdTransform3dMatrixOp::rotateCmd(double x, doub
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3dMatrixOp::scaleCmd(double x, double y, double z)
 {
-    if (!::isAttributeEditAllowed(prim(), "xformOp:scale")) {
+    if (!isAttributeEditAllowed(prim(), "xformOp:scale")) {
         return nullptr;
     }
 

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -368,7 +368,7 @@ Ufe::Vector3d UsdTransform3dMatrixOp::scale() const
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dMatrixOp::translateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:translate")) {
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
         return nullptr;
     }
 
@@ -384,7 +384,7 @@ UsdTransform3dMatrixOp::translateCmd(double x, double y, double z)
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3dMatrixOp::rotateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:rotateXYZ")) {
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
         return nullptr;
     }
 
@@ -400,7 +400,7 @@ Ufe::RotateUndoableCommand::Ptr UsdTransform3dMatrixOp::rotateCmd(double x, doub
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3dMatrixOp::scaleCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), "xformOp:scale")) {
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
         return nullptr;
     }
 

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -420,6 +420,27 @@ bool isAttributeEditAllowed(const PXR_NS::UsdAttribute& attr, std::string* errMs
     return true;
 }
 
+bool isAttributeEditAllowed(const PXR_NS::UsdPrim& prim, const std::string& tokenName)
+{
+    std::string errMsg;
+
+    // check for xformOp:tokenName in XformOpOrderAttr first
+    UsdGeomXformable xformable(prim);
+    if (!isAttributeEditAllowed(xformable.GetXformOpOrderAttr(), &errMsg)) {
+        MGlobal::displayError(errMsg.c_str());
+        return false;
+    } else {
+        // check for xformOp:tokenName
+        const TfToken xlate(tokenName);
+        if (!isAttributeEditAllowed(prim.GetAttribute(xlate), &errMsg)) {
+            MGlobal::displayError(errMsg.c_str());
+            return false;
+        }
+    }
+
+    return true;
+}
+
 Ufe::Selection removeDescendants(const Ufe::Selection& src, const Ufe::Path& filterPath)
 {
     // Filter the src selection, removing items below the filterPath

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -422,24 +422,22 @@ bool isAttributeEditAllowed(const PXR_NS::UsdAttribute& attr, std::string* errMs
 
 bool isAttributeEditAllowed(const UsdPrim& prim, const TfToken& attrName)
 {
-    if (prim.IsA<UsdGeomXformable>()) {
+    std::string errMsg;
 
-        std::string errMsg;
-
-        // check for xformOp:tokenName in XformOpOrderAttr first
-        UsdGeomXformable xformable(prim);
-        if (!isAttributeEditAllowed(xformable.GetXformOpOrderAttr(), &errMsg)) {
-            MGlobal::displayError(errMsg.c_str());
-            return false;
-        } else {
-            // check for xformOp:tokenName
-            if (UsdGeomXformOp::IsXformOp(attrName)) {
-                if (!isAttributeEditAllowed(prim.GetAttribute(attrName), &errMsg)) {
-                    MGlobal::displayError(errMsg.c_str());
-                    return false;
-                }
+    UsdGeomXformable xformable(prim);
+    if (xformable) {
+        if (UsdGeomXformOp::IsXformOp(attrName)) {
+            // check for the attribute in XformOpOrderAttr first
+            if (!isAttributeEditAllowed(xformable.GetXformOpOrderAttr(), &errMsg)) {
+                MGlobal::displayError(errMsg.c_str());
+                return false;
             }
         }
+    }
+    // check the attribute itself
+    if (!isAttributeEditAllowed(prim.GetAttribute(attrName), &errMsg)) {
+        MGlobal::displayError(errMsg.c_str());
+        return false;
     }
 
     return true;

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -420,21 +420,25 @@ bool isAttributeEditAllowed(const PXR_NS::UsdAttribute& attr, std::string* errMs
     return true;
 }
 
-bool isAttributeEditAllowed(const PXR_NS::UsdPrim& prim, const std::string& tokenName)
+bool isAttributeEditAllowed(const UsdPrim& prim, const TfToken& attrName)
 {
-    std::string errMsg;
+    if (prim.IsA<UsdGeomXformable>()) {
 
-    // check for xformOp:tokenName in XformOpOrderAttr first
-    UsdGeomXformable xformable(prim);
-    if (!isAttributeEditAllowed(xformable.GetXformOpOrderAttr(), &errMsg)) {
-        MGlobal::displayError(errMsg.c_str());
-        return false;
-    } else {
-        // check for xformOp:tokenName
-        const TfToken xlate(tokenName);
-        if (!isAttributeEditAllowed(prim.GetAttribute(xlate), &errMsg)) {
+        std::string errMsg;
+
+        // check for xformOp:tokenName in XformOpOrderAttr first
+        UsdGeomXformable xformable(prim);
+        if (!isAttributeEditAllowed(xformable.GetXformOpOrderAttr(), &errMsg)) {
             MGlobal::displayError(errMsg.c_str());
             return false;
+        } else {
+            // check for xformOp:tokenName
+            if (UsdGeomXformOp::IsXformOp(attrName)) {
+                if (!isAttributeEditAllowed(prim.GetAttribute(attrName), &errMsg)) {
+                    MGlobal::displayError(errMsg.c_str());
+                    return false;
+                }
+            }
         }
     }
 

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -130,7 +130,7 @@ MAYAUSD_CORE_PUBLIC
 bool isAttributeEditAllowed(const PXR_NS::UsdAttribute& attr, std::string* errMsg = nullptr);
 
 MAYAUSD_CORE_PUBLIC
-bool isAttributeEditAllowed(const PXR_NS::UsdPrim& prim, const std::string& tokenName);
+bool isAttributeEditAllowed(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attrName);
 
 //! Send notification for data model changes
 template <class T>

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -129,6 +129,9 @@ PXR_NS::TfTokenVector getProxyShapePurposes(const Ufe::Path& path);
 MAYAUSD_CORE_PUBLIC
 bool isAttributeEditAllowed(const PXR_NS::UsdAttribute& attr, std::string* errMsg = nullptr);
 
+MAYAUSD_CORE_PUBLIC
+bool isAttributeEditAllowed(const PXR_NS::UsdPrim& prim, const std::string& tokenName);
+
 //! Send notification for data model changes
 template <class T>
 void sendNotification(const Ufe::SceneItem::Ptr& item, const Ufe::Path& previousPath)

--- a/test/lib/ufe/testAttributeBlock.py
+++ b/test/lib/ufe/testAttributeBlock.py
@@ -261,5 +261,91 @@ class AttributeBlockTestCase(unittest.TestCase):
         # authoring new transformation edit is allowed.
         self.assertTrue(mayaUsdUfe.isAttributeEditAllowed(rotateAttr))
 
+    def testAttributeBlocking3dMatrixOps(self):
+        '''
+        Verify authoring transformation attribute(s) in weaker layer(s) are not permitted if there exist opinion(s) 
+        in stronger layer(s) when using UsdTransform3dMatrixOp.
+        '''
+
+        # create new stage
+        cmds.file(new=True, force=True)
+
+        # Open usdCylinder.ma scene in testSamples
+        mayaUtils.openCylinderScene()
+
+        # get the stage
+        proxyShapes = cmds.ls(type="mayaUsdProxyShapeBase", long=True)
+        proxyShapePath = proxyShapes[0]
+        stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
+
+        # cylinder prim
+        cylinderPrim = stage.GetPrimAtPath('/pCylinder1')
+        self.assertIsNotNone(cylinderPrim)
+
+         # create 3 sub-layers ( LayerA, LayerB, LayerC ) and set the edit target to LayerB.
+        rootLayer = stage.GetRootLayer()
+        subLayerC = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="SubLayerC")[0]
+        subLayerB = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="SubLayerB")[0]
+        subLayerA = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="SubLayerA")[0]
+
+        # check to see the sublayers added
+        addedLayers = [subLayerA, subLayerB, subLayerC]
+        self.assertEqual(rootLayer.subLayerPaths, addedLayers)
+
+        # set the edit target to LayerB
+        cmds.mayaUsdEditTarget(proxyShapePath, edit=True, editTarget=subLayerB)
+
+        # create a xformable and give it a matrix4d xformOp:transform
+        # This will match the UsdTransform3dMatrixOp, but not the Maya API.
+        cylinderXformable = UsdGeom.Xformable(cylinderPrim)
+        transformOp = cylinderXformable.AddTransformOp()
+        xform = Gf.Matrix4d(1.0).SetTranslate(Gf.Vec3d(10, 20, 30))
+        transformOp.Set(xform)
+        self.assertTrue(cylinderPrim.GetPrim().HasAttribute("xformOp:transform"))
+
+        # Now that we have set up the transform stack to be 3dMatrixOp compatible,
+        # create the Transform3d interface.
+        cylinderPath = ufe.Path([
+                     mayaUtils.createUfePathSegment("|mayaUsdTransform|shape"), 
+                     usdUtils.createUfePathSegment("/pCylinder1")])
+        cylinderItem = ufe.Hierarchy.createItem(cylinderPath)
+
+        cylinderT3d = ufe.Transform3d.transform3d(cylinderItem)
+
+        # select the cylinderItem
+        sn = ufe.GlobalSelection.get()
+        sn.clear()
+        sn.append(cylinderItem)
+
+        # move
+        cmds.move(65, 20, 10)
+        self.assertEqual(cylinderXformable.GetXformOpOrderAttr().Get(),
+                    Vt.TokenArray(('xformOp:transform', )))
+
+        # validate the Matrix4d entires
+        actual = cylinderXformable.GetLocalTransformation()
+        expected  = Gf.Matrix4d( 1, 0, 0, 0,
+                                 0, 1, 0, 0,
+                                 0, 0, 1, 0,
+                                 65, 20, 10, 1)
+
+        self.assertTrue(Gf.IsClose(actual, expected, 1e-5))
+
+        # set the edit target to a weaker layer (LayerC)
+        cmds.mayaUsdEditTarget(proxyShapePath, edit=True, editTarget=subLayerC)
+
+        # check if transform attribute is editable
+        transformAttr = cylinderPrim.GetAttribute('xformOp:transform')
+        self.assertIsNotNone(transformAttr)
+
+        # authoring new transformation edit is not allowed.
+        self.assertFalse(mayaUsdUfe.isAttributeEditAllowed(transformAttr))
+
+        # set the edit target to a stronger layer (LayerA)
+        cmds.mayaUsdEditTarget(proxyShapePath, edit=True, editTarget=subLayerA)
+
+        # authoring new transformation edit is allowed.
+        self.assertTrue(mayaUsdUfe.isAttributeEditAllowed(transformAttr))
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/ufe/testAttributeBlock.py
+++ b/test/lib/ufe/testAttributeBlock.py
@@ -261,6 +261,7 @@ class AttributeBlockTestCase(unittest.TestCase):
         # authoring new transformation edit is allowed.
         self.assertTrue(mayaUsdUfe.isAttributeEditAllowed(rotateAttr))
 
+    @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 2, 'testAttributeBlocking3dMatrixOps only available in UFE v2 or greater.')
     def testAttributeBlocking3dMatrixOps(self):
         '''
         Verify authoring transformation attribute(s) in weaker layer(s) are not permitted if there exist opinion(s) 


### PR DESCRIPTION
This PR completes the blocking of attribute edits for the remaining transformation stacks ( UsdTransform3dCommonAPI, UsdTransform3dMatrixOp )