### PR TITLE
MAYA-110917 Increase depth priority for point snapping items

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1866,6 +1866,7 @@ MHWRender::MRenderItem* HdVP2BasisCurves::_CreatePointsRenderItem(const MString&
         name, MHWRender::MRenderItem::DecorationItem, MHWRender::MGeometry::kPoints);
 
     renderItem->setDrawMode(MHWRender::MGeometry::kSelectionOnly);
+    renderItem->depthPriority(MHWRender::MRenderItem::sDormantPointDepthPriority);
     renderItem->castsShadows(false);
     renderItem->receivesShadows(false);
     renderItem->setShader(_delegate->Get3dFatPointShader());

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -2252,6 +2252,7 @@ MHWRender::MRenderItem* HdVP2Mesh::_CreatePointsRenderItem(const MString& name) 
         name, MHWRender::MRenderItem::DecorationItem, MHWRender::MGeometry::kPoints);
 
     renderItem->setDrawMode(MHWRender::MGeometry::kSelectionOnly);
+    renderItem->depthPriority(MHWRender::MRenderItem::sDormantPointDepthPriority);
     renderItem->castsShadows(false);
     renderItem->receivesShadows(false);
     renderItem->setShader(_delegate->Get3dFatPointShader());


### PR DESCRIPTION
After turning on camera-based selection and zooming out far enough
to a USD object, we could only snap to silhouette points. After
zooming in closer, the issue will become better. This is a preexisting
depth priority issue in VP2RenderDelegate so it has nothing to do with
the recent point snapping refactoring inside Maya (MAYA-109518).