### PR TITLE
List all registered Prim Types for Creation

### DIFF
--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -298,7 +298,7 @@ private:
 const char* selectUSDFileScript = R"(
 global proc string SelectUSDFileForAddReference()
 {
-    string $result[] = `fileDialog2 
+    string $result[] = `fileDialog2
         -fileMode 1
         -caption "Add Reference to USD Prim"
         -fileFilter "USD Files (*.usd *.usda *.usdc);;*.usd;;*.usda;;*.usdc"`;
@@ -314,7 +314,7 @@ SelectUSDFileForAddReference();
 const char* clearAllReferencesConfirmScript = R"(
 global proc string ClearAllUSDReferencesConfirm()
 {
-    return `confirmDialog -title "Remove All References" 
+    return `confirmDialog -title "Remove All References"
         -message "Removing all references from USD prim.  Are you sure?"
         -button "Yes" -button "No" -defaultButton "Yes"
         -cancelButton "No" -dismissString "No"`;
@@ -469,8 +469,9 @@ static const std::vector<MayaUsd::ufe::SchemaTypeGroup> getConcretePrimTypes(boo
     std::set<TfType> schemaTypes;
     plugReg.GetAllDerivedTypes<UsdSchemaBase>(&schemaTypes);
 
+    UsdSchemaRegistry& schemaReg = UsdSchemaRegistry::GetInstance();
     for (auto t : schemaTypes) {
-        if (!UsdSchemaRegistry::IsConcrete(t)) {
+        if (!schemaReg.IsConcrete(t)) {
             continue;
         }
 

--- a/lib/mayaUsd/ufe/UsdContextOps.h
+++ b/lib/mayaUsd/ufe/UsdContextOps.h
@@ -26,12 +26,14 @@
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
+#if PXR_VERSION >= 2008
 struct SchemaTypeGroup
 {
-    std::string               name;
-    std::vector<pxr::TfToken> types;
-    bool                      operator==(const std::string rhs) const { return name == rhs; }
+    std::string        _name;
+    pxr::TfTokenVector _types;
+    bool               operator==(const std::string rhs) const { return _name == rhs; }
 };
+#endif
 
 //! \brief Interface for scene item context operations.
 /*!
@@ -83,8 +85,10 @@ private:
     UsdSceneItem::Ptr fItem;
     bool              fIsAGatewayType { false };
 
+#if PXR_VERSION >= 2008
     // A cache to keep the dynamic listing of plugin types to a minimum
-    static std::vector<SchemaTypeGroup> fSchemaTypeGroups;
+    static std::vector<SchemaTypeGroup> schemaTypeGroups;
+#endif
 
 }; // UsdContextOps
 

--- a/lib/mayaUsd/ufe/UsdContextOps.h
+++ b/lib/mayaUsd/ufe/UsdContextOps.h
@@ -26,6 +26,13 @@
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
+struct SchemaTypeGroup
+{
+    std::string               name;
+    std::vector<pxr::TfToken> types;
+    bool                      operator==(const std::string rhs) const { return name == rhs; }
+};
+
 //! \brief Interface for scene item context operations.
 /*!
     This class defines the interface that USD run-time implements to
@@ -75,6 +82,9 @@ public:
 private:
     UsdSceneItem::Ptr fItem;
     bool              fIsAGatewayType { false };
+
+    // A cache to keep the dynamic listing of plugin types to a minimum
+    static std::vector<SchemaTypeGroup> fSchemaTypeGroups;
 
 }; // UsdContextOps
 


### PR DESCRIPTION
This PR adds the ability to list and create all registered concrete prim types for creation in the UFE > Add Prim menu.
Concrete Prim types are listed dynamically under a `Registered` sub-menu, allowing for listing of new types if they're loaded by USD plugins at a later point.

I currently list them as a flat, sorted list. However I could group them by schema name if that is preferred, however I was unsure which would be more intuitive. I figure that this could be a mvp of the feature, and then could be refined as needed. I also do no filtering outside of listing only concrete types. For example, it may be desirable to filter the AL prim types, but I did not want to prematurely add filtering logic.

The motivation for this PR is that various teams we've spoken to have hit the issue of trying to populate a USD stage with a mix of vanilla and custom schema prim types. The base selection of prim types wasn't adequate in this situation, even though the dynamic AE templates provided for the USD prim types was sufficient to work with them.


<img src="https://user-images.githubusercontent.com/4443090/115286076-826baa80-a103-11eb-95c8-64f455e380e6.png" data-canonical-src="https://user-images.githubusercontent.com/4443090/115286076-826baa80-a103-11eb-95c8-64f455e380e6.png" width=300>
