### PR TITLE
Add support for the parentScope to be an xform

### DIFF
--- a/lib/mayaUsd/fileio/translators/skelBindingsProcessor.h
+++ b/lib/mayaUsd/fileio/translators/skelBindingsProcessor.h
@@ -48,16 +48,17 @@ public:
     void MarkBindings(const SdfPath& path, const SdfPath& skelPath, const TfToken& config);
 
     /// Performs final processing for skel bindings.
-    bool PostProcessSkelBindings(const UsdStagePtr& stage) const;
+    bool PostProcessSkelBindings(const UsdStagePtr& stage, const SdfPath& parentScopePath) const;
 
     /// Updates the SkelRoots with a given extent value and time sample.
     bool UpdateSkelRootsWithExtent(
         const UsdStagePtr&  stage,
         const VtVec3fArray& bbox,
-        const UsdTimeCode&  timeSample);
+        const UsdTimeCode&  timeSample,
+        const SdfPath& parentScopePath);
 
 private:
-    bool _VerifyOrMakeSkelRoots(const UsdStagePtr& stage) const;
+    bool _VerifyOrMakeSkelRoots(const UsdStagePtr& stage, const SdfPath& parentScopePath) const;
 
     using _Entry = std::pair<SdfPath, TfToken>;
 

--- a/lib/mayaUsd/fileio/utils/jointWriteUtils.h
+++ b/lib/mayaUsd/fileio/utils/jointWriteUtils.h
@@ -71,7 +71,7 @@ getJointNames(const std::vector<MDagPath>& joints, const MDagPath& rootJoint, bo
 /// the given root joint. The skeleton both binds a skeleton and
 /// holds root transformations of the joint hierarchy.
 MAYAUSD_CORE_PUBLIC
-SdfPath getSkeletonPath(const MDagPath& rootJoint, bool stripNamespaces);
+SdfPath getSkeletonPath(const MDagPath& rootJoint, bool stripNamespaces, const SdfPath& parentScopePath);
 
 /// Gets the closest upstream skin cluster for the mesh at the given dag path.
 /// Warns if there is more than one skin cluster.
@@ -169,6 +169,7 @@ MObject writeSkinningData(
     const SdfPath&             usdPath,
     const MDagPath&            dagPath,
     SdfPath&                   skelPath,
+    const SdfPath&             parentScopePath,
     const bool                 stripNamespaces,
     UsdUtilsSparseValueWriter* valueWriter);
 } // namespace UsdMayaJointUtil

--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -388,7 +388,7 @@ bool UsdMayaWriteJobContext::_OpenFile(const std::string& filename, bool append)
         // scope, and will be created when we writ out the model variants
         if (mArgs.usdModelRootOverridePath.IsEmpty()) {
             mParentScopePath
-                = UsdGeomScope::Define(mStage, mParentScopePath).GetPrim().GetPrimPath();
+                = UsdGeomXform::Define(mStage, mParentScopePath).GetPrim().GetPrimPath();
         }
     }
 
@@ -434,7 +434,7 @@ bool UsdMayaWriteJobContext::_PostProcess()
         }
     }
 
-    if (!_skelBindingsProcessor->PostProcessSkelBindings(mStage)) {
+    if (!_skelBindingsProcessor->PostProcessSkelBindings(mStage, mParentScopePath)) {
         return false;
     }
 
@@ -595,7 +595,7 @@ bool UsdMayaWriteJobContext::UpdateSkelBindingsWithExtent(
     const VtVec3fArray& bbox,
     const UsdTimeCode&  timeSample)
 {
-    return _skelBindingsProcessor->UpdateSkelRootsWithExtent(stage, bbox, timeSample);
+    return _skelBindingsProcessor->UpdateSkelRootsWithExtent(stage, bbox, timeSample, mParentScopePath);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/writeJobContext.h
+++ b/lib/mayaUsd/fileio/writeJobContext.h
@@ -59,6 +59,8 @@ public:
 
     const UsdStageRefPtr& GetUsdStage() const { return mStage; }
 
+    const SdfPath& GetParentScopePath() const { return mParentScopePath; }
+    
     /// Whether we will merge the transform at \p path with its single
     /// exportable child shape, given its hierarchy and the current path
     /// translation rules. (This always returns false if the export args

--- a/lib/usd/translators/jointWriter.cpp
+++ b/lib/usd/translators/jointWriter.cpp
@@ -78,7 +78,8 @@ PxrUsdTranslators_JointWriter::PxrUsdTranslators_JointWriter(
     }
 
     SdfPath skelPath
-        = UsdMayaJointUtil::getSkeletonPath(GetDagPath(), _GetExportArgs().stripNamespaces);
+        = UsdMayaJointUtil::getSkeletonPath(GetDagPath(), 
+            _GetExportArgs().stripNamespaces, _writeJobCtx.GetParentScopePath());
 
     _skel = UsdSkelSkeleton::Define(GetUsdStage(), skelPath);
     if (!TF_VERIFY(_skel)) {

--- a/lib/usd/translators/meshWriter.cpp
+++ b/lib/usd/translators/meshWriter.cpp
@@ -378,6 +378,7 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
                 GetUsdPath(),
                 GetDagPath(),
                 skelPath,
+                _writeJobCtx.GetParentScopePath(),
                 exportArgs.stripNamespaces,
                 _GetSparseValueWriter());
 


### PR DESCRIPTION
Add support for the parentScope to be an xform so it can be converted into a SkelRoot. This solves the problem of maya scenes where the model and the joints dont share a parent. The meshes used the parentScopePath already, so just converting the parentScope prim to an xform would put the meses in the right plave but the dag path to sdfpath for skeletons did not consider this, so we have to pass the path around a bit.

This is just as an idea. for an improvement,  it works in my case, but might need more design for a generic solution. 