### PR TITLE
MAYA-110727 - Crash when editing Layer That has Permission to Edit false (locked)

### DIFF
--- a/lib/mayaUsd/ufe/UsdTransform3dHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dHandler.cpp
@@ -16,6 +16,7 @@
 #include "UsdTransform3dHandler.h"
 
 #include <mayaUsd/ufe/UsdSceneItem.h>
+#include <mayaUsd/ufe/Utils.h>
 
 #include <maya/MGlobal.h>
 
@@ -69,6 +70,12 @@ Ufe::Transform3d::Ptr UsdTransform3dHandler::transform3d(const Ufe::SceneItem::P
             MString("Authoring to the descendant of an instance [")
             + MString(usdItem->prim().GetName().GetString().c_str()) + MString("] is not allowed.")
             + MString("Please mark 'instanceable=false' to author edits to instance proxies."));
+        return nullptr;
+    }
+
+    std::string errMsg;
+    if (!MayaUsd::ufe::isEditTargetLayerModifiable(usdItem->prim().GetStage(), &errMsg)) {
+        MGlobal::displayError(errMsg.c_str());
         return nullptr;
     }
 

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
@@ -500,7 +500,7 @@ UsdTransform3dMayaXformStack::rotateCmd(double x, double y, double z)
     // If there is no rotate transform op, we will create a RotXYZ.
     CvtRotXYZToAttrFn cvt = hasRotate ? getCvtRotXYZToAttrFn(op.GetOpName()) : toXYZ;
     OpFunc            f = hasRotate
-                   ? OpFunc([attrName](const BaseUndoableCommand& cmd) {
+        ? OpFunc([attrName](const BaseUndoableCommand& cmd) {
               auto usdSceneItem = std::dynamic_pointer_cast<UsdSceneItem>(cmd.sceneItem());
               TF_AXIOM(usdSceneItem);
               auto attr = usdSceneItem->prim().GetAttribute(attrName);
@@ -514,7 +514,7 @@ UsdTransform3dMayaXformStack::rotateCmd(double x, double y, double z)
 
               return UsdGeomXformOp(attr);
           })
-                   : OpFunc([opSuffix = getTRSOpSuffix(), setXformOpOrderFn = getXformOpOrderFn(), v](
+        : OpFunc([opSuffix = getTRSOpSuffix(), setXformOpOrderFn = getXformOpOrderFn(), v](
                      const BaseUndoableCommand& cmd) {
               // Use notification guard, otherwise will generate one notification
               // for the xform op add, and another for the reorder.
@@ -734,7 +734,7 @@ UsdTransform3dMayaXformStack::pivotCmd(const TfToken& pvtOpSuffix, double x, dou
     GfVec3f v(x, y, z);
     auto    attr = prim().GetAttribute(pvtAttrName);
     OpFunc  f = attr
-         ? OpFunc([pvtAttrName](const BaseUndoableCommand& cmd) {
+        ? OpFunc([pvtAttrName](const BaseUndoableCommand& cmd) {
               auto usdSceneItem = std::dynamic_pointer_cast<UsdSceneItem>(cmd.sceneItem());
               TF_AXIOM(usdSceneItem);
               auto attr = usdSceneItem->prim().GetAttribute(pvtAttrName);
@@ -748,7 +748,7 @@ UsdTransform3dMayaXformStack::pivotCmd(const TfToken& pvtOpSuffix, double x, dou
 
               return UsdGeomXformOp(attr);
           })
-         : OpFunc([pvtOpSuffix, setXformOpOrderFn = getXformOpOrderFn(), v](
+        : OpFunc([pvtOpSuffix, setXformOpOrderFn = getXformOpOrderFn(), v](
                      const BaseUndoableCommand& cmd) {
               // Without a notification guard each operation (each transform op
               // addition, setting the attribute value, and setting the transform

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
@@ -500,7 +500,7 @@ UsdTransform3dMayaXformStack::rotateCmd(double x, double y, double z)
     // If there is no rotate transform op, we will create a RotXYZ.
     CvtRotXYZToAttrFn cvt = hasRotate ? getCvtRotXYZToAttrFn(op.GetOpName()) : toXYZ;
     OpFunc            f = hasRotate
-        ? OpFunc([attrName](const BaseUndoableCommand& cmd) {
+                   ? OpFunc([attrName](const BaseUndoableCommand& cmd) {
               auto usdSceneItem = std::dynamic_pointer_cast<UsdSceneItem>(cmd.sceneItem());
               TF_AXIOM(usdSceneItem);
               auto attr = usdSceneItem->prim().GetAttribute(attrName);
@@ -514,7 +514,7 @@ UsdTransform3dMayaXformStack::rotateCmd(double x, double y, double z)
 
               return UsdGeomXformOp(attr);
           })
-        : OpFunc([opSuffix = getTRSOpSuffix(), setXformOpOrderFn = getXformOpOrderFn(), v](
+                   : OpFunc([opSuffix = getTRSOpSuffix(), setXformOpOrderFn = getXformOpOrderFn(), v](
                      const BaseUndoableCommand& cmd) {
               // Use notification guard, otherwise will generate one notification
               // for the xform op add, and another for the reorder.
@@ -734,7 +734,7 @@ UsdTransform3dMayaXformStack::pivotCmd(const TfToken& pvtOpSuffix, double x, dou
     GfVec3f v(x, y, z);
     auto    attr = prim().GetAttribute(pvtAttrName);
     OpFunc  f = attr
-        ? OpFunc([pvtAttrName](const BaseUndoableCommand& cmd) {
+         ? OpFunc([pvtAttrName](const BaseUndoableCommand& cmd) {
               auto usdSceneItem = std::dynamic_pointer_cast<UsdSceneItem>(cmd.sceneItem());
               TF_AXIOM(usdSceneItem);
               auto attr = usdSceneItem->prim().GetAttribute(pvtAttrName);
@@ -748,7 +748,7 @@ UsdTransform3dMayaXformStack::pivotCmd(const TfToken& pvtOpSuffix, double x, dou
 
               return UsdGeomXformOp(attr);
           })
-        : OpFunc([pvtOpSuffix, setXformOpOrderFn = getXformOpOrderFn(), v](
+         : OpFunc([pvtOpSuffix, setXformOpOrderFn = getXformOpOrderFn(), v](
                      const BaseUndoableCommand& cmd) {
               // Without a notification guard each operation (each transform op
               // addition, setting the attribute value, and setting the transform
@@ -909,13 +909,10 @@ Ufe::Transform3d::Ptr UsdTransform3dMayaXformStackHandler::editTransform3d(
         return nullptr;
     }
 
-    auto stage = usdItem->prim().GetStage();
-    if (stage) {
-        const SdfLayerHandle& editLayer = stage->GetEditTarget().GetLayer();
-        if (editLayer && stage->IsLayerMuted(editLayer->GetIdentifier())) {
-            MGlobal::displayError("Editing a muted layer is not allowed.");
-            return nullptr;
-        }
+    std::string errMsg;
+    if (!MayaUsd::ufe::isEditTargetLayerModifiable(usdItem->prim().GetStage(), &errMsg)) {
+        MGlobal::displayError(errMsg.c_str());
+        return nullptr;
     }
 
     return createTransform3d(

--- a/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
@@ -82,7 +82,7 @@ void UsdUndoAddNewPrimCommand::execute()
     if (_stage) {
         std::string errMsg;
         if (!MayaUsd::ufe::isEditTargetLayerModifiable(_stage, &errMsg)) {
-            TF_RUNTIME_ERROR(errMsg.c_str());
+            TF_RUNTIME_ERROR("%s", errMsg.c_str());
         } else {
             MayaUsd::ufe::InAddOrDeleteOperation ad;
             auto                                 prim = _stage->DefinePrim(_primPath, _primToken);

--- a/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
@@ -80,10 +80,15 @@ void UsdUndoAddNewPrimCommand::execute()
     UsdUndoBlock undoBlock(&_undoableItem);
 
     if (_stage) {
-        MayaUsd::ufe::InAddOrDeleteOperation ad;
-        auto                                 prim = _stage->DefinePrim(_primPath, _primToken);
-        if (!prim.IsValid())
-            TF_RUNTIME_ERROR("Failed to create new prim type: %s", _primToken.GetText());
+        std::string errMsg;
+        if (!MayaUsd::ufe::isEditTargetLayerModifiable(_stage, &errMsg)) {
+            TF_RUNTIME_ERROR(errMsg.c_str());
+        } else {
+            MayaUsd::ufe::InAddOrDeleteOperation ad;
+            auto                                 prim = _stage->DefinePrim(_primPath, _primToken);
+            if (!prim.IsValid())
+                TF_RUNTIME_ERROR("Failed to create new prim type: %s", _primToken.GetText());
+        }
     }
 }
 

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -455,7 +455,7 @@ bool isEditTargetLayerModifiable(const PXR_NS::UsdStageWeakPtr stage, std::strin
     if (editLayer && !editLayer->PermissionToEdit()) {
         if (errMsg) {
             std::string err = TfStringPrintf(
-                "Cannot edit the layer [%s] because it is locked (PermissionToEdit is false).",
+                "Cannot edit [%s] because it is read-only. Set PermissionToEdit = true to proceed.",
                 editLayer->GetDisplayName().c_str());
 
             *errMsg = err;
@@ -467,7 +467,8 @@ bool isEditTargetLayerModifiable(const PXR_NS::UsdStageWeakPtr stage, std::strin
     if (stage->IsLayerMuted(editLayer->GetIdentifier())) {
         if (errMsg) {
             std::string err = TfStringPrintf(
-                "Cannot edit because the layer [%s] is Muted.",
+                "Cannot edit [%s] because it is muted. Unmute [%s] to proceed.",
+                editLayer->GetDisplayName().c_str(),
                 editLayer->GetDisplayName().c_str());
             *errMsg = err;
         }

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -382,6 +382,10 @@ bool isAttributeEditAllowed(const PXR_NS::UsdAttribute& attr, std::string* errMs
     const auto& stage = prim.GetStage();
     const auto& editTarget = stage->GetEditTarget();
 
+    if (!isEditTargetLayerModifiable(stage, errMsg)) {
+        return false;
+    }
+
     // get the index to edit target layer
     const auto targetLayerIndex = findLayerIndex(prim, editTarget.GetLayer());
 
@@ -437,6 +441,36 @@ bool isAttributeEditAllowed(const UsdPrim& prim, const TfToken& attrName)
     // check the attribute itself
     if (!isAttributeEditAllowed(prim.GetAttribute(attrName), &errMsg)) {
         MGlobal::displayError(errMsg.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+bool isEditTargetLayerModifiable(const PXR_NS::UsdStageWeakPtr stage, std::string* errMsg)
+{
+    const auto editTarget = stage->GetEditTarget();
+    const auto editLayer = editTarget.GetLayer();
+
+    if (editLayer && !editLayer->PermissionToEdit()) {
+        if (errMsg) {
+            std::string err = TfStringPrintf(
+                "Cannot edit the layer [%s] because it is locked (PermissionToEdit is false).",
+                editLayer->GetDisplayName());
+
+            *errMsg = err;
+        }
+
+        return false;
+    }
+
+    if (stage->IsLayerMuted(editLayer->GetIdentifier())) {
+        if (errMsg) {
+            std::string err = TfStringPrintf(
+                "Cannot edit because the layer [%s] is Muted.", editLayer->GetDisplayName());
+            *errMsg = err;
+        }
+
         return false;
     }
 

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -456,7 +456,7 @@ bool isEditTargetLayerModifiable(const PXR_NS::UsdStageWeakPtr stage, std::strin
         if (errMsg) {
             std::string err = TfStringPrintf(
                 "Cannot edit the layer [%s] because it is locked (PermissionToEdit is false).",
-                editLayer->GetDisplayName());
+                editLayer->GetDisplayName().c_str());
 
             *errMsg = err;
         }
@@ -467,7 +467,8 @@ bool isEditTargetLayerModifiable(const PXR_NS::UsdStageWeakPtr stage, std::strin
     if (stage->IsLayerMuted(editLayer->GetIdentifier())) {
         if (errMsg) {
             std::string err = TfStringPrintf(
-                "Cannot edit because the layer [%s] is Muted.", editLayer->GetDisplayName());
+                "Cannot edit because the layer [%s] is Muted.",
+                editLayer->GetDisplayName().c_str());
             *errMsg = err;
         }
 

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -132,6 +132,13 @@ bool isAttributeEditAllowed(const PXR_NS::UsdAttribute& attr, std::string* errMs
 MAYAUSD_CORE_PUBLIC
 bool isAttributeEditAllowed(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attrName);
 
+//! Check if the edit target in the stage is allowed to be changed.
+//! \return True, if the edit target layer in the stage is allowed to be changed
+MAYAUSD_CORE_PUBLIC
+bool isEditTargetLayerModifiable(
+    const PXR_NS::UsdStageWeakPtr stage,
+    std::string*                  errMsg = nullptr);
+
 //! Send notification for data model changes
 template <class T>
 void sendNotification(const Ufe::SceneItem::Ptr& item, const Ufe::Path& previousPath)

--- a/lib/mayaUsd/ufe/wrapUtils.cpp
+++ b/lib/mayaUsd/ufe/wrapUtils.cpp
@@ -199,6 +199,11 @@ bool isAttributeEditAllowed(const PXR_NS::UsdAttribute& attr)
     return ufe::isAttributeEditAllowed(attr);
 }
 
+bool isEditTargetLayerModifiable(const PXR_NS::UsdStageWeakPtr stage)
+{
+    return ufe::isEditTargetLayerModifiable(stage);
+}
+
 PXR_NS::TfTokenVector getProxyShapePurposes(const std::string& ufePathString)
 {
     auto path =
@@ -236,4 +241,5 @@ void wrapUtils()
     def("ufePathToInstanceIndex", ufePathToInstanceIndex);
     def("getProxyShapePurposes", getProxyShapePurposes);
     def("isAttributeEditAllowed", isAttributeEditAllowed);
+    def("isEditTargetLayerModifiable", isEditTargetLayerModifiable);
 }

--- a/test/lib/ufe/CMakeLists.txt
+++ b/test/lib/ufe/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TEST_SCRIPT_FILES
     testSelection.py
     testUfePythonImport.py
     testAttributeBlock.py
+    testBlockedLayerEdit.py
 )
 
 set(TEST_SUPPORT_FILES

--- a/test/lib/ufe/testBlockedLayerEdit.py
+++ b/test/lib/ufe/testBlockedLayerEdit.py
@@ -95,12 +95,13 @@ class BlockedLayerEditTestCase(unittest.TestCase):
 
         # create a transform3d and translate
         cylinderPath = ufe.Path([
-                     mayaUtils.createUfePathSegment("|mayaUsdTransform|shape"), 
+                     mayaUtils.createUfePathSegment("|mayaUsdTransform|shape"),
                      usdUtils.createUfePathSegment("/pCylinder1")])
         cylinderItem = ufe.Hierarchy.createItem(cylinderPath)
 
         cylinderT3d = ufe.Transform3d.transform3d(cylinderItem)
-        cylinderT3d.translate(5.0, 6.0, 7.0)
+        if cylinderT3d is not None:
+            cylinderT3d.translate(5.0, 6.0, 7.0)
 
         # check that the translate operation didn't change anything
         tranlateAfterEdit = translateAttr.Get()
@@ -148,12 +149,13 @@ class BlockedLayerEditTestCase(unittest.TestCase):
 
         # create a transform3d and translate
         cylinderPath = ufe.Path([
-                     mayaUtils.createUfePathSegment("|mayaUsdTransform|shape"), 
+                     mayaUtils.createUfePathSegment("|mayaUsdTransform|shape"),
                      usdUtils.createUfePathSegment("/pCylinder1")])
         cylinderItem = ufe.Hierarchy.createItem(cylinderPath)
 
         cylinderT3d = ufe.Transform3d.transform3d(cylinderItem)
-        cylinderT3d.translate(5.0, 6.0, 7.0)
+        if cylinderT3d is not None:
+            cylinderT3d.translate(5.0, 6.0, 7.0)
 
         # check that the translate operation didn't change anything
         tranlateAfterEdit = translateAttr.Get()

--- a/test/lib/ufe/testBlockedLayerEdit.py
+++ b/test/lib/ufe/testBlockedLayerEdit.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2021 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import fixturesUtils
+import mayaUtils
+import usdUtils
+
+from pxr import Sdf
+
+from maya import cmds
+from maya import standalone
+
+import mayaUsd
+from mayaUsd import ufe as mayaUsdUfe
+
+import ufe
+import unittest
+
+class BlockedLayerEditTestCase(unittest.TestCase):
+
+    pluginsLoaded = False
+
+    @classmethod
+    def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
+        if not cls.pluginsLoaded:
+            cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def setUp(self):
+        ''' Called initially to set up the Maya test environment '''
+        # Load plugins
+        self.assertTrue(self.pluginsLoaded)
+
+        # Clear selection to start off
+        cmds.select(clear=True)
+
+    def testTranslateMutedLayer(self):
+        # create new stage
+        cmds.file(new=True, force=True)
+
+        # Open usdCylinder.ma scene in testSamples
+        mayaUtils.openCylinderScene()
+
+        # get the stage
+        proxyShapes = cmds.ls(type="mayaUsdProxyShapeBase", long=True)
+        proxyShapePath = proxyShapes[0]
+        stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
+
+        # cylinder prim
+        cylinderPrim = stage.GetPrimAtPath('/pCylinder1')
+        self.assertIsNotNone(cylinderPrim)
+
+        # create a sub-layer.
+        rootLayer = stage.GetRootLayer()
+        subLayerA = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="LayerA")[0]
+
+        # check to see the if the sublayers was added
+        addedLayers = [subLayerA]
+        self.assertEqual(rootLayer.subLayerPaths, addedLayers)
+
+        # set the edit target to LayerA.
+        cmds.mayaUsdEditTarget(proxyShapePath, edit=True, editTarget=subLayerA)
+
+        # mute the layer
+        stage.MuteLayer(subLayerA)
+
+        # Check that our helper function is returning the right thing
+        self.assertFalse(mayaUsdUfe.isEditTargetLayerModifiable(stage))
+
+        # Get translate attribute and make sure its empty
+        translateAttr = cylinderPrim.GetAttribute('xformOp:translate')
+        self.assertIsNotNone(translateAttr)
+
+        tranlateBeforeEdit = translateAttr.Get()
+
+        # create a transform3d and translate
+        cylinderPath = ufe.Path([
+                     mayaUtils.createUfePathSegment("|mayaUsdTransform|shape"), 
+                     usdUtils.createUfePathSegment("/pCylinder1")])
+        cylinderItem = ufe.Hierarchy.createItem(cylinderPath)
+
+        cylinderT3d = ufe.Transform3d.transform3d(cylinderItem)
+        cylinderT3d.translate(5.0, 6.0, 7.0)
+
+        # check that the translate operation didn't change anything
+        tranlateAfterEdit = translateAttr.Get()
+        self.assertEqual(tranlateBeforeEdit, tranlateAfterEdit)
+
+    def testTranslateLockedLayer(self):
+        # create new stage
+        cmds.file(new=True, force=True)
+
+        # Open usdCylinder.ma scene in testSamples
+        mayaUtils.openCylinderScene()
+
+        # get the stage
+        proxyShapes = cmds.ls(type="mayaUsdProxyShapeBase", long=True)
+        proxyShapePath = proxyShapes[0]
+        stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
+
+        # cylinder prim
+        cylinderPrim = stage.GetPrimAtPath('/pCylinder1')
+        self.assertIsNotNone(cylinderPrim)
+
+        # create a sub-layer.
+        rootLayer = stage.GetRootLayer()
+        subLayerA = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="LayerA")[0]
+
+        # check to see the if the sublayers was added
+        addedLayers = [subLayerA]
+        self.assertEqual(rootLayer.subLayerPaths, addedLayers)
+
+        # set the edit target to LayerA.
+        cmds.mayaUsdEditTarget(proxyShapePath, edit=True, editTarget=subLayerA)
+
+        # set permission to edit to false
+        layerA = Sdf.Find(subLayerA)
+        layerA.SetPermissionToEdit(False)
+
+        # Check that our helper function is returning the right thing
+        self.assertFalse(mayaUsdUfe.isEditTargetLayerModifiable(stage))
+
+        # Get translate attribute and make sure its empty
+        translateAttr = cylinderPrim.GetAttribute('xformOp:translate')
+        self.assertIsNotNone(translateAttr)
+
+        tranlateBeforeEdit = translateAttr.Get()
+
+        # create a transform3d and translate
+        cylinderPath = ufe.Path([
+                     mayaUtils.createUfePathSegment("|mayaUsdTransform|shape"), 
+                     usdUtils.createUfePathSegment("/pCylinder1")])
+        cylinderItem = ufe.Hierarchy.createItem(cylinderPath)
+
+        cylinderT3d = ufe.Transform3d.transform3d(cylinderItem)
+        cylinderT3d.translate(5.0, 6.0, 7.0)
+
+        # check that the translate operation didn't change anything
+        tranlateAfterEdit = translateAttr.Get()
+        self.assertEqual(tranlateBeforeEdit, tranlateAfterEdit)
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Fixed the problem, also added a function to do this for both muted and locked layers (and possibly user locked layers in the future). Also added the block for adding and attribute changes. This probably doesn't cover all the cases, but its good enough for now.