### PR TITLE
MAYA-110489 - Prim AE template: categories persist their expand/colla…

### DIFF
--- a/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
@@ -20,7 +20,6 @@ import maya.cmds as cmds
 import mayaUsd.ufe as mayaUsdUfe
 import mayaUsd.lib as mayaUsdLib
 import maya.internal.common.ufe_ae.template as ufeAeTemplate
-import maya.internal.common.ae.custom as aecustom
 from maya.common.ui import LayoutManager
 from maya.common.ui import setClipboardData
 
@@ -62,7 +61,7 @@ class UfeAttributesObserver(ufe.Observer):
     def __call__(self, notification):
         if isinstance(notification, ufe.AttributeValueChanged):
             if notification.name() == UsdGeom.Tokens.xformOpOrder:
-                mel.eval("evalDeferred(\"AEbuildControls\");")
+                mel.eval("evalDeferred -low \"refreshEditorTemplates\";")
 
     def onCreate(self, *args):
         ufe.Attributes.addObserver(self._item, self)
@@ -70,17 +69,16 @@ class UfeAttributesObserver(ufe.Observer):
     def onReplace(self, *args):
         pass
 
-class MetaDataCustomControl(aecustom.CustomControl):
+class MetaDataCustomControl(object):
     # Custom control for all prim metadata we want to display.
-    def __init__(self, prim, *args, **kwargs):
+    def __init__(self, prim):
         self.prim = prim
-        super(MetaDataCustomControl, self).__init__(args, kwargs)
 
         # There are four metadata that we always show: primPath, kind, active, instanceable
         # We use a dictionary to store the various other metadata that this prim contains.
         self.extraMetadata = dict()
 
-    def buildControlUI(self):
+    def onCreate(self, *args):
         # Should we display nice names in AE?
         useNiceName = True
         if cmds.optionVar(exists='attrEditorIsLongName'):
@@ -147,6 +145,9 @@ class MetaDataCustomControl(aecustom.CustomControl):
 
         # Update all metadata values.
         self.refresh()
+
+    def onReplace(self, *args):
+        pass
 
     def refresh(self):
         # PrimPath
@@ -276,6 +277,16 @@ class AETemplate(object):
         self.createMetadataSection()
         cmds.editorTemplate(endScrollLayout=True)
 
+        if int(cmds.about(majorVersion=True)) > 2022:
+            # Because of how we dynamically build the Transform attribute section,
+            # we need this template to rebuild each time it is needed. This will
+            # also restore the collapse/expand state of the sections.
+            # Note: in Maya 2022 all UFE templates were forcefully rebuilt, but
+            #       no restore of section states.
+            try:
+                cmds.editorTemplate(forceRebuild=True)
+            except:
+                pass
 
     def addControls(self, controls):
         for c in controls:
@@ -473,7 +484,10 @@ class AETemplate(object):
                 if schemaTypeName == 'UsdGeomXformable':
                     self.createTransformAttributesSection(sectionName, attrsToAdd)
                 else:
-                    self.createSection(sectionName, attrsToAdd)
+                    sectionsToCollapse = ['Curves', 'Point Based', 'Geometric Prim', 'Boundable',
+                                          'Imageable', 'Field Asset', 'Light']
+                    collapse = sectionName in sectionsToCollapse
+                    self.createSection(sectionName, attrsToAdd, collapse)
 
     def suppressArrayAttribute(self):
         # Suppress all array attributes except UsdGeom.Tokens.xformOpOrder

--- a/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
@@ -67,6 +67,7 @@ class UfeAttributesObserver(ufe.Observer):
         ufe.Attributes.addObserver(self._item, self)
 
     def onReplace(self, *args):
+        # Nothing needed here since we don't create any UI.
         pass
 
 class MetaDataCustomControl(object):
@@ -147,6 +148,9 @@ class MetaDataCustomControl(object):
         self.refresh()
 
     def onReplace(self, *args):
+        # Nothing needed here since USD data is not time varying. Normally this template
+        # is force rebuilt all the time, except in response to time change from Maya. In
+        # that case we don't need to update our controls since none will change.
         pass
 
     def refresh(self):
@@ -233,6 +237,7 @@ class NoticeListener(object):
         cmds.scriptJob(uiDeleted=[pname, self.onClose], runOnce=True)
 
     def onReplace(self, *args):
+        # Nothing needed here since we don't create any UI.
         pass
 
     def onClose(self):

--- a/lib/mayaUsd/ufe/UsdAttribute.cpp
+++ b/lib/mayaUsd/ufe/UsdAttribute.cpp
@@ -47,7 +47,6 @@ static constexpr char kErrorMsgFailedConvertToString[]
     = "Could not convert the attribute to a string";
 static constexpr char kErrorMsgInvalidType[]
     = "USD attribute does not match created attribute class type";
-static constexpr char kErrorMsgEnumNoValue[] = "Enum string attribute has no value";
 
 //------------------------------------------------------------------------------
 // Helper functions
@@ -118,7 +117,11 @@ getUsdAttributeValueAsString(const PXR_NS::UsdAttribute& attr, const PXR_NS::Usd
         return os.str();
     }
 
-    UFE_ASSERT_MSG(false, kErrorMsgFailedConvertToString);
+    try {
+        UFE_ASSERT_MSG(false, kErrorMsgFailedConvertToString);
+    } catch (const std::exception&) {
+        // noop
+    }
     return std::string();
 }
 
@@ -135,7 +138,6 @@ U getUsdAttributeVectorAsUfe(const PXR_NS::UsdAttribute& attr, const PXR_NS::Usd
         return ret;
     }
 
-    UFE_ASSERT_MSG(false, kErrorMsgInvalidType);
     return U();
 }
 
@@ -146,7 +148,6 @@ void setUsdAttributeVectorFromUfe(
     const PXR_NS::UsdTimeCode& time)
 {
     T vec;
-    UFE_ASSERT_MSG(attr.Get<T>(&vec, time), kErrorMsgInvalidType);
     vec.Set(value.x(), value.y(), value.z());
     setUsdAttr<T>(attr, vec);
 }
@@ -263,22 +264,17 @@ UsdAttributeEnumString::create(const UsdSceneItem::Ptr& item, const PXR_NS::UsdA
 
 std::string UsdAttributeEnumString::get() const
 {
-    UFE_ASSERT_MSG(hasValue(), kErrorMsgEnumNoValue);
     PXR_NS::VtValue vt;
     if (fUsdAttr.Get(&vt, getCurrentTime(sceneItem())) && vt.IsHolding<TfToken>()) {
         TfToken tok = vt.UncheckedGet<TfToken>();
         return tok.GetString();
     }
 
-    UFE_ASSERT_MSG(false, kErrorMsgInvalidType);
     return std::string();
 }
 
 void UsdAttributeEnumString::set(const std::string& value)
 {
-    PXR_NS::TfToken dummy;
-    UFE_ASSERT_MSG(
-        fUsdAttr.Get<PXR_NS::TfToken>(&dummy, getCurrentTime(sceneItem())), kErrorMsgInvalidType);
     PXR_NS::TfToken tok(value);
     setUsdAttr<PXR_NS::TfToken>(fUsdAttr, tok);
 }
@@ -286,7 +282,11 @@ void UsdAttributeEnumString::set(const std::string& value)
 Ufe::UndoableCommand::Ptr UsdAttributeEnumString::setCmd(const std::string& value)
 {
     auto self = std::dynamic_pointer_cast<UsdAttributeEnumString>(shared_from_this());
-    UFE_ASSERT_MSG(self, kErrorMsgInvalidType);
+    try {
+        UFE_ASSERT_MSG(self, kErrorMsgInvalidType);
+    } catch (const std::exception&) {
+        // noop
+    }
     return std::make_shared<SetUndoableCommand<std::string, UsdAttributeEnumString>>(self, value);
 }
 
@@ -349,7 +349,6 @@ template <> std::string TypedUsdAttribute<std::string>::get() const
         }
     }
 
-    UFE_ASSERT_MSG(false, kErrorMsgInvalidType);
     return std::string();
 }
 
@@ -358,23 +357,20 @@ template <> void TypedUsdAttribute<std::string>::set(const std::string& value)
     // We need to figure out if the USDAttribute is holding a TfToken or string.
     const PXR_NS::SdfValueTypeName typeName = fUsdAttr.GetTypeName();
     if (typeName.GetHash() == SdfValueTypeNames->String.GetHash()) {
-        std::string dummy;
-        UFE_ASSERT_MSG(
-            fUsdAttr.Get<std::string>(&dummy, getCurrentTime(sceneItem())), kErrorMsgInvalidType);
         setUsdAttr<std::string>(fUsdAttr, value);
         return;
     } else if (typeName.GetHash() == SdfValueTypeNames->Token.GetHash()) {
-        PXR_NS::TfToken dummy;
-        UFE_ASSERT_MSG(
-            fUsdAttr.Get<PXR_NS::TfToken>(&dummy, getCurrentTime(sceneItem())),
-            kErrorMsgInvalidType);
         PXR_NS::TfToken tok(value);
         setUsdAttr<PXR_NS::TfToken>(fUsdAttr, tok);
         return;
     }
 
     // If we get here it means the USDAttribute type wasn't TfToken or string.
-    UFE_ASSERT_MSG(false, kErrorMsgInvalidType);
+    try {
+        UFE_ASSERT_MSG(false, kErrorMsgInvalidType);
+    } catch (const std::exception&) {
+        // noop
+    }
 }
 
 template <> Ufe::Color3f TypedUsdAttribute<Ufe::Color3f>::get() const
@@ -386,7 +382,6 @@ template <> Ufe::Color3f TypedUsdAttribute<Ufe::Color3f>::get() const
 template <> void TypedUsdAttribute<Ufe::Color3f>::set(const Ufe::Color3f& value)
 {
     GfVec3f vec;
-    UFE_ASSERT_MSG(fUsdAttr.Get<GfVec3f>(&vec, getCurrentTime(sceneItem())), kErrorMsgInvalidType);
     vec.Set(value.r(), value.g(), value.b());
     setUsdAttr<GfVec3f>(fUsdAttr, vec);
 }
@@ -437,15 +432,11 @@ template <typename T> T TypedUsdAttribute<T>::get() const
         return vt.UncheckedGet<T>();
     }
 
-    UFE_ASSERT_MSG(false, kErrorMsgInvalidType);
     return T();
 }
 
 template <typename T> void TypedUsdAttribute<T>::set(const T& value)
 {
-    T dummy;
-    UFE_ASSERT_MSG(
-        fUsdAttr.Get<T>(&dummy, getCurrentTime(Ufe::Attribute::sceneItem())), kErrorMsgInvalidType);
     setUsdAttr<T>(fUsdAttr, value);
 }
 

--- a/lib/mayaUsd/ufe/UsdAttribute.cpp
+++ b/lib/mayaUsd/ufe/UsdAttribute.cpp
@@ -26,17 +26,12 @@
 #include <pxr/usd/sdf/attributeSpec.h>
 #include <pxr/usd/usd/schemaRegistry.h>
 
-#include <iostream>
+#include <sstream>
 #include <unordered_map>
 #include <unordered_set>
 
-// We unconditionally want the UFE asserts here (even in release builds).
-// The UFE_ASSERT_MSG has a built-in throw which we want to use for error handling.
-#define UFE_ENABLE_ASSERTS
 #include <mayaUsd/ufe/StagesSubject.h>
 #include <mayaUsd/ufe/Utils.h>
-
-#include <ufe/ufeAssert.h>
 
 // Note: normally we would use this using directive, but here we cannot because
 //       our class is called UsdAttribute which is exactly the same as the one
@@ -117,11 +112,7 @@ getUsdAttributeValueAsString(const PXR_NS::UsdAttribute& attr, const PXR_NS::Usd
         return os.str();
     }
 
-    try {
-        UFE_ASSERT_MSG(false, kErrorMsgFailedConvertToString);
-    } catch (const std::exception&) {
-        // noop
-    }
+    TF_CODING_ERROR(kErrorMsgFailedConvertToString);
     return std::string();
 }
 
@@ -282,11 +273,8 @@ void UsdAttributeEnumString::set(const std::string& value)
 Ufe::UndoableCommand::Ptr UsdAttributeEnumString::setCmd(const std::string& value)
 {
     auto self = std::dynamic_pointer_cast<UsdAttributeEnumString>(shared_from_this());
-    try {
-        UFE_ASSERT_MSG(self, kErrorMsgInvalidType);
-    } catch (const std::exception&) {
-        // noop
-    }
+    if (!TF_VERIFY(self, kErrorMsgInvalidType))
+        return nullptr;
     return std::make_shared<SetUndoableCommand<std::string, UsdAttributeEnumString>>(self, value);
 }
 
@@ -366,11 +354,7 @@ template <> void TypedUsdAttribute<std::string>::set(const std::string& value)
     }
 
     // If we get here it means the USDAttribute type wasn't TfToken or string.
-    try {
-        UFE_ASSERT_MSG(false, kErrorMsgInvalidType);
-    } catch (const std::exception&) {
-        // noop
-    }
+    TF_CODING_ERROR(kErrorMsgInvalidType);
 }
 
 template <> Ufe::Color3f TypedUsdAttribute<Ufe::Color3f>::get() const

--- a/lib/mayaUsd/ufe/UsdAttribute.cpp
+++ b/lib/mayaUsd/ufe/UsdAttribute.cpp
@@ -17,6 +17,8 @@
 
 #include "private/Utils.h"
 
+#include <mayaUsd/ufe/StagesSubject.h>
+#include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/undo/UsdUndoBlock.h>
 #include <mayaUsd/undo/UsdUndoableItem.h>
 
@@ -29,9 +31,6 @@
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
-
-#include <mayaUsd/ufe/StagesSubject.h>
-#include <mayaUsd/ufe/Utils.h>
 
 // Note: normally we would use this using directive, but here we cannot because
 //       our class is called UsdAttribute which is exactly the same as the one


### PR DESCRIPTION
#### MAYA-110489 - Prim AE template: categories persist their expand/collapse state
* Set new forceRebuild flag true to keep our prim template always destroy/recreate itself. This is needed because
  we are dynmaically changing the transform section and we do not know the attributes to show and their order.
* Fixed bug with xformOpOrder change where copied AE tabs were not freshing to show/remove updated transforms.
* Fixed a bug in UsdAttribute where setting a value (that had no previous value) would throw error.

#### MAYA-110215 - On AE template I'd like to see some categories collapsed
* Simple logic to collapse (by default) certain categories.