### PR TITLE
MAYA-108586: Keep the TF_ERROR message format consistence with TF_WARN and TF_STATUS 

### DIFF
--- a/doc/codingGuidelines.md
+++ b/doc/codingGuidelines.md
@@ -268,6 +268,21 @@ Our goal is to develop [maya-usd](https://github.com/autodesk/maya-usd) followin
 * `nullptr` keyword
 * …
 
+## Diagnostic Facilities
+
+Developers are encouraged to use TF library diagnostic facilities in Maya USD. Please follow below guideline for picking the correct facility: https://graphics.pixar.com/usd/docs/api/page_tf__diagnostic.html
+
+In MayaUSD, `UsdMayaDiagnosticDelegate` converts TF diagnostics into native Maya infos, warnings, and errors. The environment flag `MAYAUSD_SHOW_FULL_DIAGNOSTICS`, controls the granularity of TF error/warning/status messages being displayed in Maya:
+
+e.g
+```
+Error: Failed verification: ' image ' -- Unable to create an image from RetroTVBody_Albedo.png
+```
+vs
+```
+Error: Failed verification: ' image ' -- Unable to create an image from RetroTVBody_Albedo.png -- Coding Error in _LoadTexture at line 422 of C:\maya-usd\lib\mayaUsd\render\vp2RenderDelegate\material.cpp
+```
+
 # Coding guidelines for Python
 We are adopting the [PEP-8](https://www.python.org/dev/peps/pep-0008) style for Python Code with the following modification:
 * Mixed-case for variable and function names are allowed 

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -426,7 +426,8 @@ _LoadTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& uvSca
 #else
     GlfImageSharedPtr     image = GlfImage::OpenForReading(path);
 #endif
-    if (!TF_VERIFY(image)) {
+
+    if (!TF_VERIFY(image, "Unable to create an image from %s", path.c_str())) {
         return nullptr;
     }
 

--- a/lib/mayaUsd/utils/diagnosticDelegate.cpp
+++ b/lib/mayaUsd/utils/diagnosticDelegate.cpp
@@ -107,7 +107,7 @@ void UsdMayaDiagnosticDelegate::IssueError(const TfError& err)
     // In addition, always display the full call site for errors by going
     // through _FormatDiagnostic.
     if (ArchIsMainThread()) {
-        MGlobal::displayError(_FormatDiagnostic(err));
+        MGlobal::displayError(err.GetCommentary().c_str());
     } else {
         std::cerr << _FormatDiagnostic(err) << std::endl;
     }

--- a/lib/mayaUsd/utils/diagnosticDelegate.cpp
+++ b/lib/mayaUsd/utils/diagnosticDelegate.cpp
@@ -23,7 +23,7 @@
 
 #include <maya/MGlobal.h>
 
-#include <iostream>
+#include <ghc/filesystem.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -67,17 +67,13 @@ class _WarningOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
 
 static MString _FormatDiagnostic(const TfDiagnosticBase& d)
 {
-    // strip out all the characters before "maya-usd"
-    std::string filterFilePath { d.GetContext().GetFile() };
-    filterFilePath = filterFilePath.substr(filterFilePath.find("maya-usd"));
-
     const std::string msg = TfStringPrintf(
         "%s -- %s in %s at line %zu of %s",
         d.GetCommentary().c_str(),
         TfDiagnosticMgr::GetCodeName(d.GetDiagnosticCode()).c_str(),
         d.GetContext().GetFunction(),
         d.GetContext().GetLine(),
-        filterFilePath.c_str());
+        ghc::filesystem::path(d.GetContext().GetFile()).relative_path().string().c_str());
 
     return TfGetEnvSetting(MAYAUSD_SHOW_FULL_DIAGNOSTICS) ? msg.c_str() : d.GetCommentary().c_str();
 }

--- a/lib/mayaUsd/utils/diagnosticDelegate.cpp
+++ b/lib/mayaUsd/utils/diagnosticDelegate.cpp
@@ -34,13 +34,11 @@ TF_DEFINE_ENV_SETTING(
     "If batching is off, all secondary threads' diagnostics will be "
     "printed to stderr.");
 
-
 TF_DEFINE_ENV_SETTING(
     MAYAUSD_SHOW_FULL_DIAGNOSTICS,
     false,
     "This env flag controls the granularity of TF error/warning/status messages "
-    "being displayed in Maya." );
-
+    "being displayed in Maya.");
 
 // Globally-shared delegate. Uses shared_ptr so we can have weak ptrs.
 static std::shared_ptr<UsdMayaDiagnosticDelegate> _sharedDelegate;

--- a/lib/mayaUsd/utils/diagnosticDelegate.cpp
+++ b/lib/mayaUsd/utils/diagnosticDelegate.cpp
@@ -67,13 +67,17 @@ class _WarningOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
 
 static MString _FormatDiagnostic(const TfDiagnosticBase& d)
 {
+    // strip out all the characters before "maya-usd"
+    std::string filterFilePath { d.GetContext().GetFile() };
+    filterFilePath = filterFilePath.substr(filterFilePath.find("maya-usd"));
+
     const std::string msg = TfStringPrintf(
         "%s -- %s in %s at line %zu of %s",
         d.GetCommentary().c_str(),
         TfDiagnosticMgr::GetCodeName(d.GetDiagnosticCode()).c_str(),
         d.GetContext().GetFunction(),
         d.GetContext().GetLine(),
-        d.GetContext().GetFile());
+        filterFilePath.c_str());
 
     return TfGetEnvSetting(MAYAUSD_SHOW_FULL_DIAGNOSTICS) ? msg.c_str() : d.GetCommentary().c_str();
 }

--- a/lib/mayaUsd/utils/stageCache.cpp
+++ b/lib/mayaUsd/utils/stageCache.cpp
@@ -50,7 +50,6 @@ struct _OnSceneResetListener : public TfWeakBase
 
     void OnSceneReset(const UsdMayaSceneResetNotice& notice)
     {
-        TF_STATUS("Clearing USD Stage Cache");
         UsdMayaStageCache::Clear();
 
         std::lock_guard<std::mutex> lock(_sharedSessionLayersMutex);

--- a/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
+++ b/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
@@ -118,9 +118,13 @@ class testDiagnosticDelegate(unittest.TestCase):
         # the module name will match the file name and be reported as
         # "testDiagnosticDelegate". We make the regex here recognize both
         # cases.
-        self.assertRegex(logText,
-            "^Python coding error: blah -- Coding Error in "
-            "(__main__|testDiagnosticDelegate)\.testError at line [0-9]+ of ")
+        if (Tf.GetEnvSetting('MAYAUSD_SHOW_FULL_DIAGNOSTICS')):
+            self.assertRegex(logText,
+                "^Python coding error: blah -- Coding Error in "
+                "(__main__|testDiagnosticDelegate)\.testError at line [0-9]+ of ")
+        else:
+            self.assertEqual(logText, "Python coding error: blah")
+
         self.assertEqual(logCode, OM.MCommandMessage.kError)
 
     def testError_Python(self):


### PR DESCRIPTION
This PR keeps the TF_ERROR message format consistence with TF_WARN and TF_STATUS by displaying the by only displaying the **commentary** string.

Example below shows the case where an image resource is failed to created which results in a vague message to the user.

Before:
```
// Error: Failed verification: ' image ' -- Coding Error in _LoadTexture at line 422 of S:\jenkins\workspace\ecg-mayausd-full-2022-python3-windows\ecg-maya-usd\maya-usd\lib\mayaUsd\render\vp2RenderDelegate\material.cpp // 
// Error: Failed verification: ' image ' -- Coding Error in _LoadTexture at line 422 of S:\jenkins\workspace\ecg-mayausd-full-2022-python3-windows\ecg-maya-usd\maya-usd\lib\mayaUsd\render\vp2RenderDelegate\material.cpp // 
// Error: Failed verification: ' image ' -- Coding Error in _LoadTexture at line 422 of S:\jenkins\workspace\ecg-mayausd-full-2022-python3-windows\ecg-maya-usd\maya-usd\lib\mayaUsd\render\vp2RenderDelegate\material.cpp // 
// Error: Failed verification: ' image ' -- Coding Error in _LoadTexture at line 422 of S:\jenkins\workspace\ecg-mayausd-full-2022-python3-windows\ecg-maya-usd\maya-usd\lib\mayaUsd\render\vp2RenderDelegate\material.cpp // 
// Error: Failed verification: ' image ' -- Coding Error in _LoadTexture at line 422 of S:\jenkins\workspace\ecg-mayausd-full-2022-python3-windows\ecg-maya-usd\maya-usd\lib\mayaUsd\render\vp2RenderDelegate\material.cpp // 
// Error: Failed verification: ' image ' -- Coding Error in _LoadTexture at line 422 of S:\jenkins\workspace\ecg-mayausd-full-2022-python3-windows\ecg-maya-usd\maya-usd\lib\mayaUsd\render\vp2RenderDelegate\material.cpp // 
// Error: Failed verification: ' image ' -- Coding Error in _LoadTexture at line 422 of S:\jenkins\workspace\ecg-mayausd-full-2022-python3-windows\ecg-maya-usd\maya-usd\lib\mayaUsd\render\vp2RenderDelegate\material.cpp // 
// Error: Failed verification: ' image ' -- Coding Error in _LoadTexture at line 422 of S:\jenkins\workspace\ecg-mayausd-full-2022-python3-windows\ecg-maya-usd\maya-usd\lib\mayaUsd\render\vp2RenderDelegate\material.cpp // 
```

After the fix with a more meaningful message:
```
// Error: Failed verification: ' image ' -- Unable to create an image from RetroTVBody_Albedo.png // 
// Error: Failed verification: ' image ' -- Unable to create an image from RetroTVBody_Emissive.png // 
// Error: Failed verification: ' image ' -- Unable to create an image from RetroTVBody_Metallic.png // 
// Error: Failed verification: ' image ' -- Unable to create an image from RetroTVBody_Normal.png // 
// Error: Failed verification: ' image ' -- Unable to create an image from RetroTVBody_AO.png // 
// Error: Failed verification: ' image ' -- Unable to create an image from RetroTVBody_Roughness.png // 
// Error: Failed verification: ' image ' -- Unable to create an image from RetroTVScreen_Albedo.png // 
// Error: Failed verification: ' image ' -- Unable to create an image from RetroTVScreen_Roughness.png // 
```