### PR TITLE
Check for empty paths

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -367,18 +367,21 @@ bool LayerDatabase::getStagesToSave(bool isExport)
     _proxiesToSave.clear();
     for (const auto& stage : allStages) {
         auto stagePath = MayaUsd::ufe::stagePath(stage);
-        if (!checkSelection
-            || (ufeSelection->contains(stagePath) || ufeSelection->containsAncestor(stagePath))) {
-            // Remove the leading "|world| component.
-            std::string       strStagePath = stagePath.popHead().string();
-            MDagPath          proxyDagPath = UsdMayaUtil::nameToDagPath(strStagePath);
-            MFnDependencyNode fn(proxyDagPath.node());
-            if (!fn.isFromReferencedFile() && supportedNodeType(fn.typeId())) {
-                SdfLayerHandleVector allLayers = stage->GetLayerStack(true);
-                for (auto layer : allLayers) {
-                    if (layer->IsDirty()) {
-                        _proxiesToSave.append(proxyDagPath);
-                        break;
+        if (!stagePath.empty()) {
+            if (!checkSelection
+                || (ufeSelection->contains(stagePath)
+                    || ufeSelection->containsAncestor(stagePath))) {
+                // Remove the leading "|world| component.
+                std::string       strStagePath = stagePath.popHead().string();
+                MDagPath          proxyDagPath = UsdMayaUtil::nameToDagPath(strStagePath);
+                MFnDependencyNode fn(proxyDagPath.node());
+                if (!fn.isFromReferencedFile() && supportedNodeType(fn.typeId())) {
+                    SdfLayerHandleVector allLayers = stage->GetLayerStack(true);
+                    for (auto layer : allLayers) {
+                        if (layer->IsDirty()) {
+                            _proxiesToSave.append(proxyDagPath);
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The stage map we keep that maps between usd stages <-> ufe paths, does not currently remove stage entries when the object is deleted in Maya, even though the path no longer exists.  The stage does still exist in memory, at least until Maya's undo queue is flushed and the reference to the stage is removed, but until that happens the getAllStages function will return stages that will not return to you a valid path when you look it up in the map.

I know this code is currently being refactored a bit, and I believe this function will not longer be used by the layer manager code, so this is a nice easy fix to avoid trying to access an empty ufe path.
