### PR TITLE
Write correct IOR for metallic shaders

### DIFF
--- a/lib/usd/translators/shading/usdStandardSurfaceWriter.cpp
+++ b/lib/usd/translators/shading/usdStandardSurfaceWriter.cpp
@@ -133,11 +133,6 @@ void PxrUsdTranslators_StandardSurfaceWriter::Write(const UsdTimeCode& usdTime)
             shaderSchema,
             PxrMayaUsdPreviewSurfaceTokens->MetallicAttrName,
             usdTime);
-
-        // IOR value from Gold USDPreviewSurface preset
-        shaderSchema
-            .CreateInput(PxrMayaUsdPreviewSurfaceTokens->IorAttrName, SdfValueTypeNames->Float)
-            .Set(50.0f, usdTime);
     } else {
         shaderSchema
             .CreateInput(
@@ -150,14 +145,14 @@ void PxrUsdTranslators_StandardSurfaceWriter::Write(const UsdTimeCode& usdTime)
             shaderSchema,
             PxrMayaUsdPreviewSurfaceTokens->SpecularColorAttrName,
             usdTime);
-
-        AuthorShaderInputFromShadingNodeAttr(
-            depNodeFn,
-            _tokens->specularIOR,
-            shaderSchema,
-            PxrMayaUsdPreviewSurfaceTokens->IorAttrName,
-            usdTime);
     }
+
+    AuthorShaderInputFromShadingNodeAttr(
+        depNodeFn,
+        _tokens->specularIOR,
+        shaderSchema,
+        PxrMayaUsdPreviewSurfaceTokens->IorAttrName,
+        usdTime);
 
     AuthorShaderInputFromShadingNodeAttr(
         depNodeFn,


### PR DESCRIPTION
I also added support for testing metallic roundtrip and IOR roundtrip as well.
This addresses https://github.com/Autodesk/maya-usd/issues/1343