### PR TITLE
MAYA-111329: Fix echouer to import none Usdz ( *.usd, *.usda ) files  when "USDX Texture import" option was enabled.

### DIFF
--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -261,16 +261,9 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
         CHECK_MSTATUS_AND_RETURN(status, false);
     }
 
-    if (this->mArgs.importUSDZTextures == true) {
-        // NOTE: (yliangsiew) First we check if the archive in question _is_ even a USDZ archive...
-        if (!stage->GetRootLayer()->GetFileFormat()->IsPackage()) {
-            TF_WARN(
-                "The layer being imported: %s is not a USDZ file.",
-                stage->GetRootLayer()->GetRealPath().c_str());
-            return MStatus::kFailure;
-        }
-
-        if (this->mArgs.importUSDZTexturesFilePath.length() == 0) {
+    // check if "USDZ Texture import" option is checked and the archive in question is a USDZ.
+    if (mArgs.importUSDZTextures && stage->GetRootLayer()->GetFileFormat()->IsPackage()) {
+        if (mArgs.importUSDZTexturesFilePath.length() == 0) {
             MString currentMayaWorkspacePath = UsdMayaUtil::GetCurrentMayaWorkspacePath();
             TF_WARN(
                 "Because -importUSDZTexturesFilePath was not explicitly specified, textures "


### PR DESCRIPTION
This PR fixes the issue when none packaged usd files (e.g *.usd, *.usda ) fail to import when "USDX Texture import" option is enabled.

Steps to reproduce:
```
- Go to File > Import.
- Select a regular USD file.
- In the import options enable USDZ Texture import.
- Import the file and notice in the script editor is shows the results path line, but nothing comes in.
- Try the import again with the USDZ Texture import option disabled and notice that the file comes in.
```

