### PR TITLE
Use new usdShade/material vector based API for USD versions beyond 21.05

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -31,7 +31,7 @@ See Pixar's official github page for instructions on how to build USD: https://g
 
 |               |      ![](images/pxr.png)          |        
 |:------------: |:---------------:                  |
-|  CommitID/Tags | release: [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) or [v20.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.11) or [v21.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v21.02) or [v21.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v21.05)<br> dev: [090ef0d](https://github.com/PixarAnimationStudios/USD/commit/090ef0d849ced875b3b99a15e454b69148ccd8e1) |
+|  CommitID/Tags | release: [v20.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.02) or [v20.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.05) or [v20.08](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.08) or [v20.11](https://github.com/PixarAnimationStudios/USD/releases/tag/v20.11) or [v21.02](https://github.com/PixarAnimationStudios/USD/releases/tag/v21.02) or [v21.05](https://github.com/PixarAnimationStudios/USD/releases/tag/v21.05)<br> dev: [d9580db](https://github.com/PixarAnimationStudios/USD/commit/d9580dbec274cc9e6028646582153ca9844527ed) |
 
 For additional information on building Pixar USD, see the ***Additional Build Instruction*** section below.
 

--- a/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
@@ -409,7 +409,11 @@ public:
         // renderContext is not found. Therefore we need to test first that the
         // render context output we are looking for really exists:
         if (shadeMaterial.GetSurfaceOutput(renderContext)) {
+#if PXR_VERSION > 2105
+            UsdShadeShader surfaceShader = shadeMaterial.ComputeSurfaceSource({renderContext});
+#else
             UsdShadeShader surfaceShader = shadeMaterial.ComputeSurfaceSource(renderContext);
+#endif
             if (surfaceShader) {
                 const TfToken surfaceShaderPlugName = _context->GetSurfaceShaderPlugName();
                 if (!surfaceShaderPlugName.IsEmpty()) {
@@ -419,7 +423,11 @@ public:
         }
 
         if (shadeMaterial.GetVolumeOutput(renderContext)) {
+#if PXR_VERSION > 2105
+            UsdShadeShader volumeShader = shadeMaterial.ComputeVolumeSource({renderContext});
+#else
             UsdShadeShader volumeShader = shadeMaterial.ComputeVolumeSource(renderContext);
+#endif
             if (volumeShader) {
                 const TfToken volumeShaderPlugName = _context->GetVolumeShaderPlugName();
                 if (!volumeShaderPlugName.IsEmpty()) {
@@ -429,8 +437,13 @@ public:
         }
 
         if (shadeMaterial.GetDisplacementOutput(renderContext)) {
+#if PXR_VERSION > 2105
+            UsdShadeShader displacementShader
+                = shadeMaterial.ComputeDisplacementSource({renderContext});
+#else
             UsdShadeShader displacementShader
                 = shadeMaterial.ComputeDisplacementSource(renderContext);
+#endif
             if (displacementShader) {
                 const TfToken displacementShaderPlugName
                     = _context->GetDisplacementShaderPlugName();

--- a/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
@@ -410,7 +410,7 @@ public:
         // render context output we are looking for really exists:
         if (shadeMaterial.GetSurfaceOutput(renderContext)) {
 #if PXR_VERSION > 2105
-            UsdShadeShader surfaceShader = shadeMaterial.ComputeSurfaceSource({renderContext});
+            UsdShadeShader surfaceShader = shadeMaterial.ComputeSurfaceSource({ renderContext });
 #else
             UsdShadeShader surfaceShader = shadeMaterial.ComputeSurfaceSource(renderContext);
 #endif
@@ -424,7 +424,7 @@ public:
 
         if (shadeMaterial.GetVolumeOutput(renderContext)) {
 #if PXR_VERSION > 2105
-            UsdShadeShader volumeShader = shadeMaterial.ComputeVolumeSource({renderContext});
+            UsdShadeShader volumeShader = shadeMaterial.ComputeVolumeSource({ renderContext });
 #else
             UsdShadeShader volumeShader = shadeMaterial.ComputeVolumeSource(renderContext);
 #endif
@@ -439,7 +439,7 @@ public:
         if (shadeMaterial.GetDisplacementOutput(renderContext)) {
 #if PXR_VERSION > 2105
             UsdShadeShader displacementShader
-                = shadeMaterial.ComputeDisplacementSource({renderContext});
+                = shadeMaterial.ComputeDisplacementSource({ renderContext });
 #else
             UsdShadeShader displacementShader
                 = shadeMaterial.ComputeDisplacementSource(renderContext);


### PR DESCRIPTION
The API for the Compute*Source functions in usdShade/material is changing. This change will future proof the callsites. 