### PR TITLE
MAYA-111084 - LE save icon missing when scaling is 125%

### DIFF
--- a/lib/usd/ui/layerEditor/layerEditorWidget.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.cpp
@@ -54,8 +54,16 @@ using namespace UsdLayerEditor;
 // properly support high dpi with style sheets
 QString getDPIPixmapName(QString baseName)
 {
-    QString suffix(QString::number(IS_MAC_OS ? 100 : DPIScale(100)));
-    return baseName + "_" + suffix + ".png";
+#ifdef Q_OS_DARWIN
+    return baseName + "_100.png";
+#else
+    const auto scale = utils->dpiScale();
+    if (scale >= 2.0)
+        return baseName + "_200.png";
+    else if (scale >= 1.5)
+        return baseName + "_150.png";
+    return baseName + "_100.png";
+#endif
 }
 
 // setup a push button with DPI-appropriate regular, hover and pressed png in the
@@ -71,6 +79,8 @@ static void setupButtonWithHIGBitmaps(QPushButton* button, QString baseName)
     QPushButton {
         padding : %1px;
         background-image: url(%2);
+        background-position: center center;
+        background-repeat: no-repeat;
         border: 0px;
         background-origin: content;
         }


### PR DESCRIPTION
#### MAYA-111084 - LE save icon missing when scaling is 125%
* We don't provide icons at 125% so make sure to account for that.