### PR TITLE
Removed duplicate ufePathToPrim call.

### DIFF
--- a/lib/mayaUsd/ufe/UsdHierarchyHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchyHandler.cpp
@@ -47,8 +47,8 @@ Ufe::Hierarchy::Ptr UsdHierarchyHandler::hierarchy(const Ufe::SceneItem::Ptr& it
 
 Ufe::SceneItem::Ptr UsdHierarchyHandler::createItem(const Ufe::Path& path) const
 {
-    const PXR_NS::UsdPrim prim = ufePathToPrim(path);
-    const int             instanceIndex = ufePathToInstanceIndex(path);
+    PXR_NS::UsdPrim prim;
+    const int       instanceIndex = ufePathToInstanceIndex(path, &prim);
     return prim.IsValid() ? UsdSceneItem::create(path, prim, instanceIndex) : nullptr;
 }
 

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -203,11 +203,14 @@ UsdPrim ufePathToPrim(const Ufe::Path& path)
     return prim;
 }
 
-int ufePathToInstanceIndex(const Ufe::Path& path)
+int ufePathToInstanceIndex(const Ufe::Path& path, PXR_NS::UsdPrim* prim)
 {
     int instanceIndex = UsdImagingDelegate::ALL_INSTANCES;
 
     const UsdPrim usdPrim = ufePathToPrim(path);
+    if (prim) {
+        *prim = usdPrim;
+    }
     if (!usdPrim || !usdPrim.IsA<UsdGeomPointInstancer>()) {
         return instanceIndex;
     }

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Autodesk
+// Copyright 2021 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -84,8 +84,10 @@ PXR_NS::UsdPrim ufePathToPrim(const Ufe::Path& path);
 //! represents a point instance.
 //! If the given path does not represent a point instance,
 //! UsdImagingDelegate::ALL_INSTANCES (-1) will be returned.
+//! If the optional argument prim pointer is non-null, the USD prim
+//! corresponding to the argument UFE path is returned, as per ufePathToPrim().
 MAYAUSD_CORE_PUBLIC
-int ufePathToInstanceIndex(const Ufe::Path& path);
+int ufePathToInstanceIndex(const Ufe::Path& path, PXR_NS::UsdPrim* prim = nullptr);
 
 MAYAUSD_CORE_PUBLIC
 bool isRootChild(const Ufe::Path& path);


### PR DESCRIPTION
Added optional argument to ufePathToPrimIndex to return the prim as well, thereby removing a duplicate call.  Provides a 7% gain in first point move performance in the 70k point instances test scene.