### PR TITLE
MAYA-105710: fix USD files fail to load on mapped mounted volume.

### DIFF
--- a/cmake/gulark.cmake
+++ b/cmake/gulark.cmake
@@ -38,7 +38,7 @@ else()
     FetchContent_Declare(
         ${CONTENT_NAME}
         GIT_REPOSITORY https://github.com/gulrak/filesystem.git
-        GIT_TAG        3d3c02ce35dcc68b5ebb34f21cb1fc507be9a66e
+        GIT_TAG        4e21ab305794f5309a1454b4ae82ab9a0f5e0d25
         USES_TERMINAL_DOWNLOAD TRUE
         GIT_CONFIG     advice.detachedHead=false
     )

--- a/lib/mayaUsd/utils/utilFileSystem.cpp
+++ b/lib/mayaUsd/utils/utilFileSystem.cpp
@@ -157,10 +157,12 @@ std::string UsdMayaUtilFileSystem::resolveRelativePathWithinMayaContext(
         return relativeFilePath;
     }
 
-    auto path = ghc::filesystem::path(currentFileDir).append(relativeFilePath);
+    std::error_code errorCode;
+    auto            path = ghc::filesystem::canonical(
+        ghc::filesystem::path(currentFileDir).append(relativeFilePath), errorCode);
 
-    // if file does not exist
-    if (path.empty()) {
+    if (errorCode) {
+        // file does not exist
         return std::string();
     }
 

--- a/lib/mayaUsd/utils/utilFileSystem.cpp
+++ b/lib/mayaUsd/utils/utilFileSystem.cpp
@@ -143,23 +143,24 @@ std::string UsdMayaUtilFileSystem::resolveRelativePathWithinMayaContext(
     const MObject&     proxyShape,
     const std::string& relativeFilePath)
 {
-    if (relativeFilePath.length() < 3)
+    if (relativeFilePath.length() < 3) {
         return relativeFilePath;
+    }
 
     std::string currentFileDir = getMayaReferencedFileDir(proxyShape);
 
-    if (currentFileDir.empty())
+    if (currentFileDir.empty()) {
         currentFileDir = getMayaSceneFileDir();
+    }
 
-    if (currentFileDir.empty())
+    if (currentFileDir.empty()) {
         return relativeFilePath;
+    }
 
-    std::error_code errorCode;
-    auto            path = ghc::filesystem::canonical(
-        ghc::filesystem::path(currentFileDir).append(relativeFilePath), errorCode);
+    auto path = ghc::filesystem::path(currentFileDir).append(relativeFilePath);
 
-    if (errorCode) {
-        // file does not exist
+    // if file does not exist
+    if (path.empty()) {
         return std::string();
     }
 


### PR DESCRIPTION
This PR fixes the issue with loading usd from mapped drivers.

#### Steps to reproduce the error:
```
    Plugin and external drive or USB Drive to your computer.
    Go to Disk Manager.
    Right Click on your connected drive.
    Select "Change Drive Letter and Path..."
    Select "Add".
    Use "Mount in the following empty NTFS folder:"
    Locate the folder you want to mount to.
    Extract the attached folder to that location.
    Open Maya and then open the *.ma file that contains usd with relative path
    Notice that the USD file doesn't load.
```
Note: Opening the same file if saved on a local drive or a network drive works without issues.

#### Description:
There is a bug in `gulark's filesystem::canonical` which fails to properly resolve relative path. C++17 std::filesystem::canonical doesn't have this issue and properly resolves the relative path.

**ghc::filesystem::canonical**
```
auto fullPath = ghc::filesystem::path(currentFileDir).append(relativeFilePath); 
// C:\\MOUNT_ME\\RTS\\RTS\\master_files\\..\\referenced_files\\USD\\barrelTests\\Library\\Assets\\Barrels\\Barrels.usd
auto path = ghc::filesystem::canonical(fullPath, errorCode); // error 
```

**std::filesystem::canonical**
```
auto fullPath = std::filesystem::path(currentFileDir).append(relativeFilePath);
//"C:\\MOUNT_ME\\RTS\\RTS\\master_files\\../referenced_files/USD/barrelTests/Library/Assets/Barrels/Barrels.usd"
auto path = std::filesystem::canonical(fullPath, errorCode); // Ok, good 
```

#### Workaround:

To work around this, I removed the need to call `filesystem::canonical` all together since the given path to `ArGetResolver().ConfigureResolverForAsset` is resolved properly. 

https://github.com/Autodesk/maya-usd/blob/092f52057f46c51c3ed725d9e25422c52e0bdd0c/lib/mayaUsd/nodes/proxyShapeBase.cpp#L660

e.g 
`C:\\MOUNT_ME\\RTS\\RTS\\master_files\\..\\referenced_files\\USD\\barrelTests\\Library\\Assets\\Barrels\\Barrels.usd`



