### PR TITLE
Fixed bug in reading paired xformOp operations which would result in incorrect transform applied in Maya

### DIFF
--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -70,6 +70,7 @@ set(TEST_SCRIPT_FILES
     testUsdExportImportUDIM.py
     testUsdImportSkeleton.py
     testUsdImportXforms.py
+    testUsdImportXformOps.py
     testUsdImportXformAnim.py
     testUsdMayaAdaptor.py
     testUsdMayaAdaptorGeom.py

--- a/test/lib/usd/translators/UsdImportXformOpsTest/UsdImportXformOpsTest.usda
+++ b/test/lib/usd/translators/UsdImportXformOpsTest/UsdImportXformOpsTest.usda
@@ -1,0 +1,80 @@
+#usda 1.0
+(
+    defaultPrim = "group1"
+    metersPerUnit = 0.01
+    upAxis = "Y"
+)
+
+def SkelRoot "group1" (
+    kind = "component"
+)
+{
+    float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+
+    def Skeleton "joint1" (
+        prepend apiSchemas = ["SkelBindingAPI"]
+        customData = {
+            dictionary Maya = {
+                bool generated = 1
+            }
+        }
+    )
+    {
+        uniform matrix4d[] bindTransforms = [( (2.220446049250313e-16, 0, -1.0000000000000002, 0), (0, 1, 0, 0), (1.0000000000000002, 0, 2.220446049250313e-16, 0), (0, 0, 0, 1) ), ( (1.0000000000000004, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1.0000000000000004, 0), (0, 0, -2, 1) )]
+        uniform token[] joints = ["joint1", "joint1/joint2"]
+        uniform matrix4d[] restTransforms = [( (2.220446049250313e-16, 0, -1.0000000000000002, 0), (0, 1, 0, 0), (1.0000000000000002, 0, 2.220446049250313e-16, 0), (0, 0, 0, 1) ), ( (2.220446049250313e-16, 0, 1.0000000000000002, 0), (-0, 1, 0, 0), (-1.0000000000000002, -0, 2.220446049250313e-16, 0), (1.9999999999999996, 0, -4.440892098500624e-16, 1) )]
+        rel skel:animationSource = </group1/joint1/Animation>
+
+        def SkelAnimation "Animation"
+        {
+            uniform token[] joints = ["joint1"]
+            quatf[] rotations = [(0.70710677, 0, 0.70710677, 0)]
+            half3[] scales = [(1, 1, 1)]
+            float3[] translations = [(0, 0, 0)]
+        }
+    }
+
+    def Xform "group2"
+    {
+        float3 xformOp:scale = (0.5, 0.5, 0.5)
+        uniform token[] xformOpOrder = ["xformOp:scale"]
+
+        def Mesh "pCube1" (
+            prepend apiSchemas = ["SkelBindingAPI", "MaterialBindingAPI"]
+        )
+        {
+            uniform bool doubleSided = 1
+            float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+            rel material:binding = </group1/Looks/initialShadingGroup>
+            point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5)]
+            texCoord2f[] primvars:map1 = [(0.375, 0), (0.625, 0), (0.375, 0.25), (0.625, 0.25), (0.375, 0.5), (0.625, 0.5), (0.375, 0.75), (0.625, 0.75), (0.375, 1), (0.625, 1), (0.875, 0), (0.875, 0.25), (0.125, 0), (0.125, 0.25)] (
+                interpolation = "faceVarying"
+            )
+            int[] primvars:map1:indices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 9, 8, 1, 10, 11, 3, 12, 0, 2, 13]
+            matrix4d primvars:skel:geomBindTransform = ( (0.25, 0, 0, 0), (0, 0.25, 0, 0), (0, 0, 0.25, 0), (0, -1.368141421404827, 0, 1) )
+            int[] primvars:skel:jointIndices = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1] (
+                elementSize = 2
+                interpolation = "vertex"
+            )
+            float[] primvars:skel:jointWeights = [0.89942855, 0.10057144, 0.89942855, 0.10057144, 0.93692636, 0.063073635, 0.93692636, 0.063073635, 0.9136168, 0.08638325, 0.9136168, 0.08638325, 0.8681419, 0.13185813, 0.8681419, 0.13185813] (
+                elementSize = 2
+                interpolation = "vertex"
+            )
+            uniform token[] skel:joints = ["joint1", "joint1/joint2"]
+            rel skel:skeleton = </group1/joint1>
+            float3 xformOp:scale = (0.5, 0.5, 0.5)
+            float3 xformOp:translate:pivot = (0, -5.4725657, 0)
+            uniform token[] xformOpOrder = ["xformOp:translate:pivot", "xformOp:scale", "!invert!xformOp:translate:pivot"]
+        }
+    }
+
+    def Scope "Looks"
+    {
+        def Material "initialShadingGroup"
+        {
+        }
+    }
+}
+

--- a/test/lib/usd/translators/testUsdImportXformOps.py
+++ b/test/lib/usd/translators/testUsdImportXformOps.py
@@ -1,0 +1,63 @@
+#!/pxrpythonsubst
+#
+# Copyright 2021 Apple
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import unittest
+
+import fixturesUtils
+import maya.OpenMaya as om
+from maya import cmds
+from maya import standalone
+from pxr import Usd
+from pxr import Gf
+
+
+class TestUsdImportXformOps(unittest.TestCase):
+    """
+    Verify that importing USDs with paired xform/inverted xform pivot ops creates
+    the correct transform when imported into Maya.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = fixturesUtils.setUpClass(__file__)
+        cls.scene_path = os.path.join(cls.temp_dir, "UsdImportXformOpsTest", "UsdImportXformOpsTest.usda").replace("\\", "/")
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def testImportPairedXformOps(self):
+        """
+        Tests that importing a USD cube mesh with non-identity scale that has paired
+        XformOps on it will result in the correct transform when imported into Maya.
+        """
+        om.MFileIO.newFile(True)
+        cmds.mayaUSDImport(file=self.scene_path)
+        selList = om.MSelectionList()
+        selList.add("pCube1")
+        cubeDagPath = om.MDagPath()
+        selList.getDagPath(0, cubeDagPath)
+        transform = cubeDagPath.inclusiveMatrix()
+        expectedTranslation = Gf.Vec3f(0.0, -1.3681414, 0.0)
+        actualTranslation = om.MTransformationMatrix(transform).getTranslation(om.MSpace.kTransform)  # NOTE: (yliangsiew) world space
+        actualTranslation = Gf.Vec3f(actualTranslation[0], actualTranslation[1], actualTranslation[2])
+        print actualTranslation
+        self.assertTrue(Gf.IsClose(expectedTranslation, actualTranslation, 0.001))
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Hi:

This PR fixes an issue we are encountering where import of USD files that have the pivot translated paired with its corresponding `!invert!` operation results in Maya-USD ignoring the inverse operation, resulting in an incorrect transform applied on import. This should also fix multiple xformOp ops not being applied correctly in sequence as well since the previous code essentially overwrote one xformOp with another.

An example of a basic Maya scene setup which demonstrates the issue is attached:
[unit_test.zip](https://github.com/Autodesk/maya-usd/files/6510476/unit_test.zip)

Preview of the scene:
![image](https://user-images.githubusercontent.com/74624210/118852242-73edeb80-b887-11eb-91d7-e487d4daddb6.png)

Exporting the scene to USD and re-importing it in a new Maya session, without the fix:
![image](https://user-images.githubusercontent.com/74624210/118852671-d5ae5580-b887-11eb-97b0-40a4eb6f340b.png)

With the fix, the inverse xformOp operation is no longer ignored and the result is correct on import.
![image](https://user-images.githubusercontent.com/74624210/118852639-cdeeb100-b887-11eb-8f8f-f50618c35833.png)

Please review and raise any concerns.