### PR TITLE
MAYA-111760 Invisibile prims don't get notifications on _PropagateDirtyBits or

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -665,6 +665,13 @@ void HdVP2BasisCurves::Sync(
 
     if (HdChangeTracker::IsVisibilityDirty(*dirtyBits, id)) {
         _sharedData.visible = delegate->GetVisible(id);
+
+        // Invisible rprims don't get calls to Sync or _PropagateDirtyBits while
+        // they are invisible. This means that when a prim goes from visible to
+        // invisible that we must update every repr, because if we switch reprs while
+        // invisible we'll get no chance to update!
+        if (!_sharedData.visible)
+            _MakeOtherReprRenderItemsInvisible(delegate, reprToken);
     }
 
     if (*dirtyBits
@@ -1678,6 +1685,39 @@ void HdVP2BasisCurves::_InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBit
 #else
         repr->AddDrawItem(std::move(drawItem));
 #endif
+    }
+}
+
+/*! \brief Hide all of the repr objects for this Rprim except the named repr.
+    Repr objects are created to support specific reprName tokens, and contain a list of
+    HdVP2DrawItems and corresponding RenderItems.
+*/
+void HdVP2BasisCurves::_MakeOtherReprRenderItemsInvisible(
+    HdSceneDelegate* sceneDelegate,
+    const TfToken&   reprToken)
+{
+    for (const std::pair<TfToken, HdReprSharedPtr>& pair : _reprs) {
+        if (pair.first != reprToken) {
+            // For each relevant draw item, update dirty buffer sources.
+            const HdReprSharedPtr& repr = pair.second;
+            const auto&            items = repr->GetDrawItems();
+
+#if HD_API_VERSION < 35
+            for (HdDrawItem* item : items) {
+                if (HdVP2DrawItem* drawItem = static_cast<HdVP2DrawItem*>(item)) {
+#else
+            for (const HdRepr::DrawItemUniquePtr& item : items) {
+                if (HdVP2DrawItem* const drawItem = static_cast<HdVP2DrawItem*>(item.get())) {
+#endif
+                    for (auto& renderItemData : drawItem->GetRenderItems()) {
+                        _delegate->GetVP2ResourceRegistry().EnqueueCommit([&renderItemData]() {
+                            renderItemData._enabled = false;
+                            renderItemData._renderItem->enable(false);
+                        });
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
@@ -129,6 +129,7 @@ protected:
 
 private:
     void _UpdateRepr(HdSceneDelegate* sceneDelegate, TfToken const& reprToken);
+    void _MakeOtherReprRenderItemsInvisible(HdSceneDelegate*, const TfToken&);
 
     void _CommitMVertexBuffer(MHWRender::MVertexBuffer* const, void*) const;
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1486,28 +1486,30 @@ void HdVP2Mesh::_CreateSmoothHullRenderItems(HdVP2DrawItem& drawItem)
     Repr objects are created to support specific reprName tokens, and contain a list of
     HdVP2DrawItems and corresponding RenderItems.
 */
-void HdVP2Mesh::_MakeOtherReprRenderItemsInvisible(HdSceneDelegate* sceneDelegate, const TfToken& reprToken)
+void HdVP2Mesh::_MakeOtherReprRenderItemsInvisible(
+    HdSceneDelegate* sceneDelegate,
+    const TfToken&   reprToken)
 {
     for (const std::pair<TfToken, HdReprSharedPtr>& pair : _reprs) {
         if (pair.first != reprToken) {
             // For each relevant draw item, update dirty buffer sources.
             _MeshReprConfig::DescArray reprDescs = _GetReprDesc(pair.first);
-            int drawItemIndex = 0;
+            int                        drawItemIndex = 0;
             for (size_t descIdx = 0; descIdx < reprDescs.size(); ++descIdx, drawItemIndex++) {
                 const HdMeshReprDesc& desc = reprDescs[descIdx];
                 if (desc.geomStyle == HdMeshGeomStyleInvalid) {
                     continue;
                 }
-                auto* drawItem = static_cast<HdVP2DrawItem*>(pair.second->GetDrawItem(drawItemIndex));
+                auto* drawItem
+                    = static_cast<HdVP2DrawItem*>(pair.second->GetDrawItem(drawItemIndex));
                 if (!drawItem)
                     continue;
 
                 for (auto& renderItemData : drawItem->GetRenderItems()) {
-                    _delegate->GetVP2ResourceRegistry().EnqueueCommit(
-                        [&renderItemData]() {
-                            renderItemData._enabled = false;
-                            renderItemData._renderItem->enable(false);
-                        });
+                    _delegate->GetVP2ResourceRegistry().EnqueueCommit([&renderItemData]() {
+                        renderItemData._enabled = false;
+                        renderItemData._renderItem->enable(false);
+                    });
                 }
             }
         }

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1042,6 +1042,13 @@ void HdVP2Mesh::Sync(
 
     if (HdChangeTracker::IsVisibilityDirty(*dirtyBits, id)) {
         _sharedData.visible = delegate->GetVisible(id);
+
+        // Invisible rprims don't get calls to Sync or _PropagateDirtyBits while
+        // they are invisible. This means that when a prim goes from visible to
+        // invisible that we must update every repr, because if we switch reprs while
+        // invisible we'll get no chance to update!
+        if (!_sharedData.visible)
+            _MakeOtherReprRenderItemsInvisible(delegate, reprToken);
     }
 
     if (*dirtyBits
@@ -1472,6 +1479,39 @@ void HdVP2Mesh::_CreateSmoothHullRenderItems(HdVP2DrawItem& drawItem)
     }
 
     TF_VERIFY(numFacesWithoutRenderItem == 0);
+}
+
+/*! \brief Hide all of the repr objects for this Rprim except the named repr.
+
+    Repr objects are created to support specific reprName tokens, and contain a list of
+    HdVP2DrawItems and corresponding RenderItems.
+*/
+void HdVP2Mesh::_MakeOtherReprRenderItemsInvisible(HdSceneDelegate* sceneDelegate, const TfToken& reprToken)
+{
+    for (const std::pair<TfToken, HdReprSharedPtr>& pair : _reprs) {
+        if (pair.first != reprToken) {
+            // For each relevant draw item, update dirty buffer sources.
+            _MeshReprConfig::DescArray reprDescs = _GetReprDesc(pair.first);
+            int drawItemIndex = 0;
+            for (size_t descIdx = 0; descIdx < reprDescs.size(); ++descIdx, drawItemIndex++) {
+                const HdMeshReprDesc& desc = reprDescs[descIdx];
+                if (desc.geomStyle == HdMeshGeomStyleInvalid) {
+                    continue;
+                }
+                auto* drawItem = static_cast<HdVP2DrawItem*>(pair.second->GetDrawItem(drawItemIndex));
+                if (!drawItem)
+                    continue;
+
+                for (auto& renderItemData : drawItem->GetRenderItems()) {
+                    _delegate->GetVP2ResourceRegistry().EnqueueCommit(
+                        [&renderItemData]() {
+                            renderItemData._enabled = false;
+                            renderItemData._renderItem->enable(false);
+                        });
+                }
+            }
+        }
+    }
 }
 
 /*! \brief  Update the named repr object for this Rprim.

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
@@ -125,6 +125,7 @@ private:
     void _InitRepr(const TfToken&, HdDirtyBits*) override;
 
     void _UpdateRepr(HdSceneDelegate*, const TfToken&);
+    void _MakeOtherReprRenderItemsInvisible(HdSceneDelegate*, const TfToken&);
 
     void _CommitMVertexBuffer(MHWRender::MVertexBuffer* const, void*) const;
 


### PR DESCRIPTION
Sync, so when a prim turns invisible make sure all reprs can draw correctly.