### PR TITLE
MAYA-111521: Fix error messages showing up when opening the "Applied Schema" category

### DIFF
--- a/lib/mayaUsd/ufe/UsdAttributes.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributes.cpp
@@ -66,6 +66,11 @@ Ufe::Attribute::Type UsdAttributes::attributeType(const std::string& name)
 
 Ufe::Attribute::Ptr UsdAttributes::attribute(const std::string& name)
 {
+    // early return if name is empty.
+    if (name.empty()) {
+        return nullptr;
+    }
+
     // If we've already created an attribute for this name, just return it.
     auto iter = fAttributes.find(name);
     if (iter != std::end(fAttributes))


### PR DESCRIPTION
### Description:
Accessing certain AE tabs (e.g Applied Schema, Cylinder Light ) results in "propName.IsEmpty()" error to spit out by USD. We currently allow creating attributes with an empty strings which are not accepted by USD. This doesn't only happen when accessing "Applied Schema" tabs but also in other attribute tabs "Cylinder Light". 

In USD land At Line 523 ,  the property name can't be empty. Hence the error reported.

https://github.com/PixarAnimationStudios/USD/blob/090ef0d849ced875b3b99a15e454b69148ccd8e1/pxr/usd/usd/stage.cpp#L4523


![image](https://user-images.githubusercontent.com/48299423/119667304-2aac1780-be04-11eb-8acf-c796674e3186.png)
