### PR TITLE
MAYA-110972 Disable the new point snapping support for the time being.

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -41,8 +41,9 @@
 #endif
 
 // The new Maya point snapping support doesn't require point snapping items any more.
-#if MAYA_API_VERSION >= 20220100
-#define MAYA_NEW_POINT_SNAPPING_SUPPORT
+#if MAYA_API_VERSION >= 20230000
+// The new Maya point snapping support has some known issues. Disable it for now.
+// #define MAYA_NEW_POINT_SNAPPING_SUPPORT
 #endif
 
 // Conditional compilation due to Maya API gap.


### PR DESCRIPTION
I didn't do a straight reversion of the change which enabled the new point snapping support in 2021 because I wanted to disable it in betas as well.