### PR TITLE
MAYA-112050 - Unit test will write temp files in test area

### DIFF
--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -325,7 +325,8 @@ finally:
     # Note: ${WORKING_DIR} can point to the source folder, so don't use it
     #       in any env var that will write files (such as MAYA_APP_DIR).
     set_property(TEST "${test_name}" APPEND PROPERTY ENVIRONMENT
-        "MAYA_APP_DIR=${MAYA_APP_TEMP_DIR}")
+        "MAYA_APP_DIR=${MAYA_APP_TEMP_DIR}"
+        "TEMP=${MAYA_APP_TEMP_DIR}")
     file(MAKE_DIRECTORY ${MAYA_APP_TEMP_DIR})
 
     # Set the Python major version in MAYA_PYTHON_VERSION. Maya 2020 and


### PR DESCRIPTION
On some machines the TEMP area might not be writable. Redirect unit tests to a temp folder in the build area

Result:
```
E:\Ws\UsdBuild\MayaUSD\build>ctest -V -R Package
...
104: Environment variables:
...
104:  TEMP=E:/Ws/UsdBuild/MayaUSD/build/test/Temporary/testUsdExportPackage
...
104: Opening layer 'e:/Ws/UsdBuild/MayaUSD/build/test/lib/usd/translators/tmp-8AE85DC1-4B44-D809-4259-22846078EB9C.usdc' for writing
104: Saving stage
104: Packaging USDZ file
```