### PR TITLE
MAYA-110682 - On drag and drop of a layer with an editTarget, the edi…

### DIFF
--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -649,7 +649,12 @@ MSyntax LayerEditorCommand::createSyntax()
     syntax.makeFlagMultiUse(kRemoveSubPathFlag);
     syntax.addFlag(kReplaceSubPathFlag, kReplaceSubPathFlagL, MSyntax::kString, MSyntax::kString);
     syntax.makeFlagMultiUse(kReplaceSubPathFlag);
-    syntax.addFlag(kMoveSubPathFlag, kMoveSubPathFlagL, MSyntax::kString, MSyntax::kString, MSyntax::kUnsigned);
+    syntax.addFlag(
+        kMoveSubPathFlag,
+        kMoveSubPathFlagL,
+        MSyntax::kString,    // path to move
+        MSyntax::kString,    // new parent layer
+        MSyntax::kUnsigned); // layer index inside the new parent
     syntax.addFlag(kDiscardEditsFlag, kDiscardEditsFlagL);
     syntax.addFlag(kClearLayerFlag, kClearLayerFlagL);
     // parameter: new layer name

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -305,11 +305,17 @@ public:
 };
 
 // Move a sublayer into another layer.
+// @param path The layer's path to move.
+// @param newParentLayer The new parent layer's path 
+// @param newIndex The index where the moved layer will be in the new parent.
 class MoveSubPath : public BaseCmd
 {
 public:
-    MoveSubPath()
+    MoveSubPath(const std::string& path, const std::string& newParentLayer, unsigned newIndex)
         : BaseCmd(CmdId::kMove)
+        , _path(path)
+        , _newParentLayer(newParentLayer)
+        , _newIndex(newIndex)
     {
     }
 
@@ -394,11 +400,10 @@ public:
         return true;
     }
 
+private:
     std::string  _path;
     std::string  _newParentLayer;
     unsigned int _newIndex;
-
-private:
     unsigned int _oldIndex { 0 };
 };
 
@@ -738,8 +743,6 @@ MStatus LayerEditorCommand::parseArgs(const MArgList& argList)
         }
 
         if (argParser.isFlagSet(kMoveSubPathFlag)) {
-            auto cmd = std::make_shared<Impl::MoveSubPath>();
-
             MString subPath;
             argParser.getFlagArgument(kMoveSubPathFlag, 0, subPath);
 
@@ -749,9 +752,8 @@ MStatus LayerEditorCommand::parseArgs(const MArgList& argList)
             unsigned int index { 0 };
             argParser.getFlagArgument(kMoveSubPathFlag, 2, index);
 
-            cmd->_path = subPath.asUTF8();
-            cmd->_newParentLayer = newParentLayer.asUTF8();
-            cmd->_newIndex = index;
+            auto cmd = std::make_shared<Impl::MoveSubPath>(
+                subPath.asUTF8(), newParentLayer.asUTF8(), index);
             _subCommands.push_back(std::move(cmd));
         }
 

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -318,8 +318,8 @@ public:
         auto proxy = layer->GetSubLayerPaths();
         auto subPathIndex = proxy.Find(_path);
         if (subPathIndex == size_t(-1)) {
-            std::string message = std::string("path ") + _path
-                + std::string(" not found on layer ") + layer->GetIdentifier();
+            std::string message = std::string("path ") + _path + std::string(" not found on layer ")
+                + layer->GetIdentifier();
             MPxCommand::displayError(message.c_str());
             return false;
         }
@@ -341,8 +341,8 @@ public:
         } else {
             newParentLayer = SdfLayer::Find(_newParentLayer);
             if (!newParentLayer) {
-                std::string message = std::string("Layer ") + _newParentLayer
-                    + std::string(" not found!");
+                std::string message
+                    = std::string("Layer ") + _newParentLayer + std::string(" not found!");
                 return false;
             }
 
@@ -360,7 +360,7 @@ public:
                 std::string message = std::string("SubPath ") + _path
                     + std::string(" already exist in layer ") + newParentLayer->GetIdentifier();
                 MPxCommand::displayError(message.c_str());
-                return false;        
+                return false;
             }
         }
 
@@ -394,23 +394,9 @@ public:
         return true;
     }
 
-    std::string _path;
-    std::string _newParentLayer;
+    std::string  _path;
+    std::string  _newParentLayer;
     unsigned int _newIndex;
-
-private:
-
-    static bool validateAndReportIndex(SdfLayerHandle layer, int index, int maxIndex)
-    {
-        if (index < 0 || index >= maxIndex) {
-            std::string message = std::string("Index ") + std::to_string(index)
-                + std::string(" out-of-bound for ") + layer->GetIdentifier();
-            MPxCommand::displayError(message.c_str());
-            return false;
-        } else {
-            return true;
-        }
-    }
 
 private:
     unsigned int _oldIndex { 0 };

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -746,7 +746,7 @@ MStatus LayerEditorCommand::parseArgs(const MArgList& argList)
             MString newParentLayer;
             argParser.getFlagArgument(kMoveSubPathFlag, 1, newParentLayer);
 
-            unsigned int index {0};
+            unsigned int index { 0 };
             argParser.getFlagArgument(kMoveSubPathFlag, 2, index);
 
             cmd->_path = subPath.asUTF8();

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -306,7 +306,7 @@ public:
 
 // Move a sublayer into another layer.
 // @param path The layer's path to move.
-// @param newParentLayer The new parent layer's path 
+// @param newParentLayer The new parent layer's path
 // @param newIndex The index where the moved layer will be in the new parent.
 class MoveSubPath : public BaseCmd
 {

--- a/lib/usd/ui/layerEditor/abstractCommandHook.h
+++ b/lib/usd/ui/layerEditor/abstractCommandHook.h
@@ -63,7 +63,9 @@ public:
     virtual void replaceSubLayerPath(UsdLayer usdLayer, Path oldPath, Path newPath) = 0;
 
     // move a path at a given index inside the same layer or another layer.
-    virtual void moveSubLayerPath(Path path, UsdLayer oldParentUsdLayer, UsdLayer newParentUsdLayer, int index) = 0;
+    virtual void
+    moveSubLayerPath(Path path, UsdLayer oldParentUsdLayer, UsdLayer newParentUsdLayer, int index)
+        = 0;
 
     // discard edit on a layer
     virtual void discardEdits(UsdLayer usdLayer) = 0;

--- a/lib/usd/ui/layerEditor/abstractCommandHook.h
+++ b/lib/usd/ui/layerEditor/abstractCommandHook.h
@@ -62,6 +62,9 @@ public:
     // replaces a path in the layer stack
     virtual void replaceSubLayerPath(UsdLayer usdLayer, Path oldPath, Path newPath) = 0;
 
+    // move a path at a given index inside the same layer or another layer.
+    virtual void moveSubLayerPath(Path path, UsdLayer oldParentUsdLayer, UsdLayer newParentUsdLayer, int index) = 0;
+
     // discard edit on a layer
     virtual void discardEdits(UsdLayer usdLayer) = 0;
 

--- a/lib/usd/ui/layerEditor/layerTreeModel.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeModel.cpp
@@ -177,14 +177,14 @@ bool LayerTreeModel::dropMimeData(
                 auto oldParent = layerItem->parentLayerItem()->layer();
                 int  index = (int)oldParent->GetSubLayerPaths().Find(layerItem->subLayerPath());
                 auto itemSubLayerPath = layerItem->subLayerPath();
-                context.hook()->removeSubLayerPath(oldParent, itemSubLayerPath);
+
                 // When we are moving an item (underneath the same parent)
                 // to a new location higher up we have to adjust the row
                 // (new location) to account for the remove we just did.
                 if (oldParent == parentItem->layer() && (index < row)) {
                     row -= 1;
                 }
-                context.hook()->insertSubLayerPath(parentItem->layer(), itemSubLayerPath, row);
+                context.hook()->moveSubLayerPath(itemSubLayerPath, oldParent, parentItem->layer(), row);
             }
         }
     }

--- a/lib/usd/ui/layerEditor/layerTreeModel.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeModel.cpp
@@ -184,7 +184,8 @@ bool LayerTreeModel::dropMimeData(
                 if (oldParent == parentItem->layer() && (index < row)) {
                     row -= 1;
                 }
-                context.hook()->moveSubLayerPath(itemSubLayerPath, oldParent, parentItem->layer(), row);
+                context.hook()->moveSubLayerPath(
+                    itemSubLayerPath, oldParent, parentItem->layer(), row);
             }
         }
     }

--- a/lib/usd/ui/layerEditor/mayaCommandHook.cpp
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.cpp
@@ -108,6 +108,17 @@ void MayaCommandHook::removeSubLayerPath(UsdLayer usdLayer, Path path)
     executeMel(cmd);
 }
 
+void MayaCommandHook::moveSubLayerPath(Path path, UsdLayer oldParentUsdLayer, UsdLayer newParentUsdLayer, int index)
+{
+    std::string cmd;
+    cmd = "mayaUsdLayerEditor -edit -moveSubPath ";
+    cmd += quote(path);
+    cmd += quote(newParentUsdLayer->GetIdentifier());
+    cmd += std::to_string(index);
+    cmd += quote(oldParentUsdLayer->GetIdentifier());
+    executeMel(cmd);
+}
+
 // replaces a path in the layer stack
 void MayaCommandHook::replaceSubLayerPath(UsdLayer usdLayer, Path oldPath, Path newPath)
 {

--- a/lib/usd/ui/layerEditor/mayaCommandHook.cpp
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.cpp
@@ -108,7 +108,11 @@ void MayaCommandHook::removeSubLayerPath(UsdLayer usdLayer, Path path)
     executeMel(cmd);
 }
 
-void MayaCommandHook::moveSubLayerPath(Path path, UsdLayer oldParentUsdLayer, UsdLayer newParentUsdLayer, int index)
+void MayaCommandHook::moveSubLayerPath(
+    Path     path,
+    UsdLayer oldParentUsdLayer,
+    UsdLayer newParentUsdLayer,
+    int      index)
 {
     std::string cmd;
     cmd = "mayaUsdLayerEditor -edit -moveSubPath ";

--- a/lib/usd/ui/layerEditor/mayaCommandHook.h
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.h
@@ -44,6 +44,9 @@ public:
     // replaces a path in the layer stack
     void replaceSubLayerPath(UsdLayer usdLayer, Path oldPath, Path newPath) override;
 
+    // move a path at a given index inside the same layer or another layer.
+    void moveSubLayerPath(Path path, UsdLayer oldParentUsdLayer, UsdLayer newParentUsdLayer, int index) override;
+
     // discard edit on a layer
     void discardEdits(UsdLayer usdLayer) override;
 

--- a/lib/usd/ui/layerEditor/mayaCommandHook.h
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.h
@@ -45,7 +45,9 @@ public:
     void replaceSubLayerPath(UsdLayer usdLayer, Path oldPath, Path newPath) override;
 
     // move a path at a given index inside the same layer or another layer.
-    void moveSubLayerPath(Path path, UsdLayer oldParentUsdLayer, UsdLayer newParentUsdLayer, int index) override;
+    void
+    moveSubLayerPath(Path path, UsdLayer oldParentUsdLayer, UsdLayer newParentUsdLayer, int index)
+        override;
 
     // discard edit on a layer
     void discardEdits(UsdLayer usdLayer) override;

--- a/test/lib/testMayaUsdLayerEditorCommands.py
+++ b/test/lib/testMayaUsdLayerEditorCommands.py
@@ -379,7 +379,7 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
             self.assertEqual(newParentLayer.subLayerPaths, originalSubLayerPaths)
 
         def moveElement(list, item, index):
-            l = list.copy()
+            l = list[:] #copy the list
             l.remove(item)
             l.insert(index, item)
             return l

--- a/test/lib/testMayaUsdLayerEditorCommands.py
+++ b/test/lib/testMayaUsdLayerEditorCommands.py
@@ -362,6 +362,100 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
         cmds.undo()
         self.assertEqual(path.normcase(stage.GetEditTarget().GetLayer().identifier), sharedLayer)
 
+    def testMoveSubPath(self):
+        """ test 'mayaUsdLayerEditor' command 'moveSubPath' paramater """
+
+        def moveSubPath(parentLayer, subPath, newParentLayer, index, originalSubLayerPaths, newSubLayerPaths):
+            cmds.mayaUsdLayerEditor(parentLayer.identifier, edit=True, moveSubPath=[subPath, newParentLayer.identifier, index])
+            self.assertEqual(newParentLayer.subLayerPaths, newSubLayerPaths)
+
+            cmds.undo()
+            self.assertEqual(newParentLayer.subLayerPaths, originalSubLayerPaths)
+
+            cmds.redo()
+            self.assertEqual(newParentLayer.subLayerPaths, newSubLayerPaths)
+
+            cmds.undo()
+            self.assertEqual(newParentLayer.subLayerPaths, originalSubLayerPaths)
+
+        def moveElement(list, item, index):
+            l = list.copy()
+            l.remove(item)
+            l.insert(index, item)
+            return l
+
+        shapePath, stage = getCleanMayaStage()
+        rootLayer = stage.GetRootLayer()
+
+        layerId1 = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="MyLayer1")[0]
+        layerId2 = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="MyLayer2")[0]
+        layerId3 = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="MyLayer3")[0]
+
+        originalSubLayerPaths = [layerId3, layerId2, layerId1]
+        self.assertEqual(rootLayer.subLayerPaths, originalSubLayerPaths)
+
+        # Test moving each layers under the root layer to any valid index in the root layer
+        # and test out-of-bound index
+        for layer in originalSubLayerPaths:
+            for i in range(len(originalSubLayerPaths)):
+                expectedSubPath = moveElement(originalSubLayerPaths, layer, i)
+                moveSubPath(rootLayer, layer, rootLayer, i, originalSubLayerPaths, expectedSubPath)
+
+                with self.assertRaises(RuntimeError):
+                    cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, moveSubPath=[layer, rootLayer.identifier, len(originalSubLayerPaths)])
+                self.assertEqual(rootLayer.subLayerPaths, originalSubLayerPaths)
+
+        #
+        # Test moving sublayer (layer2 and layer3) inside a new parent layer (layer1)
+        #
+
+        layer1 = Sdf.Layer.Find(layerId1)     
+        self.assertTrue(len(layer1.subLayerPaths) == 0)
+
+        # layer1 has no subLayer so index 1 is invalide
+        with self.assertRaises(RuntimeError):
+            cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, moveSubPath=[layerId3, layerId1, 1])
+        self.assertTrue(len(layer1.subLayerPaths) == 0)
+        self.assertEqual(rootLayer.subLayerPaths, originalSubLayerPaths)
+
+        # Move layer3 from the root layer inside layer1 at index 0
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, moveSubPath=[layerId3, layerId1, 0])
+        self.assertEqual(rootLayer.subLayerPaths, [layerId2, layerId1])
+        self.assertEqual(layer1.subLayerPaths, [layerId3])
+
+        # Move layer2 from the root layer inside layer1 at index 0
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, moveSubPath=[layerId2, layerId1, 0])
+        self.assertEqual(rootLayer.subLayerPaths, [layerId1])
+        self.assertEqual(layer1.subLayerPaths, [layerId2, layerId3])
+
+        cmds.undo()
+        self.assertEqual(rootLayer.subLayerPaths, [layerId2, layerId1])
+        self.assertEqual(layer1.subLayerPaths, [layerId3])
+
+        # Move layer2 from the root layer inside layer1 at index 1
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, moveSubPath=[layerId2, layerId1, 1])
+        self.assertEqual(rootLayer.subLayerPaths, [layerId1])
+        self.assertEqual(layer1.subLayerPaths, [layerId3, layerId2])
+
+        cmds.undo()
+        self.assertEqual(rootLayer.subLayerPaths, [layerId2, layerId1])
+        self.assertEqual(layer1.subLayerPaths, [layerId3])
+
+        # Undo moving layer3 inside layer1
+        cmds.undo()
+        self.assertEqual(rootLayer.subLayerPaths, [layerId3, layerId2, layerId1])
+        self.assertEqual(layer1.subLayerPaths, [])
+
+        # Insert layer3 inside layer1 and try to move the layer3 from the root layer
+        # inside layer1. This should fail.
+        cmds.mayaUsdLayerEditor(layerId1, edit=True, insertSubPath=[0, layerId3])
+        self.assertEqual(layer1.subLayerPaths, [layerId3])
+
+        with self.assertRaises(RuntimeError):
+            cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, moveSubPath=[layerId3, layerId1, 0])
+        self.assertEqual(rootLayer.subLayerPaths, originalSubLayerPaths)
+        self.assertEqual(layer1.subLayerPaths, [layerId3])
+
     def testMuteLayer(self):
         """ test 'mayaUsdLayerEditor' command 'muteLayer' paramater """
 


### PR DESCRIPTION
…tTarget moves to the root layer

Add a new flag (moveSubPath) to the mayaUsdLayerEditor command

When drag and drop a layer, we are currently doing 2 steps.
We are first removing the layer from it's current parent and after we are adding the layer to it's new parent.
If the layer we are moving is the edit target, the layer become not the edit target anymore because the command
for removing a layer will reset the edit target.

So to fix this issue I added a new flag to the  mayaUsdLayerEditor command to move layer into another layer.
I feel this solution it's better instead of doing tricky stuff to keep the edit target unmodified. 