### PR TITLE
MAYA-111835: Fix grouping a prim twice that crashed Maya.

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoCreateGroupCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoCreateGroupCommand.cpp
@@ -22,11 +22,9 @@
 #include <pxr/usd/usd/modelAPI.h>
 #include <pxr/usd/usd/prim.h>
 
-#include <maya/MGlobal.h>
 #include <ufe/globalSelection.h>
 #include <ufe/hierarchy.h>
 #include <ufe/observableSelection.h>
-#include <ufe/pathString.h>
 #include <ufe/scene.h>
 #include <ufe/sceneNotification.h>
 
@@ -92,13 +90,9 @@ void UsdUndoCreateGroupCommand::execute()
 
     // Make sure to add the newly created _group (a.k.a parent) to selection. This matches native
     // Maya behavior and also prevents the crash on grouping a prim twice.
-    auto noWorld = _group->path().popHead();
-    auto fullPath = noWorld.getSegments().front().string() + Ufe::PathString::pathSegmentSeparator()
-        + noWorld.getSegments().back().string();
-
-    MString groupPath(fullPath.c_str());
-    MStatus status = MGlobal::executeCommand(MString("select -r \"") + groupPath + "\" ");
-    CHECK_MSTATUS(status);
+    Ufe::Selection groupSelect;
+    groupSelect.append(_group);
+    Ufe::GlobalSelection::get()->replaceWith(groupSelect);
 
     TF_VERIFY(
         Ufe::GlobalSelection::get()->size() == 1,

--- a/lib/mayaUsd/ufe/UsdUndoCreateGroupCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoCreateGroupCommand.cpp
@@ -97,7 +97,8 @@ void UsdUndoCreateGroupCommand::execute()
         + noWorld.getSegments().back().string();
 
     MString groupPath(fullPath.c_str());
-    MGlobal::executeCommand(MString("select -r \"") + groupPath + "\" ");
+    MStatus status = MGlobal::executeCommand(MString("select -r \"") + groupPath + "\" ");
+    CHECK_MSTATUS(status);
 
     TF_VERIFY(
         Ufe::GlobalSelection::get()->size() == 1,

--- a/test/lib/ufe/testGroupCmd.py
+++ b/test/lib/ufe/testGroupCmd.py
@@ -109,6 +109,12 @@ class GroupCmdTestCase(unittest.TestCase):
             ufeSelectionList, newGroupName)
         groupCmd.execute()
 
+        # Group object (a.k.a parent) will be added to selection list. This behavior matches the native Maya group command.
+        globalSelection = ufe.GlobalSelection.get()
+
+        groupPath = ufe.Path([mayaPathSegment, usdUtils.createUfePathSegment("/Ball_set/Props/newGroup1")])
+        self.assertEqual(globalSelection.front(), ufe.Hierarchy.createItem(groupPath))
+
         parentChildrenPost = parentHierarchy.children()
         self.assertEqual(len(parentChildrenPost), 5)
 
@@ -130,6 +136,9 @@ class GroupCmdTestCase(unittest.TestCase):
 
         groupCmd.undo()
 
+        # gloabl selection should not be empty after undo.
+        self.assertEqual(len(globalSelection), 1)
+
         parentChildrenUndo = parentHierarchy.children()
         self.assertEqual(len(parentChildrenUndo), 6)
 
@@ -139,6 +148,9 @@ class GroupCmdTestCase(unittest.TestCase):
         self.assertTrue(ball3Path in childPathsUndo)
 
         groupCmd.redo()
+
+        # global selection should still have the group path.
+        self.assertEqual(globalSelection.front(), ufe.Hierarchy.createItem(groupPath))
 
         parentChildrenRedo = parentHierarchy.children()
         self.assertEqual(len(parentChildrenRedo), 5)


### PR DESCRIPTION
This PR fixes the grouping crash and also makes sure that the group node ( a.k.a parent ) is selected which should match Maya's native behavior. 

https://user-images.githubusercontent.com/48299423/120524018-92cea080-c3a4-11eb-8ffa-08e2b3263e03.mp4

