### PR TITLE
Fix AE template invalid char

### DIFF
--- a/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
@@ -137,7 +137,7 @@ class MetaDataCustomControl(object):
         self.active = cmds.checkBoxGrp(label='Active',
                                        ncb=1,
                                        cc1=self._onActiveChanged,
-                                       ann='If selected, the prim is set to active and contributes to the composition of a stage. If a prim is set to inactive, it doesn’t contribute to the composition of a stage (it gets striked out in the Outliner and is deactivated from the Viewport).')
+                                       ann="If selected, the prim is set to active and contributes to the composition of a stage. If a prim is set to inactive, it doesn't contribute to the composition of a stage (it gets striked out in the Outliner and is deactivated from the Viewport).")
 
         # Metadata: Instanceable
         self.instan = cmds.checkBoxGrp(label='Instanceable',


### PR DESCRIPTION
Python 2 strings are ascii by default, whereas Python 2 strings as are unicode by default. This string had a unicode char (for apostrophe) that I replaced with the ascii one.