### PR TITLE
MAYA-111943: Add support for ungroup command.

### DIFF
--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -66,6 +66,13 @@ if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
     )
 endif()
 
+if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
+    target_sources(${PROJECT_NAME}
+        PRIVATE
+            UsdUndoUngroupCommand.cpp
+    )
+endif()
+
 set(HEADERS
     Global.h
     ProxyShapeHandler.h
@@ -127,8 +134,13 @@ if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
         UsdUndoReorderCommand.h
         UsdUndoSetKindCommand.h
         UsdUndoVisibleCommand.h
-        UsdUndoUngroupCommand.h
         XformOpUtils.h
+    )
+endif()
+
+if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
+    list(APPEND HEADERS
+        UsdUndoUngroupCommand.h
     )
 endif()
 

--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -61,6 +61,7 @@ if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
             UsdUndoReorderCommand.cpp
             UsdUndoSetKindCommand.cpp
             UsdUndoVisibleCommand.cpp
+            UsdUndoUngroupCommand.cpp
             XformOpUtils.cpp
     )
 endif()
@@ -126,6 +127,7 @@ if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
         UsdUndoReorderCommand.h
         UsdUndoSetKindCommand.h
         UsdUndoVisibleCommand.h
+        UsdUndoUngroupCommand.h
         XformOpUtils.h
     )
 endif()

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
@@ -248,12 +248,6 @@ ProxyShapeHierarchy::reorderCmd(const Ufe::SceneItemList& orderedList) const
     return UsdUndoReorderCommand::create(getUsdRootPrim(), orderedTokens);
 }
 
-Ufe::UndoableCommand::Ptr ProxyShapeHierarchy::ungroupCmd() const
-{
-    // pseudo root can not be ungrouped.
-    return nullptr;
-}
-
 Ufe::SceneItem::Ptr ProxyShapeHierarchy::defaultParent() const
 {
     // Maya shape nodes cannot be unparented.
@@ -261,6 +255,14 @@ Ufe::SceneItem::Ptr ProxyShapeHierarchy::defaultParent() const
 }
 
 #endif // UFE_V2_FEATURES_AVAILABLE
+
+#ifdef UFE_V3_FEATURES_AVAILABLE
+Ufe::UndoableCommand::Ptr ProxyShapeHierarchy::ungroupCmd() const
+{
+    // pseudo root can not be ungrouped.
+    return nullptr;
+}
+#endif // UFE_V3_FEATURES_AVAILABLE
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
@@ -32,7 +32,6 @@
 #include <mayaUsd/ufe/UsdUndoCreateGroupCommand.h>
 #include <mayaUsd/ufe/UsdUndoInsertChildCommand.h>
 #include <mayaUsd/ufe/UsdUndoReorderCommand.h>
-#include <mayaUsd/ufe/UsdUndoUngroupCommand.h>
 #endif
 
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -251,9 +250,8 @@ ProxyShapeHierarchy::reorderCmd(const Ufe::SceneItemList& orderedList) const
 
 Ufe::UndoableCommand::Ptr ProxyShapeHierarchy::ungroupCmd() const
 {
-    auto usdItem = UsdSceneItem::create(sceneItem()->path(), getUsdRootPrim());
-
-    return UsdUndoUngroupCommand::create(usdItem);
+    // pseudo root can not be ungrouped.
+    return nullptr;
 }
 
 Ufe::SceneItem::Ptr ProxyShapeHierarchy::defaultParent() const

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
@@ -32,6 +32,7 @@
 #include <mayaUsd/ufe/UsdUndoCreateGroupCommand.h>
 #include <mayaUsd/ufe/UsdUndoInsertChildCommand.h>
 #include <mayaUsd/ufe/UsdUndoReorderCommand.h>
+#include <mayaUsd/ufe/UsdUndoUngroupCommand.h>
 #endif
 
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -246,6 +247,13 @@ ProxyShapeHierarchy::reorderCmd(const Ufe::SceneItemList& orderedList) const
 
     // create a reorder command and pass in the parent and its ordered children list
     return UsdUndoReorderCommand::create(getUsdRootPrim(), orderedTokens);
+}
+
+Ufe::UndoableCommand::Ptr ProxyShapeHierarchy::ungroupCmd() const
+{
+    auto usdItem = UsdSceneItem::create(sceneItem()->path(), getUsdRootPrim());
+
+    return UsdUndoUngroupCommand::create(usdItem);
 }
 
 Ufe::SceneItem::Ptr ProxyShapeHierarchy::defaultParent() const

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
@@ -77,6 +77,8 @@ public:
     insertChildCmd(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
 
     Ufe::UndoableCommand::Ptr reorderCmd(const Ufe::SceneItemList& orderedList) const override;
+
+    Ufe::UndoableCommand::Ptr ungroupCmd() const override;
 #endif
 
 private:

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
@@ -77,7 +77,9 @@ public:
     insertChildCmd(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
 
     Ufe::UndoableCommand::Ptr reorderCmd(const Ufe::SceneItemList& orderedList) const override;
+#endif
 
+#ifdef UFE_V3_FEATURES_AVAILABLE
     Ufe::UndoableCommand::Ptr ungroupCmd() const override;
 #endif
 

--- a/lib/mayaUsd/ufe/UsdHierarchy.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchy.cpp
@@ -42,8 +42,10 @@
 #include <mayaUsd/ufe/UsdUndoCreateGroupCommand.h>
 #include <mayaUsd/ufe/UsdUndoInsertChildCommand.h>
 #include <mayaUsd/ufe/UsdUndoReorderCommand.h>
-#include <mayaUsd/ufe/UsdUndoUnGroupCommand.h>
+#endif
 
+#ifdef UFE_V3_FEATURES_AVAILABLE
+#include <mayaUsd/ufe/UsdUndoUnGroupCommand.h>
 #endif
 
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -262,13 +264,14 @@ Ufe::UndoableCommand::Ptr UsdHierarchy::reorderCmd(const Ufe::SceneItemList& ord
     // create a reorder command and pass in the parent and its reordered children list
     return UsdUndoReorderCommand::create(downcast(sceneItem())->prim(), orderedTokens);
 }
+#endif // UFE_V2_FEATURES_AVAILABLE
 
+#ifdef UFE_V3_FEATURES_AVAILABLE
 Ufe::UndoableCommand::Ptr UsdHierarchy::ungroupCmd() const
 {
     return UsdUndoUngroupCommand::create(fItem);
 }
-
-#endif // UFE_V2_FEATURES_AVAILABLE
+#endif // UFE_V3_FEATURES_AVAILABLE
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdHierarchy.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchy.cpp
@@ -42,6 +42,8 @@
 #include <mayaUsd/ufe/UsdUndoCreateGroupCommand.h>
 #include <mayaUsd/ufe/UsdUndoInsertChildCommand.h>
 #include <mayaUsd/ufe/UsdUndoReorderCommand.h>
+#include <mayaUsd/ufe/UsdUndoUnGroupCommand.h>
+
 #endif
 
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -259,6 +261,11 @@ Ufe::UndoableCommand::Ptr UsdHierarchy::reorderCmd(const Ufe::SceneItemList& ord
 
     // create a reorder command and pass in the parent and its reordered children list
     return UsdUndoReorderCommand::create(downcast(sceneItem())->prim(), orderedTokens);
+}
+
+Ufe::UndoableCommand::Ptr UsdHierarchy::ungroupCmd() const
+{
+    return UsdUndoUngroupCommand::create(fItem);
 }
 
 #endif // UFE_V2_FEATURES_AVAILABLE

--- a/lib/mayaUsd/ufe/UsdHierarchy.h
+++ b/lib/mayaUsd/ufe/UsdHierarchy.h
@@ -83,6 +83,8 @@ public:
     insertChildCmd(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
 
     Ufe::UndoableCommand::Ptr reorderCmd(const Ufe::SceneItemList& orderedList) const override;
+
+    Ufe::UndoableCommand::Ptr ungroupCmd() const override;
 #endif
 
 private:

--- a/lib/mayaUsd/ufe/UsdHierarchy.h
+++ b/lib/mayaUsd/ufe/UsdHierarchy.h
@@ -83,7 +83,9 @@ public:
     insertChildCmd(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
 
     Ufe::UndoableCommand::Ptr reorderCmd(const Ufe::SceneItemList& orderedList) const override;
+#endif
 
+#ifdef UFE_V3_FEATURES_AVAILABLE
     Ufe::UndoableCommand::Ptr ungroupCmd() const override;
 #endif
 

--- a/lib/mayaUsd/ufe/UsdUndoUngroupCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoUngroupCommand.cpp
@@ -1,0 +1,128 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "UsdUndoUngroupCommand.h"
+
+#include "private/UfeNotifGuard.h"
+
+#include <mayaUsd/ufe/Utils.h>
+#include <mayaUsd/undo/UsdUndoBlock.h>
+#include <mayaUsdUtils/util.h>
+
+#include <pxr/usd/usd/editContext.h>
+
+#include <ufe/globalSelection.h>
+#include <ufe/hierarchy.h>
+#include <ufe/observableSelection.h>
+#include <ufe/scene.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+UsdUndoUngroupCommand::UsdUndoUngroupCommand(const UsdSceneItem::Ptr& groupItem)
+    : Ufe::UndoableCommand()
+    , _groupItem(groupItem)
+    , _compositeInsertCmd(std::make_shared<Ufe::CompositeUndoableCommand>())
+{
+}
+
+UsdUndoUngroupCommand::~UsdUndoUngroupCommand() { }
+
+UsdUndoUngroupCommand::Ptr UsdUndoUngroupCommand::create(const UsdSceneItem::Ptr& groupItem)
+{
+    return std::make_shared<UsdUndoUngroupCommand>(groupItem);
+}
+
+void UsdUndoUngroupCommand::execute()
+{
+    // "Ungrouping" means moving group's children up a level in hierarchy
+    // followed by group node getting removed.
+
+    // move group's children one level up
+    auto groupHier = Ufe::Hierarchy::hierarchy(_groupItem);
+    auto levelUpHier = Ufe::Hierarchy::hierarchy(groupHier->parent());
+    for (auto& child : groupHier->children()) {
+        auto insertChildCmd = levelUpHier->appendChildCmd(child);
+        _compositeInsertCmd->append(insertChildCmd);
+    }
+
+    _compositeInsertCmd->execute();
+
+    // remove group prim
+    auto status = removePrimGroup();
+    TF_VERIFY(status, "Removing group node failed!");
+}
+
+void UsdUndoUngroupCommand::undo()
+{
+    MayaUsd::ufe::InAddOrDeleteOperation ad;
+
+    _undoableItem.undo();
+
+    // After undo, the group prim loses it's specifier and type.
+    // At this point _groupItem->prim() is stale and should not be used.
+    // Create a new prim from ufe path and manually set the SetSpecifier and SetTypeName
+    // to get back the original concrete xfrom prim.
+    auto prim = ufePathToPrim(_groupItem->path());
+    TF_AXIOM(prim);
+
+    auto primSpec = MayaUsdUtils::getPrimSpecAtEditTarget(prim);
+    TF_AXIOM(primSpec);
+
+    primSpec->SetSpecifier(SdfSpecifierDef);
+    primSpec->SetTypeName("Xform");
+
+    // create a new group scene item
+    _groupItem = UsdSceneItem::create(_groupItem->path(), prim);
+    TF_AXIOM(_groupItem);
+
+    // undo the inserted children
+    _compositeInsertCmd->undo();
+
+    // Make sure to add the newly created _group (a.k.a parent) to selection. This matches native
+    // Maya behavior and also prevents the crash on grouping a prim twice.
+    Ufe::Selection groupSelect;
+    groupSelect.append(_groupItem);
+    Ufe::GlobalSelection::get()->replaceWith(groupSelect);
+
+    TF_VERIFY(
+        Ufe::GlobalSelection::get()->size() == 1,
+        "_group node should be in the global selection now. \n");
+}
+
+void UsdUndoUngroupCommand::redo()
+{
+    // redo the inserted children first
+    _compositeInsertCmd->redo();
+
+    // remove group prim
+    auto status = removePrimGroup();
+    TF_VERIFY(status, "Removing group node failed!");
+}
+
+bool UsdUndoUngroupCommand::removePrimGroup()
+{
+    MayaUsd::ufe::InAddOrDeleteOperation ad;
+    UsdUndoBlock                         undoBlock(&_undoableItem);
+
+    auto           stage = _groupItem->prim().GetStage();
+    UsdEditContext ctx(stage, stage->GetEditTarget().GetLayer());
+    return stage->RemovePrim(_groupItem->prim().GetPath());
+}
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdUndoUngroupCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoUngroupCommand.cpp
@@ -21,6 +21,7 @@
 #include <mayaUsd/undo/UsdUndoBlock.h>
 #include <mayaUsdUtils/util.h>
 
+#include <pxr/usd/sdf/changeBlock.h>
 #include <pxr/usd/usd/editContext.h>
 
 #include <ufe/globalSelection.h>
@@ -85,11 +86,15 @@ void UsdUndoUngroupCommand::undo()
     auto prim = ufePathToPrim(_groupItem->path());
     TF_AXIOM(prim);
 
-    auto primSpec = MayaUsdUtils::getPrimSpecAtEditTarget(prim);
-    TF_AXIOM(primSpec);
+    {
+        SdfChangeBlock changeBlock;
 
-    primSpec->SetSpecifier(SdfSpecifierDef);
-    primSpec->SetTypeName("Xform");
+        auto primSpec = MayaUsdUtils::getPrimSpecAtEditTarget(prim);
+        TF_AXIOM(primSpec);
+
+        primSpec->SetSpecifier(SdfSpecifierDef);
+        primSpec->SetTypeName("Xform");
+    }
 
     // create a new group scene item
     _groupItem = UsdSceneItem::create(_groupItem->path(), prim);

--- a/lib/mayaUsd/ufe/UsdUndoUngroupCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoUngroupCommand.cpp
@@ -47,7 +47,6 @@ void UsdUndoUngroupCommand::execute()
 
     // Handling insertion (a.k.a move ) is best to be done on Maya side to cover
     // all possible flags ( absolute, relative, world, parent ).
-    // For now, the prim removal must still happen in the plugin side. HS, June17, 2021
 
     // remove group prim
     MayaUsd::ufe::InAddOrDeleteOperation ad;

--- a/lib/mayaUsd/ufe/UsdUndoUngroupCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoUngroupCommand.cpp
@@ -81,23 +81,15 @@ void UsdUndoUngroupCommand::undo()
 
     // After undo, the group prim loses it's specifier and type.
     // At this point _groupItem->prim() is stale and should not be used.
-    // Create a new prim from ufe path and manually set the SetSpecifier and SetTypeName
-    // to get back the original concrete xfrom prim.
-    auto prim = ufePathToPrim(_groupItem->path());
-    TF_AXIOM(prim);
+    // Define a new prim from ufe path to get back the original concrete xfrom prim.
+    auto stage = getStage(_groupItem->path());
+    TF_AXIOM(stage);
 
-    {
-        SdfChangeBlock changeBlock;
-
-        auto primSpec = MayaUsdUtils::getPrimSpecAtEditTarget(prim);
-        TF_AXIOM(primSpec);
-
-        primSpec->SetSpecifier(SdfSpecifierDef);
-        primSpec->SetTypeName("Xform");
-    }
+    auto groupUsdPath = getPath(_groupItem->path());
+    auto groupPrim = stage->DefinePrim(groupUsdPath, TfToken("Xform"));
 
     // create a new group scene item
-    _groupItem = UsdSceneItem::create(_groupItem->path(), prim);
+    _groupItem = UsdSceneItem::create(_groupItem->path(), groupPrim);
     TF_AXIOM(_groupItem);
 
     // undo the inserted children

--- a/lib/mayaUsd/ufe/UsdUndoUngroupCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoUngroupCommand.cpp
@@ -22,11 +22,6 @@
 
 #include <pxr/usd/usd/editContext.h>
 
-#include <ufe/globalSelection.h>
-#include <ufe/hierarchy.h>
-#include <ufe/observableSelection.h>
-#include <ufe/scene.h>
-
 PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace MAYAUSD_NS_DEF {
@@ -71,7 +66,12 @@ void UsdUndoUngroupCommand::undo()
     _undoableItem.undo();
 }
 
-void UsdUndoUngroupCommand::redo() { _undoableItem.redo(); }
+void UsdUndoUngroupCommand::redo()
+{
+    MayaUsd::ufe::InAddOrDeleteOperation ad;
+
+    _undoableItem.redo();
+}
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdUndoUngroupCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoUngroupCommand.cpp
@@ -79,31 +79,7 @@ void UsdUndoUngroupCommand::undo()
 
     _undoableItem.undo();
 
-    // After undo, the group prim loses it's specifier and type.
-    // At this point _groupItem->prim() is stale and should not be used.
-    // Define a new prim from ufe path to get back the original concrete xfrom prim.
-    auto stage = getStage(_groupItem->path());
-    TF_AXIOM(stage);
-
-    auto groupUsdPath = getPath(_groupItem->path());
-    auto groupPrim = stage->DefinePrim(groupUsdPath, TfToken("Xform"));
-
-    // create a new group scene item
-    _groupItem = UsdSceneItem::create(_groupItem->path(), groupPrim);
-    TF_AXIOM(_groupItem);
-
-    // undo the inserted children
     _compositeInsertCmd->undo();
-
-    // Make sure to add the newly created _group (a.k.a parent) to selection. This matches native
-    // Maya behavior and also prevents the crash on grouping a prim twice.
-    Ufe::Selection groupSelect;
-    groupSelect.append(_groupItem);
-    Ufe::GlobalSelection::get()->replaceWith(groupSelect);
-
-    TF_VERIFY(
-        Ufe::GlobalSelection::get()->size() == 1,
-        "_group node should be in the global selection now. \n");
 }
 
 void UsdUndoUngroupCommand::redo()

--- a/lib/mayaUsd/ufe/UsdUndoUngroupCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoUngroupCommand.cpp
@@ -63,8 +63,13 @@ void UsdUndoUngroupCommand::execute()
     _compositeInsertCmd->execute();
 
     // remove group prim
-    auto status = removePrimGroup();
-    TF_VERIFY(status, "Removing group node failed!");
+    MayaUsd::ufe::InAddOrDeleteOperation ad;
+    UsdUndoBlock                         undoBlock(&_undoableItem);
+
+    auto           stage = _groupItem->prim().GetStage();
+    UsdEditContext ctx(stage, stage->GetEditTarget().GetLayer());
+    auto           retVal = stage->RemovePrim(_groupItem->prim().GetPath());
+    TF_VERIFY(retVal, "Failed to remove '%s'", _groupItem->prim().GetPath().GetText());
 }
 
 void UsdUndoUngroupCommand::undo()
@@ -109,16 +114,6 @@ void UsdUndoUngroupCommand::redo()
     _compositeInsertCmd->redo();
 
     _undoableItem.redo();
-}
-
-bool UsdUndoUngroupCommand::removePrimGroup()
-{
-    MayaUsd::ufe::InAddOrDeleteOperation ad;
-    UsdUndoBlock                         undoBlock(&_undoableItem);
-
-    auto           stage = _groupItem->prim().GetStage();
-    UsdEditContext ctx(stage, stage->GetEditTarget().GetLayer());
-    return stage->RemovePrim(_groupItem->prim().GetPath());
 }
 
 } // namespace ufe

--- a/lib/mayaUsd/ufe/UsdUndoUngroupCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoUngroupCommand.cpp
@@ -106,12 +106,9 @@ void UsdUndoUngroupCommand::undo()
 
 void UsdUndoUngroupCommand::redo()
 {
-    // redo the inserted children first
     _compositeInsertCmd->redo();
 
-    // remove group prim
-    auto status = removePrimGroup();
-    TF_VERIFY(status, "Removing group node failed!");
+    _undoableItem.redo();
 }
 
 bool UsdUndoUngroupCommand::removePrimGroup()

--- a/lib/mayaUsd/ufe/UsdUndoUngroupCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoUngroupCommand.h
@@ -28,8 +28,7 @@ namespace ufe {
 class MAYAUSD_CORE_PUBLIC UsdUndoUngroupCommand : public Ufe::UndoableCommand
 {
 public:
-    typedef std::shared_ptr<UsdUndoUngroupCommand>         Ptr;
-    typedef std::shared_ptr<Ufe::CompositeUndoableCommand> CompositeCmd;
+    using Ptr = std::shared_ptr<UsdUndoUngroupCommand>;
 
     UsdUndoUngroupCommand(const UsdSceneItem::Ptr& groupItem);
     ~UsdUndoUngroupCommand() override;
@@ -50,8 +49,6 @@ private:
 
 private:
     UsdSceneItem::Ptr _groupItem;
-
-    CompositeCmd _compositeInsertCmd;
 
     UsdUndoableItem _undoableItem;
 

--- a/lib/mayaUsd/ufe/UsdUndoUngroupCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoUngroupCommand.h
@@ -48,8 +48,6 @@ private:
     void undo() override;
     void redo() override;
 
-    bool removePrimGroup();
-
 private:
     UsdSceneItem::Ptr _groupItem;
 

--- a/lib/mayaUsd/ufe/UsdUndoUngroupCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoUngroupCommand.h
@@ -1,0 +1,63 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <mayaUsd/base/api.h>
+#include <mayaUsd/ufe/UsdSceneItem.h>
+#include <mayaUsd/undo/UsdUndoableItem.h>
+
+#include <ufe/undoableCommand.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+//! \brief UsdUndoUngroupCommand
+class MAYAUSD_CORE_PUBLIC UsdUndoUngroupCommand : public Ufe::UndoableCommand
+{
+public:
+    typedef std::shared_ptr<UsdUndoUngroupCommand>         Ptr;
+    typedef std::shared_ptr<Ufe::CompositeUndoableCommand> CompositeCmd;
+
+    UsdUndoUngroupCommand(const UsdSceneItem::Ptr& groupItem);
+    ~UsdUndoUngroupCommand() override;
+
+    // Delete the copy/move constructors assignment operators.
+    UsdUndoUngroupCommand(const UsdUndoUngroupCommand&) = delete;
+    UsdUndoUngroupCommand& operator=(const UsdUndoUngroupCommand&) = delete;
+    UsdUndoUngroupCommand(UsdUndoUngroupCommand&&) = delete;
+    UsdUndoUngroupCommand& operator=(UsdUndoUngroupCommand&&) = delete;
+
+    //! Create a UsdUndoUngroupCommand.
+    static UsdUndoUngroupCommand::Ptr create(const UsdSceneItem::Ptr& groupItem);
+
+private:
+    void execute() override;
+    void undo() override;
+    void redo() override;
+
+    bool removePrimGroup();
+
+private:
+    UsdSceneItem::Ptr _groupItem;
+
+    CompositeCmd _compositeInsertCmd;
+
+    UsdUndoableItem _undoableItem;
+
+}; // UsdUndoUngroupCommand
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -135,6 +135,11 @@ UsdStageWeakPtr getStage(const Ufe::Path& path) { return g_StageMap.stage(path);
 
 Ufe::Path stagePath(UsdStageWeakPtr stage) { return g_StageMap.path(stage); }
 
+PXR_NS::SdfPath getPath(const Ufe::Path& path)
+{
+    return SdfPath(path.getSegments().back().string());
+}
+
 TfHashSet<UsdStageWeakPtr, TfHash> getAllStages() { return g_StageMap.allStages(); }
 
 Ufe::PathSegment usdPathToUfePathSegment(const SdfPath& usdPath, int instanceIndex)

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -135,11 +135,6 @@ UsdStageWeakPtr getStage(const Ufe::Path& path) { return g_StageMap.stage(path);
 
 Ufe::Path stagePath(UsdStageWeakPtr stage) { return g_StageMap.path(stage); }
 
-PXR_NS::SdfPath getPath(const Ufe::Path& path)
-{
-    return SdfPath(path.getSegments().back().string());
-}
-
 TfHashSet<UsdStageWeakPtr, TfHash> getAllStages() { return g_StageMap.allStages(); }
 
 Ufe::PathSegment usdPathToUfePathSegment(const SdfPath& usdPath, int instanceIndex)

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -50,13 +50,17 @@ namespace ufe {
 // Helper functions
 //------------------------------------------------------------------------------
 
-//! Get USD stage corresponding to argument Maya Dag path.
+//! Get USD stage corresponding to argument UFE path.
 MAYAUSD_CORE_PUBLIC
 PXR_NS::UsdStageWeakPtr getStage(const Ufe::Path& path);
 
 //! Return the ProxyShape node UFE path for the argument stage.
 MAYAUSD_CORE_PUBLIC
 Ufe::Path stagePath(PXR_NS::UsdStageWeakPtr stage);
+
+//! Get USD path corresponding to argument UFE path.
+MAYAUSD_CORE_PUBLIC
+PXR_NS::SdfPath getPath(const Ufe::Path& path);
 
 //! Return all the USD stages.
 MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -58,10 +58,6 @@ PXR_NS::UsdStageWeakPtr getStage(const Ufe::Path& path);
 MAYAUSD_CORE_PUBLIC
 Ufe::Path stagePath(PXR_NS::UsdStageWeakPtr stage);
 
-//! Get USD path corresponding to argument UFE path.
-MAYAUSD_CORE_PUBLIC
-PXR_NS::SdfPath getPath(const Ufe::Path& path);
-
 //! Return all the USD stages.
 MAYAUSD_CORE_PUBLIC
 PXR_NS::TfHashSet<PXR_NS::UsdStageWeakPtr, PXR_NS::TfHash> getAllStages();

--- a/lib/mayaUsd/undo/UsdUndoStateDelegate.cpp
+++ b/lib/mayaUsd/undo/UsdUndoStateDelegate.cpp
@@ -380,10 +380,7 @@ void UsdUndoStateDelegate::_OnDeleteSpec(const SdfPath& path, bool inert)
 
     // traverse the hierarchy and call copySpecAtPath on each spec
     auto layerDataPtr = std::cref(*get_pointer(_GetLayerData()));
-    TF_AXIOM(layerDataPtr);
-
     auto deleteDataPtr = get_pointer(deletedData);
-    TF_AXIOM(deleteDataPtr);
 
     _GetLayer()->Traverse(
         path, [&](const SdfPath& path) { copySpecAtPath(layerDataPtr, deleteDataPtr, path); });

--- a/lib/mayaUsd/undo/UsdUndoStateDelegate.cpp
+++ b/lib/mayaUsd/undo/UsdUndoStateDelegate.cpp
@@ -38,7 +38,7 @@ void copySpecAtPath(const SdfAbstractData& src, SdfAbstractData* dst, const SdfP
     }
 }
 
-// This class is used to copy specs from source SdfAbstractData contrainer
+// This class is used to copy specs from source SdfAbstractData container
 // to the destination SdfAbstractData container.
 class SpecCopier : public SdfAbstractDataSpecVisitor
 {

--- a/test/lib/ufe/CMakeLists.txt
+++ b/test/lib/ufe/CMakeLists.txt
@@ -40,6 +40,11 @@ if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
         testTransform3dTranslate.py
         testUIInfoHandler.py
         testObservableScene.py
+    )
+endif()
+
+if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
+    list(APPEND TEST_SCRIPT_FILES
         testUngroupCmd.py
     )
 endif()

--- a/test/lib/ufe/CMakeLists.txt
+++ b/test/lib/ufe/CMakeLists.txt
@@ -40,6 +40,7 @@ if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
         testTransform3dTranslate.py
         testUIInfoHandler.py
         testObservableScene.py
+        testUngroupCmd.py
     )
 endif()
 

--- a/test/lib/ufe/testUngroupCmd.py
+++ b/test/lib/ufe/testUngroupCmd.py
@@ -57,15 +57,15 @@ class SphereGenerator():
     def createSphere(self):
         return next(self.gen)
 
-    def __addPrimSphere(self, incrment):
+    def __addPrimSphere(self, increment):
         self.contextOp.doOp(['Add New Prim', 'Sphere'])
-        return ufe.PathString.path('{},/Sphere{}'.format(self.proxyShapePathStr, incrment))
+        return ufe.PathString.path('{},/Sphere{}'.format(self.proxyShapePathStr, increment))
 
     def __generate(self, num):
-        incrment = 0
-        while incrment < self.num:
-            incrment += 1
-            yield self.__addPrimSphere(incrment)
+        increment = 0
+        while increment < self.num:
+            increment += 1
+            yield self.__addPrimSphere(increment)
 
 def joinPathSegments(ufePath):
     return ','.join([str(segment) for segment in ufePath.segments])
@@ -120,7 +120,7 @@ class UngroupCmdTestCase(unittest.TestCase):
         # verify selected item is "group1"
         self.assertEqual(len(self.globalSn), 1)
         groupItem = self.globalSn.front()
-        self.assertEqual(str(groupItem.path().back()), "group1")
+        self.assertEqual(groupItem.nodeName(), "group1")
 
         # verify that groupItem has 2 children
         groupHierarchy = ufe.Hierarchy.hierarchy(groupItem)
@@ -142,7 +142,7 @@ class UngroupCmdTestCase(unittest.TestCase):
 
         # verify group1 is selected
         self.assertEqual(len(self.globalSn), 1)
-        self.assertEqual(str(self.globalSn.front().path().back()), "group1")
+        self.assertEqual(self.globalSn.front().nodeName(), "group1")
 
         # redo
         cmds.redo()
@@ -173,17 +173,17 @@ class UngroupCmdTestCase(unittest.TestCase):
         # create group2
         cmds.group(joinPathSegments(sphere2Path))
 
-        assert ([x for x in self.stage.Traverse()] == 
+        self.assertEqual([x for x in self.stage.Traverse()],
             [self.stage.GetPrimAtPath("/group1"),
             self.stage.GetPrimAtPath("/group1/Sphere1"), 
             self.stage.GetPrimAtPath("/group2"),
-            self.stage.GetPrimAtPath("/group2/Sphere2"),])
+            self.stage.GetPrimAtPath("/group2/Sphere2")])
 
         # ungroup
         cmds.ungroup("{},/group1".format(self.proxyShapePathStr), 
                      "{},/group2".format(self.proxyShapePathStr))
 
-        assert ([x for x in self.stage.Traverse()] == 
+        self.assertEqual([x for x in self.stage.Traverse()],
             [self.stage.GetPrimAtPath("/Sphere1"), 
             self.stage.GetPrimAtPath("/Sphere2")])
 
@@ -213,7 +213,7 @@ class UngroupCmdTestCase(unittest.TestCase):
         # verify selected item is "group1"
         self.assertEqual(len(self.globalSn), 1)
         groupItem = self.globalSn.front()
-        self.assertEqual(str(groupItem.path().back()), "group1")
+        self.assertEqual(groupItem.nodeName(), "group1")
 
         # remove group1 from the hierarchy. What should remain
         # is /Sphere1, /Sphere2.
@@ -253,7 +253,7 @@ class UngroupCmdTestCase(unittest.TestCase):
         # verify selected item is "group1"
         self.assertEqual(len(self.globalSn), 1)
         groupItem = self.globalSn.front()
-        self.assertEqual(str(groupItem.path().back()), "group1")
+        self.assertEqual(groupItem.nodeName(), "group1")
 
         # remove group1 from the hierarchy. What should remain
         # is /Sphere1, /Sphere2.
@@ -285,7 +285,7 @@ class UngroupCmdTestCase(unittest.TestCase):
                    joinPathSegments(pathList[3]))
 
         # verify the paths after grouping
-        assert ([x for x in self.stage.Traverse()] == 
+        self.assertEqual([x for x in self.stage.Traverse()], 
             [self.stage.GetPrimAtPath("/Sphere1"),
             self.stage.GetPrimAtPath("/group1"),
             self.stage.GetPrimAtPath("/group1/Sphere2"),
@@ -298,7 +298,7 @@ class UngroupCmdTestCase(unittest.TestCase):
                    "{},/group1/Sphere4".format(self.proxyShapePathStr))
 
         # verify the paths after second grouping
-        assert ([x for x in self.stage.Traverse()] == 
+        self.assertEqual([x for x in self.stage.Traverse()],
             [self.stage.GetPrimAtPath("/Sphere1"),
             self.stage.GetPrimAtPath("/group1"),
             self.stage.GetPrimAtPath("/group1/group1"),
@@ -310,7 +310,7 @@ class UngroupCmdTestCase(unittest.TestCase):
         cmds.ungroup("{},/group1/group1".format(self.proxyShapePathStr), world=True)
 
         # verify the paths after ungroup
-        assert ([x for x in self.stage.Traverse()] == 
+        self.assertEqual([x for x in self.stage.Traverse()],
             [self.stage.GetPrimAtPath("/Sphere1"),
             self.stage.GetPrimAtPath("/group1"),
             self.stage.GetPrimAtPath("/Sphere2"),
@@ -385,7 +385,7 @@ class UngroupCmdTestCase(unittest.TestCase):
         # verify selected item is "group1"
         self.assertEqual(len(self.globalSn), 1)
         groupItem = self.globalSn.front()
-        self.assertEqual(str(groupItem.path().back()), "group1")
+        self.assertEqual(groupItem.nodeName(), "group1")
 
         # remove group1 from the hierarchy. What should remain
         # is /Sphere1, /Sphere2.
@@ -400,7 +400,7 @@ class UngroupCmdTestCase(unittest.TestCase):
         # verify that group1 is in global selection list
         self.assertEqual(len(self.globalSn), 1)
         groupItem = self.globalSn.front()
-        self.assertEqual(str(groupItem.path().back()), "group1")
+        self.assertEqual(groupItem.nodeName(), "group1")
 
         # Hmmm, looks like we have a bug here. HS, June 21, 2021
         # verify that group hierarchy has 2 children

--- a/test/lib/ufe/testUngroupCmd.py
+++ b/test/lib/ufe/testUngroupCmd.py
@@ -61,73 +61,37 @@ class UngroupCmdTestCase(unittest.TestCase):
         # Clear selection to start off
         cmds.select(clear=True)
 
-    def testUngroupCommand(self):
-        '''Simple test for ungroup command.'''
+    def testUngroupUndoRedo(self):
+        '''Verify multiple undo/redo.'''
+        pass
 
-        mayaPathSegment = mayaUtils.createUfePathSegment(
-            "|transform1|proxyShape1")
+    def testUngroupMultipleGroupItems(self):
+        '''Verify ungrouping of multiple group nodes.'''
+        pass
 
-        usdSegmentBall5 = usdUtils.createUfePathSegment(
-            "/Ball_set/Props/Ball_5")
-        ball5Path = ufe.Path([mayaPathSegment, usdSegmentBall5])
-        ball5Item = ufe.Hierarchy.createItem(ball5Path)
+    def testUngroupAbsolute(self):
+        '''Verify -absolute flag.'''
+        pass
 
-        usdSegmentBall3 = usdUtils.createUfePathSegment(
-            "/Ball_set/Props/Ball_3")
-        ball3Path = ufe.Path([mayaPathSegment, usdSegmentBall3])
-        ball3Item = ufe.Hierarchy.createItem(ball3Path)
+    def testUngroupRelative(self):
+        '''Verify -relative flag.'''
+        pass
 
-        usdSegmentProps = usdUtils.createUfePathSegment("/Ball_set/Props")
-        parentPath = ufe.Path([mayaPathSegment, usdSegmentProps])
-        parentItem = ufe.Hierarchy.createItem(parentPath)
+    def testUngroupWorld(self):
+        '''Verify -world flag.'''
+        pass
 
-        parentHierarchy = ufe.Hierarchy.hierarchy(parentItem)
-        parentChildrenPre = parentHierarchy.children()
-        self.assertEqual(len(parentChildrenPre), 6)
+    def testUngroupParent(self):
+        '''Verify -parent flag.'''
+        pass
 
-        newGroupName = ufe.PathComponent("newGroup")
+    def testUngroupProxyShape(self):
+        '''Verify ungrouping of the proxyShape.'''
+        pass
 
-        # get the USD stage
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
-
-        # set the edit target to balls.usda
-        layer = stage.GetLayerStack()[1]
-        self.assertEqual("ballset.usda", layer.GetDisplayName())
-        stage.SetEditTarget(layer)
-
-        ufeSelectionList = ufe.Selection()
-        ufeSelectionList.append(ball5Item)
-        ufeSelectionList.append(ball3Item)
-
-        groupCmd = parentHierarchy.createGroupCmd(
-            ufeSelectionList, newGroupName)
-        groupCmd.execute()
-
-        # Group object (a.k.a parent) will be added to selection list. This behavior matches the native Maya group command.
-        globalSelection = ufe.GlobalSelection.get()
-
-        groupPath = ufe.Path([mayaPathSegment, usdUtils.createUfePathSegment("/Ball_set/Props/newGroup1")])
-        self.assertEqual(globalSelection.front(), ufe.Hierarchy.createItem(groupPath))
-
-        # check parentHierarchy children size
-        self.assertEqual(len(parentHierarchy.children()), 5)
-
-        # ungroup
-        groupHierarchy = ufe.Hierarchy.hierarchy(globalSelection.front())
-        ungroupCmd = groupHierarchy.ungroupCmd()
-        ungroupCmd.execute()
-
-        # check parentHierarchy children size
-        self.assertEqual(len(parentHierarchy.children()), 6)
-
-        ungroupCmd.undo()
-
-        # check parentHierarchy children size
-        self.assertEqual(len(parentHierarchy.children()), 5)
-
-        ungroupCmd.redo()
-
-        self.assertEqual(len(parentHierarchy.children()), 6)
+    def testUngroupLeaf(self):
+        '''Verify ungrouping of a leaf node.'''
+        pass
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/ufe/testUngroupCmd.py
+++ b/test/lib/ufe/testUngroupCmd.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2021 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import fixturesUtils
+import mayaUtils
+import testUtils
+import ufeUtils
+import usdUtils
+
+import mayaUsd.ufe
+
+from pxr import Kind
+from pxr import Usd
+
+from maya import cmds
+from maya import standalone
+
+import ufe
+
+import os
+import unittest
+
+class UngroupCmdTestCase(unittest.TestCase):
+
+    pluginsLoaded = False
+
+    @classmethod
+    def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
+        if not cls.pluginsLoaded:
+            cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def setUp(self):
+        ''' Called initially to set up the Maya test environment '''
+        # Load plugins
+        self.assertTrue(self.pluginsLoaded)
+
+        # Open ballset.ma scene in testSamples
+        mayaUtils.openGroupBallsScene()
+
+        # Clear selection to start off
+        cmds.select(clear=True)
+
+    def testUngroupCommand(self):
+        '''Simple test for ungroup command.'''
+
+        mayaPathSegment = mayaUtils.createUfePathSegment(
+            "|transform1|proxyShape1")
+
+        usdSegmentBall5 = usdUtils.createUfePathSegment(
+            "/Ball_set/Props/Ball_5")
+        ball5Path = ufe.Path([mayaPathSegment, usdSegmentBall5])
+        ball5Item = ufe.Hierarchy.createItem(ball5Path)
+
+        usdSegmentBall3 = usdUtils.createUfePathSegment(
+            "/Ball_set/Props/Ball_3")
+        ball3Path = ufe.Path([mayaPathSegment, usdSegmentBall3])
+        ball3Item = ufe.Hierarchy.createItem(ball3Path)
+
+        usdSegmentProps = usdUtils.createUfePathSegment("/Ball_set/Props")
+        parentPath = ufe.Path([mayaPathSegment, usdSegmentProps])
+        parentItem = ufe.Hierarchy.createItem(parentPath)
+
+        parentHierarchy = ufe.Hierarchy.hierarchy(parentItem)
+        parentChildrenPre = parentHierarchy.children()
+        self.assertEqual(len(parentChildrenPre), 6)
+
+        newGroupName = ufe.PathComponent("newGroup")
+
+        # get the USD stage
+        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+
+        # set the edit target to balls.usda
+        layer = stage.GetLayerStack()[1]
+        self.assertEqual("ballset.usda", layer.GetDisplayName())
+        stage.SetEditTarget(layer)
+
+        ufeSelectionList = ufe.Selection()
+        ufeSelectionList.append(ball5Item)
+        ufeSelectionList.append(ball3Item)
+
+        groupCmd = parentHierarchy.createGroupCmd(
+            ufeSelectionList, newGroupName)
+        groupCmd.execute()
+
+        # Group object (a.k.a parent) will be added to selection list. This behavior matches the native Maya group command.
+        globalSelection = ufe.GlobalSelection.get()
+
+        groupPath = ufe.Path([mayaPathSegment, usdUtils.createUfePathSegment("/Ball_set/Props/newGroup1")])
+        self.assertEqual(globalSelection.front(), ufe.Hierarchy.createItem(groupPath))
+
+        # check parentHierarchy children size
+        self.assertEqual(len(parentHierarchy.children()), 5)
+
+        # ungroup
+        groupHierarchy = ufe.Hierarchy.hierarchy(globalSelection.front())
+        ungroupCmd = groupHierarchy.ungroupCmd()
+        ungroupCmd.execute()
+
+        # check parentHierarchy children size
+        self.assertEqual(len(parentHierarchy.children()), 6)
+
+        ungroupCmd.undo()
+
+        # check parentHierarchy children size
+        self.assertEqual(len(parentHierarchy.children()), 5)
+
+        ungroupCmd.redo()
+
+        self.assertEqual(len(parentHierarchy.children()), 6)
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testUngroupCmd.py
+++ b/test/lib/ufe/testUngroupCmd.py
@@ -67,9 +67,6 @@ class SphereGenerator():
             increment += 1
             yield self.__addPrimSphere(increment)
 
-def joinPathSegments(ufePath):
-    return ','.join([str(segment) for segment in ufePath.segments])
-
 def createTransform3d(ufeScenePath):
     return ufe.Transform3d.transform3d(ufe.Hierarchy.createItem(ufeScenePath))
 
@@ -114,8 +111,8 @@ class UngroupCmdTestCase(unittest.TestCase):
         sphere2Path = sphereGen.createSphere()
 
         # create a group
-        cmds.group(joinPathSegments(sphere1Path), 
-                   joinPathSegments(sphere2Path))
+        cmds.group(ufe.PathString.string(sphere1Path), 
+                   ufe.PathString.string(sphere2Path))
 
         # verify selected item is "group1"
         self.assertEqual(len(self.globalSn), 1)
@@ -168,10 +165,10 @@ class UngroupCmdTestCase(unittest.TestCase):
         sphere2Path = sphereGen.createSphere()
 
         # create group1
-        cmds.group(joinPathSegments(sphere1Path))
+        cmds.group(ufe.PathString.string(sphere1Path))
 
         # create group2
-        cmds.group(joinPathSegments(sphere2Path))
+        cmds.group(ufe.PathString.string(sphere2Path))
 
         self.assertEqual([x for x in self.stage.Traverse()],
             [self.stage.GetPrimAtPath("/group1"),
@@ -204,8 +201,8 @@ class UngroupCmdTestCase(unittest.TestCase):
         sphere2T3d.translate(-2.0, 0.0, 0.0)
 
         # create a group
-        cmds.group(joinPathSegments(sphere1Path), 
-                   joinPathSegments(sphere2Path))
+        cmds.group(ufe.PathString.string(sphere1Path), 
+                   ufe.PathString.string(sphere2Path))
 
         # move the group 
         cmds.move(7.0, 8.0, 12.0, r=True)
@@ -244,8 +241,8 @@ class UngroupCmdTestCase(unittest.TestCase):
         sphere2T3d.translate(-2.0, 0.0, 0.0)
 
         # create a group
-        cmds.group(joinPathSegments(sphere1Path), 
-                   joinPathSegments(sphere2Path))
+        cmds.group(ufe.PathString.string(sphere1Path), 
+                   ufe.PathString.string(sphere2Path))
 
         # move the group 
         cmds.move(20.0, 8.0, 12.0, r=True)
@@ -280,9 +277,9 @@ class UngroupCmdTestCase(unittest.TestCase):
             pathList.append(sphereGen.createSphere())
 
         # group /Sphere2, /Sphere3, /Sphere4
-        cmds.group(joinPathSegments(pathList[1]),
-                   joinPathSegments(pathList[2]),
-                   joinPathSegments(pathList[3]))
+        cmds.group(ufe.PathString.string(pathList[1]),
+                   ufe.PathString.string(pathList[2]),
+                   ufe.PathString.string(pathList[3]))
 
         # verify the paths after grouping
         self.assertEqual([x for x in self.stage.Traverse()], 
@@ -367,7 +364,7 @@ class UngroupCmdTestCase(unittest.TestCase):
         # expect the exception happens
         with self.assertRaises(RuntimeError):
             # ungroup
-            cmds.ungroup(joinPathSegments(sphere1Path))
+            cmds.ungroup(ufe.PathString.string(sphere1Path))
 
     def testUngroupAfterUndoRedo(self):
         ''' '''
@@ -379,8 +376,8 @@ class UngroupCmdTestCase(unittest.TestCase):
         sphere2Path = sphereGen.createSphere()
 
         # create a group
-        cmds.group(joinPathSegments(sphere1Path), 
-                   joinPathSegments(sphere2Path))
+        cmds.group(ufe.PathString.string(sphere1Path), 
+                   ufe.PathString.string(sphere2Path))
 
         # verify selected item is "group1"
         self.assertEqual(len(self.globalSn), 1)


### PR DESCRIPTION
![Ungroup_Command](https://user-images.githubusercontent.com/48299423/121081697-1294aa80-c7ab-11eb-8899-2a4009eed51e.gif)

This PR adds support for ungroup command.  See ungroup page:

https://download.autodesk.com/us/maya/2009help/Commands/ungroup.html

Known Issues:
- parent flag is not currently implemented. This shouldn't be a blocker since one can use the existing parent command. I will add this flag later if it is really requested. 

- Children are not selected after ungrouping.  **MAYA-112126**

- There is a bug in our selection where hierarchy item created from group item falsely report that children don't exist. See `testUngroupAfterUndoRedo` case in `testUngroup.py`  **MAYA-112510**



