### PR TITLE
Fixed bug with visibility determination

### DIFF
--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -627,7 +627,8 @@ bool UsdMayaUtil::isRenderable(const MObject& object)
     }
 
     const MDAGDrawOverrideInfo drawOverrideInfo = dagPath.getDrawOverrideInfo();
-    if (drawOverrideInfo.fOverrideEnabled && drawOverrideInfo.fDisplayType == MDAGDrawOverrideInfo::kDisplayTypeTemplate) {
+    if (drawOverrideInfo.fOverrideEnabled
+        && drawOverrideInfo.fDisplayType == MDAGDrawOverrideInfo::kDisplayTypeTemplate) {
         return false;
     }
 

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -619,6 +619,18 @@ bool UsdMayaUtil::isRenderable(const MObject& object)
         }
     }
 
+    MDagPath dagPath;
+    stat = mFn.getPath(dagPath);
+    CHECK_MSTATUS_AND_RETURN(stat, false);
+    if (!dagPath.isVisible()) {
+        return false;
+    }
+
+    const MDAGDrawOverrideInfo drawOverrideInfo = dagPath.getDrawOverrideInfo();
+    if (drawOverrideInfo.fOverrideEnabled && drawOverrideInfo.fDisplayType == MDAGDrawOverrideInfo::kDisplayTypeTemplate) {
+        return false;
+    }
+
     // this shape is renderable
     return true;
 }


### PR DESCRIPTION
Hi all:

This small PR fixes an issue where if you have the Draw Overrides option enabled on a DAG node set to template instead of using the one in the Display rollout, the utility function in Maya-USD would report it to be renderable instead of not. This was causing issues for us internally in our own internal chaser plugins when determining visibility state.

Please review and raise any concerns.