### PR TITLE
-root/-rt flag (limit export USD parents level - empty string means all selected are roots)

### DIFF
--- a/lib/mayaUsd/commands/baseExportCommand.cpp
+++ b/lib/mayaUsd/commands/baseExportCommand.cpp
@@ -324,6 +324,15 @@ MStatus MayaUSDExportCommand::doIt(const MArgList& args)
                 MGlobal::displayError("Invalid root path: " + tmpArgList.asString(0));
                 return MS::kFailure;
             }
+            // TODO: pass the selection list to rootNames in the scope below, but make sure to remove
+            //       whats under a root from the roots list
+//            if (tmpArgList.asString(0) == "") {
+//                for (const MDagPath& thisDagPath : dagPaths) {
+//                    jobArgs.rootNames.emplace_back(thisDagPath.fullPathName().asChar());
+//                }
+//            } else {
+//                jobArgs.rootNames.emplace_back(this_root);
+//            }
             jobArgs.rootNames.emplace_back(this_root);
         }
 

--- a/lib/mayaUsd/commands/baseExportCommand.cpp
+++ b/lib/mayaUsd/commands/baseExportCommand.cpp
@@ -318,15 +318,13 @@ MStatus MayaUSDExportCommand::doIt(const MArgList& args)
             MArgList tmpArgList;
             argData.getFlagArgumentList(kRootFlag, i, tmpArgList);
             std::string this_root = tmpArgList.asString(0).asChar();
-            if (!this_root.empty()) {
-                MDagPath dagPath;
-                UsdMayaUtil::GetDagPathByName(this_root, dagPath);
-                if (!dagPath.isValid() and tmpArgList.asString(0) != "|") {
-                    MGlobal::displayError("Invalid root path: " + tmpArgList.asString(0));
-                    return MS::kFailure;
-                }
-                jobArgs.rootNames.emplace_back(this_root);
+            MDagPath dagPath;
+            UsdMayaUtil::GetDagPathByName(this_root, dagPath);
+            if (!dagPath.isValid() && tmpArgList.asString(0) != "|" && tmpArgList.asString(0) != "") {
+                MGlobal::displayError("Invalid root path: " + tmpArgList.asString(0));
+                return MS::kFailure;
             }
+            jobArgs.rootNames.emplace_back(this_root);
         }
 
         unsigned int numFilteredTypes = argData.numberOfFlagUses(kFilterTypesFlag);

--- a/lib/mayaUsd/commands/baseExportCommand.cpp
+++ b/lib/mayaUsd/commands/baseExportCommand.cpp
@@ -180,6 +180,9 @@ MSyntax MayaUSDExportCommand::createSyntax()
     syntax.addFlag(kFileFlag, kFileFlagLong, MSyntax::kString);
     syntax.addFlag(kSelectionFlag, kSelectionFlagLong, MSyntax::kNoArg);
 
+    syntax.addFlag(kRootFlag, kkRootFlagLong, MSyntax::kString);
+    syntax.makeFlagMultiUse(kRootFlag);
+
     syntax.addFlag(kFilterTypesFlag, kFilterTypesFlagLong, MSyntax::kString);
     syntax.makeFlagMultiUse(kFilterTypesFlag);
 
@@ -309,6 +312,22 @@ MStatus MayaUSDExportCommand::doIt(const MArgList& args)
             = UsdMayaWriteUtil::GetTimeSamples(timeInterval, frameSamples, frameStride);
         UsdMayaJobExportArgs jobArgs
             = UsdMayaJobExportArgs::CreateFromDictionary(userArgs, dagPaths, timeSamples);
+
+        unsigned int numRoots = argData.numberOfFlagUses(kRootFlag);
+        for (unsigned int i = 0; i < numRoots; i++) {
+            MArgList tmpArgList;
+            argData.getFlagArgumentList(kRootFlag, i, tmpArgList);
+            std::string this_root = tmpArgList.asString(0).asChar();
+            if (!this_root.empty()) {
+                MDagPath dagPath;
+                UsdMayaUtil::GetDagPathByName(this_root, dagPath);
+                if (!dagPath.isValid() and tmpArgList.asString(0) != "|") {
+                    MGlobal::displayError("Invalid root path: " + tmpArgList.asString(0));
+                    return MS::kFailure;
+                }
+                jobArgs.rootNames.emplace_back(this_root);
+            }
+        }
 
         unsigned int numFilteredTypes = argData.numberOfFlagUses(kFilterTypesFlag);
         for (unsigned int i = 0; i < numFilteredTypes; i++) {

--- a/lib/mayaUsd/commands/baseExportCommand.h
+++ b/lib/mayaUsd/commands/baseExportCommand.h
@@ -83,6 +83,8 @@ public:
     // Short and Long forms of flags defined by this command itself:
     static constexpr auto kAppendFlag = "a";
     static constexpr auto kAppendFlagLong = "append";
+    static constexpr auto kRootFlag = "rt";
+    static constexpr auto kkRootFlagLong = "root";
     static constexpr auto kFilterTypesFlag = "ft";
     static constexpr auto kFilterTypesFlagLong = "filterTypes";
     static constexpr auto kFileFlag = "f";

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -206,6 +206,9 @@ struct UsdMayaJobExportArgs
     /// data should be exported.
     const std::vector<double> timeSamples;
 
+    // given root names to to start exporting from (passed by the -root/-rt multi-flag)
+    std::vector<std::string> rootNames;
+
     // This path is provided when dealing with variants
     // where a _BaseModel_ root path is used instead of
     // the model path. This to allow a proper internal reference.

--- a/lib/mayaUsd/fileio/jobs/writeJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/writeJob.cpp
@@ -311,7 +311,7 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
 
         // ignore any mArgs.dagPath above the given -root(s)
         for (const std::string& rootName : tmpRootNames) {
-            if (rootName != "|" and rootName != "*") {
+            if (rootName != "|" and rootName != "") {
                 UsdMayaUtil::GetDagPathByName(rootName, rootDagPath);
 
                 if (MFnDagNode(rootDagPath).hasParent(curDagPath.node())) {
@@ -365,25 +365,27 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
     // TODO: We want each selected object to be its own parent without passing the whole selection
     // TODO: list to the root arg... So, here are several options:
     // -------------------------------------------------------------------------------------------
-    // Option 1: All selected will work directly as roots, and their parents won't be exported
-    //           because we haven't ask for them
-    if (mJobCtx.mArgs.rootNames.empty() &! argDagPaths.empty()) { // Fixme: need to find out if the sl flag is set (add it to the if statement)
-        // put all selected objects in the rootNames list
-        for (const std::string& dgPathStr : argDagPaths) {
-            mJobCtx.mArgs.rootNames.emplace_back(dgPathStr);
-        }
-    }
-
-//    // Option 2: all selected will be roots if the "*" was passed to the root arg
-//    if (!mJobCtx.mArgs.rootNames.empty() &! argDagPaths.empty()) { // Fixme: need to find out if the sl flag is set (add it to the if statement)
-//        if (mJobCtx.mArgs.rootNames[0] == "*") {
-//            mJobCtx.mArgs.rootNames.clear();
-//            // put all selected objects in the rootNames list
-//            for (const std::string& dgPathStr : argDagPaths) {
-//                mJobCtx.mArgs.rootNames.emplace_back(dgPathStr);
-//            }
+//    // Option 1: All selected will work directly as roots, and their parents won't be exported
+//    //           because we haven't ask for them
+//    if (mJobCtx.mArgs.rootNames.empty() &! argDagPaths.empty()) {
+//        // put all selected objects in the rootNames list
+//        for (const std::string& dgPathStr : argDagPaths) {
+//            mJobCtx.mArgs.rootNames.emplace_back(dgPathStr);
 //        }
 //    }
+    // Option 2: passing '*' instead of empty str
+
+    // Option 3: all selected will be roots if the empty string "" was passed to the root arg
+    if (!mJobCtx.mArgs.rootNames.empty() &! argDagPaths.empty()) {
+        if (mJobCtx.mArgs.rootNames[0].empty()) {
+            mJobCtx.mArgs.rootNames.clear();
+            // put all selected objects in the rootNames list
+            for (const std::string& dgPathStr : argDagPaths) {
+                MGlobal::displayInfo(dgPathStr.c_str());
+                mJobCtx.mArgs.rootNames.emplace_back(dgPathStr);
+            }
+        }
+    }
 
 
     // when no roots are passed, tmpRootNames is {"|"} from above
@@ -396,7 +398,7 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
         MItDag   itDag(MItDag::kDepthFirst, MFn::kInvalid);
         MDagPath curDagPath;
         UsdMayaUtil::GetDagPathByName(rootName, rootDagPath);
-        if (rootName != "|")
+        if (rootName != "|" && rootName != "")
             itDag.reset(rootDagPath, MItDag::kDepthFirst, MFn::kInvalid);
         else
             itDag.reset();

--- a/lib/mayaUsd/fileio/jobs/writeJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/writeJob.cpp
@@ -280,11 +280,21 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
     // arg dagPaths all the way up to the world root. Partial path names are
     // enough because Maya guarantees them to still be unique, and they require
     // less work to hash and compare than full path names.
-    TfHashSet<std::string, TfHash>           argDagPaths;
-    TfHashSet<std::string, TfHash>           argDagPathParents;
+    TfHashSet<std::string, TfHash> argDagPaths;
+    TfHashSet<std::string, TfHash> argDagPathParents;
+    MDagPath                       rootDagPath;
+    MDagPath                       curLeafDagPath;
+
+    std::vector<std::string> tmpRootNames;
+    if (mJobCtx.mArgs.rootNames.empty()) {
+        // in case when no roots are passed, insert the world root "|" as if it's passed to the root arg
+        tmpRootNames.emplace_back("|");
+    } else {
+        tmpRootNames = mJobCtx.mArgs.rootNames;
+    }
+
     UsdMayaUtil::MDagPathSet::const_iterator end = mJobCtx.mArgs.dagPaths.end();
-    for (UsdMayaUtil::MDagPathSet::const_iterator it = mJobCtx.mArgs.dagPaths.begin(); it != end;
-         ++it) {
+    for (UsdMayaUtil::MDagPathSet::const_iterator it = mJobCtx.mArgs.dagPaths.begin(); it != end; ++it) {
         MDagPath curDagPath = *it;
         MStatus  status;
         bool     curDagPathIsValid = curDagPath.isValid(&status);
@@ -296,85 +306,147 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
         if (status != MS::kSuccess) {
             continue;
         }
-
-        argDagPaths.insert(curDagPathStr);
-
-        status = curDagPath.pop();
-        if (status != MS::kSuccess) {
+        if (curDagPathStr.empty())
             continue;
-        }
-        curDagPathIsValid = curDagPath.isValid(&status);
 
-        while (status == MS::kSuccess && curDagPathIsValid) {
-            curDagPathStr = curDagPath.partialPathName(&status).asChar();
-            if (status != MS::kSuccess) {
-                break;
+        // ignore any mArgs.dagPath above the given -root(s)
+        for (const std::string& rootName : tmpRootNames) {
+            if (rootName != "|" and rootName != "*") {
+                UsdMayaUtil::GetDagPathByName(rootName, rootDagPath);
+
+                if (MFnDagNode(rootDagPath).hasParent(curDagPath.node())) {
+                    curLeafDagPath = curDagPath;
+                } else if (!(rootDagPath == curDagPath
+                             || MFnDagNode(curDagPath).hasParent(rootDagPath.node()))) {
+                    continue;
+                }
             }
 
-            if (argDagPathParents.find(curDagPathStr) != argDagPathParents.end()) {
-                // We've already traversed up from this path.
-                break;
-            }
-            argDagPathParents.insert(curDagPathStr);
+            argDagPaths.insert(curDagPathStr);
 
             status = curDagPath.pop();
             if (status != MS::kSuccess) {
-                break;
+                continue;
             }
             curDagPathIsValid = curDagPath.isValid(&status);
+
+            while (status == MS::kSuccess && curDagPathIsValid) {
+                curDagPathStr = curDagPath.partialPathName(&status).asChar();
+                if (status != MS::kSuccess) {
+                    goto ctn;
+                }
+
+                if (argDagPathParents.find(curDagPathStr) != argDagPathParents.end()) {
+                    // We've already traversed up from this path.
+                    goto ctn;
+                }
+
+                // when -root flag is is set, ignore any parents above the given rootName
+                if (!rootName.empty()) {
+                    std::string rootDagFullPathStr = rootDagPath.fullPathName().asChar();
+                    std::string curDagFullPathStr = curDagPath.fullPathName().asChar();
+                    if (curDagFullPathStr.rfind(rootDagFullPathStr, 0) == 0) {
+                        argDagPathParents.insert(curDagPathStr);
+                    }
+                } else {
+                    argDagPathParents.insert(curDagPathStr);
+                }
+
+                status = curDagPath.pop();
+                if (status != MS::kSuccess) {
+                    goto ctn;
+                }
+                curDagPathIsValid = curDagPath.isValid(&status);
+            }
+            ctn:;
         }
     }
 
-    // Now do a depth-first traversal of the Maya DAG from the world root.
-    // We keep a reference to arg dagPaths as we encounter them.
-    MDagPath curLeafDagPath;
-    for (MItDag itDag(MItDag::kDepthFirst, MFn::kInvalid); !itDag.isDone(); itDag.next()) {
-        MDagPath curDagPath;
-        itDag.getPath(curDagPath);
-        std::string curDagPathStr(curDagPath.partialPathName().asChar());
-
-        if (argDagPathParents.find(curDagPathStr) != argDagPathParents.end()) {
-            // This dagPath is a parent of one of the arg dagPaths. It should
-            // be included in the export, but not necessarily all of its
-            // children should be, so we continue to traverse down.
-        } else if (argDagPaths.find(curDagPathStr) != argDagPaths.end()) {
-            // This dagPath IS one of the arg dagPaths. It AND all of its
-            // children should be included in the export.
-            curLeafDagPath = curDagPath;
-        } else if (!MFnDagNode(curDagPath).hasParent(curLeafDagPath.node())) {
-            // This dagPath is not a child of one of the arg dagPaths, so prune
-            // it and everything below it from the traversal.
-            itDag.prune();
-            continue;
+    // TODO: We want each selected object to be its own parent without passing the whole selection
+    // TODO: list to the root arg... So, here are several options:
+    // -------------------------------------------------------------------------------------------
+    // Option 1: All selected will work directly as roots, and their parents won't be exported
+    //           because we haven't ask for them
+    if (mJobCtx.mArgs.rootNames.empty() &! argDagPaths.empty()) { // Fixme: need to find out if the sl flag is set (add it to the if statement)
+        // put all selected objects in the rootNames list
+        for (const std::string& dgPathStr : argDagPaths) {
+            mJobCtx.mArgs.rootNames.emplace_back(dgPathStr);
         }
+    }
 
-        if (!mJobCtx._NeedToTraverse(curDagPath) && curDagPath.length() > 0) {
-            // This dagPath and all of its children should be pruned.
-            itDag.prune();
-        } else {
-            const MFnDagNode           dagNodeFn(curDagPath);
-            UsdMayaPrimWriterSharedPtr primWriter = mJobCtx.CreatePrimWriter(dagNodeFn);
+//    // Option 2: all selected will be roots if the "*" was passed to the root arg
+//    if (!mJobCtx.mArgs.rootNames.empty() &! argDagPaths.empty()) { // Fixme: need to find out if the sl flag is set (add it to the if statement)
+//        if (mJobCtx.mArgs.rootNames[0] == "*") {
+//            mJobCtx.mArgs.rootNames.clear();
+//            // put all selected objects in the rootNames list
+//            for (const std::string& dgPathStr : argDagPaths) {
+//                mJobCtx.mArgs.rootNames.emplace_back(dgPathStr);
+//            }
+//        }
+//    }
 
-            if (primWriter) {
-                mJobCtx.mMayaPrimWriterList.push_back(primWriter);
 
-                // Write out data (non-animated/default values).
-                if (const auto& usdPrim = primWriter->GetUsdPrim()) {
-                    if (!_CheckNameClashes(usdPrim.GetPath(), primWriter->GetDagPath())) {
-                        return false;
+    // when no roots are passed, tmpRootNames is {"|"} from above
+    if (!(mJobCtx.mArgs.rootNames.empty() &! argDagPathParents.empty()))
+        tmpRootNames = mJobCtx.mArgs.rootNames;
+
+    for (std::string& rootName : tmpRootNames) {
+        // Now do a depth-first traversal of the Maya DAG from the world root.
+        // We keep a reference to arg dagPaths as we encounter them.
+        MItDag   itDag(MItDag::kDepthFirst, MFn::kInvalid);
+        MDagPath curDagPath;
+        UsdMayaUtil::GetDagPathByName(rootName, rootDagPath);
+        if (rootName != "|")
+            itDag.reset(rootDagPath, MItDag::kDepthFirst, MFn::kInvalid);
+        else
+            itDag.reset();
+        for (; !itDag.isDone(); itDag.next()) {
+            itDag.getPath(curDagPath);
+            std::string curDagPathStr(curDagPath.partialPathName().asChar());
+
+            if (argDagPathParents.find(curDagPathStr) != argDagPathParents.end()) {
+                // This dagPath is a parent of one of the arg dagPaths. It should
+                // be included in the export, but not necessarily all of its
+                // children should be, so we continue to traverse down.
+            } else if (argDagPaths.find(curDagPathStr) != argDagPaths.end()) {
+                // This dagPath IS one of the arg dagPaths. It AND all of its
+                // children should be included in the export.
+                curLeafDagPath = curDagPath;
+            } else if (!MFnDagNode(curDagPath).hasParent(curLeafDagPath.node())) {
+                // This dagPath is not a child of one of the arg dagPaths, so prune
+                // it and everything below it from the traversal.
+                itDag.prune();
+                continue;
+            }
+
+            if (!mJobCtx._NeedToTraverse(curDagPath) && curDagPath.length() > 0) {
+                // This dagPath and all of its children should be pruned.
+                itDag.prune();
+            } else {
+                const MFnDagNode           dagNodeFn(curDagPath);
+                UsdMayaPrimWriterSharedPtr primWriter = mJobCtx.CreatePrimWriter(dagNodeFn, rootDagPath);
+
+                if (primWriter) {
+                    mJobCtx.mMayaPrimWriterList.push_back(primWriter);
+
+                    // Write out data (non-animated/default values).
+                    if (const auto& usdPrim = primWriter->GetUsdPrim()) {
+                        if (!_CheckNameClashes(usdPrim.GetPath(), primWriter->GetDagPath())) {
+                            return false;
+                        }
+
+                        primWriter->Write(UsdTimeCode::Default());
+
+                        const UsdMayaUtil::MDagPathMap<SdfPath>& mapping
+                            = primWriter->GetDagToUsdPathMapping();
+                        mDagPathToUsdPathMap.insert(mapping.begin(), mapping.end());
+
+                        _modelKindProcessor->OnWritePrim(usdPrim, primWriter);
                     }
 
-                    primWriter->Write(UsdTimeCode::Default());
-
-                    const UsdMayaUtil::MDagPathMap<SdfPath>& mapping
-                        = primWriter->GetDagToUsdPathMapping();
-                    mDagPathToUsdPathMap.insert(mapping.begin(), mapping.end());
-
-                    _modelKindProcessor->OnWritePrim(usdPrim, primWriter);
-                }
-
-                if (primWriter->ShouldPruneChildren()) {
-                    itDag.prune();
+                    if (primWriter->ShouldPruneChildren()) {
+                        itDag.prune();
+                    }
                 }
             }
         }

--- a/lib/mayaUsd/fileio/utils/writeUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/writeUtil.cpp
@@ -15,6 +15,8 @@
 //
 #include "writeUtil.h"
 
+#include "mayaUsd/fileio/writeJobContext.h"
+
 #include <mayaUsd/fileio/translators/translatorUtil.h>
 #include <mayaUsd/fileio/utils/adaptor.h>
 #include <mayaUsd/fileio/utils/userTaggedAttribute.h>
@@ -65,6 +67,8 @@
 #include <maya/MString.h>
 #include <maya/MVector.h>
 #include <maya/MVectorArray.h>
+
+#include <boost/algorithm/string.hpp>
 
 #include <string>
 #include <vector>
@@ -274,8 +278,8 @@ static VtValue _ConvertVec(const T& val, const TfToken& role, const bool lineari
 {
     return VtValue(
         ((role == SdfValueRoleNames->Color) && linearizeColors)
-            ? MayaUsd::utils::ConvertMayaToLinear(val)
-            : val);
+        ? MayaUsd::utils::ConvertMayaToLinear(val)
+        : val);
 }
 
 VtValue UsdMayaWriteUtil::GetVtValue(
@@ -948,13 +952,13 @@ bool UsdMayaWriteUtil::WriteArrayAttrsToInstancer(
 
         VtIntArray vtArray
             = _MapMayaToVtArray<MDoubleArray, double, int>(objectIndex, [numPrototypes](double x) {
-                  if (x < numPrototypes) {
-                      return (int)x;
-                  } else {
-                      // Return the *last* prototype if out of bounds.
-                      return (int)numPrototypes - 1;
-                  }
-              });
+                if (x < numPrototypes) {
+                    return (int)x;
+                } else {
+                    // Return the *last* prototype if out of bounds.
+                    return (int)numPrototypes - 1;
+                }
+            });
         SetAttribute(instancer.CreateProtoIndicesAttr(), vtArray, usdTime, valueWriter);
     } else {
         VtIntArray vtArray;
@@ -984,7 +988,7 @@ bool UsdMayaWriteUtil::WriteArrayAttrsToInstancer(
         VtQuathArray vtArray = _MapMayaToVtArray<MVectorArray, const MVector&, GfQuath>(
             rotation, [](const MVector& v) {
                 GfRotation rot = GfRotation(GfVec3d::XAxis(), v.x)
-                    * GfRotation(GfVec3d::YAxis(), v.y) * GfRotation(GfVec3d::ZAxis(), v.z);
+                                 * GfRotation(GfVec3d::YAxis(), v.y) * GfRotation(GfVec3d::ZAxis(), v.z);
                 return GfQuath(rot.GetQuat());
             });
         SetAttribute(instancer.CreateOrientationsAttr(), vtArray, usdTime, valueWriter);

--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -443,6 +443,7 @@ bool UsdMayaWriteJobContext::_PostProcess()
 
 UsdMayaPrimWriterSharedPtr UsdMayaWriteJobContext::CreatePrimWriter(
     const MFnDependencyNode& depNodeFn,
+    const MDagPath&          rootDagPath,
     const SdfPath&           usdPath,
     const bool               forceUninstance)
 {
@@ -465,6 +466,25 @@ UsdMayaPrimWriterSharedPtr UsdMayaWriteJobContext::CreatePrimWriter(
 
         if (writePath.IsEmpty()) {
             writePath = ConvertDagToUsdPath(dagPath);
+        }
+
+        // Get the relative prim paths in relation to the their argRoot passed via the -root (multi) flag
+        // to bypass writing the parent transforms of the these requested usd roots, that
+        // in case the -root arg was set (so, /any/thing/originalRoot/obj becomes /originalRoot/obj
+        // (assuming the -root "originalRoot" was passed)
+        const MFnDagNode dagFn( rootDagPath.node() );
+        const MObject rootParentObj = dagFn.parent( 0 );
+        MDagPath rootParentPath;
+        MStatus status = MDagPath::getAPathTo(rootParentObj, rootParentPath);
+
+        // Do nothing with the Sdf writePath if -root flag was not given (or the given root is already
+        // the highest root node in the scene)
+        const char* rootPathStr = rootParentPath.fullPathName().asChar();
+        if ((rootParentPath.isValid() && status == MS::kSuccess)
+            &! mArgs.rootNames.empty() && rootPathStr[0] != '\0') {
+            std::string rootParentSdfStr = ConvertDagToUsdPath(rootParentPath).GetString();
+            std::string newWritePath = TfStringReplace(writePath.GetText(), rootParentSdfStr, "");
+            writePath = SdfPath(newWritePath);
         }
 
         const MFnDagNode dagNodeFn(dagPath);
@@ -561,11 +581,14 @@ void UsdMayaWriteJobContext::CreatePrimWriterHierarchy(
 
         const MFnDagNode dagNodeFn(curDagPath);
 
+        // Fixme: temporarily passing an empty dagPath to reuse the same method declaration
+        MDagPath rootDagPath;
+
         // Currently, forceUninstance only applies to the root DAG path but not
         // to descendant nodes (i.e. nested instancing will always occur).
         // Its purpose is to allow us to do the actual write of the master.
         UsdMayaPrimWriterSharedPtr writer = this->CreatePrimWriter(
-            dagNodeFn, curActualUsdPath, curDagPath == rootDag ? forceUninstance : false);
+            dagNodeFn, rootDagPath, curActualUsdPath, curDagPath == rootDag ? forceUninstance : false);
         if (!writer) {
             continue;
         }

--- a/lib/mayaUsd/fileio/writeJobContext.h
+++ b/lib/mayaUsd/fileio/writeJobContext.h
@@ -92,6 +92,7 @@ public:
     MAYAUSD_CORE_PUBLIC
     UsdMayaPrimWriterSharedPtr CreatePrimWriter(
         const MFnDependencyNode& depNodeFn,
+        const MDagPath&          rootDagPath,
         const SdfPath&           usdPath = SdfPath(),
         const bool               forceUninstance = false);
 

--- a/lib/usd/translators/jointWriter.cpp
+++ b/lib/usd/translators/jointWriter.cpp
@@ -265,12 +265,13 @@ bool _GetLocalTransformForDagPoseMember(
         // already exists
         MIntArray allIndices;
         xformMatrixPlug.getExistingArrayAttributeIndices(allIndices);
-        if (std::find(allIndices.cbegin(), allIndices.cend(), logicalIndex) == allIndices.cend()) {
-            TfDebug::Helper().Msg(
-                "Warning - attempting to retrieve %s[%u], but that index did not exist yet",
-                xformMatrixPlug.name().asChar(),
-                logicalIndex);
-        }
+        // Fixme Fails to compile for maya 2019
+//        if (std::find(allIndices.cbegin(), allIndices.cend(), logicalIndex) == allIndices.cend()) {
+//            TfDebug::Helper().Msg(
+//                "Warning - attempting to retrieve %s[%u], but that index did not exist yet",
+//                xformMatrixPlug.name().asChar(),
+//                logicalIndex);
+//        }
     }
 #endif
     MPlug xformPlug = xformMatrixPlug.elementByLogicalIndex(logicalIndex, &status);

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/DgNodeHelper.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/DgNodeHelper.cpp
@@ -4425,8 +4425,8 @@ MStatus DgNodeHelper::addDynamicAttribute(MObject node, const UsdAttribute& usdA
     MObject                attribute = MObject::kNullObj;
     const char*            attrName = usdAttr.GetName().GetString().c_str();
     const uint32_t         flags = (isArray ? AL::maya::utils::NodeHelper::kArray : 0)
-        | AL::maya::utils::NodeHelper::kReadable | AL::maya::utils::NodeHelper::kWritable
-        | AL::maya::utils::NodeHelper::kStorable | AL::maya::utils::NodeHelper::kConnectable;
+                                   | AL::maya::utils::NodeHelper::kReadable | AL::maya::utils::NodeHelper::kWritable
+                                   | AL::maya::utils::NodeHelper::kStorable | AL::maya::utils::NodeHelper::kConnectable;
     switch (dataType) {
     case UsdDataType::kAsset: {
         return MS::kSuccess;

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -36,6 +36,7 @@ set(TEST_SCRIPT_FILES
     testUsdExportRenderLayerMode.py
     ## XXX: This test is disabled by default since it requires the RenderMan for Maya plugin.
     # testUsdExportRfMLight.py
+    testUsdExportRoot.py
     testUsdExportSelection.py
     testUsdExportSelectionHierarchy.py
     testUsdExportShadingInstanced.py

--- a/test/lib/usd/translators/UsdExportRootTest/UsdExportRootTest.ma
+++ b/test/lib/usd/translators/UsdExportRootTest/UsdExportRootTest.ma
@@ -1,0 +1,624 @@
+//Codeset: UTF-8
+requires maya "2019";
+currentUnit -l centimeter -a degree -t film;
+fileInfo "application" "maya";
+fileInfo "product" "Maya 2019";
+fileInfo "version" "2019";
+fileInfo "cutIdentifier" "201907021615-48e59968a3";
+fileInfo "osv" "Linux 3.10.0-957.27.2.el7.x86_64 #1 SMP Mon Jul 29 17:46:05 UTC 2019 x86_64";
+createNode transform -n "Top";
+	rename -uid "D0BBC940-0000-4EBB-5AD5-491C00000255";
+createNode transform -n "Mid_NoTransformation" -p "Top";
+	rename -uid "D0BBC940-0000-4EBB-5AD5-491B00000254";
+createNode transform -n "GrpRoot1" -p "Mid_NoTransformation";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A3600000475";
+	setAttr ".t" -type "double3" -0.16220328977761139 1.5246460781128439 0.76375908293246053 ;
+	setAttr ".r" -type "double3" -21.015249863472487 18.284097963354078 15.545994295870752 ;
+createNode transform -n "pCone1" -p "GrpRoot1";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3AAF00000483";
+	setAttr ".t" -type "double3" 0 1.004676766391192 0 ;
+createNode mesh -n "pCone1Shape" -p "pCone1";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3AAF00000482";
+	setAttr -k off ".v";
+	setAttr ".vir" yes;
+	setAttr ".vif" yes;
+	setAttr ".uvst[0].uvsn" -type "string" "map1";
+	setAttr ".cuvs" -type "string" "map1";
+	setAttr ".dcc" -type "string" "Ambient+Diffuse";
+	setAttr ".covm[0]"  0 1 1;
+	setAttr ".cdvm[0]"  0 1 1;
+createNode transform -n "Cube1" -p "GrpRoot1";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A3200000473";
+	setAttr ".t" -type "double3" 0 2.4658127840445712 0 ;
+createNode mesh -n "Cube1Shape" -p "Cube1";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A3200000474";
+	setAttr -k off ".v";
+	setAttr ".vir" yes;
+	setAttr ".vif" yes;
+	setAttr ".uvst[0].uvsn" -type "string" "map1";
+	setAttr -s 14 ".uvst[0].uvsp[0:13]" -type "float2" 0.375 0 0.625 0 0.375
+		 0.25 0.625 0.25 0.375 0.5 0.625 0.5 0.375 0.75 0.625 0.75 0.375 1 0.625 1 0.875 0
+		 0.875 0.25 0.125 0 0.125 0.25;
+	setAttr ".cuvs" -type "string" "map1";
+	setAttr ".dcc" -type "string" "Ambient+Diffuse";
+	setAttr ".covm[0]"  0 1 1;
+	setAttr ".cdvm[0]"  0 1 1;
+	setAttr -s 8 ".vt[0:7]"  -0.5 -0.5 0.5 0.5 -0.5 0.5 -0.5 0.5 0.5 0.5 0.5 0.5
+		 -0.5 0.5 -0.5 0.5 0.5 -0.5 -0.5 -0.5 -0.5 0.5 -0.5 -0.5;
+	setAttr -s 12 ".ed[0:11]"  0 1 0 2 3 0 4 5 0 6 7 0 0 2 0 1 3 0 2 4 0
+		 3 5 0 4 6 0 5 7 0 6 0 0 7 1 0;
+	setAttr -s 6 -ch 24 ".fc[0:5]" -type "polyFaces" 
+		f 4 0 5 -2 -5
+		mu 0 4 0 1 3 2
+		f 4 1 7 -3 -7
+		mu 0 4 2 3 5 4
+		f 4 2 9 -4 -9
+		mu 0 4 4 5 7 6
+		f 4 3 11 -1 -11
+		mu 0 4 6 7 9 8
+		f 4 -12 -10 -8 -6
+		mu 0 4 1 10 11 3
+		f 4 10 4 6 8
+		mu 0 4 12 0 2 13;
+	setAttr ".cd" -type "dataPolyComponent" Index_Data Edge 0 ;
+	setAttr ".cvd" -type "dataPolyComponent" Index_Data Vertex 0 ;
+	setAttr ".pd[0]" -type "dataPolyComponent" Index_Data UV 0 ;
+	setAttr ".hfd" -type "dataPolyComponent" Index_Data Face 0 ;
+createNode transform -n "Mid_1" -p "Top";
+	rename -uid "BDCE9940-0000-7302-5ADA-416500000268";
+createNode transform -n "Mid_2" -p "Top";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A6D00000476";
+createNode transform -n "Mid_Transformation" -p "Top";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3B1B000004DB";
+	setAttr ".t" -type "double3" -1.5423523531001315 3.4547874484192729 5.2061508595663186 ;
+	setAttr ".r" -type "double3" 68.02679954134075 -37.128693185181142 -55.684678070044654 ;
+createNode transform -n "GrpRoot2" -p "Mid_Transformation";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3B1B000004DC";
+	setAttr ".t" -type "double3" -0.16220328977761139 1.5246460781128439 0.76375908293246053 ;
+	setAttr ".r" -type "double3" -21.015249863472487 18.284097963354078 15.545994295870752 ;
+createNode transform -n "pCone2" -p "GrpRoot2";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3B1B000004DD";
+	setAttr ".t" -type "double3" 2.81022594928932 1.0046767663911917 8.8817841970012523e-16 ;
+	setAttr ".s" -type "double3" 1.36670553772346 1.36670553772346 1.36670553772346 ;
+createNode mesh -n "pCone2Shape" -p "pCone2";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3B1B000004DE";
+	setAttr -k off ".v";
+	setAttr ".vir" yes;
+	setAttr ".vif" yes;
+	setAttr ".uvst[0].uvsn" -type "string" "map1";
+	setAttr -s 42 ".uvst[0].uvsp[0:41]" -type "float2" 0.7377643 0.1727457
+		 0.70225441 0.1030536 0.64694643 0.04774563 0.5772543 0.012235746 0.5 -1.1920929e-07
+		 0.4227457 0.012235761 0.35305363 0.047745675 0.2977457 0.10305364 0.26223582 0.17274573
+		 0.24999994 0.25 0.26223582 0.32725427 0.2977457 0.39694634 0.35305366 0.4522543 0.42274573
+		 0.48776418 0.5 0.5 0.57725424 0.48776415 0.64694631 0.45225427 0.70225424 0.39694631
+		 0.73776412 0.32725424 0.75 0.25 0.25 0.5 0.27500001 0.5 0.30000001 0.5 0.32500002
+		 0.5 0.35000002 0.5 0.37500003 0.5 0.40000004 0.5 0.42500004 0.5 0.45000005 0.5 0.47500005
+		 0.5 0.50000006 0.5 0.52500004 0.5 0.55000001 0.5 0.57499999 0.5 0.59999996 0.5 0.62499994
+		 0.5 0.64999992 0.5 0.67499989 0.5 0.69999987 0.5 0.72499985 0.5 0.74999982 0.5 0.5
+		 1;
+	setAttr ".cuvs" -type "string" "map1";
+	setAttr ".dcc" -type "string" "Ambient+Diffuse";
+	setAttr ".covm[0]"  0 1 1;
+	setAttr ".cdvm[0]"  0 1 1;
+	setAttr -s 21 ".vt[0:20]"  0.95105714 -1 -0.30901718 0.80901754 -1 -0.5877856
+		 0.5877856 -1 -0.80901748 0.30901715 -1 -0.95105702 0 -1 -1.000000476837 -0.30901715 -1 -0.95105696
+		 -0.58778548 -1 -0.8090173 -0.80901724 -1 -0.58778542 -0.95105678 -1 -0.30901706 -1.000000238419 -1 0
+		 -0.95105678 -1 0.30901706 -0.80901718 -1 0.58778536 -0.58778536 -1 0.80901712 -0.30901706 -1 0.95105666
+		 -2.9802322e-08 -1 1.000000119209 0.30901697 -1 0.9510566 0.58778524 -1 0.80901706
+		 0.809017 -1 0.5877853 0.95105654 -1 0.309017 1 -1 0 0 1 0;
+	setAttr -s 40 ".ed[0:39]"  0 1 0 1 2 0 2 3 0 3 4 0 4 5 0 5 6 0 6 7 0
+		 7 8 0 8 9 0 9 10 0 10 11 0 11 12 0 12 13 0 13 14 0 14 15 0 15 16 0 16 17 0 17 18 0
+		 18 19 0 19 0 0 0 20 1 1 20 1 2 20 1 3 20 1 4 20 1 5 20 1 6 20 1 7 20 1 8 20 1 9 20 1
+		 10 20 1 11 20 1 12 20 1 13 20 1 14 20 1 15 20 1 16 20 1 17 20 1 18 20 1 19 20 1;
+	setAttr -s 21 -ch 80 ".fc[0:20]" -type "polyFaces" 
+		f 20 -20 -19 -18 -17 -16 -15 -14 -13 -12 -11 -10 -9 -8 -7 -6 -5 -4 -3 -2 -1
+		mu 0 20 0 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1
+		f 3 0 21 -21
+		mu 0 3 20 21 41
+		f 3 1 22 -22
+		mu 0 3 21 22 41
+		f 3 2 23 -23
+		mu 0 3 22 23 41
+		f 3 3 24 -24
+		mu 0 3 23 24 41
+		f 3 4 25 -25
+		mu 0 3 24 25 41
+		f 3 5 26 -26
+		mu 0 3 25 26 41
+		f 3 6 27 -27
+		mu 0 3 26 27 41
+		f 3 7 28 -28
+		mu 0 3 27 28 41
+		f 3 8 29 -29
+		mu 0 3 28 29 41
+		f 3 9 30 -30
+		mu 0 3 29 30 41
+		f 3 10 31 -31
+		mu 0 3 30 31 41
+		f 3 11 32 -32
+		mu 0 3 31 32 41
+		f 3 12 33 -33
+		mu 0 3 32 33 41
+		f 3 13 34 -34
+		mu 0 3 33 34 41
+		f 3 14 35 -35
+		mu 0 3 34 35 41
+		f 3 15 36 -36
+		mu 0 3 35 36 41
+		f 3 16 37 -37
+		mu 0 3 36 37 41
+		f 3 17 38 -38
+		mu 0 3 37 38 41
+		f 3 18 39 -39
+		mu 0 3 38 39 41
+		f 3 19 20 -40
+		mu 0 3 39 40 41;
+	setAttr ".cd" -type "dataPolyComponent" Index_Data Edge 0 ;
+	setAttr ".cvd" -type "dataPolyComponent" Index_Data Vertex 0 ;
+	setAttr ".pd[0]" -type "dataPolyComponent" Index_Data UV 0 ;
+	setAttr ".hfd" -type "dataPolyComponent" Index_Data Face 0 ;
+createNode transform -n "Cube2" -p "GrpRoot2";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3B1B000004DF";
+	setAttr ".t" -type "double3" 2.8102259492893205 2.9808578711625673 4.112542825909618e-15 ;
+	setAttr ".s" -type "double3" 1.36670553772346 1.36670553772346 1.36670553772346 ;
+createNode mesh -n "Cube2Shape" -p "Cube2";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3B1B000004E0";
+	setAttr -k off ".v";
+	setAttr ".vir" yes;
+	setAttr ".vif" yes;
+	setAttr ".uvst[0].uvsn" -type "string" "map1";
+	setAttr -s 14 ".uvst[0].uvsp[0:13]" -type "float2" 0.375 0 0.625 0 0.375
+		 0.25 0.625 0.25 0.375 0.5 0.625 0.5 0.375 0.75 0.625 0.75 0.375 1 0.625 1 0.875 0
+		 0.875 0.25 0.125 0 0.125 0.25;
+	setAttr ".cuvs" -type "string" "map1";
+	setAttr ".dcc" -type "string" "Ambient+Diffuse";
+	setAttr ".covm[0]"  0 1 1;
+	setAttr ".cdvm[0]"  0 1 1;
+	setAttr -s 8 ".vt[0:7]"  -0.5 -0.5 0.5 0.5 -0.5 0.5 -0.5 0.5 0.5 0.5 0.5 0.5
+		 -0.5 0.5 -0.5 0.5 0.5 -0.5 -0.5 -0.5 -0.5 0.5 -0.5 -0.5;
+	setAttr -s 12 ".ed[0:11]"  0 1 0 2 3 0 4 5 0 6 7 0 0 2 0 1 3 0 2 4 0
+		 3 5 0 4 6 0 5 7 0 6 0 0 7 1 0;
+	setAttr -s 6 -ch 24 ".fc[0:5]" -type "polyFaces" 
+		f 4 0 5 -2 -5
+		mu 0 4 0 1 3 2
+		f 4 1 7 -3 -7
+		mu 0 4 2 3 5 4
+		f 4 2 9 -4 -9
+		mu 0 4 4 5 7 6
+		f 4 3 11 -1 -11
+		mu 0 4 6 7 9 8
+		f 4 -12 -10 -8 -6
+		mu 0 4 1 10 11 3
+		f 4 10 4 6 8
+		mu 0 4 12 0 2 13;
+	setAttr ".cd" -type "dataPolyComponent" Index_Data Edge 0 ;
+	setAttr ".cvd" -type "dataPolyComponent" Index_Data Vertex 0 ;
+	setAttr ".pd[0]" -type "dataPolyComponent" Index_Data UV 0 ;
+	setAttr ".hfd" -type "dataPolyComponent" Index_Data Face 0 ;
+createNode transform -n "Conflicting1" -p "GrpRoot2";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3EF2000005CE";
+	setAttr ".t" -type "double3" -2.1654426531785687 1.0046767663911893 3.922874331426706e-15 ;
+	setAttr ".s" -type "double3" 0.5982021026824127 0.5982021026824127 0.5982021026824127 ;
+createNode mesh -n "Conflicting1Shape" -p "|Top|Mid_Transformation|GrpRoot2|Conflicting1";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3EF2000005CF";
+	setAttr -k off ".v";
+	setAttr ".vir" yes;
+	setAttr ".vif" yes;
+	setAttr ".uvst[0].uvsn" -type "string" "map1";
+	setAttr -s 42 ".uvst[0].uvsp[0:41]" -type "float2" 0.7377643 0.1727457
+		 0.70225441 0.1030536 0.64694643 0.04774563 0.5772543 0.012235746 0.5 -1.1920929e-07
+		 0.4227457 0.012235761 0.35305363 0.047745675 0.2977457 0.10305364 0.26223582 0.17274573
+		 0.24999994 0.25 0.26223582 0.32725427 0.2977457 0.39694634 0.35305366 0.4522543 0.42274573
+		 0.48776418 0.5 0.5 0.57725424 0.48776415 0.64694631 0.45225427 0.70225424 0.39694631
+		 0.73776412 0.32725424 0.75 0.25 0.25 0.5 0.27500001 0.5 0.30000001 0.5 0.32500002
+		 0.5 0.35000002 0.5 0.37500003 0.5 0.40000004 0.5 0.42500004 0.5 0.45000005 0.5 0.47500005
+		 0.5 0.50000006 0.5 0.52500004 0.5 0.55000001 0.5 0.57499999 0.5 0.59999996 0.5 0.62499994
+		 0.5 0.64999992 0.5 0.67499989 0.5 0.69999987 0.5 0.72499985 0.5 0.74999982 0.5 0.5
+		 1;
+	setAttr ".cuvs" -type "string" "map1";
+	setAttr ".dcc" -type "string" "Ambient+Diffuse";
+	setAttr ".covm[0]"  0 1 1;
+	setAttr ".cdvm[0]"  0 1 1;
+	setAttr -s 21 ".vt[0:20]"  0.95105714 -1 -0.30901718 0.80901754 -1 -0.5877856
+		 0.5877856 -1 -0.80901748 0.30901715 -1 -0.95105702 0 -1 -1.000000476837 -0.30901715 -1 -0.95105696
+		 -0.58778548 -1 -0.8090173 -0.80901724 -1 -0.58778542 -0.95105678 -1 -0.30901706 -1.000000238419 -1 0
+		 -0.95105678 -1 0.30901706 -0.80901718 -1 0.58778536 -0.58778536 -1 0.80901712 -0.30901706 -1 0.95105666
+		 -2.9802322e-08 -1 1.000000119209 0.30901697 -1 0.9510566 0.58778524 -1 0.80901706
+		 0.809017 -1 0.5877853 0.95105654 -1 0.309017 1 -1 0 0 1 0;
+	setAttr -s 40 ".ed[0:39]"  0 1 0 1 2 0 2 3 0 3 4 0 4 5 0 5 6 0 6 7 0
+		 7 8 0 8 9 0 9 10 0 10 11 0 11 12 0 12 13 0 13 14 0 14 15 0 15 16 0 16 17 0 17 18 0
+		 18 19 0 19 0 0 0 20 1 1 20 1 2 20 1 3 20 1 4 20 1 5 20 1 6 20 1 7 20 1 8 20 1 9 20 1
+		 10 20 1 11 20 1 12 20 1 13 20 1 14 20 1 15 20 1 16 20 1 17 20 1 18 20 1 19 20 1;
+	setAttr -s 21 -ch 80 ".fc[0:20]" -type "polyFaces" 
+		f 20 -20 -19 -18 -17 -16 -15 -14 -13 -12 -11 -10 -9 -8 -7 -6 -5 -4 -3 -2 -1
+		mu 0 20 0 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1
+		f 3 0 21 -21
+		mu 0 3 20 21 41
+		f 3 1 22 -22
+		mu 0 3 21 22 41
+		f 3 2 23 -23
+		mu 0 3 22 23 41
+		f 3 3 24 -24
+		mu 0 3 23 24 41
+		f 3 4 25 -25
+		mu 0 3 24 25 41
+		f 3 5 26 -26
+		mu 0 3 25 26 41
+		f 3 6 27 -27
+		mu 0 3 26 27 41
+		f 3 7 28 -28
+		mu 0 3 27 28 41
+		f 3 8 29 -29
+		mu 0 3 28 29 41
+		f 3 9 30 -30
+		mu 0 3 29 30 41
+		f 3 10 31 -31
+		mu 0 3 30 31 41
+		f 3 11 32 -32
+		mu 0 3 31 32 41
+		f 3 12 33 -33
+		mu 0 3 32 33 41
+		f 3 13 34 -34
+		mu 0 3 33 34 41
+		f 3 14 35 -35
+		mu 0 3 34 35 41
+		f 3 15 36 -36
+		mu 0 3 35 36 41
+		f 3 16 37 -37
+		mu 0 3 36 37 41
+		f 3 17 38 -38
+		mu 0 3 37 38 41
+		f 3 18 39 -39
+		mu 0 3 38 39 41
+		f 3 19 20 -40
+		mu 0 3 39 40 41;
+	setAttr ".cd" -type "dataPolyComponent" Index_Data Edge 0 ;
+	setAttr ".cvd" -type "dataPolyComponent" Index_Data Vertex 0 ;
+	setAttr ".pd[0]" -type "dataPolyComponent" Index_Data UV 0 ;
+	setAttr ".hfd" -type "dataPolyComponent" Index_Data Face 0 ;
+createNode transform -n "Conflicting2" -p "GrpRoot2";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3EF2000005D0";
+	setAttr ".t" -type "double3" -2.16544265317857 1.8773951983290045 8.9408419162606534e-15 ;
+	setAttr ".s" -type "double3" 0.5982021026824127 0.5982021026824127 0.5982021026824127 ;
+createNode mesh -n "Conflicting2Shape" -p "|Top|Mid_Transformation|GrpRoot2|Conflicting2";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3EF2000005D1";
+	setAttr -k off ".v";
+	setAttr ".vir" yes;
+	setAttr ".vif" yes;
+	setAttr ".uvst[0].uvsn" -type "string" "map1";
+	setAttr -s 14 ".uvst[0].uvsp[0:13]" -type "float2" 0.375 0 0.625 0 0.375
+		 0.25 0.625 0.25 0.375 0.5 0.625 0.5 0.375 0.75 0.625 0.75 0.375 1 0.625 1 0.875 0
+		 0.875 0.25 0.125 0 0.125 0.25;
+	setAttr ".cuvs" -type "string" "map1";
+	setAttr ".dcc" -type "string" "Ambient+Diffuse";
+	setAttr ".covm[0]"  0 1 1;
+	setAttr ".cdvm[0]"  0 1 1;
+	setAttr -s 8 ".vt[0:7]"  -0.5 -0.5 0.5 0.5 -0.5 0.5 -0.5 0.5 0.5 0.5 0.5 0.5
+		 -0.5 0.5 -0.5 0.5 0.5 -0.5 -0.5 -0.5 -0.5 0.5 -0.5 -0.5;
+	setAttr -s 12 ".ed[0:11]"  0 1 0 2 3 0 4 5 0 6 7 0 0 2 0 1 3 0 2 4 0
+		 3 5 0 4 6 0 5 7 0 6 0 0 7 1 0;
+	setAttr -s 6 -ch 24 ".fc[0:5]" -type "polyFaces" 
+		f 4 0 5 -2 -5
+		mu 0 4 0 1 3 2
+		f 4 1 7 -3 -7
+		mu 0 4 2 3 5 4
+		f 4 2 9 -4 -9
+		mu 0 4 4 5 7 6
+		f 4 3 11 -1 -11
+		mu 0 4 6 7 9 8
+		f 4 -12 -10 -8 -6
+		mu 0 4 1 10 11 3
+		f 4 10 4 6 8
+		mu 0 4 12 0 2 13;
+	setAttr ".cd" -type "dataPolyComponent" Index_Data Edge 0 ;
+	setAttr ".cvd" -type "dataPolyComponent" Index_Data Vertex 0 ;
+	setAttr ".pd[0]" -type "dataPolyComponent" Index_Data UV 0 ;
+	setAttr ".hfd" -type "dataPolyComponent" Index_Data Face 0 ;
+createNode transform -n "GrpRoot3" -p "Mid_Transformation";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3E09000005A2";
+	setAttr ".t" -type "double3" -0.16220328977761139 1.5246460781128439 0.76375908293246053 ;
+	setAttr ".r" -type "double3" -21.015249863472487 18.284097963354078 15.545994295870752 ;
+createNode transform -n "Conflicting1" -p "GrpRoot3";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3E09000005A3";
+	setAttr ".t" -type "double3" 2.81022594928932 1.0046767663911917 8.8817841970012523e-16 ;
+	setAttr ".s" -type "double3" 1.36670553772346 1.36670553772346 1.36670553772346 ;
+createNode mesh -n "Conflicting1Shape" -p "|Top|Mid_Transformation|GrpRoot3|Conflicting1";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3E09000005A4";
+	setAttr -k off ".v";
+	setAttr ".vir" yes;
+	setAttr ".vif" yes;
+	setAttr ".uvst[0].uvsn" -type "string" "map1";
+	setAttr -s 42 ".uvst[0].uvsp[0:41]" -type "float2" 0.7377643 0.1727457
+		 0.70225441 0.1030536 0.64694643 0.04774563 0.5772543 0.012235746 0.5 -1.1920929e-07
+		 0.4227457 0.012235761 0.35305363 0.047745675 0.2977457 0.10305364 0.26223582 0.17274573
+		 0.24999994 0.25 0.26223582 0.32725427 0.2977457 0.39694634 0.35305366 0.4522543 0.42274573
+		 0.48776418 0.5 0.5 0.57725424 0.48776415 0.64694631 0.45225427 0.70225424 0.39694631
+		 0.73776412 0.32725424 0.75 0.25 0.25 0.5 0.27500001 0.5 0.30000001 0.5 0.32500002
+		 0.5 0.35000002 0.5 0.37500003 0.5 0.40000004 0.5 0.42500004 0.5 0.45000005 0.5 0.47500005
+		 0.5 0.50000006 0.5 0.52500004 0.5 0.55000001 0.5 0.57499999 0.5 0.59999996 0.5 0.62499994
+		 0.5 0.64999992 0.5 0.67499989 0.5 0.69999987 0.5 0.72499985 0.5 0.74999982 0.5 0.5
+		 1;
+	setAttr ".cuvs" -type "string" "map1";
+	setAttr ".dcc" -type "string" "Ambient+Diffuse";
+	setAttr ".covm[0]"  0 1 1;
+	setAttr ".cdvm[0]"  0 1 1;
+	setAttr -s 21 ".vt[0:20]"  0.95105714 -1 -0.30901718 0.80901754 -1 -0.5877856
+		 0.5877856 -1 -0.80901748 0.30901715 -1 -0.95105702 0 -1 -1.000000476837 -0.30901715 -1 -0.95105696
+		 -0.58778548 -1 -0.8090173 -0.80901724 -1 -0.58778542 -0.95105678 -1 -0.30901706 -1.000000238419 -1 0
+		 -0.95105678 -1 0.30901706 -0.80901718 -1 0.58778536 -0.58778536 -1 0.80901712 -0.30901706 -1 0.95105666
+		 -2.9802322e-08 -1 1.000000119209 0.30901697 -1 0.9510566 0.58778524 -1 0.80901706
+		 0.809017 -1 0.5877853 0.95105654 -1 0.309017 1 -1 0 0 1 0;
+	setAttr -s 40 ".ed[0:39]"  0 1 0 1 2 0 2 3 0 3 4 0 4 5 0 5 6 0 6 7 0
+		 7 8 0 8 9 0 9 10 0 10 11 0 11 12 0 12 13 0 13 14 0 14 15 0 15 16 0 16 17 0 17 18 0
+		 18 19 0 19 0 0 0 20 1 1 20 1 2 20 1 3 20 1 4 20 1 5 20 1 6 20 1 7 20 1 8 20 1 9 20 1
+		 10 20 1 11 20 1 12 20 1 13 20 1 14 20 1 15 20 1 16 20 1 17 20 1 18 20 1 19 20 1;
+	setAttr -s 21 -ch 80 ".fc[0:20]" -type "polyFaces" 
+		f 20 -20 -19 -18 -17 -16 -15 -14 -13 -12 -11 -10 -9 -8 -7 -6 -5 -4 -3 -2 -1
+		mu 0 20 0 19 18 17 16 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1
+		f 3 0 21 -21
+		mu 0 3 20 21 41
+		f 3 1 22 -22
+		mu 0 3 21 22 41
+		f 3 2 23 -23
+		mu 0 3 22 23 41
+		f 3 3 24 -24
+		mu 0 3 23 24 41
+		f 3 4 25 -25
+		mu 0 3 24 25 41
+		f 3 5 26 -26
+		mu 0 3 25 26 41
+		f 3 6 27 -27
+		mu 0 3 26 27 41
+		f 3 7 28 -28
+		mu 0 3 27 28 41
+		f 3 8 29 -29
+		mu 0 3 28 29 41
+		f 3 9 30 -30
+		mu 0 3 29 30 41
+		f 3 10 31 -31
+		mu 0 3 30 31 41
+		f 3 11 32 -32
+		mu 0 3 31 32 41
+		f 3 12 33 -33
+		mu 0 3 32 33 41
+		f 3 13 34 -34
+		mu 0 3 33 34 41
+		f 3 14 35 -35
+		mu 0 3 34 35 41
+		f 3 15 36 -36
+		mu 0 3 35 36 41
+		f 3 16 37 -37
+		mu 0 3 36 37 41
+		f 3 17 38 -38
+		mu 0 3 37 38 41
+		f 3 18 39 -39
+		mu 0 3 38 39 41
+		f 3 19 20 -40
+		mu 0 3 39 40 41;
+	setAttr ".cd" -type "dataPolyComponent" Index_Data Edge 0 ;
+	setAttr ".cvd" -type "dataPolyComponent" Index_Data Vertex 0 ;
+	setAttr ".pd[0]" -type "dataPolyComponent" Index_Data UV 0 ;
+	setAttr ".hfd" -type "dataPolyComponent" Index_Data Face 0 ;
+createNode transform -n "Conflicting2" -p "GrpRoot3";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3E09000005A5";
+	setAttr ".t" -type "double3" 2.8102259492893205 2.9808578711625673 4.112542825909618e-15 ;
+	setAttr ".s" -type "double3" 1.36670553772346 1.36670553772346 1.36670553772346 ;
+createNode mesh -n "Conflicting2Shape" -p "|Top|Mid_Transformation|GrpRoot3|Conflicting2";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3E09000005A6";
+	setAttr -k off ".v";
+	setAttr ".vir" yes;
+	setAttr ".vif" yes;
+	setAttr ".uvst[0].uvsn" -type "string" "map1";
+	setAttr -s 14 ".uvst[0].uvsp[0:13]" -type "float2" 0.375 0 0.625 0 0.375
+		 0.25 0.625 0.25 0.375 0.5 0.625 0.5 0.375 0.75 0.625 0.75 0.375 1 0.625 1 0.875 0
+		 0.875 0.25 0.125 0 0.125 0.25;
+	setAttr ".cuvs" -type "string" "map1";
+	setAttr ".dcc" -type "string" "Ambient+Diffuse";
+	setAttr ".covm[0]"  0 1 1;
+	setAttr ".cdvm[0]"  0 1 1;
+	setAttr -s 8 ".vt[0:7]"  -0.5 -0.5 0.5 0.5 -0.5 0.5 -0.5 0.5 0.5 0.5 0.5 0.5
+		 -0.5 0.5 -0.5 0.5 0.5 -0.5 -0.5 -0.5 -0.5 0.5 -0.5 -0.5;
+	setAttr -s 12 ".ed[0:11]"  0 1 0 2 3 0 4 5 0 6 7 0 0 2 0 1 3 0 2 4 0
+		 3 5 0 4 6 0 5 7 0 6 0 0 7 1 0;
+	setAttr -s 6 -ch 24 ".fc[0:5]" -type "polyFaces" 
+		f 4 0 5 -2 -5
+		mu 0 4 0 1 3 2
+		f 4 1 7 -3 -7
+		mu 0 4 2 3 5 4
+		f 4 2 9 -4 -9
+		mu 0 4 4 5 7 6
+		f 4 3 11 -1 -11
+		mu 0 4 6 7 9 8
+		f 4 -12 -10 -8 -6
+		mu 0 4 1 10 11 3
+		f 4 10 4 6 8
+		mu 0 4 12 0 2 13;
+	setAttr ".cd" -type "dataPolyComponent" Index_Data Edge 0 ;
+	setAttr ".cvd" -type "dataPolyComponent" Index_Data Vertex 0 ;
+	setAttr ".pd[0]" -type "dataPolyComponent" Index_Data UV 0 ;
+	setAttr ".hfd" -type "dataPolyComponent" Index_Data Face 0 ;
+createNode transform -s -n "persp";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A0E00000456";
+	setAttr ".v" no;
+	setAttr ".t" -type "double3" 13.159266308616866 6.347633299951414 1.1351061832312555 ;
+	setAttr ".r" -type "double3" 174.86164727039653 76.199999999999207 -179.99999999999977 ;
+	setAttr ".rp" -type "double3" -8.8817841970012523e-16 -8.8817841970012523e-16 0 ;
+	setAttr ".rpt" -type "double3" 1.0815821569573157e-15 5.4291871708045674e-18 8.7239360229535795e-16 ;
+createNode camera -s -n "perspShape" -p "persp";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A0E00000457";
+	setAttr -k off ".v" no;
+	setAttr ".fl" 34.999999999999979;
+	setAttr ".ncp" 1;
+	setAttr ".fcp" 1000000;
+	setAttr ".coi" 17.503978329115146;
+	setAttr ".imn" -type "string" "persp";
+	setAttr ".den" -type "string" "persp_depth";
+	setAttr ".man" -type "string" "persp_mask";
+	setAttr ".tp" -type "double3" -3.619334695394258 6.7099206547173464 5.4021383669348992 ;
+	setAttr ".hc" -type "string" "viewSet -p %camera";
+createNode transform -s -n "top";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A0E00000458";
+	setAttr ".v" no;
+	setAttr ".t" -type "double3" 0 1000.1 0 ;
+	setAttr ".r" -type "double3" -89.999999999999986 0 0 ;
+createNode camera -s -n "topShape" -p "top";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A0E00000459";
+	setAttr -k off ".v" no;
+	setAttr ".rnd" no;
+	setAttr ".ncp" 1;
+	setAttr ".fcp" 1000000;
+	setAttr ".coi" 1000.1;
+	setAttr ".ow" 30;
+	setAttr ".imn" -type "string" "top";
+	setAttr ".den" -type "string" "top_depth";
+	setAttr ".man" -type "string" "top_mask";
+	setAttr ".hc" -type "string" "viewSet -t %camera";
+	setAttr ".o" yes;
+createNode transform -s -n "front";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A0E0000045A";
+	setAttr ".v" no;
+	setAttr ".t" -type "double3" 0 0 1000.1 ;
+createNode camera -s -n "frontShape" -p "front";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A0E0000045B";
+	setAttr -k off ".v" no;
+	setAttr ".rnd" no;
+	setAttr ".ncp" 1;
+	setAttr ".fcp" 1000000;
+	setAttr ".coi" 1000.1;
+	setAttr ".ow" 30;
+	setAttr ".imn" -type "string" "front";
+	setAttr ".den" -type "string" "front_depth";
+	setAttr ".man" -type "string" "front_mask";
+	setAttr ".hc" -type "string" "viewSet -f %camera";
+	setAttr ".o" yes;
+createNode transform -s -n "side";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A0E0000045C";
+	setAttr ".v" no;
+	setAttr ".t" -type "double3" 1000.1 0 0 ;
+	setAttr ".r" -type "double3" 0 89.999999999999986 0 ;
+createNode camera -s -n "sideShape" -p "side";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A0E0000045D";
+	setAttr -k off ".v" no;
+	setAttr ".rnd" no;
+	setAttr ".ncp" 1;
+	setAttr ".fcp" 1000000;
+	setAttr ".coi" 1000.1;
+	setAttr ".ow" 30;
+	setAttr ".imn" -type "string" "side";
+	setAttr ".den" -type "string" "side_depth";
+	setAttr ".man" -type "string" "side_mask";
+	setAttr ".hc" -type "string" "viewSet -s %camera";
+	setAttr ".o" yes;
+createNode lightLinker -s -n "lightLinker1";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A0E0000045E";
+	setAttr -s 2 ".lnk";
+	setAttr -s 2 ".slnk";
+createNode shapeEditorManager -n "shapeEditorManager";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A0E0000045F";
+createNode poseInterpolatorManager -n "poseInterpolatorManager";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A0E00000460";
+createNode displayLayerManager -n "layerManager";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A0E00000461";
+createNode displayLayer -n "defaultLayer";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A0E00000462";
+createNode renderLayerManager -n "renderLayerManager";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A0E00000463";
+createNode renderLayer -n "defaultRenderLayer";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3A0E00000464";
+	setAttr ".g" yes;
+createNode polyCone -n "polyCone1";
+	rename -uid "1C72F9C0-0003-FC42-60C2-3AAF00000481";
+	setAttr ".cuv" 3;
+createNode script -n "uiConfigurationScriptNode";
+	rename -uid "1C72F9C0-0003-FC42-60C2-401F00000606";
+	setAttr ".b" -type "string" (
+		"// Maya Mel UI Configuration File.\n//\n//  This script is machine generated.  Edit at your own risk.\n//\n//\n\nglobal string $gMainPane;\nif (`paneLayout -exists $gMainPane`) {\n\n\tglobal int $gUseScenePanelConfig;\n\tint    $useSceneConfig = $gUseScenePanelConfig;\n\tint    $nodeEditorPanelVisible = stringArrayContains(\"nodeEditorPanel1\", `getPanel -vis`);\n\tint    $nodeEditorWorkspaceControlOpen = (`workspaceControl -exists nodeEditorPanel1Window` && `workspaceControl -q -visible nodeEditorPanel1Window`);\n\tint    $menusOkayInPanels = `optionVar -q allowMenusInPanels`;\n\tint    $nVisPanes = `paneLayout -q -nvp $gMainPane`;\n\tint    $nPanes = 0;\n\tstring $editorName;\n\tstring $panelName;\n\tstring $itemFilterName;\n\tstring $panelConfig;\n\n\t//\n\t//  get current state of the UI\n\t//\n\tsceneUIReplacement -update $gMainPane;\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"modelPanel\" (localizedPanelLabel(\"Top View\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tmodelPanel -edit -l (localizedPanelLabel(\"Top View\")) -mbv $menusOkayInPanels  $panelName;\n"
+		+ "\t\t$editorName = $panelName;\n        modelEditor -e \n            -camera \"top\" \n            -useInteractiveMode 0\n            -displayLights \"default\" \n            -displayAppearance \"smoothShaded\" \n            -activeOnly 0\n            -ignorePanZoom 0\n            -wireframeOnShaded 0\n            -headsUpDisplay 1\n            -holdOuts 1\n            -selectionHiliteDisplay 1\n            -useDefaultMaterial 0\n            -bufferMode \"double\" \n            -twoSidedLighting 0\n            -backfaceCulling 0\n            -xray 0\n            -jointXray 0\n            -activeComponentsXray 0\n            -displayTextures 0\n            -smoothWireframe 0\n            -lineWidth 1\n            -textureAnisotropic 0\n            -textureHilight 1\n            -textureSampling 2\n            -textureDisplay \"modulate\" \n            -textureMaxSize 32768\n            -fogging 0\n            -fogSource \"fragment\" \n            -fogMode \"linear\" \n            -fogStart 0\n            -fogEnd 100\n            -fogDensity 0.1\n            -fogColor 0.5 0.5 0.5 1 \n"
+		+ "            -depthOfFieldPreview 1\n            -maxConstantTransparency 1\n            -rendererName \"vp2Renderer\" \n            -objectFilterShowInHUD 1\n            -isFiltered 0\n            -colorResolution 256 256 \n            -bumpResolution 512 512 \n            -textureCompression 0\n            -transparencyAlgorithm \"frontAndBackCull\" \n            -transpInShadows 0\n            -cullingOverride \"none\" \n            -lowQualityLighting 0\n            -maximumNumHardwareLights 1\n            -occlusionCulling 0\n            -shadingModel 0\n            -useBaseRenderer 0\n            -useReducedRenderer 0\n            -smallObjectCulling 0\n            -smallObjectThreshold -1 \n            -interactiveDisableShadows 0\n            -interactiveBackFaceCull 0\n            -sortTransparent 1\n            -controllers 1\n            -nurbsCurves 1\n            -nurbsSurfaces 1\n            -polymeshes 1\n            -subdivSurfaces 1\n            -planes 1\n            -lights 1\n            -cameras 1\n            -controlVertices 1\n"
+		+ "            -hulls 1\n            -grid 1\n            -imagePlane 1\n            -joints 1\n            -ikHandles 1\n            -deformers 1\n            -dynamics 1\n            -particleInstancers 1\n            -fluids 1\n            -hairSystems 1\n            -follicles 1\n            -nCloths 1\n            -nParticles 1\n            -nRigids 1\n            -dynamicConstraints 1\n            -locators 1\n            -manipulators 1\n            -pluginShapes 1\n            -dimensions 1\n            -handles 1\n            -pivots 1\n            -textures 1\n            -strokes 1\n            -motionTrails 1\n            -clipGhosts 1\n            -greasePencils 1\n            -shadows 0\n            -captureSequenceNumber -1\n            -width 1\n            -height 1\n            -sceneRenderFilter 0\n            $editorName;\n        modelEditor -e -viewSelected 0 $editorName;\n        modelEditor -e \n            -pluginObjects \"gpuCacheDisplayFilter\" 1 \n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n"
+		+ "\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"modelPanel\" (localizedPanelLabel(\"Side View\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tmodelPanel -edit -l (localizedPanelLabel(\"Side View\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        modelEditor -e \n            -camera \"side\" \n            -useInteractiveMode 0\n            -displayLights \"default\" \n            -displayAppearance \"smoothShaded\" \n            -activeOnly 0\n            -ignorePanZoom 0\n            -wireframeOnShaded 0\n            -headsUpDisplay 1\n            -holdOuts 1\n            -selectionHiliteDisplay 1\n            -useDefaultMaterial 0\n            -bufferMode \"double\" \n            -twoSidedLighting 0\n            -backfaceCulling 0\n            -xray 0\n            -jointXray 0\n            -activeComponentsXray 0\n            -displayTextures 0\n            -smoothWireframe 0\n            -lineWidth 1\n            -textureAnisotropic 0\n            -textureHilight 1\n            -textureSampling 2\n"
+		+ "            -textureDisplay \"modulate\" \n            -textureMaxSize 32768\n            -fogging 0\n            -fogSource \"fragment\" \n            -fogMode \"linear\" \n            -fogStart 0\n            -fogEnd 100\n            -fogDensity 0.1\n            -fogColor 0.5 0.5 0.5 1 \n            -depthOfFieldPreview 1\n            -maxConstantTransparency 1\n            -rendererName \"vp2Renderer\" \n            -objectFilterShowInHUD 1\n            -isFiltered 0\n            -colorResolution 256 256 \n            -bumpResolution 512 512 \n            -textureCompression 0\n            -transparencyAlgorithm \"frontAndBackCull\" \n            -transpInShadows 0\n            -cullingOverride \"none\" \n            -lowQualityLighting 0\n            -maximumNumHardwareLights 1\n            -occlusionCulling 0\n            -shadingModel 0\n            -useBaseRenderer 0\n            -useReducedRenderer 0\n            -smallObjectCulling 0\n            -smallObjectThreshold -1 \n            -interactiveDisableShadows 0\n            -interactiveBackFaceCull 0\n"
+		+ "            -sortTransparent 1\n            -controllers 1\n            -nurbsCurves 1\n            -nurbsSurfaces 1\n            -polymeshes 1\n            -subdivSurfaces 1\n            -planes 1\n            -lights 1\n            -cameras 1\n            -controlVertices 1\n            -hulls 1\n            -grid 1\n            -imagePlane 1\n            -joints 1\n            -ikHandles 1\n            -deformers 1\n            -dynamics 1\n            -particleInstancers 1\n            -fluids 1\n            -hairSystems 1\n            -follicles 1\n            -nCloths 1\n            -nParticles 1\n            -nRigids 1\n            -dynamicConstraints 1\n            -locators 1\n            -manipulators 1\n            -pluginShapes 1\n            -dimensions 1\n            -handles 1\n            -pivots 1\n            -textures 1\n            -strokes 1\n            -motionTrails 1\n            -clipGhosts 1\n            -greasePencils 1\n            -shadows 0\n            -captureSequenceNumber -1\n            -width 1\n            -height 1\n"
+		+ "            -sceneRenderFilter 0\n            $editorName;\n        modelEditor -e -viewSelected 0 $editorName;\n        modelEditor -e \n            -pluginObjects \"gpuCacheDisplayFilter\" 1 \n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"modelPanel\" (localizedPanelLabel(\"Front View\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tmodelPanel -edit -l (localizedPanelLabel(\"Front View\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        modelEditor -e \n            -camera \"front\" \n            -useInteractiveMode 0\n            -displayLights \"default\" \n            -displayAppearance \"smoothShaded\" \n            -activeOnly 0\n            -ignorePanZoom 0\n            -wireframeOnShaded 0\n            -headsUpDisplay 1\n            -holdOuts 1\n            -selectionHiliteDisplay 1\n            -useDefaultMaterial 0\n            -bufferMode \"double\" \n            -twoSidedLighting 0\n            -backfaceCulling 0\n"
+		+ "            -xray 0\n            -jointXray 0\n            -activeComponentsXray 0\n            -displayTextures 0\n            -smoothWireframe 0\n            -lineWidth 1\n            -textureAnisotropic 0\n            -textureHilight 1\n            -textureSampling 2\n            -textureDisplay \"modulate\" \n            -textureMaxSize 32768\n            -fogging 0\n            -fogSource \"fragment\" \n            -fogMode \"linear\" \n            -fogStart 0\n            -fogEnd 100\n            -fogDensity 0.1\n            -fogColor 0.5 0.5 0.5 1 \n            -depthOfFieldPreview 1\n            -maxConstantTransparency 1\n            -rendererName \"vp2Renderer\" \n            -objectFilterShowInHUD 1\n            -isFiltered 0\n            -colorResolution 256 256 \n            -bumpResolution 512 512 \n            -textureCompression 0\n            -transparencyAlgorithm \"frontAndBackCull\" \n            -transpInShadows 0\n            -cullingOverride \"none\" \n            -lowQualityLighting 0\n            -maximumNumHardwareLights 1\n            -occlusionCulling 0\n"
+		+ "            -shadingModel 0\n            -useBaseRenderer 0\n            -useReducedRenderer 0\n            -smallObjectCulling 0\n            -smallObjectThreshold -1 \n            -interactiveDisableShadows 0\n            -interactiveBackFaceCull 0\n            -sortTransparent 1\n            -controllers 1\n            -nurbsCurves 1\n            -nurbsSurfaces 1\n            -polymeshes 1\n            -subdivSurfaces 1\n            -planes 1\n            -lights 1\n            -cameras 1\n            -controlVertices 1\n            -hulls 1\n            -grid 1\n            -imagePlane 1\n            -joints 1\n            -ikHandles 1\n            -deformers 1\n            -dynamics 1\n            -particleInstancers 1\n            -fluids 1\n            -hairSystems 1\n            -follicles 1\n            -nCloths 1\n            -nParticles 1\n            -nRigids 1\n            -dynamicConstraints 1\n            -locators 1\n            -manipulators 1\n            -pluginShapes 1\n            -dimensions 1\n            -handles 1\n            -pivots 1\n"
+		+ "            -textures 1\n            -strokes 1\n            -motionTrails 1\n            -clipGhosts 1\n            -greasePencils 1\n            -shadows 0\n            -captureSequenceNumber -1\n            -width 1\n            -height 1\n            -sceneRenderFilter 0\n            $editorName;\n        modelEditor -e -viewSelected 0 $editorName;\n        modelEditor -e \n            -pluginObjects \"gpuCacheDisplayFilter\" 1 \n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"modelPanel\" (localizedPanelLabel(\"Persp View\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tmodelPanel -edit -l (localizedPanelLabel(\"Persp View\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        modelEditor -e \n            -camera \"persp\" \n            -useInteractiveMode 0\n            -displayLights \"default\" \n            -displayAppearance \"smoothShaded\" \n            -activeOnly 0\n            -ignorePanZoom 0\n"
+		+ "            -wireframeOnShaded 0\n            -headsUpDisplay 1\n            -holdOuts 1\n            -selectionHiliteDisplay 1\n            -useDefaultMaterial 0\n            -bufferMode \"double\" \n            -twoSidedLighting 0\n            -backfaceCulling 0\n            -xray 0\n            -jointXray 0\n            -activeComponentsXray 0\n            -displayTextures 0\n            -smoothWireframe 0\n            -lineWidth 1\n            -textureAnisotropic 0\n            -textureHilight 1\n            -textureSampling 2\n            -textureDisplay \"modulate\" \n            -textureMaxSize 32768\n            -fogging 0\n            -fogSource \"fragment\" \n            -fogMode \"linear\" \n            -fogStart 0\n            -fogEnd 100\n            -fogDensity 0.1\n            -fogColor 0.5 0.5 0.5 1 \n            -depthOfFieldPreview 1\n            -maxConstantTransparency 1\n            -rendererName \"vp2Renderer\" \n            -objectFilterShowInHUD 1\n            -isFiltered 0\n            -colorResolution 256 256 \n            -bumpResolution 512 512 \n"
+		+ "            -textureCompression 0\n            -transparencyAlgorithm \"frontAndBackCull\" \n            -transpInShadows 0\n            -cullingOverride \"none\" \n            -lowQualityLighting 0\n            -maximumNumHardwareLights 1\n            -occlusionCulling 0\n            -shadingModel 0\n            -useBaseRenderer 0\n            -useReducedRenderer 0\n            -smallObjectCulling 0\n            -smallObjectThreshold -1 \n            -interactiveDisableShadows 0\n            -interactiveBackFaceCull 0\n            -sortTransparent 1\n            -controllers 1\n            -nurbsCurves 1\n            -nurbsSurfaces 1\n            -polymeshes 1\n            -subdivSurfaces 1\n            -planes 1\n            -lights 1\n            -cameras 1\n            -controlVertices 1\n            -hulls 1\n            -grid 1\n            -imagePlane 1\n            -joints 1\n            -ikHandles 1\n            -deformers 1\n            -dynamics 1\n            -particleInstancers 1\n            -fluids 1\n            -hairSystems 1\n            -follicles 1\n"
+		+ "            -nCloths 1\n            -nParticles 1\n            -nRigids 1\n            -dynamicConstraints 1\n            -locators 1\n            -manipulators 1\n            -pluginShapes 1\n            -dimensions 1\n            -handles 1\n            -pivots 1\n            -textures 1\n            -strokes 1\n            -motionTrails 1\n            -clipGhosts 1\n            -greasePencils 1\n            -shadows 0\n            -captureSequenceNumber -1\n            -width 1289\n            -height 707\n            -sceneRenderFilter 0\n            $editorName;\n        modelEditor -e -viewSelected 0 $editorName;\n        modelEditor -e \n            -pluginObjects \"gpuCacheDisplayFilter\" 1 \n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"outlinerPanel\" (localizedPanelLabel(\"ToggledOutliner\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\toutlinerPanel -edit -l (localizedPanelLabel(\"ToggledOutliner\")) -mbv $menusOkayInPanels  $panelName;\n"
+		+ "\t\t$editorName = $panelName;\n        outlinerEditor -e \n            -docTag \"isolOutln_fromSeln\" \n            -showShapes 0\n            -showAssignedMaterials 0\n            -showTimeEditor 1\n            -showReferenceNodes 1\n            -showReferenceMembers 1\n            -showAttributes 0\n            -showConnected 0\n            -showAnimCurvesOnly 0\n            -showMuteInfo 0\n            -organizeByLayer 1\n            -organizeByClip 1\n            -showAnimLayerWeight 1\n            -autoExpandLayers 1\n            -autoExpand 0\n            -showDagOnly 1\n            -showAssets 1\n            -showContainedOnly 1\n            -showPublishedAsConnected 0\n            -showParentContainers 0\n            -showContainerContents 1\n            -ignoreDagHierarchy 0\n            -expandConnections 0\n            -showUpstreamCurves 1\n            -showUnitlessCurves 1\n            -showCompounds 1\n            -showLeafs 1\n            -showNumericAttrsOnly 0\n            -highlightActive 1\n            -autoSelectNewObjects 0\n"
+		+ "            -doNotSelectNewObjects 0\n            -dropIsParent 1\n            -transmitFilters 0\n            -setFilter \"defaultSetFilter\" \n            -showSetMembers 1\n            -allowMultiSelection 1\n            -alwaysToggleSelect 0\n            -directSelect 0\n            -isSet 0\n            -isSetMember 0\n            -displayMode \"DAG\" \n            -expandObjects 0\n            -setsIgnoreFilters 1\n            -containersIgnoreFilters 0\n            -editAttrName 0\n            -showAttrValues 0\n            -highlightSecondary 0\n            -showUVAttrsOnly 0\n            -showTextureNodesOnly 0\n            -attrAlphaOrder \"default\" \n            -animLayerFilterOptions \"allAffecting\" \n            -sortOrder \"none\" \n            -longNames 0\n            -niceNames 1\n            -showNamespace 1\n            -showPinIcons 0\n            -mapMotionTrails 0\n            -ignoreHiddenAttribute 0\n            -ignoreOutlinerColor 0\n            -renderFilterVisible 0\n            -renderFilterIndex 0\n            -selectionOrder \"chronological\" \n"
+		+ "            -expandAttribute 0\n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"outlinerPanel\" (localizedPanelLabel(\"Outliner\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\toutlinerPanel -edit -l (localizedPanelLabel(\"Outliner\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        outlinerEditor -e \n            -showShapes 0\n            -showAssignedMaterials 0\n            -showTimeEditor 1\n            -showReferenceNodes 0\n            -showReferenceMembers 0\n            -showAttributes 0\n            -showConnected 0\n            -showAnimCurvesOnly 0\n            -showMuteInfo 0\n            -organizeByLayer 1\n            -organizeByClip 1\n            -showAnimLayerWeight 1\n            -autoExpandLayers 1\n            -autoExpand 0\n            -showDagOnly 1\n            -showAssets 1\n            -showContainedOnly 1\n            -showPublishedAsConnected 0\n            -showParentContainers 0\n"
+		+ "            -showContainerContents 1\n            -ignoreDagHierarchy 0\n            -expandConnections 0\n            -showUpstreamCurves 1\n            -showUnitlessCurves 1\n            -showCompounds 1\n            -showLeafs 1\n            -showNumericAttrsOnly 0\n            -highlightActive 1\n            -autoSelectNewObjects 0\n            -doNotSelectNewObjects 0\n            -dropIsParent 1\n            -transmitFilters 0\n            -setFilter \"defaultSetFilter\" \n            -showSetMembers 1\n            -allowMultiSelection 1\n            -alwaysToggleSelect 0\n            -directSelect 0\n            -displayMode \"DAG\" \n            -expandObjects 0\n            -setsIgnoreFilters 1\n            -containersIgnoreFilters 0\n            -editAttrName 0\n            -showAttrValues 0\n            -highlightSecondary 0\n            -showUVAttrsOnly 0\n            -showTextureNodesOnly 0\n            -attrAlphaOrder \"default\" \n            -animLayerFilterOptions \"allAffecting\" \n            -sortOrder \"none\" \n            -longNames 0\n"
+		+ "            -niceNames 1\n            -showNamespace 1\n            -showPinIcons 0\n            -mapMotionTrails 0\n            -ignoreHiddenAttribute 0\n            -ignoreOutlinerColor 0\n            -renderFilterVisible 0\n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"graphEditor\" (localizedPanelLabel(\"Graph Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Graph Editor\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = ($panelName+\"OutlineEd\");\n            outlinerEditor -e \n                -showShapes 1\n                -showAssignedMaterials 0\n                -showTimeEditor 1\n                -showReferenceNodes 0\n                -showReferenceMembers 0\n                -showAttributes 1\n                -showConnected 1\n                -showAnimCurvesOnly 1\n                -showMuteInfo 0\n                -organizeByLayer 1\n                -organizeByClip 1\n"
+		+ "                -showAnimLayerWeight 1\n                -autoExpandLayers 1\n                -autoExpand 1\n                -showDagOnly 0\n                -showAssets 1\n                -showContainedOnly 0\n                -showPublishedAsConnected 0\n                -showParentContainers 1\n                -showContainerContents 0\n                -ignoreDagHierarchy 0\n                -expandConnections 1\n                -showUpstreamCurves 1\n                -showUnitlessCurves 1\n                -showCompounds 0\n                -showLeafs 1\n                -showNumericAttrsOnly 1\n                -highlightActive 0\n                -autoSelectNewObjects 1\n                -doNotSelectNewObjects 0\n                -dropIsParent 1\n                -transmitFilters 1\n                -setFilter \"0\" \n                -showSetMembers 0\n                -allowMultiSelection 1\n                -alwaysToggleSelect 0\n                -directSelect 0\n                -displayMode \"DAG\" \n                -expandObjects 0\n                -setsIgnoreFilters 1\n"
+		+ "                -containersIgnoreFilters 0\n                -editAttrName 0\n                -showAttrValues 0\n                -highlightSecondary 0\n                -showUVAttrsOnly 0\n                -showTextureNodesOnly 0\n                -attrAlphaOrder \"default\" \n                -animLayerFilterOptions \"allAffecting\" \n                -sortOrder \"none\" \n                -longNames 0\n                -niceNames 1\n                -showNamespace 1\n                -showPinIcons 1\n                -mapMotionTrails 1\n                -ignoreHiddenAttribute 0\n                -ignoreOutlinerColor 0\n                -renderFilterVisible 0\n                $editorName;\n\n\t\t\t$editorName = ($panelName+\"GraphEd\");\n            animCurveEditor -e \n                -displayKeys 1\n                -displayTangents 0\n                -displayActiveKeys 0\n                -displayActiveKeyTangents 1\n                -displayInfinities 0\n                -displayValues 0\n                -autoFit 1\n                -autoFitTime 0\n                -snapTime \"integer\" \n"
+		+ "                -snapValue \"none\" \n                -showResults \"off\" \n                -showBufferCurves \"off\" \n                -smoothness \"fine\" \n                -resultSamples 1\n                -resultScreenSamples 0\n                -resultUpdate \"delayed\" \n                -showUpstreamCurves 1\n                -showCurveNames 0\n                -showActiveCurveNames 0\n                -stackedCurves 0\n                -stackedCurvesMin -1\n                -stackedCurvesMax 1\n                -stackedCurvesSpace 0.2\n                -displayNormalized 0\n                -preSelectionHighlight 0\n                -constrainDrag 0\n                -classicMode 1\n                -valueLinesToggle 0\n                $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"dopeSheetPanel\" (localizedPanelLabel(\"Dope Sheet\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Dope Sheet\")) -mbv $menusOkayInPanels  $panelName;\n"
+		+ "\n\t\t\t$editorName = ($panelName+\"OutlineEd\");\n            outlinerEditor -e \n                -showShapes 1\n                -showAssignedMaterials 0\n                -showTimeEditor 1\n                -showReferenceNodes 0\n                -showReferenceMembers 0\n                -showAttributes 1\n                -showConnected 1\n                -showAnimCurvesOnly 1\n                -showMuteInfo 0\n                -organizeByLayer 1\n                -organizeByClip 1\n                -showAnimLayerWeight 1\n                -autoExpandLayers 1\n                -autoExpand 0\n                -showDagOnly 0\n                -showAssets 1\n                -showContainedOnly 0\n                -showPublishedAsConnected 0\n                -showParentContainers 1\n                -showContainerContents 0\n                -ignoreDagHierarchy 0\n                -expandConnections 1\n                -showUpstreamCurves 1\n                -showUnitlessCurves 0\n                -showCompounds 1\n                -showLeafs 1\n                -showNumericAttrsOnly 1\n"
+		+ "                -highlightActive 0\n                -autoSelectNewObjects 0\n                -doNotSelectNewObjects 1\n                -dropIsParent 1\n                -transmitFilters 0\n                -setFilter \"0\" \n                -showSetMembers 0\n                -allowMultiSelection 1\n                -alwaysToggleSelect 0\n                -directSelect 0\n                -displayMode \"DAG\" \n                -expandObjects 0\n                -setsIgnoreFilters 1\n                -containersIgnoreFilters 0\n                -editAttrName 0\n                -showAttrValues 0\n                -highlightSecondary 0\n                -showUVAttrsOnly 0\n                -showTextureNodesOnly 0\n                -attrAlphaOrder \"default\" \n                -animLayerFilterOptions \"allAffecting\" \n                -sortOrder \"none\" \n                -longNames 0\n                -niceNames 1\n                -showNamespace 1\n                -showPinIcons 0\n                -mapMotionTrails 1\n                -ignoreHiddenAttribute 0\n                -ignoreOutlinerColor 0\n"
+		+ "                -renderFilterVisible 0\n                $editorName;\n\n\t\t\t$editorName = ($panelName+\"DopeSheetEd\");\n            dopeSheetEditor -e \n                -displayKeys 1\n                -displayTangents 0\n                -displayActiveKeys 0\n                -displayActiveKeyTangents 0\n                -displayInfinities 0\n                -displayValues 0\n                -autoFit 0\n                -autoFitTime 0\n                -snapTime \"integer\" \n                -snapValue \"none\" \n                -outliner \"dopeSheetPanel1OutlineEd\" \n                -showSummary 1\n                -showScene 0\n                -hierarchyBelow 0\n                -showTicks 1\n                -selectionWindow 0 0 0 0 \n                $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"timeEditorPanel\" (localizedPanelLabel(\"Time Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Time Editor\")) -mbv $menusOkayInPanels  $panelName;\n"
+		+ "\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"clipEditorPanel\" (localizedPanelLabel(\"Trax Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Trax Editor\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = clipEditorNameFromPanel($panelName);\n            clipEditor -e \n                -displayKeys 0\n                -displayTangents 0\n                -displayActiveKeys 0\n                -displayActiveKeyTangents 0\n                -displayInfinities 0\n                -displayValues 0\n                -autoFit 0\n                -autoFitTime 0\n                -snapTime \"none\" \n                -snapValue \"none\" \n                -initialized 0\n                -manageSequencer 0 \n                $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"sequenceEditorPanel\" (localizedPanelLabel(\"Camera Sequencer\")) `;\n"
+		+ "\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Camera Sequencer\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = sequenceEditorNameFromPanel($panelName);\n            clipEditor -e \n                -displayKeys 0\n                -displayTangents 0\n                -displayActiveKeys 0\n                -displayActiveKeyTangents 0\n                -displayInfinities 0\n                -displayValues 0\n                -autoFit 0\n                -autoFitTime 0\n                -snapTime \"none\" \n                -snapValue \"none\" \n                -initialized 0\n                -manageSequencer 1 \n                $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"hyperGraphPanel\" (localizedPanelLabel(\"Hypergraph Hierarchy\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Hypergraph Hierarchy\")) -mbv $menusOkayInPanels  $panelName;\n"
+		+ "\n\t\t\t$editorName = ($panelName+\"HyperGraphEd\");\n            hyperGraph -e \n                -graphLayoutStyle \"hierarchicalLayout\" \n                -orientation \"horiz\" \n                -mergeConnections 0\n                -zoom 1\n                -animateTransition 0\n                -showRelationships 1\n                -showShapes 0\n                -showDeformers 0\n                -showExpressions 0\n                -showConstraints 0\n                -showConnectionFromSelected 0\n                -showConnectionToSelected 0\n                -showConstraintLabels 0\n                -showUnderworld 0\n                -showInvisible 0\n                -transitionFrames 1\n                -opaqueContainers 0\n                -freeform 0\n                -imagePosition 0 0 \n                -imageScale 1\n                -imageEnabled 0\n                -graphType \"DAG\" \n                -heatMapDisplay 0\n                -updateSelection 1\n                -updateNodeAdded 1\n                -useDrawOverrideColor 0\n                -limitGraphTraversal -1\n"
+		+ "                -range 0 0 \n                -iconSize \"smallIcons\" \n                -showCachedConnections 0\n                $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"hyperShadePanel\" (localizedPanelLabel(\"Hypershade\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Hypershade\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"visorPanel\" (localizedPanelLabel(\"Visor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Visor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"nodeEditorPanel\" (localizedPanelLabel(\"Node Editor\")) `;\n\tif ($nodeEditorPanelVisible || $nodeEditorWorkspaceControlOpen) {\n"
+		+ "\t\tif (\"\" == $panelName) {\n\t\t\tif ($useSceneConfig) {\n\t\t\t\t$panelName = `scriptedPanel -unParent  -type \"nodeEditorPanel\" -l (localizedPanelLabel(\"Node Editor\")) -mbv $menusOkayInPanels `;\n\n\t\t\t$editorName = ($panelName+\"NodeEditorEd\");\n            nodeEditor -e \n                -allAttributes 0\n                -allNodes 0\n                -autoSizeNodes 1\n                -consistentNameSize 1\n                -createNodeCommand \"nodeEdCreateNodeCommand\" \n                -connectNodeOnCreation 0\n                -connectOnDrop 0\n                -copyConnectionsOnPaste 0\n                -connectionStyle \"bezier\" \n                -defaultPinnedState 0\n                -additiveGraphingMode 0\n                -settingsChangedCallback \"nodeEdSyncControls\" \n                -traversalDepthLimit -1\n                -keyPressCommand \"nodeEdKeyPressCommand\" \n                -nodeTitleMode \"name\" \n                -gridSnap 0\n                -gridVisibility 1\n                -crosshairOnEdgeDragging 0\n                -popupMenuScript \"nodeEdBuildPanelMenus\" \n"
+		+ "                -showNamespace 1\n                -showShapes 1\n                -showSGShapes 0\n                -showTransforms 1\n                -useAssets 1\n                -syncedSelection 1\n                -extendToShapes 1\n                -editorMode \"default\" \n                -hasWatchpoint 0\n                $editorName;\n\t\t\t}\n\t\t} else {\n\t\t\t$label = `panel -q -label $panelName`;\n\t\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Node Editor\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = ($panelName+\"NodeEditorEd\");\n            nodeEditor -e \n                -allAttributes 0\n                -allNodes 0\n                -autoSizeNodes 1\n                -consistentNameSize 1\n                -createNodeCommand \"nodeEdCreateNodeCommand\" \n                -connectNodeOnCreation 0\n                -connectOnDrop 0\n                -copyConnectionsOnPaste 0\n                -connectionStyle \"bezier\" \n                -defaultPinnedState 0\n                -additiveGraphingMode 0\n                -settingsChangedCallback \"nodeEdSyncControls\" \n"
+		+ "                -traversalDepthLimit -1\n                -keyPressCommand \"nodeEdKeyPressCommand\" \n                -nodeTitleMode \"name\" \n                -gridSnap 0\n                -gridVisibility 1\n                -crosshairOnEdgeDragging 0\n                -popupMenuScript \"nodeEdBuildPanelMenus\" \n                -showNamespace 1\n                -showShapes 1\n                -showSGShapes 0\n                -showTransforms 1\n                -useAssets 1\n                -syncedSelection 1\n                -extendToShapes 1\n                -editorMode \"default\" \n                -hasWatchpoint 0\n                $editorName;\n\t\t\tif (!$useSceneConfig) {\n\t\t\t\tpanel -e -l $label $panelName;\n\t\t\t}\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"createNodePanel\" (localizedPanelLabel(\"Create Node\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Create Node\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n"
+		+ "\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"polyTexturePlacementPanel\" (localizedPanelLabel(\"UV Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"UV Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"renderWindowPanel\" (localizedPanelLabel(\"Render View\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Render View\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"shapePanel\" (localizedPanelLabel(\"Shape Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tshapePanel -edit -l (localizedPanelLabel(\"Shape Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n"
+		+ "\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"posePanel\" (localizedPanelLabel(\"Pose Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tposePanel -edit -l (localizedPanelLabel(\"Pose Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"dynRelEdPanel\" (localizedPanelLabel(\"Dynamic Relationships\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Dynamic Relationships\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"relationshipPanel\" (localizedPanelLabel(\"Relationship Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Relationship Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n"
+		+ "\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"referenceEditorPanel\" (localizedPanelLabel(\"Reference Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Reference Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"componentEditorPanel\" (localizedPanelLabel(\"Component Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Component Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"dynPaintScriptedPanelType\" (localizedPanelLabel(\"Paint Effects\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Paint Effects\")) -mbv $menusOkayInPanels  $panelName;\n"
+		+ "\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"scriptEditorPanel\" (localizedPanelLabel(\"Script Editor\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Script Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"profilerPanel\" (localizedPanelLabel(\"Profiler Tool\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Profiler Tool\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"contentBrowserPanel\" (localizedPanelLabel(\"Content Browser\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Content Browser\")) -mbv $menusOkayInPanels  $panelName;\n"
+		+ "\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\tif ($useSceneConfig) {\n        string $configName = `getPanel -cwl (localizedPanelLabel(\"Current Layout\"))`;\n        if (\"\" != $configName) {\n\t\t\tpanelConfiguration -edit -label (localizedPanelLabel(\"Current Layout\")) \n\t\t\t\t-userCreated false\n\t\t\t\t-defaultImage \"vacantCell.xP:/\"\n\t\t\t\t-image \"\"\n\t\t\t\t-sc false\n\t\t\t\t-configString \"global string $gMainPane; paneLayout -e -cn \\\"single\\\" -ps 1 100 100 $gMainPane;\"\n\t\t\t\t-removeAllPanels\n\t\t\t\t-ap false\n\t\t\t\t\t(localizedPanelLabel(\"Persp View\")) \n\t\t\t\t\t\"modelPanel\"\n"
+		+ "\t\t\t\t\t\"$panelName = `modelPanel -unParent -l (localizedPanelLabel(\\\"Persp View\\\")) -mbv $menusOkayInPanels `;\\n$editorName = $panelName;\\nmodelEditor -e \\n    -cam `findStartUpCamera persp` \\n    -useInteractiveMode 0\\n    -displayLights \\\"default\\\" \\n    -displayAppearance \\\"smoothShaded\\\" \\n    -activeOnly 0\\n    -ignorePanZoom 0\\n    -wireframeOnShaded 0\\n    -headsUpDisplay 1\\n    -holdOuts 1\\n    -selectionHiliteDisplay 1\\n    -useDefaultMaterial 0\\n    -bufferMode \\\"double\\\" \\n    -twoSidedLighting 0\\n    -backfaceCulling 0\\n    -xray 0\\n    -jointXray 0\\n    -activeComponentsXray 0\\n    -displayTextures 0\\n    -smoothWireframe 0\\n    -lineWidth 1\\n    -textureAnisotropic 0\\n    -textureHilight 1\\n    -textureSampling 2\\n    -textureDisplay \\\"modulate\\\" \\n    -textureMaxSize 32768\\n    -fogging 0\\n    -fogSource \\\"fragment\\\" \\n    -fogMode \\\"linear\\\" \\n    -fogStart 0\\n    -fogEnd 100\\n    -fogDensity 0.1\\n    -fogColor 0.5 0.5 0.5 1 \\n    -depthOfFieldPreview 1\\n    -maxConstantTransparency 1\\n    -rendererName \\\"vp2Renderer\\\" \\n    -objectFilterShowInHUD 1\\n    -isFiltered 0\\n    -colorResolution 256 256 \\n    -bumpResolution 512 512 \\n    -textureCompression 0\\n    -transparencyAlgorithm \\\"frontAndBackCull\\\" \\n    -transpInShadows 0\\n    -cullingOverride \\\"none\\\" \\n    -lowQualityLighting 0\\n    -maximumNumHardwareLights 1\\n    -occlusionCulling 0\\n    -shadingModel 0\\n    -useBaseRenderer 0\\n    -useReducedRenderer 0\\n    -smallObjectCulling 0\\n    -smallObjectThreshold -1 \\n    -interactiveDisableShadows 0\\n    -interactiveBackFaceCull 0\\n    -sortTransparent 1\\n    -controllers 1\\n    -nurbsCurves 1\\n    -nurbsSurfaces 1\\n    -polymeshes 1\\n    -subdivSurfaces 1\\n    -planes 1\\n    -lights 1\\n    -cameras 1\\n    -controlVertices 1\\n    -hulls 1\\n    -grid 1\\n    -imagePlane 1\\n    -joints 1\\n    -ikHandles 1\\n    -deformers 1\\n    -dynamics 1\\n    -particleInstancers 1\\n    -fluids 1\\n    -hairSystems 1\\n    -follicles 1\\n    -nCloths 1\\n    -nParticles 1\\n    -nRigids 1\\n    -dynamicConstraints 1\\n    -locators 1\\n    -manipulators 1\\n    -pluginShapes 1\\n    -dimensions 1\\n    -handles 1\\n    -pivots 1\\n    -textures 1\\n    -strokes 1\\n    -motionTrails 1\\n    -clipGhosts 1\\n    -greasePencils 1\\n    -shadows 0\\n    -captureSequenceNumber -1\\n    -width 1289\\n    -height 707\\n    -sceneRenderFilter 0\\n    $editorName;\\nmodelEditor -e -viewSelected 0 $editorName;\\nmodelEditor -e \\n    -pluginObjects \\\"gpuCacheDisplayFilter\\\" 1 \\n    $editorName\"\n"
+		+ "\t\t\t\t\t\"modelPanel -edit -l (localizedPanelLabel(\\\"Persp View\\\")) -mbv $menusOkayInPanels  $panelName;\\n$editorName = $panelName;\\nmodelEditor -e \\n    -cam `findStartUpCamera persp` \\n    -useInteractiveMode 0\\n    -displayLights \\\"default\\\" \\n    -displayAppearance \\\"smoothShaded\\\" \\n    -activeOnly 0\\n    -ignorePanZoom 0\\n    -wireframeOnShaded 0\\n    -headsUpDisplay 1\\n    -holdOuts 1\\n    -selectionHiliteDisplay 1\\n    -useDefaultMaterial 0\\n    -bufferMode \\\"double\\\" \\n    -twoSidedLighting 0\\n    -backfaceCulling 0\\n    -xray 0\\n    -jointXray 0\\n    -activeComponentsXray 0\\n    -displayTextures 0\\n    -smoothWireframe 0\\n    -lineWidth 1\\n    -textureAnisotropic 0\\n    -textureHilight 1\\n    -textureSampling 2\\n    -textureDisplay \\\"modulate\\\" \\n    -textureMaxSize 32768\\n    -fogging 0\\n    -fogSource \\\"fragment\\\" \\n    -fogMode \\\"linear\\\" \\n    -fogStart 0\\n    -fogEnd 100\\n    -fogDensity 0.1\\n    -fogColor 0.5 0.5 0.5 1 \\n    -depthOfFieldPreview 1\\n    -maxConstantTransparency 1\\n    -rendererName \\\"vp2Renderer\\\" \\n    -objectFilterShowInHUD 1\\n    -isFiltered 0\\n    -colorResolution 256 256 \\n    -bumpResolution 512 512 \\n    -textureCompression 0\\n    -transparencyAlgorithm \\\"frontAndBackCull\\\" \\n    -transpInShadows 0\\n    -cullingOverride \\\"none\\\" \\n    -lowQualityLighting 0\\n    -maximumNumHardwareLights 1\\n    -occlusionCulling 0\\n    -shadingModel 0\\n    -useBaseRenderer 0\\n    -useReducedRenderer 0\\n    -smallObjectCulling 0\\n    -smallObjectThreshold -1 \\n    -interactiveDisableShadows 0\\n    -interactiveBackFaceCull 0\\n    -sortTransparent 1\\n    -controllers 1\\n    -nurbsCurves 1\\n    -nurbsSurfaces 1\\n    -polymeshes 1\\n    -subdivSurfaces 1\\n    -planes 1\\n    -lights 1\\n    -cameras 1\\n    -controlVertices 1\\n    -hulls 1\\n    -grid 1\\n    -imagePlane 1\\n    -joints 1\\n    -ikHandles 1\\n    -deformers 1\\n    -dynamics 1\\n    -particleInstancers 1\\n    -fluids 1\\n    -hairSystems 1\\n    -follicles 1\\n    -nCloths 1\\n    -nParticles 1\\n    -nRigids 1\\n    -dynamicConstraints 1\\n    -locators 1\\n    -manipulators 1\\n    -pluginShapes 1\\n    -dimensions 1\\n    -handles 1\\n    -pivots 1\\n    -textures 1\\n    -strokes 1\\n    -motionTrails 1\\n    -clipGhosts 1\\n    -greasePencils 1\\n    -shadows 0\\n    -captureSequenceNumber -1\\n    -width 1289\\n    -height 707\\n    -sceneRenderFilter 0\\n    $editorName;\\nmodelEditor -e -viewSelected 0 $editorName;\\nmodelEditor -e \\n    -pluginObjects \\\"gpuCacheDisplayFilter\\\" 1 \\n    $editorName\"\n"
+		+ "\t\t\t\t$configName;\n\n            setNamedPanelLayout (localizedPanelLabel(\"Current Layout\"));\n        }\n\n        panelHistory -e -clear mainPanelHistory;\n        sceneUIReplacement -clear;\n\t}\n\n\ngrid -spacing 5 -size 12 -divisions 5 -displayAxes yes -displayGridLines yes -displayDivisionLines yes -displayPerspectiveLabels no -displayOrthographicLabels no -displayAxesBold yes -perspectiveLabelPosition axis -orthographicLabelPosition edge;\nviewManip -drawCompass 0 -compassAngle 0 -frontParameters \"\" -homeParameters \"\" -selectionLockParameters \"\";\n}\n");
+	setAttr ".st" 3;
+createNode script -n "sceneConfigurationScriptNode";
+	rename -uid "1C72F9C0-0003-FC42-60C2-401F00000607";
+	setAttr ".b" -type "string" "playbackOptions -min 1001 -max 1024 -ast 900 -aet 1029 ";
+	setAttr ".st" 6;
+select -ne :time1;
+	setAttr ".o" 0;
+select -ne :renderPartition;
+	setAttr -s 2 ".st";
+select -ne :renderGlobalsList1;
+select -ne :defaultShaderList1;
+	setAttr -s 4 ".s";
+select -ne :postProcessList1;
+	setAttr -s 2 ".p";
+select -ne :defaultRenderingList1;
+	setAttr -s 6 ".r";
+select -ne :initialShadingGroup;
+	setAttr -s 8 ".dsm";
+connectAttr "polyCone1.out" "pCone1Shape.i";
+relationship "link" ":lightLinker1" ":initialShadingGroup.message" ":defaultLightSet.message";
+relationship "link" ":lightLinker1" ":initialParticleSE.message" ":defaultLightSet.message";
+relationship "shadowLink" ":lightLinker1" ":initialShadingGroup.message" ":defaultLightSet.message";
+relationship "shadowLink" ":lightLinker1" ":initialParticleSE.message" ":defaultLightSet.message";
+connectAttr "layerManager.dli[0]" "defaultLayer.id";
+connectAttr "renderLayerManager.rlmi[0]" "defaultRenderLayer.rlid";
+connectAttr ":PxrPathTracer.msg" ":rmanGlobals.ri_integrator";
+connectAttr "rmanDefaultBakeDisplay.msg" ":rmanBakingGlobals.displays[0]";
+connectAttr ":bake_PxrPathTracer.msg" ":rmanBakingGlobals.ri_integrator";
+connectAttr "diffuse.msg" "rmanDefaultBakeDisplay.displayChannels[0]";
+connectAttr "a.msg" "rmanDefaultBakeDisplay.displayChannels[1]";
+connectAttr "d_openexr.msg" "rmanDefaultBakeDisplay.displayType";
+connectAttr "defaultRenderLayer.msg" ":defaultRenderingList1.r" -na;
+connectAttr ":rmanGlobals.msg" ":defaultRenderingList1.r" -na;
+connectAttr ":PxrPathTracer.msg" ":defaultRenderingList1.r" -na;
+connectAttr ":rmanBakingGlobals.msg" ":defaultRenderingList1.r" -na;
+connectAttr ":bake_PxrPathTracer.msg" ":defaultRenderingList1.r" -na;
+connectAttr "d_openexr.msg" ":defaultRenderingList1.r" -na;
+connectAttr "Cube1Shape.iog" ":initialShadingGroup.dsm" -na;
+connectAttr "pCone1Shape.iog" ":initialShadingGroup.dsm" -na;
+connectAttr "pCone2Shape.iog" ":initialShadingGroup.dsm" -na;
+connectAttr "Cube2Shape.iog" ":initialShadingGroup.dsm" -na;
+connectAttr "|Top|Mid_Transformation|GrpRoot3|Conflicting1|Conflicting1Shape.iog" ":initialShadingGroup.dsm"
+		 -na;
+connectAttr "|Top|Mid_Transformation|GrpRoot3|Conflicting2|Conflicting2Shape.iog" ":initialShadingGroup.dsm"
+		 -na;
+connectAttr "|Top|Mid_Transformation|GrpRoot2|Conflicting1|Conflicting1Shape.iog" ":initialShadingGroup.dsm"
+		 -na;
+connectAttr "|Top|Mid_Transformation|GrpRoot2|Conflicting2|Conflicting2Shape.iog" ":initialShadingGroup.dsm"
+		 -na;
+// End of UsdExportRootTest.ma

--- a/test/lib/usd/translators/UsdExportRootTest/test_usdExport.py
+++ b/test/lib/usd/translators/UsdExportRootTest/test_usdExport.py
@@ -12,7 +12,7 @@ def main():
     cmds.file('{}/UsdExportRootTest.ma'.format(scn_dir), type="mayaAscii", o=True)
    
     
-    
+    '''
     select(['pCone1', 'Cube1'], r=True)
     cmds.usdExport(file='{}/only_set1_to_top.usda'.format(tmpdir), sl=True, root="Top")
     cmds.usdExport(file='{}/only_set1_to_Grp1.usda'.format(tmpdir), sl=True, root="GrpRoot1")
@@ -31,12 +31,17 @@ def main():
     # no root, only selection
     select(['pCone1', 'Cube1', 'pCone2', 'Cube2'], r=True)
     cmds.usdExport(file='{}/onlySelected.usda'.format(tmpdir), sl=True)
-    cmds.usdExport(file='{}/onlySelectedOldBehavior.usda'.format(tmpdir), sl=True, root='|')
+    '''
+    select(['pCone1', 'Cube1', 'pCone2', 'Cube2'], r=True)
+    cmds.usdExport(file='{}/onlySelectedRootEmpty.usda'.format(tmpdir), sl=True, root='')
+    cmds.usdExport(file='{}/regularSelectedToTop.usda'.format(tmpdir), sl=True)
     
+    '''
     # neither root nor selected
     cmds.usdExport(file='{}/export_all.usda'.format(tmpdir))
 
     # select(['GrpRoot2|Conflicting1', 'GrpRoot2|Conflicting2', 'GrpRoot3|Conflicting1', 'GrpRoot3|Conflicting2'], r=True)
     # cmds.usdExport(file='{}/conflictingNames.usda'.format(tmpdir), sl=True, root=[str(Xf) for Xf in ls(sl=True)])
-
+    '''
+    
 main()

--- a/test/lib/usd/translators/UsdExportRootTest/test_usdExport.py
+++ b/test/lib/usd/translators/UsdExportRootTest/test_usdExport.py
@@ -12,7 +12,6 @@ def main():
     cmds.file('{}/UsdExportRootTest.ma'.format(scn_dir), type="mayaAscii", o=True)
    
     
-    '''
     select(['pCone1', 'Cube1'], r=True)
     cmds.usdExport(file='{}/only_set1_to_top.usda'.format(tmpdir), sl=True, root="Top")
     cmds.usdExport(file='{}/only_set1_to_Grp1.usda'.format(tmpdir), sl=True, root="GrpRoot1")
@@ -31,7 +30,6 @@ def main():
     # no root, only selection
     select(['pCone1', 'Cube1', 'pCone2', 'Cube2'], r=True)
     cmds.usdExport(file='{}/onlySelected.usda'.format(tmpdir), sl=True)
-    '''
     select(['pCone1', 'Cube1', 'pCone2', 'Cube2'], r=True)
     cmds.usdExport(file='{}/onlySelectedRootEmpty.usda'.format(tmpdir), sl=True, root='')
     cmds.usdExport(file='{}/regularSelectedToTop.usda'.format(tmpdir), sl=True)

--- a/test/lib/usd/translators/UsdExportRootTest/test_usdExport.py
+++ b/test/lib/usd/translators/UsdExportRootTest/test_usdExport.py
@@ -1,0 +1,42 @@
+from pymel.core import *
+import maya.cmds as cmds
+import tempfile
+import os
+
+def main():
+    tmpdir = tempfile.gettempdir()
+    scn_dir = os.path.dirname(os.path.realpath(__file__))
+    
+    cmds.loadPlugin('mayaUsdPlugin')
+    cmds.loadPlugin('pxrUsd')
+    cmds.file('{}/UsdExportRootTest.ma'.format(scn_dir), type="mayaAscii", o=True)
+   
+    
+    
+    select(['pCone1', 'Cube1'], r=True)
+    cmds.usdExport(file='{}/only_set1_to_top.usda'.format(tmpdir), sl=True, root="Top")
+    cmds.usdExport(file='{}/only_set1_to_Grp1.usda'.format(tmpdir), sl=True, root="GrpRoot1")
+    cmds.usdExport(file='{}/only_set1_noParents.usda'.format(tmpdir), sl=True, root=[str(Xf) for Xf in ls(sl=True)])
+
+    select(['pCone1', 'Cube1', 'pCone2', 'Cube2'], r=True)
+    cmds.usdExport(file='{}/set1n2_to_top.usda'.format(tmpdir), sl=True, root="Top")
+    cmds.usdExport(file='{}/set1n2_noParents.usda'.format(tmpdir), sl=True, root=[str(Xf) for Xf in ls(sl=True)])
+    
+    select(['pCone1'], r=True)
+    cmds.usdExport(file='{}/cone1_to_Mid_NoTrans.usda'.format(tmpdir), sl=True, root="Mid_NoTransformation")
+
+    # no selection, only roots
+    cmds.usdExport(file='{}/onlyRoots.usda'.format(tmpdir), root=['Mid_Transformation', 'Mid_NoTransformation'])
+
+    # no root, only selection
+    select(['pCone1', 'Cube1', 'pCone2', 'Cube2'], r=True)
+    cmds.usdExport(file='{}/onlySelected.usda'.format(tmpdir), sl=True)
+    cmds.usdExport(file='{}/onlySelectedOldBehavior.usda'.format(tmpdir), sl=True, root='|')
+    
+    # neither root nor selected
+    cmds.usdExport(file='{}/export_all.usda'.format(tmpdir))
+
+    # select(['GrpRoot2|Conflicting1', 'GrpRoot2|Conflicting2', 'GrpRoot3|Conflicting1', 'GrpRoot3|Conflicting2'], r=True)
+    # cmds.usdExport(file='{}/conflictingNames.usda'.format(tmpdir), sl=True, root=[str(Xf) for Xf in ls(sl=True)])
+
+main()

--- a/test/lib/usd/translators/UsdExportRootTest/test_usdExport.py
+++ b/test/lib/usd/translators/UsdExportRootTest/test_usdExport.py
@@ -36,6 +36,7 @@ def main():
     cmds.usdExport(file='{}/onlySelectedRootEmpty.usda'.format(tmpdir), sl=True, root='')
     cmds.usdExport(file='{}/regularSelectedToTop.usda'.format(tmpdir), sl=True)
     
+    cmds.usdExport(file='{}/mixedRootsAndSelRoots.usda'.format(tmpdir), sl=True, root=['Mid_Transformation', ''])
     '''
     # neither root nor selected
     cmds.usdExport(file='{}/export_all.usda'.format(tmpdir))


### PR DESCRIPTION
"-root/-rt" flag (multi-use) to USD Export plugin, can be used to specify the roots/parents the exporter shouldn't go beyond them when writing out the USD, the objects/groups passed to the root arg then becomes at the root of the written USD.

Enhancement:
------------

- If the root flag was given alone, all given objects/groups and their children will be exported to the root of the USD.

- Passing 'root' in combination with the 'exportSelected' flag, then the selected objects are exported under all their parents till the given root transform, all intermediate transform nodes are written as well, however, the objects under these exported parents will be ignored unless they are selected.

- if empty string "" is passed to root, each selected object/transform will be treated as a root by its own.

      usdExport(file='/path/to/usd.usda', sl=True, root='')