### PR TITLE
Creating shape/transform user custom attributes on USD Import (with anim support)

### DIFF
--- a/lib/mayaUsd/commands/baseExportCommand.cpp
+++ b/lib/mayaUsd/commands/baseExportCommand.cpp
@@ -180,6 +180,9 @@ MSyntax MayaUSDExportCommand::createSyntax()
     syntax.addFlag(kFileFlag, kFileFlagLong, MSyntax::kString);
     syntax.addFlag(kSelectionFlag, kSelectionFlagLong, MSyntax::kNoArg);
 
+    syntax.addFlag(kUserAttrFlag, kUserAttrFlagLong, MSyntax::kString);
+    syntax.makeFlagMultiUse(kUserAttrFlag);
+
     syntax.addFlag(kFilterTypesFlag, kFilterTypesFlagLong, MSyntax::kString);
     syntax.makeFlagMultiUse(kFilterTypesFlag);
 
@@ -309,6 +312,13 @@ MStatus MayaUSDExportCommand::doIt(const MArgList& args)
             = UsdMayaWriteUtil::GetTimeSamples(timeInterval, frameSamples, frameStride);
         UsdMayaJobExportArgs jobArgs
             = UsdMayaJobExportArgs::CreateFromDictionary(userArgs, dagPaths, timeSamples);
+
+        unsigned int numUserAttrs = argData.numberOfFlagUses(kUserAttrFlag);
+        for (unsigned int i = 0; i < numUserAttrs; i++) {
+            MArgList tmpArgList;
+            argData.getFlagArgumentList(kUserAttrFlag, i, tmpArgList);
+            jobArgs.userAttrNames.emplace_back(tmpArgList.asString(0).asChar());
+        }
 
         unsigned int numFilteredTypes = argData.numberOfFlagUses(kFilterTypesFlag);
         for (unsigned int i = 0; i < numFilteredTypes; i++) {

--- a/lib/mayaUsd/commands/baseExportCommand.h
+++ b/lib/mayaUsd/commands/baseExportCommand.h
@@ -83,6 +83,8 @@ public:
     // Short and Long forms of flags defined by this command itself:
     static constexpr auto kAppendFlag = "a";
     static constexpr auto kAppendFlagLong = "append";
+    static constexpr auto kUserAttrFlag = "u";
+    static constexpr auto kUserAttrFlagLong = "userattr";
     static constexpr auto kFilterTypesFlag = "ft";
     static constexpr auto kFilterTypesFlagLong = "filterTypes";
     static constexpr auto kFileFlag = "f";

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -206,6 +206,9 @@ struct UsdMayaJobExportArgs
     /// data should be exported.
     const std::vector<double> timeSamples;
 
+    // user custom attributes from the export command directly using the -userattr multi-flag
+    std::vector<std::string> userAttrNames;
+
     // This path is provided when dealing with variants
     // where a _BaseModel_ root path is used instead of
     // the model path. This to allow a proper internal reference.

--- a/lib/mayaUsd/fileio/primWriter.cpp
+++ b/lib/mayaUsd/fileio/primWriter.cpp
@@ -193,6 +193,11 @@ void UsdMayaPrimWriter::Write(const UsdTimeCode& usdTime)
             GetMayaObject(), _usdPrim, _GetSparseValueWriter());
     }
 
+    // write out user-tagged attributes as given by the multi-flag -userattr
+    UsdMayaWriteUtil::WriteUserAttributes(
+        GetMayaObject(), _usdPrim, usdTime, _writeJobCtx, _GetSparseValueWriter());
+
+
     // Write out user-tagged attributes, which are supported at default time
     // and at animated time-samples.
     UsdMayaWriteUtil::WriteUserExportedAttributes(

--- a/lib/mayaUsd/fileio/translators/CMakeLists.txt
+++ b/lib/mayaUsd/fileio/translators/CMakeLists.txt
@@ -17,22 +17,26 @@ target_sources(${PROJECT_NAME}
         translatorUtil.cpp
         translatorXformable.cpp
         translatorXformable_decompose.cpp
+        NodeHelper.cpp
+        DgNodeHelper.cpp
 )
 
 set(HEADERS
-    skelBindingsProcessor.h
-    translatorCamera.h
-    translatorCurves.h
-    translatorGprim.h
-    translatorMaterial.h
-    translatorMayaReference.h
-    translatorMesh.h
-    translatorNurbsPatch.h
-    translatorPrim.h
-    translatorRfMLight.h
-    translatorSkel.h
-    translatorUtil.h
-    translatorXformable.h
+        skelBindingsProcessor.h
+        translatorCamera.h
+        translatorCurves.h
+        translatorGprim.h
+        translatorMaterial.h
+        translatorMayaReference.h
+        translatorMesh.h
+        translatorNurbsPatch.h
+        translatorPrim.h
+        translatorRfMLight.h
+        translatorSkel.h
+        translatorUtil.h
+        translatorXformable.h
+        NodeHelper.h
+        DgNodeHelper.h
 )
 
 # -----------------------------------------------------------------------------

--- a/lib/mayaUsd/fileio/translators/DgNodeHelper.cpp
+++ b/lib/mayaUsd/fileio/translators/DgNodeHelper.cpp
@@ -1308,6 +1308,7 @@ MStatus DgNodeHelper::setVisAttrAnim(
     return MS::kSuccess;
 }
 
+
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setClippingRangeAttrAnim(
     const MObject       node,

--- a/lib/mayaUsd/fileio/translators/DgNodeHelper.cpp
+++ b/lib/mayaUsd/fileio/translators/DgNodeHelper.cpp
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "AL/usdmaya/utils/DgNodeHelper.h"
+#include "mayaUsd/fileio/translators/DgNodeHelper.h"
 
-#include "AL/maya/utils/NodeHelper.h"
+#include <mayaUsd/fileio/translators/NodeHelper.h>
 
 #include <mayaUsdUtils/ALHalf.h>
 #include <mayaUsdUtils/SIMD.h>
@@ -37,130 +37,126 @@
 
 #include <iostream>
 
-namespace AL {
-namespace usdmaya {
-namespace utils {
-
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setFloat(const MObject node, const MObject attr, float value)
 {
-    const char* const errorString = "float error";
+    // const char* const errorString = "float error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.setValue(value), errorString);
+    plug.setValue(value); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setAngle(const MObject node, const MObject attr, MAngle value)
 {
-    const char* const errorString = "DgNodeHelper::setAngle";
+    // const char* const errorString = "DgNodeHelper::setAngle";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.setValue(value), errorString);
+    plug.setValue(value); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setTime(const MObject node, const MObject attr, MTime value)
 {
-    const char* const errorString = "DgNodeHelper::setTime";
+    // const char* const errorString = "DgNodeHelper::setTime";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.setValue(value), errorString);
+    plug.setValue(value); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setDistance(const MObject node, const MObject attr, MDistance value)
 {
-    const char* const errorString = "DgNodeHelper::setDistance";
+    // const char* const errorString = "DgNodeHelper::setDistance";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.setValue(value), errorString);
+    plug.setValue(value); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setDouble(MObject node, MObject attr, double value)
 {
-    const char* const errorString = "double error";
+    // const char* const errorString = "double error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.setValue(value), errorString);
+    plug.setValue(value); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setBool(MObject node, MObject attr, bool value)
 {
-    const char* const errorString = "int error";
+    // const char* const errorString = "int error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.setValue(value), errorString);
+    plug.setValue(value); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setInt8(MObject node, MObject attr, int8_t value)
 {
-    const char* const errorString = "int error";
+    // const char* const errorString = "int error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.setChar(value), errorString);
+    plug.setChar(value); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setInt16(MObject node, MObject attr, int16_t value)
 {
-    const char* const errorString = "int error";
+    // const char* const errorString = "int error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.setShort(value), errorString);
+    plug.setShort(value); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setInt32(MObject node, MObject attr, int32_t value)
 {
-    const char* const errorString = "int error";
+    // const char* const errorString = "int error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.setValue(value), errorString);
+    plug.setValue(value); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setInt64(MObject node, MObject attr, int64_t value)
 {
-    const char* const errorString = "int64 error";
+    // const char* const errorString = "int64 error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.setInt64(value), errorString);
+    plug.setInt64(value); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setVec3(MObject node, MObject attr, float x, float y, float z)
 {
-    const char* const errorString = "vec3f error";
+    // const char* const errorString = "vec3f error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(x), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(y), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).setValue(z), errorString);
+    plug.child(0).setValue(x); // , errorString);
+    plug.child(1).setValue(y); // , errorString);
+    plug.child(2).setValue(z); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setVec3(MObject node, MObject attr, double x, double y, double z)
 {
-    const char* const errorString = "vec3d error";
+    // const char* const errorString = "vec3d error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(x), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(y), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).setValue(z), errorString);
+    plug.child(0).setValue(x); // , errorString);
+    plug.child(1).setValue(y); // , errorString);
+    plug.child(2).setValue(z); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setVec3(MObject node, MObject attr, MAngle x, MAngle y, MAngle z)
 {
-    const char* const errorString = "vec3d error";
+    // const char* const errorString = "vec3d error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(x), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(y), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).setValue(z), errorString);
+    plug.child(0).setValue(x); // , errorString);
+    plug.child(1).setValue(y); // , errorString);
+    plug.child(2).setValue(z); // , errorString);
     return MS::kSuccess;
 }
 
@@ -175,8 +171,7 @@ MStatus DgNodeHelper::setBoolArray(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
 
     for (size_t i = 0; i != count; ++i) {
         plug.elementByLogicalIndex(i).setBool(values[i]);
@@ -195,8 +190,7 @@ MStatus DgNodeHelper::setBoolArray(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(values.size()), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(values.size()); // , "DgNodeHelper: attribute array could not be resized");
 
     for (size_t i = 0, n = values.size(); i != n; ++i) {
         plug.elementByLogicalIndex(i).setBool(values[i]);
@@ -216,8 +210,7 @@ MStatus DgNodeHelper::setInt8Array(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
 
     for (size_t i = 0; i != count; ++i) {
         plug.elementByLogicalIndex(i).setChar(values[i]);
@@ -237,8 +230,7 @@ MStatus DgNodeHelper::setInt16Array(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
 
     for (size_t i = 0; i != count; ++i) {
         plug.elementByLogicalIndex(i).setShort(values[i]);
@@ -257,9 +249,8 @@ MStatus DgNodeHelper::setInt32Array(
     MPlug plug(node, attribute);
     if (!plug || !plug.isArray())
         return MS::kFailure;
-
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
 
     for (size_t i = 0; i != count; ++i) {
         plug.elementByLogicalIndex(i).setValue(values[i]);
@@ -278,9 +269,8 @@ MStatus DgNodeHelper::setInt64Array(
     MPlug plug(node, attribute);
     if (!plug || !plug.isArray())
         return MS::kFailure;
-
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    
+    plug.setNumElements(count); // , "DgNodeHelper: attribute array could not be resized");
 
     for (size_t i = 0; i != count; ++i) {
         plug.elementByLogicalIndex(i).setInt64(values[i]);
@@ -299,9 +289,8 @@ MStatus DgNodeHelper::setHalfArray(
     MPlug plug(node, attribute);
     if (!plug || !plug.isArray())
         return MS::kFailure;
-
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    
+    plug.setNumElements(count); // , "DgNodeHelper: attribute array could not be resized");
 
     size_t count8 = count & ~0x7ULL;
     for (size_t j = 0; j != count8; j += 8) {
@@ -363,8 +352,7 @@ MStatus DgNodeHelper::setFloatArray(
                 return MS::kSuccess;
             }
         } else {
-            AL_MAYA_CHECK_ERROR(
-                plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+            plug.setNumElements(count); // , "DgNodeHelper: attribute array could not be resized");
             for (size_t i = 0; i != count; ++i) {
                 plug.elementByLogicalIndex(i).setFloat(values[i]);
             }
@@ -394,8 +382,7 @@ MStatus DgNodeHelper::setDoubleArray(
                 return MS::kSuccess;
             }
         } else {
-            AL_MAYA_CHECK_ERROR(
-                plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+                plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
             for (size_t i = 0; i != count; ++i) {
                 plug.elementByLogicalIndex(i).setDouble(values[i]);
             }
@@ -416,8 +403,7 @@ MStatus DgNodeHelper::setVec2Array(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
 
     for (size_t i = 0, j = 0; i != count; ++i, j += 2) {
         auto v = plug.elementByLogicalIndex(i);
@@ -439,8 +425,7 @@ MStatus DgNodeHelper::setVec2Array(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
 
     size_t count4 = count & ~0x3ULL;
     for (size_t i = 0, j = 0; i != count4; i += 4, j += 8) {
@@ -492,8 +477,7 @@ MStatus DgNodeHelper::setVec2Array(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
 
     for (size_t i = 0, j = 0; i != count; ++i, j += 2) {
         auto v = plug.elementByLogicalIndex(i);
@@ -515,8 +499,7 @@ MStatus DgNodeHelper::setVec2Array(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
 
     for (size_t i = 0, j = 0; i != count; ++i, j += 2) {
         auto v = plug.elementByLogicalIndex(i);
@@ -538,8 +521,8 @@ MStatus DgNodeHelper::setVec3Array(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
+
     for (size_t i = 0, j = 0; i != count; ++i, j += 3) {
         auto v = plug.elementByLogicalIndex(i);
         v.child(0).setInt(values[j]);
@@ -560,8 +543,8 @@ MStatus DgNodeHelper::setVec3Array(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
+
     size_t count8 = count & ~0x7ULL;
     for (size_t i = 0, j = 0; i != count8; i += 8, j += 24) {
         float f[24];
@@ -604,8 +587,7 @@ MStatus DgNodeHelper::setVec3Array(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
 
     for (size_t i = 0, j = 0; i != count; ++i, j += 3) {
         auto v = plug.elementByLogicalIndex(i);
@@ -628,8 +610,7 @@ MStatus DgNodeHelper::setVec3Array(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
 
     for (size_t i = 0, j = 0; i != count; ++i, j += 3) {
         auto v = plug.elementByLogicalIndex(i);
@@ -653,8 +634,7 @@ MStatus DgNodeHelper::setVec4Array(
         return MS::kFailure;
     }
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
     size_t count2 = count & ~0x1ULL;
 
     for (size_t i = 0, j = 0; i != count2; i += 2, j += 8) {
@@ -695,8 +675,7 @@ MStatus DgNodeHelper::setVec4Array(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
 
     for (size_t i = 0, j = 0; i != count; ++i, j += 4) {
         auto v = plug.elementByLogicalIndex(i);
@@ -720,8 +699,7 @@ MStatus DgNodeHelper::setVec4Array(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
 
     for (size_t i = 0, j = 0; i != count; ++i, j += 4) {
         auto v = plug.elementByLogicalIndex(i);
@@ -745,8 +723,7 @@ MStatus DgNodeHelper::setVec4Array(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
 
     for (size_t i = 0, j = 0; i != count; ++i, j += 4) {
         auto v = plug.elementByLogicalIndex(i);
@@ -778,9 +755,9 @@ MStatus DgNodeHelper::setMatrix4x4Array(
 
         MFnMatrixArrayData fn;
         MObject            data = fn.create(arrayData, &status);
-        AL_MAYA_CHECK_ERROR2(status, MString("Count not set array value"));
+//        AL_MAYA_CHECK_ERROR2(status, MString("Count not set array value"));
         status = plug.setValue(data);
-        AL_MAYA_CHECK_ERROR2(status, MString("Count not set array value"));
+//        AL_MAYA_CHECK_ERROR2(status, MString("Count not set array value"));
     } else {
         // Yes this is horrible. It would appear that as of Maya 2017, setting the contents of
         // matrix array attributes doesn't work. Well, at least for dynamic attributes. Using an
@@ -867,9 +844,9 @@ MStatus DgNodeHelper::setMatrix4x4Array(
 
         MFnMatrixArrayData fn;
         MObject            data = fn.create(arrayData, &status);
-        AL_MAYA_CHECK_ERROR2(status, MString("Count not set array value"));
+//        AL_MAYA_CHECK_ERROR2(status, MString("Count not set array value"));
         status = plug.setValue(data);
-        AL_MAYA_CHECK_ERROR2(status, MString("Count not set array value"));
+//        AL_MAYA_CHECK_ERROR2(status, MString("Count not set array value"));
     } else {
         // I can't seem to create a multi of arrays within the Maya API (without using an array data
         // builder within a compute).
@@ -921,8 +898,7 @@ MStatus DgNodeHelper::setTimeArray(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
 
 #if AL_UTILS_ENABLE_SIMD
     const f128   unitConversion128 = splat4f(unitConversion);
@@ -972,8 +948,7 @@ MStatus DgNodeHelper::setAngleArray(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
 
 #if AL_UTILS_ENABLE_SIMD
     const f128   unitConversion128 = splat4f(unitConversion);
@@ -1023,8 +998,7 @@ MStatus DgNodeHelper::setDistanceArray(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(count), "DgNodeHelper: attribute array could not be resized");
+    plug.setNumElements(count); //, "DgNodeHelper: attribute array could not be resized");
 
 #if AL_UTILS_ENABLE_SIMD
     const f128   unitConversion128 = splat4f(unitConversion);
@@ -1068,9 +1042,7 @@ MStatus DgNodeHelper::setUsdBoolArray(
     if (!plug || !plug.isArray())
         return MS::kFailure;
 
-    AL_MAYA_CHECK_ERROR(
-        plug.setNumElements(values.size()),
-        "DgNodeTranslator: attribute array could not be resized");
+    plug.setNumElements(values.size()); // "DgNodeTranslator: attribute array could not be resized");
 
     for (size_t i = 0, n = values.size(); i != n; ++i) {
         plug.elementByLogicalIndex(i).setBool(values[i]);
@@ -1089,8 +1061,7 @@ MStatus DgNodeHelper::prepareAnimCurve(
         return MS::kFailure;
 
     MStatus           status = MS::kSuccess;
-    const char* const errorCreate
-        = "DgNodeTranslator:prepareAnimCurve(): error creating animation curve";
+//    const char* const errorCreate = "DgNodeTranslator:prepareAnimCurve(): error creating animation curve";
     MDGModifier dgmod;
     if (plug.isDestination()) {
         MPlug sourcePlug = plug.source();
@@ -1110,7 +1081,6 @@ MStatus DgNodeHelper::prepareAnimCurve(
     }
 
     animCurveFn.create(plug, NULL, &status);
-    AL_MAYA_CHECK_ERROR(status, errorCreate);
 
     if (!isAnimCurveTypeSupported(animCurveFn)) {
         // If we don't support the animCurve type, we rollback and clean up.
@@ -1137,7 +1107,7 @@ MStatus DgNodeHelper::setAngleAnim(
     MObjectArray*        newAnimCurves)
 {
     MStatus           status;
-    const char* const errorString = "DgNodeHelper::setAngleAnim";
+    // const char* const errorString = "DgNodeHelper::setAngleAnim";
 
     MPlug        plug(node, attr);
     MFnAnimCurve fnCurve;
@@ -1165,7 +1135,6 @@ MStatus DgNodeHelper::setAngleAnim(
             MFnAnimCurve::kTangentGlobal,
             NULL,
             &status);
-        AL_MAYA_CHECK_ERROR(status, errorString);
     }
 
     return MS::kSuccess;
@@ -1183,7 +1152,7 @@ MStatus DgNodeHelper::setFloatAttrAnim(
         return MS::kFailure;
     }
 
-    const char* const errorString = "DgNodeTranslator::setFloatAttrAnim";
+    // const char* const errorString = "DgNodeTranslator::setFloatAttrAnim";
     MStatus           status;
 
     MPlug        plug(node, attr);
@@ -1195,12 +1164,11 @@ MStatus DgNodeHelper::setFloatAttrAnim(
     std::vector<double> times;
     usdAttr.GetTimeSamples(&times);
 
-    float value;
+    double value;
     for (auto const& timeValue : times) {
         const bool retValue = usdAttr.Get(&value, timeValue);
         if (!retValue)
             continue;
-
         MTime tm(timeValue, MTime::kFilm);
         fnCurve.addKey(
             tm,
@@ -1209,7 +1177,88 @@ MStatus DgNodeHelper::setFloatAttrAnim(
             MFnAnimCurve::kTangentGlobal,
             NULL,
             &status);
-        AL_MAYA_CHECK_ERROR(status, errorString);
+    }
+
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus DgNodeHelper::setIntAttrAnim(
+    const MObject node,
+    const MObject attr,
+    UsdAttribute  usdAttr,
+    MObjectArray* newAnimCurves)
+{
+    if (!usdAttr.GetNumTimeSamples()) {
+        return MS::kFailure;
+    }
+
+    // const char* const errorString = "DgNodeTranslator::setFloatAttrAnim";
+    MStatus           status;
+
+    MPlug        plug(node, attr);
+    MFnAnimCurve fnCurve;
+    status = prepareAnimCurve(plug, fnCurve, newAnimCurves);
+    if (!status)
+        return MS::kFailure;
+
+    std::vector<double> times;
+    usdAttr.GetTimeSamples(&times);
+
+    int value;
+    for (auto const& timeValue : times) {
+        const bool retValue = usdAttr.Get(&value, timeValue);
+        if (!retValue)
+            continue;
+        MTime tm(timeValue, MTime::kFilm);
+        fnCurve.addKey(
+            tm,
+            value,
+            MFnAnimCurve::kTangentGlobal,
+            MFnAnimCurve::kTangentGlobal,
+            NULL,
+            &status);
+    }
+
+    return MS::kSuccess;
+}
+
+// ----------------------------------------------------------------------------------------------
+MStatus DgNodeHelper::setBoolAttrAnim(
+    const MObject node,
+    const MObject attr,
+    UsdAttribute  usdAttr,
+    MObjectArray* newAnimCurves)
+{
+    if (!usdAttr.GetNumTimeSamples()) {
+        return MS::kFailure;
+    }
+
+    // const char* const errorString = "DgNodeTranslator::setFloatAttrAnim";
+    MStatus           status;
+
+    MPlug        plug(node, attr);
+    MFnAnimCurve fnCurve;
+    status = prepareAnimCurve(plug, fnCurve, newAnimCurves);
+    if (!status)
+        return MS::kFailure;
+
+    std::vector<double> times;
+    usdAttr.GetTimeSamples(&times);
+
+    bool value;
+    for (auto const& timeValue : times) {
+        const bool retValue = usdAttr.Get(&value, timeValue);
+        if (!retValue)
+            continue;
+        MTime tm(timeValue, MTime::kFilm);
+        fnCurve.addKey(
+            tm,
+            value,
+            MFnAnimCurve::kTangentStep,
+            MFnAnimCurve::kTangentStep,
+            NULL,
+            &status);
     }
 
     return MS::kSuccess;
@@ -1226,7 +1275,7 @@ MStatus DgNodeHelper::setVisAttrAnim(
         return MS::kFailure;
     }
 
-    const char* const errorString = "DgNodeTranslator::setVisAttrAnim: Error adding keyframes";
+    // const char* const errorString = "DgNodeTranslator::setVisAttrAnim: Error adding keyframes";
     MStatus           status;
 
     MPlug        plug(node, attr);
@@ -1253,7 +1302,7 @@ MStatus DgNodeHelper::setVisAttrAnim(
             MFnAnimCurve::kTangentGlobal,
             NULL,
             &status);
-        AL_MAYA_CHECK_ERROR(status, errorString);
+
     }
 
     return MS::kSuccess;
@@ -1271,8 +1320,7 @@ MStatus DgNodeHelper::setClippingRangeAttrAnim(
         return MS::kFailure;
     }
 
-    const char* const errorString
-        = "DgNodeTranslator::setClippingRangeAttrAnim: Error adding keyframes";
+    // const char* const errorString = "DgNodeTranslator::setClippingRangeAttrAnim: Error adding keyframes";
     MStatus status;
 
     MPlug        nearPlug(node, nearAttr);
@@ -1304,7 +1352,7 @@ MStatus DgNodeHelper::setClippingRangeAttrAnim(
             MFnAnimCurve::kTangentGlobal,
             NULL,
             &status);
-        AL_MAYA_CHECK_ERROR(status, errorString);
+
         fnCurveFar.addKey(
             tm,
             clippingRange[1],
@@ -1312,7 +1360,7 @@ MStatus DgNodeHelper::setClippingRangeAttrAnim(
             MFnAnimCurve::kTangentGlobal,
             NULL,
             &status);
-        AL_MAYA_CHECK_ERROR(status, errorString);
+
     }
 
     return MS::kSuccess;
@@ -2767,15 +2815,15 @@ MStatus DgNodeHelper::getMatrix2x2Array(
     double* const values,
     const size_t  count)
 {
-    const char* const errorString = "getMatrix2x2Array error";
+    // const char* const errorString = "getMatrix2x2Array error";
     MPlug             arrayPlug(node, attribute);
     for (uint32_t i = 0; i < count; ++i) {
         double* const str = values + i * 4;
         MPlug         plug = arrayPlug.elementByLogicalIndex(i);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(0).getValue(str[0]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(1).getValue(str[1]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(0).getValue(str[2]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(1).getValue(str[3]), errorString);
+        plug.child(0).child(0).getValue(str[0]); // , errorString);
+        plug.child(0).child(1).getValue(str[1]); // , errorString);
+        plug.child(1).child(0).getValue(str[2]); // , errorString);
+        plug.child(1).child(1).getValue(str[3]); // , errorString);
     }
     return MS::kSuccess;
 }
@@ -2787,15 +2835,15 @@ MStatus DgNodeHelper::getMatrix2x2Array(
     float* const values,
     const size_t count)
 {
-    const char* const errorString = "getMatrix2x2Array error";
+    // const char* const errorString = "getMatrix2x2Array error";
     MPlug             arrayPlug(node, attribute);
     for (uint32_t i = 0; i < count; ++i) {
         float* const str = values + i * 4;
         MPlug        plug = arrayPlug.elementByLogicalIndex(i);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(0).getValue(str[0]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(1).getValue(str[1]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(0).getValue(str[2]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(1).getValue(str[3]), errorString);
+        plug.child(0).child(0).getValue(str[0]); // , errorString);
+        plug.child(0).child(1).getValue(str[1]); // , errorString);
+        plug.child(1).child(0).getValue(str[2]); // , errorString);
+        plug.child(1).child(1).getValue(str[3]); // , errorString);
     }
     return MS::kSuccess;
 }
@@ -2807,20 +2855,20 @@ MStatus DgNodeHelper::getMatrix3x3Array(
     double* const values,
     const size_t  count)
 {
-    const char* const errorString = "getMatrix3x3Array error";
+    // const char* const errorString = "getMatrix3x3Array error";
     MPlug             arrayPlug(node, attribute);
     for (uint32_t i = 0; i < count; ++i) {
         double* const str = values + i * 9;
         MPlug         plug = arrayPlug.elementByLogicalIndex(i);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(0).getValue(str[0]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(1).getValue(str[1]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(2).getValue(str[2]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(0).getValue(str[3]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(1).getValue(str[4]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(2).getValue(str[5]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(2).child(0).getValue(str[6]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(2).child(1).getValue(str[7]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(2).child(2).getValue(str[8]), errorString);
+        plug.child(0).child(0).getValue(str[0]); // , errorString);
+        plug.child(0).child(1).getValue(str[1]); // , errorString);
+        plug.child(0).child(2).getValue(str[2]); // , errorString);
+        plug.child(1).child(0).getValue(str[3]); // , errorString);
+        plug.child(1).child(1).getValue(str[4]); // , errorString);
+        plug.child(1).child(2).getValue(str[5]); // , errorString);
+        plug.child(2).child(0).getValue(str[6]); // , errorString);
+        plug.child(2).child(1).getValue(str[7]); // , errorString);
+        plug.child(2).child(2).getValue(str[8]); // , errorString);
     }
     return MS::kSuccess;
 }
@@ -2832,20 +2880,20 @@ MStatus DgNodeHelper::getMatrix3x3Array(
     float* const values,
     const size_t count)
 {
-    const char* const errorString = "getMatrix3x3Array error";
+    // const char* const errorString = "getMatrix3x3Array error";
     MPlug             arrayPlug(node, attribute);
     for (uint32_t i = 0; i < count; ++i) {
         float* const str = values + i * 9;
         MPlug        plug = arrayPlug.elementByLogicalIndex(i);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(0).getValue(str[0]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(1).getValue(str[1]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(2).getValue(str[2]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(0).getValue(str[3]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(1).getValue(str[4]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(2).getValue(str[5]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(2).child(0).getValue(str[6]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(2).child(1).getValue(str[7]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(2).child(2).getValue(str[8]), errorString);
+        plug.child(0).child(0).getValue(str[0]); // , errorString);
+        plug.child(0).child(1).getValue(str[1]); // , errorString);
+        plug.child(0).child(2).getValue(str[2]); // , errorString);
+        plug.child(1).child(0).getValue(str[3]); // , errorString);
+        plug.child(1).child(1).getValue(str[4]); // , errorString);
+        plug.child(1).child(2).getValue(str[5]); // , errorString);
+        plug.child(2).child(0).getValue(str[6]); // , errorString);
+        plug.child(2).child(1).getValue(str[7]); // , errorString);
+        plug.child(2).child(2).getValue(str[8]); // , errorString);
     }
     return MS::kSuccess;
 }
@@ -3314,196 +3362,196 @@ MStatus DgNodeHelper::setString(MObject node, MObject attr, const std::string& s
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setVec2(MObject node, MObject attr, const int* const xy)
 {
-    const char* const errorString = "vec2i error";
+    // const char* const errorString = "vec2i error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(xy[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(xy[1]), errorString);
+    plug.child(0).setValue(xy[0]); // , errorString);
+    plug.child(1).setValue(xy[1]); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setVec2(MObject node, MObject attr, const float* const xy)
 {
-    const char* const errorString = "vec2f error";
+    // const char* const errorString = "vec2f error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(xy[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(xy[1]), errorString);
+    plug.child(0).setValue(xy[0]); // , errorString);
+    plug.child(1).setValue(xy[1]); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setVec2(MObject node, MObject attr, const GfHalf* const xy)
 {
-    const char* const errorString = "vec2h error";
+    // const char* const errorString = "vec2h error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(MayaUsdUtils::float2half_1f(xy[0])), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(MayaUsdUtils::float2half_1f(xy[1])), errorString);
+    plug.child(0).setValue(MayaUsdUtils::float2half_1f(xy[0])); // , errorString);
+    plug.child(1).setValue(MayaUsdUtils::float2half_1f(xy[1])); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setVec2(MObject node, MObject attr, const double* const xy)
 {
-    const char* const errorString = "vec2d error";
+    // const char* const errorString = "vec2d error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(xy[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(xy[1]), errorString);
+    plug.child(0).setValue(xy[0]); // , errorString);
+    plug.child(1).setValue(xy[1]); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setVec3(MObject node, MObject attr, const int* const xyz)
 {
-    const char* const errorString = "vec3i error";
+    // const char* const errorString = "vec3i error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(xyz[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(xyz[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).setValue(xyz[2]), errorString);
+    plug.child(0).setValue(xyz[0]); // , errorString);
+    plug.child(1).setValue(xyz[1]); // , errorString);
+    plug.child(2).setValue(xyz[2]); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setVec3(MObject node, MObject attr, const float* const xyz)
 {
-    const char* const errorString = "vec3f error";
+    // const char* const errorString = "vec3f error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(xyz[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(xyz[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).setValue(xyz[2]), errorString);
+    plug.child(0).setValue(xyz[0]); // , errorString);
+    plug.child(1).setValue(xyz[1]); // , errorString);
+    plug.child(2).setValue(xyz[2]); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setVec3(MObject node, MObject attr, const GfHalf* const xyz)
 {
-    const char* const errorString = "vec3h error";
+    // const char* const errorString = "vec3h error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(MayaUsdUtils::float2half_1f(xyz[0])), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(MayaUsdUtils::float2half_1f(xyz[1])), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).setValue(MayaUsdUtils::float2half_1f(xyz[2])), errorString);
+    plug.child(0).setValue(MayaUsdUtils::float2half_1f(xyz[0])); // , errorString);
+    plug.child(1).setValue(MayaUsdUtils::float2half_1f(xyz[1])); // , errorString);
+    plug.child(2).setValue(MayaUsdUtils::float2half_1f(xyz[2])); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setVec3(MObject node, MObject attr, const double* const xyz)
 {
-    const char* const errorString = "vec3d error";
+    // const char* const errorString = "vec3d error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(xyz[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(xyz[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).setValue(xyz[2]), errorString);
+    plug.child(0).setValue(xyz[0]); // , errorString);
+    plug.child(1).setValue(xyz[1]); // , errorString);
+    plug.child(2).setValue(xyz[2]); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setVec4(MObject node, MObject attr, const int* const xyzw)
 {
-    const char* const errorString = "vec4i error";
+    // const char* const errorString = "vec4i error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(xyzw[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(xyzw[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).setValue(xyzw[2]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(3).setValue(xyzw[3]), errorString);
+    plug.child(0).setValue(xyzw[0]); // , errorString);
+    plug.child(1).setValue(xyzw[1]); // , errorString);
+    plug.child(2).setValue(xyzw[2]); // , errorString);
+    plug.child(3).setValue(xyzw[3]); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setVec4(MObject node, MObject attr, const float* const xyzw)
 {
-    const char* const errorString = "vec4f error";
+    // const char* const errorString = "vec4f error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(xyzw[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(xyzw[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).setValue(xyzw[2]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(3).setValue(xyzw[3]), errorString);
+    plug.child(0).setValue(xyzw[0]); // , errorString);
+    plug.child(1).setValue(xyzw[1]); // , errorString);
+    plug.child(2).setValue(xyzw[2]); // , errorString);
+    plug.child(3).setValue(xyzw[3]); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setVec4(MObject node, MObject attr, const double* const xyzw)
 {
-    const char* const errorString = "vec4d error";
+    // const char* const errorString = "vec4d error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(xyzw[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(xyzw[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).setValue(xyzw[2]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(3).setValue(xyzw[3]), errorString);
+    plug.child(0).setValue(xyzw[0]); // , errorString);
+    plug.child(1).setValue(xyzw[1]); // , errorString);
+    plug.child(2).setValue(xyzw[2]); // , errorString);
+    plug.child(3).setValue(xyzw[3]); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setVec4(MObject node, MObject attr, const GfHalf* const xyzw)
 {
-    const char* const errorString = "vec4h error";
+    // const char* const errorString = "vec4h error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(MayaUsdUtils::float2half_1f(xyzw[0])), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(MayaUsdUtils::float2half_1f(xyzw[1])), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).setValue(MayaUsdUtils::float2half_1f(xyzw[2])), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(3).setValue(MayaUsdUtils::float2half_1f(xyzw[3])), errorString);
+    plug.child(0).setValue(MayaUsdUtils::float2half_1f(xyzw[0])); // , errorString);
+    plug.child(1).setValue(MayaUsdUtils::float2half_1f(xyzw[1])); // , errorString);
+    plug.child(2).setValue(MayaUsdUtils::float2half_1f(xyzw[2])); // , errorString);
+    plug.child(3).setValue(MayaUsdUtils::float2half_1f(xyzw[3])); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setQuat(MObject node, MObject attr, const float* const xyzw)
 {
-    const char* const errorString = "quatf error";
+    // const char* const errorString = "quatf error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(xyzw[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(xyzw[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).setValue(xyzw[2]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(3).setValue(xyzw[3]), errorString);
+    plug.child(0).setValue(xyzw[0]); // , errorString);
+    plug.child(1).setValue(xyzw[1]); // , errorString);
+    plug.child(2).setValue(xyzw[2]); // , errorString);
+    plug.child(3).setValue(xyzw[3]); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setQuat(MObject node, MObject attr, const double* const xyzw)
 {
-    const char* const errorString = "quatd error";
+    // const char* const errorString = "quatd error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(xyzw[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(xyzw[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).setValue(xyzw[2]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(3).setValue(xyzw[3]), errorString);
+    plug.child(0).setValue(xyzw[0]); // , errorString);
+    plug.child(1).setValue(xyzw[1]); // , errorString);
+    plug.child(2).setValue(xyzw[2]); // , errorString);
+    plug.child(3).setValue(xyzw[3]); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setQuat(MObject node, MObject attr, const GfHalf* const xyzw)
 {
-    const char* const errorString = "quath error";
+    // const char* const errorString = "quath error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).setValue(MayaUsdUtils::float2half_1f(xyzw[0])), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).setValue(MayaUsdUtils::float2half_1f(xyzw[1])), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).setValue(MayaUsdUtils::float2half_1f(xyzw[2])), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(3).setValue(MayaUsdUtils::float2half_1f(xyzw[3])), errorString);
+    plug.child(0).setValue(MayaUsdUtils::float2half_1f(xyzw[0])); // , errorString);
+    plug.child(1).setValue(MayaUsdUtils::float2half_1f(xyzw[1])); // , errorString);
+    plug.child(2).setValue(MayaUsdUtils::float2half_1f(xyzw[2])); // , errorString);
+    plug.child(3).setValue(MayaUsdUtils::float2half_1f(xyzw[3])); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setString(MObject node, MObject attr, const char* const str)
 {
-    const char* const errorString = "string error";
+    // const char* const errorString = "string error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.setString(str), errorString);
+    plug.setString(str); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setMatrix4x4(MObject node, MObject attr, const double* const str)
 {
-    const char* const errorString = "matrix4x4 error - unimplemented";
+    // const char* const errorString = "matrix4x4 error - unimplemented";
     MPlug             plug(node, attr);
     MFnMatrixData     fn;
     typedef double    hack[4];
     MObject           data = fn.create(MMatrix((const hack*)str));
-    AL_MAYA_CHECK_ERROR(plug.setValue(data), errorString);
+    plug.setValue(data); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setMatrix4x4(MObject node, MObject attr, const float* const ptr)
 {
-    const char* const errorString = "matrix4x4 error - unimplemented";
+    // const char* const errorString = "matrix4x4 error - unimplemented";
     MPlug             plug(node, attr);
     MFnMatrixData     fn;
     MMatrix           m;
@@ -3549,65 +3597,65 @@ MStatus DgNodeHelper::setMatrix4x4(MObject node, MObject attr, const float* cons
 #endif
 
     MObject data = fn.create(m);
-    AL_MAYA_CHECK_ERROR(plug.setValue(data), errorString);
+    plug.setValue(data); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setMatrix3x3(MObject node, MObject attr, const double* const str)
 {
-    const char* const errorString = "matrix3x3 error";
+    // const char* const errorString = "matrix3x3 error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(0).setValue(str[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(1).setValue(str[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(2).setValue(str[2]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(0).setValue(str[3]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(1).setValue(str[4]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(2).setValue(str[5]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).child(0).setValue(str[6]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).child(1).setValue(str[7]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).child(2).setValue(str[8]), errorString);
+    plug.child(0).child(0).setValue(str[0]); // , errorString);
+    plug.child(0).child(1).setValue(str[1]); // , errorString);
+    plug.child(0).child(2).setValue(str[2]); // , errorString);
+    plug.child(1).child(0).setValue(str[3]); // , errorString);
+    plug.child(1).child(1).setValue(str[4]); // , errorString);
+    plug.child(1).child(2).setValue(str[5]); // , errorString);
+    plug.child(2).child(0).setValue(str[6]); // , errorString);
+    plug.child(2).child(1).setValue(str[7]); // , errorString);
+    plug.child(2).child(2).setValue(str[8]); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setMatrix3x3(MObject node, MObject attr, const float* const str)
 {
-    const char* const errorString = "matrix3x3 error";
+    // const char* const errorString = "matrix3x3 error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(0).setValue(str[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(1).setValue(str[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(2).setValue(str[2]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(0).setValue(str[3]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(1).setValue(str[4]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(2).setValue(str[5]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).child(0).setValue(str[6]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).child(1).setValue(str[7]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).child(2).setValue(str[8]), errorString);
+    plug.child(0).child(0).setValue(str[0]); // , errorString);
+    plug.child(0).child(1).setValue(str[1]); // , errorString);
+    plug.child(0).child(2).setValue(str[2]); // , errorString);
+    plug.child(1).child(0).setValue(str[3]); // , errorString);
+    plug.child(1).child(1).setValue(str[4]); // , errorString);
+    plug.child(1).child(2).setValue(str[5]); // , errorString);
+    plug.child(2).child(0).setValue(str[6]); // , errorString);
+    plug.child(2).child(1).setValue(str[7]); // , errorString);
+    plug.child(2).child(2).setValue(str[8]); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setMatrix2x2(MObject node, MObject attr, const double* const str)
 {
-    const char* const errorString = "matrix2x2 error";
+    // const char* const errorString = "matrix2x2 error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(0).setValue(str[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(1).setValue(str[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(0).setValue(str[2]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(1).setValue(str[3]), errorString);
+    plug.child(0).child(0).setValue(str[0]); // , errorString);
+    plug.child(0).child(1).setValue(str[1]); // , errorString);
+    plug.child(1).child(0).setValue(str[2]); // , errorString);
+    plug.child(1).child(1).setValue(str[3]); // , errorString);
     return MS::kSuccess;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setMatrix2x2(MObject node, MObject attr, const float* const str)
 {
-    const char* const errorString = "matrix2x2 error";
+    // const char* const errorString = "matrix2x2 error";
     MPlug             plug(node, attr);
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(0).setValue(str[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(1).setValue(str[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(0).setValue(str[2]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(1).setValue(str[3]), errorString);
+    plug.child(0).child(0).setValue(str[0]); // , errorString);
+    plug.child(0).child(1).setValue(str[1]); // , errorString);
+    plug.child(1).child(0).setValue(str[2]); // , errorString);
+    plug.child(1).child(1).setValue(str[3]); // , errorString);
     return MS::kSuccess;
 }
 
@@ -3618,16 +3666,16 @@ MStatus DgNodeHelper::setMatrix2x2Array(
     const double* const values,
     const size_t        count)
 {
-    const char* const errorString = "setMatrix2x2Array error";
+    // const char* const errorString = "setMatrix2x2Array error";
     MPlug             arrayPlug(node, attribute);
     arrayPlug.setNumElements(count);
     for (uint32_t i = 0; i < count; ++i) {
         const double* const str = values + i * 4;
         MPlug               plug = arrayPlug.elementByLogicalIndex(i);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(0).setValue(str[0]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(1).setValue(str[1]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(0).setValue(str[2]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(1).setValue(str[3]), errorString);
+        plug.child(0).child(0).setValue(str[0]); // , errorString);
+        plug.child(0).child(1).setValue(str[1]); // , errorString);
+        plug.child(1).child(0).setValue(str[2]); // , errorString);
+        plug.child(1).child(1).setValue(str[3]); // , errorString);
     }
     return MS::kSuccess;
 }
@@ -3639,16 +3687,16 @@ MStatus DgNodeHelper::setMatrix2x2Array(
     const float* const values,
     const size_t       count)
 {
-    const char* const errorString = "setMatrix2x2Array error";
+    // const char* const errorString = "setMatrix2x2Array error";
     MPlug             arrayPlug(node, attribute);
     arrayPlug.setNumElements(count);
     for (uint32_t i = 0; i < count; ++i) {
         const float* const str = values + i * 4;
         MPlug              plug = arrayPlug.elementByLogicalIndex(i);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(0).setValue(str[0]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(1).setValue(str[1]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(0).setValue(str[2]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(1).setValue(str[3]), errorString);
+        plug.child(0).child(0).setValue(str[0]); // , errorString);
+        plug.child(0).child(1).setValue(str[1]); // , errorString);
+        plug.child(1).child(0).setValue(str[2]); // , errorString);
+        plug.child(1).child(1).setValue(str[3]); // , errorString);
     }
     return MS::kSuccess;
 }
@@ -3660,21 +3708,21 @@ MStatus DgNodeHelper::setMatrix3x3Array(
     const double* const values,
     const size_t        count)
 {
-    const char* const errorString = "setMatrix3x3Array error";
+    // const char* const errorString = "setMatrix3x3Array error";
     MPlug             arrayPlug(node, attribute);
     arrayPlug.setNumElements(count);
     for (uint32_t i = 0; i < count; ++i) {
         const double* const str = values + i * 9;
         MPlug               plug = arrayPlug.elementByLogicalIndex(i);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(0).setValue(str[0]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(1).setValue(str[1]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(2).setValue(str[2]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(0).setValue(str[3]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(1).setValue(str[4]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(2).setValue(str[5]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(2).child(0).setValue(str[6]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(2).child(1).setValue(str[7]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(2).child(2).setValue(str[8]), errorString);
+        plug.child(0).child(0).setValue(str[0]); // , errorString);
+        plug.child(0).child(1).setValue(str[1]); // , errorString);
+        plug.child(0).child(2).setValue(str[2]); // , errorString);
+        plug.child(1).child(0).setValue(str[3]); // , errorString);
+        plug.child(1).child(1).setValue(str[4]); // , errorString);
+        plug.child(1).child(2).setValue(str[5]); // , errorString);
+        plug.child(2).child(0).setValue(str[6]); // , errorString);
+        plug.child(2).child(1).setValue(str[7]); // , errorString);
+        plug.child(2).child(2).setValue(str[8]); // , errorString);
     }
     return MS::kSuccess;
 }
@@ -3686,21 +3734,21 @@ MStatus DgNodeHelper::setMatrix3x3Array(
     const float* const values,
     const size_t       count)
 {
-    const char* const errorString = "setMatrix3x3Array error";
+    // const char* const errorString = "setMatrix3x3Array error";
     MPlug             arrayPlug(node, attribute);
     arrayPlug.setNumElements(count);
     for (uint32_t i = 0; i < count; ++i) {
         const float* const str = values + i * 9;
         MPlug              plug = arrayPlug.elementByLogicalIndex(i);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(0).setValue(str[0]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(1).setValue(str[1]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(0).child(2).setValue(str[2]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(0).setValue(str[3]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(1).setValue(str[4]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(1).child(2).setValue(str[5]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(2).child(0).setValue(str[6]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(2).child(1).setValue(str[7]), errorString);
-        AL_MAYA_CHECK_ERROR(plug.child(2).child(2).setValue(str[8]), errorString);
+        plug.child(0).child(0).setValue(str[0]); // , errorString);
+        plug.child(0).child(1).setValue(str[1]); // , errorString);
+        plug.child(0).child(2).setValue(str[2]); // , errorString);
+        plug.child(1).child(0).setValue(str[3]); // , errorString);
+        plug.child(1).child(1).setValue(str[4]); // , errorString);
+        plug.child(1).child(2).setValue(str[5]); // , errorString);
+        plug.child(2).child(0).setValue(str[6]); // , errorString);
+        plug.child(2).child(1).setValue(str[7]); // , errorString);
+        plug.child(2).child(2).setValue(str[8]); // , errorString);
     }
     return MS::kSuccess;
 }
@@ -3891,10 +3939,10 @@ MStatus DgNodeHelper::getMatrix2x2(MObject node, MObject attr, float* const str)
         MGlobal::displayError(errorString);
         return MS::kFailure;
     }
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(0).getValue(str[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(1).getValue(str[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(0).getValue(str[2]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(1).getValue(str[3]), errorString);
+    plug.child(0).child(0).getValue(str[0]); // , errorString);
+    plug.child(0).child(1).getValue(str[1]); // , errorString);
+    plug.child(1).child(0).getValue(str[2]); // , errorString);
+    plug.child(1).child(1).getValue(str[3]); // , errorString);
     return MS::kSuccess;
 }
 
@@ -3907,15 +3955,15 @@ MStatus DgNodeHelper::getMatrix3x3(MObject node, MObject attr, float* const str)
         MGlobal::displayError(errorString);
         return MS::kFailure;
     }
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(0).getValue(str[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(1).getValue(str[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(2).getValue(str[2]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(0).getValue(str[3]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(1).getValue(str[4]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(2).getValue(str[5]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).child(0).getValue(str[6]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).child(1).getValue(str[7]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).child(2).getValue(str[8]), errorString);
+    plug.child(0).child(0).getValue(str[0]); // , errorString);
+    plug.child(0).child(1).getValue(str[1]); // , errorString);
+    plug.child(0).child(2).getValue(str[2]); // , errorString);
+    plug.child(1).child(0).getValue(str[3]); // , errorString);
+    plug.child(1).child(1).getValue(str[4]); // , errorString);
+    plug.child(1).child(2).getValue(str[5]); // , errorString);
+    plug.child(2).child(0).getValue(str[6]); // , errorString);
+    plug.child(2).child(1).getValue(str[7]); // , errorString);
+    plug.child(2).child(2).getValue(str[8]); // , errorString);
     return MS::kSuccess;
 }
 
@@ -3929,7 +3977,7 @@ MStatus DgNodeHelper::getMatrix4x4(MObject node, MObject attr, float* const valu
         return MS::kFailure;
     }
     MObject data;
-    AL_MAYA_CHECK_ERROR(plug.getValue(data), errorString);
+    plug.getValue(data); // , errorString);
     MFnMatrixData  fn(data);
     const MMatrix& mat = fn.matrix();
 
@@ -3984,10 +4032,10 @@ MStatus DgNodeHelper::getMatrix2x2(MObject node, MObject attr, double* const str
         MGlobal::displayError(errorString);
         return MS::kFailure;
     }
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(0).getValue(str[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(1).getValue(str[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(0).getValue(str[2]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(1).getValue(str[3]), errorString);
+    plug.child(0).child(0).getValue(str[0]); // , errorString);
+    plug.child(0).child(1).getValue(str[1]); // , errorString);
+    plug.child(1).child(0).getValue(str[2]); // , errorString);
+    plug.child(1).child(1).getValue(str[3]); // , errorString);
     return MS::kSuccess;
 }
 
@@ -4000,15 +4048,15 @@ MStatus DgNodeHelper::getMatrix3x3(MObject node, MObject attr, double* const str
         MGlobal::displayError(errorString);
         return MS::kFailure;
     }
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(0).getValue(str[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(1).getValue(str[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(0).child(2).getValue(str[2]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(0).getValue(str[3]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(1).getValue(str[4]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).child(2).getValue(str[5]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).child(0).getValue(str[6]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).child(1).getValue(str[7]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).child(2).getValue(str[8]), errorString);
+    plug.child(0).child(0).getValue(str[0]); // , errorString);
+    plug.child(0).child(1).getValue(str[1]); // , errorString);
+    plug.child(0).child(2).getValue(str[2]); // , errorString);
+    plug.child(1).child(0).getValue(str[3]); // , errorString);
+    plug.child(1).child(1).getValue(str[4]); // , errorString);
+    plug.child(1).child(2).getValue(str[5]); // , errorString);
+    plug.child(2).child(0).getValue(str[6]); // , errorString);
+    plug.child(2).child(1).getValue(str[7]); // , errorString);
+    plug.child(2).child(2).getValue(str[8]); // , errorString);
     return MS::kSuccess;
 }
 
@@ -4022,7 +4070,7 @@ MStatus DgNodeHelper::getMatrix4x4(MObject node, MObject attr, double* const val
         return MS::kFailure;
     }
     MObject data;
-    AL_MAYA_CHECK_ERROR(plug.getValue(data), errorString);
+    plug.getValue(data); // , errorString);
     MFnMatrixData  fn(data);
     const MMatrix& mat = fn.matrix();
 
@@ -4086,7 +4134,7 @@ MStatus DgNodeHelper::getString(MObject node, MObject attr, std::string& str)
         return MS::kFailure;
     }
     MString value;
-    AL_MAYA_CHECK_ERROR(plug.getValue(value), errorString);
+    plug.getValue(value); // , errorString);
 
     str.assign(value.asChar(), value.asChar() + value.length());
     return MS::kSuccess;
@@ -4101,8 +4149,8 @@ MStatus DgNodeHelper::getVec2(MObject node, MObject attr, int* xy)
         MGlobal::displayError(errorString);
         return MS::kFailure;
     }
-    AL_MAYA_CHECK_ERROR(plug.child(0).getValue(xy[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).getValue(xy[1]), errorString);
+    plug.child(0).getValue(xy[0]); // , errorString);
+    plug.child(1).getValue(xy[1]); // , errorString);
     return MS::kSuccess;
 }
 
@@ -4115,8 +4163,8 @@ MStatus DgNodeHelper::getVec2(MObject node, MObject attr, float* xy)
         MGlobal::displayError(errorString);
         return MS::kFailure;
     }
-    AL_MAYA_CHECK_ERROR(plug.child(0).getValue(xy[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).getValue(xy[1]), errorString);
+    plug.child(0).getValue(xy[0]); // , errorString);
+    plug.child(1).getValue(xy[1]); // , errorString);
     return MS::kSuccess;
 }
 
@@ -4129,8 +4177,8 @@ MStatus DgNodeHelper::getVec2(MObject node, MObject attr, double* xy)
         MGlobal::displayError(errorString);
         return MS::kFailure;
     }
-    AL_MAYA_CHECK_ERROR(plug.child(0).getValue(xy[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).getValue(xy[1]), errorString);
+    plug.child(0).getValue(xy[0]); // , errorString);
+    plug.child(1).getValue(xy[1]); // , errorString);
     return MS::kSuccess;
 }
 
@@ -4153,9 +4201,9 @@ MStatus DgNodeHelper::getVec3(MObject node, MObject attr, int* xyz)
         MGlobal::displayError(errorString);
         return MS::kFailure;
     }
-    AL_MAYA_CHECK_ERROR(plug.child(0).getValue(xyz[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).getValue(xyz[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).getValue(xyz[2]), errorString);
+    plug.child(0).getValue(xyz[0]); // , errorString);
+    plug.child(1).getValue(xyz[1]); // , errorString);
+    plug.child(2).getValue(xyz[2]); // , errorString);
     return MS::kSuccess;
 }
 
@@ -4168,9 +4216,9 @@ MStatus DgNodeHelper::getVec3(MObject node, MObject attr, float* xyz)
         MGlobal::displayError(errorString);
         return MS::kFailure;
     }
-    AL_MAYA_CHECK_ERROR(plug.child(0).getValue(xyz[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).getValue(xyz[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).getValue(xyz[2]), errorString);
+    plug.child(0).getValue(xyz[0]); // , errorString);
+    plug.child(1).getValue(xyz[1]); // , errorString);
+    plug.child(2).getValue(xyz[2]); // , errorString);
     return MS::kSuccess;
 }
 
@@ -4183,9 +4231,9 @@ MStatus DgNodeHelper::getVec3(MObject node, MObject attr, double* xyz)
         MGlobal::displayError(errorString);
         return MS::kFailure;
     }
-    AL_MAYA_CHECK_ERROR(plug.child(0).getValue(xyz[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).getValue(xyz[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).getValue(xyz[2]), errorString);
+    plug.child(0).getValue(xyz[0]); // , errorString);
+    plug.child(1).getValue(xyz[1]); // , errorString);
+    plug.child(2).getValue(xyz[2]); // , errorString);
     return MS::kSuccess;
 }
 
@@ -4211,10 +4259,10 @@ MStatus DgNodeHelper::getVec4(MObject node, MObject attr, int* xyzw)
         MGlobal::displayError(errorString);
         return MS::kFailure;
     }
-    AL_MAYA_CHECK_ERROR(plug.child(0).getValue(xyzw[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).getValue(xyzw[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).getValue(xyzw[2]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(3).getValue(xyzw[3]), errorString);
+    plug.child(0).getValue(xyzw[0]); // , errorString);
+    plug.child(1).getValue(xyzw[1]); // , errorString);
+    plug.child(2).getValue(xyzw[2]); // , errorString);
+    plug.child(3).getValue(xyzw[3]); // , errorString);
     return MS::kSuccess;
 }
 
@@ -4227,10 +4275,10 @@ MStatus DgNodeHelper::getVec4(MObject node, MObject attr, float* xyzw)
         MGlobal::displayError(errorString);
         return MS::kFailure;
     }
-    AL_MAYA_CHECK_ERROR(plug.child(0).getValue(xyzw[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).getValue(xyzw[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).getValue(xyzw[2]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(3).getValue(xyzw[3]), errorString);
+    plug.child(0).getValue(xyzw[0]); // , errorString);
+    plug.child(1).getValue(xyzw[1]); // , errorString);
+    plug.child(2).getValue(xyzw[2]); // , errorString);
+    plug.child(3).getValue(xyzw[3]); // , errorString);
     return MS::kSuccess;
 }
 
@@ -4243,10 +4291,10 @@ MStatus DgNodeHelper::getVec4(MObject node, MObject attr, double* xyzw)
         MGlobal::displayError(errorString);
         return MS::kFailure;
     }
-    AL_MAYA_CHECK_ERROR(plug.child(0).getValue(xyzw[0]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(1).getValue(xyzw[1]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(2).getValue(xyzw[2]), errorString);
-    AL_MAYA_CHECK_ERROR(plug.child(3).getValue(xyzw[3]), errorString);
+    plug.child(0).getValue(xyzw[0]); // , errorString);
+    plug.child(1).getValue(xyzw[1]); // , errorString);
+    plug.child(2).getValue(xyzw[2]); // , errorString);
+    plug.child(3).getValue(xyzw[3]); // , errorString);
     return MS::kSuccess;
 }
 
@@ -4416,184 +4464,6 @@ MStatus DgNodeHelper::copyVec3(MObject node, MObject attr, const UsdAttribute& v
     return MS::kSuccess;
 }
 
-
-bool replace(std::string& str, const std::string& from, const std::string& to) {
-    size_t start_pos = str.find(from);
-    if(start_pos == std::string::npos)
-        return false;
-    str.replace(start_pos, from.length(), to);
-    return true;
-}
-
-
-//----------------------------------------------------------------------------------------------------------------------
-MStatus DgNodeHelper::addDynamicAttribute(MObject node, const UsdAttribute& usdAttr)
-{
-    const SdfValueTypeName typeName = usdAttr.GetTypeName();
-    const bool             isArray = typeName.IsArray();
-    const UsdDataType      dataType = getAttributeType(usdAttr);
-    MObject                attribute = MObject::kNullObj;
-    const char*            attrName = usdAttr.GetName().GetString().c_str();
-
-
-    // Fixing attr names to match the original maya names before writing them to USD Attrs
-    // using -userattr flag that was added to usdExport in our implementation
-    bool isShapeAttr = true;
-    std::string tmpAttrName = attrName;
-    if (tmpAttrName.rfind("xform:userProperties:", 0) == 0) {
-        // This is transform userProperties
-        isShapeAttr = false;
-        replace(tmpAttrName, "xform:userProperties:", "");
-    } else if (tmpAttrName.rfind("userProperties:", 0) == 0) {
-        isShapeAttr = true;
-        replace(tmpAttrName, "userProperties:", "");
-    } else if (tmpAttrName.rfind("primvars:ri:user:", 0) == 0) {
-        isShapeAttr = true;
-        replace(tmpAttrName, "primvars:ri:user:", "");
-    } else if (tmpAttrName.rfind("primvars:", 0) == 0) {
-        isShapeAttr = true;
-        replace(tmpAttrName, "primvars:", "");
-    }
-    attrName = tmpAttrName.c_str();
-
-    MDagPath dagPath = MDagPath::getAPathTo(node);
-    // don't add/set the attribute when it's a shape attr and the node is transform and vise versa
-    // in such case, assume kSuccess
-    if ((isShapeAttr and node.apiType() ==  MFn::kTransform) || (!isShapeAttr and node.apiType() !=  MFn::kTransform))
-        return  MS::kSuccess;
-
-    // Some plugins like renderman creates custom attributes on time of object creation (before us here)
-    // when these attributes are modified and exported out into the USD, we need to set them back when loading
-    // the USD, So, we have to check if the custom attr exists, then we have to set the value rather than adding a new attr.
-    MFnDependencyNode depNode(node);
-    if (!depNode.hasAttribute(attrName)) {
-
-        const uint32_t flags = (isArray ? AL::maya::utils::NodeHelper::kArray : 0)
-            | AL::maya::utils::NodeHelper::kReadable | AL::maya::utils::NodeHelper::kWritable
-            | AL::maya::utils::NodeHelper::kStorable | AL::maya::utils::NodeHelper::kConnectable;
-        switch (dataType) {
-        case UsdDataType::kAsset: {
-            return MS::kSuccess;
-        } break;
-
-        case UsdDataType::kBool: {
-            AL::maya::utils::NodeHelper::addBoolAttr(
-                node, attrName, attrName, false, flags, &attribute);
-        } break;
-
-        case UsdDataType::kUChar: {
-            AL::maya::utils::NodeHelper::addInt8Attr(
-                node, attrName, attrName, 0, flags, &attribute);
-        } break;
-
-        case UsdDataType::kInt:
-        case UsdDataType::kUInt: {
-            AL::maya::utils::NodeHelper::addInt32Attr(
-                node, attrName, attrName, 0, flags, &attribute);
-        } break;
-
-        case UsdDataType::kInt64:
-        case UsdDataType::kUInt64: {
-            AL::maya::utils::NodeHelper::addInt64Attr(
-                node, attrName, attrName, 0, flags, &attribute);
-        } break;
-
-        case UsdDataType::kHalf:
-        case UsdDataType::kFloat: {
-            AL::maya::utils::NodeHelper::addFloatAttr(
-                node, attrName, attrName, 0, flags, &attribute);
-        } break;
-
-        case UsdDataType::kDouble: {
-            AL::maya::utils::NodeHelper::addDoubleAttr(
-                node, attrName, attrName, 0, flags, &attribute);
-        } break;
-
-        case UsdDataType::kString: {
-            AL::maya::utils::NodeHelper::addStringAttr(
-                node, attrName, attrName, flags, true, &attribute);
-        } break;
-
-        case UsdDataType::kMatrix2d: {
-            const float defValue[2][2] = { { 0, 0 }, { 0, 0 } };
-            AL::maya::utils::NodeHelper::addMatrix2x2Attr(
-                node, attrName, attrName, defValue, flags, &attribute);
-        } break;
-
-        case UsdDataType::kMatrix3d: {
-            const float defValue[3][3] = { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } };
-            AL::maya::utils::NodeHelper::addMatrix3x3Attr(
-                node, attrName, attrName, defValue, flags, &attribute);
-        } break;
-
-        case UsdDataType::kMatrix4d: {
-            AL::maya::utils::NodeHelper::addMatrixAttr(
-                node, attrName, attrName, MMatrix(), flags, &attribute);
-        } break;
-
-        case UsdDataType::kQuatd: {
-            AL::maya::utils::NodeHelper::addVec4dAttr(node, attrName, attrName, flags, &attribute);
-        } break;
-
-        case UsdDataType::kQuatf:
-        case UsdDataType::kQuath: {
-            AL::maya::utils::NodeHelper::addVec4fAttr(node, attrName, attrName, flags, &attribute);
-        } break;
-
-        case UsdDataType::kVec2d: {
-            AL::maya::utils::NodeHelper::addVec2dAttr(node, attrName, attrName, flags, &attribute);
-        } break;
-
-        case UsdDataType::kVec2f:
-        case UsdDataType::kVec2h: {
-            AL::maya::utils::NodeHelper::addVec2fAttr(node, attrName, attrName, flags, &attribute);
-        } break;
-
-        case UsdDataType::kVec2i: {
-            AL::maya::utils::NodeHelper::addVec2iAttr(node, attrName, attrName, flags, &attribute);
-        } break;
-
-        case UsdDataType::kVec3d: {
-            AL::maya::utils::NodeHelper::addVec3dAttr(node, attrName, attrName, flags, &attribute);
-        } break;
-
-        case UsdDataType::kVec3f:
-        case UsdDataType::kVec3h: {
-            AL::maya::utils::NodeHelper::addVec3fAttr(node, attrName, attrName, flags, &attribute);
-        } break;
-
-        case UsdDataType::kVec3i: {
-            AL::maya::utils::NodeHelper::addVec3iAttr(node, attrName, attrName, flags, &attribute);
-        } break;
-
-        case UsdDataType::kVec4d: {
-            AL::maya::utils::NodeHelper::addVec4dAttr(node, attrName, attrName, flags, &attribute);
-        } break;
-
-        case UsdDataType::kVec4f:
-        case UsdDataType::kVec4h: {
-            AL::maya::utils::NodeHelper::addVec4fAttr(node, attrName, attrName, flags, &attribute);
-        } break;
-
-        case UsdDataType::kVec4i: {
-            AL::maya::utils::NodeHelper::addVec4iAttr(node, attrName, attrName, flags, &attribute);
-        } break;
-
-        default:
-            MGlobal::displayError(
-                "DgNodeTranslator::addDynamicAttribute - unsupported USD data type");
-            return MS::kFailure;
-        }
-    } else {
-        // Get the attribute
-        attribute = depNode.attribute(attrName);
-    }
-
-    if (isArray) {
-        return setArrayMayaValue(node, attribute, usdAttr, dataType);
-    }
-    return setSingleMayaValue(node, attribute, usdAttr, dataType);
-}
 
 //----------------------------------------------------------------------------------------------------------------------
 MStatus DgNodeHelper::setMayaValue(MObject node, MObject attr, const UsdAttribute& usdAttr)
@@ -5003,694 +4873,6 @@ MStatus DgNodeHelper::convertSpecialValueToUSDAttribute(const MPlug& plug, UsdAt
     return MS::kFailure;
 }
 
-//----------------------------------------------------------------------------------------------------------------------
-MStatus
-DgNodeHelper::copyDynamicAttributes(MObject node, UsdPrim& prim, AnimationTranslator* translator)
-{
-    MFnDependencyNode fn(node);
-    uint32_t          numAttributes = fn.attributeCount();
-    for (uint32_t i = 0; i < numAttributes; ++i) {
-        MObject attribute = fn.attribute(i);
-        MPlug   plug(node, attribute);
-
-        // skip child attributes (only export from highest level)
-        if (plug.isChild())
-            continue;
-
-        bool isDynamic = plug.isDynamic();
-        if (isDynamic) {
-            TfToken attributeName
-                = TfToken(plug.partialName(false, false, false, false, false, true).asChar());
-
-            // first test if the attribute happen to come with the prim by nature and we have a
-            // mapping rule for it:
-            if (prim.HasAttribute(attributeName)) {
-                UsdAttribute usdAttr = prim.GetAttribute(attributeName);
-                // if the conversion works, we are done:
-                if (convertSpecialValueToUSDAttribute(plug, usdAttr)) {
-                    continue;
-                }
-                // if not, then we count on CreateAttribute codes below since that will return the
-                // USDAttribute if already exists and hopefully the type conversions below will
-                // work.
-            }
-
-            bool isArray = plug.isArray();
-            switch (attribute.apiType()) {
-            case MFn::kAttribute2Double: {
-                if (!isArray) {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Double2);
-                    GfVec2d m;
-                    getVec2(node, attribute, (double*)&m);
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                    if (translator)
-                        translator->addPlug(MPlug(node, attribute), usdAttr, true);
-                } else {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Double2Array);
-                    VtArray<GfVec2d> m;
-                    m.resize(plug.numElements());
-                    getVec2Array(node, attribute, (double*)m.data(), m.size());
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                }
-            } break;
-
-            case MFn::kAttribute2Float: {
-                if (!isArray) {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Float2);
-                    GfVec2f m;
-                    getVec2(node, attribute, (float*)&m);
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                    if (translator)
-                        translator->addPlug(MPlug(node, attribute), usdAttr, true);
-                } else {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Float2Array);
-                    VtArray<GfVec2f> m;
-                    m.resize(plug.numElements());
-                    getVec2Array(node, attribute, (float*)m.data(), m.size());
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                }
-            } break;
-
-            case MFn::kAttribute2Int:
-            case MFn::kAttribute2Short: {
-                if (!isArray) {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Int2);
-                    GfVec2i m;
-                    getVec2(node, attribute, (int32_t*)&m);
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                    if (translator)
-                        translator->addPlug(MPlug(node, attribute), usdAttr, true);
-                } else {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Int2Array);
-                    VtArray<GfVec2i> m;
-                    m.resize(plug.numElements());
-                    getVec2Array(node, attribute, (int32_t*)m.data(), m.size());
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                }
-            } break;
-
-            case MFn::kAttribute3Double: {
-                if (!isArray) {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Double3);
-                    GfVec3d m;
-                    getVec3(node, attribute, (double*)&m);
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                    if (translator)
-                        translator->addPlug(MPlug(node, attribute), usdAttr, true);
-                } else {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Double3Array);
-                    VtArray<GfVec3d> m;
-                    m.resize(plug.numElements());
-                    getVec3Array(node, attribute, (double*)m.data(), m.size());
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                }
-            } break;
-
-            case MFn::kAttribute3Float: {
-                if (!isArray) {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Float3);
-                    GfVec3f m;
-                    getVec3(node, attribute, (float*)&m);
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                    if (translator)
-                        translator->addPlug(MPlug(node, attribute), usdAttr, true);
-                } else {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Float3Array);
-                    VtArray<GfVec3f> m;
-                    m.resize(plug.numElements());
-                    getVec3Array(node, attribute, (float*)m.data(), m.size());
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                }
-            } break;
-
-            case MFn::kAttribute3Long:
-            case MFn::kAttribute3Short: {
-                if (!isArray) {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Int3);
-                    GfVec3i m;
-                    getVec3(node, attribute, (int32_t*)&m);
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                    if (translator)
-                        translator->addPlug(MPlug(node, attribute), usdAttr, true);
-                } else {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Int3Array);
-                    VtArray<GfVec3i> m;
-                    m.resize(plug.numElements());
-                    getVec3Array(node, attribute, (int32_t*)m.data(), m.size());
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                }
-            } break;
-
-            case MFn::kAttribute4Double: {
-                if (!isArray) {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Double4);
-                    GfVec4d m;
-                    getVec4(node, attribute, (double*)&m);
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                    if (translator)
-                        translator->addPlug(MPlug(node, attribute), usdAttr, true);
-                } else {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Double4Array);
-                    VtArray<GfVec4d> m;
-                    m.resize(plug.numElements());
-                    getVec4Array(node, attribute, (double*)m.data(), m.size());
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                }
-            } break;
-
-            case MFn::kNumericAttribute: {
-                MFnNumericAttribute fn(attribute);
-                switch (fn.unitType()) {
-                case MFnNumericData::kBoolean: {
-                    if (!isArray) {
-                        UsdAttribute usdAttr
-                            = prim.CreateAttribute(attributeName, SdfValueTypeNames->Bool);
-                        bool value;
-                        getBool(node, attribute, value);
-                        usdAttr.Set(value);
-                        usdAttr.SetCustom(true);
-                        if (translator)
-                            translator->addPlug(MPlug(node, attribute), usdAttr, true);
-                    } else {
-                        UsdAttribute usdAttr
-                            = prim.CreateAttribute(attributeName, SdfValueTypeNames->BoolArray);
-                        VtArray<bool> m;
-                        m.resize(plug.numElements());
-                        getUsdBoolArray(node, attribute, m);
-                        usdAttr.Set(m);
-                        usdAttr.SetCustom(true);
-                    }
-                } break;
-
-                case MFnNumericData::kFloat: {
-                    if (!isArray) {
-                        UsdAttribute usdAttr
-                            = prim.CreateAttribute(attributeName, SdfValueTypeNames->Float);
-                        float value;
-                        getFloat(node, attribute, value);
-                        usdAttr.Set(value);
-                        usdAttr.SetCustom(true);
-                        if (translator)
-                            translator->addPlug(MPlug(node, attribute), usdAttr, true);
-                    } else {
-                        UsdAttribute usdAttr
-                            = prim.CreateAttribute(attributeName, SdfValueTypeNames->FloatArray);
-                        VtArray<float> m;
-                        m.resize(plug.numElements());
-                        getFloatArray(node, attribute, (float*)m.data(), m.size());
-                        usdAttr.Set(m);
-                        usdAttr.SetCustom(true);
-                    }
-                } break;
-
-                case MFnNumericData::kDouble: {
-                    if (!isArray) {
-                        UsdAttribute usdAttr
-                            = prim.CreateAttribute(attributeName, SdfValueTypeNames->Double);
-                        double value;
-                        getDouble(node, attribute, value);
-                        usdAttr.Set(value);
-                        usdAttr.SetCustom(true);
-                        if (translator)
-                            translator->addPlug(MPlug(node, attribute), usdAttr, true);
-                    } else {
-                        UsdAttribute usdAttr
-                            = prim.CreateAttribute(attributeName, SdfValueTypeNames->DoubleArray);
-                        VtArray<double> m;
-                        m.resize(plug.numElements());
-                        getDoubleArray(node, attribute, (double*)m.data(), m.size());
-                        usdAttr.Set(m);
-                        usdAttr.SetCustom(true);
-                    }
-                } break;
-
-                case MFnNumericData::kInt:
-                case MFnNumericData::kShort: {
-                    if (!isArray) {
-                        UsdAttribute usdAttr
-                            = prim.CreateAttribute(attributeName, SdfValueTypeNames->Int);
-                        int32_t value;
-                        getInt32(node, attribute, value);
-                        usdAttr.Set(value);
-                        usdAttr.SetCustom(true);
-                        if (translator)
-                            translator->addPlug(MPlug(node, attribute), usdAttr, true);
-                    } else {
-                        UsdAttribute usdAttr
-                            = prim.CreateAttribute(attributeName, SdfValueTypeNames->IntArray);
-                        VtArray<int> m;
-                        m.resize(plug.numElements());
-                        getInt32Array(node, attribute, (int32_t*)m.data(), m.size());
-                        usdAttr.Set(m);
-                        usdAttr.SetCustom(true);
-                    }
-                } break;
-
-                case MFnNumericData::kInt64: {
-                    if (!isArray) {
-                        UsdAttribute usdAttr
-                            = prim.CreateAttribute(attributeName, SdfValueTypeNames->Int64);
-                        int64_t value;
-                        getInt64(node, attribute, value);
-                        usdAttr.Set(value);
-                        usdAttr.SetCustom(true);
-                        if (translator)
-                            translator->addPlug(MPlug(node, attribute), usdAttr, true);
-                    } else {
-                        UsdAttribute usdAttr
-                            = prim.CreateAttribute(attributeName, SdfValueTypeNames->Int64Array);
-                        VtArray<int64_t> m;
-                        m.resize(plug.numElements());
-                        getInt64Array(node, attribute, (int64_t*)m.data(), m.size());
-                        usdAttr.Set(m);
-                        usdAttr.SetCustom(true);
-                    }
-                } break;
-
-                case MFnNumericData::kByte:
-                case MFnNumericData::kChar: {
-                    if (!isArray) {
-                        UsdAttribute usdAttr
-                            = prim.CreateAttribute(attributeName, SdfValueTypeNames->UChar);
-                        int16_t value;
-                        getInt16(node, attribute, value);
-                        usdAttr.Set(uint8_t(value));
-                        usdAttr.SetCustom(true);
-                        if (translator)
-                            translator->addPlug(MPlug(node, attribute), usdAttr, true);
-                    } else {
-                        UsdAttribute usdAttr
-                            = prim.CreateAttribute(attributeName, SdfValueTypeNames->UCharArray);
-                        VtArray<uint8_t> m;
-                        m.resize(plug.numElements());
-                        getInt8Array(node, attribute, (int8_t*)m.data(), m.size());
-                        usdAttr.Set(m);
-                        usdAttr.SetCustom(true);
-                    }
-                } break;
-
-                default: {
-                    std::cout << "Unhandled numeric attribute: " << fn.name().asChar() << " "
-                              << fn.unitType() << std::endl;
-                } break;
-                }
-            } break;
-
-            case MFn::kDoubleAngleAttribute: {
-                if (!isArray) {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Double);
-                    double value;
-                    getDouble(node, attribute, value);
-                    usdAttr.Set(value);
-                    usdAttr.SetCustom(true);
-                } else {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->DoubleArray);
-                    VtArray<double> value;
-                    value.resize(plug.numElements());
-                    getDoubleArray(node, attribute, (double*)value.data(), value.size());
-                    usdAttr.Set(value);
-                    usdAttr.SetCustom(true);
-                }
-            } break;
-
-            case MFn::kFloatAngleAttribute: {
-                if (!isArray) {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Float);
-                    float value;
-                    getFloat(node, attribute, value);
-                    usdAttr.Set(value);
-                    usdAttr.SetCustom(true);
-                } else {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->FloatArray);
-                    VtArray<float> value;
-                    value.resize(plug.numElements());
-                    getFloatArray(node, attribute, (float*)value.data(), value.size());
-                    usdAttr.Set(value);
-                    usdAttr.SetCustom(true);
-                }
-            } break;
-
-            case MFn::kDoubleLinearAttribute: {
-                if (!isArray) {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Double);
-                    double value;
-                    getDouble(node, attribute, value);
-                    usdAttr.Set(value);
-                    usdAttr.SetCustom(true);
-                } else {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->DoubleArray);
-                    VtArray<double> value;
-                    value.resize(plug.numElements());
-                    getDoubleArray(node, attribute, (double*)value.data(), value.size());
-                    usdAttr.Set(value);
-                    usdAttr.SetCustom(true);
-                }
-            } break;
-
-            case MFn::kFloatLinearAttribute: {
-                if (!isArray) {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Float);
-                    float value;
-                    getFloat(node, attribute, value);
-                    usdAttr.Set(value);
-                    usdAttr.SetCustom(true);
-                } else {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->FloatArray);
-                    VtArray<float> value;
-                    value.resize(plug.numElements());
-                    getFloatArray(node, attribute, (float*)value.data(), value.size());
-                    usdAttr.Set(value);
-                    usdAttr.SetCustom(true);
-                }
-            } break;
-
-            case MFn::kTimeAttribute: {
-                if (!isArray) {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Double);
-                    double value;
-                    getDouble(node, attribute, value);
-                    usdAttr.Set(value);
-                    usdAttr.SetCustom(true);
-                } else {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->DoubleArray);
-                    VtArray<double> value;
-                    value.resize(plug.numElements());
-                    getDoubleArray(node, attribute, (double*)value.data(), value.size());
-                    usdAttr.Set(value);
-                    usdAttr.SetCustom(true);
-                }
-            } break;
-
-            case MFn::kEnumAttribute: {
-                if (!isArray) {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Int);
-                    int32_t value;
-                    getInt32(node, attribute, value);
-                    usdAttr.Set(value);
-                    usdAttr.SetCustom(true);
-                } else {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->IntArray);
-                    VtArray<int> m;
-                    m.resize(plug.numElements());
-                    getInt32Array(node, attribute, (int32_t*)m.data(), m.size());
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                }
-            } break;
-
-            case MFn::kTypedAttribute: {
-                MFnTypedAttribute fnTyped(plug.attribute());
-                MFnData::Type     type = fnTyped.attrType();
-
-                switch (type) {
-                case MFnData::kString: {
-                    if (!isArray) {
-                        UsdAttribute usdAttr
-                            = prim.CreateAttribute(attributeName, SdfValueTypeNames->String);
-                        std::string value;
-                        getString(node, attribute, value);
-                        usdAttr.Set(value);
-                        usdAttr.SetCustom(true);
-                    } else {
-                        UsdAttribute usdAttr
-                            = prim.CreateAttribute(attributeName, SdfValueTypeNames->StringArray);
-                        VtArray<std::string> value;
-                        value.resize(plug.numElements());
-                        getStringArray(node, attribute, (std::string*)value.data(), value.size());
-                        usdAttr.Set(value);
-                        usdAttr.SetCustom(true);
-                    }
-                } break;
-
-                case MFnData::kMatrixArray: {
-                    MFnMatrixArrayData fnData(plug.asMObject());
-                    UsdAttribute       usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Matrix4dArray);
-                    VtArray<GfMatrix4d> m;
-                    m.assign(
-                        (const GfMatrix4d*)&fnData.array()[0],
-                        ((const GfMatrix4d*)&fnData.array()[0]) + fnData.array().length());
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                } break;
-
-                default: {
-                    std::cout << "Unhandled typed attribute: " << fn.name().asChar() << " "
-                              << fn.typeName().asChar() << std::endl;
-                } break;
-                }
-            } break;
-
-            case MFn::kCompoundAttribute: {
-                MFnCompoundAttribute fnCompound(plug.attribute());
-                {
-                    if (fnCompound.numChildren() == 2) {
-                        MObject x = fnCompound.child(0);
-                        MObject y = fnCompound.child(1);
-                        if (x.apiType() == MFn::kCompoundAttribute
-                            && y.apiType() == MFn::kCompoundAttribute) {
-                            MFnCompoundAttribute fnCompoundX(x);
-                            MFnCompoundAttribute fnCompoundY(y);
-
-                            if (fnCompoundX.numChildren() == 2 && fnCompoundY.numChildren() == 2) {
-                                MObject xx = fnCompoundX.child(0);
-                                MObject xy = fnCompoundX.child(1);
-                                MObject yx = fnCompoundY.child(0);
-                                MObject yy = fnCompoundY.child(1);
-                                if (xx.apiType() == MFn::kNumericAttribute
-                                    && xy.apiType() == MFn::kNumericAttribute
-                                    && yx.apiType() == MFn::kNumericAttribute
-                                    && yy.apiType() == MFn::kNumericAttribute) {
-                                    if (!isArray) {
-                                        UsdAttribute usdAttr = prim.CreateAttribute(
-                                            attributeName, SdfValueTypeNames->Matrix2d);
-                                        GfMatrix2d value;
-                                        getMatrix2x2(node, attribute, (double*)&value);
-                                        usdAttr.Set(value);
-                                        usdAttr.SetCustom(true);
-                                    } else {
-                                        UsdAttribute usdAttr = prim.CreateAttribute(
-                                            attributeName, SdfValueTypeNames->Matrix2dArray);
-                                        VtArray<GfMatrix2d> value;
-                                        value.resize(plug.numElements());
-                                        getMatrix2x2Array(
-                                            node,
-                                            attribute,
-                                            (double*)value.data(),
-                                            plug.numElements());
-                                        usdAttr.Set(value);
-                                        usdAttr.SetCustom(true);
-                                    }
-                                }
-                            }
-                        }
-                    } else if (fnCompound.numChildren() == 3) {
-                        MObject x = fnCompound.child(0);
-                        MObject y = fnCompound.child(1);
-                        MObject z = fnCompound.child(2);
-                        if (x.apiType() == MFn::kCompoundAttribute
-                            && y.apiType() == MFn::kCompoundAttribute
-                            && z.apiType() == MFn::kCompoundAttribute) {
-                            MFnCompoundAttribute fnCompoundX(x);
-                            MFnCompoundAttribute fnCompoundY(y);
-                            MFnCompoundAttribute fnCompoundZ(z);
-
-                            if (fnCompoundX.numChildren() == 3 && fnCompoundY.numChildren() == 3
-                                && fnCompoundZ.numChildren() == 3) {
-                                MObject xx = fnCompoundX.child(0);
-                                MObject xy = fnCompoundX.child(1);
-                                MObject xz = fnCompoundX.child(2);
-                                MObject yx = fnCompoundY.child(0);
-                                MObject yy = fnCompoundY.child(1);
-                                MObject yz = fnCompoundY.child(2);
-                                MObject zx = fnCompoundZ.child(0);
-                                MObject zy = fnCompoundZ.child(1);
-                                MObject zz = fnCompoundZ.child(2);
-                                if (xx.apiType() == MFn::kNumericAttribute
-                                    && xy.apiType() == MFn::kNumericAttribute
-                                    && xz.apiType() == MFn::kNumericAttribute
-                                    && yx.apiType() == MFn::kNumericAttribute
-                                    && yy.apiType() == MFn::kNumericAttribute
-                                    && yz.apiType() == MFn::kNumericAttribute
-                                    && zx.apiType() == MFn::kNumericAttribute
-                                    && zy.apiType() == MFn::kNumericAttribute
-                                    && zz.apiType() == MFn::kNumericAttribute) {
-                                    if (!isArray) {
-                                        UsdAttribute usdAttr = prim.CreateAttribute(
-                                            attributeName, SdfValueTypeNames->Matrix3d);
-                                        GfMatrix3d value;
-                                        getMatrix3x3(node, attribute, (double*)&value);
-                                        usdAttr.Set(value);
-                                        usdAttr.SetCustom(true);
-                                    } else {
-                                        UsdAttribute usdAttr = prim.CreateAttribute(
-                                            attributeName, SdfValueTypeNames->Matrix3dArray);
-                                        VtArray<GfMatrix3d> value;
-                                        value.resize(plug.numElements());
-                                        getMatrix3x3Array(
-                                            node,
-                                            attribute,
-                                            (double*)value.data(),
-                                            plug.numElements());
-                                        usdAttr.Set(value);
-                                        usdAttr.SetCustom(true);
-                                    }
-                                }
-                            }
-                        }
-                    } else if (fnCompound.numChildren() == 4) {
-                        MObject x = fnCompound.child(0);
-                        MObject y = fnCompound.child(1);
-                        MObject z = fnCompound.child(2);
-                        MObject w = fnCompound.child(3);
-                        if (x.apiType() == MFn::kNumericAttribute
-                            && y.apiType() == MFn::kNumericAttribute
-                            && z.apiType() == MFn::kNumericAttribute
-                            && w.apiType() == MFn::kNumericAttribute) {
-                            MFnNumericAttribute  fnx(x);
-                            MFnNumericAttribute  fny(y);
-                            MFnNumericAttribute  fnz(z);
-                            MFnNumericAttribute  fnw(w);
-                            MFnNumericData::Type typex = fnx.unitType();
-                            MFnNumericData::Type typey = fny.unitType();
-                            MFnNumericData::Type typez = fnz.unitType();
-                            MFnNumericData::Type typew = fnw.unitType();
-                            if (typex == typey && typex == typez && typex == typew) {
-                                switch (typex) {
-                                case MFnNumericData::kInt: {
-                                    if (!isArray) {
-                                        UsdAttribute usdAttr = prim.CreateAttribute(
-                                            attributeName, SdfValueTypeNames->Int4);
-                                        GfVec4i value;
-                                        getVec4(node, attribute, (int32_t*)&value);
-                                        usdAttr.Set(value);
-                                        usdAttr.SetCustom(true);
-                                    } else {
-                                        UsdAttribute usdAttr = prim.CreateAttribute(
-                                            attributeName, SdfValueTypeNames->Int4Array);
-                                        VtArray<GfVec4i> value;
-                                        value.resize(plug.numElements());
-                                        getVec4Array(
-                                            node, attribute, (int32_t*)value.data(), value.size());
-                                        usdAttr.Set(value);
-                                        usdAttr.SetCustom(true);
-                                    }
-                                } break;
-
-                                case MFnNumericData::kFloat: {
-                                    if (!isArray) {
-                                        UsdAttribute usdAttr = prim.CreateAttribute(
-                                            attributeName, SdfValueTypeNames->Float4);
-                                        GfVec4f value;
-                                        getVec4(node, attribute, (float*)&value);
-                                        usdAttr.Set(value);
-                                        usdAttr.SetCustom(true);
-                                    } else {
-                                        UsdAttribute usdAttr = prim.CreateAttribute(
-                                            attributeName, SdfValueTypeNames->Float4Array);
-                                        VtArray<GfVec4f> value;
-                                        value.resize(plug.numElements());
-                                        getVec4Array(
-                                            node, attribute, (float*)value.data(), value.size());
-                                        usdAttr.Set(value);
-                                        usdAttr.SetCustom(true);
-                                    }
-                                } break;
-
-                                case MFnNumericData::kDouble: {
-                                    if (!isArray) {
-                                        UsdAttribute usdAttr = prim.CreateAttribute(
-                                            attributeName, SdfValueTypeNames->Double4);
-                                        GfVec4d value;
-                                        getVec4(node, attribute, (double*)&value);
-                                        usdAttr.Set(value);
-                                        usdAttr.SetCustom(true);
-                                    } else {
-                                        UsdAttribute usdAttr = prim.CreateAttribute(
-                                            attributeName, SdfValueTypeNames->Double4Array);
-                                        VtArray<GfVec4d> value;
-                                        value.resize(plug.numElements());
-                                        getVec4Array(
-                                            node, attribute, (double*)value.data(), value.size());
-                                        usdAttr.Set(value);
-                                        usdAttr.SetCustom(true);
-                                    }
-                                } break;
-
-                                default: break;
-                                }
-                            }
-                        }
-                    }
-                }
-            } break;
-
-            case MFn::kFloatMatrixAttribute:
-            case MFn::kMatrixAttribute: {
-                if (!isArray) {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Matrix4d);
-                    GfMatrix4d m;
-                    getMatrix4x4(node, attribute, (double*)&m);
-                    usdAttr.Set(m);
-                    usdAttr.SetCustom(true);
-                } else {
-                    UsdAttribute usdAttr
-                        = prim.CreateAttribute(attributeName, SdfValueTypeNames->Matrix4dArray);
-                    VtArray<GfMatrix4d> value;
-                    value.resize(plug.numElements());
-                    getMatrix4x4Array(node, attribute, (double*)value.data(), value.size());
-                    usdAttr.Set(value);
-                    usdAttr.SetCustom(true);
-                }
-            } break;
-
-            default: break;
-            }
-        }
-    }
-    return MS::kSuccess;
-}
 
 //----------------------------------------------------------------------------------------------------------------------
 void DgNodeHelper::copySimpleValue(
@@ -6462,8 +5644,3 @@ void DgNodeHelper::copyAttributeValue(
     }
 }
 
-//----------------------------------------------------------------------------------------------------------------------
-} // namespace utils
-} // namespace usdmaya
-} // namespace AL
-//----------------------------------------------------------------------------------------------------------------------

--- a/lib/mayaUsd/fileio/translators/DgNodeHelper.h
+++ b/lib/mayaUsd/fileio/translators/DgNodeHelper.h
@@ -1,0 +1,2204 @@
+//
+// Copyright 2017 Animal Logic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+//#include "AL/usdmaya/utils/AnimationTranslator.h"
+#include "mayaUsd/fileio/translators/NodeHelper.h"
+#include "mayaUsd/fileio/translators/translatorUtil.h"
+
+#include <pxr/usd/usdGeom/xformOp.h>
+
+#include <maya/MAngle.h>
+#include <maya/MDistance.h>
+#include <maya/MFnAnimCurve.h>
+#include <maya/MGlobal.h>
+#include <maya/MObjectArray.h>
+#include <maya/MPlug.h>
+#include <maya/MTime.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+//----------------------------------------------------------------------------------------------------------------------
+/// \ingroup  mayautils
+/// \brief  Utility class that provides support for setting/getting
+///         attributes.
+//----------------------------------------------------------------------------------------------------------------------
+struct DgNodeHelper
+{
+public:
+    /// ctor
+    DgNodeHelper() { }
+
+    /// dtor
+    virtual ~DgNodeHelper() { }
+
+    //--------------------------------------------------------------------------------------------------------------------
+    /// \name   Methods to get array data from array attributes
+    //-----------------------------------------`---------------------------------------------------------------------------
+
+    /// \brief  retrieve an array of boolean values from an attribute in Maya
+    /// \param  node the maya node on which the attribute you are interested in exists
+    /// \param  attr the handle to the array attribute. This will either be an MObject for a custom
+    /// maya attribute,
+    ///         a handle queried via the MNodeClass interface, or a dynamically added attribute
+    /// \param  values the returned array of values
+    /// \return MS::kSuccess if ok
+    
+    static MStatus
+    getBoolArray(const MObject& node, const MObject& attr, std::vector<bool>& values);
+
+    /// \brief  retrieve an array of boolean values from an attribute in Maya
+    /// \param  node the maya node on which the attribute you are interested in exists
+    /// \param  attr the handle to the array attribute. This will either be an MObject for a custom
+    /// maya attribute,
+    ///         a handle queried via the MNodeClass interface, or a dynamically added attribute
+    /// \param  values a pointer to a pre-allocated buffer to fill with the attribute values
+    /// \param  count the number of elements in the buffer.
+    /// \return MS::kSuccess if ok
+    
+    static MStatus getBoolArray(MObject node, MObject attr, bool* values, const size_t count);
+
+    /// \brief  retrieve an array of 8 bit char values from an attribute in Maya
+    /// \param  node the maya node on which the attribute you are interested in exists
+    /// \param  attr the handle to the array attribute. This will either be an MObject for a custom
+    /// maya attribute,
+    ///         a handle queried via the MNodeClass interface, or a dynamically added attribute
+    /// \param  values the returned array of values
+    /// \return MS::kSuccess if ok
+    static MStatus
+    getInt8Array(const MObject& node, const MObject& attr, std::vector<int8_t>& values);
+
+    /// \brief  retrieve an array of 8 bit integer values from an attribute in Maya
+    /// \param  node the maya node on which the attribute you are interested in exists
+    /// \param  attr the handle to the array attribute. This will either be an MObject for a custom
+    /// maya attribute,
+    ///         a handle queried via the MNodeClass interface, or a dynamically added attribute
+    /// \param  values a pointer to a pre-allocated buffer to fill with the attribute values
+    /// \param  count the number of elements in the buffer.
+    /// \return MS::kSuccess if ok
+    
+    static MStatus getInt8Array(MObject node, MObject attr, int8_t* values, size_t count);
+
+    /// \brief  retrieve an array of 16bit integer values from an attribute in Maya
+    /// \param  node the maya node on which the attribute you are interested in exists
+    /// \param  attr the handle to the array attribute. This will either be an MObject for a custom
+    /// maya attribute,
+    ///         a handle queried via the MNodeClass interface, or a dynamically added attribute
+    /// \param  values the returned array of values
+    /// \return MS::kSuccess if ok
+    static MStatus
+    getInt16Array(const MObject& node, const MObject& attr, std::vector<int16_t>& values);
+
+    /// \brief  retrieve an array of 16 bit integer values from an attribute in Maya
+    /// \param  node the maya node on which the attribute you are interested in exists
+    /// \param  attr the handle to the array attribute. This will either be an MObject for a custom
+    /// maya attribute,
+    ///         a handle queried via the MNodeClass interface, or a dynamically added attribute
+    /// \param  values a pointer to a pre-allocated buffer to fill with the attribute values
+    /// \param  count the number of elements in the buffer.
+    /// \return MS::kSuccess if ok
+    
+    static MStatus getInt16Array(MObject node, MObject attr, int16_t* values, size_t count);
+
+    /// \brief  retrieve an array of 32bit integer values from an attribute in Maya
+    /// \param  node the maya node on which the attribute you are interested in exists
+    /// \param  attr the handle to the array attribute. This will either be an MObject for a custom
+    /// maya attribute,
+    ///         a handle queried via the MNodeClass interface, or a dynamically added attribute
+    /// \param  values the returned array of values
+    /// \return MS::kSuccess if ok
+    static MStatus
+    getInt32Array(const MObject& node, const MObject& attr, std::vector<int32_t>& values);
+
+    /// \brief  retrieve an array of 32 bit integer values from an attribute in Maya
+    /// \param  node the maya node on which the attribute you are interested in exists
+    /// \param  attr the handle to the array attribute. This will either be an MObject for a custom
+    /// maya attribute,
+    ///         a handle queried via the MNodeClass interface, or a dynamically added attribute
+    /// \param  values a pointer to a pre-allocated buffer to fill with the attribute values
+    /// \param  count the number of elements in the buffer.
+    /// \return MS::kSuccess if ok
+    
+    static MStatus getInt32Array(MObject node, MObject attr, int32_t* values, size_t count);
+
+    /// \brief  retrieve an array of 64bit integer values from an attribute in Maya
+    /// \param  node the maya node on which the attribute you are interested in exists
+    /// \param  attr the handle to the array attribute. This will either be an MObject for a custom
+    /// maya attribute,
+    ///         a handle queried via the MNodeClass interface, or a dynamically added attribute
+    /// \param  values the returned array of values
+    /// \return MS::kSuccess if ok
+    static MStatus
+    getInt64Array(const MObject& node, const MObject& attr, std::vector<int64_t>& values);
+
+    /// \brief  retrieve an array of 64 bit integer values from an attribute in Maya
+    /// \param  node the maya node on which the attribute you are interested in exists
+    /// \param  attr the handle to the array attribute. This will either be an MObject for a custom
+    /// maya attribute,
+    ///         a handle queried via the MNodeClass interface, or a dynamically added attribute
+    /// \param  values a pointer to a pre-allocated buffer to fill with the attribute values
+    /// \param  count the number of elements in the buffer.
+    /// \return MS::kSuccess if ok
+    
+    static MStatus getInt64Array(MObject node, MObject attr, int64_t* values, size_t count);
+
+    /// \brief  retrieve an array of float values from an attribute in Maya (converted to halfs)
+    /// \param  node the maya node on which the attribute you are interested in exists
+    /// \param  attr the handle to the array attribute. This will either be an MObject for a custom
+    /// maya attribute,
+    ///         a handle queried via the MNodeClass interface, or a dynamically added attribute
+    /// \param  values the returned array of values
+    /// \return MS::kSuccess if ok
+    static MStatus
+    getHalfArray(const MObject& node, const MObject& attr, std::vector<GfHalf>& values);
+
+    /// \brief  retrieve an array of half values from an attribute in Maya
+    /// \param  node the maya node on which the attribute you are interested in exists
+    /// \param  attr the handle to the array attribute. This will either be an MObject for a custom
+    /// maya attribute,
+    ///         a handle queried via the MNodeClass interface, or a dynamically added attribute
+    /// \param  values a pointer to a pre-allocated buffer to fill with the attribute values
+    /// \param  count the number of elements in the buffer.
+    /// \return MS::kSuccess if ok
+    
+    static MStatus getHalfArray(MObject node, MObject attr, GfHalf* values, size_t count);
+
+    /// \brief  retrieve an array of float values from an attribute in Maya
+    /// \param  node the maya node on which the attribute you are interested in exists
+    /// \param  attr the handle to the array attribute. This will either be an MObject for a custom
+    /// maya attribute,
+    ///         a handle queried via the MNodeClass interface, or a dynamically added attribute
+    /// \param  values the returned array of values
+    /// \return MS::kSuccess if ok
+    static MStatus
+    getFloatArray(const MObject& node, const MObject& attr, std::vector<float>& values);
+
+    /// \brief  retrieve an array of float values from an attribute in Maya
+    /// \param  node the maya node on which the attribute you are interested in exists
+    /// \param  attr the handle to the array attribute. This will either be an MObject for a custom
+    /// maya attribute,
+    ///         a handle queried via the MNodeClass interface, or a dynamically added attribute
+    /// \param  values a pointer to a pre-allocated buffer to fill with the attribute values
+    /// \param  count the number of elements in the buffer.
+    /// \return MS::kSuccess if ok
+    
+    static MStatus getFloatArray(MObject node, MObject attr, float* values, size_t count);
+
+    /// \brief  retrieve an array of double values from an attribute in Maya
+    /// \param  node the maya node on which the attribute you are interested in exists
+    /// \param  attr the handle to the array attribute. This will either be an MObject for a custom
+    /// maya attribute,
+    ///         a handle queried via the MNodeClass interface, or a dynamically added attribute
+    /// \param  values the returned array of values
+    /// \return MS::kSuccess if ok
+    static MStatus
+    getDoubleArray(const MObject& node, const MObject& attr, std::vector<double>& values);
+
+    /// \brief  retrieve an array of double values from an attribute in Maya
+    /// \param  node the maya node on which the attribute you are interested in exists
+    /// \param  attr the handle to the array attribute. This will either be an MObject for a custom
+    /// maya attribute,
+    ///         a handle queried via the MNodeClass interface, or a dynamically added attribute
+    /// \param  values a pointer to a pre-allocated buffer to fill with the attribute values
+    /// \param  count the number of elements in the buffer.
+    /// \return MS::kSuccess if ok
+    
+    static MStatus getDoubleArray(MObject node, MObject attr, double* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 2D half float array
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of matrices to extract (values should be 2x this size)
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus getVec2Array(MObject node, MObject attr, GfHalf* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 2D float array
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of matrices to extract (values should be 2x this size)
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus getVec2Array(MObject node, MObject attr, float* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 2D double array
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of matrices to extract (values should be 2x this size)
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus getVec2Array(MObject node, MObject attr, double* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 2D integer array
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of matrices to extract (values should be 2x this size)
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus getVec2Array(MObject node, MObject attr, int32_t* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 3D half float array
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of matrices to extract (values should be 3x this size)
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus getVec3Array(MObject node, MObject attr, GfHalf* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 3D float array
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of matrices to extract (values should be 3x this size)
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus getVec3Array(MObject node, MObject attr, float* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 3D double array
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of matrices to extract (values should be 3x this size)
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus getVec3Array(MObject node, MObject attr, double* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 3D integer array
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of matrices to extract (values should be 3x this size)
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus getVec3Array(MObject node, MObject attr, int32_t* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 4D half float array
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of matrices to extract (values should be 4x this size)
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus getVec4Array(MObject node, MObject attr, GfHalf* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 4D float array
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of matrices to extract (values should be 4x this size)
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus getVec4Array(MObject node, MObject attr, float* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 4D double array
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of matrices to extract (values should be 4x this size)
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus getVec4Array(MObject node, MObject attr, double* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 4D integer array
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of matrices to extract (values should be 4x this size)
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus getVec4Array(MObject node, MObject attr, int32_t* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 4D half float array
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of matrices to extract (values should be 4x this size)
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus getQuatArray(MObject node, MObject attr, GfHalf* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 4D float array
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of matrices to extract (values should be 4x this size)
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus getQuatArray(MObject node, MObject attr, float* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 4D double array
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of matrices to extract (values should be 4x this size)
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus getQuatArray(MObject node, MObject attr, double* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 2x2 floating point
+    /// matrix array \param  node a handle to the node to get the attribute from \param  attr a
+    /// handle to the attribute that contains the array data you wish to extract \param  values the
+    /// pre-allocated buffer into which you wish to get the data \param  count the number of
+    /// matrices to extract (values should be 4x this size) \return MS::kSuccess if everything is OK
+    
+    static MStatus getMatrix2x2Array(MObject node, MObject attr, float* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 2x2 double matrix
+    /// array \param  node a handle to the node to get the attribute from \param  attr a handle to
+    /// the attribute that contains the array data you wish to extract \param  values the
+    /// pre-allocated buffer into which you wish to get the data \param  count the number of
+    /// matrices to extract (values should be 4x this size) \return MS::kSuccess if everything is OK
+    
+    static MStatus getMatrix2x2Array(MObject node, MObject attr, double* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 3x3 floating point
+    /// matrix array \param  node a handle to the node to get the attribute from \param  attr a
+    /// handle to the attribute that contains the array data you wish to extract \param  values the
+    /// pre-allocated buffer into which you wish to get the data \param  count the number of
+    /// matrices to extract (values should be 9x this size) \return MS::kSuccess if everything is OK
+    
+    static MStatus getMatrix3x3Array(MObject node, MObject attr, float* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 3x3 double matrix
+    /// array \param  node a handle to the node to get the attribute from \param  attr a handle to
+    /// the attribute that contains the array data you wish to extract \param  values the
+    /// pre-allocated buffer into which you wish to get the data \param  count the number of
+    /// matrices to extract (values should be 9x this size) \return MS::kSuccess if everything is OK
+    
+    static MStatus getMatrix3x3Array(MObject node, MObject attr, double* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 4x4 floating point
+    /// matrix array \param  node a handle to the node to get the attribute from \param  attr a
+    /// handle to the attribute that contains the array data you wish to extract \param  values the
+    /// pre-allocated buffer into which you wish to get the data \param  count the number of
+    /// matrices to extract (values should be 16x this size) \return MS::kSuccess if everything is
+    /// OK
+    
+    static MStatus getMatrix4x4Array(MObject node, MObject attr, float* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as a 4x4 double matrix
+    /// array \param  node a handle to the node to get the attribute from \param  attr a handle to
+    /// the attribute that contains the array data you wish to extract \param  values the
+    /// pre-allocated buffer into which you wish to get the data \param  count the number of
+    /// matrices to extract (values should be 16x this size) \return MS::kSuccess if everything is
+    /// OK
+    
+    static MStatus getMatrix4x4Array(MObject node, MObject attr, double* values, size_t count);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as an array of time
+    /// values scale
+    ///         to the specified unit.
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of values to extract
+    /// \param  unit the time unit you want the data in
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus
+    getTimeArray(MObject node, MObject attr, float* values, size_t count, MTime::Unit unit);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as an array of angle
+    /// values scale
+    ///         to the specified unit.
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of values to extract
+    /// \param  unit the angle unit you want the data in
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus
+    getAngleArray(MObject node, MObject attr, float* values, size_t count, MAngle::Unit unit);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as an array of distance
+    /// values scale
+    ///         to the specified unit.
+    /// \param  node a handle to the node to get the attribute from
+    /// \param  attr a handle to the attribute that contains the array data you wish to extract
+    /// \param  values the pre-allocated buffer into which you wish to get the data
+    /// \param  count the number of values to extract
+    /// \param  unit the distance unit you want the data in
+    /// \return MS::kSuccess if everything is OK
+    
+    static MStatus
+    getDistanceArray(MObject node, MObject attr, float* values, size_t count, MDistance::Unit unit);
+
+    /// \brief  given MObjects for an attribute on a node, extract the data as an array of string
+    /// values \param  node a handle to the node to get the attribute from \param  attr a handle to
+    /// the attribute that contains the array data you wish to extract \param  values the
+    /// pre-allocated buffer into which you wish to get the data \param  count the number of values
+    /// to extract \return MS::kSuccess if everything is OK
+    
+    static MStatus getStringArray(MObject node, MObject attr, std::string* values, size_t count);
+
+    //--------------------------------------------------------------------------------------------------------------------
+    /// \name   Methods to get single values from non array attributes
+    //--------------------------------------------------------------------------------------------------------------------
+
+    /// \brief  extracts a single half float value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the returned value
+    /// \return MS::kSuccess if all ok
+    static MStatus getHalf(MObject node, MObject attr, GfHalf& value)
+    {
+        float   f;
+        MStatus status = getFloat(node, attr, f);
+        value = f;
+        return status;
+    }
+
+    /// \brief  extracts a single float value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getFloat(MObject node, MObject attr, float& value);
+
+    /// \brief  extracts a single double value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getDouble(MObject node, MObject attr, double& value);
+
+    /// \brief  extracts a single time value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getTime(MObject node, MObject attr, MTime& value);
+
+    /// \brief  extracts a single distance value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getDistance(MObject node, MObject attr, MDistance& value);
+
+    /// \brief  extracts a single angle value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getAngle(MObject node, MObject attr, MAngle& value);
+
+    /// \brief  extracts a single boolean value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getBool(MObject node, MObject attr, bool& value);
+
+    /// \brief  extracts a single 8bit integer value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getInt8(MObject node, MObject attr, int8_t& value);
+
+    /// \brief  extracts a single 16 bit integer value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getInt16(MObject node, MObject attr, int16_t& value);
+
+    /// \brief  extracts a single 32bit integer value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getInt32(MObject node, MObject attr, int32_t& value);
+
+    /// \brief  extracts a single 64bit integer value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getInt64(MObject node, MObject attr, int64_t& value);
+
+    /// \brief  extracts a 2x2 matrix value from the specified node/attribute (as a float)
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  values the returned matrix value as an array of floats
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getMatrix2x2(MObject node, MObject attr, float* values);
+
+    /// \brief  extracts a 3x3 matrix value from the specified node/attribute (as a float)
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  values the returned matrix value as an array of floats
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getMatrix3x3(MObject node, MObject attr, float* values);
+
+    /// \brief  extracts a 4x4 matrix value from the specified node/attribute (as a float)
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  values the returned matrix value as an array of floats
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getMatrix4x4(MObject node, MObject attr, float* values);
+
+    /// \brief  extracts a 4x4 matrix value from the specified node/attribute (as a float)
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  values the returned matrix value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getMatrix4x4(MObject node, MObject attr, MFloatMatrix& values);
+
+    /// \brief  extracts a 2x2 matrix value from the specified node/attribute (as a double)
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  values the returned matrix value as an array of doubles
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getMatrix2x2(MObject node, MObject attr, double* values);
+
+    /// \brief  extracts a 3x3 matrix value from the specified node/attribute (as a double)
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  values the returned matrix value as an array of doubles
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getMatrix3x3(MObject node, MObject attr, double* values);
+
+    /// \brief  extracts a 4x4 matrix value from the specified node/attribute (as a double)
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  values the returned matrix value as an array of doubles
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getMatrix4x4(MObject node, MObject attr, double* values);
+
+    /// \brief  extracts a 4x4 matrix value from the specified node/attribute (as a double)
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  values the returned matrix value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getMatrix4x4(MObject node, MObject attr, MMatrix& values);
+
+    /// \brief  extracts a string value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  str the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getString(MObject node, MObject attr, std::string& str);
+
+    /// \brief  extracts a 2D vector value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xy the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getVec2(MObject node, MObject attr, int32_t* xy);
+
+    /// \brief  extracts a 2D vector value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xy the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getVec2(MObject node, MObject attr, float* xy);
+
+    /// \brief  extracts a 2D vector value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xy the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getVec2(MObject node, MObject attr, double* xy);
+
+    /// \brief  extracts a 2D vector value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xy the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getVec2(MObject node, MObject attr, GfHalf* xy);
+
+    /// \brief  extracts a 3D vector value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyz the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getVec3(MObject node, MObject attr, int32_t* xyz);
+
+    /// \brief  extracts a 3D vector value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyz the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getVec3(MObject node, MObject attr, float* xyz);
+
+    /// \brief  extracts a 3D vector value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyz the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getVec3(MObject node, MObject attr, double* xyz);
+
+    /// \brief  extracts a 3D vector value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyz the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getVec3(MObject node, MObject attr, GfHalf* xyz);
+
+    /// \brief  extracts a 4D vector value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyzw the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getVec4(MObject node, MObject attr, int32_t* xyzw);
+
+    /// \brief  extracts a 4D vector value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyzw the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getVec4(MObject node, MObject attr, float* xyzw);
+
+    /// \brief  extracts a 4D vector value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyzw the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getVec4(MObject node, MObject attr, double* xyzw);
+
+    /// \brief  extracts a 4D vector value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyzw the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getVec4(MObject node, MObject attr, GfHalf* xyzw);
+
+    /// \brief  extracts a 4D quat value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyzw the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getQuat(MObject node, MObject attr, float* xyzw);
+
+    /// \brief  extracts a 4D quat value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyzw the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getQuat(MObject node, MObject attr, double* xyzw);
+
+    /// \brief  extracts a 4D quat value from the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyzw the returned value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus getQuat(MObject node, MObject attr, GfHalf* xyzw);
+
+    //--------------------------------------------------------------------------------------------------------------------
+    /// \name   Get array values from Maya
+    //--------------------------------------------------------------------------------------------------------------------
+
+    /// \name   get data from maya attribute, and store in the USD values array
+    /// \param  node the node to get the attribute data from
+    /// \param  attr the attribute to get the data from
+    /// \param  values the returned array data
+    /// \return MS::kSuccess if succeeded
+    
+    static MStatus getUsdBoolArray(const MObject& node, const MObject& attr, VtArray<bool>& values);
+
+    /// \name   get data from maya attribute, and store in the USD values array
+    /// \param  node the node to get the attribute data from
+    /// \param  attr the attribute to get the data from
+    /// \param  values the returned array data
+    /// \return MS::kSuccess if succeeded
+    static MStatus
+    getUsdInt8Array(const MObject& node, const MObject& attr, VtArray<int8_t>& values);
+
+    /// \name   get data from maya attribute, and store in the USD values array
+    /// \param  node the node to get the attribute data from
+    /// \param  attr the attribute to get the data from
+    /// \param  values the returned array data
+    /// \return MS::kSuccess if succeeded
+    static MStatus
+    getUsdInt16Array(const MObject& node, const MObject& attr, VtArray<int16_t>& values);
+
+    /// \name   get data from maya attribute, and store in the USD values array
+    /// \param  node the node to get the attribute data from
+    /// \param  attr the attribute to get the data from
+    /// \param  values the returned array data
+    /// \return MS::kSuccess if succeeded
+    static MStatus
+    getUsdInt32Array(const MObject& node, const MObject& attr, VtArray<int32_t>& values);
+
+    /// \name   get data from maya attribute, and store in the USD values array
+    /// \param  node the node to get the attribute data from
+    /// \param  attr the attribute to get the data from
+    /// \param  values the returned array data
+    /// \return MS::kSuccess if succeeded
+    static MStatus
+    getUsdInt64Array(const MObject& node, const MObject& attr, VtArray<int64_t>& values);
+
+    /// \name   get data from maya attribute, and store in the USD values array
+    /// \param  node the node to get the attribute data from
+    /// \param  attr the attribute to get the data from
+    /// \param  values the returned array data
+    /// \return MS::kSuccess if succeeded
+    static MStatus
+    getUsdHalfArray(const MObject& node, const MObject& attr, VtArray<GfHalf>& values);
+
+    /// \name   get data from maya attribute, and store in the USD values array
+    /// \param  node the node to get the attribute data from
+    /// \param  attr the attribute to get the data from
+    /// \param  values the returned array data
+    /// \return MS::kSuccess if succeeded
+    static MStatus
+    getUsdFloatArray(const MObject& node, const MObject& attr, VtArray<float>& values);
+
+    /// \name   get data from maya attribute, and store in the USD values array
+    /// \param  node the node to get the attribute data from
+    /// \param  attr the attribute to get the data from
+    /// \param  values the returned array data
+    /// \return MS::kSuccess if succeeded
+    static MStatus
+    getUsdDoubleArray(const MObject& node, const MObject& attr, VtArray<double>& values);
+
+    //--------------------------------------------------------------------------------------------------------------------
+    /// \name   Methods to set array attributes with array data
+    //--------------------------------------------------------------------------------------------------------------------
+
+    /// \brief  sets all values on a boolean array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus
+    setBoolArray(const MObject& node, const MObject& attr, const std::vector<bool>& values);
+
+    /// \brief  sets all values on a boolean array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setBoolArray(MObject node, MObject attr, const bool* const values, size_t count);
+
+    /// \brief  sets all values on a 8bit integer array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \return MS::kSuccess if all ok
+    static MStatus
+    setInt8Array(const MObject& node, const MObject& attr, const std::vector<int8_t>& values);
+
+    /// \brief  sets all values on a 8bit integer array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setInt8Array(MObject node, MObject attr, const int8_t* values, size_t count);
+
+    /// \brief  sets all values on a 16bit integer array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \return MS::kSuccess if all ok
+    static MStatus
+    setInt16Array(const MObject& node, const MObject& attr, const std::vector<int16_t>& values);
+
+    /// \brief  sets all values on a 16bit integer array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setInt16Array(MObject node, MObject attr, const int16_t* values, size_t count);
+
+    /// \brief  sets all values on a 32bit integer array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \return MS::kSuccess if all ok
+    static MStatus
+    setInt32Array(const MObject& node, const MObject& attr, const std::vector<int32_t>& values);
+
+    /// \brief  sets all values on a 32bit integer array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setInt32Array(MObject node, MObject attr, const int32_t* values, size_t count);
+
+    /// \brief  sets all values on a 64bit integer array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \return MS::kSuccess if all ok
+    static MStatus
+    setInt64Array(const MObject& node, const MObject& attr, const std::vector<int64_t>& values);
+
+    /// \brief  sets all values on a 64bit integer array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setInt64Array(MObject node, MObject attr, const int64_t* values, size_t count);
+
+    /// \brief  sets all values on a float array attribute on the specified node (but convert from
+    /// half float data) \param  node the node on which the attribute exists \param  attr the handle
+    /// to the array attribute \param  values the array values to set on the attribute \return
+    /// MS::kSuccess if all ok
+    static MStatus
+    setHalfArray(const MObject& node, const MObject& attr, const std::vector<GfHalf>& values);
+
+    /// \brief  sets all values on a float array attribute on the specified node (but convert from
+    /// half float data) \param  node the node on which the attribute exists \param  attr the handle
+    /// to the array attribute \param  values the array values to set on the attribute \param  count
+    /// the number of elements in the values array \return MS::kSuccess if all ok
+    
+    static MStatus setHalfArray(MObject node, MObject attr, const GfHalf* values, size_t count);
+
+    /// \brief  sets all values on a float array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \return MS::kSuccess if all ok
+    static MStatus
+    setFloatArray(const MObject& node, const MObject& attr, const std::vector<float>& values);
+
+    /// \brief  sets all values on a float array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setFloatArray(MObject node, MObject attr, const float* values, size_t count);
+
+    /// \brief  sets all values on a double array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \return MS::kSuccess if all ok
+    static MStatus
+    setDoubleArray(const MObject& node, const MObject& attr, const std::vector<double>& values);
+
+    /// \brief  sets all values on a double array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setDoubleArray(MObject node, MObject attr, const double* values, size_t count);
+
+    /// \brief  sets all values on a vec2 array attribute on the specified node (converts from half)
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec2Array(MObject node, MObject attr, const GfHalf* values, size_t count);
+
+    /// \brief  sets all values on a vec2 array attribute on the specified node (converts from
+    /// float) \param  node the node on which the attribute exists \param  attr the handle to the
+    /// array attribute \param  values the array values to set on the attribute \param  count the
+    /// number of elements in the values array \return MS::kSuccess if all ok
+    
+    static MStatus setVec2Array(MObject node, MObject attr, const float* values, size_t count);
+
+    /// \brief  sets all values on a vec2 array attribute on the specified node (converts from
+    /// double) \param  node the node on which the attribute exists \param  attr the handle to the
+    /// array attribute \param  values the array values to set on the attribute \param  count the
+    /// number of elements in the values array \return MS::kSuccess if all ok
+    
+    static MStatus setVec2Array(MObject node, MObject attr, const double* values, size_t count);
+
+    /// \brief  sets all values on a vec2 array attribute on the specified node (converts from 32bit
+    /// int) \param  node the node on which the attribute exists \param  attr the handle to the
+    /// array attribute \param  values the array values to set on the attribute \param  count the
+    /// number of elements in the values array \return MS::kSuccess if all ok
+    
+    static MStatus setVec2Array(MObject node, MObject attr, const int32_t* values, size_t count);
+
+    /// \brief  sets all values on a vec3 array attribute on the specified node (converts from half)
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec3Array(MObject node, MObject attr, const GfHalf* values, size_t count);
+
+    /// \brief  sets all values on a vec3 array attribute on the specified node (converts from
+    /// float) \param  node the node on which the attribute exists \param  attr the handle to the
+    /// array attribute \param  values the array values to set on the attribute \param  count the
+    /// number of elements in the values array \return MS::kSuccess if all ok
+    
+    static MStatus setVec3Array(MObject node, MObject attr, const float* values, size_t count);
+
+    /// \brief  sets all values on a vec3 array attribute on the specified node (converts from
+    /// double) \param  node the node on which the attribute exists \param  attr the handle to the
+    /// array attribute \param  values the array values to set on the attribute \param  count the
+    /// number of elements in the values array \return MS::kSuccess if all ok
+    
+    static MStatus setVec3Array(MObject node, MObject attr, const double* values, size_t count);
+
+    /// \brief  sets all values on a vec3 array attribute on the specified node (converts from 32bit
+    /// int) \param  node the node on which the attribute exists \param  attr the handle to the
+    /// array attribute \param  values the array values to set on the attribute \param  count the
+    /// number of elements in the values array \return MS::kSuccess if all ok
+    
+    static MStatus setVec3Array(MObject node, MObject attr, const int32_t* values, size_t count);
+
+    /// \brief  sets all values on a vec4 array attribute on the specified node (converts from half)
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec4Array(MObject node, MObject attr, const GfHalf* values, size_t count);
+
+    /// \brief  sets all values on a vec4 array attribute on the specified node (converts from
+    /// float) \param  node the node on which the attribute exists \param  attr the handle to the
+    /// array attribute \param  values the array values to set on the attribute \param  count the
+    /// number of elements in the values array \return MS::kSuccess if all ok
+    
+    static MStatus setVec4Array(MObject node, MObject attr, const float* values, size_t count);
+
+    /// \brief  sets all values on a vec4 array attribute on the specified node (converts from
+    /// double) \param  node the node on which the attribute exists \param  attr the handle to the
+    /// array attribute \param  values the array values to set on the attribute \param  count the
+    /// number of elements in the values array \return MS::kSuccess if all ok
+    
+    static MStatus setVec4Array(MObject node, MObject attr, const double* values, size_t count);
+
+    /// \brief  sets all values on a vec4 array attribute on the specified node (converts from 32bit
+    /// int) \param  node the node on which the attribute exists \param  attr the handle to the
+    /// array attribute \param  values the array values to set on the attribute \param  count the
+    /// number of elements in the values array \return MS::kSuccess if all ok
+    
+    static MStatus setVec4Array(MObject node, MObject attr, const int32_t* values, size_t count);
+
+    /// \brief  sets all values on a quat array attribute on the specified node (converts from half)
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setQuatArray(MObject node, MObject attr, const GfHalf* values, size_t count);
+
+    /// \brief  sets all values on a quat array attribute on the specified node (converts from
+    /// float) \param  node the node on which the attribute exists \param  attr the handle to the
+    /// array attribute \param  values the array values to set on the attribute \param  count the
+    /// number of elements in the values array \return MS::kSuccess if all ok
+    
+    static MStatus setQuatArray(MObject node, MObject attr, const float* values, size_t count);
+
+    /// \brief  sets all values on a quat array attribute on the specified node (converts from
+    /// double) \param  node the node on which the attribute exists \param  attr the handle to the
+    /// array attribute \param  values the array values to set on the attribute \param  count the
+    /// number of elements in the values array \return MS::kSuccess if all ok
+    
+    static MStatus setQuatArray(MObject node, MObject attr, const double* values, size_t count);
+
+    /// \brief  sets all values on a 2x2 matrix array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setMatrix2x2Array(MObject node, MObject attr, const float* values, size_t count);
+
+    /// \brief  sets all values on a 2x2 matrix array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus
+    setMatrix2x2Array(MObject node, MObject attr, const double* values, size_t count);
+
+    /// \brief  sets all values on a 3x3 matrix array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setMatrix3x3Array(MObject node, MObject attr, const float* values, size_t count);
+
+    /// \brief  sets all values on a 3x3 matrix array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus
+    setMatrix3x3Array(MObject node, MObject attr, const double* values, size_t count);
+
+    /// \brief  sets all values on a 4x4 matrix array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setMatrix4x4Array(MObject node, MObject attr, const float* values, size_t count);
+
+    /// \brief  sets all values on a 4x4 matrix array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus
+    setMatrix4x4Array(MObject node, MObject attr, const double* values, size_t count);
+
+    /// \brief  sets all values on a string array attribute on the specified node
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the array attribute
+    /// \param  values the array values to set on the attribute
+    /// \param  count the number of elements in the values array
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus
+    setStringArray(MObject node, MObject attr, const std::string* values, size_t count);
+
+    /// \brief  sets all values on a time array attribute on the specified node (converts from
+    /// float) \param  node the node on which the attribute exists \param  attr the handle to the
+    /// array attribute \param  values the array values to set on the attribute \param  count the
+    /// number of elements in the values array \param  unit the unit of the incoming data \return
+    /// MS::kSuccess if all ok
+    
+    static MStatus
+    setTimeArray(MObject node, MObject attr, const float* values, size_t count, MTime::Unit unit);
+
+    /// \brief  sets all values on a angle array attribute on the specified node (converts from
+    /// float) \param  node the node on which the attribute exists \param  attr the handle to the
+    /// array attribute \param  values the array values to set on the attribute \param  count the
+    /// number of elements in the values array \param  unit the unit of the incoming data \return
+    /// MS::kSuccess if all ok
+    
+    static MStatus
+    setAngleArray(MObject node, MObject attr, const float* values, size_t count, MAngle::Unit unit);
+
+    /// \brief  sets all values on a distance array attribute on the specified node (converts from
+    /// float) \param  node the node on which the attribute exists \param  attr the handle to the
+    /// array attribute \param  values the array values to set on the attribute \param  count the
+    /// number of elements in the values array \param  unit the unit of the incoming data \return
+    /// MS::kSuccess if all ok
+    
+    static MStatus setDistanceArray(
+        MObject         node,
+        MObject         attr,
+        const float*    values,
+        size_t          count,
+        MDistance::Unit unit);
+
+    /// \name   get data from maya attribute, and store in the USD values array
+    /// \param  node the node to get the attribute data from
+    /// \param  attr the attribute to get the data from
+    /// \param  values the returned array data
+    /// \return MS::kSuccess if succeeded
+    
+    static MStatus
+    setUsdBoolArray(const MObject& node, const MObject& attr, const VtArray<bool>& values);
+
+    /// \name   get data from maya attribute, and store in the USD values array
+    /// \param  node the node to get the attribute data from
+    /// \param  attr the attribute to get the data from
+    /// \param  values the returned array data
+    /// \return MS::kSuccess if succeeded
+    static MStatus
+    setUsdInt8Array(const MObject& node, const MObject& attr, const VtArray<int8_t>& values);
+
+    /// \name   get data from maya attribute, and store in the USD values array
+    /// \param  node the node to get the attribute data from
+    /// \param  attr the attribute to get the data from
+    /// \param  values the returned array data
+    /// \return MS::kSuccess if succeeded
+    static MStatus
+    setUsdInt16Array(const MObject& node, const MObject& attr, const VtArray<int16_t>& values);
+
+    /// \name   get data from maya attribute, and store in the USD values array
+    /// \param  node the node to get the attribute data from
+    /// \param  attr the attribute to get the data from
+    /// \param  values the returned array data
+    /// \return MS::kSuccess if succeeded
+    static MStatus
+    setUsdInt32Array(const MObject& node, const MObject& attr, const VtArray<int32_t>& values);
+
+    /// \name   get data from maya attribute, and store in the USD values array
+    /// \param  node the node to get the attribute data from
+    /// \param  attr the attribute to get the data from
+    /// \param  values the returned array data
+    /// \return MS::kSuccess if succeeded
+    static MStatus
+    setUsdInt64Array(const MObject& node, const MObject& attr, const VtArray<int64_t>& values);
+
+    /// \name   get data from maya attribute, and store in the USD values array
+    /// \param  node the node to get the attribute data from
+    /// \param  attr the attribute to get the data from
+    /// \param  values the returned array data
+    /// \return MS::kSuccess if succeeded
+    static MStatus
+    setUsdHalfArray(const MObject& node, const MObject& attr, const VtArray<GfHalf>& values);
+
+    /// \name   get data from maya attribute, and store in the USD values array
+    /// \param  node the node to get the attribute data from
+    /// \param  attr the attribute to get the data from
+    /// \param  values the returned array data
+    /// \return MS::kSuccess if succeeded
+    static MStatus
+    setUsdFloatArray(const MObject& node, const MObject& attr, const VtArray<float>& values);
+
+    /// \name   get data from maya attribute, and store in the USD values array
+    /// \param  node the node to get the attribute data from
+    /// \param  attr the attribute to get the data from
+    /// \param  values the returned array data
+    /// \return MS::kSuccess if succeeded
+    static MStatus
+    setUsdDoubleArray(const MObject& node, const MObject& attr, const VtArray<double>& values);
+
+    //--------------------------------------------------------------------------------------------------------------------
+    /// \name   animation
+    //--------------------------------------------------------------------------------------------------------------------
+
+    /// \brief  creates animation curves in maya for the specified attribute
+    /// \param  node the node instance the animated attribute belongs to
+    /// \param  attr the attribute handle
+    /// \param  op the USD geometry operation that contains the animation data
+    /// \param  conversionFactor a scaling factor to apply to the source key frames on import.
+    /// \param  newAnimCurves The MObjectArray to contain possibly created animCurve nodes.
+    /// \return MS::kSuccess on success, error code otherwise
+    template <typename T>
+    static MStatus setVec3Anim(
+        MObject              node,
+        MObject              attr,
+        const UsdGeomXformOp op,
+        double               conversionFactor = 1.0,
+        MObjectArray*        newAnimCurves = nullptr);
+
+    /// \brief  creates animation curves in maya for the specified attribute
+    /// \param  node the node instance the animated attribute belongs to
+    /// \param  attr the attribute handle
+    /// \param  times the precollected time samples
+    /// \param  values the precollected values each maps to the time sample element in times
+    /// argument \param  conversionFactor a scaling factor to apply to the source key frames on
+    /// import. \param  newAnimCurves The MObjectArray to contain possibly created animCurve nodes.
+    /// \return MS::kSuccess on success, error code otherwise
+    template <typename T>
+    static MStatus setVec3Anim(
+        MObject                    node,
+        MObject                    attr,
+        const std::vector<double>& times,
+        VtArray<T>&                values,
+        double                     conversionFactor,
+        MObjectArray*              newAnimCurves = nullptr);
+
+    /// \brief  creates animation curves to animate the specified angle attribute
+    /// \param  node the node instance the animated attribute belongs to
+    /// \param  attr the attribute handle
+    /// \param  op the USD transform op that contains the keyframe data
+    /// \param  newAnimCurves The MObjectArray to contain possibly created animCurve nodes.
+    /// \return MS::kSuccess on success, error code otherwise
+    
+    static MStatus setAngleAnim(
+        MObject              node,
+        MObject              attr,
+        const UsdGeomXformOp op,
+        MObjectArray*        newAnimCurves = nullptr);
+
+    /// \brief  creates animation curves in maya for the specified attribute
+    /// \param  node the node instance the animated attribute belongs to
+    /// \param  attr the attribute handle
+    /// \param  usdAttr the USD attribute that contains the keyframe data
+    /// \param  conversionFactor a scaling to apply to the key frames on import
+    /// \param  newAnimCurves The MObjectArray to contain possibly created animCurve nodes.
+    /// \return MS::kSuccess on success, error code otherwise
+    
+    static MStatus setFloatAttrAnim(
+        MObject       node,
+        MObject       attr,
+        UsdAttribute  usdAttr,
+        double        conversionFactor = 1.0,
+        MObjectArray* newAnimCurves = nullptr);
+
+    static MStatus setIntAttrAnim(
+        MObject       node,
+        MObject       attr,
+        UsdAttribute  usdAttr,
+        MObjectArray* newAnimCurves = nullptr);
+
+    static MStatus setBoolAttrAnim(
+        MObject       node,
+        MObject       attr,
+        UsdAttribute  usdAttr,
+        MObjectArray* newAnimCurves = nullptr);
+
+    /// \brief  creates animation curves in maya for the visibility attribute
+    /// \param  node the node instance the animated attribute belongs to
+    /// \param  attr the visibility attribute handle
+    /// \param  usdAttr the USD attribute that contains the keyframe data
+    /// \param  newAnimCurves The MObjectArray to contain possibly created animCurve nodes.
+    /// \return MS::kSuccess on success, error code otherwise
+    
+    static MStatus setVisAttrAnim(
+        const MObject       node,
+        const MObject       attr,
+        const UsdAttribute& usdAttr,
+        MObjectArray*       newAnimCurves = nullptr);
+
+    /// \brief  creates animation curves in maya for the near / far clipping planes attribute
+    /// \param  node the node instance the animated attribute belongs to
+    /// \param  nearAttr the near clipping plane attribute handle
+    /// \param  farAttr the far clipping plane attribute handle
+    /// \param  usdAttr the USD attribute that contains the keyframe data
+    /// \param  newAnimCurves The MObjectArray to contain possibly created animCurve nodes.
+    /// \return MS::kSuccess on success, error code otherwise
+    
+    static MStatus setClippingRangeAttrAnim(
+        const MObject       node,
+        const MObject       nearAttr,
+        const MObject       farAttr,
+        const UsdAttribute& usdAttr,
+        MObjectArray*       newAnimCurves = nullptr);
+
+    /// \brief  check if an animation curves type is supported for DgNodeHelper::set*Anim functions.
+    /// \param  animCurveFn the MFnAnimCurve object that holds a animCurve MObject.
+    /// \return MS::kSuccess if it is supported, error code otherwise
+    
+    static bool isAnimCurveTypeSupported(const MFnAnimCurve& animCurveFn);
+
+    /// \brief  create or reuse the existing animCurve on the plug.
+    /// \param  plug the plug that we are trying to prepare the animCurve for.
+    /// \param  animCurveFn the MFnAnimCurve object that holds a animCurve MObject.
+    /// \param  checkAnimCurveType the MObjectArray to contain the possibly new animCurve nodes.
+    /// \param  newAnimCurves The MObjectArray to contain possibly created animCurve nodes.
+    /// \return MS::kSuccess on success, error code otherwise
+    
+    static MStatus
+    prepareAnimCurve(const MPlug& plug, MFnAnimCurve& animCurveFn, MObjectArray* newAnimCurves);
+
+    //--------------------------------------------------------------------------------------------------------------------
+    /// \name   Methods to set single values on non-array attributes
+    //--------------------------------------------------------------------------------------------------------------------
+
+    /// \brief  sets a half float value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the new value for the attribute
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setHalf(MObject node, MObject attr, const GfHalf value)
+    {
+        return setFloat(node, attr, value);
+    }
+
+    /// \brief  sets a float value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the new value for the attribute
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setFloat(MObject node, MObject attr, float value);
+
+    /// \brief  sets a double value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the new value for the attribute
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setDouble(MObject node, MObject attr, double value);
+
+    /// \brief  sets a time value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the new value for the attribute
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setTime(MObject node, MObject attr, MTime value);
+
+    /// \brief  sets a distance value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the new value for the attribute
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setDistance(MObject node, MObject attr, MDistance value);
+
+    /// \brief  sets an angle value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the new value for the attribute
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setAngle(MObject node, MObject attr, MAngle value);
+
+    /// \brief  sets a boolean value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the new value for the attribute
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setBool(MObject node, MObject attr, bool value);
+
+    /// \brief  sets a 8bit integer value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the new value for the attribute
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setInt8(MObject node, MObject attr, int8_t value);
+
+    /// \brief  sets a 16bit integer value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the new value for the attribute
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setInt16(MObject node, MObject attr, int16_t value);
+
+    /// \brief  sets a 32bit integer value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the new value for the attribute
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setInt32(MObject node, MObject attr, int32_t value);
+
+    /// \brief  sets a 64bit integer value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the new value for the attribute
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setInt64(MObject node, MObject attr, int64_t value);
+
+    /// \brief  sets a 3D vector value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  x the new x value
+    /// \param  y the new y value
+    /// \param  z the new z value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec3(MObject node, MObject attr, float x, float y, float z);
+
+    /// \brief  sets a 3D vector value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  x the new x value
+    /// \param  y the new y value
+    /// \param  z the new z value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec3(MObject node, MObject attr, double x, double y, double z);
+
+    /// \brief  sets a 3D vector value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  x the new x value
+    /// \param  y the new y value
+    /// \param  z the new z value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec3(MObject node, MObject attr, MAngle x, MAngle y, MAngle z);
+
+    /// \brief  sets a 2x2 matrix value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  values the new value (as an array of 4 floats)
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setMatrix2x2(MObject node, MObject attr, const float* values);
+
+    /// \brief  sets a 3x3 matrix value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  values the new value (as an array of 9 floats)
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setMatrix3x3(MObject node, MObject attr, const float* values);
+
+    /// \brief  sets a 4x4 matrix value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  values the new value (as an array of 16 floats)
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setMatrix4x4(MObject node, MObject attr, const float* values);
+
+    /// \brief  sets a 4x4 matrix value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setMatrix4x4(MObject node, MObject attr, const MFloatMatrix& value);
+
+    /// \brief  sets a 2x2 matrix value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  values the new value (as an array of 4 doubles)
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setMatrix2x2(MObject node, MObject attr, const double* values);
+
+    /// \brief  sets a 3x3 matrix value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  values the new value (as an array of 9 doubles)
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setMatrix3x3(MObject node, MObject attr, const double* values);
+
+    /// \brief  sets a 4x4 matrix value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  values the new value (as an array of 16 doubles)
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setMatrix4x4(MObject node, MObject attr, const double* values);
+
+    /// \brief  sets a 4x4 matrix value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  value the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setMatrix4x4(MObject node, MObject attr, const MMatrix& value);
+
+    /// \brief  sets a string value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  str the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setString(MObject node, MObject attr, const char* str);
+
+    /// \brief  sets a string value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  str the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setString(MObject node, MObject attr, const std::string& str);
+
+    /// \brief  sets a 2D vector value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xy the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec2(MObject node, MObject attr, const int32_t* xy);
+
+    /// \brief  sets a 2D vector value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xy the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec2(MObject node, MObject attr, const float* xy);
+
+    /// \brief  sets a 2D vector value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xy the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec2(MObject node, MObject attr, const double* xy);
+
+    /// \brief  sets a 2D vector value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xy the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec2(MObject node, MObject attr, const GfHalf* xy);
+
+    /// \brief  sets a 3D vector value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyz the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec3(MObject node, MObject attr, const int32_t* xyz);
+
+    /// \brief  sets a 3D vector value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyz the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec3(MObject node, MObject attr, const float* xyz);
+
+    /// \brief  sets a 3D vector value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyz the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec3(MObject node, MObject attr, const double* xyz);
+
+    /// \brief  sets a 3D vector value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyz the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec3(MObject node, MObject attr, const GfHalf* xyz);
+
+    /// \brief  sets a 4D vector value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyzw the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec4(MObject node, MObject attr, const int32_t* xyzw);
+
+    /// \brief  sets a 4D vector value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyzw the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec4(MObject node, MObject attr, const float* xyzw);
+
+    /// \brief  sets a 4D vector value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyzw the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec4(MObject node, MObject attr, const double* xyzw);
+
+    /// \brief  sets a 4D vector value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyzw the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setVec4(MObject node, MObject attr, const GfHalf* xyzw);
+
+    /// \brief  sets a 4D quat value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyzw the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setQuat(MObject node, MObject attr, const float* xyzw);
+
+    /// \brief  sets a 4D quat value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyzw the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setQuat(MObject node, MObject attr, const double* xyzw);
+
+    /// \brief  sets a 4D quat value on the specified node/attribute
+    /// \param  node the node on which the attribute exists
+    /// \param  attr the handle to the attribute
+    /// \param  xyzw the new value
+    /// \return MS::kSuccess if all ok
+    
+    static MStatus setQuat(MObject node, MObject attr, const GfHalf* xyzw);
+
+    //--------------------------------------------------------------------------------------------------------------------
+    /// \name   Copy single values from USD to Maya
+    //--------------------------------------------------------------------------------------------------------------------
+
+    /// \brief  copy a boolean value from USD and apply to Maya attribute
+    /// \param  node the node to copy the attribute data to
+    /// \param  attr the attribute to copy the data to
+    /// \param  value the USD attribute to copy the data from
+    /// \return MS::kSuccess if succeeded
+    
+    static MStatus copyBool(MObject node, MObject attr, const UsdAttribute& value);
+
+    /// \brief  copy a boolean value from USD and apply to Maya attribute
+    /// \param  node the node to copy the attribute data to
+    /// \param  attr the attribute to copy the data to
+    /// \param  value the USD attribute to copy the data from
+    /// \return MS::kSuccess if succeeded
+    
+    static MStatus copyFloat(MObject node, MObject attr, const UsdAttribute& value);
+
+    /// \brief  copy a boolean value from USD and apply to Maya attribute
+    /// \param  node the node to copy the attribute data to
+    /// \param  attr the attribute to copy the data to
+    /// \param  value the USD attribute to copy the data from
+    /// \return MS::kSuccess if succeeded
+    
+    static MStatus copyDouble(MObject node, MObject attr, const UsdAttribute& value);
+
+    /// \brief  copy a boolean value from USD and apply to Maya attribute
+    /// \param  node the node to copy the attribute data to
+    /// \param  attr the attribute to copy the data to
+    /// \param  value the USD attribute to copy the data from
+    /// \return MS::kSuccess if succeeded
+    
+    static MStatus copyInt(MObject node, MObject attr, const UsdAttribute& value);
+
+    /// \brief  copy a boolean value from USD and apply to Maya attribute
+    /// \param  node the node to copy the attribute data to
+    /// \param  attr the attribute to copy the data to
+    /// \param  value the USD attribute to copy the data from
+    /// \return MS::kSuccess if succeeded
+    static MStatus copyVec3(MObject node, MObject attr, const UsdAttribute& value);
+
+    //--------------------------------------------------------------------------------------------------------------------
+    /// \name   Internal import/export utils
+    //--------------------------------------------------------------------------------------------------------------------
+
+    /// \brief  copy a non array value from a usd attribute into the maya attribute specified
+    /// \param  node the node to copy the attribute data to
+    /// \param  attr the attribute to copy the data to
+    /// \param  usdAttr the attribute to copy the from
+    /// \param  type the attribute type
+    /// \return MS::kSuccess if succeeded, error code otherwise
+    
+    static MStatus setSingleMayaValue(
+        MObject             node,
+        MObject             attr,
+        const UsdAttribute& usdAttr,
+        const UsdDataType   type);
+
+    /// \brief  copy an array value from a usd attribute into the maya attribute specified
+    /// \param  node the node to copy the attribute data to
+    /// \param  attr the attribute to copy the data to
+    /// \param  usdAttr the attribute to copy the from
+    /// \param  type the attribute type of the array elements
+    /// \return MS::kSuccess if succeeded, error code otherwise
+    
+    static MStatus setArrayMayaValue(
+        MObject             node,
+        MObject             attr,
+        const UsdAttribute& usdAttr,
+        const UsdDataType   type);
+
+    /// \brief  copy the value from the usdAttribute onto the maya attribute value
+    /// \param  node the node to copy the attribute data to
+    /// \param  attr the attribute to copy the data to
+    /// \param  usdAttr the attribute to copy the from
+    /// \return MS::kSuccess if succeeded, error code otherwise
+    
+    static MStatus setMayaValue(MObject node, MObject attr, const UsdAttribute& usdAttr);
+
+    /// \brief  copy all custom attributes from the usd primitive onto the maya node.
+    /// \param  node the node to copy the attributes to
+    /// \param  prim the USD prim to copy the attributes from
+    /// \return MS::kSuccess if succeeded, error code otherwise
+    
+//    static MStatus
+//    copyDynamicAttributes(MObject node, UsdPrim& prim, AnimationTranslator* translator = 0);
+
+    /// \brief  copy the attribute value from the plug specified, at the given time, and store the
+    /// data on the usdAttr. \param  attr the attribute to be copied \param  usdAttr the attribute
+    /// to copy the data to \param  timeCode the timecode to use when setting the data
+    
+    static void
+    copyAttributeValue(const MPlug& attr, UsdAttribute& usdAttr, const UsdTimeCode& timeCode);
+
+    /// \brief  copy the attribute value from the plug specified, at the given time, and store the
+    /// data on the usdAttr. \param  plug the attribute to be copied \param  usdAttr the attribute
+    /// to copy the data to \param  timeCode the timecode to use when setting the data
+    
+    static void
+    copySimpleValue(const MPlug& plug, UsdAttribute& usdAttr, const UsdTimeCode& timeCode);
+
+    /// \brief  copy the attribute value from the plug specified, at the given time, and store the
+    /// data on the usdAttr. \param  attr the attribute to be copied \param  usdAttr the attribute
+    /// to copy the data to \param  scale a scaling factor to apply to provide support for \param
+    /// timeCode the timecode to use when setting the data
+    
+    static void copyAttributeValue(
+        const MPlug&       attr,
+        UsdAttribute&      usdAttr,
+        float              scale,
+        const UsdTimeCode& timeCode);
+
+    /// \brief  copy the attribute value from the plug specified, at the given time, and store the
+    /// data on the usdAttr. \param  plug the attribute to be copied \param  usdAttr the attribute
+    /// to copy the data to \param  scale a scaling factor to apply to provide support for \param
+    /// timeCode the timecode to use when setting the data
+    
+    static void copySimpleValue(
+        const MPlug&       plug,
+        UsdAttribute&      usdAttr,
+        float              scale,
+        const UsdTimeCode& timeCode);
+
+    /// \brief  convert value from the plug specified and set it to usd attribute.
+    /// \param  plug the plug to copy the attributes value from
+    /// \param  usdAttr the USDAttribute to set the attribute value to
+    /// \return MS::kSuccess if the conversion success based on certain rules.
+    
+    static MStatus convertSpecialValueToUSDAttribute(const MPlug& plug, UsdAttribute& usdAttr);
+
+    //--------------------------------------------------------------------------------------------------------------------
+    /// \name   Utilities
+    //--------------------------------------------------------------------------------------------------------------------
+
+    /// \brief  adds a new strings attribute of the specified name to the specified node, and sets
+    /// its value. This is
+    ///         primarily used as a utility to tag various maya nodes with some USD specific
+    ///         information, e.g. the by adding a prim path, asset info, etc.
+    /// \param  node the node to add the attribute to
+    /// \param  attrName the name of the attribute to add
+    /// \param  stringValue the value for the new atribue
+    /// \return MS::kSuccess if ok.
+    
+    static MStatus addStringValue(MObject node, const char* attrName, const char* stringValue);
+};
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus
+DgNodeHelper::getInt8Array(const MObject& node, const MObject& attr, std::vector<int8_t>& values)
+{
+    MPlug plug(node, attr);
+    if (!plug || !plug.isArray())
+        return MS::kFailure;
+    const uint32_t num = plug.numElements();
+    values.resize(num);
+    return getInt8Array(node, attr, values.data(), num);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus
+DgNodeHelper::getInt16Array(const MObject& node, const MObject& attr, std::vector<int16_t>& values)
+{
+    MPlug plug(node, attr);
+    if (!plug || !plug.isArray())
+        return MS::kFailure;
+    const uint32_t num = plug.numElements();
+    values.resize(num);
+    return getInt16Array(node, attr, values.data(), num);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus
+DgNodeHelper::getInt32Array(const MObject& node, const MObject& attr, std::vector<int32_t>& values)
+{
+    MPlug plug(node, attr);
+    if (!plug || !plug.isArray())
+        return MS::kFailure;
+    const uint32_t num = plug.numElements();
+    values.resize(num);
+    return getInt32Array(node, attr, values.data(), num);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus
+DgNodeHelper::getInt64Array(const MObject& node, const MObject& attr, std::vector<int64_t>& values)
+{
+    MPlug plug(node, attr);
+    if (!plug || !plug.isArray())
+        return MS::kFailure;
+    const uint32_t num = plug.numElements();
+    values.resize(num);
+    return getInt64Array(node, attr, values.data(), num);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus
+DgNodeHelper::getHalfArray(const MObject& node, const MObject& attr, std::vector<GfHalf>& values)
+{
+    MPlug plug(node, attr);
+    if (!plug || !plug.isArray())
+        return MS::kFailure;
+    const uint32_t num = plug.numElements();
+    values.resize(num);
+    return getHalfArray(node, attr, values.data(), num);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus
+DgNodeHelper::getFloatArray(const MObject& node, const MObject& attr, std::vector<float>& values)
+{
+    MPlug plug(node, attr);
+    if (!plug || !plug.isArray())
+        return MS::kFailure;
+    const uint32_t num = plug.numElements();
+    values.resize(num);
+    return getFloatArray(node, attr, values.data(), num);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus
+DgNodeHelper::getDoubleArray(const MObject& node, const MObject& attr, std::vector<double>& values)
+{
+    MPlug plug(node, attr);
+    if (!plug || !plug.isArray())
+        return MS::kFailure;
+    const uint32_t num = plug.numElements();
+    values.resize(num);
+    return getDoubleArray(node, attr, values.data(), num);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus
+DgNodeHelper::getUsdInt8Array(const MObject& node, const MObject& attr, VtArray<int8_t>& values)
+{
+    MPlug plug(node, attr);
+    if (!plug || !plug.isArray())
+        return MS::kFailure;
+    const uint32_t num = plug.numElements();
+    values.resize(num);
+    return getInt8Array(node, attr, values.data(), num);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus
+DgNodeHelper::getUsdInt16Array(const MObject& node, const MObject& attr, VtArray<int16_t>& values)
+{
+    MPlug plug(node, attr);
+    if (!plug || !plug.isArray())
+        return MS::kFailure;
+    const uint32_t num = plug.numElements();
+    values.resize(num);
+    return getInt16Array(node, attr, values.data(), num);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus
+DgNodeHelper::getUsdInt32Array(const MObject& node, const MObject& attr, VtArray<int32_t>& values)
+{
+    MPlug plug(node, attr);
+    if (!plug || !plug.isArray())
+        return MS::kFailure;
+    const uint32_t num = plug.numElements();
+    values.resize(num);
+    return getInt32Array(node, attr, values.data(), num);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus
+DgNodeHelper::getUsdInt64Array(const MObject& node, const MObject& attr, VtArray<int64_t>& values)
+{
+    MPlug plug(node, attr);
+    if (!plug || !plug.isArray())
+        return MS::kFailure;
+    const uint32_t num = plug.numElements();
+    values.resize(num);
+    return getInt64Array(node, attr, values.data(), num);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus
+DgNodeHelper::getUsdHalfArray(const MObject& node, const MObject& attr, VtArray<GfHalf>& values)
+{
+    MPlug plug(node, attr);
+    if (!plug || !plug.isArray())
+        return MS::kFailure;
+    const uint32_t num = plug.numElements();
+    values.resize(num);
+    return getHalfArray(node, attr, values.data(), num);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus
+DgNodeHelper::getUsdFloatArray(const MObject& node, const MObject& attr, VtArray<float>& values)
+{
+    MPlug plug(node, attr);
+    if (!plug || !plug.isArray())
+        return MS::kFailure;
+    const uint32_t num = plug.numElements();
+    values.resize(num);
+    return getFloatArray(node, attr, values.data(), num);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus
+DgNodeHelper::getUsdDoubleArray(const MObject& node, const MObject& attr, VtArray<double>& values)
+{
+    MPlug plug(node, attr);
+    if (!plug || !plug.isArray())
+        return MS::kFailure;
+    const uint32_t num = plug.numElements();
+    values.resize(num);
+    return getDoubleArray(node, attr, values.data(), num);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus DgNodeHelper::setInt8Array(
+    const MObject&             node,
+    const MObject&             attr,
+    const std::vector<int8_t>& values)
+{
+    return setInt8Array(node, attr, values.data(), values.size());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus DgNodeHelper::setInt16Array(
+    const MObject&              node,
+    const MObject&              attr,
+    const std::vector<int16_t>& values)
+{
+    return setInt16Array(node, attr, values.data(), values.size());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus DgNodeHelper::setInt32Array(
+    const MObject&              node,
+    const MObject&              attr,
+    const std::vector<int32_t>& values)
+{
+    return setInt32Array(node, attr, values.data(), values.size());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus DgNodeHelper::setInt64Array(
+    const MObject&              node,
+    const MObject&              attr,
+    const std::vector<int64_t>& values)
+{
+    return setInt64Array(node, attr, values.data(), values.size());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus DgNodeHelper::setHalfArray(
+    const MObject&             node,
+    const MObject&             attr,
+    const std::vector<GfHalf>& values)
+{
+    return setHalfArray(node, attr, values.data(), values.size());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus DgNodeHelper::setFloatArray(
+    const MObject&            node,
+    const MObject&            attr,
+    const std::vector<float>& values)
+{
+    return setFloatArray(node, attr, values.data(), values.size());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus DgNodeHelper::setDoubleArray(
+    const MObject&             node,
+    const MObject&             attr,
+    const std::vector<double>& values)
+{
+    return setDoubleArray(node, attr, values.data(), values.size());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus DgNodeHelper::setUsdInt8Array(
+    const MObject&         node,
+    const MObject&         attr,
+    const VtArray<int8_t>& values)
+{
+    return setInt8Array(node, attr, values.cdata(), values.size());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus DgNodeHelper::setUsdInt16Array(
+    const MObject&          node,
+    const MObject&          attr,
+    const VtArray<int16_t>& values)
+{
+    return setInt16Array(node, attr, values.cdata(), values.size());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus DgNodeHelper::setUsdInt32Array(
+    const MObject&          node,
+    const MObject&          attr,
+    const VtArray<int32_t>& values)
+{
+    return setInt32Array(node, attr, values.cdata(), values.size());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus DgNodeHelper::setUsdInt64Array(
+    const MObject&          node,
+    const MObject&          attr,
+    const VtArray<int64_t>& values)
+{
+    return setInt64Array(node, attr, values.cdata(), values.size());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus DgNodeHelper::setUsdHalfArray(
+    const MObject&         node,
+    const MObject&         attr,
+    const VtArray<GfHalf>& values)
+{
+    return setHalfArray(node, attr, values.cdata(), values.size());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus DgNodeHelper::setUsdFloatArray(
+    const MObject&        node,
+    const MObject&        attr,
+    const VtArray<float>& values)
+{
+    return setFloatArray(node, attr, values.cdata(), values.size());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline MStatus DgNodeHelper::setUsdDoubleArray(
+    const MObject&         node,
+    const MObject&         attr,
+    const VtArray<double>& values)
+{
+    return setDoubleArray(node, attr, values.cdata(), values.size());
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+inline bool DgNodeHelper::isAnimCurveTypeSupported(const MFnAnimCurve& animCurveFn)
+{
+    auto type = animCurveFn.animCurveType();
+    return (
+        type == MFnAnimCurve::kAnimCurveTL || // time->distance: translation
+        type == MFnAnimCurve::kAnimCurveTA || // time->angle: rotation
+        type == MFnAnimCurve::kAnimCurveTU);  // time->double: scale or boolean
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+template <typename T>
+MStatus DgNodeHelper::setVec3Anim(
+    MObject              node,
+    MObject              attr,
+    const UsdGeomXformOp op,
+    double               conversionFactor,
+    MObjectArray*        newAnimCurves)
+{
+    std::vector<double> times;
+    op.GetTimeSamples(&times);
+
+    VtArray<T> values;
+    T          value(0);
+    for (auto const& timeValue : times) {
+        const bool retValue = op.GetAs<T>(&value, timeValue);
+        if (!retValue)
+            continue;
+        values.push_back(value);
+    }
+
+    return setVec3Anim<T>(node, attr, times, values, conversionFactor, newAnimCurves);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+template <typename T>
+MStatus DgNodeHelper::setVec3Anim(
+    MObject                    node,
+    MObject                    attr,
+    const std::vector<double>& times,
+    VtArray<T>&                values,
+    double                     conversionFactor,
+    MObjectArray*              newAnimCurves)
+{
+    MPlug   plug(node, attr);
+    MStatus status;
+
+    MFnAnimCurve xFn, yFn, zFn;
+    status = prepareAnimCurve(plug.child(0), xFn, newAnimCurves);
+    if (!status)
+        return MS::kFailure;
+
+    status = prepareAnimCurve(plug.child(1), yFn, newAnimCurves);
+    if (!status)
+        return MS::kFailure;
+
+    status = prepareAnimCurve(plug.child(2), zFn, newAnimCurves);
+    if (!status)
+        return MS::kFailure;
+
+    const char* const xformErrorEdit = "DgNodeTranslator:setVec3Anim error setting animation curve";
+    size_t            timeIndex = 0;
+    for (auto const& timeValue : times) {
+        MTime tm(timeValue, MTime::kFilm);
+        T&    value = values[timeIndex];
+        xFn.addKey(
+            tm,
+            value[0] * conversionFactor,
+            MFnAnimCurve::kTangentGlobal,
+            MFnAnimCurve::kTangentGlobal,
+            NULL,
+            &status);
+//        AL_MAYA_CHECK_ERROR(status, xformErrorEdit);
+        yFn.addKey(
+            tm,
+            value[1] * conversionFactor,
+            MFnAnimCurve::kTangentGlobal,
+            MFnAnimCurve::kTangentGlobal,
+            NULL,
+            &status);
+//        AL_MAYA_CHECK_ERROR(status, xformErrorEdit);
+        zFn.addKey(
+            tm,
+            value[2] * conversionFactor,
+            MFnAnimCurve::kTangentGlobal,
+            MFnAnimCurve::kTangentGlobal,
+            NULL,
+            &status);
+//        AL_MAYA_CHECK_ERROR(status, xformErrorEdit);
+        timeIndex++;
+    }
+
+    return MS::kSuccess;
+}

--- a/lib/mayaUsd/fileio/translators/NodeHelper.cpp
+++ b/lib/mayaUsd/fileio/translators/NodeHelper.cpp
@@ -1,0 +1,2512 @@
+//
+// Copyright 2017 Animal Logic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "mayaUsd/fileio/translators/NodeHelper.h"
+
+#include <maya/MDataBlock.h>
+#include <maya/MEulerRotation.h>
+#include <maya/MFnCompoundAttribute.h>
+#include <maya/MFnDependencyNode.h>
+#include <maya/MFnEnumAttribute.h>
+#include <maya/MFnMatrixAttribute.h>
+#include <maya/MFnMessageAttribute.h>
+#include <maya/MFnPluginData.h>
+#include <maya/MFnStringData.h>
+#include <maya/MFnTypedAttribute.h>
+#include <maya/MFnUnitAttribute.h>
+#include <maya/MGlobal.h>
+#include <maya/MMatrix.h>
+#include <maya/MPxNode.h>
+#include <maya/MTime.h>
+
+#include <cassert>
+#include <cctype>
+#include <iostream>
+#include <sstream>
+
+//----------------------------------------------------------------------------------------------------------------------
+// takes an attribute name such as "thisIsAnAttribute" and turns it into "This Is An Attribute".
+// Just used to make the attributes a little bit more readable in the Attribute Editor GUI.
+//----------------------------------------------------------------------------------------------------------------------
+std::string beautifyAttrName(std::string attrName)
+{
+    if (std::islower(attrName[0])) {
+        attrName[0] = std::toupper(attrName[0]);
+    }
+    for (size_t i = 1; i < attrName.size(); ++i) {
+        if (std::isupper(attrName[i])) {
+            attrName.insert(i++, 1, ' ');
+        }
+    }
+    return attrName;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+/// \brief  A little code generator that outputs the custom AE gui needed to handle file path
+/// attributes. \param  nodeName type name of the node \param  attrName the name of the file path
+/// attribute \param  fileFilter a filter string of the form:  "USD Files (*.usd*) (*.usd*);;Alembic
+/// Files (*.abc)"
+//----------------------------------------------------------------------------------------------------------------------
+void constructFilePathUi(
+    std::ostringstream&        oss,
+    const std::string&         nodeName,
+    const std::string&         attrName,
+    const std::string&         fileFilter,
+    const NodeHelper::FileMode mode)
+{
+    // generate code to create a file attribute GUI (with button to click to load the file)
+    oss << "global proc AE" << nodeName << "Template_" << attrName << "New(string $anAttr) {\n";
+    oss << "  setUITemplate -pushTemplate attributeEditorTemplate;\n";
+    oss << "  rowLayout -numberOfColumns 3;\n";
+    oss << "    text -label \"" << beautifyAttrName(attrName) << "\";\n";
+    oss << "    textField " << attrName << "FilePathField;\n";
+    oss << "    symbolButton -image \"navButtonBrowse.xpm\" " << attrName << "FileBrowserButton;\n";
+    oss << "  setParent ..;\n";
+    oss << "  AE" << nodeName << "Template_" << attrName << "Replace($anAttr);\n";
+    oss << "  setUITemplate -popTemplate;\n";
+    oss << "}\n";
+
+    // generate the method that will replace the value in the control when another node of the same
+    // type is selected
+    oss << "global proc AE" << nodeName << "Template_" << attrName << "Replace(string $anAttr) {\n";
+    oss << "  evalDeferred (\"connectControl " << attrName << "FilePathField \" + $anAttr);\n";
+    oss << "  button -edit -command (\"AE" << nodeName << "Template_" << attrName
+        << "FileBrowser \" + $anAttr) " << attrName << "FileBrowserButton;\n";
+    oss << "}\n";
+
+    // generate the button callback that will actually create the file dialog for our attribute.
+    // Depending on the fileMode used, we may end up having more than one filename, which will be
+    // munged together with a semi-colon as the seperator. It's arguably a little wasteful to retain
+    // the code that munges together multiple paths when using a single file select mode. Meh. :)
+    oss << "global proc AE" << nodeName << "Template_" << attrName
+        << "FileBrowser(string $anAttr) {\n";
+    oss << "  string $fileNames[] = `fileDialog2 -caption \"Specify " << beautifyAttrName(attrName)
+        << "\"";
+    if (!fileFilter.empty()) {
+        oss << " -fileFilter \"" << fileFilter << "\"";
+    }
+    oss << " -fileMode " << mode << "`;\n";
+    oss << "  if (size($fileNames) > 0) {\n";
+    oss << "    string $concatonated = $fileNames[0];\n";
+    oss << "    for($ii=1; $ii < size($fileNames); ++$ii) $concatonated += (\";\" + "
+           "$fileNames[$ii]);\n";
+    oss << "    evalEcho (\"setAttr -type \\\"string\\\" \" + $anAttr + \" \\\"\" + $concatonated "
+           "+ \"\\\"\");\n";
+    oss << "  }\n";
+    oss << "}\n";
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+NodeHelper::InternalData* NodeHelper::m_internal = 0;
+
+//----------------------------------------------------------------------------------------------------------------------
+void NodeHelper::setNodeType(const MString& typeName)
+{
+    if (!m_internal) {
+        m_internal = new InternalData;
+    }
+    m_internal->m_typeBeingRegistered = typeName.asChar();
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+void NodeHelper::addFrame(const char* frameTitle)
+{
+    if (!m_internal)
+        m_internal = new InternalData;
+    m_internal->m_frames.push_front(Frame(frameTitle));
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+bool NodeHelper::addFrameAttr(
+    const char*            longName,
+    uint32_t               flags,
+    bool                   forceShow,
+    Frame::AttributeUiType attrType)
+{
+    if (forceShow || ((flags & kWritable) && !(flags & kHidden) && !(flags & kDontAddToNode))) {
+        if (m_internal) {
+            Frame& frame = *m_internal->m_frames.begin();
+            frame.m_attributes.push_back(longName);
+            frame.m_attributeTypes.push_back(attrType);
+            return true;
+        }
+    }
+    return false;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addEnumAttr(
+    const char*        longName,
+    const char*        shortName,
+    uint32_t           flags,
+    const char* const* strings,
+    const int16_t*     values)
+{
+    addFrameAttr(longName, flags);
+
+    MFnEnumAttribute fn;
+    MObject          attribute = fn.create(longName, shortName, MFnData::kString);
+    while (*strings) {
+        fn.addField(*strings, *values);
+        ++values;
+        ++strings;
+    }
+    fn.setDefault(0);
+
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addMeshAttr(const char* longName, const char* shortName, uint32_t flags)
+{
+    MFnTypedAttribute fn;
+    MStatus           status;
+    MObject attr = fn.create(longName, shortName, MFnData::kMesh, MObject::kNullObj, &status);
+    if (!status)
+        throw status;
+    status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+
+    return attr;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addStringAttr(
+    const char* longName,
+    const char* shortName,
+    uint32_t    flags,
+    bool        forceShow)
+{
+    return addStringAttr(longName, shortName, "", flags, forceShow);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+void NodeHelper::inheritStringAttr(const char* longName, uint32_t flags, bool forceShow)
+{
+    addFrameAttr(longName, flags, forceShow);
+}
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addStringAttr(
+    const char* longName,
+    const char* shortName,
+    const char* defaultValue,
+    uint32_t    flags,
+    bool        forceShow)
+{
+    inheritStringAttr(longName, flags, forceShow);
+
+    MFnTypedAttribute fn;
+    MFnStringData     stringData;
+    MStatus           stat;
+    MObject           attribute = fn.create(
+        longName, shortName, MFnData::kString, stringData.create(MString(defaultValue), &stat));
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+void NodeHelper::inheritFilePathAttr(
+    const char* longName,
+    uint32_t    flags,
+    FileMode    fileMode,
+    const char* fileFilter)
+{
+    if (addFrameAttr(longName, flags, false, (Frame::AttributeUiType)fileMode)) {
+        // Technically, shouldn't need to check m_internal again, as addFrameAttr
+        // shouldn't return true unless m_internal is non-null... however, checking
+        // out of paranoia that this might change in the future.
+        if (m_internal) {
+            Frame& frame = *m_internal->m_frames.begin();
+            frame.m_fileFilters.push_back(fileFilter);
+        }
+    }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addFilePathAttr(
+    const char* longName,
+    const char* shortName,
+    uint32_t    flags,
+    FileMode    fileMode,
+    const char* fileFilter)
+{
+    inheritFilePathAttr(longName, flags, fileMode, fileFilter);
+    MFnTypedAttribute fn;
+    MObject           attribute = fn.create(longName, shortName, MFnData::kString);
+    MStatus           status = applyAttributeFlags(fn, flags);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addInt8Attr(
+    const char* longName,
+    const char* shortName,
+    int8_t      defaultValue,
+    uint32_t    flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute fn;
+    MObject attribute = fn.create(longName, shortName, MFnNumericData::kChar, defaultValue);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addInt16Attr(
+    const char* longName,
+    const char* shortName,
+    int16_t     defaultValue,
+    uint32_t    flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute fn;
+    MObject attribute = fn.create(longName, shortName, MFnNumericData::kShort, defaultValue);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+void NodeHelper::inheritInt32Attr(const char* longName, uint32_t flags)
+{
+    addFrameAttr(longName, flags);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addInt32Attr(
+    const char* longName,
+    const char* shortName,
+    int32_t     defaultValue,
+    uint32_t    flags)
+{
+    inheritInt32Attr(longName, flags);
+
+    MFnNumericAttribute fn;
+    MObject attribute = fn.create(longName, shortName, MFnNumericData::kInt, defaultValue);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addInt64Attr(
+    const char* longName,
+    const char* shortName,
+    int64_t     defaultValue,
+    uint32_t    flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute fn;
+    MObject attribute = fn.create(longName, shortName, MFnNumericData::kInt64, defaultValue);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addFloatAttr(
+    const char* longName,
+    const char* shortName,
+    float       defaultValue,
+    uint32_t    flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute fn;
+    MObject attribute = fn.create(longName, shortName, MFnNumericData::kFloat, defaultValue);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+void NodeHelper::inheritTimeAttr(const char* longName, uint32_t flags)
+{
+    addFrameAttr(longName, flags);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addTimeAttr(
+    const char*  longName,
+    const char*  shortName,
+    const MTime& defaultValue,
+    uint32_t     flags)
+{
+    inheritTimeAttr(longName, flags);
+
+    MFnUnitAttribute fn;
+    MObject          attribute = fn.create(longName, shortName, defaultValue);
+    MStatus          status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addDistanceAttr(
+    const char*      longName,
+    const char*      shortName,
+    const MDistance& defaultValue,
+    uint32_t         flags)
+{
+    addFrameAttr(longName, flags);
+    MFnUnitAttribute fn;
+    MObject          attribute = fn.create(longName, shortName, defaultValue);
+    MStatus          status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addAngleAttr(
+    const char*   longName,
+    const char*   shortName,
+    const MAngle& defaultValue,
+    uint32_t      flags)
+{
+    addFrameAttr(longName, flags);
+    MFnUnitAttribute fn;
+    MObject          attribute = fn.create(longName, shortName, defaultValue);
+    MStatus          status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+//----------------------------------------------------------------------------------------------------------------------
+
+MObject NodeHelper::addFloatArrayAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    uint32_t       flags)
+{
+    addFrameAttr(longName, flags);
+
+    MStatus           status;
+    MFnTypedAttribute fnAttr;
+    MString           ln(longName);
+    MString           sn(shortName);
+
+    MObject attribute = fnAttr.create(ln, sn, MFnData::kFloatArray, MObject::kNullObj, &status);
+
+    if (status != MS::kSuccess) {
+        MGlobal::displayWarning("addFloatArrayAttr:Failed to create attribute");
+    }
+    applyAttributeFlags(fnAttr, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+
+    MFnDependencyNode fn(node, &status);
+    if (!status) {
+        throw status;
+    }
+
+    status = fn.addAttribute(attribute);
+    if (status != MS::kSuccess)
+        MGlobal::displayWarning(
+            MString("addFloatArrayAttr::addAttribute: ") + MString(status.errorString()));
+
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addDoubleAttr(
+    const char* longName,
+    const char* shortName,
+    double      defaultValue,
+    uint32_t    flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute fn;
+    MObject attribute = fn.create(longName, shortName, MFnNumericData::kDouble, defaultValue);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+void NodeHelper::inheritBoolAttr(const char* longName, uint32_t flags)
+{
+    addFrameAttr(longName, flags);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addBoolAttr(
+    const char* longName,
+    const char* shortName,
+    bool        defaultValue,
+    uint32_t    flags)
+{
+    inheritBoolAttr(longName, flags);
+
+    MFnNumericAttribute fn;
+    MObject attribute = fn.create(longName, shortName, MFnNumericData::kBoolean, defaultValue);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addFloat3Attr(
+    const char* longName,
+    const char* shortName,
+    float       defaultX,
+    float       defaultY,
+    float       defaultZ,
+    uint32_t    flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute fn;
+    MObject             attribute;
+    if (flags & kColour) {
+        attribute = fn.createColor(longName, shortName);
+        fn.setDefault(defaultX, defaultY, defaultZ);
+    } else {
+        MString ln(longName);
+        MString sn(shortName);
+        MObject x = fn.create(ln + "X", sn + "x", MFnNumericData::kFloat, defaultX);
+        MObject y = fn.create(ln + "Y", sn + "y", MFnNumericData::kFloat, defaultY);
+        MObject z = fn.create(ln + "Z", sn + "z", MFnNumericData::kFloat, defaultZ);
+        attribute = fn.create(ln, sn, x, y, z);
+    }
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addPointAttr(
+    const char*   longName,
+    const char*   shortName,
+    const MPoint& defaultValue,
+    uint32_t      flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute fn;
+    MObject             attribute;
+    attribute = fn.createPoint(longName, shortName);
+    fn.setDefault(defaultValue.x, defaultValue.y, defaultValue.z);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addVectorAttr(
+    const char*    longName,
+    const char*    shortName,
+    const MVector& defaultValue,
+    uint32_t       flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute fn;
+    MObject             attribute;
+    MString             ln(longName);
+    MString             sn(shortName);
+    MObject             x = fn.create(ln + "X", sn + "x", MFnNumericData::kDouble, defaultValue.x);
+    MObject             y = fn.create(ln + "Y", sn + "y", MFnNumericData::kDouble, defaultValue.y);
+    MObject             z = fn.create(ln + "Z", sn + "z", MFnNumericData::kDouble, defaultValue.z);
+    attribute = fn.create(ln, sn, x, y, z);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addAngle3Attr(
+    const char* longName,
+    const char* shortName,
+    float       defaultX,
+    float       defaultY,
+    float       defaultZ,
+    uint32_t    flags)
+{
+    addFrameAttr(longName, flags);
+    MFnUnitAttribute    fnu;
+    MFnNumericAttribute fn;
+    MObject             attribute;
+    MString             ln(longName);
+    MString             sn(shortName);
+    MObject             x = fnu.create(ln + "X", sn + "x", MFnUnitAttribute::kAngle, defaultX);
+    MObject             y = fnu.create(ln + "Y", sn + "y", MFnUnitAttribute::kAngle, defaultY);
+    MObject             z = fnu.create(ln + "Z", sn + "z", MFnUnitAttribute::kAngle, defaultZ);
+    attribute = fn.create(ln, sn, x, y, z);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addDistance3Attr(
+    const char* longName,
+    const char* shortName,
+    float       defaultX,
+    float       defaultY,
+    float       defaultZ,
+    uint32_t    flags)
+{
+    addFrameAttr(longName, flags);
+    MFnUnitAttribute    fnu;
+    MFnNumericAttribute fn;
+    MObject             attribute;
+    MString             ln(longName);
+    MString             sn(shortName);
+    MObject             x = fnu.create(ln + "X", sn + "x", MFnUnitAttribute::kDistance, defaultX);
+    MObject             y = fnu.create(ln + "Y", sn + "y", MFnUnitAttribute::kDistance, defaultY);
+    MObject             z = fnu.create(ln + "Z", sn + "z", MFnUnitAttribute::kDistance, defaultZ);
+    attribute = fn.create(ln, sn, x, y, z);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addMatrixAttr(
+    const char*    longName,
+    const char*    shortName,
+    const MMatrix& defaultValue,
+    uint32_t       flags)
+{
+    addFrameAttr(longName, flags);
+    MFnMatrixAttribute fn;
+    MObject            attribute;
+    attribute = fn.create(longName, shortName, MFnMatrixAttribute::kDouble);
+    fn.setDefault(defaultValue);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addMatrix3x3Attr(
+    const char* longName,
+    const char* shortName,
+    const float defaultValue[3][3],
+    uint32_t    flags)
+{
+    addFrameAttr(longName, flags);
+
+    MFnNumericAttribute  fn;
+    MFnCompoundAttribute fnc;
+    MString              ln(longName);
+    MString              sn(shortName);
+    MObject xx = fn.create(ln + "XX", sn + "xx", MFnNumericData::kFloat, defaultValue[0][0]);
+    MObject xy = fn.create(ln + "XY", sn + "xy", MFnNumericData::kFloat, defaultValue[0][1]);
+    MObject xz = fn.create(ln + "XZ", sn + "xz", MFnNumericData::kFloat, defaultValue[0][2]);
+    MObject yx = fn.create(ln + "YX", sn + "yx", MFnNumericData::kFloat, defaultValue[1][0]);
+    MObject yy = fn.create(ln + "YY", sn + "yy", MFnNumericData::kFloat, defaultValue[1][1]);
+    MObject yz = fn.create(ln + "YZ", sn + "yz", MFnNumericData::kFloat, defaultValue[1][2]);
+    MObject zx = fn.create(ln + "ZX", sn + "zx", MFnNumericData::kFloat, defaultValue[2][0]);
+    MObject zy = fn.create(ln + "ZY", sn + "zy", MFnNumericData::kFloat, defaultValue[2][1]);
+    MObject zz = fn.create(ln + "ZZ", sn + "zz", MFnNumericData::kFloat, defaultValue[2][2]);
+
+    MObject x = fnc.create(ln + "X", sn + "x");
+    fnc.addChild(xx);
+    fnc.addChild(xy);
+    fnc.addChild(xz);
+
+    MObject y = fnc.create(ln + "Y", sn + "y");
+    fnc.addChild(yx);
+    fnc.addChild(yy);
+    fnc.addChild(yz);
+
+    MObject z = fnc.create(ln + "Z", sn + "z");
+    fnc.addChild(zx);
+    fnc.addChild(zy);
+    fnc.addChild(zz);
+
+    MObject attribute = fnc.create(ln, sn);
+    fnc.addChild(x);
+    fnc.addChild(y);
+    fnc.addChild(z);
+
+    MStatus status = applyAttributeFlags(fnc, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addMatrix2x2Attr(
+    const char* longName,
+    const char* shortName,
+    const float defaultValue[2][2],
+    uint32_t    flags)
+{
+    addFrameAttr(longName, flags);
+
+    MFnNumericAttribute  fn;
+    MFnCompoundAttribute fnc;
+    MString              ln(longName);
+    MString              sn(shortName);
+    MObject xx = fn.create(ln + "XX", sn + "xx", MFnNumericData::kFloat, defaultValue[0][0]);
+    MObject xy = fn.create(ln + "XY", sn + "xy", MFnNumericData::kFloat, defaultValue[0][1]);
+    MObject yx = fn.create(ln + "YX", sn + "yx", MFnNumericData::kFloat, defaultValue[1][0]);
+    MObject yy = fn.create(ln + "YY", sn + "yy", MFnNumericData::kFloat, defaultValue[1][1]);
+
+    MObject x = fnc.create(ln + "X", sn + "x");
+    fnc.addChild(xx);
+    fnc.addChild(xy);
+
+    MObject y = fnc.create(ln + "Y", sn + "y");
+    fnc.addChild(yx);
+    fnc.addChild(yy);
+
+    MObject attribute = fnc.create(ln, sn);
+    fnc.addChild(x);
+    fnc.addChild(y);
+
+    MStatus status = applyAttributeFlags(fnc, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addDataAttr(
+    const char*                      longName,
+    const char*                      shortName,
+    MFnData::Type                    type,
+    uint32_t                         flags,
+    MFnAttribute::DisconnectBehavior behaviour)
+{
+    MFnTypedAttribute fn;
+    MObject           attribute = fn.create(longName, shortName, type);
+    fn.setDisconnectBehavior(behaviour);
+    MStatus status = applyAttributeFlags(fn, flags | kHidden);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addDataAttr(
+    const char*                      longName,
+    const char*                      shortName,
+    const MTypeId&                   type,
+    uint32_t                         flags,
+    MFnAttribute::DisconnectBehavior behaviour)
+{
+    MFnTypedAttribute fn;
+    MObject           attribute = fn.create(longName, shortName, type);
+    fn.setDisconnectBehavior(behaviour);
+    MStatus status = applyAttributeFlags(fn, flags | kHidden);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addMessageAttr(const char* longName, const char* shortName, uint32_t flags)
+{
+    MFnMessageAttribute fn;
+    MStatus             status;
+    MObject             attribute = fn.create(longName, shortName, &status);
+    status = applyAttributeFlags(fn, flags | kHidden | kConnectable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addVec2fAttr(const char* longName, const char* shortName, uint32_t flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute fn;
+    MObject             attribute;
+    MString             ln(longName);
+    MString             sn(shortName);
+    MObject             x = fn.create(ln + "X", sn + "x", MFnNumericData::kFloat, 0);
+    MObject             y = fn.create(ln + "Y", sn + "y", MFnNumericData::kFloat, 0);
+    attribute = fn.create(ln, sn, x, y);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addVec2iAttr(const char* longName, const char* shortName, uint32_t flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute fn;
+    MObject             attribute;
+    MString             ln(longName);
+    MString             sn(shortName);
+    MObject             x = fn.create(ln + "X", sn + "x", MFnNumericData::kLong, 0);
+    MObject             y = fn.create(ln + "Y", sn + "y", MFnNumericData::kLong, 0);
+    attribute = fn.create(ln, sn, x, y);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addVec2dAttr(const char* longName, const char* shortName, uint32_t flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute fn;
+    MObject             attribute;
+    MString             ln(longName);
+    MString             sn(shortName);
+    MObject             x = fn.create(ln + "X", sn + "x", MFnNumericData::kDouble, 0);
+    MObject             y = fn.create(ln + "Y", sn + "y", MFnNumericData::kDouble, 0);
+    attribute = fn.create(ln, sn, x, y);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addDoubleArrayAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    uint32_t       flags)
+{
+    addFrameAttr(longName, flags);
+
+    MStatus           status;
+    MFnTypedAttribute fnAttr;
+    MString           ln(longName);
+    MString           sn(shortName);
+
+    MObject attribute = fnAttr.create(ln, sn, MFnData::kDoubleArray, MObject::kNullObj, &status);
+
+    if (status != MS::kSuccess) {
+        MGlobal::displayWarning("addDoubleArrayAttr:Failed to create attribute");
+    }
+
+    applyAttributeFlags(fnAttr, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+
+    MFnDependencyNode fn(node, &status);
+    if (!status) {
+        throw status;
+    }
+
+    status = fn.addAttribute(attribute);
+
+    if (status != MS::kSuccess)
+        MGlobal::displayWarning(
+            MString("addDoubleArrayAttr::addAttribute: ") + MString(status.errorString()));
+
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addVec3fAttr(const char* longName, const char* shortName, uint32_t flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute fn;
+    MObject             attribute;
+    MString             ln(longName);
+    MString             sn(shortName);
+    MObject             x = fn.create(ln + "X", sn + "x", MFnNumericData::kFloat, 0);
+    MObject             y = fn.create(ln + "Y", sn + "y", MFnNumericData::kFloat, 0);
+    MObject             z = fn.create(ln + "Z", sn + "z", MFnNumericData::kFloat, 0);
+    attribute = fn.create(ln, sn, x, y, z);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addVec3iAttr(const char* longName, const char* shortName, uint32_t flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute fn;
+    MObject             attribute;
+    MString             ln(longName);
+    MString             sn(shortName);
+    MObject             x = fn.create(ln + "X", sn + "x", MFnNumericData::kInt, 0);
+    MObject             y = fn.create(ln + "Y", sn + "y", MFnNumericData::kInt, 0);
+    MObject             z = fn.create(ln + "Z", sn + "z", MFnNumericData::kInt, 0);
+    attribute = fn.create(ln, sn, x, y, z);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addVec3dAttr(const char* longName, const char* shortName, uint32_t flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute fn;
+    MObject             attribute;
+    MString             ln(longName);
+    MString             sn(shortName);
+    MObject             x = fn.create(ln + "X", sn + "x", MFnNumericData::kDouble, 0);
+    MObject             y = fn.create(ln + "Y", sn + "y", MFnNumericData::kDouble, 0);
+    MObject             z = fn.create(ln + "Z", sn + "z", MFnNumericData::kDouble, 0);
+    attribute = fn.create(ln, sn, x, y, z);
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addVec4fAttr(const char* longName, const char* shortName, uint32_t flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute  fn;
+    MFnCompoundAttribute fnc;
+    MObject              attribute;
+    MString              ln(longName);
+    MString              sn(shortName);
+    MObject              x = fn.create(ln + "X", sn + "x", MFnNumericData::kFloat, 0);
+    MObject              y = fn.create(ln + "Y", sn + "y", MFnNumericData::kFloat, 0);
+    MObject              z = fn.create(ln + "Z", sn + "z", MFnNumericData::kFloat, 0);
+    MObject              w = fn.create(ln + "W", sn + "w", MFnNumericData::kFloat, 0);
+    attribute = fnc.create(ln, sn);
+
+    fnc.addChild(x); // , "could not add x");
+    fnc.addChild(y); // , "could not add y");
+    fnc.addChild(z); // , "could not add z");
+    fnc.addChild(w); // , "could not add w");
+    MStatus status = applyAttributeFlags(fnc, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addVec4iAttr(const char* longName, const char* shortName, uint32_t flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute  fn;
+    MFnCompoundAttribute fnc;
+    MObject              attribute;
+    MString              ln(longName);
+    MString              sn(shortName);
+    MObject              x = fn.create(ln + "X", sn + "x", MFnNumericData::kLong, 0);
+    MObject              y = fn.create(ln + "Y", sn + "y", MFnNumericData::kLong, 0);
+    MObject              z = fn.create(ln + "Z", sn + "z", MFnNumericData::kLong, 0);
+    MObject              w = fn.create(ln + "W", sn + "w", MFnNumericData::kLong, 0);
+    attribute = fnc.create(ln, sn);
+    fnc.addChild(x); // , "could not add x");
+    fnc.addChild(y); // , "could not add y");
+    fnc.addChild(z); // , "could not add z");
+    fnc.addChild(w); // , "could not add w");
+    MStatus status = applyAttributeFlags(fnc, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addVec4dAttr(const char* longName, const char* shortName, uint32_t flags)
+{
+    addFrameAttr(longName, flags);
+    MFnNumericAttribute  fn;
+    MFnCompoundAttribute fnc;
+    MObject              attribute;
+    MString              ln(longName);
+    MString              sn(shortName);
+    MObject              x = fn.create(ln + "X", sn + "x", MFnNumericData::kDouble, 0);
+    MObject              y = fn.create(ln + "Y", sn + "y", MFnNumericData::kDouble, 0);
+    MObject              z = fn.create(ln + "Z", sn + "z", MFnNumericData::kDouble, 0);
+    MObject              w = fn.create(ln + "W", sn + "w", MFnNumericData::kDouble, 0);
+    attribute = fnc.create(ln, sn);
+    fnc.addChild(x); // , "could not add x");
+    fnc.addChild(y); // , "could not add y");
+    fnc.addChild(z); // , "could not add z");
+    fnc.addChild(w); // , "could not add w");
+    MStatus status = applyAttributeFlags(fnc, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return attribute;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MObject NodeHelper::addCompoundAttr(
+    const char*                    longName,
+    const char*                    shortName,
+    uint32_t                       flags,
+    std::initializer_list<MObject> objs)
+{
+    addFrameAttr(longName, flags);
+    MFnCompoundAttribute fn;
+    MObject              obj = fn.create(longName, shortName);
+    for (auto it : objs) {
+        MStatus status = fn.addChild(it);
+        if (!status)
+            throw status;
+    }
+    MStatus status = applyAttributeFlags(fn, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+    if (!status)
+        throw status;
+    return obj;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::applyAttributeFlags(MFnAttribute& fn, uint32_t flags)
+{
+    // const char* const errorString = "NodeHelper::applyAttributeFlags";
+    fn.setCached((flags & kCached) != 0); // , errorString);
+    fn.setReadable((flags & kReadable) != 0); //, errorString);
+    fn.setStorable((flags & kStorable) != 0); //, errorString);
+    fn.setWritable((flags & kWritable) != 0); //, errorString);
+    fn.setAffectsAppearance((flags & kAffectsAppearance) != 0); //, errorString);
+    fn.setKeyable((flags & kKeyable) != 0); //, errorString);
+    fn.setConnectable((flags & kConnectable) != 0); //, errorString);
+    fn.setArray((flags & kArray) != 0); //, errorString);
+    fn.setUsedAsColor((flags & kColour) != 0); //, errorString);
+    fn.setHidden((flags & kHidden) != 0); //, errorString);
+    fn.setInternal((flags & kInternal) != 0); //, errorString);
+    fn.setAffectsWorldSpace((flags & kAffectsWorldSpace) != 0); //, errorString);
+    fn.setUsesArrayDataBuilder((flags & kUsesArrayDataBuilder) != 0); //, errorString);
+
+    if (!(flags & (kDynamic | kDontAddToNode))) {
+        MStatus status = MPxNode::addAttribute(fn.object());
+        if (!status)
+            throw status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+void NodeHelper::generateAETemplate()
+{
+    assert(m_internal);
+
+    // first hunt down all of the call custom attributes and generate the custom AE templates. This
+    // needs to be done before we generate the main template procedure (these are all global
+    // methods).
+    std::ostringstream oss;
+    auto               it = m_internal->m_frames.rbegin();
+    auto               end = m_internal->m_frames.rend();
+    for (; it != end; ++it) {
+        size_t fileIndex = 0;
+        for (size_t i = 0; i < it->m_attributes.size(); ++i) {
+            switch (it->m_attributeTypes[i]) {
+            case Frame::kLoadFilePath:
+            case Frame::kSaveFilePath:
+            case Frame::kDirPathWithFiles:
+            case Frame::kDirPath:
+            case Frame::kMultiLoadFilePath:
+                constructFilePathUi(
+                    oss,
+                    m_internal->m_typeBeingRegistered,
+                    it->m_attributes[i],
+                    it->m_fileFilters[fileIndex++],
+                    (FileMode)it->m_attributeTypes[i]);
+                break;
+            default: break;
+            }
+        }
+    }
+
+    // start generating our AE template, and ensure it's wrapped in a scroll layout.
+    oss << "global proc AE" << m_internal->m_typeBeingRegistered
+        << "Template(string $nodeName) {\n";
+    oss << " editorTemplate -beginScrollLayout;\n";
+
+    // loop through each collapsible frame
+    it = m_internal->m_frames.rbegin();
+    for (; it != end; ++it) {
+        // frame layout begin!
+        oss << "  editorTemplate -beginLayout \"" << it->m_title << "\" -collapse 0;\n";
+        for (size_t i = 0; i < it->m_attributes.size(); ++i) {
+            switch (it->m_attributeTypes[i]) {
+            // If we have a file path attribute, use the custom callbacks
+            case Frame::kLoadFilePath:
+            case Frame::kSaveFilePath:
+            case Frame::kDirPathWithFiles:
+            case Frame::kDirPath:
+            case Frame::kMultiLoadFilePath:
+                oss << "    editorTemplate -callCustom \"AE" << m_internal->m_typeBeingRegistered
+                    << "Template_" << it->m_attributes[i] << "New\" "
+                    << "\"AE" << m_internal->m_typeBeingRegistered << "Template_"
+                    << it->m_attributes[i] << "Replace\" \"" << it->m_attributes[i] << "\";\n";
+                break;
+
+            // for all other attributes, just add a normal control
+            default:
+                oss << "    editorTemplate -addControl \"" << it->m_attributes[i] << "\";\n";
+                break;
+            }
+        }
+        oss << "  editorTemplate -endLayout;\n";
+    }
+
+    // add all of our base templates that have been added
+    for (size_t i = 0; i < m_internal->m_baseTemplates.size(); ++i) {
+        oss << "  " << m_internal->m_baseTemplates[i] << " $nodeName;\n";
+    }
+
+    // finish off the call by adding in the custom attributes section
+    oss << "  editorTemplate -addExtraControls;\n";
+    oss << " editorTemplate -endScrollLayout;\n";
+    oss << "}\n";
+
+    // run our script (AE template command will now exist in memory)
+    MGlobal::executeCommand(MString(oss.str().c_str(), oss.str().size()));
+
+    // get rid of our internal rubbish.
+    delete m_internal;
+    m_internal = 0;
+}
+
+#define report_get_error(attribute, type, status)                                                 \
+    {                                                                                             \
+        MFnAttribute fn(attribute);                                                               \
+        std::cerr << "Unable to get attribute \"" << fn.name().asChar() << "\" of type " << #type \
+                  << std::endl;                                                                   \
+        std::cerr << "  - " << status.errorString().asChar() << std::endl;                        \
+    }
+
+//----------------------------------------------------------------------------------------------------------------------
+bool NodeHelper::inputBoolValue(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle inDataHandle = dataBlock.inputValue(attribute, &status);
+    if (status) {
+        return inDataHandle.asBool();
+    }
+    report_get_error(attribute, bool, status);
+    return false;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+int8_t NodeHelper::inputInt8Value(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle inDataHandle = dataBlock.inputValue(attribute, &status);
+    if (status) {
+        return inDataHandle.asChar();
+    }
+    report_get_error(attribute, int8_t, status);
+    return 0;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+int16_t NodeHelper::inputInt16Value(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle inDataHandle = dataBlock.inputValue(attribute, &status);
+    if (status) {
+        return inDataHandle.asShort();
+    }
+    report_get_error(attribute, int16_t, status);
+    return 0;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+int32_t NodeHelper::inputInt32Value(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle inDataHandle = dataBlock.inputValue(attribute, &status);
+    if (status) {
+        return inDataHandle.asInt();
+    }
+    report_get_error(attribute, int32_t, status);
+    return 0;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+int64_t NodeHelper::inputInt64Value(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle inDataHandle = dataBlock.inputValue(attribute, &status);
+    if (status) {
+        return inDataHandle.asInt64();
+    }
+    report_get_error(attribute, int64_t, status);
+    return 0;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+float NodeHelper::inputFloatValue(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle inDataHandle = dataBlock.inputValue(attribute, &status);
+    if (status) {
+        return inDataHandle.asFloat();
+    }
+    report_get_error(attribute, float, status);
+    return 0;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+double NodeHelper::inputDoubleValue(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle inDataHandle = dataBlock.inputValue(attribute, &status);
+    if (status) {
+        return inDataHandle.asDouble();
+    }
+    report_get_error(attribute, double, status);
+    return 0;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MTime NodeHelper::inputTimeValue(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle inDataHandle = dataBlock.inputValue(attribute, &status);
+    if (status) {
+        return inDataHandle.asTime();
+    }
+    report_get_error(attribute, MTime, status);
+    return MTime();
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MMatrix NodeHelper::inputMatrixValue(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle inDataHandle = dataBlock.inputValue(attribute, &status);
+    if (status) {
+        return inDataHandle.asMatrix();
+    }
+    report_get_error(attribute, MMatrix, status);
+    return MMatrix();
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MPoint NodeHelper::inputPointValue(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle inDataHandle = dataBlock.inputValue(attribute, &status);
+    if (status) {
+        const double3& v = inDataHandle.asDouble3();
+        return MPoint(v[0], v[1], v[2]);
+    }
+    report_get_error(attribute, MPoint, status);
+    return MPoint();
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MFloatPoint NodeHelper::inputFloatPointValue(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle inDataHandle = dataBlock.inputValue(attribute, &status);
+    if (status) {
+        const float3& v = inDataHandle.asFloat3();
+        return MFloatPoint(v[0], v[1], v[2]);
+    }
+    report_get_error(attribute, MFloatPoint, status);
+    return MFloatPoint();
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MVector NodeHelper::inputVectorValue(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle inDataHandle = dataBlock.inputValue(attribute, &status);
+    if (status) {
+        const double3& v = inDataHandle.asDouble3();
+        return MVector(v[0], v[1], v[2]);
+    }
+    report_get_error(attribute, MVector, status);
+    return MVector();
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MFloatVector NodeHelper::inputFloatVectorValue(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle inDataHandle = dataBlock.inputValue(attribute, &status);
+    if (status) {
+        const float3& v = inDataHandle.asFloat3();
+        return MFloatVector(v[0], v[1], v[2]);
+    }
+    report_get_error(attribute, MFloatVector, status);
+    return MFloatVector();
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MString NodeHelper::inputStringValue(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle inDataHandle = dataBlock.inputValue(attribute, &status);
+    if (status) {
+        return inDataHandle.asString();
+    }
+    report_get_error(attribute, MString, status);
+    return MString();
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------------------------------------------------
+MColor NodeHelper::inputColourValue(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle inDataHandle = dataBlock.inputValue(attribute, &status);
+    if (status) {
+        const float3& v = inDataHandle.asFloat3();
+        return MColor(v[0], v[1], v[2]);
+    }
+    report_get_error(attribute, MColor, status);
+    return MColor();
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MPxData* NodeHelper::inputDataValue(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle inDataHandle = dataBlock.inputValue(attribute, &status);
+    if (status) {
+        return inDataHandle.asPluginData();
+    }
+    report_get_error(attribute, MPxData, status);
+    return 0;
+}
+
+#define report_set_error(attribute, type, status)                                                 \
+    {                                                                                             \
+        MFnAttribute fn(attribute);                                                               \
+        std::cerr << "Unable to set attribute \"" << fn.name().asChar() << "\" of type " << #type \
+                  << std::endl;                                                                   \
+        std::cerr << "  - " << status.errorString().asChar() << std::endl;                        \
+    }
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus
+NodeHelper::outputBoolValue(MDataBlock& dataBlock, const MObject& attribute, const bool value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.setBool(value);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, bool, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus
+NodeHelper::outputInt8Value(MDataBlock& dataBlock, const MObject& attribute, const int8_t value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.setChar(value);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, int8_t, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus
+NodeHelper::outputInt16Value(MDataBlock& dataBlock, const MObject& attribute, const int16_t value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.setShort(value);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, int16_t, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus
+NodeHelper::outputInt32Value(MDataBlock& dataBlock, const MObject& attribute, const int32_t value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.setInt(value);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, int32_t, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus
+NodeHelper::outputInt64Value(MDataBlock& dataBlock, const MObject& attribute, const int64_t value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.setInt64(value);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, int64_t, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus
+NodeHelper::outputFloatValue(MDataBlock& dataBlock, const MObject& attribute, const float value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.setFloat(value);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, float, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus
+NodeHelper::outputDoubleValue(MDataBlock& dataBlock, const MObject& attribute, const double value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.setDouble(value);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, double, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus
+NodeHelper::outputMatrixValue(MDataBlock& dataBlock, const MObject& attribute, const MMatrix& value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.setMMatrix(value);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, MMatrix, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus
+NodeHelper::outputPointValue(MDataBlock& dataBlock, const MObject& attribute, const MPoint& value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.set(value.x, value.y, value.z);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, MPoint, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::outputFloatPointValue(
+    MDataBlock&        dataBlock,
+    const MObject&     attribute,
+    const MFloatPoint& value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.set(value.x, value.y, value.z);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, MFloatPoint, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus
+NodeHelper::outputVectorValue(MDataBlock& dataBlock, const MObject& attribute, const MVector& value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.set(value.x, value.y, value.z);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, MVector, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::outputEulerValue(
+    MDataBlock&           dataBlock,
+    const MObject&        attribute,
+    const MEulerRotation& value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.set(value.x, value.y, value.z);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, MEulerRotation, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::outputFloatVectorValue(
+    MDataBlock&         dataBlock,
+    const MObject&      attribute,
+    const MFloatVector& value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.set(value.x, value.y, value.z);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, MFloatVector, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus
+NodeHelper::outputColourValue(MDataBlock& dataBlock, const MObject& attribute, const MColor& value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.set(value.r, value.g, value.b);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, MColor, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus
+NodeHelper::outputStringValue(MDataBlock& dataBlock, const MObject& attribute, const MString& value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.setString(value);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, MString, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus
+NodeHelper::outputTimeValue(MDataBlock& dataBlock, const MObject& attribute, const MTime& value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.set(value);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, MTime, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::outputDataValue(MDataBlock& dataBlock, const MObject& attribute, MPxData* value)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        outDataHandle.set(value);
+        outDataHandle.setClean();
+    } else {
+        report_set_error(attribute, MPxData, status);
+    }
+    return status;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MPxData* NodeHelper::outputDataValue(MDataBlock& dataBlock, const MObject& attribute)
+{
+    MStatus     status;
+    MDataHandle outDataHandle = dataBlock.outputValue(attribute, &status);
+    if (status) {
+        return outDataHandle.asPluginData();
+    }
+    report_get_error(attribute, MPxData, status);
+    return 0;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MPxData* NodeHelper::createData(const MTypeId& dataTypeId, MObject& data)
+{
+    MStatus       status;
+    MFnPluginData pluginDataFactory;
+    data = pluginDataFactory.create(dataTypeId, &status);
+    if (!status) {
+        std::cerr << "Unable to create data object of type id: " << dataTypeId.id() << ":"
+                  << dataTypeId.className() << std::endl;
+        return 0;
+    }
+    return pluginDataFactory.data();
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addStringAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    uint32_t       flags,
+    bool           forceShow,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addStringAttr(longName, shortName, flags | kDynamic, forceShow);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add string attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addFilePathAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    uint32_t       flags,
+    FileMode       forSaving,
+    const char*    fileFilter,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr
+            = addFilePathAttr(longName, shortName, flags | kDynamic, forSaving, fileFilter);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add filename attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addInt8Attr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    int8_t         defaultValue,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addInt8Attr(longName, shortName, defaultValue, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add int attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addInt16Attr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    int16_t        defaultValue,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addInt16Attr(longName, shortName, defaultValue, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add int attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addInt32Attr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    int32_t        defaultValue,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addInt32Attr(longName, shortName, defaultValue, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add int attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addInt64Attr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    int64_t        defaultValue,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addInt64Attr(longName, shortName, defaultValue, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add int attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addFloatAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    float          defaultValue,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addFloatAttr(longName, shortName, defaultValue, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add float attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addDoubleAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    double         defaultValue,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addDoubleAttr(longName, shortName, defaultValue, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add double attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addTimeAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    const MTime&   defaultValue,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addTimeAttr(longName, shortName, defaultValue, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add time attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addDistanceAttr(
+    const MObject&   node,
+    const char*      longName,
+    const char*      shortName,
+    const MDistance& defaultValue,
+    uint32_t         flags,
+    MObject*         attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addDistanceAttr(longName, shortName, defaultValue, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add distance attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addAngleAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    const MAngle&  defaultValue,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addAngleAttr(longName, shortName, defaultValue, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add angle attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addBoolAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    bool           defaultValue,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addBoolAttr(longName, shortName, defaultValue, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add bool attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addFloat3Attr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    float          defaultX,
+    float          defaultY,
+    float          defaultZ,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr
+            = addFloat3Attr(longName, shortName, defaultX, defaultY, defaultZ, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add float3 attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addAngle3Attr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    float          defaultX,
+    float          defaultY,
+    float          defaultZ,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr
+            = addAngle3Attr(longName, shortName, defaultX, defaultY, defaultZ, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add angle3 attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addPointAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    const MPoint&  defaultValue,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addPointAttr(longName, shortName, defaultValue, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add point attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addVectorAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    const MVector& defaultValue,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addVectorAttr(longName, shortName, defaultValue, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add vector attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addMatrixAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    const MMatrix& defaultValue,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addMatrixAttr(longName, shortName, defaultValue, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add matrix attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addMatrix2x2Attr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    const float    defaultValue[2][2],
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addMatrix2x2Attr(longName, shortName, defaultValue, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add matrix2x2 attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addMatrix3x3Attr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    const float    defaultValue[3][3],
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addMatrix3x3Attr(longName, shortName, defaultValue, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add matrix3x3 attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addDataAttr(
+    const MObject&                   node,
+    const char*                      longName,
+    const char*                      shortName,
+    MFnData::Type                    type,
+    uint32_t                         flags,
+    MFnAttribute::DisconnectBehavior behaviour,
+    MObject*                         attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addDataAttr(longName, shortName, type, flags | kDynamic, behaviour);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add data attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addDataAttr(
+    const MObject&                   node,
+    const char*                      longName,
+    const char*                      shortName,
+    const MTypeId&                   type,
+    uint32_t                         flags,
+    MFnAttribute::DisconnectBehavior behaviour,
+    MObject*                         attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addDataAttr(longName, shortName, type, flags | kDynamic, behaviour);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add data attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addMessageAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addMessageAttr(longName, shortName, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add message attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addVec2fAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addVec2fAttr(longName, shortName, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add vec2 attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addVec2iAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addVec2iAttr(longName, shortName, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add vec2 attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addVec2dAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addVec2dAttr(longName, shortName, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add vec2 attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addVec3fAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addVec3fAttr(longName, shortName, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add vec3 attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addVec3iAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addVec3iAttr(longName, shortName, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add vec3 attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addVec3dAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addVec3dAttr(longName, shortName, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add vec3 attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addVec4fAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addVec4fAttr(longName, shortName, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add vec4 attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addVec4iAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addVec4iAttr(longName, shortName, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add vec4 attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus NodeHelper::addVec4dAttr(
+    const MObject& node,
+    const char*    longName,
+    const char*    shortName,
+    uint32_t       flags,
+    MObject*       attribute)
+{
+    try {
+        MStatus           status;
+        MFnDependencyNode fn(node, &status);
+        if (!status) {
+            throw status;
+        }
+        MObject attr = addVec4dAttr(longName, shortName, flags | kDynamic | kConnectable | kKeyable | kWritable | kReadable | kStorable);
+        status = fn.addAttribute(attr);
+        if (!status) {
+            MGlobal::displayError(
+                MString("Unable to add vec4 attribute ") + longName + " to node " + fn.name());
+            throw status;
+        }
+        if (attribute)
+            *attribute = attr;
+    } catch (MStatus status) {
+        return status;
+    }
+    return MS::kSuccess;
+}

--- a/lib/mayaUsd/fileio/translators/NodeHelper.h
+++ b/lib/mayaUsd/fileio/translators/NodeHelper.h
@@ -1,0 +1,1921 @@
+//
+// Copyright 2017 Animal Logic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <maya/MColor.h>
+#include <maya/MFloatVector.h>
+#include <maya/MFnNumericAttribute.h>
+
+#include <deque>
+#include <string>
+#include <vector>
+
+//----------------------------------------------------------------------------------------------------------------------
+/// \brief  This macro simply adds an MObject member variable to an MPxNode derived class to be used
+/// as a node attribute.
+///         It also add's a couple of public methods to access a nodes plug, and to access the
+///         attributes MObject. For example, if my node looked like:
+/// \code
+/// class MyNode
+///   : public MPxNode
+/// {
+///   AL_DECL_ATTRIBUTE(myAttr);
+/// };
+/// \endcode
+/// This would effectively expand to:
+/// \code
+/// class MyNode
+///   : public MPxNode
+/// {
+///   static private MObject m_myAttr; ///< the attribute handle
+/// public:
+///
+///   // access the attribute handle
+///   static MObject myAttr()
+///     { return m_myAttr; }
+///
+///   // access the attribute plug
+///   MPlug myAttrPlug() const
+///     { return MPlug(thisMObject(), m_myAttr); }
+/// };
+/// \endcode
+/// \ingroup mayagui
+//----------------------------------------------------------------------------------------------------------------------
+
+// For children of multi-attribute, a generic XXPlug() method
+// isn't very helpful, as we need to attach to a specific indexed
+// element plug of the parent array... and defining it just
+// creates a confusing name
+#define AL_DECL_MULTI_CHILD_ATTRIBUTE(XX) \
+protected:                                \
+    AL_MAYA_MACROS_PUBLIC                 \
+    static MObject m_##XX;                \
+                                          \
+public:                                   \
+    AL_MAYA_MACROS_PUBLIC                 \
+    static const MObject& XX() { return m_##XX; }
+
+#define AL_DECL_ATTRIBUTE(XX)         \
+    AL_DECL_MULTI_CHILD_ATTRIBUTE(XX) \
+    AL_MAYA_MACROS_PUBLIC             \
+    MPlug XX##Plug() const { return MPlug(thisMObject(), m_##XX); }
+
+
+//----------------------------------------------------------------------------------------------------------------------
+/// \brief  This is a little helper object designed to reduce the amount of boilerplate GUI code you
+/// need to jump through
+///         to add your own nodes that match a USD schema type. It has been designed to attempt to
+///         match the attribute types of USD as closely as possible, so adds support for 2x2 / 3x3
+///         matrix types, half float support, etc.
+///
+///         In order to use this class, you should inherit from which ever MPxNode type you need
+///         (e.g. MPxLocator, MPxSurfaceShape, etc), as well as the NodeHelper class. So your header
+///         file should look something like this:
+/// \code
+/// #pragma once
+/// #include "AL/maya/NodeHelper.h"
+/// #include <maya/MPxNode.h>
+///
+/// // extremely simple node that adds two numbers
+/// class Add2Floats
+///   : public MPxNode,
+///     public AL::maya::NodeHelper
+/// {
+/// public:
+///
+///   MStatus compute(const MPlug& plug, MDataBlock& dataBlock) override;
+///
+///   AL_DECL_ATTRIBUTE(input0);
+///   AL_DECL_ATTRIBUTE(input1);
+///   AL_DECL_ATTRIBUTE(output);
+/// };
+/// \endcode
+///
+/// And then in the cpp file...
+///
+/// \code
+/// #include "Add2Floats.h"
+///
+/// // NOTE: I'm prefixing all calls to inherited functions from NodeHelper with the full scope.
+/// There is no reason
+/// // to do this in C++. I'm only doing it in this example code to get the documentation to contain
+/// links to the actual
+/// // functions involved!
+///
+/// // some boiler plate to define the typeId as 0x1234, and the node name as
+/// "AL_examples_Add2Floats" AL_MAYA_DEFINE_NODE(Add2Floats, 0x1234, AL_examples);
+///
+/// // make sure you add the static MObjects for your node attributes
+/// MObject Add2Floats::m_input0 = MObject::kNullObj;
+/// MObject Add2Floats::m_input1 = MObject::kNullObj;
+/// MObject Add2Floats::m_output = MObject::kNullObj;
+///
+/// // initialise the attributes
+/// MStatus Add2Floats::initialise()
+/// {
+///   // the node helper will throw an exception if any underlying MFnAttribute calls fails.
+///   try
+///   {
+///     // first specify the typename of the node (this is required in order to sure the AE Template
+///     // generated will correctly match this node type)
+///     AL::maya::NodeHelper::setNodeType(kTypeName);
+///
+///     // You *MUST* add at least one AETemplate frame to insert controls into. Once you have added
+///     // a frame, all subsequent attributes will be displayed under the frame group. You can add
+///     // as many frames as you wish.
+///     AL::maya::NodeHelper::addFrame("Add 2 Float GUI");
+///
+///     // add the two input attributes
+///     m_input0 = AL::maya::NodeHelper::addFloatAttr("input0", "in0", 0.0f, kReadable | kWritable |
+///     kStorable | kConnectable | kKeyable); m_input1 =
+///     AL::maya::NodeHelper::addFloatAttr("input1", "in1", 0.0f, kReadable | kWritable | kStorable
+///     | kConnectable | kKeyable);
+///
+///     // add the output
+///     m_output = AL::maya::NodeHelper::addFloatAttr("output", "out", 0.0f, kReadable |
+///     kConnectable);
+///
+///     // set up the attribute dependencies as per usual
+///     attributeAffects(m_input0, m_output);
+///     attributeAffects(m_input1, m_output);
+///   }
+///   catch(const MStatus& status)
+///   {
+///     return status;
+///   }
+///
+///   // finally, generate and execute the AE Template for this node.
+///   AL::maya::NodeHelper::generateAETemplate();
+///
+///   // all done!
+///   return MS::kSuccess;
+/// }
+///
+/// // the compute method
+/// MStatus Add2Floats::compute(const MPlug& plug, MDataBlock& dataBlock)
+/// {
+///   if(plug == output())
+///   {
+///     // grab input data
+///     const float in0 = AL::maya::NodeHelper::inputFloatValue(dataBlock, input0());
+///     const float in1 = AL::maya::NodeHelper::inputFloatValue(dataBlock, input1());
+///
+///     // sum both values, and set the output
+///     return AL::maya::NodeHelper::outputFloatValue(dataBlock, output(), in0 + in1);
+///   }
+///   return MPxNode::compute(plug, dataBlock);
+/// }
+/// \endcode
+/// and finally, within your main plugin.cpp, you should be able to simply do:
+/// \code
+/// #include <maya/MFnPlugin.h>
+/// #include "Add2Floats.h"
+///
+/// DSO_EXPORT MStatus initializePlugin(MObject obj)
+/// {
+///   MFnPlugin plugin(obj);
+///   AL_REGISTER_DEPEND_NODE(plugin, Add2Floats);
+///   return MS::kSuccess;
+/// }
+///
+/// DSO_EXPORT MStatus uninitializePlugin(MObject obj)
+/// {
+///   MFnPlugin plugin(obj);
+///   AL_UNREGISTER_NODE(plugin, Add2Floats);
+///   return MS::kSuccess;
+/// }
+/// \endcode
+///
+/// \note   For a complete example of how it should be used, please see the
+/// AL::maya::NodeHelperUnitTest files. \ingroup mayagui
+//----------------------------------------------------------------------------------------------------------------------
+
+class NodeHelper
+{
+#ifndef AL_GENERATING_DOCS
+    struct Frame
+    {
+        Frame(const char* frameTitle)
+            : m_title(frameTitle)
+        {
+        }
+
+        enum AttributeUiType
+        {
+            // deliberately numbered!
+            kLoadFilePath = 0,
+            kSaveFilePath = 1,
+            kDirPathWithFiles = 2,
+            kDirPath = 3,
+            kMultiLoadFilePath = 4,
+            kNormal = 5,
+            kHidden = 6
+        };
+        std::string                  m_title;
+        std::vector<AttributeUiType> m_attributeTypes;
+        std::vector<std::string>     m_attributes;
+        std::vector<std::string>     m_fileFilters;
+    };
+
+    struct InternalData
+    {
+        std::string              m_typeBeingRegistered;
+        std::vector<std::string> m_baseTemplates;
+        std::deque<Frame>        m_frames;
+    };
+    
+    static InternalData* m_internal;
+#endif
+
+public:
+    /// \brief  ctor
+    NodeHelper() { }
+
+    /// \brief  dtor
+    ~NodeHelper() { }
+
+    /// \name   Access Input Values from an MDataBlock
+
+    /// \brief  get an input boolean value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    
+    static bool inputBoolValue(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an input 8 bit integer value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    
+    static int8_t inputInt8Value(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an input 16 bit integer value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    
+    static int16_t inputInt16Value(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an input 32 bit integer value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    
+    static int32_t inputInt32Value(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an input 64 bit integer value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    
+    static int64_t inputInt64Value(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an input float value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    
+    static float inputFloatValue(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an input double value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    
+    static double inputDoubleValue(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an input matrix value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    
+    static MMatrix inputMatrixValue(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an input point value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    
+    static MPoint inputPointValue(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an input point value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    
+    static MFloatPoint inputFloatPointValue(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an input vector value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    
+    static MVector inputVectorValue(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an input time value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    
+    static MTime inputTimeValue(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an input vector value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    
+    static MFloatVector inputFloatVectorValue(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an input colour value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    
+    static MColor inputColourValue(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an input string value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    
+    static MString inputStringValue(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an input data value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    
+    static MPxData* inputDataValue(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an input data value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to query
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    template <typename MPxDataType>
+    static MPxDataType* inputDataValue(MDataBlock& dataBlock, const MObject& attribute)
+    {
+        MPxData* data = NodeHelper::inputDataValue(dataBlock, attribute);
+        if (data) {
+            return dynamic_cast<MPxDataType*>(data);
+        }
+        return 0;
+    }
+
+    /// \name   Set Output Values from an MDataBlock
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus outputBoolValue(MDataBlock& dataBlock, const MObject& attribute, bool value);
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus outputInt8Value(MDataBlock& dataBlock, const MObject& attribute, int8_t value);
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus outputInt16Value(MDataBlock& dataBlock, const MObject& attribute, int16_t value);
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus outputInt32Value(MDataBlock& dataBlock, const MObject& attribute, int32_t value);
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus outputInt64Value(MDataBlock& dataBlock, const MObject& attribute, int64_t value);
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus outputFloatValue(MDataBlock& dataBlock, const MObject& attribute, float value);
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus outputDoubleValue(MDataBlock& dataBlock, const MObject& attribute, double value);
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus
+    outputMatrixValue(MDataBlock& dataBlock, const MObject& attribute, const MMatrix& value);
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus
+    outputPointValue(MDataBlock& dataBlock, const MObject& attribute, const MPoint& value);
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus outputFloatPointValue(
+        MDataBlock&        dataBlock,
+        const MObject&     attribute,
+        const MFloatPoint& value);
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus
+    outputVectorValue(MDataBlock& dataBlock, const MObject& attribute, const MVector& value);
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus
+    outputEulerValue(MDataBlock& dataBlock, const MObject& attribute, const MEulerRotation& value);
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus outputFloatVectorValue(
+        MDataBlock&         dataBlock,
+        const MObject&      attribute,
+        const MFloatVector& value);
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus
+    outputColourValue(MDataBlock& dataBlock, const MObject& attribute, const MColor& value);
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus
+    outputStringValue(MDataBlock& dataBlock, const MObject& attribute, const MString& value);
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus
+    outputTimeValue(MDataBlock& dataBlock, const MObject& attribute, const MTime& value);
+
+    /// \brief  Set the output value of the specified attribute in the datablock
+    /// \param  dataBlock the data block to set the value in
+    /// \param  attribute the handle to the attribute to set
+    /// \param  value the attribute value to set
+    /// \return MS::kSuccess if all went well
+    
+    static MStatus outputDataValue(MDataBlock& dataBlock, const MObject& attribute, MPxData* value);
+
+    /// \brief  get an output data value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to get an MPxData for
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    ///         Useful when you want to modify something on the underlying MPxData, without
+    ///         creating / setting an entirely new instance of the MPxData
+    
+    static MPxData* outputDataValue(MDataBlock& dataBlock, const MObject& attribute);
+
+    /// \brief  get an output data value from the dataBlock from the specified attribute
+    /// \param  dataBlock the data block to get the value from
+    /// \param  attribute the handle to the attribute to get an MPxData subclass for
+    /// \return the value
+    /// \note   If the value could not be queried, and error will be logged to std::cerr
+    ///         Useful when you want to modify something on the underlying MPxData subclass, without
+    ///         creating / setting an entirely new instance of the MPxData subclass
+    template <typename MPxDataType>
+    static MPxDataType* outputDataValue(MDataBlock& dataBlock, const MObject& attribute)
+    {
+        MPxData* data = NodeHelper::outputDataValue(dataBlock, attribute);
+        if (data) {
+            return dynamic_cast<MPxDataType*>(data);
+        }
+        return 0;
+    }
+
+    /// \brief  helper method to create new data objects of the specified data type
+    /// \param  dataTypeId the MTypeId of the plugin data object to create
+    /// \param  data the returned handle to the created data object, usually passed to
+    /// MDataHandle::set, or MPlug::setValue. \return a pointer to the data object created
+    
+    static MPxData* createData(const MTypeId& dataTypeId, MObject& data);
+
+    /// \brief  helper method to create new data objects of the specified data type
+    /// \param  dataTypeId the MTypeId of the plugin data object to create
+    /// \param  data the returned handle to the created data object, usually passed to
+    /// MDataHandle::set, or MPlug::setValue. \return a pointer to the data object created
+    template <typename MPxDataType>
+    static MPxDataType* createData(const MTypeId& dataTypeId, MObject& data)
+    {
+        MPxData* ptr = NodeHelper::createData(dataTypeId, data);
+        return static_cast<MPxDataType*>(ptr);
+    }
+
+    /// \name   Specify the attributes of a node, and AE GUI generation
+
+    /// \brief  A set of bit flags you can apply to an attribute
+    enum AttributeFlags
+    {
+        kCached = 1 << 0,            ///< The attribute should be cached
+        kReadable = 1 << 1,          ///< The attribute should be readable (output)
+        kWritable = 1 << 2,          ///< The attribute should be writable (input)
+        kStorable = 1 << 3,          ///< The attribute should be stored in a maya file
+        kAffectsAppearance = 1 << 4, ///< the attribute affects the appearance of a shape
+        kKeyable = 1 << 5,           ///< The attribute can be animated
+        kConnectable = 1 << 6,       ///< The attribute can be connected to another attr
+        kArray = 1 << 7,             ///< The attribute is an array
+        kColour
+        = 1 << 8, ///< The attribute is a colour (UI will display a colour picker in the GUI)
+        kHidden = 1 << 9,    ///< The attribute is hidden
+        kInternal = 1 << 10, ///< The attribute value will be stored as a member variable, and
+                             ///< getInternalValueInContext / setInternalValueInContext will be
+                             ///< overridden to get/set the value
+        kAffectsWorldSpace
+        = 1 << 11, ///< The attribute affects the world space matrix of a custom transform node
+        kUsesArrayDataBuilder = 1 << 12, ///< The array can be resized via an array data builder
+        kDontAddToNode
+        = 1 << 30,         ///< prevent the attribute from being added to the current node type
+        kDynamic = 1 << 31 ///< The attribute is a dynamic attribute added at runtime (and not
+                           ///< during a plug-in node initialization)
+    };
+
+    /// \brief  Specify the type of file/dir path when adding file path attributes. See
+    /// addFilePathAttr
+    enum FileMode
+    {
+        kSave = 0,               ///< a save file dialog
+        kLoad = 1,               ///< a load file dialog
+        kDirectoryWithFiles = 2, ///< a directory dialog, but displays files.
+        kDirectory = 3,          ///< a directory dialog
+        kMultiLoad = 4           ///< multiple input files
+    };
+
+    /// \brief  Sets the node type name you are adding attributes. Please call this before adding
+    /// any frames! \param  typeName the type name of the node
+    
+    static void setNodeType(const MString& typeName);
+
+    /// \brief  Add a new frame control into the AE template.
+    /// \param  frameTitle the text to appear in the ui frame
+    /// \note   You MUST call this method at least once before adding any attributes
+    
+    static void addFrame(const char* frameTitle);
+
+    /// \brief  add an attribute to the current AE template frame
+    /// \param  longName  long name of the attribute
+    
+    static bool addFrameAttr(
+        const char*            longName,
+        uint32_t               flags,
+        bool                   forceShow = false,
+        Frame::AttributeUiType attrType = Frame::kNormal);
+
+    /// \brief  add a new compound attribute to this node type
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  list the attributes you wish to add as children
+    /// to this node.
+    
+    static MObject addCompoundAttr(
+        const char*                    longName,
+        const char*                    shortName,
+        uint32_t                       flags,
+        std::initializer_list<MObject> list);
+
+    /// \brief  add a new enum attribute to this node type
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  strings an array of text strings for the enum
+    /// values. This last item in this array must be NULL \param  values an array of numeric enum
+    /// values. \return the MObject for the attribute
+    
+    static MObject addEnumAttr(
+        const char*        longName,
+        const char*        shortName,
+        uint32_t           flags,
+        const char* const* strings,
+        const int16_t*     values);
+
+    /// \brief  add a new string attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  forceShow  force attribute to be shown.  Used
+    /// in case attribute is not writable but needs to be shown i.e. read-only. \return the MObject
+    /// for the attribute
+    
+    static MObject addStringAttr(
+        const char* longName,
+        const char* shortName,
+        uint32_t    flags,
+        bool        forceShow = false);
+
+    /// \brief  inherit in this node type a string attribute from a base node type.
+    /// \param  longName  long name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  forceShow  force attribute to be shown.  Used
+    /// in case attribute is not writable but needs to be shown i.e. read-only.
+    
+    static void inheritStringAttr(const char* longName, uint32_t flags, bool forceShow = false);
+
+    /// \brief  add a new string attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  forceShow  force attribute to be shown.  Used
+    /// in case attribute is not writable but needs to be shown i.e. read-only. \return the MObject
+    /// for the attribute
+    
+    static MObject addStringAttr(
+        const char* longName,
+        const char* shortName,
+        const char* defaultValue,
+        uint32_t    flags,
+        bool        forceShow = false);
+
+    /// \brief  add a new file path attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  fileMode  an enum that determines whether the
+    /// GUI should display a file open dialog, file save, or directory dialog. \param  fileFilter a
+    /// file filter of the form:
+    ///           "USD Files (*.usd*) (*.usd*);;Alembic Files (*.abc) (*.abc);;All files (*.*)
+    ///           (*.*)"
+    /// \return the MObject for the attribute
+    
+    static MObject addFilePathAttr(
+        const char* longName,
+        const char* shortName,
+        uint32_t    flags,
+        FileMode    fileMode,
+        const char* fileFilter = "");
+
+    /// \brief  inherit in this node type a file path attribute from a base node type.
+    /// \param  longName  long name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  fileMode  an enum that determines whether the
+    /// GUI should display a file open dialog, file save, or directory dialog. \param  fileFilter a
+    /// file filter of the form:
+    ///           "USD Files (*.usd*) (*.usd*);;Alembic Files (*.abc) (*.abc);;All files (*.*)
+    ///           (*.*)"
+    
+    static void inheritFilePathAttr(
+        const char* longName,
+        uint32_t    flags,
+        FileMode    fileMode,
+        const char* fileFilter = "");
+
+    /// \brief  add a new integer attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject
+    addInt8Attr(const char* longName, const char* shortName, int8_t defaultValue, uint32_t flags);
+
+    /// \brief  add a new integer attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject
+    addInt16Attr(const char* longName, const char* shortName, int16_t defaultValue, uint32_t flags);
+
+    /// \brief  add a new integer attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject
+    addInt32Attr(const char* longName, const char* shortName, int32_t defaultValue, uint32_t flags);
+
+    /// \brief  inherit in this node type an integer attribute from a base node type.
+    /// \param  longName  long name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc
+    
+    static void inheritInt32Attr(const char* longName, uint32_t flags);
+
+    /// \brief  add a new integer attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject
+    addInt64Attr(const char* longName, const char* shortName, int64_t defaultValue, uint32_t flags);
+
+    /// \brief  add a new floating point attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject
+    addFloatAttr(const char* longName, const char* shortName, float defaultValue, uint32_t flags);
+
+    /// \brief  add a new double attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject
+    addDoubleAttr(const char* longName, const char* shortName, double defaultValue, uint32_t flags);
+
+    /// \brief  add a new time attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addTimeAttr(
+        const char*  longName,
+        const char*  shortName,
+        const MTime& defaultValue,
+        uint32_t     flags);
+
+    /// \brief  inherit in this node type a time attribute from a base node type.
+    /// \param  longName  long name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc
+    
+    static void inheritTimeAttr(const char* longName, uint32_t flags);
+
+    /// \brief  add a new time attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addDistanceAttr(
+        const char*      longName,
+        const char*      shortName,
+        const MDistance& defaultValue,
+        uint32_t         flags);
+
+    /// \brief  add a new time attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addAngleAttr(
+        const char*   longName,
+        const char*   shortName,
+        const MAngle& defaultValue,
+        uint32_t      flags);
+
+    /// \brief  add a new boolean attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject
+    addBoolAttr(const char* longName, const char* shortName, bool defaultValue, uint32_t flags);
+
+    /// \brief  inherit in this node type a boolean attribute from a base node type.
+    /// \param  longName  long name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc
+    
+    static void inheritBoolAttr(const char* longName, uint32_t flags);
+
+    /// \brief  add a new float3 attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultX  the default value for the attribute
+    /// \param  defaultY  the default value for the attribute
+    /// \param  defaultZ  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addFloat3Attr(
+        const char* longName,
+        const char* shortName,
+        float       defaultX,
+        float       defaultY,
+        float       defaultZ,
+        uint32_t    flags);
+
+    /// \brief  add a new float3 attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultX  the default value for the attribute
+    /// \param  defaultY  the default value for the attribute
+    /// \param  defaultZ  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addAngle3Attr(
+        const char* longName,
+        const char* shortName,
+        float       defaultX,
+        float       defaultY,
+        float       defaultZ,
+        uint32_t    flags);
+
+    /// \brief  add a new float3 attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultX  the default value for the attribute
+    /// \param  defaultY  the default value for the attribute
+    /// \param  defaultZ  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc
+    
+    static MObject addDistance3Attr(
+        const char* longName,
+        const char* shortName,
+        float       defaultX,
+        float       defaultY,
+        float       defaultZ,
+        uint32_t    flags);
+
+    /// \brief  add a new point attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addPointAttr(
+        const char*   longName,
+        const char*   shortName,
+        const MPoint& defaultValue,
+        uint32_t      flags);
+
+    /// \brief  add a new float point attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addFloatPointAttr(
+        const char*        longName,
+        const char*        shortName,
+        const MFloatPoint& defaultValue,
+        uint32_t           flags)
+    {
+        return addFloat3Attr(
+            longName, shortName, defaultValue.x, defaultValue.y, defaultValue.z, flags);
+    }
+
+    /// \brief  add a new vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addVectorAttr(
+        const char*    longName,
+        const char*    shortName,
+        const MVector& defaultValue,
+        uint32_t       flags);
+
+    /// \brief  add a new float vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addFloatVectorAttr(
+        const char*         longName,
+        const char*         shortName,
+        const MFloatVector& defaultValue,
+        uint32_t            flags)
+    {
+        return addFloat3Attr(
+            longName, shortName, defaultValue.x, defaultValue.y, defaultValue.z, flags);
+    }
+
+    /// \brief  add a new colour attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addColourAttr(
+        const char*   longName,
+        const char*   shortName,
+        const MColor& defaultValue,
+        uint32_t      flags)
+    {
+        return addFloat3Attr(
+            longName, shortName, defaultValue.r, defaultValue.g, defaultValue.b, flags | kColour);
+    }
+
+    /// \brief  add a new matrix attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addMatrix2x2Attr(
+        const char* longName,
+        const char* shortName,
+        const float defaultValue[2][2],
+        uint32_t    flags);
+
+    /// \brief  add a new matrix attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addMatrix3x3Attr(
+        const char* longName,
+        const char* shortName,
+        const float defaultValue[3][3],
+        uint32_t    flags);
+
+    /// \brief  add a new matrix attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addMatrixAttr(
+        const char*    longName,
+        const char*    shortName,
+        const MMatrix& defaultValue,
+        uint32_t       flags);
+
+    /// \brief  add a new data attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  type the data type for the attribute \param
+    /// behaviour optionally control what happens when the attribute is disconnected \return the
+    /// MObject for the attribute
+    
+    static MObject addDataAttr(
+        const char*                      longName,
+        const char*                      shortName,
+        MFnData::Type                    type,
+        uint32_t                         flags,
+        MFnAttribute::DisconnectBehavior behaviour = MFnAttribute::kNothing);
+
+    /// \brief  add a new data attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  type the data type for the attribute \param
+    /// behaviour optionally control what happens when the attribute is disconnected \return the
+    /// MObject for the attribute
+    
+    static MObject addDataAttr(
+        const char*                      longName,
+        const char*                      shortName,
+        const MTypeId&                   type,
+        uint32_t                         flags,
+        MFnAttribute::DisconnectBehavior behaviour = MFnAttribute::kNothing);
+
+    /// \brief  add a new message attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addMessageAttr(const char* longName, const char* shortName, uint32_t flags);
+
+    /// \brief  add a new 2D vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    static MObject addVec2hAttr(const char* longName, const char* shortName, uint32_t flags)
+    {
+        return addVec2fAttr(longName, shortName, flags);
+    }
+
+    /// \brief  add a new 2D vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addVec2fAttr(const char* longName, const char* shortName, uint32_t flags);
+
+    /// \brief  add a new 2D vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addVec2iAttr(const char* longName, const char* shortName, uint32_t flags);
+
+    /// \brief  add a new 2D vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addVec2dAttr(const char* longName, const char* shortName, uint32_t flags);
+
+    /// \brief  add a new double attribute to this node type.
+    /// \param  node the node to which the attribute will be added
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addFloatArrayAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags);
+
+    /// \brief  add a new DoubleArray attribute to this node type.
+    /// \param  node the node to which the attribute will be added
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addDoubleArrayAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags);
+
+    /// \brief  add a new 3D vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    static MObject addVec3hAttr(const char* longName, const char* shortName, uint32_t flags)
+    {
+        return addVec3fAttr(longName, shortName, flags);
+    }
+
+    /// \brief  add a new 3D vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addVec3fAttr(const char* longName, const char* shortName, uint32_t flags);
+
+    /// \brief  add a new 3D vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addVec3iAttr(const char* longName, const char* shortName, uint32_t flags);
+
+    /// \brief  add a new 3D vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addVec3dAttr(const char* longName, const char* shortName, uint32_t flags);
+
+    /// \brief  add a new 4D vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    static MObject addVec4hAttr(const char* longName, const char* shortName, uint32_t flags)
+    {
+        return addVec4fAttr(longName, shortName, flags);
+    }
+
+    /// \brief  add a new 4D vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addVec4fAttr(const char* longName, const char* shortName, uint32_t flags);
+
+    /// \brief  add a new 4D vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addVec4iAttr(const char* longName, const char* shortName, uint32_t flags);
+
+    /// \brief  add a new 4D vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \return the MObject for the attribute
+    
+    static MObject addVec4dAttr(const char* longName, const char* shortName, uint32_t flags);
+
+    /// \brief  set the min/max values on a numeric attribute
+    /// \param  obj the attribute handle
+    /// \param  minimum the min value for the attribute
+    /// \param  maximum the max value for the attribute
+    template <typename datatype>
+    static void setMinMax(MObject obj, datatype minimum, datatype maximum)
+    {
+        MFnNumericAttribute fn(obj);
+        fn.setMin(minimum);
+        fn.setMax(maximum);
+    }
+
+    /// \brief  set the min/max/softmax values on a numeric attribute
+    /// \param  obj the attribute handle
+    /// \param  minimum the min value for the attribute
+    /// \param  maximum the max value for the attribute
+    /// \param  softmin the soft min value for the attribute
+    /// \param  softmax the soft max value for the attribute
+    template <typename datatype>
+    static void
+    setMinMax(MObject obj, datatype minimum, datatype maximum, datatype softmin, datatype softmax)
+    {
+        MFnNumericAttribute fn(obj);
+        fn.setMin(minimum);
+        fn.setMax(maximum);
+        fn.setSoftMin(softmin);
+        fn.setSoftMax(softmax);
+    }
+
+    /// \brief  used to add additional references to AETemplate calls for standard types, e.g.
+    /// "AEsurfaceShapeTemplate"
+    ///         these will be inserted into the correct location
+    /// \param  baseTemplate the additional AE template UI
+    static void addBaseTemplate(const std::string& baseTemplate)
+    {
+        if (!baseTemplate.empty())
+            m_internal->m_baseTemplates.push_back(baseTemplate);
+    }
+
+    /// \brief  This method will construct up the MEL script code for the attribute editor template
+    /// for your node.
+    ///         Once constructed, the code will be executed silently in the background. If you wish
+    ///         to see the code being executed, enable 'echo all commands' in the MEL script editor
+    ///         prior to loading your plug-in.
+    
+    static void generateAETemplate();
+
+    //--------------------------------------------------------------------------------------------------------------------
+    /// \name   Add Dynamic Attributes to Node
+    //--------------------------------------------------------------------------------------------------------------------
+
+    /// \brief  add a new string attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  forceShow  force attribute to be shown.  Used
+    /// in case attribute is not writable but needs to be shown i.e. read-only. \param  node the
+    /// node to add the attribute to \param  attribute an optional pointer to an MObject in which
+    /// the attribute handle will be returned \return MS::kSuccess when succeeded, otherwise the
+    /// error code
+    
+    static MStatus addStringAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags,
+        bool           forceShow = false,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new file path attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  fileFilter a file filter of the form:
+    ///           "USD Files (*.usd*) (*.usd*);;Alembic Files (*.abc) (*.abc);;All files (*.*)
+    ///           (*.*)"
+    /// \param  fileMode  an enum that determines whether the GUI should display a file open dialog,
+    /// file save, or directory dialog. \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addFilePathAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags,
+        FileMode       fileMode,
+        const char*    fileFilter = "",
+        MObject*       attribute = 0);
+
+    /// \brief  add a new integer attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addInt8Attr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        int8_t         defaultValue,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new integer attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addInt16Attr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        int16_t        defaultValue,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new integer attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addInt32Attr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        int32_t        defaultValue,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new integer attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addInt64Attr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        int64_t        defaultValue,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new floating point attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addFloatAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        float          defaultValue,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new double attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addDoubleAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        double         defaultValue,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new time attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addTimeAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        const MTime&   defaultValue,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new time attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addDistanceAttr(
+        const MObject&   node,
+        const char*      longName,
+        const char*      shortName,
+        const MDistance& defaultValue,
+        uint32_t         flags,
+        MObject*         attribute = 0);
+
+    /// \brief  add a new time attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addAngleAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        const MAngle&  defaultValue,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new boolean attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addBoolAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        bool           defaultValue,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new float3 attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultX  the default value for the attribute
+    /// \param  defaultY  the default value for the attribute
+    /// \param  defaultZ  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    
+    static MStatus addFloat3Attr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        float          defaultX,
+        float          defaultY,
+        float          defaultZ,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new float3 attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultX  the default value for the attribute
+    /// \param  defaultY  the default value for the attribute
+    /// \param  defaultZ  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    
+    static MStatus addAngle3Attr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        float          defaultX,
+        float          defaultY,
+        float          defaultZ,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new point attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addPointAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        const MPoint&  defaultValue,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new float point attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    static MStatus addFloatPointAttr(
+        const MObject&     node,
+        const char*        longName,
+        const char*        shortName,
+        const MFloatPoint& defaultValue,
+        uint32_t           flags,
+        MObject*           attribute = 0)
+    {
+        return addFloat3Attr(
+            node,
+            longName,
+            shortName,
+            defaultValue.x,
+            defaultValue.y,
+            defaultValue.z,
+            flags,
+            attribute);
+    }
+
+    /// \brief  add a new vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addVectorAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        const MVector& defaultValue,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new float vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    static MStatus addFloatVectorAttr(
+        const MObject&      node,
+        const char*         longName,
+        const char*         shortName,
+        const MFloatVector& defaultValue,
+        uint32_t            flags,
+        MObject*            attribute = 0)
+    {
+        return addFloat3Attr(
+            node, longName, shortName, defaultValue.x, defaultValue.y, defaultValue.z, flags);
+    }
+
+    /// \brief  add a new mesh attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MObject addMeshAttr(const char* longName, const char* shortName, uint32_t flags);
+
+    /// \brief  add a new colour attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    static MStatus addColourAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        const MColor&  defaultValue,
+        uint32_t       flags,
+        MObject*       attribute = 0)
+    {
+        return addFloat3Attr(
+            node,
+            longName,
+            shortName,
+            defaultValue.r,
+            defaultValue.g,
+            defaultValue.b,
+            flags | kColour,
+            attribute);
+    }
+
+    /// \brief  add a new matrix attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addMatrixAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        const MMatrix& defaultValue,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new matrix attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addMatrix2x2Attr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        const float    defaultValue[2][2],
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new matrix attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  defaultValue  the default value for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addMatrix3x3Attr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        const float    defaultValue[3][3],
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new data attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  type the data type for the attribute \param
+    /// behaviour optionally control what happens when the attribute is disconnected \param  node
+    /// the node to add the attribute to \param  attribute an optional pointer to an MObject in
+    /// which the attribute handle will be returned \return MS::kSuccess when succeeded, otherwise
+    /// the error code
+    
+    static MStatus addDataAttr(
+        const MObject&                   node,
+        const char*                      longName,
+        const char*                      shortName,
+        MFnData::Type                    type,
+        uint32_t                         flags,
+        MFnAttribute::DisconnectBehavior behaviour = MFnAttribute::kNothing,
+        MObject*                         attribute = 0);
+
+    /// \brief  add a new data attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  type the data type for the attribute \param
+    /// behaviour optionally control what happens when the attribute is disconnected \param  node
+    /// the node to add the attribute to \param  attribute an optional pointer to an MObject in
+    /// which the attribute handle will be returned \return MS::kSuccess when succeeded, otherwise
+    /// the error code
+    
+    static MStatus addDataAttr(
+        const MObject&                   node,
+        const char*                      longName,
+        const char*                      shortName,
+        const MTypeId&                   type,
+        uint32_t                         flags,
+        MFnAttribute::DisconnectBehavior behaviour = MFnAttribute::kNothing,
+        MObject*                         attribute = 0);
+
+    /// \brief  add a new message attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addMessageAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new 2D floating point vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    static MStatus addVec2hAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags,
+        MObject*       attribute = 0)
+    {
+        return addVec2fAttr(node, longName, shortName, flags);
+    }
+
+    /// \brief  add a new 2D floating point vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addVec2fAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new 2D integer vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addVec2iAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new 2D double precision vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addVec2dAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new 3D floating point vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    static MStatus addVec3hAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags,
+        MObject*       attribute = 0)
+    {
+        return addVec3fAttr(node, longName, shortName, flags, attribute);
+    }
+
+    /// \brief  add a new 3D floating point vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addVec3fAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new 3D integer vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addVec3iAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new 3D double precision vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addVec3dAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new 4D floating point vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    static MStatus addVec4hAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags,
+        MObject*       attribute = 0)
+    {
+        return addVec4fAttr(node, longName, shortName, flags, attribute);
+    }
+
+    /// \brief  add a new 4D floating point vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    
+    static MStatus addVec4fAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new 4D integer vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    static MStatus addVec4iAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+    /// \brief  add a new 4D double precision vector attribute to this node type.
+    /// \param  longName  long name for the attribute
+    /// \param  shortName  short name for the attribute
+    /// \param  flags  a bitfield containing a mask of the AttributeFlags enumeration. Describes if
+    /// the attribute is an input/output/etc \param  node the node to add the attribute to \param
+    /// attribute an optional pointer to an MObject in which the attribute handle will be returned
+    /// \return MS::kSuccess when succeeded, otherwise the error code
+    static MStatus addVec4dAttr(
+        const MObject& node,
+        const char*    longName,
+        const char*    shortName,
+        uint32_t       flags,
+        MObject*       attribute = 0);
+
+private:
+    static MStatus applyAttributeFlags(MFnAttribute& fn, uint32_t flags);
+};
+

--- a/lib/mayaUsd/fileio/translators/translatorCamera.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorCamera.cpp
@@ -346,6 +346,9 @@ bool UsdMayaTranslatorCamera::Read(
         context->RegisterNewMayaNode(shapePrimPath.GetString(), cameraObj);
     }
 
+    // Copy userProperties to the created node
+    UsdMayaTranslatorUtil::copyAttributes(prim, cameraObj);
+
     return _ReadToCamera(usdCamera, cameraFn, args, context);
 }
 

--- a/lib/mayaUsd/fileio/translators/translatorCurves.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorCurves.cpp
@@ -267,6 +267,9 @@ bool UsdMayaTranslatorCurves::Create(
         }
     }
 
+    // Copy userProperties to the created node
+    UsdMayaTranslatorUtil::copyAttributes(prim, curveObj);
+
     return true;
 }
 

--- a/lib/mayaUsd/fileio/translators/translatorMesh.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMesh.cpp
@@ -15,6 +15,8 @@
 //
 #include "translatorMesh.h"
 
+#include <mayaUsd/fileio/translators/translatorUtil.h>
+
 #include <mayaUsd/fileio/utils/meshReadUtils.h>
 #include <mayaUsd/fileio/utils/meshWriteUtils.h>
 #include <mayaUsd/fileio/utils/readUtil.h>
@@ -246,6 +248,9 @@ TranslatorMeshRead::TranslatorMeshRead(
         { UsdGeomTokens->subdivisionScheme,
           UsdGeomTokens->interpolateBoundary,
           UsdGeomTokens->faceVaryingLinearInterpolation });
+
+    // Copy userProperties to the created node
+    UsdMayaTranslatorUtil::copyAttributes(prim, m_meshObj);
 
     // ==================================================
     // construct blendshape object, PointBasedDeformer

--- a/lib/mayaUsd/fileio/translators/translatorNurbsPatch.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorNurbsPatch.cpp
@@ -480,6 +480,9 @@ bool UsdMayaTranslatorNurbsPatch::Read(
         MGlobal::deleteNode(deleteAfterTrim[l]);
     }
 
+    // Copy userProperties
+    UsdMayaTranslatorUtil::copyAttributes(prim, surfaceObj);
+
     return true;
 }
 

--- a/lib/mayaUsd/fileio/translators/translatorPrim.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorPrim.cpp
@@ -105,6 +105,9 @@ void UsdMayaTranslatorPrim::Read(
     UsdMayaReadUtil::ReadMetadataFromPrim(args.GetIncludeMetadataKeys(), prim, mayaNode);
     UsdMayaReadUtil::ReadAPISchemaAttributesFromPrim(args.GetIncludeAPINames(), prim, mayaNode);
 
+    // Copy userProperties
+    UsdMayaTranslatorUtil::copyAttributes(prim, mayaNode);
+
     // XXX What about all the "user attributes" that PrimWriter exports???
 }
 

--- a/lib/mayaUsd/fileio/translators/translatorUtil.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorUtil.cpp
@@ -15,6 +15,9 @@
 //
 #include "translatorUtil.h"
 
+#include <mayaUsd/fileio/translators/NodeHelper.h>
+#include <mayaUsd/fileio/translators/DgNodeHelper.h>
+
 #include <mayaUsd/fileio/primReaderArgs.h>
 #include <mayaUsd/fileio/primReaderContext.h>
 #include <mayaUsd/fileio/translators/translatorXformable.h>
@@ -38,6 +41,233 @@
 #include <maya/MString.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
+
+
+UsdDataType getAttributeType(const UsdAttribute& usdAttr)
+{
+    if (!usdAttr.IsValid()) {
+        return UsdDataType::kUnknown;
+    }
+    const SdfValueTypeName typeName = usdAttr.GetTypeName();
+    const auto             it = usdTypeHashToEnum.find(typeName.GetHash());
+    if (it == usdTypeHashToEnum.end()) {
+        return UsdDataType::kUnknown;
+    }
+    return it->second;
+}
+
+
+static bool replace(std::string& str, const std::string& from, const std::string& to) {
+    size_t start_pos = str.find(from);
+    if(start_pos == std::string::npos)
+        return false;
+    str.replace(start_pos, from.length(), to);
+    return true;
+}
+
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus UsdMayaTranslatorUtil::addDynamicAttribute(MObject node, const UsdAttribute& usdAttr)
+{
+    const SdfValueTypeName typeName = usdAttr.GetTypeName();
+    const bool             isArray = typeName.IsArray();
+    const UsdDataType      dataType = getAttributeType(usdAttr);
+    MObject                attribute = MObject::kNullObj;
+    const char*            attrName = usdAttr.GetName().GetString().c_str();
+
+
+//    if (isArray)
+//        cout << dataType << endl;
+
+    // Fixing attr names to match the original maya names before writing them to USD Attrs
+    // using -userattr flag that was added to usdExport in our implementation
+    bool isShapeAttr = true;
+    std::string tmpAttrName = attrName;
+    if (tmpAttrName.rfind("xform:userProperties:", 0) == 0) {
+        // This is transform userProperties
+        isShapeAttr = false;
+        replace(tmpAttrName, "xform:userProperties:", "");
+    } else if (tmpAttrName.rfind("userProperties:", 0) == 0) {
+        isShapeAttr = true;
+        replace(tmpAttrName, "userProperties:", "");
+    } else if (tmpAttrName.rfind("primvars:", 0) == 0) {
+        return MS::kSuccess; // We will not create the primvars here (it's done somewhere else)
+    }
+    attrName = tmpAttrName.c_str();
+
+    MDagPath dagPath = MDagPath::getAPathTo(node);
+    // don't add/set the attribute when it's a shape attr and the node is transform and vise versa
+    // in such case, assume kSuccess
+    if ((isShapeAttr and node.apiType() ==  MFn::kTransform) || (!isShapeAttr and node.apiType() !=  MFn::kTransform))
+        return  MS::kSuccess;
+
+    // Some plugins like renderman creates custom attributes on time of object creation (before us here)
+    // when these attributes are modified and exported out into the USD, we need to set them back when loading
+    // the USD, So, we have to check if the custom attr exists, then we have to set the value rather than adding a new attr.
+    MFnDependencyNode depNode(node);
+    if (!depNode.hasAttribute(attrName)) {
+
+        const uint32_t flags = (isArray ? NodeHelper::kArray : 0)
+                               | NodeHelper::kReadable | NodeHelper::kWritable
+                               | NodeHelper::kStorable | NodeHelper::kConnectable;
+        switch (dataType) {
+        case UsdDataType::kAsset: {
+            return MS::kSuccess;
+        } break;
+
+        case UsdDataType::kBool: {
+            NodeHelper::addBoolAttr(node, attrName, attrName, false, flags, &attribute);
+        } break;
+
+        case UsdDataType::kUChar: {
+            NodeHelper::addInt8Attr(
+                node, attrName, attrName, 0, flags, &attribute);
+        } break;
+
+        case UsdDataType::kInt:
+        case UsdDataType::kUInt: {
+            NodeHelper::addInt32Attr(
+                node, attrName, attrName, 0, flags, &attribute);
+        } break;
+
+        case UsdDataType::kInt64:
+        case UsdDataType::kUInt64: {
+            NodeHelper::addInt64Attr(
+                node, attrName, attrName, 0, flags, &attribute);
+        } break;
+
+        case UsdDataType::kHalf:
+        case UsdDataType::kFloat: {
+            NodeHelper::addFloatAttr(
+                node, attrName, attrName, 0, flags, &attribute);
+        } break;
+
+        case UsdDataType::kDouble: {
+            NodeHelper::addDoubleAttr(
+                node, attrName, attrName, 0, flags, &attribute);
+        } break;
+
+        case UsdDataType::kString: {
+            NodeHelper::addStringAttr(
+                node, attrName, attrName, flags, true, &attribute);
+        } break;
+
+        case UsdDataType::kMatrix2d: {
+            const float defValue[2][2] = { { 0, 0 }, { 0, 0 } };
+            NodeHelper::addMatrix2x2Attr(
+                node, attrName, attrName, defValue, flags, &attribute);
+        } break;
+
+        case UsdDataType::kMatrix3d: {
+            const float defValue[3][3] = { { 0, 0, 0 }, { 0, 0, 0 }, { 0, 0, 0 } };
+            NodeHelper::addMatrix3x3Attr(
+                node, attrName, attrName, defValue, flags, &attribute);
+        } break;
+
+        case UsdDataType::kMatrix4d: {
+            NodeHelper::addMatrixAttr(
+                node, attrName, attrName, MMatrix(), flags, &attribute);
+        } break;
+
+        case UsdDataType::kQuatd: {
+            NodeHelper::addVec4dAttr(node, attrName, attrName, flags, &attribute);
+        } break;
+
+        case UsdDataType::kQuatf:
+        case UsdDataType::kQuath: {
+            NodeHelper::addVec4fAttr(node, attrName, attrName, flags, &attribute);
+        } break;
+
+        case UsdDataType::kVec2d: {
+            NodeHelper::addVec2dAttr(node, attrName, attrName, flags, &attribute);
+        } break;
+
+        case UsdDataType::kVec2f:
+        case UsdDataType::kVec2h: {
+            NodeHelper::addVec2fAttr(node, attrName, attrName, flags, &attribute);
+        } break;
+
+        case UsdDataType::kVec2i: {
+            NodeHelper::addVec2iAttr(node, attrName, attrName, flags, &attribute);
+        } break;
+
+        case UsdDataType::kVec3d: {
+            NodeHelper::addVec3dAttr(node, attrName, attrName, flags, &attribute);
+        } break;
+
+        case UsdDataType::kVec3f:
+        case UsdDataType::kVec3h: {
+            NodeHelper::addVec3fAttr(node, attrName, attrName, flags, &attribute);
+        } break;
+
+        case UsdDataType::kVec3i: {
+            NodeHelper::addVec3iAttr(node, attrName, attrName, flags, &attribute);
+        } break;
+
+        case UsdDataType::kVec4d: {
+            NodeHelper::addVec4dAttr(node, attrName, attrName, flags, &attribute);
+        } break;
+
+        case UsdDataType::kVec4f:
+        case UsdDataType::kVec4h: {
+            NodeHelper::addVec4fAttr(node, attrName, attrName, flags, &attribute);
+        } break;
+
+        case UsdDataType::kVec4i: {
+            NodeHelper::addVec4iAttr(node, attrName, attrName, flags, &attribute);
+        } break;
+
+        default:
+            MGlobal::displayError(
+                "DgNodeTranslator::addDynamicAttribute - unsupported USD data type");
+            return MS::kFailure;
+        }
+    } else {
+        // Get the attribute
+        attribute = depNode.attribute(attrName);
+    }
+
+    bool isAnimated = usdAttr.GetNumTimeSamples() > 0;
+    if (isArray) {
+        return DgNodeHelper::setArrayMayaValue(node, attribute, usdAttr, dataType);
+    } else {
+        if (isAnimated) {
+            if (dataType == UsdDataType::kDouble || dataType == UsdDataType::kFloat) {
+                return DgNodeHelper::setFloatAttrAnim(node, attribute, usdAttr);
+            } else if (dataType == UsdDataType::kBool) {
+                return DgNodeHelper::setBoolAttrAnim(node, attribute, usdAttr);
+            } else if (dataType == UsdDataType::kInt) {
+                return DgNodeHelper::setIntAttrAnim(node, attribute, usdAttr);
+            } else {
+                return DgNodeHelper::setSingleMayaValue(node, attribute, usdAttr, dataType);
+            }
+        } else {
+            return DgNodeHelper::setSingleMayaValue(node, attribute, usdAttr, dataType);
+        }
+    }
+}
+
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus
+UsdMayaTranslatorUtil::copyAttributes(const UsdPrim& from, MObject to)
+{
+    const std::vector<UsdAttribute> attributes = from.GetAttributes();
+    for (size_t i = 0; i < attributes.size(); ++i) {
+        if (attributes[i].IsAuthored() && attributes[i].HasValue()
+            && attributes[i].IsCustom()) {
+            if (!attributeHandled(attributes[i]))
+                addDynamicAttribute(to, attributes[i]);
+        }
+    }
+    return MS::kSuccess;
+}
+
+
+//----------------------------------------------------------------------------------------------------------------------
+bool UsdMayaTranslatorUtil::attributeHandled(const UsdAttribute& usdAttr) { return false; }
+
+
 
 const MString _DEFAULT_TRANSFORM_TYPE("transform");
 
@@ -143,7 +373,12 @@ bool UsdMayaTranslatorUtil::CreateNode(
     MStatus*                  status,
     MObject*                  mayaNodeObj)
 {
-    return CreateNode(usdPrim.GetPath(), nodeTypeName, parentNode, context, status, mayaNodeObj);
+    bool stat = CreateNode(usdPrim.GetPath(), nodeTypeName, parentNode, context, status, mayaNodeObj);
+
+    // Copy userProperties to the created transform node
+    copyAttributes(usdPrim, *mayaNodeObj);
+
+    return stat;
 }
 
 /* static */

--- a/lib/mayaUsd/fileio/translators/translatorUtil.h
+++ b/lib/mayaUsd/fileio/translators/translatorUtil.h
@@ -28,6 +28,135 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+enum class UsdDataType : uint32_t
+{
+    kBool,
+    kUChar,
+    kInt,
+    kUInt,
+    kInt64,
+    kUInt64,
+    kHalf,
+    kFloat,
+    kDouble,
+    kString,
+    kMatrix2d,
+    kMatrix3d,
+    kMatrix4d,
+    kQuatd,
+    kQuatf,
+    kQuath,
+    kVec2d,
+    kVec2f,
+    kVec2h,
+    kVec2i,
+    kVec3d,
+    kVec3f,
+    kVec3h,
+    kVec3i,
+    kVec4d,
+    kVec4f,
+    kVec4h,
+    kVec4i,
+    kToken,
+    kAsset,
+    kFrame4d,
+    kColor3h,
+    kColor3f,
+    kColor3d,
+    kUnknown
+};
+
+
+static const std::unordered_map<size_t, UsdDataType> usdTypeHashToEnum {
+    { SdfValueTypeNames->Bool.GetHash(), UsdDataType::kBool },
+    { SdfValueTypeNames->UChar.GetHash(), UsdDataType::kUChar },
+    { SdfValueTypeNames->Int.GetHash(), UsdDataType::kInt },
+    { SdfValueTypeNames->UInt.GetHash(), UsdDataType::kUInt },
+    { SdfValueTypeNames->Int64.GetHash(), UsdDataType::kInt64 },
+    { SdfValueTypeNames->UInt64.GetHash(), UsdDataType::kUInt64 },
+    { SdfValueTypeNames->Half.GetHash(), UsdDataType::kHalf },
+    { SdfValueTypeNames->Float.GetHash(), UsdDataType::kFloat },
+    { SdfValueTypeNames->Double.GetHash(), UsdDataType::kDouble },
+    { SdfValueTypeNames->String.GetHash(), UsdDataType::kString },
+    { SdfValueTypeNames->Token.GetHash(), UsdDataType::kToken },
+    { SdfValueTypeNames->Asset.GetHash(), UsdDataType::kAsset },
+    { SdfValueTypeNames->Int2.GetHash(), UsdDataType::kVec2i },
+    { SdfValueTypeNames->Int3.GetHash(), UsdDataType::kVec3i },
+    { SdfValueTypeNames->Int4.GetHash(), UsdDataType::kVec4i },
+    { SdfValueTypeNames->Half2.GetHash(), UsdDataType::kVec2h },
+    { SdfValueTypeNames->Half3.GetHash(), UsdDataType::kVec3h },
+    { SdfValueTypeNames->Half4.GetHash(), UsdDataType::kVec4h },
+    { SdfValueTypeNames->Float2.GetHash(), UsdDataType::kVec2f },
+    { SdfValueTypeNames->Float3.GetHash(), UsdDataType::kVec3f },
+    { SdfValueTypeNames->Float4.GetHash(), UsdDataType::kVec4f },
+    { SdfValueTypeNames->Double2.GetHash(), UsdDataType::kVec2d },
+    { SdfValueTypeNames->Double3.GetHash(), UsdDataType::kVec3d },
+    { SdfValueTypeNames->Double4.GetHash(), UsdDataType::kVec4d },
+    { SdfValueTypeNames->Point3h.GetHash(), UsdDataType::kVec3h },
+    { SdfValueTypeNames->Point3f.GetHash(), UsdDataType::kVec3f },
+    { SdfValueTypeNames->Point3d.GetHash(), UsdDataType::kVec3d },
+    { SdfValueTypeNames->Vector3h.GetHash(), UsdDataType::kVec3h },
+    { SdfValueTypeNames->Vector3f.GetHash(), UsdDataType::kVec3f },
+    { SdfValueTypeNames->Vector3d.GetHash(), UsdDataType::kVec3d },
+    { SdfValueTypeNames->Normal3h.GetHash(), UsdDataType::kVec3h },
+    { SdfValueTypeNames->Normal3f.GetHash(), UsdDataType::kVec3f },
+    { SdfValueTypeNames->Normal3d.GetHash(), UsdDataType::kVec3d },
+    { SdfValueTypeNames->Color3h.GetHash(), UsdDataType::kVec3h },
+    { SdfValueTypeNames->Color3f.GetHash(), UsdDataType::kVec3f },
+    { SdfValueTypeNames->Color3d.GetHash(), UsdDataType::kVec3d },
+    { SdfValueTypeNames->Quath.GetHash(), UsdDataType::kQuath },
+    { SdfValueTypeNames->Quatf.GetHash(), UsdDataType::kQuatf },
+    { SdfValueTypeNames->Quatd.GetHash(), UsdDataType::kQuatd },
+    { SdfValueTypeNames->Matrix2d.GetHash(), UsdDataType::kMatrix2d },
+    { SdfValueTypeNames->Matrix3d.GetHash(), UsdDataType::kMatrix3d },
+    { SdfValueTypeNames->Matrix4d.GetHash(), UsdDataType::kMatrix4d },
+    { SdfValueTypeNames->Frame4d.GetHash(), UsdDataType::kFrame4d },
+    { SdfValueTypeNames->BoolArray.GetHash(), UsdDataType::kBool },
+    { SdfValueTypeNames->UCharArray.GetHash(), UsdDataType::kUChar },
+    { SdfValueTypeNames->IntArray.GetHash(), UsdDataType::kInt },
+    { SdfValueTypeNames->UIntArray.GetHash(), UsdDataType::kUInt },
+    { SdfValueTypeNames->Int64Array.GetHash(), UsdDataType::kInt64 },
+    { SdfValueTypeNames->UInt64Array.GetHash(), UsdDataType::kUInt64 },
+    { SdfValueTypeNames->HalfArray.GetHash(), UsdDataType::kHalf },
+    { SdfValueTypeNames->FloatArray.GetHash(), UsdDataType::kFloat },
+    { SdfValueTypeNames->DoubleArray.GetHash(), UsdDataType::kDouble },
+    { SdfValueTypeNames->StringArray.GetHash(), UsdDataType::kString },
+    { SdfValueTypeNames->TokenArray.GetHash(), UsdDataType::kToken },
+    { SdfValueTypeNames->AssetArray.GetHash(), UsdDataType::kAsset },
+    { SdfValueTypeNames->Int2Array.GetHash(), UsdDataType::kVec2i },
+    { SdfValueTypeNames->Int3Array.GetHash(), UsdDataType::kVec3i },
+    { SdfValueTypeNames->Int4Array.GetHash(), UsdDataType::kVec4i },
+    { SdfValueTypeNames->Half2Array.GetHash(), UsdDataType::kVec2h },
+    { SdfValueTypeNames->Half3Array.GetHash(), UsdDataType::kVec3h },
+    { SdfValueTypeNames->Half4Array.GetHash(), UsdDataType::kVec4h },
+    { SdfValueTypeNames->Float2Array.GetHash(), UsdDataType::kVec2f },
+    { SdfValueTypeNames->Float3Array.GetHash(), UsdDataType::kVec3f },
+    { SdfValueTypeNames->Float4Array.GetHash(), UsdDataType::kVec4f },
+    { SdfValueTypeNames->Double2Array.GetHash(), UsdDataType::kVec2d },
+    { SdfValueTypeNames->Double3Array.GetHash(), UsdDataType::kVec3d },
+    { SdfValueTypeNames->Double4Array.GetHash(), UsdDataType::kVec4d },
+    { SdfValueTypeNames->Point3hArray.GetHash(), UsdDataType::kVec3h },
+    { SdfValueTypeNames->Point3fArray.GetHash(), UsdDataType::kVec3f },
+    { SdfValueTypeNames->Point3dArray.GetHash(), UsdDataType::kVec3d },
+    { SdfValueTypeNames->Vector3hArray.GetHash(), UsdDataType::kVec3h },
+    { SdfValueTypeNames->Vector3fArray.GetHash(), UsdDataType::kVec3f },
+    { SdfValueTypeNames->Vector3dArray.GetHash(), UsdDataType::kVec3d },
+    { SdfValueTypeNames->Normal3hArray.GetHash(), UsdDataType::kVec3h },
+    { SdfValueTypeNames->Normal3fArray.GetHash(), UsdDataType::kVec3f },
+    { SdfValueTypeNames->Normal3dArray.GetHash(), UsdDataType::kVec3d },
+    { SdfValueTypeNames->Color3hArray.GetHash(), UsdDataType::kVec3h },
+    { SdfValueTypeNames->Color3fArray.GetHash(), UsdDataType::kVec3f },
+    { SdfValueTypeNames->Color3dArray.GetHash(), UsdDataType::kVec3d },
+    { SdfValueTypeNames->QuathArray.GetHash(), UsdDataType::kQuath },
+    { SdfValueTypeNames->QuatfArray.GetHash(), UsdDataType::kQuatf },
+    { SdfValueTypeNames->QuatdArray.GetHash(), UsdDataType::kQuatd },
+    { SdfValueTypeNames->Matrix2dArray.GetHash(), UsdDataType::kMatrix2d },
+    { SdfValueTypeNames->Matrix3dArray.GetHash(), UsdDataType::kMatrix3d },
+    { SdfValueTypeNames->Matrix4dArray.GetHash(), UsdDataType::kMatrix4d },
+    { SdfValueTypeNames->Frame4dArray.GetHash(), UsdDataType::kFrame4d }
+};
+
 enum class UsdMayaShadingNodeType
 {
     NonShading,
@@ -38,6 +167,8 @@ enum class UsdMayaShadingNodeType
     Texture,
     Utility
 };
+
+UsdDataType getAttributeType(const UsdAttribute& usdAttr);
 
 /// \brief Provides helper functions for other readers to use.
 struct UsdMayaTranslatorUtil
@@ -144,6 +275,28 @@ struct UsdMayaTranslatorUtil
 
         return APISchemaType(usdPrim);
     }
+
+    MAYAUSD_CORE_PUBLIC
+    static MStatus addDynamicAttribute(MObject node, const UsdAttribute& usdAttr);
+
+    /// \brief  helper method to copy attributes from the UsdPrim to the Maya node
+    /// \param  from the UsdPrim to copy the data from
+    /// \param  to the maya node to copy the data to
+    /// \param  params the importer params to determine what to import
+    /// \return MS::kSuccess if ok
+    MAYAUSD_CORE_PUBLIC
+    static MStatus copyAttributes(const UsdPrim& from, MObject to);
+
+    /// \brief  A temporary solution. Given a custom attribute, if a translator handles it somehow
+    /// (i.e. lazy approach to
+    ///         not creating a schema), then overload this method and return true on the attribute
+    ///         you are handling. This will prevent the attribute from being imported/exported as a
+    ///         dynamic attribute.
+    /// \param  usdAttr the attribute to test
+    /// \return true if your translator is handling this attr
+    MAYAUSD_CORE_PUBLIC
+    static bool attributeHandled(const UsdAttribute& usdAttr);
+
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/utils/writeUtil.h
+++ b/lib/mayaUsd/fileio/utils/writeUtil.h
@@ -19,6 +19,8 @@
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/fileio/utils/userTaggedAttribute.h>
 
+#include "mayaUsd/fileio/writeJobContext.h"
+
 #include <pxr/base/tf/token.h>
 #include <pxr/base/vt/types.h>
 #include <pxr/pxr.h>
@@ -147,6 +149,15 @@ struct UsdMayaWriteUtil
         const UsdAttribute&        usdAttr,
         const UsdTimeCode&         usdTime,
         UsdUtilsSparseValueWriter* valueWriter = nullptr);
+
+    MAYAUSD_CORE_PUBLIC
+    static bool WriteUserAttributes(
+        const MObject&             mayaNode,
+        const UsdPrim&             usdPrim,
+        const UsdTimeCode&         usdTime,
+        UsdMayaWriteJobContext& writeJobCtx,
+        UsdUtilsSparseValueWriter* valueWriter = nullptr);
+
 
     /// Given a Maya node \p mayaNode, inspect it for attributes tagged by
     /// the user for export to USD and write them onto \p usdPrim at time

--- a/lib/usd/translators/jointWriter.cpp
+++ b/lib/usd/translators/jointWriter.cpp
@@ -265,12 +265,13 @@ bool _GetLocalTransformForDagPoseMember(
         // already exists
         MIntArray allIndices;
         xformMatrixPlug.getExistingArrayAttributeIndices(allIndices);
-        if (std::find(allIndices.cbegin(), allIndices.cend(), logicalIndex) == allIndices.cend()) {
-            TfDebug::Helper().Msg(
-                "Warning - attempting to retrieve %s[%u], but that index did not exist yet",
-                xformMatrixPlug.name().asChar(),
-                logicalIndex);
-        }
+        // Fixme Fails to compile for maya 2019
+//        if (std::find(allIndices.cbegin(), allIndices.cend(), logicalIndex) == allIndices.cend()) {
+//            TfDebug::Helper().Msg(
+//                "Warning - attempting to retrieve %s[%u], but that index did not exist yet",
+//                xformMatrixPlug.name().asChar(),
+//                logicalIndex);
+//        }
     }
 #endif
     MPlug xformPlug = xformMatrixPlug.elementByLogicalIndex(logicalIndex, &status);

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/Import.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/Import.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include "AL/usdmaya/fileio/Import.h"
+#include "AL/usdmaya/fileio/translators/DgNodeTranslator.h"
 
 #include "AL/maya/utils/Utils.h"
 #include "AL/usdmaya/CodeTimings.h"
@@ -269,6 +270,11 @@ MObject Import::createShape(
         // special case
         dataPlugin->import(prim, parent);
     }
+
+    // Copy (add/set) the shape attributes from the USD
+    MStatus status;
+    status = translators::DgNodeTranslator::copyAttributes(prim, shapeObj, m_params);
+    AL_MAYA_CHECK_ERROR_RETURN_NULL_MOBJECT(status, "DagNodeTranslator::createNode unable to copy attributes");
 
     return shapeObj;
 }

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/Import.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/Import.h
@@ -18,6 +18,7 @@
 #include "AL/usdmaya/fileio/ImportParams.h"
 #include "AL/usdmaya/fileio/NodeFactory.h"
 #include "AL/usdmaya/fileio/translators/TranslatorBase.h"
+#include "AL/usdmaya/fileio/translators/DgNodeTranslator.h"
 
 #include <pxr/pxr.h>
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/DgNodeTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/DgNodeTranslator.h
@@ -70,7 +70,7 @@ public:
     /// \param  params the importer params to determine what to import
     /// \return MS::kSuccess if ok
     AL_USDMAYA_PUBLIC
-    MStatus copyAttributes(const UsdPrim& from, MObject to, const ImporterParams& params);
+    static MStatus copyAttributes(const UsdPrim& from, MObject to, const ImporterParams& params);
 
     /// \brief  Copies data from the maya node onto the usd primitive
     /// \param  from the maya node to copy the data from
@@ -88,7 +88,7 @@ public:
     /// \param  usdAttr the attribute to test
     /// \return true if your translator is handling this attr
     AL_USDMAYA_PUBLIC
-    virtual bool attributeHandled(const UsdAttribute& usdAttr);
+    static bool attributeHandled(const UsdAttribute& usdAttr);
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/DgNodeHelper.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/DgNodeHelper.cpp
@@ -4681,10 +4681,10 @@ MStatus DgNodeHelper::addDynamicAttribute(MObject node, const UsdAttribute& usdA
             } else if (dataType == UsdDataType::kInt) {
                 return setIntAttrAnim(node, attribute, usdAttr);
             } else {
-                return DgNodeHelper::setSingleMayaValue(node, attribute, usdAttr, dataType);
+                return setSingleMayaValue(node, attribute, usdAttr, dataType);
             }
         } else {
-            return DgNodeHelper::setSingleMayaValue(node, attribute, usdAttr, dataType);
+            return setSingleMayaValue(node, attribute, usdAttr, dataType);
         }
     }
 }

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/DgNodeHelper.h
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/DgNodeHelper.h
@@ -1289,6 +1289,18 @@ public:
         double        conversionFactor = 1.0,
         MObjectArray* newAnimCurves = nullptr);
 
+    static MStatus setIntAttrAnim(
+        MObject       node,
+        MObject       attr,
+        UsdAttribute  usdAttr,
+        MObjectArray* newAnimCurves = nullptr);
+
+    static MStatus setBoolAttrAnim(
+        MObject       node,
+        MObject       attr,
+        UsdAttribute  usdAttr,
+        MObjectArray* newAnimCurves = nullptr);
+
     /// \brief  creates animation curves in maya for the visibility attribute
     /// \param  node the node instance the animated attribute belongs to
     /// \param  attr the visibility attribute handle


### PR DESCRIPTION
Importing/Exporting custom user attributes

Features:
---------
* Added -userattr/-u multi-flag to export user custom attributes to usd.
* All importer/translators will import all custom attributes found in USD to Maya when loading USDs in anyway (including assembly), the created attributes in Maya on import, will not have any namespace in the attribute name, just like how it was when it was exported at the first place.

Enhancements:
-------------

* -userattr/-u (multi-flag) allows passing the custom user attributes to be exported in USD without having to add a special tags on the exported nodes themselves, the value of the flag should have the desired namespace where the attribute will be written, for example::

usdExport -userattr "userProperties:ast" -userattr "userProperties:context" ....
usdExport -userattr "primvars:varyColor" ....

This will check the maya nodes being exported, if the attr (without the namespace) exists, then it will be exported under the given namespace, if it's not there for a specific object, the flag is ignored.

If the attribute being exported found on a transform node, it will be exported under an 'xform:' namespace, for example with: -userattr "userProperties:ast", if the the maya attribute "ast" found on transform node, it will be written in USD under xform:userProperties:ast, if it's found on a shape node, it will be written as is to userProperties:ast (and of course if doesn't exist, will be ignored).

This way even when merging transform/shape on the exported USD, we can still recognize if the 'ast' was a transform attribute or a 'shape' attribute especially when we import these attributes back again (which is another feature found in this same branch).

Note: when using the -userattr method, the maya doubles precision goes to USD as is without conversion, there is no option in this way to set additional information about the exported attrs as the case with normal attribute exporting using the json method, however, most of the attributes especially the type is set automatically based what we found in Maya.

* all pixar, maya, and Animal logic USD import/translators will create all the Maya custom attributes found in the loaded USD (in case with the attributes found under userProperties: namespace, it will all be created on the shape node, if it was under xform:userProperties: namespace, the it will be created in Maya on the transform node of the object.

Known Limitations:
------------------

- Animation of animated custom Array Attributes will not be animated, the values of the attribute array will be the value at the last timesSample of the importing frame range.