### PR TITLE
Add geomSidedness flag to exporter

### DIFF
--- a/lib/mayaUsd/commands/Readme.md
+++ b/lib/mayaUsd/commands/Readme.md
@@ -156,6 +156,8 @@ their own purposes, similar to the Alembic export chaser example.
 | `-selection`                     | `-sl`      | noarg            | false               | When set, only selected nodes (and their descendants) will be exported |
 | `-stripNamespaces`               | `-sn`      | bool             | false               | Remove namespaces during export. By default, namespaces are exported to the USD file in the following format: nameSpaceExample_pPlatonic1 |
 | `-staticSingleSample`            | `-sss`     | bool             | false               | Converts animated values with a single time sample to be static instead |
+| `-geomSidedness`                   | `-gs`     | string           | derived                | Determines how geometry sidedness is defined. Valid values are: `derived` - Value is taken from the shapes doubleSided attribute, `single` - Export single sided, `double` - Export double sided |
+
 | `-verbose`                       | `-v`       | noarg            | false               | Make the command output more verbose |
 
 #### Frame Samples

--- a/lib/mayaUsd/commands/baseExportCommand.cpp
+++ b/lib/mayaUsd/commands/baseExportCommand.cpp
@@ -169,6 +169,8 @@ MSyntax MayaUSDExportCommand::createSyntax()
         kStaticSingleSample,
         UsdMayaJobExportArgsTokens->staticSingleSample.GetText(),
         MSyntax::kBoolean);
+    syntax.addFlag(
+        kGeomSidednessFlag, UsdMayaJobExportArgsTokens->geomSidedness.GetText(), MSyntax::kString);
 
     // These are additional flags under our control.
     syntax.addFlag(kFrameRangeFlag, kFrameRangeFlagLong, MSyntax::kDouble, MSyntax::kDouble);

--- a/lib/mayaUsd/commands/baseExportCommand.h
+++ b/lib/mayaUsd/commands/baseExportCommand.h
@@ -79,6 +79,7 @@ public:
     static constexpr auto kPythonPostCallbackFlag = "ppc";
     static constexpr auto kVerboseFlag = "v";
     static constexpr auto kStaticSingleSample = "sss";
+    static constexpr auto kGeomSidednessFlag = "gs";
 
     // Short and Long forms of flags defined by this command itself:
     static constexpr auto kAppendFlag = "a";

--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -355,9 +355,12 @@ UsdMayaJobExportArgs::UsdMayaJobExportArgs(
           UsdMayaShadingModeRegistry::ListMaterialConversions()))
     , verbose(_Boolean(userArgs, UsdMayaJobExportArgsTokens->verbose))
     , staticSingleSample(_Boolean(userArgs, UsdMayaJobExportArgsTokens->staticSingleSample))
-    ,
-
-    chaserNames(_Vector<std::string>(userArgs, UsdMayaJobExportArgsTokens->chaser))
+    , geomSidedness(_Token(
+          userArgs,
+          UsdMayaJobExportArgsTokens->geomSidedness,
+          UsdMayaJobExportArgsTokens->derived,
+          { UsdMayaJobExportArgsTokens->single, UsdMayaJobExportArgsTokens->double_ }))
+    , chaserNames(_Vector<std::string>(userArgs, UsdMayaJobExportArgsTokens->chaser))
     , allChaserArgs(_ChaserArgs(userArgs, UsdMayaJobExportArgsTokens->chaserArgs))
     ,
 
@@ -409,6 +412,7 @@ std::ostream& operator<<(std::ostream& out, const UsdMayaJobExportArgs& exportAr
         << "stripNamespaces: " << TfStringify(exportArgs.stripNamespaces) << std::endl
         << "timeSamples: " << exportArgs.timeSamples.size() << " sample(s)" << std::endl
         << "staticSingleSample: " << TfStringify(exportArgs.staticSingleSample) << std::endl
+        << "geomSidedness: " << TfStringify(exportArgs.geomSidedness) << std::endl
         << "usdModelRootOverridePath: " << exportArgs.usdModelRootOverridePath << std::endl;
 
     out << "melPerFrameCallback: " << exportArgs.melPerFrameCallback << std::endl
@@ -504,6 +508,8 @@ const VtDictionary& UsdMayaJobExportArgs::GetDefaultDictionary()
         d[UsdMayaJobExportArgsTokens->stripNamespaces] = false;
         d[UsdMayaJobExportArgsTokens->verbose] = false;
         d[UsdMayaJobExportArgsTokens->staticSingleSample] = false;
+        d[UsdMayaJobExportArgsTokens->geomSidedness]
+            = UsdMayaJobExportArgsTokens->derived.GetString();
 
         // plugInfo.json site defaults.
         // The defaults dict should be correctly-typed, so enable

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -90,6 +90,7 @@ TF_DECLARE_PUBLIC_TOKENS(
     (stripNamespaces) \
     (verbose) \
     (staticSingleSample) \
+    (geomSidedness)   \
     /* Special "none" token */ \
     (none) \
     /* renderLayerMode values */ \
@@ -100,7 +101,11 @@ TF_DECLARE_PUBLIC_TOKENS(
     ((auto_, "auto")) \
     ((explicit_, "explicit")) \
     /* compatibility values */ \
-    (appleArKit)
+    (appleArKit)                          \
+    /* geomSidedness values */ \
+    (derived)                             \
+    (single)                              \
+    ((double_, "double"))                                          \
 // clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
@@ -189,6 +194,7 @@ struct UsdMayaJobExportArgs
     const TfToken convertMaterialsTo;
     const bool    verbose;
     const bool    staticSingleSample;
+    const TfToken geomSidedness;
 
     using ChaserArgs = std::map<std::string, std::string>;
     const std::vector<std::string>          chaserNames;

--- a/lib/mayaUsd/fileio/primWriter.cpp
+++ b/lib/mayaUsd/fileio/primWriter.cpp
@@ -169,7 +169,19 @@ void UsdMayaPrimWriter::Write(const UsdTimeCode& usdTime)
         // so it's OK to skip writing if this isn't a Gprim.
         UsdGeomGprim gprim(_usdPrim);
         if (gprim) {
-            UsdMayaTranslatorGprim::Write(GetMayaObject(), gprim, nullptr);
+            GeomSidedness sidedness = GeomSidedness::Derived;
+            auto          sidednessArg = _writeJobCtx.GetArgs().geomSidedness;
+            if (sidednessArg == UsdMayaJobExportArgsTokens->derived) {
+                sidedness = GeomSidedness::Derived;
+            } else if (sidednessArg == UsdMayaJobExportArgsTokens->single) {
+                sidedness = GeomSidedness::Single;
+            } else if (sidednessArg == UsdMayaJobExportArgsTokens->double_) {
+                sidedness = GeomSidedness::Double;
+            } else {
+                TF_CODING_ERROR("Unsupported sidedness: %s", sidednessArg.GetString().c_str());
+            }
+
+            UsdMayaTranslatorGprim::Write(GetMayaObject(), gprim, nullptr, sidedness);
         }
 
         // Only write class inherits once at default time.

--- a/lib/mayaUsd/fileio/primWriter.cpp
+++ b/lib/mayaUsd/fileio/primWriter.cpp
@@ -170,7 +170,7 @@ void UsdMayaPrimWriter::Write(const UsdTimeCode& usdTime)
         UsdGeomGprim gprim(_usdPrim);
         if (gprim) {
             GeomSidedness sidedness = GeomSidedness::Derived;
-            auto          sidednessArg = _writeJobCtx.GetArgs().geomSidedness;
+            const TfToken sidednessArg = _writeJobCtx.GetArgs().geomSidedness;
             if (sidednessArg == UsdMayaJobExportArgsTokens->derived) {
                 sidedness = GeomSidedness::Derived;
             } else if (sidednessArg == UsdMayaJobExportArgsTokens->single) {

--- a/lib/mayaUsd/fileio/translators/translatorGprim.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorGprim.cpp
@@ -15,8 +15,6 @@
 //
 #include "translatorGprim.h"
 
-#include "../writeJobContext.h"
-
 #include <mayaUsd/utils/util.h>
 
 #include <maya/MFnDagNode.h>
@@ -44,16 +42,13 @@ void UsdMayaTranslatorGprim::Write(
 {
     MFnDependencyNode depFn(mayaNode);
 
-    bool doubleSided = false;
-    if (sidedness == GeomSidedness::Derived
-        && UsdMayaUtil::getPlugValue(depFn, "doubleSided", &doubleSided) && doubleSided) {
-        doubleSided = true;
-    } else if (sidedness == GeomSidedness::Double) {
-        doubleSided = true;
-    }
-
-    if (doubleSided) {
-        gprim.CreateDoubleSidedAttr(VtValue(doubleSided), doubleSided);
+    bool doubleSided = sidedness == GeomSidedness::Double;
+    if (sidedness == GeomSidedness::Derived) {
+        if (UsdMayaUtil::getPlugValue(depFn, "doubleSided", &doubleSided)) {
+            gprim.CreateDoubleSidedAttr(VtValue(doubleSided), true);
+        }
+    } else {
+        gprim.CreateDoubleSidedAttr(VtValue(doubleSided), true);
     }
 
     bool opposite = false;

--- a/lib/mayaUsd/fileio/translators/translatorGprim.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorGprim.cpp
@@ -42,8 +42,12 @@ void UsdMayaTranslatorGprim::Write(
 {
     MFnDependencyNode depFn(mayaNode);
 
-    bool doubleSided = sidedness == GeomSidedness::Double;
+    // Write the doubleSided attribute regardless of its value, and let USD decide whether it's
+    // required
+    bool doubleSided = (sidedness == GeomSidedness::Double);
     if (sidedness == GeomSidedness::Derived) {
+        // Preserves the behaviour of writing to the boolean and then writing the attribute
+        // regardless of what the value may be, to let USD handle it.
         if (UsdMayaUtil::getPlugValue(depFn, "doubleSided", &doubleSided)) {
             gprim.CreateDoubleSidedAttr(VtValue(doubleSided), true);
         }

--- a/lib/mayaUsd/fileio/translators/translatorGprim.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorGprim.cpp
@@ -15,6 +15,8 @@
 //
 #include "translatorGprim.h"
 
+#include "../writeJobContext.h"
+
 #include <mayaUsd/utils/util.h>
 
 #include <maya/MFnDagNode.h>
@@ -37,13 +39,21 @@ void UsdMayaTranslatorGprim::Read(
 void UsdMayaTranslatorGprim::Write(
     const MObject&      mayaNode,
     const UsdGeomGprim& gprim,
-    UsdMayaPrimWriterContext*)
+    UsdMayaPrimWriterContext*,
+    GeomSidedness sidedness)
 {
     MFnDependencyNode depFn(mayaNode);
 
     bool doubleSided = false;
-    if (UsdMayaUtil::getPlugValue(depFn, "doubleSided", &doubleSided)) {
-        gprim.CreateDoubleSidedAttr(VtValue(doubleSided), true);
+    if (sidedness == GeomSidedness::Derived
+        && UsdMayaUtil::getPlugValue(depFn, "doubleSided", &doubleSided) && doubleSided) {
+        doubleSided = true;
+    } else if (sidedness == GeomSidedness::Double) {
+        doubleSided = true;
+    }
+
+    if (doubleSided) {
+        gprim.CreateDoubleSidedAttr(VtValue(doubleSided), doubleSided);
     }
 
     bool opposite = false;

--- a/lib/mayaUsd/fileio/translators/translatorGprim.h
+++ b/lib/mayaUsd/fileio/translators/translatorGprim.h
@@ -27,6 +27,13 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+enum GeomSidedness
+{
+    Derived,
+    Single,
+    Double
+};
+
 /// \brief Provides helper functions for reading UsdGeomGprim.
 struct UsdMayaTranslatorGprim
 {
@@ -35,8 +42,11 @@ struct UsdMayaTranslatorGprim
     Read(const UsdGeomGprim& gprim, MObject mayaNode, UsdMayaPrimReaderContext* context);
 
     MAYAUSD_CORE_PUBLIC
-    static void
-    Write(const MObject& mayaNode, const UsdGeomGprim& gprim, UsdMayaPrimWriterContext* context);
+    static void Write(
+        const MObject&            mayaNode,
+        const UsdGeomGprim&       gprim,
+        UsdMayaPrimWriterContext* context,
+        GeomSidedness             sidedness);
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
This PR adds a new flag to the exporter to override the sidedness of the mesh.
Options are:

* **derived** : Same behaviour as right now where it's taken from the double Sided attribute
*  **single** : All gprims are exported as single sided
* **double** : All gprims are exported as double sided

I've also updated the mesh tests and updated the command documentation.