### PR TITLE
Deleting assembly nodes that contained child assemblies crashes Maya

### DIFF
--- a/plugin/pxr/maya/lib/usdMaya/referenceAssembly.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/referenceAssembly.cpp
@@ -1101,11 +1101,11 @@ bool UsdMayaRepresentationBase::inactivate()
 
         MObject tmpNode = dagMod.createNode("transform");
 
-        // Calling removeChild here caused a crash with nested assemblies. 
-        // deleteNode will recursively call back into this function, and when 
-        // the nested node is inactivated, its own children are in a bogus 
-        // state. Reparenting nested nodes prior to delete works around this 
-        // issue 
+        // Calling removeChild here caused a crash with nested assemblies.
+        // deleteNode will recursively call back into this function, and when
+        // the nested node is inactivated, its own children are in a bogus
+        // state. Reparenting nested nodes prior to delete works around this
+        // issue
         MStatus status = dagMod.reparentNode(childNode, tmpNode);
         CHECK_MSTATUS_AND_RETURN(status, false);
 


### PR DESCRIPTION
Recursing into the inactivate function caused nested assembly nodes to end up in an
unstable state. Reparenting nested nodes prior to deleting works around
this problem.