### PR TITLE
[al] ProxyShape: add pauseUpdate attr to pause evaluation

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -342,6 +342,9 @@ public:
     /// when stage is opened
     AL_DECL_ATTRIBUTE(assetResolverConfig);
 
+    /// Don't update the proxy shape when updates to the usd stage are made
+    AL_DECL_ATTRIBUTE(pauseUpdates);
+
     /// Variant fallbacks if stage was opened and/reopened a Maya scene with custom variants
     /// fallbacks
     AL_DECL_ATTRIBUTE(variantFallbacks);
@@ -736,11 +739,21 @@ public:
     AL_USDMAYA_PUBLIC
     void resync(const SdfPath& primPath);
 
-    // \brief Serialize information unique to this shape
+    /// \brief Whether the proxy shape is currently listening to changes made to the usd stage
+    ///        Note that, because the proxy shape uses hydra for display purposes, which is
+    ///        connected to the underlying stage a a low level independent of this node, if
+    ///        ignoringUpdates / pauseUpdates are true, this does NOT mean that the displayed proxy
+    ///        shape will never reflect changes to the usd stage; rather, it just means that certain
+    ///        event listeners for the proxyShape are disabled. For instance, loading of
+    ///        ALMayaReference loads won't happen, nor will creation / destruction of transforms,
+    ///        etc.
+    inline bool ignoringUpdates() { return m_ignoringUpdates; }
+
+    /// \brief Serialize information unique to this shape
     AL_USDMAYA_PUBLIC
     void serialize(UsdStageRefPtr stage, LayerManager* layerManager);
 
-    // \brief Serialize all layers in proxyShapes to layerManager attributes; called before saving
+    /// \brief Serialize all layers in proxyShapes to layerManager attributes; called before saving
     AL_USDMAYA_PUBLIC
     static void serializeAll();
 
@@ -1141,6 +1154,7 @@ private:
 
     uint32_t m_engineRefCount = 0;
     bool     m_compositionHasChanged = false;
+    bool     m_ignoringUpdates = false;
     bool     m_pleaseIgnoreSelection = false;
     bool     m_hasChangedSelection = false;
     bool     m_filePathDirty = false;


### PR DESCRIPTION
Adds an attribute to the proxy shape to delay any costly updates to the maya viewport representation. This allows users or tools to make a series of usd edits efficiently and only pay once for the final result of all the changes.

We use this internally to pause evaluation as our users select variants from the available options and then only display the end result once the stage is fully configured. ( As a result, for now, this PR only pauses updates due to variant switches...)

Would like to make it pause updates due to other usd changes (not too hard) as well as changes in file path or prim path, too, but that is trickier. We'd be curious to know if Autodesk may have other methods for pausing evaluation that we can tap into to solve this problem. Otherwise, please consider the way we've approached it and how we might get this merged in for others.

#### Example Workflow that this enables:
1.) Open a scene with a shot stage in a proxy shape
2.) Open a pipeline specific tool and point it at the proxy shapes stage
3.) set "pauseUpdates" = True
4.) Change top level variants on a prim (which might reveals nested variants options, sub assets, new prim metadata, etc). This can be very slow if the stage is still pushing updates to the viewport or maya nodes.
5.) Use new info in your pipeline specific tool to continue making variant selections.
6.) close tool, set "pauseUpdates" = False, and allow maya + viewport to catch up and make a SINGLE sparse update to the FINAL state of the Stage.