### PR TITLE
Use SdfComputeAssetPathRelativeToLayer to compute sublayer paths

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -12,9 +12,9 @@
 #include <mayaUsd/base/tokens.h>
 #include <mayaUsd/utils/utilSerialization.h>
 
-#include <pxr/usd/ar/resolver.h>
 #include <pxr/usd/sdf/fileFormat.h>
 #include <pxr/usd/sdf/layer.h>
+#include <pxr/usd/sdf/layerUtils.h>
 
 #include <maya/MGlobal.h>
 #include <maya/MQtUtil.h>
@@ -70,9 +70,7 @@ void LayerTreeItem::populateChildren(RecursionDetector* recursionDetector)
     if (isInvalidLayer())
         return;
 
-    auto  subPaths = _layer->GetSubLayerPaths();
-    auto& resolver = ArGetResolver();
-    auto  anchor = toForwardSlashes(_layer->GetRealPath());
+    auto subPaths = _layer->GetSubLayerPaths();
 
     RecursionDetector defaultDetector;
     if (!recursionDetector) {
@@ -81,7 +79,7 @@ void LayerTreeItem::populateChildren(RecursionDetector* recursionDetector)
     recursionDetector->push(_layer->GetRealPath());
 
     for (auto const path : subPaths) {
-        std::string actualPath = computePathToLoadSublayer(path, anchor, resolver);
+        std::string actualPath = SdfComputeAssetPathRelativeToLayer(_layer, path);
         auto        subLayer = SdfLayer::FindOrOpen(actualPath);
         if (subLayer) {
             if (recursionDetector->contains(subLayer->GetRealPath())) {

--- a/lib/usd/ui/layerEditor/pathChecker.h
+++ b/lib/usd/ui/layerEditor/pathChecker.h
@@ -51,37 +51,6 @@ bool saveSubLayer(
     const std::string&     in_absolutePath,
     const std::string&     in_formatTag);
 
-// convert path string to use forward slashes
-inline std::string toForwardSlashes(const std::string& in_path)
-{
-    // it works better on windows if all the paths have forward slashes
-    auto path = in_path;
-    std::replace(path.begin(), path.end(), '\\', '/');
-    return path;
-}
-
-// contains the logic to get the right path to use for SdfLayer:::FindOrOpen
-// from a sublayerpath.
-// this path could be absolute, relative, or be an anon layer
-inline std::string computePathToLoadSublayer(
-    const std::string&  subLayerPath,
-    const std::string&  anchor,
-    PXR_NS::ArResolver& resolver)
-{
-    std::string actualPath = subLayerPath;
-    if (resolver.IsRelativePath(subLayerPath)) {
-        auto subLayer = PXR_NS::SdfLayer::Find(subLayerPath); // note: finds in the cache
-        if (subLayer) {
-            if (!resolver.IsRelativePath(subLayer->GetIdentifier())) {
-                actualPath = toForwardSlashes(subLayer->GetRealPath());
-            }
-        } else {
-            actualPath = resolver.AnchorRelativePath(anchor, subLayerPath);
-        }
-    }
-    return actualPath;
-}
-
 } // namespace UsdLayerEditor
 
 #endif // PATHCHECKER_H


### PR DESCRIPTION
This replaces custom logic that tried to anchor sublayer
paths to the parent layer using direct calls to ArResolver.
USD uses the Sdf function during composition, so using
it will match USD's behavior. This also allows us to
remove the use of ArResolver API that is deprecated
under Ar 2.0.