### PR TITLE
MAYA-112059 - UsdUVTexture works with Maya color management prefs

### DIFF
--- a/lib/mayaUsd/render/vp2ShaderFragments/UsdUVTexture.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/UsdUVTexture.xml
@@ -61,6 +61,7 @@ vec4 UsdUVTexture(
     vec2 stFlipped = stScaleOffset * vec2(1, -1) + vec2(0, 1);
     vec4 outColor = texture(fileSampler, stFlipped);
     if (isColorSpaceSRGB) {
+        // sRGB to linear:
         vec4 breakPnt = vec4(0.03928571566939354, 0.03928571566939354, 0.03928571566939354, 1.);
         vec4 slope = vec4(0.07738015800714493, 0.07738015800714493, 0.07738015800714493, 1.);
         vec4 scale = vec4(0.9478672742843628, 0.9478672742843628, 0.9478672742843628, 0.9999989867210388);
@@ -70,6 +71,8 @@ vec4 UsdUVTexture(
         vec4 linSeg = outColor * slope;
         vec4 powSeg = pow( max( vec4(0., 0., 0., 0.), scale * outColor + offset), gamma);
         outColor = isAboveBreak * powSeg + ( vec4(1., 1., 1., 1.) - isAboveBreak ) * linSeg;
+        // linear to Maya working space:
+        TO_MAYA_COLOR_SPACE_GLSL
     }
     return outColor * scale + bias;
 }
@@ -95,6 +98,7 @@ float4 UsdUVTexture(
     float2 stFlipped = stScaleOffset * float2(1, -1) + float2(0, 1);
     float4 outColor = file.Sample(fileSampler, stFlipped);
     if (isColorSpaceSRGB) {
+        // sRGB to linear:
         float4 breakPnt = float4(0.03928571566939354, 0.03928571566939354, 0.03928571566939354, 1.);
         float4 slope = float4(0.07738015800714493, 0.07738015800714493, 0.07738015800714493, 1.);
         float4 scale = float4(0.9478672742843628, 0.9478672742843628, 0.9478672742843628, 0.9999989867210388);
@@ -104,6 +108,8 @@ float4 UsdUVTexture(
         float4 linSeg = outColor * slope;
         float4 powSeg = pow( max( float4(0., 0., 0., 0.), scale * outColor + offset), gamma);
         outColor = isAboveBreak * powSeg + ( float4(1., 1., 1., 1.) - isAboveBreak ) * linSeg;
+        // linear to Maya working space:
+        TO_MAYA_COLOR_SPACE_HLSL
     }
     return outColor * scale + bias;
 }
@@ -129,6 +135,7 @@ float4 UsdUVTexture(
     float2 stFlipped = stScaleOffset * float2(1, -1) + float2(0, 1);
     float4 outColor = tex2D(fileSampler, stFlipped);
     if (isColorSpaceSRGB) {
+        // sRGB to linear
         float4 breakPnt = float4(0.03928571566939354, 0.03928571566939354, 0.03928571566939354, 1.);
         float4 slope = float4(0.07738015800714493, 0.07738015800714493, 0.07738015800714493, 1.);
         float4 scale = float4(0.9478672742843628, 0.9478672742843628, 0.9478672742843628, 0.9999989867210388);
@@ -138,6 +145,8 @@ float4 UsdUVTexture(
         float4 linSeg = outColor * slope;
         float4 powSeg = pow( max( float4(0., 0., 0., 0.), scale * outColor + offset), gamma);
         outColor = isAboveBreak * powSeg + ( float4(1., 1., 1., 1.) - isAboveBreak ) * linSeg;
+        // linear to Maya working space:
+        TO_MAYA_COLOR_SPACE_CG
     }
     return outColor * scale + bias;
 } 

--- a/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.cpp
+++ b/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.cpp
@@ -494,7 +494,7 @@ MStatus HdVP2ShaderFragments::deregisterFragments()
 #endif
 
     // De-register the various UsdUVTexture fragments:
-    for (const auto& txtFrag: _textureFragNames) {
+    for (const auto& txtFrag : _textureFragNames) {
         if (!fragmentManager->removeFragment(txtFrag.second.c_str())) {
             MGlobal::displayWarning(
                 TfStringPrintf("Failed to remove fragment graph: %s", txtFrag.second.c_str())

--- a/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.cpp
+++ b/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.cpp
@@ -25,6 +25,9 @@
 #include <maya/MShaderManager.h>
 #include <maya/MViewport2Renderer.h>
 
+#include <fstream>
+#include <regex>
+#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -102,8 +105,6 @@ static const TfTokenVector _FragmentNames = { _tokens->BasisCurvesCubicColorDoma
                                               _tokens->BasisCurvesLinearHull,
 
                                               _tokens->UsdPrimvarColor,
-
-                                              _tokens->UsdUVTexture,
 
                                               _tokens->UsdPrimvarReader_color,
                                               _tokens->UsdPrimvarReader_float,
@@ -202,6 +203,19 @@ std::vector<std::pair<MString, MString>> _domainShaderInputNameMappings
 
 namespace {
 int _registrationCount = 0;
+
+std::map<std::string, std::string> _textureFragNames;
+} // namespace
+
+MString HdVP2ShaderFragments::getUsdUVTextureFragmentName(const MString& workingColorSpace)
+{
+    auto it = _textureFragNames.find(workingColorSpace.asChar());
+    if (it != _textureFragNames.end()) {
+        return it->second.c_str();
+    }
+
+    // Default to linrec 709, which only does the gamma correction part from sRGB.
+    return "UsdUVTexture_to_linrec709";
 }
 
 // Fragment registration should be done after VP2 has been initialized, to avoid any errors from
@@ -330,6 +344,94 @@ MStatus HdVP2ShaderFragments::registerFragments()
         }
     }
 
+    {
+        // Register UVTexture readers for some common working spaces:
+        std::string uvTextureFile = TfStringPrintf("%s.xml", _tokens->UsdUVTexture.GetText());
+        uvTextureFile = _GetResourcePath(uvTextureFile);
+        std::ifstream xmlFile(uvTextureFile.c_str());
+        std::string   xmlString;
+        xmlFile.seekg(0, std::ios::end);
+        xmlString.reserve(xmlFile.tellg());
+        xmlFile.seekg(0, std::ios::beg);
+        xmlString.assign(
+            (std::istreambuf_iterator<char>(xmlFile)), std::istreambuf_iterator<char>());
+
+        const std::regex RE_FRAG("UsdUVTexture");
+        const std::regex RE_GLSL("TO_MAYA_COLOR_SPACE_GLSL");
+        const std::regex RE_HLSL("TO_MAYA_COLOR_SPACE_HLSL");
+        const std::regex RE_CG("TO_MAYA_COLOR_SPACE_CG");
+
+        auto registerSpace = [&](const std::string& spaceName,
+                                 const std::string& fragName,
+                                 const float*       convMatrix) {
+            if (!fragmentManager->hasFragment(fragName.c_str())) {
+                std::string xmlFinal = std::regex_replace(xmlString, RE_FRAG, fragName.c_str());
+                if (convMatrix) {
+                    std::stringstream op_glsl, op_hlsl, op_cg;
+                    op_glsl << "outColor = mat4(";
+                    op_hlsl << "outColor = mul(outColor, float4x4(";
+                    op_cg << "outColor = mul(float4x4(";
+                    for (int i = 0; i < 3; ++i) {
+                        op_glsl << convMatrix[3 * i] << ", " << convMatrix[3 * i + 1] << ", "
+                                << convMatrix[3 * i + 2] << ", " << 0.0 << ", ";
+                        op_hlsl << convMatrix[3 * i] << ", " << convMatrix[3 * i + 1] << ", "
+                                << convMatrix[3 * i + 2] << ", " << 0.0 << ", ";
+                        // Cg needs transposed matrix:
+                        op_cg << convMatrix[i] << ", " << convMatrix[3 + i] << ", "
+                              << convMatrix[6 + i] << ", " << 0.0 << ", ";
+                    }
+                    op_glsl << 0.0 << ", " << 0.0 << ", " << 0.0 << ", " << 1.0 << ") * outColor;";
+                    op_hlsl << 0.0 << ", " << 0.0 << ", " << 0.0 << ", " << 1.0 << "));";
+                    op_cg << 0.0 << ", " << 0.0 << ", " << 0.0 << ", " << 1.0 << "), outColor);";
+                    xmlFinal = std::regex_replace(xmlFinal, RE_GLSL, op_glsl.str().c_str());
+                    xmlFinal = std::regex_replace(xmlFinal, RE_HLSL, op_hlsl.str().c_str());
+                    xmlFinal = std::regex_replace(xmlFinal, RE_CG, op_cg.str().c_str());
+                } else {
+                    xmlFinal = std::regex_replace(xmlFinal, RE_GLSL, "");
+                    xmlFinal = std::regex_replace(xmlFinal, RE_HLSL, "");
+                    xmlFinal = std::regex_replace(xmlFinal, RE_CG, "");
+                }
+                const MString addedName
+                    = fragmentManager->addShadeFragmentFromBuffer(xmlFinal.c_str(), false);
+                if (addedName == fragName.c_str()) {
+                    _textureFragNames.emplace(spaceName, fragName);
+                } else {
+                    MGlobal::displayError(
+                        TfStringPrintf(
+                            "Failed to register UsdUVTexture fragment graph for color space: %s",
+                            spaceName.c_str())
+                            .c_str());
+                }
+            }
+        };
+
+        registerSpace("scene-linear Rec 709/sRGB", "UsdUVTexture_to_linrec709", nullptr);
+
+        const float LINEAR_TO_ACESCG[9]
+            = { 0.61309740, 0.07019372, 0.02061559, 0.33952315, 0.91635388,
+                0.10956977, 0.04737945, 0.01345240, 0.86981463 };
+        registerSpace("ACEScg", "UsdUVTexture_to_ACEScg", LINEAR_TO_ACESCG);
+
+        const float LINEAR_TO_ACES2065_1[9]
+            = { 0.43963298, 0.08977644, 0.01754117, 0.38298870, 0.81343943,
+                0.11154655, 0.17737832, 0.09678413, 0.87091228 };
+        registerSpace("ACES2065-1", "UsdUVTexture_to_ACES2065_1", LINEAR_TO_ACES2065_1);
+
+        const float LINEAR_TO_SCENE_LINEAR_DCI_P3_D65[9]
+            = { 0.82246197, 0.03319420, 0.01708263, 0.17753803, 0.96680580,
+                0.07239744, 0.,         0.,         0.91051993 };
+        registerSpace(
+            "scene-linear DCI-P3 D65",
+            "UsdUVTexture_to_lin_DCI_P3_D65",
+            LINEAR_TO_SCENE_LINEAR_DCI_P3_D65);
+
+        const float LINEAR_TO_SCENE_LINEAR_REC_2020[9]
+            = { 0.62740389, 0.06909729, 0.01639144, 0.32928304, 0.91954039,
+                0.08801331, 0.04331307, 0.01136232, 0.89559525 };
+        registerSpace(
+            "scene-linear Rec.2020", "UsdUVTexture_to_linrec2020", LINEAR_TO_SCENE_LINEAR_REC_2020);
+    }
+
 #if MAYA_API_VERSION >= 20210000
 
     // Register automatic shader stage input parameters.
@@ -390,6 +492,16 @@ MStatus HdVP2ShaderFragments::deregisterFragments()
     }
 
 #endif
+
+    // De-register the various UsdUVTexture fragments:
+    for (const auto& txtFrag: _textureFragNames) {
+        if (!fragmentManager->removeFragment(txtFrag.second.c_str())) {
+            MGlobal::displayWarning(
+                TfStringPrintf("Failed to remove fragment graph: %s", txtFrag.second.c_str())
+                    .c_str());
+            return MS::kFailure;
+        }
+    }
 
     // De-register UsdPreviewsurface graph:
     if (!fragmentManager->removeFragment(

--- a/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.h
+++ b/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.h
@@ -48,6 +48,10 @@ public:
     //! Deregister all HdVP2 fragments
     MAYAUSD_CORE_PUBLIC
     static MStatus deregisterFragments();
+
+    //! Get the right UsdUVTexture fragment name for the working color space
+    MAYAUSD_CORE_PUBLIC
+    static MString getUsdUVTextureFragmentName(const MString& workingColorSpace);
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
Maya versions before 2022 had a default color management rendering space of "scene-linear Rec 709/sRGB", which means converting a sRGB texture required only the gamma correction part,
With Maya 2022, we now use the "ACEScg" rendering color space, so an extra multiplication by a color correction matrix is required to move from linrec709 to ACEScg.
This is a user preference, though, and one that is saved with the scene. So we need to query the current rendering space and use the correct color correction.

This is the list of supported rendering color spaces:
- scene-linear Rec 709/sRGB
- ACEScg
- ACES2065-1
- scene-linear DCI-P3 D65
- scene-linear Rec.2020

Note that the VP2 render delegate does not register for notifications when the rendering color space is changed, so if you change the rendering color space, you should save the scene and reload to force the USD stages materials to be updated with the correct color space transformation.