### PR TITLE
MAYA-112227 - UV set renamed to st, st1, st2

### DIFF
--- a/lib/mayaUsd/commands/Readme.md
+++ b/lib/mayaUsd/commands/Readme.md
@@ -240,17 +240,8 @@ further `kind`/model inference optional. The current behavior is:
 #### UV Set Names
 
 Currently, for Mesh export (and similarly for NurbsPatch, also),
-the UV set names will be preserved.
-
-A previous version renamed the UV sets. To get back this old behavior,
-set the `MAYAUSD_EXPORT_MAP1_AS_PRIMARY_UV_SET` on export or
-`MAYAUSD_IMPORT_PRIMARY_UV_SET_AS_MAP1` when importing. The old
-renaming behavior worked as follow: we renamed the UV set `map1` to `st`.
-`st` is the primary UV set for RenderMan, so this was very convenient
-for a Renderman-based pipeline. The translation is reversed on
-importing USD into Maya, when the environment variable shown above
-is set. We understand this behavior was not desirable for all,
-so this translation is now off by default.
+the UV set names will be renamed st, st1, st2,... based on ordering of the
+primitive. The original name will be preserved in custom data for roundtripping.
 
 
 ### Custom Attributes and Tagging for USD

--- a/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
@@ -521,51 +521,39 @@ public:
                 "stringArrayToString(`uvLink -q -t \"^1s\"`, \" \");", nodeName.GetText());
             std::string uvLinkResult = MGlobal::executeCommandStringResult(uvLinkCmd).asChar();
             for (std::string uvSetRef : TfStringTokenize(uvLinkResult)) {
-                TfToken shapeName(uvSetRef.substr(0, uvSetRef.find('.')).c_str());
+                // NOTE: If the mesh shape has the same name as the transform, then we will get a
+                //       complete path like
+                //           |mesh|mesh.uvSet[0].uvSetName
+                //       the best way to prevent confusion is to move to the object model
+                //       immediately and process from there.
+                MSelectionList selList;
+                selList.add(uvSetRef.c_str());
+                MPlug uvNamePlug;
+                selList.getPlug(0, uvNamePlug);
+
+                MFnMesh meshFn(uvNamePlug.node());
+
+                TfToken shapeName(meshFn.name().asChar());
                 if (!exportedShapes.count(shapeName)) {
                     continue;
                 }
-                MString getAttrCmd;
-                getAttrCmd.format("getAttr \"^1s\";", uvSetRef.c_str());
-                MCommandResult mayaCmdResult;
-                TfToken        getAttrResult;
-                MGlobal::executeCommand(getAttrCmd, mayaCmdResult, false, false);
-                // NOTE: (yliangsiew) We do this because if you have a mesh shape in Maya named the
-                // same as its parent transform, you get back the result `map1 map1` instead of just
-                // `map1`. Why? Refer to the issue here:
-                // https://github.com/Autodesk/maya-usd/issues/1079
-                switch (mayaCmdResult.resultType()) {
-                case MCommandResult::kStringArray: {
-                    MStringArray cmdResult;
-                    mayaCmdResult.getResult(cmdResult);
-                    if (cmdResult.length() == 0) {
-                        TF_RUNTIME_ERROR(
-                            "No valid UV set names could be determined! The command run was: %s",
-                            getAttrCmd.asChar());
-                        continue;
+
+                MString uvSetName = uvNamePlug.asString();
+
+                // All UV sets now get renamed st, st1, st2 in the order returned by getUVSetNames
+                MStringArray uvSets;
+                meshFn.getUVSetNames(uvSets);
+                for (unsigned int i = 0; i < uvSets.length(); i++) {
+                    if (uvSets[i] == uvSetName) {
+                        uvSetName = "st";
+                        if (i) {
+                            uvSetName += i;
+                        }
+                        break;
                     }
-                    getAttrResult = TfToken(cmdResult[0].asChar());
-                    break;
-                }
-                case MCommandResult::kString: {
-                    MString cmdResult;
-                    mayaCmdResult.getResult(cmdResult);
-                    getAttrResult = TfToken(cmdResult.asChar());
-                    break;
-                }
-                default:
-                    TF_RUNTIME_ERROR(
-                        "The UV set name could not be determined; the result was of an "
-                        "unrecognized type! The command run was: %s",
-                        getAttrCmd.asChar());
-                    continue;
-                }
-                // Check if map1 should export as st:
-                if (getAttrResult == _tokens->map1 && UsdMayaWriteUtil::WriteMap1AsST()) {
-                    getAttrResult = UsdUtilsGetPrimaryUVSetName();
                 }
 
-                _shapeNameToUVNames[shapeName].push_back(getAttrResult);
+                _shapeNameToUVNames[shapeName].push_back(TfToken(uvSetName.asChar()));
             }
         }
 

--- a/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
@@ -202,7 +202,6 @@ bool assignUVSetPrimvarToMesh(const UsdGeomPrimvar& primvar, MFnMesh& meshFn, bo
     // Determine the name to use for the Maya UV set.
     MStatus status { MS::kSuccess };
     MString uvSetName(primvarName.GetText());
-    bool    createUVSet = true;
 
     TfToken originalName = UsdMayaRoundTripUtil::GetPrimVarMayaName(primvar);
     if (!originalName.IsEmpty()) {

--- a/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
@@ -186,7 +186,7 @@ MIntArray getMayaFaceVertexAssignmentIds(
     return valueIds;
 }
 
-bool assignUVSetPrimvarToMesh(const UsdGeomPrimvar& primvar, MFnMesh& meshFn, bool hasDefaultUVSet)
+bool assignUVSetPrimvarToMesh(const UsdGeomPrimvar& primvar, MFnMesh& meshFn, bool& firstUVPrimvar)
 {
     const TfToken& primvarName = primvar.GetPrimvarName();
 
@@ -204,26 +204,20 @@ bool assignUVSetPrimvarToMesh(const UsdGeomPrimvar& primvar, MFnMesh& meshFn, bo
     MString uvSetName(primvarName.GetText());
     bool    createUVSet = true;
 
-    if (primvarName == UsdUtilsGetPrimaryUVSetName() && UsdMayaReadUtil::ReadSTAsMap1()) {
-        // We assume that the primary USD UV set maps to Maya's default 'map1'
-        // set which always exists, so we shouldn't try to create it.
-        uvSetName = UsdMayaMeshPrimvarTokens->DefaultMayaTexcoordName.GetText();
-        createUVSet = false;
-    } else if (!hasDefaultUVSet) {
-        // If map1 still exists, we rename and re-use it:
-        MStringArray uvSetNames;
-        meshFn.getUVSetNames(uvSetNames);
-        if (uvSetNames[0u] == UsdMayaMeshPrimvarTokens->DefaultMayaTexcoordName.GetText()) {
-            meshFn.renameUVSet(
-                UsdMayaMeshPrimvarTokens->DefaultMayaTexcoordName.GetText(), uvSetName);
-            createUVSet = false;
-        }
-    } else if (primvarName == UsdMayaMeshPrimvarTokens->DefaultMayaTexcoordName) {
-        // For UV sets explicitly named map1
-        createUVSet = false;
+    TfToken originalName = UsdMayaRoundTripUtil::GetPrimVarMayaName(primvar);
+    if (!originalName.IsEmpty()) {
+        uvSetName = originalName.GetText();
     }
 
-    if (createUVSet) {
+    // The initial mesh will already have one empty UV set. We must re-use it.
+    if (firstUVPrimvar) {
+        MStringArray uvSetNames;
+        meshFn.getUVSetNames(uvSetNames);
+        if (uvSetNames[0u] != uvSetName) {
+            meshFn.renameUVSet(uvSetNames[0u], uvSetName);
+        }
+        firstUVPrimvar = false;
+    } else {
         status = meshFn.createUVSet(uvSetName);
         if (status != MS::kSuccess) {
             TF_WARN(
@@ -603,22 +597,7 @@ void UsdMayaMeshReadUtils::assignPrimvarsToMesh(
 
     // GETTING PRIMVARS
     const std::vector<UsdGeomPrimvar> primvars = mesh.GetPrimvars();
-
-    // Maya always has a map1 UV set. We need to find out if there is any stream in the file that
-    // will use that slot. If not, the first texcoord stream to load will replace the default map1
-    // stream.
-    bool hasDefaultUVSet = false;
-    for (const UsdGeomPrimvar& primvar : primvars) {
-        const SdfValueTypeName typeName = primvar.GetTypeName();
-        if (typeName == SdfValueTypeNames->TexCoord2fArray
-            || (UsdMayaReadUtil::ReadFloat2AsUV() && typeName == SdfValueTypeNames->Float2Array)) {
-            const TfToken fullName = primvar.GetPrimvarName();
-            if (fullName == UsdMayaMeshPrimvarTokens->DefaultMayaTexcoordName
-                || (fullName == UsdUtilsGetPrimaryUVSetName() && UsdMayaReadUtil::ReadSTAsMap1())) {
-                hasDefaultUVSet = true;
-            }
-        }
-    }
+    bool                              firstUVPrimvar = true;
 
     for (const UsdGeomPrimvar& primvar : primvars) {
         const TfToken          name = primvar.GetBaseName();
@@ -655,7 +634,7 @@ void UsdMayaMeshReadUtils::assignPrimvarsToMesh(
             // Otherwise, if env variable for reading Float2
             // as uv sets is turned on, we assume that Float2Array primvars
             // are UV sets.
-            if (!assignUVSetPrimvarToMesh(primvar, meshFn, hasDefaultUVSet)) {
+            if (!assignUVSetPrimvarToMesh(primvar, meshFn, firstUVPrimvar)) {
                 TF_WARN(
                     "Unable to retrieve and assign data for UV set <%s> on "
                     "mesh <%s>",

--- a/lib/mayaUsd/fileio/utils/readUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/readUtil.cpp
@@ -66,18 +66,6 @@ bool UsdMayaReadUtil::ReadFloat2AsUV()
     return readFloat2AsUV;
 }
 
-TF_DEFINE_ENV_SETTING(
-    MAYAUSD_IMPORT_PRIMARY_UV_SET_AS_MAP1,
-    false,
-    "Translates the primary UV set in USD to the map1 UV set in Maya. "
-    "When disabled, UV set names are translated directly (st in USD becomes st in Maya).");
-
-bool UsdMayaReadUtil::ReadSTAsMap1()
-{
-    static const bool readSTAsMap1 = TfGetEnvSetting(MAYAUSD_IMPORT_PRIMARY_UV_SET_AS_MAP1);
-    return readSTAsMap1;
-}
-
 MObject UsdMayaReadUtil::FindOrCreateMayaAttr(
     const SdfValueTypeName& typeName,
     const SdfVariability    variability,

--- a/lib/mayaUsd/fileio/utils/readUtil.h
+++ b/lib/mayaUsd/fileio/utils/readUtil.h
@@ -42,11 +42,6 @@ struct UsdMayaReadUtil
     MAYAUSD_CORE_PUBLIC
     static bool ReadFloat2AsUV();
 
-    /// Returns whether the environment setting for renaming st TexCoord to map1
-    /// is set to true
-    MAYAUSD_CORE_PUBLIC
-    static bool ReadSTAsMap1();
-
     /// Given the \p typeName and \p variability, try to create a Maya attribute
     /// on \p depNode with the name \p attrName.
     /// If the \p typeName isn't supported by this function, raises a runtime

--- a/lib/mayaUsd/fileio/utils/roundTripUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/roundTripUtil.cpp
@@ -43,6 +43,9 @@ TF_DEFINE_PRIVATE_TOKENS(
     // of the array is likely encoded in the attribute name though we could
     // extend this to store the name and index.
     (arrayIndex)
+
+    // This annotates the original Maya name of a primvar
+    (name)
 );
 // clang-format on
 
@@ -143,6 +146,18 @@ bool UsdMayaRoundTripUtil::GetAttributeArray(const UsdAttribute& attr, unsigned 
 void UsdMayaRoundTripUtil::MarkAttributeAsArray(const UsdAttribute& attr, const unsigned int index)
 {
     _SetMayaDictValue(attr, _tokens->arrayIndex, index);
+}
+
+TfToken UsdMayaRoundTripUtil::GetPrimVarMayaName(const UsdAttribute& attr)
+{
+    TfToken ret;
+    _GetMayaDictValue(attr, _tokens->name, &ret);
+    return ret;
+}
+
+void UsdMayaRoundTripUtil::SetPrimVarMayaName(const UsdAttribute& attr, const TfToken& name)
+{
+    _SetMayaDictValue(attr, _tokens->name, name);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/utils/roundTripUtil.h
+++ b/lib/mayaUsd/fileio/utils/roundTripUtil.h
@@ -61,6 +61,14 @@ struct UsdMayaRoundTripUtil
 
     MAYAUSD_CORE_PUBLIC
     static void MarkAttributeAsArray(const UsdAttribute& attr, const unsigned int index);
+
+    /// Texcoord primvars will get renamed st, st1, st2... We need to store and retrieve the
+    /// original Maya name
+    MAYAUSD_CORE_PUBLIC
+    static TfToken GetPrimVarMayaName(const UsdAttribute& attr);
+
+    MAYAUSD_CORE_PUBLIC
+    static void SetPrimVarMayaName(const UsdAttribute& attr, const TfToken& name);
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/utils/writeUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/writeUtil.cpp
@@ -81,12 +81,6 @@ TF_DEFINE_ENV_SETTING(
     "TexCoord2d, TexCoord3h, TexCoord3f, TexCoord3d and their associated "
     "Array types)");
 
-TF_DEFINE_ENV_SETTING(
-    MAYAUSD_EXPORT_MAP1_AS_PRIMARY_UV_SET,
-    false,
-    "Translates the map1 UV set in Maya to the primary UV set in USD. "
-    "When disabled, UV set names are translated directly (map1 in Maya becomes map1 in USD).");
-
 static bool _GetMayaAttributeNumericTypedAndUnitDataTypes(
     const MPlug&            attrPlug,
     MFnNumericData::Type&   numericDataType,
@@ -129,12 +123,6 @@ bool UsdMayaWriteUtil::WriteUVAsFloat2()
 {
     static const bool writeUVAsFloat2 = TfGetEnvSetting(PIXMAYA_WRITE_UV_AS_FLOAT2);
     return writeUVAsFloat2;
-}
-
-bool UsdMayaWriteUtil::WriteMap1AsST()
-{
-    static const bool writeMap1AsST = TfGetEnvSetting(MAYAUSD_EXPORT_MAP1_AS_PRIMARY_UV_SET);
-    return writeMap1AsST;
 }
 
 /* static */

--- a/lib/mayaUsd/fileio/utils/writeUtil.h
+++ b/lib/mayaUsd/fileio/utils/writeUtil.h
@@ -54,11 +54,6 @@ struct UsdMayaWriteUtil
     MAYAUSD_CORE_PUBLIC
     static bool WriteUVAsFloat2();
 
-    /// Returns whether the environment setting for renaming map1 TexCoord to st
-    /// is set to true
-    MAYAUSD_CORE_PUBLIC
-    static bool WriteMap1AsST();
-
     /// Given an \p attrPlug, try to create a USD attribute on \p usdPrim with
     /// the name \p attrName. Note, it's value will not be set.
     ///

--- a/lib/mayaUsd/python/wrapReadUtil.cpp
+++ b/lib/mayaUsd/python/wrapReadUtil.cpp
@@ -85,8 +85,6 @@ void wrapReadUtil()
     class_<This>("ReadUtil", no_init)
         .def("ReadFloat2AsUV", This::ReadFloat2AsUV)
         .staticmethod("ReadFloat2AsUV")
-        .def("ReadSTAsMap1", This::ReadSTAsMap1)
-        .staticmethod("ReadSTAsMap1")
         .def(
             "FindOrCreateMayaAttr",
             _FindOrCreateMayaAttr,

--- a/lib/mayaUsd/python/wrapRoundTripUtil.cpp
+++ b/lib/mayaUsd/python/wrapRoundTripUtil.cpp
@@ -45,5 +45,8 @@ void wrapRoundTripUtil()
               .staticmethod("IsPrimvarClamped")
 
               .def("MarkPrimvarAsClamped", This::MarkPrimvarAsClamped)
-              .staticmethod("MarkPrimvarAsClamped");
+              .staticmethod("MarkPrimvarAsClamped")
+
+              .def("GetPrimVarMayaName", This::GetPrimVarMayaName)
+              .staticmethod("GetPrimVarMayaName");
 }

--- a/lib/mayaUsd/python/wrapWriteUtil.cpp
+++ b/lib/mayaUsd/python/wrapWriteUtil.cpp
@@ -47,8 +47,6 @@ void wrapWriteUtil()
     class_<This>("WriteUtil", no_init)
         .def("WriteUVAsFloat2", This::WriteUVAsFloat2)
         .staticmethod("WriteUVAsFloat2")
-        .def("WriteMap1AsST", This::WriteMap1AsST)
-        .staticmethod("WriteMap1AsST")
         .def("GetVtValue", _GetVtValue)
         .staticmethod("GetVtValue");
 }

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -121,7 +121,6 @@ mayaUsd_add_test(testUsdExportUVSets
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     ENV
         "PIXMAYA_WRITE_UV_AS_FLOAT2=0"
-        "MAYAUSD_EXPORT_MAP1_AS_PRIMARY_UV_SET=0"
 )
 set_property(TEST testUsdExportUVSets APPEND PROPERTY LABELS translators)
 
@@ -130,43 +129,22 @@ mayaUsd_add_test(testUsdExportUVSetsFloat
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     ENV
         "PIXMAYA_WRITE_UV_AS_FLOAT2=1"
-        "MAYAUSD_EXPORT_MAP1_AS_PRIMARY_UV_SET=0"
 )
 set_property(TEST testUsdExportUVSetsFloat APPEND PROPERTY LABELS translators)
-
-mayaUsd_add_test(testUsdExportUVSetsST
-    PYTHON_MODULE testUsdExportUVSets
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    ENV
-        "PIXMAYA_WRITE_UV_AS_FLOAT2=0"
-        "MAYAUSD_EXPORT_MAP1_AS_PRIMARY_UV_SET=1"
-)
-set_property(TEST testUsdExportUVSetsST APPEND PROPERTY LABELS translators)
 
 mayaUsd_add_test(testUsdExportUVSetMappings
     PYTHON_MODULE testUsdExportUVSetMappings
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     ENV
         "PIXMAYA_WRITE_UV_AS_FLOAT2=0"
-        "MAYAUSD_EXPORT_MAP1_AS_PRIMARY_UV_SET=0"
 )
 set_property(TEST testUsdExportUVSetMappings APPEND PROPERTY LABELS translators)
-
-mayaUsd_add_test(testUsdExportUVSetMappingsST
-    PYTHON_MODULE testUsdExportUVSetMappings
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    ENV
-        "PIXMAYA_WRITE_UV_AS_FLOAT2=0"
-        "MAYAUSD_EXPORT_MAP1_AS_PRIMARY_UV_SET=1"
-)
-set_property(TEST testUsdExportUVSetMappingsST APPEND PROPERTY LABELS translators)
 
 mayaUsd_add_test(testUsdImportUVSets
     PYTHON_MODULE testUsdImportUVSets
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     ENV
         "PIXMAYA_READ_FLOAT2_AS_UV=0"
-        "MAYAUSD_IMPORT_PRIMARY_UV_SET_AS_MAP1=0"
 )
 set_property(TEST testUsdImportUVSets APPEND PROPERTY LABELS translators)
 
@@ -175,18 +153,8 @@ mayaUsd_add_test(testUsdImportUVSetsFloat
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     ENV
         "PIXMAYA_READ_FLOAT2_AS_UV=1"
-        "MAYAUSD_IMPORT_PRIMARY_UV_SET_AS_MAP1=0"
 )
 set_property(TEST testUsdImportUVSetsFloat APPEND PROPERTY LABELS translators)
-
-mayaUsd_add_test(testUsdImportUVSetsST
-    PYTHON_MODULE testUsdImportUVSets
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    ENV
-        "PIXMAYA_READ_FLOAT2_AS_UV=0"
-        "MAYAUSD_IMPORT_PRIMARY_UV_SET_AS_MAP1=1"
-)
-set_property(TEST testUsdImportUVSetsST APPEND PROPERTY LABELS translators)
 
 mayaUsd_add_test(testUsdImportChaser
     PYTHON_MODULE testUsdImportChaser

--- a/test/lib/usd/translators/UsdExportUVSetMappingsTest/UsdExportUVSetMappingsTest.ma
+++ b/test/lib/usd/translators/UsdExportUVSetMappingsTest/UsdExportUVSetMappingsTest.ma
@@ -1,6 +1,6 @@
 //Maya ASCII 2018 scene
 //Name: UsdExportUVSetMappingsTest.ma
-//Last modified: Wed, Nov 04, 2020 02:45:47 PM
+//Last modified: Tue, Jun 29, 2021 11:29:45 AM
 //Codeset: 1252
 requires maya "2018";
 currentUnit -l centimeter -a degree -t film;
@@ -79,10 +79,46 @@ createNode mesh -n "pPlaneShape1" -p "pPlane1";
 	setAttr ".vir" yes;
 	setAttr ".vif" yes;
 	setAttr ".uvst[0].uvsn" -type "string" "map1";
+	setAttr -s 16 ".uvst[0].uvsp[0:15]" -type "float2" 0 0 0.33333334 0
+		 0.66666669 0 1 0 0 0.33333334 0.33333334 0.33333334 0.66666669 0.33333334 1 0.33333334
+		 0 0.66666669 0.33333334 0.66666669 0.66666669 0.66666669 1 0.66666669 0 1 0.33333334
+		 1 0.66666669 1 1 1;
 	setAttr ".cuvs" -type "string" "map1";
 	setAttr ".dcc" -type "string" "Ambient+Diffuse";
 	setAttr ".covm[0]"  0 1 1;
 	setAttr ".cdvm[0]"  0 1 1;
+	setAttr -s 16 ".vt[0:15]"  -0.5 -1.110223e-16 0.5 -0.16666666 -1.110223e-16 0.5
+		 0.16666669 -1.110223e-16 0.5 0.5 -1.110223e-16 0.5 -0.5 -3.7007432e-17 0.16666666
+		 -0.16666666 -3.7007432e-17 0.16666666 0.16666669 -3.7007432e-17 0.16666666 0.5 -3.7007432e-17 0.16666666
+		 -0.5 3.7007439e-17 -0.16666669 -0.16666666 3.7007439e-17 -0.16666669 0.16666669 3.7007439e-17 -0.16666669
+		 0.5 3.7007439e-17 -0.16666669 -0.5 1.110223e-16 -0.5 -0.16666666 1.110223e-16 -0.5
+		 0.16666669 1.110223e-16 -0.5 0.5 1.110223e-16 -0.5;
+	setAttr -s 24 ".ed[0:23]"  0 1 0 0 4 0 1 2 0 1 5 1 2 3 0 2 6 1 3 7 0
+		 4 5 1 4 8 0 5 6 1 5 9 1 6 7 1 6 10 1 7 11 0 8 9 1 8 12 0 9 10 1 9 13 1 10 11 1 10 14 1
+		 11 15 0 12 13 0 13 14 0 14 15 0;
+	setAttr -s 9 -ch 36 ".fc[0:8]" -type "polyFaces" 
+		f 4 0 3 -8 -2
+		mu 0 4 0 1 5 4
+		f 4 2 5 -10 -4
+		mu 0 4 1 2 6 5
+		f 4 4 6 -12 -6
+		mu 0 4 2 3 7 6
+		f 4 7 10 -15 -9
+		mu 0 4 4 5 9 8
+		f 4 9 12 -17 -11
+		mu 0 4 5 6 10 9
+		f 4 11 13 -19 -13
+		mu 0 4 6 7 11 10
+		f 4 14 17 -22 -16
+		mu 0 4 8 9 13 12
+		f 4 16 19 -23 -18
+		mu 0 4 9 10 14 13
+		f 4 18 20 -24 -20
+		mu 0 4 10 11 15 14;
+	setAttr ".cd" -type "dataPolyComponent" Index_Data Edge 0 ;
+	setAttr ".cvd" -type "dataPolyComponent" Index_Data Vertex 0 ;
+	setAttr ".pd[0]" -type "dataPolyComponent" Index_Data UV 0 ;
+	setAttr ".hfd" -type "dataPolyComponent" Index_Data Face 0 ;
 createNode transform -n "pPlane2";
 	rename -uid "9B7EAF64-4E17-7D1B-FC93-128BAA356F57";
 	setAttr ".t" -type "double3" 1.2 0 0 ;
@@ -93,21 +129,10 @@ createNode mesh -n "pPlaneShape2" -p "pPlane2";
 	setAttr ".vir" yes;
 	setAttr ".vif" yes;
 	setAttr ".uvst[0].uvsn" -type "string" "st1";
-	setAttr ".cuvs" -type "string" "st1";
-	setAttr ".dcc" -type "string" "Ambient+Diffuse";
-	setAttr ".covm[0]"  0 1 1;
-	setAttr ".cdvm[0]"  0 1 1;
-createNode mesh -n "polySurfaceShape1" -p "pPlane2";
-	rename -uid "E9EEC13A-415B-D2A6-8AD6-B4AF27CCC3EC";
-	setAttr -k off ".v";
-	setAttr ".io" yes;
-	setAttr ".vir" yes;
-	setAttr ".vif" yes;
-	setAttr ".uvst[0].uvsn" -type "string" "st1";
-	setAttr -s 16 ".uvst[0].uvsp[0:15]" -type "float2" 0 0 0.33333334 0
-		 0.66666669 0 1 0 0 0.33333334 0.33333334 0.33333334 0.66666669 0.33333334 1 0.33333334
-		 0 0.66666669 0.33333334 0.66666669 0.66666669 0.66666669 1 0.66666669 0 1 0.33333334
-		 1 0.66666669 1 1 1;
+	setAttr -s 16 ".uvst[0].uvsp[0:15]" -type "float2" 0 0 -0.33333334 0
+		 -0.66666669 0 -1 0 0 0.33333334 -0.33333334 0.33333334 -0.66666669 0.33333334 -1
+		 0.33333334 0 0.66666669 -0.33333334 0.66666669 -0.66666669 0.66666669 -1 0.66666669
+		 0 1 -0.33333334 1 -0.66666669 1 -1 1;
 	setAttr ".cuvs" -type "string" "st1";
 	setAttr ".dcc" -type "string" "Ambient+Diffuse";
 	setAttr ".covm[0]"  0 1 1;
@@ -148,7 +173,7 @@ createNode transform -n "pPlane3";
 	rename -uid "A9516DAE-46FB-C555-7036-F5BFA863699B";
 	setAttr ".t" -type "double3" 2.4 0 0 ;
 	setAttr ".r" -type "double3" 89.999999999999986 0 0 ;
-createNode mesh -n "pPlaneShape3" -p "pPlane3";
+createNode mesh -n "pPlane3" -p "|pPlane3";
 	rename -uid "79274720-4D42-3A51-5BB1-BBB787218EAC";
 	setAttr -k off ".v";
 	setAttr ".vir" yes;
@@ -258,27 +283,23 @@ createNode mesh -n "pPlaneShape5" -p "pPlane5";
 	setAttr ".pv" -type "double2" 0.5 0.5 ;
 	setAttr -s 3 ".uvst";
 	setAttr ".uvst[0].uvsn" -type "string" "p5a";
-	setAttr ".uvst[1].uvsn" -type "string" "p5b";
-	setAttr ".uvst[2].uvsn" -type "string" "p5c";
-	setAttr ".cuvs" -type "string" "p5c";
-	setAttr ".dcc" -type "string" "Ambient+Diffuse";
-	setAttr ".covm[0]"  0 1 1;
-	setAttr ".cdvm[0]"  0 1 1;
-createNode mesh -n "polySurfaceShape2" -p "pPlane5";
-	rename -uid "79AAC206-4316-5D11-EE68-5DA13EBD8635";
-	setAttr -k off ".v";
-	setAttr ".io" yes;
-	setAttr ".vir" yes;
-	setAttr ".vif" yes;
-	setAttr -s 3 ".uvst";
-	setAttr ".uvst[0].uvsn" -type "string" "p5a";
 	setAttr -s 16 ".uvst[0].uvsp[0:15]" -type "float2" 0 0 0.33333334 0
 		 0.66666669 0 1 0 0 0.33333334 0.33333334 0.33333334 0.66666669 0.33333334 1 0.33333334
 		 0 0.66666669 0.33333334 0.66666669 0.66666669 0.66666669 1 0.66666669 0 1 0.33333334
 		 1 0.66666669 1 1 1;
 	setAttr ".uvst[1].uvsn" -type "string" "p5b";
+	setAttr -s 16 ".uvst[1].uvsp[0:15]" -type "float2" -0.20710677 0.5 0.028595507
+		 0.26429772 0.26429775 0.5 0.028595507 0.73570228 0.26429775 0.028595477 0.5 0.26429772
+		 0.5 -0.20710677 0.73570228 0.028595507 0.5 0.73570228 0.26429775 0.97140455 0.73570228
+		 0.5 0.97140455 0.26429775 0.73570228 0.97140449 0.5 1.20710683 0.97140455 0.73570228
+		 1.20710683 0.5;
 	setAttr ".uvst[2].uvsn" -type "string" "p5c";
-	setAttr ".cuvs" -type "string" "map1";
+	setAttr -s 16 ".uvst[2].uvsp[0:15]" -type "float2" 0.29253009 0.2962963
+		 0.43084335 0.2962963 0.43084335 0.43209878 0.29253009 0.43209878 0.56915665 0.2962963
+		 0.56915665 0.43209878 0.70746994 0.2962963 0.70746994 0.43209878 0.43084335 0.56790125
+		 0.29253009 0.56790125 0.56915665 0.56790125 0.70746994 0.56790125 0.43084335 0.7037037
+		 0.29253009 0.7037037 0.56915665 0.7037037 0.70746994 0.7037037;
+	setAttr ".cuvs" -type "string" "p5c";
 	setAttr ".dcc" -type "string" "Ambient+Diffuse";
 	setAttr ".covm[0]"  0 1 1;
 	setAttr ".cdvm[0]"  0 1 1;
@@ -294,22 +315,40 @@ createNode mesh -n "polySurfaceShape2" -p "pPlane5";
 	setAttr -s 9 -ch 36 ".fc[0:8]" -type "polyFaces" 
 		f 4 0 3 -8 -2
 		mu 0 4 0 1 5 4
+		mu 1 4 0 1 2 3
+		mu 2 4 0 1 2 3
 		f 4 2 5 -10 -4
 		mu 0 4 1 2 6 5
+		mu 1 4 1 4 5 2
+		mu 2 4 1 4 5 2
 		f 4 4 6 -12 -6
 		mu 0 4 2 3 7 6
+		mu 1 4 4 6 7 5
+		mu 2 4 4 6 7 5
 		f 4 7 10 -15 -9
 		mu 0 4 4 5 9 8
+		mu 1 4 3 2 8 9
+		mu 2 4 3 2 8 9
 		f 4 9 12 -17 -11
 		mu 0 4 5 6 10 9
+		mu 1 4 2 5 10 8
+		mu 2 4 2 5 10 8
 		f 4 11 13 -19 -13
 		mu 0 4 6 7 11 10
+		mu 1 4 5 7 11 10
+		mu 2 4 5 7 11 10
 		f 4 14 17 -22 -16
 		mu 0 4 8 9 13 12
+		mu 1 4 9 8 12 13
+		mu 2 4 9 8 12 13
 		f 4 16 19 -23 -18
 		mu 0 4 9 10 14 13
+		mu 1 4 8 10 14 12
+		mu 2 4 8 10 14 12
 		f 4 18 20 -24 -20
-		mu 0 4 10 11 15 14;
+		mu 0 4 10 11 15 14
+		mu 1 4 10 11 15 14
+		mu 2 4 10 11 15 14;
 	setAttr ".cd" -type "dataPolyComponent" Index_Data Edge 0 ;
 	setAttr ".cvd" -type "dataPolyComponent" Index_Data Vertex 0 ;
 	setAttr -s 3 ".pd";
@@ -321,7 +360,7 @@ createNode transform -n "pPlane6";
 	rename -uid "7593051F-42CF-0A8C-E8E0-2698310B206D";
 	setAttr ".t" -type "double3" 1.2 -1.2 0 ;
 	setAttr ".r" -type "double3" 90 0 0 ;
-createNode mesh -n "pPlaneShape6" -p "pPlane6";
+createNode mesh -n "pPlane6" -p "|pPlane6";
 	rename -uid "2BA445D8-44C5-9DE1-BC1C-1E9411BABD85";
 	setAttr -k off ".v";
 	setAttr ".vir" yes;
@@ -402,7 +441,7 @@ createNode mesh -n "pPlaneShape6" -p "pPlane6";
 	setAttr ".pd[1]" -type "dataPolyComponent" Index_Data UV 0 ;
 	setAttr ".pd[2]" -type "dataPolyComponent" Index_Data UV 0 ;
 	setAttr ".hfd" -type "dataPolyComponent" Index_Data Face 0 ;
-createNode mesh -n "polySurfaceShape2" -p "pPlane6";
+createNode mesh -n "polySurfaceShape2" -p "|pPlane6";
 	rename -uid "47A25D3B-4937-4470-348F-64B137408B58";
 	setAttr -k off ".v";
 	setAttr ".io" yes;
@@ -732,27 +771,22 @@ createNode mesh -n "polySurfaceShape2" -p "pPlane8";
 	setAttr ".pd[2]" -type "dataPolyComponent" Index_Data UV 0 ;
 	setAttr ".hfd" -type "dataPolyComponent" Index_Data Face 0 ;
 createNode lightLinker -s -n "lightLinker1";
-	rename -uid "32213774-4AB0-8BC1-510F-85969A23082E";
+	rename -uid "B123B922-4095-2150-8CC0-88BA9A0FEF19";
 	setAttr -s 4 ".lnk";
 	setAttr -s 4 ".slnk";
 createNode shapeEditorManager -n "shapeEditorManager";
-	rename -uid "0B528E22-4038-FB1B-D4EC-B9B9ABEF191E";
+	rename -uid "89BEB594-4221-1D76-646C-ADBAB017BB20";
 createNode poseInterpolatorManager -n "poseInterpolatorManager";
-	rename -uid "812D0AC0-4FE6-C4F2-FEEC-85842D7330DD";
+	rename -uid "80BCA0A3-476A-0EDD-4F89-C1A09850EC81";
 createNode displayLayerManager -n "layerManager";
-	rename -uid "9F7E0C52-4589-0AC0-59EC-0C8AC19D1DE4";
+	rename -uid "FB9D652C-462B-2065-B783-CDAEBCF13BB6";
 createNode displayLayer -n "defaultLayer";
 	rename -uid "3277C86B-46A9-1001-B375-18B68C9BA7F1";
 createNode renderLayerManager -n "renderLayerManager";
-	rename -uid "19F3E80F-4DCD-8198-AF3D-45989268B2EE";
+	rename -uid "CA7EEF07-4985-E96A-0D34-39864CD731DF";
 createNode renderLayer -n "defaultRenderLayer";
 	rename -uid "9BC1B5C5-4A85-3313-5ABF-49AB44D6E836";
 	setAttr ".g" yes;
-createNode polyPlane -n "polyPlane1";
-	rename -uid "B134C649-4AB6-6977-3DAD-3EBF52F8EFC3";
-	setAttr ".sw" 3;
-	setAttr ".sh" 3;
-	setAttr ".cuv" 2;
 createNode blinn -n "blinn1";
 	rename -uid "CFB37F82-443A-717A-6A5F-AC9E53A6DD8C";
 createNode shadingEngine -n "blinn1SG";
@@ -768,14 +802,6 @@ createNode file -n "file1";
 	setAttr ".cs" -type "string" "sRGB";
 createNode place2dTexture -n "place2dTexture1";
 	rename -uid "C37B299A-47C5-B34F-FECD-EE9773BAEE48";
-createNode polyFlipUV -n "polyFlipUV1";
-	rename -uid "B9283DF3-4E68-0B75-38E8-2FADE364F66C";
-	setAttr ".uopa" yes;
-	setAttr ".ics" -type "componentList" 1 "f[*]";
-	setAttr ".ix" -type "matrix" 1 0 0 0 0 2.2204460492503131e-16 1 0 0 -1 2.2204460492503131e-16 0
-		 1.2 0 0 1;
-	setAttr ".uvs" -type "string" "st1";
-	setAttr ".up" yes;
 createNode script -n "uiConfigurationScriptNode";
 	rename -uid "1ED9BE67-459D-44C0-9623-459682323026";
 	setAttr ".b" -type "string" (
@@ -792,7 +818,7 @@ createNode script -n "uiConfigurationScriptNode";
 		+ "            -sceneRenderFilter 0\n            $editorName;\n        modelEditor -e -viewSelected 0 $editorName;\n        modelEditor -e \n            -pluginObjects \"gpuCacheDisplayFilter\" 1 \n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"modelPanel\" (localizedPanelLabel(\"Persp View\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tmodelPanel -edit -l (localizedPanelLabel(\"Persp View\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        modelEditor -e \n            -camera \"persp\" \n            -useInteractiveMode 0\n            -displayLights \"default\" \n            -displayAppearance \"smoothShaded\" \n            -activeOnly 0\n            -ignorePanZoom 0\n            -wireframeOnShaded 0\n            -headsUpDisplay 1\n            -holdOuts 1\n            -selectionHiliteDisplay 1\n            -useDefaultMaterial 0\n            -bufferMode \"double\" \n            -twoSidedLighting 0\n            -backfaceCulling 0\n"
 		+ "            -xray 0\n            -jointXray 0\n            -activeComponentsXray 0\n            -displayTextures 1\n            -smoothWireframe 0\n            -lineWidth 1\n            -textureAnisotropic 0\n            -textureHilight 1\n            -textureSampling 2\n            -textureDisplay \"modulate\" \n            -textureMaxSize 16384\n            -fogging 0\n            -fogSource \"fragment\" \n            -fogMode \"linear\" \n            -fogStart 0\n            -fogEnd 100\n            -fogDensity 0.1\n            -fogColor 0.5 0.5 0.5 1 \n            -depthOfFieldPreview 1\n            -maxConstantTransparency 1\n            -rendererName \"vp2Renderer\" \n            -objectFilterShowInHUD 1\n            -isFiltered 0\n            -colorResolution 256 256 \n            -bumpResolution 512 512 \n            -textureCompression 0\n            -transparencyAlgorithm \"frontAndBackCull\" \n            -transpInShadows 0\n            -cullingOverride \"none\" \n            -lowQualityLighting 0\n            -maximumNumHardwareLights 1\n            -occlusionCulling 0\n"
 		+ "            -shadingModel 0\n            -useBaseRenderer 0\n            -useReducedRenderer 0\n            -smallObjectCulling 0\n            -smallObjectThreshold -1 \n            -interactiveDisableShadows 0\n            -interactiveBackFaceCull 0\n            -sortTransparent 1\n            -controllers 1\n            -nurbsCurves 1\n            -nurbsSurfaces 1\n            -polymeshes 1\n            -subdivSurfaces 1\n            -planes 1\n            -lights 1\n            -cameras 1\n            -controlVertices 1\n            -hulls 1\n            -grid 1\n            -imagePlane 1\n            -joints 1\n            -ikHandles 1\n            -deformers 1\n            -dynamics 1\n            -particleInstancers 1\n            -fluids 1\n            -hairSystems 1\n            -follicles 1\n            -nCloths 1\n            -nParticles 1\n            -nRigids 1\n            -dynamicConstraints 1\n            -locators 1\n            -manipulators 1\n            -pluginShapes 1\n            -dimensions 1\n            -handles 1\n            -pivots 1\n"
-		+ "            -textures 1\n            -strokes 1\n            -motionTrails 1\n            -clipGhosts 1\n            -greasePencils 1\n            -shadows 0\n            -captureSequenceNumber -1\n            -width 1072\n            -height 723\n            -sceneRenderFilter 0\n            $editorName;\n        modelEditor -e -viewSelected 0 $editorName;\n        modelEditor -e \n            -pluginObjects \"gpuCacheDisplayFilter\" 1 \n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"outlinerPanel\" (localizedPanelLabel(\"ToggledOutliner\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\toutlinerPanel -edit -l (localizedPanelLabel(\"ToggledOutliner\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        outlinerEditor -e \n            -showShapes 0\n            -showAssignedMaterials 0\n            -showTimeEditor 1\n            -showReferenceNodes 1\n            -showReferenceMembers 1\n            -showAttributes 0\n"
+		+ "            -textures 1\n            -strokes 1\n            -motionTrails 1\n            -clipGhosts 1\n            -greasePencils 1\n            -shadows 0\n            -captureSequenceNumber -1\n            -width 745\n            -height 723\n            -sceneRenderFilter 0\n            $editorName;\n        modelEditor -e -viewSelected 0 $editorName;\n        modelEditor -e \n            -pluginObjects \"gpuCacheDisplayFilter\" 1 \n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"outlinerPanel\" (localizedPanelLabel(\"ToggledOutliner\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\toutlinerPanel -edit -l (localizedPanelLabel(\"ToggledOutliner\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        outlinerEditor -e \n            -showShapes 0\n            -showAssignedMaterials 0\n            -showTimeEditor 1\n            -showReferenceNodes 1\n            -showReferenceMembers 1\n            -showAttributes 0\n"
 		+ "            -showConnected 0\n            -showAnimCurvesOnly 0\n            -showMuteInfo 0\n            -organizeByLayer 1\n            -organizeByClip 1\n            -showAnimLayerWeight 1\n            -autoExpandLayers 1\n            -autoExpand 0\n            -showDagOnly 1\n            -showAssets 1\n            -showContainedOnly 1\n            -showPublishedAsConnected 0\n            -showParentContainers 0\n            -showContainerContents 1\n            -ignoreDagHierarchy 0\n            -expandConnections 0\n            -showUpstreamCurves 1\n            -showUnitlessCurves 1\n            -showCompounds 1\n            -showLeafs 1\n            -showNumericAttrsOnly 0\n            -highlightActive 1\n            -autoSelectNewObjects 0\n            -doNotSelectNewObjects 0\n            -dropIsParent 1\n            -transmitFilters 0\n            -setFilter \"defaultSetFilter\" \n            -showSetMembers 1\n            -allowMultiSelection 1\n            -alwaysToggleSelect 0\n            -directSelect 0\n            -isSet 0\n            -isSetMember 0\n"
 		+ "            -displayMode \"DAG\" \n            -expandObjects 0\n            -setsIgnoreFilters 1\n            -containersIgnoreFilters 0\n            -editAttrName 0\n            -showAttrValues 0\n            -highlightSecondary 0\n            -showUVAttrsOnly 0\n            -showTextureNodesOnly 0\n            -attrAlphaOrder \"default\" \n            -animLayerFilterOptions \"allAffecting\" \n            -sortOrder \"none\" \n            -longNames 0\n            -niceNames 1\n            -showNamespace 1\n            -showPinIcons 0\n            -mapMotionTrails 0\n            -ignoreHiddenAttribute 0\n            -ignoreOutlinerColor 0\n            -renderFilterVisible 0\n            -renderFilterIndex 0\n            -selectionOrder \"chronological\" \n            -expandAttribute 0\n            $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextPanel \"outlinerPanel\" (localizedPanelLabel(\"Outliner\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n"
 		+ "\t\toutlinerPanel -edit -l (localizedPanelLabel(\"Outliner\")) -mbv $menusOkayInPanels  $panelName;\n\t\t$editorName = $panelName;\n        outlinerEditor -e \n            -showShapes 0\n            -showAssignedMaterials 0\n            -showTimeEditor 1\n            -showReferenceNodes 0\n            -showReferenceMembers 0\n            -showAttributes 0\n            -showConnected 0\n            -showAnimCurvesOnly 0\n            -showMuteInfo 0\n            -organizeByLayer 1\n            -organizeByClip 1\n            -showAnimLayerWeight 1\n            -autoExpandLayers 1\n            -autoExpand 0\n            -showDagOnly 1\n            -showAssets 1\n            -showContainedOnly 1\n            -showPublishedAsConnected 0\n            -showParentContainers 0\n            -showContainerContents 1\n            -ignoreDagHierarchy 0\n            -expandConnections 0\n            -showUpstreamCurves 1\n            -showUnitlessCurves 1\n            -showCompounds 1\n            -showLeafs 1\n            -showNumericAttrsOnly 0\n            -highlightActive 1\n"
@@ -814,44 +840,14 @@ createNode script -n "uiConfigurationScriptNode";
 		+ "\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Script Editor\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"profilerPanel\" (localizedPanelLabel(\"Profiler Tool\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Profiler Tool\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"contentBrowserPanel\" (localizedPanelLabel(\"Content Browser\")) `;\n\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Content Browser\")) -mbv $menusOkayInPanels  $panelName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\t$panelName = `sceneUIReplacement -getNextScriptedPanel \"nodeEditorPanel\" (localizedPanelLabel(\"Node Editor\")) `;\n"
 		+ "\tif (\"\" != $panelName) {\n\t\t$label = `panel -q -label $panelName`;\n\t\tscriptedPanel -edit -l (localizedPanelLabel(\"Node Editor\")) -mbv $menusOkayInPanels  $panelName;\n\n\t\t\t$editorName = ($panelName+\"NodeEditorEd\");\n            nodeEditor -e \n                -allAttributes 0\n                -allNodes 0\n                -autoSizeNodes 1\n                -consistentNameSize 1\n                -createNodeCommand \"nodeEdCreateNodeCommand\" \n                -connectNodeOnCreation 0\n                -connectOnDrop 0\n                -highlightConnections 0\n                -copyConnectionsOnPaste 0\n                -connectionStyle \"bezier\" \n                -defaultPinnedState 0\n                -additiveGraphingMode 0\n                -settingsChangedCallback \"nodeEdSyncControls\" \n                -traversalDepthLimit -1\n                -keyPressCommand \"nodeEdKeyPressCommand\" \n                -nodeTitleMode \"name\" \n                -gridSnap 0\n                -gridVisibility 1\n                -crosshairOnEdgeDragging 0\n                -popupMenuScript \"nodeEdBuildPanelMenus\" \n"
 		+ "                -showNamespace 1\n                -showShapes 1\n                -showSGShapes 0\n                -showTransforms 1\n                -useAssets 1\n                -syncedSelection 1\n                -extendToShapes 1\n                -activeTab -1\n                -editorMode \"default\" \n                $editorName;\n\t\tif (!$useSceneConfig) {\n\t\t\tpanel -e -l $label $panelName;\n\t\t}\n\t}\n\n\n\tif ($useSceneConfig) {\n        string $configName = `getPanel -cwl (localizedPanelLabel(\"Current Layout\"))`;\n        if (\"\" != $configName) {\n\t\t\tpanelConfiguration -edit -label (localizedPanelLabel(\"Current Layout\")) \n\t\t\t\t-userCreated false\n\t\t\t\t-defaultImage \"\"\n\t\t\t\t-image \"\"\n\t\t\t\t-sc false\n\t\t\t\t-configString \"global string $gMainPane; paneLayout -e -cn \\\"single\\\" -ps 1 100 100 $gMainPane;\"\n\t\t\t\t-removeAllPanels\n\t\t\t\t-ap false\n\t\t\t\t\t(localizedPanelLabel(\"Persp View\")) \n\t\t\t\t\t\"modelPanel\"\n"
-		+ "\t\t\t\t\t\"$panelName = `modelPanel -unParent -l (localizedPanelLabel(\\\"Persp View\\\")) -mbv $menusOkayInPanels `;\\n$editorName = $panelName;\\nmodelEditor -e \\n    -cam `findStartUpCamera persp` \\n    -useInteractiveMode 0\\n    -displayLights \\\"default\\\" \\n    -displayAppearance \\\"smoothShaded\\\" \\n    -activeOnly 0\\n    -ignorePanZoom 0\\n    -wireframeOnShaded 0\\n    -headsUpDisplay 1\\n    -holdOuts 1\\n    -selectionHiliteDisplay 1\\n    -useDefaultMaterial 0\\n    -bufferMode \\\"double\\\" \\n    -twoSidedLighting 0\\n    -backfaceCulling 0\\n    -xray 0\\n    -jointXray 0\\n    -activeComponentsXray 0\\n    -displayTextures 1\\n    -smoothWireframe 0\\n    -lineWidth 1\\n    -textureAnisotropic 0\\n    -textureHilight 1\\n    -textureSampling 2\\n    -textureDisplay \\\"modulate\\\" \\n    -textureMaxSize 16384\\n    -fogging 0\\n    -fogSource \\\"fragment\\\" \\n    -fogMode \\\"linear\\\" \\n    -fogStart 0\\n    -fogEnd 100\\n    -fogDensity 0.1\\n    -fogColor 0.5 0.5 0.5 1 \\n    -depthOfFieldPreview 1\\n    -maxConstantTransparency 1\\n    -rendererName \\\"vp2Renderer\\\" \\n    -objectFilterShowInHUD 1\\n    -isFiltered 0\\n    -colorResolution 256 256 \\n    -bumpResolution 512 512 \\n    -textureCompression 0\\n    -transparencyAlgorithm \\\"frontAndBackCull\\\" \\n    -transpInShadows 0\\n    -cullingOverride \\\"none\\\" \\n    -lowQualityLighting 0\\n    -maximumNumHardwareLights 1\\n    -occlusionCulling 0\\n    -shadingModel 0\\n    -useBaseRenderer 0\\n    -useReducedRenderer 0\\n    -smallObjectCulling 0\\n    -smallObjectThreshold -1 \\n    -interactiveDisableShadows 0\\n    -interactiveBackFaceCull 0\\n    -sortTransparent 1\\n    -controllers 1\\n    -nurbsCurves 1\\n    -nurbsSurfaces 1\\n    -polymeshes 1\\n    -subdivSurfaces 1\\n    -planes 1\\n    -lights 1\\n    -cameras 1\\n    -controlVertices 1\\n    -hulls 1\\n    -grid 1\\n    -imagePlane 1\\n    -joints 1\\n    -ikHandles 1\\n    -deformers 1\\n    -dynamics 1\\n    -particleInstancers 1\\n    -fluids 1\\n    -hairSystems 1\\n    -follicles 1\\n    -nCloths 1\\n    -nParticles 1\\n    -nRigids 1\\n    -dynamicConstraints 1\\n    -locators 1\\n    -manipulators 1\\n    -pluginShapes 1\\n    -dimensions 1\\n    -handles 1\\n    -pivots 1\\n    -textures 1\\n    -strokes 1\\n    -motionTrails 1\\n    -clipGhosts 1\\n    -greasePencils 1\\n    -shadows 0\\n    -captureSequenceNumber -1\\n    -width 1072\\n    -height 723\\n    -sceneRenderFilter 0\\n    $editorName;\\nmodelEditor -e -viewSelected 0 $editorName;\\nmodelEditor -e \\n    -pluginObjects \\\"gpuCacheDisplayFilter\\\" 1 \\n    $editorName\"\n"
-		+ "\t\t\t\t\t\"modelPanel -edit -l (localizedPanelLabel(\\\"Persp View\\\")) -mbv $menusOkayInPanels  $panelName;\\n$editorName = $panelName;\\nmodelEditor -e \\n    -cam `findStartUpCamera persp` \\n    -useInteractiveMode 0\\n    -displayLights \\\"default\\\" \\n    -displayAppearance \\\"smoothShaded\\\" \\n    -activeOnly 0\\n    -ignorePanZoom 0\\n    -wireframeOnShaded 0\\n    -headsUpDisplay 1\\n    -holdOuts 1\\n    -selectionHiliteDisplay 1\\n    -useDefaultMaterial 0\\n    -bufferMode \\\"double\\\" \\n    -twoSidedLighting 0\\n    -backfaceCulling 0\\n    -xray 0\\n    -jointXray 0\\n    -activeComponentsXray 0\\n    -displayTextures 1\\n    -smoothWireframe 0\\n    -lineWidth 1\\n    -textureAnisotropic 0\\n    -textureHilight 1\\n    -textureSampling 2\\n    -textureDisplay \\\"modulate\\\" \\n    -textureMaxSize 16384\\n    -fogging 0\\n    -fogSource \\\"fragment\\\" \\n    -fogMode \\\"linear\\\" \\n    -fogStart 0\\n    -fogEnd 100\\n    -fogDensity 0.1\\n    -fogColor 0.5 0.5 0.5 1 \\n    -depthOfFieldPreview 1\\n    -maxConstantTransparency 1\\n    -rendererName \\\"vp2Renderer\\\" \\n    -objectFilterShowInHUD 1\\n    -isFiltered 0\\n    -colorResolution 256 256 \\n    -bumpResolution 512 512 \\n    -textureCompression 0\\n    -transparencyAlgorithm \\\"frontAndBackCull\\\" \\n    -transpInShadows 0\\n    -cullingOverride \\\"none\\\" \\n    -lowQualityLighting 0\\n    -maximumNumHardwareLights 1\\n    -occlusionCulling 0\\n    -shadingModel 0\\n    -useBaseRenderer 0\\n    -useReducedRenderer 0\\n    -smallObjectCulling 0\\n    -smallObjectThreshold -1 \\n    -interactiveDisableShadows 0\\n    -interactiveBackFaceCull 0\\n    -sortTransparent 1\\n    -controllers 1\\n    -nurbsCurves 1\\n    -nurbsSurfaces 1\\n    -polymeshes 1\\n    -subdivSurfaces 1\\n    -planes 1\\n    -lights 1\\n    -cameras 1\\n    -controlVertices 1\\n    -hulls 1\\n    -grid 1\\n    -imagePlane 1\\n    -joints 1\\n    -ikHandles 1\\n    -deformers 1\\n    -dynamics 1\\n    -particleInstancers 1\\n    -fluids 1\\n    -hairSystems 1\\n    -follicles 1\\n    -nCloths 1\\n    -nParticles 1\\n    -nRigids 1\\n    -dynamicConstraints 1\\n    -locators 1\\n    -manipulators 1\\n    -pluginShapes 1\\n    -dimensions 1\\n    -handles 1\\n    -pivots 1\\n    -textures 1\\n    -strokes 1\\n    -motionTrails 1\\n    -clipGhosts 1\\n    -greasePencils 1\\n    -shadows 0\\n    -captureSequenceNumber -1\\n    -width 1072\\n    -height 723\\n    -sceneRenderFilter 0\\n    $editorName;\\nmodelEditor -e -viewSelected 0 $editorName;\\nmodelEditor -e \\n    -pluginObjects \\\"gpuCacheDisplayFilter\\\" 1 \\n    $editorName\"\n"
+		+ "\t\t\t\t\t\"$panelName = `modelPanel -unParent -l (localizedPanelLabel(\\\"Persp View\\\")) -mbv $menusOkayInPanels `;\\n$editorName = $panelName;\\nmodelEditor -e \\n    -cam `findStartUpCamera persp` \\n    -useInteractiveMode 0\\n    -displayLights \\\"default\\\" \\n    -displayAppearance \\\"smoothShaded\\\" \\n    -activeOnly 0\\n    -ignorePanZoom 0\\n    -wireframeOnShaded 0\\n    -headsUpDisplay 1\\n    -holdOuts 1\\n    -selectionHiliteDisplay 1\\n    -useDefaultMaterial 0\\n    -bufferMode \\\"double\\\" \\n    -twoSidedLighting 0\\n    -backfaceCulling 0\\n    -xray 0\\n    -jointXray 0\\n    -activeComponentsXray 0\\n    -displayTextures 1\\n    -smoothWireframe 0\\n    -lineWidth 1\\n    -textureAnisotropic 0\\n    -textureHilight 1\\n    -textureSampling 2\\n    -textureDisplay \\\"modulate\\\" \\n    -textureMaxSize 16384\\n    -fogging 0\\n    -fogSource \\\"fragment\\\" \\n    -fogMode \\\"linear\\\" \\n    -fogStart 0\\n    -fogEnd 100\\n    -fogDensity 0.1\\n    -fogColor 0.5 0.5 0.5 1 \\n    -depthOfFieldPreview 1\\n    -maxConstantTransparency 1\\n    -rendererName \\\"vp2Renderer\\\" \\n    -objectFilterShowInHUD 1\\n    -isFiltered 0\\n    -colorResolution 256 256 \\n    -bumpResolution 512 512 \\n    -textureCompression 0\\n    -transparencyAlgorithm \\\"frontAndBackCull\\\" \\n    -transpInShadows 0\\n    -cullingOverride \\\"none\\\" \\n    -lowQualityLighting 0\\n    -maximumNumHardwareLights 1\\n    -occlusionCulling 0\\n    -shadingModel 0\\n    -useBaseRenderer 0\\n    -useReducedRenderer 0\\n    -smallObjectCulling 0\\n    -smallObjectThreshold -1 \\n    -interactiveDisableShadows 0\\n    -interactiveBackFaceCull 0\\n    -sortTransparent 1\\n    -controllers 1\\n    -nurbsCurves 1\\n    -nurbsSurfaces 1\\n    -polymeshes 1\\n    -subdivSurfaces 1\\n    -planes 1\\n    -lights 1\\n    -cameras 1\\n    -controlVertices 1\\n    -hulls 1\\n    -grid 1\\n    -imagePlane 1\\n    -joints 1\\n    -ikHandles 1\\n    -deformers 1\\n    -dynamics 1\\n    -particleInstancers 1\\n    -fluids 1\\n    -hairSystems 1\\n    -follicles 1\\n    -nCloths 1\\n    -nParticles 1\\n    -nRigids 1\\n    -dynamicConstraints 1\\n    -locators 1\\n    -manipulators 1\\n    -pluginShapes 1\\n    -dimensions 1\\n    -handles 1\\n    -pivots 1\\n    -textures 1\\n    -strokes 1\\n    -motionTrails 1\\n    -clipGhosts 1\\n    -greasePencils 1\\n    -shadows 0\\n    -captureSequenceNumber -1\\n    -width 745\\n    -height 723\\n    -sceneRenderFilter 0\\n    $editorName;\\nmodelEditor -e -viewSelected 0 $editorName;\\nmodelEditor -e \\n    -pluginObjects \\\"gpuCacheDisplayFilter\\\" 1 \\n    $editorName\"\n"
+		+ "\t\t\t\t\t\"modelPanel -edit -l (localizedPanelLabel(\\\"Persp View\\\")) -mbv $menusOkayInPanels  $panelName;\\n$editorName = $panelName;\\nmodelEditor -e \\n    -cam `findStartUpCamera persp` \\n    -useInteractiveMode 0\\n    -displayLights \\\"default\\\" \\n    -displayAppearance \\\"smoothShaded\\\" \\n    -activeOnly 0\\n    -ignorePanZoom 0\\n    -wireframeOnShaded 0\\n    -headsUpDisplay 1\\n    -holdOuts 1\\n    -selectionHiliteDisplay 1\\n    -useDefaultMaterial 0\\n    -bufferMode \\\"double\\\" \\n    -twoSidedLighting 0\\n    -backfaceCulling 0\\n    -xray 0\\n    -jointXray 0\\n    -activeComponentsXray 0\\n    -displayTextures 1\\n    -smoothWireframe 0\\n    -lineWidth 1\\n    -textureAnisotropic 0\\n    -textureHilight 1\\n    -textureSampling 2\\n    -textureDisplay \\\"modulate\\\" \\n    -textureMaxSize 16384\\n    -fogging 0\\n    -fogSource \\\"fragment\\\" \\n    -fogMode \\\"linear\\\" \\n    -fogStart 0\\n    -fogEnd 100\\n    -fogDensity 0.1\\n    -fogColor 0.5 0.5 0.5 1 \\n    -depthOfFieldPreview 1\\n    -maxConstantTransparency 1\\n    -rendererName \\\"vp2Renderer\\\" \\n    -objectFilterShowInHUD 1\\n    -isFiltered 0\\n    -colorResolution 256 256 \\n    -bumpResolution 512 512 \\n    -textureCompression 0\\n    -transparencyAlgorithm \\\"frontAndBackCull\\\" \\n    -transpInShadows 0\\n    -cullingOverride \\\"none\\\" \\n    -lowQualityLighting 0\\n    -maximumNumHardwareLights 1\\n    -occlusionCulling 0\\n    -shadingModel 0\\n    -useBaseRenderer 0\\n    -useReducedRenderer 0\\n    -smallObjectCulling 0\\n    -smallObjectThreshold -1 \\n    -interactiveDisableShadows 0\\n    -interactiveBackFaceCull 0\\n    -sortTransparent 1\\n    -controllers 1\\n    -nurbsCurves 1\\n    -nurbsSurfaces 1\\n    -polymeshes 1\\n    -subdivSurfaces 1\\n    -planes 1\\n    -lights 1\\n    -cameras 1\\n    -controlVertices 1\\n    -hulls 1\\n    -grid 1\\n    -imagePlane 1\\n    -joints 1\\n    -ikHandles 1\\n    -deformers 1\\n    -dynamics 1\\n    -particleInstancers 1\\n    -fluids 1\\n    -hairSystems 1\\n    -follicles 1\\n    -nCloths 1\\n    -nParticles 1\\n    -nRigids 1\\n    -dynamicConstraints 1\\n    -locators 1\\n    -manipulators 1\\n    -pluginShapes 1\\n    -dimensions 1\\n    -handles 1\\n    -pivots 1\\n    -textures 1\\n    -strokes 1\\n    -motionTrails 1\\n    -clipGhosts 1\\n    -greasePencils 1\\n    -shadows 0\\n    -captureSequenceNumber -1\\n    -width 745\\n    -height 723\\n    -sceneRenderFilter 0\\n    $editorName;\\nmodelEditor -e -viewSelected 0 $editorName;\\nmodelEditor -e \\n    -pluginObjects \\\"gpuCacheDisplayFilter\\\" 1 \\n    $editorName\"\n"
 		+ "\t\t\t\t$configName;\n\n            setNamedPanelLayout (localizedPanelLabel(\"Current Layout\"));\n        }\n\n        panelHistory -e -clear mainPanelHistory;\n        sceneUIReplacement -clear;\n\t}\n\n\ngrid -spacing 5 -size 12 -divisions 5 -displayAxes yes -displayGridLines yes -displayDivisionLines yes -displayPerspectiveLabels no -displayOrthographicLabels no -displayAxesBold yes -perspectiveLabelPosition axis -orthographicLabelPosition edge;\nviewManip -drawCompass 0 -compassAngle 0 -frontParameters \"\" -homeParameters \"\" -selectionLockParameters \"\";\n}\n");
 	setAttr ".st" 3;
 createNode script -n "sceneConfigurationScriptNode";
 	rename -uid "2F52F36B-4D13-1CC9-1521-25A1F9E33EC2";
 	setAttr ".b" -type "string" "playbackOptions -min 1 -max 120 -ast 1 -aet 200 ";
 	setAttr ".st" 6;
-createNode polyCopyUV -n "polyCopyUV1";
-	rename -uid "98548B3B-4392-5435-383A-3B8AF040EEBD";
-	setAttr ".uopa" yes;
-	setAttr ".ics" -type "componentList" 1 "f[*]";
-	setAttr ".uvs" -type "string" "p5b";
-	setAttr ".uvi" -type "string" "p5a";
-createNode polyCopyUV -n "polyCopyUV2";
-	rename -uid "1DC5083E-478E-33F5-8702-B8B7DB736006";
-	setAttr ".uopa" yes;
-	setAttr ".ics" -type "componentList" 1 "f[*]";
-	setAttr ".uvs" -type "string" "p5c";
-	setAttr ".uvi" -type "string" "p5b";
-createNode polyTweakUV -n "polyTweakUV1";
-	rename -uid "B68ABBE4-4BA7-560F-EEDB-099DB0AFDE71";
-	setAttr ".uopa" yes;
-	setAttr -s 16 ".uvtk[0:15]" -type "float2" -0.20710677 0.5 -0.30473784
-		 0.26429772 -0.06903559 0.16666666 0.028595507 0.40236893 -0.40236893 0.028595477
-		 -0.16666669 -0.069035619 -0.5 -0.20710677 -0.26429772 -0.30473784 0.16666666 0.06903559
-		 0.26429775 0.30473787 0.06903559 -0.16666669 -0.028595448 -0.40236893 0.40236893
-		 -0.028595507 0.5 0.20710683 0.30473787 -0.26429772 0.20710683 -0.5;
-	setAttr ".uvs" -type "string" "p5b";
-createNode polyTweakUV -n "polyTweakUV2";
-	rename -uid "719DAB61-488F-55D2-42D6-109F23FBBAF2";
-	setAttr ".uopa" yes;
-	setAttr -s 16 ".uvtk[0:15]" -type "float2" 0.29253009 0.2962963 0.09751001
-		 0.2962963 0.09751001 0.098765433 0.29253009 0.098765433 -0.09751004 0.2962963 -0.09751004
-		 0.098765433 -0.29253006 0.2962963 -0.29253006 0.098765433 0.09751001 -0.098765433
-		 0.29253009 -0.098765433 -0.09751004 -0.098765433 -0.29253006 -0.098765433 0.09751001
-		 -0.2962963 0.29253009 -0.2962963 -0.09751004 -0.2962963 -0.29253006 -0.2962963;
-	setAttr ".uvs" -type "string" "p5c";
 createNode file -n "file2";
 	rename -uid "9E496CC6-4F27-CFA1-0DF8-44A1C28FA59F";
 	setAttr ".ftn" -type "string" "E:/Ws/UsdBuild/ecg-maya-usd/maya-usd/test/lib/usd/translators/UsdExportUVSetMappingsTest/blue.png";
@@ -882,6 +878,45 @@ createNode shadingEngine -n "blinn2SG";
 	setAttr ".ro" yes;
 createNode materialInfo -n "materialInfo2";
 	rename -uid "DEFA5068-4E7F-AE89-78D5-F6AD34A30050";
+createNode nodeGraphEditorInfo -n "MayaNodeEditorSavedTabsInfo";
+	rename -uid "BBB246E2-49C5-106E-1BFC-068B692C87A1";
+	setAttr ".tgi[0].tn" -type "string" "Untitled_1";
+	setAttr ".tgi[0].vl" -type "double2" -981.21637753766493 -472.73448582002567 ;
+	setAttr ".tgi[0].vh" -type "double2" 976.87831952957322 512.02714684900366 ;
+	setAttr -s 11 ".tgi[0].ni";
+	setAttr ".tgi[0].ni[0].x" 54.285713195800781;
+	setAttr ".tgi[0].ni[0].y" 130;
+	setAttr ".tgi[0].ni[0].nvs" 18304;
+	setAttr ".tgi[0].ni[1].x" -252.85714721679688;
+	setAttr ".tgi[0].ni[1].y" 237.14285278320313;
+	setAttr ".tgi[0].ni[1].nvs" 18304;
+	setAttr ".tgi[0].ni[2].x" -560;
+	setAttr ".tgi[0].ni[2].y" 234.28572082519531;
+	setAttr ".tgi[0].ni[2].nvs" 18304;
+	setAttr ".tgi[0].ni[3].x" 670.4761962890625;
+	setAttr ".tgi[0].ni[3].y" -143.80952453613281;
+	setAttr ".tgi[0].ni[3].nvs" 18304;
+	setAttr ".tgi[0].ni[4].x" -560;
+	setAttr ".tgi[0].ni[4].y" 132.85714721679688;
+	setAttr ".tgi[0].ni[4].nvs" 18304;
+	setAttr ".tgi[0].ni[5].x" 361.42855834960938;
+	setAttr ".tgi[0].ni[5].y" 160;
+	setAttr ".tgi[0].ni[5].nvs" 18304;
+	setAttr ".tgi[0].ni[6].x" -865.23809814453125;
+	setAttr ".tgi[0].ni[6].y" 134.76190185546875;
+	setAttr ".tgi[0].ni[6].nvs" 18304;
+	setAttr ".tgi[0].ni[7].x" 668.5714111328125;
+	setAttr ".tgi[0].ni[7].y" 114.28571319580078;
+	setAttr ".tgi[0].ni[7].nvs" 18304;
+	setAttr ".tgi[0].ni[8].x" 54.285713195800781;
+	setAttr ".tgi[0].ni[8].y" 231.42857360839844;
+	setAttr ".tgi[0].ni[8].nvs" 18304;
+	setAttr ".tgi[0].ni[9].x" 668.5714111328125;
+	setAttr ".tgi[0].ni[9].y" -15.714285850524902;
+	setAttr ".tgi[0].ni[9].nvs" 18304;
+	setAttr ".tgi[0].ni[10].x" -252.85714721679688;
+	setAttr ".tgi[0].ni[10].y" 131.42857360839844;
+	setAttr ".tgi[0].ni[10].nvs" 18304;
 select -ne :time1;
 	setAttr ".o" 1;
 	setAttr ".unw" 1;
@@ -912,11 +947,6 @@ select -ne :defaultResolution;
 select -ne :hardwareRenderGlobals;
 	setAttr ".ctrs" 256;
 	setAttr ".btrs" 512;
-connectAttr "polyPlane1.out" "pPlaneShape1.i";
-connectAttr "polyFlipUV1.out" "pPlaneShape2.i";
-connectAttr "polyTweakUV2.out" "pPlaneShape5.i";
-connectAttr "polyTweakUV1.uvtk[0]" "pPlaneShape5.uvst[1].uvtw";
-connectAttr "polyTweakUV2.uvtk[0]" "pPlaneShape5.uvst[2].uvtw";
 relationship "link" ":lightLinker1" ":initialShadingGroup.message" ":defaultLightSet.message";
 relationship "link" ":lightLinker1" ":initialParticleSE.message" ":defaultLightSet.message";
 relationship "link" ":lightLinker1" "blinn1SG.message" ":defaultLightSet.message";
@@ -932,11 +962,11 @@ connectAttr "file2.oc" "blinn1.ic";
 connectAttr "file3.oc" "blinn1.sc";
 connectAttr "blinn1.oc" "blinn1SG.ss";
 connectAttr "pPlaneShape2.iog" "blinn1SG.dsm" -na;
-connectAttr "pPlaneShape3.iog" "blinn1SG.dsm" -na;
+connectAttr "|pPlane3|pPlane3.iog" "blinn1SG.dsm" -na;
 connectAttr "pPlaneShape4.iog" "blinn1SG.dsm" -na;
 connectAttr "pPlaneShape1.iog" "blinn1SG.dsm" -na;
 connectAttr "pPlaneShape5.iog" "blinn1SG.dsm" -na;
-connectAttr "pPlaneShape6.iog" "blinn1SG.dsm" -na;
+connectAttr "|pPlane6|pPlane6.iog" "blinn1SG.dsm" -na;
 connectAttr "pPlaneShape7.iog" "blinn1SG.dsm" -na;
 connectAttr "blinn1SG.msg" "materialInfo1.sg";
 connectAttr "blinn1.msg" "materialInfo1.m";
@@ -968,12 +998,6 @@ connectAttr "uvChooser3.ov2" "place2dTexture1.vt2";
 connectAttr "uvChooser3.ov3" "place2dTexture1.vt3";
 connectAttr "uvChooser3.oc1" "place2dTexture1.vc1";
 connectAttr "uvChooser3.ouv" "place2dTexture1.uv";
-connectAttr "polySurfaceShape1.o" "polyFlipUV1.ip";
-connectAttr "pPlaneShape2.wm" "polyFlipUV1.mp";
-connectAttr "|pPlane5|polySurfaceShape2.o" "polyCopyUV1.ip";
-connectAttr "polyCopyUV1.out" "polyCopyUV2.ip";
-connectAttr "polyCopyUV2.out" "polyTweakUV1.ip";
-connectAttr "polyTweakUV1.out" "polyTweakUV2.ip";
 connectAttr ":defaultColorMgtGlobals.cme" "file2.cme";
 connectAttr ":defaultColorMgtGlobals.cfe" "file2.cmcf";
 connectAttr ":defaultColorMgtGlobals.cfp" "file2.cmcp";
@@ -1029,17 +1053,31 @@ connectAttr "uvChooser2.ov3" "place2dTexture3.vt3";
 connectAttr "uvChooser2.oc1" "place2dTexture3.vc1";
 connectAttr "uvChooser2.ouv" "place2dTexture3.uv";
 connectAttr "pPlaneShape5.uvst[1].uvsn" "uvChooser1.uvs[0]";
-connectAttr "pPlaneShape6.uvst[2].uvsn" "uvChooser1.uvs[2]";
+connectAttr "|pPlane6|pPlane6.uvst[2].uvsn" "uvChooser1.uvs[2]";
 connectAttr "pPlaneShape5.uvst[2].uvsn" "uvChooser2.uvs[0]";
 connectAttr "pPlaneShape7.uvst[1].uvsn" "uvChooser2.uvs[1]";
 connectAttr "pPlaneShape8.uvst[1].uvsn" "uvChooser2.uvs[2]";
-connectAttr "pPlaneShape6.uvst[1].uvsn" "uvChooser3.uvs[0]";
+connectAttr "|pPlane6|pPlane6.uvst[1].uvsn" "uvChooser3.uvs[0]";
 connectAttr "pPlaneShape7.uvst[2].uvsn" "uvChooser3.uvs[2]";
 connectAttr "pPlaneShape8.uvst[2].uvsn" "uvChooser3.uvs[3]";
 connectAttr "blinn2.oc" "blinn2SG.ss";
 connectAttr "pPlaneShape8.iog" "blinn2SG.dsm" -na;
 connectAttr "blinn2SG.msg" "materialInfo2.sg";
 connectAttr "blinn2.msg" "materialInfo2.m";
+connectAttr "file2.msg" "MayaNodeEditorSavedTabsInfo.tgi[0].ni[0].dn";
+connectAttr "place2dTexture1.msg" "MayaNodeEditorSavedTabsInfo.tgi[0].ni[1].dn";
+connectAttr "uvChooser3.msg" "MayaNodeEditorSavedTabsInfo.tgi[0].ni[2].dn";
+connectAttr "|pPlane6.msg" "MayaNodeEditorSavedTabsInfo.tgi[0].ni[3].dn";
+connectAttr "uvChooser1.msg" "MayaNodeEditorSavedTabsInfo.tgi[0].ni[4].dn";
+connectAttr "blinn1.msg" "MayaNodeEditorSavedTabsInfo.tgi[0].ni[5].dn";
+connectAttr "|pPlane6|pPlane6.msg" "MayaNodeEditorSavedTabsInfo.tgi[0].ni[6].dn"
+		;
+connectAttr "blinn1SG.msg" "MayaNodeEditorSavedTabsInfo.tgi[0].ni[7].dn";
+connectAttr "file1.msg" "MayaNodeEditorSavedTabsInfo.tgi[0].ni[8].dn";
+connectAttr "|pPlane6|polySurfaceShape2.msg" "MayaNodeEditorSavedTabsInfo.tgi[0].ni[9].dn"
+		;
+connectAttr "place2dTexture2.msg" "MayaNodeEditorSavedTabsInfo.tgi[0].ni[10].dn"
+		;
 connectAttr "blinn1SG.pa" ":renderPartition.st" -na;
 connectAttr "blinn2SG.pa" ":renderPartition.st" -na;
 connectAttr "blinn1.msg" ":defaultShaderList1.s" -na;

--- a/test/lib/usd/translators/testUsdExportMaterialX.py
+++ b/test/lib/usd/translators/testUsdExportMaterialX.py
@@ -33,11 +33,7 @@ class testUsdExportMaterialX(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        suffix = ""
-        if mayaUsdLib.WriteUtil.WriteMap1AsST():
-            suffix += "ST"
-
-        inputPath = fixturesUtils.setUpClass(__file__, suffix)
+        inputPath = fixturesUtils.setUpClass(__file__)
 
         mayaFile = os.path.join(inputPath, 'UsdExportMaterialXTest',
             'StandardSurfaceTextured.ma')
@@ -89,7 +85,7 @@ class testUsdExportMaterialX(unittest.TestCase):
         self.assertEqual(material_path, base_path)
 
         # Needs a resolved inputs:file1:varname attribute:
-        self.assertEqual(mat.GetInput("file1:varname").GetAttr().Get(), "map1")
+        self.assertEqual(mat.GetInput("file1:varname").GetAttr().Get(), "st")
 
         # Needs a MaterialX surface source:
         shader = mat.ComputeSurfaceSource("mtlx")[0]

--- a/test/lib/usd/translators/testUsdExportUVSetMappings.py
+++ b/test/lib/usd/translators/testUsdExportUVSetMappings.py
@@ -20,6 +20,7 @@ from pxr import UsdShade
 
 from maya import cmds
 from maya import standalone
+from maya.api import OpenMaya as OM
 
 import mayaUsd.lib as mayaUsdLib
 
@@ -33,23 +34,19 @@ class testUsdExportUVSetMappings(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        suffix = ""
-        if mayaUsdLib.WriteUtil.WriteMap1AsST():
-            suffix += "ST"
-
-        inputPath = fixturesUtils.setUpClass(__file__, suffix)
+        inputPath = fixturesUtils.setUpClass(__file__)
 
         mayaFile = os.path.join(inputPath, 'UsdExportUVSetMappingsTest',
             'UsdExportUVSetMappingsTest.ma')
         cmds.file(mayaFile, force=True, open=True)
 
         # Export to USD.
-        usdFilePath = os.path.abspath('UsdExportUVSetMappingsTest.usda')
-        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
+        cls._usdFilePath = os.path.abspath('UsdExportUVSetMappingsTest.usda')
+        cmds.mayaUSDExport(mergeTransformAndShape=True, file=cls._usdFilePath,
             shadingMode='useRegistry', convertMaterialsTo='UsdPreviewSurface',
             materialsScopeName='Materials')
 
-        cls._stage = Usd.Stage.Open(usdFilePath)
+        cls._stage = Usd.Stage.Open(cls._usdFilePath)
 
     @classmethod
     def tearDownClass(cls):
@@ -67,23 +64,14 @@ class testUsdExportUVSetMappings(unittest.TestCase):
         setups results in USD data with material specializations:
         '''
         expected = [
-            ("/pPlane1", "/blinn1SG_map1_map1_map1", "map1", "map1", "map1"),
-            ("/pPlane2", "/blinn1SG", "st1", "st1", "st1"),
-            ("/pPlane3", "/blinn1SG", "st1", "st1", "st1"),
-            ("/pPlane4", "/blinn1SG_st2_st2_st2", "st2", "st2", "st2"),
-            ("/pPlane5", "/blinn1SG_p5a_p5b_p5c", "p5a", "p5b", "p5c"),
-            ("/pPlane6", "/blinn1SG_p62_p63_p61", "p62", "p63", "p61"),
-            ("/pPlane7", "/blinn1SG_p7r_p7p_p7q", "p7r", "p7p", "p7q"),
+            ("/pPlane1", "/blinn1SG", "st", "st", "st"),
+            ("/pPlane2", "/blinn1SG", "st", "st", "st"),
+            ("/pPlane3", "/blinn1SG", "st", "st", "st"),
+            ("/pPlane4", "/blinn1SG", "st", "st", "st"),
+            ("/pPlane5", "/blinn1SG_st_st1_st2", "st", "st1", "st2"),
+            ("/pPlane6", "/blinn1SG_st1_st2_st", "st1", "st2", "st"),
+            ("/pPlane7", "/blinn1SG_st2_st_st1", "st2", "st", "st1"),
         ]
-
-        if mayaUsdLib.WriteUtil.WriteMap1AsST():
-            # map1 renaming has almost no impact here. Getting better results
-            # for that test would require something more radical, possibly
-            #    uvSet[0] is always renamed to "st"
-            # Which would reuse a single material for the first four planes.
-            #
-            # As currently implemented, the renaming affects only one material:
-            expected[0] = ("/pPlane1", "/blinn1SG_st_st_st", "st", "st", "st")
 
         for mesh_name, mat_name, f1_name, f2_name, f3_name in expected:
             plane_prim = self._stage.GetPrimAtPath(mesh_name)
@@ -102,6 +90,59 @@ class testUsdExportUVSetMappings(unittest.TestCase):
         mat = binding_api.ComputeBoundMaterial()[0]
         self.assertEqual(mat.GetPath(), "/pPlane8/Materials/blinn2SG")
         self.assertFalse(mat.GetPrim().HasAuthoredSpecializes())
+
+        # Gather some original information:
+        expected_uvs = []
+        for i in range(1, 9):
+            xform_name = "|pPlane%i" % i
+            selectionList = OM.MSelectionList()
+            selectionList.add(xform_name)
+            dagPath = selectionList.getDagPath(0)
+            dagPath = dagPath.extendToShape()
+            mayaMesh = OM.MFnMesh(dagPath.node())
+            expected_uvs.append(("pPlane%iShape" % i, mayaMesh.getUVSetNames()))
+
+        expected_sg = set(cmds.ls(type="shadingEngine"))
+
+        expected_links = []
+        for file_name in cmds.ls(type="file"):
+            links = []
+            for link in cmds.uvLink(texture=file_name):
+                # The name of the geometry does not survive roundtripping, but
+                # we know the pattern: pPlaneShapeX -> pPlaneXShape
+                plugPath = link.split(".")
+                selectionList = OM.MSelectionList()
+                selectionList.add(plugPath[0])
+                mayaMesh = OM.MFnMesh(selectionList.getDependNode(0))
+                meshName = mayaMesh.name()
+                plugPath[0] = "pPlane" + meshName[-1] + "Shape"
+                links.append(".".join(plugPath))
+            expected_links.append((file_name, set(links)))
+
+        # Test roundtripping:
+        cmds.file(newFile=True, force=True)
+
+        # Import back:
+        options = ["shadingMode=[[useRegistry,UsdPreviewSurface]]",
+                   "primPath=/"]
+        cmds.file(self._usdFilePath, i=True, type="USD Import",
+                  ignoreVersion=True, ra=True, mergeNamespacesOnClash=False,
+                  namespace="Test", pr=True, importTimeRange="combine",
+                  options=";".join(options))
+
+        # Names should have been restored:
+        for mesh_name, mesh_uvs in expected_uvs:
+            selectionList = OM.MSelectionList()
+            selectionList.add(mesh_name)
+            mayaMesh = OM.MFnMesh(selectionList.getDependNode(0))
+            self.assertEqual(mayaMesh.getUVSetNames(), mesh_uvs)
+
+        # Same list of shading engines:
+        self.assertEqual(set(cmds.ls(type="shadingEngine")), expected_sg)
+
+        # All links correctly restored:
+        for file_name, links in expected_links:
+            self.assertEqual(set(cmds.uvLink(texture=file_name)), links)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/usd/translators/testUsdExportUVSetMappings.py
+++ b/test/lib/usd/translators/testUsdExportUVSetMappings.py
@@ -112,7 +112,7 @@ class testUsdExportUVSetMappings(unittest.TestCase):
                 # we know the pattern: pPlaneShapeX -> pPlaneXShape
                 plugPath = link.split(".")
                 selectionList = OM.MSelectionList()
-                selectionList.add(plugPath[0])
+                selectionList.add(link)
                 mayaMesh = OM.MFnMesh(selectionList.getDependNode(0))
                 meshName = mayaMesh.name()
                 plugPath[0] = "pPlane" + meshName[-1] + "Shape"

--- a/test/lib/usd/translators/testUsdExportUVSets.py
+++ b/test/lib/usd/translators/testUsdExportUVSets.py
@@ -70,8 +70,6 @@ class testUsdExportUVSets(unittest.TestCase):
         suffix = ""
         if asFloat2:
             suffix += "Float"
-        if mayaUsdLib.WriteUtil.WriteMap1AsST():
-            suffix += "ST"
 
         inputPath = fixturesUtils.setUpClass(__file__, suffix)
 
@@ -166,10 +164,7 @@ class testUsdExportUVSets(unittest.TestCase):
         """
         usdCubeMesh = self._GetCubeUsdMesh('EmptyDefaultUVSetCube')
 
-        if mayaUsdLib.WriteUtil.WriteMap1AsST():
-            self.assertFalse(usdCubeMesh.GetPrimvar('map1'))
-        else:
-            self.assertFalse(usdCubeMesh.GetPrimvar('st'))
+        self.assertFalse(usdCubeMesh.GetPrimvar('map1'))
 
     def testExportDefaultUVSet(self):
         """
@@ -208,10 +203,7 @@ class testUsdExportUVSets(unittest.TestCase):
 
         expectedInterpolation = UsdGeom.Tokens.faceVarying
 
-        if mayaUsdLib.WriteUtil.WriteMap1AsST():
-            primvar = usdCubeMesh.GetPrimvar('st')
-        else:
-            primvar = usdCubeMesh.GetPrimvar('map1')
+        primvar = usdCubeMesh.GetPrimvar('st')
 
         self._AssertUVPrimvar(primvar,
             expectedValues=expectedValues,
@@ -254,10 +246,7 @@ class testUsdExportUVSets(unittest.TestCase):
 
         expectedInterpolation = UsdGeom.Tokens.faceVarying
 
-        if mayaUsdLib.WriteUtil.WriteMap1AsST():
-            primvar = usdCubeMesh.GetPrimvar('st')
-        else:
-            primvar = usdCubeMesh.GetPrimvar('map1')
+        primvar = usdCubeMesh.GetPrimvar('st')
 
         self._AssertUVPrimvar(primvar,
             expectedValues=expectedValues,
@@ -291,16 +280,22 @@ class testUsdExportUVSets(unittest.TestCase):
 
         expectedInterpolation = UsdGeom.Tokens.faceVarying
 
-        if mayaUsdLib.WriteUtil.WriteMap1AsST():
-            primvar = usdCubeMesh.GetPrimvar('st')
-        else:
-            primvar = usdCubeMesh.GetPrimvar('map1')
+        primvar = usdCubeMesh.GetPrimvar('st')
 
         self._AssertUVPrimvar(primvar,
             expectedValues=expectedValues,
             expectedInterpolation=expectedInterpolation,
             expectedIndices=expectedIndices,
             expectedUnauthoredValuesIndex=expectedUnauthoredValuesIndex)
+
+    @staticmethod
+    def _GetRenamedPrimvar(mesh, name):
+        """
+        Uses roundtripping utils to get a renamed primvar.
+        """
+        for primVar in mesh.GetPrimvars():
+            if mayaUsdLib.RoundTripUtil.GetPrimVarMayaName(primVar) == name:
+                return primVar
 
     def testExportSharedFacesUVSets(self):
         """
@@ -320,7 +315,7 @@ class testUsdExportUVSets(unittest.TestCase):
         expectedIndices = [0, 1, 2, 3] * 6
         expectedInterpolation = UsdGeom.Tokens.faceVarying
 
-        primvar = usdCubeMesh.GetPrimvar(uvSetName)
+        primvar = testUsdExportUVSets._GetRenamedPrimvar(usdCubeMesh, uvSetName)
         self._AssertUVPrimvar(primvar,
             expectedValues=expectedValues,
             expectedInterpolation=expectedInterpolation,
@@ -342,7 +337,7 @@ class testUsdExportUVSets(unittest.TestCase):
             2, 4, 5, 6] * 3
         expectedInterpolation = UsdGeom.Tokens.faceVarying
 
-        primvar = usdCubeMesh.GetPrimvar(uvSetName)
+        primvar = testUsdExportUVSets._GetRenamedPrimvar(usdCubeMesh, uvSetName)
         self._AssertUVPrimvar(primvar,
             expectedValues=expectedValues,
             expectedInterpolation=expectedInterpolation,
@@ -358,10 +353,7 @@ class testUsdExportUVSets(unittest.TestCase):
         """
         brokenBoxMesh = UsdGeom.Mesh(self._stage.GetPrimAtPath(
                 "/UsdExportUVSetsTest/Geom/BrokenUVs/box"))
-        if mayaUsdLib.WriteUtil.WriteMap1AsST():
-            stPrimvar = brokenBoxMesh.GetPrimvar("st").ComputeFlattened()
-        else:
-            stPrimvar = brokenBoxMesh.GetPrimvar("map1").ComputeFlattened()
+        stPrimvar = brokenBoxMesh.GetPrimvar("st").ComputeFlattened()
 
         self.assertEqual(stPrimvar[0], Gf.Vec2f(1.0, 2.0))
 

--- a/test/lib/usd/translators/testUsdExportUserTaggedAttributes.py
+++ b/test/lib/usd/translators/testUsdExportUserTaggedAttributes.py
@@ -240,8 +240,8 @@ class testUsdExportUserTaggedAttributes(unittest.TestCase):
         }
         expectedPrimvarNames = set(expectedPrimvars.keys())
         # Getting all primvars will also include the built-in displayColor,
-        # displayOpacity, and the Maya default "map1" UV set.
-        expectedPrimvarNames.update(['displayColor', 'displayOpacity', 'map1'])
+        # displayOpacity, and the USD default "st" UV set.
+        expectedPrimvarNames.update(['displayColor', 'displayOpacity', 'st'])
 
         gprim = UsdGeom.Gprim(prim)
         self.assertTrue(gprim)

--- a/test/lib/usd/translators/testUsdImportUVSets.py
+++ b/test/lib/usd/translators/testUsdImportUVSets.py
@@ -71,9 +71,6 @@ class testUsdImportUVSets(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.asFloat2 = mayaUsdLib.ReadUtil.ReadFloat2AsUV()
-        cls.defaultUVName = "st"
-        if mayaUsdLib.ReadUtil.ReadSTAsMap1():
-            cls.defaultUVName = "map1"
 
         cls.inputPath = fixturesUtils.readOnlySetUpClass(__file__)
 
@@ -139,7 +136,7 @@ class testUsdImportUVSets(unittest.TestCase):
             23: Gf.Vec2f(0.125, 0.25)
         }
 
-        self._AssertUVSet(mayaCubeMesh, self.defaultUVName, expectedValues,
+        self._AssertUVSet(mayaCubeMesh, "st", expectedValues,
             expectedNumValues=14, expectedNumUVShells=1)
 
     def testImportMap1UVSet(self):
@@ -210,7 +207,7 @@ class testUsdImportUVSets(unittest.TestCase):
             23: Gf.Vec2f(0.125, 0.25)
         }
 
-        self._AssertUVSet(mayaCubeMesh, self.defaultUVName, expectedValues,
+        self._AssertUVSet(mayaCubeMesh, "st", expectedValues,
             expectedNumValues=14, expectedNumUVShells=2)
 
     def testImportOneAssignedFaceUVSet(self):
@@ -227,7 +224,7 @@ class testUsdImportUVSets(unittest.TestCase):
             11: Gf.Vec2f(0.375, 0.75)
         }
 
-        self._AssertUVSet(mayaCubeMesh, self.defaultUVName, expectedValues,
+        self._AssertUVSet(mayaCubeMesh, "st", expectedValues,
             expectedNumValues=4, expectedNumUVShells=1)
 
     def testImportCompressedUVSets(self):
@@ -393,7 +390,7 @@ class testUsdImportUVSets(unittest.TestCase):
             23: Gf.Vec2f(0.125, 0.25)
         }
 
-        self._AssertUVSet(mayaCubeMesh, self.defaultUVName, expectedValues,
+        self._AssertUVSet(mayaCubeMesh, "st", expectedValues,
             expectedNumValues=14)
 
 


### PR DESCRIPTION
Implements automatic UV set renaming.
- The sets will be renamed st, st1, st2, st3,... in the order they are found in the mesh.
- The original name will be stored in custom data for roundtripping
- On import, the names will always be restored if the roundtripping information is found
- On import, the UV sets are restored in the same order as found in the USD primitive
- The environment variables MAYAUSD_IMPORT_PRIMARY_UV_SET_AS_MAP1 and  MAYAUSD_EXPORT_MAP1_AS_PRIMARY_UV_SET were removed as their functionnality is subsumed in the global renaming.

Caveat:
If you have a mesh with multiple UV sets, and a UV set named "map1" is not the first UV set, then it will not automatically be renamed "st" as was previously the case using MAYAUSD_EXPORT_MAP1_AS_PRIMARY_UV_SET. We expect these cases to be quite rare, but if you have post-processing scripts that are expecting "st" and scenes where "map1" is not the first UV sets; then the results at the other end of the post-processing pipeline will be different.