### PR TITLE
Pr/remove calls to configure resolver for asset under ar2

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -87,7 +87,7 @@
 #include <maya/MTime.h>
 #include <maya/MViewport2Renderer.h>
 
-#include <boost/filesystem.hpp>
+#include <ghc/filesystem.hpp>
 
 #include <map>
 #include <string>
@@ -623,7 +623,7 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                     "ProxyShapeBase::reloadStage original USD file path is %s\n",
                     fileString.c_str());
 
-            boost::filesystem::path filestringPath(fileString);
+            ghc::filesystem::path filestringPath(fileString);
             if (filestringPath.is_absolute()) {
                 fileString = UsdMayaUtilFileSystem::resolvePath(fileString);
                 TF_DEBUG(USDMAYA_PROXYSHAPEBASE)

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -87,7 +87,7 @@
 #include <maya/MTime.h>
 #include <maya/MViewport2Renderer.h>
 
-#include <ghc/filesystem.hpp>
+#include <boost/filesystem.hpp>
 
 #include <map>
 #include <string>
@@ -623,7 +623,7 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                     "ProxyShapeBase::reloadStage original USD file path is %s\n",
                     fileString.c_str());
 
-            ghc::filesystem::path filestringPath(fileString);
+            boost::filesystem::path filestringPath(fileString);
             if (filestringPath.is_absolute()) {
                 fileString = UsdMayaUtilFileSystem::resolvePath(fileString);
                 TF_DEBUG(USDMAYA_PROXYSHAPEBASE)
@@ -657,7 +657,9 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
             }
 
             {
+#if AR_VERSION == 1
                 PXR_NS::ArGetResolver().ConfigureResolverForAsset(fileString);
+#endif
 
                 // When opening or creating stages we must have an active UsdStageCache.
                 // The stage cache is the only one who holds a strong reference to the

--- a/lib/mayaUsd/utils/utilFileSystem.cpp
+++ b/lib/mayaUsd/utils/utilFileSystem.cpp
@@ -27,6 +27,28 @@
 
 #include <ghc/filesystem.hpp>
 
+#include <random>
+#include <system_error>
+namespace {
+std::string generateUniqueName()
+{
+    const auto  len { 6 };
+    std::string uniqueName;
+    uniqueName.reserve(len);
+
+    const std::string alphaNum { "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" };
+
+    std::random_device              rd;
+    std::mt19937                    gen(rd());
+    std::uniform_int_distribution<> dis(0, alphaNum.size() - 1);
+
+    for (auto i = 0; i < len; ++i) {
+        uniqueName += (alphaNum[dis(gen)]);
+    }
+    return uniqueName;
+}
+} // namespace
+
 PXR_NAMESPACE_USING_DIRECTIVE
 
 std::string UsdMayaUtilFileSystem::resolvePath(const std::string& filePath)
@@ -153,7 +175,7 @@ std::string UsdMayaUtilFileSystem::getUniqueFileName(
     const std::string& basename,
     const std::string& ext)
 {
-    std::string fileNameModel = basename + "-%%%%%%." + ext;
+    const std::string fileNameModel = basename + '-' + generateUniqueName() + '.' + ext;
 
     ghc::filesystem::path pathModel(dir);
     pathModel.append(fileNameModel);

--- a/lib/mayaUsd/utils/utilFileSystem.cpp
+++ b/lib/mayaUsd/utils/utilFileSystem.cpp
@@ -29,6 +29,7 @@
 
 #include <random>
 #include <system_error>
+
 namespace {
 std::string generateUniqueName()
 {

--- a/lib/mayaUsd/utils/utilFileSystem.cpp
+++ b/lib/mayaUsd/utils/utilFileSystem.cpp
@@ -25,7 +25,7 @@
 #include <maya/MGlobal.h>
 #include <maya/MItDependencyNodes.h>
 
-#include <boost/filesystem.hpp>
+#include <ghc/filesystem.hpp>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -40,7 +40,7 @@ std::string UsdMayaUtilFileSystem::resolvePath(const std::string& filePath)
 
 std::string UsdMayaUtilFileSystem::getDir(const std::string& fullFilePath)
 {
-    return boost::filesystem::path(fullFilePath).parent_path().string();
+    return ghc::filesystem::path(fullFilePath).parent_path().string();
 }
 
 std::string UsdMayaUtilFileSystem::getMayaReferencedFileDir(const MObject& proxyShapeNode)
@@ -136,8 +136,10 @@ std::string UsdMayaUtilFileSystem::resolveRelativePathWithinMayaContext(
         return relativeFilePath;
     }
 
-    boost::system::error_code errorCode;
-    auto path = boost::filesystem::canonical(relativeFilePath, currentFileDir, errorCode);
+    std::error_code errorCode;
+    auto            path = ghc::filesystem::canonical(
+        ghc::filesystem::path(currentFileDir).append(relativeFilePath), errorCode);
+
     if (errorCode) {
         // file does not exist
         return std::string();
@@ -153,19 +155,19 @@ std::string UsdMayaUtilFileSystem::getUniqueFileName(
 {
     std::string fileNameModel = basename + "-%%%%%%." + ext;
 
-    boost::filesystem::path pathModel(dir);
+    ghc::filesystem::path pathModel(dir);
     pathModel.append(fileNameModel);
 
-    return boost::filesystem::unique_path(pathModel).generic_string();
+    return pathModel.generic_string();
 }
 
 bool UsdMayaUtilFileSystem::pathAppendPath(std::string& a, const std::string& b)
 {
-    if (!boost::filesystem::is_directory(a)) {
+    if (!ghc::filesystem::is_directory(a)) {
         return false;
     }
-    boost::filesystem::path aPath(a);
-    boost::filesystem::path bPath(b);
+    ghc::filesystem::path aPath(a);
+    ghc::filesystem::path bPath(b);
     aPath /= b;
     a.assign(aPath.string());
     return true;
@@ -192,27 +194,27 @@ UsdMayaUtilFileSystem::writeToFilePath(const char* filePath, const void* buffer,
 
 void UsdMayaUtilFileSystem::pathStripPath(std::string& filePath)
 {
-    boost::filesystem::path p(filePath);
-    boost::filesystem::path filename = p.filename();
+    ghc::filesystem::path p(filePath);
+    ghc::filesystem::path filename = p.filename();
     filePath.assign(filename.string());
     return;
 }
 
 void UsdMayaUtilFileSystem::pathRemoveExtension(std::string& filePath)
 {
-    boost::filesystem::path p(filePath);
-    boost::filesystem::path dir = p.parent_path();
-    boost::filesystem::path finalPath = dir / p.stem();
+    ghc::filesystem::path p(filePath);
+    ghc::filesystem::path dir = p.parent_path();
+    ghc::filesystem::path finalPath = dir / p.stem();
     filePath.assign(finalPath.string());
     return;
 }
 
 std::string UsdMayaUtilFileSystem::pathFindExtension(std::string& filePath)
 {
-    boost::filesystem::path p(filePath);
+    ghc::filesystem::path p(filePath);
     if (!p.has_extension()) {
         return std::string();
     }
-    boost::filesystem::path ext = p.extension();
+    ghc::filesystem::path ext = p.extension();
     return ext.string();
 }

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -63,7 +63,7 @@
 #include <maya/MTime.h>
 #include <maya/MViewport2Renderer.h>
 
-#include <boost/filesystem.hpp>
+#include <ghc/filesystem.hpp>
 
 #if defined(WANT_UFE_BUILD)
 #include "ufe/path.h"
@@ -1246,7 +1246,7 @@ void ProxyShape::loadStage()
                 }
             }
         } else {
-            boost::filesystem::path filestringPath(fileString);
+            ghc::filesystem::path filestringPath(fileString);
             if (filestringPath.is_absolute()) {
                 fileString = UsdMayaUtilFileSystem::resolvePath(fileString);
                 TF_DEBUG(ALUSDMAYA_TRANSLATORS)

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -63,7 +63,7 @@
 #include <maya/MTime.h>
 #include <maya/MViewport2Renderer.h>
 
-#include <ghc/filesystem.hpp>
+#include <boost/filesystem.hpp>
 
 #if defined(WANT_UFE_BUILD)
 #include "ufe/path.h"
@@ -1246,7 +1246,7 @@ void ProxyShape::loadStage()
                 }
             }
         } else {
-            ghc::filesystem::path filestringPath(fileString);
+            boost::filesystem::path filestringPath(fileString);
             if (filestringPath.is_absolute()) {
                 fileString = UsdMayaUtilFileSystem::resolvePath(fileString);
                 TF_DEBUG(ALUSDMAYA_TRANSLATORS)
@@ -1320,6 +1320,7 @@ void ProxyShape::loadStage()
 
             const MString assetResolverConfig = inputStringValue(dataBlock, m_assetResolverConfig);
 
+#if AR_VERSION == 1
             if (assetResolverConfig.length() == 0) {
                 // Initialise the asset resolver with the filepath
                 PXR_NS::ArGetResolver().ConfigureResolverForAsset(fileString);
@@ -1327,6 +1328,8 @@ void ProxyShape::loadStage()
                 // Initialise the asset resolver with the resolverConfig string
                 PXR_NS::ArGetResolver().ConfigureResolverForAsset(assetResolverConfig.asChar());
             }
+#endif
+
             AL_END_PROFILE_SECTION();
 
             AL_BEGIN_PROFILE_SECTION(UpdateGlobalVariantFallbacks);


### PR DESCRIPTION
This method has been deprecated and is being removed for Ar 2.0.
Among other reasons, the resolver is a global resource and a
method for configuring it for a single asset is misleading
since the resolver may be used by many different assets at
the same time. If a resolver has asset-specific resolution
behaviors, they should be encoded in the resolver context
created via ArResolver::CreateDefaultContextForAsset.

The AL_USDMaya plugin had previously subverted this function
to configure its resolver by passing in an arbitrary string
to ConfigureResolverForAsset. This has been removed as
part of this change, but this could be replaced in the
future with ArResolver::CreateContextFromString, which
allow a resolver to create a resolver context from an
arbitrary string and was introduced in Ar 2.0.