### PR TITLE
Restore preview purpose material binding

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
@@ -827,7 +827,7 @@ void HdVP2RenderDelegate::DestroyBprim(HdBprim* bPrim) { delete bPrim; }
     The full material purpose is suggested according to
       https://github.com/PixarAnimationStudios/USD/pull/853
 */
-TfToken HdVP2RenderDelegate::GetMaterialBindingPurpose() const { return HdTokens->full; }
+TfToken HdVP2RenderDelegate::GetMaterialBindingPurpose() const { return HdTokens->preview; }
 
 #ifdef WANT_MATERIALX_BUILD
 TfTokenVector HdVP2RenderDelegate::GetShaderSourceTypes() const


### PR DESCRIPTION
Now that support for USD 19.11 has been dropped, and hydra's GL material adapter is gone, this should be safe to restore.
This will allow the display of materials bound using the `preview` purpose.