### PR TITLE
MAYA-111902 Review all standard surface default values

### DIFF
--- a/lib/usd/translators/shading/mtlxStandardSurfaceWriter.cpp
+++ b/lib/usd/translators/shading/mtlxStandardSurfaceWriter.cpp
@@ -158,11 +158,11 @@ MaterialXTranslators_StandardSurfaceWriter::MaterialXTranslators_StandardSurface
 
         const TfToken usdAttrName = renaming->second;
 
-        // Keep our authoring sparse by ignoring attributes with no values set
-        // and no connections. We know that the default value of base and base
-        // color diverged between Maya and MaterialX in version 1.38.
+        // Keep our authoring sparse by ignoring attributes with no values set and no connections.
+        // Some attributes with an history of default value updates will be written always.
         if (!(UsdMayaUtil::IsAuthored(attrPlug) || usdAttrName == TrMtlxTokens->base
-              || usdAttrName == TrMtlxTokens->base_color)
+              || usdAttrName == TrMtlxTokens->base_color || usdAttrName == TrMtlxTokens->specular
+              || usdAttrName == TrMtlxTokens->specularRoughness)
             && !attrPlug.isConnected()) {
             continue;
         }

--- a/lib/usd/translators/shading/mtlxStandardSurfaceWriter.cpp
+++ b/lib/usd/translators/shading/mtlxStandardSurfaceWriter.cpp
@@ -162,7 +162,7 @@ MaterialXTranslators_StandardSurfaceWriter::MaterialXTranslators_StandardSurface
         // Some attributes with an history of default value updates will be written always.
         if (!(UsdMayaUtil::IsAuthored(attrPlug) || usdAttrName == TrMtlxTokens->base
               || usdAttrName == TrMtlxTokens->base_color || usdAttrName == TrMtlxTokens->specular
-              || usdAttrName == TrMtlxTokens->specularRoughness)
+              || usdAttrName == TrMtlxTokens->specular_roughness)
             && !attrPlug.isConnected()) {
             continue;
         }


### PR DESCRIPTION
And always export to MaterialX any attribute with a default value that changed since standard surface was first introduced.