### PR TITLE
MAYA-111787 Pixar fixed the render tag issue in v0.20.08 so only enable the env

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -471,7 +471,9 @@ void ProxyRenderDelegate::_ClearRenderDelegate()
     // reset any version ids or dirty information that doesn't make sense if we clear
     // the render index.
     _renderTagVersion = 0;
+#ifdef ENABLE_RENDERTAG_VISIBILITY_WORKAROUND
     _visibilityVersion = 0;
+#endif
     _taskRenderTagsValid = false;
     _isPopulated = false;
 }

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -51,6 +51,7 @@
 #define MAYA_ENABLE_UPDATE_FOR_SELECTION
 #endif
 
+#if PXR_VERSION < 2008
 #define ENABLE_RENDERTAG_VISIBILITY_WORKAROUND
 /*  In USD v20.05 and earlier when the purpose of an rprim changes the visibility gets dirtied,
     and that doesn't update the render tag version.
@@ -61,6 +62,7 @@
     Logged as:
     https://github.com/PixarAnimationStudios/USD/issues/1243
 */
+#endif
 
 PXR_NAMESPACE_OPEN_SCOPE
 


### PR DESCRIPTION
var for USD versions older then that.