### PR TITLE
Don't normalize point instancer quaternions

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/instancer.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/instancer.cpp
@@ -181,8 +181,7 @@ VtMatrix4dArray HdVP2Instancer::ComputeInstanceTransforms(SdfPath const& prototy
             GfVec4f quat;
             if (sampler.Sample(instanceIndices[i], &quat)) {
                 GfMatrix4d rotateMat(1);
-                rotateMat.SetRotate(
-                    GfRotation(GfQuaternion(quat[0], GfVec3d(quat[1], quat[2], quat[3]))));
+                rotateMat.SetRotate(GfQuatd(quat[0], quat[1], quat[2], quat[3]));
                 transforms[i] = rotateMat * transforms[i];
             }
         }


### PR DESCRIPTION
Various clients of UsdGeomPointInstancer were handling per-instance
rotation quaternions differently: some renderers would normalize while
others wouldn't, and extents were generally calculated from normalized
quaternions. In an effort to make this consistent, we now never
normalize these quaternions, relying on the incoming data being normal
instead.

Note: The mechanism of normalization was a bit sneaky: the GfRotation
constructor automatically normalizes quaternions, so by converting from
vec4 to rotation to quat we would normalize; in other situations where
we went straight to GfQuat, we wouldn't normalize.