### PR TITLE
MAYA-112732: unit test for item selection after ungroup command is performed.

### DIFF
--- a/test/lib/ufe/testUngroupCmd.py
+++ b/test/lib/ufe/testUngroupCmd.py
@@ -358,6 +358,7 @@ class UngroupCmdTestCase(unittest.TestCase):
             # ungroup
             cmds.ungroup(ufe.PathString.string(sphere1Path))
 
+    @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 4, 'testUngroupSelectionAfterUndoRedo only available in UFE v3.4 or greater.')
     def testUngroupSelectionAfterUndoRedo(self):
         ''' '''
         # create a sphere generator

--- a/test/lib/ufe/testUngroupCmd.py
+++ b/test/lib/ufe/testUngroupCmd.py
@@ -358,7 +358,7 @@ class UngroupCmdTestCase(unittest.TestCase):
             # ungroup
             cmds.ungroup(ufe.PathString.string(sphere1Path))
 
-    def testUngroupAfterUndoRedo(self):
+    def testUngroupSelectionAfterUndoRedo(self):
         ''' '''
         # create a sphere generator
         sphereGen = SphereGenerator(2, self.contextOp, self.proxyShapePathStr)
@@ -383,25 +383,22 @@ class UngroupCmdTestCase(unittest.TestCase):
         # is /Sphere1, /Sphere2.
         cmds.ungroup("{},/group1".format(self.proxyShapePathStr))
 
+        # verify that Sphere1 and Sphere2 are selected
+        self.assertEqual(len(self.globalSn), 2)
+        self.assertEqual(self.globalSn.front().nodeName(), "Sphere1")
+        self.assertEqual(self.globalSn.back().nodeName(), "Sphere2")
+
         # undo again
         cmds.undo()
 
         # redo again
         cmds.redo()
 
-        # verify that group1 is in global selection list
-        self.assertEqual(len(self.globalSn), 1)
-        groupItem = self.globalSn.front()
-        self.assertEqual(groupItem.nodeName(), "group1")
+        # verify that Sphere1 and Sphere2 are selected
+        self.assertEqual(len(self.globalSn), 2)
+        self.assertEqual(self.globalSn.front().nodeName(), "Sphere1")
+        self.assertEqual(self.globalSn.back().nodeName(), "Sphere2")
 
-        # Hmmm, looks like we have a bug here. HS, June 21, 2021
-        # verify that group hierarchy has 2 children
-        # groupHierarchy = ufe.Hierarchy.hierarchy(groupItem)
-        # self.assertEqual(len(groupHierarchy.children()), 2)
-
-        # remove group1 from the hierarchy. What should remain
-        # is /Sphere1, /Sphere2.
-        # cmds.ungroup("|stage1|stageShape1,/group1")
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/ufe/testUngroupCmd.py
+++ b/test/lib/ufe/testUngroupCmd.py
@@ -358,7 +358,7 @@ class UngroupCmdTestCase(unittest.TestCase):
             # ungroup
             cmds.ungroup(ufe.PathString.string(sphere1Path))
 
-    @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 4, 'testUngroupSelectionAfterUndoRedo only available in UFE v3.4 or greater.')
+    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '3004', 'testUngroupSelectionAfterUndoRedo is only available in UFE preview version 0.3.4 and greater')
     def testUngroupSelectionAfterUndoRedo(self):
         ''' '''
         # create a sphere generator


### PR DESCRIPTION
### Description: 

MAYA PR19281 add support for item(s) selection after ungroup.

![ungroup_selection](https://user-images.githubusercontent.com/48299423/125298113-deeef800-e2f5-11eb-9064-ec9b338dd4ce.gif)
