### PR TITLE
Check that stage ptr is valid before getting prim path

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1396,11 +1396,11 @@ void ProxyShape::loadStage()
         }
     }
 
-    // Get the prim
+    // Get the prim, if the stage is valid.
     // If no primPath string specified, then use the pseudo-root.
     const SdfPath rootPath(std::string("/"));
     MString       primPathStr = inputStringValue(dataBlock, primPath());
-    if (primPathStr.length()) {
+    if (m_stage && primPathStr.length()) {
         m_path = SdfPath(AL::maya::utils::convert(primPathStr));
         UsdPrim prim = m_stage->GetPrimAtPath(m_path);
         if (!prim) {


### PR DESCRIPTION
When you create or modify an `AL_usdmaya_ProxyShape` node such that both:
 - The `.filePath` attribute refers to a file that does not exist.
 - The `.primPath` attribute has any value.

Maya will instantly hard crash. This request adds a guard against the null pointer when attempting to get the prim at the specified path.

Resolves [1571](https://github.com/Autodesk/maya-usd/issues/1571)