### PR TITLE
MAYA-112797 - Disable save for unshared layer root

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -263,7 +263,7 @@ bool LayerTreeItem::needsSaving() const
 {
     if (_layer) {
         if (!isSessionLayer() && !isReadOnly()
-            && !(!_incomingLayers.empty() && parentLayerItem() == nullptr)) {
+            && (_isSharedStage || parentLayerItem() != nullptr)) {
             return isDirty() || isAnonymous();
         }
     }


### PR DESCRIPTION
We had an issue where the root unshared layer could be saved, disabled it, had some code to do that but it wasn't working properly, cleaned it up. 