### PR TITLE
Matrix op, common API undo / redo.

### DIFF
--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -46,6 +46,7 @@ if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
             UsdContextOpsHandler.cpp
             UsdObject3d.cpp
             UsdObject3dHandler.cpp
+            UsdSetXformOpUndoableCommandBase.cpp
             UsdTransform3dBase.cpp
             UsdTransform3dCommonAPI.cpp
             UsdTransform3dFallbackMayaXformStack.cpp
@@ -118,6 +119,7 @@ if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
         UsdObject3d.h
         UsdObject3dHandler.h
         UsdPointInstanceUndoableCommands.h
+        UsdSetXformOpUndoableCommandBase.h
         UsdTransform3dBase.h
         UsdTransform3dCommonAPI.h
         UsdTransform3dFallbackMayaXformStack.h

--- a/lib/mayaUsd/ufe/StagesSubject.cpp
+++ b/lib/mayaUsd/ufe/StagesSubject.cpp
@@ -62,6 +62,11 @@ namespace {
 // Prevent re-entrant stage set.
 std::atomic_bool stageSetGuardCount { false };
 
+bool isTransformChange(const TfToken& nameToken)
+{
+    return nameToken == UsdGeomTokens->xformOpOrder || UsdGeomXformOp::IsXformOp(nameToken);
+}
+
 #ifdef UFE_V2_FEATURES_AVAILABLE
 // The attribute change notification guard is not meant to be nested, but
 // use a counter nonetheless to provide consistent behavior in such cases.
@@ -77,11 +82,6 @@ std::vector<std::pair<Ufe::Path, TfToken>> pendingAttributeChangedNotifications;
 bool inAttributeChangedNotificationGuard()
 {
     return attributeChangedNotificationGuardCount.load() > 0;
-}
-
-bool isTransformChange(const TfToken& nameToken)
-{
-    return nameToken == UsdGeomTokens->xformOpOrder || UsdGeomXformOp::IsXformOp(nameToken);
 }
 
 void sendValueChanged(const Ufe::Path& ufePath, const TfToken& changedToken)

--- a/lib/mayaUsd/ufe/UsdSetXformOpUndoableCommandBase.cpp
+++ b/lib/mayaUsd/ufe/UsdSetXformOpUndoableCommandBase.cpp
@@ -1,0 +1,87 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "UsdSetXformOpUndoableCommandBase.h"
+
+#include <mayaUsd/ufe/Utils.h>
+#include <mayaUsd/undo/UsdUndoBlock.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace {
+void warnUnimplemented(const char* msg) { TF_WARN("Illegal call to unimplemented %s", msg); }
+} // namespace
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+template <typename T>
+UsdSetXformOpUndoableCommandBase<T>::UsdSetXformOpUndoableCommandBase(
+    const Ufe::Path&   path,
+    const UsdTimeCode& writeTime)
+    : Ufe::SetVector3dUndoableCommand(path)
+    , _readTime(getTime(path)) // Always read from proxy shape time.
+    , _writeTime(writeTime)
+{
+}
+
+template <typename T> void UsdSetXformOpUndoableCommandBase<T>::execute()
+{
+    warnUnimplemented("UsdSetXformOpUndoableCommandBase::execute()");
+}
+
+template <typename T> void UsdSetXformOpUndoableCommandBase<T>::undo()
+{
+    if (_state == kInitial) {
+        // Spurious call from Maya, ignore.
+        _state = kInitialUndoCalled;
+        return;
+    }
+    _undoableItem.undo();
+    _state = kUndone;
+}
+
+template <typename T> void UsdSetXformOpUndoableCommandBase<T>::redo()
+{
+    warnUnimplemented("UsdSetXformOpUndoableCommandBase::redo()");
+}
+
+template <typename T> void UsdSetXformOpUndoableCommandBase<T>::handleSet(const T& v)
+{
+    if (_state == kInitialUndoCalled) {
+        // Spurious call from Maya, ignore.  Otherwise, we set a value that
+        // is identical to the previous, the UsdUndoBlock does not capture
+        // any invertFunc's, and subsequent undo() calls undo nothing.
+        _state = kInitial;
+    } else if (_state == kInitial) {
+        UsdUndoBlock undoBlock(&_undoableItem);
+        setValue(v);
+        _state = kExecute;
+    } else if (_state == kExecute) {
+        setValue(v);
+    } else if (_state == kUndone) {
+        _undoableItem.redo();
+        _state = kRedone;
+    }
+}
+
+// Explicit instantiation for transform ops that can be set from matrices and
+// vectors.
+template class UsdSetXformOpUndoableCommandBase<GfVec3f>;
+template class UsdSetXformOpUndoableCommandBase<GfVec3d>;
+template class UsdSetXformOpUndoableCommandBase<GfMatrix4d>;
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdSetXformOpUndoableCommandBase.h
+++ b/lib/mayaUsd/ufe/UsdSetXformOpUndoableCommandBase.h
@@ -1,0 +1,77 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <mayaUsd/undo/UsdUndoableItem.h>
+
+#include <pxr/usd/usd/timeCode.h>
+
+#include <ufe/transform3dUndoableCommands.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+//! \brief Base class for TRS commands.
+//
+// Helper class to factor out common code for translate, rotate, scale
+// undoable commands.  It is templated on the type of the transform op.
+//
+// Developing commands to work with Maya TRS commands is made more difficult
+// because Maya calls undo(), but never calls redo(): it simply calls set()
+// with the new value again.  We must distinguish cases where set() must
+// capture state, so that undo() can completely remove any added primSpecs or
+// attrSpecs.  This class implements state tracking to allow this: state is
+// saved on transition between kInitial and kExecute.
+// UsdTransform3dMayaXformStack has a state machine based implementation that
+// avoids conditionals, but UsdSetXformOpUndoableCommandBase is less invasive
+// from a development standpoint.
+
+template <typename T>
+class UsdSetXformOpUndoableCommandBase : public Ufe::SetVector3dUndoableCommand
+{
+    const PXR_NS::UsdTimeCode _readTime;
+    const PXR_NS::UsdTimeCode _writeTime;
+    MayaUsd::UsdUndoableItem  _undoableItem;
+    enum State
+    {
+        kInitial,
+        kInitialUndoCalled,
+        kExecute,
+        kUndone,
+        kRedone
+    };
+    State _state { kInitial };
+
+public:
+    UsdSetXformOpUndoableCommandBase(const Ufe::Path& path, const PXR_NS::UsdTimeCode& writeTime);
+
+    // Ufe::UndoableCommand overrides.
+    // No-op: Maya calls set() rather than execute().
+    void execute() override;
+    void undo() override;
+    // No-op: Maya calls set() rather than redo().
+    void redo() override;
+
+    PXR_NS::UsdTimeCode readTime() const { return _readTime; }
+    PXR_NS::UsdTimeCode writeTime() const { return _writeTime; }
+
+    virtual void setValue(const T&) = 0;
+
+    void handleSet(const T& v);
+};
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
@@ -39,7 +39,6 @@ public:
 
     void setValue(const GfVec3d& v) override { _commonAPI.SetTranslate(v, writeTime()); }
 
-    // Executes the command by setting the translation onto the transform op.
     bool set(double x, double y, double z) override
     {
         handleSet(GfVec3d(x, y, z));
@@ -64,7 +63,6 @@ public:
         _commonAPI.SetRotate(v, UsdGeomXformCommonAPI::RotationOrderXYZ, writeTime());
     }
 
-    // Executes the command by setting the rotation onto the transform op.
     bool set(double x, double y, double z) override
     {
         handleSet(GfVec3f(x, y, z));
@@ -87,7 +85,6 @@ public:
 
     void setValue(const GfVec3f& v) override { _commonAPI.SetScale(v, writeTime()); }
 
-    // Executes the command by setting the rotation onto the transform op.
     bool set(double x, double y, double z) override
     {
         handleSet(GfVec3f(x, y, z));
@@ -109,7 +106,6 @@ public:
 
     void setValue(const GfVec3f& v) override { _commonAPI.SetPivot(v, writeTime()); }
 
-    // Executes the command by setting the translation onto the transform op.
     bool set(double x, double y, double z) override
     {
         handleSet(GfVec3f(x, y, z));

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
@@ -15,6 +15,7 @@
 //
 #include "UsdTransform3dCommonAPI.h"
 
+#include <mayaUsd/ufe/UsdSetXformOpUndoableCommandBase.h>
 #include <mayaUsd/ufe/UsdTransform3dUndoableCommands.h>
 #include <mayaUsd/ufe/Utils.h>
 
@@ -27,167 +28,96 @@ namespace ufe {
 
 namespace {
 
-class UsdTranslateUndoableCmd : public Ufe::TranslateUndoableCommand
+class CommonAPITranslateUndoableCmd : public UsdSetXformOpUndoableCommandBase<GfVec3d>
 {
 public:
-    UsdTranslateUndoableCmd(const UsdSceneItem::Ptr& item, const UsdTimeCode& time)
-        : Ufe::TranslateUndoableCommand(item->path())
-        , _time(time)
+    CommonAPITranslateUndoableCmd(const UsdSceneItem::Ptr& item, const UsdTimeCode& writeTime)
+        : UsdSetXformOpUndoableCommandBase(item->path(), writeTime)
         , _commonAPI(item->prim())
     {
-        GfVec3d                              t;
-        GfVec3f                              r, s, pvt;
-        UsdGeomXformCommonAPI::RotationOrder rotOrder;
-
-        if (!_commonAPI.GetXformVectorsByAccumulation(&t, &r, &s, &pvt, &rotOrder, time)) {
-            TF_FATAL_ERROR(
-                "Cannot read common API transform values for prim %s",
-                item->prim().GetPath().GetText());
-        }
-
-        _prevT = t;
-        _t = t;
     }
 
-    void undo() override { _commonAPI.SetTranslate(_prevT, _time); }
-    void redo() override { _commonAPI.SetTranslate(_t, _time); }
+    void setValue(const GfVec3d& v) override { _commonAPI.SetTranslate(v, writeTime()); }
 
     // Executes the command by setting the translation onto the transform op.
     bool set(double x, double y, double z) override
     {
-        _t = GfVec3d(x, y, z);
-        redo();
+        handleSet(GfVec3d(x, y, z));
         return true;
     }
 
 private:
-    const UsdTimeCode     _time;
     UsdGeomXformCommonAPI _commonAPI;
-    GfVec3d               _prevT, _t;
 };
 
-class UsdRotateUndoableCmd : public Ufe::RotateUndoableCommand
+class CommonAPIRotateUndoableCmd : public UsdSetXformOpUndoableCommandBase<GfVec3f>
 {
 public:
-    UsdRotateUndoableCmd(const UsdSceneItem::Ptr& item, const UsdTimeCode& time)
-        : Ufe::RotateUndoableCommand(item->path())
-        , _time(time)
+    CommonAPIRotateUndoableCmd(const UsdSceneItem::Ptr& item, const UsdTimeCode& writeTime)
+        : UsdSetXformOpUndoableCommandBase(item->path(), writeTime)
         , _commonAPI(item->prim())
     {
-        GfVec3d                              t;
-        GfVec3f                              r, s, pvt;
-        UsdGeomXformCommonAPI::RotationOrder rotOrder;
-
-        if (!_commonAPI.GetXformVectorsByAccumulation(&t, &r, &s, &pvt, &rotOrder, time)) {
-            TF_FATAL_ERROR(
-                "Cannot read common API transform values for prim %s",
-                item->prim().GetPath().GetText());
-        }
-
-        _prevR = r;
-        _r = r;
     }
 
-    void undo() override
+    void setValue(const GfVec3f& v) override
     {
-        _commonAPI.SetRotate(_prevR, UsdGeomXformCommonAPI::RotationOrderXYZ, _time);
-    }
-    void redo() override
-    {
-        _commonAPI.SetRotate(_r, UsdGeomXformCommonAPI::RotationOrderXYZ, _time);
+        _commonAPI.SetRotate(v, UsdGeomXformCommonAPI::RotationOrderXYZ, writeTime());
     }
 
     // Executes the command by setting the rotation onto the transform op.
     bool set(double x, double y, double z) override
     {
-        _r = GfVec3f(x, y, z);
-        redo();
+        handleSet(GfVec3f(x, y, z));
         return true;
     }
 
 private:
-    const UsdTimeCode     _time;
     UsdGeomXformCommonAPI _commonAPI;
-    GfVec3f               _prevR, _r;
 };
 
-class UsdScaleUndoableCmd : public Ufe::ScaleUndoableCommand
+class CommonAPIScaleUndoableCmd : public UsdSetXformOpUndoableCommandBase<GfVec3f>
 {
 
 public:
-    UsdScaleUndoableCmd(const UsdSceneItem::Ptr& item, const UsdTimeCode& time)
-        : Ufe::ScaleUndoableCommand(item->path())
-        , _time(time)
+    CommonAPIScaleUndoableCmd(const UsdSceneItem::Ptr& item, const UsdTimeCode& writeTime)
+        : UsdSetXformOpUndoableCommandBase(item->path(), writeTime)
         , _commonAPI(item->prim())
     {
-        GfVec3d                              t;
-        GfVec3f                              r, s, pvt;
-        UsdGeomXformCommonAPI::RotationOrder rotOrder;
-
-        if (!_commonAPI.GetXformVectorsByAccumulation(&t, &r, &s, &pvt, &rotOrder, time)) {
-            TF_FATAL_ERROR(
-                "Cannot read common API transform values for prim %s",
-                item->prim().GetPath().GetText());
-        }
-
-        _prevS = s;
-        _s = s;
     }
 
-    void undo() override { _commonAPI.SetScale(_prevS, _time); }
-    void redo() override { _commonAPI.SetScale(_s, _time); }
+    void setValue(const GfVec3f& v) override { _commonAPI.SetScale(v, writeTime()); }
 
     // Executes the command by setting the rotation onto the transform op.
     bool set(double x, double y, double z) override
     {
-        _s = GfVec3f(x, y, z);
-        redo();
+        handleSet(GfVec3f(x, y, z));
         return true;
     }
 
 private:
-    const UsdTimeCode     _time;
     UsdGeomXformCommonAPI _commonAPI;
-    GfVec3f               _prevS, _s;
 };
 
-class UsdTranslatePivotUndoableCmd : public Ufe::TranslateUndoableCommand
+class CommonAPIPivotUndoableCmd : public UsdSetXformOpUndoableCommandBase<GfVec3f>
 {
 public:
-    UsdTranslatePivotUndoableCmd(const UsdSceneItem::Ptr& item, const UsdTimeCode& time)
-        : Ufe::TranslateUndoableCommand(item->path())
-        , _time(time)
+    CommonAPIPivotUndoableCmd(const UsdSceneItem::Ptr& item, const UsdTimeCode& writeTime)
+        : UsdSetXformOpUndoableCommandBase(item->path(), writeTime)
         , _commonAPI(item->prim())
     {
-        GfVec3d                              t;
-        GfVec3f                              r, s, pvt;
-        UsdGeomXformCommonAPI::RotationOrder rotOrder;
-
-        if (!_commonAPI.GetXformVectorsByAccumulation(&t, &r, &s, &pvt, &rotOrder, time)) {
-            TF_FATAL_ERROR(
-                "Cannot read common API transform values for prim %s",
-                item->prim().GetPath().GetText());
-        }
-
-        _prevPvt = pvt;
-        _pvt = pvt;
     }
 
-    void undo() override { _commonAPI.SetPivot(_prevPvt, _time); }
-    void redo() override { _commonAPI.SetPivot(_pvt, _time); }
+    void setValue(const GfVec3f& v) override { _commonAPI.SetPivot(v, writeTime()); }
 
     // Executes the command by setting the translation onto the transform op.
     bool set(double x, double y, double z) override
     {
-        _pvt = GfVec3f(x, y, z);
-        redo();
+        handleSet(GfVec3f(x, y, z));
         return true;
     }
 
 private:
-    const UsdTimeCode     _time;
     UsdGeomXformCommonAPI _commonAPI;
-    GfVec3f               _prevPvt, _pvt;
 };
 
 } // namespace
@@ -269,7 +199,7 @@ UsdTransform3dCommonAPI::translateCmd(double x, double y, double z)
         return nullptr;
     }
 
-    return std::make_shared<UsdTranslateUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
+    return std::make_shared<CommonAPITranslateUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3dCommonAPI::rotateCmd(double x, double y, double z)
@@ -278,7 +208,7 @@ Ufe::RotateUndoableCommand::Ptr UsdTransform3dCommonAPI::rotateCmd(double x, dou
         return nullptr;
     }
 
-    return std::make_shared<UsdRotateUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
+    return std::make_shared<CommonAPIRotateUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3dCommonAPI::scaleCmd(double x, double y, double z)
@@ -287,7 +217,7 @@ Ufe::ScaleUndoableCommand::Ptr UsdTransform3dCommonAPI::scaleCmd(double x, doubl
         return nullptr;
     }
 
-    return std::make_shared<UsdScaleUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
+    return std::make_shared<CommonAPIScaleUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
 Ufe::TranslateUndoableCommand::Ptr
@@ -297,7 +227,7 @@ UsdTransform3dCommonAPI::rotatePivotCmd(double x, double y, double z)
         return nullptr;
     }
 
-    return std::make_shared<UsdTranslatePivotUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
+    return std::make_shared<CommonAPIPivotUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
 void UsdTransform3dCommonAPI::rotatePivot(double x, double y, double z)

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -41,15 +41,6 @@ namespace {
 using namespace MayaUsd;
 using namespace MayaUsd::ufe;
 
-void warnUnimplemented(const char* msg) { TF_WARN("Illegal call to unimplemented %s", msg); }
-
-VtValue getValue(const UsdAttribute& attr, const UsdTimeCode& time)
-{
-    VtValue value;
-    attr.Get(&value, time);
-    return value;
-}
-
 const char* getMatrixOp() { return std::getenv("MAYA_USD_MATRIX_XFORM_OP_NAME"); }
 
 std::vector<UsdGeomXformOp>::const_iterator

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
@@ -31,6 +31,7 @@
 #include <cstring>
 #include <functional>
 #include <map>
+#include <typeinfo>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -164,7 +165,6 @@ createTransform3d(const Ufe::SceneItem::Ptr& item, NextTransform3dFn nextTransfo
 class UsdTRSUndoableCmdBase : public Ufe::SetVector3dUndoableCommand
 {
 private:
-    const UsdTimeCode _readTime;
     const UsdTimeCode _writeTime;
     VtValue           _newOpValue;
     UsdGeomXformOp    _op;
@@ -174,23 +174,23 @@ private:
 public:
     struct State
     {
-        virtual const char* name() const = 0;
-        virtual void        handleUndo(UsdTRSUndoableCmdBase*)
+        virtual void handleUndo(UsdTRSUndoableCmdBase*)
         {
             TF_CODING_ERROR(
-                "Illegal handleUndo() call in UsdTRSUndoableCmdBase for state '%s'.", name());
+                "Illegal handleUndo() call in UsdTRSUndoableCmdBase for state '%s'.",
+                typeid(*this).name());
         }
         virtual void handleSet(UsdTRSUndoableCmdBase*, const VtValue&)
         {
             TF_CODING_ERROR(
-                "Illegal handleSet() call in UsdTRSUndoableCmdBase for state '%s'.", name());
+                "Illegal handleSet() call in UsdTRSUndoableCmdBase for state '%s'.",
+                typeid(*this).name());
         }
     };
 
     struct InitialState : public State
     {
-        const char* name() const override { return "initial"; }
-        void        handleUndo(UsdTRSUndoableCmdBase* cmd) override
+        void handleUndo(UsdTRSUndoableCmdBase* cmd) override
         {
             // Maya triggers an undo on command creation, ignore it.
             cmd->_state = &UsdTRSUndoableCmdBase::_initialUndoCalledState;
@@ -202,7 +202,6 @@ public:
 
             // Going from initial to executing / executed state, save value.
             cmd->_op = cmd->_opFunc(*cmd);
-            cmd->_newOpValue = v;
             cmd->setValue(v);
             cmd->_state = &UsdTRSUndoableCmdBase::_executeState;
         }
@@ -210,8 +209,7 @@ public:
 
     struct InitialUndoCalledState : public State
     {
-        const char* name() const override { return "initial undo called"; }
-        void        handleSet(UsdTRSUndoableCmdBase* cmd, const VtValue&) override
+        void handleSet(UsdTRSUndoableCmdBase* cmd, const VtValue&) override
         {
             // Maya triggers a redo on command creation, ignore it.
             cmd->_state = &UsdTRSUndoableCmdBase::_initialState;
@@ -220,24 +218,18 @@ public:
 
     struct ExecuteState : public State
     {
-        const char* name() const override { return "execute"; }
-        void        handleUndo(UsdTRSUndoableCmdBase* cmd) override
+        void handleUndo(UsdTRSUndoableCmdBase* cmd) override
         {
             // Undo
             cmd->_undoableItem.undo();
             cmd->_state = &UsdTRSUndoableCmdBase::_undoneState;
         }
-        void handleSet(UsdTRSUndoableCmdBase* cmd, const VtValue& v) override
-        {
-            cmd->_newOpValue = v;
-            cmd->setValue(v);
-        }
+        void handleSet(UsdTRSUndoableCmdBase* cmd, const VtValue& v) override { cmd->setValue(v); }
     };
 
     struct UndoneState : public State
     {
-        const char* name() const override { return "undone"; }
-        void        handleSet(UsdTRSUndoableCmdBase* cmd, const VtValue&) override
+        void handleSet(UsdTRSUndoableCmdBase* cmd, const VtValue&) override
         {
             // Redo
             cmd->_undoableItem.redo();
@@ -247,8 +239,7 @@ public:
 
     struct RedoneState : public State
     {
-        const char* name() const override { return "redone"; }
-        void        handleUndo(UsdTRSUndoableCmdBase* cmd) override
+        void handleUndo(UsdTRSUndoableCmdBase* cmd) override
         {
             // Undo
             cmd->_undoableItem.undo();
@@ -260,23 +251,16 @@ public:
         // single drag, the Maya move command repeatedly calls undo, then redo,
         // setting new values after the redo.  Treat such events identically to
         // the Execute state.
-        void handleSet(UsdTRSUndoableCmdBase* cmd, const VtValue& v) override
-        {
-            cmd->_newOpValue = v;
-            cmd->setValue(v);
-        }
+        void handleSet(UsdTRSUndoableCmdBase* cmd, const VtValue& v) override { cmd->setValue(v); }
     };
 
     UsdTRSUndoableCmdBase(
         const VtValue&     newOpValue,
         const Ufe::Path&   path,
         OpFunc             opFunc,
-        const UsdTimeCode& writeTime_)
+        const UsdTimeCode& writeTime)
         : Ufe::SetVector3dUndoableCommand(path)
-        ,
-        // Always read from proxy shape time.
-        _readTime(getTime(path))
-        , _writeTime(writeTime_)
+        , _writeTime(writeTime)
         , _newOpValue(newOpValue)
         , _op()
         , _opFunc(std::move(opFunc))
@@ -294,12 +278,10 @@ public:
     {
         auto attr = _op.GetAttr();
         if (attr) {
+            _newOpValue = v;
             _op.GetAttr().Set(v, _writeTime);
         }
     }
-
-    UsdTimeCode readTime() const { return _readTime; }
-    UsdTimeCode writeTime() const { return _writeTime; }
 
     static InitialState           _initialState;
     static InitialUndoCalledState _initialUndoCalledState;

--- a/lib/mayaUsd/ufe/UsdUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoableCommand.h
@@ -21,8 +21,6 @@
 
 #include <ufe/path.h>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 

--- a/test/lib/ufe/testMoveCmd.py
+++ b/test/lib/ufe/testMoveCmd.py
@@ -23,6 +23,11 @@ from testUtils import assertVectorAlmostEqual
 import ufeUtils
 import usdUtils
 
+import mayaUsd_createStageWithNewLayer
+import mayaUsd.ufe
+
+from pxr import UsdGeom, Vt, Gf
+
 from maya import cmds
 from maya import standalone
 from maya.api import OpenMaya as om
@@ -276,6 +281,118 @@ class MoveCmdTestCase(testTRSBase.TRSTestCaseBase):
 
         self.runMultiSelectTestMove(ballItems, expected)
 
+    def runTestOpUndo(self, createTransformOp, attrSpec):
+        '''Engine method for op undo testing.'''
+        proxyShape = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        
+        proxyShapePath = ufe.PathString.path(proxyShape)
+        proxyShapeItem = ufe.Hierarchy.createItem(proxyShapePath)
+        proxyShapeContextOps = ufe.ContextOps.contextOps(proxyShapeItem)
+        proxyShapeContextOps.doOp(['Add New Prim', 'Sphere'])
+
+        spherePath = ufe.PathString.path('%s,/Sphere1' % proxyShape)
+        sphereItem = ufe.Hierarchy.createItem(spherePath)
+
+        spherePrim = mayaUsd.ufe.ufePathToPrim(ufe.PathString.string(spherePath))
+        sphereXformable = UsdGeom.Xformable(spherePrim)
+        createTransformOp(self, sphereXformable)
+
+        # Set the edit target to the session layer, then move.
+        stage = mayaUsd.ufe.getStage(proxyShape)
+        sessionLayer = stage.GetLayerStack()[0]
+        stage.SetEditTarget(sessionLayer)
+
+        sn = ufe.GlobalSelection.get()
+        sn.clear()
+        sn.append(sphereItem)
+
+        cmds.move(0, 10, 0, relative=True, os=True, wd=True)
+
+        sphereT3d = ufe.Transform3d.transform3d(sphereItem)
+        assertVectorAlmostEqual(self, sphereT3d.translation().vector, [0, 10, 0])
+
+        primSpec = stage.GetEditTarget().GetPrimSpecForScenePath('/Sphere1')
+
+        # Writing to the session layer has created a primSpec in that layer,
+        # with the xformOp:transform attrSpec.
+        self.assertIsNotNone(primSpec)
+        self.assertIn(attrSpec, primSpec.attributes)
+
+        # Undo: primSpec in session layer should be gone.
+        cmds.undo()
+
+        assertVectorAlmostEqual(self, sphereT3d.translation().vector, [0, 0, 0])
+
+        primSpec = stage.GetEditTarget().GetPrimSpecForScenePath('/Sphere1')
+        self.assertIsNone(primSpec)
+
+        cmds.redo()
+
+        assertVectorAlmostEqual(self, sphereT3d.translation().vector, [0, 10, 0])
+
+        # Undo after redo must also remove primSpec.
+        cmds.undo()
+
+        assertVectorAlmostEqual(self, sphereT3d.translation().vector, [0, 0, 0])
+
+        primSpec = stage.GetEditTarget().GetPrimSpecForScenePath('/Sphere1')
+        self.assertIsNone(primSpec)
+
+        # Performing change in main layer should also work.
+        layer = stage.GetLayerStack()[1]
+        stage.SetEditTarget(layer)
+
+        cmds.move(0, 10, 0, relative=True, os=True, wd=True)
+
+        def checkTransform(expectedTranslation):
+            # Check through both USD and UFE interfaces
+            assertVectorAlmostEqual(
+                self, sphereT3d.translation().vector, expectedTranslation)
+            expected = Gf.Matrix4d(1.0)
+            expected.SetTranslate(expectedTranslation)
+            actual = sphereXformable.GetLocalTransformation()
+            self.assertTrue(Gf.IsClose(actual, expected, 1e-5))
+            
+        checkTransform([0, 10, 0])
+
+        cmds.undo()
+
+        checkTransform([0, 0, 0])
+
+        cmds.redo()
+
+        checkTransform([0, 10, 0])
+
+    def testMatrixOpUndo(self):
+        '''Undo of matrix op move must completely remove attr spec.'''
+
+        def createMatrixTransformOp(testCase, sphereXformable):
+            transformOp = sphereXformable.AddTransformOp()
+            xform = Gf.Matrix4d(1.0)
+            transformOp.Set(xform)
+    
+            testCase.assertEqual(
+                sphereXformable.GetXformOpOrderAttr().Get(), Vt.TokenArray([
+                    "xformOp:transform"]))
+
+        self.runTestOpUndo(createMatrixTransformOp, 'xformOp:transform')
+
+    def testCommonAPIUndo(self):
+        '''Undo of move with common API must completely remove attr spec.'''
+
+        def createCommonAPI(testCase, sphereXformable):
+            sphereXformable.AddTranslateOp(
+                UsdGeom.XformOp.PrecisionFloat, "pivot")
+            sphereXformable.AddTranslateOp(
+                UsdGeom.XformOp.PrecisionFloat, "pivot", True)
+    
+            self.assertEqual(
+                sphereXformable.GetXformOpOrderAttr().Get(), 
+                Vt.TokenArray(("xformOp:translate:pivot",
+                               "!invert!xformOp:translate:pivot")))
+            self.assertTrue(UsdGeom.XformCommonAPI(sphereXformable))
+
+        self.runTestOpUndo(createCommonAPI, 'xformOp:translate')
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
The goal of this pull request is to bring matrix op and common API Transform3d interfaces to the new UndoManager undo / redo capability.  This will completely remove on undo any attrSpec's and primSpec's added during Transform3d edits.  This capability was already present in Maya transform stacks and Maya fallback transform stacks.