### PR TITLE
MAYA-112854 - Fix warnings from USDZ texture import

### DIFF
--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -318,7 +318,7 @@ struct UsdMayaJobImportArgs
     static const VtDictionary& GetDefaultDictionary();
 
     MAYAUSD_CORE_PUBLIC
-    static const std::string GetImportUSDZTexturesFilePath(const std::string& userArg);
+    static const std::string GetImportUSDZTexturesFilePath(const VtDictionary& userArgs);
 
 private:
     MAYAUSD_CORE_PUBLIC

--- a/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
+++ b/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
@@ -17,6 +17,7 @@
 
 from pxr import Gf
 from pxr import Sdf
+from pxr import Tf
 from pxr import Usd
 from pxr import UsdShade
 from pxr import UsdUtils
@@ -65,6 +66,10 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
         """
         Tests that a usdPreviewSurface exports and imports correctly.
         """
+        mark = Tf.Error.Mark()
+        mark.SetMark()
+        self.assertTrue(mark.IsClean())
+
         mayaUsdPluginName = "mayaUsdPlugin"
         if not cmds.pluginInfo(mayaUsdPluginName, query=True, loaded=True):
             cmds.loadPlugin(mayaUsdPluginName)
@@ -199,10 +204,16 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
         full_texture_path = os.path.join(usd_dir, rel_texture_path)
         self.assertTrue(os.path.isfile(full_texture_path))
 
+        self.assertTrue(mark.IsClean())
+
     def testShadingRoundtrip(self):
         """
         Test that shading group and surface node names will survive a roundtrip
         """
+        mark = Tf.Error.Mark()
+        mark.SetMark()
+        self.assertTrue(mark.IsClean())
+
         mayaUsdPluginName = "mayaUsdPlugin"
         if not cmds.pluginInfo(mayaUsdPluginName, query=True, loaded=True):
             cmds.loadPlugin(mayaUsdPluginName)
@@ -280,11 +291,17 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
                 cmds.connectionInfo(final_surf+".outColor", dfs=True),
                 [final_sg+".surfaceShader"])
 
+        self.assertTrue(mark.IsClean())
+
     def testDisplayColorLossyRoundtrip(self):
         """
         Test that shading group names created for display color import are in
         sync with their surface shaders.
         """
+        mark = Tf.Error.Mark()
+        mark.SetMark()
+        self.assertTrue(mark.IsClean())
+
         mayaUsdPluginName = "mayaUsdPlugin"
         if not cmds.pluginInfo(mayaUsdPluginName, query=True, loaded=True):
             cmds.loadPlugin(mayaUsdPluginName)
@@ -331,6 +348,7 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
                     cmds.connectionInfo(final_surf+".outColor", dfs=True),
                     [final_sg+".surfaceShader"])
 
+        self.assertTrue(mark.IsClean())
 
 
 if __name__ == '__main__':

--- a/test/lib/usd/translators/testUsdImportUSDZTextures.py
+++ b/test/lib/usd/translators/testUsdImportUSDZTextures.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import shutil
 import os
 import unittest
 
@@ -22,6 +23,7 @@ import fixturesUtils
 import maya.OpenMaya as om
 from maya import cmds
 from maya import standalone
+from pxr import Tf
 from pxr import Usd
 
 
@@ -40,11 +42,36 @@ class TestUsdImportUSDZTextures(unittest.TestCase):
         standalone.uninitialize()
 
     def testUSDZImport(self):
+        mark = Tf.Error.Mark()
+        mark.SetMark()
+        self.assertTrue(mark.IsClean())
+
         om.MFileIO.newFile(True)
         write_dir_path = os.path.dirname(self.usdz_path)
         cmds.mayaUSDImport(f=self.usdz_path, importUSDZTextures=True, importUSDZTexturesFilePath=write_dir_path)
         self.assertTrue(os.path.isfile(os.path.join(write_dir_path, "clouds_128_128.png")))
         self.assertTrue(os.path.isfile(os.path.join(write_dir_path, "red_128_128.png")))
+
+        self.assertTrue(mark.IsClean())
+
+    def testUSDZImportIntoProject(self):
+        mark = Tf.Error.Mark()
+        mark.SetMark()
+        self.assertTrue(mark.IsClean())
+
+        project_path = os.path.normpath(cmds.workspace(q=True, rd=True))
+        image_path = os.path.join(project_path, cmds.workspace(fre="sourceImages"))
+        # Purposefully erase the sourceimage directory:
+        if os.path.isdir(image_path):
+            shutil.rmtree(image_path)
+
+        # It will automatically get recreated:
+        om.MFileIO.newFile(True)
+        cmds.mayaUSDImport(f=self.usdz_path, importUSDZTextures=True)
+        self.assertTrue(os.path.isfile(os.path.join(image_path, "clouds_128_128.png")))
+        self.assertTrue(os.path.isfile(os.path.join(image_path, "red_128_128.png")))
+
+        self.assertTrue(mark.IsClean())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Do not check folders if not importing USDZ textures
- Create sourceImages if no path was given, and there is an active project, and the sourceImage folder is not yet created in that project.

Fixes #1588 