### PR TITLE
Maya 2022.1 has the Light loop API V2 and is compatible with MaterialX

### DIFF
--- a/doc/MaterialX.md
+++ b/doc/MaterialX.md
@@ -72,7 +72,7 @@ This one is more complex and requires knowledge of how to build USD.
 **Requires Maya 2022.1 or PR126**
 
 1. Build MaterialX using the [Autodesk fork of MaterialX](https://github.com/autodesk-forks/MaterialX)
-    - Requires version [v1.38.1_adsk](https://github.com/autodesk-forks/MaterialX/releases/tag/v1.38.1_adsk) or later
+    - Requires a version later than [PR 1285](https://github.com/autodesk-forks/MaterialX/pull/1285) for proper transparency support.
     - Requires at minimum MATERIALX_BUILD_CONTRIB, MATERIALX_BUILD_GEN_OGSXML, and MATERIALX_BUILD_SHARED_LIBS options to be enabled
     - We only require the OGS XML shadergen part (and USD requires the GLSL shadergen), so you can turn off all complex options like Viewer, OIIO, OSL, or Python support
 2. Install that freshly built MaterialX in the `install` location where you intend to build USD next

--- a/doc/MaterialX.md
+++ b/doc/MaterialX.md
@@ -26,7 +26,7 @@ We currently support exporting to MaterialX-compatible UsdShade networks:
 
 ### To enable:
 
-- Rebuild the MayaUsd plugin for Maya PR126 using tip of the dev branch or any commit that includes [PR 1478](https://github.com/Autodesk/maya-usd/pull/1478)
+- Rebuild the MayaUsd plugin for Maya 2022.1 or PR126 using tip of the dev branch or any commit that includes [PR 1478](https://github.com/Autodesk/maya-usd/pull/1478)
 - Look for a new "MaterialX shading" option in the `Materials` dropdown of the export options
 
 ## Import
@@ -43,7 +43,7 @@ We can import MaterialX networks.
 
 ### To enable:
 
-- Rebuild the MayaUsd plugin for Maya PR126 using tip of the dev branch or any commit that includes [PR 1478](https://github.com/Autodesk/maya-usd/pull/1478)
+- Rebuild the MayaUsd plugin for Maya 2022.1 or PR126 using tip of the dev branch or any commit that includes [PR 1478](https://github.com/Autodesk/maya-usd/pull/1478)
 - The import code will discover MaterialX shading networks and attempt to import them automatically
 
 ## USD stage support in viewport
@@ -69,7 +69,7 @@ The same spheres exported with MaterialX shading and loaded as a USD stage: ![al
 
 This one is more complex and requires knowledge of how to build USD.
 
-**Requires Maya PR126**
+**Requires Maya 2022.1 or PR126**
 
 1. Build MaterialX using the [Autodesk fork of MaterialX](https://github.com/autodesk-forks/MaterialX)
     - Requires version [v1.38.1_adsk](https://github.com/autodesk-forks/MaterialX/releases/tag/v1.38.1_adsk) or later

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -237,6 +237,24 @@ TF_DEFINE_PRIVATE_TOKENS(
     (ND_swizzle_vector4_vector2)
     (ND_swizzle_vector4_vector3)
     (ND_swizzle_vector4_vector4)
+    // Conversion nodes:
+    (ND_convert_float_color3)
+    (ND_convert_float_color4)
+    (ND_convert_float_vector2)
+    (ND_convert_float_vector3)
+    (ND_convert_float_vector4)
+    (ND_convert_vector2_vector3)
+    (ND_convert_vector3_color3)
+    (ND_convert_vector3_vector2)
+    (ND_convert_vector3_vector4)
+    (ND_convert_vector4_color4)
+    (ND_convert_vector4_vector3)
+    (ND_convert_color3_vector3)
+    (ND_convert_color4_vector4)
+    (ND_convert_color3_color4)
+    (ND_convert_color4_color3)
+    (ND_convert_boolean_float)
+    (ND_convert_integer_float)
 );
 // clang-format on
 
@@ -1876,6 +1894,8 @@ MHWRender::MShaderInstance* HdVP2Material::_CreateMaterialXShaderInstance(
 
         // Add automatic tangent generation:
         shaderInstance->addInputFragment("materialXTw", "Tw", "Tw");
+
+        shaderInstance->setIsTransparent(ogsFragment.isTransparent());
 
     } catch (mx::Exception& e) {
         TF_RUNTIME_ERROR(

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -173,7 +173,7 @@ TF_DEFINE_PRIVATE_TOKENS(
     (vector2)
 );
 
-std::set<std::string> _mtlxTopoNodeSet = {
+const std::set<std::string> _mtlxTopoNodeSet = {
     // Topo affecting nodes due to object/model/world space parameter
     "position",
     "normal",

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -173,116 +173,28 @@ TF_DEFINE_PRIVATE_TOKENS(
     (vector2)
 );
 
-TF_DEFINE_PRIVATE_TOKENS(
-    _mtlxTopoNodeTokens,
-
+std::set<std::string> _mtlxTopoNodeSet = {
     // Topo affecting nodes due to object/model/world space parameter
-    (ND_position_vector3)
-    (ND_normal_vector3)
-    (ND_tangent_vector3)
-    (ND_bitangent_vector3)
+    "position",
+    "normal",
+    "tangent",
+    "bitangent",
     // Topo affecting nodes due to channel index. We remap to geomprop in _AddMissingTexcoordReaders
-    (ND_texcoord_vector2)
-    (ND_texcoord_vector3)
+    "texcoord",
     // Color at vertices also affect topo, but we have not locked a naming scheme to go from index
     // based to name based as we did for UV sets. We will mark them as topo-affecting, but there is
     // nothing we can do to link them correctly to a primvar without specifying a naming scheme.
-    (ND_geomcolor_float)
-    (ND_geomcolor_color3)
-    (ND_geomcolor_color4)
+    "geomcolor",
     // Geompropvalue are the best way to reference a primvar by name. The primvar name is
     // topo-affecting. Note that boolean and string are not supported by the GLSL codegen.
-    (ND_geompropvalue_integer)
-    (ND_geompropvalue_boolean)
-    (ND_geompropvalue_string)
-    (ND_geompropvalue_float)
-    (ND_geompropvalue_color3)
-    (ND_geompropvalue_color4)
-    (ND_geompropvalue_vector2)
-    (ND_geompropvalue_vector3)
-    (ND_geompropvalue_vector4)
+    "geompropvalue",
     // Swizzles are inlined into the codegen and affect topology.
-    (ND_swizzle_float_color3)
-    (ND_swizzle_float_color4)
-    (ND_swizzle_float_vector2)
-    (ND_swizzle_float_vector3)
-    (ND_swizzle_float_vector4)
-    (ND_swizzle_color3_float)
-    (ND_swizzle_color3_color3)
-    (ND_swizzle_color3_color4)
-    (ND_swizzle_color3_vector2)
-    (ND_swizzle_color3_vector3)
-    (ND_swizzle_color3_vector4)
-    (ND_swizzle_color4_float)
-    (ND_swizzle_color4_color3)
-    (ND_swizzle_color4_color4)
-    (ND_swizzle_color4_vector2)
-    (ND_swizzle_color4_vector3)
-    (ND_swizzle_color4_vector4)
-    (ND_swizzle_vector2_float)
-    (ND_swizzle_vector2_color3)
-    (ND_swizzle_vector2_color4)
-    (ND_swizzle_vector2_vector2)
-    (ND_swizzle_vector2_vector3)
-    (ND_swizzle_vector2_vector4)
-    (ND_swizzle_vector3_float)
-    (ND_swizzle_vector3_color3)
-    (ND_swizzle_vector3_color4)
-    (ND_swizzle_vector3_vector2)
-    (ND_swizzle_vector3_vector3)
-    (ND_swizzle_vector3_vector4)
-    (ND_swizzle_vector4_float)
-    (ND_swizzle_vector4_color3)
-    (ND_swizzle_vector4_color4)
-    (ND_swizzle_vector4_vector2)
-    (ND_swizzle_vector4_vector3)
-    (ND_swizzle_vector4_vector4)
+    "swizzle",
     // Conversion nodes:
-    (ND_convert_float_color3)
-    (ND_convert_float_color4)
-    (ND_convert_float_vector2)
-    (ND_convert_float_vector3)
-    (ND_convert_float_vector4)
-    (ND_convert_vector2_vector3)
-    (ND_convert_vector3_color3)
-    (ND_convert_vector3_vector2)
-    (ND_convert_vector3_vector4)
-    (ND_convert_vector4_color4)
-    (ND_convert_vector4_vector3)
-    (ND_convert_color3_vector3)
-    (ND_convert_color4_vector4)
-    (ND_convert_color3_color4)
-    (ND_convert_color4_color3)
-    (ND_convert_boolean_float)
-    (ND_convert_integer_float)
-);
+    "convert"
+};
+
 // clang-format on
-
-static const std::set<TfToken> _mtlxTopoNodeTokenSet(
-    _mtlxTopoNodeTokens->allTokens.cbegin(),
-    _mtlxTopoNodeTokens->allTokens.cend());
-
-//! Return true if that node parameter has topological impact on the generated code.
-//
-// Swizzle and geompropvalue nodes are known to have an attribute that affects
-// shader topology. The "channels" and "geomprop" attributes will have effects at the codegen level,
-// not at runtime. Yes, this is forbidden internal knowledge of the MaterialX shader generator and
-// we might get other nodes like this one in a future update.
-//
-// The index input of the texcoord and geomcolor nodes affect which stream to read and is topo
-// affecting.
-//
-// Any geometric input that can specify model/object/world space is also topo affecting.
-//
-// Things to look out for are parameters of type "string" and parameters with the "uniform"
-// metadata. These need to be reviewed against the code used in their registered
-// implementations (see registerImplementation calls in the GlslShaderGenerator CTOR). Sadly
-// we can not make that a rule because the filename of an image node is both a "string" and
-// has the "uniform" metadata, yet is not affecting topology.
-bool _IsTopologicalNode(const HdMaterialNode2& inNode)
-{
-    return _mtlxTopoNodeTokenSet.find(inNode.nodeTypeId) != _mtlxTopoNodeTokenSet.cend();
-}
 
 struct _MaterialXData
 {
@@ -325,6 +237,33 @@ _MaterialXData& _GetMaterialXData()
     std::call_once(once, []() { materialXData.reset(new _MaterialXData()); });
 
     return *materialXData;
+}
+
+//! Return true if that node parameter has topological impact on the generated code.
+//
+// Swizzle and geompropvalue nodes are known to have an attribute that affects
+// shader topology. The "channels" and "geomprop" attributes will have effects at the codegen level,
+// not at runtime. Yes, this is forbidden internal knowledge of the MaterialX shader generator and
+// we might get other nodes like this one in a future update.
+//
+// The index input of the texcoord and geomcolor nodes affect which stream to read and is topo
+// affecting.
+//
+// Any geometric input that can specify model/object/world space is also topo affecting.
+//
+// Things to look out for are parameters of type "string" and parameters with the "uniform"
+// metadata. These need to be reviewed against the code used in their registered
+// implementations (see registerImplementation calls in the GlslShaderGenerator CTOR). Sadly
+// we can not make that a rule because the filename of an image node is both a "string" and
+// has the "uniform" metadata, yet is not affecting topology.
+bool _IsTopologicalNode(const HdMaterialNode2& inNode)
+{
+    mx::NodeDefPtr nodeDef
+        = _GetMaterialXData()._mtlxLibrary->getNodeDef(inNode.nodeTypeId.GetString());
+    if (nodeDef) {
+        return _mtlxTopoNodeSet.find(nodeDef->getCategory()) != _mtlxTopoNodeSet.cend();
+    }
+    return false;
 }
 
 bool _IsMaterialX(const HdMaterialNode& node)
@@ -490,8 +429,7 @@ void _AddMissingTexcoordReaders(mx::DocumentPtr& mtlxDoc)
                 }
             }
             // Check if it is an explicit texcoord reader:
-            if (nodeDef->getName() == _mtlxTopoNodeTokens->ND_texcoord_vector2
-                || nodeDef->getName() == _mtlxTopoNodeTokens->ND_texcoord_vector3) {
+            if (nodeDef->getCategory() == "texcoord") {
                 // Switch it with a geompropvalue of the same name:
                 std::string nodeName = node->getName();
                 std::string oldName = nodeName + "_toDelete";


### PR DESCRIPTION
- Updated MaterialX build how-to.
- Transparency support
- Updated list of topo nodes