### PR TITLE
MAYA-112871 MayaUSD: VS Code setup

### DIFF
--- a/cmake/compiler_config.cmake
+++ b/cmake/compiler_config.cmake
@@ -99,6 +99,12 @@ function(mayaUsd_compile_config TARGET)
             PRIVATE
                 ${GNU_CLANG_FLAGS}
         )
+        if(IS_LINUX)
+            target_compile_definitions(${TARGET}
+                PRIVATE
+                    _GLIBCXX_USE_CXX11_ABI=0 # USD is built with old ABI
+            )
+        endif()
     elseif(IS_MSVC)
         target_compile_options(${TARGET} 
             PRIVATE

--- a/cmake/googletest_download.txt.in
+++ b/cmake/googletest_download.txt.in
@@ -15,8 +15,11 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(FORCE_SHARED_CRT "")
+set(FORCE_OLD_ABI "")
 if(MSVC)
   set(FORCE_SHARED_CRT "-DFORCE_SHARED_CRT=OFF")
+elseif(UNIX AND NOT APPLE)
+  set(FORCE_OLD_ABI "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
 endif()
 
 ExternalProject_Add(googletest
@@ -37,4 +40,5 @@ ExternalProject_Add(googletest
                     "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
                     "-DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}"
                     "-DCMAKE_CXX_STANDARD_REQUIRED=${CMAKE_CXX_STANDARD_REQUIRED}"
+                    "${FORCE_OLD_ABI}"
 )

--- a/cmake/googletest_src.txt.in
+++ b/cmake/googletest_src.txt.in
@@ -13,8 +13,11 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(FORCE_SHARED_CRT "")
+set(FORCE_OLD_ABI "")
 if(MSVC)
   set(FORCE_SHARED_CRT "-DFORCE_SHARED_CRT=OFF")
+elseif(UNIX AND NOT APPLE)
+  set(FORCE_OLD_ABI "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
 endif()
 
 ExternalProject_Add(googletest
@@ -34,4 +37,5 @@ ExternalProject_Add(googletest
                     "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
                     "-DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}"
                     "-DCMAKE_CXX_STANDARD_REQUIRED=${CMAKE_CXX_STANDARD_REQUIRED}"
+                    "${FORCE_OLD_ABI}"
 )


### PR DESCRIPTION
Fix canonical path for script run-clang-format.py (fix only on Windows and when using Python 3.6 or higher).
  - reported file paths reported by Git and paths inclusion had different case making the test fail finding any files.
Fix for forcing the use of old ABI on Linux same as done in Maya so that Maya-usd can be compiled with GCC 9.x or higher without error.