### PR TITLE
Pr/allow usd reader registration for tf type tokens

### DIFF
--- a/lib/mayaUsd/fileio/primReaderRegistry.h
+++ b/lib/mayaUsd/fileio/primReaderRegistry.h
@@ -91,19 +91,6 @@ struct UsdMayaPrimReaderRegistry
     MAYAUSD_CORE_PUBLIC
     static void RegisterRaw(const TfType& type, ReaderFn fn);
 
-    /// \brief Wraps \p fn in a ReaderFactoryFn and registers that factory
-    /// function as a reader provider for \p T.
-    /// This is a helper method for the macro PXRUSDMAYA_DEFINE_READER;
-    /// you probably want to use PXRUSDMAYA_DEFINE_READER directly instead.
-    template <typename T> static void RegisterRaw(ReaderFn fn)
-    {
-        if (TfType t = TfType::Find<T>()) {
-            RegisterRaw(t, fn);
-        } else {
-            TF_CODING_ERROR("Cannot register unknown TfType: %s.", ArchGetDemangled<T>().c_str());
-        }
-    }
-
     // takes a usdType (i.e. prim.GetTypeName())
     /// \brief Finds a reader factory if one exists for \p usdTypeName.
     ///
@@ -121,11 +108,19 @@ struct UsdMayaPrimReaderRegistry
     static ReaderFactoryFn FindOrFallback(const TfToken& usdTypeName);
 };
 
+// Lookup TfType by name instead of static C++ type when
+// registering prim reader functions. This allows readers to be
+// registered for codeless schemas, which are declared in the
+// TfType system but have no corresponding C++ code.
 #define PXRUSDMAYA_DEFINE_READER(T, argsVarName, ctxVarName)                                     \
     static bool UsdMaya_PrimReader_##T(const UsdMayaPrimReaderArgs&, UsdMayaPrimReaderContext*); \
-    TF_REGISTRY_FUNCTION_WITH_TAG(UsdMayaPrimReaderRegistry, T)                                  \
+    TF_REGISTRY_FUNCTION_WITH_TAG(UsdMayaPrimReaderRegistry, T)                                              \
     {                                                                                            \
-        UsdMayaPrimReaderRegistry::RegisterRaw<T>(UsdMaya_PrimReader_##T);                       \
+        if (TfType t = TfType::FindByName(#T)) {                                          \
+            UsdMayaPrimReaderRegistry::RegisterRaw(t, UsdMaya_PrimReader_##T);                   \
+        } else {                                                                                 \
+            TF_CODING_ERROR("Cannot register unknown TfType: %s.", #T);                   \
+        }                                                                                        \
     }                                                                                            \
     bool UsdMaya_PrimReader_##T(                                                                 \
         const UsdMayaPrimReaderArgs& argsVarName, UsdMayaPrimReaderContext* ctxVarName)

--- a/lib/mayaUsd/fileio/primReaderRegistry.h
+++ b/lib/mayaUsd/fileio/primReaderRegistry.h
@@ -114,12 +114,12 @@ struct UsdMayaPrimReaderRegistry
 // TfType system but have no corresponding C++ code.
 #define PXRUSDMAYA_DEFINE_READER(T, argsVarName, ctxVarName)                                     \
     static bool UsdMaya_PrimReader_##T(const UsdMayaPrimReaderArgs&, UsdMayaPrimReaderContext*); \
-    TF_REGISTRY_FUNCTION_WITH_TAG(UsdMayaPrimReaderRegistry, T)                                              \
+    TF_REGISTRY_FUNCTION_WITH_TAG(UsdMayaPrimReaderRegistry, T)                                  \
     {                                                                                            \
-        if (TfType t = TfType::FindByName(#T)) {                                          \
+        if (TfType t = TfType::FindByName(#T)) {                                                 \
             UsdMayaPrimReaderRegistry::RegisterRaw(t, UsdMaya_PrimReader_##T);                   \
         } else {                                                                                 \
-            TF_CODING_ERROR("Cannot register unknown TfType: %s.", #T);                   \
+            TF_CODING_ERROR("Cannot register unknown TfType: %s.", #T);                          \
         }                                                                                        \
     }                                                                                            \
     bool UsdMaya_PrimReader_##T(                                                                 \

--- a/lib/mayaUsd/fileio/translators/translatorRfMLight.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorRfMLight.cpp
@@ -15,6 +15,8 @@
 //
 #include "translatorRfMLight.h"
 
+#include "pxr/usd/sdf/types.h"
+
 #include <mayaUsd/fileio/primReaderArgs.h>
 #include <mayaUsd/fileio/primReaderContext.h>
 #include <mayaUsd/fileio/primReaderRegistry.h>
@@ -29,9 +31,9 @@
 #include <pxr/base/tf/staticTokens.h>
 #include <pxr/base/tf/stringUtils.h>
 #include <pxr/base/tf/token.h>
+#include <pxr/base/tf/type.h>
 #include <pxr/base/vt/value.h>
 #include <pxr/usd/sdf/assetPath.h>
-#include "pxr/usd/sdf/types.h"
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
@@ -46,7 +48,7 @@
 #include <pxr/usd/usdLux/shapingAPI.h>
 #include <pxr/usd/usdLux/sphereLight.h>
 #include <pxr/usd/usdShade/tokens.h>
-#include <pxr/base/tf/type.h>
+
 #include <maya/MColor.h>
 #include <maya/MFnDependencyNode.h>
 #include <maya/MObject.h>
@@ -545,33 +547,33 @@ static bool _ReadLightTextureFile(const UsdLuxLight& lightSchema, MFnDependencyN
     return (status == MS::kSuccess);
 }
 
-static inline 
-TfToken
-_ShaderAttrName(const std::string& shaderParamName)
+static inline TfToken _ShaderAttrName(const std::string& shaderParamName)
 {
-   return TfToken(UsdShadeTokens->inputs.GetString() + shaderParamName);
+    return TfToken(UsdShadeTokens->inputs.GetString() + shaderParamName);
 }
 
 // Adapted from UsdSchemaBase::_CreateAttr
-static UsdAttribute _SetLightPrimAttr(UsdPrim &lightPrim,
-    TfToken const &attrName, SdfValueTypeName const & typeName,
-    bool custom, SdfVariability variability, VtValue const & defaultValue, 
-    bool writeSparsely) {
+static UsdAttribute _SetLightPrimAttr(
+    UsdPrim&                lightPrim,
+    TfToken const&          attrName,
+    SdfValueTypeName const& typeName,
+    bool                    custom,
+    SdfVariability          variability,
+    VtValue const&          defaultValue,
+    bool                    writeSparsely)
+{
 
     const TfToken& attrToken = _ShaderAttrName(attrName);
 
-    if (writeSparsely && !custom){
+    if (writeSparsely && !custom) {
         UsdAttribute attr = lightPrim.GetAttribute(attrToken);
-        VtValue fallback;
-        if (defaultValue.IsEmpty() ||
-            (!attr.HasAuthoredValue()
-             && attr.Get(&fallback)
-             && fallback == defaultValue)){
+        VtValue      fallback;
+        if (defaultValue.IsEmpty()
+            || (!attr.HasAuthoredValue() && attr.Get(&fallback) && fallback == defaultValue)) {
             return attr;
         }
     }
-    UsdAttribute attr(lightPrim.CreateAttribute(attrToken, typeName, custom,
-                variability));
+    UsdAttribute attr(lightPrim.CreateAttribute(attrToken, typeName, custom, variability));
     if (attr && !defaultValue.IsEmpty()) {
         attr.Set(defaultValue);
     }
@@ -582,15 +584,13 @@ static UsdAttribute _SetLightPrimAttr(UsdPrim &lightPrim,
 // AOV LIGHT
 static bool _WriteAovLight(const MFnDependencyNode& depFn, UsdLuxLight& lightSchema)
 {
-    //Early out
-    UsdPrim lightPrim = lightSchema.GetPrim();
-    static const TfType& usdSchemaBase = 
-        TfType::FindByName(_tokens->UsdSchemaBase);
-    static const TfType& pxrAovLightType = 
-        usdSchemaBase.FindDerivedByName(_tokens->AovLightMayaTypeName);
+    // Early out
+    UsdPrim              lightPrim = lightSchema.GetPrim();
+    static const TfType& usdSchemaBase = TfType::FindByName(_tokens->UsdSchemaBase);
+    static const TfType& pxrAovLightType
+        = usdSchemaBase.FindDerivedByName(_tokens->AovLightMayaTypeName);
 
-    const TfType& lightType = 
-        usdSchemaBase.FindDerivedByName(lightPrim.GetTypeName());
+    const TfType& lightType = usdSchemaBase.FindDerivedByName(lightPrim.GetTypeName());
     if (!lightType.IsA(pxrAovLightType)) {
         return false;
     }
@@ -609,9 +609,14 @@ static bool _WriteAovLight(const MFnDependencyNode& depFn, UsdLuxLight& lightSch
         if (status != MS::kSuccess) {
             return false;
         }
-        _SetLightPrimAttr(lightPrim, _tokens->AovNamePlugName, 
-                SdfValueTypeNames->String, /* custom */ false, 
-                SdfVariabilityVarying, VtValue(mayaAovName.asChar()), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->AovNamePlugName,
+            SdfValueTypeNames->String,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaAovName.asChar()),
+            true);
     }
 
     // In Primary Hit.
@@ -626,9 +631,14 @@ static bool _WriteAovLight(const MFnDependencyNode& depFn, UsdLuxLight& lightSch
         if (status != MS::kSuccess) {
             return false;
         }
-        _SetLightPrimAttr(lightPrim, _tokens->InPrimaryHitPlugName, 
-                SdfValueTypeNames->Bool, /* custom */ false, 
-                SdfVariabilityVarying, VtValue(mayaInPrimaryHit), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->InPrimaryHitPlugName,
+            SdfValueTypeNames->Bool,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaInPrimaryHit),
+            true);
     }
 
     // In Reflection.
@@ -643,9 +653,14 @@ static bool _WriteAovLight(const MFnDependencyNode& depFn, UsdLuxLight& lightSch
         if (status != MS::kSuccess) {
             return false;
         }
-        _SetLightPrimAttr(lightPrim, _tokens->InReflectionPlugName, 
-                SdfValueTypeNames->Bool, /* custom */ false, 
-                SdfVariabilityVarying, VtValue(mayaInReflection), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->InReflectionPlugName,
+            SdfValueTypeNames->Bool,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaInReflection),
+            true);
     }
 
     // In Refraction.
@@ -661,9 +676,14 @@ static bool _WriteAovLight(const MFnDependencyNode& depFn, UsdLuxLight& lightSch
             return false;
         }
 
-        _SetLightPrimAttr(lightPrim, _tokens->InRefractionPlugName, 
-            SdfValueTypeNames->Bool, /* custom */ false, SdfVariabilityVarying,
-            VtValue(mayaInRefraction), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->InRefractionPlugName,
+            SdfValueTypeNames->Bool,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaInRefraction),
+            true);
     }
 
     // Invert.
@@ -679,9 +699,14 @@ static bool _WriteAovLight(const MFnDependencyNode& depFn, UsdLuxLight& lightSch
             return false;
         }
 
-        _SetLightPrimAttr(lightPrim, _tokens->InvertPlugName, 
-                SdfValueTypeNames->Bool, /* custom */ false, 
-                SdfVariabilityVarying, VtValue(mayaInvert), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->InvertPlugName,
+            SdfValueTypeNames->Bool,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaInvert),
+            true);
     }
 
     // On Volume Boundaries.
@@ -698,9 +723,14 @@ static bool _WriteAovLight(const MFnDependencyNode& depFn, UsdLuxLight& lightSch
             return false;
         }
 
-        _SetLightPrimAttr(lightPrim, _tokens->OnVolumeBoundariesPlugName, 
-                SdfValueTypeNames->Bool, /* custom */ false, 
-                SdfVariabilityVarying, VtValue(mayaOnVolumeBoundaries), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->OnVolumeBoundariesPlugName,
+            SdfValueTypeNames->Bool,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaOnVolumeBoundaries),
+            true);
     }
 
     // Use Color.
@@ -716,9 +746,14 @@ static bool _WriteAovLight(const MFnDependencyNode& depFn, UsdLuxLight& lightSch
             return false;
         }
 
-        _SetLightPrimAttr(lightPrim, _tokens->UseColorPlugName, SdfValueTypeNames->Bool, 
-                /* custom */ false, SdfVariabilityVarying, 
-                VtValue(mayaUseColor), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->UseColorPlugName,
+            SdfValueTypeNames->Bool,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaUseColor),
+            true);
     }
 
     // Use Throughput.
@@ -734,9 +769,14 @@ static bool _WriteAovLight(const MFnDependencyNode& depFn, UsdLuxLight& lightSch
             return false;
         }
 
-        _SetLightPrimAttr(lightPrim, _tokens->UseThroughputPlugName, 
-                SdfValueTypeNames->Bool, /* custom */ false, 
-                SdfVariabilityVarying, VtValue(mayaUseThroughput), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->UseThroughputPlugName,
+            SdfValueTypeNames->Bool,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaUseThroughput),
+            true);
     }
 
     return true;
@@ -745,14 +785,12 @@ static bool _WriteAovLight(const MFnDependencyNode& depFn, UsdLuxLight& lightSch
 static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& depFn)
 {
     // Early out
-    const UsdPrim& lightPrim = lightSchema.GetPrim();
-    static const TfType& usdSchemaBase = 
-        TfType::FindByName(_tokens->UsdSchemaBase);
-    static const TfType& pxrAovLightType = 
-        usdSchemaBase.FindDerivedByName(_tokens->AovLightMayaTypeName);
+    const UsdPrim&       lightPrim = lightSchema.GetPrim();
+    static const TfType& usdSchemaBase = TfType::FindByName(_tokens->UsdSchemaBase);
+    static const TfType& pxrAovLightType
+        = usdSchemaBase.FindDerivedByName(_tokens->AovLightMayaTypeName);
 
-    const TfType& lightType = 
-        usdSchemaBase.FindDerivedByName(lightPrim.GetTypeName());
+    const TfType& lightType = usdSchemaBase.FindDerivedByName(lightPrim.GetTypeName());
     if (!lightType.IsA(pxrAovLightType)) {
         return false;
     }
@@ -765,8 +803,10 @@ static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& dep
         return false;
     }
     std::string lightAovName;
-    lightPrim.GetAttribute(TfToken(UsdShadeTokens->inputs.GetString() + 
-                _tokens->AovNamePlugName.GetString())).Get(&lightAovName);
+    lightPrim
+        .GetAttribute(
+            TfToken(UsdShadeTokens->inputs.GetString() + _tokens->AovNamePlugName.GetString()))
+        .Get(&lightAovName);
     status = lightAovNamePlug.setValue(MString(lightAovName.c_str()));
     if (status != MS::kSuccess) {
         return false;
@@ -778,8 +818,7 @@ static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& dep
         return false;
     }
     bool lightInPrimaryHit = true;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->InPrimaryHitPlugName))
-        .Get(&lightInPrimaryHit);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->InPrimaryHitPlugName)).Get(&lightInPrimaryHit);
     status = lightInPrimaryHitPlug.setValue(lightInPrimaryHit);
     if (status != MS::kSuccess) {
         return false;
@@ -791,8 +830,7 @@ static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& dep
         return false;
     }
     bool lightInReflection = true;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->InReflectionPlugName))
-        .Get(&lightInReflection);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->InReflectionPlugName)).Get(&lightInReflection);
     status = lightInReflectionPlug.setValue(lightInReflection);
     if (status != MS::kSuccess) {
         return false;
@@ -804,8 +842,7 @@ static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& dep
         return false;
     }
     bool lightInRefraction = true;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->InRefractionPlugName))
-        .Get(&lightInRefraction);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->InRefractionPlugName)).Get(&lightInRefraction);
     status = lightInRefractionPlug.setValue(lightInRefraction);
     if (status != MS::kSuccess) {
         return false;
@@ -817,8 +854,7 @@ static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& dep
         return false;
     }
     bool lightInvert = true;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->InvertPlugName))
-        .Get(&lightInvert);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->InvertPlugName)).Get(&lightInvert);
     status = lightInvertPlug.setValue(lightInvert);
     if (status != MS::kSuccess) {
         return false;
@@ -844,8 +880,7 @@ static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& dep
         return false;
     }
     bool lightUseColor = true;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->UseColorPlugName))
-        .Get(&lightUseColor);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->UseColorPlugName)).Get(&lightUseColor);
     status = lightUseColorPlug.setValue(lightUseColor);
     if (status != MS::kSuccess) {
         return false;
@@ -867,15 +902,13 @@ static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& dep
 // ENVDAY LIGHT
 static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLight& lightSchema)
 {
-    //Early out
-    UsdPrim lightPrim = lightSchema.GetPrim();
-    static const TfType& usdSchemaBase = 
-        TfType::FindByName(_tokens->UsdSchemaBase);
-    static const TfType& pxrEnvDayLightType = 
-        usdSchemaBase.FindDerivedByName(_tokens->EnvDayLightMayaTypeName);
+    // Early out
+    UsdPrim              lightPrim = lightSchema.GetPrim();
+    static const TfType& usdSchemaBase = TfType::FindByName(_tokens->UsdSchemaBase);
+    static const TfType& pxrEnvDayLightType
+        = usdSchemaBase.FindDerivedByName(_tokens->EnvDayLightMayaTypeName);
 
-    const TfType& lightType = 
-        usdSchemaBase.FindDerivedByName(lightPrim.GetTypeName());
+    const TfType& lightType = usdSchemaBase.FindDerivedByName(lightPrim.GetTypeName());
     if (!lightType.IsA(pxrEnvDayLightType)) {
         return false;
     }
@@ -894,9 +927,14 @@ static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLight& light
         if (status != MS::kSuccess) {
             return false;
         }
-        _SetLightPrimAttr(lightPrim, _tokens->DayPlugName, 
-                SdfValueTypeNames->Int, /* custom */ false,
-                SdfVariabilityVarying, VtValue(mayaDay), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->DayPlugName,
+            SdfValueTypeNames->Int,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaDay),
+            true);
     }
 
     // Haziness.
@@ -912,9 +950,14 @@ static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLight& light
             return false;
         }
 
-        _SetLightPrimAttr(lightPrim, _tokens->HazinessPlugName, 
-                SdfValueTypeNames->Float, /* custom */ false,
-                SdfVariabilityVarying, VtValue(mayaHaziness), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->HazinessPlugName,
+            SdfValueTypeNames->Float,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaHaziness),
+            true);
     }
 
     // Hour.
@@ -930,9 +973,14 @@ static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLight& light
             return false;
         }
 
-        _SetLightPrimAttr(lightPrim, _tokens->HourPlugName, 
-                SdfValueTypeNames->Float, /* custom */ false,
-                SdfVariabilityVarying, VtValue(mayaHour), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->HourPlugName,
+            SdfValueTypeNames->Float,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaHour),
+            true);
     }
 
     // Latitude.
@@ -948,9 +996,14 @@ static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLight& light
             return false;
         }
 
-        _SetLightPrimAttr(lightPrim, _tokens->LatitudePlugName, 
-                SdfValueTypeNames->Float, /* custom */ false,
-                SdfVariabilityVarying, VtValue(mayaLatitude), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->LatitudePlugName,
+            SdfValueTypeNames->Float,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaLatitude),
+            true);
     }
 
     // Longitude.
@@ -966,9 +1019,14 @@ static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLight& light
             return false;
         }
 
-        _SetLightPrimAttr(lightPrim, _tokens->LongitudePlugName, 
-                SdfValueTypeNames->Float, /* custom */ false,
-                SdfVariabilityVarying, VtValue(mayaLongitude), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->LongitudePlugName,
+            SdfValueTypeNames->Float,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaLongitude),
+            true);
     }
 
     // Month.
@@ -984,9 +1042,14 @@ static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLight& light
             return false;
         }
 
-        _SetLightPrimAttr(lightPrim, _tokens->MonthPlugName, 
-                SdfValueTypeNames->Int, /* custom */ false,
-                SdfVariabilityVarying, VtValue(mayaMonth), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->MonthPlugName,
+            SdfValueTypeNames->Int,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaMonth),
+            true);
     }
 
     // Sky tint.
@@ -1001,9 +1064,14 @@ static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLight& light
             skyTintPlug.child(1).asFloat(),
             skyTintPlug.child(2).asFloat());
 
-        _SetLightPrimAttr(lightPrim, _tokens->SkyTintPlugName, 
-                SdfValueTypeNames->Color3f, /* custom */ false,
-                SdfVariabilityVarying, VtValue(mayaSkyTint), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->SkyTintPlugName,
+            SdfValueTypeNames->Color3f,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaSkyTint),
+            true);
     }
 
     // Sun direction.
@@ -1018,9 +1086,14 @@ static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLight& light
             sunDirectionPlug.child(1).asFloat(),
             sunDirectionPlug.child(2).asFloat());
 
-        _SetLightPrimAttr(lightPrim, _tokens->SunDirectionPlugName, 
-                SdfValueTypeNames->Vector3f, /* custom */ false,
-                SdfVariabilityVarying, VtValue(mayaSunDirection), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->SunDirectionPlugName,
+            SdfValueTypeNames->Vector3f,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaSunDirection),
+            true);
     }
 
     // Sun size.
@@ -1036,9 +1109,14 @@ static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLight& light
             return false;
         }
 
-        _SetLightPrimAttr(lightPrim, _tokens->SunSizePlugName, 
-                SdfValueTypeNames->Float, /* custom */ false,
-                SdfVariabilityVarying, VtValue(mayaSunSize), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->SunSizePlugName,
+            SdfValueTypeNames->Float,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaSunSize),
+            true);
     }
 
     // Sun tint.
@@ -1053,9 +1131,14 @@ static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLight& light
             sunTintPlug.child(1).asFloat(),
             sunTintPlug.child(2).asFloat());
 
-        _SetLightPrimAttr(lightPrim, _tokens->SunTintPlugName, 
-                SdfValueTypeNames->Color3f, /* custom */ false,
-                SdfVariabilityVarying, VtValue(mayaSunTint), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->SunTintPlugName,
+            SdfValueTypeNames->Color3f,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaSunTint),
+            true);
     }
 
     // Year.
@@ -1071,9 +1154,14 @@ static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLight& light
             return false;
         }
 
-        _SetLightPrimAttr(lightPrim, _tokens->YearPlugName, 
-                SdfValueTypeNames->Int, /* custom */ false,
-                SdfVariabilityVarying, VtValue(mayaYear), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->YearPlugName,
+            SdfValueTypeNames->Int,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaYear),
+            true);
     }
 
     // Zone.
@@ -1089,9 +1177,14 @@ static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLight& light
             return false;
         }
 
-        _SetLightPrimAttr(lightPrim, _tokens->ZonePlugName, 
-                SdfValueTypeNames->Float, /* custom */ false,
-                SdfVariabilityVarying, VtValue(mayaZone), true);
+        _SetLightPrimAttr(
+            lightPrim,
+            _tokens->ZonePlugName,
+            SdfValueTypeNames->Float,
+            /* custom */ false,
+            SdfVariabilityVarying,
+            VtValue(mayaZone),
+            true);
     }
 
     return true;
@@ -1099,14 +1192,12 @@ static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLight& light
 
 static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& depFn)
 {
-    const UsdPrim& lightPrim = lightSchema.GetPrim();
-    static const TfType& usdSchemaBase = 
-        TfType::FindByName(_tokens->UsdSchemaBase);
-    static const TfType& pxrEnvDayLightType = 
-        usdSchemaBase.FindDerivedByName(_tokens->EnvDayLightMayaTypeName);
+    const UsdPrim&       lightPrim = lightSchema.GetPrim();
+    static const TfType& usdSchemaBase = TfType::FindByName(_tokens->UsdSchemaBase);
+    static const TfType& pxrEnvDayLightType
+        = usdSchemaBase.FindDerivedByName(_tokens->EnvDayLightMayaTypeName);
 
-    const TfType& lightType = 
-        usdSchemaBase.FindDerivedByName(lightPrim.GetTypeName());
+    const TfType& lightType = usdSchemaBase.FindDerivedByName(lightPrim.GetTypeName());
     if (!lightType.IsA(pxrEnvDayLightType)) {
         return false;
     }
@@ -1119,8 +1210,7 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     int lightDay = 1;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->DayPlugName))
-        .Get(&lightDay);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->DayPlugName)).Get(&lightDay);
     status = lightDayPlug.setValue(lightDay);
     if (status != MS::kSuccess) {
         return false;
@@ -1132,8 +1222,7 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     float lightHaziness = 2.0f;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->HazinessPlugName))
-        .Get(&lightHaziness);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->HazinessPlugName)).Get(&lightHaziness);
     status = lightHazinessPlug.setValue(lightHaziness);
     if (status != MS::kSuccess) {
         return false;
@@ -1145,8 +1234,7 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     float lightHour = 14.633333f;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->HourPlugName))
-        .Get(&lightHour);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->HourPlugName)).Get(&lightHour);
     status = lightHourPlug.setValue(lightHour);
     if (status != MS::kSuccess) {
         return false;
@@ -1158,8 +1246,7 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     float lightLatitude = 47.602f;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->LatitudePlugName))
-        .Get(&lightLatitude);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->LatitudePlugName)).Get(&lightLatitude);
     status = lightLatitudePlug.setValue(lightLatitude);
     if (status != MS::kSuccess) {
         return false;
@@ -1171,8 +1258,7 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     float lightLongitude = -122.332f;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->LongitudePlugName))
-        .Get(&lightLongitude);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->LongitudePlugName)).Get(&lightLongitude);
     status = lightLongitudePlug.setValue(lightLongitude);
     if (status != MS::kSuccess) {
         return false;
@@ -1184,8 +1270,7 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     int lightMonth = 0;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->MonthPlugName))
-        .Get(&lightMonth);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->MonthPlugName)).Get(&lightMonth);
     status = lightMonthPlug.setValue(lightMonth);
     if (status != MS::kSuccess) {
         return false;
@@ -1197,8 +1282,7 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     GfVec3f lightSkyTint(1.0f);
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->SkyTintPlugName))
-        .Get(&lightSkyTint);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->SkyTintPlugName)).Get(&lightSkyTint);
     status = lightSkyTintPlug.child(0).setValue(lightSkyTint[0]);
     status = lightSkyTintPlug.child(1).setValue(lightSkyTint[1]);
     status = lightSkyTintPlug.child(2).setValue(lightSkyTint[2]);
@@ -1212,8 +1296,7 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     GfVec3f lightSunDirection(0.0f, 0.0f, 1.0f);
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->SunDirectionPlugName))
-        .Get(&lightSunDirection);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->SunDirectionPlugName)).Get(&lightSunDirection);
     status = lightSunDirectionPlug.child(0).setValue(lightSunDirection[0]);
     status = lightSunDirectionPlug.child(1).setValue(lightSunDirection[1]);
     status = lightSunDirectionPlug.child(2).setValue(lightSunDirection[2]);
@@ -1227,8 +1310,7 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     float lightSunSize = 1.0f;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->SunSizePlugName))
-        .Get(&lightSunSize);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->SunSizePlugName)).Get(&lightSunSize);
     status = lightSunSizePlug.setValue(lightSunSize);
     if (status != MS::kSuccess) {
         return false;
@@ -1240,8 +1322,7 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     GfVec3f lightSunTint(1.0f);
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->SunTintPlugName))
-        .Get(&lightSunTint);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->SunTintPlugName)).Get(&lightSunTint);
     status = lightSunTintPlug.child(0).setValue(lightSunTint[0]);
     status = lightSunTintPlug.child(1).setValue(lightSunTint[1]);
     status = lightSunTintPlug.child(2).setValue(lightSunTint[2]);
@@ -1255,8 +1336,7 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     int lightYear = 2015;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->YearPlugName))
-        .Get(&lightYear);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->YearPlugName)).Get(&lightYear);
     status = lightYearPlug.setValue(lightYear);
     if (status != MS::kSuccess) {
         return false;
@@ -1268,8 +1348,7 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     float lightZone = -8.0f;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->ZonePlugName))
-        .Get(&lightZone);
+    lightPrim.GetAttribute(_ShaderAttrName(_tokens->ZonePlugName)).Get(&lightZone);
     status = lightZonePlug.setValue(lightZone);
     return status == MS::kSuccess;
 }
@@ -1694,8 +1773,7 @@ _DefineUsdLuxLightForMayaLight(const MFnDependencyNode& depFn, UsdMayaPrimWriter
     const TfToken mayaLightTypeToken(mayaLightTypeName.asChar());
 
     if (mayaLightTypeToken == _tokens->AovLightMayaTypeName) {
-        lightSchema = UsdLuxLight(stage->DefinePrim(authorPath, 
-                _tokens->AovLightMayaTypeName));
+        lightSchema = UsdLuxLight(stage->DefinePrim(authorPath, _tokens->AovLightMayaTypeName));
     } else if (mayaLightTypeToken == _tokens->CylinderLightMayaTypeName) {
         lightSchema = UsdLuxCylinderLight::Define(stage, authorPath);
     } else if (mayaLightTypeToken == _tokens->DiskLightMayaTypeName) {
@@ -1705,8 +1783,7 @@ _DefineUsdLuxLightForMayaLight(const MFnDependencyNode& depFn, UsdMayaPrimWriter
     } else if (mayaLightTypeToken == _tokens->DomeLightMayaTypeName) {
         lightSchema = UsdLuxDomeLight::Define(stage, authorPath);
     } else if (mayaLightTypeToken == _tokens->EnvDayLightMayaTypeName) {
-        lightSchema = UsdLuxLight(stage->DefinePrim(authorPath, 
-                _tokens->EnvDayLightMayaTypeName));
+        lightSchema = UsdLuxLight(stage->DefinePrim(authorPath, _tokens->EnvDayLightMayaTypeName));
     } else if (mayaLightTypeToken == _tokens->GeometryLightMayaTypeName) {
         lightSchema = UsdLuxGeometryLight::Define(stage, authorPath);
     } else if (mayaLightTypeToken == _tokens->RectLightMayaTypeName) {
@@ -1770,15 +1847,13 @@ static TfToken _GetMayaTypeTokenForUsdLuxLight(const UsdLuxLight& lightSchema)
 {
     const UsdPrim& lightPrim = lightSchema.GetPrim();
 
-    static const TfType& usdSchemaBase = 
-        TfType::FindByName(_tokens->UsdSchemaBase);
-    static const TfType& pxrAovLightType = 
-        usdSchemaBase.FindDerivedByName(_tokens->AovLightMayaTypeName);
-    static const TfType& pxrEnvDayLightType = 
-        usdSchemaBase.FindDerivedByName(_tokens->EnvDayLightMayaTypeName);
+    static const TfType& usdSchemaBase = TfType::FindByName(_tokens->UsdSchemaBase);
+    static const TfType& pxrAovLightType
+        = usdSchemaBase.FindDerivedByName(_tokens->AovLightMayaTypeName);
+    static const TfType& pxrEnvDayLightType
+        = usdSchemaBase.FindDerivedByName(_tokens->EnvDayLightMayaTypeName);
 
-    const TfType& lightType = 
-        usdSchemaBase.FindDerivedByName(lightPrim.GetTypeName());
+    const TfType& lightType = usdSchemaBase.FindDerivedByName(lightPrim.GetTypeName());
 
     if (lightType.IsA(pxrAovLightType)) {
         return _tokens->AovLightMayaTypeName;

--- a/lib/usd/translators/lightReader.cpp
+++ b/lib/usd/translators/lightReader.cpp
@@ -16,16 +16,6 @@
 #include <mayaUsd/fileio/primReaderRegistry.h>
 #include <mayaUsd/fileio/translators/translatorLight.h>
 
-#include <pxr/usd/usdLux/cylinderLight.h>
-#include <pxr/usd/usdLux/diskLight.h>
-#include <pxr/usd/usdLux/distantLight.h>
-#include <pxr/usd/usdLux/domeLight.h>
-#include <pxr/usd/usdLux/geometryLight.h>
-#include <pxr/usd/usdLux/rectLight.h>
-#include <pxr/usd/usdLux/sphereLight.h>
-#include <pxr/usd/usdRi/pxrAovLight.h>
-#include <pxr/usd/usdRi/pxrEnvDayLight.h>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 // Build variable used to import usd builtin

--- a/lib/usd/translators/plugInfo.json
+++ b/lib/usd/translators/plugInfo.json
@@ -18,8 +18,6 @@
                 "UsdLuxGeometryLight",
                 "UsdLuxRectLight",
                 "UsdLuxSphereLight",
-                "UsdRiPxrAovLight",
-                "UsdRiPxrEnvDayLight",
                 "UsdShadeMaterial",
                 "UsdSkelRoot",
                 "UsdSkelSkeleton",

--- a/lib/usd/translators/scopeReader.cpp
+++ b/lib/usd/translators/scopeReader.cpp
@@ -18,7 +18,6 @@
 
 #include <pxr/pxr.h>
 #include <pxr/usd/usd/prim.h>
-#include <pxr/usd/usdGeom/scope.h>
 #include <pxr/usd/usdShade/connectableAPI.h>
 
 #include <maya/MObject.h>

--- a/lib/usd/translators/xformReader.cpp
+++ b/lib/usd/translators/xformReader.cpp
@@ -18,7 +18,6 @@
 
 #include <pxr/pxr.h>
 #include <pxr/usd/usd/prim.h>
-#include <pxr/usd/usdGeom/xform.h>
 
 #include <maya/MObject.h>
 

--- a/test/lib/usd/translators/UsdImportRfMLightTest/RfMLightsTest.usda
+++ b/test/lib/usd/translators/UsdImportRfMLightTest/RfMLightsTest.usda
@@ -201,14 +201,14 @@ def Xform "RfMLightsTest" (
             prepend apiSchemas = ["ShapingAPI", "ShadowAPI"]
         )
         {
-            string aovName = "testAovName"
-            bool inPrimaryHit = 0
-            bool inReflection = 1
-            bool inRefraction = 1
-            bool invert = 1
-            bool onVolumeBoundaries = 0
-            bool useColor = 1
-            bool useThroughput = 0
+            string inputs:aovName = "testAovName"
+            bool inputs:inPrimaryHit = 0
+            bool inputs:inReflection = 1
+            bool inputs:inRefraction = 1
+            bool inputs:invert = 1
+            bool inputs:onVolumeBoundaries = 0
+            bool inputs:useColor = 1
+            bool inputs:useThroughput = 0
             double3 xformOp:translate = (8, 8, 8)
             uniform token[] xformOpOrder = ["xformOp:translate"]
         }
@@ -217,24 +217,24 @@ def Xform "RfMLightsTest" (
             prepend apiSchemas = ["ShapingAPI", "ShadowAPI"]
         )
         {
-            int day = 9
-            float haziness = 1.9
-            float hour = 9.9
+            int inputs:day = 9
+            float inputs:haziness = 1.9
+            float inputs:hour = 9.9
             float inputs:diffuse = 1.9
             float inputs:exposure = 0.9
             float inputs:intensity = 1.9
             float inputs:specular = 1.9
-            float latitude = 90
-            float longitude = -90
-            int month = 9
-            color3f skyTint = (0.9, 0.9, 0.9)
-            vector3f sunDirection = (0, 0, 0.9)
-            float sunSize = 0.9
-            color3f sunTint = (0.9, 0.9, 0.9)
+            float inputs:latitude = 90
+            float inputs:longitude = -90
+            int inputs:month = 9
+            color3f inputs:skyTint = (0.9, 0.9, 0.9)
+            vector3f inputs:sunDirection = (0, 0, 0.9)
+            float inputs:sunSize = 0.9
+            color3f inputs:sunTint = (0.9, 0.9, 0.9)
             double3 xformOp:translate = (9, 9, 9)
             uniform token[] xformOpOrder = ["xformOp:translate"]
-            int year = 2019
-            float zone = 9
+            int inputs:year = 2019
+            float inputs:zone = 9
         }
     }
 

--- a/test/lib/usd/translators/testUsdExportRfMLight.py
+++ b/test/lib/usd/translators/testUsdExportRfMLight.py
@@ -19,6 +19,7 @@ import os
 import unittest
 
 from pxr import Gf
+from pxr import Tf
 from pxr import Usd
 from pxr import UsdGeom
 from pxr import UsdLux
@@ -93,10 +94,10 @@ class testUsdExportRfMLight(unittest.TestCase):
             self.assertTrue(lightPrim.IsA(UsdLux.SphereLight))
             testNumber = 7
         elif lightTypeName == 'AovLight':
-            self.assertTrue(lightPrim.IsA(UsdRi.PxrAovLight))
+            self.assertTrue(lightPrim.GetTypeName(), "PxrAovLight")
             testNumber = 8
         elif lightTypeName == 'EnvDayLight':
-            self.assertTrue(lightPrim.IsA(UsdRi.PxrEnvDayLight))
+            self.assertTrue(lightPrim.GetTypeName(), "PxrEnvDayLight")
             testNumber = 9
         else:
             raise NotImplementedError('Invalid light type %s' % lightTypeName)
@@ -211,36 +212,39 @@ class testUsdExportRfMLight(unittest.TestCase):
         lightPrim = self._stage.GetPrimAtPath(lightPrimPath)
         self.assertTrue(lightPrim)
 
-        aovLight = UsdRi.PxrAovLight(lightPrim)
+        aovLight = self._stage.DefinePrim(lightPrimPath, "PxrAovLight")
         self.assertTrue(aovLight)
 
         expectedAovName = 'testAovName'
-        self.assertEqual(aovLight.GetAovNameAttr().Get(), expectedAovName)
+        self.assertEqual(aovLight.GetAttribute("inputs:aovName").Get(), 
+                expectedAovName)
 
         expectedInPrimaryHit = False
-        self.assertEqual(aovLight.GetInPrimaryHitAttr().Get(),
+        self.assertEqual(aovLight.GetAttribute("inputs:inPrimaryHit").Get(),
             expectedInPrimaryHit)
 
         expectedInReflection = True
-        self.assertEqual(aovLight.GetInReflectionAttr().Get(),
+        self.assertEqual(aovLight.GetAttribute("inputs:inReflection").Get(),
             expectedInReflection)
 
         expectedInRefraction = True
-        self.assertEqual(aovLight.GetInRefractionAttr().Get(),
+        self.assertEqual(aovLight.GetAttribute("inputs:inRefraction").Get(),
             expectedInRefraction)
 
         expectedInvert = True
-        self.assertEqual(aovLight.GetInvertAttr().Get(), expectedInvert)
+        self.assertEqual(aovLight.GetAttribute("inputs:invert").Get(), 
+                expectedInvert)
 
         expectedOnVolumeBoundaries = False
-        self.assertEqual(aovLight.GetOnVolumeBoundariesAttr().Get(),
+        self.assertEqual(aovLight.GetAttribute("inputs:onVolumeBoundaries").Get(),
             expectedOnVolumeBoundaries)
 
         expectedUseColor = True
-        self.assertEqual(aovLight.GetUseColorAttr().Get(), expectedUseColor)
+        self.assertEqual(aovLight.GetAttribute("inputs:useColor").Get(), 
+                expectedUseColor)
 
         expectedUseThroughput = False
-        self.assertEqual(aovLight.GetUseThroughputAttr().Get(),
+        self.assertEqual(aovLight.GetAttribute("inputs:useThroughput").Get(),
             expectedUseThroughput)
 
     def _ValidateUsdRiPxrEnvDayLight(self):
@@ -248,52 +252,53 @@ class testUsdExportRfMLight(unittest.TestCase):
         lightPrim = self._stage.GetPrimAtPath(lightPrimPath)
         self.assertTrue(lightPrim)
 
-        envDayLight = UsdRi.PxrEnvDayLight(lightPrim)
+        envDayLight = self._stage.DefinePrim(lightPrimPath, "PxrEnvDayLight")
         self.assertTrue(envDayLight)
 
         expectedDay = 9
-        self.assertEqual(envDayLight.GetDayAttr().Get(), expectedDay)
+        self.assertEqual(envDayLight.GetAttribute("inputs:day").Get(), 
+                expectedDay)
 
         expectedHaziness = 1.9
-        self.assertTrue(Gf.IsClose(envDayLight.GetHazinessAttr().Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:haziness").Get(),
             expectedHaziness, 1e-6))
 
         expectedHour = 9.9
-        self.assertTrue(Gf.IsClose(envDayLight.GetHourAttr().Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:hour").Get(),
             expectedHour, 1e-6))
 
         expectedLatitude = 90.0
-        self.assertTrue(Gf.IsClose(envDayLight.GetLatitudeAttr().Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:latitude").Get(),
             expectedLatitude, 1e-6))
 
         expectedLongitude = -90.0
-        self.assertTrue(Gf.IsClose(envDayLight.GetLongitudeAttr().Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:longitude").Get(),
             expectedLongitude, 1e-6))
 
         expectedMonth = 9
-        self.assertEqual(envDayLight.GetMonthAttr().Get(), expectedMonth)
+        self.assertEqual(envDayLight.GetAttribute("inputs:month").Get(), expectedMonth)
 
         expectedSkyTint = Gf.Vec3f(0.9)
-        self.assertTrue(Gf.IsClose(envDayLight.GetSkyTintAttr().Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:skyTint").Get(),
             expectedSkyTint, 1e-6))
 
         expectedSunDirection = Gf.Vec3f(0.0, 0.0, 0.9)
-        self.assertTrue(Gf.IsClose(envDayLight.GetSunDirectionAttr().Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:sunDirection").Get(),
             expectedSunDirection, 1e-6))
 
         expectedSunSize = 0.9
-        self.assertTrue(Gf.IsClose(envDayLight.GetSunSizeAttr().Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:sunSize").Get(),
             expectedSunSize, 1e-6))
 
         expectedSunTint = Gf.Vec3f(0.9)
-        self.assertTrue(Gf.IsClose(envDayLight.GetSunTintAttr().Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:sunTint").Get(),
             expectedSunTint, 1e-6))
 
         expectedYear = 2019
-        self.assertEqual(envDayLight.GetYearAttr().Get(), expectedYear)
+        self.assertEqual(envDayLight.GetAttribute("inputs:year").Get(), expectedYear)
 
         expectedZone = 9.0
-        self.assertTrue(Gf.IsClose(envDayLight.GetZoneAttr().Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:zone").Get(),
             expectedZone, 1e-6))
 
     def _ValidateUsdLuxShapingAPI(self):


### PR DESCRIPTION
Allow usdReader function registration for TfType tokens. This should also work for C++Types since these get registered with the TfType system.

Also update RfM light and lightFilter reading and writing code to use the generic Usd APIs instead of the soon-to-be-removed and "made" codeless UsdRiPxr* APIs