### PR TITLE
[al] fix MayaReference tolerance for stage hierarchy changes

### DIFF
--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.h
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.h
@@ -52,7 +52,8 @@ struct UsdMayaTranslatorMayaReference
         const UsdPrim& prim,
         MObject&       parent,
         MString&       mayaReferencePath,
-        MString&       rigNamespaceM);
+        MString&       rigNamespaceM,
+        const bool     createNsAttr);
 
     MAYAUSD_CORE_PUBLIC
     static MStatus UnloadMayaReference(const MObject& parent);
@@ -65,6 +66,8 @@ private:
 
     static const TfToken m_namespaceName;
     static const TfToken m_referenceName;
+
+    static const char* const m_primNSAttr;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/plugin/al/translators/tests/testMayaRefStageA.usda
+++ b/plugin/al/translators/tests/testMayaRefStageA.usda
@@ -1,0 +1,11 @@
+#usda 1.0
+
+def Xform "world"
+{
+    def ALMayaReference "mayaRefPrim"
+    {
+        string mayaNamespace = "cube"
+        asset mayaReference = @./cube.ma@
+    }
+}
+

--- a/plugin/al/translators/tests/testMayaRefStageB.usda
+++ b/plugin/al/translators/tests/testMayaRefStageB.usda
@@ -1,0 +1,14 @@
+#usda 1.0
+
+def Xform "world"
+{
+    def Xform "newGroup"
+    {
+        def ALMayaReference "mayaRefPrim"
+        {
+            string mayaNamespace = "cube"
+            asset mayaReference = @./cube.ma@
+        }
+    }
+}
+

--- a/plugin/al/translators/tests/testTranslators.py
+++ b/plugin/al/translators/tests/testTranslators.py
@@ -1,6 +1,8 @@
 import unittest
 import tempfile
 import os
+import shutil
+
 import maya.cmds as mc
 import maya.mel as mel
 
@@ -131,6 +133,58 @@ class TestTranslator(unittest.TestCase):
         assertUsingMayaReferenceVariant()
         # ...and then make sure that our ref edit was preserved
         self.assertEqual(mc.getAttr('cubeNS:pCube1.translate')[0], (4.0, 5.0, 6.0))
+
+    def testMayaReference_SurvivesHierarchyChanges(self):
+        """
+        Tests that connection between MayaReference prim and maya reference does not
+        break on hierarchy changes if mayaNamespace UsdAttribute is used.
+        """
+        import AL.usdmaya
+
+        mc.file(new=1, f=1)
+
+        # copy usd file A to temporary location that can be referenced and changed.
+        tempFile = tempfile.NamedTemporaryFile(suffix=".usda", prefix="tempTestStage", delete=True)
+        tempPath = tempFile.name
+        # windows requires tempFile to be closed before it can be opened again.
+        tempFile.close()
+        try:
+            shutil.copy('./testMayaRefStageA.usda', tempPath)
+
+            # bring in stage as proxy shape
+            mc.AL_usdmaya_ProxyShapeImport(file=tempPath, name='root')
+            stage = AL.usdmaya.StageCache.Get().GetAllStages()[0]
+
+            # confirm ref is created with ns and ref node name
+            def checkOneRef():
+                self.assertEqual(1, len(mc.ls('cube:pCube1')))
+                # Note filter out "sharedRefenceNode" which is created when ref is unloaded.
+                self.assertEqual(1, len(mc.ls('*_RN', type='reference')))
+
+            checkOneRef()
+
+            # unload ref manually, and resync
+            mc.file(unloadReference='root_world_mayaRefPrim_RN')
+            # confirm ref is unloaded.
+            self.assertEqual(0, len(mc.ls('cube:pCube1')))
+            self.assertEqual(1, len(mc.ls('*_RN', type='reference')))
+
+            # save over with file B (prim at new location)
+            # this simulates pipe level updates to the shot stage.
+            shutil.copy('./testMayaRefStageB.usda', tempPath)
+
+            # resync
+            stage.Reload()
+            shapeObj = AL.usdmaya.ProxyShape.getByName('root')
+            shapeObj.resync('/')
+
+            # confirm only one ref, and is still connected
+            checkOneRef()
+
+            # check that rename happened to keep everything clean:
+            self.assertEqual(1, len(mc.ls('root_world_newGroup_mayaRefPrim_RN', type='reference')))
+        finally:
+            os.remove(tempPath)
 
     def testMesh_TranslatorExists(self):
         """


### PR DESCRIPTION
This PR tweaks the logic that is used to reconnect maya references to the nodes that load them when they become disconnected.

#### Problem

The existing behavior can fail in two cases when references are disconnected:
a.) prim is moved or renamed and the stage hierarchy changes
b.) proxyShape is moved or renamed in the maya scene

In our pipeline, a.) happens often, especially when assemblies are being worked on early on in a project. b.) won't happen often and we've locked that node, so everyone knows to leave it alone. This PR addresses a.) and builds off [pr41](https://github.com/Autodesk/maya-usd/pull/41) to allow for flexible and reliable reconnections.

#### Fix

We take the following approach to keep MayaReference prim <-> ref connections alive in various workflows.

1.) default (current behavior)
 - auto assign maya ns based on full prim path
 - auto name reference node with proxy shape full path + full prim path.
 - do match based on maya heirarchy + prim path == reference node name
 - this rigid matching ensures that you’ll never have 2 prims fighting over the same reference

2.) specify maya namespace on prim (according to current MayaReference spec):
 - reference nodes will be tagged with specified ns
 - if attr exists, do match based on RN attribute matching specified ns and proxy shape fullpath matching start of reference node name
 - pipelines/users are in charge of ensuring these ns are unique per stage
 - use this approach for a more flexible workflow where hierarchies can change in maya or usd without breaking the connection between prim and reference node
 - if a prim (with ns attr) is duplicated in maya or the same asset is referenced on a stage, users are able to make a simple usd attribute edit and modify the prim to assign a new namespace. This should be even easier with adsk plugin and ufe. They can also clear the attribute to revert matching to default behavior.
 
#### Impact

 This way pipelines can decide whether they value safe guaranteed unique connections (1) OR more adaptable and reliable connections (2). The one meaningful change would be for pipelines that are using the custom NS but would prefer to have rigid path based connection logic. I suspect that most pipelines would be able to use the flexible logic, but if that is a concern we can think that one through.

This effectively allows pipelines to revert back to the time-tested logic before pr41 but keeps the support added by pr 41 for multi proxy shape workflows.