### PR TITLE
MAYA-113212 - Revert to using shading with the V1 lighting API

### DIFF
--- a/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.cpp
+++ b/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.cpp
@@ -17,6 +17,7 @@
 
 #include <pxr/base/plug/plugin.h>
 #include <pxr/base/plug/thisPlugin.h>
+#include <pxr/base/tf/envSetting.h>
 #include <pxr/base/tf/stringUtils.h>
 #include <pxr/usdImaging/usdImaging/tokens.h>
 
@@ -32,6 +33,11 @@
 #include <vector>
 
 PXR_NAMESPACE_OPEN_SCOPE
+
+TF_DEFINE_ENV_SETTING(
+    MAYAUSD_VP2_ENABLE_V2_LIGHTING_SHADER,
+    false,
+    "This env flag allows enabling the new shading code based on the V2 light API of Maya.");
 
 TF_DEFINE_PUBLIC_TOKENS(HdVP2ShaderFragmentsTokens, MAYAUSD_CORE_PUBLIC_USD_PREVIEW_SURFACE_TOKENS);
 
@@ -353,7 +359,13 @@ MStatus HdVP2ShaderFragments::registerFragments()
     {
         const MString fragGraphName(HdVP2ShaderFragmentsTokens->SurfaceFragmentGraphName.GetText());
 #ifdef MAYA_LIGHTAPI_VERSION_2
-        const MString fragGraphFileName(_tokens->UsdPreviewSurfaceLightAPI2.GetText());
+        const bool    useV2Lighting = TfGetEnvSetting(MAYAUSD_VP2_ENABLE_V2_LIGHTING_SHADER);
+        const MString fragGraphFileName(
+            useV2Lighting ? _tokens->UsdPreviewSurfaceLightAPI2.GetText()
+                          : _tokens->UsdPreviewSurfaceLightAPI1.GetText());
+        MString shadingInfo = (useV2Lighting ? "Using V2 Lighting API" : "Using V1 Lighting API");
+        shadingInfo += " for UsdPreviewSurface shading.";
+        MGlobal::displayInfo(shadingInfo);
 #else
         const MString fragGraphFileName(_tokens->UsdPreviewSurfaceLightAPI1.GetText());
 #endif

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
@@ -72,6 +72,7 @@ foreach(script ${TEST_SCRIPT_FILES})
             "MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/lib/maya"
             "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
             "MAYA_LIGHTAPI_VERSION=${MAYA_LIGHTAPI_VERSION}"
+            "MAYAUSD_VP2_ENABLE_V2_LIGHTING_SHADER=1"
 
             # Maya uses a very old version of GLEW, so we need support for
             # pre-loading a newer version from elsewhere.


### PR DESCRIPTION
- The shading for V2 light API is still present and will be fixed shortly. It can be enabled using the MAYAUSD_VP2_ENABLE_V2_LIGHTING_SHADER env var.

Fixes a regression found with production scenes.