### PR TITLE
Fixes incorrect Schlick Fresnel for IBL lighting

### DIFF
--- a/lib/mayaUsd/render/vp2ShaderFragments/usdPreviewSurfaceLightingAPI2.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/usdPreviewSurfaceLightingAPI2.xml
@@ -347,15 +347,9 @@ evaluateLights(
     }
 
     {
-        // Calculate necessary vector information for lighting
-        vec3 Plight = vec3(0,0,0);
-        vec3 l = normalize(Plight - Peye);
-        vec3 h = normalize(e + l);
-        float EdotH = max(0.0, dot(e, h));
-
         indirectLight = evaluateIndirectLighting(diffuseColor,
                         specularColor, Neye, e,
-                        EdotH, ior, metallic, occlusion,
+                        NdotE, ior, metallic, occlusion,
                         specularRoughness, useSpecularWorkflow,
                         clearcoatAmount, clearcoatColor, 
                         clearcoatRoughness);
@@ -707,15 +701,9 @@ evaluateLights(
     }
 
     {
-        // Calculate necessary vector information for lighting
-        vec3 Plight = vec3(0,0,0);
-        vec3 l = normalize(Plight - Peye);
-        vec3 h = normalize(e + l);
-        float EdotH = max(0.0, dot(e, h));
-
         indirectLight = evaluateIndirectLighting(diffuseColor,
                         specularColor, Neye, e,
-                        EdotH, ior, metallic, occlusion,
+                        NdotE, ior, metallic, occlusion,
                         specularRoughness, useSpecularWorkflow,
                         clearcoatAmount, clearcoatColor, 
                         clearcoatRoughness);
@@ -1067,15 +1055,9 @@ evaluateLights(
     }
 
     {
-        // Calculate necessary vector information for lighting
-        float3 Plight = float3(0,0,0);
-        float3 l = normalize(Plight - Peye);
-        float3 h = normalize(e + l);
-        float EdotH = max(0.0, dot(e, h));
-
         indirectLight = evaluateIndirectLighting(diffuseColor,
                         specularColor, Neye, e,
-                        EdotH, ior, metallic, occlusion,
+                        NdotE, ior, metallic, occlusion,
                         specularRoughness, useSpecularWorkflow,
                         clearcoatAmount, clearcoatColor, 
                         clearcoatRoughness);


### PR DESCRIPTION
- Affects only Light API V2 (requires env var to activate)

For environment mapping, we assume symmetric reflection around the normal, which means the half vector H is actually equal to the normal N. The value of dot(E, H) then becomes equal to the value previously found and used for dot(N, E).

This fixes a highlight artifacts seen when looking at the Damaged Helmet asset from below as shown in this before and after image:
![IncorrectFresnel](https://user-images.githubusercontent.com/56274617/129809512-b206b681-37dc-4f1b-bc3f-d526eb0e3f59.png)
