### PR TITLE
Improperly created scene item must not crash move tool.

### DIFF
--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
@@ -278,9 +278,10 @@ Ufe::Transform3d::Ptr
 UsdTransform3dCommonAPIHandler::transform3d(const Ufe::SceneItem::Ptr& item) const
 {
     UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
-#if !defined(NDEBUG)
-    assert(usdItem);
-#endif
+
+    if (!usdItem) {
+        return nullptr;
+    }
 
     // If the prim supports the common transform API, create a common API
     // interface for it, otherwise delegate to the next handler in the chain of
@@ -294,11 +295,10 @@ Ufe::Transform3d::Ptr UsdTransform3dCommonAPIHandler::editTransform3d(
     const Ufe::SceneItem::Ptr& item UFE_V2(, const Ufe::EditTransform3dHint& hint)) const
 {
     UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
-#if !defined(NDEBUG)
+
     if (!usdItem) {
-        TF_FATAL_ERROR("Could not create common API Transform3d interface for null item.");
+        return nullptr;
     }
-#endif
 
     // If the prim supports the common transform API, create a common API
     // interface for it, otherwise delegate to the next handler in the chain of

--- a/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.cpp
@@ -159,12 +159,10 @@ Ufe::Transform3d::Ptr createEditTransform3dImp(
     std::vector<UsdGeomXformOp>::const_iterator& firstFallbackOp)
 {
     UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
-#if !defined(NDEBUG)
+
     if (!usdItem) {
-        TF_FATAL_ERROR(
-            "Could not create fallback Maya transform stack Transform3d interface for null item.");
+        return nullptr;
     }
-#endif
 
     // If the prim isn't transformable, can't create a Transform3d interface
     // for it.

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -360,7 +360,10 @@ UsdTransform3dMatrixOpHandler::transform3d(const Ufe::SceneItem::Ptr& item) cons
     // We must create a Transform3d interface to edit the whole object,
     // e.g. setting the local transformation matrix for the complete object.
     UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
-    TF_AXIOM(usdItem);
+
+    if (!usdItem) {
+        return nullptr;
+    }
 
     UsdGeomXformable xformable(usdItem->prim());
     bool             unused;
@@ -405,7 +408,10 @@ Ufe::Transform3d::Ptr UsdTransform3dMatrixOpHandler::editTransform3d(
     const Ufe::SceneItem::Ptr& item UFE_V2(, const Ufe::EditTransform3dHint& hint)) const
 {
     UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
-    TF_AXIOM(usdItem);
+
+    if (!usdItem) {
+        return nullptr;
+    }
 
     // Beware: the default UsdGeomXformOp constructor
     // https://github.com/PixarAnimationStudios/USD/blob/71b4baace2044ea4400ba802e91667f9ebe342f0/pxr/usd/usdGeom/xformOp.h#L148

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
@@ -138,12 +138,10 @@ Ufe::Transform3d::Ptr
 createTransform3d(const Ufe::SceneItem::Ptr& item, NextTransform3dFn nextTransform3dFn)
 {
     UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
-#if !defined(NDEBUG)
+
     if (!usdItem) {
-        TF_FATAL_ERROR(
-            "Could not create Maya transform stack Transform3d interface for null item.");
+        return nullptr;
     }
-#endif
 
     // If the prim isn't transformable, can't create a Transform3d interface
     // for it.

--- a/lib/mayaUsd/ufe/UsdTransform3dPointInstance.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dPointInstance.cpp
@@ -158,7 +158,11 @@ UsdTransform3dPointInstanceHandler::transform3d(const Ufe::SceneItem::Ptr& item)
 {
     UsdSceneItem::Ptr usdItem = downcast(item);
 
-    if (!usdItem || !usdItem->isPointInstance()) {
+    if (!usdItem) {
+        return nullptr;
+    }
+
+    if (!usdItem->isPointInstance()) {
         return _nextHandler->transform3d(item);
     }
 
@@ -171,9 +175,10 @@ Ufe::Transform3d::Ptr UsdTransform3dPointInstanceHandler::editTransform3d(
     const Ufe::EditTransform3dHint& hint) const
 {
     UsdSceneItem::Ptr usdItem = downcast(item);
-#if !defined(NDEBUG)
-    assert(usdItem);
-#endif
+
+    if (!usdItem) {
+        return nullptr;
+    }
 
     if (!usdItem->isPointInstance()) {
         return _nextHandler->editTransform3d(item, hint);


### PR DESCRIPTION
https://github.com/Autodesk/maya-usd/pull/1596
fixed crashing on improperly created scene items for UFE v1.  This pull request does more of the same, for UFE v2 this time.