### PR TITLE
MAYA-113009 prevent saving layers with identical names.

### DIFF
--- a/lib/usd/ui/layerEditor/saveLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.cpp
@@ -513,10 +513,10 @@ void SaveLayersDialog::onCancel() { reject(); }
 
 bool SaveLayersDialog::okToSave()
 {
-    // Files can have the same file names in complicated ways, with one files having two copies,
+    // Files can have the same file names in complicated ways, with one file having two copies,
     // another three, so we keep the exact number of copies per file path.
-    std::map<QString, int> alreadySeenPaths;
-    QStringList            existingFiles;
+    QMap<QString, int> alreadySeenPaths;
+    QStringList        existingFiles;
 
     // The anonymous layer section in the dialog can be empty.
     if (nullptr != _anonLayersWidget) {
@@ -543,10 +543,11 @@ bool SaveLayersDialog::okToSave()
 
     QStringList identicalFiles;
     int         identicalCount = 0;
-    for (const auto& pathAndCount : alreadySeenPaths) {
-        if (pathAndCount.second > 1) {
-            identicalFiles.append(pathAndCount.first);
-            identicalCount += pathAndCount.second;
+    for (const auto& path : alreadySeenPaths.keys()) {
+        const int count = alreadySeenPaths[path];
+        if (count > 1) {
+            identicalFiles.append(path);
+            identicalCount += count;
         }
     }
 

--- a/lib/usd/ui/layerEditor/saveLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.cpp
@@ -513,25 +513,57 @@ void SaveLayersDialog::onCancel() { reject(); }
 
 bool SaveLayersDialog::okToSave()
 {
-    int         i, count;
-    QStringList existingFiles;
+    // Files can have the same file names in complicated ways, with one files having two copies,
+    // another three, so we keep the exact number of copies per file path.
+    std::map<QString, int> alreadySeenPaths;
+    QStringList            existingFiles;
 
     // The anonymous layer section in the dialog can be empty.
     if (nullptr != _anonLayersWidget) {
         QLayout* anonLayout = _anonLayersWidget->layout();
-        for (i = 0, count = anonLayout->count(); i < count; ++i) {
+        for (int i = 0, count = anonLayout->count(); i < count; ++i) {
             auto row = dynamic_cast<SaveLayerPathRow*>(anonLayout->itemAt(i)->widget());
             if (nullptr == row)
                 continue;
 
             QString path = row->pathToSaveAs();
             if (!path.isEmpty()) {
+                if (alreadySeenPaths.count(path) > 0) {
+                    alreadySeenPaths[path] += 1;
+                } else {
+                    alreadySeenPaths[path] = 1;
+                }
                 QFileInfo fInfo(path);
                 if (fInfo.exists()) {
                     existingFiles.append(path);
                 }
             }
         }
+    }
+
+    QStringList identicalFiles;
+    int         identicalCount = 0;
+    for (const auto& pathAndCount : alreadySeenPaths) {
+        if (pathAndCount.second > 1) {
+            identicalFiles.append(pathAndCount.first);
+            identicalCount += pathAndCount.second;
+        }
+    }
+
+    if (identicalCount > 0) {
+        MString errorMsg;
+        MString count;
+        count = identicalCount;
+        errorMsg.format(
+            StringResources::getAsMString(StringResources::kSaveAnonymousIdenticalFiles), count);
+
+        warningDialog(
+            StringResources::getAsQString(StringResources::kSaveAnonymousIdenticalFilesTitle),
+            MQtUtil::toQString(errorMsg),
+            &identicalFiles,
+            QMessageBox::Icon::Critical);
+
+        return false;
     }
 
     if (!existingFiles.isEmpty()) {

--- a/lib/usd/ui/layerEditor/stringResources.h
+++ b/lib/usd/ui/layerEditor/stringResources.h
@@ -99,6 +99,8 @@ const auto kSaveAnonymousLayersErrorsMsg { create("kSaveAnonymousLayersErrorsMsg
 const auto kSaveAnonymousLayersErrors    { create("kSaveAnonymousLayersErrors", "Layer ^1s could not be saved to: ^2s")};
 const auto kSaveAnonymousConfirmOverwriteTitle { create("kSaveAnonymousConfirmOverwriteTitle", "Confirm Overwrite")};
 const auto kSaveAnonymousConfirmOverwrite { create("kSaveAnonymousConfirmOverwrite", "^1s file(s) already exist and will be overwritten.  Do you want to continue?")};
+const auto kSaveAnonymousIdenticalFilesTitle { create("kSaveAnonymousIdenticalFilesTitle", "Identical Names Error")};
+const auto kSaveAnonymousIdenticalFiles { create("kSaveAnonymousIdenticalFiles", "^1s files have identical file names and prevent correct saving.  Please select different file names for each layer. Here is the list of identical file names:<br>")};
 
 const auto kSaveLayerUsdFileFormatAnn    { create("kSaveLayerUsdFileFormatAnn", "Select whether the .usd file is written out in binary or ASCII. You can save a file in .usdc (binary) or .usda (ASCII) format. Manually entering a file name with an extension overrides the selection in this drop-down menu.") };
 const auto kSaveLayerUsdFileFormatSbm    { create("kSaveLayerUsdFileFormatSbm", "Select whether the .usd file is written out in binary or ASCII") };


### PR DESCRIPTION
If one or more layers have identical file names, prevent saving and tell the user about the identical names.