### PR TITLE
Update RfMLight translators to use codeless schemas

### DIFF
--- a/lib/mayaUsd/fileio/translators/translatorRfMLight.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorRfMLight.cpp
@@ -63,7 +63,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 // clang-format off
 TF_DEFINE_PRIVATE_TOKENS(
     _tokens,
-    
+
     ((UsdSchemaBase, "UsdSchemaBase"))
 
     // RenderMan for Maya light types.
@@ -552,6 +552,12 @@ static inline TfToken _ShaderAttrName(const std::string& shaderParamName)
     return TfToken(UsdShadeTokens->inputs.GetString() + shaderParamName);
 }
 
+static inline std::string _PrefixRiLightAttrNamespace(const std::string& shaderParamName)
+{
+    static const std::string& riLightNS = "ri:light:";
+    return riLightNS + shaderParamName;
+}
+
 // Adapted from UsdSchemaBase::_CreateAttr
 static UsdAttribute _SetLightPrimAttr(
     UsdPrim&                lightPrim,
@@ -563,7 +569,7 @@ static UsdAttribute _SetLightPrimAttr(
     bool                    writeSparsely)
 {
 
-    const TfToken& attrToken = _ShaderAttrName(attrName);
+    const TfToken& attrToken = _ShaderAttrName(_PrefixRiLightAttrNamespace(attrName));
 
     if (writeSparsely && !custom) {
         UsdAttribute attr = lightPrim.GetAttribute(attrToken);
@@ -803,9 +809,7 @@ static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& dep
         return false;
     }
     std::string lightAovName;
-    lightPrim
-        .GetAttribute(
-            TfToken(UsdShadeTokens->inputs.GetString() + _tokens->AovNamePlugName.GetString()))
+    lightPrim.GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->AovNamePlugName)))
         .Get(&lightAovName);
     status = lightAovNamePlug.setValue(MString(lightAovName.c_str()));
     if (status != MS::kSuccess) {
@@ -818,7 +822,9 @@ static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& dep
         return false;
     }
     bool lightInPrimaryHit = true;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->InPrimaryHitPlugName)).Get(&lightInPrimaryHit);
+    lightPrim
+        .GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->InPrimaryHitPlugName)))
+        .Get(&lightInPrimaryHit);
     status = lightInPrimaryHitPlug.setValue(lightInPrimaryHit);
     if (status != MS::kSuccess) {
         return false;
@@ -830,7 +836,9 @@ static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& dep
         return false;
     }
     bool lightInReflection = true;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->InReflectionPlugName)).Get(&lightInReflection);
+    lightPrim
+        .GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->InReflectionPlugName)))
+        .Get(&lightInReflection);
     status = lightInReflectionPlug.setValue(lightInReflection);
     if (status != MS::kSuccess) {
         return false;
@@ -842,7 +850,9 @@ static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& dep
         return false;
     }
     bool lightInRefraction = true;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->InRefractionPlugName)).Get(&lightInRefraction);
+    lightPrim
+        .GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->InRefractionPlugName)))
+        .Get(&lightInRefraction);
     status = lightInRefractionPlug.setValue(lightInRefraction);
     if (status != MS::kSuccess) {
         return false;
@@ -854,7 +864,8 @@ static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& dep
         return false;
     }
     bool lightInvert = true;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->InvertPlugName)).Get(&lightInvert);
+    lightPrim.GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->InvertPlugName)))
+        .Get(&lightInvert);
     status = lightInvertPlug.setValue(lightInvert);
     if (status != MS::kSuccess) {
         return false;
@@ -867,7 +878,9 @@ static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& dep
         return false;
     }
     bool lightOnVolumeBoundaries = true;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->OnVolumeBoundariesPlugName))
+    lightPrim
+        .GetAttribute(
+            _ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->OnVolumeBoundariesPlugName)))
         .Get(&lightOnVolumeBoundaries);
     status = lightOnVolumeBoundariesPlug.setValue(lightOnVolumeBoundaries);
     if (status != MS::kSuccess) {
@@ -880,7 +893,8 @@ static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& dep
         return false;
     }
     bool lightUseColor = true;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->UseColorPlugName)).Get(&lightUseColor);
+    lightPrim.GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->UseColorPlugName)))
+        .Get(&lightUseColor);
     status = lightUseColorPlug.setValue(lightUseColor);
     if (status != MS::kSuccess) {
         return false;
@@ -893,7 +907,8 @@ static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& dep
         return false;
     }
     bool lightUseThroughput = true;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->UseThroughputPlugName))
+    lightPrim
+        .GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->UseThroughputPlugName)))
         .Get(&lightUseThroughput);
     status = lightUseThroughputPlug.setValue(lightUseThroughput);
     return status == MS::kSuccess;
@@ -1210,7 +1225,8 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     int lightDay = 1;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->DayPlugName)).Get(&lightDay);
+    lightPrim.GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->DayPlugName)))
+        .Get(&lightDay);
     status = lightDayPlug.setValue(lightDay);
     if (status != MS::kSuccess) {
         return false;
@@ -1222,7 +1238,8 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     float lightHaziness = 2.0f;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->HazinessPlugName)).Get(&lightHaziness);
+    lightPrim.GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->HazinessPlugName)))
+        .Get(&lightHaziness);
     status = lightHazinessPlug.setValue(lightHaziness);
     if (status != MS::kSuccess) {
         return false;
@@ -1234,7 +1251,8 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     float lightHour = 14.633333f;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->HourPlugName)).Get(&lightHour);
+    lightPrim.GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->HourPlugName)))
+        .Get(&lightHour);
     status = lightHourPlug.setValue(lightHour);
     if (status != MS::kSuccess) {
         return false;
@@ -1246,7 +1264,8 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     float lightLatitude = 47.602f;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->LatitudePlugName)).Get(&lightLatitude);
+    lightPrim.GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->LatitudePlugName)))
+        .Get(&lightLatitude);
     status = lightLatitudePlug.setValue(lightLatitude);
     if (status != MS::kSuccess) {
         return false;
@@ -1258,7 +1277,8 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     float lightLongitude = -122.332f;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->LongitudePlugName)).Get(&lightLongitude);
+    lightPrim.GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->LongitudePlugName)))
+        .Get(&lightLongitude);
     status = lightLongitudePlug.setValue(lightLongitude);
     if (status != MS::kSuccess) {
         return false;
@@ -1270,7 +1290,8 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     int lightMonth = 0;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->MonthPlugName)).Get(&lightMonth);
+    lightPrim.GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->MonthPlugName)))
+        .Get(&lightMonth);
     status = lightMonthPlug.setValue(lightMonth);
     if (status != MS::kSuccess) {
         return false;
@@ -1282,7 +1303,8 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     GfVec3f lightSkyTint(1.0f);
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->SkyTintPlugName)).Get(&lightSkyTint);
+    lightPrim.GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->SkyTintPlugName)))
+        .Get(&lightSkyTint);
     status = lightSkyTintPlug.child(0).setValue(lightSkyTint[0]);
     status = lightSkyTintPlug.child(1).setValue(lightSkyTint[1]);
     status = lightSkyTintPlug.child(2).setValue(lightSkyTint[2]);
@@ -1296,7 +1318,9 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     GfVec3f lightSunDirection(0.0f, 0.0f, 1.0f);
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->SunDirectionPlugName)).Get(&lightSunDirection);
+    lightPrim
+        .GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->SunDirectionPlugName)))
+        .Get(&lightSunDirection);
     status = lightSunDirectionPlug.child(0).setValue(lightSunDirection[0]);
     status = lightSunDirectionPlug.child(1).setValue(lightSunDirection[1]);
     status = lightSunDirectionPlug.child(2).setValue(lightSunDirection[2]);
@@ -1310,7 +1334,8 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     float lightSunSize = 1.0f;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->SunSizePlugName)).Get(&lightSunSize);
+    lightPrim.GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->SunSizePlugName)))
+        .Get(&lightSunSize);
     status = lightSunSizePlug.setValue(lightSunSize);
     if (status != MS::kSuccess) {
         return false;
@@ -1322,7 +1347,8 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     GfVec3f lightSunTint(1.0f);
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->SunTintPlugName)).Get(&lightSunTint);
+    lightPrim.GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->SunTintPlugName)))
+        .Get(&lightSunTint);
     status = lightSunTintPlug.child(0).setValue(lightSunTint[0]);
     status = lightSunTintPlug.child(1).setValue(lightSunTint[1]);
     status = lightSunTintPlug.child(2).setValue(lightSunTint[2]);
@@ -1336,7 +1362,8 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     int lightYear = 2015;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->YearPlugName)).Get(&lightYear);
+    lightPrim.GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->YearPlugName)))
+        .Get(&lightYear);
     status = lightYearPlug.setValue(lightYear);
     if (status != MS::kSuccess) {
         return false;
@@ -1348,7 +1375,8 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
         return false;
     }
     float lightZone = -8.0f;
-    lightPrim.GetAttribute(_ShaderAttrName(_tokens->ZonePlugName)).Get(&lightZone);
+    lightPrim.GetAttribute(_ShaderAttrName(_PrefixRiLightAttrNamespace(_tokens->ZonePlugName)))
+        .Get(&lightZone);
     status = lightZonePlug.setValue(lightZone);
     return status == MS::kSuccess;
 }

--- a/lib/usd/translators/lightRfMReader.cpp
+++ b/lib/usd/translators/lightRfMReader.cpp
@@ -23,8 +23,6 @@
 #include <pxr/usd/usdLux/geometryLight.h>
 #include <pxr/usd/usdLux/rectLight.h>
 #include <pxr/usd/usdLux/sphereLight.h>
-#include <pxr/usd/usdRi/pxrAovLight.h>
-#include <pxr/usd/usdRi/pxrEnvDayLight.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -66,12 +64,16 @@ PXRUSDMAYA_DEFINE_READER(UsdLuxSphereLight, args, context)
 }
 #endif
 
-PXRUSDMAYA_DEFINE_READER(UsdRiPxrAovLight, args, context)
+// Moving to use PXRUSDMAYA_DEFINE_READER_FOR_USD_TYPE in anticipation of
+// codeless schemas for UsdRi types to be available soon!
+PXRUSDMAYA_DEFINE_READER_FOR_USD_TYPE(PxrAovLight, args, context)
 {
     return UsdMayaTranslatorRfMLight::Read(args, &context);
 }
 
-PXRUSDMAYA_DEFINE_READER(UsdRiPxrEnvDayLight, args, context)
+// Moving to use PXRUSDMAYA_DEFINE_READER_FOR_USD_TYPE in anticipation of
+// codeless schemas for UsdRi types to be available soon!
+PXRUSDMAYA_DEFINE_READER_FOR_USD_TYPE(PxrEnvDayLight, args, context)
 {
     return UsdMayaTranslatorRfMLight::Read(args, &context);
 }

--- a/test/lib/usd/translators/UsdImportRfMLightTest/RfMLightsTest.usda
+++ b/test/lib/usd/translators/UsdImportRfMLightTest/RfMLightsTest.usda
@@ -201,14 +201,14 @@ def Xform "RfMLightsTest" (
             prepend apiSchemas = ["ShapingAPI", "ShadowAPI"]
         )
         {
-            string inputs:aovName = "testAovName"
-            bool inputs:inPrimaryHit = 0
-            bool inputs:inReflection = 1
-            bool inputs:inRefraction = 1
-            bool inputs:invert = 1
-            bool inputs:onVolumeBoundaries = 0
-            bool inputs:useColor = 1
-            bool inputs:useThroughput = 0
+            string inputs:ri:light:aovName = "testAovName"
+            bool inputs:ri:light:inPrimaryHit = 0
+            bool inputs:ri:light:inReflection = 1
+            bool inputs:ri:light:inRefraction = 1
+            bool inputs:ri:light:invert = 1
+            bool inputs:ri:light:onVolumeBoundaries = 0
+            bool inputs:ri:light:useColor = 1
+            bool inputs:ri:light:useThroughput = 0
             double3 xformOp:translate = (8, 8, 8)
             uniform token[] xformOpOrder = ["xformOp:translate"]
         }
@@ -217,24 +217,24 @@ def Xform "RfMLightsTest" (
             prepend apiSchemas = ["ShapingAPI", "ShadowAPI"]
         )
         {
-            int inputs:day = 9
-            float inputs:haziness = 1.9
-            float inputs:hour = 9.9
+            int inputs:ri:light:day = 9
+            float inputs:ri:light:haziness = 1.9
+            float inputs:ri:light:hour = 9.9
             float inputs:diffuse = 1.9
             float inputs:exposure = 0.9
             float inputs:intensity = 1.9
             float inputs:specular = 1.9
-            float inputs:latitude = 90
-            float inputs:longitude = -90
-            int inputs:month = 9
-            color3f inputs:skyTint = (0.9, 0.9, 0.9)
-            vector3f inputs:sunDirection = (0, 0, 0.9)
-            float inputs:sunSize = 0.9
-            color3f inputs:sunTint = (0.9, 0.9, 0.9)
+            float inputs:ri:light:latitude = 90
+            float inputs:ri:light:longitude = -90
+            int inputs:ri:light:month = 9
+            color3f inputs:ri:light:skyTint = (0.9, 0.9, 0.9)
+            vector3f inputs:ri:light:sunDirection = (0, 0, 0.9)
+            float inputs:ri:light:sunSize = 0.9
+            color3f inputs:ri:light:sunTint = (0.9, 0.9, 0.9)
+            int inputs:ri:light:year = 2019
+            float inputs:ri:light:zone = 9
             double3 xformOp:translate = (9, 9, 9)
             uniform token[] xformOpOrder = ["xformOp:translate"]
-            int inputs:year = 2019
-            float inputs:zone = 9
         }
     }
 

--- a/test/lib/usd/translators/testUsdExportRfMLight.py
+++ b/test/lib/usd/translators/testUsdExportRfMLight.py
@@ -216,35 +216,35 @@ class testUsdExportRfMLight(unittest.TestCase):
         self.assertTrue(aovLight)
 
         expectedAovName = 'testAovName'
-        self.assertEqual(aovLight.GetAttribute("inputs:aovName").Get(), 
+        self.assertEqual(aovLight.GetAttribute("inputs:ri:light:aovName").Get(), 
                 expectedAovName)
 
         expectedInPrimaryHit = False
-        self.assertEqual(aovLight.GetAttribute("inputs:inPrimaryHit").Get(),
+        self.assertEqual(aovLight.GetAttribute("inputs:ri:light:inPrimaryHit").Get(),
             expectedInPrimaryHit)
 
         expectedInReflection = True
-        self.assertEqual(aovLight.GetAttribute("inputs:inReflection").Get(),
+        self.assertEqual(aovLight.GetAttribute("inputs:ri:light:inReflection").Get(),
             expectedInReflection)
 
         expectedInRefraction = True
-        self.assertEqual(aovLight.GetAttribute("inputs:inRefraction").Get(),
+        self.assertEqual(aovLight.GetAttribute("inputs:ri:light:inRefraction").Get(),
             expectedInRefraction)
 
         expectedInvert = True
-        self.assertEqual(aovLight.GetAttribute("inputs:invert").Get(), 
+        self.assertEqual(aovLight.GetAttribute("inputs:ri:light:invert").Get(), 
                 expectedInvert)
 
         expectedOnVolumeBoundaries = False
-        self.assertEqual(aovLight.GetAttribute("inputs:onVolumeBoundaries").Get(),
+        self.assertEqual(aovLight.GetAttribute("inputs:ri:light:onVolumeBoundaries").Get(),
             expectedOnVolumeBoundaries)
 
         expectedUseColor = True
-        self.assertEqual(aovLight.GetAttribute("inputs:useColor").Get(), 
+        self.assertEqual(aovLight.GetAttribute("inputs:ri:light:useColor").Get(), 
                 expectedUseColor)
 
         expectedUseThroughput = False
-        self.assertEqual(aovLight.GetAttribute("inputs:useThroughput").Get(),
+        self.assertEqual(aovLight.GetAttribute("inputs:ri:light:useThroughput").Get(),
             expectedUseThroughput)
 
     def _ValidateUsdRiPxrEnvDayLight(self):
@@ -256,49 +256,49 @@ class testUsdExportRfMLight(unittest.TestCase):
         self.assertTrue(envDayLight)
 
         expectedDay = 9
-        self.assertEqual(envDayLight.GetAttribute("inputs:day").Get(), 
+        self.assertEqual(envDayLight.GetAttribute("inputs:ri:light:day").Get(), 
                 expectedDay)
 
         expectedHaziness = 1.9
-        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:haziness").Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:ri:light:haziness").Get(),
             expectedHaziness, 1e-6))
 
         expectedHour = 9.9
-        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:hour").Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:ri:light:hour").Get(),
             expectedHour, 1e-6))
 
         expectedLatitude = 90.0
-        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:latitude").Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:ri:light:latitude").Get(),
             expectedLatitude, 1e-6))
 
         expectedLongitude = -90.0
-        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:longitude").Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:ri:light:longitude").Get(),
             expectedLongitude, 1e-6))
 
         expectedMonth = 9
-        self.assertEqual(envDayLight.GetAttribute("inputs:month").Get(), expectedMonth)
+        self.assertEqual(envDayLight.GetAttribute("inputs:ri:light:month").Get(), expectedMonth)
 
         expectedSkyTint = Gf.Vec3f(0.9)
-        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:skyTint").Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:ri:light:skyTint").Get(),
             expectedSkyTint, 1e-6))
 
         expectedSunDirection = Gf.Vec3f(0.0, 0.0, 0.9)
-        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:sunDirection").Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:ri:light:sunDirection").Get(),
             expectedSunDirection, 1e-6))
 
         expectedSunSize = 0.9
-        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:sunSize").Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:ri:light:sunSize").Get(),
             expectedSunSize, 1e-6))
 
         expectedSunTint = Gf.Vec3f(0.9)
-        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:sunTint").Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:ri:light:sunTint").Get(),
             expectedSunTint, 1e-6))
 
         expectedYear = 2019
-        self.assertEqual(envDayLight.GetAttribute("inputs:year").Get(), expectedYear)
+        self.assertEqual(envDayLight.GetAttribute("inputs:ri:light:year").Get(), expectedYear)
 
         expectedZone = 9.0
-        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:zone").Get(),
+        self.assertTrue(Gf.IsClose(envDayLight.GetAttribute("inputs:ri:light:zone").Get(),
             expectedZone, 1e-6))
 
     def _ValidateUsdLuxShapingAPI(self):


### PR DESCRIPTION
Provide means of registering usd readers against usdTypeName to support
codeless schemas, which don't have an associated c++ class/type. Also
update the RfM lights to use ri property namespaces to differentiate
them from core usdLux schema properties.