### PR TITLE
Adopt use of references when passing ReaderContext when reading RfM

### DIFF
--- a/lib/mayaUsd/fileio/translators/translatorRfMLight.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorRfMLight.cpp
@@ -1909,7 +1909,7 @@ static TfToken _GetMayaTypeTokenForUsdLuxLight(const UsdLuxLight& lightSchema)
 /* static */
 bool UsdMayaTranslatorRfMLight::Read(
     const UsdMayaPrimReaderArgs& args,
-    UsdMayaPrimReaderContext*    context)
+    UsdMayaPrimReaderContext&    context)
 {
     const UsdPrim& usdPrim = args.GetUsdPrim();
     if (!usdPrim) {
@@ -1927,12 +1927,12 @@ bool UsdMayaTranslatorRfMLight::Read(
             "Could not determine Maya light type for UsdLuxLight prim", lightSchema.GetPath());
     }
 
-    MObject parentNode = context->GetMayaNode(lightSchema.GetPath().GetParentPath(), false);
+    MObject parentNode = context.GetMayaNode(lightSchema.GetPath().GetParentPath(), false);
 
     MStatus status;
     MObject mayaNodeTransformObj;
     if (!UsdMayaTranslatorUtil::CreateTransformNode(
-            usdPrim, parentNode, args, context, &status, &mayaNodeTransformObj)) {
+            usdPrim, parentNode, args, &context, &status, &mayaNodeTransformObj)) {
         return _ReportError("Failed to create transform node", lightSchema.GetPath());
     }
 
@@ -1953,7 +1953,7 @@ bool UsdMayaTranslatorRfMLight::Read(
 
     const std::string nodePath
         = lightSchema.GetPath().AppendChild(TfToken(nodeName.asChar())).GetString();
-    context->RegisterNewMayaNode(nodePath, lightObj);
+    context.RegisterNewMayaNode(nodePath, lightObj);
 
     MFnDependencyNode depFn(lightObj, &status);
     if (status != MS::kSuccess) {

--- a/lib/mayaUsd/fileio/translators/translatorRfMLight.h
+++ b/lib/mayaUsd/fileio/translators/translatorRfMLight.h
@@ -39,7 +39,7 @@ struct UsdMayaTranslatorRfMLight
     ///
     /// Returns true if this succeeds in creating a RenderMan for Maya light.
     MAYAUSD_CORE_PUBLIC
-    static bool Read(const UsdMayaPrimReaderArgs& args, UsdMayaPrimReaderContext* context);
+    static bool Read(const UsdMayaPrimReaderArgs& args, UsdMayaPrimReaderContext& context);
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/usd/translators/lightRfMReader.cpp
+++ b/lib/usd/translators/lightRfMReader.cpp
@@ -68,14 +68,14 @@ PXRUSDMAYA_DEFINE_READER(UsdLuxSphereLight, args, context)
 // codeless schemas for UsdRi types to be available soon!
 PXRUSDMAYA_DEFINE_READER_FOR_USD_TYPE(PxrAovLight, args, context)
 {
-    return UsdMayaTranslatorRfMLight::Read(args, &context);
+    return UsdMayaTranslatorRfMLight::Read(args, context);
 }
 
 // Moving to use PXRUSDMAYA_DEFINE_READER_FOR_USD_TYPE in anticipation of
 // codeless schemas for UsdRi types to be available soon!
 PXRUSDMAYA_DEFINE_READER_FOR_USD_TYPE(PxrEnvDayLight, args, context)
 {
-    return UsdMayaTranslatorRfMLight::Read(args, &context);
+    return UsdMayaTranslatorRfMLight::Read(args, context);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
lights

This standardizes the API around the recent Autodesk change