### PR TITLE
MAYA-113442 fix standard surface export

### DIFF
--- a/lib/usd/translators/shading/usdStandardSurfaceWriter.cpp
+++ b/lib/usd/translators/shading/usdStandardSurfaceWriter.cpp
@@ -109,30 +109,19 @@ void PxrUsdTranslators_StandardSurfaceWriter::Write(const UsdTimeCode& usdTime)
         usdTime,
         TrMayaTokens->emission);
 
-    MPlug metalnessPlug = depNodeFn.findPlug(
-        depNodeFn.attribute(TrMayaTokens->metalness.GetText()),
-        /* wantNetworkedPlug = */ true,
-        &status);
-    if (status == MS::kSuccess && UsdMayaUtil::IsAuthored(metalnessPlug)) {
-        AuthorShaderInputFromShadingNodeAttr(
-            depNodeFn,
-            TrMayaTokens->metalness,
-            shaderSchema,
-            PxrMayaUsdPreviewSurfaceTokens->MetallicAttrName,
-            usdTime);
-    } else {
-        shaderSchema
-            .CreateInput(
-                PxrMayaUsdPreviewSurfaceTokens->UseSpecularWorkflowAttrName, SdfValueTypeNames->Int)
-            .Set(1, usdTime);
+    AuthorShaderInputFromShadingNodeAttr(
+        depNodeFn,
+        TrMayaTokens->metalness,
+        shaderSchema,
+        PxrMayaUsdPreviewSurfaceTokens->MetallicAttrName,
+        usdTime);
 
-        AuthorShaderInputFromShadingNodeAttr(
-            depNodeFn,
-            TrMayaTokens->specularColor,
-            shaderSchema,
-            PxrMayaUsdPreviewSurfaceTokens->SpecularColorAttrName,
-            usdTime);
-    }
+    AuthorShaderInputFromShadingNodeAttr(
+        depNodeFn,
+        TrMayaTokens->specularColor,
+        shaderSchema,
+        PxrMayaUsdPreviewSurfaceTokens->SpecularColorAttrName,
+        usdTime);
 
     AuthorShaderInputFromShadingNodeAttr(
         depNodeFn,

--- a/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
+++ b/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
@@ -381,6 +381,9 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
             self.assertTrue(surf_prim)
             surf_shade = UsdShade.Shader(surf_prim)
             self.assertTrue(surf_shade)
+            # useSpecularWorkflow is not exported anymore:
+            use_specular_workflow = surf_shade.GetInput("useSpecularWorkflow")
+            self.assertFalse(use_specular_workflow)
             opacity = surf_shade.GetInput("opacity")
             self.assertTrue(opacity)
             if (isinstance(val, float)):


### PR DESCRIPTION
Standard surface should never turn on useSpecularWorkflow. There are no
combinations of attributes on standard surface that can predict when
useSpecularWorkflow should be used.