### PR TITLE
MAYA-113559 prevent crash when accessing a stale attribute from Python

### DIFF
--- a/lib/mayaUsd/ufe/UsdAttribute.cpp
+++ b/lib/mayaUsd/ufe/UsdAttribute.cpp
@@ -48,6 +48,11 @@ static constexpr char kErrorMsgInvalidType[]
 
 namespace {
 
+bool isAttributeValid(const PXR_NS::UsdAttribute& attr)
+{
+    return attr.GetPrim() && attr.GetStage();
+}
+
 template <typename T> bool setUsdAttr(const PXR_NS::UsdAttribute& attr, const T& value)
 {
     // USD Attribute Notification doubling problem:
@@ -74,6 +79,9 @@ template <typename T> bool setUsdAttr(const PXR_NS::UsdAttribute& attr, const T&
     // Therefore, we have implemented an attribute change block notification of
     // our own in the StagesSubject, which we invoke here, so that only a
     // single UFE attribute changed notification is generated.
+    if (!isAttributeValid(attr))
+        return false;
+
     MayaUsd::ufe::AttributeChangedNotificationGuard guard;
     std::string                                     errMsg;
     bool isSetAttrAllowed = MayaUsd::ufe::isAttributeEditAllowed(attr, &errMsg);
@@ -96,7 +104,7 @@ PXR_NS::UsdTimeCode getCurrentTime(const Ufe::SceneItem::Ptr& item)
 std::string
 getUsdAttributeValueAsString(const PXR_NS::UsdAttribute& attr, const PXR_NS::UsdTimeCode& time)
 {
-    if (!attr.HasValue())
+    if (!isAttributeValid(attr) || !attr.HasValue())
         return std::string();
 
     PXR_NS::VtValue v;
@@ -118,7 +126,7 @@ getUsdAttributeValueAsString(const PXR_NS::UsdAttribute& attr, const PXR_NS::Usd
 template <typename T, typename U>
 U getUsdAttributeVectorAsUfe(const PXR_NS::UsdAttribute& attr, const PXR_NS::UsdTimeCode& time)
 {
-    if (!attr.HasValue())
+    if (!isAttributeValid(attr) || !attr.HasValue())
         return U();
 
     PXR_NS::VtValue vt;

--- a/lib/mayaUsd/ufe/UsdAttribute.cpp
+++ b/lib/mayaUsd/ufe/UsdAttribute.cpp
@@ -48,11 +48,6 @@ static constexpr char kErrorMsgInvalidType[]
 
 namespace {
 
-bool isAttributeValid(const PXR_NS::UsdAttribute& attr)
-{
-    return attr.GetPrim() && attr.GetStage();
-}
-
 template <typename T> bool setUsdAttr(const PXR_NS::UsdAttribute& attr, const T& value)
 {
     // USD Attribute Notification doubling problem:
@@ -79,7 +74,7 @@ template <typename T> bool setUsdAttr(const PXR_NS::UsdAttribute& attr, const T&
     // Therefore, we have implemented an attribute change block notification of
     // our own in the StagesSubject, which we invoke here, so that only a
     // single UFE attribute changed notification is generated.
-    if (!isAttributeValid(attr))
+    if (!attr.IsValid())
         return false;
 
     MayaUsd::ufe::AttributeChangedNotificationGuard guard;
@@ -104,7 +99,7 @@ PXR_NS::UsdTimeCode getCurrentTime(const Ufe::SceneItem::Ptr& item)
 std::string
 getUsdAttributeValueAsString(const PXR_NS::UsdAttribute& attr, const PXR_NS::UsdTimeCode& time)
 {
-    if (!isAttributeValid(attr) || !attr.HasValue())
+    if (!attr.IsValid() || !attr.HasValue())
         return std::string();
 
     PXR_NS::VtValue v;
@@ -126,7 +121,7 @@ getUsdAttributeValueAsString(const PXR_NS::UsdAttribute& attr, const PXR_NS::Usd
 template <typename T, typename U>
 U getUsdAttributeVectorAsUfe(const PXR_NS::UsdAttribute& attr, const PXR_NS::UsdTimeCode& time)
 {
-    if (!isAttributeValid(attr) || !attr.HasValue())
+    if (!attr.IsValid() || !attr.HasValue())
         return U();
 
     PXR_NS::VtValue vt;


### PR DESCRIPTION
User (and ours) Python scripts can keep variable holding references to invalid USD attributes. Detect when an invalid USD attribute is accessed and prevent getting and setting its value rather than using invalid pointers and crash.

This was triggered in our own UI code when receiving notifications of attribute value change when two scenes with prim with identical UFE paths were manipulated in successsion in a Python script.

A typical example was a Python script that created a new Maya scene, a new USD stage, and a cone within that stage and setting a value on a property. Re-running the script within the same Maya session would crash.