### PR TITLE
Fix python 3.9 AL TransactionManager crash

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/Global.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/Global.h
@@ -54,6 +54,9 @@ public:
     /// callback used to flush the USD caches after a file new
     static AL::event::CallbackId fileNew() { return m_fileNew; }
 
+    /// callback used to flush the USD caches on exit
+    static AL::event::CallbackId mayaExit() { return m_mayaExit; }
+
     static void openingFile(bool val);
 
 private:
@@ -64,7 +67,8 @@ private:
     static AL::event::CallbackId m_postRead; ///< callback executed after opening a maya file -
                                              ///< needed to re-hook up the UsdPrims
     static AL::event::CallbackId
-        m_fileNew; ///< callback used to flush the USD caches after a file new
+                                 m_fileNew; ///< callback used to flush the USD caches after a file new
+    static AL::event::CallbackId m_mayaExit; ///< callback used to flush the USD caches on exit
     static AL::event::CallbackId
                                  m_preExport; ///< callback prior to exporting the scene (so we can store the session layer)
     static AL::event::CallbackId m_postExport; ///< callback after exporting

--- a/plugin/al/usdtransaction/AL/usd/transaction/TransactionManager.cpp
+++ b/plugin/al/usdtransaction/AL/usd/transaction/TransactionManager.cpp
@@ -200,6 +200,9 @@ bool TransactionManager::Close(const UsdStageWeakPtr& stage, const SdfLayerHandl
 }
 
 //----------------------------------------------------------------------------------------------------------------------
+void TransactionManager::CloseAll() { GetManagers().clear(); }
+
+//----------------------------------------------------------------------------------------------------------------------
 } // namespace transaction
 } // namespace usd
 } // namespace AL

--- a/plugin/al/usdtransaction/AL/usd/transaction/TransactionManager.h
+++ b/plugin/al/usdtransaction/AL/usd/transaction/TransactionManager.h
@@ -116,6 +116,11 @@ public:
     AL_USD_TRANSACTION_PUBLIC
     static bool Close(const PXR_NS::UsdStageWeakPtr& stage, const PXR_NS::SdfLayerHandle& layer);
 
+    /// \brief  clears the transaction manager of all active transactions, effectively closing them
+    /// all. Intended to be used for File->New and on exit.
+    AL_USD_TRANSACTION_PUBLIC
+    static void CloseAll();
+
 private:
     typedef std::map<PXR_NS::UsdStageWeakPtr, TransactionManager> StageManagerMap;
     static StageManagerMap&                                       GetManagers();

--- a/plugin/al/usdtransaction/AL/usd/transaction/tests/testTransaction.py
+++ b/plugin/al/usdtransaction/AL/usd/transaction/tests/testTransaction.py
@@ -18,6 +18,9 @@ class TestTransaction(unittest.TestCase):
         if sys.version_info[0] >= 3:
             self.assertItemsEqual = self.assertCountEqual
 
+    def tearDown(self):
+        transaction.TransactionManager.CloseAll()
+
     def _openNoticeHandler(self, notice, stage):
         self.assertEqual(stage, self._stage)
         self._opened += 1

--- a/plugin/al/usdtransaction/AL/usd/transaction/tests/testTransactionManager.py
+++ b/plugin/al/usdtransaction/AL/usd/transaction/tests/testTransactionManager.py
@@ -33,6 +33,8 @@ class TestManger(unittest.TestCase):
         self.assertFalse(TransactionManager.InProgress(stageA))
         self.assertFalse(TransactionManager.InProgress(stageB))
 
+        TransactionManager.CloseAll()
+
     ## Test that TransactionManager reports transactions for multiple layers as expected
     def test_InProgress_Layer(self):
         stage = Usd.Stage.CreateInMemory()
@@ -66,6 +68,8 @@ class TestManger(unittest.TestCase):
         self.assertFalse(TransactionManager.InProgress(stage))
         self.assertFalse(TransactionManager.InProgress(stage, layerA))
         self.assertFalse(TransactionManager.InProgress(stage, layerB))
+
+        TransactionManager.CloseAll()
 
 
 if __name__ == '__main__':

--- a/plugin/al/usdtransaction/AL/usd/transaction/wrapTransactionManager.cpp
+++ b/plugin/al/usdtransaction/AL/usd/transaction/wrapTransactionManager.cpp
@@ -44,6 +44,8 @@ static bool CloseStageLayer(const UsdStageWeakPtr& stage, const SdfLayerHandle& 
     return This::Close(stage, layer);
 }
 
+static void CloseAllStage() { This::CloseAll(); }
+
 void wrapTransactionManager()
 {
     {
@@ -56,6 +58,9 @@ void wrapTransactionManager()
             .staticmethod("Open")
 
             .def("Close", CloseStageLayer, (arg("stage"), arg("layer")))
-            .staticmethod("Close");
+            .staticmethod("Close")
+
+            .def("CloseAll", CloseAllStage)
+            .staticmethod("CloseAll");
     }
 }


### PR DESCRIPTION
Makes sure it does not hold stale Python objects on exit.