### PR TITLE
Use the API schema class UsdLuxLightAPI in place of USD typed class

### DIFF
--- a/lib/mayaUsd/fileio/translators/translatorLight.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorLight.cpp
@@ -36,7 +36,11 @@
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
 #include <pxr/usd/usdLux/distantLight.h>
+#if PXR_VERSION < 2111
 #include <pxr/usd/usdLux/light.h>
+#else
+#include <pxr/usd/usdLux/lightAPI.h>
+#endif
 #include <pxr/usd/usdLux/rectLight.h>
 #include <pxr/usd/usdLux/shadowAPI.h>
 #include <pxr/usd/usdLux/shapingAPI.h>
@@ -79,10 +83,14 @@ TF_DEFINE_PRIVATE_TOKENS(
 );
 // clang-format on
 
-// Export the "common" light attributes from MFnLights to UsdLuxLight
+// Export the "common" light attributes from MFnLights to UsdLuxLightAPI
 bool UsdMayaTranslatorLight::WriteLightAttrs(
-    const UsdTimeCode&         usdTime,
-    UsdLuxLight&               usdLight,
+    const UsdTimeCode& usdTime,
+#if PXR_VERSION < 2111
+    const UsdLuxLight& usdLight,
+#else
+    const UsdLuxLightAPI& usdLight,
+#endif
     MFnLight&                  mayaLight,
     UsdUtilsSparseValueWriter* valueWriter)
 {
@@ -119,7 +127,7 @@ bool UsdMayaTranslatorLight::WriteLightAttrs(
             valueWriter);
     }
 
-    // Some renderers have a float value for diffuse and specular just like UsdLuxLight does (it
+    // Some renderers have a float value for diffuse and specular just like UsdLuxLightAPI does (it
     // defaults to 1) But Maya lights also have a checkbox to enable/disable diffuse and specular.
     // We can just set it to 0 or 1 depending on this boolean
     bool lightDiffuse = mayaLight.lightDiffuse(&status);
@@ -135,12 +143,16 @@ bool UsdMayaTranslatorLight::WriteLightAttrs(
     return true;
 }
 
-// Import the common light attributes from UsdLuxLight.
+// Import the common light attributes from UsdLuxLightAPI.
 // As opposed to the writer, we can't rely on the MFnLight attribute
 // accessors, as we need to support animations. Instead we're getting
 // the Maya plugs from MFnDependencyNode
 static bool _ReadLightAttrs(
-    const UsdLuxLight&           lightSchema,
+#if PXR_VERSION < 2111
+    const UsdLuxLight& lightSchema,
+#else
+    const UsdLuxLightAPI& lightSchema,
+#endif
     MFnDependencyNode&           depFn,
     const UsdMayaPrimReaderArgs& args,
     UsdMayaPrimReaderContext&    context)
@@ -201,7 +213,7 @@ static bool _ReadLightAttrs(
 // Export the specialized MFnDirectionalLight attributes
 bool UsdMayaTranslatorLight::WriteDirectionalLightAttrs(
     const UsdTimeCode&         usdTime,
-    UsdLuxDistantLight&        usdLight,
+    const UsdLuxDistantLight&  usdLight,
     MFnDirectionalLight&       mayaLight,
     UsdUtilsSparseValueWriter* valueWriter)
 {
@@ -217,7 +229,11 @@ bool UsdMayaTranslatorLight::WriteDirectionalLightAttrs(
 
 // Import the specialized MFnDirectionalLight attributes
 static bool _ReadDirectionalLight(
-    const UsdLuxLight&           lightSchema,
+#if PXR_VERSION < 2111
+    const UsdLuxLight& lightSchema,
+#else
+    const UsdLuxLightAPI& lightSchema,
+#endif
     MFnDependencyNode&           depFn,
     const UsdMayaPrimReaderArgs& args,
     UsdMayaPrimReaderContext&    context)
@@ -237,7 +253,7 @@ static bool _ReadDirectionalLight(
 // Export the specialized MFnPointLight attributes
 bool UsdMayaTranslatorLight::WritePointLightAttrs(
     const UsdTimeCode&         usdTime,
-    UsdLuxSphereLight&         usdLight,
+    const UsdLuxSphereLight&   usdLight,
     MFnPointLight&             mayaLight,
     UsdUtilsSparseValueWriter* valueWriter)
 {
@@ -258,7 +274,11 @@ bool UsdMayaTranslatorLight::WritePointLightAttrs(
 
 // Import the specialized MFnPointLight attributes
 static bool _ReadPointLight(
-    const UsdLuxLight&           lightSchema,
+#if PXR_VERSION < 2111
+    const UsdLuxLight& lightSchema,
+#else
+    const UsdLuxLightAPI& lightSchema,
+#endif
     MFnDependencyNode&           depFn,
     const UsdMayaPrimReaderArgs& args,
     UsdMayaPrimReaderContext&    context)
@@ -278,7 +298,7 @@ static bool _ReadPointLight(
 // Export the specialized MFnSpotLight attributes
 bool UsdMayaTranslatorLight::WriteSpotLightAttrs(
     const UsdTimeCode&         usdTime,
-    UsdLuxSphereLight&         usdLight,
+    const UsdLuxSphereLight&   usdLight,
     MFnSpotLight&              mayaLight,
     UsdUtilsSparseValueWriter* valueWriter)
 {
@@ -326,7 +346,11 @@ bool UsdMayaTranslatorLight::WriteSpotLightAttrs(
 
 // Import the specialized MFnSpotLight attributes
 static bool _ReadSpotLight(
-    const UsdLuxLight&           lightSchema,
+#if PXR_VERSION < 2111
+    const UsdLuxLight& lightSchema,
+#else
+    const UsdLuxLightAPI& lightSchema,
+#endif
     MFnDependencyNode&           depFn,
     const UsdMayaPrimReaderArgs& args,
     UsdMayaPrimReaderContext&    context)
@@ -386,7 +410,7 @@ static bool _ReadSpotLight(
 // Export the specialized MFnAreaLight attributes
 bool UsdMayaTranslatorLight::WriteAreaLightAttrs(
     const UsdTimeCode&         usdTime,
-    UsdLuxRectLight&           usdLight,
+    const UsdLuxRectLight&     usdLight,
     MFnAreaLight&              mayaLight,
     UsdUtilsSparseValueWriter* valueWriter)
 {
@@ -405,7 +429,11 @@ bool UsdMayaTranslatorLight::WriteAreaLightAttrs(
 
 /// Read the parameters from UsdLuxRectLight into a Maya area light
 static bool _ReadAreaLight(
-    const UsdLuxLight&           lightSchema,
+#if PXR_VERSION < 2111
+    const UsdLuxLight& lightSchema,
+#else
+    const UsdLuxLightAPI& lightSchema,
+#endif
     MFnDependencyNode&           depFn,
     const UsdMayaPrimReaderArgs& args,
     UsdMayaPrimReaderContext&    context)
@@ -434,10 +462,14 @@ bool UsdMayaTranslatorLight::Read(
     if (!usdPrim) {
         return false;
     }
+#if PXR_VERSION < 2111
     const UsdLuxLight lightSchema(usdPrim);
+#else
+    const UsdLuxLightAPI lightSchema(usdPrim);
+#endif
     if (!lightSchema) {
         TF_RUNTIME_ERROR(
-            "Failed to read UsdLuxLight prim for light %s", usdPrim.GetPath().GetText());
+            "Failed to read UsdLuxLightAPI prim for light %s", usdPrim.GetPath().GetText());
         return false;
     }
     // Find the corresponding maya light type depending on
@@ -459,7 +491,7 @@ bool UsdMayaTranslatorLight::Read(
     }
     if (mayaLightTypeToken.IsEmpty()) {
         TF_RUNTIME_ERROR(
-            "Could not determine Maya light type for UsdLuxLight prim %s",
+            "Could not determine Maya light type for UsdLuxLightAPI prim %s",
             usdPrim.GetPath().GetText());
         return false;
     }
@@ -502,7 +534,7 @@ bool UsdMayaTranslatorLight::Read(
         return false;
     }
 
-    // Whatever the light type is, we always want to read the "common" UsdLuxLight attributes
+    // Whatever the light type is, we always want to read the "common" UsdLuxLightAPI attributes
     _ReadLightAttrs(lightSchema, depFn, args, context);
     // Read the specialized light attributes depending on the maya light type
     if (mayaLightTypeToken == _tokens->DirectionalLightMayaTypeName) {

--- a/lib/mayaUsd/fileio/translators/translatorLight.h
+++ b/lib/mayaUsd/fileio/translators/translatorLight.h
@@ -25,7 +25,11 @@
 
 #include <pxr/pxr.h>
 #include <pxr/usd/usdLux/distantLight.h>
+#if PXR_VERSION < 2111
 #include <pxr/usd/usdLux/light.h>
+#else
+#include <pxr/usd/usdLux/lightAPI.h>
+#endif
 #include <pxr/usd/usdLux/rectLight.h>
 #include <pxr/usd/usdLux/sphereLight.h>
 
@@ -39,13 +43,17 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// \brief Provides helper functions for translating to/from UsdLux
 struct UsdMayaTranslatorLight
 {
-    /// Exports the UsdLuxLight schema attributes from a generic Maya MFnLight.
+    /// Exports the UsdLuxLightAPI schema attributes from a generic Maya MFnLight.
     /// This function should be called when exporting to any of the specialized light schemas.
     /// Return true if all the parameters were exported properly.
     MAYAUSD_CORE_PUBLIC
     static bool WriteLightAttrs(
-        const UsdTimeCode&         usdTime,
-        UsdLuxLight&               usdLight,
+        const UsdTimeCode& usdTime,
+#if PXR_VERSION < 2111
+        const UsdLuxLight& usdLight,
+#else
+        const UsdLuxLightAPI& usdLight,
+#endif
         MFnLight&                  mayaLight,
         UsdUtilsSparseValueWriter* valueWriter = nullptr);
 
@@ -53,7 +61,7 @@ struct UsdMayaTranslatorLight
     MAYAUSD_CORE_PUBLIC
     static bool WriteDirectionalLightAttrs(
         const UsdTimeCode&         usdTime,
-        UsdLuxDistantLight&        usdLight,
+        const UsdLuxDistantLight&  usdLight,
         MFnDirectionalLight&       mayaLight,
         UsdUtilsSparseValueWriter* valueWriter = nullptr);
 
@@ -61,7 +69,7 @@ struct UsdMayaTranslatorLight
     MAYAUSD_CORE_PUBLIC
     static bool WritePointLightAttrs(
         const UsdTimeCode&         usdTime,
-        UsdLuxSphereLight&         usdLight,
+        const UsdLuxSphereLight&   usdLight,
         MFnPointLight&             mayaLight,
         UsdUtilsSparseValueWriter* valueWriter = nullptr);
 
@@ -69,7 +77,7 @@ struct UsdMayaTranslatorLight
     MAYAUSD_CORE_PUBLIC
     static bool WriteSpotLightAttrs(
         const UsdTimeCode&         usdTime,
-        UsdLuxSphereLight&         usdLight,
+        const UsdLuxSphereLight&   usdLight,
         MFnSpotLight&              mayaLight,
         UsdUtilsSparseValueWriter* valueWriter = nullptr);
 
@@ -77,11 +85,11 @@ struct UsdMayaTranslatorLight
     MAYAUSD_CORE_PUBLIC
     static bool WriteAreaLightAttrs(
         const UsdTimeCode&         usdTime,
-        UsdLuxRectLight&           usdLight,
+        const UsdLuxRectLight&     usdLight,
         MFnAreaLight&              mayaLight,
         UsdUtilsSparseValueWriter* valueWriter = nullptr);
 
-    /// Import a UsdLuxLight schema as a corresponding Maya light.
+    /// Import a UsdLuxLightAPI schema as a corresponding Maya light.
     /// Return true if the maya light was properly created and imported
     MAYAUSD_CORE_PUBLIC
     static bool Read(const UsdMayaPrimReaderArgs& args, UsdMayaPrimReaderContext& context);

--- a/lib/mayaUsd/fileio/translators/translatorRfMLight.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorRfMLight.cpp
@@ -42,7 +42,11 @@
 #include <pxr/usd/usdLux/distantLight.h>
 #include <pxr/usd/usdLux/domeLight.h>
 #include <pxr/usd/usdLux/geometryLight.h>
+#if PXR_VERSION < 2111
 #include <pxr/usd/usdLux/light.h>
+#else
+#include <pxr/usd/usdLux/lightAPI.h>
+#endif
 #include <pxr/usd/usdLux/rectLight.h>
 #include <pxr/usd/usdLux/shadowAPI.h>
 #include <pxr/usd/usdLux/shapingAPI.h>
@@ -143,7 +147,11 @@ static bool _ReportError(const std::string& msg, const SdfPath& primPath = SdfPa
 
 // INTENSITY
 
+#if PXR_VERSION < 2111
 static bool _WriteLightIntensity(const MFnDependencyNode& depFn, UsdLuxLight& lightSchema)
+#else
+static bool _WriteLightIntensity(const MFnDependencyNode& depFn, UsdLuxLightAPI& lightSchema)
+#endif
 {
     MStatus     status;
     const MPlug lightIntensityPlug = depFn.findPlug(_tokens->IntensityPlugName.GetText(), &status);
@@ -162,7 +170,11 @@ static bool _WriteLightIntensity(const MFnDependencyNode& depFn, UsdLuxLight& li
     return true;
 }
 
+#if PXR_VERSION < 2111
 static bool _ReadLightIntensity(const UsdLuxLight& lightSchema, MFnDependencyNode& depFn)
+#else
+static bool _ReadLightIntensity(const UsdLuxLightAPI& lightSchema, MFnDependencyNode& depFn)
+#endif
 {
     MStatus status;
     MPlug   lightIntensityPlug = depFn.findPlug(_tokens->IntensityPlugName.GetText(), &status);
@@ -180,7 +192,11 @@ static bool _ReadLightIntensity(const UsdLuxLight& lightSchema, MFnDependencyNod
 
 // EXPOSURE
 
+#if PXR_VERSION < 2111
 static bool _WriteLightExposure(const MFnDependencyNode& depFn, UsdLuxLight& lightSchema)
+#else
+static bool _WriteLightExposure(const MFnDependencyNode& depFn, UsdLuxLightAPI& lightSchema)
+#endif
 {
     MStatus     status;
     const MPlug lightExposurePlug = depFn.findPlug(_tokens->ExposurePlugName.GetText(), &status);
@@ -199,7 +215,11 @@ static bool _WriteLightExposure(const MFnDependencyNode& depFn, UsdLuxLight& lig
     return true;
 }
 
+#if PXR_VERSION < 2111
 static bool _ReadLightExposure(const UsdLuxLight& lightSchema, MFnDependencyNode& depFn)
+#else
+static bool _ReadLightExposure(const UsdLuxLightAPI& lightSchema, MFnDependencyNode& depFn)
+#endif
 {
     MStatus status;
     MPlug   lightExposurePlug = depFn.findPlug(_tokens->ExposurePlugName.GetText(), &status);
@@ -217,7 +237,11 @@ static bool _ReadLightExposure(const UsdLuxLight& lightSchema, MFnDependencyNode
 
 // DIFFUSE
 
+#if PXR_VERSION < 2111
 static bool _WriteLightDiffuse(const MFnDependencyNode& depFn, UsdLuxLight& lightSchema)
+#else
+static bool _WriteLightDiffuse(const MFnDependencyNode& depFn, UsdLuxLightAPI& lightSchema)
+#endif
 {
     MStatus     status;
     const MPlug lightDiffusePlug
@@ -237,7 +261,11 @@ static bool _WriteLightDiffuse(const MFnDependencyNode& depFn, UsdLuxLight& ligh
     return true;
 }
 
+#if PXR_VERSION < 2111
 static bool _ReadLightDiffuse(const UsdLuxLight& lightSchema, MFnDependencyNode& depFn)
+#else
+static bool _ReadLightDiffuse(const UsdLuxLightAPI& lightSchema, MFnDependencyNode& depFn)
+#endif
 {
     MStatus status;
     MPlug   lightDiffusePlug = depFn.findPlug(_tokens->DiffuseAmountPlugName.GetText(), &status);
@@ -255,7 +283,11 @@ static bool _ReadLightDiffuse(const UsdLuxLight& lightSchema, MFnDependencyNode&
 
 // SPECULAR
 
+#if PXR_VERSION < 2111
 static bool _WriteLightSpecular(const MFnDependencyNode& depFn, UsdLuxLight& lightSchema)
+#else
+static bool _WriteLightSpecular(const MFnDependencyNode& depFn, UsdLuxLightAPI& lightSchema)
+#endif
 {
     MStatus     status;
     const MPlug lightSpecularPlug
@@ -275,7 +307,11 @@ static bool _WriteLightSpecular(const MFnDependencyNode& depFn, UsdLuxLight& lig
     return true;
 }
 
+#if PXR_VERSION < 2111
 static bool _ReadLightSpecular(const UsdLuxLight& lightSchema, MFnDependencyNode& depFn)
+#else
+static bool _ReadLightSpecular(const UsdLuxLightAPI& lightSchema, MFnDependencyNode& depFn)
+#endif
 {
     MStatus status;
     MPlug   lightSpecularPlug = depFn.findPlug(_tokens->SpecularAmountPlugName.GetText(), &status);
@@ -293,7 +329,11 @@ static bool _ReadLightSpecular(const UsdLuxLight& lightSchema, MFnDependencyNode
 
 // NORMALIZE POWER
 
+#if PXR_VERSION < 2111
 static bool _WriteLightNormalizePower(const MFnDependencyNode& depFn, UsdLuxLight& lightSchema)
+#else
+static bool _WriteLightNormalizePower(const MFnDependencyNode& depFn, UsdLuxLightAPI& lightSchema)
+#endif
 {
     MStatus     status;
     const MPlug lightNormalizePowerPlug
@@ -313,7 +353,11 @@ static bool _WriteLightNormalizePower(const MFnDependencyNode& depFn, UsdLuxLigh
     return true;
 }
 
+#if PXR_VERSION < 2111
 static bool _ReadLightNormalizePower(const UsdLuxLight& lightSchema, MFnDependencyNode& depFn)
+#else
+static bool _ReadLightNormalizePower(const UsdLuxLightAPI& lightSchema, MFnDependencyNode& depFn)
+#endif
 {
     MStatus status;
     MPlug   lightNormalizePowerPlug
@@ -332,7 +376,11 @@ static bool _ReadLightNormalizePower(const UsdLuxLight& lightSchema, MFnDependen
 
 // COLOR
 
+#if PXR_VERSION < 2111
 static bool _WriteLightColor(const MFnDependencyNode& depFn, UsdLuxLight& lightSchema)
+#else
+static bool _WriteLightColor(const MFnDependencyNode& depFn, UsdLuxLightAPI& lightSchema)
+#endif
 {
     MStatus     status;
     const MPlug lightColorPlug = depFn.findPlug(_tokens->ColorPlugName.GetText(), &status);
@@ -349,7 +397,11 @@ static bool _WriteLightColor(const MFnDependencyNode& depFn, UsdLuxLight& lightS
     return true;
 }
 
+#if PXR_VERSION < 2111
 static bool _ReadLightColor(const UsdLuxLight& lightSchema, MFnDependencyNode& depFn)
+#else
+static bool _ReadLightColor(const UsdLuxLightAPI& lightSchema, MFnDependencyNode& depFn)
+#endif
 {
     MStatus status;
     MPlug   lightColorPlug = depFn.findPlug(_tokens->ColorPlugName.GetText(), &status);
@@ -369,7 +421,11 @@ static bool _ReadLightColor(const UsdLuxLight& lightSchema, MFnDependencyNode& d
 
 // TEMPERATURE
 
+#if PXR_VERSION < 2111
 static bool _WriteLightTemperature(const MFnDependencyNode& depFn, UsdLuxLight& lightSchema)
+#else
+static bool _WriteLightTemperature(const MFnDependencyNode& depFn, UsdLuxLightAPI& lightSchema)
+#endif
 {
     MStatus     status;
     const MPlug lightEnableTemperaturePlug
@@ -402,7 +458,11 @@ static bool _WriteLightTemperature(const MFnDependencyNode& depFn, UsdLuxLight& 
     return true;
 }
 
+#if PXR_VERSION < 2111
 static bool _ReadLightTemperature(const UsdLuxLight& lightSchema, MFnDependencyNode& depFn)
+#else
+static bool _ReadLightTemperature(const UsdLuxLightAPI& lightSchema, MFnDependencyNode& depFn)
+#endif
 {
     MStatus status;
     MPlug   lightEnableTemperaturePlug
@@ -437,7 +497,11 @@ static bool _ReadLightTemperature(const UsdLuxLight& lightSchema, MFnDependencyN
 
 // DISTANT LIGHT ANGLE
 
+#if PXR_VERSION < 2111
 static bool _WriteDistantLightAngle(const MFnDependencyNode& depFn, UsdLuxLight& lightSchema)
+#else
+static bool _WriteDistantLightAngle(const MFnDependencyNode& depFn, UsdLuxLightAPI& lightSchema)
+#endif
 {
     UsdLuxDistantLight distantLightSchema(lightSchema);
     if (!distantLightSchema) {
@@ -462,7 +526,11 @@ static bool _WriteDistantLightAngle(const MFnDependencyNode& depFn, UsdLuxLight&
     return true;
 }
 
+#if PXR_VERSION < 2111
 static bool _ReadDistantLightAngle(const UsdLuxLight& lightSchema, MFnDependencyNode& depFn)
+#else
+static bool _ReadDistantLightAngle(const UsdLuxLightAPI& lightSchema, MFnDependencyNode& depFn)
+#endif
 {
     const UsdLuxDistantLight distantLightSchema(lightSchema);
     if (!distantLightSchema) {
@@ -485,7 +553,11 @@ static bool _ReadDistantLightAngle(const UsdLuxLight& lightSchema, MFnDependency
 
 // LIGHT TEXTURE FILE
 
+#if PXR_VERSION < 2111
 static bool _WriteLightTextureFile(const MFnDependencyNode& depFn, UsdLuxLight& lightSchema)
+#else
+static bool _WriteLightTextureFile(const MFnDependencyNode& depFn, UsdLuxLightAPI& lightSchema)
+#endif
 {
     UsdLuxRectLight rectLightSchema(lightSchema);
     UsdLuxDomeLight domeLightSchema(lightSchema);
@@ -520,7 +592,11 @@ static bool _WriteLightTextureFile(const MFnDependencyNode& depFn, UsdLuxLight& 
     return true;
 }
 
+#if PXR_VERSION < 2111
 static bool _ReadLightTextureFile(const UsdLuxLight& lightSchema, MFnDependencyNode& depFn)
+#else
+static bool _ReadLightTextureFile(const UsdLuxLightAPI& lightSchema, MFnDependencyNode& depFn)
+#endif
 {
     const UsdLuxRectLight rectLightSchema(lightSchema);
     const UsdLuxDomeLight domeLightSchema(lightSchema);
@@ -588,7 +664,11 @@ static UsdAttribute _SetLightPrimAttr(
 }
 
 // AOV LIGHT
+#if PXR_VERSION < 2111
 static bool _WriteAovLight(const MFnDependencyNode& depFn, UsdLuxLight& lightSchema)
+#else
+static bool _WriteAovLight(const MFnDependencyNode& depFn, UsdLuxLightAPI& lightSchema)
+#endif
 {
     // Early out
     UsdPrim              lightPrim = lightSchema.GetPrim();
@@ -788,7 +868,11 @@ static bool _WriteAovLight(const MFnDependencyNode& depFn, UsdLuxLight& lightSch
     return true;
 }
 
+#if PXR_VERSION < 2111
 static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& depFn)
+#else
+static bool _ReadAovLight(const UsdLuxLightAPI& lightSchema, MFnDependencyNode& depFn)
+#endif
 {
     // Early out
     const UsdPrim&       lightPrim = lightSchema.GetPrim();
@@ -915,7 +999,11 @@ static bool _ReadAovLight(const UsdLuxLight& lightSchema, MFnDependencyNode& dep
 }
 
 // ENVDAY LIGHT
+#if PXR_VERSION < 2111
 static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLight& lightSchema)
+#else
+static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLightAPI& lightSchema)
+#endif
 {
     // Early out
     UsdPrim              lightPrim = lightSchema.GetPrim();
@@ -1205,7 +1293,11 @@ static bool _WriteEnvDayLight(const MFnDependencyNode& depFn, UsdLuxLight& light
     return true;
 }
 
+#if PXR_VERSION < 2111
 static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& depFn)
+#else
+static bool _ReadEnvDayLight(const UsdLuxLightAPI& lightSchema, MFnDependencyNode& depFn)
+#endif
 {
     const UsdPrim&       lightPrim = lightSchema.GetPrim();
     static const TfType& usdSchemaBase = TfType::FindByName(_tokens->UsdSchemaBase);
@@ -1383,7 +1475,11 @@ static bool _ReadEnvDayLight(const UsdLuxLight& lightSchema, MFnDependencyNode& 
 
 // SHAPING API
 
+#if PXR_VERSION < 2111
 static bool _WriteLightShapingAPI(const MFnDependencyNode& depFn, UsdLuxLight& lightSchema)
+#else
+static bool _WriteLightShapingAPI(const MFnDependencyNode& depFn, UsdLuxLightAPI& lightSchema)
+#endif
 {
     UsdLuxShapingAPI shapingAPI
         = UsdMayaTranslatorUtil::GetAPISchemaForAuthoring<UsdLuxShapingAPI>(lightSchema.GetPrim());
@@ -1494,7 +1590,11 @@ static bool _WriteLightShapingAPI(const MFnDependencyNode& depFn, UsdLuxLight& l
     return true;
 }
 
+#if PXR_VERSION < 2111
 static bool _ReadLightShapingAPI(const UsdLuxLight& lightSchema, MFnDependencyNode& depFn)
+#else
+static bool _ReadLightShapingAPI(const UsdLuxLightAPI& lightSchema, MFnDependencyNode& depFn)
+#endif
 {
     const UsdLuxShapingAPI shapingAPI(lightSchema);
     if (!shapingAPI) {
@@ -1591,7 +1691,11 @@ static bool _ReadLightShapingAPI(const UsdLuxLight& lightSchema, MFnDependencyNo
 
 // SHADOW API
 
+#if PXR_VERSION < 2111
 static bool _WriteLightShadowAPI(const MFnDependencyNode& depFn, UsdLuxLight& lightSchema)
+#else
+static bool _WriteLightShadowAPI(const MFnDependencyNode& depFn, UsdLuxLightAPI& lightSchema)
+#endif
 {
     UsdLuxShadowAPI shadowAPI
         = UsdMayaTranslatorUtil::GetAPISchemaForAuthoring<UsdLuxShadowAPI>(lightSchema.GetPrim());
@@ -1693,7 +1797,11 @@ static bool _WriteLightShadowAPI(const MFnDependencyNode& depFn, UsdLuxLight& li
     return true;
 }
 
+#if PXR_VERSION < 2111
 static bool _ReadLightShadowAPI(const UsdLuxLight& lightSchema, MFnDependencyNode& depFn)
+#else
+static bool _ReadLightShadowAPI(const UsdLuxLightAPI& lightSchema, MFnDependencyNode& depFn)
+#endif
 {
     const UsdLuxShadowAPI shadowAPI(lightSchema);
     if (!shadowAPI) {
@@ -1783,6 +1891,7 @@ static bool _ReadLightShadowAPI(const UsdLuxLight& lightSchema, MFnDependencyNod
     return status == MS::kSuccess;
 }
 
+#if PXR_VERSION < 2111
 static UsdLuxLight
 _DefineUsdLuxLightForMayaLight(const MFnDependencyNode& depFn, UsdMayaPrimWriterContext* context)
 {
@@ -1824,6 +1933,50 @@ _DefineUsdLuxLightForMayaLight(const MFnDependencyNode& depFn, UsdMayaPrimWriter
 
     return lightSchema;
 }
+#else
+static UsdLuxLightAPI
+_DefineUsdLuxLightForMayaLight(const MFnDependencyNode& depFn, UsdMayaPrimWriterContext* context)
+{
+    UsdLuxLightAPI lightSchema;
+
+    UsdStageRefPtr stage = context->GetUsdStage();
+    const SdfPath& authorPath = context->GetAuthorPath();
+
+    MStatus       status;
+    const MString mayaLightTypeName = depFn.typeName(&status);
+    if (status != MS::kSuccess) {
+        _ReportError("Failed to get Maya light type name", authorPath);
+        return lightSchema;
+    }
+
+    const TfToken mayaLightTypeToken(mayaLightTypeName.asChar());
+
+    if (mayaLightTypeToken == _tokens->AovLightMayaTypeName) {
+        lightSchema = UsdLuxLightAPI(stage->DefinePrim(authorPath, _tokens->AovLightMayaTypeName));
+    } else if (mayaLightTypeToken == _tokens->CylinderLightMayaTypeName) {
+        lightSchema = UsdLuxCylinderLight::Define(stage, authorPath).LightAPI();
+    } else if (mayaLightTypeToken == _tokens->DiskLightMayaTypeName) {
+        lightSchema = UsdLuxDiskLight::Define(stage, authorPath).LightAPI();
+    } else if (mayaLightTypeToken == _tokens->DistantLightMayaTypeName) {
+        lightSchema = UsdLuxDistantLight::Define(stage, authorPath).LightAPI();
+    } else if (mayaLightTypeToken == _tokens->DomeLightMayaTypeName) {
+        lightSchema = UsdLuxDomeLight::Define(stage, authorPath).LightAPI();
+    } else if (mayaLightTypeToken == _tokens->EnvDayLightMayaTypeName) {
+        lightSchema
+            = UsdLuxLightAPI(stage->DefinePrim(authorPath, _tokens->EnvDayLightMayaTypeName));
+    } else if (mayaLightTypeToken == _tokens->GeometryLightMayaTypeName) {
+        lightSchema = UsdLuxGeometryLight::Define(stage, authorPath).LightAPI();
+    } else if (mayaLightTypeToken == _tokens->RectLightMayaTypeName) {
+        lightSchema = UsdLuxRectLight::Define(stage, authorPath).LightAPI();
+    } else if (mayaLightTypeToken == _tokens->SphereLightMayaTypeName) {
+        lightSchema = UsdLuxSphereLight::Define(stage, authorPath).LightAPI();
+    } else {
+        _ReportError("Could not determine UsdLux schema for Maya light", authorPath);
+    }
+
+    return lightSchema;
+}
+#endif
 
 /* static */
 bool UsdMayaTranslatorRfMLight::Write(
@@ -1839,9 +1992,13 @@ bool UsdMayaTranslatorRfMLight::Write(
         return _ReportError("Failed to get Maya light", authorPath);
     }
 
+#if PXR_VERSION < 2111
     UsdLuxLight lightSchema = _DefineUsdLuxLightForMayaLight(depFn, context);
+#else
+    UsdLuxLightAPI lightSchema = _DefineUsdLuxLightForMayaLight(depFn, context);
+#endif
     if (!lightSchema) {
-        return _ReportError("Failed to create UsdLuxLight prim", authorPath);
+        return _ReportError("Failed to create UsdLuxLightAPI prim", authorPath);
     }
 
     _WriteLightIntensity(depFn, lightSchema);
@@ -1871,7 +2028,11 @@ bool UsdMayaTranslatorRfMLight::Write(
     return true;
 }
 
+#if PXR_VERSION < 2111
 static TfToken _GetMayaTypeTokenForUsdLuxLight(const UsdLuxLight& lightSchema)
+#else
+static TfToken _GetMayaTypeTokenForUsdLuxLight(const UsdLuxLightAPI& lightSchema)
+#endif
 {
     const UsdPrim& lightPrim = lightSchema.GetPrim();
 
@@ -1916,15 +2077,19 @@ bool UsdMayaTranslatorRfMLight::Read(
         return false;
     }
 
+#if PXR_VERSION < 2111
     const UsdLuxLight lightSchema(usdPrim);
+#else
+    const UsdLuxLightAPI lightSchema(usdPrim);
+#endif
     if (!lightSchema) {
-        return _ReportError("Failed to read UsdLuxLight prim", usdPrim.GetPath());
+        return _ReportError("Failed to read UsdLuxLightAPI prim", usdPrim.GetPath());
     }
 
     const TfToken mayaLightTypeToken = _GetMayaTypeTokenForUsdLuxLight(lightSchema);
     if (mayaLightTypeToken.IsEmpty()) {
         return _ReportError(
-            "Could not determine Maya light type for UsdLuxLight prim", lightSchema.GetPath());
+            "Could not determine Maya light type for UsdLuxLightAPI prim", lightSchema.GetPath());
     }
 
     MObject parentNode = context.GetMayaNode(lightSchema.GetPath().GetParentPath(), false);

--- a/lib/usd/translators/lightWriter.cpp
+++ b/lib/usd/translators/lightWriter.cpp
@@ -20,7 +20,11 @@
 #include <mayaUsd/fileio/utils/adaptor.h>
 
 #include <pxr/usd/usdLux/distantLight.h>
+#if PXR_VERSION < 2111
 #include <pxr/usd/usdLux/light.h>
+#else
+#include <pxr/usd/usdLux/lightAPI.h>
+#endif
 
 #include <maya/MFnDirectionalLight.h>
 #include <maya/MGlobal.h>
@@ -69,7 +73,12 @@ void PxrUsdTranslators_DirectionalLightWriter::Write(const UsdTimeCode& usdTime)
     }
 
     // First write the base light attributes
+#if PXR_VERSION < 2111
     UsdMayaTranslatorLight::WriteLightAttrs(usdTime, primSchema, lightFn, _GetSparseValueWriter());
+#else
+    UsdMayaTranslatorLight::WriteLightAttrs(
+        usdTime, primSchema.LightAPI(), lightFn, _GetSparseValueWriter());
+#endif
     // Then write the specialized attributes for directional lights
     UsdMayaTranslatorLight::WriteDirectionalLightAttrs(
         usdTime, primSchema, lightFn, _GetSparseValueWriter());
@@ -117,7 +126,12 @@ void PxrUsdTranslators_PointLightWriter::Write(const UsdTimeCode& usdTime)
     }
 
     // First write the base light attributes
+#if PXR_VERSION < 2111
     UsdMayaTranslatorLight::WriteLightAttrs(usdTime, primSchema, lightFn, _GetSparseValueWriter());
+#else
+    UsdMayaTranslatorLight::WriteLightAttrs(
+        usdTime, primSchema.LightAPI(), lightFn, _GetSparseValueWriter());
+#endif
     // Then write the specialized attributes for point lights
     UsdMayaTranslatorLight::WritePointLightAttrs(
         usdTime, primSchema, lightFn, _GetSparseValueWriter());
@@ -164,7 +178,12 @@ void PxrUsdTranslators_SpotLightWriter::Write(const UsdTimeCode& usdTime)
         return;
     }
     // First write the base light attributes
+#if PXR_VERSION < 2111
     UsdMayaTranslatorLight::WriteLightAttrs(usdTime, primSchema, lightFn, _GetSparseValueWriter());
+#else
+    UsdMayaTranslatorLight::WriteLightAttrs(
+        usdTime, primSchema.LightAPI(), lightFn, _GetSparseValueWriter());
+#endif
     // Then write the specialized attributes for spot lights
     UsdMayaTranslatorLight::WriteSpotLightAttrs(
         usdTime, primSchema, lightFn, _GetSparseValueWriter());
@@ -212,7 +231,12 @@ void PxrUsdTranslators_AreaLightWriter::Write(const UsdTimeCode& usdTime)
     }
 
     // First write the base light attributes
+#if PXR_VERSION < 2111
     UsdMayaTranslatorLight::WriteLightAttrs(usdTime, primSchema, lightFn, _GetSparseValueWriter());
+#else
+    UsdMayaTranslatorLight::WriteLightAttrs(
+        usdTime, primSchema.LightAPI(), lightFn, _GetSparseValueWriter());
+#endif
     // Then write the specialized attributes for spot lights
     UsdMayaTranslatorLight::WriteAreaLightAttrs(
         usdTime, primSchema, lightFn, _GetSparseValueWriter());

--- a/lib/usd/translators/lightWriter.h
+++ b/lib/usd/translators/lightWriter.h
@@ -30,7 +30,6 @@
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/timeCode.h>
 #include <pxr/usd/usdLux/distantLight.h>
-#include <pxr/usd/usdLux/light.h>
 
 #include <maya/MFnDependencyNode.h>
 #include <maya/MFnDirectionalLight.h>

--- a/test/lib/usd/translators/testUsdExportRfMLight.py
+++ b/test/lib/usd/translators/testUsdExportRfMLight.py
@@ -102,7 +102,11 @@ class testUsdExportRfMLight(unittest.TestCase):
         else:
             raise NotImplementedError('Invalid light type %s' % lightTypeName)
 
-        lightSchema = UsdLux.Light(lightPrim)
+        usdVersion = Usd.GetVersion()
+        if usdVersion < (0, 21, 11):
+            lightSchema = UsdLux.Light(lightPrim)
+        else:
+            lightSchema = UsdLux.LightAPI(lightPrim)
         self.assertTrue(lightSchema)
 
         if lightTypeName == 'AovLight':


### PR DESCRIPTION
UsdLuxLight

Starting with release 21.11, a UsdLuxLight will be a USD prim that "has
a" UsdLuxLightAPI as opposed to a prim that "is a" UsdLuxLight.
UsdLuxLight will be deleted in 21.11