### PR TITLE
Bail on proxyDrawOverride user select early if snapping is active

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -482,6 +482,14 @@ bool ProxyDrawOverride::userSelect(
 {
     TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyDrawOverride::userSelect\n");
 
+    // There is some unknown behaviour where this userSelect method is called
+    // multiple times while snapping is active.
+    // Calling AL_usdmaya_ProxyShapeSelect with the -cl flag will cause
+    // a crash while we are snapping. Since we do not want to change
+    // the selection while snapping, we can bail early.
+    if (pointSnappingActive())
+        return false;
+
     MString fullSelPath = objPath.fullPathName();
 
     if (!MGlobal::optionVarIntValue("AL_usdmaya_selectionEnabled"))


### PR DESCRIPTION
The `ProxyDrawOverride::userSelect` method can be called when snapping is active. The current implementation will try and update the current selection by building the `AL_usdmaya_ProxyShapeSelect` command, however this will cause a crash when called with the `-cl` flag.

Since we do not want to change the selection while snapping, this fix will bail out early in that scenario.