### PR TITLE
Only export transform rotate order if not default

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.cpp
@@ -687,6 +687,7 @@ MStatus TransformTranslator::copyAttributes(
     static const GfVec3f defaultRotatePivot(0.0f);
     static const GfVec3f defaultScalePivotTranslate(0.0f);
     static const GfVec3f defaultRotatePivotTranslate(0.0f);
+    static const int32_t defaultRotateOrder(0);
     static const bool    defaultVisible(true);
 
     const float          radToDeg = 57.295779506f;
@@ -757,7 +758,7 @@ MStatus TransformTranslator::copyAttributes(
         }
 
         plugAnimated = transformAnimated || animationCheck(animTranslator, MPlug(from, m_rotation));
-        if (plugAnimated || rotation != defaultRotation) {
+        if (plugAnimated || rotation != defaultRotation || rotateOrder != defaultRotateOrder) {
             rotation *= radToDeg;
             UsdAttribute rotateAttr
                 = addRotateOp(xformSchema, "", rotateOrder, rotation, params.m_timeCode);


### PR DESCRIPTION
Updated `TransformTranslator` to only export rotation order if the transform's `rotateOrder` attribute is not default (`0`).