### PR TITLE
Make TranslatePrim update behaviour consistent with Proxy Shape update behaviour

### DIFF
--- a/cmake/plugin/AL_USDMayaTestPlugin/test_data/translator_update_postimport.usda
+++ b/cmake/plugin/AL_USDMayaTestPlugin/test_data/translator_update_postimport.usda
@@ -1,0 +1,31 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+)
+
+def "root" () {
+
+    def Scope "peter01" (
+        variants = {
+            string prelit = "False"
+        }
+        prepend variantSets = "prelit"
+    )
+    {
+        def Scope "rig" (
+
+            assettype = "test"
+        )
+        {
+        }
+        variantSet "prelit" = {
+            "False" {
+                def "other" {}
+
+            }
+            "True" {
+                def "other2" {}
+            }
+        }
+    }
+}

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.cpp
@@ -18,6 +18,7 @@
 #include "AL/maya/utils/CommandGuiHelper.h"
 #include "AL/maya/utils/MenuBuilder.h"
 #include "AL/maya/utils/Utils.h"
+#include "AL/usdmaya/cmds/ProxyShapePostLoadProcess.h"
 #include "AL/usdmaya/nodes/LayerManager.h"
 
 #include <maya/MArgDatabase.h>
@@ -42,6 +43,19 @@ MSyntax ProxyShapeCommandBase::setUpCommonSyntax()
     syntax.setObjectType(MSyntax::kSelectionList, 0, 1);
     syntax.addFlag("-p", "-proxy", MSyntax::kString);
     return syntax;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MArgDatabase ProxyShapeCommandBase::makeDatabase(const MArgList& args)
+{
+    TF_DEBUG(ALUSDMAYA_COMMANDS).Msg("ProxyShapeCommandBase::makeDatabase\n");
+    MStatus      status;
+    MArgDatabase database(syntax(), args, &status);
+    if (!status) {
+        std::cout << status.errorString() << std::endl;
+        throw status;
+    }
+    return database;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -415,13 +429,7 @@ MStatus ProxyShapeFindLoadable::doIt(const MArgList& args)
 {
     TF_DEBUG(ALUSDMAYA_COMMANDS).Msg("ProxyShapeFindLoadable::doIt\n");
     try {
-        MStatus      status;
-        MArgDatabase db(syntax(), args, &status);
-        if (!status) {
-            std::cout << status.errorString() << std::endl;
-            return status;
-        }
-
+        MArgDatabase db = makeDatabase(args);
         AL_MAYA_COMMAND_HELP(db, g_helpText);
         bool loaded = db.isFlagSet("-l");
         bool unloaded = db.isFlagSet("-ul");
@@ -576,13 +584,7 @@ MStatus ProxyShapeImportAllTransforms::redoIt()
 MStatus ProxyShapeImportAllTransforms::doIt(const MArgList& args)
 {
     try {
-        MStatus      status;
-        MArgDatabase db(syntax(), args, &status);
-        if (!status) {
-            std::cout << status.errorString() << std::endl;
-            return status;
-        }
-
+        MArgDatabase db = makeDatabase(args);
         AL_MAYA_COMMAND_HELP(db, g_helpText);
         bool pushToPrim = false;
         if (db.isFlagSet("-p2p")) {
@@ -676,13 +678,7 @@ MStatus ProxyShapeRemoveAllTransforms::redoIt() { return m_modifier.doIt(); }
 MStatus ProxyShapeRemoveAllTransforms::doIt(const MArgList& args)
 {
     try {
-        MStatus      status;
-        MArgDatabase db(syntax(), args, &status);
-        if (!status) {
-            std::cout << status.errorString() << std::endl;
-            return status;
-        }
-
+        MArgDatabase db = makeDatabase(args);
         AL_MAYA_COMMAND_HELP(db, g_helpText);
         nodes::ProxyShape* shapeNode = getShapeNode(db);
         MDagPath           shapePath = getShapePath(db);
@@ -748,13 +744,7 @@ MStatus ProxyShapeResync::doIt(const MArgList& args)
 {
     TF_DEBUG(ALUSDMAYA_COMMANDS).Msg("ProxyShapeResync::doIt\n");
     try {
-        MStatus      status;
-        MArgDatabase db(syntax(), args, &status);
-        if (!status) {
-            std::cout << status.errorString() << std::endl;
-            return status;
-        }
-
+        MArgDatabase db = makeDatabase(args);
         AL_MAYA_COMMAND_HELP(db, g_helpText);
         m_shapeNode = getShapeNode(db);
 
@@ -822,13 +812,7 @@ MStatus InternalProxyShapeSelect::doIt(const MArgList& args)
 {
     TF_DEBUG(ALUSDMAYA_COMMANDS).Msg("InternalProxyShapeSelect::doIt\n");
     try {
-        MStatus      status;
-        MArgDatabase db(syntax(), args, &status);
-        if (!status) {
-            std::cout << status.errorString() << std::endl;
-            return status;
-        }
-
+        MArgDatabase db = makeDatabase(args);
         AL_MAYA_COMMAND_HELP(db, g_helpText);
         m_proxy = getShapeNode(db);
         if (!m_proxy) {
@@ -918,13 +902,7 @@ MStatus ProxyShapeSelect::doIt(const MArgList& args)
 {
     TF_DEBUG(ALUSDMAYA_COMMANDS).Msg("ProxyShapeSelect::doIt\n");
     try {
-        MStatus      status;
-        MArgDatabase db(syntax(), args, &status);
-        if (!status) {
-            std::cout << status.errorString() << std::endl;
-            return status;
-        }
-
+        MArgDatabase db = makeDatabase(args);
         AL_MAYA_COMMAND_HELP(db, g_helpText);
         nodes::ProxyShape* proxy = getShapeNode(db);
         if (!proxy) {
@@ -1060,13 +1038,7 @@ MStatus ProxyShapePostSelect::doIt(const MArgList& args)
 {
     TF_DEBUG(ALUSDMAYA_COMMANDS).Msg("ProxyShapePostSelect::doIt\n");
     try {
-        MStatus      status;
-        MArgDatabase db(syntax(), args, &status);
-        if (!status) {
-            std::cout << status.errorString() << std::endl;
-            return status;
-        }
-
+        MArgDatabase db = makeDatabase(args);
         AL_MAYA_COMMAND_HELP(db, g_helpText);
         m_proxy = getShapeNode(db);
         if (!m_proxy) {
@@ -1107,13 +1079,7 @@ MStatus ProxyShapeImportPrimPathAsMaya::doIt(const MArgList& args)
 {
     TF_DEBUG(ALUSDMAYA_COMMANDS).Msg("ProxyShapeImportPrimPathAsMaya::doIt\n");
     try {
-        MStatus      status;
-        MArgDatabase db(syntax(), args, &status);
-        if (!status) {
-            std::cout << status.errorString() << std::endl;
-            return status;
-        }
-
+        MArgDatabase db = makeDatabase(args);
         AL_MAYA_COMMAND_HELP(db, g_helpText);
         MDagPath shapePath = getShapePath(db);
         m_transformPath = shapePath;
@@ -1189,13 +1155,7 @@ MStatus TranslatePrim::doIt(const MArgList& args)
 {
     TF_DEBUG(ALUSDMAYA_COMMANDS).Msg("TranslatePrim::doIt\n");
     try {
-        MStatus      status;
-        MArgDatabase db(syntax(), args, &status);
-        if (!status) {
-            std::cout << status.errorString() << std::endl;
-            return status;
-        }
-
+        MArgDatabase db = makeDatabase(args);
         AL_MAYA_COMMAND_HELP(db, g_helpText);
         m_proxy = getShapeNode(db);
 
@@ -1347,20 +1307,35 @@ MStatus TranslatePrim::redoIt()
         m_proxy->processChangedMetaData(SdfPathVector(), newImportPaths);
     }
 
-    auto stage = m_proxy->usdStage();
-    auto manufacture = m_proxy->translatorManufacture();
-    for (auto it : m_updatePaths) {
-        auto prim = stage->GetPrimAtPath(it);
-        if (prim) {
-            auto translator = manufacture.get(prim);
-            if (translator && translator->supportsUpdate()) {
-                translator->update(prim);
+    // construct locks and selectability for imported prims
+    if (m_proxy->isLockPrimFeatureActive()) {
+        m_proxy->removeMetaData(m_teardownPaths);
+        m_proxy->processChangedMetaData(SdfPathVector(), newImportPaths);
+    }
+
+    if (!m_updatePaths.empty()) {
+
+        // check paths refer to valid prims for this stage
+        auto                        stage = m_proxy->usdStage();
+        MayaUsdUtils::UsdPrimVector updatePrims;
+
+        AL::usdmaya::fileio::translators::TranslatorManufacture manufacture(nullptr);
+        for (const SdfPath& path : m_updatePaths) {
+            UsdPrim prim = stage->GetPrimAtPath(path);
+            if (prim.IsValid()) {
+                auto translator = manufacture.get(prim);
+                if (translator && translator->supportsUpdate()) {
+                    translator->update(prim);
+                    updatePrims.push_back(prim);
+                }
             } else {
-                MString err = "Update requested on prim that does not support update: ";
-                err += it.GetText();
-                MGlobal::displayWarning(err);
+                TF_DEBUG(ALUSDMAYA_COMMANDS)
+                    .Msg(
+                        "TranslatePrim::redoIt '%s' resolves to an invalid prim\n", path.GetText());
             }
         }
+        cmds::ProxyShapePostLoadProcess::updateSchemaPrims(m_proxy, updatePrims);
+        cmds::ProxyShapePostLoadProcess::connectSchemaPrims(m_proxy, updatePrims);
     }
 
     return MStatus::kSuccess;
@@ -1521,13 +1496,7 @@ MStatus ProxyShapePrintRefCountState::doIt(const MArgList& args)
 {
     TF_DEBUG(ALUSDMAYA_COMMANDS).Msg("ProxyShapePrintRefCountState::doIt\n");
     try {
-        MStatus      status;
-        MArgDatabase db(syntax(), args, &status);
-        if (!status) {
-            std::cout << status.errorString() << std::endl;
-            return status;
-        }
-
+        MArgDatabase db = makeDatabase(args);
         AL_MAYA_COMMAND_HELP(db, g_helpText);
 
         /// find the proxy shape node

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.h
@@ -60,6 +60,10 @@ public:
     /// \param  args the valid argument data base
     /// \return the stage from the proxy shape specified in the selected command arguments
     UsdStageRefPtr getShapeNodeStage(const MArgDatabase& args);
+
+protected:
+    /// utility func to create the arg database
+    MArgDatabase makeDatabase(const MArgList& args);
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapePostLoadProcess.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapePostLoadProcess.h
@@ -100,8 +100,11 @@ public:
     static void
     connectSchemaPrims(nodes::ProxyShape* proxy, const std::vector<UsdPrim>& objsToCreate);
 
-    /// \brief  updates the list of UsdPrims after a variant switch (but when the nodes have not
-    /// changed) \param  proxy the proxy shape to update \param  objsToUpdate the list of prims to
+    /// \brief  updates the list of UsdPrims after a USD change (but when the nodes have not
+    /// changed).
+    ///         Note that if a prim is not found to exist, it will be imported rather than updated
+    /// \param  proxy the proxy shape to update
+    /// \param  objsToUpdate the list of prims to
     /// be updated
     static void
     updateSchemaPrims(nodes::ProxyShape* proxy, const std::vector<UsdPrim>& objsToUpdate);

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -443,7 +443,7 @@ public:
     /// \param  proxyTransformPath the DAG path of the proxy shape
     /// \param  startPath the path from which iteration needs to start in the UsdStage
     /// \param  manufacture the translator registry
-    /// \return the array of prims found that will need to be imported
+    /// \return the array of prims found that will need to be imported (can include the startPath)
     AL_USDMAYA_PUBLIC
     std::vector<UsdPrim> huntForNativeNodesUnderPrim(
         const MDagPath&                             proxyTransformPath,


### PR DESCRIPTION
Changes:
* call ProxyShapePostLoadProcess update/connect code when update requested via TranslatePrim
* TranslatePrim: remove double import/update/teardown
* added unit test

When an onObjectsChanged callback causes prims with schema translators to be called, if a translator plugin supports update, the following occurs:
 - update() is called on the translator
 - postImport() is called on the translator
 - generateUniqueKey() is called on the translator by context->updateUniqueKey()
 - any extraData plugins have their update and postImport methods called
 
We import any prims which weren't update-able because they didn't already exist in the scene, we now call the same code from TranslatePrim, so the behaviours are now consistent; have also removed a doulbe update/import/teardown call which was happening in TranslatePrim.