### PR TITLE
Fix excluded prim paths

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -318,20 +318,7 @@ void ProxyShape::constructGLImagingEngine()
 
             // delete previous instance
             destroyGLImagingEngine();
-
-            const auto& translatedGeo = m_context->excludedGeometry();
-
-            // combine the excluded paths
-            SdfPathVector excludedGeometryPaths;
-            excludedGeometryPaths.reserve(
-                m_excludedTaggedGeometry.size() + m_excludedGeometry.size() + translatedGeo.size());
-            excludedGeometryPaths.assign(
-                m_excludedTaggedGeometry.begin(), m_excludedTaggedGeometry.end());
-            excludedGeometryPaths.insert(
-                excludedGeometryPaths.end(), m_excludedGeometry.begin(), m_excludedGeometry.end());
-            for (auto& it : translatedGeo) {
-                excludedGeometryPaths.push_back(it.second);
-            }
+            SdfPathVector excludedGeometryPaths = getExcludePrimPaths();
 
             m_engine = new Engine(m_path, excludedGeometryPaths);
             // set renderer plugin based on RendererManager setting

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/ProxyShapeMetaData.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/ProxyShapeMetaData.cpp
@@ -210,6 +210,7 @@ void ProxyShape::constructExcludedPrims()
     auto excludedPaths = getExcludePrimPaths();
     if (m_excludedGeometry != excludedPaths) {
         std::swap(m_excludedGeometry, excludedPaths);
+        _IncreaseExcludePrimPathsVersion();
         constructGLImagingEngine();
     }
 }

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/ProxyShapeMetaData.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/ProxyShapeMetaData.cpp
@@ -334,6 +334,16 @@ SdfPathVector ProxyShape::getExcludePrimPaths() const
     SdfPathVector temp
         = getPrimPathsFromCommaJoinedString(excludedTranslatedGeometryPlug().asString());
     paths.insert(paths.end(), temp.begin(), temp.end());
+
+    const auto& translatedGeo = m_context->excludedGeometry();
+
+    // combine the excluded paths
+    paths.insert(paths.end(), m_excludedTaggedGeometry.begin(), m_excludedTaggedGeometry.end());
+    paths.insert(paths.end(), m_excludedGeometry.begin(), m_excludedGeometry.end());
+    for (auto& it : translatedGeo) {
+        paths.push_back(it.second);
+    }
+
     return paths;
 }
 


### PR DESCRIPTION
Ensure excluded prims (that do not need to be rendered) handled properly so that we don't get double up geo on viewport. 