### PR TITLE
Avoid opening duplicated usd stages on Maya file load

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1224,7 +1224,7 @@ void ProxyShape::loadStage()
         std::string fileString = TfStringTrimRight(file.asChar());
 
         TF_DEBUG(ALUSDMAYA_TRANSLATORS)
-            .Msg("ProxyShape::reloadStage original USD file path is %s\n", fileString.c_str());
+            .Msg("ProxyShape::loadStage original USD file path is %s\n", fileString.c_str());
 
         SdfLayerRefPtr rootLayer;
         if (SdfLayer::IsAnonymousLayerIdentifier(fileString)) {
@@ -1239,7 +1239,7 @@ void ProxyShape::loadStage()
             if (rootLayer) {
                 TF_DEBUG(ALUSDMAYA_TRANSLATORS)
                     .Msg(
-                        "ProxyShape::reloadStage found anonymous layer %s from layer manager\n",
+                        "ProxyShape::loadStage found anonymous layer %s from layer manager\n",
                         fileString.c_str());
             } else {
                 const std::string tag = SdfLayer::GetDisplayNameFromIdentifier(fileString);
@@ -1247,7 +1247,7 @@ void ProxyShape::loadStage()
                 if (rootLayer) {
                     TF_DEBUG(ALUSDMAYA_TRANSLATORS)
                         .Msg(
-                            "ProxyShape::reloadStage created anonymous layer %s (renamed to %s)\n",
+                            "ProxyShape::loadStage created anonymous layer %s (renamed to %s)\n",
                             fileString.c_str(),
                             rootLayer->GetIdentifier().c_str());
                 }
@@ -1258,14 +1258,14 @@ void ProxyShape::loadStage()
                 fileString = UsdMayaUtilFileSystem::resolvePath(fileString);
                 TF_DEBUG(ALUSDMAYA_TRANSLATORS)
                     .Msg(
-                        "ProxyShape::reloadStage resolved the USD file path to %s\n",
+                        "ProxyShape::loadStage resolved the USD file path to %s\n",
                         fileString.c_str());
             } else {
                 fileString = UsdMayaUtilFileSystem::resolveRelativePathWithinMayaContext(
                     thisMObject(), fileString);
                 TF_DEBUG(ALUSDMAYA_TRANSLATORS)
                     .Msg(
-                        "ProxyShape::reloadStage resolved the relative USD file path to %s\n",
+                        "ProxyShape::loadStage resolved the relative USD file path to %s\n",
                         fileString.c_str());
             }
 
@@ -1353,21 +1353,48 @@ void ProxyShape::loadStage()
                 UsdStage::InitialLoadSet loadOperation
                     = unloadedFlag ? UsdStage::LoadNone : UsdStage::LoadAll;
 
+                bool newStage = true;
                 if (sessionLayer) {
-                    TF_DEBUG(ALUSDMAYA_TRANSLATORS)
-                        .Msg("ProxyShape::loadStage is called with extra session layer.\n");
-                    m_stage = UsdStage::OpenMasked(rootLayer, sessionLayer, mask, loadOperation);
+                    // Here we disregard the InitialLoadSet but check the mask:
+                    m_stage = StageCache::Get().FindOneMatching(rootLayer, sessionLayer);
+                    if (!m_stage || m_stage->GetPopulationMask() != mask) {
+                        TF_DEBUG(ALUSDMAYA_TRANSLATORS)
+                            .Msg("ProxyShape::loadStage Open a stage with root layer and extra "
+                                 "session layer.\n");
+                        m_stage
+                            = UsdStage::OpenMasked(rootLayer, sessionLayer, mask, loadOperation);
+                    } else {
+                        TF_DEBUG(ALUSDMAYA_TRANSLATORS)
+                            .Msg("ProxyShape::loadStage Get existing stage from cache with the "
+                                 "same root and session layer.\n");
+                        newStage = false;
+                    }
                 } else {
-                    TF_DEBUG(ALUSDMAYA_TRANSLATORS)
-                        .Msg("ProxyShape::loadStage is called without any session layer.\n");
-                    m_stage = UsdStage::OpenMasked(rootLayer, mask, loadOperation);
+                    // Here we disregard the InitialLoadSet but check the mask:
+                    m_stage = StageCache::Get().FindOneMatching(rootLayer);
+                    if (!m_stage || m_stage->GetPopulationMask() != mask) {
+                        TF_DEBUG(ALUSDMAYA_TRANSLATORS)
+                            .Msg("ProxyShape::loadStage Open a stage with root layer but without "
+                                 "any session layer.\n");
+                        m_stage = UsdStage::OpenMasked(rootLayer, mask, loadOperation);
+                    } else {
+                        TF_DEBUG(ALUSDMAYA_TRANSLATORS)
+                            .Msg("ProxyShape::loadStage Get existing stage from cache with the "
+                                 "same root layer.\n");
+                        newStage = false;
+                    }
                 }
 
-                // Expand the mask, since we do not really want to mask the possible relation
-                // targets.
-                m_stage->ExpandPopulationMask();
+                if (newStage) {
+                    // Expand the mask, since we do not really want to mask the possible relation
+                    // targets.
+                    m_stage->ExpandPopulationMask();
 
-                stageId = StageCache::Get().Insert(m_stage);
+                    stageId = StageCache::Get().Insert(m_stage);
+                } else {
+                    stageId = StageCache::Get().GetId(m_stage);
+                }
+
                 outputInt32Value(dataBlock, stageCacheId(), stageId.ToLongInt());
 
                 // Set the stage in datablock so it's ready in case it needs to be accessed
@@ -1514,6 +1541,8 @@ MStatus ProxyShape::computeOutStageData(const MPlug& plug, MDataBlock& dataBlock
     // make sure a stage is loaded
     if (!m_stage && m_filePathDirty) {
         m_filePathDirty = false;
+        TF_DEBUG(ALUSDMAYA_EVALUATION)
+            .Msg("ProxyShape::computeOutStageData call ProxyShape::loadStage\n");
         loadStage();
     }
     // Set the output stage data params
@@ -1633,6 +1662,10 @@ bool ProxyShape::setInternalValue(const MPlug& plug, const MDataHandle& dataHand
         if (MFileIO::isReadingFile()) {
             m_unloadedProxyShapes.push_back(MObjectHandle(thisMObject()));
         } else {
+            TF_DEBUG(ALUSDMAYA_EVALUATION)
+                .Msg(
+                    "ProxyShape::setInternalValue(%s, dataHandle) call ProxyShape::loadStage \n",
+                    plug.name().asChar());
             loadStage();
         }
         return true;


### PR DESCRIPTION
This is to avoid duplicated usd stages on Maya scene reopen.

It happens in cases when we have nested proxyShapes, where the children proxyShapes got loaded twice:
- Reopen Maya file, postFileRead callback would be run;
- Root proxyShape starts to load the stage;
- Root proxyShape's outStageData plug would be computed, which will request the children proxysShapes' outStageData being computed as well;
- Children proxyShapes will be requested to load their stages, thus postFileRead callback would be triggered again.