### PR TITLE
Fill in missing export translator implementation

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/wrapTranslatorBase.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/wrapTranslatorBase.cpp
@@ -177,7 +177,12 @@ public:
     {
         MFnDependencyNode fn(obj);
         std::string       name(fn.name().asChar());
-        return this->CallVirtual<ExportFlag>("canExport", &This::canExport)(obj);
+
+        // pass a string to the python method instead of a dependency node
+        if (Override o = GetOverride("canExport")) {
+            return std::function<ExportFlag(const char*)>(TfPyCall<ExportFlag>(o))(name.c_str());
+        }
+        return ExportFlag::kNotSupported;
     }
 
     UsdPrim exportObject(
@@ -186,9 +191,20 @@ public:
         const SdfPath&                             usdPath,
         const AL::usdmaya::fileio::ExporterParams& params) override
     {
+        // note: an incomplete list, add as needed
+        boost::python::dict pyParams;
+        pyParams["dynamicAttributes"] = params.m_dynamicAttributes;
+        pyParams["m_minFrame"] = params.m_minFrame;
+        pyParams["m_maxFrame"] = params.m_maxFrame;
+
         std::string name(dagPath.fullPathName().asChar());
-        return this->CallVirtual<UsdPrim>("exportObject", &This::exportObject)(
-            stage, dagPath, usdPath, params);
+        // pass a dagPath name and dictionary of params to the python method
+        if (Override o = GetOverride("exportObject")) {
+            return std::function<UsdPrim(
+                UsdStageRefPtr, const char*, SdfPath, boost::python::dict)>(TfPyCall<UsdPrim>(o))(
+                stage, name.c_str(), usdPath, pyParams);
+        }
+        return UsdPrim();
     }
 
     static void registerTranslator(refptr_t plugin, const TfToken& assetType = TfToken())


### PR DESCRIPTION
Python translator export never worked properly, but the mismatch between the wrapping and the Python implementation is causing errors that we would like to eliminate as a potential source of problems.

Where no export is supported, `canExport()` and `exportObject()` methods are not expected to be implemented in Python translators - leaving dummy methods which don't return the corret type will cause errors.

If implementing the method but return the incorrect type, you will get a runtime error like this:
```
TF_PYTHON_EXCEPTION: in TfPyConvertPythonExceptionToTfErrors at line 114 of ../pxr/base/lib/tf/pyError.cpp -- Tf Python Exception
TypeError: No registered converter was able to produce a C++ rvalue of type AL::usdmaya::fileio::translators::ExportFlag from this Python object of type bool
```