### PR TITLE
Added caching to LayerManager

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.cpp
@@ -29,6 +29,7 @@
 #include <maya/MFnDependencyNode.h>
 #include <maya/MGlobal.h>
 #include <maya/MItDependencyNodes.h>
+#include <maya/MObjectHandle.h>
 #include <maya/MPlugArray.h>
 #include <maya/MProfiler.h>
 
@@ -43,6 +44,9 @@ const int _layerManagerProfilerCategory = MProfiler::addCategory(
     "LayerManager"
 #endif
 );
+
+MObjectHandle theLayerManagerHandle;
+
 } // namespace
 
 namespace {
@@ -299,12 +303,20 @@ MObject LayerManager::findNode()
 //----------------------------------------------------------------------------------------------------------------------
 MObject LayerManager::_findNode()
 {
+    if (theLayerManagerHandle.isValid() && theLayerManagerHandle.isAlive()) {
+        MObject theManager { theLayerManagerHandle.object() };
+        if (!theManager.isNull()) {
+            return theManager;
+        }
+    }
+
     MFnDependencyNode  fn;
     MItDependencyNodes iter(MFn::kPluginDependNode);
     for (; !iter.isDone(); iter.next()) {
         MObject mobj = iter.item();
         fn.setObject(mobj);
         if (fn.typeId() == kTypeId && !fn.isFromReferencedFile()) {
+            theLayerManagerHandle = mobj;
             return mobj;
         }
     }


### PR DESCRIPTION
This PR adds caching to the `LayerManager` node to avoid some very expensive Maya queries being run when editing begins.