### PR TITLE
MAYA-113944 Enable primvar filtering to match HdSt behavior.

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.h
@@ -127,6 +127,8 @@ public:
     TfTokenVector GetMaterialRenderContexts() const override;
 #endif
 
+    bool IsPrimvarFilteringNeeded() const override { return true; }
+
     MString GetLocalNodeName(const MString& name) const;
 
     MHWRender::MShaderInstance* GetFallbackShader(const MColor& color) const;


### PR DESCRIPTION
This gives a substantial performance improvement by avoiding calls to _ComputeAndMergePrimvar made from UsdImagingGprimAdapter::UpdateForTime.