### PR TITLE
Use new libusd library prefix when finding USD_LIBRARY

### DIFF
--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -1,26 +1,5 @@
 # Simple module to find USD.
 
-# Note that on Windows with USD <= 0.19.11, USD_LIB_PREFIX should be left at
-# default (or set to empty string), even if PXR_LIB_PREFIX was specified when
-# building core USD, due to a bug.
-
-# On all other platforms / versions, it should match the PXR_LIB_PREFIX used
-# for building USD (and shouldn't need to be touched if PXR_LIB_PREFIX was not
-# used / left at it's default value).
-
-set(USD_LIB_PREFIX ${CMAKE_SHARED_LIBRARY_PREFIX}
-    CACHE STRING "Prefix of USD libraries; generally matches the PXR_LIB_PREFIX used when building core USD")
-
-if (WIN32)
-    # ".lib" on Windows
-    set(USD_LIB_SUFFIX ${CMAKE_STATIC_LIBRARY_SUFFIX}
-        CACHE STRING "Extension of USD libraries")
-else ()
-    # ".so" on Linux, ".dylib" on MacOS
-    set(USD_LIB_SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX}
-        CACHE STRING "Extension of USD libraries")
-endif ()
-
 # On a system with an existing USD /usr/local installation added to the system
 # PATH, use of PATHS in find_path incorrectly causes the existing USD
 # installation to be found.  As per
@@ -39,20 +18,6 @@ find_path(USD_INCLUDE_DIR
     DOC
         "USD Include directory"
 )
-
-find_library(USD_LIBRARY
-    NAMES
-        ${USD_LIB_PREFIX}usd${USD_LIB_SUFFIX}
-    HINTS
-        ${PXR_USD_LOCATION}
-        $ENV{PXR_USD_LOCATION}
-    PATH_SUFFIXES
-        lib
-    DOC
-        "Main USD library"
-)
-
-get_filename_component(USD_LIBRARY_DIR ${USD_LIBRARY} DIRECTORY)
 
 find_file(USD_GENSCHEMA
     NAMES
@@ -100,6 +65,47 @@ elseif(USD_INCLUDE_DIR AND EXISTS "${USD_INCLUDE_DIR}/pxr/pxr.h")
     set(USD_VERSION ${USD_MAJOR_VERSION}.${USD_MINOR_VERSION}.${USD_PATCH_VERSION})
     math(EXPR PXR_VERSION "${USD_MAJOR_VERSION} * 10000 + ${USD_MINOR_VERSION} * 100 + ${USD_PATCH_VERSION}")
 endif()
+
+# Note that on Windows with USD <= 0.19.11, USD_LIB_PREFIX should be left at
+# default (or set to empty string), even if PXR_LIB_PREFIX was specified when
+# building core USD, due to a bug.
+
+# On all other platforms / versions, it should match the PXR_LIB_PREFIX used
+# for building USD (and shouldn't need to be touched if PXR_LIB_PREFIX was not
+# used / left at it's default value). Starting with USD 21.11, the default
+# value for PXR_LIB_PREFIX was changed to include "usd_".
+
+if (USD_VERSION VERSION_GREATER_EQUAL "0.21.11")
+    set(USD_LIB_PREFIX "${CMAKE_SHARED_LIBRARY_PREFIX}usd_"
+        CACHE STRING "Prefix of USD libraries; generally matches the PXR_LIB_PREFIX used when building core USD")
+else()
+    set(USD_LIB_PREFIX ${CMAKE_SHARED_LIBRARY_PREFIX}
+        CACHE STRING "Prefix of USD libraries; generally matches the PXR_LIB_PREFIX used when building core USD")
+endif()
+
+if (WIN32)
+    # ".lib" on Windows
+    set(USD_LIB_SUFFIX ${CMAKE_STATIC_LIBRARY_SUFFIX}
+        CACHE STRING "Extension of USD libraries")
+else ()
+    # ".so" on Linux, ".dylib" on MacOS
+    set(USD_LIB_SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX}
+        CACHE STRING "Extension of USD libraries")
+endif ()
+
+find_library(USD_LIBRARY
+    NAMES
+        ${USD_LIB_PREFIX}usd${USD_LIB_SUFFIX}
+    HINTS
+        ${PXR_USD_LOCATION}
+        $ENV{PXR_USD_LOCATION}
+    PATH_SUFFIXES
+        lib
+    DOC
+        "Main USD library"
+)
+
+get_filename_component(USD_LIBRARY_DIR ${USD_LIBRARY} DIRECTORY)
 
 # Get the boost version from the one built with USD
 if(USD_INCLUDE_DIR)


### PR DESCRIPTION
With 21.11, usd libraries change their prefix to avoid conflicts with
other non-usd libraries that may be in use in some environments. This
caused mayaUsd to fail to find the USD_LIBRARY path. Update the cmake
file to look for these new prefixes in 21.11 and beyond.