### PR TITLE
Derive ALModelAPI from APISchemaBase

### DIFF
--- a/plugin/al/schemas/AL/usd/schemas/maya/schema.usda.in
+++ b/plugin/al/schemas/AL/usd/schemas/maya/schema.usda.in
@@ -69,7 +69,7 @@ over "GLOBAL" (
 class "ALModelAPI"
 (
 doc = "Data used to import a maya reference."
-  inherits = </ModelAPI>
+  inherits = </APISchemaBase>
   customData = {
         string apiSchemaType = "nonApplied"
         string className = "ModelAPI"


### PR DESCRIPTION
With this USD change:
https://github.com/PixarAnimationStudios/USD/commit/a0f3766

Applied API schemas now have a restriction in which they must be
inherited from APISchemaBase. There was unintended fallout from this,
which is that this restiction is also being enforced on "non-applied"
API schemas, so with latest USD, the build complains.

As a stopgap, the USD team had hoped that the Animal Logic schema only
derives from UsdModelAPI for concept-correctness, and that we could
instead derive from APISchemaBase to allow builds to start passing
again. AL friends: please let me know if this is not the case!