### PR TITLE
Use HdRprim's render tag data for VP2 mesh shared data

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -685,6 +685,12 @@ void HdVP2BasisCurves::Sync(
             _MakeOtherReprRenderItemsInvisible(delegate, reprToken);
     }
 
+#if PXR_VERSION > 2111
+    // Hydra now manages and caches render tags under the hood and is clearing
+    // the dirty bit prior to calling sync. Unconditionally set the render tag
+    // in the shared data structure based on current Hydra data
+    _meshSharedData->_renderTag = GetRenderTag();
+#else
     if (*dirtyBits
         & (HdChangeTracker::DirtyRenderTag
 #ifdef ENABLE_RENDERTAG_VISIBILITY_WORKAROUND
@@ -693,6 +699,7 @@ void HdVP2BasisCurves::Sync(
            )) {
         _curvesSharedData._renderTag = delegate->GetRenderTag(id);
     }
+#endif
 
     *dirtyBits = HdChangeTracker::Clean;
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1113,6 +1113,12 @@ void HdVP2Mesh::Sync(
             _MakeOtherReprRenderItemsInvisible(delegate, reprToken);
     }
 
+#if PXR_VERSION > 2111
+    // Hydra now manages and caches render tags under the hood and is clearing
+    // the dirty bit prior to calling sync. Unconditionally set the render tag
+    // in the shared data structure based on current Hydra data
+    _meshSharedData->_renderTag = GetRenderTag();
+#else
     if (*dirtyBits
         & (HdChangeTracker::DirtyRenderTag
 #ifdef ENABLE_RENDERTAG_VISIBILITY_WORKAROUND
@@ -1121,6 +1127,7 @@ void HdVP2Mesh::Sync(
            )) {
         _meshSharedData->_renderTag = delegate->GetRenderTag(id);
     }
+#endif
 
     *dirtyBits = HdChangeTracker::Clean;
 


### PR DESCRIPTION
Starting in USD 22.02, Hydra internally manages render tag data for
rprims. This was causing the dirty bit to be cleared prior to calling
sync, causing the render tag data to never get set in _meshSharedData.
Ultimately we could always just use the rprim's GetRenderTag API, but
since MeshViewportCompute is only sent the SharedData strcuture, we'll
set _meshSharedData unconditionally for now.