### PR TITLE
Fixed tagged excluded prims to update correctly when changed

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.cpp
@@ -1315,12 +1315,6 @@ MStatus TranslatePrim::redoIt()
         m_proxy->processChangedMetaData(SdfPathVector(), newImportPaths);
     }
 
-    // construct locks and selectability for imported prims
-    if (m_proxy->isLockPrimFeatureActive()) {
-        m_proxy->removeMetaData(m_teardownPaths);
-        m_proxy->processChangedMetaData(SdfPathVector(), newImportPaths);
-    }
-
     if (!m_updatePaths.empty()) {
 
         // check paths refer to valid prims for this stage

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/ProxyShapeMetaData.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/ProxyShapeMetaData.cpp
@@ -20,6 +20,8 @@
 #include "AL/usdmaya/nodes/ProxyShape.h"
 #include "AL/usdmaya/nodes/Transform.h"
 
+#include <mayaUsd/nodes/proxyShapePlugin.h>
+
 #include <maya/MProfiler.h>
 namespace {
 const int _proxyShapeMetadataProfilerCategory = MProfiler::addCategory(
@@ -100,13 +102,14 @@ void ProxyShape::processChangedMetaData(
                 m_lockManager.setInherited(path);
             }
         }
-        m_lockManager.sort();
-    } else {
+    }
+    bool excludedPrimsModified = false;
+    {
         auto& unselectablePaths = m_selectabilityDB.m_unselectablePaths;
 
         // figure out whether selectability has changed.
         for (const SdfPath& path : resyncedPaths) {
-            UsdPrim syncPrimRoot = m_stage->GetPrimAtPath(path);
+            const UsdPrim syncPrimRoot = m_stage->GetPrimAtPath(path);
             if (!syncPrimRoot) {
                 // TODO : Ensure elements have been removed from selectabilityDB, excludeGeom, and
                 // lock prims
@@ -141,27 +144,31 @@ void ProxyShape::processChangedMetaData(
             // from the resync prim, traverse downwards through the child prims
             for (fileio::TransformIterator it(syncPrimRoot, parentTransform(), true); !it.done();
                  it.next()) {
-                auto prim = it.prim();
-                auto path = prim.GetPath();
+                const auto prim = it.prim();
+                const auto path = prim.GetPath();
 
                 // first check to see if the excluded geom has changed
                 {
                     bool excludeGeo = false;
                     if (prim.GetMetadata(Metadata::excludeFromProxyShape, &excludeGeo)
                         && excludeGeo) {
-                        auto last = m_excludedTaggedGeometry.begin() + lastTaggedPrim;
-                        auto it = std::lower_bound(m_excludedTaggedGeometry.begin(), last, path);
+                        const auto last = m_excludedTaggedGeometry.begin() + lastTaggedPrim;
+                        const auto it
+                            = std::lower_bound(m_excludedTaggedGeometry.begin(), last, path);
                         if (it != last && *it == path) {
                             // we already have an entry for this prim
                         } else {
                             // add to back of list
+                            excludedPrimsModified = true;
                             m_excludedTaggedGeometry.emplace_back(path);
                         }
                     } else {
                         // if we aren't excluding the geom, but have an existing entry, remove it.
-                        auto last = m_excludedTaggedGeometry.begin() + lastTaggedPrim;
-                        auto it = std::lower_bound(m_excludedTaggedGeometry.begin(), last, path);
+                        const auto last = m_excludedTaggedGeometry.begin() + lastTaggedPrim;
+                        const auto it
+                            = std::lower_bound(m_excludedTaggedGeometry.begin(), last, path);
                         if (it != last && *it == path) {
+                            excludedPrimsModified = true;
                             m_excludedTaggedGeometry.erase(it);
                             --lastTaggedPrim;
                         }
@@ -219,6 +226,14 @@ void ProxyShape::processChangedMetaData(
     // reconstruct the lock prims
     {
         constructLockPrims();
+    }
+
+    if (excludedPrimsModified) {
+        if (MayaUsdProxyShapePlugin::useVP2_NativeUSD_Rendering()) {
+            _IncreaseExcludePrimPathsVersion();
+        } else {
+            constructGLImagingEngine();
+        }
     }
 }
 
@@ -363,9 +378,10 @@ SdfPathVector ProxyShape::getExcludePrimPaths() const
 {
     TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("ProxyShape::getExcludePrimPaths\n");
 
-    SdfPathVector paths = getPrimPathsFromCommaJoinedString(excludePrimPathsPlug().asString());
-    SdfPathVector temp
-        = getPrimPathsFromCommaJoinedString(excludedTranslatedGeometryPlug().asString());
+    SdfPathVector paths = m_excludedTaggedGeometry;
+    SdfPathVector temp = getPrimPathsFromCommaJoinedString(excludePrimPathsPlug().asString());
+    paths.insert(paths.end(), temp.begin(), temp.end());
+    temp = getPrimPathsFromCommaJoinedString(excludedTranslatedGeometryPlug().asString());
     paths.insert(paths.end(), temp.begin(), temp.end());
 
     const auto& translatedGeo = m_context->excludedGeometry();


### PR DESCRIPTION
This PR fixes tagged excluded prims not updating correctly when changing metadata values. It also makes sure to rebuild the `UsdImagingDelegate` used within the VP2 render delegate when those prims are modified.