### PR TITLE
Added file format attribute to LayerManager and improved format detection for serialised layers

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.h
+++ b/lib/mayaUsd/nodes/layerManager.h
@@ -114,6 +114,7 @@ public:
 
     static MObject layers;
     static MObject identifier;
+    static MObject fileFormatId;
     static MObject serialized;
     static MObject anonymous;
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.cpp
@@ -268,6 +268,7 @@ AL_MAYA_DEFINE_NODE(LayerManager, AL_USDMAYA_LAYERMANAGER, AL_usdmaya);
 // serialization
 MObject LayerManager::m_layers = MObject::kNullObj;
 MObject LayerManager::m_identifier = MObject::kNullObj;
+MObject LayerManager::m_fileFormatId = MObject::kNullObj;
 MObject LayerManager::m_serialized = MObject::kNullObj;
 MObject LayerManager::m_anonymous = MObject::kNullObj;
 
@@ -300,6 +301,8 @@ MStatus LayerManager::initialise()
 
         // add attributes to store the serialization info
         m_identifier = addStringAttr("identifier", "id", kCached | kReadable | kStorable | kHidden);
+        m_fileFormatId
+            = addStringAttr("fileFormatId", "fid", kCached | kReadable | kStorable | kHidden);
         m_serialized
             = addStringAttr("serialized", "szd", kCached | kReadable | kStorable | kHidden);
         m_anonymous
@@ -309,7 +312,7 @@ MStatus LayerManager::initialise()
             "lyr",
             kCached | kReadable | kWritable | kStorable | kConnectable | kHidden | kArray
                 | kUsesArrayDataBuilder,
-            { m_identifier, m_serialized, m_anonymous });
+            { m_identifier, m_fileFormatId, m_serialized, m_anonymous });
     } catch (const MStatus& status) {
         return status;
     }
@@ -467,6 +470,9 @@ MStatus LayerManager::populateSerialisationAttributes()
             AL_MAYA_CHECK_ERROR(status, errorString);
             MDataHandle idHandle = layersElemHandle.child(m_identifier);
             idHandle.setString(AL::maya::utils::convert(layer->GetIdentifier()));
+            MDataHandle fileFormatIdHandle = layersElemHandle.child(m_fileFormatId);
+            auto        fileFormatIdToken = layer->GetFileFormat()->GetFormatId();
+            fileFormatIdHandle.setString(AL::maya::utils::convert(fileFormatIdToken.GetString()));
             MDataHandle serializedHandle = layersElemHandle.child(m_serialized);
             layer->ExportToString(&temp);
             serializedHandle.setString(AL::maya::utils::convert(temp));
@@ -519,9 +525,11 @@ void LayerManager::loadAllLayers()
     MPlug          allLayersPlug = layersPlug();
     MPlug          singleLayerPlug;
     MPlug          idPlug;
+    MPlug          fileFormatIdPlug;
     MPlug          anonymousPlug;
     MPlug          serializedPlug;
     std::string    identifierVal;
+    std::string    fileFormatIdVal;
     std::string    serializedVal;
     SdfLayerRefPtr layer;
     // We DON'T want to use evaluate num elements, because we don't want to trigger
@@ -531,6 +539,8 @@ void LayerManager::loadAllLayers()
         singleLayerPlug = allLayersPlug.elementByPhysicalIndex(i, &status);
         AL_MAYA_CHECK_ERROR_CONTINUE(status, errorString);
         idPlug = singleLayerPlug.child(m_identifier, &status);
+        AL_MAYA_CHECK_ERROR_CONTINUE(status, errorString);
+        fileFormatIdPlug = singleLayerPlug.child(m_fileFormatId, &status);
         AL_MAYA_CHECK_ERROR_CONTINUE(status, errorString);
         anonymousPlug = singleLayerPlug.child(m_anonymous, &status);
         AL_MAYA_CHECK_ERROR_CONTINUE(status, errorString);
@@ -543,6 +553,13 @@ void LayerManager::loadAllLayers()
             MGlobal::displayError(
                 MString("Error - plug ") + idPlug.partialName(true) + "had empty identifier");
             continue;
+        }
+        fileFormatIdVal = fileFormatIdPlug.asString(MDGContext::fsNormal, &status).asChar();
+        AL_MAYA_CHECK_ERROR_CONTINUE(status, errorString);
+        if (fileFormatIdVal.empty()) {
+            MGlobal::displayInfo(
+                MString("No file format in ") + fileFormatIdPlug.partialName(true)
+                + " plug. Will use identifier to work it out.");
         }
         serializedVal = serializedPlug.asString(MDGContext::fsNormal, &status).asChar();
         AL_MAYA_CHECK_ERROR_CONTINUE(status, errorString);
@@ -570,13 +587,18 @@ void LayerManager::loadAllLayers()
                 // identifier, which could cause an error. This seems unlikely, but we have a
                 // discussion with Pixar to find a way to avoid this.
 
-                auto fileFormat
-                    = SdfFileFormat::FindByExtension(ArGetResolver().GetExtension(identifierVal));
-                if (!fileFormat) {
-                    MGlobal::displayError(
-                        MString("Cannot determine file format for identifier '")
-                        + identifierVal.c_str() + "' for plug " + idPlug.partialName(true));
-                    continue;
+                SdfFileFormatConstPtr fileFormat;
+                if (!fileFormatIdVal.empty()) {
+                    fileFormat = SdfFileFormat::FindById(TfToken(fileFormatIdVal));
+                } else {
+                    fileFormat = SdfFileFormat::FindByExtension(
+                        ArGetResolver().GetExtension(identifierVal));
+                    if (!fileFormat) {
+                        MGlobal::displayError(
+                            MString("Cannot determine file format for identifier '")
+                            + identifierVal.c_str() + "' for plug " + idPlug.partialName(true));
+                        continue;
+                    }
                 }
 
                 // In order to make the layer reloadable by SdfLayer::Reload(), we hack the

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.h
@@ -358,6 +358,7 @@ public:
     // - they only make sense for a particular index of the parent array-attribute... and it taking
     // up the "identifierPlug" name is confusing
     AL_DECL_MULTI_CHILD_ATTRIBUTE(identifier);
+    AL_DECL_MULTI_CHILD_ATTRIBUTE(fileFormatId);
     AL_DECL_MULTI_CHILD_ATTRIBUTE(serialized);
     AL_DECL_MULTI_CHILD_ATTRIBUTE(anonymous);
 

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_LayerManager.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_LayerManager.cpp
@@ -353,6 +353,9 @@ def Scope "blabla"
         tempNonConst = manager->identifier();
         MPlug idPlug = layersPlug0.child(tempNonConst, &status);
         ASSERT_TRUE(status);
+        tempNonConst = manager->fileFormatId();
+        MPlug fileFormatIdPlug = layersPlug0.child(tempNonConst, &status);
+        ASSERT_TRUE(status);
         tempNonConst = manager->serialized();
         MPlug serializedPlug = layersPlug0.child(tempNonConst, &status);
         ASSERT_TRUE(status);
@@ -363,6 +366,10 @@ def Scope "blabla"
         ASSERT_EQ(
             MString(realLayer->GetIdentifier().c_str()),
             idPlug.asString(MDGContext::fsNormal, &status));
+        ASSERT_TRUE(status);
+        ASSERT_EQ(
+            MString(realLayer->GetFileFormat()->GetFormatId().GetText()),
+            fileFormatIdPlug.asString(MDGContext::fsNormal, &status));
         ASSERT_TRUE(status);
         ASSERT_EQ(MString(LAYER_CONTENTS), serializedPlug.asString(MDGContext::fsNormal, &status));
         ASSERT_TRUE(status);

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_TransformMatrix.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_TransformMatrix.cpp
@@ -41,6 +41,8 @@
 #include <maya/MSelectionList.h>
 #include <maya/MVector.h>
 
+#include <iostream>
+
 using AL::maya::test::buildTempPath;
 
 // #define TEST(X, Y) void X##Y()

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testLayerManager.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testLayerManager.py
@@ -23,7 +23,7 @@ import unittest
 from maya import cmds
 from AL.usdmaya import ProxyShape
 
-import fixturesUtils
+from pxr import Sdf, Usd
 
 class TestLayerManagerSerialisation(unittest.TestCase):
     """Test cases for layer manager serialisation and deserialisation"""
@@ -213,5 +213,9 @@ class TestLayerManagerSerialisation(unittest.TestCase):
         _reloadAndAssert(rootLayerPath, proxyName)
 
 
-if __name__ == '__main__':
-    fixturesUtils.runTests(globals())
+if __name__ == "__main__":
+
+    tests = [unittest.TestLoader().loadTestsFromTestCase(TestLayerManagerSerialisation),]
+    results = [unittest.TextTestRunner(verbosity=2).run(test) for test in tests]
+    exitCode = int(not all([result.wasSuccessful() for result in results]))
+    cmds.quit(exitCode=(exitCode))

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testTranslators.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testTranslators.py
@@ -27,8 +27,6 @@ from AL import usdmaya
 
 from pxr import Usd, UsdUtils, Tf
 
-import fixturesUtils
-
 class CubeGenerator(usdmaya.TranslatorBase):
     '''
     Basic Translator which doesn't support update
@@ -746,5 +744,11 @@ class TestPythonTranslatorsUniqueKey(unittest.TestCase):
         self.assertTrue(cmds.objExists('|bindings_grp|root|dynamic_five_cubes'))
 
 
-if __name__ == '__main__':
-    fixturesUtils.runTests(globals())
+if __name__ == "__main__":
+
+    tests = [unittest.TestLoader().loadTestsFromTestCase(TestPythonTranslators)]
+    tests += [unittest.TestLoader().loadTestsFromTestCase(TestPythonTranslatorsUniqueKey)]
+
+    results = [unittest.TextTestRunner(verbosity=2).run(test) for test in tests]
+    exitCode = int(not all([result.wasSuccessful() for result in results]))
+    cmds.quit(force=True, exitCode=(exitCode))

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testUSDMayaPythonModuleOnly.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testUSDMayaPythonModuleOnly.py
@@ -27,8 +27,6 @@
 import unittest
 import tempfile
 
-from pxr import Tf, Usd, UsdGeom, Gf
-
 class TestPythonModule(unittest.TestCase):
 
     def testImport(self):
@@ -60,7 +58,7 @@ class TestPythonModule(unittest.TestCase):
                          AL.usdmaya.ExportFlag.kSupported)
 
 
-tests = unittest.TestLoader().loadTestsFromTestCase(TestPythonModule)
-result = unittest.TextTestRunner(verbosity=2).run(tests)
-
-exit(not result.wasSuccessful())
+if __name__ == "__main__":
+    tests = unittest.TestLoader().loadTestsFromTestCase(TestPythonModule)
+    result = unittest.TextTestRunner(verbosity=2).run(tests)
+    exit(not result.wasSuccessful())


### PR DESCRIPTION
This PR allows for the extension to now be retrieved using USD's API instead of string parsing, and adds the layer's file format as a serialisation attribute (along with the current identifier and serialised content).

This is to help deserialisation in the case that the identifier does not resolve without a proper context (which is the case with the layer manager).