### PR TITLE
Adding definition for "kCreateStage" string constant

### DIFF
--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
@@ -29,7 +29,7 @@ global proc mayaUSDRegisterStrings() {
     register("kCreateUsdStageFromFile", "Create USD Stage from File");
     register("kCreateUsdStageFromFileOptions", "Create USD Stage from File Options");
     register("kCreateStageFromFile", "Create Stage from File");
-    register("kCreate", "Ok");
+    register("kCreateStage", "Create");
     register("kDefaultPrim", "Default Prim");
     register("kDefaultPrimAnn", "As part of its metadata, each stage can identify a default prim. This is the primitive that is referenced in if you reference in a file.");
     register("kExcludePrimPaths", "Exclude Prim Paths:");

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
@@ -29,6 +29,7 @@ global proc mayaUSDRegisterStrings() {
     register("kCreateUsdStageFromFile", "Create USD Stage from File");
     register("kCreateUsdStageFromFileOptions", "Create USD Stage from File Options");
     register("kCreateStageFromFile", "Create Stage from File");
+    register("kCreate", "Ok");
     register("kDefaultPrim", "Default Prim");
     register("kDefaultPrimAnn", "As part of its metadata, each stage can identify a default prim. This is the primitive that is referenced in if you reference in a file.");
     register("kExcludePrimPaths", "Exclude Prim Paths:");

--- a/plugin/adsk/scripts/mayaUsd_createStageFromFile.mel
+++ b/plugin/adsk/scripts/mayaUsd_createStageFromFile.mel
@@ -221,7 +221,7 @@ global proc mayaUsd_createStageFromFile() {
     
     $caption = getMayaUsdString("kCreateUsdStageFromFile");
     $fileFilter = getMayaUsdString("kAllUsdFiles") + " (*.usd *.usda *.usdc *.usdz);;*.usd;;*.usda;;*.usdc;;*.usdz";
-    $okCaption = getMayaUsdString("kCreate");
+    $okCaption = getMayaUsdString("kCreateStage");
     
     string $startFolder = getLatestLoadStageFolder();
 


### PR DESCRIPTION
"kCreate" string definition is missing in mayaUSDRegisterStrings.mel file which causes the following runtime error upon click on "Universal Scene Descriptor(USD)" -> "Stage From File" menu item:

// Error: file: C:/Program Files/Autodesk/Maya2022/scripts/others/getPluginResource.mel line 66: Plug-in resource lookup failed, resource ("mayaUsdPlugin","kCreate") is not registered