### PR TITLE
MAYA-114428 Compile mayapy on Linux and OSX to avoid search path issues.

### DIFF
--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -360,6 +360,8 @@ finally:
         # Necessary for tests like DiffCore to find python
         set_property(TEST "${test_name}" APPEND PROPERTY ENVIRONMENT
             "DYLD_LIBRARY_PATH=${MAYA_LOCATION}/MacOS:$ENV{DYLD_LIBRARY_PATH}")
+        set_property(TEST "${test_name}" APPEND PROPERTY ENVIRONMENT
+            "DYLD_FRAMEWORK_PATH=${MAYA_LOCATION}/Maya.app/Contents/Frameworks")
     endif()
 
     if (PREFIX_INTERACTIVE)


### PR DESCRIPTION
Set Frameworks to force the test to take Python from the correct path.