### PR TITLE
Fix textures missing on OS/X with V2 Lighting

### DIFF
--- a/lib/mayaUsd/render/vp2ShaderFragments/usdPreviewSurfaceLightingAPI2.xml
+++ b/lib/mayaUsd/render/vp2ShaderFragments/usdPreviewSurfaceLightingAPI2.xml
@@ -175,7 +175,7 @@ evaluateLight(
 
     // Evaluate specular first lobe
     vec3 s1 = vec3(0.0);
-    const float R = (1.0 - ior) / (1.0 + ior);
+    float R = (1.0 - ior) / (1.0 + ior);
     if (specularAmount > 0.0) {
         vec3 F0 = specularColor;
         vec3 F90 = vec3(1.0);
@@ -246,7 +246,7 @@ evaluateIndirectLighting(
     vec3 F0 = specularColor;
     vec3 F90 = vec3(1.0);
     vec3 d = diffuseColor;
-    const float R = (1.0 - ior) / (1.0 + ior);
+    float R = (1.0 - ior) / (1.0 + ior);
     if (!useSpecularWorkflow) {
         vec3 specColor = mix(vec3(1.0), diffuseColor, metallic);
         F0 = mix(R * R * specColor, specColor, metallic);
@@ -270,7 +270,7 @@ evaluateIndirectLighting(
     // Clearcoat Component
     vec3 clearcoat = vec3(0.0);
     if (clearcoatAmount > 0.0) {
-        const vec3 clearcoatF = clearcoatAmount * mix(
+        vec3 clearcoatF = clearcoatAmount * mix(
             R * R * clearcoatColor, // Clearcoat F0
             clearcoatColor,         // Clearcoat F90
             fresnel);
@@ -529,7 +529,7 @@ evaluateLight(
 
     // Evaluate specular first lobe
     vec3 s1 = vec3(0.0);
-    const float R = (1.0 - ior) / (1.0 + ior);
+    float R = (1.0 - ior) / (1.0 + ior);
     if (specularAmount > 0.0) {
         vec3 F0 = specularColor;
         vec3 F90 = vec3(1.0);
@@ -600,7 +600,7 @@ evaluateIndirectLighting(
     vec3 F0 = specularColor;
     vec3 F90 = vec3(1.0);
     vec3 d = diffuseColor;
-    const float R = (1.0 - ior) / (1.0 + ior);
+    float R = (1.0 - ior) / (1.0 + ior);
     if (!useSpecularWorkflow) {
         vec3 specColor = mix(vec3(1.0), diffuseColor, metallic);
         F0 = mix(R * R * specColor, specColor, metallic);
@@ -624,7 +624,7 @@ evaluateIndirectLighting(
     // Clearcoat Component
     vec3 clearcoat = vec3(0.0);
     if (clearcoatAmount > 0.0) {
-        const vec3 clearcoatF = clearcoatAmount * mix(
+        vec3 clearcoatF = clearcoatAmount * mix(
             R * R * clearcoatColor, // Clearcoat F0
             clearcoatColor,         // Clearcoat F90
             fresnel);
@@ -883,7 +883,7 @@ evaluateLight(
 
     // Evaluate specular first lobe
     float3 s1 = float3(0.0, 0.0, 0.0);
-    const float R = (1.0 - ior) / (1.0 + ior);
+    float R = (1.0 - ior) / (1.0 + ior);
     if (specularAmount > 0.0) {
         float3 F0 = specularColor;
         float3 F90 = float3(1.0, 1.0, 1.0);
@@ -954,7 +954,7 @@ evaluateIndirectLighting(
     float3 F0 = specularColor;
     float3 F90 = float3(1.0, 1.0, 1.0);
     float3 d = diffuseColor;
-    const float R = (1.0 - ior) / (1.0 + ior);
+    float R = (1.0 - ior) / (1.0 + ior);
     if (!useSpecularWorkflow) {
         float3 specColor = lerp(float3(1.0, 1.0, 1.0), diffuseColor, metallic);
         F0 = lerp(R * R * specColor, specColor, metallic);
@@ -978,7 +978,7 @@ evaluateIndirectLighting(
     // Clearcoat Component
     float3 clearcoat = float3(0.0, 0.0, 0.0);
     if (clearcoatAmount > 0.0) {
-        const float3 clearcoatF = clearcoatAmount * lerp(
+        float3 clearcoatF = clearcoatAmount * lerp(
             R * R * clearcoatColor, // Clearcoat F0
             clearcoatColor,         // Clearcoat F90
             fresnel);


### PR DESCRIPTION
The OS/X shader compilator support only literals for const initializers.