### PR TITLE
Update callsites to work with USD dev API changes

### DIFF
--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
@@ -603,8 +603,13 @@ MStatus MtohRenderOverride::Render(const MHWRender::MDrawContext& drawContext)
                         = dynamic_cast<HdMayaSceneDelegate*>(delegate.get())) {
                         params.camera = mayaScene->SetCameraViewport(camPath, _viewport);
                         if (vpDirty)
+#if HD_API_VERSION >= 43
+                            mayaScene->GetChangeTracker().MarkSprimDirty(
+                                params.camera, HdCamera::DirtyParams);
+#else
                             mayaScene->GetChangeTracker().MarkSprimDirty(
                                 params.camera, HdCamera::DirtyParams | HdCamera::DirtyProjMatrix);
+#endif
                         break;
                     }
                 }

--- a/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
@@ -141,7 +141,7 @@ PxrMayaHdSceneDelegate::PxrMayaHdSceneDelegate(
         cache[HdTokens->transform] = VtValue(GfMatrix4d(1.0));
         cache[HdCameraTokens->windowPolicy] = VtValue(CameraUtilFit);
         cache[HdCameraTokens->clipPlanes] = VtValue(std::vector<GfVec4d>());
-#if PXR_VERSION >= 2102
+#if HD_API_VERSION >= 43
         cache[HdCameraTokens->projection] = VtValue(HdCamera::Orthographic);
         cache[HdCameraTokens->horizontalAperture] = VtValue(2.0f * float(GfCamera::APERTURE_UNIT));
         cache[HdCameraTokens->verticalAperture] = VtValue(2.0f * float(GfCamera::APERTURE_UNIT));
@@ -153,6 +153,9 @@ PxrMayaHdSceneDelegate::PxrMayaHdSceneDelegate(
         cache[HdCameraTokens->worldToViewMatrix] = VtValue(GfMatrix4d(1.0));
         cache[HdCameraTokens->projectionMatrix] = VtValue(GfMatrix4d(1.0));
 
+#if PXR_VERSION >= 2102
+        cache[HdCameraTokens->projection] = VtValue();
+#endif
         cache[HdCameraTokens->horizontalAperture] = VtValue();
         cache[HdCameraTokens->verticalAperture] = VtValue();
         cache[HdCameraTokens->horizontalApertureOffset] = VtValue();
@@ -262,7 +265,7 @@ TfTokenVector PxrMayaHdSceneDelegate::GetTaskRenderTags(SdfPath const& taskId)
     return value.Get<TfTokenVector>();
 }
 
-#if PXR_VERSION >= 2102
+#if HD_API_VERSION >= 43
 static HdCamera::Projection _ToHd(const GfCamera::Projection projection)
 {
     switch (projection) {
@@ -284,7 +287,7 @@ void PxrMayaHdSceneDelegate::SetCameraState(
     cache[HdCameraTokens->windowPolicy] = VtValue(CameraUtilFit);
     cache[HdCameraTokens->clipPlanes] = VtValue(std::vector<GfVec4d>());
 
-#if PXR_VERSION >= 2102
+#if HD_API_VERSION >= 43
     GfCamera cam;
     cam.SetFromViewAndProjectionMatrix(worldToViewMatrix, projectionMatrix);
     cache[HdTokens->transform] = VtValue(cam.GetTransform());
@@ -305,6 +308,9 @@ void PxrMayaHdSceneDelegate::SetCameraState(
     cache[HdTokens->transform] = VtValue(worldToViewMatrix.GetInverse());
     cache[HdCameraTokens->worldToViewMatrix] = VtValue(worldToViewMatrix);
     cache[HdCameraTokens->projectionMatrix] = VtValue(projectionMatrix);
+#if PXR_VERSION >= 2102
+    cache[HdCameraTokens->projection] = VtValue();
+#endif
     cache[HdCameraTokens->horizontalAperture] = VtValue();
     cache[HdCameraTokens->verticalAperture] = VtValue();
     cache[HdCameraTokens->horizontalApertureOffset] = VtValue();

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -689,7 +689,7 @@ void HdVP2BasisCurves::Sync(
     // Hydra now manages and caches render tags under the hood and is clearing
     // the dirty bit prior to calling sync. Unconditionally set the render tag
     // in the shared data structure based on current Hydra data
-    _meshSharedData->_renderTag = GetRenderTag();
+    _curvesSharedData._renderTag = GetRenderTag();
 #else
     if (*dirtyBits
         & (HdChangeTracker::DirtyRenderTag

--- a/lib/usd/hdMaya/adapters/cameraAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/cameraAdapter.cpp
@@ -92,9 +92,13 @@ void HdMayaCameraAdapter::CreateCallbacks()
         obj,
         +[](MObject& obj, void* clientData) {
             auto* adapter = reinterpret_cast<HdMayaCameraAdapter*>(clientData);
-            // Dirty everything rather than track complex param and fit to projection dependencies.
+        // Dirty everything rather than track complex param and fit to projection dependencies.
+#if HD_API_VERSION >= 43
+            adapter->MarkDirty(HdCamera::DirtyParams | HdCamera::DirtyWindowPolicy);
+#else
             adapter->MarkDirty(
                 HdCamera::DirtyParams | HdCamera::DirtyProjMatrix | HdCamera::DirtyWindowPolicy);
+#endif
         },
         reinterpret_cast<void*>(this),
         &status);

--- a/lib/usd/hdMaya/adapters/materialNetworkConverter.h
+++ b/lib/usd/hdMaya/adapters/materialNetworkConverter.h
@@ -26,6 +26,8 @@
 #include <maya/MFnDependencyNode.h>
 #include <maya/MObject.h>
 
+#include <unordered_map>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 struct HdMayaShaderParam


### PR DESCRIPTION
Hydra API continues to change in latest USD dev. This change updates
callsites to allow MayaUSD to work with latest USD.

Use Physical Attributes for HdCamera
Remove deprecated HdCamera dirty bits
Fix wrong member name usage for basisCurves
Prepare for future changes which will remove unneeded headers