### PR TITLE
Use mayapy as Python interpreter on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,9 @@ endif()
 #------------------------------------------------------------------------------
 # modules and definitions
 #------------------------------------------------------------------------------
+include(cmake/utils.cmake)
+find_package(Maya 2018 REQUIRED)
+
 if (BUILD_MAYAUSD_LIBRARY)
     include(cmake/mayausd_version.info)
     set(MAYAUSD_VERSION "${MAYAUSD_MAJOR_VERSION}.${MAYAUSD_MINOR_VERSION}.${MAYAUSD_PATCH_LEVEL}")
@@ -96,11 +99,8 @@ message(STATUS "   PYTHON_INCLUDE_DIRS = ${PYTHON_INCLUDE_DIRS}")
 message(STATUS "   PYTHON_LIBRARIES    = ${PYTHON_LIBRARIES}")
 message(STATUS "   Python_EXECUTABLE   = ${Python_EXECUTABLE}")
 
-include(cmake/utils.cmake)
-
 include(cmake/jinja.cmake)
 
-find_package(Maya 2018 REQUIRED)
 if (CMAKE_WANT_MATERIALX_BUILD)
     # Requires USD_SHA1 > 891eef161aeed582b9831584ab7f31ebe4bc52e8 for hdMtlx module
     find_package(USD 0.21.08 REQUIRED)

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -64,6 +64,11 @@ function(mayaUsd_find_python_module module)
     string(TOUPPER ${module} module_upper)
     set(MODULE_FOUND "${module_upper}_FOUND")
     if(NOT ${MODULE_FOUND})
+        # Check for Python Executable
+        if(NOT DEFINED Python_EXECUTABLE OR Python_EXECUTABLE STREQUAL "")
+            MESSAGE(FATAL_ERROR "Python_EXECUTABLE is not set")
+        endif()
+
         if(ARGC GREATER 1 AND ARGV1 STREQUAL "REQUIRED")
             set(${module}_FIND_REQUIRED TRUE)
         endif()


### PR DESCRIPTION
This PR adds a workaround to compilation issues on Macs where the Python binary included with Maya points to a nonexistent path. See https://github.com/Autodesk/maya-usd/issues/1351 

I'd forgotten to clean up and update our internal workaround, so here it is.
This changes it so the CMake script will try and find Maya earlier in the generation, which then allows the `mayapy` path to be used as the Python interpreter directly.

This also seems to work fine with our Maya 2020 builds as well, so I've only left this behind a platform check and not a version check.