### PR TITLE
MAYA-114707 test passing array to Maya commands

### DIFF
--- a/test/lib/ufe/CMakeLists.txt
+++ b/test/lib/ufe/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_SCRIPT_FILES
     testMayaPickwalk.py
     testPythonWrappers.py
     testSelection.py
+    testSelectionByArray.py
     testUfePythonImport.py
     testAttributeBlock.py
     testBlockedLayerEdit.py

--- a/test/lib/ufe/testSelectionByArray.py
+++ b/test/lib/ufe/testSelectionByArray.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright 2020 Autodesk
+# Copyright 2021 Autodesk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -86,7 +86,6 @@ class SelectByArrayTestCase(unittest.TestCase):
         # Clear selection to start off
         cmds.select(clear=True)
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
     def testSelectMayaPathInMel(self):
         """
         Select multiple Maya items by passing them in an array to a mel command.
@@ -97,7 +96,7 @@ class SelectByArrayTestCase(unittest.TestCase):
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 3)
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectUFEInMel only works with fixes available in Maya 2023.')
     def testSelectUFEInMel(self):
         """
         Select multiple UFE items by passing them in an array to a mel command.
@@ -108,7 +107,7 @@ class SelectByArrayTestCase(unittest.TestCase):
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 3)
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectUFEAndMayaInMel only works with fixes available in Maya 2023.')
     def testSelectUFEAndMayaInMel(self):
         """
         Select a mix of Maya and UFE items by passing them in an array to a mel command.
@@ -124,7 +123,6 @@ class SelectByArrayTestCase(unittest.TestCase):
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 6)
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
     def testSelectMayaPathInPython(self):
         """
         Select multiple Maya items by passing them in an array to a Python command.
@@ -135,7 +133,7 @@ class SelectByArrayTestCase(unittest.TestCase):
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 3)
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectUFEInPython only works with fixes available in Maya 2023.')
     def testSelectUFEInPython(self):
         """
         Select multiple UFE items by passing them in an array to a Python command.
@@ -146,7 +144,7 @@ class SelectByArrayTestCase(unittest.TestCase):
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 3)
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectUFEAndMayaInPython only works with fixes available in Maya 2023.')
     def testSelectUFEAndMayaInPython(self):
         """
         Select a mix of Maya and UFE items by passing them in an array to a Python command.

--- a/test/lib/ufe/testSelectionByArray.py
+++ b/test/lib/ufe/testSelectionByArray.py
@@ -86,6 +86,7 @@ class SelectByArrayTestCase(unittest.TestCase):
         # Clear selection to start off
         cmds.select(clear=True)
 
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() > 2022, 'testSelectMayaPathInMel only works starting with Maya 2022.')
     def testSelectMayaPathInMel(self):
         """
         Select multiple Maya items by passing them in an array to a mel command.
@@ -123,6 +124,7 @@ class SelectByArrayTestCase(unittest.TestCase):
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 6)
 
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() > 2022, 'testSelectMayaPathInPython only works starting with Maya 2022.')
     def testSelectMayaPathInPython(self):
         """
         Select multiple Maya items by passing them in an array to a Python command.

--- a/test/lib/ufe/testSelectionByArray.py
+++ b/test/lib/ufe/testSelectionByArray.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2020 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import fixturesUtils
+import mayaUtils
+import usdUtils
+
+from maya import cmds
+from maya import standalone
+from maya import mel
+
+import ufe
+
+import unittest
+
+
+class SelectByArrayTestCase(unittest.TestCase):
+    '''Verify UFE selection on a USD scene by passing argument in arrays.'''
+
+    pluginsLoaded = False
+
+    @classmethod
+    def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
+        if not cls.pluginsLoaded:
+            cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+    
+    @classmethod
+    def tearDownClass(cls):
+        cmds.file(new=True, force=True)
+
+        standalone.uninitialize()
+
+    def setUp(self):
+        # Load plugins
+        self.assertTrue(self.pluginsLoaded)
+
+        # Load a file that has the same scene in both the Maya Dag
+        # hierarchy and the USD hierarchy.
+        mayaUtils.openTestScene("parentCmd", "simpleSceneMayaPlusUSD_TRS.ma")
+
+        shapeSegment = mayaUtils.createUfePathSegment(
+            "|mayaUsdProxy1|mayaUsdProxyShape1")
+        
+        def makeUsdPath(name):
+            return ufe.Path([shapeSegment, usdUtils.createUfePathSegment(name)])
+
+        ufeNames = ["/cubeXform", "/cylinderXform", "/sphereXform"]
+        self.usdPaths = [makeUsdPath(name) for name in ufeNames]
+        self.mayaPaths = ["pCube1", "pCylinder1", "pSphere1"]
+
+        # Clear selection to start off
+        cmds.select(clear=True)
+
+    #@unittest.skipUnless(mayaUtils.mayaMajorVersion >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
+    def testSelectByArray(self):
+        """
+        Select multiple items by passing them in an array.
+        Perform the test using Python and using mel.
+        """
+        def melSelectCmd(paths):
+            cmd = '''string $obj[];'''
+            for i, path in enumerate(paths):
+                cmd = cmd + '$obj[%s] = "%s";' % (i, path)
+            cmd = cmd + 'select $obj;'
+            return cmd
+
+        def melSelect(paths):
+            mel.eval(melSelectCmd(paths))
+
+        # Test using mel commands.
+
+        cmds.select(clear=True)
+        melSelect(self.mayaPaths)
+
+        sn = ufe.GlobalSelection.get()
+        self.assertEqual(len(sn), 3)
+
+        print(self.usdPaths)
+        cmds.select(clear=True)
+        melSelect(self.usdPaths)
+
+        sn = ufe.GlobalSelection.get()
+        self.assertEqual(len(sn), 3)
+
+        cmds.select(clear=True)
+        melSelect(self.mayaPaths + self.usdPaths)
+
+        sn = ufe.GlobalSelection.get()
+        self.assertEqual(len(sn), 6)
+
+        # Test using Python commands.
+
+        cmds.select(clear=True)
+        cmds.select(self.mayaPaths)
+
+        sn = ufe.GlobalSelection.get()
+        self.assertEqual(len(sn), 3)
+
+        print(self.usdPaths)
+        cmds.select(clear=True)
+        cmds.select(self.usdPaths)
+
+        sn = ufe.GlobalSelection.get()
+        self.assertEqual(len(sn), 3)
+
+        cmds.select(clear=True)
+        cmds.select(self.mayaPaths + self.usdPaths)
+
+        sn = ufe.GlobalSelection.get()
+        self.assertEqual(len(sn), 6)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testSelectionByArray.py
+++ b/test/lib/ufe/testSelectionByArray.py
@@ -29,6 +29,24 @@ import ufe
 import unittest
 
 
+def melSelectCmd(paths):
+    """
+    Create the mel command to select the given objects by passing them as a single array.
+    """
+    cmd = '''string $obj[];'''
+    for i, path in enumerate(paths):
+        cmd = cmd + '$obj[%s] = "%s";' % (i, path)
+    cmd = cmd + 'select $obj;'
+    return cmd
+
+
+def melSelect(paths):
+    """
+    Call the mel select command using a single array as argument.
+    """
+    mel.eval(melSelectCmd(paths))
+
+    
 class SelectByArrayTestCase(unittest.TestCase):
     '''Verify UFE selection on a USD scene by passing argument in arrays.'''
 
@@ -62,66 +80,84 @@ class SelectByArrayTestCase(unittest.TestCase):
             return ufe.Path([shapeSegment, usdUtils.createUfePathSegment(name)])
 
         ufeNames = ["/cubeXform", "/cylinderXform", "/sphereXform"]
-        self.usdPaths = [makeUsdPath(name) for name in ufeNames]
+        self.usdPaths = [ufe.PathString.string(makeUsdPath(name)) for name in ufeNames]
         self.mayaPaths = ["pCube1", "pCylinder1", "pSphere1"]
 
         # Clear selection to start off
         cmds.select(clear=True)
 
     #@unittest.skipUnless(mayaUtils.mayaMajorVersion >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
-    def testSelectByArray(self):
+    def testSelectMayaPathInMel(self):
         """
-        Select multiple items by passing them in an array.
-        Perform the test using Python and using mel.
+        Select multiple Maya items by passing them in an array to a mel command.
         """
-        def melSelectCmd(paths):
-            cmd = '''string $obj[];'''
-            for i, path in enumerate(paths):
-                cmd = cmd + '$obj[%s] = "%s";' % (i, path)
-            cmd = cmd + 'select $obj;'
-            return cmd
-
-        def melSelect(paths):
-            mel.eval(melSelectCmd(paths))
-
-        # Test using mel commands.
-
         cmds.select(clear=True)
         melSelect(self.mayaPaths)
 
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 3)
 
-        print(self.usdPaths)
+    #@unittest.skipUnless(mayaUtils.mayaMajorVersion >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
+    def testSelectUFEInMel(self):
+        """
+        Select multiple UFE items by passing them in an array to a mel command.
+        """
         cmds.select(clear=True)
         melSelect(self.usdPaths)
 
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 3)
 
+    #@unittest.skipUnless(mayaUtils.mayaMajorVersion >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
+    def testSelectUFEAndMayaInMel(self):
+        """
+        Select a mix of Maya and UFE items by passing them in an array to a mel command.
+        """
+        interleaved = []
+        for ab in zip(self.mayaPaths, self.usdPaths):
+            interleaved.append(ab[0])
+            interleaved.append(ab[1])
+
         cmds.select(clear=True)
-        melSelect(self.mayaPaths + self.usdPaths)
+        melSelect(interleaved)
 
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 6)
 
-        # Test using Python commands.
-
+    #@unittest.skipUnless(mayaUtils.mayaMajorVersion >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
+    def testSelectMayaPathInPython(self):
+        """
+        Select multiple Maya items by passing them in an array to a Python command.
+        """
         cmds.select(clear=True)
         cmds.select(self.mayaPaths)
 
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 3)
 
-        print(self.usdPaths)
+    #@unittest.skipUnless(mayaUtils.mayaMajorVersion >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
+    def testSelectUFEInPython(self):
+        """
+        Select multiple UFE items by passing them in an array to a Python command.
+        """
         cmds.select(clear=True)
         cmds.select(self.usdPaths)
 
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 3)
 
+    #@unittest.skipUnless(mayaUtils.mayaMajorVersion >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
+    def testSelectUFEAndMayaInPython(self):
+        """
+        Select a mix of Maya and UFE items by passing them in an array to a Python command.
+        """
+        interleaved = []
+        for ab in zip(self.mayaPaths, self.usdPaths):
+            interleaved.append(ab[0])
+            interleaved.append(ab[1])
+
         cmds.select(clear=True)
-        cmds.select(self.mayaPaths + self.usdPaths)
+        cmds.select(interleaved)
 
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 6)

--- a/test/lib/ufe/testSelectionByArray.py
+++ b/test/lib/ufe/testSelectionByArray.py
@@ -86,7 +86,7 @@ class SelectByArrayTestCase(unittest.TestCase):
         # Clear selection to start off
         cmds.select(clear=True)
 
-    #@unittest.skipUnless(mayaUtils.mayaMajorVersion >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
     def testSelectMayaPathInMel(self):
         """
         Select multiple Maya items by passing them in an array to a mel command.
@@ -97,7 +97,7 @@ class SelectByArrayTestCase(unittest.TestCase):
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 3)
 
-    #@unittest.skipUnless(mayaUtils.mayaMajorVersion >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
     def testSelectUFEInMel(self):
         """
         Select multiple UFE items by passing them in an array to a mel command.
@@ -108,7 +108,7 @@ class SelectByArrayTestCase(unittest.TestCase):
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 3)
 
-    #@unittest.skipUnless(mayaUtils.mayaMajorVersion >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
     def testSelectUFEAndMayaInMel(self):
         """
         Select a mix of Maya and UFE items by passing them in an array to a mel command.
@@ -124,7 +124,7 @@ class SelectByArrayTestCase(unittest.TestCase):
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 6)
 
-    #@unittest.skipUnless(mayaUtils.mayaMajorVersion >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
     def testSelectMayaPathInPython(self):
         """
         Select multiple Maya items by passing them in an array to a Python command.
@@ -135,7 +135,7 @@ class SelectByArrayTestCase(unittest.TestCase):
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 3)
 
-    #@unittest.skipUnless(mayaUtils.mayaMajorVersion >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
     def testSelectUFEInPython(self):
         """
         Select multiple UFE items by passing them in an array to a Python command.
@@ -146,7 +146,7 @@ class SelectByArrayTestCase(unittest.TestCase):
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 3)
 
-    #@unittest.skipUnless(mayaUtils.mayaMajorVersion >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectByArray only works with fixes available in Maya 2023.')
     def testSelectUFEAndMayaInPython(self):
         """
         Select a mix of Maya and UFE items by passing them in an array to a Python command.
@@ -164,4 +164,4 @@ class SelectByArrayTestCase(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main()

--- a/test/lib/ufe/testSelectionByArray.py
+++ b/test/lib/ufe/testSelectionByArray.py
@@ -96,7 +96,7 @@ class SelectByArrayTestCase(unittest.TestCase):
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 3)
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectUFEInMel only works with fixes available in Maya 2023.')
+    @unittest.skipUnless(mayaUtils.previewReleaseVersion() > 130, 'testSelectUFEInMel only works with fixes available in Maya 2023 after PR 130.')
     def testSelectUFEInMel(self):
         """
         Select multiple UFE items by passing them in an array to a mel command.
@@ -107,7 +107,7 @@ class SelectByArrayTestCase(unittest.TestCase):
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 3)
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectUFEAndMayaInMel only works with fixes available in Maya 2023.')
+    @unittest.skipUnless(mayaUtils.previewReleaseVersion() > 130, 'testSelectUFEAndMayaInMel only works with fixes available in Maya 2023 after PR 130.')
     def testSelectUFEAndMayaInMel(self):
         """
         Select a mix of Maya and UFE items by passing them in an array to a mel command.
@@ -133,7 +133,7 @@ class SelectByArrayTestCase(unittest.TestCase):
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 3)
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectUFEInPython only works with fixes available in Maya 2023.')
+    @unittest.skipUnless(mayaUtils.previewReleaseVersion() > 130, 'testSelectUFEInPython only works with fixes available in Maya 2023 after PR 130.')
     def testSelectUFEInPython(self):
         """
         Select multiple UFE items by passing them in an array to a Python command.
@@ -144,7 +144,7 @@ class SelectByArrayTestCase(unittest.TestCase):
         sn = ufe.GlobalSelection.get()
         self.assertEqual(len(sn), 3)
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'testSelectUFEAndMayaInPython only works with fixes available in Maya 2023.')
+    @unittest.skipUnless(mayaUtils.previewReleaseVersion() > 130, 'testSelectUFEAndMayaInPython only works with fixes available in Maya 2023 after PR 130.')
     def testSelectUFEAndMayaInPython(self):
         """
         Select a mix of Maya and UFE items by passing them in an array to a Python command.


### PR DESCRIPTION
Test passing array of Maya objects, UFE objects or a mix of both to Python `select` command and Mel `select` command.

Verified that the test fail in Maya 2022 and work with the new fix in Maya 2023.