### PR TITLE
Use AbsPath for INPUT_PATH env var in converter tests

### DIFF
--- a/test/lib/usd/translators/testUsdExportCustomConverter.template.py
+++ b/test/lib/usd/translators/testUsdExportCustomConverter.template.py
@@ -41,7 +41,7 @@ class testUsdExportCustomConverter(unittest.TestCase):
 
         fixturesUtils.setUpClass(__file__, suffix)
 
-        cls.input_path = os.getenv("INPUT_PATH")
+        cls.input_path = os.path.abspath(os.getenv("INPUT_PATH"))
 
         test_dir = os.path.join(cls.input_path,
                                 "UsdExportCustomConverterTest")

--- a/test/lib/usd/translators/testUsdImportCustomConverter.template.py
+++ b/test/lib/usd/translators/testUsdImportCustomConverter.template.py
@@ -38,7 +38,7 @@ class testUsdImportCustomConverter(unittest.TestCase):
 
         fixturesUtils.setUpClass(__file__, suffix)
 
-        cls.input_path = os.getenv("INPUT_PATH")
+        cls.input_path = os.path.abspath(os.getenv("INPUT_PATH"))
 
         cls.test_dir = os.path.join(cls.input_path,
                                     "UsdImportCustomConverterTest")


### PR DESCRIPTION
This allows users to run with cwd or relative paths to the cwd