### PR TITLE
MAYA-113723 improve selection performance

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
@@ -157,7 +157,6 @@ private:
 
     enum DirtyBits : HdDirtyBits
     {
-        DirtySelection = MayaPrimCommon::DirtySelection,
         DirtySelectionHighlight = MayaPrimCommon::DirtySelectionHighlight
     };
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -48,8 +48,7 @@ struct MayaPrimCommon
 {
     enum DirtyBits : HdDirtyBits
     {
-        DirtySelection = HdChangeTracker::CustomBitsBegin,
-        DirtySelectionHighlight = (DirtySelection << 1),
+        DirtySelectionHighlight = HdChangeTracker::CustomBitsBegin,
         DirtySelectionMode = (DirtySelectionHighlight << 1),
         DirtyBitLast = DirtySelectionMode
     };

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -844,7 +844,7 @@ void HdVP2Mesh::Sync(
     HdDirtyBits*     dirtyBits,
     const TfToken&   reprToken)
 {
-    const SdfPath& id = GetId();
+    const SdfPath&       id = GetId();
     auto* const          param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
     ProxyRenderDelegate& drawScene = param->GetDrawScene();
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -465,6 +465,12 @@ void HdVP2Mesh::_PrepareSharedVertexBuffers(
     const HdDirtyBits& rprimDirtyBits,
     const TfToken&     reprToken)
 {
+    MProfilingScope profilingScope(
+        HdVP2RenderDelegate::sProfilerCategory,
+        MProfiler::kColorC_L2,
+        _rprimId.asChar(),
+        "HdVP2Mesh::_PrepareSharedVertexBuffers");
+
     // Normals have two possible sources. They could be authored by the scene delegate,
     // in which case we should find them in _primvarInfo, or they could be computed
     // normals. Compute the normal buffer if necessary.
@@ -838,26 +844,21 @@ void HdVP2Mesh::Sync(
     HdDirtyBits*     dirtyBits,
     const TfToken&   reprToken)
 {
-    // We don't create render items for the selection repr. The selection repr
-    // is used when the Sync call is made during a selection pass.
-    // When the selection mode changes, we DO want the chance to update our
-    // shaded render items (to support things like point snapping to similar instances), so make
-    // another call to Sync but with the smoothHull repr.
-    if (reprToken == HdVP2ReprTokens->selection) {
-        if (*dirtyBits & DirtySelectionMode) {
-            Sync(delegate, renderParam, dirtyBits, HdReprTokens->smoothHull);
-        }
-        return;
-    }
-
     const SdfPath& id = GetId();
+    auto* const          param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
+    ProxyRenderDelegate& drawScene = param->GetDrawScene();
+
+    // Update the selection status if it changed.
+    if (*dirtyBits & DirtySelectionHighlight) {
+        _selectionStatus = drawScene.GetSelectionStatus(id);
+    } else {
+        TF_VERIFY(_selectionStatus == drawScene.GetSelectionStatus(id));
+    }
 
     // We don't update the repr if it is hidden by the render tags (purpose)
     // of the ProxyRenderDelegate. In additional, we need to hide any already
     // existing render items because they should not be drawn.
-    auto* const          param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
-    ProxyRenderDelegate& drawScene = param->GetDrawScene();
-    HdRenderIndex&       renderIndex = delegate->GetRenderIndex();
+    HdRenderIndex& renderIndex = delegate->GetRenderIndex();
     if (!drawScene.DrawRenderTag(renderIndex.GetRenderTag(id))) {
         _HideAllDrawItems(reprToken);
         *dirtyBits &= ~(
@@ -896,7 +897,14 @@ void HdVP2Mesh::Sync(
         }
 #endif
 
-        _meshSharedData->_topology = GetMeshTopology(delegate);
+        {
+            MProfilingScope profilingScope(
+                HdVP2RenderDelegate::sProfilerCategory,
+                MProfiler::kColorC_L2,
+                _rprimId.asChar(),
+                "HdVP2Mesh::GetMeshTopology");
+            _meshSharedData->_topology = GetMeshTopology(delegate);
+        }
 
         // subscribe to material updates from the new geom subset materials
 #ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
@@ -1000,6 +1008,12 @@ void HdVP2Mesh::Sync(
     }
 
     if (HdChangeTracker::IsTopologyDirty(*dirtyBits, id)) {
+        MProfilingScope profilingScope(
+            HdVP2RenderDelegate::sProfilerCategory,
+            MProfiler::kColorC_L2,
+            _rprimId.asChar(),
+            "HdVP2Mesh Create Rendering Topology");
+
         const HdMeshTopology& topology = _meshSharedData->_topology;
         const VtIntArray&     faceVertexIndices = topology.GetFaceVertexIndices();
         const size_t          numFaceVertexIndices = faceVertexIndices.size();
@@ -1208,11 +1222,6 @@ HdDirtyBits HdVP2Mesh::_PropagateDirtyBits(HdDirtyBits bits) const
         bits |= HdChangeTracker::DirtyExtent;
     }
 
-    // Visibility and selection result in highlight changes:
-    if ((bits & HdChangeTracker::DirtyVisibility) && (bits & DirtySelection)) {
-        bits |= DirtySelectionHighlight;
-    }
-
     if (bits & HdChangeTracker::AllDirty) {
         // RPrim is dirty, propagate dirty bits to all draw items.
         for (const std::pair<TfToken, HdReprSharedPtr>& pair : _reprs) {
@@ -1281,26 +1290,19 @@ void HdVP2Mesh::_InitRepr(const TfToken& reprToken, HdDirtyBits* dirtyBits)
     if (ARCH_UNLIKELY(!subSceneContainer))
         return;
 
-    // Update selection state on demand or when it is a new Rprim. DirtySelection
+    // Update selection state when it is a new Rprim. DirtySelectionHighlight
     // will be propagated to all draw items, to trigger sync for each repr.
-    if (reprToken == HdVP2ReprTokens->selection || _reprs.empty()) {
+    if (_reprs.empty()) {
         const HdVP2SelectionStatus selectionStatus
             = param->GetDrawScene().GetSelectionStatus(GetId());
         if (_selectionStatus != selectionStatus) {
             _selectionStatus = selectionStatus;
-            *dirtyBits |= DirtySelection;
+            *dirtyBits |= DirtySelectionHighlight;
         } else if (_selectionStatus == kPartiallySelected) {
-            *dirtyBits |= DirtySelection;
+            *dirtyBits |= DirtySelectionHighlight;
         }
-
-        // We don't create a repr for the selection token because it serves for
-        // selection state update only. Return from here.
-        if (reprToken == HdVP2ReprTokens->selection)
-            return;
     }
 
-    // If the repr has any draw item with the DirtySelection bit, mark the
-    // DirtySelectionHighlight bit to invoke the synchronization call.
     _ReprVector::const_iterator it
         = std::find_if(_reprs.begin(), _reprs.end(), _ReprComparator(reprToken));
     if (it != _reprs.end()) {
@@ -1320,9 +1322,6 @@ void HdVP2Mesh::_InitRepr(const TfToken& reprToken, HdDirtyBits* dirtyBits)
                         // _PropagateDirtyBits that we need to propagate the dirty bits of this draw
                         // items to ensure proper Sync
                         renderItemData.SetDirtyBits(HdChangeTracker::DirtyRepr);
-                    }
-                    if (renderItemData.GetDirtyBits() & DirtySelection) {
-                        *dirtyBits |= DirtySelectionHighlight;
                     }
                 }
             }
@@ -1606,6 +1605,12 @@ void HdVP2Mesh::_UpdateRepr(HdSceneDelegate* sceneDelegate, const TfToken& reprT
     if (ARCH_UNLIKELY(!subSceneContainer))
         return;
 
+    MProfilingScope profilingScope(
+        HdVP2RenderDelegate::sProfilerCategory,
+        MProfiler::kColorC_L2,
+        _rprimId.asChar(),
+        "HdVP2Mesh::_UpdateRepr");
+
     _MeshReprConfig::DescArray reprDescs = _GetReprDesc(reprToken);
 
     // For each relevant draw item, update dirty buffer sources.
@@ -1708,6 +1713,12 @@ void HdVP2Mesh::_UpdateDrawItem(
     // Prepare index buffer.
     if (requiresIndexUpdate && (itemDirtyBits & HdChangeTracker::DirtyTopology)) {
         const HdMeshTopology& topologyToUse = _meshSharedData->_renderingTopology;
+
+        MProfilingScope profilingScope(
+            HdVP2RenderDelegate::sProfilerCategory,
+            MProfiler::kColorC_L2,
+            _rprimId.asChar(),
+            "HdVP2Mesh prepare index buffer");
 
         if (desc.geomStyle == HdMeshGeomStyleHull) {
             // _trianglesFaceVertexIndices has the full triangulation calculated in
@@ -1938,6 +1949,12 @@ void HdVP2Mesh::_UpdateDrawItem(
     bool instancerWithNoInstances = false;
     if (!GetInstancerId().IsEmpty()) {
 
+        MProfilingScope profilingScope(
+            HdVP2RenderDelegate::sProfilerCategory,
+            MProfiler::kColorC_L2,
+            _rprimId.asChar(),
+            "HdVP2Mesh Update instances");
+
         // Retrieve instance transforms from the instancer.
         HdInstancer*    instancer = renderIndex.GetInstancer(GetInstancerId());
         VtMatrix4dArray transforms
@@ -2091,6 +2108,10 @@ void HdVP2Mesh::_UpdateDrawItem(
                     }
                 }
             }
+
+            TF_VERIFY(
+                stateToCommit._ufeIdentifiers.length()
+                == stateToCommit._instanceTransforms.length());
 
             if (stateToCommit._instanceTransforms.length() == 0)
                 instancerWithNoInstances = true;
@@ -2512,6 +2533,12 @@ void HdVP2Mesh::_UpdatePrimvarSources(
     HdDirtyBits          dirtyBits,
     const TfTokenVector& requiredPrimvars)
 {
+    MProfilingScope profilingScope(
+        HdVP2RenderDelegate::sProfilerCategory,
+        MProfiler::kColorC_L2,
+        _rprimId.asChar(),
+        "HdVP2Mesh::_UpdatePrimvarSources");
+
     const SdfPath& id = GetId();
 
     auto updatePrimvarInfo

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
@@ -187,7 +187,6 @@ private:
         DirtyFlatNormals = (DirtySmoothNormals << 1),
         //! "Forward" the enumerated types here so we don't have to keep writing MayaPrimCommon in
         //! the cpp file.
-        DirtySelection = MayaPrimCommon::DirtySelection,
         DirtySelectionHighlight = MayaPrimCommon::DirtySelectionHighlight,
         DirtySelectionMode = MayaPrimCommon::DirtySelectionMode
     };

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -829,7 +829,10 @@ void ProxyRenderDelegate::_Execute(const MHWRender::MFrameContext& frameContext)
         _taskController->SetCollection(*_defaultCollection);
     }
 
-    _engine.Execute(_renderIndex.get(), &_dummyTasks);
+    // if there are no repr's to update then don't even call sync.
+    if (reprSelector != HdReprSelector()) {
+        _engine.Execute(_renderIndex.get(), &_dummyTasks);
+    }
 }
 
 //! \brief  Main update entry from subscene override.

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -1179,7 +1179,7 @@ void ProxyRenderDelegate::_UpdateSelectionStates()
     const MHWRender::DisplayStatus previousStatus = _displayStatus;
     _displayStatus = MHWRender::MGeometryUtilities::displayStatus(_proxyShapeData->ProxyDagPath());
 
-    SdfPathVector rootPaths;
+    SdfPathVector        rootPaths;
     const SdfPathVector* dirtyPaths = nullptr;
 
     if (_displayStatus == MHWRender::kLead || _displayStatus == MHWRender::kActive) {

--- a/lib/mayaUsd/render/vp2RenderDelegate/tokens.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/tokens.h
@@ -24,8 +24,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 // clang-format off
 #define HDVP2_REPR_TOKENS \
     (bbox) \
-    (defaultMaterial) \
-    (selection)
+    (defaultMaterial)
 
 #define HDVP2_TOKENS \
     (displayColorAndOpacity) \


### PR DESCRIPTION
If there are no reprs selected then don't call execute! It causes extra dirty bits to get held on some rprims, which causes an actual update later when some reprs ARE selected, and that hurts performance. I spent a couple of days tracing a debugging this one and I still do not 100% understand how the dirty flags come back, but I know that doing an execute with no reprs is not useful so I can safely skip it.

The update with no reprs typically happens during the selection pass when we are not changing into or out of point snapping mode, which is pretty much every selection pass we do.