### PR TITLE
MAYA-114297 MAYA-114300 Job context UI

### DIFF
--- a/lib/mayaUsd/commands/baseExportCommand.cpp
+++ b/lib/mayaUsd/commands/baseExportCommand.cpp
@@ -40,7 +40,7 @@ MSyntax MayaUSDExportCommand::createSyntax()
     MSyntax syntax;
 
     // These flags correspond to entries in
-    // UsdMayaJobExportArgs::GetDefaultDictionary.
+    // UsdMayaJobExportArgs::GetGuideDictionary.
     syntax.addFlag(
         kMergeTransformAndShapeFlag,
         UsdMayaJobExportArgsTokens->mergeTransformAndShape.GetText(),
@@ -245,7 +245,7 @@ MStatus MayaUSDExportCommand::doIt(const MArgList& args)
 
         // Read all of the dictionary args first.
         const VtDictionary userArgs = UsdMayaUtil::GetDictionaryFromArgDatabase(
-            argData, UsdMayaJobExportArgs::GetDefaultDictionary());
+            argData, UsdMayaJobExportArgs::GetGuideDictionary());
 
         // Now read all of the other args that are specific to this command.
         bool        append = false;

--- a/lib/mayaUsd/commands/baseImportCommand.cpp
+++ b/lib/mayaUsd/commands/baseImportCommand.cpp
@@ -40,7 +40,7 @@ MSyntax MayaUSDImportCommand::createSyntax()
     MSyntax syntax;
 
     // These flags correspond to entries in
-    // UsdMayaJobImportArgs::GetDefaultDictionary.
+    // UsdMayaJobImportArgs::GetGuideDictionary.
     syntax.addFlag(
         kShadingModeFlag,
         UsdMayaJobImportArgsTokens->shadingMode.GetText(),
@@ -136,7 +136,7 @@ MStatus MayaUSDImportCommand::doIt(const MArgList& args)
 
     // Get dictionary values.
     const VtDictionary userArgs = UsdMayaUtil::GetDictionaryFromArgDatabase(
-        argData, UsdMayaJobImportArgs::GetDefaultDictionary());
+        argData, UsdMayaJobImportArgs::GetGuideDictionary());
 
     std::string mFileName;
     if (argData.isFlagSet(kFileFlag)) {

--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -785,6 +785,69 @@ const VtDictionary& UsdMayaJobExportArgs::GetDefaultDictionary()
     return d;
 }
 
+const VtDictionary& UsdMayaJobExportArgs::GetGuideDictionary()
+{
+    static VtDictionary   d;
+    static std::once_flag once;
+
+    std::call_once(once, []() {
+        // Common types:
+        const auto _boolean = VtValue(false);
+        const auto _string = VtValue(std::string());
+        const auto _stringVector = VtValue(std::vector<VtValue>({ _string }));
+        const auto _stringTriplet = VtValue(std::vector<VtValue>({ _string, _string, _string }));
+        const auto _stringTripletVector = VtValue(std::vector<VtValue>({ _stringTriplet }));
+
+        // Provide guide types for the parser:
+        d[UsdMayaJobExportArgsTokens->chaser] = _stringVector;
+        d[UsdMayaJobExportArgsTokens->chaserArgs] = _stringTripletVector;
+        d[UsdMayaJobExportArgsTokens->compatibility] = _string;
+        d[UsdMayaJobExportArgsTokens->defaultCameras] = _boolean;
+        d[UsdMayaJobExportArgsTokens->defaultMeshScheme] = _string;
+        d[UsdMayaJobExportArgsTokens->defaultUSDFormat] = _string;
+        d[UsdMayaJobExportArgsTokens->eulerFilter] = _boolean;
+        d[UsdMayaJobExportArgsTokens->exportCollectionBasedBindings] = _boolean;
+        d[UsdMayaJobExportArgsTokens->exportColorSets] = _boolean;
+        d[UsdMayaJobExportArgsTokens->exportDisplayColor] = _boolean;
+        d[UsdMayaJobExportArgsTokens->exportInstances] = _boolean;
+        d[UsdMayaJobExportArgsTokens->exportMaterialCollections] = _boolean;
+        d[UsdMayaJobExportArgsTokens->exportReferenceObjects] = _boolean;
+        d[UsdMayaJobExportArgsTokens->exportRefsAsInstanceable] = _boolean;
+        d[UsdMayaJobExportArgsTokens->exportRoots] = _stringVector;
+        d[UsdMayaJobExportArgsTokens->exportSkin] = _string;
+        d[UsdMayaJobExportArgsTokens->exportSkels] = _string;
+        d[UsdMayaJobExportArgsTokens->exportBlendShapes] = _boolean;
+        d[UsdMayaJobExportArgsTokens->exportUVs] = _boolean;
+        d[UsdMayaJobExportArgsTokens->exportVisibility] = _boolean;
+        d[UsdMayaJobExportArgsTokens->exportComponentTags] = _boolean;
+        d[UsdMayaJobExportArgsTokens->file] = _string;
+        d[UsdMayaJobExportArgsTokens->filterTypes] = _stringVector;
+        d[UsdMayaJobExportArgsTokens->ignoreWarnings] = _boolean;
+        d[UsdMayaJobExportArgsTokens->kind] = _string;
+        d[UsdMayaJobExportArgsTokens->materialCollectionsPath] = _string;
+        d[UsdMayaJobExportArgsTokens->materialsScopeName] = _string;
+        d[UsdMayaJobExportArgsTokens->melPerFrameCallback] = _string;
+        d[UsdMayaJobExportArgsTokens->melPostCallback] = _string;
+        d[UsdMayaJobExportArgsTokens->mergeTransformAndShape] = _boolean;
+        d[UsdMayaJobExportArgsTokens->normalizeNurbs] = _boolean;
+        d[UsdMayaJobExportArgsTokens->parentScope] = _string;
+        d[UsdMayaJobExportArgsTokens->pythonPerFrameCallback] = _string;
+        d[UsdMayaJobExportArgsTokens->pythonPostCallback] = _string;
+        d[UsdMayaJobExportArgsTokens->renderableOnly] = _boolean;
+        d[UsdMayaJobExportArgsTokens->renderLayerMode] = _string;
+        d[UsdMayaJobExportArgsTokens->shadingMode] = _string;
+        d[UsdMayaJobExportArgsTokens->convertMaterialsTo] = _stringVector;
+        d[UsdMayaJobExportArgsTokens->apiSchema] = _stringVector;
+        d[UsdMayaJobExportArgsTokens->jobContext] = _stringVector;
+        d[UsdMayaJobExportArgsTokens->stripNamespaces] = _boolean;
+        d[UsdMayaJobExportArgsTokens->verbose] = _boolean;
+        d[UsdMayaJobExportArgsTokens->staticSingleSample] = _boolean;
+        d[UsdMayaJobExportArgsTokens->geomSidedness] = _string;
+    });
+
+    return d;
+}
+
 std::string UsdMayaJobExportArgs::GetResolvedFileName() const
 {
     MFileObject fileObj;
@@ -891,6 +954,40 @@ const VtDictionary& UsdMayaJobImportArgs::GetDefaultDictionary()
         const VtDictionary site
             = UsdMaya_RegistryHelper::GetComposedInfoDictionary(_usdImportInfoScope->allTokens);
         VtDictionaryOver(site, &d, /*coerceToWeakerOpinionType*/ true);
+    });
+
+    return d;
+}
+
+/* static */
+const VtDictionary& UsdMayaJobImportArgs::GetGuideDictionary()
+{
+    static VtDictionary   d;
+    static std::once_flag once;
+    std::call_once(once, []() {
+        // Common types:
+        const auto _boolean = VtValue(false);
+        const auto _string = VtValue(std::string());
+        const auto _stringVector = VtValue(std::vector<VtValue>({ _string }));
+        const auto _stringTuplet = VtValue(std::vector<VtValue>({ _string, _string, _string }));
+        const auto _stringTriplet = VtValue(std::vector<VtValue>({ _string, _string, _string }));
+        const auto _stringTupletVector = VtValue(std::vector<VtValue>({ _stringTuplet }));
+        const auto _stringTripletVector = VtValue(std::vector<VtValue>({ _stringTriplet }));
+
+        // Provide guide types for the parser:
+        d[UsdMayaJobImportArgsTokens->assemblyRep] = _string;
+        d[UsdMayaJobImportArgsTokens->apiSchema] = _stringVector;
+        d[UsdMayaJobImportArgsTokens->excludePrimvar] = _stringVector;
+        d[UsdMayaJobImportArgsTokens->jobContext] = _stringVector;
+        d[UsdMayaJobImportArgsTokens->metadata] = _stringVector;
+        d[UsdMayaJobImportArgsTokens->shadingMode] = _stringTupletVector;
+        d[UsdMayaJobImportArgsTokens->preferredMaterial] = _string;
+        d[UsdMayaJobImportArgsTokens->importInstances] = _boolean;
+        d[UsdMayaJobImportArgsTokens->importUSDZTextures] = _boolean;
+        d[UsdMayaJobImportArgsTokens->importUSDZTexturesFilePath] = _string;
+        d[UsdMayaJobImportArgsTokens->useAsAnimationCache] = _boolean;
+        d[UsdMayaJobExportArgsTokens->chaser] = _stringVector;
+        d[UsdMayaJobExportArgsTokens->chaserArgs] = _stringTripletVector;
     });
 
     return d;

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -253,6 +253,12 @@ struct UsdMayaJobExportArgs
     MAYAUSD_CORE_PUBLIC
     static const VtDictionary& GetDefaultDictionary();
 
+    /// Gets the guide dictionary for UsdMayaJobExportArgs.
+    ///
+    /// Used in GetDictionaryFromArgDatabase() to deduce the type of an argument.
+    MAYAUSD_CORE_PUBLIC
+    static const VtDictionary& GetGuideDictionary();
+
     /// Returns the resolved file name of the final export location
     MAYAUSD_CORE_PUBLIC
     std::string GetResolvedFileName() const;
@@ -320,6 +326,12 @@ struct UsdMayaJobImportArgs
     /// Gets the default arguments dictionary for UsdMayaJobImportArgs.
     MAYAUSD_CORE_PUBLIC
     static const VtDictionary& GetDefaultDictionary();
+
+    /// Gets the guide dictionary for UsdMayaJobImportArgs.
+    ///
+    /// Used in GetDictionaryFromArgDatabase() to deduce the type of an argument.
+    MAYAUSD_CORE_PUBLIC
+    static const VtDictionary& GetGuideDictionary();
 
     MAYAUSD_CORE_PUBLIC
     static const std::string GetImportUSDZTexturesFilePath(const VtDictionary& userArgs);

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -1937,6 +1937,10 @@ std::pair<bool, std::string> UsdMayaUtil::ValueToArgument(const VtValue& value)
 {
     if (value.IsHolding<bool>()) {
         return std::make_pair(true, std::string(value.Get<bool>() ? "1" : "0"));
+    } else if (value.IsHolding<int>()) {
+        return std::make_pair(true, std::to_string(value.Get<int>()));
+    } else if (value.IsHolding<float>()) {
+        return std::make_pair(true, std::to_string(value.Get<float>()));
     } else if (value.IsHolding<std::string>()) {
         return std::make_pair(true, value.Get<std::string>());
     } else if (value.IsHolding<std::vector<VtValue>>()) {

--- a/plugin/adsk/plugin/exportTranslator.cpp
+++ b/plugin/adsk/plugin/exportTranslator.cpp
@@ -154,7 +154,7 @@ MStatus UsdMayaExportTranslator::writer(
                 userArgs[argName] = UsdMayaUtil::ParseArgumentValue(
                     argName,
                     theOption[1].asChar(),
-                    PXR_NS::UsdMayaJobExportArgs::GetDefaultDictionary());
+                    PXR_NS::UsdMayaJobExportArgs::GetGuideDictionary());
             }
         }
     }

--- a/plugin/adsk/plugin/importTranslator.cpp
+++ b/plugin/adsk/plugin/importTranslator.cpp
@@ -92,7 +92,7 @@ MStatus UsdMayaImportTranslator::reader(
                 importData.setRootPrimPath(theOption[1].asChar());
             } else {
                 userArgs[argName] = UsdMayaUtil::ParseArgumentValue(
-                    argName, theOption[1].asChar(), UsdMayaJobImportArgs::GetDefaultDictionary());
+                    argName, theOption[1].asChar(), UsdMayaJobImportArgs::GetGuideDictionary());
             }
         }
     }

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
@@ -122,6 +122,98 @@ global proc mayaUSDRegisterStrings() {
     register("kUsdOptionsFrameLabel", "Universal Scene Description (USD) Options");
     register("kSaveOption2GBWarning", "<b>Important</b>: per layer, any data exceeding the limit of 2GB will not be saved.");
 
+    // All strings for export dialog:
+    register("kExportAnimDataAnn", "Exports Maya animation data as USD time samples.");
+    register("kExportAnimDataLbl", "Animation Data: ");
+    register("kExportBlendShapesAnn", "Exports Maya Blend Shapes as USD blendshapes. Requires skeletons to be exported as well.");
+    register("kExportBlendShapesLbl", "Blend Shapes:");
+    register("kExportColorSetsAnn", "Exports Maya Color Sets as USD primvars.");
+    register("kExportColorSetsLbl", "Color Sets:");
+    register("kExportDefaultFormatAnn", "Select whether the .usd file is written out in binary or ASCII");
+    register("kExportDefaultFormatLbl", ".usd File Format:");
+    register("kExportDefaultFormatBinLbl", "Binary");
+    register("kExportDefaultFormatAscLbl", "ASCII");
+    register("kExportDefaultFormatStatus", "Select whether the .usd file is written out in binary or ASCII. You can save a file in .usdc (binary), or .usda (ASCII) format. Manually entering a file name with an extension overrides the selection in this drop-down menu.");
+    register("kExportDisplayColorAnn", "If selected, exports the diffuse color of the geometry's bound shader as a displayColor primvar on the USD mesh.");
+    register("kExportDisplayColorLbl", "Display Colors:");
+    register("kExportEulerFilterAnn", "Exports the euler angle filtering that was performed in Maya.");
+    register("kExportEulerFilterLbl", "Euler Filter:");
+    register("kExportFrameAdvancedLbl", "Advanced");
+    register("kExportFrameAnimationLbl", "Animation");
+    register("kExportFrameGeometryLbl", "Geometry");
+    register("kExportFrameMaterialsLbl", "Materials");
+    register("kExportFrameOutputLbl", "Output");
+    register("kExportFrameRangeBtn", "Use Animation Range");
+    register("kExportFrameRangeLbl", "Frame Range Start/End:");
+    register("kExportFrameSamplesAnn", "Specifies the value(s) used to multi-sample time frames during animation export. Multiple values separated by a space (-0.1 0.2) are supported.");
+    register("kExportFrameSamplesLbl", "Frame Sample:");
+    register("kExportFrameStepAnn", "Specifies the increment between USD time sample frames during animation export");
+    register("kExportFrameStepLbl", "Frame Step:");
+    register("kExportInstancesAnn", "Exports Maya instances as USD instanceable references.");
+    register("kExportInstancesLbl", "Instances:");
+    register("kExportInstancesFlatLbl", "Flatten");
+    register("kExportInstancesRefLbl", "Convert to USD Instanceable References");
+    register("kExportJobContextAnn", "Select a loaded plug-in configuration to modify export options");
+    register("kExportJobContextLbl", "Plug-in Configuration:");
+    register("kExportJobContextNoneLbl", "None");
+    register("kExportMaterialsAnn", "Select the material(s) to bind to prims for export. With USD, you can bind multiple materials to prims.");
+    register("kExportMergeShapesAnn", "Merges Maya transform and shape nodes into a single USD prim.");
+    register("kExportMergeShapesLbl", "Merge Transform and\nShape Nodes:");
+    register("kExportNamespacesAnn", "By default, namespaces are exported to the USD file in the following format: nameSpaceExample_pPlatonic1");
+    register("kExportNamespacesLbl", "Include Namespaces:");
+    register("kExportParentScopAnn", "Name of the USD scope that is the parent of the exported data.");
+    register("kExportParentScopLbl", "Create USD Parent Scope:");
+    register("kExportParentScopPht", "USD Prim Name");
+    register("kExportSkelsAnn", "Exports Maya joints as part of a USD skeleton.");
+    register("kExportSkelsLbl", "Skeletons:");
+    register("kExportSkelsNoneLbl", "None");
+    register("kExportSkelsAllLbl", "All (Automatically Create SkelRoots)");
+    register("kExportSkelsRootLbl", "Only under SkelRoots");
+    register("kExportSkinClustersAnn", "Exports Maya skin clusters as part of a USD skeleton.");
+    register("kExportSkinClustersLbl", "Skin Clusters");
+    register("kExportStaticSingleSampleAnn", "Converts animated values with a single time sample to be static instead.");
+    register("kExportStaticSingleSampleLbl", "Static Single Sample:");
+    register("kExportSubdMethodAnn", "Exports the selected subdivision method as a USD uniform attribute.");
+    register("kExportSubdMethodLbl", "Subdivision Method:");
+    register("kExportSubdMethodCCLbl", "Catmull-Clark");
+    register("kExportSubdMethodBiLbl", "Bilinear");
+    register("kExportSubdMethodLoLbl", "Loop");
+    register("kExportSubdMethodNoLbl", "None (Polygonal Mesh)");
+    register("kExportUVSetsAnn", "Exports Maya UV Sets as USD primvars.");
+    register("kExportUVSetsLbl", "UV Sets:");
+    register("kExportVisibilityAnn", "Exports Maya visibility attributes as USD metadata.");
+    register("kExportVisibilityLbl", "Visibility:");
+
+    // All strings for import dialog:
+    register("kImportAnimationDataLbl", "Animation Data: ");
+    register("kImportCustomFrameRangeLbl", "Custom Frame Range: ");
+    register("kImportFrameRangeLbl", "Frame Range Start/End: ");
+    register("kImportHierarchyViewLbl", "Hierarchy View");
+    register("kImportJobContextAnn", "Select a loaded plug-in configuration to modify import options");
+    register("kImportJobContextLbl", "Plug-in Configuration:");
+    register("kImportJobContextNoneLbl", "None");
+    register("kImportMaterialConvAnn", "Select the preferred conversion method for inbound USD shading data to bind with Maya geometry");
+    register("kImportMaterialConvLbl", "Convert to:");
+    register("kImportMaterialConvNoneLbl", "No Conversion");
+    register("kImportMaterialConvSSLbl","Standard Surface");
+    register("kImportMaterialConvLamLbl", "Lambert");
+    register("kImportMaterialConvPSLbl", "USD Preview Surface");
+    register("kImportMaterialConvBlnLbl", "Blinn");
+    register("kImportMaterialConvPhgLbl", "Phong");
+    register("kImportMaterialsAnn", "If selected, shading data is extracted from the USD file for import");
+    register("kImportMaterialsLbl", "Materials: ");
+    register("kImportPrimsInScopeNumLbl", "Total Number of Prims in Scope:");
+    register("kImportSelectFileTxt", "Please select a file to enable this option");
+    register("kImportScopeVariantsAnn", "Select a USD file and click <strong>Hierarchy View</strong> to build the scope of your import and switch variants.<br><br><strong>Scope</strong>: A USD file consists of prims, the primary container object in USD. Prims can contain any scene element, like meshes, lights, cameras, etc. Use the checkboxes in the <strong>Hierarchy View</strong> to select and deselect prims to build the scope of your import.<br><br><strong>Variant</strong>: A variant is a single, named variation of a variant set. Each variant set is a package of alternatives that users can switch between non-destructively. A variant set has no limits to what it can store. Variants can be used to swap out a material or change the entire hierarchy of an asset. A single prim can have many variants and variant sets, but only one variant from each variant set can be selected for import into Maya.");
+    register("kImportScopeVariantsLbl", "Scope and Variants: ");
+    register("kImportScopeVariantsSbm", "Select a USD file and click Hierarchy View to open the Hierarchy View window. This window lets you toggle prim checkboxes and non-destructively switch between variants to build the scope of your import.");
+    register("kImportToInstanceAnn", "Converts instanced prims to Maya instances. Instanced prims share parts of\nthe USD scenegraph through instancing. Each instanced prim is associated\nwith a master prim that serves as the root of the scenegraph. This hierarchy\nreduces the time needed to load the file. Instanced prims must be manually\ntagged.");
+    register("kImportToInstanceLbl", "Instanced Prims: ");
+    register("kImportToInstanceOpt", "Convert to Instances");
+    register("kImportUSDZTxtAnn", "When a .usdz file is chosen and this is selected, .usdz texture files are imported and copied to new files on disk. To locate these files, navigate to the current Maya workspace /sourceimages directory.");
+    register("kImportUSDZTxtLbl", "USDZ Texture Import: ");
+    register("kImportVariantsInScopeNumLbl", "Variants Switched in Scope:");
+
     // Register the strings from the python equivalent register function.
     // Note: the strings from both the MEL and python register can be loaded
     //       by either MEL or python. They all get registered together under

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -105,7 +105,7 @@ proc string mayaUsdTranslatorExport_AppendFromCheckbox(string $currentOptions, s
 
 proc string mayaUsdTranslatorExport_AppendJobContexts(string $currentOptions, string $arg) {
     string $niceName = `optionMenuGrp -q -value jobContextPopup`;
-    if ($niceName != "None") {
+    if ($niceName != `getMayaUsdString("kExportJobContextNoneLbl")`) {
         string $jobContext = `mayaUSDListJobContexts -jc $niceName`;
         if ($jobContext != "") {
             return $currentOptions + ";" + $arg + "=[" + $jobContext + "]";
@@ -128,8 +128,8 @@ proc string mayaUsdTranslatorExport_AppendFromBoolPopup(string $currentOptions, 
 }
 
 proc string mayaUsdTranslatorExport_AppendFrameRange(string $currentOptions) {
-    int $start = `intFieldGrp -q -value1 framRangeFields`;
-    int $end = `intFieldGrp -q -value2 framRangeFields`;
+    int $start = `intFieldGrp -q -value1 frameRangeFields`;
+    int $end = `intFieldGrp -q -value2 frameRangeFields`;
     return $currentOptions + ";startTime=" + $start + ";endTime=" + $end;
 }
 
@@ -164,7 +164,7 @@ global proc mayaUsdTranslatorExport_AnimationFrameLayoutExpandCB() {
 global proc mayaUsdTranslatorExport_AnimationRangeCB() {
     int $startTime = `playbackOptions -q -animationStartTime`;
     int $endTime = `playbackOptions -q -animationEndTime`;
-    intFieldGrp -e -v1 $startTime -v2 $endTime framRangeFields;
+    intFieldGrp -e -v1 $startTime -v2 $endTime frameRangeFields;
 }
 
 proc mayaUsdTranslatorExport_SetConvertMaterialsToCheckboxes(string $arg, int $enable, int $processJobContext) {
@@ -228,7 +228,7 @@ global proc mayaUsdTranslatorExport_EnableAllControls() {
     optionMenuGrp -e -en 1 exportInstancesPopup;
     optionMenuGrp -e -en 1 jobContextPopup;
 
-    intFieldGrp -e -en1 1 -en2 1 framRangeFields;
+    intFieldGrp -e -en1 1 -en2 1 frameRangeFields;
 
     floatFieldGrp -e -en1 1 frameStrideField;
 
@@ -279,10 +279,10 @@ global proc mayaUsdTranslatorExport_SetFromOptions(string $currentOptions, int $
                 mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], $enable, "staticSingleSampleCheckBox");
             } else if ($optionBreakDown[0] == "startTime") {
                 int $startTime=$optionBreakDown[1];
-                intFieldGrp -e -v1 $startTime -en1 $enable framRangeFields;
+                intFieldGrp -e -v1 $startTime -en1 $enable frameRangeFields;
             } else if ($optionBreakDown[0] == "endTime") {
                 int $endTime; $endTime=$optionBreakDown[1];
-                intFieldGrp -e -v2 $endTime -en2 $enable framRangeFields;
+                intFieldGrp -e -v2 $endTime -en2 $enable frameRangeFields;
             } else if ($optionBreakDown[0] == "frameStride") {
                 float $frameStride = $optionBreakDown[1];
                 floatFieldGrp -e -v1 $frameStride -en1 $enable frameStrideField;
@@ -315,7 +315,7 @@ global proc mayaUsdTranslatorExport_JobContextCB() {
     mayaUsdTranslatorExport_EnableAllControls();
 
     string $niceName = `optionMenuGrp -q -value jobContextPopup`;
-    if ($niceName != "None") {
+    if ($niceName != `getMayaUsdString("kExportJobContextNoneLbl")`) {
         string $affectedOptions = `mayaUSDListJobContexts -eg $niceName`;
         if ($affectedOptions != "") {
             mayaUsdTranslatorExport_SetFromOptions($affectedOptions, 0, 0);
@@ -353,85 +353,63 @@ global proc int mayaUsdTranslatorExport (string $parent,
     string $currentOptions;
 
     if ($action == "post") {
-        string $parentScopAnn = "Name of the USD scope that is the parent of the exported data.";
-        string $colorSetsAnn = "Exports Maya Color Sets as USD primvars.";
-        string $uvSetsAnn = "Exports Maya UV Sets as USD primvars.";
-        string $skelsAnn = "Exports Maya joints as part of a USD skeleton.";
-        string $skinClustersAnn = "Exports Maya skin clusters as part of a USD skeleton.";
-        string $blendShapesAnn = "Exports Maya Blend Shapes as USD blendshapes. Requires skeletons to be exported as well.";
-        string $displayColorAnn = "If selected, exports the diffuse color of the geometry's bound shader as a displayColor primvar on the USD mesh.";
-        string $materialsAnn = "Select the material(s) to bind to prims for export. With USD, you can bind multiple materials to prims.";
-        string $animDataAnn = "Exports Maya animation data as USD time samples.";
-        string $frameStepAnn = "Specifies the increment between USD time sample frames during animation export";
-        string $eulerFilterAnn = "Exports the euler angle filtering that was performed in Maya.";
-        string $staticSingleSampleAnn = "Converts animated values with a single time sample to be static instead.";
-        string $visibilityAnn = "Exports Maya visibility attributes as USD metadata.";
-        string $mergeShapesAnn = "Merges Maya transform and shape nodes into a single USD prim.";
-        string $namespacesAnn = "By default, namespaces are exported to the USD file in the following format: nameSpaceExample_pPlatonic1";
-        string $instancesAnn = "Exports Maya instances as USD instanceable references.";
-        string $subdMethodAnn = "Exports the selected subdivision method as a USD uniform attribute.";
-        string $frameSamplesAnn = "Specifies the value(s) used to multi-sample time frames during animation export. Multiple values separated by a space (-0.1 0.2) are supported.";
-        string $defaultFormatAnn = "Select whether the .usd file is written out in binary or ASCII";
-        string $defaultFormatStatus = "Select whether the .usd file is written out in binary or ASCII. You can save a file in .usdc (binary), or .usda (ASCII) format. Manually entering a file name with an extension overrides the selection in this drop-down menu.";
-        string $jobContextAnn = "Select a loaded plug-in configuration to modify export options";
-
         setParent $parent;
 
         columnLayout -adj true usdOptsCol;
 
-        optionMenuGrp -l "Plug-in Configuration:" -annotation $jobContextAnn -cc ("mayaUsdTranslatorExport_JobContextCB") jobContextPopup;
-            menuItem -l "None" -ann "None";
+        optionMenuGrp -l `getMayaUsdString("kExportJobContextLbl")` -annotation `getMayaUsdString("kExportJobContextAnn")` -cc ("mayaUsdTranslatorExport_JobContextCB") jobContextPopup;
+            menuItem -l `getMayaUsdString("kExportJobContextNoneLbl")` -ann "None";
             string $contexts[] = `mayaUSDListJobContexts -export`;
             for ($context in $contexts) {
                 string $ann = `mayaUSDListJobContexts -ea $context`;
                 menuItem -l $context -ann $ann;
             }
 
-        frameLayout -label "Output" -collapsable true -collapse false;
+        frameLayout -label `getMayaUsdString("kExportFrameOutputLbl")` -collapsable true -collapse false;
             separator -style "none";
 
-            optionMenuGrp -l ".usd File Format:" -annotation $defaultFormatAnn -statusBarMessage $defaultFormatStatus defaultUSDFormatPopup;
-                menuItem -l "Binary" -ann "usdc";
-                menuItem -l "ASCII" -ann "usda";
+            optionMenuGrp -l `getMayaUsdString("kExportDefaultFormatLbl")` -annotation `getMayaUsdString("kExportDefaultFormatAnn")` -statusBarMessage `getMayaUsdString("kExportDefaultFormatStatus")` defaultUSDFormatPopup;
+                menuItem -l `getMayaUsdString("kExportDefaultFormatBinLbl")` -ann "usdc";
+                menuItem -l `getMayaUsdString("kExportDefaultFormatAscLbl")` -ann "usda";
 
             separator -style "none";
 
-            textFieldGrp -l "Create USD Parent Scope:" -placeholderText "USD Prim Name"
-                -annotation $parentScopAnn parentScopeField;
-
-            separator -style "none";
-        setParent ..;
-
-        frameLayout -label "Geometry" -collapsable true -collapse false;
-            separator -style "none";
-            optionMenuGrp -l "Subdivision Method:" -annotation $subdMethodAnn defaultMeshSchemePopup;
-                menuItem -l "Catmull-Clark" -ann "catmullClark";
-                menuItem -l "Bilinear" -ann "bilinear";
-                menuItem -l "Loop" -ann "loop";
-                menuItem -l "None (Polygonal Mesh)" -ann "none";
-
-            checkBoxGrp -l "Color Sets:" -annotation $colorSetsAnn exportColorSetsCheckBox;
-
-            checkBoxGrp -l "UV Sets:" -annotation $uvSetsAnn exportUVsCheckBox;
-
-            optionMenuGrp -l "Skeletons:" -annotation $skelsAnn skelsPopup;
-                menuItem -l "None" -ann "none";
-                menuItem -l "All (Automatically Create SkelRoots)" -ann "auto";
-                menuItem -l "Only under SkelRoots" -ann "explicit";
-
-            optionMenuGrp -l "Skin Clusters" -annotation $skinClustersAnn skinClustersPopup;
-                menuItem -l "None" -ann "none";
-                menuItem -l "All (Automatically Create SkelRoots)" -ann "auto";
-                menuItem -l "Only Under SkelRoots" -ann "explicit";
-
-            checkBoxGrp -l "Blend Shapes:" -annotation $blendShapesAnn exportBlendShapesCheckBox;
-
-            checkBoxGrp -l "Display Colors:" -annotation $displayColorAnn exportDisplayColorCheckBox;
+            textFieldGrp -l `getMayaUsdString("kExportParentScopLbl")` -placeholderText `getMayaUsdString("kExportParentScopPht")`
+                -annotation `getMayaUsdString("kExportParentScopAnn")` parentScopeField;
 
             separator -style "none";
         setParent ..;
 
-        frameLayout -label "Materials" -collapsable true -collapse false -ann $materialsAnn;
+        frameLayout -label `getMayaUsdString("kExportFrameGeometryLbl")` -collapsable true -collapse false;
+            separator -style "none";
+            optionMenuGrp -l `getMayaUsdString("kExportSubdMethodLbl")` -annotation `getMayaUsdString("kExportSubdMethodAnn")` defaultMeshSchemePopup;
+                menuItem -l `getMayaUsdString("kExportSubdMethodCCLbl")` -ann "catmullClark";
+                menuItem -l `getMayaUsdString("kExportSubdMethodBiLbl")` -ann "bilinear";
+                menuItem -l `getMayaUsdString("kExportSubdMethodLoLbl")` -ann "loop";
+                menuItem -l `getMayaUsdString("kExportSubdMethodNoLbl")` -ann "none";
+
+            checkBoxGrp -l `getMayaUsdString("kExportColorSetsLbl")` -annotation `getMayaUsdString("kExportColorSetsAnn")` exportColorSetsCheckBox;
+
+            checkBoxGrp -l `getMayaUsdString("kExportUVSetsLbl")` -annotation `getMayaUsdString("kExportUVSetsAnn")` exportUVsCheckBox;
+
+            optionMenuGrp -l `getMayaUsdString("kExportSkelsLbl")` -annotation `getMayaUsdString("kExportSkelsAnn")` skelsPopup;
+                menuItem -l `getMayaUsdString("kExportSkelsNoneLbl")` -ann "none";
+                menuItem -l `getMayaUsdString("kExportSkelsAllLbl")` -ann "auto";
+                menuItem -l `getMayaUsdString("kExportSkelsRootLbl")` -ann "explicit";
+
+            optionMenuGrp -l `getMayaUsdString("kExportSkinClustersLbl")` -annotation `getMayaUsdString("kExportSkinClustersAnn")` skinClustersPopup;
+                menuItem -l `getMayaUsdString("kExportSkelsNoneLbl")` -ann "none";
+                menuItem -l `getMayaUsdString("kExportSkelsAllLbl")` -ann "auto";
+                menuItem -l `getMayaUsdString("kExportSkelsRootLbl")` -ann "explicit";
+
+            checkBoxGrp -l `getMayaUsdString("kExportBlendShapesLbl")` -annotation `getMayaUsdString("kExportBlendShapesAnn")` exportBlendShapesCheckBox;
+
+            checkBoxGrp -l `getMayaUsdString("kExportDisplayColorLbl")` -annotation `getMayaUsdString("kExportDisplayColorAnn")` exportDisplayColorCheckBox;
+
+            separator -style "none";
+        setParent ..;
+
+        frameLayout -label `getMayaUsdString("kExportFrameMaterialsLbl")` -collapsable true -collapse false -ann `getMayaUsdString("kExportMaterialsAnn")`;
             separator -style "none";
 
             string $conversions[] = `mayaUSDListShadingModes -export -useRegistryOnly`;
@@ -448,46 +426,46 @@ global proc int mayaUsdTranslatorExport (string $parent,
             separator -style "none";
         setParent ..;
 
-        frameLayout -label "Animation" -collapsable true -collapse false 
+        frameLayout -label `getMayaUsdString("kExportFrameAnimationLbl")` -collapsable true -collapse false 
                     -expandCommand("mayaUsdTranslatorExport_AnimationFrameLayoutExpandCB");
             separator -style "none";
 
-            checkBoxGrp -l "Animation Data: " -cc ("mayaUsdTranslatorExport_AnimationCB")
-                -annotation $animDataAnn animationCheckBox;
+            checkBoxGrp -l `getMayaUsdString("kExportAnimDataLbl")` -cc ("mayaUsdTranslatorExport_AnimationCB")
+                -annotation `getMayaUsdString("kExportAnimDataAnn")` animationCheckBox;
 
             columnLayout -width 100 animOptsCol;
                 rowLayout -numberOfColumns 2 -columnAttach 2 "left" 20;
-                    intFieldGrp -l "Frame Range Start/End:" -numberOfFields 2 -v1 1 -v2 200 -cw 1 175 framRangeFields;
-                    button -l "Use Animation Range" -command ("mayaUsdTranslatorExport_AnimationRangeCB") animRangeButton;
+                    intFieldGrp -l `getMayaUsdString("kExportFrameRangeLbl")` -numberOfFields 2 -v1 1 -v2 200 -cw 1 175 frameRangeFields;
+                    button -l `getMayaUsdString("kExportFrameRangeBtn")` -command ("mayaUsdTranslatorExport_AnimationRangeCB") animRangeButton;
                 setParent ..;
 
-                floatFieldGrp -l "Frame Step:" -v1 1 -cw 1 175 -annotation $frameStepAnn frameStrideField;
+                floatFieldGrp -l `getMayaUsdString("kExportFrameStepLbl")` -v1 1 -cw 1 175 -annotation `getMayaUsdString("kExportFrameStepAnn")` frameStrideField;
 
-                textFieldGrp -l "Frame Sample:" -cw 1 175 -annotation $frameSamplesAnn frameSampleField;
+                textFieldGrp -l `getMayaUsdString("kExportFrameSamplesLbl")` -cw 1 175 -annotation `getMayaUsdString("kExportFrameSamplesAnn")` frameSampleField;
 
-                checkBoxGrp -l "Euler Filter:" -cw 1 175
-                    -annotation $eulerFilterAnn eulerFilterCheckBox;
+                checkBoxGrp -l `getMayaUsdString("kExportEulerFilterLbl")` -cw 1 175
+                    -annotation `getMayaUsdString("kExportEulerFilterAnn")` eulerFilterCheckBox;
 
-                checkBoxGrp -l "Static Single Sample:" -annotation $staticSingleSampleAnn -v1 0 staticSingleSampleCheckBox;
+                checkBoxGrp -l `getMayaUsdString("kExportStaticSingleSampleLbl")` -annotation `getMayaUsdString("kExportStaticSingleSampleAnn")` -v1 0 staticSingleSampleCheckBox;
 
             setParent ..;
             
             separator -style "none";
         setParent ..;
 
-        frameLayout -label "Advanced" -collapsable true -collapse true;
+        frameLayout -label `getMayaUsdString("kExportFrameAdvancedLbl")` -collapsable true -collapse true;
             separator -style "none";
 
-            checkBoxGrp -l "Visibility:" -annotation $visibilityAnn exportVisibilityCheckBox;
+            checkBoxGrp -l `getMayaUsdString("kExportVisibilityLbl")` -annotation `getMayaUsdString("kExportVisibilityAnn")` exportVisibilityCheckBox;
 
-            optionMenuGrp -l "Instances:" -annotation $instancesAnn exportInstancesPopup;
-                menuItem -l "Flatten";
-                menuItem -l "Convert to USD Instanceable References";
+            optionMenuGrp -l `getMayaUsdString("kExportInstancesLbl")` -annotation `getMayaUsdString("kExportInstancesAnn")` exportInstancesPopup;
+                menuItem -l `getMayaUsdString("kExportInstancesFlatLbl")`;
+                menuItem -l `getMayaUsdString("kExportInstancesRefLbl")`;
 
-            checkBoxGrp -l "Merge Transform and\nShape Nodes:"
-                -annotation $mergeShapesAnn mergeTransformAndShapeCheckBox;
+            checkBoxGrp -l `getMayaUsdString("kExportMergeShapesLbl")`
+                -annotation `getMayaUsdString("kExportMergeShapesAnn")` mergeTransformAndShapeCheckBox;
 
-            checkBoxGrp -l "Include Namespaces:" -annotation $namespacesAnn includeNamespacesCheckBox;
+            checkBoxGrp -l `getMayaUsdString("kExportNamespacesLbl")` -annotation `getMayaUsdString("kExportNamespacesAnn")` includeNamespacesCheckBox;
 
             separator -style "none";
         setParent ..;

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -15,25 +15,29 @@
 // limitations under the License.
 //
 
-proc mayaUsdTranslatorExport_SetCheckbox(string $arg, string $widget) {
+proc mayaUsdTranslatorExport_SetCheckbox(string $arg, int $enable, string $widget) {
     if ($arg == "0") {
-        checkBoxGrp -e -v1 false $widget;
+        checkBoxGrp -e -v1 false -en $enable $widget;
     } else {
-        checkBoxGrp -e -v1 true $widget;
+        checkBoxGrp -e -v1 true -en $enable $widget;
     }
 }
 
-proc mayaUsdTranslatorExport_SetOppositeCheckbox(string $arg, string $widget) {
+proc mayaUsdTranslatorExport_SetOppositeCheckbox(string $arg, int $enable, string $widget) {
     if ($arg == "0") {
-        checkBoxGrp -e -v1 true $widget;
+        checkBoxGrp -e -v1 true -en $enable $widget;
     } else {
-        checkBoxGrp -e -v1 false $widget;
+        checkBoxGrp -e -v1 false -en $enable $widget;
     }
 }
 
 proc mayaUsdTranslatorExport_SetJobContextDropdown(string $arg) {
     if (startsWith($arg, "[") && endsWith($arg, "]")) {
-        $arg = substring($arg, 2, size($arg) - 1);
+        if (size($arg) > 2) {
+            $arg = substring($arg, 2, size($arg) - 1);
+        } else {
+            $arg = "";
+        }
     }
     string $enabledContexts[] = stringToStringArray($arg, ",");
     if (size($enabledContexts) > 0) {
@@ -50,19 +54,19 @@ proc mayaUsdTranslatorExport_SetJobContextDropdown(string $arg) {
     }
 
     // None is the default.
-    optionMenuGrp -e -select 0 jobContextPopup;
+    optionMenuGrp -e -select 1 jobContextPopup;
 }
 
-proc mayaUsdTranslatorExport_SetTextField(string $arg, string $widget) {
-    textFieldGrp -e -text $arg $widget;
+proc mayaUsdTranslatorExport_SetTextField(string $arg, int $enable, string $widget) {
+    textFieldGrp -e -text $arg -en $enable $widget;
 }
 
 proc mayaUsdTranslatorExport_SetOptionMenuByAnnotation(
-        string $ann, string $widget) {
+        string $ann, int $enable, string $widget) {
     int $index = 1; // 1-based indexing.
     for ($i in `optionMenuGrp -q -itemListLong $widget`) {
         if (`menuItem -q -ann $i` == $ann) {
-            optionMenuGrp -e -select $index $widget;
+            optionMenuGrp -e -select $index -en $enable $widget;
             return;
         }
 
@@ -71,7 +75,7 @@ proc mayaUsdTranslatorExport_SetOptionMenuByAnnotation(
 }
 
 proc mayaUsdTranslatorExport_SetOptionMenuByBool (
-        string $ann, string $widget) {
+        string $ann, int $enable, string $widget) {
     // Mapping between a boolean option and an option menu with two choices.
     // False maps to the first menu item, which is index 1.
     // True maps to the second menu item, which is index 2.
@@ -80,7 +84,7 @@ proc mayaUsdTranslatorExport_SetOptionMenuByBool (
     {
         $optionAsBool = 2;
     }
-    optionMenuGrp -e -select $optionAsBool $widget;
+    optionMenuGrp -e -select $optionAsBool -en $enable $widget;
 }
 
 proc string mayaUsdTranslatorExport_AppendOppositeFromCheckbox(string $currentOptions, string $arg, string $widget) {
@@ -163,9 +167,13 @@ global proc mayaUsdTranslatorExport_AnimationRangeCB() {
     intFieldGrp -e -v1 $startTime -v2 $endTime framRangeFields;
 }
 
-proc mayaUsdTranslatorExport_SetConvertMaterialsToCheckboxes(string $arg) {
+proc mayaUsdTranslatorExport_SetConvertMaterialsToCheckboxes(string $arg, int $enable, int $processJobContext) {
     if (startsWith($arg, "[") && endsWith($arg, "]")) {
-        $arg = substring($arg, 2, size($arg) - 1);
+        if (size($arg) > 2) {
+            $arg = substring($arg, 2, size($arg) - 1);
+        } else {
+            $arg = "";
+        }
     }
     string $enabledConversions[] = stringToStringArray($arg, ",");
     string $conversions[] = `mayaUSDListShadingModes -export -useRegistryOnly`;
@@ -174,9 +182,12 @@ proc mayaUsdTranslatorExport_SetConvertMaterialsToCheckboxes(string $arg) {
         string $widget = $opt + "_ConvertMaterialsToCheckBox";
 
         if(stringArrayFind($opt, 0, $enabledConversions) != -1) {
-            checkBoxGrp -e -v1 true $widget;
+            checkBoxGrp -e -v1 true -en $enable $widget;
         } else {
-            checkBoxGrp -e -v1 false $widget;
+            if ($processJobContext == 0) {
+                // A job context will not turn off selected options.
+                checkBoxGrp -e -v1 false $widget;
+            }
         }
     }
 }
@@ -195,6 +206,121 @@ proc string mayaUsdTranslatorExport_AppendConvertMaterialsTo(string $currentOpti
         return $currentOptions + ";shadingMode=useRegistry;" + $arg + "=[" + stringArrayToString($enabledConversions, ",") + "]";
     }
     return $currentOptions + ";shadingMode=none";
+}
+
+global proc mayaUsdTranslatorExport_EnableAllControls() {
+    // Restore all controls to fully interactive:
+    checkBoxGrp -e -en 1 exportUVsCheckBox;
+    checkBoxGrp -e -en 1 exportBlendShapesCheckBox;
+    checkBoxGrp -e -en 1 exportDisplayColorCheckBox;
+    checkBoxGrp -e -en 1 exportColorSetsCheckBox;
+    checkBoxGrp -e -en 1 animationCheckBox;
+    checkBoxGrp -e -en 1 eulerFilterCheckBox;
+    checkBoxGrp -e -en 1 staticSingleSampleCheckBox;
+    checkBoxGrp -e -en 1 exportVisibilityCheckBox;
+    checkBoxGrp -e -en 1 mergeTransformAndShapeCheckBox;
+    checkBoxGrp -e -en 1 includeNamespacesCheckBox;
+
+    optionMenuGrp -e -en 1 skelsPopup;
+    optionMenuGrp -e -en 1 skinClustersPopup;
+    optionMenuGrp -e -en 1 defaultMeshSchemePopup;
+    optionMenuGrp -e -en 1 defaultUSDFormatPopup;
+    optionMenuGrp -e -en 1 exportInstancesPopup;
+    optionMenuGrp -e -en 1 jobContextPopup;
+
+    intFieldGrp -e -en1 1 -en2 1 framRangeFields;
+
+    floatFieldGrp -e -en1 1 frameStrideField;
+
+    textFieldGrp -e -en 1 frameSampleField;
+    textFieldGrp -e -en 1 parentScopeField;
+
+    string $conversions[] = `mayaUSDListShadingModes -export -useRegistryOnly`;
+    for ($conversion in $conversions) {
+        string $opt = `mayaUSDListShadingModes -eo $conversion -useRegistryOnly`;
+        string $widgetName = $opt + "_ConvertMaterialsToCheckBox";
+        checkBoxGrp -e -en 1 $widgetName;
+    }
+}
+
+global proc mayaUsdTranslatorExport_SetFromOptions(string $currentOptions, int $enable, int $processJobContext) {
+    string $optionList[];
+    string $optionBreakDown[];
+    string $jobContext = "";
+    int $index;
+
+    if (size($currentOptions) > 0) {
+        tokenize($currentOptions, ";", $optionList);
+        for ($index = 0; $index < size($optionList); $index++) {
+            tokenize($optionList[$index], "=", $optionBreakDown);
+            if ($optionBreakDown[0] == "exportUVs") {
+                mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], $enable, "exportUVsCheckBox");
+            } else if ($optionBreakDown[0] == "exportSkels") {
+                mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], $enable, "skelsPopup");
+            } else if ($optionBreakDown[0] == "exportSkin") {
+                mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], $enable, "skinClustersPopup");
+            } else if ($optionBreakDown[0] == "exportBlendShapes") {
+                mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], $enable, "exportBlendShapesCheckBox");
+            } else if ($optionBreakDown[0] == "exportColorSets") {
+                mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], $enable, "exportColorSetsCheckBox");
+            } else if ($optionBreakDown[0] == "jobContext" && $processJobContext == 1) {
+                // Must be kept last, and only done on main options:
+                $jobContext = $optionBreakDown[1];
+            } else if ($optionBreakDown[0] == "defaultMeshScheme") {
+                mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], $enable, "defaultMeshSchemePopup");
+            } else if ($optionBreakDown[0] == "defaultUSDFormat") {
+                mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], $enable, "defaultUSDFormatPopup");
+            } else if ($optionBreakDown[0] == "animation") {
+                mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], $enable, "animationCheckBox");
+                mayaUsdTranslatorExport_AnimationCB();
+            } else if ($optionBreakDown[0] == "eulerFilter") {
+                mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], $enable, "eulerFilterCheckBox");
+            } else if ($optionBreakDown[0] == "staticSingleSample") {
+                mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], $enable, "staticSingleSampleCheckBox");
+            } else if ($optionBreakDown[0] == "startTime") {
+                int $startTime=$optionBreakDown[1];
+                intFieldGrp -e -v1 $startTime -en1 $enable framRangeFields;
+            } else if ($optionBreakDown[0] == "endTime") {
+                int $endTime; $endTime=$optionBreakDown[1];
+                intFieldGrp -e -v2 $endTime -en2 $enable framRangeFields;
+            } else if ($optionBreakDown[0] == "frameStride") {
+                float $frameStride = $optionBreakDown[1];
+                floatFieldGrp -e -v1 $frameStride -en1 $enable frameStrideField;
+            } else if ($optionBreakDown[0] == "frameSample") {
+                mayaUsdTranslatorExport_SetTextField($optionBreakDown[1], $enable, "frameSampleField");
+            } else if ($optionBreakDown[0] == "parentScope") {
+                mayaUsdTranslatorExport_SetTextField($optionBreakDown[1], $enable, "parentScopeField");
+            } else if ($optionBreakDown[0] == "convertMaterialsTo") {
+                mayaUsdTranslatorExport_SetConvertMaterialsToCheckboxes($optionBreakDown[1], $enable, $processJobContext);
+            } else if ($optionBreakDown[0] == "exportDisplayColor") {
+                mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], $enable, "exportDisplayColorCheckBox");
+            } else if ($optionBreakDown[0] == "exportInstances") {
+                mayaUsdTranslatorExport_SetOptionMenuByBool($optionBreakDown[1], $enable, "exportInstancesPopup");
+            } else if ($optionBreakDown[0] == "exportVisibility") {
+                mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], $enable, "exportVisibilityCheckBox");
+            } else if ($optionBreakDown[0] == "mergeTransformAndShape") {
+                mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], $enable, "mergeTransformAndShapeCheckBox");
+            } else if ($optionBreakDown[0] == "stripNamespaces") {
+                mayaUsdTranslatorExport_SetOppositeCheckbox($optionBreakDown[1], $enable, "includeNamespacesCheckBox");
+            }
+        }
+        if ($jobContext != "" && $processJobContext == 1) {
+            mayaUsdTranslatorExport_SetJobContextDropdown($jobContext);
+            mayaUsdTranslatorExport_JobContextCB();
+        }
+    }
+}
+
+global proc mayaUsdTranslatorExport_JobContextCB() {
+    mayaUsdTranslatorExport_EnableAllControls();
+
+    string $niceName = `optionMenuGrp -q -value jobContextPopup`;
+    if ($niceName != "None") {
+        string $affectedOptions = `mayaUSDListJobContexts -eg $niceName`;
+        if ($affectedOptions != "") {
+            mayaUsdTranslatorExport_SetFromOptions($affectedOptions, 0, 0);
+        }
+    }
 }
 
 global proc int mayaUsdTranslatorExport (string $parent,
@@ -225,9 +351,6 @@ global proc int mayaUsdTranslatorExport (string $parent,
 {
     int $bResult;
     string $currentOptions;
-    string $optionList[];
-    string $optionBreakDown[];
-    int $index;
 
     if ($action == "post") {
         string $parentScopAnn = "Name of the USD scope that is the parent of the exported data.";
@@ -236,7 +359,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
         string $skelsAnn = "Exports Maya joints as part of a USD skeleton.";
         string $skinClustersAnn = "Exports Maya skin clusters as part of a USD skeleton.";
         string $blendShapesAnn = "Exports Maya Blend Shapes as USD blendshapes. Requires skeletons to be exported as well.";
-        string $displayColorAnn = "If selected, exports the diffuse color of the geometry’s bound shader as a displayColor primvar on the USD mesh.";
+        string $displayColorAnn = "If selected, exports the diffuse color of the geometry's bound shader as a displayColor primvar on the USD mesh.";
         string $materialsAnn = "Select the material(s) to bind to prims for export. With USD, you can bind multiple materials to prims.";
         string $animDataAnn = "Exports Maya animation data as USD time samples.";
         string $frameStepAnn = "Specifies the increment between USD time sample frames during animation export";
@@ -256,7 +379,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
 
         columnLayout -adj true usdOptsCol;
 
-        optionMenuGrp -l "Plug-in Configuration:" -annotation $jobContextAnn jobContextPopup;
+        optionMenuGrp -l "Plug-in Configuration:" -annotation $jobContextAnn -cc ("mayaUsdTranslatorExport_JobContextCB") jobContextPopup;
             menuItem -l "None" -ann "None";
             string $contexts[] = `mayaUSDListJobContexts -export`;
             for ($context in $contexts) {
@@ -373,63 +496,12 @@ global proc int mayaUsdTranslatorExport (string $parent,
 
         // Now set to current settings.
         $currentOptions = $initialSettings;
-        if (size($currentOptions) > 0) {
-            tokenize($currentOptions, ";", $optionList);
-            for ($index = 0; $index < size($optionList); $index++) {
-                tokenize($optionList[$index], "=", $optionBreakDown);
-                if ($optionBreakDown[0] == "exportUVs") {
-                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportUVsCheckBox");
-                } else if ($optionBreakDown[0] == "exportSkels") {
-                    mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "skelsPopup");
-                } else if ($optionBreakDown[0] == "exportSkin") {
-                    mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "skinClustersPopup");
-                } else if ($optionBreakDown[0] == "exportBlendShapes") {
-                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportBlendShapesCheckBox");
-                } else if ($optionBreakDown[0] == "exportColorSets") {
-                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportColorSetsCheckBox");
-                } else if ($optionBreakDown[0] == "jobContext") {
-                    mayaUsdTranslatorExport_SetJobContextDropdown($optionBreakDown[1]);
-                } else if ($optionBreakDown[0] == "defaultMeshScheme") {
-                    mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "defaultMeshSchemePopup");
-                } else if ($optionBreakDown[0] == "defaultUSDFormat") {
-                    mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], "defaultUSDFormatPopup");
-                } else if ($optionBreakDown[0] == "animation") {
-                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "animationCheckBox");
-                } else if ($optionBreakDown[0] == "eulerFilter") {
-                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "eulerFilterCheckBox");
-                } else if ($optionBreakDown[0] == "staticSingleSample") {
-                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "staticSingleSampleCheckBox");
-                } else if ($optionBreakDown[0] == "startTime") {
-                    int $startTime=$optionBreakDown[1];
-                    intFieldGrp -e -v1 $startTime framRangeFields;
-                } else if ($optionBreakDown[0] == "endTime") {
-                    int $endTime; $endTime=$optionBreakDown[1];
-                    intFieldGrp -e -v2 $endTime framRangeFields;
-                } else if ($optionBreakDown[0] == "frameStride") {
-                    float $frameStride = $optionBreakDown[1];
-                    floatFieldGrp -e -v1 $frameStride frameStrideField;
-                } else if ($optionBreakDown[0] == "frameSample") {
-                    mayaUsdTranslatorExport_SetTextField($optionBreakDown[1], "frameSampleField");
-                } else if ($optionBreakDown[0] == "parentScope") {
-                    mayaUsdTranslatorExport_SetTextField($optionBreakDown[1], "parentScopeField");
-                } else if ($optionBreakDown[0] == "convertMaterialsTo") {
-                    mayaUsdTranslatorExport_SetConvertMaterialsToCheckboxes($optionBreakDown[1]);
-                } else if ($optionBreakDown[0] == "exportDisplayColor") {
-                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportDisplayColorCheckBox");
-                } else if ($optionBreakDown[0] == "exportInstances") {
-                    mayaUsdTranslatorExport_SetOptionMenuByBool($optionBreakDown[1], "exportInstancesPopup");
-                } else if ($optionBreakDown[0] == "exportVisibility") {
-                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "exportVisibilityCheckBox");
-                } else if ($optionBreakDown[0] == "mergeTransformAndShape") {
-                    mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], "mergeTransformAndShapeCheckBox");
-                } else if ($optionBreakDown[0] == "stripNamespaces") {
-                    mayaUsdTranslatorExport_SetOppositeCheckbox($optionBreakDown[1], "includeNamespacesCheckBox");
-                }
-            }
-        }
+
+        mayaUsdTranslatorExport_EnableAllControls();
+        mayaUsdTranslatorExport_SetFromOptions($currentOptions, 1, 1);
+
         // Set visibility for anim widgets
         mayaUsdTranslatorExport_AnimationCB();
-
         $bResult = 1;
 
     } else if ($action == "query") {

--- a/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
@@ -43,6 +43,100 @@ proc mayaUsdTranslatorImport_showInfo()
     }
 }
 
+proc mayaUsdTranslatorImport_SetJobContextDropdown(string $arg) {
+    if (startsWith($arg, "[") && endsWith($arg, "]")) {
+        if (size($arg) > 2) {
+            $arg = substring($arg, 2, size($arg) - 1);
+        } else {
+            $arg = "";
+        }
+    }
+    string $enabledContexts[] = stringToStringArray($arg, ",");
+    if (size($enabledContexts) > 0) {
+        // Pick first element (in case we find many...)
+        string $enabledContext = $enabledContexts[0];
+        string $niceNames[] = `mayaUSDListJobContexts -import`;
+        for ($niceName in $niceNames) {
+            string $jobContext = `mayaUSDListJobContexts -jc $niceName`;
+            if ($jobContext == $enabledContext) {
+                optionMenuGrp -e -value $niceName mayaUsdTranslator_jobContextPopup;
+                return;
+            }
+        }
+    }
+
+    // None is the default.
+    optionMenuGrp -e -select 1 mayaUsdTranslator_jobContextPopup;
+}
+
+global proc mayaUsdTranslatorImport_EnableAllControls() {
+    // Restore all controls to fully interactive:
+    checkBoxGrp -e -en 1 mayaUsdTranslator_MaterialsCheckBox;
+    checkBoxGrp -e -en 1 mayaUsdTranslator_ImportUSDZTexturesCheckBox;
+    checkBoxGrp -e -en 1 mayaUsdTranslator_ImportInstancesCheckBox;
+    checkBoxGrp -e -en 1 mayaUsdTranslator_AnimDataCheckBox;
+    checkBoxGrp -e -en 1 mayaUsdTranslator_CustomFrameRangeCheckBox;
+
+    optionMenuGrp -e -en 1 mayaUsdTranslator_jobContextPopup;
+    optionMenuGrp -e -en 1 mayaUsdTranslator_MaterialsConversionMenu;
+
+    intFieldGrp -e -en1 1 -en2 1 mayaUsdTranslator_CustomFrameRange;
+}
+
+global proc mayaUsdTranslatorImport_SetFromOptions(string $currentOptions, int $enable, int $processJobContext) {
+    string $optionList[];
+    string $optionBreakDown[];
+    string $jobContext = "";
+    int $index;
+
+    if (size($currentOptions) > 0) {
+        tokenize($currentOptions, ";", $optionList);
+        for ($index = 0; $index < size($optionList); $index++) {
+            tokenize($optionList[$index], "=", $optionBreakDown);
+            if ($optionBreakDown[0] == "shadingMode") {
+                mayaUsdTranslatorImport_SetMaterialsCheckBox($optionBreakDown[1], $enable, "mayaUsdTranslator_MaterialsCheckBox");
+            } else if ($optionBreakDown[0] == "jobContext" && $processJobContext == 1) {
+                // Must be kept last, and only done on main options:
+                $jobContext = $optionBreakDown[1];
+            } else if ($optionBreakDown[0] == "preferredMaterial") {
+                mayaUsdTranslatorImport_SetOptionMenuByAnnotation($optionBreakDown[1], $enable, "mayaUsdTranslator_MaterialsConversionMenu");
+            } else if ($optionBreakDown[0] == "readAnimData") {
+                mayaUsdTranslatorImport_SetCheckBoxGrp($optionBreakDown[1], $enable, "mayaUsdTranslator_AnimDataCheckBox");
+                mayaUsdTranslatorImport_AnimationCB();
+            } else if ($optionBreakDown[0] == "startTime") {
+                int $startTime = $optionBreakDown[1];
+                intFieldGrp -e -value1 $startTime -en1 $enable mayaUsdTranslator_CustomFrameRange;
+            } else if ($optionBreakDown[0] == "endTime") {
+                int $endTime = $optionBreakDown[1];
+                intFieldGrp -e -value2 $endTime -en2 $enable mayaUsdTranslator_CustomFrameRange;
+            } else if ($optionBreakDown[0] == "useCustomFrameRange") {
+                mayaUsdTranslatorImport_SetCheckBoxGrp($optionBreakDown[1], $enable, "mayaUsdTranslator_CustomFrameRangeCheckBox");
+                mayaUsdTranslatorImport_AnimationCB();
+            } else if ($optionBreakDown[0] == "importInstances") {
+                mayaUsdTranslatorImport_SetCheckBoxGrp($optionBreakDown[1], $enable, "mayaUsdTranslator_ImportInstancesCheckBox");
+            } else if ($optionBreakDown[0] == "importUSDZTextures") {
+                mayaUsdTranslatorImport_SetCheckBoxGrp($optionBreakDown[1], $enable, "mayaUsdTranslator_ImportUSDZTexturesCheckBox");
+            }
+        }
+        if ($jobContext != "" && $processJobContext == 1) {
+            mayaUsdTranslatorImport_SetJobContextDropdown($jobContext);
+            mayaUsdTranslatorImport_JobContextCB();
+        }
+    }
+}
+
+global proc mayaUsdTranslatorImport_JobContextCB() {
+    mayaUsdTranslatorImport_EnableAllControls();
+
+    string $niceName = `optionMenuGrp -q -value mayaUsdTranslator_jobContextPopup`;
+    if ($niceName != "None") {
+        string $affectedOptions = `mayaUSDListJobContexts -ig $niceName`;
+        if ($affectedOptions != "") {
+            mayaUsdTranslatorImport_SetFromOptions($affectedOptions, 0, 0);
+        }
+    }
+}
+
 global proc int mayaUsdTranslatorImport (string $parent,
                                  string $action,
                                  string $initialSettings,
@@ -76,9 +170,20 @@ global proc int mayaUsdTranslatorImport (string $parent,
     int $bw = 125;
 
     if ($action == "post") {
+        string $jobContextAnn = "Select a loaded plug-in configuration to modify import options";
+
         setParent $parent;
 
         columnLayout -adj true -rs 5 mayaUsdTranslator_OptsCol;
+
+        optionMenuGrp -l "Plug-in Configuration:" -cw 1 $cw1 -annotation $jobContextAnn -cc ("mayaUsdTranslatorImport_JobContextCB") mayaUsdTranslator_jobContextPopup;
+            menuItem -l "None" -ann "None";
+            string $contexts[] = `mayaUSDListJobContexts -import`;
+            for ($context in $contexts) {
+                string $ann = `mayaUSDListJobContexts -ia $context`;
+                menuItem -l $context -ann $ann;
+            }
+
 
         if (`exists usdImportDialog`)
         {
@@ -168,36 +273,10 @@ global proc int mayaUsdTranslatorImport (string $parent,
         intFieldGrp -label "Frame Range Start/End: " -nf 2 -cw 1 $cw2 mayaUsdTranslator_CustomFrameRange;
 
         // Now set to current settings.
-        string $optionList[];
-        string $optionBreakDown[];
-        int $index;
         string $currentOptions = $initialSettings;
 
-        if (size($currentOptions) > 0) {
-            tokenize($currentOptions, ";", $optionList);
-            for ($index = 0; $index < size($optionList); $index++) {
-                tokenize($optionList[$index], "=", $optionBreakDown);
-                if ($optionBreakDown[0] == "shadingMode") {
-                    mayaUsdTranslatorImport_SetMaterialsCheckBox($optionBreakDown[1], "mayaUsdTranslator_MaterialsCheckBox");
-                } else if ($optionBreakDown[0] == "preferredMaterial") {
-                    mayaUsdTranslatorImport_SetOptionMenuByAnnotation($optionBreakDown[1], "mayaUsdTranslator_MaterialsConversionMenu");
-                } else if ($optionBreakDown[0] == "readAnimData") {
-                    mayaUsdTranslatorImport_SetCheckBoxGrp($optionBreakDown[1], "mayaUsdTranslator_AnimDataCheckBox");
-                } else if ($optionBreakDown[0] == "startTime") {
-                    int $startTime = $optionBreakDown[1];
-                    intFieldGrp -e -value1 $startTime mayaUsdTranslator_CustomFrameRange;
-                } else if ($optionBreakDown[0] == "endTime") {
-                    int $endTime = $optionBreakDown[1];
-                    intFieldGrp -e -value2 $endTime mayaUsdTranslator_CustomFrameRange;
-                } else if ($optionBreakDown[0] == "useCustomFrameRange") {
-                    mayaUsdTranslatorImport_SetCheckBoxGrp($optionBreakDown[1], "mayaUsdTranslator_CustomFrameRangeCheckBox");
-                } else if ($optionBreakDown[0] == "importInstances") {
-                    mayaUsdTranslatorImport_SetCheckBoxGrp($optionBreakDown[1], "mayaUsdTranslator_ImportInstancesCheckBox");
-                } else if ($optionBreakDown[0] == "importUSDZTextures") {
-                    mayaUsdTranslatorImport_SetCheckBoxGrp($optionBreakDown[1], "mayaUsdTranslator_ImportUSDZTexturesCheckBox");
-                }
-            }
-        }
+        mayaUsdTranslatorImport_EnableAllControls();
+        mayaUsdTranslatorImport_SetFromOptions($currentOptions, 1, 1);
 
         $bResult = 1;
 
@@ -211,6 +290,7 @@ global proc int mayaUsdTranslatorImport (string $parent,
         $currentOptions = mayaUsdTranslatorImport_AppendFromIntFieldGrp($currentOptions, "startTime", 1, "mayaUsdTranslator_CustomFrameRange");
         $currentOptions = mayaUsdTranslatorImport_AppendFromIntFieldGrp($currentOptions, "endTime", 2, "mayaUsdTranslator_CustomFrameRange");
         $currentOptions = mayaUsdTranslatorImport_AppendFromCheckBoxGrp($currentOptions, "importUSDZTextures", "mayaUsdTranslator_ImportUSDZTexturesCheckBox");
+        $currentOptions = mayaUsdTranslatorImport_AppendJobContexts($currentOptions, "jobContext");
 
         eval($resultCallback+" \""+$currentOptions+"\"");
         $bResult = 1;
@@ -265,11 +345,11 @@ global proc int mayaUsdTranslatorImport (string $parent,
 }
 
 global proc mayaUsdTranslatorImport_SetOptionMenuByAnnotation(
-        string $ann, string $widget) {
+        string $ann, int $enable, string $widget) {
     int $index = 1; // 1-based indexing.
     for ($i in `optionMenuGrp -q -itemListLong $widget`) {
         if (`menuItem -q -ann $i` == $ann) {
-            optionMenuGrp -e -select $index $widget;
+            optionMenuGrp -e -select $index -en $enable $widget;
             return;
         }
 
@@ -277,14 +357,14 @@ global proc mayaUsdTranslatorImport_SetOptionMenuByAnnotation(
     }
 }
 
-global proc mayaUsdTranslatorImport_SetCheckBoxGrp(string $arg, string $widget)
+global proc mayaUsdTranslatorImport_SetCheckBoxGrp(string $arg, int $enable, string $widget)
 {
-    checkBoxGrp -e -value1 ($arg != "0") $widget;
+    checkBoxGrp -e -value1 ($arg != "0") -en $enable $widget;
 }
 
-global proc mayaUsdTranslatorImport_SetMaterialsCheckBox(string $arg, string $widget)
+global proc mayaUsdTranslatorImport_SetMaterialsCheckBox(string $arg, int $enable, string $widget)
 {
-    checkBoxGrp -e -value1 ($arg != "[[none,default]]") $widget;
+    checkBoxGrp -e -value1 ($arg != "[[none,default]]") -en $enable $widget;
     mayaUsdTranslatorImport_MaterialsCB();
 }
 
@@ -335,6 +415,17 @@ global proc string mayaUsdTranslatorImport_AppendMaterialsFromCheckBoxGrp(string
     } else {
         return $currentOptions + ";" + $arg + "=[[none,default]]";
     }
+}
+
+global proc string mayaUsdTranslatorImport_AppendJobContexts(string $currentOptions, string $arg) {
+    string $niceName = `optionMenuGrp -q -value mayaUsdTranslator_jobContextPopup`;
+    if ($niceName != "None") {
+        string $jobContext = `mayaUSDListJobContexts -jc $niceName`;
+        if ($jobContext != "") {
+            return $currentOptions + ";" + $arg + "=[" + $jobContext + "]";
+        }
+    }
+    return $currentOptions;
 }
 
 global proc string mayaUsdTranslatorImport_AppendFromPopup(string $currentOptions, string $arg, string $widget) {

--- a/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
@@ -129,7 +129,7 @@ global proc mayaUsdTranslatorImport_JobContextCB() {
     mayaUsdTranslatorImport_EnableAllControls();
 
     string $niceName = `optionMenuGrp -q -value mayaUsdTranslator_jobContextPopup`;
-    if ($niceName != "None") {
+    if ($niceName != `getMayaUsdString("kImportJobContextNoneLbl")`) {
         string $affectedOptions = `mayaUSDListJobContexts -ig $niceName`;
         if ($affectedOptions != "") {
             mayaUsdTranslatorImport_SetFromOptions($affectedOptions, 0, 0);
@@ -170,14 +170,12 @@ global proc int mayaUsdTranslatorImport (string $parent,
     int $bw = 125;
 
     if ($action == "post") {
-        string $jobContextAnn = "Select a loaded plug-in configuration to modify import options";
-
         setParent $parent;
 
         columnLayout -adj true -rs 5 mayaUsdTranslator_OptsCol;
 
-        optionMenuGrp -l "Plug-in Configuration:" -cw 1 $cw1 -annotation $jobContextAnn -cc ("mayaUsdTranslatorImport_JobContextCB") mayaUsdTranslator_jobContextPopup;
-            menuItem -l "None" -ann "None";
+        optionMenuGrp -l  `getMayaUsdString("kImportJobContextLbl")` -cw 1 $cw1 -annotation `getMayaUsdString("kImportJobContextAnn")` -cc ("mayaUsdTranslatorImport_JobContextCB") mayaUsdTranslator_jobContextPopup;
+            menuItem -l `getMayaUsdString("kImportJobContextNoneLbl")` -ann "None";
             string $contexts[] = `mayaUSDListJobContexts -import`;
             for ($context in $contexts) {
                 string $ann = `mayaUSDListJobContexts -ia $context`;
@@ -188,18 +186,15 @@ global proc int mayaUsdTranslatorImport (string $parent,
         if (`exists usdImportDialog`)
         {
             rowLayout -numberOfColumns 4 -cw 1 $cw1 -cat 1 "right" 0;
-                text -label "Scope and Variants: "
+                text -label `getMayaUsdString("kImportScopeVariantsLbl")`
                     -al "right"
-                    -sbm "Select a USD file and click Hierarchy View to open the Hierarchy View window. This window lets you toggle prim checkboxes and non-destructively switch between variants to build the scope of your import."
-                    -ann "Select a USD file and click <strong>Hierarchy View</strong> to build the scope of your import and switch variants.<br><br><strong>Scope</strong>: A USD file consists of prims, the primary container object in USD. Prims can contain any scene element, like meshes, lights, cameras, etc. Use the checkboxes in the <strong>Hierarchy View</strong> to select and deselect prims to build the scope of your import.<br><br><strong>Variant</strong>: A variant is a single, named variation of a variant set. Each variant set is a package of alternatives that users can switch between non-destructively. A variant set has no limits to what it can store. Variants can be used to swap out a material or change the entire hierarchy of an asset. A single prim can have many variants and variant sets, but only one variant from each variant set can be selected for import into Maya."
+                    -sbm `getMayaUsdString("kImportScopeVariantsSbm")`
+                    -ann `getMayaUsdString("kImportScopeVariantsAnn")`
                 ;
-                textField -ed false -nbg true -text "Please select a file to enable this option" -w $cw2 mayaUsdTranslator_SelectFileField;
-                button -label "Hierarchy View" -c "mayaUsdTranslatorImport_ViewHierCB" mayaUsdTranslator_ViewHierBtn;
-                iconTextButton -w 32 -h 32 -command ("mayaUsdTranslatorImport_ClearImportData;") -
-                    style "iconAndTextVertical" -image1 "refresh.png" -label "" mayaUsdTranslator_ResetBtn;
-
-                string $nbPrimsInScopeLabel = "Total Number of Prims in Scope:";
-                string $nbModifiedVariantsLabel = "Variants Switched in Scope:";
+                textField -ed false -nbg true -text `getMayaUsdString("kImportSelectFileTxt")` -w $cw2 mayaUsdTranslator_SelectFileField;
+                button -label `getMayaUsdString("kImportHierarchyViewLbl")` -c "mayaUsdTranslatorImport_ViewHierCB" mayaUsdTranslator_ViewHierBtn;
+                iconTextButton -w 32 -h 32 -command ("mayaUsdTranslatorImport_ClearImportData;") 
+                    -style "iconAndTextVertical" -image1 "refresh.png" -label "" mayaUsdTranslator_ResetBtn;
 
                 // Hide the button by default.
                 button -e -visible false -w 1 mayaUsdTranslator_ViewHierBtn;
@@ -208,12 +203,12 @@ global proc int mayaUsdTranslatorImport (string $parent,
 
             rowLayout -numberOfColumns 3 -cw 1 $cw1 -cat 1 "right" 0 -cal 1 "right" mayaUsd_NBPrimsInScopeRL;
                 text -label "";
-                text -label $nbPrimsInScopeLabel;
+                text -label `getMayaUsdString("kImportPrimsInScopeNumLbl")`;
                 text -label "---" mayaUsd_NBPrimsInScopeLabel;
             setParent ..;
             rowLayout -numberOfColumns 3 -cw 1 $cw1 -cat 1 "right" 0 -cal 1 "right" mayaUsd_NBSwitchedVariantsRL;
                 text -label "";
-                text -label $nbModifiedVariantsLabel;
+                text -label `getMayaUsdString("kImportVariantsInScopeNumLbl")`;
                 text -label "---" mayaUsd_NBSwitchedVariantsLabel;
             setParent ..;
             // We'll start off with the info UI hidden and only make it visible when we come out of 
@@ -228,27 +223,23 @@ global proc int mayaUsdTranslatorImport (string $parent,
 //            menuItem -label "World space";
 //        optionMenuGrp -e -sl 1 mayaUsdTranslator_CoordSystemOptionMenu;
 
-        string $materialsAnn = "If selected, shading data is extracted from the USD file for import";
-        checkBoxGrp -label "Materials: " -cw 1 $cw1 -value1 1 -ann $materialsAnn -cc ("mayaUsdTranslatorImport_MaterialsCB") mayaUsdTranslator_MaterialsCheckBox;
+        checkBoxGrp -label `getMayaUsdString("kImportMaterialsLbl")` -cw 1 $cw1 -value1 1 -ann `getMayaUsdString("kImportMaterialsAnn")` -cc ("mayaUsdTranslatorImport_MaterialsCB") mayaUsdTranslator_MaterialsCheckBox;
 
         string $apiString = `about -q -apiVersion`;
         $apiString = `substring $apiString 1 4`;
-        string $convertAnn = "Select the preferred conversion method for inbound USD shading data to bind with Maya geometry";
-        optionMenuGrp -l "Convert to:" -cw 1 $cw2 -ann $convertAnn mayaUsdTranslator_MaterialsConversionMenu;
-        menuItem -l "No Conversion" -ann "none";
+        optionMenuGrp -l `getMayaUsdString("kImportMaterialConvLbl")` -cw 1 $cw2 -ann `getMayaUsdString("kImportMaterialConvAnn")` mayaUsdTranslator_MaterialsConversionMenu;
+        menuItem -l `getMayaUsdString("kImportMaterialConvNoneLbl")` -ann "none";
         if ((int)$apiString >= 2020) {
-            menuItem -l "Standard Surface" -ann "standardSurface";
+            menuItem -l `getMayaUsdString("kImportMaterialConvSSLbl")` -ann "standardSurface";
         }
-        menuItem -l "Lambert" -ann "lambert";
-        menuItem -l "USD Preview Surface" -ann "usdPreviewSurface";
-        menuItem -l "Blinn" -ann "blinn";
-        menuItem -l "Phong" -ann "phong";
+        menuItem -l `getMayaUsdString("kImportMaterialConvLamLbl")` -ann "lambert";
+        menuItem -l `getMayaUsdString("kImportMaterialConvPSLbl")` -ann "usdPreviewSurface";
+        menuItem -l `getMayaUsdString("kImportMaterialConvBlnLbl")` -ann "blinn";
+        menuItem -l `getMayaUsdString("kImportMaterialConvPhgLbl")` -ann "phong";
 
-        string $importUSDZTexturesAnn = "When a .usdz file is chosen and this is selected, .usdz texture files are imported and copied to new files on disk. To locate these files, navigate to the current Maya workspace /sourceimages directory.";
-        checkBoxGrp -label "USDZ Texture Import: " -cw 1 $cw2 -ann $importUSDZTexturesAnn mayaUsdTranslator_ImportUSDZTexturesCheckBox;
+        checkBoxGrp -label `getMayaUsdString("kImportUSDZTxtLbl")` -cw 1 $cw2 -ann `getMayaUsdString("kImportUSDZTxtAnn")` mayaUsdTranslator_ImportUSDZTexturesCheckBox;
 
-        string $instancedAnn = "Converts instanced prims to Maya instances. Instanced prims share parts of\nthe USD scenegraph through instancing. Each instanced prim is associated\nwith a master prim that serves as the root of the scenegraph. This hierarchy\nreduces the time needed to load the file. Instanced prims must be manually\ntagged.";
-        checkBoxGrp -label "Instanced Prims: " -label1 "Convert to Instances" -cw 1 $cw1 -value1 1 -ann $instancedAnn mayaUsdTranslator_ImportInstancesCheckBox;
+        checkBoxGrp -label `getMayaUsdString("kImportToInstanceLbl")` -label1 `getMayaUsdString("kImportToInstanceOpt")` -cw 1 $cw1 -value1 1 -ann `getMayaUsdString("kImportToInstanceAnn")` mayaUsdTranslator_ImportInstancesCheckBox;
 
 //        optionMenuGrp -label "Include Metadata: " -cw 1 $cw1 mayaUsdTranslator_IncludeMetadataOptionMenu;
 //            menuItem "All";
@@ -266,11 +257,11 @@ global proc int mayaUsdTranslatorImport (string $parent,
 //            menuItem "Custom";
 //        optionMenuGrp -e -sl 2 mayaUsdTranslator_IncludeCustomAttribOptionMenu;
 
-        checkBoxGrp -label "Animation Data: " -cw 1 $cw1 -cc ("mayaUsdTranslatorImport_AnimationCB") mayaUsdTranslator_AnimDataCheckBox;
+        checkBoxGrp -label `getMayaUsdString("kImportAnimationDataLbl")` -cw 1 $cw1 -cc ("mayaUsdTranslatorImport_AnimationCB") mayaUsdTranslator_AnimDataCheckBox;
 
-        checkBoxGrp -label "Custom Frame Range: " -cw 1 $cw2 -cc ("mayaUsdTranslatorImport_AnimationCB") mayaUsdTranslator_CustomFrameRangeCheckBox;
+        checkBoxGrp -label `getMayaUsdString("kImportCustomFrameRangeLbl")` -cw 1 $cw2 -cc ("mayaUsdTranslatorImport_AnimationCB") mayaUsdTranslator_CustomFrameRangeCheckBox;
 
-        intFieldGrp -label "Frame Range Start/End: " -nf 2 -cw 1 $cw2 mayaUsdTranslator_CustomFrameRange;
+        intFieldGrp -label `getMayaUsdString("kImportFrameRangeLbl")` -nf 2 -cw 1 $cw2 mayaUsdTranslator_CustomFrameRange;
 
         // Now set to current settings.
         string $currentOptions = $initialSettings;
@@ -419,7 +410,7 @@ global proc string mayaUsdTranslatorImport_AppendMaterialsFromCheckBoxGrp(string
 
 global proc string mayaUsdTranslatorImport_AppendJobContexts(string $currentOptions, string $arg) {
     string $niceName = `optionMenuGrp -q -value mayaUsdTranslator_jobContextPopup`;
-    if ($niceName != "None") {
+    if ($niceName != `getMayaUsdString("kImportJobContextNoneLbl")`) {
         string $jobContext = `mayaUSDListJobContexts -jc $niceName`;
         if ($jobContext != "") {
             return $currentOptions + ";" + $arg + "=[" + $jobContext + "]";

--- a/plugin/pxr/maya/lib/usdMaya/exportTranslator.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/exportTranslator.cpp
@@ -128,7 +128,7 @@ MStatus UsdMayaExportTranslator::writer(
                     }
                 }
                 userArgs[argName] = UsdMayaUtil::ParseArgumentValue(
-                    argName, theOption[1].asChar(), UsdMayaJobExportArgs::GetDefaultDictionary());
+                    argName, theOption[1].asChar(), UsdMayaJobExportArgs::GetGuideDictionary());
             }
         }
     }

--- a/plugin/pxr/maya/lib/usdMaya/importTranslator.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/importTranslator.cpp
@@ -80,7 +80,7 @@ MStatus UsdMayaImportTranslator::reader(
                 timeInterval.SetMax(theOption[1].asDouble());
             } else {
                 userArgs[argName] = UsdMayaUtil::ParseArgumentValue(
-                    argName, theOption[1].asChar(), UsdMayaJobImportArgs::GetDefaultDictionary());
+                    argName, theOption[1].asChar(), UsdMayaJobImportArgs::GetGuideDictionary());
             }
         }
     }

--- a/test/lib/usd/plugin/nullApiExporter.cpp
+++ b/test/lib/usd/plugin/nullApiExporter.cpp
@@ -61,7 +61,29 @@ REGISTER_EXPORT_JOB_CONTEXT_FCT(Thierry, "Thierry", "Exports for Thierry rendere
 
 REGISTER_EXPORT_JOB_CONTEXT_FCT(SceneGrinder, "Scene Grinder", "Exports to Scene Grinder")
 {
-    return VtDictionary();
+    VtDictionary extraArgs;
+    extraArgs["exportDisplayColor"] = VtValue(true);
+    extraArgs["shadingMode"] = VtValue(std::string("useRegistry"));
+    extraArgs["convertMaterialsTo"] = VtValue(std::vector<VtValue> {
+        VtValue(std::string("MaterialX")), VtValue(std::string("UsdPreviewSurface")) });
+    extraArgs["animation"] = VtValue(true);
+    // The next two are bizarre. They are handled as double internally, but their representation in
+    // the UI are int and float.
+    extraArgs["startTime"] = VtValue(12);
+    extraArgs["frameStride"] = VtValue(1.5f);
+    return extraArgs;
+}
+
+REGISTER_IMPORT_JOB_CONTEXT_FCT(SceneGrinder, "Scene Grinder", "Imports from Scene Grinder")
+{
+    VtDictionary extraArgs;
+
+    extraArgs["preferredMaterial"] = VtValue(std::string("standardSurface"));
+    extraArgs["importUSDZTextures"] = VtValue(true);
+    extraArgs["readAnimData"] = VtValue(true);
+    extraArgs["useCustomFrameRange"] = VtValue(true);
+    extraArgs["startTime"] = VtValue(12);
+    return extraArgs;
 }
 
 REGISTER_EXPORT_JOB_CONTEXT_FCT(

--- a/test/lib/usd/translators/testUsdExportSchemaApi.py
+++ b/test/lib/usd/translators/testUsdExportSchemaApi.py
@@ -59,11 +59,28 @@ class testUsdExportSchemaApi(unittest.TestCase):
             'apiSchema=[testApi];chaser=[NullAPIChaser];chaserArgs=[[NullAPIChaser,life,42]];')
 
         modes = set(cmds.mayaUSDListJobContexts(im=True))
-        self.assertEqual(modes, set(["Null API", 'Bullet Physics API Support']))
+        self.assertEqual(modes, set(["Null API", 'Bullet Physics API Support', 'Scene Grinder']))
         self.assertEqual(cmds.mayaUSDListJobContexts(importAnnotation="Null API"),
                          "Imports an empty API for testing purpose")
         self.assertEqual(cmds.mayaUSDListJobContexts(importArguments="Null API"), 
             'apiSchema=[testApiIn];chaser=[NullAPIChaserIn];chaserArgs=[[NullAPIChaserIn,universe,42]];')
+
+        # The job context used for UI debugging have int startTime and float frameStride values to convert:
+        self.assertEqual(set(cmds.mayaUSDListJobContexts(ig="Scene Grinder").strip(";").split(";")), 
+            set(['importUSDZTextures=1',
+                 'preferredMaterial=standardSurface',
+                 'readAnimData=1',
+                 'startTime=12',
+                 'useCustomFrameRange=1']))
+
+        self.assertEqual(set([i.rstrip("0")
+                              for i in cmds.mayaUSDListJobContexts(eg="Scene Grinder").strip(";").split(";")]), 
+            set(['animation=1',
+                 'convertMaterialsTo=[MaterialX,UsdPreviewSurface]',
+                 'exportDisplayColor=1',
+                 'frameStride=1.5',
+                 'shadingMode=useRegistry',
+                 'startTime=12']))
 
     def testExportJobContextConflicts(self):
         """Testing that merging incompatible contexts generates errors"""


### PR DESCRIPTION
Add a job context dropdown called "Plug-in Configuration:" in both
import and export dialogs when in USD mode.

This dropdown will be populated with the available job contexts.

Selecting on the the job context will populate the UI with the settings
provided by the job context, and these settings will be made read-only.