### PR TITLE
MAYA-113723 If there are no reprs selected then don't call execute! It causes

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -840,7 +840,10 @@ void ProxyRenderDelegate::_Execute(const MHWRender::MFrameContext& frameContext)
         _taskController->SetCollection(*_defaultCollection);
     }
 
-    _engine.Execute(_renderIndex.get(), &_dummyTasks);
+    // if there are no repr's to update then don't even call sync.
+    if (reprSelector != HdReprSelector()) {
+        _engine.Execute(_renderIndex.get(), &_dummyTasks);
+    }
 }
 
 //! \brief  Main update entry from subscene override.


### PR DESCRIPTION
extra dirty bits to get held on some rprims, which causes an actual update later when some reprs ARE selected, and that hurts performance.