### PR TITLE
fix #1852 - Maya 2020 picked wrong MDGModifier.deleteNode

### DIFF
--- a/lib/mayaUsd/fileio/translators/translatorCurves.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorCurves.cpp
@@ -61,7 +61,7 @@ bool convertToBezier(MFnNurbsCurve& nurbsCurveFn, MObject& mayaNodeTransformObj,
     // Remove the nurbs and converter:
     MDGModifier dagm;
     dagm.deleteNode(convFn.object());
-#if MAYA_APP_VERSION >= 2020
+#if MAYA_API_VERSION >= 20200300
     dagm.deleteNode(nurbsCurveFn.object(), false);
 #else
     dagm.deleteNode(nurbsCurveFn.object());


### PR DESCRIPTION
This fix #1852.

The new deleteNode method (`MStatus MDGModifier::deleteNode( const MObject & node, bool includeParents )`) was added in 2020.3, so we better use API version to check that instead of App version.

Reference:
https://help.autodesk.com/view/MAYAUL/2020/ENU/?guid=__developer_Maya_SDK_MERGED_What_s_New_What_s_Changed_2020_3_Whats_New_in_API_html