### PR TITLE
Fixed exiting callback failing to deregister on UFE global

### DIFF
--- a/lib/mayaUsd/ufe/Global.cpp
+++ b/lib/mayaUsd/ufe/Global.cpp
@@ -66,7 +66,7 @@ void exitingCallback(void* /* unusedData */)
 
 int gRegistrationCount = 0;
 
-bool gExitingCbId = 0;
+MCallbackId gExitingCbId = 0;
 } // namespace
 
 namespace MAYAUSD_NS_DEF {


### PR DESCRIPTION
This PR fixes an issue introduced in PR https://github.com/Autodesk/maya-usd/pull/1789, causing the exit callback in `lib/mayaUsd/ufe/Global.cpp` to be run multiple times as it would not get deregistered correctly, producing the following `TF_VERIFY` failure in `lib/mayaUsd/ufe/UsdUIUfeObserver.cpp` throughout tests:

```console
Coding Error: in destroy at line 60 of /fast/the_lot/maya-usd/lib/mayaUsd/ufe/UsdUIUfeObserver.cpp -- Failed verification: ' ufeObserver '
```