### PR TITLE
MAYA-114630: Insert backup restore gl state render task around colorize-select-task

### DIFF
--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
@@ -33,10 +33,10 @@
 #include <pxr/imaging/hd/camera.h>
 #include <pxr/imaging/hd/rendererPluginRegistry.h>
 #include <pxr/imaging/hd/rprim.h>
+#include <pxr/imaging/hdx/colorizeSelectionTask.h>
 #include <pxr/imaging/hdx/pickTask.h>
 #include <pxr/imaging/hdx/renderTask.h>
 #include <pxr/imaging/hdx/tokens.h>
-#include <pxr/imaging/hdx/colorizeSelectionTask.h>
 #include <pxr/imaging/hgi/hgi.h>
 #include <pxr/imaging/hgi/tokens.h>
 #include <pxr/pxr.h>

--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
@@ -500,6 +500,7 @@ MStatus MtohRenderOverride::Render(const MHWRender::MDrawContext& drawContext)
                 TF_WARN("HdxProgressiveTask not found");
             }
         }
+
         // MAYA-114630
         // https://github.com/PixarAnimationStudios/USD/commit/fc63eaef29
         // removed backing, and restoring of GL_FRAMEBUFFER state.

--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.h
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.h
@@ -155,6 +155,7 @@ private:
 
     std::mutex                            _lastRenderTimeMutex;
     std::chrono::system_clock::time_point _lastRenderTime;
+    std::atomic<bool>                     _backupFrameBufferWorkaround = { false };
     std::atomic<bool>                     _playBlasting = { false };
     std::atomic<bool>                     _isConverged = { false };
     std::atomic<bool>                     _needsClear = { false };

--- a/lib/mayaUsd/render/mayaToHydra/renderOverrideUtils.h
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverrideUtils.h
@@ -91,6 +91,74 @@ private:
     MtohRenderOverride* _override;
 };
 
+struct HdMayaGLBackup
+{
+    GLint RestoreFramebuffer = 0;
+    GLint RestoreDrawFramebuffer = 0;
+    GLint RestoreReadFramebuffer = 0;
+};
+
+class HdMayaBackupGLStateTask : public HdTask
+{
+    using base = HdTask;
+    static const SdfPath& _Id()
+    {
+        static SdfPath path = SdfPath("HdMayaBackupGLStateTask");
+        return path;
+    }
+
+public:
+    HdMayaGLBackup& _backup;
+
+    HdMayaBackupGLStateTask(HdMayaGLBackup& backup)
+        : base(_Id())
+        , _backup(backup)
+    {
+    }
+    /// Prepare the render pass resources
+    virtual void Prepare(HdTaskContext* ctx, HdRenderIndex* renderIndex) override { }
+
+    /// Execute the task
+    /// Execute the task
+    virtual void Execute(HdTaskContext* ctx) override
+    {
+        glGetIntegerv(GL_FRAMEBUFFER_BINDING, &_backup.RestoreFramebuffer);
+        glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &_backup.RestoreDrawFramebuffer);
+        glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &_backup.RestoreReadFramebuffer);
+    }
+    virtual void Sync(HdSceneDelegate* del, HdTaskContext* ctx, HdDirtyBits* dirtyBits) { }
+};
+
+class HdMayaRestoreGLStateTask : public HdTask
+{
+    using base = HdTask;
+    static const SdfPath& _Id()
+    {
+        static SdfPath path = SdfPath("HdMayaRestoreGLStateTask");
+        return path;
+    }
+
+public:
+    HdMayaGLBackup& _backup;
+
+    HdMayaRestoreGLStateTask(HdMayaGLBackup& backup)
+        : base(_Id())
+        , _backup(backup)
+    {
+    }
+    /// Prepare the render pass resources
+    virtual void Prepare(HdTaskContext* ctx, HdRenderIndex* renderIndex) override { }
+
+    /// Execute the task
+    virtual void Execute(HdTaskContext* ctx) override
+    {
+        glBindFramebuffer(GL_FRAMEBUFFER, _backup.RestoreFramebuffer);
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, _backup.RestoreDrawFramebuffer);
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, _backup.RestoreReadFramebuffer);
+    }
+    virtual void Sync(HdSceneDelegate* del, HdTaskContext* ctx, HdDirtyBits* dirtyBits) { }
+};
+
 class HdMayaSetRenderGLState
 {
 public:

--- a/lib/mayaUsd/render/mayaToHydra/renderOverrideUtils.h
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverrideUtils.h
@@ -119,14 +119,13 @@ public:
     virtual void Prepare(HdTaskContext* ctx, HdRenderIndex* renderIndex) override { }
 
     /// Execute the task
-    /// Execute the task
     virtual void Execute(HdTaskContext* ctx) override
     {
         glGetIntegerv(GL_FRAMEBUFFER_BINDING, &_backup.RestoreFramebuffer);
         glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &_backup.RestoreDrawFramebuffer);
         glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &_backup.RestoreReadFramebuffer);
     }
-    virtual void Sync(HdSceneDelegate* del, HdTaskContext* ctx, HdDirtyBits* dirtyBits) { }
+    virtual void Sync(HdSceneDelegate* del, HdTaskContext* ctx, HdDirtyBits* dirtyBits) override { }
 };
 
 class HdMayaRestoreGLStateTask : public HdTask
@@ -156,7 +155,7 @@ public:
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, _backup.RestoreDrawFramebuffer);
         glBindFramebuffer(GL_READ_FRAMEBUFFER, _backup.RestoreReadFramebuffer);
     }
-    virtual void Sync(HdSceneDelegate* del, HdTaskContext* ctx, HdDirtyBits* dirtyBits) { }
+    virtual void Sync(HdSceneDelegate* del, HdTaskContext* ctx, HdDirtyBits* dirtyBits) override { }
 };
 
 class HdMayaSetRenderGLState


### PR DESCRIPTION
* https://github.com/PixarAnimationStudios/USD/commit/fc63eaef29 removed backing, and restoring of GL_FRAMEBUFFER state.
* At the same time HdxColorizeSelectionTask modifies the frame buffer state
* HdxColorizeSelectionTask is used by the Arnold hydra plugin, unlike maya-usd default hydra plugin.
* Manually backup and restore the state of the frame buffer for now.