### PR TITLE
[base] fix for proxyShapes in vp2 to display shaders bound to "glslfx:surface" material output

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
@@ -829,17 +829,37 @@ void HdVP2RenderDelegate::DestroyBprim(HdBprim* bPrim) { delete bPrim; }
 */
 TfToken HdVP2RenderDelegate::GetMaterialBindingPurpose() const { return HdTokens->preview; }
 
-#ifdef WANT_MATERIALX_BUILD
 TfTokenVector HdVP2RenderDelegate::GetShaderSourceTypes() const
 {
+#ifdef WANT_MATERIALX_BUILD
     return { HdVP2Tokens->mtlx, HdVP2Tokens->glslfx };
+#else
+    return { HdVP2Tokens->glslfx };
+#endif
 }
+
+#if PXR_VERSION < 2105
+
+TfToken HdVP2RenderDelegate::GetMaterialNetworkSelector() const
+{
+#ifdef WANT_MATERIALX_BUILD
+    return HdVP2Tokens->mtlx;
+#else
+    return HdVP2Tokens->glslfx;
+#endif
+}
+
+#else // PXR_VERSION < 2105
 
 TfTokenVector HdVP2RenderDelegate::GetMaterialRenderContexts() const
 {
+#ifdef WANT_MATERIALX_BUILD
     return { HdVP2Tokens->mtlx, HdVP2Tokens->glslfx };
-}
+#else
+    return { HdVP2Tokens->glslfx };
 #endif
+}
+#endif // PXR_VERSION < 2105
 
 /*! \brief  Returns a node name made as a child of delegate's id.
  */

--- a/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.h
@@ -121,9 +121,11 @@ public:
 
     void CommitResources(HdChangeTracker* tracker) override;
 
-    TfToken GetMaterialBindingPurpose() const override;
-#ifdef WANT_MATERIALX_BUILD
+    TfToken       GetMaterialBindingPurpose() const override;
     TfTokenVector GetShaderSourceTypes() const override;
+#if PXR_VERSION < 2105
+    TfToken GetMaterialNetworkSelector() const override;
+#else
     TfTokenVector GetMaterialRenderContexts() const override;
 #endif
 


### PR DESCRIPTION
Small change to make sure materials connected to "glslfx:surface" will show up as well as the unqualified "surface" port in viewport 2.0.

This fix makes sure the glslfx ports are also displayed when maya_usd is not built with "materialX" support.

(This matches the Storm implementation used by Usdview)