### PR TITLE
Made all dirty layers and anonymous sublayers serialisable

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -837,6 +837,8 @@ void ProxyShape::serialize(UsdStageRefPtr stage, LayerManager* layerManager)
 
             // Then add in the current edit target
             trackEditTargetLayer(layerManager);
+            // Add all dirty layers
+            trackAllDirtyLayers(layerManager);
         } else {
             MGlobal::displayError(
                 "ProxyShape::serialize was passed a nullptr for the layerManager");

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/test_data/layer1.usda
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/test_data/layer1.usda
@@ -1,0 +1,12 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+)
+
+def "root" ()
+{
+    def "simple" (
+    )
+    {
+    }
+}

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/test_data/layer2.usda
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/test_data/layer2.usda
@@ -1,0 +1,12 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+)
+
+def "root" ()
+{
+    def "other" (
+    )
+    {
+    }
+}

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/test_data/multiple_layers.usda
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/test_data/multiple_layers.usda
@@ -1,0 +1,12 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+    subLayers = [
+        @./layer1.usda@,
+        @./layer2.usda@,
+    ]
+)
+
+def "root"
+{
+}


### PR DESCRIPTION
This PR incorporates two changes:

The proxy shape has been updated to make all dirty layers serialisable regardless of whether they have ever been set as an edit target or not when saving Maya scenes. As a result anonymous sublayer content can be serialised.

Loading a scene serialised with anonymous sublayers results in stale references to previous sublayers' IDs. Although they exist in the registry on load, their IDs no longer match those referenced. Support has been added for the serialisation and deserialisation of anonymous sublayers to Maya files by the layer manager.