### PR TITLE
MAYA-114507 - Ufe: Investigate testValue.cpp failure on OSX

### DIFF
--- a/lib/mayaUsd/ufe/UsdAttribute.cpp
+++ b/lib/mayaUsd/ufe/UsdAttribute.cpp
@@ -45,8 +45,7 @@ static constexpr char kErrorMsgFailedConvertToString[]
 static constexpr char kErrorMsgInvalidType[]
     = "USD attribute does not match created attribute class type";
 #if (UFE_PREVIEW_VERSION_NUM >= 3013)
-static constexpr char kErrorMsgInvalidValueType[]
-    = "Unexpected Ufe::Value type";
+static constexpr char kErrorMsgInvalidValueType[] = "Unexpected Ufe::Value type";
 #endif
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
#### MAYA-114507 - Ufe: Investigate testValue.cpp failure on OSX
* Adapt to changes made to Ufe::Value class.