### PR TITLE
MAYA-113820: [Github 1543] Unloaded prims should appear in the outliner

### DIFF
--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
@@ -43,9 +43,15 @@
 PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace {
+
+    // We want to display the unloaded prims, so removed UsdPrimIsLoaded from
+    // the default UsdPrimDefaultPredicate.
+    const Usd_PrimFlagsConjunction MayaUsdPrimDefaultPredicate = UsdPrimIsActive
+        && UsdPrimIsDefined && !UsdPrimIsAbstract;
+
 UsdPrimSiblingRange getUSDFilteredChildren(
     const UsdPrim&               prim,
-    const Usd_PrimFlagsPredicate pred = UsdPrimDefaultPredicate)
+    const Usd_PrimFlagsPredicate pred = MayaUsdPrimDefaultPredicate)
 {
     // Since the equivalent of GetChildren is
     // GetFilteredChildren( UsdPrimDefaultPredicate ),
@@ -159,7 +165,7 @@ Ufe::SceneItemList ProxyShapeHierarchy::filteredChildren(const ChildFilter& chil
         // See uniqueChildName() for explanation of USD filter predicate.
         Usd_PrimFlagsPredicate flags = childFilter.front().value
             ? UsdPrimIsDefined && !UsdPrimIsAbstract
-            : UsdPrimDefaultPredicate;
+            : MayaUsdPrimDefaultPredicate;
         return createUFEChildList(getUSDFilteredChildren(rootPrim, flags));
     }
 

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
@@ -44,10 +44,10 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace {
 
-    // We want to display the unloaded prims, so removed UsdPrimIsLoaded from
-    // the default UsdPrimDefaultPredicate.
-    const Usd_PrimFlagsConjunction MayaUsdPrimDefaultPredicate = UsdPrimIsActive
-        && UsdPrimIsDefined && !UsdPrimIsAbstract;
+// We want to display the unloaded prims, so removed UsdPrimIsLoaded from
+// the default UsdPrimDefaultPredicate.
+const Usd_PrimFlagsConjunction MayaUsdPrimDefaultPredicate
+    = UsdPrimIsActive && UsdPrimIsDefined && !UsdPrimIsAbstract;
 
 UsdPrimSiblingRange getUSDFilteredChildren(
     const UsdPrim&               prim,

--- a/lib/mayaUsd/ufe/UsdHierarchy.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchy.cpp
@@ -55,10 +55,10 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace {
 
-    // We want to display the unloaded prims, so removed UsdPrimIsLoaded from
-    // the default UsdPrimDefaultPredicate.
-    const Usd_PrimFlagsConjunction MayaUsdPrimDefaultPredicate = UsdPrimIsActive
-        && UsdPrimIsDefined && !UsdPrimIsAbstract;
+// We want to display the unloaded prims, so removed UsdPrimIsLoaded from
+// the default UsdPrimDefaultPredicate.
+const Usd_PrimFlagsConjunction MayaUsdPrimDefaultPredicate
+    = UsdPrimIsActive && UsdPrimIsDefined && !UsdPrimIsAbstract;
 
 UsdPrimSiblingRange getUSDFilteredChildren(
     const MayaUsd::ufe::UsdSceneItem::Ptr usdSceneItem,

--- a/lib/mayaUsd/ufe/UsdHierarchy.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchy.cpp
@@ -54,9 +54,15 @@
 PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace {
+
+    // We want to display the unloaded prims, so removed UsdPrimIsLoaded from
+    // the default UsdPrimDefaultPredicate.
+    const Usd_PrimFlagsConjunction MayaUsdPrimDefaultPredicate = UsdPrimIsActive
+        && UsdPrimIsDefined && !UsdPrimIsAbstract;
+
 UsdPrimSiblingRange getUSDFilteredChildren(
     const MayaUsd::ufe::UsdSceneItem::Ptr usdSceneItem,
-    const Usd_PrimFlagsPredicate          pred = UsdPrimDefaultPredicate)
+    const Usd_PrimFlagsPredicate          pred = MayaUsdPrimDefaultPredicate)
 {
     // If the scene item represents a point instance of a PointInstancer prim,
     // we consider it child-less. The namespace children of a PointInstancer
@@ -125,7 +131,7 @@ Ufe::SceneItemList UsdHierarchy::filteredChildren(const ChildFilter& childFilter
         // See uniqueChildName() for explanation of USD filter predicate.
         Usd_PrimFlagsPredicate flags = childFilter.front().value
             ? UsdPrimIsDefined && !UsdPrimIsAbstract
-            : UsdPrimDefaultPredicate;
+            : MayaUsdPrimDefaultPredicate;
         return createUFEChildList(getUSDFilteredChildren(fItem, flags));
     }
 


### PR DESCRIPTION
#### MAYA-113820: [Github 1543] Unloaded prims should appear in the outliner
* In default prim predicate remove IsLoaded (so we will always display both loaded and unloaded prims).