### PR TITLE
t_bailp/MAYA-114109/undo redo push pull simplified

### DIFF
--- a/lib/mayaUsd/commands/baseImportCommand.cpp
+++ b/lib/mayaUsd/commands/baseImportCommand.cpp
@@ -18,6 +18,7 @@
 
 #include <mayaUsd/fileio/jobs/jobArgs.h>
 #include <mayaUsd/fileio/jobs/readJob.h>
+#include <mayaUsd/undo/OpUndoInfoMuting.h>
 #include <mayaUsd/utils/util.h>
 
 #include <pxr/pxr.h>
@@ -125,6 +126,10 @@ std::unique_ptr<UsdMaya_ReadJob> MayaUSDImportCommand::initializeReadJob(
 /* virtual */
 MStatus MayaUSDImportCommand::doIt(const MArgList& args)
 {
+    // The import process has its own undo/redo recording.
+    // See: UsdMaya_ReadJob::Undo() and Redo().
+    OpUndoInfoMuting undoInfoMuting;
+
     MStatus status;
 
     MArgDatabase argData(syntax(), args, &status);

--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -540,7 +540,11 @@ bool UsdMaya_ReadJob::_DoImport(UsdPrimRange& rootRange, const UsdPrim& usdRootP
                         prototypeNode.removeChildAt(prototypeNode.childCount() - 1);
                     }
                 }
+#if MAYA_APP_VERSION >= 2020
                 deletePrototypeMod.deleteNode(prototypeObject, false);
+#else
+                deletePrototypeMod.deleteNode(prototypeObject);
+#endif
             }
         }
         deletePrototypeMod.doIt();
@@ -608,7 +612,11 @@ bool UsdMaya_ReadJob::Undo()
                         }
                     }
                 }
+#if MAYA_APP_VERSION >= 2020
                 mDagModifierUndo.deleteNode(it.second, false);
+#else
+                mDagModifierUndo.deleteNode(it.second);
+#endif
             }
         }
     }

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -25,6 +25,10 @@
 #include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/ufe/Global.h>
 #include <mayaUsd/ufe/Utils.h>
+#include <mayaUsd/undo/OpUndoInfoMuting.h>
+#include <mayaUsd/undo/OpUndoItems.h>
+#include <mayaUsd/undo/UsdUndoBlock.h>
+#include <mayaUsd/undo/UsdUndoManager.h>
 #include <mayaUsd/utils/traverseLayer.h>
 
 #include <pxr/base/tf/diagnostic.h>
@@ -51,6 +55,7 @@
 #include <tuple>
 
 using UpdaterFactoryFn = UsdMayaPrimUpdaterRegistry::UpdaterFactoryFn;
+using namespace MAYAUSD_NS_DEF;
 
 // Allow for use of MObjectHandle with std::unordered_map.
 namespace std {
@@ -76,7 +81,7 @@ namespace {
 const std::string kPullParentPathKey("Maya:Pull:ParentPath");
 
 // Set name that will be used to hold all pulled objects
-const std::string kPullSetName("pullStateSet");
+const MString kPullSetName("pullStateSet");
 
 // Metadata key used to store pull information on a prim
 const TfToken kPullPrimMetadataKey("Maya:Pull:DagPath");
@@ -87,19 +92,21 @@ const MString kPullDGMetadataKey("Pull_UfePath");
 // Name of Dag node under which all pulled sub-hierarchies are rooted.
 const MString kPullRootName("__mayaUsd__");
 
-//! Lock or unlock hierarchy starting at given root.
-void lockNodes(const MDagPath& root, bool state)
+MObject findPullRoot()
 {
-    MItDag dagIt;
-    dagIt.reset(root);
-    for (; !dagIt.isDone(); dagIt.next()) {
-        MFnDependencyNode node(dagIt.currentItem());
-        if (node.isFromReferencedFile()) {
-            dagIt.prune();
-            continue;
+    // Try to find one in the scene.
+    auto       worldObj = MItDag().root();
+    MFnDagNode world(worldObj);
+    auto       nbWorldChildren = world.childCount();
+    for (unsigned int i = 0; i < nbWorldChildren; ++i) {
+        auto              childObj = world.child(i);
+        MFnDependencyNode child(childObj);
+        if (child.name() == kPullRootName) {
+            return childObj;
         }
-        node.setLocked(state);
     }
+
+    return MObject();
 }
 
 Ufe::Path usdToMaya(const Ufe::Path& usdPath)
@@ -130,35 +137,23 @@ SdfPath ufeToSdfPath(const Ufe::Path& usdPath)
 
 //------------------------------------------------------------------------------
 //
-void select(const MDagPath& dagPath)
-{
-    MSelectionList selList;
-    selList.add(dagPath);
-    MGlobal::setActiveSelectionList(selList, MGlobal::kReplaceList);
-}
-
-//------------------------------------------------------------------------------
-//
 // The UFE path and the prim refer to the same object: the prim is passed in as
 // an optimization to avoid an additional call to ufePathToPrim().
-bool writePullInformation(
-    const Ufe::Path&       ufePulledPath,
-    const PXR_NS::UsdPrim& pulledPrim,
-    const MDagPath&        path)
+bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& path)
 {
-    // Add to a set
+    auto pulledPrim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
+    if (!pulledPrim) {
+        return false;
+    }
+
+    // Add to a set, the set should already been created.
     MObject pullSetObj;
     auto    status = UsdMayaUtil::GetMObjectByName(kPullSetName, pullSetObj);
-    if (status != MStatus::kSuccess) {
-        MFnSet         fnSet;
-        MSelectionList selList;
-        MObject        pullSetObj = fnSet.create(selList, MFnSet::kNone, &status);
-        fnSet.setName(kPullSetName.c_str());
-        fnSet.addMember(path);
-    } else {
-        MFnSet fnPullSet(pullSetObj);
-        fnPullSet.addMember(path);
-    }
+    if (status != MStatus::kSuccess)
+        return false;
+
+    MFnSet fnPullSet(pullSetObj);
+    fnPullSet.addMember(path);
 
     // Store metadata on the prim.
     VtValue value(path.fullPathName().asChar());
@@ -274,6 +269,12 @@ PullImportPaths pullImport(
         return PullImportPaths(addedDagPaths, pulledUfePaths);
     }
 
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+
+    // Record all USD modifications in an undo block and item.
+    UsdUndoBlock undoBlock(
+        &UsdUndoableItemUndoItem::create("Pull import USD data modifications", undoInfo));
+
     const VtDictionary& userArgs = context.GetUserArgs();
 
     UsdMayaJobImportArgs jobArgs = UsdMayaJobImportArgs::CreateFromDictionary(
@@ -284,26 +285,46 @@ PullImportPaths pullImport(
     MayaUsd::ImportData importData(mFileName);
     importData.setRootPrimPath(pulledPrim.GetPath().GetText());
 
-    UsdMaya_ReadJob readJob(importData, jobArgs);
-    auto            found = userArgs.find("Maya:Pull:ParentPath");
-    if (found != userArgs.end()) {
-        const std::string& dagPathStr = found->second.Get<std::string>();
-        auto               pullParent = UsdMayaUtil::nameToDagPath(dagPathStr);
-        if (pullParent.isValid()) {
-            readJob.SetMayaRootDagPath(pullParent);
+    auto readJob = std::make_shared<UsdMaya_ReadJob>(importData, jobArgs);
+
+    MDagPath pullParentPath;
+    {
+        auto found = userArgs.find(kPullParentPathKey);
+        if (found != userArgs.end()) {
+            const std::string& dagPathStr = found->second.Get<std::string>();
+            pullParentPath = UsdMayaUtil::nameToDagPath(dagPathStr);
+            if (pullParentPath.isValid()) {
+                readJob->SetMayaRootDagPath(pullParentPath);
+            }
         }
     }
 
     // Execute the command, which can succeed but import nothing.
-    bool success = readJob.Read(&addedDagPaths);
+    bool success = readJob->Read(&addedDagPaths);
     if (!success || addedDagPaths.size() == 0) {
         return PullImportPaths({}, {});
     }
 
+    // Note: UsdMaya_ReadJob has explicit Read(), Undo() and Redo() functions,
+    //       and Read() has already been called, so create the function-undo item
+    //       but do not execute it.
+    FunctionUndoItem::create(
+        "Edit as Maya USD import",
+        [readJob]() { return readJob->Redo(); },
+        [readJob]() { return readJob->Undo(); },
+        undoInfo);
+
+    MDagPath addedDagPath = addedDagPaths[0];
+
     const bool isCopy = context.GetArgs()._copyOperation;
     if (!isCopy) {
         // Quick workaround to reuse some POC code - to rewrite later
-        auto ufeChild = MayaUsd::ufe::dagPathToUfe(addedDagPaths[0]);
+
+        // The "child" is the node that will receive the computed parent
+        // transformation, in its offsetParentMatrix attribute.  We are using
+        // the pull parent for this purpose, so pop the path of the ufeChild to
+        // get to its pull parent.
+        auto ufeChild = MayaUsd::ufe::dagPathToUfe(addedDagPath).pop();
 
         // Since we haven't pulled yet, obtaining the parent is simple, and
         // doesn't require going through the Hierarchy interface, which can do
@@ -311,26 +332,57 @@ PullImportPaths pullImport(
         auto ufeParent = ufePulledPath.pop();
 
         MString pyCommand;
-        // The "child" is the node that will receive the computed parent
-        // transformation, in its offsetParentMatrix attribute.  We are using
-        // the pull parent for this purpose, so pop the path of the ufeChild to
-        // get to its pull parent.
         pyCommand.format(
             "from mayaUsd.lib import proxyAccessor as pa\n"
             "import maya.cmds as cmds\n"
             "cmds.select('^1s', '^2s')\n"
             "pa.parent()\n"
             "cmds.select(clear=True)\n",
-            Ufe::PathString::string(ufeChild.pop()).c_str(),
+            Ufe::PathString::string(ufeChild).c_str(),
             Ufe::PathString::string(ufeParent).c_str());
-        MGlobal::executePythonCommand(pyCommand);
+
+        MString pyUndoCommand;
+        pyUndoCommand.format(
+            "from mayaUsd.lib import proxyAccessor as pa\n"
+            "import maya.cmds as cmds\n"
+            "cmds.select('^1s', '^2s')\n"
+            "pa.unparent()\n"
+            "cmds.select(clear=True)\n",
+            Ufe::PathString::string(ufeChild).c_str(),
+            Ufe::PathString::string(ufeParent).c_str());
+
+        PythonUndoItem::execute(
+            "Pull import proxy accessor parenting", pyCommand, pyUndoCommand, undoInfo);
         // -- end --
 
-        // Finalize the pull.
-        writePullInformation(ufePulledPath, pulledPrim, addedDagPaths[0]);
-        addExcludeFromRendering(ufePulledPath);
+        // Create the pull set if it does not exists.
+        MObject pullSetObj;
+        MStatus status = UsdMayaUtil::GetMObjectByName(kPullSetName, pullSetObj);
+        if (status != MStatus::kSuccess)
+            CreateSetUndoItem::create("Pull import pull set creation", kPullSetName, undoInfo);
 
-        select(addedDagPaths[0]);
+        // Finalize the pull.
+        FunctionUndoItem::execute(
+            "Pull import pull info writing",
+            [ufePulledPath, addedDagPath]() {
+                return writePullInformation(ufePulledPath, addedDagPath);
+            },
+            [ufePulledPath]() {
+                removePullInformation(ufePulledPath);
+                return true;
+            },
+            undoInfo);
+
+        FunctionUndoItem::execute(
+            "Pull import rendering exclusion",
+            [ufePulledPath]() { return addExcludeFromRendering(ufePulledPath); },
+            [ufePulledPath]() {
+                removeExcludeFromRendering(ufePulledPath);
+                return true;
+            },
+            undoInfo);
+
+        SelectionUndoItem::select("Pull import select DAG node", addedDagPath, undoInfo);
     }
 
     // Invert the new node registry, for MObject to Ufe::Path lookup.
@@ -338,7 +390,7 @@ PullImportPaths pullImport(
     ObjToUfePath objToUfePath;
     const auto&  ps = ufePulledPath.getSegments()[0];
     const auto   rtid = MayaUsd::ufe::getUsdRunTimeId();
-    for (const auto& v : readJob.GetNewNodeRegistry()) {
+    for (const auto& v : readJob->GetNewNodeRegistry()) {
         Ufe::Path::Segments s { ps, Ufe::PathSegment(v.first, rtid, '/') };
         Ufe::Path           p(std::move(s));
         objToUfePath.insert(ObjToUfePath::value_type(MObjectHandle(v.second), p));
@@ -360,6 +412,12 @@ PullImportPaths pullImport(
 // Perform the customization step of the pull (second step).
 bool pullCustomize(const PullImportPaths& importedPaths, const UsdMayaPrimUpdaterContext& context)
 {
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+
+    // Record all USD modifications in an undo block and item.
+    UsdUndoBlock undoBlock(
+        &UsdUndoableItemUndoItem::create("Pull customize USD data modifications", undoInfo));
+
     TF_AXIOM(importedPaths.first.size() == importedPaths.second.size());
     auto dagPathIt = importedPaths.first.begin();
     auto ufePathIt = importedPaths.second.begin();
@@ -455,8 +513,31 @@ PushCustomizeSrc pushExport(
         // it here, the push customize step won't have access to it --- but
         // maybe it doesn't need to, because the UsdPathToDagPathMap is
         // available in the context.  PPT, 14-Oct-2021.
-        removePullInformation(ufePulledPath);
-        removeExcludeFromRendering(ufePulledPath);
+
+        auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+
+        auto mayaPath = usdToMaya(ufePulledPath);
+        auto mayaDagPath = MayaUsd::ufe::ufeToDagPath(mayaPath);
+
+        FunctionUndoItem::execute(
+            "Merge to Maya pull info removal",
+            [ufePulledPath]() {
+                removePullInformation(ufePulledPath);
+                return true;
+            },
+            [ufePulledPath, mayaDagPath]() {
+                return writePullInformation(ufePulledPath, mayaDagPath);
+            },
+            undoInfo);
+
+        FunctionUndoItem::execute(
+            "Merge to Maya rendering inclusion",
+            [ufePulledPath]() {
+                removeExcludeFromRendering(ufePulledPath);
+                return true;
+            },
+            [ufePulledPath]() { return addExcludeFromRendering(ufePulledPath); },
+            undoInfo);
     }
 
     return pushCustomizeSrc;
@@ -657,14 +738,6 @@ TF_INSTANTIATE_SINGLETON(PrimUpdaterManager);
 
 PrimUpdaterManager::PrimUpdaterManager()
 {
-    MStatus res;
-    _cbIds.append(
-        MSceneMessage::addCallback(MSceneMessage::kBeforeNew, beforeNewOrOpenCallback, this, &res));
-    CHECK_MSTATUS(res);
-    _cbIds.append(MSceneMessage::addCallback(
-        MSceneMessage::kBeforeOpen, beforeNewOrOpenCallback, this, &res));
-    CHECK_MSTATUS(res);
-
     TfSingleton<PrimUpdaterManager>::SetInstanceConstructed(*this);
     TfRegistryManager::GetInstance().SubscribeTo<PrimUpdaterManager>();
 
@@ -672,11 +745,7 @@ PrimUpdaterManager::PrimUpdaterManager()
     TfNotice::Register(me, &PrimUpdaterManager::onProxyContentChanged);
 }
 
-PrimUpdaterManager::~PrimUpdaterManager()
-{
-    MMessage::removeCallbacks(_cbIds);
-    _cbIds.clear();
-}
+PrimUpdaterManager::~PrimUpdaterManager() { }
 
 bool PrimUpdaterManager::mergeToUsd(const MFnDependencyNode& depNodeFn, const Ufe::Path& pulledPath)
 {
@@ -692,9 +761,12 @@ bool PrimUpdaterManager::mergeToUsd(const MFnDependencyNode& depNodeFn, const Uf
 
     PushPullScope scopeIt(_inPushPull);
 
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+
     VtDictionary exportArgs = UsdMayaJobExportArgs::GetDefaultDictionary();
     auto         updaterArgs = UsdMayaPrimUpdaterArgs::createFromDictionary(exportArgs);
     auto         mayaPath = usdToMaya(pulledPath);
+    auto         mayaDagPath = MayaUsd::ufe::ufeToDagPath(mayaPath);
     MDagPath     pullParentPath;
     const bool   isCopy = updaterArgs._copyOperation;
     if (!isCopy) {
@@ -703,8 +775,12 @@ bool PrimUpdaterManager::mergeToUsd(const MFnDependencyNode& depNodeFn, const Uf
         if (!TF_VERIFY(pullParentPath.isValid())) {
             return false;
         }
-        lockNodes(pullParentPath, false);
+        LockNodesUndoItem::lock("Merge to USD node unlocking", pullParentPath, false, undoInfo);
     }
+
+    // Reset the selection, otherwise it will keep a reference to a deleted node
+    // and crash later on.
+    SelectionUndoItem::select("Merge to USD selection reset", MSelectionList(), undoInfo);
 
     UsdStageRefPtr            proxyStage = proxyShape->usdPrim().GetStage();
     UsdMayaPrimUpdaterContext context(proxyShape->getTime(), proxyStage, exportArgs);
@@ -735,6 +811,19 @@ bool PrimUpdaterManager::mergeToUsd(const MFnDependencyNode& depNodeFn, const Uf
         return false;
     }
 
+    // Discard all pulled Maya nodes.
+    std::vector<MDagPath> toApplyOn = UsdMayaUtil::getDescendantsStartingWithChildren(mayaDagPath);
+    for (const MDagPath& curDagPath : toApplyOn) {
+        MStatus status = NodeDeletionUndoItem::deleteNode(
+            "Merge to USD Maya scene cleanup", curDagPath.fullPathName(), curDagPath.node(), undoInfo);
+        if (status != MS::kSuccess) {
+            TF_WARN(
+                "Merge to USD Maya scene cleanup: cannot delete node \"%s\".",
+                curDagPath.fullPathName().asChar());
+            return false;
+        }
+    }
+
     if (!isCopy) {
         if (!TF_VERIFY(removePullParent(pullParentPath))) {
             return false;
@@ -763,6 +852,8 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path)
     }
 
     PushPullScope scopeIt(_inPushPull);
+
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
 
     VtDictionary importArgs = UsdMayaJobImportArgs::GetDefaultDictionary();
     auto         updaterArgs = UsdMayaPrimUpdaterArgs::createFromDictionary(importArgs);
@@ -798,7 +889,7 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path)
 
     if (!updaterArgs._copyOperation) {
         // Lock pulled nodes starting at the pull parent.
-        lockNodes(pullParentPath, true);
+        LockNodesUndoItem::lock("Edit as Maya node locking", pullParentPath, true, undoInfo);
     }
 
     // We must recreate the UFE item because it has changed data models (USD -> Maya).
@@ -834,6 +925,12 @@ bool PrimUpdaterManager::discardEdits(const Ufe::Path& pulledPath)
 
     PushPullScope scopeIt(_inPushPull);
 
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+
+    // Record all USD modifications in an undo block and item.
+    UsdUndoBlock undoBlock(
+        &UsdUndoableItemUndoItem::create("Discard edits USD data modifications", undoInfo));
+
     auto mayaPath = usdToMaya(pulledPath);
     auto mayaDagPath = MayaUsd::ufe::ufeToDagPath(mayaPath);
 
@@ -853,19 +950,37 @@ bool PrimUpdaterManager::discardEdits(const Ufe::Path& pulledPath)
     if (!TF_VERIFY(pullParent.isValid())) {
         return false;
     }
-    lockNodes(pullParent, false);
+    LockNodesUndoItem::lock("Discard edits node unlocking", pullParent, false, undoInfo);
 
-    MItDag dagIt;
-    for (dagIt.reset(mayaDagPath); !dagIt.isDone(); dagIt.next()) {
-        MDagPath curDagPath;
-        dagIt.getPath(curDagPath);
+    // Reset the selection, otherwise it will keep a reference to a deleted node
+    // and crash later on.
+    SelectionUndoItem::select("Discard edits selection reset", MSelectionList(), undoInfo);
+
+    // Discard all pulled Maya nodes.
+    std::vector<MDagPath> toApplyOn = UsdMayaUtil::getDescendantsStartingWithChildren(mayaDagPath);
+    for (const MDagPath& curDagPath : toApplyOn) {
         MFnDependencyNode   depNodeFn(curDagPath.node());
         FallbackPrimUpdater fallback(depNodeFn, Ufe::Path());
         fallback.discardEdits(context);
     }
 
-    removePullInformation(pulledPath);
-    removeExcludeFromRendering(pulledPath);
+    FunctionUndoItem::execute(
+        "Discard edits pull info removal",
+        [pulledPath]() {
+            removePullInformation(pulledPath);
+            return true;
+        },
+        [pulledPath, mayaDagPath]() { return writePullInformation(pulledPath, mayaDagPath); },
+        undoInfo);
+
+    FunctionUndoItem::execute(
+        "Discard edits rendering inclusion",
+        [pulledPath]() {
+            removeExcludeFromRendering(pulledPath);
+            return true;
+        },
+        [pulledPath]() { return addExcludeFromRendering(pulledPath); },
+        undoInfo);
 
     if (!TF_VERIFY(removePullParent(pullParent))) {
         return false;
@@ -885,6 +1000,8 @@ bool PrimUpdaterManager::duplicate(const Ufe::Path& srcPath, const Ufe::Path& ds
     MayaUsdProxyShapeBase* dstProxyShape = MayaUsd::ufe::getProxyShape(dstPath);
 
     PushPullScope scopeIt(_inPushPull);
+
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
 
     // Copy from USD to DG
     if (srcProxyShape && dstProxyShape == nullptr) {
@@ -912,6 +1029,10 @@ bool PrimUpdaterManager::duplicate(const Ufe::Path& srcPath, const Ufe::Path& ds
             return false;
         }
         VtDictionary userArgs = UsdMayaJobExportArgs::GetDefaultDictionary();
+
+        // Record all USD modifications in an undo block and item.
+        MAYAUSD_NS::UsdUndoBlock undoBlock(
+            &UsdUndoableItemUndoItem::create("Duplicate USD data modifications", undoInfo));
 
         // We will only do copy between two data models, setting this in arguments
         // to configure the updater
@@ -983,6 +1104,9 @@ void PrimUpdaterManager::onProxyContentChanged(
                     = MayaUsd::ufe::usdPathToUfePathSegment(prim.GetPath());
                 const Ufe::Path path = proxyNotice.GetProxyShape().ufePath() + pathSegment;
 
+                // TODO UNDO: is it okay to throw away the undo info in the change notification?
+                // What could we do with it anyway?
+                OpUndoInfoMuting muting;
                 editAsMaya(path);
             }
         }
@@ -994,56 +1118,48 @@ PrimUpdaterManager& PrimUpdaterManager::getInstance()
     return TfSingleton<PrimUpdaterManager>::GetInstance();
 }
 
-bool PrimUpdaterManager::findOrCreatePullRoot()
+MObject PrimUpdaterManager::findOrCreatePullRoot()
 {
-    // If we already found the pull root, good to go.
-    if (!_pullRoot.isNull()) {
-        return true;
-    }
+    MObject pullRoot = findPullRoot();
+    if (!pullRoot.isNull())
+        return pullRoot;
 
-    // No saved pull root.  Try to find one in the scene, and save its MObject.
-    auto       worldObj = MItDag().root();
-    MFnDagNode world(worldObj);
-    auto       nbWorldChildren = world.childCount();
-    for (unsigned int i = 0; i < nbWorldChildren; ++i) {
-        auto              childObj = world.child(i);
-        MFnDependencyNode child(childObj);
-        if (child.name() == kPullRootName) {
-            _pullRoot = childObj;
-            return true;
-        }
-    }
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
 
     // No pull root in the scene, so create one.
-    MDagModifier dagMod;
-    MStatus      status;
-    MObject      pullRootObj = dagMod.createNode(MString("transform"), MObject::kNullObj, &status);
+    MDagModifier& dagMod = MDagModifierUndoItem::create("Create pull root", undoInfo);
+    MStatus       status;
+    MObject       pullRootObj = dagMod.createNode(MString("transform"), MObject::kNullObj, &status);
     if (status != MStatus::kSuccess) {
-        return false;
+        return MObject();
     }
     status = dagMod.renameNode(pullRootObj, kPullRootName);
     if (status != MStatus::kSuccess) {
-        return false;
+        return MObject();
     }
 
     if (dagMod.doIt() != MStatus::kSuccess) {
-        return false;
+        return MObject();
     }
 
     // Hide all objects under the pull root in the Outliner so only the pulled
     // objects under a proxy shape will be shown.
+    //
+    // TODO UNDO: make this redoable? Pull is always redone from scratch for now, so it does not
+    // look necessary.
     MFnDependencyNode pullRootFn(pullRootObj);
     UsdMayaUtil::SetHiddenInOutliner(pullRootFn, true);
 
-    _pullRoot = pullRootObj;
-    return true;
+    return pullRootObj;
 }
 
-MObject PrimUpdaterManager::createPullParent(const Ufe::Path& pulledPath)
+MObject PrimUpdaterManager::createPullParent(const Ufe::Path& pulledPath, MObject pullRoot)
 {
-    MDagModifier dagMod;
-    MStatus      status;
-    MObject      pullParentObj = dagMod.createNode(MString("transform"), _pullRoot, &status);
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+
+    MDagModifier& dagMod = MDagModifierUndoItem::create("Create pull parent node", undoInfo);
+    MStatus       status;
+    MObject       pullParentObj = dagMod.createNode(MString("transform"), pullRoot, &status);
     if (status != MStatus::kSuccess) {
         return MObject::kNullObj;
     }
@@ -1061,32 +1177,44 @@ bool PrimUpdaterManager::removePullParent(const MDagPath& parentDagPath)
         return false;
     }
 
-    MDGModifier dgMod;
-    if (dgMod.deleteNode(parentDagPath.node()) != MStatus::kSuccess) {
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+
+    MStatus status = NodeDeletionUndoItem::deleteNode(
+        "Delete pull parent node", parentDagPath.fullPathName(), parentDagPath.node(), undoInfo);
+    if (status != MStatus::kSuccess)
         return false;
-    }
 
     // If the pull parent was the last child of the pull root, remove the pull
     // root as well, and null out our pull root cache.
-    MFnDagNode pullRoot(_pullRoot);
-    auto       nbPullRootChildren = pullRoot.childCount();
-    if (nbPullRootChildren == 1) {
-        if (dgMod.deleteNode(_pullRoot) != MStatus::kSuccess) {
-            return false;
+    MObject pullRoot = findPullRoot();
+    if (!pullRoot.isNull()) {
+        MFnDagNode pullRootNode(pullRoot);
+        auto       nbPullRootChildren = pullRootNode.childCount();
+        if (nbPullRootChildren == 1) {
+            status = NodeDeletionUndoItem::deleteNode("Delete pull root", pullRootNode.absoluteName(), pullRoot, undoInfo);
+            if (status != MStatus::kSuccess) {
+                return false;
+            }
         }
-        _pullRoot = MObject::kNullObj;
     }
 
-    return dgMod.doIt() == MStatus::kSuccess;
+    return true;
 }
 
 MDagPath PrimUpdaterManager::setupPullParent(const Ufe::Path& pulledPath, VtDictionary& args)
 {
-    if (!findOrCreatePullRoot()) {
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+
+    // Record all USD modifications in an undo block and item.
+    UsdUndoBlock undoBlock(
+        &UsdUndoableItemUndoItem::create("Setup pull parent USD data modification", undoInfo));
+
+    MObject pullRoot = findOrCreatePullRoot();
+    if (pullRoot.isNull()) {
         return MDagPath();
     }
 
-    auto pullParent = createPullParent(pulledPath);
+    auto pullParent = createPullParent(pulledPath, pullRoot);
     if (pullParent == MObject::kNullObj) {
         return MDagPath();
     }
@@ -1101,13 +1229,6 @@ MDagPath PrimUpdaterManager::setupPullParent(const Ufe::Path& pulledPath, VtDict
     args[kPullParentPathKey] = VtValue(std::string(pullParentPath.fullPathName().asChar()));
 
     return pullParentPath;
-}
-
-/*static*/
-void PrimUpdaterManager::beforeNewOrOpenCallback(void* clientData)
-{
-    auto um = static_cast<PrimUpdaterManager*>(clientData);
-    um->_pullRoot = MObject::kNullObj;
 }
 
 /* static */

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -356,10 +356,18 @@ PullImportPaths pullImport(
         // -- end --
 
         // Create the pull set if it does not exists.
+        //
+        // Note: do not use the MfnSet API to create it as it clears the redo stack
+        // and thus prevents redo.
         MObject pullSetObj;
         MStatus status = UsdMayaUtil::GetMObjectByName(kPullSetName, pullSetObj);
-        if (status != MStatus::kSuccess)
-            CreateSetUndoItem::create("Pull import pull set creation", kPullSetName, undoInfo);
+        if (status != MStatus::kSuccess) {
+            MString createSetCmd;
+            createSetCmd.format("sets -em -name \"^1s\";", kPullSetName.asChar());
+            MDGModifier& dgMod = MDGModifierUndoItem::create("Pull import pull set creation", undoInfo);
+            dgMod.commandToExecute(createSetCmd);
+            dgMod.doIt();
+        }
 
         // Finalize the pull.
         FunctionUndoItem::execute(

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -1190,7 +1190,7 @@ bool PrimUpdaterManager::removePullParent(const MDagPath& parentDagPath)
     if (!pullRoot.isNull()) {
         MFnDagNode pullRootNode(pullRoot);
         auto       nbPullRootChildren = pullRootNode.childCount();
-        if (nbPullRootChildren == 1) {
+        if (nbPullRootChildren == 0) {
             status = NodeDeletionUndoItem::deleteNode("Delete pull root", pullRootNode.absoluteName(), pullRoot, undoInfo);
             if (status != MStatus::kSuccess) {
                 return false;

--- a/lib/mayaUsd/fileio/primUpdaterManager.h
+++ b/lib/mayaUsd/fileio/primUpdaterManager.h
@@ -71,16 +71,19 @@ public:
 
 private:
     PrimUpdaterManager();
+    
+    PrimUpdaterManager(PrimUpdaterManager&) = delete;
+    PrimUpdaterManager(PrimUpdaterManager&&) = delete;
 
     void onProxyContentChanged(const MayaUsdProxyStageObjectsChangedNotice& notice);
 
     //! Ensure the Dag pull root exists.  This is the child of the Maya world
     //! node under which all pulled nodes are created.
-    bool findOrCreatePullRoot();
+    MObject findOrCreatePullRoot();
 
     //! Create the pull parent for the pulled hierarchy.  This is the node
     //! which receives the pulled node's parent transformation.
-    MObject createPullParent(const Ufe::Path& pulledPath);
+    MObject createPullParent(const Ufe::Path& pulledPath, MObject pullRoot);
 
     //! Remove the pull parent for the pulled hierarchy.
     bool removePullParent(const MDagPath& pullParent);
@@ -88,18 +91,9 @@ private:
     //! Create the pull parent and set it into the prim updater context.
     MDagPath setupPullParent(const Ufe::Path& pulledPath, VtDictionary& args);
 
-    //! Maya scene message callback.
-    static void beforeNewOrOpenCallback(void* clientData);
-
     friend class TfSingleton<PrimUpdaterManager>;
 
     bool _inPushPull { false };
-
-    // Initialize pull root MObject to null object.
-    MObject _pullRoot {};
-
-    // Reset pull root on file new / file open.
-    MCallbackIdArray _cbIds;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/shading/shadingModeDisplayColor.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeDisplayColor.cpp
@@ -167,7 +167,9 @@ DEFINE_SHADING_MODE_IMPORTER_WITH_JOB_ARGUMENTS(
 
         MPlug opacityPlug = depNodeFn.findPlug(_tokens->opacity.GetText());
         UsdMayaReadUtil::SetMayaAttr(
-            opacityPlug, VtValue(1.0f - linearTransparency[0]), /*unlinearizeColors*/ false);
+            opacityPlug,
+            VtValue(1.0f - linearTransparency[0]),
+            /*unlinearizeColors*/ false);
 
         outputPlug = depNodeFn.findPlug("outColor", &status);
         CHECK_MSTATUS_AND_RETURN(status, MObject());

--- a/lib/mayaUsd/fileio/translators/translatorCamera.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorCamera.cpp
@@ -20,6 +20,8 @@
 #include <mayaUsd/fileio/primReaderContext.h>
 #include <mayaUsd/fileio/shading/shadingModeRegistry.h>
 #include <mayaUsd/fileio/translators/translatorUtil.h>
+#include <mayaUsd/undo/OpUndoItems.h>
+#include <mayaUsd/undo/UsdUndoManager.h>
 #include <mayaUsd/utils/util.h>
 
 #include <pxr/base/gf/vec2f.h>
@@ -41,6 +43,8 @@
 
 #include <string>
 #include <vector>
+
+using namespace MAYAUSD_NS_DEF;
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -327,8 +331,9 @@ bool UsdMayaTranslatorCamera::Read(
     }
 
     // Create the camera shape node.
-    MDagModifier dagMod;
-    MObject      cameraObj
+    auto&         undoInfo = UsdUndoManager::instance().getUndoInfo();
+    MDagModifier& dagMod = MDagModifierUndoItem::create("Camera creation", undoInfo);
+    MObject       cameraObj
         = dagMod.createNode(_tokens->MayaCameraTypeName.GetText(), transformObj, &status);
     CHECK_MSTATUS_AND_RETURN(status, false);
     status = dagMod.doIt();

--- a/lib/mayaUsd/fileio/translators/translatorCurves.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorCurves.cpp
@@ -16,6 +16,8 @@
 #include "translatorCurves.h"
 
 #include <mayaUsd/fileio/translators/translatorUtil.h>
+#include <mayaUsd/undo/OpUndoItems.h>
+#include <mayaUsd/undo/UsdUndoManager.h>
 
 #include <pxr/usd/usdGeom/basisCurves.h>
 #include <pxr/usd/usdGeom/nurbsCurves.h>
@@ -31,11 +33,15 @@
 #include <maya/MTime.h>
 #include <maya/MTimeArray.h>
 
+using namespace MAYAUSD_NS_DEF;
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 /* static */
 bool convertToBezier(MFnNurbsCurve& nurbsCurveFn, MObject& mayaNodeTransformObj, MStatus& status)
 {
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+
     MFnNurbsCurve curveFn;
     MFnDagNode    dagFn;
     MObject curveObj = dagFn.create("bezierCurve", "bezierShape1", mayaNodeTransformObj, &status);
@@ -47,11 +53,11 @@ bool convertToBezier(MFnNurbsCurve& nurbsCurveFn, MObject& mayaNodeTransformObj,
     MFnDependencyNode convFn;
     convFn.create("nurbsCurveToBezier");
     // Connect the converter between the nurbs and the bezier
-    MPlug       convIn = convFn.findPlug("inputCurve", false);
-    MPlug       convOut = convFn.findPlug("outputCurve", false);
-    MPlug       nurbsOut = nurbsCurveFn.findPlug("local", false);
-    MPlug       bezIn = dagFn.findPlug("create", false);
-    MDGModifier dgm;
+    MPlug        convIn = convFn.findPlug("inputCurve", false);
+    MPlug        convOut = convFn.findPlug("outputCurve", false);
+    MPlug        nurbsOut = nurbsCurveFn.findPlug("local", false);
+    MPlug        bezIn = dagFn.findPlug("create", false);
+    MDGModifier& dgm = MDGModifierUndoItem::create("Nurbs curve connections", undoInfo);
     dgm.connect(nurbsOut, convIn);
     dgm.connect(convOut, bezIn);
     dgm.doIt();
@@ -59,7 +65,7 @@ bool convertToBezier(MFnNurbsCurve& nurbsCurveFn, MObject& mayaNodeTransformObj,
     MPlug   bezOut = dagFn.findPlug("local", false);
     MObject val = bezOut.asMObject();
     // Remove the nurbs and converter:
-    MDGModifier dagm;
+    MDGModifier& dagm = MDGModifierUndoItem::create("Nurbs curve deletion", undoInfo);
     dagm.deleteNode(convFn.object());
 #if MAYA_API_VERSION >= 20200300
     dagm.deleteNode(nurbsCurveFn.object(), false);

--- a/lib/mayaUsd/fileio/translators/translatorMaterial.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMaterial.cpp
@@ -22,6 +22,7 @@
 #include <mayaUsd/fileio/utils/readUtil.h>
 #include <mayaUsd/fileio/utils/roundTripUtil.h>
 #include <mayaUsd/fileio/writeJobContext.h>
+#include <mayaUsd/undo/UsdUndoManager.h>
 #include <mayaUsd/utils/util.h>
 
 #include <pxr/base/tf/diagnostic.h>
@@ -322,7 +323,7 @@ bool UsdMayaTranslatorMaterial::AssignMaterial(
         = UsdMayaTranslatorMaterial::Read(jobArguments, meshMaterial, primSchema, context);
 
     if (shadingEngine.isNull()) {
-        status = UsdMayaUtil::GetMObjectByName("initialShadingGroup", shadingEngine);
+        status = UsdMayaUtil::GetMObjectByName(MString("initialShadingGroup"), shadingEngine);
         if (status != MS::kSuccess) {
             return false;
         }
@@ -393,7 +394,7 @@ bool UsdMayaTranslatorMaterial::AssignMaterial(
                 _UVBindings faceUVBindings;
                 if (faceSubsetShadingEngine.isNull()) {
                     status = UsdMayaUtil::GetMObjectByName(
-                        "initialShadingGroup", faceSubsetShadingEngine);
+                        MString("initialShadingGroup"), faceSubsetShadingEngine);
                     if (status != MS::kSuccess) {
                         return false;
                     }

--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
@@ -32,6 +32,8 @@
 #include "translatorMayaReference.h"
 
 #include <mayaUsd/base/debugCodes.h>
+#include <mayaUsd/undo/OpUndoItems.h>
+#include <mayaUsd/undo/UsdUndoManager.h>
 #include <mayaUsd/utils/util.h>
 
 #include <maya/MDGModifier.h>
@@ -291,7 +293,8 @@ MStatus UsdMayaTranslatorMayaReference::connectReferenceAssociatedNode(
 
     result = MS::kFailure;
     if (!srcPlug.isNull() && !destPlug.isNull()) {
-        MDGModifier dgMod;
+        auto&        undoInfo = MAYAUSD_NS_DEF::UsdUndoManager::instance().getUndoInfo();
+        MDGModifier& dgMod = MAYAUSD_NS_DEF::MDGModifierUndoItem::create("Connect reference node", undoInfo);
         result = dgMod.connect(srcPlug, destPlug);
         CHECK_MSTATUS_AND_RETURN_IT(result);
         result = dgMod.doIt();

--- a/lib/mayaUsd/fileio/translators/translatorMesh.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMesh.cpp
@@ -20,6 +20,8 @@
 #include <mayaUsd/fileio/utils/readUtil.h>
 #include <mayaUsd/nodes/pointBasedDeformerNode.h>
 #include <mayaUsd/nodes/stageNode.h>
+#include <mayaUsd/undo/OpUndoItems.h>
+#include <mayaUsd/undo/UsdUndoManager.h>
 #include <mayaUsd/utils/util.h>
 
 #include <maya/MColor.h>
@@ -396,14 +398,14 @@ MStatus TranslatorMeshRead::setPointBasedDeformerForMayaNode(
     CHECK_MSTATUS(status);
 
     // Get the newly created point based deformer node.
-    status = UsdMayaUtil::GetMObjectByName(
-        m_newPointBasedDeformerName.asChar(), m_pointBasedDeformerNode);
+    status = UsdMayaUtil::GetMObjectByName(m_newPointBasedDeformerName, m_pointBasedDeformerNode);
     CHECK_MSTATUS(status);
 
     MFnDependencyNode depNodeFn(m_pointBasedDeformerNode, &status);
     CHECK_MSTATUS(status);
 
-    MDGModifier dgMod;
+    auto&        undoInfo = UsdUndoManager::instance().getUndoInfo();
+    MDGModifier& dgMod = MDGModifierUndoItem::create("Deformer connection", undoInfo);
 
     // Set the prim path on the deformer node.
     MPlug primPathPlug

--- a/lib/mayaUsd/fileio/utils/adaptor.cpp
+++ b/lib/mayaUsd/fileio/utils/adaptor.cpp
@@ -22,6 +22,8 @@
 #include <mayaUsd/fileio/schemaApiAdaptorRegistry.h>
 #include <mayaUsd/fileio/utils/readUtil.h>
 #include <mayaUsd/fileio/utils/writeUtil.h>
+#include <mayaUsd/undo/OpUndoItems.h>
+#include <mayaUsd/undo/UsdUndoManager.h>
 #include <mayaUsd/utils/util.h>
 
 #include <pxr/pxr.h>
@@ -33,6 +35,8 @@
 #include <maya/MFnAttribute.h>
 #include <maya/MFnDependencyNode.h>
 #include <maya/MPlug.h>
+
+using namespace MAYAUSD_NS_DEF;
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -312,8 +316,8 @@ UsdMayaSchemaAdaptorPtr UsdMayaAdaptor::GetSchemaOrInheritedSchema(const TfType&
 
 UsdMayaSchemaAdaptorPtr UsdMayaAdaptor::ApplySchema(const TfType& ty)
 {
-    MDGModifier modifier;
-    return ApplySchema(ty, modifier);
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+    return ApplySchema(ty, MDGModifierUndoItem::create("Adaptor schema application", undoInfo));
 }
 
 UsdMayaSchemaAdaptorPtr UsdMayaAdaptor::ApplySchema(const TfType& ty, MDGModifier& modifier)
@@ -329,8 +333,9 @@ UsdMayaSchemaAdaptorPtr UsdMayaAdaptor::ApplySchema(const TfType& ty, MDGModifie
 
 UsdMayaSchemaAdaptorPtr UsdMayaAdaptor::ApplySchemaByName(const TfToken& schemaName)
 {
-    MDGModifier modifier;
-    return ApplySchemaByName(schemaName, modifier);
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+    return ApplySchemaByName(
+        schemaName, MDGModifierUndoItem::create("Adaptor schema application by name", undoInfo));
 }
 
 UsdMayaSchemaAdaptorPtr
@@ -413,8 +418,8 @@ UsdMayaAdaptor::ApplySchemaByName(const TfToken& schemaName, MDGModifier& modifi
 
 void UsdMayaAdaptor::UnapplySchema(const TfType& ty)
 {
-    MDGModifier modifier;
-    UnapplySchema(ty, modifier);
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+    UnapplySchema(ty, MDGModifierUndoItem::create("Adaptor schema removal", undoInfo));
 }
 
 void UsdMayaAdaptor::UnapplySchema(const TfType& ty, MDGModifier& modifier)
@@ -430,8 +435,9 @@ void UsdMayaAdaptor::UnapplySchema(const TfType& ty, MDGModifier& modifier)
 
 void UsdMayaAdaptor::UnapplySchemaByName(const TfToken& schemaName)
 {
-    MDGModifier modifier;
-    UnapplySchemaByName(schemaName, modifier);
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+    UnapplySchemaByName(
+        schemaName, MDGModifierUndoItem::create("Adaptor schema removal by name", undoInfo));
 }
 
 void UsdMayaAdaptor::UnapplySchemaByName(const TfToken& schemaName, MDGModifier& modifier)
@@ -533,8 +539,9 @@ bool UsdMayaAdaptor::GetMetadata(const TfToken& key, VtValue* value) const
 
 bool UsdMayaAdaptor::SetMetadata(const TfToken& key, const VtValue& value)
 {
-    MDGModifier modifier;
-    return SetMetadata(key, value, modifier);
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+    return SetMetadata(
+        key, value, MDGModifierUndoItem::create("Adaptor metadata modification", undoInfo));
 }
 
 bool UsdMayaAdaptor::SetMetadata(const TfToken& key, const VtValue& value, MDGModifier& modifier)
@@ -580,8 +587,8 @@ bool UsdMayaAdaptor::SetMetadata(const TfToken& key, const VtValue& value, MDGMo
 
 void UsdMayaAdaptor::ClearMetadata(const TfToken& key)
 {
-    MDGModifier modifier;
-    ClearMetadata(key, modifier);
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+    ClearMetadata(key, MDGModifierUndoItem::create("Adaptor metadata clearing", undoInfo));
 }
 
 void UsdMayaAdaptor::ClearMetadata(const TfToken& key, MDGModifier& modifier)
@@ -796,8 +803,9 @@ UsdMayaAttributeAdaptor UsdMayaSchemaAdaptor::GetAttribute(const TfToken& attrNa
 
 UsdMayaAttributeAdaptor UsdMayaSchemaAdaptor::CreateAttribute(const TfToken& attrName)
 {
-    MDGModifier modifier;
-    return CreateAttribute(attrName, modifier);
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+    return CreateAttribute(
+        attrName, MDGModifierUndoItem::create("Adaptor attribute creation", undoInfo));
 }
 
 UsdMayaAttributeAdaptor
@@ -846,8 +854,8 @@ UsdMayaSchemaAdaptor::CreateAttribute(const TfToken& attrName, MDGModifier& modi
 
 void UsdMayaSchemaAdaptor::RemoveAttribute(const TfToken& attrName)
 {
-    MDGModifier modifier;
-    RemoveAttribute(attrName, modifier);
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+    RemoveAttribute(attrName, MDGModifierUndoItem::create("Adaptor attribute removal", undoInfo));
 }
 
 void UsdMayaSchemaAdaptor::RemoveAttribute(const TfToken& attrName, MDGModifier& modifier)
@@ -993,8 +1001,8 @@ bool UsdMayaAttributeAdaptor::Get(VtValue* value) const
 
 bool UsdMayaAttributeAdaptor::Set(const VtValue& newValue)
 {
-    MDGModifier modifier;
-    return Set(newValue, modifier);
+    auto& undoInfo = UsdUndoManager::instance().getUndoInfo();
+    return Set(newValue, MDGModifierUndoItem::create("Adaptor attribute modification", undoInfo));
 }
 
 bool UsdMayaAttributeAdaptor::Set(const VtValue& newValue, MDGModifier& modifier)

--- a/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
@@ -99,7 +99,7 @@ bool addCreaseSet(
     // .../lib/python2.7/site-packages/maya/app/general/creaseSetEditor.py
 
     MObject creasePartitionObj;
-    *statusOK = UsdMayaUtil::GetMObjectByName(":creasePartition", creasePartitionObj);
+    *statusOK = UsdMayaUtil::GetMObjectByName(MString(":creasePartition"), creasePartitionObj);
 
     if (creasePartitionObj.isNull()) {
         statusOK->clear();

--- a/lib/mayaUsd/fileio/utils/readUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/readUtil.cpp
@@ -16,6 +16,8 @@
 #include "readUtil.h"
 
 #include <mayaUsd/fileio/utils/adaptor.h>
+#include <mayaUsd/undo/OpUndoItems.h>
+#include <mayaUsd/undo/UsdUndoManager.h>
 #include <mayaUsd/utils/colorSpace.h>
 #include <mayaUsd/utils/converter.h>
 #include <mayaUsd/utils/util.h>
@@ -75,7 +77,9 @@ MObject UsdMayaReadUtil::FindOrCreateMayaAttr(
     const std::string&      attrName,
     const std::string&      attrNiceName)
 {
-    MDGModifier modifier;
+    auto&        undoInfo = UsdUndoManager::instance().getUndoInfo();
+    MDGModifier& modifier
+        = MDGModifierUndoItem::create("Generic attribute find or creation", undoInfo);
     return FindOrCreateMayaAttr(typeName, variability, depNode, attrName, attrNiceName, modifier);
 }
 
@@ -480,7 +484,9 @@ bool UsdMayaReadUtil::SetMayaAttr(
     const VtValue& newValue,
     const bool     unlinearizeColors)
 {
-    MDGModifier modifier;
+    auto&        undoInfo = UsdUndoManager::instance().getUndoInfo();
+    MDGModifier& modifier
+        = MDGModifierUndoItem::create("Generic Maya attribute modification", undoInfo);
     return SetMayaAttr(attrPlug, newValue, modifier, unlinearizeColors);
 }
 
@@ -788,7 +794,9 @@ bool UsdMayaReadUtil::SetMayaAttr(
 
 void UsdMayaReadUtil::SetMayaAttrKeyableState(MPlug& attrPlug, const SdfVariability variability)
 {
-    MDGModifier modifier;
+    auto&        undoInfo = UsdUndoManager::instance().getUndoInfo();
+    MDGModifier& modifier
+        = MDGModifierUndoItem::create("Generic Maya attribute keyable state", undoInfo);
     SetMayaAttrKeyableState(attrPlug, variability, modifier);
 }
 

--- a/lib/mayaUsd/fileio/utils/readUtil.h
+++ b/lib/mayaUsd/fileio/utils/readUtil.h
@@ -102,8 +102,7 @@ struct UsdMayaReadUtil
     /// For plugs with color roles, the value will be converted from a linear
     /// color value before being set if \p unlinearizeColors is true.
     MAYAUSD_CORE_PUBLIC
-    static bool
-    SetMayaAttr(MPlug& attrPlug, const VtValue& newValue, const bool unlinearizeColors = true);
+    static bool SetMayaAttr(MPlug& attrPlug, const VtValue& newValue, const bool unlinearizeColors = true);
 
     /// An overload of SetMayaAttr that takes an MDGModifier.
     /// \note This function will call doIt() on the MDGModifier; thus the

--- a/lib/mayaUsd/nodes/proxyAccessor.py
+++ b/lib/mayaUsd/nodes/proxyAccessor.py
@@ -215,7 +215,7 @@ def keyframeAccessPlug(ufeObject, usdAttrName):
     else:
         result = cmds.setKeyframe(proxyDagPath, attribute=plugNameValueAttr)
     
-def parentItems(ufeChildren, ufeParent):
+def parentItems(ufeChildren, ufeParent, connect=True):
     if not isUfeUsdPath(ufeParent):
         print("This method implements parenting under USD prim. Please provide UFE-USD item for ufeParent")
         return
@@ -231,11 +231,19 @@ def parentItems(ufeChildren, ufeParent):
          
         childDagPath = getDagAndPrimFromUfe(ufeChild)[0]
         
-        print('Parenting "{}" to "{}{}"'.format(childDagPath, parentDagPath,parentUsdPrimPath))
+        print('{} "{}" to "{}{}"'.format(
+            ["Unparenting", "Parenting"][connect],
+            childDagPath, parentDagPath, parentUsdPrimPath))
         childConnectionAttr = childDagPath+'.offsetParentMatrix'
-        cmds.connectAttr(parentConnectionAttr, childConnectionAttr)
+        print('{} "{}" to "{}"'.format(
+            ["Disconnecting", "Connecting"][connect],
+            parentConnectionAttr, childConnectionAttr))
+        if connect:
+            cmds.connectAttr(parentConnectionAttr, childConnectionAttr)
+        else:
+            cmds.disconnectAttr(parentConnectionAttr, childConnectionAttr)
 
-def parent():
+def __parent(doParenting):
    ufeSelection = iter(ufe.GlobalSelection.get())
    ufeSelectionList = []
    for ufeItem in ufeSelection:
@@ -252,7 +260,13 @@ def parent():
    ufeParent = ufeSelectionList[-1]
    ufeChildren = ufeSelectionList[:-1]
    
-   parentItems(ufeChildren, ufeParent)
+   parentItems(ufeChildren, ufeParent, doParenting)
+
+def parent():
+    __parent(True)
+
+def unparent():
+    __parent(False)
 
 def connectItems(ufeObjectSrc, ufeObjectDst, attrToConnect):
     connectMayaToUsd = isUfeUsdPath(ufeObjectDst)

--- a/lib/mayaUsd/python/wrapConverter.cpp
+++ b/lib/mayaUsd/python/wrapConverter.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+#include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/utils/converter.h>
 #include <mayaUsd/utils/util.h>
 
@@ -106,9 +107,11 @@ static void test_convertUsdAttrToMDGModifier(
     const std::string&   attrName,
     const ConverterArgs& args)
 {
-    MPlug plug;
+    // Testing function, no need for undo.
+    OpUndoInfo undoInfo;
+    MPlug      plug;
     if (UsdMayaUtil::GetPlugByName(attrName, plug) == MS::kSuccess) {
-        MDGModifier modifier;
+        MDGModifier& modifier = MDGModifierUndoItem::create("Test USD to DG conversion", undoInfo);
         self.convert(usdAttr, plug, modifier, args);
 
         modifier.doIt();

--- a/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
+++ b/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
@@ -95,8 +95,7 @@ bool duplicate(const std::string& srcUfePathString, const std::string& dstUfePat
 
 void wrapPrimUpdaterManager()
 {
-    using This = PrimUpdaterManager;
-    class_<This>("PrimUpdaterManager", no_init)
+    class_<PrimUpdaterManager, noncopyable>("PrimUpdaterManager", no_init)
         .def("mergeToUsd", mergeToUsd)
         .def("editAsMaya", editAsMaya)
         .def("canEditAsMaya", canEditAsMaya)

--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -75,6 +75,7 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
             PulledObjectHierarchyHandler.cpp
             UsdPathMappingHandler.cpp
             UsdUndoUngroupCommand.cpp
+            PullPushCommands.cpp
     )
 endif()
 
@@ -151,6 +152,7 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
         PulledObjectHierarchyHandler.h
         UsdPathMappingHandler.h
         UsdUndoUngroupCommand.h
+        PullPushCommands.h
     )
 endif()
 

--- a/lib/mayaUsd/ufe/PullPushCommands.cpp
+++ b/lib/mayaUsd/ufe/PullPushCommands.cpp
@@ -1,0 +1,383 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "PullPushCommands.h"
+
+#include "Utils.h"
+
+#include <mayaUsd/fileio/primUpdaterManager.h>
+#include <mayaUsd/undo/OpUndoInfoRecorder.h>
+#include <mayaUsd/undo/UsdUndoManager.h>
+#include <mayaUsd/utils/util.h>
+
+#include <maya/MArgParser.h>
+#include <maya/MGlobal.h>
+#include <maya/MStringArray.h>
+#include <maya/MSyntax.h>
+#include <ufe/path.h>
+#include <ufe/pathString.h>
+
+#include <algorithm>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+namespace {
+
+// Reports an error to the Maya scripting console.
+void reportError(const MString& errorString) { MGlobal::displayError(errorString); }
+
+// Reports an error based on the status. Reports nothing on success.
+MStatus reportError(MStatus status)
+{
+    switch (status.statusCode()) {
+    case MStatus::kNotFound: reportError("No object were provided."); break;
+    case MStatus::kInvalidParameter: reportError("Invalid object path."); break;
+    case MStatus::kUnknownParameter: reportError("Invalid parameter."); break;
+    case MStatus::kSuccess: break;
+    default: reportError("Command parsing error."); break;
+    }
+
+    return status;
+}
+
+// Parses a string as a UFE path, detecting invalid paths and empty paths.
+MStatus parseArgAsUfePath(const MString& arg, Ufe::Path& outputPath)
+{
+    // Note: parsing can throw exceptions. Treat them as parsing error and return an empty path.
+    try {
+        outputPath = Ufe::PathString::path(arg.asChar());
+
+        if (outputPath.size() == 0)
+            return MS::kNotFound;
+
+        return MS::kSuccess;
+    } catch (const std::exception&) {
+        return MS::kInvalidParameter;
+    }
+}
+
+// Create the syntax for a command taking some string parameters representing UFE paths.
+MSyntax createSyntaxWithUfeArgs(int paramCount)
+{
+    MSyntax syntax;
+
+    syntax.enableQuery(false);
+    syntax.enableEdit(false);
+
+    for (int i = 0; i < paramCount; ++i)
+        syntax.addArg(MSyntax::kString);
+
+    return syntax;
+}
+
+// Verifies if a UFE path corresponds to a valid USD prim.
+bool isPrimPath(const Ufe::Path& path) { return ufePathToPrim(path).IsValid(); }
+
+// Parse the indexed argument as text.
+MStatus parseTextArg(const MArgParser& argParser, int index, MString& outputText)
+{
+    argParser.getCommandArgument(index, outputText);
+    if (outputText.length() <= 0)
+        return MS::kNotFound;
+
+    return MS::kSuccess;
+}
+
+// Parse the indexed argument as a UFE path.
+MStatus parseUfePathArg(const MArgParser& argParser, int index, Ufe::Path& outputPath)
+{
+    MString text;
+    MStatus status = parseTextArg(argParser, index, text);
+    if (MS::kSuccess != status)
+        return status;
+
+    status = parseArgAsUfePath(text, outputPath);
+    if (MS::kSuccess != status)
+        return status;
+
+    return MS::kSuccess;
+}
+
+MStatus parseDagPathArg(const MArgParser& argParser, int index, MDagPath& outputDagPath)
+{
+    MString text;
+    MStatus status = parseTextArg(argParser, index, text);
+    if (MS::kSuccess != status)
+        return status;
+
+    MObject obj;
+    status = PXR_NS::UsdMayaUtil::GetMObjectByName(text, obj);
+    if (status != MStatus::kSuccess)
+        return status;
+
+    return MDagPath::getAPathTo(obj, outputDagPath);
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+// EditAsMayaCommand
+//------------------------------------------------------------------------------
+
+// The edit as maya command name.
+const char EditAsMayaCommand::commandName[] = "mayaUsdEditAsMaya";
+
+// Empty edit as maya command.
+EditAsMayaCommand::EditAsMayaCommand() { }
+
+// MPxCommand API to create the command object.
+void* EditAsMayaCommand::creator()
+{
+    // Note: use static cast to make sure the right pointer type is returned into the void *.
+    return static_cast<MPxCommand*>(new EditAsMayaCommand());
+}
+
+// MPxCommand API to register the command syntax.
+MSyntax EditAsMayaCommand::createSyntax() { return createSyntaxWithUfeArgs(1); }
+
+// MPxCommand API to specify the command is undoable.
+bool EditAsMayaCommand::isUndoable() const { return true; }
+
+// MPxCommand API to execute the command.
+MStatus EditAsMayaCommand::doIt(const MArgList& argList)
+{
+    clearResult();
+
+    setCommandString(commandName);
+
+    MStatus    status = MS::kSuccess;
+    MArgParser argParser(syntax(), argList, &status);
+    if (status != MS::kSuccess)
+        return status;
+
+    status = parseUfePathArg(argParser, 0, fPath);
+    if (status != MS::kSuccess)
+        return reportError(status);
+
+    if (!isPrimPath(fPath))
+        return reportError(MS::kInvalidParameter);
+
+    return redoIt();
+}
+
+// MPxCommand API to redo the command.
+MStatus EditAsMayaCommand::redoIt()
+{
+    OpUndoInfoRecorder undoRecorder(fUndoInfo);
+
+    auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
+    if (!manager.editAsMaya(fPath))
+        return MS::kFailure;
+
+    return MS::kSuccess;
+}
+
+// MPxCommand API to undo the command.
+MStatus EditAsMayaCommand::undoIt() { return fUndoInfo.undo() ? MS::kSuccess : MS::kFailure; }
+
+//------------------------------------------------------------------------------
+// MergeToUsdCommand
+//------------------------------------------------------------------------------
+
+// The merge to USD command name.
+const char MergeToUsdCommand::commandName[] = "mayaUsdMergeToUsd";
+
+// Empty merge to USD command.
+MergeToUsdCommand::MergeToUsdCommand() { }
+
+// MPxCommand API to create the command object.
+void* MergeToUsdCommand::creator()
+{
+    // Note: use static cast to make sure the right pointer type is returned into the void *.
+    return static_cast<MPxCommand*>(new MergeToUsdCommand());
+}
+
+// MPxCommand API to register the command syntax.
+MSyntax MergeToUsdCommand::createSyntax() { return createSyntaxWithUfeArgs(1); }
+
+// MPxCommand API to specify the command is undoable.
+bool MergeToUsdCommand::isUndoable() const { return true; }
+
+// MPxCommand API to execute the command.
+MStatus MergeToUsdCommand::doIt(const MArgList& argList)
+{
+    clearResult();
+
+    setCommandString(commandName);
+
+    MStatus    status = MS::kSuccess;
+    MArgParser argParser(syntax(), argList, &status);
+    if (status != MS::kSuccess)
+        return status;
+
+    if (status != MStatus::kSuccess)
+        return status;
+
+    MDagPath dagPath;
+    status = parseDagPathArg(argParser, 0, dagPath);
+    if (status != MS::kSuccess)
+        return reportError(status);
+
+    status = fDagNode.setObject(dagPath);
+    if (status != MS::kSuccess)
+        return reportError(status);
+
+    if (!PXR_NS::PrimUpdaterManager::readPullInformation(dagPath, fPulledPath))
+        return reportError(MS::kInvalidParameter);
+
+    return redoIt();
+}
+
+// MPxCommand API to redo the command.
+MStatus MergeToUsdCommand::redoIt()
+{
+    OpUndoInfoRecorder undoRecorder(fUndoInfo);
+
+    auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
+    if (!manager.mergeToUsd(fDagNode, fPulledPath))
+        return MS::kFailure;
+
+    return MS::kSuccess;
+}
+
+// MPxCommand API to undo the command.
+MStatus MergeToUsdCommand::undoIt() { return fUndoInfo.undo() ? MS::kSuccess : MS::kFailure; }
+
+//------------------------------------------------------------------------------
+// DiscardEditsCommand
+//------------------------------------------------------------------------------
+
+// The discard edits command name.
+const char DiscardEditsCommand::commandName[] = "mayaUsdDiscardEdits";
+
+// Empty discard edits command.
+DiscardEditsCommand::DiscardEditsCommand() { }
+
+// MPxCommand API to create the command object.
+void* DiscardEditsCommand::creator()
+{
+    // Note: use static cast to make sure the right pointer type is returned into the void *.
+    return static_cast<MPxCommand*>(new DiscardEditsCommand());
+}
+
+// MPxCommand API to register the command syntax.
+MSyntax DiscardEditsCommand::createSyntax() { return createSyntaxWithUfeArgs(1); }
+
+// MPxCommand API to specify the command is undoable.
+bool DiscardEditsCommand::isUndoable() const { return true; }
+
+// MPxCommand API to execute the command.
+MStatus DiscardEditsCommand::doIt(const MArgList& argList)
+{
+    clearResult();
+
+    setCommandString(commandName);
+
+    MStatus    status = MS::kSuccess;
+    MArgParser argParser(syntax(), argList, &status);
+    if (status != MS::kSuccess)
+        return status;
+
+    MString nodeName;
+    status = parseTextArg(argParser, 0, nodeName);
+    if (status != MS::kSuccess)
+        return reportError(status);
+
+    MDagPath dagPath = PXR_NS::UsdMayaUtil::nameToDagPath(nodeName.asChar());
+    if (!PXR_NS::PrimUpdaterManager::readPullInformation(dagPath, fPath))
+        return reportError(MS::kInvalidParameter);
+
+    return redoIt();
+}
+
+// MPxCommand API to redo the command.
+MStatus DiscardEditsCommand::redoIt()
+{
+    OpUndoInfoRecorder undoRecorder(fUndoInfo);
+
+    auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
+    if (!manager.discardEdits(fPath))
+        return MS::kFailure;
+
+    return MS::kSuccess;
+}
+
+// MPxCommand API to undo the command.
+MStatus DiscardEditsCommand::undoIt() { return fUndoInfo.undo() ? MS::kSuccess : MS::kFailure; }
+
+//------------------------------------------------------------------------------
+// DuplicateCommand
+//------------------------------------------------------------------------------
+
+// The copy between Maya and USD command name.
+const char DuplicateCommand::commandName[] = "mayaUsdDuplicate";
+
+// Empty copy between Maya and USD command.
+DuplicateCommand::DuplicateCommand() { }
+
+// MPxCommand API to create the command object.
+void* DuplicateCommand::creator()
+{
+    // Note: use static cast to make sure the right pointer type is returned into the void *.
+    return static_cast<MPxCommand*>(new DuplicateCommand());
+}
+
+// MPxCommand API to register the command syntax.
+MSyntax DuplicateCommand::createSyntax() { return createSyntaxWithUfeArgs(2); }
+
+// MPxCommand API to specify the command is undoable.
+bool DuplicateCommand::isUndoable() const { return true; }
+
+// MPxCommand API to execute the command.
+MStatus DuplicateCommand::doIt(const MArgList& argList)
+{
+    clearResult();
+
+    setCommandString(commandName);
+
+    MStatus    status = MS::kSuccess;
+    MArgParser argParser(syntax(), argList, &status);
+    if (status != MS::kSuccess)
+        return status;
+
+    status = parseUfePathArg(argParser, 0, fSrcPath);
+    if (status != MS::kSuccess)
+        return reportError(status);
+
+    status = parseUfePathArg(argParser, 1, fDstPath);
+    if (status != MS::kSuccess)
+        return reportError(status);
+
+    return redoIt();
+}
+
+// MPxCommand API to redo the command.
+MStatus DuplicateCommand::redoIt()
+{
+    OpUndoInfoRecorder undoRecorder(fUndoInfo);
+
+    auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
+    if (!manager.duplicate(fSrcPath, fDstPath))
+        return MS::kFailure;
+
+    return MS::kSuccess;
+}
+
+// MPxCommand API to undo the command.
+MStatus DuplicateCommand::undoIt() { return fUndoInfo.undo() ? MS::kSuccess : MS::kFailure; }
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/PullPushCommands.cpp
+++ b/lib/mayaUsd/ufe/PullPushCommands.cpp
@@ -235,12 +235,6 @@ MStatus MergeToUsdCommand::doIt(const MArgList& argList)
     if (!PXR_NS::PrimUpdaterManager::readPullInformation(dagPath, fPulledPath))
         return reportError(MS::kInvalidParameter);
 
-    return redoIt();
-}
-
-// MPxCommand API to redo the command.
-MStatus MergeToUsdCommand::redoIt()
-{
     OpUndoInfoRecorder undoRecorder(fUndoInfo);
 
     auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
@@ -249,6 +243,9 @@ MStatus MergeToUsdCommand::redoIt()
 
     return MS::kSuccess;
 }
+
+// MPxCommand API to redo the command.
+MStatus MergeToUsdCommand::redoIt() { return fUndoInfo.redo() ? MS::kSuccess : MS::kFailure; }
 
 // MPxCommand API to undo the command.
 MStatus MergeToUsdCommand::undoIt() { return fUndoInfo.undo() ? MS::kSuccess : MS::kFailure; }
@@ -297,12 +294,6 @@ MStatus DiscardEditsCommand::doIt(const MArgList& argList)
     if (!PXR_NS::PrimUpdaterManager::readPullInformation(dagPath, fPath))
         return reportError(MS::kInvalidParameter);
 
-    return redoIt();
-}
-
-// MPxCommand API to redo the command.
-MStatus DiscardEditsCommand::redoIt()
-{
     OpUndoInfoRecorder undoRecorder(fUndoInfo);
 
     auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
@@ -311,6 +302,9 @@ MStatus DiscardEditsCommand::redoIt()
 
     return MS::kSuccess;
 }
+
+// MPxCommand API to redo the command.
+MStatus DiscardEditsCommand::redoIt() { return fUndoInfo.redo() ? MS::kSuccess : MS::kFailure; }
 
 // MPxCommand API to undo the command.
 MStatus DiscardEditsCommand::undoIt() { return fUndoInfo.undo() ? MS::kSuccess : MS::kFailure; }
@@ -358,12 +352,6 @@ MStatus DuplicateCommand::doIt(const MArgList& argList)
     if (status != MS::kSuccess)
         return reportError(status);
 
-    return redoIt();
-}
-
-// MPxCommand API to redo the command.
-MStatus DuplicateCommand::redoIt()
-{
     OpUndoInfoRecorder undoRecorder(fUndoInfo);
 
     auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
@@ -372,6 +360,9 @@ MStatus DuplicateCommand::redoIt()
 
     return MS::kSuccess;
 }
+
+// MPxCommand API to redo the command.
+MStatus DuplicateCommand::redoIt() { return fUndoInfo.redo() ? MS::kSuccess : MS::kFailure; }
 
 // MPxCommand API to undo the command.
 MStatus DuplicateCommand::undoIt() { return fUndoInfo.undo() ? MS::kSuccess : MS::kFailure; }

--- a/lib/mayaUsd/ufe/PullPushCommands.cpp
+++ b/lib/mayaUsd/ufe/PullPushCommands.cpp
@@ -170,12 +170,6 @@ MStatus EditAsMayaCommand::doIt(const MArgList& argList)
     if (!isPrimPath(fPath))
         return reportError(MS::kInvalidParameter);
 
-    return redoIt();
-}
-
-// MPxCommand API to redo the command.
-MStatus EditAsMayaCommand::redoIt()
-{
     OpUndoInfoRecorder undoRecorder(fUndoInfo);
 
     auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
@@ -184,6 +178,9 @@ MStatus EditAsMayaCommand::redoIt()
 
     return MS::kSuccess;
 }
+
+// MPxCommand API to redo the command.
+MStatus EditAsMayaCommand::redoIt() { return fUndoInfo.redo() ? MS::kSuccess : MS::kFailure; }
 
 // MPxCommand API to undo the command.
 MStatus EditAsMayaCommand::undoIt() { return fUndoInfo.undo() ? MS::kSuccess : MS::kFailure; }

--- a/lib/mayaUsd/ufe/PullPushCommands.h
+++ b/lib/mayaUsd/ufe/PullPushCommands.h
@@ -1,0 +1,218 @@
+//
+// Copyright 2020 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#ifndef PXRUSDMAYA_PULLPUSHCOMMANDS_H
+#define PXRUSDMAYA_PULLPUSHCOMMANDS_H
+
+#include <mayaUsd/base/api.h>
+#include <mayaUsd/mayaUsd.h>
+#include <mayaUsd/undo/OpUndoInfo.h>
+
+#include <maya/MFnDagNode.h>
+#include <maya/MPxCommand.h>
+#include <ufe/path.h>
+#include <ufe/undoableCommand.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+//------------------------------------------------------------------------------
+// EditAsMayaCommand
+//------------------------------------------------------------------------------
+
+//! \brief Edit as maya undoable command.
+
+class EditAsMayaCommand : public MPxCommand
+{
+public:
+    //! \brief The edit as maya command name.
+    MAYAUSD_CORE_PUBLIC
+    static const char commandName[];
+
+    //! \brief MPxCommand API to create the command object.
+    MAYAUSD_CORE_PUBLIC
+    static void* creator();
+
+    //! \brief MPxCommand API to register the command syntax.
+    MAYAUSD_CORE_PUBLIC
+    static MSyntax createSyntax();
+
+    //! \brief MPxCommand API to execute the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus doIt(const MArgList& argList) override;
+
+    //! \brief MPxCommand API to undo the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus undoIt() override;
+
+    //! \brief MPxCommand API to redo the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus redoIt() override;
+
+    //! \brief MPxCommand API to specify the command is undoable.
+    MAYAUSD_CORE_PUBLIC
+    bool isUndoable() const override;
+
+private:
+    // Make sure callers need to call creator().
+    EditAsMayaCommand();
+
+    Ufe::Path  fPath;
+    OpUndoInfo fUndoInfo;
+};
+
+//------------------------------------------------------------------------------
+// MergeToUsdCommand
+//------------------------------------------------------------------------------
+
+//! \brief Merge to USD undoable command.
+
+class MergeToUsdCommand : public MPxCommand
+{
+public:
+    //! \brief The merge to USD command name.
+    MAYAUSD_CORE_PUBLIC
+    static const char commandName[];
+
+    //! \brief MPxCommand API to create the command object.
+    MAYAUSD_CORE_PUBLIC
+    static void* creator();
+
+    //! \brief MPxCommand API to register the command syntax.
+    MAYAUSD_CORE_PUBLIC
+    static MSyntax createSyntax();
+
+    //! \brief MPxCommand API to execute the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus doIt(const MArgList& argList) override;
+
+    //! \brief MPxCommand API to undo the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus undoIt() override;
+
+    //! \brief MPxCommand API to redo the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus redoIt() override;
+
+    //! \brief MPxCommand API to specify the command is undoable.
+    MAYAUSD_CORE_PUBLIC
+    bool isUndoable() const override;
+
+private:
+    // Make sure callers need to call creator().
+    MergeToUsdCommand();
+
+    MFnDagNode fDagNode;
+    Ufe::Path  fPulledPath;
+    OpUndoInfo fUndoInfo;
+};
+
+//------------------------------------------------------------------------------
+// DiscardEditsCommand
+//------------------------------------------------------------------------------
+
+//! \brief Discards edits undoable command.
+
+class DiscardEditsCommand : public MPxCommand
+{
+public:
+    //! \brief The edit as maya command name.
+    MAYAUSD_CORE_PUBLIC
+    static const char commandName[];
+
+    //! \brief MPxCommand API to create the command object.
+    MAYAUSD_CORE_PUBLIC
+    static void* creator();
+
+    //! \brief MPxCommand API to register the command syntax.
+    MAYAUSD_CORE_PUBLIC
+    static MSyntax createSyntax();
+
+    //! \brief MPxCommand API to execute the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus doIt(const MArgList& argList) override;
+
+    //! \brief MPxCommand API to undo the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus undoIt() override;
+
+    //! \brief MPxCommand API to redo the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus redoIt() override;
+
+    //! \brief MPxCommand API to specify the command is undoable.
+    MAYAUSD_CORE_PUBLIC
+    bool isUndoable() const override;
+
+private:
+    // Make sure callers need to call creator().
+    DiscardEditsCommand();
+
+    Ufe::Path  fPath;
+    OpUndoInfo fUndoInfo;
+};
+
+//------------------------------------------------------------------------------
+// DuplicateCommand
+//------------------------------------------------------------------------------
+
+//! \brief Copy between Maya and USD undoable command.
+
+class DuplicateCommand : public MPxCommand
+{
+public:
+    //! \brief The copy between Maya and USD command name.
+    MAYAUSD_CORE_PUBLIC
+    static const char commandName[];
+
+    //! \brief MPxCommand API to create the command object.
+    MAYAUSD_CORE_PUBLIC
+    static void* creator();
+
+    //! \brief MPxCommand API to register the command syntax.
+    MAYAUSD_CORE_PUBLIC
+    static MSyntax createSyntax();
+
+    //! \brief MPxCommand API to execute the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus doIt(const MArgList& argList) override;
+
+    //! \brief MPxCommand API to undo the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus undoIt() override;
+
+    //! \brief MPxCommand API to redo the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus redoIt() override;
+
+    //! \brief MPxCommand API to specify the command is undoable.
+    MAYAUSD_CORE_PUBLIC
+    bool isUndoable() const override;
+
+private:
+    // Make sure callers need to call creator().
+    DuplicateCommand();
+
+    Ufe::Path  fSrcPath;
+    Ufe::Path  fDstPath;
+    OpUndoInfo fUndoInfo;
+};
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF
+
+#endif /* PXRUSDMAYA_PULLPUSHCOMMANDS_H */

--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -19,6 +19,7 @@
 
 #ifdef UFE_V3_FEATURES_AVAILABLE
 #include <mayaUsd/fileio/primUpdaterManager.h>
+#include <mayaUsd/ufe/PullPushCommands.h>
 #endif
 #include <mayaUsd/ufe/UsdObject3d.h>
 #include <mayaUsd/ufe/UsdSceneItem.h>
@@ -839,12 +840,12 @@ Ufe::UndoableCommand::Ptr UsdContextOps::doOpCmd(const ItemPath& itemPath)
         return std::make_shared<ClearAllReferencesUndoableCommand>(prim());
     } else if (itemPath[0] == kEditAsMayaItem) {
         MString script;
-        script.format("mayaUsdMenu_pullToDG \"^1s\"", Ufe::PathString::string(path()).c_str());
-        MGlobal::executeCommand(script);
+        script.format("^1s \"^2s\"", EditAsMayaCommand::commandName, Ufe::PathString::string(path()).c_str());
+        MGlobal::executeCommand(script, true, true);
     } else if (itemPath[0] == kDuplicateAsMayaItem) {
         MString script;
-        script.format("mayaUsdMenu_duplicateToDG \"^1s\"", Ufe::PathString::string(path()).c_str());
-        MGlobal::executeCommand(script);
+        script.format("^1s \"^2s\" \"|world\"", DuplicateCommand::commandName, Ufe::PathString::string(path()).c_str());
+        MGlobal::executeCommand(script, true, true);
     }
 
     return nullptr;

--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -838,14 +838,20 @@ Ufe::UndoableCommand::Ptr UsdContextOps::doOpCmd(const ItemPath& itemPath)
             return nullptr;
 
         return std::make_shared<ClearAllReferencesUndoableCommand>(prim());
+#ifdef UFE_V3_FEATURES_AVAILABLE
     } else if (itemPath[0] == kEditAsMayaItem) {
         MString script;
-        script.format("^1s \"^2s\"", EditAsMayaCommand::commandName, Ufe::PathString::string(path()).c_str());
+        script.format(
+            "^1s \"^2s\"", EditAsMayaCommand::commandName, Ufe::PathString::string(path()).c_str());
         MGlobal::executeCommand(script, true, true);
     } else if (itemPath[0] == kDuplicateAsMayaItem) {
         MString script;
-        script.format("^1s \"^2s\" \"|world\"", DuplicateCommand::commandName, Ufe::PathString::string(path()).c_str());
+        script.format(
+            "^1s \"^2s\" \"|world\"",
+            DuplicateCommand::commandName,
+            Ufe::PathString::string(path()).c_str());
         MGlobal::executeCommand(script, true, true);
+#endif
     }
 
     return nullptr;

--- a/lib/mayaUsd/undo/CMakeLists.txt
+++ b/lib/mayaUsd/undo/CMakeLists.txt
@@ -3,16 +3,24 @@
 # -----------------------------------------------------------------------------
 target_sources(${PROJECT_NAME} 
     PRIVATE
+        OpUndoInfo.cpp
+        OpUndoInfoRecorder.cpp
+        OpUndoItems.cpp
         UsdUndoBlock.cpp
         UsdUndoManager.cpp
         UsdUndoStateDelegate.cpp
         UsdUndoableItem.cpp
+
 )
 
 # -----------------------------------------------------------------------------
 # promote headers
 # -----------------------------------------------------------------------------
 set(HEADERS
+    OpUndoInfo.h
+    OpUndoInfoMuting.h
+    OpUndoInfoRecorder.h
+    OpUndoItems.h
     UsdUndoBlock.h
     UsdUndoManager.h
     UsdUndoStateDelegate.h

--- a/lib/mayaUsd/undo/OpUndoInfo.cpp
+++ b/lib/mayaUsd/undo/OpUndoInfo.cpp
@@ -92,7 +92,7 @@ OpUndoInfo OpUndoInfo::extract()
     _deletedMayaObjects.clear();
     extracted._isUndone = _isUndone;
     
-    return std::move(extracted);
+    return extracted;
 }
 
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/undo/OpUndoInfo.cpp
+++ b/lib/mayaUsd/undo/OpUndoInfo.cpp
@@ -1,0 +1,98 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "OpUndoInfo.h"
+
+namespace MAYAUSD_NS_DEF {
+
+//------------------------------------------------------------------------------
+// OpUndoInfo
+//------------------------------------------------------------------------------
+
+OpUndoInfo::~OpUndoInfo() { clear(); }
+
+bool OpUndoInfo::undo()
+{
+    bool overallSuccess = true;
+    // Note: iterate in reverse order since operations might depends on each other.
+    const auto end = _undoItems.rend();
+    for (auto iter = _undoItems.rbegin(); iter != end; ++iter)
+        overallSuccess &= (*iter)->undo();
+
+    _isUndone = true;
+
+    return overallSuccess;
+}
+
+bool OpUndoInfo::redo()
+{
+    bool overallSuccess = true;
+    for (auto& item : _undoItems)
+        overallSuccess &= item->undo();
+
+    _isUndone = false;
+
+    return overallSuccess;
+}
+
+void OpUndoInfo::addItem(OpUndoItem::Ptr&& item)
+{
+    // Note: OpUndoItem::Ptr are unique_ptr, so we need to take ownership of them.
+    _undoItems.emplace_back(std::move(item));
+}
+
+void OpUndoInfo::addDeleted(const MObjectHandle obj)
+{
+    _deletedMayaObjects.insert(obj);
+}
+
+bool OpUndoInfo::isDeleted(const MObjectHandle obj) const
+{
+   return _deletedMayaObjects.count(obj) > 0;
+}
+
+void OpUndoInfo::clear()
+{
+    // Note: we need to destroy the undo items in reverse order
+    //       since some items might depends on previous ones.
+    if (_isUndone) {
+        const auto end = _undoItems.rend();
+        for (auto iter = _undoItems.rbegin(); iter != end; ++iter)
+            iter->reset();
+    } else {
+        const auto end = _undoItems.end();
+        for (auto iter = _undoItems.begin(); iter != end; ++iter)
+            iter->reset();
+    }
+
+    _undoItems.clear();
+    _deletedMayaObjects.clear();
+    _isUndone = false;
+}
+
+OpUndoInfo OpUndoInfo::extract()
+{
+    OpUndoInfo extracted;
+    for (auto&& item : _undoItems)
+        extracted._undoItems.emplace_back(std::move(item));
+
+    _undoItems.clear();
+    _deletedMayaObjects.clear();
+    extracted._isUndone = _isUndone;
+    
+    return std::move(extracted);
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/undo/OpUndoInfo.cpp
+++ b/lib/mayaUsd/undo/OpUndoInfo.cpp
@@ -40,7 +40,7 @@ bool OpUndoInfo::redo()
 {
     bool overallSuccess = true;
     for (auto& item : _undoItems)
-        overallSuccess &= item->undo();
+        overallSuccess &= item->redo();
 
     _isUndone = false;
 

--- a/lib/mayaUsd/undo/OpUndoInfo.h
+++ b/lib/mayaUsd/undo/OpUndoInfo.h
@@ -1,0 +1,151 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_UNDO_OP_UNDO_INFO_H
+#define MAYAUSD_UNDO_OP_UNDO_INFO_H
+
+#include <mayaUsd/base/api.h>
+
+#include <maya/MObjectHandle.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace MAYAUSD_NS_DEF {
+
+//------------------------------------------------------------------------------
+// OpUndoItem
+//------------------------------------------------------------------------------
+
+/// \class OpUndoItem
+/// \brief Record data needed to undo or redo a single undo sub-operation.
+///
+/// See OpUndoItems.h for concrete implementations.
+
+class OpUndoItem
+{
+public:
+    typedef std::unique_ptr<OpUndoItem> Ptr;
+
+    /// \brief construct a single named sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    OpUndoItem(std::string name)
+        : _name(std::move(name))
+    {
+    }
+
+    MAYAUSD_CORE_PUBLIC
+    virtual ~OpUndoItem() = default;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    virtual bool undo() = 0;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    virtual bool redo() = 0;
+
+    /// \brief get the undo item name, used for debugging and logging.
+    MAYAUSD_CORE_PUBLIC
+    const std::string& getName() const { return _name; }
+
+private:
+    // Name the undo items to help debugging, tracing and logging.
+    std::string _name;
+};
+
+//------------------------------------------------------------------------------
+// OpUndoInfo
+//------------------------------------------------------------------------------
+
+/// \class OpUndoInfo
+/// \brief Record everything needed to undo or redo a complete operation or command.
+
+class OpUndoInfo
+{
+public:
+    /// \brief construct an undo info.
+    MAYAUSD_CORE_PUBLIC
+    OpUndoInfo() = default;
+
+    MAYAUSD_CORE_PUBLIC
+    OpUndoInfo(OpUndoInfo&&) = default;
+
+    MAYAUSD_CORE_PUBLIC
+    OpUndoInfo& operator=(OpUndoInfo&&) = default;
+
+    /// \brief destroy the undo info.
+    MAYAUSD_CORE_PUBLIC
+    ~OpUndoInfo();
+
+    /// \brief undo a complete PrimUpdaterManager operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo();
+
+    /// \brief redo a complete PrimUpdaterManager operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo();
+
+    /// \brief add a undo item. This takes ownership of the item.
+    MAYAUSD_CORE_PUBLIC
+    void addItem(OpUndoItem::Ptr&& item);
+
+    /// \brief add an object that was deleted, to help avoid deleting an object twice.
+    MAYAUSD_CORE_PUBLIC
+    void addDeleted(const MObjectHandle obj);
+
+    /// \brief verify if an object was already deleted, to help avoid deleting an object twice.
+    MAYAUSD_CORE_PUBLIC
+    bool isDeleted(const MObjectHandle obj) const;
+
+    /// \brief clear all undo/redo information contained here.
+    MAYAUSD_CORE_PUBLIC
+    void clear();
+
+    /// \brief extract all undo/redo information contained here and clear.
+    MAYAUSD_CORE_PUBLIC
+    OpUndoInfo extract();
+
+private:
+    OpUndoInfo(const OpUndoInfo&) = delete;
+    OpUndoInfo& operator=(const OpUndoInfo&) = delete;
+
+    struct MObjectHandleHash
+    {
+        size_t operator()(const MObjectHandle obj ) const
+        {
+            return obj.hashCode();
+        }
+    };
+
+    using DeletedObjectSet = std::unordered_set<MObjectHandle, MObjectHandleHash>;
+
+    std::vector<OpUndoItem::Ptr> _undoItems;
+    DeletedObjectSet             _deletedMayaObjects;
+    bool                         _isUndone = false;
+};
+
+} // namespace MAYAUSD_NS_DEF
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+using OpUndoInfo = MAYAUSD_NS_DEF::OpUndoInfo;
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/lib/mayaUsd/undo/OpUndoInfoMuting.h
+++ b/lib/mayaUsd/undo/OpUndoInfoMuting.h
@@ -1,0 +1,48 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef MAYAUSD_UNDO_OPUNDOINFOMUTING_H
+#define MAYAUSD_UNDO_OPUNDOINFOMUTING_H
+
+#include <mayaUsd/undo/OpUndoInfo.h>
+#include <mayaUsd/undo/UsdUndoManager.h>
+
+namespace MAYAUSD_NS_DEF {
+
+//! \brief Turn off undo info recording for a given scope.
+//
+// Useful if code implement their own undo/redo without using the undo info
+// but calls functions that generate undo info items that need to be ignored.
+
+class MAYAUSD_CORE_PUBLIC OpUndoInfoMuting
+{
+public:
+    //! \brief Constructor extracts all undo info items.
+    OpUndoInfoMuting()
+        : _preservedUndoInfo(UsdUndoManager::instance()._undoInfo.extract())
+    {
+    }
+
+    //! \brief Destructor restores all preserved undo info items that were extracted.
+    ~OpUndoInfoMuting() { UsdUndoManager::instance()._undoInfo = std::move(_preservedUndoInfo); }
+
+private:
+    OpUndoInfo _preservedUndoInfo;
+};
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_UNDO_OPUNDOINFOMUTING_H

--- a/lib/mayaUsd/undo/OpUndoInfoRecorder.cpp
+++ b/lib/mayaUsd/undo/OpUndoInfoRecorder.cpp
@@ -49,7 +49,7 @@ void OpUndoInfoRecorder::endUndoRecording()
 
     // Extract the undo items from the global comtainer
     // into the container we we're given.
-    _undoInfo = std::move(UsdUndoManager::instance().getUndoInfo().extract());
+    _undoInfo = UsdUndoManager::instance().getUndoInfo().extract();
     
 }
 

--- a/lib/mayaUsd/undo/OpUndoInfoRecorder.cpp
+++ b/lib/mayaUsd/undo/OpUndoInfoRecorder.cpp
@@ -1,0 +1,56 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <mayaUsd/undo/OpUndoInfoRecorder.h>
+
+namespace MAYAUSD_NS_DEF {
+
+OpUndoInfoRecorder::OpUndoInfoRecorder(OpUndoInfo& undoInfo)
+    : _isRecording(false)
+    , _undoInfo(undoInfo)
+{
+    startUndoRecording();
+}
+
+OpUndoInfoRecorder::~OpUndoInfoRecorder() { endUndoRecording(); }
+
+void OpUndoInfoRecorder::startUndoRecording()
+{
+    // Don't do anything if recording already started.
+    if (_isRecording)
+        return;
+    _isRecording = true;
+
+    // Clear any previously-generated undo items, both the undo info container
+    // and in the global container.
+    _undoInfo.clear();
+    UsdUndoManager::instance().getUndoInfo().clear();
+}
+
+void OpUndoInfoRecorder::endUndoRecording()
+{
+    // Don't do anything if recording already ended.
+    if (!_isRecording)
+        return;
+    _isRecording = false;
+
+    // Extract the undo items from the global comtainer
+    // into the container we we're given.
+    _undoInfo = std::move(UsdUndoManager::instance().getUndoInfo().extract());
+    
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/undo/OpUndoInfoRecorder.h
+++ b/lib/mayaUsd/undo/OpUndoInfoRecorder.h
@@ -1,0 +1,59 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef MAYAUSD_UNDO_OPUNDOINFORECORDER_H
+#define MAYAUSD_UNDO_OPUNDOINFORECORDER_H
+
+#include <mayaUsd/undo/OpUndoInfo.h>
+#include <mayaUsd/undo/UsdUndoManager.h>
+
+namespace MAYAUSD_NS_DEF {
+
+//! \brief Record and extract undo item in the scope where it is declared.
+//
+// Useful if code implement their undo/redo using the OpUndoInfo and need
+// to relieably extract the undo items from the UsdUndoManager.
+
+class MAYAUSD_CORE_PUBLIC OpUndoInfoRecorder
+{
+public:
+    //! \brief Starts recording undo info in the given container.
+    OpUndoInfoRecorder(OpUndoInfo& undoInfo);
+
+    //! \brief Ends recording undo info.
+    ~OpUndoInfoRecorder();
+
+    //! \brief Starts recording undo info in the given container.
+    //
+    // Discard any previously recorded info.
+    void startUndoRecording();
+
+    //! \brief Ends recording undo info immediately.
+    //
+    // No further undo info will be extracted.
+    void endUndoRecording();
+
+private:
+    OpUndoInfoRecorder(const OpUndoInfoRecorder&) = delete;
+    OpUndoInfoRecorder operator=(const OpUndoInfoRecorder&) = delete;
+
+    bool        _isRecording = false;
+    OpUndoInfo& _undoInfo;
+};
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_UNDO_OPUNDOINFORECORDER_H

--- a/lib/mayaUsd/undo/OpUndoItems.cpp
+++ b/lib/mayaUsd/undo/OpUndoItems.cpp
@@ -1,0 +1,376 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "OpUndoItems.h"
+
+#include <mayaUsd/utils/util.h>
+
+#include <maya/MGlobal.h>
+#include <maya/MItDag.h>
+
+namespace MAYAUSD_NS_DEF {
+
+//------------------------------------------------------------------------------
+// NodeDeletionUndoItem
+//------------------------------------------------------------------------------
+
+MStatus
+NodeDeletionUndoItem::deleteNode(const std::string name, const MString& nodeName, const MObject& node, OpUndoInfo& undoInfo)
+{
+    // Avoid deleting the same node twice.
+    if (undoInfo.isDeleted(node))
+        return MS::kSuccess;
+
+    std::string fullName = name + std::string(" \"") + std::string(nodeName.asChar()) + std::string("\"");
+    auto item = std::make_unique<NodeDeletionUndoItem>(std::move(fullName));
+
+    MStatus status = item->_modifier.deleteNode(node, false);
+    if (status != MS::kSuccess)
+        return status;
+
+    // Note: unfortunately, if this second call fails, we will be in a
+    // semi-deleted state, where one part succeeded and another failed...
+    // but this is how MDGModifier::deleteNode works, we can't avoid it.
+    status = item->_modifier.doIt();
+    if (status != MS::kSuccess)
+        return status;
+
+    undoInfo.addItem(std::move(item));
+    undoInfo.addDeleted(node);
+
+    return MS::kSuccess;
+}
+
+NodeDeletionUndoItem::~NodeDeletionUndoItem() { }
+
+bool NodeDeletionUndoItem::undo() { return _modifier.undoIt() == MS::kSuccess; }
+
+bool NodeDeletionUndoItem::redo() { return _modifier.doIt() == MS::kSuccess; }
+
+//------------------------------------------------------------------------------
+// MDagModifierUndoItem
+//------------------------------------------------------------------------------
+
+MDagModifier& MDagModifierUndoItem::create(const std::string name, OpUndoInfo& undoInfo)
+{
+    auto          item = std::make_unique<MDagModifierUndoItem>(std::move(name));
+    MDagModifier& mod = item->getModifier();
+    undoInfo.addItem(std::move(item));
+    return mod;
+}
+
+MDagModifierUndoItem::~MDagModifierUndoItem() { }
+
+bool MDagModifierUndoItem::undo() { return _modifier.undoIt() == MS::kSuccess; }
+
+bool MDagModifierUndoItem::redo() { return _modifier.doIt() == MS::kSuccess; }
+
+//------------------------------------------------------------------------------
+// MDGModifierUndoItem
+//------------------------------------------------------------------------------
+
+MDGModifier& MDGModifierUndoItem::create(const std::string name, OpUndoInfo& undoInfo)
+{
+    auto         item = std::make_unique<MDGModifierUndoItem>(std::move(name));
+    MDGModifier& mod = item->getModifier();
+    undoInfo.addItem(std::move(item));
+    return mod;
+}
+
+MDGModifierUndoItem::~MDGModifierUndoItem() { }
+
+bool MDGModifierUndoItem::undo() { return _modifier.undoIt() == MS::kSuccess; }
+
+bool MDGModifierUndoItem::redo() { return _modifier.doIt() == MS::kSuccess; }
+
+//------------------------------------------------------------------------------
+// UsdUndoableItemUndoItem
+//------------------------------------------------------------------------------
+
+MAYAUSD_NS::UsdUndoableItem&
+UsdUndoableItemUndoItem::create(const std::string name, OpUndoInfo& undoInfo)
+{
+    auto                         item = std::make_unique<UsdUndoableItemUndoItem>(std::move(name));
+    MAYAUSD_NS::UsdUndoableItem& mod = item->getUndoableItem();
+    undoInfo.addItem(std::move(item));
+    return mod;
+}
+
+UsdUndoableItemUndoItem::~UsdUndoableItemUndoItem() { }
+
+bool UsdUndoableItemUndoItem::undo()
+{
+    _item.undo();
+    return true;
+}
+
+bool UsdUndoableItemUndoItem::redo()
+{
+    _item.redo();
+    return true;
+}
+
+//------------------------------------------------------------------------------
+// PythonUndoItem
+//------------------------------------------------------------------------------
+
+PythonUndoItem::PythonUndoItem(const std::string name, MString pythonDo, MString pythonUndo)
+    : OpUndoItem(std::move(name))
+    , _pythonDo(std::move(pythonDo))
+    , _pythonUndo(std::move(pythonUndo))
+{
+}
+
+PythonUndoItem::~PythonUndoItem() { }
+
+void PythonUndoItem::execute(
+    const std::string name,
+    MString           pythonDo,
+    MString           pythonUndo,
+    OpUndoInfo&       undoInfo)
+{
+    auto item = std::make_unique<PythonUndoItem>(
+        std::move(name), std::move(pythonDo), std::move(pythonUndo));
+    item->redo();
+    undoInfo.addItem(std::move(item));
+}
+
+namespace {
+bool executePython(const MString& python)
+{
+    if (python.length() == 0)
+        return true;
+
+    return MGlobal::executePythonCommand(python) == MS::kSuccess;
+}
+} // namespace
+
+bool PythonUndoItem::undo() { return executePython(_pythonUndo); }
+
+bool PythonUndoItem::redo() { return executePython(_pythonDo); }
+
+//------------------------------------------------------------------------------
+// FunctionUndoItem
+//------------------------------------------------------------------------------
+
+FunctionUndoItem::FunctionUndoItem(
+    const std::string     name,
+    std::function<bool()> redo,
+    std::function<bool()> undo)
+    : OpUndoItem(std::move(name))
+    , _redo(std::move(redo))
+    , _undo(std::move(undo))
+{
+}
+
+FunctionUndoItem::~FunctionUndoItem() { }
+
+void FunctionUndoItem::create(
+    const std::string     name,
+    std::function<bool()> redo,
+    std::function<bool()> undo,
+    OpUndoInfo&           undoInfo)
+{
+    auto item
+        = std::make_unique<FunctionUndoItem>(std::move(name), std::move(redo), std::move(undo));
+    undoInfo.addItem(std::move(item));
+}
+
+void FunctionUndoItem::execute(
+    const std::string     name,
+    std::function<bool()> redo,
+    std::function<bool()> undo,
+    OpUndoInfo&           undoInfo)
+{
+    auto item
+        = std::make_unique<FunctionUndoItem>(std::move(name), std::move(redo), std::move(undo));
+    item->redo();
+    undoInfo.addItem(std::move(item));
+}
+
+bool FunctionUndoItem::undo()
+{
+    if (!_undo)
+        return false;
+
+    return _undo();
+}
+
+bool FunctionUndoItem::redo()
+{
+    if (!_redo)
+        return false;
+
+    return _redo();
+}
+
+//------------------------------------------------------------------------------
+// SelectionUndoItem
+//------------------------------------------------------------------------------
+
+SelectionUndoItem::SelectionUndoItem(
+    const std::string       name,
+    const MSelectionList&   selection,
+    MGlobal::ListAdjustment selMode)
+    : OpUndoItem(std::move(name))
+    , _selection(selection)
+    , _selMode(selMode)
+{
+}
+
+SelectionUndoItem::~SelectionUndoItem() { }
+
+void SelectionUndoItem::select(
+    const std::string       name,
+    const MSelectionList&   selection,
+    MGlobal::ListAdjustment selMode,
+    OpUndoInfo&             undoInfo)
+{
+    auto item = std::make_unique<SelectionUndoItem>(std::move(name), selection, selMode);
+    item->redo();
+    undoInfo.addItem(std::move(item));
+}
+
+void SelectionUndoItem::select(
+    const std::string       name,
+    const MDagPath&         dagPath,
+    MGlobal::ListAdjustment selMode,
+    OpUndoInfo&             undoInfo)
+{
+    MSelectionList selection;
+    selection.add(dagPath);
+    SelectionUndoItem::select(std::move(name), selection, selMode, undoInfo);
+}
+
+bool SelectionUndoItem::undo()
+{
+    MStatus status = MGlobal::setActiveSelectionList(_previousSelection);
+    return status == MS::kSuccess;
+}
+
+bool SelectionUndoItem::redo()
+{
+    MGlobal::getActiveSelectionList(_previousSelection);
+    MStatus status = MGlobal::setActiveSelectionList(_selection, _selMode);
+    return status == MS::kSuccess;
+}
+
+//------------------------------------------------------------------------------
+// LockNodesUndoItem
+//------------------------------------------------------------------------------
+
+namespace {
+
+//! Lock or unlock hierarchy starting at given root.
+MStatus lockNodes(const MString& rootName, bool state)
+{
+    MObject obj;
+    MStatus status = PXR_NS::UsdMayaUtil::GetMObjectByName(rootName, obj);
+    if (status != MStatus::kSuccess)
+        return status;
+
+    MDagPath root;
+    status = MDagPath::getAPathTo(obj, root);
+    if (status != MStatus::kSuccess)
+        return status;
+
+    MItDag dagIt;
+    dagIt.reset(root);
+    for (; !dagIt.isDone(); dagIt.next()) {
+        MFnDependencyNode node(dagIt.currentItem());
+        if (node.isFromReferencedFile()) {
+            dagIt.prune();
+            continue;
+        }
+        node.setLocked(state);
+    }
+
+    return MS::kSuccess;
+}
+
+} // namespace
+
+LockNodesUndoItem::LockNodesUndoItem(const std::string name, const MDagPath& root, bool lock)
+    : OpUndoItem(std::move(name))
+    , _rootName(root.fullPathName())
+    , _lock(lock)
+{
+}
+
+LockNodesUndoItem::~LockNodesUndoItem() { }
+
+void LockNodesUndoItem::lock(
+    const std::string name,
+    const MDagPath&   root,
+    bool              lock,
+    OpUndoInfo&       undoInfo)
+{
+    auto item = std::make_unique<LockNodesUndoItem>(std::move(name), root, lock);
+    item->redo();
+    undoInfo.addItem(std::move(item));
+}
+
+bool LockNodesUndoItem::undo()
+{
+    lockNodes(_rootName, !_lock);
+    return true;
+}
+
+bool LockNodesUndoItem::redo()
+{
+    lockNodes(_rootName, _lock);
+    return true;
+}
+
+//------------------------------------------------------------------------------
+// CreateSetUndoItem
+//------------------------------------------------------------------------------
+
+CreateSetUndoItem::CreateSetUndoItem(const std::string name, const MString& setName)
+    : OpUndoItem(std::move(name))
+    , _setName(setName)
+{
+}
+
+CreateSetUndoItem::~CreateSetUndoItem() { }
+
+MObject CreateSetUndoItem::create(std::string name, const MString& setName, OpUndoInfo& undoInfo)
+{
+    auto item = std::make_unique<CreateSetUndoItem>(std::move(name), setName);
+    item->redo();
+    MObject obj = item->_setObj;
+    undoInfo.addItem(std::move(item));
+    return obj;
+}
+
+bool CreateSetUndoItem::undo()
+{
+    const MStatus status = MGlobal::deleteNode(_setObj);
+    _setObj = MObject();
+    return status == MS::kSuccess;
+}
+
+bool CreateSetUndoItem::redo()
+{
+    MSelectionList selList;
+    MStatus        status = MS::kSuccess;
+    MFnSet         setFn;
+    _setObj = setFn.create(selList, MFnSet::kNone, &status);
+    if (status == MS::kSuccess)
+        setFn.setName(_setName, &status);
+    return status == MS::kSuccess;
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/undo/OpUndoItems.cpp
+++ b/lib/mayaUsd/undo/OpUndoItems.cpp
@@ -35,7 +35,7 @@ MStringArray getDagName(const MObject& node)
 
     MSelectionList sel;
     sel.add(node);
-    MStatus status = sel.getSelectionStrings(strings);
+    sel.getSelectionStrings(strings);
 
     return strings;
 }
@@ -69,13 +69,9 @@ MStatus NodeDeletionUndoItem::deleteNode(
     auto item = std::make_unique<NodeDeletionUndoItem>(std::move(fullName));
 
     MStatus status = item->_modifier.commandToExecute(cmd);
-    // MStatus status = item->_modifier.deleteNode(node, false);
     if (status != MS::kSuccess)
         return status;
 
-    // Note: unfortunately, if this second call fails, we will be in a
-    // semi-deleted state, where one part succeeded and another failed...
-    // but this is how MDGModifier::deleteNode works, we can't avoid it.
     status = item->_modifier.doIt();
     if (status != MS::kSuccess)
         return status;

--- a/lib/mayaUsd/undo/OpUndoItems.h
+++ b/lib/mayaUsd/undo/OpUndoItems.h
@@ -1,0 +1,419 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_UNDO_OP_UNDO_ITEMS_H
+#define MAYAUSD_UNDO_OP_UNDO_ITEMS_H
+
+#include "OpUndoInfo.h"
+
+#include <mayaUsd/undo/UsdUndoableItem.h>
+
+#include <maya/MDGModifier.h>
+#include <maya/MDagModifier.h>
+#include <maya/MDagPath.h>
+#include <maya/MFnSet.h>
+#include <maya/MGlobal.h>
+#include <maya/MSelectionList.h>
+
+#include <memory>
+#include <vector>
+
+namespace MAYAUSD_NS_DEF {
+
+//------------------------------------------------------------------------------
+// NodeDeletionUndoItem
+//------------------------------------------------------------------------------
+
+/// \class NodeDeletionUndoItem
+/// \brief Record data needed to undo or redo a Maya DG sub-operation.
+///
+/// For node deletion, use the specialized undo item that tracks which objects
+/// have already been deleted and avoid double-deletions.
+class NodeDeletionUndoItem : public OpUndoItem
+{
+public:
+    /// \brief delete a node.
+    MAYAUSD_CORE_PUBLIC
+    static MStatus deleteNode(const std::string name, const MString& nodeName, const MObject& node, OpUndoInfo& undoInfo);
+
+    /// \brief construct a Maya DG modifier recorder.
+    MAYAUSD_CORE_PUBLIC
+    NodeDeletionUndoItem(std::string name)
+        : OpUndoItem(std::move(name))
+    {
+    }
+
+    MAYAUSD_CORE_PUBLIC
+    ~NodeDeletionUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+private:
+    MDGModifier _modifier;
+};
+
+//------------------------------------------------------------------------------
+// MDagModifierUndoItem
+//------------------------------------------------------------------------------
+
+/// \class MDagModifierUndoItem
+/// \brief Record data needed to undo or redo a Maya DAG sub-operation.///
+///
+/// For node deletion, use the specialized NodeDeletionUndoItem that tracks
+/// which objects have already been deleted and avoid double-deletions.
+class MDagModifierUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create a Maya DAG modifier recorder and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static MDagModifier& create(const std::string name, OpUndoInfo& undoInfo);
+
+    /// \brief construct a Maya DAG modifier recorder.
+    MAYAUSD_CORE_PUBLIC
+    MDagModifierUndoItem(std::string name)
+        : OpUndoItem(std::move(name))
+    {
+    }
+
+    MAYAUSD_CORE_PUBLIC
+    ~MDagModifierUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+    /// \brief gets the DAG modifier.
+    MAYAUSD_CORE_PUBLIC
+    MDagModifier& getModifier() { return _modifier; }
+
+private:
+    MDagModifier _modifier;
+};
+
+//------------------------------------------------------------------------------
+// MDGModifierUndoItem
+//------------------------------------------------------------------------------
+
+/// \class MDGModifierUndoItem
+/// \brief Record data needed to undo or redo a Maya DG sub-operation.
+///
+/// For node deletion, use the specialized NodeDeletionUndoItem that tracks
+/// which objects have already been deleted and avoid double-deletions.
+class MDGModifierUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create a Maya DG modifier recorder and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static MDGModifier& create(const std::string name, OpUndoInfo& undoInfo);
+
+    /// \brief construct a Maya DG modifier recorder.
+    MAYAUSD_CORE_PUBLIC
+    MDGModifierUndoItem(std::string name)
+        : OpUndoItem(std::move(name))
+    {
+    }
+
+    MAYAUSD_CORE_PUBLIC
+    ~MDGModifierUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+    /// \brief gets the DG modifier.
+    MAYAUSD_CORE_PUBLIC
+    MDGModifier& getModifier() { return _modifier; }
+
+private:
+    MDGModifier _modifier;
+};
+
+//------------------------------------------------------------------------------
+// UsdUndoableItemUndoItem
+//------------------------------------------------------------------------------
+
+/// \class UsdUndoableItemUndoItem
+/// \brief Record data needed to undo or redo USD sub-operations.
+class UsdUndoableItemUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create a USD undo item recorder and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static MAYAUSD_NS::UsdUndoableItem& create(const std::string name, OpUndoInfo& undoInfo);
+
+    /// \brief construct a USD undo item recorder.
+    MAYAUSD_CORE_PUBLIC
+    UsdUndoableItemUndoItem(std::string name)
+        : OpUndoItem(std::move(name))
+    {
+    }
+
+    MAYAUSD_CORE_PUBLIC
+    ~UsdUndoableItemUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+    /// \brief gets the DG modifier.
+    MAYAUSD_CORE_PUBLIC
+    MAYAUSD_NS::UsdUndoableItem& getUndoableItem() { return _item; }
+
+private:
+    MAYAUSD_NS::UsdUndoableItem _item;
+};
+
+//------------------------------------------------------------------------------
+// PythonUndoItem
+//------------------------------------------------------------------------------
+
+/// \class PythonUndoItem
+/// \brief Record data needed to undo or redo python sub-operations.
+class PythonUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create and execute python and and how to undo it and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static void
+    execute(const std::string name, MString pythonDo, MString pythonUndo, OpUndoInfo& undoInfo);
+
+    /// \brief create a python undo item.
+    MAYAUSD_CORE_PUBLIC
+    PythonUndoItem(const std::string name, MString pythonDo, MString pythonUndo);
+
+    MAYAUSD_CORE_PUBLIC
+    ~PythonUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+private:
+    MString _pythonDo;
+    MString _pythonUndo;
+};
+
+//------------------------------------------------------------------------------
+// FunctionUndoItem
+//------------------------------------------------------------------------------
+
+/// \class FunctionUndoItem
+/// \brief Record data needed to undo or redo generic functions sub-operations.
+class FunctionUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create but do *not* execute functions and keep track of it.
+    ///        Useful if the item execution has already been done.
+    MAYAUSD_CORE_PUBLIC
+    static void create(
+        const std::string     name,
+        std::function<bool()> redo,
+        std::function<bool()> undo,
+        OpUndoInfo&           undoInfo);
+
+    /// \brief create and execute functions and how to undo it and keep track of it.
+    ///        Useful if the item execution has *not* already been done but must done now.
+    MAYAUSD_CORE_PUBLIC
+    static void execute(
+        const std::string     name,
+        std::function<bool()> redo,
+        std::function<bool()> undo,
+        OpUndoInfo&           undoInfo);
+
+    /// \brief create a function undo item.
+    MAYAUSD_CORE_PUBLIC
+    FunctionUndoItem(
+        const std::string     name,
+        std::function<bool()> redo,
+        std::function<bool()> undo);
+
+    MAYAUSD_CORE_PUBLIC
+    ~FunctionUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+private:
+    std::function<bool()> _redo;
+    std::function<bool()> _undo;
+};
+
+//------------------------------------------------------------------------------
+// SelectionUndoItem
+//------------------------------------------------------------------------------
+
+/// \class SelectionUndoItem
+/// \brief Record data needed to undo or redo select nodes sub-operations.
+class SelectionUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create and execute a select node undo item and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static void select(
+        const std::string       name,
+        const MSelectionList&   selection,
+        MGlobal::ListAdjustment selMode,
+        OpUndoInfo&             undoInfo);
+
+    /// \brief create and execute a select node undo item and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static void select(
+        const std::string       name,
+        const MDagPath&         dagPath,
+        MGlobal::ListAdjustment selMode,
+        OpUndoInfo&             undoInfo);
+
+    /// \brief create and execute a select node undo item and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static void
+    select(const std::string name, const MSelectionList& selection, OpUndoInfo& undoInfo)
+    {
+        SelectionUndoItem::select(name, selection, MGlobal::kReplaceList, undoInfo);
+    }
+
+    /// \brief create and execute a select node undo item and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static void select(const std::string name, const MDagPath& dagPath, OpUndoInfo& undoInfo)
+    {
+        SelectionUndoItem::select(name, dagPath, MGlobal::kReplaceList, undoInfo);
+    }
+
+    MAYAUSD_CORE_PUBLIC
+    SelectionUndoItem(
+        const std::string       name,
+        const MSelectionList&   selection,
+        MGlobal::ListAdjustment selMode);
+
+    MAYAUSD_CORE_PUBLIC
+    ~SelectionUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+private:
+    MSelectionList          _selection;
+    MSelectionList          _previousSelection;
+    MGlobal::ListAdjustment _selMode;
+};
+
+//------------------------------------------------------------------------------
+// LockNodesUndoItem
+//------------------------------------------------------------------------------
+
+/// \class LockNodesUndoItem
+/// \brief Record data needed to undo or redo lock or unlock nodes sub-operations.
+class LockNodesUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create and execute a lock node undo item and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static void lock(const std::string name, const MDagPath& root, bool lock, OpUndoInfo& undoInfo);
+
+    MAYAUSD_CORE_PUBLIC
+    LockNodesUndoItem(const std::string name, const MDagPath& root, bool lock);
+
+    MAYAUSD_CORE_PUBLIC
+    ~LockNodesUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+private:
+    MString _rootName;
+    bool    _lock;
+};
+
+//------------------------------------------------------------------------------
+// CreateSetUndoItem
+//------------------------------------------------------------------------------
+
+/// \class CreateSetUndoItem
+/// \brief Record data needed to undo or redo creation of a node set sub-operations.
+class CreateSetUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create and execute a set creation undo item and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static MObject create(const std::string name, const MString& setName, OpUndoInfo& undoInfo);
+
+    MAYAUSD_CORE_PUBLIC
+    CreateSetUndoItem(const std::string name, const MString& setName);
+
+    MAYAUSD_CORE_PUBLIC
+    ~CreateSetUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+    /// \brief gets the set object.
+    MAYAUSD_CORE_PUBLIC
+    MObject& getSetObject() { return _setObj; }
+
+private:
+    MString _setName;
+    MObject _setObj;
+};
+
+} // namespace MAYAUSD_NS_DEF
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+using OpUndoInfo = MAYAUSD_NS_DEF::OpUndoInfo;
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/lib/mayaUsd/undo/UsdUndoManager.h
+++ b/lib/mayaUsd/undo/UsdUndoManager.h
@@ -17,9 +17,9 @@
 #ifndef MAYAUSD_UNDO_UNDOMANAGER_H
 #define MAYAUSD_UNDO_UNDOMANAGER_H
 
-#include "UsdUndoableItem.h"
-
 #include <mayaUsd/base/api.h>
+#include <mayaUsd/undo/OpUndoInfo.h>
+#include <mayaUsd/undo/UsdUndoableItem.h>
 
 #include <pxr/usd/sdf/layer.h>
 
@@ -29,6 +29,8 @@
 PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace MAYAUSD_NS_DEF {
+
+class OpUndoInfoMuting;
 
 //! \brief Singleton class to manage layer states.
 /*!
@@ -55,10 +57,16 @@ public:
     // tracks layer states by spawning a new UsdUndoStateDelegate
     void trackLayerStates(const SdfLayerHandle& layer);
 
+    // Retrieve the operation undo info, used to record undo items.
+    // The undo info can later be extracted into a command to implement
+    // its undo and redo. See: OpUndoInfo::extract()
+    OpUndoInfo& getUndoInfo() { return _undoInfo; }
+
 private:
     friend class UsdUndoStateDelegate;
     friend class UsdUndoBlock;
     friend class UsdUndoableItem;
+    friend class OpUndoInfoMuting;
 
     UsdUndoManager() = default;
     ~UsdUndoManager() = default;
@@ -68,6 +76,7 @@ private:
 
 private:
     InvertFuncs _invertFuncs;
+    OpUndoInfo  _undoInfo;
 };
 
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -16,6 +16,8 @@
 #include "util.h"
 
 #include <mayaUsd/nodes/proxyShapeBase.h>
+#include <mayaUsd/undo/OpUndoItems.h>
+#include <mayaUsd/undo/UsdUndoManager.h>
 
 #include <maya/MAnimControl.h>
 #include <maya/MAnimUtil.h>
@@ -38,6 +40,7 @@
 #include <maya/MFnSingleIndexedComponent.h>
 #include <maya/MFnTypedAttribute.h>
 #include <maya/MGlobal.h>
+#include <maya/MItDag.h>
 #include <maya/MItDependencyGraph.h>
 #include <maya/MItDependencyNodes.h>
 #include <maya/MItMeshFaceVertex.h>
@@ -81,6 +84,8 @@
 #include <pxr/usd/sdf/tokens.h>
 #include <pxr/usd/usdGeom/mesh.h>
 #include <pxr/usd/usdGeom/metrics.h>
+
+using namespace MAYAUSD_NS_DEF;
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -202,10 +207,10 @@ MString UsdMayaUtil::GetUniqueNameOfDagNode(const MObject& node)
     return nodeName;
 }
 
-MStatus UsdMayaUtil::GetMObjectByName(const std::string& nodeName, MObject& mObj)
+MStatus UsdMayaUtil::GetMObjectByName(const MString& nodeName, MObject& mObj)
 {
     MSelectionList selectionList;
-    MStatus        status = selectionList.add(MString(nodeName.c_str()));
+    MStatus        status = selectionList.add(nodeName);
     if (status != MS::kSuccess) {
         return status;
     }
@@ -213,6 +218,11 @@ MStatus UsdMayaUtil::GetMObjectByName(const std::string& nodeName, MObject& mObj
     status = selectionList.getDependNode(0, mObj);
 
     return status;
+}
+
+MStatus UsdMayaUtil::GetMObjectByName(const std::string& nodeName, MObject& mObj)
+{
+    return GetMObjectByName(MString(nodeName.c_str()), mObj);
 }
 
 UsdStageRefPtr UsdMayaUtil::GetStageByProxyName(const std::string& proxyPath)
@@ -1234,8 +1244,9 @@ MPlug UsdMayaUtil::GetConnected(const MPlug& plug)
 
 void UsdMayaUtil::Connect(const MPlug& srcPlug, const MPlug& dstPlug, const bool clearDstPlug)
 {
-    MStatus     status;
-    MDGModifier dgMod;
+    MStatus      status;
+    auto&        undoInfo = UsdUndoManager::instance().getUndoInfo();
+    MDGModifier& dgMod = MDGModifierUndoItem::create("Generic plug connection", undoInfo);
 
     if (clearDstPlug) {
         MPlugArray plgCons;
@@ -2022,6 +2033,23 @@ std::string UsdMayaUtil::convert(const MString& str)
 MString UsdMayaUtil::convert(const std::string& str)
 {
     return MString(str.data(), static_cast<int>(str.size()));
+}
+
+std::vector<MDagPath> UsdMayaUtil::getDescendantsStartingWithChildren(const MDagPath& path)
+{
+    std::vector<MDagPath> descendants;
+    {
+        MItDag dagIt;
+        for (dagIt.reset(path); !dagIt.isDone(); dagIt.next()) {
+            MDagPath curDagPath;
+            dagIt.getPath(curDagPath);
+            descendants.emplace_back(curDagPath);
+        }
+    }
+
+    std::reverse(descendants.begin(), descendants.end());
+
+    return descendants;
 }
 
 MDagPath UsdMayaUtil::getDagPath(const MFnDependencyNode& depNodeFn, const bool reportError)

--- a/lib/mayaUsd/utils/util.h
+++ b/lib/mayaUsd/utils/util.h
@@ -181,6 +181,10 @@ MString GetUniqueNameOfDagNode(const MObject& node);
 MAYAUSD_CORE_PUBLIC
 MStatus GetMObjectByName(const std::string& nodeName, MObject& mObj);
 
+/// Gets the Maya MObject for the node named \p nodeName.
+MAYAUSD_CORE_PUBLIC
+MStatus GetMObjectByName(const MString& nodeName, MObject& mObj);
+
 /// Gets the UsdStage for the proxy shape  node named \p nodeName.
 MAYAUSD_CORE_PUBLIC
 UsdStageRefPtr GetStageByProxyName(const std::string& nodeName);
@@ -546,6 +550,11 @@ MString convert(const TfToken& token);
 
 MAYAUSD_CORE_PUBLIC
 std::string convert(const MString&);
+
+/// Retrieve all descendant nodes, including self, but starting from the most
+/// distant grand-children.
+MAYAUSD_CORE_PUBLIC
+std::vector<MDagPath> getDescendantsStartingWithChildren(const MDagPath& path);
 
 MAYAUSD_CORE_PUBLIC
 MDagPath getDagPath(const MFnDependencyNode& depNodeFn, const bool reportError = true);

--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -74,7 +74,7 @@ bool MayaSessionState::getStageEntry(StageEntry* out_stageEntry, const MString& 
     UsdPrim prim;
 
     MObject shapeObj;
-    MStatus status = UsdMayaUtil::GetMObjectByName(shapePath.asChar(), shapeObj);
+    MStatus status = UsdMayaUtil::GetMObjectByName(shapePath, shapeObj);
     CHECK_MSTATUS_AND_RETURN(status, false);
     MFnDagNode dagNode(shapeObj, &status);
     CHECK_MSTATUS_AND_RETURN(status, false);

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -35,7 +35,6 @@
 #include <mayaUsd/nodes/stageData.h>
 #include <mayaUsd/render/pxrUsdMayaGL/proxyShapeUI.h>
 #include <mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h>
-#include <mayaUsd/ufe/PullPushCommands.h>
 #include <mayaUsd/undo/UsdUndoBlock.h>
 #include <mayaUsd/utils/diagnosticDelegate.h>
 #include <mayaUsd/utils/undoHelperCommand.h>
@@ -74,6 +73,7 @@
 
 #ifdef UFE_V3_FEATURES_AVAILABLE
 #include <mayaUsd/fileio/primUpdaterManager.h>
+#include <mayaUsd/ufe/PullPushCommands.h>
 #endif
 
 #if defined(WANT_QT_BUILD)

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -35,6 +35,7 @@
 #include <mayaUsd/nodes/stageData.h>
 #include <mayaUsd/render/pxrUsdMayaGL/proxyShapeUI.h>
 #include <mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h>
+#include <mayaUsd/ufe/PullPushCommands.h>
 #include <mayaUsd/undo/UsdUndoBlock.h>
 #include <mayaUsd/utils/diagnosticDelegate.h>
 #include <mayaUsd/utils/undoHelperCommand.h>
@@ -222,6 +223,13 @@ MStatus initializePlugin(MObject obj)
     registerCommandCheck<MayaUsd::LayerEditorWindowCommand>(plugin);
 #endif
 
+#ifdef UFE_V3_FEATURES_AVAILABLE
+    registerCommandCheck<MayaUsd::ufe::EditAsMayaCommand>(plugin);
+    registerCommandCheck<MayaUsd::ufe::MergeToUsdCommand>(plugin);
+    registerCommandCheck<MayaUsd::ufe::DiscardEditsCommand>(plugin);
+    registerCommandCheck<MayaUsd::ufe::DuplicateCommand>(plugin);
+#endif
+
     status = plugin.registerCommand(
         MayaUsd::UsdUndoBlockCmd::commandName, MayaUsd::UsdUndoBlockCmd::creator);
     CHECK_MSTATUS(status);
@@ -385,6 +393,13 @@ MStatus uninitializePlugin(MObject obj)
 #if defined(WANT_QT_BUILD)
     deregisterCommandCheck<MayaUsd::LayerEditorWindowCommand>(plugin);
     MayaUsd::LayerEditorWindowCommand::cleanupOnPluginUnload();
+#endif
+
+#ifdef UFE_V3_FEATURES_AVAILABLE
+    deregisterCommandCheck<MayaUsd::ufe::EditAsMayaCommand>(plugin);
+    deregisterCommandCheck<MayaUsd::ufe::MergeToUsdCommand>(plugin);
+    deregisterCommandCheck<MayaUsd::ufe::DiscardEditsCommand>(plugin);
+    deregisterCommandCheck<MayaUsd::ufe::DuplicateCommand>(plugin);
 #endif
 
     status = plugin.deregisterNode(MayaUsd::ProxyShape::typeId);

--- a/plugin/adsk/scripts/USDMenuProc.mel
+++ b/plugin/adsk/scripts/USDMenuProc.mel
@@ -25,28 +25,6 @@ proc int canEditAsMaya(string $obj)
     return 0;
 }
 
-global proc mayaUsdMenu_pullToDG(string $obj)
-{
-    if (size($obj) == 0) {
-        string $nonMayaObjs[] = `python("import maya.internal.ufeSupport.utils as ufeUtils; ufeUtils.getNonMayaSelectedItems()")`;
-        $obj = $nonMayaObjs[0];
-    }
-    if (size($obj) != 0) {
-        python("from mayaUsd.lib import PrimUpdaterManager; import ufe; PrimUpdaterManager.editAsMaya('" + $obj + "');");
-    }
-}
-
-global proc mayaUsdMenu_duplicateToDG( string $ufePath )
-{
-    if (size($ufePath) == 0) {
-        string $nonMayaObjs[] = `python("import maya.internal.ufeSupport.utils as ufeUtils; ufeUtils.getNonMayaSelectedItems()")`;
-        $ufePath = $nonMayaObjs[0];
-    }
-    
-    if (size($ufePath)) {
-        python("from mayaUsd.lib import PrimUpdaterManager; import maya.cmds as cmds; PrimUpdaterManager.duplicate('" + $ufePath + "', '|world');");
-    }
-}
 global proc USDMenuProc(string $parent, string $obj)
 {
     int $haveNonMaya = `python("import maya.internal.ufeSupport.utils as ufeUtils; ufeUtils.hasNonMayaSelectedItems()")`;
@@ -57,8 +35,8 @@ global proc USDMenuProc(string $parent, string $obj)
 
         setParent -menu ..;
         if (canEditAsMaya($obj)) {
-            menuItem -label "Edit As Maya Data" -image "edit_as_Maya.png" -command ("mayaUsdMenu_pullToDG \"" + $obj + "\"");
+            menuItem -label "Edit As Maya Data" -image "edit_as_Maya.png" -command ("mayaUsdEditAsMaya \"" + $obj + "\"");
         }
-        menuItem -label "Duplicate As Maya Data" -command ("mayaUsdMenu_duplicateToDG \"" + $obj + "\"");
+        menuItem -label "Duplicate As Maya Data" -command ("mayaUsdDuplicateAsMaya \"" + $obj + "\"");
     }
 }

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -589,13 +589,8 @@ global proc mayaUsdMenu_pushBackToUSD(string $obj)
         }
     }
     if (size($obj)) {
-        python("from mayaUsd.lib import PrimUpdaterManager; PrimUpdaterManager.mergeToUsd('" + $obj + "');");
+        mayaUsdMergeToUsd $obj;
     }
-}
-
-global proc mayaUsdMenu_pushClear(string $obj)
-{
-    python("from mayaUsd.lib import PrimUpdaterManager; PrimUpdaterManager.discardEdits('" + $obj + "');");
 }
 
 global proc mayaUsdMenu_duplicateToUSD( string $proxy, string $obj )
@@ -609,7 +604,7 @@ global proc mayaUsdMenu_duplicateToUSD( string $proxy, string $obj )
     string $objLong[] = `ls -l $obj`;
     string $proxyLong[] = `ls -l $proxy`;
     if (size($objLong) && size($proxyLong)) {
-        python("from mayaUsd.lib import PrimUpdaterManager; import maya.cmds as cmds; PrimUpdaterManager.duplicate('" + $objLong[0] + "', '"+ $proxyLong[0] +"');");
+        mayaUsdDuplicate $objLong[0] $proxyLong[0];
     }
 }
 
@@ -617,7 +612,7 @@ global proc mayaUsdMenu_markingMenuCallback( string $obj )
 {
     if (isPulledUsdObject($obj)) {
         string $pushback = `menuItem -label "Merge Maya Edits to USD" -insertAfter "" -image "merge_to_USD.png" -command ("mayaUsdMenu_pushBackToUSD " + $obj)`;
-        string $pushclear = `menuItem -label "Discard Maya Edits" -insertAfter $pushback -image "discard_edits.png" -command ("mayaUsdMenu_pushClear " + $obj)`;
+        string $pushclear = `menuItem -label "Discard Maya Edits" -insertAfter $pushback -image "discard_edits.png" -command ("mayaUsdDiscardEdits " + $obj)`;
         menuItem -divider true -insertAfter $pushclear;
     }
     else {

--- a/plugin/pxr/maya/lib/usdMaya/readJob_ImportWithProxies.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/readJob_ImportWithProxies.cpp
@@ -20,6 +20,8 @@
 #include <mayaUsd/fileio/primReaderContext.h>
 #include <mayaUsd/fileio/primReaderRegistry.h>
 #include <mayaUsd/fileio/translators/translatorUtil.h>
+#include <mayaUsd/undo/OpUndoItems.h>
+#include <mayaUsd/undo/UsdUndoManager.h>
 #include <mayaUsd/utils/stageCache.h>
 
 #include <pxr/base/tf/staticTokens.h>
@@ -190,8 +192,8 @@ bool UsdMaya_ReadJobWithSceneAssembly::_ProcessProxyPrims(
         std::string excludePathsString = TfStringJoin(collapsePointPathStrings, ",");
 
         // Set the excludePrimPaths attribute on the node.
-        auto&         undoInfo = UsdUndoManager::instance().getUndoInfo();
-        MDagModifier& dagMod = MDagModifierUndoItem::create("Read job prim exclusion", undoInfo);
+        auto&         undoInfo = MAYAUSD_NS_DEF::UsdUndoManager::instance().getUndoInfo();
+        MDagModifier& dagMod = MAYAUSD_NS_DEF::MDagModifierUndoItem::create("Read job prim exclusion", undoInfo);
         MPlug         excludePathsPlug
             = depNodeFn.findPlug(_tokens->ExcludePrimPathsPlugName.GetText(), true, &status);
         CHECK_MSTATUS_AND_RETURN(status, false);

--- a/plugin/pxr/maya/lib/usdMaya/readJob_ImportWithProxies.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/readJob_ImportWithProxies.cpp
@@ -190,8 +190,9 @@ bool UsdMaya_ReadJobWithSceneAssembly::_ProcessProxyPrims(
         std::string excludePathsString = TfStringJoin(collapsePointPathStrings, ",");
 
         // Set the excludePrimPaths attribute on the node.
-        MDagModifier dagMod;
-        MPlug        excludePathsPlug
+        auto&         undoInfo = UsdUndoManager::instance().getUndoInfo();
+        MDagModifier& dagMod = MDagModifierUndoItem::create("Read job prim exclusion", undoInfo);
+        MPlug         excludePathsPlug
             = depNodeFn.findPlug(_tokens->ExcludePrimPathsPlugName.GetText(), true, &status);
         CHECK_MSTATUS_AND_RETURN(status, false);
         status = dagMod.newPlugValueString(excludePathsPlug, excludePathsString.c_str());

--- a/plugin/pxr/maya/lib/usdMaya/translatorModelAssembly.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/translatorModelAssembly.cpp
@@ -374,6 +374,8 @@ bool UsdMayaTranslatorModelAssembly::Read(
     // opposed to using MDagModifier's createNode() or any other method. That
     // seems to be the only way to ensure that the assembly's namespace and
     // container are setup correctly.
+    //
+    // TODO UNDO: how to recording this in an OpUndoItem?
     const std::string assemblyCmd = TfStringPrintf(
         "import maya.cmds; maya.cmds.assembly(name=\'%s\', type=\'%s\')",
         prim.GetName().GetText(),
@@ -388,7 +390,7 @@ bool UsdMayaTranslatorModelAssembly::Read(
     CHECK_MSTATUS_AND_RETURN(status, false);
 
     // Re-parent the assembly node underneath parentNode.
-    MDagModifier dagMod;
+    MDagModifier& dagMod = MDagModifierUndoItem::create("Assembly reparenting", context->GetUndoInfo())();
     status = dagMod.reparentNode(assemblyObj, parentNode);
     CHECK_MSTATUS_AND_RETURN(status, false);
 
@@ -499,7 +501,7 @@ bool UsdMayaTranslatorModelAssembly::ReadAsProxy(
     }
 
     // Create the proxy shape node.
-    MDagModifier dagMod;
+    MDagModifier& dagMod = MDagModifierUndoItem::create("Proxy shape creation", context->GetUndoInfo())();
     MObject      proxyObj
         = dagMod.createNode(UsdMayaProxyShapeTokens->MayaTypeName.GetText(), transformObj, &status);
     CHECK_MSTATUS_AND_RETURN(status, false);

--- a/test/lib/mayaUsd/fileio/testDiscardEdits.py
+++ b/test/lib/mayaUsd/fileio/testDiscardEdits.py
@@ -102,5 +102,54 @@ class MergeToUsdTestCase(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             om.MSelectionList().add(aMayaPathStr)
 
+    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '3006', 'Test only available in UFE preview version 0.3.6 and greater')
+    def testDiscardEditsUndoRedo(self):
+        '''Discard edits on a USD transform then undo and redo.'''
+
+        # Edit as Maya first.
+        (ps, xlateOp, usdXlation, aUsdUfePathStr, aUsdUfePath, aUsdItem,
+         _, _, _, _, _) = createSimpleXformScene()
+
+        cmds.mayaUsdEditAsMaya(aUsdUfePathStr)
+
+        # Modify the scene.
+        aMayaItem = ufe.GlobalSelection.get().front()
+        mayaXlation = om.MVector(4, 5, 6)
+        (aMayaPath, aMayaPathStr, aFn, mayaMatrix) = \
+            setMayaTranslation(aMayaItem, mayaXlation)
+
+        # Verify the scene modifications.
+        def verifyScenesModifications():
+            self.assertEqual(aFn.translation(om.MSpace.kObject), mayaXlation)
+            mayaToUsd = ufe.PathMappingHandler.pathMappingHandler(aMayaItem)
+            self.assertEqual(mayaToUsd.fromHost(aMayaPath), aUsdUfePath)
+
+        verifyScenesModifications()
+
+        # Discard Maya edits.
+        cmds.mayaUsdDiscardEdits(aMayaPathStr)
+
+        def verifyDiscard():
+            # Original USD translation values are preserved.
+            usdMatrix = xlateOp.GetOpTransform(mayaUsd.ufe.getTime(aUsdUfePathStr))
+            self.assertEqual(usdMatrix.ExtractTranslation(), usdXlation)
+
+            # Maya node is removed.
+            with self.assertRaises(RuntimeError):
+                om.MSelectionList().add(aMayaPathStr)
+
+        verifyDiscard()
+
+        # undo
+        cmds.undo()
+
+        verifyScenesModifications()
+
+        # redo
+        cmds.redo()
+
+        verifyDiscard()
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/mayaUsd/fileio/testDuplicateAs.py
+++ b/test/lib/mayaUsd/fileio/testDuplicateAs.py
@@ -85,6 +85,45 @@ class DuplicateAsTestCase(unittest.TestCase):
         self.assertEqual(cmds.getAttr(bMayaPathStr + '.translate')[0],
                          bXlation)
 
+    def testDuplicateAsMayaUndoRedo(self):
+        '''Duplicate a USD transform hierarchy to Maya and then undo and redo the command.'''
+
+        (_, _, aXlation, aUsdUfePathStr, aUsdUfePath, _, _, 
+               bXlation, bUsdUfePathStr, bUsdUfePath, _) = \
+            createSimpleXformScene()
+
+        # Duplicate USD data as Maya data, placing it under the root.
+        cmds.mayaUsdDuplicate(aUsdUfePathStr, '|world')
+
+        def verifyDuplicate():
+            # Should now have two transform nodes in the Maya scene: the path
+            # components in the second segment of the aUsdItem and bUsdItem will
+            # now be under the Maya world.
+            aMayaPathStr = str(aUsdUfePath.segments[1]).replace('/', '|')
+            bMayaPathStr = str(bUsdUfePath.segments[1]).replace('/', '|')
+            self.assertEqual(cmds.ls(aMayaPathStr, long=True)[0], aMayaPathStr)
+            self.assertEqual(cmds.ls(bMayaPathStr, long=True)[0], bMayaPathStr)
+
+            # Translation should have been copied over to the Maya data model.
+            self.assertEqual(cmds.getAttr(aMayaPathStr + '.translate')[0],
+                            aXlation)
+            self.assertEqual(cmds.getAttr(bMayaPathStr + '.translate')[0],
+                            bXlation)
+
+        verifyDuplicate()
+
+        cmds.undo()
+
+        def verifyDuplicateIsGone():
+            bMayaPathStr = str(bUsdUfePath.segments[1]).replace('/', '|')
+            self.assertListEqual(cmds.ls(bMayaPathStr, long=True), [])
+
+        verifyDuplicateIsGone()
+
+        cmds.redo()
+
+        verifyDuplicate()
+
     def testDuplicateAsUsd(self):
         '''Duplicate a Maya transform hierarchy to USD.'''
 
@@ -126,6 +165,65 @@ class DuplicateAsTestCase(unittest.TestCase):
         usdGroup2T3d = ufe.Transform3d.transform3d(usdGroup2)
         self.assertEqual([1, 2, 3], usdGroup1T3d.translation().vector)
         self.assertEqual([-4, -5, -6], usdGroup2T3d.translation().vector)
+
+    def testDuplicateAsUsdUndoRedo(self):
+        '''Duplicate a Maya transform hierarchy to USD and then undo and redo the command.'''
+
+        # Create a hierarchy.  Because group1 is selected upon creation, group2
+        # will be its parent.
+        group1 = cmds.createNode('transform')
+        group2 = cmds.group()
+        self.assertEqual(cmds.listRelatives(group1, parent=True)[0], group2)
+
+        cmds.setAttr(group1 + '.translate', 1, 2, 3)
+        cmds.setAttr(group2 + '.translate', -4, -5, -6)
+
+        # Create a stage to receive the USD duplicate.
+        psPathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        
+        # Duplicate Maya data as USD data.  As of 17-Nov-2021 no single-segment
+        # path handler registered to UFE for Maya path strings, so use absolute
+        # path.
+        cmds.mayaUsdDuplicate(cmds.ls(group2, long=True)[0], psPathStr)
+
+        def verifyDuplicate():
+            # Maya hierarchy should be duplicated in USD.
+            usdGroup2PathStr = psPathStr + ',/' + group2
+            usdGroup1PathStr = usdGroup2PathStr + '/' + group1
+            usdGroup2Path = ufe.PathString.path(usdGroup2PathStr)
+            usdGroup1Path = ufe.PathString.path(usdGroup1PathStr)
+
+            # group1 is the child of group2
+            usdGroup1 = ufe.Hierarchy.createItem(usdGroup1Path)
+            usdGroup2 = ufe.Hierarchy.createItem(usdGroup2Path)
+            usdGroup1Hier = ufe.Hierarchy.hierarchy(usdGroup1)
+            usdGroup2Hier = ufe.Hierarchy.hierarchy(usdGroup2)
+            self.assertEqual(usdGroup2, usdGroup1Hier.parent())
+            self.assertEqual(len(usdGroup2Hier.children()), 1)
+            self.assertEqual(usdGroup1, usdGroup2Hier.children()[0])
+
+            # Translations have been preserved.
+            usdGroup1T3d = ufe.Transform3d.transform3d(usdGroup1)
+            usdGroup2T3d = ufe.Transform3d.transform3d(usdGroup2)
+            self.assertEqual([1, 2, 3], usdGroup1T3d.translation().vector)
+            self.assertEqual([-4, -5, -6], usdGroup2T3d.translation().vector)
+
+        verifyDuplicate()
+
+        cmds.undo()
+
+        def verifyDuplicateIsGone():
+            # Maya hierarchy should no longer be duplicated in USD.
+            usdGroup2PathStr = psPathStr + ',/' + group2
+            usdGroup2Path = ufe.PathString.path(usdGroup2PathStr)
+            usdGroup2 = ufe.Hierarchy.createItem(usdGroup2Path)
+            self.assertIsNone(usdGroup2)
+
+        verifyDuplicateIsGone()
+
+        cmds.redo()
+
+        verifyDuplicate()
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/mayaUsd/fileio/testEditAsMaya.py
+++ b/test/lib/mayaUsd/fileio/testEditAsMaya.py
@@ -111,6 +111,73 @@ class EditAsMayaTestCase(unittest.TestCase):
         assertVectorAlmostEqual(self, mayaValues, usdValues)
 
     @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '3006', 'Test only available in UFE preview version 0.3.6 and greater')
+    def testEditAsMayaUndoRedo(self):
+        '''Edit a USD transform as a Maya object and apply undo and redo.'''
+
+        (ps, xlateOp, xlation, aUsdUfePathStr, aUsdUfePath, aUsdItem,
+         _, _, _, _, _) = createSimpleXformScene()
+
+        # Edit aPrim as Maya data.
+        self.assertTrue(mayaUsd.lib.PrimUpdaterManager.canEditAsMaya(aUsdUfePathStr))
+
+        cmds.mayaUsdEditAsMaya(aUsdUfePathStr)
+
+        def getMayaPathStr():
+            aMayaItem = ufe.GlobalSelection.get().front()
+            mayaToUsd = ufe.PathMappingHandler.pathMappingHandler(aMayaItem)
+            aMayaPath = aMayaItem.path()
+            aMayaPathStr = ufe.PathString.string(aMayaPath)
+            return aMayaPathStr
+
+        aMayaPathStr = getMayaPathStr()
+
+        def verifyEditedScene():
+            aMayaItem = ufe.GlobalSelection.get().front()
+            mayaToUsd = ufe.PathMappingHandler.pathMappingHandler(aMayaItem)
+            aMayaPath = aMayaItem.path()
+            aMayaPathStr = ufe.PathString.string(aMayaPath)
+
+            # Confirm the hierarchy is preserved through the Hierarchy interface:
+            # one child, the parent of the pulled item is the proxy shape, and
+            # the proxy shape has the pulled item as a child, not the original USD
+            # scene item.
+            aMayaHier = ufe.Hierarchy.hierarchy(aMayaItem)
+            self.assertEqual(len(aMayaHier.children()), 1)
+            self.assertEqual(ps, aMayaHier.parent())
+            psHier = ufe.Hierarchy.hierarchy(ps)
+            self.assertIn(aMayaItem, psHier.children())
+            self.assertNotIn(aUsdItem, psHier.children())
+
+            # Confirm the translation has been transferred, and that the local
+            # transformation is only a translation.
+            aDagPath = om.MSelectionList().add(ufe.PathString.string(aMayaPath)).getDagPath(0)
+            aFn= om.MFnTransform(aDagPath)
+            self.assertEqual(aFn.translation(om.MSpace.kObject), om.MVector(*xlation))
+            mayaMatrix = aFn.transformation().asMatrix()
+            usdMatrix = xlateOp.GetOpTransform(mayaUsd.ufe.getTime(aUsdUfePathStr))
+            mayaValues = [v for v in mayaMatrix]
+            usdValues = [v for row in usdMatrix for v in row]
+
+            assertVectorAlmostEqual(self, mayaValues, usdValues)
+
+        verifyEditedScene()
+
+        # Undo
+        cmds.undo()
+
+        def verifyNoLongerEdited():
+            # Maya node is removed.
+            with self.assertRaises(RuntimeError):
+                om.MSelectionList().add(aMayaPathStr)
+
+        verifyNoLongerEdited()
+        
+        # Redo
+        cmds.redo()
+
+        verifyEditedScene()
+
+    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '3006', 'Test only available in UFE preview version 0.3.6 and greater')
     def testIllegalEditAsMaya(self):
         '''Trying to edit as Maya on object that doesn't support it.'''
         


### PR DESCRIPTION
Add undo / redo to Edit-as-Maya workflows.

Create commands:
- Add mayaUsdEditAsMaya command for edit as Maya.
- Add mayaUsdDuplicate command for duplicate as Maya and duplicate to USD.
- Add mayaUsdDiscardEdits command for discarding edits.
- Add mayaUsdMergeToUsd command to merge back to USD.
- This makes it easy to script and support undo/redo.
- Remove the old mel script for pull/push/discards/duplicate, replace them with these commands.
- Add unit tests for all new commands.

Create system to record undo items:
- Add OpUndoInfo to record all undoable steps for each commands.
- Add an instance to UsdUndoManager singleton to record undo items from anywhere.
- Add OpUndoItem to record a single undoable sub-operation step.
- Add OpUndoInfoMuting to muting recording undo items in block of code that handles undo differently.
- Add OpUndoInfoRecorder to automatically record all undo items in a block of scoped code.

Provide undo items for many common scenarios:
- Implement OpUndoItem for USD undo block (UsdUndoBlock / UsdUndoItem).
- Implement OpUndoItem for MDagModifier.
- Implement OpUndoItem for MDGModifier.
- Implement OpUndoItem for selection.
- Implement OpUndoItem for locking nodes.
- Implement OpUndoItem for pair of Python do/undo scripts.
- Implement OpUndoItem for any generic pair of do/undo C++ functions.

Various code adjustments:
- Remove the cached pull root from PrimUpdaterManager since it was interfering with undo/redo.
- Retrieving it for each command is not costly and avoid needing us to clear it.
- Use undo info muting in read job (import) class since it implements its own undo / redo.