### PR TITLE
MAYA-114247 Mark everything dirty when display modes change.

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -74,7 +74,7 @@ struct MayaPrimCommon
         DirtySelectionMode = (DirtySelectionHighlight << 1),
         // Maya's display mode has changed, for example for shaded to wireframe
         DirtyDisplayMode = (DirtySelectionMode << 1),
-        DirtyBitLast = DirtySelectionMode
+        DirtyBitLast = DirtyDisplayMode
     };
 };
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -67,9 +67,13 @@ struct MayaPrimCommon
 {
     enum DirtyBits : HdDirtyBits
     {
+        // The rprim has been added, removed or otherwise changed such that the selection highlight
+        // for the item is dirty
         DirtySelectionHighlight = HdChangeTracker::CustomBitsBegin,
+        // Maya's selection mode has changed, for example into point snapping mode
         DirtySelectionMode = (DirtySelectionHighlight << 1),
-        DirtyDisplayMode = (DirtySelectHighlight << 1),
+        // Maya's display mode has changed, for example for shaded to wireframe
+        DirtyDisplayMode = (DirtySelectionMode << 1),
         DirtyBitLast = DirtySelectionMode
     };
 };

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -69,6 +69,7 @@ struct MayaPrimCommon
     {
         DirtySelectionHighlight = HdChangeTracker::CustomBitsBegin,
         DirtySelectionMode = (DirtySelectionHighlight << 1),
+        DirtyDisplayMode = (DirtySelectHighlight << 1),
         DirtyBitLast = DirtySelectionMode
     };
 };

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -825,20 +825,22 @@ void ProxyRenderDelegate::_Execute(const MHWRender::MFrameContext& frameContext)
         }
     }
 
-    if (_defaultCollection->GetReprSelector() != reprSelector) {
-        _defaultCollection->SetReprSelector(reprSelector);
-        _taskController->SetCollection(*_defaultCollection);
-
-        // Mark everything "dirty" so that sync is called on everything
-        auto&            rprims = _renderIndex->GetRprimIds();
-        HdChangeTracker& changeTracker = _renderIndex->GetChangeTracker();
-        for (auto path : rprims) {
-            changeTracker.MarkRprimDirty(path, MayaPrimCommon::DirtyDisplayMode);
-        }
-    }
-
     // if there are no repr's to update then don't even call sync.
     if (reprSelector != HdReprSelector()) {
+        if (_defaultCollection->GetReprSelector() != reprSelector) {
+            _defaultCollection->SetReprSelector(reprSelector);
+            _taskController->SetCollection(*_defaultCollection);
+
+            // Mark everything "dirty" so that sync is called on everything
+            // If there are multiple views up with different viewport modes then
+            // this is slow.
+            auto&            rprims = _renderIndex->GetRprimIds();
+            HdChangeTracker& changeTracker = _renderIndex->GetChangeTracker();
+            for (auto path : rprims) {
+                changeTracker.MarkRprimDirty(path, MayaPrimCommon::DirtyDisplayMode);
+            }
+        }
+
         _engine.Execute(_renderIndex.get(), &_dummyTasks);
     }
 }

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -828,6 +828,13 @@ void ProxyRenderDelegate::_Execute(const MHWRender::MFrameContext& frameContext)
     if (_defaultCollection->GetReprSelector() != reprSelector) {
         _defaultCollection->SetReprSelector(reprSelector);
         _taskController->SetCollection(*_defaultCollection);
+
+        // Mark everything "dirty" so that sync is called on everything
+        auto& rprims = _renderIndex->GetRprimIds();
+        HdChangeTracker& changeTracker = _renderIndex->GetChangeTracker();
+        for (auto path : rprims) {
+            changeTracker.MarkRprimDirty(path, MayaPrimCommon::DirtyDisplayMode);
+        }
     }
 
     // if there are no repr's to update then don't even call sync.

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -1272,7 +1272,7 @@ void ProxyRenderDelegate::_UpdateSelectionStates()
 
         // now that the appropriate prims have been marked dirty trigger
         // a sync so that they all update.
-        HdRprimCollection collection(HdTokens->geometry, kSmoothHullReprSelector);
+        HdRprimCollection collection(HdTokens->geometry, _defaultCollection->GetReprSelector());
         collection.SetRootPaths(rootPaths);
         _taskController->SetCollection(collection);
         _engine.Execute(_renderIndex.get(), &_dummyTasks);

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -830,7 +830,7 @@ void ProxyRenderDelegate::_Execute(const MHWRender::MFrameContext& frameContext)
         _taskController->SetCollection(*_defaultCollection);
 
         // Mark everything "dirty" so that sync is called on everything
-        auto& rprims = _renderIndex->GetRprimIds();
+        auto&            rprims = _renderIndex->GetRprimIds();
         HdChangeTracker& changeTracker = _renderIndex->GetChangeTracker();
         for (auto path : rprims) {
             changeTracker.MarkRprimDirty(path, MayaPrimCommon::DirtyDisplayMode);


### PR DESCRIPTION
This fixes the issue Grace found with https://github.com/Autodesk/maya-usd/issues/1752.

MayaUSD skips updating render items whose repr is not currently in use, instead saving dirty bits about the unused items so that when they are used they can be correctly updating. With the update to USD 21.11 we're not getting a sync call for these rprims which have some dirty reprs. We clean all the dirty bits off the rprim, so it makes sense that USD skips syncing them.

I don't want to leave the rprims dirty, because then we'll have to call sync on them every frame. Instead, when the reprs in use change mark every rprim "dirty" with a flag that will cause sync to be called, but which won't trigger any actual work to occur. This way any dirty reprs get a chance to update themselves.