### PR TITLE
Add support for float and double types to the converter (and proxy accessor)

### DIFF
--- a/lib/mayaUsd/utils/converter.cpp
+++ b/lib/mayaUsd/utils/converter.cpp
@@ -37,6 +37,8 @@
 |:-----------------|:----------------------|:---------------------------------------------------------------|:------------------------|:-------------------|
 | Bool             | bool                  | MFnNumericData::kBoolean                                       | bool                    | MakeMayaSimpleData |
 | Int              | int                   | MFnNumericData::kInt                                           | int                     | MakeMayaSimpleData |
+| Float            | float                 | MFnNumericData::kFloat                                         | float                   | MakeMayaSimpleData |
+| Double           | double                | MFnNumericData::kDouble                                        | double                  | MakeMayaSimpleData |
 ||
 | String           | std::string           | MFnData::kString, MFn::kStringData                             | MString, MFnStringData  | MakeMayaFnData     |
 ||
@@ -187,6 +189,46 @@ template <> struct MakeMayaSimpleData<int> : public std::true_type
     static void set(const MPlug& plug, MDGModifier& dst, const Type& value)
     {
         dst.newPlugValueInt(plug, value);
+    }
+};
+
+//! \brief  Type trait for Maya's float type providing get and set methods for data handle and
+//! plugs.
+template <> struct MakeMayaSimpleData<float> : public std::true_type
+{
+    using Type = float;
+    enum
+    {
+        kNumericType = MFnNumericData::kFloat
+    };
+
+    static void get(const MDataHandle& handle, Type& value) { value = handle.asFloat(); }
+
+    static void set(MDataHandle& handle, const Type& value) { handle.setFloat(value); }
+
+    static void set(const MPlug& plug, MDGModifier& dst, const Type& value)
+    {
+        dst.newPlugValueFloat(plug, value);
+    }
+};
+
+//! \brief  Type trait for Maya's double type providing get and set methods for data handle and
+//! plugs.
+template <> struct MakeMayaSimpleData<double> : public std::true_type
+{
+    using Type = double;
+    enum
+    {
+        kNumericType = MFnNumericData::kDouble
+    };
+
+    static void get(const MDataHandle& handle, Type& value) { value = handle.asDouble(); }
+
+    static void set(MDataHandle& handle, const Type& value) { handle.setDouble(value); }
+
+    static void set(const MPlug& plug, MDGModifier& dst, const Type& value)
+    {
+        dst.newPlugValueDouble(plug, value);
     }
 };
 
@@ -1008,6 +1050,8 @@ struct Converter::GenerateConverters
 
         createConverter<bool, bool>(converters, SdfValueTypeNames->Bool);
         createConverter<int, int32_t>(converters, SdfValueTypeNames->Int);
+        createConverter<float, float>(converters, SdfValueTypeNames->Float);
+        createConverter<double, double>(converters, SdfValueTypeNames->Double);
 
         createConverter<MString, std::string>(converters, SdfValueTypeNames->String);
         createConverter<float3, GfVec3f>(converters, SdfValueTypeNames->Float3);

--- a/test/lib/testMayaUsdConverter.py
+++ b/test/lib/testMayaUsdConverter.py
@@ -66,7 +66,7 @@ class MayaUsdConverterTestCase(unittest.TestCase):
     
     def runTypeChecks(self, sdfValueType, value1, value2):
         """
-        Test for Sdf.ValueTypeNames.Bool type, veryfing:
+        Test for Sdf.ValueTypeNames.XXX type, veryfing:
         - we can find the converter of given sdf type name
         - we can find the converter with a pair of maya plug and usd attribute
         - we can convert vtvalue --> maya plug (value1)
@@ -149,6 +149,32 @@ class MayaUsdConverterTestCase(unittest.TestCase):
         value1 = Vt.Bool(True)
         value2 = Vt.Bool(False)
         sdfValueType = Sdf.ValueTypeNames.Bool
+        errSdfValueType = Sdf.ValueTypeNames.String
+        #
+        self.runTypeChecks(sdfValueType,value1,value2)
+        self.runErrorHandlingChecks(sdfValueType,value1,errSdfValueType)
+
+    def testFloatConverter(self):
+        """
+        Test for Sdf.ValueTypeNames.Float
+        """
+        #
+        value1 = Vt.Float(3.14)
+        value2 = Vt.Float(9.98)
+        sdfValueType = Sdf.ValueTypeNames.Float
+        errSdfValueType = Sdf.ValueTypeNames.String
+        #
+        self.runTypeChecks(sdfValueType,value1,value2)
+        self.runErrorHandlingChecks(sdfValueType,value1,errSdfValueType)
+
+    def testDoubleConverter(self):
+        """
+        Test for Sdf.ValueTypeNames.Double
+        """
+        #
+        value1 = Vt.Double(3.14)
+        value2 = Vt.Double(9.98)
+        sdfValueType = Sdf.ValueTypeNames.Double
         errSdfValueType = Sdf.ValueTypeNames.String
         #
         self.runTypeChecks(sdfValueType,value1,value2)


### PR DESCRIPTION
Addressing issue reported in https://github.com/Autodesk/maya-usd/discussions/1881 discussion.