### PR TITLE
Test fix for random failing test: TestALUSDMayaPython_LayerManager

### DIFF
--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/CMakeLists.txt
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/CMakeLists.txt
@@ -14,6 +14,7 @@ mayaUsd_add_test(TestALUSDMayaPython_Translators
 
 mayaUsd_add_test(TestALUSDMayaPython_LayerManager
     PYTHON_MODULE testLayerManager
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     ENV
         "${PXR_OVERRIDE_PLUGINPATH_NAME}=${ADDITIONAL_PXR_PLUGINPATH_NAME}"
         "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testLayerManager.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testLayerManager.py
@@ -17,7 +17,6 @@
 #
 
 import os
-import shutil
 import unittest
 
 from maya import cmds


### PR DESCRIPTION
FAIL: test_anonymousLayerSerialisation (testLayerManager.TestLayerManagerSerialisation)
09:37:31     Tests multiple anonymous sublayers can be saved and restored.
09:37:31     ----------------------------------------------------------------------
09:37:31     Traceback (most recent call last):
09:37:31       File "/local/S/jenkins/workspace/ecg-mayausd-branch-preflight-python3-osx/ecg-maya-usd/maya-usd/plugin/al/plugin/AL_USDMayaTestPlugin/py/testLayerManager.py", line 262, in test_anonymousLayerSerialisation
09:37:31         self.assertIsNotNone(sublayer01)
09:37:31     AssertionError: unexpectedly None