### PR TITLE
MAYA-112624 Add required primvars corresponding to the Maya shader's required

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -1180,40 +1180,27 @@ MHWRender::MTexture* _LoadTexture(
     return texture;
 }
 
-    TfToken MayaDescriptorToToken(const MVertexBufferDescriptor& descriptor) {
-        // Attempt to match an MVertexBufferDescriptor to the corresponding
-        // USD primvar token. The "Computed" token is used for data which 
-        // can be computed by an an rprim. Unknown is used for unsupported
-        // descriptors.
+TfToken MayaDescriptorToToken(const MVertexBufferDescriptor& descriptor)
+{
+    // Attempt to match an MVertexBufferDescriptor to the corresponding
+    // USD primvar token. The "Computed" token is used for data which
+    // can be computed by an an rprim. Unknown is used for unsupported
+    // descriptors.
 
-        TfToken token = _tokens->Unknown;
-        switch(descriptor.semantic()){
-            case MGeometry::kPosition:
-                token = HdTokens->points;
-                break;
-            case MGeometry::kNormal:
-                token = HdTokens->normals;
-                break;
-            case MGeometry::kTexture:
-                break;
-            case MGeometry::kColor:
-                token = HdTokens->displayColor;
-                break;
-            case MGeometry::kTangent:
-                token = _tokens->Computed;
-                break;
-            case MGeometry::kBitangent:
-                token = _tokens->Computed;
-                break;
-            case MGeometry::kTangentWithSign:
-                token = _tokens->Computed;
-                break;
-            default:
-                break;
-        }
-
-        return token;
+    TfToken token = _tokens->Unknown;
+    switch (descriptor.semantic()) {
+    case MGeometry::kPosition: token = HdTokens->points; break;
+    case MGeometry::kNormal: token = HdTokens->normals; break;
+    case MGeometry::kTexture: break;
+    case MGeometry::kColor: token = HdTokens->displayColor; break;
+    case MGeometry::kTangent: token = _tokens->Computed; break;
+    case MGeometry::kBitangent: token = _tokens->Computed; break;
+    case MGeometry::kTangentWithSign: token = _tokens->Computed; break;
+    default: break;
     }
+
+    return token;
+}
 
 } // anonymous namespace
 
@@ -1370,15 +1357,18 @@ void HdVP2Material::Sync(
                     MVertexBufferDescriptorList requiredVertexBuffers;
                     MStatus status = shader->requiredVertexBuffers(requiredVertexBuffers);
                     if (status) {
-                        for(int reqIndex = 0; reqIndex < requiredVertexBuffers.length(); reqIndex++) {
+                        for (int reqIndex = 0; reqIndex < requiredVertexBuffers.length();
+                             reqIndex++) {
                             MVertexBufferDescriptor desc;
                             requiredVertexBuffers.getDescriptor(reqIndex, desc);
                             TfToken requiredPrimvar = MayaDescriptorToToken(desc);
-                            // now make sure something matching requiredPrimvar is in _requiredPrimvars
-                            if (requiredPrimvar != _tokens->Unknown && requiredPrimvar != _tokens->Computed) {
+                            // now make sure something matching requiredPrimvar is in
+                            // _requiredPrimvars
+                            if (requiredPrimvar != _tokens->Unknown
+                                && requiredPrimvar != _tokens->Computed) {
                                 bool found = false;
                                 for (TfToken const& primvar : _requiredPrimvars) {
-                                    if (primvar == requiredPrimvar) { 
+                                    if (primvar == requiredPrimvar) {
                                         found = true;
                                         break;
                                     }

--- a/test/testSamples/instances/billboard.usda
+++ b/test/testSamples/instances/billboard.usda
@@ -16,46 +16,46 @@ def Xform "GEO"
         float3[] extent = [(-1.5, 0, -1.5), (1.5, 0, 1.5)]
         int[] faceVertexCounts = [4]
         int[] faceVertexIndices = [0, 1, 3, 2]
-        rel material:binding = </GEO/BILLBOARD/Looks/TEXTUREDA>
+        rel material:binding = </GEO/Looks/TEXTUREDA>
         point3f[] points = [(-1.5, 0, 1.5), (1.5, 0, 1.5), (-1.5, 0, -1.5), (1.5, 0, -1.5)]
         texCoord2f[] primvars:map1 = [(0, 0), (1, 0), (0, 1), (1, 1)] (
             interpolation = "faceVarying"
         )
         int[] primvars:map1:indices = [0, 1, 3, 2]
-
-        def Scope "Looks"
-        {
-            def Material "TEXTUREDA"
-            {
-                token inputs:file1:varname = "map1"
-                token outputs:surface.connect = </GEO/BILLBOARD/Looks/TEXTUREDA/TEXTUREDA.outputs:surface>
-
-                def Shader "TEXTUREDA"
-                {
-                    uniform token info:id = "UsdPreviewSurface"
-                    color3f inputs:diffuseColor.connect = </GEO/BILLBOARD/Looks/TEXTUREDA/file1.outputs:rgb>
-                    token outputs:displacement
-                    token outputs:surface
-                }
-
-                def Shader "file1"
-                {
-                    uniform token info:id = "UsdUVTexture"
-                    float4 inputs:fallback = (0.5, 0.5, 0.5, 1)
-                    asset inputs:file = @green_A.png@
-                    float2 inputs:st.connect = </GEO/BILLBOARD/Looks/TEXTUREDA/file1/TexCoordReader.outputs:result>
-                    token inputs:wrapS = "repeat"
-                    token inputs:wrapT = "repeat"
-                    float3 outputs:rgb
-
-                    def Shader "TexCoordReader"
-                    {
-                        uniform token info:id = "UsdPrimvarReader_float2"
-                        token inputs:varname.connect = </GEO/BILLBOARD/Looks/TEXTUREDA.inputs:file1:varname>
-                        float2 outputs:result
-                    }
-                }
-            }
-        }
     }
+
+	def Scope "Looks"
+	{
+		def Material "TEXTUREDA"
+		{
+			token inputs:file1:varname = "map1"
+			token outputs:surface.connect = </GEO/Looks/TEXTUREDA/TEXTUREDA.outputs:surface>
+
+			def Shader "TEXTUREDA"
+			{
+				uniform token info:id = "UsdPreviewSurface"
+				color3f inputs:diffuseColor.connect = </GEO/Looks/TEXTUREDA/file1.outputs:rgb>
+				token outputs:displacement
+				token outputs:surface
+			}
+
+			def Shader "file1"
+			{
+				uniform token info:id = "UsdUVTexture"
+				float4 inputs:fallback = (0.5, 0.5, 0.5, 1)
+				asset inputs:file = @green_A.png@
+				float2 inputs:st.connect = </GEO/Looks/TEXTUREDA/TexCoordReader.outputs:result>
+				token inputs:wrapS = "repeat"
+				token inputs:wrapT = "repeat"
+				float3 outputs:rgb
+			}
+
+			def Shader "TexCoordReader"
+			{
+				uniform token info:id = "UsdPrimvarReader_float2"
+				token inputs:varname.connect = </GEO/Looks/TEXTUREDA.inputs:file1:varname>
+				float2 outputs:result
+			}
+		}
+	}
 }


### PR DESCRIPTION
vertex buffers. Fix test so I can run it in debug mode.

This should address the missing normal requirement from #1532.