### PR TITLE
Fix exported normals not being used by VP2

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1153,11 +1153,11 @@ void HdVP2Mesh::Sync(
 HdDirtyBits HdVP2Mesh::GetInitialDirtyBitsMask() const
 {
     constexpr HdDirtyBits bits = HdChangeTracker::InitRepr | HdChangeTracker::DirtyPoints
-        | HdChangeTracker::DirtyTopology | HdChangeTracker::DirtyTransform
-        | HdChangeTracker::DirtyMaterialId | HdChangeTracker::DirtyPrimvar
-        | HdChangeTracker::DirtyVisibility | HdChangeTracker::DirtyInstancer
-        | HdChangeTracker::DirtyInstanceIndex | HdChangeTracker::DirtyRenderTag
-        | DirtySelectionHighlight;
+        | HdChangeTracker::DirtyNormals | HdChangeTracker::DirtyTopology
+        | HdChangeTracker::DirtyTransform | HdChangeTracker::DirtyMaterialId
+        | HdChangeTracker::DirtyPrimvar | HdChangeTracker::DirtyVisibility
+        | HdChangeTracker::DirtyInstancer | HdChangeTracker::DirtyInstanceIndex
+        | HdChangeTracker::DirtyRenderTag | DirtySelectionHighlight;
 
     return bits;
 }


### PR DESCRIPTION
Adds DirtyNormals to the initial set of dirty bits.

Vital for USD 21.11 due to USD commit [6c89bf90](https://github.com/PixarAnimationStudios/USD/commit/6c89bf909c42a5a4b32177ca2693a0c349999334).
Works with previous versions.