### PR TITLE
Unnest UV reader and optimize

### DIFF
--- a/test/lib/mayaUsd/fileio/testShaderWriter.py
+++ b/test/lib/mayaUsd/fileio/testShaderWriter.py
@@ -90,6 +90,8 @@ class testShaderWriter(unittest.TestCase):
                          ".noiseUV", ".vertexUvOne", ".vertexUvTwo",
                          ".vertexUvThree", ".vertexCameraOne"):
             cmds.connectAttr(uv_node + att_name, file_node + att_name, f=True)
+        cmds.connectAttr(uv_node + ".outUV", file_node + ".uvCoord", f=True)
+        cmds.connectAttr(uv_node + ".outUvFilterSize", file_node + ".uvFilterSize", f=True)
 
         cmds.connectAttr(file_node + ".outColor",
                          material_node + ".color", f=True)


### PR DESCRIPTION
First item in to fix in Issue #1834

- The UsdUVTexture and UsdTransform2d are no longer nested under the
  file node
- Shared place2dTexture nodes result in shared UsdUVTexture
- If a file node does not have a place2DTexture node, then is shares a
  common UsdUVTexture

More to follow.