### PR TITLE
MAYA-114979 - Validate normal maps for correctness

### DIFF
--- a/lib/usd/pxrUsdPreviewSurface/usdPreviewSurface.cpp
+++ b/lib/usd/pxrUsdPreviewSurface/usdPreviewSurface.cpp
@@ -15,12 +15,14 @@
 //
 #include "usdPreviewSurface.h"
 
+#include <pxr/base/tf/envSetting.h>
 #include <pxr/base/tf/staticTokens.h>
 #include <pxr/base/tf/stringUtils.h>
 #include <pxr/pxr.h>
 
 #include <maya/MDataBlock.h>
 #include <maya/MDataHandle.h>
+#include <maya/MFileIO.h>
 #include <maya/MFloatVector.h>
 #include <maya/MFnDependencyNode.h>
 #include <maya/MFnNumericAttribute.h>
@@ -41,6 +43,17 @@ PXR_NAMESPACE_OPEN_SCOPE
 TF_DEFINE_PUBLIC_TOKENS(
     PxrMayaUsdPreviewSurfaceTokens,
     PXRUSDPREVIEWSURFACE_USD_PREVIEW_SURFACE_TOKENS);
+
+TF_DEFINE_ENV_SETTING(
+    USDMAYA_FIX_PREVIEW_SURFACE_CORRECTNESS_ON_LOAD,
+    false,
+    "If true, Color Space on the file node will be set to Raw when driving normals and "
+    "monochromatic attributes. We will also adjust Color Gain to (2, 2, 2) and Color Offset to "
+    "(-1, -1, -1) on normal maps.");
+
+namespace {
+static const MString normalAttrShortName = "nrm";
+}
 
 /* static */
 void* PxrMayaUsdPreviewSurface::creator() { return new PxrMayaUsdPreviewSurface(); }
@@ -177,7 +190,7 @@ MStatus PxrMayaUsdPreviewSurface::initialize()
 
     normalAttr = numericAttrFn.create(
         PxrMayaUsdPreviewSurfaceTokens->NormalAttrName.GetText(),
-        "nrm",
+        normalAttrShortName,
         MFnNumericData::k3Float,
         0.0,
         &status);
@@ -485,6 +498,64 @@ MStatus PxrMayaUsdPreviewSurface::compute(const MPlug& plug, MDataBlock& dataBlo
     }
 
     return status;
+}
+
+/* virtual */
+MStatus
+PxrMayaUsdPreviewSurface::connectionMade(const MPlug& plug, const MPlug& otherPlug, bool asSrc)
+{
+    // Skip any adjustements on load, unless explicitly requested.
+    if (MFileIO::isReadingFile()
+        && !TfGetEnvSetting(USDMAYA_FIX_PREVIEW_SURFACE_CORRECTNESS_ON_LOAD)) {
+        return MPxNode::connectionMade(plug, otherPlug, asSrc);
+    }
+
+    // If we receive a connection on the "normal" input, and the connection is from a "file" node,
+    // then we want to adjust the Space, Gain, and Offset of that file node so they match the
+    // expected normal range of UsdPreviewSurface.
+    if (plug.partialName() == normalAttrShortName && otherPlug.node().hasFn(MFn::kFileTexture)) {
+        MFnDependencyNode otherDepNode(otherPlug.node());
+
+        MPlug sourceColorSpace = otherDepNode.findPlug("colorSpace");
+        if (!sourceColorSpace.isNull()) {
+            sourceColorSpace.setString("Raw");
+        }
+
+        auto setPlugValue = [&otherDepNode](const auto& plugName, const auto& plugValue) {
+            MPlug numericPlug = otherDepNode.findPlug(plugName);
+            if (!numericPlug.isNull()) {
+                numericPlug.setDouble(plugValue);
+            }
+        };
+
+        setPlugValue("colorGainR", 2);
+        setPlugValue("colorGainG", 2);
+        setPlugValue("colorGainB", 2);
+        setPlugValue("colorOffsetR", -1);
+        setPlugValue("colorOffsetG", -1);
+        setPlugValue("colorOffsetB", -1);
+        setPlugValue("alphaGain", 1);
+        setPlugValue("alphaOffset", 0);
+    }
+
+    // Similarly, if the connection is on a single channel attribute, like metalness, roughness, or
+    // opacity, and the source is a color channel, then we expect the file node to use the "Raw"
+    // colorspace:
+    if (!plug.isChild() && plug.attribute().hasFn(MFn::kNumericAttribute)
+        && otherPlug.node().hasFn(MFn::kFileTexture)
+        && (otherPlug.partialName() == "ocr" || otherPlug.partialName() == "ocg"
+            || otherPlug.partialName() == "ocb")) {
+        MFnNumericAttribute numericAttrFn(plug.attribute());
+        if (numericAttrFn.unitType() == MFnNumericData::kFloat) {
+            MFnDependencyNode otherDepNode(otherPlug.node());
+            MPlug             sourceColorSpace = otherDepNode.findPlug("colorSpace");
+            if (!sourceColorSpace.isNull()) {
+                sourceColorSpace.setString("Raw");
+            }
+        }
+    }
+
+    return MPxNode::connectionMade(plug, otherPlug, asSrc);
 }
 
 PxrMayaUsdPreviewSurface::PxrMayaUsdPreviewSurface()

--- a/lib/usd/pxrUsdPreviewSurface/usdPreviewSurface.h
+++ b/lib/usd/pxrUsdPreviewSurface/usdPreviewSurface.h
@@ -77,6 +77,9 @@ public:
     PXRUSDPREVIEWSURFACE_API
     MStatus compute(const MPlug& plug, MDataBlock& dataBlock) override;
 
+    PXRUSDPREVIEWSURFACE_API
+    MStatus connectionMade(const MPlug& plug, const MPlug& otherPlug, bool asSrc) override;
+
 private:
     PxrMayaUsdPreviewSurface();
     ~PxrMayaUsdPreviewSurface() override;

--- a/test/lib/usd/translators/testUsdExportUsdPreviewSurface.py
+++ b/test/lib/usd/translators/testUsdExportUsdPreviewSurface.py
@@ -186,6 +186,9 @@ class testUsdExportUsdPreviewSurface(unittest.TestCase):
             "%s.outColor" % file_node, "%s.diffuseColor" % shading_node, force=True
         )
 
+        # This file node should have stayed "sRGB":
+        self.assertEqual(cmds.getAttr(file_node + ".colorSpace"), "sRGB")
+
         cmds.defaultNavigation(
             createNew=True, destination="%s.roughness" % shading_node
         )
@@ -200,6 +203,9 @@ class testUsdExportUsdPreviewSurface(unittest.TestCase):
         cmds.connectAttr(
             "%s.outColorR" % file_node, "%s.roughness" % shading_node, force=True
         )
+
+        # The monochrome file node should have been set to "Raw" automatically:
+        self.assertEqual(cmds.getAttr(file_node + ".colorSpace"), "Raw")
 
         cmds.defaultNavigation(
             createNew=True, destination="%s.clearcoatRoughness" % shading_node
@@ -222,6 +228,17 @@ class testUsdExportUsdPreviewSurface(unittest.TestCase):
         cmds.connectAttr(
             "%s.outColor" % file_node, "%s.normal" % shading_node, force=True
         )
+
+        # The file node should have been set to "NormalMap" automatically:
+        self.assertEqual(cmds.getAttr(file_node + ".colorSpace"), "Raw")
+        self.assertEqual(cmds.getAttr(file_node + ".colorGainR"), 2)
+        self.assertEqual(cmds.getAttr(file_node + ".colorGainG"), 2)
+        self.assertEqual(cmds.getAttr(file_node + ".colorGainB"), 2)
+        self.assertEqual(cmds.getAttr(file_node + ".colorOffsetR"), -1)
+        self.assertEqual(cmds.getAttr(file_node + ".colorOffsetG"), -1)
+        self.assertEqual(cmds.getAttr(file_node + ".colorOffsetB"), -1)
+        self.assertEqual(cmds.getAttr(file_node + ".alphaGain"), 1)
+        self.assertEqual(cmds.getAttr(file_node + ".alphaOffset"), 0)
 
         shading_engine = "%sSG" % shading_node
         cmds.sets(


### PR DESCRIPTION
Also check monochromatic inputs.

Connecting a file texture node interactively or by script will
automatically set the color attributes on the file node according to the
destination of the connection.

@dgovil : Added an env var for automatic fixups on load.

Second PR for issue #1834