### PR TITLE
Medley of normals and a few other fixes

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Transform.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Transform.cpp
@@ -29,7 +29,6 @@
 #include <maya/MGlobal.h>
 #include <maya/MProfiler.h>
 #include <maya/MTime.h>
-#include <maya/MViewport2Renderer.h>
 
 namespace {
 const int _transformProfilerCategory = MProfiler::addCategory(
@@ -494,7 +493,6 @@ MStatus Transform::preEvaluation(const MDGContext& context, const MEvaluationNod
         UsdTimeCode usdTime(theTime.as(MTime::uiUnit()));
 
         getTransMatrix()->updateToTime(usdTime);
-        MHWRender::MRenderer::setGeometryDrawDirty(thisMObject());
     }
     return MPxTransform::preEvaluation(context, evaluationNode);
 }
@@ -515,7 +513,6 @@ MStatus Transform::postEvaluation(
     UsdTimeCode usdTime(theTime.as(MTime::uiUnit()));
 
     getTransMatrix()->updateToTime(usdTime);
-    MHWRender::MRenderer::setGeometryDrawDirty(thisMObject());
 
     return MPxTransform::postEvaluation(context, evaluationNode, evalType);
 }

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Transform.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Transform.cpp
@@ -25,9 +25,11 @@
 #include <pxr/usd/usdGeom/scope.h>
 
 #include <maya/MBoundingBox.h>
+#include <maya/MDGContextGuard.h>
 #include <maya/MGlobal.h>
 #include <maya/MProfiler.h>
 #include <maya/MTime.h>
+#include <maya/MViewport2Renderer.h>
 
 namespace {
 const int _transformProfilerCategory = MProfiler::addCategory(
@@ -377,7 +379,11 @@ MStatus Transform::validateAndSetValue(
             outputDoubleValue(dataBlock, m_timeScalar, handle.asDouble());
         }
 
+        UsdTimeCode usdTime(handle.asTime().as(MTime::uiUnit()));
+        getTransMatrix()->updateToTime(usdTime);
         updateTransform(dataBlock);
+        outputTimeValue(dataBlock, m_outTime, handle.asTime());
+        dirtyMatrix();
         return MS::kSuccess;
     } else
         // The local translate offset doesn't drive the TRS, so set the value here, and the
@@ -405,6 +411,7 @@ MStatus Transform::validateAndSetValue(
         MDataBlock dataBlock = forceCache(*(MDGContext*)&context);
         getTransMatrix()->enablePushToPrim(handle.asBool());
         outputBoolValue(dataBlock, m_pushToPrim, handle.asBool());
+        dirtyMatrix();
         return MS::kSuccess;
     } else if (plug == m_readAnimatedValues) {
         MDataBlock dataBlock = forceCache(*(MDGContext*)&context);
@@ -454,10 +461,63 @@ MStatus Transform::validateAndSetValue(
             }
             transform()->setPrim(UsdPrim(), this);
         }
+        dirtyMatrix();
         return MS::kSuccess;
     }
 
     return MPxTransform::validateAndSetValue(plug, handle, context);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus Transform::preEvaluation(const MDGContext& context, const MEvaluationNode& evaluationNode)
+{
+    MDGContextGuard contextGuard(context);
+    if (!context.isNormal()) {
+
+        MDataBlock dataBlock = forceCache(*(MDGContext*)&context);
+        auto*      data = inputDataValue<MayaUsdStageData>(dataBlock, m_inStageData);
+        if (data && data->stage) {
+            MString path = inputStringValue(dataBlock, m_primPath);
+            SdfPath primPath;
+            UsdPrim usdPrim;
+            if (path.length()) {
+                primPath = SdfPath(path.asChar());
+                usdPrim = data->stage->GetPrimAtPath(primPath);
+            }
+            getTransMatrix()->setPrim(usdPrim, this);
+        }
+
+        MTime time;
+        context.getTime(time);
+        MTime theTime = (time - inputTimeValue(dataBlock, m_timeOffset))
+            * inputDoubleValue(dataBlock, m_timeScalar);
+        UsdTimeCode usdTime(theTime.as(MTime::uiUnit()));
+
+        getTransMatrix()->updateToTime(usdTime);
+        MHWRender::MRenderer::setGeometryDrawDirty(thisMObject());
+    }
+    return MPxTransform::preEvaluation(context, evaluationNode);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus Transform::postEvaluation(
+    const MDGContext&      context,
+    const MEvaluationNode& evaluationNode,
+    PostEvaluationType     evalType)
+{
+    MDGContextGuard contextGuard(context);
+
+    MDataBlock dataBlock = forceCache();
+
+    MStatus     status;
+    MDataHandle timeInHandle = dataBlock.inputValue(m_outTime, &status);
+    MTime       theTime = timeInHandle.asTime();
+    UsdTimeCode usdTime(theTime.as(MTime::uiUnit()));
+
+    getTransMatrix()->updateToTime(usdTime);
+    MHWRender::MRenderer::setGeometryDrawDirty(thisMObject());
+
+    return MPxTransform::postEvaluation(context, evaluationNode, evalType);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Transform.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Transform.h
@@ -150,11 +150,11 @@ private:
     bool    setInternalValue(const MPlug& plug, const MDataHandle& dataHandle) override;
     bool    isBounded() const override { return true; }
     bool    treatAsTransform() const override { return false; }
-    MStatus preEvaluation(const MDGContext& context, const MEvaluationNode& evaluationNode);
+    MStatus preEvaluation(const MDGContext& context, const MEvaluationNode& evaluationNode) override;
     MStatus postEvaluation(
         const MDGContext&      context,
         const MEvaluationNode& evaluationNode,
-        PostEvaluationType     evalType);
+        PostEvaluationType     evalType) override;
 
     //--------------------------------------------------------------------------------------------------------------------
     /// utils

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Transform.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Transform.h
@@ -138,11 +138,10 @@ private:
     //--------------------------------------------------------------------------------------------------------------------
 
     MPxNode::SchedulingType schedulingType() const override { return kParallel; }
-
-    MStatus validateAndSetValue(
-        const MPlug&       plug,
-        const MDataHandle& handle,
-        const MDGContext&  context) override;
+    MStatus                 validateAndSetValue(
+                        const MPlug&       plug,
+                        const MDataHandle& handle,
+                        const MDGContext&  context) override;
     MPxTransformationMatrix* createTransformationMatrix() override;
     MStatus                  compute(const MPlug& plug, MDataBlock& datablock) override;
     void                     postConstructor() override;
@@ -151,6 +150,11 @@ private:
     bool    setInternalValue(const MPlug& plug, const MDataHandle& dataHandle) override;
     bool    isBounded() const override { return true; }
     bool    treatAsTransform() const override { return false; }
+    MStatus preEvaluation(const MDGContext& context, const MEvaluationNode& evaluationNode);
+    MStatus postEvaluation(
+        const MDGContext&      context,
+        const MEvaluationNode& evaluationNode,
+        PostEvaluationType     evalType);
 
     //--------------------------------------------------------------------------------------------------------------------
     /// utils

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Transform.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Transform.h
@@ -150,7 +150,8 @@ private:
     bool    setInternalValue(const MPlug& plug, const MDataHandle& dataHandle) override;
     bool    isBounded() const override { return true; }
     bool    treatAsTransform() const override { return false; }
-    MStatus preEvaluation(const MDGContext& context, const MEvaluationNode& evaluationNode) override;
+    MStatus
+            preEvaluation(const MDGContext& context, const MEvaluationNode& evaluationNode) override;
     MStatus postEvaluation(
         const MDGContext&      context,
         const MEvaluationNode& evaluationNode,

--- a/plugin/al/lib/AL_USDMaya/CMakeLists.txt
+++ b/plugin/al/lib/AL_USDMaya/CMakeLists.txt
@@ -297,7 +297,6 @@ set_target_properties(${PYTHON_LIBRARY_LOCATION}
 set_property(GLOBAL PROPERTY GLOBAL_PYTHON_LIBRARY_LOCATION ${AL_INSTALL_PREFIX}/lib/python/${arDirPath}/${PYTHON_LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py ${CMAKE_CURRENT_BINARY_DIR}/lib/python/${arDirPath}/__init__.py)
-execute_process(COMMAND ${Python_EXECUTABLE} -m compileall ${CMAKE_CURRENT_BINARY_DIR}/lib/python/${arDirPath}/__init__.py)
 install(FILES
         ${CMAKE_CURRENT_BINARY_DIR}/lib/python/${arDirPath}/__init__.py
     DESTINATION

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/AL/usdmaya/fileio/export_misc.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/AL/usdmaya/fileio/export_misc.cpp
@@ -29,13 +29,15 @@ using AL::maya::test::buildTempPath;
 
 TEST(export_misc, subdivision_scheme)
 {
-    auto geomType = TfToken(TfType::Find<UsdGeomMesh>().GetTypeName());
+    auto geomType = TfType::Find<UsdGeomMesh>();
 #if USD_VERSION_NUM > 2002
-    auto primDef = UsdSchemaRegistry::GetInstance().FindConcretePrimDefinition(geomType);
+    auto geomTypeToken = UsdSchemaRegistry::GetInstance().GetConcreteSchemaTypeName(geomType);
+    auto primDef = UsdSchemaRegistry::GetInstance().FindConcretePrimDefinition(geomTypeToken);
+    ASSERT_TRUE(primDef);
     auto attrSpec = primDef->GetSchemaAttributeSpec(UsdGeomTokens->subdivisionScheme);
 #else
-    auto attrSpec
-        = UsdSchemaRegistry::GetAttributeDefinition(geomType, UsdGeomTokens->subdivisionScheme);
+    auto attrSpec = UsdSchemaRegistry::GetAttributeDefinition(
+        TfToken(geomType.GetTypeName()), UsdGeomTokens->subdivisionScheme);
 #endif
     auto                   defaultToken = attrSpec->GetDefaultValue().UncheckedGet<TfToken>();
     std::map<TfToken, int> subdSchemeMap = { { defaultToken, 0 }, // No value should be authored

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/AL/usdmaya/fileio/export_misc.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/AL/usdmaya/fileio/export_misc.cpp
@@ -1,0 +1,89 @@
+
+//
+// Copyright 2020 Animal Logic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "test_usdmaya.h"
+
+#include <pxr/usd/sdf/attributeSpec.h>
+#include <pxr/usd/usdGeom/mesh.h>
+
+#include <maya/MFileIO.h>
+#include <maya/MGlobal.h>
+
+#include <string>
+
+using AL::maya::test::buildTempPath;
+
+TEST(export_misc, subdivision_scheme)
+{
+    auto geomType = TfToken(TfType::Find<UsdGeomMesh>().GetTypeName());
+#if USD_VERSION_NUM > 2002
+    auto primDef = UsdSchemaRegistry::GetInstance().FindConcretePrimDefinition(geomType);
+    auto attrSpec = primDef->GetSchemaAttributeSpec(UsdGeomTokens->subdivisionScheme);
+#else
+    auto attrSpec
+        = UsdSchemaRegistry::GetAttributeDefinition(geomType, UsdGeomTokens->subdivisionScheme);
+#endif
+    auto                   defaultToken = attrSpec->GetDefaultValue().UncheckedGet<TfToken>();
+    std::map<TfToken, int> subdSchemeMap = { { defaultToken, 0 }, // No value should be authored
+                                             { UsdGeomTokens->catmullClark, 1 },
+                                             { UsdGeomTokens->none, 2 },
+                                             { UsdGeomTokens->loop, 3 },
+                                             { UsdGeomTokens->bilinear, 4 } };
+    MFileIO::newFile(true);
+    MGlobal::executeCommand("polySphere -n testSphere;");
+    const std::string temp_path = buildTempPath("AL_USDMayaTests_subdivision_scheme.usda");
+
+    auto buildCommand = [&temp_path](int subdScheme) {
+        const std::string strCommand = "file -force -options "
+                                       "\"Filter_Sample=0;"
+                                       "Subdivision_scheme=^1s;\""
+                                       "-typ \"AL usdmaya export\" -pr -es \" ^2s\";";
+        MString command;
+        command.format(
+            strCommand.c_str(),
+            MString(std::to_string(subdScheme).c_str()),
+            MString(temp_path.c_str()));
+        return command;
+    };
+
+    auto checkAttribute = [&temp_path](TfToken subdToken, bool hasAuthored) {
+        UsdStageRefPtr stage = UsdStage::Open(temp_path);
+        ASSERT_TRUE(stage);
+
+        stage->Reload();
+        UsdPrim     prim = stage->GetPrimAtPath(SdfPath("/testSphere"));
+        UsdGeomMesh mesh(prim);
+
+        UsdAttribute subdSchemeAttr = mesh.GetSubdivisionSchemeAttr();
+        ASSERT_TRUE(subdSchemeAttr);
+        if (hasAuthored) {
+            EXPECT_TRUE(subdSchemeAttr.HasAuthoredValue());
+        } else {
+            EXPECT_FALSE(subdSchemeAttr.HasAuthoredValue());
+        }
+
+        TfToken subdScheme;
+        subdSchemeAttr.Get(&subdScheme);
+        EXPECT_EQ(subdToken, subdScheme);
+    };
+
+    for (const auto& kv : subdSchemeMap) {
+        MGlobal::executeCommand(buildCommand(kv.second));
+        // kv.second > 0 means no value should have been authored
+        checkAttribute(kv.first, kv.second);
+    };
+}

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/AL/usdmaya/fileio/export_misc.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/AL/usdmaya/fileio/export_misc.cpp
@@ -30,7 +30,7 @@ using AL::maya::test::buildTempPath;
 TEST(export_misc, subdivision_scheme)
 {
     auto geomType = TfType::Find<UsdGeomMesh>();
-#if USD_VERSION_NUM > 2002
+#if PXR_VERSION > 2002
     auto geomTypeToken = UsdSchemaRegistry::GetInstance().GetConcreteSchemaTypeName(geomType);
     auto primDef = UsdSchemaRegistry::GetInstance().FindConcretePrimDefinition(geomTypeToken);
     ASSERT_TRUE(primDef);

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/AL/usdmaya/test_DiffPrimVar.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/AL/usdmaya/test_DiffPrimVar.cpp
@@ -173,9 +173,13 @@ TEST(DiffPrimVar, diffGeomNormals)
 {
     MFileIO::newFile(true);
     MStringArray result;
+    // Creates a sphere with per face per vertex normals
     ASSERT_TRUE(
-        MGlobal::executeCommand("polySphere  -r 1 -sx 20 -sy 20 -ax 0 1 0 -cuv 2 -ch 1", result)
+        MGlobal::executeCommand("polySphere  -r 1 -sx 20 -sy 20 -ax 0 1 0 -cuv 2 -ch 1;", result)
         == MS::kSuccess);
+    ASSERT_TRUE(result.length() == 2);
+    ASSERT_TRUE(
+        MGlobal::executeCommand("LockNormals; polySoftEdge -a 0 -ch 1 pSphere1;") == MS::kSuccess);
 
     const MString temp_path = buildTempPath("AL_USDMayaTests_diffPrimVarNormals.usda");
 
@@ -187,7 +191,6 @@ TEST(DiffPrimVar, diffGeomNormals)
         + temp_path + "\";";
 
     ASSERT_TRUE(MGlobal::executeCommand(exportCommand) == MS::kSuccess);
-    ASSERT_TRUE(result.length() == 2);
 
     MSelectionList sl;
     EXPECT_TRUE(sl.add("pSphereShape1") == MS::kSuccess);

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/CMakeLists.txt
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(${TARGET_NAME}
         AL/usdmaya/commands/test_LayerManagerCommands.cpp
         AL/usdmaya/commands/test_ProxyShapeImport.cpp
         AL/usdmaya/commands/test_TranslateCommand.cpp
+        AL/usdmaya/fileio/export_misc.cpp
         AL/usdmaya/fileio/export_blendshape.cpp
         AL/usdmaya/fileio/export_constraints.cpp
         AL/usdmaya/fileio/export_ik.cpp

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/test_translators_MeshTranslator.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/test_translators_MeshTranslator.cpp
@@ -1206,6 +1206,6 @@ TEST(translators_MeshTranslator, vertexNormalsExport)
         EXPECT_EQ(UsdGeomTokens->vertex, mesh.GetNormalsInterpolation());
         VtVec3fArray normals;
         mesh.GetNormalsAttr().Get(&normals);
-        EXPECT_EQ(normals.size(), fn.numNormals());
+        EXPECT_EQ(normals.size(), static_cast<size_t>(fn.numNormals()));
     }
 }

--- a/plugin/al/schemas/AL/usd/schemas/maya/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/maya/CMakeLists.txt
@@ -146,7 +146,6 @@ install(TARGETS ${PYTHON_LIBRARY_NAME}
 
 # configure_file has a nice feature where it will copy the __init__ file over when it gets modified, unlike file(COPY ...)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/__init__.py ${CMAKE_BINARY_DIR}/AL/usd/schemas/maya/__init__.py COPYONLY)
-execute_process(COMMAND ${Python_EXECUTABLE} -m compileall ${CMAKE_BINARY_DIR}/AL/usd/schemas/maya/__init__.py)
 
 string(REPLACE "/" ";" folderHierarchy "AL/usd/schemas/maya")
 
@@ -170,7 +169,6 @@ if(${listCount} STRGREATER 1)
         ${CMAKE_BINARY_DIR}/${currentPath}/__init__.py
         "try:\n\t__import__('pkg_resources').declare_namespace(__name__)\nexcept:\n\tfrom pkgutil import extend_path\n\t__path__ = extend_path(__path__, __name__)\n"
       )
-      execute_process(COMMAND ${Python_EXECUTABLE} -m compileall ${CMAKE_BINARY_DIR}/${currentPath}/__init__.py)
     endforeach(i)
 endif()
 

--- a/plugin/al/schemas/AL/usd/schemas/mayatest/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/mayatest/CMakeLists.txt
@@ -136,7 +136,6 @@ install(TARGETS ${PYTHON_LIBRARY_NAME}
 
 # configure_file has a nice feature where it will copy the __init__ file over when it gets modified, unlike file(COPY ...)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/__init__.py ${CMAKE_BINARY_DIR}/AL/usd/schemas/mayatest/__init__.py COPYONLY)
-execute_process(COMMAND ${Python_EXECUTABLE} -m compileall ${CMAKE_BINARY_DIR}/AL/usd/schemas/mayatest/__init__.py)
 
 string(REPLACE "/" ";" folderHierarchy "AL/usd/schemas/mayatest")
 
@@ -160,7 +159,6 @@ if(${listCount} STRGREATER 1)
         ${CMAKE_BINARY_DIR}/${currentPath}/__init__.py
         "try:\n\t__import__('pkg_resources').declare_namespace(__name__)\nexcept:\n\tfrom pkgutil import extend_path\n\t__path__ = extend_path(__path__, __name__)\n"
       )
-      execute_process(COMMAND ${Python_EXECUTABLE} -m compileall ${CMAKE_BINARY_DIR}/${currentPath}/__init__.py)
     endforeach(i)
 endif()
 

--- a/plugin/al/translators/CommonTranslatorOptions.cpp
+++ b/plugin/al/translators/CommonTranslatorOptions.cpp
@@ -4,6 +4,7 @@
 
 #include <pxr/base/tf/registryManager.h>
 #include <pxr/base/tf/type.h>
+#include <pxr/usd/usdGeom/tokens.h>
 
 namespace AL {
 namespace usdmaya {
@@ -17,6 +18,14 @@ AL::maya::utils::PluginTranslatorOptions* g_importOptions = 0;
 
 //----------------------------------------------------------------------------------------------------------------------
 static const char* const g_compactionLevels[] = { "None", "Basic", "Medium", "Extensive", 0 };
+
+//----------------------------------------------------------------------------------------------------------------------
+static const char* const g_subdivisionSchemes[] = { "default", // Do not author opinion
+                                                    UsdGeomTokens->catmullClark.GetText(),
+                                                    UsdGeomTokens->none.GetText(),
+                                                    UsdGeomTokens->loop.GetText(),
+                                                    UsdGeomTokens->bilinear.GetText(),
+                                                    0 };
 
 //----------------------------------------------------------------------------------------------------------------------
 void registerCommonTranslatorOptions()
@@ -39,6 +48,8 @@ void registerCommonTranslatorOptions()
         g_exportOptions->addBool(GeometryExportOptions::kMeshHoles, true);
         g_exportOptions->addBool(GeometryExportOptions::kNormalsAsPrimvars, false);
         g_exportOptions->addBool(GeometryExportOptions::kReverseOppositeNormals, false);
+        g_exportOptions->addEnum(
+            GeometryExportOptions::kSubdivisionScheme, g_subdivisionSchemes, 0);
         g_exportOptions->addEnum(GeometryExportOptions::kCompactionLevel, g_compactionLevels, 3);
     }
 

--- a/plugin/al/translators/CommonTranslatorOptions.h
+++ b/plugin/al/translators/CommonTranslatorOptions.h
@@ -28,6 +28,8 @@ static constexpr const char* const kNormalsAsPrimvars
 static constexpr const char* const kReverseOppositeNormals
     = "Reverse Opposite Normals"; ///< if true, normals will be reversed when the opposite flag is
                                   ///< enabled
+static constexpr const char* const kSubdivisionScheme
+    = "Subdivision scheme"; ///< subdivision method
 static constexpr const char* const kCompactionLevel
     = "Compaction Level"; ///< export mesh face holes
 static constexpr const char* const kNurbsCurves

--- a/plugin/al/translators/Mesh.cpp
+++ b/plugin/al/translators/Mesh.cpp
@@ -97,7 +97,13 @@ MStatus Mesh::import(const UsdPrim& prim, MObject& parent, MObject& createdObj)
     }
 
     AL::usdmaya::utils::MeshImportContext importContext(mesh, parent, dagName, timeCode);
-    importContext.applyVertexNormals();
+    TfToken                               scheme;
+    mesh.GetSubdivisionSchemeAttr().Get(&scheme);
+    bool isSubd = (scheme != UsdGeomTokens->none);
+    // Skip normals for subdiv surfaces
+    if (!isSubd) {
+        importContext.applyVertexNormals();
+    }
     importContext.applyHoleFaces();
     importContext.applyVertexCreases();
     importContext.applyEdgeCreases();

--- a/plugin/al/translators/Mesh.cpp
+++ b/plugin/al/translators/Mesh.cpp
@@ -147,13 +147,18 @@ UsdPrim Mesh::exportObject(
     auto compaction = (AL::usdmaya::utils::MeshExportContext::CompactionLevel)params.getInt(
         GeometryExportOptions::kCompactionLevel);
 
+    auto subdivisionScheme
+        = (AL::usdmaya::utils::MeshExportContext::SubdivisionScheme)params.getInt(
+            GeometryExportOptions::kSubdivisionScheme);
+
     AL::usdmaya::utils::MeshExportContext context(
         dagPath,
         mesh,
         params.m_timeCode,
         false,
         compaction,
-        params.getBool(GeometryExportOptions::kReverseOppositeNormals));
+        params.getBool(GeometryExportOptions::kReverseOppositeNormals),
+        subdivisionScheme);
     if (context) {
         UsdAttribute pointsAttr = mesh.GetPointsAttr();
         if (params.m_animTranslator && AnimationTranslator::isAnimatedMesh(dagPath)) {

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/DiffPrimVar.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/DiffPrimVar.cpp
@@ -116,7 +116,7 @@ uint32_t diffGeom(UsdGeomPointBased& geom, MFnMesh& mesh, UsdTimeCode timeCode, 
             const float* const usdNormals = (const float* const)normalData.cdata();
             const float* const mayaNormals = (const float* const)mesh.getRawNormals(&status);
             const size_t       usdNormalsCount = normalData.size();
-            const size_t       mayaNormalsCount = mesh.numVertices();
+            const size_t       mayaNormalsCount = mesh.numNormals();
             if (!MayaUsdUtils::compareArray(
                     usdNormals, mayaNormals, usdNormalsCount * 3, mayaNormalsCount * 3)) {
                 result |= kNormals;

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
@@ -1917,8 +1917,20 @@ void MeshExportContext::copyNormalData(UsdTimeCode time, bool copyAsPrimvar)
                             mesh.SetNormalsInterpolation(UsdGeomTokens->vertex);
                         }
 
-                        VtArray<GfVec3f> normals(vecData, vecData + numNormals);
-                        normalsAttr.Set(normals, time);
+                        if (numNormals == (size_t)fnMesh.numVertices()) {
+                            auto             object = fnMesh.object();
+                            MItMeshVertex    itVertex(object);
+                            VtArray<GfVec3f> normals(numNormals);
+                            for (size_t i = 0; !itVertex.isDone(); itVertex.next(), i++) {
+                                MVector mayaNormal;
+                                itVertex.getNormal(mayaNormal);
+                                normals[i] = GfVec3f(mayaNormal.x, mayaNormal.y, mayaNormal.z);
+                            }
+                            normalsAttr.Set(normals, time);
+                        } else {
+                            VtArray<GfVec3f> normals(vecData, vecData + numNormals);
+                            normalsAttr.Set(normals, time);
+                        }
                     } else {
                         std::unordered_map<uint32_t, uint32_t> missing;
                         bool                                   isPerVertex = true;

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
@@ -980,14 +980,14 @@ MeshExportContext::MeshExportContext(
     bool              performDiff,
     CompactionLevel   compactionLevel,
     bool              reverseNormals,
-    SubdivisionScheme subdivisionScheme)
+    SubdivisionScheme inSubdivisionScheme)
     : fnMesh()
     , faceCounts()
     , faceConnects()
     , m_timeCode(timeCode)
     , mesh(mesh)
     , compaction(compactionLevel)
-    , subdivisionScheme(subdivisionScheme)
+    , subdivisionScheme(inSubdivisionScheme)
     , performDiff(performDiff)
     , reverseNormals(reverseNormals)
 {

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
@@ -1909,7 +1909,8 @@ void MeshExportContext::copyNormalData(UsdTimeCode time, bool copyAsPrimvar)
                             &normalIndices[0],
                             &faceConnects[0],
                             normalIndices.length(),
-                            faceConnects.length())) {
+                            faceConnects.length())
+                        || numNormals == (size_t)fnMesh.numVertices()) {
                         if (copyAsPrimvar) {
                             primvar.SetInterpolation(UsdGeomTokens->vertex);
                         } else {

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
@@ -505,15 +505,6 @@ bool MeshImportContext::applyVertexNormals()
         return false;
     };
 
-    // Lambda to set face vertex normals in unlocked state
-    auto setUnlockedFaceVertexNormals
-        = [&](MVectorArray& normals, MIntArray& faceList, MIntArray& vertexList) -> bool {
-        if (fnMesh.setFaceVertexNormals(normals, faceList, vertexList, MSpace::kObject)) {
-            return fnMesh.unlockFaceVertexNormals(faceList, vertexList);
-        }
-        return false;
-    };
-
     if (normals.length()) {
         // According to the docs for UsdGeomMesh: If 'normals' and 'primvars:normals' are both
         // specified, the latter has precedence.
@@ -555,9 +546,11 @@ bool MeshImportContext::applyVertexNormals()
                         ns[i] = normals[indices[i]];
                     }
 
-                    return setUnlockedFaceVertexNormals(ns, normalsFaceIds, connects);
+                    return fnMesh.setFaceVertexNormals(
+                        ns, normalsFaceIds, connects, MSpace::kObject);
                 } else {
-                    return setUnlockedFaceVertexNormals(normals, normalsFaceIds, connects);
+                    return fnMesh.setFaceVertexNormals(
+                        normals, normalsFaceIds, connects, MSpace::kObject);
                 }
             }
         } else {
@@ -574,7 +567,8 @@ bool MeshImportContext::applyVertexNormals()
                         }
                     }
                 }
-                return setUnlockedFaceVertexNormals(normals, normalsFaceIds, connects);
+                return fnMesh.setFaceVertexNormals(
+                    normals, normalsFaceIds, connects, MSpace::kObject);
             }
         }
     }
@@ -980,18 +974,20 @@ void MeshImportContext::applyUVs()
 
 //----------------------------------------------------------------------------------------------------------------------
 MeshExportContext::MeshExportContext(
-    MDagPath        path,
-    UsdGeomMesh&    mesh,
-    UsdTimeCode     timeCode,
-    bool            performDiff,
-    CompactionLevel compactionLevel,
-    bool            reverseNormals)
+    MDagPath          path,
+    UsdGeomMesh&      mesh,
+    UsdTimeCode       timeCode,
+    bool              performDiff,
+    CompactionLevel   compactionLevel,
+    bool              reverseNormals,
+    SubdivisionScheme subdivisionScheme)
     : fnMesh()
     , faceCounts()
     , faceConnects()
     , m_timeCode(timeCode)
     , mesh(mesh)
     , compaction(compactionLevel)
+    , subdivisionScheme(subdivisionScheme)
     , performDiff(performDiff)
     , reverseNormals(reverseNormals)
 {
@@ -1005,6 +1001,19 @@ MeshExportContext::MeshExportContext(
 
     if (!reverseNormals && fnMesh.findPlug("opposite", true).asBool()) {
         mesh.CreateOrientationAttr().Set(UsdGeomTokens->leftHanded);
+    }
+
+    TfToken subdToken;
+    switch (subdivisionScheme) {
+    case kSubdCatmull: subdToken = UsdGeomTokens->catmullClark; break;
+    case kSubdNone: subdToken = UsdGeomTokens->none; break;
+    case kSubdLoop: subdToken = UsdGeomTokens->loop; break;
+    case kSubdBilinear: subdToken = UsdGeomTokens->bilinear; break;
+    default: break;
+    }
+    // Author opinion only if "default" has not been used.
+    if (!subdToken.IsEmpty()) {
+        mesh.GetSubdivisionSchemeAttr().Set(subdToken);
     }
 
     if (performDiff) {
@@ -1934,14 +1943,19 @@ void MeshExportContext::copyNormalData(UsdTimeCode time, bool copyAsPrimvar)
                     } else {
                         std::unordered_map<uint32_t, uint32_t> missing;
                         bool                                   isPerVertex = true;
-                        for (uint32_t i = 0, n = normalIndices.length(); isPerVertex && i < n;
-                             ++i) {
-                            if (normalIndices[i] != faceConnects[i]) {
-                                auto it = missing.find(normalIndices[i]);
-                                if (it == missing.end()) {
-                                    missing[normalIndices[i]] = faceConnects[i];
-                                } else if (it->second != uint32_t(faceConnects[i])) {
-                                    isPerVertex = false;
+                        const unsigned int numFaceVertices = fnMesh.numFaceVertices(&status);
+                        if (numFaceVertices == normalIndices.length()) {
+                            isPerVertex = false;
+                        } else {
+                            for (uint32_t i = 0, n = normalIndices.length(); isPerVertex && i < n;
+                                 ++i) {
+                                if (normalIndices[i] != faceConnects[i]) {
+                                    auto it = missing.find(normalIndices[i]);
+                                    if (it == missing.end()) {
+                                        missing[normalIndices[i]] = faceConnects[i];
+                                    } else if (it->second != uint32_t(faceConnects[i])) {
+                                        isPerVertex = false;
+                                    }
                                 }
                             }
                         }

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.h
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.h
@@ -212,6 +212,15 @@ public:
         kFull
     };
 
+    enum SubdivisionScheme
+    {
+        kSubdDefault,
+        kSubdCatmull,
+        kSubdNone,
+        kSubdLoop,
+        kSubdBilinear,
+    };
+
     /// \brief  constructor
     /// \param  path the DAG path of the Maya mesh being exported
     /// \param  mesh an intialised USD prim into which the data should be copied
@@ -221,12 +230,13 @@ public:
     /// computing interpolation modes
     AL_USDMAYA_UTILS_PUBLIC
     MeshExportContext(
-        MDagPath        path,
-        UsdGeomMesh&    mesh,
-        UsdTimeCode     timeCode,
-        bool            performDiff = false,
-        CompactionLevel compactionLevel = kFull,
-        bool            reverseNormals = false);
+        MDagPath          path,
+        UsdGeomMesh&      mesh,
+        UsdTimeCode       timeCode,
+        bool              performDiff = false,
+        CompactionLevel   compactionLevel = kFull,
+        bool              reverseNormals = false,
+        SubdivisionScheme subdivisionScheme = kSubdDefault);
 
     /// \brief  returns true if it's ok to continue exporting the data
     operator bool() const { return valid; }
@@ -288,17 +298,18 @@ public:
     UsdTimeCode timeCode() const { return m_timeCode; }
 
 private:
-    MFnMesh         fnMesh;       ///< the maya function set
-    MIntArray       faceCounts;   ///< the number of verts in each face
-    MIntArray       faceConnects; ///< the face-vertex indices
-    UsdTimeCode     m_timeCode;   ///< the time at which to extract the mesh data
-    UsdGeomMesh&    mesh;         ///< the usd geometry
-    uint32_t        diffGeom;     ///< the bit flags for standard geom params
-    uint32_t        diffMesh;     ///< the bit flags for mesh params
-    CompactionLevel compaction;
-    bool            valid;          ///< true if the function set is ok
-    bool            performDiff;    ///< true if performing a diff on export
-    bool            reverseNormals; ///< true if reversing normals on 'opposite' meshes
+    MFnMesh           fnMesh;       ///< the maya function set
+    MIntArray         faceCounts;   ///< the number of verts in each face
+    MIntArray         faceConnects; ///< the face-vertex indices
+    UsdTimeCode       m_timeCode;   ///< the time at which to extract the mesh data
+    UsdGeomMesh&      mesh;         ///< the usd geometry
+    uint32_t          diffGeom;     ///< the bit flags for standard geom params
+    uint32_t          diffMesh;     ///< the bit flags for mesh params
+    CompactionLevel   compaction;
+    SubdivisionScheme subdivisionScheme;
+    bool              valid;          ///< true if the function set is ok
+    bool              performDiff;    ///< true if performing a diff on export
+    bool              reverseNormals; ///< true if reversing normals on 'opposite' meshes
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/plugin/al/usdtransaction/CMakeLists.txt
+++ b/plugin/al/usdtransaction/CMakeLists.txt
@@ -30,9 +30,6 @@ configure_file(
 # install python module
 foreach(INPUT_FILE ${PY_INIT_FILES})
   string(REPLACE ${CMAKE_CURRENT_SOURCE_DIR} ${AL_INSTALL_PREFIX}/lib/python OUTPUT_FILE ${INPUT_FILE})
-  # use bracket-argument-syntax for ${Python_EXECUTABLE}, which may contain
-  # backslashes on windows
-  install(CODE "execute_process(COMMAND [[${Python_EXECUTABLE}]] -m compileall \"${INPUT_FILE}\" )")
   get_filename_component(OUTPUT_PATH ${OUTPUT_FILE} DIRECTORY)
   install(FILES
         ${INPUT_FILE}  # .py files


### PR DESCRIPTION
Here are another batch of changes in AL's plugin.
The changes made around normals were aimed at restoring some coherence between the type of mesh (poly vs subdiv) and normals handling. Prior to this there was zero coupling between the which means that exporting subdiv with custom normals was perfectly valid.