### PR TITLE
MAYA-114979 MAYA-114731 Fix correctness issues

### DIFF
--- a/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
@@ -348,6 +348,9 @@ private:
             if (context.GetExportArgs().allMaterialConversions.size() > 1) {
                 // Write each material in its own scope
                 materialExportPath = materialExportPath.AppendChild(currentMaterialConversion);
+
+                // This path needs to be a NodeGraph:
+                UsdShadeNodeGraph::Define(context.GetUsdStage(), materialExportPath);
             }
 
             UsdShadeShader surfaceShaderSchema = _ExportShadingDepGraph(
@@ -364,6 +367,15 @@ private:
                 materialExportPath, context.GetDisplacementShaderPlug(), context);
             UsdMayaShadingUtil::CreateShaderOutputAndConnectMaterial(
                 displacementShaderSchema, material, UsdShadeTokens->displacement, renderContext);
+
+            // Clean-up nodegraph if nothing was exported:
+            if (context.GetExportArgs().allMaterialConversions.size() > 1) {
+                UsdPrim nodeGraphPrim(context.GetUsdStage()->GetPrimAtPath(materialExportPath));
+
+                if (nodeGraphPrim.GetAllChildren().empty()) {
+                    context.GetUsdStage()->RemovePrim(materialExportPath);
+                }
+            }
         }
         context.BindStandardMaterialPrim(materialPrim, assignments, boundPrimPaths);
     }

--- a/lib/mayaUsd/fileio/translators/translatorMaterial.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMaterial.cpp
@@ -63,6 +63,7 @@ TF_DEFINE_PRIVATE_TOKENS(
 
     (inputs)
     (varname)
+    (varnameStr)
 );
 // clang-format on
 
@@ -101,14 +102,15 @@ bool _IsMergeableMaterial(const UsdShadeMaterial& shadeMaterial)
         return false;
     }
 
-    // Check that the only properties authored are varname inputs.
+    // Check that the only properties authored are varname and varnameStr inputs.
     for (const SdfPropertySpecHandle& propSpec : primSpec->GetProperties()) {
         const SdfPath propPath = propSpec->GetPath();
 
         const std::vector<std::string> splitName = SdfPath::TokenizeIdentifier(propPath.GetName());
-        // We allow only ["inputs", "<texture_name>", "varname"]
+        // We allow only ["inputs", "<texture_name>", "varname" or "varnameStr"]
         if (splitName.size() != 3u || splitName[0u] != _tokens->inputs.GetString()
-            || splitName[2u] != _tokens->varname.GetString()) {
+            || (splitName[2u] != _tokens->varname.GetString()
+                && splitName[2u] != _tokens->varnameStr.GetString())) {
             return false;
         }
     }
@@ -178,7 +180,9 @@ _GetUVBindingsFromMaterial(const UsdShadeMaterial& material, UsdMayaPrimReaderCo
     for (const UsdShadeInput& input : material.GetInputs()) {
         const UsdAttribute&      usdAttr = input.GetAttr();
         std::vector<std::string> splitName = usdAttr.SplitName();
-        if (splitName.size() != 3 || splitName[2] != _tokens->varname.GetString()) {
+        if (splitName.size() != 3
+            || (splitName[2] != _tokens->varname.GetString()
+                && splitName[2] != _tokens->varnameStr.GetString())) {
             continue;
         }
         VtValue val;

--- a/lib/mayaUsd/fileio/utils/shadingUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/shadingUtil.cpp
@@ -149,7 +149,18 @@ UsdShadeOutput UsdMayaShadingUtil::CreateShaderOutputAndConnectMaterial(
 
     UsdShadeOutput shaderOutput = shader.CreateOutput(terminalName, materialOutput.GetTypeName());
 
-    materialOutput.ConnectToSource(shaderOutput);
+    UsdPrim parentPrim = shader.GetPrim().GetParent();
+    if (parentPrim == material.GetPrim()) {
+        materialOutput.ConnectToSource(shaderOutput);
+    } else {
+        // If the surface is inside a multi-material node graph, then we must create an intermediate
+        // output on the NodeGraph
+        UsdShadeNodeGraph parentNodeGraph(parentPrim);
+        UsdShadeOutput    parentOutput
+            = parentNodeGraph.CreateOutput(terminalName, materialOutput.GetTypeName());
+        parentOutput.ConnectToSource(shaderOutput);
+        materialOutput.ConnectToSource(parentOutput);
+    }
 
     return shaderOutput;
 }

--- a/lib/usd/translators/shading/mtlxFileTextureWriter.cpp
+++ b/lib/usd/translators/shading/mtlxFileTextureWriter.cpp
@@ -150,7 +150,8 @@ MtlxUsd_FileWriter::MtlxUsd_FileWriter(
     }
 
     // Now create a geompropvalue reader that the image shader will use.
-    SdfPath primvarReaderPath = _GetPlace2DTexturePath(depNodeFn);
+    SdfPath        primvarReaderPath = _GetPlace2DTexturePath(depNodeFn);
+    UsdShadeOutput primvarReaderOutput;
 
     if (!GetUsdStage()->GetPrimAtPath(primvarReaderPath)) {
         UsdShadeShader primvarReaderSchema
@@ -188,29 +189,20 @@ MtlxUsd_FileWriter::MtlxUsd_FileWriter(
             varnameInput.Set(UsdUtilsGetPrimaryUVSetName());
         }
 
-        UsdShadeOutput primvarReaderOutput
+        primvarReaderOutput
             = primvarReaderSchema.CreateOutput(TrMtlxTokens->out, SdfValueTypeNames->Float2);
-
-        // TODO: Handle UV SRT with a ND_place2d_vector2 node. Make sure the name derives from the
-        //       place2dTexture node if there is one (see usdFileTextureWriter for details)
-
-        // Connect the output of the primvar reader to the texture coordinate
-        // input of the UV texture.
-        texSchema.CreateInput(TrMtlxTokens->texcoord, SdfValueTypeNames->Float2)
-            .ConnectToSource(primvarReaderOutput);
     } else {
         // Re-using an existing primvar reader:
         UsdShadeShader primvarReaderShaderSchema(GetUsdStage()->GetPrimAtPath(primvarReaderPath));
-        UsdShadeOutput primvarReaderOutput = primvarReaderShaderSchema.GetOutput(TrMtlxTokens->out);
-
-        // TODO: Handle UV SRT with a ND_place2d_vector2 node. Make sure the name derives from the
-        //       place2dTexture node if there is one (see usdFileTextureWriter for details)
-
-        // Connect the output of the primvar reader to the texture coordinate
-        // input of the UV texture.
-        texSchema.CreateInput(TrMtlxTokens->texcoord, SdfValueTypeNames->Float2)
-            .ConnectToSource(primvarReaderOutput);
+        primvarReaderOutput = primvarReaderShaderSchema.GetOutput(TrMtlxTokens->out);
     }
+    // TODO: Handle UV SRT with a ND_place2d_vector2 node. Make sure the name derives from the
+    //       place2dTexture node if there is one (see usdFileTextureWriter for details)
+
+    // Connect the output of the primvar reader to the texture coordinate
+    // input of the UV texture.
+    texSchema.CreateInput(TrMtlxTokens->texcoord, SdfValueTypeNames->Float2)
+        .ConnectToSource(primvarReaderOutput);
 }
 
 /* virtual */

--- a/lib/usd/translators/shading/mtlxFileTextureWriter.cpp
+++ b/lib/usd/translators/shading/mtlxFileTextureWriter.cpp
@@ -159,8 +159,8 @@ MtlxUsd_FileWriter::MtlxUsd_FileWriter(
         UsdShadeInput varnameInput
             = primvarReaderSchema.CreateInput(TrMtlxTokens->geomprop, SdfValueTypeNames->String);
 
-        TfToken       inputName(TfStringPrintf(
-            "%s:%s", depNodeFn.name().asChar(), TrMtlxTokens->varnameStr.GetText()));
+        TfToken inputName(
+            TfStringPrintf("%s:%s", depNodeFn.name().asChar(), TrMtlxTokens->varnameStr.GetText()));
 
         // We expose the primvar reader varnameStr attribute to the material to allow
         // easy specialization based on UV mappings to geometries:
@@ -201,8 +201,7 @@ MtlxUsd_FileWriter::MtlxUsd_FileWriter(
     } else {
         // Re-using an existing primvar reader:
         UsdShadeShader primvarReaderShaderSchema(GetUsdStage()->GetPrimAtPath(primvarReaderPath));
-        UsdShadeOutput primvarReaderOutput
-            = primvarReaderShaderSchema.GetOutput(TrMtlxTokens->out);
+        UsdShadeOutput primvarReaderOutput = primvarReaderShaderSchema.GetOutput(TrMtlxTokens->out);
 
         // TODO: Handle UV SRT with a ND_place2d_vector2 node. Make sure the name derives from the
         //       place2dTexture node if there is one (see usdFileTextureWriter for details)

--- a/lib/usd/translators/shading/mtlxPreviewSurfaceWriter.cpp
+++ b/lib/usd/translators/shading/mtlxPreviewSurfaceWriter.cpp
@@ -88,13 +88,7 @@ MtlxUsd_PreviewSurfaceWriter::MtlxUsd_PreviewSurfaceWriter(
 
     shaderSchema.CreateIdAttr(VtValue(TrMtlxTokens->ND_UsdPreviewSurface_surfaceshader));
 
-    UsdShadeNodeGraph nodegraphSchema(GetNodeGraph());
-    if (!TF_VERIFY(
-            nodegraphSchema,
-            "Could not define UsdShadeNodeGraph at path '%s'\n",
-            GetUsdPath().GetText())) {
-        return;
-    }
+    UsdShadeNodeGraph nodegraphSchema;
 
     for (const TfToken& mayaAttrName : PxrMayaUsdPreviewSurfaceTokens->allTokens) {
 
@@ -135,6 +129,15 @@ MtlxUsd_PreviewSurfaceWriter::MtlxUsd_PreviewSurfaceWriter(
 
         // All connections go directly to the node graph:
         if (attrPlug.isConnected()) {
+            if (!nodegraphSchema) {
+                nodegraphSchema = UsdShadeNodeGraph(GetNodeGraph());
+                if (!TF_VERIFY(
+                        nodegraphSchema,
+                        "Could not define UsdShadeNodeGraph at path '%s'\n",
+                        GetUsdPath().GetText())) {
+                    return;
+                }
+            }
             UsdShadeOutput ngOutput = nodegraphSchema.CreateOutput(mayaAttrName, valueTypeName);
             input.ConnectToSource(ngOutput);
         }

--- a/lib/usd/translators/shading/mtlxStandardSurfaceWriter.cpp
+++ b/lib/usd/translators/shading/mtlxStandardSurfaceWriter.cpp
@@ -135,13 +135,7 @@ MaterialXTranslators_StandardSurfaceWriter::MaterialXTranslators_StandardSurface
 
     shaderSchema.CreateIdAttr(VtValue(TrMtlxTokens->ND_standard_surface_surfaceshader));
 
-    UsdShadeNodeGraph nodegraphSchema(GetNodeGraph());
-    if (!TF_VERIFY(
-            nodegraphSchema,
-            "Could not define UsdShadeNodeGraph at path '%s'\n",
-            GetUsdPath().GetText())) {
-        return;
-    }
+    UsdShadeNodeGraph nodegraphSchema;
 
     for (unsigned int i = 0u; i < depNodeFn.attributeCount(); ++i) {
         const MObject      attrObj = depNodeFn.reorderedAttribute(i);
@@ -188,6 +182,15 @@ MaterialXTranslators_StandardSurfaceWriter::MaterialXTranslators_StandardSurface
 
         // All connections go directly to the node graph:
         if (attrPlug.isConnected()) {
+            if (!nodegraphSchema) {
+                nodegraphSchema = UsdShadeNodeGraph(GetNodeGraph());
+                if (!TF_VERIFY(
+                        nodegraphSchema,
+                        "Could not define UsdShadeNodeGraph at path '%s'\n",
+                        GetUsdPath().GetText())) {
+                    return;
+                }
+            }
             UsdShadeOutput ngOutput = nodegraphSchema.CreateOutput(mayaAttrName, valueTypeName);
             input.ConnectToSource(ngOutput);
         }

--- a/lib/usd/translators/shading/shadingTokens.h
+++ b/lib/usd/translators/shading/shadingTokens.h
@@ -262,6 +262,7 @@ TF_DECLARE_PUBLIC_TOKENS(
     (cubic)
 
 #define TR_MTLX_ATTRIBUTES \
+    (varnameStr) \
     (geomprop) \
     (channels) \
     (in) \

--- a/test/lib/mayaUsd/fileio/UsdImportMaterialX/UsdImportMaterialX.usda
+++ b/test/lib/mayaUsd/fileio/UsdImportMaterialX/UsdImportMaterialX.usda
@@ -52,9 +52,9 @@ def Scope "Looks"
 {
 	def Material "standardSurface2SG"
 	{
-		string inputs:file1:varname = "map1"
-		string inputs:file2:varname = "map1"
-		string inputs:file3:varname = "map1"
+		string inputs:file1:varnameStr = "map1"
+		string inputs:file2:varnameStr = "map1"
+		string inputs:file3:varnameStr = "map1"
 		token outputs:mtlx:surface.connect = </Looks/standardSurface2SG/standardSurface2.outputs:surface>
 
 		def Shader "standardSurface2"
@@ -92,7 +92,7 @@ def Scope "Looks"
 			def Shader "MayaGeomPropValue_file1"
 			{
 				uniform token info:id = "ND_geompropvalue_vector2"
-				string inputs:geomprop.connect = </Looks/standardSurface2SG.inputs:file1:varname>
+				string inputs:geomprop.connect = </Looks/standardSurface2SG.inputs:file1:varnameStr>
 				float2 outputs:out
 			}
 
@@ -112,7 +112,7 @@ def Scope "Looks"
 			def Shader "MayaGeomPropValue_file2"
 			{
 				uniform token info:id = "ND_geompropvalue_vector2"
-				string inputs:geomprop.connect = </Looks/standardSurface2SG.inputs:file2:varname>
+				string inputs:geomprop.connect = </Looks/standardSurface2SG.inputs:file2:varnameStr>
 				float2 outputs:out
 			}
 
@@ -148,7 +148,7 @@ def Scope "Looks"
 			def Shader "MayaGeomPropValue_file3"
 			{
 				uniform token info:id = "ND_geompropvalue_vector2"
-				string inputs:geomprop.connect = </Looks/standardSurface2SG.inputs:file3:varname>
+				string inputs:geomprop.connect = </Looks/standardSurface2SG.inputs:file3:varnameStr>
 				float2 outputs:out
 			}
 

--- a/test/lib/usd/translators/UsdImportMaterialX/UsdImportMaterialX.usda
+++ b/test/lib/usd/translators/UsdImportMaterialX/UsdImportMaterialX.usda
@@ -52,9 +52,9 @@ def Scope "Looks"
 {
 	def Material "standardSurface2SG"
 	{
-		string inputs:file1:varname = "map1"
-		string inputs:file2:varname = "map1"
-		string inputs:file3:varname = "map1"
+		string inputs:file1:varnameStr = "map1"
+		string inputs:file2:varnameStr = "map1"
+		string inputs:file3:varnameStr = "map1"
 		token outputs:mtlx:surface.connect = </Looks/standardSurface2SG/standardSurface2.outputs:surface>
 
 		def Shader "standardSurface2"
@@ -92,7 +92,7 @@ def Scope "Looks"
 			def Shader "MayaGeomPropValue_file1"
 			{
 				uniform token info:id = "ND_geompropvalue_vector2"
-				string inputs:geomprop.connect = </Looks/standardSurface2SG.inputs:file1:varname>
+				string inputs:geomprop.connect = </Looks/standardSurface2SG.inputs:file1:varnameStr>
 				float2 outputs:out
 			}
 
@@ -112,7 +112,7 @@ def Scope "Looks"
 			def Shader "MayaGeomPropValue_file2"
 			{
 				uniform token info:id = "ND_geompropvalue_vector2"
-				string inputs:geomprop.connect = </Looks/standardSurface2SG.inputs:file2:varname>
+				string inputs:geomprop.connect = </Looks/standardSurface2SG.inputs:file2:varnameStr>
 				float2 outputs:out
 			}
 
@@ -148,7 +148,7 @@ def Scope "Looks"
 			def Shader "MayaGeomPropValue_file3"
 			{
 				uniform token info:id = "ND_geompropvalue_vector2"
-				string inputs:geomprop.connect = </Looks/standardSurface2SG.inputs:file3:varname>
+				string inputs:geomprop.connect = </Looks/standardSurface2SG.inputs:file3:varnameStr>
 				float2 outputs:out
 			}
 

--- a/test/lib/usd/translators/testUsdExportMaterialX.py
+++ b/test/lib/usd/translators/testUsdExportMaterialX.py
@@ -84,8 +84,8 @@ class testUsdExportMaterialX(unittest.TestCase):
         material_path = mat.GetPath().pathString
         self.assertEqual(material_path, base_path)
 
-        # Needs a resolved inputs:file1:varname attribute:
-        self.assertEqual(mat.GetInput("file1:varname").GetAttr().Get(), "st")
+        # Needs a resolved inputs:file1:varnameStr attribute:
+        self.assertEqual(mat.GetInput("file1:varnameStr").GetAttr().Get(), "st")
 
         # Needs a MaterialX surface source:
         shader = mat.ComputeSurfaceSource("mtlx")[0]
@@ -132,7 +132,7 @@ class testUsdExportMaterialX(unittest.TestCase):
         shader = UsdShade.Shader(cnxTuple[0])
         self.assertEqual(shader.GetIdAttr().Get(), "ND_geompropvalue_vector2")
         self.assertEqual(shader.GetPath(),
-                         ng_path + "/MayaGeomPropValue_file1")
+                         ng_path + "/place2dTexture1")
 
     def testExportTexturedMaterialXNodeTypes(self):
         '''
@@ -146,7 +146,7 @@ class testUsdExportMaterialX(unittest.TestCase):
             (1, 2, "file1", "ND_image_color3"),
             (4, 5, "file4", "ND_image_color4"),
 
-            (1, 2, "MayaGeomPropValue_file1", "ND_geompropvalue_vector2"),
+            (1, 2, "place2dTexture1", "ND_geompropvalue_vector2"),
 
             (4, 5, "MayaSwizzle_file4_rgb", "ND_swizzle_color4_color3"),
             (6, 7, "MayaSwizzle_file6_xxx", "ND_swizzle_vector2_color3"),
@@ -172,6 +172,7 @@ class testUsdExportMaterialX(unittest.TestCase):
             shader = UsdShade.Shader(prim)
             self.assertTrue(shader, prim_path)
             self.assertEqual(shader.GetIdAttr().Get(), id_attr, id_attr)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
This fixes #1834 for the last correctness problems mentioned

- Use a separate varnameStr for MaterialX since the type is not compatible with the varname used in UsdPreviewSurface
- Shared place2dTexture nodes are now shared on MaterialX export
- NodeGraph is used instead of Scope to isolate shaders by type in multi-material export
- NodeGraph boundaries are not skipped anymore by shader connections
- Cleaned-up code producing empty NodeGraphs