### PR TITLE
MAYA-114729 Use correct default for shading mode

### DIFF
--- a/plugin/adsk/plugin/importTranslator.cpp
+++ b/plugin/adsk/plugin/importTranslator.cpp
@@ -158,6 +158,10 @@ const std::string& UsdMayaImportTranslator::GetDefaultOptions()
         std::vector<std::string> entries;
         for (const std::pair<std::string, VtValue> keyValue :
              UsdMayaJobImportArgs::GetDefaultDictionary()) {
+            if (keyValue.first == UsdMayaJobImportArgsTokens->shadingMode.GetString()) {
+                // Shading mode varies with loaded plug-ins. Remove from defaults.
+                continue;
+            }
             bool        canConvert;
             std::string valueStr;
             std::tie(canConvert, valueStr) = UsdMayaUtil::ValueToArgument(keyValue.second);


### PR DESCRIPTION
Especially on a clean set of user prefs. The correct default is *nothing* and this allows properly merging the list of shading modes later at import time if none was specified.