### PR TITLE
MAYA-115091 Use cached textures

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -732,6 +732,11 @@ _LoadUdimTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& u
         return nullptr;
     }
 
+    MHWRender::MTexture* texture = textureMgr->findTexture(path.c_str());
+    if (texture) {
+        return texture;
+    }
+
     // HdSt sets the tile limit to the max number of textures in an array of 2d textures. OpenGL
     // says the minimum number of layers in 2048 so I'll use that.
     int                                   tileLimit = 2048;
@@ -808,7 +813,7 @@ _LoadUdimTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& u
 
     MColor               undefinedColor(0.0f, 1.0f, 0.0f, 1.0f);
     MStringArray         failedTilePaths;
-    MHWRender::MTexture* texture = textureMgr->acquireTiledTexture(
+    texture = textureMgr->acquireTiledTexture(
         textureName,
         tilePaths,
         tilePositions,
@@ -849,6 +854,11 @@ MHWRender::MTexture* _LoadTexture(
         = renderer ? renderer->getTextureManager() : nullptr;
     if (!TF_VERIFY(textureMgr)) {
         return nullptr;
+    }
+
+    MHWRender::MTexture* texture = textureMgr->findTexture(path.c_str());
+    if (texture) {
+        return texture;
     }
 
 #if PXR_VERSION >= 2102
@@ -917,8 +927,6 @@ MHWRender::MTexture* _LoadTexture(
     if (!image->Read(spec)) {
         return nullptr;
     }
-
-    MHWRender::MTexture* texture = nullptr;
 
     MHWRender::MTextureDescription desc;
     desc.setToDefault2DTexture();

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -811,8 +811,8 @@ _LoadUdimTexture(const std::string& path, bool& isColorSpaceSRGB, MFloatArray& u
         tilePositions.append(v);
     }
 
-    MColor               undefinedColor(0.0f, 1.0f, 0.0f, 1.0f);
-    MStringArray         failedTilePaths;
+    MColor       undefinedColor(0.0f, 1.0f, 0.0f, 1.0f);
+    MStringArray failedTilePaths;
     texture = textureMgr->acquireTiledTexture(
         textureName,
         tilePaths,

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1535,6 +1535,15 @@ void HdVP2Mesh::_CreateSmoothHullRenderItems(
 
         // now fill in _faceIdToGeomSubsetId at geomSubset.indices with the subset item pointer
         for (auto faceId : geomSubset.indices) {
+            if (faceId >= topology.GetNumFaces()) {
+                MString warning("Skipping faceID(");
+                warning += faceId;
+                warning += ") on GeomSubset \"";
+                warning += geomSubset.id.GetString().c_str();
+                warning += "\": greater than the number of faces in the mesh.";
+                MGlobal::displayWarning(warning);
+                continue;
+            }
             // we expect that material binding geom subsets will not overlap
             TF_VERIFY(SdfPath::EmptyPath() == _meshSharedData->_faceIdToGeomSubsetId[faceId]);
             _meshSharedData->_faceIdToGeomSubsetId[faceId] = geomSubset.id;


### PR DESCRIPTION
If 100 materials refer to the same image file, only load it once and ask the MTextureManager for cached copies for the 99 other materials.
Also fixes a crash if a GeomSubset faceId is greater than the number of faces on the mesh.
