### PR TITLE
MAYA-120860 Fix TestALUSDMayaPython_LayerManager random fails

### DIFF
--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -330,7 +330,7 @@ finally:
             "${pathvar}=${MAYAUSD_VARNAME_${pathvar}}")
     endforeach()
     
-    # Set a temporary folder path for the MAYA_APP_DIR in which the
+    # Set a temporary folder path for the TMP,TEMP and MAYA_APP_DIR in which the
     # maya profile will be created.
     # Note: replace bad chars in test_name with _.
     string(REGEX REPLACE "[:<>\|]" "_" SANITIZED_TEST_NAME ${test_name})
@@ -338,6 +338,8 @@ finally:
     # Note: ${WORKING_DIR} can point to the source folder, so don't use it
     #       in any env var that will write files (such as MAYA_APP_DIR).
     set_property(TEST "${test_name}" APPEND PROPERTY ENVIRONMENT
+        "TMP=${MAYA_APP_TEMP_DIR}"
+        "TEMP=${MAYA_APP_TEMP_DIR}"
         "MAYA_APP_DIR=${MAYA_APP_TEMP_DIR}")
     file(MAKE_DIRECTORY ${MAYA_APP_TEMP_DIR})
 
@@ -355,15 +357,6 @@ finally:
         "MAYA_NO_MORE_ASSERT=1"
         "MAYA_DISABLE_CIP=1"
         "MAYA_DISABLE_CER=1")
-
-    # Set a temporary folder path for the test
-    # Note: replace bad chars in test_name with _.
-    string(REGEX REPLACE "[:<>\|]" "_" SANITIZED_TEST_NAME ${test_name})
-    set(TEST_TEMP_DIR "${CMAKE_BINARY_DIR}/test/Temporary/${SANITIZED_TEST_NAME}")
-    set_property(TEST "${test_name}" APPEND PROPERTY ENVIRONMENT
-        "TMP=${TEST_TEMP_DIR}"
-        "TEMP=${TEST_TEMP_DIR}")
-    file(MAKE_DIRECTORY ${TEST_TEMP_DIR})
 
     if(IS_MACOSX)
         # Necessary for tests like DiffCore to find python

--- a/cmake/test.cmake
+++ b/cmake/test.cmake
@@ -356,6 +356,15 @@ finally:
         "MAYA_DISABLE_CIP=1"
         "MAYA_DISABLE_CER=1")
 
+    # Set a temporary folder path for the test
+    # Note: replace bad chars in test_name with _.
+    string(REGEX REPLACE "[:<>\|]" "_" SANITIZED_TEST_NAME ${test_name})
+    set(TEST_TEMP_DIR "${CMAKE_BINARY_DIR}/test/Temporary/${SANITIZED_TEST_NAME}")
+    set_property(TEST "${test_name}" APPEND PROPERTY ENVIRONMENT
+        "TMP=${TEST_TEMP_DIR}"
+        "TEMP=${TEST_TEMP_DIR}")
+    file(MAKE_DIRECTORY ${TEST_TEMP_DIR})
+
     if(IS_MACOSX)
         # Necessary for tests like DiffCore to find python
         set_property(TEST "${test_name}" APPEND PROPERTY ENVIRONMENT


### PR DESCRIPTION
Set TEMP and TMP environment variables for each tests registered with mayaUsd_add_test.