### PR TITLE
Add undo / redo to Edit-as-Maya workflows.

### DIFF
--- a/lib/mayaUsd/commands/CMakeLists.txt
+++ b/lib/mayaUsd/commands/CMakeLists.txt
@@ -23,6 +23,16 @@ set(HEADERS
         layerEditorWindowCommand.h
 )
 
+if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
+    target_sources(${PROJECT_NAME}
+        PRIVATE
+            PullPushCommands.cpp
+    )
+    list(APPEND HEADERS
+        PullPushCommands.h
+    )
+endif()
+
 # -----------------------------------------------------------------------------
 # promoted headers
 # -----------------------------------------------------------------------------

--- a/lib/mayaUsd/commands/PullPushCommands.cpp
+++ b/lib/mayaUsd/commands/PullPushCommands.cpp
@@ -1,0 +1,342 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "PullPushCommands.h"
+
+#include <mayaUsd/fileio/primUpdaterManager.h>
+#include <mayaUsd/ufe/Utils.h>
+#include <mayaUsd/undo/OpUndoItemRecorder.h>
+#include <mayaUsd/utils/util.h>
+
+#include <maya/MArgParser.h>
+#include <maya/MGlobal.h>
+#include <maya/MStringArray.h>
+#include <maya/MSyntax.h>
+#include <ufe/path.h>
+#include <ufe/pathString.h>
+
+#include <algorithm>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+namespace {
+
+// Reports an error to the Maya scripting console.
+void reportError(const MString& errorString) { MGlobal::displayError(errorString); }
+
+// Reports an error based on the status. Reports nothing on success.
+MStatus reportError(MStatus status)
+{
+    switch (status.statusCode()) {
+    case MStatus::kNotFound: reportError("No object were provided."); break;
+    case MStatus::kInvalidParameter: reportError("Invalid object path."); break;
+    case MStatus::kUnknownParameter: reportError("Invalid parameter."); break;
+    case MStatus::kSuccess: break;
+    default: reportError("Command parsing error."); break;
+    }
+
+    return status;
+}
+
+// Parses a string as a UFE path, detecting invalid paths and empty paths.
+MStatus parseArgAsUfePath(const MString& arg, Ufe::Path& outputPath)
+{
+    // Note: parsing can throw exceptions. Treat them as parsing error and return an empty path.
+    try {
+        outputPath = Ufe::PathString::path(arg.asChar());
+
+        if (outputPath.size() == 0)
+            return MS::kNotFound;
+
+        return MS::kSuccess;
+    } catch (const std::exception&) {
+        return MS::kInvalidParameter;
+    }
+}
+
+// Create the syntax for a command taking some string parameters representing UFE paths.
+MSyntax createSyntaxWithUfeArgs(int paramCount)
+{
+    MSyntax syntax;
+
+    syntax.enableQuery(false);
+    syntax.enableEdit(false);
+
+    for (int i = 0; i < paramCount; ++i)
+        syntax.addArg(MSyntax::kString);
+
+    return syntax;
+}
+
+// Verifies if a UFE path corresponds to a valid USD prim.
+bool isPrimPath(const Ufe::Path& path) { return ufePathToPrim(path).IsValid(); }
+
+// Parse the indexed argument as text.
+MStatus parseTextArg(const MArgParser& argParser, int index, MString& outputText)
+{
+    argParser.getCommandArgument(index, outputText);
+    if (outputText.length() <= 0)
+        return MS::kNotFound;
+
+    return MS::kSuccess;
+}
+
+// Parse the indexed argument as a UFE path.
+MStatus parseUfePathArg(const MArgParser& argParser, int index, Ufe::Path& outputPath)
+{
+    MString text;
+    MStatus status = parseTextArg(argParser, index, text);
+    if (MS::kSuccess != status)
+        return status;
+
+    return parseArgAsUfePath(text, outputPath);
+}
+
+MStatus parseDagPathArg(const MArgParser& argParser, int index, MDagPath& outputDagPath)
+{
+    MString text;
+    MStatus status = parseTextArg(argParser, index, text);
+    if (MS::kSuccess != status)
+        return status;
+
+    MObject obj;
+    status = PXR_NS::UsdMayaUtil::GetMObjectByName(text, obj);
+    if (status != MStatus::kSuccess)
+        return status;
+
+    return MDagPath::getAPathTo(obj, outputDagPath);
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+// PullPushBaseCommand
+//------------------------------------------------------------------------------
+
+// MPxCommand API to specify the command is undoable.
+bool PullPushBaseCommand::isUndoable() const { return true; }
+
+// MPxCommand API to redo the command.
+MStatus PullPushBaseCommand::redoIt() { return fUndoItemList.redo() ? MS::kSuccess : MS::kFailure; }
+
+// MPxCommand API to undo the command.
+MStatus PullPushBaseCommand::undoIt() { return fUndoItemList.undo() ? MS::kSuccess : MS::kFailure; }
+
+//------------------------------------------------------------------------------
+// EditAsMayaCommand
+//------------------------------------------------------------------------------
+
+// The edit as maya command name.
+const char EditAsMayaCommand::commandName[] = "mayaUsdEditAsMaya";
+
+// Empty edit as maya command.
+EditAsMayaCommand::EditAsMayaCommand() { }
+
+// MPxCommand API to create the command object.
+void* EditAsMayaCommand::creator()
+{
+    // Note: use static cast to make sure the right pointer type is returned into the void *.
+    return static_cast<MPxCommand*>(new EditAsMayaCommand());
+}
+
+// MPxCommand API to register the command syntax.
+MSyntax EditAsMayaCommand::createSyntax() { return createSyntaxWithUfeArgs(1); }
+
+// MPxCommand API to execute the command.
+MStatus EditAsMayaCommand::doIt(const MArgList& argList)
+{
+    clearResult();
+
+    setCommandString(commandName);
+
+    MStatus    status = MS::kSuccess;
+    MArgParser argParser(syntax(), argList, &status);
+    if (status != MS::kSuccess)
+        return status;
+
+    status = parseUfePathArg(argParser, 0, fPath);
+    if (status != MS::kSuccess)
+        return reportError(status);
+
+    if (!isPrimPath(fPath))
+        return reportError(MS::kInvalidParameter);
+
+    OpUndoItemRecorder undoRecorder(fUndoItemList);
+
+    auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
+    if (!manager.editAsMaya(fPath))
+        return MS::kFailure;
+
+    return MS::kSuccess;
+}
+
+//------------------------------------------------------------------------------
+// MergeToUsdCommand
+//------------------------------------------------------------------------------
+
+// The merge to USD command name.
+const char MergeToUsdCommand::commandName[] = "mayaUsdMergeToUsd";
+
+// Empty merge to USD command.
+MergeToUsdCommand::MergeToUsdCommand() { }
+
+// MPxCommand API to create the command object.
+void* MergeToUsdCommand::creator()
+{
+    // Note: use static cast to make sure the right pointer type is returned into the void *.
+    return static_cast<MPxCommand*>(new MergeToUsdCommand());
+}
+
+// MPxCommand API to register the command syntax.
+MSyntax MergeToUsdCommand::createSyntax() { return createSyntaxWithUfeArgs(1); }
+
+// MPxCommand API to execute the command.
+MStatus MergeToUsdCommand::doIt(const MArgList& argList)
+{
+    clearResult();
+
+    setCommandString(commandName);
+
+    MStatus    status = MS::kSuccess;
+    MArgParser argParser(syntax(), argList, &status);
+    if (status != MS::kSuccess)
+        return status;
+
+    if (status != MStatus::kSuccess)
+        return status;
+
+    MDagPath dagPath;
+    status = parseDagPathArg(argParser, 0, dagPath);
+    if (status != MS::kSuccess)
+        return reportError(status);
+
+    status = fDagNode.setObject(dagPath);
+    if (status != MS::kSuccess)
+        return reportError(status);
+
+    if (!PXR_NS::PrimUpdaterManager::readPullInformation(dagPath, fPulledPath))
+        return reportError(MS::kInvalidParameter);
+
+    OpUndoItemRecorder undoRecorder(fUndoItemList);
+
+    auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
+    if (!manager.mergeToUsd(fDagNode, fPulledPath))
+        return MS::kFailure;
+
+    return MS::kSuccess;
+}
+
+//------------------------------------------------------------------------------
+// DiscardEditsCommand
+//------------------------------------------------------------------------------
+
+// The discard edits command name.
+const char DiscardEditsCommand::commandName[] = "mayaUsdDiscardEdits";
+
+// Empty discard edits command.
+DiscardEditsCommand::DiscardEditsCommand() { }
+
+// MPxCommand API to create the command object.
+void* DiscardEditsCommand::creator()
+{
+    // Note: use static cast to make sure the right pointer type is returned into the void *.
+    return static_cast<MPxCommand*>(new DiscardEditsCommand());
+}
+
+// MPxCommand API to register the command syntax.
+MSyntax DiscardEditsCommand::createSyntax() { return createSyntaxWithUfeArgs(1); }
+
+// MPxCommand API to execute the command.
+MStatus DiscardEditsCommand::doIt(const MArgList& argList)
+{
+    clearResult();
+
+    setCommandString(commandName);
+
+    MStatus    status = MS::kSuccess;
+    MArgParser argParser(syntax(), argList, &status);
+    if (status != MS::kSuccess)
+        return status;
+
+    MString nodeName;
+    status = parseTextArg(argParser, 0, nodeName);
+    if (status != MS::kSuccess)
+        return reportError(status);
+
+    MDagPath dagPath = PXR_NS::UsdMayaUtil::nameToDagPath(nodeName.asChar());
+    if (!PXR_NS::PrimUpdaterManager::readPullInformation(dagPath, fPath))
+        return reportError(MS::kInvalidParameter);
+
+    OpUndoItemRecorder undoRecorder(fUndoItemList);
+
+    auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
+    if (!manager.discardEdits(fPath))
+        return MS::kFailure;
+
+    return MS::kSuccess;
+}
+
+//------------------------------------------------------------------------------
+// DuplicateCommand
+//------------------------------------------------------------------------------
+
+// The copy between Maya and USD command name.
+const char DuplicateCommand::commandName[] = "mayaUsdDuplicate";
+
+// Empty copy between Maya and USD command.
+DuplicateCommand::DuplicateCommand() { }
+
+// MPxCommand API to create the command object.
+void* DuplicateCommand::creator()
+{
+    // Note: use static cast to make sure the right pointer type is returned into the void *.
+    return static_cast<MPxCommand*>(new DuplicateCommand());
+}
+
+// MPxCommand API to register the command syntax.
+MSyntax DuplicateCommand::createSyntax() { return createSyntaxWithUfeArgs(2); }
+
+// MPxCommand API to execute the command.
+MStatus DuplicateCommand::doIt(const MArgList& argList)
+{
+    clearResult();
+
+    setCommandString(commandName);
+
+    MStatus    status = MS::kSuccess;
+    MArgParser argParser(syntax(), argList, &status);
+    if (status != MS::kSuccess)
+        return status;
+
+    status = parseUfePathArg(argParser, 0, fSrcPath);
+    if (status != MS::kSuccess)
+        return reportError(status);
+
+    status = parseUfePathArg(argParser, 1, fDstPath);
+    if (status != MS::kSuccess)
+        return reportError(status);
+
+    OpUndoItemRecorder undoRecorder(fUndoItemList);
+
+    auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
+    if (!manager.duplicate(fSrcPath, fDstPath))
+        return MS::kFailure;
+
+    return MS::kSuccess;
+}
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/commands/PullPushCommands.h
+++ b/lib/mayaUsd/commands/PullPushCommands.h
@@ -1,0 +1,191 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#ifndef PXRUSDMAYA_PULLPUSHCOMMANDS_H
+#define PXRUSDMAYA_PULLPUSHCOMMANDS_H
+
+#include <mayaUsd/base/api.h>
+#include <mayaUsd/mayaUsd.h>
+#include <mayaUsd/undo/OpUndoItemList.h>
+
+#include <maya/MFnDagNode.h>
+#include <maya/MPxCommand.h>
+#include <ufe/path.h>
+#include <ufe/undoableCommand.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+//------------------------------------------------------------------------------
+// PullPushBaseCommand
+//------------------------------------------------------------------------------
+
+//! \brief Base undoable command holding the undo item list.
+
+class PullPushBaseCommand : public MPxCommand
+{
+public:
+    //! \brief MPxCommand API to undo the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus undoIt() override;
+
+    //! \brief MPxCommand API to redo the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus redoIt() override;
+
+    //! \brief MPxCommand API to specify the command is undoable.
+    MAYAUSD_CORE_PUBLIC
+    bool isUndoable() const override;
+
+protected:
+    OpUndoItemList fUndoItemList;
+};
+
+//------------------------------------------------------------------------------
+// EditAsMayaCommand
+//------------------------------------------------------------------------------
+
+//! \brief Edit as maya undoable command.
+
+class EditAsMayaCommand : public PullPushBaseCommand
+{
+public:
+    //! \brief The edit as maya command name.
+    MAYAUSD_CORE_PUBLIC
+    static const char commandName[];
+
+    //! \brief MPxCommand API to create the command object.
+    MAYAUSD_CORE_PUBLIC
+    static void* creator();
+
+    //! \brief MPxCommand API to register the command syntax.
+    MAYAUSD_CORE_PUBLIC
+    static MSyntax createSyntax();
+
+    //! \brief MPxCommand API to execute the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus doIt(const MArgList& argList) override;
+
+private:
+    // Make sure callers need to call creator().
+    EditAsMayaCommand();
+
+    Ufe::Path fPath;
+};
+
+//------------------------------------------------------------------------------
+// MergeToUsdCommand
+//------------------------------------------------------------------------------
+
+//! \brief Merge to USD undoable command.
+
+class MergeToUsdCommand : public PullPushBaseCommand
+{
+public:
+    //! \brief The merge to USD command name.
+    MAYAUSD_CORE_PUBLIC
+    static const char commandName[];
+
+    //! \brief MPxCommand API to create the command object.
+    MAYAUSD_CORE_PUBLIC
+    static void* creator();
+
+    //! \brief MPxCommand API to register the command syntax.
+    MAYAUSD_CORE_PUBLIC
+    static MSyntax createSyntax();
+
+    //! \brief MPxCommand API to execute the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus doIt(const MArgList& argList) override;
+
+private:
+    // Make sure callers need to call creator().
+    MergeToUsdCommand();
+
+    MFnDagNode fDagNode;
+    Ufe::Path  fPulledPath;
+};
+
+//------------------------------------------------------------------------------
+// DiscardEditsCommand
+//------------------------------------------------------------------------------
+
+//! \brief Discards edits undoable command.
+
+class DiscardEditsCommand : public PullPushBaseCommand
+{
+public:
+    //! \brief The edit as maya command name.
+    MAYAUSD_CORE_PUBLIC
+    static const char commandName[];
+
+    //! \brief MPxCommand API to create the command object.
+    MAYAUSD_CORE_PUBLIC
+    static void* creator();
+
+    //! \brief MPxCommand API to register the command syntax.
+    MAYAUSD_CORE_PUBLIC
+    static MSyntax createSyntax();
+
+    //! \brief MPxCommand API to execute the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus doIt(const MArgList& argList) override;
+
+private:
+    // Make sure callers need to call creator().
+    DiscardEditsCommand();
+
+    Ufe::Path fPath;
+};
+
+//------------------------------------------------------------------------------
+// DuplicateCommand
+//------------------------------------------------------------------------------
+
+//! \brief Copy between Maya and USD undoable command.
+
+class DuplicateCommand : public PullPushBaseCommand
+{
+public:
+    //! \brief The copy between Maya and USD command name.
+    MAYAUSD_CORE_PUBLIC
+    static const char commandName[];
+
+    //! \brief MPxCommand API to create the command object.
+    MAYAUSD_CORE_PUBLIC
+    static void* creator();
+
+    //! \brief MPxCommand API to register the command syntax.
+    MAYAUSD_CORE_PUBLIC
+    static MSyntax createSyntax();
+
+    //! \brief MPxCommand API to execute the command.
+    MAYAUSD_CORE_PUBLIC
+    MStatus doIt(const MArgList& argList) override;
+
+private:
+    // Make sure callers need to call creator().
+    DuplicateCommand();
+
+    Ufe::Path fSrcPath;
+    Ufe::Path fDstPath;
+};
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF
+
+#endif /* PXRUSDMAYA_PULLPUSHCOMMANDS_H */

--- a/lib/mayaUsd/commands/baseImportCommand.cpp
+++ b/lib/mayaUsd/commands/baseImportCommand.cpp
@@ -18,6 +18,7 @@
 
 #include <mayaUsd/fileio/jobs/jobArgs.h>
 #include <mayaUsd/fileio/jobs/readJob.h>
+#include <mayaUsd/undo/OpUndoItemMuting.h>
 #include <mayaUsd/utils/util.h>
 
 #include <pxr/pxr.h>
@@ -125,6 +126,10 @@ std::unique_ptr<UsdMaya_ReadJob> MayaUSDImportCommand::initializeReadJob(
 /* virtual */
 MStatus MayaUSDImportCommand::doIt(const MArgList& args)
 {
+    // The import process has its own undo/redo recording.
+    // See: UsdMaya_ReadJob::Undo() and Redo().
+    OpUndoItemMuting undoInfoMuting;
+
     MStatus status;
 
     MArgDatabase argData(syntax(), args, &status);

--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -21,6 +21,7 @@
 #include <mayaUsd/fileio/translators/translatorXformable.h>
 #include <mayaUsd/fileio/utils/readUtil.h>
 #include <mayaUsd/nodes/stageNode.h>
+#include <mayaUsd/undo/OpUndoItemMuting.h>
 #include <mayaUsd/utils/stageCache.h>
 #include <mayaUsd/utils/util.h>
 #include <mayaUsd/utils/utilFileSystem.h>
@@ -64,6 +65,8 @@
 #include <utility>
 #include <vector>
 
+using namespace MAYAUSD_NS_DEF;
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 namespace {
@@ -97,6 +100,10 @@ UsdMaya_ReadJob::~UsdMaya_ReadJob() { }
 
 bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
 {
+    // Do not use the global undo info recording system.
+    // The read job Undo() / redo() functions will handle all operations.
+    OpUndoItemMuting undoMuting;
+
     MStatus status;
 
     if (!TF_VERIFY(!mImportData.empty())) {
@@ -528,7 +535,11 @@ bool UsdMaya_ReadJob::_DoImport(UsdPrimRange& rootRange, const UsdPrim& usdRootP
                         prototypeNode.removeChildAt(prototypeNode.childCount() - 1);
                     }
                 }
+#if MAYA_APP_VERSION >= 2020
+                deletePrototypeMod.deleteNode(prototypeObject, false);
+#else
                 deletePrototypeMod.deleteNode(prototypeObject);
+#endif
             }
         }
         deletePrototypeMod.doIt();
@@ -543,6 +554,10 @@ bool UsdMaya_ReadJob::SkipRootPrim(bool isImportingPseudoRoot) { return isImport
 
 bool UsdMaya_ReadJob::Redo()
 {
+    // Do not use the global undo info recording system.
+    // The read job Undo() / redo() functions will handle all operations.
+    OpUndoItemMuting undoMuting;
+
     // Undo the undo
     MStatus status = mDagModifierUndo.undoIt();
 
@@ -560,6 +575,10 @@ bool UsdMaya_ReadJob::Redo()
 
 bool UsdMaya_ReadJob::Undo()
 {
+    // Do not use the global undo info recording system.
+    // The read job Undo() / redo() functions will handle all operations.
+    OpUndoItemMuting undoMuting;
+
     // NOTE: (yliangsiew) All chasers need to have their Undo run as well.
     for (const UsdMayaImportChaserRefPtr& chaser : this->mImportChasers) {
         bool bStat = chaser->Undo();
@@ -588,7 +607,11 @@ bool UsdMaya_ReadJob::Undo()
                         }
                     }
                 }
+#if MAYA_APP_VERSION >= 2020
+                mDagModifierUndo.deleteNode(it.second, false);
+#else
                 mDagModifierUndo.deleteNode(it.second);
+#endif
             }
         }
     }

--- a/lib/mayaUsd/fileio/primUpdaterManager.h
+++ b/lib/mayaUsd/fileio/primUpdaterManager.h
@@ -69,18 +69,23 @@ public:
     MAYAUSD_CORE_PUBLIC
     static bool readPullInformation(const MDagPath& dagpath, Ufe::Path& ufePath);
 
+    bool hasPulledPrims() const { return _hasPulledPrims; }
+
 private:
     PrimUpdaterManager();
+
+    PrimUpdaterManager(PrimUpdaterManager&) = delete;
+    PrimUpdaterManager(PrimUpdaterManager&&) = delete;
 
     void onProxyContentChanged(const MayaUsdProxyStageObjectsChangedNotice& notice);
 
     //! Ensure the Dag pull root exists.  This is the child of the Maya world
     //! node under which all pulled nodes are created.
-    bool findOrCreatePullRoot();
+    MObject findOrCreatePullRoot();
 
     //! Create the pull parent for the pulled hierarchy.  This is the node
     //! which receives the pulled node's parent transformation.
-    MObject createPullParent(const Ufe::Path& pulledPath);
+    MObject createPullParent(const Ufe::Path& pulledPath, MObject pullRoot);
 
     //! Remove the pull parent for the pulled hierarchy.
     bool removePullParent(const MDagPath& pullParent);
@@ -88,18 +93,14 @@ private:
     //! Create the pull parent and set it into the prim updater context.
     MDagPath setupPullParent(const Ufe::Path& pulledPath, VtDictionary& args);
 
-    //! Maya scene message callback.
-    static void beforeNewOrOpenCallback(void* clientData);
-
     friend class TfSingleton<PrimUpdaterManager>;
 
     bool _inPushPull { false };
 
-    // Initialize pull root MObject to null object.
-    MObject _pullRoot {};
-
-    // Reset pull root on file new / file open.
-    MCallbackIdArray _cbIds;
+    // Becomes true when there is at least one pulled prim.
+    // The goal is to let code that can be optimized when there is no pull prim
+    // to check rapidly.
+    bool _hasPulledPrims { false };
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/shading/shadingModeDisplayColor.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeDisplayColor.cpp
@@ -167,7 +167,9 @@ DEFINE_SHADING_MODE_IMPORTER_WITH_JOB_ARGUMENTS(
 
         MPlug opacityPlug = depNodeFn.findPlug(_tokens->opacity.GetText());
         UsdMayaReadUtil::SetMayaAttr(
-            opacityPlug, VtValue(1.0f - linearTransparency[0]), /*unlinearizeColors*/ false);
+            opacityPlug,
+            VtValue(1.0f - linearTransparency[0]),
+            /*unlinearizeColors*/ false);
 
         outputPlug = depNodeFn.findPlug("outColor", &status);
         CHECK_MSTATUS_AND_RETURN(status, MObject());

--- a/lib/mayaUsd/fileio/translators/translatorCamera.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorCamera.cpp
@@ -20,6 +20,7 @@
 #include <mayaUsd/fileio/primReaderContext.h>
 #include <mayaUsd/fileio/shading/shadingModeRegistry.h>
 #include <mayaUsd/fileio/translators/translatorUtil.h>
+#include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/utils/util.h>
 
 #include <pxr/base/gf/vec2f.h>
@@ -41,6 +42,8 @@
 
 #include <string>
 #include <vector>
+
+using namespace MAYAUSD_NS_DEF;
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -327,8 +330,8 @@ bool UsdMayaTranslatorCamera::Read(
     }
 
     // Create the camera shape node.
-    MDagModifier dagMod;
-    MObject      cameraObj
+    MDagModifier& dagMod = MDagModifierUndoItem::create("Camera creation");
+    MObject       cameraObj
         = dagMod.createNode(_tokens->MayaCameraTypeName.GetText(), transformObj, &status);
     CHECK_MSTATUS_AND_RETURN(status, false);
     status = dagMod.doIt();

--- a/lib/mayaUsd/fileio/translators/translatorMaterial.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMaterial.cpp
@@ -326,7 +326,7 @@ bool UsdMayaTranslatorMaterial::AssignMaterial(
         = UsdMayaTranslatorMaterial::Read(jobArguments, meshMaterial, primSchema, context);
 
     if (shadingEngine.isNull()) {
-        status = UsdMayaUtil::GetMObjectByName("initialShadingGroup", shadingEngine);
+        status = UsdMayaUtil::GetMObjectByName(MString("initialShadingGroup"), shadingEngine);
         if (status != MS::kSuccess) {
             return false;
         }
@@ -397,7 +397,7 @@ bool UsdMayaTranslatorMaterial::AssignMaterial(
                 _UVBindings faceUVBindings;
                 if (faceSubsetShadingEngine.isNull()) {
                     status = UsdMayaUtil::GetMObjectByName(
-                        "initialShadingGroup", faceSubsetShadingEngine);
+                        MString("initialShadingGroup"), faceSubsetShadingEngine);
                     if (status != MS::kSuccess) {
                         return false;
                     }

--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
@@ -32,6 +32,7 @@
 #include "translatorMayaReference.h"
 
 #include <mayaUsd/base/debugCodes.h>
+#include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/utils/util.h>
 
 #include <maya/MDGModifier.h>
@@ -291,7 +292,7 @@ MStatus UsdMayaTranslatorMayaReference::connectReferenceAssociatedNode(
 
     result = MS::kFailure;
     if (!srcPlug.isNull() && !destPlug.isNull()) {
-        MDGModifier dgMod;
+        MDGModifier& dgMod = MAYAUSD_NS_DEF::MDGModifierUndoItem::create("Connect reference node");
         result = dgMod.connect(srcPlug, destPlug);
         CHECK_MSTATUS_AND_RETURN_IT(result);
         result = dgMod.doIt();

--- a/lib/mayaUsd/fileio/translators/translatorMesh.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMesh.cpp
@@ -20,6 +20,7 @@
 #include <mayaUsd/fileio/utils/readUtil.h>
 #include <mayaUsd/nodes/pointBasedDeformerNode.h>
 #include <mayaUsd/nodes/stageNode.h>
+#include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/utils/util.h>
 
 #include <maya/MColor.h>
@@ -396,14 +397,13 @@ MStatus TranslatorMeshRead::setPointBasedDeformerForMayaNode(
     CHECK_MSTATUS(status);
 
     // Get the newly created point based deformer node.
-    status = UsdMayaUtil::GetMObjectByName(
-        m_newPointBasedDeformerName.asChar(), m_pointBasedDeformerNode);
+    status = UsdMayaUtil::GetMObjectByName(m_newPointBasedDeformerName, m_pointBasedDeformerNode);
     CHECK_MSTATUS(status);
 
     MFnDependencyNode depNodeFn(m_pointBasedDeformerNode, &status);
     CHECK_MSTATUS(status);
 
-    MDGModifier dgMod;
+    MDGModifier& dgMod = MDGModifierUndoItem::create("Deformer connection");
 
     // Set the prim path on the deformer node.
     MPlug primPathPlug

--- a/lib/mayaUsd/fileio/translators/translatorUtil.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorUtil.cpp
@@ -20,6 +20,7 @@
 #include <mayaUsd/fileio/translators/translatorXformable.h>
 #include <mayaUsd/fileio/utils/adaptor.h>
 #include <mayaUsd/fileio/utils/xformStack.h>
+#include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/utils/util.h>
 
 #include <pxr/pxr.h>
@@ -36,6 +37,8 @@
 #include <maya/MObject.h>
 #include <maya/MStatus.h>
 #include <maya/MString.h>
+
+using namespace MAYAUSD_NS_DEF;
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -186,7 +189,7 @@ bool UsdMayaTranslatorUtil::CreateNode(
     // their edits to their parents-- if this is indeed the best pattern for
     // this, all Maya*Reader node creation needs to be adjusted accordingly (for
     // much less trivial cases like MFnMesh).
-    MDagModifier dagMod;
+    MDagModifier& dagMod = MDagModifierUndoItem::create("Generic node creation");
     *mayaNodeObj = dagMod.createNode(nodeTypeName, parentNode, status);
     CHECK_MSTATUS_AND_RETURN(*status, false);
     *status = dagMod.renameNode(*mayaNodeObj, nodeName);
@@ -253,7 +256,7 @@ bool UsdMayaTranslatorUtil::CreateShaderNode(
     const MString createdNode = MGlobal::executeCommandStringResult(cmd, false, false, status);
     CHECK_MSTATUS_AND_RETURN(*status, false);
 
-    *status = UsdMayaUtil::GetMObjectByName(createdNode.asChar(), *shaderObj);
+    *status = UsdMayaUtil::GetMObjectByName(createdNode, *shaderObj);
     CHECK_MSTATUS_AND_RETURN(*status, false);
 
     // Lights are unique in that they're the only DAG nodes we might create in

--- a/lib/mayaUsd/fileio/utils/adaptor.cpp
+++ b/lib/mayaUsd/fileio/utils/adaptor.cpp
@@ -22,6 +22,7 @@
 #include <mayaUsd/fileio/schemaApiAdaptorRegistry.h>
 #include <mayaUsd/fileio/utils/readUtil.h>
 #include <mayaUsd/fileio/utils/writeUtil.h>
+#include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/utils/util.h>
 
 #include <pxr/pxr.h>
@@ -33,6 +34,8 @@
 #include <maya/MFnAttribute.h>
 #include <maya/MFnDependencyNode.h>
 #include <maya/MPlug.h>
+
+using namespace MAYAUSD_NS_DEF;
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -312,8 +315,7 @@ UsdMayaSchemaAdaptorPtr UsdMayaAdaptor::GetSchemaOrInheritedSchema(const TfType&
 
 UsdMayaSchemaAdaptorPtr UsdMayaAdaptor::ApplySchema(const TfType& ty)
 {
-    MDGModifier modifier;
-    return ApplySchema(ty, modifier);
+    return ApplySchema(ty, MDGModifierUndoItem::create("Adaptor schema application"));
 }
 
 UsdMayaSchemaAdaptorPtr UsdMayaAdaptor::ApplySchema(const TfType& ty, MDGModifier& modifier)
@@ -329,8 +331,8 @@ UsdMayaSchemaAdaptorPtr UsdMayaAdaptor::ApplySchema(const TfType& ty, MDGModifie
 
 UsdMayaSchemaAdaptorPtr UsdMayaAdaptor::ApplySchemaByName(const TfToken& schemaName)
 {
-    MDGModifier modifier;
-    return ApplySchemaByName(schemaName, modifier);
+    return ApplySchemaByName(
+        schemaName, MDGModifierUndoItem::create("Adaptor schema application by name"));
 }
 
 UsdMayaSchemaAdaptorPtr
@@ -413,8 +415,7 @@ UsdMayaAdaptor::ApplySchemaByName(const TfToken& schemaName, MDGModifier& modifi
 
 void UsdMayaAdaptor::UnapplySchema(const TfType& ty)
 {
-    MDGModifier modifier;
-    UnapplySchema(ty, modifier);
+    UnapplySchema(ty, MDGModifierUndoItem::create("Adaptor schema removal"));
 }
 
 void UsdMayaAdaptor::UnapplySchema(const TfType& ty, MDGModifier& modifier)
@@ -430,8 +431,7 @@ void UsdMayaAdaptor::UnapplySchema(const TfType& ty, MDGModifier& modifier)
 
 void UsdMayaAdaptor::UnapplySchemaByName(const TfToken& schemaName)
 {
-    MDGModifier modifier;
-    UnapplySchemaByName(schemaName, modifier);
+    UnapplySchemaByName(schemaName, MDGModifierUndoItem::create("Adaptor schema removal by name"));
 }
 
 void UsdMayaAdaptor::UnapplySchemaByName(const TfToken& schemaName, MDGModifier& modifier)
@@ -533,8 +533,7 @@ bool UsdMayaAdaptor::GetMetadata(const TfToken& key, VtValue* value) const
 
 bool UsdMayaAdaptor::SetMetadata(const TfToken& key, const VtValue& value)
 {
-    MDGModifier modifier;
-    return SetMetadata(key, value, modifier);
+    return SetMetadata(key, value, MDGModifierUndoItem::create("Adaptor metadata modification"));
 }
 
 bool UsdMayaAdaptor::SetMetadata(const TfToken& key, const VtValue& value, MDGModifier& modifier)
@@ -580,8 +579,7 @@ bool UsdMayaAdaptor::SetMetadata(const TfToken& key, const VtValue& value, MDGMo
 
 void UsdMayaAdaptor::ClearMetadata(const TfToken& key)
 {
-    MDGModifier modifier;
-    ClearMetadata(key, modifier);
+    ClearMetadata(key, MDGModifierUndoItem::create("Adaptor metadata clearing"));
 }
 
 void UsdMayaAdaptor::ClearMetadata(const TfToken& key, MDGModifier& modifier)
@@ -796,8 +794,7 @@ UsdMayaAttributeAdaptor UsdMayaSchemaAdaptor::GetAttribute(const TfToken& attrNa
 
 UsdMayaAttributeAdaptor UsdMayaSchemaAdaptor::CreateAttribute(const TfToken& attrName)
 {
-    MDGModifier modifier;
-    return CreateAttribute(attrName, modifier);
+    return CreateAttribute(attrName, MDGModifierUndoItem::create("Adaptor attribute creation"));
 }
 
 UsdMayaAttributeAdaptor
@@ -846,8 +843,7 @@ UsdMayaSchemaAdaptor::CreateAttribute(const TfToken& attrName, MDGModifier& modi
 
 void UsdMayaSchemaAdaptor::RemoveAttribute(const TfToken& attrName)
 {
-    MDGModifier modifier;
-    RemoveAttribute(attrName, modifier);
+    RemoveAttribute(attrName, MDGModifierUndoItem::create("Adaptor attribute removal"));
 }
 
 void UsdMayaSchemaAdaptor::RemoveAttribute(const TfToken& attrName, MDGModifier& modifier)
@@ -993,8 +989,7 @@ bool UsdMayaAttributeAdaptor::Get(VtValue* value) const
 
 bool UsdMayaAttributeAdaptor::Set(const VtValue& newValue)
 {
-    MDGModifier modifier;
-    return Set(newValue, modifier);
+    return Set(newValue, MDGModifierUndoItem::create("Adaptor attribute modification"));
 }
 
 bool UsdMayaAttributeAdaptor::Set(const VtValue& newValue, MDGModifier& modifier)

--- a/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
@@ -99,7 +99,7 @@ bool addCreaseSet(
     // .../lib/python2.7/site-packages/maya/app/general/creaseSetEditor.py
 
     MObject creasePartitionObj;
-    *statusOK = UsdMayaUtil::GetMObjectByName(":creasePartition", creasePartitionObj);
+    *statusOK = UsdMayaUtil::GetMObjectByName(MString(":creasePartition"), creasePartitionObj);
 
     if (creasePartitionObj.isNull()) {
         statusOK->clear();

--- a/lib/mayaUsd/fileio/utils/readUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/readUtil.cpp
@@ -16,6 +16,7 @@
 #include "readUtil.h"
 
 #include <mayaUsd/fileio/utils/adaptor.h>
+#include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/utils/colorSpace.h>
 #include <mayaUsd/utils/converter.h>
 #include <mayaUsd/utils/util.h>
@@ -75,7 +76,7 @@ MObject UsdMayaReadUtil::FindOrCreateMayaAttr(
     const std::string&      attrName,
     const std::string&      attrNiceName)
 {
-    MDGModifier modifier;
+    MDGModifier& modifier = MDGModifierUndoItem::create("Generic attribute find or creation");
     return FindOrCreateMayaAttr(typeName, variability, depNode, attrName, attrNiceName, modifier);
 }
 
@@ -480,7 +481,7 @@ bool UsdMayaReadUtil::SetMayaAttr(
     const VtValue& newValue,
     const bool     unlinearizeColors)
 {
-    MDGModifier modifier;
+    MDGModifier& modifier = MDGModifierUndoItem::create("Generic Maya attribute modification");
     return SetMayaAttr(attrPlug, newValue, modifier, unlinearizeColors);
 }
 
@@ -788,7 +789,7 @@ bool UsdMayaReadUtil::SetMayaAttr(
 
 void UsdMayaReadUtil::SetMayaAttrKeyableState(MPlug& attrPlug, const SdfVariability variability)
 {
-    MDGModifier modifier;
+    MDGModifier& modifier = MDGModifierUndoItem::create("Generic Maya attribute keyable state");
     SetMayaAttrKeyableState(attrPlug, variability, modifier);
 }
 

--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -19,6 +19,8 @@
 #include <mayaUsd/listeners/proxyShapeNotice.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/ufe/Utils.h>
+#include <mayaUsd/undo/OpUndoItemMuting.h>
+#include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/utils/util.h>
 #include <mayaUsd/utils/utilFileSystem.h>
 #include <mayaUsd/utils/utilSerialization.h>
@@ -57,6 +59,8 @@
 #include <iostream>
 #include <set>
 
+using namespace MAYAUSD_NS_DEF;
+
 namespace {
 static std::recursive_mutex findNodeMutex;
 static MObjectHandle        layerManagerHandle;
@@ -67,11 +71,11 @@ static MObjectHandle        layerManagerHandle;
 // where compound/array plugs may be nested arbitrarily deep...
 MStatus disconnectCompoundArrayPlug(MPlug arrayPlug)
 {
-    MStatus     status;
-    MPlug       elemPlug;
-    MPlug       srcPlug;
-    MPlugArray  destPlugs;
-    MDGModifier dgmod;
+    MStatus      status;
+    MPlug        elemPlug;
+    MPlug        srcPlug;
+    MPlugArray   destPlugs;
+    MDGModifier& dgmod = MDGModifierUndoItem::create("Compound array plug disconnection");
 
     auto disconnectPlug = [&](MPlug plug) -> MStatus {
         MStatus status;
@@ -136,8 +140,8 @@ MayaUsd::LayerManager* findOrCreateNode()
 {
     MayaUsd::LayerManager* lm = findNode();
     if (!lm) {
-        MDGModifier modifier;
-        MObject     manager = modifier.createNode(MayaUsd::LayerManager::typeId);
+        MDGModifier& modifier = MDGModifierUndoItem::create("Node find or creation");
+        MObject      manager = modifier.createNode(MayaUsd::LayerManager::typeId);
         modifier.doIt();
 
         lm = static_cast<MayaUsd::LayerManager*>(MFnDependencyNode(manager).userNode());
@@ -337,11 +341,15 @@ void LayerDatabase::setBatchSaveDelegate(BatchSaveDelegate delegate)
 
 void LayerDatabase::prepareForSaveCheck(bool* retCode, void*)
 {
+    // This is called during a Maya notification callback, so no undo supported.
+    OpUndoItemMuting muting;
     prepareForWriteCheck(retCode, false);
 }
 
 void LayerDatabase::prepareForExportCheck(bool* retCode, void*)
 {
+    // This is called during a Maya notification callback, so no undo supported.
+    OpUndoItemMuting muting;
     prepareForWriteCheck(retCode, true);
 }
 
@@ -648,7 +656,7 @@ BatchSaveResult LayerDatabase::saveUsdToMayaFile()
     dataBlock.setClean(lm->layers);
 
     if (!atLeastOneDirty) {
-        MDGModifier modifier;
+        MDGModifier& modifier = MDGModifierUndoItem::create("Save USD to Maya node deletion");
         modifier.deleteNode(lm->thisMObject());
         modifier.doIt();
     }
@@ -870,6 +878,8 @@ void LayerDatabase::loadLayersPostRead(void*)
 
 void LayerDatabase::cleanUpNewScene(void*)
 {
+    // This is called during a Maya notification callback, so no undo supported.
+    OpUndoItemMuting muting;
     LayerDatabase::instance().removeAllLayers();
     LayerDatabase::removeManagerNode();
 }
@@ -970,7 +980,7 @@ void LayerDatabase::removeManagerNode(MayaUsd::LayerManager* lm)
     layersArrayHandle.setAllClean();
     dataBlock.setClean(lm->layers);
 
-    MDGModifier modifier;
+    MDGModifier& modifier = MDGModifierUndoItem::create("Manager node removal");
     modifier.deleteNode(lm->thisMObject());
     modifier.doIt();
 }

--- a/lib/mayaUsd/nodes/proxyAccessor.py
+++ b/lib/mayaUsd/nodes/proxyAccessor.py
@@ -215,7 +215,7 @@ def keyframeAccessPlug(ufeObject, usdAttrName):
     else:
         result = cmds.setKeyframe(proxyDagPath, attribute=plugNameValueAttr)
     
-def parentItems(ufeChildren, ufeParent):
+def parentItems(ufeChildren, ufeParent, connect=True):
     if not isUfeUsdPath(ufeParent):
         print("This method implements parenting under USD prim. Please provide UFE-USD item for ufeParent")
         return
@@ -231,11 +231,19 @@ def parentItems(ufeChildren, ufeParent):
          
         childDagPath = getDagAndPrimFromUfe(ufeChild)[0]
         
-        print('Parenting "{}" to "{}{}"'.format(childDagPath, parentDagPath,parentUsdPrimPath))
+        print('{} "{}" to "{}{}"'.format(
+            ["Unparenting", "Parenting"][connect],
+            childDagPath, parentDagPath, parentUsdPrimPath))
         childConnectionAttr = childDagPath+'.offsetParentMatrix'
-        cmds.connectAttr(parentConnectionAttr, childConnectionAttr)
+        print('{} "{}" to "{}"'.format(
+            ["Disconnecting", "Connecting"][connect],
+            parentConnectionAttr, childConnectionAttr))
+        if connect:
+            cmds.connectAttr(parentConnectionAttr, childConnectionAttr)
+        else:
+            cmds.disconnectAttr(parentConnectionAttr, childConnectionAttr)
 
-def parent():
+def __parent(doParenting):
    ufeSelection = iter(ufe.GlobalSelection.get())
    ufeSelectionList = []
    for ufeItem in ufeSelection:
@@ -252,7 +260,13 @@ def parent():
    ufeParent = ufeSelectionList[-1]
    ufeChildren = ufeSelectionList[:-1]
    
-   parentItems(ufeChildren, ufeParent)
+   parentItems(ufeChildren, ufeParent, doParenting)
+
+def parent():
+    __parent(True)
+
+def unparent():
+    __parent(False)
 
 def connectItems(ufeObjectSrc, ufeObjectDst, attrToConnect):
     connectMayaToUsd = isUfeUsdPath(ufeObjectDst)

--- a/lib/mayaUsd/python/wrapConverter.cpp
+++ b/lib/mayaUsd/python/wrapConverter.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+#include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/utils/converter.h>
 #include <mayaUsd/utils/util.h>
 
@@ -106,9 +107,11 @@ static void test_convertUsdAttrToMDGModifier(
     const std::string&   attrName,
     const ConverterArgs& args)
 {
-    MPlug plug;
+    // Testing function, no need for undo.
+    OpUndoItemList undoInfo;
+    MPlug          plug;
     if (UsdMayaUtil::GetPlugByName(attrName, plug) == MS::kSuccess) {
-        MDGModifier modifier;
+        MDGModifier& modifier = MDGModifierUndoItem::create("Test USD to DG conversion", undoInfo);
         self.convert(usdAttr, plug, modifier, args);
 
         modifier.doIt();

--- a/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
+++ b/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
@@ -95,8 +95,7 @@ bool duplicate(const std::string& srcUfePathString, const std::string& dstUfePat
 
 void wrapPrimUpdaterManager()
 {
-    using This = PrimUpdaterManager;
-    class_<This>("PrimUpdaterManager", no_init)
+    class_<PrimUpdaterManager, noncopyable>("PrimUpdaterManager", no_init)
         .def("mergeToUsd", mergeToUsd)
         .def("editAsMaya", editAsMaya)
         .def("canEditAsMaya", canEditAsMaya)

--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -18,6 +18,7 @@
 #include "private/UfeNotifGuard.h"
 
 #ifdef UFE_V3_FEATURES_AVAILABLE
+#include <mayaUsd/commands/PullPushCommands.h>
 #include <mayaUsd/fileio/primUpdaterManager.h>
 #endif
 #include <mayaUsd/ufe/UsdObject3d.h>
@@ -841,12 +842,16 @@ Ufe::UndoableCommand::Ptr UsdContextOps::doOpCmd(const ItemPath& itemPath)
 #ifdef UFE_V3_FEATURES_AVAILABLE
     else if (itemPath[0] == kEditAsMayaItem) {
         MString script;
-        script.format("mayaUsdMenu_pullToDG \"^1s\"", Ufe::PathString::string(path()).c_str());
-        MGlobal::executeCommand(script);
+        script.format(
+            "^1s \"^2s\"", EditAsMayaCommand::commandName, Ufe::PathString::string(path()).c_str());
+        MGlobal::executeCommand(script, true, true);
     } else if (itemPath[0] == kDuplicateAsMayaItem) {
         MString script;
-        script.format("mayaUsdMenu_duplicateToDG \"^1s\"", Ufe::PathString::string(path()).c_str());
-        MGlobal::executeCommand(script);
+        script.format(
+            "^1s \"^2s\" \"|world\"",
+            DuplicateCommand::commandName,
+            Ufe::PathString::string(path()).c_str());
+        MGlobal::executeCommand(script, true, true);
     }
 #endif
 

--- a/lib/mayaUsd/ufe/UsdPathMappingHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdPathMappingHandler.cpp
@@ -95,6 +95,11 @@ Ufe::Path UsdPathMappingHandler::fromHost(const Ufe::Path& hostPath) const
         return found->data();
     }
 
+    // If nothing has been pulled, then there is no mapping to be done.
+    if (!PXR_NS::PrimUpdaterManager::getInstance().hasPulledPrims()) {
+        return {};
+    }
+
     // Start by getting the dag path from the input host path. The dag path is needed
     // to get the pull information (returned as a Ufe::Path) from the plug.
     Ufe::Path mayaHostPath(hostPath);

--- a/lib/mayaUsd/undo/CMakeLists.txt
+++ b/lib/mayaUsd/undo/CMakeLists.txt
@@ -3,16 +3,24 @@
 # -----------------------------------------------------------------------------
 target_sources(${PROJECT_NAME} 
     PRIVATE
+        OpUndoItemList.cpp
+        OpUndoItemRecorder.cpp
+        OpUndoItems.cpp
         UsdUndoBlock.cpp
         UsdUndoManager.cpp
         UsdUndoStateDelegate.cpp
         UsdUndoableItem.cpp
+
 )
 
 # -----------------------------------------------------------------------------
 # promote headers
 # -----------------------------------------------------------------------------
 set(HEADERS
+    OpUndoItemList.h
+    OpUndoItemMuting.h
+    OpUndoItemRecorder.h
+    OpUndoItems.h
     UsdUndoBlock.h
     UsdUndoManager.h
     UsdUndoStateDelegate.h

--- a/lib/mayaUsd/undo/OpUndoItemList.cpp
+++ b/lib/mayaUsd/undo/OpUndoItemList.cpp
@@ -1,0 +1,99 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "OpUndoItemList.h"
+
+namespace MAYAUSD_NS_DEF {
+
+//------------------------------------------------------------------------------
+// OpUndoItemList
+//------------------------------------------------------------------------------
+
+OpUndoItemList::OpUndoItemList(OpUndoItemList&& other) { *this = std::move(other); }
+
+OpUndoItemList& OpUndoItemList::operator=(OpUndoItemList&& other)
+{
+    _undoItems = std::move(other._undoItems);
+    other._undoItems.clear();
+
+    _isUndone = other._isUndone;
+    other._isUndone = false;
+
+    return *this;
+}
+
+OpUndoItemList::~OpUndoItemList() { clear(); }
+
+bool OpUndoItemList::undo()
+{
+    if (_isUndone)
+        return true;
+
+    bool overallSuccess = true;
+    // Note: iterate in reverse order since operations might depend on each other.
+    const auto end = _undoItems.rend();
+    for (auto iter = _undoItems.rbegin(); iter != end; ++iter)
+        overallSuccess &= (*iter)->undo();
+
+    _isUndone = true;
+
+    return overallSuccess;
+}
+
+bool OpUndoItemList::redo()
+{
+    if (!_isUndone)
+        return true;
+
+    bool overallSuccess = true;
+    for (auto& item : _undoItems)
+        overallSuccess &= item->redo();
+
+    _isUndone = false;
+
+    return overallSuccess;
+}
+
+void OpUndoItemList::addItem(OpUndoItem::Ptr&& item)
+{
+    // Note: OpUndoItem::Ptr are unique_ptr, so we need to take ownership of them.
+    _undoItems.emplace_back(std::move(item));
+}
+
+void OpUndoItemList::clear()
+{
+    // Note: we need to destroy the undo items in reverse order
+    //       since some items might depend on previous ones.
+    if (_isUndone) {
+        const auto end = _undoItems.rend();
+        for (auto iter = _undoItems.rbegin(); iter != end; ++iter)
+            iter->reset();
+    } else {
+        const auto end = _undoItems.end();
+        for (auto iter = _undoItems.begin(); iter != end; ++iter)
+            iter->reset();
+    }
+
+    _undoItems.clear();
+    _isUndone = false;
+}
+
+OpUndoItemList& OpUndoItemList::instance()
+{
+    static OpUndoItemList itemList;
+    return itemList;
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/undo/OpUndoItemList.h
+++ b/lib/mayaUsd/undo/OpUndoItemList.h
@@ -1,0 +1,129 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_UNDO_OP_UNDO_INFO_H
+#define MAYAUSD_UNDO_OP_UNDO_INFO_H
+
+#include <mayaUsd/base/api.h>
+
+#include <maya/MObjectHandle.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace MAYAUSD_NS_DEF {
+
+//------------------------------------------------------------------------------
+// OpUndoItem
+//------------------------------------------------------------------------------
+
+/// \class OpUndoItem
+/// \brief Record data needed to undo or redo a single undo sub-operation.
+///
+/// See OpUndoItems.h for concrete implementations.
+
+class OpUndoItem
+{
+public:
+    typedef std::unique_ptr<OpUndoItem> Ptr;
+
+    /// \brief construct a single named sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    OpUndoItem(std::string name)
+        : _name(std::move(name))
+    {
+    }
+
+    MAYAUSD_CORE_PUBLIC
+    virtual ~OpUndoItem() = default;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    virtual bool undo() = 0;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    virtual bool redo() = 0;
+
+    /// \brief get the undo item name, used for debugging and logging.
+    MAYAUSD_CORE_PUBLIC
+    const std::string& getName() const { return _name; }
+
+private:
+    // Name the undo items to help debugging, tracing and logging.
+    const std::string _name;
+};
+
+//------------------------------------------------------------------------------
+// OpUndoItemList
+//------------------------------------------------------------------------------
+
+/// \class OpUndoItemList
+/// \brief Record everything needed to undo or redo a complete operation or command.
+
+class OpUndoItemList
+{
+public:
+    /// \brief construct an undo info.
+    MAYAUSD_CORE_PUBLIC
+    OpUndoItemList() = default;
+
+    MAYAUSD_CORE_PUBLIC
+    OpUndoItemList(OpUndoItemList&& other);
+
+    MAYAUSD_CORE_PUBLIC
+    OpUndoItemList& operator=(OpUndoItemList&& other);
+
+    /// \brief destroy the undo info.
+    MAYAUSD_CORE_PUBLIC
+    ~OpUndoItemList();
+
+    /// \brief undo a complete operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo();
+
+    /// \brief redo a complete operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo();
+
+    /// \brief add a undo item. This takes ownership of the item.
+    MAYAUSD_CORE_PUBLIC
+    void addItem(OpUndoItem::Ptr&& item);
+
+    /// \brief clear all undo/redo information contained here.
+    MAYAUSD_CORE_PUBLIC
+    void clear();
+
+    /// \brief returns the global instance.
+    ///
+    /// The undo list can later be extracted into a command to implement
+    /// its undo and redo. See extract() above.
+    MAYAUSD_CORE_PUBLIC
+    static OpUndoItemList& instance();
+
+private:
+    OpUndoItemList(const OpUndoItemList&) = delete;
+    OpUndoItemList& operator=(const OpUndoItemList&) = delete;
+
+    std::vector<OpUndoItem::Ptr> _undoItems;
+    bool                         _isUndone = false;
+};
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif

--- a/lib/mayaUsd/undo/OpUndoItemMuting.h
+++ b/lib/mayaUsd/undo/OpUndoItemMuting.h
@@ -1,0 +1,52 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef MAYAUSD_UNDO_OPUNDOINFOMUTING_H
+#define MAYAUSD_UNDO_OPUNDOINFOMUTING_H
+
+#include <mayaUsd/undo/OpUndoItemList.h>
+
+namespace MAYAUSD_NS_DEF {
+
+//! \brief Turn off undo info recording for a given scope.
+//
+// Useful if code implement their own undo/redo without using the undo info
+// but calls functions that generate undo info items that need to be ignored.
+//
+// Since all OpUndoItem are added to the UsdUndoManager singleton, for code
+// that don't want to be undoable, we need a way to clear the genarated undo
+// items. That is what the OpUndoItemMuting class does: it will clear all undo
+// items generated while a muting instance is created.
+class MAYAUSD_CORE_PUBLIC OpUndoItemMuting
+{
+public:
+    //! \brief Constructor extracts all undo info items.
+    OpUndoItemMuting()
+        : _preservedUndoInfo(std::move(OpUndoItemList::instance()))
+    {
+        OpUndoItemList::instance().clear();
+    }
+
+    //! \brief Destructor restores all preserved undo info items that were extracted.
+    ~OpUndoItemMuting() { OpUndoItemList::instance() = std::move(_preservedUndoInfo); }
+
+private:
+    OpUndoItemList _preservedUndoInfo;
+};
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_UNDO_OPUNDOINFOMUTING_H

--- a/lib/mayaUsd/undo/OpUndoItemRecorder.cpp
+++ b/lib/mayaUsd/undo/OpUndoItemRecorder.cpp
@@ -1,0 +1,38 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <mayaUsd/undo/OpUndoItemRecorder.h>
+
+namespace MAYAUSD_NS_DEF {
+
+OpUndoItemRecorder::OpUndoItemRecorder(OpUndoItemList& undoInfo)
+    : _undoInfo(undoInfo)
+{
+    // Clear anys item that may have been left behind in the given list.
+    // and in the global container.
+    _undoInfo.clear();
+    OpUndoItemList::instance().clear();
+}
+
+OpUndoItemRecorder::~OpUndoItemRecorder()
+{
+    // Extract the undo items from the global container
+    // into the container we were given.
+    _undoInfo = std::move(OpUndoItemList::instance());
+    OpUndoItemList::instance().clear();
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/undo/OpUndoItemRecorder.h
+++ b/lib/mayaUsd/undo/OpUndoItemRecorder.h
@@ -1,0 +1,49 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef MAYAUSD_UNDO_OPUNDOINFORECORDER_H
+#define MAYAUSD_UNDO_OPUNDOINFORECORDER_H
+
+#include <mayaUsd/undo/OpUndoItemList.h>
+
+namespace MAYAUSD_NS_DEF {
+
+//! \brief Record and extract undo item in the scope where it is declared.
+//
+// Useful if code implement their undo/redo using the OpUndoItemList and need
+// to reliably extract the undo items from the UsdUndoManager.
+//
+// It will transfer to the target OpUndoItemList all items generated while it
+// exists. Meant to be used on the stack.
+class MAYAUSD_CORE_PUBLIC OpUndoItemRecorder
+{
+public:
+    //! \brief Starts recording undo info in the given container.
+    OpUndoItemRecorder(OpUndoItemList& undoInfo);
+
+    //! \brief Ends recording undo info.
+    ~OpUndoItemRecorder();
+
+private:
+    OpUndoItemRecorder(const OpUndoItemRecorder&) = delete;
+    OpUndoItemRecorder operator=(const OpUndoItemRecorder&) = delete;
+
+    OpUndoItemList& _undoInfo;
+};
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_UNDO_OPUNDOINFORECORDER_H

--- a/lib/mayaUsd/undo/OpUndoItems.cpp
+++ b/lib/mayaUsd/undo/OpUndoItems.cpp
@@ -1,0 +1,475 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "OpUndoItems.h"
+
+#include <mayaUsd/utils/util.h>
+
+#include <maya/MGlobal.h>
+#include <maya/MItDag.h>
+#include <maya/MSelectionList.h>
+
+namespace MAYAUSD_NS_DEF {
+
+//------------------------------------------------------------------------------
+// NodeDeletionUndoItem
+//------------------------------------------------------------------------------
+
+namespace {
+
+MStringArray getDagName(const MObject& node)
+{
+    MStringArray strings;
+
+    MSelectionList sel;
+    sel.add(node);
+    sel.getSelectionStrings(strings);
+
+    return strings;
+}
+
+MString formatCommand(const MString& commandName, const MObject& commandArg)
+{
+    MStringArray arg = getDagName(commandArg);
+
+    MString cmd;
+    cmd.format("^1s \"^2s\"", commandName.asChar(), arg[0].asChar());
+
+    return cmd;
+}
+
+} // namespace
+
+MStatus NodeDeletionUndoItem::deleteNode(
+    const std::string name,
+    const MString&    nodeName,
+    const MObject&    node,
+    OpUndoItemList&   undoInfo)
+{
+    // Avoid deleting the same node twice.
+    if (!MObjectHandle(node).isValid())
+        return MS::kSuccess;
+
+    const MString cmd = formatCommand("delete", node);
+
+    std::string fullName
+        = name + std::string(" \"") + std::string(cmd.asChar()) + std::string("\"");
+    auto item = std::make_unique<NodeDeletionUndoItem>(std::move(fullName));
+
+    MStatus status = item->_modifier.commandToExecute(cmd);
+    if (status != MS::kSuccess)
+        return status;
+
+    status = item->_modifier.doIt();
+    if (status != MS::kSuccess)
+        return status;
+
+    undoInfo.addItem(std::move(item));
+
+    return MS::kSuccess;
+}
+
+MStatus NodeDeletionUndoItem::deleteNode(
+    const std::string name,
+    const MString&    nodeName,
+    const MObject&    node)
+{
+    return deleteNode(name, nodeName, node, OpUndoItemList::instance());
+}
+
+NodeDeletionUndoItem::~NodeDeletionUndoItem() { }
+
+bool NodeDeletionUndoItem::undo() { return _modifier.undoIt() == MS::kSuccess; }
+
+bool NodeDeletionUndoItem::redo() { return _modifier.doIt() == MS::kSuccess; }
+
+//------------------------------------------------------------------------------
+// MDagModifierUndoItem
+//------------------------------------------------------------------------------
+
+MDagModifier& MDagModifierUndoItem::create(const std::string name, OpUndoItemList& undoInfo)
+{
+    auto          item = std::make_unique<MDagModifierUndoItem>(std::move(name));
+    MDagModifier& mod = item->getModifier();
+    undoInfo.addItem(std::move(item));
+    return mod;
+}
+
+MDagModifier& MDagModifierUndoItem::create(const std::string name)
+{
+    return create(name, OpUndoItemList::instance());
+}
+
+MDagModifierUndoItem::~MDagModifierUndoItem() { }
+
+bool MDagModifierUndoItem::undo() { return _modifier.undoIt() == MS::kSuccess; }
+
+bool MDagModifierUndoItem::redo() { return _modifier.doIt() == MS::kSuccess; }
+
+//------------------------------------------------------------------------------
+// MDGModifierUndoItem
+//------------------------------------------------------------------------------
+
+MDGModifier& MDGModifierUndoItem::create(const std::string name, OpUndoItemList& undoInfo)
+{
+    auto         item = std::make_unique<MDGModifierUndoItem>(std::move(name));
+    MDGModifier& mod = item->getModifier();
+    undoInfo.addItem(std::move(item));
+    return mod;
+}
+
+MDGModifier& MDGModifierUndoItem::create(const std::string name)
+{
+    return create(name, OpUndoItemList::instance());
+}
+
+MDGModifierUndoItem::~MDGModifierUndoItem() { }
+
+bool MDGModifierUndoItem::undo() { return _modifier.undoIt() == MS::kSuccess; }
+
+bool MDGModifierUndoItem::redo() { return _modifier.doIt() == MS::kSuccess; }
+
+//------------------------------------------------------------------------------
+// UsdUndoableItemUndoItem
+//------------------------------------------------------------------------------
+
+MAYAUSD_NS::UsdUndoableItem&
+UsdUndoableItemUndoItem::create(const std::string name, OpUndoItemList& undoInfo)
+{
+    auto                         item = std::make_unique<UsdUndoableItemUndoItem>(std::move(name));
+    MAYAUSD_NS::UsdUndoableItem& mod = item->getUndoableItem();
+    undoInfo.addItem(std::move(item));
+    return mod;
+}
+
+MAYAUSD_NS::UsdUndoableItem& UsdUndoableItemUndoItem::create(const std::string name)
+{
+    return create(name, OpUndoItemList::instance());
+}
+
+UsdUndoableItemUndoItem::~UsdUndoableItemUndoItem() { }
+
+bool UsdUndoableItemUndoItem::undo()
+{
+    _item.undo();
+    return true;
+}
+
+bool UsdUndoableItemUndoItem::redo()
+{
+    _item.redo();
+    return true;
+}
+
+//------------------------------------------------------------------------------
+// PythonUndoItem
+//------------------------------------------------------------------------------
+
+PythonUndoItem::PythonUndoItem(const std::string name, MString pythonDo, MString pythonUndo)
+    : OpUndoItem(std::move(name))
+    , _pythonDo(std::move(pythonDo))
+    , _pythonUndo(std::move(pythonUndo))
+{
+}
+
+PythonUndoItem::~PythonUndoItem() { }
+
+void PythonUndoItem::execute(
+    const std::string name,
+    MString           pythonDo,
+    MString           pythonUndo,
+    OpUndoItemList&   undoInfo)
+{
+    auto item = std::make_unique<PythonUndoItem>(
+        std::move(name), std::move(pythonDo), std::move(pythonUndo));
+    item->redo();
+    undoInfo.addItem(std::move(item));
+}
+
+void PythonUndoItem::execute(const std::string name, MString pythonDo, MString pythonUndo)
+{
+    return execute(name, pythonDo, pythonUndo, OpUndoItemList::instance());
+}
+
+namespace {
+bool executePython(const MString& python)
+{
+    if (python.length() == 0)
+        return true;
+
+    return MGlobal::executePythonCommand(python) == MS::kSuccess;
+}
+} // namespace
+
+bool PythonUndoItem::undo() { return executePython(_pythonUndo); }
+
+bool PythonUndoItem::redo() { return executePython(_pythonDo); }
+
+//------------------------------------------------------------------------------
+// FunctionUndoItem
+//------------------------------------------------------------------------------
+
+FunctionUndoItem::FunctionUndoItem(
+    const std::string     name,
+    std::function<bool()> redo,
+    std::function<bool()> undo)
+    : OpUndoItem(std::move(name))
+    , _redo(std::move(redo))
+    , _undo(std::move(undo))
+{
+}
+
+FunctionUndoItem::~FunctionUndoItem() { }
+
+void FunctionUndoItem::create(
+    const std::string     name,
+    std::function<bool()> redo,
+    std::function<bool()> undo,
+    OpUndoItemList&       undoInfo)
+{
+    auto item
+        = std::make_unique<FunctionUndoItem>(std::move(name), std::move(redo), std::move(undo));
+    undoInfo.addItem(std::move(item));
+}
+
+void FunctionUndoItem::create(
+    const std::string     name,
+    std::function<bool()> redo,
+    std::function<bool()> undo)
+{
+    create(name, redo, undo, OpUndoItemList::instance());
+}
+
+void FunctionUndoItem::execute(
+    const std::string     name,
+    std::function<bool()> redo,
+    std::function<bool()> undo,
+    OpUndoItemList&       undoInfo)
+{
+    auto item
+        = std::make_unique<FunctionUndoItem>(std::move(name), std::move(redo), std::move(undo));
+    item->redo();
+    undoInfo.addItem(std::move(item));
+}
+
+void FunctionUndoItem::execute(
+    const std::string     name,
+    std::function<bool()> redo,
+    std::function<bool()> undo)
+{
+    execute(name, redo, undo, OpUndoItemList::instance());
+}
+
+bool FunctionUndoItem::undo()
+{
+    if (!_undo)
+        return false;
+
+    return _undo();
+}
+
+bool FunctionUndoItem::redo()
+{
+    if (!_redo)
+        return false;
+
+    return _redo();
+}
+
+//------------------------------------------------------------------------------
+// SelectionUndoItem
+//------------------------------------------------------------------------------
+
+SelectionUndoItem::SelectionUndoItem(
+    const std::string       name,
+    const MSelectionList&   selection,
+    MGlobal::ListAdjustment selMode)
+    : OpUndoItem(std::move(name))
+    , _selection(selection)
+    , _selMode(selMode)
+{
+}
+
+SelectionUndoItem::~SelectionUndoItem() { }
+
+void SelectionUndoItem::select(
+    const std::string       name,
+    const MSelectionList&   selection,
+    MGlobal::ListAdjustment selMode,
+    OpUndoItemList&         undoInfo)
+{
+    auto item = std::make_unique<SelectionUndoItem>(std::move(name), selection, selMode);
+    item->redo();
+    undoInfo.addItem(std::move(item));
+}
+
+void SelectionUndoItem::select(
+    const std::string       name,
+    const MSelectionList&   selection,
+    MGlobal::ListAdjustment selMode)
+{
+    select(name, selection, selMode, OpUndoItemList::instance());
+}
+
+void SelectionUndoItem::select(
+    const std::string       name,
+    const MDagPath&         dagPath,
+    MGlobal::ListAdjustment selMode,
+    OpUndoItemList&         undoInfo)
+{
+    MSelectionList selection;
+    selection.add(dagPath);
+    SelectionUndoItem::select(std::move(name), selection, selMode, undoInfo);
+}
+
+void SelectionUndoItem::select(
+    const std::string       name,
+    const MDagPath&         dagPath,
+    MGlobal::ListAdjustment selMode)
+{
+    select(name, dagPath, selMode, OpUndoItemList::instance());
+}
+
+bool SelectionUndoItem::undo()
+{
+    MStatus status = MGlobal::setActiveSelectionList(_previousSelection);
+    return status == MS::kSuccess;
+}
+
+bool SelectionUndoItem::redo()
+{
+    MGlobal::getActiveSelectionList(_previousSelection);
+    MStatus status = MGlobal::setActiveSelectionList(_selection, _selMode);
+    return status == MS::kSuccess;
+}
+
+//------------------------------------------------------------------------------
+// LockNodesUndoItem
+//------------------------------------------------------------------------------
+
+namespace {
+
+//! Lock or unlock hierarchy starting at given root.
+MStatus lockNodes(const MString& rootName, bool state)
+{
+    MObject obj;
+    MStatus status = PXR_NS::UsdMayaUtil::GetMObjectByName(rootName, obj);
+    if (status != MStatus::kSuccess)
+        return status;
+
+    MDagPath root;
+    status = MDagPath::getAPathTo(obj, root);
+    if (status != MStatus::kSuccess)
+        return status;
+
+    MItDag dagIt;
+    dagIt.reset(root);
+    for (; !dagIt.isDone(); dagIt.next()) {
+        MFnDependencyNode node(dagIt.currentItem());
+        if (node.isFromReferencedFile()) {
+            dagIt.prune();
+            continue;
+        }
+        node.setLocked(state);
+    }
+
+    return MS::kSuccess;
+}
+
+} // namespace
+
+LockNodesUndoItem::LockNodesUndoItem(const std::string name, const MDagPath& root, bool lock)
+    : OpUndoItem(std::move(name))
+    , _rootName(root.fullPathName())
+    , _lock(lock)
+{
+}
+
+LockNodesUndoItem::~LockNodesUndoItem() { }
+
+void LockNodesUndoItem::lock(
+    const std::string name,
+    const MDagPath&   root,
+    bool              dolock,
+    OpUndoItemList&   undoInfo)
+{
+    auto item = std::make_unique<LockNodesUndoItem>(std::move(name), root, dolock);
+    item->redo();
+    undoInfo.addItem(std::move(item));
+}
+
+void LockNodesUndoItem::lock(const std::string name, const MDagPath& root, bool dolock)
+{
+    lock(name, root, dolock, OpUndoItemList::instance());
+}
+
+bool LockNodesUndoItem::undo()
+{
+    lockNodes(_rootName, !_lock);
+    return true;
+}
+
+bool LockNodesUndoItem::redo()
+{
+    lockNodes(_rootName, _lock);
+    return true;
+}
+
+//------------------------------------------------------------------------------
+// CreateSetUndoItem
+//------------------------------------------------------------------------------
+
+CreateSetUndoItem::CreateSetUndoItem(const std::string name, const MString& setName)
+    : OpUndoItem(std::move(name))
+    , _setName(setName)
+{
+}
+
+CreateSetUndoItem::~CreateSetUndoItem() { }
+
+MObject
+CreateSetUndoItem::create(std::string name, const MString& setName, OpUndoItemList& undoInfo)
+{
+    auto item = std::make_unique<CreateSetUndoItem>(std::move(name), setName);
+    item->redo();
+    MObject obj = item->_setObj;
+    undoInfo.addItem(std::move(item));
+    return obj;
+}
+
+MObject CreateSetUndoItem::create(std::string name, const MString& setName)
+{
+    return create(name, setName, OpUndoItemList::instance());
+}
+
+bool CreateSetUndoItem::undo()
+{
+    const MStatus status = MGlobal::deleteNode(_setObj);
+    _setObj = MObject();
+    return status == MS::kSuccess;
+}
+
+bool CreateSetUndoItem::redo()
+{
+    MSelectionList selList;
+    MStatus        status = MS::kSuccess;
+    MFnSet         setFn;
+    _setObj = setFn.create(selList, MFnSet::kNone, &status);
+    if (status == MS::kSuccess)
+        setFn.setName(_setName, &status);
+    return status == MS::kSuccess;
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/undo/OpUndoItems.h
+++ b/lib/mayaUsd/undo/OpUndoItems.h
@@ -1,0 +1,487 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_UNDO_OP_UNDO_ITEMS_H
+#define MAYAUSD_UNDO_OP_UNDO_ITEMS_H
+
+#include "OpUndoItemList.h"
+
+#include <mayaUsd/undo/UsdUndoableItem.h>
+
+#include <maya/MDGModifier.h>
+#include <maya/MDagModifier.h>
+#include <maya/MDagPath.h>
+#include <maya/MFnSet.h>
+#include <maya/MGlobal.h>
+#include <maya/MSelectionList.h>
+
+#include <memory>
+#include <vector>
+
+namespace MAYAUSD_NS_DEF {
+
+//------------------------------------------------------------------------------
+// NodeDeletionUndoItem
+//------------------------------------------------------------------------------
+
+/// \class NodeDeletionUndoItem
+/// \brief Record data needed to undo or redo a Maya DG sub-operation.
+class NodeDeletionUndoItem : public OpUndoItem
+{
+public:
+    /// \brief delete a node.
+    MAYAUSD_CORE_PUBLIC
+    static MStatus deleteNode(
+        const std::string name,
+        const MString&    nodeName,
+        const MObject&    node,
+        OpUndoItemList&   undoInfo);
+
+    /// \brief delete a node and keep track of it in the global undo item list.
+    MAYAUSD_CORE_PUBLIC
+    static MStatus deleteNode(const std::string name, const MString& nodeName, const MObject& node);
+
+    /// \brief construct a Maya DG modifier recorder.
+    MAYAUSD_CORE_PUBLIC
+    NodeDeletionUndoItem(std::string name)
+        : OpUndoItem(std::move(name))
+    {
+    }
+
+    MAYAUSD_CORE_PUBLIC
+    ~NodeDeletionUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+private:
+    MDGModifier _modifier;
+};
+
+//------------------------------------------------------------------------------
+// MDagModifierUndoItem
+//------------------------------------------------------------------------------
+
+/// \class MDagModifierUndoItem
+/// \brief Record data needed to undo or redo a Maya DAG sub-operation.///
+///
+/// For node deletion, use the specialized NodeDeletionUndoItem that tracks
+/// which objects have already been deleted and avoid double-deletions.
+class MDagModifierUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create a Maya DAG modifier recorder and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static MDagModifier& create(const std::string name, OpUndoItemList& undoInfo);
+
+    /// \brief create a Maya DAG modifier recorder and keep track of it in the global undo item
+    /// list.
+    MAYAUSD_CORE_PUBLIC
+    static MDagModifier& create(const std::string name);
+
+    /// \brief construct a Maya DAG modifier recorder.
+    MAYAUSD_CORE_PUBLIC
+    MDagModifierUndoItem(std::string name)
+        : OpUndoItem(std::move(name))
+    {
+    }
+
+    MAYAUSD_CORE_PUBLIC
+    ~MDagModifierUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+    /// \brief gets the DAG modifier.
+    MAYAUSD_CORE_PUBLIC
+    MDagModifier& getModifier() { return _modifier; }
+
+private:
+    MDagModifier _modifier;
+};
+
+//------------------------------------------------------------------------------
+// MDGModifierUndoItem
+//------------------------------------------------------------------------------
+
+/// \class MDGModifierUndoItem
+/// \brief Record data needed to undo or redo a Maya DG sub-operation.
+///
+/// For node deletion, use the specialized NodeDeletionUndoItem that tracks
+/// which objects have already been deleted and avoid double-deletions.
+class MDGModifierUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create a Maya DG modifier recorder and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static MDGModifier& create(const std::string name, OpUndoItemList& undoInfo);
+
+    /// \brief create a Maya DG modifier recorder and keep track of it in the global undo item list.
+    MAYAUSD_CORE_PUBLIC
+    static MDGModifier& create(const std::string name);
+
+    /// \brief construct a Maya DG modifier recorder.
+    MAYAUSD_CORE_PUBLIC
+    MDGModifierUndoItem(std::string name)
+        : OpUndoItem(std::move(name))
+    {
+    }
+
+    MAYAUSD_CORE_PUBLIC
+    ~MDGModifierUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+    /// \brief gets the DG modifier.
+    MAYAUSD_CORE_PUBLIC
+    MDGModifier& getModifier() { return _modifier; }
+
+private:
+    MDGModifier _modifier;
+};
+
+//------------------------------------------------------------------------------
+// UsdUndoableItemUndoItem
+//------------------------------------------------------------------------------
+
+/// \class UsdUndoableItemUndoItem
+/// \brief Record data needed to undo or redo USD sub-operations.
+class UsdUndoableItemUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create a USD undo item recorder and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static MAYAUSD_NS::UsdUndoableItem& create(const std::string name, OpUndoItemList& undoInfo);
+
+    /// \brief create a USD undo item recorder and keep track of it in the global undo item list.
+    MAYAUSD_CORE_PUBLIC
+    static MAYAUSD_NS::UsdUndoableItem& create(const std::string name);
+
+    /// \brief construct a USD undo item recorder.
+    MAYAUSD_CORE_PUBLIC
+    UsdUndoableItemUndoItem(std::string name)
+        : OpUndoItem(std::move(name))
+    {
+    }
+
+    MAYAUSD_CORE_PUBLIC
+    ~UsdUndoableItemUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+    /// \brief gets the DG modifier.
+    MAYAUSD_CORE_PUBLIC
+    MAYAUSD_NS::UsdUndoableItem& getUndoableItem() { return _item; }
+
+private:
+    MAYAUSD_NS::UsdUndoableItem _item;
+};
+
+//------------------------------------------------------------------------------
+// PythonUndoItem
+//------------------------------------------------------------------------------
+
+/// \class PythonUndoItem
+/// \brief Record data needed to undo or redo python sub-operations.
+class PythonUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create and execute python and and how to undo it and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static void
+    execute(const std::string name, MString pythonDo, MString pythonUndo, OpUndoItemList& undoInfo);
+
+    /// \brief create and execute python and and how to undo it and keep track of it in the global
+    /// list.
+    MAYAUSD_CORE_PUBLIC
+    static void execute(const std::string name, MString pythonDo, MString pythonUndo);
+
+    /// \brief create a python undo item.
+    MAYAUSD_CORE_PUBLIC
+    PythonUndoItem(const std::string name, MString pythonDo, MString pythonUndo);
+
+    MAYAUSD_CORE_PUBLIC
+    ~PythonUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+private:
+    MString _pythonDo;
+    MString _pythonUndo;
+};
+
+//------------------------------------------------------------------------------
+// FunctionUndoItem
+//------------------------------------------------------------------------------
+
+/// \class FunctionUndoItem
+/// \brief Record data needed to undo or redo generic functions sub-operations.
+class FunctionUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create but do *not* execute functions and keep track of it.
+    ///        Useful if the item execution has already been done.
+    MAYAUSD_CORE_PUBLIC
+    static void create(
+        const std::string     name,
+        std::function<bool()> redo,
+        std::function<bool()> undo,
+        OpUndoItemList&       undoInfo);
+
+    /// \brief create but do *not* execute functions and keep track of it in the global undo list.
+    ///        Useful if the item execution has already been done.
+    MAYAUSD_CORE_PUBLIC
+    static void
+    create(const std::string name, std::function<bool()> redo, std::function<bool()> undo);
+
+    /// \brief create and execute functions and how to undo it and keep track of it.
+    ///        Useful if the item execution has *not* already been done but must done now.
+    MAYAUSD_CORE_PUBLIC
+    static void execute(
+        const std::string     name,
+        std::function<bool()> redo,
+        std::function<bool()> undo,
+        OpUndoItemList&       undoInfo);
+
+    /// \brief create and execute functions and how to undo it and keep track of it in the global
+    /// undo list.
+    ///
+    /// Useful if the item execution has *not* already been done but must done now.
+    MAYAUSD_CORE_PUBLIC
+    static void
+    execute(const std::string name, std::function<bool()> redo, std::function<bool()> undo);
+
+    /// \brief create a function undo item.
+    MAYAUSD_CORE_PUBLIC
+    FunctionUndoItem(
+        const std::string     name,
+        std::function<bool()> redo,
+        std::function<bool()> undo);
+
+    MAYAUSD_CORE_PUBLIC
+    ~FunctionUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+private:
+    std::function<bool()> _redo;
+    std::function<bool()> _undo;
+};
+
+//------------------------------------------------------------------------------
+// SelectionUndoItem
+//------------------------------------------------------------------------------
+
+/// \class SelectionUndoItem
+/// \brief Record data needed to undo or redo select nodes sub-operations.
+class SelectionUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create and execute a select node undo item and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static void select(
+        const std::string       name,
+        const MSelectionList&   selection,
+        MGlobal::ListAdjustment selMode,
+        OpUndoItemList&         undoInfo);
+
+    /// \brief create and execute a select node undo item and keep track of it in the global list.
+    MAYAUSD_CORE_PUBLIC
+    static void select(
+        const std::string       name,
+        const MSelectionList&   selection,
+        MGlobal::ListAdjustment selMode);
+
+    /// \brief create and execute a select node undo item and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static void select(
+        const std::string       name,
+        const MDagPath&         dagPath,
+        MGlobal::ListAdjustment selMode,
+        OpUndoItemList&         undoInfo);
+
+    /// \brief create and execute a select node undo item and keep track of it in the global list.
+    MAYAUSD_CORE_PUBLIC
+    static void
+    select(const std::string name, const MDagPath& dagPath, MGlobal::ListAdjustment selMode);
+
+    /// \brief create and execute a select node undo item and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static void
+    select(const std::string name, const MSelectionList& selection, OpUndoItemList& undoInfo)
+    {
+        SelectionUndoItem::select(name, selection, MGlobal::kReplaceList, undoInfo);
+    }
+
+    /// \brief create and execute a select node undo item and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static void select(const std::string name, const MSelectionList& selection)
+    {
+        SelectionUndoItem::select(name, selection, MGlobal::kReplaceList);
+    }
+
+    /// \brief create and execute a select node undo item and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static void select(const std::string name, const MDagPath& dagPath, OpUndoItemList& undoInfo)
+    {
+        SelectionUndoItem::select(name, dagPath, MGlobal::kReplaceList, undoInfo);
+    }
+
+    /// \brief create and execute a select node undo item and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static void select(const std::string name, const MDagPath& dagPath)
+    {
+        SelectionUndoItem::select(name, dagPath, MGlobal::kReplaceList);
+    }
+
+    MAYAUSD_CORE_PUBLIC
+    SelectionUndoItem(
+        const std::string       name,
+        const MSelectionList&   selection,
+        MGlobal::ListAdjustment selMode);
+
+    MAYAUSD_CORE_PUBLIC
+    ~SelectionUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+private:
+    MSelectionList          _selection;
+    MSelectionList          _previousSelection;
+    MGlobal::ListAdjustment _selMode;
+};
+
+//------------------------------------------------------------------------------
+// LockNodesUndoItem
+//------------------------------------------------------------------------------
+
+/// \class LockNodesUndoItem
+/// \brief Record data needed to undo / redo the lock / unlock of Maya nodes.
+class LockNodesUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create and execute a lock node undo item and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static void
+    lock(const std::string name, const MDagPath& root, bool lock, OpUndoItemList& undoInfo);
+
+    /// \brief create and execute a lock node undo item and keep track of it in the global undo
+    /// list.
+    MAYAUSD_CORE_PUBLIC
+    static void lock(const std::string name, const MDagPath& root, bool lock);
+
+    MAYAUSD_CORE_PUBLIC
+    LockNodesUndoItem(const std::string name, const MDagPath& root, bool lock);
+
+    MAYAUSD_CORE_PUBLIC
+    ~LockNodesUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+private:
+    MString _rootName;
+    bool    _lock;
+};
+
+//------------------------------------------------------------------------------
+// CreateSetUndoItem
+//------------------------------------------------------------------------------
+
+/// \class CreateSetUndoItem
+/// \brief Record data needed to undo or redo creation of a node set sub-operations.
+class CreateSetUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create and execute a set creation undo item and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static MObject create(const std::string name, const MString& setName, OpUndoItemList& undoInfo);
+
+    /// \brief create and execute a set creation undo item and keep track of it in the global undo
+    /// list.
+    MAYAUSD_CORE_PUBLIC
+    static MObject create(const std::string name, const MString& setName);
+
+    MAYAUSD_CORE_PUBLIC
+    CreateSetUndoItem(const std::string name, const MString& setName);
+
+    MAYAUSD_CORE_PUBLIC
+    ~CreateSetUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+    /// \brief gets the set object.
+    MAYAUSD_CORE_PUBLIC
+    MObject& getSetObject() { return _setObj; }
+
+private:
+    MString _setName;
+    MObject _setObj;
+};
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif

--- a/lib/mayaUsd/undo/UsdUndoManager.h
+++ b/lib/mayaUsd/undo/UsdUndoManager.h
@@ -17,9 +17,8 @@
 #ifndef MAYAUSD_UNDO_UNDOMANAGER_H
 #define MAYAUSD_UNDO_UNDOMANAGER_H
 
-#include "UsdUndoableItem.h"
-
 #include <mayaUsd/base/api.h>
+#include <mayaUsd/undo/UsdUndoableItem.h>
 
 #include <pxr/usd/sdf/layer.h>
 

--- a/lib/mayaUsd/utils/util.h
+++ b/lib/mayaUsd/utils/util.h
@@ -181,6 +181,10 @@ MString GetUniqueNameOfDagNode(const MObject& node);
 MAYAUSD_CORE_PUBLIC
 MStatus GetMObjectByName(const std::string& nodeName, MObject& mObj);
 
+/// Gets the Maya MObject for the node named \p nodeName.
+MAYAUSD_CORE_PUBLIC
+MStatus GetMObjectByName(const MString& nodeName, MObject& mObj);
+
 /// Gets the UsdStage for the proxy shape  node named \p nodeName.
 MAYAUSD_CORE_PUBLIC
 UsdStageRefPtr GetStageByProxyName(const std::string& nodeName);
@@ -378,6 +382,13 @@ MPlug GetConnected(const MPlug& plug);
 MAYAUSD_CORE_PUBLIC
 void Connect(const MPlug& srcPlug, const MPlug& dstPlug, const bool clearDstPlug);
 
+MAYAUSD_CORE_PUBLIC
+void Connect(
+    const MPlug& srcPlug,
+    const MPlug& dstPlug,
+    const bool   clearDstPlug,
+    MDGModifier& dgMod);
+
 /// Get a named child plug of \p plug by name.
 MAYAUSD_CORE_PUBLIC
 MPlug FindChildPlugByName(const MPlug& plug, const MString& name);
@@ -546,6 +557,15 @@ MString convert(const TfToken& token);
 
 MAYAUSD_CORE_PUBLIC
 std::string convert(const MString&);
+
+/// Retrieve all descendant nodes, including self.
+MAYAUSD_CORE_PUBLIC
+std::vector<MDagPath> getDescendants(const MDagPath& path);
+
+/// Retrieve all descendant nodes, including self, but starting from the most
+/// distant grand-children.
+MAYAUSD_CORE_PUBLIC
+std::vector<MDagPath> getDescendantsStartingWithChildren(const MDagPath& path);
 
 MAYAUSD_CORE_PUBLIC
 MDagPath getDagPath(const MFnDependencyNode& depNodeFn, const bool reportError = true);

--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -74,7 +74,7 @@ bool MayaSessionState::getStageEntry(StageEntry* out_stageEntry, const MString& 
     UsdPrim prim;
 
     MObject shapeObj;
-    MStatus status = UsdMayaUtil::GetMObjectByName(shapePath.asChar(), shapeObj);
+    MStatus status = UsdMayaUtil::GetMObjectByName(shapePath, shapeObj);
     CHECK_MSTATUS_AND_RETURN(status, false);
     MFnDagNode dagNode(shapeObj, &status);
     CHECK_MSTATUS_AND_RETURN(status, false);

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -72,6 +72,7 @@
 #endif
 
 #ifdef UFE_V3_FEATURES_AVAILABLE
+#include <mayaUsd/commands/PullPushCommands.h>
 #include <mayaUsd/fileio/primUpdaterManager.h>
 #endif
 
@@ -220,6 +221,13 @@ MStatus initializePlugin(MObject obj)
     registerCommandCheck<MayaUsd::LayerEditorCommand>(plugin);
 #if defined(WANT_QT_BUILD)
     registerCommandCheck<MayaUsd::LayerEditorWindowCommand>(plugin);
+#endif
+
+#ifdef UFE_V3_FEATURES_AVAILABLE
+    registerCommandCheck<MayaUsd::ufe::EditAsMayaCommand>(plugin);
+    registerCommandCheck<MayaUsd::ufe::MergeToUsdCommand>(plugin);
+    registerCommandCheck<MayaUsd::ufe::DiscardEditsCommand>(plugin);
+    registerCommandCheck<MayaUsd::ufe::DuplicateCommand>(plugin);
 #endif
 
     status = plugin.registerCommand(
@@ -385,6 +393,13 @@ MStatus uninitializePlugin(MObject obj)
 #if defined(WANT_QT_BUILD)
     deregisterCommandCheck<MayaUsd::LayerEditorWindowCommand>(plugin);
     MayaUsd::LayerEditorWindowCommand::cleanupOnPluginUnload();
+#endif
+
+#ifdef UFE_V3_FEATURES_AVAILABLE
+    deregisterCommandCheck<MayaUsd::ufe::EditAsMayaCommand>(plugin);
+    deregisterCommandCheck<MayaUsd::ufe::MergeToUsdCommand>(plugin);
+    deregisterCommandCheck<MayaUsd::ufe::DiscardEditsCommand>(plugin);
+    deregisterCommandCheck<MayaUsd::ufe::DuplicateCommand>(plugin);
 #endif
 
     status = plugin.deregisterNode(MayaUsd::ProxyShape::typeId);

--- a/plugin/adsk/scripts/USDMenuProc.mel
+++ b/plugin/adsk/scripts/USDMenuProc.mel
@@ -28,34 +28,6 @@ proc int canEditAsMaya(string $obj)
     return 0;
 }
 
-global proc mayaUsdMenu_pullToDG(string $obj)
-{
-    if (!hasPrimUpdater())
-        return;
-
-    if (size($obj) == 0) {
-        string $nonMayaObjs[] = `python("import maya.internal.ufeSupport.utils as ufeUtils; ufeUtils.getNonMayaSelectedItems()")`;
-        $obj = $nonMayaObjs[0];
-    }
-    if (size($obj) != 0) {
-        python("from mayaUsd.lib import PrimUpdaterManager; import ufe; PrimUpdaterManager.editAsMaya('" + $obj + "');");
-    }
-}
-
-global proc mayaUsdMenu_duplicateToDG( string $ufePath )
-{
-    if (!hasPrimUpdater())
-        return;
-        
-    if (size($ufePath) == 0) {
-        string $nonMayaObjs[] = `python("import maya.internal.ufeSupport.utils as ufeUtils; ufeUtils.getNonMayaSelectedItems()")`;
-        $ufePath = $nonMayaObjs[0];
-    }
-    
-    if (size($ufePath)) {
-        python("from mayaUsd.lib import PrimUpdaterManager; import maya.cmds as cmds; PrimUpdaterManager.duplicate('" + $ufePath + "', '|world');");
-    }
-}
 global proc USDMenuProc(string $parent, string $obj)
 {
     if (!hasPrimUpdater())
@@ -69,8 +41,8 @@ global proc USDMenuProc(string $parent, string $obj)
 
         setParent -menu ..;
         if (canEditAsMaya($obj)) {
-            menuItem -label "Edit As Maya Data" -image "edit_as_Maya.png" -command ("mayaUsdMenu_pullToDG \"" + $obj + "\"");
+            menuItem -label "Edit As Maya Data" -image "edit_as_Maya.png" -command ("mayaUsdEditAsMaya \"" + $obj + "\"");
         }
-        menuItem -label "Duplicate As Maya Data" -command ("mayaUsdMenu_duplicateToDG \"" + $obj + "\"");
+        menuItem -label "Duplicate As Maya Data" -command ("mayaUsdDuplicateAsMaya \"" + $obj + "\"");
     }
 }

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -592,16 +592,8 @@ global proc mayaUsdMenu_pushBackToUSD(string $obj)
         }
     }
     if (size($obj)) {
-        python("from mayaUsd.lib import PrimUpdaterManager; PrimUpdaterManager.mergeToUsd('" + $obj + "');");
+        mayaUsdMergeToUsd $obj;
     }
-}
-
-global proc mayaUsdMenu_pushClear(string $obj)
-{
-    if (!hasPrimUpdater())
-        return;
-
-    python("from mayaUsd.lib import PrimUpdaterManager; PrimUpdaterManager.discardEdits('" + $obj + "');");
 }
 
 global proc mayaUsdMenu_duplicateToUSD( string $proxy, string $obj )
@@ -618,7 +610,7 @@ global proc mayaUsdMenu_duplicateToUSD( string $proxy, string $obj )
     string $objLong[] = `ls -l $obj`;
     string $proxyLong[] = `ls -l $proxy`;
     if (size($objLong) && size($proxyLong)) {
-        python("from mayaUsd.lib import PrimUpdaterManager; import maya.cmds as cmds; PrimUpdaterManager.duplicate('" + $objLong[0] + "', '"+ $proxyLong[0] +"');");
+        mayaUsdDuplicate $objLong[0] $proxyLong[0];
     }
 }
 
@@ -629,7 +621,7 @@ global proc mayaUsdMenu_markingMenuCallback( string $obj )
 
     if (isPulledUsdObject($obj)) {
         string $pushback = `menuItem -label "Merge Maya Edits to USD" -insertAfter "" -image "merge_to_USD.png" -command ("mayaUsdMenu_pushBackToUSD " + $obj)`;
-        string $pushclear = `menuItem -label "Discard Maya Edits" -insertAfter $pushback -image "discard_edits.png" -command ("mayaUsdMenu_pushClear " + $obj)`;
+        string $pushclear = `menuItem -label "Discard Maya Edits" -insertAfter $pushback -image "discard_edits.png" -command ("mayaUsdDiscardEdits " + $obj)`;
         menuItem -divider true -insertAfter $pushclear;
     }
     else {

--- a/plugin/pxr/maya/lib/usdMaya/readJob_ImportWithProxies.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/readJob_ImportWithProxies.cpp
@@ -20,6 +20,7 @@
 #include <mayaUsd/fileio/primReaderContext.h>
 #include <mayaUsd/fileio/primReaderRegistry.h>
 #include <mayaUsd/fileio/translators/translatorUtil.h>
+#include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/utils/stageCache.h>
 
 #include <pxr/base/tf/staticTokens.h>
@@ -190,8 +191,9 @@ bool UsdMaya_ReadJobWithSceneAssembly::_ProcessProxyPrims(
         std::string excludePathsString = TfStringJoin(collapsePointPathStrings, ",");
 
         // Set the excludePrimPaths attribute on the node.
-        MDagModifier dagMod;
-        MPlug        excludePathsPlug
+        MDagModifier& dagMod
+            = MAYAUSD_NS_DEF::MDagModifierUndoItem::create("Read job prim exclusion");
+        MPlug excludePathsPlug
             = depNodeFn.findPlug(_tokens->ExcludePrimPathsPlugName.GetText(), true, &status);
         CHECK_MSTATUS_AND_RETURN(status, false);
         status = dagMod.newPlugValueString(excludePathsPlug, excludePathsString.c_str());

--- a/test/lib/mayaUsd/fileio/testDuplicateAs.py
+++ b/test/lib/mayaUsd/fileio/testDuplicateAs.py
@@ -85,6 +85,45 @@ class DuplicateAsTestCase(unittest.TestCase):
         self.assertEqual(cmds.getAttr(bMayaPathStr + '.translate')[0],
                          bXlation)
 
+    def testDuplicateAsMayaUndoRedo(self):
+        '''Duplicate a USD transform hierarchy to Maya and then undo and redo the command.'''
+
+        (_, _, aXlation, aUsdUfePathStr, aUsdUfePath, _, _, 
+               bXlation, bUsdUfePathStr, bUsdUfePath, _) = \
+            createSimpleXformScene()
+
+        # Duplicate USD data as Maya data, placing it under the root.
+        cmds.mayaUsdDuplicate(aUsdUfePathStr, '|world')
+
+        def verifyDuplicate():
+            # Should now have two transform nodes in the Maya scene: the path
+            # components in the second segment of the aUsdItem and bUsdItem will
+            # now be under the Maya world.
+            aMayaPathStr = str(aUsdUfePath.segments[1]).replace('/', '|')
+            bMayaPathStr = str(bUsdUfePath.segments[1]).replace('/', '|')
+            self.assertEqual(cmds.ls(aMayaPathStr, long=True)[0], aMayaPathStr)
+            self.assertEqual(cmds.ls(bMayaPathStr, long=True)[0], bMayaPathStr)
+
+            # Translation should have been copied over to the Maya data model.
+            self.assertEqual(cmds.getAttr(aMayaPathStr + '.translate')[0],
+                            aXlation)
+            self.assertEqual(cmds.getAttr(bMayaPathStr + '.translate')[0],
+                            bXlation)
+
+        verifyDuplicate()
+
+        cmds.undo()
+
+        def verifyDuplicateIsGone():
+            bMayaPathStr = str(bUsdUfePath.segments[1]).replace('/', '|')
+            self.assertListEqual(cmds.ls(bMayaPathStr, long=True), [])
+
+        verifyDuplicateIsGone()
+
+        cmds.redo()
+
+        verifyDuplicate()
+
     def testDuplicateAsUsd(self):
         '''Duplicate a Maya transform hierarchy to USD.'''
 
@@ -126,6 +165,65 @@ class DuplicateAsTestCase(unittest.TestCase):
         usdGroup2T3d = ufe.Transform3d.transform3d(usdGroup2)
         self.assertEqual([1, 2, 3], usdGroup1T3d.translation().vector)
         self.assertEqual([-4, -5, -6], usdGroup2T3d.translation().vector)
+
+    def testDuplicateAsUsdUndoRedo(self):
+        '''Duplicate a Maya transform hierarchy to USD and then undo and redo the command.'''
+
+        # Create a hierarchy.  Because group1 is selected upon creation, group2
+        # will be its parent.
+        group1 = cmds.createNode('transform')
+        group2 = cmds.group()
+        self.assertEqual(cmds.listRelatives(group1, parent=True)[0], group2)
+
+        cmds.setAttr(group1 + '.translate', 1, 2, 3)
+        cmds.setAttr(group2 + '.translate', -4, -5, -6)
+
+        # Create a stage to receive the USD duplicate.
+        psPathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        
+        # Duplicate Maya data as USD data.  As of 17-Nov-2021 no single-segment
+        # path handler registered to UFE for Maya path strings, so use absolute
+        # path.
+        cmds.mayaUsdDuplicate(cmds.ls(group2, long=True)[0], psPathStr)
+
+        def verifyDuplicate():
+            # Maya hierarchy should be duplicated in USD.
+            usdGroup2PathStr = psPathStr + ',/' + group2
+            usdGroup1PathStr = usdGroup2PathStr + '/' + group1
+            usdGroup2Path = ufe.PathString.path(usdGroup2PathStr)
+            usdGroup1Path = ufe.PathString.path(usdGroup1PathStr)
+
+            # group1 is the child of group2
+            usdGroup1 = ufe.Hierarchy.createItem(usdGroup1Path)
+            usdGroup2 = ufe.Hierarchy.createItem(usdGroup2Path)
+            usdGroup1Hier = ufe.Hierarchy.hierarchy(usdGroup1)
+            usdGroup2Hier = ufe.Hierarchy.hierarchy(usdGroup2)
+            self.assertEqual(usdGroup2, usdGroup1Hier.parent())
+            self.assertEqual(len(usdGroup2Hier.children()), 1)
+            self.assertEqual(usdGroup1, usdGroup2Hier.children()[0])
+
+            # Translations have been preserved.
+            usdGroup1T3d = ufe.Transform3d.transform3d(usdGroup1)
+            usdGroup2T3d = ufe.Transform3d.transform3d(usdGroup2)
+            self.assertEqual([1, 2, 3], usdGroup1T3d.translation().vector)
+            self.assertEqual([-4, -5, -6], usdGroup2T3d.translation().vector)
+
+        verifyDuplicate()
+
+        cmds.undo()
+
+        def verifyDuplicateIsGone():
+            # Maya hierarchy should no longer be duplicated in USD.
+            usdGroup2PathStr = psPathStr + ',/' + group2
+            usdGroup2Path = ufe.PathString.path(usdGroup2PathStr)
+            usdGroup2 = ufe.Hierarchy.createItem(usdGroup2Path)
+            self.assertIsNone(usdGroup2)
+
+        verifyDuplicateIsGone()
+
+        cmds.redo()
+
+        verifyDuplicate()
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/mayaUsd/fileio/testEditAsMaya.py
+++ b/test/lib/mayaUsd/fileio/testEditAsMaya.py
@@ -111,6 +111,71 @@ class EditAsMayaTestCase(unittest.TestCase):
         assertVectorAlmostEqual(self, mayaValues, usdValues)
 
     @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '3006', 'Test only available in UFE preview version 0.3.6 and greater')
+    def testEditAsMayaUndoRedo(self):
+        '''Edit a USD transform as a Maya object and apply undo and redo.'''
+
+        (ps, xlateOp, xlation, aUsdUfePathStr, aUsdUfePath, aUsdItem,
+         _, _, _, _, _) = createSimpleXformScene()
+
+        # Edit aPrim as Maya data.
+        self.assertTrue(mayaUsd.lib.PrimUpdaterManager.canEditAsMaya(aUsdUfePathStr))
+
+        cmds.mayaUsdEditAsMaya(aUsdUfePathStr)
+
+        def getMayaPathStr():
+            aMayaItem = ufe.GlobalSelection.get().front()
+            aMayaPath = aMayaItem.path()
+            aMayaPathStr = ufe.PathString.string(aMayaPath)
+            return aMayaPathStr
+
+        aMayaPathStr = getMayaPathStr()
+
+        def verifyEditedScene():
+            aMayaItem = ufe.GlobalSelection.get().front()
+            aMayaPath = aMayaItem.path()
+            aMayaPathStr = ufe.PathString.string(aMayaPath)
+
+            # Confirm the hierarchy is preserved through the Hierarchy interface:
+            # one child, the parent of the pulled item is the proxy shape, and
+            # the proxy shape has the pulled item as a child, not the original USD
+            # scene item.
+            aMayaHier = ufe.Hierarchy.hierarchy(aMayaItem)
+            self.assertEqual(len(aMayaHier.children()), 1)
+            self.assertEqual(ps, aMayaHier.parent())
+            psHier = ufe.Hierarchy.hierarchy(ps)
+            self.assertIn(aMayaItem, psHier.children())
+            self.assertNotIn(aUsdItem, psHier.children())
+
+            # Confirm the translation has been transferred, and that the local
+            # transformation is only a translation.
+            aDagPath = om.MSelectionList().add(ufe.PathString.string(aMayaPath)).getDagPath(0)
+            aFn= om.MFnTransform(aDagPath)
+            self.assertEqual(aFn.translation(om.MSpace.kObject), om.MVector(*xlation))
+            mayaMatrix = aFn.transformation().asMatrix()
+            usdMatrix = xlateOp.GetOpTransform(mayaUsd.ufe.getTime(aUsdUfePathStr))
+            mayaValues = [v for v in mayaMatrix]
+            usdValues = [v for row in usdMatrix for v in row]
+
+            assertVectorAlmostEqual(self, mayaValues, usdValues)
+
+        verifyEditedScene()
+
+        # Undo
+        cmds.undo()
+
+        def verifyNoLongerEdited():
+            # Maya node is removed.
+            with self.assertRaises(RuntimeError):
+                om.MSelectionList().add(aMayaPathStr)
+
+        verifyNoLongerEdited()
+        
+        # Redo
+        cmds.redo()
+
+        verifyEditedScene()
+
+    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '3006', 'Test only available in UFE preview version 0.3.6 and greater')
     def testIllegalEditAsMaya(self):
         '''Trying to edit as Maya on object that doesn't support it.'''
         


### PR DESCRIPTION
Create commands:

- Add mayaUsdEditAsMaya command for edit as Maya.
- Add mayaUsdDuplicate command for duplicate as Maya and duplicate to USD.
- Add mayaUsdDiscardEdits command for discarding edits.
- Add mayaUsdMergeToUsd command to merge back to USD.
- This makes it easy to script and support undo/redo.
- Remove the old mel script for pull/push/discards/duplicate, replace them with these commands.
- Add unit tests for all new commands.

Create system to record undo items:

- Add OpUndoInfo to record all undoable steps for each commands.
- Add an instance to UsdUndoManager singleton to record undo items from anywhere.
- Add OpUndoItem to record a single undoable sub-operation step.
- Add OpUndoInfoMuting to muting recording undo items in block of code that handles undo differently.
- Add OpUndoInfoRecorder to automatically record all undo items in a block of scoped code.

Provide undo items for many common scenarios:

- Implement OpUndoItem for USD undo block (UsdUndoBlock / UsdUndoItem).
- Implement OpUndoItem for MDagModifier.
- Implement OpUndoItem for MDGModifier.
- Implement OpUndoItem for selection.
- Implement OpUndoItem for locking nodes.
- Implement OpUndoItem for pair of Python do/undo scripts.
- Implement OpUndoItem for any generic pair of do/undo C++ functions.

Various code adjustments:

- Remove the cached pull root from PrimUpdaterManager since it was interfering with undo/redo.
- Retrieving it for each command is not costly and avoid needing us to clear it.
- Use undo info muting in read job (import) class since it implements its own undo / redo.