### PR TITLE
MAYA-114898 add merge options for missing attributes.

### DIFF
--- a/lib/mayaUsd/fileio/primUpdater.cpp
+++ b/lib/mayaUsd/fileio/primUpdater.cpp
@@ -106,7 +106,9 @@ UsdMayaPrimUpdater::PushCopySpecs UsdMayaPrimUpdater::pushCopySpecs(
     SdfLayerRefPtr dstLayer,
     const SdfPath& dstSdfPath)
 {
-    return MayaUsdUtils::mergePrims(srcStage, srcLayer, srcSdfPath, dstStage, dstLayer, dstSdfPath)
+    MayaUsdUtils::MergePrimsOptions options;
+    return MayaUsdUtils::mergePrims(
+               srcStage, srcLayer, srcSdfPath, dstStage, dstLayer, dstSdfPath, options)
         ? PushCopySpecs::Continue
         : PushCopySpecs::Failed;
 }

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -779,7 +779,10 @@ PrimUpdaterManager::PrimUpdaterManager()
 
 PrimUpdaterManager::~PrimUpdaterManager() { }
 
-bool PrimUpdaterManager::mergeToUsd(const MFnDependencyNode& depNodeFn, const Ufe::Path& pulledPath)
+bool PrimUpdaterManager::mergeToUsd(
+    const MFnDependencyNode& depNodeFn,
+    const Ufe::Path&         pulledPath,
+    const VtDictionary&      userArgs)
 {
     MayaUsdProxyShapeBase* proxyShape = MayaUsd::ufe::getProxyShape(pulledPath);
     if (!proxyShape) {
@@ -793,12 +796,13 @@ bool PrimUpdaterManager::mergeToUsd(const MFnDependencyNode& depNodeFn, const Uf
 
     PushPullScope scopeIt(_inPushPull);
 
-    VtDictionary exportArgs = UsdMayaJobExportArgs::GetDefaultDictionary();
-    auto         updaterArgs = UsdMayaPrimUpdaterArgs::createFromDictionary(exportArgs);
-    auto         mayaPath = usdToMaya(pulledPath);
-    auto         mayaDagPath = MayaUsd::ufe::ufeToDagPath(mayaPath);
-    MDagPath     pullParentPath;
-    const bool   isCopy = updaterArgs._copyOperation;
+    auto ctxArgs = VtDictionaryOver(userArgs, UsdMayaJobExportArgs::GetDefaultDictionary());
+
+    auto       updaterArgs = UsdMayaPrimUpdaterArgs::createFromDictionary(ctxArgs);
+    auto       mayaPath = usdToMaya(pulledPath);
+    auto       mayaDagPath = MayaUsd::ufe::ufeToDagPath(mayaPath);
+    MDagPath   pullParentPath;
+    const bool isCopy = updaterArgs._copyOperation;
     if (!isCopy) {
         // The pull parent is simply the parent of the pulled path.
         pullParentPath = MayaUsd::ufe::ufeToDagPath(mayaPath.pop());
@@ -813,7 +817,7 @@ bool PrimUpdaterManager::mergeToUsd(const MFnDependencyNode& depNodeFn, const Uf
     SelectionUndoItem::select("Merge to USD selection reset", MSelectionList());
 
     UsdStageRefPtr            proxyStage = proxyShape->usdPrim().GetStage();
-    UsdMayaPrimUpdaterContext context(proxyShape->getTime(), proxyStage, exportArgs);
+    UsdMayaPrimUpdaterContext context(proxyShape->getTime(), proxyStage, ctxArgs);
 
     auto  ufeMayaItem = Ufe::Hierarchy::createItem(mayaPath);
     auto& scene = Ufe::Scene::instance();
@@ -838,7 +842,7 @@ bool PrimUpdaterManager::mergeToUsd(const MFnDependencyNode& depNodeFn, const Uf
     UsdMayaPrimUpdaterContext customizeContext(
         proxyShape->getTime(),
         proxyStage,
-        exportArgs,
+        ctxArgs,
         std::get<UsdPathToDagPathMapPtr>(pushCustomizeSrc));
 
     if (!pushCustomize(pulledPath, pushCustomizeSrc, customizeContext)) {
@@ -876,7 +880,7 @@ bool PrimUpdaterManager::mergeToUsd(const MFnDependencyNode& depNodeFn, const Uf
     return true;
 }
 
-bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path)
+bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& userArgs)
 {
     MayaUsdProxyShapeBase* proxyShape = MayaUsd::ufe::getProxyShape(path);
     if (!proxyShape) {
@@ -890,16 +894,16 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path)
 
     PushPullScope scopeIt(_inPushPull);
 
-    VtDictionary importArgs = UsdMayaJobImportArgs::GetDefaultDictionary();
-    auto         updaterArgs = UsdMayaPrimUpdaterArgs::createFromDictionary(importArgs);
+    auto ctxArgs = VtDictionaryOver(userArgs, UsdMayaJobImportArgs::GetDefaultDictionary());
+    auto updaterArgs = UsdMayaPrimUpdaterArgs::createFromDictionary(ctxArgs);
 
     MDagPath pullParentPath;
     if (!updaterArgs._copyOperation
-        && !(pullParentPath = setupPullParent(path, importArgs)).isValid()) {
+        && !(pullParentPath = setupPullParent(path, ctxArgs)).isValid()) {
         return false;
     }
 
-    UsdMayaPrimUpdaterContext context(proxyShape->getTime(), pulledPrim.GetStage(), importArgs);
+    UsdMayaPrimUpdaterContext context(proxyShape->getTime(), pulledPrim.GetStage(), ctxArgs);
 
     auto& scene = Ufe::Scene::instance();
     auto  ufeItem = Ufe::Hierarchy::createItem(path);
@@ -967,9 +971,8 @@ bool PrimUpdaterManager::discardEdits(const Ufe::Path& pulledPath)
     auto mayaPath = usdToMaya(pulledPath);
     auto mayaDagPath = MayaUsd::ufe::ufeToDagPath(mayaPath);
 
-    VtDictionary              userArgs;
     UsdMayaPrimUpdaterContext context(
-        proxyShape->getTime(), proxyShape->usdPrim().GetStage(), userArgs);
+        proxyShape->getTime(), proxyShape->usdPrim().GetStage(), VtDictionary());
 
     auto  ufeMayaItem = Ufe::Hierarchy::createItem(mayaPath);
     auto& scene = Ufe::Scene::instance();
@@ -1030,7 +1033,10 @@ bool PrimUpdaterManager::discardEdits(const Ufe::Path& pulledPath)
     return true;
 }
 
-bool PrimUpdaterManager::duplicate(const Ufe::Path& srcPath, const Ufe::Path& dstPath)
+bool PrimUpdaterManager::duplicate(
+    const Ufe::Path&    srcPath,
+    const Ufe::Path&    dstPath,
+    const VtDictionary& userArgs)
 {
     MayaUsdProxyShapeBase* srcProxyShape = MayaUsd::ufe::getProxyShape(srcPath);
     MayaUsdProxyShapeBase* dstProxyShape = MayaUsd::ufe::getProxyShape(dstPath);
@@ -1044,13 +1050,14 @@ bool PrimUpdaterManager::duplicate(const Ufe::Path& srcPath, const Ufe::Path& ds
             return false;
         }
 
-        VtDictionary userArgs = UsdMayaJobImportArgs::GetDefaultDictionary();
+        auto ctxArgs = VtDictionaryOver(userArgs, UsdMayaJobImportArgs::GetDefaultDictionary());
+
         // We will only do copy between two data models, setting this in arguments
         // to configure the updater
-        userArgs[UsdMayaPrimUpdaterArgsTokens->copyOperation] = true;
+        ctxArgs[UsdMayaPrimUpdaterArgsTokens->copyOperation] = true;
 
         UsdMayaPrimUpdaterContext context(
-            srcProxyShape->getTime(), srcProxyShape->getUsdStage(), userArgs);
+            srcProxyShape->getTime(), srcProxyShape->getUsdStage(), ctxArgs);
 
         pullImport(srcPath, srcPrim, context);
         return true;
@@ -1062,7 +1069,8 @@ bool PrimUpdaterManager::duplicate(const Ufe::Path& srcPath, const Ufe::Path& ds
         if (!dagPath.isValid()) {
             return false;
         }
-        VtDictionary userArgs = UsdMayaJobExportArgs::GetDefaultDictionary();
+
+        auto ctxArgs = VtDictionaryOver(userArgs, UsdMayaJobExportArgs::GetDefaultDictionary());
 
         // Record all USD modifications in an undo block and item.
         MAYAUSD_NS::UsdUndoBlock undoBlock(
@@ -1070,9 +1078,9 @@ bool PrimUpdaterManager::duplicate(const Ufe::Path& srcPath, const Ufe::Path& ds
 
         // We will only do copy between two data models, setting this in arguments
         // to configure the updater
-        userArgs[UsdMayaPrimUpdaterArgsTokens->copyOperation] = true;
+        ctxArgs[UsdMayaPrimUpdaterArgsTokens->copyOperation] = true;
         auto                      dstStage = dstProxyShape->getUsdStage();
-        UsdMayaPrimUpdaterContext context(dstProxyShape->getTime(), dstStage, userArgs);
+        UsdMayaPrimUpdaterContext context(dstProxyShape->getTime(), dstStage, ctxArgs);
 
         // Export out to a temporary layer.
         auto        pushExportOutput = pushExport(srcPath, dagPath.node(), context);

--- a/lib/mayaUsd/fileio/primUpdaterManager.h
+++ b/lib/mayaUsd/fileio/primUpdaterManager.h
@@ -41,10 +41,13 @@ public:
     ~PrimUpdaterManager();
 
     MAYAUSD_CORE_PUBLIC
-    bool mergeToUsd(const MFnDependencyNode& depNodeFn, const Ufe::Path& pulledPath);
+    bool mergeToUsd(
+        const MFnDependencyNode& depNodeFn,
+        const Ufe::Path&         pulledPath,
+        const VtDictionary&      userArgs = VtDictionary());
 
     MAYAUSD_CORE_PUBLIC
-    bool editAsMaya(const Ufe::Path& path);
+    bool editAsMaya(const Ufe::Path& path, const VtDictionary& userArgs = VtDictionary());
 
     // Can the prim at the argument path be edited as Maya.
     MAYAUSD_CORE_PUBLIC
@@ -54,7 +57,10 @@ public:
     bool discardEdits(const Ufe::Path& path);
 
     MAYAUSD_CORE_PUBLIC
-    bool duplicate(const Ufe::Path& srcPath, const Ufe::Path& dstPath);
+    bool duplicate(
+        const Ufe::Path&    srcPath,
+        const Ufe::Path&    dstPath,
+        const VtDictionary& userArgs = VtDictionary());
 
     /// \brief Returns the singleton prim updater manager
     MAYAUSD_CORE_PUBLIC

--- a/lib/usd/utils/CMakeLists.txt
+++ b/lib/usd/utils/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(${TARGET_NAME}
         DiffRelationships.cpp
         DiffValues.cpp
         MergePrims.cpp
+        MergePrimsOptions.cpp
         util.cpp
 )
 
@@ -63,6 +64,7 @@ set(HEADERS
     DiffCore.h
     DiffPrims.h
     MergePrims.h
+    MergePrimsOptions.h
     ForwardDeclares.h
     SIMD.h
     util.h

--- a/lib/usd/utils/MergePrims.cpp
+++ b/lib/usd/utils/MergePrims.cpp
@@ -36,16 +36,16 @@ namespace {
 // Data used for merging passed to all helper functions.
 struct MergeContext
 {
-    const MergeVerbosity  verbosity;
-    const bool            mergeChildren;
-    const UsdStageRefPtr& srcStage;
-    const SdfPath&        srcRootPath;
-    const UsdStageRefPtr& dstStage;
-    const SdfPath&        dstRootPath;
+    const MergePrimsOptions& options;
+    const UsdStageRefPtr&    srcStage;
+    const SdfPath&           srcRootPath;
+    const UsdStageRefPtr&    dstStage;
+    const SdfPath&           dstRootPath;
 };
 
 //----------------------------------------------------------------------------------------------------------------------
-/// Description of a merge location: layer, path and if the field already exists at that location.
+/// Description of a merge location: layer, path, field and if the field already exists at that
+/// location.
 struct MergeLocation
 {
     const SdfLayerHandle& layer;
@@ -63,7 +63,7 @@ void printAboutField(
     const char*          message,
     const char*          message2 = nullptr)
 {
-    if (!contains(printVerbosity, ctx.verbosity))
+    if (!contains(printVerbosity, ctx.options.verbosity))
         return;
 
     TF_STATUS(
@@ -94,7 +94,7 @@ void printAboutChildren(
     const char*                     message,
     const std::vector<std::string>& childrenNames)
 {
-    if (!contains(MergeVerbosity::Children, ctx.verbosity))
+    if (!contains(MergeVerbosity::Children, ctx.options.verbosity))
         return;
 
     const std::string allNames = TfStringJoin(childrenNames);
@@ -264,6 +264,7 @@ bool shouldMergeValue(
 template <class ChildPolicy>
 bool filterTypedChildren(
     const MergeContext&  ctx,
+    const MergeMissing   missingHandling,
     const MergeLocation& src,
     const MergeLocation& dst,
     VtValue&             srcChildrenValue,
@@ -294,19 +295,54 @@ bool filterTypedChildren(
     dstFilteredChildren.reserve(dstChildren.size());
 
     for (size_t i = 0; i < srcChildren.size(); ++i) {
-        if (srcChildren[i].IsEmpty() || dstChildren[i].IsEmpty()) {
-            printAboutFailure(ctx, src, "empty child. ");
+        const auto& srcChild = srcChildren[i];
+        const auto& dstChild = dstChildren[i];
+
+        // Special handling when the source or destination are empty.
+        if (srcChild.IsEmpty() || dstChild.IsEmpty()) {
+
+            // Both empty: should not happen, but let's be safe.
+            if (srcChild.IsEmpty() && dstChild.IsEmpty()) {
+                printAboutFailure(ctx, srcChild.IsEmpty() ? dst : src, "empty child. ");
+                continue;
+            }
+
+            // Check if we are  allowing missing attributes to be preserved.
+            if (srcChild.IsEmpty() && !contains(missingHandling, MergeMissing::Preserve)) {
+                printAboutFailure(ctx, dst, "not preserving child missing in source. ");
+                continue;
+            }
+
+            // Check if we are not allowing creation of attributes.
+            if (dstChild.IsEmpty() && !contains(missingHandling, MergeMissing::Create)) {
+                printAboutFailure(ctx, src, "not creating child missing in destination. ");
+                continue;
+            }
+
+            const SdfPath childPath = srcChild.IsEmpty()
+                ? ChildPolicy::GetChildPath(dst.path, dstChild)
+                : ChildPolicy::GetChildPath(src.path, srcChild);
+
+            const MergeLocation childLoc
+                = { srcChild.IsEmpty() ? dst.layer : src.layer, childPath, TfToken(), true };
+            printAboutField(ctx, childLoc, MergeVerbosity::Child, "empty child. ");
+
+            if (contains(ctx.options.verbosity, MergeVerbosity::Children))
+                childrenNames.emplace_back(childPath.GetName());
+
+            srcFilteredChildren.emplace_back(srcChild);
+            dstFilteredChildren.emplace_back(dstChild);
             continue;
         }
 
-        const SdfPath srcChildPath = ChildPolicy::GetChildPath(src.path, srcChildren[i]);
-        const SdfPath dstChildPath = ChildPolicy::GetChildPath(dst.path, dstChildren[i]);
+        const SdfPath srcChildPath = ChildPolicy::GetChildPath(src.path, srcChild);
+        const SdfPath dstChildPath = ChildPolicy::GetChildPath(dst.path, dstChild);
 
         // Note: don't use location's field, since we're in a child path, the children field is
         // irrelevant. We will assume the child exists, but we will actually verify it just
         // below with a call to HasSpec().
-        const MergeLocation childSrc = { src.layer, srcChildPath, TfToken(), true };
-        const MergeLocation childDst = { dst.layer, dstChildPath, TfToken(), true };
+        const MergeLocation childSrcLoc = { src.layer, srcChildPath, TfToken(), true };
+        const MergeLocation childDstLoc = { dst.layer, dstChildPath, TfToken(), true };
 
         // Note: we cannot drop a children that already has an opinion at the
         // destination, otherwise SdfCopySpec() will delete that opinion!
@@ -320,23 +356,23 @@ bool filterTypedChildren(
         const char* childMessage = nullptr;
         if (dst.layer->HasSpec(dstChildPath)) {
             childMessage = "keep child. ";
-            srcFilteredChildren.emplace_back(srcChildren[i]);
-            dstFilteredChildren.emplace_back(dstChildren[i]);
-            if (contains(ctx.verbosity, MergeVerbosity::Children))
+            srcFilteredChildren.emplace_back(srcChild);
+            dstFilteredChildren.emplace_back(dstChild);
+            if (contains(ctx.options.verbosity, MergeVerbosity::Children))
                 childrenNames.emplace_back(srcChildPath.GetName());
         } else {
-            if (isDataAtPathsModified(ctx, childSrc, childDst)) {
+            if (isDataAtPathsModified(ctx, childSrcLoc, childDstLoc)) {
                 childMessage = "create child. ";
-                srcFilteredChildren.emplace_back(srcChildren[i]);
-                dstFilteredChildren.emplace_back(dstChildren[i]);
-                if (contains(ctx.verbosity, MergeVerbosity::Children))
+                srcFilteredChildren.emplace_back(srcChild);
+                dstFilteredChildren.emplace_back(dstChild);
+                if (contains(ctx.options.verbosity, MergeVerbosity::Children))
                     childrenNames.emplace_back(srcChildPath.GetName());
             } else {
-                childMessage = "drop child. ";
+                childMessage = "drop child, data identical from elsewhere. ";
             }
         }
 
-        printAboutField(ctx, childSrc, MergeVerbosity::Child, childMessage);
+        printAboutField(ctx, childSrcLoc, MergeVerbosity::Child, childMessage);
     }
 
     const bool  shouldCopy = (srcFilteredChildren.size() > 0);
@@ -357,6 +393,72 @@ bool filterTypedChildren(
     return shouldCopy;
 }
 
+template <class ChildPolicy>
+void unionChildren(
+    MergeMissing missingHandling,
+    VtValue&     srcChildrenValue,
+    VtValue&     dstChildrenValue)
+{
+    // If not preserving missing attributes then we don't need to claculate
+    // the union of the source and destintation children.
+    if (missingHandling == MergeMissing::None)
+        return;
+
+    typedef typename ChildPolicy::FieldType FieldType;
+    typedef std::vector<FieldType>          ChildrenVector;
+    typedef std::set<FieldType>             ChildrenSet;
+
+    if (!TF_VERIFY(srcChildrenValue.IsHolding<ChildrenVector>() || srcChildrenValue.IsEmpty()))
+        return;
+
+    if (!TF_VERIFY(dstChildrenValue.IsHolding<ChildrenVector>() || dstChildrenValue.IsEmpty()))
+        return;
+
+    // Extract children from source and destination.
+    ChildrenVector srcChildren;
+    if (!srcChildrenValue.IsEmpty())
+        srcChildren = srcChildrenValue.UncheckedGet<ChildrenVector>();
+
+    ChildrenVector dstChildren;
+    if (!dstChildrenValue.IsEmpty())
+        dstChildren = dstChildrenValue.UncheckedGet<ChildrenVector>();
+
+    // Create sets for fast comparison and return if both sets are equal,
+    // meaninig the source and destination already have the same children.
+    ChildrenSet srcSet(srcChildren.begin(), srcChildren.end());
+    ChildrenSet dstSet(dstChildren.begin(), dstChildren.end());
+
+    if (srcSet == dstSet)
+        return;
+
+    // If they differ, fill the source and destination to have the desired set
+    // of children.
+    ChildrenSet unionSet;
+    if (contains(missingHandling, MergeMissing::Create))
+        unionSet.insert(srcSet.begin(), srcSet.end());
+    if (contains(missingHandling, MergeMissing::Preserve))
+        unionSet.insert(dstSet.begin(), dstSet.end());
+
+    srcChildren.clear();
+    srcChildren.reserve(unionSet.size());
+
+    dstChildren.clear();
+    dstChildren.reserve(unionSet.size());
+
+    for (const FieldType child : unionSet) {
+        // Note: source cannot be a field that does not exists. To preserve a destination
+        // field, the source field must simply be invalid.
+        srcChildren.emplace_back(srcSet.count(child) ? child : FieldType {});
+
+        // For destrination field, we can put a field that does not exist in the destination.
+        // It will be created.
+        dstChildren.emplace_back(child);
+    }
+
+    srcChildrenValue = srcChildren;
+    dstChildrenValue = dstChildren;
+}
+
 //----------------------------------------------------------------------------------------------------------------------
 /// Filters the children.
 bool filterChildren(
@@ -367,41 +469,63 @@ bool filterChildren(
     VtValue&             dstChildren)
 {
     if (src.field == SdfChildrenKeys->ConnectionChildren) {
+        const auto missingHandling = ctx.options.connectionsHandling;
+        unionChildren<Sdf_AttributeConnectionChildPolicy>(
+            missingHandling, srcChildren, dstChildren);
         return filterTypedChildren<Sdf_AttributeConnectionChildPolicy>(
-            ctx, src, dst, srcChildren, dstChildren);
+            ctx, missingHandling, src, dst, srcChildren, dstChildren);
     }
     if (src.field == SdfChildrenKeys->MapperChildren) {
-        return filterTypedChildren<Sdf_MapperChildPolicy>(ctx, src, dst, srcChildren, dstChildren);
+        const auto missingHandling = ctx.options.mappersHandling;
+        unionChildren<Sdf_MapperChildPolicy>(missingHandling, srcChildren, dstChildren);
+        return filterTypedChildren<Sdf_MapperChildPolicy>(
+            ctx, missingHandling, src, dst, srcChildren, dstChildren);
     }
     if (src.field == SdfChildrenKeys->MapperArgChildren) {
+        const auto missingHandling = ctx.options.mapperArgsHandling;
+        unionChildren<Sdf_MapperArgChildPolicy>(missingHandling, srcChildren, dstChildren);
         return filterTypedChildren<Sdf_MapperArgChildPolicy>(
-            ctx, src, dst, srcChildren, dstChildren);
+            ctx, missingHandling, src, dst, srcChildren, dstChildren);
     }
     if (src.field == SdfChildrenKeys->ExpressionChildren) {
+        const auto missingHandling = ctx.options.expressionsHandling;
+        unionChildren<Sdf_ExpressionChildPolicy>(missingHandling, srcChildren, dstChildren);
         return filterTypedChildren<Sdf_ExpressionChildPolicy>(
-            ctx, src, dst, srcChildren, dstChildren);
+            ctx, missingHandling, src, dst, srcChildren, dstChildren);
     }
     if (src.field == SdfChildrenKeys->RelationshipTargetChildren) {
+        const auto missingHandling = ctx.options.relationshipsHandling;
+        unionChildren<Sdf_RelationshipTargetChildPolicy>(missingHandling, srcChildren, dstChildren);
         return filterTypedChildren<Sdf_RelationshipTargetChildPolicy>(
-            ctx, src, dst, srcChildren, dstChildren);
+            ctx, missingHandling, src, dst, srcChildren, dstChildren);
     }
     if (src.field == SdfChildrenKeys->VariantChildren) {
-        return filterTypedChildren<Sdf_VariantChildPolicy>(ctx, src, dst, srcChildren, dstChildren);
+        const auto missingHandling = ctx.options.variantsHandling;
+        unionChildren<Sdf_VariantChildPolicy>(missingHandling, srcChildren, dstChildren);
+        return filterTypedChildren<Sdf_VariantChildPolicy>(
+            ctx, missingHandling, src, dst, srcChildren, dstChildren);
     }
     if (src.field == SdfChildrenKeys->VariantSetChildren) {
+        const auto missingHandling = ctx.options.variantSetsHandling;
+        unionChildren<Sdf_VariantSetChildPolicy>(missingHandling, srcChildren, dstChildren);
         return filterTypedChildren<Sdf_VariantSetChildPolicy>(
-            ctx, src, dst, srcChildren, dstChildren);
+            ctx, missingHandling, src, dst, srcChildren, dstChildren);
     }
     if (src.field == SdfChildrenKeys->PropertyChildren) {
+        const auto missingHandling = ctx.options.propertiesHandling;
+        unionChildren<Sdf_PropertyChildPolicy>(missingHandling, srcChildren, dstChildren);
         return filterTypedChildren<Sdf_PropertyChildPolicy>(
-            ctx, src, dst, srcChildren, dstChildren);
+            ctx, missingHandling, src, dst, srcChildren, dstChildren);
     }
     if (src.field == SdfChildrenKeys->PrimChildren) {
-        if (ctx.mergeChildren)
+        if (ctx.options.mergeChildren) {
+            const auto missingHandling = ctx.options.primsHandling;
+            unionChildren<Sdf_PrimChildPolicy>(missingHandling, srcChildren, dstChildren);
             return filterTypedChildren<Sdf_PrimChildPolicy>(
-                ctx, src, dst, srcChildren, dstChildren);
-        else
+                ctx, missingHandling, src, dst, srcChildren, dstChildren);
+        } else {
             return false;
+        }
     }
 
     printAboutFailure(ctx, src, "unknown children field.");
@@ -443,14 +567,17 @@ bool shouldMergeChildren(
     }
 
     // Protect against SdfShouldCopyChildren() not filling the children.
-    if (!*srcChildren || !*dstChildren) {
+    if (!*srcChildren) {
         *srcChildren = srcLayer->GetField(srcPath, childrenField);
-        *dstChildren = *srcChildren;
+    }
 
-        if (!*srcChildren || !*dstChildren) {
-            printAboutFailure(ctx, src, "no children to copy. ");
-            return false;
-        }
+    if (!*dstChildren) {
+        *dstChildren = dstLayer->GetField(dstPath, childrenField);
+    }
+
+    if (!*srcChildren || !*dstChildren) {
+        printAboutFailure(ctx, src, "no children to copy. ");
+        return false;
     }
 
     const MergeLocation dst = { dstLayer, dstPath, childrenField, fieldInDst };
@@ -461,18 +588,18 @@ bool shouldMergeChildren(
 /// Copies a minimal prim using diff and merge, printing all fields that are copied to the Maya
 /// console.
 bool mergeDiffPrims(
-    MergeVerbosity        verbosity,
-    bool                  mergeChildren,
-    const UsdStageRefPtr& srcStage,
-    const SdfLayerRefPtr& srcLayer,
-    const SdfPath&        srcPath,
-    const UsdStageRefPtr& dstStage,
-    const SdfLayerRefPtr& dstLayer,
-    const SdfPath&        dstPath)
+    const MergePrimsOptions& options,
+    const UsdStageRefPtr&    srcStage,
+    const SdfLayerRefPtr&    srcLayer,
+    const SdfPath&           srcPath,
+    const UsdStageRefPtr&    dstStage,
+    const SdfLayerRefPtr&    dstLayer,
+    const SdfPath&           dstPath)
 {
-    MergeContext ctx = { verbosity, mergeChildren, srcStage, srcPath, dstStage, dstPath };
-    auto         copyValue = makeFuncWithContext(ctx, shouldMergeValue);
-    auto         copyChildren = makeFuncWithContext(ctx, shouldMergeChildren);
+    const MergeContext ctx = { options, srcStage, srcPath, dstStage, dstPath };
+
+    auto copyValue = makeFuncWithContext(ctx, shouldMergeValue);
+    auto copyChildren = makeFuncWithContext(ctx, shouldMergeChildren);
     return SdfCopySpec(srcLayer, srcPath, dstLayer, dstPath, copyValue, copyChildren);
 }
 
@@ -485,35 +612,29 @@ bool mergeDiffPrims(
 //----------------------------------------------------------------------------------------------------------------------
 /// merges prims starting at a source path from a source layer and stage to a destination.
 bool mergePrims(
-    const UsdStageRefPtr& srcStage,
-    const SdfLayerRefPtr& srcLayer,
-    const SdfPath&        srcPath,
-    const UsdStageRefPtr& dstStage,
-    const SdfLayerRefPtr& dstLayer,
-    const SdfPath&        dstPath,
-    bool                  mergeChildren,
-    MergeVerbosity        verbosity)
+    const UsdStageRefPtr&    srcStage,
+    const SdfLayerRefPtr&    srcLayer,
+    const SdfPath&           srcPath,
+    const UsdStageRefPtr&    dstStage,
+    const SdfLayerRefPtr&    dstLayer,
+    const SdfPath&           dstPath,
+    const MergePrimsOptions& options)
 {
-    // TODO: only create and transfer layer if: not the top layer (easy) or higher layers have an
-    // opinion (might be tricky).
-    const bool useTempStage = true;
-
-    if (useTempStage) {
+    if (options.ignoreUpperLayerOpinions) {
         auto           tempStage = UsdStage::CreateInMemory();
         SdfLayerHandle tempLayer = tempStage->GetSessionLayer();
 
         tempLayer->TransferContent(dstLayer);
 
-        const bool success = mergeDiffPrims(
-            verbosity, mergeChildren, srcStage, srcLayer, srcPath, tempStage, tempLayer, dstPath);
+        const bool success
+            = mergeDiffPrims(options, srcStage, srcLayer, srcPath, tempStage, tempLayer, dstPath);
 
         if (success)
             dstLayer->TransferContent(tempLayer);
 
         return success;
     } else {
-        return mergeDiffPrims(
-            verbosity, mergeChildren, srcStage, srcLayer, srcPath, dstStage, dstLayer, dstPath);
+        return mergeDiffPrims(options, srcStage, srcLayer, srcPath, dstStage, dstLayer, dstPath);
     }
 }
 

--- a/lib/usd/utils/MergePrims.h
+++ b/lib/usd/utils/MergePrims.h
@@ -16,40 +16,13 @@
 #pragma once
 
 #include <mayaUsdUtils/Api.h>
+#include <mayaUsdUtils/MergePrimsOptions.h>
 
 #include <pxr/usd/sdf/layer.h>
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/common.h>
 
 namespace MayaUsdUtils {
-
-//----------------------------------------------------------------------------------------------------------------------
-/// MergeVerbosity level flags.
-
-enum class MergeVerbosity
-{
-    None = 0,
-    Same = 1 << 0,
-    Differ = 1 << 1,
-    Child = 1 << 2,
-    Children = 1 << 3,
-    Failure = 1 << 4,
-    Default = Differ | Children | Failure,
-};
-
-MergeVerbosity operator|(MergeVerbosity a, MergeVerbosity b)
-{
-    return MergeVerbosity(uint32_t(a) | uint32_t(b));
-}
-MergeVerbosity operator&(MergeVerbosity a, MergeVerbosity b)
-{
-    return MergeVerbosity(uint32_t(a) & uint32_t(b));
-}
-MergeVerbosity operator^(MergeVerbosity a, MergeVerbosity b)
-{
-    return MergeVerbosity(uint32_t(a) ^ uint32_t(b));
-}
-bool contains(MergeVerbosity a, MergeVerbosity b) { return (a & b) != MergeVerbosity::None; }
 
 //----------------------------------------------------------------------------------------------------------------------
 /// \brief  merges prims starting at a source path from a source layer and stage to a destination.
@@ -59,8 +32,7 @@ bool contains(MergeVerbosity a, MergeVerbosity b) { return (a & b) != MergeVerbo
 /// \param  dstStage the stage containing the baseline prims that receive the modifications.
 /// \param  dstLayer the layer containing the baseline prims that receive the modifications.
 /// \param  dstPath the path to the baseline prims that receive the modifications.
-/// \param  mergeChildren if true, merges children too, otherwise only this prim.
-/// \param  verbosity how much info is printed about the merge in the console.
+/// \param  options merging options.
 /// \return true if the merge was successful.
 //----------------------------------------------------------------------------------------------------------------------
 MAYA_USD_UTILS_PUBLIC
@@ -71,7 +43,6 @@ bool mergePrims(
     const PXR_NS::UsdStageRefPtr& dstStage,
     const PXR_NS::SdfLayerRefPtr& dstLayer,
     const PXR_NS::SdfPath&        dstPath,
-    bool                          mergeChildren = false,
-    MergeVerbosity                verbosity = MergeVerbosity::Default);
+    const MergePrimsOptions&      options);
 
 } // namespace MayaUsdUtils

--- a/lib/usd/utils/MergePrimsOptions.cpp
+++ b/lib/usd/utils/MergePrimsOptions.cpp
@@ -1,0 +1,191 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "MergePrimsOptions.h"
+
+#include <mutex>
+
+namespace MayaUsdUtils {
+
+TF_DEFINE_PUBLIC_TOKENS(UsdMayaMergeOptionsTokens, USDMAYA_MERGE_OPTIONS_TOKENS);
+
+namespace {
+
+/// Extracts a bool at \p key from \p options, or false if it can't extract.
+bool parseBoolean(const VtDictionary& options, const TfToken& key)
+{
+    if (!VtDictionaryIsHolding<bool>(options, key)) {
+        TF_CODING_ERROR(
+            "Dictionary is missing required key '%s' or key is "
+            "not bool type",
+            key.GetText());
+        return false;
+    }
+    return VtDictionaryGet<bool>(options, key);
+}
+
+/// Extracts a MergeVerbosity array of tokens at \p key from \p options, or Default if it can't
+/// extract.
+MergeVerbosity parseVerbosity(
+    const VtDictionary&  options,
+    const TfToken&       key,
+    const MergeVerbosity def = MergeVerbosity::Default)
+{
+    if (!VtDictionaryIsHolding<std::vector<VtValue>>(options, key)) {
+        TF_CODING_ERROR(
+            "Dictionary is missing required key '%s' or key is "
+            "not a vector of tokens",
+            key.GetText());
+        return def;
+    }
+
+    MergeVerbosity verbosity = MergeVerbosity::None;
+
+    const auto tokens = VtDictionaryGet<std::vector<VtValue>>(options, key);
+    for (const auto& token : tokens) {
+        if (UsdMayaMergeOptionsTokens->None == token)
+            verbosity = verbosity | MergeVerbosity::None;
+        if (UsdMayaMergeOptionsTokens->Same == token)
+            verbosity = verbosity | MergeVerbosity::Same;
+        if (UsdMayaMergeOptionsTokens->Differ == token)
+            verbosity = verbosity | MergeVerbosity::Differ;
+        if (UsdMayaMergeOptionsTokens->Child == token)
+            verbosity = verbosity | MergeVerbosity::Child;
+        if (UsdMayaMergeOptionsTokens->Children == token)
+            verbosity = verbosity | MergeVerbosity::Children;
+        if (UsdMayaMergeOptionsTokens->Failure == token)
+            verbosity = verbosity | MergeVerbosity::Failure;
+        if (UsdMayaMergeOptionsTokens->Default == token)
+            verbosity = verbosity | MergeVerbosity::Default;
+    }
+
+    return verbosity;
+}
+
+/// Extracts a MergeMissing array of tokens at \p key from \p options, or All if it can't
+/// extract.
+MergeMissing parseMissingHandling(
+    const VtDictionary& options,
+    const TfToken&      key,
+    MergeMissing        def = MergeMissing::All)
+{
+    if (!VtDictionaryIsHolding<std::vector<VtValue>>(options, key)) {
+        TF_CODING_ERROR(
+            "Dictionary is missing required key '%s' or key is "
+            "not a vector of tokens",
+            key.GetText());
+        return def;
+    }
+
+    MergeMissing missingHandling = MergeMissing::None;
+
+    const auto tokens = VtDictionaryGet<std::vector<VtValue>>(options, key);
+    for (const auto& token : tokens) {
+        if (UsdMayaMergeOptionsTokens->None == token)
+            missingHandling = missingHandling | MergeMissing::None;
+        if (UsdMayaMergeOptionsTokens->Create == token)
+            missingHandling = missingHandling | MergeMissing::Create;
+        if (UsdMayaMergeOptionsTokens->Preserve == token)
+            missingHandling = missingHandling | MergeMissing::Preserve;
+        if (UsdMayaMergeOptionsTokens->All == token)
+            missingHandling = missingHandling | MergeMissing::All;
+    }
+
+    return missingHandling;
+}
+
+} // namespace
+
+/* static */
+const VtDictionary& MergePrimsOptions::getDefaultDictionary()
+{
+    static VtDictionary   d;
+    static std::once_flag once;
+    std::call_once(once, []() {
+        const auto _token = VtValue(TfToken());
+        const auto _tokenVector = VtValue(std::vector<VtValue>({ _token }));
+
+        d[UsdMayaMergeOptionsTokens->verbosity]
+            = VtValue(std::vector<VtValue>({ VtValue(UsdMayaMergeOptionsTokens->Default) }));
+        d[UsdMayaMergeOptionsTokens->mergeChildren] = false;
+        d[UsdMayaMergeOptionsTokens->ignoreUpperLayerOpinions] = false;
+        d[UsdMayaMergeOptionsTokens->propertiesHandling]
+            = VtValue(std::vector<VtValue>({ VtValue(UsdMayaMergeOptionsTokens->All) }));
+        d[UsdMayaMergeOptionsTokens->primsHandling]
+            = VtValue(std::vector<VtValue>({ VtValue(UsdMayaMergeOptionsTokens->All) }));
+        d[UsdMayaMergeOptionsTokens->connectionsHandling]
+            = VtValue(std::vector<VtValue>({ VtValue(UsdMayaMergeOptionsTokens->All) }));
+        d[UsdMayaMergeOptionsTokens->relationshipsHandling]
+            = VtValue(std::vector<VtValue>({ VtValue(UsdMayaMergeOptionsTokens->All) }));
+        d[UsdMayaMergeOptionsTokens->variantsHandling]
+            = VtValue(std::vector<VtValue>({ VtValue(UsdMayaMergeOptionsTokens->All) }));
+        d[UsdMayaMergeOptionsTokens->variantSetsHandling]
+            = VtValue(std::vector<VtValue>({ VtValue(UsdMayaMergeOptionsTokens->All) }));
+        d[UsdMayaMergeOptionsTokens->expressionsHandling]
+            = VtValue(std::vector<VtValue>({ VtValue(UsdMayaMergeOptionsTokens->All) }));
+        d[UsdMayaMergeOptionsTokens->mappersHandling]
+            = VtValue(std::vector<VtValue>({ VtValue(UsdMayaMergeOptionsTokens->All) }));
+        d[UsdMayaMergeOptionsTokens->mapperArgsHandling]
+            = VtValue(std::vector<VtValue>({ VtValue(UsdMayaMergeOptionsTokens->All) }));
+    });
+
+    return d;
+}
+
+MergePrimsOptions::MergePrimsOptions(const VtDictionary& options)
+{
+    // Make sure we have all options filled by merging over the default dictionary.
+    const VtDictionary optionsWithDef = VtDictionaryOver(options, getDefaultDictionary());
+
+    verbosity = parseVerbosity(optionsWithDef, UsdMayaMergeOptionsTokens->verbosity);
+
+    mergeChildren = parseBoolean(optionsWithDef, UsdMayaMergeOptionsTokens->mergeChildren);
+
+    ignoreUpperLayerOpinions
+        = parseBoolean(optionsWithDef, UsdMayaMergeOptionsTokens->ignoreUpperLayerOpinions);
+
+    propertiesHandling
+        = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->propertiesHandling);
+
+    primsHandling = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->primsHandling);
+
+    connectionsHandling
+        = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->connectionsHandling);
+
+    relationshipsHandling
+        = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->relationshipsHandling);
+
+    variantsHandling
+        = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->variantsHandling);
+
+    variantSetsHandling
+        = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->variantSetsHandling);
+
+    expressionsHandling
+        = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->expressionsHandling);
+
+    mappersHandling
+        = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->mappersHandling);
+
+    mapperArgsHandling
+        = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->mapperArgsHandling);
+}
+
+MergePrimsOptions::MergePrimsOptions()
+    : MergePrimsOptions(MergePrimsOptions::getDefaultDictionary())
+{
+}
+
+} // namespace MayaUsdUtils

--- a/lib/usd/utils/MergePrimsOptions.h
+++ b/lib/usd/utils/MergePrimsOptions.h
@@ -1,0 +1,190 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <mayaUsdUtils/Api.h>
+
+#include <pxr/base/tf/staticTokens.h>
+#include <pxr/base/tf/token.h>
+#include <pxr/base/vt/dictionary.h>
+
+namespace MayaUsdUtils {
+
+//----------------------------------------------------------------------------------------------------------------------
+/// MergeVerbosity level flags.
+
+enum class MergeVerbosity
+{
+    None = 0,
+    Same = 1 << 0,
+    Differ = 1 << 1,
+    Child = 1 << 2,
+    Children = 1 << 3,
+    Failure = 1 << 4,
+    Default = Differ | Child | Children | Failure,
+};
+
+inline MergeVerbosity operator|(MergeVerbosity a, MergeVerbosity b)
+{
+    return MergeVerbosity(uint32_t(a) | uint32_t(b));
+}
+
+inline MergeVerbosity operator&(MergeVerbosity a, MergeVerbosity b)
+{
+    return MergeVerbosity(uint32_t(a) & uint32_t(b));
+}
+
+inline MergeVerbosity operator^(MergeVerbosity a, MergeVerbosity b)
+{
+    return MergeVerbosity(uint32_t(a) ^ uint32_t(b));
+}
+
+inline bool contains(MergeVerbosity a, MergeVerbosity b) { return (a & b) != MergeVerbosity::None; }
+
+//----------------------------------------------------------------------------------------------------------------------
+// Missing field handling flags.
+
+enum class MergeMissing
+{
+    None = 0,
+
+    // If set, attributes found only in the source are created in the destination.
+    Create = 1 << 0,
+
+    // If set, attributes missing from the source are preserved in the destination.
+    Preserve = 1 << 1,
+
+    All = Create | Preserve,
+};
+
+inline MergeMissing operator|(MergeMissing a, MergeMissing b)
+{
+    return MergeMissing(uint32_t(a) | uint32_t(b));
+}
+
+inline MergeMissing operator&(MergeMissing a, MergeMissing b)
+{
+    return MergeMissing(uint32_t(a) & uint32_t(b));
+}
+
+inline MergeMissing operator^(MergeMissing a, MergeMissing b)
+{
+    return MergeMissing(uint32_t(a) ^ uint32_t(b));
+}
+
+inline bool contains(MergeMissing a, MergeMissing b) { return (a & b) != MergeMissing::None; }
+
+//----------------------------------------------------------------------------------------------------------------------
+// Options to control prims merging.
+
+struct MergePrimsOptions
+{
+    // How much logging is done during the merge.
+    MergeVerbosity verbosity = MergeVerbosity::Default;
+
+    // if true, merges children too, otherwise merge only the given prim.
+    bool mergeChildren = false;
+
+    // If true, the merge is done in a temporary layer so to ignore opinions
+    // from upper layers (and children of upper layers).
+    bool ignoreUpperLayerOpinions = false;
+
+    // How missing attributes are handled.
+    MergeMissing propertiesHandling = MergeMissing::All;
+
+    // How missing prim children are handled.
+    MergeMissing primsHandling = MergeMissing::All;
+
+    // How missing connections are handled.
+    MergeMissing connectionsHandling = MergeMissing::All;
+
+    // How missing relationships are handled.
+    MergeMissing relationshipsHandling = MergeMissing::All;
+
+    // How missing variants are handled.
+    MergeMissing variantsHandling = MergeMissing::All;
+
+    // How missing variant sets are handled.
+    MergeMissing variantSetsHandling = MergeMissing::All;
+
+    // How missing expressions are handled.
+    MergeMissing expressionsHandling = MergeMissing::All;
+
+    // How missing mappers are handled.
+    MergeMissing mappersHandling = MergeMissing::All;
+
+    // How missing mapper argumentss are handled.
+    MergeMissing mapperArgsHandling = MergeMissing::All;
+
+    // Create a VtDictionary containing the default values for the merge options.
+    MAYA_USD_UTILS_PUBLIC
+    static const PXR_NS::VtDictionary& getDefaultDictionary();
+
+    // Constructs a MergePrimsOptions with the given options.
+    // Not all options need to be filled, missing ones will use the defaults.
+    MAYA_USD_UTILS_PUBLIC
+    MergePrimsOptions(const PXR_NS::VtDictionary& options);
+
+    // Constructs a MergePrimsOptions with the default options.
+    MAYA_USD_UTILS_PUBLIC
+    MergePrimsOptions();
+};
+
+//----------------------------------------------------------------------------------------------------------------------
+// Options tokens used in the default options dictionary.
+
+// clang-format off
+#define USDMAYA_MERGE_OPTIONS_TOKENS    \
+    /* Dictionary keys */               \
+    (verbosity)                         \
+                                        \
+    (None)                              \
+    (Same)                              \
+    (Differ)                            \
+    (Child)                             \
+    (Children)                          \
+    (Failure)                           \
+    (Default)                           \
+                                        \
+    (mergeChildren)                     \
+    (ignoreUpperLayerOpinions)          \
+                                        \
+    (propertiesHandling)                \
+    (primsHandling)                     \
+    (connectionsHandling)               \
+    (relationshipsHandling)             \
+    (variantsHandling)                  \
+    (variantSetsHandling)               \
+    (expressionsHandling)               \
+    (mappersHandling)                   \
+    (mapperArgsHandling)                \
+                                        \
+    (Create)                            \
+    (Preserve)                          \
+    (All)                               \
+                                        \
+// clang-format on
+
+// Note: the macro below does not qualify the types it uses with the PXR namespace,
+// so we're forced to use the types it uses here.
+using namespace PXR_NS;
+
+TF_DECLARE_PUBLIC_TOKENS(
+    UsdMayaMergeOptionsTokens,
+    MAYA_USD_UTILS_PUBLIC,
+    USDMAYA_MERGE_OPTIONS_TOKENS);
+
+} // namespace MayaUsdUtils

--- a/test/lib/usd/utils/test_MergePrims.cpp
+++ b/test/lib/usd/utils/test_MergePrims.cpp
@@ -34,9 +34,6 @@ const TfToken otherRelName("other_rel");
 
 const SdfValueTypeName doubleType = SdfValueTypeNames->Double;
 
-const bool mergeChildren = true;
-const bool dontMergeChildren = false;
-
 UsdPrim createPrim(UsdStageRefPtr& stage, const SdfPath& path)
 {
     return stage->DefinePrim(SdfPath(path), TfToken("xform"));
@@ -92,6 +89,11 @@ TEST(MergePrims, mergePrimsEmpty)
     auto modifiedStage = UsdStage::CreateInMemory();
     auto modifiedPrim = createPrim(modifiedStage, primPath);
 
+    MergePrimsOptions options;
+    options.mergeChildren = true;
+    options.propertiesHandling = MergeMissing::Create;
+    options.verbosity = MergeVerbosity::Failure;
+
     const bool result = mergePrims(
         modifiedStage,
         modifiedStage->GetRootLayer(),
@@ -99,8 +101,7 @@ TEST(MergePrims, mergePrimsEmpty)
         baselineStage,
         baselineStage->GetRootLayer(),
         baselinePrim.GetPath(),
-        mergeChildren,
-        MergeVerbosity::Failure);
+        options);
 
     EXPECT_TRUE(result);
 
@@ -122,6 +123,11 @@ TEST(MergePrims, mergePrimsSameChildren)
     createChild(modifiedStage, childPath1, 1.0);
     createChild(modifiedStage, childPath2, 1.0);
 
+    MergePrimsOptions options;
+    options.mergeChildren = true;
+    options.propertiesHandling = MergeMissing::Create;
+    options.verbosity = MergeVerbosity::Failure;
+
     const bool result = mergePrims(
         modifiedStage,
         modifiedStage->GetRootLayer(),
@@ -129,8 +135,7 @@ TEST(MergePrims, mergePrimsSameChildren)
         baselineStage,
         baselineStage->GetRootLayer(),
         baselinePrim.GetPath(),
-        mergeChildren,
-        MergeVerbosity::Failure);
+        options);
 
     EXPECT_TRUE(result);
 
@@ -165,6 +170,11 @@ TEST(MergePrims, mergePrimsDiffChildren)
     createChild(modifiedStage, childPath1, 2.0);
     createChild(modifiedStage, childPath2, 3.0);
 
+    MergePrimsOptions options;
+    options.mergeChildren = true;
+    options.propertiesHandling = MergeMissing::Create;
+    options.verbosity = MergeVerbosity::Failure;
+
     const bool result = mergePrims(
         modifiedStage,
         modifiedStage->GetRootLayer(),
@@ -172,8 +182,7 @@ TEST(MergePrims, mergePrimsDiffChildren)
         baselineStage,
         baselineStage->GetRootLayer(),
         baselinePrim.GetPath(),
-        mergeChildren,
-        MergeVerbosity::Failure);
+        options);
 
     EXPECT_TRUE(result);
 
@@ -206,6 +215,12 @@ TEST(MergePrims, mergePrimsAbsentChild)
     auto modifiedPrim = createPrim(modifiedStage, primPath);
     createChild(modifiedStage, childPath1, 1.0);
 
+    MergePrimsOptions options;
+    options.mergeChildren = true;
+    options.propertiesHandling = MergeMissing::Create;
+    options.primsHandling = MergeMissing::Create;
+    options.verbosity = MergeVerbosity::Failure;
+
     const bool result = mergePrims(
         modifiedStage,
         modifiedStage->GetRootLayer(),
@@ -213,8 +228,7 @@ TEST(MergePrims, mergePrimsAbsentChild)
         baselineStage,
         baselineStage->GetRootLayer(),
         baselinePrim.GetPath(),
-        mergeChildren,
-        MergeVerbosity::Failure);
+        options);
 
     EXPECT_TRUE(result);
 
@@ -244,6 +258,11 @@ TEST(MergePrims, mergePrimsCreatedChild)
     createChild(modifiedStage, childPath1, 1.0);
     createChild(modifiedStage, childPath2, 2.0);
 
+    MergePrimsOptions options;
+    options.mergeChildren = true;
+    options.propertiesHandling = MergeMissing::Create;
+    options.verbosity = MergeVerbosity::Failure;
+
     const bool result = mergePrims(
         modifiedStage,
         modifiedStage->GetRootLayer(),
@@ -251,8 +270,7 @@ TEST(MergePrims, mergePrimsCreatedChild)
         baselineStage,
         baselineStage->GetRootLayer(),
         baselinePrim.GetPath(),
-        mergeChildren,
-        MergeVerbosity::Failure);
+        options);
 
     EXPECT_TRUE(result);
 
@@ -291,6 +309,11 @@ TEST(MergePrims, mergePrimsOnlySameChildren)
     createChild(modifiedStage, childPath1, 1.0);
     createChild(modifiedStage, childPath2, 1.0);
 
+    MergePrimsOptions options;
+    options.mergeChildren = false;
+    options.propertiesHandling = MergeMissing::Create;
+    options.verbosity = MergeVerbosity::Failure;
+
     const bool result = mergePrims(
         modifiedStage,
         modifiedStage->GetRootLayer(),
@@ -298,8 +321,7 @@ TEST(MergePrims, mergePrimsOnlySameChildren)
         baselineStage,
         baselineStage->GetRootLayer(),
         baselinePrim.GetPath(),
-        dontMergeChildren,
-        MergeVerbosity::Failure);
+        options);
 
     EXPECT_TRUE(result);
 
@@ -334,6 +356,11 @@ TEST(MergePrims, mergePrimsOnlyDiffChildren)
     createChild(modifiedStage, childPath1, 2.0);
     createChild(modifiedStage, childPath2, 3.0);
 
+    MergePrimsOptions options;
+    options.mergeChildren = false;
+    options.propertiesHandling = MergeMissing::Create;
+    options.verbosity = MergeVerbosity::Failure;
+
     const bool result = mergePrims(
         modifiedStage,
         modifiedStage->GetRootLayer(),
@@ -341,8 +368,7 @@ TEST(MergePrims, mergePrimsOnlyDiffChildren)
         baselineStage,
         baselineStage->GetRootLayer(),
         baselinePrim.GetPath(),
-        dontMergeChildren,
-        MergeVerbosity::Failure);
+        options);
 
     EXPECT_TRUE(result);
 
@@ -378,6 +404,11 @@ TEST(MergePrims, mergePrimsOnlyAbsentChild)
     auto modifiedPrim = createPrim(modifiedStage, primPath);
     createChild(modifiedStage, childPath1, 1.0);
 
+    MergePrimsOptions options;
+    options.mergeChildren = false;
+    options.propertiesHandling = MergeMissing::Create;
+    options.verbosity = MergeVerbosity::Failure;
+
     const bool result = mergePrims(
         modifiedStage,
         modifiedStage->GetRootLayer(),
@@ -385,8 +416,7 @@ TEST(MergePrims, mergePrimsOnlyAbsentChild)
         baselineStage,
         baselineStage->GetRootLayer(),
         baselinePrim.GetPath(),
-        dontMergeChildren,
-        MergeVerbosity::Failure);
+        options);
 
     EXPECT_TRUE(result);
 
@@ -422,6 +452,11 @@ TEST(MergePrims, mergePrimsOnlyCreatedChild)
     createChild(modifiedStage, childPath1, 1.0);
     createChild(modifiedStage, childPath2, 2.0);
 
+    MergePrimsOptions options;
+    options.mergeChildren = false;
+    options.propertiesHandling = MergeMissing::Create;
+    options.verbosity = MergeVerbosity::Failure;
+
     const bool result = mergePrims(
         modifiedStage,
         modifiedStage->GetRootLayer(),
@@ -429,8 +464,7 @@ TEST(MergePrims, mergePrimsOnlyCreatedChild)
         baselineStage,
         baselineStage->GetRootLayer(),
         baselinePrim.GetPath(),
-        dontMergeChildren,
-        MergeVerbosity::Failure);
+        options);
 
     EXPECT_TRUE(result);
 
@@ -468,6 +502,11 @@ TEST(MergePrims, mergePrimsAbsentChildAttribute)
     auto modifiedPrim = createPrim(modifiedStage, primPath);
     auto modifiedChild = createChild(modifiedStage, childPath1, 2.0);
 
+    MergePrimsOptions options;
+    options.mergeChildren = true;
+    options.propertiesHandling = MergeMissing::Create;
+    options.verbosity = MergeVerbosity::Failure;
+
     const bool result = mergePrims(
         modifiedStage,
         modifiedStage->GetRootLayer(),
@@ -475,8 +514,7 @@ TEST(MergePrims, mergePrimsAbsentChildAttribute)
         baselineStage,
         baselineStage->GetRootLayer(),
         baselinePrim.GetPath(),
-        mergeChildren,
-        MergeVerbosity::Failure);
+        options);
 
     EXPECT_TRUE(result);
 
@@ -508,6 +546,11 @@ TEST(MergePrims, mergePrimsCreatedChildAttribute)
     auto modifiedChild = createChild(modifiedStage, childPath1, 2.0);
     createAttr(modifiedChild, otherAttrName, 1.0);
 
+    MergePrimsOptions options;
+    options.mergeChildren = true;
+    options.propertiesHandling = MergeMissing::Create;
+    options.verbosity = MergeVerbosity::Failure;
+
     const bool result = mergePrims(
         modifiedStage,
         modifiedStage->GetRootLayer(),
@@ -515,8 +558,7 @@ TEST(MergePrims, mergePrimsCreatedChildAttribute)
         baselineStage,
         baselineStage->GetRootLayer(),
         baselinePrim.GetPath(),
-        mergeChildren,
-        MergeVerbosity::Failure);
+        options);
 
     EXPECT_TRUE(result);
 
@@ -553,6 +595,11 @@ TEST(MergePrims, mergePrimsAbsentChildRelationship)
     auto modifiedChild = createChild(modifiedStage, childPath1, 1.0);
     auto modifiedRel1 = createRel(modifiedChild, testRelName, targetPath1);
 
+    MergePrimsOptions options;
+    options.mergeChildren = true;
+    options.propertiesHandling = MergeMissing::Create;
+    options.verbosity = MergeVerbosity::Failure;
+
     const bool result = mergePrims(
         modifiedStage,
         modifiedStage->GetRootLayer(),
@@ -560,8 +607,7 @@ TEST(MergePrims, mergePrimsAbsentChildRelationship)
         baselineStage,
         baselineStage->GetRootLayer(),
         baselinePrim.GetPath(),
-        mergeChildren,
-        MergeVerbosity::Failure);
+        options);
 
     EXPECT_TRUE(result);
 
@@ -594,6 +640,11 @@ TEST(MergePrims, mergePrimsCreatedChildRelationship)
     createRel(modifiedChild, testRelName, targetPath1);
     createRel(modifiedChild, otherRelName, targetPath2);
 
+    MergePrimsOptions options;
+    options.mergeChildren = true;
+    options.propertiesHandling = MergeMissing::Create;
+    options.verbosity = MergeVerbosity::Failure;
+
     const bool result = mergePrims(
         modifiedStage,
         modifiedStage->GetRootLayer(),
@@ -601,8 +652,7 @@ TEST(MergePrims, mergePrimsCreatedChildRelationship)
         baselineStage,
         baselineStage->GetRootLayer(),
         baselinePrim.GetPath(),
-        mergeChildren,
-        MergeVerbosity::Failure);
+        options);
 
     EXPECT_TRUE(result);
 
@@ -640,6 +690,11 @@ TEST(MergePrims, mergePrimsChildRelationshipAddTarget)
     auto modifiedRel1 = createRel(modifiedChild, testRelName, targetPath1);
     modifiedRel1.AddTarget(targetPath3);
 
+    MergePrimsOptions options;
+    options.mergeChildren = true;
+    options.propertiesHandling = MergeMissing::Create;
+    options.verbosity = MergeVerbosity::Failure;
+
     const bool result = mergePrims(
         modifiedStage,
         modifiedStage->GetRootLayer(),
@@ -647,8 +702,7 @@ TEST(MergePrims, mergePrimsChildRelationshipAddTarget)
         baselineStage,
         baselineStage->GetRootLayer(),
         baselinePrim.GetPath(),
-        mergeChildren,
-        MergeVerbosity::Failure);
+        options);
 
     EXPECT_TRUE(result);
 


### PR DESCRIPTION
Add MergePrimsOptions structure as options to control the merging of prims.

- The options have a constructor taking a VtDictionary to allow customizing them.
- Made the default for the 'ignore upper layers' to be off.
- Add merge missing options for each different fields.
- For example: properties, relationships, variants, etc.
- The options control the creation or deletion of entries in these fields.
- For example it control if an attribute missing from the source gets deleted in the destination.
- Other example: if an attributes missing in the destination gets created.

Modify code to allow passing the options:

- Add a VtDictionary userArgs to the PrimUpdaterManager in its editAsMaya, mergeToUsd and duplicate functions.
- Make sure the merge prims options are built with the default values.
- Use these user arguments in the prim updater manager code.
