### PR TITLE
MAYA-114898 fix unit test assertions related to pull/push

### DIFF
--- a/lib/mayaUsd/python/CMakeLists.txt
+++ b/lib/mayaUsd/python/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(${PYTHON_TARGET_NAME}
         wrapConverter.cpp
         wrapDiagnosticDelegate.cpp
         wrapMeshWriteUtils.cpp
+        wrapOpUndoItem.cpp
         wrapQuery.cpp
         wrapReadUtil.cpp
         wrapRoundTripUtil.cpp

--- a/lib/mayaUsd/python/module.cpp
+++ b/lib/mayaUsd/python/module.cpp
@@ -38,6 +38,7 @@ TF_WRAP_MODULE
     TF_WRAP(PrimUpdaterContext);
     TF_WRAP(PrimUpdaterManager);
 #endif
+    TF_WRAP(OpUndoItem);
     TF_WRAP(Query);
     TF_WRAP(ReadUtil);
     TF_WRAP(RoundTripUtil);

--- a/lib/mayaUsd/python/wrapOpUndoItem.cpp
+++ b/lib/mayaUsd/python/wrapOpUndoItem.cpp
@@ -1,0 +1,78 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <mayaUsd/undo/OpUndoItemList.h>
+#include <mayaUsd/undo/OpUndoItemRecorder.h>
+
+#include <pxr/base/tf/diagnostic.h>
+
+#include <boost/python/class.hpp>
+#include <boost/python/def.hpp>
+
+#include <memory>
+
+using namespace boost::python;
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace {
+
+class PythonOpUndoItemList
+{
+public:
+    PythonOpUndoItemList()
+        : _undoItemList()
+        , _recorder()
+    {
+    }
+
+    ~PythonOpUndoItemList() { }
+
+    void enter()
+    {
+        if (!TF_VERIFY(_undoItemList == nullptr)) {
+            return;
+        }
+        _undoItemList = std::make_unique<MayaUsd::OpUndoItemList>();
+        _recorder = std::make_unique<MayaUsd::OpUndoItemRecorder>(*_undoItemList);
+    }
+
+    void exit(object, object, object)
+    {
+        if (!TF_VERIFY(_undoItemList != nullptr)) {
+            return;
+        }
+        _recorder.reset();
+        _undoItemList.reset();
+    }
+
+private:
+    std::unique_ptr<MayaUsd::OpUndoItemList>     _undoItemList;
+    std::unique_ptr<MayaUsd::OpUndoItemRecorder> _recorder;
+};
+
+} // namespace
+
+void wrapOpUndoItem()
+{
+    // OpUndoItemList
+    {
+        typedef PythonOpUndoItemList This;
+        class_<This, boost::noncopyable>("OpUndoItemList", init<>())
+            .def("__enter__", &This::enter)
+            .def("__exit__", &This::exit);
+    }
+}

--- a/lib/mayaUsd/undo/OpUndoItemList.cpp
+++ b/lib/mayaUsd/undo/OpUndoItemList.cpp
@@ -22,7 +22,7 @@
 namespace MAYAUSD_NS_DEF {
 
 //------------------------------------------------------------------------------
-// OpUndoItemList automatic celar when scene in reset.
+// Notifier to automatically clear OpUndoItemList when the scene is reset.
 //------------------------------------------------------------------------------
 
 namespace {

--- a/lib/mayaUsd/undo/OpUndoItemList.cpp
+++ b/lib/mayaUsd/undo/OpUndoItemList.cpp
@@ -15,7 +15,30 @@
 //
 #include "OpUndoItemList.h"
 
+#include <mayaUsd/listeners/notice.h>
+
+#include <pxr/base/tf/weakBase.h>
+
 namespace MAYAUSD_NS_DEF {
+
+//------------------------------------------------------------------------------
+// OpUndoItemList automatic celar when scene in reset.
+//------------------------------------------------------------------------------
+
+namespace {
+
+struct OnSceneResetListener : public PXR_NS::TfWeakBase
+{
+    OnSceneResetListener()
+    {
+        PXR_NS::TfWeakPtr<OnSceneResetListener> self(this);
+        PXR_NS::TfNotice::Register(self, &OnSceneResetListener::OnSceneReset);
+    }
+
+    void OnSceneReset(const PXR_NS::UsdMayaSceneResetNotice& notice) { OpUndoItemList::instance().clear(); }
+};
+
+} // namespace
 
 //------------------------------------------------------------------------------
 // OpUndoItemList
@@ -92,7 +115,9 @@ void OpUndoItemList::clear()
 
 OpUndoItemList& OpUndoItemList::instance()
 {
-    static OpUndoItemList itemList;
+    static OpUndoItemList       itemList;
+    static OnSceneResetListener onSceneResetListener;
+
     return itemList;
 }
 

--- a/lib/mayaUsd/undo/OpUndoItemList.cpp
+++ b/lib/mayaUsd/undo/OpUndoItemList.cpp
@@ -35,7 +35,10 @@ struct OnSceneResetListener : public PXR_NS::TfWeakBase
         PXR_NS::TfNotice::Register(self, &OnSceneResetListener::OnSceneReset);
     }
 
-    void OnSceneReset(const PXR_NS::UsdMayaSceneResetNotice& notice) { OpUndoItemList::instance().clear(); }
+    void OnSceneReset(const PXR_NS::UsdMayaSceneResetNotice& notice)
+    {
+        OpUndoItemList::instance().clear();
+    }
 };
 
 } // namespace

--- a/test/lib/mayaUsd/fileio/testDiscardEdits.py
+++ b/test/lib/mayaUsd/fileio/testDiscardEdits.py
@@ -67,7 +67,10 @@ class MergeToUsdTestCase(unittest.TestCase):
         # Edit as Maya first.
         (ps, xlateOp, usdXlation, aUsdUfePathStr, aUsdUfePath, aUsdItem,
          _, _, _, _, _) = createSimpleXformScene()
-        self.assertTrue(mayaUsd.lib.PrimUpdaterManager.editAsMaya(aUsdUfePathStr))
+
+        with mayaUsd.lib.OpUndoItemList():
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.editAsMaya(aUsdUfePathStr))
+
         aMayaItem = ufe.GlobalSelection.get().front()
         mayaXlation = om.MVector(4, 5, 6)
         (aMayaPath, aMayaPathStr, aFn, mayaMatrix) = \
@@ -83,7 +86,8 @@ class MergeToUsdTestCase(unittest.TestCase):
         self.assertIn(aMayaItem, psHier.children())
 
         # Discard Maya edits.
-        self.assertTrue(mayaUsd.lib.PrimUpdaterManager.discardEdits(aMayaPathStr))
+        with mayaUsd.lib.OpUndoItemList():
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.discardEdits(aMayaPathStr))
 
         # Original USD translation values are preserved.
         usdMatrix = xlateOp.GetOpTransform(mayaUsd.ufe.getTime(aUsdUfePathStr))

--- a/test/lib/mayaUsd/fileio/testDuplicateAs.py
+++ b/test/lib/mayaUsd/fileio/testDuplicateAs.py
@@ -68,8 +68,9 @@ class DuplicateAsTestCase(unittest.TestCase):
             createSimpleXformScene()
 
         # Duplicate USD data as Maya data, placing it under the root.
-        self.assertTrue(mayaUsd.lib.PrimUpdaterManager.duplicate(
-            aUsdUfePathStr, '|world'))
+        with mayaUsd.lib.OpUndoItemList():
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.duplicate(
+                aUsdUfePathStr, '|world'))
 
         # Should now have two transform nodes in the Maya scene: the path
         # components in the second segment of the aUsdItem and bUsdItem will
@@ -142,8 +143,9 @@ class DuplicateAsTestCase(unittest.TestCase):
         # Duplicate Maya data as USD data.  As of 17-Nov-2021 no single-segment
         # path handler registered to UFE for Maya path strings, so use absolute
         # path.
-        self.assertTrue(mayaUsd.lib.PrimUpdaterManager.duplicate(
-            cmds.ls(group2, long=True)[0], psPathStr))
+        with mayaUsd.lib.OpUndoItemList():
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.duplicate(
+                cmds.ls(group2, long=True)[0], psPathStr))
 
         # Maya hierarchy should be duplicated in USD.
         usdGroup2PathStr = psPathStr + ',/' + group2

--- a/test/lib/mayaUsd/fileio/testEditAsMaya.py
+++ b/test/lib/mayaUsd/fileio/testEditAsMaya.py
@@ -69,8 +69,9 @@ class EditAsMayaTestCase(unittest.TestCase):
          _, _, _, _, _) = createSimpleXformScene()
 
         # Edit aPrim as Maya data.
-        self.assertTrue(mayaUsd.lib.PrimUpdaterManager.canEditAsMaya(aUsdUfePathStr))
-        self.assertTrue(mayaUsd.lib.PrimUpdaterManager.editAsMaya(aUsdUfePathStr))
+        with mayaUsd.lib.OpUndoItemList():
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.canEditAsMaya(aUsdUfePathStr))
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.editAsMaya(aUsdUfePathStr))
 
         # Test the path mapping services.
         #
@@ -190,15 +191,17 @@ class EditAsMayaTestCase(unittest.TestCase):
         scopePathStr = proxyShapePathStr + ',/Scope1'
 
         # Blend shape cannot be edited as Maya: it has no importer.
-        self.assertFalse(mayaUsd.lib.PrimUpdaterManager.canEditAsMaya(blendShapePathStr))
-        self.assertFalse(mayaUsd.lib.PrimUpdaterManager.editAsMaya(blendShapePathStr))
+        with mayaUsd.lib.OpUndoItemList():
+            self.assertFalse(mayaUsd.lib.PrimUpdaterManager.canEditAsMaya(blendShapePathStr))
+            self.assertFalse(mayaUsd.lib.PrimUpdaterManager.editAsMaya(blendShapePathStr))
 
         # Scope cannot be edited as Maya: it has no exporter.
         # Unfortunately, as of 17-Nov-2021, we cannot determine how a prim will
         # round-trip, so we cannot use the information that scope has no
         # exporter.
-        # self.assertFalse(mayaUsd.lib.PrimUpdaterManager.canEditAsMaya(scopePathStr))
-        # self.assertFalse(mayaUsd.lib.PrimUpdaterManager.editAsMaya(scopePathStr))
+        # with mayaUsd.lib.OpUndoItemList():
+        #     self.assertFalse(mayaUsd.lib.PrimUpdaterManager.canEditAsMaya(scopePathStr))
+        #     self.assertFalse(mayaUsd.lib.PrimUpdaterManager.editAsMaya(scopePathStr))
 
     @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '3006', 'Test only available in UFE preview version 0.3.6 and greater')
     def testSessionLayer(self):
@@ -215,8 +218,9 @@ class EditAsMayaTestCase(unittest.TestCase):
 
         self.assertTrue(stage.GetSessionLayer().empty)
 
-        self.assertTrue(mayaUsd.lib.PrimUpdaterManager.canEditAsMaya(primPathStr))
-        self.assertTrue(mayaUsd.lib.PrimUpdaterManager.editAsMaya(primPathStr))
+        with mayaUsd.lib.OpUndoItemList():
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.canEditAsMaya(primPathStr))
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.editAsMaya(primPathStr))
 
         self.assertFalse(stage.GetSessionLayer().empty)
 
@@ -224,7 +228,8 @@ class EditAsMayaTestCase(unittest.TestCase):
         self.assertEqual(prim.GetCustomDataByKey(kPullPrimMetadataKey), "|__mayaUsd__|AParent|A")
 
         # Discard Maya edits, but there is nothing to discard.
-        self.assertTrue(mayaUsd.lib.PrimUpdaterManager.discardEdits("A"))
+        with mayaUsd.lib.OpUndoItemList():
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.discardEdits("A"))
 
         self.assertTrue(stage.GetSessionLayer().empty)
 

--- a/test/lib/mayaUsd/fileio/testMergeToUsd.py
+++ b/test/lib/mayaUsd/fileio/testMergeToUsd.py
@@ -70,7 +70,9 @@ class MergeToUsdTestCase(unittest.TestCase):
         (ps, aXlateOp, _, aUsdUfePathStr, aUsdUfePath, aUsdItem,
          bXlateOp, _, bUsdUfePathStr, bUsdUfePath, bUsdItem) = \
             createSimpleXformScene()
-        self.assertTrue(mayaUsd.lib.PrimUpdaterManager.editAsMaya(aUsdUfePathStr))
+        with mayaUsd.lib.OpUndoItemList():
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.editAsMaya(aUsdUfePathStr))
+
         aMayaItem = ufe.GlobalSelection.get().front()
         (aMayaPath, aMayaPathStr, _, aMayaMatrix) = \
             setMayaTranslation(aMayaItem, om.MVector(4, 5, 6))
@@ -91,7 +93,8 @@ class MergeToUsdTestCase(unittest.TestCase):
         psHier = ufe.Hierarchy.hierarchy(ps)
 
         # Merge edits back to USD.
-        self.assertTrue(mayaUsd.lib.PrimUpdaterManager.mergeToUsd(aMayaPathStr))
+        with mayaUsd.lib.OpUndoItemList():
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.mergeToUsd(aMayaPathStr))
 
         # Check that edits have been preserved in USD.
         for (usdUfePathStr, mayaMatrix, xlateOp) in \
@@ -209,7 +212,9 @@ class MergeToUsdTestCase(unittest.TestCase):
          bXlateOp, _, bUsdUfePathStr, bUsdUfePath, bUsdItem) = \
             createSimpleXformScene()
 
-        self.assertTrue(mayaUsd.lib.PrimUpdaterManager.editAsMaya(bUsdUfePathStr))
+        with mayaUsd.lib.OpUndoItemList():
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.editAsMaya(bUsdUfePathStr))
+
         bMayaItem = ufe.GlobalSelection.get().front()
         (bMayaPath, bMayaPathStr, _, bMayaMatrix) = \
             setMayaTranslation(bMayaItem, om.MVector(10, 11, 12))
@@ -217,9 +222,10 @@ class MergeToUsdTestCase(unittest.TestCase):
         psHier = ufe.Hierarchy.hierarchy(ps)
 
         # Merge edits back to USD.
-        stage = mayaUsd.ufe.getStage(bUsdUfePathStr)
-        stage.SetEditTarget(stage.GetSessionLayer())
-        self.assertTrue(mayaUsd.lib.PrimUpdaterManager.mergeToUsd(bMayaPathStr))
+        with mayaUsd.lib.OpUndoItemList():
+            stage = mayaUsd.ufe.getStage(bUsdUfePathStr)
+            stage.SetEditTarget(stage.GetSessionLayer())
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.mergeToUsd(bMayaPathStr))
 
         # Check that edits have been preserved in USD.
         bUsdMatrix = bXlateOp.GetOpTransform(

--- a/test/lib/mayaUsd/fileio/testPrimUpdater.py
+++ b/test/lib/mayaUsd/fileio/testPrimUpdater.py
@@ -76,25 +76,29 @@ class testPrimUpdater(unittest.TestCase):
 
         # Edit as Maya first time.
         (ps, xlateOp, usdXlation, aUsdUfePathStr, aUsdUfePath, aUsdItem, _, _, _, _, _) = createSimpleXformScene()
-        self.assertTrue(mayaUsdLib.PrimUpdaterManager.editAsMaya(aUsdUfePathStr))
+        with mayaUsdLib.OpUndoItemList():
+            self.assertTrue(mayaUsdLib.PrimUpdaterManager.editAsMaya(aUsdUfePathStr))
 
         aMayaItem = ufe.GlobalSelection.get().front()
         (aMayaPath, aMayaPathStr, _, aMayaMatrix) = setMayaTranslation(aMayaItem, om.MVector(4, 5, 6))
 
         # Discard Maya edits.
-        self.assertTrue(mayaUsdLib.PrimUpdaterManager.discardEdits(aMayaPathStr))
+        with mayaUsdLib.OpUndoItemList():
+            self.assertTrue(mayaUsdLib.PrimUpdaterManager.discardEdits(aMayaPathStr))
 
         cmds.file(new=True, force=True)
 
         # Edit as Maya second time.
         (ps, xlateOp, usdXlation, aUsdUfePathStr, aUsdUfePath, aUsdItem, _, _, _, _, _) = createSimpleXformScene()
-        self.assertTrue(mayaUsdLib.PrimUpdaterManager.editAsMaya(aUsdUfePathStr))
+        with mayaUsdLib.OpUndoItemList():
+            self.assertTrue(mayaUsdLib.PrimUpdaterManager.editAsMaya(aUsdUfePathStr))
 
         aMayaItem = ufe.GlobalSelection.get().front()
         (aMayaPath, aMayaPathStr, _, aMayaMatrix) = setMayaTranslation(aMayaItem, om.MVector(4, 5, 6))
 
         # Merge edits back to USD.
-        self.assertTrue(mayaUsdLib.PrimUpdaterManager.mergeToUsd(aMayaPathStr))
+        with mayaUsdLib.OpUndoItemList():
+            self.assertTrue(mayaUsdLib.PrimUpdaterManager.mergeToUsd(aMayaPathStr))
 
         self.assertTrue(primUpdaterTest.editAsMayaCalled)
         self.assertTrue(primUpdaterTest.discardEditsCalled)


### PR DESCRIPTION
When using the direct python API to edit-as-Maya and merge-to-USD, the calls have to be wrapped in a OpUndoItemList block to capture the undo info, otherwise it will linger on. This is not a problem, except when Maya exit, the order of cleanup makes Maya assert that some deleted nodes are still present.

Fix the tests by using a block.

Also do a best effort to clean up the undo information that may have been left behind due to not using a OpUndoInfoList block in Python. On scene reset the undo info is cleared, although currently the assertions are hit before the scene-reset callback is triggered, so we still get assertions.