### PR TITLE
MAYA-114995 avoid merging equivalent transforms.

### DIFF
--- a/lib/usd/utils/CMakeLists.txt
+++ b/lib/usd/utils/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(${TARGET_NAME}
         gf
         usd
         sdf
+        usdGeom
 )
 
 # -----------------------------------------------------------------------------

--- a/lib/usd/utils/MergePrims.cpp
+++ b/lib/usd/utils/MergePrims.cpp
@@ -208,9 +208,7 @@ bool isLocalTransformModified(
 {
     double epsilon = 1e-9;
     bool   similar = PXR_NS::GfIsClose(
-        getLocalTransform(srcPrim, timeCode),
-        getLocalTransform(dstPrim, timeCode),
-        epsilon);
+        getLocalTransform(srcPrim, timeCode), getLocalTransform(dstPrim, timeCode), epsilon);
     return !similar;
 }
 

--- a/test/testUtils/mayaUtils.py
+++ b/test/testUtils/mayaUtils.py
@@ -20,6 +20,7 @@
     Helper functions regarding Maya that will be used throughout the test.
 """
 
+from math import radians
 from mayaUsd import lib as mayaUsdLib
 from mayaUsd import ufe as mayaUsdUfe
 
@@ -194,6 +195,18 @@ def setMayaTranslation(aMayaItem, t):
     aDagPath = om.MSelectionList().add(aMayaPathStr).getDagPath(0)
     aFn= om.MFnTransform(aDagPath)
     aFn.setTranslation(t, om.MSpace.kObject)
+    return (aMayaPath, aMayaPathStr, aFn, aFn.transformation().asMatrix())
+
+def setMayaRotation(aMayaItem, r):
+    '''Set the rotation (XYZ) on the argument Maya scene item.'''
+
+    aMayaPath = aMayaItem.path()
+    aMayaPathStr = ufe.PathString.string(aMayaPath)
+    aDagPath = om.MSelectionList().add(aMayaPathStr).getDagPath(0)
+    aFn = om.MFnTransform(aDagPath)
+    rads = [ radians(v) for v in r ]
+    rot = om.MEulerRotation(rads[0], rads[1], rads[2])
+    aFn.setRotation(rot, om.MSpace.kTransform)
     return (aMayaPath, aMayaPathStr, aFn, aFn.transformation().asMatrix())
 
 def createProxyAndStage():


### PR DESCRIPTION
Compare the full local transform when deciding to merge transform-related properties to avoid authoring transforms when they did not change but their representation changed.

Get the union of all time codes of all transform properties and compre the value at all time codes.

Add a unit test. Confirmed that the test fails when the new code is disabled.