### PR TITLE
Support mergeNamespacesOnClash attribute on MayaReference prim

### DIFF
--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
@@ -140,7 +140,8 @@ const MObject getMessageAttr()
 
 const TfToken UsdMayaTranslatorMayaReference::m_namespaceName = TfToken("mayaNamespace");
 const TfToken UsdMayaTranslatorMayaReference::m_referenceName = TfToken("mayaReference");
-const TfToken UsdMayaTranslatorMayaReference::m_mergeNamespacesOnClash = TfToken("mergeNamespacesOnClash");
+const TfToken UsdMayaTranslatorMayaReference::m_mergeNamespacesOnClash
+    = TfToken("mergeNamespacesOnClash");
 
 MStatus UsdMayaTranslatorMayaReference::LoadMayaReference(
     const UsdPrim& prim,
@@ -183,14 +184,16 @@ MStatus UsdMayaTranslatorMayaReference::LoadMayaReference(
     //
     MStringArray createdNodes;
     MString      mergeNamespacesOnClashArg = mergeNamespacesOnClash ? "true" : "false";
-    MString      referenceCommand = MString("file"
-                                       " -reference"
-                                       " -returnNewNodes"
-                                       " -deferReference true"
-                                       " -mergeNamespacesOnClash " + mergeNamespacesOnClashArg +
-                                       " -ignoreVersion"
-                                       " -options \"v=0;\""
-                                       " -namespace \"")
+    MString      referenceCommand = MString(
+                                   "file"
+                                   " -reference"
+                                   " -returnNewNodes"
+                                   " -deferReference true"
+                                   " -mergeNamespacesOnClash "
+                                   + mergeNamespacesOnClashArg
+                                   + " -ignoreVersion"
+                                     " -options \"v=0;\""
+                                     " -namespace \"")
         + rigNamespaceM + "\" \"" + mayaReferencePath + "\"";
 
     TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
@@ -418,12 +421,13 @@ MStatus UsdMayaTranslatorMayaReference::update(const UsdPrim& prim, MObject pare
     // bring in the reference or it may have been imported or removed directly in maya.
     if (refNode.isNull()) {
         bool mergeNamespacesOnClash = false;
-        if (UsdAttribute mergeNamespacesOnClashAttribute = prim.GetAttribute(m_mergeNamespacesOnClash))
-        {
+        if (UsdAttribute mergeNamespacesOnClashAttribute
+            = prim.GetAttribute(m_mergeNamespacesOnClash)) {
             mergeNamespacesOnClashAttribute.Get(&mergeNamespacesOnClash);
         }
 
-        return LoadMayaReference(prim, parent, mayaReferencePath, rigNamespaceM, mergeNamespacesOnClash);
+        return LoadMayaReference(
+            prim, parent, mayaReferencePath, rigNamespaceM, mergeNamespacesOnClash);
     }
 
     if (status) {

--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
@@ -140,12 +140,14 @@ const MObject getMessageAttr()
 
 const TfToken UsdMayaTranslatorMayaReference::m_namespaceName = TfToken("mayaNamespace");
 const TfToken UsdMayaTranslatorMayaReference::m_referenceName = TfToken("mayaReference");
+const TfToken UsdMayaTranslatorMayaReference::m_mergeNamespacesOnClash = TfToken("mergeNamespacesOnClash");
 
 MStatus UsdMayaTranslatorMayaReference::LoadMayaReference(
     const UsdPrim& prim,
     MObject&       parent,
     MString&       mayaReferencePath,
-    MString&       rigNamespaceM)
+    MString&       rigNamespaceM,
+    bool           mergeNamespacesOnClash)
 {
     TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
         .Msg("MayaReferenceLogic::LoadMayaReference prim=%s\n", prim.GetPath().GetText());
@@ -180,11 +182,12 @@ MStatus UsdMayaTranslatorMayaReference::LoadMayaReference(
     // -mergeNamespacesOnClash to true.)
     //
     MStringArray createdNodes;
+    MString      mergeNamespacesOnClashArg = mergeNamespacesOnClash ? "true" : "false";
     MString      referenceCommand = MString("file"
                                        " -reference"
                                        " -returnNewNodes"
                                        " -deferReference true"
-                                       " -mergeNamespacesOnClash false"
+                                       " -mergeNamespacesOnClash " + mergeNamespacesOnClashArg +
                                        " -ignoreVersion"
                                        " -options \"v=0;\""
                                        " -namespace \"")
@@ -414,7 +417,13 @@ MStatus UsdMayaTranslatorMayaReference::update(const UsdPrim& prim, MObject pare
     // If no reference found, we'll need to create it. This may be the first time we are
     // bring in the reference or it may have been imported or removed directly in maya.
     if (refNode.isNull()) {
-        return LoadMayaReference(prim, parent, mayaReferencePath, rigNamespaceM);
+        bool mergeNamespacesOnClash = false;
+        if (UsdAttribute mergeNamespacesOnClashAttribute = prim.GetAttribute(m_mergeNamespacesOnClash))
+        {
+            mergeNamespacesOnClashAttribute.Get(&mergeNamespacesOnClash);
+        }
+
+        return LoadMayaReference(prim, parent, mayaReferencePath, rigNamespaceM, mergeNamespacesOnClash);
     }
 
     if (status) {

--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.h
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.h
@@ -52,7 +52,8 @@ struct UsdMayaTranslatorMayaReference
         const UsdPrim& prim,
         MObject&       parent,
         MString&       mayaReferencePath,
-        MString&       rigNamespaceM);
+        MString&       rigNamespaceM,
+        bool           mergeNamespacesOnClash);
 
     MAYAUSD_CORE_PUBLIC
     static MStatus UnloadMayaReference(const MObject& parent);
@@ -65,6 +66,7 @@ private:
 
     static const TfToken m_namespaceName;
     static const TfToken m_referenceName;
+    static const TfToken m_mergeNamespacesOnClash;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/test/lib/usd/translators/UsdImportMayaReferenceTest/MayaReference.usda
+++ b/test/lib/usd/translators/UsdImportMayaReferenceTest/MayaReference.usda
@@ -10,9 +10,16 @@ def Xform "World" (
     kind = "group"
 )
 {
-    def ALMayaReference "Skeleton"
+    def ALMayaReference "Skeleto1"
     {
         string mayaNamespace = "rig"
         asset mayaReference = @UsdExportSkeletonWithoutBindPose.ma@
+    }
+
+    def ALMayaReference "Skeleton2"
+    {
+        string mayaNamespace = "unique_namespace_1"
+        asset mayaReference = @UsdExportSkeletonWithoutBindPose.ma@
+        bool mergeNamespacesOnClash = true
     }
 }

--- a/test/lib/usd/translators/UsdImportMayaReferenceTest/MayaReference.usda
+++ b/test/lib/usd/translators/UsdImportMayaReferenceTest/MayaReference.usda
@@ -10,7 +10,7 @@ def Xform "World" (
     kind = "group"
 )
 {
-    def ALMayaReference "Skeleto1"
+    def ALMayaReference "Skeleton1"
     {
         string mayaNamespace = "rig"
         asset mayaReference = @UsdExportSkeletonWithoutBindPose.ma@

--- a/test/lib/usd/translators/testUsdImportMayaReference.py
+++ b/test/lib/usd/translators/testUsdImportMayaReference.py
@@ -34,6 +34,8 @@ class testUsdImportMayaReference(unittest.TestCase):
     def setUpClass(cls):
         inputPath = fixturesUtils.readOnlySetUpClass(__file__)
 
+        cmds.namespace(add='unique_namespace_1')
+
         usdFile = os.path.join(inputPath, "UsdImportMayaReferenceTest", "MayaReference.usda")
         cmds.usdImport(file=usdFile, shadingMode=[['none', 'default'], ])
 
@@ -43,6 +45,10 @@ class testUsdImportMayaReference(unittest.TestCase):
 
     def testImport(self):
         mayaReference = 'rig:cubeRig'
+        self.assertTrue(cmds.objExists(mayaReference))
+
+    def testMergeNamespacesOnClash(self):
+        mayaReference = 'unique_namespace_1:cubeRig'
         self.assertTrue(cmds.objExists(mayaReference))
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Premise
As explained in issue #640, the MayaReference prim is incompatible with a multi-proxy workflow where the proxy and a MayaReference in the proxy's stage (eg, a rig) share the same namespace.

# Changes
Add support for a `mergeNamespacesOnClash` boolean attribute on a MayaReference prim that controls the same flag on the Maya `file` MEL command.

# Tests
 - Added a test case to `testUsdImportMayaReference`
 - Tested in Maya under a mayaUsdProxyShape node(1). 
 
 ----
 
(1) Note that AutoPull was disabled for the MayaReference schema on 13/12/2021 by PPT - this behavior must be re-enabled to test the behavior under a mayaUsdProxyShape node.