### PR TITLE
MAYA-115074 Ensure duplicate-as-USD creates unique prim names.

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -1103,8 +1103,17 @@ bool PrimUpdaterManager::duplicate(
         // Copy the temporary layer contents out to the proper destination.
         const auto& srcLayer = std::get<SdfLayerRefPtr>(pushExportOutput);
         const auto& editTarget = dstStage->GetEditTarget();
-        auto        dstRootPath = editTarget.MapToSpecPath(srcRootPath);
         const auto& dstLayer = editTarget.GetLayer();
+
+        // Make the destination root path unique.
+        SdfPath     dstRootPath = editTarget.MapToSpecPath(srcRootPath);
+        SdfPath     dstParentPath = dstRootPath.GetParentPath();
+        std::string dstChildName = dstRootPath.GetName();
+        UsdPrim     dstParentPrim = dstStage->GetPrimAtPath(dstParentPath);
+        if (dstParentPrim.IsValid()) {
+            dstChildName = ufe::uniqueChildName(dstParentPrim, dstChildName);
+            dstRootPath = dstParentPath.AppendChild(TfToken(dstChildName));
+        }
 
         if (!SdfCopySpec(srcLayer, srcRootPath, dstLayer, dstRootPath)) {
             return false;

--- a/plugin/adsk/scripts/USDMenuProc.mel
+++ b/plugin/adsk/scripts/USDMenuProc.mel
@@ -50,6 +50,6 @@ global proc USDMenuProc(string $parent, string $obj)
                 menuItem -label "Edit As Maya Data" -image "edit_as_Maya.png" -command ("mayaUsdEditAsMaya \"" + $obj + "\"");
             }
         }
-        menuItem -label "Duplicate As Maya Data" -command ("mayaUsdDuplicateAsMaya \"" + $obj + "\"");
+        menuItem -label "Duplicate As Maya Data" -command ("mayaUsdDuplicate \"" + $obj + "\"" + "\"|world\"");
     }
 }

--- a/test/lib/mayaUsd/fileio/testDuplicateAs.py
+++ b/test/lib/mayaUsd/fileio/testDuplicateAs.py
@@ -187,7 +187,7 @@ class DuplicateAsTestCase(unittest.TestCase):
             self.assertTrue(mayaUsd.lib.PrimUpdaterManager.duplicate(
                 cmds.ls(mayaA, long=True)[0], psPathStr))
 
-        # Maya hierarchy should be duplicated in USD, but with a numeric suffix sue to the collision.
+        # Maya hierarchy should be duplicated in USD, but with a numeric suffix due to the collision.
         usdNewAPathStr = psPathStr + ',/' + mayaA + '1'
         usdNewAPath = ufe.PathString.path(usdNewAPathStr)
 

--- a/test/lib/mayaUsd/fileio/testDuplicateAs.py
+++ b/test/lib/mayaUsd/fileio/testDuplicateAs.py
@@ -168,6 +168,34 @@ class DuplicateAsTestCase(unittest.TestCase):
         self.assertEqual([1, 2, 3], usdGroup1T3d.translation().vector)
         self.assertEqual([-4, -5, -6], usdGroup2T3d.translation().vector)
 
+    def testDuplicateAsUsdSameName(self):
+        '''Duplicate a Maya transform to USD when USD already has a prim with that name.'''
+
+        # Create a Maya transform named 'A'.
+        mayaA = cmds.createNode('transform', name='A')
+        cmds.setAttr(mayaA + '.translate', 1, 2, 3)
+
+        # Create a stage to receive the USD duplicate, with a prim of the same name.
+        psPathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        stage = mayaUsd.lib.GetPrim(psPathStr).GetStage()
+        aPrim = stage.DefinePrim('/A', 'Xform')
+        
+        # Duplicate Maya data as USD data.  As of 17-Nov-2021 no single-segment
+        # path handler registered to UFE for Maya path strings, so use absolute
+        # path.
+        with mayaUsd.lib.OpUndoItemList():
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.duplicate(
+                cmds.ls(mayaA, long=True)[0], psPathStr))
+
+        # Maya hierarchy should be duplicated in USD, but with a numeric suffix sue to the collision.
+        usdNewAPathStr = psPathStr + ',/' + mayaA + '1'
+        usdNewAPath = ufe.PathString.path(usdNewAPathStr)
+
+        # Translations have been preserved.
+        usdNewA = ufe.Hierarchy.createItem(usdNewAPath)
+        usdNewAT3d = ufe.Transform3d.transform3d(usdNewA)
+        self.assertEqual([1, 2, 3], usdNewAT3d.translation().vector)
+
     def testDuplicateAsUsdUndoRedo(self):
         '''Duplicate a Maya transform hierarchy to USD and then undo and redo the command.'''
 


### PR DESCRIPTION
- Add code to make target of the copy have a unique name.
- Add a unit test that failed without the fix and now works.