### PR TITLE
MAYA-121208 fix references metadata lost

### DIFF
--- a/lib/usd/utils/MergePrimsOptions.cpp
+++ b/lib/usd/utils/MergePrimsOptions.cpp
@@ -128,7 +128,9 @@ const VtDictionary& MergePrimsOptions::getDefaultDictionary()
                                                   UsdMayaMergeOptionsTokens->variantSetsHandling,
                                                   UsdMayaMergeOptionsTokens->expressionsHandling,
                                                   UsdMayaMergeOptionsTokens->mappersHandling,
-                                                  UsdMayaMergeOptionsTokens->mapperArgsHandling };
+                                                  UsdMayaMergeOptionsTokens->mapperArgsHandling,
+                                                  UsdMayaMergeOptionsTokens->propMetadataHandling,
+                                                  UsdMayaMergeOptionsTokens->primMetadataHandling };
 
         for (const auto& ht : handlingTokens) {
             d[ht] = VtValue(std::vector<VtValue>({ VtValue(UsdMayaMergeOptionsTokens->All) }));
@@ -150,31 +152,26 @@ MergePrimsOptions::MergePrimsOptions(const VtDictionary& options)
     ignoreUpperLayerOpinions
         = parseBoolean(optionsWithDef, UsdMayaMergeOptionsTokens->ignoreUpperLayerOpinions);
 
-    propertiesHandling
-        = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->propertiesHandling);
+    const struct
+    {
+        TfToken       handlingToken;
+        MergeMissing& handlingValue;
+    } missingHandlings[]
+        = { { UsdMayaMergeOptionsTokens->propertiesHandling, this->propertiesHandling },
+            { UsdMayaMergeOptionsTokens->primsHandling, this->primsHandling },
+            { UsdMayaMergeOptionsTokens->connectionsHandling, this->connectionsHandling },
+            { UsdMayaMergeOptionsTokens->relationshipsHandling, this->relationshipsHandling },
+            { UsdMayaMergeOptionsTokens->variantsHandling, this->variantsHandling },
+            { UsdMayaMergeOptionsTokens->variantSetsHandling, this->variantSetsHandling },
+            { UsdMayaMergeOptionsTokens->expressionsHandling, this->expressionsHandling },
+            { UsdMayaMergeOptionsTokens->mappersHandling, this->mappersHandling },
+            { UsdMayaMergeOptionsTokens->mapperArgsHandling, this->mapperArgsHandling },
+            { UsdMayaMergeOptionsTokens->propMetadataHandling, this->propMetadataHandling },
+            { UsdMayaMergeOptionsTokens->primMetadataHandling, this->primMetadataHandling } };
 
-    primsHandling = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->primsHandling);
-
-    connectionsHandling
-        = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->connectionsHandling);
-
-    relationshipsHandling
-        = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->relationshipsHandling);
-
-    variantsHandling
-        = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->variantsHandling);
-
-    variantSetsHandling
-        = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->variantSetsHandling);
-
-    expressionsHandling
-        = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->expressionsHandling);
-
-    mappersHandling
-        = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->mappersHandling);
-
-    mapperArgsHandling
-        = parseMissingHandling(optionsWithDef, UsdMayaMergeOptionsTokens->mapperArgsHandling);
+    for (const auto& handling : missingHandlings) {
+        handling.handlingValue = parseMissingHandling(optionsWithDef, handling.handlingToken);
+    }
 }
 
 MergePrimsOptions::MergePrimsOptions()

--- a/lib/usd/utils/MergePrimsOptions.h
+++ b/lib/usd/utils/MergePrimsOptions.h
@@ -133,6 +133,12 @@ struct MergePrimsOptions
     // How missing mapper argumentss are handled.
     MergeMissing mapperArgsHandling { MergeMissing::All };
 
+    // How missing prop metadata are handled.
+    MergeMissing propMetadataHandling { MergeMissing::All };
+
+    // How missing prim metadata are handled.
+    MergeMissing primMetadataHandling { MergeMissing::All };
+
     // Create a VtDictionary containing the default values for the merge options.
     MAYA_USD_UTILS_PUBLIC
     static const PXR_NS::VtDictionary& getDefaultDictionary();
@@ -175,6 +181,9 @@ struct MergePrimsOptions
     (expressionsHandling)               \
     (mappersHandling)                   \
     (mapperArgsHandling)                \
+                                        \
+    (propMetadataHandling)              \
+    (primMetadataHandling)              \
                                         \
     (Create)                            \
     (Preserve)                          \


### PR DESCRIPTION
- Correctly detect that metadata is not present at all in the source or destination of comparison.
- Add merge option for handling missing data for property metadata and prim metadata.
- They both default to preserve missing and create newly added.
- Added code for metadata we know we always want to preserve.
- Added a unit test. It fails without the fix, passes with the fix.
