### PR TITLE
MAYA-106930 Pre-evaluate all the compute inputs so that any lazy-evaluated shared

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
+++ b/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(${PROJECT_NAME}
         bboxGeom.cpp
         debugCodes.cpp
         draw_item.cpp
+		extComputation.cpp
         instancer.cpp
         material.cpp
         mayaPrimCommon.cpp

--- a/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
+++ b/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
@@ -7,7 +7,7 @@ target_sources(${PROJECT_NAME}
         bboxGeom.cpp
         debugCodes.cpp
         draw_item.cpp
-		extComputation.cpp
+        extComputation.cpp
         instancer.cpp
         material.cpp
         mayaPrimCommon.cpp

--- a/lib/mayaUsd/render/vp2RenderDelegate/extComputation.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/extComputation.cpp
@@ -1,0 +1,67 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Modifications copyright (C) 2019 Autodesk
+//
+#include "extComputation.h"
+
+#include <pxr/base/tf/staticTokens.h>
+#include <pxr/imaging/hd/sceneDelegate.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+HdVP2ExtComputation::HdVP2ExtComputation(SdfPath const& id) : HdExtComputation(id) { }
+
+HdVP2ExtComputation::~HdVP2ExtComputation() { }
+
+void HdVP2ExtComputation::Sync(
+    HdSceneDelegate* sceneDelegate,
+    HdRenderParam*   renderParam,
+    HdDirtyBits*     dirtyBits)
+{
+    HD_TRACE_FUNCTION();
+    HF_MALLOC_TAG_FUNCTION();
+
+    HdExtComputation::_Sync(sceneDelegate, renderParam, dirtyBits);
+
+    TF_DEBUG(pxr::HD_EXT_COMPUTATION_UPDATED)
+        .Msg(
+            "HdVP2ExtComputation::Sync for %s (dirty bits = 0x%x)\n",
+            GetId().GetText(),
+            *dirtyBits);
+
+    if (!(*dirtyBits & DirtySceneInput)) {
+        // No scene inputs to sync. All other computation dirty bits (barring
+        // DirtyCompInput) are sync'd in HdExtComputation::_Sync.
+        return;
+    }
+
+    // Force pre-compute of skinning transforms to work around USD concurrency issue,
+    // see https://github.com/PixarAnimationStudios/USD/issues/1742
+
+    // Only do the input evaluation once, the first time the compute is sync.
+    // Some of the inputs vary from frame to frame and preparing them here is
+    // serial (compute is an sprim) while preparing them from the related rprim
+    // sync is parallel.
+    if (_evaluatedInputs)
+        return;
+    for (pxr::TfToken const& inputName : GetSceneInputNames()) {
+        sceneDelegate->GetExtComputationInput(GetId(), inputName);
+    }
+
+    _evaluatedInputs = true;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/render/vp2RenderDelegate/extComputation.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/extComputation.cpp
@@ -22,7 +22,10 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-HdVP2ExtComputation::HdVP2ExtComputation(SdfPath const& id) : HdExtComputation(id) { }
+HdVP2ExtComputation::HdVP2ExtComputation(SdfPath const& id)
+    : HdExtComputation(id)
+{
+}
 
 HdVP2ExtComputation::~HdVP2ExtComputation() { }
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/extComputation.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/extComputation.h
@@ -1,0 +1,58 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Modifications copyright (C) 2019 Autodesk
+//
+
+#ifndef HD_VP2_EXTCOMPUTATION
+#define HD_VP2_EXTCOMPUTATION
+
+#include <pxr/base/tf/hashmap.h>
+#include <pxr/base/tf/token.h>
+#include <pxr/imaging/hd/extComputation.h>
+#include <pxr/imaging/hd/vtBufferSource.h>
+#include <pxr/pxr.h>
+
+#include <mutex>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/*! \brief  VP2 computation
+    \class  HdVP2ExtComputation
+*/
+
+class HdVP2ExtComputation : public HdExtComputation
+{
+public:
+    /// Construct a new ExtComputation identified by id.
+    HdVP2ExtComputation(SdfPath const& id);
+
+    ~HdVP2ExtComputation() override;
+
+    void Sync(HdSceneDelegate* sceneDelegate, HdRenderParam* renderParam, HdDirtyBits* dirtyBits)
+        override;
+
+private:
+    // No default construction or copying
+    HdVP2ExtComputation() = delete;
+    HdVP2ExtComputation(const HdVP2ExtComputation&) = delete;
+    HdVP2ExtComputation& operator=(const HdVP2ExtComputation&) = delete;
+
+    bool _evaluatedInputs { false };
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
@@ -17,6 +17,7 @@
 
 #include "basisCurves.h"
 #include "bboxGeom.h"
+#include "extComputation.h"
 #include "instancer.h"
 #include "material.h"
 #include "mesh.h"
@@ -28,7 +29,6 @@
 
 #include <pxr/imaging/hd/bprim.h>
 #include <pxr/imaging/hd/camera.h>
-#include <pxr/imaging/hd/extComputation.h>
 #include <pxr/imaging/hd/instancer.h>
 #include <pxr/imaging/hd/resourceRegistry.h>
 #include <pxr/imaging/hd/rprim.h>
@@ -709,7 +709,7 @@ HdSprim* HdVP2RenderDelegate::CreateSprim(const TfToken& typeId, const SdfPath& 
         return new HdCamera(sprimId);
     }
     if (typeId == HdPrimTypeTokens->extComputation) {
-        return new HdExtComputation(sprimId);
+        return new HdVP2ExtComputation(sprimId);
     }
     /*
     if (typeId == HdPrimTypeTokens->sphereLight) {


### PR DESCRIPTION
inputs are computed serially from sprim sync instead of in parallel in rprim sync.