### PR TITLE
MAYA-121242 fix flipped normals.

### DIFF
--- a/lib/mayaUsd/fileio/translators/translatorMesh.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMesh.cpp
@@ -104,18 +104,6 @@ TranslatorMeshRead::TranslatorMeshRead(
             prim.GetPath().GetText());
     }
 
-    // If the USD mesh was left-handed, then the faces had their vertices in left-handed order.
-    // Fix them to be in right-handed order, as expected by Maya.
-    if (isPrimitiveLeftHanded(mesh)) {
-        size_t firstIndex = 0;
-        for (int vertexCount : faceVertexCounts) {
-            std::reverse(
-                faceVertexIndices.begin() + firstIndex,
-                faceVertexIndices.begin() + firstIndex + vertexCount);
-            firstIndex += vertexCount;
-        }
-    }
-
     // Gather points and normals
     // If timeInterval is non-empty, pick the first available sample in the
     // timeInterval or default.
@@ -194,6 +182,12 @@ TranslatorMeshRead::TranslatorMeshRead(
         *status = stat;
         return;
     }
+
+    // Note: the USD leftHanded orientation makes both the vertices order of faces left-handed
+    //       and the face normals be left-handed. On the other hand, the Maya 'opposite' flag
+    //       only flips faces, not normals. So, this may need further work.
+    UsdMayaUtil::setPlugValue(
+        m_meshObj, "opposite", isPrimitiveLeftHanded(mesh));
 
     // set mesh name
     const auto& primName = prim.GetName().GetString();

--- a/lib/mayaUsd/fileio/translators/translatorMesh.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMesh.cpp
@@ -186,8 +186,7 @@ TranslatorMeshRead::TranslatorMeshRead(
     // Note: the USD leftHanded orientation makes both the vertices order of faces left-handed
     //       and the face normals be left-handed. On the other hand, the Maya 'opposite' flag
     //       only flips faces, not normals. So, this may need further work.
-    UsdMayaUtil::setPlugValue(
-        m_meshObj, "opposite", isPrimitiveLeftHanded(mesh));
+    UsdMayaUtil::setPlugValue(m_meshObj, "opposite", isPrimitiveLeftHanded(mesh));
 
     // set mesh name
     const auto& primName = prim.GetName().GetString();

--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
@@ -35,7 +35,6 @@
 #include <pxr/usd/usdGeom/pointBased.h>
 #include <pxr/usd/usdGeom/primvar.h>
 #include <pxr/usd/usdGeom/subset.h>
-#include <pxr/usd/usdGeom/mesh.h>
 #include <pxr/usd/usdGeom/tokens.h>
 #include <pxr/usd/usdUtils/pipeline.h>
 
@@ -834,7 +833,8 @@ void UsdMayaMeshWriteUtils::writeFaceVertexIndicesData(
 
     bool isLeftHanded = false;
     UsdMayaUtil::getPlugValue(meshFn, "opposite", &isLeftHanded);
-    primSchema.CreateOrientationAttr(VtValue(isLeftHanded ? UsdGeomTokens->leftHanded : UsdGeomTokens->rightHanded));
+    primSchema.CreateOrientationAttr(
+        VtValue(isLeftHanded ? UsdGeomTokens->leftHanded : UsdGeomTokens->rightHanded));
 }
 
 void UsdMayaMeshWriteUtils::writeInvisibleFacesData(

--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
@@ -35,6 +35,7 @@
 #include <pxr/usd/usdGeom/pointBased.h>
 #include <pxr/usd/usdGeom/primvar.h>
 #include <pxr/usd/usdGeom/subset.h>
+#include <pxr/usd/usdGeom/mesh.h>
 #include <pxr/usd/usdGeom/tokens.h>
 #include <pxr/usd/usdUtils/pipeline.h>
 
@@ -830,6 +831,10 @@ void UsdMayaMeshWriteUtils::writeFaceVertexIndicesData(
         primSchema.GetFaceVertexCountsAttr(), &faceVertexCounts, usdTime, valueWriter);
     UsdMayaWriteUtil::SetAttribute(
         primSchema.GetFaceVertexIndicesAttr(), &faceVertexIndices, usdTime, valueWriter);
+
+    bool isLeftHanded = false;
+    UsdMayaUtil::getPlugValue(meshFn, "opposite", &isLeftHanded);
+    primSchema.CreateOrientationAttr(VtValue(isLeftHanded ? UsdGeomTokens->leftHanded : UsdGeomTokens->rightHanded));
 }
 
 void UsdMayaMeshWriteUtils::writeInvisibleFacesData(

--- a/lib/usd/utils/MergePrims.cpp
+++ b/lib/usd/utils/MergePrims.cpp
@@ -267,7 +267,7 @@ bool isMetadataAlwaysPreserved(const TfToken& metadata)
 
 bool isMetadataNeverPreserved(const TfToken& metadata)
 {
-    static const std::set<TfToken> never = { };
+    static const std::set<TfToken> never = {};
 
     return never.count(metadata) > 0;
 }

--- a/lib/usd/utils/MergePrimsOptions.cpp
+++ b/lib/usd/utils/MergePrimsOptions.cpp
@@ -69,6 +69,8 @@ MergeVerbosity parseVerbosity(
             verbosity = verbosity | MergeVerbosity::Failure;
         if (UsdMayaMergeOptionsTokens->Default == token)
             verbosity = verbosity | MergeVerbosity::Default;
+        if (UsdMayaMergeOptionsTokens->All == token)
+            verbosity = verbosity | MergeVerbosity::All;
     }
 
     return verbosity;

--- a/lib/usd/utils/MergePrimsOptions.h
+++ b/lib/usd/utils/MergePrimsOptions.h
@@ -34,6 +34,7 @@ enum class MergeVerbosity
     Child = 1 << 2,
     Children = 1 << 3,
     Failure = 1 << 4,
+    All = Same | Differ | Child | Children | Failure,
     Default = Differ | Child | Children | Failure,
 };
 


### PR DESCRIPTION
Maya did not write the USD "orientation" attribute. In addition, Maya flipped the vertices order when editing a USD mesh with "leftHanded" orientation. On merge-to-USD, Maya would write right-handed vertices but not write the "orientation" property.

The result would be righ-handed verticeswith left-handed orientation attribute.

This PR makes multiple fixes: instead of flipped vertices order, we now set the "opposite" flag on import. This is what the nurbs were already doing. More testing will be required to see what effects, if any, this may have on normals.

The second fix is to explicitly write the "orientation" attribute on export.

A few improvements in the verbosity options and simplification of some code were also made while investigating the problem and are included.