### PR TITLE
MAYA-121242 fix flipped normals.

### DIFF
--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
@@ -830,6 +830,11 @@ void UsdMayaMeshWriteUtils::writeFaceVertexIndicesData(
         primSchema.GetFaceVertexCountsAttr(), &faceVertexCounts, usdTime, valueWriter);
     UsdMayaWriteUtil::SetAttribute(
         primSchema.GetFaceVertexIndicesAttr(), &faceVertexIndices, usdTime, valueWriter);
+
+    bool isLeftHanded = false;
+    UsdMayaUtil::getPlugValue(meshFn, "opposite", &isLeftHanded);
+    primSchema.CreateOrientationAttr(
+        VtValue(isLeftHanded ? UsdGeomTokens->leftHanded : UsdGeomTokens->rightHanded));
 }
 
 void UsdMayaMeshWriteUtils::writeInvisibleFacesData(

--- a/lib/usd/utils/MergePrims.cpp
+++ b/lib/usd/utils/MergePrims.cpp
@@ -250,7 +250,7 @@ bool isLocalTransformModified(const UsdPrim& srcPrim, const UsdPrim& dstPrim)
 //
 // There are some metadata that we know the merge-to-USD temporary export-to-USD
 // will never produce. Others are generated only when needed, so their absence
-// should always means to remove them.
+// should always mean to remove them.
 //
 // isMetadataAlwaysPreserved() is for those metadata we know we never produce.
 //

--- a/lib/usd/utils/MergePrims.cpp
+++ b/lib/usd/utils/MergePrims.cpp
@@ -249,19 +249,35 @@ bool isLocalTransformModified(const UsdPrim& srcPrim, const UsdPrim& dstPrim)
 // Special metadata handling.
 //
 // There are some metadata that we know the merge-to-USD temporary export-to-USD
-// will never produce. List them here to be always preserved.
+// will never produce. Others are generated only when needed, so their absence
+// should always means to remove them.
+//
+// isMetadataAlwaysPreserved() is for those metadata we know we never produce.
+//
+// isMetadataNeverPreserved() is for those metadata we know we sometimes omit
+// to signify we want to remove them.
 //----------------------------------------------------------------------------------------------------------------------
-
-const std::set<TfToken>& getAlwaysPreservedMetadatas()
-{
-    static const std::set<TfToken> preserved = { TfToken("references") };
-
-    return preserved;
-}
 
 bool isMetadataAlwaysPreserved(const TfToken& metadata)
 {
-    return getAlwaysPreservedMetadatas().count(metadata) > 0;
+    static const std::set<TfToken> preserved = { TfToken("references") };
+
+    return preserved.count(metadata) > 0;
+}
+
+bool isMetadataNeverPreserved(const TfToken& metadata)
+{
+    static const std::set<TfToken> never = {};
+
+    return never.count(metadata) > 0;
+}
+
+bool isMetadataPreserved(const TfToken& metadata, MergeMissing missingHandling)
+{
+    if (contains(missingHandling, MergeMissing::Preserve))
+        return !isMetadataNeverPreserved(metadata);
+    else
+        return isMetadataAlwaysPreserved(metadata);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -290,8 +306,7 @@ bool isMetadataAtPathModified(
     // If the metadata is missing in the source and we preserve missing,
     // return that the metadata is *not* modified so as to preserve it.
     if (!src.fieldExists) {
-        const bool preserved = contains(missingHandling, MergeMissing::Preserve)
-            || isMetadataAlwaysPreserved(src.field);
+        const bool preserved = isMetadataPreserved(src.field, missingHandling);
         const bool changed = !preserved;
         printChangedField(ctx, src, metadataType, changed);
         return changed;
@@ -578,11 +593,6 @@ void unionChildren(
     VtValue&     srcChildrenValue,
     VtValue&     dstChildrenValue)
 {
-    // If not preserving missing attributes then we don't need to calculate
-    // the union of the source and destintation children.
-    if (missingHandling == MergeMissing::None)
-        return;
-
     typedef typename ChildPolicy::FieldType FieldType;
     typedef std::vector<FieldType>          ChildrenVector;
     typedef std::set<FieldType>             ChildrenSet;

--- a/lib/usd/utils/MergePrimsOptions.cpp
+++ b/lib/usd/utils/MergePrimsOptions.cpp
@@ -69,6 +69,8 @@ MergeVerbosity parseVerbosity(
             verbosity = verbosity | MergeVerbosity::Failure;
         if (UsdMayaMergeOptionsTokens->Default == token)
             verbosity = verbosity | MergeVerbosity::Default;
+        if (UsdMayaMergeOptionsTokens->All == token)
+            verbosity = verbosity | MergeVerbosity::All;
     }
 
     return verbosity;

--- a/lib/usd/utils/MergePrimsOptions.h
+++ b/lib/usd/utils/MergePrimsOptions.h
@@ -34,6 +34,7 @@ enum class MergeVerbosity
     Child = 1 << 2,
     Children = 1 << 3,
     Failure = 1 << 4,
+    All = Same | Differ | Child | Children | Failure,
     Default = Differ | Child | Children | Failure,
 };
 


### PR DESCRIPTION
Maya did not write the USD "orientation" attribute. In addition, Maya flipped the vertices order when editing a USD mesh with "leftHanded" orientation. On merge-to-USD, Maya would write right-handed vertices but not write the "orientation" property.

The result would be righ-handed verticeswith left-handed orientation attribute.

See: MAYA-105623 for the original reason we flip vertices orders. It has to do with the way "leftHanded" affect vertices order and normals in USD.

The fix is to explicitly write the "orientation" attribute on export.

A few improvements in the verbosity options and simplification of some code were also made whilte investigating the problem and are included.