### PR TITLE
MAYA-121245 fix failed edit-as-maya commands

### DIFF
--- a/lib/mayaUsd/commands/PullPushCommands.cpp
+++ b/lib/mayaUsd/commands/PullPushCommands.cpp
@@ -174,13 +174,19 @@ MStatus EditAsMayaCommand::doIt(const MArgList& argList)
     if (!isPrimPath(fPath))
         return reportError(MS::kInvalidParameter);
 
-    OpUndoItemRecorder undoRecorder(fUndoItemList);
+    // Scope the undo item recording so we can undo on failure.
+    {
+        OpUndoItemRecorder undoRecorder(fUndoItemList);
 
-    auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
-    if (!manager.editAsMaya(fPath))
-        return MS::kFailure;
+        auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
+        status = manager.editAsMaya(fPath) ? MS::kSuccess : MS::kFailure;
+    }
 
-    return MS::kSuccess;
+    // Undo potentially partially-made edit-as-Maya on failure.
+    if (status != MS::kSuccess)
+        fUndoItemList.undo();
+
+    return status;
 }
 
 //------------------------------------------------------------------------------
@@ -230,13 +236,19 @@ MStatus MergeToUsdCommand::doIt(const MArgList& argList)
     if (!PXR_NS::PrimUpdaterManager::readPullInformation(dagPath, fPulledPath))
         return reportError(MS::kInvalidParameter);
 
-    OpUndoItemRecorder undoRecorder(fUndoItemList);
+    // Scope the undo item recording so we can undo on failure.
+    {
+        OpUndoItemRecorder undoRecorder(fUndoItemList);
 
-    auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
-    if (!manager.mergeToUsd(fDagNode, fPulledPath))
-        return MS::kFailure;
+        auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
+        status = manager.mergeToUsd(fDagNode, fPulledPath) ? MS::kSuccess : MS::kFailure;
+    }
 
-    return MS::kSuccess;
+    // Undo potentially partially-made merge-to-USD on failure.
+    if (status != MS::kSuccess)
+        fUndoItemList.undo();
+
+    return status;
 }
 
 //------------------------------------------------------------------------------
@@ -280,13 +292,19 @@ MStatus DiscardEditsCommand::doIt(const MArgList& argList)
     if (!PXR_NS::PrimUpdaterManager::readPullInformation(dagPath, fPath))
         return reportError(MS::kInvalidParameter);
 
-    OpUndoItemRecorder undoRecorder(fUndoItemList);
+    // Scope the undo item recording so we can undo on failure.
+    {
+        OpUndoItemRecorder undoRecorder(fUndoItemList);
 
-    auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
-    if (!manager.discardEdits(fPath))
-        return MS::kFailure;
+        auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
+        status = manager.discardEdits(fPath) ? MS::kSuccess : MS::kFailure;
+    }
 
-    return MS::kSuccess;
+    // Undo potentially partially-made discard-edit on failure.
+    if (status != MS::kSuccess)
+        fUndoItemList.undo();
+
+    return status;
 }
 
 //------------------------------------------------------------------------------
@@ -329,13 +347,19 @@ MStatus DuplicateCommand::doIt(const MArgList& argList)
     if (status != MS::kSuccess)
         return reportError(status);
 
-    OpUndoItemRecorder undoRecorder(fUndoItemList);
+    // Scope the undo item recording so we can undo on failure.
+    {
+        OpUndoItemRecorder undoRecorder(fUndoItemList);
 
-    auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
-    if (!manager.duplicate(fSrcPath, fDstPath))
-        return MS::kFailure;
+        auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
+        status = manager.duplicate(fSrcPath, fDstPath) ? MS::kSuccess : MS::kFailure;
+    }
 
-    return MS::kSuccess;
+    // Undo potentially partially-made duplicate on failure.
+    if (status != MS::kSuccess)
+        fUndoItemList.undo();
+
+    return status;
 }
 
 } // namespace ufe

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -298,7 +298,7 @@ PullImportPaths pullImport(
 
     std::string mFileName = context.GetUsdStage()->GetRootLayer()->GetIdentifier();
     if (mFileName.empty()) {
-        TF_RUNTIME_ERROR("Empty file specified. Exiting.");
+        TF_WARN("Empty file specified. Exiting.");
         return PullImportPaths(addedDagPaths, pulledUfePaths);
     }
 
@@ -329,7 +329,7 @@ PullImportPaths pullImport(
     // Execute the command, which can succeed but import nothing.
     bool success = readJob->Read(&addedDagPaths);
     if (!success || addedDagPaths.size() == 0) {
-        TF_RUNTIME_ERROR("Nothing to edit in the selection.");
+        TF_WARN("Nothing to edit in the selection.");
         return PullImportPaths({}, {});
     }
 
@@ -912,7 +912,7 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
     MDagPath pullParentPath;
     if (!updaterArgs._copyOperation
         && !(pullParentPath = setupPullParent(path, ctxArgs)).isValid()) {
-        TF_RUNTIME_ERROR("Cannot setup the edit parent node.");
+        TF_WARN("Cannot setup the edit parent node.");
         return false;
     }
 
@@ -936,7 +936,7 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
 
     // 2) Iterate over all imported Dag paths.
     if (!pullCustomize(importedPaths, context)) {
-        TF_RUNTIME_ERROR("Failed to customize the edited nodes.");
+        TF_WARN("Failed to customize the edited nodes.");
         return false;
     }
 

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -298,7 +298,7 @@ PullImportPaths pullImport(
 
     std::string mFileName = context.GetUsdStage()->GetRootLayer()->GetIdentifier();
     if (mFileName.empty()) {
-        TF_WARN("Empty file specified. Exiting.");
+        TF_WARN("Nothing to edit: invalid layer.");
         return PullImportPaths(addedDagPaths, pulledUfePaths);
     }
 

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -329,6 +329,7 @@ PullImportPaths pullImport(
     // Execute the command, which can succeed but import nothing.
     bool success = readJob->Read(&addedDagPaths);
     if (!success || addedDagPaths.size() == 0) {
+        TF_RUNTIME_ERROR("Nothing to edit in the selection.");
         return PullImportPaths({}, {});
     }
 
@@ -911,6 +912,7 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
     MDagPath pullParentPath;
     if (!updaterArgs._copyOperation
         && !(pullParentPath = setupPullParent(path, ctxArgs)).isValid()) {
+        TF_RUNTIME_ERROR("Cannot setup the edit parent node.");
         return false;
     }
 
@@ -934,6 +936,7 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
 
     // 2) Iterate over all imported Dag paths.
     if (!pullCustomize(importedPaths, context)) {
+        TF_RUNTIME_ERROR("Failed to customize the edited nodes.");
         return false;
     }
 


### PR DESCRIPTION
Properly undo semi-successful edit-as-Maya command and other related commands. Also provide helpful error messages when a command fails mid-way.