### PR TITLE
MAYA-121225 reating the events from the commit task is too slow. The events do

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1367,15 +1367,12 @@ void HdVP2BasisCurves::_UpdateDrawItem(
                                                        colorBuffer,
                                                        primvarBuffers,
                                                        indexBuffer]() {
+
+        // This code executes serially, once per basisCurve updated. Keep
+        // performance in mind while modifying this code.
         MHWRender::MRenderItem* renderItem = drawItem->GetRenderItem();
         if (ARCH_UNLIKELY(!renderItem))
             return;
-
-        MProfilingScope profilingScope(
-            HdVP2RenderDelegate::sProfilerCategory,
-            MProfiler::kColorC_L2,
-            drawItem->GetDrawItemName().asChar(),
-            "Commit");
 
         // If available, something changed
         for (const auto& entry : stateToCommit._primvarBufferDataMap) {

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1367,7 +1367,6 @@ void HdVP2BasisCurves::_UpdateDrawItem(
                                                        colorBuffer,
                                                        primvarBuffers,
                                                        indexBuffer]() {
-
         // This code executes serially, once per basisCurve updated. Keep
         // performance in mind while modifying this code.
         MHWRender::MRenderItem* renderItem = drawItem->GetRenderItem();

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1996,13 +1996,6 @@ void HdVP2Mesh::_UpdateDrawItem(
 
     bool instancerWithNoInstances = false;
     if (!GetInstancerId().IsEmpty()) {
-
-        MProfilingScope profilingScope(
-            HdVP2RenderDelegate::sProfilerCategory,
-            MProfiler::kColorC_L2,
-            _rprimId.asChar(),
-            "HdVP2Mesh Update instances");
-
         // Retrieve instance transforms from the instancer.
         HdInstancer*    instancer = renderIndex.GetInstancer(GetInstancerId());
         VtMatrix4dArray transforms
@@ -2299,18 +2292,14 @@ void HdVP2Mesh::_UpdateDrawItem(
                                                            indexBuffer,
                                                            isBBoxItem,
                                                            &sharedBBoxGeom]() {
+            // This code executes serially, once per mesh updated. Keep
+            // performance in mind while modifying this code.
             const HdVP2DrawItem::RenderItemData& drawItemData = stateToCommit._renderItemData;
             MHWRender::MRenderItem*              renderItem = drawItemData._renderItem;
             if (ARCH_UNLIKELY(!renderItem))
                 return;
 
             MStatus result;
-
-            MProfilingScope profilingScope(
-                HdVP2RenderDelegate::sProfilerCategory,
-                MProfiler::kColorC_L2,
-                renderItem->name().asChar(),
-                "Commit");
 
             // If available, something changed
             if (stateToCommit._indexBufferData)


### PR DESCRIPTION
some string operations, and waiting for them all to finish is adding significant overhead.

This helps with issue #1991 but it does not fix the whole problem.