### PR TITLE
MAYA-121247 edit-as-maya whole selected object - not sub-part

### DIFF
--- a/plugin/adsk/scripts/CMakeLists.txt
+++ b/plugin/adsk/scripts/CMakeLists.txt
@@ -16,6 +16,7 @@ list(APPEND scripts_src
     mayaUsd_pluginUIDeletion.mel
     mayaUsd_pluginBatchLoad.mel
     mayaUsd_pluginBatchUnload.mel
+    mayaUsd_selectionUtils.py
     usdFileSaveOptions.mel
     USDMenuProc.mel
 )

--- a/plugin/adsk/scripts/USDMenuProc.mel
+++ b/plugin/adsk/scripts/USDMenuProc.mel
@@ -15,22 +15,13 @@
 
 proc string expandToSelection(string $obj)
 {
-    // By default, for example if the obj is empty, we want to use the selection.
-    int $expandToSel = 1;
-
-    // If obj is non-empty, expand it to the selection if it is part of the selection.
     if (size($obj)) {
-        string $script = "import maya.internal.ufeSupport.utils as ufeUtils; selection = ufeUtils.getNonMayaSelectedItems(); inSel = ['" + $obj + "'.startswith(sel) for sel in selection]; selection and sum(inSel)";
-        $expandToSel = `python($script)`;
+        // If obj is non-empty, expand it to the selection if it is part of the selection.
+        return `python("import mayaUsd_selectionUtils; mayaUsd_selectionUtils.expandPathToSelection('" + $obj + "')")`;
+    } else {
+        // If obj is empty, use the first selected item non-Maya.
+        return `python("import maya.internal.ufeSupport.utils as ufeUtils; items = ufeUtils.getNonMayaSelectedItems(); items[0] if items else None")`;
     }
-
-    // If we expand to selection, use the UFE selection.
-    if ($expandToSel) {
-        string $nonMayaObjs[] = `python("import maya.internal.ufeSupport.utils as ufeUtils; ufeUtils.getNonMayaSelectedItems()")`;
-        $obj = $nonMayaObjs[0];
-    }
-
-    return $obj;
 }
 
 proc int canEditAsMaya(string $obj)
@@ -70,6 +61,7 @@ global proc USDMenuProc(string $parent, string $obj)
         return;
         
     $obj = expandToSelection($obj);
+    print($obj);
     if (size($obj) != 0)
     {
         popupMenu -e -dai $parent;

--- a/plugin/adsk/scripts/USDMenuProc.mel
+++ b/plugin/adsk/scripts/USDMenuProc.mel
@@ -13,19 +13,6 @@
 // limitations under the License.
 //
 
-proc int canEditAsMaya()
-{
-    if (!hasPrimUpdater())
-        return 0;
-
-    string $nonMayaObjs[] = `python("import maya.internal.ufeSupport.utils as ufeUtils; ufeUtils.getNonMayaSelectedItems()")`;
-    string $obj = $nonMayaObjs[0];
-    if (size($obj) != 0) {
-        return `python("from mayaUsd.lib import PrimUpdaterManager; PrimUpdaterManager.canEditAsMaya('" + $obj + "')")`;
-    }
-    return 0;
-}
-
 proc string expandToSelection(string $obj)
 {
     // By default, for example if the obj is empty, we want to use the selection.
@@ -33,7 +20,7 @@ proc string expandToSelection(string $obj)
 
     // If obj is non-empty, expand it to the selection if it is part of the selection.
     if (size($obj)) {
-        string $script = "import maya.internal.ufeSupport.utils as ufeUtils; selection = ufeUtils.getNonMayaSelectedItems(); inSel = ['" + $obj + "'.startswith(sel) for sel in selection]; not selection or sum(inSel)";
+        string $script = "import maya.internal.ufeSupport.utils as ufeUtils; selection = ufeUtils.getNonMayaSelectedItems(); inSel = ['" + $obj + "'.startswith(sel) for sel in selection]; selection and sum(inSel)";
         $expandToSel = `python($script)`;
     }
 
@@ -46,12 +33,22 @@ proc string expandToSelection(string $obj)
     return $obj;
 }
 
+proc int canEditAsMaya(string $obj)
+{
+    if (!hasPrimUpdater())
+        return 0;
+
+    if (size($obj) != 0) {
+        return `python("from mayaUsd.lib import PrimUpdaterManager; PrimUpdaterManager.canEditAsMaya('" + $obj + "')")`;
+    }
+    return 0;
+}
+
 global proc mayaUsdMenu_editAsMaya(string $obj)
 {
     if (!hasPrimUpdater())
         return;
 
-    $obj = expandToSelection($obj);
     if (size($obj) != 0) {
         mayaUsdEditAsMaya $obj;
     }
@@ -62,7 +59,6 @@ global proc mayaUsdMenu_duplicate(string $ufePath)
     if (!hasPrimUpdater())
         return;
         
-    $ufePath = expandToSelection($ufePath);
     if (size($ufePath)) {
         mayaUsdDuplicate $ufePath "|world";
     }
@@ -73,14 +69,14 @@ global proc USDMenuProc(string $parent, string $obj)
     if (!hasPrimUpdater())
         return;
         
-    int $haveNonMaya = `python("import maya.internal.ufeSupport.utils as ufeUtils; ufeUtils.hasNonMayaSelectedItems()")`;
-    if ($haveNonMaya)
+    $obj = expandToSelection($obj);
+    if (size($obj) != 0)
     {
         popupMenu -e -dai $parent;
         setParent -menu $parent;
 
         setParent -menu ..;
-        if (canEditAsMaya()) {
+        if (canEditAsMaya($obj)) {
             // Temporary - hide this context menu items behind an
             //             env var until it is completed.
             string $s = `getenv "MAYAUSD_ENABLE_EDIT_AS_MAYA_DATA"`;

--- a/plugin/adsk/scripts/USDMenuProc.mel
+++ b/plugin/adsk/scripts/USDMenuProc.mel
@@ -26,25 +26,43 @@ proc int canEditAsMaya()
     return 0;
 }
 
-global proc mayaUsdMenu_editAsMaya()
+proc string expandToSelection(string $obj)
+{
+    // By default, for example if the obj is empty, we want to use the selection.
+    int $expandToSel = 1;
+
+    // If obj is non-empty, expand it to the selection if it is part of the selection.
+    if (size($obj)) {
+        string $script = "import maya.internal.ufeSupport.utils as ufeUtils; selection = ufeUtils.getNonMayaSelectedItems(); inSel = ['" + $obj + "'.startswith(sel) for sel in selection]; not selection or sum(inSel)";
+        $expandToSel = `python($script)`;
+    }
+
+    // If we expand to selection, use the UFE selection.
+    if ($expandToSel) {
+        string $nonMayaObjs[] = `python("import maya.internal.ufeSupport.utils as ufeUtils; ufeUtils.getNonMayaSelectedItems()")`;
+        $obj = $nonMayaObjs[0];
+    }
+
+    return $obj;
+}
+
+global proc mayaUsdMenu_editAsMaya(string $obj)
 {
     if (!hasPrimUpdater())
         return;
 
-    string $nonMayaObjs[] = `python("import maya.internal.ufeSupport.utils as ufeUtils; ufeUtils.getNonMayaSelectedItems()")`;
-    string $obj = $nonMayaObjs[0];
+    $obj = expandToSelection($obj);
     if (size($obj) != 0) {
         mayaUsdEditAsMaya $obj;
     }
 }
 
-global proc mayaUsdMenu_duplicate()
+global proc mayaUsdMenu_duplicate(string $ufePath)
 {
     if (!hasPrimUpdater())
         return;
         
-    string $nonMayaObjs[] = `python("import maya.internal.ufeSupport.utils as ufeUtils; ufeUtils.getNonMayaSelectedItems()")`;
-    string $ufePath = $nonMayaObjs[0];
+    $ufePath = expandToSelection($ufePath);
     if (size($ufePath)) {
         mayaUsdDuplicate $ufePath "|world";
     }
@@ -69,9 +87,9 @@ global proc USDMenuProc(string $parent, string $obj)
             string $ls = tolower($s);
             if (`match $ls "true|yes|on|1"` !="")
             {
-                menuItem -label "Edit As Maya Data" -image "edit_as_Maya.png" -command ("mayaUsdMenu_editAsMaya");
+                menuItem -label "Edit As Maya Data" -image "edit_as_Maya.png" -command ("mayaUsdMenu_editAsMaya \"" + $obj + "\"");
             }
         }
-        menuItem -label "Duplicate As Maya Data" -command ("mayaUsdMenu_duplicate");
+        menuItem -label "Duplicate As Maya Data" -command ("mayaUsdMenu_duplicate \"" + $obj + "\"");
     }
 }

--- a/plugin/adsk/scripts/USDMenuProc.mel
+++ b/plugin/adsk/scripts/USDMenuProc.mel
@@ -13,19 +13,41 @@
 // limitations under the License.
 //
 
-proc int canEditAsMaya(string $obj)
+proc int canEditAsMaya()
 {
     if (!hasPrimUpdater())
         return 0;
 
-    if (size($obj) == 0) {
-        string $nonMayaObjs[] = `python("import maya.internal.ufeSupport.utils as ufeUtils; ufeUtils.getNonMayaSelectedItems()")`;
-        $obj = $nonMayaObjs[0];
-    }
+    string $nonMayaObjs[] = `python("import maya.internal.ufeSupport.utils as ufeUtils; ufeUtils.getNonMayaSelectedItems()")`;
+    string $obj = $nonMayaObjs[0];
     if (size($obj) != 0) {
         return `python("from mayaUsd.lib import PrimUpdaterManager; PrimUpdaterManager.canEditAsMaya('" + $obj + "')")`;
     }
     return 0;
+}
+
+global proc mayaUsdMenu_editAsMaya()
+{
+    if (!hasPrimUpdater())
+        return;
+
+    string $nonMayaObjs[] = `python("import maya.internal.ufeSupport.utils as ufeUtils; ufeUtils.getNonMayaSelectedItems()")`;
+    string $obj = $nonMayaObjs[0];
+    if (size($obj) != 0) {
+        mayaUsdEditAsMaya $obj;
+    }
+}
+
+global proc mayaUsdMenu_duplicate()
+{
+    if (!hasPrimUpdater())
+        return;
+        
+    string $nonMayaObjs[] = `python("import maya.internal.ufeSupport.utils as ufeUtils; ufeUtils.getNonMayaSelectedItems()")`;
+    string $ufePath = $nonMayaObjs[0];
+    if (size($ufePath)) {
+        mayaUsdDuplicate $ufePath "|world";
+    }
 }
 
 global proc USDMenuProc(string $parent, string $obj)
@@ -40,16 +62,16 @@ global proc USDMenuProc(string $parent, string $obj)
         setParent -menu $parent;
 
         setParent -menu ..;
-        if (canEditAsMaya($obj)) {
+        if (canEditAsMaya()) {
             // Temporary - hide this context menu items behind an
             //             env var until it is completed.
             string $s = `getenv "MAYAUSD_ENABLE_EDIT_AS_MAYA_DATA"`;
             string $ls = tolower($s);
             if (`match $ls "true|yes|on|1"` !="")
             {
-                menuItem -label "Edit As Maya Data" -image "edit_as_Maya.png" -command ("mayaUsdEditAsMaya \"" + $obj + "\"");
+                menuItem -label "Edit As Maya Data" -image "edit_as_Maya.png" -command ("mayaUsdMenu_editAsMaya");
             }
         }
-        menuItem -label "Duplicate As Maya Data" -command ("mayaUsdDuplicate \"" + $obj + "\"" + "\"|world\"");
+        menuItem -label "Duplicate As Maya Data" -command ("mayaUsdMenu_duplicate");
     }
 }

--- a/plugin/adsk/scripts/USDMenuProc.mel
+++ b/plugin/adsk/scripts/USDMenuProc.mel
@@ -61,7 +61,6 @@ global proc USDMenuProc(string $parent, string $obj)
         return;
         
     $obj = expandToSelection($obj);
-    print($obj);
     if (size($obj) != 0)
     {
         popupMenu -e -dai $parent;

--- a/plugin/adsk/scripts/mayaUsd_selectionUtils.py
+++ b/plugin/adsk/scripts/mayaUsd_selectionUtils.py
@@ -9,9 +9,10 @@ def expandPathToSelection(path):
     selection = ufe.GlobalSelection.get()
     ufePath = ufe.PathString.path(path)
     if selection.containsAncestor(ufePath):
-        for sel in selection:
-            subSel = ufe.Selection()
-            subSel.append(sel)
-            if subSel.containsAncestor(ufePath):
-                return ufe.PathString.string(sel.path())
+        # Note: containsAncestor does *not* include the path itself,
+        #       so this will stop when we're at the top-most path
+        #       that is still in the selection but its parent is not.
+        while selection.containsAncestor(ufePath):
+            ufePath = ufePath.pop()
+        return ufe.PathString.string(ufePath)
     return path

--- a/plugin/adsk/scripts/mayaUsd_selectionUtils.py
+++ b/plugin/adsk/scripts/mayaUsd_selectionUtils.py
@@ -1,0 +1,17 @@
+import ufe
+
+def expandPathToSelection(path):
+    """
+    Retrieves the path of the selection item that contains the provided path.
+    If there is no selection or no item in the selection is an ancestor of the item,
+    then the original path itself is returned.
+    """
+    selection = ufe.GlobalSelection.get()
+    ufePath = ufe.PathString.path(path)
+    if selection.containsAncestor(ufePath):
+        for sel in selection:
+            subSel = ufe.Selection()
+            subSel.append(sel)
+            if subSel.containsAncestor(ufePath):
+                return ufe.PathString.string(sel.path())
+    return path

--- a/plugin/adsk/scripts/mayaUsd_selectionUtils.py
+++ b/plugin/adsk/scripts/mayaUsd_selectionUtils.py
@@ -8,11 +8,9 @@ def expandPathToSelection(path):
     """
     selection = ufe.GlobalSelection.get()
     ufePath = ufe.PathString.path(path)
-    if selection.containsAncestor(ufePath):
-        # Note: containsAncestor does *not* include the path itself,
-        #       so this will stop when we're at the top-most path
-        #       that is still in the selection but its parent is not.
-        while selection.containsAncestor(ufePath):
-            ufePath = ufePath.pop()
-        return ufe.PathString.string(ufePath)
-    return path
+    # Note: containsAncestor does *not* include the path itself,
+    #       so this will stop when we're at the top-most path
+    #       that is still in the selection but its parent is not.
+    while selection.containsAncestor(ufePath):
+        ufePath = ufePath.pop()
+    return ufe.PathString.string(ufePath)


### PR DESCRIPTION
Use the entire selection instead of the item under the mouse when right-clicking in the viewport to edit-as-Maya or duplicate-as-Maya.