### PR TITLE
Don't dirty invalid paths

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -1271,7 +1271,8 @@ void ProxyRenderDelegate::_UpdateSelectionStates()
 #endif
         HdChangeTracker& changeTracker = _renderIndex->GetChangeTracker();
         for (auto path : *dirtyPaths) {
-            changeTracker.MarkRprimDirty(path, dirtySelectionBits);
+            if(_renderIndex->HasRprim(path))
+                changeTracker.MarkRprimDirty(path, dirtySelectionBits);
         }
 
         // now that the appropriate prims have been marked dirty trigger

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -1271,7 +1271,7 @@ void ProxyRenderDelegate::_UpdateSelectionStates()
 #endif
         HdChangeTracker& changeTracker = _renderIndex->GetChangeTracker();
         for (auto path : *dirtyPaths) {
-            if(_renderIndex->HasRprim(path))
+            if (_renderIndex->HasRprim(path))
                 changeTracker.MarkRprimDirty(path, dirtySelectionBits);
         }
 


### PR DESCRIPTION
Leverage render index to check for validity. This prevents ugly warnings like `// Error: Failed verification: ' it != _rprimState.end() ' – /Proxy_Kitchen_setShape_000001C81675F860/Kitchen_set/Props_grp/DiningTable_grp/ChairB_2.proto_polySurface32_id6`