### PR TITLE
MAYA-115056: Group my Maya Reference on creation

### DIFF
--- a/lib/mayaUsd/resources/scripts/mayaUsdAddMayaReference.mel
+++ b/lib/mayaUsd/resources/scripts/mayaUsdAddMayaReference.mel
@@ -95,6 +95,7 @@ proc fileOptionsTabPage(string $tabLayout)
     string $action = "Reference";
     pushOptionsUITemplate();
 
+    string $lbl;
     setParent $tabLayout;
 
     // Need to keep 'optionsBoxForm' as translator plugins reference this
@@ -135,8 +136,19 @@ proc fileOptionsTabPage(string $tabLayout)
         textFieldGrp -label `getMayaUsdLibString("kMayaRefPrimName")`
             -cc "usdMayaRef_changeGroupPrimNameText \"#1\""
             usdMayaReferenceGroupPrimName;
-        textFieldGrp -label `getMayaUsdLibString("kMayaRefPrimType")` usdMayaReferenceGroupPrimType;
-        textFieldGrp -label `getMayaUsdLibString("kMayaRefPrimKind")` usdMayaReferenceGroupPrimKind;
+        optionMenuGrp -label `getMayaUsdLibString("kMayaRefPrimType")` usdMayaReferenceGroupPrimType;
+            menuItem -label "Xform";
+            menuItem -label "Scope";
+        optionMenuGrp -label `getMayaUsdLibString("kMayaRefPrimKind")` usdMayaReferenceGroupPrimKind;
+            menuItem -label "";     // empty
+            $lbl = python("from pxr import Kind; Kind.Tokens.group");
+            menuItem -label $lbl;
+            $lbl = python("from pxr import Kind; Kind.Tokens.assembly");
+            menuItem -label $lbl;
+            $lbl = python("from pxr import Kind; Kind.Tokens.component");
+            menuItem -label $lbl;
+            $lbl = python("from pxr import Kind; Kind.Tokens.subcomponent");
+            menuItem -label $lbl;
 
     checkBoxGrp -numberOfCheckBoxes 1
         -label "" -label1 `getMayaUsdLibString("kMayaRefDefineInVariant")`
@@ -174,7 +186,7 @@ proc fileOptionsTabPage(string $tabLayout)
         usdMayaReferenceEditAsMayaDatGrp;
 
     setParent $topForm;
-    string $lbl = getMayaUsdLibString("kMayaRefOptions");
+    $lbl = getMayaUsdLibString("kMayaRefOptions");
     string $mayaRefForm = `frameLayout -label $lbl`;
 
     setParent $mayaRefForm;
@@ -371,6 +383,19 @@ proc setOptionVars(int $forceFactorySettings)
     int $mjv = `about -majorVersion`;
     if ($mjv <= 2022)
     {
+        if ($forceFactorySettings || !`optionVar -exists usdMayaReferenceGroup`) {
+            optionVar -intValue usdMayaReferenceGroup false;
+        }
+        if ($forceFactorySettings || !`optionVar -exists usdMayaReferenceGroupPrimName`) {
+            optionVar -stringValue usdMayaReferenceGroupPrimName "";
+        }
+        if ($forceFactorySettings || !`optionVar -exists usdMayaReferenceGroupType`) {
+            optionVar -stringValue usdMayaReferenceGroupPrimType "Xform";
+        }
+        if ($forceFactorySettings || !`optionVar -exists usdMayaReferenceGroupKind`) {
+            string $def = python("from pxr import Kind; Kind.Tokens.group");
+            optionVar -stringValue usdMayaReferenceGroupPrimKind $def;
+        }
         string $createNew = getMayaUsdLibString("kMayaRefCreateNew");
         if ($forceFactorySettings || !`optionVar -exists usdMayaReferenceDefineInVariant`) {
             optionVar -intValue usdMayaReferenceDefineInVariant false;
@@ -450,10 +475,15 @@ proc setOptionVars(int $forceFactorySettings)
     else
     {
         string $createNew = getMayaUsdLibString("kMayaRefCreateNew");
+        string $defGroupKind = python("from pxr import Kind; Kind.Tokens.group");
         string $defVariantSetName = defaultVariantSetName();
         string $defVariantName = defaultVariantName();
 
         optionVar -init $forceFactorySettings -category "MayaUsd"
+            -iv usdMayaReferenceGroup false
+            -sv usdMayaReferenceGroupPrimName ""
+            -sv usdMayaReferenceGroupPrimType "Xform"
+            -sv usdMayaReferenceGroupPrimKind $defGroupKind
             -iv usdMayaReferenceDefineInVariant false
             -sv usdMayaReferenceVariantSetNameOption $createNew
             -sv usdMayaReferenceVariantSetNameText $defVariantSetName
@@ -600,14 +630,29 @@ proc fileOptionsSetup(string $parent, int $forceFactorySettings, string $chosenF
         -text $mayaRefPrimName
         usdMayaReferencePrimName;
 
-    // Group is initially unchecked (todo: add optionvar control).
-    usdMayaRef_changeGroupOption(0);
+    // Setup the "Group" section.
+    int $groupVar = `optionVar -q usdMayaReferenceGroup`;
+    checkBoxGrp -edit -v1 $groupVar usdMayaReferenceGroupGrp;
+
+    textFieldGrp -edit
+        -text `optionVar -q usdMayaReferenceGroupPrimName`
+        usdMayaReferenceGroupPrimName;
+    optionMenuGrp -edit
+        -value `optionVar -q usdMayaReferenceGroupPrimType`
+        usdMayaReferenceGroupPrimType;
+    optionMenuGrp -edit
+        -value `optionVar -q usdMayaReferenceGroupPrimKind`
+        usdMayaReferenceGroupPrimKind;
 
     // Setup the "Define in Variant" section.
     int $defineInVar = `optionVar -q usdMayaReferenceDefineInVariant`;
     checkBoxGrp -edit -v1 $defineInVar usdMayaReferenceDefineInVariantGrp;
     usdMayaRef_changeDefineInVariantOption($defineInVar);
     usdMayaRef_setupDefineInVariant();
+
+    // We do this "after" the define in variant stuff since enabling group
+    // changes parts of the "define in variant" section.
+    usdMayaRef_changeGroupOption($groupVar);
 
     checkBoxGrp -edit
         -v1 `optionVar -query usdMayaReferenceEditAsMayaDat`
@@ -690,6 +735,18 @@ global proc addMayaReferenceToUsdInitUi(string $parent, string $filterType)
     fileOptionsSetup($parent, false, $filterType);
 }
 
+global proc addMayaReferenceToUsdSelectionChanged(string $parent, string $selection)
+{
+    global string $gCurrentFileDialogSelection;
+
+    setParent $parent;
+    $gCurrentFileDialogSelection = $selection;
+
+    // Update the variant preview field.
+    string $groupPrimName = `textFieldGrp -q -text usdMayaReferenceGroupPrimName`;
+    usdMayaRef_changeGroupPrimNameText($groupPrimName);
+}
+
 // Verbatim copy of performFileAction.mel:makeNamespaceNameFromFileName(), 
 // which is not a global proc.
 //
@@ -753,6 +810,21 @@ global proc addMayaReferenceToUsdUiCb(string $parent, string $selectedFile)
 
     // Save the various Usd Maya Reference Options.
     $gUsdMayaReferencePrimName = `textFieldGrp -query -text usdMayaReferencePrimName`;
+
+    int $groupVar = `checkBoxGrp -q -v1 usdMayaReferenceGroupGrp`;
+    optionVar -iv usdMayaReferenceGroup $groupVar;
+
+    if ($groupVar)
+    {
+        string $groupPrimName = `textFieldGrp -q -text usdMayaReferenceGroupPrimName`;
+        optionVar -sv usdMayaReferenceGroupPrimName $groupPrimName;
+
+        string $groupPrimType = `optionMenuGrp -q -value usdMayaReferenceGroupPrimType`;
+        optionVar -sv usdMayaReferenceGroupPrimType $groupPrimType;
+
+        string $groupPrimKind = `optionMenuGrp -q -value usdMayaReferenceGroupPrimKind`;
+        optionVar -sv usdMayaReferenceGroupPrimKind $groupPrimKind;
+    }
 
     int $defineInVar = `checkBoxGrp -q -v1 usdMayaReferenceDefineInVariantGrp`;
     optionVar -iv usdMayaReferenceDefineInVariant $defineInVar;
@@ -928,11 +1000,6 @@ proc string computeNamespace(string $filePath)
     return $ns;
 }
 
-proc string quoteString(string $unquotedStr)
-{
-    return("\"" + $unquotedStr + "\"");
-}
-
 proc string sanitizeName(string $name)
 {
     return `python("from pxr import Tf; Tf.MakeValidIdentifier('" + $name + "')")`;
@@ -942,6 +1009,8 @@ global proc string addMayaReferenceToUsd(string $ufePath)
 {
     global string $gUsdMayaReferenceUfePath;
     global string $gUsdMayaReferencePrimName;
+    global string $gCurrentFileDialogSelection;
+    $gCurrentFileDialogSelection = "";
 
     // Save the Ufe Path string in a global variable so we can use it in the controls.
     $gUsdMayaReferenceUfePath = $ufePath;
@@ -966,6 +1035,7 @@ global proc string addMayaReferenceToUsd(string $ufePath)
                         -okCaption $ok
                         -optionsUICreate addMayaReferenceToUsdCreateUi
                         -optionsUIInit addMayaReferenceToUsdInitUi
+                        -selectionChanged addMayaReferenceToUsdSelectionChanged
                         -optionsUITitle ""
                         -optionsUICommit2 addMayaReferenceToUsdUiCb`;
 
@@ -976,9 +1046,21 @@ global proc string addMayaReferenceToUsd(string $ufePath)
         return "";
     }
 
-    string $qVarSetName = quoteString("");
-    string $qVarName = quoteString("");
+    // If the group checkbox was enabled get the group prim name/type/kind.
+    int $useGroup = `optionVar -query usdMayaReferenceGroup`;
+    string $groupName;
+    string $groupType;
+    string $groupKind;
+    if ($useGroup)
+    {
+        $groupName = `optionVar -query usdMayaReferenceGroupPrimName`;
+        $groupType = `optionVar -query usdMayaReferenceGroupPrimType`;
+        $groupKind = `optionVar -query usdMayaReferenceGroupPrimKind`;
+    }
+
     // If the define in variant checkbox was enabled get the variant set and variant name.
+    string $varSetName;
+    string $varName;
     if (`optionVar -query usdMayaReferenceDefineInVariant`)
     {
         string $createNew = getMayaUsdLibString("kMayaRefCreateNew");
@@ -987,14 +1069,14 @@ global proc string addMayaReferenceToUsd(string $ufePath)
         {
             $tmpValue = `optionVar -query usdMayaReferenceVariantSetNameText`;
         }
-        $qVarSetName = quoteString($tmpValue);
+        $varSetName = $tmpValue;
 
         $tmpValue = `optionVar -query usdMayaReferenceVariantNameOption`;
         if ($tmpValue == $createNew)
         {
             $tmpValue = `optionVar -query usdMayaReferenceVariantNameText`;
         }
-        $qVarName = quoteString($tmpValue);
+        $varName = $tmpValue;
     }
 
     int $autoEditAsMayaData = `optionVar -query usdMayaReferenceEditAsMayaDat`;
@@ -1002,12 +1084,20 @@ global proc string addMayaReferenceToUsd(string $ufePath)
     // No need to actually create the Maya reference node: pulling on the
     // Maya reference prim will create the Maya reference node.
     // Create the Maya reference prim under its parent.
-    string $qUfePath = quoteString($ufePath);
-    string $qPrimName = quoteString($gUsdMayaReferencePrimName);
     string $filePath = fromNativePath($file[0]);
-    string $qFilePath = quoteString($filePath);
-    string $qNs = quoteString(`computeNamespace($filePath)`);
-    python("import mayaUsdAddMayaReference; mayaUsdAddMayaReference.createMayaReferencePrim(" + $qUfePath + ", " + $qFilePath + ", " + $qNs + ", " + $qPrimName + ", " + $qVarSetName + ", " + $qVarName + ", " + $autoEditAsMayaData + ")");
+    string $ns = computeNamespace($filePath);
+    string $pyCmdArgs = `format -s $ufePath -s $filePath -s $ns -s $gUsdMayaReferencePrimName "'^1s', '^2s', '^3s', '^4s'"`;
+    if ($useGroup)
+    {
+        $pyCmdArgs += `format -s $groupName -s $groupType -s $groupKind ", groupPrim=('^1s', '^2s', '^3s')"`;
+    }
+    if (($varSetName != "") && ($varName != ""))
+    {
+        $pyCmdArgs += `format -s $varSetName -s $varName ", variantSet=('^1s', '^2s')"`;
+    }
+    $pyCmdArgs += `format -s $autoEditAsMayaData ", mayaAutoEdit='^1s'"`;
+    string $pyCmd = `format -s $pyCmdArgs "import mayaUsdAddMayaReference; mayaUsdAddMayaReference.createMayaReferencePrim(^1s)"`;
+    python($pyCmd);
 
     return $file[0];
 }
@@ -1035,11 +1125,21 @@ global proc usdMayaRef_changePrimNameText(string $primName)
 global proc usdMayaRef_changeGroupOption(int $opt)
 {
     textFieldGrp -edit -enable $opt usdMayaReferenceGroupPrimName;
-    textFieldGrp -edit -enable $opt usdMayaReferenceGroupPrimType;
-    textFieldGrp -edit -enable $opt usdMayaReferenceGroupPrimKind;
+    optionMenuGrp -edit -enable $opt usdMayaReferenceGroupPrimType;
+    optionMenuGrp -edit -enable $opt usdMayaReferenceGroupPrimKind;
 
     optionMenu -edit -visible (!$opt) usdMayaReferenceVariantSetNameOptionMenu;
     optionMenu -edit -visible (!$opt) usdMayaReferenceVariantNameOptionMenu;
+
+    // If the "Group" option was just enabled, we need to set both the variant
+    // set and variant name to "Create New". Since when group is enabled we hide
+    // the optionMenu and only show the fields.
+    if ($opt && (`optionMenu -q -ni usdMayaReferenceVariantSetNameOptionMenu` > 0)) {
+        // We know that "Create New" is always the first menu item.
+        optionMenu -edit -select 1 usdMayaReferenceVariantSetNameOptionMenu;
+        string $v = `optionMenu -q -value usdMayaReferenceVariantSetNameOptionMenu`;
+        usdMayaRef_changeVariantSetName($v);
+    }
 
     usdMayaRef_setupDefineInVariantRows($opt, -1);
 
@@ -1052,13 +1152,33 @@ global proc usdMayaRef_changeGroupPrimNameText(string $primName)
 {
     global string $gUsdMayaReferenceUfePath;
 
+    // Validate the user input (note: the group prim name is allowed to empty in which case
+    // a default name will be created).
+    string $validatedGroupPrimName;
+    if ($primName != "") {
+        $validatedGroupPrimName = sanitizeName($primName);
+    }
+    if ($validatedGroupPrimName != $primName) {
+        textFieldGrp -edit -text $validatedGroupPrimName usdMayaReferenceGroupPrimName;
+    }
+
     // Fill-in the variant preview field.
     int $groupChecked = `checkBoxGrp -q -v1 usdMayaReferenceGroupGrp`;
     string $primPath = `python("import mayaUsdAddMayaReference; mayaUsdAddMayaReference.getPrimPath('" + $gUsdMayaReferenceUfePath + "')")`;
     if ($groupChecked) {
         string $variantPreviewPath = $primPath;
-        if ($primName != "") {
-            $variantPreviewPath += ($primPath + "/" + $primName);
+        if ($validatedGroupPrimName == "") {
+            string $ns;
+            string $sel = currentFileDialogSelection();
+            if ($sel == "") {
+                $ns = "<filename>";
+            } else {
+                string $filePath = fromNativePath($sel);
+                $ns = computeNamespace($filePath);
+            }
+            $variantPreviewPath += ("/" + $ns + "RNgroup");
+        } else {
+            $variantPreviewPath += ("/" + $validatedGroupPrimName);
         }
         textField -edit -text $variantPreviewPath usdMayaReferenceVariantPrim;
     } else {

--- a/lib/mayaUsd/resources/scripts/mayaUsdAddMayaReference.mel
+++ b/lib/mayaUsd/resources/scripts/mayaUsdAddMayaReference.mel
@@ -1095,7 +1095,8 @@ global proc string addMayaReferenceToUsd(string $ufePath)
     {
         $pyCmdArgs += `format -s $varSetName -s $varName ", variantSet=('^1s', '^2s')"`;
     }
-    $pyCmdArgs += `format -s $autoEditAsMayaData ", mayaAutoEdit='^1s'"`;
+    string $autoEditAsMayaDataBool = $autoEditAsMayaData ? "True" : "False";
+    $pyCmdArgs += `format -s $autoEditAsMayaDataBool ", mayaAutoEdit=^1s"`;
     string $pyCmd = `format -s $pyCmdArgs "import mayaUsdAddMayaReference; mayaUsdAddMayaReference.createMayaReferencePrim(^1s)"`;
     python($pyCmd);
 

--- a/lib/mayaUsd/resources/scripts/mayaUsdAddMayaReference.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdAddMayaReference.py
@@ -14,11 +14,12 @@
 #
 
 import maya.api.OpenMaya as om
-import maya.cmds as cmds
-from pxr import Sdf, Tf
+from pxr import Sdf, Tf, Usd
 import mayaUsd
 import ufe
 import re
+import maya.cmds as cmds
+from mayaUsdLibRegisterStrings import getMayaUsdLibString
 
 # These names should not be localized as Usd only accepts [a-z,A-Z] as valid characters.
 kDefaultMayaReferencePrimName = 'MayaReference1'
@@ -36,7 +37,10 @@ def defaultVariantName():
     return kDefaultVariantName
 
 def createPrimAndAttributes(stage, primPath, mayaReferencePath, mayaNamespace, mayaAutoEdit):
-    prim = stage.DefinePrim(primPath.path, 'MayaReference')
+    try:
+        prim = stage.DefinePrim(primPath.path, 'MayaReference')
+    except (Tf.ErrorException):
+        return Usd.Prim()
 
     mayaReferenceAttr = prim.CreateAttribute('mayaReference', Sdf.ValueTypeNames.Asset)
     mayaReferenceAttr.Set(mayaReferencePath)
@@ -49,47 +53,158 @@ def createPrimAndAttributes(stage, primPath, mayaReferencePath, mayaNamespace, m
 
     return prim
 
+def getDefaultGroupPrimName(parentPrim, mayaNamespace):
+    # "The name of the reference file" + "RN" + "group" for example 'sphereRNgroup'.
+    # If a prim with this name already exists, then add a numeric suffix after "RN".
+    startName = mayaNamespace + "RNgroup"
+    checkName = mayaUsd.ufe.uniqueChildName(parentPrim, startName)
+    index = 1
+    while (checkName != startName):
+        startName = "%sRN%dgroup" % (mayaNamespace, index)
+        checkName = mayaUsd.ufe.uniqueChildName(parentPrim, startName)
+        index += 1
+    return startName
+
 # Adapted from testMayaUsdSchemasMayaReference.py.
 def createMayaReferencePrim(ufePathStr, mayaReferencePath, mayaNamespace, 
                             mayaReferencePrimName = kDefaultMayaReferencePrimName,
-                            variantSetName = kDefaultVariantSetName,
-                            variantName = kDefaultVariantName,
+                            groupPrim = None, variantSet = None,
                             mayaAutoEdit = kDefaultEditAsMayaData):
-    '''Create a Maya reference prim parented to the argument path.'''
+    '''Create a Maya reference prim and optional group prim parented to the argument path.
+    Optionally create a variant set and name and placed the edits inside that variant.
+
+    Naming of Maya Reference prim is supported, otherwise default name is used.
+
+    The group prim is optional.
+
+    The variant set and name are optional
+
+    Parameters:
+    -----------
+    ufePathStr : str : Ufe PathString of parent prim to add Maya Reference
+    mayaReferencePath : str : File path of Maya Reference (for attribute)
+    mayaNamespace : str : Namespace (for attribute)
+    mayaReferencePrimName : str [optional] : Name for the Maya Reference prim
+    groupPrim : tuple(str,str,str) [optional] : The Group prim Name, Type & Kind to create
+                                                Note: the name is optional and will be auto-computed
+                                                      if empty or not provided.
+                                                Note: Type and Kind are both mandatory, but Kind is
+                                                      allowed to be empty string.
+    variantSet : tuple(str,str) [optional] : The Variant Set Name and Variant Name to create
+
+    Return:
+    -------
+    The Usd prim of the newly created Maya Reference or an invalid prim if there is an error.
+    '''
 
     # Make sure the prim name is valid and doesn't already exist.
     parentPrim = mayaUsd.ufe.ufePathToPrim(ufePathStr)
 
-    checkName = mayaUsd.ufe.uniqueChildName(parentPrim, mayaReferencePrimName)
+    # There are special conditions when we are given the ProxyShape gateway node.
+    ufePath = ufe.PathString.path(ufePathStr)
+    isGateway = (ufePath.nbSegments() == 1)
+
+    # Were we given a Group prim to create?
+    groupPrimName = None
+    groupPrimType = None
+    groupPrimKind = None
+    if groupPrim:
+        if (len(groupPrim) == 2):
+            groupPrimType, groupPrimKind = groupPrim
+        elif (len(groupPrim) == 3):
+            groupPrimName, groupPrimType, groupPrimKind = groupPrim
+
+            # Make sure the input Group prim name doesn't exist already
+            # and validate the input name.
+            # Note: it is allowed to be input as empty in which case a default is used.
+            if groupPrimName:
+                checkGroupPrimName = mayaUsd.ufe.uniqueChildName(parentPrim, groupPrimName)
+                if checkGroupPrimName != groupPrimName:
+                    errorMsgFormat = getMayaUsdLibString('kErrorGroupPrimExists')
+                    errorMsg = cmds.format(errorMsgFormat, stringArg=(groupPrimName, ufePathStr))
+                    om.MGlobal.displayError(errorMsg)
+                    return Usd.Prim()
+                groupPrimName = Tf.MakeValidIdentifier(checkGroupPrimName)
+
+        # If the group prim was either not provided or empty we use a default name.
+        if not groupPrimName:
+            groupPrimName = getDefaultGroupPrimName(parentPrim, mayaNamespace)
+
+    # When the input is a gateway we cannot have in variant unless group is also given.
+    if isGateway and variantSet and not groupPrimName:
+        errorMsg = getMayaUsdLibString('kErrorCannotAddToProxyShape')
+        om.MGlobal.displayError(errorMsg)
+        return Usd.Prim()
+
+    # Make sure the input Maya Reference prim name doesn't exist already
+    # and validate the input name.
+    # Note: if we are given a group prim to create, then we know that the
+    #       Maya Reference prim name will be unique since it will be the
+    #       only child (of the newly created group prim).
+    checkName = mayaUsd.ufe.uniqueChildName(parentPrim, mayaReferencePrimName) if groupPrim is None else mayaReferencePrimName
     if checkName != mayaReferencePrimName:
-        cmds.error('Maya Reference prim name already exists.')
-        return
+        errorMsgFormat = getMayaUsdLibString('kErrorMayaRefPrimExists')
+        errorMsg = cmds.format(errorMsgFormat, stringArg=(mayaReferencePrimName, ufePathStr))
+        om.MGlobal.displayError(errorMsg)
+        return Usd.Prim()
     validatedPrimName = Tf.MakeValidIdentifier(checkName)
 
     # Extract the USD path segment from the UFE path and append the Maya
     # reference prim to it.
-    ufePath = ufe.PathString.path(ufePathStr)
     parentPath = str(ufePath.segments[1]) if ufePath.nbSegments() > 1 else ''
-    primPath = Sdf.AssetPath(parentPath + '/' + validatedPrimName)
 
     stage = mayaUsd.ufe.getStage(ufePathStr)
 
-    variantSetName = Tf.MakeValidIdentifier(variantSetName)
-    variantName = Tf.MakeValidIdentifier(variantName)
+    # Optionally insert a Group prim as a parent of the Maya reference prim.
+    groupPrim = None
+    if groupPrimName:
+        groupPath = Sdf.AssetPath(parentPath + '/' + groupPrimName)
+        try:
+            groupPrim = stage.DefinePrim(groupPath.path, groupPrimType)
+        except (Tf.ErrorException):
+            groupPrim = Usd.Prim()
+        if not groupPrim.IsValid():
+            errorMsgFormat = getMayaUsdLibString('kErrorCreatingGroupPrim')
+            errorMsg = cmds.format(errorMsgFormat, stringArg=(ufePathStr))
+            om.MGlobal.displayError(errorMsg)
+            return Usd.Prim()
+        if groupPrimKind:
+            model = Usd.ModelAPI(groupPrim)
+            model.SetKind(groupPrimKind)
+
+    if groupPrim:
+        primPath = Sdf.AssetPath(groupPrim.GetPath().pathString + '/' + validatedPrimName)
+    else:
+        primPath = Sdf.AssetPath(parentPath + '/' + validatedPrimName)
+
+    # Were we given a Variant Set to create?
+    variantSetName = None
+    variantName = None
+    if variantSet and (len(variantSet) == 2):
+        variantSetName, variantName = variantSet
     if variantSetName and variantName:
-        ufePathPrim = mayaUsd.ufe.ufePathToPrim(ufePathStr)
-        vset = ufePathPrim.GetVariantSet(variantSetName)
-        vset.AddVariant(variantName)
-        vset.SetVariantSelection(variantName)
+        validatedVariantSetName = Tf.MakeValidIdentifier(variantSetName)
+        validatedVariantName = Tf.MakeValidIdentifier(variantName)
+
+        # If we created a group prim add the variant set there, otherwise add it
+        # to the prim that corresponds to the input ufe path.
+        variantPrim = groupPrim if groupPrim else mayaUsd.ufe.ufePathToPrim(ufePathStr)
+        vset = variantPrim.GetVariantSet(validatedVariantSetName)
+        vset.AddVariant(validatedVariantName)
+        vset.SetVariantSelection(validatedVariantName)
         with vset.GetVariantEditContext():
             # Now all of our subsequent edits will go "inside" the
             # 'variantName' variant of 'variantSetName'.
             prim = createPrimAndAttributes(stage, primPath, mayaReferencePath, mayaNamespace, mayaAutoEdit)
     else:
         prim = createPrimAndAttributes(stage, primPath, mayaReferencePath, mayaNamespace, mayaAutoEdit)
-    if not prim.IsValid():
-        om.MGlobal.displayError("Could not create MayaReference prim under %s" % ufePathStr)
-        return
+    if prim is None or not prim.IsValid():
+        errorMsgFormat = getMayaUsdLibString('kErrorCreatingMayaRefPrim')
+        errorMsg = cmds.format(errorMsgFormat, stringArg=(ufePathStr))
+        om.MGlobal.displayError(errorMsg)
+        return Usd.Prim()
+
+    return prim
 
 def getVariantSetNames(ufePathStr):
     prim = mayaUsd.ufe.ufePathToPrim(ufePathStr)
@@ -107,8 +222,7 @@ def getVariantNames(ufePathStr, variantSetName):
 
 def getPrimPath(ufePathStr):
     ufePath = ufe.PathString.path(ufePathStr)
-    parentPath = ufePath.segments[1]
-    return str(parentPath)
+    return '' if ufePath.nbSegments() == 1 else str(ufePath.segments[1])
 
 def getUniqueMayaReferencePrimName(ufePathStr, startName=None):
     '''Helper function to get a unique name for the Maya Reference prim.'''

--- a/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
@@ -23,8 +23,17 @@ def getMayaUsdLibString(key):
     return getPluginResource('mayaUsdLib', key)
 
 def mayaUsdLibRegisterStrings():
+    # This function is called from the equivalent MEL proc
+    # with the same name. The strings registered here and all the
+    # ones registered from the MEL proc can be used in either
+    # MEL or python.
+
     # Any python strings from MayaUsd lib go here.
-    pass
+    register('kErrorGroupPrimExists', 'Group prim name "^1s" already exists under "^2s".')
+    register('kErrorCannotAddToProxyShape', 'Cannot add Maya Reference node to ProxyShape with VariantSet unless Group prim is used.')
+    register('kErrorMayaRefPrimExists', 'Maya Reference prim name "^1s" already exists under "^2s".')
+    register('kErrorCreatingGroupPrim', 'Could not create Group prim under "^1s".')
+    register('kErrorCreatingMayaRefPrim', 'Could not create MayaReference prim under "^1s".')
 
 def registerPluginResource(pluginId, stringId, resourceStr):
     '''See registerPluginResource.mel in Maya.

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -189,7 +189,7 @@ UsdPrim ufePathToPrim(const Ufe::Path& path)
     }
 
     // If there is only a single segment in the path, it must point to the
-    // proxy shape, otherwise we would not have retrived a valid stage.
+    // proxy shape, otherwise we would not have retrieved a valid stage.
     // The second path segment is the USD path.
     return (segments.size() == 1u)
         ? stage->GetPseudoRoot()

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -183,7 +183,7 @@ UsdPrim ufePathToPrim(const Ufe::Path& path)
     const Ufe::Path ufePrimPath = stripInstanceIndexFromUfePath(path);
 
     const Ufe::Path::Segments& segments = ufePrimPath.getSegments();
-    auto stage = getStage(Ufe::Path(segments[0]));
+    auto                       stage = getStage(Ufe::Path(segments[0]));
     if (!TF_VERIFY(stage, kIllegalUSDPath, path.string().c_str())) {
         return UsdPrim();
     }
@@ -191,8 +191,9 @@ UsdPrim ufePathToPrim(const Ufe::Path& path)
     // If there is only a single segment in the path, it must point to the
     // proxy shape, otherwise we would not have retrived a valid stage.
     // The second path segment is the USD path.
-    return (segments.size() == 1u) ? stage->GetPseudoRoot() :
-        stage->GetPrimAtPath(SdfPath(segments[1].string()).GetPrimPath());
+    return (segments.size() == 1u)
+        ? stage->GetPseudoRoot()
+        : stage->GetPrimAtPath(SdfPath(segments[1].string()).GetPrimPath());
 }
 
 int ufePathToInstanceIndex(const Ufe::Path& path, PXR_NS::UsdPrim* prim)


### PR DESCRIPTION
#### MAYA-115056: Group my Maya Reference on creation
* Implement the "Group" section with optionMenu's for the type and kind and optionVar's (to remember values) for checkbox/type/kind.
* Update the variant preview field with group prim name (including logic when name field is empty).
* Added error checking for DefinePrim.
* Added documentation for createMayaReferencePrim() function and input group params for creating a group prim.
* Fixed adding MayaReference directly under the ProxyShape.
* Enhanced testAddMayaReference with error cases and separate test functions for each feature.