### PR TITLE
MAYA-106075 - USD selection highlighting doesn't take Color Settings into consideration

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1207,8 +1207,8 @@ void HdVP2BasisCurves::_UpdateDrawItem(
             // with one color vertex buffer.
             if (drawItem->ContainsUsage(HdVP2DrawItem::kSelectionHighlight)) {
                 const MColor colors[] = { drawScene.GetWireframeColor(),
-                                          drawScene.GetSelectionHighlightColor(false),
-                                          drawScene.GetSelectionHighlightColor(true) };
+                                          drawScene.GetSelectionHighlightColor("curve"),
+                                          drawScene.GetSelectionHighlightColor() };
 
                 // Store the indices to colors.
                 std::vector<unsigned char> colorIndices;
@@ -1264,9 +1264,9 @@ void HdVP2BasisCurves::_UpdateDrawItem(
                 int  primitiveStride = 0;
 
                 const MColor& color
-                    = (_selectionStatus != kUnselected
-                           ? drawScene.GetSelectionHighlightColor(_selectionStatus == kFullyLead)
-                           : drawScene.GetWireframeColor());
+                    = (_selectionStatus != kUnselected ? drawScene.GetSelectionHighlightColor(
+                           _selectionStatus == kFullyLead ? nullptr : "curve")
+                                                       : drawScene.GetWireframeColor());
 
                 if (desc.geomStyle == HdBasisCurvesGeomStylePatch) {
                     if (_selectionStatus != kUnselected) {

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1206,9 +1206,10 @@ void HdVP2BasisCurves::_UpdateDrawItem(
             // it needs to display both wireframe color and selection highlight
             // with one color vertex buffer.
             if (drawItem->ContainsUsage(HdVP2DrawItem::kSelectionHighlight)) {
-                const MColor colors[] = { drawScene.GetWireframeColor(),
-                                          drawScene.GetSelectionHighlightColor("curve"),
-                                          drawScene.GetSelectionHighlightColor() };
+                const MColor colors[]
+                    = { drawScene.GetWireframeColor(),
+                        drawScene.GetSelectionHighlightColor(HdPrimTypeTokens->basisCurves),
+                        drawScene.GetSelectionHighlightColor() };
 
                 // Store the indices to colors.
                 std::vector<unsigned char> colorIndices;
@@ -1265,7 +1266,8 @@ void HdVP2BasisCurves::_UpdateDrawItem(
 
                 const MColor& color
                     = (_selectionStatus != kUnselected ? drawScene.GetSelectionHighlightColor(
-                           _selectionStatus == kFullyLead ? nullptr : "curve")
+                           _selectionStatus == kFullyLead ? TfToken()
+                                                          : HdPrimTypeTokens->basisCurves)
                                                        : drawScene.GetWireframeColor());
 
                 if (desc.geomStyle == HdBasisCurvesGeomStylePatch) {

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -2105,10 +2105,11 @@ void HdVP2Mesh::_UpdateDrawItem(
             // render item.
 
             // Set up the source color buffers.
-            const MColor wireframeColors[] = { drawScene.GetWireframeColor(),
-                                               drawScene.GetSelectionHighlightColor("surface"),
-                                               drawScene.GetSelectionHighlightColor() };
-            bool         useWireframeColors = stateToCommit._instanceColorParam == kSolidColorStr;
+            const MColor wireframeColors[]
+                = { drawScene.GetWireframeColor(),
+                    drawScene.GetSelectionHighlightColor(HdPrimTypeTokens->mesh),
+                    drawScene.GetSelectionHighlightColor() };
+            bool useWireframeColors = stateToCommit._instanceColorParam == kSolidColorStr;
 
             MFloatArray*    shadedColors = nullptr;
             HdInterpolation colorInterpolation = HdInterpolationConstant;
@@ -2209,7 +2210,7 @@ void HdVP2Mesh::_UpdateDrawItem(
             && drawItem->ContainsUsage(HdVP2DrawItem::kSelectionHighlight)) {
             const MColor& color
                 = (_selectionStatus != kUnselected ? drawScene.GetSelectionHighlightColor(
-                       _selectionStatus == kFullyLead ? nullptr : "surface")
+                       _selectionStatus == kFullyLead ? TfToken() : HdPrimTypeTokens->mesh)
                                                    : drawScene.GetWireframeColor());
 
             MHWRender::MShaderInstance* shader = _delegate->Get3dSolidShader(color);

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -2106,8 +2106,8 @@ void HdVP2Mesh::_UpdateDrawItem(
 
             // Set up the source color buffers.
             const MColor wireframeColors[] = { drawScene.GetWireframeColor(),
-                                               drawScene.GetSelectionHighlightColor(false),
-                                               drawScene.GetSelectionHighlightColor(true) };
+                                               drawScene.GetSelectionHighlightColor("surface"),
+                                               drawScene.GetSelectionHighlightColor() };
             bool         useWireframeColors = stateToCommit._instanceColorParam == kSolidColorStr;
 
             MFloatArray*    shadedColors = nullptr;
@@ -2208,9 +2208,9 @@ void HdVP2Mesh::_UpdateDrawItem(
         if ((itemDirtyBits & DirtySelectionHighlight)
             && drawItem->ContainsUsage(HdVP2DrawItem::kSelectionHighlight)) {
             const MColor& color
-                = (_selectionStatus != kUnselected
-                       ? drawScene.GetSelectionHighlightColor(_selectionStatus == kFullyLead)
-                       : drawScene.GetWireframeColor());
+                = (_selectionStatus != kUnselected ? drawScene.GetSelectionHighlightColor(
+                       _selectionStatus == kFullyLead ? nullptr : "surface")
+                                                   : drawScene.GetWireframeColor());
 
             MHWRender::MShaderInstance* shader = _delegate->Get3dSolidShader(color);
             if (shader != nullptr && shader != drawItemData._shader) {

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -1539,7 +1539,7 @@ MColor ProxyRenderDelegate::GetSelectionHighlightColor(const char* className)
 #endif
 
     // In case of any failure, return the default color
-    static const MColor kDefaultLeadColor(0.351f, 5.519f, 0.408f, 1.0f);
+    static const MColor kDefaultLeadColor(0.056f, 1.0f, 0.366f, 1.0f);
     static const MColor kDefaultActiveColor(1.0f, 1.0f, 1.0f, 1.0f);
 
     return className ? kDefaultActiveColor : kDefaultLeadColor;

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -1506,7 +1506,7 @@ MColor ProxyRenderDelegate::GetSelectionHighlightColor(const char* className)
 {
     // Query display colors from Maya Command Engine only starting from Maya 2023 because the
     // function MColorPickerUtilities::applyViewTransform is supported only in that case
-#if MAYA_APP_VERSION >= 2023
+#if MAYA_API_VERSION >= 20230000
     // Construct the query command string.
     MString queryCommand;
     if (className) {

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -173,10 +173,10 @@ public:
     MAYAUSD_CORE_PUBLIC
     GfVec3f GetCurveDefaultColor();
 
-    // Returns the selection highlight color for a given class.
-    // If className is null, returns the lead highlight color.
+    // Returns the selection highlight color for a given HdPrim type.
+    // If className is empty, returns the lead highlight color.
     MAYAUSD_CORE_PUBLIC
-    MColor GetSelectionHighlightColor(const char* className = nullptr);
+    MColor GetSelectionHighlightColor(const TfToken& className = TfToken());
 
     MAYAUSD_CORE_PUBLIC
     const HdSelection::PrimSelectionState* GetLeadSelectionState(const SdfPath& path) const;

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -173,8 +173,10 @@ public:
     MAYAUSD_CORE_PUBLIC
     GfVec3f GetCurveDefaultColor();
 
+    // Returns the selection highlight color for a given class.
+    // If className is null, returns the lead highlight color.
     MAYAUSD_CORE_PUBLIC
-    const MColor& GetSelectionHighlightColor(bool lead) const;
+    MColor GetSelectionHighlightColor(const char* className = nullptr);
 
     MAYAUSD_CORE_PUBLIC
     const HdSelection::PrimSelectionState* GetLeadSelectionState(const SdfPath& path) const;


### PR DESCRIPTION
Get up-to-date selection color settings from Maya. This includes 'lead' color as well as curve and surface active colors.