### PR TITLE
MAYA-115117 Deactivate prim on pull instead of using exclude feature

### DIFF
--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
@@ -46,8 +46,7 @@ namespace {
 
 // We want to display the unloaded prims, so removed UsdPrimIsLoaded from
 // the default UsdPrimDefaultPredicate.
-const Usd_PrimFlagsConjunction MayaUsdPrimDefaultPredicate
-    = UsdPrimIsActive && UsdPrimIsDefined && !UsdPrimIsAbstract;
+const Usd_PrimFlagsConjunction MayaUsdPrimDefaultPredicate = UsdPrimIsDefined && !UsdPrimIsAbstract;
 
 UsdPrimSiblingRange getUSDFilteredChildren(
     const UsdPrim&               prim,
@@ -133,12 +132,12 @@ Ufe::SceneItem::Ptr ProxyShapeHierarchy::sceneItem() const { return fItem; }
 
 bool ProxyShapeHierarchy::hasChildren() const
 {
-    const UsdPrim& rootPrim = getUsdRootPrim();
-    if (!rootPrim.IsValid()) {
-        UFE_LOG("invalid root prim in ProxyShapeHierarchy::hasChildren()");
-        return false;
-    }
-    return !getUSDFilteredChildren(rootPrim).empty();
+    // We have an extra logic in createUFEChildList to remap and filter
+    // prims. Going this direction is more costly, but easier to maintain.
+    //
+    // I don't have data that proves we need to worry about performance in here,
+    // so going after maintainablility.
+    return !children().empty();
 }
 
 Ufe::SceneItemList ProxyShapeHierarchy::children() const
@@ -148,7 +147,7 @@ Ufe::SceneItemList ProxyShapeHierarchy::children() const
     if (!rootPrim.IsValid())
         return Ufe::SceneItemList();
 
-    return createUFEChildList(getUSDFilteredChildren(rootPrim));
+    return createUFEChildList(getUSDFilteredChildren(rootPrim), true);
 }
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
@@ -166,7 +165,7 @@ Ufe::SceneItemList ProxyShapeHierarchy::filteredChildren(const ChildFilter& chil
         Usd_PrimFlagsPredicate flags = childFilter.front().value
             ? UsdPrimIsDefined && !UsdPrimIsAbstract
             : MayaUsdPrimDefaultPredicate;
-        return createUFEChildList(getUSDFilteredChildren(rootPrim, flags));
+        return createUFEChildList(getUSDFilteredChildren(rootPrim, flags), false);
     }
 
     UFE_LOG("Unknown child filter");
@@ -175,7 +174,8 @@ Ufe::SceneItemList ProxyShapeHierarchy::filteredChildren(const ChildFilter& chil
 #endif
 
 // Return UFE child list from input USD child list.
-Ufe::SceneItemList ProxyShapeHierarchy::createUFEChildList(const UsdPrimSiblingRange& range) const
+Ufe::SceneItemList
+ProxyShapeHierarchy::createUFEChildList(const UsdPrimSiblingRange& range, bool filterInactive) const
 {
     // We must create selection items for our children.  These will have as
     // path the path of the proxy shape, with a single path segment of a
@@ -192,11 +192,13 @@ Ufe::SceneItemList ProxyShapeHierarchy::createUFEChildList(const UsdPrimSiblingR
             }
         } else {
 #endif
-            children.emplace_back(UsdSceneItem::create(
-                parentPath
-                    + Ufe::PathSegment(
-                        Ufe::PathComponent(child.GetName().GetString()), g_USDRtid, '/'),
-                child));
+            if (!filterInactive || child.IsActive()) {
+                children.emplace_back(UsdSceneItem::create(
+                    parentPath
+                        + Ufe::PathSegment(
+                            Ufe::PathComponent(child.GetName().GetString()), g_USDRtid, '/'),
+                    child));
+            }
 #ifdef UFE_V3_FEATURES_AVAILABLE
         }
 #endif

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
@@ -98,7 +98,8 @@ public:
 
 private:
     const PXR_NS::UsdPrim& getUsdRootPrim() const;
-    Ufe::SceneItemList     createUFEChildList(const PXR_NS::UsdPrimSiblingRange& range) const;
+    Ufe::SceneItemList
+    createUFEChildList(const PXR_NS::UsdPrimSiblingRange& range, bool filterInactive) const;
 
 private:
     Ufe::SceneItem::Ptr        fItem;

--- a/test/lib/mayaUsd/fileio/testMergeToUsd.py
+++ b/test/lib/mayaUsd/fileio/testMergeToUsd.py
@@ -96,6 +96,11 @@ class MergeToUsdTestCase(unittest.TestCase):
         with mayaUsd.lib.OpUndoItemList():
             self.assertTrue(mayaUsd.lib.PrimUpdaterManager.mergeToUsd(aMayaPathStr))
 
+        # Edit will re-allocate anything that was under pulled prim due to deactivation
+        # Grab new references for /A/B prim
+        bUsdPrim = mayaUsd.ufe.ufePathToPrim(bUsdUfePathStr)
+        bXlateOp = UsdGeom.Xformable(bUsdPrim).GetOrderedXformOps()[0]
+        
         # Check that edits have been preserved in USD.
         for (usdUfePathStr, mayaMatrix, xlateOp) in \
             zip([aUsdUfePathStr, bUsdUfePathStr], [aMayaMatrix, bMayaMatrix], 
@@ -158,6 +163,11 @@ class MergeToUsdTestCase(unittest.TestCase):
         cmds.mayaUsdMergeToUsd(aMayaPathStr)
 
         def verifyMergeToUsd():
+            # Edit will re-allocate anything that was under pulled prim due to deactivation
+            # Grab new references for /A/B prim
+            bUsdPrim = mayaUsd.ufe.ufePathToPrim(bUsdUfePathStr)
+            bXlateOp = UsdGeom.Xformable(bUsdPrim).GetOrderedXformOps()[0]
+
             # Check that edits have been preserved in USD.
             for (usdUfePathStr, mayaMatrix, xlateOp) in \
                 zip([aUsdUfePathStr, bUsdUfePathStr], [aMayaMatrix, bMayaMatrix], 


### PR DESCRIPTION
Exclude prim is way too expensive for complex scenes since it repopulates the entire render index. We decided to switch to deactivation which reduces the cost to what changed.