### PR TITLE
MAYA-113541 Allow updating registered Python class

### DIFF
--- a/lib/mayaUsd/python/CMakeLists.txt
+++ b/lib/mayaUsd/python/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(${PYTHON_TARGET_NAME} SHARED)
 target_sources(${PYTHON_TARGET_NAME} 
     PRIVATE
         module.cpp
+        pythonObjectRegistry.cpp
         wrapSparseValueWriter.cpp
         wrapAdaptor.cpp
         wrapBlockSceneModificationContext.cpp

--- a/lib/mayaUsd/python/pythonObjectRegistry.cpp
+++ b/lib/mayaUsd/python/pythonObjectRegistry.cpp
@@ -17,6 +17,7 @@
 #include "pythonObjectRegistry.h"
 
 #include <pxr/base/tf/diagnostic.h>
+#include <pxr/base/tf/pyUtils.h>
 #include <pxr/pxr.h>
 
 #include <boost/python.hpp>
@@ -67,6 +68,22 @@ bool UsdMayaPythonObjectRegistry::IsPythonClass(object cl)
     }
     std::string name = extract<std::string>(nameAttr);
     return name == "class";
+}
+
+std::string UsdMayaPythonObjectRegistry::ClassName(object cl)
+{
+    // Is it a Python class:
+    if (!IsPythonClass(cl)) {
+        // So far class is always first parameter, so we can have this check be here.
+        TfPyThrowRuntimeError("First argument must be a Python class");
+    }
+
+    auto nameAttr = cl.attr("__name__");
+    if (!nameAttr) {
+        TfPyThrowRuntimeError("Unexpected Python error: No __name__ attribute");
+    }
+
+    return std::string(boost::python::extract<std::string>(nameAttr));
 }
 
 UsdMayaPythonObjectRegistry::TClassVec   UsdMayaPythonObjectRegistry::_sClassVec;

--- a/lib/mayaUsd/python/pythonObjectRegistry.cpp
+++ b/lib/mayaUsd/python/pythonObjectRegistry.cpp
@@ -1,0 +1,90 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "pythonObjectRegistry.h"
+
+#include <pxr/base/tf/diagnostic.h>
+#include <pxr/pxr.h>
+
+#include <boost/python.hpp>
+#include <boost/python/def.hpp>
+
+using namespace std;
+using namespace boost::python;
+using namespace boost;
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+// Registers or updates a Python class for the provided key.
+size_t UsdMayaPythonObjectRegistry::RegisterPythonObject(object cl, const std::string& key)
+{
+    TClassIndex::const_iterator target = _sIndex.find(key);
+    if (target == _sIndex.cend()) {
+        HookInterpreterExit();
+        // Create a new entry:
+        size_t classIndex = _sClassVec.size();
+        _sClassVec.emplace_back(cl);
+        _sIndex.emplace(key, classIndex);
+        // Return a new factory function:
+        return classIndex;
+    } else {
+        _sClassVec[target->second] = cl;
+        return UPDATED;
+    }
+}
+
+void UsdMayaPythonObjectRegistry::UnregisterPythonObject(object cl, const std::string& key)
+{
+    TClassIndex::const_iterator target = _sIndex.find(key);
+    if (target != _sIndex.cend()) {
+        // Clear the Python class:
+        _sClassVec[target->second] = object();
+    }
+}
+
+bool UsdMayaPythonObjectRegistry::IsPythonClass(object cl)
+{
+    auto classAttr = cl.attr("__class__");
+    if (!classAttr) {
+        return false;
+    }
+    auto nameAttr = classAttr.attr("__name__");
+    if (!nameAttr) {
+        return false;
+    }
+    std::string name = extract<std::string>(nameAttr);
+    return name == "class";
+}
+
+UsdMayaPythonObjectRegistry::TClassVec   UsdMayaPythonObjectRegistry::_sClassVec;
+UsdMayaPythonObjectRegistry::TClassIndex UsdMayaPythonObjectRegistry::_sIndex;
+
+void UsdMayaPythonObjectRegistry::HookInterpreterExit()
+{
+    if (_sClassVec.empty()) {
+        if (import("atexit").attr("register")(&OnInterpreterExit).is_none()) {
+            TF_CODING_ERROR("Couldn't register unloader to atexit");
+        }
+    }
+}
+
+void UsdMayaPythonObjectRegistry::OnInterpreterExit()
+{
+    // Release all Python classes:
+    for (size_t i = 0; i < _sClassVec.size(); ++i) {
+        _sClassVec[i] = object();
+    }
+}

--- a/lib/mayaUsd/python/pythonObjectRegistry.h
+++ b/lib/mayaUsd/python/pythonObjectRegistry.h
@@ -1,0 +1,64 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef USDMAYA_PYTHON_CLASS_REGISTRY_H
+#define USDMAYA_PYTHON_CLASS_REGISTRY_H
+
+#include <pxr/pxr.h>
+
+#include <boost/python/class.hpp>
+
+#include <map>
+#include <string>
+#include <vector>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+//---------------------------------------------------------------------------------------------
+/// \brief Keeps track of registered Python classes and allows updating and unregistering them
+//---------------------------------------------------------------------------------------------
+class UsdMayaPythonObjectRegistry
+{
+protected:
+    static const size_t UPDATED = 0xFFFFFFFF;
+
+    // Registers or updates a Python class for the provided key.
+    static size_t RegisterPythonObject(boost::python::object cl, const std::string& key);
+
+    // Unregister a Python class for a given key. This will cause the associated factory function to
+    // stop producing this Python class.
+    static void UnregisterPythonObject(boost::python::object cl, const std::string& key);
+
+    static boost::python::object GetPythonObject(size_t index) { return _sClassVec[index]; }
+
+    static bool IsPythonClass(boost::python::object cl);
+
+private:
+    // Static table of all registered Python classes, with associated index:
+    typedef std::vector<boost::python::object> TClassVec;
+    static TClassVec                           _sClassVec;
+    typedef std::map<std::string, size_t>      TClassIndex;
+    static TClassIndex                         _sIndex;
+
+    static void HookInterpreterExit();
+
+public:
+    // To be called when the Python interpreter exits.
+    static void OnInterpreterExit();
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/lib/mayaUsd/python/pythonObjectRegistry.h
+++ b/lib/mayaUsd/python/pythonObjectRegistry.h
@@ -45,6 +45,8 @@ protected:
 
     static bool IsPythonClass(boost::python::object cl);
 
+    static std::string ClassName(boost::python::object cl);
+
 private:
     // Static table of all registered Python classes, with associated index:
     typedef std::vector<boost::python::object> TClassVec;

--- a/lib/mayaUsd/python/wrapExportChaser.cpp
+++ b/lib/mayaUsd/python/wrapExportChaser.cpp
@@ -126,19 +126,7 @@ public:
         // purpose:
         static std::string GetKey(boost::python::object cl, const std::string& mayaTypeName)
         {
-            // Is it a Python class:
-            if (!IsPythonClass(cl)) {
-                TfPyThrowRuntimeError("First argument must be a Python class");
-            }
-
-            auto nameAttr = cl.attr("__name__");
-            if (!nameAttr) {
-                TfPyThrowRuntimeError("Unexpected Python error: No __name__ attribute");
-            }
-
-            std::string key = boost::python::extract<std::string>(nameAttr);
-            key = key + "," + mayaTypeName + "," + ",ExportChaser";
-            return key;
+            return ClassName(cl) + "," + mayaTypeName + "," + ",ExportChaser";
         }
     };
 

--- a/lib/mayaUsd/python/wrapExportChaser.cpp
+++ b/lib/mayaUsd/python/wrapExportChaser.cpp
@@ -93,7 +93,7 @@ public:
         }
 
         // Create a new wrapper for a Python class that is seen for the first time for a given
-        // purpose. It we already have a registration for this purpose: update the class to
+        // purpose. If we already have a registration for this purpose: update the class to
         // allow the previously issued factory function to use it.
         static UsdMayaExportChaserRegistry::FactoryFn
         Register(boost::python::object cl, const std::string& mayaTypeName)

--- a/lib/mayaUsd/python/wrapExportChaser.cpp
+++ b/lib/mayaUsd/python/wrapExportChaser.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+#include "pythonObjectRegistry.h"
+
 #include <mayaUsd/fileio/chaser/exportChaser.h>
 #include <mayaUsd/fileio/chaser/exportChaserRegistry.h>
 #include <mayaUsd/fileio/registryHelper.h>
@@ -65,19 +67,92 @@ public:
         return this->CallVirtual<>("PostExport", &This::default_PostExport)();
     }
 
+    //---------------------------------------------------------------------------------------------
+    /// \brief  wraps a factory function that allows registering an updated Python class
+    //---------------------------------------------------------------------------------------------
+    class FactoryFnWrapper : public UsdMayaPythonObjectRegistry
+    {
+    public:
+        // Instances of this class act as "function objects" that are fully compatible with the
+        // std::function requested by UsdMayaSchemaApiAdaptorRegistry::Register. These will create
+        // python wrappers based on the latest Class registered.
+        UsdMayaExportChaser*
+        operator()(const UsdMayaExportChaserRegistry::FactoryContext& factoryContext)
+        {
+            boost::python::object pyClass = GetPythonObject(_classIndex);
+            if (!pyClass) {
+                // Prototype was unregistered
+                return nullptr;
+            }
+            auto                  chaser = new ExportChaserWrapper();
+            TfPyLock              pyLock;
+            boost::python::object instance = pyClass(factoryContext, (uintptr_t)chaser);
+            boost::python::incref(instance.ptr());
+            initialize_wrapper(instance.ptr(), chaser);
+            return chaser;
+        }
+
+        // Create a new wrapper for a Python class that is seen for the first time for a given
+        // purpose. It we already have a registration for this purpose: update the class to
+        // allow the previously issued factory function to use it.
+        static UsdMayaExportChaserRegistry::FactoryFn
+        Register(boost::python::object cl, const std::string& mayaTypeName)
+        {
+            size_t classIndex = RegisterPythonObject(cl, GetKey(cl, mayaTypeName));
+            if (classIndex != UsdMayaPythonObjectRegistry::UPDATED) {
+                // Return a new factory function:
+                return FactoryFnWrapper { classIndex };
+            } else {
+                // We already registered a factory function for this purpose:
+                return nullptr;
+            }
+        }
+
+        // Unregister a class for a given purpose. This will cause the associated factory
+        // function to stop producing this Python class.
+        static void Unregister(boost::python::object cl, const std::string& mayaTypeName)
+        {
+            UnregisterPythonObject(cl, GetKey(cl, mayaTypeName));
+        }
+
+    private:
+        // Function object constructor. Requires only the index of the Python class to use.
+        FactoryFnWrapper(size_t classIndex)
+            : _classIndex(classIndex) {};
+
+        size_t _classIndex;
+
+        // Generates a unique key based on the name of the class, along with the class
+        // purpose:
+        static std::string GetKey(boost::python::object cl, const std::string& mayaTypeName)
+        {
+            // Is it a Python class:
+            if (!IsPythonClass(cl)) {
+                TfPyThrowRuntimeError("First argument must be a Python class");
+            }
+
+            auto nameAttr = cl.attr("__name__");
+            if (!nameAttr) {
+                TfPyThrowRuntimeError("Unexpected Python error: No __name__ attribute");
+            }
+
+            std::string key = boost::python::extract<std::string>(nameAttr);
+            key = key + "," + mayaTypeName + "," + ",ExportChaser";
+            return key;
+        }
+    };
+
     static void Register(boost::python::object cl, const std::string& mayaTypeName)
     {
-        UsdMayaExportChaserRegistry::GetInstance().RegisterFactory(
-            mayaTypeName,
-            [=](const UsdMayaExportChaserRegistry::FactoryContext& factoryContext) {
-                auto                  chaser = new ExportChaserWrapper();
-                TfPyLock              pyLock;
-                boost::python::object instance = cl(factoryContext, (uintptr_t)chaser);
-                boost::python::incref(instance.ptr());
-                initialize_wrapper(instance.ptr(), chaser);
-                return chaser;
-            },
-            true);
+        UsdMayaExportChaserRegistry::FactoryFn fn = FactoryFnWrapper::Register(cl, mayaTypeName);
+        if (fn) {
+            UsdMayaExportChaserRegistry::GetInstance().RegisterFactory(mayaTypeName, fn, true);
+        }
+    }
+
+    static void Unregister(boost::python::object cl, const std::string& mayaTypeName)
+    {
+        FactoryFnWrapper::Unregister(cl, mayaTypeName);
     }
 };
 
@@ -109,5 +184,7 @@ void wrapExportChaser()
         .def("ExportFrame", &This::ExportFrame, &ExportChaserWrapper::default_ExportFrame)
         .def("PostExport", &This::PostExport, &ExportChaserWrapper::default_PostExport)
         .def("Register", &ExportChaserWrapper::Register)
-        .staticmethod("Register");
+        .staticmethod("Register")
+        .def("Unregister", &ExportChaserWrapper::Unregister)
+        .staticmethod("Unregister");
 }

--- a/lib/mayaUsd/python/wrapImportChaser.cpp
+++ b/lib/mayaUsd/python/wrapImportChaser.cpp
@@ -101,7 +101,7 @@ public:
         }
 
         // Create a new wrapper for a Python class that is seen for the first time for a given
-        // purpose. It we already have a registration for this purpose: update the class to
+        // purpose. If we already have a registration for this purpose: update the class to
         // allow the previously issued factory function to use it.
         static UsdMayaImportChaserRegistry::FactoryFn
         Register(boost::python::object cl, const std::string& mayaTypeName)

--- a/lib/mayaUsd/python/wrapImportChaser.cpp
+++ b/lib/mayaUsd/python/wrapImportChaser.cpp
@@ -134,19 +134,7 @@ public:
         // purpose:
         static std::string GetKey(boost::python::object cl, const std::string& mayaTypeName)
         {
-            // Is it a Python class:
-            if (!IsPythonClass(cl)) {
-                TfPyThrowRuntimeError("First argument must be a Python class");
-            }
-
-            auto nameAttr = cl.attr("__name__");
-            if (!nameAttr) {
-                TfPyThrowRuntimeError("Unexpected Python error: No __name__ attribute");
-            }
-
-            std::string key = boost::python::extract<std::string>(nameAttr);
-            key = key + "," + mayaTypeName + "," + ",ImportChaser";
-            return key;
+            return ClassName(cl) + "," + mayaTypeName + "," + ",ImportChaser";
         }
     };
 

--- a/lib/mayaUsd/python/wrapPrimReader.cpp
+++ b/lib/mayaUsd/python/wrapPrimReader.cpp
@@ -146,19 +146,7 @@ public:
         // purpose:
         static std::string GetKey(boost::python::object cl, const std::string& typeName)
         {
-            // Is it a Python class:
-            if (!IsPythonClass(cl)) {
-                TfPyThrowRuntimeError("First argument must be a Python class");
-            }
-
-            auto nameAttr = cl.attr("__name__");
-            if (!nameAttr) {
-                TfPyThrowRuntimeError("Unexpected Python error: No __name__ attribute");
-            }
-
-            std::string key = boost::python::extract<std::string>(nameAttr);
-            key = key + "," + typeName + "," + ",PrimReader";
-            return key;
+            return ClassName(cl) + "," + typeName + "," + ",PrimReader";
         }
     };
 
@@ -358,19 +346,7 @@ public:
         // purpose:
         static std::string GetKey(boost::python::object cl, const std::string& usdShaderId)
         {
-            // Is it a Python class:
-            if (!IsPythonClass(cl)) {
-                TfPyThrowRuntimeError("First argument must be a Python class");
-            }
-
-            auto nameAttr = cl.attr("__name__");
-            if (!nameAttr) {
-                TfPyThrowRuntimeError("Unexpected Python error: No __name__ attribute");
-            }
-
-            std::string key = boost::python::extract<std::string>(nameAttr);
-            key = key + "," + usdShaderId + "," + ",ShaderReader";
-            return key;
+            return ClassName(cl) + "," + usdShaderId + "," + ",ShaderReader";
         }
     };
 

--- a/lib/mayaUsd/python/wrapPrimReader.cpp
+++ b/lib/mayaUsd/python/wrapPrimReader.cpp
@@ -113,7 +113,7 @@ public:
         }
 
         // Create a new wrapper for a Python class that is seen for the first time for a given
-        // purpose. It we already have a registration for this purpose: update the class to
+        // purpose. If we already have a registration for this purpose: update the class to
         // allow the previously issued factory function to use it.
         static UsdMayaPrimReaderRegistry::ReaderFactoryFn
         Register(boost::python::object cl, const std::string& typeName)
@@ -317,7 +317,7 @@ public:
         }
 
         // Create a new wrapper for a Python class that is seen for the first time for a given
-        // purpose. It we already have a registration for this purpose: update the class to
+        // purpose. If we already have a registration for this purpose: update the class to
         // allow the previously issued factory function to use it.
         static FactoryFnWrapper
         Register(boost::python::object cl, const std::string& usdShaderId, bool& updated)

--- a/lib/mayaUsd/python/wrapPrimReader.cpp
+++ b/lib/mayaUsd/python/wrapPrimReader.cpp
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+#include "pythonObjectRegistry.h"
+
 #include <mayaUsd/fileio/primReader.h>
 #include <mayaUsd/fileio/primReaderRegistry.h>
 #include <mayaUsd/fileio/registryHelper.h>
@@ -86,20 +88,92 @@ public:
     // UsdMayaPrimReader
     const UsdMayaPrimReaderArgs& _GetArgs() { return base_t::_GetArgs(); }
 
+    //---------------------------------------------------------------------------------------------
+    /// \brief  wraps a factory function that allows registering an updated Python class
+    //---------------------------------------------------------------------------------------------
+    class FactoryFnWrapper : public UsdMayaPythonObjectRegistry
+    {
+    public:
+        // Instances of this class act as "function objects" that are fully compatible with the
+        // std::function requested by UsdMayaSchemaApiAdaptorRegistry::Register. These will create
+        // python wrappers based on the latest class registered.
+        UsdMayaPrimReaderSharedPtr operator()(const UsdMayaPrimReaderArgs& args)
+        {
+            boost::python::object pyClass = GetPythonObject(_classIndex);
+            if (!pyClass) {
+                // Prototype was unregistered
+                return nullptr;
+            }
+            auto                  sptr = std::make_shared<This>(args);
+            TfPyLock              pyLock;
+            boost::python::object instance = pyClass((uintptr_t)&sptr);
+            boost::python::incref(instance.ptr());
+            initialize_wrapper(instance.ptr(), sptr.get());
+            return sptr;
+        }
+
+        // Create a new wrapper for a Python class that is seen for the first time for a given
+        // purpose. It we already have a registration for this purpose: update the class to
+        // allow the previously issued factory function to use it.
+        static UsdMayaPrimReaderRegistry::ReaderFactoryFn
+        Register(boost::python::object cl, const std::string& typeName)
+        {
+            size_t classIndex = RegisterPythonObject(cl, GetKey(cl, typeName));
+            if (classIndex != UsdMayaPythonObjectRegistry::UPDATED) {
+                // Return a new factory function:
+                return FactoryFnWrapper { classIndex };
+            } else {
+                // We already registered a factory function for this purpose:
+                return nullptr;
+            }
+        }
+
+        // Unregister a class for a given purpose. This will cause the associated factory
+        // function to stop producing this Python class.
+        static void Unregister(boost::python::object cl, const std::string& typeName)
+        {
+            UnregisterPythonObject(cl, GetKey(cl, typeName));
+        }
+
+    private:
+        // Function object constructor. Requires only the index of the Python class to use.
+        FactoryFnWrapper(size_t classIndex)
+            : _classIndex(classIndex) {};
+
+        size_t _classIndex;
+
+        // Generates a unique key based on the name of the class, along with the class
+        // purpose:
+        static std::string GetKey(boost::python::object cl, const std::string& typeName)
+        {
+            // Is it a Python class:
+            if (!IsPythonClass(cl)) {
+                TfPyThrowRuntimeError("First argument must be a Python class");
+            }
+
+            auto nameAttr = cl.attr("__name__");
+            if (!nameAttr) {
+                TfPyThrowRuntimeError("Unexpected Python error: No __name__ attribute");
+            }
+
+            std::string key = boost::python::extract<std::string>(nameAttr);
+            key = key + "," + typeName + "," + ",PrimReader";
+            return key;
+        }
+    };
+
     static void Register(boost::python::object cl, const std::string& typeName)
     {
-        auto type = TfType::FindByName(typeName);
-        UsdMayaPrimReaderRegistry::Register(
-            type,
-            [=](const UsdMayaPrimReaderArgs& args) {
-                auto                  sptr = std::make_shared<This>(args);
-                TfPyLock              pyLock;
-                boost::python::object instance = cl((uintptr_t)&sptr);
-                boost::python::incref(instance.ptr());
-                initialize_wrapper(instance.ptr(), sptr.get());
-                return sptr;
-            },
-            true);
+        UsdMayaPrimReaderRegistry::ReaderFactoryFn fn = FactoryFnWrapper::Register(cl, typeName);
+        if (fn) {
+            auto type = TfType::FindByName(typeName);
+            UsdMayaPrimReaderRegistry::Register(type, fn, true);
+        }
+    }
+
+    static void Unregister(boost::python::object cl, const std::string& typeName)
+    {
+        FactoryFnWrapper::Unregister(cl, typeName);
     }
 };
 
@@ -211,30 +285,107 @@ public:
 
     std::shared_ptr<UsdMayaShaderReader> GetDownstreamReader() { return _downstreamReader; }
 
+    //---------------------------------------------------------------------------------------------
+    /// \brief  wraps a factory function that allows registering an updated Python class
+    //---------------------------------------------------------------------------------------------
+    class FactoryFnWrapper : public UsdMayaPythonObjectRegistry
+    {
+    public:
+        // Instances of this class act as "function objects" that are fully compatible with the
+        // std::function requested by UsdMayaSchemaApiAdaptorRegistry::Register. These will create
+        // python wrappers based on the latest class registered.
+        UsdMayaPrimReaderSharedPtr operator()(const UsdMayaPrimReaderArgs& args)
+        {
+            boost::python::object pyClass = GetPythonObject(_classIndex);
+            if (!pyClass) {
+                // Prototype was unregistered
+                return nullptr;
+            }
+            auto                  sptr = std::make_shared<This>(args);
+            TfPyLock              pyLock;
+            boost::python::object instance = pyClass((uintptr_t)&sptr);
+            boost::python::incref(instance.ptr());
+            initialize_wrapper(instance.ptr(), sptr.get());
+            return sptr;
+        }
+
+        // We can have multiple function objects, this one apapts the CanImport function:
+        UsdMayaShaderReader::ContextSupport operator()(const UsdMayaJobImportArgs& args)
+        {
+            boost::python::object pyClass = GetPythonObject(_classIndex);
+            if (!pyClass) {
+                // Prototype was unregistered
+                return UsdMayaShaderReader::ContextSupport::Unsupported;
+            }
+            TfPyLock pyLock;
+            if (PyObject_HasAttrString(pyClass.ptr(), "CanImport")) {
+                boost::python::object CanImport = pyClass.attr("CanImport");
+                PyObject*             callable = CanImport.ptr();
+                auto                  res = boost::python::call<int>(callable, args);
+                return UsdMayaShaderReader::ContextSupport(res);
+            } else {
+                return UsdMayaShaderReader::CanImport(args);
+            }
+        }
+
+        // Create a new wrapper for a Python class that is seen for the first time for a given
+        // purpose. It we already have a registration for this purpose: update the class to
+        // allow the previously issued factory function to use it.
+        static FactoryFnWrapper
+        Register(boost::python::object cl, const std::string& usdShaderId, bool& updated)
+        {
+            size_t classIndex = RegisterPythonObject(cl, GetKey(cl, usdShaderId));
+            updated = classIndex == UsdMayaPythonObjectRegistry::UPDATED;
+            // Return a new factory function:
+            return FactoryFnWrapper { classIndex };
+        }
+
+        // Unregister a class for a given purpose. This will cause the associated factory
+        // function to stop producing this Python class.
+        static void Unregister(boost::python::object cl, const std::string& usdShaderId)
+        {
+            UnregisterPythonObject(cl, GetKey(cl, usdShaderId));
+        }
+
+    private:
+        // Function object constructor. Requires only the index of the Python class to use.
+        FactoryFnWrapper(size_t classIndex)
+            : _classIndex(classIndex) {};
+
+        size_t _classIndex;
+
+        // Generates a unique key based on the name of the class, along with the class
+        // purpose:
+        static std::string GetKey(boost::python::object cl, const std::string& usdShaderId)
+        {
+            // Is it a Python class:
+            if (!IsPythonClass(cl)) {
+                TfPyThrowRuntimeError("First argument must be a Python class");
+            }
+
+            auto nameAttr = cl.attr("__name__");
+            if (!nameAttr) {
+                TfPyThrowRuntimeError("Unexpected Python error: No __name__ attribute");
+            }
+
+            std::string key = boost::python::extract<std::string>(nameAttr);
+            key = key + "," + usdShaderId + "," + ",ShaderReader";
+            return key;
+        }
+    };
+
     static void Register(boost::python::object cl, const TfToken& usdShaderId)
     {
-        UsdMayaShaderReaderRegistry::Register(
-            usdShaderId,
-            [=](const UsdMayaJobImportArgs& args) {
-                TfPyLock pyLock;
-                if (PyObject_HasAttrString(cl.ptr(), "CanImport")) {
-                    boost::python::object CanImport = cl.attr("CanImport");
-                    PyObject*             callable = CanImport.ptr();
-                    auto                  res = boost::python::call<int>(callable, args);
-                    return UsdMayaShaderReader::ContextSupport(res);
-                } else {
-                    return UsdMayaShaderReader::CanImport(args);
-                }
-            },
-            [=](const UsdMayaPrimReaderArgs& args) {
-                auto                  sptr = std::make_shared<This>(args);
-                TfPyLock              pyLock;
-                boost::python::object instance = cl((uintptr_t)&sptr);
-                boost::python::incref(instance.ptr());
-                initialize_wrapper(instance.ptr(), sptr.get());
-                return sptr;
-            },
-            true);
+        bool             updated = false;
+        FactoryFnWrapper fn = FactoryFnWrapper::Register(cl, usdShaderId, updated);
+        if (!updated) {
+            UsdMayaShaderReaderRegistry::Register(usdShaderId, fn, fn, true);
+        }
+    }
+
+    static void Unregister(boost::python::object cl, const TfToken& usdShaderId)
+    {
+        FactoryFnWrapper::Unregister(cl, usdShaderId);
     }
 
     static void RegisterSymmetric(
@@ -389,7 +540,9 @@ void wrapPrimReader()
             &PrimReaderWrapper<>::default_PostReadSubtree)
         .def("_GetArgs", &PrimReaderWrapper<>::_GetArgs, return_internal_reference<>())
         .def("Register", &PrimReaderWrapper<>::Register)
-        .staticmethod("Register");
+        .staticmethod("Register")
+        .def("Unregister", &PrimReaderWrapper<>::Unregister)
+        .staticmethod("Unregister");
 }
 
 TF_REGISTRY_FUNCTION(TfEnum)
@@ -436,6 +589,8 @@ void wrapShaderReader()
 
         .def("Register", &ShaderReaderWrapper::Register)
         .staticmethod("Register")
+        .def("Unregister", &ShaderReaderWrapper::Unregister)
+        .staticmethod("Unregister")
         .def("RegisterSymmetric", &ShaderReaderWrapper::RegisterSymmetric)
         .staticmethod("RegisterSymmetric");
 

--- a/lib/mayaUsd/python/wrapPrimUpdater.cpp
+++ b/lib/mayaUsd/python/wrapPrimUpdater.cpp
@@ -188,20 +188,8 @@ public:
             const std::string&    mayaType,
             int                   sup)
         {
-            // Is it a Python class:
-            if (!IsPythonClass(cl)) {
-                TfPyThrowRuntimeError("First argument must be a Python class");
-            }
-
-            auto nameAttr = cl.attr("__name__");
-            if (!nameAttr) {
-                TfPyThrowRuntimeError("Unexpected Python error: No __name__ attribute");
-            }
-
-            std::string key = boost::python::extract<std::string>(nameAttr);
-            key = key + "," + usdTypeName + "," + mayaType + "," + std::to_string(sup)
+            return ClassName(cl) + "," + usdTypeName + "," + mayaType + "," + std::to_string(sup)
                 + ",PrimUpdater";
-            return key;
         }
     };
 

--- a/lib/mayaUsd/python/wrapPrimUpdater.cpp
+++ b/lib/mayaUsd/python/wrapPrimUpdater.cpp
@@ -144,7 +144,7 @@ public:
         }
 
         // Create a new wrapper for a Python class that is seen for the first time for a given
-        // purpose. It we already have a registration for this purpose: update the class to
+        // purpose. If we already have a registration for this purpose: update the class to
         // allow the previously issued factory function to use it.
         static UsdMayaPrimUpdaterRegistry::UpdaterFactoryFn Register(
             boost::python::object cl,

--- a/lib/mayaUsd/python/wrapPrimWriter.cpp
+++ b/lib/mayaUsd/python/wrapPrimWriter.cpp
@@ -207,7 +207,7 @@ public:
         }
 
         // Create a new wrapper for a Python class that is seen for the first time for a given
-        // purpose. It we already have a registration for this purpose: update the class to
+        // purpose. If we already have a registration for this purpose: update the class to
         // allow the previously issued factory function to use it.
         static UsdMayaPrimWriterRegistry::WriterFactoryFn
         Register(boost::python::object cl, const std::string& mayaTypeName)
@@ -352,7 +352,7 @@ public:
         }
 
         // Create a new wrapper for a Python class that is seen for the first time for a given
-        // purpose. It we already have a registration for this purpose: update the class to
+        // purpose. If we already have a registration for this purpose: update the class to
         // allow the previously issued factory function to use it.
         static FactoryFnWrapper
         Register(boost::python::object cl, const std::string& usdShaderId, bool& updated)

--- a/lib/mayaUsd/python/wrapPrimWriter.cpp
+++ b/lib/mayaUsd/python/wrapPrimWriter.cpp
@@ -240,19 +240,7 @@ public:
         // purpose:
         static std::string GetKey(boost::python::object cl, const std::string& mayaTypeName)
         {
-            // Is it a Python class:
-            if (!IsPythonClass(cl)) {
-                TfPyThrowRuntimeError("First argument must be a Python class");
-            }
-
-            auto nameAttr = cl.attr("__name__");
-            if (!nameAttr) {
-                TfPyThrowRuntimeError("Unexpected Python error: No __name__ attribute");
-            }
-
-            std::string key = boost::python::extract<std::string>(nameAttr);
-            key = key + "," + mayaTypeName + "," + ",PrimWriter";
-            return key;
+            return ClassName(cl) + "," + mayaTypeName + "," + ",PrimWriter";
         }
     };
 
@@ -393,19 +381,7 @@ public:
         // purpose:
         static std::string GetKey(boost::python::object cl, const std::string& usdShaderId)
         {
-            // Is it a Python class:
-            if (!IsPythonClass(cl)) {
-                TfPyThrowRuntimeError("First argument must be a Python class");
-            }
-
-            auto nameAttr = cl.attr("__name__");
-            if (!nameAttr) {
-                TfPyThrowRuntimeError("Unexpected Python error: No __name__ attribute");
-            }
-
-            std::string key = boost::python::extract<std::string>(nameAttr);
-            key = key + "," + usdShaderId + "," + ",ShaderWriter";
-            return key;
+            return ClassName(cl) + "," + usdShaderId + "," + ",ShaderWriter";
         }
     };
 

--- a/lib/mayaUsd/python/wrapPrimWriter.cpp
+++ b/lib/mayaUsd/python/wrapPrimWriter.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+#include "pythonObjectRegistry.h"
 #include "wrapSparseValueWriter.h"
 
 #include <mayaUsd/fileio/primWriter.h>
@@ -178,21 +179,95 @@ public:
         return This::default_GetDagToUsdPathMapping();
     }
 
+    //---------------------------------------------------------------------------------------------
+    /// \brief  wraps a factory function that allows registering an updated Python class
+    //---------------------------------------------------------------------------------------------
+    class FactoryFnWrapper : public UsdMayaPythonObjectRegistry
+    {
+    public:
+        // Instances of this class act as "function objects" that are fully compatible with the
+        // std::function requested by UsdMayaSchemaApiAdaptorRegistry::Register. These will create
+        // python wrappers based on the latest class registered.
+        UsdMayaPrimWriterSharedPtr operator()(
+            const MFnDependencyNode& depNodeFn,
+            const SdfPath&           usdPath,
+            UsdMayaWriteJobContext&  jobCtx)
+        {
+            boost::python::object pyClass = GetPythonObject(_classIndex);
+            if (!pyClass) {
+                // Prototype was unregistered
+                return nullptr;
+            }
+            auto                  sptr = std::make_shared<This>(depNodeFn, usdPath, jobCtx);
+            TfPyLock              pyLock;
+            boost::python::object instance = pyClass((uintptr_t)&sptr);
+            boost::python::incref(instance.ptr());
+            initialize_wrapper(instance.ptr(), sptr.get());
+            return sptr;
+        }
+
+        // Create a new wrapper for a Python class that is seen for the first time for a given
+        // purpose. It we already have a registration for this purpose: update the class to
+        // allow the previously issued factory function to use it.
+        static UsdMayaPrimWriterRegistry::WriterFactoryFn
+        Register(boost::python::object cl, const std::string& mayaTypeName)
+        {
+            size_t classIndex = RegisterPythonObject(cl, GetKey(cl, mayaTypeName));
+            if (classIndex != UsdMayaPythonObjectRegistry::UPDATED) {
+                // Return a new factory function:
+                return FactoryFnWrapper { classIndex };
+            } else {
+                // We already registered a factory function for this purpose:
+                return nullptr;
+            }
+        }
+
+        // Unregister a class for a given purpose. This will cause the associated factory
+        // function to stop producing this Python class.
+        static void Unregister(boost::python::object cl, const std::string& mayaTypeName)
+        {
+            UnregisterPythonObject(cl, GetKey(cl, mayaTypeName));
+        }
+
+    private:
+        // Function object constructor. Requires only the index of the Python class to use.
+        FactoryFnWrapper(size_t classIndex)
+            : _classIndex(classIndex) {};
+
+        size_t _classIndex;
+
+        // Generates a unique key based on the name of the class, along with the class
+        // purpose:
+        static std::string GetKey(boost::python::object cl, const std::string& mayaTypeName)
+        {
+            // Is it a Python class:
+            if (!IsPythonClass(cl)) {
+                TfPyThrowRuntimeError("First argument must be a Python class");
+            }
+
+            auto nameAttr = cl.attr("__name__");
+            if (!nameAttr) {
+                TfPyThrowRuntimeError("Unexpected Python error: No __name__ attribute");
+            }
+
+            std::string key = boost::python::extract<std::string>(nameAttr);
+            key = key + "," + mayaTypeName + "," + ",PrimWriter";
+            return key;
+        }
+    };
+
     static void Register(boost::python::object cl, const std::string& mayaTypeName)
     {
-        UsdMayaPrimWriterRegistry::Register(
-            mayaTypeName,
-            [=](const MFnDependencyNode& depNodeFn,
-                const SdfPath&           usdPath,
-                UsdMayaWriteJobContext&  jobCtx) {
-                auto                  sptr = std::make_shared<This>(depNodeFn, usdPath, jobCtx);
-                TfPyLock              pyLock;
-                boost::python::object instance = cl((uintptr_t)&sptr);
-                boost::python::incref(instance.ptr());
-                initialize_wrapper(instance.ptr(), sptr.get());
-                return sptr;
-            },
-            true);
+        UsdMayaPrimWriterRegistry::WriterFactoryFn fn
+            = FactoryFnWrapper::Register(cl, mayaTypeName);
+        if (fn) {
+            UsdMayaPrimWriterRegistry::Register(mayaTypeName, fn, true);
+        }
+    }
+
+    static void Unregister(boost::python::object cl, const std::string& mayaTypeName)
+    {
+        FactoryFnWrapper::Unregister(cl, mayaTypeName);
     }
 
 private:
@@ -250,28 +325,102 @@ public:
             &This::default_GetShadingAttributeForMayaAttrName)(mayaAttrName, typeName);
     }
 
-    static void Register(boost::python::object cl, const TfToken& mayaNodeTypeName)
+    //---------------------------------------------------------------------------------------------
+    /// \brief  wraps a factory function that allows registering an updated Python class
+    //---------------------------------------------------------------------------------------------
+    class FactoryFnWrapper : public UsdMayaPythonObjectRegistry
     {
-        UsdMayaShaderWriterRegistry::Register(
-            mayaNodeTypeName,
-            [=](const UsdMayaJobExportArgs& exportArgs) {
-                TfPyLock              pyLock;
-                boost::python::object CanExport = cl.attr("CanExport");
-                PyObject*             callable = CanExport.ptr();
-                auto                  res = boost::python::call<int>(callable, exportArgs);
-                return UsdMayaShaderWriter::ContextSupport(res);
-            },
-            [=](const MFnDependencyNode& depNodeFn,
-                const SdfPath&           usdPath,
-                UsdMayaWriteJobContext&  jobCtx) {
-                auto                  sptr = std::make_shared<This>(depNodeFn, usdPath, jobCtx);
-                TfPyLock              pyLock;
-                boost::python::object instance = cl((uintptr_t)&sptr);
-                boost::python::incref(instance.ptr());
-                initialize_wrapper(instance.ptr(), sptr.get());
-                return sptr;
-            },
-            true);
+    public:
+        // Instances of this class act as "function objects" that are fully compatible with the
+        // std::function requested by UsdMayaSchemaApiAdaptorRegistry::Register. These will create
+        // python wrappers based on the latest class registered.
+        UsdMayaShaderWriterSharedPtr operator()(
+            const MFnDependencyNode& depNodeFn,
+            const SdfPath&           usdPath,
+            UsdMayaWriteJobContext&  jobCtx)
+        {
+            boost::python::object pyClass = GetPythonObject(_classIndex);
+            auto                  sptr = std::make_shared<This>(depNodeFn, usdPath, jobCtx);
+            TfPyLock              pyLock;
+            boost::python::object instance = pyClass((uintptr_t)&sptr);
+            boost::python::incref(instance.ptr());
+            initialize_wrapper(instance.ptr(), sptr.get());
+            return sptr;
+        }
+
+        // We can have multiple function objects, this one apapts the CanImport function:
+        UsdMayaShaderWriter::ContextSupport operator()(const UsdMayaJobExportArgs& exportArgs)
+        {
+            boost::python::object pyClass = GetPythonObject(_classIndex);
+            if (!pyClass) {
+                // Prototype was unregistered
+                return UsdMayaShaderWriter::ContextSupport::Unsupported;
+            }
+            TfPyLock              pyLock;
+            boost::python::object CanExport = pyClass.attr("CanExport");
+            PyObject*             callable = CanExport.ptr();
+            auto                  res = boost::python::call<int>(callable, exportArgs);
+            return UsdMayaShaderWriter::ContextSupport(res);
+        }
+
+        // Create a new wrapper for a Python class that is seen for the first time for a given
+        // purpose. It we already have a registration for this purpose: update the class to
+        // allow the previously issued factory function to use it.
+        static FactoryFnWrapper
+        Register(boost::python::object cl, const std::string& usdShaderId, bool& updated)
+        {
+            size_t classIndex = RegisterPythonObject(cl, GetKey(cl, usdShaderId));
+            updated = classIndex == UsdMayaPythonObjectRegistry::UPDATED;
+            // Return a new factory function:
+            return FactoryFnWrapper { classIndex };
+        }
+
+        // Unregister a class for a given purpose. This will cause the associated factory
+        // function to stop producing this Python class.
+        static void Unregister(boost::python::object cl, const std::string& usdShaderId)
+        {
+            UnregisterPythonObject(cl, GetKey(cl, usdShaderId));
+        }
+
+    private:
+        // Function object constructor. Requires only the index of the Python class to use.
+        FactoryFnWrapper(size_t classIndex)
+            : _classIndex(classIndex) {};
+
+        size_t _classIndex;
+
+        // Generates a unique key based on the name of the class, along with the class
+        // purpose:
+        static std::string GetKey(boost::python::object cl, const std::string& usdShaderId)
+        {
+            // Is it a Python class:
+            if (!IsPythonClass(cl)) {
+                TfPyThrowRuntimeError("First argument must be a Python class");
+            }
+
+            auto nameAttr = cl.attr("__name__");
+            if (!nameAttr) {
+                TfPyThrowRuntimeError("Unexpected Python error: No __name__ attribute");
+            }
+
+            std::string key = boost::python::extract<std::string>(nameAttr);
+            key = key + "," + usdShaderId + "," + ",ShaderWriter";
+            return key;
+        }
+    };
+
+    static void Register(boost::python::object cl, const TfToken& usdShaderId)
+    {
+        bool             updated = false;
+        FactoryFnWrapper fn = FactoryFnWrapper::Register(cl, usdShaderId, updated);
+        if (!updated) {
+            UsdMayaShaderWriterRegistry::Register(usdShaderId, fn, fn, true);
+        }
+    }
+
+    static void Unregister(boost::python::object cl, const TfToken& usdShaderId)
+    {
+        FactoryFnWrapper::Unregister(cl, usdShaderId);
     }
 
     static void RegisterSymmetric(
@@ -500,7 +649,9 @@ void wrapPrimWriter()
             boost::python::return_value_policy<boost::python::return_by_value>())
 
         .def("Register", &PrimWriterWrapper<>::Register)
-        .staticmethod("Register");
+        .staticmethod("Register")
+        .def("Unregister", &PrimWriterWrapper<>::Unregister)
+        .staticmethod("Unregister");
 }
 
 TF_REGISTRY_FUNCTION(TfEnum)
@@ -533,6 +684,8 @@ void wrapShaderWriter()
 
         .def("Register", &ShaderWriterWrapper::Register)
         .staticmethod("Register")
+        .def("Unregister", &ShaderWriterWrapper::Unregister)
+        .staticmethod("Unregister")
         .def("RegisterSymmetric", &ShaderWriterWrapper::RegisterSymmetric)
         .staticmethod("RegisterSymmetric");
 }

--- a/lib/mayaUsd/python/wrapSchemaApiAdaptor.cpp
+++ b/lib/mayaUsd/python/wrapSchemaApiAdaptor.cpp
@@ -245,7 +245,7 @@ public:
         }
 
         // Create a new wrapper for a Python class that is seen for the first time for a given
-        // purpose. It we already have a registration for this purpose: update the class to
+        // purpose. If we already have a registration for this purpose: update the class to
         // allow the previously issued factory function to use it.
         static UsdMayaSchemaApiAdaptorRegistry::AdaptorFactoryFn Register(
             boost::python::object cl,

--- a/lib/mayaUsd/python/wrapSchemaApiAdaptor.cpp
+++ b/lib/mayaUsd/python/wrapSchemaApiAdaptor.cpp
@@ -286,19 +286,7 @@ public:
             const std::string&    mayaType,
             const std::string&    schemaApiName)
         {
-            // Is it a Python class:
-            if (!IsPythonClass(cl)) {
-                TfPyThrowRuntimeError("First argument must be a Python class");
-            }
-
-            auto nameAttr = cl.attr("__name__");
-            if (!nameAttr) {
-                TfPyThrowRuntimeError("Unexpected Python error: No __name__ attribute");
-            }
-
-            std::string key = boost::python::extract<std::string>(nameAttr);
-            key = key + "," + mayaType + "," + schemaApiName + ",SchemaApiAdaptor";
-            return key;
+            return ClassName(cl) + "," + mayaType + "," + schemaApiName + ",SchemaApiAdaptor";
         }
     };
 


### PR DESCRIPTION
Allow updating class registrations while actively implementing prim reader/writer/updaters and all other
class-based MayaUSD Python workflows.