### PR TITLE
Write Sparsely when exporting mesh orientation

### DIFF
--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
@@ -834,7 +834,7 @@ void UsdMayaMeshWriteUtils::writeFaceVertexIndicesData(
     bool isLeftHanded = false;
     UsdMayaUtil::getPlugValue(meshFn, "opposite", &isLeftHanded);
     primSchema.CreateOrientationAttr(
-        VtValue(isLeftHanded ? UsdGeomTokens->leftHanded : UsdGeomTokens->rightHanded));
+        VtValue(isLeftHanded ? UsdGeomTokens->leftHanded : UsdGeomTokens->rightHanded), true);
 }
 
 void UsdMayaMeshWriteUtils::writeInvisibleFacesData(


### PR DESCRIPTION
Don't explicitly write mesh orientation attributes if they are set to
the default value (rightHanded)