### PR TITLE
MAYA-114898 fix merge UI option defaults.

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -776,6 +776,16 @@ bool PrimUpdaterManager::mergeToUsd(
     if (!isCopy && TF_VERIFY(ufeMayaItem))
         scene.notify(Ufe::ObjectPreDelete(ufeMayaItem));
 
+    if (!isCopy) {
+        FunctionUndoItem::execute(
+            "Merge to Maya rendering inclusion",
+            [pulledPath]() {
+                removeExcludeFromRendering(pulledPath);
+                return true;
+            },
+            [pulledPath]() { return addExcludeFromRendering(pulledPath); });
+    }
+
     // Record all USD modifications in an undo block and item.
     UsdUndoBlock undoBlock(
         &UsdUndoableItemUndoItem::create("Merge to Maya USD data modifications"));
@@ -796,16 +806,6 @@ bool PrimUpdaterManager::mergeToUsd(
         proxyStage,
         ctxArgs,
         std::get<UsdPathToDagPathMapPtr>(pushCustomizeSrc));
-
-    if (!isCopy) {
-        FunctionUndoItem::execute(
-            "Merge to Maya rendering inclusion",
-            [pulledPath]() {
-                removeExcludeFromRendering(pulledPath);
-                return true;
-            },
-            [pulledPath]() { return addExcludeFromRendering(pulledPath); });
-    }
 
     if (!pushCustomize(pulledPath, pushCustomizeSrc, customizeContext)) {
         return false;

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -776,16 +776,6 @@ bool PrimUpdaterManager::mergeToUsd(
     if (!isCopy && TF_VERIFY(ufeMayaItem))
         scene.notify(Ufe::ObjectPreDelete(ufeMayaItem));
 
-    if (!isCopy) {
-        FunctionUndoItem::execute(
-            "Merge to Maya rendering inclusion",
-            [pulledPath]() {
-                removeExcludeFromRendering(pulledPath);
-                return true;
-            },
-            [pulledPath]() { return addExcludeFromRendering(pulledPath); });
-    }
-
     // Record all USD modifications in an undo block and item.
     UsdUndoBlock undoBlock(
         &UsdUndoableItemUndoItem::create("Merge to Maya USD data modifications"));
@@ -806,6 +796,16 @@ bool PrimUpdaterManager::mergeToUsd(
         proxyStage,
         ctxArgs,
         std::get<UsdPathToDagPathMapPtr>(pushCustomizeSrc));
+
+    if (!isCopy) {
+        FunctionUndoItem::execute(
+            "Merge to Maya rendering inclusion",
+            [pulledPath]() {
+                removeExcludeFromRendering(pulledPath);
+                return true;
+            },
+            [pulledPath]() { return addExcludeFromRendering(pulledPath); });
+    }
 
     if (!pushCustomize(pulledPath, pushCustomizeSrc, customizeContext)) {
         return false;

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -613,7 +613,7 @@ global string $mayaUsdMergeToUsdOptions = "";
 
 proc string getMergeToUsdOptionsDefaultSettings()
 {
-    return "exportColorSets=1;exportUVs=1;exportSkels=0;exportSkin=0;exportBlendShapes=0;exportDisplayColor=1;shadingMode=none;animation=1;exportVisibility=1;exportInstances=1;mergeTransformAndShape=1;stripNamespaces=0";
+    return "exportColorSets=1;exportUVs=1;exportSkels=none;exportSkin=none;exportBlendShapes=0;exportDisplayColor=1;shadingMode=none;animation=1;exportVisibility=1;exportInstances=1;mergeTransformAndShape=1;stripNamespaces=0";
 }
 
 global proc mayaUsdMenu_pushBackToUSD(string $obj)

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -609,6 +609,13 @@ proc int isObjectSelected(string $obj)
     return 0;
 }
 
+global string $mayaUsdMergeToUsdOptions = "";
+
+proc string getMergeToUsdOptionsDefaultSettings()
+{
+    return "exportColorSets=1;exportUVs=1;exportSkels=0;exportSkin=0;exportBlendShapes=0;exportDisplayColor=1;shadingMode=none;animation=1;exportVisibility=1;exportInstances=1;mergeTransformAndShape=1;stripNamespaces=0";
+}
+
 global proc mayaUsdMenu_pushBackToUSD(string $obj)
 {
     if (!hasPrimUpdater())
@@ -621,11 +628,10 @@ global proc mayaUsdMenu_pushBackToUSD(string $obj)
         }
     }
     if (size($obj)) {
-        mayaUsdMergeToUsd -exportOptions "animation=0;shadingMode=none;exportSkels=0;exportSkin=0;exportBlendShapes=0" $obj;
+        string $exportOptions = getMergeToUsdOptionsDefaultSettings();
+        mayaUsdMergeToUsd -exportOptions $exportOptions $obj;
     }
 }
-
-global string $mayaUsdMergeToUsdOptions = "";
 
 global proc mayaUsdPushBackToUSDReceiveExportOptions(string $exportOptions)
 {
@@ -635,7 +641,8 @@ global proc mayaUsdPushBackToUSDReceiveExportOptions(string $exportOptions)
 
 global proc mayaUsdPushBackToUSDOptionsAccepted()
 {
-    mayaUsdTranslatorExport("", "query=all;!output;!animation-data", "", "mayaUsdPushBackToUSDReceiveExportOptions");
+    string $initialSettings = getMergeToUsdOptionsDefaultSettings();
+    mayaUsdTranslatorExport("", "query=all;!output;!animation-data", $initialSettings, "mayaUsdPushBackToUSDReceiveExportOptions");
     layoutDialog -dismiss "Merge";
 }
 
@@ -649,7 +656,8 @@ global proc mayaUsdShowPushBackToUSDOptions()
 
     setParent $subLayout;
 
-    mayaUsdTranslatorExport($subLayout, "post=all;!output;!animation-data", "animation=0;shadingMode=none;exportSkels=0;exportSkin=0;exportBlendShapes=0", "");
+    string $initialSettings = getMergeToUsdOptionsDefaultSettings();
+    mayaUsdTranslatorExport($subLayout, "post=all;!output;!animation-data", $initialSettings, "");
 
     setParent $form;
 


### PR DESCRIPTION
Also moved the re-activation of the edited prim before the merge in case deactivated prim would cause problems. (I'm frankly surprised it works when it was deactivated... it thought USD would ignore it.)