### PR TITLE
MAYA-121514 fix leaking node due to undo items being left behind.

### DIFF
--- a/lib/mayaUsd/listeners/notice.cpp
+++ b/lib/mayaUsd/listeners/notice.cpp
@@ -40,6 +40,13 @@ static void _OnMayaNewOrOpenSceneCallback(void* /*clientData*/)
     UsdMayaSceneResetNotice().Send();
 }
 
+static int _beforeSceneResetRegistrationCount = 0;
+
+static void _OnMayaBeforeResetCallback(void* /*clientData*/)
+{
+    UsdMayaBeforeSceneResetNotice().Send();
+}
+
 static int _exitRegistrationCount = 0;
 
 static void _OnMayaExitCallback(void* /*clientData*/)
@@ -97,6 +104,37 @@ void UsdMayaSceneResetNotice::RemoveListener()
 
     if (_beforeFileReadCallbackId == 0) {
         MMessage::removeCallback(_beforeFileReadCallbackId);
+    }
+}
+
+TF_INSTANTIATE_TYPE(UsdMayaBeforeSceneResetNotice, TfType::CONCRETE, TF_1_PARENT(TfNotice));
+
+MCallbackId UsdMayaBeforeSceneResetNotice::_beforeNewCallbackId = 0;
+
+UsdMayaBeforeSceneResetNotice::UsdMayaBeforeSceneResetNotice() { }
+
+/* static */
+void UsdMayaBeforeSceneResetNotice::InstallListener()
+{
+    if (_beforeSceneResetRegistrationCount++ > 0) {
+        return;
+    }
+
+    if (_beforeNewCallbackId == 0) {
+        _beforeNewCallbackId
+            = MSceneMessage::addCallback(MSceneMessage::kBeforeNew, _OnMayaBeforeResetCallback);
+    }
+}
+
+/* static */
+void UsdMayaBeforeSceneResetNotice::RemoveListener()
+{
+    if (_beforeSceneResetRegistrationCount-- > 1) {
+        return;
+    }
+
+    if (_beforeNewCallbackId != 0) {
+        MMessage::removeCallback(_beforeNewCallbackId);
     }
 }
 

--- a/lib/mayaUsd/listeners/notice.cpp
+++ b/lib/mayaUsd/listeners/notice.cpp
@@ -52,7 +52,7 @@ static void _OnMayaExitCallback(void* /*clientData*/)
 
 TF_INSTANTIATE_TYPE(UsdMayaSceneResetNotice, TfType::CONCRETE, TF_1_PARENT(TfNotice));
 
-MCallbackId UsdMayaSceneResetNotice::_beforeNewCallbackId = 0;
+MCallbackId UsdMayaSceneResetNotice::_afterNewCallbackId = 0;
 MCallbackId UsdMayaSceneResetNotice::_beforeFileReadCallbackId = 0;
 
 UsdMayaSceneResetNotice::UsdMayaSceneResetNotice() { }
@@ -73,9 +73,9 @@ void UsdMayaSceneResetNotice::InstallListener()
     // the new scene has been opened). However, they are also emitted when a
     // file is imported or referenced, so we check for that and do *not* send
     // a scene reset notice.
-    if (_beforeNewCallbackId == 0) {
-        _beforeNewCallbackId
-            = MSceneMessage::addCallback(MSceneMessage::kBeforeNew, _OnMayaNewOrOpenSceneCallback);
+    if (_afterNewCallbackId == 0) {
+        _afterNewCallbackId
+            = MSceneMessage::addCallback(MSceneMessage::kAfterNew, _OnMayaNewOrOpenSceneCallback);
     }
 
     if (_beforeFileReadCallbackId == 0) {
@@ -91,8 +91,8 @@ void UsdMayaSceneResetNotice::RemoveListener()
         return;
     }
 
-    if (_beforeNewCallbackId != 0) {
-        MMessage::removeCallback(_beforeNewCallbackId);
+    if (_afterNewCallbackId != 0) {
+        MMessage::removeCallback(_afterNewCallbackId);
     }
 
     if (_beforeFileReadCallbackId == 0) {

--- a/lib/mayaUsd/listeners/notice.h
+++ b/lib/mayaUsd/listeners/notice.h
@@ -44,7 +44,7 @@ public:
     static void RemoveListener();
 
 private:
-    static MCallbackId _beforeNewCallbackId;
+    static MCallbackId _afterNewCallbackId;
     static MCallbackId _beforeFileReadCallbackId;
 };
 

--- a/lib/mayaUsd/listeners/notice.h
+++ b/lib/mayaUsd/listeners/notice.h
@@ -29,12 +29,9 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// switching to a new scene.
 /// It is *very important* that you call InstallListener() during plugin
 /// initialization and removeListener() during plugin uninitialization.
-class UsdMayaSceneResetNotice : public TfNotice
+class UsdMayaNoticeListener
 {
 public:
-    MAYAUSD_CORE_PUBLIC
-    UsdMayaSceneResetNotice();
-
     /// Registers the proper Maya callbacks for recognizing stage resets.
     MAYAUSD_CORE_PUBLIC
     static void InstallListener();
@@ -44,8 +41,31 @@ public:
     static void RemoveListener();
 
 private:
+    static MCallbackId _beforeNewCallbackId;
     static MCallbackId _afterNewCallbackId;
     static MCallbackId _beforeFileReadCallbackId;
+    static MCallbackId _exitingCallbackId;
+};
+
+/// Notice sent when the Maya scene resets, either by opening a new scene or
+/// switching to a new scene.
+/// It is *very important* that you call InstallListener() during plugin
+/// initialization and removeListener() during plugin uninitialization.
+class UsdMayaSceneResetNotice : public TfNotice
+{
+public:
+    MAYAUSD_CORE_PUBLIC
+    UsdMayaSceneResetNotice() = default;
+};
+
+/// Notice sent before  Maya exit and before it reset the scene.
+/// It is *very important* that you call InstallListener() during plugin
+/// initialization and removeListener() during plugin uninitialization.
+class UsdMayaSceneBeforeResetNotice : public TfNotice
+{
+public:
+    MAYAUSD_CORE_PUBLIC
+    UsdMayaSceneBeforeResetNotice() = default;
 };
 
 class UsdMaya_AssemblyInstancerNoticeBase : public TfNotice

--- a/lib/mayaUsd/listeners/notice.h
+++ b/lib/mayaUsd/listeners/notice.h
@@ -29,9 +29,12 @@ PXR_NAMESPACE_OPEN_SCOPE
 /// switching to a new scene.
 /// It is *very important* that you call InstallListener() during plugin
 /// initialization and removeListener() during plugin uninitialization.
-class UsdMayaNoticeListener
+class UsdMayaSceneResetNotice : public TfNotice
 {
 public:
+    MAYAUSD_CORE_PUBLIC
+    UsdMayaSceneResetNotice();
+
     /// Registers the proper Maya callbacks for recognizing stage resets.
     MAYAUSD_CORE_PUBLIC
     static void InstallListener();
@@ -42,30 +45,28 @@ public:
 
 private:
     static MCallbackId _beforeNewCallbackId;
-    static MCallbackId _afterNewCallbackId;
     static MCallbackId _beforeFileReadCallbackId;
-    static MCallbackId _exitingCallbackId;
 };
 
-/// Notice sent when the Maya scene resets, either by opening a new scene or
-/// switching to a new scene.
+/// Notice sent when the Maya is about to exit.
 /// It is *very important* that you call InstallListener() during plugin
 /// initialization and removeListener() during plugin uninitialization.
-class UsdMayaSceneResetNotice : public TfNotice
+class UsdMayaExitNotice : public TfNotice
 {
 public:
     MAYAUSD_CORE_PUBLIC
-    UsdMayaSceneResetNotice() = default;
-};
+    UsdMayaExitNotice();
 
-/// Notice sent before  Maya exit and before it reset the scene.
-/// It is *very important* that you call InstallListener() during plugin
-/// initialization and removeListener() during plugin uninitialization.
-class UsdMayaSceneBeforeResetNotice : public TfNotice
-{
-public:
+    /// Registers the proper Maya callbacks for recognizing stage resets.
     MAYAUSD_CORE_PUBLIC
-    UsdMayaSceneBeforeResetNotice() = default;
+    static void InstallListener();
+
+    /// Removes any Maya callbacks for recognizing stage resets.
+    MAYAUSD_CORE_PUBLIC
+    static void RemoveListener();
+
+private:
+    static MCallbackId _beforeExitCallbackId;
 };
 
 class UsdMaya_AssemblyInstancerNoticeBase : public TfNotice

--- a/lib/mayaUsd/listeners/notice.h
+++ b/lib/mayaUsd/listeners/notice.h
@@ -48,6 +48,27 @@ private:
     static MCallbackId _beforeFileReadCallbackId;
 };
 
+/// Notice sent before the Maya scene resets.
+/// It is *very important* that you call InstallListener() during plugin
+/// initialization and removeListener() during plugin uninitialization.
+class UsdMayaBeforeSceneResetNotice : public TfNotice
+{
+public:
+    MAYAUSD_CORE_PUBLIC
+    UsdMayaBeforeSceneResetNotice();
+
+    /// Registers the proper Maya callbacks for recognizing stage resets.
+    MAYAUSD_CORE_PUBLIC
+    static void InstallListener();
+
+    /// Removes any Maya callbacks for recognizing stage resets.
+    MAYAUSD_CORE_PUBLIC
+    static void RemoveListener();
+
+private:
+    static MCallbackId _beforeNewCallbackId;
+};
+
 /// Notice sent when the Maya is about to exit.
 /// It is *very important* that you call InstallListener() during plugin
 /// initialization and removeListener() during plugin uninitialization.

--- a/lib/mayaUsd/undo/OpUndoItemList.cpp
+++ b/lib/mayaUsd/undo/OpUndoItemList.cpp
@@ -33,7 +33,7 @@ struct OnSceneResetListener : public PXR_NS::TfWeakBase
     {
         PXR_NS::TfWeakPtr<OnSceneResetListener> self(this);
         PXR_NS::TfNotice::Register(self, &OnSceneResetListener::OnSceneReset);
-        PXR_NS::TfNotice::Register(self, &OnSceneResetListener::OnSceneBeforeReset);
+        PXR_NS::TfNotice::Register(self, &OnSceneResetListener::OnMayaAboutToExit);
     }
 
     void OnSceneReset(const PXR_NS::UsdMayaSceneResetNotice& notice)
@@ -41,7 +41,7 @@ struct OnSceneResetListener : public PXR_NS::TfWeakBase
         OpUndoItemList::instance().clear();
     }
 
-    void OnSceneBeforeReset(const PXR_NS::UsdMayaSceneBeforeResetNotice& notice)
+    void OnMayaAboutToExit(const PXR_NS::UsdMayaExitNotice& notice)
     {
         OpUndoItemList::instance().clear();
     }

--- a/lib/mayaUsd/undo/OpUndoItemList.cpp
+++ b/lib/mayaUsd/undo/OpUndoItemList.cpp
@@ -33,9 +33,15 @@ struct OnSceneResetListener : public PXR_NS::TfWeakBase
     {
         PXR_NS::TfWeakPtr<OnSceneResetListener> self(this);
         PXR_NS::TfNotice::Register(self, &OnSceneResetListener::OnSceneReset);
+        PXR_NS::TfNotice::Register(self, &OnSceneResetListener::OnSceneBeforeReset);
     }
 
     void OnSceneReset(const PXR_NS::UsdMayaSceneResetNotice& notice)
+    {
+        OpUndoItemList::instance().clear();
+    }
+
+    void OnSceneBeforeReset(const PXR_NS::UsdMayaSceneBeforeResetNotice& notice)
     {
         OpUndoItemList::instance().clear();
     }

--- a/lib/mayaUsd/undo/OpUndoItemList.cpp
+++ b/lib/mayaUsd/undo/OpUndoItemList.cpp
@@ -34,6 +34,7 @@ struct OnSceneResetListener : public PXR_NS::TfWeakBase
         PXR_NS::TfWeakPtr<OnSceneResetListener> self(this);
         PXR_NS::TfNotice::Register(self, &OnSceneResetListener::OnSceneReset);
         PXR_NS::TfNotice::Register(self, &OnSceneResetListener::OnMayaAboutToExit);
+        PXR_NS::TfNotice::Register(self, &OnSceneResetListener::OnMayaAboutToResetScene);
     }
 
     void OnSceneReset(const PXR_NS::UsdMayaSceneResetNotice& notice)
@@ -42,6 +43,11 @@ struct OnSceneResetListener : public PXR_NS::TfWeakBase
     }
 
     void OnMayaAboutToExit(const PXR_NS::UsdMayaExitNotice& notice)
+    {
+        OpUndoItemList::instance().clear();
+    }
+
+    void OnMayaAboutToResetScene(const PXR_NS::UsdMayaBeforeSceneResetNotice& notice)
     {
         OpUndoItemList::instance().clear();
     }

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -333,7 +333,7 @@ MStatus initializePlugin(MObject obj)
 #endif
 #endif
 
-    UsdMayaSceneResetNotice::InstallListener();
+    UsdMayaNoticeListener::InstallListener();
     UsdMayaDiagnosticDelegate::InstallDelegate();
 
 #ifdef UFE_V3_FEATURES_AVAILABLE
@@ -439,7 +439,7 @@ MStatus uninitializePlugin(MObject obj)
 #endif
 #endif
 
-    UsdMayaSceneResetNotice::RemoveListener();
+    UsdMayaNoticeListener::RemoveListener();
     UsdMayaDiagnosticDelegate::RemoveDelegate();
 
     return status;

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -333,7 +333,8 @@ MStatus initializePlugin(MObject obj)
 #endif
 #endif
 
-    UsdMayaNoticeListener::InstallListener();
+    UsdMayaSceneResetNotice::InstallListener();
+    UsdMayaExitNotice::InstallListener();
     UsdMayaDiagnosticDelegate::InstallDelegate();
 
 #ifdef UFE_V3_FEATURES_AVAILABLE
@@ -439,7 +440,8 @@ MStatus uninitializePlugin(MObject obj)
 #endif
 #endif
 
-    UsdMayaNoticeListener::RemoveListener();
+    UsdMayaSceneResetNotice::RemoveListener();
+    UsdMayaExitNotice::RemoveListener();
     UsdMayaDiagnosticDelegate::RemoveDelegate();
 
     return status;

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -334,6 +334,7 @@ MStatus initializePlugin(MObject obj)
 #endif
 
     UsdMayaSceneResetNotice::InstallListener();
+    UsdMayaBeforeSceneResetNotice::InstallListener();
     UsdMayaExitNotice::InstallListener();
     UsdMayaDiagnosticDelegate::InstallDelegate();
 
@@ -441,6 +442,7 @@ MStatus uninitializePlugin(MObject obj)
 #endif
 
     UsdMayaSceneResetNotice::RemoveListener();
+    UsdMayaBeforeSceneResetNotice::RemoveListener();
     UsdMayaExitNotice::RemoveListener();
     UsdMayaDiagnosticDelegate::RemoveDelegate();
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/Global.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/Global.cpp
@@ -482,6 +482,7 @@ void Global::onPluginLoad()
 #endif
 
     UsdMayaSceneResetNotice::InstallListener();
+    UsdMayaBeforeSceneResetNotice::InstallListener();
     UsdMayaExitNotice::InstallListener();
 
     // For callback initialization for stage cache callback, it will be done via proxy node
@@ -514,6 +515,7 @@ void Global::onPluginUnload()
 #endif
 
     UsdMayaSceneResetNotice::RemoveListener();
+    UsdMayaBeforeSceneResetNotice::RemoveListener();
     UsdMayaExitNotice::RemoveListener();
 }
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/Global.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/Global.cpp
@@ -481,7 +481,8 @@ void Global::onPluginLoad()
     }
 #endif
 
-    UsdMayaNoticeListener::InstallListener();
+    UsdMayaSceneResetNotice::InstallListener();
+    UsdMayaExitNotice::InstallListener();
 
     // For callback initialization for stage cache callback, it will be done via proxy node
     // attribute change.
@@ -512,7 +513,8 @@ void Global::onPluginUnload()
     }
 #endif
 
-    UsdMayaNoticeListener::RemoveListener();
+    UsdMayaSceneResetNotice::RemoveListener();
+    UsdMayaExitNotice::RemoveListener();
 }
 
 void Global::openingFile(bool val)

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/Global.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/Global.cpp
@@ -481,7 +481,7 @@ void Global::onPluginLoad()
     }
 #endif
 
-    UsdMayaSceneResetNotice::InstallListener();
+    UsdMayaNoticeListener::InstallListener();
 
     // For callback initialization for stage cache callback, it will be done via proxy node
     // attribute change.
@@ -512,7 +512,7 @@ void Global::onPluginUnload()
     }
 #endif
 
-    UsdMayaSceneResetNotice::RemoveListener();
+    UsdMayaNoticeListener::RemoveListener();
 }
 
 void Global::openingFile(bool val)

--- a/plugin/pxr/maya/plugin/pxrUsd/plugin.cpp
+++ b/plugin/pxr/maya/plugin/pxrUsd/plugin.cpp
@@ -161,6 +161,7 @@ MStatus initializePlugin(MObject obj)
     }
 
     UsdMayaSceneResetNotice::InstallListener();
+    UsdMayaBeforeSceneResetNotice::InstallListener();
     UsdMayaExitNotice::InstallListener();
     UsdMayaDiagnosticDelegate::InstallDelegate();
 
@@ -246,6 +247,7 @@ MStatus uninitializePlugin(MObject obj)
     CHECK_MSTATUS(status);
 
     UsdMayaSceneResetNotice::RemoveListener();
+    UsdMayaBeforeSceneResetNotice::RemoveListener();
     UsdMayaExitNotice::RemoveListener();
     UsdMayaDiagnosticDelegate::RemoveDelegate();
 

--- a/plugin/pxr/maya/plugin/pxrUsd/plugin.cpp
+++ b/plugin/pxr/maya/plugin/pxrUsd/plugin.cpp
@@ -160,7 +160,8 @@ MStatus initializePlugin(MObject obj)
         status.perror("pxrUsd: unable to register USD Export translator.");
     }
 
-    UsdMayaNoticeListener::InstallListener();
+    UsdMayaSceneResetNotice::InstallListener();
+    UsdMayaExitNotice::InstallListener();
     UsdMayaDiagnosticDelegate::InstallDelegate();
 
     // As of 2-Aug-2019, these PlugPlugin translators are not loaded
@@ -244,7 +245,8 @@ MStatus uninitializePlugin(MObject obj)
     status = MayaUsdProxyShapePlugin::finalize(plugin);
     CHECK_MSTATUS(status);
 
-    UsdMayaNoticeListener::RemoveListener();
+    UsdMayaSceneResetNotice::RemoveListener();
+    UsdMayaExitNotice::RemoveListener();
     UsdMayaDiagnosticDelegate::RemoveDelegate();
 
     return status;

--- a/plugin/pxr/maya/plugin/pxrUsd/plugin.cpp
+++ b/plugin/pxr/maya/plugin/pxrUsd/plugin.cpp
@@ -160,7 +160,7 @@ MStatus initializePlugin(MObject obj)
         status.perror("pxrUsd: unable to register USD Export translator.");
     }
 
-    UsdMayaSceneResetNotice::InstallListener();
+    UsdMayaNoticeListener::InstallListener();
     UsdMayaDiagnosticDelegate::InstallDelegate();
 
     // As of 2-Aug-2019, these PlugPlugin translators are not loaded
@@ -244,7 +244,7 @@ MStatus uninitializePlugin(MObject obj)
     status = MayaUsdProxyShapePlugin::finalize(plugin);
     CHECK_MSTATUS(status);
 
-    UsdMayaSceneResetNotice::RemoveListener();
+    UsdMayaNoticeListener::RemoveListener();
     UsdMayaDiagnosticDelegate::RemoveDelegate();
 
     return status;

--- a/test/lib/mayaUsd/fileio/testCustomRig.py
+++ b/test/lib/mayaUsd/fileio/testCustomRig.py
@@ -193,8 +193,7 @@ class testCustomRig(unittest.TestCase):
         cmds.setKeyframe( "bob|pCube2.ty", time=10.0, value=10 )
         
         # Push the animation back to USD. This will use a custom logic that will write it to a new prim
-        with mayaUsdLib.OpUndoItemList():
-            self.assertTrue(mayaUsdLib.PrimUpdaterManager.mergeToUsd(bobMayaPathStr))
+        self.assertTrue(mayaUsdLib.PrimUpdaterManager.mergeToUsd(bobMayaPathStr))
         
         # After push, all Maya objects should be gone
         self.assertFalse(self._GetMFnDagNode("bob"))

--- a/test/lib/mayaUsd/fileio/testCustomRig.py
+++ b/test/lib/mayaUsd/fileio/testCustomRig.py
@@ -193,7 +193,8 @@ class testCustomRig(unittest.TestCase):
         cmds.setKeyframe( "bob|pCube2.ty", time=10.0, value=10 )
         
         # Push the animation back to USD. This will use a custom logic that will write it to a new prim
-        self.assertTrue(mayaUsdLib.PrimUpdaterManager.mergeToUsd(bobMayaPathStr))
+        with mayaUsdLib.OpUndoItemList():
+            self.assertTrue(mayaUsdLib.PrimUpdaterManager.mergeToUsd(bobMayaPathStr))
         
         # After push, all Maya objects should be gone
         self.assertFalse(self._GetMFnDagNode("bob"))


### PR DESCRIPTION
- Use an OpUndoItemList to capture the undo items of mergeToUsd in the test.
- Add a new notice sent before scene change, including Maya exit.
- Clear the recorded global undo items that were not picked up by any command on exit.