### PR TITLE
[al] Use quaternion form to compare rotation angles

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/BasicTransformationMatrix.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/BasicTransformationMatrix.h
@@ -41,10 +41,12 @@ class BasicTransformationMatrix : public MPxTransformationMatrix
 {
 public:
     /// \brief  ctor
+    AL_USDMAYA_PUBLIC
     BasicTransformationMatrix();
 
     /// \brief  ctor
     /// \param  prim the USD prim that this matrix should represent
+    AL_USDMAYA_PUBLIC
     BasicTransformationMatrix(const UsdPrim& prim);
 
     /// \brief  dtor
@@ -53,6 +55,7 @@ public:
     /// \brief  set the prim that this transformation matrix will read/write to.
     /// \param  prim the prim
     /// \param  scopeNode the owning maya node
+    AL_USDMAYA_PUBLIC
     virtual void setPrim(const UsdPrim& prim, Scope* scopeNode);
 
     /// \brief  sets the MObject for the transform

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.h
@@ -431,15 +431,18 @@ public:
     static MPxTransformationMatrix* creator();
 
     /// \brief  ctor
+    AL_USDMAYA_PUBLIC
     TransformationMatrix();
 
     /// \brief  ctor
     /// \param  prim the USD prim that this matrix should represent
+    AL_USDMAYA_PUBLIC
     TransformationMatrix(const UsdPrim& prim);
 
     /// \brief  set the prim that this transformation matrix will read/write to.
     /// \param  prim the prim
     /// \param  transformNode the owning transform node
+    AL_USDMAYA_PUBLIC
     void setPrim(const UsdPrim& prim, Scope* transformNode) override;
 
     /// \brief  Returns the timecode to use when pushing the transform values to the USD prim. If
@@ -538,19 +541,31 @@ public:
     /// \param  readFromPrim if true, the maya attribute values will be updated from those found on
     /// the USD prim \param  node the transform node to which this matrix belongs (and where the USD
     /// prim will be extracted from)
+    AL_USDMAYA_PUBLIC
     void initialiseToPrim(bool readFromPrim = true, Scope* node = 0) override;
-
+    AL_USDMAYA_PUBLIC
     void pushTranslateToPrim();
+    AL_USDMAYA_PUBLIC
     void pushPivotToPrim();
+    AL_USDMAYA_PUBLIC
     void pushRotatePivotTranslateToPrim();
+    AL_USDMAYA_PUBLIC
     void pushRotatePivotToPrim();
+    AL_USDMAYA_PUBLIC
     void pushRotateToPrim();
+    AL_USDMAYA_PUBLIC
     void pushRotateQuatToPrim();
+    AL_USDMAYA_PUBLIC
     void pushRotateAxisToPrim();
+    AL_USDMAYA_PUBLIC
     void pushScalePivotTranslateToPrim();
+    AL_USDMAYA_PUBLIC
     void pushScalePivotToPrim();
+    AL_USDMAYA_PUBLIC
     void pushScaleToPrim();
+    AL_USDMAYA_PUBLIC
     void pushShearToPrim();
+    AL_USDMAYA_PUBLIC
     void pushTransformToPrim();
 
     // Helper class.  Creating a variable of this class temporarily disables


### PR DESCRIPTION
The PR changed the rotation comparison to use quaternion instead of raw value (rx, ry, rz) in Euler space.

In USD, rotation ops, "xformOp:rotateXYZ" etc. are in Euler space, we had an issue in production that the rotation was twisted but in fact they should be treated as the same, e.g. `(180, -2.3171844, 180) == (0, 182.31718, 0)`, thus converting to quaternion for comparison.