### PR TITLE
Export: read plug values at current time

### DIFF
--- a/lib/mayaUsd/fileio/utils/writeUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/writeUtil.cpp
@@ -41,6 +41,8 @@
 #include <pxr/usd/usdRi/statementsAPI.h>
 #include <pxr/usd/usdUtils/sparseValueWriter.h>
 
+#include <maya/MAnimControl.h>
+#include <maya/MDGContextGuard.h>
 #include <maya/MDoubleArray.h>
 #include <maya/MFnAttribute.h>
 #include <maya/MFnDependencyNode.h>
@@ -647,7 +649,9 @@ bool UsdMayaWriteUtil::SetUsdAttr(
         return true;
     }
 
-    VtValue val = GetVtValue(attrPlug, usdAttr.GetTypeName());
+    MDGContext      dgContext(MAnimControl::currentTime());
+    MDGContextGuard contextGuard(dgContext);
+    VtValue         val = GetVtValue(attrPlug, usdAttr.GetTypeName());
     if (val.IsEmpty()) {
         return false;
     }

--- a/test/lib/mayaUsd/fileio/testSchemaApiAdaptor.py
+++ b/test/lib/mayaUsd/fileio/testSchemaApiAdaptor.py
@@ -373,11 +373,11 @@ class testSchemaApiAdaptor(unittest.TestCase):
         cmds.setKeyframe(bulletPath, at="mass", t=10, v=30.0)
 
         # Modify the velocity so it can be exported to the RBD Physics schema.
-        cmds.setKeyframe(bulletPath, at="initialVelocityX", t=0, v=5.0)
+        cmds.setKeyframe(bulletPath, at="initialVelocityX", t=1, v=5.0)
         cmds.setKeyframe(bulletPath, at="initialVelocityX", t=10, v=50.0)
-        cmds.setKeyframe(bulletPath, at="initialVelocityY", t=0, v=6.0)
+        cmds.setKeyframe(bulletPath, at="initialVelocityY", t=1, v=6.0)
         cmds.setKeyframe(bulletPath, at="initialVelocityY", t=10, v=60.0)
-        cmds.setKeyframe(bulletPath, at="initialVelocityZ", t=0, v=7.0)
+        cmds.setKeyframe(bulletPath, at="initialVelocityZ", t=1, v=7.0)
         cmds.setKeyframe(bulletPath, at="initialVelocityZ", t=10, v=70.0)
 
         # Try applying the schema on a new sphere:


### PR DESCRIPTION
Used to read whatever was there, which might be stale data. This fixes invalid/incomplete animation export.