### PR TITLE
MAYA-109380 - Create a common parent class for HdVP2BasisCurves, HdVP2Mesh and future VP2 shapes

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1429,7 +1429,7 @@ void HdVP2BasisCurves::_InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBit
         case HdBasisCurvesGeomStyleWire:
             // The item is used for wireframe display and selection highlight.
             if (reprToken == HdReprTokens->wire) {
-                renderItem = _CreateWireRenderItem(renderItemName);
+                renderItem = _CreateWireframeRenderItem(renderItemName, kOpaqueGray, MSelectionMask::kSelectNurbsCurves, MHWRender::MFrameContext::kExcludeNurbsCurves);
                 drawItem->AddUsage(HdVP2DrawItem::kSelectionHighlight);
 #ifdef HAS_DEFAULT_MATERIAL_SUPPORT_API
                 renderItem->setDefaultMaterialHandling(MRenderItem::SkipWhenDefaultMaterialActive);
@@ -1445,7 +1445,7 @@ void HdVP2BasisCurves::_InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBit
             }
 #ifdef HAS_DEFAULT_MATERIAL_SUPPORT_API
             else if (reprToken == HdVP2ReprTokens->defaultMaterial) {
-                renderItem = _CreateWireRenderItem(renderItemName);
+                renderItem = _CreateWireframeRenderItem(renderItemName, kOpaqueGray, MSelectionMask::kSelectNurbsCurves, MHWRender::MFrameContext::kExcludeNurbsCurves);
                 renderItem->setDrawMode(MHWRender::MGeometry::kAll);
                 drawItem->AddUsage(HdVP2DrawItem::kSelectionHighlight);
                 renderItem->setDefaultMaterialHandling(
@@ -1639,41 +1639,6 @@ void HdVP2BasisCurves::_UpdatePrimvarSources(
             }
         }
     }
-}
-
-/*! \brief  Create render item for wireframe repr.
- */
-MHWRender::MRenderItem* HdVP2BasisCurves::_CreateWireRenderItem(const MString& name) const
-{
-    MHWRender::MRenderItem* const renderItem = MHWRender::MRenderItem::Create(
-        name, MHWRender::MRenderItem::DecorationItem, MHWRender::MGeometry::kLines);
-
-    renderItem->setDrawMode(MHWRender::MGeometry::kWireframe);
-    renderItem->depthPriority(MHWRender::MRenderItem::sDormantWireDepthPriority);
-    renderItem->castsShadows(false);
-    renderItem->receivesShadows(false);
-    renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueGray));
-#ifdef MAYA_MRENDERITEM_UFE_IDENTIFIER_SUPPORT
-    auto* const          param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
-    ProxyRenderDelegate& drawScene = param->GetDrawScene();
-    drawScene.setUfeIdentifiers(*renderItem, _PrimSegmentString);
-#endif
-
-#ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
-    MSelectionMask selectionMask(MSelectionMask::kSelectNurbsCurves);
-    selectionMask.addMask(MSelectionMask::kSelectPointsForGravity);
-    renderItem->setSelectionMask(selectionMask);
-#else
-    renderItem->setSelectionMask(MSelectionMask::kSelectNurbsCurves);
-#endif
-
-#if MAYA_API_VERSION >= 20220000
-    renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeNurbsCurves);
-#endif
-
-    _SetWantConsolidation(*renderItem, true);
-
-    return renderItem;
 }
 
 /*! \brief  Create render item for smoothHull repr.

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -464,7 +464,7 @@ void HdVP2BasisCurves::Sync(
     ProxyRenderDelegate& drawScene = param->GetDrawScene();
     HdRenderIndex&       renderIndex = delegate->GetRenderIndex();
     if (!drawScene.DrawRenderTag(renderIndex.GetRenderTag(GetId()))) {
-        _HideAllDrawItems(reprToken);
+        _HideAllDrawItems(_GetRepr(reprToken));
         *dirtyBits &= ~(
             HdChangeTracker::DirtyRenderTag
 #ifdef ENABLE_RENDERTAG_VISIBILITY_WORKAROUND
@@ -1521,31 +1521,6 @@ HdDirtyBits HdVP2BasisCurves::GetInitialDirtyBitsMask() const
         | DirtySelectionHighlight;
 
     return bits;
-}
-
-void HdVP2BasisCurves::_HideAllDrawItems(const TfToken& reprToken)
-{
-    HdReprSharedPtr const& curRepr = _GetRepr(reprToken);
-    if (!curRepr) {
-        return;
-    }
-
-    const auto& items = curRepr->GetDrawItems();
-
-#if HD_API_VERSION < 35
-    for (HdDrawItem* item : items) {
-        if (HdVP2DrawItem* drawItem = static_cast<HdVP2DrawItem*>(item)) {
-#else
-    for (const HdRepr::DrawItemUniquePtr& item : items) {
-        if (HdVP2DrawItem* const drawItem = static_cast<HdVP2DrawItem*>(item.get())) {
-#endif
-            for (auto& renderItemData : drawItem->GetRenderItems()) {
-                renderItemData._enabled = false;
-                _delegate->GetVP2ResourceRegistry().EnqueueCommit(
-                    [&]() { renderItemData._renderItem->enable(false); });
-            }
-        }
-    }
 }
 
 /*! \brief  Update _primvarSourceMap, our local cache of raw primvar data.

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1437,7 +1437,7 @@ void HdVP2BasisCurves::_InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBit
             }
             // The item is used for bbox display and selection highlight.
             else if (reprToken == HdVP2ReprTokens->bbox) {
-                renderItem = _CreateBBoxRenderItem(renderItemName);
+                renderItem = _CreateBoundingBoxRenderItem(renderItemName, kOpaqueGray, MSelectionMask::kSelectNurbsCurves, MHWRender::MFrameContext::kExcludeNurbsCurves);
                 drawItem->AddUsage(HdVP2DrawItem::kSelectionHighlight);
 #ifdef HAS_DEFAULT_MATERIAL_SUPPORT_API
                 renderItem->setDefaultMaterialHandling(MRenderItem::SkipWhenDefaultMaterialActive);
@@ -1665,33 +1665,6 @@ MHWRender::MRenderItem* HdVP2BasisCurves::_CreateWireRenderItem(const MString& n
     renderItem->setSelectionMask(selectionMask);
 #else
     renderItem->setSelectionMask(MSelectionMask::kSelectNurbsCurves);
-#endif
-
-#if MAYA_API_VERSION >= 20220000
-    renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeNurbsCurves);
-#endif
-
-    _SetWantConsolidation(*renderItem, true);
-
-    return renderItem;
-}
-
-/*! \brief  Create render item for bbox repr.
- */
-MHWRender::MRenderItem* HdVP2BasisCurves::_CreateBBoxRenderItem(const MString& name) const
-{
-    MHWRender::MRenderItem* const renderItem = MHWRender::MRenderItem::Create(
-        name, MHWRender::MRenderItem::DecorationItem, MHWRender::MGeometry::kLines);
-
-    renderItem->setDrawMode(MHWRender::MGeometry::kBoundingBox);
-    renderItem->castsShadows(false);
-    renderItem->receivesShadows(false);
-    renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueGray));
-    renderItem->setSelectionMask(MSelectionMask::kSelectNurbsCurves);
-#ifdef MAYA_MRENDERITEM_UFE_IDENTIFIER_SUPPORT
-    auto* const          param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
-    ProxyRenderDelegate& drawScene = param->GetDrawScene();
-    drawScene.setUfeIdentifiers(*renderItem, _PrimSegmentString);
 #endif
 
 #if MAYA_API_VERSION >= 20220000

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1455,7 +1455,7 @@ void HdVP2BasisCurves::_InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBit
             break;
 #ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
         case HdBasisCurvesGeomStylePoints:
-            renderItem = _CreatePointsRenderItem(renderItemName);
+            renderItem = _CreatePointsRenderItem(renderItemName, MSelectionMask::kSelectNurbsCurves, MHWRender::MFrameContext::kExcludeNurbsCurves);
             break;
 #endif
         default: TF_WARN("Unsupported geomStyle"); break;
@@ -1675,38 +1675,5 @@ MHWRender::MRenderItem* HdVP2BasisCurves::_CreatePatchRenderItem(const MString& 
 
     return renderItem;
 }
-
-#ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
-/*! \brief  Create render item for points repr.
- */
-MHWRender::MRenderItem* HdVP2BasisCurves::_CreatePointsRenderItem(const MString& name) const
-{
-    MHWRender::MRenderItem* const renderItem = MHWRender::MRenderItem::Create(
-        name, MHWRender::MRenderItem::DecorationItem, MHWRender::MGeometry::kPoints);
-
-    renderItem->setDrawMode(MHWRender::MGeometry::kSelectionOnly);
-    renderItem->depthPriority(MHWRender::MRenderItem::sDormantPointDepthPriority);
-    renderItem->castsShadows(false);
-    renderItem->receivesShadows(false);
-    renderItem->setShader(_delegate->Get3dFatPointShader());
-#ifdef MAYA_MRENDERITEM_UFE_IDENTIFIER_SUPPORT
-    auto* const          param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
-    ProxyRenderDelegate& drawScene = param->GetDrawScene();
-    drawScene.setUfeIdentifiers(*renderItem, _PrimSegmentString);
-#endif
-
-    MSelectionMask selectionMask(MSelectionMask::kSelectPointsForGravity);
-    selectionMask.addMask(MSelectionMask::kSelectNurbsCurves);
-    renderItem->setSelectionMask(selectionMask);
-
-#if MAYA_API_VERSION >= 20220000
-    renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeNurbsCurves);
-#endif
-
-    _SetWantConsolidation(*renderItem, true);
-
-    return renderItem;
-}
-#endif
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -599,7 +599,7 @@ void HdVP2BasisCurves::Sync(
         // invisible that we must update every repr, because if we switch reprs while
         // invisible we'll get no chance to update!
         if (!_sharedData.visible)
-            _MakeOtherReprRenderItemsInvisible(delegate, reprToken);
+            _MakeOtherReprRenderItemsInvisible(reprToken, _reprs);
     }
 
 #if PXR_VERSION > 2111
@@ -1474,39 +1474,6 @@ void HdVP2BasisCurves::_InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBit
 #else
         repr->AddDrawItem(std::move(drawItem));
 #endif
-    }
-}
-
-/*! \brief Hide all of the repr objects for this Rprim except the named repr.
-    Repr objects are created to support specific reprName tokens, and contain a list of
-    HdVP2DrawItems and corresponding RenderItems.
-*/
-void HdVP2BasisCurves::_MakeOtherReprRenderItemsInvisible(
-    HdSceneDelegate* sceneDelegate,
-    const TfToken&   reprToken)
-{
-    for (const std::pair<TfToken, HdReprSharedPtr>& pair : _reprs) {
-        if (pair.first != reprToken) {
-            // For each relevant draw item, update dirty buffer sources.
-            const HdReprSharedPtr& repr = pair.second;
-            const auto&            items = repr->GetDrawItems();
-
-#if HD_API_VERSION < 35
-            for (HdDrawItem* item : items) {
-                if (HdVP2DrawItem* drawItem = static_cast<HdVP2DrawItem*>(item)) {
-#else
-            for (const HdRepr::DrawItemUniquePtr& item : items) {
-                if (HdVP2DrawItem* const drawItem = static_cast<HdVP2DrawItem*>(item.get())) {
-#endif
-                    for (auto& renderItemData : drawItem->GetRenderItems()) {
-                        _delegate->GetVP2ResourceRegistry().EnqueueCommit([&renderItemData]() {
-                            renderItemData._enabled = false;
-                            renderItemData._renderItem->enable(false);
-                        });
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -606,7 +606,7 @@ void HdVP2BasisCurves::Sync(
     // Hydra now manages and caches render tags under the hood and is clearing
     // the dirty bit prior to calling sync. Unconditionally set the render tag
     // in the shared data structure based on current Hydra data
-    _curvesSharedData._renderTag = GetRenderTag();
+    _RenderTag() = GetRenderTag();
 #else
     if (*dirtyBits
         & (HdChangeTracker::DirtyRenderTag
@@ -614,7 +614,7 @@ void HdVP2BasisCurves::Sync(
            | HdChangeTracker::DirtyVisibility
 #endif
            )) {
-        _curvesSharedData._renderTag = delegate->GetRenderTag(id);
+        _RenderTag() = delegate->GetRenderTag(id);
     }
 #endif
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1340,7 +1340,11 @@ void HdVP2BasisCurves::_InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBit
         case HdBasisCurvesGeomStyleWire:
             // The item is used for wireframe display and selection highlight.
             if (reprToken == HdReprTokens->wire) {
-                renderItem = _CreateWireframeRenderItem(renderItemName, kOpaqueGray, MSelectionMask::kSelectNurbsCurves, MHWRender::MFrameContext::kExcludeNurbsCurves);
+                renderItem = _CreateWireframeRenderItem(
+                    renderItemName,
+                    kOpaqueGray,
+                    MSelectionMask::kSelectNurbsCurves,
+                    MHWRender::MFrameContext::kExcludeNurbsCurves);
                 drawItem->AddUsage(HdVP2DrawItem::kSelectionHighlight);
 #ifdef HAS_DEFAULT_MATERIAL_SUPPORT_API
                 renderItem->setDefaultMaterialHandling(MRenderItem::SkipWhenDefaultMaterialActive);
@@ -1348,7 +1352,11 @@ void HdVP2BasisCurves::_InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBit
             }
             // The item is used for bbox display and selection highlight.
             else if (reprToken == HdVP2ReprTokens->bbox) {
-                renderItem = _CreateBoundingBoxRenderItem(renderItemName, kOpaqueGray, MSelectionMask::kSelectNurbsCurves, MHWRender::MFrameContext::kExcludeNurbsCurves);
+                renderItem = _CreateBoundingBoxRenderItem(
+                    renderItemName,
+                    kOpaqueGray,
+                    MSelectionMask::kSelectNurbsCurves,
+                    MHWRender::MFrameContext::kExcludeNurbsCurves);
                 drawItem->AddUsage(HdVP2DrawItem::kSelectionHighlight);
 #ifdef HAS_DEFAULT_MATERIAL_SUPPORT_API
                 renderItem->setDefaultMaterialHandling(MRenderItem::SkipWhenDefaultMaterialActive);
@@ -1356,7 +1364,11 @@ void HdVP2BasisCurves::_InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBit
             }
 #ifdef HAS_DEFAULT_MATERIAL_SUPPORT_API
             else if (reprToken == HdVP2ReprTokens->defaultMaterial) {
-                renderItem = _CreateWireframeRenderItem(renderItemName, kOpaqueGray, MSelectionMask::kSelectNurbsCurves, MHWRender::MFrameContext::kExcludeNurbsCurves);
+                renderItem = _CreateWireframeRenderItem(
+                    renderItemName,
+                    kOpaqueGray,
+                    MSelectionMask::kSelectNurbsCurves,
+                    MHWRender::MFrameContext::kExcludeNurbsCurves);
                 renderItem->setDrawMode(MHWRender::MGeometry::kAll);
                 drawItem->AddUsage(HdVP2DrawItem::kSelectionHighlight);
                 renderItem->setDefaultMaterialHandling(
@@ -1366,7 +1378,10 @@ void HdVP2BasisCurves::_InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBit
             break;
 #ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
         case HdBasisCurvesGeomStylePoints:
-            renderItem = _CreatePointsRenderItem(renderItemName, MSelectionMask::kSelectNurbsCurves, MHWRender::MFrameContext::kExcludeNurbsCurves);
+            renderItem = _CreatePointsRenderItem(
+                renderItemName,
+                MSelectionMask::kSelectNurbsCurves,
+                MHWRender::MFrameContext::kExcludeNurbsCurves);
             break;
 #endif
         default: TF_WARN("Unsupported geomStyle"); break;

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -457,13 +457,15 @@ void HdVP2BasisCurves::Sync(
     HdDirtyBits*     dirtyBits,
     TfToken const&   reprToken)
 {
+    const SdfPath& id = GetId();
+    auto* const          param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
+    ProxyRenderDelegate& drawScene = param->GetDrawScene();
+
     // We don't update the repr if it is hidden by the render tags (purpose)
     // of the ProxyRenderDelegate. In additional, we need to hide any already
     // existing render items because they should not be drawn.
-    auto* const          param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
-    ProxyRenderDelegate& drawScene = param->GetDrawScene();
     HdRenderIndex&       renderIndex = delegate->GetRenderIndex();
-    if (!drawScene.DrawRenderTag(renderIndex.GetRenderTag(GetId()))) {
+    if (!drawScene.DrawRenderTag(renderIndex.GetRenderTag(id))) {
         _HideAllDrawItems(_GetRepr(reprToken));
         *dirtyBits &= ~(
             HdChangeTracker::DirtyRenderTag
@@ -479,8 +481,6 @@ void HdVP2BasisCurves::Sync(
         MProfiler::kColorC_L2,
         _rprimId.asChar(),
         "HdVP2BasisCurves::Sync");
-
-    const SdfPath& id = GetId();
 
     // Update the selection status if it changed.
     if (*dirtyBits & DirtySelectionHighlight) {

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -470,29 +470,7 @@ void HdVP2BasisCurves::Sync(
         "HdVP2BasisCurves::Sync");
 
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
-        const SdfPath materialId = delegate->GetMaterialId(id);
-
-#ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
-        const SdfPath& origMaterialId = GetMaterialId();
-        if (materialId != origMaterialId) {
-            if (!origMaterialId.IsEmpty()) {
-                HdVP2Material* material = static_cast<HdVP2Material*>(
-                    renderIndex.GetSprim(HdPrimTypeTokens->material, origMaterialId));
-                if (material) {
-                    material->UnsubscribeFromMaterialUpdates(id);
-                }
-            }
-
-            if (!materialId.IsEmpty()) {
-                HdVP2Material* material = static_cast<HdVP2Material*>(
-                    renderIndex.GetSprim(HdPrimTypeTokens->material, materialId));
-                if (material) {
-                    material->SubscribeForMaterialUpdates(id);
-                }
-            }
-        }
-#endif
-
+        const SdfPath materialId = _GetUpdatedMaterialId(this, delegate);
 #if HD_API_VERSION < 37
         _SetMaterialId(renderIndex.GetChangeTracker(), materialId);
 #else

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -583,40 +583,7 @@ void HdVP2BasisCurves::Sync(
         }
     }
 
-    if (HdChangeTracker::IsExtentDirty(*dirtyBits, id)) {
-        _sharedData.bounds.SetRange(delegate->GetExtent(id));
-    }
-
-    if (HdChangeTracker::IsTransformDirty(*dirtyBits, id)) {
-        _sharedData.bounds.SetMatrix(delegate->GetTransform(id));
-    }
-
-    if (HdChangeTracker::IsVisibilityDirty(*dirtyBits, id)) {
-        _sharedData.visible = delegate->GetVisible(id);
-
-        // Invisible rprims don't get calls to Sync or _PropagateDirtyBits while
-        // they are invisible. This means that when a prim goes from visible to
-        // invisible that we must update every repr, because if we switch reprs while
-        // invisible we'll get no chance to update!
-        if (!_sharedData.visible)
-            _MakeOtherReprRenderItemsInvisible(reprToken, _reprs);
-    }
-
-#if PXR_VERSION > 2111
-    // Hydra now manages and caches render tags under the hood and is clearing
-    // the dirty bit prior to calling sync. Unconditionally set the render tag
-    // in the shared data structure based on current Hydra data
-    _RenderTag() = GetRenderTag();
-#else
-    if (*dirtyBits
-        & (HdChangeTracker::DirtyRenderTag
-#ifdef ENABLE_RENDERTAG_VISIBILITY_WORKAROUND
-           | HdChangeTracker::DirtyVisibility
-#endif
-           )) {
-        _RenderTag() = delegate->GetRenderTag(id);
-    }
-#endif
+    _SyncSharedData(_sharedData, delegate, dirtyBits, reprToken, id, _reprs);
 
     *dirtyBits = HdChangeTracker::Clean;
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1306,23 +1306,9 @@ void HdVP2BasisCurves::_InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBit
     if (ARCH_UNLIKELY(!subSceneContainer))
         return;
 
-    if (_reprs.empty()) {
-        _FirstInitRepr(dirtyBits, GetId());
-    }
-
-    _ReprVector::iterator it
-        = std::find_if(_reprs.begin(), _reprs.end(), _ReprComparator(reprToken));
-    if (it != _reprs.end()) {
-        _SetDirtyRepr(it->second);
+    HdReprSharedPtr repr = _AddNewRepr(reprToken, _reprs, dirtyBits, GetId());
+    if (!repr)
         return;
-    }
-
-    // add new repr
-    _reprs.emplace_back(reprToken, std::make_shared<HdRepr>());
-    HdReprSharedPtr repr = _reprs.back().second;
-
-    // set dirty bit to say we need to sync a new repr
-    *dirtyBits |= HdChangeTracker::NewRepr;
 
     _BasisCurvesReprConfig::DescArray descs = _GetReprDesc(reprToken);
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
@@ -131,6 +131,8 @@ protected:
 
     void _InitRepr(TfToken const& reprToken, HdDirtyBits* dirtyBits) override;
 
+    TfToken& _RenderTag() override { return _curvesSharedData._renderTag; }
+
 private:
     void _UpdateRepr(HdSceneDelegate* sceneDelegate, TfToken const& reprToken);
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
@@ -149,7 +149,6 @@ private:
 
     MHWRender::MRenderItem* _CreatePatchRenderItem(const MString& name) const;
     MHWRender::MRenderItem* _CreateWireRenderItem(const MString& name) const;
-    MHWRender::MRenderItem* _CreateBBoxRenderItem(const MString& name) const;
 
 #ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
     MHWRender::MRenderItem* _CreatePointsRenderItem(const MString& name) const;

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
@@ -148,7 +148,6 @@ private:
         TfTokenVector const& requiredPrimvars);
 
     MHWRender::MRenderItem* _CreatePatchRenderItem(const MString& name) const;
-    MHWRender::MRenderItem* _CreateWireRenderItem(const MString& name) const;
 
 #ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
     MHWRender::MRenderItem* _CreatePointsRenderItem(const MString& name) const;

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
@@ -133,7 +133,6 @@ protected:
 
 private:
     void _UpdateRepr(HdSceneDelegate* sceneDelegate, TfToken const& reprToken);
-    void _MakeOtherReprRenderItemsInvisible(HdSceneDelegate*, const TfToken&);
 
     void _UpdateDrawItem(
         HdSceneDelegate*             sceneDelegate,

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
@@ -149,10 +149,6 @@ private:
 
     MHWRender::MRenderItem* _CreatePatchRenderItem(const MString& name) const;
 
-#ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
-    MHWRender::MRenderItem* _CreatePointsRenderItem(const MString& name) const;
-#endif
-
     enum DirtyBits : HdDirtyBits
     {
         DirtySelectionHighlight = MayaUsdRPrim::DirtySelectionHighlight

--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.h
@@ -139,8 +139,6 @@ private:
         HdVP2DrawItem*               drawItem,
         HdBasisCurvesReprDesc const& desc);
 
-    void _HideAllDrawItems(const TfToken& reprToken);
-
     void _UpdatePrimvarSources(
         HdSceneDelegate*     sceneDelegate,
         HdDirtyBits          dirtyBits,

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
@@ -288,4 +288,31 @@ void MayaUsdRPrim::_PropagateDirtyBitsCommon(HdDirtyBits& bits, const ReprVector
     }
 }
 
+/*! \brief  Create render item for bbox repr.
+ */
+MHWRender::MRenderItem* MayaUsdRPrim::_CreateBoundingBoxRenderItem(const MString& name, const MColor& color, const MSelectionMask& selectionMask, MUint64 exclusionFlag) const
+{
+    MHWRender::MRenderItem* const renderItem = MHWRender::MRenderItem::Create(
+        name, MHWRender::MRenderItem::DecorationItem, MHWRender::MGeometry::kLines);
+
+    renderItem->setDrawMode(MHWRender::MGeometry::kBoundingBox);
+    renderItem->castsShadows(false);
+    renderItem->receivesShadows(false);
+    renderItem->setShader(_delegate->Get3dSolidShader(color));
+    renderItem->setSelectionMask(selectionMask);
+#ifdef MAYA_MRENDERITEM_UFE_IDENTIFIER_SUPPORT
+    auto* const          param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
+    ProxyRenderDelegate& drawScene = param->GetDrawScene();
+    drawScene.setUfeIdentifiers(*renderItem, _PrimSegmentString);
+#endif
+
+#if MAYA_API_VERSION >= 20220000
+    renderItem->setObjectTypeExclusionFlag(exclusionFlag);
+#endif
+
+    _SetWantConsolidation(*renderItem, true);
+
+    return renderItem;
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
@@ -245,14 +245,20 @@ void MayaUsdRPrim::_SetDirtyRepr(const HdReprSharedPtr& repr)
     }
 }
 
-HdReprSharedPtr MayaUsdRPrim::_AddNewRepr(TfToken const& reprToken, ReprVector& reprs, HdDirtyBits* dirtyBits, SdfPath const& id)
+HdReprSharedPtr MayaUsdRPrim::_AddNewRepr(
+    TfToken const& reprToken,
+    ReprVector&    reprs,
+    HdDirtyBits*   dirtyBits,
+    SdfPath const& id)
 {
     if (reprs.empty()) {
         _FirstInitRepr(dirtyBits, id);
     }
 
     ReprVector::const_iterator it
-        = std::find_if(reprs.begin(), reprs.end(), [reprToken](ReprVector::const_reference e) { return reprToken == e.first; });
+        = std::find_if(reprs.begin(), reprs.end(), [reprToken](ReprVector::const_reference e) {
+              return reprToken == e.first;
+          });
     if (it != reprs.end()) {
         _SetDirtyRepr(it->second);
         return nullptr;
@@ -311,7 +317,11 @@ void MayaUsdRPrim::_PropagateDirtyBitsCommon(HdDirtyBits& bits, const ReprVector
 
 /*! \brief  Create render item for bbox repr.
  */
-MHWRender::MRenderItem* MayaUsdRPrim::_CreateBoundingBoxRenderItem(const MString& name, const MColor& color, const MSelectionMask& selectionMask, MUint64 exclusionFlag) const
+MHWRender::MRenderItem* MayaUsdRPrim::_CreateBoundingBoxRenderItem(
+    const MString&        name,
+    const MColor&         color,
+    const MSelectionMask& selectionMask,
+    MUint64               exclusionFlag) const
 {
     MHWRender::MRenderItem* const renderItem = MHWRender::MRenderItem::Create(
         name, MHWRender::MRenderItem::DecorationItem, MHWRender::MGeometry::kLines);
@@ -338,7 +348,11 @@ MHWRender::MRenderItem* MayaUsdRPrim::_CreateBoundingBoxRenderItem(const MString
 
 /*! \brief  Create render item for wireframe repr.
  */
-MHWRender::MRenderItem* MayaUsdRPrim::_CreateWireframeRenderItem(const MString& name, const MColor& color, const MSelectionMask& selectionMask, MUint64 exclusionFlag) const
+MHWRender::MRenderItem* MayaUsdRPrim::_CreateWireframeRenderItem(
+    const MString&        name,
+    const MColor&         color,
+    const MSelectionMask& selectionMask,
+    MUint64               exclusionFlag) const
 {
     MHWRender::MRenderItem* const renderItem = MHWRender::MRenderItem::Create(
         name, MHWRender::MRenderItem::DecorationItem, MHWRender::MGeometry::kLines);
@@ -374,7 +388,10 @@ MHWRender::MRenderItem* MayaUsdRPrim::_CreateWireframeRenderItem(const MString& 
 #ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
 /*! \brief  Create render item for points repr.
  */
-MHWRender::MRenderItem* MayaUsdRPrim::_CreatePointsRenderItem(const MString& name, const MSelectionMask& selectionMask, MUint64 exclusionFlag) const
+MHWRender::MRenderItem* MayaUsdRPrim::_CreatePointsRenderItem(
+    const MString&        name,
+    const MSelectionMask& selectionMask,
+    MUint64               exclusionFlag) const
 {
     MHWRender::MRenderItem* const renderItem = MHWRender::MRenderItem::Create(
         name, MHWRender::MRenderItem::DecorationItem, MHWRender::MGeometry::kPoints);
@@ -409,7 +426,7 @@ MHWRender::MRenderItem* MayaUsdRPrim::_CreatePointsRenderItem(const MString& nam
     HdVP2DrawItems and corresponding RenderItems.
 */
 void MayaUsdRPrim::_MakeOtherReprRenderItemsInvisible(
-    const TfToken&   reprToken,
+    const TfToken&    reprToken,
     const ReprVector& reprs)
 {
     for (const std::pair<TfToken, HdReprSharedPtr>& pair : reprs) {
@@ -461,7 +478,13 @@ void MayaUsdRPrim::_HideAllDrawItems(HdReprSharedPtr const& curRepr)
     }
 }
 
-void MayaUsdRPrim::_SyncSharedData(HdRprimSharedData& sharedData, HdSceneDelegate* delegate, HdDirtyBits const* dirtyBits, TfToken const& reprToken, SdfPath const& id, ReprVector const& reprs)
+void MayaUsdRPrim::_SyncSharedData(
+    HdRprimSharedData& sharedData,
+    HdSceneDelegate*   delegate,
+    HdDirtyBits const* dirtyBits,
+    TfToken const&     reprToken,
+    SdfPath const&     id,
+    ReprVector const&  reprs)
 {
     if (HdChangeTracker::IsExtentDirty(*dirtyBits, id)) {
         sharedData.bounds.SetRange(delegate->GetExtent(id));
@@ -499,7 +522,11 @@ void MayaUsdRPrim::_SyncSharedData(HdRprimSharedData& sharedData, HdSceneDelegat
 #endif
 }
 
-bool MayaUsdRPrim::_SyncCommon(HdDirtyBits* dirtyBits, const SdfPath& id, HdReprSharedPtr const& curRepr, HdRenderIndex& renderIndex)
+bool MayaUsdRPrim::_SyncCommon(
+    HdDirtyBits*           dirtyBits,
+    const SdfPath&         id,
+    HdReprSharedPtr const& curRepr,
+    HdRenderIndex&         renderIndex)
 {
     auto* const          param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
     ProxyRenderDelegate& drawScene = param->GetDrawScene();
@@ -531,7 +558,7 @@ bool MayaUsdRPrim::_SyncCommon(HdDirtyBits* dirtyBits, const SdfPath& id, HdRepr
 SdfPath MayaUsdRPrim::_GetUpdatedMaterialId(HdRprim* rprim, HdSceneDelegate* delegate)
 {
     const SdfPath& id = rprim->GetId();
-    const SdfPath materialId = delegate->GetMaterialId(id);
+    const SdfPath  materialId = delegate->GetMaterialId(id);
 
 #ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
     const SdfPath& origMaterialId = rprim->GetMaterialId();

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -189,6 +189,10 @@ protected:
     MHWRender::MRenderItem* _CreateWireframeRenderItem(const MString& name, const MColor& color, const MSelectionMask& selectionMask, MUint64 exclusionFlag) const;
     MHWRender::MRenderItem* _CreateBoundingBoxRenderItem(const MString& name, const MColor& color, const MSelectionMask& selectionMask, MUint64 exclusionFlag) const;
 
+#ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
+    MHWRender::MRenderItem* _CreatePointsRenderItem(const MString& name, const MSelectionMask& selectionMask, MUint64 exclusionFlag) const;
+#endif
+
     //! VP2 render delegate for which this prim was created
     HdVP2RenderDelegate* _delegate { nullptr };
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -185,6 +185,8 @@ protected:
 
     void _SyncSharedData(HdRprimSharedData& sharedData, HdSceneDelegate* delegate, HdDirtyBits const* dirtyBits, TfToken const& reprToken, SdfPath const& id, ReprVector const& reprs);
 
+    SdfPath _GetUpdatedMaterialId(HdRprim* rprim, HdSceneDelegate* delegate);
+
     void _PropagateDirtyBitsCommon(HdDirtyBits& bits, const ReprVector& reprs) const;
 
     void _MakeOtherReprRenderItemsInvisible(const TfToken&, const ReprVector&);

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -181,11 +181,25 @@ protected:
 
     void _SetDirtyRepr(const HdReprSharedPtr& repr);
 
-    HdReprSharedPtr _AddNewRepr(TfToken const& reprToken, ReprVector& reprs, HdDirtyBits* dirtyBits, SdfPath const& id);
+    HdReprSharedPtr _AddNewRepr(
+        TfToken const& reprToken,
+        ReprVector&    reprs,
+        HdDirtyBits*   dirtyBits,
+        SdfPath const& id);
 
-    bool _SyncCommon(HdDirtyBits* dirtyBits, const SdfPath& id, HdReprSharedPtr const& curRepr, HdRenderIndex& renderIndex);
+    bool _SyncCommon(
+        HdDirtyBits*           dirtyBits,
+        const SdfPath&         id,
+        HdReprSharedPtr const& curRepr,
+        HdRenderIndex&         renderIndex);
 
-    void _SyncSharedData(HdRprimSharedData& sharedData, HdSceneDelegate* delegate, HdDirtyBits const* dirtyBits, TfToken const& reprToken, SdfPath const& id, ReprVector const& reprs);
+    void _SyncSharedData(
+        HdRprimSharedData& sharedData,
+        HdSceneDelegate*   delegate,
+        HdDirtyBits const* dirtyBits,
+        TfToken const&     reprToken,
+        SdfPath const&     id,
+        ReprVector const&  reprs);
 
     SdfPath _GetUpdatedMaterialId(HdRprim* rprim, HdSceneDelegate* delegate);
 
@@ -198,11 +212,22 @@ protected:
     //! Helper utility function to adapt Maya API changes.
     static void _SetWantConsolidation(MHWRender::MRenderItem& renderItem, bool state);
 
-    MHWRender::MRenderItem* _CreateWireframeRenderItem(const MString& name, const MColor& color, const MSelectionMask& selectionMask, MUint64 exclusionFlag) const;
-    MHWRender::MRenderItem* _CreateBoundingBoxRenderItem(const MString& name, const MColor& color, const MSelectionMask& selectionMask, MUint64 exclusionFlag) const;
+    MHWRender::MRenderItem* _CreateWireframeRenderItem(
+        const MString&        name,
+        const MColor&         color,
+        const MSelectionMask& selectionMask,
+        MUint64               exclusionFlag) const;
+    MHWRender::MRenderItem* _CreateBoundingBoxRenderItem(
+        const MString&        name,
+        const MColor&         color,
+        const MSelectionMask& selectionMask,
+        MUint64               exclusionFlag) const;
 
 #ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
-    MHWRender::MRenderItem* _CreatePointsRenderItem(const MString& name, const MSelectionMask& selectionMask, MUint64 exclusionFlag) const;
+    MHWRender::MRenderItem* _CreatePointsRenderItem(
+        const MString&        name,
+        const MSelectionMask& selectionMask,
+        MUint64               exclusionFlag) const;
 #endif
 
     virtual TfToken& _RenderTag() = 0;

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -197,6 +197,8 @@ protected:
     MHWRender::MRenderItem* _CreatePointsRenderItem(const MString& name, const MSelectionMask& selectionMask, MUint64 exclusionFlag) const;
 #endif
 
+    virtual TfToken& _RenderTag() = 0;
+
     //! VP2 render delegate for which this prim was created
     HdVP2RenderDelegate* _delegate { nullptr };
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -185,6 +185,8 @@ protected:
 
     void _MakeOtherReprRenderItemsInvisible(const TfToken&, const ReprVector&);
 
+    void _HideAllDrawItems(HdReprSharedPtr const& curRepr);
+
     //! Helper utility function to adapt Maya API changes.
     static void _SetWantConsolidation(MHWRender::MRenderItem& renderItem, bool state);
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -181,6 +181,8 @@ protected:
 
     void _SetDirtyRepr(const HdReprSharedPtr& repr);
 
+    bool _SyncCommon(HdDirtyBits* dirtyBits, const SdfPath& id, HdReprSharedPtr const& curRepr, HdRenderIndex& renderIndex);
+
     void _SyncSharedData(HdRprimSharedData& sharedData, HdSceneDelegate* delegate, HdDirtyBits const* dirtyBits, TfToken const& reprToken, SdfPath const& id, ReprVector const& reprs);
 
     void _PropagateDirtyBitsCommon(HdDirtyBits& bits, const ReprVector& reprs) const;

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -181,6 +181,8 @@ protected:
 
     void _SetDirtyRepr(const HdReprSharedPtr& repr);
 
+    void _SyncSharedData(HdRprimSharedData& sharedData, HdSceneDelegate* delegate, HdDirtyBits const* dirtyBits, TfToken const& reprToken, SdfPath const& id, ReprVector const& reprs);
+
     void _PropagateDirtyBitsCommon(HdDirtyBits& bits, const ReprVector& reprs) const;
 
     void _MakeOtherReprRenderItemsInvisible(const TfToken&, const ReprVector&);

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -183,6 +183,8 @@ protected:
 
     void _PropagateDirtyBitsCommon(HdDirtyBits& bits, const ReprVector& reprs) const;
 
+    void _MakeOtherReprRenderItemsInvisible(const TfToken&, const ReprVector&);
+
     //! Helper utility function to adapt Maya API changes.
     static void _SetWantConsolidation(MHWRender::MRenderItem& renderItem, bool state);
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -186,6 +186,7 @@ protected:
     //! Helper utility function to adapt Maya API changes.
     static void _SetWantConsolidation(MHWRender::MRenderItem& renderItem, bool state);
 
+    MHWRender::MRenderItem* _CreateWireframeRenderItem(const MString& name, const MColor& color, const MSelectionMask& selectionMask, MUint64 exclusionFlag) const;
     MHWRender::MRenderItem* _CreateBoundingBoxRenderItem(const MString& name, const MColor& color, const MSelectionMask& selectionMask, MUint64 exclusionFlag) const;
 
     //! VP2 render delegate for which this prim was created

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -181,6 +181,8 @@ protected:
 
     void _SetDirtyRepr(const HdReprSharedPtr& repr);
 
+    HdReprSharedPtr _AddNewRepr(TfToken const& reprToken, ReprVector& reprs, HdDirtyBits* dirtyBits, SdfPath const& id);
+
     bool _SyncCommon(HdDirtyBits* dirtyBits, const SdfPath& id, HdReprSharedPtr const& curRepr, HdRenderIndex& renderIndex);
 
     void _SyncSharedData(HdRprimSharedData& sharedData, HdSceneDelegate* delegate, HdDirtyBits const* dirtyBits, TfToken const& reprToken, SdfPath const& id, ReprVector const& reprs);

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -186,6 +186,8 @@ protected:
     //! Helper utility function to adapt Maya API changes.
     static void _SetWantConsolidation(MHWRender::MRenderItem& renderItem, bool state);
 
+    MHWRender::MRenderItem* _CreateBoundingBoxRenderItem(const MString& name, const MColor& color, const MSelectionMask& selectionMask, MUint64 exclusionFlag) const;
+
     //! VP2 render delegate for which this prim was created
     HdVP2RenderDelegate* _delegate { nullptr };
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1284,7 +1284,7 @@ void HdVP2Mesh::_InitRepr(const TfToken& reprToken, HdDirtyBits* dirtyBits)
             }
             break;
 #ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
-        case HdMeshGeomStylePoints: renderItem = _CreatePointsRenderItem(renderItemName); break;
+        case HdMeshGeomStylePoints: renderItem = _CreatePointsRenderItem(renderItemName, MSelectionMask::kSelectMeshVerts, MHWRender::MFrameContext::kExcludeMeshes); break;
 #endif
         default: TF_WARN("Unsupported geomStyle"); break;
         }
@@ -2548,39 +2548,6 @@ void HdVP2Mesh::_UpdatePrimvarSources(
         }
     }
 }
-
-#ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
-/*! \brief  Create render item for points repr.
- */
-MHWRender::MRenderItem* HdVP2Mesh::_CreatePointsRenderItem(const MString& name) const
-{
-    MHWRender::MRenderItem* const renderItem = MHWRender::MRenderItem::Create(
-        name, MHWRender::MRenderItem::DecorationItem, MHWRender::MGeometry::kPoints);
-
-    renderItem->setDrawMode(MHWRender::MGeometry::kSelectionOnly);
-    renderItem->depthPriority(MHWRender::MRenderItem::sDormantPointDepthPriority);
-    renderItem->castsShadows(false);
-    renderItem->receivesShadows(false);
-    renderItem->setShader(_delegate->Get3dFatPointShader());
-
-    MSelectionMask selectionMask(MSelectionMask::kSelectPointsForGravity);
-    selectionMask.addMask(MSelectionMask::kSelectMeshVerts);
-    renderItem->setSelectionMask(selectionMask);
-#ifdef MAYA_MRENDERITEM_UFE_IDENTIFIER_SUPPORT
-    auto* const          param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
-    ProxyRenderDelegate& drawScene = param->GetDrawScene();
-    drawScene.setUfeIdentifiers(*renderItem, _PrimSegmentString);
-#endif
-
-#if MAYA_API_VERSION >= 20220000
-    renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeMeshes);
-#endif
-
-    _SetWantConsolidation(*renderItem, true);
-
-    return renderItem;
-}
-#endif
 
 #ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
 MHWRender::MRenderItem* HdVP2Mesh::_CreateShadedSelectedInstancesItem(

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1189,17 +1189,30 @@ void HdVP2Mesh::_InitRepr(const TfToken& reprToken, HdDirtyBits* dirtyBits)
 #endif
             // The item is used for wireframe display and selection highlight.
             else if (reprToken == HdReprTokens->wire) {
-                renderItem = _CreateWireframeRenderItem(renderItemName, kOpaqueBlue, MSelectionMask::kSelectMeshes, MHWRender::MFrameContext::kExcludeMeshes);
+                renderItem = _CreateWireframeRenderItem(
+                    renderItemName,
+                    kOpaqueBlue,
+                    MSelectionMask::kSelectMeshes,
+                    MHWRender::MFrameContext::kExcludeMeshes);
                 drawItem->AddUsage(HdVP2DrawItem::kSelectionHighlight);
             }
             // The item is used for bbox display and selection highlight.
             else if (reprToken == HdVP2ReprTokens->bbox) {
-                renderItem = _CreateBoundingBoxRenderItem(renderItemName, kOpaqueBlue, MSelectionMask::kSelectMeshes, MHWRender::MFrameContext::kExcludeMeshes);
+                renderItem = _CreateBoundingBoxRenderItem(
+                    renderItemName,
+                    kOpaqueBlue,
+                    MSelectionMask::kSelectMeshes,
+                    MHWRender::MFrameContext::kExcludeMeshes);
                 drawItem->AddUsage(HdVP2DrawItem::kSelectionHighlight);
             }
             break;
 #ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
-        case HdMeshGeomStylePoints: renderItem = _CreatePointsRenderItem(renderItemName, MSelectionMask::kSelectMeshVerts, MHWRender::MFrameContext::kExcludeMeshes); break;
+        case HdMeshGeomStylePoints:
+            renderItem = _CreatePointsRenderItem(
+                renderItemName,
+                MSelectionMask::kSelectMeshVerts,
+                MHWRender::MFrameContext::kExcludeMeshes);
+            break;
 #endif
         default: TF_WARN("Unsupported geomStyle"); break;
         }

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1274,7 +1274,7 @@ void HdVP2Mesh::_InitRepr(const TfToken& reprToken, HdDirtyBits* dirtyBits)
 #endif
             // The item is used for wireframe display and selection highlight.
             else if (reprToken == HdReprTokens->wire) {
-                renderItem = _CreateWireframeRenderItem(renderItemName);
+                renderItem = _CreateWireframeRenderItem(renderItemName, kOpaqueBlue, MSelectionMask::kSelectMeshes, MHWRender::MFrameContext::kExcludeMeshes);
                 drawItem->AddUsage(HdVP2DrawItem::kSelectionHighlight);
             }
             // The item is used for bbox display and selection highlight.
@@ -2581,41 +2581,6 @@ MHWRender::MRenderItem* HdVP2Mesh::_CreatePointsRenderItem(const MString& name) 
     return renderItem;
 }
 #endif
-
-/*! \brief  Create render item for wireframe repr.
- */
-MHWRender::MRenderItem* HdVP2Mesh::_CreateWireframeRenderItem(const MString& name) const
-{
-    MHWRender::MRenderItem* const renderItem = MHWRender::MRenderItem::Create(
-        name, MHWRender::MRenderItem::DecorationItem, MHWRender::MGeometry::kLines);
-
-    renderItem->setDrawMode(MHWRender::MGeometry::kWireframe);
-    renderItem->depthPriority(MHWRender::MRenderItem::sDormantWireDepthPriority);
-    renderItem->castsShadows(false);
-    renderItem->receivesShadows(false);
-    renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueBlue));
-
-#ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
-    MSelectionMask selectionMask(MSelectionMask::kSelectMeshes);
-    selectionMask.addMask(MSelectionMask::kSelectPointsForGravity);
-    renderItem->setSelectionMask(selectionMask);
-#else
-    renderItem->setSelectionMask(MSelectionMask::kSelectMeshes);
-#endif
-#ifdef MAYA_MRENDERITEM_UFE_IDENTIFIER_SUPPORT
-    auto* const          param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
-    ProxyRenderDelegate& drawScene = param->GetDrawScene();
-    drawScene.setUfeIdentifiers(*renderItem, _PrimSegmentString);
-#endif
-
-#if MAYA_API_VERSION >= 20220000
-    renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeMeshes);
-#endif
-
-    _SetWantConsolidation(*renderItem, true);
-
-    return renderItem;
-}
 
 #ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
 MHWRender::MRenderItem* HdVP2Mesh::_CreateShadedSelectedInstancesItem(

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -752,19 +752,11 @@ void HdVP2Mesh::Sync(
     HdSceneDelegate* delegate,
     HdRenderParam*   renderParam,
     HdDirtyBits*     dirtyBits,
-    const TfToken&   reprToken)
+    TfToken const&   reprToken)
 {
     const SdfPath&       id = GetId();
     auto* const          param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
     ProxyRenderDelegate& drawScene = param->GetDrawScene();
-    UsdImagingDelegate*  usdImagingDelegate = drawScene.GetUsdImagingDelegate();
-
-    // Update the selection status if it changed.
-    if (*dirtyBits & DirtySelectionHighlight) {
-        _selectionStatus = drawScene.GetSelectionStatus(id);
-    } else {
-        TF_VERIFY(_selectionStatus == drawScene.GetSelectionStatus(id));
-    }
 
     // We don't update the repr if it is hidden by the render tags (purpose)
     // of the ProxyRenderDelegate. In additional, we need to hide any already
@@ -787,6 +779,8 @@ void HdVP2Mesh::Sync(
         _rprimId.asChar(),
         "HdVP2Mesh::Sync");
 
+    UsdImagingDelegate*  usdImagingDelegate = drawScene.GetUsdImagingDelegate();
+    
     // Geom subsets are accessed through the mesh topology. I need to know about
     // the additional materialIds that get bound by geom subsets before we build the
     // _primvaInfo. So the very first thing I need to do is grab the topology.
@@ -831,6 +825,13 @@ void HdVP2Mesh::Sync(
             }
         }
 #endif
+    }
+
+    // Update the selection status if it changed.
+    if (*dirtyBits & DirtySelectionHighlight) {
+        _selectionStatus = drawScene.GetSelectionStatus(id);
+    } else {
+        TF_VERIFY(_selectionStatus == drawScene.GetSelectionStatus(id));
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1016,40 +1016,7 @@ void HdVP2Mesh::Sync(
 
     _PrepareSharedVertexBuffers(delegate, *dirtyBits, reprToken);
 
-    if (HdChangeTracker::IsExtentDirty(*dirtyBits, id)) {
-        _sharedData.bounds.SetRange(delegate->GetExtent(id));
-    }
-
-    if (HdChangeTracker::IsTransformDirty(*dirtyBits, id)) {
-        _sharedData.bounds.SetMatrix(delegate->GetTransform(id));
-    }
-
-    if (HdChangeTracker::IsVisibilityDirty(*dirtyBits, id)) {
-        _sharedData.visible = delegate->GetVisible(id);
-
-        // Invisible rprims don't get calls to Sync or _PropagateDirtyBits while
-        // they are invisible. This means that when a prim goes from visible to
-        // invisible that we must update every repr, because if we switch reprs while
-        // invisible we'll get no chance to update!
-        if (!_sharedData.visible)
-            _MakeOtherReprRenderItemsInvisible(reprToken, _reprs);
-    }
-
-#if PXR_VERSION > 2111
-    // Hydra now manages and caches render tags under the hood and is clearing
-    // the dirty bit prior to calling sync. Unconditionally set the render tag
-    // in the shared data structure based on current Hydra data
-    _RenderTag() = GetRenderTag();
-#else
-    if (*dirtyBits
-        & (HdChangeTracker::DirtyRenderTag
-#ifdef ENABLE_RENDERTAG_VISIBILITY_WORKAROUND
-           | HdChangeTracker::DirtyVisibility
-#endif
-           )) {
-        _RenderTag() = delegate->GetRenderTag(id);
-    }
-#endif
+    _SyncSharedData(_sharedData, delegate, dirtyBits, reprToken, id, _reprs);
 
     *dirtyBits = HdChangeTracker::Clean;
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -2191,24 +2191,20 @@ void HdVP2Mesh::_HideAllDrawItems(const TfToken& reprToken)
         return;
     }
 
-    _MeshReprConfig::DescArray reprDescs = _GetReprDesc(reprToken);
+    const auto& items = curRepr->GetDrawItems();
 
-    // For each relevant draw item, update dirty buffer sources.
-    int drawItemIndex = 0;
-    for (size_t descIdx = 0; descIdx < reprDescs.size(); ++descIdx) {
-        const HdMeshReprDesc& desc = reprDescs[descIdx];
-        if (desc.geomStyle == HdMeshGeomStyleInvalid) {
-            continue;
-        }
-
-        auto* drawItem = static_cast<HdVP2DrawItem*>(curRepr->GetDrawItem(drawItemIndex++));
-        if (!drawItem)
-            continue;
-
-        for (auto& renderItemData : drawItem->GetRenderItems()) {
-            renderItemData._enabled = false;
-            _delegate->GetVP2ResourceRegistry().EnqueueCommit(
-                [&]() { renderItemData._renderItem->enable(false); });
+#if HD_API_VERSION < 35
+    for (HdDrawItem* item : items) {
+        if (HdVP2DrawItem* drawItem = static_cast<HdVP2DrawItem*>(item)) {
+#else
+    for (const HdRepr::DrawItemUniquePtr& item : items) {
+        if (HdVP2DrawItem* const drawItem = static_cast<HdVP2DrawItem*>(item.get())) {
+#endif
+            for (auto& renderItemData : drawItem->GetRenderItems()) {
+                renderItemData._enabled = false;
+                _delegate->GetVP2ResourceRegistry().EnqueueCommit(
+                    [&]() { renderItemData._renderItem->enable(false); });
+            }
         }
     }
 }

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1087,22 +1087,9 @@ void HdVP2Mesh::_InitRepr(const TfToken& reprToken, HdDirtyBits* dirtyBits)
     if (ARCH_UNLIKELY(!subSceneContainer))
         return;
 
-    if (_reprs.empty()) {
-        _FirstInitRepr(dirtyBits, GetId());
-    }
-
-    _ReprVector::const_iterator it
-        = std::find_if(_reprs.begin(), _reprs.end(), _ReprComparator(reprToken));
-    if (it != _reprs.end()) {
-        _SetDirtyRepr(it->second);
+    HdReprSharedPtr repr = _AddNewRepr(reprToken, _reprs, dirtyBits, GetId());
+    if (!repr)
         return;
-    }
-
-    _reprs.emplace_back(reprToken, std::make_shared<HdRepr>());
-    HdReprSharedPtr repr = _reprs.back().second;
-
-    // set dirty bit to say we need to sync a new repr
-    *dirtyBits |= HdChangeTracker::NewRepr;
 
     _MeshReprConfig::DescArray descs = _GetReprDesc(reprToken);
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -817,29 +817,7 @@ void HdVP2Mesh::Sync(
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {
-        const SdfPath materialId = delegate->GetMaterialId(id);
-
-#ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
-        const SdfPath& origMaterialId = GetMaterialId();
-        if (materialId != origMaterialId) {
-            if (!origMaterialId.IsEmpty()) {
-                HdVP2Material* material = static_cast<HdVP2Material*>(
-                    renderIndex.GetSprim(HdPrimTypeTokens->material, origMaterialId));
-                if (material) {
-                    material->UnsubscribeFromMaterialUpdates(id);
-                }
-            }
-
-            if (!materialId.IsEmpty()) {
-                HdVP2Material* material = static_cast<HdVP2Material*>(
-                    renderIndex.GetSprim(HdPrimTypeTokens->material, materialId));
-                if (material) {
-                    material->SubscribeForMaterialUpdates(id);
-                }
-            }
-        }
-#endif
-
+        const SdfPath materialId = _GetUpdatedMaterialId(this, delegate);
 #if HD_API_VERSION < 37
         _SetMaterialId(renderIndex.GetChangeTracker(), materialId);
 #else

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1039,7 +1039,7 @@ void HdVP2Mesh::Sync(
     // Hydra now manages and caches render tags under the hood and is clearing
     // the dirty bit prior to calling sync. Unconditionally set the render tag
     // in the shared data structure based on current Hydra data
-    _meshSharedData->_renderTag = GetRenderTag();
+    _RenderTag() = GetRenderTag();
 #else
     if (*dirtyBits
         & (HdChangeTracker::DirtyRenderTag
@@ -1047,7 +1047,7 @@ void HdVP2Mesh::Sync(
            | HdChangeTracker::DirtyVisibility
 #endif
            )) {
-        _meshSharedData->_renderTag = delegate->GetRenderTag(id);
+        _RenderTag() = delegate->GetRenderTag(id);
     }
 #endif
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1032,7 +1032,7 @@ void HdVP2Mesh::Sync(
         // invisible that we must update every repr, because if we switch reprs while
         // invisible we'll get no chance to update!
         if (!_sharedData.visible)
-            _MakeOtherReprRenderItemsInvisible(delegate, reprToken);
+            _MakeOtherReprRenderItemsInvisible(reprToken, _reprs);
     }
 
 #if PXR_VERSION > 2111
@@ -1409,41 +1409,6 @@ void HdVP2Mesh::_CreateSmoothHullRenderItems(
     }
 
     TF_VERIFY(numFacesWithoutRenderItem == 0);
-}
-
-/*! \brief Hide all of the repr objects for this Rprim except the named repr.
-
-    Repr objects are created to support specific reprName tokens, and contain a list of
-    HdVP2DrawItems and corresponding RenderItems.
-*/
-void HdVP2Mesh::_MakeOtherReprRenderItemsInvisible(
-    HdSceneDelegate* sceneDelegate,
-    const TfToken&   reprToken)
-{
-    for (const std::pair<TfToken, HdReprSharedPtr>& pair : _reprs) {
-        if (pair.first != reprToken) {
-            // For each relevant draw item, update dirty buffer sources.
-            _MeshReprConfig::DescArray reprDescs = _GetReprDesc(pair.first);
-            int                        drawItemIndex = 0;
-            for (size_t descIdx = 0; descIdx < reprDescs.size(); ++descIdx, drawItemIndex++) {
-                const HdMeshReprDesc& desc = reprDescs[descIdx];
-                if (desc.geomStyle == HdMeshGeomStyleInvalid) {
-                    continue;
-                }
-                auto* drawItem
-                    = static_cast<HdVP2DrawItem*>(pair.second->GetDrawItem(drawItemIndex));
-                if (!drawItem)
-                    continue;
-
-                for (auto& renderItemData : drawItem->GetRenderItems()) {
-                    _delegate->GetVP2ResourceRegistry().EnqueueCommit([&renderItemData]() {
-                        renderItemData._enabled = false;
-                        renderItemData._renderItem->enable(false);
-                    });
-                }
-            }
-        }
-    }
 }
 
 /*! \brief  Update the named repr object for this Rprim.

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -54,8 +54,6 @@ namespace {
 const TfTokenVector sFallbackShaderPrimvars
     = { HdTokens->displayColor, HdTokens->displayOpacity, HdTokens->normals };
 
-const MColor kOpaqueBlue(0.0f, 0.0f, 1.0f, 1.0f); //!< Opaque blue
-
 //! Helper utility function to fill primvar data to vertex buffer.
 template <class DEST_TYPE, class SRC_TYPE>
 void _FillPrimvarData(
@@ -1281,7 +1279,7 @@ void HdVP2Mesh::_InitRepr(const TfToken& reprToken, HdDirtyBits* dirtyBits)
             }
             // The item is used for bbox display and selection highlight.
             else if (reprToken == HdVP2ReprTokens->bbox) {
-                renderItem = _CreateBoundingBoxRenderItem(renderItemName);
+                renderItem = _CreateBoundingBoxRenderItem(renderItemName, kOpaqueBlue, MSelectionMask::kSelectMeshes, MHWRender::MFrameContext::kExcludeMeshes);
                 drawItem->AddUsage(HdVP2DrawItem::kSelectionHighlight);
             }
             break;
@@ -2604,33 +2602,6 @@ MHWRender::MRenderItem* HdVP2Mesh::_CreateWireframeRenderItem(const MString& nam
 #else
     renderItem->setSelectionMask(MSelectionMask::kSelectMeshes);
 #endif
-#ifdef MAYA_MRENDERITEM_UFE_IDENTIFIER_SUPPORT
-    auto* const          param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
-    ProxyRenderDelegate& drawScene = param->GetDrawScene();
-    drawScene.setUfeIdentifiers(*renderItem, _PrimSegmentString);
-#endif
-
-#if MAYA_API_VERSION >= 20220000
-    renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeMeshes);
-#endif
-
-    _SetWantConsolidation(*renderItem, true);
-
-    return renderItem;
-}
-
-/*! \brief  Create render item for bbox repr.
- */
-MHWRender::MRenderItem* HdVP2Mesh::_CreateBoundingBoxRenderItem(const MString& name) const
-{
-    MHWRender::MRenderItem* const renderItem = MHWRender::MRenderItem::Create(
-        name, MHWRender::MRenderItem::DecorationItem, MHWRender::MGeometry::kLines);
-
-    renderItem->setDrawMode(MHWRender::MGeometry::kBoundingBox);
-    renderItem->castsShadows(false);
-    renderItem->receivesShadows(false);
-    renderItem->setShader(_delegate->Get3dSolidShader(kOpaqueBlue));
-    renderItem->setSelectionMask(MSelectionMask::kSelectMeshes);
 #ifdef MAYA_MRENDERITEM_UFE_IDENTIFIER_SUPPORT
     auto* const          param = static_cast<HdVP2RenderParam*>(_delegate->GetRenderParam());
     ProxyRenderDelegate& drawScene = param->GetDrawScene();

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
@@ -171,7 +171,6 @@ private:
         MSubSceneContainer& subSceneContainer,
         const HdGeomSubset* geomSubset) const;
     MHWRender::MRenderItem* _CreateSelectionHighlightRenderItem(const MString& name) const;
-    MHWRender::MRenderItem* _CreateWireframeRenderItem(const MString& name) const;
 
 #ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
     MHWRender::MRenderItem* _CreatePointsRenderItem(const MString& name) const;

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
@@ -135,6 +135,8 @@ private:
     void _CreateOSDTables();
 #endif
 
+    TfToken& _RenderTag() override { return _meshSharedData->_renderTag; }
+
     void _UpdateDrawItem(
         HdSceneDelegate*,
         HdVP2DrawItem*,

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
@@ -172,10 +172,6 @@ private:
         const HdGeomSubset* geomSubset) const;
     MHWRender::MRenderItem* _CreateSelectionHighlightRenderItem(const MString& name) const;
 
-#ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
-    MHWRender::MRenderItem* _CreatePointsRenderItem(const MString& name) const;
-#endif
-
     static void _InitGPUCompute();
 
     //! Custom dirty bits used by this mesh

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
@@ -172,7 +172,6 @@ private:
         const HdGeomSubset* geomSubset) const;
     MHWRender::MRenderItem* _CreateSelectionHighlightRenderItem(const MString& name) const;
     MHWRender::MRenderItem* _CreateWireframeRenderItem(const MString& name) const;
-    MHWRender::MRenderItem* _CreateBoundingBoxRenderItem(const MString& name) const;
 
 #ifndef MAYA_NEW_POINT_SNAPPING_SUPPORT
     MHWRender::MRenderItem* _CreatePointsRenderItem(const MString& name) const;

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
@@ -125,7 +125,6 @@ private:
     void _InitRepr(const TfToken&, HdDirtyBits*) override;
 
     void _UpdateRepr(HdSceneDelegate*, const TfToken&);
-    void _MakeOtherReprRenderItemsInvisible(HdSceneDelegate*, const TfToken&);
 
     bool _PrimvarIsRequired(const TfToken&) const;
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
@@ -142,8 +142,6 @@ private:
         const HdMeshReprDesc& desc,
         const TfToken&        reprToken);
 
-    void _HideAllDrawItems(const TfToken& reprToken);
-
     void _UpdatePrimvarSources(
         HdSceneDelegate*     sceneDelegate,
         HdDirtyBits          dirtyBits,


### PR DESCRIPTION
Final part of the code refactoring that merges more common methods into MayaUsdRPrim class.