### PR TITLE
MAYA-121450 - Error when attempting to add a Maya reference to a vari…

### DIFF
--- a/lib/mayaUsd/resources/scripts/mayaUsdAddMayaReference.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdAddMayaReference.py
@@ -154,7 +154,7 @@ def createMayaReferencePrim(ufePathStr, mayaReferencePath, mayaNamespace,
             groupPrim = Usd.Prim()
         if not groupPrim.IsValid():
             errorMsgFormat = getMayaUsdLibString('kErrorCreatingGroupPrim')
-            errorMsg = cmds.format(errorMsgFormat, stringArg=(ufePathStr))
+            errorMsg = cmds.format(errorMsgFormat, stringArg=(ufePathStr, groupPrimName))
             om.MGlobal.displayError(errorMsg)
             return Usd.Prim()
         if groupPrimKind:
@@ -178,9 +178,16 @@ def createMayaReferencePrim(ufePathStr, mayaReferencePath, mayaNamespace,
         # If we created a group prim add the variant set there, otherwise add it
         # to the prim that corresponds to the input ufe path.
         variantPrim = groupPrim if groupPrim else mayaUsd.ufe.ufePathToPrim(ufePathStr)
-        vset = variantPrim.GetVariantSet(validatedVariantSetName)
-        vset.AddVariant(validatedVariantName)
-        vset.SetVariantSelection(validatedVariantName)
+        try:
+            vset = variantPrim.GetVariantSet(validatedVariantSetName)
+            vset.AddVariant(validatedVariantName)
+            vset.SetVariantSelection(validatedVariantName)
+        except (Tf.ErrorException):
+            errorMsgFormat = getMayaUsdLibString('kErrorCreateVariantSet')
+            errorMsg = cmds.format(errorMsgFormat,
+                                   stringArg=(str(variantPrim.GetPrimPath()), validatedVariantName, str(variantPrim.GetName())))
+            om.MGlobal.displayError(errorMsg)
+            return Usd.Prim()
         with vset.GetVariantEditContext():
             # Now all of our subsequent edits will go "inside" the
             # 'variantName' variant of 'variantSetName'.
@@ -189,7 +196,7 @@ def createMayaReferencePrim(ufePathStr, mayaReferencePath, mayaNamespace,
         prim = createPrimAndAttributes(stage, primPath, mayaReferencePath, mayaNamespace, mayaAutoEdit)
     if prim is None or not prim.IsValid():
         errorMsgFormat = getMayaUsdLibString('kErrorCreatingMayaRefPrim')
-        errorMsg = cmds.format(errorMsgFormat, stringArg=(ufePathStr))
+        errorMsg = cmds.format(errorMsgFormat, stringArg=(ufePathStr, validatedPrimName))
         om.MGlobal.displayError(errorMsg)
         return Usd.Prim()
 

--- a/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
@@ -31,11 +31,12 @@ def mayaUsdLibRegisterStrings():
     # Any python strings from MayaUsd lib go here.
 
     # mayaUsdAddMayaReference.py
-    register('kErrorGroupPrimExists', 'Group prim name "^1s" already exists under "^2s".')
-    register('kErrorCannotAddToProxyShape', 'Cannot add Maya Reference node to ProxyShape with VariantSet unless Group prim is used.')
-    register('kErrorMayaRefPrimExists', 'Maya Reference prim name "^1s" already exists under "^2s".')
-    register('kErrorCreatingGroupPrim', 'Could not create Group prim under "^1s".')
-    register('kErrorCreatingMayaRefPrim', 'Could not create MayaReference prim under "^1s".')
+    register('kErrorGroupPrimExists', 'Group prim "^1s" already exists under "^2s". Choose prim name other than "^1s" to proceed.')
+    register('kErrorCannotAddToProxyShape', 'Cannot add Maya Reference node to ProxyShape with Variant Set unless grouped. Enable Group checkbox to proceed.')
+    register('kErrorMayaRefPrimExists', 'Maya Reference prim "^1s" already exists under "^2s". Choose Maya Reference prim name other than "^1s" to proceed.')
+    register('kErrorCreatingGroupPrim', 'Cannot create group prim under "^1s". Ensure target layer is editable and "^2s" can be added to "^1s".')
+    register('kErrorCreatingMayaRefPrim', 'Cannot create MayaReference prim under "^1s". Ensure target layer is editable and "^2s" can be added to "^1s".')
+    register('kErrorCreateVariantSet', 'Cannot create Variant Set on prim at path "^1s". Ensure target layer is editable and "^2s" can be added to "^3s".')
 
     # mayaUsdCacheMayaReference.py
     register('kButtonNewChildPrim', 'New Child Prim')

--- a/test/lib/mayaUsd/fileio/testAddMayaReference.py
+++ b/test/lib/mayaUsd/fileio/testAddMayaReference.py
@@ -143,6 +143,21 @@ class AddMayaReferenceTestCase(unittest.TestCase):
         self.assertTrue(attr.IsValid())
         self.assertEqual(attr.Get(),True)
 
+        # Test an error creating the Variant Set by disabling permission to edit on the
+        # edit target layer.
+        editTarget = self.stage.GetEditTarget()
+        editLayer = editTarget.GetLayer()
+        editLayer.SetPermissionToEdit(False)
+        badMayaRefPrim = mayaUsdAddMayaReference.createMayaReferencePrim(
+            primPathStr,
+            self.mayaSceneStr,
+            self.kDefaultNamespace,
+            mayaReferencePrimName='PrimVariantFail',
+            variantSet=('VariantFailSet', 'VariantNameFail'),
+            mayaAutoEdit=False)
+        self.assertFalse(badMayaRefPrim.IsValid())
+        editLayer.SetPermissionToEdit(True)
+
     def testBadNames(self):
         '''Test using bad prim and variant names.
 


### PR DESCRIPTION
#### MAYA-121450 - Error when attempting to add a Maya reference to a variant when the Layer edits are locked
* Update error messages.
* Added error message/test for Variant Set creation error.