### PR TITLE
MAYA-115079: USD: MayaUsd test failures with USD built with AssetResolver 2

### DIFF
--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
@@ -37,6 +37,7 @@
 
 #include <maya/MDGModifier.h>
 #include <maya/MFileIO.h>
+#include <maya/MFileObject.h>
 #include <maya/MFnCamera.h>
 #include <maya/MFnDagNode.h>
 #include <maya/MFnStringData.h>
@@ -324,6 +325,10 @@ MStatus UsdMayaTranslatorMayaReference::update(const UsdPrim& prim, MObject pare
     if (!mayaReferencePath.length()) {
         return MS::kFailure;
     }
+    MFileObject fileObj;
+    fileObj.setRawFullName(mayaReferencePath);
+    mayaReferencePath = fileObj.resolvedFullName();
+
     TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
         .Msg(
             "MayaReferenceLogic::update Looking for attribute on \"%s\".\"%s\"\n",

--- a/test/lib/mayaUsd/fileio/CMakeLists.txt
+++ b/test/lib/mayaUsd/fileio/CMakeLists.txt
@@ -4,6 +4,9 @@ set(TEST_SCRIPT_FILES
     testExportChaser.py
     testImportChaser.py
     testJobContextRegistry.py
+
+    # Once of the tests in this file requires UsdMaya (from the Pixar plugin). That test
+    # will be skipped if not found (probably because BUILD_PXR_PLUGIN is off).
     testSchemaApiAdaptor.py
 )
 if (MAYA_APP_VERSION VERSION_GREATER_EQUAL 2022)

--- a/test/lib/mayaUsd/fileio/testAddMayaReference.py
+++ b/test/lib/mayaUsd/fileio/testAddMayaReference.py
@@ -28,7 +28,7 @@ from maya import standalone
 import mayaUsdAddMayaReference
 import mayaUsdMayaReferenceUtils as mayaRefUtils
 
-import unittest
+import os, unittest
 
 class AddMayaReferenceTestCase(unittest.TestCase):
     '''Test Add Maya Reference.
@@ -135,7 +135,7 @@ class AddMayaReferenceTestCase(unittest.TestCase):
         # and that it has the expected metadata.
         attr = mayaRefPrim.GetAttribute('mayaReference')
         self.assertTrue(attr.IsValid())
-        self.assertEqual(attr.Get().resolvedPath, self.mayaSceneStr)
+        self.assertTrue(os.path.samefile(attr.Get().resolvedPath, self.mayaSceneStr))
         attr = mayaRefPrim.GetAttribute('mayaNamespace')
         self.assertTrue(attr.IsValid())
         self.assertEqual(attr.Get(), self.kDefaultNamespace)

--- a/test/lib/mayaUsd/fileio/testSchemaApiAdaptor.py
+++ b/test/lib/mayaUsd/fileio/testSchemaApiAdaptor.py
@@ -17,12 +17,19 @@
 
 import mayaUsd.lib as mayaUsdLib
 
-from pxr import Tf, Gf, UsdMaya, Usd
+from pxr import Tf, Gf, Usd
 
 from maya import cmds
 import maya.api.OpenMaya as om
 import maya.api.OpenMayaAnim as oma
 from maya import standalone
+
+HAS_USDMAYA = False
+try:
+    from pxr import UsdMaya
+    HAS_USDMAYA = True
+except ImportError as ie:
+    pass
 
 HAS_BULLET = False
 try:
@@ -294,7 +301,7 @@ class testSchemaApiAdaptor(unittest.TestCase):
         colorAttr.Set((1,0,1))
         self.assertEqual(cmds.getAttr(lightShape1 + ".shadowColor"), [(1.0, 0.0, 1.0)])
 
-    @unittest.skipUnless(HAS_BULLET, 'Requires the bullet plugin.')  
+    @unittest.skipUnless(HAS_BULLET and HAS_USDMAYA, 'Requires the Pixar and bullet plugins.')
     def testComplexAdaptation(self):
         """Test that we can adapt a bullet simulation"""
 

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -22,7 +22,6 @@ set(TEST_SCRIPT_FILES
     testUsdExportNurbsCurve.py
     testUsdExportOpenLayer.py
     testUsdExportOverImport.py
-    testUsdExportUsdzPackage.py
     testUsdExportUsdPreviewSurface.py
     testUsdExportParentScope.py
     # To investigate: following test asserts in MFnParticleSystem, but passes.
@@ -90,6 +89,13 @@ if(BUILD_PXR_PLUGIN)
     # Pixar plugin.
     list(APPEND TEST_SCRIPT_FILES
         testUsdExportUVTransforms.py
+    )
+
+    # This test uses the file "asset.ma" which
+    # requires the plugin "pxrUsdPreviewSurface" that is built by the
+    # Pixar plugin.
+    list(APPEND TEST_SCRIPT_FILES
+        testUsdExportUsdzPackage.py
     )
 endif()
 
@@ -242,6 +248,8 @@ set_property(TEST testUsdMayaListShadingModesCommand APPEND PROPERTY LABELS tran
 
 # Requires Physics API to test some exporters:
 if (PXR_VERSION VERSION_GREATER 2105)
+    # Once of the tests in this file requires UsdMaya (from the Pixar plugin). That test
+    # will be skipped if not found (probably because BUILD_PXR_PLUGIN is off).
     mayaUsd_add_test(testUsdExportSchemaApi
         PYTHON_MODULE testUsdExportSchemaApi
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/test/lib/usd/translators/testUsdExportSchemaApi.py
+++ b/test/lib/usd/translators/testUsdExportSchemaApi.py
@@ -23,9 +23,16 @@ from maya import standalone
 import maya.api.OpenMaya as om
 import maya.api.OpenMayaAnim as oma
 
-from pxr import Tf, Gf, UsdMaya, Usd
+from pxr import Tf, Gf, Usd
 
 import fixturesUtils
+
+HAS_USDMAYA = False
+try:
+    from pxr import UsdMaya
+    HAS_USDMAYA = True
+except ImportError as ie:
+    pass
 
 HAS_BULLET = False
 try:
@@ -130,7 +137,7 @@ class testUsdExportSchemaApi(unittest.TestCase):
 
         cmds.file(f=True, new=True)
 
-    @unittest.skipUnless(HAS_BULLET, 'Requires the bullet plugin.')  
+    @unittest.skipUnless(HAS_BULLET and HAS_USDMAYA, 'Requires the Pixar and bullet plugins.')
     def testPluginSchemaAdaptors(self):
         """Testing a plugin Schema adaptor in a generic context:"""
 


### PR DESCRIPTION
#### MAYA-115079: USD: MayaUsd test failures with USD built with AssetResolver 2
* Code + test fixes for Usd compiled with AssetResolver v2.
* Minor test fixes when missing Pixar plugin.