### PR TITLE
Fixed recursive calls to bound Python translators under Python 3

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/wrapTranslatorBase.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/wrapTranslatorBase.cpp
@@ -96,6 +96,11 @@ public:
         return this->CallPureVirtual<TfType>("getTranslatedType")();
     }
 
+    std::size_t default_generateUniqueKey(const UsdPrim& prim) const
+    {
+        return base_t::generateUniqueKey(prim);
+    }
+
     std::size_t generateUniqueKey(const UsdPrim& prim) const override
     {
         if (Override o = GetOverride("generateUniqueKey")) {
@@ -114,6 +119,8 @@ public:
         return 0;
     }
 
+    bool default_needsTransformParent() const { return base_t::needsTransformParent(); }
+
     bool needsTransformParent() const override
     {
         return this->CallVirtual<bool>("needsTransformParent", &This::needsTransformParent)();
@@ -124,14 +131,23 @@ public:
         return this->CallVirtual<bool>("supportsUpdate", &This::supportsUpdate)();
     }
 
+    bool default_importableByDefault() const { return base_t::importableByDefault(); }
+
     bool importableByDefault() const override
     {
         return this->CallVirtual<bool>("importableByDefault", &This::importableByDefault)();
     }
 
+    MStatus default_initialize() { return base_t::initialize(); }
+
     MStatus initialize() override
     {
         return this->CallVirtual<MStatus>("initialize", &This::initialize)();
+    }
+
+    MStatus default_import(const UsdPrim& prim, MObject& parent, MObject& createdObj)
+    {
+        return base_t::import(prim, parent, createdObj);
     }
 
     MStatus import(const UsdPrim& prim, MObject& parent, MObject& createdObj) override
@@ -149,6 +165,8 @@ public:
         return MS::kSuccess;
     }
 
+    MStatus default_postImport(const UsdPrim& prim) { return base_t::postImport(prim); }
+
     MStatus postImport(const UsdPrim& prim) override
     {
         if (Override o = GetOverride("postImport")) {
@@ -158,10 +176,14 @@ public:
         return MS::kSuccess;
     }
 
+    MStatus default_preTearDown(UsdPrim& prim) { return base_t::preTearDown(prim); }
+
     MStatus preTearDown(UsdPrim& prim) override
     {
         return this->CallVirtual<MStatus>("preTearDown", &This::preTearDown)(prim);
     }
+
+    MStatus default_tearDown(const SdfPath& path) { return base_t::tearDown(path); }
 
     MStatus tearDown(const SdfPath& path) override
     {
@@ -173,6 +195,8 @@ public:
         return this->CallVirtual<MStatus>("update", &This::update)(prim);
     }
 
+    ExportFlag default_canExport(const MObject& obj) { return base_t::canExport(obj); }
+
     ExportFlag canExport(const MObject& obj) override
     {
         MFnDependencyNode fn(obj);
@@ -183,6 +207,15 @@ public:
             return std::function<ExportFlag(const char*)>(TfPyCall<ExportFlag>(o))(name.c_str());
         }
         return ExportFlag::kNotSupported;
+    }
+
+    UsdPrim default_exportObject(
+        UsdStageRefPtr                             stage,
+        MDagPath                                   dagPath,
+        const SdfPath&                             usdPath,
+        const AL::usdmaya::fileio::ExporterParams& params)
+    {
+        return base_t::exportObject(stage, dagPath, usdPath, params);
     }
 
     UsdPrim exportObject(
@@ -295,27 +328,33 @@ void wrapTranslatorBase()
         "TranslatorBase", boost::python::no_init)
         .def(TfPyRefAndWeakPtr())
         .def(TfMakePyConstructor(&TranslatorBaseWrapper::New))
-        .def("initialize", &TranslatorBase::initialize, &TranslatorBaseWrapper::initialize)
+        .def("initialize", &TranslatorBase::initialize, &TranslatorBaseWrapper::default_initialize)
         .def("getTranslatedType", boost::python::pure_virtual(&TranslatorBase::getTranslatedType))
         .def(
             "generateUniqueKey",
             &TranslatorBase::generateUniqueKey,
-            &TranslatorBaseWrapper::generateUniqueKey)
+            &TranslatorBaseWrapper::default_generateUniqueKey)
         .def("context", &TranslatorBase::context)
         .def(
             "needsTransformParent",
             &TranslatorBase::needsTransformParent,
-            &TranslatorBaseWrapper::needsTransformParent)
+            &TranslatorBaseWrapper::default_needsTransformParent)
         .def(
             "importableByDefault",
             &TranslatorBase::importableByDefault,
-            &TranslatorBaseWrapper::importableByDefault)
-        .def("importObject", &TranslatorBase::import, &TranslatorBaseWrapper::import)
-        .def("exportObject", &TranslatorBase::exportObject, &TranslatorBaseWrapper::exportObject)
-        .def("postImport", &TranslatorBase::postImport, &TranslatorBaseWrapper::postImport)
-        .def("preTearDown", &TranslatorBase::preTearDown, &TranslatorBaseWrapper::preTearDown)
-        .def("tearDown", &TranslatorBase::tearDown, &TranslatorBaseWrapper::tearDown)
-        .def("canExport", &TranslatorBase::canExport, &TranslatorBaseWrapper::canExport)
+            &TranslatorBaseWrapper::default_importableByDefault)
+        .def("importObject", &TranslatorBase::import, &TranslatorBaseWrapper::default_import)
+        .def(
+            "exportObject",
+            &TranslatorBase::exportObject,
+            &TranslatorBaseWrapper::default_exportObject)
+        .def("postImport", &TranslatorBase::postImport, &TranslatorBaseWrapper::default_postImport)
+        .def(
+            "preTearDown",
+            &TranslatorBase::preTearDown,
+            &TranslatorBaseWrapper::default_preTearDown)
+        .def("tearDown", &TranslatorBase::tearDown, &TranslatorBaseWrapper::default_tearDown)
+        .def("canExport", &TranslatorBase::canExport, &TranslatorBaseWrapper::default_canExport)
         .def("stage", &TranslatorBaseWrapper::stage)
         .def("getMObjects", &TranslatorBaseWrapper::getMObjects)
         .def(

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testTranslators.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testTranslators.py
@@ -281,7 +281,6 @@ class TestPythonTranslators(unittest.TestCase):
         prim = stage.GetPrimAtPath('/root/peter01/rig')
         # self.assertTrue(usdmaya.TranslatorBase.generateTranslatorId(prim)=="assettype:beast_rig")
 
-    @unittest.skipIf(sys.version_info[0] >= 3, "RecursionError: maximum recursion depth exceeded while calling a Python object")
     def test_variantSwitch_that_removes_prim_and_create_new_one(self):
 
         usdmaya.TranslatorBase.registerTranslator(CubeGenerator(), 'beast_rig')
@@ -303,7 +302,11 @@ class TestPythonTranslators(unittest.TestCase):
         '''
         Variant switch that leads to another prim being created.
         '''
-        vs.SetVariantSelection("sixCubesRig2")
+        try:
+            vs.SetVariantSelection("sixCubesRig2")
+        except RecursionError:
+            # Force RecursionErrors to fail the test instead of erroring them
+            self.fail("Raised RecursionError unexpectedly!")
 
         self.assertEqual(CubeGenerator.getState()["tearDownCount"],1)
         self.assertEqual(CubeGenerator.getState()["importObjectCount"],2)
@@ -338,7 +341,6 @@ class TestPythonTranslators(unittest.TestCase):
         self.assertEqual(CubeGenerator.getState()["importObjectCount"], 1)
         self.assertFalse(cmds.objExists('|bobo|root|peter01|rig'))
 
-    @unittest.skipIf(sys.version_info[0] >= 3, "RecursionError: maximum recursion depth exceeded while calling a Python object")
     def test_variantSwitch_that_keeps_existing_prim_runs_teardown_and_import(self):
         usdmaya.TranslatorBase.registerTranslator(CubeGenerator(), 'beast_rig')
 
@@ -366,7 +368,11 @@ class TestPythonTranslators(unittest.TestCase):
         '''
         Variant switch that leads to same prim still existing.
         '''
-        vs.SetVariantSelection("sixCubesRig")
+        try:
+            vs.SetVariantSelection("sixCubesRig")
+        except RecursionError:
+            # Force RecursionErrors to fail the test instead of erroring them
+            self.fail("Raised RecursionError unexpectedly!")
 
         self.assertEqual(CubeGenerator.getState()["tearDownCount"],1)
         self.assertEqual(CubeGenerator.getState()["importObjectCount"],2)


### PR DESCRIPTION
Maya was spitting out `RecursionError`s when enabling or disabling certain Python translated objects. It was also noted that similar `RecursionError`s would be generated from a handful of other operations concerning the Python translators. It was later identified that the error would only occur in Python 3.

It was found that the fallback method (to be called in the event no Python override existed for it) was not properly wired up in such a way that it would short the method and still technically function correctly under Python 2:

```cpp
std::size_t generateUniqueKey(const UsdPrim& prim) const override
{
    if (Override o = GetOverride("generateUniqueKey")) {
        auto res = std::function<boost::python::object(const UsdPrim&)>(
            TfPyCall<boost::python::object>(o))(prim);
        if (!res) {
            return 0;
        }
        TfPyLock                            pyLock;
        boost::python::str                  strObj(res);
        boost::python::extract<std::string> strValue(strObj);
        if (strValue.check()) {
            return std::hash<std::string> {}(strValue);
        }
    }
    return 0;
}

...

.def(
    "generateUniqueKey",
    &TranslatorBase::generateUniqueKey,
    &TranslatorBaseWrapper::generateUniqueKey) // <- fallback method, calling wrapper override
```

Default methods were added to properly redirect to the base class as so:
```cpp
std::size_t default_generateUniqueKey(const UsdPrim& prim) const
{
    return base_t::generateUniqueKey(prim);
}

std::size_t generateUniqueKey(const UsdPrim& prim) const override

...

.def(
    "generateUniqueKey",
    &TranslatorBase::generateUniqueKey,
    &TranslatorBaseWrapper::default_generateUniqueKey) // <- fallback method, calling default method to base
```

This solution has been applied to each of the bound methods and seems to now be running without recursion errors (which were previously silenced) under both Python versions.