### PR TITLE
Pr/fix import of usd lux light prims

### DIFF
--- a/lib/usd/translators/scopeReader.cpp
+++ b/lib/usd/translators/scopeReader.cpp
@@ -24,8 +24,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-static bool
-_IsShadingNode(const UsdPrim& prim)
+static bool _IsShadingNode(const UsdPrim& prim)
 {
     // Note, UsdShadeShader prims are used in other contexts that aren't just
     // surface shading, so we just look for UsdShadeMaterial nodes.

--- a/lib/usd/translators/scopeReader.cpp
+++ b/lib/usd/translators/scopeReader.cpp
@@ -18,21 +18,30 @@
 
 #include <pxr/pxr.h>
 #include <pxr/usd/usd/prim.h>
-#include <pxr/usd/usdShade/connectableAPI.h>
+#include <pxr/usd/usdShade/material.h>
 
 #include <maya/MObject.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+static bool
+_IsShadingNode(const UsdPrim& prim)
+{
+    // Note, UsdShadeShader prims are used in other contexts that aren't just
+    // surface shading, so we just look for UsdShadeMaterial nodes.
+    return prim.IsA<UsdShadeMaterial>();
+}
+
 PXRUSDMAYA_DEFINE_READER(UsdGeomScope, args, context)
 {
     const UsdPrim& usdPrim = args.GetUsdPrim();
 
-    // If this scope contains only UsdShade nodes, just skip.
+    // If this scope contains only "shading" nodes (as in the "Looks" or
+    // "Material" scopes that is often in assets), just skip.
     bool hasShadingData = false;
     bool hasNonShadingData = false;
     for (const auto& child : usdPrim.GetChildren()) {
-        if (UsdShadeConnectableAPI(child)) {
+        if (_IsShadingNode(child)) {
             hasShadingData = true;
         } else {
             hasNonShadingData = true;

--- a/test/lib/usd/translators/UsdImportLightTest/LightsTest.usda
+++ b/test/lib/usd/translators/UsdImportLightTest/LightsTest.usda
@@ -128,4 +128,10 @@ def Xform "LightsTest" (
         uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
     }
 
+    def Scope "NonMaterialsScope"
+    {
+        def RectLight "NonRootRectLight"
+        {
+        }
+    }
 }

--- a/test/lib/usd/translators/UsdImportLightTest/LightsTest_2011.usda
+++ b/test/lib/usd/translators/UsdImportLightTest/LightsTest_2011.usda
@@ -128,4 +128,10 @@ def Xform "LightsTest" (
         uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
     }
 
+    def Scope "NonMaterialsScope"
+    {
+        def RectLight "NonRootRectLight"
+        {
+        }
+    }
 }

--- a/test/lib/usd/translators/UsdImportLightTest/LightsTest_2102.usda
+++ b/test/lib/usd/translators/UsdImportLightTest/LightsTest_2102.usda
@@ -128,4 +128,10 @@ def Xform "LightsTest" (
         uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
     }
 
+    def Scope "NonMaterialsScope"
+    {
+        def RectLight "NonRootRectLight"
+        {
+        }
+    }
 }

--- a/test/lib/usd/translators/UsdImportRfMLightTest/RfMLightsTest.usda
+++ b/test/lib/usd/translators/UsdImportRfMLightTest/RfMLightsTest.usda
@@ -266,5 +266,12 @@ def Xform "RfMLightsTest" (
             }
         }
     }
+
+    def Scope "NonMaterialsScope"
+    {
+        def RectLight "NonRootRectLight"
+        {
+        }
+    }
 }
 

--- a/test/lib/usd/translators/testUsdImportLight.py
+++ b/test/lib/usd/translators/testUsdImportLight.py
@@ -234,6 +234,16 @@ class testUsdImportLight(unittest.TestCase):
         if getMayaAPIVersion() > 2019:
             self.assertTrue(cmds.getAttr('%s.normalize' % nodePath) == 0)
    
+    def _ValidateLightImportedUnderScope(self):
+        # This tests a case where the "Scope" translator was treating lights as
+        # materials and deciding to not translate the scope.  This would result in
+        # the "NonRootRectLight" here to be translated at the scene root.
+        nodePath = '|LightsTest|NonMaterialsScope|NonRootRectLight'
+        depNodeFn = self._GetMayaDependencyNode(nodePath)
+
+        # _GetMayaDependencyNode already does this assert, but in case we ever
+        # remove that, just redundantly assert here.
+        self.assertTrue(depNodeFn)
 
     def testImportMayaLights(self):
         """
@@ -243,6 +253,7 @@ class testUsdImportLight(unittest.TestCase):
         self._ValidateMayaPointLight()
         self._ValidateMayaSpotLight()
         self._ValidateMayaAreaLight()
+        self._ValidateLightImportedUnderScope()
 
 
 

--- a/test/lib/usd/translators/testUsdImportRfMLight.py
+++ b/test/lib/usd/translators/testUsdImportRfMLight.py
@@ -347,6 +347,17 @@ class testUsdImportRfMLight(unittest.TestCase):
         self.assertTrue(Gf.IsClose(cmds.getAttr('%s.shadowFalloffGamma' % nodePath),
             expectedShadowFalloffGamma, 1e-6))
 
+    def _ValidatePxrLightImportedUnderScope(self):
+        # This tests a case where the "Scope" translator was treating lights as
+        # materials and deciding to not translate the scope.  This would result in
+        # the "NonRootRectLight" here to be translated at the scene root.
+        nodePath = '|RfMLightsTest|NonMaterialsScope|NonRootRectLight'
+        depNodeFn = self._GetMayaDependencyNode(nodePath)
+
+        # _GetMayaDependencyNode already does this assert, but in case we ever
+        # remove that, just redundantly assert here.
+        self.assertTrue(depNodeFn)
+
     def testImportRenderManForMayaLights(self):
         """
         Tests that UsdLux schema USD prims import into Maya as the appropriate
@@ -379,6 +390,8 @@ class testUsdImportRfMLight(unittest.TestCase):
         self._ValidateMayaLightShaping()
 
         self._ValidateMayaLightShadow()
+
+        self._ValidatePxrLightImportedUnderScope()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes a bug where UsdLuxLight prims underneath a Scope
were not being imported properly (if the Scope only had light prims
underneath it).

The import logic for "Scope" uses a heuristic to see if that scope is a
"Looks" or "Materials" scope.  It did this by checking if any of the
children nodes were UsdShadeConnectableAPI.  Unfortunately, lights (and
other non-shading prims) can be UsdShadeConnectableAPI.

This new heursistic checks for Material prims.  Note, this was more or
less the original version that Autodesk proposed in:
https://github.com/Autodesk/maya-usd/pull/985