### PR TITLE
MAYA-114855 - Ufe v1: Crash when interacting with Outliner after unloading payload

### DIFF
--- a/lib/mayaUsd/ufe/StagesSubject.cpp
+++ b/lib/mayaUsd/ufe/StagesSubject.cpp
@@ -386,8 +386,7 @@ void StagesSubject::stageChanged(
 #ifndef MAYA_ENABLE_NEW_PRIM_DELETE
             }
 #endif
-        }
-        else if (!prim.IsValid() && !InPathChange::inPathChange()) {
+        } else if (!prim.IsValid() && !InPathChange::inPathChange()) {
             Ufe::SceneItem::Ptr sceneItem = Ufe::Hierarchy::createItem(ufePath);
             if (!sceneItem || InAddOrDeleteOperation::inAddOrDeleteOperation()) {
                 sendObjectDestroyed(ufePath);


### PR DESCRIPTION
MAYA-114855 - [GIthub #1688] crashes when a user tries to interact with the outliner after unloading a payload.

* Use helpers to mimic some specific Ufe v2 notifs in Ufe v1.