### PR TITLE
Varying display colour bug

### DIFF
--- a/plugin/al/plugin/AL_USDMayaTestPlugin/py/testCommands.py
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/py/testCommands.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2020 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import tempfile
+import unittest
+
+from maya import cmds
+
+from pxr import Sdf, Usd, UsdGeom
+
+
+class TestImportCommand(unittest.TestCase):
+    """Test cases for AL_USDMaya importer command"""
+
+    app = "maya"
+
+    def setUp(self):
+        """Export some sphere geometry as .usda, and import into a new Maya scene."""
+
+        cmds.file(force=True, new=True)
+        cmds.loadPlugin("AL_USDMayaPlugin", quiet=True)
+        self.assertTrue(cmds.pluginInfo("AL_USDMayaPlugin", query=True, loaded=True))
+
+    def tearDown(self):
+        """Unload plugin, new Maya scene, reset class member variables."""
+
+        cmds.file(force=True, new=True)
+        cmds.unloadPlugin("AL_USDMayaPlugin", force=True)
+
+    def test_varyingDisplayColorConstantOpacity(self):
+        """ Varying displayOpacity primvar authored alongside constant displayOpacity
+        """
+
+        pathin = "../test_data/cube_displayColor.usda"
+        _, pathout = tempfile.mkstemp(suffix=".usda")
+
+        cmds.AL_usdmaya_ImportCommand(file=pathin)
+        cmds.AL_usdmaya_ExportCommand(file=pathout)
+
+        primpath = "/cube"
+
+        stagein = Usd.Stage.Open(pathin)
+        gprimin = UsdGeom.Mesh(stagein.GetPrimAtPath(primpath))
+        primvarin = gprimin.GetDisplayColorPrimvar()
+        valuein = primvarin.GetAttr().Get()
+
+        stageout = Usd.Stage.Open(pathout)
+        gprimout = UsdGeom.Mesh(stageout.GetPrimAtPath(primpath))
+        primvarout = gprimout.GetDisplayColorPrimvar()
+        valueout = primvarout.GetAttr().Get()
+
+        self.assertEqual(
+            primvarin.GetDeclarationInfo(), primvarout.GetDeclarationInfo()
+        )
+        self.assertEqual(valuein, valueout)
+
+        os.remove(pathout)
+
+
+if __name__ == "__main__":
+
+    tests = [
+        unittest.TestLoader().loadTestsFromTestCase(TestImportCommand),
+    ]
+    results = [unittest.TextTestRunner(verbosity=2).run(test) for test in tests]
+    exitCode = int(not all([result.wasSuccessful() for result in results]))
+    # Note: cmds.quit() does not return exit code as expected, we use Python builtin function instead
+    os._exit(exitCode)

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/test_data/cube_displayColor.usda
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/test_data/cube_displayColor.usda
@@ -1,0 +1,18 @@
+#usda 1.0
+(
+    defaultPrim = "cube"
+)
+
+def Mesh "cube"
+{
+    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+    int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+    point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5)]
+    color3f[] primvars:displayColor = [(1, 0, 1), (1, 1, 1), (1, 1, 0), (0, 1, 1), (0, 0, 1), (1, 0, 0), (1, 1, 0), (0, 1, 1)] (
+        interpolation = "vertex"
+    )
+    float[] primvars:displayOpacity = [0.5] (
+        interpolation = "constant"
+    )
+
+}

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
@@ -729,19 +729,25 @@ void MeshImportContext::applyColourSetData()
                                     if (opacityValues.IsHolding<VtArray<float>>()) {
                                         const VtArray<float> rawValOpacity
                                             = opacityValues.UncheckedGet<VtArray<float>>();
-                                        colours.setLength(rawValOpacity.size());
                                         const VtArray<GfVec3f> rawValColour
                                             = vtValue.UncheckedGet<VtArray<GfVec3f>>();
-                                        assert(rawValOpacity.size() == rawValColour.size());
-
-                                        for (uint32_t i = 0, n = rawValColour.size(); i < n; ++i)
-                                            colours[i] = MColor(
-                                                rawValColour[i][0],
-                                                rawValColour[i][1],
-                                                rawValColour[i][2],
-                                                rawValOpacity[i]);
-                                        representation = MFnMesh::kRGBA;
-                                        setCombinedDisplayAndOpacityColourSet = true;
+                                        bool isConstantDisplayOpacity
+                                            = primvar.GetInterpolation() == UsdGeomTokens->constant;
+                                        if ((rawValOpacity.size() == rawValColour.size()
+                                             && interpolation == primvar.GetInterpolation())
+                                            || isConstantDisplayOpacity) {
+                                            colours.setLength(rawValColour.size());
+                                            for (uint32_t i = 0, n = rawValColour.size(); i < n;
+                                                 ++i)
+                                                colours[i] = MColor(
+                                                    rawValColour[i][0],
+                                                    rawValColour[i][1],
+                                                    rawValColour[i][2],
+                                                    isConstantDisplayOpacity ? rawValOpacity[0]
+                                                                             : rawValOpacity[i]);
+                                            representation = MFnMesh::kRGBA;
+                                            setCombinedDisplayAndOpacityColourSet = true;
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
This is a fix for a crash occurring in case a varying `displayColor` and a constant `displayOpacity` was authored.

The code assumed that `displayColor` and `displayOpacity` would have arrays of equal sizes. Furthermore it was asserting the size of these arrays way too late (and asserting wasn't the best option anyway).
I've enforced the check earlier and added the possibility to combine a constant opacity primvar.

As it stands, with this change, the export of a prim with varying `displayColor` and constant `displayOpacity` will result in a varying `displayOpacity` primvars if the `compaction` wasn't enabled during export.