### PR TITLE
MAYA-121544 improve the merge-to-USD UI

### DIFF
--- a/lib/mayaUsd/resources/scripts/CMakeLists.txt
+++ b/lib/mayaUsd/resources/scripts/CMakeLists.txt
@@ -5,7 +5,10 @@ list(APPEND scripts_src
     mayaUsdAddMayaReference.py
     mayaUsdCacheMayaReference.mel
     mayaUsdCacheMayaReference.py
+    mayaUsdMergeToUSDOptions.mel
+    mayaUsdMergeToUSDOptions.py
     mayaUsdMergeToUsd.py
+    mayaUsdOptions.py
     mayaUsdMayaReferenceUtils.py
 )
 

--- a/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
@@ -55,6 +55,17 @@ def mayaUsdLibRegisterStrings():
     register('kTextDefineIn', 'Define in:')
     register('kTextVariant', 'Variant')
 
+    # mayaUsdMergeToUSDOptions.py
+    register('kMergeToUSDOptionsTitle', 'Merge Maya Edits to USD Options')
+    register('kMergeButton', 'Merge')
+    register('kApplyButton', 'Apply')
+    register('kCancelButton', 'Cancel')
+    register('kEditMenu', 'Edit')
+    register('kSaveSettingsMenuItem', 'Save Settings')
+    register('kResetSettingsMenuItem', 'Reset Settings')
+    register('kHelpMenu', 'Help')
+    register('kHelpMergeToUSDOptionsMenuItem', 'Help on Merge Maya Edits to USD Options')
+
     # mayaUsdMergeToUsd.py
     register('kErrorMergeToUsdMenuItem', 'Could not create menu item for merge to USD')
     register('kMenuCacheToUsd', 'Cache to USD...')

--- a/lib/mayaUsd/resources/scripts/mayaUsdMergeToUSDOptions.mel
+++ b/lib/mayaUsd/resources/scripts/mayaUsdMergeToUSDOptions.mel
@@ -1,0 +1,26 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Many MEL commands take as argument a MEL procedure, not a Python function.
+//
+// All the following MEL proceduces serves to redirect to Python.
+
+global proc receiveMergeToUSDOptionsTextFromDialog(string $exportOptions)
+{
+    // Note: use raw triple-quoted string in case there are backslash in file paths on Windows.
+    python("import mayaUsdMergeToUSDOptions; mayaUsdMergeToUSDOptions.setMergeToUSDOptionsText(r'''" + $exportOptions + "''')");
+}
+

--- a/lib/mayaUsd/resources/scripts/mayaUsdMergeToUSDOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdMergeToUSDOptions.py
@@ -1,0 +1,249 @@
+#
+# Copyright 2022 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import maya.cmds as cmds
+import maya.mel as mel
+
+from mayaUsdLibRegisterStrings import getMayaUsdLibString
+import mayaUsdOptions
+
+from functools import partial
+
+
+_mergeTarget = None
+
+
+def showMergeToUSDOptions(target):
+    """
+    Shows the Merge to USD options dialog.
+    """
+    _setMergeToUSDTarget(target)
+
+    windowName = "MergeToUSDOptionsDialog"
+    if cmds.window(windowName, query=True, exists=True):
+        if cmds.window(windowName, query=True, visible=True):
+            return
+        # If it exists but is not visible, assume something wrong happened.
+        # Delete the window and recreate it.
+        cmds.deleteUI(windowName)
+
+    window = cmds.window(windowName, title=getMayaUsdLibString("kMergeToUSDOptionsTitle"))
+    _createMergeToUSDOptionsDialog(window, target)
+
+
+def _getMergeToUSDTarget():
+    """
+    Retrieves the current target for the merge-to-USD command.
+    """
+    global _mergeTarget
+    return _mergeTarget
+
+
+def _setMergeToUSDTarget(target):
+    """
+    Sets the current target for the merge-to-USD command.
+    """
+    global _mergeTarget
+    _mergeTarget = target
+
+
+def _createMergeToUSDOptionsDialog(window, target):
+    """
+    Creates the merge-to-USD dialog.
+    """
+
+    windowLayout = cmds.setParent(query=True)
+
+    menuLayout = cmds.columnLayout("MergeToUSDOptionsDialogMenuLayout", adjustableColumn=True, parent=windowLayout)
+
+    menuBarLayout = cmds.menuBarLayout()
+
+    subLayout = cmds.columnLayout("MergeToUSDOptionsDialogSubLayout", adjustableColumn=True, parent=windowLayout)
+
+    optionsText = getMergeToUSDOptionsText()
+    _fillMergeToUSDOptionsDialog(subLayout, optionsText, "post")
+
+    menu = cmds.menu(label=getMayaUsdLibString("kEditMenu"), parent=menuBarLayout)
+    cmds.menuItem(label=getMayaUsdLibString("kSaveSettingsMenuItem"), command=_saveMergeToUSDOptions)
+    cmds.menuItem(label=getMayaUsdLibString("kResetSettingsMenuItem"), command=partial(_resetMergeToUSDOptions, subLayout))
+
+    cmds.setParent(menuBarLayout)
+    menu = cmds.menu(label=getMayaUsdLibString("kHelpMenu"), parent=menuBarLayout)
+    cmds.menuItem(label=getMayaUsdLibString("kHelpMergeToUSDOptionsMenuItem"), command=_helpMergeToUSDOptions)
+
+    buttonsLayout = cmds.formLayout(parent=windowLayout)
+
+    mergeText  = getMayaUsdLibString("kMergeButton")
+    applyText  = getMayaUsdLibString("kApplyButton")
+    cancelText = getMayaUsdLibString("kCancelButton")
+    bMerge     = cmds.button(label=mergeText,  width=100, command=partial(_acceptMergeToUSDOptionsDialog, window))
+    bApply     = cmds.button(label=applyText,  width=100, command=_applyMergeToUSDOptionsDialog)
+    bCancel    = cmds.button(label=cancelText, width=100, command=partial(_cancelMergeToUSDOptionsDialog, window))
+
+    spacer = 10
+    edge   = 20
+
+    cmds.formLayout(buttonsLayout, edit=True,
+        attachForm=[
+            (bCancel,   "top",    edge),
+            (bCancel,   "bottom", edge),
+            (bCancel,   "right",  edge),
+
+            (bApply,    "top",    edge),
+            (bApply,    "bottom", edge),
+
+            (bMerge,    "top",    edge),
+            (bMerge,    "bottom", edge),
+            (bMerge,    "left",   edge),
+        ],
+        attachPosition=[
+            (bCancel,   "left",   spacer/2, 67),
+            (bApply,    "right",  spacer/2, 67),
+            (bApply,    "left",   spacer/2, 33),
+            (bMerge,    "right",  spacer/2, 33),
+        ])
+
+    cmds.scriptJob(parent=window, event=("SelectionChanged", partial(_updateMergeToUSDOptionsDialogOnSelectionChanged, [bMerge, bApply])))
+
+    cmds.showWindow()
+
+
+def _updateMergeToUSDOptionsDialogOnSelectionChanged(buttons):
+    """
+    Reacts to selection changes to enable or disable the merge and apply buttons.
+    """
+    # If we still are using the original target, don't update the buttons.
+    target = _getMergeToUSDTarget()
+    if target:
+        hasSelection = True
+    else:
+        hasSelection = len(cmds.ls(sl=True)) > 0
+    for button in buttons:
+        cmds.button(button, edit=True, enable=hasSelection)
+
+
+def _acceptMergeToUSDOptionsDialog(window, data=None):
+    """
+    Reacts to the merge-to-USD options dialog being OK'ed by the user.
+    """
+    _applyMergeToUSDOptionsDialog(data)
+    cmds.deleteUI(window)
+
+
+def _applyMergeToUSDOptionsDialog(data=None):
+    """
+    Reacts to the merge-to-USD options dialog being applied by the user.
+    """
+    _saveMergeToUSDOptions()
+
+    target = _getMergeToUSDTarget()
+    if not target:
+        sel = cmds.ls(sl=True)
+        if len(sel):
+            target = sel[0]
+
+    if target:
+        optionsText = getMergeToUSDOptionsText()
+        cmds.mayaUsdMergeToUsd(target, exportOptions=optionsText)
+        # This will force using the current selection if applied again.
+        _setMergeToUSDTarget(None)
+
+
+def _cancelMergeToUSDOptionsDialog(window, data=None):
+    """
+    Reacts to the merge-to-USD options dialog being canceled by the user.
+    """
+    cmds.deleteUI(window)
+
+
+def _saveMergeToUSDOptions(data=None):
+    """
+    Saves the merge-to-USD options as currently set in the dialog.
+    The MEL receiveMergeToUSDOptionsTextFromDialog will call setMergeToUSDOptionsText.
+    """
+    mel.eval('''mayaUsdTranslatorExport("", "query=all;!output;!animation-data", "", "receiveMergeToUSDOptionsTextFromDialog");''')
+
+
+def _resetMergeToUSDOptions(subLayout, data=None):
+    """
+    Resets the merge-to-USD options in the dialog.
+    """
+    optionsText = mayaUsdOptions.convertOptionsDictToText(_getDefaultMergeToUSDOptionsDict())
+    _fillMergeToUSDOptionsDialog(subLayout, optionsText, "fill")
+
+
+def _fillMergeToUSDOptionsDialog(subLayout, optionsText, action):
+    """
+    Fills the merge-to-USD options dialog UI elements with the given options.
+    """
+    cmds.setParent(subLayout)
+    mel.eval(
+        '''
+        mayaUsdTranslatorExport("{subLayout}", "{action}=all;!output;!animation-data", "{optionsText}", "")
+        '''.format(optionsText=optionsText, subLayout=subLayout, action=action))
+
+
+def _helpMergeToUSDOptions(data=None):
+    """
+    Shows help on the merge-to-USD options dialog.
+    """
+    # TODO: add help about the options UI instead of the merge command
+    cmds.help('mayaUsdMergeToUsd', doc=True)
+
+
+def _getMergeToUSDOptionsVarName():
+    """
+    Retrieves the option var name under which the merge-to-USD options are kept.
+    """
+    return "mayaUsd_MergeToUSDOptions"
+
+
+def getMergeToUSDOptionsText():
+    """
+    Retrieves the current merge-to-USD options as text with column-spearated key/value pairs.
+    """
+    return mayaUsdOptions.getOptionsText(
+        _getMergeToUSDOptionsVarName(),
+        _getDefaultMergeToUSDOptionsDict())
+    
+
+def setMergeToUSDOptionsText(optionsText):
+    """
+    Sets the current merge-to-USD options as text with column-spearated key/value pairs.
+    Called via receiveMergeToUSDOptionsTextFromDialog in MEL, which gets called via
+    mayaUsdTranslatorExport in query mode.
+    """
+    mayaUsdOptions.setOptionsText(_getMergeToUSDOptionsVarName(), optionsText)
+
+
+def _getDefaultMergeToUSDOptionsDict():
+    """
+    Retrieves the current merge-to-USD options.
+    """
+    return {
+        "exportColorSets":          "1",
+        "exportUVs":                "1",
+        "exportSkels":              "none",
+        "exportSkin":               "none",
+        "exportBlendShapes":        "0",
+        "exportDisplayColor":       "1",
+        "shadingMode":              "none",
+        "animation":                "1",
+        "exportVisibility":         "1",
+        "exportInstances":          "1",
+        "mergeTransformAndShape":   "1",
+        "stripNamespaces":          "0",
+    }

--- a/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
@@ -1,0 +1,43 @@
+#
+# Copyright 2022 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import maya.cmds as cmds
+
+
+def getOptionsText(varName, defaultOptionsDict):
+    """
+    Retrieves the current options as text with column-separated key/value pairs.
+    If the options don't exist, return the default options in the same text format.
+    """
+    if cmds.optionVar(exists=varName):
+        return cmds.optionVar(query=varName)
+    else:
+        return convertOptionsDictToText(defaultOptionsDict)
+    
+
+def setOptionsText(varName, optionsText):
+    """
+    Sets the current options as text with column-separated key/value pairs.
+    """
+    return cmds.optionVar(stringValue=(varName, optionsText))
+
+
+def convertOptionsDictToText(optionsDict):
+    """
+    Converts options to text with column-separated key/value pairs.
+    """
+    optionsList = ['%s=%s' % (name, value) for name, value in optionsDict.items()]
+    return ';'.join(optionsList)

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
@@ -215,8 +215,6 @@ global proc mayaUSDRegisterStrings()
     register("kImportUSDZTxtLbl", "USDZ Texture Import: ");
     register("kImportVariantsInScopeNumLbl", "Variants Switched in Scope:");
     register("kMayaRefMergeEdits", "Merge Maya Edits to USD");
-    register("kMergeToUSDOptionsTitle", "Merge Maya Edits to USD Options");
-    register("kMergeButton", "Merge");
     register("kMayaRefDiscardEdits", "Discard Maya Edits");
     register("kMayaRefDuplicateAsUsdData", "Duplicate As USD Data");
     register("kMayaRefDuplicateAsUsdDataDiv", "Stages");

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -609,13 +609,6 @@ proc int isObjectSelected(string $obj)
     return 0;
 }
 
-global string $mayaUsdMergeToUsdOptions = "";
-
-proc string getMergeToUsdOptionsDefaultSettings()
-{
-    return "exportColorSets=1;exportUVs=1;exportSkels=none;exportSkin=none;exportBlendShapes=0;exportDisplayColor=1;shadingMode=none;animation=1;exportVisibility=1;exportInstances=1;mergeTransformAndShape=1;stripNamespaces=0";
-}
-
 global proc mayaUsdMenu_pushBackToUSD(string $obj)
 {
     if (!hasPrimUpdater())
@@ -628,63 +621,9 @@ global proc mayaUsdMenu_pushBackToUSD(string $obj)
         }
     }
     if (size($obj)) {
-        string $exportOptions = getMergeToUsdOptionsDefaultSettings();
+        string $exportOptions = `python("import mayaUsdMergeToUSDOptions; mayaUsdMergeToUSDOptions.getMergeToUSDOptionsText()")`;
         mayaUsdMergeToUsd -exportOptions $exportOptions $obj;
     }
-}
-
-global proc mayaUsdPushBackToUSDReceiveExportOptions(string $exportOptions)
-{
-    global string $mayaUsdMergeToUsdOptions = "";
-    $mayaUsdMergeToUsdOptions = $exportOptions;
-}
-
-global proc mayaUsdPushBackToUSDOptionsAccepted()
-{
-    string $initialSettings = getMergeToUsdOptionsDefaultSettings();
-    mayaUsdTranslatorExport("", "query=all;!output;!animation-data", $initialSettings, "mayaUsdPushBackToUSDReceiveExportOptions");
-    layoutDialog -dismiss "Merge";
-}
-
-global proc mayaUsdShowPushBackToUSDOptions()
-{
-    string $form = `setParent -q`;
-
-    formLayout -e -width 420 $form;
-
-    string $subLayout = `columnLayout -adj true -parent $form "pushBackToUSDOptionsLayout"`;
-
-    setParent $subLayout;
-
-    string $initialSettings = getMergeToUsdOptionsDefaultSettings();
-    mayaUsdTranslatorExport($subLayout, "post=all;!output;!animation-data", $initialSettings, "");
-
-    setParent $form;
-
-    string $mergeText = getMayaUsdString("kMergeButton");
-    string $cancelText = getMayaUsdString("kButtonCancel");
-    string $bMerge   = `button -l $mergeText -c "mayaUsdPushBackToUSDOptionsAccepted()"`;
-    string $bCancel = `button -l $cancelText -c "layoutDialog -dismiss \"Cancel\""`;
-
-    int $spacer = 10;
-    int $edge   = 20;
-
-    formLayout -edit
-        -attachForm            $subLayout  "top" $edge
-        -attachForm            $subLayout  "left" $edge
-        -attachControl         $subLayout  "bottom" $edge $bCancel
-        -attachForm            $subLayout  "right"  $edge
-
-        -attachNone            $bCancel  "top"
-        -attachNone            $bCancel  "left"
-        -attachForm            $bCancel  "bottom" $edge
-        -attachForm            $bCancel  "right"  $edge
-
-        -attachNone            $bMerge   "top"
-        -attachNone            $bMerge   "left"
-        -attachForm            $bMerge   "bottom"  $edge
-        -attachControl         $bMerge   "right"   $spacer $bCancel
-    $form;
 }
 
 global proc mayaUsdMenu_pushBackToUSDOptions(string $obj)
@@ -699,15 +638,9 @@ global proc mayaUsdMenu_pushBackToUSDOptions(string $obj)
         }
     }
     if (size($obj)) {
-        global string $mayaUsdMergeToUsdOptions = "";
-        string $dlgTitle = getMayaUsdString("kMergeToUSDOptionsTitle");
-        string $dlgReturn = `layoutDialog -ui "mayaUsdShowPushBackToUSDOptions" -title $dlgTitle`;
-        if ("Merge" == $dlgReturn) {
-            mayaUsdMergeToUsd -exportOptions $mayaUsdMergeToUsdOptions $obj;
-        }
+        python("import mayaUsdMergeToUSDOptions; mayaUsdMergeToUSDOptions.showMergeToUSDOptions('''" + $obj + "''')");
     }
 }
-
 
 global proc mayaUsdMenu_duplicateToUSD( string $proxy, string $obj )
 {

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -469,6 +469,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
 //        Valid options are:
 //            "query" - construct the options string and pass it to the resultCallback.
 //            "post" - post all the elf controls.
+//            "fill" - refill all the elf controls with the data.
 //
 //        In addition to the action, the list of UI sections that are desired can be added
 //        with the syntax "action=section1;section2;..." where the section names can be:
@@ -643,16 +644,6 @@ global proc int mayaUsdTranslatorExport (string $parent,
             setParent ..;
         }
 
-        setParent $parent;
-
-        // Now set to current settings.
-        $currentOptions = $initialSettings;
-
-        mayaUsdTranslatorExport_EnableAllControls();
-        mayaUsdTranslatorExport_SetFromOptions($currentOptions, 1, 1);
-
-        // Set visibility for anim widgets
-        mayaUsdTranslatorExport_AnimationCB();
         $bResult = 1;
 
     } else if ($action == "query") {
@@ -704,6 +695,21 @@ global proc int mayaUsdTranslatorExport (string $parent,
 
     } else {
         $bResult = 0;
+    }
+
+    if ($action == "post" || $action == "fill") {
+        setParent $parent;
+
+        // Now set to current settings.
+        $currentOptions = $initialSettings;
+
+        mayaUsdTranslatorExport_EnableAllControls();
+        mayaUsdTranslatorExport_SetFromOptions($currentOptions, 1, 1);
+
+        // Set visibility for anim widgets
+        mayaUsdTranslatorExport_AnimationCB();
+
+        $bResult = 1;
     }
 
     return $bResult;

--- a/plugin/adsk/scripts/mayaUsd_pluginUICreation.mel
+++ b/plugin/adsk/scripts/mayaUsd_pluginUICreation.mel
@@ -49,5 +49,6 @@ global proc mayaUsd_pluginUICreation()
         // loaded, so source it here in this plugin.  PPT, 29-Nov-2021.
         source "mayaUsdAddMayaReference.mel";
         source "mayaUsdCacheMayaReference.mel";
+        source "mayaUsdMergeToUSDOptions.mel";
     }
 }


### PR DESCRIPTION
- Add Edit, Save Settings, Reset Settings and Help menu.
- Add apply button to merge but keep the window open.
- Refactor code to be cleaner.
- Added a "fill" action to mayaUsdTranslatorExport to be able to refill the UI.
- Add selection listening