### PR TITLE
MAYA-121545 persist cache-to-USD options

### DIFF
--- a/lib/mayaUsd/resources/scripts/cacheToUsd.py
+++ b/lib/mayaUsd/resources/scripts/cacheToUsd.py
@@ -17,18 +17,39 @@
 import mayaUsd
 import maya.cmds as cmds
 
+import mayaUsdOptions
+
 import re
 
-def turnOnAnimation(textOptions):
+
+def forceCacheOptions(textOptions):
+    """
+    Adjusts the export options with cache-to-USD specific values.
+    """
     return re.sub(r'animation=.', 'animation=1', textOptions)
 
-def getDefaultExportOptions():
-    # Animation is always on for cache to USD.
-    return turnOnAnimation(cmds.translator('USD Export', query=True, do=True))
 
-def getCacheCreationOptions(exportOptions, cacheFile, cachePrimName,
+def getDefaultExportOptions():
+    """
+    Retrieves the default export options used by cache-to-USD.
+    """
+    optionsText = cmds.translator('USD Export', query=True, do=True)
+    return forceCacheOptions(optionsText)
+
+
+def getDefaultCacheCreationOptions():
+    """
+    Retrieves the default cache-to-USD options as a dictionary.
+    """
+    return createCacheCreationOptions(getDefaultExportOptions(), "", 'Cache1', 'Payload', 'Append', None, 'Cache')
+
+
+def createCacheCreationOptions(exportOptions, cacheFile, cachePrimName,
                             payloadOrReference, listEditType,
                             variantSetName = None, variantName = None):
+    """
+    Creates the dict containing the export options and the cache-to-USD options.
+    """
 
     defineInVariant = 0 if variantSetName is None else 1
 
@@ -45,3 +66,26 @@ def getCacheCreationOptions(exportOptions, cacheFile, cachePrimName,
         userArgs['rn_variantName'] = variantName
 
     return userArgs
+
+
+def _getVarName():
+    """
+    Retrieves the option var name used to save the cache-to-USD options.
+    """
+    return "mayaUsd_CacheToUSDOptions"
+
+
+def saveCacheCreationOptions(optionsDict):
+    """
+    Saves the options dictionary into an option var.
+    """
+    optionsText = mayaUsdOptions.convertOptionsDictToText(optionsDict)
+    mayaUsdOptions.setOptionsText(_getVarName(), optionsText)
+
+
+def loadCacheCreationOptions():
+    """
+    Loads the cache-to-USD options from the option var and returns them as a dictionary.
+    """
+    optionsText = mayaUsdOptions.getOptionsText(_getVarName(), getDefaultExportOptions())
+    return mayaUsdOptions.convertOptionsTextToDict(optionsText, getDefaultCacheCreationOptions())

--- a/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
@@ -22,6 +22,7 @@ from mayaUsd.lib import cacheToUsd
 
 from mayaUsdLibRegisterStrings import getMayaUsdLibString
 import mayaUsdMayaReferenceUtils as mayaRefUtils
+import mayaUsdOptions
 
 from pxr import Sdf, Tf
 
@@ -41,13 +42,55 @@ _mayaRefDagPath = None
 # Pulled Maya reference prim.
 _pulledMayaRefPrim = None
 
+_compositionArcLabels = [getMayaUsdLibString('kMenuPayload'), getMayaUsdLibString('kMenuReference')]
+_compositionArcValues = [                         'Payload',                           'Reference' ]
+
+_listEditedAsLabels = [getMayaUsdLibString('kMenuAppend'), getMayaUsdLibString('kMenuPrepend')]
+_listEditedAsValues = [                         'Append',                           'Prepend' ]
+
+
+def _getMenuValue(menuName, values, defaultIndex = 0):
+    """
+    Retrieves the currently selected values from a menu.
+    """
+    # Note: option menu selection index start at 1, so we subtract 1.
+    menuIndex = cmds.optionMenuGrp('compositionArcTypeMenu', query=True, select=True) - 1
+    if 0 <= menuIndex < len(values):
+        return values[menuIndex]
+    else:
+        return values[defaultIndex]
+
+
+def _getMenuIndex(values, current, defaultIndex = 1):
+    """
+    Retrieves the menu index corresponding to the current value selected amongst values.
+    If the value is invalid, returns the defaultIndex.
+    """
+    try:
+        # Note: menu index is 1-based.
+        return values.index(current) + 1
+    except:
+        return defaultIndex
+
+
 def compositionArcChanged(selectedItem):
+    """
+    Reacts to the composition arc type being selected by the user.
+    """
     pass
+
 
 def listEditChanged(selectedItem):
+    """
+    Reacts to the list edited UI being changed by the user.
+    """
     pass
 
+
 def variantSetNameChanged(selectedItem):
+    """
+    Reacts to the variant set name being changed by the user.
+    """
     # Update the Variant Name option menu from the input Variant Set.
     mayaRefPrimParent = _pulledMayaRefPrim.GetParent()
     cmds.optionMenu('variantNameMenu', edit=True, deleteAllItems=True)
@@ -61,14 +104,22 @@ def variantSetNameChanged(selectedItem):
     cmds.optionMenu('variantNameMenu', edit=True, select=1)
     cmds.textField('variantNameText', edit=True, visible=True, text=kDefaultCacheVariantName)
 
+
 def variantNameChanged(selectedItem):
+    """
+    Reacts to the variant name being changed by the user by picking from the menu.
+    """
     # If the "Create New" item is selected, we show the text input
     # to the right of the optionMenu. For existing variant names
     # the field is hidden.
     createNew = getMayaUsdLibString('kMayaRefCreateNew')
     cmds.textField('variantNameText', edit=True, visible=(selectedItem == createNew))
 
+
 def variantNameTextChanged(variantName):
+    """
+    Reacts to the variant name being changed by the user by editing the text.
+    """
     # The text field cannot be empty. Reset to default value if it is.
     if not variantName:
         cmds.textField('variantNameText', edit=True, text=kDefaultCacheVariantName)
@@ -78,7 +129,11 @@ def variantNameTextChanged(variantName):
         if validatedName != variantName:
             cmds.textField('variantNameText', edit=True, text=validatedName)
 
+
 def primNameTextChanged(primName):
+    """
+    Reacts to the prim name being changed by the user.
+    """
     # The text field cannot be empty. Reset to default value if it is.
     mayaRefPrimParent = _pulledMayaRefPrim.GetParent()
     if not primName:
@@ -91,6 +146,7 @@ def primNameTextChanged(primName):
         validatedName = mayaUsd.ufe.uniqueChildName(mayaRefPrimParent, validatedName)
         if validatedName != primName:
             cmds.textFieldGrp('primNameText', edit=True, text=validatedName)
+
 
 def cacheFileUsdHierarchyOptions(topForm):
     '''Create controls to insert Maya reference USD cache into USD hierarchy.'''
@@ -109,13 +165,13 @@ def cacheFileUsdHierarchyOptions(topForm):
         cmds.optionMenuGrp('compositionArcTypeMenu',
                            label=getMayaUsdLibString('kOptionAsCompositionArc'),
                            cc=compositionArcChanged)
-        cmds.menuItem(label=getMayaUsdLibString('kMenuPayload'))
-        cmds.menuItem(label=getMayaUsdLibString('kMenuReference'))
+        for label in _compositionArcLabels:
+            cmds.menuItem(label=label)
         cmds.optionMenu('listEditedAsMenu',
                         label=getMayaUsdLibString('kOptionListEditedAs'),
                         cc=listEditChanged)
-        cmds.menuItem(label=getMayaUsdLibString('kMenuAppend'))
-        cmds.menuItem(label=getMayaUsdLibString('kMenuPrepend'))
+        for label in _listEditedAsLabels:
+            cmds.menuItem(label=label)
 
     variantRb = cmds.radioButtonGrp('variantRadioBtn',
                                     nrb=1,
@@ -149,8 +205,12 @@ def cacheFileUsdHierarchyOptions(topForm):
 
     cmds.radioButtonGrp(variantRb, edit=True, select=1)
 
+
 # Adapted from fileOptions.mel:fileOptionsTabPage().
 def fileOptionsTabPage(tabLayout):
+    """
+    Creates the UI element of the file dialog options tab.
+    """
     mayaRefUtils.pushOptionsUITemplate()
 
     cmds.setParent(tabLayout)
@@ -181,33 +241,60 @@ def fileOptionsTabPage(tabLayout):
     # USD file option controls will be parented under this layout.
     # resultCallback not called on "post", is therefore an empty string.
     fileOptionsScroll = cmds.columnLayout('fileOptionsScroll')
-    mel.eval('mayaUsdTranslatorExport("fileOptionsScroll", "post=all;!animation-data", "' + getCacheExportOptions() + '", "")') 
+    optionsText = mayaUsdOptions.convertOptionsDictToText(cacheToUsd.loadCacheCreationOptions())
+    mel.eval('mayaUsdTranslatorExport("fileOptionsScroll", "post=all;!animation-data", "' + optionsText + '", "")') 
 
     cacheFileUsdHierarchyOptions(topForm)
 
     cmds.setUITemplate(popTemplate=True)
 
+
 def getCacheExportOptions():
+    """
+    Retrieves the export options.
+    """
     global _cacheExportOptions
     if _cacheExportOptions is None:
         _cacheExportOptions = cacheToUsd.getDefaultExportOptions()
     return _cacheExportOptions
 
+
 def setCacheOptions(newCacheOptions):
+    """
+    Sets the export options.
+    Called from mayaUsdTranslatorExport via mayaUsdCacheMayaReference_setCacheOptions in MEL.
+    """
     global _cacheExportOptions
-    # Animation is always on for cache to USD.
-    _cacheExportOptions = cacheToUsd.turnOnAnimation(newCacheOptions)
+    _cacheExportOptions = cacheToUsd.forceCacheOptions(newCacheOptions)
+
 
 def cacheCreateUi(parent):
+    """
+    Creates the cache-to-USD UI.
+    Called by the fileDialog command via the MEL mayaUsdCacheMayaReference_cacheCreateUi function.
+    """
     cmds.setParent(parent)
     fileOptionsTabPage(cmds.scrollLayout(childResizable=True))
 
+
 def cacheInitUi(parent, filterType):
+    """
+    Fills the cache-to-USD UI.
+    Called by the fileDialog command via the MEL mayaUsdCacheMayaReference_cacheInitUi function.
+    """
+    optionsDict = cacheToUsd.loadCacheCreationOptions()
+
     cmds.setParent(parent)
     
     # If the parent of the Maya reference prim has a variant set, define in
     # variant is the default, otherwise all variant options are disabled.
     mayaRefPrimParent = _pulledMayaRefPrim.GetParent()
+
+    menuIndex = _getMenuIndex(_compositionArcValues, optionsDict['rn_payloadOrReference'])
+    cmds.optionMenuGrp('compositionArcTypeMenu', edit=True, select=menuIndex)
+
+    menuIndex = _getMenuIndex(_listEditedAsValues, optionsDict['rn_listEditType'])
+    cmds.optionMenu('listEditedAsMenu', edit=True, select=menuIndex)
 
     if mayaRefPrimParent.HasVariantSets():
         # Define in variant is the default.
@@ -218,9 +305,12 @@ def cacheInitUi(parent, filterType):
             cmds.menuItem(label=vsName, parent='variantSetMenu')
         cmds.optionMenu('variantSetMenu', edit=True, select=1)
 
-        # If there is a variant set name 'Representation' then
+        # If the previous variant set name is available, select it,
+        # Otherwise if there is a variant set name 'Representation' then
         # automatically select it, otherwise select the first one.
-        if mayaRefUtils.defaultVariantSetName() in variantSetsNames:
+        if optionsDict['rn_variantSetName'] in variantSetsNames:
+            variantSetNameChanged(optionsDict['rn_variantSetName'])
+        elif mayaRefUtils.defaultVariantSetName() in variantSetsNames:
             variantSetNameChanged(mayaRefUtils.defaultVariantSetName())
         else:
             variantSetNameChanged(variantSetsNames[0])
@@ -233,10 +323,18 @@ def cacheInitUi(parent, filterType):
         cmds.radioButtonGrp('newChildPrimRadioBtn', edit=True, select=1)
 
     # Set initial (unique) name for child prim.
-    primName = mayaUsd.ufe.uniqueChildName(mayaRefPrimParent, kDefaultCachePrimName)
+    if optionsDict['rn_primName']:
+        primName = optionsDict['rn_primName']
+    else:
+        primName = mayaUsd.ufe.uniqueChildName(mayaRefPrimParent, kDefaultCachePrimName)
     cmds.textFieldGrp('primNameText', edit=True, text=primName)
 
+
 def cacheCommitUi(parent, selectedFile):
+    """
+    Reacts to the file dialog being accepted by the user.
+    Called by the fileDialog command via the MEL mayaUsdCacheMayaReference_cacheCommitUi function.
+    """
     # Read data to set up cache.
 
     # The following call will set _cacheExportOptions.  Initial settings not
@@ -244,8 +342,8 @@ def cacheCommitUi(parent, selectedFile):
     mel.eval('mayaUsdTranslatorExport("fileOptionsScroll", "query", "", "mayaUsdCacheMayaReference_setCacheOptions")')
 
     primName = cmds.textFieldGrp('primNameText', query=True, text=True)
-    payloadOrReference = cmds.optionMenuGrp('compositionArcTypeMenu', query=True, value=True)
-    listEditType = cmds.optionMenu('listEditedAsMenu', query=True, value=True)
+    payloadOrReference = _getMenuValue('compositionArcTypeMenu', _compositionArcValues)
+    listEditType = _getMenuValue('listEditedAsMenu', _listEditedAsValues)
     
     defineInVariant = cmds.radioButtonGrp('variantRadioBtn', query=True, select=True)
     if defineInVariant:
@@ -257,15 +355,18 @@ def cacheCommitUi(parent, selectedFile):
         variantName = None
         variantSetName = None
 
-    userArgs = cacheToUsd.getCacheCreationOptions(
+    userArgs = cacheToUsd.createCacheCreationOptions(
         getCacheExportOptions(), selectedFile, primName, payloadOrReference,
         listEditType, variantSetName, variantName)
+
+    cacheToUsd.saveCacheCreationOptions(userArgs)
 
     # Call push.
     if not mayaUsd.lib.PrimUpdaterManager.mergeToUsd(_mayaRefDagPath, userArgs):
         errorMsgFormat = getMayaUsdLibString('kErrorCacheToUsdFailed')
         errorMsg = cmds.format(errorMsgFormat, stringArg=(_mayaRefDagPath))
         cmds.error(errorMsg)
+
 
 def cacheDialog(dagPath, pulledMayaRefPrim, _):
     '''Display dialog to cache the argument pulled Maya reference prim to USD.'''

--- a/test/lib/mayaUsd/fileio/testCacheToUsd.py
+++ b/test/lib/mayaUsd/fileio/testCacheToUsd.py
@@ -141,7 +141,7 @@ class CacheToUsdTestCase(unittest.TestCase):
         cachePrimName = 'cachePrimName'
         payloadOrReference = 'Payload'
         listEditType = 'Prepend'
-        cacheOptions = cacheToUsd.getCacheCreationOptions(
+        cacheOptions = cacheToUsd.createCacheCreationOptions(
             defaultExportOptions, cacheFile, cachePrimName,
             payloadOrReference, listEditType)
 


### PR DESCRIPTION
- Add convertOptionsTextToDict function.
- Save and load the cache-to-USD options from an option var.
- Make the menu options values separate from the localized labels.
- Fill the cache-to-USD UI from the saved options.