### PR TITLE
MAYA-115146 As a user, I'd like my Maya Reference node to be named th…

### DIFF
--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -1018,6 +1018,7 @@ UsdMayaJobImportArgs::UsdMayaJobImportArgs(
     , importInstances(_Boolean(userArgs, UsdMayaJobImportArgsTokens->importInstances))
     , useAsAnimationCache(_Boolean(userArgs, UsdMayaJobImportArgsTokens->useAsAnimationCache))
     , importWithProxyShapes(importWithProxyShapes)
+    , pullImport(_Boolean(userArgs, UsdMayaJobImportArgsTokens->pullImport))
     , timeInterval(timeInterval)
     , chaserNames(_Vector<std::string>(userArgs, UsdMayaJobImportArgsTokens->chaser))
     , allChaserArgs(_ChaserArgs(userArgs, UsdMayaJobImportArgsTokens->chaserArgs))
@@ -1069,6 +1070,7 @@ const VtDictionary& UsdMayaJobImportArgs::GetDefaultDictionary()
         d[UsdMayaJobImportArgsTokens->importInstances] = true;
         d[UsdMayaJobImportArgsTokens->importUSDZTextures] = false;
         d[UsdMayaJobImportArgsTokens->importUSDZTexturesFilePath] = "";
+        d[UsdMayaJobImportArgsTokens->pullImport] = false;
         d[UsdMayaJobImportArgsTokens->useAsAnimationCache] = false;
         d[UsdMayaJobExportArgsTokens->chaser] = std::vector<VtValue>();
         d[UsdMayaJobExportArgsTokens->chaserArgs] = std::vector<VtValue>();
@@ -1144,6 +1146,7 @@ const VtDictionary& UsdMayaJobImportArgs::GetGuideDictionary()
         d[UsdMayaJobImportArgsTokens->importInstances] = _boolean;
         d[UsdMayaJobImportArgsTokens->importUSDZTextures] = _boolean;
         d[UsdMayaJobImportArgsTokens->importUSDZTexturesFilePath] = _string;
+        d[UsdMayaJobImportArgsTokens->pullImport] = _boolean;
         d[UsdMayaJobImportArgsTokens->useAsAnimationCache] = _boolean;
         d[UsdMayaJobExportArgsTokens->chaser] = _stringVector;
         d[UsdMayaJobExportArgsTokens->chaserArgs] = _stringTripletVector;
@@ -1229,6 +1232,7 @@ std::ostream& operator<<(std::ostream& out, const UsdMayaJobImportArgs& importAr
         << "importInstances: " << TfStringify(importArgs.importInstances) << std::endl
         << "importUSDZTextures: " << TfStringify(importArgs.importUSDZTextures) << std::endl
         << "importUSDZTexturesFilePath: " << TfStringify(importArgs.importUSDZTexturesFilePath)
+        << "pullImport: " << TfStringify(importArgs.pullImport) << std::endl
         << std::endl
         << "timeInterval: " << importArgs.timeInterval << std::endl
         << "useAsAnimationCache: " << TfStringify(importArgs.useAsAnimationCache) << std::endl

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -133,6 +133,7 @@ TF_DECLARE_PUBLIC_TOKENS(
     (importInstances) \
     (importUSDZTextures) \
     (importUSDZTexturesFilePath) \
+    (pullImport) \
     /* assemblyRep values */ \
     (Collapsed) \
     (Full) \
@@ -304,6 +305,7 @@ struct UsdMayaJobImportArgs
     const bool        importInstances;
     const bool        useAsAnimationCache;
     const bool        importWithProxyShapes;
+    const bool        pullImport;
     /// The interval over which to import animated data.
     /// An empty interval (<tt>GfInterval::IsEmpty()</tt>) means that no
     /// animated (time-sampled) data should be imported.

--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -141,7 +141,11 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
     } else {
         UsdStageCacheContext stageCacheContext(UsdMayaStageCache::Get(
             mImportData.stageInitialLoadSet() == UsdStage::InitialLoadSet::LoadAll));
-        stage = UsdStage::Open(rootLayer, sessionLayer, mImportData.stageInitialLoadSet());
+
+        if (mArgs.pullImport)
+            stage = UsdStage::Open(rootLayer, mImportData.stageInitialLoadSet());
+        else
+            stage = UsdStage::Open(rootLayer, sessionLayer, mImportData.stageInitialLoadSet());
     }
     if (!stage) {
         return false;

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -270,7 +270,9 @@ PullImportPaths pullImport(
         return PullImportPaths(addedDagPaths, pulledUfePaths);
     }
 
-    const VtDictionary& userArgs = context.GetUserArgs();
+    VtDictionary userArgs(context.GetUserArgs());
+
+    userArgs[UsdMayaJobImportArgsTokens->pullImport] = true;
 
     UsdMayaJobImportArgs jobArgs = UsdMayaJobImportArgs::CreateFromDictionary(
         userArgs,

--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.h
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.h
@@ -62,6 +62,8 @@ struct UsdMayaTranslatorMayaReference
     static MStatus update(const UsdPrim& prim, MObject parent);
 
 private:
+    static MString namespaceFromPrim(const UsdPrim& prim);
+    static MString getUniqueRefNodeName(const UsdPrim& prim, const MFnDagNode& parentDag, const MFnReference& refDependNode);
     static MStatus connectReferenceAssociatedNode(MFnDagNode& dagNode, MFnReference& refNode);
 
     static const TfToken m_namespaceName;

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -183,7 +183,10 @@ UsdPrim ufePathToPrim(const Ufe::Path& path)
     const Ufe::Path ufePrimPath = stripInstanceIndexFromUfePath(path);
 
     const Ufe::Path::Segments& segments = ufePrimPath.getSegments();
-    auto                       stage = getStage(Ufe::Path(segments[0]));
+    if (!TF_VERIFY(!segments.empty(), kIllegalUSDPath, path.string().c_str())) {
+        return UsdPrim();
+    }
+    auto stage = getStage(Ufe::Path(segments[0]));
     if (!TF_VERIFY(stage, kIllegalUSDPath, path.string().c_str())) {
         return UsdPrim();
     }

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -53,15 +53,16 @@ endforeach()
 # Can be started with VS Code but won't be part of test suites.
 # -----------------------------------------------------------------------------
 set(target _Interactive_Maya)
-mayaUsd_add_test(${target}
+add_test(
+    NAME "${target}"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMAND ${MAYA_EXECUTABLE}
-    ENV
-        "MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/lib/maya"
-        "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
 )
+
 set_property(TEST ${target} APPEND PROPERTY DISABLED True)
 set_property(TEST ${target} APPEND PROPERTY LABELS Debugging)
+set_property(TEST ${target} APPEND PROPERTY ENVIRONMENT "MAYA_MODULE_PATH=${CMAKE_INSTALL_PREFIX}")
+set_property(TEST ${target} APPEND PROPERTY ENVIRONMENT "MAYAUSD_ENABLE_ADD_MAYA_REFERENCE=TRUE")
 
 #
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
…e regular Maya way

1. On Maya Reference behavior is modified.
2. Maya Reference Node is named using the mayaNamespace or filename if mayaNamespace is not set. And "RN" is added to the end.
3. On reconnect Maya Reference Node is rename to match any mayaNamespace or filename change.

+ modify the way Interactive Maya test is setup to use the .mod files.
+ adding another crash protection for ufe.