### PR TITLE
Proper selection for edit as Maya, merge to USD, and discard Maya edits.

### DIFF
--- a/lib/mayaUsd/commands/PullPushCommands.cpp
+++ b/lib/mayaUsd/commands/PullPushCommands.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Autodesk
+// Copyright 2022 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -286,7 +286,7 @@ MStatus MergeToUsdCommand::doIt(const MArgList& argList)
             // Select the merged prim.  See DuplicateCommand::doIt() comments.
             Ufe::Selection sn;
             sn.append(Ufe::Hierarchy::createItem(pulledPath));
-            UfeSelectionUndoItem::select("mergeToUsd", sn);
+            UfeSelectionUndoItem::select("mergeToUsd: select merged prim", sn);
         }
     }
 
@@ -355,7 +355,7 @@ MStatus DiscardEditsCommand::doIt(const MArgList& argList)
             if (pulledItem) {
                 sn.append(pulledItem);
             }
-            UfeSelectionUndoItem::select("discardEdits", sn);
+            UfeSelectionUndoItem::select("discardEdits: select original prim", sn);
         }
     }
 
@@ -453,7 +453,7 @@ MStatus DuplicateCommand::doIt(const MArgList& argList)
             // It is appropriate to use the overload that uses the global list,
             // as the undo recorder will transfer the items on the global list
             // to fUndoItemList.
-            UfeSelectionUndoItem::select("duplicate", sn);
+            UfeSelectionUndoItem::select("duplicate: select duplicate", sn);
         }
     }
 

--- a/lib/mayaUsd/commands/PullPushCommands.h
+++ b/lib/mayaUsd/commands/PullPushCommands.h
@@ -22,7 +22,6 @@
 #include <mayaUsd/mayaUsd.h>
 #include <mayaUsd/undo/OpUndoItemList.h>
 
-#include <maya/MFnDagNode.h>
 #include <maya/MPxCommand.h>
 #include <ufe/path.h>
 #include <ufe/undoableCommand.h>
@@ -115,9 +114,6 @@ public:
 private:
     // Make sure callers need to call creator().
     MergeToUsdCommand();
-
-    MFnDagNode fDagNode;
-    Ufe::Path  fPulledPath;
 };
 
 //------------------------------------------------------------------------------
@@ -148,8 +144,6 @@ public:
 private:
     // Make sure callers need to call creator().
     DiscardEditsCommand();
-
-    Ufe::Path fPath;
 };
 
 //------------------------------------------------------------------------------

--- a/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
+++ b/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
@@ -94,6 +94,14 @@ bool duplicate(
 
 BOOST_PYTHON_FUNCTION_OVERLOADS(duplicate_overloads, duplicate, 2, 3)
 
+std::string readPullInformation(const PXR_NS::UsdPrim& prim)
+{
+    std::string dagPathStr;
+    // Ignore boolean return value, empty string is the proper error result.
+    PrimUpdaterManager::getInstance().readPullInformation(prim, dagPathStr);
+    return dagPathStr;
+}
+
 } // namespace
 
 void wrapPrimUpdaterManager()
@@ -103,5 +111,6 @@ void wrapPrimUpdaterManager()
         .def("editAsMaya", editAsMaya)
         .def("canEditAsMaya", canEditAsMaya)
         .def("discardEdits", discardEdits)
-        .def("duplicate", duplicate, duplicate_overloads());
+        .def("duplicate", duplicate, duplicate_overloads())
+        .def("readPullInformation", readPullInformation);
 }

--- a/lib/mayaUsd/undo/OpUndoItems.cpp
+++ b/lib/mayaUsd/undo/OpUndoItems.cpp
@@ -16,12 +16,16 @@
 #include "OpUndoItems.h"
 
 #include <mayaUsd/utils/util.h>
+#ifdef WANT_UFE_BUILD
+#include <mayaUsd/ufe/Utils.h>
+#endif
 
 #include <maya/MGlobal.h>
 #include <maya/MItDag.h>
 #include <maya/MSelectionList.h>
 #ifdef WANT_UFE_BUILD
 #include <ufe/globalSelection.h>
+#include <ufe/hierarchy.h>
 #include <ufe/observableSelection.h>
 #endif
 
@@ -385,6 +389,31 @@ void UfeSelectionUndoItem::select(
 void UfeSelectionUndoItem::select(const std::string& name, const Ufe::Selection& selection)
 {
     select(name, selection, OpUndoItemList::instance());
+}
+
+void UfeSelectionUndoItem::select(
+    const std::string& name,
+    const MDagPath&    dagPath,
+    OpUndoItemList&    undoInfo)
+{
+    Ufe::Selection sn;
+    sn.append(Ufe::Hierarchy::createItem(MayaUsd::ufe::dagPathToUfe(dagPath)));
+    select(name, sn, undoInfo);
+}
+
+void UfeSelectionUndoItem::select(const std::string& name, const MDagPath& dagPath)
+{
+    select(name, dagPath, OpUndoItemList::instance());
+}
+
+void UfeSelectionUndoItem::clear(const std::string& name, OpUndoItemList& undoInfo)
+{
+    select(name, Ufe::Selection(), undoInfo);
+}
+
+void UfeSelectionUndoItem::clear(const std::string& name)
+{
+    clear(name, OpUndoItemList::instance());
 }
 
 bool UfeSelectionUndoItem::undo()

--- a/lib/mayaUsd/undo/OpUndoItems.h
+++ b/lib/mayaUsd/undo/OpUndoItems.h
@@ -427,6 +427,26 @@ public:
     MAYAUSD_CORE_PUBLIC
     static void select(const std::string& name, const Ufe::Selection& selection);
 
+    /// \brief create and execute a select node undo item and keep track of it.
+    /// The global selection is replaced.
+    MAYAUSD_CORE_PUBLIC
+    static void select(const std::string& name, const MDagPath& dagPath, OpUndoItemList& undoInfo);
+
+    /// \brief create and execute a select node undo item and keep track of it on the global list.
+    /// The global selection is replaced.
+    MAYAUSD_CORE_PUBLIC
+    static void select(const std::string& name, const MDagPath& dagPath);
+
+    /// \brief Create and execute a select node undo item and keep track of it.  The global
+    /// selection is cleared.
+    MAYAUSD_CORE_PUBLIC
+    static void clear(const std::string& name, OpUndoItemList& undoInfo);
+
+    /// \brief create and execute a select node undo item and keep track of it in the global list.
+    /// The global selection is cleared.
+    MAYAUSD_CORE_PUBLIC
+    static void clear(const std::string& name);
+
     MAYAUSD_CORE_PUBLIC
     UfeSelectionUndoItem(const std::string& name, const Ufe::Selection& selection);
 

--- a/lib/mayaUsd/undo/OpUndoItems.h
+++ b/lib/mayaUsd/undo/OpUndoItems.h
@@ -437,13 +437,13 @@ public:
     MAYAUSD_CORE_PUBLIC
     static void select(const std::string& name, const MDagPath& dagPath);
 
-    /// \brief Create and execute a select node undo item and keep track of it.  The global
+    /// \brief Create and execute a clear selection undo item and keep track of it.  The global
     /// selection is cleared.
     MAYAUSD_CORE_PUBLIC
     static void clear(const std::string& name, OpUndoItemList& undoInfo);
 
-    /// \brief create and execute a select node undo item and keep track of it in the global list.
-    /// The global selection is cleared.
+    /// \brief create and execute a clear selection undo item and keep track of it in the global
+    /// list. The global selection is cleared.
     MAYAUSD_CORE_PUBLIC
     static void clear(const std::string& name);
 

--- a/test/lib/mayaUsd/fileio/testDiscardEdits.py
+++ b/test/lib/mayaUsd/fileio/testDiscardEdits.py
@@ -144,6 +144,10 @@ class MergeToUsdTestCase(unittest.TestCase):
 
         verifyScenesModifications()
 
+        # Make a selection before discard Maya edits.
+        cmds.select('persp')
+        previousSn = cmds.ls(sl=True, ufe=True, long=True)
+
         # Discard Maya edits.
         cmds.mayaUsdDiscardEdits(aMayaPathStr)
 
@@ -156,12 +160,19 @@ class MergeToUsdTestCase(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 om.MSelectionList().add(aMayaPathStr)
 
+            # Selection is on the USD object.
+            sn = cmds.ls(sl=True, ufe=True, long=True)
+            self.assertEqual(len(sn), 1)
+            self.assertEqual(sn[0], aUsdUfePathStr)
+
         verifyDiscard()
 
         # undo
         cmds.undo()
 
         verifyScenesModifications()
+        # Selection is restored.
+        self.assertEqual(cmds.ls(sl=True, ufe=True, long=True), previousSn)
 
         # redo
         cmds.redo()
@@ -189,7 +200,7 @@ class MergeToUsdTestCase(unittest.TestCase):
         pulledDagPath = '|__mayaUsd__|skinParent|skin'
         self.assertTrue(self._GetMayaDependencyNode(pulledDagPath))
         
-        # now we will make the pulled prim goes away...which makes state in DG orphaned
+        # now we will make the pulled prim go away...which makes state in DG orphaned
         primToDeactivate = stage.GetPrimAtPath('/apple/payload')
         primToDeactivate.SetActive(False)
         self.assertFalse(stage.GetPrimAtPath('/apple/payload/geo/skin'))

--- a/test/lib/mayaUsd/fileio/testMergeToUsd.py
+++ b/test/lib/mayaUsd/fileio/testMergeToUsd.py
@@ -160,6 +160,10 @@ class MergeToUsdTestCase(unittest.TestCase):
 
         psHier = ufe.Hierarchy.hierarchy(ps)
 
+        # Make a selection before merge edits back to USD.
+        cmds.select('persp')
+        previousSn = cmds.ls(sl=True, ufe=True, long=True)
+
         # Merge edits back to USD.
         cmds.mayaUsdMergeToUsd(aMayaPathStr)
 
@@ -195,6 +199,11 @@ class MergeToUsdTestCase(unittest.TestCase):
                 with self.assertRaises(RuntimeError):
                     om.MSelectionList().add(mayaPathStr)
 
+            # Selection is on the restored USD object.
+            sn = cmds.ls(sl=True, ufe=True, long=True)
+            self.assertEqual(len(sn), 1)
+            self.assertEqual(sn[0], aUsdUfePathStr)
+
         verifyMergeToUsd()
 
         cmds.undo()
@@ -206,6 +215,8 @@ class MergeToUsdTestCase(unittest.TestCase):
                     om.MSelectionList().add(mayaPathStr)
                 except:
                     self.assertTrue(False, "Selecting node should not have raise an exception")
+            # Selection is restored.
+            self.assertEqual(cmds.ls(sl=True, ufe=True, long=True), previousSn)
 
         verifyMergeIsUndone()
 


### PR DESCRIPTION
On edit as Maya, Maya object is selected.  On merge to USD, USD prim is selected.  On discard edits, USD prim is selected.  All implementations correctly support undo / redo.