### PR TITLE
MAYA-121814 change label to cancel maya ref edit

### DIFF
--- a/lib/mayaUsd/resources/scripts/CMakeLists.txt
+++ b/lib/mayaUsd/resources/scripts/CMakeLists.txt
@@ -9,6 +9,7 @@ list(APPEND scripts_src
     mayaUsdMergeToUSDOptions.py
     mayaUsdMergeToUsd.py
     mayaUsdOptions.py
+    mayaUsdUtils.py
     mayaUsdMayaReferenceUtils.py
 )
 

--- a/lib/mayaUsd/resources/scripts/mayaUsdMergeToUsd.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdMergeToUsd.py
@@ -20,6 +20,7 @@ import maya.cmds as cmds
 
 import mayaUsd
 import mayaUsdCacheMayaReference
+import mayaUsdUtils
 from mayaUsdLibRegisterStrings import getMayaUsdLibString
 
 import ufe
@@ -47,16 +48,7 @@ def createMayaReferenceMenuItem(dagPath, precedingItem):
     # prim.  If this prim is of type Maya reference, create a specific menu
     # item for it, otherwise return an empty string for the chain of
     # responsibility.
-
-    # The dagPath may come in as a shortest unique name.  Expand it to full
-    # name; ls -l would be an alternate implementation.
-    sn = om.MSelectionList()
-    sn.add(dagPath)
-    fullDagPath = sn.getDagPath(0).fullPathName()
-    mayaItem = ufe.Hierarchy.createItem(ufe.PathString.path(fullDagPath))
-    pathMapper = ufe.PathMappingHandler.pathMappingHandler(mayaItem)
-    pulledPath = pathMapper.fromHost(mayaItem.path())
-    prim = mayaUsd.ufe.ufePathToPrim(ufe.PathString.string(pulledPath))
+    fullDagPath, _, _, prim = mayaUsdUtils.getPulledInfo(dagPath)
 
     # If the pulled prim doesn't exist anymore, we won't delegate the reponsibility to
     # another creator and handle the menu item in here. We already have all the information

--- a/lib/mayaUsd/resources/scripts/mayaUsdUtils.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdUtils.py
@@ -1,0 +1,34 @@
+from maya.api import OpenMaya as om
+
+import mayaUsd
+
+import ufe
+
+def getPulledInfo(dagPath):
+    """
+    Retrieves the full DAG path, UFE hierarchy item, FE path of the USD pulled path and the USD prim.
+    The USD pulled path and USD prim may be invalid if the pulled object is orphaned.
+    """
+    # The dagPath must have the pull information that brings us to the USD
+    # prim.  If this prim is of type Maya reference, create a specific menu
+    # item for it, otherwise return an empty string for the chain of
+    # responsibility.
+
+    # The dagPath may come in as a shortest unique name.  Expand it to full
+    # name; ls -l would be an alternate implementation.
+    sn = om.MSelectionList()
+    sn.add(dagPath)
+    fullDagPath = sn.getDagPath(0).fullPathName()
+    mayaItem = ufe.Hierarchy.createItem(ufe.PathString.path(fullDagPath))
+    pathMapper = ufe.PathMappingHandler.pathMappingHandler(mayaItem)
+    pulledPath = pathMapper.fromHost(mayaItem.path())
+    prim = mayaUsd.ufe.ufePathToPrim(ufe.PathString.string(pulledPath))
+    return fullDagPath, mayaItem, pulledPath, prim
+
+
+def isPulledMayaReference(dagPath):
+    """
+    Verifies if the DAG path refers to a pulled prim that is a Maya reference.
+    """
+    _, _, _, prim = getPulledInfo(dagPath)
+    return prim and prim.GetTypeName() == 'MayaReference'

--- a/lib/mayaUsd/resources/scripts/mayaUsdUtils.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdUtils.py
@@ -1,3 +1,19 @@
+#
+# Copyright 2022 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 from maya.api import OpenMaya as om
 
 import mayaUsd

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
@@ -215,7 +215,8 @@ global proc mayaUSDRegisterStrings()
     register("kImportUSDZTxtLbl", "USDZ Texture Import: ");
     register("kImportVariantsInScopeNumLbl", "Variants Switched in Scope:");
     register("kMayaRefMergeEdits", "Merge Maya Edits to USD");
-    register("kMayaRefDiscardEdits", "Discard Maya Edits");
+    register("kMayaDiscardEdits", "Discard Maya Edits");
+    register("kMayaRefDiscardEdits", "Cancel Editing as Maya Data");
     register("kMayaRefDuplicateAsUsdData", "Duplicate As USD Data");
     register("kMayaRefDuplicateAsUsdDataDiv", "Stages");
 

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -670,8 +670,18 @@ global proc mayaUsdMenu_markingMenuCallback( string $obj )
     if ($pulledObject != "") {
         string $pushback = python("import mayaUsdMergeToUsd; mayaUsdMergeToUsd.createMenuItem(\"" + $pulledObject + "\", \"\")");
         
-        $tmp = getMayaUsdString("kMayaRefDiscardEdits");
-        string $pushclear = `menuItem -label $tmp -insertAfter $pushback -image "discard_edits.png" -command ("mayaUsdDiscardEdits " + $pulledObject)`;
+        int $isMayaRef = python("import mayaUsdUtils; mayaUsdUtils.isPulledMayaReference('''" + $pulledObject + "''')");
+
+        string $label;
+        string $icon;
+        if ($isMayaRef) {
+            $label = getMayaUsdString("kMayaRefDiscardEdits");
+            $icon = "discard_edits.png";
+        } else {
+            $label = getMayaUsdString("kMayaDiscardEdits");
+            $icon = "discard_edits.png";
+        }
+        string $pushclear = `menuItem -label $label -insertAfter $pushback -image $icon -command ("mayaUsdDiscardEdits " + $pulledObject)`;
         
         menuItem -divider true -insertAfter $pushclear;
     }


### PR DESCRIPTION
- Refactor code to detect if a pulled path is a maya reference.
- Use refactored code to detect maya reference when building the menu.
- Use different label for Maya reference when discarding edits.