### PR TITLE
:bug: change _GetLocalTransformForDagPoseMember check from maya api version to diffrence_type iterator trait support, since 2019's MArrayIteratorTemplate.h has missing iterator traits.

### DIFF
--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -20,6 +20,7 @@
 # MAYA_UPDATE_UFE_IDENTIFIER_SUPPORT Presence of MPxSubSceneOverride::updateUfeIdentifier.
 # MAYA_ENABLE_NEW_PRIM_DELETE Enable new delete behaviour for delete command
 # MAYA_HAS_DISPLAY_STYLE_ALL_VIEWPORTS Presence of MFrameContext::getDisplayStyleOfAllViewports.
+# MAYA_ARRAY_ITERATOR_DIFFERENCE_TYPE_SUPPORT Presence of maya array iterator difference_type trait
 
 #=============================================================================
 # Copyright 2011-2012 Francisco Requena <frarees@gmail.com>
@@ -417,6 +418,14 @@ if(MAYA_INCLUDE_DIRS AND EXISTS "${MAYA_INCLUDE_DIR}/maya/MFrameContext.h")
     endif()
 endif()
 
+set(MAYA_ARRAY_ITERATOR_DIFFERENCE_TYPE_SUPPORT FALSE CACHE INTERNAL "hasArrayIteratorDifferenceType")
+if(MAYA_INCLUDE_DIRS AND EXISTS "${MAYA_INCLUDE_DIR}/maya/MArrayIteratorTemplate.h")
+    file(STRINGS ${MAYA_INCLUDE_DIR}/maya/MArrayIteratorTemplate.h MAYA_HAS_API REGEX "difference_type")
+    if(MAYA_HAS_API)
+        set(MAYA_ARRAY_ITERATOR_DIFFERENCE_TYPE_SUPPORT TRUE CACHE INTERNAL "hasArrayIteratorDifferenceType")
+        message(STATUS "Maya array iterator has difference_type trait")
+    endif()
+endif()
 
 # handle the QUIETLY and REQUIRED arguments and set MAYA_FOUND to TRUE if
 # all listed variables are TRUE

--- a/lib/usd/translators/jointWriter.cpp
+++ b/lib/usd/translators/jointWriter.cpp
@@ -259,7 +259,7 @@ bool _GetLocalTransformForDagPoseMember(
     MStatus status;
 
     MPlug xformMatrixPlug = dagPoseDep.findPlug("xformMatrix");
-#if MAYA_API_VERSION >= 20190000
+#ifdef MAYA_ARRAY_ITERATOR_DIFFERENCE_TYPE_SUPPORT
     if (TfDebug::IsEnabled(PXRUSDMAYA_TRANSLATORS)) {
         // As an extra debug sanity check, make sure that the logicalIndex
         // already exists


### PR DESCRIPTION
Maya 2019 MArrayIteratorTemplate.h has missing iterator traits. This has been fix in Maya 2020 onwards.