### PR TITLE
MAYA-114593 preserve load state of prims

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
@@ -19,6 +19,7 @@
 #include "private/Utils.h"
 
 #include <mayaUsd/ufe/Utils.h>
+#include <mayaUsd/utils/loadRules.h>
 #include <mayaUsdUtils/util.h>
 
 #include <pxr/base/tf/stringUtils.h>
@@ -108,6 +109,16 @@ bool UsdUndoRenameCommand::renameRedo()
             return false;
         }
 
+        // Make sure the load state of the renamed prim will be preserved.
+        // We copy all rules that applied to it specifically and remove the rules
+        // that applied to it specifically.
+        {
+            auto fromPath = SdfPath(_ufeSrcItem->path().getSegments()[1].string());
+            auto destPath = SdfPath(ufeSiblingPath.getSegments()[1].string());
+            duplicateLoadRules(*_stage, fromPath, destPath);
+            removeRulesForPath(*_stage, fromPath);
+        }
+
         // set the new name
         auto primSpec = MayaUsdUtils::getPrimSpecAtEditTarget(prim);
         status = primSpec->SetName(_newName);
@@ -151,6 +162,16 @@ bool UsdUndoRenameCommand::renameUndo()
             prim, SdfPath(ufeSiblingPath.getSegments()[1].string()));
         if (!status) {
             return false;
+        }
+
+        // Make sure the load state of the renamed prim will be preserved.
+        // We copy all rules that applied to it specifically and remove the rules
+        // that applied to it specifically.
+        {
+            auto fromPath = SdfPath(_ufeDstItem->path().getSegments()[1].string());
+            auto destPath = SdfPath(ufeSiblingPath.getSegments()[1].string());
+            duplicateLoadRules(*_stage, fromPath, destPath);
+            removeRulesForPath(*_stage, fromPath);
         }
 
         auto primSpec = MayaUsdUtils::getPrimSpecAtEditTarget(prim);

--- a/lib/mayaUsd/utils/CMakeLists.txt
+++ b/lib/mayaUsd/utils/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(${PROJECT_NAME}
         diagnosticDelegate.cpp
         editability.cpp
         editRouter.cpp
+        loadRules.cpp
         query.cpp
         plugRegistryHelper.cpp
         selectability.cpp
@@ -30,6 +31,7 @@ set(HEADERS
     editability.h
     editRouter.h
     hash.h
+    loadRules.h
     query.h
     plugRegistryHelper.h
     selectability.h

--- a/lib/mayaUsd/utils/loadRules.cpp
+++ b/lib/mayaUsd/utils/loadRules.cpp
@@ -1,0 +1,106 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "loadRules.h"
+
+namespace MAYAUSD_NS_DEF {
+
+void duplicateLoadRules(
+    PXR_NS::UsdStage&      stage,
+    const PXR_NS::SdfPath& fromPath,
+    const PXR_NS::SdfPath& destPath)
+{
+    // Note: get a *copy* of the rules since we are going to insert new rules as we iterate.
+    auto loadRules = stage.GetLoadRules();
+
+    // Retrieve the effective rule for the source path.
+    //
+    // The reason we retrieve the effetive rule is that even
+    // though we will modify all rules specific to that path,
+    // its actual effective rule might be dictated by an ancestor.
+    //
+    // For example, there might be *no* rules at all for the path
+    // while its parent has a rule to unload it. So its effective
+    // rule would be "unloaded".
+    //
+    // In that case, we will have to reproduce that rule at the
+    // destination as a path-specific rule.
+    const auto desiredRule = loadRules.GetEffectiveRuleForPath(fromPath);
+
+    // Analyze the reasons the source path was loaded or unloaded and
+    // replicate them to the destination.
+    //
+    // The case we need to explicitly handle is when the path is controlled
+    // by a rule on itself or a descendent and not from an ancestor. Then we
+    // need to duplicate the load or unload rule.
+    //
+    // We do this by iterating over all rules and duplicating all rules that
+    // contain the source path to create rules with the destination path.
+
+    auto oldRules = loadRules.GetRules();
+    for (const auto& rule : oldRules) {
+        const PXR_NS::SdfPath& rulePath = rule.first;
+        if (rulePath.HasPrefix(fromPath)) {
+            const auto newPath = rulePath.ReplacePrefix(fromPath, destPath);
+            loadRules.AddRule(newPath, rule.second);
+        }
+    }
+
+    // Verify if the effective rule at the destination was covered by the
+    // modified rules above. If not, add a specific rule that will give us
+    // the desired behaviour.
+    //
+    // The reason we don't simply add this specific rule for all cases and
+    // avoid the above work is that sub-paths might have rules and we need
+    // to preserve those rules. So we would need to do the above work anyway.
+    //
+    // Given that, a common case is that we don't need to add an additional
+    // rule. Always adding it would add unnecessary rules.
+    //
+    // Note: the UsdStageLoadRules has a Minimize function that simplifies
+    // rules, but we don't want to change rules the user might have set.
+    // The user may expect those rules to exists for some future purpose
+    // even though they are not currently used. As a general principle
+    // we try to not change user data unless necessary.
+    if (desiredRule != loadRules.GetEffectiveRuleForPath(destPath)) {
+        loadRules.AddRule(destPath, desiredRule);
+    }
+
+    // Update the rules in the load rules object and then in the stage
+    // since we were operating on a copy.
+    stage.SetLoadRules(loadRules);
+}
+
+void removeRulesForPath(PXR_NS::UsdStage& stage, const PXR_NS::SdfPath& path)
+{
+    // Note: get a *copy* of the rules since we are going to remove rules.
+    auto loadRules = stage.GetLoadRules();
+    auto rules = loadRules.GetRules();
+
+    // Remove all rules that match the given path.
+    auto newEnd = std::remove_if(rules.begin(), rules.end(), [&path](const auto& rule) {
+        const PXR_NS::SdfPath& rulePath = rule.first;
+        return rulePath.HasPrefix(path);
+    });
+    rules.erase(newEnd, rules.end());
+
+    // Update the rules in the load rules object and then in the stage
+    // since we were operating on a copy.
+    loadRules.SetRules(rules);
+    stage.SetLoadRules(loadRules);
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/loadRules.cpp
+++ b/lib/mayaUsd/utils/loadRules.cpp
@@ -28,7 +28,7 @@ void duplicateLoadRules(
 
     // Retrieve the effective rule for the source path.
     //
-    // The reason we retrieve the effetive rule is that even
+    // The reason we retrieve the effective rule is that even
     // though we will modify all rules specific to that path,
     // its actual effective rule might be dictated by an ancestor.
     //
@@ -72,7 +72,7 @@ void duplicateLoadRules(
     //
     // Note: the UsdStageLoadRules has a Minimize function that simplifies
     // rules, but we don't want to change rules the user might have set.
-    // The user may expect those rules to exists for some future purpose
+    // The user may expect those rules to exist for some future purpose
     // even though they are not currently used. As a general principle
     // we try to not change user data unless necessary.
     if (desiredRule != loadRules.GetEffectiveRuleForPath(destPath)) {

--- a/lib/mayaUsd/utils/loadRules.h
+++ b/lib/mayaUsd/utils/loadRules.h
@@ -1,0 +1,41 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_LOADRULES_H
+#define MAYAUSD_LOADRULES_H
+
+#include <mayaUsd/base/api.h>
+
+#include <pxr/usd/usd/stage.h>
+
+namespace MAYAUSD_NS_DEF {
+
+/*! \brief modify the stage load rules so that the rules governing fromPath are replicated for
+ * destPath.
+ */
+MAYAUSD_CORE_PUBLIC
+void duplicateLoadRules(
+    PXR_NS::UsdStage&      stage,
+    const PXR_NS::SdfPath& fromPath,
+    const PXR_NS::SdfPath& destPath);
+
+/*! \brief modify the stage load rules so that all rules governing the path are removed.
+ */
+MAYAUSD_CORE_PUBLIC
+void removeRulesForPath(PXR_NS::UsdStage& stage, const PXR_NS::SdfPath& path);
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif

--- a/test/lib/ufe/testGroupCmd.py
+++ b/test/lib/ufe/testGroupCmd.py
@@ -548,9 +548,8 @@ class GroupCmdTestCase(unittest.TestCase):
         sphere3Prim = mayaUsd.ufe.ufePathToPrim(ufe.PathString.string(sphere3Path))
 
         # Setup the load rules:
-        #     /Props is unloaded
-        #     /Props/Ball1 is loaded
-        #     /Props/Ball2 has no rule, so is governed by /Props
+        #     /Sphere1 is unloaded
+        #     /Sphere2 is loaded
         loadRules = stage.GetLoadRules()
         loadRules.AddRule('/Sphere1', loadRules.NoneRule)
         loadRules.AddRule('/Sphere2', loadRules.AllRule)

--- a/test/lib/ufe/testGroupCmd.py
+++ b/test/lib/ufe/testGroupCmd.py
@@ -374,7 +374,7 @@ class GroupCmdTestCase(unittest.TestCase):
         cmds.file(new=True, force=True)
 
          # create a stage
-        (stage, proxyShapePathStr, proxyShapeItem, contextOp) = createStage();
+        (stage, proxyShapePathStr, proxyShapeItem, contextOp) = createStage()
 
         # create a sphere generator
         sphereGen = SphereGenerator(1, contextOp, proxyShapePathStr)
@@ -410,7 +410,7 @@ class GroupCmdTestCase(unittest.TestCase):
         cmds.file(new=True, force=True)
 
          # create a stage
-        (stage, proxyShapePathStr, proxyShapeItem, contextOp) = createStage();
+        (stage, proxyShapePathStr, proxyShapeItem, contextOp) = createStage()
 
         # create a sphere generator
         sphereGen = SphereGenerator(1, contextOp, proxyShapePathStr)
@@ -445,7 +445,7 @@ class GroupCmdTestCase(unittest.TestCase):
         cmds.file(new=True, force=True)
 
          # create a stage
-        (stage, proxyShapePathStr, proxyShapeItem, contextOp) = createStage();
+        (stage, proxyShapePathStr, proxyShapeItem, contextOp) = createStage()
 
         # create a sphere generator
         sphereGen = SphereGenerator(3, contextOp, proxyShapePathStr)
@@ -488,7 +488,7 @@ class GroupCmdTestCase(unittest.TestCase):
         cmds.file(new=True, force=True)
 
          # create a stage
-        (stage, proxyShapePathStr, proxyShapeItem, contextOp) = createStage();
+        (stage, proxyShapePathStr, proxyShapeItem, contextOp) = createStage()
 
         # create a sphere generator
         sphereGen = SphereGenerator(3, contextOp, proxyShapePathStr)
@@ -526,6 +526,61 @@ class GroupCmdTestCase(unittest.TestCase):
             stage.GetPrimAtPath("/group1/Sphere1"), 
             stage.GetPrimAtPath("/group1/Sphere2"),
             stage.GetPrimAtPath("/group1/Sphere3")])
+
+    @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 3, 'testGroupUndoRedo is only available in UFE v3 or greater.')
+    def testGroupPreserveLoadRules(self):
+        '''Verify load rules are preserved when grouping.'''
+        cmds.file(new=True, force=True)
+
+         # create a stage
+        (stage, proxyShapePathStr, proxyShapeItem, contextOp) = createStage()
+
+        # create a sphere generator
+        sphereGen = SphereGenerator(3, contextOp, proxyShapePathStr)
+
+        sphere1Path = sphereGen.createSphere()
+        sphere1Prim = mayaUsd.ufe.ufePathToPrim(ufe.PathString.string(sphere1Path))
+
+        sphere2Path = sphereGen.createSphere()
+        sphere2Prim = mayaUsd.ufe.ufePathToPrim(ufe.PathString.string(sphere2Path))
+
+        sphere3Path = sphereGen.createSphere()
+        sphere3Prim = mayaUsd.ufe.ufePathToPrim(ufe.PathString.string(sphere3Path))
+
+        # Setup the load rules:
+        #     /Props is unloaded
+        #     /Props/Ball1 is loaded
+        #     /Props/Ball2 has no rule, so is governed by /Props
+        loadRules = stage.GetLoadRules()
+        loadRules.AddRule('/Sphere1', loadRules.NoneRule)
+        loadRules.AddRule('/Sphere2', loadRules.AllRule)
+        stage.SetLoadRules(loadRules)
+
+        self.assertEqual(loadRules.NoneRule, stage.GetLoadRules().GetEffectiveRuleForPath('/Sphere1'))
+        self.assertEqual(loadRules.AllRule, stage.GetLoadRules().GetEffectiveRuleForPath('/Sphere2'))
+
+        # group Sphere1, Sphere2, and Sphere3
+        groupName = cmds.group(ufe.PathString.string(sphere1Path),
+                               ufe.PathString.string(sphere2Path),
+                               ufe.PathString.string(sphere3Path))
+
+        # verify that groupItem has 3 children
+        groupItem = ufe.GlobalSelection.get().front()
+        groupHierarchy = ufe.Hierarchy.hierarchy(groupItem)
+        self.assertEqual(len(groupHierarchy.children()), 3)
+
+        self.assertEqual(loadRules.NoneRule, stage.GetLoadRules().GetEffectiveRuleForPath('/group1/Sphere1'))
+        self.assertEqual(loadRules.AllRule, stage.GetLoadRules().GetEffectiveRuleForPath('/group1/Sphere2'))
+
+        cmds.undo()
+
+        self.assertEqual(loadRules.NoneRule, stage.GetLoadRules().GetEffectiveRuleForPath('/Sphere1'))
+        self.assertEqual(loadRules.AllRule, stage.GetLoadRules().GetEffectiveRuleForPath('/Sphere2'))
+
+        cmds.redo()
+
+        self.assertEqual(loadRules.NoneRule, stage.GetLoadRules().GetEffectiveRuleForPath('/group1/Sphere1'))
+        self.assertEqual(loadRules.AllRule, stage.GetLoadRules().GetEffectiveRuleForPath('/group1/Sphere2'))
 
     @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'Requires Maya fixes only available in Maya 2023 or greater.')
     def testGroupHierarchy(self):

--- a/test/lib/ufe/testRename.py
+++ b/test/lib/ufe/testRename.py
@@ -362,7 +362,7 @@ class RenameTestCase(unittest.TestCase):
         self.assertEqual(loadRules.NoneRule, stage.GetLoadRules().GetEffectiveRuleForPath(ball2SdfRenamedPath))
 
         # Undo both rename commands and re-verify load rules.
-        # Note: each renaming does slect + rename, so we need to undo four times.
+        # Note: each renaming does select + rename, so we need to undo four times.
         cmds.undo()
         cmds.undo()
         cmds.undo()
@@ -377,7 +377,7 @@ class RenameTestCase(unittest.TestCase):
         self.assertEqual(loadRules.NoneRule, stage.GetLoadRules().GetEffectiveRuleForPath(ball2SdfPath))
 
         # Redo both rename commands and re-verify load rules.
-        # Note: each renaming does slect + rename, so we need to redo four times.
+        # Note: each renaming does select + rename, so we need to redo four times.
         cmds.redo()
         cmds.redo()
         cmds.redo()

--- a/test/lib/ufe/testRename.py
+++ b/test/lib/ufe/testRename.py
@@ -148,6 +148,9 @@ class RenameTestCase(unittest.TestCase):
         assertStageAndPrimAccess(mayaSegment, ball35PathStr, usdSegment)
 
     def testRename(self):
+        '''
+        Testing renaming a USD node.
+        '''
         # open tree.ma scene in testSamples
         mayaUtils.openTreeScene()
 
@@ -178,7 +181,7 @@ class RenameTestCase(unittest.TestCase):
         assert len(defaultPrim.GetChildren()) == 2
 
         # get prim spec for defaultPrim
-        primspec = stage.GetEditTarget().GetPrimSpecForScenePath(defaultPrim.GetPath());
+        primspec = stage.GetEditTarget().GetPrimSpecForScenePath(defaultPrim.GetPath())
 
         # set primspec name
         primspec.name = "TreeBase_potato"
@@ -187,7 +190,7 @@ class RenameTestCase(unittest.TestCase):
         renamedPrim = stage.GetPrimAtPath('/TreeBase_potato')
 
         # One must use the SdfLayer API for setting the defaultPrim when you rename the prim it identifies.
-        stage.SetDefaultPrim(renamedPrim);
+        stage.SetDefaultPrim(renamedPrim)
 
         # get defaultPrim again
         defaultPrim = stage.GetDefaultPrim()
@@ -206,7 +209,9 @@ class RenameTestCase(unittest.TestCase):
         self.assertEqual(leavesPrimSpec.GetName(), 'leaves')
 
     def testRenameUndo(self):
-        '''Rename USD node.'''
+        '''
+        Testing rename USD node undo/redo.
+        '''
 
         # open usdCylinder.ma scene in testSamples
         mayaUtils.openCylinderScene()
@@ -278,6 +283,113 @@ class RenameTestCase(unittest.TestCase):
         self.assertIn(pCylinder1RenName, propsChildrenNames)
         self.assertNotIn('pCylinder1', propsChildrenNames)
         self.assertEqual(len(propsChildren), len(propsChildrenPre))
+
+    def testRenamePreserveLoadRules(self):
+        '''
+        Testing that renaming a USD node preserve load rules targeting it.
+        '''
+
+        # open scene in testSamples. Relevant hierarchy is:
+        #    |transform1
+        #       |proxyShape1
+        #          /Ball_set
+        #             /Props
+        #                /Ball_1
+        #                /Ball_2
+        #                ...
+
+        mayaUtils.openGroupBallsScene()
+
+        # USD paths used in the test.
+        propsSdfPath = '/Ball_set/Props'
+        ball1SdfPath = '/Ball_set/Props/Ball_1'
+        ball2SdfPath = '/Ball_set/Props/Ball_2'
+
+        ball1SdfRenamedPath = '/Ball_set/Props/Round_1'
+        ball2SdfRenamedPath = '/Ball_set/Props/Round_2'
+
+        # Maya UFE segment and USD stage, needed in various places below.
+        mayaPathSegment = mayaUtils.createUfePathSegment('|transform1|proxyShape1')
+        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+
+        # Setup the load rules:
+        #     /Props is unloaded
+        #     /Props/Ball1 is loaded
+        #     /Props/Ball2 has no rule, so is governed by /Props
+        loadRules = stage.GetLoadRules()
+        loadRules.AddRule(propsSdfPath, loadRules.NoneRule)
+        loadRules.AddRule(ball1SdfPath, loadRules.AllRule)
+        stage.SetLoadRules(loadRules)
+
+        self.assertEqual(loadRules.OnlyRule, stage.GetLoadRules().GetEffectiveRuleForPath(propsSdfPath))
+        self.assertEqual(loadRules.AllRule, stage.GetLoadRules().GetEffectiveRuleForPath(ball1SdfPath))
+        self.assertEqual(loadRules.NoneRule, stage.GetLoadRules().GetEffectiveRuleForPath(ball2SdfPath))
+
+        def childrenNames(children):
+           return [str(child.path().back()) for child in children]
+
+        # Verify we can find the expected prims.
+        def verifyNames(expectedNames):
+            propsPathSegment = usdUtils.createUfePathSegment(propsSdfPath)
+            propsUfePath = ufe.Path([mayaPathSegment, propsPathSegment])
+            propsUfeItem = ufe.Hierarchy.createItem(propsUfePath)
+            propsHierarchy = ufe.Hierarchy.hierarchy(propsUfeItem)
+            propsChildren = propsHierarchy.children()
+            propsChildrenNames = childrenNames(propsChildren)
+            for name in expectedNames:
+                self.assertIn(name, propsChildrenNames)
+
+        verifyNames(['Ball_1', 'Ball_2'])
+
+        # Rename the balls.
+        def rename(sdfPath, newName):
+            ufePathSegment = usdUtils.createUfePathSegment(sdfPath)
+            ufePath = ufe.Path([mayaPathSegment, ufePathSegment])
+            ufeItem = ufe.Hierarchy.createItem(ufePath)
+            cmds.select(clear=True)
+            ufe.GlobalSelection.get().append(ufeItem)
+            cmds.rename(newName)
+
+        rename(ball1SdfPath, "Round_1")
+        rename(ball2SdfPath, "Round_2")
+
+        # Verify we can find the expected renamed prims.
+        verifyNames(['Round_1', 'Round_2'])
+
+        # Verify the load rules for each item has not changed.
+        self.assertEqual(loadRules.OnlyRule, stage.GetLoadRules().GetEffectiveRuleForPath(propsSdfPath))
+        self.assertEqual(loadRules.AllRule, stage.GetLoadRules().GetEffectiveRuleForPath(ball1SdfRenamedPath))
+        self.assertEqual(loadRules.NoneRule, stage.GetLoadRules().GetEffectiveRuleForPath(ball2SdfRenamedPath))
+
+        # Undo both rename commands and re-verify load rules.
+        # Note: each renaming does slect + rename, so we need to undo four times.
+        cmds.undo()
+        cmds.undo()
+        cmds.undo()
+        cmds.undo()
+
+        # Verify we can find the expected renamed prims.
+        verifyNames(['Ball_1', 'Ball_2'])
+
+        # Verify the load rules for each item has not changed.
+        self.assertEqual(loadRules.OnlyRule, stage.GetLoadRules().GetEffectiveRuleForPath(propsSdfPath))
+        self.assertEqual(loadRules.AllRule, stage.GetLoadRules().GetEffectiveRuleForPath(ball1SdfPath))
+        self.assertEqual(loadRules.NoneRule, stage.GetLoadRules().GetEffectiveRuleForPath(ball2SdfPath))
+
+        # Redo both rename commands and re-verify load rules.
+        # Note: each renaming does slect + rename, so we need to redo four times.
+        cmds.redo()
+        cmds.redo()
+        cmds.redo()
+        cmds.redo()
+        
+        # Verify we can find the expected renamed prims.
+        verifyNames(['Round_1', 'Round_2'])
+
+        # Verify the load rules for each item has not changed.
+        self.assertEqual(loadRules.OnlyRule, stage.GetLoadRules().GetEffectiveRuleForPath(propsSdfPath))
+        self.assertEqual(loadRules.AllRule, stage.GetLoadRules().GetEffectiveRuleForPath(ball1SdfRenamedPath))
+        self.assertEqual(loadRules.NoneRule, stage.GetLoadRules().GetEffectiveRuleForPath(ball2SdfRenamedPath))
 
     def testRenameRestrictionSameLayerDef(self):
         '''Restrict renaming USD node. Cannot rename a prim defined on another layer.'''


### PR DESCRIPTION
Added code to preserve the loaded or unloaded state of a prim when grouped, reparented or renamed. Note that we don't remove the old rules when duplicating since the source prim still exists.

- Refactor the existing load-state preservation code in reusable functions.
- Use them in the duplicate, rename, and reparenting commands.
- Add unit tests for grouping and renaming, which also covers parenting since grouping reparents.