### PR TITLE
MAYA-113944 If USD reports that the topology is dirty compare the

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/draw_item.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/draw_item.h
@@ -54,6 +54,7 @@ public:
 
         //! Render item index buffer - use when updating data
         std::unique_ptr<MHWRender::MIndexBuffer> _indexBuffer;
+        bool                                     _indexBufferValid { false };
         //! Bounding box of the render item.
         MBoundingBox _boundingBox;
         //! World matrix of the render item.

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -531,14 +531,15 @@ void HdVP2Mesh::_PrepareSharedVertexBuffers(
                 if (!_meshSharedData->_adjacency) {
                     _meshSharedData->_adjacency.reset(new Hd_VertexAdjacency());
 
-                    HdBufferSourceSharedPtr     adjacencyComputation
-                        = _meshSharedData->_adjacency->GetSharedAdjacencyBuilderComputation(&_meshSharedData->_topology);
+                    HdBufferSourceSharedPtr adjacencyComputation
+                        = _meshSharedData->_adjacency->GetSharedAdjacencyBuilderComputation(
+                            &_meshSharedData->_topology);
                     MProfilingScope profilingScope(
                         HdVP2RenderDelegate::sProfilerCategory,
                         MProfiler::kColorC_L2,
                         _rprimId.asChar(),
                         "HdVP2Mesh::computeAdjacency");
-                        
+
                     adjacencyComputation->Resolve();
                 }
 
@@ -929,7 +930,7 @@ void HdVP2Mesh::Sync(
                 _rprimId.asChar(),
                 "HdVP2Mesh::GetMeshTopology");
             HdMeshTopology newTopology = GetMeshTopology(delegate);
-            
+
             // Test to see if the topology actually changed. If not, we don't have to do anything!
             // Don't test IsTopologyDirty anywhere below this because it is not accurate. Instead
             // using the _indexBufferValid flag on render item data.
@@ -2534,8 +2535,7 @@ void HdVP2Mesh::_ForEachRenderItemInRepr(const TfToken& reprToken, Func func)
     }
 }
 
-template <typename Func>
-void HdVP2Mesh::_ForEachRenderItem(Func func)
+template <typename Func> void HdVP2Mesh::_ForEachRenderItem(Func func)
 {
     for (const std::pair<TfToken, HdReprSharedPtr>& pair : _reprs) {
         _ForEachRenderItemInRepr(pair.first, func);

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
@@ -24,6 +24,7 @@
 #include <mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h>
 
 #include <pxr/imaging/hd/mesh.h>
+#include <pxr/imaging/hd/vertexAdjacency.h>
 #include <pxr/pxr.h>
 
 #include <maya/MHWGeometry.h>
@@ -47,6 +48,9 @@ struct HdVP2MeshSharedData
     //! only call const accessors keeping them around doesn't incur a buffer
     //! copy.
     HdMeshTopology _topology;
+
+    //! Adjacency based off of _topology
+    Hd_VertexAdjacencySharedPtr _adjacency;
 
     //! The rendering topology is to create unshared or sorted vertice layout
     //! for efficient GPU rendering.
@@ -144,6 +148,12 @@ private:
         const TfToken&        reprToken);
 
     void _HideAllDrawItems(const TfToken& reprToken);
+
+    template <typename Func>
+    void _ForEachRenderItemInRepr(const TfToken& reprToken, Func func);
+
+    template <typename Func>
+    void _ForEachRenderItem(Func func);
 
     void _UpdatePrimvarSources(
         HdSceneDelegate*     sceneDelegate,

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
@@ -149,11 +149,9 @@ private:
 
     void _HideAllDrawItems(const TfToken& reprToken);
 
-    template <typename Func>
-    void _ForEachRenderItemInRepr(const TfToken& reprToken, Func func);
+    template <typename Func> void _ForEachRenderItemInRepr(const TfToken& reprToken, Func func);
 
-    template <typename Func>
-    void _ForEachRenderItem(Func func);
+    template <typename Func> void _ForEachRenderItem(Func func);
 
     void _UpdatePrimvarSources(
         HdSceneDelegate*     sceneDelegate,


### PR DESCRIPTION
new topology to the old. Only do the topology updates if the old and new typologies are different. Save the adjacency calculation used to compute normals.