### PR TITLE
MAYA-121837: Maya Reference: Clean up 'Cache to USD' UI options

### DIFF
--- a/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
@@ -150,12 +150,19 @@ def primNameTextChanged(primName):
         if validatedName != primName:
             cmds.textFieldGrp('primNameText', edit=True, text=validatedName)
 
+def variantOrNewPrim(buttonChecked):
+    # The variant and new child prim radio buttons are part of a collection.
+    # So only one can be checked.
+    variantSelected = cmds.radioButtonGrp('variantRadioBtn', query=True, select=1)
+    cmds.rowLayout('usdCacheVariantSetRow', edit=True, enable=variantSelected)
+    cmds.rowLayout('usdCacheVariantNameRow', edit=True, enable=variantSelected)
+    cmds.textFieldGrp('primNameText', edit=True, enable=not variantSelected)
 
 def cacheFileUsdHierarchyOptions(topForm):
     '''Create controls to insert Maya reference USD cache into USD hierarchy.'''
 
     cmds.setParent(topForm)
-    cmds.frameLayout(label=getMayaUsdLibString("kCacheMayaRefUsdHierarchy"))
+    cmds.frameLayout('authorFrameLayout', label=getMayaUsdLibString("kCacheMayaRefUsdHierarchy"))
     widgetColumn = cmds.columnLayout()
 
     rl = mel.eval('createRowLayoutforMayaReference("' + widgetColumn + '", "cacheFilePreviewRow", 2)')
@@ -166,7 +173,7 @@ def cacheFileUsdHierarchyOptions(topForm):
 
     with mayaRefUtils.SetParentContext(cmds.rowLayout(numberOfColumns=2)):
         cmds.optionMenuGrp('compositionArcTypeMenu',
-                           label=getMayaUsdLibString('kOptionAsCompositionArc'),
+                           label=getMayaUsdLibString('kOptionAsUSDReference'),
                            cc=compositionArcChanged)
         for label in _compositionArcLabels:
             cmds.menuItem(label=label)
@@ -178,6 +185,7 @@ def cacheFileUsdHierarchyOptions(topForm):
 
     variantRb = cmds.radioButtonGrp('variantRadioBtn',
                                     nrb=1,
+                                    changeCommand1=variantOrNewPrim,
                                     label=getMayaUsdLibString('kTextDefineIn'),
                                     l1=getMayaUsdLibString('kTextVariant'))
 
@@ -196,6 +204,8 @@ def cacheFileUsdHierarchyOptions(topForm):
         cmds.textField('variantNameText',
                        cc=variantNameTextChanged)
 
+    # Note: this radio button doesn't need the change command since its part of
+    #       the same collection as the variantRb (which has the changeCommand).
     newChildRb = cmds.radioButtonGrp('newChildPrimRadioBtn',
                                      nrb=1,
                                      label='',
@@ -207,6 +217,7 @@ def cacheFileUsdHierarchyOptions(topForm):
                       cc=primNameTextChanged)
 
     cmds.radioButtonGrp(variantRb, edit=True, select=1)
+    variantOrNewPrim(True)
 
 
 # Adapted from fileOptions.mel:fileOptionsTabPage().
@@ -332,6 +343,13 @@ def cacheInitUi(parent, filterType):
         primName = mayaUsd.ufe.uniqueChildName(mayaRefPrimParent, kDefaultCachePrimName)
     cmds.textFieldGrp('primNameText', edit=True, text=primName)
 
+    # By default we want to collapse certain sections.
+    cmds.frameLayout('outputFrameLayout', edit=True, collapse=False)
+    cmds.frameLayout('geometryFrameLayout', edit=True, collapse=True)
+    cmds.frameLayout('materialsFrameLayout', edit=True, collapse=True)
+    cmds.frameLayout('animationFrameLayout', edit=True, collapse=True)
+    cmds.frameLayout('advancedFrameLayout', edit=True, collapse=True)
+    cmds.frameLayout('authorFrameLayout', edit=True, collapse=False)
 
 def cacheCommitUi(parent, selectedFile):
     """

--- a/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
@@ -42,7 +42,7 @@ def mayaUsdLibRegisterStrings():
     register('kButtonNewChildPrim', 'New Child Prim')
     register('kCacheFileWillAppear', 'Cache file will appear\non parent prim:')
     register('kCacheMayaRefCache', 'Cache');
-    register('kCacheMayaRefOptions', 'Cache Options');
+    register('kCacheMayaRefOptions', 'Cache File Options');
     register('kCacheMayaRefUsdHierarchy', 'Author Cache File to USD Hierarchy');
     register('kCaptionCacheToUsd', 'Cache to USD')
     register('kErrorCacheToUsdFailed', 'Cache to USD failed for "^1s".')
@@ -50,7 +50,7 @@ def mayaUsdLibRegisterStrings():
     register('kMenuPayload', 'Payload')
     register('kMenuPrepend', 'Prepend')
     register('kMenuReference', 'Reference')
-    register('kOptionAsCompositionArc', 'As Composition Arc:')
+    register('kOptionAsUSDReference', 'As USD Reference:')
     register('kOptionListEditedAs', 'List Edited As')
     register('kTextDefineIn', 'Define in:')
     register('kTextVariant', 'Variant')

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -530,7 +530,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
         }
 
         if (stringArrayContains("output", $sectionNames)) {
-            frameLayout -label `getMayaUsdString("kExportFrameOutputLbl")` -collapsable true -collapse false;
+            frameLayout -label `getMayaUsdString("kExportFrameOutputLbl")` -collapsable true -collapse false outputFrameLayout;
                 separator -style "none";
 
                 optionMenuGrp -l `getMayaUsdString("kExportDefaultFormatLbl")` -annotation `getMayaUsdString("kExportDefaultFormatAnn")` -statusBarMessage `getMayaUsdString("kExportDefaultFormatStatus")` defaultUSDFormatPopup;
@@ -549,7 +549,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
         }
 
         if (stringArrayContains("geometry", $sectionNames)) {
-            frameLayout -label `getMayaUsdString("kExportFrameGeometryLbl")` -collapsable true -collapse false;
+            frameLayout -label `getMayaUsdString("kExportFrameGeometryLbl")` -collapsable true -collapse false geometryFrameLayout;
                 separator -style "none";
                 optionMenuGrp -l `getMayaUsdString("kExportSubdMethodLbl")` -annotation `getMayaUsdString("kExportSubdMethodAnn")` defaultMeshSchemePopup;
                     menuItem -l `getMayaUsdString("kExportSubdMethodCCLbl")` -ann "catmullClark";
@@ -580,7 +580,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
         }
 
         if (stringArrayContains("materials", $sectionNames)) {
-            frameLayout -label `getMayaUsdString("kExportFrameMaterialsLbl")` -collapsable true -collapse false -ann `getMayaUsdString("kExportMaterialsAnn")`;
+            frameLayout -label `getMayaUsdString("kExportFrameMaterialsLbl")` -collapsable true -collapse false -ann `getMayaUsdString("kExportMaterialsAnn")` materialsFrameLayout;
                 separator -style "none";
 
                 string $conversions[] = `mayaUSDListShadingModes -export -useRegistryOnly`;
@@ -600,7 +600,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
 
         if (stringArrayContains("animation", $sectionNames)) {
             frameLayout -label `getMayaUsdString("kExportFrameAnimationLbl")` -collapsable true -collapse false 
-                        -expandCommand("mayaUsdTranslatorExport_AnimationFrameLayoutExpandCB");
+                        -expandCommand("mayaUsdTranslatorExport_AnimationFrameLayoutExpandCB") animationFrameLayout;
                 separator -style "none";
 
                 if (stringArrayContains("animation-data", $sectionNames)) {
@@ -630,7 +630,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
         }
 
         if (stringArrayContains("advanced", $sectionNames)) {
-            frameLayout -label `getMayaUsdString("kExportFrameAdvancedLbl")` -collapsable true -collapse true;
+            frameLayout -label `getMayaUsdString("kExportFrameAdvancedLbl")` -collapsable true -collapse true advancedFrameLayout;
                 separator -style "none";
 
                 checkBoxGrp -l `getMayaUsdString("kExportVisibilityLbl")` -annotation `getMayaUsdString("kExportVisibilityAnn")` exportVisibilityCheckBox;


### PR DESCRIPTION
#### MAYA-121837: Maya Reference: Clean up 'Cache to USD' UI options
* Two small renaming.
* Collapse some sections by default (only for cache).
* enable/disable based on radio button selection.