### PR TITLE
MAYA-121882 Share the cached HdVP2TextureInfo between all materials so that isSRGB

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -1318,6 +1318,7 @@ private:
 std::mutex                            HdVP2Material::_refreshMutex;
 std::chrono::steady_clock::time_point HdVP2Material::_startTime;
 std::atomic_size_t                    HdVP2Material::_runningTasksCounter;
+HdVP2TextureMap                       HdVP2Material::_textureMap;
 
 /*! \brief  Releases the reference to the texture owned by a smart pointer.
  */
@@ -2491,6 +2492,7 @@ const HdVP2TextureInfo& HdVP2Material::_AcquireTexture(
     const std::string&    path,
     const HdMaterialNode& node)
 {
+    fprintf(stderr, "Searching for texture %s in the texture map\n", path.c_str());
     const auto it = _textureMap.find(path);
     if (it != _textureMap.end()) {
         return it->second;
@@ -2512,6 +2514,8 @@ const HdVP2TextureInfo& HdVP2Material::_AcquireTexture(
         MHWRender::MTexture* texture
             = _LoadTexture(path, hasFallbackColor, fallbackColor, isSRGB, uvScaleOffset);
 
+
+        fprintf(stderr, "Adding texture %s in the texture map\n", path.c_str());
         HdVP2TextureInfo& info = _textureMap[path];
         info._texture.reset(texture);
         info._isColorSpaceSRGB = isSRGB;

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -2492,7 +2492,6 @@ const HdVP2TextureInfo& HdVP2Material::_AcquireTexture(
     const std::string&    path,
     const HdMaterialNode& node)
 {
-    fprintf(stderr, "Searching for texture %s in the texture map\n", path.c_str());
     const auto it = _textureMap.find(path);
     if (it != _textureMap.end()) {
         return it->second;
@@ -2514,8 +2513,6 @@ const HdVP2TextureInfo& HdVP2Material::_AcquireTexture(
         MHWRender::MTexture* texture
             = _LoadTexture(path, hasFallbackColor, fallbackColor, isSRGB, uvScaleOffset);
 
-
-        fprintf(stderr, "Adding texture %s in the texture map\n", path.c_str());
         HdVP2TextureInfo& info = _textureMap[path];
         info._texture.reset(texture);
         info._isColorSpaceSRGB = isSRGB;

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.h
@@ -147,10 +147,10 @@ private:
 
     TfToken _surfaceNetworkToken; //!< Generated token to uniquely identify a material network
 
-    HdVP2ShaderUniquePtr _surfaceShader;    //!< VP2 surface shader instance
-    SdfPath              _surfaceShaderId;  //!< Path of the surface shader
-    static HdVP2TextureMap      _textureMap;       //!< Textures used by this material
-    TfTokenVector        _requiredPrimvars; //!< primvars required by this material
+    HdVP2ShaderUniquePtr   _surfaceShader;    //!< VP2 surface shader instance
+    SdfPath                _surfaceShaderId;  //!< Path of the surface shader
+    static HdVP2TextureMap _textureMap;       //!< Textures used by this material
+    TfTokenVector          _requiredPrimvars; //!< primvars required by this material
 
     std::unordered_map<std::string, TextureLoadingTask*> _textureLoadingTasks;
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.h
@@ -149,7 +149,7 @@ private:
 
     HdVP2ShaderUniquePtr _surfaceShader;    //!< VP2 surface shader instance
     SdfPath              _surfaceShaderId;  //!< Path of the surface shader
-    HdVP2TextureMap      _textureMap;       //!< Textures used by this material
+    static HdVP2TextureMap      _textureMap;       //!< Textures used by this material
     TfTokenVector        _requiredPrimvars; //!< primvars required by this material
 
     std::unordered_map<std::string, TextureLoadingTask*> _textureLoadingTasks;


### PR DESCRIPTION
and uvScaleOffset and re-used correctly when hitting a texture in the cache.