### PR TITLE
[al] Fixed a bug where bbox did not recalculate if prims visibilities changed

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1036,7 +1036,8 @@ void ProxyShape::processChangedObjects(
             UsdPrim changedPrim = m_stage->GetPrimAtPath(path);
             if (path.IsPrimPropertyPath()) {
                 const std::string tokenString = path.GetElementString();
-                if (std::strncmp(tokenString.c_str(), ".xformOp", 8) == 0) {
+                if (std::strncmp(tokenString.c_str(), ".xformOp", 8) == 0
+                    || std::strncmp(tokenString.c_str(), ".visibility", 11) == 0) {
                     shouldCleanBBoxCache = true;
                     break;
                 }


### PR DESCRIPTION
As per title, if prim visibility changed, invalidate the bbox cache so that the bbox on screen can be kept up to date.