### PR TITLE
 MAYA-121626 Automatically set the animation option

### DIFF
--- a/lib/mayaUsd/commands/PullPushCommands.cpp
+++ b/lib/mayaUsd/commands/PullPushCommands.cpp
@@ -270,7 +270,7 @@ MStatus MergeToUsdCommand::doIt(const MArgList& argList)
     const MString exportOptions = parseTextArg(argData, kExportOptionsFlag, "");
     if (exportOptions.length() > 0) {
         status = PXR_NS::UsdMayaJobExportArgs::GetDictionaryFromEncodedOptions(
-            exportOptions, &userArgs, nullptr);
+            exportOptions, &userArgs);
         if (status != MS::kSuccess)
             return status;
     }
@@ -420,7 +420,7 @@ MStatus DuplicateCommand::doIt(const MArgList& argList)
     const MString exportOptions = parseTextArg(argData, kExportOptionsFlag, "");
     if (exportOptions.length() > 0) {
         status = PXR_NS::UsdMayaJobExportArgs::GetDictionaryFromEncodedOptions(
-            exportOptions, &userArgs, nullptr);
+            exportOptions, &userArgs);
         if (status != MS::kSuccess)
             return status;
     }

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -53,6 +53,11 @@ TF_DECLARE_PUBLIC_TOKENS(
 // clang-format off
 #define PXRUSDMAYA_JOB_EXPORT_ARGS_TOKENS \
     /* Dictionary keys */ \
+    (animation) \
+    (startTime) \
+    (endTime) \
+    (frameStride) \
+    (frameSample) \
     (apiSchema) \
     (chaser) \
     (chaserArgs) \
@@ -256,10 +261,13 @@ struct UsdMayaJobExportArgs
     ///
     /// The text encoding is in the form: name1=value1;name2=value2;...
     MAYAUSD_CORE_PUBLIC
-    static MStatus GetDictionaryFromEncodedOptions(
-        const MString&       textEncodedOptions,
-        VtDictionary*        userArgs,
-        std::vector<double>* timeSamples);
+    static MStatus
+    GetDictionaryFromEncodedOptions(const MString& textEncodedOptions, VtDictionary* userArgs);
+
+    /// Extract the time samples corresponding to the animation options.
+    MAYAUSD_CORE_PUBLIC
+    static void
+    GetDictionaryTimeSamples(const VtDictionary& userArgs, std::vector<double>& timeSamples);
 
     /// Gets the default arguments dictionary for UsdMayaJobExportArgs.
     MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -481,14 +481,8 @@ PushCustomizeSrc pushExport(
     UsdMayaUtil::MDagPathSet dagPaths;
     dagPaths.insert(dagPath);
 
-    GfInterval timeInterval = PXR_NS::UsdMayaPrimUpdater::isAnimated(dagPath)
-        ? GfInterval(MAnimControl::minTime().value(), MAnimControl::maxTime().value())
-        : GfInterval();
-    double           frameStride = 1.0;
-    std::set<double> frameSamples;
-
-    const std::vector<double> timeSamples
-        = UsdMayaWriteUtil::GetTimeSamples(timeInterval, frameSamples, frameStride);
+    std::vector<double> timeSamples;
+    UsdMayaJobExportArgs::GetDictionaryTimeSamples(userArgs, timeSamples);
 
     // The pushed Dag node is the root of the export job.
     std::vector<VtValue> rootPathString(

--- a/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
+++ b/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
@@ -35,6 +35,21 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace {
 
+bool isAnimated(const std::string& nodeName)
+{
+    MObject obj;
+    MStatus status = UsdMayaUtil::GetMObjectByName(nodeName, obj);
+    if (status != MStatus::kSuccess)
+        return false;
+
+    MDagPath dagPath;
+    status = MDagPath::getAPathTo(obj, dagPath);
+    if (status != MStatus::kSuccess)
+        return false;
+
+    return UsdMayaPrimUpdater::isAnimated(dagPath);
+}
+
 bool mergeToUsd(const std::string& nodeName, const VtDictionary& userArgs = VtDictionary())
 {
     MObject obj;
@@ -107,6 +122,7 @@ std::string readPullInformation(const PXR_NS::UsdPrim& prim)
 void wrapPrimUpdaterManager()
 {
     class_<PrimUpdaterManager, noncopyable>("PrimUpdaterManager", no_init)
+        .def("isAnimated", isAnimated)
         .def("mergeToUsd", mergeToUsd, mergeToUsd_overloads())
         .def("editAsMaya", editAsMaya)
         .def("canEditAsMaya", canEditAsMaya)

--- a/lib/mayaUsd/python/wrapUtil.cpp
+++ b/lib/mayaUsd/python/wrapUtil.cpp
@@ -37,7 +37,7 @@ VtDictionary getDictionaryFromEncodedOptions(const std::string& textOptions)
 {
     VtDictionary dictOptions;
     auto         status = UsdMayaJobExportArgs::GetDictionaryFromEncodedOptions(
-        MString(textOptions.c_str()), &dictOptions, nullptr);
+        MString(textOptions.c_str()), &dictOptions);
     if (status != MS::kSuccess)
         return VtDictionary();
     return dictOptions;

--- a/lib/mayaUsd/resources/scripts/cacheToUsd.py
+++ b/lib/mayaUsd/resources/scripts/cacheToUsd.py
@@ -22,19 +22,11 @@ import mayaUsdOptions
 import re
 
 
-def forceCacheOptions(textOptions):
-    """
-    Adjusts the export options with cache-to-USD specific values.
-    """
-    return re.sub(r'animation=.', 'animation=1', textOptions)
-
-
 def getDefaultExportOptions():
     """
     Retrieves the default export options used by cache-to-USD.
     """
-    optionsText = cmds.translator('USD Export', query=True, do=True)
-    return forceCacheOptions(optionsText)
+    return cmds.translator('USD Export', query=True, do=True)
 
 
 def getDefaultCacheCreationOptions():

--- a/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
@@ -269,7 +269,7 @@ def setCacheOptions(newCacheOptions):
     Called from mayaUsdTranslatorExport via mayaUsdCacheMayaReference_setCacheOptions in MEL.
     """
     global _cacheExportOptions
-    _cacheExportOptions = cacheToUsd.forceCacheOptions(newCacheOptions)
+    _cacheExportOptions = newCacheOptions
 
 
 def cacheCreateUi(parent):

--- a/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
@@ -36,7 +36,7 @@ kDefaultCachePrimName = 'Cache1'
 _cacheExportOptions = None
 
 # The options string that we pass to mayaUsdTranslatorExport.
-kTranslatorExportOptions = 'all;!output-parentscope;!animation-data'
+kTranslatorExportOptions = 'all;!output-parentscope'
 
 # Dag path corresponding to pulled prim.  This is a Maya transform node that is
 # not in the Maya reference itself, but is its parent.

--- a/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
@@ -245,6 +245,7 @@ def fileOptionsTabPage(tabLayout):
     # resultCallback not called on "post", is therefore an empty string.
     fileOptionsScroll = cmds.columnLayout('fileOptionsScroll')
     optionsText = mayaUsdOptions.convertOptionsDictToText(cacheToUsd.loadCacheCreationOptions())
+    optionsText = mayaUsdOptions.setAnimateOption(_mayaRefDagPath, optionsText)
     mel.eval('mayaUsdTranslatorExport("fileOptionsScroll", "post={exportOpts}", "{cacheOpts}", "")'.format(exportOpts=kTranslatorExportOptions, cacheOpts=optionsText))
 
     cacheFileUsdHierarchyOptions(topForm)

--- a/lib/mayaUsd/resources/scripts/mayaUsdMergeToUSDOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdMergeToUSDOptions.py
@@ -74,11 +74,11 @@ def _createMergeToUSDOptionsDialog(window, target):
     subLayout = cmds.columnLayout("MergeToUSDOptionsDialogSubLayout", adjustableColumn=True, parent=windowLayout)
 
     optionsText = getMergeToUSDOptionsText()
-    _fillMergeToUSDOptionsDialog(subLayout, optionsText, "post")
+    _fillMergeToUSDOptionsDialog(target, subLayout, optionsText, "post")
 
     menu = cmds.menu(label=getMayaUsdLibString("kEditMenu"), parent=menuBarLayout)
     cmds.menuItem(label=getMayaUsdLibString("kSaveSettingsMenuItem"), command=_saveMergeToUSDOptions)
-    cmds.menuItem(label=getMayaUsdLibString("kResetSettingsMenuItem"), command=partial(_resetMergeToUSDOptions, subLayout))
+    cmds.menuItem(label=getMayaUsdLibString("kResetSettingsMenuItem"), command=partial(_resetMergeToUSDOptions, target, subLayout))
 
     cmds.setParent(menuBarLayout)
     menu = cmds.menu(label=getMayaUsdLibString("kHelpMenu"), parent=menuBarLayout)
@@ -177,19 +177,20 @@ def _saveMergeToUSDOptions(data=None):
     mel.eval('''mayaUsdTranslatorExport("", "query=all;!output", "", "receiveMergeToUSDOptionsTextFromDialog");''')
 
 
-def _resetMergeToUSDOptions(subLayout, data=None):
+def _resetMergeToUSDOptions(target, subLayout, data=None):
     """
     Resets the merge-to-USD options in the dialog.
     """
     optionsText = mayaUsdOptions.convertOptionsDictToText(_getDefaultMergeToUSDOptionsDict())
-    _fillMergeToUSDOptionsDialog(subLayout, optionsText, "fill")
+    _fillMergeToUSDOptionsDialog(target, subLayout, optionsText, "fill")
 
 
-def _fillMergeToUSDOptionsDialog(subLayout, optionsText, action):
+def _fillMergeToUSDOptionsDialog(target, subLayout, optionsText, action):
     """
     Fills the merge-to-USD options dialog UI elements with the given options.
     """
     cmds.setParent(subLayout)
+    optionsText = mayaUsdOptions.setAnimateOption(target, optionsText)
     mel.eval(
         '''
         mayaUsdTranslatorExport("{subLayout}", "{action}=all;!output", "{optionsText}", "")

--- a/lib/mayaUsd/resources/scripts/mayaUsdMergeToUSDOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdMergeToUSDOptions.py
@@ -174,7 +174,7 @@ def _saveMergeToUSDOptions(data=None):
     Saves the merge-to-USD options as currently set in the dialog.
     The MEL receiveMergeToUSDOptionsTextFromDialog will call setMergeToUSDOptionsText.
     """
-    mel.eval('''mayaUsdTranslatorExport("", "query=all;!output;!animation-data", "", "receiveMergeToUSDOptionsTextFromDialog");''')
+    mel.eval('''mayaUsdTranslatorExport("", "query=all;!output", "", "receiveMergeToUSDOptionsTextFromDialog");''')
 
 
 def _resetMergeToUSDOptions(subLayout, data=None):
@@ -192,7 +192,7 @@ def _fillMergeToUSDOptionsDialog(subLayout, optionsText, action):
     cmds.setParent(subLayout)
     mel.eval(
         '''
-        mayaUsdTranslatorExport("{subLayout}", "{action}=all;!output;!animation-data", "{optionsText}", "")
+        mayaUsdTranslatorExport("{subLayout}", "{action}=all;!output", "{optionsText}", "")
         '''.format(optionsText=optionsText, subLayout=subLayout, action=action))
 
 

--- a/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
@@ -41,8 +41,24 @@ def convertOptionsDictToText(optionsDict):
     """
     Converts options to text with column-separated key/value pairs.
     """
-    optionsList = ['%s=%s' % (name, value) for name, value in optionsDict.items()]
+    optionsList = ['%s=%s' % (name, _convertValueToText(value)) for name, value in optionsDict.items()]
     return ';'.join(optionsList)
+
+
+def _convertValueToText(value):
+    # Unfortunately, for historical reasons, text lists have used
+    # comma-separated values, while floating-point used space-separated values.
+    if isinstance(value,list):
+        # Note: empty list must create empty text.
+        if not len(value):
+            return ''
+        if isinstance(value[0], str):
+            sep = ','
+        else:
+            sep = ' '
+        return sep.join([_convertValueToText(v) for v in value])
+    else:
+        return str(value)
 
 
 def convertOptionsTextToDict(optionsText, defaultOptionsDict):
@@ -60,16 +76,16 @@ def convertOptionsTextToDict(optionsText, defaultOptionsDict):
         else:
             key, value = opt, ""
 
-        # Use the default values to try to convert the saved value to the correct type.
+        # Use the guide values to try to convert the saved value to the correct type.
         if key in optionsDict:
-            optionsDict[key] = _convertType(value, optionsDict[key])
+            optionsDict[key] = _convertTextToType(value, optionsDict[key])
         else:
             optionsDict[key] = value
 
     return optionsDict
 
 
-def _convertType(valueToConvert, defaultValue):
+def _convertTextToType(valueToConvert, defaultValue, desiredType=None):
     """
     Ensure the value has the correct expected type by converting it.
     Since the values are extracted from text, it is normal that they
@@ -79,7 +95,8 @@ def _convertType(valueToConvert, defaultValue):
     happen if the optionVar got corrupted, for example from corrupted user
     prefs.
     """
-    desiredType = type(defaultValue)
+    if not desiredType:
+        desiredType = type(defaultValue)
     if isinstance(valueToConvert, desiredType):
         return valueToConvert
     # Try to convert the value to the desired value.
@@ -95,4 +112,29 @@ def _convertType(valueToConvert, defaultValue):
             if isinstance(defaultValue, t):
                 return t(valueToConvert)
     except:
-        return defaultValue
+        pass
+
+    # Verify to convert list values by converting each element.
+    # Unfortunately, for historical reasons, text lists have used
+    # comma-separated values, while floating-point used space-separated values.
+    try:
+        if isinstance(defaultValue, list):
+            if ',' in valueToConvert:
+                values = valueToConvert.split(',')
+                desiredType = str
+            else:
+                values = valueToConvert.split()
+                desiredType = float
+            convertedValues = []
+            for value in values:
+                value = value.strip()
+                if not value:
+                    continue
+                convertedValue = _convertTextToType(value.strip(), None, desiredType)
+                if convertedValue is None:
+                    continue
+                convertedValues.append(convertedValue)
+            return convertedValues
+    except:
+        pass
+    return defaultValue

--- a/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
@@ -65,7 +65,7 @@ def _convertValueToText(value):
     # comma-separated values, while floating-point used space-separated values.
     if isinstance(value,list):
         # Note: empty list must create empty text.
-        if not len(value):
+        if not value:
             return ''
         if isinstance(value[0], str):
             sep = ','

--- a/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
@@ -116,18 +116,20 @@ def _convertTextToType(valueToConvert, defaultValue, desiredType=None):
         desiredType = type(defaultValue)
     if isinstance(valueToConvert, desiredType):
         return valueToConvert
-    # Try to convert the value to the desired value.
+    # Try to convert the value to the desired type.
     # We only support a subset of types to avoid problems,
     # for example trying to convert text to a list would
     # create a list of single letters.
-    #
-    # Use the default value if the data is somehow corrupted,
-    # for example from corrupted user prefs.
     try:
-        types = [str, int, float, bool]
-        for t in types:
-            if isinstance(defaultValue, t):
-                return t(valueToConvert)
+        textConvertibleTypes = [str, int, float]
+        if desiredType in textConvertibleTypes:
+            return desiredType(valueToConvert)
+        elif desiredType == bool:
+            if valueToConvert.lower() == 'true':
+                return True
+            if valueToConvert.lower() == 'false':
+                return False
+            return bool(int(valueToConvert))
     except:
         pass
 
@@ -154,4 +156,7 @@ def _convertTextToType(valueToConvert, defaultValue, desiredType=None):
             return convertedValues
     except:
         pass
+
+    # Use the default value if the data is somehow corrupted,
+    # for example from corrupted user prefs.
     return defaultValue

--- a/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
@@ -16,6 +16,21 @@
 
 import maya.cmds as cmds
 
+import mayaUsd
+
+import re
+
+def setAnimateOption(nodeName, textOptions):
+    """
+    Adjusts the export options to fill the animate value based on the node or subnode being animated.
+    """
+    animated = int(mayaUsd.lib.PrimUpdaterManager.isAnimated(nodeName))
+    animateOption = 'animation={animated}'.format(animated=animated)
+    if 'animation=' in textOptions:
+        return re.sub(r'animation=[^;]+', animateOption, textOptions)
+    else:
+        return textOptions + ';' + animateOption
+
 
 def getOptionsText(varName, defaultOptions):
     """
@@ -57,6 +72,8 @@ def _convertValueToText(value):
         else:
             sep = ' '
         return sep.join([_convertValueToText(v) for v in value])
+    elif isinstance(value,bool):
+        return str(int(value))
     else:
         return str(value)
 

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -1886,6 +1886,10 @@ VtValue _ParseArgumentValue(const std::string& value, const VtValue& guideValue)
     // The export UI only has boolean and string parameters.
     if (guideValue.IsHolding<bool>()) {
         return VtValue(TfUnstringify<bool>(value));
+    } else if (guideValue.IsHolding<double>()) {
+        return VtValue(TfUnstringify<double>(value));
+    } else if (guideValue.IsHolding<int>()) {
+        return VtValue(TfUnstringify<int>(value));
     } else if (guideValue.IsHolding<std::string>()) {
         return VtValue(value);
     } else if (guideValue.IsHolding<std::vector<VtValue>>()) {

--- a/plugin/adsk/plugin/exportTranslator.cpp
+++ b/plugin/adsk/plugin/exportTranslator.cpp
@@ -66,12 +66,14 @@ MStatus UsdMayaExportTranslator::writer(
         return MS::kSuccess;
     }
 
-    VtDictionary        userArgs;
-    std::vector<double> timeSamples;
-    MStatus             status = UsdMayaJobExportArgs::GetDictionaryFromEncodedOptions(
-        optionsString, &userArgs, &timeSamples);
+    VtDictionary userArgs;
+    MStatus      status
+        = UsdMayaJobExportArgs::GetDictionaryFromEncodedOptions(optionsString, &userArgs);
     if (status != MS::kSuccess)
         return status;
+
+    std::vector<double> timeSamples;
+    UsdMayaJobExportArgs::GetDictionaryTimeSamples(userArgs, timeSamples);
 
     auto jobArgs = UsdMayaJobExportArgs::CreateFromDictionary(userArgs, dagPaths, timeSamples);
     bool append = false;

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -621,7 +621,7 @@ global proc mayaUsdMenu_pushBackToUSD(string $obj)
         }
     }
     if (size($obj)) {
-        string $exportOptions = `python("import mayaUsdMergeToUSDOptions; mayaUsdMergeToUSDOptions.getMergeToUSDOptionsText()")`;
+        string $exportOptions = `python("import mayaUsdMergeToUSDOptions; import mayaUsdOptions; mayaUsdOptions.setAnimateOption('''" + $obj + "''', mayaUsdMergeToUSDOptions.getMergeToUSDOptionsText())")`;
         mayaUsdMergeToUsd -exportOptions $exportOptions $obj;
     }
 }

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -714,6 +714,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
 
         // Set visibility for anim widgets
         mayaUsdTranslatorExport_AnimationCB();
+        mayaUsdTranslatorExport_AnimationRangeCB();
 
         $bResult = 1;
     }

--- a/plugin/pxr/maya/lib/usdMaya/exportTranslator.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/exportTranslator.cpp
@@ -67,12 +67,14 @@ MStatus UsdMayaExportTranslator::writer(
         return MS::kSuccess;
     }
 
-    VtDictionary        userArgs;
-    std::vector<double> timeSamples;
-    MStatus             status = UsdMayaJobExportArgs::GetDictionaryFromEncodedOptions(
-        optionsString, &userArgs, &timeSamples);
+    VtDictionary userArgs;
+    MStatus      status
+        = UsdMayaJobExportArgs::GetDictionaryFromEncodedOptions(optionsString, &userArgs);
     if (status != MS::kSuccess)
         return status;
+
+    std::vector<double> timeSamples;
+    UsdMayaJobExportArgs::GetDictionaryTimeSamples(userArgs, timeSamples);
 
     auto jobArgs = UsdMayaJobExportArgs::CreateFromDictionary(userArgs, dagPaths, timeSamples);
     bool append = false;

--- a/test/lib/mayaUsd/fileio/CMakeLists.txt
+++ b/test/lib/mayaUsd/fileio/CMakeLists.txt
@@ -24,6 +24,7 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
         testDuplicateAs.py
         testPrimUpdater.py
         testCacheToUsd.py
+        testMayaUsdOptions.py
     )
 endif()
 

--- a/test/lib/mayaUsd/fileio/testCustomRig.py
+++ b/test/lib/mayaUsd/fileio/testCustomRig.py
@@ -210,6 +210,75 @@ class testCustomRig(unittest.TestCase):
         self.assertEqual(attr.GetNumTimeSamples(), 11)
         self.assertEqual(attr.GetTimeSamples(), [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
 
+    def testCustomRigUpdaterSubsetAnim(self):
+        "Validate prim updater for CustomRig codeless schema but with only a subset of frames"
+        
+        import mayaUsd_createStageWithNewLayer
+        proxyShape = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        
+        stage = mayaUsdUfe.getStage(proxyShape)
+        self.assertTrue(stage)
+        
+        layer = stage.GetRootLayer()
+        layer.ImportFromString(
+        ''' #sdf 1
+            (
+                defaultPrim = "world"
+            )
+            def Xform "world" {
+                def Xform "anim" {
+                    def CustomRig "bob" {
+                        int cubes = 2
+                    }
+                }
+            }
+        '''
+        )
+        
+        bobUfePathStr = "{},/world/anim/bob".format(proxyShape)
+        
+        # Pull the object for editing in Maya
+        self.assertTrue(mayaUsdLib.PrimUpdaterManager.editAsMaya(bobUfePathStr))
+        
+        # Retrieve pulled object
+        bobMayaPathStr = cmds.ls(sl=True)[0]
+        
+        # Test partial paths to make the test more robust with any changes around "invisible" __mayaUsd__
+        # parent
+        self.assertTrue(self._GetMFnDagNode("bob|pCube1"))
+        self.assertTrue(self._GetMFnDagNode("bob|pCube2"))
+        
+        # Animate the cubes
+        cmds.playbackOptions( minTime=0, maxTime=10 )
+        cmds.setKeyframe( "bob|pCube1.ry", time=1.0, value=0 )
+        cmds.setKeyframe( "bob|pCube1.ry", time=10.0, value=100 )
+        cmds.setKeyframe( "bob|pCube2.ty", time=1.0, value=0 )
+        cmds.setKeyframe( "bob|pCube2.ty", time=10.0, value=10 )
+        
+        # Push the animation back to USD. This will use a custom logic that will write it to a new prim
+        userArgs = {
+            'animation': True,
+            'startTime': 0.,
+            'endTime': 9.0,
+            'frameStride': 2.0,
+        }
+        self.assertTrue(mayaUsdLib.PrimUpdaterManager.mergeToUsd(bobMayaPathStr, userArgs))
+        
+        # After push, all Maya objects should be gone
+        self.assertFalse(self._GetMFnDagNode("bob"))
+        self.assertFalse(self._GetMFnDagNode("bob|pCube1"))
+        self.assertFalse(self._GetMFnDagNode("bob|pCube2"))
+        
+        # Validate the data we pushed back via custom updater
+        self.assertTrue(stage.GetPrimAtPath("/world/anim/bob_cache"))
+        self.assertTrue(stage.GetPrimAtPath("/world/anim/bob_cache/pCube1"))
+        self.assertTrue(stage.GetPrimAtPath("/world/anim/bob_cache/pCube2"))
+        
+        prim = stage.GetPrimAtPath("/world/anim/bob_cache/pCube2")
+        attr = prim.GetAttribute("xformOp:translate")
+        self.assertEqual(attr.GetNumTimeSamples(), 5)
+        self.assertEqual(attr.GetTimeSamples(), [0.0, 2.0, 4.0, 6.0, 8.0])
+
     def testCustomRigUpdaterAutoEditLoad(self):
         "Validate auto edit on stage load for CustomRig codeless schema"
         

--- a/test/lib/mayaUsd/fileio/testMayaUsdOptions.py
+++ b/test/lib/mayaUsd/fileio/testMayaUsdOptions.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mayaUsdOptions
+import unittest
+
+from testUtils import assertVectorAlmostEqual, getTestScene
+
+import os
+
+class testMayaUsdOptions(unittest.TestCase):
+    '''
+    Test mayaUsdOptions helper functions.
+    '''
+
+    def assertTextContains(self, text, expectedParts):
+        '''
+        Verify if the expected text parts are in the text as column-separated items.
+        '''
+        parts = text.split(';')
+        for expected in expectedParts:
+            self.assertTrue(expected in parts)
+
+    def testconvertOptionsDictToText(self):
+        '''
+        Test Conversion of options dictionary to text.
+        '''
+
+        simpleDict = {
+            'integer': 1,
+            'float': 0.1,
+            'text': 'hello',
+            'truth': True,
+            'lies': False,
+        }
+
+        simpleText = mayaUsdOptions.convertOptionsDictToText(simpleDict)
+        self.assertTextContains(simpleText, ['integer=1', 'float=0.1', 'text=hello', 'truth=1', 'lies=0'])
+
+        compositeDict = {
+            'floats': [1.0, 2.0],
+            'texts': ['hello', 'goodbye'],
+            'empty': [],
+        }
+
+        compositeText = mayaUsdOptions.convertOptionsDictToText(compositeDict)
+        self.assertTextContains(compositeText, ['floats=1.0 2.0', 'texts=hello,goodbye', 'empty='])
+
+    def convertOptionsTextToDict(self):
+        '''
+        Test Conversion of options text to dictionary.
+        '''
+
+        defaultDict = {
+            'integer': 1,
+            'float': 1.,
+            'text': '',
+            'truth': bool,
+            'lies': bool,
+            'floats': [],
+            'texts': [],
+            'empty': [],
+        }
+
+        simpleText = ';'.join(['integer=1', 'float=0.1', 'text=hello', 'truth=1', 'lies=0'])
+        simpleDict = mayaUsdOptions.convertOptionsTextToDict(simpleText, defaultDict)
+        self.assertEqual(simpleDict, {
+            'integer': 1,
+            'float': 0.1,
+            'text': 'hello',
+            'truth': True,
+            'lies': False,
+        })
+
+        compositeText = ';'.join(['floats=1.0 2.0   0.0', 'texts=hello, goodbye', 'empty='])
+
+
+        compositeDict = mayaUsdOptions.convertOptionsTextToDict(compositeText, defaultDict)
+        self.assertEqual(compositeDict, {
+            'floats': [1.0, 2.0],
+            'texts': ['hello', 'goodbye'],
+            'empty': [],
+        })
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/mayaUsd/fileio/testMayaUsdOptions.py
+++ b/test/lib/mayaUsd/fileio/testMayaUsdOptions.py
@@ -61,23 +61,22 @@ class testMayaUsdOptions(unittest.TestCase):
         compositeText = mayaUsdOptions.convertOptionsDictToText(compositeDict)
         self.assertTextContains(compositeText, ['floats=1.0 2.0', 'texts=hello,goodbye', 'empty='])
 
-    def convertOptionsTextToDict(self):
+    def testConvertOptionsTextToDict(self):
         '''
         Test Conversion of options text to dictionary.
         '''
 
         defaultDict = {
-            'integer': 1,
-            'float': 1.,
+            'integer': 22,
+            'float': 33.,
             'text': '',
-            'truth': bool,
-            'lies': bool,
-            'floats': [],
-            'texts': [],
-            'empty': [],
+            'truth': True,
+            'lies': True,
+            'truth2': True,
+            'lies2': True,
         }
 
-        simpleText = ';'.join(['integer=1', 'float=0.1', 'text=hello', 'truth=1', 'lies=0'])
+        simpleText = ';'.join(['integer=1', 'float=0.1', 'text=hello', 'truth=1', 'lies=0', 'truth2=True', 'lies2=False'])
         simpleDict = mayaUsdOptions.convertOptionsTextToDict(simpleText, defaultDict)
         self.assertEqual(simpleDict, {
             'integer': 1,
@@ -85,16 +84,24 @@ class testMayaUsdOptions(unittest.TestCase):
             'text': 'hello',
             'truth': True,
             'lies': False,
+            'truth2': True,
+            'lies2': False,
         })
 
+        defaultDict = {
+            'floats': [1.],
+            'texts': [],
+            'empty': [],
+            'use_default': 'default',
+        }
+
         compositeText = ';'.join(['floats=1.0 2.0   0.0', 'texts=hello, goodbye', 'empty='])
-
-
         compositeDict = mayaUsdOptions.convertOptionsTextToDict(compositeText, defaultDict)
         self.assertEqual(compositeDict, {
-            'floats': [1.0, 2.0],
+            'floats': [1.0, 2.0, 0.0],
             'texts': ['hello', 'goodbye'],
             'empty': [],
+            'use_default': 'default',
         })
 
 


### PR DESCRIPTION
- Add animation, startTime, endTime, frameStride and frameSample to the users args dictionary.
- This allows passing these user options to merge-to-USD and cache-to-USD.
- Split translating text-format to a dictionary from extracting the time sample range.
- This allows passing only a dictionary for all user options instead of having additional separate options for the time samples.
- Adapt users of JobArgs to use the new pure-dictionary internal API.
- In particular, mergeToUsd and duplicate now use these dictionary options.
- Add animation data check-box in cache-to-USD options UI.
- Add animation data check-box in merge-to-USD options UI.
- Improve the text to dict conversion in Python to respect the historical format for options containing list of items.
- In particular, some use comma-separated values, others space-separated values.
- Add support for floating-point and integer values when parsing values when converting from text to VtDictionary in C++.
- Expose the isAnimated C++ function to Python.
- No longer always force the animation option on.
- Conditionally set it on if an object is animated.
- Properly handle the case where the animation option is set to more than 1 character when changing it.
- Prefill the animation range UI.