### PR TITLE
MAYA-121937 - Renaming 2 prims w/illegal chars will crash Maya

### DIFF
--- a/lib/mayaUsd/resources/scripts/mayaUsdAddMayaReference.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdAddMayaReference.py
@@ -107,13 +107,14 @@ def createMayaReferencePrim(ufePathStr, mayaReferencePath, mayaNamespace,
             # and validate the input name.
             # Note: it is allowed to be input as empty in which case a default is used.
             if groupPrimName:
+                groupPrimName = Tf.MakeValidIdentifier(groupPrimName)
                 checkGroupPrimName = mayaUsd.ufe.uniqueChildName(parentPrim, groupPrimName)
                 if checkGroupPrimName != groupPrimName:
                     errorMsgFormat = getMayaUsdLibString('kErrorGroupPrimExists')
                     errorMsg = cmds.format(errorMsgFormat, stringArg=(groupPrimName, ufePathStr))
                     om.MGlobal.displayError(errorMsg)
                     return Usd.Prim()
-                groupPrimName = Tf.MakeValidIdentifier(checkGroupPrimName)
+                groupPrimName = checkGroupPrimName
 
         # If the group prim was either not provided or empty we use a default name.
         if not groupPrimName:
@@ -130,13 +131,14 @@ def createMayaReferencePrim(ufePathStr, mayaReferencePath, mayaNamespace,
     # Note: if we are given a group prim to create, then we know that the
     #       Maya Reference prim name will be unique since it will be the
     #       only child (of the newly created group prim).
+    mayaReferencePrimName = Tf.MakeValidIdentifier(mayaReferencePrimName)
     checkName = mayaUsd.ufe.uniqueChildName(parentPrim, mayaReferencePrimName) if groupPrim is None else mayaReferencePrimName
     if checkName != mayaReferencePrimName:
         errorMsgFormat = getMayaUsdLibString('kErrorMayaRefPrimExists')
         errorMsg = cmds.format(errorMsgFormat, stringArg=(mayaReferencePrimName, ufePathStr))
         om.MGlobal.displayError(errorMsg)
         return Usd.Prim()
-    validatedPrimName = Tf.MakeValidIdentifier(checkName)
+    validatedPrimName = checkName
 
     # Extract the USD path segment from the UFE path and append the Maya
     # reference prim to it.

--- a/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
@@ -74,7 +74,7 @@ UsdUndoRenameCommand::UsdUndoRenameCommand(
     ufe::applyCommandRestriction(prim, "rename");
 
     // handle unique name for _newName
-    _newName = TfMakeValidIdentifier(uniqueChildName(prim.GetParent(), newName.string()));
+    _newName = uniqueChildName(prim.GetParent(), TfMakeValidIdentifier(newName.string()));
 }
 
 UsdUndoRenameCommand::~UsdUndoRenameCommand() { }

--- a/test/lib/ufe/testRename.py
+++ b/test/lib/ufe/testRename.py
@@ -522,6 +522,23 @@ class RenameTestCase(unittest.TestCase):
         newValidName = Tf.MakeValidIdentifier(newNameStartingWithDigit)
         self.assertEqual(usdPrim.GetName(), newValidName)
 
+        # [GitHub #2150] renaming 2 usd items with illegal characters will cause Maya to crash
+        cmds.file(new=True, force=True)
+        import mayaUsd_createStageWithNewLayer
+        psPathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        stage = mayaUsd.lib.GetPrim(psPathStr).GetStage()
+        x1 = stage.DefinePrim('/Xform1', 'Xform')
+        x2 = stage.DefinePrim('/Xform2', 'Xform')
+        cmds.select('|stage1|stageShape1,/Xform1', replace=True)
+        cmds.rename('test.') # Rename first object with illegal name
+        cmds.select('|stage1|stageShape1,/Xform2', replace=True)
+        cmds.rename('test.') # Rename second object with same illegal name
+
+        # Make sure they got renamed as we expect.
+        cmds.select('|stage1|stageShape1,/test_', '|stage1|stageShape1,/test_1', replace=True)
+        sel = ufe.GlobalSelection.get()
+        self.assertEqual(2, len(sel))
+
     def testRenameNotifications(self):
         '''Rename a USD node and test for the UFE notifications.'''
 


### PR DESCRIPTION
MAYA-121937 - Renaming 2 usd items with illegal characters will cause Maya to crash
* Validate the name before making it unique.