### PR TITLE
MAYA-107839 [GitHub 800] USD: exporting the attached maya file using …

### DIFF
--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -120,6 +120,8 @@ bool UsdMayaWriteJobContext::IsMergedTransform(const MDagPath& path) const
 
     // Any transform with multiple (non-intermediate) shapes below is
     // non-mergeable.
+    // Expanded out the implementation of MDagPath::numberOfShapesDirectlyBelow() to cut down
+    // the time by half.
     unsigned int numShapes = 0;
     const auto   childCount = path.childCount();
     for (auto child = decltype(childCount) { 0 }; child < childCount; ++child) {

--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -120,9 +120,21 @@ bool UsdMayaWriteJobContext::IsMergedTransform(const MDagPath& path) const
 
     // Any transform with multiple (non-intermediate) shapes below is
     // non-mergeable.
-    unsigned int numberOfShapesDirectlyBelow = 0u;
-    path.numberOfShapesDirectlyBelow(numberOfShapesDirectlyBelow);
-    if (numberOfShapesDirectlyBelow != 1) {
+    unsigned int numShapes = 0;
+    const auto childCount = path.childCount();
+    for (auto child = decltype(childCount) { 0 }; child < childCount; ++child) {
+        const auto dagObj = path.child(child);
+        MFnDagNode dagNode(dagObj);
+        if (dagNode.isIntermediateObject() || dagNode.isIntermediateObject()) {
+            continue;
+        }
+        if (dagObj.hasFn(MFn::kShape)) {
+            numShapes++;
+            if (numShapes > 1)
+                return false;
+        }
+    }
+    if (numShapes != 1) {
         return false;
     }
 
@@ -132,7 +144,6 @@ bool UsdMayaWriteJobContext::IsMergedTransform(const MDagPath& path) const
     // For efficiency reasons, since (# exportable children <= # children),
     // check the total child count first before checking whether they're
     // exportable.
-    const unsigned int childCount = path.childCount();
     if (childCount != 1) {
         MDagPath     childDag(path);
         unsigned int numExportableChildren = 0u;

--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -121,7 +121,7 @@ bool UsdMayaWriteJobContext::IsMergedTransform(const MDagPath& path) const
     // Any transform with multiple (non-intermediate) shapes below is
     // non-mergeable.
     unsigned int numShapes = 0;
-    const auto childCount = path.childCount();
+    const auto   childCount = path.childCount();
     for (auto child = decltype(childCount) { 0 }; child < childCount; ++child) {
         const auto dagObj = path.child(child);
         MFnDagNode dagNode(dagObj);


### PR DESCRIPTION
…USD takes extremely long

I was able to cut in half the time to export going from about 10 min. to 5 min with an improved algorithm for shapes below dagpath.
The next bottleneck is here with 87% of the time spent: https://github.com/Autodesk/maya-usd/blob/dev/lib/usd/translators/nurbsCurveWriter.cpp#L61