### PR TITLE
MAYA-121277 Create usdGeomNode to extract usd geometry

### DIFF
--- a/lib/mayaUsd/fileio/jobs/CMakeLists.txt
+++ b/lib/mayaUsd/fileio/jobs/CMakeLists.txt
@@ -4,6 +4,7 @@
 target_sources(${PROJECT_NAME} 
     PRIVATE
         jobArgs.cpp
+        meshDataReadJob.cpp
         modelKindProcessor.cpp
         readJob.cpp
         writeJob.cpp
@@ -11,6 +12,7 @@ target_sources(${PROJECT_NAME}
 
 set(HEADERS
     jobArgs.h
+    meshDataReadJob.h
     modelKindProcessor.h
     readJob.h
     writeJob.h

--- a/lib/mayaUsd/fileio/jobs/meshDataReadJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/meshDataReadJob.cpp
@@ -106,7 +106,7 @@ bool UsdMaya_MeshDataReadJob::OverridePrimReader(
     MStatus status = MS::kSuccess;
 
     const UsdPrim& primMesh = args.GetUsdPrim();
-    UsdGeomMesh mesh(primMesh);
+    UsdGeomMesh    mesh(primMesh);
 
     if (!mesh) {
         // Skip non mesh objects

--- a/lib/mayaUsd/fileio/jobs/meshDataReadJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/meshDataReadJob.cpp
@@ -1,0 +1,158 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "meshDataReadJob.h"
+
+#include <mayaUsd/fileio/translators/translatorMesh.h>
+#include <mayaUsd/fileio/utils/meshReadUtils.h>
+
+#include <pxr/base/gf/matrix4d.h>
+#include <pxr/usd/usdGeom/xformable.h>
+
+#include <maya/MFnMatrixData.h>
+#include <maya/MFnMeshData.h>
+#include <maya/MMatrix.h>
+#include <maya/MObject.h>
+
+using namespace MAYAUSD_NS_DEF;
+
+namespace {
+void convertMatrix(const GfMatrix4d& inMatrix, MMatrix& outMatrix, MObject& outMatrixObj)
+{
+    double usdLocalTransformData[4u][4u];
+    inMatrix.Get(usdLocalTransformData);
+
+    outMatrix = MMatrix(usdLocalTransformData);
+
+    MFnMatrixData matrixData;
+    outMatrixObj = matrixData.create();
+    matrixData.set(outMatrix);
+}
+
+GfMatrix4d getTransform(const UsdPrim& prim, const std::map<SdfPath, GfMatrix4d>& parentTransforms)
+{
+    auto transformable = UsdGeomXformable(prim);
+
+    GfMatrix4d usdTransform(1.0);
+    if (transformable) {
+        bool reset = false;
+        transformable.GetLocalTransformation(&usdTransform, &reset);
+    }
+
+    SdfPath parentPath = prim.GetPath().GetParentPath();
+    while (parentPath != SdfPath::AbsoluteRootPath()) {
+        auto found = parentTransforms.find(parentPath);
+
+        if (found != parentTransforms.end()) {
+            usdTransform *= found->second;
+        }
+
+        parentPath = parentPath.GetParentPath();
+    }
+
+    return usdTransform;
+}
+
+void getComponentTags(MFnMeshData& dataCreator, const UsdGeomMesh& mesh)
+{
+#if MAYA_API_VERSION >= 20220000
+
+    std::vector<UsdMayaMeshReadUtils::ComponentTagData> componentTags;
+    UsdMayaMeshReadUtils::getComponentTags(mesh, componentTags);
+
+    for (auto& tag : componentTags) {
+        auto& name = tag.first;
+        auto& content = tag.second;
+
+        if (!dataCreator.hasComponentTag(name)) {
+            dataCreator.addComponentTag(name);
+        }
+
+        dataCreator.setComponentTagContents(name, content);
+    }
+
+#endif
+}
+} // namespace
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+UsdMaya_MeshDataReadJob::UsdMaya_MeshDataReadJob(
+    const MayaUsd::ImportData&  iImportData,
+    const UsdMayaJobImportArgs& iArgs)
+    : UsdMaya_ReadJob(iImportData, iArgs)
+{
+}
+
+bool UsdMaya_MeshDataReadJob::OverridePrimReader(
+    const UsdPrim&               usdRootPrim,
+    const UsdPrim&               prim,
+    const UsdMayaPrimReaderArgs& args,
+    UsdMayaPrimReaderContext&    readCtx,
+    UsdPrimRange::iterator&      primIt)
+{
+    MStatus status = MS::kSuccess;
+
+    const UsdPrim& primMesh = args.GetUsdPrim();
+    UsdGeomMesh mesh(primMesh);
+
+    if (!mesh) {
+        // Skip non mesh objects
+        return true;
+    }
+
+    GfMatrix4d usdTransform = getTransform(prim, mTransforms);
+    mTransforms[prim.GetPath()] = usdTransform;
+
+    // Create an object of type MMeshData and use that as the parent in the
+    // translator so that MFnMesh creates mesh data without a node.
+    MFnMeshData dataCreator;
+    MObject     meshData = dataCreator.create(&status);
+    CHECK_MSTATUS_AND_RETURN(status, true);
+
+    MObject stageNode;
+
+    // Usd mesh translator to get mesh data from prim.
+    MayaUsd::TranslatorMeshRead meshRead(
+        mesh,
+        prim,
+        meshData,
+        stageNode,
+        args.GetTimeInterval(),
+        args.GetUseAsAnimationCache(),
+        &readCtx,
+        &status);
+    CHECK_MSTATUS_AND_RETURN(status, true);
+
+    mMeshData.emplace_back();
+    auto& newData = mMeshData.back();
+
+    // Get the mesh transformation matrix.
+    MMatrix matrix;
+    convertMatrix(usdTransform, matrix, newData.matrix);
+
+    // Set the matrix on the mesh object.
+    dataCreator.setMatrix(matrix);
+
+    // Get the mesh geometry.
+    newData.geometry = meshData;
+
+    // Get the mesh component tags.
+    getComponentTags(dataCreator, mesh);
+
+    return true;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/jobs/meshDataReadJob.h
+++ b/lib/mayaUsd/fileio/jobs/meshDataReadJob.h
@@ -1,0 +1,62 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef PXRUSDMAYA_MESHDATAREAD_JOB_H
+#define PXRUSDMAYA_MESHDATAREAD_JOB_H
+
+#include <mayaUsd/fileio/jobs/readJob.h>
+
+#include <maya/MObject.h>
+
+#include <vector>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+// Custom class to prevent read job from creating new nodes and to access
+// geometric data directly.
+class UsdMaya_MeshDataReadJob : public UsdMaya_ReadJob
+{
+public:
+    MAYAUSD_CORE_PUBLIC
+    UsdMaya_MeshDataReadJob(
+        const MayaUsd::ImportData&  iImportData,
+        const UsdMayaJobImportArgs& iArgs);
+
+protected:
+    // Override prim reader to create a mesh without a node and to store
+    // the mesh then access it and return it in the plug.
+    bool OverridePrimReader(
+        const UsdPrim&               usdRootPrim,
+        const UsdPrim&               prim,
+        const UsdMayaPrimReaderArgs& args,
+        UsdMayaPrimReaderContext&    readCtx,
+        UsdPrimRange::iterator&      primIt) override;
+
+public:
+    struct Data
+    {
+        MObject geometry;
+        MObject matrix;
+    };
+
+    std::vector<Data> mMeshData;
+
+private:
+    std::map<SdfPath, GfMatrix4d> mTransforms;
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/lib/mayaUsd/fileio/translators/translatorMesh.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMesh.cpp
@@ -198,11 +198,15 @@ TranslatorMeshRead::TranslatorMeshRead(
     // set mesh name
     const auto& primName = prim.GetName().GetString();
     const auto  shapeName = TfStringPrintf("%sShape", primName.c_str());
-    meshFn.setName(MString(shapeName.c_str()), false, &stat);
 
-    if (!stat) {
-        *status = stat;
-        return;
+    // Set the mesh name if creating a maya mesh object
+    if (transformObj.isNull() || MFn::kMeshData != transformObj.apiType()) {
+        meshFn.setName(MString(shapeName.c_str()), false, &stat);
+
+        if (!stat) {
+            *status = stat;
+            return;
+        }
     }
 
     // store the path

--- a/lib/mayaUsd/fileio/utils/meshReadUtils.h
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.h
@@ -33,6 +33,9 @@
 #include <maya/MObject.h>
 #include <maya/MString.h>
 
+#include <utility>
+#include <vector>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 class UsdGeomMesh;
@@ -78,6 +81,12 @@ MStatus assignSubDivTagsToMesh(const UsdGeomMesh&, MObject&, MFnMesh&);
 
 MAYAUSD_CORE_PUBLIC
 MStatus createComponentTags(const UsdGeomMesh& mesh, const MObject& meshObj);
+
+// Pair of component tag name and data.
+using ComponentTagData = std::pair<MString, MObject>;
+
+MAYAUSD_CORE_PUBLIC
+MStatus getComponentTags(const UsdGeomMesh& mesh, std::vector<ComponentTagData>& tags);
 
 #endif
 

--- a/plugin/adsk/plugin/CMakeLists.txt
+++ b/plugin/adsk/plugin/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${TARGET_NAME}
         adskListJobContextsCommand.cpp
         adskListShadingModesCommand.cpp
         adskStageLoadUnloadCommands.cpp
+        geomNode.cpp
         importTranslator.cpp
         exportTranslator.cpp
         ProxyShape.cpp

--- a/plugin/adsk/plugin/geomNode.cpp
+++ b/plugin/adsk/plugin/geomNode.cpp
@@ -1,0 +1,236 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "geomNode.h"
+
+#include <mayaUsd/fileio/jobs/meshDataReadJob.h>
+#include <mayaUsd/fileio/jobs/readJob.h>
+#include <mayaUsd/fileio/utils/meshReadUtils.h>
+#include <mayaUsd/utils/util.h>
+
+#include <pxr/usd/usdGeom/mesh.h>
+
+#include <maya/MArrayDataBuilder.h>
+#include <maya/MArrayDataHandle.h>
+#include <maya/MFnCompoundAttribute.h>
+#include <maya/MFnStringData.h>
+#include <maya/MFnTypedAttribute.h>
+#include <maya/MObject.h>
+
+namespace MAYAUSD_NS_DEF {
+// ========================================================
+
+const MTypeId MAYAUSD_GEOMNODE_ID(0x58000099);
+
+const MTypeId MayaUsdGeomNode::typeId(MayaUsd::MAYAUSD_GEOMNODE_ID);
+const MString MayaUsdGeomNode::typeName("mayaUsdGeomNode");
+
+// Attributes
+MObject MayaUsdGeomNode::filePathAttr;
+MObject MayaUsdGeomNode::rootPrimAttr;
+
+// Output attributes
+MObject MayaUsdGeomNode::outGeomAttr;
+MObject MayaUsdGeomNode::outGeomMatrixAttr;
+
+namespace {
+class OutputArrayHandler
+{
+public:
+    OutputArrayHandler(MDataBlock& dataBlock, const MObject& attribute, int size, MStatus& retValue)
+        : mArrayDataHandle(dataBlock.outputValue(attribute, &retValue))
+        , mBuilder(&dataBlock, attribute, size)
+    {
+    }
+
+    template <typename T> void add(const T& item)
+    {
+        MDataHandle element = mBuilder.addLast();
+        element.set(item);
+    }
+
+    void finish() { mArrayDataHandle.set(mBuilder); }
+
+private:
+    MArrayDataHandle  mArrayDataHandle;
+    MArrayDataBuilder mBuilder;
+};
+} // namespace
+
+struct MayaUsdGeomNode::CacheData
+{
+    std::string                                loadedFile;
+    std::string                                rootPrim;
+    std::vector<UsdMaya_MeshDataReadJob::Data> primitives;
+};
+
+/* static */
+void* MayaUsdGeomNode::creator() { return new MayaUsdGeomNode(); }
+
+/* static */
+MStatus MayaUsdGeomNode::initialize()
+{
+    MStatus retValue = MS::kSuccess;
+
+    MFnTypedAttribute    typedAttrFn;
+    MFnCompoundAttribute compAttrFn;
+
+    // Inputs
+    filePathAttr
+        = typedAttrFn.create("filePath", "fp", MFnData::kString, MObject::kNullObj, &retValue);
+    typedAttrFn.setWritable(true);
+    typedAttrFn.setReadable(false);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+    retValue = addAttribute(filePathAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+    rootPrimAttr
+        = typedAttrFn.create("rootPrim", "rp", MFnData::kString, MObject::kNullObj, &retValue);
+    typedAttrFn.setWritable(true);
+    typedAttrFn.setReadable(false);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+    retValue = addAttribute(rootPrimAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+    // Outputs
+    outGeomAttr
+        = typedAttrFn.create("geometry", "geo", MFnData::kMesh, MObject::kNullObj, &retValue);
+    typedAttrFn.setWritable(false);
+    typedAttrFn.setReadable(true);
+    typedAttrFn.setStorable(true);
+    typedAttrFn.setArray(true);
+    typedAttrFn.setUsesArrayDataBuilder(true);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+    retValue = addAttribute(outGeomAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+    outGeomMatrixAttr
+        = typedAttrFn.create("matrix", "tra", MFnData::kMatrix, MObject::kNullObj, &retValue);
+    typedAttrFn.setWritable(false);
+    typedAttrFn.setReadable(true);
+    typedAttrFn.setStorable(true);
+    typedAttrFn.setArray(true);
+    typedAttrFn.setUsesArrayDataBuilder(true);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+    retValue = addAttribute(outGeomMatrixAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+    //
+    // add attribute dependencies
+    //
+    retValue = attributeAffects(filePathAttr, outGeomAttr);
+    retValue = attributeAffects(rootPrimAttr, outGeomAttr);
+    retValue = attributeAffects(filePathAttr, outGeomMatrixAttr);
+    retValue = attributeAffects(rootPrimAttr, outGeomMatrixAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+    return retValue;
+}
+
+MayaUsdGeomNode::MayaUsdGeomNode()
+    : MPxNode()
+    , _cache(std::make_unique<CacheData>())
+{
+    TfRegistryManager::GetInstance().SubscribeTo<MayaUsdGeomNode>();
+}
+
+/* virtual */
+MayaUsdGeomNode::~MayaUsdGeomNode() { }
+
+/* virtual */
+MStatus MayaUsdGeomNode::compute(const MPlug& plug, MDataBlock& dataBlock)
+{
+    MStatus retValue = MS::kSuccess;
+
+    if (plug == outGeomAttr || plug == outGeomMatrixAttr) {
+        MDataHandle filePathHandle = dataBlock.inputValue(filePathAttr, &retValue);
+        CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+        MDataHandle rootPrimHandle = dataBlock.inputValue(rootPrimAttr, &retValue);
+        CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+        const std::string fileName = TfStringTrim(filePathHandle.asString().asChar());
+        const std::string rootPrim = TfStringTrim(rootPrimHandle.asString().asChar());
+
+        if (!fileName.empty()) {
+            if (_cache->loadedFile.empty() || _cache->loadedFile != fileName
+                || _cache->rootPrim != rootPrim) {
+                MayaUsd::ImportData readData;
+                readData.setFilename(fileName);
+
+                if (!rootPrim.empty()) {
+                    // Set the root prim to import from
+                    readData.setRootPrimPath(rootPrim);
+                }
+
+                VtDictionary userArgs;
+                GfInterval   timeInterval;
+
+                UsdMayaJobImportArgs jobArgs = UsdMayaJobImportArgs::CreateFromDictionary(
+                    userArgs,
+                    /* importWithProxyShapes = */ false,
+                    timeInterval);
+
+                UsdMaya_MeshDataReadJob reader(readData, jobArgs);
+
+                std::vector<MDagPath> addedDagPaths;
+                reader.Read(&addedDagPaths);
+
+                _cache->primitives.swap(reader.mMeshData);
+                _cache->loadedFile = fileName;
+                _cache->rootPrim = rootPrim;
+            }
+
+            OutputArrayHandler geomOut(dataBlock, outGeomAttr, _cache->primitives.size(), retValue);
+            CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+            OutputArrayHandler matrixOut(
+                dataBlock, outGeomMatrixAttr, _cache->primitives.size(), retValue);
+            CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+            // MDataHandle outputGeomHandle = dataBlock.outputValue(outGeomAttr, &retValue);
+            // CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+            // MDataHandle outputMatrixHandle = dataBlock.outputValue(outGeomMatrixAttr, &retValue);
+            // CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+            // MArrayDataHandle geomDst(outputGeomHandle);
+            // MArrayDataHandle matrixDst(outputMatrixHandle);
+
+            // MArrayDataBuilder geomBuilder(&dataBlock, outGeomAttr, _cache->primitives.size());
+            // MArrayDataBuilder marixbuilder(&dataBlock, outGeomMatrixAttr,
+            // _cache->primitives.size());
+
+            for (auto& prim : _cache->primitives) {
+                geomOut.add(prim.geometry);
+                matrixOut.add(prim.matrix);
+                // MDataHandle geomElement = geomBuilder.addLast();
+                // geomElement.set(prim.geom);
+
+                // MDataHandle matrixElement = marixbuilder.addLast();
+                // matrixElement.set(prim.matrix);
+            }
+
+            geomOut.finish();
+            matrixOut.finish();
+            // geomDst.set(geomBuilder);
+            // geomDst.set(matrixDst);
+        }
+    }
+
+    return retValue;
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/plugin/adsk/plugin/geomNode.h
+++ b/plugin/adsk/plugin/geomNode.h
@@ -1,0 +1,74 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef PXRUSDMAYA_MAYAUSDGEOMNODE_H
+#define PXRUSDMAYA_MAYAUSDGEOMNODE_H
+
+#include "base/api.h"
+
+#include <mayaUsd/base/api.h>
+
+#include <maya/MObject.h>
+#include <maya/MPxNode.h>
+#include <maya/MStatus.h>
+
+#include <memory>
+#include <vector>
+
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace MAYAUSD_NS_DEF {
+class MayaUsdGeomNode : public MPxNode
+{
+public:
+    MAYAUSD_PLUGIN_PUBLIC
+    static const MTypeId typeId;
+    MAYAUSD_PLUGIN_PUBLIC
+    static const MString typeName;
+
+    // Attributes
+    MAYAUSD_PLUGIN_PUBLIC
+    static MObject filePathAttr;
+
+    MAYAUSD_PLUGIN_PUBLIC
+    static MObject rootPrimAttr;
+
+    // Output attributes
+    MAYAUSD_PLUGIN_PUBLIC
+    static MObject outGeomAttr;
+
+    MAYAUSD_PLUGIN_PUBLIC
+    static MObject outGeomMatrixAttr;
+
+    MAYAUSD_PLUGIN_PUBLIC
+    static void* creator();
+
+    MAYAUSD_PLUGIN_PUBLIC
+    static MStatus initialize();
+
+    MayaUsdGeomNode();
+    virtual ~MayaUsdGeomNode();
+
+    virtual MStatus compute(const MPlug&, MDataBlock&);
+
+private:
+    struct CacheData;
+    std::unique_ptr<CacheData> _cache;
+};
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -21,6 +21,7 @@
 #include "adskStageLoadUnloadCommands.h"
 #include "base/api.h"
 #include "exportTranslator.h"
+#include "geomNode.h"
 #include "importTranslator.h"
 
 #include <mayaUsd/base/api.h>
@@ -271,6 +272,13 @@ MStatus initializePlugin(MObject obj)
         MayaUsdProxyShapePlugin::getProxyShapeClassification());
     CHECK_MSTATUS(status);
 
+    status = plugin.registerNode(
+        MayaUsd::MayaUsdGeomNode::typeName,
+        MayaUsd::MayaUsdGeomNode::typeId,
+        MayaUsd::MayaUsdGeomNode::creator,
+        MayaUsd::MayaUsdGeomNode::initialize);
+    CHECK_MSTATUS(status);
+
     registerCommandCheck<MayaUsd::ADSKMayaUSDListJobContextsCommand>(plugin);
     registerCommandCheck<MayaUsd::ADSKMayaUSDListShadingModesCommand>(plugin);
 
@@ -405,6 +413,9 @@ MStatus uninitializePlugin(MObject obj)
 #endif
 
     status = plugin.deregisterNode(MayaUsd::ProxyShape::typeId);
+    CHECK_MSTATUS(status);
+
+    status = plugin.deregisterNode(MayaUsd::MayaUsdGeomNode::typeId);
     CHECK_MSTATUS(status);
 
     status = MayaUsdProxyShapePlugin::finalize(plugin);


### PR DESCRIPTION
This is part from a long term goal to simplify the maya mesh file by embedding 'usd' or other format directly in the scene.
The performance angle is to be able to load on demand the geometry, so if the node is not visible it would not even load the file immediatly. When this work we could have low res and high res version in the same Maya file without paying memory and load time cost for the high res, as long as the user work with the low res. But this pull request here simply add the possibility to prototype things further in maya.