### PR TITLE
MAYA-122014 support duplicate to Maya to non root

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -1108,10 +1108,10 @@ bool PrimUpdaterManager::duplicate(
         // to configure the updater
         ctxArgs[UsdMayaPrimUpdaterArgsTokens->copyOperation] = true;
 
-        // Set destination of duplicate. The Maya root MDagPath is not valid,
-        // so don't try to validate the path if it is the root.
+        // Set destination of duplicate. The Maya world MDagPath is not valid,
+        // so don't try to validate the path if it is the world root.
         MDagPath pullParentPath;
-        if (!MayaUsd::ufe::isMayaRootPath(dstPath)) {
+        if (!MayaUsd::ufe::isMayaWorldPath(dstPath)) {
             pullParentPath = MayaUsd::ufe::ufeToDagPath(dstPath);
             if (!pullParentPath.isValid()) {
                 return false;

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -1108,6 +1108,17 @@ bool PrimUpdaterManager::duplicate(
         // to configure the updater
         ctxArgs[UsdMayaPrimUpdaterArgsTokens->copyOperation] = true;
 
+        // Set destination of duplicate. The Maya root MDagPath is not valid,
+        // so don't try to validate the path if it is the root.
+        MDagPath pullParentPath;
+        if (!MayaUsd::ufe::isMayaRootPath(dstPath)) {
+            pullParentPath = MayaUsd::ufe::ufeToDagPath(dstPath);
+            if (!pullParentPath.isValid()) {
+                return false;
+            }
+        }
+        ctxArgs[kPullParentPathKey] = VtValue(std::string(pullParentPath.fullPathName().asChar()));
+
         UsdMayaPrimUpdaterContext context(
             srcProxyShape->getTime(), srcProxyShape->getUsdStage(), ctxArgs);
 

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -372,6 +372,21 @@ MDagPath ufeToDagPath(const Ufe::Path& ufePath)
     );
 }
 
+bool isMayaRootPath(const Ufe::Path& ufePath)
+{
+    if (ufePath.runTimeId() != g_MayaRtid)
+        return false;
+
+    const auto& segments = ufePath.getSegments();
+    if (segments.size() != 1)
+        return false;
+
+    if (segments[0].components().size() != 1)
+        return false;
+
+    return true;
+}
+
 PXR_NS::MayaUsdProxyShapeBase* getProxyShape(const Ufe::Path& path)
 {
     // Path should not be empty.

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -372,19 +372,9 @@ MDagPath ufeToDagPath(const Ufe::Path& ufePath)
     );
 }
 
-bool isMayaRootPath(const Ufe::Path& ufePath)
+bool isMayaWorldPath(const Ufe::Path& ufePath)
 {
-    if (ufePath.runTimeId() != g_MayaRtid)
-        return false;
-
-    const auto& segments = ufePath.getSegments();
-    if (segments.size() != 1)
-        return false;
-
-    if (segments[0].components().size() != 1)
-        return false;
-
-    return true;
+    return (ufePath.runTimeId() == g_MayaRtid && ufePath.size() == 1);
 }
 
 PXR_NS::MayaUsdProxyShapeBase* getProxyShape(const Ufe::Path& path)

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -125,9 +125,9 @@ Ufe::PathSegment dagPathToPathSegment(const MDagPath& dagPath);
 MAYAUSD_CORE_PUBLIC
 MDagPath ufeToDagPath(const Ufe::Path& ufePath);
 
-//! Verify if the UFE path is the Maya root.
+//! Verify if the UFE path is the Maya world (root) path.
 MAYAUSD_CORE_PUBLIC
-bool isMayaRootPath(const Ufe::Path& ufePath);
+bool isMayaWorldPath(const Ufe::Path& ufePath);
 
 //! Return the gateway node (i.e. proxy shape)
 MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -125,6 +125,10 @@ Ufe::PathSegment dagPathToPathSegment(const MDagPath& dagPath);
 MAYAUSD_CORE_PUBLIC
 MDagPath ufeToDagPath(const Ufe::Path& ufePath);
 
+//! Verify if the UFE path is the Maya root.
+MAYAUSD_CORE_PUBLIC
+bool isMayaRootPath(const Ufe::Path& ufePath);
+
 //! Return the gateway node (i.e. proxy shape)
 MAYAUSD_CORE_PUBLIC
 PXR_NS::MayaUsdProxyShapeBase* getProxyShape(const Ufe::Path& path);

--- a/test/lib/mayaUsd/fileio/testDuplicateAs.py
+++ b/test/lib/mayaUsd/fileio/testDuplicateAs.py
@@ -98,14 +98,14 @@ class DuplicateAsTestCase(unittest.TestCase):
         self.assertEqual(1, len(xformNames))
         xformName = xformNames[0]
 
-        # Duplicate USD data as Maya data, placing it under the root.
+        # Duplicate USD data as Maya data, placing it under the transform we created.
         with mayaUsd.lib.OpUndoItemList():
             self.assertTrue(mayaUsd.lib.PrimUpdaterManager.duplicate(
                 aUsdUfePathStr, '|world|'+ xformName))
 
         # Should now have two transform nodes in the Maya scene: the path
         # components in the second segment of the aUsdItem and bUsdItem will
-        # now be under the Maya world.
+        # now be under the transform.
         aMayaPathStr = '|' + xformName + str(aUsdUfePath.segments[1]).replace('/', '|')
         bMayaPathStr = '|' + xformName + str(bUsdUfePath.segments[1]).replace('/', '|')
         self.assertEqual(1, len(cmds.ls(aMayaPathStr, long=True)))

--- a/test/lib/mayaUsd/fileio/testDuplicateAs.py
+++ b/test/lib/mayaUsd/fileio/testDuplicateAs.py
@@ -86,6 +86,39 @@ class DuplicateAsTestCase(unittest.TestCase):
         self.assertEqual(cmds.getAttr(bMayaPathStr + '.translate')[0],
                          bXlation)
 
+    def testDuplicateAsNonRootMaya(self):
+        '''Duplicate a USD transform hierarchy to Maya.'''
+
+        (_, _, aXlation, aUsdUfePathStr, aUsdUfePath, _, _, 
+               bXlation, bUsdUfePathStr, bUsdUfePath, _) = \
+            createSimpleXformScene()
+
+        xform = cmds.createNode('transform')
+        xformNames = cmds.ls(xform)
+        self.assertEqual(1, len(xformNames))
+        xformName = xformNames[0]
+
+        # Duplicate USD data as Maya data, placing it under the root.
+        with mayaUsd.lib.OpUndoItemList():
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.duplicate(
+                aUsdUfePathStr, '|world|'+ xformName))
+
+        # Should now have two transform nodes in the Maya scene: the path
+        # components in the second segment of the aUsdItem and bUsdItem will
+        # now be under the Maya world.
+        aMayaPathStr = '|' + xformName + str(aUsdUfePath.segments[1]).replace('/', '|')
+        bMayaPathStr = '|' + xformName + str(bUsdUfePath.segments[1]).replace('/', '|')
+        self.assertEqual(1, len(cmds.ls(aMayaPathStr, long=True)))
+        self.assertEqual(1, len(cmds.ls(bMayaPathStr, long=True)))
+        self.assertEqual(cmds.ls(aMayaPathStr, long=True)[0], aMayaPathStr)
+        self.assertEqual(cmds.ls(bMayaPathStr, long=True)[0], bMayaPathStr)
+
+        # Translation should have been copied over to the Maya data model.
+        self.assertEqual(cmds.getAttr(aMayaPathStr + '.translate')[0],
+                         aXlation)
+        self.assertEqual(cmds.getAttr(bMayaPathStr + '.translate')[0],
+                         bXlation)
+
     def testDuplicateAsMayaUndoRedo(self):
         '''Duplicate a USD transform hierarchy to Maya and then undo and redo the command.'''
 


### PR DESCRIPTION
- Add isMayaRootPath helper function.
- Use the destination path when duplicating as Maya.
- Add a unit test.