### PR TITLE
Locked attributes on Maya reference prim transform stand-in.

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -434,7 +434,7 @@ bool pullCustomize(const PullImportPaths& importedPaths, const UsdMayaPrimUpdate
 
         // If the Maya node holds USD type information (e.g. a dummy transform
         // node which is a stand-in for a non-transform USD prim type), use the
-        // USD type instead.
+        // USD type instead of the Maya type.
         auto       usdTypeNamePlug = dgNodeFn.findPlug("USD_typeName", true);
         const bool useUsdType = !usdTypeNamePlug.isNull();
 

--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
@@ -38,10 +38,8 @@
 #include <maya/MDGModifier.h>
 #include <maya/MFileIO.h>
 #include <maya/MFileObject.h>
-#include <maya/MFnCamera.h>
 #include <maya/MFnDagNode.h>
 #include <maya/MFnStringData.h>
-#include <maya/MFnTransform.h>
 #include <maya/MFnTypedAttribute.h>
 #include <maya/MGlobal.h>
 #include <maya/MItDependencyNodes.h>

--- a/lib/mayaUsd/fileio/translators/translatorUtil.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorUtil.cpp
@@ -289,4 +289,16 @@ bool UsdMayaTranslatorUtil::CreateShaderNode(
     return true;
 }
 
+/* static */
+bool UsdMayaTranslatorUtil::SetUsdTypeName(const MObject& mayaNodeObj, const TfToken& usdTypeName)
+{
+    if (UsdMayaAdaptor adaptor = UsdMayaAdaptor(mayaNodeObj)) {
+        VtValue typeName;
+        typeName = usdTypeName;
+        adaptor.SetMetadata(SdfFieldKeys->TypeName, typeName);
+        return true;
+    }
+    return false;
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/translators/translatorUtil.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorUtil.cpp
@@ -70,13 +70,14 @@ bool UsdMayaTranslatorUtil::CreateTransformNode(
 
 /* static */
 bool UsdMayaTranslatorUtil::CreateDummyTransformNode(
-    const UsdPrim&               usdPrim,
-    MObject&                     parentNode,
-    bool                         importTypeName,
-    const UsdMayaPrimReaderArgs& args,
-    UsdMayaPrimReaderContext*    context,
-    MStatus*                     status,
-    MObject*                     mayaNodeObj)
+    const UsdPrim&                  usdPrim,
+    MObject&                        parentNode,
+    bool                            importTypeName,
+    const UsdMayaPrimReaderArgs&    args,
+    UsdMayaPrimReaderContext*       context,
+    MStatus*                        status,
+    MObject*                        mayaNodeObj,
+    const UsdMayaDummyTransformType dummyTransformType)
 {
     if (!usdPrim) {
         return false;
@@ -111,6 +112,10 @@ bool UsdMayaTranslatorUtil::CreateDummyTransformNode(
             UsdMayaUtil::SetNotes(dagNode, notes);
         }
         adaptor.SetMetadata(SdfFieldKeys->TypeName, typeName);
+    }
+
+    if (dummyTransformType == UsdMayaDummyTransformType::UnlockedTransform) {
+        return true;
     }
 
     // Lock all the transform attributes.

--- a/lib/mayaUsd/fileio/translators/translatorUtil.h
+++ b/lib/mayaUsd/fileio/translators/translatorUtil.h
@@ -152,6 +152,11 @@ struct UsdMayaTranslatorUtil
 
         return APISchemaType(usdPrim);
     }
+
+    /// Write USD type information into the argument Maya object.  Returns true
+    /// for success.
+    MAYAUSD_CORE_PUBLIC
+    static bool SetUsdTypeName(const MObject& mayaNodeObj, const TfToken& usdTypeName);
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/translators/translatorUtil.h
+++ b/lib/mayaUsd/fileio/translators/translatorUtil.h
@@ -39,6 +39,12 @@ enum class UsdMayaShadingNodeType
     Utility
 };
 
+enum class UsdMayaDummyTransformType
+{
+    UnlockedTransform,
+    LockedTransform
+};
+
 /// \brief Provides helper functions for other readers to use.
 struct UsdMayaTranslatorUtil
 {
@@ -66,13 +72,15 @@ struct UsdMayaTranslatorUtil
     /// empty string, so a typeless def will be generated on export.
     MAYAUSD_CORE_PUBLIC
     static bool CreateDummyTransformNode(
-        const UsdPrim&               usdPrim,
-        MObject&                     parentNode,
-        bool                         importTypeName,
-        const UsdMayaPrimReaderArgs& args,
-        UsdMayaPrimReaderContext*    context,
-        MStatus*                     status,
-        MObject*                     mayaNodeObj);
+        const UsdPrim&                  usdPrim,
+        MObject&                        parentNode,
+        bool                            importTypeName,
+        const UsdMayaPrimReaderArgs&    args,
+        UsdMayaPrimReaderContext*       context,
+        MStatus*                        status,
+        MObject*                        mayaNodeObj,
+        const UsdMayaDummyTransformType dummyTransformType
+        = UsdMayaDummyTransformType::LockedTransform);
 
     /// \brief Helper to create a node for \p usdPrim of type \p
     /// nodeTypeName under \p parentNode. If \p context is non-NULL,

--- a/lib/mayaUsd/python/CMakeLists.txt
+++ b/lib/mayaUsd/python/CMakeLists.txt
@@ -40,6 +40,7 @@ target_sources(${PYTHON_TARGET_NAME}
         wrapRoundTripUtil.cpp
         wrapStageCache.cpp
         wrapTokens.cpp
+        wrapTranslatorUtil.cpp
         wrapUsdUndoManager.cpp
         wrapUserTaggedAttribute.cpp
         wrapUtil.cpp

--- a/lib/mayaUsd/python/module.cpp
+++ b/lib/mayaUsd/python/module.cpp
@@ -46,6 +46,7 @@ TF_WRAP_MODULE
     TF_WRAP(RoundTripUtil);
     TF_WRAP(StageCache);
     TF_WRAP(Tokens);
+    TF_WRAP(TranslatorUtil);
     TF_WRAP(UsdUndoManager);
     TF_WRAP(UserTaggedAttribute);
     TF_WRAP(WriteUtil);

--- a/lib/mayaUsd/python/wrapTranslatorUtil.cpp
+++ b/lib/mayaUsd/python/wrapTranslatorUtil.cpp
@@ -1,0 +1,40 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include <mayaUsd/fileio/translators/translatorUtil.h>
+
+#include <pxr/pxr.h>
+#include <pxr/usd/usd/pyConversions.h>
+
+#include <boost/python/class.hpp>
+#include <boost/python/def.hpp>
+
+using namespace boost::python;
+
+PXR_NAMESPACE_USING_DIRECTIVE;
+
+namespace {
+class UsdMayaTranslatorUtilScope
+{
+};
+
+} // namespace
+
+void wrapTranslatorUtil()
+{
+    scope s(class_<UsdMayaTranslatorUtilScope>("TranslatorUtil"));
+
+    def("SetUsdTypeName", UsdMayaTranslatorUtil::SetUsdTypeName);
+}

--- a/lib/mayaUsd/undo/OpUndoItems.h
+++ b/lib/mayaUsd/undo/OpUndoItems.h
@@ -474,6 +474,13 @@ private:
 
 /// \class LockNodesUndoItem
 /// \brief Record data needed to undo / redo the lock / unlock of Maya nodes.
+///
+/// The node at the Dag path root, and all its children, will be locked.
+/// Since referenced nodes cannot be deleted, locking such nodes is not a
+/// useful workflow for maya-usd.  Therefore, if a child of the Dag path root
+/// is a referenced node, the lock traversal is pruned at that point, for
+/// efficiency.
+
 class LockNodesUndoItem : public OpUndoItem
 {
 public:

--- a/lib/usd/translators/mayaReferenceReader.cpp
+++ b/lib/usd/translators/mayaReferenceReader.cpp
@@ -57,8 +57,14 @@ PXRUSDMAYA_DEFINE_READER(MayaUsd_SchemasMayaReference, args, context)
     // support workflows where this dummy transform node has its transform
     // changed, we leave its transform unlocked.
     UsdMayaTranslatorUtil::CreateDummyTransformNode(
-        usdPrim, parentNode, /*importTypeName*/ true, args, &context, &status,
-        &referenceParentNode, UsdMayaDummyTransformType::UnlockedTransform);
+        usdPrim,
+        parentNode,
+        /*importTypeName*/ true,
+        args,
+        &context,
+        &status,
+        &referenceParentNode,
+        UsdMayaDummyTransformType::UnlockedTransform);
 
     return UsdMayaTranslatorMayaReference::update(usdPrim, referenceParentNode);
 }

--- a/lib/usd/translators/mayaReferenceReader.cpp
+++ b/lib/usd/translators/mayaReferenceReader.cpp
@@ -52,8 +52,13 @@ PXRUSDMAYA_DEFINE_READER(MayaUsd_SchemasMayaReference, args, context)
 
     MObject referenceParentNode;
 
-    UsdMayaTranslatorUtil::CreateTransformNode(
-        usdPrim, parentNode, args, &context, &status, &referenceParentNode);
+    // The stand-in for a Maya reference prim is a dummy transform node, which
+    // preserves the source USD prim type in attribute "USD_typeName".  To
+    // support workflows where this dummy transform node has its transform
+    // changed, we leave its transform unlocked.
+    UsdMayaTranslatorUtil::CreateDummyTransformNode(
+        usdPrim, parentNode, /*importTypeName*/ true, args, &context, &status,
+        &referenceParentNode, UsdMayaDummyTransformType::UnlockedTransform);
 
     return UsdMayaTranslatorMayaReference::update(usdPrim, referenceParentNode);
 }

--- a/lib/usd/translators/mayaReferenceUpdater.h
+++ b/lib/usd/translators/mayaReferenceUpdater.h
@@ -53,6 +53,13 @@ public:
     MAYAUSD_CORE_PUBLIC
     bool canEditAsMaya() const override;
 
+    /// Customize the pulled prim after pull import.  Pull import of the Maya
+    /// reference prim produces a loaded Maya reference, and a Maya transform
+    /// node that is a transformable stand-in for the Maya reference prim in
+    /// the Dag hierarchy.
+    MAYAUSD_CORE_PUBLIC
+    bool editAsMaya() override;
+
 protected:
     MAYAUSD_CORE_PUBLIC
     PushCopySpecs pushCopySpecs(

--- a/test/lib/mayaUsd/fileio/testCacheToUsd.py
+++ b/test/lib/mayaUsd/fileio/testCacheToUsd.py
@@ -45,6 +45,45 @@ from testUtils import assertVectorAlmostEqual, getTestScene
 
 import os
 
+def createMayaRefPrimSiblingCache(testCase, cacheParent, cacheParentPathStr):
+    '''Create a Maya reference prim for the sibling cache test case.'''
+    testCase.assertFalse(cacheParent.HasVariantSets())
+    mayaRefPrim = mayaUsdAddMayaReference.createMayaReferencePrim(
+        cacheParentPathStr, testCase.mayaSceneStr, testCase.kDefaultNamespace)
+
+    # The sibling cache is a new child of its parent, thus the parent has no
+    # variant data.
+    return (mayaRefPrim, None, None, None)
+
+def checkSiblingCacheParent(testCase, cacheParentChildren, vs, vn):
+    '''Verify the cache parent after caching in the sibling cache test case.'''
+    # After caching the cache parent has the original child and its sibling
+    # cache.
+    testCase.assertTrue(len(cacheParentChildren), 2)
+
+def createMayaRefPrimVariantCache(testCase, cacheParent, cacheParentPathStr):
+    '''Create a Maya reference prim for the variant cache test case.'''
+    # Add a variant set to the cache parent.
+    variantSetName = 'animation'
+    variantSet = cacheParent.GetVariantSets().AddVariantSet(variantSetName)
+
+    # Add a rig variant to the variant set.
+    variantSet.AddVariant('Rig')
+
+    # Author a Maya reference prim to the rig variant.
+    with variantSet.GetVariantEditContext():
+        mayaRefPrim = mayaUsdAddMayaReference.createMayaReferencePrim(
+            cacheParentPathStr, testCase.mayaSceneStr, testCase.kDefaultNamespace)
+
+    return (mayaRefPrim, variantSetName, variantSet, 'Cache')
+
+def checkVariantCacheParent(testCase, cacheParentChildren, variantSet, cacheVariantName):
+    '''Verify the cache parent after caching in the variant cache test case.'''
+    # The variant set in the cache parent now has the cache variant
+    # selected, and its only child is called the cache prim name.
+    testCase.assertEqual(variantSet.GetVariantSelection(), cacheVariantName)
+    testCase.assertTrue(len(cacheParentChildren), 1)
+
 class CacheToUsdTestCase(unittest.TestCase):
     '''Test cache to USD: commit edits done to a Maya reference back into USD.
     '''
@@ -69,8 +108,8 @@ class CacheToUsdTestCase(unittest.TestCase):
         self.proxyShapePathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
         self.stage = mayaUsd.lib.GetPrim(self.proxyShapePathStr).GetStage()
 
-    def testCacheToUsd(self):
-        '''Cache edits on a pulled Maya reference prim back to USD.'''
+    def runTestCacheToUsd(self, createMayaRefPrimFn, checkCacheParentFn):
+        '''Cache edits on a pulled Maya reference prim test engine.'''
 
         # Create a Maya reference prim using the defaults, under a
         # newly-created parent, without any variant sets.
@@ -78,8 +117,8 @@ class CacheToUsdTestCase(unittest.TestCase):
         cacheParentPathStr = self.proxyShapePathStr + ',/CacheParent'
         self.assertFalse(cacheParent.HasVariantSets())
 
-        mayaRefPrim = mayaUsdAddMayaReference.createMayaReferencePrim(
-            cacheParentPathStr, self.mayaSceneStr, self.kDefaultNamespace)
+        (mayaRefPrim, variantSetName, variantSet, cacheVariantName) = \
+            createMayaRefPrimFn(self, cacheParent, cacheParentPathStr)
 
         # The Maya reference prim is a child of the cache parent.
         cacheParentItem = createItem(cacheParentPathStr)
@@ -135,15 +174,17 @@ class CacheToUsdTestCase(unittest.TestCase):
         (_, _, _, mayaMatrix) = \
             setMayaTranslation(sphereTransformItem, om.MVector(4, 5, 6))
 
-        # Cache to USD, using a sibling prim and a payload composition arc.
+        # Cache to USD, using a payload composition arc.
         defaultExportOptions = cacheToUsd.getDefaultExportOptions()
         cacheFile = 'testCacheToUsd.usda'
         cachePrimName = 'cachePrimName'
         payloadOrReference = 'Payload'
         listEditType = 'Prepend'
+        # In the sibling cache case variantSetName and cacheVariantName will be
+        # None.
         cacheOptions = cacheToUsd.createCacheCreationOptions(
             defaultExportOptions, cacheFile, cachePrimName,
-            payloadOrReference, listEditType)
+            payloadOrReference, listEditType, variantSetName, cacheVariantName)
 
         # Before caching, the cache file does not exist.
         self.assertFalse(os.path.exists(cacheFile))
@@ -161,7 +202,7 @@ class CacheToUsdTestCase(unittest.TestCase):
         # There is a new child under the cache parent, with the chosen cache
         # prim name.
         cacheParentChildren = cacheParentHier.children()
-        self.assertTrue(len(cacheParentChildren), 2)
+        checkCacheParentFn(self, cacheParentChildren, variantSet, cacheVariantName)
         cacheItem = next((c for c in cacheParentChildren if c.nodeName() == cachePrimName), None)
         self.assertIsNotNone(cacheItem)
 
@@ -194,6 +235,15 @@ class CacheToUsdTestCase(unittest.TestCase):
                 break
 
         self.assertTrue(foundPayload)
+
+        # Clean up
+        os.remove(cacheFile)
+
+    def testCacheToUsdSibling(self):
+        self.runTestCacheToUsd(createMayaRefPrimSiblingCache, checkSiblingCacheParent)
+
+    def testCacheToUsdVariant(self):
+        self.runTestCacheToUsd(createMayaRefPrimVariantCache, checkVariantCacheParent)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/mayaUsd/fileio/testCustomRig.py
+++ b/test/lib/mayaUsd/fileio/testCustomRig.py
@@ -28,6 +28,8 @@ import fixturesUtils
 
 import unittest
 
+_customRigTypeName = None
+
 class customRigPrimReader(mayaUsdLib.PrimReader):
     def Read(self, context):
         usdPrim = self._GetArgs().GetUsdPrim()
@@ -47,6 +49,8 @@ class customRigPrimReader(mayaUsdLib.PrimReader):
         selectionList = OpenMaya.MSelectionList()
         selectionList.add(rigNode[0])
         rigNodeObj = selectionList.getDependNode(0)
+        # Add USD original type information to corresponding Maya node.
+        mayaUsdLib.TranslatorUtil.SetUsdTypeName(rigNodeObj, _customRigTypeName)
         nodePath = usdPrim.GetPath().pathString
         context.RegisterNewMayaNode(nodePath, rigNodeObj);
 
@@ -82,10 +86,11 @@ class testCustomRig(unittest.TestCase):
     def setUpClass(cls):
         cls.inputPath = fixturesUtils.setUpClass(__file__)
         
-        typeName = Usd.SchemaRegistry.GetTypeFromSchemaTypeName("CustomRig").typeName
-        
-        mayaUsdLib.PrimReader.Register(customRigPrimReader, typeName)
-        mayaUsdLib.PrimUpdater.Register(customRigPrimUpdater, typeName, "transform", customRigPrimUpdater.Supports.All.value + customRigPrimUpdater.Supports.AutoPull.value)
+        global _customRigTypeName
+        _customRigTypeName = Usd.SchemaRegistry.GetTypeFromSchemaTypeName("CustomRig").typeName
+
+        mayaUsdLib.PrimReader.Register(customRigPrimReader, _customRigTypeName)
+        mayaUsdLib.PrimUpdater.Register(customRigPrimUpdater, _customRigTypeName, "transform", customRigPrimUpdater.Supports.All.value + customRigPrimUpdater.Supports.AutoPull.value)
 
 
     @classmethod


### PR DESCRIPTION
Design wants all attributes except transform attributes to be locked on the Maya transform node stand-in which is created for the Maya reference prim on pull.  There might be other attributes that we will decide we don't want to lock, so this may evolve after we gain experience.