### PR TITLE
MAYA-122122 void crash when editing as maya

### DIFF
--- a/lib/usd/ui/layerEditor/mayaSessionState.h
+++ b/lib/usd/ui/layerEditor/mayaSessionState.h
@@ -89,7 +89,7 @@ protected:
     static void sceneClosingCB(void* clientData);
 
     void proxyShapeAddedCBOnIdle(const MObject& node);
-    void nodeRenamedCBOnIdle(std::string const& oldName, const MObject& obj);
+    void nodeRenamedCBOnIdle(const MString& shapePath);
 
     // Notice listener method for proxy stage set
     void mayaUsdStageReset(const MayaUsdProxyStageSetNotice& notice);


### PR DESCRIPTION
- Extract the path of the node immediately instead of doing it later on idle.
- In some scenarios, the object is no longer valid on idle.