### PR TITLE
Update the MaterialNetwork conversion function

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -1755,10 +1755,15 @@ void HdVP2Material::Sync(
             if (!bxdfNet.nodes.empty()) {
                 if (_IsMaterialX(bxdfNet.nodes.back())) {
 
-                    bool               isVolume = false;
+                    bool isVolume = false;
+#if PXR_VERSION > 2203
+                    const HdMaterialNetwork2 surfaceNetwork
+                        = HdConvertToHdMaterialNetwork2(networkMap, &isVolume);
+#else
                     HdMaterialNetwork2 surfaceNetwork;
                     HdMaterialNetwork2ConvertFromHdMaterialNetworkMap(
                         networkMap, &surfaceNetwork, &isVolume);
+#endif
                     if (isVolume) {
                         // Not supported.
                         return;


### PR DESCRIPTION
Changing the conversion function to return an HdMaterialNetwork2 for the
given HdMaterialNetworkMap. Doing so to hopefully avoid potential issues
if the caller passes in an existing HdMaterialNetwork2, in which it
would give an inaccurate final material network.