### PR TITLE
MAYA-121877 cancel edit on maya ref under an xform

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -1015,7 +1015,6 @@ bool PrimUpdaterManager::discardPrimEdits(const Ufe::Path& pulledPath)
 
         const Ufe::Path path = MayaUsd::ufe::dagPathToPathSegment(curDagPath);
 
-        bool usePulledPrim = (curDagPath == mayaDagPath);
         auto registryItem = getUpdaterItem(dgNodeFn);
         auto factory = std::get<UsdMayaPrimUpdaterRegistry::UpdaterFactoryFn>(registryItem);
         auto updater = factory(context, dgNodeFn, path);

--- a/lib/mayaUsd/resources/scripts/mayaUsdUtils.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdUtils.py
@@ -42,9 +42,32 @@ def getPulledInfo(dagPath):
     return fullDagPath, mayaItem, pulledPath, prim
 
 
+def getDagPathUsdTypeName(dagPath):
+    """
+    Retrieves the type name of the USD object that created the node pointed to by the DAG path.
+    This type name is kept in the 'USD_typeName' attribute.
+    Returns None if the attribute is not found.
+    """
+    sn = om.MSelectionList()
+    sn.add(dagPath)
+    obj = sn.getDependNode(0)
+    node = om.MFnDependencyNode(obj)
+    if not node.hasAttribute('USD_typeName'):
+        return None
+
+    plug = node.findPlug('USD_typeName', True)
+    if not plug:
+        return None
+        
+    return plug.asString()
+
+
 def isPulledMayaReference(dagPath):
     """
     Verifies if the DAG path refers to a pulled prim that is a Maya reference.
     """
+    if getDagPathUsdTypeName(dagPath) == 'MayaReference':
+        return True
+
     _, _, _, prim = getPulledInfo(dagPath)
     return prim and prim.GetTypeName() == 'MayaReference'


### PR DESCRIPTION
When a Maya ref is under a xofrm and that xform is edited-as-maya, show the proper menu for the maya ref and handle the cancel-edit correctly.

- Detect the Maya ref for the context menu using the USD_typeName.
- Refactor the code that use the USD_typeName attribute in the prim update manager.
- Use the new common code in merge-to-USD, edit-as-Maya, discard edits and orphaned edits.