### PR TITLE
[al] Added export option to merge offset parent matrix

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/AnimationTranslator.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/AnimationTranslator.cpp
@@ -60,15 +60,20 @@ void AnimationTranslator::exportAnimation(const ExporterParams& params)
                 ///         maya::Dg
                 ///         usdmaya::Dg
                 ///         usdmaya::fileio::translator::Dg
-                translators::DgNodeTranslator::copyAttributeValue(it->first, it->second, timeCode);
+                translators::TransformTranslator::copyAttributeValue(
+                    it->first, it->second, timeCode, params.m_mergeOffsetParentMatrix);
             }
             for (auto it = startAttribScaled; it != endAttribScaled; ++it) {
                 /// \todo This feels wrong. Split the DgNodeTranslator class into 3 ...
                 ///         maya::Dg
                 ///         usdmaya::Dg
                 ///         usdmaya::fileio::translator::Dg
-                translators::DgNodeTranslator::copyAttributeValue(
-                    it->first, it->second.attr, it->second.scale, timeCode);
+                translators::TransformTranslator::copyAttributeValue(
+                    it->first,
+                    it->second.attr,
+                    it->second.scale,
+                    timeCode,
+                    params.m_mergeOffsetParentMatrix);
             }
             for (auto it = startTransformAttrib; it != endTransformAttrib; ++it) {
                 translators::TransformTranslator::copyAttributeValue(

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/Export.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/Export.cpp
@@ -1082,6 +1082,11 @@ MStatus ExportCommand::doIt(const MArgList& args)
             argData.getFlagArgument("mt", 0, m_params.m_mergeTransforms),
             "ALUSDExport: Unable to fetch \"merge transforms\" argument");
     }
+    if (argData.isFlagSet("mom", &status)) {
+        AL_MAYA_CHECK_ERROR(
+            argData.getFlagArgument("mom", 0, m_params.m_mergeOffsetParentMatrix),
+            "ALUSDExport: Unable to fetch \"merge offset parent matrix\" argument");
+    }
     if (argData.isFlagSet("nc", &status)) {
         bool option;
         argData.getFlagArgument("nc", 0, option);
@@ -1239,6 +1244,8 @@ MSyntax ExportCommand::createSyntax()
     status = syntax.addFlag("-di", "-duplicateInstances", MSyntax::kBoolean);
     AL_MAYA_CHECK_ERROR2(status, errorString);
     status = syntax.addFlag("-mt", "-mergeTransforms", MSyntax::kBoolean);
+    AL_MAYA_CHECK_ERROR2(status, errorString);
+    status = syntax.addFlag("-mom", "-mergeOffsetParentMatrix", MSyntax::kBoolean);
     AL_MAYA_CHECK_ERROR2(status, errorString);
     status = syntax.addFlag("-ani", "-animation", MSyntax::kNoArg);
     AL_MAYA_CHECK_ERROR2(status, errorString);

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportParams.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportParams.h
@@ -53,6 +53,9 @@ struct ExporterParams
     bool m_mergeTransforms
         = true; ///< if true, shapes will be merged into their parent transforms in the exported
                 ///< data. If false, the transform and shape will be exported seperately
+    bool m_mergeOffsetParentMatrix
+        = false; ///< if true, offset parent matrix would be merged to produce local space matrix;
+                 ///< if false, offset parent matrix would be exported separately in USD.
     bool m_animation = false;        ///< if true, animation will be exported.
     bool m_useTimelineRange = false; ///< if true, then the export uses Maya's timeline range.
     bool m_filterSample = false; ///< if true, duplicate sample of attribute will be filtered out

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportTranslator.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportTranslator.cpp
@@ -54,6 +54,7 @@ MStatus ExportTranslator::writer(
     params.m_dynamicAttributes = options.getBool(kDynamicAttributes);
     params.m_duplicateInstances = options.getBool(kDuplicateInstances);
     params.m_mergeTransforms = options.getBool(kMergeTransforms);
+    params.m_mergeOffsetParentMatrix = options.getBool(kMergeOffsetParentMatrix);
     params.m_fileName = file.fullName();
     params.m_selected = mode == MPxFileTranslator::kExportActiveAccessMode;
     params.m_animation = options.getBool(kAnimation);

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportTranslator.h
@@ -60,6 +60,8 @@ static constexpr const char* const kDuplicateInstances
     = "Duplicate Instances"; ///< export instances option name
 static constexpr const char* const kMergeTransforms
     = "Merge Transforms"; ///< export by merging transforms and shapes option name
+static constexpr const char* const kMergeOffsetParentMatrix
+    = "Merge Offset Parent Matrix"; ///< export by merging offset parent matrix
 static constexpr const char* const kAnimation = "Animation"; ///< export animation data option name
 static constexpr const char* const kUseTimelineRange
     = "Use Timeline Range"; ///< export using the timeline range option name
@@ -102,6 +104,8 @@ static MStatus specifyOptions(AL::maya::utils::FileTranslatorOptions& options)
     if (!options.addBool(kDuplicateInstances, defaultValues.m_duplicateInstances))
         return MS::kFailure;
     if (!options.addBool(kMergeTransforms, defaultValues.m_mergeTransforms))
+        return MS::kFailure;
+    if (!options.addBool(kMergeOffsetParentMatrix, defaultValues.m_mergeOffsetParentMatrix))
         return MS::kFailure;
     if (!options.addBool(kAnimation, defaultValues.m_animation))
         return MS::kFailure;

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.cpp
@@ -49,6 +49,143 @@ namespace fileio {
 namespace translators {
 
 //----------------------------------------------------------------------------------------------------------------------
+static const GfMatrix4d g_identityMatrix(1.0);
+static constexpr double g_tolerance = 1e-9;
+
+namespace {
+//----------------------------------------------------------------------------------------------------------------------
+bool extractOffsetMatrixComponents(
+    const MObject& node,
+    GfVec3d&       translation,
+    GfVec3f&       rotation,
+    int32_t&       rotateOrder,
+    GfVec3f&       scale,
+    GfVec3f&       shear)
+{
+    // Compose local matrix and offset parent matrix, then decompose components
+    // at once.
+
+    MMatrix offsetMatrix;
+    if (translators::DgNodeTranslator::getMatrix4x4(
+            node, MPxTransform::offsetParentMatrix, offsetMatrix)
+        != MStatus::kSuccess) {
+        // Cannot find offset parent matrix
+        return false;
+    }
+    if (GfIsClose(GfMatrix4d(offsetMatrix.matrix), g_identityMatrix, g_tolerance)) {
+        // Offset parent matrix is default, not need to compute
+        return false;
+    }
+
+    MMatrix localMatrix;
+    if (translators::DgNodeTranslator::getMatrix4x4(node, MPxTransform::xformMatrix, localMatrix)
+        != MStatus::kSuccess) {
+        // Cannot find local matrix
+        return false;
+    }
+
+    MStatus               status;
+    MTransformationMatrix transformationMatrix(offsetMatrix * localMatrix);
+    // Translate
+    MVector t(transformationMatrix.getTranslation(MSpace::kTransform, &status));
+    if (status != MStatus::kSuccess) {
+        return false;
+    }
+    translation = { t[0], t[1], t[2] };
+    // Rotate
+    double                               value[3];
+    MTransformationMatrix::RotationOrder tempRotateOrder;
+    if (transformationMatrix.getRotation(value, tempRotateOrder) != MStatus::kSuccess) {
+        return false;
+    }
+    rotation = { float(value[0]), float(value[1]), float(value[2]) };
+    // MTransformationMatrix::RotationOrder starts with kInvalid (0)
+    // Minus 1 to match MEulerRotation::RotationOrder
+    rotateOrder = static_cast<int32_t>(tempRotateOrder) - 1;
+    // Scale
+    if (transformationMatrix.getScale(value, MSpace::kTransform) != MStatus::kSuccess) {
+        return false;
+    }
+    scale = { float(value[0]), float(value[1]), float(value[2]) };
+    // Shear
+    if (transformationMatrix.getShear(value, MSpace::kTransform) != MStatus::kSuccess) {
+        return false;
+    }
+    shear = { float(value[0]), float(value[1]), float(value[2]) };
+    return true;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+bool extractOffsetMatrixComponent(const MPlug& attr, double* value)
+{
+    // Similar as above function but decompose one component at a time,
+    // this is called when writing out animation values.
+
+    // Attributes that are affected by offset parent matrix:
+    // "t" -> "translate"
+    // "r" -> "rotate"
+    // "s" -> "scale"
+    // "sh" -> "shear"
+    static const std::array<MString, 4> supportedAttrs { "t", "r", "s", "sh" };
+
+    MString shortName(attr.partialName());
+    auto    it = std::find(supportedAttrs.cbegin(), supportedAttrs.cend(), shortName);
+    if (it == supportedAttrs.cend()) {
+        // Not supported attribute name
+        return false;
+    }
+
+    MMatrix offsetMatrix;
+    if (translators::DgNodeTranslator::getMatrix4x4(
+            attr.node(), MPxTransform::offsetParentMatrix, offsetMatrix)
+        != MStatus::kSuccess) {
+        // Cannot find offset parent matrix
+        return false;
+    }
+
+    if (GfIsClose(GfMatrix4d(offsetMatrix.matrix), g_identityMatrix, g_tolerance)) {
+        // Offset parent matrix is default, not need to compute
+        return false;
+    }
+
+    MMatrix localMatrix;
+    if (translators::DgNodeTranslator::getMatrix4x4(
+            attr.node(), MPxTransform::xformMatrix, localMatrix)
+        != MStatus::kSuccess) {
+        // Cannot find local matrix
+        return false;
+    }
+
+    MStatus               status;
+    MTransformationMatrix transformationMatrix(offsetMatrix * localMatrix);
+    if (shortName == "t") {
+        MVector t(transformationMatrix.getTranslation(MSpace::kTransform, &status));
+        if (status != MStatus::kSuccess) {
+            return false;
+        }
+        value[0] = t[0];
+        value[1] = t[1];
+        value[2] = t[2];
+    } else if (shortName == "r") {
+        MTransformationMatrix::RotationOrder order;
+        if (transformationMatrix.getRotation(value, order) != MStatus::kSuccess) {
+            return false;
+        }
+    } else if (shortName == "s") {
+        if (transformationMatrix.getScale(value, MSpace::kTransform) != MStatus::kSuccess) {
+            return false;
+        }
+    } else if (shortName == "sh") {
+        if (transformationMatrix.getShear(value, MSpace::kTransform) != MStatus::kSuccess) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+//----------------------------------------------------------------------------------------------------------------------
 MObject TransformTranslator::m_inheritsTransform = MObject::kNullObj;
 MObject TransformTranslator::m_scale = MObject::kNullObj;
 MObject TransformTranslator::m_shear = MObject::kNullObj;
@@ -703,12 +840,7 @@ MStatus TransformTranslator::copyAttributes(
     if (!exportInWorldSpace) {
         getBool(from, m_inheritsTransform, inheritsTransform);
         getBool(from, m_visible, visible);
-        getVec3(from, m_scale, (float*)&scale);
-        getVec3(from, m_shear, (float*)&shear);
-        getVec3(from, m_rotation, (float*)&rotation);
-        getInt32(from, m_rotateOrder, rotateOrder);
         getVec3(from, m_rotateAxis, (float*)&rotateAxis);
-        getVec3(from, m_translation, (double*)&translation);
         getVec3(from, m_scalePivot, (float*)&scalePivot);
         getVec3(from, m_rotatePivot, (float*)&rotatePivot);
         getVec3(from, m_scalePivotTranslate, (float*)&scalePivotTranslate);
@@ -719,6 +851,21 @@ MStatus TransformTranslator::copyAttributes(
 
         // This adds an op to the stack so we should do it after ClearXformOpOrder():
         xformSchema.SetResetXformStack(!inheritsTransform);
+
+        if (params.m_mergeOffsetParentMatrix
+            && extractOffsetMatrixComponents(
+                from, translation, rotation, rotateOrder, scale, shear)) {
+            // Update the animated flag
+            transformAnimated
+                |= animationCheck(animTranslator, MPlug(from, MPxTransform::offsetParentMatrix));
+        } else {
+            /// Retrieve the values directly from Maya
+            getVec3(from, m_scale, (float*)&scale);
+            getVec3(from, m_shear, (float*)&shear);
+            getVec3(from, m_rotation, (float*)&rotation);
+            getInt32(from, m_rotateOrder, rotateOrder);
+            getVec3(from, m_translation, (double*)&translation);
+        }
 
         bool plugAnimated = animationCheck(animTranslator, MPlug(from, m_visible));
         if (plugAnimated || visible != defaultVisible) {
@@ -864,6 +1011,80 @@ void TransformTranslator::copyAttributeValue(
         getBool(node, attribute, value);
         usdAttr.Set(value ? UsdGeomTokens->inherited : UsdGeomTokens->invisible, timeCode);
     }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+void TransformTranslator::copyAttributeValue(
+    const MPlug&       attr,
+    UsdAttribute&      usdAttr,
+    const UsdTimeCode& timeCode,
+    bool               mergeOffsetMatrix)
+{
+    double value[3];
+    if (mergeOffsetMatrix && extractOffsetMatrixComponent(attr, value)) {
+        if (usdAttr.GetTypeName() == SdfValueTypeNames->Float3) {
+            usdAttr.Set(
+                GfVec3f(
+                    static_cast<float>(value[0]),
+                    static_cast<float>(value[1]),
+                    static_cast<float>(value[2])),
+                timeCode);
+        } else if (usdAttr.GetTypeName() == SdfValueTypeNames->Double3) {
+            usdAttr.Set(GfVec3d(value[0], value[1], value[2]), timeCode);
+        } else if (usdAttr.GetTypeName() == SdfValueTypeNames->Matrix4d) {
+            // Notice that the only case for this Matrix4d type is "shear"
+            GfMatrix4d shearMatrix(
+                1.0f,
+                0.0f,
+                0.0f,
+                0.0f,
+                value[0],
+                1.0f,
+                0.0f,
+                0.0f,
+                value[1],
+                value[2],
+                1.0f,
+                0.0f,
+                0.0f,
+                0.0f,
+                0.0f,
+                1.0f);
+            usdAttr.Set(shearMatrix, timeCode);
+        }
+        return;
+    }
+
+    usdmaya::utils::DgNodeHelper::copyAttributeValue(attr, usdAttr, timeCode);
+}
+
+void TransformTranslator::copyAttributeValue(
+    const MPlug&       attr,
+    UsdAttribute&      usdAttr,
+    const float        scale,
+    const UsdTimeCode& timeCode,
+    bool               mergeOffsetMatrix)
+{
+    // Notice that "rotate" is the only one we supported at the moment,
+    // The rotation order is ignored, due to it's been created at the
+    // first place (the USD attribute), no intention to further check rotation
+    // order for non-default time code values.
+    double value[3];
+    if (mergeOffsetMatrix && extractOffsetMatrixComponent(attr, value)) {
+        if (usdAttr.GetTypeName() == SdfValueTypeNames->Float3) {
+            usdAttr.Set(
+                GfVec3f(
+                    static_cast<float>(value[0] * scale),
+                    static_cast<float>(value[1] * scale),
+                    static_cast<float>(value[2] * scale)),
+                timeCode);
+        } else if (usdAttr.GetTypeName() == SdfValueTypeNames->Double3) {
+            usdAttr.Set(GfVec3d(value[0] * scale, value[1] * scale, value[2] * scale), timeCode);
+        }
+        return;
+    }
+
+    translators::DgNodeTranslator::copyAttributeValue(attr, usdAttr, scale, timeCode);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.h
@@ -100,6 +100,32 @@ public:
         MObject&           attribute,
         double&            conversionFactor);
 
+    /// \brief  helper method to copy attributes from the UsdPrim to the Maya node
+    /// \param  attr the maya node to copy the data from
+    /// \param  usdAttr the UsdPrim to copy the data to
+    /// \param  timeCode Usd timecode to copy to
+    /// \param  mergeOffsetMatrix flag if needs to merge offset parent matrix
+    AL_USDMAYA_PUBLIC
+    static void copyAttributeValue(
+        const MPlug&       attr,
+        UsdAttribute&      usdAttr,
+        const UsdTimeCode& timeCode,
+        bool               mergeOffsetMatrix);
+
+    /// \brief  helper method to copy attributes from the UsdPrim to the Maya node
+    /// \param  attr the maya node to copy the data from
+    /// \param  usdAttr the UsdPrim to copy the data to
+    /// \param  scale additional scale value to apply before copying to USD
+    /// \param  timeCode Usd timecode to copy to
+    /// \param  mergeOffsetMatrix flag if needs to merge offset parent matrix
+    AL_USDMAYA_PUBLIC
+    static void copyAttributeValue(
+        const MPlug&       attr,
+        UsdAttribute&      usdAttr,
+        float              scale,
+        const UsdTimeCode& timeCode,
+        bool               mergeOffsetMatrix);
+
 private:
     static MStatus processMetaData(const UsdPrim& from, MObject& to, const ImporterParams& params);
 

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/test_translators_TransformTranslator.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/test_translators_TransformTranslator.cpp
@@ -499,3 +499,283 @@ TEST(translators_TranformTranslator, worldSpaceGroupsExport)
     ASSERT_TRUE(stage->GetPrimAtPath(SdfPath("/C/X2/Y3")));
     ASSERT_TRUE(stage->GetPrimAtPath(SdfPath("/C/X2/Y3/cube1")));
 }
+
+TEST(translators_TranformTranslator, withOffsetParentMatrix)
+{
+    MFileIO::newFile(true);
+
+    MString buildCommand = R"(
+      polyCube;
+      // Local translate
+      move 1 2 3 pCube1;
+      // Offset translate
+      setAttr "pCube1.offsetParentMatrix" -type "matrix" 1 0 0 0 0 1 0 0 0 0 1 0 1 2 3 1 ;
+      group "pCube1";
+      move 1 2 3 group1;
+      setAttr "group1.rp" -type "double3" 0 0 0;
+      setAttr "group1.sp" -type "double3" 0 0 0;
+      // Translate XYZ = (1, 2, 3)
+      // Rotate XYZ == (30.0, 45.0, 60.0)
+      setAttr "group1.offsetParentMatrix" -type "matrix" 0.353553 0.612373 -0.707107 0 -0.573223 0.739199 0.353554 0 0.739199 0.28033 0.612372 0 1 2 3 1 ;
+      group "group1";
+      move 1 2 3 group2;
+      setAttr "group2.rp" -type "double3" 0 0 0;
+      setAttr "group2.sp" -type "double3" 0 0 0;
+      // Scale XYZ = (2, 2, 2)
+      //setAttr "group2.offsetParentMatrix" -type "matrix" 2 0 0 0 0 2 0 0 0 0 2 0 0 0 0 1 ;
+      group "group2";
+      move 1 2 3 group3;
+      setAttr "group3.rp" -type "double3" 0 0 0;
+      setAttr "group3.sp" -type "double3" 0 0 0;
+      // Drive group2.offsetParentMatrix by other node
+      createNode "composeMatrix";
+      connectAttr -f composeMatrix1.outputMatrix group2.offsetParentMatrix;
+      currentTime 1;
+      setAttr "composeMatrix1.inputTranslate" 1 1 1; setKeyframe "composeMatrix1.inputTranslate";
+      setAttr "composeMatrix1.inputRotate" 10 10 10 ;   setKeyframe "composeMatrix1.inputRotate";
+      setAttr "composeMatrix1.inputScale" 1 1 1;     setKeyframe "composeMatrix1.inputScale";
+      currentTime 2;
+      setAttr "composeMatrix1.inputTranslate" 2 2 2; setKeyframe "composeMatrix1.inputTranslate";
+      setAttr "composeMatrix1.inputRotate" 20 20 20 ;   setKeyframe "composeMatrix1.inputRotate";
+      setAttr "composeMatrix1.inputScale"  2 2 2;     setKeyframe "composeMatrix1.inputScale";
+      currentTime 3;
+      setAttr "composeMatrix1.inputTranslate" 3 3 3; setKeyframe "composeMatrix1.inputTranslate";
+      setAttr "composeMatrix1.inputRotate" 30 30 30 ;   setKeyframe "composeMatrix1.inputRotate";
+      setAttr "composeMatrix1.inputScale"  3 3 3;     setKeyframe "composeMatrix1.inputScale";
+      // Animate the local matrix
+      currentTime 1;
+      setAttr "pCube1.tx" 1; setKeyframe "pCube1.tx";
+      setAttr "pCube1.ty" 2; setKeyframe "pCube1.ty";
+      setAttr "pCube1.tz" 3; setKeyframe "pCube1.tz";
+      currentTime 2;
+      setAttr "pCube1.tx" 4; setKeyframe "pCube1.tx";
+      setAttr "pCube1.ty" 5; setKeyframe "pCube1.ty";
+      setAttr "pCube1.tz" 6; setKeyframe "pCube1.tz";
+      currentTime 3;
+      setAttr "pCube1.tx" 7; setKeyframe  "pCube1.tx";
+      setAttr "pCube1.ty" 8; setKeyframe  "pCube1.ty";
+      setAttr "pCube1.tz" 9; setKeyframe  "pCube1.tz";
+      currentTime 1;
+      )";
+
+    ASSERT_TRUE(MGlobal::executeCommand(buildCommand));
+
+    auto    path = buildTempPath("AL_USDMayaTests_withOffsetParentMatrix.usda");
+    MString exportCommand = "file -force -options "
+                            "\""
+                            "Animation=1;"
+                            "Use_Timeline_Range=0;Frame_Min=1;Frame_Max=3;"
+                            "Merge_Offset_Parent_Matrix=1;"
+                            "Export_In_World_Space=0;"
+                            "Merge_Transforms=1;"
+                            "Dynamic_Attributes=0;Mesh_Normals=0;"
+                            "Mesh_Vertex_Creases=0;Mesh_Edge_Creases=0;"
+                            "Mesh_UVs=0;Mesh_UV_Only=0;Mesh_Points_as_PRef=0;"
+                            "Mesh_Colours=0;Mesh_Holes=0;Compaction_Level=0;"
+                            "Nurbs_Curves=0;Duplicate_Instances=0;"
+                            "Sub_Samples=1;Filter_Sample=0;Export_At_Which_Time=2;"
+                            "Meshes=1;Mesh_Face_Connects=1;Mesh_Points=1;"
+                            "\" -typ \"AL usdmaya export\" -pr -ea ";
+    exportCommand += "\"";
+    exportCommand += path;
+    exportCommand += "\"";
+
+    // export cube in world space
+    ASSERT_TRUE(MGlobal::executeCommand(exportCommand));
+
+    auto stage = UsdStage::Open(path);
+
+    ASSERT_TRUE(stage);
+    bool resetsXformStack = false;
+
+    // group3 has static xform matrix, translate == (1, 2, 3)
+    {
+        auto prim = stage->GetPrimAtPath(SdfPath("/group3"));
+        ASSERT_TRUE(prim);
+        UsdGeomXform xform(prim);
+        GfMatrix4d   transform(1.0);
+        xform.GetLocalTransformation(&transform, &resetsXformStack, UsdTimeCode::EarliestTime());
+        // make sure the local space tm values match the world coords.
+        EXPECT_NEAR(1.0, transform[0][0], 1e-6);
+        EXPECT_NEAR(0.0, transform[0][1], 1e-6);
+        EXPECT_NEAR(0.0, transform[0][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[0][3], 1e-6);
+        EXPECT_NEAR(0.0, transform[1][0], 1e-6);
+        EXPECT_NEAR(1.0, transform[1][1], 1e-6);
+        EXPECT_NEAR(0.0, transform[1][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[1][3], 1e-6);
+        EXPECT_NEAR(0.0, transform[2][0], 1e-6);
+        EXPECT_NEAR(0.0, transform[2][1], 1e-6);
+        EXPECT_NEAR(1.0, transform[2][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[2][3], 1e-6);
+        EXPECT_NEAR(1.0, transform[3][0], 1e-6);
+        EXPECT_NEAR(2.0, transform[3][1], 1e-6);
+        EXPECT_NEAR(3.0, transform[3][2], 1e-6);
+        EXPECT_NEAR(1.0, transform[3][3], 1e-6);
+    }
+
+    // group2 offset parent matrix is driven by connection
+    {
+        auto prim = stage->GetPrimAtPath(SdfPath("/group3/group2"));
+        ASSERT_TRUE(prim);
+
+        UsdGeomXform xform(prim);
+        GfMatrix4d   transform(1.0);
+
+        // group2 at frame 1:
+        // translate: 2, 3, 4
+        // rotate xyz: 10, 10, 10
+        // scale: 1, 1, 1
+        xform.GetLocalTransformation(&transform, &resetsXformStack, UsdTimeCode(1));
+        EXPECT_NEAR(0.9698463103929541, transform[0][0], 1e-6);
+        EXPECT_NEAR(0.17101007166283433, transform[0][1], 1e-6);
+        EXPECT_NEAR(-0.17364817766693033, transform[0][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[0][3], 1e-6);
+        EXPECT_NEAR(-0.14131448435589197, transform[1][0], 1e-6);
+        EXPECT_NEAR(0.9750824436431519, transform[1][1], 1e-6);
+        EXPECT_NEAR(0.17101007166283433, transform[1][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[1][3], 1e-6);
+        EXPECT_NEAR(0.19856573402377836, transform[2][0], 1e-6);
+        EXPECT_NEAR(-0.141314484355892, transform[2][1], 1e-6);
+        EXPECT_NEAR(0.9698463103929541, transform[2][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[2][3], 1e-6);
+        EXPECT_NEAR(2.0, transform[3][0], 1e-6);
+        EXPECT_NEAR(3.0, transform[3][1], 1e-6);
+        EXPECT_NEAR(4.0, transform[3][2], 1e-6);
+        EXPECT_NEAR(1.0, transform[3][3], 1e-6);
+        // group2 at frame 2:
+        // translate: 3, 4, 5
+        // rotate xyz: 20, 20, 20
+        // scale: 2, 2, 2
+        xform.GetLocalTransformation(&transform, &resetsXformStack, UsdTimeCode(2));
+        EXPECT_NEAR(1.7660444431189781, transform[0][0], 1e-6);
+        EXPECT_NEAR(0.6427876096865395, transform[0][1], 1e-6);
+        EXPECT_NEAR(-0.6840402866513375, transform[0][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[0][3], 1e-6);
+        EXPECT_NEAR(-0.42294129929358526, transform[1][0], 1e-6);
+        EXPECT_NEAR(1.8460619562152618, transform[1][1], 1e-6);
+        EXPECT_NEAR(0.6427876096865395, transform[1][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[1][3], 1e-6);
+        EXPECT_NEAR(0.8379783304360758, transform[2][0], 1e-6);
+        EXPECT_NEAR(-0.4229412992935852, transform[2][1], 1e-6);
+        EXPECT_NEAR(1.7660444431189781, transform[2][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[2][3], 1e-6);
+        EXPECT_NEAR(3.0, transform[3][0], 1e-6);
+        EXPECT_NEAR(4.0, transform[3][1], 1e-6);
+        EXPECT_NEAR(5.0, transform[3][2], 1e-6);
+        EXPECT_NEAR(1.0, transform[3][3], 1e-6);
+        // group2 at frame 3:
+        // translate: 4, 5, 6
+        // rotate xyz: 30, 30, 30
+        // scale: 3, 3, 3
+        xform.GetLocalTransformation(&transform, &resetsXformStack, UsdTimeCode(3));
+        EXPECT_NEAR(2.2500000000000004, transform[0][0], 1e-6);
+        EXPECT_NEAR(1.299038105676658, transform[0][1], 1e-6);
+        EXPECT_NEAR(-1.4999999999999998, transform[0][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[0][3], 1e-6);
+        EXPECT_NEAR(-0.649519052838329, transform[1][0], 1e-6);
+        EXPECT_NEAR(2.6250000000000004, transform[1][1], 1e-6);
+        EXPECT_NEAR(1.299038105676658, transform[1][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[1][3], 1e-6);
+        EXPECT_NEAR(1.875, transform[2][0], 1e-6);
+        EXPECT_NEAR(-0.649519052838329, transform[2][1], 1e-6);
+        EXPECT_NEAR(2.2500000000000004, transform[2][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[2][3], 1e-6);
+        EXPECT_NEAR(4.0, transform[3][0], 1e-6);
+        EXPECT_NEAR(5.0, transform[3][1], 1e-6);
+        EXPECT_NEAR(6.0, transform[3][2], 1e-6);
+        EXPECT_NEAR(1.0, transform[3][3], 1e-6);
+    }
+    // group1 local matrix and offset parent matrix are both static at
+    //  local translate: 1, 2, 3
+    // offset translate: 1, 2, 3
+    // offset    rotate: 30, 45, 60
+    {
+        auto prim = stage->GetPrimAtPath(SdfPath("/group3/group2/group1"));
+        ASSERT_TRUE(prim);
+
+        UsdGeomXform xform(prim);
+        GfMatrix4d   transform(1.0);
+        xform.GetLocalTransformation(&transform, &resetsXformStack, UsdTimeCode::EarliestTime());
+        EXPECT_NEAR(0.3535533905932738, transform[0][0], 1e-6);
+        EXPECT_NEAR(0.6123724356957945, transform[0][1], 1e-6);
+        EXPECT_NEAR(-0.7071067811865476, transform[0][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[0][3], 1e-6);
+        EXPECT_NEAR(-0.5732233047033631, transform[1][0], 1e-6);
+        EXPECT_NEAR(0.7391989197401168, transform[1][1], 1e-6);
+        EXPECT_NEAR(0.3535533905932737, transform[1][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[1][3], 1e-6);
+        EXPECT_NEAR(0.7391989197401165, transform[2][0], 1e-6);
+        EXPECT_NEAR(0.2803300858899107, transform[2][1], 1e-6);
+        EXPECT_NEAR(0.6123724356957945, transform[2][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[2][3], 1e-6);
+        EXPECT_NEAR(2.0, transform[3][0], 1e-6);
+        EXPECT_NEAR(4.0, transform[3][1], 1e-6);
+        EXPECT_NEAR(6.0, transform[3][2], 1e-6);
+        EXPECT_NEAR(1.0, transform[3][3], 1e-6);
+    }
+    // cube1 local translate is animated, offset parent matrix is static
+    //  local translate: 1, 2, 3 -> 4, 5, 6 -> 7, 8, 9
+    // offset translate: 1, 2, 3
+    {
+        auto prim = stage->GetPrimAtPath(SdfPath("/group3/group2/group1/pCube1"));
+        ASSERT_TRUE(prim);
+
+        UsdGeomXform xform(prim);
+        GfMatrix4d   transform(1.0);
+        // frame 1: local translate: 1, 2, 3
+        xform.GetLocalTransformation(&transform, &resetsXformStack, UsdTimeCode(1));
+        EXPECT_NEAR(1.0, transform[0][0], 1e-6);
+        EXPECT_NEAR(0.0, transform[0][1], 1e-6);
+        EXPECT_NEAR(0.0, transform[0][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[0][3], 1e-6);
+        EXPECT_NEAR(0.0, transform[1][0], 1e-6);
+        EXPECT_NEAR(1.0, transform[1][1], 1e-6);
+        EXPECT_NEAR(0.0, transform[1][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[1][3], 1e-6);
+        EXPECT_NEAR(0.0, transform[2][0], 1e-6);
+        EXPECT_NEAR(0.0, transform[2][1], 1e-6);
+        EXPECT_NEAR(1.0, transform[2][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[2][3], 1e-6);
+        EXPECT_NEAR(2.0, transform[3][0], 1e-6);
+        EXPECT_NEAR(4.0, transform[3][1], 1e-6);
+        EXPECT_NEAR(6.0, transform[3][2], 1e-6);
+        EXPECT_NEAR(1.0, transform[3][3], 1e-6);
+        // frame 2: local translate: 4, 5, 6
+        xform.GetLocalTransformation(&transform, &resetsXformStack, UsdTimeCode(2));
+        EXPECT_NEAR(1.0, transform[0][0], 1e-6);
+        EXPECT_NEAR(0.0, transform[0][1], 1e-6);
+        EXPECT_NEAR(0.0, transform[0][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[0][3], 1e-6);
+        EXPECT_NEAR(0.0, transform[1][0], 1e-6);
+        EXPECT_NEAR(1.0, transform[1][1], 1e-6);
+        EXPECT_NEAR(0.0, transform[1][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[1][3], 1e-6);
+        EXPECT_NEAR(0.0, transform[2][0], 1e-6);
+        EXPECT_NEAR(0.0, transform[2][1], 1e-6);
+        EXPECT_NEAR(1.0, transform[2][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[2][3], 1e-6);
+        EXPECT_NEAR(5.0, transform[3][0], 1e-6);
+        EXPECT_NEAR(7.0, transform[3][1], 1e-6);
+        EXPECT_NEAR(9.0, transform[3][2], 1e-6);
+        EXPECT_NEAR(1.0, transform[3][3], 1e-6);
+        // frame 3: local translate: 7, 8, 9
+        xform.GetLocalTransformation(&transform, &resetsXformStack, UsdTimeCode(3));
+        EXPECT_NEAR(1.0, transform[0][0], 1e-6);
+        EXPECT_NEAR(0.0, transform[0][1], 1e-6);
+        EXPECT_NEAR(0.0, transform[0][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[0][3], 1e-6);
+        EXPECT_NEAR(0.0, transform[1][0], 1e-6);
+        EXPECT_NEAR(1.0, transform[1][1], 1e-6);
+        EXPECT_NEAR(0.0, transform[1][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[1][3], 1e-6);
+        EXPECT_NEAR(0.0, transform[2][0], 1e-6);
+        EXPECT_NEAR(0.0, transform[2][1], 1e-6);
+        EXPECT_NEAR(1.0, transform[2][2], 1e-6);
+        EXPECT_NEAR(0.0, transform[2][3], 1e-6);
+        EXPECT_NEAR(8.0, transform[3][0], 1e-6);
+        EXPECT_NEAR(10.0, transform[3][1], 1e-6);
+        EXPECT_NEAR(12.0, transform[3][2], 1e-6);
+        EXPECT_NEAR(1.0, transform[3][3], 1e-6);
+    }
+}

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/AnimationTranslator.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/AnimationTranslator.cpp
@@ -286,6 +286,8 @@ MStatus AnimationCheckTransformAttributes::initialise()
     AL_MAYA_CHECK_ERROR(status, errorString);
     m_commonTransformAttributes[12] = transformNodeClass.attribute("rotateOrder", &status);
     AL_MAYA_CHECK_ERROR(status, errorString);
+    m_commonTransformAttributes[13] = transformNodeClass.attribute("offsetParentMatrix", &status);
+    AL_MAYA_CHECK_ERROR(status, errorString);
 
     m_inheritTransformAttribute = transformNodeClass.attribute("inheritsTransform", &status);
     AL_MAYA_CHECK_ERROR(status, errorString);

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/AnimationTranslator.h
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/AnimationTranslator.h
@@ -310,7 +310,7 @@ protected:
 class AnimationCheckTransformAttributes
 {
 private:
-    constexpr static int transformAttributesCount { 13 };
+    constexpr static int transformAttributesCount { 14 };
 
 public:
     AL_USDMAYA_UTILS_PUBLIC


### PR DESCRIPTION
This PR added consideration of offset parent matrix being part of the 'local space matrix' of a Maya node, since it's only needed for anim cache, note that there is no round-tripping support to/from Maya <-> USD.