### PR TITLE
MAYA-114603 persist USD payload state

### DIFF
--- a/lib/mayaUsd/listeners/notice.cpp
+++ b/lib/mayaUsd/listeners/notice.cpp
@@ -100,10 +100,12 @@ void UsdMayaSceneResetNotice::RemoveListener()
 
     if (_afterNewCallbackId != 0) {
         MMessage::removeCallback(_afterNewCallbackId);
+        _afterNewCallbackId = 0;
     }
 
-    if (_beforeFileReadCallbackId == 0) {
+    if (_beforeFileReadCallbackId != 0) {
         MMessage::removeCallback(_beforeFileReadCallbackId);
+        _beforeFileReadCallbackId = 0;
     }
 }
 

--- a/lib/mayaUsd/nodes/CMakeLists.txt
+++ b/lib/mayaUsd/nodes/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(${PROJECT_NAME}
         pointBasedDeformerNode.cpp
         proxyAccessor.cpp
         proxyShapeBase.cpp
+        proxyShapeLoadRules.cpp
         proxyShapePlugin.cpp
         stageData.cpp
         stageNode.cpp
@@ -18,6 +19,7 @@ set(HEADERS
     pointBasedDeformerNode.h
     proxyAccessor.h
     proxyShapeBase.h
+    proxyShapeLoadRules.h
     proxyShapePlugin.h
     proxyStageProvider.h
     stageData.h

--- a/lib/mayaUsd/nodes/proxyShapeLoadRules.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeLoadRules.cpp
@@ -1,0 +1,95 @@
+//
+// Copyright 2016 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "proxyShapeLoadRules.h"
+
+#include <mayaUsd/utils/loadRules.h>
+
+#include <maya/MSceneMessage.h>
+
+#include <set>
+
+namespace MAYAUSD_NS_DEF {
+
+namespace {
+
+using ProxyShapeSet = std::set<MayaUsdProxyShapeBase*>;
+
+MCallbackId beforeFileSaveCallbackId = 0;
+
+ProxyShapeSet& getTrackedProxyShapes()
+{
+    static ProxyShapeSet tracked;
+    return tracked;
+}
+
+void onMayaAboutToSave(void* /* unused */)
+{
+    ProxyShapeSet& tracked = getTrackedProxyShapes();
+    for (MayaUsdProxyShapeBase* proxyShape : tracked) {
+        if (!proxyShape)
+            continue;
+
+        auto stagePtr = proxyShape->getUsdStage();
+        if (!stagePtr)
+            continue;
+
+        MObject proxyObj = proxyShape->thisMObject();
+        if (proxyObj.isNull())
+            continue;
+
+        copyLoadRulesToAttribute(*stagePtr, proxyObj);
+    }
+}
+
+} // namespace
+
+/* static */
+MStatus MayaUsdProxyShapeLoadRules::initialize()
+{
+    MStatus status = MS::kSuccess;
+    if (beforeFileSaveCallbackId == 0) {
+        beforeFileSaveCallbackId = MSceneMessage::addCallback(
+            MSceneMessage::kBeforeSave, onMayaAboutToSave, nullptr, &status);
+    }
+    return status;
+}
+
+/* static */
+MStatus MayaUsdProxyShapeLoadRules::finalize()
+{
+    MStatus status = MS::kSuccess;
+
+    if (beforeFileSaveCallbackId != 0) {
+        status = MMessage::removeCallback(beforeFileSaveCallbackId);
+        beforeFileSaveCallbackId = 0;
+    }
+
+    return status;
+}
+
+/* static */
+void MayaUsdProxyShapeLoadRules::addProxyShape(MayaUsdProxyShapeBase& proxyShape)
+{
+    getTrackedProxyShapes().insert(&proxyShape);
+}
+
+/* static */
+void MayaUsdProxyShapeLoadRules::removeProxyShape(MayaUsdProxyShapeBase& proxyShape)
+{
+    getTrackedProxyShapes().erase(&proxyShape);
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/nodes/proxyShapeLoadRules.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeLoadRules.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2016 Pixar
+// Copyright 2022 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/mayaUsd/nodes/proxyShapeLoadRules.h
+++ b/lib/mayaUsd/nodes/proxyShapeLoadRules.h
@@ -1,0 +1,58 @@
+//
+// Copyright 2022 Pixar
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_PROXY_SHAPE_LOAD_RULES_H
+#define MAYAUSD_PROXY_SHAPE_LOAD_RULES_H
+
+#include <mayaUsd/base/api.h>
+#include <mayaUsd/nodes/proxyShapeBase.h>
+
+#include <pxr/pxr.h>
+#include <pxr/usd/usd/stage.h>
+
+#include <maya/MObject.h>
+
+namespace MAYAUSD_NS_DEF {
+
+/// \class MayaUsdProxyShapeLoadRules
+/// \brief Encapsulates plugin registration and deregistration for the load rules handling.
+///
+/// USD load rules are persisted on-disk in the proxy shape. We use a Maya callback
+/// triggered before a scene is saved to copy the current load rules from the stage
+/// to the proxy shape.
+
+class MayaUsdProxyShapeLoadRules
+{
+public:
+    /// \brief initialise by  registering the callbacks.
+    MAYAUSD_CORE_PUBLIC
+    static MStatus initialize();
+
+    /// \brief finalize by deregistering the callbacks.
+    MAYAUSD_CORE_PUBLIC
+    static MStatus finalize();
+
+    /// \brief add a proxy shape so that it will have its load rules saved and loaded.
+    MAYAUSD_CORE_PUBLIC
+    static void addProxyShape(MayaUsdProxyShapeBase& proxyShape);
+
+    /// \brief remove a proxy shape so that it will no longer have its load rules saved and loaded.
+    MAYAUSD_CORE_PUBLIC
+    static void removeProxyShape(MayaUsdProxyShapeBase& proxyShape);
+};
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif

--- a/lib/mayaUsd/nodes/proxyShapeLoadRules.h
+++ b/lib/mayaUsd/nodes/proxyShapeLoadRules.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Pixar
+// Copyright 2022 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/mayaUsd/nodes/proxyShapePlugin.cpp
+++ b/lib/mayaUsd/nodes/proxyShapePlugin.cpp
@@ -18,6 +18,7 @@
 #include <mayaUsd/nodes/hdImagingShape.h>
 #include <mayaUsd/nodes/pointBasedDeformerNode.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
+#include <mayaUsd/nodes/proxyShapeLoadRules.h>
 #include <mayaUsd/nodes/stageData.h>
 #include <mayaUsd/nodes/stageNode.h>
 #include <mayaUsd/render/pxrUsdMayaGL/hdImagingShapeDrawOverride.h>
@@ -158,6 +159,9 @@ MStatus MayaUsdProxyShapePlugin::initialize(MFnPlugin& plugin)
         PxrMayaHdImagingShapeDrawOverride::creator);
     CHECK_MSTATUS(status);
 
+    status = MAYAUSD_NS::MayaUsdProxyShapeLoadRules::initialize();
+    CHECK_MSTATUS(status);
+
     return status;
 }
 
@@ -180,6 +184,9 @@ MStatus MayaUsdProxyShapePlugin::finalize(MFnPlugin& plugin)
     }
 
     MStatus status = HdVP2ShaderFragments::deregisterFragments();
+    CHECK_MSTATUS(status);
+
+    status = MAYAUSD_NS::MayaUsdProxyShapeLoadRules::finalize();
     CHECK_MSTATUS(status);
 
     status = MHWRender::MDrawRegistry::deregisterDrawOverrideCreator(

--- a/lib/mayaUsd/utils/CMakeLists.txt
+++ b/lib/mayaUsd/utils/CMakeLists.txt
@@ -11,6 +11,8 @@ target_sources(${PROJECT_NAME}
         editability.cpp
         editRouter.cpp
         loadRules.cpp
+        loadRulesText.cpp
+        loadRulesAttribute.cpp
         query.cpp
         plugRegistryHelper.cpp
         selectability.cpp

--- a/lib/mayaUsd/utils/loadRules.h
+++ b/lib/mayaUsd/utils/loadRules.h
@@ -19,6 +19,10 @@
 #include <mayaUsd/base/api.h>
 
 #include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usd/stageLoadRules.h>
+
+#include <maya/MObject.h>
+#include <maya/MString.h>
 
 namespace MAYAUSD_NS_DEF {
 
@@ -35,6 +39,41 @@ void duplicateLoadRules(
  */
 MAYAUSD_CORE_PUBLIC
 void removeRulesForPath(PXR_NS::UsdStage& stage, const PXR_NS::SdfPath& path);
+
+/*! \brief convert the stage load rules to a text format.
+ */
+MAYAUSD_CORE_PUBLIC
+MString convertLoadRulesToText(const PXR_NS::UsdStage& stage);
+
+/*! \brief set the stage load rules from a text format.
+ */
+MAYAUSD_CORE_PUBLIC
+void setLoadRulesFromText(PXR_NS::UsdStage& stage, const MString& text);
+
+/*! \brief convert the load rules to a text format.
+ */
+MAYAUSD_CORE_PUBLIC
+MString convertLoadRulesToText(const PXR_NS::UsdStageLoadRules& rules);
+
+/*! \brief create load rules from a text format.
+ */
+MAYAUSD_CORE_PUBLIC
+PXR_NS::UsdStageLoadRules createLoadRulesFromText(const MString& text);
+
+/*! \brief verify if there is a dynamic attribute on the object for load rules.
+ */
+MAYAUSD_CORE_PUBLIC
+bool hasLoadRulesAttribute(const MObject& obj);
+
+/*! \brief copy the stage load rules in a dynamic attribute on the object.
+ */
+MAYAUSD_CORE_PUBLIC
+MStatus copyLoadRulesToAttribute(const PXR_NS::UsdStage& stage, MObject& obj);
+
+/*! \brief set the stage load rules from data in a dynamic attribute on the object.
+ */
+MAYAUSD_CORE_PUBLIC
+MStatus copyLoadRulesFromAttribute(const MObject& obj, PXR_NS::UsdStage& stage);
 
 } // namespace MAYAUSD_NS_DEF
 

--- a/lib/mayaUsd/utils/loadRulesAttribute.cpp
+++ b/lib/mayaUsd/utils/loadRulesAttribute.cpp
@@ -1,0 +1,134 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "loadRules.h"
+
+#include <maya/MCommandResult.h>
+#include <maya/MDGModifier.h>
+#include <maya/MFnDependencyNode.h>
+#include <maya/MFnTypedAttribute.h>
+#include <maya/MGlobal.h>
+#include <maya/MString.h>
+
+namespace MAYAUSD_NS_DEF {
+
+namespace {
+
+const char loadRulesAttrName[] = "usdStageLoadRules";
+
+bool hasLoadRulesAttribute(const MFnDependencyNode& depNode)
+{
+    MString nodeName = depNode.absoluteName();
+    MString cmd;
+    cmd.format("addAttr -query -exists \"^2s.^1s\"", loadRulesAttrName, nodeName);
+
+    int        result = 0;
+    const bool display = false;
+    const bool undoable = false;
+    MGlobal::executeCommand(cmd, result, display, undoable);
+
+    return result != 0;
+}
+
+MStatus createLoadRulesAttribute(const MFnDependencyNode& depNode)
+{
+    MStatus status = MS::kSuccess;
+
+    MString nodeName = depNode.absoluteName();
+    MString cmd;
+    cmd.format(
+        "addAttr -longName \"^1s\" -dataType \"string\" -hidden true -keyable false -writable true "
+        "-storable true \"^2s\";",
+        loadRulesAttrName,
+        nodeName);
+
+    const bool display = false;
+    const bool undoable = false;
+    status = MGlobal::executeCommand(cmd, display, undoable);
+
+    return status;
+}
+
+MStatus getLoadRulesAttribute(const MFnDependencyNode& depNode, MString& value)
+{
+    MStatus status = MS::kSuccess;
+
+    MString nodeName = depNode.absoluteName();
+    MString cmd;
+    cmd.format("getAttr \"^2s.^1s\";", loadRulesAttrName, nodeName);
+
+    const bool display = false;
+    const bool undoable = false;
+    status = MGlobal::executeCommand(cmd, value, display, undoable);
+
+    return status;
+}
+
+MStatus setLoadRulesAttribute(const MFnDependencyNode& depNode, const MString& value)
+{
+    MStatus status = MS::kSuccess;
+
+    MString nodeName = depNode.absoluteName();
+    MString cmd;
+    cmd.format("setAttr \"^2s.^1s\" -type \"string\" \"^3s\";", loadRulesAttrName, nodeName, value);
+
+    MString    result;
+    const bool display = false;
+    const bool undoable = false;
+    status = MGlobal::executeCommand(cmd, result, display, undoable);
+
+    return status;
+}
+
+} // namespace
+
+bool hasLoadRulesAttribute(const MObject& obj)
+{
+    return hasLoadRulesAttribute(MFnDependencyNode(obj));
+}
+
+MStatus copyLoadRulesToAttribute(const PXR_NS::UsdStage& stage, MObject& obj)
+{
+    MStatus status = MS::kSuccess;
+
+    MFnDependencyNode depNode(obj);
+    if (!hasLoadRulesAttribute(depNode))
+        createLoadRulesAttribute(depNode);
+
+    MString loadRulesText = convertLoadRulesToText(stage);
+
+    status = setLoadRulesAttribute(depNode, loadRulesText);
+
+    return status;
+}
+
+MStatus copyLoadRulesFromAttribute(const MObject& obj, PXR_NS::UsdStage& stage)
+{
+    MStatus status = MS::kSuccess;
+
+    MFnDependencyNode depNode(obj);
+    if (!hasLoadRulesAttribute(depNode))
+        return MS::kNotFound;
+
+    MString loadRulesText;
+    status = getLoadRulesAttribute(depNode, loadRulesText);
+    if (status == MS::kSuccess)
+        setLoadRulesFromText(stage, loadRulesText);
+
+    return status;
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/loadRulesText.cpp
+++ b/lib/mayaUsd/utils/loadRulesText.cpp
@@ -1,0 +1,108 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "loadRules.h"
+
+#include <maya/MStringArray.h>
+
+namespace MAYAUSD_NS_DEF {
+
+MString convertLoadRulesToText(const PXR_NS::UsdStage& stage)
+{
+    return convertLoadRulesToText(stage.GetLoadRules());
+}
+
+void setLoadRulesFromText(PXR_NS::UsdStage& stage, const MString& text)
+{
+    const auto newLoadRules = createLoadRulesFromText(text);
+    if (stage.GetLoadRules() != newLoadRules)
+        stage.SetLoadRules(newLoadRules);
+}
+
+static MString convertRuleToText(const PXR_NS::UsdStageLoadRules::Rule rule)
+{
+    // Note: using namespace required for the TF_WARN macro.
+    using namespace PXR_NS;
+
+    switch (rule) {
+    case UsdStageLoadRules::AllRule: return "all";
+    case UsdStageLoadRules::OnlyRule: return "only";
+    case UsdStageLoadRules::NoneRule: return "none";
+    default: TF_WARN("convert rule to text: invalid rule: %d", (int)rule); return "all";
+    }
+}
+
+static MString
+convertPerPathRuleToText(const PXR_NS::SdfPath& path, const PXR_NS::UsdStageLoadRules::Rule rule)
+{
+    MString text;
+    text.format("^1s=^2s", path.GetAsString().c_str(), convertRuleToText(rule));
+    return text;
+}
+
+MString convertLoadRulesToText(const PXR_NS::UsdStageLoadRules& rules)
+{
+    MString text;
+
+    const auto& perPathRules = rules.GetRules();
+    for (const auto& pathAndRule : perPathRules) {
+        if (text.length() > 0)
+            text += ";";
+
+        text += convertPerPathRuleToText(pathAndRule.first, pathAndRule.second);
+    }
+
+    return text;
+}
+
+static PXR_NS::UsdStageLoadRules::Rule createRuleFromText(const MString& text)
+{
+    // Note: using namespace required for the TF_WARN macro.
+    using namespace PXR_NS;
+
+    if (text == "all")
+        return UsdStageLoadRules::AllRule;
+    if (text == "only")
+        return UsdStageLoadRules::OnlyRule;
+    if (text == "none")
+        return UsdStageLoadRules::NoneRule;
+
+    TF_WARN("Convert text to rule: invalid rule: %s", text.asChar());
+    return PXR_NS::UsdStageLoadRules::AllRule;
+}
+
+PXR_NS::UsdStageLoadRules createLoadRulesFromText(const MString& text)
+{
+    PXR_NS::UsdStageLoadRules rules;
+
+    MStringArray perPathRules;
+    text.split(';', perPathRules);
+    for (const auto& item : perPathRules) {
+        MStringArray pathAndRule;
+        item.split('=', pathAndRule);
+        if (pathAndRule.length() != 2)
+            continue;
+
+        auto path = PXR_NS::SdfPath(pathAndRule[0].asChar());
+        auto rule = createRuleFromText(pathAndRule[1]);
+
+        rules.AddRule(path, rule);
+    }
+
+    return rules;
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/test/lib/mayaUsd/utils/CMakeLists.txt
+++ b/test/lib/mayaUsd/utils/CMakeLists.txt
@@ -1,3 +1,7 @@
+# -----------------------------------------------------------------------------
+# Python unit tests
+# -----------------------------------------------------------------------------
+
 set(TEST_SCRIPT_FILES
     testBlockSceneModificationContext.py
     testDiagnosticDelegate.py
@@ -39,3 +43,65 @@ foreach(script ${INTERACTIVE_TEST_SCRIPT_FILES})
     # Add a ctest label to these tests for easy filtering.
     set_property(TEST ${target} APPEND PROPERTY LABELS utils)
 endforeach()
+
+
+# -----------------------------------------------------------------------------
+# C++ unit tests
+# -----------------------------------------------------------------------------
+
+function(add_mayaUsdLibUtils_test TARGET_NAME)
+    add_executable(${TARGET_NAME})
+
+    # -----------------------------------------------------------------------------
+    # sources
+    # -----------------------------------------------------------------------------
+    target_sources(${TARGET_NAME}
+        PRIVATE
+            main.cpp
+            ${ARGN}
+    )
+
+    # -----------------------------------------------------------------------------
+    # compiler configuration
+    # -----------------------------------------------------------------------------
+    mayaUsd_compile_config(${TARGET_NAME})
+
+    target_compile_definitions(${TARGET_NAME}
+        PRIVATE
+            $<$<STREQUAL:${CMAKE_BUILD_TYPE},Debug>:TBB_USE_DEBUG>
+            $<$<STREQUAL:${CMAKE_BUILD_TYPE},Debug>:BOOST_DEBUG_PYTHON>
+            $<$<STREQUAL:${CMAKE_BUILD_TYPE},Debug>:BOOST_LINKING_PYTHON>
+    )
+
+    # -----------------------------------------------------------------------------
+    # link libraries
+    # -----------------------------------------------------------------------------
+    target_link_libraries(${TARGET_NAME}
+        PRIVATE 
+            GTest::GTest
+            mayaUsdUtils
+            ${MAYA_LIBRARIES}
+            mayaUsd
+    )
+
+    # -----------------------------------------------------------------------------
+    # unit tests
+    # -----------------------------------------------------------------------------
+    mayaUsd_add_test(${TARGET_NAME}
+        COMMAND $<TARGET_FILE:${TARGET_NAME}>
+        ENV
+            "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
+            "MAYA_LOCATION=${MAYA_LOCATION}"
+    )
+endfunction()
+
+if(IS_WINDOWS)
+    # There are link problems on Linux and OSX with C++ test using USD + Maya,
+    # so only run the test on Windows. The code is not platform-specific anwyay,
+    # testing on Windows is sufficient.
+    add_mayaUsdLibUtils_test(
+        testLoadRules
+        testLoadRules.cpp
+    )
+endif()
+

--- a/test/lib/mayaUsd/utils/main.cpp
+++ b/test/lib/mayaUsd/utils/main.cpp
@@ -1,0 +1,7 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/lib/mayaUsd/utils/testLoadRules.cpp
+++ b/test/lib/mayaUsd/utils/testLoadRules.cpp
@@ -1,0 +1,61 @@
+#include <mayaUsd/utils/loadRules.h>
+
+#include <gtest/gtest.h>
+
+using namespace PXR_NS;
+using namespace MAYAUSD_NS_DEF;
+
+TEST(ConvertLoadRules, convertEmptyLoadRules)
+{
+    UsdStageLoadRules originalLoadRules;
+
+    const MString text = convertLoadRulesToText(originalLoadRules);
+
+    UsdStageLoadRules convertedLoadRules = createLoadRulesFromText(text);
+
+    EXPECT_EQ(originalLoadRules, convertedLoadRules);
+}
+
+TEST(ConvertLoadRules, convertSimpleLoadRules)
+{
+    UsdStageLoadRules originalLoadRules;
+    originalLoadRules.AddRule(SdfPath("/a/b/c"), UsdStageLoadRules::AllRule);
+    originalLoadRules.AddRule(SdfPath("/a/b"), UsdStageLoadRules::NoneRule);
+    originalLoadRules.AddRule(SdfPath("/d"), UsdStageLoadRules::OnlyRule);
+
+    const MString text = convertLoadRulesToText(originalLoadRules);
+
+    UsdStageLoadRules convertedLoadRules = createLoadRulesFromText(text);
+
+    EXPECT_EQ(originalLoadRules, convertedLoadRules);
+}
+
+TEST(ConvertLoadRules, convertEmptyStageLoadRules)
+{
+    auto originalStage = UsdStage::CreateInMemory();
+
+    const MString text = convertLoadRulesToText(*originalStage);
+
+    auto convertedStage = UsdStage::CreateInMemory();
+    setLoadRulesFromText(*convertedStage, text);
+
+    EXPECT_EQ(originalStage->GetLoadRules(), convertedStage->GetLoadRules());
+}
+
+TEST(ConvertLoadRules, convertSimpleStageLoadRules)
+{
+    UsdStageLoadRules originalLoadRules;
+    originalLoadRules.AddRule(SdfPath("/a/b/c"), UsdStageLoadRules::AllRule);
+    originalLoadRules.AddRule(SdfPath("/a/b"), UsdStageLoadRules::NoneRule);
+    originalLoadRules.AddRule(SdfPath("/d"), UsdStageLoadRules::OnlyRule);
+    originalLoadRules.AddRule(SdfPath("/d/e"), UsdStageLoadRules::AllRule);
+    auto originalStage = UsdStage::CreateInMemory();
+    originalStage->SetLoadRules(originalLoadRules);
+
+    const MString text = convertLoadRulesToText(*originalStage);
+
+    auto convertedStage = UsdStage::CreateInMemory();
+    setLoadRulesFromText(*convertedStage, text);
+
+    EXPECT_EQ(originalStage->GetLoadRules(), convertedStage->GetLoadRules());
+}


### PR DESCRIPTION
Load rules conversions

- Add functions to convert the USD stage load rules into text and back.
- Add function to save/load load rules on a dynamic Maya attribute.
- Add unit tests for the text conversions.
- Only run load rules unit test on Windows.
- Other platforms have linker or run-time link problems with Cg and OpenMaya.

Load rules persistence

- Add a class to handle the persistence.
- It keeps a list of proxy shape that need to be updated before being saved
- Listen to kBeforeSave Maya message and transfers the load rules to the proxy stage.
- Each proxy shape registers with this class.
- The proxy shape applies the persisted load rules on load if present.
- Implemented the persistence using dynamic attributes.
- Since there won't be a ton of them, use MEL as it is more robust and simpler.

Others

- Fix a bug in UsdMayaSceneResetNotice.