### PR TITLE
MAYA-122124 avoid errors in marking menu

### DIFF
--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -184,9 +184,8 @@ UsdPrim ufePathToPrim(const Ufe::Path& path)
 
     const Ufe::Path::Segments& segments = ufePrimPath.getSegments();
     auto                       stage = getStage(Ufe::Path(segments[0]));
-    if (!TF_VERIFY(stage, kIllegalUSDPath, path.string().c_str())) {
+    if (!stage)
         return UsdPrim();
-    }
 
     // If there is only a single segment in the path, it must point to the
     // proxy shape, otherwise we would not have retrieved a valid stage.


### PR DESCRIPTION
The function used to try to convert a UFE path to a USD prim prints assertion when the path is not to a USD prim. Caller need to check if the prim is valid anyway, so don't cause spurious, unconditional errors to get printed.