### PR TITLE
Fix cotd preflights image comparison failures

### DIFF
--- a/test/testUtils/imageUtils.py
+++ b/test/testUtils/imageUtils.py
@@ -2,6 +2,7 @@ import os
 import unittest
 
 import maya.cmds as cmds
+import maya.mel
 
 import testUtils
 import mayaUtils
@@ -19,6 +20,10 @@ KNOWN_FORMATS = {
     'png': 32,
 }
 
+"""If the current Maya version supports setting the default light intensity,
+    then restore it to 1 so snapshots look equal across versions."""
+if maya.mel.eval("optionVar -exists defaultLightIntensity"):
+    maya.mel.eval("optionVar -fv defaultLightIntensity 1")
 
 def snapshot(outputPath, width=400, height=None, hud=False, grid=False, camera=None):
     if height is None:


### PR DESCRIPTION
The default light intensity can be tuned in cotd and the default value
causes image comparison failures. Bring it back to pre-cotd values so
image comparisons work across the versions.