### PR TITLE
[al] Add support for default rgba values and color threshold for exporting

### DIFF
--- a/plugin/al/mayautils/AL/maya/utils/PluginTranslatorOptions.cpp
+++ b/plugin/al/mayautils/AL/maya/utils/PluginTranslatorOptions.cpp
@@ -157,11 +157,11 @@ bool PluginTranslatorOptions::addFloat(
     float       value,
     int         precision,
     const char* controller,
-    bool        state)
+    bool        enableState)
 {
     if (isOption(optionName))
         return false;
-    m_options.emplace_back(optionName, value, precision, controller, state);
+    m_options.emplace_back(optionName, value, precision, controller, enableState);
     return true;
 }
 
@@ -560,14 +560,14 @@ void PluginTranslatorOptions::generateIntGlobals(
 
 //----------------------------------------------------------------------------------------------------------------------
 void PluginTranslatorOptions::generateFloatGlobals(
-    const char* const  prefix,
-    const MString&     niceName,
-    const MString&     optionName,
-    MString&           code,
-    float              value,
-    int                precision,
-    const std::string& controller,
-    bool               enableState)
+    const char* const prefix,
+    const MString&    niceName,
+    const MString&    optionName,
+    MString&          code,
+    float             value,
+    int               precision,
+    const MString&    controller,
+    bool              enableState)
 {
     MString valueStr;
     valueStr = value;
@@ -576,8 +576,8 @@ void PluginTranslatorOptions::generateFloatGlobals(
     MString onOffCmd;
     MString postUpdateCmd;
     MString deferredPostUpdateCmd;
-    if (!controller.empty()) {
-        MString prefixedCtrl(MString(prefix) + "_" + makeName(controller.c_str()));
+    if (controller.length()) {
+        MString prefixedCtrl(MString(prefix) + "_" + makeName(controller));
         if (enableState) {
             onOffCmd = "checkBox -e "
                        "-onCommand \"floatFieldGrp -e -en 1 "

--- a/plugin/al/mayautils/AL/maya/utils/PluginTranslatorOptions.h
+++ b/plugin/al/mayautils/AL/maya/utils/PluginTranslatorOptions.h
@@ -322,7 +322,7 @@ public:
     /// \param  value the default value for the option
     /// \param  precision the default precision for the option
     /// \param  controller the controller UI name that triggers enabling
-    /// \param  state the state for enabling this field
+    /// \param  enableState the state for enabling this field
     /// \return true if the option was successfully added. False if the option is a duplicate
     AL_MAYA_UTILS_PUBLIC
     bool addFloat(
@@ -330,7 +330,7 @@ public:
         float       value,
         int         precision,
         const char* controller,
-        bool        state);
+        bool        enableState);
 
     /// \brief  Add a string value to the translator options
     /// \param  optionName the name of the option
@@ -411,7 +411,7 @@ public:
         std::vector<MString> enumStrings; ///< the text values for the enums
         OptionType           type;        ///< the type of the option
         int                  precision { 1 };
-        std::string          controller {};
+        MString              controller {};
         bool                 enableState { true };
 
         /// \brief  ctor
@@ -437,17 +437,20 @@ public:
         /// \brief  ctor
         /// \param  name the name of the option
         /// \param  defVal the default value
+        /// \param  precision the default precision for the option
+        /// \param  controller the controller UI name that triggers enabling
+        /// \param  enableState the state for enabling this field
         Option(
             const char* const name,
             const float&      defVal,
-            int               defPre,
-            const char*       defController,
-            bool              defState)
+            int               precision,
+            const char*       controller,
+            bool              enableState)
             : name(name)
             , type(OptionType::kFloat)
-            , precision(defPre)
-            , controller(defController ? defController : "")
-            , enableState(defState)
+            , precision(precision)
+            , controller(controller ? controller : "")
+            , enableState(enableState)
         {
             defFloat = defVal;
         }
@@ -514,10 +517,10 @@ private:
         const MString&    niceName,
         const MString&    optionName,
         MString&          code,
-        float,
-        int,
-        const std::string&,
-        bool);
+        float             value,
+        int               precision,
+        const MString&    controller,
+        bool              enableState);
     static void generateStringGlobals(
         const char* const prefix,
         const MString&    niceName,

--- a/plugin/al/mayautils/AL/maya/utils/PluginTranslatorOptions.h
+++ b/plugin/al/mayautils/AL/maya/utils/PluginTranslatorOptions.h
@@ -309,6 +309,29 @@ public:
     AL_MAYA_UTILS_PUBLIC
     bool addFloat(const char* optionName, float defaultValue = 0.0f);
 
+    /// \brief  Add a float value with precision to the translator options
+    /// \param  optionName the name of the option
+    /// \param  value the default value for the option
+    /// \param  precision the default precision for the option
+    /// \return true if the option was successfully added. False if the option is a duplicate
+    AL_MAYA_UTILS_PUBLIC
+    bool addFloat(const char* optionName, float value, int precision);
+
+    /// \brief  Add a float value with precision and controller state to the translator options
+    /// \param  optionName the name of the option
+    /// \param  value the default value for the option
+    /// \param  precision the default precision for the option
+    /// \param  controller the controller UI name that triggers enabling
+    /// \param  state the state for enabling this field
+    /// \return true if the option was successfully added. False if the option is a duplicate
+    AL_MAYA_UTILS_PUBLIC
+    bool addFloat(
+        const char* optionName,
+        float       value,
+        int         precision,
+        const char* controller,
+        bool        state);
+
     /// \brief  Add a string value to the translator options
     /// \param  optionName the name of the option
     /// \param  defaultValue the default value for the option
@@ -387,6 +410,9 @@ public:
         MString              defString;   ///< default string value
         std::vector<MString> enumStrings; ///< the text values for the enums
         OptionType           type;        ///< the type of the option
+        int                  precision { 1 };
+        std::string          controller {};
+        bool                 enableState { true };
 
         /// \brief  ctor
         /// \param  name the name of the option
@@ -411,9 +437,17 @@ public:
         /// \brief  ctor
         /// \param  name the name of the option
         /// \param  defVal the default value
-        Option(const char* const name, const float& defVal)
+        Option(
+            const char* const name,
+            const float&      defVal,
+            int               defPre,
+            const char*       defController,
+            bool              defState)
             : name(name)
             , type(OptionType::kFloat)
+            , precision(defPre)
+            , controller(defController ? defController : "")
+            , enableState(defState)
         {
             defFloat = defVal;
         }
@@ -480,7 +514,10 @@ private:
         const MString&    niceName,
         const MString&    optionName,
         MString&          code,
-        float);
+        float,
+        int,
+        const std::string&,
+        bool);
     static void generateStringGlobals(
         const char* const prefix,
         const MString&    niceName,

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/AL/usdmaya/test_DiffPrimVar.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/AL/usdmaya/test_DiffPrimVar.cpp
@@ -171,67 +171,66 @@ TEST(DiffPrimVar, diffGeomExtent)
 
 TEST(DiffPrimVar, diffGeomRGBA)
 {
-  MFileIO::newFile(true);
-  MStringArray result;
-  ASSERT_TRUE(MGlobal::executeCommand("polyCube -w 1 -h 1 -d 1 -sx 1 -sy 1 -sz 1 -ax 0 1 0 -cuv 4 -ch 1;;", result) == MS::kSuccess);
-  ASSERT_TRUE(MGlobal::executeCommand("setAttr \"pCubeShape1.displayColors\" 1;") == MS::kSuccess);
+    MFileIO::newFile(true);
+    MStringArray result;
+    ASSERT_TRUE(
+        MGlobal::executeCommand(
+            "polyCube -w 1 -h 1 -d 1 -sx 1 -sy 1 -sz 1 -ax 0 1 0 -cuv 4 -ch 1;;", result)
+        == MS::kSuccess);
+    ASSERT_TRUE(
+        MGlobal::executeCommand("setAttr \"pCubeShape1.displayColors\" 1;") == MS::kSuccess);
 
-  MSelectionList mSel;
-  EXPECT_TRUE(mSel.add("pCube1")  == MS::kSuccess);
+    MSelectionList mSel;
+    EXPECT_TRUE(mSel.add("pCube1") == MS::kSuccess);
 
-  MDagPath mDagPath;
-  mSel.getDagPath(0, mDagPath);
-  MFnMesh mFnMesh(mDagPath);
-  mFnMesh.createColorSetWithName("displayColor");
+    MDagPath mDagPath;
+    mSel.getDagPath(0, mDagPath);
+    MFnMesh mFnMesh(mDagPath);
+    mFnMesh.createColorSetWithName("displayColor");
 
-  // Set one polyCube face color to blue and the alpha to 1
-  MColor blueColour(0.0f, 0.0f, 1.0f, 1.0f);
-  mFnMesh.setFaceColor(blueColour, 4);
+    // Set one polyCube face color to blue and the alpha to 1
+    MColor blueColour(0.0f, 0.0f, 1.0f, 1.0f);
+    mFnMesh.setFaceColor(blueColour, 4);
 
-  // Run export comand
-  auto tempPath = buildTempPath("AL_USDMayaTests_diffRGBA.usda");
-  std::string exportCommand = R"(
+    // Run export comand
+    auto        tempPath = buildTempPath("AL_USDMayaTests_diffRGBA.usda");
+    std::string exportCommand = R"(
     file -force -options "Dynamic_Attributes=1;Duplicate_Instances=1;Merge_Transforms=1;Animation=0;Use_Timeline_Range=0;Frame_Min=0;Frame_Max=1;Sub_Samples=1;Filter_Sample=0;Export_At_Which_Time=0;Export_In_World_Space=0;Activate_all_Plugin_Translators=1;Active_Translator_List=;Inactive_Translator_List=;Nurbs_Curves=1;Meshes=1;Mesh_Face_Connects=1;Mesh_Points=1;Mesh_Extents=1;Mesh_Normals=1;Mesh_Vertex_Creases=1;Mesh_Edge_Creases=1;Mesh_UVs=1;Mesh_UV_Only=0;Mesh_Points_as_PRef=0;Mesh_Colours=1;Default_RGB=0.2;Default_Alpha=1;Mesh_Holes=1;Write_Normals_as_Primvars=0;Reverse_Opposite_Normals=0;Subdivision_scheme=0;Compaction_Level=3;" -type "AL usdmaya export" -pr -ea
   )";
-  exportCommand += "\"";
-  exportCommand += tempPath;
-  exportCommand += "\"";
-  ASSERT_TRUE(MGlobal::executeCommand(exportCommand.c_str()) == MS::kSuccess);
+    exportCommand += "\"";
+    exportCommand += tempPath;
+    exportCommand += "\"";
+    ASSERT_TRUE(MGlobal::executeCommand(exportCommand.c_str()) == MS::kSuccess);
 
-  // Validate export
-  UsdStageRefPtr stage = UsdStage::Open(tempPath);
+    // Validate export
+    UsdStageRefPtr stage = UsdStage::Open(tempPath);
 
-  MString path = MString("/pCube1");
-  SdfPath primPath(path.asChar());
-  UsdPrim geomPrim = stage->GetPrimAtPath(primPath);
-  ASSERT_TRUE(geomPrim.IsValid());
-  UsdGeomMesh geom(geomPrim);
+    MString path = MString("/pCube1");
+    SdfPath primPath(path.asChar());
+    UsdPrim geomPrim = stage->GetPrimAtPath(primPath);
+    ASSERT_TRUE(geomPrim.IsValid());
+    UsdGeomMesh geom(geomPrim);
 
-  // Confirm displayOpacity is 1.0
-  const TfToken displayOpacityToken("primvars:displayOpacity");
-  UsdAttribute opacityAttribute = geomPrim.GetAttribute(displayOpacityToken);
+    // Confirm displayOpacity is 1.0
+    const TfToken displayOpacityToken("primvars:displayOpacity");
+    UsdAttribute  opacityAttribute = geomPrim.GetAttribute(displayOpacityToken);
 
-  VtFloatArray opacity;
-  opacityAttribute.Get(&opacity);
-  VtFloatArray expectedOpacity { 1.f, 1.f, 1.f, 1.f, 1.f, 1.f};
-  EXPECT_EQ(opacity, expectedOpacity);
+    VtFloatArray opacity;
+    opacityAttribute.Get(&opacity);
+    VtFloatArray expectedOpacity { 1.f, 1.f, 1.f, 1.f, 1.f, 1.f };
+    EXPECT_EQ(opacity, expectedOpacity);
 
-  // Confirm displayColor has been applied
-  const TfToken displayColorToken("primvars:displayColor");
-  UsdAttribute colorAttribute = geomPrim.GetAttribute(displayColorToken);
+    // Confirm displayColor has been applied
+    const TfToken displayColorToken("primvars:displayColor");
+    UsdAttribute  colorAttribute = geomPrim.GetAttribute(displayColorToken);
 
-  VtVec3fArray color;
-  colorAttribute.Get(&color);
-  VtVec3fArray expectedColor {
-    GfVec3f(0.2f),
-    GfVec3f(0.2f),
-    GfVec3f(0.2f),
-    GfVec3f(0.2f),
-    GfVec3f(0.f, 0.f, 1.f),
-    GfVec3f(0.2f),
-  };
-  EXPECT_EQ(color, expectedColor);
-
+    VtVec3fArray color;
+    colorAttribute.Get(&color);
+    VtVec3fArray expectedColor {
+        GfVec3f(0.2f), GfVec3f(0.2f),          GfVec3f(0.2f),
+        GfVec3f(0.2f), GfVec3f(0.f, 0.f, 1.f), GfVec3f(0.2f),
+    };
+    EXPECT_EQ(color, expectedColor);
 }
 
 TEST(DiffPrimVar, diffGeomNormals)

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/test_translators_MeshTranslator.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/test_translators_MeshTranslator.cpp
@@ -1209,7 +1209,7 @@ TEST(translators_MeshTranslator, colourThresholdExportWithBasicCompaction)
     }
 }
 
-/// \brief  Test exporting mesh with color threshold value and compaction 1 (basic level)
+/// \brief  Test exporting mesh with color threshold value and compaction 3 (extensive level)
 ///         Internally the test would call DiffPrimVar::guessColourSetInterpolationTypeExtensive()
 TEST(translators_MeshTranslator, colourThresholdExportWithFullCompaction)
 {

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/test_translators_MeshTranslator.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/test_translators_MeshTranslator.cpp
@@ -1066,6 +1066,220 @@ TEST(translators_MeshTranslator, faceVaryingColourExport)
     }
 };
 
+/// \brief  Test exporting mesh with color threshold value and compaction 0 (none)
+///         Internally the test does not do any compaction at all
+TEST(translators_MeshTranslator, colourThresholdExportWithNoCompaction)
+{
+    MFileIO::newFile(true);
+
+    // create a cube, and assign a colour set of the same value
+    MString command = "polyCube -w 1 -h 1 -d 1 -sx 1 -sy 1 -sz 1 -ax 0 1 0 -cuv 2 -ch 1;";
+    MGlobal::executeCommand(command);
+
+    MSelectionList sl;
+    sl.add("pCubeShape1");
+    MObject obj;
+    sl.getDependNode(0, obj);
+
+    MFnMesh fn(obj);
+    MString name = fn.createColorSetWithName("test");
+
+    // Add a tiny difference on the R channel for all face vertices
+    {
+        MIntArray counts, indices;
+        fn.getVertices(counts, indices);
+
+        MColorArray colours;
+        colours.setLength(24);
+        indices.setLength(24);
+        for (int i = 0; i < 24; i++) {
+            colours[i] = MColor(0.001 + 0.00001f * i, 0.4f, 0.5f, 1.0f);
+            indices[i] = i;
+        }
+        fn.setColors(colours, &name);
+        fn.assignColors(indices, &name);
+    }
+
+    const MString temp_path = buildTempPath("AL_USDMayaTests_colourThresholdExport.usda");
+
+    // export with threshold value 0.001
+    MGlobal::executeCommand(
+        MString(
+            "select -r pCube1;"
+            "file -force -options "
+            "\"Dynamic_Attributes=0;Meshes=1;Mesh_Normals=1;Nurbs_Curves=1;Duplicate_Instances=1;"
+            "Merge_Transforms=1;Animation=0;Use_Timeline_Range=0;Frame_Min=1;Frame_Max=50;Filter_"
+            "Sample=0;"
+            "Compaction_Level=0;Custom_Colour_Threshold=1;Colour_Threshold_Value=0.001;"
+            "\" -typ \"AL usdmaya export\" -pr -es \"")
+        + temp_path + "\";");
+
+    {
+        UsdStageRefPtr stage = UsdStage::Open(temp_path.asChar());
+        ASSERT_TRUE(stage);
+
+        UsdPrim prim = stage->GetPrimAtPath(SdfPath("/pCube1"));
+        ASSERT_TRUE(prim);
+
+        UsdGeomMesh mesh(prim);
+        auto        pvar = getDefaultColourSet(mesh);
+        ASSERT_TRUE(pvar);
+        EXPECT_EQ(UsdGeomTokens->faceVarying, pvar.GetInterpolation());
+
+        VtArray<GfVec4f> received;
+        pvar.Get(&received);
+        ASSERT_EQ(24u, received.size());
+        for (int i = 0; i < 24; ++i) {
+            EXPECT_NEAR(0.001 + 0.00001f * i, received[i][0], 1e-5f);
+            EXPECT_NEAR(0.4f, received[i][1], 1e-5f);
+            EXPECT_NEAR(0.5f, received[i][2], 1e-5f);
+            EXPECT_NEAR(1.0f, received[i][3], 1e-5f);
+        }
+    }
+}
+
+/// \brief  Test exporting mesh with color threshold value and compaction 1 (basic level)
+///         Internally the test would call DiffPrimVar::guessColourSetInterpolationType()
+TEST(translators_MeshTranslator, colourThresholdExportWithBasicCompaction)
+{
+    MFileIO::newFile(true);
+
+    // create a cube, and assign a colour set of the same value
+    MString command = "polyCube -w 1 -h 1 -d 1 -sx 1 -sy 1 -sz 1 -ax 0 1 0 -cuv 2 -ch 1;";
+    MGlobal::executeCommand(command);
+
+    MSelectionList sl;
+    sl.add("pCubeShape1");
+    MObject obj;
+    sl.getDependNode(0, obj);
+
+    MFnMesh fn(obj);
+    MString name = fn.createColorSetWithName("test");
+
+    // Add a tiny difference on the R channel for all face vertices
+    {
+        MIntArray counts, indices;
+        fn.getVertices(counts, indices);
+
+        MColorArray colours;
+        colours.setLength(24);
+        indices.setLength(24);
+        for (int i = 0; i < 24; i++) {
+            colours[i] = MColor(0.001 + 0.00001f * i, 0.4f, 0.5f, 1.0f);
+            indices[i] = i;
+        }
+        fn.setColors(colours, &name);
+        fn.assignColors(indices, &name);
+    }
+
+    const MString temp_path = buildTempPath("AL_USDMayaTests_colourThresholdExport.usda");
+
+    // export with threshold value 0.001
+    MGlobal::executeCommand(
+        MString(
+            "select -r pCube1;"
+            "file -force -options "
+            "\"Dynamic_Attributes=0;Meshes=1;Mesh_Normals=1;Nurbs_Curves=1;Duplicate_Instances=1;"
+            "Merge_Transforms=1;Animation=0;Use_Timeline_Range=0;Frame_Min=1;Frame_Max=50;Filter_"
+            "Sample=0;"
+            "Compaction_Level=1;Custom_Colour_Threshold=1;Colour_Threshold_Value=0.001;"
+            "\" -typ \"AL usdmaya export\" -pr -es \"")
+        + temp_path + "\";");
+
+    {
+        UsdStageRefPtr stage = UsdStage::Open(temp_path.asChar());
+        ASSERT_TRUE(stage);
+
+        UsdPrim prim = stage->GetPrimAtPath(SdfPath("/pCube1"));
+        ASSERT_TRUE(prim);
+
+        UsdGeomMesh mesh(prim);
+        auto        pvar = getDefaultColourSet(mesh);
+        ASSERT_TRUE(pvar);
+        EXPECT_EQ(UsdGeomTokens->constant, pvar.GetInterpolation());
+
+        VtArray<GfVec4f> received;
+        pvar.Get(&received);
+        ASSERT_EQ(1u, received.size());
+
+        EXPECT_NEAR(0.001f, received[0][0], 1e-5f);
+        EXPECT_NEAR(0.4f, received[0][1], 1e-5f);
+        EXPECT_NEAR(0.5f, received[0][2], 1e-5f);
+        EXPECT_NEAR(1.0f, received[0][3], 1e-5f);
+    }
+}
+
+/// \brief  Test exporting mesh with color threshold value and compaction 1 (basic level)
+///         Internally the test would call DiffPrimVar::guessColourSetInterpolationTypeExtensive()
+TEST(translators_MeshTranslator, colourThresholdExportWithFullCompaction)
+{
+    MFileIO::newFile(true);
+
+    // create a cube, and assign a colour set of the same value
+    MString command = "polyCube -w 1 -h 1 -d 1 -sx 1 -sy 1 -sz 1 -ax 0 1 0 -cuv 2 -ch 1;";
+    MGlobal::executeCommand(command);
+
+    MSelectionList sl;
+    sl.add("pCubeShape1");
+    MObject obj;
+    sl.getDependNode(0, obj);
+
+    MFnMesh fn(obj);
+    MString name = fn.createColorSetWithName("test");
+
+    // Add a tiny difference on the R channel for all face vertices
+    {
+        MIntArray counts, indices;
+        fn.getVertices(counts, indices);
+
+        MColorArray colours;
+        colours.setLength(24);
+        indices.setLength(24);
+        for (int i = 0; i < 24; i++) {
+            colours[i] = MColor(0.001 + 0.00001f * i, 0.4f, 0.5f, 1.0f);
+            indices[i] = i;
+        }
+        fn.setColors(colours, &name);
+        fn.assignColors(indices, &name);
+    }
+
+    const MString temp_path = buildTempPath("AL_USDMayaTests_colourThresholdExport.usda");
+
+    // export with threshold value 0.001
+    MGlobal::executeCommand(
+        MString(
+            "select -r pCube1;"
+            "file -force -options "
+            "\"Dynamic_Attributes=0;Meshes=1;Mesh_Normals=1;Nurbs_Curves=1;Duplicate_Instances=1;"
+            "Merge_Transforms=1;Animation=0;Use_Timeline_Range=0;Frame_Min=1;Frame_Max=50;Filter_"
+            "Sample=0;"
+            "Compaction_Level=3;Custom_Colour_Threshold=1;Colour_Threshold_Value=0.001;"
+            "\" -typ \"AL usdmaya export\" -pr -es \"")
+        + temp_path + "\";");
+
+    {
+        UsdStageRefPtr stage = UsdStage::Open(temp_path.asChar());
+        ASSERT_TRUE(stage);
+
+        UsdPrim prim = stage->GetPrimAtPath(SdfPath("/pCube1"));
+        ASSERT_TRUE(prim);
+
+        UsdGeomMesh mesh(prim);
+        auto        pvar = getDefaultColourSet(mesh);
+        ASSERT_TRUE(pvar);
+        EXPECT_EQ(UsdGeomTokens->constant, pvar.GetInterpolation());
+
+        VtArray<GfVec4f> received;
+        pvar.Get(&received);
+        ASSERT_EQ(1u, received.size());
+
+        EXPECT_NEAR(0.001f, received[0][0], 1e-5f);
+        EXPECT_NEAR(0.4f, received[0][1], 1e-5f);
+        EXPECT_NEAR(0.5f, received[0][2], 1e-5f);
+        EXPECT_NEAR(1.0f, received[0][3], 1e-5f);
+    }
+}
+
 TEST(translators_MeshTranslator, reverseNormalsFlag)
 {
     MFileIO::newFile(true);

--- a/plugin/al/translators/CommonTranslatorOptions.cpp
+++ b/plugin/al/translators/CommonTranslatorOptions.cpp
@@ -45,6 +45,8 @@ void registerCommonTranslatorOptions()
         g_exportOptions->addBool(GeometryExportOptions::kMeshUvOnly, false);
         g_exportOptions->addBool(GeometryExportOptions::kMeshPointsAsPref, false);
         g_exportOptions->addBool(GeometryExportOptions::kMeshColours, true);
+        g_exportOptions->addFloat(GeometryExportOptions::kMeshDefaultColourRGB, 0.18);
+        g_exportOptions->addFloat(GeometryExportOptions::kMeshDefaultColourA, 1.0);
         g_exportOptions->addBool(GeometryExportOptions::kMeshHoles, true);
         g_exportOptions->addBool(GeometryExportOptions::kNormalsAsPrimvars, false);
         g_exportOptions->addBool(GeometryExportOptions::kReverseOppositeNormals, false);

--- a/plugin/al/translators/CommonTranslatorOptions.cpp
+++ b/plugin/al/translators/CommonTranslatorOptions.cpp
@@ -45,8 +45,15 @@ void registerCommonTranslatorOptions()
         g_exportOptions->addBool(GeometryExportOptions::kMeshUvOnly, false);
         g_exportOptions->addBool(GeometryExportOptions::kMeshPointsAsPref, false);
         g_exportOptions->addBool(GeometryExportOptions::kMeshColours, true);
-        g_exportOptions->addFloat(GeometryExportOptions::kMeshDefaultColourRGB, 0.18);
-        g_exportOptions->addFloat(GeometryExportOptions::kMeshDefaultColourA, 1.0);
+        g_exportOptions->addFloat(GeometryExportOptions::kMeshDefaultColourRGB, 0.18, 3);
+        g_exportOptions->addFloat(GeometryExportOptions::kMeshDefaultColourA, 1.0, 3);
+        g_exportOptions->addBool(GeometryExportOptions::kCustomColourThreshold, true);
+        g_exportOptions->addFloat(
+            GeometryExportOptions::kColourThresholdValue,
+            0.00001,
+            5,
+            GeometryExportOptions::kCustomColourThreshold,
+            true);
         g_exportOptions->addBool(GeometryExportOptions::kMeshHoles, true);
         g_exportOptions->addBool(GeometryExportOptions::kNormalsAsPrimvars, false);
         g_exportOptions->addBool(GeometryExportOptions::kReverseOppositeNormals, false);

--- a/plugin/al/translators/CommonTranslatorOptions.h
+++ b/plugin/al/translators/CommonTranslatorOptions.h
@@ -24,6 +24,10 @@ static constexpr const char* const kMeshPointsAsPref
 static constexpr const char* const kMeshColours = "Mesh Colours"; ///< export mesh Colour Sets
 static constexpr const char* const kMeshDefaultColourRGB = "Default RGB"; ///< default rgb values
 static constexpr const char* const kMeshDefaultColourA = "Default Alpha"; ///< default alpha values
+static constexpr const char* const kCustomColourThreshold
+    = "Custom Colour Threshold"; ///< default alpha values
+static constexpr const char* const kColourThresholdValue
+    = "Colour Threshold Value";                               ///< default alpha values
 static constexpr const char* const kMeshHoles = "Mesh Holes"; ///< export mesh face holes
 static constexpr const char* const kNormalsAsPrimvars
     = "Write Normals as Primvars"; ///< if true, allow indexed normals to be written as primvars

--- a/plugin/al/translators/CommonTranslatorOptions.h
+++ b/plugin/al/translators/CommonTranslatorOptions.h
@@ -25,9 +25,9 @@ static constexpr const char* const kMeshColours = "Mesh Colours"; ///< export me
 static constexpr const char* const kMeshDefaultColourRGB = "Default RGB"; ///< default rgb values
 static constexpr const char* const kMeshDefaultColourA = "Default Alpha"; ///< default alpha values
 static constexpr const char* const kCustomColourThreshold
-    = "Custom Colour Threshold"; ///< default alpha values
+    = "Custom Colour Threshold"; ///< if true, allow setting custom color threshold value
 static constexpr const char* const kColourThresholdValue
-    = "Colour Threshold Value";                               ///< default alpha values
+    = "Colour Threshold Value";                               ///< default color threshold value
 static constexpr const char* const kMeshHoles = "Mesh Holes"; ///< export mesh face holes
 static constexpr const char* const kNormalsAsPrimvars
     = "Write Normals as Primvars"; ///< if true, allow indexed normals to be written as primvars

--- a/plugin/al/translators/CommonTranslatorOptions.h
+++ b/plugin/al/translators/CommonTranslatorOptions.h
@@ -22,7 +22,9 @@ static constexpr const char* const kMeshUvOnly = "Mesh UV Only"; ///< export mes
 static constexpr const char* const kMeshPointsAsPref
     = "Mesh Points as PRef"; ///< export mesh Points as PRef, duplicating "P"
 static constexpr const char* const kMeshColours = "Mesh Colours"; ///< export mesh Colour Sets
-static constexpr const char* const kMeshHoles = "Mesh Holes";     ///< export mesh face holes
+static constexpr const char* const kMeshDefaultColourRGB = "Default RGB"; ///< default rgb values
+static constexpr const char* const kMeshDefaultColourA = "Default Alpha"; ///< default alpha values
+static constexpr const char* const kMeshHoles = "Mesh Holes"; ///< export mesh face holes
 static constexpr const char* const kNormalsAsPrimvars
     = "Write Normals as Primvars"; ///< if true, allow indexed normals to be written as primvars
 static constexpr const char* const kReverseOppositeNormals

--- a/plugin/al/translators/Mesh.cpp
+++ b/plugin/al/translators/Mesh.cpp
@@ -187,7 +187,9 @@ UsdPrim Mesh::exportObject(
         if (params.getBool(GeometryExportOptions::kMeshColours)) {
             context.copyColourSetData(
                 params.getFloat(GeometryExportOptions::kMeshDefaultColourRGB),
-                params.getFloat(GeometryExportOptions::kMeshDefaultColourA));
+                params.getFloat(GeometryExportOptions::kMeshDefaultColourA),
+                params.getBool(GeometryExportOptions::kCustomColourThreshold),
+                params.getFloat(GeometryExportOptions::kColourThresholdValue));
         }
         if (params.getBool(GeometryExportOptions::kMeshVertexCreases)) {
             context.copyCreaseVertices();

--- a/plugin/al/translators/Mesh.cpp
+++ b/plugin/al/translators/Mesh.cpp
@@ -185,7 +185,9 @@ UsdPrim Mesh::exportObject(
                 context.timeCode(), params.getBool(GeometryExportOptions::kNormalsAsPrimvars));
         }
         if (params.getBool(GeometryExportOptions::kMeshColours)) {
-            context.copyColourSetData();
+            context.copyColourSetData(
+                params.getFloat(GeometryExportOptions::kMeshDefaultColourRGB),
+                params.getFloat(GeometryExportOptions::kMeshDefaultColourA));
         }
         if (params.getBool(GeometryExportOptions::kMeshVertexCreases)) {
             context.copyCreaseVertices();

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/DiffPrimVar.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/DiffPrimVar.cpp
@@ -1581,6 +1581,47 @@ TfToken guessColourSetInterpolationType(const float* rgba, const size_t numEleme
 }
 
 //----------------------------------------------------------------------------------------------------------------------
+inline bool isNearlyEqual(const float& a, const float& b, const float& threshold)
+{
+    return std::abs(std::abs(a) - std::abs(b)) <= threshold;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+static bool isWithinThreshold(const float* array, const size_t count, float threshold)
+{
+    // TODO: This function is extracted from MayaUsdUtils::vec4AreAllTheSame(),
+    //       it is generally slower then the SSE/AVX version.
+    //       Improve it with SSE/AVX at some point when needed, for now the optimization is left for
+    //       the compiler.
+    float absThreshold = std::abs(threshold);
+    // Iterate the values and check if they are within the threshold
+    const float x = array[0];
+    const float y = array[1];
+    const float z = array[2];
+    const float w = array[3];
+    for (size_t i = 4, n = count * 4; i < n; i += 4) {
+        if (!isNearlyEqual(x, array[i], absThreshold)
+            || !isNearlyEqual(y, array[i + 1], absThreshold)
+            || !isNearlyEqual(z, array[i + 2], absThreshold)
+            || !isNearlyEqual(w, array[i + 3], absThreshold)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+TfToken
+guessColourSetInterpolationType(const float* rgba, const size_t numElements, float threshold)
+{
+    // Specialized test if there is threshold provided.
+    if (numElements <= 1 || isWithinThreshold(rgba, numElements, threshold)) {
+        return UsdGeomTokens->constant;
+    }
+    return UsdGeomTokens->faceVarying;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
 TfToken guessColourSetInterpolationTypeExtensive(
     const float*           rgba,
     const size_t           numElements,
@@ -1672,6 +1713,78 @@ uniform_test:
 
 faceVarying:
     return UsdGeomTokens->faceVarying;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+TfToken guessColourSetInterpolationTypeExtensive(
+    const float*           rgba,
+    const size_t           numElements,
+    float                  threshold,
+    const size_t           numPoints,
+    MIntArray&             pointIndices,
+    MIntArray&             faceCounts,
+    std::vector<uint32_t>& indicesToExtract)
+{
+    // Specialized test if there is threshold provided.
+    // TODO: This function is extracted from guessColourSetInterpolationTypeExtensive() but without
+    // SSE/AVX optimization.
+    //       It is generally slower then the SSE/AVX version.
+    //       Improve it with SSE/AVX at some point when needed, for now the optimization is left for
+    //       the compiler.
+
+    if (numElements <= 1 || isWithinThreshold(rgba, numElements, threshold)) {
+        return UsdGeomTokens->constant;
+    }
+
+    float absThreshold = std::abs(threshold);
+
+    // check for per-vertex assignment
+    std::vector<uint32_t> indicesMap;
+    indicesMap.resize(numPoints, -1);
+    for (uint32_t pntInx = 0, n = pointIndices.length(); pntInx < n; ++pntInx) {
+        auto index = pointIndices[pntInx];
+        auto lastIndex = indicesMap[index];
+        if (lastIndex == 0xFFFFFFFF) {
+            indicesMap[index] = pntInx;
+        } else {
+            // if not, check to see if the indices differ, but the values are the same
+            const float x0 = rgba[4 * lastIndex + 0];
+            const float y0 = rgba[4 * lastIndex + 1];
+            const float z0 = rgba[4 * lastIndex + 2];
+            const float w0 = rgba[4 * lastIndex + 3];
+            const float x1 = rgba[4 * pntInx + 0];
+            const float y1 = rgba[4 * pntInx + 1];
+            const float z1 = rgba[4 * pntInx + 2];
+            const float w1 = rgba[4 * pntInx + 3];
+            if (!isNearlyEqual(x0, x1, absThreshold) || !isNearlyEqual(y0, y1, absThreshold)
+                || !isNearlyEqual(z0, z1, absThreshold) || !isNearlyEqual(w0, w1, absThreshold)) {
+                const uint32_t numFaces = faceCounts.length();
+                indicesMap.resize(numFaces);
+                uint32_t offset = 0;
+                for (uint32_t faceIdx = 0; faceIdx < numFaces; ++faceIdx) {
+                    indicesMap[faceIdx] = offset;
+
+                    int numPointsInFace = faceCounts[faceIdx];
+
+                    const float* rgba0 = rgba + 4 * offset;
+                    for (int32_t j = 1; j < numPointsInFace; ++j) {
+                        const float* rgba1 = rgba + 4 * (offset + j);
+                        if (!isNearlyEqual(rgba0[0], rgba1[0], absThreshold)
+                            || !isNearlyEqual(rgba0[1], rgba1[1], absThreshold)
+                            || !isNearlyEqual(rgba0[2], rgba1[2], absThreshold)
+                            || !isNearlyEqual(rgba0[3], rgba1[3], absThreshold)) {
+                            return UsdGeomTokens->faceVarying;
+                        }
+                    }
+                    offset += numPointsInFace;
+                }
+                std::swap(indicesToExtract, indicesMap);
+                return UsdGeomTokens->uniform;
+            }
+        }
+    }
+    std::swap(indicesToExtract, indicesMap);
+    return UsdGeomTokens->vertex;
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/DiffPrimVar.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/DiffPrimVar.cpp
@@ -1637,15 +1637,19 @@ TfToken guessColourSetInterpolationTypeExtensive(
 
     // check for per-vertex assignment
     std::vector<uint32_t> indicesMap;
-    indicesMap.resize(numPoints, -1);
-
+    indicesMap.resize(numPoints);
+    std::set<int> visitedIndices;
     {
         for (uint32_t i = 0, n = pointIndices.length(); i < n; ++i) {
             auto index = pointIndices[i];
-            auto lastIndex = indicesMap[index];
-            if (lastIndex == 0xFFFFFFFF) {
+            if (uint32_t(index + 1) > numPoints) {
+                indicesMap.resize(index + 1);
+            }
+            if (visitedIndices.find(index) == visitedIndices.end()) {
                 indicesMap[index] = i;
+                visitedIndices.emplace(index);
             } else {
+                auto lastIndex = indicesMap[index];
 #if defined(__SSE__)
 
                 const f128 rgba0 = loadu4f(rgba + 4 * lastIndex);
@@ -1740,13 +1744,19 @@ TfToken guessColourSetInterpolationTypeExtensive(
 
     // check for per-vertex assignment
     std::vector<uint32_t> indicesMap;
-    indicesMap.resize(numPoints, -1);
+    indicesMap.resize(numPoints);
+    std::set<int> visitedIndices;
     for (uint32_t pntInx = 0, n = pointIndices.length(); pntInx < n; ++pntInx) {
         auto index = pointIndices[pntInx];
-        auto lastIndex = indicesMap[index];
-        if (lastIndex == 0xFFFFFFFF) {
+        if (uint32_t(index + 1) > numPoints) {
+            indicesMap.resize(index + 1);
+        }
+
+        if (visitedIndices.find(index) == visitedIndices.end()) {
             indicesMap[index] = pntInx;
+            visitedIndices.emplace(index);
         } else {
+            auto lastIndex = indicesMap[index];
             // if not, check to see if the indices differ, but the values are the same
             const float x0 = rgba[4 * lastIndex + 0];
             const float y0 = rgba[4 * lastIndex + 1];

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/DiffPrimVar.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/DiffPrimVar.cpp
@@ -1637,19 +1637,15 @@ TfToken guessColourSetInterpolationTypeExtensive(
 
     // check for per-vertex assignment
     std::vector<uint32_t> indicesMap;
-    indicesMap.resize(numPoints);
-    std::set<int> visitedIndices;
+    indicesMap.resize(numPoints, -1);
+
     {
         for (uint32_t i = 0, n = pointIndices.length(); i < n; ++i) {
             auto index = pointIndices[i];
-            if (uint32_t(index + 1) > numPoints) {
-                indicesMap.resize(index + 1);
-            }
-            if (visitedIndices.find(index) == visitedIndices.end()) {
+            auto lastIndex = indicesMap[index];
+            if (lastIndex == 0xFFFFFFFF) {
                 indicesMap[index] = i;
-                visitedIndices.emplace(index);
             } else {
-                auto lastIndex = indicesMap[index];
 #if defined(__SSE__)
 
                 const f128 rgba0 = loadu4f(rgba + 4 * lastIndex);
@@ -1744,19 +1740,13 @@ TfToken guessColourSetInterpolationTypeExtensive(
 
     // check for per-vertex assignment
     std::vector<uint32_t> indicesMap;
-    indicesMap.resize(numPoints);
-    std::set<int> visitedIndices;
+    indicesMap.resize(numPoints, -1);
     for (uint32_t pntInx = 0, n = pointIndices.length(); pntInx < n; ++pntInx) {
         auto index = pointIndices[pntInx];
-        if (uint32_t(index + 1) > numPoints) {
-            indicesMap.resize(index + 1);
-        }
-
-        if (visitedIndices.find(index) == visitedIndices.end()) {
+        auto lastIndex = indicesMap[index];
+        if (lastIndex == 0xFFFFFFFF) {
             indicesMap[index] = pntInx;
-            visitedIndices.emplace(index);
         } else {
-            auto lastIndex = indicesMap[index];
             // if not, check to see if the indices differ, but the values are the same
             const float x0 = rgba[4 * lastIndex + 0];
             const float y0 = rgba[4 * lastIndex + 1];

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/DiffPrimVar.h
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/DiffPrimVar.h
@@ -542,6 +542,16 @@ AL_USDMAYA_UTILS_PUBLIC
 TfToken guessColourSetInterpolationType(const float* rgba, const size_t numElements);
 
 //----------------------------------------------------------------------------------------------------------------------
+/// \brief  performs a basic set of tests to determine the interpolation mode of the rgba prim var
+/// data. \param  rgba the face varying colour array \param  numElements the number of RGBA colours
+/// in the rgba array \param  threshold the threshold value for RGBA colours \return
+/// UsdGeomTokens->constant, UsdGeomTokens->uniform, or UsdGeomTokens->faceVarying
+//----------------------------------------------------------------------------------------------------------------------
+AL_USDMAYA_UTILS_PUBLIC
+TfToken
+guessColourSetInterpolationType(const float* rgba, const size_t numElements, float threshold);
+
+//----------------------------------------------------------------------------------------------------------------------
 /// \brief  performs a more comprehensive set of tests to determine the interpolation mode for the
 /// rgba prim var data. \param  rgba the face varying colour array \param  numElements the number of
 /// RGBA colours in the rgba array \param  numPoints the number of points \param  pointIndices the
@@ -554,6 +564,25 @@ AL_USDMAYA_UTILS_PUBLIC
 TfToken guessColourSetInterpolationTypeExtensive(
     const float*           rgba,
     const size_t           numElements,
+    const size_t           numPoints,
+    MIntArray&             pointIndices,
+    MIntArray&             faceCounts,
+    std::vector<uint32_t>& indicesToExtract);
+
+//----------------------------------------------------------------------------------------------------------------------
+/// \brief  performs a more comprehensive set of tests to determine the interpolation mode for the
+/// rgba prim var data. \param  rgba the face varying colour array \param  numElements the number of
+/// RGBA colours in the rgba array \param  threshold the threshold value for RGBA colours \param
+/// numPoints the number of points \param  pointIndices the point indices in the mesh \param
+/// faceCounts the face counts for the mesh \param  indicesToExtract the resulting set of indices
+/// which will be later used to extract the correct data \return UsdGeomTokens->constant,
+/// UsdGeomTokens->vertex, UsdGeomTokens->uniform, or UsdGeomTokens->faceVarying
+//----------------------------------------------------------------------------------------------------------------------
+AL_USDMAYA_UTILS_PUBLIC
+TfToken guessColourSetInterpolationTypeExtensive(
+    const float*           rgba,
+    const size_t           numElements,
+    float                  threshold,
     const size_t           numPoints,
     MIntArray&             pointIndices,
     MIntArray&             faceCounts,

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
@@ -1481,7 +1481,7 @@ void interleaveIndexedUvData(
 // RGBA assigned to the mesh. Have a special case for "displayColor" which write as RGB
 // @todo: needs refactoring to handle face/vert/faceVarying correctly, allow separate RGB/A to be
 // written etc.
-void MeshExportContext::copyColourSetData() { copyColourSetData(0.18f, 1.0f); }
+void MeshExportContext::copyColourSetData() { copyColourSetData(0.18f, 1.0f, true, 1e-5); }
 
 //----------------------------------------------------------------------------------------------------------------------
 // Loops through each Colour Set in the mesh writing out a set of non-indexed Colour Values in RGBA
@@ -1490,6 +1490,21 @@ void MeshExportContext::copyColourSetData() { copyColourSetData(0.18f, 1.0f); }
 // @todo: needs refactoring to handle face/vert/faceVarying correctly, allow separate RGB/A to be
 // written etc.
 void MeshExportContext::copyColourSetData(float defaultColour, float defaultAlpha)
+{
+    copyColourSetData(defaultColour, defaultAlpha, true, 1e-5);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Loops through each Colour Set in the mesh writing out a set of non-indexed Colour Values in RGBA
+// format, Writes out faceVarying values only Have a special case for "displayColor" which write as
+// RGB
+// @todo: needs refactoring to handle face/vert/faceVarying correctly, allow separate RGB/A to be
+// written etc.
+void MeshExportContext::copyColourSetData(
+    float defaultColour,
+    float defaultAlpha,
+    bool  hasThreshold,
+    float threshold)
 {
     UsdPrim                           prim = mesh.GetPrim();
     MStringArray                      colourSetNames;
@@ -1535,18 +1550,28 @@ void MeshExportContext::copyColourSetData(float defaultColour, float defaultAlph
         switch (compaction) {
         case kNone: break;
         case kBasic:
-            interpolation = guessColourSetInterpolationType(&colours[0].r, coloursLength);
+            interpolation = hasThreshold
+                ? guessColourSetInterpolationType(&colours[0].r, coloursLength, threshold)
+                : guessColourSetInterpolationType(&colours[0].r, coloursLength);
             break;
 
         case kMedium:
         case kFull:
-            interpolation = guessColourSetInterpolationTypeExtensive(
-                &colours[0].r,
-                coloursLength,
-                fnMesh.numVertices(),
-                faceConnects,
-                faceCounts,
-                indicesToExtract);
+            interpolation = hasThreshold ? guessColourSetInterpolationTypeExtensive(
+                                &colours[0].r,
+                                coloursLength,
+                                threshold,
+                                fnMesh.numVertices(),
+                                faceConnects,
+                                faceCounts,
+                                indicesToExtract)
+                                         : guessColourSetInterpolationTypeExtensive(
+                                             &colours[0].r,
+                                             coloursLength,
+                                             fnMesh.numVertices(),
+                                             faceConnects,
+                                             faceCounts,
+                                             indicesToExtract);
             break;
         }
 

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
@@ -1481,7 +1481,7 @@ void interleaveIndexedUvData(
 // RGB
 // @todo: needs refactoring to handle face/vert/faceVarying correctly, allow separate RGB/A to be
 // written etc.
-void MeshExportContext::copyColourSetData()
+void MeshExportContext::copyColourSetData(float defaultColour, float defaultAlpha)
 {
     UsdPrim                           prim = mesh.GetPrim();
     MStringArray                      colourSetNames;
@@ -1508,12 +1508,18 @@ void MeshExportContext::copyColourSetData()
         while (!it.isDone()) {
             MColorArray faceColours;
             it.getColors(faceColours, &colourSetNames[i]);
-            it.next();
             // Append face colours
             uint32_t offset = colours.length();
             colours.setLength(offset + faceColours.length());
-            for (uint32_t j = 0, n = faceColours.length(); j < n; ++j)
-                colours[offset + j] = faceColours[j];
+            for (uint32_t j = 0, n = faceColours.length(); j < n; ++j) {
+                if (it.hasColor()) {
+                    colours[offset + j] = faceColours[j];
+                } else {
+                    colours[offset + j]
+                        = MColor(defaultColour, defaultColour, defaultColour, defaultAlpha);
+                }
+            }
+            it.next();
         }
         TfToken interpolation = UsdGeomTokens->faceVarying;
         coloursLength = colours.length();

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.cpp
@@ -1477,6 +1477,14 @@ void interleaveIndexedUvData(
 
 //----------------------------------------------------------------------------------------------------------------------
 // Loops through each Colour Set in the mesh writing out a set of non-indexed Colour Values in RGBA
+// format, Writes out faceVarying values only Default RGB is 0.18 and alpha is 1.0 if there is no
+// RGBA assigned to the mesh. Have a special case for "displayColor" which write as RGB
+// @todo: needs refactoring to handle face/vert/faceVarying correctly, allow separate RGB/A to be
+// written etc.
+void MeshExportContext::copyColourSetData() { copyColourSetData(0.18f, 1.0f); }
+
+//----------------------------------------------------------------------------------------------------------------------
+// Loops through each Colour Set in the mesh writing out a set of non-indexed Colour Values in RGBA
 // format, Writes out faceVarying values only Have a special case for "displayColor" which write as
 // RGB
 // @todo: needs refactoring to handle face/vert/faceVarying correctly, allow separate RGB/A to be

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.h
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.h
@@ -280,10 +280,14 @@ public:
     void copyBindPoseData(UsdTimeCode time);
 
     /// \brief  copies the colour set data from maya into the usd prim.
+    AL_USDMAYA_UTILS_PUBLIC
+    void copyColourSetData();
+
+    /// \brief  copies the colour set data from maya into the usd prim.
     /// \param defaultColour the default colour if the polyFace has no colour.
     /// \param defaultAlpha the default colour if the polyFace has no alpha.
     AL_USDMAYA_UTILS_PUBLIC
-    void copyColourSetData(float defaultColour = 0.18, float defaultAlpha = 1.0);
+    void copyColourSetData(float defaultColour, float defaultAlpha);
 
     /// \brief  copies invisible face information into the usd file from maya
     AL_USDMAYA_UTILS_PUBLIC

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.h
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.h
@@ -289,6 +289,15 @@ public:
     AL_USDMAYA_UTILS_PUBLIC
     void copyColourSetData(float defaultColour, float defaultAlpha);
 
+    /// \brief  copies the colour set data from maya into the usd prim.
+    /// \param defaultColour the default colour if the polyFace has no colour.
+    /// \param defaultAlpha the default colour if the polyFace has no alpha.
+    /// \param hasThreshold flag indicate if there is any threshold
+    /// \param threshold the threshold value
+    AL_USDMAYA_UTILS_PUBLIC
+    void
+    copyColourSetData(float defaultColour, float defaultAlpha, bool hasThreshold, float threshold);
+
     /// \brief  copies invisible face information into the usd file from maya
     AL_USDMAYA_UTILS_PUBLIC
     void copyInvisibleHoles();

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.h
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/MeshUtils.h
@@ -280,8 +280,10 @@ public:
     void copyBindPoseData(UsdTimeCode time);
 
     /// \brief  copies the colour set data from maya into the usd prim.
+    /// \param defaultColour the default colour if the polyFace has no colour.
+    /// \param defaultAlpha the default colour if the polyFace has no alpha.
     AL_USDMAYA_UTILS_PUBLIC
-    void copyColourSetData();
+    void copyColourSetData(float defaultColour = 0.18, float defaultAlpha = 1.0);
 
     /// \brief  copies invisible face information into the usd file from maya
     AL_USDMAYA_UTILS_PUBLIC


### PR DESCRIPTION
This PR mainly contains two features for exporting:
 - Default RGBA value (RGB = 0.18, A =1.0) so that the value is always meaningful
 - Optionally accept color "threshold", the UI is also extended to support custom precision to allow displaying high precision of floating point numbers, defaults to 1e-5 which should be enough for color.