### PR TITLE
[al] Mark outTime attribute dirty to force updating Maya bbox; fix incorrect time code for bbox

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1605,6 +1605,7 @@ MStatus ProxyShape::compute(const MPlug& plug, MDataBlock& dataBlock)
     m_requestedRedraw = true;
     MTime currentTime;
     if (plug == outTime()) {
+        MHWRender::MRenderer::setGeometryDrawDirty(thisMObject());
         return computeOutputTime(plug, dataBlock, currentTime);
     } else if (plug == outStageData()) {
         MStatus status = computeOutputTime(MPlug(plug.node(), outTime()), dataBlock, currentTime);
@@ -1734,7 +1735,7 @@ void ProxyShape::CacheEmptyBoundingBox(MBoundingBox& cachedBBox)
 //----------------------------------------------------------------------------------------------------------------------
 UsdTimeCode ProxyShape::GetOutputTime(MDataBlock dataBlock) const
 {
-    return UsdTimeCode(inputDoubleValue(dataBlock, outTime()));
+    return MayaUsdProxyShapeBase::GetOutputTime(dataBlock);
 }
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Changes for this PR:
 - Mark geometry dirty explicitly otherwise bbox won't move
 - Fix GetOutputTime() to return the correct time code