### PR TITLE
Use USDLuxTokens for spot light

### DIFF
--- a/lib/usd/hdMaya/adapters/spotLightAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/spotLightAdapter.cpp
@@ -134,11 +134,23 @@ protected:
             } else if (paramName == UsdLuxTokens->treatAsPoint) {
                 const bool treatAsPoint = (light.shadowRadius() == 0.0);
                 return VtValue(treatAsPoint);
+#if PXR_VERSION >= 2105
             } else if (paramName == UsdLuxTokens->inputsShapingConeAngle) {
+#else
+            } else if (paramName == HdLightTokens->shapingConeAngle) {
+#endif
                 return VtValue(GetSpotCutoff(light));
+#if PXR_VERSION >= 2105
             } else if (paramName == UsdLuxTokens->inputsShapingConeSoftness) {
+#else
+            } else if (paramName == HdLightTokens->shapingConeSoftness) {
+#endif
                 return VtValue(GetSpotSoftness(light));
+#if PXR_VERSION >= 2105
             } else if (paramName == UsdLuxTokens->inputsShapingFocus) {
+#else
+            } else if (paramName == HdLightTokens->shapingFocus) {
+#endif
                 return VtValue(GetSpotFalloff(light));
             }
         }

--- a/lib/usd/hdMaya/adapters/spotLightAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/spotLightAdapter.cpp
@@ -134,11 +134,11 @@ protected:
             } else if (paramName == UsdLuxTokens->treatAsPoint) {
                 const bool treatAsPoint = (light.shadowRadius() == 0.0);
                 return VtValue(treatAsPoint);
-            } else if (paramName == HdLightTokens->shapingConeAngle) {
+            } else if (paramName == UsdLuxTokens->inputsShapingConeAngle) {
                 return VtValue(GetSpotCutoff(light));
-            } else if (paramName == HdLightTokens->shapingConeSoftness) {
+            } else if (paramName == UsdLuxTokens->inputsShapingConeSoftness) {
                 return VtValue(GetSpotSoftness(light));
-            } else if (paramName == HdLightTokens->shapingFocus) {
+            } else if (paramName == UsdLuxTokens->inputsShapingFocus) {
                 return VtValue(GetSpotFalloff(light));
             }
         }


### PR DESCRIPTION
If I understand correctly starting with Pixar USD 21.05 we should use UsdLuxTokens for spot light parameters instead of HdLightTokes

From 21.05 release notes:
"UsdLux Shadow and Shaping APIs are now connectable. All attributes on these APIs have been given the "inputs:" prefix."

In our "hdRPR" render delegate we use these "inputs" prefixes but it does not work with MtoH without such fixes.