### PR TITLE
MAYA-121681 lieft restrictions when a prim has empty over or def.

### DIFF
--- a/lib/mayaUsd/ufe/private/Utils.cpp
+++ b/lib/mayaUsd/ufe/private/Utils.cpp
@@ -128,14 +128,20 @@ void applyCommandRestriction(const UsdPrim& prim, const std::string& commandName
         return;
     }
 
-    auto        primSpec = MayaUsdUtils::getPrimSpecAtEditTarget(prim);
-    auto        primStack = prim.GetPrimStack();
+    SdfPrimSpecHandle       primSpec = MayaUsdUtils::getPrimSpecAtEditTarget(prim);
+    SdfPrimSpecHandleVector primStack = prim.GetPrimStack();
     std::string layerDisplayName;
     std::string message { "It is defined on another layer" };
 
     // iterate over the prim stack, starting at the highest-priority layer.
-    for (const auto& spec : primStack) {
+    for (const SdfPrimSpecHandle& spec : primStack) {
         const auto& layerName = spec->GetLayer()->GetDisplayName();
+
+        // Don't block edits if there are no authored properties (attributes, relationships, etc)
+        // in this layer.
+        if (spec->GetProperties().size() == 0) {
+            continue;
+        }
 
         // skip if there is no primSpec for the selected prim in the current stage's local layer.
         if (!primSpec) {


### PR DESCRIPTION
If a layer has an entry for a prim but that entry is entirely empty, do not block edition of that prim on a different layer. This happens when a prim is merely used to build the hierarchy leading to another prim.