### PR TITLE
MAYA-114603 use correct way to query attribute

### DIFF
--- a/lib/mayaUsd/utils/loadRulesAttribute.cpp
+++ b/lib/mayaUsd/utils/loadRulesAttribute.cpp
@@ -33,7 +33,7 @@ bool hasLoadRulesAttribute(const MFnDependencyNode& depNode)
 {
     MString nodeName = depNode.absoluteName();
     MString cmd;
-    cmd.format("addAttr -query -exists \"^2s.^1s\"", loadRulesAttrName, nodeName);
+    cmd.format("attributeQuery -exists -n \"^2s\" \"^1s\"", loadRulesAttrName, nodeName);
 
     int        result = 0;
     const bool display = false;


### PR DESCRIPTION
Use the correct mel command to querythe existence of an attribute. The new code avoids errors being printed in teh MEL console when the attribute does not exists.