### PR TITLE
MAYA-122640 fix crash with deactivate and console

### DIFF
--- a/lib/mayaUsd/ufe/UsdUIInfoHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdUIInfoHandler.cpp
@@ -69,20 +69,21 @@ void addMetadataCount(
     }
 }
 
-const double* getInvisibleColor()
+std::vector<double> getInvisibleColor()
 {
-    auto colorInit = []() {
-        std::vector<double> rgb(3);
-        MDoubleArray        outlinerInvisibleColor;
+    static std::vector<double> rgb;
+    static bool                initialized = false;
+    if (!initialized) {
+        MDoubleArray outlinerInvisibleColor;
         if (MGlobal::executeCommand(
                 "displayRGBColor -q \"outlinerInvisibleColor\"", outlinerInvisibleColor)
             && (outlinerInvisibleColor.length() == 3)) {
+            rgb.resize(3);
             outlinerInvisibleColor.get(rgb.data());
+            initialized = true;
         }
-        return rgb;
-    };
-    static const std::vector<double> rgb = colorInit();
-    return rgb.data();
+    }
+    return rgb;
 }
 
 } // namespace
@@ -124,11 +125,15 @@ bool UsdUIInfoHandler::treeViewCellInfo(const Ufe::SceneItem::Ptr& item, Ufe::Ce
         if (!usdItem->prim().IsActive()) {
             changed = true;
             info.fontStrikeout = true;
-            const double* rgb = getInvisibleColor();
-            info.textFgColor.set(
-                static_cast<float>(rgb[0]), static_cast<float>(rgb[1]), static_cast<float>(rgb[2]));
-        } else {
-            info.textFgColor.set(0.403922f, 0.403922f, 0.403922f);
+            const std::vector<double> rgb = getInvisibleColor();
+            if (rgb.size() == 3) {
+                info.textFgColor.set(
+                    static_cast<float>(rgb[0]),
+                    static_cast<float>(rgb[1]),
+                    static_cast<float>(rgb[2]));
+            } else {
+                info.textFgColor.set(0.403922f, 0.403922f, 0.403922f);
+            }
         }
     }
 

--- a/lib/mayaUsd/ufe/UsdUIInfoHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdUIInfoHandler.cpp
@@ -77,6 +77,11 @@ namespace ufe {
 UsdUIInfoHandler::UsdUIInfoHandler()
     : Ufe::UIInfoHandler()
 {
+    // Initialize to invalid values.
+    fInvisibleColor[0] = -1.;
+    fInvisibleColor[1] = -1.;
+    fInvisibleColor[2] = -1.;
+
     // Register a callback to invalidate the invisible color.
     fColorChangedCallbackId = MEventMessage::addEventCallback(
         "DisplayRGBColorChanged", onColorChanged, reinterpret_cast<void*>(this));
@@ -110,9 +115,8 @@ void UsdUIInfoHandler::updateInvisibleColor()
     MDoubleArray color;
     MGlobal::executeCommand("displayRGBColor -q \"outlinerInvisibleColor\"", color);
 
-    if (color.length() >= 3) {
+    if (color.length() == 3) {
         color.get(fInvisibleColor.data());
-        fInvisibleColorValid = true;
     }
 }
 
@@ -141,7 +145,7 @@ bool UsdUIInfoHandler::treeViewCellInfo(const Ufe::SceneItem::Ptr& item, Ufe::Ce
         if (!usdItem->prim().IsActive()) {
             changed = true;
             info.fontStrikeout = true;
-            if (fInvisibleColorValid) {
+            if (fInvisibleColor[0] >= 0) {
                 info.textFgColor.set(
                     static_cast<float>(fInvisibleColor[0]),
                     static_cast<float>(fInvisibleColor[1]),

--- a/lib/mayaUsd/ufe/UsdUIInfoHandler.h
+++ b/lib/mayaUsd/ufe/UsdUIInfoHandler.h
@@ -59,7 +59,6 @@ private:
     static void onColorChanged(void*);
 
     std::array<double, 3> fInvisibleColor;
-    bool                  fInvisibleColorValid = false;
     MCallbackId           fColorChangedCallbackId = 0;
 }; // UsdUIInfoHandler
 

--- a/lib/mayaUsd/ufe/UsdUIInfoHandler.h
+++ b/lib/mayaUsd/ufe/UsdUIInfoHandler.h
@@ -19,7 +19,10 @@
 
 #include <mayaUsd/base/api.h>
 
+#include <maya/MEventMessage.h>
 #include <ufe/uiInfoHandler.h>
+
+#include <array>
 
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
@@ -47,6 +50,17 @@ public:
     Ufe::UIInfoHandler::Icon treeViewIcon(const Ufe::SceneItem::Ptr& item) const override;
     std::string              treeViewTooltip(const Ufe::SceneItem::Ptr& item) const override;
     std::string              getLongRunTimeLabel() const override;
+
+private:
+    void updateInvisibleColor();
+
+    // Note: the on-color-changed callback function is declared taking a void pointer
+    //       to be compatible with MMessage callback API.
+    static void onColorChanged(void*);
+
+    std::array<double, 3> fInvisibleColor;
+    bool                  fInvisibleColorValid = false;
+    MCallbackId           fColorChangedCallbackId = 0;
 }; // UsdUIInfoHandler
 
 } // namespace ufe


### PR DESCRIPTION
Fix a crash that happened when a prim was deactivated in the outliner while the MEL console was docked and MEl history options "show all commands" was on. It was due to recursive paint event corrupting the Qt internal paint engine.