### PR TITLE
MAYA-105662 Maya USD does not build with gcc 9

### DIFF
--- a/plugin/al/plugin/AL_USDMayaTestPlugin/AL/maya/test_EventHandler.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/AL/maya/test_EventHandler.cpp
@@ -277,7 +277,7 @@ TEST(EventDispatcher, triggerEvent2)
 TEST(EventScheduler, registerEvent)
 {
     EventScheduler registrar(&g_eventSystem);
-    int            associated;
+    int            associated=0;
     EventId id1 = registrar.registerEvent("eventName", kUserSpecifiedEventType, &associated, 0);
     EXPECT_TRUE(id1 != 0);
     auto eventInfo = registrar.event(id1);
@@ -316,7 +316,7 @@ TEST(EventScheduler, registerEvent)
 TEST(EventScheduler, registerChildEvent)
 {
     EventScheduler registrar(&g_eventSystem);
-    int            associated;
+    int            associated=0;
     EventId id1 = registrar.registerEvent("EventType1", kUserSpecifiedEventType, &associated, 0);
     EXPECT_TRUE(id1 != 0);
     auto parentEventInfo = registrar.event(id1);
@@ -361,7 +361,7 @@ TEST(EventScheduler, registerChildEvent)
 TEST(EventScheduler, registerCallback)
 {
     EventScheduler registrar(&g_eventSystem);
-    int            associated;
+    int            associated=0;
     EventId id1 = registrar.registerEvent("EventType1", kUserSpecifiedEventType, &associated, 0);
     EXPECT_TRUE(id1 != 0);
     auto parentEventInfo = registrar.event(id1);


### PR DESCRIPTION
Only fixed a few compiler warnings and I could build in Release with gcc 11.2.1