### PR TITLE
MAYA-121599 - Active Selection Highlighting color doesn't work in Maya 2022 with USD

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -1551,8 +1551,12 @@ MColor ProxyRenderDelegate::GetSelectionHighlightColor(const TfToken& className)
         queryName = "lead";
     } else if (className == HdPrimTypeTokens->mesh) {
         colorCache = &_activeMeshColorCache;
+#if MAYA_API_VERSION >= 20230000
         fromPalette = false;
         queryName = "polymeshActive";
+#else
+        queryName = "polymesh";
+#endif
     } else if (className == HdPrimTypeTokens->basisCurves) {
         colorCache = &_activeCurveColorCache;
         queryName = "curve";


### PR DESCRIPTION
Proper script call to fetch polymesh active color for Maya 2022 and below