### PR TITLE
Fix build for USD versions past 21.11

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -503,7 +503,13 @@ void HdVP2BasisCurves::Sync(
         }
     }
 
-    _SyncSharedData(_sharedData, delegate, dirtyBits, reprToken, id, _reprs);
+#if PXR_VERSION > 2111
+    const TfToken& renderTag = GetRenderTag();
+#else
+    const TfToken& renderTag = delegate->GetRenderTag(id);
+#endif
+
+    _SyncSharedData(_sharedData, delegate, dirtyBits, reprToken, id, _reprs, renderTag);
 
     *dirtyBits = HdChangeTracker::Clean;
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
@@ -552,7 +552,8 @@ void MayaUsdRPrim::_SyncSharedData(
     HdDirtyBits const* dirtyBits,
     TfToken const&     reprToken,
     SdfPath const&     id,
-    ReprVector const&  reprs)
+    ReprVector const&  reprs,
+    TfToken const&     renderTag)
 {
     if (HdChangeTracker::IsExtentDirty(*dirtyBits, id)) {
         sharedData.bounds.SetRange(delegate->GetExtent(id));
@@ -577,7 +578,7 @@ void MayaUsdRPrim::_SyncSharedData(
     // Hydra now manages and caches render tags under the hood and is clearing
     // the dirty bit prior to calling sync. Unconditionally set the render tag
     // in the shared data structure based on current Hydra data
-    _RenderTag() = GetRenderTag();
+    _RenderTag() = renderTag;
 #else
     if (*dirtyBits
         & (HdChangeTracker::DirtyRenderTag
@@ -585,7 +586,7 @@ void MayaUsdRPrim::_SyncSharedData(
            | HdChangeTracker::DirtyVisibility
 #endif
            )) {
-        _RenderTag() = delegate->GetRenderTag(id);
+        _RenderTag() = renderTag;
     }
 #endif
 }

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -202,7 +202,8 @@ protected:
         HdDirtyBits const* dirtyBits,
         TfToken const&     reprToken,
         SdfPath const&     id,
-        ReprVector const&  reprs);
+        ReprVector const&  reprs,
+        TfToken const&     renderTag);
 
     void _UpdatePrimvarSourcesGeneric(
         HdSceneDelegate*       sceneDelegate,

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1002,7 +1002,13 @@ void HdVP2Mesh::Sync(
 
     _PrepareSharedVertexBuffers(delegate, *dirtyBits, reprToken);
 
-    _SyncSharedData(_sharedData, delegate, dirtyBits, reprToken, id, _reprs);
+#if PXR_VERSION > 2111
+    const TfToken& renderTag = GetRenderTag();
+#else
+    const TfToken& renderTag = delegate->GetRenderTag(id);
+#endif
+
+    _SyncSharedData(_sharedData, delegate, dirtyBits, reprToken, id, _reprs, renderTag);
 
     *dirtyBits = HdChangeTracker::Clean;
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/points.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/points.cpp
@@ -192,7 +192,13 @@ void HdVP2Points::Sync(
         }
     }
 
-    _SyncSharedData(_sharedData, delegate, dirtyBits, reprToken, id, _reprs);
+#if PXR_VERSION > 2111
+    const TfToken& renderTag = GetRenderTag();
+#else
+    const TfToken& renderTag = delegate->GetRenderTag(id);
+#endif
+
+    _SyncSharedData(_sharedData, delegate, dirtyBits, reprToken, id, _reprs, renderTag);
 
     *dirtyBits = HdChangeTracker::Clean;
 


### PR DESCRIPTION
GetRenderTag is a function defined in HdRprim, but the callsite has been
moved from classes derived from HdRprim to a different parent class.
Pass the render tag into the _SyncSharedData from the HdRprim derived
classes to fix the build