### PR TITLE
Removed proxy shape pre/post selection events notification

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1961,8 +1961,6 @@ void ProxyShape::registerEvents()
     registerEvent("PostStageLoaded", AL::event::kUSDMayaEventType);
     registerEvent("ConstructGLEngine", AL::event::kUSDMayaEventType);
     registerEvent("DestroyGLEngine", AL::event::kUSDMayaEventType);
-    registerEvent("PreSelectionChanged", AL::event::kUSDMayaEventType);
-    registerEvent("PostSelectionChanged", AL::event::kUSDMayaEventType);
     registerEvent("PreVariantChanged", AL::event::kUSDMayaEventType);
     registerEvent("PostVariantChanged", AL::event::kUSDMayaEventType);
     registerEvent("PreSerialiseContext", AL::event::kUSDMayaEventType, Global::postSave());
@@ -1974,8 +1972,6 @@ void ProxyShape::registerEvents()
     registerEvent("PreDeserialiseTransformRefs", AL::event::kUSDMayaEventType, Global::postRead());
     registerEvent("PostDeserialiseTransformRefs", AL::event::kUSDMayaEventType, Global::postRead());
     registerEvent("EditTargetChanged", AL::event::kUSDMayaEventType);
-    registerEvent("SelectionStarted", AL::event::kUSDMayaEventType);
-    registerEvent("SelectionEnded", AL::event::kUSDMayaEventType);
 }
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR removes the events registered in service of non-UFE proxy shape callbacks for refresh stages and pre/post selection from `MayaUsdProxyShapeBase` and `Ufe::Global`. As suggested in PR [`Autodesk/maya-usd#1855`](https://github.com/Autodesk/maya-usd/pull/1855), these were no longer be required and are superseded by UFE observability.