### PR TITLE
MAYA-122123 make Define In options enabled

### DIFF
--- a/lib/mayaUsd/resources/scripts/mayaUsdAddMayaReference.mel
+++ b/lib/mayaUsd/resources/scripts/mayaUsdAddMayaReference.mel
@@ -401,7 +401,7 @@ proc setOptionVars(int $forceFactorySettings)
         }
         string $createNew = getMayaUsdLibString("kMayaRefCreateNew");
         if ($forceFactorySettings || !`optionVar -exists usdMayaReferenceDefineInVariant`) {
-            optionVar -intValue usdMayaReferenceDefineInVariant false;
+            optionVar -intValue usdMayaReferenceDefineInVariant true;
         }
         if ($forceFactorySettings || !`optionVar -exists usdMayaReferenceVariantSetNameOption`) {
             optionVar -stringValue usdMayaReferenceVariantSetNameOption $createNew;
@@ -487,7 +487,7 @@ proc setOptionVars(int $forceFactorySettings)
             -sv usdMayaReferenceGroupPrimName ""
             -sv usdMayaReferenceGroupPrimType "Xform"
             -sv usdMayaReferenceGroupPrimKind $defGroupKind
-            -iv usdMayaReferenceDefineInVariant false
+            -iv usdMayaReferenceDefineInVariant true
             -sv usdMayaReferenceVariantSetNameOption $createNew
             -sv usdMayaReferenceVariantSetNameText $defVariantSetName
             -sv usdMayaReferenceVariantNameOption $createNew

--- a/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
@@ -154,11 +154,11 @@ def variantOrNewPrim(variantSelected):
     # The variant and new child prim radio buttons are mutually exclusive.
     # So only one can be checked.
     if variantSelected:
-        cmds.radioButtonGrp('variantRadioButton', edit=True, select=True)
-        cmds.radioButtonGrp('newChildPrimInvisibleRadioButton', edit=True, select=True)
+        cmds.radioButtonGrp('variantRadioButton', edit=True, select=1)
+        cmds.radioButtonGrp('newChildPrimInvisibleRadioButton', edit=True, select=1)
     else:
-        cmds.radioButtonGrp('variantInvisibleRadioButton', edit=True, select=True)
-        cmds.radioButtonGrp('newChildPrimRadioButton', edit=True, select=True)
+        cmds.radioButtonGrp('variantInvisibleRadioButton', edit=True, select=1)
+        cmds.radioButtonGrp('newChildPrimRadioButton', edit=True, select=1)
     
     cmds.rowLayout('usdCacheVariantSetRow', edit=True, enable=variantSelected)
     cmds.rowLayout('usdCacheVariantNameRow', edit=True, enable=variantSelected)

--- a/lib/mayaUsd/utils/editRouter.cpp
+++ b/lib/mayaUsd/utils/editRouter.cpp
@@ -113,7 +113,7 @@ void cacheMayaReference(const PXR_NS::VtDictionary& context, PXR_NS::VtDictionar
     auto compositionArc = PXR_NS::VtDictionaryGet<std::string>(
         context, "rn_payloadOrReference", PXR_NS::VtDefault = "");
     bool dstIsVariant
-        = (PXR_NS::VtDictionaryGet<int>(context, "rn_defineInVariant", PXR_NS::VtDefault = 0) == 1);
+        = (PXR_NS::VtDictionaryGet<int>(context, "rn_defineInVariant", PXR_NS::VtDefault = 1) == 1);
     const auto parentPath = pulledPath.GetParentPath();
     const auto cachePrimPath = parentPath.AppendChild(PXR_NS::TfToken(dstPrimName));
 


### PR DESCRIPTION
Also fixes MAYA-122127 and MAYA-122135: remove tooltip from Deinf In and makre vairiant the default when creating a ref when Maya prefs are empty.