### PR TITLE
MAYA-122128 NURBS defaut to off when caching

### DIFF
--- a/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
@@ -149,6 +149,8 @@ def _convertTextToType(valueToConvert, defaultValue, desiredType=None):
             else:
                 values = valueToConvert.split()
                 desiredType = float
+            if len(defaultValue):
+                desiredType = type(defaultValue[0])
             convertedValues = []
             for value in values:
                 value = value.strip()


### PR DESCRIPTION
The defaults were not parsed properly when a list with a single item was given as teh default as it could not determine if it was a text or floating-point values.