### PR TITLE
MAYA-122361 user-selected file format when caching

### DIFF
--- a/lib/mayaUsd/utils/editRouter.cpp
+++ b/lib/mayaUsd/utils/editRouter.cpp
@@ -23,6 +23,7 @@
 #include <pxr/usd/usd/payloads.h>
 #include <pxr/usd/usd/references.h>
 #include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usd/usdFileFormat.h>
 #include <pxr/usd/usd/variantSets.h>
 #include <pxr/usd/usdGeom/gprim.h>
 
@@ -79,13 +80,29 @@ void cacheMayaReference(const PXR_NS::VtDictionary& context, PXR_NS::VtDictionar
     if (dstLayerPath.empty() || dstPrimName.empty())
         return;
 
+    // Determine the file format
+    PXR_NS::SdfLayer::FileFormatArguments fileFormatArgs;
+    PXR_NS::SdfFileFormatConstPtr         fileFormat;
+
+    auto fileFormatExtension
+        = PXR_NS::VtDictionaryGet<std::string>(context, "defaultUSDFormat", PXR_NS::VtDefault = "");
+    if (fileFormatExtension.size() > 0) {
+        fileFormatArgs[PXR_NS::UsdUsdFileFormatTokens->FormatArg] = fileFormatExtension;
+        auto filename = std::string("a.") + fileFormatExtension;
+        fileFormat = PXR_NS::SdfFileFormat::FindByExtension(filename, fileFormatArgs);
+        if (PXR_NS::SdfFileFormat::GetFileExtension(dstLayerPath) != fileFormatExtension) {
+            dstLayerPath += std::string(".") + fileFormatExtension;
+        }
+    }
+
     // Prepare the layer
     PXR_NS::SdfPath dstPrimPath
         = PXR_NS::SdfPath(dstPrimName).MakeAbsolutePath(PXR_NS::SdfPath::AbsoluteRootPath());
-    PXR_NS::SdfLayerRefPtr tmpLayer = PXR_NS::SdfLayer::CreateAnonymous();
+    PXR_NS::SdfLayerRefPtr tmpLayer
+        = PXR_NS::SdfLayer::CreateAnonymous("", fileFormat, fileFormatArgs);
     SdfJustCreatePrimInLayer(tmpLayer, dstPrimPath);
 
-    tmpLayer->Export(dstLayerPath);
+    tmpLayer->Export(dstLayerPath, "", fileFormatArgs);
     PXR_NS::SdfLayerRefPtr dstLayer = PXR_NS::SdfLayer::FindOrOpen(dstLayerPath);
     if (!dstLayer)
         return;


### PR DESCRIPTION
Force the use of the format selected in the binary/ASCII drop-down when caching.