### PR TITLE
MAYA-122361 enforce cache file format

### DIFF
--- a/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.mel
+++ b/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.mel
@@ -34,6 +34,11 @@ global proc mayaUsdCacheMayaReference_cacheCommitUi(string $parent, string $sele
         + $parent + "', '" + $selectedFile + "')");
 }
 
+global proc mayaUsdCacheMayaReference_fileTypeChangedUi(string $parent, string $fileType)
+{
+    python("from mayaUsdCacheMayaReference import fileTypeChangedUi; fileTypeChangedUi('"
+        + $parent + "', '" + $fileType + "')");
+}
 
 // mayaUsdTranslatorExport() requires a MEL procedure as a callback, to return
 // options read from the UI.

--- a/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
@@ -409,6 +409,16 @@ def cacheCommitUi(parent, selectedFile):
         cmds.error(errorMsg)
 
 
+def fileTypeChangedUi(parent, fileType):
+    '''
+    Callback called when the user change the file dialog file format drop-down.
+    Used to disable the binary/ASCII drop-down when the selected file format only
+    supports one type.
+    '''
+    forcedFormat = fileType in ['*.usda', '*.usdc', '*.usdz']
+    cmds.optionMenuGrp("defaultUSDFormatPopup", edit=True, enable=not forcedFormat)
+
+
 def cacheDialog(dagPath, pulledMayaRefPrim, _):
     '''Display dialog to cache the argument pulled Maya reference prim to USD.'''
 
@@ -433,5 +443,6 @@ def cacheDialog(dagPath, pulledMayaRefPrim, _):
         optionsUIInit="mayaUsdCacheMayaReference_cacheInitUi",
         optionsUITitle="",
         optionsUICommit2="mayaUsdCacheMayaReference_cacheCommitUi",
+        fileTypeChanged="mayaUsdCacheMayaReference_fileTypeChangedUi",
         startingDirectory=cmds.workspace(query=True, directory=True)
     )

--- a/lib/mayaUsd/utils/editRouter.cpp
+++ b/lib/mayaUsd/utils/editRouter.cpp
@@ -88,11 +88,8 @@ void cacheMayaReference(const PXR_NS::VtDictionary& context, PXR_NS::VtDictionar
         = PXR_NS::VtDictionaryGet<std::string>(context, "defaultUSDFormat", PXR_NS::VtDefault = "");
     if (fileFormatExtension.size() > 0) {
         fileFormatArgs[PXR_NS::UsdUsdFileFormatTokens->FormatArg] = fileFormatExtension;
-        auto filename = std::string("a.") + fileFormatExtension;
-        fileFormat = PXR_NS::SdfFileFormat::FindByExtension(filename, fileFormatArgs);
-        if (PXR_NS::SdfFileFormat::GetFileExtension(dstLayerPath) != fileFormatExtension) {
-            dstLayerPath += std::string(".") + fileFormatExtension;
-        }
+        auto dummyFilename = std::string("a.") + fileFormatExtension;
+        fileFormat = PXR_NS::SdfFileFormat::FindByExtension(dummyFilename, fileFormatArgs);
     }
 
     // Prepare the layer

--- a/lib/mayaUsd/utils/editRouter.cpp
+++ b/lib/mayaUsd/utils/editRouter.cpp
@@ -23,6 +23,7 @@
 #include <pxr/usd/usd/payloads.h>
 #include <pxr/usd/usd/references.h>
 #include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usd/usdFileFormat.h>
 #include <pxr/usd/usd/variantSets.h>
 #include <pxr/usd/usdGeom/gprim.h>
 
@@ -79,13 +80,29 @@ void cacheMayaReference(const PXR_NS::VtDictionary& context, PXR_NS::VtDictionar
     if (dstLayerPath.empty() || dstPrimName.empty())
         return;
 
+    // Determine the file format
+    PXR_NS::SdfLayer::FileFormatArguments fileFormatArgs;
+    PXR_NS::SdfFileFormatConstPtr         fileFormat;
+
+    auto fileFormatExtension
+        = PXR_NS::VtDictionaryGet<std::string>(context, "defaultUSDFormat", PXR_NS::VtDefault = "");
+    if (fileFormatExtension.size() > 0) {
+        fileFormatArgs[PXR_NS::UsdUsdFileFormatTokens->FormatArg] = fileFormatExtension;
+        auto filename = std::string("a.") + fileFormatExtension;
+        fileFormat = PXR_NS::SdfFileFormat::FindByExtension(filename, fileFormatArgs);
+        if (PXR_NS::SdfFileFormat::GetFileExtension(dstLayerPath) != fileFormatExtension) {
+            dstLayerPath += std::string(".") + fileFormatExtension;
+        }
+    }
+
     // Prepare the layer
     PXR_NS::SdfPath dstPrimPath
         = PXR_NS::SdfPath(dstPrimName).MakeAbsolutePath(PXR_NS::SdfPath::AbsoluteRootPath());
-    PXR_NS::SdfLayerRefPtr tmpLayer = PXR_NS::SdfLayer::CreateAnonymous();
+    PXR_NS::SdfLayerRefPtr tmpLayer
+        = PXR_NS::SdfLayer::CreateAnonymous("", fileFormat, fileFormatArgs);
     SdfJustCreatePrimInLayer(tmpLayer, dstPrimPath);
 
-    tmpLayer->Export(dstLayerPath);
+    tmpLayer->Export(dstLayerPath, "", fileFormatArgs);
     PXR_NS::SdfLayerRefPtr dstLayer = PXR_NS::SdfLayer::FindOrOpen(dstLayerPath);
     if (!dstLayer)
         return;


### PR DESCRIPTION
- Disable the Binary/ASCII drop-down when the file format only supports one type.
- Properly enforce the selected type otherwise.