### PR TITLE
Implement pivot accessors for wrapped matrix ops.

### DIFF
--- a/lib/mayaUsd/ufe/UsdTransform3dSetObjectMatrix.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dSetObjectMatrix.cpp
@@ -64,6 +64,20 @@ Ufe::Vector3d UsdTransform3dSetObjectMatrix::scale() const
     return getScale(UsdTransform3dBase::matrix());
 }
 
+Ufe::Vector3d UsdTransform3dSetObjectMatrix::rotatePivot() const { return _wrapped->rotatePivot(); }
+
+Ufe::Vector3d UsdTransform3dSetObjectMatrix::scalePivot() const { return _wrapped->scalePivot(); }
+
+Ufe::Vector3d UsdTransform3dSetObjectMatrix::rotatePivotTranslation() const
+{
+    return _wrapped->rotatePivotTranslation();
+}
+
+Ufe::Vector3d UsdTransform3dSetObjectMatrix::scalePivotTranslation() const
+{
+    return _wrapped->scalePivotTranslation();
+}
+
 Ufe::SetMatrix4dUndoableCommand::Ptr
 UsdTransform3dSetObjectMatrix::setMatrixCmd(const Ufe::Matrix4d& m)
 {

--- a/lib/mayaUsd/ufe/UsdTransform3dSetObjectMatrix.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dSetObjectMatrix.h
@@ -104,10 +104,18 @@ public:
         const PXR_NS::GfMatrix4d&    mlInv,
         const PXR_NS::GfMatrix4d&    mrInv);
 
-    // Implementation for base class pure virtuals (illegal calls).
+    // Implementation for base class pure virtuals.  translation(), rotation()
+    // and scale() extract the translation, rotation and scale from the
+    // complete local transform.
     Ufe::Vector3d translation() const override;
     Ufe::Vector3d rotation() const override;
     Ufe::Vector3d scale() const override;
+
+    // Forward the pivot queries to the wrapped Transform3d.
+    Ufe::Vector3d rotatePivot() const override;
+    Ufe::Vector3d scalePivot() const override;
+    Ufe::Vector3d rotatePivotTranslation() const override;
+    Ufe::Vector3d scalePivotTranslation() const override;
 
     Ufe::SetMatrix4dUndoableCommand::Ptr setMatrixCmd(const Ufe::Matrix4d& m) override;
     void                                 setMatrix(const Ufe::Matrix4d& m) override;


### PR DESCRIPTION
Setting the rotate or scale pivot on a prim with a matrix (a.k.a. transform) transform op immediately creates a Maya fallback matrix stack, because pivot values are not supported by the single matrix data model.  When this occurs, a UsdTransform3dSetObjectMatrix wrapper Ufe::Transform3d interface is created to wrap the Maya fallback matrix stack.  This wrapper did not forward the pivot accessors to the wrapped Maya fallback stack, now fixed.