### PR TITLE
Fixed NURBS curve extents calculation to include widths

### DIFF
--- a/plugin/al/translators/NurbsCurve.cpp
+++ b/plugin/al/translators/NurbsCurve.cpp
@@ -143,7 +143,7 @@ UsdPrim NurbsCurve::exportObject(
     }
 
     if (params.getBool(GeometryExportOptions::kMeshExtents)) {
-        AL::usdmaya::utils::copyExtent(fnCurve, nurbs.GetExtentAttr(), params.m_timeCode);
+        AL::usdmaya::utils::copyExtent(fnCurve, nurbs, params.m_timeCode);
     }
 
     return nurbs.GetPrim();
@@ -233,27 +233,6 @@ void NurbsCurve::writeEdits(
             AL::usdmaya::utils::kAllNurbsCurveComponents);
     }
 
-    if (diff_curves & AL::usdmaya::utils::kCurvePoints) {
-        AL::usdmaya::utils::copyPoints(fnCurve, nurbsCurvesPrim.GetPointsAttr());
-    }
-    if (diff_curves & AL::usdmaya::utils::kCurveExtent) {
-        AL::usdmaya::utils::copyExtent(fnCurve, nurbsCurvesPrim.GetExtentAttr());
-    }
-    if (diff_curves & AL::usdmaya::utils::kCurveVertexCounts) {
-        AL::usdmaya::utils::copyCurveVertexCounts(
-            fnCurve, nurbsCurvesPrim.GetCurveVertexCountsAttr());
-    }
-    if (diff_curves & AL::usdmaya::utils::kKnots) {
-        UsdAttribute knotsAttr = nurbsCurvesPrim.GetKnotsAttr();
-        AL::usdmaya::utils::copyKnots(fnCurve, knotsAttr);
-    }
-    if (diff_curves & AL::usdmaya::utils::kRanges) {
-        UsdAttribute rangeAttr = nurbsCurvesPrim.GetRangesAttr();
-        AL::usdmaya::utils::copyRanges(fnCurve, rangeAttr);
-    }
-    if (diff_curves & AL::usdmaya::utils::kOrder) {
-        AL::usdmaya::utils::copyOrder(fnCurve, nurbsCurvesPrim.GetOrderAttr());
-    }
     if (diff_curves & AL::usdmaya::utils::kWidths) {
         /*TODO: Move into AL internal ExtraData translator code as this Width/Widths attribute
           follows internal render conventions*/
@@ -292,6 +271,28 @@ void NurbsCurve::writeEdits(
             dataWidths.push_back(widthPlug.asFloat());
             nurbsCurvesPrim.GetWidthsAttr().Set(dataWidths);
         }
+    }
+    if (diff_curves & AL::usdmaya::utils::kCurvePoints) {
+        AL::usdmaya::utils::copyPoints(fnCurve, nurbsCurvesPrim.GetPointsAttr());
+    }
+    if (diff_curves & AL::usdmaya::utils::kCurveExtent) {
+        // Proper extent calculation requires widths, must happen after width calculation
+        AL::usdmaya::utils::copyExtent(fnCurve, nurbsCurvesPrim);
+    }
+    if (diff_curves & AL::usdmaya::utils::kCurveVertexCounts) {
+        AL::usdmaya::utils::copyCurveVertexCounts(
+            fnCurve, nurbsCurvesPrim.GetCurveVertexCountsAttr());
+    }
+    if (diff_curves & AL::usdmaya::utils::kKnots) {
+        UsdAttribute knotsAttr = nurbsCurvesPrim.GetKnotsAttr();
+        AL::usdmaya::utils::copyKnots(fnCurve, knotsAttr);
+    }
+    if (diff_curves & AL::usdmaya::utils::kRanges) {
+        UsdAttribute rangeAttr = nurbsCurvesPrim.GetRangesAttr();
+        AL::usdmaya::utils::copyRanges(fnCurve, rangeAttr);
+    }
+    if (diff_curves & AL::usdmaya::utils::kOrder) {
+        AL::usdmaya::utils::copyOrder(fnCurve, nurbsCurvesPrim.GetOrderAttr());
     }
 }
 

--- a/plugin/al/translators/tests/testTranslators.py
+++ b/plugin/al/translators/tests/testTranslators.py
@@ -382,6 +382,66 @@ class TestTranslator(unittest.TestCase):
 
         os.remove(tempFile.name)
 
+    def testNurbsCurve_curve_width_none_export(self):
+        mc.CreateNURBSCircle()
+        with self.assertRaises(ValueError):
+            mc.getAttr("nurbsCircleShape1.width")
+
+        tempFile = tempfile.NamedTemporaryFile(suffix=".usda", prefix="testNurbsCurve_curve_width_export", delete=False)
+        tempFile.close()
+
+        mc.AL_usdmaya_ExportCommand(file=tempFile.name)
+        stage = Usd.Stage.Open(tempFile.name)
+        prim = stage.GetPrimAtPath("/nurbsCircle1")
+        nurbPrim = UsdGeom.NurbsCurves(prim)
+        self.assertTrue(nurbPrim.GetWidthsAttr())
+        actualWidths = nurbPrim.GetWidthsAttr().Get()
+        self.assertIsNone(actualWidths)
+
+        os.remove(tempFile.name)
+
+    def testNurbsCurve_curve_width_floatarrayempty_export(self):
+        expectedWidths = []
+        mc.CreateNURBSCircle()
+        mc.select("nurbsCircleShape1")
+        mc.addAttr(longName="width", dt="floatArray")
+        mc.setAttr("nurbsCircleShape1.width", expectedWidths ,type="floatArray")
+        self.assertIsNone(mc.getAttr("nurbsCircleShape1.width"))
+
+        tempFile = tempfile.NamedTemporaryFile(suffix=".usda", prefix="testNurbsCurve_curve_width_export", delete=False)
+        tempFile.close()
+
+        mc.AL_usdmaya_ExportCommand(file=tempFile.name)
+        stage = Usd.Stage.Open(tempFile.name)
+        prim = stage.GetPrimAtPath("/nurbsCircle1")
+        nurbPrim = UsdGeom.NurbsCurves(prim)
+        self.assertTrue(nurbPrim.GetWidthsAttr())
+        actualWidths = nurbPrim.GetWidthsAttr().Get()
+        self.assertEqual(len(actualWidths), 0)
+
+        os.remove(tempFile.name)
+
+    def testNurbsCurve_curve_width_doublearrayempty_export(self):
+        expectedWidths = []
+        mc.CreateNURBSCircle()
+        mc.select("nurbsCircleShape1")
+        mc.addAttr(longName="width", dt="doubleArray")
+        mc.setAttr("nurbsCircleShape1.width", expectedWidths ,type="doubleArray")
+        self.assertIsNone(mc.getAttr("nurbsCircleShape1.width"))
+
+        tempFile = tempfile.NamedTemporaryFile(suffix=".usda", prefix="testNurbsCurve_curve_width_export", delete=False)
+        tempFile.close()
+
+        mc.AL_usdmaya_ExportCommand(file=tempFile.name)
+        stage = Usd.Stage.Open(tempFile.name)
+        prim = stage.GetPrimAtPath("/nurbsCircle1")
+        nurbPrim = UsdGeom.NurbsCurves(prim)
+        self.assertTrue(nurbPrim.GetWidthsAttr())
+        actualWidths = nurbPrim.GetWidthsAttr().Get()
+        self.assertEqual(len(actualWidths), 0)
+
+        os.remove(tempFile.name)
+
     def testNurbsCurve_curve_width_double_export(self):
         expectedWidths = 1.
         mc.CreateNURBSCircle()

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/NurbsCurveUtils.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/NurbsCurveUtils.cpp
@@ -69,7 +69,7 @@ void copyPoints(const MFnNurbsCurve& fnCurve, const UsdAttribute& pointsAttr, Us
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-void copyExtent(const MFnNurbsCurve& fnCurve, const UsdAttribute& extentAttr, UsdTimeCode time)
+void copyExtent(const MFnNurbsCurve& fnCurve, const UsdGeomNurbsCurves& nurbs, UsdTimeCode time)
 {
     MPointArray controlVertices;
     fnCurve.getCVs(controlVertices);
@@ -81,9 +81,16 @@ void copyExtent(const MFnNurbsCurve& fnCurve, const UsdAttribute& extentAttr, Us
 
     convertDoubleVec4ArrayToFloatVec3Array(mayaCVs, usdPoints, cvCount);
 
+    // Extents calculation requires widths - set default width if empty or unfound for prim
+    VtFloatArray curveWidths;
+    nurbs.GetWidthsAttr().Get<VtFloatArray>(&curveWidths);
+    if (curveWidths.empty()) {
+        curveWidths.push_back(1.0f);
+    }
+
     VtArray<GfVec3f> mayaExtent(2);
-    UsdGeomPointBased::ComputeExtent(dataPoints, &mayaExtent);
-    extentAttr.Set(mayaExtent, time);
+    UsdGeomCurves::ComputeExtent(dataPoints, curveWidths, &mayaExtent);
+    nurbs.GetExtentAttr().Set(mayaExtent, time);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/NurbsCurveUtils.h
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/NurbsCurveUtils.h
@@ -37,9 +37,9 @@ void copyPoints(
 
 AL_USDMAYA_UTILS_PUBLIC
 void copyExtent(
-    const MFnNurbsCurve& fnCurve,
-    const UsdAttribute&  extentAttr,
-    UsdTimeCode          time = UsdTimeCode::Default());
+    const MFnNurbsCurve&      fnCurve,
+    const UsdGeomNurbsCurves& nurbs,
+    UsdTimeCode               time = UsdTimeCode::Default());
 
 AL_USDMAYA_UTILS_PUBLIC
 void copyCurveVertexCounts(


### PR DESCRIPTION
This PR aims to continue the alignment between the AL and ADSK plugins' export functionality, updating the AL plugin's NURBS curve export to perform the proper calculations on curve extents (authored as `float3[] extent`) by factoring in curve widths using the `UsdGeomCurves` implementation of `ComputeExtent` in lieu of `UsdGeomPointBased` (as it is in the ADSK plugin).