### PR TITLE
MAYA-123100 - Suppress UFE-proxy lights in Maya Scene Delegate to avoid lights duplication

### DIFF
--- a/lib/usd/hdMaya/delegates/sceneDelegate.cpp
+++ b/lib/usd/hdMaya/delegates/sceneDelegate.cpp
@@ -552,6 +552,15 @@ void HdMayaSceneDelegate::InsertDag(const MDagPath& dag)
         return;
     }
 
+    // Skip UFE nodes coming from USD runtime
+    // Those will be handled by USD Imaging delegate
+    MStatus              status;
+    static const MString ufeRuntimeStr = "ufeRuntime";
+    MPlug                ufeRuntimePlug = dagNode.findPlug(ufeRuntimeStr, false, &status);
+    if ((status == MS::kSuccess) && ufeRuntimePlug.asString() == "USD") {
+        return;
+    }
+
     // Custom lights don't have MFn::kLight.
     if (GetLightsEnabled()) {
         if (Create(dag, HdMayaAdapterRegistry::GetLightAdapterCreator(dag), _lightAdapters, true))


### PR DESCRIPTION
Adding a check into M2H scene delegate to not translate DAG nodes coming from UFE/USD runtime. This avoids object duplication as those objects are already hadled by USD Imaging delegate