### PR TITLE
MAYA-122541 fix hydra crash with skydome

### DIFF
--- a/lib/mayaUsd/render/mayaToHydra/plugin.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/plugin.cpp
@@ -102,6 +102,10 @@ PLUGIN_EXPORT MStatus uninitializePlugin(MObject obj)
             gsRenderOverrides[i] = nullptr;
         }
     }
+
+    // Note: when Maya is doing its default "quick exit" that does not uninitialize plugins,
+    //       these overrides crash on destruction because Hydra ha already destroyed things
+    //       these rely on. There is not much we can do about it...
     gsRenderOverrides.clear();
 
     // Clear any registered callbacks

--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
@@ -830,6 +830,15 @@ void MtohRenderOverride::ClearHydraResources()
     _delegates.clear();
     _defaultLightDelegate.reset();
 
+    // Cleanup internal context data that keep references to data that is now
+    // invalid.
+#if PXR_VERSION >= 2108
+    _engine.ClearTaskContextData();
+#else
+    for (const auto& token : HdxTokens->allTokens)
+        _engine.RemoveTaskContextData(token);
+#endif
+
     if (_taskController != nullptr) {
         delete _taskController;
         _taskController = nullptr;

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -183,7 +183,7 @@ UsdPrim ufePathToPrim(const Ufe::Path& path)
     const Ufe::Path ufePrimPath = stripInstanceIndexFromUfePath(path);
 
     const Ufe::Path::Segments& segments = ufePrimPath.getSegments();
-    auto                       stage = getStage(Ufe::Path(segments[0]));
+    UsdStageWeakPtr stage = segments.empty() ? UsdStageWeakPtr() : getStage(Ufe::Path(segments[0]));
     if (!stage)
         return UsdPrim();
 


### PR DESCRIPTION
Some resources used by the Hydra renderer are cached in the Hydra engine task context. The shutdown of the Maya-to-Hydra render override destroyed many Hydra-related objects, but the Hydra engine itself is kept by value and is never destroyed. We ended-up having data in teh task context that still referred to deleted objects and that led to a crsh if the Hydra render override was initialized and used again.

Arguably, the bug is in Hydra itself, where the texture handles (HdStTextureHandle) keep a raw pointer to the texture registry (HdSt_TextureHandleRegistry) instead of a smart pointer. That raw pointer is taken from the HdRenderIndex, which does keep its pointer to the registry as a shared_ptr.

OTOH, semi-shutting-down Hydra like our render override does is probably not correct. These low-level interactions and handling of shutdown and restart are rarely well documented.

In passing, I also fixed a bug in the UFE helper that assumed there always was at least one segment in teh given UFE path, which tured out to be wrong in some cases.