### PR TITLE
MAYA-123013 obey file-format choice in layer editor

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -697,7 +697,7 @@ BatchSaveResult LayerDatabase::saveUsdToUsdFiles()
                 SdfLayerHandleVector allLayers = stage->GetLayerStack(false);
                 for (auto layer : allLayers) {
                     if (layer->PermissionToSave()) {
-                        layer->Save();
+                        MayaUsd::utils::saveLayerWithFormat(layer);
                     }
                 }
             }
@@ -719,9 +719,8 @@ void LayerDatabase::convertAnonymousLayers(MayaUsdProxyShapeBase* pShape, UsdSta
 
     if (root->IsAnonymous()) {
         PXR_NS::SdfFileFormat::FileFormatArguments args;
-        args["format"] = MayaUsd::utils::usdFormatArgOption();
         std::string newFileName = MayaUsd::utils::generateUniqueFileName(proxyName);
-        root->Export(newFileName, "", args);
+        MayaUsd::utils::saveLayerWithFormat(root, newFileName);
 
         MayaUsd::utils::setNewProxyPath(pShape->name(), UsdMayaUtil::convert(newFileName));
     }

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -26,6 +26,7 @@
 #include <mayaUsd/utils/stageCache.h>
 #include <mayaUsd/utils/util.h>
 #include <mayaUsd/utils/utilFileSystem.h>
+#include <mayaUsd/utils/utilSerialization.h>
 
 #include <pxr/base/gf/bbox3d.h>
 #include <pxr/base/gf/range3d.h>
@@ -817,7 +818,10 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                     }
                 } else {
                     // Create a new stage in memory with an anonymous root layer.
-                    usdStage = UsdStage::CreateInMemory(kAnonymousLayerName, loadSet);
+                    SdfLayer::FileFormatArguments args;
+                    args["format"] = MayaUsd::utils::usdFormatArgOption();
+                    auto anonLayer = SdfLayer::CreateAnonymous(kAnonymousLayerName + ".usd", args);
+                    usdStage = UsdStage::Open(anonLayer, loadSet);
                 }
             }
         }

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -26,7 +26,6 @@
 #include <mayaUsd/utils/stageCache.h>
 #include <mayaUsd/utils/util.h>
 #include <mayaUsd/utils/utilFileSystem.h>
-#include <mayaUsd/utils/utilSerialization.h>
 
 #include <pxr/base/gf/bbox3d.h>
 #include <pxr/base/gf/range3d.h>
@@ -818,10 +817,7 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                     }
                 } else {
                     // Create a new stage in memory with an anonymous root layer.
-                    SdfLayer::FileFormatArguments args;
-                    args["format"] = MayaUsd::utils::usdFormatArgOption();
-                    auto anonLayer = SdfLayer::CreateAnonymous(kAnonymousLayerName + ".usd", args);
-                    usdStage = UsdStage::Open(anonLayer, loadSet);
+                    usdStage = UsdStage::CreateInMemory(kAnonymousLayerName, loadSet);
                 }
             }
         }

--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -184,6 +184,20 @@ void setNewProxyPath(const MString& proxyNodeName, const MString& newValue)
         /*undo*/ false);
 }
 
+bool saveLayerWithFormat(
+    SdfLayerRefPtr     layer,
+    const std::string& potentialFilePath,
+    std::string        formatArg)
+{
+    const std::string& filePath
+        = potentialFilePath.empty() ? layer->GetRealPath() : potentialFilePath;
+
+    PXR_NS::SdfFileFormat::FileFormatArguments args;
+    args["format"] = formatArg.empty() ? usdFormatArgOption() : formatArg;
+
+    return layer->Export(filePath, "", args);
+}
+
 SdfLayerRefPtr saveAnonymousLayer(
     SdfLayerRefPtr     anonLayer,
     LayerParent        parent,
@@ -204,14 +218,7 @@ SdfLayerRefPtr saveAnonymousLayer(
         return nullptr;
     }
 
-    PXR_NS::SdfFileFormat::FileFormatArguments args;
-    if (!formatArg.empty()) {
-        args["format"] = formatArg;
-    } else {
-        args["format"] = usdFormatArgOption();
-    }
-
-    anonLayer->Export(path, "", args);
+    saveLayerWithFormat(anonLayer, path, formatArg);
 
     SdfLayerRefPtr newLayer = SdfLayer::FindOrOpen(path);
     if (newLayer) {

--- a/lib/mayaUsd/utils/utilSerialization.h
+++ b/lib/mayaUsd/utils/utilSerialization.h
@@ -90,8 +90,8 @@ struct stageLayersToSave
 MAYAUSD_CORE_PUBLIC
 bool saveLayerWithFormat(
     SdfLayerRefPtr     layer,
-    const std::string& potentialFilePath = "",
-    std::string        formatArg = "");
+    const std::string& requestedFilePath = "",
+    const std::string& requestedFormatArg = "");
 
 /*! \brief Save an anonymous layer to disk and update the sublayer path array
     in the parent layer.

--- a/lib/mayaUsd/utils/utilSerialization.h
+++ b/lib/mayaUsd/utils/utilSerialization.h
@@ -82,6 +82,17 @@ struct stageLayersToSave
     std::vector<SdfLayerRefPtr>                         _dirtyFileBackedLayers;
 };
 
+/*! \brief Save an layer to disk to the given file path and using the given format.
+    If the file path is empty then use the current file path of the layer.
+    If the format is empty then use the current user-selected USD format option
+    as defined by the usdFormatArgOption() function. (See above.)
+ */
+MAYAUSD_CORE_PUBLIC
+bool saveLayerWithFormat(
+    SdfLayerRefPtr     layer,
+    const std::string& potentialFilePath = "",
+    std::string        formatArg = "");
+
 /*! \brief Save an anonymous layer to disk and update the sublayer path array
     in the parent layer.
  */

--- a/lib/usd/translators/mayaReferenceUpdater.cpp
+++ b/lib/usd/translators/mayaReferenceUpdater.cpp
@@ -24,6 +24,7 @@
 #include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/utils/editRouter.h>
 #include <mayaUsd/utils/util.h>
+#include <mayaUsd/utils/utilSerialization.h>
 #include <mayaUsdUtils/MergePrims.h>
 #include <mayaUsd_Schemas/ALMayaReference.h>
 #include <mayaUsd_Schemas/MayaReference.h>
@@ -211,7 +212,7 @@ UsdMayaPrimUpdater::PushCopySpecs PxrUsdTranslators_MayaReferenceUpdater::pushCo
 
         auto dstLayerStr = findValue(routingData, TfToken("save_layer"));
         if (dstLayerStr == "yes")
-            dstLayer->Save();
+            MayaUsd::utils::saveLayerWithFormat(dstLayer);
 
         // No further traversal should take place.
         return PushCopySpecs::Prune;

--- a/lib/usd/translators/mayaReferenceUpdater.cpp
+++ b/lib/usd/translators/mayaReferenceUpdater.cpp
@@ -212,7 +212,7 @@ UsdMayaPrimUpdater::PushCopySpecs PxrUsdTranslators_MayaReferenceUpdater::pushCo
 
         auto dstLayerStr = findValue(routingData, TfToken("save_layer"));
         if (dstLayerStr == "yes")
-            MayaUsd::utils::saveLayerWithFormat(dstLayer);
+            dstLayer->Save();
 
         // No further traversal should take place.
         return PushCopySpecs::Prune;

--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -351,7 +351,9 @@ void LayerTreeItem::saveEditsNoPrompt()
         if (!isSessionLayer())
             saveAnonymousLayer();
     } else {
-        layer()->Save();
+        PXR_NS::SdfFileFormat::FileFormatArguments args;
+        args["format"] = MayaUsd::utils::usdFormatArgOption();
+        layer()->Export(layer()->GetRealPath(), "", args);
     }
 }
 

--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -351,9 +351,7 @@ void LayerTreeItem::saveEditsNoPrompt()
         if (!isSessionLayer())
             saveAnonymousLayer();
     } else {
-        PXR_NS::SdfFileFormat::FileFormatArguments args;
-        args["format"] = MayaUsd::utils::usdFormatArgOption();
-        layer()->Export(layer()->GetRealPath(), "", args);
+        MayaUsd::utils::saveLayerWithFormat(layer());
     }
 }
 

--- a/lib/usd/ui/layerEditor/pathChecker.cpp
+++ b/lib/usd/ui/layerEditor/pathChecker.cpp
@@ -19,6 +19,8 @@
 #include "stringResources.h"
 #include "warningDialogs.h"
 
+#include <mayaUsd/utils/utilSerialization.h>
+
 #include <pxr/usd/ar/resolver.h>
 #include <pxr/usd/sdf/fileFormat.h>
 #include <pxr/usd/sdf/layerUtils.h>
@@ -181,10 +183,7 @@ bool saveSubLayer(
     }
 
     if (!fileError) {
-        PXR_NS::SdfFileFormat::FileFormatArguments formatArgs;
-        formatArgs["format"] = in_formatTag;
-
-        if (!in_layer->Export(in_absolutePath, "", formatArgs)) {
+        if (!MayaUsd::utils::saveLayerWithFormat(in_layer, in_absolutePath, in_formatTag)) {
             fileError = true;
         } else {
             // parent item is null if we're saving the root later

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/LayerCommands.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/LayerCommands.cpp
@@ -22,6 +22,8 @@
 #include "AL/usdmaya/nodes/ProxyShape.h"
 #include "AL/usdmaya/nodes/Transform.h"
 
+#include <mayaUsd/utils/utilSerialization.h>
+
 #include <pxr/usd/sdf/listOp.h>
 #include <pxr/usd/usd/stage.h>
 
@@ -737,12 +739,12 @@ MStatus LayerSave::doIt(const MArgList& argList)
                         MString temp;
                         args.getFlagArgument("-f", 0, temp);
                         const std::string filename = AL::maya::utils::convert(temp);
-                        bool              result = handle->Export(filename);
+                        bool result = MayaUsd::utils::saveLayerWithFormat(handle, filename);
                         setResult(result);
                         if (!result)
                             MGlobal::displayError("LayerSave: could not export layer");
                     } else {
-                        bool result = handle->Save();
+                        bool result = MayaUsd::utils::saveLayerWithFormat(handle);
                         setResult(result);
                         if (!result)
                             MGlobal::displayError("LayerSave: could not save layer");

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/LayerCommands.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/LayerCommands.cpp
@@ -739,12 +739,12 @@ MStatus LayerSave::doIt(const MArgList& argList)
                         MString temp;
                         args.getFlagArgument("-f", 0, temp);
                         const std::string filename = AL::maya::utils::convert(temp);
-                        bool result = MayaUsd::utils::saveLayerWithFormat(handle, filename);
+                        bool              result = handle->Export(filename);
                         setResult(result);
                         if (!result)
                             MGlobal::displayError("LayerSave: could not export layer");
                     } else {
-                        bool result = MayaUsd::utils::saveLayerWithFormat(handle);
+                        bool result = handle->Save();
                         setResult(result);
                         if (!result)
                             MGlobal::displayError("LayerSave: could not save layer");


### PR DESCRIPTION
When re-saving a modified layer, follow the current ASCII / Binary format selected in the layer editor.

Notes:
- USD SdfLayer does not have a Save() function taking the desired format. The only option we have is to use Export().
- The choice of binary / ASCII is in a sub-menu and is global to all layers and all stages. That may not be convenient for the user: changing it will affect all stages and all layers. Beware!