### PR TITLE
MAYA-115146 Simplify Maya Ref Node naming

### DIFF
--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
@@ -229,7 +229,7 @@ MStatus UsdMayaTranslatorMayaReference::LoadMayaReference(
 {
     TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
         .Msg("MayaReferenceLogic::LoadMayaReference prim=%s\n", prim.GetPath().GetText());
-    MStatus       status;
+    MStatus status;
 
     MFnDagNode parentDag(parent, &status);
     CHECK_MSTATUS_AND_RETURN_IT(status);


### PR DESCRIPTION
- Allow the old naming scheme if the environment variable MAYAUSD_ENABLE_MAYA_REFERENCE_OLD_BEHAVIOUR is set to 1.
- That was in case a user need the old behaviour while using the Al plugin.
- The new scheme keeps a custom attribute that records the correspondence between the namespace used for the Maya Ref and the Maya Ref node name.