### PR TITLE
MAYA-115146 change Maya Ref node naming

### DIFF
--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
@@ -35,6 +35,8 @@
 #include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/utils/util.h>
 
+#include <pxr/base/tf/getenv.h>
+
 #include <maya/MDGModifier.h>
 #include <maya/MFileIO.h>
 #include <maya/MFileObject.h>
@@ -46,6 +48,8 @@
 #include <maya/MNodeClass.h>
 #include <maya/MPlug.h>
 #include <maya/MSelectionList.h>
+
+#include <ghc/filesystem.hpp>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -136,6 +140,19 @@ const MObject getMessageAttr()
     return messageAttr;
 }
 
+const bool isMayaReference(const UsdPrim& prim)
+{
+    if (TfGetenvBool("MAYAUSD_ENABLE_MAYA_REFERENCE_OLD_BEHAVIOUR", false)) {
+        const TfToken MayaReference("MayaReference");
+        return prim.GetTypeName()
+            == MayaReference; // Only MayaReference prims are using the new behaviour.
+    } else {
+        return true; // Force new behaviour for all Maya Reference prims.
+    }
+}
+
+const TfToken MayaReferenceNodeName("MayaReferenceNodeName");
+
 MStatus LoadOrUnloadMayaReferenceWithUndo(const MObject& referenceObject, bool load)
 {
     MStatus status = MS::kSuccess;
@@ -171,6 +188,81 @@ const TfToken UsdMayaTranslatorMayaReference::m_referenceName = TfToken("mayaRef
 const TfToken UsdMayaTranslatorMayaReference::m_mergeNamespacesOnClash
     = TfToken("mergeNamespacesOnClash");
 
+// Get required namespace attribute from prim
+MString UsdMayaTranslatorMayaReference::namespaceFromPrim(const UsdPrim& prim)
+{
+    std::string ns;
+    if (UsdAttribute namespaceAttribute = prim.GetAttribute(m_namespaceName)) {
+        TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
+            .Msg(
+                "MayaReferenceLogic::update Checking namespace on prim \"%s\".\n",
+                prim.GetPath().GetText());
+
+        if (!namespaceAttribute.Get<std::string>(&ns)) {
+            TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
+                .Msg(
+                    "MayaReferenceLogic::update Missing namespace on prim \"%s\". Will create one "
+                    "from prim path.\n",
+                    prim.GetPath().GetText());
+            // Creating default namespace from prim path. Converts /a/b/c to a_b_c.
+            ns = prim.GetPath().GetString();
+            std::replace(ns.begin() + 1, ns.end(), '/', '_');
+        }
+    }
+    return MString(ns.c_str(), ns.size());
+}
+
+MString UsdMayaTranslatorMayaReference::getRefNodeNameFromPrim(const UsdPrim& prim)
+{
+    MString refNodeName;
+    refNodeName = namespaceFromPrim(prim);
+
+    if (refNodeName.length() == 0) {
+        SdfAssetPath mayaReferenceAssetPath;
+        // Check to see if we have a valid Maya reference node name
+        UsdAttribute mayaReferenceNodeName = prim.GetAttribute(m_referenceName);
+        mayaReferenceNodeName.Get(&mayaReferenceAssetPath);
+        ghc::filesystem::path fsFilePath(mayaReferenceAssetPath.GetAssetPath().c_str());
+        fsFilePath.replace_extension(""); // Remove the extension
+
+        refNodeName += fsFilePath.filename().string().c_str();
+    }
+    refNodeName += L"RN";
+    return refNodeName;
+}
+
+MString UsdMayaTranslatorMayaReference::getUniqueRefNodeName(
+    const UsdPrim&      prim,
+    const MFnDagNode&   parentDag,
+    const MFnReference& refDependNode)
+{
+    MString uniqueRefNodeName;
+    if (isMayaReference(prim)) {
+        // New behaviour for MayaReference
+        // Rename the reference node. Append "RN" to the end of filename, to indicate it's a
+        // reference node.
+        //
+        uniqueRefNodeName = namespaceFromPrim(prim);
+
+        if (uniqueRefNodeName.length() == 0) {
+            MString               filePath = refDependNode.fileName(false, false, false);
+            ghc::filesystem::path fsFilePath(filePath.asWChar());
+            fsFilePath.replace_extension(""); // Remove the extension
+            uniqueRefNodeName += fsFilePath.filename().wstring().c_str();
+        }
+        uniqueRefNodeName += L"RN";
+    } else {
+        // Old behaviour for ALMayaReference
+        // Rename the reference node.  We want a unique name so that multiple copies
+        // of a given prim can each have their own reference edits. We make a name
+        // from the full path to the prim for which the reference is being created
+        // (and append "_RN" to the end, to indicate it's a reference node, just
+        // because).
+        uniqueRefNodeName = refNameFromPath(parentDag) + "_RN";
+    }
+    return uniqueRefNodeName;
+}
+
 MStatus UsdMayaTranslatorMayaReference::LoadMayaReference(
     const UsdPrim& prim,
     MObject&       parent,
@@ -180,8 +272,7 @@ MStatus UsdMayaTranslatorMayaReference::LoadMayaReference(
 {
     TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
         .Msg("MayaReferenceLogic::LoadMayaReference prim=%s\n", prim.GetPath().GetText());
-    const TfToken maya_associatedReferenceNode("maya_associatedReferenceNode");
-    MStatus       status;
+    MStatus status;
 
     MFnDagNode parentDag(parent, &status);
     CHECK_MSTATUS_AND_RETURN_IT(status);
@@ -252,25 +343,17 @@ MStatus UsdMayaTranslatorMayaReference::LoadMayaReference(
     MFnReference refDependNode(referenceObject);
     connectReferenceAssociatedNode(parentDag, refDependNode);
 
-    // Rename the reference node.  We want a unique name so that multiple copies
-    // of a given prim can each have their own reference edits. We make a name
-    // from the full path to the prim for which the reference is being created
-    // (and append "_RN" to the end, to indicate it's a reference node, just
-    // because).
-    //
-    MString uniqueRefNodeName = refNameFromPath(parentDag) + "_RN";
+    MString uniqueRefNodeName = getUniqueRefNodeName(prim, parentDag, refDependNode);
     refDependNode.setName(uniqueRefNodeName);
+
+    // Always have to try to create the attribute to make sure it is in the prim scope and not
+    // inherited. If it was already created, it will be used.
+    UsdAttribute attr = prim.CreateAttribute(MayaReferenceNodeName, SdfValueTypeNames->String);
+    attr.Set(refDependNode.name().asChar());
 
     // Now load the reference to properly trigger the kAfterReferenceLoad callback
     status = LoadMayaReferenceWithUndo(referenceObject);
     CHECK_MSTATUS_AND_RETURN_IT(status);
-    {
-        // To avoid the error that USD complains about editing to same layer simultaneously from
-        // different threads, we record it as custom data instead of creating an attribute.
-        MString refDependNodeName = refDependNode.name();
-        VtValue value(std::string(refDependNodeName.asChar(), refDependNodeName.length()));
-        prim.SetCustomDataByKey(maya_associatedReferenceNode, value);
-    }
 
     return MS::kSuccess;
 }
@@ -339,9 +422,9 @@ MStatus UsdMayaTranslatorMayaReference::update(const UsdPrim& prim, MObject pare
 {
     MStatus      status;
     SdfAssetPath mayaReferenceAssetPath;
-    // Check to see if we have a valid Maya reference attribute
-    UsdAttribute mayaReferenceAttribute = prim.GetAttribute(m_referenceName);
-    mayaReferenceAttribute.Get(&mayaReferenceAssetPath);
+    // Check to see if we have a valid Maya reference node name
+    UsdAttribute mayaReferenceNodeName = prim.GetAttribute(m_referenceName);
+    mayaReferenceNodeName.Get(&mayaReferenceAssetPath);
     MString mayaReferencePath(mayaReferenceAssetPath.GetResolvedPath().c_str());
 
     // The resolved path is empty if the maya reference is a full path.
@@ -363,30 +446,12 @@ MStatus UsdMayaTranslatorMayaReference::update(const UsdPrim& prim, MObject pare
             prim.GetTypeName().GetText(),
             m_namespaceName.GetText());
 
-    // Get required namespace attribute from prim
-    std::string rigNamespace;
-    if (UsdAttribute rigNamespaceAttribute = prim.GetAttribute(m_namespaceName)) {
-        TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
-            .Msg(
-                "MayaReferenceLogic::update Checking namespace on prim \"%s\".\n",
-                prim.GetPath().GetText());
-
-        if (!rigNamespaceAttribute.Get<std::string>(&rigNamespace)) {
-            TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
-                .Msg(
-                    "MayaReferenceLogic::update Missing namespace on prim \"%s\". Will create one "
-                    "from prim path.\n",
-                    prim.GetPath().GetText());
-            // Creating default namespace from prim path. Converts /a/b/c to a_b_c.
-            rigNamespace = prim.GetPath().GetString();
-            std::replace(rigNamespace.begin() + 1, rigNamespace.end(), '/', '_');
-        }
-    }
-
     MFnDagNode parentDag(parent, &status);
     CHECK_MSTATUS_AND_RETURN_IT(status);
 
-    MString rigNamespaceM(rigNamespace.c_str(), rigNamespace.size());
+    // Get required namespace attribute from prim
+    MString     rigNamespaceM = namespaceFromPrim(prim);
+    std::string rigNamespace = rigNamespaceM.asChar();
 
     MObject refNode;
 
@@ -407,44 +472,107 @@ MStatus UsdMayaTranslatorMayaReference::update(const UsdPrim& prim, MObject pare
     // Check to see whether we have previously created a reference node for this
     // prim.  If so, we can just reuse it.
     //
-    // The check is based on comparing the prim's full path and the name of the
-    // reference node, which we had originally created from the prim's full
-    // path.  (Because of this, if the name or parentage of the prim has changed
-    // since we created the reference, we won't find the old reference node.
-    // The old one will be left orphaned, a new one will be created, and we will
-    // lose any reference edits we had made.  Ideally, this won't happen often.
-    // To prevent the problem, we could store the name of the reference node in
-    // an attribute on the prim node.  The reference node would never be renamed
-    // by the user, since it's locked.  If the user were to rename the prim
-    // node, we could update the reference node's name too, for consistency,
-    // when the two nodes got reattached.  Not doing this currently, but can
-    // revisit if renaming/reparenting of prims with reference nodes turns out
-    // to be a common thing in the workflow.)
-    //
     if (refNode.isNull()) {
-        for (MItDependencyNodes refIter(MFn::kReference); !refIter.isDone(); refIter.next()) {
-            MObject      tempRefNode = refIter.item();
-            MFnReference tempRefFn(tempRefNode);
-            if (!tempRefFn.isFromReferencedFile()) {
+        if (isMayaReference(prim)) {
+            // New behaviour for MayaReference
+            // Using a MayaReferenceNodeName attribute in the session layer to
+            // uniquely identify by name the MayaReferenceNode and reconnect to it.
+            // MayaReferenceNode is named using the mayaNamespace or filename if
+            // mayaNamespace is not set. And "RN" is added to the end.
+            // On reconnect MayaReferenceNode is rename to match any mayaNamespace
+            // or filename change.
+            // If the MayaReferenceNodeName is not found, we try a name match
+            // with all the non-connected reference node.
+            MString      expectedValue;
+            UsdAttribute attr;
 
-                // Get the name of the reference node so we can check if this node
-                // matches the prim we are processing.  Strip off the "_RN" suffix.
-                //
-                MString refNodeName = tempRefFn.name();
-                MString refName(refNodeName.asChar(), refNodeName.numChars() - 3);
+            if (prim.HasAttribute(MayaReferenceNodeName)) {
+                attr = prim.GetAttribute(MayaReferenceNodeName);
+                VtValue value;
+                attr.Get(&value);
+                auto resInfo = attr.GetResolveInfo();
+                // Check if attribute was directly on prim or inherited.
+                bool isAttributeOnPrim = resInfo.GetNode().GetPath() == prim.GetPath();
+                if (isAttributeOnPrim && value.GetType() == SdfValueTypeNames->String.GetType()) {
+                    expectedValue = MString(value.Get<std::string>().c_str());
+                }
+            }
 
-                // What reference node name is the prim expecting?
-                MString expectedRefName = refNameFromPath(parentDag);
+            // If the prim didn't have the MayaReferenceNodeName set properly used the prim info to
+            // try to match.
+            if (expectedValue.length() == 0) {
+                expectedValue = getRefNodeNameFromPrim(prim);
+            }
 
-                // If found a match, reconnect the reference node's `associatedNode`
-                // attr before loading it, since the previous connection may be gone.
-                //
-                if (refName == expectedRefName) {
-                    // Reconnect the reference node's `associatedNode` attr before
-                    // loading it, since the previous connection may be gone.
-                    connectReferenceAssociatedNode(parentDag, tempRefFn);
-                    refNode = tempRefNode;
-                    break;
+            if (expectedValue.length() != 0) {
+                for (MItDependencyNodes refIter(MFn::kReference); !refIter.isDone();
+                     refIter.next()) {
+                    MObject      tempRefNode = refIter.item();
+                    MFnReference tempRefFn(tempRefNode);
+                    if (!tempRefFn.isFromReferencedFile()) {
+                        if (expectedValue == tempRefFn.name()) {
+                            // Reconnect the reference node's `associatedNode` attr before
+                            // loading it, since the previous connection may be gone.
+                            connectReferenceAssociatedNode(parentDag, tempRefFn);
+                            refNode = tempRefNode;
+
+                            // Update Maya Ref Node on reconnect
+                            MString uniqueRefNodeName
+                                = getUniqueRefNodeName(prim, parentDag, tempRefFn);
+                            tempRefFn.setName(uniqueRefNodeName);
+
+                            MString refDependNodeName = tempRefFn.name();
+                            if (!attr.IsValid()) {
+                                attr = prim.CreateAttribute(
+                                    MayaReferenceNodeName, SdfValueTypeNames->String);
+                            }
+
+                            attr.Set(refDependNodeName.asChar());
+                            break;
+                        }
+                    }
+                }
+            }
+        } else {
+            // Old behaviour for ALMayaReference
+            // The check is based on comparing the prim's full path and the name of the
+            // reference node, which we had originally created from the prim's full
+            // path.  (Because of this, if the name or parentage of the prim has changed
+            // since we created the reference, we won't find the old reference node.
+            // The old one will be left orphaned, a new one will be created, and we will
+            // lose any reference edits we had made.  Ideally, this won't happen often.
+            // To prevent the problem, we could store the name of the reference node in
+            // an attribute on the prim node.  The reference node would never be renamed
+            // by the user, since it's locked.  If the user were to rename the prim
+            // node, we could update the reference node's name too, for consistency,
+            // when the two nodes got reattached.  Not doing this currently, but can
+            // revisit if renaming/reparenting of prims with reference nodes turns out
+            // to be a common thing in the workflow.)
+            //
+            for (MItDependencyNodes refIter(MFn::kReference); !refIter.isDone(); refIter.next()) {
+                MObject      tempRefNode = refIter.item();
+                MFnReference tempRefFn(tempRefNode);
+                if (!tempRefFn.isFromReferencedFile()) {
+
+                    // Get the name of the reference node so we can check if this node
+                    // matches the prim we are processing.  Strip off the "_RN" suffix.
+                    //
+                    MString refNodeName = tempRefFn.name();
+                    MString refName(refNodeName.asChar(), refNodeName.numChars() - 3);
+
+                    // What reference node name is the prim expecting?
+                    MString expectedRefName = refNameFromPath(parentDag);
+
+                    // If found a match, reconnect the reference node's `associatedNode`
+                    // attr before loading it, since the previous connection may be gone.
+                    //
+                    if (refName == expectedRefName) {
+                        // Reconnect the reference node's `associatedNode` attr before
+                        // loading it, since the previous connection may be gone.
+                        connectReferenceAssociatedNode(parentDag, tempRefFn);
+                        refNode = tempRefNode;
+                        break;
+                    }
                 }
             }
         }

--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.h
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.h
@@ -62,6 +62,12 @@ struct UsdMayaTranslatorMayaReference
     static MStatus update(const UsdPrim& prim, MObject parent);
 
 private:
+    static MString namespaceFromPrim(const UsdPrim& prim);
+    static MString getRefNodeNameFromPrim(const UsdPrim& prim);
+    static MString getUniqueRefNodeName(
+        const UsdPrim&      prim,
+        const MFnDagNode&   parentDag,
+        const MFnReference& refDependNode);
     static MStatus connectReferenceAssociatedNode(MFnDagNode& dagNode, MFnReference& refNode);
 
     static const TfToken m_namespaceName;

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -60,7 +60,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace {
 
-constexpr auto kIllegalUSDPath = "Illegal USD run-time path %s.";
+constexpr auto kIllegalUFEPath = "Illegal UFE run-time path %s.";
 
 bool stringBeginsWithDigit(const std::string& inputString)
 {
@@ -183,9 +183,13 @@ UsdPrim ufePathToPrim(const Ufe::Path& path)
     const Ufe::Path ufePrimPath = stripInstanceIndexFromUfePath(path);
 
     const Ufe::Path::Segments& segments = ufePrimPath.getSegments();
-    auto                       stage = getStage(Ufe::Path(segments[0]));
-    if (!stage)
+    if (!TF_VERIFY(!segments.empty(), kIllegalUFEPath, path.string().c_str())) {
         return UsdPrim();
+    }
+    auto stage = getStage(Ufe::Path(segments[0]));
+    if (!TF_VERIFY(stage, kIllegalUFEPath, path.string().c_str())) {
+        return UsdPrim();
+    }
 
     // If there is only a single segment in the path, it must point to the
     // proxy shape, otherwise we would not have retrieved a valid stage.
@@ -224,7 +228,7 @@ bool isRootChild(const Ufe::Path& path)
     // path and we are only testing whether or not we are a root child.
     auto segments = path.getSegments();
     if (segments.size() != 2) {
-        TF_RUNTIME_ERROR(kIllegalUSDPath, path.string().c_str());
+        TF_RUNTIME_ERROR(kIllegalUFEPath, path.string().c_str());
     }
     return (segments[1].size() == 1);
 }

--- a/plugin/al/translators/tests/testMayaRefStageA.usda
+++ b/plugin/al/translators/tests/testMayaRefStageA.usda
@@ -1,0 +1,10 @@
+#usda 1.0
+
+def Xform "world"
+{
+    def ALMayaReference "mayaRefPrim"
+    {
+        string mayaNamespace = "cube"
+        asset mayaReference = @./cube.ma@
+    }
+}

--- a/plugin/al/translators/tests/testMayaRefStageB.usda
+++ b/plugin/al/translators/tests/testMayaRefStageB.usda
@@ -1,0 +1,13 @@
+#usda 1.0
+
+def Xform "world"
+{
+    def Xform "newGroup"
+    {
+        def ALMayaReference "mayaRefPrim"
+        {
+            string mayaNamespace = "cube"
+            asset mayaReference = @./cube.ma@
+        }
+    }
+}

--- a/plugin/al/translators/tests/testTranslators.py
+++ b/plugin/al/translators/tests/testTranslators.py
@@ -1,6 +1,8 @@
 import unittest
 import tempfile
 import os
+import shutil
+
 import maya.cmds as mc
 import maya.mel as mel
 
@@ -131,6 +133,60 @@ class TestTranslator(unittest.TestCase):
         assertUsingMayaReferenceVariant()
         # ...and then make sure that our ref edit was preserved
         self.assertEqual(mc.getAttr('cubeNS:pCube1.translate')[0], (4.0, 5.0, 6.0))
+
+    @unittest.skipIf(os.getenv('MAYAUSD_ENABLE_MAYA_REFERENCE_OLD_BEHAVIOUR'),
+        'Not applicable with old Maya Reference behaviour')
+    def testMayaReference_SurvivesHierarchyChanges(self):
+        """
+        Tests that connection between MayaReference prim and maya reference does not
+        break on hierarchy changes if mayaNamespace UsdAttribute is used.
+        """
+        import AL.usdmaya
+
+        mc.file(new=1, f=1)
+
+        # copy usd file A to temporary location that can be referenced and changed.
+        tempFile = tempfile.NamedTemporaryFile(suffix=".usda", prefix="tempTestStage", delete=True)
+        tempPath = tempFile.name
+        # windows requires tempFile to be closed before it can be opened again.
+        tempFile.close()
+        try:
+            shutil.copy('./testMayaRefStageA.usda', tempPath)
+
+            # bring in stage as proxy shape
+            mc.AL_usdmaya_ProxyShapeImport(file=tempPath, name='root')
+            stage = AL.usdmaya.StageCache.Get().GetAllStages()[0]
+
+            # confirm ref is created with ns and ref node name
+            def checkOneRef():
+                self.assertEqual(1, len(mc.ls('cube:pCube1')))
+                # Note filter out "sharedRefenceNode" which is created when ref is unloaded.
+                self.assertEqual(1, len(mc.ls('*RN', type='reference')))
+
+            checkOneRef()
+
+            # unload ref manually, and resync
+            mc.file(unloadReference='cubeRN')
+            # confirm ref is unloaded.
+            self.assertEqual(0, len(mc.ls('cube:pCube1')))
+            self.assertEqual(1, len(mc.ls('*RN', type='reference')))
+
+            # save over with file B (prim at new location)
+            # this simulates pipe level updates to the shot stage.
+            shutil.copy('./testMayaRefStageB.usda', tempPath)
+
+            # resync
+            stage.Reload()
+            shapeObj = AL.usdmaya.ProxyShape.getByName('root')
+            shapeObj.resync('/')
+
+            # confirm only one ref, and is still connected
+            checkOneRef()
+
+            # check that rename happened to keep everything clean:
+            self.assertEqual(1, len(mc.ls('cubeRN', type='reference')))
+        finally:
+            os.remove(tempPath)
 
     def testMesh_TranslatorExists(self):
         """

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -53,15 +53,16 @@ endforeach()
 # Can be started with VS Code but won't be part of test suites.
 # -----------------------------------------------------------------------------
 set(target _Interactive_Maya)
-mayaUsd_add_test(${target}
+add_test(
+    NAME "${target}"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMAND ${MAYA_EXECUTABLE}
-    ENV
-        "MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/lib/maya"
-        "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
 )
+
 set_property(TEST ${target} APPEND PROPERTY DISABLED True)
 set_property(TEST ${target} APPEND PROPERTY LABELS Debugging)
+set_property(TEST ${target} APPEND PROPERTY ENVIRONMENT "MAYA_MODULE_PATH=${CMAKE_INSTALL_PREFIX}")
+set_property(TEST ${target} APPEND PROPERTY ENVIRONMENT "MAYAUSD_ENABLE_ADD_MAYA_REFERENCE=TRUE")
 
 #
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Based on Yves Boudreault's branch. Simplified it a bit after merging

- Add an environment variable MAYAUSD_ENABLE_MAYA_REFERENCE_OLD_BEHAVIOUR to use the old behaviour in AL.
- Keeps the Maya Ref node name in a custom attribute.
- Requires that the attribute be directly on the prim, not in a lower layer or indirect reference.
- This allows having a different Maya Ref Node for each prim even if they are built from teh same substrate.
- Adds more unit tests.