### PR TITLE
[al] Fixed issue that resync prim would cause irrelevant translators being removed

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.cpp
@@ -781,7 +781,7 @@ MStatus ProxyShapeResync::redoIt()
         return MStatus::kFailure;
     }
 
-    m_shapeNode->primChangedAtPath(m_resyncPrimPath);
+    m_shapeNode->resync(m_resyncPrimPath);
 
     return MStatus::kSuccess;
 }

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.cpp
@@ -33,6 +33,23 @@ const int _translatorContextProfilerCategory = MProfiler::addCategory(
     "TranslatorContext"
 #endif
 );
+
+bool isDescendantPath(const SdfPathSet& affectedPaths, const SdfPath& path)
+{
+    if (affectedPaths.empty()) {
+        // Preserve the behaviour for translate prim command that would not
+        // have any path
+        return true;
+    }
+
+    for (const auto& affectedPath : affectedPaths) {
+        if (path.HasPrefix(affectedPath)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 } // namespace
 
 namespace AL {
@@ -89,7 +106,7 @@ bool TranslatorContext::getTransform(const SdfPath& path, MObjectHandle& object)
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-void TranslatorContext::updatePrimTypes()
+void TranslatorContext::updatePrimTypes(const SdfPathSet& affectedPaths)
 {
     MProfilingScope profilerScope(
         _translatorContextProfilerCategory, MProfiler::kColorE_L3, "Update prim types");
@@ -100,8 +117,11 @@ void TranslatorContext::updatePrimTypes()
         UsdPrim prim = stage->GetPrimAtPath(path);
         bool    modifiedIt = false;
         if (!prim) {
-            it = m_primMapping.erase(it);
-            modifiedIt = true;
+            // Check if the registered prim path is being affected
+            if (isDescendantPath(affectedPaths, path)) {
+                it = m_primMapping.erase(it);
+                modifiedIt = true;
+            }
         } else {
             std::string translatorId
                 = m_proxyShape->translatorManufacture().generateTranslatorId(prim);

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.cpp
@@ -117,7 +117,7 @@ void TranslatorContext::updatePrimTypes(const SdfPathSet& affectedPaths)
         UsdPrim prim = stage->GetPrimAtPath(path);
         bool    modifiedIt = false;
         if (!prim) {
-            // Check if the registered prim path is being affected
+            // Check if the registered prim path is affected
             if (isDescendantPath(affectedPaths, path)) {
                 it = m_primMapping.erase(it);
                 modifiedIt = true;

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.h
@@ -261,8 +261,9 @@ public:
     /// \brief  this method is used after a variant switch to check to see if the prim types have
     /// changed in the
     ///         stage, and will update the internal state accordingly.
+    /// \param affectedPaths paths that being affected during translation
     AL_USDMAYA_PUBLIC
-    void updatePrimTypes();
+    void updatePrimTypes(const SdfPathSet& affectedPaths = SdfPathSet());
 
     /// \brief  Internal method.
     ///         If within your custom translator plug-in you need to create any maya nodes,

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.h
@@ -261,7 +261,7 @@ public:
     /// \brief  this method is used after a variant switch to check to see if the prim types have
     /// changed in the
     ///         stage, and will update the internal state accordingly.
-    /// \param affectedPaths paths that being affected during translation
+    /// \param affectedPaths affected paths during translation
     AL_USDMAYA_PUBLIC
     void updatePrimTypes(const SdfPathSet& affectedPaths = SdfPathSet());
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -766,7 +766,7 @@ public:
     /// \param importPrims array of prims you wish to import
     /// \param teardownPaths paths you wish to teardown
     /// \param param are flags which direct the translation of the prims
-    /// \param affectedPaths paths that being affected during translation
+    /// \param affectedPaths affected paths during translation
     AL_USDMAYA_PUBLIC
     void translatePrimsIntoMaya(
         const MayaUsdUtils::UsdPrimVector&               importPrims,

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -766,12 +766,14 @@ public:
     /// \param importPrims array of prims you wish to import
     /// \param teardownPaths paths you wish to teardown
     /// \param param are flags which direct the translation of the prims
+    /// \param affectedPaths paths that being affected during translation
     AL_USDMAYA_PUBLIC
     void translatePrimsIntoMaya(
         const MayaUsdUtils::UsdPrimVector&               importPrims,
         const SdfPathVector&                             teardownPaths,
         const fileio::translators::TranslatorParameters& param
-        = fileio::translators::TranslatorParameters());
+        = fileio::translators::TranslatorParameters(),
+        const SdfPathSet& affectedPaths = SdfPathSet());
 
     /// \brief  Breaks a comma separated string up into a SdfPath Vector
     /// \param  paths the comma separated list of paths

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/test_data/resync_root.usda
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/test_data/resync_root.usda
@@ -1,0 +1,29 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+    subLayers = [
+        @./resync_sublayer.usda@
+    ]
+)
+
+def "root"
+{
+    over "group1"
+    {
+        def "rig1"
+        {
+        }
+    }
+    over "group2"
+    {
+        def "rig2"
+        {
+        }
+    }
+    over "group3"
+    {
+        def "rig3"
+        {
+        }
+    }
+}

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/test_data/resync_sublayer.usda
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/test_data/resync_sublayer.usda
@@ -1,0 +1,42 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+)
+
+over "root" (
+)
+{
+    def "group1"
+    {
+        over "rig1"
+        {
+            def "test1" (
+                assettype = "test"
+            )
+            {
+            }
+        }
+    }
+    def "group2"
+    {
+        over "rig2"
+        {
+            def "test2" (
+                assettype = "test"
+            )
+            {
+            }
+        }
+    }
+    def "group3"
+    {
+        over "rig3"
+        {
+            def "test3" (
+                assettype = "test"
+            )
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
USD hierarchy might become invalid after resync (managed by translators that are not in AL_USDMaya's scope), this PR fixed the issue that irrelevant translators were removed on resync, if the registered prim is not a child of requested resync path, keep the translator and do nothing (leaving it handled by its own translator).