### PR TITLE
MAYA-122146 - Selecting a camera and framing it with "f" shows the origin instead of the camera

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -1241,8 +1241,10 @@ MBoundingBox MayaUsdProxyShapeBase::boundingBox() const
     const TfToken purpose3 = drawProxyPurpose ? UsdGeomTokens->proxy : TfToken();
     const TfToken purpose4 = drawGuidePurpose ? UsdGeomTokens->guide : TfToken();
 
-    const GfBBox3d allBox
+    GfBBox3d allBox
         = imageablePrim.ComputeUntransformedBound(currTime, purpose1, purpose2, purpose3, purpose4);
+
+    UsdMayaUtil::AddMayaExtents(allBox, prim, currTime);
 
     MBoundingBox& retval = nonConstThis->_boundingBoxCache[currTime];
 

--- a/lib/mayaUsd/ufe/UsdLight.h
+++ b/lib/mayaUsd/ufe/UsdLight.h
@@ -83,10 +83,10 @@ public:
     float                        specular() const override;
 
 protected:
-    std::shared_ptr<DirectionalInterface> directionalInterfaceImpl();
-    std::shared_ptr<SphereInterface>      sphereInterfaceImpl();
-    std::shared_ptr<ConeInterface>        coneInterfaceImpl();
-    std::shared_ptr<AreaInterface>        areaInterfaceImpl();
+    std::shared_ptr<DirectionalInterface> directionalInterfaceImpl() override;
+    std::shared_ptr<SphereInterface>      sphereInterfaceImpl() override;
+    std::shared_ptr<ConeInterface>        coneInterfaceImpl() override;
+    std::shared_ptr<AreaInterface>        areaInterfaceImpl() override;
 
 private:
     UsdSceneItem::Ptr fItem;

--- a/lib/mayaUsd/utils/util.h
+++ b/lib/mayaUsd/utils/util.h
@@ -695,6 +695,14 @@ MAYAUSD_CORE_PUBLIC
 std::set<std::string>
 getAllSublayers(const std::vector<std::string>& parentLayerPaths, bool includeParents = false);
 
+/// Takes the supplied bounding box and adds to it Maya-specific extents
+/// that come from the nodes originating from the supplied root node
+MAYAUSD_CORE_PUBLIC
+void AddMayaExtents(
+    PXR_NS::GfBBox3d&         bbox,
+    const PXR_NS::UsdPrim&    root,
+    const PXR_NS::UsdTimeCode time);
+
 } // namespace UsdMayaUtil
 
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
Add Maya-specific camera extents to the USD UFE bounding box calculation