### PR TITLE
MAYA-123016 stage clear now resets the outliner

### DIFF
--- a/lib/mayaUsd/utils/stageCache.cpp
+++ b/lib/mayaUsd/utils/stageCache.cpp
@@ -58,15 +58,19 @@ struct _OnSceneResetListener : public TfWeakBase
     }
 };
 
-void clearMayaOutliner()
+void clearMayaAttributeEditor()
 {
-    // When a stage is deleted, the outliner could still refer to prims that were on that stage.
-    // If the outliner is collapsed, then it won't refresh itself and could later on try to access
-    // the prim. This happens when it receives a UFE notification that it thinks is about the prim
-    // it is showing. This only happens if one re-stage the same file, as the UFE notification will
-    // contain the same stage name and the same prim path.
+    // When a stage is deleted, the attribute editor could still refer to prims
+    // that were on that stage. If the attribute editor is collapsed, then it
+    // won't refresh itself and could later on try to access the prim.
     //
-    // To avoid crashes, we reset the outliner templates when the stages get cleared.
+    // This happens when it receives a UFE notification that it thinks is about
+    // the prim it is showing. This only happens if one re-stage the same file,
+    // as the UFE notification will contain the same stage name and the same
+    // prim path.
+    //
+    // To avoid crashes, we refresh the attribute editor templates when the
+    // stages get cleared.
     MGlobal::executeCommand("refreshEditorTemplates");
 }
 
@@ -87,7 +91,7 @@ UsdStageCache& UsdMayaStageCache::Get(const bool loadAll)
 /* static */
 void UsdMayaStageCache::Clear()
 {
-    clearMayaOutliner();
+    clearMayaAttributeEditor();
     Get(true).Clear();
     Get(false).Clear();
 }
@@ -102,7 +106,7 @@ size_t UsdMayaStageCache::EraseAllStagesWithRootLayerPath(const std::string& lay
         return erasedStages;
     }
 
-    clearMayaOutliner();
+    clearMayaAttributeEditor();
 
     erasedStages += Get(true).EraseAll(rootLayer);
     erasedStages += Get(false).EraseAll(rootLayer);


### PR DESCRIPTION
When a prim is shown in the outliner and  the outliner gets collapsed, then the outliner still keeps the reference to the prim. But because it is collapsed it does not update when the selection changes. On the other hand, stages only go away when a new Maya scene is created since they are cached. Also, UFE notifications are based on UFE paths.

So if a USD file was staged, a prim selected and shown in the AE, then the AE gets collapsed, then a new Maya scene gets created and the same USD file is staged, then selecting the same prim and modifying (say, translating it), it would send a UFE notification with the same UFE path, but the prim in the AE is the prim in the old stage that no longer exists.

We now reset the outliner when clearing the stage cache for this reason.