### PR TITLE
MAYA-123419 add execution validation during pull/push

### DIFF
--- a/lib/mayaUsd/commands/PullPushCommands.cpp
+++ b/lib/mayaUsd/commands/PullPushCommands.cpp
@@ -286,7 +286,9 @@ MStatus MergeToUsdCommand::doIt(const MArgList& argList)
             // Select the merged prim.  See DuplicateCommand::doIt() comments.
             Ufe::Selection sn;
             sn.append(Ufe::Hierarchy::createItem(pulledPath));
-            UfeSelectionUndoItem::select("mergeToUsd: select merged prim", sn);
+            if (!UfeSelectionUndoItem::select("mergeToUsd: select merged prim", sn)) {
+                return MS::kFailure;
+            }
         }
     }
 
@@ -355,7 +357,9 @@ MStatus DiscardEditsCommand::doIt(const MArgList& argList)
             if (pulledItem) {
                 sn.append(pulledItem);
             }
-            UfeSelectionUndoItem::select("discardEdits: select original prim", sn);
+            if (!UfeSelectionUndoItem::select("discardEdits: select original prim", sn)) {
+                return MS::kFailure;
+            }
         }
     }
 
@@ -453,7 +457,9 @@ MStatus DuplicateCommand::doIt(const MArgList& argList)
             // It is appropriate to use the overload that uses the global list,
             // as the undo recorder will transfer the items on the global list
             // to fUndoItemList.
-            UfeSelectionUndoItem::select("duplicate: select duplicate", sn);
+            if (!UfeSelectionUndoItem::select("duplicate: select duplicate", sn)) {
+                return MS::kFailure;
+            }
         }
     }
 

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -173,26 +173,29 @@ bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& path)
     }
 
     // Add to a set, the set should already been created.
-    FunctionUndoItem::execute(
-        "Add edited item to pull set.",
-        [path]() {
-            MObject pullSetObj;
-            auto    status = UsdMayaUtil::GetMObjectByName(kPullSetName, pullSetObj);
-            if (status != MStatus::kSuccess)
-                return false;
-            MFnSet fnPullSet(pullSetObj);
-            fnPullSet.addMember(path);
-            return true;
-        },
-        [path]() {
-            MObject pullSetObj;
-            auto    status = UsdMayaUtil::GetMObjectByName(kPullSetName, pullSetObj);
-            if (status != MStatus::kSuccess)
-                return false;
-            MFnSet fnPullSet(pullSetObj);
-            fnPullSet.removeMember(path, MObject::kNullObj);
-            return true;
-        });
+    if (!FunctionUndoItem::execute(
+            "Add edited item to pull set.",
+            [path]() {
+                MObject pullSetObj;
+                auto    status = UsdMayaUtil::GetMObjectByName(kPullSetName, pullSetObj);
+                if (status != MStatus::kSuccess)
+                    return false;
+                MFnSet fnPullSet(pullSetObj);
+                fnPullSet.addMember(path);
+                return true;
+            },
+            [path]() {
+                MObject pullSetObj;
+                auto    status = UsdMayaUtil::GetMObjectByName(kPullSetName, pullSetObj);
+                if (status != MStatus::kSuccess)
+                    return false;
+                MFnSet fnPullSet(pullSetObj);
+                fnPullSet.removeMember(path, MObject::kNullObj);
+                return true;
+            })) {
+        TF_WARN("Cannot edited object to pulled set.");
+        return false;
+    }
 
     // Store metadata on the prim in the Session Layer.
     auto stage = pulledPrim.GetStage();
@@ -200,7 +203,8 @@ bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& path)
         return false;
     UsdEditContext editContext(stage, stage->GetSessionLayer());
     VtValue        value(path.fullPathName().asChar());
-    pulledPrim.SetCustomDataByKey(kPullPrimMetadataKey, value);
+    if (!pulledPrim.SetMetadataByDictKey(SdfFieldKeys->CustomData, kPullPrimMetadataKey, value))
+        return false;
 
     // Store medata on DG node
     auto              ufePathString = Ufe::PathString::string(ufePulledPath);
@@ -253,7 +257,8 @@ bool addExcludeFromRendering(const Ufe::Path& ufePulledPath)
         return false;
 
     UsdEditContext editContext(stage, stage->GetSessionLayer());
-    prim.SetActive(false);
+    if (!prim.SetActive(false))
+        return false;
 
     return true;
 }
@@ -272,7 +277,9 @@ bool removeExcludeFromRendering(const Ufe::Path& ufePulledPath)
     UsdEditContext editContext(stage, sessionLayer);
 
     // Cleanup the field and potentially empty over
-    prim.ClearActive();
+    if (!prim.ClearActive())
+        return false;
+
     SdfPrimSpecHandle primSpec = MayaUsdUtils::getPrimSpecAtEditTarget(prim);
     if (sessionLayer && primSpec)
         sessionLayer->ScheduleRemoveIfInert(primSpec.GetSpec());
@@ -312,13 +319,10 @@ PullImportPaths pullImport(
     const UsdPrim&                   pulledPrim,
     const UsdMayaPrimUpdaterContext& context)
 {
-    std::vector<MDagPath>  addedDagPaths;
-    std::vector<Ufe::Path> pulledUfePaths;
-
     std::string mFileName = context.GetUsdStage()->GetRootLayer()->GetIdentifier();
     if (mFileName.empty()) {
         TF_WARN("Nothing to edit: invalid layer.");
-        return PullImportPaths(addedDagPaths, pulledUfePaths);
+        return PullImportPaths();
     }
 
     VtDictionary userArgs(context.GetUserArgs());
@@ -345,6 +349,9 @@ PullImportPaths pullImport(
             }
         }
     }
+
+    std::vector<MDagPath>  addedDagPaths;
+    std::vector<Ufe::Path> pulledUfePaths;
 
     // Execute the command, which can succeed but import nothing.
     bool success = readJob->Read(&addedDagPaths);
@@ -404,8 +411,11 @@ PullImportPaths pullImport(
             Ufe::PathString::string(ufeChild).c_str(),
             Ufe::PathString::string(ufeParent).c_str());
 
-        PythonUndoItem::execute("Pull import proxy accessor parenting", pyCommand, pyUndoCommand);
-        // -- end --
+        if (!PythonUndoItem::execute(
+                "Pull import proxy accessor parenting", pyCommand, pyUndoCommand)) {
+            TF_WARN("Cannot parent pulled object.");
+            return PullImportPaths();
+        }
 
         // Create the pull set if it does not exists.
         //
@@ -423,23 +433,29 @@ PullImportPaths pullImport(
         }
 
         // Finalize the pull.
-        FunctionUndoItem::execute(
-            "Pull import pull info writing",
-            [ufePulledPath, addedDagPath]() {
-                return writePullInformation(ufePulledPath, addedDagPath);
-            },
-            [ufePulledPath]() {
-                removePullInformation(ufePulledPath);
-                return true;
-            });
+        if (!FunctionUndoItem::execute(
+                "Pull import pull info writing",
+                [ufePulledPath, addedDagPath]() {
+                    return writePullInformation(ufePulledPath, addedDagPath);
+                },
+                [ufePulledPath]() {
+                    removePullInformation(ufePulledPath);
+                    return true;
+                })) {
+            TF_WARN("Cannot write pull information metadata.");
+            return PullImportPaths();
+        }
 
-        FunctionUndoItem::execute(
-            "Pull import rendering exclusion",
-            [ufePulledPath]() { return addExcludeFromRendering(ufePulledPath); },
-            [ufePulledPath]() {
-                removeExcludeFromRendering(ufePulledPath);
-                return true;
-            });
+        if (!FunctionUndoItem::execute(
+                "Pull import rendering exclusion",
+                [ufePulledPath]() { return addExcludeFromRendering(ufePulledPath); },
+                [ufePulledPath]() {
+                    removeExcludeFromRendering(ufePulledPath);
+                    return true;
+                })) {
+            TF_WARN("Cannot exclude original USD data from viewport rendering.");
+            return PullImportPaths();
+        }
 
         UfeSelectionUndoItem::select("Pull import select DAG node", addedDagPath);
     }
@@ -878,13 +894,16 @@ bool PrimUpdaterManager::mergeToUsd(
         std::get<UsdPathToDagPathMapPtr>(pushCustomizeSrc));
 
     if (!isCopy) {
-        FunctionUndoItem::execute(
-            "Merge to Maya rendering inclusion",
-            [pulledPath]() {
-                removeExcludeFromRendering(pulledPath);
-                return true;
-            },
-            [pulledPath]() { return addExcludeFromRendering(pulledPath); });
+        if (!FunctionUndoItem::execute(
+                "Merge to Maya rendering inclusion",
+                [pulledPath]() {
+                    removeExcludeFromRendering(pulledPath);
+                    return true;
+                },
+                [pulledPath]() { return addExcludeFromRendering(pulledPath); })) {
+            TF_WARN("Cannot re-enable original USD data in viewport rendering.");
+            return false;
+        }
     }
 
     if (!pushCustomize(pulledPath, pushCustomizeSrc, customizeContext)) {
@@ -892,13 +911,18 @@ bool PrimUpdaterManager::mergeToUsd(
     }
 
     if (!isCopy) {
-        FunctionUndoItem::execute(
-            "Merge to Maya pull info removal",
-            [pulledPath]() {
-                removePullInformation(pulledPath);
-                return true;
-            },
-            [pulledPath, mayaDagPath]() { return writePullInformation(pulledPath, mayaDagPath); });
+        if (!FunctionUndoItem::execute(
+                "Merge to Maya pull info removal",
+                [pulledPath]() {
+                    removePullInformation(pulledPath);
+                    return true;
+                },
+                [pulledPath, mayaDagPath]() {
+                    return writePullInformation(pulledPath, mayaDagPath);
+                })) {
+            TF_WARN("Cannot remove pull information metadata.");
+            return false;
+        }
     }
 
     // Discard all pulled Maya nodes.
@@ -1086,21 +1110,29 @@ bool PrimUpdaterManager::discardPrimEdits(const Ufe::Path& pulledPath)
         updater->discardEdits();
     }
 
-    FunctionUndoItem::execute(
-        "Discard edits pull info removal",
-        [pulledPath]() {
-            removePullInformation(pulledPath);
-            return true;
-        },
-        [pulledPath, mayaDagPath]() { return writePullInformation(pulledPath, mayaDagPath); });
+    if (!FunctionUndoItem::execute(
+            "Discard edits pull info removal",
+            [pulledPath]() {
+                removePullInformation(pulledPath);
+                return true;
+            },
+            [pulledPath, mayaDagPath]() {
+                return writePullInformation(pulledPath, mayaDagPath);
+            })) {
+        TF_WARN("Cannot remove pull information metadata.");
+        return false;
+    }
 
-    FunctionUndoItem::execute(
-        "Discard edits rendering inclusion",
-        [pulledPath]() {
-            removeExcludeFromRendering(pulledPath);
-            return true;
-        },
-        [pulledPath]() { return addExcludeFromRendering(pulledPath); });
+    if (!FunctionUndoItem::execute(
+            "Discard edits rendering inclusion",
+            [pulledPath]() {
+                removeExcludeFromRendering(pulledPath);
+                return true;
+            },
+            [pulledPath]() { return addExcludeFromRendering(pulledPath); })) {
+        TF_WARN("Cannot re-enable original USD data in viewport rendering.");
+        return false;
+    }
 
     if (!TF_VERIFY(removePullParent(pullParent))) {
         return false;
@@ -1358,16 +1390,19 @@ MObject PrimUpdaterManager::findOrCreatePullRoot()
     MFnDependencyNode pullRootFn(pullRootObj);
     UsdMayaUtil::SetHiddenInOutliner(pullRootFn, true);
 
-    FunctionUndoItem::execute(
-        "Create pull root cache has pulled prims",
-        [self = this]() {
-            self->_hasPulledPrims = true;
-            return true;
-        },
-        [self = this]() {
-            self->_hasPulledPrims = false;
-            return true;
-        });
+    if (!FunctionUndoItem::execute(
+            "Create pull root cache has pulled prims",
+            [self = this]() {
+                self->_hasPulledPrims = true;
+                return true;
+            },
+            [self = this]() {
+                self->_hasPulledPrims = false;
+                return true;
+            })) {
+        TF_WARN("Cannot create pulled prim cache.");
+        return MObject();
+    }
 
     return pullRootObj;
 }
@@ -1411,16 +1446,19 @@ bool PrimUpdaterManager::removePullParent(const MDagPath& parentDagPath)
             if (status != MStatus::kSuccess) {
                 return false;
             }
-            FunctionUndoItem::execute(
-                "Delete pull root cache no pulled prims",
-                [self = this]() {
-                    self->_hasPulledPrims = false;
-                    return true;
-                },
-                [self = this]() {
-                    self->_hasPulledPrims = true;
-                    return true;
-                });
+            if (!FunctionUndoItem::execute(
+                    "Delete pull root cache no pulled prims",
+                    [self = this]() {
+                        self->_hasPulledPrims = false;
+                        return true;
+                    },
+                    [self = this]() {
+                        self->_hasPulledPrims = true;
+                        return true;
+                    })) {
+                TF_WARN("Cannot removed pulled prim from the pulled prim cache.");
+                return false;
+            }
         }
     }
 

--- a/lib/mayaUsd/undo/OpUndoItems.cpp
+++ b/lib/mayaUsd/undo/OpUndoItems.cpp
@@ -194,7 +194,7 @@ PythonUndoItem::PythonUndoItem(const std::string name, MString pythonDo, MString
 
 PythonUndoItem::~PythonUndoItem() { }
 
-void PythonUndoItem::execute(
+bool PythonUndoItem::execute(
     const std::string name,
     MString           pythonDo,
     MString           pythonUndo,
@@ -202,11 +202,13 @@ void PythonUndoItem::execute(
 {
     auto item = std::make_unique<PythonUndoItem>(
         std::move(name), std::move(pythonDo), std::move(pythonUndo));
-    item->redo();
+    if (!item->redo())
+        return false;
     undoInfo.addItem(std::move(item));
+    return true;
 }
 
-void PythonUndoItem::execute(const std::string name, MString pythonDo, MString pythonUndo)
+bool PythonUndoItem::execute(const std::string name, MString pythonDo, MString pythonUndo)
 {
     return execute(name, pythonDo, pythonUndo, OpUndoItemList::instance());
 }
@@ -260,7 +262,7 @@ void FunctionUndoItem::create(
     create(name, redo, undo, OpUndoItemList::instance());
 }
 
-void FunctionUndoItem::execute(
+bool FunctionUndoItem::execute(
     const std::string     name,
     std::function<bool()> redo,
     std::function<bool()> undo,
@@ -268,16 +270,18 @@ void FunctionUndoItem::execute(
 {
     auto item
         = std::make_unique<FunctionUndoItem>(std::move(name), std::move(redo), std::move(undo));
-    item->redo();
+    if (!item->redo())
+        return false;
     undoInfo.addItem(std::move(item));
+    return true;
 }
 
-void FunctionUndoItem::execute(
+bool FunctionUndoItem::execute(
     const std::string     name,
     std::function<bool()> redo,
     std::function<bool()> undo)
 {
-    execute(name, redo, undo, OpUndoItemList::instance());
+    return execute(name, redo, undo, OpUndoItemList::instance());
 }
 
 bool FunctionUndoItem::undo()

--- a/lib/mayaUsd/undo/OpUndoItems.cpp
+++ b/lib/mayaUsd/undo/OpUndoItems.cpp
@@ -58,6 +58,14 @@ MString formatCommand(const MString& commandName, const MObject& commandArg)
     return cmd;
 }
 
+bool redoAndAdd(std::unique_ptr<OpUndoItem>&& item, OpUndoItemList& undoInfo)
+{
+    if (!item->redo())
+        return false;
+    undoInfo.addItem(std::move(item));
+    return true;
+}
+
 } // namespace
 
 MStatus NodeDeletionUndoItem::deleteNode(
@@ -202,10 +210,7 @@ bool PythonUndoItem::execute(
 {
     auto item = std::make_unique<PythonUndoItem>(
         std::move(name), std::move(pythonDo), std::move(pythonUndo));
-    if (!item->redo())
-        return false;
-    undoInfo.addItem(std::move(item));
-    return true;
+    return redoAndAdd(std::move(item), undoInfo);
 }
 
 bool PythonUndoItem::execute(const std::string name, MString pythonDo, MString pythonUndo)
@@ -270,10 +275,7 @@ bool FunctionUndoItem::execute(
 {
     auto item
         = std::make_unique<FunctionUndoItem>(std::move(name), std::move(redo), std::move(undo));
-    if (!item->redo())
-        return false;
-    undoInfo.addItem(std::move(item));
-    return true;
+    return redoAndAdd(std::move(item), undoInfo);
 }
 
 bool FunctionUndoItem::execute(
@@ -316,26 +318,25 @@ SelectionUndoItem::SelectionUndoItem(
 
 SelectionUndoItem::~SelectionUndoItem() { }
 
-void SelectionUndoItem::select(
+bool SelectionUndoItem::select(
     const std::string       name,
     const MSelectionList&   selection,
     MGlobal::ListAdjustment selMode,
     OpUndoItemList&         undoInfo)
 {
     auto item = std::make_unique<SelectionUndoItem>(std::move(name), selection, selMode);
-    item->redo();
-    undoInfo.addItem(std::move(item));
+    return redoAndAdd(std::move(item), undoInfo);
 }
 
-void SelectionUndoItem::select(
+bool SelectionUndoItem::select(
     const std::string       name,
     const MSelectionList&   selection,
     MGlobal::ListAdjustment selMode)
 {
-    select(name, selection, selMode, OpUndoItemList::instance());
+    return select(name, selection, selMode, OpUndoItemList::instance());
 }
 
-void SelectionUndoItem::select(
+bool SelectionUndoItem::select(
     const std::string       name,
     const MDagPath&         dagPath,
     MGlobal::ListAdjustment selMode,
@@ -343,15 +344,15 @@ void SelectionUndoItem::select(
 {
     MSelectionList selection;
     selection.add(dagPath);
-    SelectionUndoItem::select(std::move(name), selection, selMode, undoInfo);
+    return SelectionUndoItem::select(std::move(name), selection, selMode, undoInfo);
 }
 
-void SelectionUndoItem::select(
+bool SelectionUndoItem::select(
     const std::string       name,
     const MDagPath&         dagPath,
     MGlobal::ListAdjustment selMode)
 {
-    select(name, dagPath, selMode, OpUndoItemList::instance());
+    return select(name, dagPath, selMode, OpUndoItemList::instance());
 }
 
 bool SelectionUndoItem::undo()
@@ -380,44 +381,43 @@ UfeSelectionUndoItem::UfeSelectionUndoItem(const std::string& name, const Ufe::S
 
 UfeSelectionUndoItem::~UfeSelectionUndoItem() { }
 
-void UfeSelectionUndoItem::select(
+bool UfeSelectionUndoItem::select(
     const std::string&    name,
     const Ufe::Selection& selection,
     OpUndoItemList&       undoInfo)
 {
     auto item = std::make_unique<UfeSelectionUndoItem>(name, selection);
-    item->redo();
-    undoInfo.addItem(std::move(item));
+    return redoAndAdd(std::move(item), undoInfo);
 }
 
-void UfeSelectionUndoItem::select(const std::string& name, const Ufe::Selection& selection)
+bool UfeSelectionUndoItem::select(const std::string& name, const Ufe::Selection& selection)
 {
-    select(name, selection, OpUndoItemList::instance());
+    return select(name, selection, OpUndoItemList::instance());
 }
 
-void UfeSelectionUndoItem::select(
+bool UfeSelectionUndoItem::select(
     const std::string& name,
     const MDagPath&    dagPath,
     OpUndoItemList&    undoInfo)
 {
     Ufe::Selection sn;
     sn.append(Ufe::Hierarchy::createItem(MayaUsd::ufe::dagPathToUfe(dagPath)));
-    select(name, sn, undoInfo);
+    return select(name, sn, undoInfo);
 }
 
-void UfeSelectionUndoItem::select(const std::string& name, const MDagPath& dagPath)
+bool UfeSelectionUndoItem::select(const std::string& name, const MDagPath& dagPath)
 {
-    select(name, dagPath, OpUndoItemList::instance());
+    return select(name, dagPath, OpUndoItemList::instance());
 }
 
-void UfeSelectionUndoItem::clear(const std::string& name, OpUndoItemList& undoInfo)
+bool UfeSelectionUndoItem::clear(const std::string& name, OpUndoItemList& undoInfo)
 {
-    select(name, Ufe::Selection(), undoInfo);
+    return select(name, Ufe::Selection(), undoInfo);
 }
 
-void UfeSelectionUndoItem::clear(const std::string& name)
+bool UfeSelectionUndoItem::clear(const std::string& name)
 {
-    clear(name, OpUndoItemList::instance());
+    return clear(name, OpUndoItemList::instance());
 }
 
 bool UfeSelectionUndoItem::undo()
@@ -473,20 +473,19 @@ LockNodesUndoItem::LockNodesUndoItem(const std::string name, const MDagPath& roo
 
 LockNodesUndoItem::~LockNodesUndoItem() { }
 
-void LockNodesUndoItem::lock(
+bool LockNodesUndoItem::lock(
     const std::string name,
     const MDagPath&   root,
     bool              dolock,
     OpUndoItemList&   undoInfo)
 {
     auto item = std::make_unique<LockNodesUndoItem>(std::move(name), root, dolock);
-    item->redo();
-    undoInfo.addItem(std::move(item));
+    return redoAndAdd(std::move(item), undoInfo);
 }
 
-void LockNodesUndoItem::lock(const std::string name, const MDagPath& root, bool dolock)
+bool LockNodesUndoItem::lock(const std::string name, const MDagPath& root, bool dolock)
 {
-    lock(name, root, dolock, OpUndoItemList::instance());
+    return lock(name, root, dolock, OpUndoItemList::instance());
 }
 
 bool LockNodesUndoItem::undo()

--- a/lib/mayaUsd/undo/OpUndoItems.h
+++ b/lib/mayaUsd/undo/OpUndoItems.h
@@ -328,7 +328,7 @@ class SelectionUndoItem : public OpUndoItem
 public:
     /// \brief create and execute a select node undo item and keep track of it.
     MAYAUSD_CORE_PUBLIC
-    static void select(
+    static bool select(
         const std::string       name,
         const MSelectionList&   selection,
         MGlobal::ListAdjustment selMode,
@@ -336,14 +336,14 @@ public:
 
     /// \brief create and execute a select node undo item and keep track of it in the global list.
     MAYAUSD_CORE_PUBLIC
-    static void select(
+    static bool select(
         const std::string       name,
         const MSelectionList&   selection,
         MGlobal::ListAdjustment selMode);
 
     /// \brief create and execute a select node undo item and keep track of it.
     MAYAUSD_CORE_PUBLIC
-    static void select(
+    static bool select(
         const std::string       name,
         const MDagPath&         dagPath,
         MGlobal::ListAdjustment selMode,
@@ -351,36 +351,36 @@ public:
 
     /// \brief create and execute a select node undo item and keep track of it in the global list.
     MAYAUSD_CORE_PUBLIC
-    static void
+    static bool
     select(const std::string name, const MDagPath& dagPath, MGlobal::ListAdjustment selMode);
 
     /// \brief create and execute a select node undo item and keep track of it.
     MAYAUSD_CORE_PUBLIC
-    static void
+    static bool
     select(const std::string name, const MSelectionList& selection, OpUndoItemList& undoInfo)
     {
-        SelectionUndoItem::select(name, selection, MGlobal::kReplaceList, undoInfo);
+        return SelectionUndoItem::select(name, selection, MGlobal::kReplaceList, undoInfo);
     }
 
     /// \brief create and execute a select node undo item and keep track of it.
     MAYAUSD_CORE_PUBLIC
-    static void select(const std::string name, const MSelectionList& selection)
+    static bool select(const std::string name, const MSelectionList& selection)
     {
-        SelectionUndoItem::select(name, selection, MGlobal::kReplaceList);
+        return SelectionUndoItem::select(name, selection, MGlobal::kReplaceList);
     }
 
     /// \brief create and execute a select node undo item and keep track of it.
     MAYAUSD_CORE_PUBLIC
-    static void select(const std::string name, const MDagPath& dagPath, OpUndoItemList& undoInfo)
+    static bool select(const std::string name, const MDagPath& dagPath, OpUndoItemList& undoInfo)
     {
-        SelectionUndoItem::select(name, dagPath, MGlobal::kReplaceList, undoInfo);
+        return SelectionUndoItem::select(name, dagPath, MGlobal::kReplaceList, undoInfo);
     }
 
     /// \brief create and execute a select node undo item and keep track of it.
     MAYAUSD_CORE_PUBLIC
-    static void select(const std::string name, const MDagPath& dagPath)
+    static bool select(const std::string name, const MDagPath& dagPath)
     {
-        SelectionUndoItem::select(name, dagPath, MGlobal::kReplaceList);
+        return SelectionUndoItem::select(name, dagPath, MGlobal::kReplaceList);
     }
 
     MAYAUSD_CORE_PUBLIC
@@ -419,33 +419,33 @@ public:
     /// \brief Create and execute a select node undo item and keep track of it.  The global
     /// selection is replaced.
     MAYAUSD_CORE_PUBLIC
-    static void
+    static bool
     select(const std::string& name, const Ufe::Selection& selection, OpUndoItemList& undoInfo);
 
     /// \brief create and execute a select node undo item and keep track of it in the global list.
     /// The global selection is replaced.
     MAYAUSD_CORE_PUBLIC
-    static void select(const std::string& name, const Ufe::Selection& selection);
+    static bool select(const std::string& name, const Ufe::Selection& selection);
 
     /// \brief create and execute a select node undo item and keep track of it.
     /// The global selection is replaced.
     MAYAUSD_CORE_PUBLIC
-    static void select(const std::string& name, const MDagPath& dagPath, OpUndoItemList& undoInfo);
+    static bool select(const std::string& name, const MDagPath& dagPath, OpUndoItemList& undoInfo);
 
     /// \brief create and execute a select node undo item and keep track of it on the global list.
     /// The global selection is replaced.
     MAYAUSD_CORE_PUBLIC
-    static void select(const std::string& name, const MDagPath& dagPath);
+    static bool select(const std::string& name, const MDagPath& dagPath);
 
     /// \brief Create and execute a clear selection undo item and keep track of it.  The global
     /// selection is cleared.
     MAYAUSD_CORE_PUBLIC
-    static void clear(const std::string& name, OpUndoItemList& undoInfo);
+    static bool clear(const std::string& name, OpUndoItemList& undoInfo);
 
     /// \brief create and execute a clear selection undo item and keep track of it in the global
     /// list. The global selection is cleared.
     MAYAUSD_CORE_PUBLIC
-    static void clear(const std::string& name);
+    static bool clear(const std::string& name);
 
     MAYAUSD_CORE_PUBLIC
     UfeSelectionUndoItem(const std::string& name, const Ufe::Selection& selection);
@@ -486,13 +486,13 @@ class LockNodesUndoItem : public OpUndoItem
 public:
     /// \brief create and execute a lock node undo item and keep track of it.
     MAYAUSD_CORE_PUBLIC
-    static void
+    static bool
     lock(const std::string name, const MDagPath& root, bool lock, OpUndoItemList& undoInfo);
 
     /// \brief create and execute a lock node undo item and keep track of it in the global undo
     /// list.
     MAYAUSD_CORE_PUBLIC
-    static void lock(const std::string name, const MDagPath& root, bool lock);
+    static bool lock(const std::string name, const MDagPath& root, bool lock);
 
     MAYAUSD_CORE_PUBLIC
     LockNodesUndoItem(const std::string name, const MDagPath& root, bool lock);

--- a/lib/mayaUsd/undo/OpUndoItems.h
+++ b/lib/mayaUsd/undo/OpUndoItems.h
@@ -225,13 +225,13 @@ class PythonUndoItem : public OpUndoItem
 public:
     /// \brief create and execute python and and how to undo it and keep track of it.
     MAYAUSD_CORE_PUBLIC
-    static void
+    static bool
     execute(const std::string name, MString pythonDo, MString pythonUndo, OpUndoItemList& undoInfo);
 
     /// \brief create and execute python and and how to undo it and keep track of it in the global
     /// list.
     MAYAUSD_CORE_PUBLIC
-    static void execute(const std::string name, MString pythonDo, MString pythonUndo);
+    static bool execute(const std::string name, MString pythonDo, MString pythonUndo);
 
     /// \brief create a python undo item.
     MAYAUSD_CORE_PUBLIC
@@ -280,7 +280,7 @@ public:
     /// \brief create and execute functions and how to undo it and keep track of it.
     ///        Useful if the item execution has *not* already been done but must done now.
     MAYAUSD_CORE_PUBLIC
-    static void execute(
+    static bool execute(
         const std::string     name,
         std::function<bool()> redo,
         std::function<bool()> undo,
@@ -291,7 +291,7 @@ public:
     ///
     /// Useful if the item execution has *not* already been done but must done now.
     MAYAUSD_CORE_PUBLIC
-    static void
+    static bool
     execute(const std::string name, std::function<bool()> redo, std::function<bool()> undo);
 
     /// \brief create a function undo item.


### PR DESCRIPTION
The undoable execution items were not returning the success/failure status from the convenience static execute function, preventing the validation of correct execution.

Fix this by making the execute function of PythonUndoItem and FunctionUndoItem return a boolean success flag, received from the redo function. Use this flag during pull and pull to validate that key steps executed correctly.

In our case, the authoring of metadata on an instance prototype is forbidden by USD and was failing, but that fact was lost. So no pull information was written, which entirely broke the pull/push workflow.

Many other convenience functions of undo items (select and lock) were not returning errors. Now they return a success flag and callers verify it.