### PR TITLE
MAYA-122926 reset auto-edit in all variants

### DIFF
--- a/lib/mayaUsd/utils/CMakeLists.txt
+++ b/lib/mayaUsd/utils/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(${PROJECT_NAME}
         util.cpp
         utilFileSystem.cpp
         utilSerialization.cpp
+        variants.cpp
 )
 
 set(HEADERS
@@ -43,6 +44,7 @@ set(HEADERS
     util.h
     utilFileSystem.h
     utilSerialization.h
+    variants.h
 )
 
 set(PLUGINFO

--- a/lib/mayaUsd/utils/variants.cpp
+++ b/lib/mayaUsd/utils/variants.cpp
@@ -1,0 +1,62 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "variants.h"
+
+#include <pxr/usd/usd/stage.h>
+
+/// General utility functions for variants
+namespace MAYAUSD_NS_DEF {
+
+void applyToAllVariants(
+    const PXR_NS::UsdPrim&       primWithVariants,
+    bool                         includeNonVariant,
+    const std::function<void()>& func)
+{
+    // Record if we saw at least one variant to apply the function on.
+    // Used when non-variant are included.
+    bool atLeastOneVariant = false;
+
+    // Clear the edit flag in all other variants, in all variant sets if any.
+    PXR_NS::UsdStagePtr    stage = primWithVariants.GetStage();
+    PXR_NS::UsdVariantSets variantSets = primWithVariants.GetVariantSets();
+    for (const std::string& variantSetName : variantSets.GetNames()) {
+
+        PXR_NS::UsdVariantSet variantSet = primWithVariants.GetVariantSet(variantSetName);
+
+        // Make sure to restore the current selected variant even if the face
+        // of exceptions.
+        AutoVariantRestore variantRestore(variantSet);
+
+        for (const std::string& variantName : variantSet.GetVariantNames()) {
+            if (variantSet.SetVariantSelection(variantName)) {
+                PXR_NS::UsdEditTarget target = stage->GetEditTarget();
+
+                PXR_NS::UsdEditContext switchEditContext(
+                    stage, variantSet.GetVariantEditTarget(target.GetLayer()));
+
+                func();
+                atLeastOneVariant = true;
+            }
+        }
+    }
+
+    // When not a single variant was found and the caller wants to apply
+    // the function even in the absence of vairants, call it now.
+    if (includeNonVariant && !atLeastOneVariant)
+        func();
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/variants.h
+++ b/lib/mayaUsd/utils/variants.h
@@ -1,0 +1,75 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_UTILS_VARIANTS_H
+#define MAYAUSD_UTILS_VARIANTS_H
+
+#include <mayaUsd/base/api.h>
+
+#include <pxr/usd/usd/editContext.h>
+#include <pxr/usd/usd/prim.h>
+#include <pxr/usd/usd/variantSets.h>
+
+#include <functional>
+#include <string>
+
+/// General utility functions for variants
+namespace MAYAUSD_NS_DEF {
+
+/*! \brief Apply a function to all variants on a prim.
+
+    Optionally, if includeNonVariant is true, apply it even if the prim
+    has no variant at all, which is useful when you want to edit something
+    on all variations of a prim, even if there are no variations.
+*/
+MAYAUSD_CORE_PUBLIC
+void applyToAllVariants(
+    const PXR_NS::UsdPrim&       primWithVariants,
+    bool                         includeNonVariant,
+    const std::function<void()>& func);
+
+/*! \brief Keep track of the current variant and restore it on destruction.
+
+    The reason we don't make this an variant auto-switcher is that
+    switching variant recomposes the stage and one main user of the
+    restore is visiting all variants, which would double the number
+    of recompose if we restored the variant between each visit.
+
+    IOW, for a set with three variants A, B, C, this design permits
+    the switch Current -> A -> B -> C -> Current instead of doing
+    Current -> A -> Current -> B -> Current -> C -> Current.
+*/
+
+class AutoVariantRestore
+{
+public:
+    MAYAUSD_CORE_PUBLIC
+    AutoVariantRestore(PXR_NS::UsdVariantSet& variantSet)
+        : _variantSet(variantSet)
+        , _variant(variantSet.GetVariantSelection())
+    {
+    }
+
+    MAYAUSD_CORE_PUBLIC
+    ~AutoVariantRestore() { _variantSet.SetVariantSelection(_variant); }
+
+private:
+    PXR_NS::UsdVariantSet& _variantSet;
+    std::string            _variant;
+};
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_UTILS_VARIANTS_H


### PR DESCRIPTION
- Add a utility function to apply a function to all variants of a prim.
- Add a utility class to automatically restore the current variant on exit.
- Use these to clear the auto-edit flag in all variants.
- Remove obsolete comments about type info not being correctly preserved and psuhEnd not being called (now it is called).