### PR TITLE
Force Y-up axis for image compare tests

### DIFF
--- a/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateConsolidation.py
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateConsolidation.py
@@ -40,9 +40,9 @@ class testVP2RenderDelegateConsolidation(imageUtils.ImageDiffingTestCase):
 
     @classmethod
     def setUpClass(cls):
-        # The test USD data is authored Z-up, so make sure Maya is configured
+        # The baselines assume Y-up, so make sure Maya is configured
         # that way too.
-        # cmds.upAxis(axis='z')
+        cmds.upAxis(axis='y')
 
         inputPath = fixturesUtils.setUpClass(__file__,
             initializeStandalone=False, loadPlugin=False)

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateDuplicateProxy.py
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateDuplicateProxy.py
@@ -39,9 +39,9 @@ class testVP2RenderDelegateDuplicateProxy(imageUtils.ImageDiffingTestCase):
 
     @classmethod
     def setUpClass(cls):
-        # The test USD data is authored Z-up, so make sure Maya is configured
+        # The baselines assume Y-up, so make sure Maya is configured
         # that way too.
-        # cmds.upAxis(axis='z')
+        cmds.upAxis(axis='y')
 
         inputPath = fixturesUtils.setUpClass(__file__,
             initializeStandalone=False, loadPlugin=False)

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateInteractiveWorkflows.py
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateInteractiveWorkflows.py
@@ -44,6 +44,10 @@ class testVP2RenderDelegateInteractiveWorkflows(imageUtils.ImageDiffingTestCase)
 
     @classmethod
     def setUpClass(cls):
+        # The baselines assume Y-up, so make sure Maya is configured
+        # that way too.
+        cmds.upAxis(axis='y')
+        
         inputPath = fixturesUtils.setUpClass(__file__,
             initializeStandalone=False, loadPlugin=False)
 

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegatePerInstanceInheritedData.py
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegatePerInstanceInheritedData.py
@@ -43,9 +43,9 @@ class testVP2RenderDelegatePerInstanceInheritedData(imageUtils.ImageDiffingTestC
 
     @classmethod
     def setUpClass(cls):
-        # The test USD data is authored Z-up, so make sure Maya is configured
+        # The baselines assume Y-up, so make sure Maya is configured
         # that way too.
-        # cmds.upAxis(axis='z')
+        cmds.upAxis(axis='y')
 
         inputPath = fixturesUtils.setUpClass(__file__,
             initializeStandalone=False, loadPlugin=False)


### PR DESCRIPTION
Pixar uses Z-up by default. This preference is set in userSetup.mel and
in many user's saved preferences. This change ensures image compare
tests pass even when run in this environment.