### PR TITLE
Don't author the loadRules attribute for Pxr reference assemblies

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -1616,7 +1616,9 @@ MDagPath MayaUsdProxyShapeBase::parentTransform()
     return proxyTransformPath;
 }
 
-MayaUsdProxyShapeBase::MayaUsdProxyShapeBase(const bool enableUfeSelection)
+MayaUsdProxyShapeBase::MayaUsdProxyShapeBase(
+    const bool enableUfeSelection,
+    const bool useLoadRulesHandling)
     : MPxSurfaceShape()
     , _isUfeSelectionEnabled(enableUfeSelection)
     , _unsharedStageRootLayer(nullptr)
@@ -1625,9 +1627,11 @@ MayaUsdProxyShapeBase::MayaUsdProxyShapeBase(const bool enableUfeSelection)
 {
     TfRegistryManager::GetInstance().SubscribeTo<MayaUsdProxyShapeBase>();
 
-    // Register with the load-rules handling used to transfer load rules
-    // between the USD stage and a dynamic attribute on the proxy shape.
-    MayaUsdProxyShapeLoadRules::addProxyShape(*this);
+    if (useLoadRulesHandling) {
+        // Register with the load-rules handling used to transfer load rules
+        // between the USD stage and a dynamic attribute on the proxy shape.
+        MayaUsdProxyShapeLoadRules::addProxyShape(*this);
+    }
 }
 
 /* virtual */

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -283,7 +283,9 @@ public:
 
 protected:
     MAYAUSD_CORE_PUBLIC
-    MayaUsdProxyShapeBase(const bool enableUfeSelection = true);
+    MayaUsdProxyShapeBase(
+        const bool enableUfeSelection = true,
+        const bool useLoadRulesHandling = true);
 
     MAYAUSD_CORE_PUBLIC
     ~MayaUsdProxyShapeBase() override;

--- a/plugin/pxr/maya/lib/usdMaya/proxyShape.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/proxyShape.cpp
@@ -247,7 +247,9 @@ bool UsdMayaProxyShape::getInternalValueInContext(
 }
 
 UsdMayaProxyShape::UsdMayaProxyShape()
-    : MayaUsdProxyShapeBase(/* enableUfeSelection = */ false)
+    : MayaUsdProxyShapeBase(
+        /* enableUfeSelection = */ false,
+        /* useLoadRulesHandling = */ false)
     , _useFastPlayback(false)
 {
     TfRegistryManager::GetInstance().SubscribeTo<UsdMayaProxyShape>();


### PR DESCRIPTION
Allow derived classes to opt out of authoring loadRules attributes on
proxyShapes in order to prevent clutter within Pixar Usd Reference
Assemblies.