### PR TITLE
Respect prim writer ShouldPruneChildren when shading mode is useRegistry

### DIFF
--- a/lib/mayaUsd/fileio/shaderWriterRegistry.cpp
+++ b/lib/mayaUsd/fileio/shaderWriterRegistry.cpp
@@ -18,6 +18,7 @@
 #include <mayaUsd/base/debugCodes.h>
 #include <mayaUsd/fileio/functorPrimWriter.h>
 #include <mayaUsd/fileio/registryHelper.h>
+#include <mayaUsd/fileio/shading/shadingModeRegistry.h>
 
 #include <pxr/base/tf/debug.h>
 #include <pxr/base/tf/diagnostic.h>
@@ -58,6 +59,10 @@ _Registry::const_iterator _Find(const TfToken& usdInfoId, const UsdMayaJobExport
 {
     using ContextSupport = UsdMayaShaderWriter::ContextSupport;
 
+    TfToken conversion = exportArgs.convertMaterialsTo;
+    const bool noFallback =
+        UsdMayaShadingModeRegistry::GetMaterialConversionInfo(conversion).noFallbackExport;
+
     _Registry::const_iterator ret = _reg.cend();
     _Registry::const_iterator first, last;
     std::tie(first, last) = _reg.equal_range(usdInfoId);
@@ -66,7 +71,7 @@ _Registry::const_iterator _Find(const TfToken& usdInfoId, const UsdMayaJobExport
         if (support == ContextSupport::Supported) {
             ret = first;
             break;
-        } else if (support == ContextSupport::Fallback && ret == _reg.end()) {
+        } else if (!noFallback && support == ContextSupport::Fallback && ret == _reg.end()) {
             ret = first;
         }
         ++first;

--- a/lib/mayaUsd/fileio/shaderWriterRegistry.cpp
+++ b/lib/mayaUsd/fileio/shaderWriterRegistry.cpp
@@ -59,9 +59,9 @@ _Registry::const_iterator _Find(const TfToken& usdInfoId, const UsdMayaJobExport
 {
     using ContextSupport = UsdMayaShaderWriter::ContextSupport;
 
-    TfToken conversion = exportArgs.convertMaterialsTo;
-    const bool noFallback =
-        UsdMayaShadingModeRegistry::GetMaterialConversionInfo(conversion).noFallbackExport;
+    TfToken    conversion = exportArgs.convertMaterialsTo;
+    const bool noFallback
+        = UsdMayaShadingModeRegistry::GetMaterialConversionInfo(conversion).noFallbackExport;
 
     _Registry::const_iterator ret = _reg.cend();
     _Registry::const_iterator first, last;

--- a/lib/mayaUsd/fileio/shading/shadingModeRegistry.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeRegistry.cpp
@@ -180,20 +180,11 @@ void UsdMayaShadingModeRegistry::RegisterExportConversion(
     // especially if exporters for a conversion are split across multiple libraries.
     // We will keep the first niceName registered.
     UsdMayaShadingModeRegistry::ConversionInfo conversionInfo(
-        renderContext,
-        niceName,
-        description,
-        TfToken(),
-        true,
-        false,
-        noFallback,
-        false);
+        renderContext, niceName, description, TfToken(), true, false, noFallback, false);
     _MaterialConversionRegistry::iterator insertionPoint;
     bool                                  hasInserted;
-    std::tie(insertionPoint, hasInserted)
-        = _conversionReg.insert(_MaterialConversionRegistry::value_type(
-            materialConversion,
-            conversionInfo));
+    std::tie(insertionPoint, hasInserted) = _conversionReg.insert(
+        _MaterialConversionRegistry::value_type(materialConversion, conversionInfo));
     if (!hasInserted) {
         // Update the info:
         if (insertionPoint->second.exportDescription.IsEmpty()) {
@@ -216,20 +207,11 @@ void UsdMayaShadingModeRegistry::RegisterImportConversion(
     // especially if importers for a conversion are split across multiple libraries.
     // We will keep the first niceName registered.
     UsdMayaShadingModeRegistry::ConversionInfo conversionInfo(
-        renderContext,
-        niceName,
-        TfToken(),
-        description,
-        false,
-        true,
-        false,
-        noFallback);
+        renderContext, niceName, TfToken(), description, false, true, false, noFallback);
     _MaterialConversionRegistry::iterator insertionPoint;
     bool                                  hasInserted;
-    std::tie(insertionPoint, hasInserted)
-        = _conversionReg.insert(_MaterialConversionRegistry::value_type(
-            materialConversion,
-            conversionInfo));
+    std::tie(insertionPoint, hasInserted) = _conversionReg.insert(
+        _MaterialConversionRegistry::value_type(materialConversion, conversionInfo));
     if (!hasInserted) {
         // Update the info:
         if (insertionPoint->second.importDescription.IsEmpty()) {

--- a/lib/mayaUsd/fileio/shading/shadingModeRegistry.h
+++ b/lib/mayaUsd/fileio/shading/shadingModeRegistry.h
@@ -191,8 +191,7 @@ public:
             bool    he,
             bool    hi,
             bool    nfe,
-            bool    nfi
-        )
+            bool    nfi)
             : renderContext(rc)
             , niceName(nn)
             , exportDescription(ed)

--- a/lib/mayaUsd/fileio/shading/shadingModeRegistry.h
+++ b/lib/mayaUsd/fileio/shading/shadingModeRegistry.h
@@ -178,15 +178,29 @@ public:
         TfToken importDescription;
         bool    hasExporter = false;
         bool    hasImporter = false;
+        bool    noFallbackExport = false;
+        bool    noFallbackImport = false;
 
         ConversionInfo() = default;
-        ConversionInfo(TfToken rc, TfToken nn, TfToken ed, TfToken id, bool he, bool hi)
+
+        ConversionInfo(
+            TfToken rc,
+            TfToken nn,
+            TfToken ed,
+            TfToken id,
+            bool    he,
+            bool    hi,
+            bool    nfe,
+            bool    nfi
+        )
             : renderContext(rc)
             , niceName(nn)
             , exportDescription(ed)
             , importDescription(id)
             , hasExporter(he)
             , hasImporter(hi)
+            , noFallbackExport(nfe)
+            , noFallbackImport(nfi)
         {
         }
     };
@@ -211,12 +225,16 @@ public:
     /// The \p niceName is the name displayed in the render options dialog.
     ///
     /// The \p description is displayed as a tooltip in the render options dialog.
+    ///
+    /// \p noFallback is a hint that shader writers returning ContextSupport::Fallback will be
+    /// ignored while using this material conversion.
     MAYAUSD_CORE_PUBLIC
     void RegisterExportConversion(
         const TfToken& materialConversion,
         const TfToken& renderContext,
         const TfToken& niceName,
-        const TfToken& description);
+        const TfToken& description,
+        bool           noFallback = false);
 
     /// Registers an import material conversion, with render context, nice name and description.
     /// This is the import counterpart of the RegisterExportConversion to be used if importers are
@@ -233,12 +251,16 @@ public:
     /// The \p niceName is the name to be displayed in the import options dialog.
     ///
     /// The \p description is displayed as a tooltip in the import options dialog.
+    ///
+    /// \p noFallback is a hint that shader readers returning ContextSupport::Fallback will be
+    /// ignored while using this material conversion.
     MAYAUSD_CORE_PUBLIC
     void RegisterImportConversion(
         const TfToken& materialConversion,
         const TfToken& renderContext,
         const TfToken& niceName,
-        const TfToken& description);
+        const TfToken& description,
+        bool           noFallback = false);
 
 private:
     MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
@@ -247,9 +247,6 @@ private:
             if (shaderPrim && !topLevelShader) {
                 topLevelShader = UsdShadeShader(shaderPrim);
             }
-            if (srcShaderInfo->ShouldPruneChildren()) {
-                iterDepGraph.prune();
-            }
 
             for (unsigned int i = 0u; i < dstPlugs.length(); ++i) {
                 const MPlug dstPlug = dstPlugs[i];

--- a/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
@@ -247,6 +247,9 @@ private:
             if (shaderPrim && !topLevelShader) {
                 topLevelShader = UsdShadeShader(shaderPrim);
             }
+            if (srcShaderInfo->ShouldPruneChildren()) {
+                iterDepGraph.prune();
+            }
 
             for (unsigned int i = 0u; i < dstPlugs.length(); ++i) {
                 const MPlug dstPlug = dstPlugs[i];


### PR DESCRIPTION
Currently, there is no way to register a shader writer that handles all
connected plugs to the shader. For example, the writer might handle file
nodes connected to the shader, but useRegistry shading mode will invoke
FileTextureWriter unconditionally. It will write out a UsdUVTexture
shader, which useRegistry won't be able to connect to the shading network.