### PR TITLE
MAYA-123509 fix merging of normals

### DIFF
--- a/lib/mayaUsd/fileio/utils/readUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/readUtil.cpp
@@ -356,6 +356,12 @@ MObject UsdMayaReadUtil::FindOrCreateMayaAttr(
     } else if (type.IsA<int>()) {
         return _FindOrCreateMayaNumericAttr(
             attrName, attrNiceName, MFnNumericData::kInt, keyable, usedAsColor, depNode, modifier);
+    } else if (type.IsA<unsigned int>()) {
+        return _FindOrCreateMayaNumericAttr(
+            attrName, attrNiceName, MFnNumericData::kInt, keyable, usedAsColor, depNode, modifier);
+    } else if (type.IsA<unsigned char>()) {
+        return _FindOrCreateMayaNumericAttr(
+            attrName, attrNiceName, MFnNumericData::kByte, keyable, usedAsColor, depNode, modifier);
     } else if (type.IsA<GfVec2i>()) {
         return _FindOrCreateMayaNumericAttr(
             attrName, attrNiceName, MFnNumericData::k2Int, keyable, usedAsColor, depNode, modifier);
@@ -663,10 +669,19 @@ bool UsdMayaReadUtil::SetMayaAttr(
             modifier.newPlugValueBool(attrPlug, b);
             ok = true;
         }
+    } else if (newValue.IsHolding<unsigned char>()) {
+        if (Converter::hasNumericType(attrPlug, MFnNumericData::kByte)) {
+            unsigned char b = newValue.Get<unsigned char>();
+            modifier.newPlugValueBool(attrPlug, b);
+            ok = true;
+        }
     } else if (
-        newValue.IsHolding<int>() || newValue.IsHolding<float>() || newValue.IsHolding<double>()) {
+        newValue.IsHolding<int>() || newValue.IsHolding<unsigned int>()
+        || newValue.IsHolding<float>() || newValue.IsHolding<double>()) {
         if (Converter::hasNumericType(attrPlug, MFnNumericData::kInt)) {
-            int i = VtValue::Cast<int>(newValue).Get<int>();
+            int i = newValue.IsHolding<unsigned int>()
+                ? int(VtValue::Cast<unsigned int>(newValue).Get<unsigned int>())
+                : VtValue::Cast<int>(newValue).Get<int>();
             modifier.newPlugValueInt(attrPlug, i);
             ok = true;
         } else if (Converter::hasNumericType(attrPlug, MFnNumericData::kFloat)) {
@@ -677,8 +692,12 @@ bool UsdMayaReadUtil::SetMayaAttr(
             double d = VtValue::Cast<double>(newValue).Get<double>();
             modifier.newPlugValueDouble(attrPlug, d);
             ok = true;
-        } else if (newValue.IsHolding<int>() && Converter::hasEnumType(attrPlug)) {
-            int i = VtValue::Cast<int>(newValue).Get<int>();
+        } else if (
+            (newValue.IsHolding<int>() || newValue.IsHolding<unsigned int>())
+            && Converter::hasEnumType(attrPlug)) {
+            int i = newValue.IsHolding<unsigned int>()
+                ? int(VtValue::Cast<unsigned int>(newValue).Get<unsigned int>())
+                : VtValue::Cast<int>(newValue).Get<int>();
             modifier.newPlugValueInt(attrPlug, i);
             ok = true;
         }

--- a/lib/usd/utils/DiffPrims.cpp
+++ b/lib/usd/utils/DiffPrims.cpp
@@ -225,6 +225,12 @@ static DiffResult comparePrims(
         }
     }
 
+    // TODO: should we compare metadata? We currently don't as it contains stuf we
+    //       would need to consider equivalent like types (for example we consider
+    //       float3f and nromal3f to be equivalent), declarations (def vs over), etc
+    //
+    //       OTOH, there are other metadata we could consider.
+
     if (compareChildren) {
         const auto childrenDiffs = comparePrimsChildren(modified, baseline, quickDiff);
         USD_MAYA_RETURN_QUICK_RESULT(*quickDiff, *quickDiff);


### PR DESCRIPTION
Normals in USD can be kept in the "normals" attribute or the "primvars:normals" attribute. This breaks the semantic-agnostic merge algorithm as it did not relate the two attributes.

In addition, the "privars:normals" has higher priority.

The result was that the round-trip of Edit-as-Maya and Merge-to-USD would create the "normals" attribute attribute and the resulting prim would have both attributes, but the old unmodified primvats would win.

This was bad when the mesh was edited as the wrong normals were used, but catastrophic when the topology was edited as the number of normals was incorrect.

The fix is to add custom logic to handle normals merging. The new strategy is to rely on the USD exportdone during merge to always author the "normals" attribute and to delete the existing "primvars:normals" from the original USD data so that it does not take priority on the newly edited normals.

While fixing this, other small fixes were done:
- the messages printed during merging were improved to be easier to understand.
- Added support for some additional data-type during USD import: byte and unsigned int were not supported.
- Added a comments about the fact that we currently do no compare metadata to determine if a prim has changed.