### PR TITLE
Fix issues between two versions of standard_surface

### DIFF
--- a/lib/mayaUsd/ufe/UsdShaderNodeDefHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdShaderNodeDefHandler.cpp
@@ -76,7 +76,8 @@ Ufe::NodeDef::Ptr UsdShaderNodeDefHandler::definition(const Ufe::SceneItem::Ptr&
 Ufe::NodeDef::Ptr UsdShaderNodeDefHandler::definition(const std::string& type) const
 {
     PXR_NS::SdrRegistry&          registry = PXR_NS::SdrRegistry::GetInstance();
-    PXR_NS::SdrShaderNodeConstPtr shaderNodeDef = registry.GetShaderNodeByName(type);
+    PXR_NS::TfToken               mxNodeType(type);
+    PXR_NS::SdrShaderNodeConstPtr shaderNodeDef = registry.GetShaderNodeByIdentifier(mxNodeType);
     if (!shaderNodeDef) {
         return nullptr;
     }


### PR DESCRIPTION
Using GetShaderNodeByIdentifier resolves issues where there is more than
one node sharing the same name with two different versions.

See Pixar Issue #1873 about version parsing failure in usdMtlx.