### PR TITLE
Allowing a new prim spec to be written in edit target layers

### DIFF
--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -78,7 +78,7 @@ bool stringBeginsWithDigit(const std::string& inputString)
 
 // This function calculates the position index for a given layer across all
 // the site's local LayerStacks
-uint32_t findLayerIndex(const UsdPrim& prim, const SdfLayerHandle& layer, bool& foundLayer)
+uint32_t findLayerIndex(const UsdPrim& prim, const SdfLayerHandle& layer)
 {
     uint32_t position { 0 };
 
@@ -96,7 +96,6 @@ uint32_t findLayerIndex(const UsdPrim& prim, const SdfLayerHandle& layer, bool& 
         // to find the layer
         for (SdfLayerRefPtr const& l : layerStack->GetLayers()) {
             if (l == layer) {
-                foundLayer = true;
                 return position;
             }
             ++position;
@@ -452,15 +451,8 @@ bool isAttributeEditAllowed(const PXR_NS::UsdAttribute& attr, std::string* errMs
         return false;
     }
 
-    bool foundLayer = false;
-
     // get the index to edit target layer
-    const auto targetLayerIndex = findLayerIndex(prim, editTarget.GetLayer(), foundLayer);
-
-    // If the edit target layer not found in the prim's layer stack, we return true to allow
-    // new future edits go to the edit target layer.
-    if (!foundLayer)
-        return true;
+    const auto targetLayerIndex = findLayerIndex(prim, editTarget.GetLayer());
 
     // HS March 22th,2021
     // TODO: "Value Clips" are UsdStage-level feature, unknown to Pcp.So if the attribute in
@@ -478,15 +470,14 @@ bool isAttributeEditAllowed(const PXR_NS::UsdAttribute& attr, std::string* errMs
     if (!propertyStack.empty()) {
         // get the strongest layer that has the attr.
         auto strongestLayer = attr.GetPropertyStack().front()->GetLayer();
-        foundLayer = false;
 
         // compare the calculated index between the "attr" and "edit target" layers.
-        if (findLayerIndex(prim, strongestLayer, foundLayer) < targetLayerIndex) {
+        if (findLayerIndex(prim, strongestLayer) < targetLayerIndex) {
             if (errMsg) {
                 *errMsg = TfStringPrintf(
                     "Cannot edit [%s] attribute because there is a stronger opinion in [%s].",
-                    attr.GetName().GetText(),
-                    strongestLayer->GetIdentifier().c_str());
+                    attr.GetBaseName().GetText(),
+                    strongestLayer->GetDisplayName().c_str());
             }
 
             return false;

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -82,7 +82,7 @@ uint32_t findLayerIndex(const UsdPrim& prim, const SdfLayerHandle& layer)
 {
     uint32_t position { 0 };
 
-    const PcpPrimIndex& primIndex = prim.GetPrimIndex();
+    const PcpPrimIndex& primIndex = prim.ComputeExpandedPrimIndex();
 
     // iterate through the expanded primIndex
     for (PcpNodeRef node : primIndex.GetNodeRange()) {

--- a/test/lib/ufe/testAttributeBlock.py
+++ b/test/lib/ufe/testAttributeBlock.py
@@ -21,7 +21,7 @@ import mayaUtils
 import ufeUtils
 import usdUtils
 
-from pxr import UsdGeom, Vt, Gf, Usd, Sdf
+from pxr import UsdGeom, Vt, Gf
 
 from maya import cmds
 from maya import standalone
@@ -32,8 +32,6 @@ from mayaUsd import ufe as mayaUsdUfe
 import ufe
 import os
 import unittest
-import textwrap
-
 
 class AttributeBlockTestCase(unittest.TestCase):
 
@@ -349,83 +347,6 @@ class AttributeBlockTestCase(unittest.TestCase):
 
         # authoring new transformation edit is allowed.
         self.assertTrue(mayaUsdUfe.isAttributeEditAllowed(transformAttr))
-    
-    def testIsAttributeEditAllowedFunction(self):
-        rootLayerStr = """\
-        #sdf 1.4.32
-        ()
-        def "root"
-        {
-        }
-        """
-        subLayerAStr = """\
-        #sdf 1.4.32
-        over "root"
-        {
-            def "a" 
-            {
-                float foo = 0.0
-            }
-
-            def "b" 
-            {
-                float foo = 0.0
-            }
-        }
-        """
-        subLayerBStr = """\
-        #sdf 1.4.32
-        over "root"
-        {
-        }
-        """
-        subLayerCStr = """\
-        #sdf 1.4.32
-        over "root"
-        {
-            over "a" 
-            {
-                float foo = 10.0
-            }
-        }
-        """
-
-        rootLayer = Sdf.Layer.CreateAnonymous()
-        rootLayer.ImportFromString(textwrap.dedent(rootLayerStr))
-
-        subLayerA = Sdf.Layer.CreateAnonymous()
-        subLayerA.ImportFromString(textwrap.dedent(subLayerAStr))
-
-        subLayerB = Sdf.Layer.CreateAnonymous()
-        subLayerB.ImportFromString(textwrap.dedent(subLayerBStr))
-
-        subLayerC = Sdf.Layer.CreateAnonymous()
-        subLayerC.ImportFromString(textwrap.dedent(subLayerCStr))
-
-        rootLayer.subLayerPaths = [
-            subLayerC.identifier,
-            subLayerB.identifier,
-            subLayerA.identifier,
-        ]
-        stage = Usd.Stage.Open(rootLayer)
-
-        primB = stage.GetPrimAtPath("/root/b")
-        self.assertTrue(primB.IsValid())
-
-        fooattrB = primB.GetAttribute("foo")
-        self.assertTrue(fooattrB.IsValid())
-
-        stage.SetEditTarget(Usd.EditTarget(subLayerB))
-        self.assertTrue(mayaUsdUfe.isAttributeEditAllowed(fooattrB))
-
-        primA = stage.GetPrimAtPath("/root/a")
-        self.assertTrue(primA.IsValid())
-
-        fooattrA = primA.GetAttribute("foo")
-        self.assertTrue(fooattrA.IsValid())
-
-        self.assertFalse(mayaUsdUfe.isAttributeEditAllowed(fooattrA))
-
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/ufe/testAttributeBlock.py
+++ b/test/lib/ufe/testAttributeBlock.py
@@ -21,7 +21,7 @@ import mayaUtils
 import ufeUtils
 import usdUtils
 
-from pxr import UsdGeom, Vt, Gf
+from pxr import UsdGeom, Vt, Gf, Usd, Sdf
 
 from maya import cmds
 from maya import standalone
@@ -32,6 +32,8 @@ from mayaUsd import ufe as mayaUsdUfe
 import ufe
 import os
 import unittest
+import textwrap
+
 
 class AttributeBlockTestCase(unittest.TestCase):
 
@@ -347,6 +349,83 @@ class AttributeBlockTestCase(unittest.TestCase):
 
         # authoring new transformation edit is allowed.
         self.assertTrue(mayaUsdUfe.isAttributeEditAllowed(transformAttr))
+    
+    def testIsAttributeEditAllowedFunction(self):
+        rootLayerStr = """\
+        #sdf 1.4.32
+        ()
+        def "root"
+        {
+        }
+        """
+        subLayerAStr = """\
+        #sdf 1.4.32
+        over "root"
+        {
+            def "a" 
+            {
+                float foo = 0.0
+            }
+
+            def "b" 
+            {
+                float foo = 0.0
+            }
+        }
+        """
+        subLayerBStr = """\
+        #sdf 1.4.32
+        over "root"
+        {
+        }
+        """
+        subLayerCStr = """\
+        #sdf 1.4.32
+        over "root"
+        {
+            over "a" 
+            {
+                float foo = 10.0
+            }
+        }
+        """
+
+        rootLayer = Sdf.Layer.CreateAnonymous()
+        rootLayer.ImportFromString(textwrap.dedent(rootLayerStr))
+
+        subLayerA = Sdf.Layer.CreateAnonymous()
+        subLayerA.ImportFromString(textwrap.dedent(subLayerAStr))
+
+        subLayerB = Sdf.Layer.CreateAnonymous()
+        subLayerB.ImportFromString(textwrap.dedent(subLayerBStr))
+
+        subLayerC = Sdf.Layer.CreateAnonymous()
+        subLayerC.ImportFromString(textwrap.dedent(subLayerCStr))
+
+        rootLayer.subLayerPaths = [
+            subLayerC.identifier,
+            subLayerB.identifier,
+            subLayerA.identifier,
+        ]
+        stage = Usd.Stage.Open(rootLayer)
+
+        primB = stage.GetPrimAtPath("/root/b")
+        self.assertTrue(primB.IsValid())
+
+        fooattrB = primB.GetAttribute("foo")
+        self.assertTrue(fooattrB.IsValid())
+
+        stage.SetEditTarget(Usd.EditTarget(subLayerB))
+        self.assertTrue(mayaUsdUfe.isAttributeEditAllowed(fooattrB))
+
+        primA = stage.GetPrimAtPath("/root/a")
+        self.assertTrue(primA.IsValid())
+
+        fooattrA = primA.GetAttribute("foo")
+        self.assertTrue(fooattrA.IsValid())
+
+        self.assertFalse(mayaUsdUfe.isAttributeEditAllowed(fooattrA))
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/testSamples/attributeBlock/root.usda
+++ b/test/testSamples/attributeBlock/root.usda
@@ -1,0 +1,12 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+    subLayers = [
+        @subB.usda@,
+        @subC.usda@,
+    ]
+)
+
+def "root"
+{
+}

--- a/test/testSamples/attributeBlock/subB.usda
+++ b/test/testSamples/attributeBlock/subB.usda
@@ -1,0 +1,15 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+    subLayers = [
+        @sublayerOfSubB.usda@,
+    ]
+
+)
+
+def "root" (
+    prepend references = @subBRef.usda@
+)
+{
+
+}

--- a/test/testSamples/attributeBlock/subBRef.usda
+++ b/test/testSamples/attributeBlock/subBRef.usda
@@ -1,0 +1,12 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+)
+def "root"
+{
+    over "b" 
+    {
+        float foo = 10.0
+    }
+
+}

--- a/test/testSamples/attributeBlock/subC.usda
+++ b/test/testSamples/attributeBlock/subC.usda
@@ -1,0 +1,9 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+)
+def "root" (
+    prepend references = @subCRef.usda@
+)
+{
+}

--- a/test/testSamples/attributeBlock/subCRef.usda
+++ b/test/testSamples/attributeBlock/subCRef.usda
@@ -1,0 +1,16 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+)
+def "root"
+{
+    def "a" 
+    {
+        float foo = 0.0
+    }
+
+    def "b" 
+    {
+        float foo = 0.0
+    }
+}

--- a/test/testSamples/attributeBlock/sublayerOfSubB.usda
+++ b/test/testSamples/attributeBlock/sublayerOfSubB.usda
@@ -1,0 +1,9 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+)
+def "root"
+{
+    
+  
+}


### PR DESCRIPTION
This PR is for addressing the issue discussed in here https://github.com/Autodesk/maya-usd/discussions/2212. In short, at Animal Logic, we found `isAttributeEditAllowed` function in UFE a bit confusing and was blocking our pipeline so we updated its logic in our internal code base. This PR is to promote our internal solution. 

