### PR TITLE
MAYA-123579 fix crash when deleting a stage

### DIFF
--- a/lib/mayaUsd/ufe/UsdStageMap.cpp
+++ b/lib/mayaUsd/ufe/UsdStageMap.cpp
@@ -230,9 +230,21 @@ UsdStageMap::StageSet UsdStageMap::allStages()
 {
     rebuildIfDirty();
 
-    StageSet stages;
+    // Note: stage() calls proxyShape() which can modify fPathToObject,
+    //       so we cannot call stage within a loop on fPathToObject.
+    //
+    //       So, we first cache all UFE paths and then loop over them
+    //       calling stage().
+
+    std::vector<Ufe::Path> paths;
+    paths.reserve(fPathToObject.size());
     for (const auto& pair : fPathToObject) {
-        stages.insert(stage(pair.first));
+        paths.emplace_back(pair.first);
+    }
+
+    StageSet stages;
+    for (const auto& path : paths) {
+        stages.insert(stage(path));
     }
     return stages;
 }

--- a/test/lib/mayaUsd/nodes/testProxyShapeBase.py
+++ b/test/lib/mayaUsd/nodes/testProxyShapeBase.py
@@ -116,6 +116,31 @@ class testProxyShapeBase(unittest.TestCase):
         self.assertEqual(0, len(ufe.Hierarchy.hierarchy(duplProxyShapeItem).children()))
         self.assertEqual(1, len(ufe.Hierarchy.hierarchy(proxyShapeItem).children()))
 
+    def testDeleteStage(self):
+        '''
+        Verify that we can delete the stage.
+        '''
+        # create new stage
+        cmds.file(new=True, force=True)
+
+        # Open usdCylinder.ma scene in testSamples twice, so that deleting one instance
+        # will still leave another and have something to iterate over in th estage cache.
+        mayaUtils.openCylinderScene()
+        mayaUtils.openCylinderScene()
+
+        # get the proxy shape path
+        proxyShapes = cmds.ls(type="mayaUsdProxyShapeBase", long=True)
+
+        # Get the USD handler.
+        proxyShapePath = ufe.PathString.path(proxyShapes[0])
+        handler = ufe.RunTimeMgr.instance().sceneSegmentHandler(proxyShapePath.runTimeId())
+
+        # Delete the proxy shape.
+        cmds.delete(proxyShapes[0])
+
+        # Request the now dead proxy shape. This should not crash.
+        result = handler.findGatewayItems(proxyShapePath)
+
     @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 2, 'testDuplicateProxyStageFileBacked only available in UFE v2 or greater.')
     def testDuplicateProxyStageFileBacked(self):
         '''


### PR DESCRIPTION
The loop that retrieved all the stage was calling a function that could modify the container that was iterated over. Fix this by first caching the items we want to iterate.

It only crashed in debug build due to the luck that the meory was still present and accessible in release build.

Added a unit test that crashed in debug and now works with the fix.