### PR TITLE
Guard against a NULL Usd Stage when rendering

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -828,6 +828,10 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
         }
     }
 
+    if (!usdStage) {
+        return MS::kFailure;
+    }
+
     // Create the output outData
     MFnPluginData pluginDataFn;
     pluginDataFn.create(MayaUsdStageData::mayaTypeId, &retValue);


### PR DESCRIPTION
We were running into null pointer crashes when trying to load invalid
stages. This was hit internally when dealing with Usd Scene Assemblies -
I'm unsure if this is a problem in a pure UFE environment