### PR TITLE
MAYA-123122 remember shared/unshared load state

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -693,6 +693,20 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
 
     bool isIncomingStage = false;
 
+    // Compute the laod set for the stage.
+    MDataHandle loadPayloadsHandle = dataBlock.inputValue(loadPayloadsAttr, &retValue);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+    UsdStage::InitialLoadSet loadSet = loadPayloadsHandle.asBool()
+        ? UsdStage::InitialLoadSet::LoadAll
+        : UsdStage::InitialLoadSet::LoadNone;
+
+    // If there is a dynamic attribute containing the exact load rules
+    // for payload, start by loading nothing. The correct payload will
+    // be loaded by the load rules.
+    if (hasLoadRulesAttribute(thisMObject()))
+        loadSet = UsdStage::InitialLoadSet::LoadNone;
+
     // If inData has an incoming connection, then use it. Otherwise generate stage from the filepath
     if (!inDataHandle.data().isNull()) {
         MayaUsdStageData* inStageData
@@ -753,18 +767,6 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                 .Msg("ProxyShapeBase::loadStage called for the usd file: %s\n", fileString.c_str());
 
             // == Load the Stage
-            MDataHandle loadPayloadsHandle = dataBlock.inputValue(loadPayloadsAttr, &retValue);
-            CHECK_MSTATUS_AND_RETURN_IT(retValue);
-
-            UsdStage::InitialLoadSet loadSet = loadPayloadsHandle.asBool()
-                ? UsdStage::InitialLoadSet::LoadAll
-                : UsdStage::InitialLoadSet::LoadNone;
-
-            // If there is a dynamic attribute containing the exact load rules
-            // for payload, start by loading nothing. The correct payload will
-            // be loaded by the load rules.
-            if (hasLoadRulesAttribute(thisMObject()))
-                loadSet = UsdStage::InitialLoadSet::LoadNone;
 
             {
 #if AR_VERSION == 1
@@ -821,11 +823,6 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                 }
             }
         }
-
-        if (usdStage) {
-            primPath = usdStage->GetPseudoRoot().GetPath();
-            copyLoadRulesFromAttribute(thisMObject(), *usdStage);
-        }
     }
 
     // Create the output outData
@@ -858,19 +855,6 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                 }
             }
         }
-
-        // Set the outUsdStageData
-        stageData->stage = usdStage;
-        stageData->primPath = primPath;
-
-        // Set the data on the output plug
-        MDataHandle inDataCachedHandle = dataBlock.outputValue(inStageDataCachedAttr, &retValue);
-        CHECK_MSTATUS_AND_RETURN_IT(retValue);
-
-        inDataCachedHandle.set(stageData);
-        inDataCachedHandle.setClean();
-
-        return MS::kSuccess;
     }
     // Own the stage
     else {
@@ -915,17 +899,26 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                 newReferencedLayers, _unsharedStageRootLayer, MayaUsdMetadata->ReferencedLayers);
         }
 
-        stageData->stage = UsdStage::UsdStage::Open(_unsharedStageRootLayer);
-        stageData->primPath = stageData->stage->GetPseudoRoot().GetPath();
-
-        MDataHandle inDataCachedHandle = dataBlock.outputValue(inStageDataCachedAttr, &retValue);
-        CHECK_MSTATUS_AND_RETURN_IT(retValue);
-
-        inDataCachedHandle.set(stageData);
-        inDataCachedHandle.setClean();
-
-        return MS::kSuccess;
+        usdStage = UsdStage::UsdStage::Open(_unsharedStageRootLayer, loadSet);
     }
+
+    if (usdStage) {
+        primPath = usdStage->GetPseudoRoot().GetPath();
+        copyLoadRulesFromAttribute(thisMObject(), *usdStage);
+    }
+
+    // Set the outUsdStageData
+    stageData->stage = usdStage;
+    stageData->primPath = primPath;
+
+    // Set the data on the output plug
+    MDataHandle inDataCachedHandle = dataBlock.outputValue(inStageDataCachedAttr, &retValue);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+    inDataCachedHandle.set(stageData);
+    inDataCachedHandle.setClean();
+
+    return MS::kSuccess;
 }
 
 MStatus MayaUsdProxyShapeBase::computeOutStageData(MDataBlock& dataBlock)

--- a/lib/mayaUsd/nodes/proxyShapeLoadRules.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeLoadRules.cpp
@@ -37,6 +37,12 @@ ProxyShapeSet& getTrackedProxyShapes()
 
 void onMayaAboutToSave(void* /* unused */)
 {
+    // Note: passing nullptr means save all stages.
+    MayaUsdProxyShapeLoadRules::saveLoadRules(nullptr);
+}
+
+void saveTrackedLoadRules(const UsdStageRefPtr& stage)
+{
     ProxyShapeSet& tracked = getTrackedProxyShapes();
     for (MayaUsdProxyShapeBase* proxyShape : tracked) {
         if (!proxyShape)
@@ -44,6 +50,9 @@ void onMayaAboutToSave(void* /* unused */)
 
         auto stagePtr = proxyShape->getUsdStage();
         if (!stagePtr)
+            continue;
+
+        if (stage && stage != stagePtr)
             continue;
 
         MObject proxyObj = proxyShape->thisMObject();
@@ -90,6 +99,19 @@ void MayaUsdProxyShapeLoadRules::addProxyShape(MayaUsdProxyShapeBase& proxyShape
 void MayaUsdProxyShapeLoadRules::removeProxyShape(MayaUsdProxyShapeBase& proxyShape)
 {
     getTrackedProxyShapes().erase(&proxyShape);
+}
+
+/* static */
+void MayaUsdProxyShapeLoadRules::saveAllLoadRules()
+{
+    // Note: passing nullptr means save all stages.
+    saveTrackedLoadRules(nullptr);
+}
+
+/* static */
+void MayaUsdProxyShapeLoadRules::saveLoadRules(const UsdStageRefPtr& stage)
+{
+    saveTrackedLoadRules(stage);
 }
 
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/nodes/proxyShapeLoadRules.h
+++ b/lib/mayaUsd/nodes/proxyShapeLoadRules.h
@@ -51,6 +51,14 @@ public:
     /// \brief remove a proxy shape so that it will no longer have its load rules saved and loaded.
     MAYAUSD_CORE_PUBLIC
     static void removeProxyShape(MayaUsdProxyShapeBase& proxyShape);
+
+    /// \brief save load rules of tracked proxy shapes.
+    MAYAUSD_CORE_PUBLIC
+    static void saveAllLoadRules();
+
+    /// \brief save load rules of the tracked proxy shape corresponding to the given stage.
+    MAYAUSD_CORE_PUBLIC
+    static void saveLoadRules(const UsdStageRefPtr& stage);
 };
 
 } // namespace MAYAUSD_NS_DEF


### PR DESCRIPTION
- Move and refactor code in proxy shape to avoid code duplication.
- (There was duplication between shared and unshared case.)
- Now unshared stage also applied the load state.
- Add functions to the proxy shape load rule helper class to trigger saving load rules.
- Save load rules when modifying the loaded state of prims.
- Refactor the load state commands to share mode code.