### PR TITLE
MAYA-114376 preserve unsaved root layer

### DIFF
--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -141,7 +141,7 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
             mImportData.stageInitialLoadSet());
     } else {
         UsdStageCacheContext stageCacheContext(UsdMayaStageCache::Get(
-            mImportData.stageInitialLoadSet() == UsdStage::InitialLoadSet::LoadAll));
+            mImportData.stageInitialLoadSet(), UsdMayaStageCache::ShareMode::Shared));
         if (mArgs.pullImportStage)
             stage = mArgs.pullImportStage;
         else

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -787,7 +787,14 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                 if (nullptr == rootLayer)
                     rootLayer = SdfLayer::FindOrOpen(fileString);
 
-                if (rootLayer) {
+                if (nullptr == rootLayer) {
+                    // Create a new stage in memory with an anonymous root layer.
+                    if (!_anonymousRootLayer)
+                        _anonymousRootLayer = SdfLayer::CreateAnonymous(kAnonymousLayerName);
+                    rootLayer = _anonymousRootLayer;
+                }
+
+                {
                     // Note: computeSessionLayer will find a session layer *only* if the
                     //       Maya scene had been saved and thus serialized the session
                     //       layer. Othersise it returns null which will mean to use
@@ -840,9 +847,6 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                     } else {
                         sharedUsdStage->SetEditTarget(sharedUsdStage->GetRootLayer());
                     }
-                } else {
-                    // Create a new stage in memory with an anonymous root layer.
-                    sharedUsdStage = UsdStage::CreateInMemory(kAnonymousLayerName, loadSet);
                 }
             }
         }
@@ -1722,6 +1726,7 @@ MayaUsdProxyShapeBase::MayaUsdProxyShapeBase(
     : MPxSurfaceShape()
     , _isUfeSelectionEnabled(enableUfeSelection)
     , _previousShareMode(ShareMode::Unknown)
+    , _anonymousRootLayer(nullptr)
     , _unsharedStageSessionLayer(nullptr)
     , _unsharedStageRootLayer(nullptr)
     , _unsharedStageRootSublayers()

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -651,7 +651,9 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
     }
 
     // Normal context computation
-    UsdStageRefPtr usdStage;
+    UsdStageRefPtr sharedUsdStage;
+    UsdStageRefPtr unsharedUsdStage;
+    UsdStageRefPtr finalUsdStage;
     SdfPath        primPath;
 
     MDataHandle inDataHandle = dataBlock.inputValue(inStageDataAttr, &retValue);
@@ -711,7 +713,7 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
     if (!inDataHandle.data().isNull()) {
         MayaUsdStageData* inStageData
             = dynamic_cast<MayaUsdStageData*>(inDataHandle.asPluginData());
-        usdStage = inStageData->stage;
+        sharedUsdStage = inStageData->stage;
         primPath = inStageData->primPath;
         isIncomingStage = true;
     } else {
@@ -721,7 +723,7 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
         const auto cacheId = UsdStageCache::Id::FromLongInt(cacheIdNum);
         const auto stageCached = cacheId.IsValid() && UsdUtilsStageCache::Get().Contains(cacheId);
         if (stageCached) {
-            usdStage = UsdUtilsStageCache::Get().Find(cacheId);
+            sharedUsdStage = UsdUtilsStageCache::Get().Find(cacheId);
             isIncomingStage = true;
         } else {
             //
@@ -778,7 +780,7 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                 // UsdStage. See https://github.com/Autodesk/maya-usd/issues/528 for
                 // more information.
                 UsdStageCacheContext ctx(
-                    UsdMayaStageCache::Get(loadSet == UsdStage::InitialLoadSet::LoadAll));
+                    UsdMayaStageCache::Get(loadSet, UsdMayaStageCache::ShareMode::Shared));
 
                 SdfLayerRefPtr rootLayer
                     = sharableStage ? computeRootLayer(dataBlock, fileString) : nullptr;
@@ -786,6 +788,11 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                     rootLayer = SdfLayer::FindOrOpen(fileString);
 
                 if (rootLayer) {
+                    // Note: computeSessionLayer will find a session layer *only* if the
+                    //       Maya scene had been saved and thus serialized the session
+                    //       layer. Othersise it returns null which will mean to use
+                    //       whatever session layer happens to be associated with the
+                    //       stage we potentially find in the stage cache.
                     SdfLayerRefPtr sessionLayer = computeSessionLayer(dataBlock);
 
                     MProfilingScope profilingScope(
@@ -798,34 +805,49 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                         = MGlobal::optionVarIntValue(kSessionLayerOptionVarName) == 1;
                     targetSession = targetSession || !rootLayer->PermissionToEdit();
 
-                    if (sessionLayer || targetSession) {
-                        if (!sessionLayer)
-                            sessionLayer = SdfLayer::CreateAnonymous();
-                        usdStage = UsdStage::Open(
+                    // Note: UsdStage::Open has the peculiar design that it will return
+                    //       any previously open stage that happen to match its arguments,
+                    //       all its arguments, but only those arguments.
+                    //
+                    //       So *not* passing in a session layer will find any stage that
+                    //       has the given root layer. That is why it is important *not* to
+                    //       pass the session layer if the session layer is null. Otherwise
+                    //       the cache would try find a stage *without* a session layer.
+                    //
+                    //       So, not passing the (null) session layer is how a newly-created
+                    //       shared stage with the same root layer will find the correct stage
+                    //       with the existing session layer.
+                    //
+                    //       If the stage is not in the cache and no session layer is passed
+                    //       then UsdStage::Open will create the in-memory session layer for us,
+                    //       just as we want.
+                    if (sessionLayer) {
+                        sharedUsdStage = UsdStage::Open(
                             rootLayer,
                             sessionLayer,
                             ArGetResolver().CreateDefaultContextForAsset(fileString),
                             loadSet);
                     } else {
-                        usdStage = UsdStage::Open(
+                        sharedUsdStage = UsdStage::Open(
                             rootLayer,
                             ArGetResolver().CreateDefaultContextForAsset(fileString),
                             loadSet);
                     }
+
                     if (sessionLayer && targetSession) {
-                        usdStage->SetEditTarget(sessionLayer);
+                        sharedUsdStage->SetEditTarget(sessionLayer);
                     } else {
-                        usdStage->SetEditTarget(usdStage->GetRootLayer());
+                        sharedUsdStage->SetEditTarget(sharedUsdStage->GetRootLayer());
                     }
                 } else {
                     // Create a new stage in memory with an anonymous root layer.
-                    usdStage = UsdStage::CreateInMemory(kAnonymousLayerName, loadSet);
+                    sharedUsdStage = UsdStage::CreateInMemory(kAnonymousLayerName, loadSet);
                 }
             }
         }
     }
 
-    if (!usdStage) {
+    if (!sharedUsdStage) {
         return MS::kFailure;
     }
 
@@ -838,7 +860,7 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
     if (isIncomingStage) {
-        std::vector<std::string> incomingLayers { usdStage->GetRootLayer()->GetIdentifier() };
+        std::vector<std::string> incomingLayers { sharedUsdStage->GetRootLayer()->GetIdentifier() };
         _incomingLayers = UsdMayaUtil::getAllSublayers(incomingLayers, true);
     } else {
         _incomingLayers.clear();
@@ -859,10 +881,11 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                 }
             }
         }
+        finalUsdStage = sharedUsdStage;
     }
     // Own the stage
     else {
-        SdfLayerRefPtr inRootLayer = usdStage->GetRootLayer();
+        SdfLayerRefPtr inRootLayer = sharedUsdStage->GetRootLayer();
 
         if (!_unsharedStageRootLayer) {
             _unsharedStageRootLayer = SdfLayer::CreateAnonymous(kUnsharedStageLayerName);
@@ -903,16 +926,18 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                 newReferencedLayers, _unsharedStageRootLayer, MayaUsdMetadata->ReferencedLayers);
         }
 
-        usdStage = UsdStage::UsdStage::Open(_unsharedStageRootLayer, loadSet);
+        unsharedUsdStage = getUnsharedStage(loadSet);
+        finalUsdStage = unsharedUsdStage;
     }
 
-    if (usdStage) {
-        primPath = usdStage->GetPseudoRoot().GetPath();
-        copyLoadRulesFromAttribute(thisMObject(), *usdStage);
+    if (finalUsdStage) {
+        primPath = finalUsdStage->GetPseudoRoot().GetPath();
+        copyLoadRulesFromAttribute(thisMObject(), *finalUsdStage);
+        updateShareMode(sharedUsdStage, unsharedUsdStage, loadSet);
     }
 
     // Set the outUsdStageData
-    stageData->stage = usdStage;
+    stageData->stage = finalUsdStage;
     stageData->primPath = primPath;
 
     // Set the data on the output plug
@@ -923,6 +948,83 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
     inDataCachedHandle.setClean();
 
     return MS::kSuccess;
+}
+
+UsdStageRefPtr MayaUsdProxyShapeBase::getUnsharedStage(UsdStage::InitialLoadSet loadSet)
+{
+    // The unshared stages are *also* kept in a stage cache so that we can find them
+    // again when proxy shape attribute change. For example, if the 'loadPayloads'
+    // attribute change, we want to find the same unshared stage, we don't want to lose
+    // edits, in particular in its session layer.
+    //
+    // We also need to be ble to find them when switching a stage between non-shared
+    // and shared, so that we can transfer the content of the session layer.
+    //
+    // Fortunately, the USD stage cache matches stages using *all* arguments provided.
+    // So if the unshared session layer is unique to this proxy shape, there is no
+    // chance of finding it by accident from another proxy shape.
+    UsdStageCacheContext ctx(
+        UsdMayaStageCache::Get(loadSet, UsdMayaStageCache::ShareMode::Unshared));
+
+    if (!_unsharedStageSessionLayer)
+        _unsharedStageSessionLayer = SdfLayer::CreateAnonymous();
+
+    return UsdStage::UsdStage::Open(_unsharedStageRootLayer, _unsharedStageSessionLayer, loadSet);
+}
+
+void MayaUsdProxyShapeBase::updateShareMode(
+    UsdStageRefPtr           sharedUsdStage,
+    UsdStageRefPtr           unsharedUsdStage,
+    UsdStage::InitialLoadSet loadSet)
+{
+    // Based on the previous shared mode and current shared mode of the stage,
+    // transfer the content of the session layer from one to the other as needed.
+    const auto shareMode = isShareableStage() ? ShareMode::Shared : ShareMode::Unshared;
+    if (shareMode == _previousShareMode)
+        return;
+
+    // Only transfer the session content if the previous mode was known
+    // or if the current mode is unshared, as the session layer content
+    // is put in the shared stage when loaded from disk in a Maya scene.
+    //
+    // IOW:
+    //     Shared   -> Unshared : copy
+    //     Unshared -> Shared   : copy
+    //     Unknown  -> Unshared : copy
+    //
+    //     Shared   -> Shared   : content already in place, pruned above
+    //     Unshared -> Unshared : content already in place, pruned above
+    //     Unknown  -> Shared   : content already in place
+    //
+    //     X -> Unknown : impossible since the new mode is always known
+    if (_previousShareMode != ShareMode::Unknown || shareMode == ShareMode::Unshared)
+        transferSessionLayer(shareMode, sharedUsdStage, unsharedUsdStage, loadSet);
+
+    _previousShareMode = shareMode;
+}
+
+void MayaUsdProxyShapeBase::transferSessionLayer(
+    ShareMode                currentMode,
+    UsdStageRefPtr           sharedUsdStage,
+    UsdStageRefPtr           unsharedUsdStage,
+    UsdStage::InitialLoadSet loadSet)
+{
+    // When flipping to shared from unshared, the unshared set was not loaded.
+    // Load it now to be able to transfer the session layer content.
+    if (!unsharedUsdStage)
+        unsharedUsdStage = getUnsharedStage(loadSet);
+
+    SdfLayerHandle sharedSession = sharedUsdStage->GetSessionLayer();
+    SdfLayerHandle unsharedSession = unsharedUsdStage->GetSessionLayer();
+
+    if (!sharedSession || !unsharedSession)
+        return;
+
+    if (currentMode == ShareMode::Shared) {
+        sharedSession->TransferContent(unsharedSession);
+    } else {
+        unsharedSession->TransferContent(sharedSession);
+    }
 }
 
 MStatus MayaUsdProxyShapeBase::computeOutStageData(MDataBlock& dataBlock)
@@ -1618,6 +1720,8 @@ MayaUsdProxyShapeBase::MayaUsdProxyShapeBase(
     const bool useLoadRulesHandling)
     : MPxSurfaceShape()
     , _isUfeSelectionEnabled(enableUfeSelection)
+    , _previousShareMode(ShareMode::Unknown)
+    , _unsharedStageSessionLayer(nullptr)
     , _unsharedStageRootLayer(nullptr)
     , _unsharedStageRootSublayers()
     , _incomingLayers()

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -834,7 +834,8 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                             loadSet);
                     }
 
-                    if (sessionLayer && targetSession) {
+                    if (targetSession) {
+                        sessionLayer = sharedUsdStage->GetSessionLayer();
                         sharedUsdStage->SetEditTarget(sessionLayer);
                     } else {
                         sharedUsdStage->SetEditTarget(sharedUsdStage->GetRootLayer());

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -339,6 +339,15 @@ protected:
     void copyInternalData(MPxNode* srcNode) override;
 
 private:
+    // The possible the shared mode of the stage.
+    // The 'Unknown' mode is when the orxy shape is created and has not yet been computed.
+    enum class ShareMode
+    {
+        Unknown,
+        Shared,
+        Unshared
+    };
+
     MayaUsdProxyShapeBase(const MayaUsdProxyShapeBase&);
     MayaUsdProxyShapeBase& operator=(const MayaUsdProxyShapeBase&);
 
@@ -346,6 +355,19 @@ private:
     MStatus computeInStageDataCached(MDataBlock& dataBlock);
     MStatus computeOutStageData(MDataBlock& dataBlock);
     MStatus computeOutStageCacheId(MDataBlock& dataBlock);
+
+    void updateShareMode(
+        UsdStageRefPtr           sharedUsdStage,
+        UsdStageRefPtr           unsharedUsdStage,
+        UsdStage::InitialLoadSet loadSet);
+
+    void transferSessionLayer(
+        ShareMode                currentMode,
+        UsdStageRefPtr           sharedUsdStage,
+        UsdStageRefPtr           unsharedUsdStage,
+        UsdStage::InitialLoadSet loadSet);
+
+    UsdStageRefPtr getUnsharedStage(UsdStage::InitialLoadSet loadSet);
 
     SdfPathVector _GetExcludePrimPaths(MDataBlock dataBlock) const;
     int           _GetComplexity(MDataBlock dataBlock) const;
@@ -373,7 +395,12 @@ private:
     // Whether or not the proxy shape has enabled UFE/subpath selection
     const bool _isUfeSelectionEnabled;
 
+    // Track the shared mode of the stage as seen in the last compute.
+    // Starts off as Unknown when the proxy shape is first created.
+    ShareMode _previousShareMode;
+
     // For unshared composition
+    SdfLayerRefPtr _unsharedStageSessionLayer;
     SdfLayerRefPtr _unsharedStageRootLayer;
 
     // We need to keep track of unshared sublayers (otherwise they get removed)

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -399,6 +399,9 @@ private:
     // Starts off as Unknown when the proxy shape is first created.
     ShareMode _previousShareMode;
 
+    // Anonymous layer that was created when a new proxy shape is created without a named layer.
+    SdfLayerRefPtr _anonymousRootLayer;
+
     // For unshared composition
     SdfLayerRefPtr _unsharedStageSessionLayer;
     SdfLayerRefPtr _unsharedStageRootLayer;

--- a/lib/mayaUsd/python/wrapStageCache.cpp
+++ b/lib/mayaUsd/python/wrapStageCache.cpp
@@ -18,6 +18,7 @@
 #include <pxr/base/tf/pyResultConversions.h>
 #include <pxr/pxr.h>
 
+#include <boost/python.hpp>
 #include <boost/python/args.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/def.hpp>
@@ -28,14 +29,24 @@ using namespace boost;
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
+namespace {
+UsdStageCache& _UsdMayaStageCacheGet(bool loadAll, bool shared)
+{
+    return UsdMayaStageCache::Get(
+        loadAll ? UsdStage::InitialLoadSet::LoadAll : UsdStage::InitialLoadSet::LoadNone,
+        shared ? UsdMayaStageCache::ShareMode::Shared : UsdMayaStageCache::ShareMode::Unshared);
+}
+
+} // namespace
+
 void wrapStageCache()
 {
     class_<UsdMayaStageCache>("StageCache")
 
         .def(
             "Get",
-            &UsdMayaStageCache::Get,
-            args("loadAll"),
+            _UsdMayaStageCacheGet,
+            python::args("loadAll", "shared"),
             return_value_policy<reference_existing_object>())
         .staticmethod("Get")
         .def("Clear", &UsdMayaStageCache::Clear)

--- a/lib/mayaUsd/utils/stageCache.h
+++ b/lib/mayaUsd/utils/stageCache.h
@@ -20,6 +20,7 @@
 
 #include <pxr/pxr.h>
 #include <pxr/usd/sdf/path.h>
+#include <pxr/usd/usd/stage.h>
 #include <pxr/usd/usd/stageCache.h>
 
 #include <string>
@@ -29,12 +30,24 @@ PXR_NAMESPACE_OPEN_SCOPE
 class UsdMayaStageCache
 {
 public:
+    enum class ShareMode
+    {
+        Shared,
+        Unshared
+    };
+
     /// Return the singleton stage cache for use by all USD clients within Maya.
-    /// 2 stage caches are maintained; 1 for stages that have been opened with
-    /// UsdStage::InitialLoadSet::LoadAll, and 1 for stages that have been
-    /// opened with UsdStage::InitialLoadSet::LoadNode.
+    /// Four stage caches are maintained. They are divided based on two criteria:
+    ///
+    ///    stages that have been opened with UsdStage::InitialLoadSet::LoadAll
+    ///                                  vs
+    ///    stages that have been opened with UsdStage::InitialLoadSet::LoadNode.
+    ///
+    ///    stages that are shared
+    ///            vs
+    ///    stages that are not-shared
     MAYAUSD_CORE_PUBLIC
-    static UsdStageCache& Get(const bool loadAll);
+    static UsdStageCache& Get(UsdStage::InitialLoadSet, ShareMode);
 
     /// Clear the cache
     MAYAUSD_CORE_PUBLIC

--- a/plugin/pxr/maya/lib/usdMaya/referenceAssembly.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/referenceAssembly.cpp
@@ -664,8 +664,8 @@ MStatus UsdMayaReferenceAssembly::computeInStageDataCached(MDataBlock& dataBlock
                 sessionLayer = unsharedSessionLayer;
             }
 
-            const bool           loadAll = true;
-            UsdStageCacheContext ctx(UsdMayaStageCache::Get(loadAll));
+            UsdStageCacheContext ctx(UsdMayaStageCache::Get(
+                UsdStage::InitialLoadSet::LoadAll, UsdMayaStageCache::ShareMode::Shared));
             usdStage = UsdStage::Open(rootLayer, sessionLayer, ArGetResolver().GetCurrentContext());
             usdStage->SetEditTarget(usdStage->GetSessionLayer());
 
@@ -818,8 +818,8 @@ MStatus UsdMayaReferenceAssembly::computeOutStageData(MDataBlock& dataBlock)
             sessionLayer->TransferContent(oldLayer);
             sessionLayer->TransferContent(newLayer);
 
-            const bool           loadAll = true;
-            UsdStageCacheContext ctx(UsdMayaStageCache::Get(loadAll));
+            UsdStageCacheContext ctx(UsdMayaStageCache::Get(
+                UsdStage::InitialLoadSet::LoadAll, UsdMayaStageCache::ShareMode::Shared));
             usdStage = UsdStage::Open(
                 usdPrim.GetStage()->GetRootLayer(),
                 sessionLayer,

--- a/plugin/pxr/maya/lib/usdMaya/translatorModelAssembly.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/translatorModelAssembly.cpp
@@ -349,8 +349,8 @@ bool UsdMayaTranslatorModelAssembly::Read(
         return false;
     }
 
-    const bool           loadAll = true;
-    UsdStageCacheContext stageCacheContext(UsdMayaStageCache::Get(loadAll));
+    UsdStageCacheContext stageCacheContext(UsdMayaStageCache::Get(
+        UsdStage::InitialLoadSet::LoadAll, UsdMayaStageCache::ShareMode::Shared));
     UsdStageRefPtr       usdStage = UsdStage::Open(assetIdentifier);
     if (!usdStage) {
         TF_RUNTIME_ERROR("Cannot open USD file %s", assetIdentifier.c_str());

--- a/test/lib/testMayaUsdPythonImport.py
+++ b/test/lib/testMayaUsdPythonImport.py
@@ -32,5 +32,5 @@ class MayaUsdPythonImportTestCase(unittest.TestCase):
         # mayaUsd library also loaded its dependencies (i.e. the core USD
         # libraries). We test the type name as a string to ensure that we're
         # not causing USD libraries to be loaded any other way.
-        stageCache = mayaUsdLib.StageCache.Get(True)
+        stageCache = mayaUsdLib.StageCache.Get(True, True)
         self.assertEqual(type(stageCache).__name__, 'StageCache')


### PR DESCRIPTION
When the proxy stage is recompute with an unsaved root layer, the attribute keeping the root layer name would be empty. A new root layer would be created each time, losing any previous content.

This attribute only gets set once the stage gets saved.

Fix this by re-using the same anonymous root layer when the stage has not been saved yet.

Also, as a bonus, this fix change teh code so that the same code path for newly created stage is used, which means that if the user ahas set the option var to target the session layer, it will also be honored for newly-created stages. It will also re-use any pre-existing stage, so we also avoid creating stages repeatedly for the same unsaved proxy stage node every time an attribute get sets.