### PR TITLE
MAYA-114724/MAYA-114039 - Progress bar for import/export/push/pull

### DIFF
--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -23,6 +23,7 @@
 #include <mayaUsd/nodes/stageNode.h>
 #include <mayaUsd/undo/OpUndoItemMuting.h>
 #include <mayaUsd/utils/stageCache.h>
+#include <mayaUsd/utils/progressBarScope.h>
 #include <mayaUsd/utils/util.h>
 #include <mayaUsd/utils/utilFileSystem.h>
 
@@ -101,6 +102,11 @@ UsdMaya_ReadJob::~UsdMaya_ReadJob() { }
 
 bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
 {
+    // When we are called from PrimUpdaterManager we should already have
+    // a computation scope. If we are called from elsewhere don't show any
+    // progress bar here.
+    MayaUsd::ProgressBarScope progressBar(16);
+
     // Do not use the global undo info recording system.
     // The read job Undo() / redo() functions will handle all operations.
     OpUndoItemMuting undoMuting;
@@ -115,6 +121,7 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
     if (!rootLayer) {
         return false;
     }
+    progressBar.advance();
 
     TfToken modelName = UsdUtilsGetModelNameFromRootLayer(rootLayer);
 
@@ -129,6 +136,7 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
 
     SdfLayerRefPtr sessionLayer
         = UsdUtilsStageCache::GetSessionLayerForVariantSelections(modelName, varSelsVec);
+    progressBar.advance();
 
     // Layer and Stage used to Read in the USD file
     UsdStageRefPtr stage;
@@ -150,10 +158,12 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
     if (!stage) {
         return false;
     }
+    progressBar.advance();
 
     UsdEditContext editContext(stage, stage->GetSessionLayer());
     stage->SetEditTarget(stage->GetSessionLayer());
     _setTimeSampleMultiplierFrom(stage->GetTimeCodesPerSecond());
+    progressBar.advance();
 
     // XXX Currently all distance values are set directly from USD and will be
     // interpreted as centimeters (Maya's internal distance unit). Future work
@@ -169,6 +179,7 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
                     "distance unit.");
         }
     }
+    progressBar.advance();
 
     // If the import time interval isn't empty, we expand the Min/Max time
     // sliders to include the stage's range if necessary.
@@ -201,6 +212,7 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
                 MTime(stageInterval.GetMax() * mTimeSampleMultiplier, timeUnit));
         }
     }
+    progressBar.advance();
 
     // Use the primPath to get the root usdNode
     std::string primPath = mImportData.rootPrimPath();
@@ -214,6 +226,7 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
             mImportData.filename().c_str());
         usdRootPrim = stage->GetPseudoRoot();
     }
+    progressBar.advance();
 
     bool isImportingPseudoRoot = (usdRootPrim == stage->GetPseudoRoot());
 
@@ -226,6 +239,7 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
     for (auto& variant : mImportData.rootVariantSelections()) {
         usdRootPrim.GetVariantSet(variant.first).SetVariantSelection(variant.second);
     }
+    progressBar.advance();
 
     // Set the variants on all the import data prims.
     for (auto& varPrim : mImportData.primVariantSelections()) {
@@ -234,10 +248,12 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
             usdVarPrim.GetVariantSet(variant.first).SetVariantSelection(variant.second);
         }
     }
+    progressBar.advance();
 
     Usd_PrimFlagsPredicate predicate = UsdPrimDefaultPredicate;
 
     PreImport(predicate);
+    progressBar.advance();
 
     UsdPrimRange range(usdRootPrim, predicate);
     if (range.empty()) {
@@ -264,6 +280,7 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
 
     mNewNodeRegistry.insert(
         std::make_pair(rootPathToRegister.GetString(), mMayaRootDagPath.node()));
+    progressBar.advance();
 
     if (mArgs.useAsAnimationCache) {
         MDGModifier dgMod;
@@ -288,6 +305,7 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
         status = dgMod.doIt();
         CHECK_MSTATUS_AND_RETURN(status, false);
     }
+    progressBar.advance();
 
     // check if "USDZ Texture Import" option is checked and the archive in question is a USDZ.
     if (mArgs.importUSDZTextures && stage->GetRootLayer()->GetFileFormat()->IsPackage()) {
@@ -301,6 +319,7 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
     }
 
     DoImport(range, usdRootPrim);
+    progressBar.advance();
 
     // NOTE: (yliangsiew) Storage to later pass on to `PostImport` for import chasers.
     MDagPathArray currentAddedDagPaths;
@@ -329,6 +348,7 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
             }
         }
     }
+    progressBar.advance();
 
     // NOTE: (yliangsiew) Look into a registry of post-import "chasers" here
     // and call `PostImport` on each of them.
@@ -343,6 +363,7 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
             TF_RUNTIME_ERROR("Failed to create import chaser: %s", importChaserName.c_str());
         }
     }
+    progressBar.advance();
 
     for (const UsdMayaImportChaserRefPtr& chaser : this->mImportChasers) {
         bool bStat
@@ -352,6 +373,7 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
             return false;
         }
     }
+    progressBar.advance();
 
     UsdMayaReadUtil::mapFileHashes.clear();
 
@@ -498,6 +520,8 @@ bool UsdMaya_ReadJob::_DoImport(UsdPrimRange& rootRange, const UsdPrim& usdRootP
 {
     const bool buildInstances = mArgs.importInstances;
 
+    MayaUsd::ProgressBarScope progressBar(0);
+
     // We want both pre- and post- visit iterations over the prims in this
     // method. To do so, iterate over all the root prims of the input range,
     // and create new PrimRanges to iterate over their subtrees.
@@ -510,6 +534,9 @@ bool UsdMaya_ReadJob::_DoImport(UsdPrimRange& rootRange, const UsdPrim& usdRootP
             ? UsdPrimRange::PreAndPostVisit(rootPrim)
             : UsdPrimRange::PreAndPostVisit(
                 rootPrim, UsdTraverseInstanceProxies(UsdPrimAllPrimsPredicate));
+
+        const int loopSize = std::distance(range.begin(), range.end());
+        MayaUsd::ProgressBarLoopScope instanceLoop(loopSize);
         for (auto primIt = range.begin(); primIt != range.end(); ++primIt) {
             const UsdPrim&           prim = *primIt;
             UsdMayaPrimReaderContext readCtx(&mNewNodeRegistry);
@@ -520,19 +547,26 @@ bool UsdMaya_ReadJob::_DoImport(UsdPrimRange& rootRange, const UsdPrim& usdRootP
             } else {
                 _DoImportPrimIt(primIt, usdRootPrim, readCtx, primReaderMap);
             }
+            instanceLoop.loopAdvance();
         }
     }
 
     if (buildInstances) {
+        progressBar.addSteps(1);
+
         MDGModifier              deletePrototypeMod;
         UsdMayaPrimReaderContext readCtx(&mNewNodeRegistry);
         readCtx.SetTimeSampleMultiplier(mTimeSampleMultiplier);
 
 #if PXR_VERSION < 2011
-        for (const auto& prototype : usdRootPrim.GetStage()->GetMasters()) {
+        auto prototypes = usdRootPrim.GetStage()->GetMasters();
 #else
-        for (const auto& prototype : usdRootPrim.GetStage()->GetPrototypes()) {
+        auto prototypes = usdRootPrim.GetStage()->GetPrototypes();
 #endif
+        const int loopSize = prototypes.size();
+        MayaUsd::ProgressBarLoopScope prototypesLoop(loopSize);
+        for (const auto& prototype : prototypes) {
+
             const SdfPath prototypePath = prototype.GetPath();
             MObject       prototypeObject = readCtx.GetMayaNode(prototypePath, false);
             if (prototypeObject != MObject::kNullObj) {
@@ -549,8 +583,10 @@ bool UsdMaya_ReadJob::_DoImport(UsdPrimRange& rootRange, const UsdPrim& usdRootP
                 deletePrototypeMod.deleteNode(prototypeObject);
 #endif
             }
+            prototypesLoop.loopAdvance();
         }
         deletePrototypeMod.doIt();
+        progressBar.advance();
     }
 
     return true;

--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -22,8 +22,8 @@
 #include <mayaUsd/fileio/utils/readUtil.h>
 #include <mayaUsd/nodes/stageNode.h>
 #include <mayaUsd/undo/OpUndoItemMuting.h>
-#include <mayaUsd/utils/stageCache.h>
 #include <mayaUsd/utils/progressBarScope.h>
+#include <mayaUsd/utils/stageCache.h>
 #include <mayaUsd/utils/util.h>
 #include <mayaUsd/utils/utilFileSystem.h>
 
@@ -535,7 +535,7 @@ bool UsdMaya_ReadJob::_DoImport(UsdPrimRange& rootRange, const UsdPrim& usdRootP
             : UsdPrimRange::PreAndPostVisit(
                 rootPrim, UsdTraverseInstanceProxies(UsdPrimAllPrimsPredicate));
 
-        const int loopSize = std::distance(range.begin(), range.end());
+        const int                     loopSize = std::distance(range.begin(), range.end());
         MayaUsd::ProgressBarLoopScope instanceLoop(loopSize);
         for (auto primIt = range.begin(); primIt != range.end(); ++primIt) {
             const UsdPrim&           prim = *primIt;
@@ -563,7 +563,7 @@ bool UsdMaya_ReadJob::_DoImport(UsdPrimRange& rootRange, const UsdPrim& usdRootP
 #else
         auto prototypes = usdRootPrim.GetStage()->GetPrototypes();
 #endif
-        const int loopSize = prototypes.size();
+        const int                     loopSize = prototypes.size();
         MayaUsd::ProgressBarLoopScope prototypesLoop(loopSize);
         for (const auto& prototype : prototypes) {
 

--- a/lib/mayaUsd/fileio/jobs/writeJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/writeJob.cpp
@@ -54,6 +54,7 @@
 #include <mayaUsd/fileio/shading/shadingModeExporterContext.h>
 #include <mayaUsd/fileio/transformWriter.h>
 #include <mayaUsd/fileio/translators/translatorMaterial.h>
+#include <mayaUsd/utils/progressBarScope.h>
 #include <mayaUsd/utils/util.h>
 
 #include <pxr/usd/sdf/variantSetSpec.h>
@@ -115,19 +116,15 @@ bool UsdMaya_WriteJob::Write(const std::string& fileName, bool append)
 {
     const std::vector<double>& timeSamples = mJobCtx.mArgs.timeSamples;
 
-    MComputation computation;
-    if (timeSamples.empty()) {
-        // Non-animated export doesn't show progress.
-        computation.beginComputation(/*showProgressBar*/ false);
-    } else {
-        // Animated export shows frame-by-frame progress.
-        computation.beginComputation(/*showProgressBar*/ true);
-        computation.setProgressRange(0, timeSamples.size());
-    }
+    // Non-animated export doesn't show progress.
+    const bool showProgress = !timeSamples.empty();
+
+    // Animated export shows frame-by-frame progress.
+    int nbSteps = 1 + timeSamples.size();
+    MayaUsd::ProgressBarScope progressBar(showProgress, true /*interruptible */, nbSteps, "");
 
     // Default-time export.
     if (!_BeginWriting(fileName, append)) {
-        computation.endComputation();
         return false;
     }
 
@@ -135,24 +132,21 @@ bool UsdMaya_WriteJob::Write(const std::string& fileName, bool append)
     if (!timeSamples.empty()) {
         const MTime oldCurTime = MAnimControl::currentTime();
 
-        int progress = 0;
         for (double t : timeSamples) {
             if (mJobCtx.mArgs.verbose) {
                 TF_STATUS("%f", t);
             }
             MGlobal::viewFrame(t);
-            computation.setProgress(progress);
-            progress++;
+            progressBar.advance();
 
             // Process per frame data.
             if (!_WriteFrame(t)) {
                 MGlobal::viewFrame(oldCurTime);
-                computation.endComputation();
                 return false;
             }
 
             // Allow user cancellation.
-            if (computation.isInterruptRequested()) {
+            if (progressBar.isInterruptRequested()) {
                 break;
             }
         }
@@ -163,16 +157,16 @@ bool UsdMaya_WriteJob::Write(const std::string& fileName, bool append)
 
     // Finalize the export, close the stage.
     if (!_FinishWriting()) {
-        computation.endComputation();
         return false;
     }
-
-    computation.endComputation();
+    progressBar.advance();
     return true;
 }
 
 bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
 {
+    MayaUsd::ProgressBarScope progressBar(8);
+
     // Check for DAG nodes that are a child of an already specified DAG node to export
     // if that's the case, report the issue and skip the export
     UsdMayaUtil::MDagPathSet::const_iterator m, n;
@@ -193,6 +187,7 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
             }
         } // for n
     }     // for m
+    progressBar.advance();
 
     // Make sure the file name is a valid one with a proper USD extension.
     TfToken     fileExt(TfGetExtension(fileName));
@@ -209,6 +204,7 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
         // Has correct extension; use as-is.
         fileNameWithExt = fileName;
     }
+    progressBar.advance();
 
     // Setup file structure for export based on whether we are doing a
     // "standard" flat file export or a "packaged" export to usdz.
@@ -234,6 +230,7 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
         _fileName = fileNameWithExt;
         _packageName = std::string();
     }
+    progressBar.advance();
 
     TF_STATUS("Opening layer '%s' for writing", _fileName.c_str());
     if (mJobCtx.mArgs.renderLayerMode == UsdMayaJobExportArgsTokens->modelingVariant) {
@@ -253,6 +250,7 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
     if (!mJobCtx._OpenFile(_fileName, append)) {
         return false;
     }
+    progressBar.advance();
 
     // Set time range for the USD file if we're exporting animation.
     if (!mJobCtx.mArgs.timeSamples.empty()) {
@@ -288,6 +286,7 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
             false,
             false);
     }
+    progressBar.advance();
 
     // Pre-process the argument dagPath path names into two sets. One set
     // contains just the arg dagPaths, and the other contains all parents of
@@ -338,9 +337,21 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
             curDagPathIsValid = curDagPath.isValid(&status);
         }
     }
+    progressBar.advance();
+
+    // We are entering a loop here, so count the number of dag objects
+    // so we can have a better progress bar status.
+    // Note: Maya does the same thing during its write.
+    uint32_t numberDagObjects { 0 };
+    {
+        for (MItDag itDag(MItDag::kDepthFirst, MFn::kInvalid); !itDag.isDone(); itDag.next()) {
+            ++numberDagObjects;
+        }
+    }
 
     // Now do a depth-first traversal of the Maya DAG from the world root.
     // We keep a reference to arg dagPaths as we encounter them.
+    MayaUsd::ProgressBarLoopScope dagObjLoop(numberDagObjects);
     MDagPath curLeafDagPath;
     for (MItDag itDag(MItDag::kDepthFirst, MFn::kInvalid); !itDag.isDone(); itDag.next()) {
         MDagPath curDagPath;
@@ -392,6 +403,7 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
                 }
             }
         }
+        dagObjLoop.loopAdvance();
     }
 
     if (!mJobCtx.mArgs.rootMapFunction.IsNull()) {
@@ -407,6 +419,7 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
 
     // Writing Materials/Shading
     UsdMayaTranslatorMaterial::ExportShadingEngines(mJobCtx, mDagPathToUsdPathMap);
+    progressBar.advance();
 
     // Perform post-processing for instances, skel, etc.
     // We shouldn't be creating new instance masters after this point, and we
@@ -414,6 +427,7 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
     if (!mJobCtx._PostProcess()) {
         return false;
     }
+    progressBar.advance();
 
     if (!_modelKindProcessor->MakeModelHierarchy(mJobCtx.mStage)) {
         return false;
@@ -423,6 +437,7 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
     mChasers.clear();
     UsdMayaExportChaserRegistry::FactoryContext ctx(
         mJobCtx.mStage, mDagPathToUsdPathMap, mJobCtx.mArgs);
+    MayaUsd::ProgressBarLoopScope chaserNamesLoop(mJobCtx.mArgs.chaserNames.size());
     for (const std::string& chaserName : mJobCtx.mArgs.chaserNames) {
         if (UsdMayaExportChaserRefPtr fn
             = UsdMayaExportChaserRegistry::GetInstance().Create(chaserName, ctx)) {
@@ -430,12 +445,15 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
         } else {
             TF_RUNTIME_ERROR("Failed to create chaser: %s", chaserName.c_str());
         }
+        chaserNamesLoop.loopAdvance();
     }
 
+    MayaUsd::ProgressBarLoopScope chasersLoop(mChasers.size());
     for (const UsdMayaExportChaserRefPtr& chaser : mChasers) {
         if (!chaser->ExportDefault()) {
             return false;
         }
+        chasersLoop.loopAdvance();
     }
 
     return true;
@@ -465,6 +483,8 @@ bool UsdMaya_WriteJob::_WriteFrame(double iFrame)
 
 bool UsdMaya_WriteJob::_FinishWriting()
 {
+    MayaUsd::ProgressBarScope progressBar(6);
+
     UsdPrimSiblingRange usdRootPrims = mJobCtx.mStage->GetPseudoRoot().GetChildren();
 
     // Write Variants (to first root prim path)
@@ -488,6 +508,7 @@ bool UsdMaya_WriteJob::_FinishWriting()
         //     to take precedence.
         defaultPrim = _WriteVariants(usdRootPrim);
     }
+    progressBar.advance();
 
     // Restoring the currentRenderLayer
     MFnRenderLayer currentLayer(MFnRenderLayer::currentLayer());
@@ -497,6 +518,7 @@ bool UsdMaya_WriteJob::_FinishWriting()
             false,
             false);
     }
+    progressBar.advance();
 
     // Unfortunately, MGlobal::isZAxisUp() is merely session state that does
     // not get recorded in Maya files, so we cannot rely on it being set
@@ -529,20 +551,27 @@ bool UsdMaya_WriteJob::_FinishWriting()
         // prim for the export... usdVariantRootPrimPath
         mJobCtx.mStage->GetRootLayer()->SetDefaultPrim(defaultPrim);
     }
+    progressBar.advance();
 
     // Running post export function on all the prim writers.
+    const int loopSize = mJobCtx.mMayaPrimWriterList.size();
+    MayaUsd::ProgressBarLoopScope primWriterLoop(loopSize);
     for (auto& primWriter : mJobCtx.mMayaPrimWriterList) {
         primWriter->PostExport();
+        primWriterLoop.loopAdvance();
     }
 
     // Run post export function on the chasers.
+    MayaUsd::ProgressBarLoopScope chasersLoop(mChasers.size());
     for (const UsdMayaExportChaserRefPtr& chaser : mChasers) {
         if (!chaser->PostExport()) {
             return false;
         }
+        chasersLoop.loopAdvance();
     }
 
     _PostCallback();
+    progressBar.advance();
 
     TF_STATUS("Saving stage");
     if (mJobCtx.mStage->GetRootLayer()->PermissionToSave()) {
@@ -555,6 +584,7 @@ bool UsdMaya_WriteJob::_FinishWriting()
         TF_STATUS("Packaging USDZ file");
         _CreatePackage();
     }
+    progressBar.advance();
 
     mJobCtx.mStage = UsdStageRefPtr();
     mJobCtx.mMayaPrimWriterList.clear(); // clear this so that no stage references are left around
@@ -566,6 +596,7 @@ bool UsdMaya_WriteJob::_FinishWriting()
     if (!_packageName.empty()) {
         TfDeleteFile(_fileName);
     }
+    progressBar.advance();
 
     return true;
 }

--- a/lib/mayaUsd/fileio/jobs/writeJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/writeJob.cpp
@@ -120,7 +120,7 @@ bool UsdMaya_WriteJob::Write(const std::string& fileName, bool append)
     const bool showProgress = !timeSamples.empty();
 
     // Animated export shows frame-by-frame progress.
-    int nbSteps = 1 + timeSamples.size();
+    int                       nbSteps = 1 + timeSamples.size();
     MayaUsd::ProgressBarScope progressBar(showProgress, true /*interruptible */, nbSteps, "");
 
     // Default-time export.
@@ -352,7 +352,7 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
     // Now do a depth-first traversal of the Maya DAG from the world root.
     // We keep a reference to arg dagPaths as we encounter them.
     MayaUsd::ProgressBarLoopScope dagObjLoop(numberDagObjects);
-    MDagPath curLeafDagPath;
+    MDagPath                      curLeafDagPath;
     for (MItDag itDag(MItDag::kDepthFirst, MFn::kInvalid); !itDag.isDone(); itDag.next()) {
         MDagPath curDagPath;
         itDag.getPath(curDagPath);
@@ -554,7 +554,7 @@ bool UsdMaya_WriteJob::_FinishWriting()
     progressBar.advance();
 
     // Running post export function on all the prim writers.
-    const int loopSize = mJobCtx.mMayaPrimWriterList.size();
+    const int                     loopSize = mJobCtx.mMayaPrimWriterList.size();
     MayaUsd::ProgressBarLoopScope primWriterLoop(loopSize);
     for (auto& primWriter : mJobCtx.mMayaPrimWriterList) {
         primWriter->PostExport();

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -28,6 +28,7 @@
 #include <mayaUsd/undo/OpUndoItemMuting.h>
 #include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/undo/UsdUndoBlock.h>
+#include <mayaUsd/utils/progressBarScope.h>
 #include <mayaUsd/utils/traverseLayer.h>
 #include <mayaUsdUtils/util.h>
 
@@ -167,6 +168,8 @@ bool hasEditedDescendant(const Ufe::Path& ufeQueryPath)
 // Maya pulled object.
 bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& path)
 {
+    MayaUsd::ProgressBarScope progressBar(3);
+
     auto pulledPrim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
     if (!pulledPrim) {
         return false;
@@ -196,6 +199,7 @@ bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& path)
         TF_WARN("Cannot edited object to pulled set.");
         return false;
     }
+    progressBar.advance();
 
     // Store metadata on the prim in the Session Layer.
     auto stage = pulledPrim.GetStage();
@@ -205,6 +209,7 @@ bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& path)
     VtValue        value(path.fullPathName().asChar());
     if (!pulledPrim.SetMetadataByDictKey(SdfFieldKeys->CustomData, kPullPrimMetadataKey, value))
         return false;
+    progressBar.advance();
 
     // Store medata on DG node
     auto              ufePathString = Ufe::PathString::string(ufePulledPath);
@@ -225,6 +230,7 @@ bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& path)
         }
     }
     dgMetadata.setValue(ufePathString.c_str());
+    progressBar.advance();
 
     return true;
 }
@@ -233,16 +239,21 @@ bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& path)
 //
 void removePullInformation(const Ufe::Path& ufePulledPath)
 {
+    MayaUsd::ProgressBarScope progressBar(1);
     UsdPrim prim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
     auto    stage = prim.GetStage();
     if (!stage)
         return;
     UsdEditContext editContext(stage, stage->GetSessionLayer());
     prim.ClearCustomDataByKey(kPullPrimMetadataKey);
+    progressBar.advance();
 
     // Session layer cleanup
-    for (const SdfPrimSpecHandle& rootPrimSpec : stage->GetSessionLayer()->GetRootPrims()) {
+    auto rootPrims = stage->GetSessionLayer()->GetRootPrims();
+    MayaUsd::ProgressBarLoopScope rootPrimsLoop(rootPrims.size());
+    for (const SdfPrimSpecHandle& rootPrimSpec : rootPrims) {
         stage->GetSessionLayer()->RemovePrimIfInert(rootPrimSpec);
+        rootPrimsLoop.loopAdvance();
     }
 }
 
@@ -319,11 +330,14 @@ PullImportPaths pullImport(
     const UsdPrim&                   pulledPrim,
     const UsdMayaPrimUpdaterContext& context)
 {
+    MayaUsd::ProgressBarScope progressBar(9);
+
     std::string mFileName = context.GetUsdStage()->GetRootLayer()->GetIdentifier();
     if (mFileName.empty()) {
         TF_WARN("Nothing to edit: invalid layer.");
         return PullImportPaths();
     }
+    progressBar.advance();
 
     VtDictionary userArgs(context.GetUserArgs());
     userArgs[UsdMayaJobImportArgsTokens->pullImportStage] = PXR_NS::VtValue(context.GetUsdStage());
@@ -337,6 +351,7 @@ PullImportPaths pullImport(
     importData.setRootPrimPath(pulledPrim.GetPath().GetText());
 
     auto readJob = std::make_shared<UsdMaya_ReadJob>(importData, jobArgs);
+    progressBar.advance();
 
     MDagPath pullParentPath;
     {
@@ -349,6 +364,7 @@ PullImportPaths pullImport(
             }
         }
     }
+    progressBar.advance();
 
     std::vector<MDagPath>  addedDagPaths;
     std::vector<Ufe::Path> pulledUfePaths;
@@ -359,6 +375,7 @@ PullImportPaths pullImport(
         TF_WARN("Nothing to edit in the selection.");
         return PullImportPaths({}, {});
     }
+    progressBar.advance();
 
     // Note: UsdMaya_ReadJob has explicit Read(), Undo() and Redo() functions,
     //       and Read() has already been called, so create the function-undo item
@@ -369,9 +386,12 @@ PullImportPaths pullImport(
         [readJob]() { return readJob->Undo(); });
 
     MDagPath addedDagPath = addedDagPaths[0];
+    progressBar.advance();
 
     const bool isCopy = context.GetArgs()._copyOperation;
     if (!isCopy) {
+        progressBar.addSteps(4);
+
         // Quick workaround to reuse some POC code - to rewrite later
 
         // Communication to current proxyAccessor code is through the global
@@ -420,6 +440,7 @@ PullImportPaths pullImport(
             TF_WARN("Cannot parent pulled object.");
             return PullImportPaths();
         }
+        progressBar.advance();
 
         // Create the pull set if it does not exists.
         //
@@ -435,6 +456,7 @@ PullImportPaths pullImport(
             dgMod.commandToExecute(createSetCmd);
             dgMod.doIt();
         }
+        progressBar.advance();
 
         // Finalize the pull.
         if (!FunctionUndoItem::execute(
@@ -449,6 +471,7 @@ PullImportPaths pullImport(
             TF_WARN("Cannot write pull information metadata.");
             return PullImportPaths();
         }
+        progressBar.advance();
 
         if (!FunctionUndoItem::execute(
                 "Pull import rendering exclusion",
@@ -460,12 +483,14 @@ PullImportPaths pullImport(
             TF_WARN("Cannot exclude original USD data from viewport rendering.");
             return PullImportPaths();
         }
+        progressBar.advance();
 
         if (!UfeSelectionUndoItem::select("Pull import select DAG node", addedDagPath)) {
             TF_WARN("Cannot select the pulled nodes.");
             return PullImportPaths();
         }
     }
+    progressBar.advance();
 
     // Invert the new node registry, for MObject to Ufe::Path lookup.
     using ObjToUfePath = std::unordered_map<MObjectHandle, Ufe::Path>;
@@ -477,6 +502,7 @@ PullImportPaths pullImport(
         Ufe::Path           p(std::move(s));
         objToUfePath.insert(ObjToUfePath::value_type(MObjectHandle(v.second), p));
     }
+    progressBar.advance();
 
     // For each added Dag path, get the UFE path of the pulled USD prim.
     pulledUfePaths.reserve(addedDagPaths.size());
@@ -485,8 +511,11 @@ PullImportPaths pullImport(
         TF_AXIOM(found != objToUfePath.end());
         pulledUfePaths.emplace_back(found->second);
     }
+    progressBar.advance();
 
-    return PullImportPaths(addedDagPaths, pulledUfePaths);
+    auto ret = PullImportPaths(addedDagPaths, pulledUfePaths);
+    progressBar.advance();
+    return ret;
 }
 
 //------------------------------------------------------------------------------
@@ -511,6 +540,10 @@ UsdMayaPrimUpdaterRegistry::RegisterItem getUpdaterItem(const MFnDependencyNode&
 // Perform the customization step of the pull (second step).
 bool pullCustomize(const PullImportPaths& importedPaths, const UsdMayaPrimUpdaterContext& context)
 {
+    // The number of imported paths should (hopefully) never be so great
+    // as to overwhelm the computation with progress bar updates.
+    MayaUsd::ProgressBarScope progressBar(importedPaths.first.size());
+
     // Record all USD modifications in an undo block and item.
     UsdUndoBlock undoBlock(
         &UsdUndoableItemUndoItem::create("Pull customize USD data modifications"));
@@ -534,6 +567,7 @@ bool pullCustomize(const PullImportPaths& importedPaths, const UsdMayaPrimUpdate
         if (!updater->editAsMaya()) {
             return false;
         }
+        progressBar.advance();
     }
     return true;
 }
@@ -553,6 +587,8 @@ PushCustomizeSrc pushExport(
     const MObject&                   mayaObject,
     const UsdMayaPrimUpdaterContext& context)
 {
+    MayaUsd::ProgressBarScope progressBar(3);
+
     UsdStageRefPtr         srcStage = UsdStage::CreateInMemory();
     SdfLayerRefPtr         srcLayer = srcStage->GetRootLayer();
     UsdPathToDagPathMapPtr pathMapPtr;
@@ -580,11 +616,13 @@ PushCustomizeSrc pushExport(
 
     UsdMayaJobExportArgs jobArgs
         = UsdMayaJobExportArgs::CreateFromDictionary(userArgs, dagPaths, timeSamples);
+    progressBar.advance();
 
     UsdMaya_WriteJob writeJob(jobArgs);
     if (!writeJob.Write(fileName, false /* append */)) {
         return pushCustomizeSrc;
     }
+    progressBar.advance();
 
     std::get<SdfPath>(pushCustomizeSrc) = writeJob.MapDagPathToSdfPath(dagPath);
 
@@ -595,6 +633,7 @@ PushCustomizeSrc pushExport(
     }
 
     std::get<UsdPathToDagPathMapPtr>(pushCustomizeSrc) = usdPathToDagPathMap;
+    progressBar.advance();
 
     return pushCustomizeSrc;
 }
@@ -689,6 +728,8 @@ bool pushCustomize(
         return false;
     }
 
+    MayaUsd::ProgressBarScope progressBar(2);
+
     const bool  isCopy = context.GetArgs()._copyOperation;
     const auto& editTarget = context.GetUsdStage()->GetEditTarget();
     auto dstRootPath = editTarget.MapToSpecPath(getDstSdfPath(ufePulledPath, srcRootPath, isCopy));
@@ -732,6 +773,7 @@ bool pushCustomize(
     if (!MayaUsd::traverseLayer(srcLayer, srcRootPath, pushCopySpecsFn)) {
         return false;
     }
+    progressBar.advance();
 
     // Push end is a separate traversal, not a second phase of the same
     // traversal, because it is post-order: parents are traversed after
@@ -778,6 +820,7 @@ bool pushCustomize(
             e.reason().c_str());
         return false;
     }
+    progressBar.advance();
 
     return true;
 }
@@ -835,6 +878,11 @@ bool PrimUpdaterManager::mergeToUsd(
         return false;
     }
 
+    // Are we doing a merge or cache?
+    MString progStr(
+        VtDictionaryIsHolding<std::string>(userArgs, "rn_primName") ? "Caching to USD"
+                                                                    : "Merging to USD");
+    MayaUsd::ProgressBarScope progressBar(9, progStr);
     PushPullScope scopeIt(_inPushPull);
 
     auto ctxArgs = VtDictionaryOver(userArgs, UsdMayaJobExportArgs::GetDefaultDictionary());
@@ -854,6 +902,7 @@ bool PrimUpdaterManager::mergeToUsd(
             return false;
         }
     }
+    progressBar.advance();
 
     // If the user-provided argument does *not* contain an animation key, then
     // automatically infer if we should merge animations.
@@ -868,6 +917,7 @@ bool PrimUpdaterManager::mergeToUsd(
         ctxArgs[UsdMayaJobExportArgsTokens->startTime] = timeInterval.GetMin();
         ctxArgs[UsdMayaJobExportArgsTokens->endTime] = timeInterval.GetMax();
     }
+    progressBar.advance();
 
     // Reset the selection, otherwise it will keep a reference to a deleted node
     // and crash later on.
@@ -883,6 +933,7 @@ bool PrimUpdaterManager::mergeToUsd(
     auto& scene = Ufe::Scene::instance();
     if (!isCopy && TF_VERIFY(ufeMayaItem))
         scene.notify(Ufe::ObjectPreDelete(ufeMayaItem));
+    progressBar.advance();
 
     // Record all USD modifications in an undo block and item.
     UsdUndoBlock undoBlock(
@@ -895,6 +946,7 @@ bool PrimUpdaterManager::mergeToUsd(
 
     // 1) Perform the export to the temporary layer.
     auto pushCustomizeSrc = pushExport(pulledPath, depNodeFn.object(), context);
+    progressBar.advance();
 
     // 2) Traverse the in-memory layer, creating a prim updater for each prim,
     // and call Push for each updater.  Build a new context with the USD path
@@ -917,10 +969,12 @@ bool PrimUpdaterManager::mergeToUsd(
             return false;
         }
     }
+    progressBar.advance();
 
     if (!pushCustomize(pulledPath, pushCustomizeSrc, customizeContext)) {
         return false;
     }
+    progressBar.advance();
 
     if (!isCopy) {
         if (!FunctionUndoItem::execute(
@@ -936,9 +990,11 @@ bool PrimUpdaterManager::mergeToUsd(
             return false;
         }
     }
+    progressBar.advance();
 
     // Discard all pulled Maya nodes.
     std::vector<MDagPath> toApplyOn = UsdMayaUtil::getDescendantsStartingWithChildren(mayaDagPath);
+    MayaUsd::ProgressBarLoopScope toApplyOnLoop(toApplyOn.size());
     for (const MDagPath& curDagPath : toApplyOn) {
         MStatus status = NodeDeletionUndoItem::deleteNode(
             "Merge to USD Maya scene cleanup", curDagPath.fullPathName(), curDagPath.node());
@@ -948,6 +1004,7 @@ bool PrimUpdaterManager::mergeToUsd(
                 curDagPath.fullPathName().asChar());
             return false;
         }
+        toApplyOnLoop.loopAdvance();
     }
 
     if (!isCopy) {
@@ -955,6 +1012,7 @@ bool PrimUpdaterManager::mergeToUsd(
             return false;
         }
     }
+    progressBar.advance();
 
     discardPullSetIfEmpty();
 
@@ -965,6 +1023,7 @@ bool PrimUpdaterManager::mergeToUsd(
     if (TF_VERIFY(hier)) {
         scene.notify(Ufe::SubtreeInvalidate(hier->defaultParent()));
     }
+    progressBar.advance();
 
     return true;
 }
@@ -986,6 +1045,8 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
         return false;
     }
 
+    MayaUsd::ProgressBarScope progressBar(6, "Converting to Maya Data");
+
     PushPullScope scopeIt(_inPushPull);
 
     auto ctxArgs = VtDictionaryOver(userArgs, UsdMayaJobImportArgs::GetDefaultDictionary());
@@ -997,6 +1058,7 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
         TF_WARN("Cannot setup the edit parent node.");
         return false;
     }
+    progressBar.advance();
 
     UsdMayaPrimUpdaterContext context(proxyShape->getTime(), pulledPrim.GetStage(), ctxArgs);
 
@@ -1004,6 +1066,8 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
     auto  ufeItem = Ufe::Hierarchy::createItem(path);
     if (!updaterArgs._copyOperation && TF_VERIFY(ufeItem))
         scene.notify(Ufe::ObjectPreDelete(ufeItem));
+
+    progressBar.advance();
 
     // The pull is done in two stages:
     // 1) Perform the import into Maya.
@@ -1015,12 +1079,14 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
     if (importedPaths.first.empty()) {
         return false;
     }
+    progressBar.advance();
 
     // 2) Iterate over all imported Dag paths.
     if (!pullCustomize(importedPaths, context)) {
         TF_WARN("Failed to customize the edited nodes.");
         return false;
     }
+    progressBar.advance();
 
     if (!updaterArgs._copyOperation) {
         // Lock pulled nodes starting at the pull parent.
@@ -1031,11 +1097,13 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
         if (!allowTopologyModifications(pullParentPath))
             return false;
     }
+    progressBar.advance();
 
     // We must recreate the UFE item because it has changed data models (USD -> Maya).
     ufeItem = Ufe::Hierarchy::createItem(usdToMaya(path));
     if (TF_VERIFY(ufeItem))
         scene.notify(Ufe::ObjectAdd(ufeItem));
+    progressBar.advance();
 
     return true;
 }
@@ -1070,8 +1138,12 @@ bool PrimUpdaterManager::discardEdits(const MDagPath& dagPath)
     if (!PXR_NS::PrimUpdaterManager::readPullInformation(dagPath, primPath))
         return false;
 
+    MayaUsd::ProgressBarScope progressBar(1, "Discarding Converted Maya Data");
+
     auto usdPrim = MayaUsd::ufe::ufePathToPrim(primPath);
-    return usdPrim ? discardPrimEdits(primPath) : discardOrphanedEdits(dagPath);
+    auto ret = usdPrim ? discardPrimEdits(primPath) : discardOrphanedEdits(dagPath);
+    progressBar.advance();
+    return ret;
 }
 
 bool PrimUpdaterManager::discardPrimEdits(const Ufe::Path& pulledPath)
@@ -1081,6 +1153,7 @@ bool PrimUpdaterManager::discardPrimEdits(const Ufe::Path& pulledPath)
         return false;
     }
 
+    MayaUsd::ProgressBarScope progressBar(5);
     PushPullScope scopeIt(_inPushPull);
 
     // Record all USD modifications in an undo block and item.
@@ -1097,6 +1170,7 @@ bool PrimUpdaterManager::discardPrimEdits(const Ufe::Path& pulledPath)
     auto& scene = Ufe::Scene::instance();
     if (TF_VERIFY(ufeMayaItem))
         scene.notify(Ufe::ObjectPreDelete(ufeMayaItem));
+    progressBar.advance();
 
     // Unlock the pulled hierarchy, clear the pull information, and remove the
     // pull parent, which is simply the parent of the pulled path.
@@ -1108,6 +1182,7 @@ bool PrimUpdaterManager::discardPrimEdits(const Ufe::Path& pulledPath)
     if (!LockNodesUndoItem::lock("Discard edits node unlocking", pullParent, false)) {
         return false;
     }
+    progressBar.advance();
 
     // Reset the selection, otherwise it will keep a reference to a deleted node
     // and crash later on.
@@ -1115,9 +1190,11 @@ bool PrimUpdaterManager::discardPrimEdits(const Ufe::Path& pulledPath)
         TF_WARN("Cannot reset the selection.");
         return false;
     }
+    progressBar.advance();
 
     // Discard all pulled Maya nodes.
     std::vector<MDagPath> toApplyOn = UsdMayaUtil::getDescendantsStartingWithChildren(mayaDagPath);
+    MayaUsd::ProgressBarLoopScope toApplyOnLoop(toApplyOn.size());
     for (const MDagPath& curDagPath : toApplyOn) {
         MFnDependencyNode dgNodeFn(curDagPath.node());
 
@@ -1128,6 +1205,7 @@ bool PrimUpdaterManager::discardPrimEdits(const Ufe::Path& pulledPath)
         auto updater = factory(context, dgNodeFn, path);
 
         updater->discardEdits();
+        toApplyOnLoop.loopAdvance();
     }
 
     if (!FunctionUndoItem::execute(
@@ -1157,6 +1235,7 @@ bool PrimUpdaterManager::discardPrimEdits(const Ufe::Path& pulledPath)
     if (!TF_VERIFY(removePullParent(pullParent))) {
         return false;
     }
+    progressBar.advance();
 
     discardPullSetIfEmpty();
 
@@ -1165,11 +1244,13 @@ bool PrimUpdaterManager::discardPrimEdits(const Ufe::Path& pulledPath)
     if (TF_VERIFY(hier)) {
         scene.notify(Ufe::SubtreeInvalidate(hier->defaultParent()));
     }
+    progressBar.advance();
     return true;
 }
 
 bool PrimUpdaterManager::discardOrphanedEdits(const MDagPath& dagPath)
 {
+    MayaUsd::ProgressBarScope progressBar(2);
     PushPullScope scopeIt(_inPushPull);
 
     // Unlock the pulled hierarchy, clear the pull information, and remove the
@@ -1189,9 +1270,11 @@ bool PrimUpdaterManager::discardOrphanedEdits(const MDagPath& dagPath)
     }
 
     UsdMayaPrimUpdaterContext context(UsdTimeCode(), nullptr, VtDictionary());
+    progressBar.advance();
 
     // Discard all pulled Maya nodes.
     std::vector<MDagPath> toApplyOn = UsdMayaUtil::getDescendantsStartingWithChildren(dagPath);
+    MayaUsd::ProgressBarLoopScope toApplyOnLoop(toApplyOn.size());
     for (const MDagPath& curDagPath : toApplyOn) {
         MFnDependencyNode dgNodeFn(curDagPath.node());
 
@@ -1200,11 +1283,13 @@ bool PrimUpdaterManager::discardOrphanedEdits(const MDagPath& dagPath)
         auto updater = factory(context, dgNodeFn, Ufe::Path());
 
         updater->discardEdits();
+        toApplyOnLoop.loopAdvance();
     }
 
     if (!TF_VERIFY(removePullParent(pullParent))) {
         return false;
     }
+    progressBar.advance();
 
     return true;
 }
@@ -1251,6 +1336,8 @@ bool PrimUpdaterManager::duplicate(
             return false;
         }
 
+        MayaUsd::ProgressBarScope progressBar(2, "Duplicating to Maya Data");
+
         auto ctxArgs = VtDictionaryOver(userArgs, UsdMayaJobImportArgs::GetDefaultDictionary());
 
         // We will only do copy between two data models, setting this in arguments
@@ -1270,8 +1357,10 @@ bool PrimUpdaterManager::duplicate(
 
         UsdMayaPrimUpdaterContext context(
             srcProxyShape->getTime(), srcProxyShape->getUsdStage(), ctxArgs);
+        progressBar.advance();
 
         pullImport(srcPath, srcPrim, context);
+        progressBar.advance();
         return true;
     }
     // Copy from DG to USD
@@ -1282,11 +1371,14 @@ bool PrimUpdaterManager::duplicate(
             return false;
         }
 
+        MayaUsd::ProgressBarScope progressBar(6, "Duplicating to USD");
+
         auto ctxArgs = VtDictionaryOver(userArgs, UsdMayaJobExportArgs::GetDefaultDictionary());
 
         // Record all USD modifications in an undo block and item.
         MAYAUSD_NS::UsdUndoBlock undoBlock(
             &UsdUndoableItemUndoItem::create("Duplicate USD data modifications"));
+        progressBar.advance();
 
         // We will only do copy between two data models, setting this in arguments
         // to configure the updater
@@ -1300,6 +1392,7 @@ bool PrimUpdaterManager::duplicate(
         if (srcRootPath.IsEmpty()) {
             return false;
         }
+        progressBar.advance();
 
         // Copy the temporary layer contents out to the proper destination.
         const auto& srcLayer = std::get<SdfLayerRefPtr>(pushExportOutput);
@@ -1311,20 +1404,24 @@ bool PrimUpdaterManager::duplicate(
         if (!dstParentPrim.IsValid()) {
             return false;
         }
+        progressBar.advance();
 
         // Make the destination root path unique.
         SdfPath     dstParentPath = dstParentPrim.GetPath();
         std::string dstChildName = ufe::uniqueChildName(dstParentPrim, srcRootPath.GetName());
         SdfPath     dstRootPath = dstParentPath.AppendChild(TfToken(dstChildName));
+        progressBar.advance();
 
         if (!SdfCopySpec(srcLayer, srcRootPath, dstLayer, dstRootPath)) {
             return false;
         }
+        progressBar.advance();
 
         auto ufeItem = Ufe::Hierarchy::createItem(dstPath);
         if (TF_VERIFY(ufeItem)) {
             Ufe::Scene::instance().notify(Ufe::SubtreeInvalidate(ufeItem));
         }
+        progressBar.advance();
         return true;
     }
 
@@ -1413,10 +1510,13 @@ PrimUpdaterManager& PrimUpdaterManager::getInstance()
 
 MObject PrimUpdaterManager::findOrCreatePullRoot()
 {
+    MayaUsd::ProgressBarScope progressBar(5);
+
     MObject pullRoot = findPullRoot();
     if (!pullRoot.isNull()) {
         return pullRoot;
     }
+    progressBar.advance();
 
     // No pull root in the scene, so create one.
     MDagModifier& dagMod = MDagModifierUndoItem::create("Create pull root");
@@ -1425,14 +1525,17 @@ MObject PrimUpdaterManager::findOrCreatePullRoot()
     if (status != MStatus::kSuccess) {
         return MObject();
     }
+    progressBar.advance();
     status = dagMod.renameNode(pullRootObj, kPullRootName);
     if (status != MStatus::kSuccess) {
         return MObject();
     }
+    progressBar.advance();
 
     if (dagMod.doIt() != MStatus::kSuccess) {
         return MObject();
     }
+    progressBar.advance();
 
     // Hide all objects under the pull root in the Outliner so only the pulled
     // objects under a proxy shape will be shown.
@@ -1455,12 +1558,15 @@ MObject PrimUpdaterManager::findOrCreatePullRoot()
         TF_WARN("Cannot create pulled prim cache.");
         return MObject();
     }
+    progressBar.advance();
 
     return pullRootObj;
 }
 
 MObject PrimUpdaterManager::createPullParent(const Ufe::Path& pulledPath, MObject pullRoot)
 {
+    MayaUsd::ProgressBarScope progressBar(2);
+
     MDagModifier& dagMod = MDagModifierUndoItem::create("Create pull parent node");
     MStatus       status;
     MObject       pullParentObj = dagMod.createNode(MString("transform"), pullRoot, &status);
@@ -1471,8 +1577,11 @@ MObject PrimUpdaterManager::createPullParent(const Ufe::Path& pulledPath, MObjec
     // Rename the pull parent to be the name of the node plus a "Parent" suffix.
     status = dagMod.renameNode(
         pullParentObj, MString(pulledPath.back().string().c_str()) + MString("Parent"));
+    progressBar.advance();
 
-    return (dagMod.doIt() == MStatus::kSuccess) ? pullParentObj : MObject::kNullObj;
+    auto ret = dagMod.doIt();
+    progressBar.advance();
+    return (ret == MStatus::kSuccess) ? pullParentObj : MObject::kNullObj;
 }
 
 bool PrimUpdaterManager::removePullParent(const MDagPath& parentDagPath)
@@ -1481,10 +1590,12 @@ bool PrimUpdaterManager::removePullParent(const MDagPath& parentDagPath)
         return false;
     }
 
+    MayaUsd::ProgressBarScope progressBar(2);
     MStatus status = NodeDeletionUndoItem::deleteNode(
         "Delete pull parent node", parentDagPath.fullPathName(), parentDagPath.node());
     if (status != MStatus::kSuccess)
         return false;
+    progressBar.advance();
 
     // If the pull parent was the last child of the pull root, remove the pull
     // root as well, and null out our pull root cache.
@@ -1513,12 +1624,15 @@ bool PrimUpdaterManager::removePullParent(const MDagPath& parentDagPath)
             }
         }
     }
+    progressBar.advance();
 
     return true;
 }
 
 MDagPath PrimUpdaterManager::setupPullParent(const Ufe::Path& pulledPath, VtDictionary& args)
 {
+    MayaUsd::ProgressBarScope progressBar(3);
+
     // Record all USD modifications in an undo block and item.
     UsdUndoBlock undoBlock(
         &UsdUndoableItemUndoItem::create("Setup pull parent USD data modification"));
@@ -1527,17 +1641,20 @@ MDagPath PrimUpdaterManager::setupPullParent(const Ufe::Path& pulledPath, VtDict
     if (pullRoot.isNull()) {
         return MDagPath();
     }
+    progressBar.advance();
 
     auto pullParent = createPullParent(pulledPath, pullRoot);
     if (pullParent == MObject::kNullObj) {
         return MDagPath();
     }
+    progressBar.advance();
 
     // Pull parent is not instanced, so use first path found.
     MDagPath pullParentPath;
     if (MDagPath::getAPathTo(pullParent, pullParentPath) != MStatus::kSuccess) {
         return MDagPath();
     }
+    progressBar.advance();
 
     // Add pull parent path to import args as a string.
     args[kPullParentPathKey] = VtValue(std::string(pullParentPath.fullPathName().asChar()));

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -240,8 +240,8 @@ bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& path)
 void removePullInformation(const Ufe::Path& ufePulledPath)
 {
     MayaUsd::ProgressBarScope progressBar(1);
-    UsdPrim prim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
-    auto    stage = prim.GetStage();
+    UsdPrim                   prim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
+    auto                      stage = prim.GetStage();
     if (!stage)
         return;
     UsdEditContext editContext(stage, stage->GetSessionLayer());
@@ -249,7 +249,7 @@ void removePullInformation(const Ufe::Path& ufePulledPath)
     progressBar.advance();
 
     // Session layer cleanup
-    auto rootPrims = stage->GetSessionLayer()->GetRootPrims();
+    auto                          rootPrims = stage->GetSessionLayer()->GetRootPrims();
     MayaUsd::ProgressBarLoopScope rootPrimsLoop(rootPrims.size());
     for (const SdfPrimSpecHandle& rootPrimSpec : rootPrims) {
         stage->GetSessionLayer()->RemovePrimIfInert(rootPrimSpec);
@@ -883,7 +883,7 @@ bool PrimUpdaterManager::mergeToUsd(
         VtDictionaryIsHolding<std::string>(userArgs, "rn_primName") ? "Caching to USD"
                                                                     : "Merging to USD");
     MayaUsd::ProgressBarScope progressBar(9, progStr);
-    PushPullScope scopeIt(_inPushPull);
+    PushPullScope             scopeIt(_inPushPull);
 
     auto ctxArgs = VtDictionaryOver(userArgs, UsdMayaJobExportArgs::GetDefaultDictionary());
 
@@ -1154,7 +1154,7 @@ bool PrimUpdaterManager::discardPrimEdits(const Ufe::Path& pulledPath)
     }
 
     MayaUsd::ProgressBarScope progressBar(5);
-    PushPullScope scopeIt(_inPushPull);
+    PushPullScope             scopeIt(_inPushPull);
 
     // Record all USD modifications in an undo block and item.
     UsdUndoBlock undoBlock(
@@ -1251,7 +1251,7 @@ bool PrimUpdaterManager::discardPrimEdits(const Ufe::Path& pulledPath)
 bool PrimUpdaterManager::discardOrphanedEdits(const MDagPath& dagPath)
 {
     MayaUsd::ProgressBarScope progressBar(2);
-    PushPullScope scopeIt(_inPushPull);
+    PushPullScope             scopeIt(_inPushPull);
 
     // Unlock the pulled hierarchy, clear the pull information, and remove the
     // pull parent, which is simply the parent of the pulled path.
@@ -1591,7 +1591,7 @@ bool PrimUpdaterManager::removePullParent(const MDagPath& parentDagPath)
     }
 
     MayaUsd::ProgressBarScope progressBar(2);
-    MStatus status = NodeDeletionUndoItem::deleteNode(
+    MStatus                   status = NodeDeletionUndoItem::deleteNode(
         "Delete pull parent node", parentDagPath.fullPathName(), parentDagPath.node());
     if (status != MStatus::kSuccess)
         return false;

--- a/lib/mayaUsd/fileio/shading/shadingModeExporter.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporter.cpp
@@ -19,6 +19,7 @@
 #include <mayaUsd/fileio/shading/shadingModeExporterContext.h>
 #include <mayaUsd/fileio/translators/translatorUtil.h>
 #include <mayaUsd/fileio/writeJobContext.h>
+#include <mayaUsd/utils/progressBarScope.h>
 #include <mayaUsd/utils/util.h>
 
 #include <pxr/base/tf/diagnostic.h>
@@ -81,6 +82,8 @@ void UsdMayaShadingModeExporter::DoExport(
     UsdMayaWriteJobContext&                  writeJobContext,
     const UsdMayaUtil::MDagPathMap<SdfPath>& dagPathToUsdMap)
 {
+    MayaUsd::ProgressBarScope progressBar(4);
+
     const UsdMayaJobExportArgs& exportArgs = writeJobContext.GetArgs();
     const UsdStageRefPtr&       stage = writeJobContext.GetUsdStage();
 
@@ -99,19 +102,27 @@ void UsdMayaShadingModeExporter::DoExport(
                 materialCollectionsPath.GetText());
         }
     }
+    progressBar.advance();
 
     UsdMayaShadingModeExportContext context(MObject(), writeJobContext, dagPathToUsdMap);
 
     PreExport(&context);
+    progressBar.advance();
 
     using MaterialAssignments = std::vector<std::pair<TfToken, SdfPathSet>>;
     MaterialAssignments matAssignments;
 
     std::vector<UsdShadeMaterial> exportedMaterials;
 
+    std::vector<MObject> shadingEngines;
     MItDependencyNodes shadingEngineIter(MFn::kShadingEngine);
     for (; !shadingEngineIter.isDone(); shadingEngineIter.next()) {
         MObject shadingEngine(shadingEngineIter.thisNode());
+        shadingEngines.emplace_back(shadingEngine);
+    }
+    MayaUsd::ProgressBarLoopScope shadingEngineLoop(shadingEngines.size());
+    for (const auto& shadingEngine : shadingEngines)
+    {
         context.SetShadingEngine(shadingEngine);
 
         UsdShadeMaterial mat;
@@ -122,10 +133,12 @@ void UsdMayaShadingModeExporter::DoExport(
             exportedMaterials.push_back(mat);
             matAssignments.push_back(std::make_pair(_GetCollectionName(mat), boundPrimPaths));
         }
+        shadingEngineLoop.loopAdvance();
     }
 
     context.SetShadingEngine(MObject());
     PostExport(context);
+    progressBar.advance();
 
     if ((materialCollectionsPrim || exportArgs.exportCollectionBasedBindings)
         && !matAssignments.empty()) {
@@ -190,6 +203,7 @@ void UsdMayaShadingModeExporter::DoExport(
             }
         }
     }
+    progressBar.advance();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/shading/shadingModeExporter.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporter.cpp
@@ -115,14 +115,13 @@ void UsdMayaShadingModeExporter::DoExport(
     std::vector<UsdShadeMaterial> exportedMaterials;
 
     std::vector<MObject> shadingEngines;
-    MItDependencyNodes shadingEngineIter(MFn::kShadingEngine);
+    MItDependencyNodes   shadingEngineIter(MFn::kShadingEngine);
     for (; !shadingEngineIter.isDone(); shadingEngineIter.next()) {
         MObject shadingEngine(shadingEngineIter.thisNode());
         shadingEngines.emplace_back(shadingEngine);
     }
     MayaUsd::ProgressBarLoopScope shadingEngineLoop(shadingEngines.size());
-    for (const auto& shadingEngine : shadingEngines)
-    {
+    for (const auto& shadingEngine : shadingEngines) {
         context.SetShadingEngine(shadingEngine);
 
         UsdShadeMaterial mat;

--- a/lib/mayaUsd/utils/CMakeLists.txt
+++ b/lib/mayaUsd/utils/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(${PROJECT_NAME}
         loadRulesAttribute.cpp
         query.cpp
         plugRegistryHelper.cpp
+        progressBarScope.cpp
         selectability.cpp
         stageCache.cpp
         traverseLayer.cpp
@@ -37,6 +38,7 @@ set(HEADERS
     loadRules.h
     query.h
     plugRegistryHelper.h
+    progressBarScope.h
     selectability.h
     stageCache.h
     traverseLayer.h

--- a/lib/mayaUsd/utils/progressBarScope.cpp
+++ b/lib/mayaUsd/utils/progressBarScope.cpp
@@ -1,0 +1,163 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "progressBarScope.h"
+
+#include <pxr/base/tf/diagnostic.h>
+#include <pxr/base/tf/getenv.h>
+
+// For TF_WARN macro
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace MAYAUSD_NS_DEF {
+
+std::unique_ptr<MComputation> ProgressBarScope::progBar;
+int                           ProgressBarScope::totalStepsAdded = 0;
+
+// Create a scope with default values for showProgress and interruptible.
+ProgressBarScope::ProgressBarScope(
+    const int      nbSteps,
+    const MString& progressStr)
+    : ProgressBarScope(true, false, nbSteps, progressStr)
+{
+}
+
+ProgressBarScope::ProgressBarScope(
+    bool           showProgress,
+    bool           interruptible,
+    const int      nbSteps,
+    const MString& progressStr)
+{
+    // Allow user (or QA) to disable the display of the progress bar.
+    // Default display value is ON.
+    bool createProgressBar = TfGetenvBool("MAYAUSD_ENABLE_PROGRESSBAR", true);
+
+    // If this is the first scope being created for an operation we need
+    // to create the MComputation which we use for the progress bar.
+    if (createProgressBar && (progBar.get() == nullptr)) {
+        progBar = std::make_unique<MComputation>();
+        _created = true;
+        progBar->beginComputation(showProgress, interruptible);
+        setProgressString(progressStr);
+
+        // In the usage from most cases, we do NOT know how many steps
+        // there will be for any given task. So we start with a normal range
+        // and can add extra steps along the way.
+        progBar->setProgressRange(0, 100);
+        totalStepsAdded = 0;
+    }
+    addSteps(nbSteps);
+}
+
+ProgressBarScope::ProgressBarScope(const int nbSteps)
+{
+    // Uses a previously created MComputation to add steps to.
+    // If the MComputation (our progBar) is nullptr, then the steps added
+    // don't do anything.
+    addSteps(nbSteps);
+}
+
+ProgressBarScope::~ProgressBarScope()
+{
+    // Make sure to advance by all the steps for this scope.
+    advance(_nbSteps);
+
+    // If we created the MComputation we end and delete it.
+    if (_created) {
+        // Verify that we advances the number of steps added.
+        if (progBar->progress() != totalStepsAdded) {
+            TF_WARN("ProgressBarScope: did not advance progress bar correct number of steps.");
+        }
+        totalStepsAdded = 0;
+
+        progBar->setProgress(progBar->progressMax());
+        progBar->endComputation();
+        progBar.release();
+    }
+}
+
+void ProgressBarScope::addSteps(int nbSteps)
+{
+    if ((nbSteps > 0) && (progBar != nullptr)) {
+        // If the current computation doesn't have at least nbSteps left
+        // adjust the range by adding in the new number of steps.
+        const auto progMax = progBar->progressMax();
+        if ((totalStepsAdded + nbSteps) > progMax) {
+            progBar->setProgressRange(progBar->progressMin(), totalStepsAdded + nbSteps);
+        }
+        totalStepsAdded += nbSteps;
+        _nbSteps += nbSteps;
+    }
+}
+
+void ProgressBarScope::setProgressString(const MString& progressStr)
+{
+    if (progBar != nullptr) {
+        progBar->setProgressStatus(progressStr);
+    }
+}
+
+void ProgressBarScope::advance(const int steps /*= 1*/)
+{
+    if ((steps != 0) && (progBar != nullptr)) {
+        progBar->setProgress(progBar->progress() + steps);
+        _nbSteps -= steps;
+    }
+}
+
+bool ProgressBarScope::isInterruptRequested() const
+{
+    if (progBar != nullptr) {
+        return progBar->isInterruptRequested();
+    }
+    return false;
+}
+
+ProgressBarLoopScope::ProgressBarLoopScope(int nbLoopSteps)
+    : ProgressBarScope(0) // Start with adding 0 steps
+{
+    // We add the real number of steps for the loop here.
+    addLoopSteps(nbLoopSteps);
+}
+
+void ProgressBarLoopScope::addLoopSteps(int loopSize)
+{
+    if (loopSize <= maxStepsForLoops) {
+        // Number of loop steps to add is less than the max we want
+        // to allow we add them and set our loop counter value to 1 (so each
+        // iteration thru the loop advances progress bar).
+        addSteps(loopSize);
+        _minProgressStep = 1;
+    } else {
+        // Number of loop steps requested is larger than the max we allow
+        // so only add the max and then save a loop counter value to know
+        // how many loop iterations to perform before advancing progress.
+        addSteps(maxStepsForLoops);
+        _minProgressStep = (loopSize / maxStepsForLoops);
+    }
+}
+
+void ProgressBarLoopScope::loopAdvance()
+{
+    // If we have run thru the loop the required number of steps we
+    // will advance the progress bar.
+    if (++_currLoopCounter == _minProgressStep) {
+        advance(1);
+        _currLoopCounter = 0;
+    }
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/progressBarScope.cpp
+++ b/lib/mayaUsd/utils/progressBarScope.cpp
@@ -28,9 +28,7 @@ std::unique_ptr<MComputation> ProgressBarScope::progBar;
 int                           ProgressBarScope::totalStepsAdded = 0;
 
 // Create a scope with default values for showProgress and interruptible.
-ProgressBarScope::ProgressBarScope(
-    const int      nbSteps,
-    const MString& progressStr)
+ProgressBarScope::ProgressBarScope(const int nbSteps, const MString& progressStr)
     : ProgressBarScope(true, false, nbSteps, progressStr)
 {
 }

--- a/lib/mayaUsd/utils/progressBarScope.h
+++ b/lib/mayaUsd/utils/progressBarScope.h
@@ -1,0 +1,130 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_PROGRSSBARSCOPE_H
+#define MAYAUSD_PROGRSSBARSCOPE_H
+
+#include <mayaUsd/base/api.h>
+
+#include <maya/MComputation.h>
+#include <maya/MString.h>
+
+#include <memory>
+
+namespace MAYAUSD_NS_DEF {
+
+//! \brief Helper class for displaying a progress bar during an operation.
+/*!
+    This class is a helper class that can be used to show a progress bar for
+    a given operation. When starting a long operation (such as import USD file)
+    one would use of the first two constructors to create the top-level scope
+    which will create the internal MComputation (for displaying progress bar).
+    Then in any methods called from this top-level you use the third constructor
+    to add steps to the existing scope.
+*/
+class MAYAUSD_CORE_PUBLIC ProgressBarScope
+{
+public:
+    // Constructors which will create the internal MComputation if not already
+    // exists. They are meant to be used at a top-level for starting an operation,
+    // such as import USD file.
+    ProgressBarScope(const int nbSteps, const MString& progressStr);
+    ProgressBarScope(
+        bool           showProgress,
+        bool           interruptible,
+        const int      nbSteps,
+        const MString& progressStr);
+
+    // Constructor which uses a previously created MComputation. If not exists
+    // then this scope will do nothing. Meant to be used by method called from a
+    // top-level operation (above two constructors).
+    ProgressBarScope(const int nbSteps);
+
+    ~ProgressBarScope();
+
+    // Delete the copy/move constructors assignment operators.
+    ProgressBarScope(const ProgressBarScope&) = delete;
+    ProgressBarScope& operator=(const ProgressBarScope&) = delete;
+    ProgressBarScope(ProgressBarScope&&) = delete;
+    ProgressBarScope& operator=(ProgressBarScope&&) = delete;
+
+    // Add the input number of steps to the current range.
+    void addSteps(int nbSteps);
+
+    void setProgressString(const MString&);
+
+    // Advance the current progress by n step(s).
+    void advance(const int steps = 1);
+
+    bool isInterruptRequested() const;
+
+private:
+    bool _created { false };
+    int  _nbSteps { 0 };
+
+    // There can be only one progress bar during a given operation.
+    static std::unique_ptr<MComputation> progBar;
+
+    // Keep track of the total number of steps added so at the end we can
+    // verify that the progress bar was advanced that many steps.
+    static int totalStepsAdded;
+};
+
+//! \brief Helper class to add steps for a loop to a progress bar.
+/*!
+    At the start of a loop creating a stack variable of this type will add a
+    given number of steps to the progress bar. Internally this class will
+    limit that number to a max so as to not overwhelm the process with updates
+    to the progress bar.
+
+    The loopAdvance() method internally knows how many loop iterations need
+    to be performed before advancing the progress bar.
+*/
+class MAYAUSD_CORE_PUBLIC ProgressBarLoopScope : public ProgressBarScope
+{
+public:
+    ProgressBarLoopScope(const int nbLoopSteps);
+
+    // Delete the copy/move constructors assignment operators.
+    ProgressBarLoopScope(const ProgressBarLoopScope&) = delete;
+    ProgressBarLoopScope& operator=(const ProgressBarLoopScope&) = delete;
+    ProgressBarLoopScope(ProgressBarLoopScope&&) = delete;
+    ProgressBarLoopScope& operator=(ProgressBarLoopScope&&) = delete;
+
+    // Advance the current progress of the loop by 1 step if we have
+    // run thru the required number of loop iterations.
+    void loopAdvance();
+
+private:
+    // Add a variable number of steps for a new for-loop.
+    // The number of steps will be capped at a known value (maxStepsForLoops)
+    // so we don't overwhelm the action with progress bar updates.
+    void addLoopSteps(int loopSize);
+
+    // The current loop iteration counter.
+    int _currLoopCounter { 0 };
+
+     // Number of loop iterations to perform before advancing progress bar.
+    int _minProgressStep { 0 };
+
+    // Just like Maya don't add to many steps as the progress bar update
+    // will overwhelm the process. So for a loop we'll limit the number of
+    // steps added to this value.
+    static const int maxStepsForLoops { 20 };
+};
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif

--- a/lib/mayaUsd/utils/progressBarScope.h
+++ b/lib/mayaUsd/utils/progressBarScope.h
@@ -116,7 +116,7 @@ private:
     // The current loop iteration counter.
     int _currLoopCounter { 0 };
 
-     // Number of loop iterations to perform before advancing progress bar.
+    // Number of loop iterations to perform before advancing progress bar.
     int _minProgressStep { 0 };
 
     // Just like Maya don't add to many steps as the progress bar update

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
@@ -212,7 +212,6 @@ global proc mayaUSDRegisterStrings()
     register("kImportUSDZTxtAnn", "When a .usdz file is chosen and this is selected, .usdz texture files are imported and copied to new files on disk. To locate these files, navigate to the current Maya workspace /sourceimages directory.");
     register("kImportUSDZTxtLbl", "USDZ Texture Import: ");
     register("kImportVariantsInScopeNumLbl", "Variants Switched in Scope:");
-    register("kMayaRefMergeEdits", "Merge Maya Edits to USD");
     register("kMayaDiscardEdits", "Discard Maya Edits");
     register("kMayaRefDiscardEdits", "Cancel Editing as Maya Data");
     register("kMayaRefDuplicateAsUsdData", "Duplicate As USD Data");


### PR DESCRIPTION
#### MAYA-114724: As a user, I'd like to see a progress bar when merging my Maya edits back
#### MAYA-114039: On import/pull I'd like to see a progress bar

* New progress bar utility file with classes: ProgressBarScope/ProgressBarLoopScope.
* Use these new classes in read/write job import/export translator, prim updater manager and shadingModeExporter to display a progress bar for the various workflows.
* Track the number of steps advanced and output message if it doesn't equal number set.
* Added env var "MAYAUSD_ENABLE_PROGRESSBAR" (default true) which can be used to disable progress bar display.