### PR TITLE
MAYA-122511 Set the color and specular roughness on the default standard surface 

### DIFF
--- a/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegatePerInstanceInheritedData.py
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegatePerInstanceInheritedData.py
@@ -150,6 +150,14 @@ class testVP2RenderDelegatePerInstanceInheritedData(imageUtils.ImageDiffingTestC
     @unittest.skipUnless("SkipWhenDefaultMaterialActive" in dir(omr.MRenderItem), "Requires new SDK API")
     def testInstanceDefaultMaterial(self):
         self._StartTest('defaultMaterialBillboards')
+
+        # The color and specular roughness of the default standard surface changed, set
+        # them back to the old default value so the tests keep on working correctly.
+        if maya.mel.eval("defaultShaderName") == "standardSurface1":
+            color = (0.8, 0.8, 0.8)
+            cmds.setAttr("standardSurface1.baseColor", type='float3', *color)
+            cmds.setAttr("standardSurface1.specularRoughness", 0.4)
+
         cmds.select("|stage|stageShape,/root/group/billboard_03",
                     "|stage|stageShape,/root/group/flatquad_03")
         self.assertSnapshotClose('%s_selected.png' % self._testName)

--- a/test/testUtils/mtohUtils.py
+++ b/test/testUtils/mtohUtils.py
@@ -2,6 +2,7 @@ import inspect
 import os
 
 import maya.cmds as cmds
+import maya.mel
 
 import fixturesUtils
 import testUtils
@@ -71,6 +72,13 @@ class MtohTestCase(ImageDiffingTestCase):
         self.assertVisible(self.cubeRprim)
         self.setBasicCam(dist=camDist)
         cmds.select(clear=True)
+
+        # The color and specular roughness of the default standard surface changed, set
+        # them back to the old default value so the tests keep on working correctly.
+        if maya.mel.eval("defaultShaderName") == "standardSurface1":
+            color = (0.8, 0.8, 0.8)
+            cmds.setAttr("standardSurface1.baseColor", type='float3', *color)
+            cmds.setAttr("standardSurface1.specularRoughness", 0.4)
 
     def rprimPath(self, fullPath):
         if not fullPath.startswith('|'):


### PR DESCRIPTION
to match the default values in Maya 2023 so we don't have to update images.