### PR TITLE
MAYA-114376 preserve unsaved root layer

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -788,7 +788,10 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                     rootLayer = SdfLayer::FindOrOpen(fileString);
 
                 if (nullptr == rootLayer) {
-                    // Create a new stage in memory with an anonymous root layer.
+                    // Create an empty in-memory root layer so that a new stage in memory
+                    // will be created below by the UsdStage::Open call. This happens when
+                    // a brand new stage with a new anonymous layer is requested to be
+                    // created by the user.
                     if (!_anonymousRootLayer)
                         _anonymousRootLayer = SdfLayer::CreateAnonymous(kAnonymousLayerName);
                     rootLayer = _anonymousRootLayer;

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -787,7 +787,14 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                 if (nullptr == rootLayer)
                     rootLayer = SdfLayer::FindOrOpen(fileString);
 
-                if (rootLayer) {
+                if (nullptr == rootLayer) {
+                    // Create a new stage in memory with an anonymous root layer.
+                    if (!_anonymousRootLayer)
+                        _anonymousRootLayer = SdfLayer::CreateAnonymous(kAnonymousLayerName);
+                    rootLayer = _anonymousRootLayer;
+                }
+
+                {
                     // Note: computeSessionLayer will find a session layer *only* if the
                     //       Maya scene had been saved and thus serialized the session
                     //       layer. Otherwise it returns null which will mean to use
@@ -837,9 +844,6 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                     sharedUsdStage->SetEditTarget(
                         targetSession ? sharedUsdStage->GetSessionLayer()
                                       : sharedUsdStage->GetRootLayer());
-                } else {
-                    // Create a new stage in memory with an anonymous root layer.
-                    sharedUsdStage = UsdStage::CreateInMemory(kAnonymousLayerName, loadSet);
                 }
             }
         }
@@ -1719,6 +1723,7 @@ MayaUsdProxyShapeBase::MayaUsdProxyShapeBase(
     : MPxSurfaceShape()
     , _isUfeSelectionEnabled(enableUfeSelection)
     , _previousShareMode(ShareMode::Unknown)
+    , _anonymousRootLayer(nullptr)
     , _unsharedStageSessionLayer(nullptr)
     , _unsharedStageRootLayer(nullptr)
     , _unsharedStageRootSublayers()

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -399,6 +399,9 @@ private:
     // Starts off as Unknown when the proxy shape is first created.
     ShareMode _previousShareMode { ShareMode::Unknown };
 
+    // Anonymous layer that was created when a new proxy shape is created without a named layer.
+    SdfLayerRefPtr _anonymousRootLayer;
+
     // For unshared composition
     SdfLayerRefPtr _unsharedStageSessionLayer;
     SdfLayerRefPtr _unsharedStageRootLayer;

--- a/test/lib/mayaUsd/nodes/testProxyShapeBase.py
+++ b/test/lib/mayaUsd/nodes/testProxyShapeBase.py
@@ -322,7 +322,7 @@ class testProxyShapeBase(unittest.TestCase):
         # It was already set, this only triggers a Maya node recompute.
         cmds.setAttr('{}.{}'.format(proxyShapePath,"loadPayloads"), True)
 
-        # Verify that we did not loose the data on the root layer.
+        # Verify that we did not lose the data on the root layer.
         verifyPrim()
 
     @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 2, 'testShareStageLoadRules only available in UFE v2 or greater.')


### PR DESCRIPTION
When the proxy stage is recompute with an unsaved root layer, the attribute keeping the root layer name would be empty. A new root layer would be created each time, losing any previous content.

This attribute only gets set once the stage gets saved.

Fix this by re-using the same anonymous root layer when the stage has not been saved yet.

Also, as a bonus, this fix change teh code so that the same code path for newly created stage is used, which means that if the user ahas set the option var to target the session layer, it will also be honored for newly-created stages. It will also re-use any pre-existing stage, so we also avoid creating stages repeatedly for the same unsaved proxy stage node every time an attribute get sets.