### PR TITLE
Provide explicit export options in tests

### DIFF
--- a/test/lib/mayaUsd/fileio/testComponentTags.py
+++ b/test/lib/mayaUsd/fileio/testComponentTags.py
@@ -50,7 +50,8 @@ class testComponentTags(unittest.TestCase):
         usdFilePath = os.path.join(os.environ.get('MAYA_APP_DIR'),'testComponentTags.usda')
         cmds.mayaUSDExport(mergeTransformAndShape=True,
             file=usdFilePath,
-            shadingMode='none')
+            shadingMode='none',
+            exportComponentTags=True)
 
         cmds.file(new=True, force=True)
         rootPaths = cmds.mayaUSDImport(v=True, f=usdFilePath)

--- a/test/lib/usd/translators/testUsdExportUVSetMappings.py
+++ b/test/lib/usd/translators/testUsdExportUVSetMappings.py
@@ -44,7 +44,8 @@ class testUsdExportUVSetMappings(unittest.TestCase):
         cls._usdFilePath = os.path.abspath('UsdExportUVSetMappingsTest.usda')
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=cls._usdFilePath,
             shadingMode='useRegistry', convertMaterialsTo=['UsdPreviewSurface'],
-            materialsScopeName='Materials')
+            materialsScopeName='Materials', preserveUVSetNames=False,
+            remapUVSetsTo=['',''])
 
         cls._stage = Usd.Stage.Open(cls._usdFilePath)
 

--- a/test/lib/usd/translators/testUsdExportUVSets.py
+++ b/test/lib/usd/translators/testUsdExportUVSets.py
@@ -140,7 +140,9 @@ class testUsdExportUVSets(unittest.TestCase):
             shadingMode='none',
             exportColorSets=False,
             exportDisplayColor=False,
-            exportUVs=True)
+            exportUVs=True,
+            preserveUVSetNames=False,
+            remapUVSetsTo=[['','']])
 
         testUsdExportUVSets._stage = Usd.Stage.Open(usdFilePath)
 
@@ -394,7 +396,7 @@ class testUsdExportUVSets(unittest.TestCase):
         # Sets should not be renamed at all when preserveUVSetNames is True
         usdCubeMesh = reexportUVSets(
             preserveUVSetNames=True,
-            remapUVSetsTo=[])
+            remapUVSetsTo=[['','']])
         pvAPI = UsdGeom.PrimvarsAPI(usdCubeMesh)
         map1 = pvAPI.GetPrimvar('map1')
         st = pvAPI.GetPrimvar('st')


### PR DESCRIPTION
Provide explicit values for export options in open source tests even if
they match defaults. This allows tests to pass in environments which
run with site-specific export option overrides