### PR TITLE
MAYA-123877 Prepend reference/payload doesn't work in Caching Maya Ref

### DIFF
--- a/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
@@ -54,6 +54,17 @@ _listEditedAsLabels = [getMayaUsdLibString('kMenuAppend'), getMayaUsdLibString('
 _listEditedAsValues = [                         'Append',                           'Prepend' ]
 
 
+def _getMenuGrpValue(menuName, values, defaultIndex = 0):
+    """
+    Retrieves the currently selected values from a menu.
+    """
+    # Note: option menu selection index start at 1, so we subtract 1.
+    menuIndex = cmds.optionMenuGrp(menuName, query=True, select=True) - 1
+    if 0 <= menuIndex < len(values):
+        return values[menuIndex]
+    else:
+        return values[defaultIndex]
+
 def _getMenuValue(menuName, values, defaultIndex = 0):
     """
     Retrieves the currently selected values from a menu.
@@ -181,7 +192,7 @@ def cacheFileUsdHierarchyOptions(topForm):
         cmds.textField(text=str(_pulledMayaRefPrim.GetParent().GetPath()), editable=False)
 
     with mayaRefUtils.SetParentContext(cmds.rowLayout(numberOfColumns=2)):
-        cmds.optionMenu('compositionArcTypeMenu',
+        cmds.optionMenuGrp('compositionArcTypeMenu',
                            label=getMayaUsdLibString('kOptionAsUSDReference'),
                            cc=compositionArcChanged,
                            annotation=getMayaUsdLibString('kOptionAsUSDReferenceToolTip'))
@@ -325,7 +336,7 @@ def cacheInitUi(parent, filterType):
     mayaRefPrimParent = _pulledMayaRefPrim.GetParent()
 
     menuIndex = _getMenuIndex(_compositionArcValues, optionsDict['rn_payloadOrReference'])
-    cmds.optionMenu('compositionArcTypeMenu', edit=True, select=menuIndex)
+    cmds.optionMenuGrp('compositionArcTypeMenu', edit=True, select=menuIndex)
 
     menuIndex = _getMenuIndex(_listEditedAsValues, optionsDict['rn_listEditType'])
     cmds.optionMenu('listEditedAsMenu', edit=True, select=menuIndex)
@@ -381,7 +392,7 @@ def cacheCommitUi(parent, selectedFile):
     mel.eval('mayaUsdTranslatorExport("fileOptionsScroll", "query={exportOpts}", "", "mayaUsdCacheMayaReference_setCacheOptions")'.format(exportOpts=kTranslatorExportOptions))
 
     primName = cmds.textFieldGrp('primNameText', query=True, text=True)
-    payloadOrReference = _getMenuValue('compositionArcTypeMenu', _compositionArcValues)
+    payloadOrReference = _getMenuGrpValue('compositionArcTypeMenu', _compositionArcValues)
     listEditType = _getMenuValue('listEditedAsMenu', _listEditedAsValues)
     
     defineInVariant = cmds.radioButtonGrp('variantRadioButton', query=True, select=True)

--- a/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
@@ -59,7 +59,7 @@ def _getMenuValue(menuName, values, defaultIndex = 0):
     Retrieves the currently selected values from a menu.
     """
     # Note: option menu selection index start at 1, so we subtract 1.
-    menuIndex = cmds.optionMenuGrp('compositionArcTypeMenu', query=True, select=True) - 1
+    menuIndex = cmds.optionMenu(menuName, query=True, select=True) - 1
     if 0 <= menuIndex < len(values):
         return values[menuIndex]
     else:
@@ -181,7 +181,7 @@ def cacheFileUsdHierarchyOptions(topForm):
         cmds.textField(text=str(_pulledMayaRefPrim.GetParent().GetPath()), editable=False)
 
     with mayaRefUtils.SetParentContext(cmds.rowLayout(numberOfColumns=2)):
-        cmds.optionMenuGrp('compositionArcTypeMenu',
+        cmds.optionMenu('compositionArcTypeMenu',
                            label=getMayaUsdLibString('kOptionAsUSDReference'),
                            cc=compositionArcChanged,
                            annotation=getMayaUsdLibString('kOptionAsUSDReferenceToolTip'))
@@ -325,7 +325,7 @@ def cacheInitUi(parent, filterType):
     mayaRefPrimParent = _pulledMayaRefPrim.GetParent()
 
     menuIndex = _getMenuIndex(_compositionArcValues, optionsDict['rn_payloadOrReference'])
-    cmds.optionMenuGrp('compositionArcTypeMenu', edit=True, select=menuIndex)
+    cmds.optionMenu('compositionArcTypeMenu', edit=True, select=menuIndex)
 
     menuIndex = _getMenuIndex(_listEditedAsValues, optionsDict['rn_listEditType'])
     cmds.optionMenu('listEditedAsMenu', edit=True, select=menuIndex)


### PR DESCRIPTION
UI element fixes to read the "Prepend/Append" menu correctly.