### PR TITLE
MAYA-124064 fix unit test for Maya 2023

### DIFF
--- a/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
+++ b/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
@@ -162,7 +162,9 @@ class testDiagnosticDelegate(unittest.TestCase):
             ("spam warning 0 -- and 2 similar", OM.MCommandMessage.kWarning)
         ])
 
-    def testBatching_DelegateRemoved(self):
+    # Note: giving the test a name starting with Z so it is run last because unloading the plugin
+    #       can break other tests when they try to reload the plugin.
+    def testZZZBatching_DelegateRemoved(self):
         """Tests removing the diagnostic delegate when the batch context is
         still open."""
         self._StartRecording()

--- a/test/lib/ufe/testObservableScene.py
+++ b/test/lib/ufe/testObservableScene.py
@@ -80,7 +80,7 @@ class UFEObservableSceneTest(unittest.TestCase):
         cb = ufe.PathComponent("b")
         cc = ufe.PathComponent("c")
 
-        sa = ufe.PathSegment([ca], 3, '/')
+        sa = ufe.PathSegment([ca], 1, '/')
         sab = ufe.PathSegment([ca, cb], 1, '|')
         sc = ufe.PathSegment([cc], 2, '/')
 


### PR DESCRIPTION
- Diagnostic was unloading the plugin and for some reason reloading it failed on the CI.
- Making the test that unloads the plugin run last should fix the test.
- Note that I could not reproduce this failure, but comparing test logs showed that the failing CI had an extra error message in the log when trying to reload the plugin.
- Observable scene test was creating a path segment with an invalid runtime ID.
- On master, we catch exception during notification delivery, but not in 2023, so fix the test to use a valid run-time ID.