### PR TITLE
MAYA-123903 reset all merge and duplicate options

### DIFF
--- a/lib/mayaUsd/resources/scripts/mayaUsdDuplicateAsMayaDataOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdDuplicateAsMayaDataOptions.py
@@ -18,7 +18,7 @@ import maya.cmds as cmds
 import maya.mel as mel
 
 from mayaUsdLibRegisterStrings import getMayaUsdLibString
-from mayaUsdMergeToUSDOptions import _getDefaultMergeToUSDOptionsDict
+from mayaUsdMergeToUSDOptions import getDefaultMergeToUSDOptionsDict
 import mayaUsdOptions
 
 from functools import partial
@@ -136,7 +136,7 @@ def _resetDuplicateAsMayaDataOptions(subLayout, data=None):
     """
     Resets the duplicate-as-Maya-data options in the dialog.
     """
-    optionsText = mayaUsdOptions.convertOptionsDictToText(_getDefaultDuplicateAsMayaDataOptionsDict())
+    optionsText = mayaUsdOptions.convertOptionsDictToText(getDefaultDuplicateAsMayaDataOptionsDict())
     _fillDuplicateAsMayaDataOptionsDialog(subLayout, optionsText, "fill")
 
 
@@ -180,7 +180,7 @@ def getDuplicateAsMayaDataOptionsText():
     """
     return mayaUsdOptions.getOptionsText(
         _getDuplicateAsMayaDataOptionsVarName(),
-        _getDefaultDuplicateAsMayaDataOptionsDict())
+        getDefaultDuplicateAsMayaDataOptionsDict())
     
 
 def setDuplicateAsMayaDataOptionsText(optionsText):
@@ -192,9 +192,9 @@ def setDuplicateAsMayaDataOptionsText(optionsText):
     mayaUsdOptions.setOptionsText(_getDuplicateAsMayaDataOptionsVarName(), optionsText)
 
 
-def _getDefaultDuplicateAsMayaDataOptionsDict():
+def getDefaultDuplicateAsMayaDataOptionsDict():
     """
     Retrieves the default duplicate-as-Maya-data options.
     """
     # For now, the duplicate and merge options defaults are the same.
-    return _getDefaultMergeToUSDOptionsDict()
+    return getDefaultMergeToUSDOptionsDict()

--- a/lib/mayaUsd/resources/scripts/mayaUsdDuplicateAsMayaDataOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdDuplicateAsMayaDataOptions.py
@@ -18,6 +18,7 @@ import maya.cmds as cmds
 import maya.mel as mel
 
 from mayaUsdLibRegisterStrings import getMayaUsdLibString
+from mayaUsdMergeToUSDOptions import _getDefaultMergeToUSDOptionsDict
 import mayaUsdOptions
 
 from functools import partial
@@ -195,17 +196,5 @@ def _getDefaultDuplicateAsMayaDataOptionsDict():
     """
     Retrieves the default duplicate-as-Maya-data options.
     """
-    return {
-        "exportColorSets":          "1",
-        "exportUVs":                "1",
-        "exportSkels":              "none",
-        "exportSkin":               "none",
-        "exportBlendShapes":        "0",
-        "exportDisplayColor":       "1",
-        "shadingMode":              "none",
-        "animation":                "1",
-        "exportVisibility":         "1",
-        "exportInstances":          "1",
-        "mergeTransformAndShape":   "1",
-        "stripNamespaces":          "0",
-    }
+    # For now, the duplicate and merge options defaults are the same.
+    return _getDefaultMergeToUSDOptionsDict()

--- a/lib/mayaUsd/resources/scripts/mayaUsdMergeToUSDOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdMergeToUSDOptions.py
@@ -266,16 +266,23 @@ def _getDefaultMergeToUSDOptionsDict():
     Retrieves the default merge-to-USD options.
     """
     return {
-        "exportColorSets":          "1",
         "exportUVs":                "1",
         "exportSkels":              "none",
         "exportSkin":               "none",
         "exportBlendShapes":        "0",
         "exportDisplayColor":       "1",
-        "shadingMode":              "none",
+        "exportColorSets":          "1",
+        "defaultMeshScheme":        "catmullClark",
         "animation":                "1",
-        "exportVisibility":         "1",
+        "eulerFilter":              "0",
+        "staticSingleSample":       "0",
+        "startTime":                "0",
+        "endTime":                  "200",
+        "frameStride":              "1",
+        "frameSample":              "",
+        "shadingMode":              "none",
         "exportInstances":          "1",
+        "exportVisibility":         "1",
         "mergeTransformAndShape":   "1",
         "stripNamespaces":          "0",
     }

--- a/lib/mayaUsd/resources/scripts/mayaUsdMergeToUSDOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdMergeToUSDOptions.py
@@ -203,7 +203,7 @@ def _resetMergeToUSDOptions(target, subLayout, data=None):
     """
     Resets the merge-to-USD options in the dialog.
     """
-    optionsText = mayaUsdOptions.convertOptionsDictToText(_getDefaultMergeToUSDOptionsDict())
+    optionsText = mayaUsdOptions.convertOptionsDictToText(getDefaultMergeToUSDOptionsDict())
     _fillMergeToUSDOptionsDialog(target, subLayout, optionsText, "fill")
 
 
@@ -249,7 +249,7 @@ def getMergeToUSDOptionsText():
     """
     return mayaUsdOptions.getOptionsText(
         _getMergeToUSDOptionsVarName(),
-        _getDefaultMergeToUSDOptionsDict())
+        getDefaultMergeToUSDOptionsDict())
     
 
 def setMergeToUSDOptionsText(optionsText):
@@ -261,7 +261,7 @@ def setMergeToUSDOptionsText(optionsText):
     mayaUsdOptions.setOptionsText(_getMergeToUSDOptionsVarName(), optionsText)
 
 
-def _getDefaultMergeToUSDOptionsDict():
+def getDefaultMergeToUSDOptionsDict():
     """
     Retrieves the default merge-to-USD options.
     """


### PR DESCRIPTION
Make sure the default options contain all the possible options so that when using the defaults to reset options, all options get reset.