### PR TITLE
Fix handling of empty materialCollectionsPath

### DIFF
--- a/lib/mayaUsd/fileio/shading/shadingModeExporter.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporter.cpp
@@ -143,7 +143,6 @@ void UsdMayaShadingModeExporter::DoExport(
                 "Could not get prim at path <%s>. Not exporting material "
                 "collections / bindings.",
                 rootPrimPath.GetText());
-            return;
         }
 
         std::vector<UsdCollectionAPI> collections


### PR DESCRIPTION
If -materialCollectionsPath is empty, an appropriate path is selected
to hold the material bindings. But the control flow ends there, which
looks unintentional.