### PR TITLE
MAYA-123876 preserve session layer

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.h
+++ b/lib/mayaUsd/nodes/layerManager.h
@@ -25,10 +25,10 @@
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
 
+#include <maya/MDagPath.h>
 #include <maya/MDagPathArray.h>
 #include <maya/MMessage.h>
 #include <maya/MObject.h>
-#include <maya/MDagPath.h>
 #include <maya/MPxNode.h>
 #include <maya/MString.h>
 #include <maya/MTypeId.h>

--- a/lib/mayaUsd/nodes/layerManager.h
+++ b/lib/mayaUsd/nodes/layerManager.h
@@ -23,16 +23,19 @@
 #include <pxr/usd/sdf/layer.h>
 #include <pxr/usd/sdf/types.h>
 #include <pxr/usd/usd/prim.h>
+#include <pxr/usd/usd/stage.h>
 
 #include <maya/MDagPathArray.h>
 #include <maya/MMessage.h>
 #include <maya/MObject.h>
+#include <maya/MDagPath.h>
 #include <maya/MPxNode.h>
 #include <maya/MString.h>
 #include <maya/MTypeId.h>
 
 #include <functional>
 #include <string>
+#include <vector>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -47,7 +50,22 @@ enum BatchSaveResult
     kPartiallyCompleted // Callback has handled the saving of some stages, but not all. Layer
                         // Manager should continue to look for unsaved stages.
 };
-typedef std::function<BatchSaveResult(const MDagPathArray&)> BatchSaveDelegate;
+
+/*! \brief Information about the stages that need to be saved.
+ */
+struct BatchSaveInfo
+{
+    MDagPath    dagPath;
+    UsdStagePtr stage;
+    bool        shareable = true;
+    bool        isIncoming = false;
+};
+
+/*! \brief Callback function to handle saving of Usd edits.  In a default build of the
+    plugin a delegate will be installed that posts a UI dialog that provides an opportunity
+    to choose file names and locations of all anonymous layers that need to be saved to disk.
+ */
+using BatchSaveDelegate = std::function<BatchSaveResult(const std::vector<BatchSaveInfo>&)>;
 
 /*! \brief Maya dependency node responsible for serializing unsaved Usd edits.
 

--- a/lib/mayaUsd/utils/stageCache.h
+++ b/lib/mayaUsd/utils/stageCache.h
@@ -23,6 +23,7 @@
 #include <pxr/usd/usd/stage.h>
 #include <pxr/usd/usd/stageCache.h>
 
+#include <array>
 #include <string>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -30,11 +31,24 @@ PXR_NAMESPACE_OPEN_SCOPE
 class UsdMayaStageCache
 {
 public:
+    /// The shared mode of stage kept in a particular cache.
+    ///
+    /// Shared stages allow staging the same root layer multiple times in Maya
+    /// with the same session layer.
+    ///
+    /// Unshared stages ensure they do not share their session layer.
     enum class ShareMode
     {
         Shared,
         Unshared
     };
+
+    /// Container of caches.
+    using Caches = std::array<UsdStageCache, 4>;
+
+    /// Return all the stage caches.
+    MAYAUSD_CORE_PUBLIC
+    static Caches& GetAllCaches();
 
     /// Return the singleton stage cache for use by all USD clients within Maya.
     /// Four stage caches are maintained. They are divided based on two criteria:

--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -16,11 +16,13 @@
 #include "utilSerialization.h"
 
 #include <mayaUsd/base/tokens.h>
+#include <mayaUsd/utils/stageCache.h>
 #include <mayaUsd/utils/util.h>
 #include <mayaUsd/utils/utilFileSystem.h>
 
 #include <pxr/base/tf/stringUtils.h>
 #include <pxr/usd/sdf/layerUtils.h>
+#include <pxr/usd/usd/stageCacheContext.h>
 #include <pxr/usd/usd/usdFileFormat.h>
 #include <pxr/usd/usd/usdaFileFormat.h>
 #include <pxr/usd/usd/usdcFileFormat.h>
@@ -98,6 +100,21 @@ bool saveRootLayer(SdfLayerRefPtr layer, const std::string& proxy)
     MayaUsd::utils::setNewProxyPath(MString(proxy.c_str()), MString(fp.c_str()));
 
     return true;
+}
+
+void updateAllCachedStageWithLayer(SdfLayerRefPtr originalLayer, const std::string& newFilePath)
+{
+    SdfLayerRefPtr newLayer = SdfLayer::FindOrOpen(newFilePath);
+    for (UsdStageCache& cache : UsdMayaStageCache::GetAllCaches()) {
+        UsdStageCacheContext        ctx(cache);
+        std::vector<UsdStageRefPtr> stages = cache.FindAllMatching(originalLayer);
+        for (const auto& stage : stages) {
+            auto sessionLayer = stage->GetSessionLayer();
+            auto newStage = UsdStage::UsdStage::Open(
+                newLayer, sessionLayer, UsdStage::InitialLoadSet::LoadNone);
+            newStage->SetLoadRules(stage->GetLoadRules());
+        }
+    }
 }
 
 } // namespace
@@ -225,12 +242,20 @@ bool saveLayerWithFormat(
         = requestedFormatArg.empty() ? usdFormatArgOption() : requestedFormatArg;
 
     if (isCompatibleWithSave(layer, filePath, formatArg)) {
-        return layer->Save();
+            if (!layer->Save()) {
+                return false;
+            }
     } else {
         PXR_NS::SdfFileFormat::FileFormatArguments args;
         args["format"] = formatArg;
-        return layer->Export(filePath, "", args);
+        if (!layer->Export(filePath, "", args)) {
+            return false;
+        }
     }
+
+    updateAllCachedStageWithLayer(layer, filePath);
+
+    return true;
 }
 
 SdfLayerRefPtr saveAnonymousLayer(

--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -242,9 +242,9 @@ bool saveLayerWithFormat(
         = requestedFormatArg.empty() ? usdFormatArgOption() : requestedFormatArg;
 
     if (isCompatibleWithSave(layer, filePath, formatArg)) {
-            if (!layer->Save()) {
-                return false;
-            }
+        if (!layer->Save()) {
+            return false;
+        }
     } else {
         PXR_NS::SdfFileFormat::FileFormatArguments args;
         args["format"] = formatArg;

--- a/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.cpp
+++ b/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.cpp
@@ -32,7 +32,8 @@ void UsdLayerEditor::initialize()
     }
 }
 
-MayaUsd::BatchSaveResult UsdLayerEditor::batchSaveLayersUIDelegate(const MDagPathArray& proxyShapes)
+MayaUsd::BatchSaveResult
+UsdLayerEditor::batchSaveLayersUIDelegate(const std::vector<MayaUsd::BatchSaveInfo>& infos)
 {
     if (MGlobal::kInteractive == MGlobal::mayaState()) {
         auto opt = MayaUsd::utils::serializeUsdEditsLocationOption();
@@ -46,10 +47,10 @@ MayaUsd::BatchSaveResult UsdLayerEditor::batchSaveLayersUIDelegate(const MDagPat
             // if at least one stage contains anonymous layers, you need to show the comfirm dialog
             // so the user can choose where to save the anonymous layers.
             if (!showConfirmDgl) {
-                for (auto& shape : proxyShapes) {
+                for (const auto& info : infos) {
                     MayaUsd::utils::stageLayersToSave stageLayersToSave;
                     MayaUsd::utils::getLayersToSaveFromProxy(
-                        shape.fullPathName().asChar(), stageLayersToSave);
+                        info.dagPath.fullPathName().asChar(), stageLayersToSave);
                     if (!stageLayersToSave._anonLayers.empty()) {
                         showConfirmDgl = true;
                         break;
@@ -58,7 +59,7 @@ MayaUsd::BatchSaveResult UsdLayerEditor::batchSaveLayersUIDelegate(const MDagPat
             }
 
             if (showConfirmDgl) {
-                UsdLayerEditor::SaveLayersDialog dlg(nullptr, proxyShapes);
+                UsdLayerEditor::SaveLayersDialog dlg(nullptr, infos);
 
                 // The SaveLayers dialog only handles choosing new names for anonymous layers and
                 // making sure that they are remapped correctly in either their parent layer or by

--- a/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.h
+++ b/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.h
@@ -35,7 +35,8 @@ MAYAUSD_UI_PUBLIC
 void initialize();
 
 MAYAUSD_UI_PUBLIC
-MayaUsd::BatchSaveResult batchSaveLayersUIDelegate(const MDagPathArray&);
+MayaUsd::BatchSaveResult
+batchSaveLayersUIDelegate(const std::vector<MayaUsd::BatchSaveInfo>& infos);
 
 } // namespace UsdLayerEditor
 

--- a/lib/usd/ui/layerEditor/saveLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.cpp
@@ -227,28 +227,28 @@ public:
 namespace UsdLayerEditor {
 
 #if defined(WANT_UFE_BUILD)
-SaveLayersDialog::SaveLayersDialog(QWidget* in_parent, const MDagPathArray& proxyShapes)
+SaveLayersDialog::SaveLayersDialog(
+    QWidget*                                   in_parent,
+    const std::vector<MayaUsd::BatchSaveInfo>& infos)
     : QDialog(in_parent)
     , _sessionState(nullptr)
 {
     MString msg, nbStages;
 
-    nbStages = proxyShapes.length();
+    nbStages = infos.size();
     msg.format(StringResources::getAsMString(StringResources::kSaveXStages), nbStages);
     setWindowTitle(MQtUtil::toQString(msg));
 
     // For each stage collect the layers to save.
-    for (const auto& shape : proxyShapes) {
+    for (const auto& info : infos) {
 
-        getLayersToSave(shape.fullPathName().asChar(), shape.partialPathName().asChar());
+        getLayersToSave(
+            info.dagPath.fullPathName().asChar(), info.dagPath.partialPathName().asChar());
     }
 
     QString msg1, msg2;
     getDialogMessages(
-        static_cast<int>(proxyShapes.length()),
-        static_cast<int>(_anonLayerPairs.size()),
-        msg1,
-        msg2);
+        static_cast<int>(infos.size()), static_cast<int>(_anonLayerPairs.size()), msg1, msg2);
     buildDialog(msg1, msg2);
 }
 #endif

--- a/lib/usd/ui/layerEditor/saveLayersDialog.h
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.h
@@ -1,6 +1,7 @@
 #ifndef SAVELAYERSDIALOG_H
 #define SAVELAYERSDIALOG_H
 
+#include <mayaUsd/nodes/layerManager.h>
 #include <mayaUsd/utils/utilSerialization.h>
 
 #include <pxr/usd/sdf/layer.h>
@@ -32,7 +33,7 @@ public:
 
 #if defined(WANT_UFE_BUILD)
     // Create dialog for bulk save using all provided proxy shapes and their owned stages.
-    SaveLayersDialog(QWidget* in_parent, const MDagPathArray& proxyShapes);
+    SaveLayersDialog(QWidget* in_parent, const std::vector<MayaUsd::BatchSaveInfo>& infos);
 #endif
 
     ~SaveLayersDialog();

--- a/test/lib/mayaUsd/nodes/testProxyShapeBase.py
+++ b/test/lib/mayaUsd/nodes/testProxyShapeBase.py
@@ -291,6 +291,152 @@ class testProxyShapeBase(unittest.TestCase):
 
         verifyPrim()
 
+    def _saveStagePreserveLayerHelper(self, targetRoot, saveInMaya):
+        '''
+        Verify that a freshly-created stage preserve its session or root layer data
+        when saved to Maya or USD files.
+
+        (What happens internally is that the root layer changes name when saved,
+        so the stage cache needs to be updated by the save code in order to end-up
+        with the same session layer.)
+        '''
+        # Create an empty stage.
+        cmds.file(new=True, force=True)
+        mayaUtils.createProxyAndStage()
+
+        # Helper to get the stage, Needed since the stage instance will change
+        # after saving.
+        def getStage():
+            proxyShapes = cmds.ls(type="mayaUsdProxyShapeBase", long=True)
+            self.assertGreater(len(proxyShapes), 0)
+            proxyShapePath = proxyShapes[0]
+            return mayaUsd.lib.GetPrim(proxyShapePath).GetStage(), proxyShapePath
+
+        stage, proxyShapePath = getStage()
+
+        # Create a prim in the root layer.
+        stage.SetEditTarget(stage.GetRootLayer())
+        stage.DefinePrim("/dummy", "xform")
+
+        # Make the prim inactive in the desired target layer.
+        target = stage.GetRootLayer() if targetRoot else stage.GetSessionLayer()
+        stage.SetEditTarget(target)
+        prim = stage.GetPrimAtPath("/dummy")
+        prim.SetActive(False)
+
+        # verify that the prim exists but is inactive.
+        def verifyPrim():
+            stage, _ = getStage()
+            prim = stage.GetPrimAtPath("/dummy")
+            self.assertIsNotNone(prim)
+            self.assertFalse(prim.IsActive())
+
+        verifyPrim()
+
+        # Temp file names for Maya scene and USD file.
+        testDir = tempfile.mkdtemp(prefix='ProxyShapeBase')
+        tempMayaFile = os.path.join(testDir, 'SaveStagePreserveSessionLayerTest.ma')
+        tempUSDFile = os.path.join(testDir, 'SaveStagePreserveSessionLayer.usd')
+
+        # Make sure layers are saved to the desired location (Maya or USD)
+        # when the Maya scene is saved.
+        location = 2 if saveInMaya else 1
+        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', location))
+        if not saveInMaya:
+            cmds.setAttr('{}.{}'.format(proxyShapePath,"filePath"), tempUSDFile, type='string')
+
+        # Save the stage.
+        cmds.file(rename=tempMayaFile)
+        cmds.file(save=True, force=True)
+
+        # Verify that the prim is still inactive in the target layer.
+
+        verifyPrim()
+
+    def testSaveStageToUSDPreserveSessionLayer(self):
+        '''
+        Verify that a freshly-created stage preserve its session layer data when saved
+        to USD files.
+        '''
+        self._saveStagePreserveLayerHelper(False, False)
+
+    def testSaveStageToMayaPreserveSessionLayer(self):
+        '''
+        Verify that a freshly-created stage preserve its session layer data when saved
+        to Maya.
+        '''
+        self._saveStagePreserveLayerHelper(False, True)
+
+    def testSaveStageToUSDPreserveRootLayer(self):
+        '''
+        Verify that a freshly-created stage preserve its root layer data when saved
+        to USD files.
+        '''
+        self._saveStagePreserveLayerHelper(True, False)
+
+    def testSaveStageToMayaPreserveRootLayer(self):
+        '''
+        Verify that a freshly-created stage preserve its root layer data when saved
+        to Maya.
+        '''
+        self._saveStagePreserveLayerHelper(True, True)
+
+    def testSaveStagePreserveSessionLayer(self):
+        '''
+        Verify that a freshly-created stage preserve its session layer data when saved
+        to USD files.
+
+        (What happens internally is that the root layer changes name when saved,
+        so the stage cache needs to be updated by the save code in order to end-up
+        with the same session layer.)
+        '''
+        # Create an empty stage.
+        cmds.file(new=True, force=True)
+        mayaUtils.createProxyAndStage()
+
+        # Helper to get the stage, Needed since the stage instance will change
+        # after saving.
+        def getStage():
+            proxyShapes = cmds.ls(type="mayaUsdProxyShapeBase", long=True)
+            self.assertGreater(len(proxyShapes), 0)
+            proxyShapePath = proxyShapes[0]
+            return mayaUsd.lib.GetPrim(proxyShapePath).GetStage(), proxyShapePath
+
+        stage, proxyShapePath = getStage()
+
+        # Create a prim in the root layer.
+        stage.SetEditTarget(stage.GetRootLayer())
+        stage.DefinePrim("/dummy", "xform")
+
+        # Make the prim inactive in the session layer.
+        stage.SetEditTarget(stage.GetSessionLayer())
+        prim = stage.GetPrimAtPath("/dummy")
+        prim.SetActive(False)
+
+        # verify that the prim exists but is inactive.
+        def verifyPrim():
+            stage, _ = getStage()
+            prim = stage.GetPrimAtPath("/dummy")
+            self.assertIsNotNone(prim)
+            self.assertFalse(prim.IsActive())
+
+        verifyPrim()
+
+        # Make sure layers are saved to their own file when the Maya scene is saved.
+        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 1))
+
+        # Save the stage.
+        testDir = tempfile.mkdtemp(prefix='ProxyShapeBase')
+        tempMayaFile = os.path.join(testDir, 'SaveStagePreserveSessionLayerTest.ma')
+        tempUSDFile = os.path.join(testDir, 'SaveStagePreserveSessionLayer.usd')
+        cmds.setAttr('{}.{}'.format(proxyShapePath,"filePath"), tempUSDFile, type='string')
+        cmds.file(rename=tempMayaFile)
+        cmds.file(save=True, force=True)
+
+        # Verify that the prim is still inactive in the session layer.
+
+        verifyPrim()
+
     def testUnsavedStagePreserveRootLayerWhenUpdated(self):
         '''
         Verify that a freshly-created stage preserve its data when an attribute is set.


### PR DESCRIPTION
When a new stage with an anonymous root layer is saved for the first time, the session layer was lost.

The reason was that when a new stage is saved, its root layer change ID. When the proxy shape was recomputed, it tried to find the root layer with the new ID in the stage cache. Since the just-saved stage was previously using an anonymous root layer, the cache did not find the just-saved stage. A new stage got created, which meant it got a brand new empty session layer.

This re-computation happened mid-save.

The fix is to avoid recomputing the proxy stage mid-save and to pre-fill the stage cache with the newly-saved root with its new ID and with the pre-existing session layer. This requires keeping more information when initially gathering the layers to be saved to avoid touching the proxy shape again during the save.

- Add BatchSaveInfo to the layer manager to cache all info necessary during saving.
- Pass these info instead of only the DAG path to callbacks and various internal functions.
- Have the LayerDatabase fill this info when gathering layers to save.
- Avoid calling getProxiesToSave() mid-save.
- Add hasDirtyLayer() to support the previous point.
- Refactor clearing proxies to save into its own function to avoid code duplication.
- Add GetAllCaches() to UsdMayaStageCache to allow access to all caches without knowing the details of how caches are segregated.
- When saving a layer, prefill all stage caches that were holding the stages that were using the original layer to now cache a stage that uses the new layer and the session layer of the existing stage.
- This will allow the proxy shape to find these stage with the correct session layer when recomputed later.
- Update the batch save layer UI to the new API with BatchSaveInfo.