### PR TITLE
MAYA-123876 preserve session layer

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -251,8 +251,8 @@ private:
     std::map<std::string, SdfLayerRefPtr> _idToLayer;
     TfNotice::Key                         _onStageSetKey;
     std::set<unsigned int>                _supportedTypes;
-    std::vector<BatchSaveInfo>            _proxiesToSave;
-    std::vector<BatchSaveInfo>            _internalProxiesToSave;
+    std::vector<LayerSavingInfo>          _proxiesToSave;
+    std::vector<LayerSavingInfo>          _internalProxiesToSave;
     static MCallbackId                    preSaveCallbackId;
     static MCallbackId                    postSaveCallbackId;
     static MCallbackId                    preExportCallbackId;
@@ -487,7 +487,7 @@ bool LayerDatabase::getProxiesToSave(bool isExport)
                     SdfLayerHandleVector allLayers = stage->GetLayerStack(true);
                     for (auto layer : allLayers) {
                         if (layer->IsDirty()) {
-                            BatchSaveInfo info;
+                            LayerSavingInfo info;
                             MDagPath::getAPathTo(mobj, info.dagPath);
                             info.stage = stage;
                             info.shareable = pShape->isShareableStage();
@@ -700,7 +700,7 @@ BatchSaveResult LayerDatabase::saveUsdToMayaFile()
 
     MFnDependencyNode fn;
     for (size_t i = 0; i < _proxiesToSave.size() + _internalProxiesToSave.size(); i++) {
-        const BatchSaveInfo& info = i < _proxiesToSave.size()
+        const LayerSavingInfo& info = i < _proxiesToSave.size()
             ? _proxiesToSave[i]
             : _internalProxiesToSave[i - _proxiesToSave.size()];
         MObject mobj = info.dagPath.node();
@@ -736,7 +736,7 @@ BatchSaveResult LayerDatabase::saveUsdToUsdFiles()
 {
     MFnDependencyNode fn;
     for (size_t i = 0; i < _proxiesToSave.size() + _internalProxiesToSave.size(); i++) {
-        const BatchSaveInfo& info = i < _proxiesToSave.size()
+        const LayerSavingInfo& info = i < _proxiesToSave.size()
             ? _proxiesToSave[i]
             : _internalProxiesToSave[i - _proxiesToSave.size()];
 

--- a/lib/mayaUsd/nodes/layerManager.h
+++ b/lib/mayaUsd/nodes/layerManager.h
@@ -23,7 +23,9 @@
 #include <pxr/usd/sdf/layer.h>
 #include <pxr/usd/sdf/types.h>
 #include <pxr/usd/usd/prim.h>
+#include <pxr/usd/usd/stage.h>
 
+#include <maya/MDagPath.h>
 #include <maya/MDagPathArray.h>
 #include <maya/MMessage.h>
 #include <maya/MObject.h>
@@ -33,6 +35,7 @@
 
 #include <functional>
 #include <string>
+#include <vector>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -47,7 +50,22 @@ enum BatchSaveResult
     kPartiallyCompleted // Callback has handled the saving of some stages, but not all. Layer
                         // Manager should continue to look for unsaved stages.
 };
-typedef std::function<BatchSaveResult(const MDagPathArray&)> BatchSaveDelegate;
+
+/*! \brief Information about the stages that need to be saved.
+ */
+struct BatchSaveInfo
+{
+    MDagPath    dagPath;
+    UsdStagePtr stage;
+    bool        shareable = true;
+    bool        isIncoming = false;
+};
+
+/*! \brief Callback function to handle saving of Usd edits.  In a default build of the
+    plugin a delegate will be installed that posts a UI dialog that provides an opportunity
+    to choose file names and locations of all anonymous layers that need to be saved to disk.
+ */
+using BatchSaveDelegate = std::function<BatchSaveResult(const std::vector<BatchSaveInfo>&)>;
 
 /*! \brief Maya dependency node responsible for serializing unsaved Usd edits.
 

--- a/lib/mayaUsd/nodes/layerManager.h
+++ b/lib/mayaUsd/nodes/layerManager.h
@@ -53,7 +53,7 @@ enum BatchSaveResult
 
 /*! \brief Information about the stages that need to be saved.
  */
-struct BatchSaveInfo
+struct LayerSavingInfo
 {
     MDagPath    dagPath;
     UsdStagePtr stage;
@@ -65,7 +65,7 @@ struct BatchSaveInfo
     plugin a delegate will be installed that posts a UI dialog that provides an opportunity
     to choose file names and locations of all anonymous layers that need to be saved to disk.
  */
-using BatchSaveDelegate = std::function<BatchSaveResult(const std::vector<BatchSaveInfo>&)>;
+using BatchSaveDelegate = std::function<BatchSaveResult(const std::vector<LayerSavingInfo>&)>;
 
 /*! \brief Maya dependency node responsible for serializing unsaved Usd edits.
 

--- a/lib/mayaUsd/utils/stageCache.h
+++ b/lib/mayaUsd/utils/stageCache.h
@@ -23,6 +23,7 @@
 #include <pxr/usd/usd/stage.h>
 #include <pxr/usd/usd/stageCache.h>
 
+#include <array>
 #include <string>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -30,11 +31,24 @@ PXR_NAMESPACE_OPEN_SCOPE
 class UsdMayaStageCache
 {
 public:
+    /// The shared mode of stage kept in a particular cache.
+    ///
+    /// Shared stages allow staging the same root layer multiple times in Maya
+    /// with the same session layer.
+    ///
+    /// Unshared stages ensure they do not share their session layer.
     enum class ShareMode
     {
         Shared,
         Unshared
     };
+
+    /// Container of caches.
+    using Caches = std::array<UsdStageCache, 4>;
+
+    /// Return all the stage caches.
+    MAYAUSD_CORE_PUBLIC
+    static Caches& GetAllCaches();
 
     /// Return the singleton stage cache for use by all USD clients within Maya.
     /// Four stage caches are maintained. They are divided based on two criteria:

--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -16,11 +16,13 @@
 #include "utilSerialization.h"
 
 #include <mayaUsd/base/tokens.h>
+#include <mayaUsd/utils/stageCache.h>
 #include <mayaUsd/utils/util.h>
 #include <mayaUsd/utils/utilFileSystem.h>
 
 #include <pxr/base/tf/stringUtils.h>
 #include <pxr/usd/sdf/layerUtils.h>
+#include <pxr/usd/usd/stageCacheContext.h>
 #include <pxr/usd/usd/usdFileFormat.h>
 #include <pxr/usd/usd/usdaFileFormat.h>
 #include <pxr/usd/usd/usdcFileFormat.h>
@@ -98,6 +100,21 @@ bool saveRootLayer(SdfLayerRefPtr layer, const std::string& proxy)
     MayaUsd::utils::setNewProxyPath(MString(proxy.c_str()), MString(fp.c_str()));
 
     return true;
+}
+
+void updateAllCachedStageWithLayer(SdfLayerRefPtr originalLayer, const std::string& newFilePath)
+{
+    SdfLayerRefPtr newLayer = SdfLayer::FindOrOpen(newFilePath);
+    for (UsdStageCache& cache : UsdMayaStageCache::GetAllCaches()) {
+        UsdStageCacheContext        ctx(cache);
+        std::vector<UsdStageRefPtr> stages = cache.FindAllMatching(originalLayer);
+        for (const auto& stage : stages) {
+            auto sessionLayer = stage->GetSessionLayer();
+            auto newStage = UsdStage::UsdStage::Open(
+                newLayer, sessionLayer, UsdStage::InitialLoadSet::LoadNone);
+            newStage->SetLoadRules(stage->GetLoadRules());
+        }
+    }
 }
 
 } // namespace
@@ -225,12 +242,20 @@ bool saveLayerWithFormat(
         = requestedFormatArg.empty() ? usdFormatArgOption() : requestedFormatArg;
 
     if (isCompatibleWithSave(layer, filePath, formatArg)) {
-        return layer->Save();
+        if (!layer->Save()) {
+            return false;
+        }
     } else {
         PXR_NS::SdfFileFormat::FileFormatArguments args;
         args["format"] = formatArg;
-        return layer->Export(filePath, "", args);
+        if (!layer->Export(filePath, "", args)) {
+            return false;
+        }
     }
+
+    updateAllCachedStageWithLayer(layer, filePath);
+
+    return true;
 }
 
 SdfLayerRefPtr saveAnonymousLayer(

--- a/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.cpp
+++ b/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.cpp
@@ -33,7 +33,7 @@ void UsdLayerEditor::initialize()
 }
 
 MayaUsd::BatchSaveResult
-UsdLayerEditor::batchSaveLayersUIDelegate(const std::vector<MayaUsd::BatchSaveInfo>& infos)
+UsdLayerEditor::batchSaveLayersUIDelegate(const std::vector<MayaUsd::LayerSavingInfo>& infos)
 {
     if (MGlobal::kInteractive == MGlobal::mayaState()) {
         auto opt = MayaUsd::utils::serializeUsdEditsLocationOption();

--- a/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.cpp
+++ b/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.cpp
@@ -32,7 +32,8 @@ void UsdLayerEditor::initialize()
     }
 }
 
-MayaUsd::BatchSaveResult UsdLayerEditor::batchSaveLayersUIDelegate(const MDagPathArray& proxyShapes)
+MayaUsd::BatchSaveResult
+UsdLayerEditor::batchSaveLayersUIDelegate(const std::vector<MayaUsd::BatchSaveInfo>& infos)
 {
     if (MGlobal::kInteractive == MGlobal::mayaState()) {
         auto opt = MayaUsd::utils::serializeUsdEditsLocationOption();
@@ -46,10 +47,10 @@ MayaUsd::BatchSaveResult UsdLayerEditor::batchSaveLayersUIDelegate(const MDagPat
             // if at least one stage contains anonymous layers, you need to show the comfirm dialog
             // so the user can choose where to save the anonymous layers.
             if (!showConfirmDgl) {
-                for (auto& shape : proxyShapes) {
+                for (const auto& info : infos) {
                     MayaUsd::utils::stageLayersToSave stageLayersToSave;
                     MayaUsd::utils::getLayersToSaveFromProxy(
-                        shape.fullPathName().asChar(), stageLayersToSave);
+                        info.dagPath.fullPathName().asChar(), stageLayersToSave);
                     if (!stageLayersToSave._anonLayers.empty()) {
                         showConfirmDgl = true;
                         break;
@@ -58,7 +59,7 @@ MayaUsd::BatchSaveResult UsdLayerEditor::batchSaveLayersUIDelegate(const MDagPat
             }
 
             if (showConfirmDgl) {
-                UsdLayerEditor::SaveLayersDialog dlg(nullptr, proxyShapes);
+                UsdLayerEditor::SaveLayersDialog dlg(nullptr, infos);
 
                 // The SaveLayers dialog only handles choosing new names for anonymous layers and
                 // making sure that they are remapped correctly in either their parent layer or by

--- a/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.h
+++ b/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.h
@@ -36,7 +36,7 @@ void initialize();
 
 MAYAUSD_UI_PUBLIC
 MayaUsd::BatchSaveResult
-batchSaveLayersUIDelegate(const std::vector<MayaUsd::BatchSaveInfo>& infos);
+batchSaveLayersUIDelegate(const std::vector<MayaUsd::LayerSavingInfo>& infos);
 
 } // namespace UsdLayerEditor
 

--- a/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.h
+++ b/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.h
@@ -35,7 +35,8 @@ MAYAUSD_UI_PUBLIC
 void initialize();
 
 MAYAUSD_UI_PUBLIC
-MayaUsd::BatchSaveResult batchSaveLayersUIDelegate(const MDagPathArray&);
+MayaUsd::BatchSaveResult
+batchSaveLayersUIDelegate(const std::vector<MayaUsd::BatchSaveInfo>& infos);
 
 } // namespace UsdLayerEditor
 

--- a/lib/usd/ui/layerEditor/saveLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.cpp
@@ -227,28 +227,28 @@ public:
 namespace UsdLayerEditor {
 
 #if defined(WANT_UFE_BUILD)
-SaveLayersDialog::SaveLayersDialog(QWidget* in_parent, const MDagPathArray& proxyShapes)
+SaveLayersDialog::SaveLayersDialog(
+    QWidget*                                   in_parent,
+    const std::vector<MayaUsd::BatchSaveInfo>& infos)
     : QDialog(in_parent)
     , _sessionState(nullptr)
 {
     MString msg, nbStages;
 
-    nbStages = proxyShapes.length();
+    nbStages = infos.size();
     msg.format(StringResources::getAsMString(StringResources::kSaveXStages), nbStages);
     setWindowTitle(MQtUtil::toQString(msg));
 
     // For each stage collect the layers to save.
-    for (const auto& shape : proxyShapes) {
+    for (const auto& info : infos) {
 
-        getLayersToSave(shape.fullPathName().asChar(), shape.partialPathName().asChar());
+        getLayersToSave(
+            info.dagPath.fullPathName().asChar(), info.dagPath.partialPathName().asChar());
     }
 
     QString msg1, msg2;
     getDialogMessages(
-        static_cast<int>(proxyShapes.length()),
-        static_cast<int>(_anonLayerPairs.size()),
-        msg1,
-        msg2);
+        static_cast<int>(infos.size()), static_cast<int>(_anonLayerPairs.size()), msg1, msg2);
     buildDialog(msg1, msg2);
 }
 #endif

--- a/lib/usd/ui/layerEditor/saveLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.cpp
@@ -228,8 +228,8 @@ namespace UsdLayerEditor {
 
 #if defined(WANT_UFE_BUILD)
 SaveLayersDialog::SaveLayersDialog(
-    QWidget*                                   in_parent,
-    const std::vector<MayaUsd::BatchSaveInfo>& infos)
+    QWidget*                                     in_parent,
+    const std::vector<MayaUsd::LayerSavingInfo>& infos)
     : QDialog(in_parent)
     , _sessionState(nullptr)
 {

--- a/lib/usd/ui/layerEditor/saveLayersDialog.h
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.h
@@ -35,7 +35,7 @@ public:
 
 #if defined(WANT_UFE_BUILD)
     // Create dialog for bulk save using all provided proxy shapes and their owned stages.
-    SaveLayersDialog(QWidget* in_parent, const std::vector<MayaUsd::BatchSaveInfo>& infos);
+    SaveLayersDialog(QWidget* in_parent, const std::vector<MayaUsd::LayerSavingInfo>& infos);
 #endif
 
     ~SaveLayersDialog();

--- a/lib/usd/ui/layerEditor/saveLayersDialog.h
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.h
@@ -1,6 +1,9 @@
 #ifndef SAVELAYERSDIALOG_H
 #define SAVELAYERSDIALOG_H
 
+#if defined(WANT_UFE_BUILD)
+#include <mayaUsd/nodes/layerManager.h>
+#endif
 #include <mayaUsd/utils/utilSerialization.h>
 
 #include <pxr/usd/sdf/layer.h>
@@ -32,7 +35,7 @@ public:
 
 #if defined(WANT_UFE_BUILD)
     // Create dialog for bulk save using all provided proxy shapes and their owned stages.
-    SaveLayersDialog(QWidget* in_parent, const MDagPathArray& proxyShapes);
+    SaveLayersDialog(QWidget* in_parent, const std::vector<MayaUsd::BatchSaveInfo>& infos);
 #endif
 
     ~SaveLayersDialog();

--- a/test/lib/mayaUsd/nodes/testLayerManagerSerialization.py
+++ b/test/lib/mayaUsd/nodes/testLayerManagerSerialization.py
@@ -185,7 +185,7 @@ class testLayerManagerSerialization(unittest.TestCase):
         self.assertTrue(stage.GetPrimAtPath(newPrimPath))
 
         newPrimPath = "/ChangeInSessionLayer"
-        self.assertFalse(stage.GetPrimAtPath(newPrimPath))
+        self.assertTrue(stage.GetPrimAtPath(newPrimPath))
 
         self.confirmEditsSavedStatus(True, False)
 

--- a/test/lib/mayaUsd/nodes/testProxyShapeBase.py
+++ b/test/lib/mayaUsd/nodes/testProxyShapeBase.py
@@ -23,9 +23,8 @@ import fixturesUtils
 
 import os
 import unittest
-import tempfile
 
-import usdUtils, mayaUtils, ufeUtils
+import usdUtils, mayaUtils, ufeUtils, testUtils
 
 import ufe
 import mayaUsd.ufe
@@ -334,24 +333,25 @@ class testProxyShapeBase(unittest.TestCase):
         verifyPrim()
 
         # Temp file names for Maya scene and USD file.
-        testDir = tempfile.mkdtemp(prefix='ProxyShapeBase')
-        tempMayaFile = os.path.join(testDir, 'SaveStagePreserveSessionLayerTest.ma')
-        tempUSDFile = os.path.join(testDir, 'SaveStagePreserveSessionLayer.usd')
+        with testUtils.TemporaryDirectory(prefix='ProxyShapeBase', ignore_errors=True) as testDir:
+            targetName = 'Root' if targetRoot else 'Session'
+            inMayaName = 'InMaya' if saveInMaya else 'InUSD'
+            tempMayaFile = os.path.join(testDir, 'SaveStagePreserve%s%s.ma' % (targetName, inMayaName))
 
-        # Make sure layers are saved to the desired location (Maya or USD)
-        # when the Maya scene is saved.
-        location = 2 if saveInMaya else 1
-        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', location))
-        if not saveInMaya:
-            cmds.setAttr('{}.{}'.format(proxyShapePath,"filePath"), tempUSDFile, type='string')
+            # Make sure layers are saved to the desired location (Maya or USD)
+            # when the Maya scene is saved.
+            location = 2 if saveInMaya else 1
+            cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', location))
 
-        # Save the stage.
-        cmds.file(rename=tempMayaFile)
-        cmds.file(save=True, force=True)
+            # Save the stage.
+            cmds.file(rename=tempMayaFile)
+            cmds.file(save=True, force=True, type='mayaAscii')
 
-        # Verify that the prim is still inactive in the target layer.
+            # Verify that the prim is still inactive in the target layer.
 
-        verifyPrim()
+            verifyPrim()
+
+            cmds.file(new=True, force=True)
 
     def testSaveStageToUSDPreserveSessionLayer(self):
         '''
@@ -508,37 +508,39 @@ class testProxyShapeBase(unittest.TestCase):
         rootLayer.subLayerPaths  = [middleLayer.identifier]
 
         # Save and re-open
-        testDir = tempfile.mkdtemp(prefix='ProxyShapeBase')
-        tempMayaFile = os.path.join(testDir, 'ShareStageSerializationTest.ma')
-        cmds.file(rename=tempMayaFile)
-        # make the USD layer absolute otherwise it won't be found
-        cmds.setAttr('{}.{}'.format(proxyShapePath,"filePath"), originalRootIdentifier, type='string')
-        cmds.file(save=True, force=True)
-        cmds.file(new=True, force=True)
-        cmds.file(tempMayaFile, open=True)
+        with testUtils.TemporaryDirectory(prefix='ProxyShapeBase') as testDir:
+            tempMayaFile = os.path.join(testDir, 'ShareStageSerializationTest.ma')
+            cmds.file(rename=tempMayaFile)
+            # make the USD layer absolute otherwise it won't be found
+            cmds.setAttr('{}.{}'.format(proxyShapePath,"filePath"), originalRootIdentifier, type='string')
+            cmds.file(save=True, force=True)
+            cmds.file(new=True, force=True)
+            cmds.file(tempMayaFile, open=True)
 
-        # get the stage again (since we opened a new file)
-        proxyShapes = cmds.ls(type="mayaUsdProxyShapeBase", long=True)
-        proxyShapePath = proxyShapes[0]
-        stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
-        rootLayer = stage.GetRootLayer()
+            # get the stage again (since we opened a new file)
+            proxyShapes = cmds.ls(type="mayaUsdProxyShapeBase", long=True)
+            proxyShapePath = proxyShapes[0]
+            stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
+            rootLayer = stage.GetRootLayer()
 
-        # make sure the middle layer is back (only one)
-        self.assertEqual(len(rootLayer.subLayerPaths), 1)
-        middleLayer = Sdf.Layer.Find(rootLayer.subLayerPaths[0])
-        self.assertEqual(middleLayer.GetDisplayName(), "middleLayer")
+            # make sure the middle layer is back (only one)
+            self.assertEqual(len(rootLayer.subLayerPaths), 1)
+            middleLayer = Sdf.Layer.Find(rootLayer.subLayerPaths[0])
+            self.assertEqual(middleLayer.GetDisplayName(), "middleLayer")
 
-        # make sure the middle layer still contains the original root only
-        self.assertEqual(len(middleLayer.subLayerPaths), 1)
-        self.assertEqual(middleLayer.subLayerPaths[0], originalRootIdentifier)
+            # make sure the middle layer still contains the original root only
+            self.assertEqual(len(middleLayer.subLayerPaths), 1)
+            self.assertEqual(middleLayer.subLayerPaths[0], originalRootIdentifier)
 
-        # re-share the stage
-        cmds.setAttr('{}.{}'.format(proxyShapePath,"shareStage"), True)
-        stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
+            # re-share the stage
+            cmds.setAttr('{}.{}'.format(proxyShapePath,"shareStage"), True)
+            stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
 
-        # check that the stage is now shared again and the identifier is correct
-        self.assertTrue(cmds.getAttr('{}.{}'.format(proxyShapePath,"shareStage")))
-        self.assertEqual(stage.GetRootLayer().identifier, originalRootIdentifier)
+            # check that the stage is now shared again and the identifier is correct
+            self.assertTrue(cmds.getAttr('{}.{}'.format(proxyShapePath,"shareStage")))
+            self.assertEqual(stage.GetRootLayer().identifier, originalRootIdentifier)
+
+            cmds.file(new=True, force=True)
 
     def testShareStageComplexHierarchyToggle(self):
         '''
@@ -576,44 +578,46 @@ class testProxyShapeBase(unittest.TestCase):
         rootLayer.subLayerPaths  = [middleLayer.identifier]
 
          # Save and re-open
-        testDir = tempfile.mkdtemp(prefix='ProxyShapeBase')
-        tempMayaFile = os.path.join(testDir, 'ShareStageComplexHierarchyToggle.ma')
-        cmds.file(rename=tempMayaFile)
-        # make the USD layer absolute otherwise it won't be found
-        cmds.setAttr('{}.{}'.format(proxyShapePath,"filePath"), originalRootIdentifier, type='string')
-        cmds.file(save=True, force=True)
-        cmds.file(new=True, force=True)
-        cmds.file(tempMayaFile, open=True)
+        with testUtils.TemporaryDirectory(prefix='ProxyShapeBase') as testDir:
+            tempMayaFile = os.path.join(testDir, 'ShareStageComplexHierarchyToggle.ma')
+            cmds.file(rename=tempMayaFile)
+            # make the USD layer absolute otherwise it won't be found
+            cmds.setAttr('{}.{}'.format(proxyShapePath,"filePath"), originalRootIdentifier, type='string')
+            cmds.file(save=True, force=True)
+            cmds.file(new=True, force=True)
+            cmds.file(tempMayaFile, open=True)
 
-        # get the stage again (since we opened a new file)
-        proxyShapes = cmds.ls(type="mayaUsdProxyShapeBase", long=True)
-        proxyShapePath = proxyShapes[0]
-        stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
-        rootLayer = stage.GetRootLayer()
+            # get the stage again (since we opened a new file)
+            proxyShapes = cmds.ls(type="mayaUsdProxyShapeBase", long=True)
+            proxyShapePath = proxyShapes[0]
+            stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
+            rootLayer = stage.GetRootLayer()
 
-        # make sure the middle layer is back (only one)
-        self.assertEqual(len(rootLayer.subLayerPaths), 1)
-        middleLayer = Sdf.Layer.Find(rootLayer.subLayerPaths[0])
-        self.assertEqual(middleLayer.GetDisplayName(), "middleLayer")
+            # make sure the middle layer is back (only one)
+            self.assertEqual(len(rootLayer.subLayerPaths), 1)
+            middleLayer = Sdf.Layer.Find(rootLayer.subLayerPaths[0])
+            self.assertEqual(middleLayer.GetDisplayName(), "middleLayer")
 
-        # re-share the stage
-        cmds.setAttr('{}.{}'.format(proxyShapePath,"shareStage"), True)
-        stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
+            # re-share the stage
+            cmds.setAttr('{}.{}'.format(proxyShapePath,"shareStage"), True)
+            stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
 
-        # check that the stage is now shared again and the identifier is correct
-        self.assertTrue(cmds.getAttr('{}.{}'.format(proxyShapePath,"shareStage")))
-        self.assertEqual(stage.GetRootLayer().identifier, originalRootIdentifier)
+            # check that the stage is now shared again and the identifier is correct
+            self.assertTrue(cmds.getAttr('{}.{}'.format(proxyShapePath,"shareStage")))
+            self.assertEqual(stage.GetRootLayer().identifier, originalRootIdentifier)
 
-        # unshare the stage
-        cmds.setAttr('{}.{}'.format(proxyShapePath,"shareStage"), False)
-        stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
-        rootLayer = stage.GetRootLayer()
+            # unshare the stage
+            cmds.setAttr('{}.{}'.format(proxyShapePath,"shareStage"), False)
+            stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
+            rootLayer = stage.GetRootLayer()
 
-        # check that the stage is now shared and the root is the anon layer
-        # and the old root is now sublayered under that
-        self.assertFalse(cmds.getAttr('{}.{}'.format(proxyShapePath,"shareStage")))
-        self.assertEqual(rootLayer.GetDisplayName(), "unshareableLayer")
-        self.assertEqual(rootLayer.subLayerPaths, [middleLayer.identifier])
+            # check that the stage is now shared and the root is the anon layer
+            # and the old root is now sublayered under that
+            self.assertFalse(cmds.getAttr('{}.{}'.format(proxyShapePath,"shareStage")))
+            self.assertEqual(rootLayer.GetDisplayName(), "unshareableLayer")
+            self.assertEqual(rootLayer.subLayerPaths, [middleLayer.identifier])
+
+            cmds.file(new=True, force=True)
 
     def testShareStageSourceChange(self):
         '''

--- a/test/testUtils/testUtils.py
+++ b/test/testUtils/testUtils.py
@@ -19,7 +19,8 @@
 """
 
 import os
-
+import shutil
+import tempfile
 
 def stripPrefix(input_str, prefix):
     if input_str.startswith(prefix):
@@ -45,3 +46,25 @@ def assertVectorEqual(testCase, a, b):
 
 def getTestScene(*args):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "testSamples", *args)
+
+class TemporaryDirectory:
+    '''
+    Context manager that creates a temporary directory and deletes it on exit,
+    so it's usable with "with" statement.
+    '''
+    def __init__(self, suffix=None, prefix=None, ignore_errors=True, keep_files=False):
+        self.name = tempfile.mkdtemp(suffix=suffix, prefix=prefix)
+        self.ignore_errors = ignore_errors
+        self.keep_files = keep_files
+
+    def __enter__(self):
+        return self.name
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.keep_files:
+            return
+        try:
+            shutil.rmtree(self.name)
+        except:
+            if not self.ignore_errors:
+                raise


### PR DESCRIPTION
When a new stage with an anonymous root layer is saved for the first time, the session layer was lost.

The reason was that when a new stage is saved, its root layer change ID. When the proxy shape was recomputed, it tried to find the root layer with the new ID in the stage cache. Since the just-saved stage was previously using an anonymous root layer, the cache did not find the just-saved stage. A new stage got created, which meant it got a brand new empty session layer.

This recomputation happened mid-save.

The fix is to avoid recomputing the proxy stage mid-save and to pre-fill the stage cache with the newly-saved root with its new ID and with the pre-existing session layer. This requires keeping more information when initially gathering the layers to be saved to avoid touching the proxy shape again during the save.

- Add BatchSaveInfo to the layer manager to cache all info necessary during saving.
- Pass these info instead of only the DAG path to callbacks and various internal functions.
- Have the LayerDatabase fill this info when gathering layers to save.
- Avoid calling getProxiesToSave() mid-save.
- Add hasDirtyLayer() to support the previous point.
- Refactor clearing proxies to save into its own function to avoid code duplication.
- Add GetAllCaches() to UsdMayaStageCache to allow access to all caches without knowing the details of how caches are segregated.
- When saving a layer, prefill all stage caches that were holding the stages that were using the original layer to now cache a stage that uses the new layer and the session layer of the existing stage.
- This will allow the proxy shape to find these stage with the correct session layer when recomputed later.
- Update the batch save layer UI to the new API with BatchSaveInfo.
- Add a unit test for session layer in save

Furthermore, the layer manager would not save the session layer of the stage in the Maya scene file when the layers were being saved to external USD files.

There were two problems: the session layer name was not being set on the stage proxy node and the layer manager was not saved to the Maya scene.

The layer manager node would be lost when saving layer to separate USD files. (Actually, this one but one possible case where the layer manager would be lost.) The reason was that the layer manager node would be deleted mid-save because some other code happened to access the stage while the stage was dirty, which would cause the DG to re-compute the stage node, which would access layers in the layer manager, which would wipe the layer manager node. And all this was dependent on the order some save callbacks were being called.

To avoid this, we now no longer wipe the layer manager node when in the middle of a save operation.

Also, improved the proxy shape test to cleanup after themselves, deleting their temp files.