### PR TITLE
MAYA-124244 MacOS: mayausd doesn't load on older Mac systems. (10.15.7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,10 +56,14 @@ set(PXR_OVERRIDE_PLUGINPATH_NAME PXR_PLUGINPATH_NAME
 # Avoid noisy install messages
 set(CMAKE_INSTALL_MESSAGE "NEVER")
 
-if (BUILD_UB2)
-    set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
-else()
-    set(CMAKE_OSX_ARCHITECTURES "x86_64")
+if(APPLE)
+    if(BUILD_UB2)
+        set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
+        set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0)
+    else()
+        set(CMAKE_OSX_ARCHITECTURES "x86_64")
+        set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14)
+    endif()
 endif()
 
 set(CMAKE_MODULE_PATH


### PR DESCRIPTION
CMAKE_OSX_DEPLOYMENT_TARGET set as in Maya, 11.0 for UB2 otherwise10.14