### PR TITLE
Fix attribute creation on connect

### DIFF
--- a/lib/mayaUsd/ufe/UsdAttribute.cpp
+++ b/lib/mayaUsd/ufe/UsdAttribute.cpp
@@ -712,6 +712,10 @@ bool UsdAttribute::hasMetadata(const std::string& key) const
 }
 #endif
 
+#ifdef UFE_V4_FEATURES_AVAILABLE
+PXR_NS::SdfValueTypeName UsdAttribute::usdAttributeType() const { return ufeTypeToUsd(typeName()); }
+#endif
+
 //------------------------------------------------------------------------------
 // UsdAttributeGeneric:
 //------------------------------------------------------------------------------

--- a/lib/mayaUsd/ufe/UsdAttribute.h
+++ b/lib/mayaUsd/ufe/UsdAttribute.h
@@ -134,8 +134,9 @@ public:
     bool                      _clearMetadata(const std::string& key);
     bool                      _hasMetadata(const std::string& key) const;
 
-    PXR_NS::UsdPrim      usdPrim() const { return fPrim; }
-    PXR_NS::UsdAttribute usdAttribute() const { return fUsdAttr; }
+    PXR_NS::UsdPrim          usdPrim() const { return fPrim; }
+    PXR_NS::UsdAttribute     usdAttribute() const { return fUsdAttr; }
+    PXR_NS::SdfValueTypeName usdAttributeType() const;
 #else
     // Ufe::Attribute override methods that we've mimic'd here.
     bool                      hasValue() const;

--- a/lib/mayaUsd/ufe/UsdConnectionHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdConnectionHandler.cpp
@@ -141,6 +141,10 @@ bool UsdConnectionHandler::createConnection(
                 PXR_NS::SdrShaderNodeConstPtr srcShaderNodeDef
                     = registry.GetShaderNodeByIdentifier(srcInfoId);
                 if (!srcShaderNodeDef) {
+                    TF_RUNTIME_ERROR(
+                        "Could not find node definition '%s' for node '%s'.",
+                        srcInfoId.GetText(),
+                        Ufe::PathString::string(srcAttr->sceneItem()->path()).c_str());
                     return false;
                 }
                 TfToken renderContext = srcShaderNodeDef->GetSourceType() == "glslfx"

--- a/lib/mayaUsd/ufe/UsdConnectionHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdConnectionHandler.cpp
@@ -96,6 +96,12 @@ bool UsdConnectionHandler::createConnection(
         return false;
     }
 
+    // Use the UsdShadeConnectableAPI to create the connections and attributes to make sure the USD
+    // data model ends up in the right state.
+    //
+    // Using lower level APIs, like UsdPrim::CreateAttribute() tend leave the attributes marked as
+    // being custom instead of native.
+
     UsdShadeConnectableAPI srcApi(srcUsdAttr->usdPrim());
     TfToken                srcBaseName;
     UsdShadeAttributeType  srcAttrType;

--- a/test/lib/ufe/testConnections.py
+++ b/test/lib/ufe/testConnections.py
@@ -22,7 +22,6 @@ import usdUtils
 import testUtils
 
 from maya import cmds
-from maya.internal.ufeSupport import ufeCmdWrapper as ufeCmd
 
 import ufe
 import unittest
@@ -429,6 +428,8 @@ class ConnectionTestCase(unittest.TestCase):
         #
         # We start with standard code from testContextOps:
         #
+        # Not testing undo/redo at this point in time.
+        #
         #
         cmds.file(new=True, force=True)
 
@@ -442,10 +443,8 @@ class ConnectionTestCase(unittest.TestCase):
         proxyShapeItem = ufe.Hierarchy.createItem(proxyShapePath)
         contextOps = ufe.ContextOps.contextOps(proxyShapeItem)
 
-        cmd = contextOps.doOpCmd(['Add New Prim', 'Capsule'])
-        ufeCmd.execute(cmd)
-        cmd = contextOps.doOpCmd(['Add New Prim', 'Material'])
-        ufeCmd.execute(cmd)
+        cmd = contextOps.doOp(['Add New Prim', 'Capsule'])
+        cmd = contextOps.doOp(['Add New Prim', 'Material'])
 
         rootHier = ufe.Hierarchy.hierarchy(proxyShapeItem)
 
@@ -453,8 +452,7 @@ class ConnectionTestCase(unittest.TestCase):
         materialAttrs = ufe.Attributes.attributes(materialItem)
         contextOps = ufe.ContextOps.contextOps(materialItem)
 
-        cmd = contextOps.doOpCmd(['Add New Prim', 'Shader'])
-        ufeCmd.execute(cmd)
+        cmd = contextOps.doOp(['Add New Prim', 'Shader'])
 
         materialHier = ufe.Hierarchy.hierarchy(materialItem)
         materialPrim = usdUtils.getPrimFromSceneItem(materialItem)

--- a/test/lib/ufe/testConnections.py
+++ b/test/lib/ufe/testConnections.py
@@ -480,7 +480,7 @@ class ConnectionTestCase(unittest.TestCase):
         # The attributes are not created yet:
         self.assertEqual(len(materialPrim.GetAuthoredProperties()), 0)
         self.assertEqual(len(shaderPrim.GetAuthoredProperties()), 1)
-        self.assertIn("info:id", [i.GetName() for i in shaderPrim.GetAuthoredProperties()])
+        self.assertEqual("info:id", shaderPrim.GetAuthoredProperties()[0].GetName())
 
         connectionHandler.connect(shaderOutput, materialOutput)
 

--- a/test/lib/ufe/testConnections.py
+++ b/test/lib/ufe/testConnections.py
@@ -18,9 +18,11 @@
 
 import mayaUtils
 import ufeUtils
+import usdUtils
 import testUtils
 
 from maya import cmds
+from maya.internal.ufeSupport import ufeCmdWrapper as ufeCmd
 
 import ufe
 import unittest
@@ -420,6 +422,100 @@ class ConnectionTestCase(unittest.TestCase):
         self.assertIsNotNone(connections)
         conns = connections.allConnections()
         self.assertEqual(len(conns), 1)
+
+    def testCreateStandardSurface(self):
+        '''Test create a working standard surface shader.'''
+        #
+        #
+        # We start with standard code from testContextOps:
+        #
+        #
+        cmds.file(new=True, force=True)
+
+        # Create a proxy shape with empty stage to start with.
+        import mayaUsd_createStageWithNewLayer
+        proxyShape = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+
+        # Create a ContextOps interface for the proxy shape.
+        proxyPathSegment = mayaUtils.createUfePathSegment(proxyShape)
+        proxyShapePath = ufe.Path([proxyPathSegment])
+        proxyShapeItem = ufe.Hierarchy.createItem(proxyShapePath)
+        contextOps = ufe.ContextOps.contextOps(proxyShapeItem)
+
+        cmd = contextOps.doOpCmd(['Add New Prim', 'Capsule'])
+        ufeCmd.execute(cmd)
+        cmd = contextOps.doOpCmd(['Add New Prim', 'Material'])
+        ufeCmd.execute(cmd)
+
+        rootHier = ufe.Hierarchy.hierarchy(proxyShapeItem)
+
+        materialItem = rootHier.children()[-1]
+        materialAttrs = ufe.Attributes.attributes(materialItem)
+        contextOps = ufe.ContextOps.contextOps(materialItem)
+
+        cmd = contextOps.doOpCmd(['Add New Prim', 'Shader'])
+        ufeCmd.execute(cmd)
+
+        materialHier = ufe.Hierarchy.hierarchy(materialItem)
+        materialPrim = usdUtils.getPrimFromSceneItem(materialItem)
+
+
+        shaderItem = materialHier.children()[0]
+        shaderAttrs = ufe.Attributes.attributes(shaderItem)
+        shaderPrim = usdUtils.getPrimFromSceneItem(shaderItem)
+
+        shaderAttr = shaderAttrs.attribute("info:id")
+        shaderAttr.set("ND_standard_surface_surfaceshader")
+        #
+        #
+        # Then switch to connection code to connect the shader. Since we never created the
+        # attributes, we expect the connection code to create them.
+        #
+        #
+        shaderOutput = shaderAttrs.attribute("outputs:out")
+        materialOutput = materialAttrs.attribute("outputs:surface")
+
+        connectionHandler = ufe.RunTimeMgr.instance().connectionHandler(materialItem.runTimeId())
+
+        # The attributes are not created yet:
+        self.assertEqual(len(materialPrim.GetAuthoredProperties()), 0)
+        self.assertEqual(len(shaderPrim.GetAuthoredProperties()), 1)
+        self.assertIn("info:id", [i.GetName() for i in shaderPrim.GetAuthoredProperties()])
+
+        connectionHandler.connect(shaderOutput, materialOutput)
+
+        connections = connectionHandler.sourceConnections(materialItem)
+        self.assertIsNotNone(connections)
+        conns = connections.allConnections()
+        self.assertEqual(len(conns), 1)
+
+        # The attributes directly used by the connection got created:
+        self.assertEqual(len(shaderPrim.GetAuthoredProperties()), 2)
+        self.assertIn("info:id", [i.GetName() for i in shaderPrim.GetAuthoredProperties()])
+        self.assertIn("outputs:out", [i.GetName() for i in shaderPrim.GetAuthoredProperties()])
+        # The connection of a MaterialX shader to the material got redirected to the proper render context.
+        self.assertEqual(len(materialPrim.GetAuthoredProperties()), 1)
+        self.assertEqual(materialPrim.GetAuthoredProperties()[0].GetName(), "outputs:mtlx:surface")
+
+        materialOutput = materialAttrs.attribute("outputs:mtlx:surface")
+        connectionHandler.disconnect(shaderOutput, materialOutput)
+
+        connections = connectionHandler.sourceConnections(materialItem)
+        self.assertIsNotNone(connections)
+        conns = connections.allConnections()
+        self.assertEqual(len(conns), 0)
+
+        # Not redirected since already on outputs:mtlx:surface:
+        connectionHandler.connect(shaderOutput, materialOutput)
+
+        connections = connectionHandler.sourceConnections(materialItem)
+        self.assertIsNotNone(connections)
+        conns = connections.allConnections()
+        self.assertEqual(len(conns), 1)
+
+        # TODO: Test the undoable versions of these commands. They MUST restore the prims as they
+        #       were before connecting, which might require deleting authored attributes.
+        #       The undo must also be aware that the connection on the material got redirected.
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
 - When unauthored attributes get connected, they must become authored.
 - When Material outputs are connected, we need to check the render context of the source node and use the right render context