### PR TITLE
Check for invalid prim

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -803,6 +803,9 @@ void ProxyRenderDelegate::_UpdateSceneDelegate()
 #ifdef MAYA_HAS_DISPLAY_LAYER_API
 void ProxyRenderDelegate::_DirtyUsdSubtree(const UsdPrim& prim)
 {
+    if (!prim.IsValid())
+        return;
+
     HdChangeTracker&      changeTracker = _renderIndex->GetChangeTracker();
     constexpr HdDirtyBits dirtyBits = HdChangeTracker::DirtyVisibility
         | MayaUsdRPrim::DirtyDisplayMode | MayaUsdRPrim::DirtySelectionHighlight;


### PR DESCRIPTION
Check for invalid prim, which is possible from Display Layer that contains invalid paths (because of Variant Change).