### PR TITLE
MAYA-124458 - When caching to USD, 'Prim Name' is disabled when Define in Variant is selected

### DIFF
--- a/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
@@ -169,7 +169,6 @@ def variantOrNewPrim(buttonChecked):
     variantSelected = cmds.radioButtonGrp('variantRadioButton', query=True, select=1)
     cmds.rowLayout('usdCacheVariantSetRow', edit=True, enable=variantSelected)
     cmds.rowLayout('usdCacheVariantNameRow', edit=True, enable=variantSelected)
-    cmds.textFieldGrp('primNameText', edit=True, enable=not variantSelected)
 
 def cacheFileUsdHierarchyOptions(topForm):
     '''Create controls to insert Maya reference USD cache into USD hierarchy.'''


### PR DESCRIPTION
Removed the code which disabled this field. Just leave the field enabled all the time.