### PR TITLE
Author normalization attribute when exporting RfM Lights

### DIFF
--- a/lib/mayaUsd/fileio/translators/translatorRfMLight.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorRfMLight.cpp
@@ -126,6 +126,7 @@ TF_DEFINE_PRIVATE_TOKENS(
     ((ConeSoftnessPlugName, "coneSoftness"))
     ((ProfileFilePlugName, "iesProfile"))
     ((ProfileScalePlugName, "iesProfileScale"))
+    ((ProfileNormalizePlugName, "iesProfileNormalize"))
 
     // ShadowAPI plug names.
     ((EnableShadowsPlugName, "enableShadows"))
@@ -1587,6 +1588,23 @@ static bool _WriteLightShapingAPI(const MFnDependencyNode& depFn, UsdLuxLightAPI
         shapingAPI.CreateShapingIesAngleScaleAttr(VtValue(mayaLightProfileScale), true);
     }
 
+    // Profile Normalize.
+    MPlug lightProfileNormalizePlug
+        = depFn.findPlug(_tokens->ProfileNormalizePlugName.GetText(), &status);
+    if (status != MS::kSuccess) {
+        return false;
+    }
+
+    if (UsdMayaUtil::IsAuthored(lightProfileNormalizePlug)) {
+        bool mayaLightProfileNormalize = false;
+        status = lightProfileNormalizePlug.getValue(mayaLightProfileNormalize);
+        if (status != MS::kSuccess) {
+            return false;
+        }
+
+        shapingAPI.CreateShapingIesNormalizeAttr(VtValue(mayaLightProfileNormalize), true);
+    }
+
     return true;
 }
 
@@ -1686,6 +1704,18 @@ static bool _ReadLightShapingAPI(const UsdLuxLightAPI& lightSchema, MFnDependenc
     shapingAPI.GetShapingIesAngleScaleAttr().Get(&lightProfileScale);
 
     status = lightProfileScalePlug.setValue(lightProfileScale);
+
+    // Profile Normalize.
+    MPlug lightProfileNormalizePlug
+        = depFn.findPlug(_tokens->ProfileNormalizePlugName.GetText(), &status);
+    if (status != MS::kSuccess) {
+        return false;
+    }
+
+    bool lightProfileNormalize = false;
+    shapingAPI.GetShapingIesNormalizeAttr().Get(&lightProfileNormalize);
+
+    status = lightProfileNormalizePlug.setValue(lightProfileNormalize);
     return status == MS::kSuccess;
 }
 

--- a/test/lib/usd/translators/testUsdImportRfMLight.py
+++ b/test/lib/usd/translators/testUsdImportRfMLight.py
@@ -320,6 +320,10 @@ class testUsdImportRfMLight(unittest.TestCase):
         self.assertTrue(Gf.IsClose(cmds.getAttr('%s.iesProfileScale' % nodePath),
             expectedProfileScale, 1e-6))
 
+        expectedProfileNormalize = False
+        self.assertEqual(cmds.getAttr('%s.iesProfileNormalize' % nodePath),
+            expectedProfileNormalize)
+
     def _ValidateMayaLightShadow(self):
         nodePath = '|RfMLightsTest|Lights|RectLight|RectLightShape'
 


### PR DESCRIPTION
Keep translator code in sync with the usdLux schema and args file.
Ideally we wouldn't need to keep these in sync manually, so we're
considering a future change to use Sdr to do this for us.