### PR TITLE
Maya-121636 parenting scope tests

### DIFF
--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -138,6 +138,14 @@ if(CMAKE_UFE_V4_FEATURES_AVAILABLE)
                 UsdConnectionHandler.cpp
         )
     endif()
+
+    if(${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4025)
+        target_sources(${PROJECT_NAME}
+            PRIVATE
+            UsdTransform3dRead.cpp
+        )
+    endif()
+
 endif()
 
 if(PXR_VERSION GREATER_EQUAL 2108)
@@ -226,7 +234,7 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
     )
 endif()
 
-if (UFE_LIGHTS_SUPPORT)
+if(UFE_LIGHTS_SUPPORT)
     list(APPEND HEADERS
         UsdLight.h
         UsdLightHandler.h
@@ -264,6 +272,12 @@ if(CMAKE_UFE_V4_FEATURES_AVAILABLE)
         list(APPEND HEADERS
             UsdConnections.h
             UsdConnectionHandler.h
+        )
+    endif()
+
+    if(${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4025)
+        list(APPEND HEADERS
+            UsdTransform3dRead.h
         )
     endif()
 endif()

--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -3,164 +3,163 @@
 # -----------------------------------------------------------------------------
 target_sources(${PROJECT_NAME}
     PRIVATE
-    Global.cpp
-    ProxyShapeHandler.cpp
-    ProxyShapeHierarchy.cpp
-    ProxyShapeHierarchyHandler.cpp
-    StagesSubject.cpp
-    UsdHierarchy.cpp
-    UsdHierarchyHandler.cpp
-    UsdPointInstanceOrientationModifier.cpp
-    UsdPointInstancePositionModifier.cpp
-    UsdPointInstanceScaleModifier.cpp
-    UsdRootChildHierarchy.cpp
-    UsdRotatePivotTranslateUndoableCommand.cpp
-    UsdRotateUndoableCommand.cpp
-    UsdScaleUndoableCommand.cpp
-    UsdSceneItem.cpp
-    UsdSceneItemOps.cpp
-    UsdSceneItemOpsHandler.cpp
-    UsdStageMap.cpp
-    UsdTRSUndoableCommandBase.cpp
-    UsdTransform3d.cpp
-    UsdTransform3dHandler.cpp
-    UsdTranslateUndoableCommand.cpp
-    UsdUndoDeleteCommand.cpp
-    UsdUndoDuplicateCommand.cpp
-    UsdUndoRenameCommand.cpp
-    Utils.cpp
-    moduleDeps.cpp
+        Global.cpp
+        ProxyShapeHandler.cpp
+        ProxyShapeHierarchy.cpp
+        ProxyShapeHierarchyHandler.cpp
+        StagesSubject.cpp
+        UsdHierarchy.cpp
+        UsdHierarchyHandler.cpp
+        UsdPointInstanceOrientationModifier.cpp
+        UsdPointInstancePositionModifier.cpp
+        UsdPointInstanceScaleModifier.cpp
+        UsdRootChildHierarchy.cpp
+        UsdRotatePivotTranslateUndoableCommand.cpp
+        UsdRotateUndoableCommand.cpp
+        UsdScaleUndoableCommand.cpp
+        UsdSceneItem.cpp
+        UsdSceneItemOps.cpp
+        UsdSceneItemOpsHandler.cpp
+        UsdStageMap.cpp
+        UsdTRSUndoableCommandBase.cpp
+        UsdTransform3d.cpp
+        UsdTransform3dHandler.cpp
+        UsdTranslateUndoableCommand.cpp
+        UsdUndoDeleteCommand.cpp
+        UsdUndoDuplicateCommand.cpp
+        UsdUndoRenameCommand.cpp
+        Utils.cpp
+        moduleDeps.cpp
 )
 
 if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
     target_sources(${PROJECT_NAME}
         PRIVATE
-        ProxyShapeContextOpsHandler.cpp
-        RotationUtils.cpp
-        UsdAttribute.cpp
-        UsdAttributes.cpp
-        UsdAttributesHandler.cpp
-        UsdCamera.cpp
-        UsdCameraHandler.cpp
-        UsdContextOps.cpp
-        UsdContextOpsHandler.cpp
-        UsdObject3d.cpp
-        UsdObject3dHandler.cpp
-        UsdSetXformOpUndoableCommandBase.cpp
-        UsdTransform3dBase.cpp
-        UsdTransform3dCommonAPI.cpp
-        UsdTransform3dFallbackMayaXformStack.cpp
-        UsdTransform3dMatrixOp.cpp
-        UsdTransform3dMayaXformStack.cpp
-        UsdTransform3dPointInstance.cpp
-        UsdTransform3dSetObjectMatrix.cpp
-        UsdTransform3dUndoableCommands.cpp
-        UsdUIInfoHandler.cpp
-        UsdUIUfeObserver.cpp
-        UsdUndoAddNewPrimCommand.cpp
-        UsdUndoCreateGroupCommand.cpp
-        UsdUndoInsertChildCommand.cpp
-        UsdUndoReorderCommand.cpp
-        UsdUndoSetKindCommand.cpp
-        UsdUndoVisibleCommand.cpp
-        UsdUndoUngroupCommand.cpp
-        XformOpUtils.cpp
+            ProxyShapeContextOpsHandler.cpp
+            RotationUtils.cpp
+            UsdAttribute.cpp
+            UsdAttributes.cpp
+            UsdAttributesHandler.cpp
+            UsdCamera.cpp
+            UsdCameraHandler.cpp
+            UsdContextOps.cpp
+            UsdContextOpsHandler.cpp
+            UsdObject3d.cpp
+            UsdObject3dHandler.cpp
+            UsdSetXformOpUndoableCommandBase.cpp
+            UsdTransform3dBase.cpp
+            UsdTransform3dCommonAPI.cpp
+            UsdTransform3dFallbackMayaXformStack.cpp
+            UsdTransform3dMatrixOp.cpp
+            UsdTransform3dMayaXformStack.cpp
+            UsdTransform3dPointInstance.cpp
+            UsdTransform3dSetObjectMatrix.cpp
+            UsdTransform3dUndoableCommands.cpp
+            UsdUIInfoHandler.cpp
+            UsdUIUfeObserver.cpp
+            UsdUndoAddNewPrimCommand.cpp
+            UsdUndoCreateGroupCommand.cpp
+            UsdUndoInsertChildCommand.cpp
+            UsdUndoReorderCommand.cpp
+            UsdUndoSetKindCommand.cpp
+            UsdUndoVisibleCommand.cpp
+            UsdUndoUngroupCommand.cpp
+            XformOpUtils.cpp
     )
 endif()
 
 if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
     target_sources(${PROJECT_NAME}
         PRIVATE
-
-        # See MayaUIInfoHandler.h comments.
-        MayaUIInfoHandler.cpp
-        PulledObjectHierarchy.cpp
-        PulledObjectHierarchyHandler.cpp
-        UsdPathMappingHandler.cpp
-        UsdUndoUngroupCommand.cpp
+            # See MayaUIInfoHandler.h comments.
+            MayaUIInfoHandler.cpp
+            PulledObjectHierarchy.cpp
+            PulledObjectHierarchyHandler.cpp
+            UsdPathMappingHandler.cpp
+            UsdUndoUngroupCommand.cpp
     )
 endif()
 
 message(STATUS "UFE_LIGHTS_SUPPORT is ${UFE_LIGHTS_SUPPORT}")
 
-if(UFE_LIGHTS_SUPPORT)
+if (UFE_LIGHTS_SUPPORT)
     target_sources(${PROJECT_NAME}
         PRIVATE
-        UsdLight.cpp
-        UsdLightHandler.cpp
+            UsdLight.cpp
+            UsdLightHandler.cpp
     )
 
     target_compile_definitions(${PROJECT_NAME}
-        PRIVATE
+    PRIVATE
         UFE_LIGHTS_SUPPORT=1
     )
 endif()
 
 message(STATUS "UFE_SCENE_SEGMENT_SUPPORT is ${UFE_SCENE_SEGMENT_SUPPORT}")
 
-if(UFE_SCENE_SEGMENT_SUPPORT)
+if (UFE_SCENE_SEGMENT_SUPPORT)
     target_sources(${PROJECT_NAME}
-        PRIVATE
+    PRIVATE
         ProxyShapeSceneSegmentHandler.cpp
     )
 
     target_compile_definitions(${PROJECT_NAME}
-        PRIVATE
+    PRIVATE
         UFE_SCENE_SEGMENT_SUPPORT=1
     )
 endif()
 
 if(CMAKE_UFE_V4_FEATURES_AVAILABLE)
-    if(${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4001)
+    if (${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4001)
         target_sources(${PROJECT_NAME}
             PRIVATE
-            UsdShaderNodeDef.cpp
-            UsdShaderNodeDefHandler.cpp
+                UsdShaderNodeDef.cpp
+                UsdShaderNodeDefHandler.cpp
         )
     endif()
 
-    if(${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4010)
+    if (${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4010)
         target_sources(${PROJECT_NAME}
             PRIVATE
-            UsdShaderAttributeDef.cpp
-            UsdUndoCreateFromNodeDefCommand.cpp
+                UsdShaderAttributeDef.cpp
+                UsdUndoCreateFromNodeDefCommand.cpp
         )
     endif()
 
-    if(${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4013)
+    if (${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4013)
         target_sources(${PROJECT_NAME}
             PRIVATE
-            ProxyShapeCameraHandler.cpp
+                ProxyShapeCameraHandler.cpp
         )
     endif()
 
-    if(${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4020)
+    if (${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4020)
         target_sources(${PROJECT_NAME}
             PRIVATE
-            UsdConnections.cpp
-            UsdConnectionHandler.cpp
+                UsdConnections.cpp
+                UsdConnectionHandler.cpp
         )
     endif()
 
-    if(${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4023)
+    if (${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4023)
         target_sources(${PROJECT_NAME}
             PRIVATE
-            UsdUINodeGraphNode.cpp
-            UsdUINodeGraphNodeHandler.cpp
+                UsdUINodeGraphNode.cpp
+                UsdUINodeGraphNodeHandler.cpp
         )
     endif()
 
-    if(${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4024)
+    if (${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4024)
         target_sources(${PROJECT_NAME}
             PRIVATE
-            UsdUndoAttributesCommands.cpp
+                UsdUndoAttributesCommands.cpp
         )
     endif()
 
-    if(${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4025)
+    if (${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4025)
         target_sources(${PROJECT_NAME}
             PRIVATE
-            UsdTransform3dRead.cpp
+                UsdTransform3dRead.cpp
         )
     endif()
 endif()
@@ -168,7 +167,7 @@ endif()
 if(PXR_VERSION GREATER_EQUAL 2108)
     target_sources(${PROJECT_NAME}
         PRIVATE
-        UsdUndoMaterialCommands.cpp
+            UsdUndoMaterialCommands.cpp
     )
 endif()
 
@@ -241,7 +240,6 @@ endif()
 
 if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
     list(APPEND HEADERS
-
         # Not dependent on UFE v3, but used to draw orphaned pulled Maya nodes
         # in the Outliner, which is a UFE v3 feature.
         MayaUIInfoHandler.h
@@ -252,61 +250,61 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
     )
 endif()
 
-if(UFE_LIGHTS_SUPPORT)
+if (UFE_LIGHTS_SUPPORT)
     list(APPEND HEADERS
         UsdLight.h
         UsdLightHandler.h
     )
 endif()
 
-if(UFE_SCENE_SEGMENT_SUPPORT)
+if (UFE_SCENE_SEGMENT_SUPPORT)
     list(APPEND HEADERS
         ProxyShapeSceneSegmentHandler.h
     )
 endif()
 
 if(CMAKE_UFE_V4_FEATURES_AVAILABLE)
-    if(${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4001)
+    if (${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4001)
         list(APPEND HEADERS
             UsdShaderNodeDef.h
             UsdShaderNodeDefHandler.h
         )
     endif()
 
-    if(${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4010)
+    if (${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4010)
         list(APPEND HEADERS
             UsdShaderAttributeDef.h
             UsdUndoCreateFromNodeDefCommand.h
         )
     endif()
 
-    if(${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4013)
+    if (${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4013)
         list(APPEND HEADERS
             ProxyShapeCameraHandler.h
         )
     endif()
 
-    if(${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4020)
+    if (${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4020)
         list(APPEND HEADERS
             UsdConnections.h
             UsdConnectionHandler.h
         )
     endif()
 
-    if(${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4023)
+    if (${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4023)
         list(APPEND HEADERS
             UsdUINodeGraphNode.h
             UsdUINodeGraphNodeHandler.h
         )
     endif()
 
-    if(${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4024)
+    if (${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4024)
         list(APPEND HEADERS
             UsdUndoAttributesCommands.h
         )
     endif()
 
-    if(${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4025)
+    if (${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4025)
         list(APPEND HEADERS
             UsdTransform3dRead.h
         )
@@ -354,12 +352,12 @@ add_library(${UFE_PYTHON_TARGET_NAME} SHARED)
 # -----------------------------------------------------------------------------
 # sources
 # -----------------------------------------------------------------------------
-target_sources(${UFE_PYTHON_TARGET_NAME}
+target_sources(${UFE_PYTHON_TARGET_NAME} 
     PRIVATE
-    module.cpp
-    wrapGlobal.cpp
-    wrapUtils.cpp
-    wrapNotice.cpp
+        module.cpp
+        wrapGlobal.cpp
+        wrapUtils.cpp
+        wrapNotice.cpp
 )
 
 # -----------------------------------------------------------------------------
@@ -367,10 +365,10 @@ target_sources(${UFE_PYTHON_TARGET_NAME}
 # -----------------------------------------------------------------------------
 target_compile_definitions(${UFE_PYTHON_TARGET_NAME}
     PRIVATE
-    $<$<BOOL:${IS_MACOSX}>:OSMac_>
-    MFB_PACKAGE_NAME=${UFE_PYTHON_MODULE_NAME}
-    MFB_ALT_PACKAGE_NAME=${UFE_PYTHON_MODULE_NAME}
-    MFB_PACKAGE_MODULE="${PROJECT_NAME}.${UFE_PYTHON_MODULE_NAME}"
+        $<$<BOOL:${IS_MACOSX}>:OSMac_>
+        MFB_PACKAGE_NAME=${UFE_PYTHON_MODULE_NAME}
+        MFB_ALT_PACKAGE_NAME=${UFE_PYTHON_MODULE_NAME}
+        MFB_PACKAGE_MODULE="${PROJECT_NAME}.${UFE_PYTHON_MODULE_NAME}"
 )
 
 mayaUsd_compile_config(${UFE_PYTHON_TARGET_NAME})
@@ -380,7 +378,7 @@ mayaUsd_compile_config(${UFE_PYTHON_TARGET_NAME})
 # -----------------------------------------------------------------------------
 target_link_libraries(${UFE_PYTHON_TARGET_NAME}
     PUBLIC
-    ${PROJECT_NAME}
+        ${PROJECT_NAME}
 )
 
 # -----------------------------------------------------------------------------
@@ -416,5 +414,5 @@ install(FILES __init__.py
 
 if(IS_WINDOWS)
     install(FILES $<TARGET_PDB_FILE:${UFE_PYTHON_TARGET_NAME}>
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python/${PROJECT_NAME}/${UFE_PYTHON_MODULE_NAME} OPTIONAL)
+            DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python/${PROJECT_NAME}/${UFE_PYTHON_MODULE_NAME} OPTIONAL)
 endif()

--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -394,11 +394,9 @@ set_python_module_property(${UFE_PYTHON_TARGET_NAME})
 if(IS_MACOSX OR IS_LINUX)
     mayaUsd_init_rpath(rpath "${PROJECT_NAME}")
     mayaUsd_add_rpath(rpath "../../..")
-
     if(IS_MACOSX AND DEFINED MAYAUSD_TO_USD_RELATIVE_PATH)
         mayaUsd_add_rpath(rpath "../../../../${MAYAUSD_TO_USD_RELATIVE_PATH}/lib")
     endif()
-
     mayaUsd_install_rpath(rpath ${UFE_PYTHON_TARGET_NAME})
 endif()
 

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
@@ -291,6 +291,22 @@ UsdTransform3dCommonAPIHandler::transform3d(const Ufe::SceneItem::Ptr& item) con
     return commonAPI ? UsdTransform3dCommonAPI::create(usdItem) : _nextHandler->transform3d(item);
 }
 
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4025)
+/* override */
+Ufe::Transform3dRead::Ptr
+UsdTransform3dCommonAPIHandler::transform3dRead(const Ufe::SceneItem::Ptr& item) const
+{
+    auto trfRead = transform3d(item);
+    if (trfRead) {
+        return trfRead;
+    }
+
+    return _nextHandler->transform3dRead(item);
+}
+#endif
+#endif
+
 Ufe::Transform3d::Ptr UsdTransform3dCommonAPIHandler::editTransform3d(
     const Ufe::SceneItem::Ptr& item UFE_V2(, const Ufe::EditTransform3dHint& hint)) const
 {

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.h
@@ -86,6 +86,11 @@ public:
 
     // Ufe::Transform3dHandler overrides
     Ufe::Transform3d::Ptr transform3d(const Ufe::SceneItem::Ptr& item) const override;
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4025)
+    Ufe::Transform3dRead::Ptr transform3dRead(const Ufe::SceneItem::Ptr& item) const override;
+#endif
+#endif
     Ufe::Transform3d::Ptr editTransform3d(const Ufe::SceneItem::Ptr& item UFE_V2(
         ,
         const Ufe::EditTransform3dHint& hint)) const override;

--- a/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.cpp
@@ -20,6 +20,12 @@
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/ufe/XformOpUtils.h>
 
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4025)
+#include <mayaUsd/ufe/UsdTransform3dRead.h>
+#endif
+#endif
+
 #include <pxr/usd/usdGeom/xformCache.h>
 
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -368,6 +374,31 @@ UsdTransform3dFallbackMayaXformStackHandler::transform3d(const Ufe::SceneItem::P
 {
     return createTransform3d(item);
 }
+
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4025)
+/* override */
+Ufe::Transform3dRead::Ptr
+UsdTransform3dFallbackMayaXformStackHandler::transform3dRead(const Ufe::SceneItem::Ptr& item) const
+{
+    auto trfRead = transform3d(item);
+    if (trfRead) {
+        return trfRead;
+    }
+
+    UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
+#if !defined(NDEBUG)
+    assert(usdItem);
+#endif
+
+    if (!usdItem) {
+        return nullptr;
+    }
+
+    return UsdTransform3dRead::create(usdItem);
+}
+#endif
+#endif
 
 Ufe::Transform3d::Ptr UsdTransform3dFallbackMayaXformStackHandler::editTransform3d(
     const Ufe::SceneItem::Ptr& item UFE_V2(, const Ufe::EditTransform3dHint& hint)) const

--- a/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.h
@@ -105,6 +105,11 @@ public:
 
     // Ufe::Transform3dHandler overrides
     Ufe::Transform3d::Ptr transform3d(const Ufe::SceneItem::Ptr& item) const override;
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4025)
+    Ufe::Transform3dRead::Ptr transform3dRead(const Ufe::SceneItem::Ptr& item) const override;
+#endif
+#endif
     Ufe::Transform3d::Ptr editTransform3d(const Ufe::SceneItem::Ptr& item UFE_V2(
         ,
         const Ufe::EditTransform3dHint& hint)) const override;

--- a/lib/mayaUsd/ufe/UsdTransform3dHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dHandler.cpp
@@ -24,6 +24,14 @@
 #include <mayaUsd/ufe/UsdTransform3dPointInstance.h>
 #endif
 
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4025)
+#include <mayaUsd/ufe/UsdTransform3dRead.h>
+#endif
+#endif
+
+#include <pxr/usd/usdGeom/xformable.h>
+
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -85,6 +93,29 @@ Ufe::Transform3d::Ptr UsdTransform3dHandler::transform3d(const Ufe::SceneItem::P
 
     return UsdTransform3d::create(usdItem);
 }
+
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4025)
+Ufe::Transform3dRead::Ptr
+UsdTransform3dHandler::transform3dRead(const Ufe::SceneItem::Ptr& item) const
+{
+    UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
+#if !defined(NDEBUG)
+    assert(usdItem);
+#endif
+
+    if (!usdItem) {
+        return nullptr;
+    }
+
+    if (!PXR_NS::UsdGeomXformable(usdItem->prim())) {
+        return UsdTransform3dRead::create(usdItem);
+    } else {
+        return transform3d(item);
+    }
+}
+#endif
+#endif
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdTransform3dHandler.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dHandler.h
@@ -44,6 +44,11 @@ public:
     // Ufe::Transform3dHandler overrides
     Ufe::Transform3d::Ptr transform3d(const Ufe::SceneItem::Ptr& item) const override;
 
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4025)
+    Ufe::Transform3dRead::Ptr transform3dRead(const Ufe::SceneItem::Ptr& item) const override;
+#endif
+#endif
 }; // UsdTransform3dHandler
 
 } // namespace ufe

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -404,6 +404,22 @@ UsdTransform3dMatrixOpHandler::transform3d(const Ufe::SceneItem::Ptr& item) cons
         UsdTransform3dMatrixOp::create(usdItem, *i), mlInv, mrInv);
 }
 
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4025)
+/* override */
+Ufe::Transform3dRead::Ptr
+UsdTransform3dMatrixOpHandler::transform3dRead(const Ufe::SceneItem::Ptr& item) const
+{
+    auto trfRead = transform3d(item);
+    if (trfRead) {
+        return trfRead;
+    }
+
+    return _nextHandler->transform3dRead(item);
+}
+#endif
+#endif
+
 Ufe::Transform3d::Ptr UsdTransform3dMatrixOpHandler::editTransform3d(
     const Ufe::SceneItem::Ptr& item UFE_V2(, const Ufe::EditTransform3dHint& hint)) const
 {

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.h
@@ -88,6 +88,11 @@ public:
 
     // Ufe::Transform3dHandler overrides
     Ufe::Transform3d::Ptr transform3d(const Ufe::SceneItem::Ptr& item) const override;
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4025)
+    Ufe::Transform3dRead::Ptr transform3dRead(const Ufe::SceneItem::Ptr& item) const override;
+#endif
+#endif
     Ufe::Transform3d::Ptr editTransform3d(const Ufe::SceneItem::Ptr& item UFE_V2(
         ,
         const Ufe::EditTransform3dHint& hint)) const override;

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
@@ -817,6 +817,22 @@ UsdTransform3dMayaXformStackHandler::transform3d(const Ufe::SceneItem::Ptr& item
     return createTransform3d(item, [&]() { return _nextHandler->transform3d(item); });
 }
 
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4025)
+/* override */
+Ufe::Transform3dRead::Ptr
+UsdTransform3dMayaXformStackHandler::transform3dRead(const Ufe::SceneItem::Ptr& item) const
+{
+    auto trfRead = transform3d(item);
+    if (trfRead) {
+        return trfRead;
+    }
+
+    return _nextHandler->transform3dRead(item);
+}
+#endif
+#endif
+
 Ufe::Transform3d::Ptr UsdTransform3dMayaXformStackHandler::editTransform3d(
     const Ufe::SceneItem::Ptr& item UFE_V2(, const Ufe::EditTransform3dHint& hint)) const
 {

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
@@ -134,6 +134,11 @@ public:
 
     // Ufe::Transform3dHandler overrides
     Ufe::Transform3d::Ptr transform3d(const Ufe::SceneItem::Ptr& item) const override;
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4025)
+    Ufe::Transform3dRead::Ptr transform3dRead(const Ufe::SceneItem::Ptr& item) const override;
+#endif
+#endif
     Ufe::Transform3d::Ptr editTransform3d(const Ufe::SceneItem::Ptr& item UFE_V2(
         ,
         const Ufe::EditTransform3dHint& hint)) const override;

--- a/lib/mayaUsd/ufe/UsdTransform3dPointInstance.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dPointInstance.cpp
@@ -169,6 +169,22 @@ UsdTransform3dPointInstanceHandler::transform3d(const Ufe::SceneItem::Ptr& item)
     return UsdTransform3dPointInstance::create(usdItem);
 }
 
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4025)
+/* override */
+Ufe::Transform3dRead::Ptr
+UsdTransform3dPointInstanceHandler::transform3dRead(const Ufe::SceneItem::Ptr& item) const
+{
+    auto trfRead = transform3d(item);
+    if (trfRead) {
+        return trfRead;
+    }
+
+    return _nextHandler->transform3dRead(item);
+}
+#endif
+#endif
+
 /* override */
 Ufe::Transform3d::Ptr UsdTransform3dPointInstanceHandler::editTransform3d(
     const Ufe::SceneItem::Ptr&      item,

--- a/lib/mayaUsd/ufe/UsdTransform3dPointInstance.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dPointInstance.h
@@ -80,6 +80,11 @@ public:
 
     // Ufe::Transform3dHandler overrides
     Ufe::Transform3d::Ptr transform3d(const Ufe::SceneItem::Ptr& item) const override;
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4025)
+    Ufe::Transform3dRead::Ptr transform3dRead(const Ufe::SceneItem::Ptr& item) const override;
+#endif
+#endif
     Ufe::Transform3d::Ptr editTransform3d(
         const Ufe::SceneItem::Ptr&      item,
         const Ufe::EditTransform3dHint& hint) const override;

--- a/lib/mayaUsd/ufe/UsdTransform3dRead.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dRead.cpp
@@ -1,0 +1,73 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "UsdTransform3dRead.h"
+
+#include <mayaUsd/ufe/Utils.h>
+
+#include <pxr/usd/usdGeom/xformCache.h>
+#include <pxr/usd/usdGeom/xformCommonAPI.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+UsdTransform3dRead::Ptr UsdTransform3dRead::create(const UsdSceneItem::Ptr& item)
+{
+    return std::make_shared<UsdTransform3dRead>(item);
+}
+
+UsdTransform3dRead::UsdTransform3dRead(const UsdSceneItem::Ptr& item)
+    : Transform3dRead()
+    , fItem(item)
+    , fPrim(item->prim())
+{
+}
+
+const Ufe::Path& UsdTransform3dRead::path() const { return fItem->path(); }
+
+Ufe::SceneItem::Ptr UsdTransform3dRead::sceneItem() const { return fItem; }
+
+Ufe::Matrix4d UsdTransform3dRead::matrix() const
+{
+    GfMatrix4d       m(1);
+    UsdGeomXformable xformable(prim());
+    if (xformable) {
+        bool unused;
+        auto ops = xformable.GetOrderedXformOps(&unused);
+        if (!UsdGeomXformable::GetLocalTransformation(&m, ops, getTime(path()))) {
+            TF_FATAL_ERROR(
+                "Local transformation computation for prim %s failed.", prim().GetPath().GetText());
+        }
+    }
+
+    return toUfe(m);
+}
+
+Ufe::Matrix4d UsdTransform3dRead::segmentInclusiveMatrix() const
+{
+    UsdGeomXformCache xformCache(getTime(path()));
+    return toUfe(xformCache.GetLocalToWorldTransform(fPrim));
+}
+
+Ufe::Matrix4d UsdTransform3dRead::segmentExclusiveMatrix() const
+{
+    UsdGeomXformCache xformCache(getTime(path()));
+    return toUfe(xformCache.GetParentToWorldTransform(fPrim));
+}
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdTransform3dRead.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dRead.h
@@ -1,0 +1,70 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <mayaUsd/base/api.h>
+#include <mayaUsd/ufe/UsdSceneItem.h>
+
+#include <pxr/usd/usd/prim.h>
+
+#include <ufe/transform3d.h>
+#include <ufe/transform3dHandler.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+//! \brief Read-only implementation for USD object 3D transform information.
+//
+// Note that all calls to specify time use the default time, but this
+// could be changed to use the current time, using getTime(path()).
+
+class MAYAUSD_CORE_PUBLIC UsdTransform3dRead : public Ufe::Transform3dRead
+{
+public:
+    typedef std::shared_ptr<UsdTransform3dRead> Ptr;
+
+    //! Create a UsdTransform3dRead.
+    static UsdTransform3dRead::Ptr create(const UsdSceneItem::Ptr& item);
+
+    UsdTransform3dRead(const UsdSceneItem::Ptr& item);
+    ~UsdTransform3dRead() override = default;
+
+    // Delete the copy/move constructors assignment operators.
+    UsdTransform3dRead(const UsdTransform3dRead&) = delete;
+    UsdTransform3dRead& operator=(const UsdTransform3dRead&) = delete;
+    UsdTransform3dRead(UsdTransform3dRead&&) = delete;
+    UsdTransform3dRead& operator=(UsdTransform3dRead&&) = delete;
+
+    // Ufe::Transform3d overrides
+    const Ufe::Path&    path() const override;
+    Ufe::SceneItem::Ptr sceneItem() const override;
+
+    inline UsdSceneItem::Ptr usdSceneItem() const { return fItem; }
+    inline PXR_NS::UsdPrim   prim() const { return fPrim; }
+
+    Ufe::Matrix4d matrix() const override;
+
+    Ufe::Matrix4d segmentInclusiveMatrix() const override;
+    Ufe::Matrix4d segmentExclusiveMatrix() const override;
+
+private:
+    UsdSceneItem::Ptr fItem;
+    PXR_NS::UsdPrim   fPrim;
+
+}; // UsdTransform3dRead
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/test/lib/ufe/testParentCmd.py
+++ b/test/lib/ufe/testParentCmd.py
@@ -1249,7 +1249,7 @@ class ParentCmdTestCase(unittest.TestCase):
         # Restore default edit router.
         mayaUsd.lib.restoreDefaultEditRouter('parent')
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2024 and mayaUtils.ufeSupportFixLevel() >= 5, 'Requires Maya fixes only available in Maya 2024 or greater.')
+    @unittest.skipUnless(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') >= '4025', 'Require Transform3dRead interface in Ufe 0.4.25')
     def testParentAbsoluteUnderScope(self):
         """Test parent -absolute to move prim under scope."""
 
@@ -1370,7 +1370,7 @@ class ParentCmdTestCase(unittest.TestCase):
         checkParentDone()
         checkCapsuleMatrix('/Xform1/Scope1/Capsule1')
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2024 and mayaUtils.ufeSupportFixLevel() >= 5, 'Requires Maya fixes only available in Maya 2024 or greater.')
+    @unittest.skipUnless(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') >= '4025', 'Require Transform3dRead interface in Ufe 0.4.25')
     def testParentAbsoluteScope(self):
         """Test parent -absolute to move a scope with a prim under it under an xform."""
 

--- a/test/lib/ufe/testParentCmd.py
+++ b/test/lib/ufe/testParentCmd.py
@@ -1249,7 +1249,7 @@ class ParentCmdTestCase(unittest.TestCase):
         # Restore default edit router.
         mayaUsd.lib.restoreDefaultEditRouter('parent')
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2024, 'Requires Maya fixes only available in Maya 2024 or greater.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2024 and mayaUtils.ufeSupportFixLevel() >= 5, 'Requires Maya fixes only available in Maya 2024 or greater.')
     def testParentAbsoluteUnderScope(self):
         """Test parent -absolute to move prim under scope."""
 
@@ -1370,7 +1370,7 @@ class ParentCmdTestCase(unittest.TestCase):
         checkParentDone()
         checkCapsuleMatrix('/Xform1/Scope1/Capsule1')
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2024, 'Requires Maya fixes only available in Maya 2024 or greater.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2024 and mayaUtils.ufeSupportFixLevel() >= 5, 'Requires Maya fixes only available in Maya 2024 or greater.')
     def testParentAbsoluteScope(self):
         """Test parent -absolute to move a scope with a prim under it under an xform."""
 


### PR DESCRIPTION
- Use the new Transform3dRead interface if available in UFE.
- Implement the interface if available in UFE.
- Add a new test for parenting scopes and parenting under a scope.