### PR TITLE
MAYA-113642 disallow switching variants in a weaker layer.

### DIFF
--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -16,6 +16,7 @@
 #include "UsdContextOps.h"
 
 #include "private/UfeNotifGuard.h"
+#include "private/Utils.h"
 
 #ifdef UFE_V3_FEATURES_AVAILABLE
 #include <mayaUsd/commands/PullPushCommands.h>
@@ -395,6 +396,11 @@ public:
         , _oldSelection(_varSet.GetVariantSelection())
         , _newSelection(itemPath[2])
     {
+        const bool allowStronger = true;
+        MayaUsd::ufe::applyCommandRestriction(
+            prim,
+            "set variant set " + _varSet.GetName() + " to variant " + _newSelection + " on",
+            allowStronger);
     }
 
     void undo() override

--- a/lib/mayaUsd/ufe/private/Utils.cpp
+++ b/lib/mayaUsd/ufe/private/Utils.cpp
@@ -148,7 +148,10 @@ SdfLayerHandle getStrongerLayer(
     return SdfLayerHandle();
 }
 
-bool allowedInStrongerLayer(const UsdPrim& prim, const SdfPrimSpecHandleVector& primStack, bool allowStronger)
+bool allowedInStrongerLayer(
+    const UsdPrim&                 prim,
+    const SdfPrimSpecHandleVector& primStack,
+    bool                           allowStronger)
 {
     // If the flag to allow edits in a stronger layer if off, then it is not allowed.
     if (!allowStronger)


### PR DESCRIPTION
Also fix a bug in the allow check when dealing with variant: it was refusing even when the allow-stronger-layer flag was on and in a stronger layer.