### PR TITLE
Use TF_WARN when passed an invalid Path

### DIFF
--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -194,7 +194,8 @@ UsdPrim ufePathToPrim(const Ufe::Path& path)
         return UsdPrim();
     }
     auto stage = getStage(Ufe::Path(segments[0]));
-    if (!TF_VERIFY(stage, kIllegalUFEPath, path.string().c_str())) {
+    if (!stage) {
+        TF_WARN(kIllegalUFEPath, path.string().c_str());
         return UsdPrim();
     }
 


### PR DESCRIPTION
ufePathToPrim would TF_VERIFY when failing to resolve the provided path,
which reports a TF_CODING_ERROR. Since this isn't actually a result of a
coding error, downgrade this to a TF_WARN.