### PR TITLE
Fix MaterialX conversion crash with invalid graphs

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -654,6 +654,9 @@ void _AddMissingTangents(mx::DocumentPtr& mtlxDoc)
             material = surfaceInput->getConnectedNode();
         }
         mx::NodeDefPtr nodeDef = material->getNodeDef();
+        if (!nodeDef) {
+            continue;
+        }
         for (mx::InputPtr input : nodeDef->getActiveInputs()) {
             if (input->hasDefaultGeomPropString()) {
                 const std::string& geomPropString = input->getDefaultGeomPropString();


### PR DESCRIPTION
A MaterialX shader graph can be transitively in a bad state while being
edited. Make sure it does not cause a crash is a NodeDef is missing.