### PR TITLE
Always write color space to usd texture prims

### DIFF
--- a/lib/usd/translators/shading/usdFileTextureWriter.cpp
+++ b/lib/usd/translators/shading/usdFileTextureWriter.cpp
@@ -51,6 +51,13 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
+// Maya USD used to only write the colorspace if the colorspace was not the default.
+// This env var allows users to go back to the sparse write method when desired
+TF_DEFINE_ENV_SETTING(
+    MAYAUSD_EXPORT_VERBOSE_COLORSPACE_METADATA,
+    true,
+    "This env flag controls whether colorspace values are written even if they're the default.")
+
 class PxrUsdTranslators_FileTextureWriter : public UsdMayaShaderWriter
 {
 public:
@@ -241,12 +248,13 @@ void PxrUsdTranslators_FileTextureWriter::Write(const UsdTimeCode& usdTime)
 
     MPlug colorSpacePlug = depNodeFn.findPlug(TrMayaTokens->colorSpace.GetText(), true, &status);
     if (status == MS::kSuccess) {
-        MString colorRuleCmd;
+        const bool verboseColorspace = TfGetEnvSetting(MAYAUSD_EXPORT_VERBOSE_COLORSPACE_METADATA);
+        MString    colorRuleCmd;
         colorRuleCmd.format(
             "colorManagementFileRules -evaluate \"^1s\";", fileTextureNamePlug.asString());
-
+        const MString colorSpaceByRule(MGlobal::executeCommandStringResult(colorRuleCmd));
         const MString colorSpace(colorSpacePlug.asString(&status));
-        if (status == MS::kSuccess) {
+        if (status == MS::kSuccess && (verboseColorspace || colorSpace != colorSpaceByRule)) {
             fileInput.GetAttr().SetColorSpace(TfToken(colorSpace.asChar()));
         }
 

--- a/lib/usd/translators/shading/usdFileTextureWriter.cpp
+++ b/lib/usd/translators/shading/usdFileTextureWriter.cpp
@@ -244,9 +244,9 @@ void PxrUsdTranslators_FileTextureWriter::Write(const UsdTimeCode& usdTime)
         MString colorRuleCmd;
         colorRuleCmd.format(
             "colorManagementFileRules -evaluate \"^1s\";", fileTextureNamePlug.asString());
-        const MString colorSpaceByRule(MGlobal::executeCommandStringResult(colorRuleCmd));
+
         const MString colorSpace(colorSpacePlug.asString(&status));
-        if (status == MS::kSuccess && colorSpace != colorSpaceByRule) {
+        if (status == MS::kSuccess) {
             fileInput.GetAttr().SetColorSpace(TfToken(colorSpace.asChar()));
         }
 


### PR DESCRIPTION
This changes the behaviour of the texture prim writer to **always** write the colorSpace attribute, whereas currently they are elided if they match the default.
This is important for us, and other software vendors, who have software that needs to ingest data from a multitude of pipelines with different defaults. This means we currently have to apply heuristics to figure out the default for a given texture, but it would be most ideal to be able to just always write out the intended color space into the file.

I think this would be a beneficial default for Maya USD in general, because even in a film studio, we might share assets between shows that have different OCIO defaults, so it's beneficial to know that information up front as much as possible.