### PR TITLE
Use Hydra fix for Geom subset mat Id paths

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -1852,10 +1852,14 @@ void HdVP2Material::Sync(
                             _CreateMaterialXShaderInstance(GetId(), surfaceNetwork));
                         _pointShader.reset(nullptr);
                         _topoHash = topoHash;
+                        // TopoChanged: We have a brand new surface material, tell the mesh to use
+                        // it.
+                        _MaterialChanged(sceneDelegate);
                     }
 
                     if (_surfaceShader) {
                         _UpdateShaderInstance(sceneDelegate, bxdfNet);
+// Consolidation workaround requires dirtying the mesh even on a ValueChanged
 #ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
                         _MaterialChanged(sceneDelegate);
 #endif
@@ -1911,6 +1915,8 @@ void HdVP2Material::Sync(
                     // The shader instance is owned by the material solely.
                     _surfaceShader.reset(shader);
                     _pointShader.reset(nullptr);
+                    // TopoChanged: We have a brand new surface material, tell the mesh to use it.
+                    _MaterialChanged(sceneDelegate);
 
                     if (TfDebug::IsEnabled(HDVP2_DEBUG_MATERIAL)) {
                         std::cout << "BXDF material network for " << id << ":\n"
@@ -1982,6 +1988,7 @@ void HdVP2Material::Sync(
 
                 _UpdateShaderInstance(sceneDelegate, bxdfNet);
 
+// Consolidation workaround requires dirtying the mesh even on a ValueChanged
 #ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
                 _MaterialChanged(sceneDelegate);
 #endif
@@ -3259,8 +3266,6 @@ MHWRender::MShaderInstance* HdVP2Material::GetPointShader() const
     return _pointShader.get();
 }
 
-#ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
-
 void HdVP2Material::SubscribeForMaterialUpdates(const SdfPath& rprimId)
 {
     std::lock_guard<std::mutex> lock(_materialSubscriptionsMutex);
@@ -3284,8 +3289,6 @@ void HdVP2Material::_MaterialChanged(HdSceneDelegate* sceneDelegate)
         changeTracker.MarkRprimDirty(rprimId, HdChangeTracker::DirtyMaterialId);
     }
 }
-
-#endif
 
 void HdVP2Material::OnMayaExit()
 {

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.h
@@ -109,13 +109,11 @@ public:
     void EnqueueLoadTextures();
     void ClearPendingTasks();
 
-#ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
     //! The specified Rprim starts listening to changes on this material.
     void SubscribeForMaterialUpdates(const SdfPath& rprimId);
 
     //! The specified Rprim stops listening to changes on this material.
     void UnsubscribeFromMaterialUpdates(const SdfPath& rprimId);
-#endif
 
     class TextureLoadingTask;
     friend class TextureLoadingTask;
@@ -143,10 +141,8 @@ private:
         bool                 isColorSpaceSRGB,
         const MFloatArray&   uvScaleOffset);
 
-#ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
     //! Trigger sync on all Rprims which are listening to changes on this material.
     void _MaterialChanged(HdSceneDelegate* sceneDelegate);
-#endif
 
     static void _ScheduleRefresh();
 
@@ -171,13 +167,11 @@ private:
 
     std::unordered_map<std::string, TextureLoadingTask*> _textureLoadingTasks;
 
-#ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
     //! Mutex protecting concurrent access to the Rprim set
     std::mutex _materialSubscriptionsMutex;
 
     //! The set of Rprims listening to changes on this material
     std::set<SdfPath> _materialSubscriptions;
-#endif
 
 #ifdef WANT_MATERIALX_BUILD
     // MaterialX-only at the moment, but will be used for UsdPreviewSurface when the upgrade to

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
@@ -818,7 +818,7 @@ SdfPath MayaUsdRPrim::_GetUpdatedMaterialId(HdRprim* rprim, HdSceneDelegate* del
         }
     }
 
-#ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
+    // Register to be notified if the surface shader changes due to a topology change:
     const SdfPath& origMaterialId = rprim->GetMaterialId();
     if (materialId != origMaterialId) {
         HdRenderIndex& renderIndex = delegate->GetRenderIndex();
@@ -839,7 +839,6 @@ SdfPath MayaUsdRPrim::_GetUpdatedMaterialId(HdRprim* rprim, HdSceneDelegate* del
             }
         }
     }
-#endif
 
     return materialId;
 }

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -785,6 +785,7 @@ void HdVP2Mesh::Sync(
     ProxyRenderDelegate& drawScene = param->GetDrawScene();
     UsdImagingDelegate*  usdImagingDelegate = drawScene.GetUsdImagingDelegate();
 #endif
+
     // Geom subsets are accessed through the mesh topology. I need to know about
     // the additional materialIds that get bound by geom subsets before we build the
     // _primvaInfo. So the very first thing I need to do is grab the topology.

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -785,7 +785,6 @@ void HdVP2Mesh::Sync(
     ProxyRenderDelegate& drawScene = param->GetDrawScene();
     UsdImagingDelegate*  usdImagingDelegate = drawScene.GetUsdImagingDelegate();
 #endif
-
     // Geom subsets are accessed through the mesh topology. I need to know about
     // the additional materialIds that get bound by geom subsets before we build the
     // _primvaInfo. So the very first thing I need to do is grab the topology.

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -784,8 +784,7 @@ void HdVP2Mesh::Sync(
     // the additional materialIds that get bound by geom subsets before we build the
     // _primvaInfo. So the very first thing I need to do is grab the topology.
     if (HdChangeTracker::IsTopologyDirty(*dirtyBits, id)) {
-        // unsubscribe from material updates from the old geom subset materials
-#ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
+        // unsubscribe from material TopoChanged updates from the old geom subset materials
         for (const auto& geomSubset : _meshSharedData->_topology.GetGeomSubsets()) {
             if (!geomSubset.materialId.IsEmpty()) {
                 const SdfPath materialId
@@ -798,7 +797,6 @@ void HdVP2Mesh::Sync(
                 }
             }
         }
-#endif
 
         {
             MProfilingScope profilingScope(
@@ -824,8 +822,7 @@ void HdVP2Mesh::Sync(
             }
         }
 
-        // subscribe to material updates from the new geom subset materials
-#ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
+        // subscribe to material TopoChanged updates from the new geom subset materials
         for (const auto& geomSubset : _meshSharedData->_topology.GetGeomSubsets()) {
             if (!geomSubset.materialId.IsEmpty()) {
                 const SdfPath materialId
@@ -838,7 +835,6 @@ void HdVP2Mesh::Sync(
                 }
             }
         }
-#endif
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {

--- a/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
@@ -41,7 +41,7 @@ def mayaUsdLibRegisterStrings():
     # mayaUsdCacheMayaReference.py
     register('kButtonNewChildPrim', 'New Child Prim')
     register('kButtonNewChildPrimToolTip', 'If selected, your Maya reference will be defined in a new child prim. This will enable\nyou to work with your Maya reference and its USD cache side-by-side.')
-    register('kCacheFileWillAppear', 'Cache file will appear\non parent prim:')
+    register('kCacheFileWillAppear', 'Cache file will\nappear on parent\nprim:')
     register('kCacheMayaRefCache', 'Cache')
     register('kCacheMayaRefOptions', 'Cache File Options')
     register('kCacheMayaRefUsdHierarchy', 'Author Cache File to USD Hierarchy')

--- a/lib/mayaUsd/ufe/MayaUIInfoHandler.cpp
+++ b/lib/mayaUsd/ufe/MayaUIInfoHandler.cpp
@@ -121,9 +121,14 @@ bool MayaUIInfoHandler::treeViewCellInfo(const Ufe::SceneItem::Ptr& mayaItem, Uf
 
 Ufe::UIInfoHandler::Icon MayaUIInfoHandler::treeViewIcon(const Ufe::SceneItem::Ptr& mayaItem) const
 {
-    return isOrphaned(mayaItem)
-        ? Ufe::UIInfoHandler::Icon("", "orphaned_node_badge", Ufe::UIInfoHandler::LowerRight)
-        : Ufe::UIInfoHandler::Icon();
+    Ufe::UIInfoHandler::Icon icon;
+    if (isOrphaned(mayaItem)) {
+        icon = Ufe::UIInfoHandler::Icon("", "orphaned_node_badge", Ufe::UIInfoHandler::LowerRight);
+#if (UFE_PREVIEW_VERSION_NUM >= 4029)
+        icon.mode = UIInfoHandler::Disabled;
+#endif
+    }
+    return icon;
 }
 
 std::string MayaUIInfoHandler::treeViewTooltip(const Ufe::SceneItem::Ptr& mayaItem) const

--- a/test/lib/mayaUsd/fileio/CMakeLists.txt
+++ b/test/lib/mayaUsd/fileio/CMakeLists.txt
@@ -43,6 +43,8 @@ foreach(script ${TEST_SCRIPT_FILES})
     mayaUsd_add_test(${target}
         PYTHON_MODULE ${target}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        ENV
+            "UFE_PREVIEW_VERSION_NUM=${UFE_PREVIEW_VERSION_NUM}"
     )
 
     # Add a ctest label to these tests for easy filtering.

--- a/test/lib/ufe/testUIInfoHandler.py
+++ b/test/lib/ufe/testUIInfoHandler.py
@@ -68,7 +68,7 @@ class UIInfoHandlerTestCase(unittest.TestCase):
         # Deactivate one of the balls.
         ballSetPrim = mayaUsd.ufe.ufePathToPrim('|transform1|proxyShape1,/Ball_set/Props/Ball_3')
         ballSetPrim.SetActive(False)
-		
+
         # Now ask for the treeViewCellInfo and test that some values were set
         # (because the ball is inactive).
         ball3Path = ufe.PathString.path('|transform1|proxyShape1,/Ball_set/Props/Ball_3')
@@ -91,6 +91,9 @@ class UIInfoHandlerTestCase(unittest.TestCase):
         self.assertEqual(icon.baseIcon, "out_USD_Sphere.png")
         self.assertFalse(icon.badgeIcon)    # empty string
 
+        if os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') >= '4029':
+            # Ball_3 should have a "normal" icon mode.
+            self.assertEqual(ufe.UIInfoHandler.Normal, icon.mode)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Geom Subsets accessed via UsdImagingDelegate::GetMeshTopology now have
correctly prefixed index paths for id and materialId, so callsites no
longer have to perform this conversion