### PR TITLE
Mark primitives as dirty if the shader has been rebuilt

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -1852,7 +1852,8 @@ void HdVP2Material::Sync(
                             _CreateMaterialXShaderInstance(GetId(), surfaceNetwork));
                         _pointShader.reset(nullptr);
                         _topoHash = topoHash;
-                        // TopoChanged: We have a brand new surface material, tell the mesh to use it.
+                        // TopoChanged: We have a brand new surface material, tell the mesh to use
+                        // it.
                         _MaterialChanged(sceneDelegate);
                     }
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.h
@@ -109,13 +109,11 @@ public:
     void EnqueueLoadTextures();
     void ClearPendingTasks();
 
-#ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
     //! The specified Rprim starts listening to changes on this material.
     void SubscribeForMaterialUpdates(const SdfPath& rprimId);
 
     //! The specified Rprim stops listening to changes on this material.
     void UnsubscribeFromMaterialUpdates(const SdfPath& rprimId);
-#endif
 
     class TextureLoadingTask;
     friend class TextureLoadingTask;
@@ -143,10 +141,8 @@ private:
         bool                 isColorSpaceSRGB,
         const MFloatArray&   uvScaleOffset);
 
-#ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
     //! Trigger sync on all Rprims which are listening to changes on this material.
     void _MaterialChanged(HdSceneDelegate* sceneDelegate);
-#endif
 
     static void _ScheduleRefresh();
 
@@ -171,13 +167,11 @@ private:
 
     std::unordered_map<std::string, TextureLoadingTask*> _textureLoadingTasks;
 
-#ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
     //! Mutex protecting concurrent access to the Rprim set
     std::mutex _materialSubscriptionsMutex;
 
     //! The set of Rprims listening to changes on this material
     std::set<SdfPath> _materialSubscriptions;
-#endif
 
 #ifdef WANT_MATERIALX_BUILD
     // MaterialX-only at the moment, but will be used for UsdPreviewSurface when the upgrade to

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
@@ -818,7 +818,7 @@ SdfPath MayaUsdRPrim::_GetUpdatedMaterialId(HdRprim* rprim, HdSceneDelegate* del
         }
     }
 
-#ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
+    // Register to be notified if the surface shader changes due to a topology change:
     const SdfPath& origMaterialId = rprim->GetMaterialId();
     if (materialId != origMaterialId) {
         HdRenderIndex& renderIndex = delegate->GetRenderIndex();
@@ -839,7 +839,6 @@ SdfPath MayaUsdRPrim::_GetUpdatedMaterialId(HdRprim* rprim, HdSceneDelegate* del
             }
         }
     }
-#endif
 
     return materialId;
 }

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -784,8 +784,7 @@ void HdVP2Mesh::Sync(
     // the additional materialIds that get bound by geom subsets before we build the
     // _primvaInfo. So the very first thing I need to do is grab the topology.
     if (HdChangeTracker::IsTopologyDirty(*dirtyBits, id)) {
-        // unsubscribe from material updates from the old geom subset materials
-#ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
+        // unsubscribe from material TopoChanged updates from the old geom subset materials
         for (const auto& geomSubset : _meshSharedData->_topology.GetGeomSubsets()) {
             if (!geomSubset.materialId.IsEmpty()) {
                 const SdfPath materialId
@@ -798,7 +797,6 @@ void HdVP2Mesh::Sync(
                 }
             }
         }
-#endif
 
         {
             MProfilingScope profilingScope(
@@ -824,8 +822,7 @@ void HdVP2Mesh::Sync(
             }
         }
 
-        // subscribe to material updates from the new geom subset materials
-#ifdef HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
+        // subscribe to material TopoChanged updates from the new geom subset materials
         for (const auto& geomSubset : _meshSharedData->_topology.GetGeomSubsets()) {
             if (!geomSubset.materialId.IsEmpty()) {
                 const SdfPath materialId
@@ -838,7 +835,6 @@ void HdVP2Mesh::Sync(
                 }
             }
         }
-#endif
     }
 
     if (*dirtyBits & HdChangeTracker::DirtyMaterialId) {


### PR DESCRIPTION
Happens when the shader topology changes, and requires a mesh update to push the latest MShaderInstance.

Thanks to William Krick and Huidong Chen for the code. I only needed to enable it for TopoChanged material updates.