### PR TITLE
MAYA-124107 - MayaUSD: build as Universal Binary 2 (x86_64 + arm64)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ set(CMAKE_INSTALL_MESSAGE "NEVER")
 
 if(APPLE)
     if(BUILD_UB2)
+        message(STATUS "Building with Universal Binary 2")
         set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
         set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0)
     else()

--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -25,12 +25,6 @@ macro(fetch_googletest)
         # sequence parsing errors.  PPT, 22-Nov-2018.
         file(TO_CMAKE_PATH ${CMAKE_MAKE_PROGRAM} CMAKE_MAKE_PROGRAM)
 
-        # Force the use of ABI version 0 on Linux.
-        # This is what Maya has been using for 2019...2023
-        if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-            set(FORCE_OLD_ABI "-D_GLIBCXX_USE_CXX11_ABI=0")
-        endif()
- 
         if (GOOGLETEST_SRC_DIR)
             configure_file(cmake/googletest_src.txt.in ${GOOGLETEST_BUILD_ROOT}/googletest-config/CMakeLists.txt)
         else()

--- a/cmake/googletest_download.txt.in
+++ b/cmake/googletest_download.txt.in
@@ -21,9 +21,8 @@ ExternalProject_Add(googletest
   SOURCE_DIR        "${GOOGLETEST_BUILD_ROOT}/googletest-src"
   BINARY_DIR        "${GOOGLETEST_BUILD_ROOT}/googletest-build"
   CMAKE_ARGS
-                    "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}"
+                    "${MAYAUSD_EXTERNAL_PROJECT_GENERAL_SETTINGS}"
                     "-DCMAKE_INSTALL_PREFIX=${GOOGLETEST_BUILD_ROOT}/googletest-install"
-                    "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
                     "-Dgtest_force_shared_crt=ON"
                     "-DBUILD_GMOCK=OFF"
                     "-DBUILD_SHARED_LIBS=ON"
@@ -32,5 +31,5 @@ ExternalProject_Add(googletest
                     "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
                     "-DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}"
                     "-DCMAKE_CXX_STANDARD_REQUIRED=${CMAKE_CXX_STANDARD_REQUIRED}"
-                    "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} ${FORCE_OLD_ABI}"                    
+                    "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
 )

--- a/cmake/googletest_src.txt.in
+++ b/cmake/googletest_src.txt.in
@@ -18,9 +18,8 @@ ExternalProject_Add(googletest
   SOURCE_DIR        "${GOOGLETEST_SRC_DIR}"
   BINARY_DIR        "${GOOGLETEST_BUILD_ROOT}/googletest-build"
   CMAKE_ARGS
-                    "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}"
+                    "${MAYAUSD_EXTERNAL_PROJECT_GENERAL_SETTINGS}"
                     "-DCMAKE_INSTALL_PREFIX=${GOOGLETEST_BUILD_ROOT}/googletest-install"
-                    "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
                     "-Dgtest_force_shared_crt=ON"
                     "-DBUILD_GMOCK=OFF"
                     "-DBUILD_SHARED_LIBS=ON"
@@ -29,5 +28,5 @@ ExternalProject_Add(googletest
                     "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
                     "-DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}"
                     "-DCMAKE_CXX_STANDARD_REQUIRED=${CMAKE_CXX_STANDARD_REQUIRED}"
-                    "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} ${FORCE_OLD_ABI}"                    
+                    "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
 )

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -263,3 +263,55 @@ function(set_python_module_property target)
         )
     endif()
 endfunction()
+
+# This fuction will populate "out_var" with the default values external
+# projects are expected to need.
+# It can take an optional argument that will replace the list separator
+# in CMake values. For instance, if an external project uses a different
+# list separator, the values in here must be changed to reflect this.
+function(get_external_project_default_values out_var)
+    # Some of these variables might end up not being used by some projects
+    # Therefore avoid useless warnings in the log.
+    list(APPEND setting_list --no-warn-unused-cli)
+
+    # Force the use of ABI version 0 on Linux.
+    # This is what Maya has been using for 2019...2023
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+        list(APPEND setting_list -D_GLIBCXX_USE_CXX11_ABI=0)
+    endif()
+
+    if(ARGN)
+        list(GET ARGN 0 custom_sep)
+    endif()
+
+    # Macro to add the value only if it's present.
+    macro(external_project_conditional_define option)
+        if (${option})
+            if(custom_sep)
+                # This will change the list separator to the desired one.
+                # i.e. -DCMAKE_OSX_ARCHITECTURES=x86_64;arm64 -> -DCMAKE_OSX_ARCHITECTURES=x86_64|arm64
+                string(REPLACE ";" ${custom_sep} ${option} "${${option}}")
+            endif()
+            list(APPEND setting_list -D${option}=${${option}})
+        endif()
+    endmacro(external_project_conditional_define)
+
+    external_project_conditional_define(CMAKE_INSTALL_MESSAGE)
+    external_project_conditional_define(CMAKE_BUILD_TYPE)
+    external_project_conditional_define(CMAKE_MAKE_PROGRAM)
+
+    if(BUILD_UB2)
+        # UB2 builds require this flag
+        external_project_conditional_define(CMAKE_OSX_ARCHITECTURES)
+        external_project_conditional_define(CMAKE_OSX_DEPLOYMENT_TARGET)
+    endif()
+
+    # Debugging informations for external projects
+    external_project_conditional_define(CMAKE_VERBOSE_MAKEFILE)
+    external_project_conditional_define(CMAKE_FIND_DEBUG_MODE)
+
+    set(${out_var} ${setting_list} PARENT_SCOPE)
+endfunction(get_external_project_default_values)
+
+# Create one for all the project using the default list separator
+get_external_project_default_values(MAYAUSD_EXTERNAL_PROJECT_GENERAL_SETTINGS "$<SEMICOLON>")


### PR DESCRIPTION
#### MAYA-124107 - MayaUSD: build as Universal Binary 2 (x86_64 + arm64)
* Added support for Microsoft Visual Studio 2019/2022.
* Created helper for general external project settings. Includes OSX UB2 and Linux CXX11_ABI.