### PR TITLE
MAYA-124106 preserve timeline during edit-as-Maya

### DIFF
--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -1122,6 +1122,7 @@ UsdMayaJobImportArgs::UsdMayaJobImportArgs(
     , importInstances(_Boolean(userArgs, UsdMayaJobImportArgsTokens->importInstances))
     , useAsAnimationCache(_Boolean(userArgs, UsdMayaJobImportArgsTokens->useAsAnimationCache))
     , importWithProxyShapes(importWithProxyShapes)
+    , preserveTimeline(_Boolean(userArgs, UsdMayaJobImportArgsTokens->preserveTimeline))
     , pullImportStage(_UsdStageRefPtr(userArgs, UsdMayaJobImportArgsTokens->pullImportStage))
     , timeInterval(timeInterval)
     , chaserNames(_Vector<std::string>(userArgs, UsdMayaJobImportArgsTokens->chaser))
@@ -1176,6 +1177,7 @@ const VtDictionary& UsdMayaJobImportArgs::GetDefaultDictionary()
         d[UsdMayaJobImportArgsTokens->importUSDZTexturesFilePath] = "";
         d[UsdMayaJobImportArgsTokens->pullImportStage] = UsdStageRefPtr();
         d[UsdMayaJobImportArgsTokens->useAsAnimationCache] = false;
+        d[UsdMayaJobImportArgsTokens->preserveTimeline] = false;
         d[UsdMayaJobExportArgsTokens->chaser] = std::vector<VtValue>();
         d[UsdMayaJobExportArgsTokens->chaserArgs] = std::vector<VtValue>();
 
@@ -1253,6 +1255,7 @@ const VtDictionary& UsdMayaJobImportArgs::GetGuideDictionary()
         d[UsdMayaJobImportArgsTokens->importUSDZTexturesFilePath] = _string;
         d[UsdMayaJobImportArgsTokens->pullImportStage] = _usdStageRefPtr;
         d[UsdMayaJobImportArgsTokens->useAsAnimationCache] = _boolean;
+        d[UsdMayaJobImportArgsTokens->preserveTimeline] = _boolean;
         d[UsdMayaJobExportArgsTokens->chaser] = _stringVector;
         d[UsdMayaJobExportArgsTokens->chaserArgs] = _stringTripletVector;
     });
@@ -1341,6 +1344,7 @@ std::ostream& operator<<(std::ostream& out, const UsdMayaJobImportArgs& importAr
         << std::endl
         << "timeInterval: " << importArgs.timeInterval << std::endl
         << "useAsAnimationCache: " << TfStringify(importArgs.useAsAnimationCache) << std::endl
+        << "preserveTimeline: " << TfStringify(importArgs.preserveTimeline) << std::endl
         << "importWithProxyShapes: " << TfStringify(importArgs.importWithProxyShapes) << std::endl;
 
     out << "jobContextNames (" << importArgs.jobContextNames.size() << ")" << std::endl;

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -146,6 +146,7 @@ TF_DECLARE_PUBLIC_TOKENS(
     (importUSDZTextures) \
     (importUSDZTexturesFilePath) \
     (pullImportStage) \
+    (preserveTimeline) \
     /* assemblyRep values */ \
     (Collapsed) \
     (Full) \
@@ -325,6 +326,7 @@ struct UsdMayaJobImportArgs
     const bool           importInstances;
     const bool           useAsAnimationCache;
     const bool           importWithProxyShapes;
+    const bool           preserveTimeline;
     const UsdStageRefPtr pullImportStage;
     /// The interval over which to import animated data.
     /// An empty interval (<tt>GfInterval::IsEmpty()</tt>) means that no

--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -95,13 +95,11 @@ struct AutoTimelineRestore
         , originalMaxTime(MAnimControl::maxTime())
 
     {
-        
     }
 
     ~AutoTimelineRestore()
     {
-        try
-        {
+        try {
             if (MAnimControl::minTime() != originalMinTime) {
                 MAnimControl::setMinTime(originalMinTime);
             }

--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -125,7 +125,7 @@ struct AutoTimelineRestore
         }
     }
 
-    const bool  preserveTimeline;       // If false, the timeline values are not preserved.
+    const bool  preserveTimeline; // If false, the timeline values are not preserved.
     const MTime originalAnimStartTime;
     const MTime originalAnimEndTime;
     const MTime originalMinTime;

--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -88,8 +88,9 @@ struct TempNodeTrackerScope
 
 struct AutoTimelineRestore
 {
-    AutoTimelineRestore()
-        : originalAnimStartTime(MAnimControl::animationStartTime())
+    AutoTimelineRestore(bool preserve)
+        : preserveTimeline(preserve)
+        , originalAnimStartTime(MAnimControl::animationStartTime())
         , originalAnimEndTime(MAnimControl::animationEndTime())
         , originalMinTime(MAnimControl::minTime())
         , originalMaxTime(MAnimControl::maxTime())
@@ -99,6 +100,9 @@ struct AutoTimelineRestore
 
     ~AutoTimelineRestore()
     {
+        if (!preserveTimeline)
+            return;
+
         try {
             if (MAnimControl::minTime() != originalMinTime) {
                 MAnimControl::setMinTime(originalMinTime);
@@ -121,6 +125,7 @@ struct AutoTimelineRestore
         }
     }
 
+    const bool  preserveTimeline;       // If false, the timeline values are not preserved.
     const MTime originalAnimStartTime;
     const MTime originalAnimEndTime;
     const MTime originalMinTime;
@@ -225,7 +230,7 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
 
     // If the import time interval isn't empty, we expand the Min/Max time
     // sliders to include the stage's range if necessary.
-    AutoTimelineRestore timelineRestore;
+    AutoTimelineRestore timelineRestore(mArgs.preserveTimeline);
     if (!mArgs.timeInterval.IsEmpty()) {
         GfInterval stageInterval;
         if (mArgs.timeInterval.IsFinite()) {

--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -85,6 +85,50 @@ struct TempNodeTrackerScope
 
     UsdMayaPrimReaderContext& _context;
 };
+
+struct AutoTimelineRestore
+{
+    AutoTimelineRestore()
+        : originalAnimStartTime(MAnimControl::animationStartTime())
+        , originalAnimEndTime(MAnimControl::animationEndTime())
+        , originalMinTime(MAnimControl::minTime())
+        , originalMaxTime(MAnimControl::maxTime())
+
+    {
+        
+    }
+
+    ~AutoTimelineRestore()
+    {
+        try
+        {
+            if (MAnimControl::minTime() != originalMinTime) {
+                MAnimControl::setMinTime(originalMinTime);
+            }
+
+            if (MAnimControl::maxTime() != originalMaxTime) {
+                MAnimControl::setMaxTime(originalMaxTime);
+            }
+
+            if (MAnimControl::animationStartTime() != originalAnimStartTime) {
+                MAnimControl::setAnimationStartTime(originalAnimStartTime);
+            }
+
+            if (MAnimControl::animationEndTime() != originalAnimEndTime) {
+                MAnimControl::setAnimationEndTime(originalAnimEndTime);
+            }
+
+        } catch (std::exception&) {
+            // Ignore - don't trhow exceptions from the destructor.
+        }
+    }
+
+    const MTime originalAnimStartTime;
+    const MTime originalAnimEndTime;
+    const MTime originalMinTime;
+    const MTime originalMaxTime;
+};
+
 } // namespace
 
 UsdMaya_ReadJob::UsdMaya_ReadJob(
@@ -183,10 +227,8 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
 
     // If the import time interval isn't empty, we expand the Min/Max time
     // sliders to include the stage's range if necessary.
+    AutoTimelineRestore timelineRestore;
     if (!mArgs.timeInterval.IsEmpty()) {
-        MTime currentMinTime = MAnimControl::minTime();
-        MTime currentMaxTime = MAnimControl::maxTime();
-
         GfInterval stageInterval;
         if (mArgs.timeInterval.IsFinite()) {
             if (mArgs.timeInterval.GetMin() > mArgs.timeInterval.GetMax()) {
@@ -203,11 +245,11 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
         }
 
         MTime::Unit timeUnit = MTime::uiUnit();
-        if (stageInterval.GetMin() < currentMinTime.value()) {
+        if (stageInterval.GetMin() < timelineRestore.originalMinTime.value()) {
             MAnimControl::setMinTime(
                 MTime(stageInterval.GetMin() * mTimeSampleMultiplier, timeUnit));
         }
-        if (stageInterval.GetMax() > currentMaxTime.value()) {
+        if (stageInterval.GetMax() > timelineRestore.originalMaxTime.value()) {
             MAnimControl::setMaxTime(
                 MTime(stageInterval.GetMax() * mTimeSampleMultiplier, timeUnit));
         }

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -341,6 +341,7 @@ PullImportPaths pullImport(
 
     VtDictionary userArgs(context.GetUserArgs());
     userArgs[UsdMayaJobImportArgsTokens->pullImportStage] = PXR_NS::VtValue(context.GetUsdStage());
+    userArgs[UsdMayaJobImportArgsTokens->preserveTimeline] = true;
 
     UsdMayaJobImportArgs jobArgs = UsdMayaJobImportArgs::CreateFromDictionary(
         userArgs,

--- a/lib/mayaUsd/python/wrapPrimReader.cpp
+++ b/lib/mayaUsd/python/wrapPrimReader.cpp
@@ -465,6 +465,7 @@ void wrapJobImportArgs()
             make_getter(
                 &UsdMayaJobImportArgs::timeInterval, return_value_policy<return_by_value>()))
         .def_readonly("useAsAnimationCache", &UsdMayaJobImportArgs::useAsAnimationCache)
+        .def_readonly("preserveTimeline", &UsdMayaJobImportArgs::preserveTimeline)
         .def("GetMaterialConversion", &UsdMayaJobImportArgs::GetMaterialConversion);
 
     to_python_converter<


### PR DESCRIPTION
- Preserve the timeline start/end and min/max after editing a Maya reference.
- Add a unit test that checks the timeline preservation.
- Corrected two tests that had their named swapped.