### PR TITLE
MAYA-115170 fix export when exportRoots and stripNamespaces are combined

### DIFF
--- a/lib/mayaUsd/commands/baseExportCommand.cpp
+++ b/lib/mayaUsd/commands/baseExportCommand.cpp
@@ -19,6 +19,7 @@
 #include <mayaUsd/fileio/jobs/jobArgs.h>
 #include <mayaUsd/fileio/shading/shadingModeRegistry.h>
 #include <mayaUsd/fileio/utils/writeUtil.h>
+#include <mayaUsd/utils/utilDictionary.h>
 
 #include <pxr/pxr.h>
 
@@ -332,11 +333,33 @@ MStatus MayaUSDExportCommand::doIt(const MArgList& args)
             frameSamples.insert(tmpArgList.asDouble(0));
         }
 
+        // The priority order for what objects get exported is (from highest to lowest):
+        //
+        //     - Requesting to export the current selection.
+        //     - Explicit export roots provided to the command.
+        //     - Explicit objects given to the command.
+        //     - Otherwise defaults to all objects.
+        //
+        // This priority order is embodied from code here and from code in the function
+        // UsdMayaUtil::GetFilteredSelectionToExport.
+
         MSelectionList           objSelList;
         UsdMayaUtil::MDagPathSet dagPaths;
         bool                     exportSelected = argData.isFlagSet(kSelectionFlag);
         if (!exportSelected) {
-            argData.getObjects(objSelList);
+            if (userArgs.count(UsdMayaJobExportArgsTokens->exportRoots) > 0) {
+                const auto exportRoots = DictUtils::extractVector<std::string>(
+                    userArgs, UsdMayaJobExportArgsTokens->exportRoots);
+                if (exportRoots.size() > 0) {
+                    for (const std::string root : exportRoots) {
+                        objSelList.add(root.c_str());
+                    }
+                }
+            }
+
+            if (objSelList.isEmpty()) {
+                argData.getObjects(objSelList);
+            }
         }
         UsdMayaUtil::GetFilteredSelectionToExport(exportSelected, objSelList, dagPaths);
 

--- a/lib/mayaUsd/utils/CMakeLists.txt
+++ b/lib/mayaUsd/utils/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(${PROJECT_NAME}
         traverseLayer.cpp
         undoHelperCommand.cpp
         util.cpp
+        utilDictionary.cpp
         utilFileSystem.cpp
         utilSerialization.cpp
         variants.cpp
@@ -44,6 +45,7 @@ set(HEADERS
     traverseLayer.h
     undoHelperCommand.h
     util.h
+    utilDictionary.h
     utilFileSystem.h
     utilSerialization.h
     variants.h

--- a/lib/mayaUsd/utils/utilDictionary.cpp
+++ b/lib/mayaUsd/utils/utilDictionary.cpp
@@ -1,0 +1,143 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "utilDictionary.h"
+
+namespace MAYAUSD_NS_DEF {
+
+namespace DictUtils {
+
+using namespace PXR_NS;
+
+/// Extracts a bool at \p key from \p userArgs, or false if it can't extract.
+bool extractBoolean(const VtDictionary& userArgs, const TfToken& key)
+{
+    if (!VtDictionaryIsHolding<bool>(userArgs, key)) {
+        TF_CODING_ERROR(
+            "Dictionary is missing required key '%s' or key is "
+            "not bool type",
+            key.GetText());
+        return false;
+    }
+    return VtDictionaryGet<bool>(userArgs, key);
+}
+
+/// Extracts a pointer at \p key from \p userArgs, or nullptr if it can't extract.
+UsdStageRefPtr extractUsdStageRefPtr(const VtDictionary& userArgs, const TfToken& key)
+{
+    if (!VtDictionaryIsHolding<UsdStageRefPtr>(userArgs, key)) {
+        TF_CODING_ERROR(
+            "Dictionary is missing required key '%s' or key is "
+            "not pointer type",
+            key.GetText());
+        return nullptr;
+    }
+    return VtDictionaryGet<UsdStageRefPtr>(userArgs, key);
+}
+
+/// Extracts a double at \p key from \p userArgs, or defaultValue if it can't extract.
+double extractDouble(const VtDictionary& userArgs, const TfToken& key, double defaultValue)
+{
+    if (VtDictionaryIsHolding<double>(userArgs, key))
+        return VtDictionaryGet<double>(userArgs, key);
+
+    // Since user dictionary can be provided from Python and in Python it is easy to
+    // mix int and double, especially since value literal will take the simplest value
+    // they can, for example 0 will be an int, support receiving the value as an integer.
+    if (VtDictionaryIsHolding<int>(userArgs, key))
+        return VtDictionaryGet<int>(userArgs, key);
+
+    TF_CODING_ERROR(
+        "Dictionary is missing required key '%s' or key is "
+        "not double type",
+        key.GetText());
+    return defaultValue;
+}
+
+/// Extracts a string at \p key from \p userArgs, or "" if it can't extract.
+std::string extractString(const VtDictionary& userArgs, const TfToken& key)
+{
+    if (!VtDictionaryIsHolding<std::string>(userArgs, key)) {
+        TF_CODING_ERROR(
+            "Dictionary is missing required key '%s' or key is "
+            "not string type",
+            key.GetText());
+        return std::string();
+    }
+    return VtDictionaryGet<std::string>(userArgs, key);
+}
+
+/// Extracts a token at \p key from \p userArgs.
+/// If the token value is not either \p defaultToken or one of the
+/// \p otherTokens, then returns \p defaultToken instead.
+TfToken extractToken(
+    const VtDictionary&         userArgs,
+    const TfToken&              key,
+    const TfToken&              defaultToken,
+    const std::vector<TfToken>& otherTokens)
+{
+    const TfToken tok(extractString(userArgs, key));
+    for (const TfToken& allowedTok : otherTokens) {
+        if (tok == allowedTok) {
+            return tok;
+        }
+    }
+
+    // Empty token will silently be promoted to default value.
+    // Warning for non-empty tokens that don't match.
+    if (tok != defaultToken && !tok.IsEmpty()) {
+        TF_WARN(
+            "Value '%s' is not allowed for flag '%s'; using fallback '%s' "
+            "instead",
+            tok.GetText(),
+            key.GetText(),
+            defaultToken.GetText());
+    }
+    return defaultToken;
+}
+
+/// Extracts an absolute path at \p key from \p userArgs, or the empty path if
+/// it can't extract.
+SdfPath extractAbsolutePath(const VtDictionary& userArgs, const TfToken& key)
+{
+    const std::string s = extractString(userArgs, key);
+    // Assume that empty strings are empty paths. (This might be an error case.)
+    if (s.empty()) {
+        return SdfPath();
+    }
+    // Make all relative paths into absolute paths.
+    SdfPath path(s);
+    if (path.IsAbsolutePath()) {
+        return path;
+    } else {
+        return SdfPath::AbsoluteRootPath().AppendPath(path);
+    }
+}
+
+/// Convenience function that takes the result of extractVector and converts it to a
+/// TfToken::Set.
+TfToken::Set extractTokenSet(const VtDictionary& userArgs, const TfToken& key)
+{
+    const std::vector<std::string> vec = extractVector<std::string>(userArgs, key);
+    TfToken::Set                   result;
+    for (const std::string& s : vec) {
+        result.insert(TfToken(s));
+    }
+    return result;
+}
+
+} // namespace DictUtils
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/utilDictionary.h
+++ b/lib/mayaUsd/utils/utilDictionary.h
@@ -1,0 +1,128 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYA_USD_UTIL_DICTIONARY_H
+#define MAYA_USD_UTIL_DICTIONARY_H
+
+#include <mayaUsd/base/api.h>
+
+#include <pxr/base/tf/token.h>
+#include <pxr/base/vt/dictionary.h>
+#include <pxr/base/vt/value.h>
+#include <pxr/usd/sdf/path.h>
+#include <pxr/usd/usd/property.h>
+#include <pxr/usd/usd/stage.h>
+
+#include <vector>
+
+namespace MAYAUSD_NS_DEF {
+
+namespace DictUtils {
+
+/// \brief Extracts a bool at \p key from \p userArgs, or false if it can't extract.
+MAYAUSD_CORE_PUBLIC
+bool extractBoolean(const PXR_NS::VtDictionary& userArgs, const PXR_NS::TfToken& key);
+
+/// \brief Extracts a pointer at \p key from \p userArgs, or nullptr if it can't extract.
+MAYAUSD_CORE_PUBLIC
+PXR_NS::UsdStageRefPtr
+extractUsdStageRefPtr(const PXR_NS::VtDictionary& userArgs, const PXR_NS::TfToken& key);
+
+/// \brief Extracts a double at \p key from \p userArgs, or defaultValue if it can't extract.
+MAYAUSD_CORE_PUBLIC
+double extractDouble(
+    const PXR_NS::VtDictionary& userArgs,
+    const PXR_NS::TfToken&      key,
+    double                      defaultValue);
+
+/// \brief Extracts a string at \p key from \p userArgs, or "" if it can't extract.
+MAYAUSD_CORE_PUBLIC
+std::string extractString(const PXR_NS::VtDictionary& userArgs, const PXR_NS::TfToken& key);
+
+/// \brief Extracts a token at \p key from \p userArgs.
+/// If the token value is not either \p defaultToken or one of the
+/// \p otherTokens, then returns \p defaultToken instead.
+MAYAUSD_CORE_PUBLIC
+PXR_NS::TfToken extractToken(
+    const PXR_NS::VtDictionary&         userArgs,
+    const PXR_NS::TfToken&              key,
+    const PXR_NS::TfToken&              defaultToken,
+    const std::vector<PXR_NS::TfToken>& otherTokens);
+
+/// \brief Extracts an absolute path at \p key from \p userArgs, or the empty path if
+/// it can't extract.
+MAYAUSD_CORE_PUBLIC
+PXR_NS::SdfPath
+extractAbsolutePath(const PXR_NS::VtDictionary& userArgs, const PXR_NS::TfToken& key);
+
+/// \brief Extracts an vector<T> from the vector<VtValue> at \p key in \p userArgs.
+/// Returns an empty vector if it can't convert the entire value at \p key into
+/// a vector<T>.
+template <typename T>
+MAYAUSD_CORE_PUBLIC std::vector<T>
+                    extractVector(const PXR_NS::VtDictionary& userArgs, const PXR_NS::TfToken& key);
+
+/// \brief Convenience function that takes the result of extractVector and converts it to a
+/// TfToken::Set.
+MAYAUSD_CORE_PUBLIC
+PXR_NS::TfToken::Set
+extractTokenSet(const PXR_NS::VtDictionary& userArgs, const PXR_NS::TfToken& key);
+
+// Implementation of the templated function declared above.
+template <typename T>
+MAYAUSD_CORE_PUBLIC std::vector<T>
+                    extractVector(const PXR_NS::VtDictionary& userArgs, const PXR_NS::TfToken& key)
+{
+    // Using declaration is necessary for the TF_ macros to compile as they assume
+    // to be in that namespace.
+    using namespace PXR_NS;
+
+    // Check that vector exists.
+    if (VtDictionaryIsHolding<std::vector<T>>(userArgs, key)) {
+        std::vector<T> vals = VtDictionaryGet<std::vector<T>>(userArgs, key);
+        return vals;
+    }
+
+    if (!VtDictionaryIsHolding<std::vector<VtValue>>(userArgs, key)) {
+        TF_CODING_ERROR(
+            "Dictionary is missing required key '%s' or key is "
+            "not vector type",
+            key.GetText());
+        return std::vector<T>();
+    }
+
+    // Check that vector is correctly-typed.
+    std::vector<VtValue> vals = VtDictionaryGet<std::vector<VtValue>>(userArgs, key);
+    if (!std::all_of(vals.begin(), vals.end(), [](const VtValue& v) { return v.IsHolding<T>(); })) {
+        TF_CODING_ERROR(
+            "Vector at dictionary key '%s' contains elements of "
+            "the wrong type",
+            key.GetText());
+        return std::vector<T>();
+    }
+
+    // Extract values.
+    std::vector<T> result;
+    for (const VtValue& v : vals) {
+        result.push_back(v.UncheckedGet<T>());
+    }
+    return result;
+}
+
+} // namespace DictUtils
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif // MAYA_USD_UTIL_DICTIONARY_H

--- a/test/lib/usd/translators/testUsdExportRoots.py
+++ b/test/lib/usd/translators/testUsdExportRoots.py
@@ -33,14 +33,15 @@ class testUsdExportRoot(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         inputPath = fixturesUtils.setUpClass(__file__)
-
-        filePath = os.path.join(inputPath, "UsdExportRootsTest", "UsdExportRootsTest.ma")
-        cmds.file(filePath, force=True, open=True)
+        cls.filePath = os.path.join(inputPath, "UsdExportRootsTest", "UsdExportRootsTest.ma")
 
     @classmethod
     def tearDownClass(cls):
         standalone.uninitialize()
         
+    def setUp(self):
+        cmds.file(testUsdExportRoot.filePath, force=True, open=True)
+
     def doExportImportOneMethod(self, method, shouldError=False, root=None, selection=None):
         if isinstance(root, str):
             root = [root]
@@ -100,11 +101,11 @@ class testUsdExportRoot(unittest.TestCase):
 
     def assertPrim(self, stage, path, type):
         prim = stage.GetPrimAtPath(path)
-        self.assertTrue(prim.IsValid())
-        self.assertEqual(prim.GetTypeName(), type)
+        self.assertTrue(prim.IsValid(), "Expected to find %s" % path)
+        self.assertEqual(prim.GetTypeName(), type, "Expected prim %s to have type %s" % (path, type))
 
     def assertNotPrim(self, stage, path):
-        self.assertFalse(stage.GetPrimAtPath(path).IsValid())
+        self.assertFalse(stage.GetPrimAtPath(path).IsValid(), "Did not expect to find %s" % path)
 
     def testNonOverlappingSelectionRoot(self):
         # test that the command errors if we give it a root + selection that
@@ -305,6 +306,29 @@ class testUsdExportRoot(unittest.TestCase):
         def validator(stage):
             pass
         self.doExportImportTest(validator, shouldError=True, root='NoneExisting', selection='OtherTop')
+
+    def testExportRootStripNamespace(self):
+        # Test that stipnamespace works with export roots when stripped node names would conflict
+        # but only one was specified as root.
+
+        cmds.file(new=True, force=True)
+
+        cmds.namespace(add="myAssetA")
+        cmds.polySphere(name="myAssetA:sphere_GEO")
+        cmds.namespace(add="myAssetB")
+        cmds.polySphere(name="myAssetB:sphere_GEO")
+
+        usdFile = os.path.abspath("testExportRootStripNamespace.usda")
+
+        cmds.mayaUSDExport(file=usdFile,
+            exportRoots=['|myAssetA:sphere_GEO'],
+            stripNamespaces=True,
+            )
+            
+        stage = Usd.Stage.Open(usdFile)
+
+        self.assertPrim(stage, '/sphere_GEO', 'Mesh')
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
- Move the dictionary-value extractor functions from jobArgs.cpp to a utility namespace.
- Fix the problem of export roots and strip namespace by using the list of roots to limit whih objects are processed.
- This is done by using the roots as the list of objects to export.
- Add unit test based on problem report.