### PR TITLE
Broken AL_USDMaya and AL_USDTransaction builds (AL)

### DIFF
--- a/plugin/al/schemas/AL/usd/schemas/maya/tests/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/maya/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(${TARGET_NAME}
     tf
     vt
     plug
+    ${Boost_PYTHON_LIBRARY}
 )
 
 # install

--- a/plugin/al/schemas/AL/usd/schemas/maya/tests/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/maya/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries(${TARGET_NAME}
     tf
     vt
     plug
-    ${Boost_PYTHON_LIBRARY}
+    $<$<BOOL:${IS_LINUX}>:${Boost_PYTHON_LIBRARY}>
 )
 
 # install

--- a/plugin/al/usdtransaction/AL/usd/transaction/tests/CMakeLists.txt
+++ b/plugin/al/usdtransaction/AL/usd/transaction/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries(${TARGET_NAME}
     arch
     usd
     vt
-    ${Boost_PYTHON_LIBRARY}
+    $<$<BOOL:${IS_LINUX}>:${Boost_PYTHON_LIBRARY}>
     ${USDTRANSACTION_LIBRARY_NAME}
 )
 

--- a/plugin/al/usdtransaction/AL/usd/transaction/tests/CMakeLists.txt
+++ b/plugin/al/usdtransaction/AL/usd/transaction/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(${TARGET_NAME}
     arch
     usd
     vt
+    ${Boost_PYTHON_LIBRARY}
     ${USDTRANSACTION_LIBRARY_NAME}
 )
 


### PR DESCRIPTION
Sorry I didn't catch it earlier but one of the changes in https://github.com/Autodesk/maya-usd/pull/2456 , i.e., linking the boost python's library to the test executables, breaks our builds.
As I'm not across the reason for the removal in the first place, I reintroduce it here so we can discuss the best approach to get builds up and running.