### PR TITLE
MAYA-125054 - Fix namespace renaming

### DIFF
--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -215,7 +215,10 @@ void MayaSessionState::proxyShapeRemovedCB(MObject& node, void* clientData)
 }
 
 /* static */
-void MayaSessionState::namespaceRenamedCB(const MString& oldName, const MString& newName, void* clientData)
+void MayaSessionState::namespaceRenamedCB(
+    const MString& oldName,
+    const MString& newName,
+    void*          clientData)
 {
     if (oldName.length() != 0) {
         auto THIS = static_cast<MayaSessionState*>(clientData);

--- a/lib/usd/ui/layerEditor/mayaSessionState.h
+++ b/lib/usd/ui/layerEditor/mayaSessionState.h
@@ -86,7 +86,8 @@ protected:
     static void proxyShapeAddedCB(MObject& node, void* clientData);
     static void proxyShapeRemovedCB(MObject& node, void* clientData);
     static void nodeRenamedCB(MObject& node, const MString& oldName, void* clientData);
-    static void namespaceRenamedCB(const MString& oldName, const MString& newName, void* clientData);
+    static void
+                namespaceRenamedCB(const MString& oldName, const MString& newName, void* clientData);
     static void sceneClosingCB(void* clientData);
 
     void proxyShapeAddedCBOnIdle(const MObject& node);

--- a/lib/usd/ui/layerEditor/mayaSessionState.h
+++ b/lib/usd/ui/layerEditor/mayaSessionState.h
@@ -86,6 +86,7 @@ protected:
     static void proxyShapeAddedCB(MObject& node, void* clientData);
     static void proxyShapeRemovedCB(MObject& node, void* clientData);
     static void nodeRenamedCB(MObject& node, const MString& oldName, void* clientData);
+    static void namespaceRenamedCB(const MString& oldName, const MString& newName, void* clientData);
     static void sceneClosingCB(void* clientData);
 
     void proxyShapeAddedCBOnIdle(const MObject& node);


### PR DESCRIPTION
When a Maya namespace is renamed, we now update the stages proxy shape names that are managed by the layer manager.