### PR TITLE
MAYA-125149 - When "Enable Overrides" is unchecked for a Display Layer USD Data still uses Bounding Box

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
@@ -728,12 +728,12 @@ void MayaUsdRPrim::_SyncDisplayLayerModes(const HdRprim&
                 continue;
             }
 
-            MPlug             layerVisible = displayLayerNodeFn.findPlug("visibility");
-            MPlug             layerHidesOnPlayback = displayLayerNodeFn.findPlug("hideOnPlayback");
-            MPlug             layerDisplayType = displayLayerNodeFn.findPlug("displayType");
-            MPlug             levelOfDetail = displayLayerNodeFn.findPlug("levelOfDetail");
-            MPlug             shading = displayLayerNodeFn.findPlug("shading");
-            MPlug             texturing = displayLayerNodeFn.findPlug("texturing");
+            MPlug layerVisible = displayLayerNodeFn.findPlug("visibility");
+            MPlug layerHidesOnPlayback = displayLayerNodeFn.findPlug("hideOnPlayback");
+            MPlug layerDisplayType = displayLayerNodeFn.findPlug("displayType");
+            MPlug levelOfDetail = displayLayerNodeFn.findPlug("levelOfDetail");
+            MPlug shading = displayLayerNodeFn.findPlug("shading");
+            MPlug texturing = displayLayerNodeFn.findPlug("texturing");
 
             _displayLayerModes._visibility &= layerVisible.asBool();
             _displayLayerModes._hideOnPlayback |= layerHidesOnPlayback.asBool();
@@ -916,22 +916,26 @@ SdfPath MayaUsdRPrim::_GetUpdatedMaterialId(HdRprim* rprim, HdSceneDelegate* del
     return materialId;
 }
 
-bool MayaUsdRPrim::_GetMaterialPrimvars(HdRenderIndex& renderIndex, const SdfPath& materialId, TfTokenVector& primvars)
+bool MayaUsdRPrim::_GetMaterialPrimvars(
+    HdRenderIndex& renderIndex,
+    const SdfPath& materialId,
+    TfTokenVector& primvars)
 {
-    const HdVP2Material* material = static_cast<const HdVP2Material*>(renderIndex.GetSprim(HdPrimTypeTokens->material, materialId));
+    const HdVP2Material* material = static_cast<const HdVP2Material*>(
+        renderIndex.GetSprim(HdPrimTypeTokens->material, materialId));
     if (!material || !material->GetSurfaceShader(TfToken())) {
         return false;
     }
 
     // Get basic primvars
     primvars = material->GetRequiredPrimvars(TfToken());
-    
+
     // Get extra primvars
     if (material->GetSurfaceShader(HdReprTokens->smoothHull)) {
         const auto& extraPrimvars = material->GetRequiredPrimvars(HdReprTokens->smoothHull);
-        for (const auto& extraPrimvar: extraPrimvars) {
+        for (const auto& extraPrimvar : extraPrimvars) {
             if (std::find(primvars.begin(), primvars.end(), extraPrimvar) == primvars.end()) {
-               primvars.push_back(extraPrimvar); 
+                primvars.push_back(extraPrimvar);
             }
         }
     }

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
@@ -177,21 +177,20 @@ void MayaUsdRPrim::_UpdateTransform(
     }
 
     // Local-to-world transformation
-    MMatrix& worldMatrix = drawItemData._worldMatrix;
-    sharedData.bounds.GetMatrix().Get(worldMatrix.matrix);
-
     // The bounding box draw item uses a globally-shared unit wire cube as the
     // geometry and transfers scale and offset of the bounds to world matrix.
     if (isBoundingBoxItem) {
         if ((itemDirtyBits & (HdChangeTracker::DirtyExtent | HdChangeTracker::DirtyTransform))
             && !range.IsEmpty()) {
+            sharedData.bounds.GetMatrix().Get(drawItemData._worldMatrix.matrix);
+
             const GfVec3d midpoint = range.GetMidpoint();
             const GfVec3d size = range.GetSize();
 
             MPoint midp(midpoint[0], midpoint[1], midpoint[2]);
-            midp *= worldMatrix;
+            midp *= drawItemData._worldMatrix;
 
-            auto& m = worldMatrix.matrix;
+            auto& m = drawItemData._worldMatrix.matrix;
             m[0][0] *= size[0];
             m[0][1] *= size[0];
             m[0][2] *= size[0];
@@ -212,6 +211,7 @@ void MayaUsdRPrim::_UpdateTransform(
             stateToCommit._worldMatrix = &drawItemData._worldMatrix;
         }
     } else if (itemDirtyBits & HdChangeTracker::DirtyTransform) {
+        sharedData.bounds.GetMatrix().Get(drawItemData._worldMatrix.matrix);
         stateToCommit._worldMatrix = &drawItemData._worldMatrix;
     }
 }
@@ -724,6 +724,10 @@ void MayaUsdRPrim::_SyncDisplayLayerModes(const HdRprim&
         for (unsigned int i = 0; i < ancestorDisplayLayers.length(); i++) {
             MFnDependencyNode displayLayerNodeFn(ancestorDisplayLayers[i]);
             MPlug             layerEnabled = displayLayerNodeFn.findPlug("enabled");
+            if (!layerEnabled.asBool()) {
+                continue;
+            }
+
             MPlug             layerVisible = displayLayerNodeFn.findPlug("visibility");
             MPlug             layerHidesOnPlayback = displayLayerNodeFn.findPlug("hideOnPlayback");
             MPlug             layerDisplayType = displayLayerNodeFn.findPlug("displayType");
@@ -731,7 +735,7 @@ void MayaUsdRPrim::_SyncDisplayLayerModes(const HdRprim&
             MPlug             shading = displayLayerNodeFn.findPlug("shading");
             MPlug             texturing = displayLayerNodeFn.findPlug("texturing");
 
-            _displayLayerModes._visibility &= layerEnabled.asBool() ? layerVisible.asBool() : true;
+            _displayLayerModes._visibility &= layerVisible.asBool();
             _displayLayerModes._hideOnPlayback |= layerHidesOnPlayback.asBool();
             _displayLayerModes._texturing = texturing.asBool();
             if (levelOfDetail.asShort() != 0) {
@@ -767,13 +771,13 @@ void MayaUsdRPrim::_SyncSharedData(
     }
 
     if (HdChangeTracker::IsVisibilityDirty(*dirtyBits, id)) {
-        bool usdVisibility = delegate->GetVisible(id);
+        sharedData.visible = delegate->GetVisible(id) && _displayLayerModes._visibility;
 
         // Invisible rprims don't get calls to Sync or _PropagateDirtyBits while
         // they are invisible. This means that when a prim goes from visible to
         // invisible that we must update every repr, because if we switch reprs while
         // invisible we'll get no chance to update!
-        if (!usdVisibility)
+        if (!sharedData.visible)
             _MakeOtherReprRenderItemsInvisible(reprToken, reprs);
 
         // Update "hide on playback" status
@@ -788,8 +792,6 @@ void MayaUsdRPrim::_SyncSharedData(
             _ForEachRenderItem(reprs, setHideOnPlayback);
 #endif
         }
-
-        sharedData.visible = usdVisibility && _displayLayerModes._visibility;
     }
 
 #if PXR_VERSION > 2111
@@ -912,6 +914,29 @@ SdfPath MayaUsdRPrim::_GetUpdatedMaterialId(HdRprim* rprim, HdSceneDelegate* del
     }
 
     return materialId;
+}
+
+bool MayaUsdRPrim::_GetMaterialPrimvars(HdRenderIndex& renderIndex, const SdfPath& materialId, TfTokenVector& primvars)
+{
+    const HdVP2Material* material = static_cast<const HdVP2Material*>(renderIndex.GetSprim(HdPrimTypeTokens->material, materialId));
+    if (!material || !material->GetSurfaceShader(TfToken())) {
+        return false;
+    }
+
+    // Get basic primvars
+    primvars = material->GetRequiredPrimvars(TfToken());
+    
+    // Get extra primvars
+    if (material->GetSurfaceShader(HdReprTokens->smoothHull)) {
+        const auto& extraPrimvars = material->GetRequiredPrimvars(HdReprTokens->smoothHull);
+        for (const auto& extraPrimvar: extraPrimvars) {
+            if (std::find(primvars.begin(), primvars.end(), extraPrimvar) == primvars.end()) {
+               primvars.push_back(extraPrimvar); 
+            }
+        }
+    }
+
+    return true;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -83,7 +83,7 @@ struct MayaUsdCommitState
     PrimvarBufferDataMap _primvarBufferDataMap;
 
     //! If valid, world matrix to set on the render item
-    MMatrix* _worldMatrix { nullptr };
+    const MMatrix* _worldMatrix { nullptr };
 
     //! If valid, bounding box to set on the render item
     MBoundingBox* _boundingBox { nullptr };
@@ -270,6 +270,8 @@ protected:
 
     //! Helper utility function to adapt Maya API changes.
     static void _SetWantConsolidation(MHWRender::MRenderItem& renderItem, bool state);
+
+    static bool _GetMaterialPrimvars(HdRenderIndex&, const SdfPath&, TfTokenVector&);
 
     void _InitRenderItemCommon(MHWRender::MRenderItem* renderItem) const;
 

--- a/lib/mayaUsd/ufe/UsdAttributes.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributes.cpp
@@ -61,7 +61,7 @@ _GetSdrPropertyAndType(const Ufe::SceneItem::Ptr& item, const std::string& tokNa
 {
     auto shaderNode = UsdShaderNodeDefHandler::usdDefinition(item);
     if (shaderNode) {
-        auto baseNameAndType = PXR_NS::UsdShadeUtils::GetBaseNameAndType(TfToken(tokName));
+        auto baseNameAndType = PXR_NS::UsdShadeUtils::GetBaseNameAndType(PXR_NS::TfToken(tokName));
         switch (baseNameAndType.second) {
         case PXR_NS::UsdShadeAttributeType::Invalid: return { nullptr, baseNameAndType.second };
         case PXR_NS::UsdShadeAttributeType::Input:


### PR DESCRIPTION
- properly handle display layer's attribute "enable"
- fixing an issue with bound box dimensions when a display layer is switched to bound box mode in multi-viewport
- fixing an issue with visibility when a display layer is switched into invisible state while in multi-viewport
- fixing an issue with enabling all required material primvars from both networks: full and untextured