### PR TITLE
MAYA-124951: Duplicate as USD Data timeline options don't show what is currently applied

### DIFF
--- a/lib/mayaUsd/resources/scripts/mayaUsdMergeToUSDOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdMergeToUSDOptions.py
@@ -245,12 +245,12 @@ def _getMergeToUSDOptionsVarName():
 
 def getMergeToUSDOptionsText():
     """
-    Retrieves the current merge-to-USD options as text with column-spearated key/value pairs.
+    Retrieves the current merge-to-USD options as text with column-seperated key/value pairs.
     """
     return mayaUsdOptions.getOptionsText(
         _getMergeToUSDOptionsVarName(),
         getDefaultMergeToUSDOptionsDict())
-    
+
 
 def setMergeToUSDOptionsText(optionsText):
     """

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -796,9 +796,9 @@ global proc int mayaUsdTranslatorExport (string $parent,
         mayaUsdTranslatorExport_EnableAllControls();
         mayaUsdTranslatorExport_SetFromOptions($currentOptions, 1, 1);
 
-        // Set visibility for anim widgets
+        // Set visibility for anim widgets (but do not update the start/end time to playback range
+        // as they will be set by the caller).
         mayaUsdTranslatorExport_AnimationCB();
-        mayaUsdTranslatorExport_AnimationRangeCB();
 
         $bResult = 1;
     }


### PR DESCRIPTION
MAYA-124951: Duplicate as USD Data timeline options don't show what is currently applied

* Do not auto-update the animation start/end to the playback range as it doesn't actually reflect the values used by the options other than export (edit as maya, merge to maya).