### PR TITLE
Show correct render backend name

### DIFF
--- a/lib/mayaUsd/render/mayaToHydra/utils.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/utils.cpp
@@ -33,7 +33,7 @@
 #include <pxr/imaging/glf/contextCaps.h>
 #include <pxr/imaging/hd/rendererPlugin.h>
 #include <pxr/imaging/hd/rendererPluginRegistry.h>
-
+#include <pxr/usdImaging/usdImagingGL/engine.h>
 #include <maya/MGlobal.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -87,11 +87,13 @@ MtohInitializeRenderPlugins()
             // Null it out to make any possible usage later obv, wrong!
             delegate = nullptr;
 
+            std::shared_ptr<pxr::UsdImagingGLEngine> _engine;
             store.first.emplace_back(
                 renderer,
                 TfToken(TfStringPrintf("%s%s", MTOH_RENDER_OVERRIDE_PREFIX, renderer.GetText())),
                 TfToken(TfStringPrintf(
-                    "(Mtoh Experimental) Hydra %s", pluginDesc.displayName.c_str())));
+                    "(Mtoh Experimental) Hydra %s",
+                    _engine->GetRendererDisplayName(pluginDesc.id).c_str())));
             MtohRenderGlobals::BuildOptionsMenu(store.first.back(), rendererSettingDescriptors);
         }
 


### PR DESCRIPTION
This is a small PR to show the correct render name for MtoH in the UI. This doesn't help mtoh work better on mac yet, but it does help my OCD slightly.

This API exists on USD 20.02 and higher. Hopefully that's fine for the current USD versioning being used for Maya USD

<img width="283" alt="image" src="https://user-images.githubusercontent.com/4443090/191604050-72b6cb57-c40f-4dce-87bf-bc08bfb6000e.png">
