### PR TITLE
MAYA-125364 - MayaUsd: Maya master blessing failing (Linux only)

### DIFF
--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -25,6 +25,10 @@ macro(fetch_googletest)
         # sequence parsing errors.  PPT, 22-Nov-2018.
         file(TO_CMAKE_PATH ${CMAKE_MAKE_PROGRAM} CMAKE_MAKE_PROGRAM)
 
+        set(CMAKE_CXX_STANDARD 11)
+        set(CMAKE_CXX_EXTENSIONS OFF)
+        set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
         if (GOOGLETEST_SRC_DIR)
             configure_file(cmake/googletest_src.txt.in ${GOOGLETEST_BUILD_ROOT}/googletest-config/CMakeLists.txt)
         else()

--- a/cmake/googletest_download.txt.in
+++ b/cmake/googletest_download.txt.in
@@ -10,13 +10,9 @@ project(googletest-download NONE)
 
 include(ExternalProject)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           release-1.10.0
+  GIT_TAG           release-1.11.0
   GIT_CONFIG        advice.detachedHead=false
   SOURCE_DIR        "${GOOGLETEST_BUILD_ROOT}/googletest-src"
   BINARY_DIR        "${GOOGLETEST_BUILD_ROOT}/googletest-build"

--- a/cmake/googletest_src.txt.in
+++ b/cmake/googletest_src.txt.in
@@ -8,10 +8,6 @@ project(googletest-download NONE)
 
 include(ExternalProject)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 ExternalProject_Add(googletest
   DOWNLOAD_COMMAND  ""
   UPDATE_COMMAND    ""


### PR DESCRIPTION
#### MAYA-125364 - MayaUsd: Maya master blessing failing (Linux only)
* Update googletest (release-1.10.0 -> release-1.11.0) to get fix required for update to gcc 11.