### PR TITLE
MAYA-125364 - MayaUsd: Maya master blessing failing (Linux only)

### DIFF
--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -25,6 +25,18 @@ macro(fetch_googletest)
         # sequence parsing errors.  PPT, 22-Nov-2018.
         file(TO_CMAKE_PATH ${CMAKE_MAKE_PROGRAM} CMAKE_MAKE_PROGRAM)
 
+        # Set some options used when compiling googletest.
+        set(CMAKE_CXX_STANDARD 11)
+        set(CMAKE_CXX_EXTENSIONS OFF)
+        set(CMAKE_CXX_STANDARD_REQUIRED ON)
+        if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+            # In gcc 11 there was a new warning (about uninit variable) in googletest.
+            # Since we have warnings as errors, this causes build error.
+            # Simply disable all warnings in googletest since we won't fix them anyways.
+            # We will just update to newer version, if required.
+            set(disable_all_warnings_flag -w)
+        endif()
+
         if (GOOGLETEST_SRC_DIR)
             configure_file(cmake/googletest_src.txt.in ${GOOGLETEST_BUILD_ROOT}/googletest-config/CMakeLists.txt)
         else()

--- a/cmake/googletest_download.txt.in
+++ b/cmake/googletest_download.txt.in
@@ -10,10 +10,6 @@ project(googletest-download NONE)
 
 include(ExternalProject)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   GIT_TAG           release-1.10.0
@@ -31,5 +27,5 @@ ExternalProject_Add(googletest
                     "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
                     "-DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}"
                     "-DCMAKE_CXX_STANDARD_REQUIRED=${CMAKE_CXX_STANDARD_REQUIRED}"
-                    "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
+                    "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} ${disable_all_warnings_flag}"
 )

--- a/cmake/googletest_src.txt.in
+++ b/cmake/googletest_src.txt.in
@@ -8,10 +8,6 @@ project(googletest-download NONE)
 
 include(ExternalProject)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 ExternalProject_Add(googletest
   DOWNLOAD_COMMAND  ""
   UPDATE_COMMAND    ""
@@ -28,5 +24,5 @@ ExternalProject_Add(googletest
                     "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
                     "-DCMAKE_CXX_EXTENSIONS=${CMAKE_CXX_EXTENSIONS}"
                     "-DCMAKE_CXX_STANDARD_REQUIRED=${CMAKE_CXX_STANDARD_REQUIRED}"
-                    "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}"
+                    "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} ${disable_all_warnings_flag}"
 )


### PR DESCRIPTION
#### MAYA-125364 - MayaUsd: Maya master blessing failing (Linux only)
* Minor changes to settings used when compiling googletest required for building with gcc 11.