### PR TITLE
 MAYA-125101 Correct handling of display list vs variants

### DIFF
--- a/lib/mayaUsd/fileio/orphanedNodesManager.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.cpp
@@ -335,8 +335,8 @@ void OrphanedNodesManager::recursiveSwitch(
         // it will have the same runtime ID by default and only retrieve
         // the new runtime ID if we cross a gateway node.
         const Ufe::Rtid runtimeId = ufePath.runTimeId();
-        Ufe::Rtid childRuntimeId = runtimeId;
-        char      childSep = ufePath.getSegments().back().separator();
+        Ufe::Rtid       childRuntimeId = runtimeId;
+        char            childSep = ufePath.getSegments().back().separator();
         if (Ufe::SceneSegmentHandler::isGateway(ufePath)) {
             if (Ufe::SceneItem::Ptr sceneItem = Ufe::Hierarchy::createItem(ufePath)) {
                 if (Ufe::Hierarchy::Ptr itemHier = Ufe::Hierarchy::hierarchy(sceneItem)) {

--- a/lib/mayaUsd/ufe/UsdStageMap.cpp
+++ b/lib/mayaUsd/ufe/UsdStageMap.cpp
@@ -176,6 +176,11 @@ MObject UsdStageMap::proxyShape(const Ufe::Path& path)
         for (const auto& entry : pathToObject) {
             const auto& cachedPath = entry.first;
             const auto& cachedObject = entry.second;
+            // If the cached object itself is invalid then remove it from the map.
+            if (!cachedObject.isValid()) {
+                fPathToObject.erase(cachedPath);
+                continue;
+            }
             // Get the UFE path from the map value.
             auto newPath = firstPath(cachedObject);
             if (newPath != cachedPath) {

--- a/lib/mayaUsd/ufe/UsdStageMap.cpp
+++ b/lib/mayaUsd/ufe/UsdStageMap.cpp
@@ -182,7 +182,8 @@ MObject UsdStageMap::proxyShape(const Ufe::Path& path)
                 // Key is stale.  Remove it from our cache, and add the new entry.
                 auto count = fPathToObject.erase(cachedPath);
                 TF_AXIOM(count);
-                fPathToObject[newPath] = cachedObject;
+                if (!newPath.empty())
+                    fPathToObject[newPath] = cachedObject;
             }
         }
 
@@ -220,7 +221,8 @@ MObject UsdStageMap::proxyShape(const Ufe::Path& path)
             // we are in scenario 2. Update the entry in fPathToObject so that the key path
             // is the current object path.
             fPathToObject.erase(singleSegmentPath);
-            fPathToObject[objectPath] = object;
+            if (!objectPath.empty())
+                fPathToObject[objectPath] = object;
             TF_VERIFY(std::end(fPathToObject) == fPathToObject.find(singleSegmentPath));
             return MObject();
         }


### PR DESCRIPTION
When undoing the deletion of an ancestor of a USD prim with variant which had some of its children edited as Maya, we need to validate that the correct set of variant is active before showing the edited Maya data.

Also, when going down the items of the trie that contains the UFE path component, we need to properly handle the points where we cross run-times (currenly there is only Maya and USD). When crossing runtimes, we must create a new segment.