### PR TITLE
Clearing out stage listeners before creating new ones

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1581,9 +1581,9 @@ MStatus ProxyShape::computeOutStageData(const MPlug& plug, MDataBlock& dataBlock
         return MS::kFailure;
     }
 
-    // Sending MayaUsdProxyStageInvalidateNotice will trigger a callback in StagesSubject 
-    // to clear out stage listeners before adding new stage listeners by the callback triggered by 
-    // MayaUsdProxyStageSetNotice. 
+    // Sending MayaUsdProxyStageInvalidateNotice will trigger a callback in StagesSubject
+    // to clear out stage listeners before adding new stage listeners by the callback triggered by
+    // MayaUsdProxyStageSetNotice.
     MayaUsdProxyStageInvalidateNotice(*this).Send();
     MayaUsdProxyStageSetNotice(*this).Send();
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1581,6 +1581,10 @@ MStatus ProxyShape::computeOutStageData(const MPlug& plug, MDataBlock& dataBlock
         return MS::kFailure;
     }
 
+    // Sending MayaUsdProxyStageInvalidateNotice will trigger a callback in StagesSubject 
+    // to clear out stage listeners before adding new stage listeners by the callback triggered by 
+    // MayaUsdProxyStageSetNotice. 
+    MayaUsdProxyStageInvalidateNotice(*this).Send();
     MayaUsdProxyStageSetNotice(*this).Send();
 
     return status;


### PR DESCRIPTION
This PR is related to this post: https://github.com/Autodesk/maya-usd/discussions/2516. In short, we recently found in our production in Animal Logic that, in some cases, `StagesSubject::onStageSet()` was called when `fStageListeners` was not empty which was causing verification message  being emitted constantly in Maya script editor:

```
// Error: Failed verification: ' g_StageMap.isDirty() ' // 
// Error: Failed verification: ' fStageListeners.empty() ' // 
```

We found `StagesSubject::onStageSet()` is triggered by `MayaUsdProxyStageSetNotice`, and `fStageListeners` is cleared out in
https://github.com/Autodesk/maya-usd/blob/dev/lib/mayaUsd/ufe/StagesSubject.cpp#L415-L442 which is called in `StagesSubject::onStageInvalidate()` https://github.com/Autodesk/maya-usd/blob/dev/lib/mayaUsd/ufe/StagesSubject.cpp#L733-L743. Because`StagesSubject::onStageInvalidate()` is triggered by `MayaUsdProxyStageInvalidateNotice`, so we made change like this PR internally to clear out the `fStageListeners` in AL_USDMaya's `ProxyShape::computeOutStageData()` before sending `MayaUsdProxyStageSetNotice` to fill in new listeners. I also discovered that maya-usd's proxyShapeBase is doing the similar thing to clear out the stage listeners in `MayaUsdProxyShapeBase::computeOutStageData()` https://github.com/Autodesk/maya-usd/blob/dev/lib/mayaUsd/nodes/proxyShapeBase.cpp#L1049-L1056. And the new stage listeners are filled in here https://github.com/Autodesk/maya-usd/blob/dev/lib/mayaUsd/nodes/proxyShapeBase.cpp#L1128-L1139 before sending `MayaUsdProxyStageSetNotice`. 