### PR TITLE
Fix orphaned node discard edits with unloaded ancestor.

### DIFF
--- a/lib/mayaUsd/fileio/orphanedNodesManager.h
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.h
@@ -124,6 +124,10 @@ public:
     // Return true if there are no pulled paths in the trie of pulled prims.
     bool empty() const;
 
+    // Return whether the Dag hierarchy corresponding to the pulled path is
+    // orphaned.
+    bool isOrphaned(const Ufe::Path& pulledPath) const;
+
 private:
     void handleOp(const Ufe::SceneCompositeNotification::Op& op);
 
@@ -136,7 +140,8 @@ private:
     recursiveSwitch(const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode, const Ufe::Path& ufePath);
 
     static bool
-    setVisibilityPlug(const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode, bool visibility);
+                setVisibilityPlug(const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode, bool visibility);
+    static bool getVisibilityPlug(const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode);
 
     // Member function to access private nested classes.
     static std::list<VariantSetDescriptor> variantSetDescriptors(const Ufe::Path& path);

--- a/test/lib/mayaUsd/fileio/CMakeLists.txt
+++ b/test/lib/mayaUsd/fileio/CMakeLists.txt
@@ -22,7 +22,6 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
         testAddMayaReference.py
         testEditAsMaya.py
         testMergeToUsd.py
-        testDiscardEdits.py
         testDuplicateAs.py
         testPrimUpdater.py
         testCacheToUsd.py
@@ -83,6 +82,27 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
         ENV
             "${PXR_OVERRIDE_PLUGINPATH_NAME}=${CMAKE_CURRENT_SOURCE_DIR}/UsdCustomRigSchema/"
     )
+endif()
+
+if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
+    set(TEST_DISCARD_EDITS testDiscardEdits.py)
+    mayaUsd_get_unittest_target(target ${TEST_DISCARD_EDITS})
+    if(UFE_TRIE_NODE_HAS_CHILDREN_COMPONENTS_ACCESSOR)
+        mayaUsd_add_test(${target}
+            PYTHON_MODULE ${target}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            ENV
+                "HAS_ORPHANED_NODES_MANAGER=1"
+        )
+    else()
+        mayaUsd_add_test(${target}
+            PYTHON_MODULE ${target}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+    endif()
+
+    # Add a ctest label for easy filtering.
+    set_property(TEST ${target} APPEND PROPERTY LABELS fileio)
 endif()
 
 add_subdirectory(utils)


### PR DESCRIPTION
As per MAYA-123378, discarding edits on an orphaned Maya node whose USD ancestor is unloaded causes an error.

Added a unit test for this case.  Without the fix, the test fails, with the fix, the test succeeds.
