### PR TITLE
Added test for getAllStages() versus delete.

### DIFF
--- a/lib/mayaUsd/ufe/wrapUtils.cpp
+++ b/lib/mayaUsd/ufe/wrapUtils.cpp
@@ -17,8 +17,8 @@
 #include <mayaUsd/ufe/UsdSceneItem.h>
 #include <mayaUsd/ufe/Utils.h>
 
-#include <pxr/base/tf/stringUtils.h>
 #include <pxr/base/tf/pyResultConversions.h>
+#include <pxr/base/tf/stringUtils.h>
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usdImaging/usdImaging/delegate.h>
 
@@ -94,10 +94,10 @@ PXR_NS::UsdStageWeakPtr getStage(const std::string& ufePathString)
 
 std::vector<PXR_NS::UsdStageRefPtr> getAllStages()
 {
-    auto allStages = ufe::getAllStages();
+    auto                                allStages = ufe::getAllStages();
     std::vector<PXR_NS::UsdStageRefPtr> output;
     for (auto stage : allStages) {
-        PXR_NS::UsdStageRefPtr stageRefPtr{stage};
+        PXR_NS::UsdStageRefPtr stageRefPtr { stage };
         output.push_back(stageRefPtr);
     }
     return output;

--- a/lib/mayaUsd/ufe/wrapUtils.cpp
+++ b/lib/mayaUsd/ufe/wrapUtils.cpp
@@ -18,6 +18,7 @@
 #include <mayaUsd/ufe/Utils.h>
 
 #include <pxr/base/tf/stringUtils.h>
+#include <pxr/base/tf/pyResultConversions.h>
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usdImaging/usdImaging/delegate.h>
 
@@ -30,6 +31,7 @@
 #include <ufe/pathString.h>
 #endif
 
+#include <boost/python.hpp>
 #include <boost/python/def.hpp>
 
 #include <string>
@@ -88,6 +90,17 @@ PXR_NS::UsdStageWeakPtr getStage(const std::string& ufePathString)
     }
     return ufe::getStage(Ufe::Path(Ufe::PathSegment(proxyPath, 1, '|')));
 #endif
+}
+
+std::vector<PXR_NS::UsdStageRefPtr> getAllStages()
+{
+    auto allStages = ufe::getAllStages();
+    std::vector<PXR_NS::UsdStageRefPtr> output;
+    for (auto stage : allStages) {
+        PXR_NS::UsdStageRefPtr stageRefPtr{stage};
+        output.push_back(stageRefPtr);
+    }
+    return output;
 }
 
 std::string stagePath(PXR_NS::UsdStageWeakPtr stage)
@@ -236,6 +249,7 @@ void wrapUtils()
     // representation of Ufe::Path as comma-separated segments.  We know that
     // the USD path separator is '/'.  PPT, 8-Dec-2019.
     def("getStage", getStage);
+    def("getAllStages", getAllStages, return_value_policy<PXR_NS::TfPySequenceToList>());
     def("stagePath", stagePath);
     def("usdPathToUfePathSegment",
         usdPathToUfePathSegment,

--- a/test/lib/ufe/testPythonWrappers.py
+++ b/test/lib/ufe/testPythonWrappers.py
@@ -54,7 +54,7 @@ class PythonWrappersTestCase(unittest.TestCase):
 
     def testWrappers(self):
 
-        ''' Verify the python wappers.'''
+        ''' Verify the python wrappers.'''
 
         # Create empty stage and add a prim.
         import mayaUsd_createStageWithNewLayer
@@ -117,6 +117,29 @@ class PythonWrappersTestCase(unittest.TestCase):
         # from USD when it tries to destroy the layer data by creating
         # a worker thread.
         cmds.file(new=True, force=True)
+
+    def testGetAllStages(self):
+
+        # Create two stages.
+        import mayaUsd_createStageWithNewLayer
+        proxyShape1 = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        proxyShape2 = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+
+        # Test maya-usd getAllStages() wrapper.
+        self.assertEqual(len(mayaUsd.ufe.getAllStages()), 2)
+
+        # Delete one of the stages.
+        cmds.delete(proxyShape1)
+
+        self.assertEqual(len(mayaUsd.ufe.getAllStages()), 1)
+
+        cmds.undo()
+
+        self.assertEqual(len(mayaUsd.ufe.getAllStages()), 2)
+
+        cmds.redo()
+
+        self.assertEqual(len(mayaUsd.ufe.getAllStages()), 1)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/ufe/testPythonWrappers.py
+++ b/test/lib/ufe/testPythonWrappers.py
@@ -118,6 +118,9 @@ class PythonWrappersTestCase(unittest.TestCase):
         # a worker thread.
         cmds.file(new=True, force=True)
 
+    # In Maya 2020 and 2022, undo does not restore the stage.  To be
+    # investigated as needed.
+    @unittest.skipUnless((mayaUtils.mayaMajorVersion() == 2023) or mayaUtils.previewReleaseVersion() >= 139, 'Only supported in Maya 2023 or greater.')
     def testGetAllStages(self):
 
         # Create two stages.


### PR DESCRIPTION
MAYA-111420 was entered to ensure that getAllStages() would not return stages whose proxy shape was deleted.  This bug was fixed by previous code, so simply added a test to demonstrate the fix, with undo and redo.