### PR TITLE
Removing unnecessary explicit 'pxr' namespacing

### DIFF
--- a/lib/mayaUsd/render/mayaToHydra/utils.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/utils.cpp
@@ -87,7 +87,7 @@ MtohInitializeRenderPlugins()
             // Null it out to make any possible usage later obv, wrong!
             delegate = nullptr;
 
-            std::shared_ptr<pxr::UsdImagingGLEngine> _engine;
+            std::shared_ptr<UsdImagingGLEngine> _engine;
             store.first.emplace_back(
                 renderer,
                 TfToken(TfStringPrintf("%s%s", MTOH_RENDER_OVERRIDE_PREFIX, renderer.GetText())),


### PR DESCRIPTION
We are already using the pxr namespace via the directive in this file, and the explicit namespacing breaks internal builds at Pixar.