### PR TITLE
MAYA-125747 Implement filtered version of findGatewayItems().

### DIFF
--- a/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.cpp
@@ -54,7 +54,7 @@ Ufe::Selection ProxyShapeSceneSegmentHandler::findGatewayItems_(const Ufe::Path&
 
     // Find the MayaUSD proxyShapes
     for (const auto& stage : getAllStages()) {
-        Ufe::Path proxyShapePath = stagePath(stage);
+        const Ufe::Path proxyShapePath = stagePath(stage);
         // recall that findGatewayItems searches for descendants of path that are
         // gateway nodes. If path itself is a gateway node it should not be included
         // in the results.
@@ -63,7 +63,7 @@ Ufe::Selection ProxyShapeSceneSegmentHandler::findGatewayItems_(const Ufe::Path&
         }
     }
 
-    // If there were Usd prims that are gateway items then we'd have an implementation
+    // TODO: If there were Usd prims that are gateway items then we'd have an implementation
     // of UsdSceneSegmentHandler that could find the gateway items and extra code
     // here to handle the case where isAGatewayType() for path is true. But right now
     // there are no gateway items in Usd, so I don't have to handle that.
@@ -87,7 +87,7 @@ ProxyShapeSceneSegmentHandler::findGatewayItems_(const Ufe::Path& path, Ufe::Rti
     // `nestedRtid` matches the MayaUSD runtime ID. Find the MayaUSD proxyShapes.
     Ufe::Selection result = Ufe::Selection();
     for (const auto& stage : getAllStages()) {
-        Ufe::Path proxyShapePath = stagePath(stage);
+        const Ufe::Path proxyShapePath = stagePath(stage);
         // recall that findGatewayItems searches for descendants of path that are
         // gateway nodes. If path itself is a gateway node it should not be included
         // in the results.
@@ -96,7 +96,7 @@ ProxyShapeSceneSegmentHandler::findGatewayItems_(const Ufe::Path& path, Ufe::Rti
         }
     }
 
-    // If there were Usd prims that are gateway items then we'd have an implementation
+    // TODO: If there were Usd prims that are gateway items then we'd have an implementation
     // of UsdSceneSegmentHandler that could find the gateway items and extra code
     // here to handle the case where isAGatewayType() for path is true. But right now
     // there are no gateway items in Usd, so I don't have to handle that.

--- a/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.cpp
@@ -25,6 +25,25 @@ namespace ufe {
 
 extern Ufe::Rtid g_USDRtid;
 
+namespace {
+
+// Find the gateway items into USD which are descendants of path within path's scene segment. If
+// path is a gateway node then search the scene segment which is an immediate child of path.
+void findUsdGatewayItems(const Ufe::Path& path, Ufe::Selection& result)
+{
+    for (const auto& stage : getAllStages()) {
+        const Ufe::Path proxyShapePath = stagePath(stage);
+        // recall that findGatewayItems searches for descendants of path that are
+        // gateway nodes. If path itself is a gateway node it should not be included
+        // in the results.
+        if (proxyShapePath.startsWith(path) && proxyShapePath != path) {
+            result.append(Ufe::Hierarchy::createItem(proxyShapePath));
+        }
+    }
+}
+
+} // namespace
+
 ProxyShapeSceneSegmentHandler::ProxyShapeSceneSegmentHandler(
     const Ufe::SceneSegmentHandler::Ptr& mayaSceneSegmentHandler)
     : Ufe::SceneSegmentHandler()
@@ -53,15 +72,7 @@ Ufe::Selection ProxyShapeSceneSegmentHandler::findGatewayItems_(const Ufe::Path&
         : Ufe::Selection();
 
     // Find the MayaUSD proxyShapes
-    for (const auto& stage : getAllStages()) {
-        const Ufe::Path proxyShapePath = stagePath(stage);
-        // recall that findGatewayItems searches for descendants of path that are
-        // gateway nodes. If path itself is a gateway node it should not be included
-        // in the results.
-        if (proxyShapePath.startsWith(path) && proxyShapePath != path) {
-            result.append(Ufe::Hierarchy::createItem(proxyShapePath));
-        }
-    }
+    findUsdGatewayItems(path, result);
 
     // TODO: If there were Usd prims that are gateway items then we'd have an implementation
     // of UsdSceneSegmentHandler that could find the gateway items and extra code
@@ -86,15 +97,7 @@ ProxyShapeSceneSegmentHandler::findGatewayItems_(const Ufe::Path& path, Ufe::Rti
 
     // `nestedRtid` matches the MayaUSD runtime ID. Find the MayaUSD proxyShapes.
     Ufe::Selection result = Ufe::Selection();
-    for (const auto& stage : getAllStages()) {
-        const Ufe::Path proxyShapePath = stagePath(stage);
-        // recall that findGatewayItems searches for descendants of path that are
-        // gateway nodes. If path itself is a gateway node it should not be included
-        // in the results.
-        if (proxyShapePath.startsWith(path) && proxyShapePath != path) {
-            result.append(Ufe::Hierarchy::createItem(proxyShapePath));
-        }
-    }
+    findUsdGatewayItems(path, result);
 
     // TODO: If there were Usd prims that are gateway items then we'd have an implementation
     // of UsdSceneSegmentHandler that could find the gateway items and extra code

--- a/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.cpp
@@ -60,8 +60,8 @@ ProxyShapeSceneSegmentHandler::findGatewayItems_(const Ufe::Path& path, Ufe::Rti
 
     // Find the MayaUSD proxyShapes.
     // `nestedRtid` is used as a filter. Only add MayaUSD proxyShapes to the result if the argument
-    // matches the MayaUSD runtime ID or if the argument is 0 which means return all.
-    if (nestedRtid == 0 || nestedRtid == g_USDRtid) {
+    // matches the MayaUSD runtime ID or `Ufe::kAllRtid` which is used to refer to all runtimes.
+    if (nestedRtid == g_USDRtid || nestedRtid == Ufe::kAllRtid) {
         for (const auto& stage : getAllStages()) {
             Ufe::Path proxyShapePath = stagePath(stage);
             // recall that findGatewayItems searches for descendants of path that are gateway nodes.

--- a/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.cpp
@@ -71,7 +71,7 @@ Ufe::Selection ProxyShapeSceneSegmentHandler::findGatewayItems_(const Ufe::Path&
     return result;
 }
 
-#if (UFE_PREVIEW_VERSION_NUM >= 4033)
+#if (UFE_PREVIEW_VERSION_NUM >= 4035)
 Ufe::Selection
 ProxyShapeSceneSegmentHandler::findGatewayItems_(const Ufe::Path& path, Ufe::Rtid nestedRtid) const
 {

--- a/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.h
+++ b/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.h
@@ -47,8 +47,12 @@ public:
     create(const Ufe::SceneSegmentHandler::Ptr& mayaSceneSegmentHandler);
 
     // Ufe::SceneSegmentHandler overrides
+#if (UFE_PREVIEW_VERSION_NUM >= 4033)
     Ufe::Selection
-         findGatewayItems_(const Ufe::Path& path, Ufe::Rtid nestedRtid = 0) const override;
+    findGatewayItems_(const Ufe::Path& path, Ufe::Rtid nestedRtid = 0) const override;
+#else
+    Ufe::Selection findGatewayItems_(const Ufe::Path& path) const override;
+#endif
     bool isGateway_(const Ufe::Path& path) const override;
 
 private:

--- a/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.h
+++ b/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.h
@@ -47,11 +47,9 @@ public:
     create(const Ufe::SceneSegmentHandler::Ptr& mayaSceneSegmentHandler);
 
     // Ufe::SceneSegmentHandler overrides
-#if (UFE_PREVIEW_VERSION_NUM >= 4033)
-    Ufe::Selection
-    findGatewayItems_(const Ufe::Path& path, Ufe::Rtid nestedRtid = Ufe::kAllRtid) const override;
-#else
     Ufe::Selection findGatewayItems_(const Ufe::Path& path) const override;
+#if (UFE_PREVIEW_VERSION_NUM >= 4033)
+    Ufe::Selection findGatewayItems_(const Ufe::Path& path, Ufe::Rtid nestedRtid) const override;
 #endif
     bool isGateway_(const Ufe::Path& path) const override;
 

--- a/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.h
+++ b/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.h
@@ -47,8 +47,9 @@ public:
     create(const Ufe::SceneSegmentHandler::Ptr& mayaSceneSegmentHandler);
 
     // Ufe::SceneSegmentHandler overrides
-    Ufe::Selection findGatewayItems_(const Ufe::Path& path) const override;
-    bool           isGateway_(const Ufe::Path& path) const override;
+    Ufe::Selection
+         findGatewayItems_(const Ufe::Path& path, Ufe::Rtid nestedRtid = 0) const override;
+    bool isGateway_(const Ufe::Path& path) const override;
 
 private:
     Ufe::SceneSegmentHandler::Ptr fMayaSceneSegmentHandler;

--- a/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.h
+++ b/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.h
@@ -49,7 +49,7 @@ public:
     // Ufe::SceneSegmentHandler overrides
 #if (UFE_PREVIEW_VERSION_NUM >= 4033)
     Ufe::Selection
-    findGatewayItems_(const Ufe::Path& path, Ufe::Rtid nestedRtid = 0) const override;
+    findGatewayItems_(const Ufe::Path& path, Ufe::Rtid nestedRtid = Ufe::kAllRtid) const override;
 #else
     Ufe::Selection findGatewayItems_(const Ufe::Path& path) const override;
 #endif

--- a/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.h
+++ b/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.h
@@ -48,7 +48,7 @@ public:
 
     // Ufe::SceneSegmentHandler overrides
     Ufe::Selection findGatewayItems_(const Ufe::Path& path) const override;
-#if (UFE_PREVIEW_VERSION_NUM >= 4033)
+#if (UFE_PREVIEW_VERSION_NUM >= 4035)
     Ufe::Selection findGatewayItems_(const Ufe::Path& path, Ufe::Rtid nestedRtid) const override;
 #endif
     bool isGateway_(const Ufe::Path& path) const override;

--- a/test/lib/ufe/testSceneSegment.py
+++ b/test/lib/ufe/testSceneSegment.py
@@ -25,6 +25,7 @@ from maya import standalone
 
 import ufe
 
+import os
 import unittest
 
 class SceneSegmentTestCase(unittest.TestCase):
@@ -72,17 +73,6 @@ class SceneSegmentTestCase(unittest.TestCase):
         result = handler.findGatewayItems(proxyShapePath)
         self.assertTrue(result.empty())
 
-        # When using the filtered version of `findGatewayItems()` on the
-        # same gateway item, the result should still be empty. Filtering
-        # can never increase the cardinality of the result.
-        usdRunTimeId = ufe.RunTimeMgr.instance().getId('USD');
-        result = handler.findGatewayItems(proxyShapePath, usdRunTimeId)
-        self.assertTrue(result.empty())
-
-        otherRunTimeId = 6174
-        result = handler.findGatewayItems(proxyShapePath, otherRunTimeId)
-        self.assertTrue(result.empty())
-
         # searching the the parent of a gateway item searches the Maya scene segment
         # for gateway nodes without recursing into USD. should be the proxy shape
         handler = ufe.RunTimeMgr.instance().sceneSegmentHandler(proxyShapeParentPath.runTimeId())
@@ -90,20 +80,50 @@ class SceneSegmentTestCase(unittest.TestCase):
         self.assertTrue(result.contains(proxyShapePath))
         self.assertEqual(len(result), 1)
 
-        # Searching the the parent of a gateway item using the filtered 
-        # version of `findGatewayItems()` should result in the proxy 
-        # shape if the runtime ID that is used as a filter matches the 
-        # USD runtime ID. Otherwise the result should be empty.
+        # searching for the USD parent of both cameras should find no scene segment handler
+        handler = ufe.RunTimeMgr.instance().sceneSegmentHandler(camerasParentPath.runTimeId())
+        self.assertEqual(handler, None)
+
+    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '4033', 'Test for UFE preview version 0.4.33 and later')
+    def testFilteredFindGatewayItems(self):
+        proxyShapePath = ufe.PathString.path('|stage|stageShape')
+        proxyShapeParentPath = ufe.PathString.path('|stage')
+
+        # Searching on a gateway item should give all gateway nodes in
+        # the child segment. USD doesn't have any gateway nodes, so the
+        # result should be empty. When using the filtered version of
+        # `findGatewayItems()`, the result should still be empty.
+        # Filtering can never increase the cardinality of the result.
+        handler = ufe.RunTimeMgr.instance().sceneSegmentHandler(proxyShapePath.runTimeId())
+        
+        result = handler.findGatewayItems(proxyShapePath)
+        self.assertTrue(result.empty())
+
+        usdRunTimeId = ufe.RunTimeMgr.instance().getId('USD')
+        result = handler.findGatewayItems(proxyShapePath, usdRunTimeId)
+        self.assertTrue(result.empty())
+
+        otherRunTimeId = 6174
+        result = handler.findGatewayItems(proxyShapePath, otherRunTimeId)
+        self.assertTrue(result.empty())
+
+        # Searching the the parent of a gateway item searches the Maya
+        # scene segment for gateway nodes without recursing into USD.
+        # If no filter is specified or if the USD runtime ID is used as
+        # a filter, this should return the proxy shape. If a different
+        # runtime ID is used as a filter, the result should be empty.
+        handler = ufe.RunTimeMgr.instance().sceneSegmentHandler(proxyShapeParentPath.runTimeId())
+        
+        result = handler.findGatewayItems(proxyShapeParentPath)
+        self.assertTrue(result.contains(proxyShapePath))
+        self.assertEqual(len(result), 1)
+
         result = handler.findGatewayItems(proxyShapeParentPath, usdRunTimeId)
         self.assertTrue(result.contains(proxyShapePath))
         self.assertTrue(len(result), 1)
 
         result = handler.findGatewayItems(proxyShapeParentPath, otherRunTimeId)
         self.assertTrue(result.empty())
-
-        # searching for the USD parent of both cameras should find no scene segment handler
-        handler = ufe.RunTimeMgr.instance().sceneSegmentHandler(camerasParentPath.runTimeId())
-        self.assertEqual(handler, None)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/ufe/testSceneSegment.py
+++ b/test/lib/ufe/testSceneSegment.py
@@ -72,12 +72,34 @@ class SceneSegmentTestCase(unittest.TestCase):
         result = handler.findGatewayItems(proxyShapePath)
         self.assertTrue(result.empty())
 
+        # When using the filtered version of `findGatewayItems()` on the
+        # same gateway item, the result should still be empty. Filtering
+        # can never increase the cardinality of the result.
+        usdRunTimeId = ufe.RunTimeMgr.instance().getId('USD');
+        result = handler.findGatewayItems(proxyShapePath, usdRunTimeId)
+        self.assertTrue(result.empty())
+
+        otherRunTimeId = 6174
+        result = handler.findGatewayItems(proxyShapePath, otherRunTimeId)
+        self.assertTrue(result.empty())
+
         # searching the the parent of a gateway item searches the Maya scene segment
         # for gateway nodes without recursing into USD. should be the proxy shape
         handler = ufe.RunTimeMgr.instance().sceneSegmentHandler(proxyShapeParentPath.runTimeId())
         result = handler.findGatewayItems(proxyShapeParentPath)
         self.assertTrue(result.contains(proxyShapePath))
         self.assertEqual(len(result), 1)
+
+        # Searching the the parent of a gateway item using the filtered 
+        # version of `findGatewayItems()` should result in the proxy 
+        # shape if the runtime ID that is used as a filter matches the 
+        # USD runtime ID. Otherwise the result should be empty.
+        result = handler.findGatewayItems(proxyShapeParentPath, usdRunTimeId)
+        self.assertTrue(result.contains(proxyShapePath))
+        self.assertTrue(len(result), 1)
+
+        result = handler.findGatewayItems(proxyShapeParentPath, otherRunTimeId)
+        self.assertTrue(result.empty())
 
         # searching for the USD parent of both cameras should find no scene segment handler
         handler = ufe.RunTimeMgr.instance().sceneSegmentHandler(camerasParentPath.runTimeId())

--- a/test/lib/ufe/testSceneSegment.py
+++ b/test/lib/ufe/testSceneSegment.py
@@ -107,7 +107,7 @@ class SceneSegmentTestCase(unittest.TestCase):
         result = handler.findGatewayItems(proxyShapePath, otherRunTimeId)
         self.assertTrue(result.empty())
 
-        # Searching the the parent of a gateway item searches the Maya
+        # Searching from the parent of a gateway item searches the Maya
         # scene segment for gateway nodes without recursing into USD.
         # If no filter is specified or if the USD runtime ID is used as
         # a filter, this should return the proxy shape. If a different

--- a/test/lib/ufe/testSceneSegment.py
+++ b/test/lib/ufe/testSceneSegment.py
@@ -84,7 +84,7 @@ class SceneSegmentTestCase(unittest.TestCase):
         handler = ufe.RunTimeMgr.instance().sceneSegmentHandler(camerasParentPath.runTimeId())
         self.assertEqual(handler, None)
 
-    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '4033', 'Test for UFE preview version 0.4.33 and later')
+    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '4035', 'Test for UFE preview version 0.4.35 and later')
     def testFilteredFindGatewayItems(self):
         proxyShapePath = ufe.PathString.path('|stage|stageShape')
         proxyShapeParentPath = ufe.PathString.path('|stage')


### PR DESCRIPTION
Implement filtered version of `Ufe::SceneSegmentHandler::findGatewayItems()`.

Allows `findGatewayItems()` to filter the returned Selection by the specified nested runtime ID. For example, `findGatewayItems(path, usdRtid)` will only search for MayaUSD proxy shapes.

The according changes to UFE can be found in [this PR](https://git.autodesk.com/media-and-entertainment/ufe/pull/310).