### PR TITLE
MAYA-125867 fix edit-as-Maya on fresh Maya session

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -90,22 +90,19 @@ const MString kPullDGMetadataKey("Pull_UfePath");
 
 // Name of Dag node under which all pulled sub-hierarchies are rooted.
 const MString kPullRootName("__mayaUsd__");
+const MString kPullRootPath("|__mayaUsd__");
 
 MObject findPullRoot()
 {
-    // Try to find one in the scene.
-    auto       worldObj = MItDag().root();
-    MFnDagNode world(worldObj);
-    auto       nbWorldChildren = world.childCount();
-    for (unsigned int i = 0; i < nbWorldChildren; ++i) {
-        auto              childObj = world.child(i);
-        MFnDependencyNode child(childObj);
-        if (child.name() == kPullRootName) {
-            return childObj;
-        }
-    }
+    // Try to find the pull root in the scene.
+    MSelectionList sel;
+    sel.add(kPullRootPath);
+    if (sel.isEmpty())
+        return MObject();
 
-    return MObject();
+    MObject obj;
+    sel.getDependNode(0, obj);
+    return obj;
 }
 
 Ufe::Path usdToMaya(const Ufe::Path& usdPath)

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -1681,19 +1681,6 @@ MObject PrimUpdaterManager::findOrCreatePullRoot()
     MFnDependencyNode pullRootFn(pullRootObj);
     UsdMayaUtil::SetHiddenInOutliner(pullRootFn, true);
 
-    if (!FunctionUndoItem::execute(
-            "Create pull root cache has pulled prims",
-            [self = this]() {
-                self->_hasPulledPrims = true;
-                return true;
-            },
-            [self = this]() {
-                self->_hasPulledPrims = false;
-                return true;
-            })) {
-        TF_WARN("Cannot create pulled prim cache.");
-        return MObject();
-    }
     progressBar.advance();
 
     // As soon as we've pulled something, we must observe the scene for
@@ -1767,12 +1754,10 @@ bool PrimUpdaterManager::removePullParent(
             if (!TF_VERIFY(FunctionUndoItem::execute(
                     "Remove orphaned nodes manager, pulled prims flag reset",
                     [&]() {
-                        _hasPulledPrims = false;
                         endManagePulledPrims();
                         return true;
                     },
                     [&]() {
-                        _hasPulledPrims = true;
                         beginManagePulledPrims();
                         return true;
                     }))) {
@@ -1887,6 +1872,12 @@ bool PrimUpdaterManager::readPullInformation(const MDagPath& dagPath, Ufe::Path&
     }
 
     return false;
+}
+
+bool PrimUpdaterManager::hasPulledPrims() const
+{
+    MObject pullRoot = findPullRoot();
+    return !pullRoot.isNull();
 }
 
 #ifdef HAS_ORPHANED_NODES_MANAGER

--- a/lib/mayaUsd/fileio/primUpdaterManager.h
+++ b/lib/mayaUsd/fileio/primUpdaterManager.h
@@ -79,7 +79,7 @@ public:
     MAYAUSD_CORE_PUBLIC
     static bool readPullInformation(const MDagPath& dagpath, Ufe::Path& ufePath);
 
-    bool hasPulledPrims() const { return _hasPulledPrims; }
+    bool hasPulledPrims() const;
 
 private:
     PrimUpdaterManager();
@@ -127,11 +127,6 @@ private:
     friend class TfSingleton<PrimUpdaterManager>;
 
     bool _inPushPull { false };
-
-    // Becomes true when there is at least one pulled prim.
-    // The goal is to let code that can be optimized when there is no pull prim
-    // to check rapidly.
-    bool _hasPulledPrims { false };
 
     // Orphaned nodes manager that observes the scene, to determine when to hide
     // pulled prims that have become orphaned, or to show them again, because


### PR DESCRIPTION
When a USD object is edited as Maya and the Maya scene is saved, if Maya is restarted and teh scene reloaded, the edited USD object cannot be manipulated again. That was due to internal non-saved state not being set properly when restarting Maya.

Avoid the problem by not using non-persistent state.