### PR TITLE
Allow custom UI hooks for mayaUsdProxyShape

### DIFF
--- a/plugin/adsk/scripts/AEmayaUsdProxyShapeBaseTemplate.mel
+++ b/plugin/adsk/scripts/AEmayaUsdProxyShapeBaseTemplate.mel
@@ -221,6 +221,8 @@ global proc AEmayaUsdProxyShapeBaseTemplate( string $nodeName )
             editorTemplate -callCustom AEnewBbox AEreplaceBbox "boundingBoxMin" "boundingBoxMax";
         editorTemplate -endLayout;
 
+        // Apply hooks for custom UI (from AEdependNodeTemplate.mel):
+        callbacks -executeCallbacks -hook "AETemplateCustomContent" $nodeName;
         // UUID (from AEdependNodeTemplate.mel):
         editorTemplate -beginLayout (uiRes("m_AEdependNodeTemplate.kUUID"));
             editorTemplate -suppress "nodeState";


### PR DESCRIPTION
Inside the AE template of mayaUsdProxyShape, a code segment from the AEdependNodeTemplate function is copied to avoid calling it. Probably to avoid creating Node Behavior layout. This commit adds the line which allows mayaUsdProxyShape to be assigned custom UI via callbacks -hook "AETemplateCustomContent".