### PR TITLE
MAYA-125038 serialization of pull variant info into JSON

### DIFF
--- a/lib/mayaUsd/fileio/CMakeLists.txt
+++ b/lib/mayaUsd/fileio/CMakeLists.txt
@@ -45,6 +45,7 @@ if(UFE_TRIE_NODE_HAS_CHILDREN_COMPONENTS_ACCESSOR)
     target_sources(${PROJECT_NAME}
         PRIVATE
             orphanedNodesManager.cpp
+            orphanedNodesManagerIO.cpp
     )
 
     target_compile_definitions(${PROJECT_NAME}

--- a/lib/mayaUsd/fileio/orphanedNodesManager.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.cpp
@@ -91,7 +91,7 @@ void OrphanedNodesManager::add(const Ufe::Path& pulledPath, const MDagPath& pull
 
 OrphanedNodesManager::Memento OrphanedNodesManager::remove(const Ufe::Path& pulledPath)
 {
-    Memento oldPulledPrims(deepCopy(pulledPrims()));
+    Memento oldPulledPrims(preserve());
     TF_AXIOM(pulledPrims().remove(pulledPath) != nullptr);
     return oldPulledPrims;
 }
@@ -260,6 +260,11 @@ void OrphanedNodesManager::clear() { pulledPrims().clear(); }
 
 bool OrphanedNodesManager::empty() const { return pulledPrims().root()->empty(); }
 
+OrphanedNodesManager::Memento OrphanedNodesManager::preserve() const
+{
+    return Memento(deepCopy(pulledPrims()));
+}
+
 void OrphanedNodesManager::restore(Memento&& previous) { _pulledPrims = previous.release(); }
 
 bool OrphanedNodesManager::isOrphaned(const Ufe::Path& pulledPath) const
@@ -280,7 +285,7 @@ bool OrphanedNodesManager::setVisibilityPlug(
     bool                                       visibility)
 {
     TF_VERIFY(trieNode->hasData());
-    const auto& pullParentPath = trieNode->data().dagPath;
+    const auto& pullParentPath = trieNode->data().pulledParentPath;
     MFnDagNode  fn(pullParentPath);
     auto        visibilityPlug = fn.findPlug("visibility", /* tryNetworked */ true);
     return (visibilityPlug.setBool(visibility) == MS::kSuccess);
@@ -290,7 +295,7 @@ bool OrphanedNodesManager::setVisibilityPlug(
 bool OrphanedNodesManager::getVisibilityPlug(const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode)
 {
     TF_VERIFY(trieNode->hasData());
-    const auto& pullParentPath = trieNode->data().dagPath;
+    const auto& pullParentPath = trieNode->data().pulledParentPath;
     MFnDagNode  fn(pullParentPath);
     auto        visibilityPlug = fn.findPlug("visibility", /* tryNetworked */ true);
     return visibilityPlug.asBool();

--- a/lib/mayaUsd/fileio/orphanedNodesManager.h
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.h
@@ -26,8 +26,26 @@
 
 namespace MAYAUSD_NS_DEF {
 
+/// \class OrphanedNodesManager
+///
+/// \brief Records the data that affects which exact USD prim was edited as Maya.
+///
+/// Prims edited as Maya nodes are only valid if the prim is still accessible
+/// in the USD stage. If no longer accessible, we declared the Maya nodes as
+/// orphaned and hide them.
+///
+/// Observes the scene, to determine when to hide edited prims that have become
+/// orphaned, or to show them again, because of structural changes to their USD
+/// or Maya ancestors.
+///
+/// Currently, the only state that we monitor and consider for prim validity
+/// and edit orphaning is the set of variant selections of all ancestors of
+/// the prim being edited.
+
 class OrphanedNodesManager : public Ufe::Observer
 {
+public:
+    /// \brief Records a single variant selection of a single variant set.
     struct VariantSelection
     {
         VariantSelection() = default;
@@ -46,6 +64,7 @@ class OrphanedNodesManager : public Ufe::Observer
         std::string variantSelection;
     };
 
+    /// \brief Records all variant selections of a single prim.
     struct VariantSetDescriptor
     {
         VariantSetDescriptor() = default;
@@ -63,21 +82,21 @@ class OrphanedNodesManager : public Ufe::Observer
         std::list<VariantSelection> variantSelections;
     };
 
+    /// \brief Records all variant selections of all ancestors of the prim edited as maya,
+    ///        with the DAG path of the root of Maya nodes corresponding to the edited prim.
     struct PullVariantInfo
     {
         PullVariantInfo() = default;
-        PullVariantInfo(const MDagPath& dp, const std::list<VariantSetDescriptor>& vsd)
-            : dagPath(dp)
+        PullVariantInfo(const MDagPath& pulledParent, const std::list<VariantSetDescriptor>& vsd)
+            : pulledParentPath(pulledParent)
             , variantSetDescriptors(vsd)
         {
         }
-        MDagPath                        dagPath;
+        MDagPath                        pulledParentPath;
         std::list<VariantSetDescriptor> variantSetDescriptors;
     };
 
-public:
-    typedef std::shared_ptr<OrphanedNodesManager> Ptr;
-
+    /// \brief Entire state of the OrphanedNodesManager at a point in time, used for undo/redo.
     class Memento
     {
     public:
@@ -91,6 +110,9 @@ public:
         Memento(const Memento&) = delete;
         Memento& operator=(const Memento&) = delete;
 
+        static std::string convertToJson(const Memento&);
+        static Memento     convertFromJson(const std::string&);
+
     private:
         // Private, for opacity.
         friend class OrphanedNodesManager;
@@ -102,8 +124,10 @@ public:
         Ufe::Trie<PullVariantInfo> _pulledPrims;
     };
 
+    // Construct an empty orphan manager.
     OrphanedNodesManager();
 
+    // Notifications handling, part of the Ufe::Observer interface.
     void operator()(const Ufe::Notification&) override;
 
     // Add the pulled path and its Maya pull parent to the trie of pulled
@@ -114,6 +138,9 @@ public:
     // path is in the trie.  Returns a memento (see Memento Pattern) for undo
     // purposes, to be used as argument to restore().
     Memento remove(const Ufe::Path& pulledPath);
+
+    // Preserve the trie of pulled prims into a memento.
+    Memento preserve() const;
 
     // Restore the trie of pulled prims to the content of the argument memento.
     void restore(Memento&& previous);

--- a/lib/mayaUsd/fileio/orphanedNodesManagerIO.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManagerIO.cpp
@@ -1,0 +1,295 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "orphanedNodesManager.h"
+
+#include <mayaUsd/utils/json.h>
+
+#include <pxr/base/js/json.h>
+#include <pxr/base/tf/diagnostic.h>
+
+#include <maya/MDagPath.h>
+#include <maya/MString.h>
+#include <ufe/pathString.h>
+#include <ufe/trie.imp.h>
+
+namespace MAYAUSD_NS_DEF {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Conversion of the OrphanedNodesManager PullVariantInfo to JSON has the
+// following structure:
+//
+//    {
+//       "/UFE-path-component-1" : {
+//          "/UFE-path-component-2" : {
+//             "pull info": {
+//                "pulledParentPath": "DAG-path-of-pulled-object",
+//                "variantSetDescriptors": [
+//                   {
+//                       "path": "UFE-path-of-one-ancestor",
+//                       "variantSelections": [
+//                           [ "variant-set-1-name", "variant-set-1-selection" ],
+//                           [ "variant-set-2-name", "variant-set-2-selection" ],
+//                       ],
+//                   },
+//                ],
+//             },
+//          },
+//       },
+//    }
+//
+// Each UFE path component is prefixed by a slash ('/') to differentiate them
+// from pull info data, which has a JOSN key without that slash prefix.
+
+static const std::string ufeComponentPrefix = "/";
+static const std::string pullInfoJsonKey = "pull info";
+static const std::string dagPathJsonKey = "pulledParentPath";
+static const std::string variantSetDescriptorsJsonKey = "variantSetDescriptors";
+static const std::string pathJsonKey = "path";
+static const std::string variantSelKey = "variantSelections";
+
+static const char* invalidJson = "Invalid JSON";
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Types used in the pulled variant info, so shorten the code and make it more readable.
+
+using VariantSelection = OrphanedNodesManager::VariantSelection;
+using VariantSetDesc = OrphanedNodesManager::VariantSetDescriptor;
+using VariantSetDescList = std::list<VariantSetDesc>;
+using PullVariantInfo = OrphanedNodesManager::PullVariantInfo;
+using PullInfoTrie = Ufe::Trie<PullVariantInfo>;
+using PullInfoTrieNode = Ufe::TrieNode<PullVariantInfo>;
+using Memento = OrphanedNodesManager::Memento;
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Conversion functions to and from JSON for orphaned nodes types.
+
+using MAYAUSD_NS_DEF::convertToArray;
+using MAYAUSD_NS_DEF::convertToObject;
+using MAYAUSD_NS_DEF::convertToValue;
+
+PXR_NS::JsArray  convertToArray(const VariantSelection& variantSel);
+PXR_NS::JsObject convertToObject(const VariantSetDesc& variantDesc);
+PXR_NS::JsArray  convertToArray(const std::list<VariantSetDesc>& allVariantDesc);
+PXR_NS::JsObject convertToObject(const PullVariantInfo& pullInfo);
+PXR_NS::JsObject convertToObject(const PullInfoTrieNode::Ptr& pullInfoNode);
+PXR_NS::JsObject convertToObject(const PullInfoTrie& allPulledInfo);
+
+VariantSelection   convertToVariantSelection(const PXR_NS::JsArray& variantSelJson);
+VariantSetDesc     convertToVariantSetDescriptor(const PXR_NS::JsObject& variantDescJson);
+VariantSetDescList convertToVariantSetDescList(const PXR_NS::JsArray& allVariantDescJson);
+PullVariantInfo    convertToPullVariantInfo(const PXR_NS::JsObject& pullInfoJson);
+void         convertToPullInfoTrieNodePtr(const PXR_NS::JsObject&, PullInfoTrieNode::Ptr intoRoot);
+PullInfoTrie convertToPullInfoTrie(const PXR_NS::JsObject& allPulledInfoJson);
+
+PXR_NS::JsArray convertToArray(const VariantSelection& variantSel)
+{
+    PXR_NS::JsArray variantSelJson;
+
+    variantSelJson.push_back(convertToValue(variantSel.variantSetName));
+    variantSelJson.push_back(convertToValue(variantSel.variantSelection));
+
+    return variantSelJson;
+}
+
+VariantSelection convertToVariantSelection(const PXR_NS::JsArray& variantSelJson)
+{
+    VariantSelection variantSel;
+
+    if (variantSelJson.size() < 2)
+        throw std::runtime_error(invalidJson);
+
+    variantSel.variantSetName = convertToString(variantSelJson[0]);
+    variantSel.variantSelection = convertToString(variantSelJson[1]);
+
+    return variantSel;
+}
+
+PXR_NS::JsObject convertToObject(const VariantSetDesc& variantDesc)
+{
+    PXR_NS::JsObject variantDescJson;
+
+    variantDescJson[pathJsonKey] = convertToValue(variantDesc.path);
+
+    PXR_NS::JsArray selections;
+
+    for (const auto& variantSel : variantDesc.variantSelections) {
+        selections.emplace_back(convertToArray(variantSel));
+    }
+
+    variantDescJson[variantSelKey] = selections;
+
+    return variantDescJson;
+}
+
+VariantSetDesc convertToVariantSetDescriptor(const PXR_NS::JsObject& variantDescJson)
+{
+    VariantSetDesc variantDesc;
+
+    variantDesc.path = convertToUfePath(convertJsonKeyToValue(variantDescJson, pathJsonKey));
+
+    PXR_NS::JsArray variantSelectionsJson
+        = convertToArray(convertJsonKeyToValue(variantDescJson, variantSelKey));
+
+    for (const PXR_NS::JsValue& value : variantSelectionsJson)
+        variantDesc.variantSelections.emplace_back(
+            convertToVariantSelection(convertToArray(value)));
+
+    return variantDesc;
+}
+
+PXR_NS::JsArray convertToArray(const std::list<VariantSetDesc>& allVariantDesc)
+{
+    PXR_NS::JsArray allVariantDescJson;
+
+    for (const auto& variantDesc : allVariantDesc) {
+        allVariantDescJson.emplace_back(convertToObject(variantDesc));
+    }
+
+    return allVariantDescJson;
+}
+
+VariantSetDescList convertToVariantSetDescList(const PXR_NS::JsArray& allVariantDescJson)
+{
+    VariantSetDescList allVariantDesc;
+
+    for (const PXR_NS::JsValue& value : allVariantDescJson)
+        allVariantDesc.emplace_back(convertToVariantSetDescriptor(convertToObject(value)));
+
+    return allVariantDesc;
+}
+
+PXR_NS::JsObject convertToObject(const PullVariantInfo& pullInfo)
+{
+    PXR_NS::JsObject pullInfoJson;
+
+    pullInfoJson[dagPathJsonKey] = convertToValue(pullInfo.pulledParentPath);
+    pullInfoJson[variantSetDescriptorsJsonKey] = convertToArray(pullInfo.variantSetDescriptors);
+
+    return pullInfoJson;
+}
+
+PullVariantInfo convertToPullVariantInfo(const PXR_NS::JsObject& pullInfoJson)
+{
+    PullVariantInfo pullInfo;
+
+    pullInfo.pulledParentPath
+        = convertToDagPath(convertJsonKeyToValue(pullInfoJson, dagPathJsonKey));
+    pullInfo.variantSetDescriptors = convertToVariantSetDescList(
+        convertToArray(convertJsonKeyToValue(pullInfoJson, variantSetDescriptorsJsonKey)));
+
+    return pullInfo;
+}
+
+PXR_NS::JsObject convertToObject(const PullInfoTrieNode::Ptr& pullInfoNodePtr)
+{
+    if (!pullInfoNodePtr)
+        return {};
+
+    const PullInfoTrieNode& pullInfoNode = *pullInfoNodePtr;
+
+    PXR_NS::JsObject pullInfoNodeJson;
+
+    if (pullInfoNode.hasData()) {
+        pullInfoNodeJson[pullInfoJsonKey] = convertToObject(pullInfoNode.data());
+    }
+
+    for (const auto& child : pullInfoNode.childrenComponents()) {
+        PXR_NS::JsObject childJson = convertToObject(pullInfoNode[child]);
+        if (childJson.empty())
+            continue;
+        pullInfoNodeJson[ufeComponentPrefix + child.string()] = childJson;
+    }
+
+    return pullInfoNodeJson;
+}
+
+void convertToPullInfoTrieNodePtr(
+    const PXR_NS::JsObject& pullInfoNodeJson,
+    PullInfoTrieNode::Ptr   intoRoot)
+{
+    for (const auto& keyValue : pullInfoNodeJson) {
+        const std::string&     key = keyValue.first;
+        const PXR_NS::JsValue& value = keyValue.second;
+        if (key.size() <= 0) {
+            continue;
+        } else if (key == pullInfoJsonKey) {
+            intoRoot->setData(convertToPullVariantInfo(convertToObject(value)));
+
+        } else if (key[0] == '/') {
+            PullInfoTrieNode::Ptr child = std::make_shared<PullInfoTrieNode>(key.substr(1));
+            intoRoot->add(child);
+            convertToPullInfoTrieNodePtr(convertToObject(value), child);
+        }
+    }
+}
+
+PXR_NS::JsObject convertToObject(const PullInfoTrie& allPullInfo)
+{
+    return convertToObject(allPullInfo.root());
+}
+
+PullInfoTrie convertToPullInfoTrie(const PXR_NS::JsObject& allPullInfoJson)
+{
+    PullInfoTrie allPullInfo;
+
+    convertToPullInfoTrieNodePtr(allPullInfoJson, allPullInfo.root());
+
+    return allPullInfo;
+}
+
+} // namespace
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Conversion of OrphanedNodesManager::Memento to and from JSON.
+
+std::string Memento::convertToJson(const Memento& memento)
+{
+    try {
+        return PXR_NS::JsWriteToString(convertToObject(memento._pulledPrims));
+    } catch (const std::exception& e) {
+        // Note: the TF_RUNTIME_ERROR macro needs to be used within the PXR_NS.
+        using namespace PXR_NS;
+        TF_RUNTIME_ERROR(
+            "Unable to convert the orphaned nodes manager state to JSON: %s", e.what());
+    }
+
+    return {};
+}
+
+Memento Memento::convertFromJson(const std::string& json)
+{
+    Memento memento;
+
+    try {
+        memento._pulledPrims = convertToPullInfoTrie(convertToObject(PXR_NS::JsParseString(json)));
+    } catch (const std::exception& e) {
+        // Note: the TF_RUNTIME_ERROR macro needs to be used within the PXR_NS.
+        using namespace PXR_NS;
+        TF_RUNTIME_ERROR(
+            "Unable to convert the JSON text to the orphaned nodes manager state: %s", e.what());
+    }
+
+    return memento;
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -32,6 +32,7 @@
 #include <mayaUsd/undo/OpUndoItemMuting.h>
 #include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/undo/UsdUndoBlock.h>
+#include <mayaUsd/utils/dynamicAttribute.h>
 #include <mayaUsd/utils/progressBarScope.h>
 #include <mayaUsd/utils/traverseLayer.h>
 #include <mayaUsdUtils/util.h>
@@ -969,9 +970,19 @@ PrimUpdaterManager::PrimUpdaterManager()
 
     TfWeakPtr<PrimUpdaterManager> me(this);
     TfNotice::Register(me, &PrimUpdaterManager::onProxyContentChanged);
+
+#ifdef HAS_ORPHANED_NODES_MANAGER
+    beginLoadSaveCallbacks();
+#endif
 }
 
-PrimUpdaterManager::~PrimUpdaterManager() { }
+PrimUpdaterManager::~PrimUpdaterManager()
+{
+#ifdef HAS_ORPHANED_NODES_MANAGER
+    endLoadSaveCallbacks();
+    endManagePulledPrims();
+#endif
+}
 
 bool PrimUpdaterManager::mergeToUsd(
     const MFnDependencyNode& depNodeFn,
@@ -1890,6 +1901,7 @@ bool PrimUpdaterManager::readPullInformation(const MDagPath& dagPath, Ufe::Path&
 }
 
 #ifdef HAS_ORPHANED_NODES_MANAGER
+
 void PrimUpdaterManager::beginManagePulledPrims()
 {
     TF_VERIFY(_orphanedNodesManager->empty());
@@ -1919,6 +1931,77 @@ void PrimUpdaterManager::beforeNewOrOpenCallback(void* clientData)
     auto* pum = static_cast<PrimUpdaterManager*>(clientData);
     pum->endManagePulledPrims();
 }
+
+void PrimUpdaterManager::beginLoadSaveCallbacks()
+{
+    MStatus                status;
+    MSceneMessage::Message msgs[] = { MSceneMessage::kAfterNew, MSceneMessage::kAfterOpen };
+    for (auto msg : msgs) {
+        _openSaveCbs.append(MSceneMessage::addCallback(msg, afterNewOrOpenCallback, this, &status));
+        CHECK_MSTATUS(status);
+    }
+
+    _openSaveCbs.append(
+        MSceneMessage::addCallback(MSceneMessage::kBeforeSave, beforeSaveCallback, this, &status));
+    CHECK_MSTATUS(status);
+}
+
+void PrimUpdaterManager::endLoadSaveCallbacks()
+{
+    auto status = MMessage::removeCallbacks(_openSaveCbs);
+    CHECK_MSTATUS(status);
+    _openSaveCbs.clear();
+}
+
+/*static*/
+void PrimUpdaterManager::afterNewOrOpenCallback(void* clientData)
+{
+    auto* pum = static_cast<PrimUpdaterManager*>(clientData);
+    pum->loadOrphanedNodesManagerData();
+}
+
+/*static*/
+void PrimUpdaterManager::beforeSaveCallback(void* clientData)
+{
+    auto* pum = static_cast<PrimUpdaterManager*>(clientData);
+    pum->saveOrphanedNodesManagerData();
+}
+
+static const char* orphanedNodesManagerDynAttrName = "orphanedNodeManagerState";
+
+void PrimUpdaterManager::loadOrphanedNodesManagerData()
+{
+    MObject pullRoot = findPullRoot();
+    if (pullRoot.isNull())
+        return;
+
+    beginManagePulledPrims();
+
+    if (!hasDynamicAttribute(pullRoot, orphanedNodesManagerDynAttrName))
+        return;
+
+    MString json;
+    if (!getDynamicAttribute(pullRoot, orphanedNodesManagerDynAttrName, json))
+        return;
+
+    _orphanedNodesManager->restore(OrphanedNodesManager::Memento::convertFromJson(json.asChar()));
+}
+
+void PrimUpdaterManager::saveOrphanedNodesManagerData()
+{
+    MObject pullRoot = findPullRoot();
+    if (pullRoot.isNull())
+        return;
+
+    OrphanedNodesManager::Memento memento = _orphanedNodesManager->preserve();
+    const std::string             json = OrphanedNodesManager::Memento::convertToJson(memento);
+
+    MFnDependencyNode pullRootDepNode(pullRoot);
+    MStatus           status
+        = setDynamicAttribute(pullRootDepNode, orphanedNodesManagerDynAttrName, json.c_str());
+    CHECK_MSTATUS(status);
+}
+
 #endif
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/primUpdaterManager.h
+++ b/lib/mayaUsd/fileio/primUpdaterManager.h
@@ -122,6 +122,15 @@ private:
 
     void beginManagePulledPrims();
     void endManagePulledPrims();
+
+    void beginLoadSaveCallbacks();
+    void endLoadSaveCallbacks();
+
+    static void afterNewOrOpenCallback(void* clientData);
+    static void beforeSaveCallback(void* clientData);
+
+    void loadOrphanedNodesManagerData();
+    void saveOrphanedNodesManagerData();
 #endif
 
     friend class TfSingleton<PrimUpdaterManager>;
@@ -141,6 +150,8 @@ private:
 
     // Maya scene observation, to stop UFE scene observation.
     MCallbackIdArray _fileCbs;
+
+    MCallbackIdArray _openSaveCbs;
 #endif
 };
 

--- a/lib/mayaUsd/utils/CMakeLists.txt
+++ b/lib/mayaUsd/utils/CMakeLists.txt
@@ -29,6 +29,13 @@ target_sources(${PROJECT_NAME}
         variants.cpp
 )
 
+if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
+    target_sources(${PROJECT_NAME}
+        PRIVATE
+            json.cpp
+    )
+endif()
+
 set(HEADERS
     blockSceneModificationContext.h
     colorSpace.h
@@ -54,6 +61,11 @@ set(HEADERS
     utilSerialization.h
     variants.h
 )
+if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
+    list(APPEND HEADERS
+        json.h
+    )
+endif()
 
 set(PLUGINFO
     plugInfo.json)

--- a/lib/mayaUsd/utils/dynamicAttribute.h
+++ b/lib/mayaUsd/utils/dynamicAttribute.h
@@ -30,7 +30,7 @@ bool hasDynamicAttribute(const MFnDependencyNode& depNode, const MString& attrNa
 /*! \brief create the named dynamic attribute on the Maya node.
  */
 MAYAUSD_CORE_PUBLIC
-MStatus createDynamicAttribute(const MFnDependencyNode& depNode, const MString& attrName);
+MStatus createDynamicAttribute(MFnDependencyNode& depNode, const MString& attrName);
 
 /*! \brief get the string value of the named dynamic attribute from the Maya node.
  */
@@ -41,10 +41,8 @@ getDynamicAttribute(const MFnDependencyNode& depNode, const MString& attrName, M
 /*! \brief set the named dynamic attribute to the given string value on the Maya node.
  */
 MAYAUSD_CORE_PUBLIC
-MStatus setDynamicAttribute(
-    const MFnDependencyNode& depNode,
-    const MString&           attrName,
-    const MString&           value);
+MStatus
+setDynamicAttribute(MFnDependencyNode& depNode, const MString& attrName, const MString& value);
 
 } // namespace MAYAUSD_NS_DEF
 

--- a/lib/mayaUsd/utils/json.cpp
+++ b/lib/mayaUsd/utils/json.cpp
@@ -1,0 +1,96 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "json.h"
+
+#include <mayaUsd/utils/util.h>
+
+#include <ufe/pathString.h>
+
+namespace MAYAUSD_NS_DEF {
+
+static const char* invalidJson = "Invalid JSON";
+
+PXR_NS::JsValue convertToValue(const std::string& text)
+{
+    // Provided for call consistency and in case we need to do some filtering
+    // in the future.
+    return PXR_NS::JsValue(text);
+}
+
+std::string convertToString(const PXR_NS::JsValue& value)
+{
+    if (!value.IsString())
+        throw std::runtime_error(invalidJson);
+
+    return value.GetString();
+}
+
+PXR_NS::JsValue convertToValue(const MString& text)
+{
+    // Provided for call consistency and in case we need to do some filtering
+    // in the future.
+    return PXR_NS::JsValue(text.asChar());
+}
+
+MString convertToMString(const PXR_NS::JsValue& value)
+{
+    return MString(convertToString(value).c_str());
+}
+
+PXR_NS::JsValue convertToValue(const Ufe::Path& path)
+{
+    return convertToValue(Ufe::PathString::string(path));
+}
+
+Ufe::Path convertToUfePath(const PXR_NS::JsValue& pathJson)
+{
+    return Ufe::PathString::path(convertToString(pathJson));
+}
+
+PXR_NS::JsValue convertToValue(const MDagPath& path) { return convertToValue(path.fullPathName()); }
+
+MDagPath convertToDagPath(const PXR_NS::JsValue& value)
+{
+    return PXR_NS::UsdMayaUtil::nameToDagPath(convertToString(value));
+}
+
+PXR_NS::JsArray convertToArray(const PXR_NS::JsValue& value)
+{
+    if (!value.IsArray())
+        throw std::runtime_error(invalidJson);
+
+    return value.GetJsArray();
+}
+
+PXR_NS::JsObject convertToObject(const PXR_NS::JsValue& value)
+{
+    if (!value.IsObject())
+        throw std::runtime_error(invalidJson);
+
+    return value.GetJsObject();
+}
+
+PXR_NS::JsValue convertJsonKeyToValue(const PXR_NS::JsObject& object, const std::string& key)
+{
+    const auto pos = object.find(key);
+    if (pos == object.end())
+        throw std::runtime_error(invalidJson);
+
+    return pos->second;
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/json.h
+++ b/lib/mayaUsd/utils/json.h
@@ -1,0 +1,57 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <mayaUsd/base/api.h>
+
+#include <pxr/base/js/json.h>
+
+#include <maya/MDagPath.h>
+#include <maya/MString.h>
+#include <ufe/path.h>
+
+namespace MAYAUSD_NS_DEF {
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Conversion functions to and from JSON for C++, Maya and UFE types.
+//
+// All functions throw C++ exceptions on error.
+
+MAYAUSD_CORE_PUBLIC
+PXR_NS::JsValue convertToValue(const std::string& text);
+MAYAUSD_CORE_PUBLIC
+PXR_NS::JsValue convertToValue(const MString& text);
+MAYAUSD_CORE_PUBLIC
+PXR_NS::JsValue convertToValue(const Ufe::Path& path);
+MAYAUSD_CORE_PUBLIC
+PXR_NS::JsValue convertToValue(const MDagPath& path);
+
+MAYAUSD_CORE_PUBLIC
+std::string convertToString(const PXR_NS::JsValue& value);
+MAYAUSD_CORE_PUBLIC
+MString convertToMString(const PXR_NS::JsValue& value);
+MAYAUSD_CORE_PUBLIC
+Ufe::Path convertToUfePath(const PXR_NS::JsValue& value);
+MAYAUSD_CORE_PUBLIC
+MDagPath convertToDagPath(const PXR_NS::JsValue& value);
+MAYAUSD_CORE_PUBLIC
+PXR_NS::JsArray convertToArray(const PXR_NS::JsValue& value);
+MAYAUSD_CORE_PUBLIC
+PXR_NS::JsObject convertToObject(const PXR_NS::JsValue& value);
+MAYAUSD_CORE_PUBLIC
+PXR_NS::JsValue convertJsonKeyToValue(const PXR_NS::JsObject& object, const std::string& key);
+
+} // namespace MAYAUSD_NS_DEF

--- a/test/lib/mayaUsd/fileio/testHideOrphanedNodes.py
+++ b/test/lib/mayaUsd/fileio/testHideOrphanedNodes.py
@@ -31,6 +31,7 @@ from maya.api import OpenMaya as om
  
 import ufe
 
+import os.path
 import unittest
 
 from testUtils import getTestScene
@@ -98,9 +99,19 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
         self.cPathStr = self.ps + ',/A/B/C'
         self.ePathStr = self.ps + ',/D/E'
 
+    def getVisibilityPlugs(self, mayaPaths):
+        visibilityPlugs = {}
+
+        for pathStr, mayaPath in mayaPaths.items():
+            # Get the pull parent from the path.  Pulled node is visible.
+            visibility = visibilityPlug(ufe.PathString.string(mayaPath.pop()))
+            visibilityPlugs[pathStr] = visibility
+
+        return visibilityPlugs
+
     def pullAndGetParentVisibility(self, pathStrings):
 
-        visibilityPlugs = {}
+        mayaPaths = {}
 
         for pathStr in pathStrings:
             # See testEditAsMaya.py comments: PathMappingHandler toHost()
@@ -109,17 +120,18 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
             mayaItem = ufe.GlobalSelection.get().front()
             mayaPath = mayaItem.path()
             self.assertEqual(mayaPath.nbSegments(), 1)
-    
-            # Get the pull parent from the path.  Pulled node is visible.
-            visibility = visibilityPlug(ufe.PathString.string(mayaPath.pop()))
-            visibilityPlugs[pathStr] = visibility
+            mayaPaths[pathStr] = mayaPath
+
+        visibilityPlugs = self.getVisibilityPlugs(mayaPaths)
+
+        for pathStr, visibility in visibilityPlugs.items():
             self.assertTrue(visibility.asBool())
         
-        return visibilityPlugs
+        return visibilityPlugs, mayaPaths
 
     def testHideOnDelete(self):
         # Pull on C and E.
-        pullParentVisibilityPlug = self.pullAndGetParentVisibility(
+        pullParentVisibilityPlug, _ = self.pullAndGetParentVisibility(
             [self.cPathStr, self.ePathStr])
 
         # Delete the proxy shape.  Both pulled nodes should be orphaned and
@@ -137,7 +149,7 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
 
     def testHideOnInactivate(self):
         # Pull on C and E.
-        pullParentVisibilityPlug = self.pullAndGetParentVisibility(
+        pullParentVisibilityPlug, _ = self.pullAndGetParentVisibility(
             [self.cPathStr, self.ePathStr])
 
         # Inactivate B, C's parent.
@@ -156,7 +168,7 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
 
     def testHideOnPayloadUnload(self):
         # Pull on C and E.
-        pullParentVisibilityPlug = self.pullAndGetParentVisibility(
+        pullParentVisibilityPlug, _ = self.pullAndGetParentVisibility(
             [self.cPathStr, self.ePathStr])
 
         # Unload A, C's grandparent.
@@ -176,7 +188,7 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
 
     def testHideOnNestedVariantSwitch(self):
         # Pull on C and E.
-        pullParentVisibilityPlug = self.pullAndGetParentVisibility(
+        pullParentVisibilityPlug, _ = self.pullAndGetParentVisibility(
             [self.cPathStr, self.ePathStr])
 
         # B's variant set cdVariant is set to variant selection c, so Maya
@@ -211,9 +223,68 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
         self.assertTrue(pullParentVisibilityPlug[self.cPathStr].asBool())
         self.assertTrue(pullParentVisibilityPlug[self.ePathStr].asBool())
 
+    def _saveScene(self, filename):
+        cmds.file(rename=filename)
+        cmds.file(save=True, force=True, type="mayaAscii")
+    
+    def _reloadScene(self, filename):
+        cmds.file(new=True, force=True)
+        cmds.file(filename, open=True)
+
+    def testHideOnNestedVariantSwitchOnReload(self):
+        # Pull on C and E.
+        pullParentVisibilityPlug, mayaPaths = self.pullAndGetParentVisibility(
+            [self.cPathStr, self.ePathStr])
+
+        # B's variant set cdVariant is set to variant selection c, so Maya
+        # version of pulled node C has translation (1, 2, 3).
+        variantCXlation = (1, 2, 3)
+        cPrim = mayaUsd.ufe.ufePathToPrim(self.cPathStr)
+        cMayaPathStr = mayaUsd.lib.PrimUpdaterManager.readPullInformation(cPrim)
+        cDagPath = om.MSelectionList().add(cMayaPathStr).getDagPath(0)
+        cFn= om.MFnTransform(cDagPath)
+        self.assertEqual(cFn.translation(om.MSpace.kObject),
+                         om.MVector(*variantCXlation))
+
+        bPrim = cPrim.GetParent()
+        cdVariant = bPrim.GetVariantSet('cdVariant')
+        self.assertEqual(cdVariant.GetVariantSelection(), 'c')
+
+        # Switch B's variant set cdVariant to variant selection d.  The prim in
+        # that variant is also called C, but it is a different prim, with a
+        # different translation, so the pulled node is hidden.
+        cdVariant.SetVariantSelection('d')
+
+        cPrim = mayaUsd.ufe.ufePathToPrim(self.cPathStr)
+        cXformable = UsdGeom.Xformable(cPrim)
+        self.assertEqual(cXformable.GetLocalTransformation().GetRow3(3), [4, 5, 6])
+
+        self.assertFalse(pullParentVisibilityPlug[self.cPathStr].asBool())
+        self.assertTrue(pullParentVisibilityPlug[self.ePathStr].asBool())
+
+        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 2))
+        filename = os.path.abspath("orphaned.ma")
+        self._saveScene(filename)
+        self._reloadScene(filename)
+
+        # # Verify the hidden state of the edited nodes.
+        pullParentVisibilityPlug = self.getVisibilityPlugs(mayaPaths)
+
+        self.assertFalse(pullParentVisibilityPlug[self.cPathStr].asBool())
+        self.assertTrue(pullParentVisibilityPlug[self.ePathStr].asBool())
+
+        # # Revert back to variant selection c, pulled node is shown.
+        cPrim = mayaUsd.ufe.ufePathToPrim(self.cPathStr)
+        bPrim = cPrim.GetParent()
+        cdVariant = bPrim.GetVariantSet('cdVariant')
+        cdVariant.SetVariantSelection('c')
+
+        self.assertTrue(pullParentVisibilityPlug[self.cPathStr].asBool())
+        self.assertTrue(pullParentVisibilityPlug[self.ePathStr].asBool())
+
     def testHideOnNestingVariantSwitch(self):
         # Pull on C and E.
-        pullParentVisibilityPlug = self.pullAndGetParentVisibility(
+        pullParentVisibilityPlug, _ = self.pullAndGetParentVisibility(
             [self.cPathStr, self.ePathStr])
 
         # A's variant set abVariant is set to variant selection a, so Maya
@@ -252,7 +323,7 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
         the deletion. The Maya object should still be deleted.
         '''
         # Pull on C.
-        pullParentVisibilityPlug = self.pullAndGetParentVisibility(
+        pullParentVisibilityPlug, _ = self.pullAndGetParentVisibility(
             [self.cPathStr])
 
         # A's variant set abVariant is set to variant selection a, so Maya
@@ -295,7 +366,7 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
         be visible.
         '''
         # Pull on C.
-        pullParentVisibilityPlug = self.pullAndGetParentVisibility(
+        pullParentVisibilityPlug, _ = self.pullAndGetParentVisibility(
             [self.cPathStr])
 
         # A's variant set abVariant is set to variant selection a, so Maya


### PR DESCRIPTION
- Conversion to and from JSON
- Save and restore the orphaned nodes manager state
- Register unregister callbacks on construction, unregister on destruction of the prim updater manager.
- Add after new / open callback to load the orphaned nodes manager state.
- Add before save callback to save the orphnaed nodes manager state.
- Move generic JSON function to their own file under mayaUsd/utils.
- Improve the dynamic attribute functions to use C++ API instead of MEL.
- Add unit test