### PR TITLE
MAYA-125649 - Build MayaUsd on RHEL8 with new ABI when Maya switches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,10 @@ endif()
 include(cmake/utils.cmake)
 find_package(Maya 2018 REQUIRED)
 
+if(APPLE AND BUILD_UB2 AND NOT MAYA_MACOSX_BUILT_WITH_UB2)
+    message(WARNING  "Maya was NOT built with Universal Binary 2")
+endif()
+
 if (BUILD_MAYAUSD_LIBRARY)
     include(cmake/mayausd_version.info)
     set(MAYAUSD_VERSION "${MAYAUSD_MAJOR_VERSION}.${MAYAUSD_MINOR_VERSION}.${MAYAUSD_PATCH_LEVEL}")

--- a/cmake/compiler_config.cmake
+++ b/cmake/compiler_config.cmake
@@ -106,7 +106,7 @@ function(mayaUsd_compile_config TARGET)
         if(IS_LINUX)
             target_compile_definitions(${TARGET}
                 PRIVATE
-                    _GLIBCXX_USE_CXX11_ABI=0 # USD is built with old ABI
+                    _GLIBCXX_USE_CXX11_ABI=$<IF:$<BOOL:${MAYA_LINUX_BUILT_WITH_CXX11_ABI}>,1,0>
             )
         endif()
     elseif(IS_MSVC)

--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -36,9 +36,7 @@ macro(fetch_googletest)
             # We will just update to newer version, if required.
             set(disable_all_warnings_flag -w)
 
-            # Force the use of ABI version 0 on Linux.
-            # This is what Maya has been using for 2019...2023
-            set(glibcxx_abi -D_GLIBCXX_USE_CXX11_ABI=0)
+            set(glibcxx_abi -D_GLIBCXX_USE_CXX11_ABI=$<IF:$<BOOL:${MAYA_LINUX_BUILT_WITH_CXX11_ABI}>,1,0>)
         endif()
 
         if (GOOGLETEST_SRC_DIR)

--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -12,17 +12,25 @@
 # MAYA_API_VERSION    Maya version (6-8 digits)
 # MAYA_APP_VERSION    Maya app version (4 digits)
 # MAYA_LIGHTAPI_VERSION Maya light API version (1 or 2 or 3)
+# MAYA_PREVIEW_RELEASE_VERSION Preview Release number (3 or more digits) in preview releases, 0 in official releases
+#
+# Cache variables:
 # MAYA_HAS_DEFAULT_MATERIAL_API Presence of a default material API on MRenderItem.
 # MAYA_NEW_POINT_SNAPPING_SUPPORT Presence of point new snapping support.
-# MAYA_PREVIEW_RELEASE_VERSION Preview Release number (3 or more digits) in preview releases, 0 in official releases
 # MAYA_CURRENT_UFE_CAMERA_SUPPORT Presence of MFrameContext::getCurrentUfeCameraPath.
+# MAYA_HAS_CRASH_DETECTION Presence of isInCrashHandler API
 # MAYA_MRENDERITEM_UFE_IDENTIFIER_SUPPORT Presence of MPxSubSceneOverride::setUfeIdentifier.
 # MAYA_UPDATE_UFE_IDENTIFIER_SUPPORT Presence of MPxSubSceneOverride::updateUfeIdentifier.
 # MAYA_ENABLE_NEW_PRIM_DELETE Enable new delete behaviour for delete command
 # MAYA_HAS_DISPLAY_STYLE_ALL_VIEWPORTS Presence of MFrameContext::getDisplayStyleOfAllViewports.
 # MAYA_ARRAY_ITERATOR_DIFFERENCE_TYPE_SUPPORT Presence of maya array iterator difference_type trait
 # MAYA_HAS_GET_MEMBER_PATHS Presence of MFnSet::getMemberPaths
+# MAYA_HAS_DISPLAY_LAYER_API Presence of MFnDisplayLayer
+# MAYA_HAS_NEW_DISPLAY_LAYER_MESSAGING_API Presence of MDisplayLayerMemberChangedFunction
+# MAYA_HAS_RENDER_ITEM_HIDE_ON_PLAYBACK_API Presence of MRenderItem has HideOnPlayback API
 # MAYA_CAMERA_GIZMO_SUPPORT Support for drawing Ufe cameras and lights in the viewport.
+# MAYA_LINUX_BUILT_WITH_CXX11_ABI Maya Linux was built with new cxx11 ABI.
+# MAYA_MACOSX_BUILT_WITH_UB2 Maya OSX was built with Universal Binary 2.
 
 #=============================================================================
 # Copyright 2011-2012 Francisco Requena <frarees@gmail.com>
@@ -472,6 +480,50 @@ set(MAYA_CAMERA_GIZMO_SUPPORT FALSE CACHE INTERNAL "ufeCameraGizmos")
 if (MAYA_API_VERSION VERSION_GREATER_EQUAL 20230200)
     set(MAYA_CAMERA_GIZMO_SUPPORT TRUE CACHE INTERNAL "ufeCameraGizmos")
     message(STATUS "Maya has UFE gizmo drawing")
+endif()
+
+set(MAYA_LINUX_BUILT_WITH_CXX11_ABI FALSE CACHE INTERNAL "MayaLinuxBuiltWithCxx11ABI")
+if(IS_LINUX AND MAYA_Foundation_LIBRARY)
+    # Determine if Maya (on Linux) was built using the new CXX11 ABI.
+    # If yes, then MayaUsd MUST also be built with new ABI.
+    execute_process(
+        COMMAND
+            nm "${MAYA_Foundation_LIBRARY}"
+        COMMAND
+            grep findVariableReplacement
+        COMMAND
+            grep " T "
+       WORKING_DIRECTORY
+            ${MAYA_LIBRARY_DIR}
+        OUTPUT_VARIABLE
+            maya_cxx11_abi)
+    string(FIND ${maya_cxx11_abi} "__cxx1112basic_string" maya_cxx11_abi_index)
+    if(NOT (${maya_cxx11_abi_index} STREQUAL "-1"))
+        set(MAYA_LINUX_BUILT_WITH_CXX11_ABI TRUE CACHE INTERNAL "MayaLinuxBuiltWithCxx11ABI")
+        message(STATUS "Linux: Maya was built with new cxx11 ABI")
+    endif()
+endif()
+
+set(MAYA_MACOSX_BUILT_WITH_UB2 FALSE CACHE INTERNAL "MayaMacOSXBuiltWithUB2")
+if(IS_MACOSX AND MAYA_Foundation_LIBRARY)
+    # Determine if Maya (on OSX) was built with Universal Binary 2 (x86_64 & arm64).
+    # If yes, then MayaUsd can be built with either: Intel, Arm or both.
+    execute_process(
+        COMMAND
+            lipo -archs "${MAYA_Foundation_LIBRARY}"
+        WORKING_DIRECTORY
+            ${MAYA_LIBRARY_DIR}
+        OUTPUT_VARIABLE
+            maya_lipo_output)
+    string(REGEX MATCHALL "(x86_64|arm64)" maya_ub2_match ${maya_lipo_output})
+    if (maya_ub2_match)
+        list(FIND maya_ub2_match "x86_64" ub2_index1)
+        list(FIND maya_ub2_match "arm64" ub2_index2)
+        if((NOT (${ub2_index1} STREQUAL "-1")) AND (NOT (${ub2_index2} STREQUAL "-1")))
+            set(MAYA_MACOSX_BUILT_WITH_UB2 TRUE CACHE INTERNAL "MayaMacOSXBuiltWithUB2")
+            message(STATUS "MacOSX: Maya was built with Universal Binary 2 (x86_64/arm64)")
+        endif()
+    endif()
 endif()
 
 # handle the QUIETLY and REQUIRED arguments and set MAYA_FOUND to TRUE if

--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -493,14 +493,16 @@ if(IS_LINUX AND MAYA_Foundation_LIBRARY)
             grep findVariableReplacement
         COMMAND
             grep " T "
-       WORKING_DIRECTORY
+        WORKING_DIRECTORY
             ${MAYA_LIBRARY_DIR}
         OUTPUT_VARIABLE
             maya_cxx11_abi)
-    string(FIND ${maya_cxx11_abi} "__cxx1112basic_string" maya_cxx11_abi_index)
-    if(NOT (${maya_cxx11_abi_index} STREQUAL "-1"))
-        set(MAYA_LINUX_BUILT_WITH_CXX11_ABI TRUE CACHE INTERNAL "MayaLinuxBuiltWithCxx11ABI")
-        message(STATUS "Linux: Maya was built with new cxx11 ABI")
+    if (NOT ("${maya_cxx11_abi}" STREQUAL ""))
+        string(FIND ${maya_cxx11_abi} "__cxx1112basic_string" maya_cxx11_abi_index)
+        if(NOT (${maya_cxx11_abi_index} STREQUAL "-1"))
+            set(MAYA_LINUX_BUILT_WITH_CXX11_ABI TRUE CACHE INTERNAL "MayaLinuxBuiltWithCxx11ABI")
+            message(STATUS "Linux: Maya was built with new cxx11 ABI")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
#### MAYA-125649 - Build MayaUsd on RHEL8 with new ABI when Maya switches to new ABI
#### MAYA-125320 - Enable UB2 on MacOSX
- Support for RHEL8 with new ABI. If Maya was built with new ABI then MayaUsd must also be.
- Detect if Maya was built with UB2 and issue warning if MayaUsd is UB2, but Maya is not.