### PR TITLE
MAYA-125036 wipe and restore orphaned session data

### DIFF
--- a/lib/mayaUsd/commands/PullPushCommands.cpp
+++ b/lib/mayaUsd/commands/PullPushCommands.cpp
@@ -260,7 +260,7 @@ MStatus MergeToUsdCommand::doIt(const MArgList& argList)
         return reportError(status);
 
     Ufe::Path pulledPath;
-    if (!PXR_NS::PrimUpdaterManager::readPullInformation(dagPath, pulledPath))
+    if (!PXR_NS::readPullInformation(dagPath, pulledPath))
         return reportError(MS::kInvalidParameter);
 
     MArgDatabase argData(syntax(), argList, &status);
@@ -338,7 +338,7 @@ MStatus DiscardEditsCommand::doIt(const MArgList& argList)
 
     MDagPath  dagPath = PXR_NS::UsdMayaUtil::nameToDagPath(nodeName.asChar());
     Ufe::Path pulledPath;
-    if (!PXR_NS::PrimUpdaterManager::readPullInformation(dagPath, pulledPath))
+    if (!PXR_NS::readPullInformation(dagPath, pulledPath))
         return reportError(MS::kInvalidParameter);
 
     // Scope the undo item recording so we can undo on failure.

--- a/lib/mayaUsd/fileio/CMakeLists.txt
+++ b/lib/mayaUsd/fileio/CMakeLists.txt
@@ -45,6 +45,7 @@ if(UFE_TRIE_NODE_HAS_CHILDREN_COMPONENTS_ACCESSOR)
     target_sources(${PROJECT_NAME}
         PRIVATE
             orphanedNodesManager.cpp
+            orphanedNodesManagerIO.cpp
     )
 
     target_compile_definitions(${PROJECT_NAME}

--- a/lib/mayaUsd/fileio/CMakeLists.txt
+++ b/lib/mayaUsd/fileio/CMakeLists.txt
@@ -38,6 +38,7 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
             primUpdaterContext.cpp
             primUpdaterRegistry.cpp
             primUpdaterManager.cpp
+            pullInformation.cpp
     )
 endif()
 
@@ -89,6 +90,7 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
         primUpdaterContext.h
         primUpdaterRegistry.h
         primUpdaterManager.h
+        pullInformation.h
     )
 endif()
 

--- a/lib/mayaUsd/fileio/orphanedNodesManager.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.cpp
@@ -91,7 +91,7 @@ void OrphanedNodesManager::add(const Ufe::Path& pulledPath, const MDagPath& pull
 
 OrphanedNodesManager::Memento OrphanedNodesManager::remove(const Ufe::Path& pulledPath)
 {
-    Memento oldPulledPrims(deepCopy(pulledPrims()));
+    Memento oldPulledPrims(preserve());
     TF_AXIOM(pulledPrims().remove(pulledPath) != nullptr);
     return oldPulledPrims;
 }
@@ -260,6 +260,11 @@ void OrphanedNodesManager::clear() { pulledPrims().clear(); }
 
 bool OrphanedNodesManager::empty() const { return pulledPrims().root()->empty(); }
 
+OrphanedNodesManager::Memento OrphanedNodesManager::preserve() const
+{
+    return Memento(deepCopy(pulledPrims()));
+}
+
 void OrphanedNodesManager::restore(Memento&& previous) { _pulledPrims = previous.release(); }
 
 bool OrphanedNodesManager::isOrphaned(const Ufe::Path& pulledPath) const
@@ -280,7 +285,7 @@ bool OrphanedNodesManager::setVisibilityPlug(
     bool                                       visibility)
 {
     TF_VERIFY(trieNode->hasData());
-    const auto& pullParentPath = trieNode->data().dagPath;
+    const auto& pullParentPath = trieNode->data().pulledParentPath;
     MFnDagNode  fn(pullParentPath);
     auto        visibilityPlug = fn.findPlug("visibility", /* tryNetworked */ true);
     return (visibilityPlug.setBool(visibility) == MS::kSuccess);
@@ -290,7 +295,7 @@ bool OrphanedNodesManager::setVisibilityPlug(
 bool OrphanedNodesManager::getVisibilityPlug(const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode)
 {
     TF_VERIFY(trieNode->hasData());
-    const auto& pullParentPath = trieNode->data().dagPath;
+    const auto& pullParentPath = trieNode->data().pulledParentPath;
     MFnDagNode  fn(pullParentPath);
     auto        visibilityPlug = fn.findPlug("visibility", /* tryNetworked */ true);
     return visibilityPlug.asBool();

--- a/lib/mayaUsd/fileio/orphanedNodesManager.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.cpp
@@ -323,7 +323,7 @@ namespace ufe {
 extern Ufe::Rtid g_MayaRtid;
 extern Ufe::Rtid g_USDRtid;
 
-}
+} // namespace ufe
 
 namespace {
 
@@ -374,7 +374,7 @@ MStatus setNodeVisibility(const MDagPath& dagPath, bool visibility)
     return visibilityPlug.setBool(visibility);
 }
 
-} // namespace ufe
+} // namespace
 
 /* static */
 bool OrphanedNodesManager::setOrphaned(

--- a/lib/mayaUsd/fileio/orphanedNodesManager.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.cpp
@@ -16,6 +16,7 @@
 #include "orphanedNodesManager.h"
 
 #include <mayaUsd/fileio/primUpdaterManager.h>
+#include <mayaUsd/fileio/pullInformation.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/ufe/Global.h>
 #include <mayaUsd/ufe/UsdSceneItem.h>
@@ -373,11 +374,11 @@ bool OrphanedNodesManager::setOrphaned(
     const Ufe::Path        pulledPrimPath = trieNodeToPullePrimUfePath(trieNode);
 
     if (orphaned) {
-        PrimUpdaterManager::removePulledPrimMetadata(pulledPrimPath);
-        PrimUpdaterManager::removeExcludeFromRendering(pulledPrimPath);
+        removePulledPrimMetadata(pulledPrimPath);
+        removeExcludeFromRendering(pulledPrimPath);
     } else {
-        PrimUpdaterManager::writePulledPrimMetadata(pulledPrimPath, variantInfo.editedAsMayaRoot);
-        PrimUpdaterManager::addExcludeFromRendering(pulledPrimPath);
+        writePulledPrimMetadata(pulledPrimPath, variantInfo.editedAsMayaRoot);
+        addExcludeFromRendering(pulledPrimPath);
     }
 
     MFnDagNode fn(variantInfo.pulledParentPath);

--- a/lib/mayaUsd/fileio/orphanedNodesManager.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.cpp
@@ -389,7 +389,6 @@ bool OrphanedNodesManager::setOrphaned(
     //       the outliner reacts to UFe notifications received following the USD edits
     //       to rebuild the node tree and the Maya node we want to hide must have been
     //       hidden by that point. So the node visibility change must be done *first*.
-    CHECK_MSTATUS_AND_RETURN(setNodeVisibility(variantInfo.editedAsMayaRoot, !orphaned), false);
     CHECK_MSTATUS_AND_RETURN(setNodeVisibility(variantInfo.pulledParentPath, !orphaned), false);
 
     const Ufe::Path pulledPrimPath = trieNodeToPullePrimUfePath(trieNode);

--- a/lib/mayaUsd/fileio/orphanedNodesManager.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.cpp
@@ -15,6 +15,8 @@
 //
 #include "orphanedNodesManager.h"
 
+#include <mayaUsd/fileio/primUpdaterManager.h>
+#include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/ufe/Global.h>
 #include <mayaUsd/ufe/UsdSceneItem.h>
 #include <mayaUsd/ufe/Utils.h>
@@ -72,7 +74,10 @@ OrphanedNodesManager::OrphanedNodesManager()
 {
 }
 
-void OrphanedNodesManager::add(const Ufe::Path& pulledPath, const MDagPath& pullParentPath)
+void OrphanedNodesManager::add(
+    const Ufe::Path& pulledPath,
+    const MDagPath&  pullParentPath,
+    const MDagPath&  editedAsMayaRoot)
 {
     // Add the pull parent to our pulled prims prefix tree.  Also add the full
     // configuration of variant set selections for each ancestor, up to the USD
@@ -81,12 +86,37 @@ void OrphanedNodesManager::add(const Ufe::Path& pulledPath, const MDagPath& pull
     TF_AXIOM(!pulledPrims().containsDescendantInclusive(pulledPath));
     TF_AXIOM(pulledPath.runTimeId() == MayaUsd::ufe::getUsdRunTimeId());
 
+    MayaUsdProxyShapeBase* proxyShape = MayaUsd::ufe::getProxyShape(pulledPath);
+    if (!proxyShape)
+        return;
+
+    // Note: the reason we store the proxy shape path when it would seem we
+    //       could derive it from the pulledPath is exactly the reason we are
+    //       keeping all this information: when we need to use the information,
+    //       the pulled prim might no longer be accessible. For example, the
+    //       pulled prim might not be acccessible because an ancestor has
+    //       switched variant.
+    //
+    //       This is why we keep the proxy shape path.
+    //
+    //       We currently assume the user does not make the path to the proxy
+    //       shape invalid by renaming any ancestor or reparenting an ancestor...
+    //
+    //       FIXME: update the proxy shape path when objects are renamed or
+    //              reparented. Currently tracked as MAYA-125039.
+    //              This also affects the pulledPath, pullParentPath and
+    //              editedAsMayaRoot.
+    MDagPath proxyShapePath;
+    if (!MDagPath::getAPathTo(proxyShape->thisMObject(), proxyShapePath))
+        return;
+
     // We store a list of (path, list of (variant set, variant set selection)),
     // for all ancestors, starting at closest ancestor.
     auto ancestorPath = pulledPath.pop();
     auto vsd = variantSetDescriptors(ancestorPath);
 
-    pulledPrims().add(pulledPath, PullVariantInfo(pullParentPath, vsd));
+    pulledPrims().add(
+        pulledPath, PullVariantInfo(proxyShapePath, pullParentPath, editedAsMayaRoot, vsd));
 }
 
 OrphanedNodesManager::Memento OrphanedNodesManager::remove(const Ufe::Path& pulledPath)
@@ -164,7 +194,7 @@ void OrphanedNodesManager::handleOp(const Ufe::SceneCompositeNotification::Op& o
         // the path.  It may be an internal node, without data.
         auto ancestorNode = pulledPrims().node(op.path);
         TF_VERIFY(ancestorNode);
-        recursiveSetVisibility(ancestorNode, false);
+        recursiveSetOrphaned(ancestorNode, true);
     } break;
     case Ufe::SceneCompositeNotification::OpType::SubtreeInvalidate: {
         // On subtree invalidate, the scene item itself has not had a structure
@@ -184,7 +214,7 @@ void OrphanedNodesManager::handleOp(const Ufe::SceneCompositeNotification::Op& o
         if (!parentHier->hasChildren()) {
             auto ancestorNode = pulledPrims().node(op.path);
             if (ancestorNode) {
-                recursiveSetVisibility(ancestorNode, false);
+                recursiveSetOrphaned(ancestorNode, true);
             }
             return;
         } else {
@@ -234,7 +264,7 @@ void OrphanedNodesManager::handleOp(const Ufe::SceneCompositeNotification::Op& o
                 // hidden.
                 auto ancestorNode = pulledPrims().node(op.path);
                 if (ancestorNode) {
-                    recursiveSetVisibility(ancestorNode, false);
+                    recursiveSetOrphaned(ancestorNode, true);
                 }
             }
         }
@@ -274,47 +304,101 @@ bool OrphanedNodesManager::isOrphaned(const Ufe::Path& pulledPath) const
         // If the argument path has not been pulled, it can't be orphaned.
         return false;
     }
-    TF_VERIFY(trieNode->hasData());
+
+    if (!trieNode->hasData()) {
+        // If the argument path has not been pulled, it can't be orphaned.
+        return false;
+    }
+
     // If the pull parent is visible, the pulled path is not orphaned.
-    return !getVisibilityPlug(trieNode);
-}
-
-/* static */
-bool OrphanedNodesManager::setVisibilityPlug(
-    const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode,
-    bool                                       visibility)
-{
-    TF_VERIFY(trieNode->hasData());
     const auto& pullParentPath = trieNode->data().pulledParentPath;
     MFnDagNode  fn(pullParentPath);
     auto        visibilityPlug = fn.findPlug("visibility", /* tryNetworked */ true);
-    return (visibilityPlug.setBool(visibility) == MS::kSuccess);
+    return !visibilityPlug.asBool();
+}
+
+namespace ufe {
+extern Ufe::Rtid g_MayaRtid;
+extern Ufe::Rtid g_USDRtid;
+} // namespace ufe
+
+Ufe::Path
+trieNodeToPullePrimUfePath(Ufe::TrieNode<OrphanedNodesManager::PullVariantInfo>::Ptr trieNode)
+{
+    const OrphanedNodesManager::PullVariantInfo& variantInfo = trieNode->data();
+
+    Ufe::Path proxyShapeUfePath = ufe::dagPathToUfe(variantInfo.proxyShapePath);
+    if (proxyShapeUfePath.getSegments().size() < 1)
+        return Ufe::Path();
+
+    UsdStagePtr stage = ufe::getStage(proxyShapeUfePath);
+    if (!stage)
+        return Ufe::Path();
+
+    // Note: the trie root node is not really part of the hierarchy, so do not
+    //       include it in the components. We detect we are at the root when
+    //       the node has no parent.
+    Ufe::PathSegment::Components pathComponents;
+    while (trieNode->parent()) {
+        pathComponents.push_back(trieNode->component());
+        trieNode = trieNode->parent();
+    }
+    std::reverse(pathComponents.begin(), pathComponents.end());
+
+    const size_t proxyShapeComponentCount = proxyShapeUfePath.size();
+    if (pathComponents.size() < proxyShapeComponentCount)
+        return Ufe::Path();
+
+    const Ufe::PathSegment::Components proxyShapeComponents(
+        pathComponents.begin(), pathComponents.begin() + proxyShapeComponentCount);
+    const Ufe::PathSegment proxyShapeSegment(proxyShapeComponents, ufe::g_MayaRtid, '|');
+    if (proxyShapeSegment != proxyShapeUfePath.getSegments()[0])
+        return Ufe::Path();
+
+    Ufe::PathSegment::Components primComponents(
+        pathComponents.begin() + proxyShapeComponentCount, pathComponents.end());
+    const Ufe::PathSegment primSegment(primComponents, ufe::g_USDRtid, '/');
+    Ufe::Path              primPath = proxyShapeUfePath + primSegment;
+    return primPath;
 }
 
 /* static */
-bool OrphanedNodesManager::getVisibilityPlug(const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode)
+bool OrphanedNodesManager::setOrphaned(
+    const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode,
+    bool                                       orphaned)
 {
     TF_VERIFY(trieNode->hasData());
-    const auto& pullParentPath = trieNode->data().pulledParentPath;
-    MFnDagNode  fn(pullParentPath);
-    auto        visibilityPlug = fn.findPlug("visibility", /* tryNetworked */ true);
-    return visibilityPlug.asBool();
+
+    const PullVariantInfo& variantInfo = trieNode->data();
+    const Ufe::Path        pulledPrimPath = trieNodeToPullePrimUfePath(trieNode);
+
+    if (orphaned) {
+        PrimUpdaterManager::removePulledPrimMetadata(pulledPrimPath);
+        PrimUpdaterManager::removeExcludeFromRendering(pulledPrimPath);
+    } else {
+        PrimUpdaterManager::writePulledPrimMetadata(pulledPrimPath, variantInfo.editedAsMayaRoot);
+        PrimUpdaterManager::addExcludeFromRendering(pulledPrimPath);
+    }
+
+    MFnDagNode fn(variantInfo.pulledParentPath);
+    auto       visibilityPlug = fn.findPlug("visibility", /* tryNetworked */ true);
+    return (visibilityPlug.setBool(!orphaned) == MS::kSuccess);
 }
 
 /* static */
-void OrphanedNodesManager::recursiveSetVisibility(
+void OrphanedNodesManager::recursiveSetOrphaned(
     const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode,
-    bool                                       visibility)
+    bool                                       orphaned)
 {
     // We know in our case that a trie node with data can't have children,
     // since descendants of a pulled prim can't be pulled.
     if (trieNode->hasData()) {
         TF_VERIFY(trieNode->empty());
-        TF_VERIFY(setVisibilityPlug(trieNode, visibility));
+        TF_VERIFY(setOrphaned(trieNode, orphaned));
     } else {
         auto childrenComponents = trieNode->childrenComponents();
         for (const auto& c : childrenComponents) {
-            recursiveSetVisibility((*trieNode)[c], visibility);
+            recursiveSetOrphaned((*trieNode)[c], orphaned);
         }
     }
 }
@@ -342,19 +426,8 @@ void OrphanedNodesManager::recursiveSwitch(
         // inactive on pull, to avoid rendering it.
         const bool variantSetsMatch
             = (trieNode->data().variantSetDescriptors == variantSetDescriptors(ufePath.pop()));
-        const bool visibility = (pulledNode && variantSetsMatch);
-        TF_VERIFY(setVisibilityPlug(trieNode, visibility));
-
-        // Set the activation of the pulled USD prim to the opposite of that of
-        // the corresponding Maya node: other variants may refer to the same
-        // path, and we don't want those paths to hit an inactive prim.  No
-        // need to remove an inert primSpec: this will be done on push.
-        auto prim = MayaUsd::ufe::ufePathToPrim(ufePath);
-        auto stage = prim.GetStage();
-        if (TF_VERIFY(stage)) {
-            UsdEditContext editContext(stage, stage->GetSessionLayer());
-            TF_VERIFY(prim.SetActive(!visibility));
-        }
+        const bool orphaned = (pulledNode && !variantSetsMatch);
+        TF_VERIFY(setOrphaned(trieNode, orphaned));
     } else {
         const bool isGatewayToUsd = Ufe::SceneSegmentHandler::isGateway(ufePath);
         for (const auto& c : trieNode->childrenComponents()) {

--- a/lib/mayaUsd/fileio/orphanedNodesManager.h
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.h
@@ -87,12 +87,20 @@ public:
     struct PullVariantInfo
     {
         PullVariantInfo() = default;
-        PullVariantInfo(const MDagPath& pulledParent, const std::list<VariantSetDescriptor>& vsd)
-            : pulledParentPath(pulledParent)
+        PullVariantInfo(
+            const MDagPath&                        proxyShape,
+            const MDagPath&                        pulledParent,
+            const MDagPath&                        editedMayaRoot,
+            const std::list<VariantSetDescriptor>& vsd)
+            : proxyShapePath(proxyShape)
+            , pulledParentPath(pulledParent)
+            , editedAsMayaRoot(editedMayaRoot)
             , variantSetDescriptors(vsd)
         {
         }
+        MDagPath                        proxyShapePath;
         MDagPath                        pulledParentPath;
+        MDagPath                        editedAsMayaRoot;
         std::list<VariantSetDescriptor> variantSetDescriptors;
     };
 
@@ -130,9 +138,13 @@ public:
     // Notifications handling, part of the Ufe::Observer interface.
     void operator()(const Ufe::Notification&) override;
 
-    // Add the pulled path and its Maya pull parent to the trie of pulled
-    // prims.  Asserts that the pulled path is not in the trie.
-    void add(const Ufe::Path& pulledPath, const MDagPath& pullParentPath);
+    // Add the pulled path, its Maya pull parent and the root of the generated
+    // Maya nodes to the trie of pulled prims.
+    // Asserts that the pulled path is not in the trie.
+    void
+    add(const Ufe::Path& pulledPath,
+        const MDagPath&  pullParentPath,
+        const MDagPath&  editedAsMayaRoot);
 
     // Remove the pulled path from the trie of pulled prims.  Asserts that the
     // path is in the trie.  Returns a memento (see Memento Pattern) for undo
@@ -162,13 +174,11 @@ private:
     const Ufe::Trie<PullVariantInfo>& pulledPrims() const;
 
     static void
-    recursiveSetVisibility(const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode, bool visibility);
+    recursiveSetOrphaned(const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode, bool orphaned);
     static void
     recursiveSwitch(const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode, const Ufe::Path& ufePath);
 
-    static bool
-                setVisibilityPlug(const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode, bool visibility);
-    static bool getVisibilityPlug(const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode);
+    static bool setOrphaned(const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode, bool orphaned);
 
     // Member function to access private nested classes.
     static std::list<VariantSetDescriptor> variantSetDescriptors(const Ufe::Path& path);

--- a/lib/mayaUsd/fileio/orphanedNodesManager.h
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.h
@@ -26,8 +26,26 @@
 
 namespace MAYAUSD_NS_DEF {
 
+/// \class OrphanedNodesManager
+///
+/// \brief Records the data that affects which exact USD prim was edited as Maya.
+///
+/// Prims edited as Maya nodes are only valid if the prim is still accessible
+/// in the USD stage. If no longer accessible, we declared the Maya nodes as
+/// orphaned and hide them.
+///
+/// Observes the scene, to determine when to hide edited prims that have become
+/// orphaned, or to show them again, because of structural changes to their USD
+/// or Maya ancestors.
+///
+/// Currently, the only state that we monitor and consider for prim validity
+/// and edit orphaning is the set of variant selections of all ancestors of
+/// the prim being edited.
+
 class OrphanedNodesManager : public Ufe::Observer
 {
+public:
+    /// \brief Records a single variant selection of a single variant set.
     struct VariantSelection
     {
         VariantSelection() = default;
@@ -46,6 +64,7 @@ class OrphanedNodesManager : public Ufe::Observer
         std::string variantSelection;
     };
 
+    /// \brief Records all variant selections of a single prim.
     struct VariantSetDescriptor
     {
         VariantSetDescriptor() = default;
@@ -63,21 +82,21 @@ class OrphanedNodesManager : public Ufe::Observer
         std::list<VariantSelection> variantSelections;
     };
 
+    /// \brief Records all variant selections of all ancestors of the prim edited as maya,
+    ///        with the DAG path of the root of Maya nodes corresponding to the edited prim.
     struct PullVariantInfo
     {
         PullVariantInfo() = default;
-        PullVariantInfo(const MDagPath& dp, const std::list<VariantSetDescriptor>& vsd)
-            : dagPath(dp)
+        PullVariantInfo(const MDagPath& pulledParent, const std::list<VariantSetDescriptor>& vsd)
+            : pulledParentPath(pulledParent)
             , variantSetDescriptors(vsd)
         {
         }
-        MDagPath                        dagPath;
+        MDagPath                        pulledParentPath;
         std::list<VariantSetDescriptor> variantSetDescriptors;
     };
 
-public:
-    typedef std::shared_ptr<OrphanedNodesManager> Ptr;
-
+    /// \brief Entire state of the OrphanedNodesManager at a point in time, used for undo/redo.
     class Memento
     {
     public:
@@ -91,6 +110,9 @@ public:
         Memento(const Memento&) = delete;
         Memento& operator=(const Memento&) = delete;
 
+        static std::string convertToJson(const Memento&);
+        static Memento     convertFromJson(const std::string&);
+
     private:
         // Private, for opacity.
         friend class OrphanedNodesManager;
@@ -102,8 +124,10 @@ public:
         Ufe::Trie<PullVariantInfo> _pulledPrims;
     };
 
+    // Construct an empty orphan manager.
     OrphanedNodesManager();
 
+    // Notifications handling, part of the Ufe::Observer interface.
     void operator()(const Ufe::Notification&) override;
 
     // Add the pulled path and its Maya pull parent to the trie of pulled
@@ -114,6 +138,9 @@ public:
     // path is in the trie.  Returns a memento (see Memento Pattern) for undo
     // purposes, to be used as argument to restore().
     Memento remove(const Ufe::Path& pulledPath);
+
+    // Preserve the trie of pulled prims into a memento.
+    Memento preserve() const;
 
     // Restore the trie of pulled prims to the content of the argument memento.
     void restore(Memento&& previous);

--- a/lib/mayaUsd/fileio/orphanedNodesManagerIO.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManagerIO.cpp
@@ -1,0 +1,295 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "orphanedNodesManager.h"
+
+#include <mayaUsd/utils/json.h>
+
+#include <pxr/base/js/json.h>
+#include <pxr/base/tf/diagnostic.h>
+
+#include <maya/MDagPath.h>
+#include <maya/MString.h>
+#include <ufe/pathString.h>
+#include <ufe/trie.imp.h>
+
+namespace MAYAUSD_NS_DEF {
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Conversion of the OrphanedNodesManager PullVariantInfo to JSON has the
+// following structure:
+//
+//    {
+//       "/UFE-path-component-1" : {
+//          "/UFE-path-component-2" : {
+//             "pull info": {
+//                "pulledParentPath": "DAG-path-of-pulled-object",
+//                "variantSetDescriptors": [
+//                   {
+//                       "path": "UFE-path-of-one-ancestor",
+//                       "variantSelections": [
+//                           [ "variant-set-1-name", "variant-set-1-selection" ],
+//                           [ "variant-set-2-name", "variant-set-2-selection" ],
+//                       ],
+//                   },
+//                ],
+//             },
+//          },
+//       },
+//    }
+//
+// Each UFE path component is prefixed by a slash ('/') to differentiate them
+// from pull info data, which has a JOSN key without that slash prefix.
+
+static const std::string ufeComponentPrefix = "/";
+static const std::string pullInfoJsonKey = "pull info";
+static const std::string dagPathJsonKey = "pulledParentPath";
+static const std::string variantSetDescriptorsJsonKey = "variantSetDescriptors";
+static const std::string pathJsonKey = "path";
+static const std::string variantSelKey = "variantSelections";
+
+static const char* invalidJson = "Invalid JSON";
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Types used in the pulled variant info, so shorten the code and make it more readable.
+
+using VariantSelection = OrphanedNodesManager::VariantSelection;
+using VariantSetDesc = OrphanedNodesManager::VariantSetDescriptor;
+using VariantSetDescList = std::list<VariantSetDesc>;
+using PullVariantInfo = OrphanedNodesManager::PullVariantInfo;
+using PullInfoTrie = Ufe::Trie<PullVariantInfo>;
+using PullInfoTrieNode = Ufe::TrieNode<PullVariantInfo>;
+using Memento = OrphanedNodesManager::Memento;
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Conversion functions to and from JSON for orphaned nodes types.
+
+using MAYAUSD_NS_DEF::convertToArray;
+using MAYAUSD_NS_DEF::convertToObject;
+using MAYAUSD_NS_DEF::convertToValue;
+
+PXR_NS::JsArray  convertToArray(const VariantSelection& variantSel);
+PXR_NS::JsObject convertToObject(const VariantSetDesc& variantDesc);
+PXR_NS::JsArray  convertToArray(const std::list<VariantSetDesc>& allVariantDesc);
+PXR_NS::JsObject convertToObject(const PullVariantInfo& pullInfo);
+PXR_NS::JsObject convertToObject(const PullInfoTrieNode::Ptr& pullInfoNode);
+PXR_NS::JsObject convertToObject(const PullInfoTrie& allPulledInfo);
+
+VariantSelection   convertToVariantSelection(const PXR_NS::JsArray& variantSelJson);
+VariantSetDesc     convertToVariantSetDescriptor(const PXR_NS::JsObject& variantDescJson);
+VariantSetDescList convertToVariantSetDescList(const PXR_NS::JsArray& allVariantDescJson);
+PullVariantInfo    convertToPullVariantInfo(const PXR_NS::JsObject& pullInfoJson);
+void         convertToPullInfoTrieNodePtr(const PXR_NS::JsObject&, PullInfoTrieNode::Ptr intoRoot);
+PullInfoTrie convertToPullInfoTrie(const PXR_NS::JsObject& allPulledInfoJson);
+
+PXR_NS::JsArray convertToArray(const VariantSelection& variantSel)
+{
+    PXR_NS::JsArray variantSelJson;
+
+    variantSelJson.push_back(convertToValue(variantSel.variantSetName));
+    variantSelJson.push_back(convertToValue(variantSel.variantSelection));
+
+    return variantSelJson;
+}
+
+VariantSelection convertToVariantSelection(const PXR_NS::JsArray& variantSelJson)
+{
+    VariantSelection variantSel;
+
+    if (variantSelJson.size() < 2)
+        throw std::runtime_error(invalidJson);
+
+    variantSel.variantSetName = convertToString(variantSelJson[0]);
+    variantSel.variantSelection = convertToString(variantSelJson[1]);
+
+    return variantSel;
+}
+
+PXR_NS::JsObject convertToObject(const VariantSetDesc& variantDesc)
+{
+    PXR_NS::JsObject variantDescJson;
+
+    variantDescJson[pathJsonKey] = convertToValue(variantDesc.path);
+
+    PXR_NS::JsArray selections;
+
+    for (const auto& variantSel : variantDesc.variantSelections) {
+        selections.emplace_back(convertToArray(variantSel));
+    }
+
+    variantDescJson[variantSelKey] = selections;
+
+    return variantDescJson;
+}
+
+VariantSetDesc convertToVariantSetDescriptor(const PXR_NS::JsObject& variantDescJson)
+{
+    VariantSetDesc variantDesc;
+
+    variantDesc.path = convertToUfePath(convertJsonKeyToValue(variantDescJson, pathJsonKey));
+
+    PXR_NS::JsArray variantSelectionsJson
+        = convertToArray(convertJsonKeyToValue(variantDescJson, variantSelKey));
+
+    for (const PXR_NS::JsValue& value : variantSelectionsJson)
+        variantDesc.variantSelections.emplace_back(
+            convertToVariantSelection(convertToArray(value)));
+
+    return variantDesc;
+}
+
+PXR_NS::JsArray convertToArray(const std::list<VariantSetDesc>& allVariantDesc)
+{
+    PXR_NS::JsArray allVariantDescJson;
+
+    for (const auto& variantDesc : allVariantDesc) {
+        allVariantDescJson.emplace_back(convertToObject(variantDesc));
+    }
+
+    return allVariantDescJson;
+}
+
+VariantSetDescList convertToVariantSetDescList(const PXR_NS::JsArray& allVariantDescJson)
+{
+    VariantSetDescList allVariantDesc;
+
+    for (const PXR_NS::JsValue& value : allVariantDescJson)
+        allVariantDesc.emplace_back(convertToVariantSetDescriptor(convertToObject(value)));
+
+    return allVariantDesc;
+}
+
+PXR_NS::JsObject convertToObject(const PullVariantInfo& pullInfo)
+{
+    PXR_NS::JsObject pullInfoJson;
+
+    pullInfoJson[dagPathJsonKey] = convertToValue(pullInfo.pulledParentPath);
+    pullInfoJson[variantSetDescriptorsJsonKey] = convertToArray(pullInfo.variantSetDescriptors);
+
+    return pullInfoJson;
+}
+
+PullVariantInfo convertToPullVariantInfo(const PXR_NS::JsObject& pullInfoJson)
+{
+    PullVariantInfo pullInfo;
+
+    pullInfo.pulledParentPath
+        = convertToDagPath(convertJsonKeyToValue(pullInfoJson, dagPathJsonKey));
+    pullInfo.variantSetDescriptors = convertToVariantSetDescList(
+        convertToArray(convertJsonKeyToValue(pullInfoJson, variantSetDescriptorsJsonKey)));
+
+    return pullInfo;
+}
+
+PXR_NS::JsObject convertToObject(const PullInfoTrieNode::Ptr& pullInfoNodePtr)
+{
+    if (!pullInfoNodePtr)
+        return {};
+
+    const PullInfoTrieNode& pullInfoNode = *pullInfoNodePtr;
+
+    PXR_NS::JsObject pullInfoNodeJson;
+
+    if (pullInfoNode.hasData()) {
+        pullInfoNodeJson[pullInfoJsonKey] = convertToObject(pullInfoNode.data());
+    }
+
+    for (const auto& child : pullInfoNode.childrenComponents()) {
+        PXR_NS::JsObject childJson = convertToObject(pullInfoNode[child]);
+        if (childJson.empty())
+            continue;
+        pullInfoNodeJson[ufeComponentPrefix + child.string()] = childJson;
+    }
+
+    return pullInfoNodeJson;
+}
+
+void convertToPullInfoTrieNodePtr(
+    const PXR_NS::JsObject& pullInfoNodeJson,
+    PullInfoTrieNode::Ptr   intoRoot)
+{
+    for (const auto& keyValue : pullInfoNodeJson) {
+        const std::string&     key = keyValue.first;
+        const PXR_NS::JsValue& value = keyValue.second;
+        if (key.size() <= 0) {
+            continue;
+        } else if (key == pullInfoJsonKey) {
+            intoRoot->setData(convertToPullVariantInfo(convertToObject(value)));
+
+        } else if (key[0] == '/') {
+            PullInfoTrieNode::Ptr child = std::make_shared<PullInfoTrieNode>(key.substr(1));
+            intoRoot->add(child);
+            convertToPullInfoTrieNodePtr(convertToObject(value), child);
+        }
+    }
+}
+
+PXR_NS::JsObject convertToObject(const PullInfoTrie& allPullInfo)
+{
+    return convertToObject(allPullInfo.root());
+}
+
+PullInfoTrie convertToPullInfoTrie(const PXR_NS::JsObject& allPullInfoJson)
+{
+    PullInfoTrie allPullInfo;
+
+    convertToPullInfoTrieNodePtr(allPullInfoJson, allPullInfo.root());
+
+    return allPullInfo;
+}
+
+} // namespace
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Conversion of OrphanedNodesManager::Memento to and from JSON.
+
+std::string Memento::convertToJson(const Memento& memento)
+{
+    try {
+        return PXR_NS::JsWriteToString(convertToObject(memento._pulledPrims));
+    } catch (const std::exception& e) {
+        // Note: the TF_RUNTIME_ERROR macro needs to be used within the PXR_NS.
+        using namespace PXR_NS;
+        TF_RUNTIME_ERROR(
+            "Unable to convert the orphaned nodes manager state to JSON: %s", e.what());
+    }
+
+    return {};
+}
+
+Memento Memento::convertFromJson(const std::string& json)
+{
+    Memento memento;
+
+    try {
+        memento._pulledPrims = convertToPullInfoTrie(convertToObject(PXR_NS::JsParseString(json)));
+    } catch (const std::exception& e) {
+        // Note: the TF_RUNTIME_ERROR macro needs to be used within the PXR_NS.
+        using namespace PXR_NS;
+        TF_RUNTIME_ERROR(
+            "Unable to convert the JSON text to the orphaned nodes manager state: %s", e.what());
+    }
+
+    return memento;
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/fileio/orphanedNodesManagerIO.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManagerIO.cpp
@@ -39,7 +39,9 @@ namespace {
 //       "/UFE-path-component-1" : {
 //          "/UFE-path-component-2" : {
 //             "pull info": {
+//                "proxyShapePath": "DAG-path-to-proxy-shape",
 //                "pulledParentPath": "DAG-path-of-pulled-object",
+//                "editedAsMayaRoot": "DAG-path-of-root-of-generated-Maya-data"
 //                "variantSetDescriptors": [
 //                   {
 //                       "path": "UFE-path-of-one-ancestor",
@@ -59,7 +61,9 @@ namespace {
 
 static const std::string ufeComponentPrefix = "/";
 static const std::string pullInfoJsonKey = "pull info";
-static const std::string dagPathJsonKey = "pulledParentPath";
+static const std::string proxyShapePathJsonKey = "proxyShapePath";
+static const std::string pulledParentPathJsonKey = "pulledParentPath";
+static const std::string editedAsMayaRootJsonKey = "editedAsMayaRoot";
 static const std::string variantSetDescriptorsJsonKey = "variantSetDescriptors";
 static const std::string pathJsonKey = "path";
 static const std::string variantSelKey = "variantSelections";
@@ -181,7 +185,9 @@ PXR_NS::JsObject convertToObject(const PullVariantInfo& pullInfo)
 {
     PXR_NS::JsObject pullInfoJson;
 
-    pullInfoJson[dagPathJsonKey] = convertToValue(pullInfo.pulledParentPath);
+    pullInfoJson[proxyShapePathJsonKey] = convertToValue(pullInfo.proxyShapePath);
+    pullInfoJson[pulledParentPathJsonKey] = convertToValue(pullInfo.pulledParentPath);
+    pullInfoJson[editedAsMayaRootJsonKey] = convertToValue(pullInfo.editedAsMayaRoot);
     pullInfoJson[variantSetDescriptorsJsonKey] = convertToArray(pullInfo.variantSetDescriptors);
 
     return pullInfoJson;
@@ -191,8 +197,12 @@ PullVariantInfo convertToPullVariantInfo(const PXR_NS::JsObject& pullInfoJson)
 {
     PullVariantInfo pullInfo;
 
+    pullInfo.proxyShapePath
+        = convertToDagPath(convertJsonKeyToValue(pullInfoJson, proxyShapePathJsonKey));
     pullInfo.pulledParentPath
-        = convertToDagPath(convertJsonKeyToValue(pullInfoJson, dagPathJsonKey));
+        = convertToDagPath(convertJsonKeyToValue(pullInfoJson, pulledParentPathJsonKey));
+    pullInfo.editedAsMayaRoot
+        = convertToDagPath(convertJsonKeyToValue(pullInfoJson, editedAsMayaRootJsonKey));
     pullInfo.variantSetDescriptors = convertToVariantSetDescList(
         convertToArray(convertJsonKeyToValue(pullInfoJson, variantSetDescriptorsJsonKey)));
 

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -32,6 +32,7 @@
 #include <mayaUsd/undo/OpUndoItemMuting.h>
 #include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/undo/UsdUndoBlock.h>
+#include <mayaUsd/utils/dynamicAttribute.h>
 #include <mayaUsd/utils/progressBarScope.h>
 #include <mayaUsd/utils/traverseLayer.h>
 #include <mayaUsdUtils/util.h>
@@ -969,9 +970,19 @@ PrimUpdaterManager::PrimUpdaterManager()
 
     TfWeakPtr<PrimUpdaterManager> me(this);
     TfNotice::Register(me, &PrimUpdaterManager::onProxyContentChanged);
+
+#ifdef HAS_ORPHANED_NODES_MANAGER
+    beginLoadSaveCallbacks();
+#endif
 }
 
-PrimUpdaterManager::~PrimUpdaterManager() { }
+PrimUpdaterManager::~PrimUpdaterManager()
+{
+#ifdef HAS_ORPHANED_NODES_MANAGER
+    endLoadSaveCallbacks();
+    endManagePulledPrims();
+#endif
+}
 
 bool PrimUpdaterManager::mergeToUsd(
     const MFnDependencyNode& depNodeFn,
@@ -1890,6 +1901,7 @@ bool PrimUpdaterManager::readPullInformation(const MDagPath& dagPath, Ufe::Path&
 }
 
 #ifdef HAS_ORPHANED_NODES_MANAGER
+
 void PrimUpdaterManager::beginManagePulledPrims()
 {
     TF_VERIFY(_orphanedNodesManager->empty());
@@ -1919,6 +1931,77 @@ void PrimUpdaterManager::beforeNewOrOpenCallback(void* clientData)
     auto* pum = static_cast<PrimUpdaterManager*>(clientData);
     pum->endManagePulledPrims();
 }
+
+void PrimUpdaterManager::beginLoadSaveCallbacks()
+{
+    MStatus                status;
+    MSceneMessage::Message msgs[] = { MSceneMessage::kAfterNew, MSceneMessage::kAfterOpen };
+    for (auto msg : msgs) {
+        _openSaveCbs.append(MSceneMessage::addCallback(msg, afterNewOrOpenCallback, this, &status));
+        CHECK_MSTATUS(status);
+    }
+
+    _openSaveCbs.append(
+        MSceneMessage::addCallback(MSceneMessage::kBeforeSave, beforeSaveCallback, this, &status));
+    CHECK_MSTATUS(status);
+}
+
+void PrimUpdaterManager::endLoadSaveCallbacks()
+{
+    auto status = MMessage::removeCallbacks(_openSaveCbs);
+    CHECK_MSTATUS(status);
+    _openSaveCbs.clear();
+}
+
+/*static*/
+void PrimUpdaterManager::afterNewOrOpenCallback(void* clientData)
+{
+    auto* pum = static_cast<PrimUpdaterManager*>(clientData);
+    pum->loadOrphanedNodesManagerData();
+}
+
+/*static*/
+void PrimUpdaterManager::beforeSaveCallback(void* clientData)
+{
+    auto* pum = static_cast<PrimUpdaterManager*>(clientData);
+    pum->saveOrphanedNodesManagerData();
+}
+
+static const char* orphanedNodesManagerDynAttrName = "orphanedNodeManagerState";
+
+void PrimUpdaterManager::loadOrphanedNodesManagerData()
+{
+    MObject pullRoot = findPullRoot();
+    if (pullRoot.isNull())
+        return;
+
+    beginManagePulledPrims();
+
+    if (!hasDynamicAttribute(pullRoot, orphanedNodesManagerDynAttrName))
+        return;
+
+    MString json;
+    if (!getDynamicAttribute(pullRoot, orphanedNodesManagerDynAttrName, json))
+        return;
+
+    _orphanedNodesManager->restore(OrphanedNodesManager::Memento::convertFromJson(json.asChar()));
+}
+
+void PrimUpdaterManager::saveOrphanedNodesManagerData()
+{
+    MObject pullRoot = findPullRoot();
+    if (pullRoot.isNull())
+        return;
+
+    OrphanedNodesManager::Memento memento = _orphanedNodesManager->preserve();
+    const std::string             json = OrphanedNodesManager::Memento::convertToJson(memento);
+
+    MFnDependencyNode pullRootDepNode(pullRoot);
+    MStatus           status
+        = setDynamicAttribute(pullRootDepNode, orphanedNodesManagerDynAttrName, json.c_str());
+    CHECK_MSTATUS(status);
+}
+
 #endif
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -162,7 +162,7 @@ bool hasEditedDescendant(const Ufe::Path& ufeQueryPath)
 //
 // The UFE path is to the pulled prim, and the Dag path is the corresponding
 // Maya pulled object.
-bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& path)
+bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& editedAsMayaRoot)
 {
     MayaUsd::ProgressBarScope progressBar(3);
 
@@ -174,22 +174,22 @@ bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& path)
     // Add to a set, the set should already been created.
     if (!FunctionUndoItem::execute(
             "Add edited item to pull set.",
-            [path]() {
+            [editedAsMayaRoot]() {
                 MObject pullSetObj;
                 auto    status = UsdMayaUtil::GetMObjectByName(kPullSetName, pullSetObj);
                 if (status != MStatus::kSuccess)
                     return false;
                 MFnSet fnPullSet(pullSetObj);
-                fnPullSet.addMember(path);
+                fnPullSet.addMember(editedAsMayaRoot);
                 return true;
             },
-            [path]() {
+            [editedAsMayaRoot]() {
                 MObject pullSetObj;
                 auto    status = UsdMayaUtil::GetMObjectByName(kPullSetName, pullSetObj);
                 if (status != MStatus::kSuccess)
                     return false;
                 MFnSet fnPullSet(pullSetObj);
-                fnPullSet.removeMember(path, MObject::kNullObj);
+                fnPullSet.removeMember(editedAsMayaRoot, MObject::kNullObj);
                 return true;
             })) {
         TF_WARN("Cannot edited object to pulled set.");
@@ -198,18 +198,12 @@ bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& path)
     progressBar.advance();
 
     // Store metadata on the prim in the Session Layer.
-    auto stage = pulledPrim.GetStage();
-    if (!stage)
-        return false;
-    UsdEditContext editContext(stage, stage->GetSessionLayer());
-    VtValue        value(path.fullPathName().asChar());
-    if (!pulledPrim.SetMetadataByDictKey(SdfFieldKeys->CustomData, kPullPrimMetadataKey, value))
-        return false;
+    PrimUpdaterManager::writePulledPrimMetadata(ufePulledPath, editedAsMayaRoot);
     progressBar.advance();
 
     // Store medata on DG node
     auto              ufePathString = Ufe::PathString::string(ufePulledPath);
-    MFnDependencyNode depNode(path.node());
+    MFnDependencyNode depNode(editedAsMayaRoot.node());
     MStatus           status;
     MPlug             dgMetadata = depNode.findPlug(kPullDGMetadataKey, &status);
     if (status != MStatus::kSuccess) {
@@ -235,13 +229,13 @@ bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& path)
 //
 void removePullInformation(const Ufe::Path& ufePulledPath)
 {
-    MayaUsd::ProgressBarScope progressBar(1);
-    UsdPrim                   prim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
-    auto                      stage = prim.GetStage();
+    UsdPrim     pulledPrim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
+    UsdStagePtr stage = pulledPrim.GetStage();
     if (!stage)
         return;
-    UsdEditContext editContext(stage, stage->GetSessionLayer());
-    prim.ClearCustomDataByKey(kPullPrimMetadataKey);
+
+    MayaUsd::ProgressBarScope progressBar(1);
+    PrimUpdaterManager::removePulledPrimMetadata(stage, pulledPrim);
     progressBar.advance();
 
     // Session layer cleanup
@@ -251,47 +245,6 @@ void removePullInformation(const Ufe::Path& ufePulledPath)
         stage->GetSessionLayer()->RemovePrimIfInert(rootPrimSpec);
         rootPrimsLoop.loopAdvance();
     }
-}
-
-//------------------------------------------------------------------------------
-//
-bool addExcludeFromRendering(const Ufe::Path& ufePulledPath)
-{
-    UsdPrim prim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
-
-    auto stage = prim.GetStage();
-    if (!stage)
-        return false;
-
-    UsdEditContext editContext(stage, stage->GetSessionLayer());
-    if (!prim.SetActive(false))
-        return false;
-
-    return true;
-}
-
-//------------------------------------------------------------------------------
-//
-bool removeExcludeFromRendering(const Ufe::Path& ufePulledPath)
-{
-    UsdPrim prim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
-
-    auto stage = prim.GetStage();
-    if (!stage)
-        return false;
-
-    SdfLayerHandle sessionLayer = stage->GetSessionLayer();
-    UsdEditContext editContext(stage, sessionLayer);
-
-    // Cleanup the field and potentially empty over
-    if (!prim.ClearActive())
-        return false;
-
-    SdfPrimSpecHandle primSpec = MayaUsdUtils::getPrimSpecAtEditTarget(prim);
-    if (sessionLayer && primSpec)
-        sessionLayer->ScheduleRemoveIfInert(primSpec.GetSpec());
-
-    return true;
 }
 
 //------------------------------------------------------------------------------
@@ -472,9 +425,11 @@ PullImportPaths pullImport(
 
         if (!FunctionUndoItem::execute(
                 "Pull import rendering exclusion",
-                [ufePulledPath]() { return addExcludeFromRendering(ufePulledPath); },
                 [ufePulledPath]() {
-                    removeExcludeFromRendering(ufePulledPath);
+                    return PrimUpdaterManager::addExcludeFromRendering(ufePulledPath);
+                },
+                [ufePulledPath]() {
+                    PrimUpdaterManager::removeExcludeFromRendering(ufePulledPath);
                     return true;
                 })) {
             TF_WARN("Cannot exclude original USD data from viewport rendering.");
@@ -847,7 +802,7 @@ private:
 };
 
 #ifdef HAS_ORPHANED_NODES_MANAGER
-class AddPullPathUndoItem : public MayaUsd::OpUndoItem
+class RecordPullVariantInfoUndoItem : public MayaUsd::OpUndoItem
 {
 public:
     // Add the path to the orphaned nodes manager, and add an undo entry onto
@@ -855,13 +810,14 @@ public:
     static bool execute(
         const std::shared_ptr<OrphanedNodesManager>& orphanedNodesManager,
         const Ufe::Path&                             pulledPath,
-        const MDagPath&                              pullParentPath)
+        const MDagPath&                              pullParentPath,
+        const MDagPath&                              editedAsMayaRoot)
     {
         // Get the global undo list.
         auto& undoInfo = OpUndoItemList::instance();
 
-        auto item = std::make_unique<AddPullPathUndoItem>(
-            orphanedNodesManager, pulledPath, pullParentPath);
+        auto item = std::make_unique<RecordPullVariantInfoUndoItem>(
+            orphanedNodesManager, pulledPath, pullParentPath, editedAsMayaRoot);
         if (!item->redo()) {
             return false;
         }
@@ -871,16 +827,18 @@ public:
         return true;
     }
 
-    AddPullPathUndoItem(
+    RecordPullVariantInfoUndoItem(
         const std::shared_ptr<OrphanedNodesManager>& orphanedNodesManager,
         const Ufe::Path&                             pulledPath,
-        const MDagPath&                              pullParentPath)
+        const MDagPath&                              pullParentPath,
+        const MDagPath&                              editedAsMayaRoot)
         : OpUndoItem(
             std::string("Add to orphaned nodes manager pull path ")
             + Ufe::PathString::string(pulledPath))
         , _orphanedNodesManager(orphanedNodesManager)
         , _pulledPath(pulledPath)
         , _pullParentPath(pullParentPath)
+        , _editedAsMayaRoot(editedAsMayaRoot)
     {
     }
 
@@ -892,7 +850,7 @@ public:
 
     bool redo() override
     {
-        _orphanedNodesManager->add(_pulledPath, _pullParentPath);
+        _orphanedNodesManager->add(_pulledPath, _pullParentPath, _editedAsMayaRoot);
         return true;
     }
 
@@ -900,9 +858,10 @@ private:
     const std::shared_ptr<OrphanedNodesManager> _orphanedNodesManager;
     const Ufe::Path                             _pulledPath;
     const MDagPath                              _pullParentPath;
+    const MDagPath                              _editedAsMayaRoot;
 };
 
-class RemovePullPathUndoItem : public MayaUsd::OpUndoItem
+class RemovePullVariantInfoUndoItem : public MayaUsd::OpUndoItem
 {
 public:
     // Remove the path from the orphaned nodes manager, and add an entry onto
@@ -914,7 +873,8 @@ public:
         // Get the global undo list.
         auto& undoInfo = OpUndoItemList::instance();
 
-        auto item = std::make_unique<RemovePullPathUndoItem>(orphanedNodesManager, pulledPath);
+        auto item
+            = std::make_unique<RemovePullVariantInfoUndoItem>(orphanedNodesManager, pulledPath);
         if (!item->redo()) {
             return false;
         }
@@ -924,7 +884,7 @@ public:
         return true;
     }
 
-    RemovePullPathUndoItem(
+    RemovePullVariantInfoUndoItem(
         const std::shared_ptr<OrphanedNodesManager>& orphanedNodesManager,
         const Ufe::Path&                             pulledPath)
         : OpUndoItem(std::string("Remove pull path ") + Ufe::PathString::string(pulledPath))
@@ -1217,6 +1177,11 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
         return false;
     }
     progressBar.advance();
+
+#ifdef HAS_ORPHANED_NODES_MANAGER
+    RecordPullVariantInfoUndoItem::execute(
+        _orphanedNodesManager, path, pullParentPath, importedPaths.first[0]);
+#endif
 
     if (!updaterArgs._copyOperation) {
         // Lock pulled nodes starting at the pull parent.
@@ -1750,7 +1715,7 @@ bool PrimUpdaterManager::removePullParent(
         return false;
     }
 
-    if (!TF_VERIFY(RemovePullPathUndoItem::execute(_orphanedNodesManager, pulledPath))) {
+    if (!TF_VERIFY(RemovePullVariantInfoUndoItem::execute(_orphanedNodesManager, pulledPath))) {
         return false;
     }
 #endif
@@ -1823,9 +1788,6 @@ MDagPath PrimUpdaterManager::setupPullParent(const Ufe::Path& pulledPath, VtDict
         return MDagPath();
     }
 
-#ifdef HAS_ORPHANED_NODES_MANAGER
-    recordPullVariantInfo(pulledPath, pullParentPath);
-#endif
     progressBar.advance();
 
     // Add pull parent path to import args as a string.
@@ -1833,15 +1795,6 @@ MDagPath PrimUpdaterManager::setupPullParent(const Ufe::Path& pulledPath, VtDict
 
     return pullParentPath;
 }
-
-#ifdef HAS_ORPHANED_NODES_MANAGER
-void PrimUpdaterManager::recordPullVariantInfo(
-    const Ufe::Path& pulledPath,
-    const MDagPath&  pullParentPath)
-{
-    AddPullPathUndoItem::execute(_orphanedNodesManager, pulledPath, pullParentPath);
-}
-#endif
 
 /* static */
 bool PrimUpdaterManager::readPullInformation(const PXR_NS::UsdPrim& prim, std::string& dagPathStr)
@@ -1898,6 +1851,94 @@ bool PrimUpdaterManager::readPullInformation(const MDagPath& dagPath, Ufe::Path&
     }
 
     return false;
+}
+
+//------------------------------------------------------------------------------
+//
+/* static */
+bool PrimUpdaterManager::addExcludeFromRendering(const Ufe::Path& ufePulledPath)
+{
+    UsdPrim prim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
+
+    auto stage = prim.GetStage();
+    if (!stage)
+        return false;
+
+    UsdEditContext editContext(stage, stage->GetSessionLayer());
+    if (!prim.SetActive(false))
+        return false;
+
+    return true;
+}
+
+//------------------------------------------------------------------------------
+//
+/* static */
+bool PrimUpdaterManager::removeExcludeFromRendering(const Ufe::Path& ufePulledPath)
+{
+    UsdPrim prim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
+
+    auto stage = prim.GetStage();
+    if (!stage)
+        return false;
+
+    SdfLayerHandle sessionLayer = stage->GetSessionLayer();
+    UsdEditContext editContext(stage, sessionLayer);
+
+    // Cleanup the field and potentially empty over
+    if (!prim.ClearActive())
+        return false;
+
+    SdfPrimSpecHandle primSpec = MayaUsdUtils::getPrimSpecAtEditTarget(prim);
+    if (sessionLayer && primSpec)
+        sessionLayer->ScheduleRemoveIfInert(primSpec.GetSpec());
+
+    return true;
+}
+
+//------------------------------------------------------------------------------
+//
+
+/* static */
+bool PrimUpdaterManager::writePulledPrimMetadata(
+    const Ufe::Path& ufePulledPath,
+    const MDagPath&  editedAsMayaRoot)
+{
+    auto pulledPrim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
+    if (!pulledPrim)
+        return false;
+    return writePulledPrimMetadata(pulledPrim, editedAsMayaRoot);
+}
+
+/* static */
+bool PrimUpdaterManager::writePulledPrimMetadata(
+    UsdPrim&        pulledPrim,
+    const MDagPath& editedAsMayaRoot)
+{
+    auto stage = pulledPrim.GetStage();
+    if (!stage)
+        return false;
+
+    UsdEditContext editContext(stage, stage->GetSessionLayer());
+    VtValue        value(editedAsMayaRoot.fullPathName().asChar());
+    return pulledPrim.SetMetadataByDictKey(SdfFieldKeys->CustomData, kPullPrimMetadataKey, value);
+}
+
+/* static */
+void PrimUpdaterManager::removePulledPrimMetadata(const Ufe::Path& ufePulledPath)
+{
+    UsdPrim     prim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
+    UsdStagePtr stage = prim.GetStage();
+    if (!stage)
+        return;
+    removePulledPrimMetadata(stage, prim);
+}
+
+/* static */
+void PrimUpdaterManager::removePulledPrimMetadata(const UsdStagePtr& stage, UsdPrim& prim)
+{
+    UsdEditContext editContext(stage, stage->GetSessionLayer());
+    prim.ClearCustomDataByKey(kPullPrimMetadataKey);
 }
 
 #ifdef HAS_ORPHANED_NODES_MANAGER

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -393,9 +393,7 @@ PullImportPaths pullImport(
 
         if (!FunctionUndoItem::execute(
                 "Pull import rendering exclusion",
-                [ufePulledPath]() {
-                    return addExcludeFromRendering(ufePulledPath);
-                },
+                [ufePulledPath]() { return addExcludeFromRendering(ufePulledPath); },
                 [ufePulledPath]() {
                     removeExcludeFromRendering(ufePulledPath);
                     return true;
@@ -1763,7 +1761,6 @@ MDagPath PrimUpdaterManager::setupPullParent(const Ufe::Path& pulledPath, VtDict
 
     return pullParentPath;
 }
-
 
 #ifdef HAS_ORPHANED_NODES_MANAGER
 

--- a/lib/mayaUsd/fileio/primUpdaterManager.h
+++ b/lib/mayaUsd/fileio/primUpdaterManager.h
@@ -79,6 +79,20 @@ public:
     MAYAUSD_CORE_PUBLIC
     static bool readPullInformation(const MDagPath& dagpath, Ufe::Path& ufePath);
 
+    MAYAUSD_CORE_PUBLIC
+    static bool writePulledPrimMetadata(const Ufe::Path& ufePulledPath, const MDagPath& editedRoot);
+    MAYAUSD_CORE_PUBLIC
+    static bool writePulledPrimMetadata(PXR_NS::UsdPrim& pulledPrim, const MDagPath& editedRoot);
+    MAYAUSD_CORE_PUBLIC
+    static void removePulledPrimMetadata(const Ufe::Path& ufePulledPath);
+    MAYAUSD_CORE_PUBLIC
+    static void removePulledPrimMetadata(const UsdStagePtr& stage, UsdPrim& prim);
+
+    MAYAUSD_CORE_PUBLIC
+    static bool addExcludeFromRendering(const Ufe::Path& ufePulledPath);
+    MAYAUSD_CORE_PUBLIC
+    static bool removeExcludeFromRendering(const Ufe::Path& ufePulledPath);
+
     bool hasPulledPrims() const { return _hasPulledPrims; }
 
 private:
@@ -114,8 +128,6 @@ private:
     //! Record pull information for the pulled path, for inspection on
     //! scene changes.
 #ifdef HAS_ORPHANED_NODES_MANAGER
-    void recordPullVariantInfo(const Ufe::Path& pulledPath, const MDagPath& pullParentPath);
-
     // Maya file new or open callback.  Member function to access other private
     // member functions.
     static void beforeNewOrOpenCallback(void* clientData);

--- a/lib/mayaUsd/fileio/primUpdaterManager.h
+++ b/lib/mayaUsd/fileio/primUpdaterManager.h
@@ -122,6 +122,15 @@ private:
 
     void beginManagePulledPrims();
     void endManagePulledPrims();
+
+    void beginLoadSaveCallbacks();
+    void endLoadSaveCallbacks();
+
+    static void afterNewOrOpenCallback(void* clientData);
+    static void beforeSaveCallback(void* clientData);
+
+    void loadOrphanedNodesManagerData();
+    void saveOrphanedNodesManagerData();
 #endif
 
     friend class TfSingleton<PrimUpdaterManager>;
@@ -141,6 +150,8 @@ private:
 
     // Maya scene observation, to stop UFE scene observation.
     MCallbackIdArray _fileCbs;
+
+    MCallbackIdArray _openSaveCbs;
 #endif
 };
 

--- a/lib/mayaUsd/fileio/primUpdaterManager.h
+++ b/lib/mayaUsd/fileio/primUpdaterManager.h
@@ -18,15 +18,15 @@
 
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/fileio/primUpdaterContext.h>
+#include <mayaUsd/fileio/pullInformation.h>
 #include <mayaUsd/listeners/proxyShapeNotice.h>
-#include <mayaUsd/utils/util.h>
 
 #include <pxr/base/tf/registryManager.h>
 #include <pxr/pxr.h>
 #include <pxr/usd/sdf/path.h>
+#include <pxr/usd/usd/prim.h>
 
 #include <maya/MCallbackIdArray.h>
-#include <ufe/sceneItem.h>
 
 UFE_NS_DEF { class Path; }
 
@@ -69,29 +69,6 @@ public:
     /// \brief Returns the singleton prim updater manager
     MAYAUSD_CORE_PUBLIC
     static PrimUpdaterManager& getInstance();
-
-    MAYAUSD_CORE_PUBLIC
-    static bool readPullInformation(const PXR_NS::UsdPrim& prim, std::string& dagPathStr);
-    MAYAUSD_CORE_PUBLIC
-    static bool readPullInformation(const PXR_NS::UsdPrim& prim, Ufe::SceneItem::Ptr& dagPathItem);
-    MAYAUSD_CORE_PUBLIC
-    static bool readPullInformation(const Ufe::Path& ufePath, MDagPath& dagPath);
-    MAYAUSD_CORE_PUBLIC
-    static bool readPullInformation(const MDagPath& dagpath, Ufe::Path& ufePath);
-
-    MAYAUSD_CORE_PUBLIC
-    static bool writePulledPrimMetadata(const Ufe::Path& ufePulledPath, const MDagPath& editedRoot);
-    MAYAUSD_CORE_PUBLIC
-    static bool writePulledPrimMetadata(PXR_NS::UsdPrim& pulledPrim, const MDagPath& editedRoot);
-    MAYAUSD_CORE_PUBLIC
-    static void removePulledPrimMetadata(const Ufe::Path& ufePulledPath);
-    MAYAUSD_CORE_PUBLIC
-    static void removePulledPrimMetadata(const UsdStagePtr& stage, UsdPrim& prim);
-
-    MAYAUSD_CORE_PUBLIC
-    static bool addExcludeFromRendering(const Ufe::Path& ufePulledPath);
-    MAYAUSD_CORE_PUBLIC
-    static bool removeExcludeFromRendering(const Ufe::Path& ufePulledPath);
 
     bool hasPulledPrims() const { return _hasPulledPrims; }
 

--- a/lib/mayaUsd/fileio/pullInformation.cpp
+++ b/lib/mayaUsd/fileio/pullInformation.cpp
@@ -16,8 +16,8 @@
 
 #include "pullInformation.h"
 
-#include <MayaUsdUtils/util.h>
 #include <mayaUsd/ufe/Utils.h>
+#include <mayaUsdUtils/util.h>
 
 #include <pxr/usd/usd/editContext.h>
 

--- a/lib/mayaUsd/fileio/pullInformation.cpp
+++ b/lib/mayaUsd/fileio/pullInformation.cpp
@@ -1,0 +1,209 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "pullInformation.h"
+
+#include <MayaUsdUtils/util.h>
+#include <mayaUsd/ufe/Utils.h>
+
+#include <pxr/usd/usd/editContext.h>
+
+#include <maya/MDagPath.h>
+#include <maya/MFnDependencyNode.h>
+#include <maya/MFnStringData.h>
+#include <maya/MFnTypedAttribute.h>
+#include <maya/MPlug.h>
+#include <maya/MSelectionList.h>
+#include <maya/MStatus.h>
+#include <ufe/hierarchy.h>
+#include <ufe/pathString.h>
+#include <ufe/sceneItem.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace {
+
+// Metadata key used to store pull information on a prim
+const TfToken kPullPrimMetadataKey("Maya:Pull:DagPath");
+
+// Metadata key used to store pull information on a DG node
+const MString kPullDGMetadataKey("Pull_UfePath");
+
+} // namespace
+
+//------------------------------------------------------------------------------
+//
+
+bool readPullInformation(const PXR_NS::UsdPrim& prim, std::string& dagPathStr)
+{
+    auto value = prim.GetCustomDataByKey(kPullPrimMetadataKey);
+    if (!value.IsEmpty() && value.CanCast<std::string>()) {
+        dagPathStr = value.Get<std::string>();
+        return !dagPathStr.empty();
+    }
+    return false;
+}
+
+bool readPullInformation(const PXR_NS::UsdPrim& prim, Ufe::SceneItem::Ptr& dagPathItem)
+{
+    std::string dagPathStr;
+    if (readPullInformation(prim, dagPathStr)) {
+        dagPathItem = Ufe::Hierarchy::createItem(Ufe::PathString::path(dagPathStr));
+        return (bool)dagPathItem;
+    }
+    return false;
+}
+
+bool readPullInformation(const Ufe::Path& ufePath, MDagPath& dagPath)
+{
+    auto        prim = MayaUsd::ufe::ufePathToPrim(ufePath);
+    std::string dagPathStr;
+    if (readPullInformation(prim, dagPathStr)) {
+        MSelectionList sel;
+        sel.add(dagPathStr.c_str());
+        sel.getDagPath(0, dagPath);
+        return dagPath.isValid();
+    }
+    return false;
+}
+
+bool readPullInformation(const MDagPath& dagPath, Ufe::Path& ufePath)
+{
+    MStatus status;
+
+    MFnDependencyNode depNode(dagPath.node());
+    MPlug             dgMetadata = depNode.findPlug(kPullDGMetadataKey, &status);
+    if (status == MStatus::kSuccess) {
+        MString pulledUfePathStr;
+        status = dgMetadata.getValue(pulledUfePathStr);
+        if (status) {
+            ufePath = Ufe::PathString::path(pulledUfePathStr.asChar());
+            return !ufePath.empty();
+        }
+    }
+
+    return false;
+}
+
+//------------------------------------------------------------------------------
+//
+
+bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& editedAsMayaRoot)
+{
+    auto              ufePathString = Ufe::PathString::string(ufePulledPath);
+    MFnDependencyNode depNode(editedAsMayaRoot.node());
+    MStatus           status;
+    MPlug             dgMetadata = depNode.findPlug(kPullDGMetadataKey, &status);
+    if (status != MStatus::kSuccess) {
+        MFnStringData fnStringData;
+        MObject       strAttrObject = fnStringData.create("");
+
+        MFnTypedAttribute attr;
+        MObject           attrObj
+            = attr.create(kPullDGMetadataKey, kPullDGMetadataKey, MFnData::kString, strAttrObject);
+        status = depNode.addAttribute(attrObj);
+        dgMetadata = depNode.findPlug(kPullDGMetadataKey, &status);
+        if (status != MStatus::kSuccess) {
+            return false;
+        }
+    }
+    return dgMetadata.setValue(ufePathString.c_str());
+}
+
+//------------------------------------------------------------------------------
+//
+
+bool writePulledPrimMetadata(const Ufe::Path& ufePulledPath, const MDagPath& editedAsMayaRoot)
+{
+    auto pulledPrim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
+    if (!pulledPrim)
+        return false;
+    return writePulledPrimMetadata(pulledPrim, editedAsMayaRoot);
+}
+
+bool writePulledPrimMetadata(UsdPrim& pulledPrim, const MDagPath& editedAsMayaRoot)
+{
+    auto stage = pulledPrim.GetStage();
+    if (!stage)
+        return false;
+
+    UsdEditContext editContext(stage, stage->GetSessionLayer());
+    VtValue        value(editedAsMayaRoot.fullPathName().asChar());
+    return pulledPrim.SetMetadataByDictKey(SdfFieldKeys->CustomData, kPullPrimMetadataKey, value);
+}
+
+//------------------------------------------------------------------------------
+//
+
+void removePulledPrimMetadata(const Ufe::Path& ufePulledPath)
+{
+    UsdPrim     prim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
+    UsdStagePtr stage = prim.GetStage();
+    if (!stage)
+        return;
+    removePulledPrimMetadata(stage, prim);
+}
+
+void removePulledPrimMetadata(const UsdStagePtr& stage, UsdPrim& prim)
+{
+    UsdEditContext editContext(stage, stage->GetSessionLayer());
+    prim.ClearCustomDataByKey(kPullPrimMetadataKey);
+}
+
+//------------------------------------------------------------------------------
+//
+
+bool addExcludeFromRendering(const Ufe::Path& ufePulledPath)
+{
+    UsdPrim prim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
+
+    auto stage = prim.GetStage();
+    if (!stage)
+        return false;
+
+    UsdEditContext editContext(stage, stage->GetSessionLayer());
+    if (!prim.SetActive(false))
+        return false;
+
+    return true;
+}
+
+//------------------------------------------------------------------------------
+//
+
+bool removeExcludeFromRendering(const Ufe::Path& ufePulledPath)
+{
+    UsdPrim prim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
+
+    auto stage = prim.GetStage();
+    if (!stage)
+        return false;
+
+    SdfLayerHandle sessionLayer = stage->GetSessionLayer();
+    UsdEditContext editContext(stage, sessionLayer);
+
+    // Cleanup the field and potentially empty over
+    if (!prim.ClearActive())
+        return false;
+
+    SdfPrimSpecHandle primSpec = MayaUsdUtils::getPrimSpecAtEditTarget(prim);
+    if (sessionLayer && primSpec)
+        sessionLayer->ScheduleRemoveIfInert(primSpec.GetSpec());
+
+    return true;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/pullInformation.h
+++ b/lib/mayaUsd/fileio/pullInformation.h
@@ -21,9 +21,8 @@
 #include <pxr/pxr.h>
 #include <pxr/usd/usd/prim.h>
 
-#include <ufe/sceneItem.h>
-
 #include <maya/MDagPath.h>
+#include <ufe/sceneItem.h>
 
 UFE_NS_DEF { class Path; }
 

--- a/lib/mayaUsd/fileio/pullInformation.h
+++ b/lib/mayaUsd/fileio/pullInformation.h
@@ -1,0 +1,62 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef PXRUSDMAYA_MAYAPRIMUPDATER_MANAGER_IMPL_H
+#define PXRUSDMAYA_MAYAPRIMUPDATER_MANAGER_IMPL_H
+
+#include <mayaUsd/base/api.h>
+
+#include <pxr/pxr.h>
+#include <pxr/usd/usd/prim.h>
+
+#include <ufe/sceneItem.h>
+
+#include <maya/MDagPath.h>
+
+UFE_NS_DEF { class Path; }
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+MAYAUSD_CORE_PUBLIC
+bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& editedAsMayaRoot);
+
+MAYAUSD_CORE_PUBLIC
+bool readPullInformation(const PXR_NS::UsdPrim& prim, std::string& dagPathStr);
+MAYAUSD_CORE_PUBLIC
+bool readPullInformation(const PXR_NS::UsdPrim& prim, Ufe::SceneItem::Ptr& dagPathItem);
+MAYAUSD_CORE_PUBLIC
+bool readPullInformation(const Ufe::Path& ufePath, MDagPath& dagPath);
+MAYAUSD_CORE_PUBLIC
+bool readPullInformation(const MDagPath& dagpath, Ufe::Path& ufePath);
+
+MAYAUSD_CORE_PUBLIC
+bool writePulledPrimMetadata(const Ufe::Path& ufePulledPath, const MDagPath& editedRoot);
+MAYAUSD_CORE_PUBLIC
+bool writePulledPrimMetadata(PXR_NS::UsdPrim& pulledPrim, const MDagPath& editedRoot);
+
+MAYAUSD_CORE_PUBLIC
+void removePulledPrimMetadata(const Ufe::Path& ufePulledPath);
+MAYAUSD_CORE_PUBLIC
+void removePulledPrimMetadata(const UsdStagePtr& stage, UsdPrim& prim);
+
+MAYAUSD_CORE_PUBLIC
+bool addExcludeFromRendering(const Ufe::Path& ufePulledPath);
+
+MAYAUSD_CORE_PUBLIC
+bool removeExcludeFromRendering(const Ufe::Path& ufePulledPath);
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
+++ b/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
@@ -67,7 +67,7 @@ bool mergeToUsd(const std::string& nodeName, const VtDictionary& userArgs = VtDi
         return false;
 
     Ufe::Path path;
-    if (!PrimUpdaterManager::readPullInformation(dagPath, path))
+    if (!readPullInformation(dagPath, path))
         return false;
 
     return PrimUpdaterManager::getInstance().mergeToUsd(dagNode, path, userArgs);
@@ -109,11 +109,11 @@ bool duplicate(
 
 BOOST_PYTHON_FUNCTION_OVERLOADS(duplicate_overloads, duplicate, 2, 3)
 
-std::string readPullInformation(const PXR_NS::UsdPrim& prim)
+std::string readPullInformationString(const PXR_NS::UsdPrim& prim)
 {
     std::string dagPathStr;
     // Ignore boolean return value, empty string is the proper error result.
-    PrimUpdaterManager::getInstance().readPullInformation(prim, dagPathStr);
+    readPullInformation(prim, dagPathStr);
     return dagPathStr;
 }
 
@@ -128,5 +128,5 @@ void wrapPrimUpdaterManager()
         .def("canEditAsMaya", canEditAsMaya)
         .def("discardEdits", discardEdits)
         .def("duplicate", duplicate, duplicate_overloads())
-        .def("readPullInformation", readPullInformation);
+        .def("readPullInformation", readPullInformationString);
 }

--- a/lib/mayaUsd/ufe/MayaUIInfoHandler.cpp
+++ b/lib/mayaUsd/ufe/MayaUIInfoHandler.cpp
@@ -58,7 +58,7 @@ MayaUsd::ufe::UsdSceneItem::Ptr pulledUsdAncestorItem(const Ufe::SceneItem::Ptr&
         }
         const auto mayaPathStr = Ufe::PathString::string(mayaPath);
         const auto dagPath = UsdMayaUtil::nameToDagPath(mayaPathStr);
-        if (PrimUpdaterManager::readPullInformation(dagPath, usdItemPath)) {
+        if (readPullInformation(dagPath, usdItemPath)) {
             found = true;
         } else {
             mayaPath = mayaPath.pop();
@@ -112,7 +112,7 @@ bool MayaUIInfoHandler::treeViewCellInfo(const Ufe::SceneItem::Ptr& mayaItem, Uf
     // hierarchy, set its font to italics.
     auto      dagPath = UsdMayaUtil::nameToDagPath(Ufe::PathString::string(mayaItem->path()));
     Ufe::Path usdItemPath;
-    if (PrimUpdaterManager::readPullInformation(dagPath, usdItemPath)) {
+    if (readPullInformation(dagPath, usdItemPath)) {
         info.fontItalics = true;
         return true;
     }

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
@@ -219,7 +219,7 @@ ProxyShapeHierarchy::createUFEChildList(const UsdPrimSiblingRange& range, bool f
     UFE_V3(std::string dagPathStr;)
     for (const auto& child : range) {
 #ifdef UFE_V3_FEATURES_AVAILABLE
-        if (PXR_NS::PrimUpdaterManager::readPullInformation(child, dagPathStr)) {
+        if (PXR_NS::readPullInformation(child, dagPathStr)) {
             auto item = Ufe::Hierarchy::createItem(Ufe::PathString::path(dagPathStr));
             // if we mapped to a valid object, insert it. it's possible that we got stale object
             // so in this case simply fallback to the usual processing of items

--- a/lib/mayaUsd/ufe/PulledObjectHierarchyHandler.cpp
+++ b/lib/mayaUsd/ufe/PulledObjectHierarchyHandler.cpp
@@ -57,7 +57,7 @@ Ufe::Hierarchy::Ptr PulledObjectHierarchyHandler::hierarchy(const Ufe::SceneItem
     Ufe::Path ufePath;
 
     auto dagPath = PXR_NS::UsdMayaUtil::nameToDagPath(path.getSegments()[nbSegs - 1].string());
-    if (PXR_NS::PrimUpdaterManager::readPullInformation(dagPath, ufePath)) {
+    if (PXR_NS::readPullInformation(dagPath, ufePath)) {
         return PulledObjectHierarchy::create(_mayaHierarchyHandler, item, ufePath);
     } else {
         return _mayaHierarchyHandler->hierarchy(item);

--- a/lib/mayaUsd/ufe/UsdHierarchy.cpp
+++ b/lib/mayaUsd/ufe/UsdHierarchy.cpp
@@ -225,7 +225,7 @@ UsdHierarchy::createUFEChildList(const UsdPrimSiblingRange& range, bool filterIn
     UFE_V3(std::string dagPathStr;)
     for (const auto& child : range) {
 #ifdef UFE_V3_FEATURES_AVAILABLE
-        if (PXR_NS::PrimUpdaterManager::readPullInformation(child, dagPathStr)) {
+        if (PXR_NS::readPullInformation(child, dagPathStr)) {
             auto item = Ufe::Hierarchy::createItem(Ufe::PathString::path(dagPathStr));
             // if we mapped to a valid object, insert it. it's possible that we got stale object
             // so in this case simply fallback to the usual processing of items

--- a/lib/mayaUsd/ufe/UsdPathMappingHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdPathMappingHandler.cpp
@@ -138,7 +138,7 @@ Ufe::Path UsdPathMappingHandler::fromHost(const Ufe::Path& hostPath) const
         mayaComps.emplace_back(mayaHostPath.back());
         mayaHostPath = mayaHostPath.pop();
         Ufe::Path ufePath;
-        if (PXR_NS::PrimUpdaterManager::readPullInformation(dagPath, ufePath)) {
+        if (PXR_NS::readPullInformation(dagPath, ufePath)) {
             // From the pulled info path, we pop only the last component and
             // append the Maya component array.
             std::reverse(mayaComps.begin(), mayaComps.end());

--- a/lib/mayaUsd/utils/CMakeLists.txt
+++ b/lib/mayaUsd/utils/CMakeLists.txt
@@ -29,6 +29,13 @@ target_sources(${PROJECT_NAME}
         variants.cpp
 )
 
+if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
+    target_sources(${PROJECT_NAME}
+        PRIVATE
+            json.cpp
+    )
+endif()
+
 set(HEADERS
     blockSceneModificationContext.h
     colorSpace.h
@@ -54,6 +61,11 @@ set(HEADERS
     utilSerialization.h
     variants.h
 )
+if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
+    list(APPEND HEADERS
+        json.h
+    )
+endif()
 
 set(PLUGINFO
     plugInfo.json)

--- a/lib/mayaUsd/utils/dynamicAttribute.h
+++ b/lib/mayaUsd/utils/dynamicAttribute.h
@@ -30,7 +30,7 @@ bool hasDynamicAttribute(const MFnDependencyNode& depNode, const MString& attrNa
 /*! \brief create the named dynamic attribute on the Maya node.
  */
 MAYAUSD_CORE_PUBLIC
-MStatus createDynamicAttribute(const MFnDependencyNode& depNode, const MString& attrName);
+MStatus createDynamicAttribute(MFnDependencyNode& depNode, const MString& attrName);
 
 /*! \brief get the string value of the named dynamic attribute from the Maya node.
  */
@@ -41,10 +41,8 @@ getDynamicAttribute(const MFnDependencyNode& depNode, const MString& attrName, M
 /*! \brief set the named dynamic attribute to the given string value on the Maya node.
  */
 MAYAUSD_CORE_PUBLIC
-MStatus setDynamicAttribute(
-    const MFnDependencyNode& depNode,
-    const MString&           attrName,
-    const MString&           value);
+MStatus
+setDynamicAttribute(MFnDependencyNode& depNode, const MString& attrName, const MString& value);
 
 } // namespace MAYAUSD_NS_DEF
 

--- a/lib/mayaUsd/utils/json.cpp
+++ b/lib/mayaUsd/utils/json.cpp
@@ -1,0 +1,96 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "json.h"
+
+#include <mayaUsd/utils/util.h>
+
+#include <ufe/pathString.h>
+
+namespace MAYAUSD_NS_DEF {
+
+static const char* invalidJson = "Invalid JSON";
+
+PXR_NS::JsValue convertToValue(const std::string& text)
+{
+    // Provided for call consistency and in case we need to do some filtering
+    // in the future.
+    return PXR_NS::JsValue(text);
+}
+
+std::string convertToString(const PXR_NS::JsValue& value)
+{
+    if (!value.IsString())
+        throw std::runtime_error(invalidJson);
+
+    return value.GetString();
+}
+
+PXR_NS::JsValue convertToValue(const MString& text)
+{
+    // Provided for call consistency and in case we need to do some filtering
+    // in the future.
+    return PXR_NS::JsValue(text.asChar());
+}
+
+MString convertToMString(const PXR_NS::JsValue& value)
+{
+    return MString(convertToString(value).c_str());
+}
+
+PXR_NS::JsValue convertToValue(const Ufe::Path& path)
+{
+    return convertToValue(Ufe::PathString::string(path));
+}
+
+Ufe::Path convertToUfePath(const PXR_NS::JsValue& pathJson)
+{
+    return Ufe::PathString::path(convertToString(pathJson));
+}
+
+PXR_NS::JsValue convertToValue(const MDagPath& path) { return convertToValue(path.fullPathName()); }
+
+MDagPath convertToDagPath(const PXR_NS::JsValue& value)
+{
+    return PXR_NS::UsdMayaUtil::nameToDagPath(convertToString(value));
+}
+
+PXR_NS::JsArray convertToArray(const PXR_NS::JsValue& value)
+{
+    if (!value.IsArray())
+        throw std::runtime_error(invalidJson);
+
+    return value.GetJsArray();
+}
+
+PXR_NS::JsObject convertToObject(const PXR_NS::JsValue& value)
+{
+    if (!value.IsObject())
+        throw std::runtime_error(invalidJson);
+
+    return value.GetJsObject();
+}
+
+PXR_NS::JsValue convertJsonKeyToValue(const PXR_NS::JsObject& object, const std::string& key)
+{
+    const auto pos = object.find(key);
+    if (pos == object.end())
+        throw std::runtime_error(invalidJson);
+
+    return pos->second;
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/json.h
+++ b/lib/mayaUsd/utils/json.h
@@ -1,0 +1,57 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <mayaUsd/base/api.h>
+
+#include <pxr/base/js/json.h>
+
+#include <maya/MDagPath.h>
+#include <maya/MString.h>
+#include <ufe/path.h>
+
+namespace MAYAUSD_NS_DEF {
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Conversion functions to and from JSON for C++, Maya and UFE types.
+//
+// All functions throw C++ exceptions on error.
+
+MAYAUSD_CORE_PUBLIC
+PXR_NS::JsValue convertToValue(const std::string& text);
+MAYAUSD_CORE_PUBLIC
+PXR_NS::JsValue convertToValue(const MString& text);
+MAYAUSD_CORE_PUBLIC
+PXR_NS::JsValue convertToValue(const Ufe::Path& path);
+MAYAUSD_CORE_PUBLIC
+PXR_NS::JsValue convertToValue(const MDagPath& path);
+
+MAYAUSD_CORE_PUBLIC
+std::string convertToString(const PXR_NS::JsValue& value);
+MAYAUSD_CORE_PUBLIC
+MString convertToMString(const PXR_NS::JsValue& value);
+MAYAUSD_CORE_PUBLIC
+Ufe::Path convertToUfePath(const PXR_NS::JsValue& value);
+MAYAUSD_CORE_PUBLIC
+MDagPath convertToDagPath(const PXR_NS::JsValue& value);
+MAYAUSD_CORE_PUBLIC
+PXR_NS::JsArray convertToArray(const PXR_NS::JsValue& value);
+MAYAUSD_CORE_PUBLIC
+PXR_NS::JsObject convertToObject(const PXR_NS::JsValue& value);
+MAYAUSD_CORE_PUBLIC
+PXR_NS::JsValue convertJsonKeyToValue(const PXR_NS::JsObject& object, const std::string& key);
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/usd/translators/mayaReferenceUpdater.cpp
+++ b/lib/usd/translators/mayaReferenceUpdater.cpp
@@ -266,7 +266,7 @@ bool PxrUsdTranslators_MayaReferenceUpdater::discardEdits()
     MStatus  status = MDagPath::getAPathTo(parentNode, dagPath);
     if (status == MS::kSuccess) {
         Ufe::Path pulledPath;
-        if (PrimUpdaterManager::readPullInformation(dagPath, pulledPath)) {
+        if (readPullInformation(dagPath, pulledPath)) {
             // Reset the auto-edit when discarding the edit.
             UsdPrim prim = MayaUsd::ufe::ufePathToPrim(pulledPath);
             clearAutoEdit(prim);

--- a/test/lib/mayaUsd/fileio/testHideOrphanedNodes.py
+++ b/test/lib/mayaUsd/fileio/testHideOrphanedNodes.py
@@ -31,6 +31,7 @@ from maya.api import OpenMaya as om
  
 import ufe
 
+import os.path
 import unittest
 
 from testUtils import getTestScene
@@ -98,9 +99,19 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
         self.cPathStr = self.ps + ',/A/B/C'
         self.ePathStr = self.ps + ',/D/E'
 
+    def getVisibilityPlugs(self, mayaPaths):
+        visibilityPlugs = {}
+
+        for pathStr, mayaPath in mayaPaths.items():
+            # Get the pull parent from the path.  Pulled node is visible.
+            visibility = visibilityPlug(ufe.PathString.string(mayaPath.pop()))
+            visibilityPlugs[pathStr] = visibility
+
+        return visibilityPlugs
+
     def pullAndGetParentVisibility(self, pathStrings):
 
-        visibilityPlugs = {}
+        mayaPaths = {}
 
         for pathStr in pathStrings:
             # See testEditAsMaya.py comments: PathMappingHandler toHost()
@@ -109,17 +120,18 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
             mayaItem = ufe.GlobalSelection.get().front()
             mayaPath = mayaItem.path()
             self.assertEqual(mayaPath.nbSegments(), 1)
-    
-            # Get the pull parent from the path.  Pulled node is visible.
-            visibility = visibilityPlug(ufe.PathString.string(mayaPath.pop()))
-            visibilityPlugs[pathStr] = visibility
+            mayaPaths[pathStr] = mayaPath
+
+        visibilityPlugs = self.getVisibilityPlugs(mayaPaths)
+
+        for pathStr, visibility in visibilityPlugs.items():
             self.assertTrue(visibility.asBool())
         
-        return visibilityPlugs
+        return visibilityPlugs, mayaPaths
 
     def testHideOnDelete(self):
         # Pull on C and E.
-        pullParentVisibilityPlug = self.pullAndGetParentVisibility(
+        pullParentVisibilityPlug, _ = self.pullAndGetParentVisibility(
             [self.cPathStr, self.ePathStr])
 
         # Delete the proxy shape.  Both pulled nodes should be orphaned and
@@ -137,7 +149,7 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
 
     def testHideOnInactivate(self):
         # Pull on C and E.
-        pullParentVisibilityPlug = self.pullAndGetParentVisibility(
+        pullParentVisibilityPlug, _ = self.pullAndGetParentVisibility(
             [self.cPathStr, self.ePathStr])
 
         # Inactivate B, C's parent.
@@ -156,7 +168,7 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
 
     def testHideOnPayloadUnload(self):
         # Pull on C and E.
-        pullParentVisibilityPlug = self.pullAndGetParentVisibility(
+        pullParentVisibilityPlug, _ = self.pullAndGetParentVisibility(
             [self.cPathStr, self.ePathStr])
 
         # Unload A, C's grandparent.
@@ -176,7 +188,7 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
 
     def testHideOnNestedVariantSwitch(self):
         # Pull on C and E.
-        pullParentVisibilityPlug = self.pullAndGetParentVisibility(
+        pullParentVisibilityPlug, _ = self.pullAndGetParentVisibility(
             [self.cPathStr, self.ePathStr])
 
         # B's variant set cdVariant is set to variant selection c, so Maya
@@ -211,9 +223,68 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
         self.assertTrue(pullParentVisibilityPlug[self.cPathStr].asBool())
         self.assertTrue(pullParentVisibilityPlug[self.ePathStr].asBool())
 
+    def _saveScene(self, filename):
+        cmds.file(rename=filename)
+        cmds.file(save=True, force=True, type="mayaAscii")
+    
+    def _reloadScene(self, filename):
+        cmds.file(new=True, force=True)
+        cmds.file(filename, open=True)
+
+    def testHideOnNestedVariantSwitchOnReload(self):
+        # Pull on C and E.
+        pullParentVisibilityPlug, mayaPaths = self.pullAndGetParentVisibility(
+            [self.cPathStr, self.ePathStr])
+
+        # B's variant set cdVariant is set to variant selection c, so Maya
+        # version of pulled node C has translation (1, 2, 3).
+        variantCXlation = (1, 2, 3)
+        cPrim = mayaUsd.ufe.ufePathToPrim(self.cPathStr)
+        cMayaPathStr = mayaUsd.lib.PrimUpdaterManager.readPullInformation(cPrim)
+        cDagPath = om.MSelectionList().add(cMayaPathStr).getDagPath(0)
+        cFn= om.MFnTransform(cDagPath)
+        self.assertEqual(cFn.translation(om.MSpace.kObject),
+                         om.MVector(*variantCXlation))
+
+        bPrim = cPrim.GetParent()
+        cdVariant = bPrim.GetVariantSet('cdVariant')
+        self.assertEqual(cdVariant.GetVariantSelection(), 'c')
+
+        # Switch B's variant set cdVariant to variant selection d.  The prim in
+        # that variant is also called C, but it is a different prim, with a
+        # different translation, so the pulled node is hidden.
+        cdVariant.SetVariantSelection('d')
+
+        cPrim = mayaUsd.ufe.ufePathToPrim(self.cPathStr)
+        cXformable = UsdGeom.Xformable(cPrim)
+        self.assertEqual(cXformable.GetLocalTransformation().GetRow3(3), [4, 5, 6])
+
+        self.assertFalse(pullParentVisibilityPlug[self.cPathStr].asBool())
+        self.assertTrue(pullParentVisibilityPlug[self.ePathStr].asBool())
+
+        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 2))
+        filename = os.path.abspath("orphaned.ma")
+        self._saveScene(filename)
+        self._reloadScene(filename)
+
+        # # Verify the hidden state of the edited nodes.
+        pullParentVisibilityPlug = self.getVisibilityPlugs(mayaPaths)
+
+        self.assertFalse(pullParentVisibilityPlug[self.cPathStr].asBool())
+        self.assertTrue(pullParentVisibilityPlug[self.ePathStr].asBool())
+
+        # # Revert back to variant selection c, pulled node is shown.
+        cPrim = mayaUsd.ufe.ufePathToPrim(self.cPathStr)
+        bPrim = cPrim.GetParent()
+        cdVariant = bPrim.GetVariantSet('cdVariant')
+        cdVariant.SetVariantSelection('c')
+
+        self.assertTrue(pullParentVisibilityPlug[self.cPathStr].asBool())
+        self.assertTrue(pullParentVisibilityPlug[self.ePathStr].asBool())
+
     def testHideOnNestingVariantSwitch(self):
         # Pull on C and E.
-        pullParentVisibilityPlug = self.pullAndGetParentVisibility(
+        pullParentVisibilityPlug, _ = self.pullAndGetParentVisibility(
             [self.cPathStr, self.ePathStr])
 
         # A's variant set abVariant is set to variant selection a, so Maya
@@ -252,7 +323,7 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
         the deletion. The Maya object should still be deleted.
         '''
         # Pull on C.
-        pullParentVisibilityPlug = self.pullAndGetParentVisibility(
+        pullParentVisibilityPlug, _ = self.pullAndGetParentVisibility(
             [self.cPathStr])
 
         # A's variant set abVariant is set to variant selection a, so Maya
@@ -295,7 +366,7 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
         be visible.
         '''
         # Pull on C.
-        pullParentVisibilityPlug = self.pullAndGetParentVisibility(
+        pullParentVisibilityPlug, _ = self.pullAndGetParentVisibility(
             [self.cPathStr])
 
         # A's variant set abVariant is set to variant selection a, so Maya

--- a/test/lib/mayaUsd/fileio/testHideOrphanedNodes.py
+++ b/test/lib/mayaUsd/fileio/testHideOrphanedNodes.py
@@ -241,6 +241,7 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
         variantCXlation = (1, 2, 3)
         cPrim = mayaUsd.ufe.ufePathToPrim(self.cPathStr)
         cMayaPathStr = mayaUsd.lib.PrimUpdaterManager.readPullInformation(cPrim)
+        self.assertNotEqual(cMayaPathStr, '')
         cDagPath = om.MSelectionList().add(cMayaPathStr).getDagPath(0)
         cFn= om.MFnTransform(cDagPath)
         self.assertEqual(cFn.translation(om.MSpace.kObject),
@@ -262,6 +263,10 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
         self.assertFalse(pullParentVisibilityPlug[self.cPathStr].asBool())
         self.assertTrue(pullParentVisibilityPlug[self.ePathStr].asBool())
 
+        # Also verify that the session layer data has been removed.
+        cMayaPathStr = mayaUsd.lib.PrimUpdaterManager.readPullInformation(cPrim)
+        self.assertEqual(cMayaPathStr, '')
+
         cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 2))
         filename = os.path.abspath("orphaned.ma")
         self._saveScene(filename)
@@ -281,6 +286,10 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
 
         self.assertTrue(pullParentVisibilityPlug[self.cPathStr].asBool())
         self.assertTrue(pullParentVisibilityPlug[self.ePathStr].asBool())
+
+        # Also verify that the session layer data has been restored.
+        cMayaPathStr = mayaUsd.lib.PrimUpdaterManager.readPullInformation(cPrim)
+        self.assertNotEqual(cMayaPathStr, '')
 
     def testHideOnNestingVariantSwitch(self):
         # Pull on C and E.


### PR DESCRIPTION
When an edited-as-Maya object is under a variant and that variant selection changes, we need to remove the information that was stored in the session layer about that edition. Note that if a prim with the same name is under the new variant, currently it cannot be edited. If we allow edition of variants with the same name, it would make the session cleanup harder since we would need to also restore the info from one edition at the same we remove the info from the other edition.

Note that the implementation would be broken by rename or reparent of ancestors, but there is another story to handle that.

Update the data held by the orphaned nodes manager:
- Add the DAG path to the proxy shape and edited Maya root to the pull variant info in order to be able to set or reset session info.
- Pass the edited Maya root to the add() function of the orphan manager.
- Add helper function to convert a trie node of pull variant info to a valid UFE path.
- Implement the clearing and restoring of session info when orphaning.
- Remove the explicit setting of prim activation since the clearing and restoring of session info now does it.
- Add the new pull variant info to the JSON I/O used to save the orphan data.

Renamed functions referencing visibility to instead reference orphans to make the intention clearer.
- So, recursiveSetVisibility becomes recursiveSetOrphaned.
- So, setVisibilityPlug becomes setOrphaned.
- getVisibilityPlug is no longer needed.

Refactored the prim updater manager to make some session info functions shared with the orphan manager. This centralizes pull information code and simplifies the PrimUpdaterManager class.
- Renamed generic "path" variable names to more specific "editedAsMayaRoot" to make the code clearer.
- Renamed the AddPullPathUndoItem class to RecordPullVariantInfoUndoItem to make the code clearer.
- Especially since it now records more than just the pull path...
- Renamed RemovePullPathUndoItem to RemovePullVariantInfoUndoItem for the same reason.
- Moved all pull information reading and writing into its own header and C++ file.
- Refactor all callers to use these new functions.

Modified an existing unit test that had two variants with prims of the same name to verify that the session layer data gets removed and restored properly.