### PR TITLE
LOOKDEVX-606 - Improve undo/redo capabilities

### DIFF
--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -284,7 +284,6 @@ public:
     std::string commandString() const override { return cmdsList().front()->commandString(); }
 #endif
 #endif
-
 };
 
 //! \brief Create a working Material and select it:
@@ -315,7 +314,6 @@ public:
     std::string commandString() const override { return cmdsList().front()->commandString(); }
 #endif
 #endif
-
 };
 #endif
 

--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -278,6 +278,16 @@ public:
                 Ufe::GlobalSelection::get(), newSelection));
         }
     }
+
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4032)
+    std::string commandString() const override
+    {
+        return cmdsList().front()->commandString();
+    }
+#endif
+#endif
+
 };
 
 //! \brief Create a working Material and select it:
@@ -302,6 +312,16 @@ public:
                 Ufe::GlobalSelection::get(), newSelection));
         }
     }
+
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4032)
+    std::string commandString() const override
+    {
+        return cmdsList().front()->commandString();
+    }
+#endif
+#endif
+
 };
 #endif
 

--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -281,10 +281,7 @@ public:
 
 #ifdef UFE_V4_FEATURES_AVAILABLE
 #if (UFE_PREVIEW_VERSION_NUM >= 4032)
-    std::string commandString() const override
-    {
-        return cmdsList().front()->commandString();
-    }
+    std::string commandString() const override { return cmdsList().front()->commandString(); }
 #endif
 #endif
 
@@ -315,10 +312,7 @@ public:
 
 #ifdef UFE_V4_FEATURES_AVAILABLE
 #if (UFE_PREVIEW_VERSION_NUM >= 4032)
-    std::string commandString() const override
-    {
-        return cmdsList().front()->commandString();
-    }
+    std::string commandString() const override { return cmdsList().front()->commandString(); }
 #endif
 #endif
 

--- a/lib/mayaUsd/ufe/UsdSceneItemOps.cpp
+++ b/lib/mayaUsd/ufe/UsdSceneItemOps.cpp
@@ -50,7 +50,7 @@ const Ufe::Path& UsdSceneItemOps::path() const { return fItem->path(); }
 Ufe::SceneItem::Ptr UsdSceneItemOps::sceneItem() const { return fItem; }
 
 #ifdef UFE_V4_FEATURES_AVAILABLE
-#if (UFE_PREVIEW_VERSION_NUM >= 4034)
+#if (UFE_PREVIEW_VERSION_NUM >= 4033)
 Ufe::UndoableCommand::Ptr UsdSceneItemOps::deleteItemCmdNoExecute()
 {
     return UsdUndoDeleteCommand::create(prim());
@@ -77,7 +77,7 @@ bool UsdSceneItemOps::deleteItem()
 }
 
 #ifdef UFE_V4_FEATURES_AVAILABLE
-#if (UFE_PREVIEW_VERSION_NUM >= 4034)
+#if (UFE_PREVIEW_VERSION_NUM >= 4033)
 Ufe::UndoableCommand::Ptr UsdSceneItemOps::duplicateItemCmdNoExecute()
 {
     return UsdUndoDuplicateCommand::create(fItem);
@@ -99,7 +99,7 @@ Ufe::SceneItem::Ptr UsdSceneItemOps::duplicateItem()
 }
 
 #ifdef UFE_V4_FEATURES_AVAILABLE
-#if (UFE_PREVIEW_VERSION_NUM >= 4034)
+#if (UFE_PREVIEW_VERSION_NUM >= 4033)
 Ufe::UndoableCommand::Ptr UsdSceneItemOps::renameItemCmdNoExecute(const Ufe::PathComponent& newName)
 {
     return UsdUndoRenameCommand::create(fItem, newName);

--- a/lib/mayaUsd/ufe/UsdSceneItemOps.cpp
+++ b/lib/mayaUsd/ufe/UsdSceneItemOps.cpp
@@ -50,7 +50,7 @@ const Ufe::Path& UsdSceneItemOps::path() const { return fItem->path(); }
 Ufe::SceneItem::Ptr UsdSceneItemOps::sceneItem() const { return fItem; }
 
 #ifdef UFE_V4_FEATURES_AVAILABLE
-#if (UFE_PREVIEW_VERSION_NUM >= 4033)
+#if (UFE_PREVIEW_VERSION_NUM >= 4034)
 Ufe::UndoableCommand::Ptr UsdSceneItemOps::deleteItemCmdNoExecute()
 {
     return UsdUndoDeleteCommand::create(prim());
@@ -77,7 +77,7 @@ bool UsdSceneItemOps::deleteItem()
 }
 
 #ifdef UFE_V4_FEATURES_AVAILABLE
-#if (UFE_PREVIEW_VERSION_NUM >= 4033)
+#if (UFE_PREVIEW_VERSION_NUM >= 4034)
 Ufe::UndoableCommand::Ptr UsdSceneItemOps::duplicateItemCmdNoExecute()
 {
     return UsdUndoDuplicateCommand::create(fItem);
@@ -99,7 +99,7 @@ Ufe::SceneItem::Ptr UsdSceneItemOps::duplicateItem()
 }
 
 #ifdef UFE_V4_FEATURES_AVAILABLE
-#if (UFE_PREVIEW_VERSION_NUM >= 4033)
+#if (UFE_PREVIEW_VERSION_NUM >= 4034)
 Ufe::UndoableCommand::Ptr UsdSceneItemOps::renameItemCmdNoExecute(const Ufe::PathComponent& newName)
 {
     return UsdUndoRenameCommand::create(fItem, newName);

--- a/lib/mayaUsd/ufe/UsdSceneItemOps.cpp
+++ b/lib/mayaUsd/ufe/UsdSceneItemOps.cpp
@@ -49,6 +49,15 @@ const Ufe::Path& UsdSceneItemOps::path() const { return fItem->path(); }
 
 Ufe::SceneItem::Ptr UsdSceneItemOps::sceneItem() const { return fItem; }
 
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4033)
+Ufe::UndoableCommand::Ptr UsdSceneItemOps::deleteItemCmdNoExecute()
+{
+    return UsdUndoDeleteCommand::create(prim());
+}
+#endif
+#endif
+
 Ufe::UndoableCommand::Ptr UsdSceneItemOps::deleteItemCmd()
 {
     auto deleteCmd = UsdUndoDeleteCommand::create(prim());
@@ -67,6 +76,15 @@ bool UsdSceneItemOps::deleteItem()
     return false;
 }
 
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4033)
+Ufe::UndoableCommand::Ptr UsdSceneItemOps::duplicateItemCmdNoExecute()
+{
+    return UsdUndoDuplicateCommand::create(fItem);
+}
+#endif
+#endif
+
 Ufe::Duplicate UsdSceneItemOps::duplicateItemCmd()
 {
     auto duplicateCmd = UsdUndoDuplicateCommand::create(fItem);
@@ -80,18 +98,27 @@ Ufe::SceneItem::Ptr UsdSceneItemOps::duplicateItem()
     return duplicate.item;
 }
 
-Ufe::SceneItem::Ptr UsdSceneItemOps::renameItem(const Ufe::PathComponent& newName)
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4033)
+Ufe::UndoableCommand::Ptr UsdSceneItemOps::renameItemCmdNoExecute(const Ufe::PathComponent& newName)
 {
-    auto renameCmd = UsdUndoRenameCommand::create(fItem, newName);
-    renameCmd->execute();
-    return renameCmd->renamedItem();
+    return UsdUndoRenameCommand::create(fItem, newName);
 }
+#endif
+#endif
 
 Ufe::Rename UsdSceneItemOps::renameItemCmd(const Ufe::PathComponent& newName)
 {
     auto renameCmd = UsdUndoRenameCommand::create(fItem, newName);
     renameCmd->execute();
     return Ufe::Rename(renameCmd->renamedItem(), renameCmd);
+}
+
+Ufe::SceneItem::Ptr UsdSceneItemOps::renameItem(const Ufe::PathComponent& newName)
+{
+    auto renameCmd = UsdUndoRenameCommand::create(fItem, newName);
+    renameCmd->execute();
+    return renameCmd->renamedItem();
 }
 
 } // namespace ufe

--- a/lib/mayaUsd/ufe/UsdSceneItemOps.h
+++ b/lib/mayaUsd/ufe/UsdSceneItemOps.h
@@ -55,7 +55,7 @@ public:
 
     //@{
     // Ufe::SceneItemOps overrides
-    Ufe::SceneItem::Ptr       sceneItem() const override;
+    Ufe::SceneItem::Ptr sceneItem() const override;
 #ifdef UFE_V4_FEATURES_AVAILABLE
 #if (UFE_PREVIEW_VERSION_NUM >= 4033)
     Ufe::UndoableCommand::Ptr deleteItemCmdNoExecute() override;
@@ -68,15 +68,15 @@ public:
     Ufe::UndoableCommand::Ptr duplicateItemCmdNoExecute() override;
 #endif
 #endif
-    Ufe::Duplicate            duplicateItemCmd() override;
-    Ufe::SceneItem::Ptr       duplicateItem() override;
+    Ufe::Duplicate      duplicateItemCmd() override;
+    Ufe::SceneItem::Ptr duplicateItem() override;
 #ifdef UFE_V4_FEATURES_AVAILABLE
 #if (UFE_PREVIEW_VERSION_NUM >= 4033)
     Ufe::UndoableCommand::Ptr renameItemCmdNoExecute(const Ufe::PathComponent& newName) override;
 #endif
 #endif
-    Ufe::Rename               renameItemCmd(const Ufe::PathComponent& newName) override;
-    Ufe::SceneItem::Ptr       renameItem(const Ufe::PathComponent& newName) override;
+    Ufe::Rename         renameItemCmd(const Ufe::PathComponent& newName) override;
+    Ufe::SceneItem::Ptr renameItem(const Ufe::PathComponent& newName) override;
     //@}
 
 private:

--- a/lib/mayaUsd/ufe/UsdSceneItemOps.h
+++ b/lib/mayaUsd/ufe/UsdSceneItemOps.h
@@ -57,21 +57,21 @@ public:
     // Ufe::SceneItemOps overrides
     Ufe::SceneItem::Ptr       sceneItem() const override;
 #ifdef UFE_V4_FEATURES_AVAILABLE
-#if (UFE_PREVIEW_VERSION_NUM >= 4034)
+#if (UFE_PREVIEW_VERSION_NUM >= 4033)
     Ufe::UndoableCommand::Ptr deleteItemCmdNoExecute() override;
 #endif
 #endif
     Ufe::UndoableCommand::Ptr deleteItemCmd() override;
     bool                      deleteItem() override;
 #ifdef UFE_V4_FEATURES_AVAILABLE
-#if (UFE_PREVIEW_VERSION_NUM >= 4034)
+#if (UFE_PREVIEW_VERSION_NUM >= 4033)
     Ufe::UndoableCommand::Ptr duplicateItemCmdNoExecute() override;
 #endif
 #endif
     Ufe::Duplicate            duplicateItemCmd() override;
     Ufe::SceneItem::Ptr       duplicateItem() override;
 #ifdef UFE_V4_FEATURES_AVAILABLE
-#if (UFE_PREVIEW_VERSION_NUM >= 4034)
+#if (UFE_PREVIEW_VERSION_NUM >= 4033)
     Ufe::UndoableCommand::Ptr renameItemCmdNoExecute(const Ufe::PathComponent& newName) override;
 #endif
 #endif

--- a/lib/mayaUsd/ufe/UsdSceneItemOps.h
+++ b/lib/mayaUsd/ufe/UsdSceneItemOps.h
@@ -57,21 +57,21 @@ public:
     // Ufe::SceneItemOps overrides
     Ufe::SceneItem::Ptr       sceneItem() const override;
 #ifdef UFE_V4_FEATURES_AVAILABLE
-#if (UFE_PREVIEW_VERSION_NUM >= 4033)
+#if (UFE_PREVIEW_VERSION_NUM >= 4034)
     Ufe::UndoableCommand::Ptr deleteItemCmdNoExecute() override;
 #endif
 #endif
     Ufe::UndoableCommand::Ptr deleteItemCmd() override;
     bool                      deleteItem() override;
 #ifdef UFE_V4_FEATURES_AVAILABLE
-#if (UFE_PREVIEW_VERSION_NUM >= 4033)
+#if (UFE_PREVIEW_VERSION_NUM >= 4034)
     Ufe::UndoableCommand::Ptr duplicateItemCmdNoExecute() override;
 #endif
 #endif
     Ufe::Duplicate            duplicateItemCmd() override;
     Ufe::SceneItem::Ptr       duplicateItem() override;
 #ifdef UFE_V4_FEATURES_AVAILABLE
-#if (UFE_PREVIEW_VERSION_NUM >= 4033)
+#if (UFE_PREVIEW_VERSION_NUM >= 4034)
     Ufe::UndoableCommand::Ptr renameItemCmdNoExecute(const Ufe::PathComponent& newName) override;
 #endif
 #endif

--- a/lib/mayaUsd/ufe/UsdSceneItemOps.h
+++ b/lib/mayaUsd/ufe/UsdSceneItemOps.h
@@ -53,14 +53,31 @@ public:
         return fItem->prim();
     }
 
+    //@{
     // Ufe::SceneItemOps overrides
     Ufe::SceneItem::Ptr       sceneItem() const override;
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4033)
+    Ufe::UndoableCommand::Ptr deleteItemCmdNoExecute() override;
+#endif
+#endif
     Ufe::UndoableCommand::Ptr deleteItemCmd() override;
     bool                      deleteItem() override;
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4033)
+    Ufe::UndoableCommand::Ptr duplicateItemCmdNoExecute() override;
+#endif
+#endif
     Ufe::Duplicate            duplicateItemCmd() override;
     Ufe::SceneItem::Ptr       duplicateItem() override;
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4033)
+    Ufe::UndoableCommand::Ptr renameItemCmdNoExecute(const Ufe::PathComponent& newName) override;
+#endif
+#endif
     Ufe::Rename               renameItemCmd(const Ufe::PathComponent& newName) override;
     Ufe::SceneItem::Ptr       renameItem(const Ufe::PathComponent& newName) override;
+    //@}
 
 private:
     UsdSceneItem::Ptr fItem;

--- a/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
@@ -120,7 +120,8 @@ void UsdUndoAddNewPrimCommand::redo()
 #if (UFE_PREVIEW_VERSION_NUM >= 4032)
 std::string UsdUndoAddNewPrimCommand::commandString() const
 {
-    return std::string("CreatePrim ") + _primToken.GetText() + " " + Ufe::PathString::string(_newUfePath);
+    return std::string("CreatePrim ") + _primToken.GetText() + " "
+        + Ufe::PathString::string(_newUfePath);
 }
 #endif
 #endif

--- a/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
@@ -22,6 +22,9 @@
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/undo/UsdUndoBlock.h>
 
+#include <ufe/pathString.h>
+
+
 namespace {
 
 Ufe::Path appendToPath(const Ufe::Path& path, const std::string& name)
@@ -112,6 +115,15 @@ void UsdUndoAddNewPrimCommand::redo()
 
     _undoableItem.redo();
 }
+
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4032)
+std::string UsdUndoAddNewPrimCommand::commandString() const
+{
+    return std::string("CreatePrim ") + _primToken.GetText() + " " + Ufe::PathString::string(_newUfePath);
+}
+#endif
+#endif
 
 const Ufe::Path& UsdUndoAddNewPrimCommand::newUfePath() const { return _newUfePath; }
 

--- a/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
@@ -24,7 +24,6 @@
 
 #include <ufe/pathString.h>
 
-
 namespace {
 
 Ufe::Path appendToPath(const Ufe::Path& path, const std::string& name)

--- a/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.h
@@ -44,6 +44,12 @@ public:
     const Ufe::Path& newUfePath() const;
     PXR_NS::UsdPrim  newPrim() const;
 
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4032)
+    std::string commandString() const override;
+#endif
+#endif
+
     static UsdUndoAddNewPrimCommand::Ptr
     create(const UsdSceneItem::Ptr& usdSceneItem, const std::string& name, const std::string& type);
 

--- a/lib/mayaUsd/ufe/UsdUndoAttributesCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoAttributesCommands.cpp
@@ -18,6 +18,7 @@
 #include <mayaUsd/ufe/UsdAttributes.h>
 
 #include <ufe/hierarchy.h>
+#include <ufe/pathString.h>
 
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
@@ -68,6 +69,15 @@ void UsdAddAttributeCommand::executeUndoBlock()
     }
 }
 
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4032)
+std::string UsdAddAttributeCommand::commandString() const
+{
+    return std::string("AddAttribute ") + _name + " " + Ufe::PathString::string(_sceneItemPath);
+}
+#endif
+#endif
+
 UsdRemoveAttributeCommand::UsdRemoveAttributeCommand(
     const UsdSceneItem::Ptr& sceneItem,
     const std::string&       name)
@@ -95,6 +105,15 @@ void UsdRemoveAttributeCommand::executeUndoBlock()
         = std::dynamic_pointer_cast<UsdSceneItem>(Ufe::Hierarchy::createItem(_sceneItemPath));
     UsdAttributes::doRemoveAttribute(sceneItem, _name);
 }
+
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4032)
+std::string UsdRemoveAttributeCommand::commandString() const
+{
+    return std::string("RemoveAttribute ") + _name + " " + Ufe::PathString::string(_sceneItemPath);
+}
+#endif
+#endif
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdUndoAttributesCommands.h
+++ b/lib/mayaUsd/ufe/UsdUndoAttributesCommands.h
@@ -63,6 +63,12 @@ public:
 
     void executeUndoBlock() override;
 
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4032)
+    std::string commandString() const override;
+#endif
+#endif
+
 private:
     const Ufe::Path            _sceneItemPath;
     std::string                _name;
@@ -92,6 +98,12 @@ public:
     create(const UsdSceneItem::Ptr& sceneItem, const std::string& name);
 
     void executeUndoBlock() override;
+
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4032)
+    std::string commandString() const override;
+#endif
+#endif
 
 private:
     const Ufe::Path   _sceneItemPath;

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
@@ -31,6 +31,7 @@
 #include <pxr/usd/usdGeom/gprim.h>
 
 #include <ufe/log.h>
+#include <ufe/pathString.h>
 #include <ufe/scene.h>
 #include <ufe/sceneNotification.h>
 
@@ -97,6 +98,16 @@ UsdUndoInsertChildCommand::UsdUndoInsertChildCommand(
 }
 
 UsdUndoInsertChildCommand::~UsdUndoInsertChildCommand() { }
+
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4032)
+std::string UsdUndoInsertChildCommand::commandString() const
+{
+    return std::string("InsertChild ") + Ufe::PathString::string(_ufeSrcPath)
+           + " " + Ufe::PathString::string(_ufeParentPath);
+}
+#endif
+#endif
 
 /*static*/
 UsdUndoInsertChildCommand::Ptr UsdUndoInsertChildCommand::create(

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
@@ -103,8 +103,8 @@ UsdUndoInsertChildCommand::~UsdUndoInsertChildCommand() { }
 #if (UFE_PREVIEW_VERSION_NUM >= 4032)
 std::string UsdUndoInsertChildCommand::commandString() const
 {
-    return std::string("InsertChild ") + Ufe::PathString::string(_ufeSrcPath)
-           + " " + Ufe::PathString::string(_ufeParentPath);
+    return std::string("InsertChild ") + Ufe::PathString::string(_ufeSrcPath) + " "
+        + Ufe::PathString::string(_ufeParentPath);
 }
 #endif
 #endif

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
@@ -48,6 +48,12 @@ public:
 
     Ufe::SceneItem::Ptr insertedChild() const override { return _ufeDstItem; }
 
+#ifdef UFE_V4_FEATURES_AVAILABLE
+#if (UFE_PREVIEW_VERSION_NUM >= 4032)
+    std::string commandString() const override;
+#endif
+#endif
+
 protected:
     //! Construct a UsdUndoInsertChildCommand.  Note that as of 4-May-2020 the
     //! pos argument is ignored, and only append is supported.


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul [Patrick.Hodoul@autodesk.com](mailto:Patrick.Hodoul@autodesk.com)

The pull request improves some existing code to provide an access to commands (without being executed). The aim is to enable command aggregation so the execution can be one single composite command (instead of several undoable commands).

Being in that code area, the pull request also adds extra information to the commands so, the DCC undoable queue can log meaningful information when undoing a command for example. Please refer to the `Ufe` pull request [#302](https://git.autodesk.com/media-and-entertainment/ufe/pull/302).

The pull request implements the `Ufe` pull request [#309](https://git.autodesk.com/media-and-entertainment/ufe/pull/309).

As the changes only consists to slightly refactor some existing code there are no associated unit tests.