### PR TITLE
MAYA-125895 transfer state from root layer when toggling shareable stage

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -627,7 +627,7 @@ void reproduceSharedStageState(
         return;
     if (!TF_VERIFY(unsharedRootLayer))
         return;
-        
+
     // Transfer the FPS (frames-per-second) of the original root layer to the new unshared
     // root layer, so that the animation timeline does not change. We copy both the metadata
     // on the layer and on the stage object itself.

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -617,20 +617,24 @@ void remapSublayerRecursive(
 }
 
 void reproduceSharedStageState(
-    const UsdStageRefPtr& finalUsdStage,
-    const SdfLayerRefPtr& inRootLayer,
-    const SdfLayerRefPtr& unsharedStageRootLayer)
+    const UsdStageRefPtr& stage,
+    const SdfLayerRefPtr& sharedRootLayer,
+    const SdfLayerRefPtr& unsharedRootLayer)
 {
+    if (!TF_VERIFY(stage))
+        return;
+    if (!TF_VERIFY(sharedRootLayer))
+        return;
+    if (!TF_VERIFY(unsharedRootLayer))
+        return;
+        
     // Transfer the FPS (frames-per-second) of the original root layer to the new unshared
     // root layer, so that the animation timeline does not change. We copy both the metadata
     // on the layer and on the stage object itself.
-    if (SdfDataRefPtr metadata = inRootLayer->GetMetadata()) {
-        VtValue fpsValue;
-        if (metadata->Has(SdfPath("/"), TfToken("framesPerSecond"), &fpsValue)) {
-            unsharedStageRootLayer->GetMetadata()->Set(
-                SdfPath("/"), TfToken("framesPerSecond"), fpsValue);
-            finalUsdStage->SetFramesPerSecond(fpsValue.Get<double>());
-        }
+    if (sharedRootLayer->HasFramesPerSecond()) {
+        const double fps = sharedRootLayer->GetFramesPerSecond();
+        unsharedRootLayer->SetFramesPerSecond(fps);
+        stage->SetFramesPerSecond(fps);
     }
 }
 

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -616,6 +616,24 @@ void remapSublayerRecursive(
     }
 }
 
+void reproduceSharedStageState(
+    const UsdStageRefPtr& finalUsdStage,
+    const SdfLayerRefPtr& inRootLayer,
+    const SdfLayerRefPtr& unsharedStageRootLayer)
+{
+    // Transfer the FPS (frames-per-second) of the original root layer to the new unshared
+    // root layer, so that the animation timeline does not change. We copy both the metadata
+    // on the layer and on the stage object itself.
+    if (SdfDataRefPtr metadata = inRootLayer->GetMetadata()) {
+        VtValue fpsValue;
+        if (metadata->Has(SdfPath("/"), TfToken("framesPerSecond"), &fpsValue)) {
+            unsharedStageRootLayer->GetMetadata()->Set(
+                SdfPath("/"), TfToken("framesPerSecond"), fpsValue);
+            finalUsdStage->SetFramesPerSecond(fpsValue.Get<double>());
+        }
+    }
+}
+
 } // namespace
 
 MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
@@ -948,6 +966,12 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
 
         unsharedUsdStage = getUnsharedStage(loadSet);
         finalUsdStage = unsharedUsdStage;
+
+        // Transfer data of the original root layer to the new unshared root layer,
+        // so that some user-visible state does not change. For example, we need to
+        // transfer the FPS (frames-per-second) metadata so that the animations play
+        // at the same rate.
+        reproduceSharedStageState(finalUsdStage, inRootLayer, _unsharedStageRootLayer);
     }
 
     if (finalUsdStage) {


### PR DESCRIPTION
Currently, we reproduce the FPS (frames-per-second) of the shared root layer to the
newly-created unshared root layer so that the animation playback speed stays consistent.                                                                                         