### PR TITLE
MAYA-125897 support duplicate xform ops

### DIFF
--- a/lib/mayaUsd/fileio/transformWriter.cpp
+++ b/lib/mayaUsd/fileio/transformWriter.cpp
@@ -260,6 +260,35 @@ bool UsdMayaTransformWriter::_GatherAnimChannel(
     return false;
 }
 
+void
+UsdMayaTransformWriter::_MakeAnimChannelsUnique(const UsdGeomXformable& usdXformable)
+{
+    using OpName = TfToken;
+    std::set<OpName>     existingOps;
+    bool                 xformReset = false;
+    for (const UsdGeomXformOp& op : usdXformable.GetOrderedXformOps(&xformReset)) {
+        existingOps.emplace(op.GetOpName());
+    }
+
+    if (existingOps.size() == 0)
+        return;
+
+    for (_AnimChannel& channel : _animChannels) {
+        // We will put a upper limit on the number of similar transform operations
+        // that a prim can use. Having 1000 separate translations on a single prim
+        // seems both generous. Having more is highly improbable.
+        for (int suffixIndex = 1; suffixIndex < 1000; ++suffixIndex) {
+            TfToken channelOpName
+                = UsdGeomXformOp::GetOpName(channel.usdOpType, channel.opName, channel.isInverse);
+            if (existingOps.count(channelOpName) == 0)
+                break;
+            std::ostringstream oss;
+            oss << "channel" << suffixIndex;
+            channel.opName = TfToken(oss.str());
+        }
+    }
+}
+
 void UsdMayaTransformWriter::_PushTransformStack(
     const MFnTransform&     iTrans,
     const UsdGeomXformable& usdXformable,
@@ -476,6 +505,8 @@ void UsdMayaTransformWriter::_PushTransformStack(
             _animChannels.erase(_animChannels.begin() + rotPivotINVIdx);
         }
     }
+
+    _MakeAnimChannelsUnique(usdXformable);
 
     // Loop over anim channel vector and create corresponding XFormOps
     // including the inverse ones if needed

--- a/lib/mayaUsd/fileio/transformWriter.h
+++ b/lib/mayaUsd/fileio/transformWriter.h
@@ -118,6 +118,11 @@ private:
         const bool                 isWritingAnimation,
         const bool                 setOpName);
 
+    // Change the channel suffix so that the USD XformOp becomes unique.
+    // This is to deal with complex rigs that can have multiple transforms
+    // affecting the same transform operation on the same UsdGeomXformable.
+    void _MakeAnimChannelsUnique(const UsdGeomXformable& usdXformable);
+
     /// Populates the AnimChannel vector with various ops based on
     /// the Maya transformation logic. If scale and/or rotate pivot are
     /// declared, creates inverse ops in the appropriate order.


### PR DESCRIPTION
When a complex rig controls geometry, it is possible that the USD exporter will author a given transform operation (for example, translate) multiple times on a single USD trasformable geometry. The old exporter code would try to create the same USD transform operation, which would fail. Instead, we now detect that a transform operation already has an instance and create new ones with a suffix for each extra duplicate op.

A limit of 1000 instances of a given transform op has been set. It seems unlikely that any single geometry will have more than 1000 direct operations applied to it at the same times. (This number does not count indirect transform from parents.)