### PR TITLE
MAYA-123716 - Duplicated prim to be on the Display Layer that the source prim was on

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
@@ -31,6 +31,7 @@
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
 
+#include <ufe/hierarchy.h>
 #include <ufe/log.h>
 #include <ufe/path.h>
 #include <ufe/scene.h>
@@ -78,6 +79,10 @@ void UsdUndoDuplicateCommand::execute()
     auto path = prim.GetPath();
     auto stage = prim.GetStage();
 
+    auto                               item = Ufe::Hierarchy::createItem(_ufeSrcPath);
+    MayaUsd::ufe::ReplicateExtrasToUSD extras;
+    extras.initRecursive(item);
+
     // The loaded state of a model is controlled by the load rules of the stage.
     // When duplicating a node, we want the new node to be in the same loaded
     // state.
@@ -89,6 +94,9 @@ void UsdUndoDuplicateCommand::execute()
         "Failed to copy spec data at '%s' to '%s'",
         prim.GetPath().GetText(),
         _usdDstPath.GetText());
+
+    auto duplicatedName = duplicatedItem()->path().back().string();
+    extras.finalize(MayaUsd::ufe::stagePath(prim.GetStage()), &duplicatedName);
 }
 
 void UsdUndoDuplicateCommand::undo()

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -238,6 +238,7 @@ class ReplicateExtrasFromUSD
 public:
     // Prepares the replication operation for the subtree starting with the given scene item
     void initRecursive(Ufe::SceneItem::Ptr) const;
+
     // Replicates extra features from the USD item defined by 'path' to the maya object
     void processItem(const Ufe::Path& path, const MObject& mayaObject) const;
 
@@ -251,6 +252,10 @@ public:
     // Processes replication from a maya object defined by 'dagPath'
     // to the usd item defined by 'usdPath'
     void processItem(const MDagPath& dagPath, const PXR_NS::SdfPath& usdPath) const;
+
+    // Prepares the replication operation for the subtree starting at the given scene item.
+    void initRecursive(const Ufe::SceneItem::Ptr& item) const;
+
     // Finalizes the replication operation to the USD stage defined by 'stagePath'
     // with a possibility to rename the usd root node name to 'renameRoot'
     void finalize(const Ufe::Path& stagePath, const std::string* renameRoot = nullptr) const;


### PR DESCRIPTION
#### MAYA-123716 - Duplicated prim to be on the Display Layer that the source prim was on
* Use new MayaUsd::ufe::ReplicateExtrasToUSD helper class to perform dupication of Display Layer (USD -> USD).