### PR TITLE
MAYA-125895 Handle timecodes-per-second when flipping shared state

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -636,6 +636,13 @@ void reproduceSharedStageState(
         unsharedRootLayer->SetFramesPerSecond(fps);
         stage->SetFramesPerSecond(fps);
     }
+
+    // Transfer the TCPS (timecodes-per-second) for the same reason as above.
+    if (sharedRootLayer->HasTimeCodesPerSecond()) {
+        const double tcps = sharedRootLayer->GetTimeCodesPerSecond();
+        unsharedRootLayer->SetTimeCodesPerSecond(tcps);
+        stage->SetTimeCodesPerSecond(tcps);
+    }
 }
 
 } // namespace

--- a/test/lib/mayaUsd/nodes/testProxyShapeBase.py
+++ b/test/lib/mayaUsd/nodes/testProxyShapeBase.py
@@ -350,6 +350,50 @@ class testProxyShapeBase(unittest.TestCase):
         self.assertEqual(stage.GetFramesPerSecond(), fps)
         self.assertEqual(stage.GetRootLayer().framesPerSecond, fps)
 
+    def testShareStagePreserveTCPS(self):
+        '''
+        Verify share/unshare stage preserve the TCPS metadata of the stage.
+        '''
+        # create new stage
+        cmds.file(new=True, force=True)
+
+        # Open usdCylinder.ma scene in testSamples
+        mayaUtils.openCylinderScene()
+
+        # get the stage
+        proxyShapes = cmds.ls(type="mayaUsdProxyShapeBase", long=True)
+        proxyShapePath = proxyShapes[0]
+        stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
+        stage.GetRootLayer().identifier
+
+        # Set an unusual TCPS on the stage.
+        tcps = 35.0
+        stage.SetTimeCodesPerSecond(tcps)
+        stage.GetRootLayer().timeCodesPerSecond = tcps
+
+        # Check that the stage TCPS is 35.
+        self.assertEqual(stage.GetTimeCodesPerSecond(), tcps)
+        self.assertEqual(stage.GetRootLayer().timeCodesPerSecond, tcps)
+
+        # Unshare the stage
+        cmds.setAttr('{}.{}'.format(proxyShapePath,"shareStage"), False)
+        stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
+        rootLayer = stage.GetRootLayer()
+
+        # Check that the stage is now unshared and the TCPS is still 35.
+        self.assertFalse(cmds.getAttr('{}.{}'.format(proxyShapePath,"shareStage")))
+        self.assertEqual(stage.GetTimeCodesPerSecond(), tcps)
+        self.assertEqual(stage.GetRootLayer().timeCodesPerSecond, tcps)
+
+        # Re-share the stage
+        cmds.setAttr('{}.{}'.format(proxyShapePath,"shareStage"), True)
+        stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
+
+        # Check that the stage is now shared again and the TCPS is the same.
+        self.assertTrue(cmds.getAttr('{}.{}'.format(proxyShapePath,"shareStage")))
+        self.assertEqual(stage.GetTimeCodesPerSecond(), tcps)
+        self.assertEqual(stage.GetRootLayer().timeCodesPerSecond, tcps)
+
     def testShareStagePreserveSession(self):
         '''
         Verify share/unshare stage preserves the data in the session layer


### PR DESCRIPTION
Tramsfer the timecodes-per-second when flipping shared flag on a stage.