### PR TITLE
MAYA-125954 USD import command support prim variants

### DIFF
--- a/lib/mayaUsd/commands/baseImportCommand.cpp
+++ b/lib/mayaUsd/commands/baseImportCommand.cpp
@@ -201,9 +201,9 @@ MStatus MayaUSDImportCommand::doIt(const MArgList& args)
     for (unsigned int i = 0; i < nbFlags; ++i) {
         MArgList tmpArgList;
         status = argData.getFlagArgumentList(kPrimVariantFlag, i, tmpArgList);
-        PXR_NS::SdfPath primPath{ tmpArgList.asString(0, &status).asChar() };
-        std::string variantName{ tmpArgList.asString(1, &status).asChar() };
-        std::string variantSel{ tmpArgList.asString(2, &status).asChar() };
+        PXR_NS::SdfPath primPath { tmpArgList.asString(0, &status).asChar() };
+        std::string     variantName { tmpArgList.asString(1, &status).asChar() };
+        std::string     variantSel { tmpArgList.asString(2, &status).asChar() };
         primVariants[primPath].emplace(variantName, variantSel);
     }
 

--- a/lib/mayaUsd/commands/baseImportCommand.h
+++ b/lib/mayaUsd/commands/baseImportCommand.h
@@ -64,8 +64,10 @@ public:
     static constexpr auto kFrameRangeFlagLong = "frameRange";
     static constexpr auto kPrimPathFlag = "pp";
     static constexpr auto kPrimPathFlagLong = "primPath";
-    static constexpr auto kVariantFlag = "var";
-    static constexpr auto kVariantFlagLong = "variant";
+    static constexpr auto kRootVariantFlag = "var";
+    static constexpr auto kRootVariantFlagLong = "variant";
+    static constexpr auto kPrimVariantFlag = "pv";
+    static constexpr auto kPrimVariantFlagLong = "primVariant";
     static constexpr auto kVerboseFlag = "v";
     static constexpr auto kVerboseFlagLong = "verbose";
 

--- a/test/lib/usd/translators/UsdImportSessionLayerTest/Cubes.usda
+++ b/test/lib/usd/translators/UsdImportSessionLayerTest/Cubes.usda
@@ -18,7 +18,12 @@ def Xform "Cubes" (
 
     def Xform "Geom"
     {
-        def Mesh "CubeOne"
+        def Mesh "CubeOne" (
+            variants = {
+                string displacement = "none"
+            }
+            add variantSets = "displacement"
+        )
         {
             float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
             int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
@@ -34,8 +39,18 @@ def Xform "Cubes" (
             texCoord2f[] primvars:st = [(0.375, 0), (0.625, 0), (0.625, 0.25), (0.375, 0.25), (0.375, 0.25), (0.625, 0.25), (0.625, 0.5), (0.375, 0.5), (0.375, 0.5), (0.625, 0.5), (0.625, 0.75), (0.375, 0.75), (0.375, 0.75), (0.625, 0.75), (0.625, 1), (0.375, 1), (0.625, 0), (0.875, 0), (0.875, 0.25), (0.625, 0.25), (0.125, 0), (0.375, 0), (0.375, 0.25), (0.125, 0.25)] (
                 interpolation = "faceVarying"
             )
-            double3 xformOp:translate = (-2, 0, 0.5)
+
             uniform token[] xformOpOrder = ["xformOp:translate"]
+
+            variantSet "displacement" = {
+                "none" {
+                    double3 xformOp:translate = (-2, 0, 0.5)
+                }
+
+                "moved" {
+                    double3 xformOp:translate = (20, 10, 50)
+                }
+            }
         }
 
         def Mesh "CubeTwo"


### PR DESCRIPTION
- Add a new -primVariant (-pv) flag to the mayaUSDimport command.
- Takes three argument: prim path, variant name, variant selection.
- Can be repeated.
- Extended an existing unit test to test it.