### PR TITLE
MAYA-125275 preserve the layer manager expanded layers

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeView.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeView.cpp
@@ -166,6 +166,8 @@ void LayerViewMemento::restore(LayerTreeView& view, LayerTreeModel& model)
 {
     const LayerItemVector items = model.getAllItems();
 
+    QtDisableRepaintUpdates disableUpdates(view);
+
     for (const LayerTreeItem* item : items) {
         if (!item)
             continue;
@@ -177,7 +179,7 @@ void LayerViewMemento::restore(LayerTreeView& view, LayerTreeModel& model)
             const ItemId id = layer->GetIdentifier();
             const auto   state = itemsState.find(id);
             if (state != itemsState.end()) {
-                expanded = state->second.expanded;
+                expanded = state->second._expanded;
             }
         }
 

--- a/lib/usd/ui/layerEditor/layerTreeView.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeView.cpp
@@ -158,7 +158,7 @@ void LayerViewMemento::preserve(const LayerTreeView& view, const LayerTreeModel&
         const ItemId    id = layer->GetIdentifier();
         const ItemState state = { view.isExpanded(item->index()) };
 
-        itemsState[id] = state;
+        _itemsState[id] = state;
     }
 }
 
@@ -177,8 +177,8 @@ void LayerViewMemento::restore(LayerTreeView& view, LayerTreeModel& model)
         PXR_NS::SdfLayerRefPtr layer = item->layer();
         if (layer) {
             const ItemId id = layer->GetIdentifier();
-            const auto   state = itemsState.find(id);
-            if (state != itemsState.end()) {
+            const auto   state = _itemsState.find(id);
+            if (state != _itemsState.end()) {
                 expanded = state->second._expanded;
             }
         }

--- a/lib/usd/ui/layerEditor/layerTreeView.h
+++ b/lib/usd/ui/layerEditor/layerTreeView.h
@@ -31,10 +31,36 @@ namespace UsdLayerEditor {
 class LayerTreeItem;
 class LayerTreeItemDelegate;
 class LayerTreeModel;
+class LayerTreeView;
 class SessionState;
 
 typedef std::vector<LayerTreeItem*> LayerItemVector;
 typedef void (LayerTreeItem::*simpleLayerMethod)();
+
+/**
+ * @brief State of the layer tree view and layer model.
+ * Used to save and restore the state when the model is rebuilt.
+ *
+ */
+class LayerViewMemento
+{
+public:
+    LayerViewMemento(const LayerTreeView&, const LayerTreeModel&);
+
+    void preserve(const LayerTreeView&, const LayerTreeModel&);
+    void restore(LayerTreeView&, LayerTreeModel&);
+
+    bool empty() const { return itemsState.empty(); }
+
+private:
+    using ItemId = std::string;
+    struct ItemState
+    {
+        bool expanded = false;
+    };
+
+    std::map<ItemId, ItemState> itemsState;
+};
 
 /**
  * @brief Implements the Qt TreeView for USD layers. This widget is owned by the LayerEditorWidget.
@@ -82,6 +108,7 @@ public:
 
 protected:
     // slot:
+    void onModelAboutToBeReset();
     void onModelReset();
     void onItemDoubleClicked(const QModelIndex& index);
     void onMuteLayerButtonPushed();
@@ -92,6 +119,8 @@ protected:
     LayerTreeViewStyle       _treeViewStyle;
     QPointer<LayerTreeModel> _model;
     LayerTreeItemDelegate*   _delegate;
+
+    std::unique_ptr<LayerViewMemento> _cachedModelState;
 
     void handleTooltips(QHelpEvent* event);
 

--- a/lib/usd/ui/layerEditor/layerTreeView.h
+++ b/lib/usd/ui/layerEditor/layerTreeView.h
@@ -56,7 +56,7 @@ private:
     using ItemId = std::string;
     struct ItemState
     {
-        bool expanded = false;
+        bool _expanded = false;
     };
 
     std::map<ItemId, ItemState> itemsState;

--- a/lib/usd/ui/layerEditor/layerTreeView.h
+++ b/lib/usd/ui/layerEditor/layerTreeView.h
@@ -50,7 +50,7 @@ public:
     void preserve(const LayerTreeView&, const LayerTreeModel&);
     void restore(LayerTreeView&, LayerTreeModel&);
 
-    bool empty() const { return itemsState.empty(); }
+    bool empty() const { return _itemsState.empty(); }
 
 private:
     using ItemId = std::string;
@@ -59,7 +59,7 @@ private:
         bool _expanded = false;
     };
 
-    std::map<ItemId, ItemState> itemsState;
+    std::map<ItemId, ItemState> _itemsState;
 };
 
 /**

--- a/lib/usd/ui/layerEditor/qtUtils.cpp
+++ b/lib/usd/ui/layerEditor/qtUtils.cpp
@@ -62,4 +62,23 @@ QWidget* QtUtils::fixedWidget(QWidget* widget)
     return widget;
 }
 
+QtDisableRepaintUpdates::QtDisableRepaintUpdates(QWidget& widget)
+: _widget(widget)
+{
+    widget.setUpdatesEnabled(false);
+}
+
+QtDisableRepaintUpdates::~QtDisableRepaintUpdates()
+{
+    try
+    {
+        // Note: re-enabling updates automatically triggers a repaint.
+        _widget.setUpdatesEnabled(true);
+    }
+    catch (std::exception&)
+    {
+        // Don't let exceptions out of destructor.
+    }
+}
+
 } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/qtUtils.cpp
+++ b/lib/usd/ui/layerEditor/qtUtils.cpp
@@ -63,20 +63,17 @@ QWidget* QtUtils::fixedWidget(QWidget* widget)
 }
 
 QtDisableRepaintUpdates::QtDisableRepaintUpdates(QWidget& widget)
-: _widget(widget)
+    : _widget(widget)
 {
     widget.setUpdatesEnabled(false);
 }
 
 QtDisableRepaintUpdates::~QtDisableRepaintUpdates()
 {
-    try
-    {
+    try {
         // Note: re-enabling updates automatically triggers a repaint.
         _widget.setUpdatesEnabled(true);
-    }
-    catch (std::exception&)
-    {
+    } catch (std::exception&) {
         // Don't let exceptions out of destructor.
     }
 }

--- a/lib/usd/ui/layerEditor/qtUtils.h
+++ b/lib/usd/ui/layerEditor/qtUtils.h
@@ -54,7 +54,7 @@ public:
 };
 
 /**
- * @brief Disable repaint updates for the given widget until the disabler is destoryed.
+ * @brief Disable repaint updates for the given widget until the disabler is destroyed.
  *
  */
 class QtDisableRepaintUpdates

--- a/lib/usd/ui/layerEditor/qtUtils.h
+++ b/lib/usd/ui/layerEditor/qtUtils.h
@@ -53,6 +53,20 @@ public:
     }
 };
 
+/**
+ * @brief Disable repaint updates for the given widget until the disabler is destoryed.
+ *
+ */
+class QtDisableRepaintUpdates
+{
+public:
+    QtDisableRepaintUpdates(QWidget& widget);
+    ~QtDisableRepaintUpdates();
+
+private:
+    QWidget& _widget;
+};
+
 #ifdef Q_OS_DARWIN
 const bool IS_MAC_OS = true;
 #else


### PR DESCRIPTION
When the layer manager model is rebuilt, preserve the state of the layer view (currently, only the expanded state of each layer) so that it can be restored once the model rebuilt is done.

- Add a LayerViewMemento to preserve the view state.
- Provide a preserve() and restore() method to save and restorethe state.
- Provide an empty method to avoid losing state when multiple calls to About-to-reset are made.
- Preserve befor ethe model reset, restore after.
- Note that, yes Qt emits the signal multiple times when the model is reset, so we have to take that into accouunt.