### PR TITLE
MAYA-126117 - Point instancer: performance drop on point instanced selection.

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
@@ -700,7 +700,9 @@ void MayaUsdRPrim::_UpdatePrimvarSourcesGeneric(
 }
 
 #ifdef MAYA_HAS_DISPLAY_LAYER_API
-void MayaUsdRPrim::_ProcessDisplayLayerModes(const MObject& displayLayerObj, DisplayLayerModes& displayLayerModes)
+void MayaUsdRPrim::_ProcessDisplayLayerModes(
+    const MObject&     displayLayerObj,
+    DisplayLayerModes& displayLayerModes)
 {
     MFnDependencyNode displayLayerNodeFn(displayLayerObj);
     MPlug             layerEnabled = displayLayerNodeFn.findPlug("enabled");
@@ -742,10 +744,10 @@ void MayaUsdRPrim::_ProcessDisplayLayerModes(const MObject& displayLayerObj, Dis
 }
 
 void MayaUsdRPrim::_PopulateDisplayLayerModes(
-    const SdfPath& usdPath,
-    DisplayLayerModes& displayLayerModes,
+    const SdfPath&       usdPath,
+    DisplayLayerModes&   displayLayerModes,
     ProxyRenderDelegate& drawScene)
-{        
+{
     displayLayerModes = DisplayLayerModes();
 
     // First, process the hierarchy of usd paths
@@ -768,7 +770,10 @@ void MayaUsdRPrim::_PopulateDisplayLayerModes(
     }
 }
 #else
-void MayaUsdRPrim::_PopulateDisplayLayerModes(const SdfPath&, DisplayLayerModes& displayLayerModes, ProxyRenderDelegate&)
+void MayaUsdRPrim::_PopulateDisplayLayerModes(
+    const SdfPath&,
+    DisplayLayerModes& displayLayerModes,
+    ProxyRenderDelegate&)
 {
     displayLayerModes = DisplayLayerModes();
 }
@@ -805,7 +810,7 @@ void MayaUsdRPrim::_SyncDisplayLayerModesInstanced(SdfPath const& id, unsigned i
     if (drawScene.SupportPerInstanceDisplayLayers(id)) {
         _displayLayerModesInstanced.resize(instanceCount);
         for (unsigned int usdInstanceId = 0; usdInstanceId < instanceCount; usdInstanceId++) {
-            auto usdPath = drawScene.GetScenePrimPath(id, usdInstanceId);
+            auto  usdPath = drawScene.GetScenePrimPath(id, usdInstanceId);
             auto& displayLayerModes = _displayLayerModesInstanced[usdInstanceId];
             _PopulateDisplayLayerModes(usdPath, displayLayerModes, drawScene);
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -213,8 +213,11 @@ protected:
         MColor _wireframeColorRGBA;
     };
 
+    static void 
+    _ProcessDisplayLayerModes(const MObject& displayLayerObj, DisplayLayerModes& displayLayerModes);
+
     static void
-    _PopulateDisplayLayerModes(const MString& pathString, DisplayLayerModes& displayLayerModes);
+    _PopulateDisplayLayerModes(const SdfPath& usdPath, DisplayLayerModes& displayLayerModes, ProxyRenderDelegate& drawScene);
 
     static HdReprSharedPtr _FindRepr(const ReprVector& reprs, const TfToken& reprToken);
 
@@ -260,7 +263,7 @@ protected:
         ReprVector const&  reprs,
         TfToken const&     renderTag);
 
-    void _SyncDisplayLayerModes();
+    void _SyncDisplayLayerModes(SdfPath const& id);
     void _SyncDisplayLayerModesInstanced(SdfPath const& id, unsigned int instanceCount);
 
     bool _ShouldSkipInstance(unsigned int usdInstanceId, const TfToken& reprToken) const;

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -342,6 +342,7 @@ protected:
     DisplayLayerModes              _displayLayerModes;
     std::vector<DisplayLayerModes> _displayLayerModesInstanced;
     uint64_t                       _displayLayerModesFrame { 0 };
+    uint64_t                       _displayLayerModesInstancedFrame { 0 };
 
     // forced representations runtime state
     bool     _needForcedBBox = false;

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.h
@@ -213,11 +213,13 @@ protected:
         MColor _wireframeColorRGBA;
     };
 
-    static void 
+    static void
     _ProcessDisplayLayerModes(const MObject& displayLayerObj, DisplayLayerModes& displayLayerModes);
 
-    static void
-    _PopulateDisplayLayerModes(const SdfPath& usdPath, DisplayLayerModes& displayLayerModes, ProxyRenderDelegate& drawScene);
+    static void _PopulateDisplayLayerModes(
+        const SdfPath&       usdPath,
+        DisplayLayerModes&   displayLayerModes,
+        ProxyRenderDelegate& drawScene);
 
     static HdReprSharedPtr _FindRepr(const ReprVector& reprs, const TfToken& reprToken);
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -337,16 +337,18 @@ public:
         }
 #else
         if (auto objectRenamed = dynamic_cast<const Ufe::ObjectRename*>(&notification)) {
-            _proxyRenderDelegate.DisplayLayerPathChanged(objectRenamed->previousPath(), objectRenamed->item()->path());
-        }
-        else if (auto objectReparented = dynamic_cast<const Ufe::ObjectReparent*>(&notification)) {
-            _proxyRenderDelegate.DisplayLayerPathChanged(objectReparented->previousPath(), objectReparented->item()->path());
-        }
-        else if (auto compositeNotification = dynamic_cast<const Ufe::SceneCompositeNotification*>(&notification)) {
-            for (const auto &op : compositeNotification->opsList())
-            {
-                if (op.opType == Ufe::SceneCompositeNotification::OpType::ObjectRename || 
-                    op.opType == Ufe::SceneCompositeNotification::OpType::ObjectReparent) {
+            _proxyRenderDelegate.DisplayLayerPathChanged(
+                objectRenamed->previousPath(), objectRenamed->item()->path());
+        } else if (
+            auto objectReparented = dynamic_cast<const Ufe::ObjectReparent*>(&notification)) {
+            _proxyRenderDelegate.DisplayLayerPathChanged(
+                objectReparented->previousPath(), objectReparented->item()->path());
+        } else if (
+            auto compositeNotification
+            = dynamic_cast<const Ufe::SceneCompositeNotification*>(&notification)) {
+            for (const auto& op : compositeNotification->opsList()) {
+                if (op.opType == Ufe::SceneCompositeNotification::OpType::ObjectRename
+                    || op.opType == Ufe::SceneCompositeNotification::OpType::ObjectReparent) {
                     _proxyRenderDelegate.DisplayLayerPathChanged(op.path, op.item->path());
                 }
             }
@@ -371,8 +373,8 @@ public:
     void handleSceneOp(const Ufe::SceneCompositeNotification::Op& op)
     {
         if (op.opType == Ufe::SceneChanged::ObjectPathChange) {
-            if (op.subOpType == Ufe::ObjectPathChange::ObjectReparent || 
-                op.subOpType == Ufe::ObjectPathChange::ObjectRename) {
+            if (op.subOpType == Ufe::ObjectPathChange::ObjectReparent
+                || op.subOpType == Ufe::ObjectPathChange::ObjectRename) {
                 _proxyRenderDelegate.DisplayLayerPathChanged(op.path, op.item->path());
             }
         }

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -321,6 +321,19 @@ public:
 
     void operator()(const Ufe::Notification& notification) override
     {
+        // Handle path change notifications here
+        if (const auto sceneChanged = dynamic_cast<const Ufe::SceneChanged*>(&notification)) {
+            if (Ufe::SceneChanged::SceneCompositeNotification == sceneChanged->opType()) {
+                const auto& compNotification = notification.staticCast<Ufe::SceneCompositeNotification>();
+                for (const auto& op : compNotification) {
+                    handleSceneOp(op);
+                }
+            } else {
+                handleSceneOp(*sceneChanged);
+            }
+        }
+
+        // Handle selection change notifications here
         // During Maya file read, each node will be selected in turn, so we get
         // notified for each node in the scene.  Prune this out.
         if (MFileIO::isOpeningFile()) {
@@ -332,6 +345,14 @@ public:
             _proxyRenderDelegate.SelectionChanged();
         }
     }
+
+    void handleSceneOp(const Ufe::SceneCompositeNotification::Op& op) {
+        if (op.opType == Ufe::SceneChanged::ObjectPathChange) {
+#ifdef MAYA_HAS_DISPLAY_LAYER_API
+          _proxyRenderDelegate.DisplayLayerPathChanged(op.path, op.item->path());  
+#endif
+        }
+    }    
 
 private:
     ProxyRenderDelegate& _proxyRenderDelegate;
@@ -684,12 +705,14 @@ void ProxyRenderDelegate::_InitRenderDelegate()
 #endif
 
 #ifdef MAYA_HAS_DISPLAY_LAYER_API
-        // Display layers maybe loaded before us, so make sure to track them
+        // Display layers maybe loaded before us, so make sure to track/cache them
+        _usdStageDisplayLayersDirty = true;
         MFnDisplayLayerManager displayLayerManager(
             MFnDisplayLayerManager::currentDisplayLayerManager());
         auto layers = displayLayerManager.getAllDisplayLayers();
         for (unsigned int j = 0; j < layers.length(); ++j) {
             DisplayLayerAdded(layers[j], this);
+            AddDisplayLayerToCache(layers[j]);
         }
 
         // Monitor display layers
@@ -897,34 +920,47 @@ void ProxyRenderDelegate::_DirtyUsdSubtree(const UsdPrim& prim)
     }
 }
 
-void ProxyRenderDelegate::_DirtyUfeSubtree(const Ufe::Path& rootPath)
+bool ProxyRenderDelegate::_DirtyUfeSubtree(const Ufe::Path& rootPath)
 {
+    Ufe::Path proxyShapePath = MayaUsd::ufe::stagePath(_proxyShapeData->UsdStage());
     if (rootPath.runTimeId() == MayaUsd::ufe::getUsdRunTimeId()) {
-        _DirtyUsdSubtree(MayaUsd::ufe::ufePathToPrim(rootPath));
-    } else {
-        for (const auto& stage : MayaUsd::ufe::getAllStages()) {
-            Ufe::Path proxyShapePath = MayaUsd::ufe::stagePath(stage);
-            if (proxyShapePath.startsWith(rootPath)) {
-                _DirtyUsdSubtree(stage->GetPseudoRoot());
-            }
+        if (rootPath.startsWith(proxyShapePath)) {
+            _DirtyUsdSubtree(MayaUsd::ufe::ufePathToPrim(rootPath));
+            return true;
+        }
+    } else if (rootPath.runTimeId() == MayaUsd::ufe::getMayaRunTimeId()) {
+        if (proxyShapePath.startsWith(rootPath)) {
+            _DirtyUsdSubtree(_proxyShapeData->UsdStage()->GetPseudoRoot());
+            return true;
         }
     }
+
+    return false;
 }
 
-void ProxyRenderDelegate::_DirtyUfeSubtree(const MString& rootStr)
+bool _StringToUfePath(const MString& str, Ufe::Path& path)
 {
-    Ufe::Path rootPath;
     try {
-        rootPath = Ufe::PathString::path(rootStr.asChar());
+        path = Ufe::PathString::path(str.asChar());
     } catch (const Ufe::InvalidPath&) {
-        return;
+        return false;
     } catch (const Ufe::InvalidPathComponentSeparator&) {
-        return;
+        return false;
     } catch (const Ufe::EmptyPathSegment&) {
-        return;
+        return false;
     }
 
-    _DirtyUfeSubtree(rootPath);
+    return true;
+}
+
+bool ProxyRenderDelegate::_DirtyUfeSubtree(const MString& rootStr)
+{
+    Ufe::Path rootPath;
+    if (_StringToUfePath(rootStr, rootPath)) {
+        return _DirtyUfeSubtree(rootPath);
+    }
+
+    return false;
 }
 #endif
 
@@ -986,6 +1022,10 @@ void ProxyRenderDelegate::_Execute(const MHWRender::MFrameContext& frameContext)
     _refreshRequested = false;
 
     _UpdateRenderTags();
+
+#ifdef MAYA_HAS_DISPLAY_LAYER_API
+    UpdateProxyShapeDisplayLayers();
+#endif
 
     // If update for selection is enabled, the draw data for the "points" repr
     // won't be prepared until point snapping is activated; otherwise the draw
@@ -1241,15 +1281,6 @@ SdfPath ProxyRenderDelegate::GetScenePrimPath(const SdfPath& rprimId, int instan
 #endif
 
     return usdPath;
-}
-
-MString ProxyRenderDelegate::GetUfePathPrefix() const
-{
-#if defined(WANT_UFE_BUILD)
-    return GetProxyShapeDagPath().fullPathName() + MayaUsd::ufe::pathSegmentSeparator().c_str();
-#else
-    return MString();
-#endif
 }
 
 //! \brief  Selection for both instanced and non-instanced cases.
@@ -1508,8 +1539,37 @@ void ProxyRenderDelegate::DisplayLayerRemoved(MObject& node, void* clientData)
 //! \brief  Notify of display layer membership change.
 void ProxyRenderDelegate::DisplayLayerMembershipChanged(const MString& memberPath)
 {
-    _DirtyUfeSubtree(memberPath);
-    _RequestRefresh();
+    Ufe::Path path;
+    if (!_StringToUfePath(memberPath, path)) {
+        return;
+    }
+
+    // First, update the caches
+    Ufe::Path proxyShapePath = MayaUsd::ufe::stagePath(_proxyShapeData->UsdStage());
+    if (path.runTimeId() == MayaUsd::ufe::getUsdRunTimeId()) {
+        if (path.startsWith(proxyShapePath) && path.nbSegments() > 1) {
+            MFnDisplayLayerManager displayLayerManager(
+                MFnDisplayLayerManager::currentDisplayLayerManager());
+            
+            SdfPath usdPath(path.getSegments()[1].string());
+            MObject displayLayerObj = displayLayerManager.getLayer(memberPath);
+            if (displayLayerObj.hasFn(MFn::kDisplayLayer) && 
+                    MFnDisplayLayer(displayLayerObj).name() != "defaultLayer") {
+                _usdPathToDisplayLayerMap[usdPath] = displayLayerObj;
+            } else {
+                _usdPathToDisplayLayerMap.erase(usdPath);
+            }
+        }
+    } else if (path.runTimeId() == MayaUsd::ufe::getMayaRunTimeId()) {
+        if (proxyShapePath.startsWith(path)) {
+            _usdStageDisplayLayersDirty = true;
+        }
+    }
+
+    // Then, dirty the subtree
+    if (_DirtyUfeSubtree(path)) {
+        _RequestRefresh();
+    }
 }
 
 void ProxyRenderDelegate::DisplayLayerDirty(MFnDisplayLayer& displayLayer)
@@ -1517,25 +1577,118 @@ void ProxyRenderDelegate::DisplayLayerDirty(MFnDisplayLayer& displayLayer)
     MSelectionList members;
     displayLayer.getMembers(members);
 
+    bool subtreeDirtied = false;
     auto membersCount = members.length();
     for (unsigned int j = 0; j < membersCount; ++j) {
         MDagPath dagPath;
         if (members.getDagPath(j, dagPath) == MS::kSuccess) {
-            _DirtyUfeSubtree(MayaUsd::ufe::dagPathToUfe(dagPath));
+            subtreeDirtied |= _DirtyUfeSubtree(MayaUsd::ufe::dagPathToUfe(dagPath));
         } else {
             MStringArray selectionStrings;
             members.getSelectionStrings(j, selectionStrings);
             for (auto it = selectionStrings.begin(); it != selectionStrings.end(); ++it) {
-                _DirtyUfeSubtree(*it);
+                subtreeDirtied |= _DirtyUfeSubtree(*it);
             }
         }
     }
 
-    if (membersCount) {
+    if (subtreeDirtied) {
         _RequestRefresh();
     }
 }
 
+void ProxyRenderDelegate::DisplayLayerPathChanged(const Ufe::Path& oldPath, const Ufe::Path& newPath)
+{
+    Ufe::Path proxyShapePath = MayaUsd::ufe::stagePath(_proxyShapeData->UsdStage());
+    if (oldPath.runTimeId() == MayaUsd::ufe::getUsdRunTimeId()) {
+        if (oldPath.startsWith(proxyShapePath) && oldPath.nbSegments() > 1 && newPath.nbSegments() > 1) {
+            std::vector<std::pair<SdfPath, MObject>> pathsToUpdate;
+            SdfPath oldUsdPrefix(oldPath.getSegments()[1].string());
+            auto it = _usdPathToDisplayLayerMap.lower_bound(oldUsdPrefix);
+            while (it != _usdPathToDisplayLayerMap.end() && it->first.HasPrefix(oldUsdPrefix)) {
+                pathsToUpdate.push_back(*it);
+                _usdPathToDisplayLayerMap.erase(it++);
+            }
+
+            SdfPath newUsdPrefix(newPath.getSegments()[1].string());
+            for (const auto& item : pathsToUpdate) {
+                SdfPath newItemPath = item.first.ReplacePrefix(oldUsdPrefix, newUsdPrefix);
+                _usdPathToDisplayLayerMap[newItemPath] = item.second;
+            }
+        }
+    } else if (oldPath.runTimeId() == MayaUsd::ufe::getMayaRunTimeId()) {
+        // Check both paths since we don't know if the proxy shape path has already been updated
+        if (proxyShapePath.startsWith(oldPath) || proxyShapePath.startsWith(newPath)) {
+            _usdStageDisplayLayersDirty = true;
+        }
+    }
+
+    // Try to dirty both paths since we don't know if the proxy shape path has already been updated
+    if (_DirtyUfeSubtree(oldPath) || _DirtyUfeSubtree(newPath)) {
+        _RequestRefresh();
+    }
+}
+
+void ProxyRenderDelegate::AddDisplayLayerToCache(MObject& displayLayerObj)
+{
+    if (!displayLayerObj.hasFn(MFn::kDisplayLayer)) {
+        return;
+    }
+
+    MFnDisplayLayer displayLayer(displayLayerObj);
+    if (displayLayer.name() == "defaultLayer") {
+        return;
+    }
+    
+    MSelectionList members;
+    displayLayer.getMembers(members);
+    auto membersCount = members.length();
+    Ufe::Path proxyShapePath = MayaUsd::ufe::stagePath(_proxyShapeData->UsdStage());
+    for (unsigned int j = 0; j < membersCount; ++j) {
+        // skip maya paths, as they will be updated from UpdateProxyShapeDisplayLayers
+        MDagPath dagPath;
+        if (members.getDagPath(j, dagPath) == MS::kSuccess) {
+            continue;
+        }
+        
+        // add usd paths
+        MStringArray selectionStrings;
+        members.getSelectionStrings(j, selectionStrings);
+        for (auto it = selectionStrings.begin(); it != selectionStrings.end(); ++it) {
+            Ufe::Path path;
+            if (!_StringToUfePath(*it, path)) {
+                continue;
+            }
+
+            if (!path.startsWith(proxyShapePath) || (path.nbSegments() < 2)) {
+                continue;
+            }
+
+            SdfPath usdPath(path.getSegments()[1].string());
+            _usdPathToDisplayLayerMap[usdPath] = displayLayerObj;
+        }
+    }
+}
+
+void ProxyRenderDelegate::UpdateProxyShapeDisplayLayers()
+{
+    if (!_usdStageDisplayLayersDirty) {
+        return;
+    }
+
+    _usdStageDisplayLayersDirty = false;    
+    MFnDisplayLayerManager displayLayerManager(
+        MFnDisplayLayerManager::currentDisplayLayerManager());
+
+    _usdStageDisplayLayers 
+        = displayLayerManager.getAncestorLayersInclusive(GetProxyShapeDagPath().fullPathName());
+}
+
+MObject ProxyRenderDelegate::GetDisplayLayer(const SdfPath& path)
+{
+    auto it = _usdPathToDisplayLayerMap.find(path);
+    return it != _usdPathToDisplayLayerMap.end() ? it->second : MObject();
+}
 #endif
 
 void ProxyRenderDelegate::_RequestRefresh()

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -322,6 +322,7 @@ public:
     void operator()(const Ufe::Notification& notification) override
     {
         // Handle path change notifications here
+#ifdef MAYA_HAS_DISPLAY_LAYER_API
         if (const auto sceneChanged = dynamic_cast<const Ufe::SceneChanged*>(&notification)) {
             if (Ufe::SceneChanged::SceneCompositeNotification == sceneChanged->opType()) {
                 const auto& compNotification
@@ -333,7 +334,7 @@ public:
                 handleSceneOp(*sceneChanged);
             }
         }
-
+#endif
         // Handle selection change notifications here
         // During Maya file read, each node will be selected in turn, so we get
         // notified for each node in the scene.  Prune this out.
@@ -347,14 +348,14 @@ public:
         }
     }
 
+#ifdef MAYA_HAS_DISPLAY_LAYER_API
     void handleSceneOp(const Ufe::SceneCompositeNotification::Op& op)
     {
         if (op.opType == Ufe::SceneChanged::ObjectPathChange) {
-#ifdef MAYA_HAS_DISPLAY_LAYER_API
             _proxyRenderDelegate.DisplayLayerPathChanged(op.path, op.item->path());
-#endif
         }
     }
+#endif
 
 private:
     ProxyRenderDelegate& _proxyRenderDelegate;

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -1283,6 +1283,15 @@ SdfPath ProxyRenderDelegate::GetScenePrimPath(const SdfPath& rprimId, int instan
     return usdPath;
 }
 
+bool ProxyRenderDelegate::SupportPerInstanceDisplayLayers(const SdfPath& rprimId) const
+{
+    // For now, per-instance display layers are supported only for native instancing 
+    HdInstancerContext instancerContext;
+    GetScenePrimPath(rprimId, 0, &instancerContext);
+    bool nativeInstancing = instancerContext.empty();
+    return nativeInstancing;
+}
+
 //! \brief  Selection for both instanced and non-instanced cases.
 bool ProxyRenderDelegate::getInstancedSelectionPath(
     const MHWRender::MRenderItem&   renderItem,

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -324,7 +324,8 @@ public:
         // Handle path change notifications here
         if (const auto sceneChanged = dynamic_cast<const Ufe::SceneChanged*>(&notification)) {
             if (Ufe::SceneChanged::SceneCompositeNotification == sceneChanged->opType()) {
-                const auto& compNotification = notification.staticCast<Ufe::SceneCompositeNotification>();
+                const auto& compNotification
+                    = notification.staticCast<Ufe::SceneCompositeNotification>();
                 for (const auto& op : compNotification) {
                     handleSceneOp(op);
                 }
@@ -346,13 +347,14 @@ public:
         }
     }
 
-    void handleSceneOp(const Ufe::SceneCompositeNotification::Op& op) {
+    void handleSceneOp(const Ufe::SceneCompositeNotification::Op& op)
+    {
         if (op.opType == Ufe::SceneChanged::ObjectPathChange) {
 #ifdef MAYA_HAS_DISPLAY_LAYER_API
-          _proxyRenderDelegate.DisplayLayerPathChanged(op.path, op.item->path());  
+            _proxyRenderDelegate.DisplayLayerPathChanged(op.path, op.item->path());
 #endif
         }
-    }    
+    }
 
 private:
     ProxyRenderDelegate& _proxyRenderDelegate;
@@ -1285,7 +1287,7 @@ SdfPath ProxyRenderDelegate::GetScenePrimPath(const SdfPath& rprimId, int instan
 
 bool ProxyRenderDelegate::SupportPerInstanceDisplayLayers(const SdfPath& rprimId) const
 {
-    // For now, per-instance display layers are supported only for native instancing 
+    // For now, per-instance display layers are supported only for native instancing
     HdInstancerContext instancerContext;
     GetScenePrimPath(rprimId, 0, &instancerContext);
     bool nativeInstancing = instancerContext.empty();
@@ -1559,11 +1561,11 @@ void ProxyRenderDelegate::DisplayLayerMembershipChanged(const MString& memberPat
         if (path.startsWith(proxyShapePath) && path.nbSegments() > 1) {
             MFnDisplayLayerManager displayLayerManager(
                 MFnDisplayLayerManager::currentDisplayLayerManager());
-            
+
             SdfPath usdPath(path.getSegments()[1].string());
             MObject displayLayerObj = displayLayerManager.getLayer(memberPath);
-            if (displayLayerObj.hasFn(MFn::kDisplayLayer) && 
-                    MFnDisplayLayer(displayLayerObj).name() != "defaultLayer") {
+            if (displayLayerObj.hasFn(MFn::kDisplayLayer)
+                && MFnDisplayLayer(displayLayerObj).name() != "defaultLayer") {
                 _usdPathToDisplayLayerMap[usdPath] = displayLayerObj;
             } else {
                 _usdPathToDisplayLayerMap.erase(usdPath);
@@ -1606,14 +1608,17 @@ void ProxyRenderDelegate::DisplayLayerDirty(MFnDisplayLayer& displayLayer)
     }
 }
 
-void ProxyRenderDelegate::DisplayLayerPathChanged(const Ufe::Path& oldPath, const Ufe::Path& newPath)
+void ProxyRenderDelegate::DisplayLayerPathChanged(
+    const Ufe::Path& oldPath,
+    const Ufe::Path& newPath)
 {
     Ufe::Path proxyShapePath = MayaUsd::ufe::stagePath(_proxyShapeData->UsdStage());
     if (oldPath.runTimeId() == MayaUsd::ufe::getUsdRunTimeId()) {
-        if (oldPath.startsWith(proxyShapePath) && oldPath.nbSegments() > 1 && newPath.nbSegments() > 1) {
+        if (oldPath.startsWith(proxyShapePath) && oldPath.nbSegments() > 1
+            && newPath.nbSegments() > 1) {
             std::vector<std::pair<SdfPath, MObject>> pathsToUpdate;
             SdfPath oldUsdPrefix(oldPath.getSegments()[1].string());
-            auto it = _usdPathToDisplayLayerMap.lower_bound(oldUsdPrefix);
+            auto    it = _usdPathToDisplayLayerMap.lower_bound(oldUsdPrefix);
             while (it != _usdPathToDisplayLayerMap.end() && it->first.HasPrefix(oldUsdPrefix)) {
                 pathsToUpdate.push_back(*it);
                 _usdPathToDisplayLayerMap.erase(it++);
@@ -1648,10 +1653,10 @@ void ProxyRenderDelegate::AddDisplayLayerToCache(MObject& displayLayerObj)
     if (displayLayer.name() == "defaultLayer") {
         return;
     }
-    
+
     MSelectionList members;
     displayLayer.getMembers(members);
-    auto membersCount = members.length();
+    auto      membersCount = members.length();
     Ufe::Path proxyShapePath = MayaUsd::ufe::stagePath(_proxyShapeData->UsdStage());
     for (unsigned int j = 0; j < membersCount; ++j) {
         // skip maya paths, as they will be updated from UpdateProxyShapeDisplayLayers
@@ -1659,7 +1664,7 @@ void ProxyRenderDelegate::AddDisplayLayerToCache(MObject& displayLayerObj)
         if (members.getDagPath(j, dagPath) == MS::kSuccess) {
             continue;
         }
-        
+
         // add usd paths
         MStringArray selectionStrings;
         members.getSelectionStrings(j, selectionStrings);
@@ -1685,11 +1690,11 @@ void ProxyRenderDelegate::UpdateProxyShapeDisplayLayers()
         return;
     }
 
-    _usdStageDisplayLayersDirty = false;    
+    _usdStageDisplayLayersDirty = false;
     MFnDisplayLayerManager displayLayerManager(
         MFnDisplayLayerManager::currentDisplayLayerManager());
 
-    _usdStageDisplayLayers 
+    _usdStageDisplayLayers
         = displayLayerManager.getAncestorLayersInclusive(GetProxyShapeDagPath().fullPathName());
 }
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -174,9 +174,6 @@ public:
 #endif
 
     MAYAUSD_CORE_PUBLIC
-    MString GetUfePathPrefix() const;
-
-    MAYAUSD_CORE_PUBLIC
     void SelectionChanged();
 
 #ifdef MAYA_HAS_DISPLAY_LAYER_API
@@ -191,6 +188,21 @@ public:
 
     MAYAUSD_CORE_PUBLIC
     void DisplayLayerDirty(MFnDisplayLayer& displayLayer);
+
+    MAYAUSD_CORE_PUBLIC
+    void DisplayLayerPathChanged(const Ufe::Path& oldPath, const Ufe::Path& newPath);
+
+    MAYAUSD_CORE_PUBLIC
+    void AddDisplayLayerToCache(MObject& displayLayerObj);
+
+    MAYAUSD_CORE_PUBLIC
+    void UpdateProxyShapeDisplayLayers();
+
+    MAYAUSD_CORE_PUBLIC
+    MObject GetDisplayLayer(const SdfPath& path);
+
+    MAYAUSD_CORE_PUBLIC
+    const MObjectArray& GetProxyShapeDisplayLayers() const { return _usdStageDisplayLayers; }
 #endif
 
     MAYAUSD_CORE_PUBLIC
@@ -280,8 +292,8 @@ private:
         bool          colorCorrection,
         const MColor& defaultColor);
 #ifdef MAYA_HAS_DISPLAY_LAYER_API
-    void _DirtyUfeSubtree(const Ufe::Path& rootPath);
-    void _DirtyUfeSubtree(const MString& rootStr);
+    bool _DirtyUfeSubtree(const Ufe::Path& rootPath);
+    bool _DirtyUfeSubtree(const MString& rootStr);
     void _DirtyUsdSubtree(const UsdPrim& prim);
 #endif
     void _RequestRefresh();
@@ -369,6 +381,11 @@ private:
     MCallbackId               _mayaDisplayLayerRemovedCallbackId { 0 };
     MCallbackId               _mayaDisplayLayerMembersCallbackId { 0 };
     NodeHandleToCallbackIdMap _mayaDisplayLayerDirtyCallbackIds;
+
+    // for performace reasons we need to cache display layers' info
+    bool                       _usdStageDisplayLayersDirty = false;
+    MObjectArray               _usdStageDisplayLayers;
+    std::map<SdfPath, MObject> _usdPathToDisplayLayerMap;
 #endif
 
     std::vector<MCallbackId> _mayaColorPrefsCallbackIds;

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -174,6 +174,9 @@ public:
 #endif
 
     MAYAUSD_CORE_PUBLIC
+    bool SupportPerInstanceDisplayLayers(const SdfPath& rprimId) const;
+
+    MAYAUSD_CORE_PUBLIC
     void SelectionChanged();
 
 #ifdef MAYA_HAS_DISPLAY_LAYER_API

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateDisplayLayers.py
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateDisplayLayers.py
@@ -147,6 +147,7 @@ class testVP2RenderDelegateDisplayLayers(imageUtils.ImageDiffingTestCase):
         cmds.setAttr('layer1.drawInfo.hideOnPlayback', False)
 
         # templated
+        cmds.displayRGBColor("templateActive", 1.0, 0.69, 0.69)
         cmds.setAttr('layer1.drawInfo.displayType', 1)
         self.assertSnapshotClose('%s_sphere234_templated.png' % self._testName)
         cmds.setAttr('layer1.drawInfo.displayType', 0)


### PR DESCRIPTION
1. Introducing display layer cache in vp2RenderDelegate to drastically optimize Syncing of massive amounts of render items/instances
2. Explicitly disable display layers for point instancers until we figure out exactly what to do with them