### PR TITLE
Allow connecting filename attributes.

### DIFF
--- a/lib/mayaUsd/ufe/UsdAttribute.h
+++ b/lib/mayaUsd/ufe/UsdAttribute.h
@@ -188,7 +188,11 @@ public:
 //! \brief Interface for USD token attributes.
 class UsdAttributeFilename
     : public Ufe::AttributeFilename
+#ifdef UFE_V4_FEATURES_AVAILABLE
+    , public UsdAttribute
+#else
     , private UsdAttribute
+#endif
 {
 public:
     typedef std::shared_ptr<UsdAttributeFilename> Ptr;


### PR DESCRIPTION
The connection API requires being able to cast to UfeAttribute, the UsdAttributeFilename class was the only one not allowing that. This makes the code uniform.