### PR TITLE
MAYA-126368 make import *not* use the shared stage cache

### DIFF
--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -195,8 +195,8 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
             mImportData.stagePopulationMask(),
             mImportData.stageInitialLoadSet());
     } else {
-        UsdStageCacheContext stageCacheContext(UsdMayaStageCache::Get(
-            mImportData.stageInitialLoadSet(), UsdMayaStageCache::ShareMode::Shared));
+        UsdStageCache        stageCache;
+        UsdStageCacheContext stageCacheContext(stageCache);
         if (mArgs.pullImportStage)
             stage = mArgs.pullImportStage;
         else

--- a/test/testUtils/usdUtils.py
+++ b/test/testUtils/usdUtils.py
@@ -164,8 +164,6 @@ def createLayeredStage(layersCount = 3):
     '''
     (psPathStr, psPath, ps) = createSimpleStage()
 
-    import os
-    print(os.environ)
     stage = mayaUsd.lib.GetPrim(psPathStr).GetStage()
     layer = stage.GetRootLayer()
     layers = [layer]


### PR DESCRIPTION
Importing a USD file should not be able to affect staged USD files. Avoid such problem by not using any cache when importing.