### PR TITLE
MAYA-122481 fix rendering crash with MtoH

### DIFF
--- a/lib/usd/hdMaya/delegates/sceneDelegate.cpp
+++ b/lib/usd/hdMaya/delegates/sceneDelegate.cpp
@@ -43,6 +43,8 @@
 #include <maya/MObjectHandle.h>
 #include <maya/MString.h>
 
+#include <algorithm>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 namespace {
@@ -607,12 +609,9 @@ void HdMayaSceneDelegate::NodeAdded(const MObject& obj) { _addedNodes.push_back(
 
 void HdMayaSceneDelegate::NodeRemoved(const MObject& obj)
 {
-    // Note: remove in backward order to avoid processing items twice.
-    for (size_t i = _addedNodes.size() - 1; i < _addedNodes.size(); ++i) {
-        if (_addedNodes[i] == obj) {
-            _addedNodes.erase(_addedNodes.begin() + i);
-        }
-    }
+    const auto newEnd = std::remove_if(
+        _addedNodes.begin(), _addedNodes.end(), [&obj](const auto& item) { return item == obj; });
+    _addedNodes.erase(newEnd, _addedNodes.end());
 }
 
 void HdMayaSceneDelegate::UpdateLightVisibility(const MDagPath& dag)

--- a/lib/usd/hdMaya/delegates/sceneDelegate.h
+++ b/lib/usd/hdMaya/delegates/sceneDelegate.h
@@ -103,6 +103,9 @@ public:
     void NodeAdded(const MObject& obj);
 
     HDMAYA_API
+    void NodeRemoved(const MObject& obj);
+
+    HDMAYA_API
     void UpdateLightVisibility(const MDagPath& dag);
 
     HDMAYA_API


### PR DESCRIPTION
When rendering, with some options, the renderer adds atemporary light to the scene, then removes it as soon as the render ends. The Maya scene delegate receives scene addition notifications, but in this case by the time the consequences if the notifications are processed, the light has already been deleted and the delegate access freed memory.

Make the scene delegate also listen to scene item removal notifications to remove items that have been deleted before they can be processed.