### PR TITLE
Fix duplication of homonyms

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoDuplicateSelectionCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateSelectionCommand.cpp
@@ -177,7 +177,7 @@ Ufe::SceneItem::Ptr UsdUndoDuplicateSelectionCommand::targetItem(const Ufe::Path
     }
 
     while (numSegments == path.getSegments().size()) {
-        CommandMap::const_iterator it = _perItemCommands.find(path);
+        it = _perItemCommands.find(path);
         if (it != _perItemCommands.cend() && it->second->duplicatedItem()) {
             Ufe::Path duplicatedChildPath
                 = sourcePath.reparent(path, it->second->duplicatedItem()->path());

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateSelectionCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateSelectionCommand.cpp
@@ -50,18 +50,8 @@ UsdUndoDuplicateSelectionCommand::UsdUndoDuplicateSelectionCommand(
     const Ufe::ValueDictionary& duplicateOptions)
     : Ufe::SelectionUndoableCommand()
     , _copyExternalInputs(shouldConnectExternalInputs(duplicateOptions))
+    , _sourceSelection(selection)
 {
-    // TODO: MAYA-125854. If duplicating /a/b and /a/b/c, it would make sense to order the
-    // operations by SdfPath, and always check if the previously processed path is a prefix of the
-    // one currently being processed. In that case, a duplicate task is not necessary because the
-    // resulting SceneItem should be built by using SdfPath::ReplacePrefix on the current item to
-    // get its location in the previously duplicated parent item.
-    for (auto&& item : selection) {
-        if (UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item)) {
-            // Currently unordered_map since we need to streamline the targetItem override.
-            _perItemCommands[item->path()] = UsdUndoDuplicateCommand::create(usdItem);
-        }
-    }
 }
 
 UsdUndoDuplicateSelectionCommand::~UsdUndoDuplicateSelectionCommand() { }
@@ -70,24 +60,46 @@ UsdUndoDuplicateSelectionCommand::Ptr UsdUndoDuplicateSelectionCommand::create(
     const Ufe::Selection&       selection,
     const Ufe::ValueDictionary& duplicateOptions)
 {
-    auto retVal = std::make_shared<UsdUndoDuplicateSelectionCommand>(selection, duplicateOptions);
-    if (retVal->_perItemCommands.empty()) {
-        // Could not find any item from this runtime in the selection.
-        return {};
+    bool canDuplicate = false;
+    for (auto&& item : selection) {
+        UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
+        if (usdItem) {
+            canDuplicate = true;
+            break;
+        }
     }
-    return retVal;
+    if (canDuplicate) {
+        return std::make_shared<UsdUndoDuplicateSelectionCommand>(selection, duplicateOptions);
+    }
+    return {};
 }
 
 void UsdUndoDuplicateSelectionCommand::execute()
 {
     UsdUndoBlock undoBlock(&_undoableItem);
 
-    for (auto&& duplicateItem : _perItemCommands) {
-        duplicateItem.second->execute();
+    // TODO: MAYA-125854. If duplicating /a/b and /a/b/c, it would make sense to order the
+    // operations by SdfPath, and always check if the previously processed path is a prefix of the
+    // one currently being processed. In that case, a duplicate task is not necessary because the
+    // resulting SceneItem should be built by using SdfPath::ReplacePrefix on the current item to
+    // get its location in the previously duplicated parent item.
+    for (auto&& item : _sourceSelection) {
+        UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
+        if (!usdItem) {
+            continue;
+        }
 
-        auto            dstSceneItem = duplicateItem.second->duplicatedItem();
-        PXR_NS::UsdPrim srcPrim = ufePathToPrim(duplicateItem.first);
-        PXR_NS::UsdPrim dstPrim = std::dynamic_pointer_cast<UsdSceneItem>(dstSceneItem)->prim();
+        // Need to create and execute. If we create all before executing any, then the collision
+        // resolution on names will merge bob1 and bob2 into a single bob3 instead of creating a
+        // bob3 and a bob4.
+        auto duplicateCmd = UsdUndoDuplicateCommand::create(usdItem);
+        duplicateCmd->execute();
+
+        // Currently unordered_map since we need to streamline the targetItem override.
+        _perItemCommands[item->path()] = duplicateCmd;
+
+        PXR_NS::UsdPrim srcPrim = usdItem->prim();
+        PXR_NS::UsdPrim dstPrim = duplicateCmd->duplicatedItem()->prim();
 
         Ufe::Path stgPath = stagePath(dstPrim.GetStage());
         auto      stageIt = _duplicatesMap.find(stgPath);
@@ -99,6 +111,9 @@ void UsdUndoDuplicateSelectionCommand::execute()
         TF_VERIFY(stageIt->second.count(srcPrim.GetPath()) == 0);
         stageIt->second.insert({ srcPrim.GetPath(), dstPrim.GetPath() });
     }
+
+    // We no longer require the source selection:
+    _sourceSelection.clear();
 
     // Fixups were grouped by stage.
     for (const auto& stageData : _duplicatesMap) {

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateSelectionCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateSelectionCommand.h
@@ -17,6 +17,7 @@
 #define MAYAUSD_UFE_USDUNDODUPLICATESELECTIONCOMMAND_H
 
 #include <mayaUsd/base/api.h>
+#include <mayaUsd/ufe/UsdSceneItem.h>
 #include <mayaUsd/ufe/UsdUndoDuplicateCommand.h>
 #include <mayaUsd/undo/UsdUndoableItem.h>
 
@@ -63,7 +64,7 @@ private:
     const bool      _copyExternalInputs;
 
     // Transient list of items to duplicate. Needed by execute.
-    Ufe::Selection _sourceSelection;
+    std::vector<UsdSceneItem::Ptr> _sourceItems;
 
     using CommandMap = std::unordered_map<Ufe::Path, UsdUndoDuplicateCommand::Ptr>;
     CommandMap _perItemCommands;

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateSelectionCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateSelectionCommand.h
@@ -62,6 +62,9 @@ private:
     UsdUndoableItem _undoableItem;
     const bool      _copyExternalInputs;
 
+    // Transient list of items to duplicate. Needed by execute.
+    Ufe::Selection _sourceSelection;
+
     using CommandMap = std::unordered_map<Ufe::Path, UsdUndoDuplicateCommand::Ptr>;
     CommandMap _perItemCommands;
 

--- a/test/lib/ufe/testDuplicateCmd.py
+++ b/test/lib/ufe/testDuplicateCmd.py
@@ -486,6 +486,53 @@ class DuplicateCmdTestCase(unittest.TestCase):
 
         self.assertNotEqual(cmd.targetItem(geomItem1.path()).path(), cmd.targetItem(geomItem2.path()).path())
 
+    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '4041', 'Test only available in UFE preview version 0.4.41 and greater')
+    def testUfeDuplicateDescendants(self):
+        '''MAYA-125854: Test that duplicating a descendant of a selected ancestor results in the
+           duplicate from the ancestor.'''
+        testFile = testUtils.getTestScene('MaterialX', 'BatchOpsTestScene.usda')
+        shapeNode,shapeStage = mayaUtils.createProxyFromFile(testFile)
+
+        # Take 3 items that are in a hierarchical relationship.
+        shaderItem1 = ufeUtils.createUfeSceneItem(shapeNode, '/pPlane2/mtl/ss2SG')
+        self.assertIsNotNone(shaderItem1)
+        geomItem = ufeUtils.createUfeSceneItem(shapeNode, '/pPlane2')
+        self.assertIsNotNone(geomItem)
+        shaderItem2 = ufeUtils.createUfeSceneItem(shapeNode, '/pPlane2/mtl/ss2SG/MayaNG_ss2SG/MayaConvert_file2_MayafileTexture')
+        self.assertIsNotNone(shaderItem2)
+
+        batchOpsHandler = ufe.RunTimeMgr.instance().batchOpsHandler(geomItem.runTimeId())
+        self.assertIsNotNone(batchOpsHandler)
+
+        # Put then in a selection, making sure one child item is first, and that another child item is last.
+        sel = ufe.Selection()
+        sel.append(shaderItem1)
+        sel.append(geomItem)
+        sel.append(shaderItem2)
+        cmd = batchOpsHandler.duplicateSelectionCmd(sel, {"inputConnections": False})
+        cmd.execute()
+
+        duplicatedGeomItem = cmd.targetItem(geomItem.path())
+        self.assertEqual(ufe.PathString.string(duplicatedGeomItem.path()), "|stage|stageShape,/pPlane7" )
+
+        # Make sure the duplicated shader items are descendants of the duplicated geom pPlane7.
+        sel.clear()
+        sel.append(duplicatedGeomItem)
+        duplicatedShaderItem1 = cmd.targetItem(shaderItem1.path())
+        self.assertEqual(ufe.PathString.string(duplicatedShaderItem1.path()),
+                         "|stage|stageShape,/pPlane7/mtl/ss2SG" )
+        self.assertTrue(sel.containsAncestor(duplicatedShaderItem1.path()))
+
+        duplicatedShaderItem2 = cmd.targetItem(shaderItem2.path())
+        self.assertEqual(ufe.PathString.string(duplicatedShaderItem2.path()),
+                         "|stage|stageShape,/pPlane7/mtl/ss2SG/MayaNG_ss2SG/MayaConvert_file2_MayafileTexture" )
+        self.assertTrue(sel.containsAncestor(duplicatedShaderItem2.path()))
+
+        # Test that the ancestor search terminates correctly:
+        nonDuplicatedGeomItem = ufeUtils.createUfeSceneItem(shapeNode, '/pPlane1')
+        self.assertIsNotNone(nonDuplicatedGeomItem)
+        self.assertIsNone(cmd.targetItem(nonDuplicatedGeomItem.path()))
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/ufe/testDuplicateCmd.py
+++ b/test/lib/ufe/testDuplicateCmd.py
@@ -504,7 +504,7 @@ class DuplicateCmdTestCase(unittest.TestCase):
         batchOpsHandler = ufe.RunTimeMgr.instance().batchOpsHandler(geomItem.runTimeId())
         self.assertIsNotNone(batchOpsHandler)
 
-        # Put then in a selection, making sure one child item is first, and that another child item is last.
+        # Put them in a selection, making sure one child item is first, and that another child item is last.
         sel = ufe.Selection()
         sel.append(shaderItem1)
         sel.append(geomItem)

--- a/test/lib/ufe/testDuplicateCmd.py
+++ b/test/lib/ufe/testDuplicateCmd.py
@@ -464,6 +464,28 @@ class DuplicateCmdTestCase(unittest.TestCase):
         self.assertIsNotNone(plane7Item)
         self.assertEqual(plane7Item, duplicatedItem)
 
+    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '4041', 'Test only available in UFE preview version 0.4.41 and greater')
+    def testUfeDuplicateHomonyms(self):
+        '''Test that duplicating two items with similar names end up in two new duplicates.'''
+        testFile = testUtils.getTestScene('MaterialX', 'BatchOpsTestScene.usda')
+        shapeNode,shapeStage = mayaUtils.createProxyFromFile(testFile)
+
+        geomItem1 = ufeUtils.createUfeSceneItem(shapeNode, '/pPlane1')
+        self.assertIsNotNone(geomItem1)
+        geomItem2 = ufeUtils.createUfeSceneItem(shapeNode, '/pPlane2')
+        self.assertIsNotNone(geomItem2)
+
+        batchOpsHandler = ufe.RunTimeMgr.instance().batchOpsHandler(geomItem1.runTimeId())
+        self.assertIsNotNone(batchOpsHandler)
+
+        sel = ufe.Selection()
+        sel.append(geomItem1)
+        sel.append(geomItem2)
+        cmd = batchOpsHandler.duplicateSelectionCmd(sel, {"inputConnections": False})
+        cmd.execute()
+
+        self.assertNotEqual(cmd.targetItem(geomItem1.path()).path(), cmd.targetItem(geomItem2.path()).path())
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes: Two items that would resolve to the same path after name conflict resolution actually end up being duplicated into the same name.

So duplicating "bob1" and "bob2" in the same selection would result in a single "bob3" and a missing "bob4".

The code now creates and executes sub-duplication tasks in the main loop to make sure the name conflict resolution sees the complete picture.