### PR TITLE
MAYA-123716 - As a user, I'd like my duplicated prim to be on the Display Layer that the source prim was on

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -1483,8 +1483,10 @@ bool PrimUpdaterManager::duplicate(
         }
         progressBar.advance();
 
-        std::string* rootRename = (dstChildName != srcRootPath.GetName()) ? &dstChildName : nullptr;
-        context._pushExtras.finalize(MayaUsd::ufe::stagePath(context.GetUsdStage()), rootRename);
+        bool           needRenaming = (dstRootPath != srcRootPath);
+        const SdfPath* oldPrefix = needRenaming ? &srcRootPath : nullptr;
+        const SdfPath* newPrefix = needRenaming ? &dstRootPath : nullptr;
+        context._pushExtras.finalize(MayaUsd::ufe::stagePath(dstStage), oldPrefix, newPrefix);
         progressBar.advance();
 
         auto ufeItem = Ufe::Hierarchy::createItem(dstPath);

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
@@ -95,8 +95,7 @@ void UsdUndoDuplicateCommand::execute()
         prim.GetPath().GetText(),
         _usdDstPath.GetText());
 
-    auto duplicatedName = duplicatedItem()->path().back().string();
-    extras.finalize(MayaUsd::ufe::stagePath(prim.GetStage()), &duplicatedName);
+    extras.finalize(MayaUsd::ufe::stagePath(stage), &path, &_usdDstPath);
 }
 
 void UsdUndoDuplicateCommand::undo()

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -1016,18 +1016,22 @@ void ReplicateExtrasToUSD::initRecursive(const Ufe::SceneItem::Ptr& item) const
 #endif
 }
 
-void ReplicateExtrasToUSD::finalize(const Ufe::Path& stagePath, const std::string* renameRoot) const
+void ReplicateExtrasToUSD::finalize(
+    const Ufe::Path&       stagePath,
+    const PXR_NS::SdfPath* oldPrefix,
+    const PXR_NS::SdfPath* newPrefix) const
 {
 #ifdef MAYA_HAS_DISPLAY_LAYER_API
     // Replicate display layer membership
     for (const auto& entry : _primToLayerMap) {
         if (entry.second.hasFn(MFn::kDisplayLayer)) {
-            auto rootPath = MayaUsd::ufe::usdPathToUfePathSegment(entry.first);
-            if (renameRoot && !rootPath.empty()) {
-                *rootPath.begin() = Ufe::PathComponent(*renameRoot);
+            auto usdPrimPath = entry.first;
+            if (oldPrefix && newPrefix) {
+                usdPrimPath = usdPrimPath.ReplacePrefix(*oldPrefix, *newPrefix);
             }
 
-            Ufe::Path::Segments segments { stagePath.getSegments()[0], rootPath };
+            auto                primPath = MayaUsd::ufe::usdPathToUfePathSegment(usdPrimPath);
+            Ufe::Path::Segments segments { stagePath.getSegments()[0], primPath };
             Ufe::Path           ufePath(std::move(segments));
 
             MFnDisplayLayer displayLayer(entry.second);

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -257,8 +257,11 @@ public:
     void initRecursive(const Ufe::SceneItem::Ptr& item) const;
 
     // Finalizes the replication operation to the USD stage defined by 'stagePath'
-    // with a possibility to rename the usd root node name to 'renameRoot'
-    void finalize(const Ufe::Path& stagePath, const std::string* renameRoot = nullptr) const;
+    // with a possibility to rename the old usd prefix to a new one
+    void finalize(
+        const Ufe::Path&       stagePath,
+        const PXR_NS::SdfPath* oldPrefix = nullptr,
+        const PXR_NS::SdfPath* newPrefix = nullptr) const;
 
 private:
     mutable std::map<PXR_NS::SdfPath, MObject> _primToLayerMap;


### PR DESCRIPTION
This PR fixes a bug in the original code by introducing a code to properly replace USD prefixes when copying to USD.