### PR TITLE
MAYA-125918 auto re-edit when merging a Maya Ref

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterContext.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterContext.cpp
@@ -16,6 +16,8 @@
 //
 #include "primUpdaterContext.h"
 
+#include <memory>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 UsdMayaPrimUpdaterContext::UsdMayaPrimUpdaterContext(
@@ -28,6 +30,7 @@ UsdMayaPrimUpdaterContext::UsdMayaPrimUpdaterContext(
     , _pathMap(pathMap)
     , _userArgs(userArgs)
     , _args(UsdMayaPrimUpdaterArgs::createFromDictionary(userArgs))
+    , _additionalCommands(std::make_shared<Ufe::CompositeUndoableCommand>())
 {
 }
 
@@ -39,6 +42,11 @@ MDagPath UsdMayaPrimUpdaterContext::MapSdfPathToDagPath(const SdfPath& sdfPath) 
 
     auto found = _pathMap->find(sdfPath);
     return found == _pathMap->end() ? MDagPath() : found->second;
+}
+
+void UsdMayaPrimUpdaterContext::SetUsdPathToDagPathMap(const UsdPathToDagPathMapPtr& pathMap)
+{
+    _pathMap = pathMap;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/primUpdaterContext.h
+++ b/lib/mayaUsd/fileio/primUpdaterContext.h
@@ -27,6 +27,7 @@
 #include <pxr/usd/usd/timeCode.h>
 
 #include <maya/MDagPath.h>
+#include <ufe/undoableCommand.h>
 
 #include <memory> // shared_ptr
 
@@ -68,16 +69,29 @@ public:
     MAYAUSD_CORE_PUBLIC
     MDagPath MapSdfPathToDagPath(const SdfPath& sdfPath) const;
 
+    /// \brief Sets the USD path to DAG path map.
+    MAYAUSD_CORE_PUBLIC
+    void SetUsdPathToDagPathMap(const UsdPathToDagPathMapPtr& pathMap);
+
+    /// \brief Returns the UFE composite command that can be extended and will be executed when
+    ///        the pull or push have completed successfully.
+    const std::shared_ptr<Ufe::CompositeUndoableCommand>& GetAdditionalFinalCommands() const
+    {
+        return _additionalCommands;
+    }
+
     const MayaUsd::ufe::ReplicateExtrasFromUSD _pullExtras;
     const MayaUsd::ufe::ReplicateExtrasToUSD   _pushExtras;
 
 private:
-    const UsdTimeCode&           _timeCode;
-    const UsdStageRefPtr         _stage;
-    const UsdPathToDagPathMapPtr _pathMap;
+    const UsdTimeCode&     _timeCode;
+    const UsdStageRefPtr   _stage;
+    UsdPathToDagPathMapPtr _pathMap;
 
     const VtDictionary&          _userArgs;
     const UsdMayaPrimUpdaterArgs _args;
+
+    std::shared_ptr<Ufe::CompositeUndoableCommand> _additionalCommands;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/python/wrapPrimUpdater.cpp
+++ b/lib/mayaUsd/python/wrapPrimUpdater.cpp
@@ -246,6 +246,10 @@ void wrapPrimUpdaterContext()
             "GetArgs",
             &UsdMayaPrimUpdaterContext::GetArgs,
             boost::python::return_internal_reference<>())
+        .def(
+            "GetAdditionalFinalCommands",
+            &UsdMayaPrimUpdaterContext::GetAdditionalFinalCommands,
+            boost::python::return_internal_reference<>())
         .def("MapSdfPathToDagPath", &UsdMayaPrimUpdaterContext::MapSdfPathToDagPath);
 }
 
@@ -289,6 +293,7 @@ void wrapPrimUpdater()
             boost::python::return_value_policy<boost::python::return_by_value>())
         .def("getUfePath", &This::getUfePath, boost::python::return_internal_reference<>())
         .def("getUsdPrim", &This::getUsdPrim)
+        .def("getContext", &This::getContext, boost::python::return_internal_reference<>())
         .def("isAnimated", &This::isAnimated)
         .staticmethod("isAnimated")
         .def("Register", &PrimUpdaterWrapper::Register)

--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -3,10 +3,12 @@
 # -----------------------------------------------------------------------------
 target_sources(${PROJECT_NAME} 
     PRIVATE
+        EditAsMayaCommand.cpp
         Global.cpp
         ProxyShapeHandler.cpp
         ProxyShapeHierarchy.cpp
         ProxyShapeHierarchyHandler.cpp
+        SetVariantSelectionCommand.cpp
         StagesSubject.cpp
         UsdHierarchy.cpp
         UsdHierarchyHandler.cpp
@@ -198,10 +200,12 @@ if(PXR_VERSION GREATER_EQUAL 2108)
 endif()
 
 set(HEADERS
+    EditAsMayaCommand.h
     Global.h
     ProxyShapeHandler.h
     ProxyShapeHierarchy.h
     ProxyShapeHierarchyHandler.h
+    SetVariantSelectionCommand.h
     StagesSubject.h
     UsdHierarchy.h
     UsdHierarchyHandler.h

--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -3,7 +3,6 @@
 # -----------------------------------------------------------------------------
 target_sources(${PROJECT_NAME} 
     PRIVATE
-        EditAsMayaCommand.cpp
         Global.cpp
         ProxyShapeHandler.cpp
         ProxyShapeHierarchy.cpp
@@ -76,6 +75,7 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
     target_sources(${PROJECT_NAME}
         PRIVATE
             # See MayaUIInfoHandler.h comments.
+            EditAsMayaCommand.cpp
             MayaUIInfoHandler.cpp
             PulledObjectHierarchy.cpp
             PulledObjectHierarchyHandler.cpp
@@ -200,7 +200,6 @@ if(PXR_VERSION GREATER_EQUAL 2108)
 endif()
 
 set(HEADERS
-    EditAsMayaCommand.h
     Global.h
     ProxyShapeHandler.h
     ProxyShapeHierarchy.h
@@ -274,6 +273,7 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
     list(APPEND HEADERS
         # Not dependent on UFE v3, but used to draw orphaned pulled Maya nodes
         # in the Outliner, which is a UFE v3 feature.
+        EditAsMayaCommand.h
         MayaUIInfoHandler.h
         PulledObjectHierarchy.h
         PulledObjectHierarchyHandler.h

--- a/lib/mayaUsd/ufe/EditAsMayaCommand.cpp
+++ b/lib/mayaUsd/ufe/EditAsMayaCommand.cpp
@@ -1,0 +1,60 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "EditAsMayaCommand.h"
+
+#include <mayaUsd/fileio/primUpdaterManager.h>
+#include <mayaUsd/undo/OpUndoItemRecorder.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+EditAsMayaUfeCommand::Ptr EditAsMayaUfeCommand::create(const Ufe::Path& path)
+{
+    return std::make_shared<ufe::EditAsMayaUfeCommand>(path);
+}
+
+EditAsMayaUfeCommand::EditAsMayaUfeCommand(const Ufe::Path& path)
+    : _path(path)
+{
+}
+
+EditAsMayaUfeCommand::~EditAsMayaUfeCommand() { }
+
+void EditAsMayaUfeCommand::execute()
+{
+    bool status = false;
+
+    // Scope the undo item recording so we can undo on failure.
+    {
+        OpUndoItemRecorder undoRecorder(_undoItemList);
+
+        auto& manager = PXR_NS::PrimUpdaterManager::getInstance();
+        status = manager.editAsMaya(_path);
+    }
+
+    // Undo potentially partially-made edit-as-Maya on failure.
+    if (!status)
+        _undoItemList.undo();
+}
+
+void EditAsMayaUfeCommand::undo() { _undoItemList.redo(); }
+
+void EditAsMayaUfeCommand::redo() { _undoItemList.redo(); }
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/EditAsMayaCommand.cpp
+++ b/lib/mayaUsd/ufe/EditAsMayaCommand.cpp
@@ -18,8 +18,6 @@
 #include <mayaUsd/fileio/primUpdaterManager.h>
 #include <mayaUsd/undo/OpUndoItemRecorder.h>
 
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 

--- a/lib/mayaUsd/ufe/EditAsMayaCommand.h
+++ b/lib/mayaUsd/ufe/EditAsMayaCommand.h
@@ -1,0 +1,56 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <mayaUsd/base/api.h>
+#include <mayaUsd/undo/OpUndoItemList.h>
+
+#include <ufe/path.h>
+#include <ufe/undoableCommand.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+//! \brief Command to edit as Maya data and USD prim.
+class MAYAUSD_CORE_PUBLIC EditAsMayaUfeCommand : public Ufe::UndoableCommand
+{
+public:
+    using Ptr = std::shared_ptr<EditAsMayaUfeCommand>;
+
+    //! Construct and destruct a EditAsMayaCommand. Does not execute it.
+    EditAsMayaUfeCommand(const Ufe::Path& path);
+    ~EditAsMayaUfeCommand() override;
+
+    //! Create a EditAsMayaCommand. Does not execute it.
+    static EditAsMayaUfeCommand::Ptr create(const Ufe::Path& path);
+
+    void execute() override;
+    void undo() override;
+    void redo() override;
+
+private:
+    // Delete the copy/move constructors assignment operators.
+    EditAsMayaUfeCommand(const EditAsMayaUfeCommand&) = delete;
+    EditAsMayaUfeCommand& operator=(const EditAsMayaUfeCommand&) = delete;
+    EditAsMayaUfeCommand(EditAsMayaUfeCommand&&) = delete;
+    EditAsMayaUfeCommand& operator=(EditAsMayaUfeCommand&&) = delete;
+
+    OpUndoItemList _undoItemList;
+    Ufe::Path      _path;
+};
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/SetVariantSelectionCommand.cpp
+++ b/lib/mayaUsd/ufe/SetVariantSelectionCommand.cpp
@@ -1,0 +1,90 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "SetVariantSelectionCommand.h"
+
+#include <mayaUsd/ufe/Utils.h>
+
+#include <pxr/usd/usd/variantSets.h>
+
+#include <ufe/globalSelection.h>
+#include <ufe/observableSelection.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+SetVariantSelectionCommand::Ptr SetVariantSelectionCommand::create(
+    const Ufe::Path&       path,
+    const PXR_NS::UsdPrim& prim,
+    const std::string&     variantName,
+    const std::string&     variantSelection)
+{
+    return std::make_shared<SetVariantSelectionCommand>(path, prim, variantName, variantSelection);
+}
+
+SetVariantSelectionCommand::SetVariantSelectionCommand(
+    const Ufe::Path&       path,
+    const PXR_NS::UsdPrim& prim,
+    const std::string&     variantName,
+    const std::string&     variantSelection)
+    : _path(path)
+    , _prim(prim)
+    , _varSet(prim.GetVariantSets().GetVariantSet(variantName))
+    , _oldSelection(_varSet.GetVariantSelection())
+    , _newSelection(variantSelection)
+{
+}
+
+SetVariantSelectionCommand::~SetVariantSelectionCommand() { }
+
+void SetVariantSelectionCommand::redo()
+{
+    std::string errMsg;
+    if (!MayaUsd::ufe::isPrimMetadataEditAllowed(
+            _prim,
+            PXR_NS::SdfFieldKeys->VariantSelection,
+            PXR_NS::TfToken(_varSet.GetName()),
+            &errMsg)) {
+        throw std::runtime_error(errMsg.c_str());
+    }
+
+    // Make a copy of the global selection, to restore it on undo.
+    auto globalSn = Ufe::GlobalSelection::get();
+    _savedSn.replaceWith(*globalSn);
+    // Filter the global selection, removing items below our prim.
+    globalSn->replaceWith(MayaUsd::ufe::removeDescendants(_savedSn, _path));
+    _varSet.SetVariantSelection(_newSelection);
+}
+
+void SetVariantSelectionCommand::undo()
+{
+    std::string errMsg;
+    if (!MayaUsd::ufe::isPrimMetadataEditAllowed(
+            _prim,
+            PXR_NS::SdfFieldKeys->VariantSelection,
+            PXR_NS::TfToken(_varSet.GetName()),
+            &errMsg)) {
+        throw std::runtime_error(errMsg.c_str());
+    }
+
+    _varSet.SetVariantSelection(_oldSelection);
+    // Restore the saved selection to the global selection.  If a saved
+    // selection item started with the prim's path, re-create it.
+    auto globalSn = Ufe::GlobalSelection::get();
+    globalSn->replaceWith(MayaUsd::ufe::recreateDescendants(_savedSn, _path));
+}
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/SetVariantSelectionCommand.h
+++ b/lib/mayaUsd/ufe/SetVariantSelectionCommand.h
@@ -1,0 +1,72 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <mayaUsd/base/api.h>
+
+#include <pxr/usd/usd/prim.h>
+#include <pxr/usd/usd/variantSets.h>
+
+#include <ufe/path.h>
+#include <ufe/selection.h>
+#include <ufe/undoableCommand.h>
+
+#include <string>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+//! \brief Command to change a variant selection.
+class MAYAUSD_CORE_PUBLIC SetVariantSelectionCommand : public Ufe::UndoableCommand
+{
+public:
+    using Ptr = std::shared_ptr<SetVariantSelectionCommand>;
+
+    //! Create a SetVariantSelectionCommand. Does not execute it.
+    static SetVariantSelectionCommand::Ptr create(
+        const Ufe::Path&       path,
+        const PXR_NS::UsdPrim& prim,
+        const std::string&     variantName,
+        const std::string&     variantSelection);
+
+    SetVariantSelectionCommand(
+        const Ufe::Path&       path,
+        const PXR_NS::UsdPrim& prim,
+        const std::string&     variantName,
+        const std::string&     variantSelection);
+
+    ~SetVariantSelectionCommand() override;
+
+    void redo() override;
+    void undo() override;
+
+private:
+    // Delete the copy/move constructors assignment operators.
+    SetVariantSelectionCommand(const SetVariantSelectionCommand&) = delete;
+    SetVariantSelectionCommand& operator=(const SetVariantSelectionCommand&) = delete;
+    SetVariantSelectionCommand(SetVariantSelectionCommand&&) = delete;
+    SetVariantSelectionCommand& operator=(SetVariantSelectionCommand&&) = delete;
+
+    const Ufe::Path       _path;
+    PXR_NS::UsdPrim       _prim;
+    PXR_NS::UsdVariantSet _varSet;
+    const std::string     _oldSelection;
+    const std::string     _newSelection;
+    Ufe::Selection        _savedSn; // For global selection save and restore.
+};
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -457,6 +457,12 @@ SdfLayerHandle getStrongerLayer(
     if (layer1 == layer2)
         return layer1;
 
+    if (!layer1)
+        return layer2;
+
+    if (!layer2)
+        return layer1;
+
     if (root == layer1)
         return layer1;
 

--- a/lib/mayaUsd/undo/OpUndoItemList.h
+++ b/lib/mayaUsd/undo/OpUndoItemList.h
@@ -52,6 +52,10 @@ public:
     MAYAUSD_CORE_PUBLIC
     virtual ~OpUndoItem() = default;
 
+    /// \brief execute a single sub-operation. By default calls redo.
+    MAYAUSD_CORE_PUBLIC
+    virtual bool execute() { return redo(); }
+
     /// \brief undo a single sub-operation.
     MAYAUSD_CORE_PUBLIC
     virtual bool undo() = 0;

--- a/lib/mayaUsd/undo/OpUndoItems.h
+++ b/lib/mayaUsd/undo/OpUndoItems.h
@@ -28,6 +28,7 @@
 #include <maya/MSelectionList.h>
 #ifdef WANT_UFE_BUILD
 #include <ufe/selection.h>
+#include <ufe/undoableCommand.h>
 #endif
 
 #include <memory>
@@ -407,6 +408,7 @@ private:
 };
 
 #ifdef WANT_UFE_BUILD
+
 //------------------------------------------------------------------------------
 // UfeSelectionUndoItem
 //------------------------------------------------------------------------------
@@ -466,6 +468,60 @@ private:
 
     Ufe::Selection _selection;
 };
+
+//------------------------------------------------------------------------------
+// UfeCommandUndoItem
+//------------------------------------------------------------------------------
+
+/// \class UfeCommandUndoItem
+/// \brief Record data needed to undo or redo a UFE command.
+class UfeCommandUndoItem : public OpUndoItem
+{
+public:
+    /// \brief Execute a UFE command and keep track of it.
+    MAYAUSD_CORE_PUBLIC
+    static bool
+    execute(const std::string& name, const std::shared_ptr<Ufe::UndoableCommand>& command, OpUndoItemList& undoInfo);
+
+    /// \brief Execute a UFE command and keep track of it in the global list.
+    MAYAUSD_CORE_PUBLIC
+    static bool
+    execute(const std::string& name, const std::shared_ptr<Ufe::UndoableCommand>& command);
+
+    /// \brief Keep track of a UFE command.
+    MAYAUSD_CORE_PUBLIC
+    static bool add(
+        const std::string&                           name,
+        const std::shared_ptr<Ufe::UndoableCommand>& command,
+        OpUndoItemList&                              undoInfo);
+
+    /// \brief Keep track of a UFE command in the global list.
+    MAYAUSD_CORE_PUBLIC
+    static bool
+    add(const std::string& name, const std::shared_ptr<Ufe::UndoableCommand>& command);
+
+    MAYAUSD_CORE_PUBLIC
+    UfeCommandUndoItem(const std::string& name, const std::shared_ptr<Ufe::UndoableCommand>& command);
+
+    MAYAUSD_CORE_PUBLIC
+    ~UfeCommandUndoItem() override;
+
+    /// \brief execute the UFE command.
+    MAYAUSD_CORE_PUBLIC
+    bool execute() override;
+
+    /// \brief undo the UFE command.
+    MAYAUSD_CORE_PUBLIC
+    bool undo() override;
+
+    /// \brief redo the UFE command.
+    MAYAUSD_CORE_PUBLIC
+    bool redo() override;
+
+private:
+    std::shared_ptr<Ufe::UndoableCommand> _command;
+};
+
 #endif
 
 //------------------------------------------------------------------------------

--- a/lib/mayaUsd/undo/OpUndoItems.h
+++ b/lib/mayaUsd/undo/OpUndoItems.h
@@ -480,8 +480,10 @@ class UfeCommandUndoItem : public OpUndoItem
 public:
     /// \brief Execute a UFE command and keep track of it.
     MAYAUSD_CORE_PUBLIC
-    static bool
-    execute(const std::string& name, const std::shared_ptr<Ufe::UndoableCommand>& command, OpUndoItemList& undoInfo);
+    static bool execute(
+        const std::string&                           name,
+        const std::shared_ptr<Ufe::UndoableCommand>& command,
+        OpUndoItemList&                              undoInfo);
 
     /// \brief Execute a UFE command and keep track of it in the global list.
     MAYAUSD_CORE_PUBLIC
@@ -490,18 +492,19 @@ public:
 
     /// \brief Keep track of a UFE command.
     MAYAUSD_CORE_PUBLIC
-    static bool add(
-        const std::string&                           name,
+    static bool
+    add(const std::string&                           name,
         const std::shared_ptr<Ufe::UndoableCommand>& command,
         OpUndoItemList&                              undoInfo);
 
     /// \brief Keep track of a UFE command in the global list.
     MAYAUSD_CORE_PUBLIC
-    static bool
-    add(const std::string& name, const std::shared_ptr<Ufe::UndoableCommand>& command);
+    static bool add(const std::string& name, const std::shared_ptr<Ufe::UndoableCommand>& command);
 
     MAYAUSD_CORE_PUBLIC
-    UfeCommandUndoItem(const std::string& name, const std::shared_ptr<Ufe::UndoableCommand>& command);
+    UfeCommandUndoItem(
+        const std::string&                           name,
+        const std::shared_ptr<Ufe::UndoableCommand>& command);
 
     MAYAUSD_CORE_PUBLIC
     ~UfeCommandUndoItem() override;

--- a/lib/usd/translators/mayaReferenceUpdater.cpp
+++ b/lib/usd/translators/mayaReferenceUpdater.cpp
@@ -20,6 +20,7 @@
 #include <mayaUsd/fileio/translators/translatorMayaReference.h>
 #include <mayaUsd/fileio/utils/adaptor.h>
 #include <mayaUsd/fileio/utils/xformStack.h>
+#include <mayaUsd/ufe/SetVariantSelectionCommand.h>
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/utils/editRouter.h>
@@ -291,8 +292,46 @@ bool PxrUsdTranslators_MayaReferenceUpdater::pushEnd()
     MayaUsd::LockNodesUndoItem::lock(
         "Maya reference pulled transform unlocking", transformPath, false);
 
-    // Clear the auto-edit flag.
-    clearAutoEdit(getUsdPrim());
+    // Note: we don't know in which variant the Maya reference is, so check
+    //       in all variants to find the MayaReference prim.
+    UsdPrim                primWithVariants = getUsdPrim().GetParent();
+    PXR_NS::UsdStagePtr    stage = primWithVariants.GetStage();
+    PXR_NS::UsdVariantSets variantSets = primWithVariants.GetVariantSets();
+    for (const std::string& variantSetName : variantSets.GetNames()) {
+
+        PXR_NS::UsdVariantSet variantSet = primWithVariants.GetVariantSet(variantSetName);
+
+        // Make sure to restore the current selected variant even in the face
+        // of exceptions.
+        MAYAUSD_NS_DEF::AutoVariantRestore variantRestore(variantSet);
+
+        for (const std::string& variantSelection : variantSet.GetVariantNames()) {
+            if (variantSet.SetVariantSelection(variantSelection)) {
+                PXR_NS::UsdEditTarget target = stage->GetEditTarget();
+
+                PXR_NS::UsdEditContext switchEditContext(
+                    stage, variantSet.GetVariantEditTarget(target.GetLayer()));
+
+                // Note: the prim might not exist in all variants, so check its validity.
+                UsdPrim prim = getUsdPrim();
+                if (!prim.IsValid())
+                    continue;
+
+                UsdAttribute mayaAutoEditAttr
+                    = prim.GetAttribute(MayaUsd_SchemasTokens->mayaAutoEdit);
+                if (!mayaAutoEditAttr.IsValid())
+                    continue;
+
+                bool autoEdited = false;
+                if (!mayaAutoEditAttr.Get<bool>(&autoEdited))
+                    continue;
+
+                auto cmd = MayaUsd::ufe::SetVariantSelectionCommand::create(
+                    getUfePath().pop(), primWithVariants, variantSetName, variantSelection);
+                getContext()->GetAdditionalFinalCommands()->append(cmd);
+            }
+        }
+    }
 
     return true;
 }

--- a/lib/usd/translators/mayaReferenceUpdater.cpp
+++ b/lib/usd/translators/mayaReferenceUpdater.cpp
@@ -326,6 +326,9 @@ bool PxrUsdTranslators_MayaReferenceUpdater::pushEnd()
                 if (!mayaAutoEditAttr.Get<bool>(&autoEdited))
                     continue;
 
+                if (!autoEdited)
+                    continue;
+
                 auto cmd = MayaUsd::ufe::SetVariantSelectionCommand::create(
                     getUfePath().pop(), primWithVariants, variantSetName, variantSelection);
                 getContext()->GetAdditionalFinalCommands()->append(cmd);

--- a/test/lib/mayaUsd/fileio/testAddMayaReference.py
+++ b/test/lib/mayaUsd/fileio/testAddMayaReference.py
@@ -312,6 +312,9 @@ class AddMayaReferenceTestCase(unittest.TestCase):
 
         # The prim should have a variant set.
         self.assertTrue(primTestDefault.HasVariantSets())
+        vs = primTestDefault.GetVariantSets()
+        variantSet = vs.GetVariantSet(variantSetName)
+        self.assertEqual(variantSet.GetVariantSelection(), variantName)
 
         # Verify that a Maya Reference prim was created.
         self.assertTrue(mayaRefPrim.IsValid())
@@ -341,13 +344,22 @@ class AddMayaReferenceTestCase(unittest.TestCase):
         aMayaPathStr = ufe.PathString.string(aMayaPath)
         with mayaUsd.lib.OpUndoItemList():
             self.assertTrue(mayaUsd.lib.PrimUpdaterManager.mergeToUsd(aMayaPathStr, cacheOptions))
-        
-        # Verify that the auto-edit is still on and the prim
-        # is inactive because it is being edited in Maya.
+
+        # Verify the cache variant is active and the prim
+        # is active.
+        self.assertTrue(primTestDefault.HasVariantSets())
+        vs = primTestDefault.GetVariantSets()
+        variantSet = vs.GetVariantSet(variantSetName)
+        self.assertEqual(variantSet.GetVariantSelection(), cacheVariantName)
+        self.assertTrue(mayaRefPrim.IsActive())
+
+        # Switch to Maya Ref variant and verify that the auto-edit is
+        # still on and the prim is now inactive.
+        variantSet.SetVariantSelection(variantName)
+        self.assertFalse(mayaRefPrim.IsActive())
         attr = mayaRefPrim.GetAttribute('mayaAutoEdit')
         self.assertTrue(attr.IsValid())
         self.assertEqual(attr.Get(), True)
-        self.assertFalse(mayaRefPrim.IsActive())
 
 
     def testBadNames(self):

--- a/test/lib/mayaUsd/fileio/testCacheToUsd.py
+++ b/test/lib/mayaUsd/fileio/testCacheToUsd.py
@@ -328,10 +328,10 @@ class CacheToUsdTestCase(unittest.TestCase):
         with mayaUsd.lib.OpUndoItemList():
             self.assertTrue(mayaUsd.lib.PrimUpdaterManager.mergeToUsd(aMayaPathStr, userArgs))
         
-        # Verify that the auto-edit has been turned off
+        # Verify that the auto-edit is still on.
         attr = mayaRefPrim.GetAttribute('mayaAutoEdit')
         self.assertTrue(attr.IsValid())
-        self.assertEqual(attr.Get(), False)
+        self.assertEqual(attr.Get(), True)
 
         self.verifyCacheFileDefaultPrim(cacheFile, cachePrimName)
 

--- a/test/lib/mayaUsd/fileio/testPrimUpdater.py
+++ b/test/lib/mayaUsd/fileio/testPrimUpdater.py
@@ -33,11 +33,29 @@ import fixturesUtils, os
 
 import unittest
 
+class primUpdaterAdditionalCommand(ufe.UndoableCommand):
+    def __init__(self):
+        self.executeCalled = False
+        self.undoCalled = False
+        self.redoCalled = False
+
+    def execute(self):
+        self.executeCalled = True
+
+    def undo(self):
+        self.undoCalled = True
+
+    def redo(self):
+        self.redoCalled = True
+
+
 class primUpdaterTest(mayaUsdLib.PrimUpdater):
     pushCopySpecsCalled = False
     discardEditsCalled = False
     editAsMayaCalled = False
     pushEndCalled = False
+    gotValidContext = False
+    additionalCmd = None
 
     def __init__(self, *args, **kwargs):
         super(primUpdaterTest, self).__init__(*args, **kwargs)
@@ -48,6 +66,14 @@ class primUpdaterTest(mayaUsdLib.PrimUpdater):
 
     def editAsMaya(self):
         primUpdaterTest.editAsMayaCalled = True
+        context = self.getContext()
+        if context:
+            primUpdaterTest.gotValidContext = True
+            # TODO: UFE does not expose CompositeUndoableCommand to Python yet.
+            # compositeCmd = context.GetAdditionalFinalCommands()
+            # if compositeCmd:
+            #     primUpdaterTest.additionalCmd = primUpdaterAdditionalCommand()
+            #     compositeCmd.append(primUpdaterTest.additionalCmd)
         return super(primUpdaterTest, self).editAsMaya()
 
     def discardEdits(self):
@@ -104,6 +130,12 @@ class testPrimUpdater(unittest.TestCase):
         self.assertTrue(primUpdaterTest.discardEditsCalled)
         self.assertTrue(primUpdaterTest.pushCopySpecsCalled)
         self.assertTrue(primUpdaterTest.pushEndCalled)
+        self.assertTrue(primUpdaterTest.gotValidContext)
+        # TODO: UFE does not expose CompositeUndoableCommand yet.
+        # self.assertIsNotNone(primUpdaterTest.additionalCmd)
+        # self.assertTrue(primUpdaterTest.additionalCmd.executeCalled)
+        # self.assertFalse(primUpdaterTest.additionalCmd.undoCalled)
+        # self.assertFalse(primUpdaterTest.additionalCmd.redoCalled)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/ufe/testContextOps.py
+++ b/test/lib/ufe/testContextOps.py
@@ -205,7 +205,7 @@ class ContextOpsTestCase(unittest.TestCase):
 
         # Verify we cannot switch variant in a weaker layer.
         self.assertRaises(RuntimeError, lambda: self.contextOps.doOpCmd(
-            ['Variant Sets', 'shadingVariant', 'Ball_8']))
+            ['Variant Sets', 'shadingVariant', 'Ball_8']).execute())
 
         # Verify the variant has not switched.
         self.assertEqual(shadingVariant(), 'Cue')


### PR DESCRIPTION
This required many fixes and improvements.

The main challenges were:
- The fact that a given prim is a Maya reference is the knowledge of custom prim update manager.
- Some things were not available as UFE commands.
- It is possible to edit multiple Maya Ref at the same time in a single edit session (for example two ref as child of an edited prim)
- Many small bugs or limitations that had to be fixed.

The first item was addressed by having the possibility for prim updater to add extra work to be done once an operation (edit-as-Maya, merge-to-USD, etc) is done successfully:
- Add a composite UFE command to the prim updater context.
- This command contains sub-commands that are executed at the end of a prim updater operation.
- The prim updater customization classes can thus add final work that need to be done after the edit-as-Maya or merge-to-USD is done.

Augment the updater undo items to support UFE commands:
- Added execute to OpUndoItem because UFE and Maya commands sometimes do things differently in execute vs redo.
- Added a UfeCommandUndoItem to execute UFE commands in the prim updater manager undo item system.

Add commands for edit and switching variants:
- Added Edit-as-Maya UFE command.
- Added Set-Variant-Selection UFE command.
- Change context op to use the new commands.

Modify the Maya ref prim updater to use this:
- Made the Maya Ref prim updater automatically switch to the Maya Ref variant when merge-to-USD ends.
- This uses the new prim updater context additional command system.
- This trigger an edit due to the existing code to edit when switching variant on auto-edit Maya Ref.
- (That code is in the prim updater manager, listening to scene notifications.)

Small fixes to make things work:
- Made the USD path to DAG path map settable on the context to avoid recreating the context multiple times.
- (Recreating the context  caused the additional commands to be lost...)
- Fixed the code that check if commands and property changes, etc are allowed when one layer is invalid (null).

Testing:
- Add a unit test.