### PR TITLE
MAYA-126179 merge-to-USD into variants

### DIFF
--- a/lib/mayaUsd/fileio/orphanedNodesManager.h
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.h
@@ -140,6 +140,10 @@ public:
     // purposes, to be used as argument to restore().
     Memento remove(const Ufe::Path& pulledPath);
 
+    // Retrieve the variant information of a pulled prim.
+    // Returns an empty info if the prim ws not tracked by the orphan manager.
+    const PullVariantInfo& get(const Ufe::Path& pulledPath) const;
+
     // Preserve the trie of pulled prims into a memento.
     Memento preserve() const;
 

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -648,11 +648,12 @@ bool pushCustomize(
 
     MayaUsd::ProgressBarScope progressBar(2);
 
-    const bool  isCopy = context.GetArgs()._copyOperation;
-    const auto& editTarget = context.GetUsdStage()->GetEditTarget();
-    auto dstRootPath = editTarget.MapToSpecPath(getDstSdfPath(ufePulledPath, srcRootPath, isCopy));
-    auto dstRootParentPath = dstRootPath.GetParentPath();
-    const auto& dstLayer = editTarget.GetLayer();
+    const bool            isCopy = context.GetArgs()._copyOperation;
+    const UsdEditTarget&  editTarget = context.GetUsdStage()->GetEditTarget();
+    const SdfPath         dstPath = getDstSdfPath(ufePulledPath, srcRootPath, isCopy);
+    const SdfPath         dstRootPath = editTarget.MapToSpecPath(dstPath);
+    const SdfPath         dstRootParentPath = dstRootPath.GetParentPath();
+    const SdfLayerHandle& dstLayer = editTarget.GetLayer();
 
     // Traverse the layer, creating a prim updater for each primSpec
     // along the way, and call PushCopySpec on the prim.
@@ -980,6 +981,20 @@ bool PrimUpdaterManager::mergeToUsd(
         scene.notify(Ufe::ObjectPreDelete(ufeMayaItem));
     progressBar.advance();
 
+    // Remove the pulled path from the orphan node manager *before* exporting
+    // and merging into the original USD. Otherwise, the orphan manager can
+    // receive notification mid-way through the merge process, while the variants
+    // have not all been authored and think the variant set has changed back
+    // to the correct variant and thus decide to deactivate the USD prim again,
+    // thinking the Maya data shoudl be shown again...
+#ifdef HAS_ORPHANED_NODES_MANAGER
+    if (_orphanedNodesManager) {
+        if (!TF_VERIFY(RemovePullVariantInfoUndoItem::execute(_orphanedNodesManager, pulledPath))) {
+            return false;
+        }
+    }
+#endif
+
     // Record all USD modifications in an undo block and item.
     UsdUndoBlock undoBlock(
         &UsdUndoableItemUndoItem::create("Merge to Maya USD data modifications"));
@@ -1138,7 +1153,9 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
     progressBar.advance();
 
 #ifdef HAS_ORPHANED_NODES_MANAGER
-    RecordPullVariantInfoUndoItem::execute(_orphanedNodesManager, path, importedPaths.first[0]);
+    if (_orphanedNodesManager) {
+        RecordPullVariantInfoUndoItem::execute(_orphanedNodesManager, path, importedPaths.first[0]);
+    }
 #endif
 
     if (!updaterArgs._copyOperation) {
@@ -1656,16 +1673,6 @@ bool PrimUpdaterManager::removePullParent(
     if (!TF_VERIFY(parentDagPath.isValid())) {
         return false;
     }
-
-#ifdef HAS_ORPHANED_NODES_MANAGER
-    if (!TF_VERIFY(_orphanedNodesManager)) {
-        return false;
-    }
-
-    if (!TF_VERIFY(RemovePullVariantInfoUndoItem::execute(_orphanedNodesManager, pulledPath))) {
-        return false;
-    }
-#endif
 
     MayaUsd::ProgressBarScope progressBar(2);
     MStatus                   status = NodeDeletionUndoItem::deleteNode(

--- a/lib/mayaUsd/fileio/utils/orphanedNodesManagerUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/orphanedNodesManagerUtil.cpp
@@ -19,6 +19,7 @@
 #include <ufe/trie.imp.h>
 
 namespace MAYAUSD_NS_DEF {
+namespace utils {
 
 namespace {
 
@@ -59,6 +60,8 @@ void toText(std::string& buf, const char* pfix, const Ufe::Path& ufePath, int in
     toText(buf, pfix, ufePath.string(), indent, eol);
 }
 
+} // namespace
+
 void toText(std::string& buf, const VariantSelection& sel, int indent, bool eol)
 {
     toText(buf, "Variant  ", sel.variantSetName, indent, eol);
@@ -92,9 +95,7 @@ void toText(std::string& buf, const PullVariantInfo& variantInfo, int indent, bo
     toText(buf, "", "}", indent, eol);
 }
 
-} // namespace
-
-void orphanedNodesManagerPullInfoToText(
+void toText(
     std::string&                               buffer,
     const Ufe::TrieNode<PullVariantInfo>::Ptr& trieNode,
     int                                        indent,
@@ -112,7 +113,7 @@ void orphanedNodesManagerPullInfoToText(
     }
 
     for (const auto& childComp : node.childrenComponents()) {
-        orphanedNodesManagerPullInfoToText(buffer, node[childComp], indent + 1, eol);
+        toText(buffer, node[childComp], indent + 1, eol);
     }
 
     if (eol)
@@ -125,8 +126,9 @@ void printOrphanedNodesManagerPullInfo(
     bool                                       eol)
 {
     std::string buffer("Trie ==========================================\n");
-    orphanedNodesManagerPullInfoToText(buffer, trieNode, indent, eol);
+    toText(buffer, trieNode, indent, eol);
     MGlobal::displayInfo(buffer.c_str());
 }
 
+} // namespace utils
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/fileio/utils/orphanedNodesManagerUtil.h
+++ b/lib/mayaUsd/fileio/utils/orphanedNodesManagerUtil.h
@@ -19,8 +19,27 @@
 #include <mayaUsd/fileio/orphanedNodesManager.h>
 
 namespace MAYAUSD_NS_DEF {
+namespace utils {
 
-void orphanedNodesManagerPullInfoToText(
+void toText(
+    std::string&                                  buf,
+    const OrphanedNodesManager::VariantSelection& sel,
+    int                                           indent = 0,
+    bool                                          eol = true);
+
+void toText(
+    std::string&                                      buf,
+    const OrphanedNodesManager::VariantSetDescriptor& descriptor,
+    int                                               indent = 0,
+    bool                                              eol = true);
+
+void toText(
+    std::string&                                 buf,
+    const OrphanedNodesManager::PullVariantInfo& variantInfo,
+    int                                          indent,
+    bool                                         eol);
+
+void toText(
     std::string&                                                     buffer,
     const Ufe::TrieNode<OrphanedNodesManager::PullVariantInfo>::Ptr& trieNode,
     int                                                              indent = 0,
@@ -31,4 +50,5 @@ void printOrphanedNodesManagerPullInfo(
     int                                                              indent = 0,
     bool                                                             eol = true);
 
+} // namespace utils
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/resources/scripts/mayaUsdMergeToUsd.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdMergeToUsd.py
@@ -53,7 +53,7 @@ def createMayaReferenceMenuItem(dagPath, precedingItem):
     # If the pulled prim doesn't exist anymore, we won't delegate the reponsibility to
     # another creator and handle the menu item in here. We already have all the information
     # available.
-    if prim:
+    if prim and prim.IsDefined():
         # If the pulled prim isn't a MayaReference, not our responsibility.
         if prim.GetTypeName() != 'MayaReference':
             return ''

--- a/lib/usd/utils/DiffMetadatas.cpp
+++ b/lib/usd/utils/DiffMetadatas.cpp
@@ -39,8 +39,6 @@ std::unordered_set<TfToken, TfToken::HashFunctor>& getIgnoredMetadata()
         PXR_NS::SdfFieldKeys->SubLayers,            // List of sub-layers names, we should not to deal with this when merging.
         PXR_NS::SdfFieldKeys->SubLayerOffsets,      // Time offset and scaling for the sub-layers. We treat animation data at the level it is already applied.
         PXR_NS::SdfFieldKeys->TypeName,             // Property data type. We should not have to copy this over by hand.
-        PXR_NS::SdfFieldKeys->VariantSetNames,      // The merge/copy process will take care of copying the selected variant.
-        PXR_NS::SdfFieldKeys->VariantSelection,     // The merge/copy process will take care of copying the selected variant.
     });
 
     // These other build-in metadata are allowed to be compared and merged:
@@ -92,6 +90,8 @@ std::unordered_set<TfToken, TfToken::HashFunctor>& getIgnoredMetadata()
     // SdfFieldKeys->SymmetryFunction,      // Property symmetry. (No docs)
     // SdfFieldKeys->TimeCodesPerSecond,    // Time code per second for playback (TCPS is advisory)
     // SdfFieldKeys->Variability,           // Control if the property can be animated.
+    // SdfFieldKeys->VariantSetNames,       // The merge/copy process will take care of copying the selected variant.
+    // SdfFieldKeys->VariantSelection,      // The merge/copy process will take care of copying the selected variant.
     // clang-format on
     return ignored;
 }


### PR DESCRIPTION
Code refactor:
- Add a get method on the orphaned node manager to access the saved variant sets.
- Expose more helping functions to convert to text the orphaned node manager data, to help debugging.

Fix mid-merge orphaning:
- Move where the orphaned node manager data for a pulled prim is removed when merging to USD.
- This is necessary because while merging, USD sends out notifications which would trigger the orphaned node manage mid-merge and cause havok.

Support merging into variants:
- Add support to merge into variants in mergePrims().
- This involves augmenting the target path with variant selections for intermediary prims and to create a edit target for any final variant selection.
- We need two different ways to handle variant selections because SdfCopySpec() has a bug that prevents it from copying into a target path that ends with a variant selection.
- Fix how we determine if merge to USD should be enabled.
- Fix prim retrieval during merge when calling GetPrimAtPath.

The function GetPrimAtPath in USD does not support variant selection. (Surprisingly, IMO.) So we need to explicitly strip variant selection when retrieving a prim.  This API limitation is both non-intuitive and error-prone: given that the function does not support variant selection, why does it not ignore them? This fix makes merging into sub-variants (variant within variant) work.