### PR TITLE
Write sourceColorSpace=raw when using Utility - Raw

### DIFF
--- a/lib/usd/translators/shading/shadingTokens.h
+++ b/lib/usd/translators/shading/shadingTokens.h
@@ -158,7 +158,8 @@ TF_DECLARE_PUBLIC_TOKENS(TrUsdTokens, , TR_USD_COMMON TR_USD_TEXTURE TR_USD_PRIM
     (filterType) \
     (invert) \
     ((UDIMTag, "<UDIM>")) \
-    (uvTilingMode) \
+    (uvTilingMode)   \
+    ((utilityRaw, "Utility - Raw"))  \
     (Raw) \
     (sRGB)
 

--- a/lib/usd/translators/shading/usdFileTextureWriter.cpp
+++ b/lib/usd/translators/shading/usdFileTextureWriter.cpp
@@ -289,7 +289,8 @@ void PxrUsdTranslators_FileTextureWriter::Write(const UsdTimeCode& usdTime)
         // Set the sourceColorSpace as well. The color space metadata will not be transmitted via
         // Hydra, so we need to set this attribute as well if we want hdStorm and the VP2 render
         // delegate to look correct
-        if (colorSpace == TrMayaTokens->Raw.GetText()) {
+        if (colorSpace == TrMayaTokens->Raw.GetText()
+            || colorSpace == TrMayaTokens->utilityRaw.GetText()) {
             shaderSchema.CreateInput(TrUsdTokens->sourceColorSpace, SdfValueTypeNames->Token)
                 .Set(TrUsdTokens->raw);
         } else if (colorSpace == TrMayaTokens->sRGB.GetText()) {


### PR DESCRIPTION
The logic for writing our `sourceColorSpace = "raw"` in the USD files was based on looking to see if the colorSpace was set to `Raw`.
However, if you're using OCIO colorspaces, `Utility - Raw` is also another valid option based on the [standard ocio config](https://github.com/colour-science/OpenColorIO-Configs/blob/master/aces_1.2/config.ocio) .

This also adds a case for that scenario. It would be the most common Raw setup in OCIO based studios unless they diverge from the base config.

Unfortunately, I do not know if your CI supports OCIO colorspace configs, so I didn't add a test for this. Please let me know how you'd like to handle that.