### PR TITLE
MAYA-126483 Fix a bug where materials got created in the wrong scope.

### DIFF
--- a/test/lib/ufe/testContextOps.py
+++ b/test/lib/ufe/testContextOps.py
@@ -848,13 +848,13 @@ class ContextOpsTestCase(unittest.TestCase):
 
         # Helper function to create a new proxy shape.
         import mayaUsd_createStageWithNewLayer
-        def createProxyShape() -> ufe.SceneItem:
+        def createProxyShape():
             proxyShapePathString = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
             proxyShapePath = ufe.PathString.path(proxyShapePathString)
             return ufe.Hierarchy.createItem(proxyShapePath)
 
         # Helper function to add a named new prim to a proxy shape.
-        def addNewPrim(proxyShape: ufe.SceneItem, primType: str, name: str = None) -> ufe.SceneItem:
+        def addNewPrim(proxyShape, primType, name = None):
             ufe.ContextOps.contextOps(proxyShape).doOp(["Add New Prim", primType])
             primItem = ufe.Hierarchy.hierarchy(proxyShape).children()[-1]
             assert primItem
@@ -867,7 +867,7 @@ class ContextOpsTestCase(unittest.TestCase):
             return primItem
 
         # Helper function that adds a sphere prim to a proxy shape and assigns it a new material.
-        def createMaterial(proxyShape: ufe.SceneItem) -> None:
+        def createMaterial(proxyShape):
             ufe.ContextOps.contextOps(proxyShape).doOp(['Add New Prim', 'Sphere'])
             sphereItem = ufe.Hierarchy.hierarchy(proxyShape).children()[-1]
             ufe.ContextOps.contextOps(sphereItem).doOp(['Assign New Material', 'USD', 'UsdPreviewSurface'])


### PR DESCRIPTION
When using "Assign New Material", a new material gets created in the default materials scope. This scope is usually called "mtl". In the previous implementation, there was a bug where materials got created in *any* scope that starts with "mtl". If, for example, there was a scope called "mtlFoo", and no scope called "mtl", the new material got created in "mtlFoo". However, the expected behaviour in this example is to create a scope called "mtl" and to create the new material in there.

This is the expected behaviour in a more general sense: If the default materials scope name (usually "mtl") is available, create the new material in a scope with this name. If the default materials scope name is not available i.e., there is already something that is not of type "Scope" that is using that name (e.g. an Xform called "mtl"), append a number suffix to the default materials scope name (e.g. "mtl1") and try to use that. If this name is not available either, increment the number suffix until an available name is found.

This PDF contains a list of examples to illustrate the expected behaviour: [materialScopesAcceptanceCriteria.pdf](https://github.com/Autodesk/maya-usd/files/10237427/materialScopesAcceptanceCriteria.pdf)
