### PR TITLE
MAYA-109455 UFE USD camera commands

### DIFF
--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -60,6 +60,7 @@ if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
             UsdTransform3dUndoableCommands.cpp
             UsdUIInfoHandler.cpp
             UsdUIUfeObserver.cpp
+            UsdUndoableCommand.cpp
             UsdUndoAddNewPrimCommand.cpp
             UsdUndoCreateGroupCommand.cpp
             UsdUndoInsertChildCommand.cpp

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -91,11 +91,11 @@ GfMatrix4d xformInv(
 }
 
 // Class for setMatrixCmd() implementation.
-class UsdSetMatrix4dUndoableCmd : public UsdBaseUndoableCommand<Ufe::SetMatrix4dUndoableCommand>
+class UsdSetMatrix4dUndoableCmd : public UsdUndoableCommand<Ufe::SetMatrix4dUndoableCommand>
 {
 public:
     UsdSetMatrix4dUndoableCmd(const Ufe::Path& path, const Ufe::Matrix4d& newM)
-        : UsdBaseUndoableCommand<Ufe::SetMatrix4dUndoableCommand>(path)
+        : UsdUndoableCommand<Ufe::SetMatrix4dUndoableCommand>(path)
         , _newM(newM)
     {
     }
@@ -109,7 +109,7 @@ public:
         return true;
     }
 
-    void executeUndoBlock() override
+    void executeImplementation() override
     {
         // Use editTransform3d() to set a single matrix transform op.
         // transform3d() returns a whole-object interface, which may include

--- a/lib/mayaUsd/ufe/UsdTransform3dUndoableCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dUndoableCommands.cpp
@@ -27,7 +27,7 @@ namespace ufe {
 UsdSetMatrix4dUndoableCommand::UsdSetMatrix4dUndoableCommand(
     const Ufe::Path&     path,
     const Ufe::Matrix4d& newM)
-    : UsdBaseUndoableCommand<Ufe::SetMatrix4dUndoableCommand>(path)
+    : UsdUndoableCommand<Ufe::SetMatrix4dUndoableCommand>(path)
 {
     // Decompose new matrix to extract TRS.  Neither GfMatrix4d::Factor
     // nor GfTransform decomposition provide results that match Maya,
@@ -57,7 +57,7 @@ bool UsdSetMatrix4dUndoableCommand::set(const Ufe::Matrix4d&)
     return true;
 }
 
-void UsdSetMatrix4dUndoableCommand::executeUndoBlock()
+void UsdSetMatrix4dUndoableCommand::executeImplementation()
 {
     // transform3d() and editTransform3d() are equivalent for a normal Maya
     // transform stack, but not for a fallback Maya transform stack, and

--- a/lib/mayaUsd/ufe/UsdTransform3dUndoableCommands.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dUndoableCommands.h
@@ -29,7 +29,7 @@ namespace ufe {
 // derived classes, with undo / redo support.
 //
 class MAYAUSD_CORE_PUBLIC UsdSetMatrix4dUndoableCommand
-    : public UsdBaseUndoableCommand<Ufe::SetMatrix4dUndoableCommand>
+    : public UsdUndoableCommand<Ufe::SetMatrix4dUndoableCommand>
 {
 public:
     UsdSetMatrix4dUndoableCommand(const Ufe::Path& path, const Ufe::Matrix4d& newM);
@@ -40,7 +40,7 @@ public:
     bool set(const Ufe::Matrix4d&) override;
 
 protected:
-    void executeUndoBlock() override;
+    void executeImplementation() override;
 
 private:
     Ufe::Vector3d _newT;

--- a/lib/mayaUsd/ufe/UsdUndoAttributesCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoAttributesCommands.cpp
@@ -60,7 +60,7 @@ Ufe::Attribute::Ptr UsdAddAttributeCommand::attribute() const
 
 void UsdAddAttributeCommand::setName(const std::string& newName) { _name = newName; }
 
-void UsdAddAttributeCommand::executeUndoBlock()
+void UsdAddAttributeCommand::executeImplementation()
 {
     // Validation has already been done. Just create the attribute.
     auto sceneItem
@@ -102,7 +102,7 @@ UsdRemoveAttributeCommand::create(const UsdSceneItem::Ptr& sceneItem, const std:
     return nullptr;
 }
 
-void UsdRemoveAttributeCommand::executeUndoBlock()
+void UsdRemoveAttributeCommand::executeImplementation()
 {
     // Validation has already been done. Just remove the attribute.
     auto sceneItem
@@ -143,7 +143,7 @@ UsdRenameAttributeCommand::Ptr UsdRenameAttributeCommand::create(
     return nullptr;
 }
 
-void UsdRenameAttributeCommand::executeUndoBlock()
+void UsdRenameAttributeCommand::executeImplementation()
 {
     // Validation has already been done. Just rename the attribute.
     auto sceneItem

--- a/lib/mayaUsd/ufe/UsdUndoAttributesCommands.h
+++ b/lib/mayaUsd/ufe/UsdUndoAttributesCommands.h
@@ -67,7 +67,7 @@ public:
 
     Ufe::Attribute::Ptr attribute() const override;
 
-    void executeUndoBlock() override;
+    void executeImplementation() override;
 
 #ifdef UFE_V4_FEATURES_AVAILABLE
 #if (UFE_PREVIEW_VERSION_NUM >= 4032)
@@ -103,7 +103,7 @@ public:
     static UsdRemoveAttributeCommand::Ptr
     create(const UsdSceneItem::Ptr& sceneItem, const std::string& name);
 
-    void executeUndoBlock() override;
+    void executeImplementation() override;
 
 #ifdef UFE_V4_FEATURES_AVAILABLE
 #if (UFE_PREVIEW_VERSION_NUM >= 4032)
@@ -142,7 +142,7 @@ public:
         const std::string&       originalName,
         const std::string&       newName);
 
-    void executeUndoBlock() override;
+    void executeImplementation() override;
 
     Ufe::Attribute::Ptr attribute() const override;
 

--- a/lib/mayaUsd/ufe/UsdUndoableCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoableCommand.cpp
@@ -1,0 +1,48 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "UsdUndoableCommand.h"
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+UsdUndoCapture::UsdUndoCapture() { }
+UsdUndoCapture::~UsdUndoCapture() { }
+
+void UsdUndoCapture::executeWithUndoCapture()
+{
+    UsdUndoBlock undoBlock(&_undoableItem);
+    executeImplementation();
+}
+
+bool UsdUndoCapture::setWithUndoCapture()
+{
+    UsdUndoBlock undoBlock(&_undoableItem);
+    return setImplementation();
+}
+
+bool UsdUndoCapture::setImplementation()
+{
+    executeImplementation();
+    return true;
+}
+
+void UsdUndoCapture::undoUsdChanges() { _undoableItem.undo(); }
+
+void UsdUndoCapture::redoUsdChanges() { _undoableItem.redo(); }
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoableCommand.h
@@ -95,18 +95,16 @@ class UsdUndoableCommand
 public:
     // This constructor allows passing arguments to the command bae class.
     // The magic of templated function will elide this if not used.
-    template <class ...ARGS>
-    UsdUndoableCommand(const ARGS& ...values)
+    template <class... ARGS>
+    UsdUndoableCommand(const ARGS&... values)
         : Cmd(values...)
-    {}
+    {
+    }
 
     // Ufe::UndoableCommand overrides.
     // Implemented by the UsdUndoCapture base class.
 
-    void execute() override
-    {
-        executeWithUndoCapture();
-    }
+    void execute() override { executeWithUndoCapture(); }
     void undo() override { undoUsdChanges(); }
     void redo() override { redoUsdChanges(); }
 };
@@ -124,8 +122,8 @@ public:
 
     // This constructor allows passing arguments to the command bae class.
     // The magic of templated function will elide this if not used.
-    template <class ...ARGS>
-    UsdFunctionUndoableCommand(const ARGS& ...values, Function&& func)
+    template <class... ARGS>
+    UsdFunctionUndoableCommand(const ARGS&... values, Function&& func)
         : UsdUndoableCommand<Cmd>(values...)
         , _func(func)
     {
@@ -158,7 +156,7 @@ public:
     // This constructor allows passing arguments to the command bae class.
     // The magic of templated function will elide this if not used.
     template <class... ARGS>
-    UsdUndoableSetCommand(const ARGS& ...values)
+    UsdUndoableSetCommand(const ARGS&... values)
         : Cmd(values...)
     {
     }
@@ -167,9 +165,10 @@ public:
     // Implemented by the UsdUndoCapture base class.
 
     void execute() override { executeWithUndoCapture(); }
-    bool set(ValueType value) override {
+    bool set(ValueType value) override
+    {
         _value = value;
-         return setWithUndoCapture();
+        return setWithUndoCapture();
     }
     void undo() override { undoUsdChanges(); }
     void redo() override { redoUsdChanges(); }

--- a/test/lib/ufe/testCamera.py
+++ b/test/lib/ufe/testCamera.py
@@ -127,12 +127,12 @@ class CameraTestCase(unittest.TestCase):
         self.assertAlmostEqual(ufeCamera.nearClipPlane(), clippingRange[0])
         self.assertAlmostEqual(ufeCamera.farClipPlane(), clippingRange[1])
 
-        # setting camera values through Ufe is not yet implemented in MayaUSD
-        # ufeCamera.nearClipPlane(10)
-        # ufeCamera.farClipPlane(20)
-        # clippingRange = clippingAttr.Get()
-        # self.assertAlmostEqual(10, clippingRange[0])
-        # self.assertAlmostEqual(20, clippingRange[1])
+        # set the clipping planes using UFE
+        ufeCamera.nearClipPlane(10)
+        ufeCamera.farClipPlane(20)
+        clippingRange = clippingAttr.Get()
+        self.assertAlmostEqual(10, clippingRange[0])
+        self.assertAlmostEqual(20, clippingRange[1])
 
         # set the clipping planes using USD
         clippingAttr.Set(Gf.Vec2f(1, 50))
@@ -149,8 +149,11 @@ class CameraTestCase(unittest.TestCase):
         # the ufeCamera gives us inches
         self.assertAlmostEqual(self.mmToCm * horizontalAperture, self.inchesToCm * ufeCamera.horizontalAperture())
 
-        # setting camera values through Ufe is not yet implemented in MayaUSD
+        # set the horizontal aperture using UFE
+        ufeCamera.horizontalAperture(0.9)
+        self.assertAlmostEqual(0.9, ufeCamera.horizontalAperture())
 
+        # set the horizontal aperture using USD
         usdAttr.Set(0.5)
         self.assertAlmostEqual(self.mmToCm * 0.5, self.inchesToCm * ufeCamera.horizontalAperture())
     
@@ -160,8 +163,11 @@ class CameraTestCase(unittest.TestCase):
 
         self.assertAlmostEqual(self.mmToCm * verticalAperture, self.inchesToCm * ufeCamera.verticalAperture())
 
-        # setting camera values through Ufe is not yet implemented in MayaUSD
+        # set the vertical aperture using UFE
+        ufeCamera.verticalAperture(0.3)
+        self.assertAlmostEqual(0.3, ufeCamera.verticalAperture())
 
+        # set the vertical aperture using UFE
         usdAttr.Set(0.5)
         self.assertAlmostEqual(self.mmToCm * 0.5, self.inchesToCm * ufeCamera.verticalAperture())
 
@@ -171,8 +177,11 @@ class CameraTestCase(unittest.TestCase):
 
         self.assertAlmostEqual(self.mmToCm * horizontalApertureOffset, self.inchesToCm * ufeCamera.horizontalApertureOffset())
 
-        # setting camera values through Ufe is not yet implemented in MayaUSD
+        # set the horizontal aperture offset using UFE
+        ufeCamera.horizontalApertureOffset(0.2)
+        self.assertAlmostEqual(0.2, ufeCamera.horizontalApertureOffset())
 
+        # set the horizontal aperture offset using USD
         usdAttr.Set(0.5)
         self.assertAlmostEqual(self.mmToCm * 0.5, self.inchesToCm * ufeCamera.horizontalApertureOffset())
     
@@ -182,8 +191,11 @@ class CameraTestCase(unittest.TestCase):
 
         self.assertAlmostEqual(self.mmToCm * verticalApertureOffset, self.inchesToCm * ufeCamera.verticalApertureOffset())
 
-        # setting camera values through Ufe is not yet implemented in MayaUSD
+        # set the vertical aperture offset using UFE
+        ufeCamera.verticalApertureOffset(0.1)
+        self.assertAlmostEqual(0.1, ufeCamera.verticalApertureOffset())
 
+        # set the vertical aperture offset using USD
         usdAttr.Set(0.5)
         self.assertAlmostEqual(self.mmToCm * 0.5, self.inchesToCm * ufeCamera.verticalApertureOffset())
     
@@ -194,8 +206,11 @@ class CameraTestCase(unittest.TestCase):
         # precision error here from converting units so use a less precise comparison, 6 digits instead of 7
         self.assertAlmostEqual(fStop, self.mmToCm * ufeCamera.fStop(), 6)
 
-        # setting camera values through Ufe is not yet implemented in MayaUSD
+        # set the f-stop offset using UFE
+        ufeCamera.fStop(8.)
+        self.assertAlmostEqual(8., ufeCamera.fStop())
 
+        # set the f-stop offset using USD
         usdAttr.Set(0.5)
         self.assertAlmostEqual(0.5, self.mmToCm * ufeCamera.fStop(), 6)
 
@@ -205,8 +220,11 @@ class CameraTestCase(unittest.TestCase):
 
         self.assertAlmostEqual(self.mmToCm * focalLength, self.mmToCm * ufeCamera.focalLength())
 
-        # setting camera values through Ufe is not yet implemented in MayaUSD
+        # set the focal length offset using UFE
+        ufeCamera.focalLength(12.)
+        self.assertAlmostEqual(12., ufeCamera.focalLength())
 
+        # set the focal length offset using USD
         usdAttr.Set(0.5)
         self.assertAlmostEqual(self.mmToCm * 0.5, self.mmToCm * ufeCamera.focalLength())
 
@@ -216,8 +234,11 @@ class CameraTestCase(unittest.TestCase):
 
         self.assertAlmostEqual(self.mmToCm * focusDistance, self.mmToCm * ufeCamera.focusDistance())
 
-        # setting camera values through Ufe is not yet implemented in MayaUSD
+        # set the focus distance offset using UFE
+        ufeCamera.focusDistance(9.)
+        self.assertAlmostEqual(9., ufeCamera.focusDistance())
 
+        # set the focus distance offset using USD
         usdAttr.Set(0.5)
         self.assertAlmostEqual(self.mmToCm * 0.5, self.mmToCm * ufeCamera.focusDistance())
 
@@ -227,10 +248,13 @@ class CameraTestCase(unittest.TestCase):
 
         self.assertEqual(ufe.Camera.Perspective, ufeCamera.projection())
 
-        # setting camera values through Ufe is not yet implemented in MayaUSD
-
-        usdAttr.Set("orthographic")
+        # set the projection offset using UFE
+        ufeCamera.projection(ufe.Camera.Orthographic)
         self.assertAlmostEqual(ufe.Camera.Orthographic, ufeCamera.projection())
+
+        # set the projection offset using USD
+        usdAttr.Set("perspective")
+        self.assertAlmostEqual(ufe.Camera.Perspective, ufeCamera.projection())
 
     @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'Requires Python API only available in Maya 2023 or greater.')
     def testUsdCamera(self):


### PR DESCRIPTION
Implemeted the UFE commands necessary to set values on a camera via UFE.

Extended the available base classes to implement UFE commands that modify USD data. Make each base class do one thing only, to clarify the purpose of each.

Add UsdUndoCapture class:
- It captures the changes to USD data within a UFE command.
- Its sub-classes only need to implement executeImplementation() and optionally setImplementation().
- It provides executeWithUndoCapture to do the command execution implementation while capture USD changes.
- Same for setWithUndoCapture.
- Provides undoUsdChanges() to undo all changes that were capture.
- Same with redoUsdChanges, to redo the changes.

Refactor UsdUndoableCommand class:
- Make UsdUndoableCommand use UsdUndoCapture class.
- Add templated variable-arguments constructor to support any command base classs that can take arguments in its constructor.
- This includes taking zero argument.

Add UsdFunctionUndoableCommand class:
- This is a UFE command implementation where the actual command execution is done in a free function.
- Avoids having to declare entire classes only to implement a single execute function.

Added UsdUndoableSetCommand class:
- This is for undoable commands that sets value and must implement a set function.
- Also has a Function sub-class to impelment it with a single free function.

Refactor existing command to use the new base class:
- Refactor UsdAttribute commands to use the new classes.
- Refactor UsdLight commands to use the new classes.
- Refactor UsdSetMatridx4Undoable command the same way,
- This avoids code duplication.
- There are more commands that could be refactored, but this is a starting set.

Implement USDCamera commands.
- Implement various commands related to UFE/USD cameras.
- These use the new funciton-base command helper classes.
- Added helper function to convert units.
- Re-verified the units used by the camera and documented them.