### PR TITLE
MAYA-122927 interaction between deactivation and cancel edit

### DIFF
--- a/lib/mayaUsd/fileio/orphanedNodesManager.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.cpp
@@ -149,6 +149,22 @@ void handlePathChange(
     }
 }
 
+// Control the orphaned nodes manager in-orphaning flag.
+class Orphaning
+{
+public:
+    Orphaning(int& orphaning)
+        : _orphaning(orphaning)
+    {
+        ++_orphaning;
+    }
+
+    ~Orphaning() { --_orphaning; }
+
+private:
+    int& _orphaning;
+};
+
 } // namespace
 
 OrphanedNodesManager::OrphanedNodesManager()
@@ -235,6 +251,11 @@ void OrphanedNodesManager::operator()(const Ufe::Notification& n)
 
 void OrphanedNodesManager::handleOp(const Ufe::SceneCompositeNotification::Op& op)
 {
+    if (_inOrphaning > 0)
+        return;
+
+    Orphaning orphaning(_inOrphaning);
+
     switch (op.opType) {
     case Ufe::SceneCompositeNotification::OpType::ObjectAdd: {
         // Restoring a previously-deleted scene item may restore an orphaned

--- a/lib/mayaUsd/fileio/orphanedNodesManager.h
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.h
@@ -185,6 +185,10 @@ private:
     // UFE pulled path, and the Trie value is the corresponding Dag pull parent
     // and all ancestor variant set selections.
     Ufe::Trie<PullVariantInfo> _pulledPrims;
+
+    // Flag to tell that the orphaned nodes manager is currently orphaning
+    // nodes and should not react to its own actions.
+    int _inOrphaning = 0;
 };
 
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/fileio/pullInformation.cpp
+++ b/lib/mayaUsd/fileio/pullInformation.cpp
@@ -17,6 +17,7 @@
 #include "pullInformation.h"
 
 #include <mayaUsd/ufe/Utils.h>
+#include <mayaUsd/utils/primActivation.h>
 #include <mayaUsdUtils/util.h>
 
 #include <pxr/usd/usd/editContext.h>
@@ -174,6 +175,9 @@ void removePulledPrimMetadata(const PXR_NS::UsdStagePtr& stage, PXR_NS::UsdPrim&
 
 bool addExcludeFromRendering(const Ufe::Path& ufePulledPath)
 {
+    // Note: must make sure the prim is accessible by activating all its ancestors.
+    PrimActivation activation(ufePulledPath);
+
     PXR_NS::UsdPrim prim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
     if (!prim.IsValid())
         return false;
@@ -194,9 +198,17 @@ bool addExcludeFromRendering(const Ufe::Path& ufePulledPath)
 
 bool removeExcludeFromRendering(const Ufe::Path& ufePulledPath)
 {
+    // Note: must make sure the prim is accessible by activating all its ancestors.
+    PrimActivation activation(ufePulledPath);
+
     PXR_NS::UsdPrim prim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
     if (!prim.IsValid())
         return false;
+
+    // If already active, nothing to do. This happens in some recursive
+    // notification situations.
+    if (prim.IsActive())
+        return true;
 
     auto stage = prim.GetStage();
     if (!stage)

--- a/lib/mayaUsd/utils/CMakeLists.txt
+++ b/lib/mayaUsd/utils/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(${PROJECT_NAME}
         loadRulesAttribute.cpp
         query.cpp
         plugRegistryHelper.cpp
+        primActivation.cpp
         progressBarScope.cpp
         selectability.cpp
         stageCache.cpp
@@ -50,6 +51,7 @@ set(HEADERS
     loadRules.h
     query.h
     plugRegistryHelper.h
+    primActivation.h
     progressBarScope.h
     selectability.h
     stageCache.h

--- a/lib/mayaUsd/utils/CMakeLists.txt
+++ b/lib/mayaUsd/utils/CMakeLists.txt
@@ -17,7 +17,6 @@ target_sources(${PROJECT_NAME}
         loadRulesAttribute.cpp
         query.cpp
         plugRegistryHelper.cpp
-        primActivation.cpp
         progressBarScope.cpp
         selectability.cpp
         stageCache.cpp
@@ -34,6 +33,7 @@ if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
     target_sources(${PROJECT_NAME}
         PRIVATE
             json.cpp
+            primActivation.cpp
     )
 endif()
 
@@ -51,7 +51,6 @@ set(HEADERS
     loadRules.h
     query.h
     plugRegistryHelper.h
-    primActivation.h
     progressBarScope.h
     selectability.h
     stageCache.h
@@ -66,6 +65,7 @@ set(HEADERS
 if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
     list(APPEND HEADERS
         json.h
+        primActivation.h
     )
 endif()
 

--- a/lib/mayaUsd/utils/primActivation.cpp
+++ b/lib/mayaUsd/utils/primActivation.cpp
@@ -1,0 +1,118 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "primActivation.h"
+
+#include <mayaUsd/ufe/Utils.h>
+
+#include <pxr/usd/sdf/layer.h>
+#include <pxr/usd/usd/editContext.h>
+#include <pxr/usd/usd/prim.h>
+
+namespace MAYAUSD_NS_DEF {
+
+using namespace PXR_NS;
+
+namespace {
+
+void activate(
+    const UsdStagePtr& stage,
+    const SdfPath&     path,
+    SdfPathSet&        previouslyInactive,
+    SdfPathSet&        forcedActive)
+{
+    if (!stage)
+        return;
+
+    SdfLayerHandle sessionLayer = stage->GetSessionLayer();
+    UsdEditContext editContext(stage, sessionLayer);
+
+    // The last prefix is the path itself and we don't need to activate
+    // it, so skip processing if there is only one prefix, otherwise
+    // remove the last prefix since it is the path and we don't want
+    // to explicitly activate it.
+    SdfPathVector prefixes = path.GetPrefixes();
+    if (prefixes.size() < 2)
+        return;
+    prefixes.pop_back();
+
+    for (const SdfPath& prefixPath : prefixes) {
+        UsdPrim prim = stage->GetPrimAtPath(prefixPath);
+        if (prim.IsActive())
+            continue;
+
+        // If the prim at the path has a "active" field in the session
+        // layer, then we must remember to set the opinion back to deactivated.
+        // Otherwise, we must remember to clear the opinion we are authoring.
+        if (sessionLayer->HasField(prefixPath, TfToken("active"))) {
+            previouslyInactive.insert(prefixPath);
+        } else {
+            forcedActive.insert(prefixPath);
+        }
+
+        prim.SetActive(true);
+    }
+}
+
+void deactivate(const UsdStagePtr& stage, SdfPathSet& previouslyInactive, SdfPathSet& forcedActive)
+{
+    if (!stage)
+        return;
+
+    SdfLayerHandle sessionLayer = stage->GetSessionLayer();
+    UsdEditContext editContext(stage, sessionLayer);
+
+    for (const SdfPath& path : previouslyInactive) {
+        UsdPrim prim = stage->GetPrimAtPath(path);
+        prim.SetActive(false);
+    }
+
+    previouslyInactive.clear();
+
+    for (const SdfPath& path : forcedActive) {
+        UsdPrim prim = stage->GetPrimAtPath(path);
+        prim.ClearActive();
+    }
+
+    forcedActive.clear();
+}
+
+} // namespace
+
+PrimActivation::PrimActivation(const UsdStagePtr& stage, const SdfPath& path)
+    : _stage(stage)
+{
+    if (!_stage)
+        throw std::runtime_error("Cannot find stage to activate prims.");
+
+    activate(stage, path, _previouslyInactive, _forcedActive);
+}
+
+PrimActivation::PrimActivation(const Ufe::Path& path)
+    : _stage(MayaUsd::ufe::getStage(path))
+{
+    if (!_stage)
+        throw std::runtime_error("Cannot find stage to activate prims.");
+
+    const auto    segments = path.getSegments();
+    const SdfPath usdPath = (segments.size() < 2) ? SdfPath("/") : SdfPath(segments[1].string());
+    activate(_stage, usdPath, _previouslyInactive, _forcedActive);
+}
+
+PrimActivation::~PrimActivation() { restore(); }
+
+void PrimActivation::restore() { deactivate(_stage, _previouslyInactive, _forcedActive); }
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/primActivation.h
+++ b/lib/mayaUsd/utils/primActivation.h
@@ -1,0 +1,73 @@
+//
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_ACTIVATION_H
+#define MAYAUSD_ACTIVATION_H
+
+#include <mayaUsd/base/api.h>
+
+#include <pxr/usd/sdf/path.h>
+#include <pxr/usd/usd/stage.h>
+
+#include <ufe/path.h>
+
+namespace MAYAUSD_NS_DEF {
+
+//! \brief  Change the active status of a prim.
+//
+// Record the previous activation status of ancestors so that they can be
+// restored once the manipulation is done. This is necessary because children
+// of a deactivated prim cannot be accessed nor modified in USD. We must first
+// activate all ancestor, do the modifications, then restore the ancestor
+// activation state.
+//
+// The temporary activations are done in the session layer.
+
+class MAYAUSD_CORE_PUBLIC PrimActivation
+{
+public:
+    //! \brief empty prim activation. Allow delayed initialization, for example
+    //         inside a conditional.
+    PrimActivation() = default;
+
+    //! \brief make the prim at the given path accessible.
+    PrimActivation(const PXR_NS::UsdStagePtr& stage, const PXR_NS::SdfPath& path);
+
+    //! \brief make the prim at the given path accessible.
+    PrimActivation(const Ufe::Path& path);
+
+    //! \brief restore the previous activation status of ancestors.
+    ~PrimActivation();
+
+    //! \brief restore the previous activation status of ancestors.
+    void restore();
+
+private:
+    PXR_NS::UsdStagePtr _stage;
+
+    // Record prims that had de-activation opinions already
+    // authored in the session layer. Those are the opinions
+    // that need to be explicitly restored as inactive.
+    PXR_NS::SdfPathSet _previouslyInactive;
+
+    // Record prims that had de-activation opinions already
+    // authored in the layers below the session layer. Those
+    // are the opinions that need to be explicitly cleared.
+    PXR_NS::SdfPathSet _forcedActive;
+};
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_ACTIVATION_H

--- a/lib/usd/translators/mayaReferenceUpdater.cpp
+++ b/lib/usd/translators/mayaReferenceUpdater.cpp
@@ -24,6 +24,7 @@
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/utils/editRouter.h>
+#include <mayaUsd/utils/primActivation.h>
 #include <mayaUsd/utils/util.h>
 #include <mayaUsd/utils/utilSerialization.h>
 #include <mayaUsd/utils/variants.h>
@@ -52,10 +53,13 @@ namespace {
 // Clear the auto-edit flag on a USD Maya Reference so that it does not
 // get edited immediately again. Clear in all variants, since each
 // variant has its own copy of the flag.
-void clearAutoEdit(const UsdPrim& prim)
+void clearAutoEdit(const Ufe::Path& pulledPath)
 {
+    MAYAUSD_NS::PrimActivation activation(pulledPath);
+
     // The given prim can be invalid. This happens for example if an
     // ancestor was deactivated.
+    UsdPrim prim = MayaUsd::ufe::ufePathToPrim(pulledPath);
     if (!prim.IsValid())
         return;
 
@@ -269,8 +273,7 @@ bool PxrUsdTranslators_MayaReferenceUpdater::discardEdits()
         Ufe::Path pulledPath;
         if (MAYAUSD_NS_DEF::readPullInformation(dagPath, pulledPath)) {
             // Reset the auto-edit when discarding the edit.
-            UsdPrim prim = MayaUsd::ufe::ufePathToPrim(pulledPath);
-            clearAutoEdit(prim);
+            clearAutoEdit(pulledPath);
         }
     }
 

--- a/test/lib/mayaUsd/fileio/CMakeLists.txt
+++ b/test/lib/mayaUsd/fileio/CMakeLists.txt
@@ -19,7 +19,6 @@ endif()
 
 if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
     list(APPEND TEST_SCRIPT_FILES
-        testAddMayaReference.py
         testEditAsMaya.py
         testMergeToUsd.py
         testDuplicateAs.py
@@ -93,6 +92,27 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             ENV
                 "HAS_ORPHANED_NODES_MANAGER=1"
+        )
+    else()
+        mayaUsd_add_test(${target}
+            PYTHON_MODULE ${target}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+    endif()
+
+    # Add a ctest label for easy filtering.
+    set_property(TEST ${target} APPEND PROPERTY LABELS fileio)
+endif()
+
+if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
+    mayaUsd_get_unittest_target(target testAddMayaReference.py)
+
+    if(UFE_TRIE_NODE_HAS_CHILDREN_COMPONENTS_ACCESSOR)
+        mayaUsd_add_test(${target}
+            PYTHON_MODULE ${target}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            ENV
+            "HAS_ORPHANED_NODES_MANAGER=1"
         )
     else()
         mayaUsd_add_test(${target}

--- a/test/lib/mayaUsd/fileio/testAddMayaReference.py
+++ b/test/lib/mayaUsd/fileio/testAddMayaReference.py
@@ -283,7 +283,9 @@ class AddMayaReferenceTestCase(unittest.TestCase):
         attr = mayaRefPrim.GetAttribute('mayaAutoEdit')
         self.assertTrue(attr.IsValid())
         self.assertEqual(attr.Get(), False)
-        self.assertTrue(mayaRefPrim.IsActive())
+        # This functionality requires the orphaned nodes manager.
+        if os.getenv('HAS_ORPHANED_NODES_MANAGER', '0') >= '1':
+            self.assertTrue(mayaRefPrim.IsActive())
 
 
     def testEditAndMergeMayaRef(self):

--- a/test/lib/mayaUsd/fileio/testAddMayaReference.py
+++ b/test/lib/mayaUsd/fileio/testAddMayaReference.py
@@ -272,9 +272,8 @@ class AddMayaReferenceTestCase(unittest.TestCase):
         primTestDefault.SetActive(True)
         self.assertTrue(primTestDefault.IsActive())
 
-        # Verify that the auto-edit has *not* been turned off since it could not
-        # be edited when discarding edits since the prim was not accessible since
-        # its parent prim was deactivated.
+        # Verify that the auto-edit has been turned off even though its parent prim
+        # was deactivated.
         #
         # Note: we have to retrieved the Maya ref prim again because when its parent
         #       was deactivated, the UsdPrim object became invalid and cannot be used
@@ -283,8 +282,8 @@ class AddMayaReferenceTestCase(unittest.TestCase):
         mayaRefPrim = usdUtils.getPrimFromSceneItem(mayaRefUsdItem)
         attr = mayaRefPrim.GetAttribute('mayaAutoEdit')
         self.assertTrue(attr.IsValid())
-        self.assertEqual(attr.Get(), True)
-        self.assertFalse(mayaRefPrim.IsActive())
+        self.assertEqual(attr.Get(), False)
+        self.assertTrue(mayaRefPrim.IsActive())
 
 
     def testEditAndMergeMayaRef(self):

--- a/test/lib/mayaUsd/fileio/testDiscardEdits.py
+++ b/test/lib/mayaUsd/fileio/testDiscardEdits.py
@@ -121,7 +121,7 @@ class DiscardEditsTestCase(unittest.TestCase):
 
     @unittest.skipUnless(ufeFeatureSetVersion() >= 3, 'Test only available in UFE v3 or greater.')
     def testDiscardEditsWhenParentIsDeactivated(self):
-        '''Discard edits on a USD transform when its parent is deactivated shoudl fail but not crash.'''
+        '''Discard edits on a USD transform when its parent is deactivated should not fail and not crash.'''
 
         # Edit as Maya the B item.
         (ps,
@@ -162,17 +162,10 @@ class DiscardEditsTestCase(unittest.TestCase):
         aUsdPrim = usdUtils.getPrimFromSceneItem(aUsdItem)
         aUsdPrim.SetActive(True)
 
-        # The B item is still inactive.
+        # The B item is still active, because we forced it to be ditable through teh session layer.
         # Recreate the UFE item since the USD Prim was temporarily deactive
         bUsdItem = ufeUtils.createItem(bUsdUfePath)
         bUsdPrim = usdUtils.getPrimFromSceneItem(bUsdItem)
-        self.assertFalse(bUsdPrim.IsActive())
-
-        # Activate the B item. Need to target the session layer since edit-as-Maya
-        # had deactivated the prim in the session layer.
-        stage = bUsdPrim.GetStage()
-        with Usd.EditContext(stage, Usd.EditTarget(stage.GetSessionLayer())):
-            bUsdPrim.SetActive(True)
         self.assertTrue(bUsdPrim.IsActive())
 
         # Hierarchy is restored: USD item is child of proxy shape, Maya item is

--- a/test/lib/mayaUsd/fileio/testDiscardEdits.py
+++ b/test/lib/mayaUsd/fileio/testDiscardEdits.py
@@ -162,17 +162,20 @@ class DiscardEditsTestCase(unittest.TestCase):
         aUsdPrim = usdUtils.getPrimFromSceneItem(aUsdItem)
         aUsdPrim.SetActive(True)
 
-        # The B item is still active, because we forced it to be ditable through teh session layer.
         # Recreate the UFE item since the USD Prim was temporarily deactive
         bUsdItem = ufeUtils.createItem(bUsdUfePath)
         bUsdPrim = usdUtils.getPrimFromSceneItem(bUsdItem)
-        self.assertTrue(bUsdPrim.IsActive())
 
-        # Hierarchy is restored: USD item is child of proxy shape, Maya item is
-        # not.  Be careful to use the Maya path rather than the Maya item, which
-        # should no longer exist.
-        self.assertIn(bUsdItem, aHier.children())
-        self.assertNotIn(bMayaPath, [child.path() for child in aHier.children()])
+        # The B item is still active, because we forced it to be editable through the session layer.
+        # This functionality requires the orphaned nodes manager.
+        if os.getenv('HAS_ORPHANED_NODES_MANAGER', '0') >= '1':
+            self.assertTrue(bUsdPrim.IsActive())
+
+            # Hierarchy is restored: USD item is child of proxy shape, Maya item is
+            # not.  Be careful to use the Maya path rather than the Maya item, which
+            # should no longer exist.
+            self.assertIn(bUsdItem, aHier.children())
+            self.assertNotIn(bMayaPath, [child.path() for child in aHier.children()])
 
         # Maya node is removed.
         with self.assertRaises(RuntimeError):


### PR DESCRIPTION
When a Maya reference is edited, its USD prim is deactivated to hide it in the outliner. If its parent prim is then deactivated, the edit is orphaned. At that point the Maya Ref prim and its parent are both deactivated. If the edit is cancelled while the parent is deactivated, the code could not activate the Maya Ref USD prim because children of deactivated prims cannot be modified. We needed to fix this.

The fix is to add code to temporarily reactivate ancestors prims when trying to activate a prim. The design actually provides a class to temporarily activate all ancestors of a prim, for any possible edits.

- Add PrimActivation class to temporarily make a prim accessible even when its ancestors are deactivated.
- It works by activating all inactive ancestors by authoring opinions in the session layer.
- Use this class in the addExcludedFromRendering and removeExcludedFromRendering functions.
- Add a flag in the orphaned nodes manager to avoid responding to notifications caused by its own responses to notifications.
- This avoids infinite recursion when the work done to orphan an edited node caused notifications to be sent.
- In our case, the temporary reactivation of prims would cause an infinite flip-flop or orphaning and de-orphaning.

A unit test already checked the case where an edited prim was under a dectivated prim, but had not checked for the proper result due to the known bug. Simply fix the test for the fix.

Also, fix that the auto-edit flag was not being properly updated due to the same ancestor-is-deactivated problem.