### PR TITLE
MAYA-104552 improve message diagnostics

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -23,6 +23,7 @@
 #include <mayaUsd/nodes/proxyShapeStageExtraData.h>
 #include <mayaUsd/nodes/stageData.h>
 #include <mayaUsd/utils/customLayerData.h>
+#include <mayaUsd/utils/diagnosticDelegate.h>
 #include <mayaUsd/utils/layerMuting.h>
 #include <mayaUsd/utils/loadRules.h>
 #include <mayaUsd/utils/query.h>
@@ -509,6 +510,8 @@ void MayaUsdProxyShapeBase::postConstructor()
 /* virtual */
 MStatus MayaUsdProxyShapeBase::compute(const MPlug& plug, MDataBlock& dataBlock)
 {
+    UsdMayaDiagnosticBatchContext batchDiagnosticMessages;
+
     if (plug == outTimeAttr || plug.isDynamic())
         ProxyAccessor::compute(_usdAccessor, plug, dataBlock);
 

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -510,8 +510,6 @@ void MayaUsdProxyShapeBase::postConstructor()
 /* virtual */
 MStatus MayaUsdProxyShapeBase::compute(const MPlug& plug, MDataBlock& dataBlock)
 {
-    UsdMayaDiagnosticBatchContext batchDiagnosticMessages;
-
     if (plug == outTimeAttr || plug.isDynamic())
         ProxyAccessor::compute(_usdAccessor, plug, dataBlock);
 

--- a/lib/mayaUsd/python/wrapDiagnosticDelegate.cpp
+++ b/lib/mayaUsd/python/wrapDiagnosticDelegate.cpp
@@ -28,16 +28,14 @@ PXR_NAMESPACE_USING_DIRECTIVE;
 
 namespace {
 
-// This exposes UsdMayaDiagnosticBatchContext as a Python "context manager"
-// object that can be used with the "with"-statement.
+// This exposes a DiagnosticBatchContext as a Python "context manager"
+// object that can be used with the "with"-statement to flush diagostic
+// messages
 class _PyDiagnosticBatchContext
 {
 public:
-    void __enter__() { _context.reset(new UsdMayaDiagnosticBatchContext()); }
-    void __exit__(object, object, object) { _context.reset(); }
-
-private:
-    std::unique_ptr<UsdMayaDiagnosticBatchContext> _context;
+    void __enter__() { }
+    void __exit__(object, object, object) { UsdMayaDiagnosticDelegate::Flush(); }
 };
 
 } // anonymous namespace
@@ -46,8 +44,8 @@ void wrapDiagnosticDelegate()
 {
     typedef UsdMayaDiagnosticDelegate This;
     class_<This, boost::noncopyable>("DiagnosticDelegate", no_init)
-        .def("GetBatchCount", &This::GetBatchCount)
-        .staticmethod("GetBatchCount");
+        .def("Flush", &This::Flush)
+        .staticmethod("Flush");
 
     typedef _PyDiagnosticBatchContext Context;
     class_<Context, boost::noncopyable>("DiagnosticBatchContext")

--- a/lib/mayaUsd/python/wrapDiagnosticDelegate.cpp
+++ b/lib/mayaUsd/python/wrapDiagnosticDelegate.cpp
@@ -49,7 +49,9 @@ void wrapDiagnosticDelegate()
     typedef UsdMayaDiagnosticDelegate This;
     class_<This, boost::noncopyable>("DiagnosticDelegate", no_init)
         .def("Flush", &This::Flush)
-        .staticmethod("Flush");
+        .staticmethod("Flush")
+        .def("SetMaximumUnbatchedDiagnostics", &This::SetMaximumUnbatchedDiagnostics)
+        .staticmethod("SetMaximumUnbatchedDiagnostics");
 
     typedef _PyDiagnosticBatchContext Context;
     class_<Context, boost::noncopyable>("DiagnosticBatchContext")

--- a/lib/mayaUsd/python/wrapDiagnosticDelegate.cpp
+++ b/lib/mayaUsd/python/wrapDiagnosticDelegate.cpp
@@ -34,8 +34,12 @@ namespace {
 class _PyDiagnosticBatchContext
 {
 public:
-    void __enter__() { }
-    void __exit__(object, object, object) { UsdMayaDiagnosticDelegate::Flush(); }
+    void __enter__() { UsdMayaDiagnosticDelegate::SetMaximumUnbatchedDiagnostics(0); }
+    void __exit__(object, object, object)
+    {
+        UsdMayaDiagnosticDelegate::Flush();
+        UsdMayaDiagnosticDelegate::SetMaximumUnbatchedDiagnostics(100);
+    }
 };
 
 } // anonymous namespace

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -1374,21 +1374,11 @@ bool UsdMayaGLBatchRenderer::_UpdateIsSelectionPending(const bool isPending)
     return true;
 }
 
-void UsdMayaGLBatchRenderer::StartBatchingFrameDiagnostics()
-{
-    if (!_sharedDiagBatchCtx) {
-        _sharedDiagBatchCtx.reset(new UsdMayaDiagnosticBatchContext());
-    }
-}
-
 void UsdMayaGLBatchRenderer::_MayaRenderDidEnd(const MHWRender::MDrawContext* /* context */)
 {
     // Completing a viewport render invalidates any previous selection
     // computation we may have done, so mark a new one as pending.
     _UpdateIsSelectionPending(true);
-
-    // End any diagnostics batching.
-    _sharedDiagBatchCtx.reset();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
@@ -271,12 +271,6 @@ public:
     MAYAUSD_CORE_PUBLIC
     inline bool GetObjectSoftSelectEnabled() { return _objectSoftSelectEnabled; }
 
-    /// Starts batching all diagnostics until the end of the current frame draw.
-    /// The batch renderer will automatically release the diagnostics when Maya
-    /// is done rendering the frame.
-    MAYAUSD_CORE_PUBLIC
-    void StartBatchingFrameDiagnostics();
-
 private:
     friend class TfSingleton<UsdMayaGLBatchRenderer>;
 
@@ -479,12 +473,6 @@ private:
     HdxSelectionTrackerSharedPtr _selectionTracker;
 
     UsdMayaGLSoftSelectHelper _softSelectHelper;
-
-    /// Shared diagnostic batch context. Used for cases where we want to batch
-    /// diagnostics across multiple function calls, e.g., batching all of the
-    /// Sync() diagnostics across all prepareForDraw() callbacks in a single
-    /// frame.
-    std::unique_ptr<UsdMayaDiagnosticBatchContext> _sharedDiagBatchCtx;
 };
 
 MAYAUSD_TEMPLATE_CLASS(TfSingleton<UsdMayaGLBatchRenderer>);

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
@@ -98,8 +98,6 @@ bool PxrMayaHdShapeAdapter::Sync(
 {
     // Legacy viewport implementation.
 
-    UsdMayaGLBatchRenderer::GetInstance().StartBatchingFrameDiagnostics();
-
     const unsigned int displayStyle
         = px_LegacyViewportUtils::GetMFrameContextDisplayStyle(legacyDisplayStyle);
     const MHWRender::DisplayStatus displayStatus = _ToMHWRenderDisplayStatus(legacyDisplayStatus);
@@ -134,8 +132,6 @@ bool PxrMayaHdShapeAdapter::Sync(
     const MHWRender::DisplayStatus displayStatus)
 {
     // Viewport 2.0 implementation.
-
-    UsdMayaGLBatchRenderer::GetInstance().StartBatchingFrameDiagnostics();
 
     TF_DEBUG(PXRUSDMAYAGL_SHAPE_ADAPTER_LIFECYCLE)
         .Msg("Synchronizing PxrMayaHdShapeAdapter for Viewport 2.0: %p\n", this);

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -1191,8 +1191,6 @@ void ProxyRenderDelegate::update(MSubSceneContainer& container, const MFrameCont
         MProfiler::kColorD_L1,
         "ProxyRenderDelegate::update");
 
-    UsdMayaDiagnosticBatchContext batchDiagnosticMessages;
-
     // Without a proxy shape we can't do anything
     if (_proxyShapeData->ProxyShape() == nullptr)
         return;

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -23,6 +23,7 @@
 #include <mayaUsd/base/tokens.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/nodes/stageData.h>
+#include <mayaUsd/utils/diagnosticDelegate.h>
 #include <mayaUsd/utils/selectability.h>
 
 #include <pxr/base/tf/diagnostic.h>
@@ -1189,6 +1190,8 @@ void ProxyRenderDelegate::update(MSubSceneContainer& container, const MFrameCont
         HdVP2RenderDelegate::sProfilerCategory,
         MProfiler::kColorD_L1,
         "ProxyRenderDelegate::update");
+
+    UsdMayaDiagnosticBatchContext batchDiagnosticMessages;
 
     // Without a proxy shape we can't do anything
     if (_proxyShapeData->ProxyShape() == nullptr)

--- a/lib/mayaUsd/utils/diagnosticDelegate.cpp
+++ b/lib/mayaUsd/utils/diagnosticDelegate.cpp
@@ -25,14 +25,12 @@
 
 #include <ghc/filesystem.hpp>
 
-PXR_NAMESPACE_OPEN_SCOPE
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
 
-TF_DEFINE_ENV_SETTING(
-    PIXMAYA_DIAGNOSTICS_BATCH,
-    true,
-    "Whether to batch diagnostics coming from the same call site. "
-    "If batching is off, all secondary threads' diagnostics will be "
-    "printed to stderr.");
+PXR_NAMESPACE_OPEN_SCOPE
 
 TF_DEFINE_ENV_SETTING(
     MAYAUSD_SHOW_FULL_DIAGNOSTICS,
@@ -40,144 +38,193 @@ TF_DEFINE_ENV_SETTING(
     "This env flag controls the granularity of TF error/warning/status messages "
     "being displayed in Maya.");
 
-// Globally-shared delegate. Uses shared_ptr so we can have weak ptrs.
-static std::shared_ptr<UsdMayaDiagnosticDelegate> _sharedDelegate;
+namespace {
+
+class DiagnosticFlusher;
+
+std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedStatuses;
+std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedWarnings;
+std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedErrors;
+std::unique_ptr<DiagnosticFlusher>                    _flusher;
+std::atomic<bool>                                     _hasPendingDiagnostic;
 
 // The delegate can be installed by multiple plugins (e.g. pxrUsd and
 // mayaUsdPlugin), so keep track of installations to ensure that we only add
 // the delegate for the first installation call, and that we only remove it for
 // the last removal call.
-static int _installationCount = 0;
+std::atomic<int> _installationCount = 0;
 
-namespace {
-
-class _StatusOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
+/// @brief USD diagnostic delegate that accumulates all status messages.
+class StatusOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
 {
-    void IssueWarning(const TfWarning&) override { }
+    void IssueWarning(const TfWarning&) override { _hasPendingDiagnostic = true; }
+    void IssueError(const TfError&) override { _hasPendingDiagnostic = true; }
+    void IssueFatalError(const TfCallContext&, const std::string&) override { }
+};
+
+/// @brief USD diagnostic delegate that accumulates all warning messages.
+class WarningOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
+{
+    void IssueStatus(const TfStatus&) override { _hasPendingDiagnostic = true; }
     void IssueError(const TfError&) override { }
     void IssueFatalError(const TfCallContext&, const std::string&) override { }
 };
 
-class _WarningOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
-{
-    void IssueStatus(const TfStatus&) override { }
-    void IssueError(const TfError&) override { }
-    void IssueFatalError(const TfCallContext&, const std::string&) override { }
-};
-
-class _ErrorOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
+/// @brief USD diagnostic delegate that accumulates all error messages.
+class ErrorOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
 {
     void IssueWarning(const TfWarning&) override { }
     void IssueStatus(const TfStatus&) override { }
-    void IssueFatalError(const TfCallContext&, const std::string&) override { }
+    void IssueFatalError(const TfCallContext& context, const std::string& msg) override
+    {
+        UsdMayaDiagnosticDelegate::Flush();
+
+        TfLogCrash(
+            "FATAL ERROR",
+            msg,
+            /*additionalInfo*/ std::string(),
+            context,
+            /*logToDb*/ true);
+        _UnhandledAbort();
+    }
+};
+
+/// @brief Periodically flushes the accumulated messages.
+///
+/// The design goes like this:
+///
+///     - All messages are accumulated by the above delegates.
+///     - A thread, periodicFlusher, wakes up every second to conditionally flush
+///       pending messages.
+///     - The condition for flushing are that a forced flush is requested or some messages
+//        have been received and one second has elapsed.
+///     - Requesting a flushing of accumulated messages is done by queuing a task to be
+///       run on idle in the main thread. If a task is already queued, nothing is done.
+///     - The main-thread task takes (extract and removes) all accumulted messages and
+///       prints them in the script console via MGlobal.
+///     - This can only be done in the main thread because that is what MGlobal supports.
+class DiagnosticFlusher
+{
+public:
+    DiagnosticFlusher()
+    {
+        _periodicThread = std::make_unique<std::thread>([this]() { periodicFlusher(); });
+    }
+
+    ~DiagnosticFlusher()
+    {
+        if (_periodicThread) {
+            _periodicThread->join();
+            _periodicThread.reset();
+        }
+    }
+
+    void forceFlush()
+    {
+        if (ArchIsMainThread()) {
+            flushPerformedInMainThread();
+        } else {
+            _forceFlush = true;
+            std::unique_lock<std::mutex> lock(_pendingDiagnosticsMutex);
+            _pendingDiagnosticCond.notify_all();
+        }
+    }
+
+private:
+    using Clock = std::chrono::steady_clock;
+    template <class Duration> using TimePoint = std::chrono::time_point<Clock, Duration>;
+    using Sec = std::chrono::seconds;
+
+    static MString formatCoalescedDiagnostic(const UsdUtilsCoalescingDiagnosticDelegateItem& item)
+    {
+        const size_t      numItems = item.unsharedItems.size();
+        const std::string suffix
+            = numItems == 1 ? std::string() : TfStringPrintf(" -- and %zu similar", numItems - 1);
+        const std::string message
+            = TfStringPrintf("%s%s", item.unsharedItems[0].commentary.c_str(), suffix.c_str());
+
+        return message.c_str();
+    }
+
+    static void flushDiagnostics(
+        const std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate>& delegate,
+        const std::function<void(const MString&)>&                   printer)
+    {
+        const UsdUtilsCoalescingDiagnosticDelegateVector messages = delegate
+            ? delegate->TakeCoalescedDiagnostics()
+            : UsdUtilsCoalescingDiagnosticDelegateVector();
+        for (const UsdUtilsCoalescingDiagnosticDelegateItem& item : messages) {
+            printer(formatCoalescedDiagnostic(item));
+        }
+    }
+
+    void flushPerformedInMainThread()
+    {
+        TF_AXIOM(ArchIsMainThread());
+
+        {
+            std::unique_lock<std::mutex> lock(_pendingDiagnosticsMutex);
+            _triggeredFlush = false;
+            _hasPendingDiagnostic = false;
+        }
+
+        // Note that we must be in the main thread here, so it's safe to call
+        // displayInfo/displayWarning.
+        flushDiagnostics(_batchedStatuses, MGlobal::displayInfo);
+        flushDiagnostics(_batchedWarnings, MGlobal::displayWarning);
+        flushDiagnostics(_batchedErrors, MGlobal::displayError);
+    }
+
+    static void flushPerformedInMainThreadCallback(void* data)
+    {
+        DiagnosticFlusher* self = static_cast<DiagnosticFlusher*>(data);
+        self->flushPerformedInMainThread();
+    }
+
+    void triggerFlushInMainThread()
+    {
+        if (_triggeredFlush)
+            return;
+        _triggeredFlush = true;
+        MGlobal::executeTaskOnIdle(flushPerformedInMainThreadCallback, this);
+    }
+
+    void periodicFlusher()
+    {
+        using namespace std::chrono_literals;
+
+        while (_installationCount > 0) {
+            try {
+                std::unique_lock<std::mutex> lock(_pendingDiagnosticsMutex);
+                _pendingDiagnosticCond.wait_for(lock, 1s);
+                if (_forceFlush) {
+                    _forceFlush = false;
+                    triggerFlushInMainThread();
+                } else if (_hasPendingDiagnostic) {
+                    const auto now = Clock::now();
+                    const auto elapsed = std::chrono::duration<double>(now - _lastFlushTime);
+                    if (elapsed.count() >= 1.) {
+                        _lastFlushTime = now;
+                        triggerFlushInMainThread();
+                    }
+                }
+            } catch (const std::exception&) {
+                // Do nothing.
+            }
+        }
+    }
+
+    std::unique_ptr<std::thread> _periodicThread;
+
+    std::mutex              _pendingDiagnosticsMutex;
+    std::condition_variable _pendingDiagnosticCond;
+    Clock::time_point       _lastFlushTime;
+    std::atomic<bool>       _forceFlush = false;
+    std::atomic<bool>       _triggeredFlush = false;
 };
 
 } // anonymous namespace
 
-static MString _FormatDiagnostic(const TfDiagnosticBase& d)
-{
-    if (!TfGetEnvSetting(MAYAUSD_SHOW_FULL_DIAGNOSTICS)) {
-        return d.GetCommentary().c_str();
-    } else {
-        const std::string msg = TfStringPrintf(
-            "%s -- %s in %s at line %zu of %s",
-            d.GetCommentary().c_str(),
-            TfDiagnosticMgr::GetCodeName(d.GetDiagnosticCode()).c_str(),
-            d.GetContext().GetFunction(),
-            d.GetContext().GetLine(),
-            ghc::filesystem::path(d.GetContext().GetFile()).relative_path().string().c_str());
-        return msg.c_str();
-    }
-}
-
-static MString _FormatCoalescedDiagnostic(const UsdUtilsCoalescingDiagnosticDelegateItem& item)
-{
-    const size_t      numItems = item.unsharedItems.size();
-    const std::string suffix
-        = numItems == 1 ? std::string() : TfStringPrintf(" -- and %zu similar", numItems - 1);
-    const std::string message
-        = TfStringPrintf("%s%s", item.unsharedItems[0].commentary.c_str(), suffix.c_str());
-
-    return message.c_str();
-}
-
-static bool _IsDiagnosticBatchingEnabled() { return TfGetEnvSetting(PIXMAYA_DIAGNOSTICS_BATCH); }
-
-UsdMayaDiagnosticDelegate::UsdMayaDiagnosticDelegate()
-    : _batchCount(0)
-{
-    TfDiagnosticMgr::GetInstance().AddDelegate(this);
-}
-
-UsdMayaDiagnosticDelegate::~UsdMayaDiagnosticDelegate()
-{
-    // If a batch context was open when the delegate is removed, we need to
-    // flush all the batched diagnostics in order to avoid losing any.
-    // The batch context should know how to clean itself up when the delegate
-    // is gone.
-    _FlushBatch();
-    TfDiagnosticMgr::GetInstance().RemoveDelegate(this);
-}
-
-void UsdMayaDiagnosticDelegate::IssueError(const TfError& err)
-{
-    if (_batchCount.load() > 0) {
-        return; // Batched.
-    }
-
-    const auto diagnosticMessage = _FormatDiagnostic(err);
-
-    if (ArchIsMainThread()) {
-        MGlobal::displayError(diagnosticMessage);
-    } else {
-        std::cerr << diagnosticMessage << std::endl;
-    }
-}
-
-void UsdMayaDiagnosticDelegate::IssueStatus(const TfStatus& status)
-{
-    if (_batchCount.load() > 0) {
-        return; // Batched.
-    }
-
-    const auto diagnosticMessage = _FormatDiagnostic(status);
-
-    if (ArchIsMainThread()) {
-        MGlobal::displayInfo(diagnosticMessage);
-    } else {
-        std::cerr << diagnosticMessage << std::endl;
-    }
-}
-
-void UsdMayaDiagnosticDelegate::IssueWarning(const TfWarning& warning)
-{
-    if (_batchCount.load() > 0) {
-        return; // Batched.
-    }
-
-    const auto diagnosticMessage = _FormatDiagnostic(warning);
-
-    if (ArchIsMainThread()) {
-        MGlobal::displayWarning(diagnosticMessage);
-    } else {
-        std::cerr << diagnosticMessage << std::endl;
-    }
-}
-
-void UsdMayaDiagnosticDelegate::IssueFatalError(
-    const TfCallContext& context,
-    const std::string&   msg)
-{
-    TfLogCrash(
-        "FATAL ERROR",
-        msg,
-        /*additionalInfo*/ std::string(),
-        context,
-        /*logToDb*/ true);
-    _UnhandledAbort();
-}
-
-/* static */
 void UsdMayaDiagnosticDelegate::InstallDelegate()
 {
     if (!ArchIsMainThread()) {
@@ -192,10 +239,12 @@ void UsdMayaDiagnosticDelegate::InstallDelegate()
         return;
     }
 
-    _sharedDelegate.reset(new UsdMayaDiagnosticDelegate());
+    _flusher = std::make_unique<DiagnosticFlusher>();
+    _batchedStatuses = std::make_unique<StatusOnlyDelegate>();
+    _batchedWarnings = std::make_unique<WarningOnlyDelegate>();
+    _batchedErrors = std::make_unique<ErrorOnlyDelegate>();
 }
 
-/* static */
 void UsdMayaDiagnosticDelegate::RemoveDelegate()
 {
     if (!ArchIsMainThread()) {
@@ -210,93 +259,18 @@ void UsdMayaDiagnosticDelegate::RemoveDelegate()
         return;
     }
 
-    _sharedDelegate.reset();
+    Flush();
+
+    _flusher.reset();
+    _batchedStatuses.reset();
+    _batchedWarnings.reset();
+    _batchedErrors.reset();
 }
 
-/* static */
-int UsdMayaDiagnosticDelegate::GetBatchCount()
+void UsdMayaDiagnosticDelegate::Flush()
 {
-    if (std::shared_ptr<UsdMayaDiagnosticDelegate> ptr = _sharedDelegate) {
-        return ptr->_batchCount.load();
-    }
-
-    TF_RUNTIME_ERROR("Delegate is not installed");
-    return 0;
-}
-
-void UsdMayaDiagnosticDelegate::_StartBatch()
-{
-    if (!ArchIsMainThread())
-        return;
-
-    if (_batchCount.fetch_add(1) == 0) {
-        // This is the first _StartBatch; add the batching delegates.
-        _batchedStatuses.reset(new _StatusOnlyDelegate());
-        _batchedWarnings.reset(new _WarningOnlyDelegate());
-        _batchedErrors.reset(new _ErrorOnlyDelegate());
-    }
-}
-
-void UsdMayaDiagnosticDelegate::_EndBatch()
-{
-    if (!ArchIsMainThread())
-        return;
-
-    const int prevValue = _batchCount.fetch_sub(1);
-    if (prevValue <= 0) {
-        TF_RUNTIME_ERROR("_EndBatch invoked before _StartBatch");
-    } else if (prevValue == 1) {
-        // This is the last _EndBatch; print the diagnostic messages.
-        // and remove the batching delegates.
-        _FlushBatch();
-        _batchedStatuses.reset();
-        _batchedWarnings.reset();
-        _batchedErrors.reset();
-    }
-}
-
-static void flushDiagnostics(
-    const std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate>& delegate,
-    const std::function<void(const MString&)>&                   printer)
-{
-    const UsdUtilsCoalescingDiagnosticDelegateVector messages = delegate
-        ? delegate->TakeCoalescedDiagnostics()
-        : UsdUtilsCoalescingDiagnosticDelegateVector();
-    for (const UsdUtilsCoalescingDiagnosticDelegateItem& item : messages) {
-        printer(_FormatCoalescedDiagnostic(item));
-    }
-}
-
-void UsdMayaDiagnosticDelegate::_FlushBatch()
-{
-    TF_AXIOM(ArchIsMainThread());
-
-    // Note that we must be in the main thread here, so it's safe to call
-    // displayInfo/displayWarning.
-    flushDiagnostics(_batchedStatuses, MGlobal::displayInfo);
-    flushDiagnostics(_batchedWarnings, MGlobal::displayWarning);
-    flushDiagnostics(_batchedErrors, MGlobal::displayError);
-}
-
-UsdMayaDiagnosticBatchContext::UsdMayaDiagnosticBatchContext()
-    : _delegate(_IsDiagnosticBatchingEnabled() ? _sharedDelegate : nullptr)
-{
-    if (ArchIsMainThread()) {
-        TF_DEBUG(PXRUSDMAYA_DIAGNOSTICS).Msg(">> Entering batch context\n");
-        if (std::shared_ptr<UsdMayaDiagnosticDelegate> ptr = _delegate.lock()) {
-            ptr->_StartBatch();
-        }
-    }
-}
-
-UsdMayaDiagnosticBatchContext::~UsdMayaDiagnosticBatchContext()
-{
-    if (ArchIsMainThread()) {
-        TF_DEBUG(PXRUSDMAYA_DIAGNOSTICS).Msg("!! Exiting batch context\n");
-        if (std::shared_ptr<UsdMayaDiagnosticDelegate> ptr = _delegate.lock()) {
-            ptr->_EndBatch();
-        }
-    }
+    if (_flusher)
+        _flusher->forceFlush();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/utils/diagnosticDelegate.cpp
+++ b/lib/mayaUsd/utils/diagnosticDelegate.cpp
@@ -45,8 +45,8 @@ class DiagnosticFlusher;
 std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedStatuses;
 std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedWarnings;
 std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedErrors;
+std::unique_ptr<TfDiagnosticMgr::Delegate>            _waker;
 std::unique_ptr<DiagnosticFlusher>                    _flusher;
-std::atomic<bool>                                     _hasPendingDiagnostic;
 
 // The delegate can be installed by multiple plugins (e.g. pxrUsd and
 // mayaUsdPlugin), so keep track of installations to ensure that we only add
@@ -57,15 +57,15 @@ std::atomic<int> _installationCount = 0;
 /// @brief USD diagnostic delegate that accumulates all status messages.
 class StatusOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
 {
-    void IssueWarning(const TfWarning&) override { _hasPendingDiagnostic = true; }
-    void IssueError(const TfError&) override { _hasPendingDiagnostic = true; }
+    void IssueWarning(const TfWarning&) override { }
+    void IssueError(const TfError&) override { }
     void IssueFatalError(const TfCallContext&, const std::string&) override { }
 };
 
 /// @brief USD diagnostic delegate that accumulates all warning messages.
 class WarningOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
 {
-    void IssueStatus(const TfStatus&) override { _hasPendingDiagnostic = true; }
+    void IssueStatus(const TfStatus&) override { }
     void IssueError(const TfError&) override { }
     void IssueFatalError(const TfCallContext&, const std::string&) override { }
 };
@@ -108,32 +108,53 @@ class DiagnosticFlusher
 public:
     DiagnosticFlusher()
     {
+        // Note: the periodic thread access member variables, so it must be initialized
+        //       after all members are initialized. That is why we create it in the
+        //       constructor body and not the initialization list.
         _periodicThread = std::make_unique<std::thread>([this]() { periodicFlusher(); });
     }
 
     ~DiagnosticFlusher()
     {
-        if (_periodicThread) {
-            _periodicThread->join();
-            _periodicThread.reset();
+        try {
+            if (_periodicThread) {
+                _periodicThread->join();
+                _periodicThread.reset();
+            }
+        } catch (const std::exception&) {
         }
     }
 
     void forceFlush()
     {
-        if (ArchIsMainThread()) {
-            flushPerformedInMainThread();
-        } else {
-            _forceFlush = true;
+        triggerFlushInMainThread();
+    }
+
+    void setMaximumUnbatchedDiagnostics(unsigned count) { _maximumUnbatchedDiagnostics = count; }
+
+    void receivedDiagnostic()
+    {
+        // On the first diagnostic message, check how long since we flushed the diagnostics.
+        // If it is less than a minimum, we assume we are in a burst of messages and delay
+        // writing messages.
+        //
+        // If it is the first message in a long time, we flush it immediately.
+        if (_pendingDiagnosticCount.fetch_add(1) > _maximumUnbatchedDiagnostics)
+            return;
+        {
             std::unique_lock<std::mutex> lock(_pendingDiagnosticsMutex);
-            _pendingDiagnosticCond.notify_all();
+            ElapsedTimePoint             elapsed = getElapsedSeconds();
+            if (elapsed.first < _flushingPeriod)
+                return;
         }
+        triggerFlushInMainThread();
     }
 
 private:
     using Clock = std::chrono::steady_clock;
     template <class Duration> using TimePoint = std::chrono::time_point<Clock, Duration>;
     using Sec = std::chrono::seconds;
+    using ElapsedTimePoint = std::pair<double, Clock::time_point>;
 
     static MString formatCoalescedDiagnostic(const UsdUtilsCoalescingDiagnosticDelegateItem& item)
     {
@@ -146,15 +167,47 @@ private:
         return message.c_str();
     }
 
+    static MString formatDiagnostic(const std::unique_ptr<TfDiagnosticBase>& item)
+    {
+        if (!item)
+            return MString();
+        if (!TfGetEnvSetting(MAYAUSD_SHOW_FULL_DIAGNOSTICS)) {
+            return item->GetCommentary().c_str();
+        } else {
+            const std::string msg = TfStringPrintf(
+                "%s -- %s in %s at line %zu of %s",
+                item->GetCommentary().c_str(),
+                TfDiagnosticMgr::GetCodeName(item->GetDiagnosticCode()).c_str(),
+                item->GetContext().GetFunction(),
+                item->GetContext().GetLine(),
+                ghc::filesystem::path(item->GetContext().GetFile())
+                    .relative_path()
+                    .string()
+                    .c_str());
+            return msg.c_str();
+        }
+    }
+
     static void flushDiagnostics(
         const std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate>& delegate,
+        const bool                                                   printBatched,
         const std::function<void(const MString&)>&                   printer)
     {
-        const UsdUtilsCoalescingDiagnosticDelegateVector messages = delegate
-            ? delegate->TakeCoalescedDiagnostics()
-            : UsdUtilsCoalescingDiagnosticDelegateVector();
-        for (const UsdUtilsCoalescingDiagnosticDelegateItem& item : messages) {
-            printer(formatCoalescedDiagnostic(item));
+        if (!delegate)
+            return;
+
+        if (printBatched) {
+            const UsdUtilsCoalescingDiagnosticDelegateVector messages
+                = delegate->TakeCoalescedDiagnostics();
+            for (const UsdUtilsCoalescingDiagnosticDelegateItem& item : messages) {
+                printer(formatCoalescedDiagnostic(item));
+            }
+        } else {
+            std::vector<std::unique_ptr<TfDiagnosticBase>> messages
+                = delegate->TakeUncoalescedDiagnostics();
+            for (const std::unique_ptr<TfDiagnosticBase>& item : messages) {
+                printer(formatDiagnostic(item));
+            }
         }
     }
 
@@ -162,17 +215,19 @@ private:
     {
         TF_AXIOM(ArchIsMainThread());
 
+        bool printBatched = false;
         {
             std::unique_lock<std::mutex> lock(_pendingDiagnosticsMutex);
             _triggeredFlush = false;
-            _hasPendingDiagnostic = false;
+            printBatched = _pendingDiagnosticCount > _maximumUnbatchedDiagnostics;
+            _pendingDiagnosticCount = 0;
         }
 
         // Note that we must be in the main thread here, so it's safe to call
         // displayInfo/displayWarning.
-        flushDiagnostics(_batchedStatuses, MGlobal::displayInfo);
-        flushDiagnostics(_batchedWarnings, MGlobal::displayWarning);
-        flushDiagnostics(_batchedErrors, MGlobal::displayError);
+        flushDiagnostics(_batchedStatuses, printBatched, MGlobal::displayInfo);
+        flushDiagnostics(_batchedWarnings, printBatched, MGlobal::displayWarning);
+        flushDiagnostics(_batchedErrors, printBatched, MGlobal::displayError);
     }
 
     static void flushPerformedInMainThreadCallback(void* data)
@@ -183,10 +238,21 @@ private:
 
     void triggerFlushInMainThread()
     {
-        if (_triggeredFlush)
-            return;
-        _triggeredFlush = true;
-        MGlobal::executeTaskOnIdle(flushPerformedInMainThreadCallback, this);
+        if (ArchIsMainThread()) {
+            flushPerformedInMainThread();
+        } else {
+            if (_triggeredFlush)
+                return;
+            _triggeredFlush = true;
+            MGlobal::executeTaskOnIdle(flushPerformedInMainThreadCallback, this);
+        }
+    }
+
+    ElapsedTimePoint getElapsedSeconds() const
+    {
+        const auto now = Clock::now();
+        const auto elapsed = std::chrono::duration<double>(now - _lastFlushTime);
+        return std::make_pair(elapsed.count(), now);
     }
 
     void periodicFlusher()
@@ -197,16 +263,14 @@ private:
             try {
                 std::unique_lock<std::mutex> lock(_pendingDiagnosticsMutex);
                 _pendingDiagnosticCond.wait_for(lock, 1s);
-                if (_forceFlush) {
-                    _forceFlush = false;
+
+                if (_pendingDiagnosticCount == 0)
+                    continue;
+
+                const ElapsedTimePoint elapsed = getElapsedSeconds();
+                if (elapsed.first >= _flushingPeriod) {
+                    _lastFlushTime = elapsed.second;
                     triggerFlushInMainThread();
-                } else if (_hasPendingDiagnostic) {
-                    const auto now = Clock::now();
-                    const auto elapsed = std::chrono::duration<double>(now - _lastFlushTime);
-                    if (elapsed.count() >= 1.) {
-                        _lastFlushTime = now;
-                        triggerFlushInMainThread();
-                    }
                 }
             } catch (const std::exception&) {
                 // Do nothing.
@@ -218,9 +282,31 @@ private:
 
     std::mutex              _pendingDiagnosticsMutex;
     std::condition_variable _pendingDiagnosticCond;
-    Clock::time_point       _lastFlushTime;
-    std::atomic<bool>       _forceFlush = false;
+    Clock::time_point       _lastFlushTime = Clock::now();
     std::atomic<bool>       _triggeredFlush = false;
+    std::atomic<unsigned>   _pendingDiagnosticCount = 0;
+    unsigned                _maximumUnbatchedDiagnostics = 100;
+
+    static constexpr double   _flushingPeriod = 1.;
+};
+
+/// @brief USD diagnostic delegate that wakes up the flushing thread.
+class WakeUpDelegate : public TfDiagnosticMgr::Delegate
+{
+public:
+    WakeUpDelegate() { TfDiagnosticMgr::GetInstance().AddDelegate(this); }
+    ~WakeUpDelegate()
+    {
+        try {
+            TfDiagnosticMgr::GetInstance().RemoveDelegate(this);
+        } catch (const std::exception&) {
+        }
+    }
+
+    void IssueError(const TfError&) override { _flusher->receivedDiagnostic(); }
+    void IssueWarning(const TfWarning&) override { _flusher->receivedDiagnostic(); }
+    void IssueStatus(const TfStatus&) override { _flusher->receivedDiagnostic(); }
+    void IssueFatalError(const TfCallContext&, const std::string&) override { }
 };
 
 } // anonymous namespace
@@ -239,10 +325,17 @@ void UsdMayaDiagnosticDelegate::InstallDelegate()
         return;
     }
 
-    _flusher = std::make_unique<DiagnosticFlusher>();
     _batchedStatuses = std::make_unique<StatusOnlyDelegate>();
     _batchedWarnings = std::make_unique<WarningOnlyDelegate>();
     _batchedErrors = std::make_unique<ErrorOnlyDelegate>();
+
+    // Note: flusher accesses the batched status, so the flusher must be created
+    //       after the batcher.
+    _flusher = std::make_unique<DiagnosticFlusher>();
+
+    // Note: waker accesses the flusher, so the waker must be created
+    //       after the flusher.
+    _waker = std::make_unique<WakeUpDelegate>();
 }
 
 void UsdMayaDiagnosticDelegate::RemoveDelegate()
@@ -261,7 +354,14 @@ void UsdMayaDiagnosticDelegate::RemoveDelegate()
 
     Flush();
 
+    // Note: waker accesses the flusher, so the waker must be destroyed
+    //       before the flusher.
+    _waker.reset();
+
+    // Note: flusher accesses the batched status, so the flusher must be destroyed
+    //       before the batcher.
     _flusher.reset();
+
     _batchedStatuses.reset();
     _batchedWarnings.reset();
     _batchedErrors.reset();
@@ -271,6 +371,12 @@ void UsdMayaDiagnosticDelegate::Flush()
 {
     if (_flusher)
         _flusher->forceFlush();
+}
+
+void UsdMayaDiagnosticDelegate::SetMaximumUnbatchedDiagnostics(unsigned count)
+{
+    if (_flusher)
+        _flusher->setMaximumUnbatchedDiagnostics(count);
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/utils/diagnosticDelegate.cpp
+++ b/lib/mayaUsd/utils/diagnosticDelegate.cpp
@@ -183,7 +183,8 @@ void UsdMayaDiagnosticDelegate::InstallDelegate()
     if (!ArchIsMainThread()) {
         // Don't crash, but inform user about failure to install
         // the USD diagnostic message handler.
-        TF_ERROR("Cannot install the USD diagnostic message printer from a secondary thread");
+        TF_RUNTIME_ERROR(
+            "Cannot install the USD diagnostic message printer from a secondary thread");
         return;
     }
 
@@ -200,7 +201,8 @@ void UsdMayaDiagnosticDelegate::RemoveDelegate()
     if (!ArchIsMainThread()) {
         // Don't crash, but inform user about failure to remove
         // the USD diagnostic message handler.
-        TF_ERROR("Cannot remove the USD diagnostic message printer from a secondary thread");
+        TF_RUNTIME_ERROR(
+            "Cannot remove the USD diagnostic message printer from a secondary thread");
         return;
     }
 
@@ -242,7 +244,7 @@ void UsdMayaDiagnosticDelegate::_EndBatch()
 
     const int prevValue = _batchCount.fetch_sub(1);
     if (prevValue <= 0) {
-        TF_ERROR("_EndBatch invoked before _StartBatch");
+        TF_RUNTIME_ERROR("_EndBatch invoked before _StartBatch");
     } else if (prevValue == 1) {
         // This is the last _EndBatch; print the diagnostic messages.
         // and remove the batching delegates.

--- a/lib/mayaUsd/utils/diagnosticDelegate.cpp
+++ b/lib/mayaUsd/utils/diagnosticDelegate.cpp
@@ -54,11 +54,20 @@ namespace {
 class _StatusOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
 {
     void IssueWarning(const TfWarning&) override { }
+    void IssueError(const TfError&) override { }
     void IssueFatalError(const TfCallContext&, const std::string&) override { }
 };
 
 class _WarningOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
 {
+    void IssueStatus(const TfStatus&) override { }
+    void IssueError(const TfError&) override { }
+    void IssueFatalError(const TfCallContext&, const std::string&) override { }
+};
+
+class _ErrorOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
+{
+    void IssueWarning(const TfWarning&) override { }
     void IssueStatus(const TfStatus&) override { }
     void IssueFatalError(const TfCallContext&, const std::string&) override { }
 };
@@ -112,8 +121,9 @@ UsdMayaDiagnosticDelegate::~UsdMayaDiagnosticDelegate()
 
 void UsdMayaDiagnosticDelegate::IssueError(const TfError& err)
 {
-    // Errors are never batched. They should be rare, and in those cases, we
-    // want to see them separately.
+    if (_batchCount.load() > 0) {
+        return; // Batched.
+    }
 
     const auto diagnosticMessage = _FormatDiagnostic(err);
 
@@ -171,7 +181,10 @@ void UsdMayaDiagnosticDelegate::IssueFatalError(
 void UsdMayaDiagnosticDelegate::InstallDelegate()
 {
     if (!ArchIsMainThread()) {
-        TF_FATAL_CODING_ERROR("Cannot install delegate from secondary thread");
+        // Don't crash, but inform user about failure to install
+        // the USD diagnostic message handler.
+        TF_ERROR("Cannot install the USD diagnostic message printer from a secondary thread");
+        return;
     }
 
     if (_installationCount++ > 0) {
@@ -185,7 +198,10 @@ void UsdMayaDiagnosticDelegate::InstallDelegate()
 void UsdMayaDiagnosticDelegate::RemoveDelegate()
 {
     if (!ArchIsMainThread()) {
-        TF_FATAL_CODING_ERROR("Cannot remove delegate from secondary thread");
+        // Don't crash, but inform user about failure to remove
+        // the USD diagnostic message handler.
+        TF_ERROR("Cannot remove the USD diagnostic message printer from a secondary thread");
+        return;
     }
 
     if (_installationCount == 0 || _installationCount-- > 1) {
@@ -208,28 +224,44 @@ int UsdMayaDiagnosticDelegate::GetBatchCount()
 
 void UsdMayaDiagnosticDelegate::_StartBatch()
 {
-    TF_AXIOM(ArchIsMainThread());
+    if (!ArchIsMainThread())
+        return;
 
     if (_batchCount.fetch_add(1) == 0) {
         // This is the first _StartBatch; add the batching delegates.
         _batchedStatuses.reset(new _StatusOnlyDelegate());
         _batchedWarnings.reset(new _WarningOnlyDelegate());
+        _batchedErrors.reset(new _ErrorOnlyDelegate());
     }
 }
 
 void UsdMayaDiagnosticDelegate::_EndBatch()
 {
-    TF_AXIOM(ArchIsMainThread());
+    if (!ArchIsMainThread())
+        return;
 
     const int prevValue = _batchCount.fetch_sub(1);
     if (prevValue <= 0) {
-        TF_FATAL_ERROR("_EndBatch invoked before _StartBatch");
+        TF_ERROR("_EndBatch invoked before _StartBatch");
     } else if (prevValue == 1) {
         // This is the last _EndBatch; print the diagnostic messages.
         // and remove the batching delegates.
         _FlushBatch();
         _batchedStatuses.reset();
         _batchedWarnings.reset();
+        _batchedErrors.reset();
+    }
+}
+
+static void flushDiagnostics(
+    const std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate>& delegate,
+    const std::function<void(const MString&)>&                   printer)
+{
+    const UsdUtilsCoalescingDiagnosticDelegateVector messages = delegate
+        ? delegate->TakeCoalescedDiagnostics()
+        : UsdUtilsCoalescingDiagnosticDelegateVector();
+    for (const UsdUtilsCoalescingDiagnosticDelegateItem& item : messages) {
+        printer(_FormatCoalescedDiagnostic(item));
     }
 }
 
@@ -237,43 +269,31 @@ void UsdMayaDiagnosticDelegate::_FlushBatch()
 {
     TF_AXIOM(ArchIsMainThread());
 
-    const UsdUtilsCoalescingDiagnosticDelegateVector statuses = _batchedStatuses
-        ? _batchedStatuses->TakeCoalescedDiagnostics()
-        : UsdUtilsCoalescingDiagnosticDelegateVector();
-    const UsdUtilsCoalescingDiagnosticDelegateVector warnings = _batchedWarnings
-        ? _batchedWarnings->TakeCoalescedDiagnostics()
-        : UsdUtilsCoalescingDiagnosticDelegateVector();
-
     // Note that we must be in the main thread here, so it's safe to call
     // displayInfo/displayWarning.
-    for (const UsdUtilsCoalescingDiagnosticDelegateItem& item : statuses) {
-        MGlobal::displayInfo(_FormatCoalescedDiagnostic(item));
-    }
-    for (const UsdUtilsCoalescingDiagnosticDelegateItem& item : warnings) {
-        MGlobal::displayWarning(_FormatCoalescedDiagnostic(item));
-    }
+    flushDiagnostics(_batchedStatuses, MGlobal::displayInfo);
+    flushDiagnostics(_batchedWarnings, MGlobal::displayWarning);
+    flushDiagnostics(_batchedErrors, MGlobal::displayError);
 }
 
 UsdMayaDiagnosticBatchContext::UsdMayaDiagnosticBatchContext()
     : _delegate(_IsDiagnosticBatchingEnabled() ? _sharedDelegate : nullptr)
 {
-    TF_DEBUG(PXRUSDMAYA_DIAGNOSTICS).Msg(">> Entering batch context\n");
-    if (!ArchIsMainThread()) {
-        TF_FATAL_CODING_ERROR("Cannot construct context on secondary thread");
-    }
-    if (std::shared_ptr<UsdMayaDiagnosticDelegate> ptr = _delegate.lock()) {
-        ptr->_StartBatch();
+    if (ArchIsMainThread()) {
+        TF_DEBUG(PXRUSDMAYA_DIAGNOSTICS).Msg(">> Entering batch context\n");
+        if (std::shared_ptr<UsdMayaDiagnosticDelegate> ptr = _delegate.lock()) {
+            ptr->_StartBatch();
+        }
     }
 }
 
 UsdMayaDiagnosticBatchContext::~UsdMayaDiagnosticBatchContext()
 {
-    TF_DEBUG(PXRUSDMAYA_DIAGNOSTICS).Msg("!! Exiting batch context\n");
-    if (!ArchIsMainThread()) {
-        TF_FATAL_CODING_ERROR("Cannot destruct context on secondary thread");
-    }
-    if (std::shared_ptr<UsdMayaDiagnosticDelegate> ptr = _delegate.lock()) {
-        ptr->_EndBatch();
+    if (ArchIsMainThread()) {
+        TF_DEBUG(PXRUSDMAYA_DIAGNOSTICS).Msg("!! Exiting batch context\n");
+        if (std::shared_ptr<UsdMayaDiagnosticDelegate> ptr = _delegate.lock()) {
+            ptr->_EndBatch();
+        }
     }
 }
 

--- a/lib/mayaUsd/utils/diagnosticDelegate.h
+++ b/lib/mayaUsd/utils/diagnosticDelegate.h
@@ -22,14 +22,7 @@
 #include <pxr/pxr.h>
 #include <pxr/usd/usdUtils/coalescingDiagnosticDelegate.h>
 
-#include <maya/MGlobal.h>
-
-#include <atomic>
-#include <memory>
-
 PXR_NAMESPACE_OPEN_SCOPE
-
-class UsdMayaDiagnosticBatchContext;
 
 /// Converts Tf diagnostics into native Maya infos, warnings, and errors.
 ///
@@ -46,21 +39,9 @@ class UsdMayaDiagnosticBatchContext;
 ///
 /// Installing and removing this diagnostic delegate is not thread-safe, and
 /// must be done only on the main thread.
-class UsdMayaDiagnosticDelegate : TfDiagnosticMgr::Delegate
+class UsdMayaDiagnosticDelegate
 {
 public:
-    MAYAUSD_CORE_PUBLIC
-    ~UsdMayaDiagnosticDelegate() override;
-
-    MAYAUSD_CORE_PUBLIC
-    void IssueError(const TfError& err) override;
-    MAYAUSD_CORE_PUBLIC
-    void IssueStatus(const TfStatus& status) override;
-    MAYAUSD_CORE_PUBLIC
-    void IssueWarning(const TfWarning& warning) override;
-    MAYAUSD_CORE_PUBLIC
-    void IssueFatalError(const TfCallContext& context, const std::string& msg) override;
-
     /// Installs a shared delegate globally.
     /// If this is invoked on a secondary thread, issues a fatal coding error.
     MAYAUSD_CORE_PUBLIC
@@ -69,61 +50,10 @@ public:
     /// If this is invoked on a secondary thread, issues a fatal coding error.
     MAYAUSD_CORE_PUBLIC
     static void RemoveDelegate();
-    /// Returns the number of active batch contexts associated with the global
-    /// delegate. 0 means no batching; 1 or more means diagnostics are batched.
-    /// If there is no delegate installed, issues a runtime error and returns 0.
+
+    /// @brief Write all accumulated diagnostic messages.
     MAYAUSD_CORE_PUBLIC
-    static int GetBatchCount();
-
-private:
-    friend class UsdMayaDiagnosticBatchContext;
-
-    std::atomic_int                                       _batchCount;
-    std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedStatuses;
-    std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedWarnings;
-    std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedErrors;
-
-    UsdMayaDiagnosticDelegate();
-
-    void _StartBatch();
-    void _EndBatch();
-    void _FlushBatch();
-};
-
-/// As long as a batch context remains alive (process-wide), the
-/// UsdMayaDiagnosticDelegate will save diagnostic messages, only emitting
-/// them when the last batch context is destructed. Note that errors are never
-/// batched.
-///
-/// Batch contexts must only exist on the main thread (though they will apply
-/// to any diagnostics issued on secondary threads while they're alive). If
-/// they're constructed on secondary threads, they will do nothing.
-///
-/// Batch contexts can be constructed and destructed out of "scope" order, e.g.,
-/// this is allowed:
-///   1. Context A constructed
-///   2. Context B constructed
-///   3. Context A destructed
-///   4. Context B destructed
-class UsdMayaDiagnosticBatchContext
-{
-public:
-    /// Constructs a batch context, causing all subsequent diagnostic messages
-    /// to be batched on all threads.
-    /// If this is invoked on a secondary thread, issues a fatal coding error.
-    MAYAUSD_CORE_PUBLIC
-    UsdMayaDiagnosticBatchContext();
-    MAYAUSD_CORE_PUBLIC
-    ~UsdMayaDiagnosticBatchContext();
-
-    UsdMayaDiagnosticBatchContext(const UsdMayaDiagnosticBatchContext&) = delete;
-    UsdMayaDiagnosticBatchContext& operator=(const UsdMayaDiagnosticBatchContext&) = delete;
-
-private:
-    /// This pointer is used to "bind" this context to a specific delegate in
-    /// case the global delegate is removed (and possibly re-installed) while
-    /// this batch context is alive.
-    std::weak_ptr<UsdMayaDiagnosticDelegate> _delegate;
+    static void Flush();
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/utils/diagnosticDelegate.h
+++ b/lib/mayaUsd/utils/diagnosticDelegate.h
@@ -54,6 +54,11 @@ public:
     /// @brief Write all accumulated diagnostic messages.
     MAYAUSD_CORE_PUBLIC
     static void Flush();
+
+    /// @brief Sets the maximum number of diagnostics messages that can be emitted in
+    ///        one second before we start to batch messages. Default is 100.
+    MAYAUSD_CORE_PUBLIC
+    static void SetMaximumUnbatchedDiagnostics(unsigned count);
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/utils/diagnosticDelegate.h
+++ b/lib/mayaUsd/utils/diagnosticDelegate.h
@@ -81,6 +81,7 @@ private:
     std::atomic_int                                       _batchCount;
     std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedStatuses;
     std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedWarnings;
+    std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedErrors;
 
     UsdMayaDiagnosticDelegate();
 
@@ -96,8 +97,7 @@ private:
 ///
 /// Batch contexts must only exist on the main thread (though they will apply
 /// to any diagnostics issued on secondary threads while they're alive). If
-/// they're constructed on secondary threads, they will issue a fatal coding
-/// error.
+/// they're constructed on secondary threads, they will do nothing.
 ///
 /// Batch contexts can be constructed and destructed out of "scope" order, e.g.,
 /// this is allowed:

--- a/lib/mayaUsd/utils/diagnosticDelegate.h
+++ b/lib/mayaUsd/utils/diagnosticDelegate.h
@@ -58,7 +58,7 @@ public:
     /// @brief Sets the maximum number of diagnostics messages that can be emitted in
     ///        one second before we start to batch messages. Default is 100.
     MAYAUSD_CORE_PUBLIC
-    static void SetMaximumUnbatchedDiagnostics(unsigned count);
+    static void SetMaximumUnbatchedDiagnostics(int count);
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
+++ b/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
@@ -66,6 +66,7 @@ class testDiagnosticDelegate(unittest.TestCase):
         self.messageLog = []
 
     def _StopRecording(self):
+        mayaUsdLib.DiagnosticDelegate.Flush()
         OM.MMessage.removeCallback(self.callback)
         self.callback = None
         return list(self.messageLog)
@@ -185,15 +186,6 @@ class testDiagnosticDelegate(unittest.TestCase):
             ("this status won't be lost", OM.MCommandMessage.kInfo),
         ])
 
-    def testBatching_BatchCount(self):
-        """Tests the GetBatchCount() debugging function."""
-        count = -1
-        with mayaUsdLib.DiagnosticBatchContext():
-            with mayaUsdLib.DiagnosticBatchContext():
-                count = mayaUsdLib.DiagnosticDelegate.GetBatchCount()
-        self.assertEqual(count, 2)
-        count = mayaUsdLib.DiagnosticDelegate.GetBatchCount()
-        self.assertEqual(count, 0)
 
 
 if __name__ == '__main__':

--- a/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
+++ b/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
@@ -54,6 +54,8 @@ class testDiagnosticDelegate(unittest.TestCase):
         if sys.version_info[0] >= 3:
             self.assertItemsEqual = self.assertCountEqual
 
+        mayaUsdLib.DiagnosticDelegate.Flush()
+
     def _OnCommandOutput(self, message, messageType, _):
         if (messageType == OM.MCommandMessage.kInfo
                 or messageType == OM.MCommandMessage.kWarning
@@ -161,6 +163,23 @@ class testDiagnosticDelegate(unittest.TestCase):
             ("informative status", OM.MCommandMessage.kInfo),
             ("repeated status 0 -- and 4 similar", OM.MCommandMessage.kInfo),
             ("spam warning 0 -- and 2 similar", OM.MCommandMessage.kWarning)
+        ])
+
+    def testMaximumUnbatched(self):
+        self._StartRecording()
+        mayaUsdLib.DiagnosticDelegate.SetMaximumUnbatchedDiagnostics(2)
+
+        for i in range(5):
+            Tf.Status("repeated status %d" % i)
+
+        log = self._StopRecording()
+
+        # Note: we use assertItemsEqual because coalescing may re-order the
+        # diagnostic messages.
+        self.assertItemsEqual(log, [
+            ("repeated status 0", OM.MCommandMessage.kInfo),
+            ("repeated status 1", OM.MCommandMessage.kInfo),
+            ("repeated status 2 -- and 2 similar", OM.MCommandMessage.kInfo),
         ])
 
     # Note: giving the test a name starting with Z so it is run last because unloading the plugin


### PR DESCRIPTION
Imperove the message batching to be usable for errors too. Also, remove hard-coded crash when we can. We should never explicitly choose crash Maya under the user's feet just because of some-sub-system is unhappy. Errors are fine for those cases.

Use the diagnostic batch context in places that caused problems due to the flood of error messages when loading large scene with missing textures or layers.

Unfortunately, there are some messages that comes from OGS and which require a Maya fix to avoid flooding the script editor, those cannot be fixed in the plugin. (Well, it would need investigation why the VP2 delegate does what it does and causs those OGS errors.)