### PR TITLE
Bailp/maya 104552/improve diagnostics

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -23,6 +23,7 @@
 #include <mayaUsd/nodes/proxyShapeStageExtraData.h>
 #include <mayaUsd/nodes/stageData.h>
 #include <mayaUsd/utils/customLayerData.h>
+#include <mayaUsd/utils/diagnosticDelegate.h>
 #include <mayaUsd/utils/layerMuting.h>
 #include <mayaUsd/utils/loadRules.h>
 #include <mayaUsd/utils/query.h>
@@ -509,6 +510,8 @@ void MayaUsdProxyShapeBase::postConstructor()
 /* virtual */
 MStatus MayaUsdProxyShapeBase::compute(const MPlug& plug, MDataBlock& dataBlock)
 {
+    UsdMayaDiagnosticBatchContext batchDiagnosticMessages;
+
     if (plug == outTimeAttr || plug.isDynamic())
         ProxyAccessor::compute(_usdAccessor, plug, dataBlock);
 

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -510,8 +510,6 @@ void MayaUsdProxyShapeBase::postConstructor()
 /* virtual */
 MStatus MayaUsdProxyShapeBase::compute(const MPlug& plug, MDataBlock& dataBlock)
 {
-    UsdMayaDiagnosticBatchContext batchDiagnosticMessages;
-
     if (plug == outTimeAttr || plug.isDynamic())
         ProxyAccessor::compute(_usdAccessor, plug, dataBlock);
 

--- a/lib/mayaUsd/python/wrapDiagnosticDelegate.cpp
+++ b/lib/mayaUsd/python/wrapDiagnosticDelegate.cpp
@@ -28,16 +28,18 @@ PXR_NAMESPACE_USING_DIRECTIVE;
 
 namespace {
 
-// This exposes UsdMayaDiagnosticBatchContext as a Python "context manager"
-// object that can be used with the "with"-statement.
+// This exposes a DiagnosticBatchContext as a Python "context manager"
+// object that can be used with the "with"-statement to flush diagostic
+// messages
 class _PyDiagnosticBatchContext
 {
 public:
-    void __enter__() { _context.reset(new UsdMayaDiagnosticBatchContext()); }
-    void __exit__(object, object, object) { _context.reset(); }
-
-private:
-    std::unique_ptr<UsdMayaDiagnosticBatchContext> _context;
+    void __enter__() { UsdMayaDiagnosticDelegate::SetMaximumUnbatchedDiagnostics(0); }
+    void __exit__(object, object, object)
+    {
+        UsdMayaDiagnosticDelegate::Flush();
+        UsdMayaDiagnosticDelegate::SetMaximumUnbatchedDiagnostics(100);
+    }
 };
 
 } // anonymous namespace
@@ -46,8 +48,10 @@ void wrapDiagnosticDelegate()
 {
     typedef UsdMayaDiagnosticDelegate This;
     class_<This, boost::noncopyable>("DiagnosticDelegate", no_init)
-        .def("GetBatchCount", &This::GetBatchCount)
-        .staticmethod("GetBatchCount");
+        .def("Flush", &This::Flush)
+        .staticmethod("Flush")
+        .def("SetMaximumUnbatchedDiagnostics", &This::SetMaximumUnbatchedDiagnostics)
+        .staticmethod("SetMaximumUnbatchedDiagnostics");
 
     typedef _PyDiagnosticBatchContext Context;
     class_<Context, boost::noncopyable>("DiagnosticBatchContext")

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -1374,21 +1374,11 @@ bool UsdMayaGLBatchRenderer::_UpdateIsSelectionPending(const bool isPending)
     return true;
 }
 
-void UsdMayaGLBatchRenderer::StartBatchingFrameDiagnostics()
-{
-    if (!_sharedDiagBatchCtx) {
-        _sharedDiagBatchCtx.reset(new UsdMayaDiagnosticBatchContext());
-    }
-}
-
 void UsdMayaGLBatchRenderer::_MayaRenderDidEnd(const MHWRender::MDrawContext* /* context */)
 {
     // Completing a viewport render invalidates any previous selection
     // computation we may have done, so mark a new one as pending.
     _UpdateIsSelectionPending(true);
-
-    // End any diagnostics batching.
-    _sharedDiagBatchCtx.reset();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
@@ -271,12 +271,6 @@ public:
     MAYAUSD_CORE_PUBLIC
     inline bool GetObjectSoftSelectEnabled() { return _objectSoftSelectEnabled; }
 
-    /// Starts batching all diagnostics until the end of the current frame draw.
-    /// The batch renderer will automatically release the diagnostics when Maya
-    /// is done rendering the frame.
-    MAYAUSD_CORE_PUBLIC
-    void StartBatchingFrameDiagnostics();
-
 private:
     friend class TfSingleton<UsdMayaGLBatchRenderer>;
 
@@ -479,12 +473,6 @@ private:
     HdxSelectionTrackerSharedPtr _selectionTracker;
 
     UsdMayaGLSoftSelectHelper _softSelectHelper;
-
-    /// Shared diagnostic batch context. Used for cases where we want to batch
-    /// diagnostics across multiple function calls, e.g., batching all of the
-    /// Sync() diagnostics across all prepareForDraw() callbacks in a single
-    /// frame.
-    std::unique_ptr<UsdMayaDiagnosticBatchContext> _sharedDiagBatchCtx;
 };
 
 MAYAUSD_TEMPLATE_CLASS(TfSingleton<UsdMayaGLBatchRenderer>);

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
@@ -98,8 +98,6 @@ bool PxrMayaHdShapeAdapter::Sync(
 {
     // Legacy viewport implementation.
 
-    UsdMayaGLBatchRenderer::GetInstance().StartBatchingFrameDiagnostics();
-
     const unsigned int displayStyle
         = px_LegacyViewportUtils::GetMFrameContextDisplayStyle(legacyDisplayStyle);
     const MHWRender::DisplayStatus displayStatus = _ToMHWRenderDisplayStatus(legacyDisplayStatus);
@@ -134,8 +132,6 @@ bool PxrMayaHdShapeAdapter::Sync(
     const MHWRender::DisplayStatus displayStatus)
 {
     // Viewport 2.0 implementation.
-
-    UsdMayaGLBatchRenderer::GetInstance().StartBatchingFrameDiagnostics();
 
     TF_DEBUG(PXRUSDMAYAGL_SHAPE_ADAPTER_LIFECYCLE)
         .Msg("Synchronizing PxrMayaHdShapeAdapter for Viewport 2.0: %p\n", this);

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -1191,8 +1191,6 @@ void ProxyRenderDelegate::update(MSubSceneContainer& container, const MFrameCont
         MProfiler::kColorD_L1,
         "ProxyRenderDelegate::update");
 
-    UsdMayaDiagnosticBatchContext batchDiagnosticMessages;
-
     // Without a proxy shape we can't do anything
     if (_proxyShapeData->ProxyShape() == nullptr)
         return;

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -23,6 +23,7 @@
 #include <mayaUsd/base/tokens.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/nodes/stageData.h>
+#include <mayaUsd/utils/diagnosticDelegate.h>
 #include <mayaUsd/utils/selectability.h>
 
 #include <pxr/base/tf/diagnostic.h>
@@ -1189,6 +1190,8 @@ void ProxyRenderDelegate::update(MSubSceneContainer& container, const MFrameCont
         HdVP2RenderDelegate::sProfilerCategory,
         MProfiler::kColorD_L1,
         "ProxyRenderDelegate::update");
+
+    UsdMayaDiagnosticBatchContext batchDiagnosticMessages;
 
     // Without a proxy shape we can't do anything
     if (_proxyShapeData->ProxyShape() == nullptr)

--- a/lib/mayaUsd/utils/diagnosticDelegate.cpp
+++ b/lib/mayaUsd/utils/diagnosticDelegate.cpp
@@ -27,9 +27,9 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <memory>
 #include <thread>
-#include <condition_variable>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/lib/mayaUsd/utils/diagnosticDelegate.h
+++ b/lib/mayaUsd/utils/diagnosticDelegate.h
@@ -22,14 +22,7 @@
 #include <pxr/pxr.h>
 #include <pxr/usd/usdUtils/coalescingDiagnosticDelegate.h>
 
-#include <maya/MGlobal.h>
-
-#include <atomic>
-#include <memory>
-
 PXR_NAMESPACE_OPEN_SCOPE
-
-class UsdMayaDiagnosticBatchContext;
 
 /// Converts Tf diagnostics into native Maya infos, warnings, and errors.
 ///
@@ -46,21 +39,9 @@ class UsdMayaDiagnosticBatchContext;
 ///
 /// Installing and removing this diagnostic delegate is not thread-safe, and
 /// must be done only on the main thread.
-class UsdMayaDiagnosticDelegate : TfDiagnosticMgr::Delegate
+class UsdMayaDiagnosticDelegate
 {
 public:
-    MAYAUSD_CORE_PUBLIC
-    ~UsdMayaDiagnosticDelegate() override;
-
-    MAYAUSD_CORE_PUBLIC
-    void IssueError(const TfError& err) override;
-    MAYAUSD_CORE_PUBLIC
-    void IssueStatus(const TfStatus& status) override;
-    MAYAUSD_CORE_PUBLIC
-    void IssueWarning(const TfWarning& warning) override;
-    MAYAUSD_CORE_PUBLIC
-    void IssueFatalError(const TfCallContext& context, const std::string& msg) override;
-
     /// Installs a shared delegate globally.
     /// If this is invoked on a secondary thread, issues a fatal coding error.
     MAYAUSD_CORE_PUBLIC
@@ -69,61 +50,15 @@ public:
     /// If this is invoked on a secondary thread, issues a fatal coding error.
     MAYAUSD_CORE_PUBLIC
     static void RemoveDelegate();
-    /// Returns the number of active batch contexts associated with the global
-    /// delegate. 0 means no batching; 1 or more means diagnostics are batched.
-    /// If there is no delegate installed, issues a runtime error and returns 0.
+
+    /// @brief Write all accumulated diagnostic messages.
     MAYAUSD_CORE_PUBLIC
-    static int GetBatchCount();
+    static void Flush();
 
-private:
-    friend class UsdMayaDiagnosticBatchContext;
-
-    std::atomic_int                                       _batchCount;
-    std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedStatuses;
-    std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedWarnings;
-    std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedErrors;
-
-    UsdMayaDiagnosticDelegate();
-
-    void _StartBatch();
-    void _EndBatch();
-    void _FlushBatch();
-};
-
-/// As long as a batch context remains alive (process-wide), the
-/// UsdMayaDiagnosticDelegate will save diagnostic messages, only emitting
-/// them when the last batch context is destructed. Note that errors are never
-/// batched.
-///
-/// Batch contexts must only exist on the main thread (though they will apply
-/// to any diagnostics issued on secondary threads while they're alive). If
-/// they're constructed on secondary threads, they will do nothing.
-///
-/// Batch contexts can be constructed and destructed out of "scope" order, e.g.,
-/// this is allowed:
-///   1. Context A constructed
-///   2. Context B constructed
-///   3. Context A destructed
-///   4. Context B destructed
-class UsdMayaDiagnosticBatchContext
-{
-public:
-    /// Constructs a batch context, causing all subsequent diagnostic messages
-    /// to be batched on all threads.
-    /// If this is invoked on a secondary thread, issues a fatal coding error.
+    /// @brief Sets the maximum number of diagnostics messages that can be emitted in
+    ///        one second before we start to batch messages. Default is 100.
     MAYAUSD_CORE_PUBLIC
-    UsdMayaDiagnosticBatchContext();
-    MAYAUSD_CORE_PUBLIC
-    ~UsdMayaDiagnosticBatchContext();
-
-    UsdMayaDiagnosticBatchContext(const UsdMayaDiagnosticBatchContext&) = delete;
-    UsdMayaDiagnosticBatchContext& operator=(const UsdMayaDiagnosticBatchContext&) = delete;
-
-private:
-    /// This pointer is used to "bind" this context to a specific delegate in
-    /// case the global delegate is removed (and possibly re-installed) while
-    /// this batch context is alive.
-    std::weak_ptr<UsdMayaDiagnosticDelegate> _delegate;
+    static void SetMaximumUnbatchedDiagnostics(int count);
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/utils/diagnosticDelegate.h
+++ b/lib/mayaUsd/utils/diagnosticDelegate.h
@@ -81,6 +81,7 @@ private:
     std::atomic_int                                       _batchCount;
     std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedStatuses;
     std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedWarnings;
+    std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedErrors;
 
     UsdMayaDiagnosticDelegate();
 
@@ -96,8 +97,7 @@ private:
 ///
 /// Batch contexts must only exist on the main thread (though they will apply
 /// to any diagnostics issued on secondary threads while they're alive). If
-/// they're constructed on secondary threads, they will issue a fatal coding
-/// error.
+/// they're constructed on secondary threads, they will do nothing.
 ///
 /// Batch contexts can be constructed and destructed out of "scope" order, e.g.,
 /// this is allowed:

--- a/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
+++ b/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
@@ -178,8 +178,7 @@ class testDiagnosticDelegate(unittest.TestCase):
         # diagnostic messages.
         self.assertItemsEqual(log, [
             ("repeated status 0", OM.MCommandMessage.kInfo),
-            ("repeated status 1", OM.MCommandMessage.kInfo),
-            ("repeated status 2 -- and 2 similar", OM.MCommandMessage.kInfo),
+            ("repeated status 1 -- and 3 similar", OM.MCommandMessage.kInfo),
         ])
 
     # Note: giving the test a name starting with Z so it is run last because unloading the plugin

--- a/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
+++ b/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
@@ -54,6 +54,8 @@ class testDiagnosticDelegate(unittest.TestCase):
         if sys.version_info[0] >= 3:
             self.assertItemsEqual = self.assertCountEqual
 
+        mayaUsdLib.DiagnosticDelegate.Flush()
+
     def _OnCommandOutput(self, message, messageType, _):
         if (messageType == OM.MCommandMessage.kInfo
                 or messageType == OM.MCommandMessage.kWarning
@@ -66,6 +68,7 @@ class testDiagnosticDelegate(unittest.TestCase):
         self.messageLog = []
 
     def _StopRecording(self):
+        mayaUsdLib.DiagnosticDelegate.Flush()
         OM.MMessage.removeCallback(self.callback)
         self.callback = None
         return list(self.messageLog)
@@ -162,6 +165,23 @@ class testDiagnosticDelegate(unittest.TestCase):
             ("spam warning 0 -- and 2 similar", OM.MCommandMessage.kWarning)
         ])
 
+    def testMaximumUnbatched(self):
+        self._StartRecording()
+        mayaUsdLib.DiagnosticDelegate.SetMaximumUnbatchedDiagnostics(2)
+
+        for i in range(5):
+            Tf.Status("repeated status %d" % i)
+
+        log = self._StopRecording()
+
+        # Note: we use assertItemsEqual because coalescing may re-order the
+        # diagnostic messages.
+        self.assertItemsEqual(log, [
+            ("repeated status 0", OM.MCommandMessage.kInfo),
+            ("repeated status 1", OM.MCommandMessage.kInfo),
+            ("repeated status 2 -- and 2 similar", OM.MCommandMessage.kInfo),
+        ])
+
     # Note: giving the test a name starting with Z so it is run last because unloading the plugin
     #       can break other tests when they try to reload the plugin.
     def testZZZBatching_DelegateRemoved(self):
@@ -185,15 +205,6 @@ class testDiagnosticDelegate(unittest.TestCase):
             ("this status won't be lost", OM.MCommandMessage.kInfo),
         ])
 
-    def testBatching_BatchCount(self):
-        """Tests the GetBatchCount() debugging function."""
-        count = -1
-        with mayaUsdLib.DiagnosticBatchContext():
-            with mayaUsdLib.DiagnosticBatchContext():
-                count = mayaUsdLib.DiagnosticDelegate.GetBatchCount()
-        self.assertEqual(count, 2)
-        count = mayaUsdLib.DiagnosticDelegate.GetBatchCount()
-        self.assertEqual(count, 0)
 
 
 if __name__ == '__main__':

--- a/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
+++ b/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
@@ -173,6 +173,7 @@ class testDiagnosticDelegate(unittest.TestCase):
             Tf.Status("repeated status %d" % i)
 
         log = self._StopRecording()
+        mayaUsdLib.DiagnosticDelegate.SetMaximumUnbatchedDiagnostics(100)
 
         # Note: we use assertItemsEqual because coalescing may re-order the
         # diagnostic messages.


### PR DESCRIPTION
Improve the message batching to be usable for errors too. Also, remove hard-coded crash when we can. We should never explicitly choose crash Maya under the user's feet just because of some-sub-system is unhappy. Errors are fine for those cases.

Use the diagnostic batch context in places that caused problems due to the flood of error messages when loading large scene with missing textures or layers.

Unfortunately, there are some messages that comes from OGS and which require a Maya fix to avoid flooding the script editor, those cannot be fixed in the plugin. (Well, it would need investigation why the VP2 delegate does what it does and causs those OGS errors.)

- Always accumulate and coalesce messages.
- Use a thread to periodically write messages.
- Only write messages if there are some pending and at least a second has passed.
- For low-volume messages, this will print all messages.
- For high-volumes messages, this avoids a flood of messages.

The design goes like this:
- All messages are accumulated by the above delegates.
- A thread, periodicFlusher, wakes up every second to conditionally flush pending messages.
- The condition for flushing are that a forced flush is requested or some messages have been received and one second has elapsed.
- Requesting a flushing of accumulated messages is done by queuing a task to be run on idle in the main thread. If a task is already queued, nothing is done.
- The main-thread task takes (extract and removes) all accumulated messages and prints them in the script console via MGlobal.
- This can only be done in the main thread because that is what MGlobal supports.
- Only start to batch message if more than a threshold are received within one second.
- Flush directly if flushing is triggered in the main thread.