### PR TITLE
MAYA-104552 improve diagnostics

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -23,6 +23,7 @@
 #include <mayaUsd/nodes/proxyShapeStageExtraData.h>
 #include <mayaUsd/nodes/stageData.h>
 #include <mayaUsd/utils/customLayerData.h>
+#include <mayaUsd/utils/diagnosticDelegate.h>
 #include <mayaUsd/utils/layerMuting.h>
 #include <mayaUsd/utils/loadRules.h>
 #include <mayaUsd/utils/query.h>
@@ -509,6 +510,8 @@ void MayaUsdProxyShapeBase::postConstructor()
 /* virtual */
 MStatus MayaUsdProxyShapeBase::compute(const MPlug& plug, MDataBlock& dataBlock)
 {
+    UsdMayaDiagnosticBatchContext batchDiagnosticMessages;
+
     if (plug == outTimeAttr || plug.isDynamic())
         ProxyAccessor::compute(_usdAccessor, plug, dataBlock);
 

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -510,8 +510,6 @@ void MayaUsdProxyShapeBase::postConstructor()
 /* virtual */
 MStatus MayaUsdProxyShapeBase::compute(const MPlug& plug, MDataBlock& dataBlock)
 {
-    UsdMayaDiagnosticBatchContext batchDiagnosticMessages;
-
     if (plug == outTimeAttr || plug.isDynamic())
         ProxyAccessor::compute(_usdAccessor, plug, dataBlock);
 

--- a/lib/mayaUsd/python/wrapDiagnosticDelegate.cpp
+++ b/lib/mayaUsd/python/wrapDiagnosticDelegate.cpp
@@ -28,16 +28,26 @@ PXR_NAMESPACE_USING_DIRECTIVE;
 
 namespace {
 
-// This exposes UsdMayaDiagnosticBatchContext as a Python "context manager"
-// object that can be used with the "with"-statement.
+// This exposes a DiagnosticBatchContext as a Python "context manager"
+// object that can be used with the "with"-statement to flush diagostic
+// messages
 class _PyDiagnosticBatchContext
 {
 public:
-    void __enter__() { _context.reset(new UsdMayaDiagnosticBatchContext()); }
-    void __exit__(object, object, object) { _context.reset(); }
+    _PyDiagnosticBatchContext() { }
+    _PyDiagnosticBatchContext(int c)
+        : count(c)
+    {
+    }
+    void __enter__() { UsdMayaDiagnosticDelegate::SetMaximumUnbatchedDiagnostics(count); }
+    void __exit__(object, object, object)
+    {
+        UsdMayaDiagnosticDelegate::Flush();
+        UsdMayaDiagnosticDelegate::SetMaximumUnbatchedDiagnostics(100);
+    }
 
 private:
-    std::unique_ptr<UsdMayaDiagnosticBatchContext> _context;
+    int count = 0;
 };
 
 } // anonymous namespace
@@ -46,11 +56,14 @@ void wrapDiagnosticDelegate()
 {
     typedef UsdMayaDiagnosticDelegate This;
     class_<This, boost::noncopyable>("DiagnosticDelegate", no_init)
-        .def("GetBatchCount", &This::GetBatchCount)
-        .staticmethod("GetBatchCount");
+        .def("Flush", &This::Flush)
+        .staticmethod("Flush")
+        .def("SetMaximumUnbatchedDiagnostics", &This::SetMaximumUnbatchedDiagnostics)
+        .staticmethod("SetMaximumUnbatchedDiagnostics");
 
     typedef _PyDiagnosticBatchContext Context;
     class_<Context, boost::noncopyable>("DiagnosticBatchContext")
+        .def(init<int>())
         .def("__enter__", &Context::__enter__, return_self<>())
         .def("__exit__", &Context::__exit__);
 }

--- a/lib/mayaUsd/python/wrapDiagnosticDelegate.cpp
+++ b/lib/mayaUsd/python/wrapDiagnosticDelegate.cpp
@@ -36,18 +36,19 @@ class _PyDiagnosticBatchContext
 public:
     _PyDiagnosticBatchContext() { }
     _PyDiagnosticBatchContext(int c)
-        : count(c)
+        : _count(c)
     {
     }
-    void __enter__() { UsdMayaDiagnosticDelegate::SetMaximumUnbatchedDiagnostics(count); }
+    void __enter__() { UsdMayaDiagnosticDelegate::SetMaximumUnbatchedDiagnostics(_count); }
     void __exit__(object, object, object)
     {
         UsdMayaDiagnosticDelegate::Flush();
-        UsdMayaDiagnosticDelegate::SetMaximumUnbatchedDiagnostics(100);
+        UsdMayaDiagnosticDelegate::SetMaximumUnbatchedDiagnostics(_previousCount);
     }
 
 private:
-    int count = 0;
+    int _count = 0;
+    int _previousCount = UsdMayaDiagnosticDelegate::GetMaximumUnbatchedDiagnostics();
 };
 
 } // anonymous namespace
@@ -59,7 +60,9 @@ void wrapDiagnosticDelegate()
         .def("Flush", &This::Flush)
         .staticmethod("Flush")
         .def("SetMaximumUnbatchedDiagnostics", &This::SetMaximumUnbatchedDiagnostics)
-        .staticmethod("SetMaximumUnbatchedDiagnostics");
+        .staticmethod("SetMaximumUnbatchedDiagnostics")
+        .def("GetMaximumUnbatchedDiagnostics", &This::GetMaximumUnbatchedDiagnostics)
+        .staticmethod("GetMaximumUnbatchedDiagnostics");
 
     typedef _PyDiagnosticBatchContext Context;
     class_<Context, boost::noncopyable>("DiagnosticBatchContext")

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -1374,21 +1374,11 @@ bool UsdMayaGLBatchRenderer::_UpdateIsSelectionPending(const bool isPending)
     return true;
 }
 
-void UsdMayaGLBatchRenderer::StartBatchingFrameDiagnostics()
-{
-    if (!_sharedDiagBatchCtx) {
-        _sharedDiagBatchCtx.reset(new UsdMayaDiagnosticBatchContext());
-    }
-}
-
 void UsdMayaGLBatchRenderer::_MayaRenderDidEnd(const MHWRender::MDrawContext* /* context */)
 {
     // Completing a viewport render invalidates any previous selection
     // computation we may have done, so mark a new one as pending.
     _UpdateIsSelectionPending(true);
-
-    // End any diagnostics batching.
-    _sharedDiagBatchCtx.reset();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
@@ -271,12 +271,6 @@ public:
     MAYAUSD_CORE_PUBLIC
     inline bool GetObjectSoftSelectEnabled() { return _objectSoftSelectEnabled; }
 
-    /// Starts batching all diagnostics until the end of the current frame draw.
-    /// The batch renderer will automatically release the diagnostics when Maya
-    /// is done rendering the frame.
-    MAYAUSD_CORE_PUBLIC
-    void StartBatchingFrameDiagnostics();
-
 private:
     friend class TfSingleton<UsdMayaGLBatchRenderer>;
 
@@ -479,12 +473,6 @@ private:
     HdxSelectionTrackerSharedPtr _selectionTracker;
 
     UsdMayaGLSoftSelectHelper _softSelectHelper;
-
-    /// Shared diagnostic batch context. Used for cases where we want to batch
-    /// diagnostics across multiple function calls, e.g., batching all of the
-    /// Sync() diagnostics across all prepareForDraw() callbacks in a single
-    /// frame.
-    std::unique_ptr<UsdMayaDiagnosticBatchContext> _sharedDiagBatchCtx;
 };
 
 MAYAUSD_TEMPLATE_CLASS(TfSingleton<UsdMayaGLBatchRenderer>);

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.cpp
@@ -98,8 +98,6 @@ bool PxrMayaHdShapeAdapter::Sync(
 {
     // Legacy viewport implementation.
 
-    UsdMayaGLBatchRenderer::GetInstance().StartBatchingFrameDiagnostics();
-
     const unsigned int displayStyle
         = px_LegacyViewportUtils::GetMFrameContextDisplayStyle(legacyDisplayStyle);
     const MHWRender::DisplayStatus displayStatus = _ToMHWRenderDisplayStatus(legacyDisplayStatus);
@@ -134,8 +132,6 @@ bool PxrMayaHdShapeAdapter::Sync(
     const MHWRender::DisplayStatus displayStatus)
 {
     // Viewport 2.0 implementation.
-
-    UsdMayaGLBatchRenderer::GetInstance().StartBatchingFrameDiagnostics();
 
     TF_DEBUG(PXRUSDMAYAGL_SHAPE_ADAPTER_LIFECYCLE)
         .Msg("Synchronizing PxrMayaHdShapeAdapter for Viewport 2.0: %p\n", this);

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -1191,8 +1191,6 @@ void ProxyRenderDelegate::update(MSubSceneContainer& container, const MFrameCont
         MProfiler::kColorD_L1,
         "ProxyRenderDelegate::update");
 
-    UsdMayaDiagnosticBatchContext batchDiagnosticMessages;
-
     // Without a proxy shape we can't do anything
     if (_proxyShapeData->ProxyShape() == nullptr)
         return;

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -23,6 +23,7 @@
 #include <mayaUsd/base/tokens.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/nodes/stageData.h>
+#include <mayaUsd/utils/diagnosticDelegate.h>
 #include <mayaUsd/utils/selectability.h>
 
 #include <pxr/base/tf/diagnostic.h>
@@ -1189,6 +1190,8 @@ void ProxyRenderDelegate::update(MSubSceneContainer& container, const MFrameCont
         HdVP2RenderDelegate::sProfilerCategory,
         MProfiler::kColorD_L1,
         "ProxyRenderDelegate::update");
+
+    UsdMayaDiagnosticBatchContext batchDiagnosticMessages;
 
     // Without a proxy shape we can't do anything
     if (_proxyShapeData->ProxyShape() == nullptr)

--- a/lib/mayaUsd/utils/diagnosticDelegate.cpp
+++ b/lib/mayaUsd/utils/diagnosticDelegate.cpp
@@ -22,17 +22,55 @@
 #include <pxr/base/tf/stackTrace.h>
 
 #include <maya/MGlobal.h>
+#include <maya/MSceneMessage.h>
 
 #include <ghc/filesystem.hpp>
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <thread>
+
 PXR_NAMESPACE_OPEN_SCOPE
+
+// The design goes like this:
+//
+//     - All messages are accumulated by the diagnostic delegates. (See below.)
+//     - Another delegate (see below) tells the diagnostic message flusher when
+//       any message arrives.
+//     - The diagnostic message flusher has two purposes:
+//       - the first purpose is to detect bursts of messages and to withhold
+//         further messages from being written out when a burst is detected,
+//       - the second purpose is to write out (flush) the messages periodically.
+//     - The condition for flushing are either:
+//       - that a forced flush is requested,
+//       - or that fewer than a maximum consecutive messages have been received,
+//       - or that one second has elapsed since the last time messages were flushed.
+//     - Flushing can either be immediate or delayed.
+//       - Immediate flushing is done when a forced flush is requested or when
+//         *outside* of bursts of messages.
+//       - Delayed flushing is done when a burst of messages is detected,
+//         to avoid writing too many messages in the log.
+//     - Requesting a flushing of accumulated messages is done either directly
+//       or indirectly.
+//       - Direct flushing is done when the flushing request is triggered in the
+//         main thread.
+//       - Indirect flushing is done by queuing a task to be run on-idle in the
+//         main thread. If a task is already queued, nothing is done, to avoid
+//         queuing multiple redundant tasks to do the same thing.
+//     - The actual flushing takes (extract and removes) all accumulated messages
+//       and prints them in the script console via MGlobal.
+//     - This can only be done in the main thread due to the limitations of MGlobal.
+//     - Printing of messages is done either fully or coalesced.
+//       - All messages are printed fully when not in a burst.
+//       - All messages are printed coalesced when in a burst. Coalesced messages
+//         only print a sample of the message followed by "and X similar".
 
 TF_DEFINE_ENV_SETTING(
     PIXMAYA_DIAGNOSTICS_BATCH,
     true,
-    "Whether to batch diagnostics coming from the same call site. "
-    "If batching is off, all secondary threads' diagnostics will be "
-    "printed to stderr.");
+    "Whether to batch diagnostics coming from the same call site.");
 
 TF_DEFINE_ENV_SETTING(
     MAYAUSD_SHOW_FULL_DIAGNOSTICS,
@@ -40,144 +78,308 @@ TF_DEFINE_ENV_SETTING(
     "This env flag controls the granularity of TF error/warning/status messages "
     "being displayed in Maya.");
 
-// Globally-shared delegate. Uses shared_ptr so we can have weak ptrs.
-static std::shared_ptr<UsdMayaDiagnosticDelegate> _sharedDelegate;
+TF_DEFINE_ENV_SETTING(
+    MAYAUSD_MAXIMUM_UNBATCHED_DIAGNOSTICS,
+    10,
+    "This env flag controls the maximum number of diagnostic messages that can "
+    "be emitted in one second before automatic batching of messages is used.");
+
+namespace {
+
+class DiagnosticFlusher;
+
+std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedStatuses;
+std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedWarnings;
+std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedErrors;
+std::unique_ptr<TfDiagnosticMgr::Delegate>            _waker;
+std::unique_ptr<DiagnosticFlusher>                    _flusher;
 
 // The delegate can be installed by multiple plugins (e.g. pxrUsd and
 // mayaUsdPlugin), so keep track of installations to ensure that we only add
 // the delegate for the first installation call, and that we only remove it for
 // the last removal call.
-static int _installationCount = 0;
+std::atomic<int> _installationCount;
 
-namespace {
+std::atomic<int> _batchedContextCount;
 
-class _StatusOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
+bool IsDiagnosticBatchingEnabled() { return TfGetEnvSetting(PIXMAYA_DIAGNOSTICS_BATCH); }
+
+/// @brief USD diagnostic delegate that accumulates all status messages.
+class StatusOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
 {
     void IssueWarning(const TfWarning&) override { }
     void IssueError(const TfError&) override { }
     void IssueFatalError(const TfCallContext&, const std::string&) override { }
 };
 
-class _WarningOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
+/// @brief USD diagnostic delegate that accumulates all warning messages.
+class WarningOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
 {
     void IssueStatus(const TfStatus&) override { }
     void IssueError(const TfError&) override { }
     void IssueFatalError(const TfCallContext&, const std::string&) override { }
 };
 
-class _ErrorOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
+/// @brief USD diagnostic delegate that accumulates all error messages.
+class ErrorOnlyDelegate : public UsdUtilsCoalescingDiagnosticDelegate
 {
     void IssueWarning(const TfWarning&) override { }
     void IssueStatus(const TfStatus&) override { }
+    void IssueError(const TfError& err) override
+    {
+        // Note: UsdUtilsCoalescingDiagnosticDelegate does not coalesces errors!
+        //       So, the only way to make it keep errors is to convert the error
+        //       into a warning.
+        //
+        // Note: USD warnings and errors have the exact same layout, only a different concrete type.
+        //       More-over, USD made all its diagnostic classes have private constructors! So
+        //       the only way to convert an error into a warning is through a rei-interpret cast.
+        const TfWarning& warning = reinterpret_cast<const TfWarning&>(err);
+        UsdUtilsCoalescingDiagnosticDelegate ::IssueWarning(warning);
+    }
+    void IssueFatalError(const TfCallContext& context, const std::string& msg) override
+    {
+        UsdMayaDiagnosticDelegate::Flush();
+
+        TfLogCrash(
+            "FATAL ERROR",
+            msg,
+            /*additionalInfo*/ std::string(),
+            context,
+            /*logToDb*/ true);
+        _UnhandledAbort();
+    }
+};
+
+/// @brief Periodically flushes the accumulated messages.
+class DiagnosticFlusher
+{
+public:
+    DiagnosticFlusher() { }
+
+    ~DiagnosticFlusher() { }
+
+    /// @brief Force all mesage to be immediately flushed.
+    void forceFlush()
+    {
+        _burstDiagnosticCount = 0;
+        resetLastFlushTime();
+        triggerFlushInMainThread();
+    }
+
+    /// @brief Sets the maximum number of consecutive messages before they
+    ///        are considered a burst.
+    void setMaximumUnbatchedDiagnostics(int count) { _maximumUnbatchedDiagnostics = count; }
+
+    /// @brief Gets the maximum number of consecutive messages before they
+    ///        are considered a burst.
+    int getMaximumUnbatchedDiagnostics() const { return _maximumUnbatchedDiagnostics; }
+
+    /// @brief Gets the default maximum number of consecutive messages
+    ///        before they are considered a burst.
+    static int getDefaultMaximumUnbatchedDiagnostics()
+    {
+        return TfGetEnvSetting<int>(MAYAUSD_MAXIMUM_UNBATCHED_DIAGNOSTICS);
+    }
+
+    /// @brief Called when a diagnostic message is created to be printed.
+    void receivedDiagnostic()
+    {
+        // On the first diagnostic message, check how long since we flushed the diagnostics.
+        // If it is less than a minimum, we assume we are in a burst of messages and delay
+        // writing messages.
+        //
+        // If it is the first message in a long time, we flush it immediately.
+        const int burstCount = _burstDiagnosticCount.fetch_add(1);
+        if (_pendingDiagnosticCount.fetch_add(1) >= _maximumUnbatchedDiagnostics)
+            return triggerFlushInMainThreadLaterIfNeeded();
+
+        const double elapsed = getElapsedSecondsSinceLastFlush();
+        if (elapsed < _flushingPeriod) {
+            if (burstCount >= _maximumUnbatchedDiagnostics) {
+                return triggerFlushInMainThreadLaterIfNeeded();
+            }
+        } else {
+            // Note: clear the burst count since the time elapsed since the last
+            //       diagnostic is greater than the flushing period. We reset to
+            //       one instead of zero since this message is part of the new
+            //       potential burst of diagnostic messages.
+            _burstDiagnosticCount = 1;
+        }
+
+        triggerFlushInMainThreadIfNeeded();
+    }
+
+private:
+    using Clock = std::chrono::steady_clock;
+    using TimePoint = Clock::time_point;
+    using Sec = std::chrono::seconds;
+
+    static MString formatCoalescedDiagnostic(const UsdUtilsCoalescingDiagnosticDelegateItem& item)
+    {
+        const size_t      numItems = item.unsharedItems.size();
+        const std::string suffix
+            = numItems == 1 ? std::string() : TfStringPrintf(" -- and %zu similar", numItems - 1);
+        const std::string message
+            = TfStringPrintf("%s%s", item.unsharedItems[0].commentary.c_str(), suffix.c_str());
+
+        return message.c_str();
+    }
+
+    static MString formatDiagnostic(const std::unique_ptr<TfDiagnosticBase>& item)
+    {
+        if (!item)
+            return MString();
+        if (!TfGetEnvSetting(MAYAUSD_SHOW_FULL_DIAGNOSTICS)) {
+            return item->GetCommentary().c_str();
+        } else {
+            const std::string msg = TfStringPrintf(
+                "%s -- %s in %s at line %zu of %s",
+                item->GetCommentary().c_str(),
+                TfDiagnosticMgr::GetCodeName(item->GetDiagnosticCode()).c_str(),
+                item->GetContext().GetFunction(),
+                item->GetContext().GetLine(),
+                ghc::filesystem::path(item->GetContext().GetFile())
+                    .relative_path()
+                    .string()
+                    .c_str());
+            return msg.c_str();
+        }
+    }
+
+    static void flushDiagnostics(
+        const std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate>& delegate,
+        const bool                                                   printBatched,
+        const std::function<void(const MString&)>&                   printer)
+    {
+        if (!delegate)
+            return;
+
+        if (printBatched) {
+            const UsdUtilsCoalescingDiagnosticDelegateVector messages
+                = delegate->TakeCoalescedDiagnostics();
+            for (const UsdUtilsCoalescingDiagnosticDelegateItem& item : messages) {
+                printer(formatCoalescedDiagnostic(item));
+            }
+        } else {
+            std::vector<std::unique_ptr<TfDiagnosticBase>> messages
+                = delegate->TakeUncoalescedDiagnostics();
+            for (const std::unique_ptr<TfDiagnosticBase>& item : messages) {
+                printer(formatDiagnostic(item));
+            }
+        }
+    }
+
+    void flushPerformedInMainThread()
+    {
+        TF_AXIOM(ArchIsMainThread());
+
+        _triggeredFlush = false;
+        const bool printBatched
+            = _pendingDiagnosticCount.fetch_and(0) > _maximumUnbatchedDiagnostics;
+
+        updateLastFlushTime();
+
+        // Note that we must be in the main thread here, so it's safe to call
+        // displayInfo/displayWarning.
+        flushDiagnostics(_batchedStatuses, printBatched, MGlobal::displayInfo);
+        flushDiagnostics(_batchedWarnings, printBatched, MGlobal::displayWarning);
+        flushDiagnostics(_batchedErrors, printBatched, MGlobal::displayError);
+    }
+
+    static void flushPerformedInMainThreadCallback(void* data)
+    {
+        DiagnosticFlusher* self = static_cast<DiagnosticFlusher*>(data);
+        self->flushPerformedInMainThread();
+    }
+
+    void triggerFlushInMainThreadLaterIfNeeded()
+    {
+        if (_triggeredFlush)
+            return;
+        _triggeredFlush = true;
+
+        // Note: the periodic thread access member variables, so it must be initialized
+        //       after all members are initialized. That is why we create it in the
+        //       constructor body and not the initialization list.
+        std::thread([this]() {
+            using namespace std::chrono_literals;
+            std::this_thread::sleep_for(1s);
+            triggerFlushInMainThread();
+        }).detach();
+    }
+
+    void triggerFlushInMainThreadIfNeeded()
+    {
+        if (_triggeredFlush)
+            return;
+        _triggeredFlush = true;
+        triggerFlushInMainThread();
+    }
+
+    void triggerFlushInMainThread()
+    {
+        if (ArchIsMainThread()) {
+            flushPerformedInMainThread();
+        } else {
+            MGlobal::executeTaskOnIdle(flushPerformedInMainThreadCallback, this);
+        }
+    }
+
+    static TimePoint getElapsedTimePoint() { return Clock::now(); }
+
+    void updateLastFlushTime()
+    {
+        const TimePoint              now = getElapsedTimePoint();
+        std::unique_lock<std::mutex> lock(_pendingDiagnosticsMutex);
+        _lastFlushTime = now;
+    }
+
+    void resetLastFlushTime()
+    {
+        std::unique_lock<std::mutex> lock(_pendingDiagnosticsMutex);
+        _lastFlushTime = TimePoint();
+    }
+
+    double getElapsedSecondsSinceLastFlush()
+    {
+        const auto                   now = getElapsedTimePoint();
+        std::unique_lock<std::mutex> lock(_pendingDiagnosticsMutex);
+        return std::chrono::duration<double>(now - _lastFlushTime).count();
+    }
+
+    std::mutex        _pendingDiagnosticsMutex;
+    TimePoint         _lastFlushTime = TimePoint();
+    std::atomic<bool> _triggeredFlush;
+    std::atomic<int>  _pendingDiagnosticCount;
+    std::atomic<int>  _burstDiagnosticCount;
+
+    int _maximumUnbatchedDiagnostics = getDefaultMaximumUnbatchedDiagnostics();
+
+    static constexpr double _flushingPeriod = 1.;
+};
+
+/// @brief USD diagnostic delegate that wakes up the flushing thread.
+class WakeUpDelegate : public TfDiagnosticMgr::Delegate
+{
+public:
+    WakeUpDelegate() { TfDiagnosticMgr::GetInstance().AddDelegate(this); }
+    ~WakeUpDelegate()
+    {
+        try {
+            TfDiagnosticMgr::GetInstance().RemoveDelegate(this);
+        } catch (const std::exception&) {
+        }
+    }
+
+    void IssueError(const TfError&) override { _flusher->receivedDiagnostic(); }
+    void IssueWarning(const TfWarning&) override { _flusher->receivedDiagnostic(); }
+    void IssueStatus(const TfStatus&) override { _flusher->receivedDiagnostic(); }
     void IssueFatalError(const TfCallContext&, const std::string&) override { }
 };
 
 } // anonymous namespace
 
-static MString _FormatDiagnostic(const TfDiagnosticBase& d)
-{
-    if (!TfGetEnvSetting(MAYAUSD_SHOW_FULL_DIAGNOSTICS)) {
-        return d.GetCommentary().c_str();
-    } else {
-        const std::string msg = TfStringPrintf(
-            "%s -- %s in %s at line %zu of %s",
-            d.GetCommentary().c_str(),
-            TfDiagnosticMgr::GetCodeName(d.GetDiagnosticCode()).c_str(),
-            d.GetContext().GetFunction(),
-            d.GetContext().GetLine(),
-            ghc::filesystem::path(d.GetContext().GetFile()).relative_path().string().c_str());
-        return msg.c_str();
-    }
-}
-
-static MString _FormatCoalescedDiagnostic(const UsdUtilsCoalescingDiagnosticDelegateItem& item)
-{
-    const size_t      numItems = item.unsharedItems.size();
-    const std::string suffix
-        = numItems == 1 ? std::string() : TfStringPrintf(" -- and %zu similar", numItems - 1);
-    const std::string message
-        = TfStringPrintf("%s%s", item.unsharedItems[0].commentary.c_str(), suffix.c_str());
-
-    return message.c_str();
-}
-
-static bool _IsDiagnosticBatchingEnabled() { return TfGetEnvSetting(PIXMAYA_DIAGNOSTICS_BATCH); }
-
-UsdMayaDiagnosticDelegate::UsdMayaDiagnosticDelegate()
-    : _batchCount(0)
-{
-    TfDiagnosticMgr::GetInstance().AddDelegate(this);
-}
-
-UsdMayaDiagnosticDelegate::~UsdMayaDiagnosticDelegate()
-{
-    // If a batch context was open when the delegate is removed, we need to
-    // flush all the batched diagnostics in order to avoid losing any.
-    // The batch context should know how to clean itself up when the delegate
-    // is gone.
-    _FlushBatch();
-    TfDiagnosticMgr::GetInstance().RemoveDelegate(this);
-}
-
-void UsdMayaDiagnosticDelegate::IssueError(const TfError& err)
-{
-    if (_batchCount.load() > 0) {
-        return; // Batched.
-    }
-
-    const auto diagnosticMessage = _FormatDiagnostic(err);
-
-    if (ArchIsMainThread()) {
-        MGlobal::displayError(diagnosticMessage);
-    } else {
-        std::cerr << diagnosticMessage << std::endl;
-    }
-}
-
-void UsdMayaDiagnosticDelegate::IssueStatus(const TfStatus& status)
-{
-    if (_batchCount.load() > 0) {
-        return; // Batched.
-    }
-
-    const auto diagnosticMessage = _FormatDiagnostic(status);
-
-    if (ArchIsMainThread()) {
-        MGlobal::displayInfo(diagnosticMessage);
-    } else {
-        std::cerr << diagnosticMessage << std::endl;
-    }
-}
-
-void UsdMayaDiagnosticDelegate::IssueWarning(const TfWarning& warning)
-{
-    if (_batchCount.load() > 0) {
-        return; // Batched.
-    }
-
-    const auto diagnosticMessage = _FormatDiagnostic(warning);
-
-    if (ArchIsMainThread()) {
-        MGlobal::displayWarning(diagnosticMessage);
-    } else {
-        std::cerr << diagnosticMessage << std::endl;
-    }
-}
-
-void UsdMayaDiagnosticDelegate::IssueFatalError(
-    const TfCallContext& context,
-    const std::string&   msg)
-{
-    TfLogCrash(
-        "FATAL ERROR",
-        msg,
-        /*additionalInfo*/ std::string(),
-        context,
-        /*logToDb*/ true);
-    _UnhandledAbort();
-}
-
-/* static */
 void UsdMayaDiagnosticDelegate::InstallDelegate()
 {
     if (!ArchIsMainThread()) {
@@ -192,10 +394,19 @@ void UsdMayaDiagnosticDelegate::InstallDelegate()
         return;
     }
 
-    _sharedDelegate.reset(new UsdMayaDiagnosticDelegate());
+    _batchedStatuses = std::make_unique<StatusOnlyDelegate>();
+    _batchedWarnings = std::make_unique<WarningOnlyDelegate>();
+    _batchedErrors = std::make_unique<ErrorOnlyDelegate>();
+
+    // Note: flusher accesses the batched status, so the flusher must be created
+    //       after the batcher.
+    _flusher = std::make_unique<DiagnosticFlusher>();
+
+    // Note: waker accesses the flusher, so the waker must be created
+    //       after the flusher.
+    _waker = std::make_unique<WakeUpDelegate>();
 }
 
-/* static */
 void UsdMayaDiagnosticDelegate::RemoveDelegate()
 {
     if (!ArchIsMainThread()) {
@@ -210,93 +421,65 @@ void UsdMayaDiagnosticDelegate::RemoveDelegate()
         return;
     }
 
-    _sharedDelegate.reset();
+    Flush();
+
+    // Note: waker accesses the flusher, so the waker must be destroyed
+    //       before the flusher.
+    _waker.reset();
+
+    // Note: flusher accesses the batched status, so the flusher must be destroyed
+    //       before the batcher.
+    _flusher.reset();
+
+    _batchedStatuses.reset();
+    _batchedWarnings.reset();
+    _batchedErrors.reset();
 }
 
-/* static */
-int UsdMayaDiagnosticDelegate::GetBatchCount()
+void UsdMayaDiagnosticDelegate::Flush()
 {
-    if (std::shared_ptr<UsdMayaDiagnosticDelegate> ptr = _sharedDelegate) {
-        return ptr->_batchCount.load();
-    }
-
-    TF_RUNTIME_ERROR("Delegate is not installed");
-    return 0;
+    if (_flusher)
+        _flusher->forceFlush();
 }
 
-void UsdMayaDiagnosticDelegate::_StartBatch()
+void UsdMayaDiagnosticDelegate::SetMaximumUnbatchedDiagnostics(int count)
 {
-    if (!ArchIsMainThread())
+    if (_flusher)
+        _flusher->setMaximumUnbatchedDiagnostics(count);
+}
+
+int UsdMayaDiagnosticDelegate::GetMaximumUnbatchedDiagnostics()
+{
+    if (_flusher)
+        return _flusher->getMaximumUnbatchedDiagnostics();
+    else
+        return DiagnosticFlusher::getDefaultMaximumUnbatchedDiagnostics();
+}
+
+UsdMayaDiagnosticBatchContext::UsdMayaDiagnosticBatchContext(int maximumUnbatchedCount)
+    : previousCount(UsdMayaDiagnosticDelegate::GetMaximumUnbatchedDiagnostics())
+{
+    if (!IsDiagnosticBatchingEnabled())
         return;
 
-    if (_batchCount.fetch_add(1) == 0) {
-        // This is the first _StartBatch; add the batching delegates.
-        _batchedStatuses.reset(new _StatusOnlyDelegate());
-        _batchedWarnings.reset(new _WarningOnlyDelegate());
-        _batchedErrors.reset(new _ErrorOnlyDelegate());
-    }
-}
+    TF_DEBUG(PXRUSDMAYA_DIAGNOSTICS).Msg(">> Entering batch context\n");
 
-void UsdMayaDiagnosticDelegate::_EndBatch()
-{
-    if (!ArchIsMainThread())
-        return;
+    UsdMayaDiagnosticDelegate::SetMaximumUnbatchedDiagnostics(maximumUnbatchedCount);
 
-    const int prevValue = _batchCount.fetch_sub(1);
-    if (prevValue <= 0) {
-        TF_RUNTIME_ERROR("_EndBatch invoked before _StartBatch");
-    } else if (prevValue == 1) {
-        // This is the last _EndBatch; print the diagnostic messages.
-        // and remove the batching delegates.
-        _FlushBatch();
-        _batchedStatuses.reset();
-        _batchedWarnings.reset();
-        _batchedErrors.reset();
-    }
-}
-
-static void flushDiagnostics(
-    const std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate>& delegate,
-    const std::function<void(const MString&)>&                   printer)
-{
-    const UsdUtilsCoalescingDiagnosticDelegateVector messages = delegate
-        ? delegate->TakeCoalescedDiagnostics()
-        : UsdUtilsCoalescingDiagnosticDelegateVector();
-    for (const UsdUtilsCoalescingDiagnosticDelegateItem& item : messages) {
-        printer(_FormatCoalescedDiagnostic(item));
-    }
-}
-
-void UsdMayaDiagnosticDelegate::_FlushBatch()
-{
-    TF_AXIOM(ArchIsMainThread());
-
-    // Note that we must be in the main thread here, so it's safe to call
-    // displayInfo/displayWarning.
-    flushDiagnostics(_batchedStatuses, MGlobal::displayInfo);
-    flushDiagnostics(_batchedWarnings, MGlobal::displayWarning);
-    flushDiagnostics(_batchedErrors, MGlobal::displayError);
-}
-
-UsdMayaDiagnosticBatchContext::UsdMayaDiagnosticBatchContext()
-    : _delegate(_IsDiagnosticBatchingEnabled() ? _sharedDelegate : nullptr)
-{
-    if (ArchIsMainThread()) {
-        TF_DEBUG(PXRUSDMAYA_DIAGNOSTICS).Msg(">> Entering batch context\n");
-        if (std::shared_ptr<UsdMayaDiagnosticDelegate> ptr = _delegate.lock()) {
-            ptr->_StartBatch();
-        }
-    }
+    _batchedContextCount.fetch_add(1);
 }
 
 UsdMayaDiagnosticBatchContext::~UsdMayaDiagnosticBatchContext()
 {
-    if (ArchIsMainThread()) {
-        TF_DEBUG(PXRUSDMAYA_DIAGNOSTICS).Msg("!! Exiting batch context\n");
-        if (std::shared_ptr<UsdMayaDiagnosticDelegate> ptr = _delegate.lock()) {
-            ptr->_EndBatch();
-        }
-    }
+    if (!IsDiagnosticBatchingEnabled())
+        return;
+
+    TF_DEBUG(PXRUSDMAYA_DIAGNOSTICS).Msg("!! Exiting batch context\n");
+
+    UsdMayaDiagnosticDelegate::SetMaximumUnbatchedDiagnostics(previousCount);
+
+    if (_batchedContextCount.fetch_sub(1) <= 1)
+        UsdMayaDiagnosticDelegate::Flush();
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/utils/diagnosticDelegate.h
+++ b/lib/mayaUsd/utils/diagnosticDelegate.h
@@ -81,6 +81,7 @@ private:
     std::atomic_int                                       _batchCount;
     std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedStatuses;
     std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedWarnings;
+    std::unique_ptr<UsdUtilsCoalescingDiagnosticDelegate> _batchedErrors;
 
     UsdMayaDiagnosticDelegate();
 
@@ -96,8 +97,7 @@ private:
 ///
 /// Batch contexts must only exist on the main thread (though they will apply
 /// to any diagnostics issued on secondary threads while they're alive). If
-/// they're constructed on secondary threads, they will issue a fatal coding
-/// error.
+/// they're constructed on secondary threads, they will do nothing.
 ///
 /// Batch contexts can be constructed and destructed out of "scope" order, e.g.,
 /// this is allowed:

--- a/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
+++ b/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
@@ -168,11 +168,15 @@ class testDiagnosticDelegate(unittest.TestCase):
     def testBatchingWithLimit(self):
         self._StartRecording()
 
+        previousMax = mayaUsdLib.DiagnosticDelegate.GetMaximumUnbatchedDiagnostics()
+
         with mayaUsdLib.DiagnosticBatchContext(2):
             for i in range(5):
                 Tf.Status("repeated status %d" % i)
 
         log = self._StopRecording()
+
+        self.assertEqual(previousMax, mayaUsdLib.DiagnosticDelegate.GetMaximumUnbatchedDiagnostics())
 
         # Note: we use assertItemsEqual because coalescing may re-order the
         # diagnostic messages.

--- a/test/lib/ufe/testAttribute.py
+++ b/test/lib/ufe/testAttribute.py
@@ -1749,22 +1749,19 @@ class AttributeTestCase(unittest.TestCase):
         pathStr = '|transform1|proxyShape1,/Room_set/Props/Ball_35'
 
         # No attribute was specified.
-        self.assertRaisesRegex(RuntimeError,
-                               'No attribute was specified\.$',
-                               cmds.getAttr, pathStr)
+        with self.assertRaisesRegex(RuntimeError, 'No attribute was specified\.$') as cm:
+            with mayaUsdLib.DiagnosticBatchContext(1000) as bc:
+                cmds.getAttr(pathStr)
 
         # Cannot evaluate more than one attribute.
-        self.assertRaisesRegex(RuntimeError,
-                               'Cannot evaluate more than one attribute\.$',
-                               cmds.getAttr,
-                               pathStr+'.xformOp:translate',
-                               pathStr+'.xformOpOrder')
+        with self.assertRaisesRegex(RuntimeError, 'Cannot evaluate more than one attribute\.$') as cm:
+            with mayaUsdLib.DiagnosticBatchContext(1000) as bc:
+                cmds.getAttr(pathStr+'.xformOp:translate', pathStr+'.xformOpOrder')
 
         # Mixing Maya and non-Maya attributes is an error.
-        self.assertRaisesRegex(RuntimeError,
-                               'Cannot evaluate more than one attribute\.$',
-                               cmds.getAttr,
-                               'proxyShape1.shareStage',pathStr+'.xformOp:translate')
+        with self.assertRaisesRegex(RuntimeError, 'Cannot evaluate more than one attribute\.$') as cm:
+            with mayaUsdLib.DiagnosticBatchContext(1000) as bc:
+                cmds.getAttr('proxyShape1.shareStage',pathStr+'.xformOp:translate')
 
     def createAndTestAttribute(self, materialItem, shaderDefName, shaderName, origValue, newValue, validation):
         surfDef = ufe.NodeDef.definition(materialItem.runTimeId(), shaderDefName)

--- a/test/lib/ufe/testAttributes.py
+++ b/test/lib/ufe/testAttributes.py
@@ -22,6 +22,8 @@ import ufeUtils
 import usdUtils
 import testUtils
 
+import mayaUsd.lib as mayaUsdLib
+
 from pxr import UsdGeom
 
 from maya import cmds
@@ -150,7 +152,8 @@ class AttributesTestCase(unittest.TestCase):
 
         self.assertNotIn("MyAttribute", ball35Attrs.attributeNames)
         with self.assertRaisesRegex(KeyError, "Attribute 'MyAttribute' does not exist") as cm:
-            attr = ball35Attrs.attribute("MyAttribute")
+            with mayaUsdLib.DiagnosticBatchContext(1000) as bc:
+                attr = ball35Attrs.attribute("MyAttribute")
 
         cmds.redo()
         ballObserver.assertNotificationCount(self, numAdded = 2, numRemoved = 1)
@@ -166,9 +169,11 @@ class AttributesTestCase(unittest.TestCase):
 
         self.assertNotIn("MyAttribute", ball35Attrs.attributeNames)
         with self.assertRaisesRegex(KeyError, "Attribute 'MyAttribute' does not exist") as cm:
-            attr = ball35Attrs.attribute("MyAttribute")
+            with mayaUsdLib.DiagnosticBatchContext(1000) as bc:
+                attr = ball35Attrs.attribute("MyAttribute")
         with self.assertRaisesRegex(ValueError, "Requested attribute with empty name") as cm:
-            attr = ball35Attrs.attribute("")
+            with mayaUsdLib.DiagnosticBatchContext(1000) as bc:
+                attr = ball35Attrs.attribute("")
 
         cmds.undo()
         ballObserver.assertNotificationCount(self, numAdded = 3, numRemoved = 2)
@@ -181,7 +186,8 @@ class AttributesTestCase(unittest.TestCase):
 
         self.assertNotIn("MyAttribute", ball35Attrs.attributeNames)
         with self.assertRaisesRegex(KeyError, "Attribute 'MyAttribute' does not exist") as cm:
-            attr = ball35Attrs.attribute("MyAttribute")
+            with mayaUsdLib.DiagnosticBatchContext(1000) as bc:
+                attr = ball35Attrs.attribute("MyAttribute")
 
     @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '4024', 'Test for UFE preview version 0.4.24 and later')
     def testUniqueNameAttribute(self):

--- a/test/lib/ufe/testConnections.py
+++ b/test/lib/ufe/testConnections.py
@@ -21,6 +21,8 @@ import ufeUtils
 import usdUtils
 import testUtils
 
+import mayaUsd.lib as mayaUsdLib
+
 from maya import cmds
 from pxr import Sdr
 
@@ -649,7 +651,8 @@ class ConnectionTestCase(unittest.TestCase):
 
         # Cleanup on disconnection should remove the MaterialX surface output.
         with self.assertRaisesRegex(KeyError, "Attribute 'outputs:mtlx:surface' does not exist") as cm:
-            materialAttrs.attribute("outputs:mtlx:surface")
+            with mayaUsdLib.DiagnosticBatchContext(1000) as bc:
+                materialAttrs.attribute("outputs:mtlx:surface")
 
         connections = connectionHandler.sourceConnections(materialItem)
         self.assertIsNotNone(connections)

--- a/test/lib/usd/translators/testUsdExportStripNamespaces.py
+++ b/test/lib/usd/translators/testUsdExportStripNamespaces.py
@@ -23,6 +23,8 @@ import unittest
 from maya import cmds
 from maya import standalone
 
+import mayaUsd.lib as mayaUsdLib
+
 from pxr import Usd
 
 import fixturesUtils
@@ -55,22 +57,24 @@ class testUsdExportStripNamespaces(unittest.TestCase):
 
         usdFilePath = os.path.abspath('UsdExportStripNamespaces_EXPORTED.usda')
 
-        errorRegexp = "Multiple dag nodes map to the same prim path" \
-            ".+|cube1 - |foo:cube1.*"
+        errorRegexp = "(Multiple dag nodes map to the same prim path" \
+            ".+|cube1 - |foo:cube1.*)|(Maya command error)"
 
         with self.assertRaisesRegex(RuntimeError, errorRegexp) as cm:
-            cmds.usdExport(mergeTransformAndShape=True,
-                           selection=False,
-                           stripNamespaces=True,
-                           file=usdFilePath,
-                           shadingMode='none')
+            with mayaUsdLib.DiagnosticBatchContext(0) as bc:
+                cmds.usdExport(mergeTransformAndShape=True,
+                            selection=False,
+                            stripNamespaces=True,
+                            file=usdFilePath,
+                            shadingMode='none')
 
         with self.assertRaisesRegex(RuntimeError,errorRegexp) as cm:
-            cmds.usdExport(mergeTransformAndShape=False,
-                           selection=False,
-                           stripNamespaces=True,
-                           file=usdFilePath,
-                           shadingMode='none')
+            with mayaUsdLib.DiagnosticBatchContext(1000) as bc:
+                cmds.usdExport(mergeTransformAndShape=False,
+                            selection=False,
+                            stripNamespaces=True,
+                            file=usdFilePath,
+                            shadingMode='none')
 
     def testExportWithStripAndMerge(self):
         mayaFilePath = os.path.abspath('UsdExportStripNamespaces.ma')


### PR DESCRIPTION
Improve the message batching to be usable for errors too. Also, remove
hard-coded crash when we can. We should never explicitly choose crash Maya
under the user's feet just because of some-sub-system is unhappy. Errors are
fine for those cases.

Unfortunately, there are some messages that comes from OGS and which require a
Maya fix to avoid flooding the script editor, those cannot be fixed in the
plugin. (Well, it would need investigation why the VP2 delegate does what it
does and causes those OGS errors.)

- Always accumulate and coalesce messages.
- Use a thread to periodically write messages.
- Only write messages if there are some pending and at least a second has passed.
- For low-volume messages, this will print all messages.
- For high-volumes messages, this avoids a flood of messages.

The design goes like this:
- All messages are accumulated by the diagnostic delegates.
- Another delegate tells the diagnostic message flusher when
  any message arrives.
- The diagnostic message flusher has two purposes:
  * the first purpose is to detect bursts of messages and to withhold
    further messages from being written out when a burst is detected,
  * the second purpose is to write out (flush) the messages periodically.
- The condition for flushing are either:
  * that a forced flush is requested,
  * or that fewer than a maximum consecutive messages have been received,
  * or that one second has elapsed since the last time messages were flushed.
- Flushing can either be immediate or delayed.
  * Immediate flushing is done when a forced flush is requested or when
    *outside* of burst of messages.
  * Delayed flushing is done when a burst of messages is detected,
    to avoid writing too many messages in the log.
- Requesting a flushing of accumulated messages is done either directly
  or indirectly.
  * Direct flushing is done when the flushing request is triggered in the
    main thread.
  * Indirect flushing is done by queuing a task to be run on-idle in the
    main thread. If a task is already queued, nothing is done, to avoid
    queuing multiple redundant tasks to do the same thing.
- The actual flushing takes (extract and removes) all accumulated messages
  and prints them in the script console via MGlobal.
- This can only be done in the main thread due to the limitations of MGlobal.
- Printing of messages is done either fully or coalesced.
  * All messages are printed fully when not in a burst.
  * All messages are printed coalesced when in a burst. Coalesced messages
    only print a sample of the message followed by "and X similar".
