### PR TITLE
MAYA-125036 correctly identify orphaned edited prims

### DIFF
--- a/lib/mayaUsd/fileio/pullInformation.cpp
+++ b/lib/mayaUsd/fileio/pullInformation.cpp
@@ -46,6 +46,8 @@ const MString kPullDGMetadataKey("Pull_UfePath");
 
 //------------------------------------------------------------------------------
 //
+// Read on the Maya node the information necessary to merge the USD prim
+// that is edited as Maya.
 
 bool readPullInformation(const PXR_NS::UsdPrim& prim, std::string& dagPathStr)
 {
@@ -103,6 +105,8 @@ bool readPullInformation(const MDagPath& dagPath, Ufe::Path& ufePath)
 
 //------------------------------------------------------------------------------
 //
+// Write on the Maya node the information necessary later-on to merge
+// the USD prim that is edited as Maya.
 
 bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& editedAsMayaRoot)
 {
@@ -128,6 +132,8 @@ bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& edited
 
 //------------------------------------------------------------------------------
 //
+// Write on the USD prim the information necessary later-on to merge
+// the USD prim that is edited as Maya.
 
 bool writePulledPrimMetadata(const Ufe::Path& ufePulledPath, const MDagPath& editedAsMayaRoot)
 {
@@ -150,6 +156,8 @@ bool writePulledPrimMetadata(PXR_NS::UsdPrim& pulledPrim, const MDagPath& edited
 
 //------------------------------------------------------------------------------
 //
+// Remove from the USD prim the information necessary to merge the USD prim
+// that was edited as Maya.
 
 void removePulledPrimMetadata(const Ufe::Path& ufePulledPath)
 {
@@ -171,6 +179,9 @@ void removePulledPrimMetadata(const PXR_NS::UsdStagePtr& stage, PXR_NS::UsdPrim&
 
 //------------------------------------------------------------------------------
 //
+// Hide the USD prim that is edited as Maya.
+// This is done so that the USD prim and edited Maya data are not superposed
+// in the viewport.
 
 bool addExcludeFromRendering(const Ufe::Path& ufePulledPath)
 {
@@ -191,6 +202,8 @@ bool addExcludeFromRendering(const Ufe::Path& ufePulledPath)
 
 //------------------------------------------------------------------------------
 //
+// Show again the USD prim that was edited as Maya.
+// This is done once the Maya data is meged into USD and removed from the scene.
 
 bool removeExcludeFromRendering(const Ufe::Path& ufePulledPath)
 {
@@ -214,6 +227,23 @@ bool removeExcludeFromRendering(const Ufe::Path& ufePulledPath)
         sessionLayer->ScheduleRemoveIfInert(primSpec.GetSpec());
 
     return true;
+}
+
+//------------------------------------------------------------------------------
+//
+// Verify if the edited as Maya nodes corresponding to the given prim is orphaned.
+
+bool isEditedAsMayaOrphaned(const PXR_NS::UsdPrim& prim)
+{
+    std::string dagPathStr;
+    return !readPullInformation(prim, dagPathStr);
+}
+
+MAYAUSD_CORE_PUBLIC
+bool isEditedAsMayaOrphaned(const Ufe::Path& editedUsdPrim)
+{
+    MDagPath dagPath;
+    return !readPullInformation(editedUsdPrim, dagPath);
 }
 
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/fileio/pullInformation.h
+++ b/lib/mayaUsd/fileio/pullInformation.h
@@ -28,9 +28,13 @@ UFE_NS_DEF { class Path; }
 
 namespace MAYAUSD_NS_DEF {
 
+/// @brief Write on the Maya node the information necessary later-on to merge
+///        the USD prim that is edited as Maya.
 MAYAUSD_CORE_PUBLIC
 bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& editedAsMayaRoot);
 
+/// @brief Read on the Maya node the information necessary to merge the USD prim
+///        that is edited as Maya.
 MAYAUSD_CORE_PUBLIC
 bool readPullInformation(const PXR_NS::UsdPrim& prim, std::string& dagPathStr);
 MAYAUSD_CORE_PUBLIC
@@ -40,21 +44,37 @@ bool readPullInformation(const Ufe::Path& ufePath, MDagPath& dagPath);
 MAYAUSD_CORE_PUBLIC
 bool readPullInformation(const MDagPath& dagpath, Ufe::Path& ufePath);
 
+/// @brief Write on the USD prim the information necessary later-on to merge
+///        the USD prim that is edited as Maya.
 MAYAUSD_CORE_PUBLIC
 bool writePulledPrimMetadata(const Ufe::Path& ufePulledPath, const MDagPath& editedRoot);
 MAYAUSD_CORE_PUBLIC
 bool writePulledPrimMetadata(PXR_NS::UsdPrim& pulledPrim, const MDagPath& editedRoot);
 
+/// @brief Remove from the USD prim the information necessary to merge the USD prim
+///        that was edited as Maya.
 MAYAUSD_CORE_PUBLIC
 void removePulledPrimMetadata(const Ufe::Path& ufePulledPath);
 MAYAUSD_CORE_PUBLIC
 void removePulledPrimMetadata(const PXR_NS::UsdStagePtr& stage, PXR_NS::UsdPrim& prim);
 
+/// @brief Hide the USD prim that is edited as Maya.
+///        This is done so that the USD prim and edited Maya data are not superposed
+///        in the viewport.
 MAYAUSD_CORE_PUBLIC
 bool addExcludeFromRendering(const Ufe::Path& ufePulledPath);
 
+/// @brief Show again the USD prim that was edited as Maya.
+///        This is done once the Maya data is meged into USD and removed from the scene.
 MAYAUSD_CORE_PUBLIC
 bool removeExcludeFromRendering(const Ufe::Path& ufePulledPath);
+
+/// @brief Verify if the edited as Maya nodes corresponding to the given prim is orphaned.
+MAYAUSD_CORE_PUBLIC
+bool isEditedAsMayaOrphaned(const PXR_NS::UsdPrim& prim);
+
+MAYAUSD_CORE_PUBLIC
+bool isEditedAsMayaOrphaned(const Ufe::Path& editedUsdPrim);
 
 } // namespace MAYAUSD_NS_DEF
 

--- a/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
+++ b/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
@@ -117,6 +117,11 @@ std::string readPullInformationString(const PXR_NS::UsdPrim& prim)
     return dagPathStr;
 }
 
+bool isEditedPrimOrphaned(const PXR_NS::UsdPrim& prim)
+{
+    return MAYAUSD_NS_DEF::isEditedAsMayaOrphaned(prim);
+}
+
 } // namespace
 
 void wrapPrimUpdaterManager()
@@ -128,5 +133,6 @@ void wrapPrimUpdaterManager()
         .def("canEditAsMaya", canEditAsMaya)
         .def("discardEdits", discardEdits)
         .def("duplicate", duplicate, duplicate_overloads())
+        .def("isEditedAsMayaOrphaned", isEditedPrimOrphaned)
         .def("readPullInformation", readPullInformationString);
 }

--- a/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
+++ b/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
@@ -67,7 +67,7 @@ bool mergeToUsd(const std::string& nodeName, const VtDictionary& userArgs = VtDi
         return false;
 
     Ufe::Path path;
-    if (!MAYAUSD_NS_DEF::readPullInformation(dagPath, path))
+    if (!MayaUsd::readPullInformation(dagPath, path))
         return false;
 
     return PrimUpdaterManager::getInstance().mergeToUsd(dagNode, path, userArgs);
@@ -113,13 +113,13 @@ std::string readPullInformationString(const PXR_NS::UsdPrim& prim)
 {
     std::string dagPathStr;
     // Ignore boolean return value, empty string is the proper error result.
-    MAYAUSD_NS_DEF::readPullInformation(prim, dagPathStr);
+    MayaUsd::readPullInformation(prim, dagPathStr);
     return dagPathStr;
 }
 
 bool isEditedPrimOrphaned(const PXR_NS::UsdPrim& prim)
 {
-    return MAYAUSD_NS_DEF::isEditedAsMayaOrphaned(prim);
+    return MayaUsd::isEditedAsMayaOrphaned(prim);
 }
 
 } // namespace

--- a/lib/mayaUsd/resources/scripts/mayaUsdMergeToUsd.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdMergeToUsd.py
@@ -31,7 +31,7 @@ def createDefaultMenuItem(dagPath, precedingItem):
     # This is the final callable in the chain of responsibility, so it must
     # always return a menu item.
     _, _, _, prim = mayaUsdUtils.getPulledInfo(dagPath)
-    if prim and prim.IsValid() and mayaUsd.lib.PrimUpdaterManager.readPullInformation(prim):
+    if prim and prim.IsValid() and not mayaUsd.lib.PrimUpdaterManager.isEditedAsMayaOrphaned(prim):
         enabled = 1
     else:
         enabled = 0

--- a/lib/mayaUsd/ufe/MayaUIInfoHandler.cpp
+++ b/lib/mayaUsd/ufe/MayaUIInfoHandler.cpp
@@ -52,8 +52,10 @@ MayaUsd::ufe::UsdSceneItem::Ptr pulledUsdAncestorItem(const Ufe::SceneItem::Ptr&
     Ufe::Path usdItemPath;
     while (!found) {
         // A pulled node either has the pull information itself, or has a
-        // pulled ancestor that does.
-        if (!TF_VERIFY(!mayaPath.empty())) {
+        // pulled ancestor that does. Not finding it is not an error but a
+        // possible consequence of being orphaned: for example if the stage
+        // proxy shape was deleted.
+        if (mayaPath.empty()) {
             return nullptr;
         }
         const auto mayaPathStr = Ufe::PathString::string(mayaPath);
@@ -64,6 +66,13 @@ MayaUsd::ufe::UsdSceneItem::Ptr pulledUsdAncestorItem(const Ufe::SceneItem::Ptr&
             mayaPath = mayaPath.pop();
         }
     }
+
+    // Validate that the prim pointed to by the UFE path really is the
+    // pulled node and not some node that just happens to have the same
+    // name. This can happen, for example, when two variants each contain
+    // a child with the same name, one pulled, one not.
+    if (MAYAUSD_NS_DEF::isEditedAsMayaOrphaned(usdItemPath))
+        return nullptr;
 
     // Try to create a USD scene item (and its underlying prim) from the pulled
     // ancestor USD path.  If no such USD prim exists, our argument Maya node

--- a/lib/mayaUsd/ufe/MayaUIInfoHandler.cpp
+++ b/lib/mayaUsd/ufe/MayaUIInfoHandler.cpp
@@ -60,7 +60,7 @@ MayaUsd::ufe::UsdSceneItem::Ptr pulledUsdAncestorItem(const Ufe::SceneItem::Ptr&
         }
         const auto mayaPathStr = Ufe::PathString::string(mayaPath);
         const auto dagPath = UsdMayaUtil::nameToDagPath(mayaPathStr);
-        if (MAYAUSD_NS_DEF::readPullInformation(dagPath, usdItemPath)) {
+        if (MayaUsd::readPullInformation(dagPath, usdItemPath)) {
             found = true;
         } else {
             mayaPath = mayaPath.pop();
@@ -71,7 +71,7 @@ MayaUsd::ufe::UsdSceneItem::Ptr pulledUsdAncestorItem(const Ufe::SceneItem::Ptr&
     // pulled node and not some node that just happens to have the same
     // name. This can happen, for example, when two variants each contain
     // a child with the same name, one pulled, one not.
-    if (MAYAUSD_NS_DEF::isEditedAsMayaOrphaned(usdItemPath))
+    if (MayaUsd::isEditedAsMayaOrphaned(usdItemPath))
         return nullptr;
 
     // Try to create a USD scene item (and its underlying prim) from the pulled


### PR DESCRIPTION
Also fixes MAYA-126891

- Provide a function to explicitly determine if an edited prim is orphaned.
- Provide the function in Python too.
- Use it both to build the context menu and do the outliner item rendering.