### PR TITLE
Update mayaUsd_layerEditorFileDialogs.mel

### DIFF
--- a/plugin/adsk/scripts/mayaUsd_layerEditorFileDialogs.mel
+++ b/plugin/adsk/scripts/mayaUsd_layerEditorFileDialogs.mel
@@ -48,7 +48,7 @@ global proc string[] UsdLayerEditor_LoadLayersFileDialog(string $title, string $
             -caption $title
             -fileMode 4
             -okCaption $okCaption
-            -fileFilter $fileFilter -dialogStyle 2
+            -fileFilter $fileFilter
             -optionsUICreate "UsdLayerEditor_LoadLayersFileDialogOptions_Create"
             -startingDirectory $folder
             `;


### PR DESCRIPTION
this is a simple fix to enable the use of the native file dialog when loading layers on the layer Editor, the original code has an argument forcing use of the maya native browser. this change simply removes the that flag.

I have tested that this works as expected and it doesn't affect any other issues.