### PR TITLE
Remove frequent warning in Arnold/RenderMan shading workflows

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1714,7 +1714,6 @@ void HdVP2Mesh::_UpdateDrawItem(
                 }
             } else {
                 drawItemData._shaderIsFallback = true;
-                TF_WARN("Could not resolve material <%s>\n", materialId.GetText());
             }
         }
 


### PR DESCRIPTION
When working in an Arnold or RenderMan shading workflow, it is perfectly normal that there is no VP2 materials to be found. Remove the warning since the code correctly handles the situation by using the fallback shader.