### PR TITLE
UDIM: Use default LOD values in anisotropic mode

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -1142,8 +1142,6 @@ MHWRender::MSamplerStateDesc _GetSamplerStateDesc(const HdMaterialNode& node)
                 } else if (token == _mtlxTokens->cubic) {
                     desc.filter = MHWRender::MSamplerState::kAnisotropic;
                     desc.maxAnisotropy = 16;
-                    desc.maxLOD = 1000;
-                    desc.minLOD = -1000;
                 }
             }
         }


### PR DESCRIPTION
Loading a MaterialX stage with cubic texture sampling does not work with UDIMs.

The default range for LOD values in OpenGL is -1000 to 1000.
The default range for Dx11 is 0 to 16.
The minLOD parameter in MSamplerStateDesc is unsigned int.

Leave the values as initialized by the API to prevent breaking the UDIM texture queries.