### PR TITLE
MAYA-127074 - MayaUSD : Bump UFE version to 4.0

### DIFF
--- a/cmake/modules/FindUFE.cmake
+++ b/cmake/modules/FindUFE.cmake
@@ -50,6 +50,10 @@ if(UFE_INCLUDE_DIR AND EXISTS "${UFE_INCLUDE_DIR}/ufe/ufe.h")
 
     if("${UFE_MAJOR_VERSION}" STREQUAL "0")
         math(EXPR UFE_PREVIEW_VERSION_NUM "${UFE_MINOR_VERSION} * 1000 + ${UFE_PATCH_LEVEL}")
+    elseif("${UFE_VERSION}" STREQUAL "4.0.0")
+        # Temporary. Once next Maya PR is released with UFE v4.0.0 this should
+        # be removed (along with all the UFE_PREVIEW_VERSION_NUM checks).
+        set(UFE_PREVIEW_VERSION_NUM 4045)
     endif()
 
     file(STRINGS


### PR DESCRIPTION
#### MAYA-127074 - MayaUSD : Bump UFE version to 4.0
* Temporary setting of UFE_PREVIEW_VERSION_NUM while we transition to UFE v4.0.0.