### PR TITLE
MAYA-125816 fix USD export curve options

### DIFF
--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -393,7 +393,7 @@ global proc mayaUsdTranslatorExport_SetFromOptions(string $currentOptions, int $
         tokenize($currentOptions, ";", $optionList);
         int $supportsMultiExport = 1;
         int $exportNurbsCurves = 1;
-        int $contextForcesFilterTypes = 0;
+        int $contextForcesFilterTypes = $enable;
         for ($index = 0; $index < size($optionList); $index++) {
             tokenize($optionList[$index], "=", $optionBreakDown);
             if ($optionBreakDown[0] == "exportUVs") {


### PR DESCRIPTION
When the option is enabled, it should get its default value if not explicitly set.

The previous fix aim was to avoid disabling the UI when the option is absent, but it also prevented setting the option to its default value. The fix is to fill the default value when the UI is enabled.