### PR TITLE
MAYA-126175: fix plugInfo to use relative path

### DIFF
--- a/lib/mayaUsd/sceneIndex/CMakeLists.txt
+++ b/lib/mayaUsd/sceneIndex/CMakeLists.txt
@@ -36,7 +36,6 @@ elseif(IS_LINUX)
 endif()
 
 set(PLUG_INFO_DIR ${CMAKE_INSTALL_PREFIX}/lib/usd/sceneIndex/resources)
-set(PLUG_INFO_ROOT ${CMAKE_INSTALL_PREFIX}/lib)
 
 configure_file(
     plugInfo.json

--- a/lib/mayaUsd/sceneIndex/plugInfo.json
+++ b/lib/mayaUsd/sceneIndex/plugInfo.json
@@ -14,7 +14,7 @@
             "LibraryPath": "@PLUG_INFO_LIBRARY_PATH@",
             "Name": "mayaUsd",
             "ResourcePath": "resources",
-            "Root": "@PLUG_INFO_ROOT@",
+            "Root": "../../..",
             "Type": "library"
         }
     ]


### PR DESCRIPTION
* The plugInfo specified as part of https://github.com/Autodesk/maya-usd/pull/2805 incorrectly included an absolute path.