### PR TITLE
LOOKDEVX-1084 - Prevent string conversions to throw exceptions with empty value

### DIFF
--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -1007,11 +1007,17 @@ VtValue vtValueFromString(const SdfValueTypeName& typeName, const std::string& s
             { SdfValueTypeNames->Bool.GetCPPTypeName(),
               [](const std::string& s) { return VtValue("true" == s ? true : false); } },
             { SdfValueTypeNames->Int.GetCPPTypeName(),
-              [](const std::string& s) { return VtValue(std::stoi(s.c_str())); } },
+              [](const std::string& s) {
+                  return s.empty() ? VtValue() : VtValue(std::stoi(s.c_str()));
+              } },
             { SdfValueTypeNames->Float.GetCPPTypeName(),
-              [](const std::string& s) { return VtValue(std::stof(s.c_str())); } },
+              [](const std::string& s) {
+                  return s.empty() ? VtValue() : VtValue(std::stof(s.c_str()));
+              } },
             { SdfValueTypeNames->Double.GetCPPTypeName(),
-              [](const std::string& s) { return VtValue(std::stod(s.c_str())); } },
+              [](const std::string& s) {
+                  return s.empty() ? VtValue() : VtValue(std::stod(s.c_str()));
+              } },
             { SdfValueTypeNames->String.GetCPPTypeName(),
               [](const std::string& s) { return VtValue(s); } },
             { SdfValueTypeNames->Token.GetCPPTypeName(),


### PR DESCRIPTION
Minor changes in UFE utility `vtValueFromString()`:
- If the input string is empty, the functors stored in the converter map for int,float,double numeric types now return an empty variant value. 
- The change prevents throwing of exceptions when `std::stoi/f/d` fail.