### PR TITLE
Token updates in preparation for Schema Versioning

### DIFF
--- a/lib/usd/schemas/tokens.cpp
+++ b/lib/usd/schemas/tokens.cpp
@@ -21,7 +21,9 @@ MayaUsd_SchemasTokensType::MayaUsd_SchemasTokensType()
     : mayaAutoEdit("mayaAutoEdit", TfToken::Immortal)
     , mayaNamespace("mayaNamespace", TfToken::Immortal)
     , mayaReference("mayaReference", TfToken::Immortal)
-    , allTokens({ mayaAutoEdit, mayaNamespace, mayaReference })
+    , ALMayaReference("ALMayaReference", TfToken::Immortal)
+    , MayaReference("MayaReference", TfToken::Immortal)
+    , allTokens({ mayaAutoEdit, mayaNamespace, mayaReference, ALMayaReference, MayaReference })
 {
 }
 

--- a/lib/usd/schemas/tokens.h
+++ b/lib/usd/schemas/tokens.h
@@ -68,6 +68,14 @@ struct MayaUsd_SchemasTokensType
     ///
     /// MayaUsd_SchemasMayaReference
     const TfToken mayaReference;
+    /// \brief "ALMayaReference"
+    ///
+    /// Schema identifer and family for MayaUsd_SchemasALMayaReference
+    const TfToken ALMayaReference;
+    /// \brief "MayaReference"
+    ///
+    /// Schema identifer and family for MayaUsd_SchemasMayaReference
+    const TfToken MayaReference;
     /// A vector of all of the tokens listed above.
     const std::vector<TfToken> allTokens;
 };

--- a/lib/usd/schemas/wrapTokens.cpp
+++ b/lib/usd/schemas/wrapTokens.cpp
@@ -59,4 +59,6 @@ void wrapMayaUsd_SchemasTokens()
     _AddToken(cls, "mayaAutoEdit", MayaUsd_SchemasTokens->mayaAutoEdit);
     _AddToken(cls, "mayaNamespace", MayaUsd_SchemasTokens->mayaNamespace);
     _AddToken(cls, "mayaReference", MayaUsd_SchemasTokens->mayaReference);
+    _AddToken(cls, "ALMayaReference", MayaUsd_SchemasTokens->ALMayaReference);
+    _AddToken(cls, "MayaReference", MayaUsd_SchemasTokens->MayaReference);
 }


### PR DESCRIPTION
Latest UsdGenSchema generates tokens for each schema's identifier and family in the library's token class. Updating MayaUsd schema tokens to comply with this change