### PR TITLE
Preserve NodeGraph boundaries on duplicate.

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoDuplicateSelectionCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateSelectionCommand.cpp
@@ -131,7 +131,7 @@ void UsdUndoDuplicateSelectionCommand::execute()
                                 sources, duplicatePair, stageData.second, _copyExternalInputs)) {
                             if (sources.empty()) {
                                 attr.ClearConnections();
-                                if (!attr.HasValue()) {
+                                if (!attr.HasValue() && !UsdShadeNodeGraph(attr.GetPrim())) {
                                     p.RemoveProperty(prop.GetName());
                                 }
                             } else {

--- a/test/lib/ufe/testBatchOpsHandler.py
+++ b/test/lib/ufe/testBatchOpsHandler.py
@@ -363,6 +363,28 @@ class BatchOpsHandlerTestCase(unittest.TestCase):
 
         checkStatus(self, cmd, geomItem)
 
+    def testDuplicatedNodeGraph(self):
+        """When cleaning the incoming connections of a duplicated NodeGraph, we want to keep the
+           unconnected attributes since they are not intrinsic (like for shader nodes)."""
+        testFile = testUtils.getTestScene('MaterialX', 'BatchOpsTestScene.usda')
+        shapeNode,shapeStage = mayaUtils.createProxyFromFile(testFile)
+
+        ngItem = ufeUtils.createUfeSceneItem(shapeNode, '/mtl/ss4SG/MayaNG_ss4SG')
+        self.assertIsNotNone(ngItem)
+
+        batchOpsHandler = ufe.RunTimeMgr.instance().batchOpsHandler(ngItem.runTimeId())
+        self.assertIsNotNone(batchOpsHandler)
+
+        sel = ufe.Selection()
+        sel.append(ngItem)
+
+        cmd = batchOpsHandler.duplicateSelectionCmd(sel, {"inputConnections": False})
+        cmd.execute()
+
+        dNgPrim = usdUtils.getPrimFromSceneItem(cmd.targetItem(ngItem.path()))
+        self.assertTrue(dNgPrim.HasProperty("inputs:file4:varname"))
+        self.assertTrue(dNgPrim.HasProperty("outputs:baseColor"))
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
The post-duplicate cleanup would delete an unconnected port knowing that it would still survive via the shader node definition.

However NodeGraphs do not have an underlying definition, so we need to preserve those unconnected ports even though they might not have a value at this point in time.