### PR TITLE
MAYA-126515 clean options of materials scope name

### DIFF
--- a/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
@@ -36,6 +36,24 @@ def setAnimateOption(nodeName, textOptions):
     else:
         return textOptions + ';' + animateOption
 
+def _cleanupOptionsText(text):
+    """
+    The saved options variable can have been polluted by forced value from
+    environment variables saved in previous run of Maya. If these forced
+    values are no longer forced, becaue they were saved, they would still
+    be forced... so, since all code paths that use MayaUSD export-like options,
+    like duplicate-to-USD, merge-to-USD, cache-to-USD, go through here,
+    we do the cleanup here.
+
+    Note that this kind of cleanup is only correct to do for options that have
+    no UI at all and are intended to only be controlled by such an environment
+    variable. Currently, only "materialsScopeName" is set like this, through
+    the env var "MAYAUSD_MATERIALS_SCOPE_NAME".
+    """
+    options = text.split(';')
+    options = [opt for opt in options if not "materialsScopeName=" in opt]
+    return ';'.join(options)
+
 
 def getOptionsText(varName, defaultOptions):
     """
@@ -43,11 +61,11 @@ def getOptionsText(varName, defaultOptions):
     If the options don't exist, return the default options in the same text format.
     """
     if cmds.optionVar(exists=varName):
-        return cmds.optionVar(query=varName)
+        return _cleanupOptionsText(cmds.optionVar(query=varName))
     elif isinstance(defaultOptions, dict):
-        return convertOptionsDictToText(defaultOptions)
+        return _cleanupOptionsText(convertOptionsDictToText(defaultOptions))
     else:
-        return defaultOptions
+        return _cleanupOptionsText(defaultOptions)
     
 
 def setOptionsText(varName, optionsText):

--- a/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
@@ -38,14 +38,14 @@ def setAnimateOption(nodeName, textOptions):
 
 def _cleanupOptionsText(text):
     """
-    The saved options variable can have been polluted by forced value from
-    environment variables saved in previous run of Maya. If these forced
-    values are no longer forced, becaue they were saved, they would still
-    be forced... so, since all code paths that use MayaUSD export-like options,
-    like duplicate-to-USD, merge-to-USD, cache-to-USD, go through here,
+    The saved option variables can have been polluted by forced values from
+    environment variables saved in a previous run of Maya. If these forced
+    values are no longer forced, because they were saved, they would still
+    be forced. Since all code paths that use MayaUSD export-like options like
+    duplicate-to-USD, merge-to-USD and cache-to-USD go through here
     we do the cleanup here.
 
-    Note that this kind of cleanup is only correct to do for options that have
+    Note: this kind of cleanup is only correct to do for options that have
     no UI at all and are intended to only be controlled by such an environment
     variable. Currently, only "materialsScopeName" is set like this, through
     the env var "MAYAUSD_MATERIALS_SCOPE_NAME".


### PR DESCRIPTION
- The materials scope name is only modifiable with the environment variable.
- OTOH, the options used for duplicate, merge and cache to USD are all saved in options vars.
- This resulted in that the environment variable value was saved in options vars and would persists even when the env var was no longer set.
- This changes cleans up the option vars of the value that were set by the env var.
- It is a bit unfortunate that the materials scope choice was designed this way but now we are too close to release to re-design it.