### PR TITLE
Fixes an issue on layer editor save dialog, where an invalid extension could cause a crash. The fallback is .usd.

### DIFF
--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -106,6 +106,10 @@ bool saveRootLayer(SdfLayerRefPtr layer, const std::string& proxy)
 void updateAllCachedStageWithLayer(SdfLayerRefPtr originalLayer, const std::string& newFilePath)
 {
     SdfLayerRefPtr newLayer = SdfLayer::FindOrOpen(newFilePath);
+    if (!newLayer) {
+        TF_WARN("The filename %s is an invalid file name for a layer.", newFilePath.c_str());
+        return;
+    }
     for (UsdStageCache& cache : UsdMayaStageCache::GetAllCaches()) {
         UsdStageCacheContext        ctx(cache);
         std::vector<UsdStageRefPtr> stages = cache.FindAllMatching(originalLayer);

--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -16,6 +16,7 @@
 #include "utilSerialization.h"
 
 #include <mayaUsd/base/tokens.h>
+#include <mayaUsd/fileio/jobs/jobArgs.h>
 #include <mayaUsd/utils/stageCache.h>
 #include <mayaUsd/utils/util.h>
 #include <mayaUsd/utils/utilFileSystem.h>
@@ -278,10 +279,20 @@ SdfLayerRefPtr saveAnonymousLayer(
     if (!anonLayer || !anonLayer->IsAnonymous()) {
         return nullptr;
     }
+    
+    std::string        filePath(path);
+    const std::string& extension = SdfFileFormat::GetFileExtension(filePath);
+    const std::string  defaultExt(UsdMayaTranslatorTokens->UsdFileExtensionDefault.GetText());
+    const std::string  usdCrateExt(UsdMayaTranslatorTokens->UsdFileExtensionCrate.GetText());
+    const std::string  usdASCIIExt(UsdMayaTranslatorTokens->UsdFileExtensionASCII.GetText());
+    if (extension != defaultExt && extension != usdCrateExt && extension != usdASCIIExt) {
+        filePath.append(".");
+        filePath.append(defaultExt.c_str()); 
+    }
+    
+    saveLayerWithFormat(anonLayer, filePath, formatArg);
 
-    saveLayerWithFormat(anonLayer, path, formatArg);
-
-    SdfLayerRefPtr newLayer = SdfLayer::FindOrOpen(path);
+    SdfLayerRefPtr newLayer = SdfLayer::FindOrOpen(filePath);
     if (newLayer) {
         if (parent._layerParent) {
             parent._layerParent->GetSubLayerPaths().Replace(

--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -279,7 +279,7 @@ SdfLayerRefPtr saveAnonymousLayer(
     if (!anonLayer || !anonLayer->IsAnonymous()) {
         return nullptr;
     }
-    
+
     std::string        filePath(path);
     const std::string& extension = SdfFileFormat::GetFileExtension(filePath);
     const std::string  defaultExt(UsdMayaTranslatorTokens->UsdFileExtensionDefault.GetText());
@@ -287,9 +287,9 @@ SdfLayerRefPtr saveAnonymousLayer(
     const std::string  usdASCIIExt(UsdMayaTranslatorTokens->UsdFileExtensionASCII.GetText());
     if (extension != defaultExt && extension != usdCrateExt && extension != usdASCIIExt) {
         filePath.append(".");
-        filePath.append(defaultExt.c_str()); 
+        filePath.append(defaultExt.c_str());
     }
-    
+
     saveLayerWithFormat(anonLayer, filePath, formatArg);
 
     SdfLayerRefPtr newLayer = SdfLayer::FindOrOpen(filePath);


### PR DESCRIPTION
When an invalid extension string is provided, USD fails to relocate the file when trying update the cached stage layers and will return a TfNullPtr which results in crash. The fix is to check and update the file path prior to passing to layer export and load operations.