### PR TITLE
Fixes an issue on layer editor when trying to save a root layer directly (by right clicking on the layer and Save As.), where an invalid extension could cause a crash. The fallback is .usd.

### DIFF
--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -105,6 +105,10 @@ bool saveRootLayer(SdfLayerRefPtr layer, const std::string& proxy)
 void updateAllCachedStageWithLayer(SdfLayerRefPtr originalLayer, const std::string& newFilePath)
 {
     SdfLayerRefPtr newLayer = SdfLayer::FindOrOpen(newFilePath);
+    if (!newLayer) {
+        TF_WARN("The filename %s is an invalid file name for a layer.", newFilePath.c_str());
+        return;
+    }
     for (UsdStageCache& cache : UsdMayaStageCache::GetAllCaches()) {
         UsdStageCacheContext        ctx(cache);
         std::vector<UsdStageRefPtr> stages = cache.FindAllMatching(originalLayer);

--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -289,15 +289,8 @@ SdfLayerRefPtr saveAnonymousLayer(
         return nullptr;
     }
 
-    std::string        filePath(path);
-    const std::string& extension = SdfFileFormat::GetFileExtension(filePath);
-    const std::string  defaultExt(UsdMayaTranslatorTokens->UsdFileExtensionDefault.GetText());
-    const std::string  usdCrateExt(UsdMayaTranslatorTokens->UsdFileExtensionCrate.GetText());
-    const std::string  usdASCIIExt(UsdMayaTranslatorTokens->UsdFileExtensionASCII.GetText());
-    if (extension != defaultExt && extension != usdCrateExt && extension != usdASCIIExt) {
-        filePath.append(".");
-        filePath.append(defaultExt.c_str());
-    }
+    std::string filePath(path);
+    ensureUSDFileExtension(filePath);
 
     saveLayerWithFormat(anonLayer, filePath, formatArg);
 
@@ -311,6 +304,18 @@ SdfLayerRefPtr saveAnonymousLayer(
         }
     }
     return newLayer;
+}
+
+void ensureUSDFileExtension(std::string& filePath)
+{
+    const std::string& extension = SdfFileFormat::GetFileExtension(filePath);
+    const std::string  defaultExt(UsdMayaTranslatorTokens->UsdFileExtensionDefault.GetText());
+    const std::string  usdCrateExt(UsdMayaTranslatorTokens->UsdFileExtensionCrate.GetText());
+    const std::string  usdASCIIExt(UsdMayaTranslatorTokens->UsdFileExtensionASCII.GetText());
+    if (extension != defaultExt && extension != usdCrateExt && extension != usdASCIIExt) {
+        filePath.append(".");
+        filePath.append(defaultExt.c_str());
+    }
 }
 
 void getLayersToSaveFromProxy(const std::string& proxyPath, stageLayersToSave& layersInfo)

--- a/lib/mayaUsd/utils/utilSerialization.h
+++ b/lib/mayaUsd/utils/utilSerialization.h
@@ -114,7 +114,12 @@ PXR_NS::SdfLayerRefPtr saveAnonymousLayer(
     LayerParent            parent,
     std::string            formatArg = "");
 
-/*! \brief Check the sublayer stack of the stage looking for any anonymnous
+/*! \brief Ensures that the filepath contains a valid USD extension.
+ */
+MAYAUSD_CORE_PUBLIC
+void ensureUSDFileExtension(std::string& filePath);
+
+/*! \brief Check the sublayer stack of the stage looking for any anonymous
     layers that will need to be saved.
  */
 MAYAUSD_CORE_PUBLIC

--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -365,33 +365,24 @@ void LayerTreeItem::saveAnonymousLayer()
     std::string fileName;
     if (sessionState->saveLayerUI(nullptr, &fileName)) {
 
-        std::string        filePath(fileName);
-        const std::string& extension = SdfFileFormat::GetFileExtension(filePath);
-        const std::string  defaultExt(UsdMayaTranslatorTokens->UsdFileExtensionDefault.GetText());
-        const std::string  usdCrateExt(UsdMayaTranslatorTokens->UsdFileExtensionCrate.GetText());
-        const std::string  usdASCIIExt(UsdMayaTranslatorTokens->UsdFileExtensionASCII.GetText());
-        if (extension != defaultExt && extension != usdCrateExt && extension != usdASCIIExt) {
-            filePath.append(".");
-            filePath.append(defaultExt.c_str());
-        }
+        MayaUsd::utils::ensureUSDFileExtension(fileName);
 
-        // the path we has is an absolute path
+        // the path we have is an absolute path
         const QString dialogTitle = StringResources::getAsQString(StringResources::kSaveLayer);
         std::string   formatTag = MayaUsd::utils::usdFormatArgOption();
-        if (saveSubLayer(dialogTitle, parentLayerItem(), layer(), filePath, formatTag)) {
-            printf("USD Layer written to %s\n", filePath.c_str());
+        if (saveSubLayer(dialogTitle, parentLayerItem(), layer(), fileName, formatTag)) {
+            printf("USD Layer written to %s\n", fileName.c_str());
 
             // now replace the layer in the parent
             if (isRootLayer()) {
-                sessionState->rootLayerPathChanged(filePath);
                 sessionState->rootLayerPathChanged(
                     UsdMayaUtilFileSystem::requireUsdPathsRelativeToMayaSceneFile()
-                        ? UsdMayaUtilFileSystem::getPathRelativeToMayaSceneFile(filePath)
-                        : filePath);
+                        ? UsdMayaUtilFileSystem::getPathRelativeToMayaSceneFile(fileName)
+                        : fileName);
             } else {
                 // now replace the layer in the parent
                 auto parentItem = parentLayerItem();
-                auto newLayer = SdfLayer::FindOrOpen(filePath);
+                auto newLayer = SdfLayer::FindOrOpen(fileName);
                 if (newLayer) {
                     bool setTarget = _isTargetLayer;
                     auto model = parentModel();

--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -10,7 +10,6 @@
 #include "warningDialogs.h"
 
 #include <mayaUsd/base/tokens.h>
-#include <mayaUsd/fileio/jobs/jobArgs.h>
 #include <mayaUsd/utils/utilFileSystem.h>
 #include <mayaUsd/utils/utilSerialization.h>
 


### PR DESCRIPTION
Fixes an issue on layer editor when trying to save a root layer directly (by right clicking on the layer and Save As.), where an invalid extension could cause a crash. The fallback is .usd.

It also blocks the path that will result in the crash for any other scenario where the file cannot be opened after it was exported. The user is then displayed a message dialog indicating the layer saving was not successful.

Similar PR: https://github.com/Autodesk/maya-usd/pull/2845