### PR TITLE
MAYA-127393 allow USD ref to be relative

### DIFF
--- a/lib/mayaUsd/resources/scripts/CMakeLists.txt
+++ b/lib/mayaUsd/resources/scripts/CMakeLists.txt
@@ -3,6 +3,7 @@ list(APPEND scripts_src
     mayaUsdLibRegisterStrings.py
     mayaUsdAddMayaReference.mel
     mayaUsdAddMayaReference.py
+    mayaUsdAddUSDReference.mel
     mayaUsdCacheMayaReference.mel
     mayaUsdCacheMayaReference.py
     mayaUsdDuplicateAsMayaDataOptions.mel

--- a/lib/mayaUsd/resources/scripts/mayaUsdAddUSDReference.mel
+++ b/lib/mayaUsd/resources/scripts/mayaUsdAddUSDReference.mel
@@ -1,0 +1,46 @@
+// Copyright 2022 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Unfortunate MEL to Python shims because of fileDialog2 requirements that
+// optionsUICreate, optionsUIInit and optionsUICommit2 arguments be MEL
+// procedures.
+
+global proc setUSDReferenceRelativeFilePathRoot(string $filePath)
+{
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdFileRelativeToEditTargetLayer.setRelativeFilePathRoot(r'''" + $filePath + "''')");
+}
+
+global proc addUSDReferenceCreateUi(string $parent)
+{
+    setParent $parent;
+    string $layout = `scrollLayout -childResizable true`;
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdFileRelativeToEditTargetLayer.uiCreate(r'''" + $layout + "''')");
+}
+
+global proc addUSDReferenceInitUi(string $parent, string $filterType)
+{
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdFileRelativeToEditTargetLayer.uiInit(r'''" + $parent + "''', r'''" + $filterType + "''')");
+}
+
+global proc addUSDReferenceSelectionChanged(string $parent, string $selection)
+{
+    // For now, nothing.
+}
+
+global proc addUSDReferenceToUsdCommitUi(string $parent, string $selectedFile)
+{
+    setParent $parent;
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdFileRelativeToEditTargetLayer.uiCommit(r'''" + $parent + "''', r'''" + $selectedFile + "''')");
+}

--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -550,15 +550,14 @@ const char* _selectUSDFileScript()
         )mel";
 
         commandString = TfStringPrintf(
-            script,
-            TfStringJoin(usdUiStrings).c_str(),
-            TfStringJoin(usdSelectors, ";;").c_str());
+            script, TfStringJoin(usdUiStrings).c_str(), TfStringJoin(usdSelectors, ";;").c_str());
     }
 
     return commandString.c_str();
 }
 
-std::string makeUSDReferenceFilePathRelativeIfRequested(const std::string& filePath, const UsdPrim& prim)
+std::string
+makeUSDReferenceFilePathRelativeIfRequested(const std::string& filePath, const UsdPrim& prim)
 {
     if (!UsdMayaUtilFileSystem::requireUsdPathsRelativeToEditTargetLayer())
         return filePath;
@@ -1267,7 +1266,8 @@ Ufe::UndoableCommand::Ptr UsdContextOps::doOpCmd(const ItemPath& itemPath)
 
         MString fileRef = MGlobal::executeCommandStringResult(_selectUSDFileScript());
 
-        const std::string path = makeUSDReferenceFilePathRelativeIfRequested(UsdMayaUtil::convert(fileRef), prim());
+        const std::string path
+            = makeUSDReferenceFilePathRelativeIfRequested(UsdMayaUtil::convert(fileRef), prim());
         if (path.empty())
             return nullptr;
 

--- a/lib/mayaUsd/utils/utilFileSystem.cpp
+++ b/lib/mayaUsd/utils/utilFileSystem.cpp
@@ -131,7 +131,8 @@ std::pair<std::string, bool> UsdMayaUtilFileSystem::makePathRelativeTo(
     ghc::filesystem::path relativePath = absolutePath.lexically_relative(relativeToDir);
 
     if (relativePath.empty()) {
-        return std::make_pair(fileName, false);;
+        return std::make_pair(fileName, false);
+        ;
     }
 
     return std::make_pair(relativePath.generic_string(), true);

--- a/lib/mayaUsd/utils/utilFileSystem.cpp
+++ b/lib/mayaUsd/utils/utilFileSystem.cpp
@@ -117,27 +117,38 @@ std::string UsdMayaUtilFileSystem::getMayaSceneFileDir()
     return std::string();
 }
 
-std::string UsdMayaUtilFileSystem::getPathRelativeToMayaSceneFile(const std::string& fileName)
+std::pair<std::string, bool> UsdMayaUtilFileSystem::makePathRelativeTo(
+    const std::string& fileName,
+    const std::string& relativeToDir)
 {
     ghc::filesystem::path absolutePath(fileName);
-    ghc::filesystem::path basePath(getMayaSceneFileDir());
 
-    // If Maya scene file doesn't exist yet, use the absolute path
-    if (basePath.empty()) {
-        return fileName;
+    // If Maya scene file doesn't exist yet, use the unchanged path
+    if (relativeToDir.empty()) {
+        return std::make_pair(fileName, false);
     }
 
-    ghc::filesystem::path relativePath = absolutePath.lexically_relative(basePath);
+    ghc::filesystem::path relativePath = absolutePath.lexically_relative(relativeToDir);
 
     if (relativePath.empty()) {
+        return std::make_pair(fileName, false);;
+    }
+
+    return std::make_pair(relativePath.generic_string(), true);
+}
+
+std::string UsdMayaUtilFileSystem::getPathRelativeToMayaSceneFile(const std::string& fileName)
+{
+    auto relativePathAndSuccess = makePathRelativeTo(fileName, getMayaSceneFileDir());
+
+    if (!relativePathAndSuccess.second) {
         TF_WARN(
             "File name (%s) cannot be resolved as relative to the Maya scene file, using the "
             "absolute path.",
             fileName.c_str());
-        return fileName;
     }
 
-    return relativePath.generic_string();
+    return relativePathAndSuccess.first;
 }
 
 bool UsdMayaUtilFileSystem::requireUsdPathsRelativeToMayaSceneFile()
@@ -145,6 +156,14 @@ bool UsdMayaUtilFileSystem::requireUsdPathsRelativeToMayaSceneFile()
     static const MString MAKE_PATH_RELATIVE_TO_SCENE_FILE = "mayaUsd_MakePathRelativeToSceneFile";
     return MGlobal::optionVarExists(MAKE_PATH_RELATIVE_TO_SCENE_FILE)
         && MGlobal::optionVarIntValue(MAKE_PATH_RELATIVE_TO_SCENE_FILE);
+}
+
+bool UsdMayaUtilFileSystem::requireUsdPathsRelativeToEditTargetLayer()
+{
+    static const MString MAKE_PATH_RELATIVE_TO_EDIT_TARGET_LAYER_FILE
+        = "mayaUsd_MakePathRelativeToEditTargetLayer";
+    return MGlobal::optionVarExists(MAKE_PATH_RELATIVE_TO_EDIT_TARGET_LAYER_FILE)
+        && MGlobal::optionVarIntValue(MAKE_PATH_RELATIVE_TO_EDIT_TARGET_LAYER_FILE);
 }
 
 const char* getScenesFolderScript = R"(

--- a/lib/mayaUsd/utils/utilFileSystem.cpp
+++ b/lib/mayaUsd/utils/utilFileSystem.cpp
@@ -123,9 +123,12 @@ std::pair<std::string, bool> UsdMayaUtilFileSystem::makePathRelativeTo(
 {
     ghc::filesystem::path absolutePath(fileName);
 
-    // If Maya scene file doesn't exist yet, use the unchanged path
+    // If the anchor relative-to-directory doesn't exist yet, use the unchanged path,
+    // but don't return a failure. The anchor path being empty is not considered
+    // a failure. If the caller needs to detect this, they can verify that the
+    // anchor path is empty themselves before calling this function.
     if (relativeToDir.empty()) {
-        return std::make_pair(fileName, false);
+        return std::make_pair(fileName, true);
     }
 
     ghc::filesystem::path relativePath = absolutePath.lexically_relative(relativeToDir);

--- a/lib/mayaUsd/utils/utilFileSystem.h
+++ b/lib/mayaUsd/utils/utilFileSystem.h
@@ -37,12 +37,13 @@ std::string getDir(const std::string& fullFilePath);
 /*! \brief takes in two absolute file paths and returns the first one to second one.
            Also return a boolean: true if the path was successfully made relative,
            false otherwise.
-           
+
            If the second path is not absolute or is not reachable from the first,
            then the returned path will still be absolute.
  */
 MAYAUSD_CORE_PUBLIC
-std::pair<std::string, bool> makePathRelativeTo(const std::string& fileName, const std::string& relativeToDir);
+std::pair<std::string, bool>
+makePathRelativeTo(const std::string& fileName, const std::string& relativeToDir);
 
 /*! \brief returns parent directory of a maya scene file opened by reference
  */

--- a/lib/mayaUsd/utils/utilFileSystem.h
+++ b/lib/mayaUsd/utils/utilFileSystem.h
@@ -34,6 +34,16 @@ std::string resolvePath(const std::string& filePath);
 MAYAUSD_CORE_PUBLIC
 std::string getDir(const std::string& fullFilePath);
 
+/*! \brief takes in two absolute file paths and returns the first one to second one.
+           Also return a boolean: true if the path was successfully made relative,
+           false otherwise.
+           
+           If the second path is not absolute or is not reachable from the first,
+           then the returned path will still be absolute.
+ */
+MAYAUSD_CORE_PUBLIC
+std::pair<std::string, bool> makePathRelativeTo(const std::string& fileName, const std::string& relativeToDir);
+
 /*! \brief returns parent directory of a maya scene file opened by reference
  */
 MAYAUSD_CORE_PUBLIC
@@ -55,11 +65,17 @@ When there is no scene file, the absolute (input) path will be returned.
 MAYAUSD_CORE_PUBLIC
 std::string getPathRelativeToMayaSceneFile(const std::string& fileName);
 
-/*! \brief returns the flag specifying whether Usd file paths should be saevd as relative to Maya
+/*! \brief returns the flag specifying whether USD file paths should be saved as relative to Maya
  * scene file
  */
 MAYAUSD_CORE_PUBLIC
 bool requireUsdPathsRelativeToMayaSceneFile();
+
+/*! \brief returns the flag specifying whether USD file paths should be saved
+ *         as relative to the current edit target layer.
+ */
+MAYAUSD_CORE_PUBLIC
+bool requireUsdPathsRelativeToEditTargetLayer();
 
 /*! \brief returns a unique file name
  */

--- a/lib/mayaUsd/utils/utilFileSystem.h
+++ b/lib/mayaUsd/utils/utilFileSystem.h
@@ -35,8 +35,18 @@ MAYAUSD_CORE_PUBLIC
 std::string getDir(const std::string& fullFilePath);
 
 /*! \brief takes in two absolute file paths and returns the first one to second one.
-           Also return a boolean: true if the path was successfully made relative,
-           false otherwise.
+
+           Also return a boolean that indicates if the attempt to make the file name
+           relative to the valid anchor path failed.
+
+           If the anchor relative-to-directory is empty, then the original file name
+           is returned but no failure is returned. If the caller needs to detect
+           this as a failure case, they can verify that the relative-to directory
+           name is empty themselves before calling this function.
+
+           The rationale for this is that, for example, we don't want to flag as
+           an error when the user tries to make a path relative to the scene when
+           the scene has not yet been saved.
 
            If the second path is not absolute or is not reachable from the first,
            then the returned path will still be absolute.

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.py
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.py
@@ -36,3 +36,4 @@ def mayaUSDRegisterStrings():
     register("kLoadUSDFile", "Load USD File")
     register("kFileOptions", "File Options")
     register("kMakePathRelativeToSceneFile", "Make Path Relative to Scene File Directory")
+    register("kMakePathRelativeToEditTargetLayer", "Make Path Relative to Edit Target Layer Directory")

--- a/plugin/adsk/scripts/mayaUsd_USDRootFileRelative.py
+++ b/plugin/adsk/scripts/mayaUsd_USDRootFileRelative.py
@@ -3,18 +3,50 @@ import maya.mel as mel
 from mayaUSDRegisterStrings import getMayaUsdString
 from mayaUsdMayaReferenceUtils import pushOptionsUITemplate
 
-class usdRootFileRelative(object):
-    fileNameEditField = None
+class usdFileRelative(object):
+    '''
+    Helper class to create the UI for load/save dialog boxes that need to make the
+    selected file name optionally relative.
 
-    kMakePathRelativeCheckBox = 'MakePathRelative'
+    The caller must tell each function to what the file should be made relative.
+    The 'what' is used to select the correct UI element, UI label and to read
+    and write the correct option var.
+
+    For example by passing 'SceneFile', the functions will use:
+        UI element:           MakePathRelativeToSceneFile
+        UI label:            kMakePathRelativeToSceneFile
+        option var:   mayaUsd_MakePathRelativeToSceneFile
+    '''
+
+    kMakePathRelativeCheckBox = 'MakePathRelativeTo'
+
+    _relativeToFilePath = None
 
     @classmethod
-    def uiCreate(cls, parentLayout):
+    def setRelativeFilePathRoot(cls, filePath):
+        '''
+        Sets to which file the relative file will be anchored.
+        Set to empty or None to have the file be absolute, not relative.
+        '''
+        cls._relativeToFilePath = filePath
+
+    @classmethod
+    def getRelativeFilePathRoot(cls):
+        '''
+        Gets to which file the relative file will be anchored.
+        Empty or None to have the file be absolute, not relative.
+        '''
+        return cls._relativeToFilePath
+
+    @classmethod
+    def uiCreate(cls, parentLayout, relativeToWhat):
         """
-        Helper method to create the UI layout for the USD root file relative actions.
+        Helper method to create the UI layout for the file relative actions.
 
         Input parentLayout arg is expected to the a scroll layout into which controls
         can be added.
+
+        Input relativeToWhat tells what the file is relative to. See the class docs.
         """
         pushOptionsUITemplate()
         cmds.setParent(parentLayout)
@@ -32,31 +64,113 @@ class usdRootFileRelative(object):
         topForm = cmds.columnLayout('actionOptionsForm', rowSpacing=5)
 
         kFileOptionsStr = getMayaUsdString("kFileOptions")
-        kMakePathRelativeStr = getMayaUsdString("kMakePathRelativeToSceneFile")
+        kMakePathRelativeStr = getMayaUsdString("kMakePathRelativeTo" + relativeToWhat)
  
         optBoxMarginWidth = mel.eval('global int $gOptionBoxTemplateDescriptionMarginWidth; $gOptionBoxTemplateDescriptionMarginWidth += 0')
         cmds.setParent(topForm)
         cmds.frameLayout(label=kFileOptionsStr, collapsable=False)
         widgetColumn = cmds.columnLayout()
-        cmds.checkBox(cls.kMakePathRelativeCheckBox, label=kMakePathRelativeStr)
+        cmds.checkBox(cls.kMakePathRelativeCheckBox + relativeToWhat, label=kMakePathRelativeStr)
 
     @classmethod
-    def uiInit(cls, parentLayout, filterType):
+    def uiInit(cls, parentLayout, canBeRelative, relativeToWhat):
+        """
+        Helper method to initialize the UI layout for the file relative actions.
+
+        Input parentLayout arg is expected to the a scroll layout into which controls
+        can be added.
+
+        Input canBeRelative tells if the file can be made relative at all. If false,
+        the relative path UI is shown but disabled.
+
+        Input relativeToWhat tells what the file is relative to. See the class docs.
+        """
         cmds.setParent(parentLayout)
 
         # Get the current checkbox value from optionVar (if any) and update checkbox.
-        if cmds.optionVar(exists='mayaUsd_MakePathRelativeToSceneFile'):
-            relative = cmds.optionVar(query='mayaUsd_MakePathRelativeToSceneFile')
-            cmds.checkBox(cls.kMakePathRelativeCheckBox, edit=True, value=relative)
+        if cmds.optionVar(exists='mayaUsd_MakePathRelativeTo' + relativeToWhat):
+            relative = cmds.optionVar(query='mayaUsd_MakePathRelativeTo' + relativeToWhat)
+            cmds.checkBox(cls.kMakePathRelativeCheckBox + relativeToWhat, edit=True, value=relative)
 
-        # If there is no Maya scene file saved, then the checkbox and label should be disabled.
-        haveSceneFile = cmds.file(q=True, exists=True)
-        cmds.checkBox(cls.kMakePathRelativeCheckBox, edit=True, enable=haveSceneFile)
+        # If if cannot be relative, then the checkbox and label should be disabled.
+        cmds.checkBox(cls.kMakePathRelativeCheckBox + relativeToWhat, edit=True, enable=canBeRelative)
 
     @classmethod
-    def uiCommit(cls, parentLayout, selectedFile=None):
+    def uiCommit(cls, parentLayout, relativeToWhat):
+        """
+        Helper method to commit the UI layout for the file relative actions.
+
+        Input parentLayout arg is expected to the a scroll layout into which controls
+        can be added.
+
+        Input relativeToWhat tells what the file is relative to. See the class docs.
+        """
         cmds.setParent(parentLayout)
 
         # Get the current checkbox state and save to optionVar.
-        relative = cmds.checkBox(cls.kMakePathRelativeCheckBox, query=True, value=True)
-        cmds.optionVar(iv=('mayaUsd_MakePathRelativeToSceneFile', relative))
+        relative = cmds.checkBox(cls.kMakePathRelativeCheckBox + relativeToWhat, query=True, value=True)
+        cmds.optionVar(iv=('mayaUsd_MakePathRelativeTo' + relativeToWhat, relative))
+
+
+class usdRootFileRelative(usdFileRelative):
+    '''
+    Helper class to create the UI for load/save dialog boxes that need to make the
+    selected file name optionally relative to the Maya scene file.
+    '''
+
+    kRelativeToWhat = 'SceneFile'
+
+    @classmethod
+    def uiCreate(cls, parentLayout):
+        usdFileRelative.uiCreate(parentLayout, cls.kRelativeToWhat)
+
+    @classmethod
+    def uiInit(cls, parentLayout, filterType):
+        '''
+        Note: the function takes an unused filterType argument to be compatible
+              with the dialog2 command API.
+        '''
+        # If there is no Maya scene file saved, then the checkbox and label should be disabled.
+        haveSceneFile = cmds.file(q=True, exists=True)
+        usdFileRelative.setRelativeFilePathRoot(cmds.file(query=True, sceneName=True))
+        usdFileRelative.uiInit(parentLayout, haveSceneFile, cls.kRelativeToWhat)
+
+    @classmethod
+    def uiCommit(cls, parentLayout, selectedFile=None):
+        '''
+        Note: the function takes an unused selectedFile argument to be compatible
+              with the dialog2 command API.
+        '''
+        usdFileRelative.uiCommit(parentLayout, cls.kRelativeToWhat)
+
+
+class usdFileRelativeToEditTargetLayer(usdFileRelative):
+    '''
+    Helper class to create the UI for load/save dialog boxes that need to make the
+    selected file name optionally relative to a layer file.
+    '''
+
+    kRelativeToWhat = 'EditTargetLayer'
+
+    @classmethod
+    def uiCreate(cls, parentLayout):
+        usdFileRelative.uiCreate(parentLayout, cls.kRelativeToWhat)
+
+    @classmethod
+    def uiInit(cls, parentLayout, filterType):
+        '''
+        Note: the function takes an unused filterType argument to be compatible
+              with the dialog2 command API.
+        '''
+        # If there is no Maya scene file saved, then the checkbox and label should be disabled.
+        print(usdFileRelative.getRelativeFilePathRoot())
+        canBeRelative = bool(usdFileRelative.getRelativeFilePathRoot())
+        usdFileRelative.uiInit(parentLayout, canBeRelative, cls.kRelativeToWhat)
+
+    @classmethod
+    def uiCommit(cls, parentLayout, selectedFile=None):
+        '''
+        Note: the function takes an unused selectedFile argument to be compatible
+              with the dialog2 command API.
+        '''
+        usdFileRelative.uiCommit(parentLayout, cls.kRelativeToWhat)

--- a/plugin/adsk/scripts/mayaUsd_pluginUICreation.mel
+++ b/plugin/adsk/scripts/mayaUsd_pluginUICreation.mel
@@ -48,6 +48,7 @@ global proc mayaUsd_pluginUICreation()
         // is no mechanism to source such a file once, if multiple plugins are
         // loaded, so source it here in this plugin.  PPT, 29-Nov-2021.
         source "mayaUsdAddMayaReference.mel";
+        source "mayaUsdAddUSDReference.mel";
         source "mayaUsdCacheMayaReference.mel";
         source "mayaUsdMergeToUSDOptions.mel";
         source "mayaUsdDuplicateAsMayaDataOptions.mel";


### PR DESCRIPTION
- Refactor the Python helper to handle the relative-path UI in file dialogs.
- Make it more generic by abstracting to which file the path will be relative to, the label of the UI and the option var used.
- Add makePathRelativeTo function to UsdMayaUtilFileSystem to make any file path relative to a given directory.
- Add requireUsdPathsRelativeToEditTargetLayer function to verify if USD ref paths should be relative.
- Make the USD context menu use the new relative ref UI and functions.
- Refactor its code a bit to make reading the generated scripts easier.