### PR TITLE
Add a version upper bound on Hydra workaround

### DIFF
--- a/lib/mayaUsd/ufe/UsdConnectionHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdConnectionHandler.cpp
@@ -111,6 +111,7 @@ _GetShaderNodeDef(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attrName)
     return registry.GetShaderNodeByIdentifier(srcInfoId);
 }
 
+#if PXR_VERSION < 2302
 void _SendStrongConnectionChangeNotification(const UsdPrim& usdPrim)
 {
     // See https://github.com/PixarAnimationStudios/USD/issues/2013 for details.
@@ -124,6 +125,7 @@ void _SendStrongConnectionChangeNotification(const UsdPrim& usdPrim)
     usdPrim.GetStage()->DefinePrim(waPath);
     usdPrim.GetStage()->RemovePrim(waPath);
 }
+#endif
 
 } // namespace
 
@@ -246,9 +248,11 @@ bool UsdConnectionHandler::createConnection(
         }
     }
 
+#if PXR_VERSION < 2302
     if (retVal) {
         _SendStrongConnectionChangeNotification(dstApi.GetPrim());
     }
+#endif
 
     return retVal;
 }
@@ -295,9 +299,11 @@ bool UsdConnectionHandler::deleteConnection(
         }
     }
 
+#if PXR_VERSION < 2302
     if (retVal) {
         _SendStrongConnectionChangeNotification(dstUsdAttr->usdPrim());
     }
+#endif
 
     return retVal;
 }

--- a/lib/mayaUsd/ufe/UsdUndoConnectionCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoConnectionCommands.cpp
@@ -118,6 +118,7 @@ _GetShaderNodeDef(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attrName)
     return registry.GetShaderNodeByIdentifier(srcInfoId);
 }
 
+#if PXR_VERSION < 2302
 void _SendStrongConnectionChangeNotification(const UsdPrim& usdPrim)
 {
     // See https://github.com/PixarAnimationStudios/USD/issues/2013 for details.
@@ -131,6 +132,7 @@ void _SendStrongConnectionChangeNotification(const UsdPrim& usdPrim)
     usdPrim.GetStage()->DefinePrim(waPath);
     usdPrim.GetStage()->RemovePrim(waPath);
 }
+#endif
 
 } // namespace
 
@@ -243,12 +245,20 @@ void UsdUndoCreateConnectionCommand::execute()
         }
     }
 
+#if PXR_VERSION < 2302
     if (isConnected) {
         _SendStrongConnectionChangeNotification(dstApi.GetPrim());
     } else {
         _srcInfo = nullptr;
         _dstInfo = nullptr;
     }
+#else
+    if (!isConnected) {
+        _srcInfo = nullptr;
+        _dstInfo = nullptr;
+    }
+#endif
+
 }
 
 Ufe::Connection::Ptr UsdUndoCreateConnectionCommand::connection() const
@@ -328,9 +338,11 @@ void UsdUndoDeleteConnectionCommand::execute()
         }
     }
 
+#if PXR_VERSION < 2302
     if (isDisconnected) {
         _SendStrongConnectionChangeNotification(dstUsdAttr->usdPrim());
     }
+#endif
 }
 
 void UsdUndoDeleteConnectionCommand::undo() { _undoableItem.undo(); }

--- a/lib/mayaUsd/ufe/UsdUndoConnectionCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoConnectionCommands.cpp
@@ -258,7 +258,6 @@ void UsdUndoCreateConnectionCommand::execute()
         _dstInfo = nullptr;
     }
 #endif
-
 }
 
 Ufe::Connection::Ptr UsdUndoCreateConnectionCommand::connection() const


### PR DESCRIPTION
A workaround was created for
https://github.com/PixarAnimationStudios/USD/issues/2013 which was fixed in USD 23.02 via https://github.com/PixarAnimationStudios/USD/pull/2017/commits/e3b963b4ee622d2d07ae5f60ce9c5684f0d4966f

This makes sure the workaround ends once we reach that USD version.