### PR TITLE
MAYA-127119 - Save USD root file relative to scene file

### DIFF
--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.py
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.py
@@ -35,4 +35,5 @@ def mayaUSDRegisterStrings():
     register("kDiscardStageEditsReloadMsg", "Are you sure you want to reload ^1s as the stage source?\n\nAll edits on your layers (except the session layer) in ^2s will be discarded.")
     register("kLoadUSDFile", "Load USD File")
     register("kFileOptions", "File Options")
-    register("kMakePathRelativeToSceneFile", "Make Path Relative to Scene File Directory")
+    register("kMakePathRelativeToSceneFile", "Make Path Relative to Scene File")
+    register("kMakePathRelativeToSceneFileAnn", "If enabled, path will be relative to your Maya scene file. If this option is disabled, there is no Maya scene file and the path will be absolute. Save your Maya scene file to disk to make this option available.")

--- a/plugin/adsk/scripts/mayaUsd_USDRootFileRelative.py
+++ b/plugin/adsk/scripts/mayaUsd_USDRootFileRelative.py
@@ -33,12 +33,13 @@ class usdRootFileRelative(object):
 
         kFileOptionsStr = getMayaUsdString("kFileOptions")
         kMakePathRelativeStr = getMayaUsdString("kMakePathRelativeToSceneFile")
+        kMakePathRelativeAnnStr = getMayaUsdString("kMakePathRelativeToSceneFileAnn")
  
         optBoxMarginWidth = mel.eval('global int $gOptionBoxTemplateDescriptionMarginWidth; $gOptionBoxTemplateDescriptionMarginWidth += 0')
         cmds.setParent(topForm)
         cmds.frameLayout(label=kFileOptionsStr, collapsable=False)
         widgetColumn = cmds.columnLayout()
-        cmds.checkBox(cls.kMakePathRelativeCheckBox, label=kMakePathRelativeStr)
+        cmds.checkBox(cls.kMakePathRelativeCheckBox, label=kMakePathRelativeStr, ann=kMakePathRelativeAnnStr)
 
     @classmethod
     def uiInit(cls, parentLayout, filterType):


### PR DESCRIPTION
MAYA-127119 - Save USD root file relative to scene file
MAYA-127352 - Save USD root file relative to scene file using Bulk Save
MAYA-127358 - Load my USD root file relative to scene file using 'Create Stage from File'
MAYA-127353 - Load my USD root file relative to the scene file

* Small update to UI string for checkbox (with new tooltip).