### PR TITLE
Adding a MaterialX v1.38.5 update for closures

### DIFF
--- a/lib/mayaUsd/render/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
@@ -385,8 +385,45 @@ ShaderPtr GlslFragmentGenerator::generate(
                 true);
         }
 
-        // Add all function calls
+        // Add all function calls (varies greatly by MaterialX version)
+#if MX_COMBINED_VERSION < 13803
         emitFunctionCalls(graph, context, pixelStage);
+#else
+        // Surface shaders need special handling.
+        if (graph.hasClassification(
+                ShaderNode::Classification::SHADER | ShaderNode::Classification::SURFACE)) {
+            // Emit all texturing nodes. These are inputs to any
+            // closure/shader nodes and need to be emitted first.
+            emitFunctionCalls(graph, context, pixelStage, ShaderNode::Classification::TEXTURE);
+
+#if MX_COMBINED_VERSION < 13805
+            // Emit function calls for all surface shader nodes.
+            // These will internally emit their closure function calls.
+            emitFunctionCalls(
+                graph,
+                context,
+                pixelStage,
+                ShaderNode::Classification::SHADER | ShaderNode::Classification::SURFACE);
+#else
+            // Emit function calls for "root" closure/shader nodes.
+            // These will internally emit function calls for any dependent closure nodes upstream.
+            for (ShaderGraphOutputSocket* socket : graph.getOutputSockets()) {
+                if (socket->getConnection()) {
+                    const ShaderNode* upstream = socket->getConnection()->getNode();
+                    if (upstream->getParent() == &graph
+                        && (upstream->hasClassification(ShaderNode::Classification::CLOSURE)
+                            || upstream->hasClassification(ShaderNode::Classification::SHADER))) {
+                        emitFunctionCall(*upstream, context, pixelStage);
+                    }
+                }
+            }
+#endif
+        } else {
+            // No surface shader graph so just generate all
+            // function calls in order.
+            emitFunctionCalls(graph, context, pixelStage);
+        }
+#endif
 
         // Emit final result
         //


### PR DESCRIPTION
Shading graphs containing closures would fail to work with MaterialX 1.38.5.