### PR TITLE
mayaUsd scene hierarchies need flattening scene index filter.

### DIFF
--- a/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
+++ b/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
@@ -18,10 +18,10 @@
 
 #if PXR_VERSION >= 2211
 
+#include <pxr/imaging/hd/flatteningSceneIndex.h>
 #include <pxr/imaging/hd/retainedDataSource.h>
 #include <pxr/imaging/hd/sceneIndexPlugin.h>
 #include <pxr/imaging/hd/sceneIndexPluginRegistry.h>
-#include <pxr/imaging/hd/flatteningSceneIndex.h>
 #include <pxr/usd/usd/primFlags.h>
 #include <pxr/usdImaging/usdImaging/delegate.h>
 

--- a/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
+++ b/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
@@ -21,6 +21,7 @@
 #include <pxr/imaging/hd/retainedDataSource.h>
 #include <pxr/imaging/hd/sceneIndexPlugin.h>
 #include <pxr/imaging/hd/sceneIndexPluginRegistry.h>
+#include <pxr/imaging/hd/flatteningSceneIndex.h>
 #include <pxr/usd/usd/primFlags.h>
 #include <pxr/usdImaging/usdImaging/delegate.h>
 
@@ -60,7 +61,10 @@ HdSceneIndexBaseRefPtr MayaUsdProxyShapeMayaNodeSceneIndexPlugin::_AppendSceneIn
 
         auto proxyShape = dynamic_cast<MayaUsdProxyShapeBase*>(dependNodeFn.userNode());
         if (TF_VERIFY(proxyShape, "Error getting MayaUsdProxyShapeBase")) {
-            return MayaUsd::MayaUsdProxyShapeSceneIndex::New(proxyShape);
+            auto psSceneIndex = MayaUsd::MayaUsdProxyShapeSceneIndex::New(proxyShape);
+            // Flatten transforms, visibility, purpose, model, and material
+            // bindings over hierarchies.
+            return HdFlatteningSceneIndex::New(psSceneIndex);
         }
     }
 


### PR DESCRIPTION
As per
https://groups.google.com/g/usd-interest/c/PuZud-IQ6gE/m/TZJ2BOtYBQAJ
the legacy UsdImaging scene delegate flattens the USD scene. Moving to the new Hydra 2.0 scene index framework requires adding an explicit flattening filtering scene index.