### PR TITLE
MAYA-127478 fix bulk save of root layer filename

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -248,6 +248,7 @@ private:
     void saveUsdLayerToMayaFile(SdfLayerRefPtr layer, bool asAnonymous);
     void clearProxies();
     bool hasDirtyLayer() const;
+    void refreshProxiesToSave();
 
     std::map<std::string, SdfLayerRefPtr> _idToLayer;
     TfNotice::Key                         _onStageSetKey;
@@ -520,6 +521,27 @@ bool LayerDatabase::getProxiesToSave(bool isExport)
 
 bool LayerDatabase::saveInteractionRequired() { return _proxiesToSave.size() > 0; }
 
+static void refreshSavingInfo(StageSavingInfo& info)
+{
+    MFnDependencyNode fn;
+    MObject           mobj = info.dagPath.node();
+    fn.setObject(mobj);
+    if (!fn.isFromReferencedFile() && LayerDatabase::instance().supportedNodeType(fn.typeId())) {
+        MayaUsdProxyShapeBase* pShape = static_cast<MayaUsdProxyShapeBase*>(fn.userNode());
+        info.stage = pShape ? pShape->getUsdStage() : nullptr;
+    }
+}
+
+void LayerDatabase::refreshProxiesToSave()
+{
+    for (StageSavingInfo& info : _proxiesToSave) {
+        refreshSavingInfo(info);
+    }
+    for (StageSavingInfo& info : _internalProxiesToSave) {
+        refreshSavingInfo(info);
+    }
+}
+
 bool LayerDatabase::saveUsd(bool isExport)
 {
     BatchSaveResult result = MayaUsd::kNotHandled;
@@ -554,6 +576,12 @@ bool LayerDatabase::saveUsd(bool isExport)
         } else if (result == kPartiallyCompleted && !hasDirtyLayer()) {
             return true;
         }
+
+        // After the potentially partial save, we need to refresh the stages
+        // to be saved because the saving might have modified the proxy shape
+        // attributes and we need to re-evaluate these nodes so that the stages
+        // are re-created with the new attribute values if needed.
+        refreshProxiesToSave();
 
         if (MayaUsd::utils::kSaveToUSDFiles == opt) {
             result = saveUsdToUsdFiles();
@@ -781,6 +809,9 @@ void LayerDatabase::convertAnonymousLayers(
 
     convertAnonymousLayersRecursive(root, proxyName, stage);
 
+    // Note: retrieve root again since it may have been changed by the call
+    //       to convertAnonymousLayersRecursive
+    root = stage->GetRootLayer();
     if (root->IsAnonymous()) {
         PXR_NS::SdfFileFormat::FileFormatArguments args;
         std::string newFileName = MayaUsd::utils::generateUniqueFileName(proxyName);


### PR DESCRIPTION
When doing a bulk-save of layers when saving a Maya scene for the first time, the multiple-parts of the saving process could end-up using stale data. That is because there is a first batch-save delegate (customizable callback) that can do a partial save, then a fallback save is done for any layer that did not get saved.

When a stage has just been created, it contains an anonymous root layer which gets replaced by a non-anonymous by the batch save delegate. When the root layer is swapped, the stage proxy shape is updated by setting its stage name attribute.  Unfortunately, the USD stage object was being cached and the attribute change was thus not use immediately. Thus the 2nd part fallback-save thought that the root layer was still anonymous.

The fix is to refresh the cached USD stages by pulling again on the proxy stage node so that it updates itself when its attributes have been changed.