### PR TITLE
MAYA-126541 - Create a more extensive unit test for display layer support during USD to USD duplication 

### DIFF
--- a/test/lib/ufe/testDisplayLayer.py
+++ b/test/lib/ufe/testDisplayLayer.py
@@ -389,7 +389,7 @@ class DisplayLayerTestCase(unittest.TestCase):
         self._testLayerFromPath(CUBE2, self.LAYER1)
         self._testLayerFromPath(XFORM2_CUBE1, self.LAYER1)
 
-        # Now duplicate XFORM1_CUBE1 itself.
+        # Let's also test duplicating a node that is not the root child: XFORM1_CUBE1.
         cmds.select(self.XFORM1_CUBE1)
         cmds.duplicate()
 

--- a/test/lib/ufe/testDisplayLayer.py
+++ b/test/lib/ufe/testDisplayLayer.py
@@ -389,6 +389,16 @@ class DisplayLayerTestCase(unittest.TestCase):
         self._testLayerFromPath(CUBE2, self.LAYER1)
         self._testLayerFromPath(XFORM2_CUBE1, self.LAYER1)
 
+        # Now duplicate XFORM1_CUBE1 itself.
+        cmds.select(self.XFORM1_CUBE1)
+        cmds.duplicate()
+
+        # Verify that the duplicate object is in the same display layer.
+        layerObjs = cmds.editDisplayLayerMembers(self.LAYER1, query=True, **self.kwArgsEditDisplayLayerMembers)
+        XFORM1_CUBE2 = '|stage1|stageShape1,/Xform1/Cube2'
+        self.assertTrue(XFORM1_CUBE2 in layerObjs)
+        self._testLayerFromPath(XFORM1_CUBE2, self.LAYER1)    
+
     def testDisplayLayerClear(self):
         cmdHelp = cmds.help('editDisplayLayerMembers')
         if '-clear' not in cmdHelp:


### PR DESCRIPTION
Additional testing for USD to USD duplication with display layers. This case covers the bug found by QA during the original feature testing