### PR TITLE
MAYA-124897 implement scale pivot for common API

### DIFF
--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
@@ -245,6 +245,8 @@ Ufe::Vector3d UsdTransform3dCommonAPI::rotatePivot() const
     return toUfe(pvt);
 }
 
+Ufe::Vector3d UsdTransform3dCommonAPI::scalePivot() const { return rotatePivot(); }
+
 Ufe::SetMatrix4dUndoableCommand::Ptr UsdTransform3dCommonAPI::setMatrixCmd(const Ufe::Matrix4d& m)
 {
     if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.h
@@ -62,6 +62,8 @@ public:
     void                               rotatePivot(double x, double y, double z) override;
     Ufe::Vector3d                      rotatePivot() const override;
 
+    Ufe::Vector3d                      scalePivot() const override;
+
     Ufe::SetMatrix4dUndoableCommand::Ptr setMatrixCmd(const Ufe::Matrix4d& m) override;
 
 private:

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.h
@@ -62,7 +62,7 @@ public:
     void                               rotatePivot(double x, double y, double z) override;
     Ufe::Vector3d                      rotatePivot() const override;
 
-    Ufe::Vector3d                      scalePivot() const override;
+    Ufe::Vector3d scalePivot() const override;
 
     Ufe::SetMatrix4dUndoableCommand::Ptr setMatrixCmd(const Ufe::Matrix4d& m) override;
 


### PR DESCRIPTION
 Like the other implementations, call the rotate pivot function. This fixes the visual position of the scale pivot in Maya when using the scaling tool.