### PR TITLE
MAYA-125340 improve error messages

### DIFF
--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -539,9 +539,8 @@ void applyCommandRestriction(
     // layer that would allow it to proceed. In that case, do not suggest changing
     // the target.
     std::string message = allowStronger ? "It is defined on another layer. " : "";
-    std::string instructions = allowStronger
-        ? "Please set [%s] as the target layer to proceed."
-        : "It would orphan opinions on the layer [%s].";
+    std::string instructions = allowStronger ? "Please set [%s] as the target layer to proceed."
+                                             : "It would orphan opinions on the layer [%s].";
 
     // iterate over the prim stack, starting at the highest-priority layer.
     for (const auto& spec : primStack) {

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -539,8 +539,8 @@ void applyCommandRestriction(
     // layer that would allow it to proceed. In that case, do not suggest changing
     // the target.
     std::string message = allowStronger ? "It is defined on another layer. " : "";
-    std::string instructions = allowStronger ? "Please set [%s] as the target layer to proceed."
-                                             : "It would orphan opinions on the layer [%s].";
+    std::string instructions = allowStronger ? "Please set %s as the target layer to proceed."
+                                             : "It would orphan opinions on the layer %s.";
 
     // iterate over the prim stack, starting at the highest-priority layer.
     for (const auto& spec : primStack) {


### PR DESCRIPTION
When an operation cannot proceed because it would need to modify multiple layers at the same time, use a different error message. Do not tell the user to switch layer.