### PR TITLE
MAYA-114188 save the target layer

### DIFF
--- a/lib/mayaUsd/listeners/stageNoticeListener.h
+++ b/lib/mayaUsd/listeners/stageNoticeListener.h
@@ -54,6 +54,8 @@ public:
         = std::function<void(const UsdNotice::ObjectsChanged& notice)>;
     using StageLayerMutingChangedCallback
         = std::function<void(const UsdNotice::LayerMutingChanged& notice)>;
+    using StageEditTargetChangedCallback
+        = std::function<void(const UsdNotice::StageEditTargetChanged& notice)>;
 
     /// Sets the callback to be invoked when the listener receives a
     /// StageContentsChanged notice.
@@ -66,9 +68,14 @@ public:
     void SetStageObjectsChangedCallback(const StageObjectsChangedCallback& callback);
 
     /// Sets the callback to be invoked when the listener receives a
-    /// ObjectsChanged notice.
+    /// LayerMutingChanged notice.
     MAYAUSD_CORE_PUBLIC
     void SetStageLayerMutingChangedCallback(const StageLayerMutingChangedCallback& callback);
+
+    /// Sets the callback to be invoked when the listener receives a
+    /// EditTargetChanged notice.
+    MAYAUSD_CORE_PUBLIC
+    void SetStageEditTargetChangedCallback(const StageEditTargetChangedCallback& callback);
 
 private:
     UsdMayaStageNoticeListener(const UsdMayaStageNoticeListener&) = delete;
@@ -86,12 +93,16 @@ private:
     TfNotice::Key                   _stageLayerMutingChangedKey {};
     StageLayerMutingChangedCallback _stageLayerMutingChangedCallback {};
 
+    TfNotice::Key                   _stageEditTargetChangedKey {};
+    StageEditTargetChangedCallback  _stageEditTargetChangedCallback {};
+
     void _UpdateStageContentsChangedRegistration();
     void _OnStageContentsChanged(const UsdNotice::StageContentsChanged& notice) const;
     void _OnStageLayerMutingChanged(const UsdNotice::LayerMutingChanged& notice) const;
     void _OnStageObjectsChanged(
         const UsdNotice::ObjectsChanged& notice,
         const UsdStageWeakPtr&           sender) const;
+    void _OnStageEditTargetChanged(const UsdNotice::StageEditTargetChanged& notice) const;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/listeners/stageNoticeListener.h
+++ b/lib/mayaUsd/listeners/stageNoticeListener.h
@@ -93,8 +93,8 @@ private:
     TfNotice::Key                   _stageLayerMutingChangedKey {};
     StageLayerMutingChangedCallback _stageLayerMutingChangedCallback {};
 
-    TfNotice::Key                   _stageEditTargetChangedKey {};
-    StageEditTargetChangedCallback  _stageEditTargetChangedCallback {};
+    TfNotice::Key                  _stageEditTargetChangedKey {};
+    StageEditTargetChangedCallback _stageEditTargetChangedCallback {};
 
     void _UpdateStageContentsChangedRegistration();
     void _OnStageContentsChanged(const UsdNotice::StageContentsChanged& notice) const;

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -1195,6 +1195,11 @@ MStatus MayaUsdProxyShapeBase::computeOutStageData(MDataBlock& dataBlock)
                 return _OnLayerMutingChanged(notice);
             });
 
+        _stageNoticeListener.SetStageEditTargetChangedCallback(
+            [this](const UsdNotice::StageEditTargetChanged& notice) {
+                return _OnStageEditTargetChanged(notice);
+            });
+
         MayaUsdProxyStageSetNotice(*this).Send();
     }
 
@@ -1874,6 +1879,15 @@ void MayaUsdProxyShapeBase::_OnLayerMutingChanged(const UsdNotice::LayerMutingCh
         return;
 
     copyLayerMutingToAttribute(*stage, *this);
+}
+
+void  MayaUsdProxyShapeBase::_OnStageEditTargetChanged(const UsdNotice::StageEditTargetChanged& notice)
+{
+    const auto stage = getUsdStage();
+    if (!stage)
+        return;
+
+    copyTargetLayerToAttribute(*stage, *this);
 }
 
 void MayaUsdProxyShapeBase::_OnStageObjectsChanged(const UsdNotice::ObjectsChanged& notice)

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -1881,7 +1881,8 @@ void MayaUsdProxyShapeBase::_OnLayerMutingChanged(const UsdNotice::LayerMutingCh
     copyLayerMutingToAttribute(*stage, *this);
 }
 
-void  MayaUsdProxyShapeBase::_OnStageEditTargetChanged(const UsdNotice::StageEditTargetChanged& notice)
+void MayaUsdProxyShapeBase::_OnStageEditTargetChanged(
+    const UsdNotice::StageEditTargetChanged& notice)
 {
     const auto stage = getUsdStage();
     if (!stage)

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -28,6 +28,7 @@
 #include <mayaUsd/utils/loadRules.h>
 #include <mayaUsd/utils/query.h>
 #include <mayaUsd/utils/stageCache.h>
+#include <mayaUsd/utils/targetLayer.h>
 #include <mayaUsd/utils/util.h>
 #include <mayaUsd/utils/utilFileSystem.h>
 
@@ -990,6 +991,7 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
         primPath = finalUsdStage->GetPseudoRoot().GetPath();
         copyLoadRulesFromAttribute(*this, *finalUsdStage);
         copyLayerMutingFromAttribute(*this, *finalUsdStage);
+        copyTargetLayerFromAttribute(*this, *finalUsdStage);
         updateShareMode(sharedUsdStage, unsharedUsdStage, loadSet);
     }
 

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -390,6 +390,7 @@ private:
     void _OnStageContentsChanged(const UsdNotice::StageContentsChanged& notice);
     void _OnStageObjectsChanged(const UsdNotice::ObjectsChanged& notice);
     void _OnLayerMutingChanged(const UsdNotice::LayerMutingChanged& notice);
+    void _OnStageEditTargetChanged(const UsdNotice::StageEditTargetChanged& notice);
 
     UsdMayaStageNoticeListener _stageNoticeListener;
 

--- a/lib/mayaUsd/nodes/proxyShapeStageExtraData.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeStageExtraData.cpp
@@ -16,6 +16,7 @@
 #include "proxyShapeStageExtraData.h"
 
 #include <mayaUsd/utils/loadRules.h>
+#include <mayaUsd/utils/targetLayer.h>
 
 #include <maya/MSceneMessage.h>
 
@@ -62,6 +63,11 @@ void saveTrackedLoadRules(const UsdStageRefPtr& stage)
     saveTrackedData(stage, copyLoadRulesToAttribute);
 }
 
+void saveTrackedTargetLayer(const UsdStageRefPtr& stage)
+{
+    saveTrackedData(stage, copyTargetLayerToAttribute);
+}
+
 } // namespace
 
 /* static */
@@ -101,7 +107,11 @@ void MayaUsdProxyShapeStageExtraData::removeProxyShape(MayaUsdProxyShapeBase& pr
 }
 
 /* static */
-void MayaUsdProxyShapeStageExtraData::saveAllStageData() { saveAllLoadRules(); }
+void MayaUsdProxyShapeStageExtraData::saveAllStageData()
+{
+    saveAllLoadRules();
+    saveAllTargetLayers();
+}
 
 /* static */
 void MayaUsdProxyShapeStageExtraData::saveAllLoadRules()
@@ -114,6 +124,19 @@ void MayaUsdProxyShapeStageExtraData::saveAllLoadRules()
 void MayaUsdProxyShapeStageExtraData::saveLoadRules(const UsdStageRefPtr& stage)
 {
     saveTrackedLoadRules(stage);
+}
+
+/* static */
+void MayaUsdProxyShapeStageExtraData::saveAllTargetLayers()
+{
+    // Note: passing nullptr means save all stages.
+    saveTrackedTargetLayer(nullptr);
+}
+
+/* static */
+void MayaUsdProxyShapeStageExtraData::saveTargetLayer(const UsdStageRefPtr& stage)
+{
+    saveTrackedTargetLayer(stage);
 }
 
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/nodes/proxyShapeStageExtraData.h
+++ b/lib/mayaUsd/nodes/proxyShapeStageExtraData.h
@@ -34,7 +34,7 @@ namespace MAYAUSD_NS_DEF {
 /// triggered before a scene is saved to copy the current proxy shape extra data from the stage
 /// to the proxy shape.
 ///
-/// The extra data saved this way currently are: payload load rules.
+/// The extra data saved this way currently are: payload load rules and current target layer.
 
 class MayaUsdProxyShapeStageExtraData
 {
@@ -67,6 +67,14 @@ public:
     /// \brief save load rules of the tracked proxy shape corresponding to the given stage.
     MAYAUSD_CORE_PUBLIC
     static void saveLoadRules(const UsdStageRefPtr& stage);
+
+    /// \brief save the target layers of tracked proxy shapes.
+    MAYAUSD_CORE_PUBLIC
+    static void saveAllTargetLayers();
+
+    /// \brief save the target layer of the tracked proxy shape corresponding to the given stage.
+    MAYAUSD_CORE_PUBLIC
+    static void saveTargetLayer(const UsdStageRefPtr& stage);
 };
 
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/CMakeLists.txt
+++ b/lib/mayaUsd/utils/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(${PROJECT_NAME}
         progressBarScope.cpp
         selectability.cpp
         stageCache.cpp
+        targetLayer.cpp
         traverseLayer.cpp
         undoHelperCommand.cpp
         util.cpp
@@ -54,6 +55,7 @@ set(HEADERS
     progressBarScope.h
     selectability.h
     stageCache.h
+    targetLayer.h
     traverseLayer.h
     undoHelperCommand.h
     util.h

--- a/lib/mayaUsd/utils/targetLayer.cpp
+++ b/lib/mayaUsd/utils/targetLayer.cpp
@@ -1,0 +1,104 @@
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "targetLayer.h"
+
+#include "dynamicAttribute.h"
+
+#include <pxr/usd/sdf/layer.h>
+#include <pxr/usd/usd/editTarget.h>
+
+#include <maya/MCommandResult.h>
+#include <maya/MDGModifier.h>
+#include <maya/MFnDependencyNode.h>
+#include <maya/MFnTypedAttribute.h>
+#include <maya/MGlobal.h>
+#include <maya/MObject.h>
+#include <maya/MString.h>
+
+namespace MAYAUSD_NS_DEF {
+
+MString convertTargetLayerToText(const PXR_NS::UsdStage& stage)
+{
+    MString text;
+
+    const PXR_NS::UsdEditTarget   target = stage.GetEditTarget();
+    if (!target.IsValid())
+        return text;
+
+    const PXR_NS::SdfLayerHandle& layer = target.GetLayer();
+    if (!layer)
+        return text;
+
+    text = layer->GetIdentifier().c_str();
+
+    return text;
+}
+
+void setTargetLayerFromText(PXR_NS::UsdStage& stage, const MString& text)
+{
+    if (text.isEmpty())
+        return;
+
+    const std::string layerId(text.asChar());
+    for (const auto& layer : stage.GetLayerStack())
+        if (layer->GetIdentifier() == layerId)
+            stage.SetEditTarget(layer);
+}
+
+namespace {
+
+const char targetLayerAttrName[] = "usdStageTargetLayer";
+
+} // namespace
+
+MStatus copyTargetLayerToAttribute(const PXR_NS::UsdStage& stage, MayaUsdProxyShapeBase& proxyShape)
+{
+    MObject proxyObj = proxyShape.thisMObject();
+    if (proxyObj.isNull())
+        return MS::kFailure;
+
+    MFnDependencyNode depNode(proxyObj);
+    if (!hasDynamicAttribute(depNode, targetLayerAttrName))
+        createDynamicAttribute(depNode, targetLayerAttrName);
+
+    MString loadRulesText = convertTargetLayerToText(stage);
+
+    MStatus status = setDynamicAttribute(depNode, targetLayerAttrName, loadRulesText);
+
+    return status;
+}
+
+MStatus
+copyTargetLayerFromAttribute(const MayaUsdProxyShapeBase& proxyShape, PXR_NS::UsdStage& stage)
+{
+    MObject proxyObj = proxyShape.thisMObject();
+    if (proxyObj.isNull())
+        return MS::kFailure;
+
+    MFnDependencyNode depNode(proxyObj);
+    if (!hasDynamicAttribute(depNode, targetLayerAttrName))
+        return MS::kNotFound;
+
+    MString loadRulesText;
+    MStatus status = getDynamicAttribute(depNode, targetLayerAttrName, loadRulesText);
+    if (status == MS::kSuccess)
+        setTargetLayerFromText(stage, loadRulesText);
+
+    return status;
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/targetLayer.cpp
+++ b/lib/mayaUsd/utils/targetLayer.cpp
@@ -35,7 +35,7 @@ MString convertTargetLayerToText(const PXR_NS::UsdStage& stage)
 {
     MString text;
 
-    const PXR_NS::UsdEditTarget   target = stage.GetEditTarget();
+    const PXR_NS::UsdEditTarget target = stage.GetEditTarget();
     if (!target.IsValid())
         return text;
 

--- a/lib/mayaUsd/utils/targetLayer.cpp
+++ b/lib/mayaUsd/utils/targetLayer.cpp
@@ -75,9 +75,9 @@ MStatus copyTargetLayerToAttribute(const PXR_NS::UsdStage& stage, MayaUsdProxySh
     if (!hasDynamicAttribute(depNode, targetLayerAttrName))
         createDynamicAttribute(depNode, targetLayerAttrName);
 
-    MString loadRulesText = convertTargetLayerToText(stage);
+    MString targetLayerText = convertTargetLayerToText(stage);
 
-    MStatus status = setDynamicAttribute(depNode, targetLayerAttrName, loadRulesText);
+    MStatus status = setDynamicAttribute(depNode, targetLayerAttrName, targetLayerText);
 
     return status;
 }
@@ -93,10 +93,10 @@ copyTargetLayerFromAttribute(const MayaUsdProxyShapeBase& proxyShape, PXR_NS::Us
     if (!hasDynamicAttribute(depNode, targetLayerAttrName))
         return MS::kNotFound;
 
-    MString loadRulesText;
-    MStatus status = getDynamicAttribute(depNode, targetLayerAttrName, loadRulesText);
+    MString targetLayerText;
+    MStatus status = getDynamicAttribute(depNode, targetLayerAttrName, targetLayerText);
     if (status == MS::kSuccess)
-        setTargetLayerFromText(stage, loadRulesText);
+        setTargetLayerFromText(stage, targetLayerText);
 
     return status;
 }

--- a/lib/mayaUsd/utils/targetLayer.h
+++ b/lib/mayaUsd/utils/targetLayer.h
@@ -1,0 +1,63 @@
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_TARGETLAYER_H
+#define MAYAUSD_TARGETLAYER_H
+
+#include <mayaUsd/base/api.h>
+#include <mayaUsd/nodes/proxyShapeBase.h>
+
+#include <pxr/usd/usd/stage.h>
+
+#include <maya/MApiNamespace.h>
+
+namespace MAYAUSD_NS_DEF {
+
+// The current target layer is stage-level data. As such, it is not saved
+// within the layer (i.e. in the USD files that have been staged.) The reason
+// behind this is that two stages could have different target layers. So, the
+// target layer cannot be a layer-level data.
+//
+// Furthermore, stages in USD are not saved but are a pure run-time entity,
+// part of the hosting application. It is thus the host responsibility to save
+// stage-level state. So, we need to explicitly save the target layer.
+//
+// We thus save the target layer in the proxy shape as an attribute.
+
+/*! \brief convert the stage target layer to a text format.
+ */
+MAYAUSD_CORE_PUBLIC
+MString convertTargetLayerToText(const PXR_NS::UsdStage& stage);
+
+/*! \brief set the stage target layer from a text format.
+ */
+MAYAUSD_CORE_PUBLIC
+void setTargetLayerFromText(PXR_NS::UsdStage& stage, const MString& text);
+
+/*! \brief copy the stage target layer in the corresponding attribute of the proxy shape.
+ */
+MAYAUSD_CORE_PUBLIC
+MStatus
+copyTargetLayerToAttribute(const PXR_NS::UsdStage& stage, MayaUsdProxyShapeBase& proxyShape);
+
+/*! \brief set the stage target layer from data in the corresponding attribute of the proxy shape.
+ */
+MAYAUSD_CORE_PUBLIC
+MStatus
+copyTargetLayerFromAttribute(const MayaUsdProxyShapeBase& proxyShape, PXR_NS::UsdStage& stage);
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif

--- a/test/lib/mayaUsd/utils/CMakeLists.txt
+++ b/test/lib/mayaUsd/utils/CMakeLists.txt
@@ -103,6 +103,10 @@ if(IS_WINDOWS)
         testLoadRules.cpp
     )
     add_mayaUsdLibUtils_test(
+        testTargetLayer
+        testTargetLayer.cpp
+    )
+    add_mayaUsdLibUtils_test(
         testSplitString
         testSplitString.cpp
     )

--- a/test/lib/mayaUsd/utils/testTargetLayer.cpp
+++ b/test/lib/mayaUsd/utils/testTargetLayer.cpp
@@ -1,0 +1,36 @@
+#include <mayaUsd/utils/targetLayer.h>
+
+#include <pxr/usd/sdf/layer.h>
+
+#include <gtest/gtest.h>
+
+using namespace PXR_NS;
+using namespace MAYAUSD_NS_DEF;
+
+TEST(ConvertTargetLayer, convertDefaultTargetLayer)
+{
+    auto originalStage = UsdStage::CreateInMemory();
+    auto originalTargetLayer = originalStage->GetEditTarget();
+
+    const MString text = convertTargetLayerToText(*originalStage);
+    setTargetLayerFromText(*originalStage, text);
+
+    auto restoredTargetLayer = originalStage->GetEditTarget();
+    EXPECT_EQ(originalTargetLayer, restoredTargetLayer);
+}
+
+TEST(ConvertTargetLayer, convertSubLayerTargetLayer)
+{
+    auto originalStage = UsdStage::CreateInMemory();
+    auto subLayer = SdfLayer::CreateAnonymous();
+    originalStage->GetRootLayer()->InsertSubLayerPath(subLayer->GetIdentifier());
+    originalStage->SetEditTarget(subLayer);
+
+    auto originalTargetLayer = originalStage->GetEditTarget();
+
+    const MString text = convertTargetLayerToText(*originalStage);
+    setTargetLayerFromText(*originalStage, text);
+
+    auto restoredTargetLayer = originalStage->GetEditTarget();
+    EXPECT_EQ(originalTargetLayer, restoredTargetLayer);
+}


### PR DESCRIPTION
- When saving a Maya scene, the current target layer of USD stage get saved in an attribute on the proxy shape.
- When loading a scene, when creating the USD stage, set the target layer to the one that was saved.
- The target layer is persisted as a text attribute containing the USD layer identifier.
- Listen to edit target change to save the attribute when the target is set to avoid losing it if the proxy shape gets recomputed.
-  Add a unit test,.
