### PR TITLE
Releases the memory a data handle is holding onto when exporting meshes.

### DIFF
--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
@@ -1443,6 +1443,7 @@ MStatus UsdMayaMeshWriteUtils::exportComponentTags(UsdGeomMesh& primSchema, MObj
             }
         }
     }
+    outShp.destructHandle(geomDataHandle);
 
     return status;
 }


### PR DESCRIPTION
When exporting the entire scene, a data handle is used to create objects for writing meshes. When the user tries to export all again, the previous handle is not cleaned up and this results in a memory leak. The fix is to destruct the handle after use so that the memory does not increase after repetition.