### PR TITLE
MAYA-127808 update edit target when saving an anonymous layer

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -176,7 +176,8 @@ void convertAnonymousLayersRecursive(
             convertAnonymousLayersRecursive(subL, basename, stage);
 
             if (subL->IsAnonymous()) {
-                auto newLayer = MayaUsd::utils::saveAnonymousLayer(subL, parentPtr, basename);
+                auto newLayer
+                    = MayaUsd::utils::saveAnonymousLayer(stage, subL, parentPtr, basename);
                 if (subL == currentTarget) {
                     stage->SetEditTarget(newLayer);
                 }

--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -52,10 +52,11 @@ public:
 };
 
 void populateChildren(
-    SdfLayerRefPtr                                                       layer,
-    RecursionDetector*                                                   recursionDetector,
-    std::vector<std::pair<SdfLayerRefPtr, MayaUsd::utils::LayerParent>>& anonLayersToSave,
-    std::vector<SdfLayerRefPtr>&                                         dirtyLayersToSave)
+    const UsdStageRefPtr&        stage,
+    SdfLayerRefPtr               layer,
+    RecursionDetector*           recursionDetector,
+    MayaUsd::utils::LayerInfos&  anonLayersToSave,
+    std::vector<SdfLayerRefPtr>& dirtyLayersToSave)
 {
     auto subPaths = layer->GetSubLayerPaths();
 
@@ -69,13 +70,16 @@ void populateChildren(
         std::string actualPath = PXR_NS::SdfComputeAssetPathRelativeToLayer(layer, path);
         auto        subLayer = PXR_NS::SdfLayer::FindOrOpen(actualPath);
         if (subLayer && !recursionDetector->contains(subLayer->GetRealPath())) {
-            populateChildren(subLayer, recursionDetector, anonLayersToSave, dirtyLayersToSave);
+            populateChildren(
+                stage, subLayer, recursionDetector, anonLayersToSave, dirtyLayersToSave);
 
             if (subLayer->IsAnonymous()) {
-                MayaUsd::utils::LayerParent p;
-                p._proxyPath.clear();
-                p._layerParent = layer;
-                anonLayersToSave.push_back(std::make_pair(subLayer, p));
+                MayaUsd::utils::LayerInfo info;
+                info.stage = stage;
+                info.layer = subLayer;
+                info.parent._proxyPath.clear();
+                info.parent._layerParent = layer;
+                anonLayersToSave.push_back(info);
             } else if (subLayer->IsDirty()) {
                 dirtyLayersToSave.push_back(subLayer);
             }
@@ -269,16 +273,18 @@ bool saveLayerWithFormat(
 }
 
 SdfLayerRefPtr saveAnonymousLayer(
+    UsdStageRefPtr     stage,
     SdfLayerRefPtr     anonLayer,
     LayerParent        parent,
     const std::string& basename,
     std::string        formatArg)
 {
     std::string newFileName = generateUniqueFileName(basename);
-    return saveAnonymousLayer(anonLayer, newFileName, false, parent, formatArg);
+    return saveAnonymousLayer(stage, anonLayer, newFileName, false, parent, formatArg);
 }
 
 SdfLayerRefPtr saveAnonymousLayer(
+    UsdStageRefPtr     stage,
     SdfLayerRefPtr     anonLayer,
     const std::string& path,
     bool               savePathAsRelative,
@@ -292,6 +298,8 @@ SdfLayerRefPtr saveAnonymousLayer(
     std::string filePath(path);
     ensureUSDFileExtension(filePath);
 
+    const bool wasTargetLayer = (stage->GetEditTarget().GetLayer() == anonLayer);
+
     saveLayerWithFormat(anonLayer, filePath, formatArg);
 
     SdfLayerRefPtr newLayer = SdfLayer::FindOrOpen(filePath);
@@ -303,6 +311,10 @@ SdfLayerRefPtr saveAnonymousLayer(
             saveRootLayer(newLayer, parent._proxyPath, savePathAsRelative);
         }
     }
+
+    if (wasTargetLayer)
+        stage->SetEditTarget(newLayer);
+
     return newLayer;
 }
 
@@ -318,7 +330,7 @@ void ensureUSDFileExtension(std::string& filePath)
     }
 }
 
-void getLayersToSaveFromProxy(const std::string& proxyPath, stageLayersToSave& layersInfo)
+void getLayersToSaveFromProxy(const std::string& proxyPath, StageLayersToSave& layersInfo)
 {
     auto stage = UsdMayaUtil::GetStageByProxyName(proxyPath);
     if (!stage) {
@@ -326,18 +338,22 @@ void getLayersToSaveFromProxy(const std::string& proxyPath, stageLayersToSave& l
     }
 
     auto root = stage->GetRootLayer();
-    populateChildren(root, nullptr, layersInfo._anonLayers, layersInfo._dirtyFileBackedLayers);
+    populateChildren(
+        stage, root, nullptr, layersInfo._anonLayers, layersInfo._dirtyFileBackedLayers);
     if (root->IsAnonymous()) {
-        LayerParent p;
-        p._proxyPath = proxyPath;
-        p._layerParent = nullptr;
-        layersInfo._anonLayers.push_back(std::make_pair(root, p));
+        LayerInfo info;
+        info.stage = stage;
+        info.layer = root;
+        info.parent._proxyPath = proxyPath;
+        info.parent._layerParent = nullptr;
+        layersInfo._anonLayers.push_back(info);
     } else if (root->IsDirty()) {
         layersInfo._dirtyFileBackedLayers.push_back(root);
     }
 
     auto session = stage->GetSessionLayer();
-    populateChildren(session, nullptr, layersInfo._anonLayers, layersInfo._dirtyFileBackedLayers);
+    populateChildren(
+        stage, session, nullptr, layersInfo._anonLayers, layersInfo._dirtyFileBackedLayers);
 }
 
 } // namespace utils

--- a/lib/mayaUsd/utils/utilSerialization.h
+++ b/lib/mayaUsd/utils/utilSerialization.h
@@ -76,10 +76,19 @@ struct LayerParent
     std::string    _proxyPath;
 };
 
-struct stageLayersToSave
+struct LayerInfo
 {
-    std::vector<std::pair<SdfLayerRefPtr, LayerParent>> _anonLayers;
-    std::vector<SdfLayerRefPtr>                         _dirtyFileBackedLayers;
+    UsdStageRefPtr              stage;
+    SdfLayerRefPtr              layer;
+    MayaUsd::utils::LayerParent parent;
+};
+
+using LayerInfos = std::vector<LayerInfo>;
+
+struct StageLayersToSave
+{
+    LayerInfos                  _anonLayers;
+    std::vector<SdfLayerRefPtr> _dirtyFileBackedLayers;
 };
 
 /*! \brief Save an layer to disk to the given file path and using the given format.
@@ -98,6 +107,7 @@ bool saveLayerWithFormat(
  */
 MAYAUSD_CORE_PUBLIC
 PXR_NS::SdfLayerRefPtr saveAnonymousLayer(
+    PXR_NS::UsdStageRefPtr stage,
     PXR_NS::SdfLayerRefPtr anonLayer,
     LayerParent            parent,
     const std::string&     basename,
@@ -108,6 +118,7 @@ PXR_NS::SdfLayerRefPtr saveAnonymousLayer(
  */
 MAYAUSD_CORE_PUBLIC
 PXR_NS::SdfLayerRefPtr saveAnonymousLayer(
+    PXR_NS::UsdStageRefPtr stage,
     PXR_NS::SdfLayerRefPtr anonLayer,
     const std::string&     path,
     bool                   savePathAsRelative,
@@ -123,7 +134,7 @@ void ensureUSDFileExtension(std::string& filePath);
     layers that will need to be saved.
  */
 MAYAUSD_CORE_PUBLIC
-void getLayersToSaveFromProxy(const std::string& proxyPath, stageLayersToSave& layersInfo);
+void getLayersToSaveFromProxy(const std::string& proxyPath, StageLayersToSave& layersInfo);
 
 } // namespace utils
 } // namespace MAYAUSD_NS_DEF

--- a/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.cpp
+++ b/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.cpp
@@ -48,10 +48,10 @@ UsdLayerEditor::batchSaveLayersUIDelegate(const std::vector<MayaUsd::StageSaving
             // so the user can choose where to save the anonymous layers.
             if (!showConfirmDgl) {
                 for (const auto& info : infos) {
-                    MayaUsd::utils::stageLayersToSave stageLayersToSave;
+                    MayaUsd::utils::StageLayersToSave StageLayersToSave;
                     MayaUsd::utils::getLayersToSaveFromProxy(
-                        info.dagPath.fullPathName().asChar(), stageLayersToSave);
-                    if (!stageLayersToSave._anonLayers.empty()) {
+                        info.dagPath.fullPathName().asChar(), StageLayersToSave);
+                    if (!StageLayersToSave._anonLayers.empty()) {
                         showConfirmDgl = true;
                         break;
                     }

--- a/lib/usd/ui/layerEditor/layerTreeModel.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeModel.cpp
@@ -453,10 +453,10 @@ void LayerTreeModel::saveStage(QWidget* in_parent)
     // so the user can choose where to save the anonymous layers.
     if (!showConfirmDgl) {
         // Get the layers to save for this stage.
-        MayaUsd::utils::stageLayersToSave stageLayersToSave;
+        MayaUsd::utils::StageLayersToSave StageLayersToSave;
         auto&                             stageEntry = _sessionState->stageEntry();
-        MayaUsd::utils::getLayersToSaveFromProxy(stageEntry._proxyShapePath, stageLayersToSave);
-        showConfirmDgl = !stageLayersToSave._anonLayers.empty();
+        MayaUsd::utils::getLayersToSaveFromProxy(stageEntry._proxyShapePath, StageLayersToSave);
+        showConfirmDgl = !StageLayersToSave._anonLayers.empty();
     }
 
     if (showConfirmDgl) {

--- a/lib/usd/ui/layerEditor/saveLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.cpp
@@ -98,9 +98,10 @@ class SaveLayersDialog;
 class SaveLayerPathRow : public QWidget
 {
 public:
-    SaveLayerPathRow(
-        SaveLayersDialog*                                             in_parent,
-        const std::pair<SdfLayerRefPtr, MayaUsd::utils::LayerParent>& in_layerPair);
+    using LayerInfo = MayaUsd::utils::LayerInfo;
+    using LayerInfos = MayaUsd::utils::LayerInfos;
+
+    SaveLayerPathRow(SaveLayersDialog* in_parent, const LayerInfo& in_layerInfo);
 
     QString layerDisplayName() const;
 
@@ -113,20 +114,18 @@ protected:
     void onTextChanged(const QString& text);
 
 public:
-    QString                                                _pathToSaveAs;
-    SaveLayersDialog*                                      _parent { nullptr };
-    std::pair<SdfLayerRefPtr, MayaUsd::utils::LayerParent> _layerPair;
-    QLabel*                                                _label { nullptr };
-    QLineEdit*                                             _pathEdit { nullptr };
-    QAbstractButton*                                       _openBrowser { nullptr };
+    QString           _pathToSaveAs;
+    SaveLayersDialog* _parent { nullptr };
+    LayerInfo         _layerInfo;
+    QLabel*           _label { nullptr };
+    QLineEdit*        _pathEdit { nullptr };
+    QAbstractButton*  _openBrowser { nullptr };
 };
 
-SaveLayerPathRow::SaveLayerPathRow(
-    SaveLayersDialog*                                             in_parent,
-    const std::pair<SdfLayerRefPtr, MayaUsd::utils::LayerParent>& in_layerPair)
+SaveLayerPathRow::SaveLayerPathRow(SaveLayersDialog* in_parent, const LayerInfo& in_layerInfo)
     : QWidget(in_parent)
     , _parent(in_parent)
-    , _layerPair(in_layerPair)
+    , _layerInfo(in_layerInfo)
 {
     auto gridLayout = new QGridLayout();
     QtUtils::initLayoutMargins(gridLayout);
@@ -134,14 +133,14 @@ SaveLayerPathRow::SaveLayerPathRow(
     // Since this is an anonymous layer, it should only be associated with a single stage.
     std::string stageName;
     const auto& stageLayers = in_parent->stageLayers();
-    if (TF_VERIFY(1 == stageLayers.count(_layerPair.first))) {
-        auto search = stageLayers.find(_layerPair.first);
+    if (TF_VERIFY(1 == stageLayers.count(_layerInfo.layer))) {
+        auto search = stageLayers.find(_layerInfo.layer);
         stageName = search->second;
     }
 
-    QString displayName = _layerPair.first->GetDisplayName().c_str();
+    QString displayName = _layerInfo.layer->GetDisplayName().c_str();
     _label = new QLabel(displayName);
-    _label->setToolTip(in_parent->buildTooltipForLayer(_layerPair.first));
+    _label->setToolTip(in_parent->buildTooltipForLayer(_layerInfo.layer));
     gridLayout->addWidget(_label, 0, 0);
 
     _pathToSaveAs = MayaUsd::utils::generateUniqueFileName(stageName).c_str();
@@ -245,12 +244,14 @@ SaveLayersDialog::SaveLayersDialog(
     for (const auto& info : infos) {
 
         getLayersToSave(
-            info.dagPath.fullPathName().asChar(), info.dagPath.partialPathName().asChar());
+            info.stage,
+            info.dagPath.fullPathName().asChar(),
+            info.dagPath.partialPathName().asChar());
     }
 
     QString msg1, msg2;
     getDialogMessages(
-        static_cast<int>(infos.size()), static_cast<int>(_anonLayerPairs.size()), msg1, msg2);
+        static_cast<int>(infos.size()), static_cast<int>(_anonLayerInfos.size()), msg1, msg2);
     buildDialog(msg1, msg2);
 }
 #endif
@@ -266,28 +267,31 @@ SaveLayersDialog::SaveLayersDialog(SessionState* in_sessionState, QWidget* in_pa
         std::string stageName = stageEntry._displayName;
         msg.format(StringResources::getAsMString(StringResources::kSaveName), stageName.c_str());
         dialogTitle = MQtUtil::toQString(msg);
-        getLayersToSave(stageEntry._proxyShapePath, stageName);
+        getLayersToSave(stageEntry._stage, stageEntry._proxyShapePath, stageName);
     }
     setWindowTitle(dialogTitle);
 
     QString msg1, msg2;
-    getDialogMessages(1, static_cast<int>(_anonLayerPairs.size()), msg1, msg2);
+    getDialogMessages(1, static_cast<int>(_anonLayerInfos.size()), msg1, msg2);
     buildDialog(msg1, msg2);
 }
 
 SaveLayersDialog ::~SaveLayersDialog() { QApplication::restoreOverrideCursor(); }
 
-void SaveLayersDialog::getLayersToSave(const std::string& proxyPath, const std::string& stageName)
+void SaveLayersDialog::getLayersToSave(
+    const PXR_NS::UsdStageRefPtr& stage,
+    const std::string&            proxyPath,
+    const std::string&            stageName)
 {
     // Get the layers to save for this stage.
-    MayaUsd::utils::stageLayersToSave stageLayersToSave;
-    MayaUsd::utils::getLayersToSaveFromProxy(proxyPath, stageLayersToSave);
+    MayaUsd::utils::StageLayersToSave StageLayersToSave;
+    MayaUsd::utils::getLayersToSaveFromProxy(proxyPath, StageLayersToSave);
 
     // Keep track of all the layers for this particular stage.
-    for (const auto& layerPairs : stageLayersToSave._anonLayers) {
-        _stageLayerMap.emplace(std::make_pair(layerPairs.first, stageName));
+    for (const auto& layerInfo : StageLayersToSave._anonLayers) {
+        _stageLayerMap.emplace(std::make_pair(layerInfo.layer, stageName));
     }
-    for (const auto& dirtyLayer : stageLayersToSave._dirtyFileBackedLayers) {
+    for (const auto& dirtyLayer : StageLayersToSave._dirtyFileBackedLayers) {
         _stageLayerMap.emplace(std::make_pair(dirtyLayer, stageName));
     }
 
@@ -295,10 +299,10 @@ void SaveLayersDialog::getLayersToSave(const std::string& proxyPath, const std::
     // Note: we use a set for the dirty file back layers because they
     //       can come from multiple stages, but we only want them to
     //       appear once in the dialog.
-    moveAppendVector(stageLayersToSave._anonLayers, _anonLayerPairs);
+    moveAppendVector(StageLayersToSave._anonLayers, _anonLayerInfos);
     _dirtyFileBackedLayers.insert(
-        std::begin(stageLayersToSave._dirtyFileBackedLayers),
-        std::end(stageLayersToSave._dirtyFileBackedLayers));
+        std::begin(StageLayersToSave._dirtyFileBackedLayers),
+        std::end(StageLayersToSave._dirtyFileBackedLayers));
 }
 
 void SaveLayersDialog::buildDialog(const QString& msg1, const QString& msg2)
@@ -319,7 +323,7 @@ void SaveLayersDialog::buildDialog(const QString& msg1, const QString& msg2)
     buttonsLayout->addWidget(okButton);
     buttonsLayout->addWidget(cancelButton);
 
-    const bool            haveAnonLayers { !_anonLayerPairs.empty() };
+    const bool            haveAnonLayers { !_anonLayerInfos.empty() };
     const bool            haveFileBackedLayers { !_dirtyFileBackedLayers.empty() };
     SaveLayerPathRowArea* anonScrollArea { nullptr };
     SaveLayerPathRowArea* fileScrollArea { nullptr };
@@ -331,7 +335,7 @@ void SaveLayersDialog::buildDialog(const QString& msg1, const QString& msg2)
         anonLayout->setContentsMargins(margin, margin, margin, 0);
         anonLayout->setSpacing(DPIScale(8));
         anonLayout->setAlignment(Qt::AlignTop);
-        for (auto iter = _anonLayerPairs.cbegin(); iter != _anonLayerPairs.cend(); ++iter) {
+        for (auto iter = _anonLayerInfos.cbegin(); iter != _anonLayerInfos.cend(); ++iter) {
             auto row = new SaveLayerPathRow(this, (*iter));
             anonLayout->addWidget(row);
         }
@@ -467,13 +471,14 @@ void SaveLayersDialog::onSaveAll()
         QLayout* anonLayout = _anonLayersWidget->layout();
         for (i = 0, count = anonLayout->count(); i < count; ++i) {
             auto row = dynamic_cast<SaveLayerPathRow*>(anonLayout->itemAt(i)->widget());
-            if (!row || !row->_layerPair.first)
+            if (!row || !row->_layerInfo.layer)
                 continue;
 
             QString path = row->pathToSaveAs();
             if (!path.isEmpty()) {
-                auto sdfLayer = row->_layerPair.first;
-                auto parent = row->_layerPair.second;
+                auto sdfLayer = row->_layerInfo.layer;
+                auto parent = row->_layerInfo.parent;
+                auto stage = row->_layerInfo.stage;
                 auto qFileName = row->pathToSaveAs();
 
                 // If the qFileName is a relative path, compute the absolute path from the scene
@@ -488,7 +493,7 @@ void SaveLayersDialog::onSaveAll()
                 auto sFileName = qFileName.toStdString();
 
                 auto newLayer = MayaUsd::utils::saveAnonymousLayer(
-                    sdfLayer, sFileName, savePathAsRelative, parent);
+                    stage, sdfLayer, sFileName, savePathAsRelative, parent);
                 if (newLayer) {
                     _newPaths.append(QString::fromStdString(sdfLayer->GetDisplayName()));
                     _newPaths.append(qFileName);

--- a/lib/usd/ui/layerEditor/saveLayersDialog.h
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.h
@@ -60,18 +60,21 @@ public:
 
 private:
     void buildDialog(const QString& msg1, const QString& msg2);
-    void getLayersToSave(const std::string& proxyPath, const std::string& stageName);
+    void getLayersToSave(
+        const UsdStageRefPtr& stage,
+        const std::string&    proxyPath,
+        const std::string&    stageName);
 
 private:
-    typedef std::vector<std::pair<SdfLayerRefPtr, MayaUsd::utils::LayerParent>> layerPairs;
-    typedef std::unordered_set<SdfLayerRefPtr, TfHash>                          layerSet;
+    typedef std::unordered_set<SdfLayerRefPtr, TfHash> layerSet;
+    using LayerInfos = MayaUsd::utils::LayerInfos;
 
     QStringList   _newPaths;
     QStringList   _problemLayers;
     QStringList   _emptyLayers;
     QWidget*      _anonLayersWidget { nullptr };
     QWidget*      _fileLayersWidget { nullptr };
-    layerPairs    _anonLayerPairs;
+    LayerInfos    _anonLayerInfos;
     layerSet      _dirtyFileBackedLayers;
     stageLayerMap _stageLayerMap;
     SessionState* _sessionState;


### PR DESCRIPTION
- Record from which stage the saved layer are from.
- Update the edit target to the new layer of the stage if the old layer was the edit target.
- Adjust save dialog callers to track and pass the necessary info.