### PR TITLE
MAYA-106352 keep hierarchy window on top of import window

### DIFF
--- a/lib/usd/ui/importDialog/USDImportDialogCmd.cpp
+++ b/lib/usd/ui/importDialog/USDImportDialogCmd.cpp
@@ -219,8 +219,7 @@ MStatus USDImportDialogCmd::doIt(const MArgList& args)
             QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
 
             QWidget*      parentWindow = MQtUtil::mainWindow();
-            const MString parentWindowName
-                = parseTextArg(argData, kParentWindowFlag, "");
+            const MString parentWindowName = parseTextArg(argData, kParentWindowFlag, "");
             if (parentWindowName.length() > 0) {
                 QWidget* potentialParent = MQtUtil::findWindow(parentWindowName);
                 if (potentialParent) {

--- a/lib/usd/ui/importDialog/USDImportDialogCmd.cpp
+++ b/lib/usd/ui/importDialog/USDImportDialogCmd.cpp
@@ -65,7 +65,7 @@ constexpr auto kSwitchedVariantCountFlagLong = "-switchedVariantCount";
 constexpr auto kParentWindowFlag = "-pw";
 constexpr auto kParentWindowFlagLong = "-parentWindow";
 
-MString parseTextArg(const MArgDatabase& argData, const char* flag, const MString& defaultValue)
+MString parseTextArg(const MArgParser& argData, const char* flag, const MString& defaultValue)
 {
     MString value = defaultValue;
     if (argData.isFlagSet(flag))
@@ -220,7 +220,7 @@ MStatus USDImportDialogCmd::doIt(const MArgList& args)
 
             QWidget*      parentWindow = MQtUtil::mainWindow();
             const MString parentWindowName
-                = parseTextArg(MArgDatabase(syntax(), args), kParentWindowFlag, "");
+                = parseTextArg(argData, kParentWindowFlag, "");
             if (parentWindowName.length() > 0) {
                 QWidget* potentialParent = MQtUtil::findWindow(parentWindowName);
                 if (potentialParent) {

--- a/lib/usd/ui/importDialog/USDImportDialogCmd.cpp
+++ b/lib/usd/ui/importDialog/USDImportDialogCmd.cpp
@@ -219,7 +219,8 @@ MStatus USDImportDialogCmd::doIt(const MArgList& args)
             QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
 
             QWidget*      parentWindow = MQtUtil::mainWindow();
-            const MString parentWindowName = parseTextArg(MArgDatabase(syntax(), args), kParentWindowFlag, "");
+            const MString parentWindowName
+                = parseTextArg(MArgDatabase(syntax(), args), kParentWindowFlag, "");
             if (parentWindowName.length() > 0) {
                 QWidget* potentialParent = MQtUtil::findWindow(parentWindowName);
                 if (potentialParent) {

--- a/lib/usd/ui/importDialog/USDImportDialogCmd.cpp
+++ b/lib/usd/ui/importDialog/USDImportDialogCmd.cpp
@@ -23,6 +23,7 @@
 #include <maya/MFileObject.h>
 #include <maya/MFnDependencyNode.h>
 #include <maya/MFnStringData.h>
+#include <maya/MGlobal.h>
 #include <maya/MQtUtil.h>
 #include <maya/MSelectionList.h>
 #include <maya/MStatus.h>
@@ -60,6 +61,17 @@ constexpr auto kPrimCountFlag = "-pc";
 constexpr auto kPrimCountFlagLong = "-primCount";
 constexpr auto kSwitchedVariantCountFlag = "-swc";
 constexpr auto kSwitchedVariantCountFlagLong = "-switchedVariantCount";
+
+constexpr auto kParentWindowFlag = "-pw";
+constexpr auto kParentWindowFlagLong = "-parentWindow";
+
+MString parseTextArg(const MArgDatabase& argData, const char* flag, const MString& defaultValue)
+{
+    MString value = defaultValue;
+    if (argData.isFlagSet(flag))
+        argData.getFlagArgument(flag, 0, value);
+    return value;
+}
 
 } // namespace
 
@@ -206,8 +218,23 @@ MStatus USDImportDialogCmd::doIt(const MArgList& args)
             // toggle the wait cursor to show that it's working.
             QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
 
-            std::unique_ptr<USDImportDialog> usdImportDialog(new USDImportDialog(
-                assetPath.asChar(), &importData, usdQtUtil, MQtUtil::mainWindow()));
+            QWidget*      parentWindow = MQtUtil::mainWindow();
+            const MString parentWindowName = parseTextArg(MArgDatabase(syntax(), args), kParentWindowFlag, "");
+            if (parentWindowName.length() > 0) {
+                QWidget* potentialParent = MQtUtil::findWindow(parentWindowName);
+                if (potentialParent) {
+                    parentWindow = potentialParent;
+                } else {
+                    MString warning;
+                    warning.format(
+                        "Could not find parent window named ^1s, using Maya main window instead.",
+                        parentWindowName);
+                    MGlobal::displayWarning(warning);
+                }
+            }
+
+            std::unique_ptr<USDImportDialog> usdImportDialog(
+                new USDImportDialog(assetPath.asChar(), &importData, usdQtUtil, parentWindow));
 
             QApplication::restoreOverrideCursor();
 
@@ -244,6 +271,7 @@ MSyntax USDImportDialogCmd::createSyntax()
     syntax.addFlag(kApplyToProxyFlag, kApplyToProxyFlagLong);
     syntax.addFlag(kPrimCountFlag, kPrimCountFlagLong);
     syntax.addFlag(kSwitchedVariantCountFlag, kSwitchedVariantCountFlagLong);
+    syntax.addFlag(kParentWindowFlag, kParentWindowFlagLong, MSyntax::kString);
 
     syntax.setObjectType(MSyntax::kStringObjects, 0, 1);
     return syntax;

--- a/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
@@ -453,19 +453,8 @@ global proc string mayaUsdTranslatorImport_AppendFromDialog(string $currentOptio
 
 global proc mayaUsdTranslatorImport_ViewHierCB(string $parent)
 {
-    string $parentWindow = "";
-    {
-        string $result[];
-        string $windows = `window -parent $parent`;
-        tokenize $windows "|" $result;
-        if (size($result) > 0)
-        {
-            $parentWindow = $result[0];
-        }
-    }
-
     string $usdFile = currentFileDialogSelection(); 
-    string $result = `usdImportDialog -parentWindow $parentWindow $usdFile`;
+    string $result = `usdImportDialog -parentWindow $parent $usdFile`;
     if ("" != $result)
     {
         mayaUsdTranslatorImport_showInfo();

--- a/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
@@ -196,7 +196,7 @@ global proc int mayaUsdTranslatorImport (string $parent,
                     -ann `getMayaUsdString("kImportScopeVariantsAnn")`
                 ;
                 textField -ed false -nbg true -text `getMayaUsdString("kImportSelectFileTxt")` -w $cw2 mayaUsdTranslator_SelectFileField;
-                button -label `getMayaUsdString("kImportHierarchyViewLbl")` -c "mayaUsdTranslatorImport_ViewHierCB" mayaUsdTranslator_ViewHierBtn;
+                button -label `getMayaUsdString("kImportHierarchyViewLbl")` -c ("mayaUsdTranslatorImport_ViewHierCB\"" + $parent + "\"") mayaUsdTranslator_ViewHierBtn;
                 iconTextButton -w 32 -h 32 -command ("mayaUsdTranslatorImport_ClearImportData;") 
                     -style "iconAndTextVertical" -image1 "refresh.png" -label "" mayaUsdTranslator_ResetBtn;
 
@@ -451,10 +451,21 @@ global proc string mayaUsdTranslatorImport_AppendFromDialog(string $currentOptio
     return $currentOptions;
 }
 
-global proc mayaUsdTranslatorImport_ViewHierCB()
+global proc mayaUsdTranslatorImport_ViewHierCB(string $parent)
 {
+    string $parentWindow = "";
+    {
+        string $result[];
+        string $windows = `window -parent $parent`;
+        tokenize $windows "|" $result;
+        if (size($result) > 0)
+        {
+            $parentWindow = $result[0];
+        }
+    }
+
     string $usdFile = currentFileDialogSelection(); 
-    string $result = `usdImportDialog $usdFile`;
+    string $result = `usdImportDialog -parentWindow $parentWindow $usdFile`;
     if ("" != $result)
     {
         mayaUsdTranslatorImport_showInfo();


### PR DESCRIPTION
- Add a flag to the UsdImportDialog command to specify the parent window name.
- Use that flag when invoking the command from the import panel.
- Use the flag in the command to find the parent window.