### PR TITLE
MAYA-124737 improve duplicate command

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
@@ -119,7 +119,7 @@ void UsdUndoDuplicateCommand::execute()
             result,
             "Failed to copy the USD prim at '%s' in layer '%s' to '%s'",
             path.GetText(),
-            layer->GetDisplayName(),
+            layer->GetDisplayName().c_str(),
             _usdDstPath.GetText());
 
         isFirst = false;

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
@@ -23,6 +23,7 @@
 #include <mayaUsd/utils/loadRules.h>
 #ifdef UFE_V2_FEATURES_AVAILABLE
 #include <mayaUsd/undo/UsdUndoBlock.h>
+#include <mayaUsdUtils/MergePrims.h>
 #endif
 #include <mayaUsdUtils/util.h>
 
@@ -36,6 +37,8 @@
 #include <ufe/path.h>
 #include <ufe/scene.h>
 #include <ufe/sceneNotification.h>
+
+#include <algorithm>
 
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
@@ -51,12 +54,10 @@ UsdUndoDuplicateCommand::UsdUndoDuplicateCommand(const UsdSceneItem::Ptr& srcIte
     auto srcPrim = srcItem->prim();
     auto parentPrim = srcPrim.GetParent();
 
-    ufe::applyCommandRestriction(srcPrim, "duplicate");
-
     auto newName = uniqueChildName(parentPrim, srcPrim.GetName());
     _usdDstPath = parentPrim.GetPath().AppendChild(TfToken(newName));
 
-    _srcLayer = srcPrim.GetStage()->GetEditTarget().GetLayer();
+    _srcLayer = MayaUsdUtils::getDefiningLayerAndPath(srcPrim).layer;
     _dstLayer = getEditRouterLayer(PXR_NS::TfToken("duplicate"), srcPrim);
 }
 
@@ -92,12 +93,37 @@ void UsdUndoDuplicateCommand::execute()
     // state.
     duplicateLoadRules(*stage, path, _usdDstPath);
 
-    bool retVal = PXR_NS::SdfCopySpec(_srcLayer, path, _dstLayer, _usdDstPath);
-    TF_VERIFY(
-        retVal,
-        "Failed to copy spec data at '%s' to '%s'",
-        prim.GetPath().GetText(),
-        _usdDstPath.GetText());
+    // Make sure all necessary parent exists in the target layer, at least as over,
+    // otherwise SdfCopySepc will fail.
+    SdfJustCreatePrimInLayer(_dstLayer, _usdDstPath.GetParentPath());
+
+    // Retrieve the layers where there are opinion and order them from weak
+    // to strong. We will copy the weakest opinions first, so that they will
+    // get over-written by the stronger opinions.
+    using namespace MayaUsdUtils;
+    std::vector<LayerAndPath> authLayerAndPaths = getAuthoredLayerAndPaths(prim);
+    std::reverse(authLayerAndPaths.begin(), authLayerAndPaths.end());
+
+    MergePrimsOptions options;
+    options.verbosity = MergeVerbosity::None;
+    bool isFirst = true;
+
+    for (const LayerAndPath& layerAndPath : authLayerAndPaths) {
+        const auto layer = layerAndPath.layer;
+        const auto path = layerAndPath.path;
+        const bool result = isFirst
+            ? SdfCopySpec(layer, path, _dstLayer, _usdDstPath)
+            : mergePrims(stage, layer, path, stage, _dstLayer, _usdDstPath, options);
+
+        TF_VERIFY(
+            result,
+            "Failed to copy the USD prim at '%s' in layer '%s' to '%s'",
+            path.GetText(),
+            layer->GetDisplayName(),
+            _usdDstPath.GetText());
+
+        isFirst = false;
+    }
 
     extras.finalize(MayaUsd::ufe::stagePath(stage), &path, &_usdDstPath);
 }
@@ -140,6 +166,7 @@ bool UsdUndoDuplicateCommand::duplicateUndo()
 bool UsdUndoDuplicateCommand::duplicateRedo()
 {
     auto prim = ufePathToPrim(_ufeSrcPath);
+    SdfJustCreatePrimInLayer(_dstLayer, _usdDstPath.GetParentPath());
     return SdfCopySpec(_srcLayer, prim.GetPath(), _dstLayer, _usdDstPath);
 }
 

--- a/lib/usd/utils/util.h
+++ b/lib/usd/utils/util.h
@@ -28,6 +28,32 @@ namespace MayaUsdUtils {
 MAYA_USD_UTILS_PUBLIC
 SdfLayerHandle defPrimSpecLayer(const UsdPrim& prim);
 
+//! Hold a layer a path relative to that layer.
+struct LayerAndPath
+{
+    SdfLayerHandle layer;
+    SdfPath        path;
+
+    LayerAndPath() = default;
+    LayerAndPath(const LayerAndPath&) = default;
+    LayerAndPath(const SdfLayerHandle& a_layer, const SdfPath& a_path)
+        : layer(a_layer)
+        , path(a_path)
+    {
+    }
+};
+
+//! Return all layers where the prim has opinions and the paths relative to that layer.
+//  The strongest layer is the first in the list.
+//  When the prim is in a reference, that path will not be equal to the path of the input prim.
+MAYA_USD_UTILS_PUBLIC
+std::vector<LayerAndPath> getAuthoredLayerAndPaths(const UsdPrim& prim);
+
+//! Return the layer where the prim is defined and the path relative to that layer.
+//  When the prim is in a reference, that path will not be equal to the path of the input prim.
+MAYA_USD_UTILS_PUBLIC
+LayerAndPath getDefiningLayerAndPath(const UsdPrim& prim);
+
 //! Return a PrimSpec for the argument prim in the layer containing the stage's current edit target.
 MAYA_USD_UTILS_PUBLIC
 SdfPrimSpecHandle getPrimSpecAtEditTarget(const UsdPrim& prim);

--- a/test/testSamples/cubeRef/cube-root.usda
+++ b/test/testSamples/cubeRef/cube-root.usda
@@ -1,0 +1,14 @@
+#usda 1.0
+(
+    defaultPrim = "RootPrim"
+    upAxis = "Z"
+)
+
+def Xform "RootPrim"
+{
+    def Xform "PrimWithRef" (
+        prepend references = @cube.usda@
+    )
+    {
+    }
+}

--- a/test/testSamples/cubeRef/cube.usda
+++ b/test/testSamples/cubeRef/cube.usda
@@ -1,0 +1,24 @@
+#usda 1.0
+(
+    defaultPrim = "CubePrim"
+    upAxis = "Z"
+)
+
+def Xform "CubePrim"
+{
+    def Mesh "CubeMesh" (
+        kind = "component"
+    )
+    {
+        uniform bool doubleSided = 1
+        float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+        int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+        int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+        point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5)]
+        color3f[] primvars:displayColor = [(0.13320851, 0.13320851, 0.13320851)]
+        int[] primvars:st:indices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 9, 8, 1, 10, 11, 3, 12, 0, 2, 13]
+
+        double3 xformOp:translate = (2, 0, -2)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+}


### PR DESCRIPTION
The concept of layer from within the USD API is confusing relative to the high-level concept of layers. When talking about layers at a high-level, what is meant are the root and session layers and their sub-layers. OTOH, in the API, the layers are also used for references.  A reference is kept in a layer object (SdfLayer), but is not part of the stage layer stack!

In the case of duplication, we use SdfCopySpec to do the heavy lifting, and that takes a source path and source layer. But these are low-level layers, not high-level layers. in particular, if the source prim is in a reference, we must use the reference layer as the layer and the path must be relative to reference, not the stage root!

So, change the duplicate code to handle references correctly.

- Add a helper function to retrieve the defining layer and path of a prim.
- The defining path may not be the prim path if the prim is in a reference.
- In that case, the path is relative to the reference target, in the referenced layer.
- Also, refactor the defPrimSpecLayer function to make each check alone and separate to clarify and help when debugging.
- Remove the restriction on duplicate: a new prim is about to be created, it does not care about the structure of the source prim, so it should not be restricted.
- Use the new helper to find the correct source layer and path.
- Make sure to create missing parent 'overs'.
- Make the error message clearer by making it about USD prim, not low-level prim spec that the user might not know about.
- Make duplicate work with multi-layers prims by iterating over all layers with opinions and merge all opinions into the destination.
- Add helper function to retrieve all layer and path that have opinions.
- Add a unit test for the duplication multi-layers prim.
- Add a unit test for the duplication of a prim in a reference.