### PR TITLE
MAYA-124922 use Load/Unload for payload

### DIFF
--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -344,8 +344,8 @@ protected:
         // what the current policy is.
         UsdStageLoadRules loadRules = _stage->GetLoadRules();
         _policy = loadRules.GetEffectiveRuleForPath(_primPath) == UsdStageLoadRules::Rule::AllRule
-                ? UsdLoadPolicy::UsdLoadWithDescendants
-                : UsdLoadPolicy::UsdLoadWithoutDescendants;
+            ? UsdLoadPolicy::UsdLoadWithDescendants
+            : UsdLoadPolicy::UsdLoadWithoutDescendants;
     }
 
     void doLoad() const


### PR DESCRIPTION
Unfortunately, USD stage's SetLoadRules function does not optimize the change notifications it sends out. Its Load and Unload functions do optimize the notifications they send out. Normally, this is an implementation details inside USD that we should not have to rely on. Pragmatically though, using the functions which send out the most narrow notification is better. So even though calling SetLoadRules is simpler and more precise, it is less efficient.