### PR TITLE
MAYA-127737 allow loading relative sub layers

### DIFF
--- a/lib/usd/ui/layerEditor/loadLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/loadLayersDialog.cpp
@@ -43,12 +43,6 @@
 namespace {
 using namespace UsdLayerEditor;
 
-bool isAbsolutePath(const std::string& in_path)
-{
-    QFileInfo fileInfo(QString::fromStdString(in_path));
-    return fileInfo.isAbsolute();
-}
-
 class MyLineEdit : public QLineEdit
 {
 public:

--- a/lib/usd/ui/layerEditor/loadLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/loadLayersDialog.cpp
@@ -301,6 +301,7 @@ void LoadLayersDialog::onOpenBrowser()
     if (files.size() == 0)
         return;
 
+    // Replace selected filenames with relative ones if enabled.
     if (requireUsdPathsRelativeToParentLayer()) {
         for (std::string& fileName : files) {
             fileName = getPathRelativeToLayerFile(fileName, parentLayer);

--- a/lib/usd/ui/layerEditor/loadLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/loadLayersDialog.cpp
@@ -24,6 +24,8 @@
 #include "qtUtils.h"
 #include "stringResources.h"
 
+#include <mayaUsd/utils/utilFileSystem.h>
+
 #include <maya/MQtUtil.h>
 
 #include <QtCore/QDir>
@@ -72,14 +74,12 @@ LayerPathRow::LayerPathRow(LoadLayersDialog* in_parent)
 {
     auto gridLayout = new QGridLayout();
     QtUtils::initLayoutMargins(gridLayout);
-    _absolutePath = "";
     _parentPath = _parent->findDirectoryToUse("");
 
     _label = new QLabel(StringResources::getAsQString(StringResources::kLayerPath));
     gridLayout->addWidget(_label, 0, 0);
 
     _pathEdit = new MyLineEdit(this);
-    connect(_pathEdit, &QLineEdit::textChanged, this, &LayerPathRow::onTextChanged);
     gridLayout->addWidget(_pathEdit, 0, 1);
 
     QIcon icon;
@@ -102,56 +102,17 @@ LayerPathRow::LayerPathRow(LoadLayersDialog* in_parent)
     connect(_addPathIcon, &QAbstractButton::clicked, in_parent, &LoadLayersDialog::onAddRow);
     gridLayout->addWidget(_addPathIcon, 0, 3);
 
-    _convertToRel
-        = new QCheckBox(StringResources::getAsQString(StringResources::kConvertToRelativePath));
-    connect(_convertToRel, &QAbstractButton::clicked, this, &LayerPathRow::onRelativeButtonChecked);
-    _convertToRel->setEnabled(false);
-    gridLayout->addWidget(_convertToRel, 1, 1);
-
     setLayout(gridLayout);
 
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Maximum);
 }
 
-void LayerPathRow::onTextChanged(const QString& text)
+std::string LayerPathRow::pathToUse() const { return _pathEdit->text().toStdString(); }
+
+void LayerPathRow::setPathToUse(const std::string& path)
 {
-    if (!_convertToRel->isChecked()) {
-        _absolutePath = text.toStdString();
-        _convertToRel->setEnabled(isAbsolutePath(_absolutePath));
-    }
-}
-
-void LayerPathRow::onRelativeButtonChecked(bool checked)
-{
-    if (checked) {
-        QDir dir(_parentPath.c_str());
-
-        QString relativePath = dir.relativeFilePath(_absolutePath.c_str());
-        _pathEdit->setText(relativePath);
-        _pathEdit->setEnabled(false);
-    } else {
-        _pathEdit->setEnabled(true);
-        _pathEdit->setText(_absolutePath.c_str());
-    }
-}
-
-std::string LayerPathRow::pathToUse() const
-{
-    if (_convertToRel->isChecked())
-        return _pathEdit->text().toStdString();
-    else
-        return _absolutePath;
-}
-
-void LayerPathRow::setAbsolutePath(const std::string& path)
-{
-
-    _absolutePath = path;
     _pathEdit->setText(path.c_str());
     _pathEdit->setEnabled(true);
-
-    _convertToRel->setChecked(false);
-    _convertToRel->setEnabled(isAbsolutePath(_absolutePath));
 }
 
 void LayerPathRow::setAsRowInserter(bool setIt)
@@ -160,7 +121,6 @@ void LayerPathRow::setAsRowInserter(bool setIt)
     _label->setEnabled(enabled);
     _pathEdit->setEnabled(enabled);
     _openBrowser->setEnabled(enabled);
-    _convertToRel->setEnabled(enabled);
 
     _trashIcon->setVisible(!setIt);
     _addPathIcon->setVisible(setIt);
@@ -334,14 +294,26 @@ std::string LoadLayersDialog::findDirectoryToUse(const std::string& rowText) con
 
 void LoadLayersDialog::onOpenBrowser()
 {
-    auto row = dynamic_cast<LayerPathRow*>(sender()->parent());
-    auto defaultPath = findDirectoryToUse(row->absolutePath());
+    using namespace PXR_NS::UsdMayaUtilFileSystem;
+
+    const bool useSceneFileForRoot = false;
+    const auto parentLayer = _treeItem->layer();
+    prepareLayerSaveUILayer(parentLayer, useSceneFileForRoot);
+
+    LayerPathRow*     row = dynamic_cast<LayerPathRow*>(sender()->parent());
+    const std::string defaultPath = findDirectoryToUse(row->pathToUse());
 
     auto files = _treeItem->parentModel()->sessionState()->loadLayersUI(windowTitle(), defaultPath);
     if (files.size() == 0)
         return;
 
-    row->setAbsolutePath(files[0]);
+    if (requireUsdPathsRelativeToParentLayer()) {
+        for (std::string& fileName : files) {
+            fileName = getPathRelativeToLayerFile(fileName, parentLayer);
+        }
+    }
+
+    row->setPathToUse(files[0]);
 
     // insert new rows if more than one file selected
     if (files.size() > 1) {
@@ -361,7 +333,7 @@ void LoadLayersDialog::onOpenBrowser()
         for (size_t i = 1; i < files.size(); i++) {
             auto newRow = new LayerPathRow(this);
             _rowsLayout->insertWidget(index, newRow);
-            newRow->setAbsolutePath(files[i]);
+            newRow->setPathToUse(files[i]);
             ++index;
         }
 

--- a/lib/usd/ui/layerEditor/loadLayersDialog.h
+++ b/lib/usd/ui/layerEditor/loadLayersDialog.h
@@ -80,17 +80,10 @@ public:
 
     // returns the path to store, either the rel or abs path
     std::string pathToUse() const;
-    // returns the absolute path, always
-    std::string absolutePath() const { return _absolutePath; }
     // sets the absolute path
-    void setAbsolutePath(const std::string& path);
+    void setPathToUse(const std::string& path);
 
 protected:
-    void onTextChanged(const QString& text);
-    void onRelativeButtonChecked(bool checked);
-
-protected:
-    std::string       _absolutePath;
     std::string       _parentPath;
     LoadLayersDialog* _parent;
     QLabel*           _label;
@@ -98,7 +91,6 @@ protected:
     QAbstractButton*  _openBrowser;
     QAbstractButton*  _trashIcon;
     QAbstractButton*  _addPathIcon;
-    QCheckBox*        _convertToRel;
 };
 
 }; // namespace UsdLayerEditor

--- a/plugin/adsk/scripts/mayaUsd_layerEditorFileDialogs.mel
+++ b/plugin/adsk/scripts/mayaUsd_layerEditorFileDialogs.mel
@@ -90,8 +90,10 @@ global proc string UsdLayerEditor_SaveLayerFileDialog(int $isRootLayer)
     }
 }
 
-global proc string UsdLayerEditor_LoadLayersFileDialogOptions_Create(string $parent)
+global proc UsdLayerEditor_LoadLayersFileDialogOptions_UICreate(string $parent)
 {
+    // First create the scroll layout here and then call the python
+    // helper to add the rest of the UI.
     setParent $parent;
 
     string $layout = `scrollLayout -childResizable true`;
@@ -99,7 +101,19 @@ global proc string UsdLayerEditor_LoadLayersFileDialogOptions_Create(string $par
     frameLayout -collapsable false -labelVisible false -marginHeight 20 -marginWidth 20;
 
     text -label `getMayaUsdString("kTipYouCanChooseMultipleFiles")` -align "left";
-    return $layout;
+
+    string $layout = `scrollLayout -childResizable true`;
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdSubLayerFileRelative.uiCreate('" + $layout + "')");
+}
+
+global proc UsdLayerEditor_LoadLayersFileDialogOptions_UIInit(string $parent, string $filterType)
+{
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdSubLayerFileRelative.uiInit('" + $parent + "', '" + $filterType + "')");
+}
+
+global proc UsdLayerEditor_LoadLayersFileDialogOptions_UICommit(string $parent, string $selectedFile)
+{
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdSubLayerFileRelative.uiCommit('" + $parent + "', '" + $selectedFile + "')");
 }
 
 global proc string[] UsdLayerEditor_LoadLayersFileDialog(string $title, string $folder)
@@ -112,7 +126,9 @@ global proc string[] UsdLayerEditor_LoadLayersFileDialog(string $title, string $
             -fileMode 4
             -okCaption $okCaption
             -fileFilter $fileFilter
-            -optionsUICreate "UsdLayerEditor_LoadLayersFileDialogOptions_Create"
+            -optionsUICreate "UsdLayerEditor_LoadLayersFileDialogOptions_UICreate"
+            -optionsUIInit "UsdLayerEditor_LoadLayersFileDialogOptions_UIInit"
+            -optionsUICommit2 "UsdLayerEditor_LoadLayersFileDialogOptions_UICommit"
             -startingDirectory $folder
             `;
 


### PR DESCRIPTION
- Add UI to load-layer file dialog to make the file path relative, in MEL.
- Modify the overall load-layer dialog to support relative sub-layers.