### PR TITLE
MAYA-127370 - Preview of my relative path (resolved and unresolved)

### DIFF
--- a/lib/mayaUsd/python/wrapUtil.cpp
+++ b/lib/mayaUsd/python/wrapUtil.cpp
@@ -16,6 +16,7 @@
 #include <mayaUsd/fileio/jobs/jobArgs.h>
 #include <mayaUsd/utils/util.h>
 #include <mayaUsd/utils/utilFileSystem.h>
+#include <mayaUsd/utils/utilSerialization.h>
 
 #include <pxr/base/tf/pyResultConversions.h>
 #include <pxr/pxr.h>
@@ -44,6 +45,13 @@ VtDictionary getDictionaryFromEncodedOptions(const std::string& textOptions)
     return dictOptions;
 }
 
+std::string ensureUSDFileExtension(const std::string& fileToCheck)
+{
+    std::string ret(fileToCheck);
+    MayaUsd::utils::ensureUSDFileExtension(ret);
+    return ret;
+}
+
 } // namespace
 
 void wrapUtil()
@@ -56,5 +64,6 @@ void wrapUtil()
                   .def(
                       "getPathRelativeToMayaSceneFile",
                       UsdMayaUtilFileSystem::getPathRelativeToMayaSceneFile)
+                  .def("ensureUSDFileExtension", ensureUSDFileExtension)
                   .staticmethod("getPathRelativeToMayaSceneFile");
 }

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.py
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.py
@@ -39,3 +39,7 @@ def mayaUSDRegisterStrings():
     register("kMakePathRelativeToSceneFileAnn", "If enabled, path will be relative to your Maya scene file.\nIf this option is disabled, there is no Maya scene file and the path will be absolute.\nSave your Maya scene file to disk to make this option available.")
     register("kMakePathRelativeToEditTargetLayer", "Make Path Relative to Edit Target Layer Directory")
     register("kMakePathRelativeToEditTargetLayerAnn", "Enable to activate relative pathing to your current edit target layer’s directory.\nIf this option is disabled, verify that your target layer is not anonymous and save it to disk.")
+    register("kUnresolvedPath", "Unresolved Path:")
+    register("kUnresolvedPathAnn", "This field indicates the path with the file name currently chosen in your text input. Note: This is the string that will be written out to the file in the chosen directory in order to enable portability.")
+    register("kResolvedPath", "Resolved Path:")
+    register("kResolvedPathAnn", "This field indicates the resolved path of your chosen working directory for your USD file. Note: The resolved path for the file can vary for each individual as the file is handed off.")

--- a/plugin/adsk/scripts/mayaUsd_USDRootFileRelative.py
+++ b/plugin/adsk/scripts/mayaUsd_USDRootFileRelative.py
@@ -1,7 +1,21 @@
 import maya.cmds as cmds
 import maya.mel as mel
+import maya.OpenMayaUI as omui
+import mayaUsd.lib as mayaUsdLib
 from mayaUSDRegisterStrings import getMayaUsdString
 from mayaUsdMayaReferenceUtils import pushOptionsUITemplate
+
+try:
+    from PySide2.QtCore import QObject, QFileInfo
+    from PySide2.QtWidgets import QFileDialog, QLayout, QWidget, QLineEdit, QDialogButtonBox, QComboBox
+    from shiboken2 import wrapInstance
+except:
+    from PySide6.QtCore import QObject, QFileInfo
+    from PySide6.QtWidgets import QFileDialog, QLayout, QWidget, QLineEdit, QDialogButtonBox, QComboBox
+    from shiboken6 import wrapInstance
+
+# Global variables
+_relativeToFilePath = None
 
 class usdFileRelative(object):
     '''
@@ -18,26 +32,38 @@ class usdFileRelative(object):
         UI tool-tip:      kMakePathRelativeToSceneFileAnn
         option var:   mayaUsd_MakePathRelativeToSceneFile
     '''
+    # We will find (and store) some of the dialog controls so we can query them.
+    # Note: are initialized when calling the uiInit() method.
+    _fileDialog = None
+    _acceptButton = None
 
     kMakePathRelativeCheckBox = 'MakePathRelativeTo'
+    kUnresolvedPathTextField = 'UnresolvedPath'
+    kResolvedPathTextField = 'ResolvedPath'
 
-    _relativeToFilePath = None
+    # We will store whether or not the file can be made relative. Used to know when we need
+    # to update fields.
+    # Note: are initialized in the uiInit() method.
+    _canBeRelative = False
+    _haveRelativePathFields = False
 
-    @classmethod
-    def setRelativeFilePathRoot(cls, filePath):
+    @staticmethod
+    def setRelativeFilePathRoot(filePath):
         '''
         Sets to which file the relative file will be anchored.
         Set to empty or None to have the file be absolute, not relative.
         '''
-        cls._relativeToFilePath = filePath
+        global _relativeToFilePath
+        _relativeToFilePath = filePath
 
-    @classmethod
-    def getRelativeFilePathRoot(cls):
+    @staticmethod
+    def getRelativeFilePathRoot():
         '''
         Gets to which file the relative file will be anchored.
         Empty or None to have the file be absolute, not relative.
         '''
-        return cls._relativeToFilePath
+        global _relativeToFilePath
+        return _relativeToFilePath
 
     @classmethod
     def uiCreate(cls, parentLayout, relativeToWhat):
@@ -67,12 +93,21 @@ class usdFileRelative(object):
         kFileOptionsStr = getMayaUsdString("kFileOptions")
         kMakePathRelativeStr = getMayaUsdString("kMakePathRelativeTo" + relativeToWhat)
         kMakePathRelativeAnnStr = getMayaUsdString("kMakePathRelativeTo" + relativeToWhat + "Ann")
+        kUnresolvedPathStr = getMayaUsdString("kUnresolvedPath")
+        kUnresolvedPathAnnStr = getMayaUsdString("kUnresolvedPathAnn")
+        kResolvedPathStr = getMayaUsdString("kResolvedPath")
+        kResolvedPathAnnStr = getMayaUsdString("kResolvedPathAnn")
  
         optBoxMarginWidth = mel.eval('global int $gOptionBoxTemplateDescriptionMarginWidth; $gOptionBoxTemplateDescriptionMarginWidth += 0')
         cmds.setParent(topForm)
         cmds.frameLayout(label=kFileOptionsStr, collapsable=False)
         widgetColumn = cmds.columnLayout()
-        cmds.checkBox(cls.kMakePathRelativeCheckBox + relativeToWhat, label=kMakePathRelativeStr, ann=kMakePathRelativeAnnStr)
+        cmds.checkBox(cls.kMakePathRelativeCheckBox, label=kMakePathRelativeStr, ann=kMakePathRelativeAnnStr)
+        if relativeToWhat == 'SceneFile':
+            cmds.checkBox(cls.kMakePathRelativeCheckBox, edit=True, changeCommand=cls.onMakePathRelativeChanged)
+            cmds.textFieldGrp(cls.kUnresolvedPathTextField, label=kUnresolvedPathStr, ann=kUnresolvedPathAnnStr, editable=False)
+            cmds.textFieldGrp(cls.kResolvedPathTextField, label=kResolvedPathStr, ann=kResolvedPathAnnStr , editable=False)
+            cls._haveRelativePathFields = True
 
     @classmethod
     def uiInit(cls, parentLayout, canBeRelative, relativeToWhat):
@@ -89,13 +124,29 @@ class usdFileRelative(object):
         """
         cmds.setParent(parentLayout)
 
+        # Initialize the class variables.
+        cls._fileDialog = None
+        cls._acceptButton = None
+        cls._canBeRelative = canBeRelative
+        cls._haveRelativePathFields = cmds.textFieldGrp(cls.kUnresolvedPathTextField, exists=True)
+
         # Get the current checkbox value from optionVar (if any) and update checkbox.
         if cmds.optionVar(exists='mayaUsd_MakePathRelativeTo' + relativeToWhat):
             relative = cmds.optionVar(query='mayaUsd_MakePathRelativeTo' + relativeToWhat)
-            cmds.checkBox(cls.kMakePathRelativeCheckBox + relativeToWhat, edit=True, value=relative)
+            cmds.checkBox(cls.kMakePathRelativeCheckBox, edit=True, value=relative)
 
         # If if cannot be relative, then the checkbox and label should be disabled.
-        cmds.checkBox(cls.kMakePathRelativeCheckBox + relativeToWhat, edit=True, enable=canBeRelative)
+        cmds.checkBox(cls.kMakePathRelativeCheckBox, edit=True, enable=cls._canBeRelative)
+
+        # We only need to connect to the dialog box controls when we can be relative because
+        # that is when the file path preview fields are enabled.
+        if cls._canBeRelative:
+            cls.connectToDialogControls(parentLayout)
+
+        if cls._haveRelativePathFields:
+            # Only enable fields when make relative is checked.
+            makePathRelative = cmds.checkBox(cls.kMakePathRelativeCheckBox, query=True, value=True)
+            cls.onMakePathRelativeChanged(makePathRelative)
 
     @classmethod
     def uiCommit(cls, parentLayout, relativeToWhat):
@@ -110,9 +161,100 @@ class usdFileRelative(object):
         cmds.setParent(parentLayout)
 
         # Get the current checkbox state and save to optionVar.
-        relative = cmds.checkBox(cls.kMakePathRelativeCheckBox + relativeToWhat, query=True, value=True)
+        relative = cmds.checkBox(cls.kMakePathRelativeCheckBox, query=True, value=True)
         cmds.optionVar(iv=('mayaUsd_MakePathRelativeTo' + relativeToWhat, relative))
 
+    @classmethod
+    def connectToDialogControls(cls, parentLayout):
+        """
+        Find some of the conrols (such as file name edit field) in the dialog
+        (under the input parent layout) and connect to them for change notifs.
+        Used so we can update the file path preview fields.
+        """
+
+        # Get the Qt pointer for the input parent string (layout from mel).
+        ptr = omui.MQtUtil.findLayout(parentLayout)
+        if ptr is not None:
+            # Find the top-level window from that parent layout.
+            maya_widget = wrapInstance(int(ptr), QWidget)
+            pp = maya_widget.parent()
+            while pp:
+                if pp.inherits('QFileDialog'):
+                    cls._fileDialog = pp
+                pp = pp.parent()
+                if pp:
+                    maya_window = pp
+
+        if maya_window:
+            # Find the file name edit field and connect to it to be notified when text changes.
+            fileNameEditField = maya_window.findChild(QLineEdit, 'fileNameEdit')
+            if fileNameEditField:
+                fileNameEditField.textChanged.connect(cls.onfileNameEditFieldChanged)
+
+            # Find the accept button, so we can know when there is valid input in the file name edit field.
+            buttonBox = maya_window.findChild(QDialogButtonBox, 'buttonBox')
+            if buttonBox and cls._fileDialog:
+                btn = QDialogButtonBox.Open if (cls._fileDialog.acceptMode() == QFileDialog.AcceptOpen) else QDialogButtonBox.Save
+                cls._acceptButton = buttonBox.button(btn)
+
+            # Find the lookin combobox and connect to it so we know when user changes directories.
+            lookinComboBox = maya_window.findChild(QComboBox, 'lookInCombo')
+            if lookinComboBox:
+                lookinComboBox.currentTextChanged.connect(cls.onLookinTextChanged)
+
+    @classmethod
+    def onMakePathRelativeChanged(cls, checked):
+        """Callback from MakePathRelativeCheckBox changeCommand."""
+        if not cls._haveRelativePathFields:
+            return
+        enableFields = cls._canBeRelative and checked
+        cmds.textFieldGrp(cls.kUnresolvedPathTextField, edit=True, enable=enableFields, text='')
+        cmds.textFieldGrp(cls.kResolvedPathTextField, edit=True, enable=enableFields, text='')
+        if enableFields:
+            cls.updateFilePathPreviewFields(checked)
+
+    @classmethod
+    def onfileNameEditFieldChanged(cls, text):
+        """Callback from Qt textChanged event from fileNameEditField."""
+        cls.updateFilePathPreviewFields()
+
+    @classmethod
+    def onLookinTextChanged(cls, text):
+        """Callback from Qt currentTextChanged from LookIn combobox."""
+        cls.updateFilePathPreviewFields()
+
+    @classmethod
+    def updateFilePathPreviewFields(cls, makePathRelative=None):
+        if not cls._haveRelativePathFields:
+            return
+        if makePathRelative == None:
+            makePathRelative = cmds.checkBox(cls.kMakePathRelativeCheckBox, query=True, value=True)
+
+        if cls._canBeRelative and makePathRelative:
+            # If the accept button is disabled it means there is no valid input in the file
+            # name edit field.
+            selFiles = cls._fileDialog.selectedFiles() if cls._fileDialog and cls._acceptButton and cls._acceptButton.isEnabled() else None
+            selectedFile = selFiles[0] if selFiles else ''
+
+            # Make sure the file path has a valid USD extension. This is NOT done by the fileDialog so
+            # the user is free to enter any extension they want. The layer editor code will then verify
+            # (and fix if needed) the file path before saving. We do the same here for preview.
+            unresolvedPath = mayaUsdLib.Util.ensureUSDFileExtension(selectedFile) if selectedFile else ''
+            relativePath = mayaUsdLib.Util.getPathRelativeToMayaSceneFile(unresolvedPath) if unresolvedPath else ''
+            cmds.textFieldGrp(cls.kUnresolvedPathTextField, edit=True, text=relativePath)
+            cmds.textFieldGrp(cls.kResolvedPathTextField, edit=True, text=unresolvedPath)
+
+    @classmethod
+    def selectionChanged(cls, parentLayout, selection):
+        """Callback from fileDialog selectionChanged."""
+        cmds.setParent(parentLayout)
+        cls.updateFilePathPreviewFields()
+
+    @classmethod
+    def fileTypeChanged(cls, parentLayout, newType):
+        """Callback from fileDialog command fileTypeChanged."""
+        cmds.setParent(parentLayout)
+        cls.updateFilePathPreviewFields()
 
 class usdRootFileRelative(usdFileRelative):
     '''
@@ -124,7 +266,7 @@ class usdRootFileRelative(usdFileRelative):
 
     @classmethod
     def uiCreate(cls, parentLayout):
-        usdFileRelative.uiCreate(parentLayout, cls.kRelativeToWhat)
+        super(usdRootFileRelative, cls).uiCreate(parentLayout, cls.kRelativeToWhat)
 
     @classmethod
     def uiInit(cls, parentLayout, filterType):
@@ -134,8 +276,8 @@ class usdRootFileRelative(usdFileRelative):
         '''
         # If there is no Maya scene file saved, then the checkbox and label should be disabled.
         haveSceneFile = cmds.file(q=True, exists=True)
-        usdFileRelative.setRelativeFilePathRoot(cmds.file(query=True, sceneName=True))
-        usdFileRelative.uiInit(parentLayout, haveSceneFile, cls.kRelativeToWhat)
+        cls.setRelativeFilePathRoot(cmds.file(query=True, sceneName=True))
+        super(usdRootFileRelative, cls).uiInit(parentLayout, haveSceneFile, cls.kRelativeToWhat)
 
     @classmethod
     def uiCommit(cls, parentLayout, selectedFile=None):
@@ -143,7 +285,7 @@ class usdRootFileRelative(usdFileRelative):
         Note: the function takes an unused selectedFile argument to be compatible
               with the dialog2 command API.
         '''
-        usdFileRelative.uiCommit(parentLayout, cls.kRelativeToWhat)
+        super(usdRootFileRelative, cls).uiCommit(parentLayout, cls.kRelativeToWhat)
 
 
 class usdFileRelativeToEditTargetLayer(usdFileRelative):
@@ -156,7 +298,7 @@ class usdFileRelativeToEditTargetLayer(usdFileRelative):
 
     @classmethod
     def uiCreate(cls, parentLayout):
-        usdFileRelative.uiCreate(parentLayout, cls.kRelativeToWhat)
+        super(usdFileRelativeToEditTargetLayer, cls).uiCreate(parentLayout, cls.kRelativeToWhat)
 
     @classmethod
     def uiInit(cls, parentLayout, filterType):
@@ -166,7 +308,7 @@ class usdFileRelativeToEditTargetLayer(usdFileRelative):
         '''
         # If there is no target layer saved, then the checkbox and label should be disabled.
         canBeRelative = bool(usdFileRelative.getRelativeFilePathRoot())
-        usdFileRelative.uiInit(parentLayout, canBeRelative, cls.kRelativeToWhat)
+        super(usdFileRelativeToEditTargetLayer, cls).uiInit(parentLayout, canBeRelative, cls.kRelativeToWhat)
 
     @classmethod
     def uiCommit(cls, parentLayout, selectedFile=None):
@@ -174,4 +316,4 @@ class usdFileRelativeToEditTargetLayer(usdFileRelative):
         Note: the function takes an unused selectedFile argument to be compatible
               with the dialog2 command API.
         '''
-        usdFileRelative.uiCommit(parentLayout, cls.kRelativeToWhat)
+        super(usdFileRelativeToEditTargetLayer, cls).uiCommit(parentLayout, cls.kRelativeToWhat)

--- a/plugin/adsk/scripts/mayaUsd_layerEditorFileDialogs.mel
+++ b/plugin/adsk/scripts/mayaUsd_layerEditorFileDialogs.mel
@@ -32,6 +32,16 @@ global proc mayaUsd_USDRootFileRelative_UICommit(string $parent, string $selecte
     python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdRootFileRelative.uiCommit('" + $parent + "', '" + $selectedFile + "')");
 }
 
+global proc mayaUsd_USDRootFileRelative_SelectionChanged(string $parent, string $selection)
+{
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdRootFileRelative.selectionChanged('" + $parent + "', '" + $selection + "')");
+}
+
+global proc mayaUsd_USDRootFileRelative_FileTypeChanged(string $parent, string $newType)
+{
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdRootFileRelative.fileTypeChanged('" + $parent + "', '" + $newType + "')");
+}
+
 global proc string UsdLayerEditor_SaveLayerFileDialog()
 {
     string $fileFilter = python("from mayaUsdUtils import getUSDDialogFileFilters; getUSDDialogFileFilters(False)");
@@ -48,6 +58,8 @@ global proc string UsdLayerEditor_SaveLayerFileDialog()
         -optionsUICreate "mayaUsd_USDRootFileRelative_UICreate"
         -optionsUIInit "mayaUsd_USDRootFileRelative_UIInit"
         -optionsUICommit2 "mayaUsd_USDRootFileRelative_UICommit"
+        -fileTypeChanged "mayaUsd_USDRootFileRelative_FileTypeChanged"
+        -selectionChanged "mayaUsd_USDRootFileRelative_SelectionChanged"
         -startingDirectory $startDir
     `;
 


### PR DESCRIPTION
#### MAYA-127370 - Preview of my relative path (resolved and unresolved)
* Added two path preview fields with logic to update them on any change to path/file from save/load dialog where the relative path is used.
* Added python wrapper for util ensureUSDFileExtension()