### PR TITLE
MAYA-127959 avoid crash when world node has an unexpected name

### DIFF
--- a/lib/mayaUsd/ufe/ProxyShapeCameraHandler.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeCameraHandler.cpp
@@ -57,7 +57,7 @@ Ufe::Camera::Ptr ProxyShapeCameraHandler::camera(const Ufe::SceneItem::Ptr& item
 Ufe::Selection ProxyShapeCameraHandler::find_(const Ufe::Path& path) const
 {
     Ufe::SceneItem::Ptr item = Ufe::Hierarchy::createItem(path);
-    if (isAGatewayType(item->nodeType())) {
+    if (item && isAGatewayType(item->nodeType())) {
         // path is a path to a proxyShape node.
         // Get the UsdStage for this proxy shape node and search it for cameras
         PXR_NS::UsdStageWeakPtr stage = getStage(path);


### PR DESCRIPTION
Verify that the UFE item has been successfully created before using it.