### PR TITLE
MAYA-128001 - clearMetadata doesn't work for UsdShadeNodeGraph attribute.

### DIFF
--- a/lib/mayaUsd/ufe/UsdAttributeHolder.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributeHolder.cpp
@@ -425,11 +425,20 @@ bool UsdAttributeHolder::clearMetadata(const std::string& key)
 {
     PXR_NAMESPACE_USING_DIRECTIVE
     if (isValid()) {
+        PXR_NS::TfToken tok(key);
+        // Special cases for NodeGraphs:
+        if (PXR_NS::UsdShadeNodeGraph(usdPrim())) {
+            if (PXR_NS::UsdShadeInput::IsInput(_usdAttr)) {
+                PXR_NS::UsdShadeInput(_usdAttr).ClearSdrMetadataByKey(tok);
+            } else if (PXR_NS::UsdShadeOutput::IsOutput(_usdAttr)) {
+                PXR_NS::UsdShadeOutput(_usdAttr).ClearSdrMetadataByKey(tok);
+            }
+            return !hasMetadata(key);
+        }
         // Special cases for known Ufe metadata keys.
         if (key == Ufe::Attribute::kLocked) {
             return _usdAttr.ClearMetadata(MayaUsdMetadata->Lock);
         }
-        PXR_NS::TfToken tok(key);
         return _usdAttr.ClearMetadata(tok);
     } else {
         return true;

--- a/test/lib/ufe/testAttributes.py
+++ b/test/lib/ufe/testAttributes.py
@@ -479,5 +479,29 @@ class AttributesTestCase(unittest.TestCase):
             '|stage|stageShape,/pCube2/Looks/standardSurface2SG')
         self.assertEqual(dstAttr.name, 'outputs:out')
 
+    @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 3, 'clearMetadata is only available in UFE v3 or greater.')
+    def testClearNodeGraphAttributeMetadata(self):
+        '''Test cleaning a node graph attribute metadata'''
+
+        # Load a scene.
+      
+        testFile = testUtils.getTestScene('MaterialX', 'MayaSurfaces.usda')
+        shapeNode,shapeStage = mayaUtils.createProxyFromFile(testFile)
+        ufeItem = ufeUtils.createUfeSceneItem(shapeNode,
+            '/pCube2/Looks/standardSurface2SG/MayaNG_standardSurface2SG')
+        self.assertIsNotNone(ufeItem)
+
+        # Then create the attributes interface for that item.
+        attrs = ufe.Attributes.attributes(ufeItem)
+        self.assertIsNotNone(attrs)
+        attr = attrs.attribute('inputs:file2:varnameStr')
+        self.assertIsNotNone(attr)
+
+        # Set a metadata for the attribute.
+        self.assertTrue(attr.setMetadata('TestMetadata', 'test value'))
+
+        # Clear the metadata for the attribute.
+        self.assertTrue(attr.clearMetadata('TestMetadata'))
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
# Description

This PR fixes [Jira MAYA-128001](https://jira.autodesk.com/browse/MAYA-128001):  If we try to clear a Compound attribute, we get the error: "Cannot clear metadata. 'metadataName' is not registered as valid metadata for spec type SdfSpecTypeAttribute." and the attribute metadata is not cleaned. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
