### PR TITLE
Add a getter for usdimaging delegate in proxy adapter

### DIFF
--- a/lib/usd/hdMaya/adapters/proxyAdapter.h
+++ b/lib/usd/hdMaya/adapters/proxyAdapter.h
@@ -90,6 +90,7 @@ public:
     }
 
     const SdfPath& GetUsdDelegateID() const { return _usdDelegate->GetDelegateID(); }
+    HdMayaProxyUsdImagingDelegate* GetUsdImagingDelegate() { return _usdDelegate.get(); }
 
 private:
     /// Notice listener method for proxy stage set


### PR DESCRIPTION
Hello !
Could we add a getter for usd imaging delegate in proxy adapter?

We are making production render feature in our plugin with our hydra render delegate (RadeonProRender hdRPR) and we try reuse as much code as possible from MtoH.
Thank you!