### PR TITLE
Update the title of Duplicate As Usd Data Option Dialog to match. Also refactored various files that used duplicate as Maya data while the business logic within them meant to perform duplicate as Usd data.

### DIFF
--- a/lib/mayaUsd/resources/scripts/CMakeLists.txt
+++ b/lib/mayaUsd/resources/scripts/CMakeLists.txt
@@ -6,8 +6,8 @@ list(APPEND scripts_src
     mayaUsdAddUSDReference.mel
     mayaUsdCacheMayaReference.mel
     mayaUsdCacheMayaReference.py
-    mayaUsdDuplicateAsMayaDataOptions.mel
-    mayaUsdDuplicateAsMayaDataOptions.py
+    mayaUsdDuplicateAsUsdDataOptions.mel
+    mayaUsdDuplicateAsUsdDataOptions.py
     mayaUsdMergeToUSDOptions.mel
     mayaUsdMergeToUSDOptions.py
     mayaUsdMergeToUsd.py

--- a/lib/mayaUsd/resources/scripts/mayaUsdDuplicateAsUsdDataOptions.mel
+++ b/lib/mayaUsd/resources/scripts/mayaUsdDuplicateAsUsdDataOptions.mel
@@ -18,9 +18,9 @@
 //
 // All the following MEL proceduces serves to redirect to Python.
 
-global proc receiveDuplicateAsMayaDataOptionsTextFromDialog(string $exportOptions)
+global proc receiveDuplicateAsUsdDataOptionsTextFromDialog(string $exportOptions)
 {
     // Note: use raw triple-quoted string in case there are backslash in file paths on Windows.
-    python("import mayaUsdDuplicateAsMayaDataOptions; mayaUsdDuplicateAsMayaDataOptions.setDuplicateAsMayaDataOptionsText(r'''" + $exportOptions + "''')");
+    python("import mayaUsdDuplicateAsUsdDataOptions; mayaUsdDuplicateAsUsdDataOptions.setDuplicateAsUsdDataOptionsText(r'''" + $exportOptions + "''')");
 }
 

--- a/lib/mayaUsd/resources/scripts/mayaUsdDuplicateAsUsdDataOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdDuplicateAsUsdDataOptions.py
@@ -24,14 +24,14 @@ import mayaUsdOptions
 from functools import partial
 
 
-_kDuplicateAsMayaDataOptionsHelpContentId = 'UsdEditDuplicateAsMaya'
+_kDuplicateAsUsdDataOptionsHelpContentId = 'UsdEditDuplicateAsMaya'
 
-def showDuplicateAsMayaDataOptions():
+def showDuplicateAsUsdDataOptions():
     """
-    Shows the duplicate-as-Maya-data options dialog.
+    Shows the duplicate-as-Usd-data options dialog.
     """
 
-    windowName = "DuplicateAsMayaDataOptionsDialog"
+    windowName = "DuplicateAsUsdDataOptionsDialog"
     if cmds.window(windowName, query=True, exists=True):
         if cmds.window(windowName, query=True, visible=True):
             return
@@ -39,13 +39,13 @@ def showDuplicateAsMayaDataOptions():
         # Delete the window and recreate it.
         cmds.deleteUI(windowName)
 
-    window = cmds.window(windowName, title=getMayaUsdLibString("kDuplicateAsMayaDataOptionsTitle"), widthHeight=mayaUsdOptions.defaultOptionBoxSize())
-    _createDuplicateAsMayaDataOptionsDialog(window)
+    window = cmds.window(windowName, title=getMayaUsdLibString("kDuplicateAsUsdDataOptionsTitle"), widthHeight=mayaUsdOptions.defaultOptionBoxSize())
+    _createDuplicateAsUsdDataOptionsDialog(window)
 
 
-def _createDuplicateAsMayaDataOptionsDialog(window):
+def _createDuplicateAsUsdDataOptionsDialog(window):
     """
-    Creates the duplicate-as-Maya-data dialog.
+    Creates the duplicate-as-Usd-data dialog.
     """
 
     windowLayout = cmds.setParent(query=True)
@@ -55,34 +55,34 @@ def _createDuplicateAsMayaDataOptionsDialog(window):
     windowFormLayout = cmds.formLayout(parent=windowLayout)
 
     subFormLayout = cmds.formLayout(parent=windowFormLayout)
-    subScrollLayout = cmds.scrollLayout('DuplicateAsMayaDataOptionsDialogSubScrollLayout', cr=True, bv=True)
+    subScrollLayout = cmds.scrollLayout('DuplicateAsUsdDataOptionsDialogSubScrollLayout', cr=True, bv=True)
     cmds.formLayout(subFormLayout, edit=True,
         attachForm=[
             (subScrollLayout,       "top",      0),
             (subScrollLayout,       "bottom",   0),
             (subScrollLayout,       "left",     0),
             (subScrollLayout,       "right",    0)]);
-    subLayout = cmds.columnLayout("DuplicateAsMayaDataOptionsDialogSubLayout", adjustableColumn=True)
+    subLayout = cmds.columnLayout("DuplicateAsUsdDataOptionsDialogSubLayout", adjustableColumn=True)
 
-    optionsText = getDuplicateAsMayaDataOptionsText()
-    _fillDuplicateAsMayaDataOptionsDialog(subLayout, optionsText, "post")
+    optionsText = getDuplicateAsUsdDataOptionsText()
+    _fillDuplicateAsUsdDataOptionsDialog(subLayout, optionsText, "post")
 
     menu = cmds.menu(label=getMayaUsdLibString("kEditMenu"), parent=menuBarLayout)
-    cmds.menuItem(label=getMayaUsdLibString("kSaveSettingsMenuItem"), command=_saveDuplicateAsMayaDataOptions)
-    cmds.menuItem(label=getMayaUsdLibString("kResetSettingsMenuItem"), command=partial(_resetDuplicateAsMayaDataOptions, subLayout))
+    cmds.menuItem(label=getMayaUsdLibString("kSaveSettingsMenuItem"), command=_saveDuplicateAsUsdDataOptions)
+    cmds.menuItem(label=getMayaUsdLibString("kResetSettingsMenuItem"), command=partial(_resetDuplicateAsUsdDataOptions, subLayout))
 
     cmds.setParent(menuBarLayout)
-    if _hasDuplicateAsMayaDataOptionsHelp():
+    if _hasDuplicateAsUsdDataOptionsHelp():
         menu = cmds.menu(label=getMayaUsdLibString("kHelpMenu"), parent=menuBarLayout)
-        cmds.menuItem(label=getMayaUsdLibString("kHelpDuplicateAsMayaDataOptionsMenuItem"), command=_helpDuplicateAsMayaDataOptions)
+        cmds.menuItem(label=getMayaUsdLibString("kHelpDuplicateAsUsdDataOptionsMenuItem"), command=_helpDuplicateAsUsdDataOptions)
 
     buttonsLayout = cmds.formLayout(parent=windowFormLayout)
 
     applyText  = getMayaUsdLibString("kApplyButton")
     closeText = getMayaUsdLibString("kCloseButton")
     # Use same height for buttons as in Maya option boxes.
-    bApply     = cmds.button(label=applyText, width=100, height=26, command=_saveDuplicateAsMayaDataOptions)
-    bClose     = cmds.button(label=closeText, width=100, height=26, command=partial(_closeDuplicateAsMayaDataOptionsDialog, window))
+    bApply     = cmds.button(label=applyText, width=100, height=26, command=_saveDuplicateAsUsdDataOptions)
+    bClose     = cmds.button(label=closeText, width=100, height=26, command=partial(_closeDuplicateAsUsdDataOptionsDialog, window))
 
     spacer = 8      # Same spacing as Maya option boxes.
     edge   = 6
@@ -117,32 +117,32 @@ def _createDuplicateAsMayaDataOptionsDialog(window):
     cmds.showWindow()
 
 
-def _closeDuplicateAsMayaDataOptionsDialog(window, data=None):
+def _closeDuplicateAsUsdDataOptionsDialog(window, data=None):
     """
-    Reacts to the duplicate-as-Maya-data options dialog being closed by the user.
+    Reacts to the duplicate-as-Usd-data options dialog being closed by the user.
     """
     cmds.deleteUI(window)
 
 
-def _saveDuplicateAsMayaDataOptions(data=None):
+def _saveDuplicateAsUsdDataOptions(data=None):
     """
-    Saves the duplicate-as-Maya-data options as currently set in the dialog.
-    The MEL receiveDuplicateAsMayaDataOptionsTextFromDialog will call setDuplicateAsMayaDataOptionsText.
+    Saves the duplicate-as-Usd-data options as currently set in the dialog.
+    The MEL receiveDuplicateAsUsdDataOptionsTextFromDialog will call setDuplicateAsUsdDataOptionsText.
     """
-    mel.eval('''mayaUsdTranslatorExport("", "query=all;!output", "", "receiveDuplicateAsMayaDataOptionsTextFromDialog");''')
+    mel.eval('''mayaUsdTranslatorExport("", "query=all;!output", "", "receiveDuplicateAsUsdDataOptionsTextFromDialog");''')
 
 
-def _resetDuplicateAsMayaDataOptions(subLayout, data=None):
+def _resetDuplicateAsUsdDataOptions(subLayout, data=None):
     """
-    Resets the duplicate-as-Maya-data options in the dialog.
+    Resets the duplicate-as-Usd-data options in the dialog.
     """
-    optionsText = mayaUsdOptions.convertOptionsDictToText(getDefaultDuplicateAsMayaDataOptionsDict())
-    _fillDuplicateAsMayaDataOptionsDialog(subLayout, optionsText, "fill")
+    optionsText = mayaUsdOptions.convertOptionsDictToText(getDefaultDuplicateAsUsdDataOptionsDict())
+    _fillDuplicateAsUsdDataOptionsDialog(subLayout, optionsText, "fill")
 
 
-def _fillDuplicateAsMayaDataOptionsDialog(subLayout, optionsText, action):
+def _fillDuplicateAsUsdDataOptionsDialog(subLayout, optionsText, action):
     """
-    Fills the duplicate-as-Maya-data options dialog UI elements with the given options.
+    Fills the duplicate-as-Usd-data options dialog UI elements with the given options.
     """
     cmds.setParent(subLayout)
     mel.eval(
@@ -151,50 +151,50 @@ def _fillDuplicateAsMayaDataOptionsDialog(subLayout, optionsText, action):
         '''.format(optionsText=optionsText, subLayout=subLayout, action=action))
 
 
-def _hasDuplicateAsMayaDataOptionsHelp():
+def _hasDuplicateAsUsdDataOptionsHelp():
     """
     Returns True if the help topic for the options is available in Maya.
     """
     # Note: catchQuiet returns 0 or 1, not the value, so we use a dummy assignment
     #       to produce the value to be returned by eval().
-    url = mel.eval('''catchQuiet($url = `showHelp -q "''' + _kDuplicateAsMayaDataOptionsHelpContentId + '''"`); $a = $url;''')
+    url = mel.eval('''catchQuiet($url = `showHelp -q "''' + _kDuplicateAsUsdDataOptionsHelpContentId + '''"`); $a = $url;''')
     return bool(url)
 
-def _helpDuplicateAsMayaDataOptions(data=None):
+def _helpDuplicateAsUsdDataOptions(data=None):
     """
-    Shows help on the duplicate-as-Maya-data options dialog.
+    Shows help on the duplicate-as-Usd-data options dialog.
     """
-    cmds.showHelp(_kDuplicateAsMayaDataOptionsHelpContentId)
+    cmds.showHelp(_kDuplicateAsUsdDataOptionsHelpContentId)
 
 
-def _getDuplicateAsMayaDataOptionsVarName():
+def _getDuplicateAsUsdDataOptionsVarName():
     """
-    Retrieves the option var name under which the duplicate-as-Maya-data options are kept.
+    Retrieves the option var name under which the duplicate-as-Usd-data options are kept.
     """
-    return "mayaUsd_DuplicateAsMayaDataOptions"
+    return "mayaUsd_DuplicateAsUsdDataOptions"
 
 
-def getDuplicateAsMayaDataOptionsText():
+def getDuplicateAsUsdDataOptionsText():
     """
-    Retrieves the current duplicate-as-Maya-data options as text with column-spearated key/value pairs.
+    Retrieves the current duplicate-as-Usd-data options as text with column-spearated key/value pairs.
     """
     return mayaUsdOptions.getOptionsText(
-        _getDuplicateAsMayaDataOptionsVarName(),
-        getDefaultDuplicateAsMayaDataOptionsDict())
+        _getDuplicateAsUsdDataOptionsVarName(),
+        getDefaultDuplicateAsUsdDataOptionsDict())
     
 
-def setDuplicateAsMayaDataOptionsText(optionsText):
+def setDuplicateAsUsdDataOptionsText(optionsText):
     """
-    Sets the current duplicate-as-Maya-data options as text with column-spearated key/value pairs.
-    Called via receiveDuplicateAsMayaDataOptionsTextFromDialog in MEL, which gets called via
+    Sets the current duplicate-as-Usd-data options as text with column-spearated key/value pairs.
+    Called via receiveDuplicateAsUsdDataOptionsTextFromDialog in MEL, which gets called via
     mayaUsdTranslatorExport in query mode.
     """
-    mayaUsdOptions.setOptionsText(_getDuplicateAsMayaDataOptionsVarName(), optionsText)
+    mayaUsdOptions.setOptionsText(_getDuplicateAsUsdDataOptionsVarName(), optionsText)
 
 
-def getDefaultDuplicateAsMayaDataOptionsDict():
+def getDefaultDuplicateAsUsdDataOptionsDict():
     """
-    Retrieves the default duplicate-as-Maya-data options.
+    Retrieves the default duplicate-as-Usd-data options.
     """
     # For now, the duplicate and merge options defaults are the same.
     return getDefaultMergeToUSDOptionsDict()

--- a/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
@@ -81,8 +81,8 @@ def mayaUsdLibRegisterStrings():
     register('kHelpMergeToUSDOptionsMenuItem', 'Help on Merge Maya Edits to USD Options')
 
     # mayaUsdDuplicateAsUsdDataOptions.py
-    register('kDuplicateAsUsdDataOptionsTitle', 'Duplicate As Usd Data Options')
-    register('kHelpDuplicateAsUsdDataOptionsMenuItem', 'Help on Duplicate As Usd Data Options')
+    register('kDuplicateAsUsdDataOptionsTitle', 'Duplicate As USD Data Options')
+    register('kHelpDuplicateAsUsdDataOptionsMenuItem', 'Help on Duplicate As USD Data Options')
 
     # mayaUsdMergeToUsd.py
     register('kErrorMergeToUsdMenuItem', 'Could not create menu item for merge to USD')

--- a/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
@@ -80,9 +80,9 @@ def mayaUsdLibRegisterStrings():
     register('kHelpMenu', 'Help')
     register('kHelpMergeToUSDOptionsMenuItem', 'Help on Merge Maya Edits to USD Options')
 
-    # mayaUsdDuplicateAsMayaDataOptions.py
-    register('kDuplicateAsMayaDataOptionsTitle', 'Duplicate As Maya Data Options')
-    register('kHelpDuplicateAsMayaDataOptionsMenuItem', 'Help on Duplicate As Maya Data Options')
+    # mayaUsdDuplicateAsUsdDataOptions.py
+    register('kDuplicateAsUsdDataOptionsTitle', 'Duplicate As Usd Data Options')
+    register('kHelpDuplicateAsUsdDataOptionsMenuItem', 'Help on Duplicate As Usd Data Options')
 
     # mayaUsdMergeToUsd.py
     register('kErrorMergeToUsdMenuItem', 'Could not create menu item for merge to USD')

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -671,7 +671,7 @@ global proc mayaUsdMenu_duplicateToUSD( string $proxy, string $obj )
     string $objLong[] = `ls -l $obj`;
     string $proxyLong[] = `ls -l $proxy`;
     if (size($objLong) && size($proxyLong)) {
-        string $exportOptions = `python("import mayaUsdDuplicateAsMayaDataOptions; import mayaUsdOptions; mayaUsdOptions.setAnimateOption('''" + $obj + "''', mayaUsdDuplicateAsMayaDataOptions.getDuplicateAsMayaDataOptionsText())")`;
+        string $exportOptions = `python("import mayaUsdDuplicateAsUsdDataOptions; import mayaUsdOptions; mayaUsdOptions.setAnimateOption('''" + $obj + "''', mayaUsdDuplicateAsUsdDataOptions.getDuplicateAsUsdDataOptionsText())")`;
         mayaUsdDuplicate -exportOptions $exportOptions $objLong[0] $proxyLong[0];
     }
 }
@@ -681,7 +681,7 @@ global proc mayaUsdMenu_duplicateAsUsdDataOptions(string $obj)
     if (!hasPrimUpdater())
         return;
 
-    python("import mayaUsdDuplicateAsMayaDataOptions; mayaUsdDuplicateAsMayaDataOptions.showDuplicateAsMayaDataOptions()");
+    python("import mayaUsdDuplicateAsUsdDataOptions; mayaUsdDuplicateAsUsdDataOptions.showDuplicateAsUsdDataOptions()");
 }
 
 global proc mayaUsdMenu_markingMenuCallback( string $obj )

--- a/plugin/adsk/scripts/mayaUsd_pluginUICreation.mel
+++ b/plugin/adsk/scripts/mayaUsd_pluginUICreation.mel
@@ -51,6 +51,6 @@ global proc mayaUsd_pluginUICreation()
         source "mayaUsdAddUSDReference.mel";
         source "mayaUsdCacheMayaReference.mel";
         source "mayaUsdMergeToUSDOptions.mel";
-        source "mayaUsdDuplicateAsMayaDataOptions.mel";
+        source "mayaUsdDuplicateAsUsdDataOptions.mel";
     }
 }

--- a/test/lib/mayaUsd/fileio/testDuplicateAs.py
+++ b/test/lib/mayaUsd/fileio/testDuplicateAs.py
@@ -33,7 +33,7 @@ from maya import cmds
 from maya import standalone
 from maya.api import OpenMaya as om
 
-import mayaUsdDuplicateAsMayaDataOptions
+import mayaUsdDuplicateAsUsdDataOptions
 
 import ufe
 
@@ -395,9 +395,9 @@ class DuplicateAsTestCase(unittest.TestCase):
         stage = mayaUsd.lib.GetPrim(psPathStr).GetStage()
         
         # Duplicate Maya data as USD data using modified default options to export materials
-        defaultDuplicateAsMayaDataOptions = mayaUsdDuplicateAsMayaDataOptions.getDuplicateAsMayaDataOptionsText()
-        modifiedDuplicateAsMayaDataOptions = defaultDuplicateAsMayaDataOptions.replace('shadingMode=useRegistry','shadingMode=none')
-        cmds.mayaUsdDuplicate(cmds.ls(sphere, long=True)[0], psPathStr, exportOptions=modifiedDuplicateAsMayaDataOptions)
+        defaultDuplicateAsUsdDataOptions = mayaUsdDuplicateAsUsdDataOptions.getDuplicateAsUsdDataOptionsText()
+        modifiedDuplicateAsUsdDataOptions = defaultDuplicateAsUsdDataOptions.replace('shadingMode=useRegistry','shadingMode=none')
+        cmds.mayaUsdDuplicate(cmds.ls(sphere, long=True)[0], psPathStr, exportOptions=modifiedDuplicateAsUsdDataOptions)
 
         # Verify that the copied sphere does not have a look (material) prim.
         looksPrim = stage.GetPrimAtPath("/pSphere1/Looks")
@@ -408,8 +408,8 @@ class DuplicateAsTestCase(unittest.TestCase):
 
         # Duplicate Maya data as USD data using default options. The default do not specify any
         # material conversion option, so we still get no material.
-        modifiedDuplicateAsMayaDataOptions = defaultDuplicateAsMayaDataOptions[:]
-        cmds.mayaUsdDuplicate(cmds.ls(sphere, long=True)[0], psPathStr, exportOptions=modifiedDuplicateAsMayaDataOptions)
+        modifiedDuplicateAsUsdDataOptions = defaultDuplicateAsUsdDataOptions[:]
+        cmds.mayaUsdDuplicate(cmds.ls(sphere, long=True)[0], psPathStr, exportOptions=modifiedDuplicateAsUsdDataOptions)
 
         # Verify that the copied sphere does not have a look (material) prim.
         looksPrim = stage.GetPrimAtPath("/pSphere1/Looks")
@@ -419,15 +419,15 @@ class DuplicateAsTestCase(unittest.TestCase):
         cmds.undo()
 
         # Duplicate Maya data as USD data using default options that are with materials.
-        modifiedDuplicateAsMayaDataOptions = defaultDuplicateAsMayaDataOptions.replace("convertMaterialsTo=[]", "convertMaterialsTo=[UsdPreviewSurface]")
-        cmds.mayaUsdDuplicate(cmds.ls(sphere, long=True)[0], psPathStr, exportOptions=modifiedDuplicateAsMayaDataOptions)
+        modifiedDuplicateAsUsdDataOptions = defaultDuplicateAsUsdDataOptions.replace("convertMaterialsTo=[]", "convertMaterialsTo=[UsdPreviewSurface]")
+        cmds.mayaUsdDuplicate(cmds.ls(sphere, long=True)[0], psPathStr, exportOptions=modifiedDuplicateAsUsdDataOptions)
 
         # Verify that the copied sphere has a look (material) prim.
         looksPrim = stage.GetPrimAtPath("/pSphere1/Looks")
         self.assertTrue(looksPrim.IsValid())
 
         # Restore default options
-        mayaUsdDuplicateAsMayaDataOptions.setDuplicateAsMayaDataOptionsText(defaultDuplicateAsMayaDataOptions)
+        mayaUsdDuplicateAsUsdDataOptions.setDuplicateAsUsdDataOptionsText(defaultDuplicateAsUsdDataOptions)
 
     def testDuplicateRigWithOPMAsUsd(self):
         '''Duplicate a Maya rig using offset-parent-matrix to USD.'''
@@ -448,9 +448,9 @@ class DuplicateAsTestCase(unittest.TestCase):
         # path handler registered to UFE for Maya path strings, so use absolute
         # path.
         # Duplicate Maya data as USD data using modified default options to export materials
-        defaultDuplicateAsMayaDataOptions = mayaUsdDuplicateAsMayaDataOptions.getDuplicateAsMayaDataOptionsText()
-        modifiedDuplicateAsMayaDataOptions = defaultDuplicateAsMayaDataOptions.replace('animation=0','animation=1')
-        cmds.mayaUsdDuplicate(cmds.ls(rigName, long=True)[0], psPathStr, exportOptions=modifiedDuplicateAsMayaDataOptions)
+        defaultDuplicateAsUsdDataOptions = mayaUsdDuplicateAsUsdDataOptions.getDuplicateAsUsdDataOptionsText()
+        modifiedDuplicateAsUsdDataOptions = defaultDuplicateAsUsdDataOptions.replace('animation=0','animation=1')
+        cmds.mayaUsdDuplicate(cmds.ls(rigName, long=True)[0], psPathStr, exportOptions=modifiedDuplicateAsUsdDataOptions)
 
         # Maya hierarchy should be duplicated in USD.
         usdRigPathStr = psPathStr + ',/' + rigName


### PR DESCRIPTION
Update the title of Duplicate As Usd Data Option Dialog to match. Also refactored various files that used duplicate as Maya data while the business logic within them meant to perform duplicate as Usd data.