### PR TITLE
MAYA-128040: isDisconnected local variable treated as error if pxr > v0.23

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoConnectionCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoConnectionCommands.cpp
@@ -292,9 +292,11 @@ void UsdUndoDeleteConnectionCommand::execute()
         || !MayaUsd::ufe::isConnected(srcUsdAttr->usdAttribute(), dstUsdAttr->usdAttribute())) {
         return;
     }
-
-    bool isDisconnected = UsdShadeConnectableAPI::DisconnectSource(
-        dstUsdAttr->usdAttribute(), srcUsdAttr->usdAttribute());
+#if PXR_VERSION < 2302
+    bool isDisconnected =
+#endif
+        UsdShadeConnectableAPI::DisconnectSource(
+            dstUsdAttr->usdAttribute(), srcUsdAttr->usdAttribute());
 
     // We need to make sure we cleanup on disconnection. Since having an empty connection array
     // counts as having connections, we need to get the array and see if it is empty.


### PR DESCRIPTION
* I have found "isDisconnected  not used" treated as error that if PXR > v0.23 is used