### PR TITLE
MAYA-126128 sync session layer for various commands

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -25,6 +25,7 @@
 #include <mayaUsd/utils/customLayerData.h>
 #include <mayaUsd/utils/diagnosticDelegate.h>
 #include <mayaUsd/utils/layerMuting.h>
+#include <mayaUsd/utils/layers.h>
 #include <mayaUsd/utils/loadRules.h>
 #include <mayaUsd/utils/query.h>
 #include <mayaUsd/utils/stageCache.h>
@@ -929,7 +930,7 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
 
     if (isIncomingStage) {
         std::vector<std::string> incomingLayers { sharedUsdStage->GetRootLayer()->GetIdentifier() };
-        _incomingLayers = UsdMayaUtil::getAllSublayers(incomingLayers, true);
+        _incomingLayers = getAllSublayers(incomingLayers, true);
     } else {
         _incomingLayers.clear();
     }
@@ -940,14 +941,10 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
         // they get the same state they were in, but in order to this we have to keep the layers in
         // the heirharchy alive since the stage is gone and so they will get removed
         if (_unsharedStageRootLayer) {
-            auto subLayerIds = UsdMayaUtil::getAllSublayers(_unsharedStageRootLayer);
             _unsharedStageRootSublayers.clear();
-            for (const auto& identifier : subLayerIds) {
-                SdfLayerRefPtr sublayer = SdfLayer::Find(identifier);
-                if (sublayer) {
-                    _unsharedStageRootSublayers.push_back(sublayer);
-                }
-            }
+            auto subLayers = getAllSublayerRefs(_unsharedStageRootLayer);
+            _unsharedStageRootSublayers.insert(
+                _unsharedStageRootSublayers.begin(), subLayers.begin(), subLayers.end());
         }
         finalUsdStage = sharedUsdStage;
     }
@@ -980,7 +977,7 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
             }
 
             // If its a new layer (or wasn't remapped properly)
-            auto sublayerIds = UsdMayaUtil::getAllSublayers(_unsharedStageRootLayer);
+            auto sublayerIds = getAllSublayers(_unsharedStageRootLayer);
             if (sublayerIds.find(inRootLayer->GetIdentifier()) == sublayerIds.end()) {
                 // Add new layer to subpaths
                 auto subLayers = _unsharedStageRootLayer->GetSubLayerPaths();

--- a/lib/mayaUsd/ufe/UsdUndoDeleteCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDeleteCommand.cpp
@@ -19,9 +19,11 @@
 #include "private/Utils.h"
 
 #include <mayaUsd/ufe/Utils.h>
+#include <mayaUsd/utils/layers.h>
 
 #include <pxr/usd/pcp/layerStack.h>
 #include <pxr/usd/sdf/layer.h>
+#include <pxr/usd/usd/editContext.h>
 
 #ifdef UFE_V2_FEATURES_AVAILABLE
 #include <mayaUsd/undo/UsdUndoBlock.h>
@@ -85,8 +87,10 @@ void UsdUndoDeleteCommand::execute()
     auto        targetPrimSpec = stage->GetEditTarget().GetPrimSpecForScenePath(_prim.GetPath());
 
     if (hasLayersMuted(_prim)) {
-        TF_WARN("Cannot remove prim because there are muted layers.");
-        return;
+        const std::string error = TfStringPrintf(
+            "Cannot remove prim \"%s\" because there are muted layers.", _prim.GetPath().GetText());
+        TF_WARN("%s", error.c_str());
+        throw std::runtime_error(error);
     }
 
     if (MayaUsd::ufe::applyCommandRestrictionNoThrow(_prim, "delete")) {
@@ -95,10 +99,19 @@ void UsdUndoDeleteCommand::execute()
         UsdAttributes::removeAttributesConnections(_prim);
 #endif
 #endif
-        auto retVal = stage->RemovePrim(_prim.GetPath());
-        if (!retVal) {
-            TF_VERIFY(retVal, "Failed to delete '%s'", _prim.GetPath().GetText());
-        }
+        bool success = true;
+
+        PrimSpecFunc deleteFunc
+            = [&success, stage](const UsdPrim& prim, const SdfPrimSpecHandle& primSpec) -> void {
+            PXR_NS::UsdEditContext ctx(stage, primSpec->GetLayer());
+            if (!stage->RemovePrim(prim.GetPath())) {
+                const std::string error
+                    = TfStringPrintf("Failed to delete prim \"%s\".", prim.GetPath().GetText());
+                TF_WARN("%s", error.c_str());
+                throw std::runtime_error(error);
+            }
+        };
+        applyToAllPrimSpecs(_prim, deleteFunc);
     }
 #else
     _prim.SetActive(false);

--- a/lib/mayaUsd/ufe/UsdUndoDeleteCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDeleteCommand.cpp
@@ -99,10 +99,8 @@ void UsdUndoDeleteCommand::execute()
         UsdAttributes::removeAttributesConnections(_prim);
 #endif
 #endif
-        bool success = true;
-
         PrimSpecFunc deleteFunc
-            = [&success, stage](const UsdPrim& prim, const SdfPrimSpecHandle& primSpec) -> void {
+            = [stage](const UsdPrim& prim, const SdfPrimSpecHandle& primSpec) -> void {
             PXR_NS::UsdEditContext ctx(stage, primSpec->GetLayer());
             if (!stage->RemovePrim(prim.GetPath())) {
                 const std::string error

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
@@ -66,8 +66,8 @@ private:
     void undo() override;
     void redo() override;
 
-    bool insertChildRedo();
-    bool insertChildUndo();
+    void insertChildRedo();
+    void insertChildUndo();
 
     UsdSceneItem::Ptr _ufeDstItem;
 

--- a/lib/mayaUsd/ufe/UsdUndoRenameCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoRenameCommand.h
@@ -54,8 +54,8 @@ public:
 #endif
 
 private:
-    bool renameRedo();
-    bool renameUndo();
+    void renameRedo();
+    void renameUndo();
 
     void undo() override;
     void redo() override;

--- a/lib/mayaUsd/utils/CMakeLists.txt
+++ b/lib/mayaUsd/utils/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(${PROJECT_NAME}
         editability.cpp
         editRouter.cpp
         layerMuting.cpp
+        layers.cpp
         loadRules.cpp
         loadRulesText.cpp
         loadRulesAttribute.cpp
@@ -49,6 +50,7 @@ set(HEADERS
     editRouter.h
     hash.h
     layerMuting.h
+    layers.h
     loadRules.h
     query.h
     plugRegistryHelper.h

--- a/lib/mayaUsd/utils/layers.cpp
+++ b/lib/mayaUsd/utils/layers.cpp
@@ -1,0 +1,179 @@
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "layers.h"
+
+#include <pxr/usd/pcp/layerStack.h>
+
+#include <deque>
+
+namespace MAYAUSD_NS_DEF {
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace {
+
+void getAllSublayers(
+    const SdfLayerRefPtr&     layer,
+    std::set<std::string>*    layerIds,
+    std::set<SdfLayerRefPtr>* layerRefs)
+{
+    std::deque<SdfLayerRefPtr> processing;
+    processing.push_back(layer);
+    while (!processing.empty()) {
+        auto layerToProcess = processing.front();
+        processing.pop_front();
+        SdfSubLayerProxy sublayerPaths = layerToProcess->GetSubLayerPaths();
+        for (auto path : sublayerPaths) {
+            SdfLayerRefPtr sublayer = SdfLayer::FindOrOpen(path);
+            if (sublayer) {
+                if (layerIds)
+                    layerIds->insert(path);
+                if (layerRefs)
+                    layerRefs->insert(sublayer);
+                processing.push_back(sublayer);
+            }
+        }
+    }
+}
+
+} // namespace
+
+std::set<std::string> getAllSublayers(const SdfLayerRefPtr& layer)
+{
+    std::set<std::string> allSublayers;
+    getAllSublayers(layer, &allSublayers, nullptr);
+    return allSublayers;
+}
+
+std::set<SdfLayerRefPtr> getAllSublayerRefs(const SdfLayerRefPtr& layer, bool includeTopLayer)
+{
+    std::set<SdfLayerRefPtr> allSublayers;
+    getAllSublayers(layer, nullptr, &allSublayers);
+    if (includeTopLayer)
+        allSublayers.insert(layer);
+    return allSublayers;
+}
+
+std::set<std::string>
+getAllSublayers(const std::vector<std::string>& layerPaths, bool includeParents)
+{
+    std::set<std::string> layers;
+
+    for (auto layerPath : layerPaths) {
+        SdfLayerRefPtr layer = SdfLayer::Find(layerPath);
+        if (layer) {
+            if (includeParents)
+                layers.insert(layerPath);
+            auto sublayerPaths = getAllSublayers(layer);
+            std::move(sublayerPaths.begin(), sublayerPaths.end(), inserter(layers, layers.end()));
+        }
+    }
+
+    return layers;
+}
+
+void applyToAllPrimSpecs(const UsdPrim& prim, const PrimSpecFunc& func)
+{
+    const SdfPrimSpecHandleVector primStack = prim.GetPrimStack();
+    for (const SdfPrimSpecHandle& spec : primStack)
+        func(prim, spec);
+}
+
+void applyToAllLayersWithOpinions(const UsdPrim& prim, PrimLayerFunc& func)
+{
+    const SdfPrimSpecHandleVector primStack = prim.GetPrimStack();
+    for (const SdfPrimSpecHandle& spec : primStack) {
+        const auto layer = spec->GetLayer();
+        func(prim, layer);
+    }
+}
+
+void applyToSomeLayersWithOpinions(
+    const UsdPrim&                  prim,
+    const std::set<SdfLayerRefPtr>& layers,
+    PrimLayerFunc&                  func)
+{
+    const SdfPrimSpecHandleVector primStack = prim.GetPrimStack();
+    for (const SdfPrimSpecHandle& spec : primStack) {
+        const auto layer = spec->GetLayer();
+        if (layers.count(layer) == 0)
+            continue;
+        func(prim, layer);
+    }
+}
+
+bool isSessionLayer(const SdfLayerHandle& layer, const std::set<SdfLayerRefPtr>& sessionLayers)
+{
+    return sessionLayers.count(layer) > 0;
+}
+
+SdfLayerHandle getStrongerLayer(
+    const SdfLayerHandle& root,
+    const SdfLayerHandle& layer1,
+    const SdfLayerHandle& layer2)
+{
+    if (layer1 == layer2)
+        return layer1;
+
+    if (!layer1)
+        return layer2;
+
+    if (!layer2)
+        return layer1;
+
+    if (root == layer1)
+        return layer1;
+
+    if (root == layer2)
+        return layer2;
+
+    for (auto path : root->GetSubLayerPaths()) {
+        SdfLayerRefPtr subLayer = SdfLayer::FindOrOpen(path);
+        if (subLayer) {
+            SdfLayerHandle stronger = getStrongerLayer(subLayer, layer1, layer2);
+            if (!stronger.IsInvalid()) {
+                return stronger;
+            }
+        }
+    }
+
+    return SdfLayerHandle();
+}
+
+SdfLayerHandle getStrongerLayer(
+    const UsdStagePtr&    stage,
+    const SdfLayerHandle& layer1,
+    const SdfLayerHandle& layer2,
+    bool                  compareSessionLayers)
+{
+    if (compareSessionLayers) {
+        // Session Layer is the strongest in the stage, so check its hierarchy first
+        // when enabled.
+        auto strongerLayer = getStrongerLayer(stage->GetSessionLayer(), layer1, layer2);
+        if (strongerLayer == layer1) {
+            return layer1;
+        } else if (strongerLayer == layer2) {
+            return layer2;
+        }
+    }
+
+    // Only verify the stage's general layer hierarchy. Do not check the session
+    // layer hierarchy because we don't want to let opinions that are owned by
+    // the application interfere with the user commands.
+    return getStrongerLayer(stage->GetRootLayer(), layer1, layer2);
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/layers.h
+++ b/lib/mayaUsd/utils/layers.h
@@ -1,0 +1,149 @@
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef PXRUSDMAYA_UTIL_LAYERS_H
+#define PXRUSDMAYA_UTIL_LAYERS_H
+
+#include <mayaUsd/base/api.h>
+
+#include <pxr/usd/sdf/layer.h>
+#include <pxr/usd/usd/prim.h>
+
+#include <functional>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace MAYAUSD_NS_DEF {
+
+/**
+ * Returns all the sublayers recursively for a given layer
+ *
+ * @param layer The layer to start from and get the sublayers
+ *
+ * @return The list of identifiers for all the sublayers
+ */
+MAYAUSD_CORE_PUBLIC
+std::set<std::string> getAllSublayers(const PXR_NS::SdfLayerRefPtr& layer);
+
+/**
+ * Returns all the sublayers recursively for a list of layers
+ *
+ * @param parentLayerPaths The list of the parent layer paths to traverse recursively
+ * @param includeParents   This will add the parents passed in to the output
+ *
+ * @return The list of identifiers for all the sublayers for each parent (plus the parents
+ * potentially)
+ */
+MAYAUSD_CORE_PUBLIC
+std::set<std::string>
+getAllSublayers(const std::vector<std::string>& parentLayerPaths, bool includeParents = false);
+
+/**
+ * Returns all the sublayers reference pointers recursively for a given layer
+ *
+ * @param layer The layer to start from and get the sublayers
+ * @param includeTopLayer also add the layer that was passed in
+ *
+ * @return The list of layers for all the sublayers
+ */
+MAYAUSD_CORE_PUBLIC
+std::set<PXR_NS::SdfLayerRefPtr>
+getAllSublayerRefs(const PXR_NS::SdfLayerRefPtr& layer, bool includeTopLayer = false);
+
+/**
+ * Apply the given function to all the opinions about the given prim.
+ *
+ * @param prim The prim to be modified.
+ * @param func The function to be applied.
+ */
+
+using PrimSpecFunc = std::function<void(const PXR_NS::UsdPrim&, const PXR_NS::SdfPrimSpecHandle&)>;
+
+MAYAUSD_CORE_PUBLIC
+void applyToAllPrimSpecs(const PXR_NS::UsdPrim& prim, const PrimSpecFunc& func);
+
+/**
+ * Apply the given function to all the layers that have an opinion about the given prim.
+ *
+ * @param prim The prim to be modified.
+ * @param func The function to be applied.
+ */
+
+using PrimLayerFunc = std::function<void(const PXR_NS::UsdPrim&, const PXR_NS::SdfLayerRefPtr&)>;
+
+MAYAUSD_CORE_PUBLIC
+void applyToAllLayersWithOpinions(const PXR_NS::UsdPrim& prim, PrimLayerFunc& func);
+
+/**
+ * Apply the given function to some of the layers that have an opinion about the given prim.
+ * Only the layers that are part of the given set will be affected.
+ *
+ * @param prim The prim to be modified.
+ * @param layers The set of layers that can be affected if they contain an opinion.
+ * @param func The function to be applied.
+ */
+
+MAYAUSD_CORE_PUBLIC
+void applyToSomeLayersWithOpinions(
+    const PXR_NS::UsdPrim&                  prim,
+    const std::set<PXR_NS::SdfLayerRefPtr>& layers,
+    PrimLayerFunc&                          func);
+
+/**
+ * Verify if a layer is in the given set of session layers.
+ *
+ * @param layer the layer to verify.
+ * @param sessionLayers the set of session layers.
+ */
+
+MAYAUSD_CORE_PUBLIC
+bool isSessionLayer(
+    const PXR_NS::SdfLayerHandle&           layer,
+    const std::set<PXR_NS::SdfLayerRefPtr>& sessionLayers);
+
+/**
+ * Get which of the two given layers is the strongest under the given root layer hierarchy.
+ *
+ * @param root The root layer that will determine which is stronger.
+ * @param layer1 one of the layers to be compared.
+ * @param layer2 one of the layers to be compared.
+ */
+
+MAYAUSD_CORE_PUBLIC
+PXR_NS::SdfLayerHandle getStrongerLayer(
+    const PXR_NS::SdfLayerHandle& root,
+    const PXR_NS::SdfLayerHandle& layer1,
+    const PXR_NS::SdfLayerHandle& layer2);
+
+/**
+ * Get which of the two given layers is the strongest under the given stage root layer hierarchy.
+ *
+ * @param stage The stage with the root layer that will determine which is stronger.
+ * @param layer1 one of the layers to be compared.
+ * @param layer2 one of the layers to be compared.
+ * @param compareSessionLayers if true, also search the session layer. False by default.
+ */
+
+MAYAUSD_CORE_PUBLIC
+PXR_NS::SdfLayerHandle getStrongerLayer(
+    const PXR_NS::UsdStagePtr&    stage,
+    const PXR_NS::SdfLayerHandle& layer1,
+    const PXR_NS::SdfLayerHandle& layer2,
+    bool                          compareSessionLayers = false);
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -2535,45 +2535,6 @@ MString UsdMayaUtil::GetCurrentSceneFilePath()
     return currentSceneFilePath;
 }
 
-std::set<std::string> UsdMayaUtil::getAllSublayers(const PXR_NS::SdfLayerRefPtr& layer)
-{
-    std::set<std::string>      allSublayers;
-    std::deque<SdfLayerRefPtr> processing;
-    processing.push_back(layer);
-    while (!processing.empty()) {
-        auto layerToProcess = processing.front();
-        processing.pop_front();
-        SdfSubLayerProxy sublayerPaths = layerToProcess->GetSubLayerPaths();
-        for (auto path : sublayerPaths) {
-            SdfLayerRefPtr sublayer = SdfLayer::FindOrOpen(path);
-            if (sublayer) {
-                allSublayers.insert(path);
-                processing.push_back(sublayer);
-            }
-        }
-    }
-
-    return allSublayers;
-}
-
-std::set<std::string>
-UsdMayaUtil::getAllSublayers(const std::vector<std::string>& layerPaths, bool includeParents)
-{
-    std::set<std::string> layers;
-
-    for (auto layerPath : layerPaths) {
-        SdfLayerRefPtr layer = PXR_NS::SdfLayer::Find(layerPath);
-        if (layer) {
-            if (includeParents)
-                layers.insert(layerPath);
-            auto sublayerPaths = UsdMayaUtil::getAllSublayers(layer);
-            std::move(sublayerPaths.begin(), sublayerPaths.end(), inserter(layers, layers.end()));
-        }
-    }
-
-    return layers;
-}
-
 void UsdMayaUtil::AddMayaExtents(GfBBox3d& bbox, const UsdPrim& root, const UsdTimeCode time)
 {
     GfRange3d localExtents;

--- a/lib/mayaUsd/utils/util.h
+++ b/lib/mayaUsd/utils/util.h
@@ -682,29 +682,6 @@ MString GetCurrentMayaWorkspacePath();
 MAYAUSD_CORE_PUBLIC
 MString GetCurrentSceneFilePath();
 
-/**
- * Returns all the sublayers recursively for a given layer
- *
- * @param layer   The layer to start from and get the sublayers
- *
- * @return The list of identifiers for all the sublayers
- */
-MAYAUSD_CORE_PUBLIC
-std::set<std::string> getAllSublayers(const PXR_NS::SdfLayerRefPtr& layer);
-
-/**
- * Returns all the sublayers recursively for a list of layers
- *
- * @param parentLayerPaths   The list of the parent layer paths to traverse recursively
- * @param includeParents   This will add the parents passed in to the output
- *
- * @return The list of identifiers for all the sublayers for each parent (plus the parents
- * potentially)
- */
-MAYAUSD_CORE_PUBLIC
-std::set<std::string>
-getAllSublayers(const std::vector<std::string>& parentLayerPaths, bool includeParents = false);
-
 /// Takes the supplied bounding box and adds to it Maya-specific extents
 /// that come from the nodes originating from the supplied root node
 MAYAUSD_CORE_PUBLIC

--- a/lib/usd/ui/layerEditor/layerTreeModel.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeModel.cpp
@@ -24,7 +24,7 @@
 
 #include <mayaUsd/base/tokens.h>
 #include <mayaUsd/utils/customLayerData.h>
-#include <mayaUsd/utils/util.h>
+#include <mayaUsd/utils/layers.h>
 #include <mayaUsd/utils/utilSerialization.h>
 
 #include <pxr/base/tf/notice.h>
@@ -273,7 +273,7 @@ void LayerTreeModel::rebuildModel()
                 rootLayer, MayaUsdMetadata->ReferencedLayers);
             std::vector<std::string> layerIds;
             std::move(layers.begin(), layers.end(), inserter(layerIds, layerIds.begin()));
-            sharedLayers = UsdMayaUtil::getAllSublayers(layerIds, true);
+            sharedLayers = MAYAUSD_NS_DEF::getAllSublayers(layerIds, true);
         }
 
         std::set<std::string> incomingLayers;
@@ -284,7 +284,7 @@ void LayerTreeModel::rebuildModel()
             } else {
                 std::vector<std::string> layerIds;
                 layerIds.push_back(rootLayer->GetIdentifier());
-                incomingLayers = UsdMayaUtil::getAllSublayers(layerIds, true);
+                incomingLayers = MAYAUSD_NS_DEF::getAllSublayers(layerIds, true);
             }
         }
 

--- a/test/lib/ufe/testGroupCmd.py
+++ b/test/lib/ufe/testGroupCmd.py
@@ -25,7 +25,7 @@ import usdUtils
 
 import mayaUsd.ufe
 
-from pxr import Kind, Usd, UsdGeom, Vt
+from pxr import Kind, Usd, UsdGeom, Vt, Sdf
 
 from maya import cmds, mel
 from maya import standalone
@@ -325,8 +325,14 @@ class GroupCmdTestCase(unittest.TestCase):
         # get the USD stage
         stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
 
-        # set the edit target to the session layer
-        stage.SetEditTarget(stage.GetSessionLayer())
+        # set the edit target to a new layer
+        newLayerName = 'Layer_1'
+        usdFormat = Sdf.FileFormat.FindByExtension('usd')
+        newLayer = Sdf.Layer.New(usdFormat, newLayerName)
+        stage.GetRootLayer().subLayerPaths.append(newLayer.identifier)
+
+        stage.SetEditTarget(newLayer)
+        self.assertEqual(stage.GetEditTarget().GetLayer(), newLayer)
 
         # expect the exception happens
         with self.assertRaises(RuntimeError):
@@ -346,7 +352,7 @@ class GroupCmdTestCase(unittest.TestCase):
         ufeSelection.append(sphereItem)
 
         # set the edit target to the session layer
-        stage.SetEditTarget(stage.GetSessionLayer())
+        stage.SetEditTarget(newLayer)
 
         # expect the exception happens.
         with self.assertRaises(RuntimeError):
@@ -526,6 +532,100 @@ class GroupCmdTestCase(unittest.TestCase):
             stage.GetPrimAtPath("/group1/Sphere1"), 
             stage.GetPrimAtPath("/group1/Sphere2"),
             stage.GetPrimAtPath("/group1/Sphere3")])
+
+    @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 3, 'testGroupUndoRedo is only available in UFE v3 or greater.')
+    def testGroupRestrictionsAllowSession(self):
+        '''
+        Verify that grouping is allowed even ifthe prim as opinions in the session layer.
+        '''
+        cmds.file(new=True, force=True)
+
+        # Create a stage
+        (stage, proxyShapePathStr, proxyShapeItem, contextOp) = createStage()
+
+        # Some helper functions used during the test
+        def getItem(name):
+            proxySegment = mayaUtils.createUfePathSegment(proxyShapePathStr)
+            self.assertIsNotNone(proxySegment)
+            itemPathSegment = usdUtils.createUfePathSegment(name)
+            self.assertIsNotNone(itemPathSegment)
+            itemPath = ufe.Path([proxySegment, itemPathSegment])
+            item = ufe.Hierarchy.createItem(itemPath)
+            self.assertIsNotNone(item)
+            return item
+
+        def applyRotation(item, rotation):
+            itemTrf = ufe.Transform3d.transform3d(item)
+            itemTrf.rotate(*rotation)
+            itemTrf = None
+
+        def verifyRotation(item, rotation):
+            itemTrf = ufe.Transform3d.transform3d(item)
+            self.assertEqual(itemTrf.rotation(), ufe.PyUfe.Vector3d(*rotation))
+
+        # Some values used during the test
+        rotation = [30., 20., 10.]
+        oldSphere1Name = '/Sphere1'
+        newSphere1Name = '/group1/Sphere1'
+
+        # Create a sphere generator and geerate 3 spheres
+        sphereGen = SphereGenerator(3, contextOp, proxyShapePathStr)
+
+        sphere1Path = sphereGen.createSphere()
+        sphere1Prim = mayaUsd.ufe.ufePathToPrim(ufe.PathString.string(sphere1Path))
+
+        sphere2Path = sphereGen.createSphere()
+        sphere2Prim = mayaUsd.ufe.ufePathToPrim(ufe.PathString.string(sphere2Path))
+
+        sphere3Path = sphereGen.createSphere()
+        sphere3Prim = mayaUsd.ufe.ufePathToPrim(ufe.PathString.string(sphere3Path))
+
+        # Add an opinion about one sphere in the session layer
+        stage.SetEditTarget(stage.GetSessionLayer())
+        self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetSessionLayer())
+
+        applyRotation(getItem(oldSphere1Name), rotation)
+        verifyRotation(getItem(oldSphere1Name), rotation)
+
+        # Group Sphere1, Sphere2, and Sphere3 in the root layer
+        stage.SetEditTarget(stage.GetRootLayer())
+        self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetRootLayer())
+
+        groupName = cmds.group(ufe.PathString.string(sphere1Path),
+                               ufe.PathString.string(sphere2Path),
+                               ufe.PathString.string(sphere3Path))
+
+        # Verify that groupItem has 3 children
+        groupItem = ufe.GlobalSelection.get().front()
+        groupHierarchy = ufe.Hierarchy.hierarchy(groupItem)
+        self.assertEqual(len(groupHierarchy.children()), 3)
+
+        self.assertEqual([item for item in stage.Traverse()],
+            [stage.GetPrimAtPath("/group1"),
+            stage.GetPrimAtPath("/group1/Sphere1"), 
+            stage.GetPrimAtPath("/group1/Sphere2"),
+            stage.GetPrimAtPath("/group1/Sphere3")])
+        
+        verifyRotation(getItem(newSphere1Name), rotation)
+
+        cmds.undo()
+
+        self.assertEqual([item for item in stage.Traverse()],
+            [stage.GetPrimAtPath("/Sphere3"), 
+            stage.GetPrimAtPath("/Sphere2"),
+            stage.GetPrimAtPath("/Sphere1")])
+
+        verifyRotation(getItem(oldSphere1Name), rotation)
+
+        cmds.redo()
+
+        self.assertEqual([item for item in stage.Traverse()],
+            [stage.GetPrimAtPath("/group1"),
+            stage.GetPrimAtPath("/group1/Sphere1"), 
+            stage.GetPrimAtPath("/group1/Sphere2"),
+            stage.GetPrimAtPath("/group1/Sphere3")])
+
+        verifyRotation(getItem(newSphere1Name), rotation)
 
     @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 3, 'testGroupUndoRedo is only available in UFE v3 or greater.')
     def testGroupPreserveLoadRules(self):

--- a/test/lib/ufe/testRename.py
+++ b/test/lib/ufe/testRename.py
@@ -416,6 +416,102 @@ class RenameTestCase(unittest.TestCase):
             newName = 'Ball_35_Renamed'
             cmds.rename(newName)
 
+    def testRenameRestrictionSessionLayer(self):
+        '''
+        Verify that having an opinion in the session layer does *not* prevent
+        renaming a prim defined on another layer.
+        '''
+        # Open usdCylinder.ma scene in testSamples
+        mayaUtils.openCylinderScene()
+
+        # clear the selection to start off
+        cmds.select(clear=True)
+
+        # Some values used during the test
+        oldName = 'pCylinder1'
+        newName = 'pCylinder1_Renamed'
+        rotation = [30., 20., 10.]
+        mayaPathSegment = mayaUtils.createUfePathSegment('|mayaUsdTransform|shape')
+
+        # Some helper functions used during the test
+        def getItem(name):
+            itemPathSegment = usdUtils.createUfePathSegment('/' + name)
+            itemPath = ufe.Path([mayaPathSegment, itemPathSegment])
+            return ufe.Hierarchy.createItem(itemPath)
+
+        def applyRotation(item, rotation):
+            itemTrf = ufe.Transform3d.transform3d(item)
+            itemTrf.rotate(*rotation)
+            itemTrf = None
+
+        def verifyRotation(item, rotation):
+            itemTrf = ufe.Transform3d.transform3d(item)
+            self.assertEqual(itemTrf.rotation(), ufe.PyUfe.Vector3d(*rotation))
+
+        def applyRename(name):
+            cmds.rename(newName)
+
+        def verifyName(expectedName, expectedType, badName):
+            # The renamed item is in the selection and has the correct name and type
+            snIter = iter(ufe.GlobalSelection.get())
+            item = next(snIter)
+            itemName = str(item.path().back())
+
+            self.assertEqual(itemName, expectedName)
+            self.assertEqual(item.nodeType(), expectedType)
+
+            # The renamed item is a child of its parent
+            propsChildren = propsHierarchy.children()
+            propsChildrenNames = [str(child.path().back()) for child in propsChildren]
+
+            self.assertEqual(len(propsChildren), len(propsChildrenPre))
+            self.assertIn(item, propsChildren)
+
+            self.assertNotIn(badName, propsChildrenNames)
+            self.assertIn(expectedName, propsChildrenNames)
+
+        # Select a the USD cylinder object
+        self.assertIsNotNone(getItem(oldName))
+        cylinderItemType = getItem(oldName).nodeType()
+
+        propsItem = ufe.Hierarchy.hierarchy(getItem(oldName)).parent()
+        propsHierarchy = ufe.Hierarchy.hierarchy(propsItem)
+        propsChildrenPre = propsHierarchy.children()
+
+        ufe.GlobalSelection.get().append(getItem(oldName))
+
+        # Get the USD stage
+        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+
+        # Add an opinion about the cylinder in the session layer
+        stage.SetEditTarget(stage.GetSessionLayer())
+        self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetSessionLayer())
+
+        applyRotation(getItem(oldName), rotation)
+        verifyRotation(getItem(oldName), rotation)
+
+        # Verify the cylinder name and hierarchy before we do anything.
+        verifyName(oldName, cylinderItemType, newName)
+
+        # Rename the cylinder in the root layer
+        stage.SetEditTarget(stage.GetRootLayer())
+        self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetRootLayer())
+
+        applyRename(newName)
+        verifyName(newName, cylinderItemType, oldName)
+        verifyRotation(getItem(newName), rotation)
+
+        # Undo the rename and verify that the name and hierarchy are back to what they were
+        cmds.undo()
+        verifyName(oldName, cylinderItemType, newName)
+        verifyRotation(getItem(oldName), rotation)
+
+        # Redo the rename and verify that the name and hierarchy are changed again
+        cmds.redo()
+        verifyName(newName, cylinderItemType, oldName)
+        verifyRotation(getItem(newName), rotation)
+
+
     def testRenameRestrictionHasSpecs(self):
         '''Restrict renaming USD node. Cannot rename a node that doesn't contribute to the final composed prim'''
 


### PR DESCRIPTION
Keep opinions in the session layer in sync when a prim is renamed while targeting another layer. Do the same for insert child, group delete and reorder commands.

Provide helper functions to deal with the session layer and enhance the various commands to allow them when the session layer contains opinions, by using these helper functions.

Allow authoring in session layer: detect that the target is in the session layer and allow edits there if it is the strongest session opinion.

- Move many layer-related helpers into their own file.
- Refactor code that used the old functions to use the new functions.
- Add applyToAllPrimSpecs and applyToAllLayersWithOpinions helper functions.
- Add applyToSomeLayersWithOpinions helper function to apply a change to a subset of layers.
- Use applyToAllPrimSpecs helper function in the rename command.
- Use the helper functions in the rename, delete, insert child and reorder commands..
- Properly delete all prim spec in session layer when deleting a prim.
- Properly throw an exception when failing.
- This is necessary so that composite commands know a sub-command has failed.
- Add rename unit test that demonstrate that prims can be renamed when they have opinions in the session layer.
- Add unit tests for group (insert child) and reorder.
- Fix the delete command unit test.
- Fix unit tests to use non-session layer when testing restrictions.