### PR TITLE
MAYA-126128 transform command error reporting

### DIFF
--- a/lib/mayaUsd/ufe/UsdAttributeHolder.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributeHolder.cpp
@@ -48,11 +48,7 @@ bool setUsdAttrMetadata(
     }
 
     // If attribute is locked don't allow setting Metadata.
-    std::string errMsg;
-    const bool  isSetAttrAllowed = MayaUsd::ufe::isAttributeEditAllowed(attr, &errMsg);
-    if (!isSetAttrAllowed) {
-        throw std::runtime_error(errMsg);
-    }
+    MayaUsd::ufe::enforceAttributeEditAllowed(attr);
 
     PXR_NS::TfToken tok(key);
     if (PXR_NS::UsdShadeNodeGraph(attr.GetPrim())) {

--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -96,10 +96,7 @@ Ufe::SceneItem::Ptr UsdTransform3d::sceneItem() const { return fItem; }
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate"));
     return UsdTranslateUndoableCommand::create(path(), x, y, z);
 }
 #endif
@@ -160,10 +157,7 @@ Ufe::Vector3d UsdTransform3d::scale() const
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"));
     return UsdRotateUndoableCommand::create(path(), x, y, z);
 }
 #endif
@@ -176,38 +170,26 @@ void UsdTransform3d::rotate(double x, double y, double z)
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:scale"));
     return UsdScaleUndoableCommand::create(path(), x, y, z);
 }
 
 #else
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd()
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate"));
     return UsdTranslateUndoableCommand::create(fItem, 0, 0, 0);
 }
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd()
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"));
     return UsdRotateUndoableCommand::create(fItem, 0, 0, 0);
 }
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd()
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:scale"));
     return UsdScaleUndoableCommand::create(fItem, 1, 1, 1);
 }
 #endif
@@ -251,9 +233,7 @@ UsdTransform3d::rotatePivotCmd(double, double, double)
 UsdTransform3d::rotatePivotTranslateCmd()
 #endif
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate:pivot"))) {
-        return nullptr;
-    }
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate:pivot"));
 
     // As of 12-Oct-2020, setting rotate pivot on command creation
     // unsupported.  Use translate() method on returned command.

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
@@ -191,38 +191,26 @@ void UsdTransform3dCommonAPI::scale(double x, double y, double z)
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dCommonAPI::translateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate"));
     return std::make_shared<CommonAPITranslateUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3dCommonAPI::rotateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"));
     return std::make_shared<CommonAPIRotateUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3dCommonAPI::scaleCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:scale"));
     return std::make_shared<CommonAPIScaleUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dCommonAPI::rotatePivotCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate:pivot"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate:pivot"));
     return std::make_shared<CommonAPIPivotUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
@@ -249,12 +237,9 @@ Ufe::Vector3d UsdTransform3dCommonAPI::scalePivot() const { return rotatePivot()
 
 Ufe::SetMatrix4dUndoableCommand::Ptr UsdTransform3dCommonAPI::setMatrixCmd(const Ufe::Matrix4d& m)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))
-        || !isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))
-        || !isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate"));
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"));
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:scale"));
     return std::make_shared<UsdSetMatrix4dUndoableCommand>(path(), m);
 }
 

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -279,28 +279,19 @@ Ufe::Vector3d UsdTransform3dMatrixOp::scale() const { return getScale(matrix());
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dMatrixOp::translateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate"));
     return std::make_shared<MatrixOpTranslateUndoableCmd>(path(), _op, UsdTimeCode::Default());
 }
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3dMatrixOp::rotateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
-        return nullptr;
-    }
-
-    return std::make_shared<MatrixOpRotateUndoableCmd>(path(), _op, UsdTimeCode::Default());
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"));
+    return nullptr;
 }
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3dMatrixOp::scaleCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:scale"));
     return std::make_shared<MatrixOpScaleUndoableCmd>(path(), _op, UsdTimeCode::Default());
 }
 

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
@@ -114,7 +114,7 @@ private:
     Ufe::TranslateUndoableCommand::Ptr
     pivotCmd(const PXR_NS::TfToken& pvtOpSuffix, double x, double y, double z);
 
-    bool isAttributeEditAllowed(const PXR_NS::TfToken attrName, std::string& errMsg) const;
+    void enforceAttributeEditAllowed(const PXR_NS::TfToken attrName) const;
 }; // UsdTransform3dMayaXformStack
 
 //! \brief Factory to create a UsdTransform3dMayaXformStack interface object.

--- a/lib/mayaUsd/ufe/UsdUndoVisibleCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoVisibleCommand.cpp
@@ -49,11 +49,7 @@ UsdUndoVisibleCommand::Ptr UsdUndoVisibleCommand::create(const UsdPrim& prim, bo
 
     EditTargetGuard guard(prim, layer);
 
-    std::string errMsg;
-    if (!MayaUsd::ufe::isAttributeEditAllowed(primImageable.GetVisibilityAttr(), &errMsg)) {
-        MGlobal::displayError(errMsg.c_str());
-        return nullptr;
-    }
+    enforceAttributeEditAllowed(primImageable.GetVisibilityAttr());
 
     return std::make_shared<UsdUndoVisibleCommand>(prim, vis, layer);
 }

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -277,7 +277,20 @@ MAYAUSD_CORE_PUBLIC
 bool isAttributeEditAllowed(const PXR_NS::UsdAttribute& attr, std::string* errMsg = nullptr);
 
 MAYAUSD_CORE_PUBLIC
+bool isAttributeEditAllowed(
+    const PXR_NS::UsdPrim& prim,
+    const PXR_NS::TfToken& attrName,
+    std::string*           errMsg = nullptr);
+
+MAYAUSD_CORE_PUBLIC
 bool isAttributeEditAllowed(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attrName);
+
+//! Enforce if an attribute value is allowed to be changed. Throw an exceptio if not allowed.
+MAYAUSD_CORE_PUBLIC
+void enforceAttributeEditAllowed(const PXR_NS::UsdAttribute& attr);
+
+MAYAUSD_CORE_PUBLIC
+void enforceAttributeEditAllowed(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attrName);
 
 //! Check if a prim metadata is allowed to be changed.
 //! Can check a specific key in a metadata dictionary, optionally, if keyPaty is not empty.


### PR DESCRIPTION
Make the transform commands propagate the errors they encounters instead of just logging them. This is necessary to make UFE composite commands work properly: they need to know that a sub-command failed and stop execution. Otherwise they just keep going and pretend they worked when they didn't, corrupting the state of USD or Maya.

- Add helper functions to enforce blocked attribute edits by throwing exception with a clear message when edits are not allowed.
- Make all transform commands enforce the blocked edits.
- This fixes the group, ungroup and parenting UFE composite commands when a subset of items cannot be modified.