### PR TITLE
MAYA-126128 transform command error reporting

### DIFF
--- a/lib/mayaUsd/ufe/UsdAttributeHolder.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributeHolder.cpp
@@ -48,11 +48,7 @@ bool setUsdAttrMetadata(
     }
 
     // If attribute is locked don't allow setting Metadata.
-    std::string errMsg;
-    const bool  isSetAttrAllowed = MayaUsd::ufe::isAttributeEditAllowed(attr, &errMsg);
-    if (!isSetAttrAllowed) {
-        throw std::runtime_error(errMsg);
-    }
+    MayaUsd::ufe::enforceAttributeEditAllowed(attr);
 
     PXR_NS::TfToken tok(key);
     if (PXR_NS::UsdShadeNodeGraph(attr.GetPrim())) {

--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -96,10 +96,7 @@ Ufe::SceneItem::Ptr UsdTransform3d::sceneItem() const { return fItem; }
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate"));
     return UsdTranslateUndoableCommand::create(path(), x, y, z);
 }
 #endif
@@ -160,10 +157,7 @@ Ufe::Vector3d UsdTransform3d::scale() const
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"));
     return UsdRotateUndoableCommand::create(path(), x, y, z);
 }
 #endif
@@ -176,38 +170,26 @@ void UsdTransform3d::rotate(double x, double y, double z)
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:scale"));
     return UsdScaleUndoableCommand::create(path(), x, y, z);
 }
 
 #else
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd()
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate"));
     return UsdTranslateUndoableCommand::create(fItem, 0, 0, 0);
 }
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd()
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"));
     return UsdRotateUndoableCommand::create(fItem, 0, 0, 0);
 }
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd()
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:scale"));
     return UsdScaleUndoableCommand::create(fItem, 1, 1, 1);
 }
 #endif
@@ -251,9 +233,7 @@ UsdTransform3d::rotatePivotCmd(double, double, double)
 UsdTransform3d::rotatePivotTranslateCmd()
 #endif
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate:pivot"))) {
-        return nullptr;
-    }
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate:pivot"));
 
     // As of 12-Oct-2020, setting rotate pivot on command creation
     // unsupported.  Use translate() method on returned command.

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
@@ -191,38 +191,26 @@ void UsdTransform3dCommonAPI::scale(double x, double y, double z)
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dCommonAPI::translateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate"));
     return std::make_shared<CommonAPITranslateUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3dCommonAPI::rotateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"));
     return std::make_shared<CommonAPIRotateUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3dCommonAPI::scaleCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:scale"));
     return std::make_shared<CommonAPIScaleUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dCommonAPI::rotatePivotCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate:pivot"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate:pivot"));
     return std::make_shared<CommonAPIPivotUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
@@ -249,12 +237,9 @@ Ufe::Vector3d UsdTransform3dCommonAPI::scalePivot() const { return rotatePivot()
 
 Ufe::SetMatrix4dUndoableCommand::Ptr UsdTransform3dCommonAPI::setMatrixCmd(const Ufe::Matrix4d& m)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))
-        || !isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))
-        || !isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate"));
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"));
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:scale"));
     return std::make_shared<UsdSetMatrix4dUndoableCommand>(path(), m);
 }
 

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -279,28 +279,19 @@ Ufe::Vector3d UsdTransform3dMatrixOp::scale() const { return getScale(matrix());
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dMatrixOp::translateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate"));
     return std::make_shared<MatrixOpTranslateUndoableCmd>(path(), _op, UsdTimeCode::Default());
 }
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3dMatrixOp::rotateCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
-        return nullptr;
-    }
-
-    return std::make_shared<MatrixOpRotateUndoableCmd>(path(), _op, UsdTimeCode::Default());
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"));
+    return nullptr;
 }
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3dMatrixOp::scaleCmd(double x, double y, double z)
 {
-    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
-        return nullptr;
-    }
-
+    enforceAttributeEditAllowed(prim(), TfToken("xformOp:scale"));
     return std::make_shared<MatrixOpScaleUndoableCmd>(path(), _op, UsdTimeCode::Default());
 }
 

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
@@ -152,6 +152,8 @@ createTransform3d(const Ufe::SceneItem::Ptr& item, NextTransform3dFn nextTransfo
     UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
 
     if (!usdItem) {
+        TF_WARN(
+            "Cannot create 3D transform for non-USD item \"%s\".", item->path().string().c_str());
         return nullptr;
     }
 
@@ -159,6 +161,9 @@ createTransform3d(const Ufe::SceneItem::Ptr& item, NextTransform3dFn nextTransfo
     // for it.
     UsdGeomXformable xformSchema(usdItem->prim());
     if (!xformSchema) {
+        TF_WARN(
+            "Cannot create 3D transform for non-transformable item \"%s\".",
+            item->path().string().c_str());
         return nullptr;
     }
     bool resetsXformStack = false;
@@ -444,12 +449,8 @@ UsdTransform3dMayaXformStack::rotateCmd(double x, double y, double z)
         attrName = op.GetOpName();
     }
 
-    // Return null command if the attribute edit is not allowed.
-    std::string errMsg;
-    if (!isAttributeEditAllowed(attrName, errMsg)) {
-        MGlobal::displayError(errMsg.c_str());
-        return nullptr;
-    }
+    // Enforce failure if the attribute edit is not allowed.
+    enforceAttributeEditAllowed(attrName);
 
     // If there is no rotate transform op, we will create a RotXYZ.
     GfVec3f           v(x, y, z);
@@ -495,12 +496,8 @@ Ufe::ScaleUndoableCommand::Ptr UsdTransform3dMayaXformStack::scaleCmd(double x, 
         attrName = op.GetOpName();
     }
 
-    // Return null command if the attribute edit is not allowed.
-    std::string errMsg;
-    if (!isAttributeEditAllowed(attrName, errMsg)) {
-        MGlobal::displayError(errMsg.c_str());
-        return nullptr;
-    }
+    // Enforce failure if the attribute edit is not allowed.
+    enforceAttributeEditAllowed(attrName);
 
     GfVec3f v(x, y, z);
     auto    f = OpFunc(
@@ -608,12 +605,8 @@ Ufe::SetVector3dUndoableCommand::Ptr UsdTransform3dMayaXformStack::setVector3dCm
     const TfToken& attrName,
     const TfToken& opSuffix)
 {
-    // Return null command if the attribute edit is not allowed.
-    std::string errMsg;
-    if (!isAttributeEditAllowed(attrName, errMsg)) {
-        MGlobal::displayError(errMsg.c_str());
-        return nullptr;
-    }
+    // Enforce failure if the attribute edit is not allowed.
+    enforceAttributeEditAllowed(attrName);
 
     auto setXformOpOrderFn = getXformOpOrderFn();
     auto f = OpFunc(
@@ -651,12 +644,8 @@ UsdTransform3dMayaXformStack::pivotCmd(const TfToken& pvtOpSuffix, double x, dou
 {
     auto pvtAttrName = UsdGeomXformOp::GetOpName(UsdGeomXformOp::TypeTranslate, pvtOpSuffix);
 
-    // Return null command if the attribute edit is not allowed.
-    std::string errMsg;
-    if (!isAttributeEditAllowed(pvtAttrName, errMsg)) {
-        MGlobal::displayError(errMsg.c_str());
-        return nullptr;
-    }
+    // Enforce failure if the attribute edit is not allowed.
+    enforceAttributeEditAllowed(pvtAttrName);
 
     GfVec3f v(x, y, z);
     auto    f = OpFunc([pvtAttrName, pvtOpSuffix, setXformOpOrderFn = getXformOpOrderFn(), v](
@@ -775,22 +764,17 @@ UsdTransform3dMayaXformStack::getCvtRotXYZToAttrFn(const TfToken& opName) const
     return cvt.at(opName);
 }
 
-bool UsdTransform3dMayaXformStack::isAttributeEditAllowed(
-    const PXR_NS::TfToken attrName,
-    std::string&          errMsg) const
+void UsdTransform3dMayaXformStack::enforceAttributeEditAllowed(const PXR_NS::TfToken attrName) const
 {
     PXR_NS::UsdAttribute attr;
     if (!attrName.IsEmpty())
         attr = prim().GetAttribute(attrName);
-    if (attr && !MayaUsd::ufe::isAttributeEditAllowed(attr, &errMsg)) {
-        return false;
-    } else if (!attr) {
+    if (attr) {
+        MayaUsd::ufe::enforceAttributeEditAllowed(attr);
+    } else {
         UsdGeomXformable xformable(prim());
-        if (!MayaUsd::ufe::isAttributeEditAllowed(xformable.GetXformOpOrderAttr(), &errMsg)) {
-            return false;
-        }
+        MayaUsd::ufe::enforceAttributeEditAllowed(xformable.GetXformOpOrderAttr());
     }
-    return true;
 }
 
 //------------------------------------------------------------------------------
@@ -831,17 +815,18 @@ Ufe::Transform3d::Ptr UsdTransform3dMayaXformStackHandler::editTransform3d(
     // https://graphics.pixar.com/usd/docs/api/_usd__page__scenegraph_instancing.html#Usd_ScenegraphInstancing_InstanceProxies
     UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
     if (usdItem->prim().IsInstanceProxy()) {
-        MGlobal::displayError(
-            MString("Authoring to the descendant of an instance [")
-            + MString(usdItem->prim().GetName().GetString().c_str()) + MString("] is not allowed. ")
-            + MString("Please mark 'instanceable=false' to author edits to instance proxies."));
-        return nullptr;
+        const std::string error = TfStringPrintf(
+            "Authoring to the descendant of an instance \"%s\" is not allowed. "
+            "Please mark 'instanceable=false' to author edits to instance proxies.",
+            usdItem->prim().GetName().GetString().c_str());
+        TF_WARN("%s", error.c_str());
+        throw std::runtime_error(error);
     }
 
     std::string errMsg;
     if (!MayaUsd::ufe::isEditTargetLayerModifiable(usdItem->prim().GetStage(), &errMsg)) {
-        MGlobal::displayError(errMsg.c_str());
-        return nullptr;
+        TF_WARN("%s", errMsg.c_str());
+        throw std::runtime_error(errMsg);
     }
 
     return createTransform3d(

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
@@ -114,7 +114,7 @@ private:
     Ufe::TranslateUndoableCommand::Ptr
     pivotCmd(const PXR_NS::TfToken& pvtOpSuffix, double x, double y, double z);
 
-    bool isAttributeEditAllowed(const PXR_NS::TfToken attrName, std::string& errMsg) const;
+    void enforceAttributeEditAllowed(const PXR_NS::TfToken attrName) const;
 }; // UsdTransform3dMayaXformStack
 
 //! \brief Factory to create a UsdTransform3dMayaXformStack interface object.

--- a/lib/mayaUsd/ufe/UsdUndoVisibleCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoVisibleCommand.cpp
@@ -49,11 +49,7 @@ UsdUndoVisibleCommand::Ptr UsdUndoVisibleCommand::create(const UsdPrim& prim, bo
 
     EditTargetGuard guard(prim, layer);
 
-    std::string errMsg;
-    if (!MayaUsd::ufe::isAttributeEditAllowed(primImageable.GetVisibilityAttr(), &errMsg)) {
-        MGlobal::displayError(errMsg.c_str());
-        return nullptr;
-    }
+    enforceAttributeEditAllowed(primImageable.GetVisibilityAttr());
 
     return std::make_shared<UsdUndoVisibleCommand>(prim, vis, layer);
 }

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -277,7 +277,20 @@ MAYAUSD_CORE_PUBLIC
 bool isAttributeEditAllowed(const PXR_NS::UsdAttribute& attr, std::string* errMsg = nullptr);
 
 MAYAUSD_CORE_PUBLIC
+bool isAttributeEditAllowed(
+    const PXR_NS::UsdPrim& prim,
+    const PXR_NS::TfToken& attrName,
+    std::string*           errMsg = nullptr);
+
+MAYAUSD_CORE_PUBLIC
 bool isAttributeEditAllowed(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attrName);
+
+//! Enforce if an attribute value is allowed to be changed. Throw an exceptio if not allowed.
+MAYAUSD_CORE_PUBLIC
+void enforceAttributeEditAllowed(const PXR_NS::UsdAttribute& attr);
+
+MAYAUSD_CORE_PUBLIC
+void enforceAttributeEditAllowed(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attrName);
 
 //! Check if a prim metadata is allowed to be changed.
 //! Can check a specific key in a metadata dictionary, optionally, if keyPaty is not empty.

--- a/test/lib/ufe/testBlockedLayerEdit.py
+++ b/test/lib/ufe/testBlockedLayerEdit.py
@@ -100,9 +100,12 @@ class BlockedLayerEditTestCase(unittest.TestCase):
         cylinderItem = ufe.Hierarchy.createItem(cylinderPath)
 
         cylinderT3d = ufe.Transform3d.transform3d(cylinderItem)
-        with self.assertRaises(RuntimeError):
+        # Note: pre-UFE v2, no exception is raised.
+        try:
             if cylinderT3d is not None:
                 cylinderT3d.translate(5.0, 6.0, 7.0)
+        except RuntimeError:
+            pass
 
         # check that the translate operation didn't change anything
         tranlateAfterEdit = translateAttr.Get()
@@ -155,9 +158,12 @@ class BlockedLayerEditTestCase(unittest.TestCase):
         cylinderItem = ufe.Hierarchy.createItem(cylinderPath)
 
         cylinderT3d = ufe.Transform3d.transform3d(cylinderItem)
-        with self.assertRaises(RuntimeError):
+        # Note: pre-UFE v2, no exception is raised.
+        try:
             if cylinderT3d is not None:
                 cylinderT3d.translate(5.0, 6.0, 7.0)
+        except RuntimeError:
+            pass
 
         # check that the translate operation didn't change anything
         tranlateAfterEdit = translateAttr.Get()

--- a/test/lib/ufe/testBlockedLayerEdit.py
+++ b/test/lib/ufe/testBlockedLayerEdit.py
@@ -100,8 +100,9 @@ class BlockedLayerEditTestCase(unittest.TestCase):
         cylinderItem = ufe.Hierarchy.createItem(cylinderPath)
 
         cylinderT3d = ufe.Transform3d.transform3d(cylinderItem)
-        if cylinderT3d is not None:
-            cylinderT3d.translate(5.0, 6.0, 7.0)
+        with self.assertRaises(RuntimeError):
+            if cylinderT3d is not None:
+                cylinderT3d.translate(5.0, 6.0, 7.0)
 
         # check that the translate operation didn't change anything
         tranlateAfterEdit = translateAttr.Get()
@@ -154,8 +155,9 @@ class BlockedLayerEditTestCase(unittest.TestCase):
         cylinderItem = ufe.Hierarchy.createItem(cylinderPath)
 
         cylinderT3d = ufe.Transform3d.transform3d(cylinderItem)
-        if cylinderT3d is not None:
-            cylinderT3d.translate(5.0, 6.0, 7.0)
+        with self.assertRaises(RuntimeError):
+            if cylinderT3d is not None:
+                cylinderT3d.translate(5.0, 6.0, 7.0)
 
         # check that the translate operation didn't change anything
         tranlateAfterEdit = translateAttr.Get()

--- a/test/lib/ufe/testGroupCmd.py
+++ b/test/lib/ufe/testGroupCmd.py
@@ -554,17 +554,16 @@ class GroupCmdTestCase(unittest.TestCase):
             self.assertIsNotNone(item)
             return item
 
-        def applyRotation(item, rotation):
-            itemTrf = ufe.Transform3d.transform3d(item)
-            itemTrf.rotate(*rotation)
-            itemTrf = None
+        def applyRadius(item, radius):
+            radAttr = ufe.Attributes.attributes(item).attribute('radius')
+            radAttr.set(radius)
 
-        def verifyRotation(item, rotation):
-            itemTrf = ufe.Transform3d.transform3d(item)
-            self.assertEqual(itemTrf.rotation(), ufe.PyUfe.Vector3d(*rotation))
+        def verifyRadius(item, radius):
+            radAttr = ufe.Attributes.attributes(item).attribute('radius')
+            self.assertEqual(radAttr.get(), radius)
 
         # Some values used during the test
-        rotation = [30., 20., 10.]
+        radius = 30.
         oldSphere1Name = '/Sphere1'
         newSphere1Name = '/group1/Sphere1'
 
@@ -584,8 +583,8 @@ class GroupCmdTestCase(unittest.TestCase):
         stage.SetEditTarget(stage.GetSessionLayer())
         self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetSessionLayer())
 
-        applyRotation(getItem(oldSphere1Name), rotation)
-        verifyRotation(getItem(oldSphere1Name), rotation)
+        applyRadius(getItem(oldSphere1Name), radius)
+        verifyRadius(getItem(oldSphere1Name), radius)
 
         # Group Sphere1, Sphere2, and Sphere3 in the root layer
         stage.SetEditTarget(stage.GetRootLayer())
@@ -606,7 +605,7 @@ class GroupCmdTestCase(unittest.TestCase):
             stage.GetPrimAtPath("/group1/Sphere2"),
             stage.GetPrimAtPath("/group1/Sphere3")])
         
-        verifyRotation(getItem(newSphere1Name), rotation)
+        verifyRadius(getItem(newSphere1Name), radius)
 
         cmds.undo()
 
@@ -615,7 +614,7 @@ class GroupCmdTestCase(unittest.TestCase):
             stage.GetPrimAtPath("/Sphere2"),
             stage.GetPrimAtPath("/Sphere1")])
 
-        verifyRotation(getItem(oldSphere1Name), rotation)
+        verifyRadius(getItem(oldSphere1Name), radius)
 
         cmds.redo()
 
@@ -625,7 +624,7 @@ class GroupCmdTestCase(unittest.TestCase):
             stage.GetPrimAtPath("/group1/Sphere2"),
             stage.GetPrimAtPath("/group1/Sphere3")])
 
-        verifyRotation(getItem(newSphere1Name), rotation)
+        verifyRadius(getItem(newSphere1Name), radius)
 
     @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 3, 'testGroupUndoRedo is only available in UFE v3 or greater.')
     def testGroupPreserveLoadRules(self):


### PR DESCRIPTION
Make the transform commands propagate the errors they encounters instead of just logging them. This is necessary to make UFE composite commands work properly: they need to know that a sub-command failed and stop execution. Otherwise they just keep going and pretend they worked when they didn't, corrupting the state of USD or Maya.

- Add helper functions to enforce blocked attribute edits by throwing exception with a clear message when edits are not allowed.
- Make all transform commands enforce the blocked edits.
- This fixes the group, ungroup and parenting UFE composite commands when a subset of items cannot be modified.