### PR TITLE
Add a getter and a setter for enableMaterials in HdMayaSceneDelegate

### DIFF
--- a/lib/usd/hdMaya/delegates/sceneDelegate.h
+++ b/lib/usd/hdMaya/delegates/sceneDelegate.h
@@ -132,6 +132,9 @@ public:
         MPointArray&                     worldSpaceHitPts) override;
 #endif
 
+    bool GetEnableMaterials() const { return _enableMaterials; }
+    void SetEnableMaterials(bool enable) { _enableMaterials = enable; }
+
 protected:
     HDMAYA_API
     HdMeshTopology GetMeshTopology(const SdfPath& id) override;


### PR DESCRIPTION
Hello!
We are working on our custom render delegate and production render mode and would like to add getter and setter functions to be able to reuse the code from MtoH.
Actually, we need only setter for now, but probably its ok to add a getter as well to get full control over the variable.
Thank you!

