### PR TITLE
Added applyEulerFilter to import

### DIFF
--- a/lib/mayaUsd/commands/baseImportCommand.cpp
+++ b/lib/mayaUsd/commands/baseImportCommand.cpp
@@ -95,6 +95,11 @@ MSyntax MayaUSDImportCommand::createSyntax()
         MSyntax::kString);
     syntax.makeFlagMultiUse(kImportChaserArgsFlag);
 
+    syntax.addFlag(
+        kApplyEulerFilterFlag,
+        UsdMayaJobImportArgsTokens->applyEulerFilter.GetText(),
+        MSyntax::kBoolean);
+
     // These are additional flags under our control.
     syntax.addFlag(kFileFlag, kFileFlagLong, MSyntax::kString);
     syntax.addFlag(kParentFlag, kParentFlagLong, MSyntax::kString);

--- a/lib/mayaUsd/commands/baseImportCommand.h
+++ b/lib/mayaUsd/commands/baseImportCommand.h
@@ -52,6 +52,7 @@ public:
     static constexpr auto kUseAsAnimationCacheFlag = "uac";
     static constexpr auto kImportChaserFlag = "chr";
     static constexpr auto kImportChaserArgsFlag = "cha";
+    static constexpr auto kApplyEulerFilterFlag = "aef";
 
     // Short and Long forms of flags defined by this command itself:
     static constexpr auto kFileFlag = "f";

--- a/lib/mayaUsd/fileio/importData.cpp
+++ b/lib/mayaUsd/fileio/importData.cpp
@@ -30,6 +30,7 @@ ImportData::ImportData()
     , fRootPrimPath(kRootPrimPath)
     , fPrimsInScopeCount(0)
     , fSwitchedVariantCount(0)
+    , fApplyEulerFilter(false)
 {
 }
 
@@ -39,6 +40,7 @@ ImportData::ImportData(const std::string& f)
     , fFilename(f)
     , fPrimsInScopeCount(0)
     , fSwitchedVariantCount(0)
+    , fApplyEulerFilter(false)
 {
 }
 
@@ -87,6 +89,10 @@ const std::string& ImportData::rootPrimPath() const { return fRootPrimPath; }
 void ImportData::setRootPrimPath(const std::string& primPath) { fRootPrimPath = primPath; }
 
 bool ImportData::hasPopulationMask() const { return !fPopMask.IsEmpty(); }
+
+void ImportData::setApplyEulerFilter(bool value) { fApplyEulerFilter = value; }
+
+bool ImportData::applyEulerFilter() const { return fApplyEulerFilter; }
 
 const UsdStagePopulationMask& ImportData::stagePopulationMask() const { return fPopMask; }
 

--- a/lib/mayaUsd/fileio/importData.h
+++ b/lib/mayaUsd/fileio/importData.h
@@ -77,6 +77,12 @@ public:
     //! \return True if the USD population mask is not empty.
     bool hasPopulationMask() const;
 
+    //! Apply euler filter to imported rotation animCurves
+    void setApplyEulerFilter(bool value);
+
+    //! \return True if the imported rotation curves should be euler filtered
+    bool applyEulerFilter() const;
+
     //! \return The USD population mask of the stage to use for import.
     const UsdStagePopulationMask& stagePopulationMask() const;
 
@@ -134,8 +140,9 @@ private:
     std::string              fRootPrimPath;
     std::string              fFilename;
 
-    int fPrimsInScopeCount;
-    int fSwitchedVariantCount;
+    int  fPrimsInScopeCount;
+    int  fSwitchedVariantCount;
+    bool fApplyEulerFilter;
 };
 
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -1112,6 +1112,7 @@ UsdMayaJobImportArgs::UsdMayaJobImportArgs(
     , useAsAnimationCache(extractBoolean(userArgs, UsdMayaJobImportArgsTokens->useAsAnimationCache))
     , importWithProxyShapes(importWithProxyShapes)
     , preserveTimeline(extractBoolean(userArgs, UsdMayaJobImportArgsTokens->preserveTimeline))
+    , applyEulerFilter(extractBoolean(userArgs, UsdMayaJobImportArgsTokens->applyEulerFilter))
     , pullImportStage(extractUsdStageRefPtr(userArgs, UsdMayaJobImportArgsTokens->pullImportStage))
     , timeInterval(timeInterval)
     , chaserNames(extractVector<std::string>(userArgs, UsdMayaJobImportArgsTokens->chaser))
@@ -1169,6 +1170,7 @@ const VtDictionary& UsdMayaJobImportArgs::GetDefaultDictionary()
         d[UsdMayaJobImportArgsTokens->preserveTimeline] = false;
         d[UsdMayaJobExportArgsTokens->chaser] = std::vector<VtValue>();
         d[UsdMayaJobExportArgsTokens->chaserArgs] = std::vector<VtValue>();
+        d[UsdMayaJobImportArgsTokens->applyEulerFilter] = false;
 
         // plugInfo.json site defaults.
         // The defaults dict should be correctly-typed, so enable
@@ -1247,6 +1249,7 @@ const VtDictionary& UsdMayaJobImportArgs::GetGuideDictionary()
         d[UsdMayaJobImportArgsTokens->preserveTimeline] = _boolean;
         d[UsdMayaJobExportArgsTokens->chaser] = _stringVector;
         d[UsdMayaJobExportArgsTokens->chaserArgs] = _stringTripletVector;
+        d[UsdMayaJobImportArgsTokens->applyEulerFilter] = _boolean;
     });
 
     return d;
@@ -1333,8 +1336,8 @@ std::ostream& operator<<(std::ostream& out, const UsdMayaJobImportArgs& importAr
         << std::endl
         << "timeInterval: " << importArgs.timeInterval << std::endl
         << "useAsAnimationCache: " << TfStringify(importArgs.useAsAnimationCache) << std::endl
-        << "preserveTimeline: " << TfStringify(importArgs.preserveTimeline) << std::endl
-        << "importWithProxyShapes: " << TfStringify(importArgs.importWithProxyShapes) << std::endl;
+        << "importWithProxyShapes: " << TfStringify(importArgs.importWithProxyShapes) << std::endl
+        << "applyEulerFilter: " << importArgs.applyEulerFilter << std::endl;
 
     out << "jobContextNames (" << importArgs.jobContextNames.size() << ")" << std::endl;
     for (const std::string& jobContextName : importArgs.jobContextNames) {

--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -1336,6 +1336,7 @@ std::ostream& operator<<(std::ostream& out, const UsdMayaJobImportArgs& importAr
         << std::endl
         << "timeInterval: " << importArgs.timeInterval << std::endl
         << "useAsAnimationCache: " << TfStringify(importArgs.useAsAnimationCache) << std::endl
+        << "preserveTimeline: " << TfStringify(importArgs.preserveTimeline) << std::endl
         << "importWithProxyShapes: " << TfStringify(importArgs.importWithProxyShapes) << std::endl
         << "applyEulerFilter: " << importArgs.applyEulerFilter << std::endl;
 

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -155,7 +155,8 @@ TF_DECLARE_PUBLIC_TOKENS(
     (Import) \
     ((Unloaded, "")) \
     (chaser) \
-    (chaserArgs)
+    (chaserArgs) \
+    (applyEulerFilter)
 // clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(
@@ -338,6 +339,7 @@ struct UsdMayaJobImportArgs
     const bool           useAsAnimationCache;
     const bool           importWithProxyShapes;
     const bool           preserveTimeline;
+    const bool           applyEulerFilter;
     const UsdStageRefPtr pullImportStage;
     /// The interval over which to import animated data.
     /// An empty interval (<tt>GfInterval::IsEmpty()</tt>) means that no

--- a/lib/mayaUsd/fileio/translators/translatorSkel.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorSkel.cpp
@@ -284,6 +284,20 @@ bool _SetTransformAnim(
                     transformNode, _MayaTokens->scales[c], scales[c], times, context, discard)) {
                 return false;
             }
+            if (!rotCurve.isNull())
+                curves.append(rotCurve);
+        }
+        // This feels hacky, but I couldn't find a C++ api method for running the
+        if (applyEulerFilter && curves.length() == 3) {
+            std::ostringstream cmd;
+            cmd << "filterCurve";
+            for (unsigned i = 0; i < 3; ++i) {
+                MFnDependencyNode fn(curves[i]);
+                cmd << " " << fn.name();
+            }
+            cmd << ";";
+            // MGlobal::displayWarning(cmd.str().c_str());
+            MGlobal::executeCommand(cmd.str().c_str(), false);
         }
     } else {
         const auto& xform = xforms.front();

--- a/lib/mayaUsd/fileio/translators/translatorSkel.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorSkel.cpp
@@ -269,8 +269,7 @@ bool _SetTransformAnim(
 
         for (int c = 0; c < 3; ++c) {
             if (!_SetAnimPlugData(
-                    transformNode, _MayaTokens->translates[c],
-  translates[c], times, context)
+                    transformNode, _MayaTokens->translates[c], translates[c], times, context)
                 || !_SetAnimPlugData(
                     transformNode, _MayaTokens->rotates[c], rotates[c], times, context)
                 || !_SetAnimPlugData(
@@ -521,8 +520,12 @@ bool _CopyAnimFromSkel(
         MFnDependencyNode skelXformDep(jointContainer, &status);
         CHECK_MSTATUS_AND_RETURN(status, false);
 
-        if (!_SetTransformAnim(skelXformDep, skelLocalXforms,
-  mayaTimes, context, args.GetJobArguments().applyEulerFilter)) {
+        if (!_SetTransformAnim(
+                skelXformDep,
+                skelLocalXforms,
+                mayaTimes,
+                context,
+                args.GetJobArguments().applyEulerFilter)) {
             return false;
         }
     }
@@ -560,8 +563,8 @@ bool _CopyAnimFromSkel(
             xforms[i] = samples[i][jointIdx];
         }
 
-        if (!_SetTransformAnim(jointDep, xforms, mayaTimes, 
-  context, args.GetJobArguments().applyEulerFilter))
+        if (!_SetTransformAnim(
+                jointDep, xforms, mayaTimes, context, args.GetJobArguments().applyEulerFilter))
             return false;
     }
     return true;

--- a/lib/mayaUsd/fileio/translators/translatorSkel.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorSkel.cpp
@@ -181,8 +181,7 @@ bool _SetAnimPlugData(
     const MString&                  attr,
     MDoubleArray&                   values,
     MTimeArray&                     times,
-    const UsdMayaPrimReaderContext* context
-    )
+    const UsdMayaPrimReaderContext* context)
 {
     MStatus status;
 
@@ -195,7 +194,7 @@ bool _SetAnimPlugData(
     }
 
     MFnAnimCurve animFn;
-    MObject animObj = animFn.create(plug, nullptr, &status);
+    MObject      animObj = animFn.create(plug, nullptr, &status);
     CHECK_MSTATUS_AND_RETURN(status, false);
 
     // XXX: Why do the input arrays need to be mutable here?
@@ -270,11 +269,8 @@ bool _SetTransformAnim(
 
         for (int c = 0; c < 3; ++c) {
             if (!_SetAnimPlugData(
-                    transformNode,
-                    _MayaTokens->translates[c],
-                    translates[c],
-                    times,
-                    context)
+                    transformNode, _MayaTokens->translates[c],
+  translates[c], times, context)
                 || !_SetAnimPlugData(
                     transformNode, _MayaTokens->rotates[c], rotates[c], times, context)
                 || !_SetAnimPlugData(
@@ -525,12 +521,8 @@ bool _CopyAnimFromSkel(
         MFnDependencyNode skelXformDep(jointContainer, &status);
         CHECK_MSTATUS_AND_RETURN(status, false);
 
-        if (!_SetTransformAnim(
-                skelXformDep,
-                skelLocalXforms,
-                mayaTimes,
-                context,
-                args.GetJobArguments().applyEulerFilter)) {
+        if (!_SetTransformAnim(skelXformDep, skelLocalXforms,
+  mayaTimes, context, args.GetJobArguments().applyEulerFilter)) {
             return false;
         }
     }
@@ -568,8 +560,8 @@ bool _CopyAnimFromSkel(
             xforms[i] = samples[i][jointIdx];
         }
 
-        if (!_SetTransformAnim(
-                jointDep, xforms, mayaTimes, context, args.GetJobArguments().applyEulerFilter))
+        if (!_SetTransformAnim(jointDep, xforms, mayaTimes, 
+  context, args.GetJobArguments().applyEulerFilter))
             return false;
     }
     return true;

--- a/lib/mayaUsd/fileio/translators/translatorXformable.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorXformable.cpp
@@ -207,7 +207,7 @@ static void _setMayaAttribute(
         if (!plg.isNull()) {
             plg.setDouble(xVal[0]);
             if (xVal.size() > 1 && (applyEulerFilter || _isArrayVarying(xVal))) {
-                MObject curve = _setAnimPlugData(plg, xVal, timeArray, context);
+                _setAnimPlugData(plg, xVal, timeArray, context);
             }
         }
     }
@@ -216,7 +216,7 @@ static void _setMayaAttribute(
         if (!plg.isNull()) {
             plg.setDouble(yVal[0]);
             if (yVal.size() > 1 && (applyEulerFilter || _isArrayVarying(yVal))) {
-                MObject curve = _setAnimPlugData(plg, yVal, timeArray, context);
+                _setAnimPlugData(plg, yVal, timeArray, context);
             }
         }
     }
@@ -225,7 +225,7 @@ static void _setMayaAttribute(
         if (!plg.isNull()) {
             plg.setDouble(zVal[0]);
             if (zVal.size() > 1 && (applyEulerFilter || _isArrayVarying(zVal))) {
-                MObject curve = _setAnimPlugData(plg, zVal, timeArray, context);
+                _setAnimPlugData(plg, zVal, timeArray, context);
             }
         }
     }

--- a/plugin/adsk/plugin/importTranslator.cpp
+++ b/plugin/adsk/plugin/importTranslator.cpp
@@ -97,6 +97,8 @@ MStatus UsdMayaImportTranslator::reader(
                 timeInterval.SetMax(theOption[1].asDouble());
             } else if (argName == "primPath") {
                 importData.setRootPrimPath(theOption[1].asChar());
+            } else if (argName == "applyEulerFilter") {
+                importData.setApplyEulerFilter(theOption[1].asInt() != 0);
             } else {
                 userArgs[argName] = UsdMayaUtil::ParseArgumentValue(
                     argName, theOption[1].asChar(), UsdMayaJobImportArgs::GetGuideDictionary());

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -76,6 +76,7 @@ set(TEST_SCRIPT_FILES
     testUsdImportSkeleton.py
     testUsdImportXforms.py
     testUsdImportXformAnim.py
+    testUsdImportEulerFilter.py
     testUsdMayaAdaptor.py
     testUsdMayaAdaptorGeom.py
     testUsdMayaAdaptorMetadata.py

--- a/test/lib/usd/translators/testUsdImportEulerFilter.py
+++ b/test/lib/usd/translators/testUsdImportEulerFilter.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env mayapy
+#
+# Copyright 2023 Apple Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import unittest
+
+from maya import cmds
+from maya import standalone
+
+from pxr import Usd
+
+import fixturesUtils
+
+def write_usd_source_file(out_file):
+    stage = Usd.Stage.CreateNew(out_file)
+
+
+def build_skel_scene(out_file):
+    cmds.file(f=1, new=1)
+    cmds.createNode('transform', name='group')
+    cmds.joint()
+    cmds.joint(p=(0.0, 2.154, 0.0,))
+    
+    cmds.select(cl=1)
+    cmds.polyPlane(sh=1, sw=1)
+    cmds.parent('pPlane1', 'group')
+    cmds.skinCluster('joint1', 'pPlane1')
+
+    cmds.setKeyframe('joint1.rx', 'joint1.rz', v=0.0, t=[1])
+    cmds.setKeyframe('joint1.rx', 'joint1.rz', v=180.0, t=[2])
+
+    cmds.setKeyframe('joint1.ry', v=-85.968, t=[1])
+    cmds.setKeyframe('joint1.ry', v=-85.127, t=[2])
+    
+    cmds.mayaUSDExport(file=out_file, skl='auto', skn='auto', fr=[1,2])
+    
+    
+
+def build_xform_scene(out_file):
+    cmds.file(f=1, new=1)
+    cmds.polyCube()
+
+    cmds.setKeyframe('pCube1.rx', 'pCube1.rz', v=0.0, t=[1])
+    cmds.setKeyframe('pCube1.rx', 'pCube1.rz', v=180.0, t=[2])
+
+    cmds.setKeyframe('pCube1.ry', v=-85.968, t=[1])
+    cmds.setKeyframe('pCube1.ry', v=-85.127, t=[2])
+
+    cmds.mayaUSDExport(file=out_file, fr=[1,2])
+
+
+class testUsdImportEulerFilter(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        inputPath = fixturesUtils.setUpClass(__file__)
+
+        cls.skel_file = os.path.join(inputPath, "UsdImportEulerFilterTest", "UsdImportEulerFilterTest_skel.usda")
+        
+        build_skel_scene(cls.skel_file)
+
+        cls.xform_file = os.path.join(inputPath, "UsdImportEulerFilterTest", "UsdImportEulerFilterTest_xform.usda")
+        build_xform_scene(cls.xform_file)
+
+    def test_skel_rotation_fail(self):
+        """The original behaviour should not correct euler angles on import"""
+        cmds.file(f=1, new=1)
+        cmds.mayaUSDImport(file=self.skel_file, ani=1)
+
+        values =  cmds.keyframe('joint1.rx', q=1, vc=1)
+        self.assertNotAlmostEqual(0.0, values[-1])
+
+    def test_xform_rotation_fail(self):
+        """The original behaviour should not correct euler angles on import"""
+        cmds.file(f=1, new=1)
+        cmds.mayaUSDImport(file=self.xform_file, ani=1)
+
+        values =  cmds.keyframe('pCube1.rx', q=1, vc=1)
+        self.assertNotAlmostEqual(0.0, values[-1])
+
+
+    def test_skel_rotation(self):
+        """Test that the channels on the imported joints have been euler filtered"""
+        cmds.file(f=1, new=1)
+        cmds.mayaUSDImport(file=self.skel_file, ani=1, aef=1)
+
+        values =  cmds.keyframe('joint1.rx', q=1, vc=1)
+        self.assertAlmostEqual(0.0, values[-1])
+
+    def test_xform_rotation(self):
+        """Test that the channels on the imported transforms have been euler filtered"""
+        cmds.file(f=1, new=1)
+        cmds.mayaUSDImport(file=self.xform_file, ani=1, aef=1)
+
+        values =  cmds.keyframe('pCube1.rx', q=1, vc=1)
+        self.assertAlmostEqual(0.0, values[-1])
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
It has proven useful to allow the Euler filtering of rotational animation on import as well as export. This P/R adds a flag `aef/applyEulerFilter` flag to `mayaUSDImport` that applies Euler filtering for transform and skeletal animation data.