### PR TITLE
MAYA-127758 add edit routing for attributes

### DIFF
--- a/lib/mayaUsd/python/wrapEditRouter.cpp
+++ b/lib/mayaUsd/python/wrapEditRouter.cpp
@@ -15,6 +15,7 @@
 //
 #include <mayaUsd/utils/editRouter.h>
 
+#include <pxr/base/tf/pyError.h>
 #include <pxr/base/tf/pyLock.h>
 
 #include <boost/python.hpp>
@@ -25,6 +26,22 @@
 using namespace boost::python;
 
 namespace {
+
+std::string handlePythonException()
+{
+    PyObject* exc = nullptr;
+    PyObject* val = nullptr;
+    PyObject* tb = nullptr;
+    PyErr_Fetch(&exc, &val, &tb);
+    handle<> hexc(exc);
+    handle<> hval(allow_null(val));
+    handle<> htb(allow_null(tb));
+    object   traceback(import("traceback"));
+    object   format_exception_only(traceback.attr("format_exception_only"));
+    object   formatted_list = format_exception_only(hexc, hval);
+    object   formatted = str("\n").join(formatted_list);
+    return extract<std::string>(formatted);
+}
 
 class PyEditRouter : public MayaUsd::EditRouter
 {
@@ -38,20 +55,30 @@ public:
 
     void operator()(const PXR_NS::VtDictionary& context, PXR_NS::VtDictionary& routingData) override
     {
+        // Note: necessary to compile the TF_WARN macro as it refers to USD types without using
+        //       the namespace prefix.
+        PXR_NAMESPACE_USING_DIRECTIVE;
+
         PXR_NS::TfPyLock pyLock;
         if (!PyCallable_Check(_pyCb)) {
             return;
         }
+        boost::python::object dictObject(routingData);
         try {
-            boost::python::object dictObject(routingData);
             call<void>(_pyCb, context, dictObject);
-            boost::python::extract<PXR_NS::VtDictionary> extractedDict(dictObject);
-            if (extractedDict.check()) {
-                routingData = extractedDict;
-            }
-        } catch (const error_already_set&) {
-            std::cout << "Python exception raised in call() of Python callback." << std::endl;
-            PyErr_Print();
+        } catch (const boost::python::error_already_set&) {
+            const std::string errorMessage = handlePythonException();
+            boost::python::handle_exception();
+            PyErr_Clear();
+            TF_WARN("%s", errorMessage.c_str());
+            throw std::runtime_error(errorMessage);
+        } catch (const std::exception& ex) {
+            TF_WARN("%s", ex.what());
+            throw;
+        }
+        boost::python::extract<PXR_NS::VtDictionary> extractedDict(dictObject);
+        if (extractedDict.check()) {
+            routingData = extractedDict;
         }
     }
 

--- a/lib/mayaUsd/python/wrapEditRouter.cpp
+++ b/lib/mayaUsd/python/wrapEditRouter.cpp
@@ -103,4 +103,6 @@ void wrapEditRouter()
         });
 
     def("restoreDefaultEditRouter", &MayaUsd::restoreDefaultEditRouter);
+
+    def("restoreAllDefaultEditRouters", &MayaUsd::restoreAllDefaultEditRouters);
 }

--- a/lib/mayaUsd/ufe/Global.cpp
+++ b/lib/mayaUsd/ufe/Global.cpp
@@ -302,10 +302,7 @@ MStatus initialize()
     UFE_V2(Ufe::PathString::registerPathComponentSeparator(g_USDRtid, '/');)
 
     // Initialize edit router registry with default routers.
-    auto defaults = defaultEditRouters();
-    for (const auto& entry : defaults) {
-        registerEditRouter(entry.first, entry.second);
-    }
+    restoreAllDefaultEditRouters();
 
     gExitingCbId = MSceneMessage::addCallback(MSceneMessage::kMayaExiting, exitingCallback);
 

--- a/lib/mayaUsd/ufe/UsdAttributeHolder.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributeHolder.cpp
@@ -116,6 +116,10 @@ UsdAttributeHolder::UPtr UsdAttributeHolder::create(const PXR_NS::UsdAttribute& 
 std::string UsdAttributeHolder::isEditAllowedMsg() const
 {
     if (isValid()) {
+        PXR_NS::UsdPrim        prim = _usdAttr.GetPrim();
+        PXR_NS::SdfLayerHandle layer = getAttrEditRouterLayer(prim, _usdAttr.GetName());
+        PXR_NS::UsdEditContext ctx(prim.GetStage(), layer);
+
         std::string errMsg;
         isAttributeEditAllowed(_usdAttr, &errMsg);
         return errMsg;

--- a/lib/mayaUsd/ufe/UsdAttributeHolder.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributeHolder.cpp
@@ -17,6 +17,7 @@
 
 #include "Utils.h"
 
+#include <mayaUsd/utils/editRouter.h>
 #include <mayaUsd/utils/util.h>
 #ifdef UFE_V3_FEATURES_AVAILABLE
 #include <mayaUsd/base/tokens.h>
@@ -26,6 +27,11 @@
 #include <pxr/base/tf/token.h>
 #include <pxr/base/vt/value.h>
 #include <pxr/pxr.h>
+#include <pxr/usd/usd/editContext.h>
+#include <pxr/usd/usd/stage.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
 
 namespace {
 #ifdef UFE_V3_FEATURES_AVAILABLE
@@ -48,7 +54,11 @@ bool setUsdAttrMetadata(
     }
 
     // If attribute is locked don't allow setting Metadata.
-    MayaUsd::ufe::enforceAttributeEditAllowed(attr);
+    enforceAttributeEditAllowed(attr);
+
+    PXR_NS::UsdPrim        prim = attr.GetPrim();
+    PXR_NS::SdfLayerHandle layer = getAttrEditRouterLayer(prim, attr.GetName());
+    PXR_NS::UsdEditContext ctx(prim.GetStage(), layer);
 
     PXR_NS::TfToken tok(key);
     if (PXR_NS::UsdShadeNodeGraph(attr.GetPrim())) {
@@ -88,9 +98,6 @@ bool setUsdAttrMetadata(
 #endif
 
 } // namespace
-
-namespace MAYAUSD_NS_DEF {
-namespace ufe {
 
 //------------------------------------------------------------------------------
 // UsdAttributeHolder:
@@ -144,6 +151,10 @@ bool UsdAttributeHolder::set(const PXR_NS::VtValue& value, PXR_NS::UsdTimeCode t
             return false;
         }
     }
+
+    PXR_NS::UsdPrim        prim = _usdAttr.GetPrim();
+    PXR_NS::SdfLayerHandle layer = getAttrEditRouterLayer(prim, _usdAttr.GetName());
+    PXR_NS::UsdEditContext ctx(prim.GetStage(), layer);
 
     return _usdAttr.Set(value, time);
 }
@@ -421,6 +432,10 @@ bool UsdAttributeHolder::clearMetadata(const std::string& key)
 {
     PXR_NAMESPACE_USING_DIRECTIVE
     if (isValid()) {
+        PXR_NS::UsdPrim        prim = _usdAttr.GetPrim();
+        PXR_NS::SdfLayerHandle layer = getAttrEditRouterLayer(prim, _usdAttr.GetName());
+        PXR_NS::UsdEditContext ctx(prim.GetStage(), layer);
+
         PXR_NS::TfToken tok(key);
         // Special cases for NodeGraphs:
         if (PXR_NS::UsdShadeNodeGraph(usdPrim())) {
@@ -431,6 +446,7 @@ bool UsdAttributeHolder::clearMetadata(const std::string& key)
             }
             return !hasMetadata(key);
         }
+
         // Special cases for known Ufe metadata keys.
         if (key == Ufe::Attribute::kLocked) {
             return _usdAttr.ClearMetadata(MayaUsdMetadata->Lock);

--- a/lib/mayaUsd/ufe/UsdObject3d.cpp
+++ b/lib/mayaUsd/ufe/UsdObject3d.cpp
@@ -17,8 +17,10 @@
 
 #include <mayaUsd/ufe/UsdUndoVisibleCommand.h>
 #include <mayaUsd/ufe/Utils.h>
+#include <mayaUsd/utils/editRouter.h>
 #include <mayaUsd/utils/util.h>
 
+#include <pxr/usd/usd/editContext.h>
 #include <pxr/usd/usd/timeCode.h>
 #include <pxr/usd/usdGeom/bboxCache.h>
 #include <pxr/usd/usdGeom/tokens.h>
@@ -96,6 +98,9 @@ bool UsdObject3d::visibility() const
 
 void UsdObject3d::setVisibility(bool vis)
 {
+    PXR_NS::SdfLayerHandle layer = getAttrEditRouterLayer(fPrim, UsdGeomTokens->visibility);
+    PXR_NS::UsdEditContext ctx(fPrim.GetStage(), layer);
+
     vis ? UsdGeomImageable(fPrim).MakeVisible() : UsdGeomImageable(fPrim).MakeInvisible();
 }
 

--- a/lib/mayaUsd/utils/editRouter.cpp
+++ b/lib/mayaUsd/utils/editRouter.cpp
@@ -293,6 +293,14 @@ bool restoreDefaultEditRouter(const PXR_NS::TfToken& operation)
     return true;
 }
 
+void restoreAllDefaultEditRouters()
+{
+    auto defaults = defaultEditRouters();
+    for (const auto& entry : defaults) {
+        registerEditRouter(entry.first, entry.second);
+    }
+}
+
 static void setEditTarget(const PXR_NS::UsdPrim& prim, const PXR_NS::UsdEditTarget& editTarget)
 {
     prim.GetStage()->SetEditTarget(editTarget);
@@ -331,6 +339,7 @@ getEditRouterLayer(const PXR_NS::TfToken& operation, const PXR_NS::UsdPrim& prim
     PXR_NS::VtDictionary context;
     PXR_NS::VtDictionary routingData;
     context["prim"] = PXR_NS::VtValue(prim);
+    context["operation"] = operation;
     (*dstEditRouter)(context, routingData);
     // Try to retrieve the layer from the routing data.
     auto found = routingData.find("layer");
@@ -365,7 +374,8 @@ getAttrEditRouterLayer(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attrN
     PXR_NS::VtDictionary context;
     PXR_NS::VtDictionary routingData;
     context["prim"] = PXR_NS::VtValue(prim);
-    context["attribute"] = PXR_NS::VtValue(attrName);
+    context["operation"] = operation;
+    context[operation] = PXR_NS::VtValue(attrName);
     (*dstEditRouter)(context, routingData);
 
     // Try to retrieve the layer from the routing data.

--- a/lib/mayaUsd/utils/editRouter.h
+++ b/lib/mayaUsd/utils/editRouter.h
@@ -97,6 +97,12 @@ getEditRouterLayer(const PXR_NS::TfToken& operation, const PXR_NS::UsdPrim& prim
 MAYAUSD_CORE_PUBLIC
 EditRouter::Ptr getEditRouter(const PXR_NS::TfToken& operation);
 
+// Retrieve the edit router for the "attribute" operation for teh given attribute.  If no such edit
+// router exist, the current edit target layer is returned.
+MAYAUSD_CORE_PUBLIC
+PXR_NS::SdfLayerHandle
+getAttrEditRouterLayer(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attrName);
+
 // Register an edit router for the argument operation.
 MAYAUSD_CORE_PUBLIC
 void registerEditRouter(const PXR_NS::TfToken& operation, const EditRouter::Ptr& editRouter);

--- a/lib/mayaUsd/utils/editRouter.h
+++ b/lib/mayaUsd/utils/editRouter.h
@@ -113,6 +113,10 @@ void registerEditRouter(const PXR_NS::TfToken& operation, const EditRouter::Ptr&
 MAYAUSD_CORE_PUBLIC
 bool restoreDefaultEditRouter(const PXR_NS::TfToken& operation);
 
+// Restore all the default edit router, overwriting the currently-registered edit routers.
+MAYAUSD_CORE_PUBLIC
+void restoreAllDefaultEditRouters();
+
 // Return built-in default edit routers.
 EditRouters defaultEditRouters();
 

--- a/test/lib/ufe/testVisibilityCmd.py
+++ b/test/lib/ufe/testVisibilityCmd.py
@@ -8,6 +8,7 @@ import mayaUtils
 import ufe
 import unittest
 import usdUtils
+from pxr import UsdGeom
 
 def filterUsdStr(usdSceneStr):
     '''Remove empty lines and lines starting with pound character.'''
@@ -19,6 +20,18 @@ def getSessionLayer(context, routingData):
     prim = context.get('prim')
     if prim is None:
         print('Prim not in context')
+        return
+    
+    routingData['layer'] = prim.GetStage().GetSessionLayer().identifier
+    
+def routerForVisibilityAttribute(context, routingData):
+    prim = context.get('prim')
+    if prim is None:
+        print('Prim not in context')
+        return
+    
+    attrName = context.get('attribute')
+    if attrName != UsdGeom.Tokens.visibility:
         return
     
     routingData['layer'] = prim.GetStage().GetSessionLayer().identifier
@@ -78,8 +91,10 @@ class VisibilityCmdTestCase(unittest.TestCase):
         # Restore default edit router.
         mayaUsd.lib.restoreDefaultEditRouter('visibility')
 
-    def testEditRouter(self):
-        '''Test edit router functionality.'''
+    def testEditRouterForCmd(self):
+        '''
+        Test edit router functionality for the set-visibility command.
+        '''
 
         # Select /A
         sn = ufe.GlobalSelection.get()
@@ -96,9 +111,6 @@ class VisibilityCmdTestCase(unittest.TestCase):
         # Send visibility edits to the session layer.
         mayaUsd.lib.registerEditRouter('visibility', getSessionLayer)
  
-        # Check that something was written to the session layer
-        self.assertIsNotNone(sessionLayer)
-
         # Select /B
         sn = ufe.GlobalSelection.get()
         sn.clear()
@@ -118,8 +130,10 @@ class VisibilityCmdTestCase(unittest.TestCase):
         self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
                          'over "B"\n{\n    token visibility = "invisible"\n}')
 
-    def testEditRouterShowHideMultipleSelection(self):
-        '''Test edit routing under show and hide scenarios with multiple selection.'''
+    def testEditRouterForCmdShowHideMultipleSelection(self):
+        '''
+        Test edit routing under for the set-visibility command with multiple selection.
+        '''
 
         # Get the session layer, check it's empty.
         prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
@@ -150,6 +164,71 @@ class VisibilityCmdTestCase(unittest.TestCase):
         # Check visibility was written to the session layer.
         self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
                          'over "A"\n{\n    token visibility = "invisible"\n}\nover "B"\n{\n    token visibility = "invisible"\n}')
+
+    def testEditRouterForSetVisibility(self):
+        '''
+        Test edit router for the visibility attribute triggered
+        via UFE Object3d's setVisibility function.
+        '''
+
+        # Get the session layer
+        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
+        sessionLayer = prim.GetStage().GetSessionLayer()
+ 
+        # Check that the session layer is empty
+        self.assertTrue(sessionLayer.empty)
+ 
+        # Send visibility edits to the session layer.
+        mayaUsd.lib.registerEditRouter('attribute', routerForVisibilityAttribute)
+ 
+        # Hide B via the UFE Object3d setVisbility function
+        object3d = ufe.Object3d.object3d(self.b)
+        object3d.setVisibility(False)
+ 
+        # Check that something was written to the session layer
+        self.assertIsNotNone(sessionLayer)
+        self.assertFalse(sessionLayer.empty)
+        self.assertIsNotNone(sessionLayer.GetPrimAtPath('/B'))
+ 
+        # Check that any visibility changes were written to the session layer
+        self.assertIsNotNone(sessionLayer.GetAttributeAtPath('/B.visibility').default)
+ 
+        # Check that correct visibility changes were written to the session layer
+        self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
+                         'over "B"\n{\n    token visibility = "invisible"\n}')
+
+    def testEditRouterForAttributeVisibility(self):
+        '''
+        Test edit router for the visibility attribute triggered
+         via UFE attribute's set function.
+        '''
+
+        # Get the session layer
+        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
+        sessionLayer = prim.GetStage().GetSessionLayer()
+ 
+        # Check that the session layer is empty
+        self.assertTrue(sessionLayer.empty)
+ 
+        # Send visibility edits to the session layer.
+        mayaUsd.lib.registerEditRouter('attribute', routerForVisibilityAttribute)
+ 
+        # Hide B via the UFE attribute set function.
+        attrs = ufe.Attributes.attributes(self.b)
+        visibilityAttr = attrs.attribute(UsdGeom.Tokens.visibility)
+        visibilityAttr.set(UsdGeom.Tokens.invisible)
+ 
+        # Check that something was written to the session layer
+        self.assertIsNotNone(sessionLayer)
+        self.assertFalse(sessionLayer.empty)
+        self.assertIsNotNone(sessionLayer.GetPrimAtPath('/B'))
+ 
+        # Check that any visibility changes were written to the session layer
+        self.assertIsNotNone(sessionLayer.GetAttributeAtPath('/B.visibility').default)
+ 
+        # Check that correct visibility changes were written to the session layer
+        self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
+                         'over "B"\n{\n    token visibility = "invisible"\n}')
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/ufe/testVisibilityCmd.py
+++ b/test/lib/ufe/testVisibilityCmd.py
@@ -229,6 +229,13 @@ class VisibilityCmdTestCase(unittest.TestCase):
         # Check that correct visibility changes were written to the session layer
         self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
                          'over "B"\n{\n    token visibility = "invisible"\n}')
+        
+        # Check we are still allowed to set the attribute without
+        # explicitly changing the edit target.
+        try:
+            self.assertIsNotNone(visibilityAttr.setCmd(UsdGeom.Tokens.invisible))
+        except Exception:
+            self.assertFalse(True,"Should have been able to create a command")
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
- Add a getAttrEditRouterLayer helper function to route attribute editions.
- The routing operation for attribute is named... 'attribute'
- It receives the attribute name in teh routing context under the 'attribute' key.
- Allow cancelling routed operation by throwing an exception.
- Add the name of the operation to the routing context so the same router can be used for multiple operations but have a different behaviour.
- Use it in UFE Object3d setVisibility implementation.
- Use it in UFE attribute holder inplementation for setMetadata, set, clearMetadata.
- Add unit tests for attribute routing.