### PR TITLE
MAYA-128407 fix edit-target loops in proxy shape compute

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -529,9 +529,6 @@ MStatus MayaUsdProxyShapeBase::compute(const MPlug& plug, MDataBlock& dataBlock)
 {
     InComputeGuard inComputeGuard(*this);
 
-    if (plug == outTimeAttr || plug.isDynamic())
-        ProxyAccessor::compute(_usdAccessor, plug, dataBlock);
-
     if (plug == excludePrimPathsAttr || plug == timeAttr || plug == complexityAttr
         || plug == drawRenderPurposeAttr || plug == drawProxyPurposeAttr
         || plug == drawGuidePurposeAttr) {

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -416,6 +416,11 @@ private:
     SdfLayerRefPtr _unsharedStageSessionLayer;
     SdfLayerRefPtr _unsharedStageRootLayer;
 
+    // Current edit target for the stage. Kept in a dynamic attribute for save/load,
+    // transferred to this variable on the first compute. Afterward, when the edit
+    // target is changed, this gets updated via a notification listener.
+    SdfLayerRefPtr _targetLayer;
+
     // We need to keep track of unshared sublayers (otherwise they get removed)
     std::vector<SdfLayerRefPtr> _unsharedStageRootSublayers;
 

--- a/lib/mayaUsd/utils/layers.cpp
+++ b/lib/mayaUsd/utils/layers.cpp
@@ -146,6 +146,14 @@ void applyToSomeLayersWithOpinions(
     }
 }
 
+bool isLayerInStage(const PXR_NS::SdfLayerHandle& layer, const PXR_NS::UsdStage& stage)
+{
+    for (const auto& stageLayer : stage.GetLayerStack())
+        if (stageLayer == layer)
+            return true;
+    return false;
+}
+
 bool isSessionLayer(const SdfLayerHandle& layer, const std::set<SdfLayerRefPtr>& sessionLayers)
 {
     return sessionLayers.count(layer) > 0;

--- a/lib/mayaUsd/utils/layers.h
+++ b/lib/mayaUsd/utils/layers.h
@@ -123,6 +123,16 @@ void applyToSomeLayersWithOpinions(
     PrimLayerFunc&                          func);
 
 /**
+ * Verify if a layer is in the given stage.
+ *
+ * @param layer the layer to verify.
+ * @param stage the stage to verify.
+ */
+
+MAYAUSD_CORE_PUBLIC
+bool isLayerInStage(const PXR_NS::SdfLayerHandle& layer, const PXR_NS::UsdStage& stage);
+
+/**
  * Verify if a layer is in the given set of session layers.
  *
  * @param layer the layer to verify.

--- a/lib/mayaUsd/utils/targetLayer.cpp
+++ b/lib/mayaUsd/utils/targetLayer.cpp
@@ -100,8 +100,7 @@ MStatus copyTargetLayerToAttribute(const PXR_NS::UsdStage& stage, MayaUsdProxySh
     return status;
 }
 
-MString
-getTargetLayerFromAttribute(const MayaUsdProxyShapeBase& proxyShape)
+MString getTargetLayerFromAttribute(const MayaUsdProxyShapeBase& proxyShape)
 {
     MString targetLayerText;
 

--- a/lib/mayaUsd/utils/targetLayer.h
+++ b/lib/mayaUsd/utils/targetLayer.h
@@ -19,6 +19,7 @@
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
 
+#include <pxr/usd/sdf/layer.h>
 #include <pxr/usd/usd/stage.h>
 
 #include <maya/MApiNamespace.h>
@@ -41,10 +42,27 @@ namespace MAYAUSD_NS_DEF {
 MAYAUSD_CORE_PUBLIC
 MString convertTargetLayerToText(const PXR_NS::UsdStage& stage);
 
+/*! \brief get the target layer from a text format if it exists on the given stage.
+ */
+MAYAUSD_CORE_PUBLIC
+PXR_NS::SdfLayerHandle getTargetLayerFromText(PXR_NS::UsdStage& stage, const MString& text);
+
 /*! \brief set the stage target layer from a text format.
  */
 MAYAUSD_CORE_PUBLIC
-void setTargetLayerFromText(PXR_NS::UsdStage& stage, const MString& text);
+bool setTargetLayerFromText(PXR_NS::UsdStage& stage, const MString& text);
+
+/*! \brief get the target layer ID from data in the corresponding attribute of the proxy shape.
+ */
+MAYAUSD_CORE_PUBLIC
+MString getTargetLayerFromAttribute(const MayaUsdProxyShapeBase& proxyShape);
+
+/*! \brief get the target layer from data in the corresponding attribute of the proxy shape if it
+ * exists on the given stage.
+ */
+MAYAUSD_CORE_PUBLIC
+PXR_NS::SdfLayerHandle
+getTargetLayerFromAttribute(const MayaUsdProxyShapeBase& proxyShape, PXR_NS::UsdStage& stage);
 
 /*! \brief copy the stage target layer in the corresponding attribute of the proxy shape.
  */


### PR DESCRIPTION
The problem is recursive interactions between multiple actors.

First actor: the ProxyAccessor class.

This class is only vaguely documented, that is there is a mechanical description but not an explanation of why it needs to exists nor why it is written as it is. It's mechanical purpose, as I understand it from its docs, is to copy input plugs into the proxy shape to stage data and copy stage data to output plugs. For some reason which are not explained, it writes its data to the session layer. To do so, it temporarily sets the target layer to the session layer.

Second actor: the ProxyShapeBase class.

The class is the representation of the USD stage as a Maya node. As part if its computation, it creates the stage. It holds multiple attributes to do so:

- The root layer
- The session layer
- The list of muted layers
- The load/unload state of various payload
- The current edit target layer.

And, in its implementation of its computation uses the ProxyAccessor. So, computing the ProxyShapeBase use a ProxyAccessor, which switch the target layer.

Third actor: the Edit Target Notifications

In order for the ProxyShapeBase to set the correct edit target when computed, it needs to know when the edit target has changed. Otherwise, after the user changed the edit target, recomputing the ProxyShapeBase would set the edit target to the old target. So the ProxyShapeBase register a notification listener to be told when the edit target changes. When the edit target changes, the notification listener sets the edit-target attribute on the ProxyShapeBase so that it sets the correct target if it is recomputed.

End Result

So, the sequence of events is:

- The ProxyShapeBase is recomputed.
- The ProxyAccessor changes the target to the session layer.
- This trigger the edit-target change notification
- This updates the ProxyShapeBase attribute
- This dirties the ProxyShapeBase
- The ProxyShapeBase compute ends.
- This destroys the ProxyAccessor
- This reset the edit target to its previous value.
- This trigger the edit-target change notification
- This updates the ProxyShapeBase attribute
- This dirties the ProxyShapeBase
- And... now the ProxyShapeBase will get recomputed again when accessed.

There are two ways to break the chain:

- Detect temporary changes in the edit target and ignore them.
- Not dirty the ProxyShapeBase when the edit target change.

The first one would be dangerous since if a recompute is triggered at that moment, it would use the incorrect edit target. OTOH, it is unclear what is the correct edit target at that point: is it the temporary edit target set by the proxy accessor or the edit target set by the user?

The second one can be done by keeping the current edit target in a member variable in the ProxyShapeBase and only use the attribute at load time to initially fill that variable, say on the first compute. I think that is what I will do to fix the problem.

- Add a member variable to ProxyShapeBase to keep track of the current edit target.
- Fill it on first compute.
- Update it when the edit target change, via the notifications.
- Only save the edit target on save (this was already existing).
- Refactor edit-target helper functions to support all this.