### PR TITLE
[al]Updating AL USDMaya's NurbsCurve static import export to use USD's curve spec

### DIFF
--- a/plugin/al/translators/NurbsCurve.cpp
+++ b/plugin/al/translators/NurbsCurve.cpp
@@ -223,6 +223,11 @@ void NurbsCurve::writeEdits(
     MProfilingScope profilerScope(
         _nurbsCurveProfilerCategory, MProfiler::kColorE_L3, "Write edits");
 
+    const int curveOrder = fnCurve.degree() + 1;
+    if (!TF_VERIFY(curveOrder <= fnCurve.numCVs())) {
+        return;
+    }
+
     uint32_t diff_curves = AL::usdmaya::utils::kAllNurbsCurveComponents;
     bool     performDiff = !writeAll;
     if (performDiff) {

--- a/plugin/al/translators/tests/testTranslators.py
+++ b/plugin/al/translators/tests/testTranslators.py
@@ -830,7 +830,7 @@ class TestTranslator(unittest.TestCase):
         
         # Export Maya curve to USD.
         mc.select('nurbsCircle1', r=True)
-        mc.file(tempPath, exportSelected=True, force=True, type="AL usdmaya export", 
+        mc.file(tempPath, exportSelected=True, force=True, type="AL usdmaya export",
             options="Dynamic_Attributes=1;Duplicate_Instances=1;Merge_Transforms=1;Merge_Offset_Parent_Matrix=0;Animation=0;Use_Timeline_Range=0;Frame_Min=0;Frame_Max=1;Sub_Samples=1;Filter_Sample=0;Export_At_Which_Time=0;Export_In_World_Space=0;Activate_all_Plugin_Translators=1;Active_Translator_List=;Inactive_Translator_List=;Nurbs_Curves=1;Meshes=1;Mesh_Face_Connects=1;Mesh_Points=1;Mesh_Extents=1;Mesh_Normals=1;Mesh_Vertex_Creases=1;Mesh_Edge_Creases=1;Mesh_UVs=1;Mesh_UV_Only=0;Mesh_Points_as_PRef=0;Mesh_Colours=1;Default_RGB=0.18;Default_Alpha=1;Custom_Colour_Threshold=1;Colour_Threshold_Value=1e-05;Mesh_Holes=1;Write_Normals_as_Primvars=1;Reverse_Opposite_Normals=1;Subdivision_scheme=0;Compaction_Level=3;"
         )
 
@@ -843,7 +843,7 @@ class TestTranslator(unittest.TestCase):
 
         # Import exported USD curve back to Maya.
         mc.file(f=True, new=True)
-        mc.file(tempPath, i=True, force=True, type="AL usdmaya import",  ignoreVersion=True, ra=True, 
+        mc.file(tempPath, i=True, force=True, type="AL usdmaya import",  ignoreVersion=True, ra=True,
             options="Parent_Path=;Prim_Path=;Import_Animations=1;Import_Dynamic_Attributes=1;Load_None=0;Read_Default_Values=1;Activate_all_Plugin_Translators=1;Active_Translator_List=;Inactive_Translator_List=;Import_Curves=1;Import_Meshes=1;", 
             pr=True, importFrameRate=True, importTimeRange='override'
         )

--- a/plugin/al/translators/tests/testTranslators.py
+++ b/plugin/al/translators/tests/testTranslators.py
@@ -823,7 +823,7 @@ class TestTranslator(unittest.TestCase):
         spans =  mc.getAttr('nurbsCircleShape1.spans')
         degree = mc.getAttr('nurbsCircleShape1.degree')
         mayaKnotCount = spans + 2 * degree - 1
-        usdnotCount = spans + 2 * degree + 1
+        usdknotCount = spans + 2 * degree + 1
         
         # Export Maya curve to USD.
         mc.select('nurbsCircle1', r=True)
@@ -831,7 +831,7 @@ class TestTranslator(unittest.TestCase):
             options="Dynamic_Attributes=1;Duplicate_Instances=1;Merge_Transforms=1;Merge_Offset_Parent_Matrix=0;Animation=0;Use_Timeline_Range=0;Frame_Min=0;Frame_Max=1;Sub_Samples=1;Filter_Sample=0;Export_At_Which_Time=0;Export_In_World_Space=0;Activate_all_Plugin_Translators=1;Active_Translator_List=;Inactive_Translator_List=;Nurbs_Curves=1;Meshes=1;Mesh_Face_Connects=1;Mesh_Points=1;Mesh_Extents=1;Mesh_Normals=1;Mesh_Vertex_Creases=1;Mesh_Edge_Creases=1;Mesh_UVs=1;Mesh_UV_Only=0;Mesh_Points_as_PRef=0;Mesh_Colours=1;Default_RGB=0.18;Default_Alpha=1;Custom_Colour_Threshold=1;Colour_Threshold_Value=1e-05;Mesh_Holes=1;Write_Normals_as_Primvars=1;Reverse_Opposite_Normals=1;Subdivision_scheme=0;Compaction_Level=3;"
         )
 
-        # Check whether exported curve's knot cout matches USD's curve spec.
+        # Check whether exported curve's knot count matches USD's curve spec.
         # Reference: https://graphics.pixar.com/usd/release/api/class_usd_geom_nurbs_curves.html#details
         stage = Usd.Stage.Open(tempFile.name)
         prim = stage.GetPrimAtPath('/nurbsCircle1')
@@ -845,7 +845,7 @@ class TestTranslator(unittest.TestCase):
             pr=True, importFrameRate=True, importTimeRange='override'
         )
 
-        # Check whether exported curve's knot cout matches USD's curve spec.
+        # Check whether exported curve's knot count matches USD's curve spec.
         mc.select('nurbsCircle1Shape', r=True)
         sel = OpenMaya.MGlobal.getActiveSelectionList()
         curveFn = OpenMaya.MFnNurbsCurve(sel.getDependNode(0))

--- a/plugin/al/translators/tests/testTranslators.py
+++ b/plugin/al/translators/tests/testTranslators.py
@@ -836,7 +836,7 @@ class TestTranslator(unittest.TestCase):
         stage = Usd.Stage.Open(tempFile.name)
         prim = stage.GetPrimAtPath('/nurbsCircle1')
         knotValues = prim.GetAttribute('knots').Get()
-        self.assertEqual(len(knotValues), usdnotCount)
+        self.assertEqual(len(knotValues), usdknotCount)
 
         # Import exported USD curve back to Maya.
         mc.file(f=True, new=True)

--- a/plugin/al/translators/tests/testTranslators.py
+++ b/plugin/al/translators/tests/testTranslators.py
@@ -5,6 +5,7 @@ import shutil
 
 import maya.cmds as mc
 import maya.mel as mel
+from maya.api import OpenMaya
 
 from pxr import Tf, Usd, UsdGeom, Gf
 import translatortestutils
@@ -815,6 +816,43 @@ class TestTranslator(unittest.TestCase):
 
         os.remove(tempPath)
 
+    def testUSDSpecNurbsCurveExportImport(self):
+        """Testing exporting maya nurbsCurves in USD's curve spec, and importing USD curve spec in Maya"""
+        tempFile = tempfile.NamedTemporaryFile(suffix=".usda", prefix="test_USDNurbsCurveExportImport_", delete=False)
+        mc.CreateNURBSCircle()
+        spans =  mc.getAttr('nurbsCircleShape1.spans')
+        degree = mc.getAttr('nurbsCircleShape1.degree')
+        mayaKnotCount = spans + 2 * degree - 1
+        usdnotCount = spans + 2 * degree + 1
+        
+        # Export Maya curve to USD.
+        mc.select('nurbsCircle1', r=True)
+        mc.file(tempFile.name, exportSelected=True, force=True, type="AL usdmaya export", 
+            options="Dynamic_Attributes=1;Duplicate_Instances=1;Merge_Transforms=1;Merge_Offset_Parent_Matrix=0;Animation=0;Use_Timeline_Range=0;Frame_Min=0;Frame_Max=1;Sub_Samples=1;Filter_Sample=0;Export_At_Which_Time=0;Export_In_World_Space=0;Activate_all_Plugin_Translators=1;Active_Translator_List=;Inactive_Translator_List=;Nurbs_Curves=1;Meshes=1;Mesh_Face_Connects=1;Mesh_Points=1;Mesh_Extents=1;Mesh_Normals=1;Mesh_Vertex_Creases=1;Mesh_Edge_Creases=1;Mesh_UVs=1;Mesh_UV_Only=0;Mesh_Points_as_PRef=0;Mesh_Colours=1;Default_RGB=0.18;Default_Alpha=1;Custom_Colour_Threshold=1;Colour_Threshold_Value=1e-05;Mesh_Holes=1;Write_Normals_as_Primvars=1;Reverse_Opposite_Normals=1;Subdivision_scheme=0;Compaction_Level=3;"
+        )
+
+        # Check whether exported curve's knot cout matches USD's curve spec.
+        # Reference: https://graphics.pixar.com/usd/release/api/class_usd_geom_nurbs_curves.html#details
+        stage = Usd.Stage.Open(tempFile.name)
+        prim = stage.GetPrimAtPath('/nurbsCircle1')
+        knotValues = prim.GetAttribute('knots').Get()
+        self.assertEqual(len(knotValues), usdnotCount)
+
+        # Import exported USD curve back to Maya.
+        mc.file(f=True, new=True)
+        mc.file(tempFile.name, i=True, force=True, type="AL usdmaya import",  ignoreVersion=True, ra=True, 
+            options="Parent_Path=;Prim_Path=;Import_Animations=1;Import_Dynamic_Attributes=1;Load_None=0;Read_Default_Values=1;Activate_all_Plugin_Translators=1;Active_Translator_List=;Inactive_Translator_List=;Import_Curves=1;Import_Meshes=1;", 
+            pr=True, importFrameRate=True, importTimeRange='override'
+        )
+
+        # Check whether exported curve's knot cout matches USD's curve spec.
+        mc.select('nurbsCircle1Shape', r=True)
+        sel = OpenMaya.MGlobal.getActiveSelectionList()
+        curveFn = OpenMaya.MFnNurbsCurve(sel.getDependNode(0))
+        self.assertEqual(list(curveFn.knots()), list(knotValues[1:-1]))
+        
+        os.remove(tempFile.name)
+        
 
 tests = unittest.TestLoader().loadTestsFromTestCase(TestTranslator)
 result = unittest.TextTestRunner(verbosity=2).run(tests)


### PR DESCRIPTION
Previously, AL USDMaya was exporting maya NurbsCurves as-is but USD's NurbsCurve spec is different from maya's. From USD's doc, we can see it uses a different knot spec than Maya does:
https://graphics.pixar.com/usd/release/api/class_usd_geom_nurbs_curves.html#details

Also, in Maya's [MFnNurbsCurve](https://help.autodesk.com/view/MAYAUL/2022/ENU/?guid=Maya_SDK_cpp_ref_class_m_fn_nurbs_curve_html) API doc, it says:

```
Managing different knot representations in external applications

Note that some third party applications use a different format for knots, where the number of knots required for a curve is M+2N+1 rather than M+2N-1 as used in Maya. Both knot representations are equivalent mathematically. To convert from one of these external representations into the Maya representation, simply omit the first and last knots from the external representation when creating the Maya representation. To convert from the Maya representation into the external representation, add two new knots at the beginning and end of the Maya knot sequence. The value of these new knots depends on the existing knot sequence. For a knot sequence with multiple end knots, simply duplicate the existing first and last knots once more, for example:

Maya representation: {0,0,0,...,N,N,N}
External representation: {0,0,0,0,...,N,N,N,N}

For a knot sequence with uniform end knots, create the new knots offset at an interval equal to the existing first and last knot intervals, for example:

Maya representation: {0,1,2,...,N,N+1,N+2}
External representation: {-1,0,1,2,...,N,N+1,N+2,N+3}
```
