### PR TITLE
MAYA-128463 transform command return null.

### DIFF
--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -96,7 +96,10 @@ Ufe::SceneItem::Ptr UsdTransform3d::sceneItem() const { return fItem; }
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd(double x, double y, double z)
 {
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate"));
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
+        return nullptr;
+    }
+
     return UsdTranslateUndoableCommand::create(path(), x, y, z);
 }
 #endif
@@ -157,7 +160,10 @@ Ufe::Vector3d UsdTransform3d::scale() const
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd(double x, double y, double z)
 {
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"));
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
+        return nullptr;
+    }
+
     return UsdRotateUndoableCommand::create(path(), x, y, z);
 }
 #endif
@@ -170,26 +176,38 @@ void UsdTransform3d::rotate(double x, double y, double z)
 #ifdef UFE_V2_FEATURES_AVAILABLE
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd(double x, double y, double z)
 {
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:scale"));
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
+        return nullptr;
+    }
+
     return UsdScaleUndoableCommand::create(path(), x, y, z);
 }
 
 #else
 Ufe::TranslateUndoableCommand::Ptr UsdTransform3d::translateCmd()
 {
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate"));
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
+        return nullptr;
+    }
+
     return UsdTranslateUndoableCommand::create(fItem, 0, 0, 0);
 }
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3d::rotateCmd()
 {
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"));
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
+        return nullptr;
+    }
+
     return UsdRotateUndoableCommand::create(fItem, 0, 0, 0);
 }
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3d::scaleCmd()
 {
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:scale"));
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
+        return nullptr;
+    }
+
     return UsdScaleUndoableCommand::create(fItem, 1, 1, 1);
 }
 #endif
@@ -233,7 +251,9 @@ UsdTransform3d::rotatePivotCmd(double, double, double)
 UsdTransform3d::rotatePivotTranslateCmd()
 #endif
 {
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate:pivot"));
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate:pivot"))) {
+        return nullptr;
+    }
 
     // As of 12-Oct-2020, setting rotate pivot on command creation
     // unsupported.  Use translate() method on returned command.

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
@@ -191,26 +191,38 @@ void UsdTransform3dCommonAPI::scale(double x, double y, double z)
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dCommonAPI::translateCmd(double x, double y, double z)
 {
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate"));
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
+        return nullptr;
+    }
+
     return std::make_shared<CommonAPITranslateUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3dCommonAPI::rotateCmd(double x, double y, double z)
 {
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"));
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
+        return nullptr;
+    }
+
     return std::make_shared<CommonAPIRotateUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3dCommonAPI::scaleCmd(double x, double y, double z)
 {
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:scale"));
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
+        return nullptr;
+    }
+
     return std::make_shared<CommonAPIScaleUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dCommonAPI::rotatePivotCmd(double x, double y, double z)
 {
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate:pivot"));
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate:pivot"))) {
+        return nullptr;
+    }
+
     return std::make_shared<CommonAPIPivotUndoableCmd>(usdSceneItem(), UsdTimeCode::Default());
 }
 
@@ -237,9 +249,12 @@ Ufe::Vector3d UsdTransform3dCommonAPI::scalePivot() const { return rotatePivot()
 
 Ufe::SetMatrix4dUndoableCommand::Ptr UsdTransform3dCommonAPI::setMatrixCmd(const Ufe::Matrix4d& m)
 {
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate"));
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"));
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:scale"));
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))
+        || !isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))
+        || !isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
+        return nullptr;
+    }
+
     return std::make_shared<UsdSetMatrix4dUndoableCommand>(path(), m);
 }
 

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -279,19 +279,28 @@ Ufe::Vector3d UsdTransform3dMatrixOp::scale() const { return getScale(matrix());
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dMatrixOp::translateCmd(double x, double y, double z)
 {
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:translate"));
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
+        return nullptr;
+    }
+
     return std::make_shared<MatrixOpTranslateUndoableCmd>(path(), _op, UsdTimeCode::Default());
 }
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3dMatrixOp::rotateCmd(double x, double y, double z)
 {
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"));
-    return nullptr;
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
+        return nullptr;
+    }
+
+    return std::make_shared<MatrixOpRotateUndoableCmd>(path(), _op, UsdTimeCode::Default());
 }
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3dMatrixOp::scaleCmd(double x, double y, double z)
 {
-    enforceAttributeEditAllowed(prim(), TfToken("xformOp:scale"));
+    if (!isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
+        return nullptr;
+    }
+
     return std::make_shared<MatrixOpScaleUndoableCmd>(path(), _op, UsdTimeCode::Default());
 }
 

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
@@ -114,7 +114,7 @@ private:
     Ufe::TranslateUndoableCommand::Ptr
     pivotCmd(const PXR_NS::TfToken& pvtOpSuffix, double x, double y, double z);
 
-    void enforceAttributeEditAllowed(const PXR_NS::TfToken attrName) const;
+    bool isAttributeEditAllowed(const PXR_NS::TfToken attrName, std::string& errMsg) const;
 }; // UsdTransform3dMayaXformStack
 
 //! \brief Factory to create a UsdTransform3dMayaXformStack interface object.

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -280,7 +280,7 @@ MAYAUSD_CORE_PUBLIC
 bool isAttributeEditAllowed(
     const PXR_NS::UsdPrim& prim,
     const PXR_NS::TfToken& attrName,
-    std::string*           errMsg = nullptr);
+    std::string*           errMsg);
 
 MAYAUSD_CORE_PUBLIC
 bool isAttributeEditAllowed(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attrName);


### PR DESCRIPTION
The creation of transform command cannot throw exception because Maya is not ready to handle them. Since we cannot change Maya at this point revert to the old behaviour of returning a null command.