### PR TITLE
MAYA-128460 - undoing rename of prim causes prim's icon to change to def

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
@@ -222,7 +222,7 @@ void renameHelper(
     sendNotificationToAllStageProxies(stage, ufeDstItem->prim(), srcPath, dstPath);
 }
 
-} // namespace 
+} // namespace
 
 void UsdUndoRenameCommand::renameRedo()
 {


### PR DESCRIPTION
#### MAYA-128460 - undoing the rename of a prim causes prim's icon to change to a def

* For undo send the correct (new) prim in the Ufe notification.
* Refactor undo/redo into common helper method.