### PR TITLE
Check skin cluster weights

### DIFF
--- a/lib/mayaUsd/fileio/utils/jointWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/jointWriteUtils.cpp
@@ -237,6 +237,16 @@ int UsdMayaJointUtil::getCompressedSkinWeights(
     unsigned int numInfluences;
     skinCluster.getWeights(outputDagPath, components.object(), weights, numInfluences);
 
+    if(weights.length() < numVertices * numInfluences) {
+        MString msg("Number of weights (");
+        msg += weights.length();
+        msg += ") exceeds number of influences * number of vertices (";
+        msg += numInfluences * numVertices;
+        msg += ") - skin binding will not be written";
+        MGlobal::displayError(msg);
+        throw std::runtime_error(msg.asChar());
+    }
+
     // Determine how many influence/weight "slots" we actually need per point.
     // For example, if there are the joints /a, /a/b, and /a/c, but each point
     // only has non-zero weighting for a single joint, then we only need one

--- a/lib/mayaUsd/fileio/utils/jointWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/jointWriteUtils.cpp
@@ -237,12 +237,23 @@ int UsdMayaJointUtil::getCompressedSkinWeights(
     unsigned int numInfluences;
     skinCluster.getWeights(outputDagPath, components.object(), weights, numInfluences);
 
+    if (numInfluences <= 0) {
+        MString msg("No influences found for skinCluster ");
+        msg += skinCluster.name();
+        MGlobal::displayError(msg);
+        throw std::runtime_error(msg.asChar());
+    }
+
     if (weights.length() < numVertices * numInfluences) {
-        MString msg("Number of weights (");
-        msg += weights.length();
-        msg += ") exceeds number of influences * number of vertices (";
-        msg += numInfluences * numVertices;
-        msg += ") - skin binding will not be written";
+        MString msg("The number of vertices on the exported mesh ");
+        msg += outputDagPath.partialPathName();
+        msg += "(";
+        msg += numVertices;
+
+        msg += ") do not match the number of vertices where the skinCluster was applied (";
+        msg += weights.length() / numInfluences;
+        msg += "). Remove any nodes that change mesh topology after the skinCluster.";
+
         MGlobal::displayError(msg);
         throw std::runtime_error(msg.asChar());
     }

--- a/lib/mayaUsd/fileio/utils/jointWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/jointWriteUtils.cpp
@@ -237,7 +237,7 @@ int UsdMayaJointUtil::getCompressedSkinWeights(
     unsigned int numInfluences;
     skinCluster.getWeights(outputDagPath, components.object(), weights, numInfluences);
 
-    if(weights.length() < numVertices * numInfluences) {
+    if (weights.length() < numVertices * numInfluences) {
         MString msg("Number of weights (");
         msg += weights.length();
         msg += ") exceeds number of influences * number of vertices (";

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -39,6 +39,7 @@ set(TEST_SCRIPT_FILES
     testUsdExportSelection.py
     testUsdExportSelectionHierarchy.py
     testUsdExportSkeleton.py
+    testUsdExportSkin.py
     testUsdExportStripNamespaces.py
     testUsdExportStroke.py
     testUsdExportUserTaggedAttributes.py

--- a/test/lib/usd/translators/testUsdExportSkin.py
+++ b/test/lib/usd/translators/testUsdExportSkin.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env mayapy
+#
+# Copyright 2023 Apple Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+import unittest
+
+from maya import cmds
+from maya import standalone
+from maya.api import OpenMaya as OM
+
+from pxr import Gf, Sdf, Tf, Usd, UsdGeom, UsdSkel, UsdUtils, Vt
+
+import fixturesUtils
+
+
+def build_scene():
+    """Set up simple skinCluster, add a polyReduce after"""
+    cmds.file(f=1, new=1)
+    root = cmds.joint()
+    cmds.joint()
+    sphere = cmds.polySphere()
+    cmds.select(root, add=1)
+    group = cmds.group()
+
+    cmds.skinCluster(root, sphere[0])
+    cmds.select(sphere[0])
+
+    cmds.polyReduce(p=50)
+    return group
+
+class TestUsdExportSkin(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        inputPath = fixturesUtils.setUpClass(__file__)
+        # cls.outFile = os.path.join
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def test_exportSkinDifferingTopology(self):
+        """Raise a runtime error if the topology has changed downstream from the skinCluster"""
+        grp = build_scene()
+        self.assertRaises(RuntimeError, cmds.mayaUSDExport, file="Does_not_export.usdc", skn="auto", skl="auto")
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
If an artist uses polyReduce (or other node that changes the vertex count) after a skinCluster has been applied, the Usd exporter tries to compare the weights of the original vertex count with the assigned weights of the reduced vertex count. This results in an out-of-bounds access to the MDoubleArray that holds the weights.

This P/R checks for that condition and throws an exception if encountered (this occurs in a part of the plugin that is not using `MStatus` to signal success/failure/error).