### PR TITLE
Add smart signaling for renderers.

### DIFF
--- a/lib/mayaUsd/nodes/CMakeLists.txt
+++ b/lib/mayaUsd/nodes/CMakeLists.txt
@@ -9,6 +9,7 @@ target_sources(${PROJECT_NAME}
         proxyShapeBase.cpp
         proxyShapePlugin.cpp
         proxyShapeStageExtraData.cpp
+        proxyShapeUpdateManager.cpp
         stageData.cpp
         stageNode.cpp
         usdPrimProvider.cpp
@@ -22,6 +23,7 @@ set(HEADERS
     proxyShapePlugin.h
     proxyStageProvider.h
     proxyShapeStageExtraData.h
+    proxyShapeUpdateManager.h
     stageData.h
     stageNode.h
     usdPrimProvider.h

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -2092,8 +2092,9 @@ void MayaUsdProxyShapeBase::_OnStageObjectsChanged(const UsdNotice::ObjectsChang
 
     switch (_ClassifyUsdObjectsChanged(notice)) {
     case _UsdChangeType::kIgnored: return;
+    case _UsdChangeType::kResync: ++_UsdStageResyncCounter;
+    // [[fallthrough]]; // We want that fallthrough to have the update always triggered.
     case _UsdChangeType::kUpdate: ++_UsdStageUpdateCounter; break;
-    case _UsdChangeType::kResync: ++_UsdStageResyncCounter; break;
     }
 
     // Recompute the extents of any UsdGeomBoundable that has authored extents

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -50,17 +50,20 @@
 #include <pxr/usd/ar/resolver.h>
 #include <pxr/usd/sdf/attributeSpec.h>
 #include <pxr/usd/sdf/layer.h>
+#include <pxr/usd/sdf/listOp.h>
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/editContext.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
 #include <pxr/usd/usd/stageCacheContext.h>
 #include <pxr/usd/usd/timeCode.h>
+#include <pxr/usd/usd/tokens.h>
 #include <pxr/usd/usdGeom/bboxCache.h>
 #include <pxr/usd/usdGeom/boundable.h>
 #include <pxr/usd/usdGeom/gprim.h>
 #include <pxr/usd/usdGeom/imageable.h>
 #include <pxr/usd/usdGeom/tokens.h>
+#include <pxr/usd/usdUI/tokens.h>
 #include <pxr/usd/usdUtils/stageCache.h>
 
 #include <maya/MBoundingBox.h>
@@ -154,6 +157,9 @@ MObject MayaUsdProxyShapeBase::drawGuidePurposeAttr;
 MObject MayaUsdProxyShapeBase::sessionLayerNameAttr;
 MObject MayaUsdProxyShapeBase::rootLayerNameAttr;
 MObject MayaUsdProxyShapeBase::mutedLayersAttr;
+// Change counter attributes
+MObject MayaUsdProxyShapeBase::updateCounterAttr;
+MObject MayaUsdProxyShapeBase::resyncCounterAttr;
 // Output attributes
 MObject MayaUsdProxyShapeBase::outTimeAttr;
 MObject MayaUsdProxyShapeBase::outStageDataAttr;
@@ -388,6 +394,26 @@ MStatus MayaUsdProxyShapeBase::initialize()
     retValue = addAttribute(outStageDataAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
+    updateCounterAttr
+        = numericAttrFn.create("updateid", "upid", MFnNumericData::kInt64, -1, &retValue);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+    numericAttrFn.setStorable(false);
+    numericAttrFn.setWritable(false);
+    numericAttrFn.setHidden(true);
+    numericAttrFn.setInternal(true);
+    retValue = addAttribute(updateCounterAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+    resyncCounterAttr
+        = numericAttrFn.create("resyncid", "rsid", MFnNumericData::kInt64, -1, &retValue);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+    numericAttrFn.setStorable(false);
+    numericAttrFn.setWritable(false);
+    numericAttrFn.setHidden(true);
+    numericAttrFn.setInternal(true);
+    retValue = addAttribute(resyncCounterAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
     outStageCacheIdAttr
         = numericAttrFn.create("outStageCacheId", "ostcid", MFnNumericData::kInt, -1, &retValue);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
@@ -522,6 +548,22 @@ void MayaUsdProxyShapeBase::postConstructor()
     setRenderable(true);
 
     MayaUsdProxyStageInvalidateNotice(*this).Send();
+}
+
+/* virtual */
+bool MayaUsdProxyShapeBase::getInternalValue(const MPlug& plug, MDataHandle& handle)
+{
+    bool retVal = true;
+
+    if (plug == updateCounterAttr) {
+        handle.set(_UsdStageUpdateCounter);
+    } else if (plug == resyncCounterAttr) {
+        handle.set(_UsdStageResyncCounter);
+    } else {
+        retVal = MPxSurfaceShape::getInternalValue(plug, handle);
+    }
+
+    return retVal;
 }
 
 /* virtual */
@@ -1923,6 +1965,118 @@ void MayaUsdProxyShapeBase::_OnStageEditTargetChanged(
     _targetLayer = layer;
 }
 
+namespace {
+
+// We have incoming changes that USD will consider either requiring an
+// update (meaning the render delegate needs to refresh and redraw) or
+// a resync (meaning the scene delegate needs to fetch new datum). We
+// want external clients to be aware of these classes of updates in case
+// they do not use the Hydra system for refreshing and drawing the scene.
+enum class _UsdChangeType
+{
+    kIgnored, // Change does not require redraw: UI change, metadata change.
+    kUpdate,  // Change requires redraw after refreshing parameter values
+    kResync   // Change requires refreshing cached buffers
+};
+
+// If the notification is about prepending a UI schema, we don't want a refresh. These structures
+// are quite large to inspect, but they hash easily, so let's compare known hashes.
+bool _IsUiSchemaPrepend(const VtValue& v)
+{
+    static std::set<size_t> UiSchemaPrependHashes;
+    std::once_flag          hasHashes;
+    std::call_once(hasHashes, [&]() {
+        SdfTokenListOp op;
+        op.SetPrependedItems(TfTokenVector { TfToken("NodeGraphNodeAPI") });
+        UiSchemaPrependHashes.insert(hash_value(op));
+    });
+
+    if (v.IsHolding<SdfTokenListOp>()) {
+        const size_t hash = hash_value(v.UncheckedGet<SdfTokenListOp>());
+        if (UiSchemaPrependHashes.count(hash)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// This is a stripped down copy of UsdImagingDelegate::_OnUsdObjectsChanged which is the main USD
+// notification handler where paths to refresh and paths to update are compiled for the next Hydra
+// refresh. We do not gather paths as there is no simple way to know when tho flush these maps.
+//
+// This needs to stay as quick as possible since it is stuck in the middle of the notification code
+// path.
+//
+// This is a work in progress. Some improvements might be necessary in the future. The following
+// potential issues are already visible:
+//
+//  - Changing a parameter value for the first time creates the attribute, which is a kResync
+_UsdChangeType _ClassifyUsdObjectsChanged(UsdNotice::ObjectsChanged const& notice)
+{
+    using PathRange = UsdNotice::ObjectsChanged::PathRange;
+
+    auto range = notice.GetResyncedPaths();
+    if (!range.empty()) {
+        size_t ignoredCount = 0;
+        size_t resyncCount = 0;
+        for (auto it = range.begin(); it != range.end(); ++it) {
+            if (it->IsPropertyPath()) {
+                // We have a bunch of UI properties to ignore. Especially anything that comes from
+                // UI schemas.
+                if (it->GetName().rfind("ui:", 0) == 0) {
+                    ++ignoredCount;
+                    continue;
+                }
+            }
+            for (const SdfChangeList::Entry* entry : it.base()->second) {
+                for (auto&& infoChanged : entry->infoChanged) {
+                    if (infoChanged.first == UsdTokens->apiSchemas
+                        && _IsUiSchemaPrepend(infoChanged.second.second)) {
+                        ++ignoredCount;
+                    } else {
+                        ++resyncCount;
+                    }
+                }
+            }
+        }
+
+        if (ignoredCount) {
+            return resyncCount ? _UsdChangeType::kResync : _UsdChangeType::kIgnored;
+        } else {
+            return _UsdChangeType::kResync;
+        }
+    }
+
+    auto retVal = _UsdChangeType::kIgnored;
+
+    const PathRange pathsToUpdate = notice.GetChangedInfoOnlyPaths();
+    for (PathRange::const_iterator it = pathsToUpdate.begin(); it != pathsToUpdate.end(); ++it) {
+        if (it->IsAbsoluteRootOrPrimPath()) {
+            const TfTokenVector changedFields = it.GetChangedFields();
+            if (!changedFields.empty()) {
+                retVal = _UsdChangeType::kUpdate;
+            }
+        } else if (it->IsPropertyPath()) {
+            // We have a bunch of UI properties to ignore. Especially anything that comes from UI
+            // schemas.
+            if (it->GetName().rfind("ui:", 0) == 0) {
+                continue;
+            }
+            retVal = _UsdChangeType::kUpdate;
+            for (const auto& entry : it.base()->second) {
+                if (entry->flags.didChangeAttributeConnection) {
+                    retVal = _UsdChangeType::kResync;
+                    break;
+                }
+            }
+        }
+    }
+
+    return retVal;
+}
+
+} // namespace
+
 void MayaUsdProxyShapeBase::_OnStageObjectsChanged(const UsdNotice::ObjectsChanged& notice)
 {
     MProfilingScope profilingScope(
@@ -1935,6 +2089,12 @@ void MayaUsdProxyShapeBase::_OnStageObjectsChanged(const UsdNotice::ObjectsChang
 
     ProxyAccessor::stageChanged(_usdAccessor, thisMObject(), notice);
     MayaUsdProxyStageObjectsChangedNotice(*this, notice).Send();
+
+    switch (_ClassifyUsdObjectsChanged(notice)) {
+    case _UsdChangeType::kIgnored: return;
+    case _UsdChangeType::kUpdate: ++_UsdStageUpdateCounter; break;
+    case _UsdChangeType::kResync: ++_UsdStageResyncCounter; break;
+    }
 
     // Recompute the extents of any UsdGeomBoundable that has authored extents
     const auto& stage = notice.GetStage();

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -124,6 +124,12 @@ public:
     MAYAUSD_CORE_PUBLIC
     static MObject mutedLayersAttr;
 
+    // Change counter attributes
+    MAYAUSD_CORE_PUBLIC
+    static MObject updateCounterAttr;
+    MAYAUSD_CORE_PUBLIC
+    static MObject resyncCounterAttr;
+
     // Output attributes
     MAYAUSD_CORE_PUBLIC
     static MObject outTimeAttr;
@@ -169,6 +175,8 @@ public:
 
     MAYAUSD_CORE_PUBLIC
     void postConstructor() override;
+    MAYAUSD_CORE_PUBLIC
+    bool getInternalValue(const MPlug&, MDataHandle&) override;
     MAYAUSD_CORE_PUBLIC
     MStatus compute(const MPlug& plug, MDataBlock& dataBlock) override;
     MAYAUSD_CORE_PUBLIC
@@ -397,6 +405,8 @@ private:
     std::map<UsdTimeCode, MBoundingBox> _boundingBoxCache;
     size_t                              _excludePrimPathsVersion { 1 };
     size_t                              _UsdStageVersion { 1 };
+    MInt64                              _UsdStageUpdateCounter { 1 };
+    MInt64                              _UsdStageResyncCounter { 1 };
 
     MayaUsd::ProxyAccessor::Owner _usdAccessor;
 

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -55,6 +55,7 @@ constexpr char USD_UFE_SEPARATOR = '/';
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/listeners/stageNoticeListener.h>
 #include <mayaUsd/nodes/proxyAccessor.h>
+#include <mayaUsd/nodes/proxyShapeUpdateManager.h>
 #include <mayaUsd/nodes/proxyStageProvider.h>
 #include <mayaUsd/nodes/usdPrimProvider.h>
 
@@ -405,8 +406,9 @@ private:
     std::map<UsdTimeCode, MBoundingBox> _boundingBoxCache;
     size_t                              _excludePrimPathsVersion { 1 };
     size_t                              _UsdStageVersion { 1 };
-    MInt64                              _UsdStageUpdateCounter { 1 };
-    MInt64                              _UsdStageResyncCounter { 1 };
+
+    // This helper class keeps track of the notification counters:
+    MayaUsdProxyShapeUpdateManager _shapeUpdateManager;
 
     MayaUsd::ProxyAccessor::Owner _usdAccessor;
 

--- a/lib/mayaUsd/nodes/proxyShapeUpdateManager.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeUpdateManager.cpp
@@ -1,0 +1,156 @@
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "proxyShapeUpdateManager.h"
+
+#include <pxr/base/vt/value.h>
+#include <pxr/usd/sdf/listOp.h>
+#include <pxr/usd/usd/tokens.h>
+#include <pxr/usd/usdUI/tokens.h>
+
+using namespace MAYAUSD_NS_DEF;
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+namespace {
+
+// We have incoming changes that USD will consider either requiring an
+// update (meaning the render delegate needs to refresh and redraw) or
+// a resync (meaning the scene delegate needs to fetch new datum). We
+// want external clients to be aware of these classes of updates in case
+// they do not use the Hydra system for refreshing and drawing the scene.
+enum class _UsdChangeType
+{
+    kIgnored, // Change does not require redraw: UI change, metadata change.
+    kUpdate,  // Change requires redraw after refreshing parameter values
+    kResync   // Change requires refreshing cached buffers
+};
+
+// If the notification is about prepending a UI schema, we don't want a refresh. These structures
+// are quite large to inspect, but they hash easily, so let's compare known hashes.
+bool _IsUiSchemaPrepend(const VtValue& v)
+{
+    static std::set<size_t> UiSchemaPrependHashes;
+    std::once_flag          hasHashes;
+    std::call_once(hasHashes, [&]() {
+        SdfTokenListOp op;
+        op.SetPrependedItems(TfTokenVector { TfToken("NodeGraphNodeAPI") });
+        UiSchemaPrependHashes.insert(hash_value(op));
+    });
+
+    if (v.IsHolding<SdfTokenListOp>()) {
+        const size_t hash = hash_value(v.UncheckedGet<SdfTokenListOp>());
+        if (UiSchemaPrependHashes.count(hash)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// This is a stripped down copy of UsdImagingDelegate::_OnUsdObjectsChanged which is the main USD
+// notification handler where paths to refresh and paths to update are compiled for the next Hydra
+// refresh. We do not gather paths as there is no simple way to know when to flush these maps.
+//
+// This needs to stay as quick as possible since it is stuck in the middle of the notification code
+// path.
+//
+// This is a work in progress. Some improvements might be necessary in the future. The following
+// potential issues are already visible:
+//
+//  - Changing a parameter value for the first time creates the attribute, which is a kResync
+_UsdChangeType _ClassifyUsdObjectsChanged(UsdNotice::ObjectsChanged const& notice)
+{
+    using PathRange = UsdNotice::ObjectsChanged::PathRange;
+
+    auto range = notice.GetResyncedPaths();
+    if (!range.empty()) {
+        size_t ignoredCount = 0;
+        size_t resyncCount = 0;
+        for (auto it = range.begin(); it != range.end(); ++it) {
+            if (it->IsPropertyPath()) {
+                // We have a bunch of UI properties to ignore. Especially anything that comes from
+                // UI schemas.
+                if (it->GetName().rfind("ui:", 0) == 0) {
+                    ++ignoredCount;
+                    continue;
+                }
+            }
+            for (const SdfChangeList::Entry* entry : it.base()->second) {
+                for (auto&& infoChanged : entry->infoChanged) {
+                    if (infoChanged.first == UsdTokens->apiSchemas
+                        && _IsUiSchemaPrepend(infoChanged.second.second)) {
+                        ++ignoredCount;
+                    } else {
+                        ++resyncCount;
+                    }
+                }
+            }
+        }
+
+        if (ignoredCount) {
+            return resyncCount ? _UsdChangeType::kResync : _UsdChangeType::kIgnored;
+        } else {
+            return _UsdChangeType::kResync;
+        }
+    }
+
+    auto retVal = _UsdChangeType::kIgnored;
+
+    const PathRange pathsToUpdate = notice.GetChangedInfoOnlyPaths();
+    for (PathRange::const_iterator it = pathsToUpdate.begin(); it != pathsToUpdate.end(); ++it) {
+        if (it->IsAbsoluteRootOrPrimPath()) {
+            const TfTokenVector changedFields = it.GetChangedFields();
+            if (!changedFields.empty()) {
+                retVal = _UsdChangeType::kUpdate;
+            }
+        } else if (it->IsPropertyPath()) {
+            // We have a bunch of UI properties to ignore. Especially anything that comes from UI
+            // schemas.
+            if (it->GetName().rfind("ui:", 0) == 0) {
+                continue;
+            }
+            retVal = _UsdChangeType::kUpdate;
+            for (const auto& entry : it.base()->second) {
+                if (entry->flags.didChangeAttributeConnection) {
+                    retVal = _UsdChangeType::kResync;
+                    break;
+                }
+            }
+        }
+    }
+
+    return retVal;
+}
+
+} // namespace
+
+bool MayaUsdProxyShapeUpdateManager::CanIgnoreObjectsChanged(
+    const UsdNotice::ObjectsChanged& notice)
+{
+    switch (_ClassifyUsdObjectsChanged(notice)) {
+    case _UsdChangeType::kIgnored: return true;
+    case _UsdChangeType::kResync: ++_UsdStageResyncCounter;
+    // [[fallthrough]]; // We want that fallthrough to have the update always triggered.
+    case _UsdChangeType::kUpdate: ++_UsdStageUpdateCounter; break;
+    }
+
+    return false;
+}
+
+MInt64 MayaUsdProxyShapeUpdateManager::GetUpdateCount() { return _UsdStageUpdateCounter; }
+
+MInt64 MayaUsdProxyShapeUpdateManager::GetResyncCount() { return _UsdStageResyncCounter; }
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/nodes/proxyShapeUpdateManager.h
+++ b/lib/mayaUsd/nodes/proxyShapeUpdateManager.h
@@ -1,0 +1,47 @@
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef PXRUSDMAYA_PROXY_SHAPE_UPDATE_MANAGER_H
+#define PXRUSDMAYA_PROXY_SHAPE_UPDATE_MANAGER_H
+
+#include <mayaUsd/base/api.h>
+
+#include <pxr/pxr.h>
+#include <pxr/usd/usd/notice.h>
+
+#include <maya/MStatus.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+class MayaUsdProxyShapeUpdateManager
+{
+public:
+    MAYAUSD_CORE_PUBLIC
+    bool CanIgnoreObjectsChanged(const UsdNotice::ObjectsChanged& notice);
+
+    MAYAUSD_CORE_PUBLIC
+    MInt64 GetUpdateCount();
+
+    MAYAUSD_CORE_PUBLIC
+    MInt64 GetResyncCount();
+
+private:
+    MInt64 _UsdStageUpdateCounter { 1 };
+    MInt64 _UsdStageResyncCounter { 1 };
+};
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif

--- a/test/lib/ufe/testContextOps.py
+++ b/test/lib/ufe/testContextOps.py
@@ -1483,20 +1483,20 @@ class ContextOpsTestCase(unittest.TestCase):
         self.assertEqual(topSubset.GetFamilyNameAttr().Get(), "componentTag")
         self.assertFalse(topSubset.GetPrim().HasAPI(UsdShade.MaterialBindingAPI))
 
-        counters= { "resync": cmds.getAttr(psPathStr + '.resyncid'),
+        counters= { "resync": cmds.getAttr(psPathStr + '.resyncId'),
                     "update" : cmds.getAttr(psPathStr + '.upid')}
 
         def assertIsOnlyUpdate(self, counters, shapePathStr):
-            resyncCounter = cmds.getAttr(shapePathStr + '.resyncid')
-            updateCounter = cmds.getAttr(shapePathStr + '.updateid')
+            resyncCounter = cmds.getAttr(shapePathStr + '.resyncId')
+            updateCounter = cmds.getAttr(shapePathStr + '.updateId')
             self.assertEqual(resyncCounter, counters["resync"])
             self.assertGreater(updateCounter, counters["update"])
             counters["resync"] = resyncCounter
             counters["update"] = updateCounter
 
         def assertIsResync(self, counters, shapePathStr):
-            resyncCounter = cmds.getAttr(shapePathStr + '.resyncid')
-            updateCounter = cmds.getAttr(shapePathStr + '.updateid')
+            resyncCounter = cmds.getAttr(shapePathStr + '.resyncId')
+            updateCounter = cmds.getAttr(shapePathStr + '.updateId')
             self.assertGreater(resyncCounter, counters["resync"])
             self.assertGreater(updateCounter, counters["update"])
             counters["resync"] = resyncCounter

--- a/test/lib/ufe/testUINodeGraphNode.py
+++ b/test/lib/ufe/testUINodeGraphNode.py
@@ -60,8 +60,8 @@ class UINodeGraphNodeTestCase(unittest.TestCase):
         ball3Path = ufe.PathString.path('|transform1|proxyShape1,/Ball_set/Props/Ball_3')
         ball3SceneItem = ufe.Hierarchy.createItem(ball3Path)
 
-        initialUpdateCount = cmds.getAttr('|transform1|proxyShape1.updateid')
-        initialResyncCount = cmds.getAttr('|transform1|proxyShape1.resyncid')
+        initialUpdateCount = cmds.getAttr('|transform1|proxyShape1.updateId')
+        initialResyncCount = cmds.getAttr('|transform1|proxyShape1.resyncId')
                                           
         uiNodeGraphNode = ufe.UINodeGraphNode.uiNodeGraphNode(ball3SceneItem)
 
@@ -89,8 +89,8 @@ class UINodeGraphNodeTestCase(unittest.TestCase):
         self.assertEqual(pos4.y(), pos5.y())
 
         # None of these changes should force a render refresh:
-        self.assertEqual(initialUpdateCount, cmds.getAttr('|transform1|proxyShape1.updateid'))
-        self.assertEqual(initialResyncCount, cmds.getAttr('|transform1|proxyShape1.resyncid'))
+        self.assertEqual(initialUpdateCount, cmds.getAttr('|transform1|proxyShape1.updateId'))
+        self.assertEqual(initialResyncCount, cmds.getAttr('|transform1|proxyShape1.resyncId'))
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/ufe/testUINodeGraphNode.py
+++ b/test/lib/ufe/testUINodeGraphNode.py
@@ -60,6 +60,9 @@ class UINodeGraphNodeTestCase(unittest.TestCase):
         ball3Path = ufe.PathString.path('|transform1|proxyShape1,/Ball_set/Props/Ball_3')
         ball3SceneItem = ufe.Hierarchy.createItem(ball3Path)
 
+        initialUpdateCount = cmds.getAttr('|transform1|proxyShape1.updateid')
+        initialResyncCount = cmds.getAttr('|transform1|proxyShape1.resyncid')
+                                          
         uiNodeGraphNode = ufe.UINodeGraphNode.uiNodeGraphNode(ball3SceneItem)
 
         self.assertFalse(uiNodeGraphNode.hasPosition())
@@ -84,6 +87,10 @@ class UINodeGraphNodeTestCase(unittest.TestCase):
         pos5 = uiNodeGraphNode.getPosition()
         self.assertEqual(pos4.x(), pos5.x())
         self.assertEqual(pos4.y(), pos5.y())
+
+        # None of these changes should force a render refresh:
+        self.assertEqual(initialUpdateCount, cmds.getAttr('|transform1|proxyShape1.updateid'))
+        self.assertEqual(initialResyncCount, cmds.getAttr('|transform1|proxyShape1.resyncid'))
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
A renderer now only has to track the "updateid" and "resyncid" attributes of the stage to know if something significant happened.

All UINodeGraphNodeAPI notifications were suppressed.