### PR TITLE
Adding missing <mutex> include

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeUpdateManager.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeUpdateManager.cpp
@@ -20,6 +20,8 @@
 #include <pxr/usd/usd/tokens.h>
 #include <pxr/usd/usdUI/tokens.h>
 
+#include <mutex>
+
 using namespace MAYAUSD_NS_DEF;
 
 PXR_NAMESPACE_OPEN_SCOPE


### PR DESCRIPTION
This is needed for the calls to std::once_flag and std::call_once