### PR TITLE
Restrict namespace edits to current stage

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeUpdateManager.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeUpdateManager.cpp
@@ -20,6 +20,8 @@
 #include <pxr/usd/usd/tokens.h>
 #include <pxr/usd/usdUI/tokens.h>
 
+#include <mutex>
+
 using namespace MAYAUSD_NS_DEF;
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/lib/mayaUsd/utils/layers.cpp
+++ b/lib/mayaUsd/utils/layers.cpp
@@ -124,6 +124,17 @@ static SdfPrimSpecHandleVector _GetLocalPrimStack(const UsdPrim& prim)
     if (!stage)
         return primSpecs;
 
+    // The goal is to avoid editing non-local layers. This issue is,
+    // for example, that a rename operation would fail when applied
+    // to a prim that references a show asset because the rename operation
+    // would be attempted on the reference and classes it inherits.
+    //
+    // Concrete example:
+    //     - Create a test asset that inherits from one or more classes
+    //     - Create a prim within a Maya Usd scene that references this asset
+    //     - Attempt to rename the prim
+    //     - Observe the failure due to Sdf policy
+
     for (const SdfLayerHandle& layer : stage->GetLayerStack()) {
         const SdfPrimSpecHandle primSpec = layer->GetPrimAtPath(prim.GetPath());
         if (primSpec)


### PR DESCRIPTION
This will restrict namespace edits to your current usd stage. This avoids the issue of spanning references and inherits, etc, which will often be illegal operations. This addresses the issue I posted here:

https://github.com/Autodesk/maya-usd/issues/2953