### PR TITLE
Expose MaterialX feature in build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -375,6 +375,11 @@ def BuildAndInstall(context, buildArgs, stages):
             extraArgs.append('-DMAYA_DEVKIT_LOCATION="{devkitLocation}"'
                              .format(devkitLocation=context.devkitLocation))
 
+        if context.materialxEnabled and context.pxrUsdLocation:
+            extraArgs.append('-DCMAKE_WANT_MATERIALX_BUILD=ON')
+            extraArgs.append('-DCMAKE_PREFIX_PATH="{materialxLocation}"'
+                             .format(materialxLocation=context.pxrUsdLocation))
+
         # Many people on Windows may not have python with the 
         # debugging symbol (python27_d.lib) installed, this is the common case.
         if context.buildDebug and context.debugPython:
@@ -450,6 +455,9 @@ parser.add_argument("--pxrusd-location", type=str,
 
 parser.add_argument("--devkit-location", type=str,
                     help="Directory where Maya Devkit is installed.")
+
+parser.add_argument("--materialx", dest="build_materialx", action="store_true",
+                    help="Build with MaterialX features enabled. Must provide a USD location built with MaterialX support.")
 
 varGroup = parser.add_mutually_exclusive_group()
 varGroup.add_argument("--build-debug", dest="build_debug", action="store_true",
@@ -541,6 +549,9 @@ class InstallContext:
         # Qt Location
         self.qtLocation = (os.path.abspath(args.qt_location)
                            if args.qt_location else None)
+
+        # MaterialX
+        self.materialxEnabled = args.build_materialx
 
         # Log File Name
         logFileName="build_log.txt"

--- a/doc/MaterialX.md
+++ b/doc/MaterialX.md
@@ -84,7 +84,7 @@ The same spheres exported with MaterialX shading and loaded as a USD stage: ![al
 
 Two options:
 - Install MayaUSD v0.16.0 on top of Maya 2022.3 or PR132
-- Rebuild tip of MayaUSD repo using a MaterialX-enabled build of USD and a supported Maya version
+- Rebuild tip of MayaUSD repo using a MaterialX-enabled build of USD and a supported Maya version using the `--materialx` option to enable MaterialX in MayaUSD.
 
 Once the updated plugin is in use, the viewport will automatically select MaterialX shading over UsdPreviewSurface shading if the referenced USD stage contains MaterialX shading networks.
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -96,11 +96,12 @@ Windows:
 c:\maya-usd> python build.py --maya-location "C:\Program Files\Autodesk\Maya2020" --pxrusd-location C:\USD-Release --devkit-location C:\devkitBase C:\workspace
 ```
 
-##### Build Arguments
+##### Optional Build Arguments
 
 | Flag                  | Description                                                                           |
 |--------------------   |---------------------------------------------------------------------------------------|
 |   --build-args        | comma-separated list of cmake variables can be also passed to build system.           |
+|   --materialx         | build with MaterialX features enabled. Must provide a USD location built with MaterialX support. |
 
 ```
 --build-args="-DBUILD_ADSK_PLUGIN=ON,-DBUILD_PXR_PLUGIN=OFF,-DBUILD_TESTS=OFF"


### PR DESCRIPTION
Previously required injecting definitions directly in the CMake command line.