### PR TITLE
Remove explicit call to sceneIndex::Populate

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeUpdateManager.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeUpdateManager.cpp
@@ -20,6 +20,8 @@
 #include <pxr/usd/usd/tokens.h>
 #include <pxr/usd/usdUI/tokens.h>
 
+#include <mutex>
+
 using namespace MAYAUSD_NS_DEF;
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
+++ b/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
@@ -133,7 +133,9 @@ void MayaUsdProxyShapeSceneIndex::Populate()
             // care of inside MayaUsdProxyShapeSceneIndex::_StageSet callback.
             {
                 _usdImagingStageSceneIndex->SetStage(stage);
+#if PXR_VERSION <= 2302
                 _usdImagingStageSceneIndex->Populate();
+#endif
                 _populated = true;
             }
         }


### PR DESCRIPTION
In most recent USD, Populate is called from within SetStage, so there is no need to callsites to call it explicitly