### PR TITLE
MAYA-128607 fix dynamic attribute short names

### DIFF
--- a/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
@@ -577,7 +577,11 @@ void UsdMayaMeshReadUtils::setEmitNormalsTag(MFnMesh& meshFn, const bool emitNor
     MStatus             status { MS::kSuccess };
     MFnNumericAttribute nAttr;
     MObject             attr = nAttr.create(
-        _meshTokens->USD_EmitNormals.GetText(), "", MFnNumericData::kBoolean, 0, &status);
+        _meshTokens->USD_EmitNormals.GetText(),
+        _meshTokens->USD_EmitNormals.GetText(),
+        MFnNumericData::kBoolean,
+        0,
+        &status);
     if (status == MS::kSuccess) {
         meshFn.addAttribute(attr);
         MPlug plug = meshFn.findPlug(attr);

--- a/lib/mayaUsd/utils/dynamicAttribute.cpp
+++ b/lib/mayaUsd/utils/dynamicAttribute.cpp
@@ -34,7 +34,8 @@ MStatus createDynamicAttribute(MFnDependencyNode& depNode, const MString& attrNa
     MStatus status;
 
     MFnTypedAttribute typedAttrFn;
-    MObject attr = typedAttrFn.create(attrName, attrName, MFnData::kString, MObject::kNullObj, &status);
+    MObject           attr
+        = typedAttrFn.create(attrName, attrName, MFnData::kString, MObject::kNullObj, &status);
     CHECK_MSTATUS_AND_RETURN_IT(status);
 
     typedAttrFn.setReadable(true);

--- a/lib/mayaUsd/utils/dynamicAttribute.cpp
+++ b/lib/mayaUsd/utils/dynamicAttribute.cpp
@@ -34,7 +34,7 @@ MStatus createDynamicAttribute(MFnDependencyNode& depNode, const MString& attrNa
     MStatus status;
 
     MFnTypedAttribute typedAttrFn;
-    MObject attr = typedAttrFn.create(attrName, "", MFnData::kString, MObject::kNullObj, &status);
+    MObject attr = typedAttrFn.create(attrName, attrName, MFnData::kString, MObject::kNullObj, &status);
     CHECK_MSTATUS_AND_RETURN_IT(status);
 
     typedAttrFn.setReadable(true);


### PR DESCRIPTION
Usd the same name as the long name. Other code do the same elsewhere, so this seems like a valid thing to do. These are our private attributes, so we don't need the short names to be really short.