### PR TITLE
MAYA128513 edit routing of composite commands

### DIFF
--- a/lib/mayaUsd/python/wrapEditRouter.cpp
+++ b/lib/mayaUsd/python/wrapEditRouter.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include <mayaUsd/utils/editRouter.h>
+#include <mayaUsd/utils/editRouterContext.h>
 
 #include <pxr/base/tf/pyError.h>
 #include <pxr/base/tf/pyLock.h>
@@ -86,6 +87,18 @@ private:
     PyObject* _pyCb;
 };
 
+MayaUsd::OperationEditRouterContext*
+OperationEditRouterContextInit(const PXR_NS::TfToken& operationName, const PXR_NS::UsdPrim& prim)
+{
+    return new MayaUsd::OperationEditRouterContext(operationName, prim);
+}
+
+MayaUsd::AttributeEditRouterContext*
+AttributeEditRouterContextInit(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attributeName)
+{
+    return new MayaUsd::AttributeEditRouterContext(prim, attributeName);
+}
+
 } // namespace
 
 void wrapEditRouter()
@@ -105,4 +118,12 @@ void wrapEditRouter()
     def("restoreDefaultEditRouter", &MayaUsd::restoreDefaultEditRouter);
 
     def("restoreAllDefaultEditRouters", &MayaUsd::restoreAllDefaultEditRouters);
+
+    using OpThis = MayaUsd::OperationEditRouterContext;
+    class_<OpThis, boost::noncopyable>("OperationEditRouterContext", no_init)
+        .def("__init__", make_constructor(OperationEditRouterContextInit));
+
+    using AttrThis = MayaUsd::AttributeEditRouterContext;
+    class_<AttrThis, boost::noncopyable>("AttributeEditRouterContextInit", no_init)
+        .def("__init__", make_constructor(AttributeEditRouterContextInit));
 }

--- a/lib/mayaUsd/ufe/UsdObject3d.cpp
+++ b/lib/mayaUsd/ufe/UsdObject3d.cpp
@@ -18,9 +18,9 @@
 #include <mayaUsd/ufe/UsdUndoVisibleCommand.h>
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/utils/editRouter.h>
+#include <mayaUsd/utils/editRouterContext.h>
 #include <mayaUsd/utils/util.h>
 
-#include <pxr/usd/usd/editContext.h>
 #include <pxr/usd/usd/timeCode.h>
 #include <pxr/usd/usdGeom/bboxCache.h>
 #include <pxr/usd/usdGeom/tokens.h>
@@ -98,8 +98,7 @@ bool UsdObject3d::visibility() const
 
 void UsdObject3d::setVisibility(bool vis)
 {
-    PXR_NS::SdfLayerHandle layer = getAttrEditRouterLayer(fPrim, UsdGeomTokens->visibility);
-    PXR_NS::UsdEditContext ctx(fPrim.GetStage(), layer);
+    AttributeEditRouterContext ctx(fPrim, UsdGeomTokens->visibility);
 
     vis ? UsdGeomImageable(fPrim).MakeVisible() : UsdGeomImageable(fPrim).MakeInvisible();
 }

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
@@ -21,6 +21,7 @@
 #include <mayaUsd/base/tokens.h>
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/utils/editRouter.h>
+#include <mayaUsd/utils/editRouterContext.h>
 #include <mayaUsd/utils/loadRules.h>
 #ifdef UFE_V2_FEATURES_AVAILABLE
 #include <mayaUsd/undo/UsdUndoBlock.h>
@@ -59,7 +60,6 @@ UsdUndoDuplicateCommand::UsdUndoDuplicateCommand(const UsdSceneItem::Ptr& srcIte
     _usdDstPath = parentPrim.GetPath().AppendChild(TfToken(newName));
 
     _srcLayer = MayaUsdUtils::getDefiningLayerAndPath(srcPrim).layer;
-    _dstLayer = getEditRouterLayer(MayaUsdEditRoutingTokens->RouteDuplicate, srcPrim);
 }
 
 UsdUndoDuplicateCommand::~UsdUndoDuplicateCommand() { }
@@ -84,6 +84,9 @@ void UsdUndoDuplicateCommand::execute()
     auto prim = ufePathToPrim(_ufeSrcPath);
     auto path = prim.GetPath();
     auto stage = prim.GetStage();
+
+    OperationEditRouterContext ctx(MayaUsdEditRoutingTokens->RouteDuplicate, prim);
+    _dstLayer = stage->GetEditTarget().GetLayer();
 
     auto                               item = Ufe::Hierarchy::createItem(_ufeSrcPath);
     MayaUsd::ufe::ReplicateExtrasToUSD extras;

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
@@ -22,6 +22,7 @@
 
 #include <mayaUsd/base/tokens.h>
 #include <mayaUsd/utils/editRouter.h>
+#include <mayaUsd/utils/editRouterContext.h>
 #include <mayaUsd/utils/layers.h>
 #include <mayaUsd/utils/loadRules.h>
 #include <mayaUsdUtils/util.h>
@@ -133,7 +134,6 @@ UsdUndoInsertChildCommand::UsdUndoInsertChildCommand(
     ufe::applyCommandRestriction(parentPrim, "reparent");
 
     _childLayer = childPrim.GetStage()->GetEditTarget().GetLayer();
-    _parentLayer = getEditRouterLayer(MayaUsdEditRoutingTokens->RouteParent, parentPrim);
 }
 
 UsdUndoInsertChildCommand::~UsdUndoInsertChildCommand() { }
@@ -246,6 +246,12 @@ void UsdUndoInsertChildCommand::insertChildRedo()
 {
     if (_usdDstPath.IsEmpty()) {
         const auto& parentPrim = ufePathToPrim(_ufeParentPath);
+
+        // Enforce the edit routing for the insert-child command in order to find
+        // the target layer. The edit router context sets the edit target of the
+        // stage of the given prim, if it gets routed.
+        OperationEditRouterContext ctx(MayaUsdEditRoutingTokens->RouteParent, parentPrim);
+        _parentLayer = parentPrim.GetStage()->GetEditTarget().GetLayer();
 
         // First, check if we need to rename the child.
         const auto childName = uniqueChildName(parentPrim, _ufeSrcPath.back().string());

--- a/lib/mayaUsd/ufe/UsdUndoVisibleCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoVisibleCommand.cpp
@@ -19,6 +19,7 @@
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/undo/UsdUndoBlock.h>
 #include <mayaUsd/utils/editRouter.h>
+#include <mayaUsd/utils/editRouterContext.h>
 
 #include <pxr/usd/usdGeom/imageable.h>
 
@@ -29,10 +30,9 @@ UsdUndoVisibleCommand::UsdUndoVisibleCommand(const UsdPrim& prim, bool vis)
     : Ufe::UndoableCommand()
     , _prim(prim)
     , _visible(vis)
-    , _layer(getEditRouterLayer(MayaUsdEditRoutingTokens->RouteVisibility, prim))
 {
-    EditTargetGuard  guard(prim, _layer);
-    UsdGeomImageable primImageable(prim);
+    OperationEditRouterContext ctx(MayaUsdEditRoutingTokens->RouteVisibility, prim);
+    UsdGeomImageable           primImageable(prim);
     enforceAttributeEditAllowed(primImageable.GetVisibilityAttr());
 }
 
@@ -53,7 +53,7 @@ void UsdUndoVisibleCommand::execute()
 
     UsdUndoBlock undoBlock(&_undoableItem);
 
-    EditTargetGuard guard(_prim, _layer);
+    OperationEditRouterContext ctx(MayaUsdEditRoutingTokens->RouteVisibility, _prim);
 
     _visible ? primImageable.MakeVisible() : primImageable.MakeInvisible();
 }

--- a/lib/mayaUsd/ufe/UsdUndoVisibleCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoVisibleCommand.h
@@ -53,8 +53,6 @@ private:
 
     bool _visible;
 
-    PXR_NS::SdfLayerHandle _layer;
-
     UsdUndoableItem _undoableItem;
 
 }; // UsdUndoVisibleCommand

--- a/lib/mayaUsd/utils/CMakeLists.txt
+++ b/lib/mayaUsd/utils/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(${PROJECT_NAME}
         dynamicAttribute.cpp
         editability.cpp
         editRouter.cpp
+        editRouterContext.cpp
         layerMuting.cpp
         layers.cpp
         loadRules.cpp
@@ -48,6 +49,7 @@ set(HEADERS
     dynamicAttribute.h
     editability.h
     editRouter.h
+    editRouterContext.h
     hash.h
     layerMuting.h
     layers.h

--- a/lib/mayaUsd/utils/editRouter.h
+++ b/lib/mayaUsd/utils/editRouter.h
@@ -64,23 +64,6 @@ private:
     EditRouterCb _cb;
 };
 
-// Guard class that holds previous edit target
-// Note : _prevEditTarget is a by-value copy rather than reference
-// since a reference does not change the edit target upon destruction
-class MAYAUSD_CORE_PUBLIC EditTargetGuard
-{
-public:
-    EditTargetGuard(const PXR_NS::UsdPrim& prim, const PXR_NS::UsdEditTarget& editTarget);
-
-    ~EditTargetGuard();
-
-private:
-    const PXR_NS::UsdPrim& _prim;
-
-    // The previous edit target, as a by-value copy.
-    const PXR_NS::UsdEditTarget _prevEditTarget;
-};
-
 using EditRouters
     = PXR_NS::TfHashMap<PXR_NS::TfToken, EditRouter::Ptr, PXR_NS::TfToken::HashFunctor>;
 
@@ -97,8 +80,8 @@ getEditRouterLayer(const PXR_NS::TfToken& operation, const PXR_NS::UsdPrim& prim
 MAYAUSD_CORE_PUBLIC
 EditRouter::Ptr getEditRouter(const PXR_NS::TfToken& operation);
 
-// Retrieve the edit router for the "attribute" operation for teh given attribute.  If no such edit
-// router exist, the current edit target layer is returned.
+// Retrieve the layer for the attribute operation. If no edit router for the
+// "attribute" operationis found, a nullptr is returned.
 MAYAUSD_CORE_PUBLIC
 PXR_NS::SdfLayerHandle
 getAttrEditRouterLayer(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attrName);
@@ -108,12 +91,13 @@ MAYAUSD_CORE_PUBLIC
 void registerEditRouter(const PXR_NS::TfToken& operation, const EditRouter::Ptr& editRouter);
 
 // Restore the default edit router for the argument operation, overwriting
-// the currently-registered edit router.  Returns false if no such default
-// exists.
+// the currently-registered edit router.  Returns false if no such operation
+// exists among the registered edit routers.
 MAYAUSD_CORE_PUBLIC
 bool restoreDefaultEditRouter(const PXR_NS::TfToken& operation);
 
-// Restore all the default edit router, overwriting the currently-registered edit routers.
+// Restore all the default edit routers, overwriting the currently-registered edit routers.
+// Also remove all routers that have no default.
 MAYAUSD_CORE_PUBLIC
 void restoreAllDefaultEditRouters();
 

--- a/lib/mayaUsd/utils/editRouterContext.cpp
+++ b/lib/mayaUsd/utils/editRouterContext.cpp
@@ -1,0 +1,108 @@
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "editRouterContext.h"
+
+#include <mayaUsd/utils/editRouter.h>
+
+#include <pxr/base/tf/instantiateStacked.h>
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+TF_INSTANTIATE_STACKED(MAYAUSD_NS_DEF::StackedEditRouterContext);
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+namespace MAYAUSD_NS_DEF {
+
+StackedEditRouterContext::StackedEditRouterContext(
+    const PXR_NS::UsdStagePtr&    stage,
+    const PXR_NS::SdfLayerHandle& layer)
+    : _stage(stage)
+    , _layer(layer)
+    , _previousTarget()
+{
+    if (stage && layer) {
+        _previousTarget = stage->GetEditTarget();
+        stage->SetEditTarget(layer);
+    }
+}
+
+StackedEditRouterContext::~StackedEditRouterContext()
+{
+    if (_stage && _layer) {
+        _stage->SetEditTarget(_previousTarget);
+    }
+}
+
+const PXR_NS::SdfLayerHandle& StackedEditRouterContext::getLayer() const
+{
+    if (_layer)
+        return _layer;
+
+    if (const StackedEditRouterContext* ctx = GetStackPrevious())
+        return ctx->getLayer();
+
+    static const PXR_NS::SdfLayerHandle empty;
+    return empty;
+}
+
+bool StackedEditRouterContext::isTargetAlreadySet() const
+{
+    // Use the edit target of a edit router context higher-up in the call
+    // stack only if it is not ourself and if it had been routed to a specific
+    // layer.
+    for (const StackedEditRouterContext* ctx : GetStack())
+        if (ctx && ctx != this && ctx->getLayer())
+            return true;
+
+    return false;
+}
+
+PXR_NS::SdfLayerHandle OperationEditRouterContext::getOperationLayer(
+    const PXR_NS::TfToken& operationName,
+    const PXR_NS::UsdPrim& prim)
+{
+    if (isTargetAlreadySet())
+        return nullptr;
+
+    return getEditRouterLayer(operationName, prim);
+}
+
+OperationEditRouterContext::OperationEditRouterContext(
+    const PXR_NS::TfToken& operationName,
+    const PXR_NS::UsdPrim& prim)
+    : StackedEditRouterContext(prim.GetStage(), getOperationLayer(operationName, prim))
+{
+}
+
+PXR_NS::SdfLayerHandle AttributeEditRouterContext::getAttributeLayer(
+    const PXR_NS::UsdPrim& prim,
+    const PXR_NS::TfToken& attributeName)
+{
+    if (isTargetAlreadySet())
+        return nullptr;
+
+    return getAttrEditRouterLayer(prim, attributeName);
+}
+
+AttributeEditRouterContext::AttributeEditRouterContext(
+    const PXR_NS::UsdPrim& prim,
+    const PXR_NS::TfToken& attributeName)
+    : StackedEditRouterContext(prim.GetStage(), getAttributeLayer(prim, attributeName))
+{
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/editRouterContext.h
+++ b/lib/mayaUsd/utils/editRouterContext.h
@@ -1,0 +1,109 @@
+//
+// Copyright 2021 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <mayaUsd/base/api.h>
+
+#include <pxr/base/tf/stacked.h>
+#include <pxr/base/tf/token.h>
+#include <pxr/usd/sdf/layer.h>
+#include <pxr/usd/usd/editTarget.h>
+#include <pxr/usd/usd/prim.h>
+#include <pxr/usd/usd/stage.h>
+
+namespace MAYAUSD_NS_DEF {
+
+/*! \brief Base class for recursive edit router context.
+ *
+ * Only its sub-classes should be used, which is why its constructor is protected.
+ */
+
+class MAYAUSD_CORE_PUBLIC StackedEditRouterContext
+    : public PXR_NS::TfStacked<StackedEditRouterContext>
+{
+protected:
+    /*! \brief Retrieve the current targeted layer.
+     * \return The targeted layer. Null if the edit target was not changed.
+     */
+    const PXR_NS::SdfLayerHandle& getLayer() const;
+
+    /*! \brief Check if an edit context higher-up in the call-stack of this
+     *         thread already routed the edits to a specific layer.
+     */
+    bool isTargetAlreadySet() const;
+
+    /*! \brief Set the edit target of the given stage to the given layer.
+     *         If the layer is null, then the target is not changed.
+     */
+    StackedEditRouterContext(const PXR_NS::UsdStagePtr& stage, const PXR_NS::SdfLayerHandle& layer);
+    ~StackedEditRouterContext();
+
+private:
+    PXR_NS::UsdStagePtr    _stage;
+    PXR_NS::SdfLayerHandle _layer;
+    PXR_NS::UsdEditTarget  _previousTarget;
+};
+
+/*! \brief Select the target layer for an operation, via the edit router.
+ *
+ * Commands and other code that wish to be routable via an operation name
+ * should use this instead of the native USD USdEditContext class.
+ *
+ * Support nesting properly, so that if a composite command is routed to a layer,
+ * all sub-commands will use that layer and not individually routted layers. The
+ * nesting is per-thread.
+ *
+ * We may add ways for edit routers of sub-command to force routing to a different
+ * layer in the future. Using this class will make this transparent.
+ */
+
+class MAYAUSD_CORE_PUBLIC OperationEditRouterContext : public StackedEditRouterContext
+{
+public:
+    /*! \brief Route the given operation on a prim.
+     */
+    OperationEditRouterContext(const PXR_NS::TfToken& operationName, const PXR_NS::UsdPrim& prim);
+
+private:
+    PXR_NS::SdfLayerHandle
+    getOperationLayer(const PXR_NS::TfToken& operationName, const PXR_NS::UsdPrim& prim);
+};
+
+/*! \brief Select the target layer when modifying USD attributes, via the edit router.
+ *
+ * Commands and other code that wish to be routable when modifying an USD attribute
+ * should use this instead of the native USD USdEditContext class.
+ *
+ * Support nesting properly, so that if a composite command is routed to a layer,
+ * all sub-commands will use that layer and not individually routted layers. The
+ * nesting is per-thread.
+ *
+ * We may add ways for edit routers of sub-command to force routing to a different
+ * layer in the future. Using this class will make this transparent.
+ */
+class MAYAUSD_CORE_PUBLIC AttributeEditRouterContext : public StackedEditRouterContext
+{
+public:
+    /*! \brief Route an attribute operation on a prim for the given attribute.
+     */
+    AttributeEditRouterContext(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attributeName);
+
+private:
+    PXR_NS::SdfLayerHandle
+    getAttributeLayer(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attributeName);
+};
+
+} // namespace MAYAUSD_NS_DEF

--- a/test/lib/ufe/testEditRouting.py
+++ b/test/lib/ufe/testEditRouting.py
@@ -5,6 +5,7 @@ from maya import cmds
 from maya import standalone
 import mayaUsd.ufe
 import mayaUtils
+import ufeUtils
 import ufe
 import unittest
 import usdUtils
@@ -383,6 +384,7 @@ class EditRoutingTestCase(unittest.TestCase):
  
         self._verifyEditRouterPreventingCmd('duplicate', duplicate, verifyNoDuplicate)
  
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2024, 'Requires fixes in Maya only from 2024 onward.')
     def testPreventParentingCmd(self):
         '''
         Test edit router preventing the parent operation by raising an exception.
@@ -397,6 +399,7 @@ class EditRoutingTestCase(unittest.TestCase):
  
         self._verifyEditRouterPreventingCmd('parent', group, verifyNoGroup)
  
+    @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 4, 'UFE composite commands only available in Python from UFE v4.')
     def testRoutingCompositeCmd(self):
         '''
         Test that an edit router for a composite command prevent routing of sub-commands.
@@ -441,6 +444,7 @@ class EditRoutingTestCase(unittest.TestCase):
         self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
                          'def Xform "A"\n{\n}\ndef Xform "B"\n{\n    token visibility = "invisible"\n}')
 
+    @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 4, 'UFE composite commands only available in Python from UFE v4.')
     def testNotRoutingCompositeCmd(self):
         '''
         Test that a composite command with not edit router registered works as expected.

--- a/test/lib/ufe/testEditRouting.py
+++ b/test/lib/ufe/testEditRouting.py
@@ -10,11 +10,20 @@ import unittest
 import usdUtils
 from pxr import UsdGeom
 
+#####################################################################
+#
+# Helper to compare strings.
+
 def filterUsdStr(usdSceneStr):
     '''Remove empty lines and lines starting with pound character.'''
     nonBlankLines = filter(None, [l.rstrip() for l in usdSceneStr.splitlines()])
     finalLines = [l for l in nonBlankLines if not l.startswith('#')]
     return '\n'.join(finalLines)
+
+
+#####################################################################
+#
+# Edit routers used in test
 
 def routeCmdToSessionLayer(context, routingData):
     '''
@@ -26,6 +35,17 @@ def routeCmdToSessionLayer(context, routingData):
         return
     
     routingData['layer'] = prim.GetStage().GetSessionLayer().identifier
+    
+def routeCmdToRootLayer(context, routingData):
+    '''
+    Edit router for commands, routing to the root layer.
+    '''
+    prim = context.get('prim')
+    if prim is None:
+        print('Prim not in context')
+        return
+    
+    routingData['layer'] = prim.GetStage().GetRootLayer().identifier
     
 def routeVisibilityAttribute(context, routingData):
     '''
@@ -48,7 +68,51 @@ def preventCommandRouter(context, routingData):
     '''
     opName = context.get('operation') or 'operation'
     raise Exception('Sorry, %s is not permitted' % opName)
-    
+
+class CustomCompositeCmd(ufe.CompositeUndoableCommand):
+    '''
+    Custom composite command that route using the 'custom' operation.
+    '''
+
+    # The name of the composite operation. Used for edit routing.
+    # Registering an edit router for this operation will affect this
+    # composite command and its sub-commands.
+    customOpName = 'custom'
+
+    def __init__(self, prim, sceneItem):
+        super().__init__()
+        self._prim = prim
+        # Note: the edit router must be kept alive in a variable to affect
+        #       subsequent code, in particular the creation of sub-commands.
+        ctx = mayaUsd.lib.OperationEditRouterContext(self.customOpName, self._prim)
+        o3d = ufe.Object3d.object3d(sceneItem)
+        self.append(o3d.setVisibleCmd(False))
+
+    def execute(self):
+        # Note: the edit router must be kept alive in a variable to affect
+        #       the call to the base class implementation where sub-commands
+        #       are executed.
+        ctx = mayaUsd.lib.OperationEditRouterContext(self.customOpName, self._prim)
+        super().execute()
+
+    def undo(self):
+        # Note: the edit router must be kept alive in a variable to affect
+        #       the call to the base class implementation where sub-commands
+        #       are undone.
+        ctx = mayaUsd.lib.OperationEditRouterContext(self.customOpName, self._prim)
+        super().undo()
+
+    def redo(self):
+        # Note: the edit router must be kept alive in a variable to affect
+        #       the call to the base class implementation where sub-commands
+        #       are redone.
+        ctx = mayaUsd.lib.OperationEditRouterContext('custom', self._prim)
+        super().redo()
+
+
+#####################################################################
+#
+# Tests
 
 class EditRoutingTestCase(unittest.TestCase):
     '''Verify the Maya Edit Router for visibility.'''
@@ -333,6 +397,87 @@ class EditRoutingTestCase(unittest.TestCase):
  
         self._verifyEditRouterPreventingCmd('parent', group, verifyNoGroup)
  
+    def testRoutingCompositeCmd(self):
+        '''
+        Test that an edit router for a composite command prevent routing of sub-commands.
+        The B xform will be in the global selection and is assumed to be affected by the command.
+        '''
+        # Get the session layer
+        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
+        stage = prim.GetStage()
+        sessionLayer = stage.GetSessionLayer()
+ 
+        # Check that the session layer is empty
+        self.assertTrue(sessionLayer.empty)
+
+        # Check to root layer only contains bare A and B xforms.
+        rootLayer = stage.GetRootLayer()
+        self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
+                         'def Xform "A"\n{\n}\ndef Xform "B"\n{\n}')
+ 
+        # Route the visibility command to the session layer.
+        # Route the custom composite command to the root layer.
+        # The composite command routing shoud win.
+        mayaUsd.lib.registerEditRouter('visibility', routeCmdToSessionLayer)
+        mayaUsd.lib.registerEditRouter('custom', routeCmdToRootLayer)
+ 
+        # Select /B
+        sn = ufe.GlobalSelection.get()
+        sn.clear()
+        sn.append(self.b)
+ 
+        # try to affect B via the command, should be prevented
+        compCmd = CustomCompositeCmd(prim, self.b)
+        compCmd.execute()
+ 
+        # Check that nothing was written to the session layer
+        self.assertIsNotNone(sessionLayer)
+        self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
+                         '')
+        self.assertTrue(sessionLayer.empty)
+ 
+        # Check that visibility was written to the root layer
+        rootLayer = stage.GetRootLayer()
+        self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
+                         'def Xform "A"\n{\n}\ndef Xform "B"\n{\n    token visibility = "invisible"\n}')
+
+    def testNotRoutingCompositeCmd(self):
+        '''
+        Test that a composite command with not edit router registered works as expected.
+        '''
+        # Get the session layer
+        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
+        stage = prim.GetStage()
+        sessionLayer = stage.GetSessionLayer()
+ 
+        # Check that the session layer is empty
+        self.assertTrue(sessionLayer.empty)
+
+        # Check to root layer only contains bare A and B xforms.
+        rootLayer = stage.GetRootLayer()
+        self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
+                         'def Xform "A"\n{\n}\ndef Xform "B"\n{\n}')
+ 
+        # Select /B
+        sn = ufe.GlobalSelection.get()
+        sn.clear()
+        sn.append(self.b)
+ 
+        # try to affect B via the command, should be prevented
+        compCmd = CustomCompositeCmd(prim, self.b)
+        compCmd.execute()
+ 
+        # Check that nothing was written to the session layer
+        self.assertIsNotNone(sessionLayer)
+        self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
+                         '')
+        self.assertTrue(sessionLayer.empty)
+ 
+        # Check that visibility was written to the root layer
+        rootLayer = stage.GetRootLayer()
+        self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
+                         'def Xform "A"\n{\n}\ndef Xform "B"\n{\n    token visibility = "invisible"\n}')
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/ufe/testEditRouting.py
+++ b/test/lib/ufe/testEditRouting.py
@@ -369,7 +369,7 @@ class EditRoutingTestCase(unittest.TestCase):
 
         self._verifyEditRouterPreventingCmd('visibility', hide, verifyNoHide)
  
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2025, 'Requires Maya fixes for duplicate command error messages only available in Maya 2025 or greater.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() > 2024, 'Requires Maya fixes for duplicate command error messages only available in versions of Maya greater than 2024.')
     def testPreventDuplicateCmd(self):
         '''
         Test edit router preventing the duplicate command by raising an exception.
@@ -384,7 +384,7 @@ class EditRoutingTestCase(unittest.TestCase):
  
         self._verifyEditRouterPreventingCmd('duplicate', duplicate, verifyNoDuplicate)
  
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2025, 'Requires fixes in Maya only from 2025 onward.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() > 2024, 'Requires fixes in versions of Maya greater than 2024.')
     def testPreventParentingCmd(self):
         '''
         Test edit router preventing the parent operation by raising an exception.

--- a/test/lib/ufe/testEditRouting.py
+++ b/test/lib/ufe/testEditRouting.py
@@ -384,7 +384,7 @@ class EditRoutingTestCase(unittest.TestCase):
  
         self._verifyEditRouterPreventingCmd('duplicate', duplicate, verifyNoDuplicate)
  
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2024, 'Requires fixes in Maya only from 2024 onward.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2025, 'Requires fixes in Maya only from 2025 onward.')
     def testPreventParentingCmd(self):
         '''
         Test edit router preventing the parent operation by raising an exception.


### PR DESCRIPTION
Add a context classes that reuse previous edit routing before doing a new edit routing.

- One is OperationEditRouterContext, used to route commands.
- The other is AttributeEditRouterContext, used to route attribute modifications.
- This is done by keeping track of edit routing contexts higher in the call stack.
- Remove the EditTargetGuard class since it was doing the same work as USD UsdEditContext class.
- Add documentation about how to route a custom composite command.

Modified the commands that were routing edits to use the new EditRoutingContext. This makes the code using them clearer.
- Fetch the current edit target via the stage, not the context, since the context may not have a target layer if the operation was not routed.

Correctly support absence of edit router. This happens for custom commands that do not have built-in default edit router. It also makes the code more general, consistent and safe.

- Make the edit router lookup functions always return a null layer handler when there is no edit router.
- Make these same functions also return null if the router does not route to a layer.
- This allows the caller to know if the editing is not routed.
- This is necessary to make nested routing work.
- Make the edit router context use the fact that the layer is null to know it is not being routed.
- Allow removing an edit router of a custom command in the restoreDefaultEditRouter function.
- Make the registered edit routers container be initialized dynamically by wrapping it in a function.

Add unit tests:
- Added a unit test for composite command edit routing.
- The unit test serves as an example of how to route composite commands.
- The unit test validates the Python binding.