### PR TITLE
MAYA-128199 fix error on save

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -163,10 +163,10 @@ void convertAnonymousLayersRecursive(
         parentPtr._proxyPath = basename;
     } else if (stage->GetSessionLayer() == layer) {
         parentPtr._layerParent = nullptr;
-        parentPtr._proxyPath.clear();
+        parentPtr._proxyPath = basename;
     } else {
         parentPtr._layerParent = layer;
-        parentPtr._proxyPath.clear();
+        parentPtr._proxyPath = basename;
     }
 
     std::vector<std::string> sublayers = layer->GetSubLayerPaths();
@@ -788,7 +788,12 @@ BatchSaveResult LayerDatabase::saveUsdToUsdFiles()
                 SdfLayerHandleVector allLayers = info.stage->GetLayerStack(false);
                 for (auto layer : allLayers) {
                     if (layer->PermissionToSave()) {
-                        MayaUsd::utils::saveLayerWithFormat(layer);
+                        if (!MayaUsd::utils::saveLayerWithFormat(layer)) {
+                            MString errMsg;
+                            MString layerName(layer->GetDisplayName().c_str());
+                            errMsg.format("Could not save layer ^1s.", layerName);
+                            MGlobal::displayError(errMsg);
+                        }
                     }
                 }
             }
@@ -814,14 +819,22 @@ void LayerDatabase::convertAnonymousLayers(
     //       to convertAnonymousLayersRecursive
     root = stage->GetRootLayer();
     if (root->IsAnonymous()) {
+        const bool wasTargetLayer = (stage->GetEditTarget().GetLayer() == root);
         PXR_NS::SdfFileFormat::FileFormatArguments args;
         std::string newFileName = MayaUsd::utils::generateUniqueFileName(proxyName);
         if (UsdMayaUtilFileSystem::requireUsdPathsRelativeToMayaSceneFile()) {
             newFileName = UsdMayaUtilFileSystem::getPathRelativeToMayaSceneFile(newFileName);
         }
-        MayaUsd::utils::saveLayerWithFormat(root, newFileName);
+        if (!MayaUsd::utils::saveLayerWithFormat(root, newFileName)) {
+            MString errMsg;
+            MString layerName(root->GetDisplayName().c_str());
+            errMsg.format("Could not save layer ^1s.", layerName);
+            MGlobal::displayError(errMsg);
+        }
 
-        MayaUsd::utils::setNewProxyPath(pShape->name(), UsdMayaUtil::convert(newFileName));
+        SdfLayerRefPtr newLayer = SdfLayer::FindOrOpen(newFileName);
+        MayaUsd::utils::setNewProxyPath(
+            pShape->name(), UsdMayaUtil::convert(newFileName), newLayer, wasTargetLayer);
     }
 
     SdfLayerHandle session = stage->GetSessionLayer();
@@ -830,6 +843,7 @@ void LayerDatabase::convertAnonymousLayers(
 
         saveUsdLayerToMayaFile(session, true);
 
+        // TODO: should update the target layer of the proxy shape if the session was the target.
         setValueForAttr(
             proxyNode,
             MayaUsdProxyShapeBase::sessionLayerNameAttr,

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -240,18 +240,22 @@ MStatus UsdMayaUtil::GetMObjectByName(const std::string& nodeName, MObject& mObj
     return GetMObjectByName(MString(nodeName.c_str()), mObj);
 }
 
-UsdStageRefPtr UsdMayaUtil::GetStageByProxyName(const std::string& proxyPath)
+MayaUsdProxyShapeBase* UsdMayaUtil::GetProxyShapeByProxyName(const std::string& proxyPath)
 {
     MObject mobj;
     MStatus status = UsdMayaUtil::GetMObjectByName(proxyPath, mobj);
-    if (status == MStatus::kSuccess) {
-        MFnDependencyNode fn;
-        fn.setObject(mobj);
-        MayaUsdProxyShapeBase* pShape = static_cast<MayaUsdProxyShapeBase*>(fn.userNode());
-        return pShape ? pShape->getUsdStage() : nullptr;
-    }
+    if (status != MStatus::kSuccess)
+        return nullptr;
 
-    return nullptr;
+    MFnDependencyNode fn;
+    fn.setObject(mobj);
+    return static_cast<MayaUsdProxyShapeBase*>(fn.userNode());
+}
+
+UsdStageRefPtr UsdMayaUtil::GetStageByProxyName(const std::string& proxyPath)
+{
+    MayaUsdProxyShapeBase* pShape = UsdMayaUtil::GetProxyShapeByProxyName(proxyPath);
+    return pShape ? pShape->getUsdStage() : nullptr;
 }
 
 MStatus UsdMayaUtil::GetPlugByName(const std::string& attrPath, MPlug& plug)

--- a/lib/mayaUsd/utils/util.h
+++ b/lib/mayaUsd/utils/util.h
@@ -17,6 +17,7 @@
 #define PXRUSDMAYA_UTIL_H
 
 #include <mayaUsd/base/api.h>
+#include <mayaUsd/nodes/proxyShapeBase.h>
 
 #include <pxr/base/gf/vec2f.h>
 #include <pxr/base/gf/vec3f.h>
@@ -184,6 +185,10 @@ MStatus GetMObjectByName(const std::string& nodeName, MObject& mObj);
 /// Gets the Maya MObject for the node named \p nodeName.
 MAYAUSD_CORE_PUBLIC
 MStatus GetMObjectByName(const MString& nodeName, MObject& mObj);
+
+/// Gets the proxy shape node named \p nodeName.
+MAYAUSD_CORE_PUBLIC
+MayaUsdProxyShapeBase* GetProxyShapeByProxyName(const std::string& nodeName);
 
 /// Gets the UsdStage for the proxy shape  node named \p nodeName.
 MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -17,8 +17,6 @@
 
 #include <mayaUsd/base/tokens.h>
 #include <mayaUsd/fileio/jobs/jobArgs.h>
-#include <mayaUsd/ufe/Global.h>
-#include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/utils/stageCache.h>
 #include <mayaUsd/utils/targetLayer.h>
 #include <mayaUsd/utils/util.h>

--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -118,7 +118,8 @@ void updateRootLayer(
     const std::string& fp = layerPath;
 #endif
 
-    MayaUsd::utils::setNewProxyPath(MString(proxy.c_str()), MString(fp.c_str()), layer, isTargetLayer);
+    MayaUsd::utils::setNewProxyPath(
+        MString(proxy.c_str()), MString(fp.c_str()), layer, isTargetLayer);
 }
 
 void updateAllCachedStageWithLayer(SdfLayerRefPtr originalLayer, const std::string& newFilePath)

--- a/lib/mayaUsd/utils/utilSerialization.h
+++ b/lib/mayaUsd/utils/utilSerialization.h
@@ -62,10 +62,15 @@ MAYAUSD_CORE_PUBLIC
 USDUnsavedEditsOption serializeUsdEditsLocationOption();
 
 /*! \brief Utility function to update the file path attribute on the proxy shape
-    when an anonymous root layer gets exported to disk.
+    when an anonymous root layer gets exported to disk. Also optionally updates
+    the target layer if the anonymous layer was the target layer.
  */
 MAYAUSD_CORE_PUBLIC
-void setNewProxyPath(const MString& proxyNodeName, const MString& newValue);
+void setNewProxyPath(
+    const MString&        proxyNodeName,
+    const MString&        newValue,
+    const SdfLayerRefPtr& layer,
+    bool                  isTargetLayer);
 
 struct LayerParent
 {

--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -352,7 +352,12 @@ void LayerTreeItem::saveEditsNoPrompt()
         if (!isSessionLayer())
             saveAnonymousLayer();
     } else {
-        MayaUsd::utils::saveLayerWithFormat(layer());
+        if (!MayaUsd::utils::saveLayerWithFormat(layer())) {
+            MString errMsg;
+            MString layerName(layer()->GetDisplayName().c_str());
+            errMsg.format("Could not save layer ^1s.", layerName);
+            MGlobal::displayError(errMsg);
+        }
     }
 }
 


### PR DESCRIPTION
The problem was that when saving an anonynous layer, the stage changes since the root layer changes identity. We need to set the target layer, but not on the current stage, but on the new computed stage.

Also, I added error messages when a save operation fails.

- Add a helper function to retrieve the proxy shape node from its node name.
- Pass the new layer to the helper function that sets the new proxy path of the proxy shape.
- Make sure that all layer info contain the proxy shape path since it is needed to update the target layer when a target anonymous layer is saved.
- Renamed the saveRootLayer function to updateRootLayer since it is not saving the layer, it is updating the proxy shape.