### PR TITLE
MAYA-127095 remove usage of macros leading to fatal exits

### DIFF
--- a/doc/codingGuidelines.md
+++ b/doc/codingGuidelines.md
@@ -165,7 +165,7 @@ In general, macros should be avoided (see [Modern C++](https://docs.google.com/d
 inline PXR_NS::UsdPrim prim() const
 {
     PXR_NAMESPACE_USING_DIRECTIVE
-    TF_AXIOM(fItem != nullptr);
+    TF_VERIFY(fItem != nullptr);
     return fItem->prim();
 }
 ```

--- a/lib/mayaUsd/fileio/primUpdater.cpp
+++ b/lib/mayaUsd/fileio/primUpdater.cpp
@@ -71,7 +71,9 @@ bool UsdMayaPrimUpdater::canEditAsMaya() const
     // prim will round-trip back through export, so we do not check for
     // exporter (to USD) capability.
     auto prim = MayaUsd::ufe::ufePathToPrim(_path);
-    TF_AXIOM(prim);
+    // Invalid prim cannot be edited.
+    if (!prim)
+        return false;
     return (UsdMayaPrimReaderRegistry::Find(prim.GetTypeName()) != nullptr);
 }
 

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -239,7 +239,7 @@ bool allowTopologyModifications(MDagPath& root)
 // prim as the root of the USD hierarchy to be pulled.  The UFE path and
 // the prim refer to the same object: the prim is passed in as an
 // optimization to avoid an additional call to ufePathToPrim().
-using PullImportPaths = std::pair<std::vector<MDagPath>, std::vector<Ufe::Path>>;
+using PullImportPaths = std::vector<std::pair<MDagPath, Ufe::Path>>;
 PullImportPaths pullImport(
     const Ufe::Path&                 ufePulledPath,
     const UsdPrim&                   pulledPrim,
@@ -282,14 +282,13 @@ PullImportPaths pullImport(
     }
     progressBar.advance();
 
-    std::vector<MDagPath>  addedDagPaths;
-    std::vector<Ufe::Path> pulledUfePaths;
+    std::vector<MDagPath> addedDagPaths;
 
     // Execute the command, which can succeed but import nothing.
     bool success = readJob->Read(&addedDagPaths);
     if (!success || addedDagPaths.size() == 0) {
         TF_WARN("Nothing to edit in the selection.");
-        return PullImportPaths({}, {});
+        return PullImportPaths();
     }
     progressBar.advance();
 
@@ -423,17 +422,18 @@ PullImportPaths pullImport(
     progressBar.advance();
 
     // For each added Dag path, get the UFE path of the pulled USD prim.
-    pulledUfePaths.reserve(addedDagPaths.size());
+    PullImportPaths pulledPaths;
+    pulledPaths.reserve(addedDagPaths.size());
     for (const auto& dagPath : addedDagPaths) {
         auto found = objToUfePath.find(MObjectHandle(dagPath.node()));
-        TF_AXIOM(found != objToUfePath.end());
-        pulledUfePaths.emplace_back(found->second);
+        if (TF_VERIFY(found != objToUfePath.end())) {
+            pulledPaths.emplace_back(std::make_pair(dagPath, found->second));
+        }
     }
     progressBar.advance();
 
-    auto ret = PullImportPaths(addedDagPaths, pulledUfePaths);
     progressBar.advance();
-    return ret;
+    return pulledPaths;
 }
 
 //------------------------------------------------------------------------------
@@ -460,18 +460,15 @@ bool pullCustomize(const PullImportPaths& importedPaths, const UsdMayaPrimUpdate
 {
     // The number of imported paths should (hopefully) never be so great
     // as to overwhelm the computation with progress bar updates.
-    MayaUsd::ProgressBarScope progressBar(importedPaths.first.size());
+    MayaUsd::ProgressBarScope progressBar(importedPaths.size());
 
     // Record all USD modifications in an undo block and item.
     UsdUndoBlock undoBlock(
         &UsdUndoableItemUndoItem::create("Pull customize USD data modifications"));
 
-    TF_AXIOM(importedPaths.first.size() == importedPaths.second.size());
-    auto dagPathIt = importedPaths.first.begin();
-    auto ufePathIt = importedPaths.second.begin();
-    for (; dagPathIt != importedPaths.first.end(); ++dagPathIt, ++ufePathIt) {
-        const auto&       dagPath = *dagPathIt;
-        const auto&       pulledUfePath = *ufePathIt;
+    for (const auto& importedPair : importedPaths) {
+        const auto&       dagPath = importedPair.first;
+        const auto&       pulledUfePath = importedPair.second;
         MFnDependencyNode dgNodeFn(dagPath.node());
 
         auto registryItem = getUpdaterItem(dgNodeFn);
@@ -1156,7 +1153,7 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
 
     // 1) Perform the import
     PullImportPaths importedPaths = pullImport(path, pulledPrim, context);
-    if (importedPaths.first.empty()) {
+    if (importedPaths.empty()) {
         return false;
     }
     progressBar.advance();
@@ -1170,7 +1167,7 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
 
 #ifdef HAS_ORPHANED_NODES_MANAGER
     if (_orphanedNodesManager) {
-        RecordPullVariantInfoUndoItem::execute(_orphanedNodesManager, path, importedPaths.first[0]);
+        RecordPullVariantInfoUndoItem::execute(_orphanedNodesManager, path, importedPaths[0].first);
     }
 #endif
 
@@ -1498,7 +1495,6 @@ bool PrimUpdaterManager::duplicate(
     }
     // Copy from DG to USD
     else if (srcProxyShape == nullptr && dstProxyShape) {
-        TF_AXIOM(srcPath.nbSegments() == 1);
         MDagPath dagPath = PXR_NS::UsdMayaUtil::nameToDagPath(Ufe::PathString::string(srcPath));
         if (!dagPath.isValid()) {
             return false;

--- a/lib/mayaUsd/ufe/UsdCamera.h
+++ b/lib/mayaUsd/ufe/UsdCamera.h
@@ -51,8 +51,10 @@ public:
     inline PXR_NS::UsdPrim prim() const
     {
         PXR_NAMESPACE_USING_DIRECTIVE
-        TF_AXIOM(fItem != nullptr);
-        return fItem->prim();
+        if (TF_VERIFY(fItem != nullptr))
+            return fItem->prim();
+        else
+            return PXR_NS::UsdPrim();
     }
 
     // Ufe::Camera overrides

--- a/lib/mayaUsd/ufe/UsdConnections.cpp
+++ b/lib/mayaUsd/ufe/UsdConnections.cpp
@@ -41,9 +41,8 @@ UsdConnections::UsdConnections(const Ufe::SceneItem::Ptr& item)
     , _sceneItem(std::dynamic_pointer_cast<UsdSceneItem>(item))
 #endif
 {
-    if (!TF_VERIFY(_sceneItem)) {
-        TF_FATAL_ERROR("Invalid scene item.");
-    }
+    // Note: TF_VERIFY emits a TF_CODING_ERROR.
+    TF_VERIFY(_sceneItem);
 }
 
 UsdConnections::~UsdConnections() { }
@@ -55,7 +54,8 @@ UsdConnections::Ptr UsdConnections::create(const Ufe::SceneItem::Ptr& item)
 
 std::vector<Ufe::Connection::Ptr> UsdConnections::allConnections() const
 {
-    TF_AXIOM(_sceneItem);
+    if (!TF_VERIFY(_sceneItem))
+        return {};
 
     std::vector<Ufe::Connection::Ptr> result;
 

--- a/lib/mayaUsd/ufe/UsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/UsdContextOps.cpp
@@ -1176,7 +1176,8 @@ Ufe::UndoableCommand::Ptr UsdContextOps::doOpCmd(const ItemPath& itemPath)
     } // Variant sets
     else if (itemPath[0] == kUSDToggleVisibilityItem) {
         auto object3d = UsdObject3d::create(fItem);
-        TF_AXIOM(object3d);
+        if (!TF_VERIFY(object3d))
+            return nullptr;
         auto current = object3d->visibility();
         return object3d->setVisibleCmd(!current);
     } // Visibility

--- a/lib/mayaUsd/ufe/UsdContextOps.h
+++ b/lib/mayaUsd/ufe/UsdContextOps.h
@@ -66,8 +66,10 @@ public:
     inline PXR_NS::UsdPrim prim() const
     {
         PXR_NAMESPACE_USING_DIRECTIVE
-        TF_AXIOM(fItem != nullptr);
-        return fItem->prim();
+        if (TF_VERIFY(fItem != nullptr))
+            return fItem->prim();
+        else
+            return PXR_NS::UsdPrim();
     }
 
     // When we are created from the ProxyShapeContextOpsHandler we do not have the proper

--- a/lib/mayaUsd/ufe/UsdHierarchy.h
+++ b/lib/mayaUsd/ufe/UsdHierarchy.h
@@ -53,8 +53,10 @@ public:
     inline PXR_NS::UsdPrim prim() const
     {
         PXR_NAMESPACE_USING_DIRECTIVE
-        TF_AXIOM(fItem != nullptr);
-        return fItem->prim();
+        if (TF_VERIFY(fItem != nullptr))
+            return fItem->prim();
+        else
+            return PXR_NS::UsdPrim();
     }
 
     UsdSceneItem::Ptr usdSceneItem() const;

--- a/lib/mayaUsd/ufe/UsdLight.h
+++ b/lib/mayaUsd/ufe/UsdLight.h
@@ -49,8 +49,10 @@ public:
     inline PXR_NS::UsdPrim prim() const
     {
         PXR_NAMESPACE_USING_DIRECTIVE
-        TF_AXIOM(fItem != nullptr);
-        return fItem->prim();
+        if (TF_VERIFY(fItem != nullptr))
+            return fItem->prim();
+        else
+            return PXR_NS::UsdPrim();
     }
 
     // Ufe::Light overrides

--- a/lib/mayaUsd/ufe/UsdPathMappingHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdPathMappingHandler.cpp
@@ -109,7 +109,7 @@ Ufe::Path UsdPathMappingHandler::toHost(const Ufe::Path& runTimePath) const { re
 
 Ufe::Path UsdPathMappingHandler::fromHost(const Ufe::Path& hostPath) const
 {
-    TF_AXIOM(hostPath.nbSegments() == 1);
+    TF_VERIFY(hostPath.nbSegments() == 1);
 
     // First look in our cache to see if we've already computed a mapping for the input.
     auto found = fromHostCache.find(hostPath);
@@ -134,7 +134,9 @@ Ufe::Path UsdPathMappingHandler::fromHost(const Ufe::Path& hostPath) const
     Ufe::Path                    mayaMappedPath;
     Ufe::PathSegment::Components mayaComps;
     while (dagPath.isValid() && (dagPath.length() > 0)) {
-        TF_AXIOM(!mayaHostPath.empty());
+        if (!TF_VERIFY(!mayaHostPath.empty())) {
+            return {};
+        }
         mayaComps.emplace_back(mayaHostPath.back());
         mayaHostPath = mayaHostPath.pop();
         Ufe::Path ufePath;
@@ -143,7 +145,9 @@ Ufe::Path UsdPathMappingHandler::fromHost(const Ufe::Path& hostPath) const
             // append the Maya component array.
             std::reverse(mayaComps.begin(), mayaComps.end());
 
-            TF_AXIOM(ufePath.nbSegments() == 2);
+            if (!TF_VERIFY(ufePath.nbSegments() == 2)) {
+                return {};
+            }
             const auto& usdSegment = ufePath.getSegments()[1];
             mayaMappedPath = ufePath.popSegment() + replaceLastComponent(usdSegment, mayaComps);
 

--- a/lib/mayaUsd/ufe/UsdRotatePivotTranslateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdRotatePivotTranslateUndoableCommand.h
@@ -75,8 +75,10 @@ public:
     inline PXR_NS::UsdPrim prim() const
     {
         PXR_NAMESPACE_USING_DIRECTIVE
-        TF_AXIOM(fItem != nullptr);
-        return fItem->prim();
+        if (TF_VERIFY(fItem != nullptr))
+            return fItem->prim();
+        else
+            return PXR_NS::UsdPrim();
     }
 
 private:

--- a/lib/mayaUsd/ufe/UsdSceneItemOps.h
+++ b/lib/mayaUsd/ufe/UsdSceneItemOps.h
@@ -49,8 +49,10 @@ public:
     inline PXR_NS::UsdPrim prim() const
     {
         PXR_NAMESPACE_USING_DIRECTIVE
-        TF_AXIOM(fItem != nullptr);
-        return fItem->prim();
+        if (TF_VERIFY(fItem != nullptr))
+            return fItem->prim();
+        else
+            return PXR_NS::UsdPrim();
     }
 
     //@{

--- a/lib/mayaUsd/ufe/UsdShaderAttributeDef.cpp
+++ b/lib/mayaUsd/ufe/UsdShaderAttributeDef.cpp
@@ -47,19 +47,19 @@ UsdShaderAttributeDef::~UsdShaderAttributeDef() { }
 
 std::string UsdShaderAttributeDef::name() const
 {
-    TF_AXIOM(fShaderAttributeDef);
+    TF_DEV_AXIOM(fShaderAttributeDef);
     return fShaderAttributeDef->GetName().GetString();
 }
 
 std::string UsdShaderAttributeDef::type() const
 {
-    TF_AXIOM(fShaderAttributeDef);
+    TF_DEV_AXIOM(fShaderAttributeDef);
     return usdTypeToUfe(fShaderAttributeDef);
 }
 
 std::string UsdShaderAttributeDef::defaultValue() const
 {
-    TF_AXIOM(fShaderAttributeDef);
+    TF_DEV_AXIOM(fShaderAttributeDef);
     std::ostringstream defaultValue;
     defaultValue << fShaderAttributeDef->GetDefaultValue();
     return defaultValue.str();
@@ -67,7 +67,7 @@ std::string UsdShaderAttributeDef::defaultValue() const
 
 Ufe::AttributeDef::IOType UsdShaderAttributeDef::ioType() const
 {
-    TF_AXIOM(fShaderAttributeDef);
+    TF_DEV_AXIOM(fShaderAttributeDef);
     return fShaderAttributeDef->IsOutput() ? Ufe::AttributeDef::OUTPUT_ATTR
                                            : Ufe::AttributeDef::INPUT_ATTR;
 }
@@ -131,7 +131,7 @@ static const MetadataMap _metaMap = {
 
 Ufe::Value UsdShaderAttributeDef::getMetadata(const std::string& key) const
 {
-    TF_AXIOM(fShaderAttributeDef);
+    TF_DEV_AXIOM(fShaderAttributeDef);
     const NdrTokenMap& metadata = fShaderAttributeDef->GetMetadata();
     auto               it = metadata.find(TfToken(key));
     if (it != metadata.cend()) {
@@ -154,7 +154,7 @@ Ufe::Value UsdShaderAttributeDef::getMetadata(const std::string& key) const
 
 bool UsdShaderAttributeDef::hasMetadata(const std::string& key) const
 {
-    TF_AXIOM(fShaderAttributeDef);
+    TF_DEV_AXIOM(fShaderAttributeDef);
     const NdrTokenMap& metadata = fShaderAttributeDef->GetMetadata();
     auto               it = metadata.find(TfToken(key));
     if (it != metadata.cend()) {

--- a/lib/mayaUsd/ufe/UsdShaderAttributeHolder.cpp
+++ b/lib/mayaUsd/ufe/UsdShaderAttributeHolder.cpp
@@ -52,7 +52,9 @@ UsdShaderAttributeHolder::UsdShaderAttributeHolder(
 
     // sdrProp must be valid at creation and will stay valid.
     PXR_NAMESPACE_USING_DIRECTIVE
-    TF_AXIOM(sdrProp && sdrType != PXR_NS::UsdShadeAttributeType::Invalid);
+    if (!TF_VERIFY(sdrProp && sdrType != PXR_NS::UsdShadeAttributeType::Invalid)) {
+        throw std::runtime_error("Invalid shader attribute holder");
+    }
 }
 
 UsdAttributeHolder::UPtr UsdShaderAttributeHolder::create(

--- a/lib/mayaUsd/ufe/UsdShaderNodeDef.cpp
+++ b/lib/mayaUsd/ufe/UsdShaderNodeDef.cpp
@@ -107,7 +107,7 @@ const Ufe::ConstAttributeDefs& UsdShaderNodeDef::outputs() const { return fOutpu
 
 std::string UsdShaderNodeDef::type() const
 {
-    TF_AXIOM(fShaderNodeDef);
+    TF_DEV_AXIOM(fShaderNodeDef);
     return fShaderNodeDef->GetIdentifier();
 }
 
@@ -137,7 +137,7 @@ bool _isArnoldWithIssue1214(const PXR_NS::SdrShaderNode& shaderNodeDef)
 
 std::size_t UsdShaderNodeDef::nbClassifications() const
 {
-    TF_AXIOM(fShaderNodeDef);
+    TF_DEV_AXIOM(fShaderNodeDef);
 
     // Based on a review of all items found in the Sdr registry as of USD 21.11:
 
@@ -169,7 +169,7 @@ std::size_t UsdShaderNodeDef::nbClassifications() const
 
 std::string UsdShaderNodeDef::classification(std::size_t level) const
 {
-    TF_AXIOM(fShaderNodeDef);
+    TF_DEV_AXIOM(fShaderNodeDef);
     if (fShaderNodeDef->GetFamily().IsEmpty()) {
         switch (level) {
         // UsdLux:
@@ -215,7 +215,7 @@ std::string UsdShaderNodeDef::classification(std::size_t level) const
 
 std::vector<std::string> UsdShaderNodeDef::inputNames() const
 {
-    TF_AXIOM(fShaderNodeDef);
+    TF_DEV_AXIOM(fShaderNodeDef);
     std::vector<std::string> retVal;
     auto names = fShaderNodeDef->GetInputNames();
     retVal.reserve(names.size());
@@ -227,13 +227,13 @@ std::vector<std::string> UsdShaderNodeDef::inputNames() const
 
 bool UsdShaderNodeDef::hasInput(const std::string& name) const
 {
-    TF_AXIOM(fShaderNodeDef);
+    TF_DEV_AXIOM(fShaderNodeDef);
     return fShaderNodeDef->GetShaderInput(TfToken(name));
 }
 
 Ufe::AttributeDef::ConstPtr UsdShaderNodeDef::input(const std::string& name) const
 {
-    TF_AXIOM(fShaderNodeDef);
+    TF_DEV_AXIOM(fShaderNodeDef);
     if (SdrShaderPropertyConstPtr property = fShaderNodeDef->GetShaderInput(TfToken(name))) {
         return Ufe::AttributeDef::ConstPtr(new UsdShaderAttributeDef(property));
     }
@@ -242,13 +242,13 @@ Ufe::AttributeDef::ConstPtr UsdShaderNodeDef::input(const std::string& name) con
 
 Ufe::ConstAttributeDefs UsdShaderNodeDef::inputs() const
 {
-    TF_AXIOM(fShaderNodeDef);
+    TF_DEV_AXIOM(fShaderNodeDef);
     return getAttrs<Ufe::AttributeDef::INPUT_ATTR>(fShaderNodeDef);
 }
 
 std::vector<std::string> UsdShaderNodeDef::outputNames() const
 {
-    TF_AXIOM(fShaderNodeDef);
+    TF_DEV_AXIOM(fShaderNodeDef);
     std::vector<std::string> retVal;
     auto names = fShaderNodeDef->GetOutputNames();
     retVal.reserve(names.size());
@@ -260,13 +260,13 @@ std::vector<std::string> UsdShaderNodeDef::outputNames() const
 
 bool UsdShaderNodeDef::hasOutput(const std::string& name) const
 {
-    TF_AXIOM(fShaderNodeDef);
+    TF_DEV_AXIOM(fShaderNodeDef);
     return fShaderNodeDef->GetShaderOutput(TfToken(name));
 }
 
 Ufe::AttributeDef::ConstPtr UsdShaderNodeDef::output(const std::string& name) const
 {
-    TF_AXIOM(fShaderNodeDef);
+    TF_DEV_AXIOM(fShaderNodeDef);
     if (SdrShaderPropertyConstPtr property = fShaderNodeDef->GetShaderOutput(TfToken(name))) {
         return Ufe::AttributeDef::ConstPtr(new UsdShaderAttributeDef(property));
     }
@@ -275,7 +275,7 @@ Ufe::AttributeDef::ConstPtr UsdShaderNodeDef::output(const std::string& name) co
 
 Ufe::ConstAttributeDefs UsdShaderNodeDef::outputs() const
 {
-    TF_AXIOM(fShaderNodeDef);
+    TF_DEV_AXIOM(fShaderNodeDef);
     return getAttrs<Ufe::AttributeDef::OUTPUT_ATTR>(fShaderNodeDef);
 }
 
@@ -305,7 +305,7 @@ static const MetadataMap _metaMap = {
 
 Ufe::Value UsdShaderNodeDef::getMetadata(const std::string& key) const
 {
-    TF_AXIOM(fShaderNodeDef);
+    TF_DEV_AXIOM(fShaderNodeDef);
     const NdrTokenMap& metadata = fShaderNodeDef->GetMetadata();
     auto it = metadata.find(TfToken(key));
     if (it != metadata.cend()) {
@@ -322,7 +322,7 @@ Ufe::Value UsdShaderNodeDef::getMetadata(const std::string& key) const
 
 bool UsdShaderNodeDef::hasMetadata(const std::string& key) const
 {
-    TF_AXIOM(fShaderNodeDef);
+    TF_DEV_AXIOM(fShaderNodeDef);
     const NdrTokenMap& metadata = fShaderNodeDef->GetMetadata();
     auto it = metadata.find(TfToken(key));
     if (it != metadata.cend()) {
@@ -341,7 +341,7 @@ Ufe::SceneItem::Ptr UsdShaderNodeDef::createNode(
     const Ufe::SceneItem::Ptr& parent,
     const Ufe::PathComponent& name) const
 {
-    TF_AXIOM(fShaderNodeDef);
+    TF_DEV_AXIOM(fShaderNodeDef);
     UsdSceneItem::Ptr parentItem = std::dynamic_pointer_cast<UsdSceneItem>(parent);
     if (parentItem) {
         UsdUndoCreateFromNodeDefCommand::Ptr cmd
@@ -358,7 +358,7 @@ Ufe::InsertChildCommand::Ptr UsdShaderNodeDef::createNodeCmd(
     const Ufe::SceneItem::Ptr& parent,
     const Ufe::PathComponent& name) const
 {
-    TF_AXIOM(fShaderNodeDef);
+    TF_DEV_AXIOM(fShaderNodeDef);
     UsdSceneItem::Ptr parentItem = std::dynamic_pointer_cast<UsdSceneItem>(parent);
     if (parentItem) {
         return UsdUndoCreateFromNodeDefCommand::create(

--- a/lib/mayaUsd/ufe/UsdStageMap.cpp
+++ b/lib/mayaUsd/ufe/UsdStageMap.cpp
@@ -186,7 +186,7 @@ MObject UsdStageMap::proxyShape(const Ufe::Path& path)
             if (newPath != cachedPath) {
                 // Key is stale.  Remove it from our cache, and add the new entry.
                 auto count = fPathToObject.erase(cachedPath);
-                TF_AXIOM(count);
+                TF_VERIFY(count);
                 if (!newPath.empty())
                     fPathToObject[newPath] = cachedObject;
             }

--- a/lib/mayaUsd/ufe/UsdTransform3d.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3d.cpp
@@ -23,6 +23,7 @@
 #include <mayaUsd/ufe/UsdTranslateUndoableCommand.h>
 #include <mayaUsd/ufe/Utils.h>
 
+#include <pxr/base/tf/stringUtils.h>
 #include <pxr/usd/usdGeom/xformCache.h>
 
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -231,8 +232,9 @@ Ufe::Matrix4d UsdTransform3d::matrix() const
 
     // 4x4 local affine transformation matrix. 4th column of matrix is [0 0 0 1]
     if (!UsdGeomXformable::GetLocalTransformation(&m, ops, getTime(path()))) {
-        TF_FATAL_ERROR(
+        std::string msg = TfStringPrintf(
             "Local transformation computation for prim %s failed.", prim().GetPath().GetText());
+        throw std::runtime_error(msg.c_str());
     }
 
     return convertFromUsd(m);

--- a/lib/mayaUsd/ufe/UsdTransform3d.h
+++ b/lib/mayaUsd/ufe/UsdTransform3d.h
@@ -54,8 +54,10 @@ public:
     inline PXR_NS::UsdPrim prim() const
     {
         PXR_NAMESPACE_USING_DIRECTIVE
-        TF_AXIOM(fItem != nullptr);
-        return fItem->prim();
+        if (TF_VERIFY(fItem != nullptr))
+            return fItem->prim();
+        else
+            return PXR_NS::UsdPrim();
     }
 
     inline UsdSceneItem::Ptr usdSceneItem() const { return fItem; }

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
@@ -19,6 +19,7 @@
 #include <mayaUsd/ufe/UsdTransform3dUndoableCommands.h>
 #include <mayaUsd/ufe/Utils.h>
 
+#include <pxr/base/tf/stringUtils.h>
 #include <pxr/usd/usdGeom/xformCache.h>
 
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -137,8 +138,9 @@ Ufe::Vector3d UsdTransform3dCommonAPI::translation() const
     UsdGeomXformCommonAPI::RotationOrder rotOrder;
 
     if (!_commonAPI.GetXformVectorsByAccumulation(&t, &r, &s, &pvt, &rotOrder, getTime(path()))) {
-        TF_FATAL_ERROR(
+        std::string msg = TfStringPrintf(
             "Cannot read common API transform values for prim %s", prim().GetPath().GetText());
+        throw std::runtime_error(msg.c_str());
     }
 
     return toUfe(t);
@@ -151,8 +153,9 @@ Ufe::Vector3d UsdTransform3dCommonAPI::rotation() const
     UsdGeomXformCommonAPI::RotationOrder rotOrder;
 
     if (!_commonAPI.GetXformVectorsByAccumulation(&t, &r, &s, &pvt, &rotOrder, getTime(path()))) {
-        TF_FATAL_ERROR(
+        std::string msg = TfStringPrintf(
             "Cannot read common API transform values for prim %s", prim().GetPath().GetText());
+        throw std::runtime_error(msg.c_str());
     }
 
     return toUfe(r);
@@ -165,8 +168,9 @@ Ufe::Vector3d UsdTransform3dCommonAPI::scale() const
     UsdGeomXformCommonAPI::RotationOrder rotOrder;
 
     if (!_commonAPI.GetXformVectorsByAccumulation(&t, &r, &s, &pvt, &rotOrder, getTime(path()))) {
-        TF_FATAL_ERROR(
+        std::string msg = TfStringPrintf(
             "Cannot read common API transform values for prim %s", prim().GetPath().GetText());
+        throw std::runtime_error(msg.c_str());
     }
 
     return toUfe(s);
@@ -238,8 +242,9 @@ Ufe::Vector3d UsdTransform3dCommonAPI::rotatePivot() const
     UsdGeomXformCommonAPI::RotationOrder rotOrder;
 
     if (!_commonAPI.GetXformVectorsByAccumulation(&t, &r, &s, &pvt, &rotOrder, getTime(path()))) {
-        TF_FATAL_ERROR(
+        std::string msg = TfStringPrintf(
             "Cannot read common API transform values for prim %s", prim().GetPath().GetText());
+        throw std::runtime_error(msg.c_str());
     }
 
     return toUfe(pvt);

--- a/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.cpp
@@ -20,6 +20,7 @@
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/ufe/XformOpUtils.h>
 
+#include <pxr/base/tf/stringUtils.h>
 #include <pxr/usd/usdGeom/xformCache.h>
 
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -120,7 +121,6 @@ bool setXformOpOrder(const UsdGeomXformable& xformable)
     bool resetsXformStack = false;
     auto oldOrder = xformable.GetOrderedXformOps(&resetsXformStack);
     auto i = findFirstFallbackOp(oldOrder);
-    TF_AXIOM(i != oldOrder.end());
 
     // Copy ops before the Maya sub-stack unchanged.
     std::vector<UsdGeomXformOp> newOrder;
@@ -173,10 +173,6 @@ Ufe::Transform3d::Ptr createEditTransform3dImp(
     bool resetsXformStack = false;
     xformOps = xformSchema.GetOrderedXformOps(&resetsXformStack);
 
-    // We are the fallback Transform3d handler: there must be transform ops to
-    // match.
-    TF_AXIOM(!xformOps.empty());
-
     // We find the first transform op in the vector that has our fallback
     // component token in its attribute name.  From that point on, all
     // remaining transform ops must match a Maya transform stack with the
@@ -224,8 +220,9 @@ Ufe::Transform3d::Ptr createTransform3d(const Ufe::SceneItem::Ptr& item)
 
     GfMatrix4d ml { 1 };
     if (!UsdGeomXformable::GetLocalTransformation(&ml, mlOps, getTime(item->path()))) {
-        TF_FATAL_ERROR(
+        std::string msg = TfStringPrintf(
             "Local transformation computation for item %s failed.", item->path().string().c_str());
+        throw std::runtime_error(msg.c_str());
     }
 
     // The Maya fallback transform stack is the last group of transform ops in

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -26,6 +26,7 @@
 
 #include <pxr/base/gf/rotation.h>
 #include <pxr/base/gf/transform.h>
+#include <pxr/base/tf/stringUtils.h>
 #include <pxr/usd/usdGeom/xformCache.h>
 #include <pxr/usd/usdGeom/xformOp.h>
 #include <pxr/usd/usdGeom/xformable.h>
@@ -83,8 +84,9 @@ GfMatrix4d xformInv(
 
     GfMatrix4d m { 1 };
     if (!UsdGeomXformable::GetLocalTransformation(&m, ops, getTime(path))) {
-        TF_FATAL_ERROR(
+        std::string msg = TfStringPrintf(
             "Local transformation computation for item %s failed.", path.string().c_str());
+        throw std::runtime_error(msg.c_str());
     }
 
     return m.GetInverse();
@@ -189,7 +191,9 @@ public:
         GfMatrix4d unusedR, unusedP;
         GfVec3d    s;
         if (!opTransform.Factor(&unusedR, &s, &fU, &fT, &unusedP)) {
-            TF_FATAL_ERROR("Cannot decompose transform for op %s", op.GetOpName().GetText());
+            std::string msg
+                = TfStringPrintf("Cannot decompose transform for op %s", op.GetOpName().GetText());
+            throw std::runtime_error(msg.c_str());
         }
 
         fS = GfMatrix4d(GfVec4d(s[0], s[1], s[2], 1.0));
@@ -233,7 +237,9 @@ public:
         GfMatrix4d unusedR, unusedP;
         GfVec3d    unusedS;
         if (!opTransform.Factor(&unusedR, &unusedS, &fU, &fT, &unusedP)) {
-            TF_FATAL_ERROR("Cannot decompose transform for op %s", op.GetOpName().GetText());
+            std::string msg
+                = TfStringPrintf("Cannot decompose transform for op %s", op.GetOpName().GetText());
+            throw std::runtime_error(msg.c_str());
         }
     }
 

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
@@ -371,13 +371,31 @@ private:
     UsdTransform3dMayaXformStack::CvtRotXYZToAttrFn _cvtRotXYZToAttr;
 };
 
+struct SceneItemHolder
+{
+    SceneItemHolder(const BaseUndoableCommand& cmd)
+    {
+        _sceneItem = std::dynamic_pointer_cast<UsdSceneItem>(cmd.sceneItem());
+        if (!_sceneItem) {
+            throw std::runtime_error("Cannot transform invalid scene item");
+        }
+    }
+
+    UsdSceneItem& item() const { return *_sceneItem; }
+
+private:
+    std::shared_ptr<UsdSceneItem> _sceneItem;
+};
+
 } // namespace
 
 UsdTransform3dMayaXformStack::UsdTransform3dMayaXformStack(const UsdSceneItem::Ptr& item)
     : UsdTransform3dBase(item)
     , _xformable(prim())
 {
-    TF_AXIOM(_xformable);
+    if (!TF_VERIFY(_xformable)) {
+        throw std::runtime_error("Invalid scene item for transform stack");
+    }
 }
 
 /* static */
@@ -399,7 +417,7 @@ Ufe::Vector3d UsdTransform3dMayaXformStack::rotation() const
         return Ufe::Vector3d(0, 0, 0);
     }
     UsdGeomXformOp r = getOp(NdxRotate);
-    TF_AXIOM(r);
+    TF_DEV_AXIOM(r);
     if (!r.GetAttr().HasValue()) {
         return Ufe::Vector3d(0, 0, 0);
     }
@@ -414,7 +432,7 @@ Ufe::Vector3d UsdTransform3dMayaXformStack::scale() const
         return Ufe::Vector3d(1, 1, 1);
     }
     UsdGeomXformOp s = getOp(NdxScale);
-    TF_AXIOM(s);
+    TF_DEV_AXIOM(s);
     if (!s.GetAttr().HasValue()) {
         return Ufe::Vector3d(1, 1, 1);
     }
@@ -458,25 +476,25 @@ UsdTransform3dMayaXformStack::rotateCmd(double x, double y, double z)
     auto f = OpFunc(
         [attrName, opSuffix = getTRSOpSuffix(), setXformOpOrderFn = getXformOpOrderFn(), v](
             const BaseUndoableCommand& cmd) {
-            auto usdSceneItem = std::dynamic_pointer_cast<UsdSceneItem>(cmd.sceneItem());
-            TF_AXIOM(usdSceneItem);
+            SceneItemHolder usdSceneItem(cmd);
 
-            auto attr = getUsdPrimAttribute(usdSceneItem->prim(), attrName);
+            auto attr = getUsdPrimAttribute(usdSceneItem.item().prim(), attrName);
             if (attr) {
                 return UsdGeomXformOp(attr);
             } else {
                 // Use notification guard, otherwise will generate one notification
                 // for the xform op add, and another for the reorder.
                 InTransform3dChange guard(cmd.path());
-                auto usdSceneItem = std::dynamic_pointer_cast<UsdSceneItem>(cmd.sceneItem());
-                TF_AXIOM(usdSceneItem);
-                UsdGeomXformable xformable(usdSceneItem->prim());
+                UsdGeomXformable    xformable(usdSceneItem.item().prim());
 
                 auto r = xformable.AddRotateXYZOp(UsdGeomXformOp::PrecisionFloat, opSuffix);
-                TF_VERIFY(r);
+                if (!r) {
+                    throw std::runtime_error("Cannot add rotation transform operation");
+                }
                 r.Set(v);
-                auto result = setXformOpOrderFn(xformable);
-                TF_AXIOM(result);
+                if (!setXformOpOrderFn(xformable)) {
+                    throw std::runtime_error("Cannot set rotation transform operation");
+                }
 
                 return r;
             }
@@ -506,24 +524,24 @@ Ufe::ScaleUndoableCommand::Ptr UsdTransform3dMayaXformStack::scaleCmd(double x, 
     auto    f = OpFunc(
         [attrName, opSuffix = getTRSOpSuffix(), setXformOpOrderFn = getXformOpOrderFn(), v](
             const BaseUndoableCommand& cmd) {
-            auto usdSceneItem = std::dynamic_pointer_cast<UsdSceneItem>(cmd.sceneItem());
-            TF_AXIOM(usdSceneItem);
+            SceneItemHolder usdSceneItem(cmd);
 
-            auto attr = getUsdPrimAttribute(usdSceneItem->prim(), attrName);
+            auto attr = getUsdPrimAttribute(usdSceneItem.item().prim(), attrName);
             if (attr) {
                 return UsdGeomXformOp(attr);
             } else {
 
                 InTransform3dChange guard(cmd.path());
-                auto usdSceneItem = std::dynamic_pointer_cast<UsdSceneItem>(cmd.sceneItem());
-                TF_AXIOM(usdSceneItem);
-                UsdGeomXformable xformable(usdSceneItem->prim());
+                UsdGeomXformable    xformable(usdSceneItem.item().prim());
 
                 auto s = xformable.AddScaleOp(UsdGeomXformOp::PrecisionFloat, opSuffix);
-                TF_VERIFY(s);
+                if (!s) {
+                    throw std::runtime_error("Cannot add scaling transform operation");
+                }
                 s.Set(v);
-                auto result = setXformOpOrderFn(xformable);
-                TF_AXIOM(result);
+                if (!setXformOpOrderFn(xformable)) {
+                    throw std::runtime_error("Cannot set scaling transform operation");
+                }
 
                 return s;
             }
@@ -594,11 +612,8 @@ Ufe::Vector3d UsdTransform3dMayaXformStack::getVector3d(const TfToken& attrName)
         return Ufe::Vector3d(0, 0, 0);
     }
 
-    UsdGeomXformOp op(attr);
-    TF_AXIOM(op);
-
     V v;
-    op.Get(&v, getTime(path()));
+    UsdGeomXformOp(attr).Get(&v, getTime(path()));
     return toUfe(v);
 }
 
@@ -623,21 +638,22 @@ Ufe::SetVector3dUndoableCommand::Ptr UsdTransform3dMayaXformStack::setVector3dCm
         // [opSuffix, setXformOpOrderFn = getXformOpOrderFn(), v](const BaseUndoableCommand&
         // cmd) {
         [attrName, opSuffix, setXformOpOrderFn, v](const BaseUndoableCommand& cmd) {
-            auto usdSceneItem = std::dynamic_pointer_cast<UsdSceneItem>(cmd.sceneItem());
-            TF_AXIOM(usdSceneItem);
+            SceneItemHolder usdSceneItem(cmd);
 
-            auto attr = getUsdPrimAttribute(usdSceneItem->prim(), attrName);
+            auto attr = getUsdPrimAttribute(usdSceneItem.item().prim(), attrName);
             if (attr) {
                 return UsdGeomXformOp(attr);
             } else {
                 InTransform3dChange guard(cmd.path());
-                UsdGeomXformable    xformable(usdSceneItem->prim());
+                UsdGeomXformable    xformable(usdSceneItem.item().prim());
                 auto op = xformable.AddTranslateOp(OpPrecision<V>::precision, opSuffix);
-                TF_VERIFY(op);
+                if (!op) {
+                    throw std::runtime_error("Cannot add translation transform operation");
+                }
                 op.Set(v);
-                auto result = setXformOpOrderFn(xformable);
-                TF_AXIOM(result);
-
+                if (!setXformOpOrderFn(xformable)) {
+                    throw std::runtime_error("Cannot set translation transform operation");
+                }
                 return op;
             }
         });
@@ -661,12 +677,11 @@ UsdTransform3dMayaXformStack::pivotCmd(const TfToken& pvtOpSuffix, double x, dou
     GfVec3f v(x, y, z);
     auto    f = OpFunc([pvtAttrName, pvtOpSuffix, setXformOpOrderFn = getXformOpOrderFn(), v](
                         const BaseUndoableCommand& cmd) {
-        auto usdSceneItem = std::dynamic_pointer_cast<UsdSceneItem>(cmd.sceneItem());
-        TF_AXIOM(usdSceneItem);
+        SceneItemHolder usdSceneItem(cmd);
 
-        auto attr = usdSceneItem->prim().GetAttribute(pvtAttrName);
+        auto attr = usdSceneItem.item().prim().GetAttribute(pvtAttrName);
         if (attr) {
-            auto attr = usdSceneItem->prim().GetAttribute(pvtAttrName);
+            auto attr = usdSceneItem.item().prim().GetAttribute(pvtAttrName);
             return UsdGeomXformOp(attr);
         } else {
             // Without a notification guard each operation (each transform op
@@ -677,17 +692,18 @@ UsdTransform3dMayaXformStack::pivotCmd(const TfToken& pvtOpSuffix, double x, dou
             // stack.  Use of SdfChangeBlock is discouraged when calling USD
             // APIs above Sdf, so use our own guard.
             InTransform3dChange guard(cmd.path());
-            auto usdSceneItem = std::dynamic_pointer_cast<UsdSceneItem>(cmd.sceneItem());
-            TF_AXIOM(usdSceneItem);
-            UsdGeomXformable xformable(usdSceneItem->prim());
+            UsdGeomXformable    xformable(usdSceneItem.item().prim());
             auto p = xformable.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, pvtOpSuffix);
 
             auto pInv = xformable.AddTranslateOp(
                 UsdGeomXformOp::PrecisionFloat, pvtOpSuffix, /* isInverseOp */ true);
-            TF_AXIOM(p && pInv);
+            if (!(p && pInv)) {
+                throw std::runtime_error("Cannot add translation transform operation");
+            }
             p.Set(v);
-            auto result = setXformOpOrderFn(xformable);
-            TF_AXIOM(result);
+            if (!setXformOpOrderFn(xformable)) {
+                throw std::runtime_error("Cannot set translation transform operation");
+            }
             return p;
         }
     });

--- a/lib/mayaUsd/ufe/UsdTransform3dReadImpl.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dReadImpl.cpp
@@ -17,6 +17,8 @@
 
 #include <mayaUsd/ufe/Utils.h>
 
+#include <pxr/base/tf/stringUtils.h>
+
 PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace MAYAUSD_NS_DEF {
@@ -37,8 +39,9 @@ Ufe::Matrix4d UsdTransform3dReadImpl::matrix() const
         bool unused;
         auto ops = xformable.GetOrderedXformOps(&unused);
         if (!UsdGeomXformable::GetLocalTransformation(&m, ops, getTime(path()))) {
-            TF_FATAL_ERROR(
+            std::string msg = TfStringPrintf(
                 "Local transformation computation for prim %s failed.", prim().GetPath().GetText());
+            throw std::runtime_error(msg.c_str());
         }
     }
 

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -99,7 +99,8 @@ uint32_t findLayerIndex(const UsdPrim& prim, const SdfLayerHandle& layer)
     // iterate through the expanded primIndex
     for (PcpNodeRef node : primIndex.GetNodeRange()) {
 
-        TF_AXIOM(node);
+        if (!node)
+            continue;
 
         const PcpLayerStackSite&   site = node.GetSite();
         const PcpLayerStackRefPtr& layerStack = site.layerStack;
@@ -873,8 +874,11 @@ bool isAttributeEditAllowed(const PXR_NS::UsdAttribute& attr, std::string* errMs
 
 bool isAttributeEditAllowed(const UsdPrim& prim, const TfToken& attrName, std::string* errMsg)
 {
-    TF_AXIOM(prim);
-    TF_AXIOM(!attrName.IsEmpty());
+    if (!prim)
+        return false;
+
+    if (attrName.IsEmpty())
+        return false;
 
     UsdGeomXformable xformable(prim);
     if (xformable) {
@@ -1286,8 +1290,8 @@ Ufe::Selection recreateDescendants(const Ufe::Selection& src, const Ufe::Path& f
             dst.append(item);
         } else {
             auto recreatedItem = Ufe::Hierarchy::createItem(item->path());
-            TF_AXIOM(recreatedItem);
-            dst.append(recreatedItem);
+            if (recreatedItem)
+                dst.append(recreatedItem);
         }
     }
     return dst;

--- a/lib/mayaUsd/ufe/XformOpUtils.cpp
+++ b/lib/mayaUsd/ufe/XformOpUtils.cpp
@@ -16,6 +16,7 @@
 
 #include "XformOpUtils.h"
 
+#include <pxr/base/tf/stringUtils.h>
 #include <pxr/usd/usdGeom/xformable.h>
 
 #include <maya/MMatrix.h>
@@ -37,8 +38,7 @@ GfMatrix4d computeLocalTransformWithIterator(
     const UsdTimeCode&                          time)
 {
     // If we want the op to be included, increment the end op iterator.
-    if (INCLUSIVE) {
-        TF_AXIOM(endOp != ops.end());
+    if (INCLUSIVE && endOp != ops.end()) {
         ++endOp;
     }
 
@@ -49,7 +49,7 @@ GfMatrix4d computeLocalTransformWithIterator(
 
     GfMatrix4d m(1);
     if (!UsdGeomXformable::GetLocalTransformation(&m, argOps, time)) {
-        TF_FATAL_ERROR("Local transformation computation failed.");
+        throw std::runtime_error("Local transformation computation failed.");
     }
 
     return m;
@@ -74,7 +74,9 @@ computeLocalTransformWithOp(const UsdPrim& prim, const UsdGeomXformOp& op, const
 #endif
 
     if (i == ops.end()) {
-        TF_FATAL_ERROR("Matrix op %s not found in transform ops.", op.GetOpName().GetText());
+        std::string msg
+            = TfStringPrintf("Matrix op %s not found in transform ops.", op.GetOpName().GetText());
+        throw std::runtime_error(msg.c_str());
     }
 
     return computeLocalTransformWithIterator<INCLUSIVE>(ops, i, time);

--- a/lib/mayaUsd/ufe/private/Utils.cpp
+++ b/lib/mayaUsd/ufe/private/Utils.cpp
@@ -107,7 +107,7 @@ UsdGeomXformCommonAPI convertToCompatibleCommonAPI(const UsdPrim& prim)
         else {
             // Restore old
             auto result = xformable.SetXformOpOrder(xformOps);
-            TF_AXIOM(result);
+            TF_VERIFY(result);
             std::string err
                 = TfStringPrintf("Incompatible xform op %s:", op.GetOpName().GetString().c_str());
             throw std::runtime_error(err.c_str());

--- a/lib/mayaUsd/undo/UsdUndoStateDelegate.cpp
+++ b/lib/mayaUsd/undo/UsdUndoStateDelegate.cpp
@@ -136,7 +136,6 @@ void UsdUndoStateDelegate::invertDeleteSpec(
     CreateSpec(path, deletedSpecType, inert);
 
     auto layerDataPtr = get_pointer(_GetLayerData());
-    TF_AXIOM(layerDataPtr);
 
     // copy back every spec(s) with the given visitor
     SpecCopier specCopier(layerDataPtr);


### PR DESCRIPTION
We should strive to reduce the number of scenarios under which Maya crashes. Instead, when possible, we should report an error to user and abort the operation. MayaUSD has extensive undo/redo capabilities now and code is able to undo partially done operations. Given this, errors should be reported and propagated back.

The macros TF_AXIOM and TF_FATAL_ERROR cause crashes when their conditions are not met, even in release builds. Remove TF_AXIOM and TF_FATAL_ERROR, replacing them with:

- TF_WARN when the situation was not an error but an unusual situation.
- TF_VERIFY when it still warrant an error message to the user, for example during error handling.
- Simple if/else, with an error return value when not a hard error.
- Simple if when the condition was trivial, like an empty node when iterating over USD nodes.
- In a few cases, TF_DEV_AXIOM when the condition was really strictly enforced by a class constructor.
- Entirely removed, when the code was already dealing with the error.
- C++ exception when the error needs to propagate to caller, in particular in constructors.