### PR TITLE
HYDRA-300: Update proxyShapeSceneIndexPlugin.cpp

### DIFF
--- a/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
+++ b/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
@@ -133,7 +133,7 @@ void MayaUsdProxyShapeSceneIndex::Populate()
             // care of inside MayaUsdProxyShapeSceneIndex::_StageSet callback.
             {
                 _usdImagingStageSceneIndex->SetStage(stage);
-#if PXR_VERSION <= 2302
+#if PXR_VERSION <= 2305
                 _usdImagingStageSceneIndex->Populate();
 #endif
                 _populated = true;


### PR DESCRIPTION
Came as a result of this
https://github.com/Autodesk/maya-usd/pull/2983

Implicit Populate was only added as part of patch version 2305, the code was added here
https://github.com/PixarAnimationStudios/USD/commit/3091ceaecd6d6dfc574199c2500594bade84939c

The PXR_VERSION used is incorrect it will break versions predating the patch version 2305.
https://github.com/PixarAnimationStudios/USD/blob/3091ceaecd6d6dfc574199c2500594bade84939c/cmake/defaults/Version.cmake

Should be fixed like this
```
#if PXR_VERSION <= 2305
                // In most recent USD, Populate is called from within SetStage, so there is no need to callsites to call it explicitly
                _usdImagingStageSceneIndex->Populate();
#endif
```
