### PR TITLE
MAYA-127817 make stage set by ID reloadable

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -828,6 +828,15 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
         if (stageCached) {
             sharedUsdStage = UsdUtilsStageCache::Get().Find(cacheId);
             isIncomingStage = true;
+            // If the stage set by stage ID is not anonymous, set the filePath
+            // attribute to it so that it can be reloaded when teh Maya scene
+            // is re-opened.
+            SdfLayerHandle rootLayer = sharedUsdStage->GetRootLayer();
+            if (rootLayer && !rootLayer->IsAnonymous()) {
+                MDataHandle outDataHandle = dataBlock.outputValue(filePathAttr, &retValue);
+                CHECK_MSTATUS_AND_RETURN_IT(retValue);
+                outDataHandle.set(MString(rootLayer->GetIdentifier().c_str()));
+            }
         } else {
             //
             // Calculate from USD filepath and primPath and variantKey


### PR DESCRIPTION
When the stage is set on the proxy shape via the stage ID attribute, fill the file path attribute automatically so that the stage can be reloaded when the Maya scene file is reloaded.

The stage ID attribute is not saved and the ID is a run-time value in USD that is not constant from run to run. The only way to be reloadeable is to save the file path to the root layer.

- Fill the file path attribute when computing the stage if the stage is set by stage ID.
- Only do this if the stage is not anonymous.
- Add a unit test that verifies the stage is reloaded when the Maya scene is reloaded.