### PR TITLE
MAYA-128504 - As a user, I'd like to load my USD root file as relative before I save my scene file

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -92,6 +92,7 @@
 #include <maya/MPoint.h>
 #include <maya/MProfiler.h>
 #include <maya/MPxSurfaceShape.h>
+#include <maya/MSceneMessage.h>
 #include <maya/MSelectionMask.h>
 #include <maya/MStatus.h>
 #include <maya/MString.h>
@@ -140,6 +141,7 @@ const MString MayaUsdProxyShapeBase::displayFilterLabel("USD Proxies");
 
 // Attributes
 MObject MayaUsdProxyShapeBase::filePathAttr;
+MObject MayaUsdProxyShapeBase::filePathRelativeAttr;
 MObject MayaUsdProxyShapeBase::primPathAttr;
 MObject MayaUsdProxyShapeBase::excludePrimPathsAttr;
 MObject MayaUsdProxyShapeBase::loadPayloadsAttr;
@@ -258,6 +260,15 @@ MStatus MayaUsdProxyShapeBase::initialize()
     typedAttrFn.setAffectsAppearance(true);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
     retValue = addAttribute(filePathAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+    filePathRelativeAttr
+        = numericAttrFn.create("filePathRelative", "fpr", MFnNumericData::kBoolean, 0.0, &retValue);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+    numericAttrFn.setInternal(true);
+    numericAttrFn.setStorable(false);
+    numericAttrFn.setWritable(false);
+    retValue = addAttribute(filePathRelativeAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
     primPathAttr
@@ -537,6 +548,29 @@ void MayaUsdProxyShapeBase::enableProxyAccessor()
     _usdAccessor = ProxyAccessor::createAndRegister(*this);
 }
 
+void beforeSaveCallback(void* clientData)
+{
+    auto proxyShape = static_cast<MayaUsdProxyShapeBase*>(clientData);
+    if (!proxyShape) {
+        return;
+    }
+
+    MStatus           status;
+    MFnDependencyNode depNode(proxyShape->thisMObject(), &status);
+    CHECK_MSTATUS(status);
+
+    MPlug filePathPlug = depNode.findPlug(MayaUsdProxyShapeBase::filePathAttr);
+    MPlug filePathRelativePlug = depNode.findPlug(MayaUsdProxyShapeBase::filePathRelativeAttr);
+
+    // Make proxy shape's file path relative if needed
+    ghc::filesystem::path filePath(filePathPlug.asString().asChar());
+    if (filePath.is_absolute() && filePathRelativePlug.asBool()) {
+        auto relativePath
+            = UsdMayaUtilFileSystem::getPathRelativeToMayaSceneFile(filePath.generic_string());
+        filePathPlug.setString(relativePath.c_str());
+    }
+}
+
 /* virtual */
 void MayaUsdProxyShapeBase::postConstructor()
 {
@@ -548,6 +582,11 @@ void MayaUsdProxyShapeBase::postConstructor()
     MayaUsdProxyStageInvalidateNotice(*this).Send();
 
     updateAncestorCallbacks();
+
+    if (_preSaveCallbackId == 0) {
+        _preSaveCallbackId
+            = MSceneMessage::addCallback(MSceneMessage::kBeforeSave, beforeSaveCallback, this);
+    }
 }
 
 /* virtual */
@@ -1906,6 +1945,11 @@ MayaUsdProxyShapeBase::MayaUsdProxyShapeBase(
 /* virtual */
 MayaUsdProxyShapeBase::~MayaUsdProxyShapeBase()
 {
+    if (_preSaveCallbackId != 0) {
+        MMessage::removeCallback(_preSaveCallbackId);
+        _preSaveCallbackId = 0;
+    }
+
     clearAncestorCallbacks();
 
     // Deregister from the load-rules handling used to transfer load rules

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -94,6 +94,8 @@ public:
     MAYAUSD_CORE_PUBLIC
     static MObject filePathAttr;
     MAYAUSD_CORE_PUBLIC
+    static MObject filePathRelativeAttr;
+    MAYAUSD_CORE_PUBLIC
     static MObject primPathAttr;
     MAYAUSD_CORE_PUBLIC
     static MObject excludePrimPathsAttr;
@@ -450,6 +452,8 @@ private:
     std::vector<MCallbackId> _ancestorCallbacks;
     MString                  _ancestorCallbacksPath;
     bool                     _inAncestorCallback { false };
+
+    MCallbackId _preSaveCallbackId { 0 };
 
 public:
     // Counter for the number of times compute is re-entered

--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -224,8 +224,12 @@ void setNewProxyPath(
     const SdfLayerRefPtr& layer,
     bool                  isTargetLayer)
 {
+    const bool  needRelativePath = UsdMayaUtilFileSystem::requireUsdPathsRelativeToMayaSceneFile();
+    const char* filePathCmd = "setAttr -type \"string\" ^1s.filePath \"^2s\"; "
+                              "setAttr ^1s.filePathRelative ^3s; ";
+
     MString script;
-    script.format("setAttr -type \"string\" ^1s.filePath \"^2s\"", proxyNodeName, newRootLayerPath);
+    script.format(filePathCmd, proxyNodeName, newRootLayerPath, needRelativePath ? "1" : "0");
     MGlobal::executeCommand(
         script,
         /*display*/ true,

--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -360,15 +360,9 @@ std::string MayaSessionState::defaultLoadPath() const
 void MayaSessionState::rootLayerPathChanged(std::string const& in_path)
 {
     if (!_currentStageEntry._proxyShapePath.empty()) {
-
-        MString script;
         MString proxyShape(_currentStageEntry._proxyShapePath.c_str());
         MString newValue(in_path.c_str());
-        script.format("setAttr -type \"string\" ^1s.filePath \"^2s\"", proxyShape, newValue);
-        MGlobal::executeCommand(
-            script,
-            /*display*/ true,
-            /*undo*/ false);
+        MayaUsd::utils::setNewProxyPath(proxyShape, newValue, nullptr, false);
     }
 }
 

--- a/plugin/adsk/scripts/AETemplateHelpers.py
+++ b/plugin/adsk/scripts/AETemplateHelpers.py
@@ -144,9 +144,11 @@ def ProxyShapeFilePathChanged(filePathAttr, newFilePath=None):
                 debugMessage('    User picked USD file, setting file path attribute')
                 # Simply set the file path attribute. The proxy shape will load the file.
                 usdFileToLoad = res[0]
-                if RequireUsdPathsRelativeToMayaSceneFile():
+                requireRelative = RequireUsdPathsRelativeToMayaSceneFile()
+                if requireRelative:
                     usdFileToLoad = mayaUsdLib.Util.getPathRelativeToMayaSceneFile(usdFileToLoad)
                 cmds.setAttr(filePathAttr, usdFileToLoad, type='string')
+                cmds.setAttr(filePathAttr+"Relative", requireRelative)
                 return True
         elif newFilePath is not None:
             # Instead of opening a file dialog to get the USD file, simply

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.py
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.py
@@ -36,7 +36,7 @@ def mayaUSDRegisterStrings():
     register("kLoadUSDFile", "Load USD File")
     register("kFileOptions", "File Options")
     register("kMakePathRelativeToSceneFile", "Make Path Relative to Scene File")
-    register("kMakePathRelativeToSceneFileAnn", "If enabled, path will be relative to your Maya scene file.\nIf this option is disabled, there is no Maya scene file and the path will be absolute.\nSave your Maya scene file to disk to make this option available.")
+    register("kMakePathRelativeToSceneFileAnn", "Path will be relative to your Maya scene file.")
     register("kMakePathRelativeToEditTargetLayer", "Make Path Relative to Edit Target Layer Directory")
     register("kMakePathRelativeToEditTargetLayerAnn", "Enable to activate relative pathing to your current edit target layer's directory.\nIf this option is disabled, verify that your target layer is not anonymous and save it to disk.")
     register("kMakePathRelativeToParentLayer", "Make Path Relative to Parent Layer Directory")

--- a/plugin/adsk/scripts/mayaUsd_USDRootFileRelative.py
+++ b/plugin/adsk/scripts/mayaUsd_USDRootFileRelative.py
@@ -146,12 +146,12 @@ class usdFileRelative(object):
 
         if cls._haveRelativePathFields:
             # We may need to hide the preview fields in certain cases
-            showPreviewFileds = True
+            showPreviewFields = True
             if relativeToWhat == 'SceneFile':
-                showPreviewFileds = cmds.file(q=True, exists=True)
+                showPreviewFields = cmds.file(q=True, exists=True)
 
-            cmds.textFieldGrp(cls.kUnresolvedPathTextField, edit=True, visible=showPreviewFileds)
-            cmds.textFieldGrp(cls.kResolvedPathTextField, edit=True, visible=showPreviewFileds)
+            cmds.textFieldGrp(cls.kUnresolvedPathTextField, edit=True, visible=showPreviewFields)
+            cmds.textFieldGrp(cls.kResolvedPathTextField, edit=True, visible=showPreviewFields)
 
             # Only enable fields when make relative is checked.
             makePathRelative = cmds.checkBox(cls.kMakePathRelativeCheckBox, query=True, value=True)

--- a/plugin/adsk/scripts/mayaUsd_USDRootFileRelative.py
+++ b/plugin/adsk/scripts/mayaUsd_USDRootFileRelative.py
@@ -145,6 +145,14 @@ class usdFileRelative(object):
             cls.connectToDialogControls(parentLayout)
 
         if cls._haveRelativePathFields:
+            # We may need to hide the preview fields in certain cases
+            showPreviewFileds = True
+            if relativeToWhat == 'SceneFile':
+                showPreviewFileds = cmds.file(q=True, exists=True)
+
+            cmds.textFieldGrp(cls.kUnresolvedPathTextField, edit=True, visible=showPreviewFileds)
+            cmds.textFieldGrp(cls.kResolvedPathTextField, edit=True, visible=showPreviewFileds)
+
             # Only enable fields when make relative is checked.
             makePathRelative = cmds.checkBox(cls.kMakePathRelativeCheckBox, query=True, value=True)
             cls.onMakePathRelativeChanged(makePathRelative)
@@ -279,10 +287,11 @@ class usdRootFileRelative(usdFileRelative):
         Note: the function takes an unused filterType argument to be compatible
               with the dialog2 command API.
         '''
-        # If there is no Maya scene file saved, then the checkbox and label should be disabled.
-        haveSceneFile = cmds.file(q=True, exists=True)
+        # USD root layer can always be set relative to Maya scene file. 
+        # If the latter doesn't exist, we use a special approach with 
+        # postponed relative file path assignment 
         cls.setRelativeFilePathRoot(cmds.file(query=True, sceneName=True))
-        super(usdRootFileRelative, cls).uiInit(parentLayout, haveSceneFile, cls.kRelativeToWhat)
+        super(usdRootFileRelative, cls).uiInit(parentLayout, True, cls.kRelativeToWhat)
 
     @classmethod
     def uiCommit(cls, parentLayout, selectedFile=None):

--- a/plugin/adsk/scripts/mayaUsd_createStageFromFile.mel
+++ b/plugin/adsk/scripts/mayaUsd_createStageFromFile.mel
@@ -143,12 +143,14 @@ proc string doCreateStage(string $fileName)
     int $loadp = `optionVar -q stageFromFile_loadPayloads`;
 
     string $fileNameToSave = $fileName;
-    if (`optionVar -exists mayaUsd_MakePathRelativeToSceneFile` && `optionVar -query mayaUsd_MakePathRelativeToSceneFile`) {
+    int $requireRelative = (`optionVar -exists mayaUsd_MakePathRelativeToSceneFile` && `optionVar -query mayaUsd_MakePathRelativeToSceneFile`);
+    if ($requireRelative) {
         $fileNameToSave = `python("import mayaUsd.lib as mayaUsdLib; mayaUsdLib.Util.getPathRelativeToMayaSceneFile('" + $fileName + "')")`;
     }
 
     string $shapeNode = `createNode "mayaUsdProxyShape" -skipSelect -name ($baseName+"Shape")`;
     setAttr -type "string" ($shapeNode+".filePath") $fileNameToSave;
+    setAttr ($shapeNode+".filePathRelative") $requireRelative;
     setAttr -type "string" ($shapeNode+".primPath") $ppath;
     setAttr -type "string" ($shapeNode+".excludePrimPaths") $exppath;
     setAttr ($shapeNode+".loadPayloads") $loadp;


### PR DESCRIPTION
When saving/loading root layer as relative to Maya scene file, if Maya scene file doesn't exist, we update the appropriate file path in a postponed fashion, when Maya scene is saved