### PR TITLE
MAYA-128934 - Bug fix: Prevent right click-material assignment for physics-related nodes

### DIFF
--- a/plugin/adsk/plugin/adskMaterialCommands.cpp
+++ b/plugin/adsk/plugin/adskMaterialCommands.cpp
@@ -242,6 +242,12 @@ static bool isNodeTypeInList(
         const auto canonicalAncestorName
             = TfType::Find<UsdSchemaBase>().FindDerivedByName(ancestorType.c_str());
 
+        // Make sure we see at least one actual ancestor: For some types the first reported
+        // ancestor is the same as the node type itself.
+        if (canonicalAncestorName == canonicalName) {
+            continue;
+        }
+
         // Check whether an ancestor of our node matches one of the listed node types.
         if (std::find(
                 nodeTypeList.begin(),


### PR DESCRIPTION
Bug fix for my earlier PR https://github.com/Autodesk/maya-usd/pull/2958.

For some reason, certain node types report their first ancestor as the same name as the node type itself. This threw off the logic in my original implementation, so this fix makes sure we check against at least one actual ancestor type.