### PR TITLE
MAYA-128513 implement composite command handler

### DIFF
--- a/cmake/modules/FindUFE.cmake
+++ b/cmake/modules/FindUFE.cmake
@@ -106,6 +106,10 @@ if (UFE_INCLUDE_DIR AND EXISTS "${UFE_INCLUDE_DIR}/ufe/batchOpsHandler.h")
     list(APPEND UFE_PREVIEW_FEATURES v4_BatchOps)
 endif()
 
+if(UFE_INCLUDE_DIR AND EXISTS "${UFE_INCLUDE_DIR}/ufe/compositeCommandHandler.h")
+    list(APPEND UFE_PREVIEW_FEATURES CompositeCommandHandler)
+endif()
+
 # Handle the QUIETLY and REQUIRED arguments and set UFE_FOUND to TRUE if
 # all listed variables are TRUE.
 include(FindPackageHandleStandardArgs)

--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -144,6 +144,19 @@ if (v4_BatchOps IN_LIST UFE_PREVIEW_FEATURES)
     )
 endif()
 
+if(CompositeCommandHandler IN_LIST UFE_PREVIEW_FEATURES)
+    message(STATUS "UFE_PREVIEW has composite command handler support")
+    target_sources(${PROJECT_NAME}
+        PRIVATE
+        UsdCompositeCommandHandler.cpp
+    )
+
+    target_compile_definitions(${PROJECT_NAME}
+        PRIVATE
+        UFE_PREVIEW_COMPOSITE_COMMAND_HANDLER_SUPPORT=1
+    )
+endif()
+
 if(CMAKE_UFE_V4_FEATURES_AVAILABLE)
     if (${UFE_PREVIEW_VERSION_NUM} GREATER_EQUAL 4001)
         target_sources(${PROJECT_NAME}
@@ -321,6 +334,12 @@ if (v4_BatchOps IN_LIST UFE_PREVIEW_FEATURES)
     list(APPEND HEADERS
         UsdBatchOpsHandler.h
         UsdUndoDuplicateSelectionCommand.h
+    )
+endif()
+
+if(v5_CompositeCommandHandler IN_LIST UFE_PREVIEW_FEATURES)
+    list(APPEND HEADERS
+        UsdCompositeCommandHandler.h
     )
 endif()
 

--- a/lib/mayaUsd/ufe/Global.cpp
+++ b/lib/mayaUsd/ufe/Global.cpp
@@ -65,6 +65,9 @@
 #if UFE_PREVIEW_BATCHOPS_SUPPORT
 #include <mayaUsd/ufe/UsdBatchOpsHandler.h>
 #endif
+#if UFE_PREVIEW_COMPOSITE_COMMAND_HANDLER_SUPPORT
+#include <mayaUsd/ufe/UsdCompositeCommandHandler.h>
+#endif
 #if (UFE_PREVIEW_VERSION_NUM >= 4001)
 #include <mayaUsd/ufe/UsdShaderNodeDefHandler.h>
 #endif
@@ -210,9 +213,13 @@ MStatus initialize()
 #if (UFE_PREVIEW_VERSION_NUM >= 4023)
     handlers.uiNodeGraphNodeHandler = UsdUINodeGraphNodeHandler::create();
 #endif
-#if UFE_PREVIEW_BATCHOPS_SUPPORT
+
+#if UFE_PREVIEW_COMPOSITE_COMMAND_HANDLER_SUPPORT
+    handlers.batchOpsHandler = UsdCompositeCommandHandler::create();
+#elif UFE_PREVIEW_BATCHOPS_SUPPORT
     handlers.batchOpsHandler = UsdBatchOpsHandler::create();
 #endif
+
 #if (UFE_PREVIEW_VERSION_NUM >= 4001)
     handlers.nodeDefHandler = UsdShaderNodeDefHandler::create();
 #endif

--- a/lib/mayaUsd/ufe/UsdBatchOpsHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdBatchOpsHandler.cpp
@@ -21,7 +21,6 @@ namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
 UsdBatchOpsHandler::UsdBatchOpsHandler()
-    : Ufe::BatchOpsHandler()
 {
 }
 

--- a/lib/mayaUsd/ufe/UsdBatchOpsHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdBatchOpsHandler.cpp
@@ -20,9 +20,7 @@
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
-UsdBatchOpsHandler::UsdBatchOpsHandler()
-{
-}
+UsdBatchOpsHandler::UsdBatchOpsHandler() { }
 
 UsdBatchOpsHandler::~UsdBatchOpsHandler() { }
 

--- a/lib/mayaUsd/ufe/UsdBatchOpsHandler.h
+++ b/lib/mayaUsd/ufe/UsdBatchOpsHandler.h
@@ -23,13 +23,21 @@
 #include <pxr/usd/sdf/types.h>
 #include <pxr/usd/usd/stage.h>
 
+#if UFE_PREVIEW_COMPOSITE_COMMAND_HANDLER_SUPPORT
+#include <ufe/compositeCommandHandler.h>
+#else
 #include <ufe/batchOpsHandler.h>
+#endif
 
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
 //! \brief Interface to create a UsdBatchOpsHandler interface object.
+#if UFE_PREVIEW_COMPOSITE_COMMAND_HANDLER_SUPPORT
+class MAYAUSD_CORE_PUBLIC UsdBatchOpsHandler : public Ufe::CompositeCommandHandler
+#else
 class MAYAUSD_CORE_PUBLIC UsdBatchOpsHandler : public Ufe::BatchOpsHandler
+#endif
 {
 public:
     typedef std::shared_ptr<UsdBatchOpsHandler> Ptr;

--- a/lib/mayaUsd/ufe/UsdCompositeCommandHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdCompositeCommandHandler.cpp
@@ -36,7 +36,15 @@ public:
 
     void preCall() override
     {
-        _editRouterContext = std::make_unique<OperationEditRouterContext>(_operationName, _prim);
+        if (_alreadyRouted) {
+            _editRouterContext = std::make_unique<OperationEditRouterContext>(_stage, _layer);
+        } else {
+            _editRouterContext
+                = std::make_unique<OperationEditRouterContext>(_operationName, _prim);
+            _stage = _editRouterContext->getStage();
+            _layer = _editRouterContext->getLayer();
+            _alreadyRouted = true;
+        }
     }
 
     void postCall() override { _editRouterContext.reset(); }
@@ -56,6 +64,9 @@ private:
 
     PXR_NS::UsdPrim                             _prim;
     PXR_NS::TfToken                             _operationName;
+    bool                                        _alreadyRouted = false;
+    PXR_NS::UsdStagePtr                         _stage;
+    PXR_NS::SdfLayerHandle                      _layer;
     std::unique_ptr<OperationEditRouterContext> _editRouterContext;
 };
 

--- a/lib/mayaUsd/ufe/UsdCompositeCommandHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdCompositeCommandHandler.cpp
@@ -1,0 +1,91 @@
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "UsdCompositeCommandHandler.h"
+
+#include <mayaUsd/ufe/UsdSceneItem.h>
+#include <mayaUsd/utils/editRouterContext.h>
+
+#include <ufe/sceneItem.h>
+#include <ufe/selection.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+namespace {
+class UsdCodeWrapper : public Ufe::CodeWrapper
+{
+public:
+    UsdCodeWrapper(const Ufe::Selection& selection, const std::string& operationName)
+        : _prim(findPrimInSelection(selection))
+        , _operationName(PXR_NS::TfToken(operationName))
+    {
+    }
+
+    void preCall() override
+    {
+        _editRouterContext = std::make_unique<OperationEditRouterContext>(_operationName, _prim);
+    }
+
+    void postCall() override { _editRouterContext.reset(); }
+
+private:
+    static PXR_NS::UsdPrim findPrimInSelection(const Ufe::Selection& selection)
+    {
+        for (const Ufe::SceneItem::Ptr& item : selection) {
+            const auto usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
+            if (!usdItem)
+                continue;
+            return usdItem->prim();
+        }
+
+        return {};
+    }
+
+    PXR_NS::UsdPrim                             _prim;
+    PXR_NS::TfToken                             _operationName;
+    std::unique_ptr<OperationEditRouterContext> _editRouterContext;
+};
+
+class UsdCompositeCommandWrapper : public Ufe::CompositeCommandWrapper
+{
+public:
+    UsdCompositeCommandWrapper(const Ufe::Selection& selection, const std::string& operationName)
+        : _wrapper(selection, operationName)
+    {
+    }
+
+    Ufe::CodeWrapper& executeWrapper() override { return _wrapper; }
+
+private:
+    UsdCodeWrapper _wrapper;
+};
+} // namespace
+
+/*static*/
+std::shared_ptr<UsdCompositeCommandHandler> UsdCompositeCommandHandler::create()
+{
+    return std::make_shared<UsdCompositeCommandHandler>();
+}
+
+Ufe::CompositeCommandWrapper::Ptr UsdCompositeCommandHandler::createCompositeCommandWrapper_(
+    const Ufe::Selection& selection,
+    const std::string&    operationName)
+{
+    return std::make_unique<UsdCompositeCommandWrapper>(selection, operationName);
+}
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdCompositeCommandHandler.h
+++ b/lib/mayaUsd/ufe/UsdCompositeCommandHandler.h
@@ -32,8 +32,8 @@ public:
 protected:
     // Ufe::CompositeCommandHandler overrides.
     Ufe::CompositeCommandWrapper::Ptr createCompositeCommandWrapper_(
-        const Ufe::Selection&   selection,
-        const std::string& operationName) override;
+        const Ufe::Selection& selection,
+        const std::string&    operationName) override;
 }; // UsdCompositeCommandHandler
 
 } // namespace ufe

--- a/lib/mayaUsd/ufe/UsdCompositeCommandHandler.h
+++ b/lib/mayaUsd/ufe/UsdCompositeCommandHandler.h
@@ -1,0 +1,40 @@
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <mayaUsd/ufe/UsdBatchOpsHandler.h>
+
+#include <ufe/compositeCommandHandler.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+//! \brief Interface to create a UsdCompositeCommandHandler interface object.
+class MAYAUSD_CORE_PUBLIC UsdCompositeCommandHandler : public UsdBatchOpsHandler
+{
+public:
+    //! Create a UsdCompositeCommandHandler.
+    static std::shared_ptr<UsdCompositeCommandHandler> create();
+
+protected:
+    // Ufe::CompositeCommandHandler overrides.
+    Ufe::CompositeCommandWrapper::Ptr createCompositeCommandWrapper_(
+        const Ufe::Selection&   selection,
+        const std::string& operationName) override;
+}; // UsdCompositeCommandHandler
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
@@ -184,10 +184,10 @@ static void doUsdInsertion(
 }
 
 static UsdSceneItem::Ptr doInsertion(
-    const SdfPath&        srcUsdPath,
-    const Ufe::Path&      srcUfePath,
-    const SdfPath&        dstUsdPath,
-    const Ufe::Path&      dstUfePath)
+    const SdfPath&   srcUsdPath,
+    const Ufe::Path& srcUfePath,
+    const SdfPath&   dstUsdPath,
+    const Ufe::Path& dstUfePath)
 {
     // We must retrieve the item every time we are called since it could be stale.
     // We need to get the USD prim from the UFE path.
@@ -225,10 +225,11 @@ static UsdSceneItem::Ptr doInsertion(
     // restrictions that have been verified when the command was created, should
     // only be session layers.
     {
-        PrimLayerFunc insertionFunc =
-            [stage, srcUsdPath, dstUsdPath](const UsdPrim& prim, const PXR_NS::SdfLayerRefPtr& layer) {
-                doUsdInsertion(stage, layer, srcUsdPath, layer, dstUsdPath);
-            };
+        PrimLayerFunc insertionFunc
+            = [stage, srcUsdPath, dstUsdPath](
+                  const UsdPrim& prim, const PXR_NS::SdfLayerRefPtr& layer) {
+                  doUsdInsertion(stage, layer, srcUsdPath, layer, dstUsdPath);
+              };
 
         const bool includeTopLayer = true;
         const auto sessionLayers = getAllSublayerRefs(stage->GetSessionLayer(), includeTopLayer);

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
@@ -17,6 +17,7 @@
 
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/ufe/UsdSceneItem.h>
+#include <mayaUsd/undo/UsdUndoableItem.h>
 
 #include <pxr/usd/usd/prim.h>
 
@@ -63,11 +64,9 @@ protected:
         const UsdSceneItem::Ptr& pos);
 
 private:
+    void execute() override;
     void undo() override;
     void redo() override;
-
-    void insertChildRedo();
-    void insertChildUndo();
 
     UsdSceneItem::Ptr _ufeDstItem;
 
@@ -78,9 +77,7 @@ private:
     PXR_NS::SdfPath _usdSrcPath;
     PXR_NS::SdfPath _usdDstPath;
 
-    PXR_NS::SdfLayerHandle _childLayer;
-    PXR_NS::SdfLayerHandle _parentLayer;
-
+    UsdUndoableItem _undoableItem;
 }; // UsdUndoInsertChildCommand
 
 } // namespace ufe

--- a/lib/mayaUsd/utils/editRouterContext.cpp
+++ b/lib/mayaUsd/utils/editRouterContext.cpp
@@ -59,6 +59,18 @@ const PXR_NS::SdfLayerHandle& StackedEditRouterContext::getLayer() const
     return empty;
 }
 
+const PXR_NS::UsdStagePtr& StackedEditRouterContext::getStage() const
+{
+    if (_stage)
+        return _stage;
+
+    if (const StackedEditRouterContext* ctx = GetStackPrevious())
+        return ctx->getStage();
+
+    static const PXR_NS::UsdStagePtr empty;
+    return empty;
+}
+
 bool StackedEditRouterContext::isTargetAlreadySet() const
 {
     // Use the edit target of a edit router context higher-up in the call
@@ -88,6 +100,13 @@ OperationEditRouterContext::OperationEditRouterContext(
 {
 }
 
+OperationEditRouterContext::OperationEditRouterContext(
+    const PXR_NS::UsdStagePtr&    stage,
+    const PXR_NS::SdfLayerHandle& layer)
+    : StackedEditRouterContext(stage, layer)
+{
+}
+
 PXR_NS::SdfLayerHandle AttributeEditRouterContext::getAttributeLayer(
     const PXR_NS::UsdPrim& prim,
     const PXR_NS::TfToken& attributeName)
@@ -102,6 +121,13 @@ AttributeEditRouterContext::AttributeEditRouterContext(
     const PXR_NS::UsdPrim& prim,
     const PXR_NS::TfToken& attributeName)
     : StackedEditRouterContext(prim.GetStage(), getAttributeLayer(prim, attributeName))
+{
+}
+
+AttributeEditRouterContext::AttributeEditRouterContext(
+    const PXR_NS::UsdStagePtr&    stage,
+    const PXR_NS::SdfLayerHandle& layer)
+    : StackedEditRouterContext(stage, layer)
 {
 }
 

--- a/lib/mayaUsd/utils/editRouterContext.h
+++ b/lib/mayaUsd/utils/editRouterContext.h
@@ -34,12 +34,18 @@ namespace MAYAUSD_NS_DEF {
 class MAYAUSD_CORE_PUBLIC StackedEditRouterContext
     : public PXR_NS::TfStacked<StackedEditRouterContext>
 {
-protected:
+public:
     /*! \brief Retrieve the current targeted layer.
      * \return The targeted layer. Null if the edit target was not changed.
      */
     const PXR_NS::SdfLayerHandle& getLayer() const;
 
+    /*! \brief Retrieve the routed stage.
+     * \return The stage that is being routed. Null if the edit target was not changed.
+     */
+    const PXR_NS::UsdStagePtr& getStage() const;
+
+protected:
     /*! \brief Check if an edit context higher-up in the call-stack of this
      *         thread already routed the edits to a specific layer.
      */
@@ -77,6 +83,13 @@ public:
      */
     OperationEditRouterContext(const PXR_NS::TfToken& operationName, const PXR_NS::UsdPrim& prim);
 
+    /*! \brief Route to the given stage and layer.
+     *  Should be used in undo to ensure the same target is used as in the initial execution.
+     */
+    OperationEditRouterContext(
+        const PXR_NS::UsdStagePtr&    stage,
+        const PXR_NS::SdfLayerHandle& layer);
+
 private:
     PXR_NS::SdfLayerHandle
     getOperationLayer(const PXR_NS::TfToken& operationName, const PXR_NS::UsdPrim& prim);
@@ -100,6 +113,13 @@ public:
     /*! \brief Route an attribute operation on a prim for the given attribute.
      */
     AttributeEditRouterContext(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attributeName);
+
+    /*! \brief Route to the given stage and layer.
+     *  Should be used in undo to ensure the same target is used as in the initial execution.
+     */
+    AttributeEditRouterContext(
+        const PXR_NS::UsdStagePtr&    stage,
+        const PXR_NS::SdfLayerHandle& layer);
 
 private:
     PXR_NS::SdfLayerHandle

--- a/test/lib/ufe/testEditRouting.py
+++ b/test/lib/ufe/testEditRouting.py
@@ -7,6 +7,7 @@ import mayaUsd.ufe
 import mayaUtils
 import ufeUtils
 import ufe
+import os
 import unittest
 import usdUtils
 from pxr import UsdGeom
@@ -17,7 +18,7 @@ from pxr import UsdGeom
 
 def filterUsdStr(usdSceneStr):
     '''Remove empty lines and lines starting with pound character.'''
-    nonBlankLines = filter(None, [l.rstrip() for l in usdSceneStr.splitlines()])
+    nonBlankLines = filter(None, [l.strip() for l in usdSceneStr.splitlines()])
     finalLines = [l for l in nonBlankLines if not l.startswith('#')]
     return '\n'.join(finalLines)
 
@@ -206,7 +207,7 @@ class EditRoutingTestCase(unittest.TestCase):
  
             # Check that correct visibility changes were written to the session layer
             self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
-                            'over "B"\n{\n    token visibility = "invisible"\n}')
+                            filterUsdStr('over "B"\n{\n    token visibility = "invisible"\n}'))
             
         self._verifyEditRouterForCmd('visibility', setVisibility, verifyVisibility)
 
@@ -225,7 +226,7 @@ class EditRoutingTestCase(unittest.TestCase):
  
             # Check that correct duplicated prim was written to the session layer
             self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
-                            'def Xform "B1"\n{\n}')
+                            filterUsdStr('def Xform "B1"\n{\n}'))
             
         self._verifyEditRouterForCmd('duplicate', duplicate, verifyDuplicate)
 
@@ -240,7 +241,7 @@ class EditRoutingTestCase(unittest.TestCase):
         def verifyGroup(sessionLayer):
             # Check that correct grouped prim was written to the session layer
             self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
-                            'over "group1"\n{\n    def Xform "B"\n    {\n    }\n}')
+                            filterUsdStr('over "group1"\n{\n    def Xform "B"\n    {\n    }\n}'))
 
             # Check that the grouped prim was created in the session layer
             self.assertIsNotNone(sessionLayer.GetPrimAtPath('/group1'))
@@ -280,7 +281,7 @@ class EditRoutingTestCase(unittest.TestCase):
  
         # Check that correct visibility changes were written to the session layer
         self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
-                         'over "B"\n{\n    token visibility = "invisible"\n}')
+                         filterUsdStr('over "B"\n{\n    token visibility = "invisible"\n}'))
 
     def testEditRouterForAttributeVisibility(self):
         '''
@@ -313,7 +314,7 @@ class EditRoutingTestCase(unittest.TestCase):
  
         # Check that correct visibility changes were written to the session layer
         self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
-                         'over "B"\n{\n    token visibility = "invisible"\n}')
+                         filterUsdStr('over "B"\n{\n    token visibility = "invisible"\n}'))
         
         # Check we are still allowed to set the attribute without
         # explicitly changing the edit target.
@@ -416,7 +417,7 @@ class EditRoutingTestCase(unittest.TestCase):
         # Check to root layer only contains bare A and B xforms.
         rootLayer = stage.GetRootLayer()
         self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
-                         'def Xform "A"\n{\n}\ndef Xform "B"\n{\n}')
+                         filterUsdStr('def Xform "A"\n{\n}\ndef Xform "B"\n{\n}'))
  
         # Route the visibility command to the session layer.
         # Route the custom composite command to the root layer.
@@ -442,7 +443,7 @@ class EditRoutingTestCase(unittest.TestCase):
         # Check that visibility was written to the root layer
         rootLayer = stage.GetRootLayer()
         self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
-                         'def Xform "A"\n{\n}\ndef Xform "B"\n{\n    token visibility = "invisible"\n}')
+                         filterUsdStr('def Xform "A"\n{\n}\ndef Xform "B"\n{\n    token visibility = "invisible"\n}'))
 
     @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 4, 'UFE composite commands only available in Python from UFE v4.')
     def testNotRoutingCompositeCmd(self):
@@ -460,7 +461,7 @@ class EditRoutingTestCase(unittest.TestCase):
         # Check to root layer only contains bare A and B xforms.
         rootLayer = stage.GetRootLayer()
         self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
-                         'def Xform "A"\n{\n}\ndef Xform "B"\n{\n}')
+                         filterUsdStr('def Xform "A"\n{\n}\ndef Xform "B"\n{\n}'))
  
         # Select /B
         sn = ufe.GlobalSelection.get()
@@ -480,8 +481,61 @@ class EditRoutingTestCase(unittest.TestCase):
         # Check that visibility was written to the root layer
         rootLayer = stage.GetRootLayer()
         self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
-                         'def Xform "A"\n{\n}\ndef Xform "B"\n{\n    token visibility = "invisible"\n}')
+                         filterUsdStr('def Xform "A"\n{\n}\ndef Xform "B"\n{\n    token visibility = "invisible"\n}'))
 
+    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '5002', 'Test requires composite command handler only available in UFE 0.5.2 and later')
+    def testRoutingCompositeGroupCmd(self):
+        '''
+        Test that an edit router for the group composite command routes all sub-commands.
+        '''
+        # Get the session layer
+        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
+        stage = prim.GetStage()
+        sessionLayer = stage.GetSessionLayer()
+ 
+        # Check that the session layer is empty
+        self.assertTrue(sessionLayer.empty)
+
+        # Check to root layer only contains bare A and B xforms.
+        rootLayer = stage.GetRootLayer()
+        self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
+                         filterUsdStr('def Xform "A"\n{\n}\ndef Xform "B"\n{\n}'))
+ 
+        # Route the group command to the session layer.
+        mayaUsd.lib.registerEditRouter('group', routeCmdToSessionLayer)
+ 
+        # Select /B
+        sn = ufe.GlobalSelection.get()
+        sn.clear()
+        sn.append(self.b)
+ 
+        # Group
+        cmds.group()
+ 
+        # Check that everything was written to the session layer
+        self.assertIsNotNone(sessionLayer)
+        expectedContents = '''
+            def Xform "group1" (
+                kind = "group"
+            )
+            {
+                float3 xformOp:translate:rotatePivot = (0, 0, 0)
+                float3 xformOp:translate:rotatePivotTranslate = (0, 0, 0)
+                float3 xformOp:translate:scalePivot = (0, 0, 0)
+                float3 xformOp:translate:scalePivotTranslate = (0, 0, 0)
+                uniform token[] xformOpOrder = ["xformOp:translate:rotatePivotTranslate", "xformOp:translate:rotatePivot", "!invert!xformOp:translate:rotatePivot", "xformOp:translate:scalePivotTranslate", "xformOp:translate:scalePivot", "!invert!xformOp:translate:scalePivot"]
+                def Xform "B"
+                {
+                    float3 xformOp:rotateXYZ = (0, -0, 0)
+                    float3 xformOp:scale = (1, 1, 1)
+                    double3 xformOp:translate = (0, 0, 0)
+                    uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
+                }
+            }
+            '''
+        self.maxDiff = None
+        self.assertEqual(filterUsdStr(sessionLayer.ExportToString()), filterUsdStr(expectedContents))
+ 
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/ufe/testGroupCmd.py
+++ b/test/lib/ufe/testGroupCmd.py
@@ -521,9 +521,9 @@ class GroupCmdTestCase(unittest.TestCase):
         cmds.undo()
 
         self.assertEqual([item for item in stage.Traverse()],
-            [stage.GetPrimAtPath("/Sphere3"), 
+            [stage.GetPrimAtPath("/Sphere1"), 
             stage.GetPrimAtPath("/Sphere2"),
-            stage.GetPrimAtPath("/Sphere1")])
+            stage.GetPrimAtPath("/Sphere3")])
 
         cmds.redo()
 
@@ -610,9 +610,9 @@ class GroupCmdTestCase(unittest.TestCase):
         cmds.undo()
 
         self.assertEqual([item for item in stage.Traverse()],
-            [stage.GetPrimAtPath("/Sphere3"), 
+            [stage.GetPrimAtPath("/Sphere1"), 
             stage.GetPrimAtPath("/Sphere2"),
-            stage.GetPrimAtPath("/Sphere1")])
+            stage.GetPrimAtPath("/Sphere3")])
 
         verifyRadius(getItem(oldSphere1Name), radius)
 
@@ -666,6 +666,8 @@ class GroupCmdTestCase(unittest.TestCase):
         groupItem = ufe.GlobalSelection.get().front()
         groupHierarchy = ufe.Hierarchy.hierarchy(groupItem)
         self.assertEqual(len(groupHierarchy.children()), 3)
+
+        print(stage.GetLoadRules())
 
         self.assertEqual(loadRules.NoneRule, stage.GetLoadRules().GetEffectiveRuleForPath('/group1/Sphere1'))
         self.assertEqual(loadRules.AllRule, stage.GetLoadRules().GetEffectiveRuleForPath('/group1/Sphere2'))


### PR DESCRIPTION
We implement the composite command handler and make the group (insert-child) command work within composite commands. The real, true Maya group command is actually composed of several UFE command and has been modified in a Maya branch to use the new UFE composite-command handler.

Implement the composite command handler:
- Make the batch-ops handler derive from the correct class depending on which feature is supported in UFE.
- Implement a composite command handler derived from the batch ops handler.
- The composite handler creates edit-routing wrappers for composite commands.
- Cache the stage and layer used when first executing a composite command.
- This allows using the same values when undoing.
- This is necessary because the original prim that was used when executing the command might not exist anymore once the command executed.
- In particular, this is true for the group command, the original prim no longer exists.

Make the group command work with edit routing:)
- Use the generic undo/redo support to record the changes, undo and redo them.
- Don't assume that the current edit target is where the source prim has opinion.
- Instead, apply the child-insertion to the layer that have opinion about the moving prim.
- The command restrictions already ensures that we only affect prims that have a single opinion.
- (But the code will be ready if we support multi-layers command later on.)
- The problem was that the command restriction was correctly looking at where the prim was authored, but the command execution was assuming that the source opinion was on the target layer.
- When routing commands, that can obviously be false: the target might not be where the original opinions were.
- We do the right thing using similar code as when affecting the session layer, except the target layer is the layer where the command was routed.
- By default, when no routing is registered, that is the current edit target.