### PR TITLE
UsdLight*.cpp: fix building with non-pxr namespace

### DIFF
--- a/lib/mayaUsd/ufe/UsdLight.cpp
+++ b/lib/mayaUsd/ufe/UsdLight.cpp
@@ -123,7 +123,7 @@ Ufe::Light::Type UsdLight::type() const
 float getLightIntensity(const UsdPrim& prim)
 {
     const UsdLuxLightCommon lightSchema(prim);
-    const pxr::UsdAttribute lightAttribute = lightSchema.GetIntensityAttr();
+    const PXR_NS::UsdAttribute lightAttribute = lightSchema.GetIntensityAttr();
 
     float val = 0.f;
     lightAttribute.Get(&val);
@@ -133,7 +133,7 @@ float getLightIntensity(const UsdPrim& prim)
 void setLightIntensity(const UsdPrim& prim, float attrVal)
 {
     const UsdLuxLightCommon lightSchema(prim);
-    const pxr::UsdAttribute lightAttribute = lightSchema.GetIntensityAttr();
+    const PXR_NS::UsdAttribute lightAttribute = lightSchema.GetIntensityAttr();
 
     lightAttribute.Set(attrVal);
 }
@@ -153,7 +153,7 @@ float UsdLight::intensity() const { return getLightIntensity(prim()); }
 Ufe::Color3f getLightColor(const UsdPrim& prim)
 {
     const UsdLuxLightCommon lightSchema(prim);
-    const pxr::UsdAttribute lightAttribute = lightSchema.GetColorAttr();
+    const PXR_NS::UsdAttribute lightAttribute = lightSchema.GetColorAttr();
 
     GfVec3f val(0.f, 0.f, 0.f);
     lightAttribute.Get(&val);
@@ -163,7 +163,7 @@ Ufe::Color3f getLightColor(const UsdPrim& prim)
 void setLightColor(const UsdPrim& prim, const Ufe::Color3f& attrVal)
 {
     const UsdLuxLightCommon lightSchema(prim);
-    const pxr::UsdAttribute lightAttribute = lightSchema.GetColorAttr();
+    const PXR_NS::UsdAttribute lightAttribute = lightSchema.GetColorAttr();
 
     lightAttribute.Set(GfVec3f(attrVal.r(), attrVal.g(), attrVal.b()));
 }
@@ -184,7 +184,7 @@ Ufe::Color3f UsdLight::color() const { return getLightColor(prim()); }
 bool getLightShadowEnable(const UsdPrim& prim)
 {
     const UsdLuxShadowAPI   shadowAPI(prim);
-    const pxr::UsdAttribute lightAttribute = shadowAPI.GetShadowEnableAttr();
+    const PXR_NS::UsdAttribute lightAttribute = shadowAPI.GetShadowEnableAttr();
 
     bool val = false;
     lightAttribute.Get(&val);
@@ -194,7 +194,7 @@ bool getLightShadowEnable(const UsdPrim& prim)
 void setLightShadowEnable(const UsdPrim& prim, bool attrVal)
 {
     const UsdLuxShadowAPI   shadowAPI(prim);
-    const pxr::UsdAttribute lightAttribute = shadowAPI.GetShadowEnableAttr();
+    const PXR_NS::UsdAttribute lightAttribute = shadowAPI.GetShadowEnableAttr();
 
     lightAttribute.Set(attrVal);
 }
@@ -214,7 +214,7 @@ bool UsdLight::shadowEnable() const { return getLightShadowEnable(prim()); }
 Ufe::Color3f getLightShadowColor(const UsdPrim& prim)
 {
     const UsdLuxShadowAPI   shadowAPI(prim);
-    const pxr::UsdAttribute lightAttribute = shadowAPI.GetShadowColorAttr();
+    const PXR_NS::UsdAttribute lightAttribute = shadowAPI.GetShadowColorAttr();
 
     GfVec3f val(0.f, 0.f, 0.f);
     lightAttribute.Get(&val);
@@ -224,7 +224,7 @@ Ufe::Color3f getLightShadowColor(const UsdPrim& prim)
 void setLightShadowColor(const UsdPrim& prim, const Ufe::Color3f& attrVal)
 {
     const UsdLuxShadowAPI   shadowAPI(prim);
-    const pxr::UsdAttribute lightAttribute = shadowAPI.GetShadowColorAttr();
+    const PXR_NS::UsdAttribute lightAttribute = shadowAPI.GetShadowColorAttr();
 
     lightAttribute.Set(GfVec3f(attrVal.r(), attrVal.g(), attrVal.b()));
 }
@@ -248,7 +248,7 @@ Ufe::Color3f UsdLight::shadowColor() const { return getLightShadowColor(prim());
 float getLightDiffuse(const UsdPrim& prim)
 {
     const UsdLuxLightCommon lightSchema(prim);
-    const pxr::UsdAttribute lightAttribute = lightSchema.GetDiffuseAttr();
+    const PXR_NS::UsdAttribute lightAttribute = lightSchema.GetDiffuseAttr();
 
     float val = 0.f;
     lightAttribute.Get(&val);
@@ -258,7 +258,7 @@ float getLightDiffuse(const UsdPrim& prim)
 void setLightDiffuse(const UsdPrim& prim, float attrVal)
 {
     const UsdLuxLightCommon lightSchema(prim);
-    const pxr::UsdAttribute lightAttribute = lightSchema.GetDiffuseAttr();
+    const PXR_NS::UsdAttribute lightAttribute = lightSchema.GetDiffuseAttr();
 
     lightAttribute.Set(attrVal);
 }
@@ -278,7 +278,7 @@ float UsdLight::diffuse() const { return getLightDiffuse(prim()); }
 float getLightSpecular(const UsdPrim& prim)
 {
     const UsdLuxLightCommon lightSchema(prim);
-    const pxr::UsdAttribute lightAttribute = lightSchema.GetSpecularAttr();
+    const PXR_NS::UsdAttribute lightAttribute = lightSchema.GetSpecularAttr();
 
     float val = 0.f;
     lightAttribute.Get(&val);
@@ -288,7 +288,7 @@ float getLightSpecular(const UsdPrim& prim)
 void setLightSpecular(const UsdPrim& prim, float attrVal)
 {
     const UsdLuxLightCommon lightSchema(prim);
-    const pxr::UsdAttribute lightAttribute = lightSchema.GetSpecularAttr();
+    const PXR_NS::UsdAttribute lightAttribute = lightSchema.GetSpecularAttr();
 
     lightAttribute.Set(attrVal);
 }
@@ -308,7 +308,7 @@ float UsdLight::specular() const { return getLightSpecular(prim()); }
 float getLightAngle(const UsdPrim& prim)
 {
     const UsdLuxDistantLight lightSchema(prim);
-    const pxr::UsdAttribute  lightAttribute = lightSchema.GetAngleAttr();
+    const PXR_NS::UsdAttribute  lightAttribute = lightSchema.GetAngleAttr();
 
     float val = 0.f;
     lightAttribute.Get(&val);
@@ -318,7 +318,7 @@ float getLightAngle(const UsdPrim& prim)
 void setLightAngle(const UsdPrim& prim, float attrVal)
 {
     const UsdLuxDistantLight lightSchema(prim);
-    const pxr::UsdAttribute  lightAttribute = lightSchema.GetAngleAttr();
+    const PXR_NS::UsdAttribute  lightAttribute = lightSchema.GetAngleAttr();
 
     lightAttribute.Set(attrVal);
 }
@@ -338,7 +338,7 @@ float UsdDirectionalInterface::angle() const { return getLightAngle(fItem->prim(
 Ufe::Light::SphereProps getLightSphereProps(const UsdPrim& prim)
 {
     const UsdLuxSphereLight lightSchema(prim);
-    const pxr::UsdAttribute lightAttribute = lightSchema.GetRadiusAttr();
+    const PXR_NS::UsdAttribute lightAttribute = lightSchema.GetRadiusAttr();
 
     Ufe::Light::SphereProps sp;
     lightAttribute.Get(&sp.radius);
@@ -349,7 +349,7 @@ Ufe::Light::SphereProps getLightSphereProps(const UsdPrim& prim)
 void setLightSphereProps(const UsdPrim& prim, const Ufe::Light::SphereProps& attrVal)
 {
     const UsdLuxSphereLight lightSchema(prim);
-    const pxr::UsdAttribute lightAttribute = lightSchema.GetRadiusAttr();
+    const PXR_NS::UsdAttribute lightAttribute = lightSchema.GetRadiusAttr();
 
     lightAttribute.Set(attrVal.radius);
 }
@@ -377,9 +377,9 @@ Ufe::Light::SphereProps UsdSphereInterface::sphereProps() const
 Ufe::Light::ConeProps getLightConeProps(const UsdPrim& prim)
 {
     const UsdLuxShapingAPI  lightSchema(prim);
-    const pxr::UsdAttribute focusAttribute = lightSchema.GetShapingFocusAttr();
-    const pxr::UsdAttribute coneAngleAttribute = lightSchema.GetShapingConeAngleAttr();
-    const pxr::UsdAttribute coneSoftnessAttribute = lightSchema.GetShapingConeSoftnessAttr();
+    const PXR_NS::UsdAttribute focusAttribute = lightSchema.GetShapingFocusAttr();
+    const PXR_NS::UsdAttribute coneAngleAttribute = lightSchema.GetShapingConeAngleAttr();
+    const PXR_NS::UsdAttribute coneSoftnessAttribute = lightSchema.GetShapingConeSoftnessAttr();
 
     Ufe::Light::ConeProps cp;
     focusAttribute.Get(&cp.focus);
@@ -391,9 +391,9 @@ Ufe::Light::ConeProps getLightConeProps(const UsdPrim& prim)
 void setLightConeProps(const UsdPrim& prim, const Ufe::Light::ConeProps& attrVal)
 {
     const UsdLuxShapingAPI  lightSchema(prim);
-    const pxr::UsdAttribute focusAttribute = lightSchema.GetShapingFocusAttr();
-    const pxr::UsdAttribute coneAngleAttribute = lightSchema.GetShapingConeAngleAttr();
-    const pxr::UsdAttribute coneSoftnessAttribute = lightSchema.GetShapingConeSoftnessAttr();
+    const PXR_NS::UsdAttribute focusAttribute = lightSchema.GetShapingFocusAttr();
+    const PXR_NS::UsdAttribute coneAngleAttribute = lightSchema.GetShapingConeAngleAttr();
+    const PXR_NS::UsdAttribute coneSoftnessAttribute = lightSchema.GetShapingConeSoftnessAttr();
 
     focusAttribute.Set(attrVal.focus);
     coneAngleAttribute.Set(attrVal.angle);
@@ -423,7 +423,7 @@ Ufe::Light::ConeProps UsdConeInterface::coneProps() const
 bool getLightNormalize(const UsdPrim& prim)
 {
     const UsdLuxRectLight   rectLight(prim);
-    const pxr::UsdAttribute lightAttribute = rectLight.GetNormalizeAttr();
+    const PXR_NS::UsdAttribute lightAttribute = rectLight.GetNormalizeAttr();
 
     bool val = false;
     lightAttribute.Get(&val);
@@ -433,7 +433,7 @@ bool getLightNormalize(const UsdPrim& prim)
 void setLightNormalize(const UsdPrim& prim, bool attrVal)
 {
     const UsdLuxRectLight   rectLight(prim);
-    const pxr::UsdAttribute lightAttribute = rectLight.GetNormalizeAttr();
+    const PXR_NS::UsdAttribute lightAttribute = rectLight.GetNormalizeAttr();
 
     lightAttribute.Set(attrVal);
 }

--- a/lib/mayaUsd/ufe/UsdLightHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdLightHandler.cpp
@@ -29,9 +29,9 @@ namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
 #if PXR_VERSION < 2111
-using UsdLuxLightCommon = pxr::UsdLuxLight;
+using UsdLuxLightCommon = PXR_NS::UsdLuxLight;
 #else
-using UsdLuxLightCommon = pxr::UsdLuxLightAPI;
+using UsdLuxLightCommon = PXR_NS::UsdLuxLightAPI;
 #endif
 
 UsdLightHandler::UsdLightHandler()


### PR DESCRIPTION
Just a small find/replace build fix for those of us using a custom pxr namespace.

This brings these usages into line with the rest of the code base.