### PR TITLE
MAYA-128764 fix AE refresh

### DIFF
--- a/lib/mayaUsd/ufe/Global.cpp
+++ b/lib/mayaUsd/ufe/Global.cpp
@@ -151,6 +151,7 @@ StagesSubject::Ptr g_StagesSubject;
 
 bool InPathChange::inGuard = false;
 bool InAddOrDeleteOperation::inGuard = false;
+int  InSetAttribute::inGuard = 0;
 
 //------------------------------------------------------------------------------
 // Functions

--- a/lib/mayaUsd/ufe/StagesSubject.cpp
+++ b/lib/mayaUsd/ufe/StagesSubject.cpp
@@ -178,8 +178,17 @@ void sendAttributeChanged(
         }
     } break;
     case AttributeChangeType::kAdded: {
-        notifyWithoutExceptions<Ufe::Attributes>(
-            Ufe::AttributeAdded(ufePath, changedToken.GetString()));
+        if (MayaUsd::ufe::InSetAttribute::inSetAttribute()) {
+            notifyWithoutExceptions<Ufe::Attributes>(
+                Ufe::AttributeValueChanged(ufePath, changedToken.GetString()));
+
+            if (MayaUsd::ufe::UsdCamera::isCameraToken(changedToken)) {
+                notifyWithoutExceptions<Ufe::Camera>(ufePath);
+            }
+        } else {
+            notifyWithoutExceptions<Ufe::Attributes>(
+                Ufe::AttributeAdded(ufePath, changedToken.GetString()));
+        }
     } break;
     case AttributeChangeType::kRemoved: {
         notifyWithoutExceptions<Ufe::Attributes>(

--- a/lib/mayaUsd/ufe/UsdAttribute.cpp
+++ b/lib/mayaUsd/ufe/UsdAttribute.cpp
@@ -16,6 +16,7 @@
 #include "UsdAttribute.h"
 
 #include "Utils.h"
+#include "private/UfeNotifGuard.h"
 #include "private/Utils.h"
 
 #include <mayaUsd/ufe/StagesSubject.h>
@@ -86,6 +87,7 @@ template <typename T> bool setUsdAttr(MayaUsd::ufe::UsdAttribute& attr, const T&
     // our own in the StagesSubject, which we invoke here, so that only a
     // single UFE attribute changed notification is generated.
 
+    MayaUsd::ufe::InSetAttribute                    inSetAttr;
     MayaUsd::ufe::AttributeChangedNotificationGuard guard;
     const std::string                               errMsg = attr.isEditAllowedMsg();
     if (!errMsg.empty()) {

--- a/lib/mayaUsd/ufe/UsdAttribute.cpp
+++ b/lib/mayaUsd/ufe/UsdAttribute.cpp
@@ -265,6 +265,18 @@ public:
     {
     }
 
+    void undo() override
+    {
+        MayaUsd::ufe::InSetAttribute inSetAttr;
+        MayaUsd::ufe::UsdUndoableCommand<Ufe::UndoableCommand>::undo();
+    }
+    
+    void redo() override
+    {
+        MayaUsd::ufe::InSetAttribute inSetAttr;
+        MayaUsd::ufe::UsdUndoableCommand<Ufe::UndoableCommand>::redo();
+    }
+
 protected:
     void executeImplementation() override { _attr->set(_newValue); }
 
@@ -285,6 +297,18 @@ public:
         , _key(key)
         , _newValue(newValue)
     {
+    }
+
+    void undo() override
+    {
+        MayaUsd::ufe::InSetAttribute inSetAttr;
+        MayaUsd::ufe::UsdUndoableCommand<Ufe::UndoableCommand>::undo();
+    }
+
+    void redo() override
+    {
+        MayaUsd::ufe::InSetAttribute inSetAttr;
+        MayaUsd::ufe::UsdUndoableCommand<Ufe::UndoableCommand>::redo();
     }
 
 protected:

--- a/lib/mayaUsd/ufe/UsdAttributeHolder.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributeHolder.cpp
@@ -16,6 +16,7 @@
 #include "UsdAttributeHolder.h"
 
 #include "Utils.h"
+#include "private/UfeNotifGuard.h"
 
 #include <mayaUsd/utils/editRouter.h>
 #include <mayaUsd/utils/editRouterContext.h>
@@ -41,6 +42,8 @@ bool setUsdAttrMetadata(
     const Ufe::Value&           value)
 {
     PXR_NAMESPACE_USING_DIRECTIVE
+    MayaUsd::ufe::InSetAttribute inSetAttr;
+
     // Special cases for known Ufe metadata keys.
 
     // Note: we allow the locking attribute to be changed even if attribute is locked
@@ -162,6 +165,7 @@ bool UsdAttributeHolder::set(const PXR_NS::VtValue& value, PXR_NS::UsdTimeCode t
 
     AttributeEditRouterContext ctx(_usdAttr.GetPrim(), _usdAttr.GetName());
 
+    InSetAttribute inSetAttr;
     return _usdAttr.Set(value, time);
 }
 
@@ -437,6 +441,8 @@ bool UsdAttributeHolder::setMetadata(const std::string& key, const Ufe::Value& v
 bool UsdAttributeHolder::clearMetadata(const std::string& key)
 {
     PXR_NAMESPACE_USING_DIRECTIVE
+    InSetAttribute inSetAttr;
+
     if (isValid()) {
         AttributeEditRouterContext ctx(_usdAttr.GetPrim(), _usdAttr.GetName());
 

--- a/lib/mayaUsd/ufe/private/UfeNotifGuard.h
+++ b/lib/mayaUsd/ufe/private/UfeNotifGuard.h
@@ -47,6 +47,33 @@ private:
     static bool inGuard;
 };
 
+//! \brief Helper class to scope when we are in a set attribute operation.
+//
+//         It allows detecting that adding an attribute really was setting the
+//         attribute. When a USD prim did not have an opinion about an attribute
+//         value, it gets notified by USD as adding a property instead of setting
+//         a property, which is very unfortunate. This allows detecting this
+//         situation.
+//
+// This simple guard class can be used within a single scope.
+class InSetAttribute
+{
+public:
+    InSetAttribute() { inGuard += 1; }
+    ~InSetAttribute() { inGuard -= 1; }
+
+    // Delete the copy/move constructors assignment operators.
+    InSetAttribute(const InSetAttribute&) = delete;
+    InSetAttribute& operator=(const InSetAttribute&) = delete;
+    InSetAttribute(InSetAttribute&&) = delete;
+    InSetAttribute& operator=(InSetAttribute&&) = delete;
+
+    static bool inSetAttribute() { return inGuard > 0; }
+
+private:
+    static int inGuard;
+};
+
 //! \brief Helper class to scope when we are in an add or delete operation.
 //
 // This simple guard class can be used within a single scope, but does not have

--- a/test/lib/ufe/testAttribute.py
+++ b/test/lib/ufe/testAttribute.py
@@ -1248,47 +1248,47 @@ class AttributeTestCase(unittest.TestCase):
         # "Props" and "Room_set". Ufe should be filtering out those notifications
         # so the global observer should still only see one notification.
         ufeCmd.execute(ball34XlateAttr.setCmd(ufe.Vector3d(4, 4, 15)))
-        ball34Obs.assertNotificationCount(self, numAdded = 1, numValue = 1)
+        ball34Obs.assertNotificationCount(self, numValue = 2)
         ball35Obs.assertNotificationCount(self)
-        globalObs.assertNotificationCount(self, numAdded = 1, numValue = 1)
+        globalObs.assertNotificationCount(self, numValue = 2)
 
         # The second modification only sends one USD notification for "xformOps:translate"
         # because all the spec's already exist. Ufe should also see one notification.
         ufeCmd.execute(ball34XlateAttr.setCmd(ufe.Vector3d(4, 4, 20)))
-        ball34Obs.assertNotificationCount(self, numAdded = 1, numValue = 2)
+        ball34Obs.assertNotificationCount(self, numValue = 3)
         ball35Obs.assertNotificationCount(self)
-        globalObs.assertNotificationCount(self, numAdded = 1, numValue = 2)
+        globalObs.assertNotificationCount(self, numValue = 3)
 
         # Undo, redo
         cmds.undo()
-        ball34Obs.assertNotificationCount(self, numAdded = 1, numValue = 3)
+        ball34Obs.assertNotificationCount(self, numValue = 4)
         ball35Obs.assertNotificationCount(self)
-        globalObs.assertNotificationCount(self, numAdded = 1, numValue = 3)
+        globalObs.assertNotificationCount(self, numValue = 4)
 
         cmds.redo()
-        ball34Obs.assertNotificationCount(self, numAdded = 1, numValue = 4)
+        ball34Obs.assertNotificationCount(self, numValue = 5)
         ball35Obs.assertNotificationCount(self)
-        globalObs.assertNotificationCount(self, numAdded = 1, numValue = 4)
+        globalObs.assertNotificationCount(self, numValue = 5)
 
         # get ready to undo the first modification
         cmds.undo()
-        ball34Obs.assertNotificationCount(self, numAdded = 1, numValue = 5)
+        ball34Obs.assertNotificationCount(self, numValue = 6)
         ball35Obs.assertNotificationCount(self)
-        globalObs.assertNotificationCount(self, numAdded = 1, numValue = 5)
+        globalObs.assertNotificationCount(self, numValue = 6)
 
         # Undo-ing the modification which created the USD specs is a little
         # different in USD, but from Ufe we should just still see one notification.
         cmds.undo()
-        ball34Obs.assertNotificationCount(self, numAdded = 1, numRemoved = 1, numValue = 5)
+        ball34Obs.assertNotificationCount(self, numRemoved = 1, numValue = 6)
         ball35Obs.assertNotificationCount(self)
-        globalObs.assertNotificationCount(self, numAdded = 1, numRemoved = 1, numValue = 5)
+        globalObs.assertNotificationCount(self, numRemoved = 1, numValue = 6)
 
         cmds.redo()
         # Note that UsdUndoHelper add an attribute with its value in one shot, which results in a
         # single AttributeAdded notification:
-        ball34Obs.assertNotificationCount(self, numAdded = 2, numRemoved = 1, numValue = 5)
+        ball34Obs.assertNotificationCount(self, numRemoved = 1, numValue = 7)
         ball35Obs.assertNotificationCount(self)
-        globalObs.assertNotificationCount(self, numAdded = 2, numRemoved = 1, numValue = 5)
+        globalObs.assertNotificationCount(self, numRemoved = 1, numValue = 7)
 
         # Make a change to ball35, global and ball35 observers change.
         ball35Attrs = ufe.Attributes.attributes(ball35)
@@ -1296,20 +1296,20 @@ class AttributeTestCase(unittest.TestCase):
 
         # "xformOp:translate"
         ufeCmd.execute(ball35XlateAttr.setCmd(ufe.Vector3d(4, 8, 15)))
-        ball34Obs.assertNotificationCount(self, numAdded = 2, numRemoved = 1, numValue = 5)
-        ball35Obs.assertNotificationCount(self, numAdded = 1, numValue = 1)
-        globalObs.assertNotificationCount(self, numAdded = 3, numRemoved = 1, numValue = 6)
+        ball34Obs.assertNotificationCount(self, numRemoved = 1, numValue = 7)
+        ball35Obs.assertNotificationCount(self, numValue = 2)
+        globalObs.assertNotificationCount(self, numRemoved = 1, numValue = 9)
 
         # Undo, redo
         cmds.undo()
-        ball34Obs.assertNotificationCount(self, numAdded = 2, numRemoved = 1, numValue = 5)
-        ball35Obs.assertNotificationCount(self, numAdded = 1, numRemoved = 1, numValue = 1)
-        globalObs.assertNotificationCount(self, numAdded = 3, numRemoved = 2, numValue = 6)
+        ball34Obs.assertNotificationCount(self, numRemoved = 1, numValue = 7)
+        ball35Obs.assertNotificationCount(self, numRemoved = 1, numValue = 2)
+        globalObs.assertNotificationCount(self, numRemoved = 2, numValue = 9)
 
         cmds.redo()
-        ball34Obs.assertNotificationCount(self, numAdded = 2, numRemoved = 1, numValue = 5)
-        ball35Obs.assertNotificationCount(self, numAdded = 2, numRemoved = 1, numValue = 1)
-        globalObs.assertNotificationCount(self, numAdded = 4, numRemoved = 2, numValue = 6)
+        ball34Obs.assertNotificationCount(self, numRemoved = 1, numValue = 7)
+        ball35Obs.assertNotificationCount(self, numRemoved = 1, numValue = 3)
+        globalObs.assertNotificationCount(self, numRemoved = 2, numValue = 10)
 
         # Test removeObserver.
         ufe.Attributes.removeObserver(ball34, ball34Obs)
@@ -1322,9 +1322,9 @@ class AttributeTestCase(unittest.TestCase):
 
         ufeCmd.execute(ball34XlateAttr.setCmd(ufe.Vector3d(4, 4, 25)))
 
-        ball34Obs.assertNotificationCount(self, numAdded = 2, numRemoved = 1, numValue = 5)
-        ball35Obs.assertNotificationCount(self, numAdded = 2, numRemoved = 1, numValue = 1)
-        globalObs.assertNotificationCount(self, numAdded = 4, numRemoved = 2, numValue = 7)
+        ball34Obs.assertNotificationCount(self, numRemoved = 1, numValue = 7)
+        ball35Obs.assertNotificationCount(self, numRemoved = 1, numValue = 3)
+        globalObs.assertNotificationCount(self, numRemoved = 2, numValue = 11)
 
         ufe.Attributes.removeObserver(globalObs)
 
@@ -1332,9 +1332,9 @@ class AttributeTestCase(unittest.TestCase):
 
         ufeCmd.execute(ball34XlateAttr.setCmd(ufe.Vector3d(7, 8, 9)))
 
-        ball34Obs.assertNotificationCount(self, numAdded = 2, numRemoved = 1, numValue = 5)
-        ball35Obs.assertNotificationCount(self, numAdded = 2, numRemoved = 1, numValue = 1)
-        globalObs.assertNotificationCount(self, numAdded = 4, numRemoved = 2, numValue = 7)
+        ball34Obs.assertNotificationCount(self, numRemoved = 1, numValue = 7)
+        ball35Obs.assertNotificationCount(self, numRemoved = 1, numValue = 3)
+        globalObs.assertNotificationCount(self, numRemoved = 2, numValue = 11)
 
     def testAttrChangeRedoAfterPrimCreateRedo(self):
         '''Redo attribute change after redo of prim creation.'''

--- a/test/lib/ufe/testUINodeGraphNode.py
+++ b/test/lib/ufe/testUINodeGraphNode.py
@@ -99,12 +99,19 @@ class UINodeGraphNodeTestCase(unittest.TestCase):
         self.doPosAndSizeTests(uiNodeGraphNode.hasPosition, uiNodeGraphNode.setPosition,
             uiNodeGraphNode.getPosition, uiNodeGraphNode.setPositionCmd)
 
+        # None of these changes should force a render refresh:
+        self.assertEqual(initialUpdateCount, cmds.getAttr('|transform1|proxyShape1.updateId'))
+        self.assertEqual(initialResyncCount, cmds.getAttr('|transform1|proxyShape1.resyncId'))
+
     @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '4100',
                      'Size interface only available in Ufe preview version greater equal to 4.0.100, or 0.5.0.')
     def testSize(self):
         ball3Path = ufe.PathString.path('|transform1|proxyShape1,/Ball_set/Props/Ball_3')
         ball3SceneItem = ufe.Hierarchy.createItem(ball3Path)
 
+        initialUpdateCount = cmds.getAttr('|transform1|proxyShape1.updateId')
+        initialResyncCount = cmds.getAttr('|transform1|proxyShape1.resyncId')
+        
         if(hasattr(ufe, "UINodeGraphNode_v4_1")):
             uiNodeGraphNode = ufe.UINodeGraphNode_v4_1.uiNodeGraphNode(ball3SceneItem)
         else:

--- a/test/lib/ufe/testUINodeGraphNode.py
+++ b/test/lib/ufe/testUINodeGraphNode.py
@@ -103,19 +103,12 @@ class UINodeGraphNodeTestCase(unittest.TestCase):
         self.doPosAndSizeTests(uiNodeGraphNode.hasPosition, uiNodeGraphNode.setPosition,
             uiNodeGraphNode.getPosition, uiNodeGraphNode.setPositionCmd)
 
-        # None of these changes should force a render refresh:
-        self.assertEqual(initialUpdateCount, cmds.getAttr('|transform1|proxyShape1.updateId'))
-        self.assertEqual(initialResyncCount, cmds.getAttr('|transform1|proxyShape1.resyncId'))
-
     @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '4100',
                      'Size interface only available in Ufe preview version greater equal to 4.0.100, or 0.5.0.')
     def testSize(self):
         ball3Path = ufe.PathString.path('|transform1|proxyShape1,/Ball_set/Props/Ball_3')
         ball3SceneItem = ufe.Hierarchy.createItem(ball3Path)
 
-        initialUpdateCount = cmds.getAttr('|transform1|proxyShape1.updateId')
-        initialResyncCount = cmds.getAttr('|transform1|proxyShape1.resyncId')
-        
         if(hasattr(ufe, "UINodeGraphNode_v4_1")):
             uiNodeGraphNode = ufe.UINodeGraphNode_v4_1.uiNodeGraphNode(ball3SceneItem)
         else:


### PR DESCRIPTION
Setting the value of a USD property that previously had the default value for that property creates a USD property-spec, which trigger a USD notification about a property being added. In reality, it is not that a new custom property is added, just that an opinion about a property that is being set.

The attribute editor handled the addition of a property by recreating the UI entirely.

To differentiate between a real property being added and a property getting a non-default value, we now add a guard in the various places where we are setting a value to allow the notification handler to know the difference.