### PR TITLE
MAYA-128783 - Material api: hasMaterial implementation

### DIFF
--- a/lib/mayaUsd/ufe/UsdMaterial.cpp
+++ b/lib/mayaUsd/ufe/UsdMaterial.cpp
@@ -52,20 +52,20 @@ std::vector<Ufe::SceneItem::Ptr> UsdMaterial::getMaterials() const
 
     std::vector<PXR_NS::UsdPrim> materialPrims;
 
-    const PXR_NS::UsdPrim&                            prim = _item->prim();
-    PXR_NS::UsdShadeMaterialBindingAPI                bindingApi(prim);
-    PXR_NS::UsdShadeMaterialBindingAPI::DirectBinding directBinding = bindingApi.GetDirectBinding();
+    const PXR_NS::UsdPrim&             prim = _item->prim();
+    PXR_NS::UsdShadeMaterialBindingAPI bindingApi(prim);
 
     // 1. Simple case: A material is directly attached to our object.
-    const PXR_NS::UsdShadeMaterial material = directBinding.GetMaterial();
+    PXR_NS::UsdShadeMaterialBindingAPI::DirectBinding directBinding = bindingApi.GetDirectBinding();
+    const PXR_NS::UsdShadeMaterial                    material = directBinding.GetMaterial();
     if (material) {
         materialPrims.push_back(material.GetPrim());
     }
 
     // 2. Check whether multiple materials are attached to this object via geometry subsets.
     for (const auto& geometrySubset : bindingApi.GetMaterialBindSubsets()) {
-        const UsdShadeMaterialBindingAPI subsetBindingAPI(geometrySubset.GetPrim());
-        const UsdShadeMaterial           material
+        const PXR_NS::UsdShadeMaterialBindingAPI subsetBindingAPI(geometrySubset.GetPrim());
+        const PXR_NS::UsdShadeMaterial           material
             = subsetBindingAPI.ComputeBoundMaterial(UsdShadeTokens->surface);
         if (material) {
             materialPrims.push_back(material.GetPrim());
@@ -92,6 +92,39 @@ std::vector<Ufe::SceneItem::Ptr> UsdMaterial::getMaterials() const
 
     return materials;
 }
+
+#if (UFE_PREVIEW_VERSION_NUM >= 5002)
+
+bool UsdMaterial::hasMaterial() const
+{
+    if (!TF_VERIFY(_item)) {
+        return false;
+    }
+
+    const PXR_NS::UsdPrim&             prim = _item->prim();
+    PXR_NS::UsdShadeMaterialBindingAPI bindingApi(prim);
+
+    // 1. Simple case: A material is directly attached to our object.
+    PXR_NS::UsdShadeMaterialBindingAPI::DirectBinding directBinding = bindingApi.GetDirectBinding();
+    const PXR_NS::UsdShadeMaterial                    material = directBinding.GetMaterial();
+    if (material) {
+        return true;
+    }
+
+    // 2. Check whether any material is attached to this object via geometry subsets.
+    for (const auto& geometrySubset : bindingApi.GetMaterialBindSubsets()) {
+        const PXR_NS::UsdShadeMaterialBindingAPI subsetBindingAPI(geometrySubset.GetPrim());
+        const PXR_NS::UsdShadeMaterial           material
+            = subsetBindingAPI.ComputeBoundMaterial(UsdShadeTokens->surface);
+        if (material) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+#endif
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdMaterial.h
+++ b/lib/mayaUsd/ufe/UsdMaterial.h
@@ -49,6 +49,10 @@ public:
 
     std::vector<Ufe::SceneItem::Ptr> getMaterials() const override;
 
+#if (UFE_PREVIEW_VERSION_NUM >= 5002)
+    bool hasMaterial() const override;
+#endif
+
 private:
     UsdSceneItem::Ptr _item;
 }; // UsdMaterial

--- a/test/lib/ufe/testMaterial.py
+++ b/test/lib/ufe/testMaterial.py
@@ -33,6 +33,8 @@ import ufe
 from functools import partial
 import unittest
 
+import os
+
 class MaterialTestCase(unittest.TestCase):
     '''Verify the Material UFE interface.
     
@@ -66,6 +68,10 @@ class MaterialTestCase(unittest.TestCase):
         globalSelection = ufe.GlobalSelection.get()
         globalSelection.clear()
 
+    # methods:
+    #   - getMaterials
+    #   - hasMaterial   (since UFE version 0.5.2 , or '5002')
+
     def testUsdNoMaterial(self):
         """
         Checks that an object is bound to zero materials.
@@ -78,8 +84,13 @@ class MaterialTestCase(unittest.TestCase):
         cubeItem = ufe.Hierarchy.createItem(cubePath)
 
         materialInterface = ufe.Material.material(cubeItem)
+
         materials = materialInterface.getMaterials()
         self.assertEqual(len(materials), 0)
+
+        if(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') >= '5002'):
+            hasAnyMaterial = materialInterface.hasMaterial()
+            self.assertFalse(hasAnyMaterial)
 
     def testUsdSingleMaterial(self):
         """
@@ -93,8 +104,13 @@ class MaterialTestCase(unittest.TestCase):
         cubeItem = ufe.Hierarchy.createItem(cubePath)
 
         materialInterface = ufe.Material.material(cubeItem)
+
         materials = materialInterface.getMaterials()
         self.assertEqual(len(materials), 1)
+
+        if(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') >= '5002'):
+            hasAnyMaterial = materialInterface.hasMaterial()
+            self.assertTrue(hasAnyMaterial)
 
     def testUsdMultipleMaterials(self):
         """
@@ -108,8 +124,13 @@ class MaterialTestCase(unittest.TestCase):
         cubeItem = ufe.Hierarchy.createItem(cubePath)
 
         materialInterface = ufe.Material.material(cubeItem)
+
         materials = materialInterface.getMaterials()
         self.assertEqual(len(materials), 2)
+
+        if(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') >= '5002'):
+            hasAnyMaterial = materialInterface.hasMaterial()
+            self.assertTrue(hasAnyMaterial)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Extends the UFE Material Interface, mainly intended for internal use in the LookdevX team
- implements `hasMaterial` query that is being introduced in the UFE abstract interface