### PR TITLE
Use Hd_VertexAdjacency API directly

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -426,18 +426,15 @@ void HdVP2Mesh::_PrepareSharedVertexBuffers(
                 // note: normals gets dirty when points are marked as dirty,
                 // at change tracker.
                 if (!_meshSharedData->_adjacency) {
-                    _meshSharedData->_adjacency.reset(new Hd_VertexAdjacency());
-
-                    HdBufferSourceSharedPtr adjacencyComputation
-                        = _meshSharedData->_adjacency->GetSharedAdjacencyBuilderComputation(
-                            &_meshSharedData->_topology);
                     MProfilingScope profilingScope(
                         HdVP2RenderDelegate::sProfilerCategory,
                         MProfiler::kColorC_L2,
                         _rprimId.asChar(),
                         "HdVP2Mesh::computeAdjacency");
 
-                    adjacencyComputation->Resolve();
+                    _meshSharedData->_adjacency.reset(new Hd_VertexAdjacency());
+
+                    _meshSharedData->_adjacency->BuildAdjacencyTable(&_meshSharedData->_topology);
                 }
 
                 // Only the points referenced by the topology are used to compute
@@ -1738,9 +1735,8 @@ void HdVP2Mesh::_UpdateDrawItem(
                 renderIndex.GetSprim(HdPrimTypeTokens->material, materialId));
 
             if (material) {
-                const HdCullStyle           cullStyle = GetCullStyle(sceneDelegate);
-                MHWRender::MShaderInstance* shader = material->GetSurfaceShader(
-                    _GetMaterialNetworkToken(reprToken), cullStyle == HdCullStyleBack);
+                MHWRender::MShaderInstance* shader
+                    = material->GetSurfaceShader(_GetMaterialNetworkToken(reprToken));
                 if (shader != nullptr
                     && (shader != drawItemData._shader || shader != stateToCommit._shader)) {
                     drawItemData._shader = shader;

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1735,8 +1735,9 @@ void HdVP2Mesh::_UpdateDrawItem(
                 renderIndex.GetSprim(HdPrimTypeTokens->material, materialId));
 
             if (material) {
-                MHWRender::MShaderInstance* shader
-                    = material->GetSurfaceShader(_GetMaterialNetworkToken(reprToken));
+                const HdCullStyle           cullStyle = GetCullStyle(sceneDelegate);
+                MHWRender::MShaderInstance* shader = material->GetSurfaceShader(
+                    _GetMaterialNetworkToken(reprToken), cullStyle == HdCullStyleBack);
                 if (shader != nullptr
                     && (shader != drawItemData._shader || shader != stateToCommit._shader)) {
                     drawItemData._shader = shader;

--- a/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.cpp
@@ -355,12 +355,10 @@ void MeshViewportCompute::createConsolidatedAdjacency()
         MProfiler::kColorD_L2,
         "MeshViewportCompute:createConsolidatedAdjacency");
 
-    Hd_VertexAdjacencySharedPtr adjacency(new Hd_VertexAdjacency());
-    HdBufferSourceSharedPtr     adjacencyComputation
-        = adjacency->GetSharedAdjacencyBuilderComputation(&_meshSharedData->_topology);
-    adjacencyComputation->Resolve();
+    Hd_VertexAdjacency adjacency;
+    adjacency.BuildAdjacencyTable(&_meshSharedData->_topology);
 
-    const VtIntArray& adjacencyTable = adjacency->GetAdjacencyTable();
+    const VtIntArray& adjacencyTable = adjacency.GetAdjacencyTable();
     size_t            adjacencyBufferSize = adjacencyTable.size();
     int*              adjCopy = new int[adjacencyBufferSize];
     memcpy(adjCopy, adjacencyTable.data(), adjacencyBufferSize * sizeof(int));


### PR DESCRIPTION
Updated to use the vertex adjacency API directly to build the vertex adjacency table instead of using Storm specific shared builder computations.

This simplifies the code sightly while avoiding a dependency on API that is being moved from imaging/hd to imaging/hdSt.

Not using a version guard here since the interface we're switching to has been available for a long time.