### PR TITLE
MAYA-129061 - Refactor material commands.

### DIFF
--- a/lib/mayaUsd/ufe/UsdShaderNodeDef.cpp
+++ b/lib/mayaUsd/ufe/UsdShaderNodeDef.cpp
@@ -361,9 +361,7 @@ Ufe::InsertChildCommand::Ptr UsdShaderNodeDef::createNodeCmd(
     TF_AXIOM(fShaderNodeDef);
     UsdSceneItem::Ptr parentItem = std::dynamic_pointer_cast<UsdSceneItem>(parent);
     if (parentItem) {
-        if (parentItem->nodeType() == "Scope"
-            && parentItem->nodeName()
-                == UsdUndoAssignNewMaterialCommand::resolvedMaterialScopeName()) {
+        if (UsdUndoAddNewMaterialCommand::CompatiblePrim(parentItem)) {
             return UsdUndoAddNewMaterialCommand::create(
                 parentItem, fShaderNodeDef->GetIdentifier());
         }

--- a/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
@@ -22,6 +22,7 @@
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/undo/UsdUndoBlock.h>
 
+#include <ufe/hierarchy.h>
 #include <ufe/pathString.h>
 
 namespace {
@@ -47,7 +48,11 @@ UsdUndoAddNewPrimCommand::UsdUndoAddNewPrimCommand(
     const UsdSceneItem::Ptr& usdSceneItem,
     const std::string&       name,
     const std::string&       type)
+#ifdef UFE_V4_FEATURES_AVAILABLE
+    : Ufe::SceneItemResultUndoableCommand()
+#else
     : Ufe::UndoableCommand()
+#endif
 {
     // First get the stage from the proxy shape.
     auto ufePath = usdSceneItem->path();
@@ -114,6 +119,11 @@ std::string UsdUndoAddNewPrimCommand::commandString() const
 {
     return std::string("CreatePrim ") + _primToken.GetText() + " "
         + Ufe::PathString::string(_newUfePath);
+}
+
+Ufe::SceneItem::Ptr UsdUndoAddNewPrimCommand::sceneItem() const
+{
+    return Ufe::Hierarchy::createItem(newUfePath());
 }
 #endif
 

--- a/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.h
@@ -32,7 +32,11 @@ namespace ufe {
 // This command is not restricted: it is always possible to create a new
 // prim even in weaker layer since the new prim, by the fact that it is new
 // cannot have an already-existing opinon that would shadow it.
+#ifdef UFE_V4_FEATURES_AVAILABLE
+class MAYAUSD_CORE_PUBLIC UsdUndoAddNewPrimCommand : public Ufe::SceneItemResultUndoableCommand
+#else
 class MAYAUSD_CORE_PUBLIC UsdUndoAddNewPrimCommand : public Ufe::UndoableCommand
+#endif
 {
 public:
     typedef std::shared_ptr<UsdUndoAddNewPrimCommand> Ptr;
@@ -50,6 +54,7 @@ public:
     PXR_NS::UsdPrim  newPrim() const;
 
     UFE_V4(std::string commandString() const override;)
+    UFE_V4(Ufe::SceneItem::Ptr sceneItem() const override;)
 
     static UsdUndoAddNewPrimCommand::Ptr
     create(const UsdSceneItem::Ptr& usdSceneItem, const std::string& name, const std::string& type);

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
@@ -86,31 +86,6 @@ bool connectShaderToMaterial(
     UsdShadeConnectableAPI::ConnectToSource(materialOutput, shaderOutput);
     return true;
 }
-#endif
-
-bool _BindMaterialCompatiblePrim(const UsdPrim& usdPrim)
-{
-    if (UsdShadeNodeGraph(usdPrim) || UsdShadeShader(usdPrim)) {
-        // The binding schema can be applied anywhere, but it makes no sense on a
-        // material or a shader.
-        return false;
-    }
-    if (UsdGeomScope(usdPrim)
-        && usdPrim.GetName() == UsdMayaJobExportArgs::GetDefaultMaterialsScopeName()) {
-        return false;
-    }
-    if (auto subset = UsdGeomSubset(usdPrim)) {
-        TfToken elementType;
-        subset.GetElementTypeAttr().Get(&elementType);
-        if (elementType != UsdGeomTokens->face) {
-            return false;
-        }
-    }
-    if (PXR_NS::UsdShadeMaterialBindingAPI::CanApply(usdPrim)) {
-        return true;
-    }
-    return false;
-}
 
 //! Returns true if \p item is a materials scope.
 bool isMaterialsScope(const Ufe::SceneItem::Ptr& item)
@@ -178,6 +153,31 @@ Ufe::SceneItem::Ptr getMaterialsScope(const Ufe::Path& parentPath)
         // Name is already used by something that is not a scope. Try the next name.
         scopeName = scopeNamePrefix + std::to_string(i);
     }
+}
+#endif
+
+bool _BindMaterialCompatiblePrim(const UsdPrim& usdPrim)
+{
+    if (UsdShadeNodeGraph(usdPrim) || UsdShadeShader(usdPrim)) {
+        // The binding schema can be applied anywhere, but it makes no sense on a
+        // material or a shader.
+        return false;
+    }
+    if (UsdGeomScope(usdPrim)
+        && usdPrim.GetName() == UsdMayaJobExportArgs::GetDefaultMaterialsScopeName()) {
+        return false;
+    }
+    if (auto subset = UsdGeomSubset(usdPrim)) {
+        TfToken elementType;
+        subset.GetElementTypeAttr().Get(&elementType);
+        if (elementType != UsdGeomTokens->face) {
+            return false;
+        }
+    }
+    if (PXR_NS::UsdShadeMaterialBindingAPI::CanApply(usdPrim)) {
+        return true;
+    }
+    return false;
 }
 
 } // namespace

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
@@ -415,8 +415,8 @@ void UsdUndoAssignNewMaterialCommand::execute()
         //
         // 3. Create the Shader:
         //
-        UsdSceneItem::Ptr materialItem = std::dynamic_pointer_cast<UsdSceneItem>(
-            Ufe::Hierarchy::createItem(createMaterialCmd->newUfePath()));
+        UsdSceneItem::Ptr materialItem
+            = std::dynamic_pointer_cast<UsdSceneItem>(createMaterialCmd->sceneItem());
         auto createShaderCmd = UsdUndoCreateFromNodeDefCommand::create(
             shaderNodeDef, materialItem, shaderNodeDef->GetFamily().GetString());
         if (!createShaderCmd) {
@@ -582,8 +582,7 @@ void UsdUndoAddNewMaterialCommand::execute()
     //
     // Create the Shader:
     //
-    auto materialItem = std::dynamic_pointer_cast<UsdSceneItem>(
-        Ufe::Hierarchy::createItem(_createMaterialCmd->newUfePath()));
+    auto materialItem = std::dynamic_pointer_cast<UsdSceneItem>(_createMaterialCmd->sceneItem());
     _createShaderCmd = UsdUndoCreateFromNodeDefCommand::create(
         shaderNodeDef, materialItem, shaderNodeDef->GetFamily().GetString());
     if (!_createShaderCmd) {
@@ -686,8 +685,7 @@ void UsdUndoCreateMaterialsScopeCommand::execute()
     }
     createScopeCmd->execute();
 
-    auto scopePath = createScopeCmd->newUfePath();
-    auto scopeItem = std::dynamic_pointer_cast<UsdSceneItem>(Ufe::Hierarchy::createItem(scopePath));
+    auto scopeItem = std::dynamic_pointer_cast<UsdSceneItem>(createScopeCmd->sceneItem());
     auto materialsScopeName = UsdMayaJobExportArgs::GetDefaultMaterialsScopeName();
     auto renameCmd = UsdUndoRenameCommand::create(scopeItem, materialsScopeName);
     if (!renameCmd) {

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
@@ -373,7 +373,7 @@ void UsdUndoAssignNewMaterialCommand::execute()
         createMaterialsScopeCmd->execute();
         _cmds->append(createMaterialsScopeCmd);
 
-        auto materialsScope = createMaterialsScopeCmd->sceneItem(); 
+        auto materialsScope = createMaterialsScopeCmd->sceneItem();
         if (!materialsScope || materialsScope->path().empty()) {
             // The _createScopeCmd and/or _renameScopeCmd will have emitted errors.
             markAsFailed();

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.h
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.h
@@ -123,9 +123,6 @@ public:
     void undo() override;
     void redo() override;
 
-    // Returns the name of the material scope in this Maya session.
-    static std::string resolvedMaterialScopeName();
-
 private:
     void markAsFailed();
 
@@ -178,6 +175,45 @@ private:
     UsdUndoCreateFromNodeDefCommand::Ptr _createShaderCmd;
 
 }; // UsdUndoAddNewMaterialCommand
+
+//! \brief This command is used to create a materials scope under a specified parent item. A
+//! materials scope is a USD Scope with a special name (usually "mtl"), which holds materials. By
+//! convention, all materials should reside within such a scope.
+class MAYAUSD_CORE_PUBLIC UsdUndoCreateMaterialsScopeCommand
+    : public Ufe::SceneItemResultUndoableCommand
+{
+public:
+    typedef std::shared_ptr<UsdUndoCreateMaterialsScopeCommand> Ptr;
+
+    UsdUndoCreateMaterialsScopeCommand(const UsdSceneItem::Ptr& parentItem);
+    ~UsdUndoCreateMaterialsScopeCommand() override;
+
+    // Delete the copy/move constructors assignment operators.
+    UsdUndoCreateMaterialsScopeCommand(const UsdUndoCreateMaterialsScopeCommand&) = delete;
+    UsdUndoCreateMaterialsScopeCommand& operator=(const UsdUndoCreateMaterialsScopeCommand&)
+        = delete;
+    UsdUndoCreateMaterialsScopeCommand(UsdUndoCreateMaterialsScopeCommand&&) = delete;
+    UsdUndoCreateMaterialsScopeCommand& operator=(UsdUndoCreateMaterialsScopeCommand&&) = delete;
+
+    //! Create a UsdUndoCreateMaterialsScopeCommand that creates a new materials scope under \p
+    //! parentItem. If there already is a materials scope under \p parentItem, the command will
+    //! not create a new materials scope but simply point to the existing one.
+    static UsdUndoCreateMaterialsScopeCommand::Ptr create(const UsdSceneItem::Ptr& parentItem);
+
+    Ufe::SceneItem::Ptr sceneItem() const override;
+
+    void execute() override;
+    void undo() override;
+    void redo() override;
+
+private:
+    void markAsFailed();
+
+    UsdSceneItem::Ptr   _parentItem;
+    Ufe::SceneItem::Ptr _insertedChild;
+
+    UsdUndoableItem _undoableItem;
+}; // UsdUndoCreateMaterialsScopeCommand
 #endif
 
 } // namespace ufe


### PR DESCRIPTION
In UsdUndoMaterialCommands, factor out the code related to materials scopes into separate commands and functions. This will allow reusing them and is required by future work (MAYA-128151).

Also, make `UsdUndoAddNewPrimCommand` derive from `SceneItemResultUndoableCommand`. This allows UFE clients to access the newly created prim by calling `SceneItemResultUndoableCommand::sceneItem()`.