### PR TITLE
MAYA-126933 - [GitHub#2804] Maya crashes if USD instanceable is used together with varying visibility

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
@@ -352,10 +352,8 @@ HdReprSharedPtr MayaUsdRPrim::_InitReprCommon(
     auto delegate = drawScene.GetUsdImagingDelegate();
     auto instancerId = delegate->GetInstancerId(id);
     bool instanced = !instancerId.IsEmpty();
-#if PXR_VERSION < 2211
-    // The additional condition here is to prevent a crash in USD versions below 22.11
+    // The additional condition below is to prevent a crash in USD function GetScenePrimPath
     instanced &= !delegate->GetInstanceIndices(instancerId, id).empty();
-#endif
 
     // display layers handling
     if (instanced) {
@@ -893,10 +891,8 @@ void MayaUsdRPrim::_SyncSharedData(
     // If instancer is dirty, update instancing map
     if (HdChangeTracker::IsInstancerDirty(*dirtyBits, id)) {
         bool instanced = !refThis.GetInstancerId().IsEmpty();
-#if PXR_VERSION < 2211
-        // The additional condition here is to prevent a crash in USD versions below 22.11
+        // The additional condition below is to prevent a crash in USD function GetScenePrimPath
         instanced &= !delegate->GetInstanceIndices(refThis.GetInstancerId(), id).empty();
-#endif
 
         // UpdateInstancingMapEntry is not multithread-safe, so enqueue the call
         _delegate->GetVP2ResourceRegistry().EnqueueCommit([this, id, instanced]() {


### PR DESCRIPTION
This also fixes MAYA-127101 - [github #2812] Point Instancer: Maya crashes if protoIndices doesn't include first item on the array.