### PR TITLE
MAYA-126014 - Clipboard cut, copy and paste.

### DIFF
--- a/cmake/modules/FindUFE.cmake
+++ b/cmake/modules/FindUFE.cmake
@@ -13,6 +13,7 @@
 # UFE_MATERIALS_SUPPORT     Presence of UFE materials support
 # UFE_SCENE_SEGMENT_SUPPORT Presence of UFE scene segment support
 # UFE_PREVIEW_FEATURES      List of all features introduced gradually in the UFE preview version
+# UFE_CLIPBOARD_SUPPORT     Presence of UFE Clipboard support
 #
 
 find_path(UFE_INCLUDE_DIR
@@ -153,4 +154,10 @@ if(UFE_INCLUDE_DIR AND EXISTS "${UFE_INCLUDE_DIR}/ufe/uiNodeGraphNode.h")
         set(UFE_UINODEGRAPHNODE_HAS_SIZE TRUE CACHE INTERNAL "ufeUINodeGraphNodeHasSize")
         message(STATUS "Maya has UFE UINodeGraphNode size interface")
     endif()
+endif()
+
+set(UFE_CLIPBOARD_SUPPORT FALSE CACHE INTERNAL "ufeClipboard")
+if (UFE_INCLUDE_DIR AND EXISTS "${UFE_INCLUDE_DIR}/ufe/clipboardHandler.h")
+    set(UFE_CLIPBOARD_SUPPORT TRUE CACHE INTERNAL "ufeClipboard")
+    message(STATUS "Maya has UFE Clipboard API")
 endif()

--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -130,6 +130,19 @@ if (UFE_UINODEGRAPHNODE_HAS_SIZE)
     )
 endif()
 
+if (UFE_CLIPBOARD_SUPPORT)
+    target_sources(${PROJECT_NAME}
+        PRIVATE
+            UsdClipboardHandler.cpp
+            UsdUndoClipboardCommand.cpp
+    )
+
+    target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+        UFE_CLIPBOARD_SUPPORT=1
+    )
+endif()
+
 if (v4_BatchOps IN_LIST UFE_PREVIEW_FEATURES)
     message(STATUS "UFE_PREVIEW has V4 BatchOps support")
     target_sources(${PROJECT_NAME}
@@ -270,6 +283,13 @@ endif()
 if (UFE_SCENE_SEGMENT_SUPPORT)
     list(APPEND HEADERS
         ProxyShapeSceneSegmentHandler.h
+    )
+endif()
+
+if (UFE_CLIPBOARD_SUPPORT)
+    list(APPEND HEADERS
+        UsdClipboardHandler.h
+        UsdUndoClipboardCommand.h
     )
 endif()
 

--- a/lib/mayaUsd/ufe/Global.cpp
+++ b/lib/mayaUsd/ufe/Global.cpp
@@ -57,6 +57,9 @@
 #if UFE_PREVIEW_BATCHOPS_SUPPORT
 #include <mayaUsd/ufe/UsdBatchOpsHandler.h>
 #endif
+#if UFE_CLIPBOARD_SUPPORT
+#include <mayaUsd/ufe/UsdClipboardHandler.h>
+#endif
 #include <mayaUsd/ufe/ProxyShapeCameraHandler.h>
 #include <mayaUsd/ufe/UsdShaderNodeDefHandler.h>
 #endif
@@ -197,6 +200,9 @@ MStatus initialize()
     handlers.uiNodeGraphNodeHandler = UsdUINodeGraphNodeHandler::create();
 #if UFE_PREVIEW_BATCHOPS_SUPPORT
     handlers.batchOpsHandler = UsdBatchOpsHandler::create();
+#endif
+#if UFE_CLIPBOARD_SUPPORT
+    handlers.clipboardHandler = UsdClipboardHandler::create();
 #endif
     handlers.nodeDefHandler = UsdShaderNodeDefHandler::create();
 #endif

--- a/lib/mayaUsd/ufe/UsdClipboardHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdClipboardHandler.cpp
@@ -1,0 +1,57 @@
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "UsdClipboardHandler.h"
+
+#include <mayaUsd/ufe/UsdUndoClipboardCommand.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+UsdClipboardHandler::UsdClipboardHandler() { }
+
+UsdClipboardHandler::~UsdClipboardHandler() { }
+
+/*static*/
+UsdClipboardHandler::Ptr UsdClipboardHandler::create()
+{
+    return std::make_shared<UsdClipboardHandler>();
+}
+
+//------------------------------------------------------------------------------
+// Ufe::ClipboardHandler overrides
+//------------------------------------------------------------------------------
+
+Ufe::UndoableCommand::Ptr UsdClipboardHandler::cutCmd_(const Ufe::Selection& selection)
+{
+    return UsdUndoCutClipboardCommand::create(selection);
+}
+
+Ufe::UndoableCommand::Ptr UsdClipboardHandler::copyCmd_(const Ufe::Selection& selection)
+{
+    return UsdUndoCopyClipboardCommand::create(selection);
+}
+
+Ufe::SelectionUndoableCommand::Ptr
+UsdClipboardHandler::pasteCmd_(const Ufe::SceneItem::Ptr& parentItem)
+{
+    return UsdUndoPasteClipboardCommand::create(parentItem);
+}
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdClipboardHandler.h
+++ b/lib/mayaUsd/ufe/UsdClipboardHandler.h
@@ -1,0 +1,55 @@
+#ifndef USDCLIPBOARDHANDLER_H
+#define USDCLIPBOARDHANDLER_H
+
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <mayaUsd/base/api.h>
+
+#include <ufe/clipboardHandler.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+//! \brief Interface to create a UsdClipboardHandler interface object.
+class MAYAUSD_CORE_PUBLIC UsdClipboardHandler : public Ufe::ClipboardHandler
+{
+public:
+    typedef std::shared_ptr<UsdClipboardHandler> Ptr;
+
+    UsdClipboardHandler();
+    ~UsdClipboardHandler() override;
+
+    // Delete the copy/move constructors assignment operators.
+    UsdClipboardHandler(const UsdClipboardHandler&) = delete;
+    UsdClipboardHandler& operator=(const UsdClipboardHandler&) = delete;
+    UsdClipboardHandler(UsdClipboardHandler&&) = delete;
+    UsdClipboardHandler& operator=(UsdClipboardHandler&&) = delete;
+
+    //! Create a UsdClipboardHandler.
+    static UsdClipboardHandler::Ptr create();
+
+    // Ufe::ClipboardHandler overrides.
+    Ufe::UndoableCommand::Ptr          cutCmd_(const Ufe::Selection& selection) override;
+    Ufe::UndoableCommand::Ptr          copyCmd_(const Ufe::Selection& selection) override;
+    Ufe::SelectionUndoableCommand::Ptr pasteCmd_(const Ufe::SceneItem::Ptr& parentItem) override;
+
+}; // UsdClipboardHandler
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF
+
+#endif // USDCLIPBOARDHANDLER_H

--- a/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoAddNewPrimCommand.cpp
@@ -24,22 +24,6 @@
 
 #include <ufe/pathString.h>
 
-namespace {
-
-Ufe::Path appendToPath(const Ufe::Path& path, const std::string& name)
-{
-    Ufe::Path newUfePath;
-    if (1 == path.getSegments().size()) {
-        newUfePath = path
-            + Ufe::PathSegment(Ufe::PathComponent(name), MayaUsd::ufe::getUsdRunTimeId(), '/');
-    } else {
-        newUfePath = path + name;
-    }
-    return newUfePath;
-}
-
-} // namespace
-
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 

--- a/lib/mayaUsd/ufe/UsdUndoClipboardCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoClipboardCommand.cpp
@@ -1,0 +1,277 @@
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "UsdUndoClipboardCommand.h"
+
+#include "UsdUndoDeleteCommand.h"
+#include "UsdUndoDuplicateSelectionCommand.h"
+
+#include <mayaUsd/ufe/Utils.h>
+#include <mayaUsd/undo/UsdUndoBlock.h>
+
+#include <ufe/pathString.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+namespace {
+
+static constexpr char stageClipboard[] = "stageClipboard";
+
+void deleteStage(const Ufe::Path& stageUfePath)
+{
+    auto splittedStrings = splitString(stageUfePath.string(), "|");
+
+    if (splittedStrings.size() >= 1) {
+        MString script;
+        script.format("delete \"^1s\"", splittedStrings[1].c_str());
+
+        MStatus status = MGlobal::executeCommand(script, false, false);
+        if (!status) {
+            const std::string error = TfStringPrintf(
+                "Failed to delete Clipboard stage with ufe path: \"%s\".", stageUfePath);
+            throw std::runtime_error(error);
+        }
+    }
+}
+
+void hideStage(const Ufe::Path& stageUfePath)
+{
+    auto splittedStrings = splitString(stageUfePath.string(), "|");
+    if (splittedStrings.size() >= 1) {
+        MString script;
+        script.format("setAttr ^1s.hiddenInOutliner 1;", splittedStrings[1].c_str());
+        MStatus status = MGlobal::executeCommand(script, false, false);
+
+        if (!status) {
+            const std::string error = TfStringPrintf(
+                "Failed to hide Clipboard stage with ufe path: \"%s\".", stageUfePath);
+            throw std::runtime_error(error);
+        }
+    }
+}
+
+} // namespace
+
+UsdUndoCopyClipboardCommand::UsdUndoCopyClipboardCommand(const Ufe::Selection& selection)
+    : Ufe::UndoableCommand()
+    , _selection(selection)
+{
+}
+
+UsdUndoCopyClipboardCommand::~UsdUndoCopyClipboardCommand() { }
+
+UsdUndoCopyClipboardCommand::Ptr
+UsdUndoCopyClipboardCommand::create(const Ufe::Selection& selection)
+{
+    auto retVal = std::make_shared<UsdUndoCopyClipboardCommand>(selection);
+
+    if (retVal->_selection.empty()) {
+        return {};
+    }
+
+    return retVal;
+}
+
+void UsdUndoCopyClipboardCommand::execute()
+{
+    UsdUndoBlock undoBlock(&_undoableItem);
+
+    // Step 1. Create a stage for the Clipboard.
+    MString script;
+    script.format("createNode -name \"^1s\" -ss \"^2s\"", stageClipboard, "mayaUsdProxyShape");
+
+    std::string cmdResult
+        = MGlobal::executeCommandStringResult(script, /*display = */ false, /* undoable = */ false)
+              .asChar();
+
+    if (cmdResult.length() == 0) {
+        const std::string error = TfStringPrintf("Failed to create Clipboard stage.");
+        throw std::runtime_error(error);
+    }
+
+    // Get the newly created stage.
+    std::string ufePathString = "|world|";
+    ufePathString
+        += cmdResult == stageClipboard ? "mayaUsdProxy1|" + std::string(stageClipboard) : cmdResult;
+    Ufe::Path       ufeClipboardPath = Ufe::PathString::path(ufePathString);
+    UsdStageWeakPtr clipboardStage = ufe::getStage(ufeClipboardPath);
+
+    if (!clipboardStage) {
+        const std::string error
+            = TfStringPrintf("Cannot find Clipboard stage for ufe path: \"%s\".", ufeClipboardPath);
+        throw std::runtime_error(error);
+    }
+
+    // Step 2. Hide the Clipboard stage in the outliner.
+    hideStage(ufeClipboardPath);
+
+    // Step 3. Duplicate the selected items to the Clipboard stage using its pseudo-root as parent
+    // item destination.
+    auto usdParentItem = UsdSceneItem::create(ufeClipboardPath, clipboardStage->GetPseudoRoot());
+    auto duplicateSelectionUndoableCmd = UsdUndoDuplicateSelectionCommand::create(
+        _selection, Ufe::ValueDictionary(), usdParentItem);
+    duplicateSelectionUndoableCmd->execute();
+
+    // Step 4. Export the Clipboard stage.
+    const auto tmpDir = std::string(getenv("TMPDIR")) + "/Clipboard.usda";
+
+    if (!clipboardStage->Export(tmpDir)) {
+        const std::string error = TfStringPrintf(
+            "Failed to export Clipboard stage with ufe path: \"%s\".", ufeClipboardPath);
+        throw std::runtime_error(error);
+    }
+
+    // Step 5. Delete the Clipboard stage.
+    deleteStage(ufeClipboardPath);
+}
+
+void UsdUndoCopyClipboardCommand::undo() { _undoableItem.undo(); }
+
+void UsdUndoCopyClipboardCommand::redo() { _undoableItem.redo(); }
+
+UsdUndoCutClipboardCommand::UsdUndoCutClipboardCommand(const Ufe::Selection& selection)
+    : Ufe::UndoableCommand()
+    , _selection(selection)
+{
+}
+
+UsdUndoCutClipboardCommand::~UsdUndoCutClipboardCommand() { }
+
+UsdUndoCutClipboardCommand::Ptr UsdUndoCutClipboardCommand::create(const Ufe::Selection& selection)
+{
+    return std::make_shared<UsdUndoCutClipboardCommand>(selection);
+}
+
+void UsdUndoCutClipboardCommand::execute()
+{
+    UsdUndoBlock undoBlock(&_undoableItem);
+
+    // Step 1. Copy the selected items to the Clipboard.
+    auto copyClipboardCommand = UsdUndoCopyClipboardCommand::create(_selection);
+    copyClipboardCommand->execute();
+
+    // Step 2. Delete the selected items.
+    for (auto&& item : _selection) {
+        UsdSceneItem::Ptr usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
+        if (!usdItem) {
+            continue;
+        }
+
+        auto deleteCmd = UsdUndoDeleteCommand::create(usdItem->prim());
+        deleteCmd->execute();
+    }
+}
+
+void UsdUndoCutClipboardCommand::undo() { _undoableItem.undo(); }
+
+void UsdUndoCutClipboardCommand::redo() { _undoableItem.redo(); }
+
+UsdUndoPasteClipboardCommand::Ptr
+UsdUndoPasteClipboardCommand::create(const Ufe::SceneItem::Ptr& dstParentItem)
+{
+    auto retVal = std::make_shared<UsdUndoPasteClipboardCommand>(dstParentItem);
+
+    if (retVal->_dstParentItem) {
+        return retVal;
+    }
+    return {};
+}
+
+void UsdUndoPasteClipboardCommand::execute()
+{
+    UsdUndoBlock undoBlock(&_undoableItem);
+
+    // Step 1. Load and open the Clipboard stage.
+    const auto tmpDir = std::string(getenv("TMPDIR")) + "/Clipboard.usda";
+
+    MString script;
+    script.format("mayaUsd_createStageFromFilePath \"^1s\"", tmpDir.c_str());
+
+    std::string cmdResult
+        = MGlobal::executeCommandStringResult(script, /*display = */ false, /* undoable = */ false)
+              .asChar();
+
+    if (cmdResult.length() == 0) {
+        const std::string error
+            = TfStringPrintf("Failed to load Clipboard stage in dir: \"%s\".", tmpDir);
+        throw std::runtime_error(error);
+    }
+
+    // Get the newly created stage.
+    const std::string ufePathString = "|world" + cmdResult;
+    Ufe::Path         ufeClipboardPath = Ufe::PathString::path(ufePathString);
+    UsdStageWeakPtr   clipboardStage = ufe::getStage(ufeClipboardPath);
+
+    if (!clipboardStage) {
+        const std::string error
+            = TfStringPrintf("Cannot find Clipboard stage for ufe path: \"%s\".", ufeClipboardPath);
+        throw std::runtime_error(error);
+    }
+
+    // Step 2. Hide the Clipboard stage in the outliner.
+    hideStage(ufeClipboardPath);
+
+    // Step 3. Duplicate the first-level in depth items from the Clipboard stage to the destination
+    // parent item.
+
+    Ufe::Selection selection;
+    for (auto prim : clipboardStage->Traverse()) {
+        // Step 3.1 Add to the selection only the first-level in depth items.
+        if (prim.GetParent() == clipboardStage->GetPseudoRoot()) {
+            auto ufeChildPath = Ufe::PathString::path(
+                ufeClipboardPath.string() + ",/" + prim.GetName().GetString());
+            auto usdItem = UsdSceneItem::create(ufeChildPath, prim);
+            selection.append(usdItem);
+        }
+    }
+
+    _selectionUndoableCmd = UsdUndoDuplicateSelectionCommand::create(
+        selection, Ufe::ValueDictionary(), _dstParentItem);
+    _selectionUndoableCmd->execute();
+
+    // Step 4. Delete the Clipboard stage.
+    deleteStage(ufeClipboardPath);
+}
+
+void UsdUndoPasteClipboardCommand::undo() { _undoableItem.undo(); }
+
+void UsdUndoPasteClipboardCommand::redo() { _undoableItem.redo(); }
+
+Ufe::SceneItem::Ptr UsdUndoPasteClipboardCommand::targetItem(const Ufe::Path& sourcePath) const
+{
+    if (_selectionUndoableCmd) {
+        return _selectionUndoableCmd->targetItem(sourcePath);
+    }
+    return {};
+}
+
+std::vector<Ufe::SceneItem::Ptr> UsdUndoPasteClipboardCommand::targetItems() const
+{
+    if (_selectionUndoableCmd) {
+        return _selectionUndoableCmd->targetItems();
+    }
+    return {};
+}
+
+UsdUndoPasteClipboardCommand::UsdUndoPasteClipboardCommand(const Ufe::SceneItem::Ptr& dstParentItem)
+    : Ufe::SelectionUndoableCommand()
+{
+    _dstParentItem = std::dynamic_pointer_cast<UsdSceneItem>(dstParentItem);
+}
+UsdUndoPasteClipboardCommand::~UsdUndoPasteClipboardCommand() { }
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdUndoClipboardCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoClipboardCommand.h
@@ -1,0 +1,124 @@
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_UFE_USDUNDOCLIPBOARDCOMMAND_H
+#define MAYAUSD_UFE_USDUNDOCLIPBOARDCOMMAND_H
+
+#include "UsdUndoDuplicateSelectionCommand.h"
+
+#include <mayaUsd/base/api.h>
+#include <mayaUsd/ufe/UsdSceneItem.h>
+#include <mayaUsd/undo/UsdUndoableItem.h>
+
+#include <ufe/selection.h>
+#include <ufe/undoableCommand.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+//! \brief UsdUndoCopyClipboardCommand
+class MAYAUSD_CORE_PUBLIC UsdUndoCopyClipboardCommand : public Ufe::UndoableCommand
+{
+public:
+    typedef std::shared_ptr<UsdUndoCopyClipboardCommand> Ptr;
+
+    UsdUndoCopyClipboardCommand(const Ufe::Selection& selection);
+    ~UsdUndoCopyClipboardCommand() override;
+
+    // Delete the copy/move constructors assignment operators.
+    UsdUndoCopyClipboardCommand(const UsdUndoCopyClipboardCommand&) = delete;
+    UsdUndoCopyClipboardCommand& operator=(const UsdUndoCopyClipboardCommand&) = delete;
+    UsdUndoCopyClipboardCommand(UsdUndoCopyClipboardCommand&&) = delete;
+    UsdUndoCopyClipboardCommand& operator=(UsdUndoCopyClipboardCommand&&) = delete;
+
+    //! Create a UsdUndoCopyClipboardCommand from a selection.
+    static Ptr create(const Ufe::Selection& selection);
+
+    void execute() override;
+    void undo() override;
+    void redo() override;
+
+private:
+    UsdUndoableItem _undoableItem;
+    Ufe::Selection  _selection;
+}; // UsdUndoCopyClipboardCommand
+
+//! \brief UsdUndoCutClipboardCommand
+class MAYAUSD_CORE_PUBLIC UsdUndoCutClipboardCommand : public Ufe::UndoableCommand
+{
+public:
+    typedef std::shared_ptr<UsdUndoCutClipboardCommand> Ptr;
+
+    UsdUndoCutClipboardCommand(const Ufe::Selection& selection);
+    ~UsdUndoCutClipboardCommand() override;
+
+    // Delete the copy/move constructors assignment operators.
+    UsdUndoCutClipboardCommand(const UsdUndoCutClipboardCommand&) = delete;
+    UsdUndoCutClipboardCommand& operator=(const UsdUndoCutClipboardCommand&) = delete;
+    UsdUndoCutClipboardCommand(UsdUndoCutClipboardCommand&&) = delete;
+    UsdUndoCutClipboardCommand& operator=(UsdUndoCutClipboardCommand&&) = delete;
+
+    //! Create a UsdUndoCutClipboardCommand from a selection.
+    static Ptr create(const Ufe::Selection& selection);
+
+    void execute() override;
+    void undo() override;
+    void redo() override;
+
+private:
+    UsdUndoableItem _undoableItem;
+    Ufe::Selection  _selection;
+}; // UsdUndoCutClipboardCommand
+
+//! \brief UsdUndoPasteClipboardCommand
+class MAYAUSD_CORE_PUBLIC UsdUndoPasteClipboardCommand : public Ufe::SelectionUndoableCommand
+{
+public:
+    typedef std::shared_ptr<UsdUndoPasteClipboardCommand> Ptr;
+
+    UsdUndoPasteClipboardCommand(const Ufe::SceneItem::Ptr& dstParentItem);
+    ~UsdUndoPasteClipboardCommand() override;
+
+    // Delete the copy/move constructors assignment operators.
+    UsdUndoPasteClipboardCommand(const UsdUndoPasteClipboardCommand&) = delete;
+    UsdUndoPasteClipboardCommand& operator=(const UsdUndoPasteClipboardCommand&) = delete;
+    UsdUndoPasteClipboardCommand(UsdUndoPasteClipboardCommand&&) = delete;
+    UsdUndoPasteClipboardCommand& operator=(UsdUndoPasteClipboardCommand&&) = delete;
+
+    //! Create a UsdUndoPasteClipboardCommand from a scene item.
+    static Ptr create(const Ufe::SceneItem::Ptr& dstParentItem);
+
+    void execute() override;
+    void undo() override;
+    void redo() override;
+
+    Ufe::SceneItem::Ptr              targetItem(const Ufe::Path& sourcePath) const override;
+    std::vector<Ufe::SceneItem::Ptr> targetItems() const override;
+
+private:
+    UsdUndoableItem _undoableItem;
+
+    // The destination parent item for the pasted items.
+    UsdSceneItem::Ptr _dstParentItem;
+
+    // Needed by targetItem and by targetItems.
+    UsdUndoDuplicateSelectionCommand::Ptr _selectionUndoableCmd;
+
+}; // UsdUndoPasteClipboardCommand
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF
+
+#endif

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.h
@@ -42,6 +42,10 @@ public:
     typedef std::shared_ptr<UsdUndoDuplicateCommand> Ptr;
 
     UsdUndoDuplicateCommand(const UsdSceneItem::Ptr& srcItem);
+    UsdUndoDuplicateCommand(
+        const UsdSceneItem::Ptr& srcItem,
+        const UsdSceneItem::Ptr& dstParentItem);
+
     ~UsdUndoDuplicateCommand() override;
 
     // Delete the copy/move constructors assignment operators.
@@ -52,6 +56,10 @@ public:
 
     //! Create a UsdUndoDuplicateCommand from a USD prim and UFE path.
     static UsdUndoDuplicateCommand::Ptr create(const UsdSceneItem::Ptr& srcItem);
+
+    //! Create a UsdUndoDuplicateCommand from a USD prim and its parent destination.
+    static UsdUndoDuplicateCommand::Ptr
+    create(const UsdSceneItem::Ptr& srcItem, const UsdSceneItem::Ptr& dstParentItem);
 
     UsdSceneItem::Ptr duplicatedItem() const;
     UFE_V4(Ufe::SceneItem::Ptr sceneItem() const override { return duplicatedItem(); })
@@ -69,6 +77,7 @@ private:
 #endif
 
     Ufe::Path       _ufeSrcPath;
+    Ufe::Path       _ufeDstPath;
     PXR_NS::SdfPath _usdDstPath;
 
     PXR_NS::SdfLayerHandle _srcLayer;

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateSelectionCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateSelectionCommand.h
@@ -41,6 +41,10 @@ public:
     UsdUndoDuplicateSelectionCommand(
         const Ufe::Selection&       selection,
         const Ufe::ValueDictionary& duplicateOptions);
+    UsdUndoDuplicateSelectionCommand(
+        const Ufe::Selection&       selection,
+        const Ufe::ValueDictionary& duplicateOptions,
+        const UsdSceneItem::Ptr&    dstParentItem);
     ~UsdUndoDuplicateSelectionCommand() override;
 
     // Delete the copy/move constructors assignment operators.
@@ -52,12 +56,17 @@ public:
     //! Create a UsdUndoDuplicateSelectionCommand from a USD prim and UFE path.
     static Ptr
     create(const Ufe::Selection& selection, const Ufe::ValueDictionary& duplicateOptions);
+    static Ptr create(
+        const Ufe::Selection&       selection,
+        const Ufe::ValueDictionary& duplicateOptions,
+        const UsdSceneItem::Ptr&    dstParentItem);
 
     void execute() override;
     void undo() override;
     void redo() override;
 
-    Ufe::SceneItem::Ptr targetItem(const Ufe::Path& sourcePath) const override;
+    Ufe::SceneItem::Ptr              targetItem(const Ufe::Path& sourcePath) const override;
+    std::vector<Ufe::SceneItem::Ptr> targetItems() const override;
 
 private:
     UsdUndoableItem _undoableItem;
@@ -73,6 +82,9 @@ private:
     using DuplicatePathsMap = std::map<PXR_NS::SdfPath, PXR_NS::SdfPath>;
     using DuplicatesMap = std::unordered_map<Ufe::Path, DuplicatePathsMap>;
     DuplicatesMap _duplicatesMap;
+
+    // If provided, the parent item target destination.
+    UsdSceneItem::Ptr _dstParentItem;
 
     bool updateSdfPathVector(
         PXR_NS::SdfPathVector&               pathVec,

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -238,6 +238,18 @@ int ufePathToInstanceIndex(const Ufe::Path& path, UsdPrim* prim)
     return instanceIndex;
 }
 
+Ufe::Path appendToPath(const Ufe::Path& path, const std::string& name)
+{
+    Ufe::Path newUfePath;
+    if (1 == path.getSegments().size()) {
+        newUfePath = path
+            + Ufe::PathSegment(Ufe::PathComponent(name), MayaUsd::ufe::getUsdRunTimeId(), '/');
+    } else {
+        newUfePath = path + name;
+    }
+    return newUfePath;
+}
+
 bool isRootChild(const Ufe::Path& path)
 {
     // When called we make the assumption that we are given a valid

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -100,6 +100,9 @@ MAYAUSD_CORE_PUBLIC
 int ufePathToInstanceIndex(const Ufe::Path& path, PXR_NS::UsdPrim* prim = nullptr);
 
 MAYAUSD_CORE_PUBLIC
+Ufe::Path appendToPath(const Ufe::Path& path, const std::string& name);
+
+MAYAUSD_CORE_PUBLIC
 bool isRootChild(const Ufe::Path& path);
 
 MAYAUSD_CORE_PUBLIC

--- a/test/lib/ufe/CMakeLists.txt
+++ b/test/lib/ufe/CMakeLists.txt
@@ -121,6 +121,11 @@ if (MAYA_HAS_DISPLAY_LAYER_API)
         )
 endif()
 
+if (UFE_CLIPBOARD_SUPPORT)
+    list(APPEND TEST_SCRIPT_FILES
+        testClipboardHandler.py
+    )
+endif()
 
 foreach(script ${TEST_SCRIPT_FILES})
     mayaUsd_get_unittest_target(target ${script})

--- a/test/lib/ufe/testClipboardHandler.py
+++ b/test/lib/ufe/testClipboardHandler.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2023 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import mayaUtils
+import ufeUtils
+import usdUtils
+import testUtils
+
+from maya import cmds
+
+from pxr import UsdShade, Sdf
+
+import os
+import ufe
+import unittest
+
+import maya.mel as mel
+
+class ClipboardHandlerTestCase(unittest.TestCase):
+    '''Test clipboard operations.'''
+
+    pluginsLoaded = False
+
+    @classmethod
+    def setUpClass(cls):
+        if not cls.pluginsLoaded:
+            cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    def setUp(self):
+        self.assertTrue(self.pluginsLoaded)
+
+        cmds.file(new=True, force=True)
+
+    def testCutCopyPasteCmd(self):
+        '''Test the Clipboard cut, copy and paste cmds.'''
+        # The cut cmd copies the selected nodes to the clipboard and then deletes them.
+        # To test the cut cmd, we must also test the paste cmd.
+        testFile = testUtils.getTestScene('MaterialX', 'BatchOpsTestScene.usda')
+        shapeNode,shapeStage = mayaUtils.createProxyFromFile(testFile)
+
+        ngParentItem = ufeUtils.createUfeSceneItem(shapeNode, '/mtl/ss3SG')
+        self.assertIsNotNone(ngParentItem)
+        
+        # Copy a compound and a connected node.
+        ngCompoundItem = ufeUtils.createUfeSceneItem(shapeNode, '/mtl/ss3SG/MayaNG_ss3SG')
+        self.assertIsNotNone(ngCompoundItem)
+
+        ngItem = ufeUtils.createUfeSceneItem(shapeNode, '/mtl/ss3SG/ss3')
+        self.assertIsNotNone(ngItem)
+
+        clipboardHandler = ufe.RunTimeMgr.instance().clipboardHandler(ngItem.runTimeId())
+        self.assertIsNotNone(clipboardHandler)
+
+        # Create a selection.
+        sel = ufe.Selection()
+        sel.append(ngItem)
+        sel.append(ngCompoundItem)
+
+        # Execute the clipboard cut cmd.
+        cmd = clipboardHandler.cutCmd(sel)
+        cmd.execute()
+
+        # Check we cut (aka delete and copy to clipboard) the selected items.
+        self.assertIsNone(ufeUtils.createUfeSceneItem(shapeNode, '/mtl/ss3SG/MayaNG_ss3SG'))
+        self.assertIsNone(ufeUtils.createUfeSceneItem(shapeNode, '/mtl/ss3SG/ss3'))
+
+        # The cut cmd undo brings back the cut items.
+        cmd.undo()
+        self.assertIsNotNone(ufeUtils.createUfeSceneItem(shapeNode, '/mtl/ss3SG/MayaNG_ss3SG'))
+        self.assertIsNotNone(ufeUtils.createUfeSceneItem(shapeNode, '/mtl/ss3SG/ss3'))
+
+        cmd.redo()
+        self.assertIsNone(ufeUtils.createUfeSceneItem(shapeNode, '/mtl/ss3SG/MayaNG_ss3SG'))
+        self.assertIsNone(ufeUtils.createUfeSceneItem(shapeNode, '/mtl/ss3SG/ss3'))
+
+        # Execute the clipboard paste cmd in the current stage.
+        mel.eval('source \"mayaUsd_createStageFromFile.mel\"')
+        cmd = clipboardHandler.pasteCmd(ngParentItem)
+        cmd.execute()
+
+        # Check we paste back the items which were deleted and then copied to the clipboard.
+        ngCompoundItem = ufeUtils.createUfeSceneItem(shapeNode, '/mtl/ss3SG/MayaNG_ss3SG')
+        ngItem = ufeUtils.createUfeSceneItem(shapeNode, '/mtl/ss3SG/ss3')
+        self.assertIsNotNone(ngCompoundItem)
+        self.assertIsNotNone(ngItem)
+        self.assertEqual(len(cmd.targetItems()), 2)
+
+        # Check we preserve the same number of children for the pasted compound.
+        usdCompoundHier = ufe.Hierarchy.hierarchy(ngCompoundItem)
+        self.assertEqual(len(usdCompoundHier.children()), 3)
+
+        # Check we preserve the same number of connections for the pasted node.
+        connectionHandler = ufe.RunTimeMgr.instance().connectionHandler(ngItem.runTimeId())
+        connections = connectionHandler.sourceConnections(ngItem)
+        self.assertIsNotNone(connections)
+        conns = connections.allConnections()
+        self.assertEqual(len(conns), 1)
+                
+        # The paste cmd undo acts as a cut cmd execute.
+        cmd.undo()
+        self.assertIsNone(ufeUtils.createUfeSceneItem(shapeNode, '/mtl/ss3SG/MayaNG_ss3SG'))
+        self.assertIsNone(ufeUtils.createUfeSceneItem(shapeNode, '/mtl/ss3SG/ss3'))
+
+        # The paste cmd redo pastes back the deleted nodes.
+        cmd.undo()
+        self.assertIsNotNone(ufeUtils.createUfeSceneItem(shapeNode, '/mtl/ss3SG/MayaNG_ss3SG'))
+        self.assertIsNotNone(ufeUtils.createUfeSceneItem(shapeNode, '/mtl/ss3SG/ss3'))
+        
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

This PR solves Jira ticket [MAYA-126014](https://jira.autodesk.com/browse/MAYA-126014) .

The correspondent UFE PR is [here](https://git.autodesk.com/media-and-entertainment/ufe/pull/340). 
We are introducing the clipboard concept so we can cut, copy and paste.

The proposed approach is similar to what we do for  [cutCopyPaste.mel ](https://git.autodesk.com/maya3d/maya/blob/master/Maya/src/Maya/Maya/scripts/cutCopyPaste.mel) and [defaultRunTimeCommands.mel
](https://git.autodesk.com/maya3d/maya/blob/master/Maya/src/Maya/Maya/scripts/defaultRunTimeCommands.mel)
