### PR TITLE
MAYA-128513 implement code wrapper handler

### DIFF
--- a/cmake/modules/FindUFE.cmake
+++ b/cmake/modules/FindUFE.cmake
@@ -99,6 +99,10 @@ if (UFE_INCLUDE_DIR AND EXISTS "${UFE_INCLUDE_DIR}/ufe/batchOpsHandler.h")
     list(APPEND UFE_PREVIEW_FEATURES v4_BatchOps)
 endif()
 
+if(UFE_INCLUDE_DIR AND EXISTS "${UFE_INCLUDE_DIR}/ufe/codeWrapperHandler.h")
+    list(APPEND UFE_PREVIEW_FEATURES CodeWrapperHandler)
+endif()
+
 # Handle the QUIETLY and REQUIRED arguments and set UFE_FOUND to TRUE if
 # all listed variables are TRUE.
 include(FindPackageHandleStandardArgs)

--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -144,6 +144,19 @@ if (v4_BatchOps IN_LIST UFE_PREVIEW_FEATURES)
     )
 endif()
 
+if(CodeWrapperHandler IN_LIST UFE_PREVIEW_FEATURES)
+    message(STATUS "UFE_PREVIEW has composite command handler support")
+    target_sources(${PROJECT_NAME}
+        PRIVATE
+        UsdCodeWrapperHandler.cpp
+    )
+
+    target_compile_definitions(${PROJECT_NAME}
+        PRIVATE
+        UFE_PREVIEW_CODE_WRAPPER_HANDLER_SUPPORT=1
+    )
+endif()
+
 if(CMAKE_UFE_V4_FEATURES_AVAILABLE)
     target_sources(${PROJECT_NAME}
         PRIVATE
@@ -277,6 +290,12 @@ if (v4_BatchOps IN_LIST UFE_PREVIEW_FEATURES)
     list(APPEND HEADERS
         UsdBatchOpsHandler.h
         UsdUndoDuplicateSelectionCommand.h
+    )
+endif()
+
+if(CodeWrapperHandler IN_LIST UFE_PREVIEW_FEATURES)
+    list(APPEND HEADERS
+        UsdCodeWrapperHandler.h
     )
 endif()
 

--- a/lib/mayaUsd/ufe/Global.cpp
+++ b/lib/mayaUsd/ufe/Global.cpp
@@ -24,6 +24,7 @@
 #include <mayaUsd/ufe/UsdHierarchyHandler.h>
 #include <mayaUsd/ufe/UsdSceneItemOpsHandler.h>
 #include <mayaUsd/ufe/UsdTransform3dHandler.h>
+
 #ifdef UFE_V2_FEATURES_AVAILABLE
 #include <mayaUsd/ufe/ProxyShapeContextOpsHandler.h>
 #include <mayaUsd/ufe/UsdAttributesHandler.h>
@@ -38,36 +39,56 @@
 #include <mayaUsd/ufe/UsdUIInfoHandler.h>
 #include <mayaUsd/ufe/UsdUIUfeObserver.h>
 #endif
+
 #ifdef UFE_V3_FEATURES_AVAILABLE
 #define HAVE_PATH_MAPPING
 #include <mayaUsd/ufe/MayaUIInfoHandler.h>
 #include <mayaUsd/ufe/PulledObjectHierarchyHandler.h>
 #include <mayaUsd/ufe/UsdPathMappingHandler.h>
 #endif
+
 #if UFE_LIGHTS_SUPPORT
 #include <mayaUsd/ufe/UsdLightHandler.h>
 #endif
+
 #if UFE_MATERIALS_SUPPORT
 #include <mayaUsd/ufe/UsdMaterialHandler.h>
 #endif
+
 #ifdef UFE_V4_FEATURES_AVAILABLE
 #include <mayaUsd/ufe/UsdConnectionHandler.h>
 #include <mayaUsd/ufe/UsdTransform3dRead.h>
 #include <mayaUsd/ufe/UsdUINodeGraphNodeHandler.h>
+
 #if UFE_PREVIEW_BATCHOPS_SUPPORT
 #include <mayaUsd/ufe/UsdBatchOpsHandler.h>
 #endif
+
+#if UFE_PREVIEW_CODE_WRAPPER_HANDLER_SUPPORT
+#include <mayaUsd/ufe/UsdCodeWrapperHandler.h>
+#endif
+
+#if (UFE_PREVIEW_VERSION_NUM >= 4001)
+#include <mayaUsd/ufe/UsdShaderNodeDefHandler.h>
+#endif
+
+#endif
+
+#if defined(UFE_V4_FEATURES_AVAILABLE) && (UFE_PREVIEW_VERSION_NUM >= 4013)
 #include <mayaUsd/ufe/ProxyShapeCameraHandler.h>
 #include <mayaUsd/ufe/UsdShaderNodeDefHandler.h>
 #endif
+
 #if UFE_SCENE_SEGMENT_SUPPORT
 #include <mayaUsd/ufe/ProxyShapeSceneSegmentHandler.h>
 #endif
+
 #include <mayaUsd/utils/editRouter.h>
 
 #include <maya/MSceneMessage.h>
 #include <ufe/hierarchyHandler.h>
 #include <ufe/runTimeMgr.h>
+
 #ifdef UFE_V2_FEATURES_AVAILABLE
 #include <ufe/pathString.h>
 #endif
@@ -186,20 +207,30 @@ MStatus initialize()
     handlers.contextOpsHandler = UsdContextOpsHandler::create();
     handlers.uiInfoHandler = UsdUIInfoHandler::create();
     handlers.cameraHandler = UsdCameraHandler::create();
+
 #ifdef UFE_V4_FEATURES_AVAILABLE
+
 #if UFE_LIGHTS_SUPPORT
     handlers.lightHandler = UsdLightHandler::create();
 #endif
+
 #if UFE_MATERIALS_SUPPORT
     handlers.materialHandler = UsdMaterialHandler::create();
 #endif
     handlers.connectionHandler = UsdConnectionHandler::create();
     handlers.uiNodeGraphNodeHandler = UsdUINodeGraphNodeHandler::create();
-#if UFE_PREVIEW_BATCHOPS_SUPPORT
+
+#if UFE_PREVIEW_CODE_WRAPPER_HANDLER_SUPPORT
+    handlers.batchOpsHandler = UsdCodeWrapperHandler::create();
+#elif UFE_PREVIEW_BATCHOPS_SUPPORT
     handlers.batchOpsHandler = UsdBatchOpsHandler::create();
 #endif
+
+#if (UFE_PREVIEW_VERSION_NUM >= 4001)
     handlers.nodeDefHandler = UsdShaderNodeDefHandler::create();
 #endif
+
+#endif /* UFE_V4_FEATURES_AVAILABLE */
 
 #if UFE_SCENE_SEGMENT_SUPPORT
     // set up the SceneSegmentHandler
@@ -208,6 +239,7 @@ MStatus initialize()
         = ProxyShapeSceneSegmentHandler::create(g_MayaSceneSegmentHandler);
     Ufe::RunTimeMgr::instance().setSceneSegmentHandler(g_MayaRtid, proxyShapeSceneSegmentHandler);
 #endif
+
 #ifdef UFE_V4_FEATURES_AVAILABLE
     // set up the ProxyShapeCameraHandler
     g_MayaCameraHandler = Ufe::RunTimeMgr::instance().cameraHandler(g_MayaRtid);
@@ -244,13 +276,15 @@ MStatus initialize()
     MayaUsd::ufe::UsdUIUfeObserver::create();
 
 #ifndef UFE_V4_FEATURES_AVAILABLE
+
 #if UFE_LIGHTS_SUPPORT
     runTimeMgr.setLightHandler(g_USDRtid, UsdLightHandler::create());
 #endif
 #if UFE_MATERIALS_SUPPORT
     runTimeMgr.setMaterialHandler(g_USDRtid, UsdMaterialHandler::create());
 #endif
-#endif
+
+#endif /* UFE_V4_FEATURES_AVAILABLE */
 
 #ifdef HAVE_PATH_MAPPING
     g_MayaPathMappingHandler = runTimeMgr.pathMappingHandler(g_MayaRtid);
@@ -263,13 +297,13 @@ MStatus initialize()
     runTimeMgr.setUIInfoHandler(g_MayaRtid, uiInfoHandler);
 #endif
 
-#else
+#else  /* UFE_V2_FEATURES_AVAILABLE */
     auto usdHierHandler = UsdHierarchyHandler::create();
     auto usdTrans3dHandler = UsdTransform3dHandler::create();
     auto usdSceneItemOpsHandler = UsdSceneItemOpsHandler::create();
     g_USDRtid = runTimeMgr.register_(
         kUSDRunTimeName, usdHierHandler, usdTrans3dHandler, usdSceneItemOpsHandler);
-#endif
+#endif /* UFE_V2_FEATURES_AVAILABLE */
 
 #if !defined(NDEBUG)
     assert(g_USDRtid != 0);

--- a/lib/mayaUsd/ufe/UsdBatchOpsHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdBatchOpsHandler.cpp
@@ -20,10 +20,7 @@
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
-UsdBatchOpsHandler::UsdBatchOpsHandler()
-    : Ufe::BatchOpsHandler()
-{
-}
+UsdBatchOpsHandler::UsdBatchOpsHandler() { }
 
 UsdBatchOpsHandler::~UsdBatchOpsHandler() { }
 

--- a/lib/mayaUsd/ufe/UsdBatchOpsHandler.h
+++ b/lib/mayaUsd/ufe/UsdBatchOpsHandler.h
@@ -23,13 +23,21 @@
 #include <pxr/usd/sdf/types.h>
 #include <pxr/usd/usd/stage.h>
 
+#if UFE_PREVIEW_CODE_WRAPPER_HANDLER_SUPPORT
+#include <ufe/codeWrapperHandler.h>
+#else
 #include <ufe/batchOpsHandler.h>
+#endif
 
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
 //! \brief Interface to create a UsdBatchOpsHandler interface object.
+#if UFE_PREVIEW_CODE_WRAPPER_HANDLER_SUPPORT
+class MAYAUSD_CORE_PUBLIC UsdBatchOpsHandler : public Ufe::CodeWrapperHandler
+#else
 class MAYAUSD_CORE_PUBLIC UsdBatchOpsHandler : public Ufe::BatchOpsHandler
+#endif
 {
 public:
     typedef std::shared_ptr<UsdBatchOpsHandler> Ptr;

--- a/lib/mayaUsd/ufe/UsdCodeWrapperHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdCodeWrapperHandler.cpp
@@ -1,0 +1,97 @@
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "UsdCodeWrapperHandler.h"
+
+#include <mayaUsd/ufe/UsdSceneItem.h>
+#include <mayaUsd/utils/editRouterContext.h>
+
+#include <ufe/sceneItem.h>
+#include <ufe/selection.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+namespace {
+
+// A code wrapper that does edit routing for a command name by its operation.
+// The edit routing decision is cached after the first sub-operation and is
+// reused in subsequent sub-operations. This ensures the same edit routing is
+// used during a command execution and during undo and redo.
+//
+// Note: the code wrapper is the same for the command execute, undo and redo,
+//       so we don't need the sub-operation name.
+class UsdEditRoutingCodeWrapper : public Ufe::CodeWrapper
+{
+public:
+    UsdEditRoutingCodeWrapper(const Ufe::Selection& selection, const std::string& operationName)
+        : _prim(findPrimInSelection(selection))
+        , _operationName(PXR_NS::TfToken(operationName))
+    {
+    }
+
+    void prelude(const std::string& /* subOperation */) override
+    {
+        if (_alreadyRouted) {
+            _editRouterContext = std::make_unique<OperationEditRouterContext>(_stage, _layer);
+        } else {
+            _editRouterContext
+                = std::make_unique<OperationEditRouterContext>(_operationName, _prim);
+            _stage = _editRouterContext->getStage();
+            _layer = _editRouterContext->getLayer();
+            _alreadyRouted = true;
+        }
+    }
+
+    void cleanup(const std::string& /* subOperation */) override { _editRouterContext.reset(); }
+
+private:
+    static PXR_NS::UsdPrim findPrimInSelection(const Ufe::Selection& selection)
+    {
+        for (const Ufe::SceneItem::Ptr& item : selection) {
+            const auto usdItem = std::dynamic_pointer_cast<UsdSceneItem>(item);
+            if (!usdItem)
+                continue;
+            return usdItem->prim();
+        }
+
+        return {};
+    }
+
+    PXR_NS::UsdPrim                             _prim;
+    PXR_NS::TfToken                             _operationName;
+    bool                                        _alreadyRouted = false;
+    PXR_NS::UsdStagePtr                         _stage;
+    PXR_NS::SdfLayerHandle                      _layer;
+    std::unique_ptr<OperationEditRouterContext> _editRouterContext;
+};
+
+} // namespace
+
+/*static*/
+std::shared_ptr<UsdCodeWrapperHandler> UsdCodeWrapperHandler::create()
+{
+    return std::make_shared<UsdCodeWrapperHandler>();
+}
+
+Ufe::CodeWrapper::Ptr UsdCodeWrapperHandler::createCodeWrapper(
+    const Ufe::Selection& selection,
+    const std::string&    operationName)
+{
+    return std::make_unique<UsdEditRoutingCodeWrapper>(selection, operationName);
+}
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdCodeWrapperHandler.h
+++ b/lib/mayaUsd/ufe/UsdCodeWrapperHandler.h
@@ -1,0 +1,39 @@
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <mayaUsd/ufe/UsdBatchOpsHandler.h>
+
+#include <ufe/codeWrapperHandler.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+//! \brief Interface to create a UsdCodeWrapperHandler interface object.
+class MAYAUSD_CORE_PUBLIC UsdCodeWrapperHandler : public UsdBatchOpsHandler
+{
+public:
+    //! Create a UsdCodeWrapperHandler.
+    static std::shared_ptr<UsdCodeWrapperHandler> create();
+
+protected:
+    // Ufe::CodeWrapperHandler overrides.
+    Ufe::CodeWrapper::Ptr
+    createCodeWrapper(const Ufe::Selection& selection, const std::string& operationName) override;
+}; // UsdCodeWrapperHandler
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.cpp
@@ -21,6 +21,7 @@
 #include "private/Utils.h"
 
 #include <mayaUsd/base/tokens.h>
+#include <mayaUsd/undo/UsdUndoBlock.h>
 #include <mayaUsd/utils/editRouter.h>
 #include <mayaUsd/utils/editRouterContext.h>
 #include <mayaUsd/utils/layers.h>
@@ -132,8 +133,6 @@ UsdUndoInsertChildCommand::UsdUndoInsertChildCommand(
     // Apply restriction rules
     ufe::applyCommandRestriction(childPrim, "reparent");
     ufe::applyCommandRestriction(parentPrim, "reparent");
-
-    _childLayer = childPrim.GetStage()->GetEditTarget().GetLayer();
 }
 
 UsdUndoInsertChildCommand::~UsdUndoInsertChildCommand() { }
@@ -182,41 +181,52 @@ static void doUsdInsertion(
     }
 }
 
-static UsdSceneItem::Ptr doInsertion(
-    const SdfLayerHandle& srcLayer,
-    const SdfPath&        srcUsdPath,
-    const Ufe::Path&      srcUfePath,
-    const SdfLayerHandle& dstLayer,
-    const SdfPath&        dstUsdPath,
-    const Ufe::Path&      dstUfePath)
+static void doInsertion(
+    const SdfPath&   srcUsdPath,
+    const Ufe::Path& srcUfePath,
+    const SdfPath&   dstUsdPath,
+    const Ufe::Path& dstUfePath)
 {
     // We must retrieve the item every time we are called since it could be stale.
     // We need to get the USD prim from the UFE path.
     const UsdPrim     srcPrim = ufePathToPrim(srcUfePath);
     const UsdStagePtr stage = srcPrim.GetStage();
 
+    // Enforce the edit routing for the insert-child command in order to find
+    // the target layer. The edit router context sets the edit target of the
+    // stage of the given prim, if it gets routed.
+    OperationEditRouterContext ctx(MayaUsdEditRoutingTokens->RouteParent, srcPrim);
+    const SdfLayerHandle&      dstLayer = srcPrim.GetStage()->GetEditTarget().GetLayer();
+
     enforceMutedLayer(srcPrim, "reparent");
 
-    // Make sure the load state of the reparented prim will be preserved.
-    // We copy all rules that applied to it specifically and remove the rules
-    // that applied to it specifically.
-    duplicateLoadRules(*stage, srcUsdPath, dstUsdPath);
-    removeRulesForPath(*stage, srcUsdPath);
+    // Do the insertion from the source layer to the target layer.
+    {
+        PrimLayerFunc insertionFunc
+            = [stage, srcUsdPath, dstLayer, dstUsdPath](
+                  const UsdPrim& prim, const PXR_NS::SdfLayerRefPtr& layer) {
+                  doUsdInsertion(stage, layer, srcUsdPath, dstLayer, dstUsdPath);
+              };
 
-    // Do the insertion fro, the soufce layer to the target layer.
-    doUsdInsertion(stage, srcLayer, srcUsdPath, dstLayer, dstUsdPath);
+        const bool includeTopLayer = true;
+        const auto rootLayers = getAllSublayerRefs(stage->GetRootLayer(), includeTopLayer);
+        applyToSomeLayersWithOpinions(srcPrim, rootLayers, insertionFunc);
+    }
 
     // Do the insertion in all other applicable layers, which, due to the command
     // restrictions that have been verified when the command was created, should
     // only be session layers.
-    PrimLayerFunc insertionFunc =
-        [stage, srcUsdPath, dstUsdPath](const UsdPrim& prim, const PXR_NS::SdfLayerRefPtr& layer) {
-            doUsdInsertion(stage, layer, srcUsdPath, layer, dstUsdPath);
-        };
+    {
+        PrimLayerFunc insertionFunc
+            = [stage, srcUsdPath, dstUsdPath](
+                  const UsdPrim& prim, const PXR_NS::SdfLayerRefPtr& layer) {
+                  doUsdInsertion(stage, layer, srcUsdPath, layer, dstUsdPath);
+              };
 
-    const bool includeTopLayer = true;
-    const auto sessionLayers = getAllSublayerRefs(stage->GetSessionLayer(), includeTopLayer);
-    applyToSomeLayersWithOpinions(srcPrim, sessionLayers, insertionFunc);
+        const bool includeTopLayer = true;
+        const auto sessionLayers = getAllSublayerRefs(stage->GetSessionLayer(), includeTopLayer);
+        applyToSomeLayersWithOpinions(srcPrim, sessionLayers, insertionFunc);
+    }
 
     // Remove all scene descriptions for the source path and its subtree in the source layer.
     // Note: is the layer targeting really needed? We are removing the prim entirely.
@@ -234,22 +244,38 @@ static UsdSceneItem::Ptr doInsertion(
           };
 
     applyToAllLayersWithOpinions(srcPrim, removeFunc);
-
-    UsdSceneItem::Ptr dstItem = UsdSceneItem::create(dstUfePath, ufePathToPrim(dstUfePath));
-    sendNotification<Ufe::ObjectReparent>(dstItem, srcUfePath);
-    return dstItem;
 }
 
-void UsdUndoInsertChildCommand::insertChildRedo()
+static void
+preserveLoadRules(const Ufe::Path& srcUfePath, const SdfPath& srcUsdPath, const SdfPath& dstUsdPath)
 {
+    UsdPrim           srcPrim = ufePathToPrim(srcUfePath);
+    const UsdStagePtr stage = srcPrim.GetStage();
+
+    // Make sure the load state of the reparented prim will be preserved.
+    // We copy all rules that applied to it specifically and remove the rules
+    // that applied to it specifically.
+    duplicateLoadRules(*stage, srcUsdPath, dstUsdPath);
+    removeRulesForPath(*stage, srcUsdPath);
+}
+
+static const UsdSceneItem::Ptr
+sendReparentNotification(const Ufe::Path& srcUfePath, const Ufe::Path& dstUfePath)
+{
+    UsdPrim                 dstPrim = ufePathToPrim(dstUfePath);
+    const UsdSceneItem::Ptr ufeDstItem = UsdSceneItem::create(dstUfePath, dstPrim);
+
+    sendNotification<Ufe::ObjectReparent>(ufeDstItem, srcUfePath);
+
+    return ufeDstItem;
+}
+
+void UsdUndoInsertChildCommand::execute()
+{
+    InPathChange pc;
+
     if (_usdDstPath.IsEmpty()) {
         const auto& parentPrim = ufePathToPrim(_ufeParentPath);
-
-        // Enforce the edit routing for the insert-child command in order to find
-        // the target layer. The edit router context sets the edit target of the
-        // stage of the given prim, if it gets routed.
-        OperationEditRouterContext ctx(MayaUsdEditRoutingTokens->RouteParent, parentPrim);
-        _parentLayer = parentPrim.GetStage()->GetEditTarget().GetLayer();
 
         // First, check if we need to rename the child.
         const auto childName = uniqueChildName(parentPrim, _ufeSrcPath.back().string());
@@ -267,29 +293,46 @@ void UsdUndoInsertChildCommand::insertChildRedo()
         _usdDstPath = parentPrim.GetPath().AppendChild(TfToken(childName));
     }
 
+    // Load rules must be duplicated before the prim is moved to be able
+    // to access the existing rules.
+    preserveLoadRules(_ufeSrcPath, _usdSrcPath, _usdDstPath);
+
     // We need to keep the generated item to be able to return it to the caller
     // via the insertedChild() member function.
-    _ufeDstItem = doInsertion(
-        _childLayer, _usdSrcPath, _ufeSrcPath, _parentLayer, _usdDstPath, _ufeDstPath);
-}
+    {
+        UsdUndoBlock undoBlock(&_undoableItem);
+        doInsertion(_usdSrcPath, _ufeSrcPath, _usdDstPath, _ufeDstPath);
+    }
 
-void UsdUndoInsertChildCommand::insertChildUndo()
-{
-    // Note: we don't need to keep the source item, we only need it to validate
-    //       that the operation worked.
-    doInsertion(_parentLayer, _usdDstPath, _ufeDstPath, _childLayer, _usdSrcPath, _ufeSrcPath);
+    _ufeDstItem = sendReparentNotification(_ufeSrcPath, _ufeDstPath);
 }
 
 void UsdUndoInsertChildCommand::undo()
 {
     InPathChange pc;
-    insertChildUndo();
+
+    // Load rules must be duplicated before the prim is moved to be able
+    // to access the existing rules.
+    // Note: the arguments passed are the opposite of those in execute and redo().
+    preserveLoadRules(_ufeDstPath, _usdDstPath, _usdSrcPath);
+
+    _undoableItem.undo();
+
+    // Note: the arguments passed are the opposite of those in execute and redo().
+    sendReparentNotification(_ufeDstPath, _ufeSrcPath);
 }
 
 void UsdUndoInsertChildCommand::redo()
 {
     InPathChange pc;
-    insertChildRedo();
+
+    // Load rules must be duplicated before the prim is moved to be able
+    // to access the existing rules.
+    preserveLoadRules(_ufeSrcPath, _usdSrcPath, _usdDstPath);
+
+    _undoableItem.redo();
+
+    _ufeDstItem = sendReparentNotification(_ufeSrcPath, _ufeDstPath);
 }
 
 } // namespace ufe

--- a/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoInsertChildCommand.h
@@ -18,6 +18,7 @@
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/ufe/UfeVersionCompat.h>
 #include <mayaUsd/ufe/UsdSceneItem.h>
+#include <mayaUsd/undo/UsdUndoableItem.h>
 
 #include <pxr/usd/usd/prim.h>
 
@@ -60,11 +61,9 @@ protected:
         const UsdSceneItem::Ptr& pos);
 
 private:
+    void execute() override;
     void undo() override;
     void redo() override;
-
-    void insertChildRedo();
-    void insertChildUndo();
 
     UsdSceneItem::Ptr _ufeDstItem;
 
@@ -75,9 +74,7 @@ private:
     PXR_NS::SdfPath _usdSrcPath;
     PXR_NS::SdfPath _usdDstPath;
 
-    PXR_NS::SdfLayerHandle _childLayer;
-    PXR_NS::SdfLayerHandle _parentLayer;
-
+    UsdUndoableItem _undoableItem;
 }; // UsdUndoInsertChildCommand
 
 } // namespace ufe

--- a/lib/mayaUsd/utils/editRouterContext.cpp
+++ b/lib/mayaUsd/utils/editRouterContext.cpp
@@ -59,6 +59,18 @@ const PXR_NS::SdfLayerHandle& StackedEditRouterContext::getLayer() const
     return empty;
 }
 
+const PXR_NS::UsdStagePtr& StackedEditRouterContext::getStage() const
+{
+    if (_stage)
+        return _stage;
+
+    if (const StackedEditRouterContext* ctx = GetStackPrevious())
+        return ctx->getStage();
+
+    static const PXR_NS::UsdStagePtr empty;
+    return empty;
+}
+
 bool StackedEditRouterContext::isTargetAlreadySet() const
 {
     // Use the edit target of a edit router context higher-up in the call
@@ -88,6 +100,13 @@ OperationEditRouterContext::OperationEditRouterContext(
 {
 }
 
+OperationEditRouterContext::OperationEditRouterContext(
+    const PXR_NS::UsdStagePtr&    stage,
+    const PXR_NS::SdfLayerHandle& layer)
+    : StackedEditRouterContext(stage, layer)
+{
+}
+
 PXR_NS::SdfLayerHandle AttributeEditRouterContext::getAttributeLayer(
     const PXR_NS::UsdPrim& prim,
     const PXR_NS::TfToken& attributeName)
@@ -102,6 +121,13 @@ AttributeEditRouterContext::AttributeEditRouterContext(
     const PXR_NS::UsdPrim& prim,
     const PXR_NS::TfToken& attributeName)
     : StackedEditRouterContext(prim.GetStage(), getAttributeLayer(prim, attributeName))
+{
+}
+
+AttributeEditRouterContext::AttributeEditRouterContext(
+    const PXR_NS::UsdStagePtr&    stage,
+    const PXR_NS::SdfLayerHandle& layer)
+    : StackedEditRouterContext(stage, layer)
 {
 }
 

--- a/lib/mayaUsd/utils/editRouterContext.h
+++ b/lib/mayaUsd/utils/editRouterContext.h
@@ -34,12 +34,18 @@ namespace MAYAUSD_NS_DEF {
 class MAYAUSD_CORE_PUBLIC StackedEditRouterContext
     : public PXR_NS::TfStacked<StackedEditRouterContext>
 {
-protected:
+public:
     /*! \brief Retrieve the current targeted layer.
      * \return The targeted layer. Null if the edit target was not changed.
      */
     const PXR_NS::SdfLayerHandle& getLayer() const;
 
+    /*! \brief Retrieve the routed stage.
+     * \return The stage that is being routed. Null if the edit target was not changed.
+     */
+    const PXR_NS::UsdStagePtr& getStage() const;
+
+protected:
     /*! \brief Check if an edit context higher-up in the call-stack of this
      *         thread already routed the edits to a specific layer.
      */
@@ -77,6 +83,13 @@ public:
      */
     OperationEditRouterContext(const PXR_NS::TfToken& operationName, const PXR_NS::UsdPrim& prim);
 
+    /*! \brief Route to the given stage and layer.
+     *  Should be used in undo to ensure the same target is used as in the initial execution.
+     */
+    OperationEditRouterContext(
+        const PXR_NS::UsdStagePtr&    stage,
+        const PXR_NS::SdfLayerHandle& layer);
+
 private:
     PXR_NS::SdfLayerHandle
     getOperationLayer(const PXR_NS::TfToken& operationName, const PXR_NS::UsdPrim& prim);
@@ -100,6 +113,13 @@ public:
     /*! \brief Route an attribute operation on a prim for the given attribute.
      */
     AttributeEditRouterContext(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attributeName);
+
+    /*! \brief Route to the given stage and layer.
+     *  Should be used in undo to ensure the same target is used as in the initial execution.
+     */
+    AttributeEditRouterContext(
+        const PXR_NS::UsdStagePtr&    stage,
+        const PXR_NS::SdfLayerHandle& layer);
 
 private:
     PXR_NS::SdfLayerHandle

--- a/test/lib/ufe/testEditRouting.py
+++ b/test/lib/ufe/testEditRouting.py
@@ -7,6 +7,7 @@ import mayaUsd.ufe
 import mayaUtils
 import ufeUtils
 import ufe
+import os
 import unittest
 import usdUtils
 from pxr import UsdGeom
@@ -17,7 +18,7 @@ from pxr import UsdGeom
 
 def filterUsdStr(usdSceneStr):
     '''Remove empty lines and lines starting with pound character.'''
-    nonBlankLines = filter(None, [l.rstrip() for l in usdSceneStr.splitlines()])
+    nonBlankLines = filter(None, [l.strip() for l in usdSceneStr.splitlines()])
     finalLines = [l for l in nonBlankLines if not l.startswith('#')]
     return '\n'.join(finalLines)
 
@@ -206,7 +207,7 @@ class EditRoutingTestCase(unittest.TestCase):
  
             # Check that correct visibility changes were written to the session layer
             self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
-                            'over "B"\n{\n    token visibility = "invisible"\n}')
+                            filterUsdStr('over "B"\n{\n    token visibility = "invisible"\n}'))
             
         self._verifyEditRouterForCmd('visibility', setVisibility, verifyVisibility)
 
@@ -225,7 +226,7 @@ class EditRoutingTestCase(unittest.TestCase):
  
             # Check that correct duplicated prim was written to the session layer
             self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
-                            'def Xform "B1"\n{\n}')
+                            filterUsdStr('def Xform "B1"\n{\n}'))
             
         self._verifyEditRouterForCmd('duplicate', duplicate, verifyDuplicate)
 
@@ -240,7 +241,7 @@ class EditRoutingTestCase(unittest.TestCase):
         def verifyGroup(sessionLayer):
             # Check that correct grouped prim was written to the session layer
             self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
-                            'over "group1"\n{\n    def Xform "B"\n    {\n    }\n}')
+                            filterUsdStr('over "group1"\n{\n    def Xform "B"\n    {\n    }\n}'))
 
             # Check that the grouped prim was created in the session layer
             self.assertIsNotNone(sessionLayer.GetPrimAtPath('/group1'))
@@ -280,7 +281,7 @@ class EditRoutingTestCase(unittest.TestCase):
  
         # Check that correct visibility changes were written to the session layer
         self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
-                         'over "B"\n{\n    token visibility = "invisible"\n}')
+                         filterUsdStr('over "B"\n{\n    token visibility = "invisible"\n}'))
 
     def testEditRouterForAttributeVisibility(self):
         '''
@@ -313,7 +314,7 @@ class EditRoutingTestCase(unittest.TestCase):
  
         # Check that correct visibility changes were written to the session layer
         self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
-                         'over "B"\n{\n    token visibility = "invisible"\n}')
+                         filterUsdStr('over "B"\n{\n    token visibility = "invisible"\n}'))
         
         # Check we are still allowed to set the attribute without
         # explicitly changing the edit target.
@@ -416,7 +417,7 @@ class EditRoutingTestCase(unittest.TestCase):
         # Check to root layer only contains bare A and B xforms.
         rootLayer = stage.GetRootLayer()
         self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
-                         'def Xform "A"\n{\n}\ndef Xform "B"\n{\n}')
+                         filterUsdStr('def Xform "A"\n{\n}\ndef Xform "B"\n{\n}'))
  
         # Route the visibility command to the session layer.
         # Route the custom composite command to the root layer.
@@ -442,7 +443,7 @@ class EditRoutingTestCase(unittest.TestCase):
         # Check that visibility was written to the root layer
         rootLayer = stage.GetRootLayer()
         self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
-                         'def Xform "A"\n{\n}\ndef Xform "B"\n{\n    token visibility = "invisible"\n}')
+                         filterUsdStr('def Xform "A"\n{\n}\ndef Xform "B"\n{\n    token visibility = "invisible"\n}'))
 
     @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 4, 'UFE composite commands only available in Python from UFE v4.')
     def testNotRoutingCompositeCmd(self):
@@ -460,7 +461,7 @@ class EditRoutingTestCase(unittest.TestCase):
         # Check to root layer only contains bare A and B xforms.
         rootLayer = stage.GetRootLayer()
         self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
-                         'def Xform "A"\n{\n}\ndef Xform "B"\n{\n}')
+                         filterUsdStr('def Xform "A"\n{\n}\ndef Xform "B"\n{\n}'))
  
         # Select /B
         sn = ufe.GlobalSelection.get()
@@ -480,8 +481,61 @@ class EditRoutingTestCase(unittest.TestCase):
         # Check that visibility was written to the root layer
         rootLayer = stage.GetRootLayer()
         self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
-                         'def Xform "A"\n{\n}\ndef Xform "B"\n{\n    token visibility = "invisible"\n}')
+                         filterUsdStr('def Xform "A"\n{\n}\ndef Xform "B"\n{\n    token visibility = "invisible"\n}'))
 
+    @unittest.skipIf(os.getenv('UFE_PREVIEW_VERSION_NUM', '0000') < '5002', 'Test requires composite command handler only available in UFE 0.5.2 and later')
+    def testRoutingCompositeGroupCmd(self):
+        '''
+        Test that an edit router for the group composite command routes all sub-commands.
+        '''
+        # Get the session layer
+        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
+        stage = prim.GetStage()
+        sessionLayer = stage.GetSessionLayer()
+ 
+        # Check that the session layer is empty
+        self.assertTrue(sessionLayer.empty)
+
+        # Check to root layer only contains bare A and B xforms.
+        rootLayer = stage.GetRootLayer()
+        self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
+                         filterUsdStr('def Xform "A"\n{\n}\ndef Xform "B"\n{\n}'))
+ 
+        # Route the group command to the session layer.
+        mayaUsd.lib.registerEditRouter('group', routeCmdToSessionLayer)
+ 
+        # Select /B
+        sn = ufe.GlobalSelection.get()
+        sn.clear()
+        sn.append(self.b)
+ 
+        # Group
+        cmds.group()
+ 
+        # Check that everything was written to the session layer
+        self.assertIsNotNone(sessionLayer)
+        expectedContents = '''
+            def Xform "group1" (
+                kind = "group"
+            )
+            {
+                float3 xformOp:translate:rotatePivot = (0, 0, 0)
+                float3 xformOp:translate:rotatePivotTranslate = (0, 0, 0)
+                float3 xformOp:translate:scalePivot = (0, 0, 0)
+                float3 xformOp:translate:scalePivotTranslate = (0, 0, 0)
+                uniform token[] xformOpOrder = ["xformOp:translate:rotatePivotTranslate", "xformOp:translate:rotatePivot", "!invert!xformOp:translate:rotatePivot", "xformOp:translate:scalePivotTranslate", "xformOp:translate:scalePivot", "!invert!xformOp:translate:scalePivot"]
+                def Xform "B"
+                {
+                    float3 xformOp:rotateXYZ = (0, -0, 0)
+                    float3 xformOp:scale = (1, 1, 1)
+                    double3 xformOp:translate = (0, 0, 0)
+                    uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:rotateXYZ", "xformOp:scale"]
+                }
+            }
+            '''
+        self.maxDiff = None
+        self.assertEqual(filterUsdStr(sessionLayer.ExportToString()), filterUsdStr(expectedContents))
+ 
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/ufe/testGroupCmd.py
+++ b/test/lib/ufe/testGroupCmd.py
@@ -521,9 +521,9 @@ class GroupCmdTestCase(unittest.TestCase):
         cmds.undo()
 
         self.assertEqual([item for item in stage.Traverse()],
-            [stage.GetPrimAtPath("/Sphere3"), 
+            [stage.GetPrimAtPath("/Sphere1"), 
             stage.GetPrimAtPath("/Sphere2"),
-            stage.GetPrimAtPath("/Sphere1")])
+            stage.GetPrimAtPath("/Sphere3")])
 
         cmds.redo()
 
@@ -610,9 +610,9 @@ class GroupCmdTestCase(unittest.TestCase):
         cmds.undo()
 
         self.assertEqual([item for item in stage.Traverse()],
-            [stage.GetPrimAtPath("/Sphere3"), 
+            [stage.GetPrimAtPath("/Sphere1"), 
             stage.GetPrimAtPath("/Sphere2"),
-            stage.GetPrimAtPath("/Sphere1")])
+            stage.GetPrimAtPath("/Sphere3")])
 
         verifyRadius(getItem(oldSphere1Name), radius)
 
@@ -666,6 +666,8 @@ class GroupCmdTestCase(unittest.TestCase):
         groupItem = ufe.GlobalSelection.get().front()
         groupHierarchy = ufe.Hierarchy.hierarchy(groupItem)
         self.assertEqual(len(groupHierarchy.children()), 3)
+
+        print(stage.GetLoadRules())
 
         self.assertEqual(loadRules.NoneRule, stage.GetLoadRules().GetEffectiveRuleForPath('/group1/Sphere1'))
         self.assertEqual(loadRules.AllRule, stage.GetLoadRules().GetEffectiveRuleForPath('/group1/Sphere2'))


### PR DESCRIPTION
Implement a code wrapper handler to support edit routing for composite commands:

- Make the batch-ops handler derive from the correct class depending on which feature is supported in UFE.
- Implement a code wrapper handler derived from the batch ops handler.
- This code wrapper handler creates edit-routing wrappers for composite commands.

Implement a code wrapper that does the edit routing:

- The code wrapper cache the stage and layer used when first executing a composite command.
- This allows using the same values when undoing.
- This is necessary because the original prim that was used when executing the command might not exist anymore once the command executed.
- In particular, this is true for the group command, the original prim no longer exists.

Make the group command work with edit routing. Note that the Maya group command is implemented in term of the insert-child UFE command. That is why we are modifying the insert-child command.

- Use the generic undo/redo support to record the changes, undo and redo them.
- Don't assume that the current edit target is where the source prim has opinion.
- Instead, apply the child-insertion to the layer that have opinion about the moving prim.
- The command restrictions already ensure that we only affect prims that have a single opinion.
- (But with these changes, the code will be ready if we support multi-layers command later on.)
- The problem was that the command restrictions were correctly looking at where the prim was authored, but the command execution was assuming that the source opinion was on the target layer.
- When routing commands, that can obviously be false: the target might not be where the original opinions were.
- We do the right thing using similar code as when affecting the session layer, except the target layer is the layer where the command was routed.
- By default, when no routing is registered, that is the current edit target.
- Fix load rules duplication: the Load rules are not part of the USD data that gets restore by automatic USD undo block, so we need to duplicate them explicitly. Also, the UFE reparent notification need to be triggered during undo and redo.

Fix unit tests:

- The unit tests were tied to some subtle behavior of the implementation. Now that we use "perfect" undo/redo, the order of items is also preserved, so the testGroupCmd assertions had to be fixed. Similarly, the parent command was assuming the parent prim was passed to the edit router. It was also creating the parent prims, which is not necessary. (The problem was fixed before, but the fix was hidden due to the exact timing of the edit routing call.)
- Also made the parent unit test for edit routing properly unregister the router even when the test fails. Otherwise, the subsequent test crashes due to the invalid edit router being left behind.
- Added a unit test for the Maya group composite command.
- Made text filtering ignore all white spaces at the start and end of lines to avoid to have to write the exact indentations.