### PR TITLE
MAYA-129186 clearer layer file names

### DIFF
--- a/lib/mayaUsd/nodes/proxyAccessor.cpp
+++ b/lib/mayaUsd/nodes/proxyAccessor.cpp
@@ -689,7 +689,8 @@ MStatus ProxyAccessor::stageChanged(const MObject& node, const UsdNotice::Object
     if (_accessorInputItems.size() > 0) {
         auto findInputItemFn = [this](const SdfPath& changedPath) -> Item* {
             for (Item& item : _accessorInputItems) {
-                if (item.path == changedPath || item.path.AppendProperty(item.property) == changedPath) {
+                if (item.path == changedPath
+                    || item.path.AppendProperty(item.property) == changedPath) {
                     return &item;
                 }
             }

--- a/lib/mayaUsd/utils/utilFileSystem.cpp
+++ b/lib/mayaUsd/utils/utilFileSystem.cpp
@@ -364,7 +364,7 @@ size_t UsdMayaUtilFileSystem::getNumberSuffixPosition(const std::string& text)
 {
     const size_t length = text.size();
 
-    if (length == 0)
+    if (length <= 1)
         return 0;
 
     size_t nonDigitPos = length - 1;

--- a/lib/mayaUsd/utils/utilFileSystem.h
+++ b/lib/mayaUsd/utils/utilFileSystem.h
@@ -147,6 +147,29 @@ MAYAUSD_CORE_PUBLIC
 std::string
 getUniqueFileName(const std::string& dir, const std::string& basename, const std::string& ext);
 
+/*! \brief returns a unique file name, make sure it does not exist on disk.
+ */
+MAYAUSD_CORE_PUBLIC
+std::string ensureUniqueFileName(const std::string& filename);
+
+/*! \brief returns the position of the numbered suffix.
+           Returns the end of the string position if no such suffix is present.
+ */
+MAYAUSD_CORE_PUBLIC
+size_t getNumberSuffixPosition(const std::string& text);
+
+/*! \brief returns the numbered suffix.
+           Returns the an empty string if no such suffix is present.
+ */
+MAYAUSD_CORE_PUBLIC
+std::string getNumberSuffix(const std::string& text);
+
+/*! \brief returns a new text with the numbered suffix increased by one.
+           Returns the text with 1 appended if no such suffix is present.
+ */
+MAYAUSD_CORE_PUBLIC
+std::string increaseNumberSuffix(const std::string& text);
+
 /*! \brief returns the aboluste path relative to the maya file
  */
 MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -178,6 +178,20 @@ std::string generateUniqueFileName(const std::string& basename)
     return newFileName;
 }
 
+std::string generateUniqueLayerFileName(const std::string& basename, const SdfLayerRefPtr& layer)
+{
+    std::string layerNumber("1");
+    if (layer)
+        layerNumber = UsdMayaUtilFileSystem::getNumberSuffix(layer->GetDisplayName());
+
+    const std::string ext = PXR_NS::UsdUsdFileFormatTokens->Id.GetText();
+    const std::string layerFilename = basename + "-layer" + layerNumber + "." + ext;
+    const std::string dir = getSceneFolder();
+
+    return UsdMayaUtilFileSystem::ensureUniqueFileName(
+        UsdMayaUtilFileSystem::appendPaths(dir, layerFilename));
+}
+
 std::string usdFormatArgOption()
 {
     static const MString kSaveLayerFormatBinaryOption(
@@ -303,7 +317,7 @@ SdfLayerRefPtr saveAnonymousLayer(
     const std::string& basename,
     std::string        formatArg)
 {
-    std::string newFileName = generateUniqueFileName(basename);
+    std::string newFileName = generateUniqueLayerFileName(basename, anonLayer);
     return saveAnonymousLayer(stage, anonLayer, newFileName, false, parent, formatArg);
 }
 

--- a/lib/mayaUsd/utils/utilSerialization.h
+++ b/lib/mayaUsd/utils/utilSerialization.h
@@ -43,6 +43,9 @@ std::string getSceneFolder();
 MAYAUSD_CORE_PUBLIC
 std::string generateUniqueFileName(const std::string& basename);
 
+MAYAUSD_CORE_PUBLIC
+std::string generateUniqueLayerFileName(const std::string& basename, const SdfLayerRefPtr& layer);
+
 /*! \brief Queries the Maya optionVar that decides what the internal format
     of a .usd file should be, either "usdc" or "usda".
  */

--- a/lib/usd/ui/layerEditor/saveLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.cpp
@@ -144,7 +144,7 @@ SaveLayerPathRow::SaveLayerPathRow(SaveLayersDialog* in_parent, const LayerInfo&
     _label->setToolTip(in_parent->buildTooltipForLayer(_layerInfo.layer));
     gridLayout->addWidget(_label, 0, 0);
 
-    _pathToSaveAs = MayaUsd::utils::generateUniqueFileName(stageName).c_str();
+    _pathToSaveAs = MayaUsd::utils::generateUniqueLayerFileName(stageName, _layerInfo.layer).c_str();
 
     QFileInfo fileInfo(_pathToSaveAs);
     QString   suggestedFullPath = fileInfo.absoluteFilePath();

--- a/lib/usd/ui/layerEditor/saveLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.cpp
@@ -144,7 +144,8 @@ SaveLayerPathRow::SaveLayerPathRow(SaveLayersDialog* in_parent, const LayerInfo&
     _label->setToolTip(in_parent->buildTooltipForLayer(_layerInfo.layer));
     gridLayout->addWidget(_label, 0, 0);
 
-    _pathToSaveAs = MayaUsd::utils::generateUniqueLayerFileName(stageName, _layerInfo.layer).c_str();
+    _pathToSaveAs
+        = MayaUsd::utils::generateUniqueLayerFileName(stageName, _layerInfo.layer).c_str();
 
     QFileInfo fileInfo(_pathToSaveAs);
     QString   suggestedFullPath = fileInfo.absoluteFilePath();

--- a/test/lib/mayaUsd/utils/CMakeLists.txt
+++ b/test/lib/mayaUsd/utils/CMakeLists.txt
@@ -109,6 +109,10 @@ if(IS_WINDOWS)
         testLoadRules.cpp
     )
     add_mayaUsdLibUtils_test(
+        testUtilsFileSystem
+        testUtilsFileSystem.cpp
+    )
+    add_mayaUsdLibUtils_test(
         testTargetLayer
         testTargetLayer.cpp
     )

--- a/test/lib/mayaUsd/utils/testUtilsFileSystem.cpp
+++ b/test/lib/mayaUsd/utils/testUtilsFileSystem.cpp
@@ -1,0 +1,34 @@
+#include <mayaUsd/utils/utilFileSystem.h>
+
+#include <gtest/gtest.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+using namespace UsdMayaUtilFileSystem;
+
+TEST(ConvertLoadRules, getNumberSuffixPosition)
+{
+    EXPECT_EQ(size_t(0), getNumberSuffixPosition(""));
+    EXPECT_EQ(size_t(0), getNumberSuffixPosition("1"));
+    EXPECT_EQ(size_t(2), getNumberSuffixPosition("1a"));
+    EXPECT_EQ(size_t(1), getNumberSuffixPosition("a1"));
+    EXPECT_EQ(size_t(8), getNumberSuffixPosition("abc35def19753"));
+}
+
+TEST(ConvertLoadRules, getNumberSuffix)
+{
+    EXPECT_EQ(std::string(""), getNumberSuffix(""));
+    EXPECT_EQ(std::string("1"), getNumberSuffix("1"));
+    EXPECT_EQ(std::string(""), getNumberSuffix("1a"));
+    EXPECT_EQ(std::string("1"), getNumberSuffix("a1"));
+    EXPECT_EQ(std::string("19753"), getNumberSuffix("abc35def19753"));
+}
+
+TEST(ConvertLoadRules, increaseNumberSuffix)
+{
+    EXPECT_EQ(std::string("1"), increaseNumberSuffix(""));
+    EXPECT_EQ(std::string("2"), increaseNumberSuffix("1"));
+    EXPECT_EQ(std::string("1a1"), increaseNumberSuffix("1a"));
+    EXPECT_EQ(std::string("a2"), increaseNumberSuffix("a1"));
+    EXPECT_EQ(std::string("abc35def19754"), increaseNumberSuffix("abc35def19753"));
+}


### PR DESCRIPTION
- Added helper functions to extract and manipulate the numbered suffix of a file name.
- Added a helper function to ensure a filename is unique on-disk.
- Added a helper function to generate the layer file name.
- Use the new function when saving layers.