### PR TITLE
 MAYA-129039 save and restore selected stage

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -228,6 +228,12 @@ public:
     bool removeLayer(SdfLayerRefPtr layer);
     void removeAllLayers();
 
+    void        setSelectedStage(const std::string& stage);
+    std::string getSelectedStage() const;
+
+    bool saveLayerManagerSelectedStage();
+    bool loadLayerManagerSelectedStage();
+
     SdfLayerHandle findLayer(std::string identifier) const;
 
 private:
@@ -254,6 +260,7 @@ private:
     std::set<unsigned int>                _supportedTypes;
     std::vector<StageSavingInfo>          _proxiesToSave;
     std::vector<StageSavingInfo>          _internalProxiesToSave;
+    std::string                           _selectedStage;
     static MCallbackId                    preSaveCallbackId;
     static MCallbackId                    postSaveCallbackId;
     static MCallbackId                    preExportCallbackId;
@@ -397,6 +404,8 @@ void LayerDatabase::prepareForWriteCheck(bool* retCode, bool isExport)
     _isSavingMayaFile = true;
     cleanUpNewScene(nullptr);
 
+    LayerDatabase::instance().saveLayerManagerSelectedStage();
+
     if (LayerDatabase::instance().getProxiesToSave(isExport)) {
 
         int dialogResult = true;
@@ -539,6 +548,43 @@ void LayerDatabase::refreshProxiesToSave()
     for (StageSavingInfo& info : _internalProxiesToSave) {
         refreshSavingInfo(info);
     }
+}
+
+void LayerDatabase::setSelectedStage(const std::string& stage) { _selectedStage = stage; }
+
+std::string LayerDatabase::getSelectedStage() const { return _selectedStage; }
+
+bool LayerDatabase::saveLayerManagerSelectedStage()
+{
+    MayaUsd::LayerManager* lm = findOrCreateNode();
+    if (!lm)
+        return false;
+
+    MStatus     status;
+    MDataBlock  dataBlock = lm->_forceCache();
+    MDataHandle selectedStageHandle = dataBlock.outputValue(lm->selectedStage, &status);
+    if (!status)
+        return false;
+
+    selectedStageHandle.setString(getSelectedStage().c_str());
+
+    selectedStageHandle.setClean();
+    dataBlock.setClean(lm->selectedStage);
+
+    return true;
+}
+
+bool LayerDatabase::loadLayerManagerSelectedStage()
+{
+    MayaUsd::LayerManager* lm = findNode();
+    if (!lm)
+        return false;
+
+    MStatus status;
+    MPlug selectedStagePlug(lm->thisMObject(), lm->selectedStage);
+    setSelectedStage(selectedStagePlug.asString(MDGContext::fsNormal, &status).asChar());
+
+    return status;
 }
 
 bool LayerDatabase::saveUsd(bool isExport)
@@ -983,6 +1029,8 @@ void LayerDatabase::loadLayersPostRead(void*)
         }
     }
 
+    LayerDatabase::instance().loadLayerManagerSelectedStage();
+
     if (!_isSavingMayaFile)
         removeManagerNode(lm);
 
@@ -1119,6 +1167,7 @@ MObject LayerManager::identifier = MObject::kNullObj;
 MObject LayerManager::fileFormatId = MObject::kNullObj;
 MObject LayerManager::serialized = MObject::kNullObj;
 MObject LayerManager::anonymous = MObject::kNullObj;
+MObject LayerManager::selectedStage = MObject::kNullObj;
 
 struct _OnSceneResetListener : public TfWeakBase
 {
@@ -1150,6 +1199,16 @@ MStatus LayerManager::initialize()
         MStatus           stat;
         MFnTypedAttribute fn_str;
         MFnStringData     stringData;
+
+        selectedStage
+            = fn_str.create("selectedStage", "sst", MFnData::kString, MObject::kNullObj, &stat);
+        CHECK_MSTATUS_AND_RETURN_IT(stat);
+        fn_str.setCached(true);
+        fn_str.setReadable(true);
+        fn_str.setStorable(true);
+        fn_str.setHidden(true);
+        stat = addAttribute(selectedStage);
+        CHECK_MSTATUS_AND_RETURN_IT(stat);
 
         identifier = fn_str.create("identifier", "id", MFnData::kString, MObject::kNullObj, &stat);
         CHECK_MSTATUS_AND_RETURN_IT(stat);
@@ -1256,6 +1315,19 @@ void LayerManager::removeSupportForNodeType(MTypeId type)
 bool LayerManager::supportedNodeType(MTypeId nodeId)
 {
     return LayerDatabase::instance().supportedNodeType(nodeId);
+}
+
+/* static */
+void LayerManager::setSelectedStage(const std::string& stage)
+{
+    return LayerDatabase::instance().setSelectedStage(stage);
+}
+
+/* static */
+std::string LayerManager::getSelectedStage()
+{
+    LayerDatabase::loadLayersPostRead(nullptr);
+    return LayerDatabase::instance().getSelectedStage();
 }
 
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/nodes/layerManager.h
+++ b/lib/mayaUsd/nodes/layerManager.h
@@ -117,6 +117,11 @@ public:
     static void removeSupportForNodeType(MTypeId nodeId);
     static bool supportedNodeType(MTypeId nodeId);
 
+    //! \brief set the stage that is currently selected in the layer manager.
+    static void setSelectedStage(const std::string& stage);
+    //! \brief get the stage that should be selected in the layer manager.
+    static std::string getSelectedStage();
+
     /*! \brief  Supported Proxy Shapes should call this to possibly retrieve their Root and Session
        layers before calling Sdf::FindOrOpen.  If a handle is found and returned then it will be the
        recreated layer, and all sublayers, with edits from a previous Maya session and should be
@@ -135,6 +140,7 @@ public:
     static MObject fileFormatId;
     static MObject serialized;
     static MObject anonymous;
+    static MObject selectedStage;
 
 protected:
     LayerManager();

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
@@ -353,7 +353,7 @@ HdReprSharedPtr MayaUsdRPrim::_InitReprCommon(
     auto instancerId = delegate->GetInstancerId(id);
     bool instanced = !instancerId.IsEmpty();
     // The additional condition below is to prevent a crash in USD function GetScenePrimPath
-    instanced &= !delegate->GetInstanceIndices(instancerId, id).empty();
+    instanced = (instanced && !delegate->GetInstanceIndices(instancerId, id).empty());
 
     // display layers handling
     if (instanced) {

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
@@ -892,7 +892,8 @@ void MayaUsdRPrim::_SyncSharedData(
     if (HdChangeTracker::IsInstancerDirty(*dirtyBits, id)) {
         bool instanced = !refThis.GetInstancerId().IsEmpty();
         // The additional condition below is to prevent a crash in USD function GetScenePrimPath
-        instanced &= !delegate->GetInstanceIndices(refThis.GetInstancerId(), id).empty();
+        instanced
+            = (instanced && !delegate->GetInstanceIndices(refThis.GetInstancerId(), id).empty());
 
         // UpdateInstancingMapEntry is not multithread-safe, so enqueue the call
         _delegate->GetVP2ResourceRegistry().EnqueueCommit([this, id, instanced]() {

--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -19,6 +19,7 @@
 #include "saveLayersDialog.h"
 #include "stringResources.h"
 
+#include <mayaUsd/nodes/layerManager.h>
 #include <mayaUsd/nodes/usdPrimProvider.h>
 #include <mayaUsd/utils/util.h>
 
@@ -66,6 +67,9 @@ void MayaSessionState::setStageEntry(StageEntry const& inEntry)
     if (!inEntry._stage) {
         _currentStageEntry.clear();
     }
+
+    if (!_inLoad)
+        MayaUsd::LayerManager::setSelectedStage(_currentStageEntry._proxyShapePath);
 }
 
 bool MayaSessionState::getStageEntry(StageEntry* out_stageEntry, const MString& shapePath)
@@ -145,11 +149,21 @@ void MayaSessionState::registerNotifications()
         MSceneMessage::kBeforeNew, MayaSessionState::sceneClosingCB, this);
     _callbackIds.push_back(id);
 
+    id = MSceneMessage::addCallback(
+        MSceneMessage::kAfterOpen, MayaSessionState::sceneLoadedCB, this);
+    _callbackIds.push_back(id);
+
+    id = MSceneMessage::addCallback(
+        MSceneMessage::kAfterNew, MayaSessionState::sceneLoadedCB, this);
+    _callbackIds.push_back(id);
+
     id = MSceneMessage::addNamespaceRenamedCallback(MayaSessionState::namespaceRenamedCB, this);
     _callbackIds.push_back(id);
 
     TfWeakPtr<MayaSessionState> me(this);
     _stageResetNoticeKey = TfNotice::Register(me, &MayaSessionState::mayaUsdStageReset);
+
+    loadSelectedStage();
 }
 
 void MayaSessionState::unregisterNotifications()
@@ -268,7 +282,25 @@ void MayaSessionState::nodeRenamedCBOnIdle(const MString& shapePath)
 void MayaSessionState::sceneClosingCB(void* clientData)
 {
     auto   THIS = static_cast<MayaSessionState*>(clientData);
+    THIS->_inLoad = true;
     Q_EMIT THIS->clearUIOnSceneResetSignal();
+}
+
+/* static */
+void MayaSessionState::sceneLoadedCB(void* clientData)
+{
+    auto THIS = static_cast<MayaSessionState*>(clientData);
+    THIS->loadSelectedStage();
+    THIS->_inLoad = false;
+}
+
+void MayaSessionState::loadSelectedStage()
+{
+    const std::string shapePath = MayaUsd::LayerManager::getSelectedStage();
+    StageEntry entry;
+    if (getStageEntry(&entry, shapePath.c_str())) {
+        setStageEntry(entry);
+    }
 }
 
 bool MayaSessionState::saveLayerUI(

--- a/lib/usd/ui/layerEditor/mayaSessionState.h
+++ b/lib/usd/ui/layerEditor/mayaSessionState.h
@@ -92,6 +92,7 @@ protected:
     static void
                 namespaceRenamedCB(const MString& oldName, const MString& newName, void* clientData);
     static void sceneClosingCB(void* clientData);
+    static void sceneLoadedCB(void* clientData);
 
     void proxyShapeAddedCBOnIdle(const MObject& node);
     void nodeRenamedCBOnIdle(const MString& shapePath);
@@ -100,9 +101,12 @@ protected:
     void mayaUsdStageReset(const MayaUsdProxyStageSetNotice& notice);
     void mayaUsdStageResetCBOnIdle(StageEntry const& entry);
 
+    void loadSelectedStage();
+
     std::vector<MCallbackId> _callbackIds;
     TfNotice::Key            _stageResetNoticeKey;
     MayaCommandHook          _mayaCommandHook;
+    bool                     _inLoad = false;
 };
 
 } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
@@ -250,7 +250,7 @@ void StageSelectorWidget::setSessionState(SessionState* in_sessionState)
         _sessionState, &SessionState::stageRenamedSignal, this, &StageSelectorWidget::stageRenamed);
     connect(_sessionState, &SessionState::stageResetSignal, this, &StageSelectorWidget::stageReset);
 
-    updateFromSessionState();
+    updateFromSessionState(_sessionState->stageEntry());
 }
 
 SessionState::StageEntry const StageSelectorWidget::selectedStage()


### PR DESCRIPTION
- Add a selected stage attribute on the LayerManager Maya node.
- Add functions on the LayerManager node and its internal LayerDatabase class to set and get the currently selected stage.
- Add functions to save and load the selected stage from the attribute.
- Add functions to the Maya session state to retrieve the selected stage from the LayerManager node.
- Add protection to avoid clobbering the selected stage during load, while the UI is being built.
- Make the stage selection widget use the selected stage from the session state when initializing.
- Support selecting the stage via its parent xform. 