### PR TITLE
MAYA-129309 save and restore selected stage

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.h
+++ b/lib/mayaUsd/nodes/layerManager.h
@@ -117,6 +117,11 @@ public:
     static void removeSupportForNodeType(MTypeId nodeId);
     static bool supportedNodeType(MTypeId nodeId);
 
+    //! \brief set the stage that is currently selected in the layer manager.
+    static void setSelectedStage(const std::string& stage);
+    //! \brief get the stage that should be selected in the layer manager.
+    static std::string getSelectedStage();
+
     /*! \brief  Supported Proxy Shapes should call this to possibly retrieve their Root and Session
        layers before calling Sdf::FindOrOpen.  If a handle is found and returned then it will be the
        recreated layer, and all sublayers, with edits from a previous Maya session and should be
@@ -135,6 +140,7 @@ public:
     static MObject fileFormatId;
     static MObject serialized;
     static MObject anonymous;
+    static MObject selectedStage;
 
 protected:
     LayerManager();

--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -19,7 +19,9 @@
 #include "saveLayersDialog.h"
 #include "stringResources.h"
 
+#if defined(WANT_UFE_BUILD)
 #include <mayaUsd/nodes/layerManager.h>
+#endif
 #include <mayaUsd/nodes/usdPrimProvider.h>
 #include <mayaUsd/utils/util.h>
 
@@ -68,8 +70,10 @@ void MayaSessionState::setStageEntry(StageEntry const& inEntry)
         _currentStageEntry.clear();
     }
 
+#if defined(WANT_UFE_BUILD)
     if (!_inLoad)
         MayaUsd::LayerManager::setSelectedStage(_currentStageEntry._proxyShapePath);
+#endif
 }
 
 bool MayaSessionState::getStageEntry(StageEntry* out_stageEntry, const MString& shapePath)
@@ -296,11 +300,13 @@ void MayaSessionState::sceneLoadedCB(void* clientData)
 
 void MayaSessionState::loadSelectedStage()
 {
+#if defined(WANT_UFE_BUILD)
     const std::string shapePath = MayaUsd::LayerManager::getSelectedStage();
     StageEntry        entry;
     if (getStageEntry(&entry, shapePath.c_str())) {
         setStageEntry(entry);
     }
+#endif
 }
 
 bool MayaSessionState::saveLayerUI(

--- a/lib/usd/ui/layerEditor/mayaSessionState.h
+++ b/lib/usd/ui/layerEditor/mayaSessionState.h
@@ -92,6 +92,7 @@ protected:
     static void
                 namespaceRenamedCB(const MString& oldName, const MString& newName, void* clientData);
     static void sceneClosingCB(void* clientData);
+    static void sceneLoadedCB(void* clientData);
 
     void proxyShapeAddedCBOnIdle(const MObject& node);
     void nodeRenamedCBOnIdle(const MString& shapePath);
@@ -100,9 +101,12 @@ protected:
     void mayaUsdStageReset(const MayaUsdProxyStageSetNotice& notice);
     void mayaUsdStageResetCBOnIdle(StageEntry const& entry);
 
+    void loadSelectedStage();
+
     std::vector<MCallbackId> _callbackIds;
     TfNotice::Key            _stageResetNoticeKey;
     MayaCommandHook          _mayaCommandHook;
+    bool                     _inLoad = false;
 };
 
 } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
@@ -295,7 +295,7 @@ static MayaUsdProxyShapeBase* getChildProxyShape(const Ufe::SceneItem::Ptr& item
     if (!hierarchy)
         return nullptr;
 
-    for (const auto subItem : hierarchy->children()) {
+    for (const auto& subItem : hierarchy->children()) {
         auto proxyShapePtr = MayaUsd::ufe::getProxyShape(subItem->path());
         if (!proxyShapePtr)
             continue;

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
@@ -289,6 +289,7 @@ void StageSelectorWidget::selectedIndexChanged(int index)
     _internalChange = false;
 }
 
+#if defined(WANT_UFE_BUILD)
 static MayaUsdProxyShapeBase* getChildProxyShape(const Ufe::SceneItem::Ptr& item)
 {
     Ufe::Hierarchy::Ptr hierarchy = Ufe::Hierarchy::hierarchy(item);
@@ -305,6 +306,7 @@ static MayaUsdProxyShapeBase* getChildProxyShape(const Ufe::SceneItem::Ptr& item
 
     return nullptr;
 }
+#endif
 
 void StageSelectorWidget::selectionChanged()
 {

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
@@ -40,6 +40,7 @@
 
 #if defined(WANT_UFE_BUILD)
 #include <ufe/globalSelection.h>
+#include <ufe/hierarchy.h>
 #include <ufe/observableSelection.h>
 #include <ufe/selection.h>
 #include <ufe/selectionNotification.h>
@@ -250,7 +251,7 @@ void StageSelectorWidget::setSessionState(SessionState* in_sessionState)
         _sessionState, &SessionState::stageRenamedSignal, this, &StageSelectorWidget::stageRenamed);
     connect(_sessionState, &SessionState::stageResetSignal, this, &StageSelectorWidget::stageReset);
 
-    updateFromSessionState();
+    updateFromSessionState(_sessionState->stageEntry());
 }
 
 SessionState::StageEntry const StageSelectorWidget::selectedStage()
@@ -288,6 +289,23 @@ void StageSelectorWidget::selectedIndexChanged(int index)
     _internalChange = false;
 }
 
+static MayaUsdProxyShapeBase* getChildProxyShape(const Ufe::SceneItem::Ptr& item)
+{
+    Ufe::Hierarchy::Ptr hierarchy = Ufe::Hierarchy::hierarchy(item);
+    if (!hierarchy)
+        return nullptr;
+
+    for (const auto subItem : hierarchy->children()) {
+        auto proxyShapePtr = MayaUsd::ufe::getProxyShape(subItem->path());
+        if (!proxyShapePtr)
+            continue;
+
+        return proxyShapePtr;
+    }
+
+    return nullptr;
+}
+
 void StageSelectorWidget::selectionChanged()
 {
 #if defined(WANT_UFE_BUILD)
@@ -304,8 +322,12 @@ void StageSelectorWidget::selectionChanged()
     const Ufe::Selection& ufeSelection = *ufeGlobalSelection;
     for (const auto& item : ufeSelection) {
         auto proxyShapePtr = MayaUsd::ufe::getProxyShape(item->path());
-        if (!proxyShapePtr)
-            continue;
+        if (!proxyShapePtr) {
+            proxyShapePtr = getChildProxyShape(item);
+            if (!proxyShapePtr) {
+                continue;
+            }
+        }
 
         MFnDagNode        dagNode(proxyShapePtr->thisMObject());
         const std::string id = dagNode.uuid().asString().asChar();


### PR DESCRIPTION
- Add a selected stage attribute on the LayerManager Maya node.
- Add functions on the LayerManager node and its internal LayerDatabase class to set and get the currently selected stage.
- Add functions to save and load the selected stage from the attribute.
- Add functions to the Maya session state to retrieve the selected stage from the LayerManager node.
- Add protection to avoid clobbering the selected stage during load, while the UI is being built.
- Make the stage selection widget use the selected stage from the session state when initializing.
- Support selecting the stage via its parent xform.