### PR TITLE
MAYA-128939 remove error message on deleting a stage

### DIFF
--- a/lib/mayaUsd/ufe/UsdStageMap.cpp
+++ b/lib/mayaUsd/ufe/UsdStageMap.cpp
@@ -56,7 +56,7 @@ Ufe::Path firstPath(const MObject& object)
 // Assuming proxy shape nodes cannot be instanced, simply return the first path.
 Ufe::Path firstPath(const MObjectHandle& handle)
 {
-    if (!TF_VERIFY(handle.isValid(), "Cannot get path from invalid object handle")) {
+    if (!handle.isValid()) {
         return Ufe::Path();
     }
     return firstPath(handle.object());


### PR DESCRIPTION
The error was printed from a utility function to map from a DAG object to a USD stage. Utility functions should not warn, the caller should warn if it realyl thinks it is an error. Here, we are responding to a notification sent in the middle of DAG object deletion, so it is expected that the object is not valid. This shows that printing an error in this case is incorrect.