### PR TITLE
MAYA-129420 - Fix a bug where `UsdUINodeGraphNode::hasPosOrSize()` returned the wrong value.

### DIFF
--- a/lib/mayaUsd/ufe/UsdUINodeGraphNode.cpp
+++ b/lib/mayaUsd/ufe/UsdUINodeGraphNode.cpp
@@ -92,7 +92,12 @@ bool UsdUINodeGraphNode::hasPosOrSize(CoordType coordType) const
     }
     UsdAttribute attr
         = coordType == CoordType::Position ? posApi.GetPosAttr() : posApi.GetSizeAttr();
-    return attr.IsValid();
+    if (!attr.IsValid()) {
+        return false;
+    }
+    VtValue v;
+    attr.Get(&v);
+    return v.IsHolding<GfVec2f>();
 }
 
 Ufe::Vector2f UsdUINodeGraphNode::getPosOrSize(CoordType coordType) const


### PR DESCRIPTION
MAYA-129420 - Fix a bug where `UsdUINodeGraphNode::hasPosOrSize()` returned the wrong value.

`hasPosOrSize()` was returning true, even if the underlying `VtValue` was not holding a value.