### PR TITLE
Adds support to compile against Qt 6.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Autodesk
+# Copyright 2023 Autodesk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,6 +39,8 @@ endif()
 set(BUILD_WITH_PYTHON_3_VERSION 3.7 CACHE STRING "The version of Python 3 to build with")
 option(CMAKE_WANT_UFE_BUILD "Enable building with UFE (if found)." ON)
 option(CMAKE_WANT_MATERIALX_BUILD "Enable building with MaterialX (experimental)." OFF)
+
+option(BUILD_WITH_QT_6 "Build with QT 6." OFF)
 
 set(PXR_OVERRIDE_PLUGINPATH_NAME PXR_PLUGINPATH_NAME
     CACHE STRING "Name of env var USD searches to find plugins")
@@ -158,17 +160,32 @@ endif()
 
 if(DEFINED QT_LOCATION)
     if(NOT DEFINED QT_VERSION)
-        if(${MAYA_APP_VERSION} STRLESS_EQUAL "2019")
+		if(BUILD_WITH_QT_6)
+			set(QT_VERSION "6.5")
+			message(STATUS "Setting Qt version to Qt ${QT_VERSION}")
+        elseif(${MAYA_APP_VERSION} STRLESS_EQUAL "2019")
             set(QT_VERSION "5.6")
-        else()
-            set(QT_VERSION "5.12")
+			message(STATUS "Setting Qt version to Qt ${QT_VERSION}")
+		elseif(${MAYA_APP_VERSION} STRLESS_EQUAL "2020")
+			set(QT_VERSION "5.12")
+			message(STATUS "Setting Qt version to Qt ${QT_VERSION}")
+        else() # 2022, 2023, 2024
+            set(QT_VERSION "5.15")
+			message(STATUS "Setting Qt version to Qt ${QT_VERSION}")
         endif()
     endif()
     set(CMAKE_PREFIX_PATH "${QT_LOCATION}")
-    find_package(Qt5 ${QT_VERSION} COMPONENTS Core Gui Widgets REQUIRED)
-    if(Qt5_FOUND)
-        message(STATUS "Building with Qt features enabled.")
-    endif()
+	if(BUILD_WITH_QT_6)
+		find_package(Qt6 ${QT_VERSION} COMPONENTS Core Gui Widgets REQUIRED)
+		if(Qt6_FOUND)
+			message(STATUS "Building with Qt ${QT_VERSION} features enabled.")
+		endif()
+	else()
+		find_package(Qt5 ${QT_VERSION} COMPONENTS Core Gui Widgets REQUIRED)
+		if(Qt5_FOUND)
+			message(STATUS "Building with Qt ${QT_VERSION} features enabled.")
+		endif()
+	endif()
 else()
     message(STATUS "QT_LOCATION not set. Building Qt features will be disabled.")
 endif()

--- a/lib/mayaUsd/CMakeLists.txt
+++ b/lib/mayaUsd/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Autodesk
+# Copyright 2023 Autodesk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ target_compile_definitions(${PROJECT_NAME}
         $<$<BOOL:${IS_LINUX}>:GL_GLEXT_PROTOTYPES>
         $<$<BOOL:${IS_LINUX}>:GLX_GLXEXT_PROTOTYPES>
         $<$<BOOL:${CMAKE_WANT_MATERIALX_BUILD}>:WANT_MATERIALX_BUILD>
-        $<$<BOOL:${Qt5_FOUND}>:WANT_QT_BUILD>
+		$<$<OR:$<BOOL:${Qt5_FOUND}>,$<BOOL:${Qt6_FOUND}>>:WANT_QT_BUILD>
         $<$<BOOL:${BUILD_HDMAYA}>:BUILD_HDMAYA>
 
         # this flag is needed when building maya-usd in Maya

--- a/lib/usd/CMakeLists.txt
+++ b/lib/usd/CMakeLists.txt
@@ -1,3 +1,18 @@
+#
+# Copyright 2023 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 if(BUILD_HDMAYA)
     add_subdirectory(hdMaya)
 endif()
@@ -8,7 +23,7 @@ add_subdirectory(schemas)
 
 add_subdirectory(utils)
 
-if(Qt5_FOUND)
+if(Qt5_FOUND OR Qt6_FOUND)
     add_subdirectory(ui)
 endif()
 

--- a/lib/usd/ui/CMakeLists.txt
+++ b/lib/usd/ui/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Autodesk
+# Copyright 2023 Autodesk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,7 +47,11 @@ target_compile_definitions(${PROJECT_NAME}
 
 # QT_NO_KEYWORDS prevents Qt from defining the foreach, signals, slots and emit macros.
 # this avoids overlap between Qt macros and boost, and enforces using Q_ macros.
-set_target_properties(Qt5::Core PROPERTIES INTERFACE_COMPILE_DEFINITIONS QT_NO_KEYWORDS)
+if (Qt6_FOUND)
+	set_target_properties(Qt6::Core PROPERTIES INTERFACE_COMPILE_DEFINITIONS QT_NO_KEYWORDS)
+else()
+	set_target_properties(Qt5::Core PROPERTIES INTERFACE_COMPILE_DEFINITIONS QT_NO_KEYWORDS)
+endif()
 
 mayaUsd_compile_config(${PROJECT_NAME})
 
@@ -58,9 +62,9 @@ target_link_libraries(${PROJECT_NAME}
     PUBLIC
         mayaUsd
     PRIVATE
-        Qt5::Core
-        Qt5::Gui
-        Qt5::Widgets
+		$<IF:$<BOOL:${Qt6_FOUND}>,Qt6::Core,Qt5::Core>
+		$<IF:$<BOOL:${Qt6_FOUND}>,Qt6::Gui,Qt5::Gui>
+		$<IF:$<BOOL:${Qt6_FOUND}>,Qt6::Widgets,Qt5::Widgets>
 )
 
 # -----------------------------------------------------------------------------

--- a/lib/usd/ui/importDialog/ItemDelegate.cpp
+++ b/lib/usd/ui/importDialog/ItemDelegate.cpp
@@ -252,7 +252,13 @@ QLayout* VariantsEditorWidget::createVariantSet(
     QComboBox* cb = new QComboBox;
 
     ItemDelegate* id = const_cast<ItemDelegate*>(itemDelegate);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    connect(
+        cb,
+        static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::textActivated),
+        id,
+        [this, id] { id->commitVariantSelection(this); });
+#elif QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
     connect(cb, QOverload<const QString&>::of(&QComboBox::activated), id, [this, id] {
         id->commitVariantSelection(this);
     });

--- a/lib/usd/ui/importDialog/TreeModel.cpp
+++ b/lib/usd/ui/importDialog/TreeModel.cpp
@@ -118,7 +118,7 @@ QVariant TreeModel::data(const QModelIndex& index, int role /*= Qt::DisplayRole*
 Qt::ItemFlags TreeModel::flags(const QModelIndex& index) const
 {
     if (!index.isValid())
-        return 0;
+        return static_cast<Qt::ItemFlags>(0);
 
     // The base class implementation returns a combination of flags that enables
     // the item (ItemIsEnabled) and allows it to be selected (ItemIsSelectable).

--- a/lib/usd/ui/importDialog/USDImportDialog.cpp
+++ b/lib/usd/ui/importDialog/USDImportDialog.cpp
@@ -54,8 +54,13 @@ USDImportDialog::USDImportDialog(
         fRootPrimPath = importData->rootPrimPath();
         matchingImportData = importData;
     }
-
+    
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    int minW = fUI->nbPrimsInScopeLabel->fontMetrics().horizontalAdvance("12345");
+#else
     int minW = fUI->nbPrimsInScopeLabel->fontMetrics().width("12345");
+#endif
+
     fUI->nbPrimsInScopeLabel->setMinimumWidth(minW);
     fUI->nbVariantsChangedLabel->setMinimumWidth(minW);
 

--- a/lib/usd/ui/importDialogDemo/CMakeLists.txt
+++ b/lib/usd/ui/importDialogDemo/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Autodesk
+# Copyright 2023 Autodesk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,9 +40,9 @@ mayaUsd_compile_config(${PROJECT_NAME})
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
         mayaUsdUI
-        Qt5::Core
-        Qt5::Gui
-        Qt5::Widgets
+		$<IF:$<BOOL:${Qt6_FOUND}>,Qt6::Core,Qt5::Core>
+		$<IF:$<BOOL:${Qt6_FOUND}>,Qt6::Gui,Qt5::Gui>
+		$<IF:$<BOOL:${Qt6_FOUND}>,Qt6::Widgets,Qt5::Widgets>
 )
 
 if (IS_LINUX)

--- a/lib/usd/ui/layerEditor/layerEditorWidget.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.cpp
@@ -31,7 +31,13 @@
 
 #include <QtCore/QItemSelectionModel>
 #include <QtCore/QTimer>
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QActionGroup>
+#else
 #include <QtWidgets/QActionGroup>
+#endif
+
 #include <QtWidgets/QGraphicsOpacityEffect>
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QMainWindow>

--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -191,9 +191,13 @@ void LayerTreeItem::fetchData(RebuildChildren in_rebuild, RecursionDetector* in_
 QVariant LayerTreeItem::data(int role) const
 {
     switch (role) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    case Qt::ForegroundRole: return QColor(200, 200, 200);
+#else
     case Qt::TextColorRole: return QColor(200, 200, 200);
+#endif
     case Qt::BackgroundRole: return QColor(71, 71, 71);
-    case Qt::TextAlignmentRole: return Qt::AlignLeft + Qt::AlignVCenter;
+    case Qt::TextAlignmentRole: return (static_cast<int>(Qt::AlignLeft) + static_cast<int>(Qt::AlignVCenter));
     case Qt::SizeHintRole: return QSize(0, DPIScale(30));
     default: return QStandardItem::data(role);
     }

--- a/lib/usd/ui/layerEditor/layerTreeItemDelegate.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItemDelegate.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Autodesk
+// Copyright 2023 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -164,7 +164,11 @@ void LayerTreeItemDelegate::paint_drawArrow(QPainter* painter, QRectC rect, Item
 void LayerTreeItemDelegate::paint_drawText(QPainter* painter, QRectC rect, Item item) const
 {
     const auto oldPen = painter->pen();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    painter->setPen(QPen(item->data(Qt::ForegroundRole).value<QColor>(), 1));
+#else
     painter->setPen(QPen(item->data(Qt::TextColorRole).value<QColor>(), 1));
+#endif
     const auto textRect = getTextRect(rect);
     bool       muted = item->appearsMuted();
     bool       readOnly = item->isReadOnly();

--- a/lib/usd/ui/layerEditor/layerTreeViewStyle.h
+++ b/lib/usd/ui/layerEditor/layerTreeViewStyle.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Autodesk
+// Copyright 2023 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -157,7 +157,11 @@ protected:
         const override
     {
         if (hint == QStyle::SH_Slider_AbsoluteSetButtons) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            return Qt::LeftButton | Qt::MiddleButton | Qt::RightButton;
+#else
             return Qt::LeftButton | Qt::MidButton | Qt::RightButton;
+#endif
         } else if (hint == QStyle::SH_ItemView_ShowDecorationSelected) {
             return 0;
         } else {

--- a/plugin/adsk/plugin/CMakeLists.txt
+++ b/plugin/adsk/plugin/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Autodesk
+# Copyright 2023 Autodesk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ endif()
 target_compile_definitions(${TARGET_NAME}
     PRIVATE
         MAYAUSD_PLUGIN_EXPORT
-        $<$<BOOL:${Qt5_FOUND}>:WANT_QT_BUILD>
+        $<$<OR:$<BOOL:${Qt5_FOUND}>,$<BOOL:${Qt6_FOUND}>>:WANT_QT_BUILD>
 )
 
 if(DEFINED MAYAUSD_VERSION)
@@ -77,7 +77,7 @@ target_link_libraries(${TARGET_NAME}
         basePxrUsdPreviewSurface
 )
 
-if (${Qt5_FOUND})
+if (Qt5_FOUND OR Qt6_FOUND)
     target_link_libraries(${TARGET_NAME}
         PRIVATE
             mayaUsdUI

--- a/plugin/pxr/maya/lib/usdMaya/userExportedAttributesUI.py
+++ b/plugin/pxr/maya/lib/usdMaya/userExportedAttributesUI.py
@@ -21,27 +21,32 @@ from maya import OpenMaya as OM
 from maya import cmds
 from maya.app.general import mayaMixin
 
-from PySide2 import QtCore
+try:
+    from PySide2 import QtCore
+except:
+    from PySide6 import QtCore
+
 try:
     # Maya 2020 and later use Qt/PySide2 5.12.5, where QStringListModel is
     # exported with QtCore, which is also where it lives in C++.
-    from PySide2.QtCore import QStringListModel
+    try:
+        from PySide2.QtCore import QStringListModel
+    except:
+        from PySide6.QtCore import QStringListModel
 except ImportError:
     # Maya 2019 and earlier use Qt 5.6.1 and PySide2 2.0.0-alpha, where
     # QStringListModel was incorrectly exported with QtGui.
     # See this bug for more detail:
     # https://bugreports.qt.io/browse/PYSIDE-614
-    from PySide2.QtGui import QStringListModel
-from PySide2.QtWidgets import QAbstractItemView
-from PySide2.QtWidgets import QCheckBox
-from PySide2.QtWidgets import QComboBox
-from PySide2.QtWidgets import QLabel
-from PySide2.QtWidgets import QListView
-from PySide2.QtWidgets import QPushButton
-from PySide2.QtWidgets import QStyledItemDelegate
-from PySide2.QtWidgets import QTableView
-from PySide2.QtWidgets import QVBoxLayout
-from PySide2.QtWidgets import QWidget
+    try:
+        from PySide2.QtGui import QStringListModel
+    except:
+        from PySide6.QtGui import QStringListModel
+
+try:
+    from PySide2.QtGui import QAbstractItemView, QCheckBox, QComboBox, QLabel, QListView, QPushButton, QStyledItemDelegate, QTableView, QVBoxLayout, QWidget
+except:
+    from PySide6.QtGui import QAbstractItemView, QCheckBox, QComboBox, QLabel, QListView, QPushButton, QStyledItemDelegate, QTableView, QVBoxLayout, QWidget
 
 import json
 

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeLiveSurface.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeLiveSurface.py
@@ -20,11 +20,16 @@ from pxr import Gf
 from maya import OpenMayaUI as OMUI
 from maya import cmds
 
-from PySide2 import QtCore
-from PySide2.QtTest import QTest
-from PySide2.QtWidgets import QWidget
-
-from shiboken2 import wrapInstance
+try:
+    from PySide2 import QtCore
+    from PySide2.QtTest import QTest
+    from PySide2.QtWidgets import QWidget
+    from shiboken2 import wrapInstance
+except:
+    from PySide6 import QtCore
+    from PySide6.QtTest import QTest
+    from PySide6.QtWidgets import QWidget
+    from shiboken6 import wrapInstance
 
 import os
 import sys

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeSelectionPerformance.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeSelectionPerformance.py
@@ -26,12 +26,18 @@ from maya.api import OpenMayaUI as OMUI
 
 import ufe
 
-from PySide2 import QtCore
-from PySide2.QtTest import QTest
-from PySide2.QtWidgets import QApplication
-from PySide2.QtWidgets import QWidget
-
-from shiboken2 import wrapInstance
+try:
+    from PySide2 import QtCore
+    from PySide2.QtTest import QTest
+    from PySide2.QtWidgets import QApplication
+    from PySide2.QtWidgets import QWidget
+    from shiboken2 import wrapInstance
+except:
+    from PySide6 import QtCore
+    from PySide6.QtTest import QTest
+    from PySide6.QtWidgets import QApplication
+    from PySide6.QtWidgets import QWidget
+    from shiboken6 import wrapInstance
 
 import contextlib
 import json

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegatePointInstancesPickMode.py
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegatePointInstancesPickMode.py
@@ -28,11 +28,16 @@ from maya.api import OpenMayaUI as OMUI
 
 import ufe
 
-from PySide2 import QtCore
-from PySide2.QtTest import QTest
-from PySide2.QtWidgets import QWidget
-
-from shiboken2 import wrapInstance
+try:
+    from PySide2 import QtCore
+    from PySide2.QtTest import QTest
+    from PySide2.QtWidgets import QWidget
+    from shiboken2 import wrapInstance
+except:
+    from PySide6 import QtCore
+    from PySide6.QtTest import QTest
+    from PySide6.QtWidgets import QWidget
+    from shiboken6 import wrapInstance
 
 import os
 

--- a/test/lib/mayaUsd/utils/testUtilsSelectability.py
+++ b/test/lib/mayaUsd/utils/testUtilsSelectability.py
@@ -31,11 +31,16 @@ import ufe
 import mayaUsd.ufe
 import mayaUsd.lib 
 
-from PySide2 import QtCore
-from PySide2.QtTest import QTest
-from PySide2.QtWidgets import QWidget
-
-from shiboken2 import wrapInstance
+try:
+    from PySide2 import QtCore
+    from PySide2.QtTest import QTest
+    from PySide2.QtWidgets import QWidget
+    from shiboken2 import wrapInstance
+except:
+    from PySide6 import QtCore
+    from PySide6.QtTest import QTest
+    from PySide6.QtWidgets import QWidget
+    from shiboken6 import wrapInstance
 
 class testUtilsSelectability(unittest.TestCase):
     """

--- a/test/lib/mayaUsd/utils/testUtilsSelectabilityPointInstanceSelection.py
+++ b/test/lib/mayaUsd/utils/testUtilsSelectabilityPointInstanceSelection.py
@@ -32,11 +32,16 @@ import ufe
 import os
 import unittest
 
-from PySide2 import QtCore
-from PySide2.QtTest import QTest
-from PySide2.QtWidgets import QWidget
-
-from shiboken2 import wrapInstance
+try:
+    from PySide2 import QtCore
+    from PySide2.QtTest import QTest
+    from PySide2.QtWidgets import QWidget
+    from shiboken2 import wrapInstance
+except:
+    from PySide6 import QtCore
+    from PySide6.QtTest import QTest
+    from PySide6.QtWidgets import QWidget
+    from shiboken6 import wrapInstance
 
 class testUtilsSelectabilityPointInstanceSelection(unittest.TestCase):
     """

--- a/test/lib/ufe/testUIIcons.py
+++ b/test/lib/ufe/testUIIcons.py
@@ -26,8 +26,12 @@ import ufe
 import mayaUsd
 from pxr import Usd, Tf
 
-from shiboken2 import wrapInstance
-from PySide2.QtGui import QIcon
+try:
+    from shiboken2 import wrapInstance
+    from PySide2.QtGui import QIcon
+except:
+    from shiboken6 import wrapInstance
+    from PySide6.QtGui import QIcon
 
 class UIIconsTestCase(unittest.TestCase):
     """

--- a/test/testUtils/imageUtils.py
+++ b/test/testUtils/imageUtils.py
@@ -129,10 +129,13 @@ def imageDiff(imagePath1, imagePath2):
 
     # We use QImage because we know we should have access to
     # it in maya...
-    import PySide2.QtGui
+    try:
+        from PySide2.QtGui import QImage
+    except:
+        from PySide6.QtGui import QImage
 
     def loadImage(imagePath):
-        img = PySide2.QtGui.QImage()
+        img = QImage()
         if not img.load(imagePath):
             raise ValueError("unable to load image: {}".format(imagePath))
         return img


### PR DESCRIPTION
MAYA-128960
Updates the build system as well as some python and cpp code to support Qt 6.5.

This works by setting the build parameter 

> BUILD_WITH_QT_6=ON