### PR TITLE
LOOKDEVX-1429 - Mark USD and MayaUSD Python bindings as safe

### DIFF
--- a/modules/mayaUSD.mod.template
+++ b/modules/mayaUSD.mod.template
@@ -2,7 +2,7 @@
 icons: 
 plug-ins: 
 presets: 
-scripts: 
+scripts: lib/python
 resources: 
 PYTHONPATH+:=lib/python
 USD_LOCATION:=
@@ -13,7 +13,7 @@ PXR_MTLX_STDLIB_SEARCH_PATHS+:=libraries
 icons: lib/icons
 plug-ins: 
 presets: 
-scripts: lib/scripts
+scripts: lib/scripts:lib/python
 resources: 
 PYTHONPATH+:=lib/python
 ${PXR_OVERRIDE_PLUGINPATH_NAME}+:=lib/usd

--- a/modules/mayaUSD_Win.mod.template
+++ b/modules/mayaUSD_Win.mod.template
@@ -2,7 +2,7 @@
 icons: 
 plug-ins: 
 presets: 
-scripts: 
+scripts: lib/python
 resources: 
 PYTHONPATH+:=lib/python
 PATH+:=bin
@@ -19,7 +19,7 @@ PXR_MTLX_STDLIB_SEARCH_PATHS+:=libraries
 icons: lib/icons
 plug-ins: 
 presets: 
-scripts: lib/scripts
+scripts: lib/scripts;lib/python
 resources: 
 PATH+:=lib
 PXR_USD_WINDOWS_DLL_PATH+:=lib

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -47,6 +47,14 @@ foreach(script ${INTERACTIVE_TEST_SCRIPT_FILES})
     set_property(TEST ${target} APPEND PROPERTY LABELS MayaUsd)
 endforeach()
 
+# The testMayaUsdPythonImport now checks that we can import both the USD Python bindings
+# and the MayaUSD Python bindings in a script node context. For this to be tested, we
+# need to point to the updated module file and explicitly ask Maya to block execution of
+# insecure scripts.
+mayaUsd_get_unittest_target(target testMayaUsdPythonImport.py)
+set_property(TEST ${target} APPEND PROPERTY ENVIRONMENT "MAYA_MODULE_PATH=${CMAKE_INSTALL_PREFIX}")
+set_property(TEST ${target} APPEND PROPERTY ENVIRONMENT "MAYA_SECURE_BATCH_ENABLE=1")
+
 #
 # -----------------------------------------------------------------------------
 # Special interactive test to be able to start Maya with test configurations.


### PR DESCRIPTION
This allows importing USD and MayaUSD modules in script nodes. Either directly, or from surprisingly deep in the C++ callstack as USD can call Python to read shader definitions via code found in the pxr.SdrGlslfx module.