### PR TITLE
Deprecate use of TF_REFPTR_CONST_VOLATILE_GET

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/wrapTranslatorBase.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/wrapTranslatorBase.cpp
@@ -25,6 +25,7 @@
 #include <pxr/base/tf/pyPtrHelpers.h>
 #include <pxr/base/tf/pyResultConversions.h>
 #include <pxr/base/tf/refPtr.h>
+#include <pxr/pxr.h>
 
 #include <maya/MBoundingBox.h>
 #include <maya/MDGModifier.h>
@@ -378,5 +379,9 @@ void wrapTranslatorBase()
     MStatusFromPythonBool::Register();
 }
 
+// This macro was removed in USD 23.08. It was only needed to support
+// Visual Studio 2015, which USD itself no longer supports.
+#if PXR_VERSION < 2308
 TF_REFPTR_CONST_VOLATILE_GET(TranslatorBaseWrapper)
 TF_REFPTR_CONST_VOLATILE_GET(TranslatorBase)
+#endif

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/wrapTranslatorContext.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/wrapTranslatorContext.cpp
@@ -19,6 +19,7 @@
 
 #include <pxr/base/tf/makePyConstructor.h>
 #include <pxr/base/tf/pyPtrHelpers.h>
+#include <pxr/pxr.h>
 
 #include <maya/MFnDagNode.h>
 #include <maya/MFnDependencyNode.h>
@@ -163,4 +164,8 @@ void wrapTranslatorContext()
         .def("insertItem", &_insertItem);
 }
 
+// This macro was removed in USD 23.08. It was only needed to support
+// Visual Studio 2015, which USD itself no longer supports.
+#if PXR_VERSION < 2308
 TF_REFPTR_CONST_VOLATILE_GET(TranslatorContext)
+#endif

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/wrapLayerManager.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/wrapLayerManager.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include <pxr/base/tf/refPtr.h>
+#include <pxr/pxr.h>
 
 #include <maya/MStringArray.h>
 
@@ -102,4 +103,8 @@ void wrapLayerManager()
         .def("getLayerIdentifiers", PyLayerManager::getLayerIdentifiers);
 }
 
+// This macro was removed in USD 23.08. It was only needed to support
+// Visual Studio 2015, which USD itself no longer supports.
+#if PXR_VERSION < 2308
 TF_REFPTR_CONST_VOLATILE_GET(LayerManager)
+#endif

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/wrapProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/wrapProxyShape.cpp
@@ -486,6 +486,11 @@ void wrapProxyShape()
 // The best place to put this fix would be in pxr/base/lib/tf/refPtr.h
 // where TF_REFPTR_CONST_VOLATILE_GET is defined, but for now we are
 // patching it locally.
+//
+// This macro was removed in USD 23.08. It was only needed to support
+// Visual Studio 2015, which USD itself no longer supports.
+#if PXR_VERSION < 2308
 #if defined(ARCH_COMPILER_MSVC) && ARCH_COMPILER_MSVC_VERSION <= 1910
 TF_REFPTR_CONST_VOLATILE_GET(ProxyShape)
+#endif
 #endif


### PR DESCRIPTION
This macro will be removed in USD 23.08. It was only needed to workaround a bug in Visual Studio 2015, which USD no longer supports as of 22.08.