### PR TITLE
MAYA-129309 fixing saving the pinned stage

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -550,7 +550,15 @@ void LayerDatabase::refreshProxiesToSave()
     }
 }
 
-void LayerDatabase::setSelectedStage(const std::string& stage) { _selectedStage = stage; }
+void LayerDatabase::setSelectedStage(const std::string& stage)
+{
+    if (_selectedStage == stage)
+        return;
+
+    _selectedStage = stage;
+    // Mark the scene as modified.
+    MGlobal::executeCommand("file -modified 1");
+}
 
 std::string LayerDatabase::getSelectedStage() const { return _selectedStage; }
 

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
@@ -108,7 +108,7 @@ MayaLayerEditorWindow::MayaLayerEditorWindow(const char* panelName, QWidget* par
         &MayaLayerEditorWindow::onClearUIOnSceneReset);
 }
 
-MayaLayerEditorWindow::~MayaLayerEditorWindow() { _sessionState.unregisterNotifications(); }
+MayaLayerEditorWindow::~MayaLayerEditorWindow() { }
 
 void MayaLayerEditorWindow::onClearUIOnSceneReset()
 {
@@ -116,7 +116,6 @@ void MayaLayerEditorWindow::onClearUIOnSceneReset()
     // safer to delete the entire UI and re-recreate it on scene changes
     // to release all the proxies
     LayerTreeModel::suspendUsdNotices(true);
-    _sessionState.unregisterNotifications();
     setCentralWidget(nullptr);
     delete _layerEditor;
 
@@ -129,7 +128,6 @@ void MayaLayerEditorWindow::onCreateUI()
     _layerEditor = new LayerEditorWidget(_sessionState, this);
     setCentralWidget(_layerEditor);
     _layerEditor->show();
-    _sessionState.registerNotifications();
 
     connect(
         treeView(),

--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -56,11 +56,17 @@ MayaSessionState::MayaSessionState()
     if (MGlobal::optionVarExists(AUTO_HIDE_OPTION_VAR)) {
         _autoHideSessionLayer = MGlobal::optionVarIntValue(AUTO_HIDE_OPTION_VAR) != 0;
     }
+
+    registerNotifications();
 }
 
 MayaSessionState::~MayaSessionState()
 {
-    //
+    try {
+        unregisterNotifications();
+    } catch (const std::exception&) {
+        // Ignore errors in destructor.
+    }
 }
 
 void MayaSessionState::setStageEntry(StageEntry const& inEntry)

--- a/lib/usd/ui/layerEditor/mayaSessionState.h
+++ b/lib/usd/ui/layerEditor/mayaSessionState.h
@@ -78,13 +78,13 @@ Q_SIGNALS:
     void clearUIOnSceneResetSignal();
 
 public:
-    void registerNotifications();
-    void unregisterNotifications();
-
     // get the stage and proxy name for a path
     static bool getStageEntry(StageEntry* out_stageEntry, const MString& shapePath);
 
 protected:
+    void registerNotifications();
+    void unregisterNotifications();
+
     // maya callback handers
     static void proxyShapeAddedCB(MObject& node, void* clientData);
     static void proxyShapeRemovedCB(MObject& node, void* clientData);


### PR DESCRIPTION
- Make the Maya session state resgister and unreguster its Maya notification on creation and deletion.
- No longer de-regiuster the notifictions whne the layer manager window is created or closed.
- That was causing the session state to not save the pinned stage because the layer manager would get destroyed before the pinned stage was saved and the notifications would no longer be received.
- When switching pinned stage, mark the Maya scene as dirty.