### PR TITLE
MAYA-128462 relative path error fix

### DIFF
--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -398,11 +398,13 @@ void updateSubLayer(
     subLayers.Replace(oldSubLayer->GetIdentifier(), newSubLayerPath);
 
     const std::string oldAbsPath = oldSubLayer->GetRealPath();
-    subLayers.Replace(oldAbsPath, newSubLayerPath);
+    if (oldAbsPath.length() > 0) {
+        subLayers.Replace(oldAbsPath, newSubLayerPath);
 
-    const std::string oldRelPath
-        = UsdMayaUtilFileSystem::getPathRelativeToLayerFile(oldAbsPath, parentLayer);
-    subLayers.Replace(oldRelPath, newSubLayerPath);
+        const std::string oldRelPath
+            = UsdMayaUtilFileSystem::getPathRelativeToLayerFile(oldAbsPath, parentLayer);
+        subLayers.Replace(oldRelPath, newSubLayerPath);
+    }
 }
 
 void ensureUSDFileExtension(std::string& filePath)


### PR DESCRIPTION
Fix unnecessary error when saving a relative path: the path was empty, an empty path cannot be made relative.