### PR TITLE
MAYA-129682 - Move `isMaterialsScope()` into Utils.

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
@@ -88,37 +88,6 @@ bool connectShaderToMaterial(
     return true;
 }
 
-//! Returns true if \p item is a materials scope.
-bool isMaterialsScope(const Ufe::SceneItem::Ptr& item)
-{
-    if (!item) {
-        return false;
-    }
-
-    // Must be a scope.
-    if (item->nodeType() != "Scope") {
-        return false;
-    }
-
-    // With the magic name.
-    if (item->nodeName() == UsdMayaJobExportArgs::GetDefaultMaterialsScopeName()) {
-        return true;
-    }
-
-    // Or with only materials inside
-    auto scopeHierarchy = Ufe::Hierarchy::hierarchy(item);
-    if (scopeHierarchy) {
-        for (auto&& child : scopeHierarchy->children()) {
-            if (child->nodeType() != "Material") {
-                // At least one non material
-                return false;
-            }
-        }
-    }
-
-    return true;
-}
-
 //! Searches the children of \p parentPath for a materials scope. Returns a null pointer if no
 //! materials scope is found.
 Ufe::SceneItem::Ptr getMaterialsScope(const Ufe::Path& parentPath)

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -15,6 +15,7 @@
 //
 #include "Utils.h"
 
+#include <mayaUsd/fileio/jobs/jobArgs.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/ufe/Global.h>
 #include <mayaUsd/ufe/ProxyShapeHandler.h>
@@ -213,6 +214,36 @@ bool isAGatewayType(const std::string& mayaNodeType)
         g_GatewayType[mayaNodeType] = isInherited;
     }
     return isInherited;
+}
+
+bool isMaterialsScope(const Ufe::SceneItem::Ptr& item)
+{
+    if (!item) {
+        return false;
+    }
+
+    // Must be a scope.
+    if (item->nodeType() != "Scope") {
+        return false;
+    }
+
+    // With the magic name.
+    if (item->nodeName() == UsdMayaJobExportArgs::GetDefaultMaterialsScopeName()) {
+        return true;
+    }
+
+    // Or with only materials inside
+    auto scopeHierarchy = Ufe::Hierarchy::hierarchy(item);
+    if (scopeHierarchy) {
+        for (auto&& child : scopeHierarchy->children()) {
+            if (child->nodeType() != "Material") {
+                // At least one non material
+                return false;
+            }
+        }
+    }
+
+    return true;
 }
 
 Ufe::Path dagPathToUfe(const MDagPath& dagPath)

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -104,6 +104,10 @@ inline std::string uniqueChildName(const PXR_NS::UsdPrim& parent, const std::str
 MAYAUSD_CORE_PUBLIC
 bool isAGatewayType(const std::string& mayaNodeType);
 
+//! Returns true if \p item is a materials scope.
+MAYAUSD_CORE_PUBLIC
+bool isMaterialsScope(const Ufe::SceneItem::Ptr& item);
+
 MAYAUSD_CORE_PUBLIC
 Ufe::Path dagPathToUfe(const MDagPath& dagPath);
 


### PR DESCRIPTION
Move `isMaterialsScope()` to a shared location, so that it can be reused by LookdevX.