### PR TITLE
MAYA-128907 fix layer parenting of relative layers

### DIFF
--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -330,6 +330,9 @@ SdfLayerRefPtr saveAnonymousLayer(
     LayerParent     parent,
     std::string     formatArg)
 {
+    // TODO: the code below is very similar to LayerTreeItem::saveAnonymousLayer().
+    //       When fixing bug here or there, we need to fix it in the other. Refactor to have a single copy.
+
     if (!anonLayer || !anonLayer->IsAnonymous()) {
         return nullptr;
     }
@@ -361,13 +364,15 @@ SdfLayerRefPtr saveAnonymousLayer(
         }
     }
 
-    // When the filePath was made relative, we need to help FindOrOpen to locate
-    //      the sub-layers when using relative paths. We temporarily chande the
-    //      current directory to the location the file path is relative to.
-    UsdMayaUtilFileSystem::TemporaryCurrentDir tempCurDir(relativePathAnchor);
-    SdfLayerRefPtr                             newLayer = SdfLayer::FindOrOpen(filePath);
-    tempCurDir.restore();
+    // Note: we need to open the layer with the absolute path. The relative path is only
+    //       used by the parent layer to refer to the sub-layer relative to itself. When
+    //       opening the layer in isolation, we need to use the absolute path. Failure to
+    //       do so will make finding the layer by its own identifier fail! A symptom of
+    //       this failure is that drag-and-drop in the Layer Manager UI fails immediately
+    //       after saving a lyer with relative paths.
+    SdfLayerRefPtr newLayer = SdfLayer::FindOrOpen(pathInfo.absolutePath);
 
+    // Now replace the layer in the parent, using a relative path if requested.
     if (newLayer) {
         if (isSubLayer) {
             updateSubLayer(parent._layerParent, anonLayer, filePath);

--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -364,6 +364,9 @@ void LayerTreeItem::saveEditsNoPrompt()
 // helper to save anon layers called by saveEdits()
 void LayerTreeItem::saveAnonymousLayer()
 {
+    // TODO: the code below is very similar to mayaUsd::utils::saveAnonymousLayer().
+    //       When fixing bug here or there, we need to fix it in the other. Refactor to have a single copy.
+
     auto sessionState = parentModel()->sessionState();
 
     std::string fileName;
@@ -375,6 +378,8 @@ void LayerTreeItem::saveAnonymousLayer()
         const QString dialogTitle = StringResources::getAsQString(StringResources::kSaveLayer);
         std::string   formatTag = MayaUsd::utils::usdFormatArgOption();
         if (saveSubLayer(dialogTitle, parentLayerItem(), layer(), fileName, formatTag)) {
+
+            const std::string absoluteFileName = fileName;
 
             // now replace the layer in the parent
             if (isRootLayer()) {
@@ -393,15 +398,15 @@ void LayerTreeItem::saveAnonymousLayer()
                         = UsdMayaUtilFileSystem::getLayerFileDir(parentItem->layer());
                 }
 
-                // Now replace the layer in the parent
-                //
-                // When the filePath was made relative, we need to help FindOrOpen to locate
-                //      the sub-layers when using relative paths. We temporarily chande the
-                //      current directory to the location the file path is relative to.
-                UsdMayaUtilFileSystem::TemporaryCurrentDir tempCurDir(relativePathAnchor);
-                auto newLayer = SdfLayer::FindOrOpen(fileName);
-                tempCurDir.restore();
+                // Note: we need to open the layer with the absolute path. The relative path is only
+                //       used by the parent layer to refer to the sub-layer relative to itself. When
+                //       opening the layer in isolation, we need to use the absolute path. Failure
+                //       to do so will make finding the layer by its own identifier fail! A symptom
+                //       of this failure is that drag-and-drop in the Layer Manager UI fails
+                //       immediately after saving a lyer with relative paths.
+                SdfLayerRefPtr newLayer = SdfLayer::FindOrOpen(absoluteFileName);
 
+                // Now replace the layer in the parent, using a relative path if requested.
                 if (newLayer) {
                     bool setTarget = _isTargetLayer;
                     auto model = parentModel();


### PR DESCRIPTION
When a layers is saved as relative to its parent just before tryign to reparenting it to anotehr layer, the parenting would fail. That was because the layer identifier use inside the layer itself was relative, which prevented finding the layer afterward.

The problem goes away when the stage is reloaded because when loading relative layers, it correctly set the lauer identifier to its absolute path.

Fix the problem for recently-saved layers by making sure its identifier uses the absolute path, not the relative path.