### PR TITLE
MAYA-126887 fix context menu when in a set

### DIFF
--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -582,6 +582,11 @@ proc string getPulledUsdObject(string $dagObject) {
         if (size(`ls -set $dagObject`) > 0) {
             string $selection[] = `ls -sl`;
             $dagObject = $selection[0];
+            // If there is no selection, try to fetch the item under the mouse in the outliner editor
+            if (size($dagObject) == 0 || size(`ls -set $dagObject`) > 0) {
+                string $outliner = `getPanel -underPointer`;
+                $dagObject = `outlinerEditor -query -feedbackItemName $outliner`;
+            }
         }
         if (size(`ls -dagObjects $dagObject`) > 0) {
             for (;;) {


### PR DESCRIPTION
When calling the context menu and the mouse is over an object in a set, Maya returns the set instead of the object. Fix this by finding what is under the mouse in the outliner.