### PR TITLE
Add options to UsdExport in new test

### DIFF
--- a/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
+++ b/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
@@ -473,13 +473,15 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
                 file=usd_path,
                 shadingMode='useRegistry',
                 exportDisplayColor=False,
-                exportCollectionBasedBindings=True)
+                exportCollectionBasedBindings=True,
+                exportComponentTags=True)
         else:
             usd_path = os.path.abspath('CubeWithAssignedFaces.usda')
             cmds.usdExport(mergeTransformAndShape=True,
                 file=usd_path,
                 shadingMode='useRegistry',
-                exportDisplayColor=False)
+                exportDisplayColor=False,
+                exportComponentTags=True)
 
         stage = Usd.Stage.Open(usd_path)
 
@@ -647,13 +649,15 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
                 file=reexported_usd_path,
                 shadingMode='useRegistry',
                 exportDisplayColor=False,
-                exportCollectionBasedBindings=True)
+                exportCollectionBasedBindings=True,
+                exportComponentTags=True)
         else:
             reexported_usd_path = os.path.abspath('CubeWithAssignedFaces_reexported.usda')
             cmds.usdExport(mergeTransformAndShape=True,
                 file=reexported_usd_path,
                 shadingMode='useRegistry',
-                exportDisplayColor=False)
+                exportDisplayColor=False,
+                exportComponentTags=True)
         
         stage = Usd.Stage.Open(reexported_usd_path)
 


### PR DESCRIPTION
This test was failing due to our usd export configuration. This change adds the explicit option that was needed to ensure the expected result was produced.