### PR TITLE
MAYA-129259 - MayaUsd: drop support for Maya 2018/2019/2020 and Qt 5.6.1 & 5.12.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,6 @@ option(BUILD_MAYAUSD_LIBRARY "Build Core USD libraries." ON)
 option(BUILD_ADSK_PLUGIN "Build Autodesk USD plugin." ON)
 option(BUILD_PXR_PLUGIN "Build the Pixar USD plugin and libraries." ON)
 option(BUILD_AL_PLUGIN "Build the Animal Logic USD plugin and libraries." ON)
-# Default value made dependent on maya + usd version - see below
-#   Convert back to a normal option if we no longer support maya-2019, or
-#   no longer support USD-20.11
 option(BUILD_HDMAYA "Build the legacy Maya-To-Hydra plugin and scene delegate." OFF)
 option(BUILD_RFM_TRANSLATORS "Build translators for RenderMan for Maya shaders." ON)
 option(BUILD_TESTS "Build tests." ON)
@@ -86,7 +83,7 @@ endif()
 #------------------------------------------------------------------------------
 include(cmake/utils.cmake)
 if (BUILD_MAYAUSD_LIBRARY)
-    find_package(Maya 2018 REQUIRED)
+    find_package(Maya 2022 REQUIRED)
 endif()
 
 if(APPLE AND BUILD_UB2 AND NOT MAYA_MACOSX_BUILT_WITH_UB2)
@@ -138,15 +135,6 @@ if (CMAKE_WANT_MATERIALX_BUILD)
 endif()
 include(cmake/usd.cmake)
 
-if(DEFINED MAYA_APP_VERSION)
-    if (${MAYA_APP_VERSION} STRLESS "2019" AND CMAKE_WANT_UFE_BUILD)
-        set(CMAKE_WANT_UFE_BUILD OFF)
-        message(AUTHOR_WARNING "========================================================================================= \
-                                UFE is not available in Maya${MAYA_MAJOR_VERSION}. Maya2019 and later are supported only. \
-                                ========================================================================================= ")
-    endif()
-endif()
-
 if(CMAKE_WANT_UFE_BUILD)
     find_package(UFE QUIET)
     if(UFE_FOUND)
@@ -173,18 +161,10 @@ if(DEFINED QT_LOCATION)
     if(NOT DEFINED QT_VERSION)
 		if(BUILD_WITH_QT_6)
 			set(QT_VERSION "6.5")
-			message(STATUS "Setting Qt version to Qt ${QT_VERSION}")
-        else()
-            set(QT_VERSION "5.15")  # default version Maya 2022/2023/2024
-            if(DEFINED MAYA_APP_VERSION)
-                if(${MAYA_APP_VERSION} STRLESS_EQUAL "2019")
-                    set(QT_VERSION "5.6")
-                elseif(${MAYA_APP_VERSION} STRLESS_EQUAL "2020")
-                    set(QT_VERSION "5.12")
-                endif()
-                message(STATUS "Setting Qt version to Qt ${QT_VERSION}")
-            endif()
+        else() # Maya 2022, 2023, 2024
+            set(QT_VERSION "5.15")
         endif()
+        message(STATUS "Setting Qt version to Qt ${QT_VERSION}")
     endif()
     set(CMAKE_PREFIX_PATH "${QT_LOCATION}")
 	if(BUILD_WITH_QT_6)

--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -9,8 +9,8 @@
 # MAYA_<lib>_FOUND    Defined if <lib> has been found
 # MAYA_<lib>_LIBRARY  Path to <lib> library
 # MAYA_INCLUDE_DIRS   Path to the devkit's include directories
-# MAYA_API_VERSION    Maya version (6-8 digits)
-# MAYA_APP_VERSION    Maya app version (4 digits)
+# MAYA_API_VERSION    Maya API version (6-8 digits) - defined in MTypes.h
+# MAYA_APP_VERSION    Maya app version (4 digits) - either from MTypes.h or first 4 digits of MAYA_API_VERSION
 # MAYA_LIGHTAPI_VERSION Maya light API version (1 or 2 or 3)
 # MAYA_PREVIEW_RELEASE_VERSION Preview Release number (3 or more digits) in preview releases, 0 in official releases
 #
@@ -89,8 +89,8 @@ endif()
 
 if(IS_MACOSX)
     # On OSX, setting MAYA_LOCATION to either the base installation dir (ie,
-    # `/Application/Autodesk/maya20xx`), or the Contents folder in the Maya.app dir
-    # (ie, `/Application/Autodesk/maya20xx/Maya.app/Contents`) are supported.
+    # `/Application/Autodesk/maya202x`), or the Contents folder in the Maya.app dir
+    # (ie, `/Application/Autodesk/maya202x/Maya.app/Contents`) are supported.
     find_path(MAYA_BASE_DIR
             include/maya/MFn.h
         HINTS
@@ -98,12 +98,6 @@ if(IS_MACOSX)
             "$ENV{MAYA_LOCATION}/../.."
             "${MAYA_LOCATION}"
             "$ENV{MAYA_LOCATION}"
-            "/Applications/Autodesk/maya2020"
-            "/Applications/Autodesk/maya2019"
-            "/Applications/Autodesk/maya2018"
-            "/Applications/Autodesk/maya2017"
-            "/Applications/Autodesk/maya2016.5"
-            "/Applications/Autodesk/maya2016"
         DOC
             "Maya installation root directory"
     )
@@ -125,12 +119,6 @@ elseif(IS_LINUX)
         HINTS
             "${MAYA_LOCATION}"
             "$ENV{MAYA_LOCATION}"
-            "/usr/autodesk/maya2020-x64"
-            "/usr/autodesk/maya2019-x64"
-            "/usr/autodesk/maya2018-x64"
-            "/usr/autodesk/maya2017-x64"
-            "/usr/autodesk/maya2016.5-x64"
-            "/usr/autodesk/maya2016-x64"
         DOC
             "Maya installation root directory"
     )
@@ -151,12 +139,6 @@ elseif(IS_WINDOWS)
         HINTS
             "${MAYA_LOCATION}"
             "$ENV{MAYA_LOCATION}"
-            "C:/Program Files/Autodesk/Maya2020"
-            "C:/Program Files/Autodesk/Maya2019"
-            "C:/Program Files/Autodesk/Maya2018"
-            "C:/Program Files/Autodesk/Maya2017"
-            "C:/Program Files/Autodesk/Maya2016.5"
-            "C:/Program Files/Autodesk/Maya2016"
         DOC
             "Maya installation root directory"
     )
@@ -290,10 +272,8 @@ endif()
 
 # Determine the Python version and switch between mayapy and mayapy2.
 set(MAYAPY_EXE mayapy)
-set(MAYA_PY_VERSION 2)
-if(${MAYA_APP_VERSION} STRGREATER_EQUAL "2021")
-    set(MAYA_PY_VERSION 3)
-
+set(MAYA_PY_VERSION 3)
+if(MAYA_APP_VERSION VERSION_EQUAL 2022)
     # check to see if we have a mayapy2 executable
     find_program(MAYA_PY_EXECUTABLE2
             mayapy2

--- a/doc/build.md
+++ b/doc/build.md
@@ -10,18 +10,18 @@ Before building the project, consult the following table to ensure you use the r
 
 |        Required       | ![](images/windows.png)   |                            ![](images/mac.png)               |   ![](images/linux.png)     |
 |:---------------------:|:-------------------------:|:------------------------------------------------------------:|:---------------------------:|
-|    Operating System   |         Windows 10        | High Sierra (10.13)<br>Mojave (10.14)<br>Catalina (10.15)<br>Big Sur (11.2.x)<br>Monterey (12.6) |    CentOS 7/8<br>RHEL 8.6    |
-|   Compiler Requirement| Maya 2019 (VS 2017)<br>Maya 2020 (VS 2017)<br>Maya 2022 (VS 2017/2019)<br>Maya 2023 (VS 2019)<br>Maya 2024 (VS 2022) | Maya 2019 (Xcode 7.3.1)<br>Maya 2020 (Xcode 10.2.1)<br>Maya 2022 (Xcode 10.2.1)<br>Maya 2023 (Xcode 10.2.1)<br>Maya 2024 (Xcode 13.4) | Maya 2019 (gcc 6.3.1)<br>Maya 2020 (gcc 6.3.1)<br>Maya 2022 (gcc 6.3.1/9.3.1)<br>Maya 2023 (gcc 9.3.1)<br>Maya 2024 (gcc 11.2.1) |
+|    Operating System   |       Windows 10/11        | High Sierra (10.13)<br>Mojave (10.14)<br>Catalina (10.15)<br>Big Sur (11.2.x)<br>Monterey (12.6) | CentOS 7/8<br>RHEL 8.6<br>Rocky 8.6    |
+|   Compiler Requirement| Maya 2022 (VS 2017/2019)<br>Maya 2023 (VS 2019)<br>Maya 2024 (VS 2022) | Maya 2022 (Xcode 10.2.1)<br>Maya 2023 (Xcode 10.2.1)<br>Maya 2024 (Xcode 13.4) | Maya 2022 (gcc 6.3.1/9.3.1)<br>Maya 2023 (gcc 9.3.1)<br>Maya 2024 (gcc 11.2.1) |
 | CMake Version (min/max) |        3.13 - 3.17      |                              3.13 - 3.17                     |           3.13 - 3.17       |
 |         Python        | 2.7.15 or 3.7.7 or 3.9.7  |                       2.7.15 or 3.7.7 or 3.9.7               |  2.7.15 or 3.7.7 or 3.9.7   |
 |    Python Packages    | PyYAML, PySide, PyOpenGL, Jinja2        | PyYAML, PySide2, PyOpenGL, Jinja2              | PyYAML, PySide, PyOpenGL, Jinja2 |
 |    Build generator    | Visual Studio, Ninja (Recommended)    |  XCode, Ninja (Recommended)                      |    Ninja (Recommended)      |
 |    Command processor  | Visual Studio X64 2017 or 2019 command prompt  |                     bash                |             bash            |
-| Supported Maya Version| 2019, 2020, 2022, 2023, 2024 |               2019, 2020, 2022, 2023, 2024                | 2019, 2020, 2022, 2023, 2024 |
+| Supported Maya Version| 2022, 2023, 2024 | 2022, 2023, 2024 | 2022, 2023, 2024 |
 
 |        Optional       | ![](images/windows.png)   |                            ![](images/mac.png)               |   ![](images/linux.png)     |
 |:---------------------:|:-------------------------:|:------------------------------------------------------------:|:---------------------------:|
-|          Qt           | Maya 2019 = 5.6.1<br>Maya 2020 = 5.12.5<br>Maya 2022 = 5.15.2<br>Maya 2023 = 5.15.2<br>Maya 2024 = 5.15.2 | Maya 2019 = 5.6.1<br>Maya 2020 = 5.12.5<br>Maya 2022 = 5.15.2<br>Maya 2023 = 5.15.2<br>Maya 2024 = 5.15.2 | Maya 2019 = 5.6.1<br>Maya 2020 = 5.12.5<br>Maya 2022 = 5.15.2<br>Maya 2023 = 5.15.2<br>Maya 2024 = 5.15.2 |
+|          Qt           | Maya 2022 = 5.15.2<br>Maya 2023 = 5.15.2<br>Maya 2024 = 5.15.2 | Maya 2022 = 5.15.2<br>Maya 2023 = 5.15.2<br>Maya 2024 = 5.15.2 | Maya 2022 = 5.15.2<br>Maya 2023 = 5.15.2<br>Maya 2024 = 5.15.2 |
 
 ***NOTE:*** Visit the online Maya developer help document under ***Setting up your build environment*** for additional compiler requirements on different platforms.
 
@@ -54,7 +54,7 @@ To build the project with UFE support, you will need to use the headers and libr
 
 https://www.autodesk.com/developer-network/platform-technologies/maya
 
-***NOTE:*** UFE is only supported in Maya 2019 and later. Earlier versions of Maya should still be able to load the plug-ins but without the features enabled by UFE.
+***NOTE:*** UFE is only supported in Maya 2019 and later.
 
 #### 4. Download the source code
 
@@ -88,13 +88,13 @@ There are four arguments that must be passed to the script:
 
 ```
 Linux:
-➜ maya-usd python build.py --maya-location /usr/autodesk/maya2020 --pxrusd-location /usr/local/USD-Release --devkit-location /usr/local/devkitBase /usr/local/workspace
+➜ maya-usd python build.py --maya-location /usr/autodesk/maya2024 --pxrusd-location /usr/local/USD-Release --devkit-location /usr/local/devkitBase /usr/local/workspace
 
 MacOSX:
-➜ maya-usd python build.py --maya-location /Applications/Autodesk/maya2020 --pxrusd-location /opt/local/USD-Release --devkit-location /opt/local/devkitBase /opt/local/workspace
+➜ maya-usd python build.py --maya-location /Applications/Autodesk/maya2024 --pxrusd-location /opt/local/USD-Release --devkit-location /opt/local/devkitBase /opt/local/workspace
 
 Windows:
-c:\maya-usd> python build.py --maya-location "C:\Program Files\Autodesk\Maya2020" --pxrusd-location C:\USD-Release --devkit-location C:\devkitBase C:\workspace
+c:\maya-usd> python build.py --maya-location "C:\Program Files\Autodesk\Maya2024" --pxrusd-location C:\USD-Release --devkit-location C:\devkitBase C:\workspace
 ```
 
 ##### Default Build Arguments
@@ -122,13 +122,15 @@ BUILD_MAYAUSD_LIBRARY       | builds Core USD libraries.                        
 BUILD_ADSK_PLUGIN           | builds Autodesk USD plugin.                                | ON
 BUILD_PXR_PLUGIN            | builds the Pixar USD plugin and libraries.                 | ON
 BUILD_AL_PLUGIN             | builds the Animal Logic USD plugin and libraries.          | ON
-BUILD_HDMAYA                | builds the Maya-To-Hydra plugin and scene delegate.        | ON
+BUILD_HDMAYA                | builds the legacy Maya-To-Hydra plugin and scene delegate. | OFF
 BUILD_RFM_TRANSLATORS       | builds translators for RenderMan for Maya shaders.         | ON
 BUILD_TESTS                 | builds all unit tests.                                     | ON
 BUILD_STRICT_MODE           | enforces all warnings as errors.                           | ON
 BUILD_WITH_PYTHON_3			| build with python 3.										 | OFF
 BUILD_SHARED_LIBS			| build libraries as shared or static.						 | ON
+BUILD_UB2                   | build universal binary 2 (UB2) Intel64+arm64 (apple only)  | OFF
 CMAKE_WANT_UFE_BUILD        | enables building with UFE (if found).                      | ON
+CMAKE_WANT_MATERIALX_BUILD  | enable building with MaterialX (experimental). | OFF
 
 ##### Stages
 
@@ -207,9 +209,9 @@ Test project /Users/sabrih/Desktop/workspace/build/Debug/plugin/al
 
 It is important to use the Python version shipped with Maya and not the system version when building USD on MacOS. Note that this is primarily an issue on MacOS, where Maya's version of Python is likely to conflict with the version provided by the system. 
 
-To build USD and the Maya plug-ins on MacOS for Maya (2019, 2020, 2022, 2023, 2024), run:
+To build USD and the Maya plug-ins on MacOS for Maya (2022, 2023, 2024), run:
 ```
-/Applications/Autodesk/maya2019/Maya.app/Contents/bin/mayapy build_usd.py ~/Desktop/BUILD
+/Applications/Autodesk/maya2024/Maya.app/Contents/bin/mayapy build_usd.py ~/Desktop/BUILD
 ```
 By default, ``usdview`` is built which has a dependency on PyOpenGL. Since the Python version of Maya doesn't ship with PyOpenGL you will be prompted with the following error message:
 ```

--- a/doc/codingGuidelines.md
+++ b/doc/codingGuidelines.md
@@ -239,7 +239,8 @@ Headers should be included in the following order, with each section separated b
 ### Conditional compilation (Maya, USD, UFE version)
 **Maya**
 	* `MAYA_API_VERSION` is the consistent macro to test Maya version (`MAYA_APP_VERSION` * 10000 + `MAJOR_VERSION` * 100 + `MINOR_VERSION`)
-	* `MAYA_APP_VERSION` is available only since Maya 2019 and is a simple year number, so it is not allowed.
+	* `MAYA_APP_VERSION` is a simple year number, so it is not allowed in C++ code. However it is set as a CMake variable and allowed in cmake files.
+
 **UFE**
 	* `WANT_UFE_BUILD` equals 1 if UFE is found and it should be used for conditional compilation on codes depending on UFE.
 

--- a/lib/mayaUsd/fileio/jobs/meshDataReadJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/meshDataReadJob.cpp
@@ -63,8 +63,6 @@ GfMatrix4d getTransform(const UsdPrim& prim, const std::map<SdfPath, GfMatrix4d>
 
 void getComponentTags(MFnMeshData& dataCreator, const UsdGeomMesh& mesh)
 {
-#if MAYA_API_VERSION >= 20220000
-
     // Unclear at this time if this mesh requires roundtripping info
     // for the component tags.
     std::vector<UsdMayaMeshReadUtils::ComponentTagData> componentTags;
@@ -81,8 +79,6 @@ void getComponentTags(MFnMeshData& dataCreator, const UsdGeomMesh& mesh)
 
         dataCreator.setComponentTagContents(name, content);
     }
-
-#endif
 }
 } // namespace
 

--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -675,11 +675,7 @@ bool UsdMaya_ReadJob::_DoImport(UsdPrimRange& rootRange, const UsdPrim& usdRootP
                         prototypeNode.removeChildAt(prototypeNode.childCount() - 1);
                     }
                 }
-#if MAYA_API_VERSION > 20200200
                 deletePrototypeMod.deleteNode(prototypeObject, false);
-#else
-                deletePrototypeMod.deleteNode(prototypeObject);
-#endif
             }
             prototypesLoop.loopAdvance();
         }
@@ -749,11 +745,7 @@ bool UsdMaya_ReadJob::Undo()
                         }
                     }
                 }
-#if MAYA_API_VERSION > 20200200
                 mDagModifierUndo.deleteNode(it.second, false);
-#else
-                mDagModifierUndo.deleteNode(it.second);
-#endif
             }
         }
     }

--- a/lib/mayaUsd/fileio/shading/shadingModeDisplayColor.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeDisplayColor.cpp
@@ -46,14 +46,11 @@
 #include <maya/MFnDependencyNode.h>
 #include <maya/MFnLambertShader.h>
 #include <maya/MFnSet.h>
+#include <maya/MFnStandardSurfaceShader.h>
 #include <maya/MObject.h>
 #include <maya/MPlug.h>
 #include <maya/MStatus.h>
 #include <maya/MString.h>
-
-#if MAYA_API_VERSION >= 20200000
-#include <maya/MFnStandardSurfaceShader.h>
-#endif
 
 #include <string>
 
@@ -136,7 +133,6 @@ DEFINE_SHADING_MODE_IMPORTER_WITH_JOB_ARGUMENTS(
 
     MPlug       outputPlug;
     std::string surfaceNodeName;
-#if MAYA_API_VERSION >= 20200000
     if (preferredMaterial == UsdMayaPreferredMaterialTokens->standardSurface) {
         MFnStandardSurfaceShader surfaceFn;
         surfaceFn.setObject(shadingObj);
@@ -154,9 +150,7 @@ DEFINE_SHADING_MODE_IMPORTER_WITH_JOB_ARGUMENTS(
         // shading engine.
         outputPlug = surfaceFn.findPlug("outColor", &status);
         CHECK_MSTATUS_AND_RETURN(status, MObject());
-    } else
-#endif
-        if (preferredMaterial == UsdMayaPreferredMaterialTokens->usdPreviewSurface) {
+    } else if (preferredMaterial == UsdMayaPreferredMaterialTokens->usdPreviewSurface) {
         MFnDependencyNode depNodeFn;
         depNodeFn.setObject(shadingObj);
         surfaceNodeName = depNodeFn.name().asChar();

--- a/lib/mayaUsd/fileio/shading/shadingModePxrRis.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModePxrRis.cpp
@@ -439,12 +439,7 @@ _ComputeShadingNodeTypeForShaderId(const TfToken& shaderId, const UsdMayaShading
 
     // Loop over the compoundClassifications, though I believe
     // compoundClassifications will always have size 0 or 1.
-#if MAYA_API_VERSION >= 20190000
     for (const MString& compoundClassification : compoundClassifications) {
-#else
-    for (unsigned int i = 0; i < compoundClassifications.length(); ++i) {
-        const MString& compoundClassification = compoundClassifications[i];
-#endif
         const std::string compoundClassificationStr(compoundClassification.asChar());
         for (const std::string& classification : TfStringSplit(compoundClassificationStr, ":")) {
             for (const auto& classPrefixAndType : _classificationsToTypes) {

--- a/lib/mayaUsd/fileio/translators/translatorCurves.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorCurves.cpp
@@ -62,12 +62,7 @@ bool convertToBezier(MFnNurbsCurve& nurbsCurveFn, MObject& mayaNodeTransformObj,
     // Remove the nurbs and converter:
     MDGModifier& dagm = MayaUsd::MDGModifierUndoItem::create("Nurbs curve deletion");
     dagm.deleteNode(convFn.object());
-#if MAYA_API_VERSION >= 20200300
     dagm.deleteNode(nurbsCurveFn.object(), false);
-#else
-    dagm.deleteNode(nurbsCurveFn.object());
-#endif
-
     dagm.doIt();
     // replace deleted nurbs node with bezier node
     nurbsCurveFn.setObject(curveObj);

--- a/lib/mayaUsd/fileio/translators/translatorUtil.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorUtil.cpp
@@ -333,12 +333,7 @@ UsdMayaTranslatorUtil::ComputeShadingNodeTypeForMayaTypeName(const TfToken& maya
 
     // Loop over the compoundClassifications, though I believe
     // compoundClassifications will always have size 0 or 1.
-#if MAYA_API_VERSION >= 20190000
     for (const MString& compoundClassification : compoundClassifications) {
-#else
-    for (unsigned int i = 0u; i < compoundClassifications.length(); ++i) {
-        const MString& compoundClassification = compoundClassifications[i];
-#endif
         const std::string compoundClassificationStr(compoundClassification.asChar());
         for (const std::string& classification : TfStringSplit(compoundClassificationStr, ":")) {
             for (const auto& classPrefixAndType : _classificationsToTypes) {

--- a/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
@@ -892,8 +892,6 @@ MStatus UsdMayaMeshReadUtils::assignSubDivTagsToMesh(
     return MS::kSuccess;
 }
 
-#if MAYA_API_VERSION >= 20220000
-
 bool UsdMayaMeshReadUtils::getGeomSubsetInfo(const MObject& mesh, JsValue& meshRoundtripData)
 {
     MFnDependencyNode depNodeFn(mesh);
@@ -1076,7 +1074,5 @@ MStatus UsdMayaMeshReadUtils::createComponentTags(const UsdGeomMesh& mesh, const
 
     return status;
 }
-
-#endif
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/utils/meshReadUtils.h
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.h
@@ -90,8 +90,6 @@ void assignInvisibleFaces(const UsdGeomMesh& mesh, const MObject& meshObj);
 MAYAUSD_CORE_PUBLIC
 MStatus assignSubDivTagsToMesh(const UsdGeomMesh&, MObject&, MFnMesh&);
 
-#if MAYA_API_VERSION >= 20220000
-
 /// Gets the internal UsdGeomSubset info on the Maya \p mesh, placing it in
 /// \p value. Returns true if the info exists on the mesh, and false if not.
 MAYAUSD_CORE_PUBLIC
@@ -113,8 +111,6 @@ MStatus getComponentTags(
     const UsdGeomMesh&             mesh,
     std::vector<ComponentTagData>& tags,
     JsValue&                       meshRoundtripData);
-
-#endif
 
 } // namespace UsdMayaMeshReadUtils
 

--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.cpp
@@ -1397,8 +1397,6 @@ bool UsdMayaMeshWriteUtils::getMeshColorSetData(
     return true;
 }
 
-#if MAYA_API_VERSION >= 20220000
-
 MStatus UsdMayaMeshWriteUtils::exportComponentTags(UsdGeomMesh& primSchema, MObject obj)
 {
     MStatus status { MS::kSuccess };
@@ -1479,7 +1477,5 @@ MStatus UsdMayaMeshWriteUtils::exportComponentTags(UsdGeomMesh& primSchema, MObj
 
     return status;
 }
-
-#endif
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/utils/meshWriteUtils.h
+++ b/lib/mayaUsd/fileio/utils/meshWriteUtils.h
@@ -242,12 +242,8 @@ bool getMeshColorSetData(
     MFnMesh::MColorRepresentation* colorSetRep,
     bool*                          clamped);
 
-#if MAYA_API_VERSION >= 20220000
-
 MAYAUSD_CORE_PUBLIC
 MStatus exportComponentTags(UsdGeomMesh& primSchema, MObject obj);
-
-#endif
 
 } // namespace UsdMayaMeshWriteUtils
 

--- a/lib/mayaUsd/nodes/proxyAccessor.cpp
+++ b/lib/mayaUsd/nodes/proxyAccessor.cpp
@@ -146,14 +146,7 @@ public:
 
 namespace {
 //! Profiler category for proxy accessor events
-const int _accessorProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "ProxyAccessor",
-    "ProxyAccessor"
-#else
-    "ProxyAccessor"
-#endif
-);
+const int _accessorProfilerCategory = MProfiler::addCategory("ProxyAccessor", "ProxyAccessor");
 
 static const TfToken combinedVisibilityToken("combinedVisibility");
 

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -213,14 +213,8 @@ void createNewAnonSubLayerRecursive(
     }
 }
 //! Profiler category for proxy accessor events
-const int _shapeBaseProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "ProxyShapeBase",
-    "ProxyShapeBase events"
-#else
-    "ProxyShapeBase"
-#endif
-);
+const int _shapeBaseProfilerCategory
+    = MProfiler::addCategory("ProxyShapeBase", "ProxyShapeBase events");
 
 struct InComputeGuard
 {
@@ -1671,7 +1665,6 @@ MStatus MayaUsdProxyShapeBase::setDependentsDirty(const MPlug& plug, MPlugArray&
     return retValue;
 }
 
-#if MAYA_API_VERSION >= 20210000
 /* virtual */
 void MayaUsdProxyShapeBase::getCacheSetup(
     const MEvaluationNode&   evalNode,
@@ -1697,7 +1690,6 @@ void MayaUsdProxyShapeBase::configCache(const MEvaluationNode& evalNode, MCacheS
         schema.add(outStageDataAttr);
     }
 }
-#endif
 
 UsdPrim MayaUsdProxyShapeBase::_GetUsdPrim(MDataBlock dataBlock) const
 {

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -239,7 +239,6 @@ public:
         const MEvaluationNode& evaluationNode,
         PostEvaluationType     evalType) override;
 
-#if MAYA_API_VERSION >= 20210000
     MAYAUSD_CORE_PUBLIC
     void getCacheSetup(
         const MEvaluationNode&   evalNode,
@@ -249,7 +248,6 @@ public:
 
     MAYAUSD_CORE_PUBLIC
     void configCache(const MEvaluationNode& evalNode, MCacheSchema& schema) const override;
-#endif
 
     MAYAUSD_CORE_PUBLIC
     MStatus setDependentsDirty(const MPlug& plug, MPlugArray& plugArray) override;

--- a/lib/mayaUsd/python/wrapOpenMaya.cpp
+++ b/lib/mayaUsd/python/wrapOpenMaya.cpp
@@ -19,11 +19,8 @@
 #include <maya/MTypes.h>
 
 // Hack because MDGModifier assign operator is not public.
-// For 2019, the hack is different see MDGModifier2019 in this file
-#if MAYA_API_VERSION >= 20200000
 #undef OPENMAYA_PRIVATE
 #define OPENMAYA_PRIVATE public
-#endif
 
 #include <maya/MDGModifier.h>
 #include <maya/MDagPath.h>
@@ -44,23 +41,6 @@ template <class MayaClass> void copyOperator(void* dst, const MayaClass& object)
 {
     *((MayaClass*)(dst)) = object;
 }
-
-// Hack to have access at MDGModifier assign operator from OpenMaya 2019
-#if MAYA_API_VERSION < 20200000
-class MDGModifier2019 : public MDGModifier
-{
-public:
-    MDGModifier2019& operator=(const MDGModifier2019& rhs)
-    {
-        MDGModifier::operator=(rhs);
-        return *this;
-    }
-};
-template <> void copyOperator(void* dst, const MDGModifier& object)
-{
-    *((MDGModifier2019*)(dst)) = (MDGModifier2019&)object;
-}
-#endif
 
 /* Should be detectable detecting maya_useNewAPI in plugin
 

--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.cpp
@@ -120,8 +120,6 @@ private:
 
 #endif // WANT_UFE_BUILD
 
-#if MAYA_API_VERSION >= 20210000
-
 //! \brief  Get the index of the hit nearest to a given cursor point.
 int GetNearestHitIndex(
     const MHWRender::MFrameContext& frameContext,
@@ -191,8 +189,6 @@ void ResolveUniqueHits_Workaround(const HdxPickHitVector& inHits, HdxPickHitVect
         }
     }
 }
-
-#endif
 
 } // namespace
 
@@ -980,7 +976,6 @@ bool MtohRenderOverride::nextRenderOperation()
     return ++_currentOperation < static_cast<int>(_operations.size());
 }
 
-#if MAYA_API_VERSION >= 20210000
 bool MtohRenderOverride::select(
     const MHWRender::MFrameContext&  frameContext,
     const MHWRender::MSelectionInfo& selectInfo,
@@ -1083,7 +1078,6 @@ bool MtohRenderOverride::select(
 
     return true;
 }
-#endif
 
 void MtohRenderOverride::_ClearHydraCallback(void* data)
 {

--- a/lib/mayaUsd/render/mayaToHydra/renderOverride.h
+++ b/lib/mayaUsd/render/mayaToHydra/renderOverride.h
@@ -91,14 +91,12 @@ public:
     MHWRender::MRenderOperation* renderOperation() override;
     bool                         nextRenderOperation() override;
 
-#if MAYA_API_VERSION >= 20210000
     bool select(
         const MHWRender::MFrameContext&  frameContext,
         const MHWRender::MSelectionInfo& selectInfo,
         bool                             useDepth,
         MSelectionList&                  selectionList,
         MPointArray&                     worldSpaceHitPts) override;
-#endif
 
 private:
     typedef std::pair<MString, MCallbackIdArray> PanelCallbacks;
@@ -165,28 +163,17 @@ private:
     HdRenderIndex*                            _renderIndex = nullptr;
     std::unique_ptr<MtohDefaultLightDelegate> _defaultLightDelegate = nullptr;
     HdxSelectionTrackerSharedPtr              _selectionTracker;
-    HdRprimCollection                         _renderCollection
-    {
-        HdTokens->geometry,
-            HdReprSelector(
-#if MAYA_APP_VERSION >= 2019
-                HdReprTokens->refined
-#else
-                HdReprTokens->smoothHull
-#endif
-                ),
-            SdfPath::AbsoluteRootPath()
-    };
-    HdRprimCollection _selectionCollection { HdReprTokens->wire,
+    HdRprimCollection                         _renderCollection { HdTokens->geometry,
+                                          HdReprSelector(HdReprTokens->refined),
+                                          SdfPath::AbsoluteRootPath() };
+    HdRprimCollection                         _selectionCollection { HdReprTokens->wire,
                                              HdReprSelector(HdReprTokens->wire) };
 
-#if MAYA_API_VERSION >= 20210000
     HdRprimCollection _pointSnappingCollection {
         HdTokens->geometry,
         HdReprSelector(HdReprTokens->refined, TfToken(), HdReprTokens->points),
         SdfPath::AbsoluteRootPath()
     };
-#endif
 
     GlfSimpleLight _defaultLight;
 

--- a/lib/mayaUsd/render/px_vp20/utils_legacy.h
+++ b/lib/mayaUsd/render/px_vp20/utils_legacy.h
@@ -18,17 +18,6 @@
 
 /// \file px_vp20/utils_legacy.h
 
-// XXX: With Maya versions up through 2019 on Linux, M3dView.h ends up
-// indirectly including an X11 header that #define's "Bool" as int:
-//   - <maya/M3dView.h> includes <maya/MNativeWindowHdl.h>
-//   - <maya/MNativeWindowHdl.h> includes <X11/Intrinsic.h>
-//   - <X11/Intrinsic.h> includes <X11/Xlib.h>
-//   - <X11/Xlib.h> does: "#define Bool int"
-// This can cause compilation issues if <pxr/usd/sdf/types.h> is included
-// afterwards, so to fix this, we ensure that it gets included first.
-//
-// The X11 include appears to have been removed in Maya 2020+, so this should
-// no longer be an issue with later versions.
 #include <mayaUsd/base/api.h>
 
 #include <pxr/base/gf/matrix4d.h>

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.cpp
@@ -91,14 +91,8 @@ TF_DEFINE_PRIVATE_TOKENS(
 
 TF_INSTANTIATE_SINGLETON(UsdMayaGLBatchRenderer);
 
-const int UsdMayaGLBatchRenderer::ProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "UsdMayaGLBatchRenderer",
-    "UsdMayaGLBatchRenderer"
-#else
-    "UsdMayaGLBatchRenderer"
-#endif
-);
+const int UsdMayaGLBatchRenderer::ProfilerCategory
+    = MProfiler::addCategory("UsdMayaGLBatchRenderer", "UsdMayaGLBatchRenderer");
 
 /* static */
 void UsdMayaGLBatchRenderer::Init()

--- a/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/batchRenderer.h
@@ -17,22 +17,6 @@
 #define PXRUSDMAYAGL_BATCH_RENDERER_H
 
 /// \file pxrUsdMayaGL/batchRenderer.h
-#include <memory>
-#include <unordered_map>
-#include <unordered_set>
-#include <utility>
-
-// XXX: With Maya versions up through 2019 on Linux, M3dView.h ends up
-// indirectly including an X11 header that #define's "Bool" as int:
-//   - <maya/M3dView.h> includes <maya/MNativeWindowHdl.h>
-//   - <maya/MNativeWindowHdl.h> includes <X11/Intrinsic.h>
-//   - <X11/Intrinsic.h> includes <X11/Xlib.h>
-//   - <X11/Xlib.h> does: "#define Bool int"
-// This can cause compilation issues if <pxr/usd/sdf/types.h> is included
-// afterwards, so to fix this, we ensure that it gets included first.
-//
-// The X11 include appears to have been removed in Maya 2020+, so this should
-// no longer be an issue with later versions.
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/listeners/notice.h>
 #include <mayaUsd/render/pxrUsdMayaGL/renderParams.h>
@@ -69,6 +53,11 @@
 #include <maya/MSelectionContext.h>
 #include <maya/MTypes.h>
 #include <maya/MUserData.h>
+
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/hdImagingShapeUI.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/hdImagingShapeUI.h
@@ -17,20 +17,9 @@
 #define PXRUSDMAYAGL_HD_IMAGING_SHAPE_UI_H
 
 /// \file pxrUsdMayaGL/hdImagingShapeUI.h
-#include <pxr/pxr.h>
-// XXX: With Maya versions up through 2019 on Linux, M3dView.h ends up
-// indirectly including an X11 header that #define's "Bool" as int:
-//   - <maya/M3dView.h> includes <maya/MNativeWindowHdl.h>
-//   - <maya/MNativeWindowHdl.h> includes <X11/Intrinsic.h>
-//   - <X11/Intrinsic.h> includes <X11/Xlib.h>
-//   - <X11/Xlib.h> does: "#define Bool int"
-// This can cause compilation issues if <pxr/usd/sdf/types.h> is included
-// afterwards, so to fix this, we ensure that it gets included first.
-//
-// The X11 include appears to have been removed in Maya 2020+, so this should
-// no longer be an issue with later versions.
 #include <mayaUsd/base/api.h>
 
+#include <pxr/pxr.h>
 #include <pxr/usd/sdf/types.h>
 
 #include <maya/M3dView.h>

--- a/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/instancerShapeAdapter.h
@@ -17,19 +17,6 @@
 #define PXRUSDMAYAGL_INSTANCER_SHAPE_ADAPTER_H
 
 /// \file pxrUsdMayaGL/instancerShapeAdapter.h
-#include <memory>
-
-// XXX: With Maya versions up through 2019 on Linux, M3dView.h ends up
-// indirectly including an X11 header that #define's "Bool" as int:
-//   - <maya/M3dView.h> includes <maya/MNativeWindowHdl.h>
-//   - <maya/MNativeWindowHdl.h> includes <X11/Intrinsic.h>
-//   - <X11/Intrinsic.h> includes <X11/Xlib.h>
-//   - <X11/Xlib.h> does: "#define Bool int"
-// This can cause compilation issues if <pxr/usd/sdf/types.h> is included
-// afterwards, so to fix this, we ensure that it gets included first.
-//
-// The X11 include appears to have been removed in Maya 2020+, so this should
-// no longer be an issue with later versions.
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h>
 
@@ -41,6 +28,8 @@
 #include <pxr/usdImaging/usdImaging/delegate.h>
 
 #include <maya/M3dView.h>
+
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/proxyShapeUI.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/proxyShapeUI.h
@@ -18,17 +18,6 @@
 
 /// \file pxrUsdMayaGL/proxyShapeUI.h
 
-// XXX: With Maya versions up through 2019 on Linux, M3dView.h ends up
-// indirectly including an X11 header that #define's "Bool" as int:
-//   - <maya/M3dView.h> includes <maya/MNativeWindowHdl.h>
-//   - <maya/MNativeWindowHdl.h> includes <X11/Intrinsic.h>
-//   - <X11/Intrinsic.h> includes <X11/Xlib.h>
-//   - <X11/Xlib.h> does: "#define Bool int"
-// This can cause compilation issues if <pxr/usd/sdf/types.h> is included
-// afterwards, so to fix this, we ensure that it gets included first.
-//
-// The X11 include appears to have been removed in Maya 2020+, so this should
-// no longer be an issue with later versions.
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.h>
 

--- a/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h
@@ -27,24 +27,12 @@
 #include <pxr/imaging/hd/types.h>
 #include <pxr/pxr.h>
 #include <pxr/usd/sdf/path.h>
-
-#include <memory>
-#include <unordered_map>
-
-// XXX: With Maya versions up through 2019 on Linux, M3dView.h ends up
-// indirectly including an X11 header that #define's "Bool" as int:
-//   - <maya/M3dView.h> includes <maya/MNativeWindowHdl.h>
-//   - <maya/MNativeWindowHdl.h> includes <X11/Intrinsic.h>
-//   - <X11/Intrinsic.h> includes <X11/Xlib.h>
-//   - <X11/Xlib.h> does: "#define Bool int"
-// This can cause compilation issues if <pxr/usd/sdf/types.h> is included
-// afterwards, so to fix this, we ensure that it gets included first.
-//
-// The X11 include appears to have been removed in Maya 2020+, so this should
-// no longer be an issue with later versions.
 #include <pxr/usd/sdf/types.h>
 
 #include <maya/M3dView.h>
+
+#include <memory>
+#include <unordered_map>
 #undef Always // Defined in /usr/lib/X11/X.h (eventually included by M3dView.h) - breaks
               // pxr/usd/lib/usdUtils/registeredVariantSet.h
 #include <mayaUsd/base/api.h>

--- a/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.h
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/usdProxyShapeAdapter.h
@@ -18,19 +18,6 @@
 
 /// \file pxrUsdMayaGL/usdProxyShapeAdapter.h
 
-#include <memory>
-
-// XXX: With Maya versions up through 2019 on Linux, M3dView.h ends up
-// indirectly including an X11 header that #define's "Bool" as int:
-//   - <maya/M3dView.h> includes <maya/MNativeWindowHdl.h>
-//   - <maya/MNativeWindowHdl.h> includes <X11/Intrinsic.h>
-//   - <X11/Intrinsic.h> includes <X11/Xlib.h>
-//   - <X11/Xlib.h> does: "#define Bool int"
-// This can cause compilation issues if <pxr/usd/sdf/types.h> is included
-// afterwards, so to fix this, we ensure that it gets included first.
-//
-// The X11 include appears to have been removed in Maya 2020+, so this should
-// no longer be an issue with later versions.
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/render/pxrUsdMayaGL/shapeAdapter.h>
 
@@ -45,6 +32,8 @@
 #include <maya/M3dView.h>
 #include <maya/MHWGeometryUtilities.h>
 #include <maya/MPxSurfaceShape.h>
+
+#include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -3026,11 +3026,6 @@ HdVP2Material::CompiledNetwork::_CreateShaderInstance(const HdMaterialNetwork& m
 
     MHWRender::MShaderInstance* shaderInstance = nullptr;
 
-    // MShaderInstance supports multiple connections between shaders on Maya 2018.7, 2019.3, 2020
-    // and above.
-#if (MAYA_API_VERSION >= 20190300) \
-    || ((MAYA_API_VERSION >= 20180700) && (MAYA_API_VERSION < 20190000))
-
     // UsdImagingMaterialAdapter has walked the shader graph and emitted nodes
     // and relationships in topological order to avoid forward-references, thus
     // we can run a reverse iteration to avoid connecting a fragment before any
@@ -3102,98 +3097,6 @@ HdVP2Material::CompiledNetwork::_CreateShaderInstance(const HdMaterialNetwork& m
                 .Msg("Failed to connect shader %s\n", node.path.GetText());
         }
     }
-
-#elif MAYA_API_VERSION >= 20190000
-
-    // UsdImagingMaterialAdapter has walked the shader graph and emitted nodes
-    // and relationships in topological order to avoid forward-references, thus
-    // we can run a reverse iteration to avoid connecting a fragment before any
-    // of its downstream fragments.
-    const auto rend = mat.nodes.rend();
-    for (auto rit = mat.nodes.rbegin(); rit != rend; rit++) {
-        const HdMaterialNode& node = *rit;
-
-        const MString nodeId = node.identifier.GetText();
-        const MString nodeName = node.path.GetNameToken().GetText();
-
-        if (shaderInstance == nullptr) {
-            shaderInstance = shaderMgr->getFragmentShader(nodeId, "outSurfaceFinal", true);
-            if (shaderInstance == nullptr) {
-                TF_WARN("Failed to create shader instance for %s", nodeId.asChar());
-                break;
-            }
-
-            continue;
-        }
-
-        MStringArray outputNames, inputNames;
-
-        std::string primvarname;
-
-        for (const HdMaterialRelationship& rel : mat.relationships) {
-            if (rel.inputId == node.path) {
-                outputNames.append(rel.inputName.GetText());
-                inputNames.append(rel.outputName.GetText());
-            }
-
-            if (_IsUsdUVTexture(node)) {
-                if (rel.outputId == node.path && rel.outputName == _tokens->st) {
-                    for (const HdMaterialNode& n : mat.nodes) {
-                        if (n.path == rel.inputId && _IsUsdPrimvarReader(n)) {
-                            auto it = n.parameters.find(_tokens->varname);
-                            if (it != n.parameters.end()) {
-                                primvarname = TfStringify(it->second);
-                            }
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        // Without multi-connection support for MShaderInstance, this code path
-        // can only support common patterns of UsdShade material network, i.e.
-        // a UsdUVTexture is connected to a single input of a USD Preview Surface.
-        // More generic fix is coming.
-        if (outputNames.length() == 1) {
-            MStatus status
-                = shaderInstance->addInputFragment(nodeId, outputNames[0], inputNames[0]);
-
-            if (!status) {
-                TF_DEBUG(HDVP2_DEBUG_MATERIAL)
-                    .Msg(
-                        "Error %s happened when connecting shader %s\n",
-                        status.errorString().asChar(),
-                        node.path.GetText());
-            }
-
-            if (_IsUsdUVTexture(node)) {
-                const MString paramNames[]
-                    = { "file", "fileSampler", "isColorSpaceSRGB", "fallback", "scale", "bias" };
-
-                for (const MString& paramName : paramNames) {
-                    const MString resolvedName = nodeName + paramName;
-                    shaderInstance->renameParameter(paramName, resolvedName);
-                }
-
-                const MString paramName = _tokens->st.GetText();
-                shaderInstance->setSemantic(paramName, "uvCoord");
-                shaderInstance->setAsVarying(paramName, true);
-                shaderInstance->renameParameter(paramName, primvarname.c_str());
-            }
-        } else {
-            TF_DEBUG(HDVP2_DEBUG_MATERIAL)
-                .Msg("Failed to connect shader %s\n", node.path.GetText());
-
-            if (outputNames.length() > 1) {
-                TF_DEBUG(HDVP2_DEBUG_MATERIAL)
-                    .Msg("MShaderInstance doesn't support "
-                         "multiple connections between shaders on the current Maya version.\n");
-            }
-        }
-    }
-
-#endif
 
     return shaderInstance;
 }

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.h
@@ -32,7 +32,7 @@
 // Workaround for a material consolidation update issue in VP2. Before USD 0.20.11, a Rprim will be
 // recreated if its material has any change, so everything gets refreshed and the update issue gets
 // masked. Once the update issue is fixed in VP2 we will disable this workaround.
-#if MAYA_API_VERSION >= 20210000 && MAYA_API_VERSION < 20230000
+#if MAYA_API_VERSION < 20230000
 #define HDVP2_MATERIAL_CONSOLIDATION_UPDATE_WORKAROUND
 #endif
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
@@ -133,11 +133,7 @@ void MayaUsdRPrim::_CommitMVertexBuffer(MHWRender::MVertexBuffer* const buffer, 
 
 void MayaUsdRPrim::_SetWantConsolidation(MHWRender::MRenderItem& renderItem, bool state)
 {
-#if MAYA_API_VERSION >= 20190000
     renderItem.setWantConsolidation(state);
-#else
-    renderItem.setWantSubSceneConsolidation(state);
-#endif
 }
 
 void MayaUsdRPrim::_UpdateTransform(
@@ -497,9 +493,7 @@ MHWRender::MRenderItem* MayaUsdRPrim::_CreateBoundingBoxRenderItem(
     renderItem->setSelectionMask(selectionMask);
     _InitRenderItemCommon(renderItem);
 
-#if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(exclusionFlag);
-#endif
 
     return renderItem;
 }
@@ -530,9 +524,7 @@ MHWRender::MRenderItem* MayaUsdRPrim::_CreateWireframeRenderItem(
 #endif
     _InitRenderItemCommon(renderItem);
 
-#if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(exclusionFlag);
-#endif
 
     return renderItem;
 }
@@ -559,9 +551,7 @@ MHWRender::MRenderItem* MayaUsdRPrim::_CreatePointsRenderItem(
     renderItem->setSelectionMask(selectionMasks);
     _InitRenderItemCommon(renderItem);
 
-#if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(exclusionFlag);
-#endif
 
     return renderItem;
 }

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -2307,21 +2307,7 @@ void HdVP2Mesh::_UpdateDrawItem(
                         *stateToCommit._instanceColors);
                     TF_VERIFY(result == MStatus::kSuccess);
                 }
-            }
-#if MAYA_API_VERSION >= 20210000
-            else if (newInstanceCount >= 1) {
-#else
-            // In Maya 2020 and before, GPU instancing and consolidation are two separate
-            // systems that cannot be used by a render item at the same time. In case of single
-            // instance, we keep the original render item to allow consolidation with other
-            // prims. In case of multiple instances, we need to disable consolidation to allow
-            // GPU instancing to be used.
-            else if (newInstanceCount == 1) {
-                bool success = renderItem->setMatrix(&(*stateToCommit._instanceTransforms)[0]);
-                TF_VERIFY(success);
-            } else if (newInstanceCount > 1) {
-                _SetWantConsolidation(*renderItem, false);
-#endif
+            } else if (newInstanceCount >= 1) {
                 if (stateToCommit._instanceTransforms) {
                     result = drawScene.setInstanceTransformArray(
                         *renderItem, *stateToCommit._instanceTransforms);
@@ -2685,9 +2671,7 @@ HdVP2DrawItem::RenderItemData& HdVP2Mesh::_CreateSmoothHullRenderItem(
     renderItem->setSelectionMask(MSelectionMask::kSelectMeshes);
 #endif
 
-#if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeMeshes);
-#endif
 
 #ifdef HAS_DEFAULT_MATERIAL_SUPPORT_API
     renderItem->setDefaultMaterialHandling(MRenderItem::SkipWhenDefaultMaterialActive);
@@ -2714,9 +2698,7 @@ MHWRender::MRenderItem* HdVP2Mesh::_CreateSelectionHighlightRenderItem(const MSt
     renderItem->setSelectionMask(MSelectionMask());
     _InitRenderItemCommon(renderItem);
 
-#if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeMeshes);
-#endif
 
     return renderItem;
 }

--- a/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.h
@@ -42,7 +42,6 @@
 
 // Maya 2020 is missing API necessary for compute support
 // OSX doesn't have OpenGL 4.3 support necessary for compute
-// USD before 20.08 doesn't include some OSD commits we rely on
 #if MAYA_API_VERSION >= 20210000 && !defined(OSMac_)
 #define HDVP2_ENABLE_GPU_COMPUTE
 #endif

--- a/lib/mayaUsd/render/vp2RenderDelegate/points.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/points.cpp
@@ -866,19 +866,7 @@ void HdVP2Points::_UpdateDrawItem(
                 drawScene.setExtraInstanceData(
                     *renderItem, extraColorChannelName, *stateToCommit._instanceColors);
             }
-        }
-#if MAYA_API_VERSION >= 20210000
-        else if (newInstanceCount >= 1) {
-#else
-        // In Maya 2020 and before, GPU instancing and consolidation are two separate systems that
-        // cannot be used by a render item at the same time. In case of single instance, we keep
-        // the original render item to allow consolidation with other prims. In case of multiple
-        // instances, we need to disable consolidation to allow GPU instancing to be used.
-        else if (newInstanceCount == 1) {
-            renderItem->setMatrix(&(*stateToCommit._instanceTransforms)[0]);
-        } else if (newInstanceCount > 1) {
-            _SetWantConsolidation(*renderItem, false);
-#endif
+        } else if (newInstanceCount >= 1) {
             drawScene.setInstanceTransformArray(*renderItem, *stateToCommit._instanceTransforms);
 
             if (stateToCommit._instanceColors->length() == newInstanceCount * kNumColorChannels) {
@@ -1096,9 +1084,7 @@ HdVP2Points::_CreateFatPointsRenderItem(const MString& name, const TfToken& repr
     renderItem->setSelectionMask(MSelectionMask::kSelectParticleShapes);
 #endif
 
-#if MAYA_API_VERSION >= 20220000
     renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeNParticles);
-#endif
 
     return renderItem;
 }

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -604,11 +604,9 @@ ProxyRenderDelegate::~ProxyRenderDelegate()
 //! \brief  This drawing routine supports all devices (DirectX and OpenGL)
 MHWRender::DrawAPI ProxyRenderDelegate::supportedDrawAPIs() const { return MHWRender::kAllDevices; }
 
-#if defined(MAYA_ENABLE_UPDATE_FOR_SELECTION)
 //! \brief  Enable subscene update in selection passes for deferred update of selection render
 //! items.
 bool ProxyRenderDelegate::enableUpdateForSelection() const { return true; }
-#endif
 
 //! \brief  Always requires update since changes are tracked by Hydraw change tracker and it will
 //! guarantee minimal update; only exception is if rendering through Maya-to-Hydra
@@ -1094,7 +1092,6 @@ void ProxyRenderDelegate::_Execute(const MHWRender::MFrameContext& frameContext)
     // If update for selection is enabled, the draw data for the "points" repr
     // won't be prepared until point snapping is activated; otherwise the draw
     // data have to be prepared early for possible activation of point snapping.
-#if defined(MAYA_ENABLE_UPDATE_FOR_SELECTION)
     const bool inSelectionPass = (frameContext.getSelectionInfo() != nullptr);
 #if !defined(MAYA_NEW_POINT_SNAPPING_SUPPORT) || defined(WANT_UFE_BUILD)
     const bool inPointSnapping = pointSnappingActive();
@@ -1112,15 +1109,6 @@ void ProxyRenderDelegate::_Execute(const MHWRender::MFrameContext& frameContext)
         _pointInstancesPickMode = UsdPointInstancesPickMode::PointInstancer;
     }
 #endif // defined(WANT_UFE_BUILD)
-
-#else // !defined(MAYA_ENABLE_UPDATE_FOR_SELECTION)
-    _combinedDisplayStyles[HdReprTokens->points] = _frameCounter;
-
-    constexpr bool inSelectionPass = false;
-#if !defined(MAYA_NEW_POINT_SNAPPING_SUPPORT)
-    constexpr bool inPointSnapping = false;
-#endif
-#endif // defined(MAYA_ENABLE_UPDATE_FOR_SELECTION)
 
     // Work around USD issue #1516. There is a significant performance overhead caused by populating
     // selection, so only force the populate selection to occur when we detect a change which
@@ -1234,11 +1222,7 @@ void ProxyRenderDelegate::update(MSubSceneContainer& container, const MFrameCont
     const MSelectionInfo* selectionInfo = frameContext.getSelectionInfo();
     if (selectionInfo) {
         bool oldSnapToPoints = _snapToPoints;
-#if MAYA_API_VERSION >= 20220000
         _snapToPoints = selectionInfo->pointSnapping();
-#else
-        _snapToPoints = pointSnappingActive();
-#endif
         if (_snapToPoints != oldSnapToPoints) {
             _selectionModeChanged = true;
         }
@@ -1404,22 +1388,16 @@ bool ProxyRenderDelegate::getInstancedSelectionPath(
         topLevelInstanceIndex = instancerContext.front().second;
     }
 #else
-    SdfPath                         usdPath = GetScenePrimPath(rprimId, instanceIndex);
+    SdfPath usdPath = GetScenePrimPath(rprimId, instanceIndex);
 #endif
 
     // If update for selection is enabled, we can query the Maya selection list
     // adjustment, USD selection kind, and USD point instances pick mode once
     // per selection update to avoid the cost of executing MEL commands or
     // searching optionVars for each intersection.
-#if defined(MAYA_ENABLE_UPDATE_FOR_SELECTION)
     const TfToken&                   selectionKind = _selectionKind;
     const UsdPointInstancesPickMode& pointInstancesPickMode = _pointInstancesPickMode;
     const MGlobal::ListAdjustment&   listAdjustment = _globalListAdjustment;
-#else
-    const TfToken                   selectionKind = GetSelectionKind();
-    const UsdPointInstancesPickMode pointInstancesPickMode = GetPointInstancesPickMode();
-    const MGlobal::ListAdjustment   listAdjustment = GetListAdjustment();
-#endif
 
     UsdPrim       prim = _proxyShapeData->UsdStage()->GetPrimAtPath(usdPath);
     const UsdPrim topLevelPrim = _proxyShapeData->UsdStage()->GetPrimAtPath(topLevelPath);
@@ -1503,7 +1481,7 @@ bool ProxyRenderDelegate::getInstancedSelectionPath(
     auto ufeSel = Ufe::NamedSelection::get("MayaSelectTool");
     ufeSel->append(si);
 #else
-    auto                            globalSelection = Ufe::GlobalSelection::get();
+    auto    globalSelection = Ufe::GlobalSelection::get();
 
     switch (listAdjustment) {
     case MGlobal::kReplaceList:

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -43,11 +43,6 @@
 #include <ufe/path.h>
 #endif
 
-// Conditional compilation due to Maya API gap.
-#if MAYA_API_VERSION >= 20200000
-#define MAYA_ENABLE_UPDATE_FOR_SELECTION
-#endif
-
 // Use the latest MPxSubSceneOverride API
 #ifndef OPENMAYA_MPXSUBSCENEOVERRIDE_LATEST_NAMESPACE
 #define OPENMAYA_MPXSUBSCENEOVERRIDE_LATEST_NAMESPACE OPENMAYA_MAJOR_NAMESPACE
@@ -129,10 +124,8 @@ public:
     MAYAUSD_CORE_PUBLIC
     MHWRender::DrawAPI supportedDrawAPIs() const override;
 
-#if defined(MAYA_ENABLE_UPDATE_FOR_SELECTION)
     MAYAUSD_CORE_PUBLIC
     bool enableUpdateForSelection() const override;
-#endif
 
     MAYAUSD_CORE_PUBLIC
     bool requiresUpdate(const MSubSceneContainer& container, const MFrameContext& frameContext)
@@ -473,7 +466,7 @@ private:
     MCallbackId _mayaSelectionCallbackId { 0 };
 #endif
 
-#if defined(WANT_UFE_BUILD) && defined(MAYA_ENABLE_UPDATE_FOR_SELECTION)
+#if defined(WANT_UFE_BUILD)
     //! Adjustment mode for global selection list: ADD, REMOVE, REPLACE, XOR
     MGlobal::ListAdjustment _globalListAdjustment;
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/render_delegate.cpp
@@ -565,14 +565,8 @@ const HdVP2BBoxGeom* sSharedBBoxGeom
 
 } // namespace
 
-const int HdVP2RenderDelegate::sProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "HdVP2RenderDelegate",
-    "HdVP2RenderDelegate"
-#else
-    "HdVP2RenderDelegate"
-#endif
-);
+const int HdVP2RenderDelegate::sProfilerCategory
+    = MProfiler::addCategory("HdVP2RenderDelegate", "HdVP2RenderDelegate");
 
 std::mutex                  HdVP2RenderDelegate::_renderDelegateMutex;
 std::atomic_int             HdVP2RenderDelegate::_renderDelegateCounter;

--- a/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.cpp
+++ b/lib/mayaUsd/render/vp2ShaderFragments/shaderFragments.cpp
@@ -188,8 +188,6 @@ std::string _GetResourcePath(const std::string& resource)
     return path;
 }
 
-#if MAYA_API_VERSION >= 20210000
-
 //! Structure for Automatic shader stage input parameter to register in VP2.
 struct AutomaticShaderStageInput
 {
@@ -232,8 +230,6 @@ std::vector<AutomaticShaderStageInput> _automaticShaderStageInputs
 std::vector<std::pair<MString, MString>> _domainShaderInputNameMappings
     = { { "BasisCurvesCubicColor", "BasisCurvesCubicColorDomain" },
         { "BasisCurvesLinearColor", "BasisCurvesLinearColorDomain" } };
-
-#endif
 
 } // anonymous namespace
 
@@ -555,8 +551,6 @@ MStatus HdVP2ShaderFragments::registerFragments()
     }
 #endif // not HAS_COLOR_MANAGEMENT_SUPPORT_API
 
-#if MAYA_API_VERSION >= 20210000
-
     // Register automatic shader stage input parameters.
     for (const auto& input : _automaticShaderStageInputs) {
         fragmentManager->addAutomaticShaderStageInput(
@@ -571,8 +565,6 @@ MStatus HdVP2ShaderFragments::registerFragments()
     for (const auto& mapping : _domainShaderInputNameMappings) {
         fragmentManager->addDomainShaderInputNameMapping(mapping.first, mapping.second);
     }
-
-#endif
 
     _registrationCount++;
 
@@ -602,8 +594,6 @@ MStatus HdVP2ShaderFragments::deregisterFragments()
         return MS::kFailure;
     }
 
-#if MAYA_API_VERSION >= 20210000
-
     // De-register a desired domain shader fragment for each input parameter.
     for (const auto& mapping : _domainShaderInputNameMappings) {
         fragmentManager->removeDomainShaderInputNameMapping(mapping.first);
@@ -613,8 +603,6 @@ MStatus HdVP2ShaderFragments::deregisterFragments()
     for (const auto& input : _automaticShaderStageInputs) {
         fragmentManager->removeAutomaticShaderStageInput(input._shaderStage, input._parameterName);
     }
-
-#endif
 
     // De-register the various UsdUVTexture fragments:
     for (const auto& txtFrag : _textureFragNames) {

--- a/lib/mayaUsd/utils/converter.cpp
+++ b/lib/mayaUsd/utils/converter.cpp
@@ -820,10 +820,8 @@ template <class MAYA_Type, class USD_Type, NeedsGammaCorrection ColorCorrection>
     }
 };
 
-// Missing attribute method for MDataHandle prior to Maya 2020. For now disable all
-// array converters to avoid complicating interface and error handling. If needed,
-// we should be able to back-port the change to an update.
-#if MAYA_API_VERSION >= 20200000
+// For now disable all array converters to avoid complicating interface and
+// error handling. If needed, we should be able to back-port the change to an update.
 //! \brief  Utility class for conversion between array data handles and Usd.
 template <class MAYA_Type, class USD_Type, NeedsGammaCorrection ColorCorrection>
 struct MArrayDataHandleConvert
@@ -998,7 +996,6 @@ struct MArrayPlugConvert
         }
     }
 };
-#endif
 
 //---------------------------------------------------------------------------------
 //! \brief  Storage for generated instances of converters.
@@ -1081,7 +1078,6 @@ struct Converter::GenerateConverters
 //! \brief  Utility class responsible for generating all supported array attribute converters.
 struct Converter::GenerateArrayPlugConverters
 {
-#if MAYA_API_VERSION >= 20200000
     template <
         class MAYA_Type,
         class USD_Type,
@@ -1130,13 +1126,6 @@ struct Converter::GenerateArrayPlugConverters
         createArrayConverter<MMatrix, GfMatrix4d>(converters, SdfValueTypeNames->Matrix4dArray);
         return converters;
     }
-#else
-    static ConvertStorage generate()
-    {
-        ConvertStorage converters;
-        return converters;
-    }
-#endif
 };
 
 namespace {

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -17,6 +17,7 @@
 
 #include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/undo/OpUndoItems.h>
+#include <mayaUsd/utils/colorSpace.h>
 
 #include <maya/MAnimControl.h>
 #include <maya/MAnimUtil.h>
@@ -37,6 +38,7 @@
 #include <maya/MFnNumericAttribute.h>
 #include <maya/MFnSet.h>
 #include <maya/MFnSingleIndexedComponent.h>
+#include <maya/MFnStandardSurfaceShader.h>
 #include <maya/MFnTypedAttribute.h>
 #include <maya/MGlobal.h>
 #include <maya/MItDag.h>
@@ -61,12 +63,6 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#if MAYA_API_VERSION >= 20200000
-#include <maya/MFnStandardSurfaceShader.h>
-#endif
-
-#include <mayaUsd/utils/colorSpace.h>
 
 #include <pxr/base/gf/gamma.h>
 #include <pxr/base/gf/vec2f.h>
@@ -852,7 +848,6 @@ bool _GetColorAndTransparencyFromStandardSurface(
     GfVec3f*       rgb,
     float*         alpha)
 {
-#if MAYA_API_VERSION >= 20200000
     MStatus                  status;
     MFnStandardSurfaceShader surfaceFn(shaderObj, &status);
     if (status == MS::kSuccess) {
@@ -870,7 +865,6 @@ bool _GetColorAndTransparencyFromStandardSurface(
         }
         return true;
     }
-#endif
     return false;
 }
 
@@ -2326,11 +2320,9 @@ double UsdMayaUtil::ConvertMTimeUnitToDouble(const MTime::Unit& unit)
     case MTime::k80FPS: {
         ret = 80.0;
     } break;
-#if MAYA_API_VERSION >= 20200000
     case MTime::k90FPS: {
         ret = 90.0;
     } break;
-#endif
     case MTime::k100FPS: {
         ret = 100.0;
     } break;

--- a/lib/usd/hdMaya/adapters/meshAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/meshAdapter.cpp
@@ -233,15 +233,9 @@ public:
 
         // TODO: Maybe we could use the flat shading of the display style?
         return HdMeshTopology(
-#if MAYA_APP_VERSION >= 2019
             (GetDelegate()->GetParams().displaySmoothMeshes || GetDisplayStyle().refineLevel > 0)
                 ? PxOsdOpenSubdivTokens->catmullClark
                 : PxOsdOpenSubdivTokens->none,
-#else
-            GetDelegate()->GetParams().displaySmoothMeshes ? PxOsdOpenSubdivTokens->catmullClark
-                                                           : PxOsdOpenSubdivTokens->none,
-#endif
-
             UsdGeomTokens->rightHanded,
             faceVertexCounts,
             faceVertexIndices);
@@ -249,7 +243,6 @@ public:
 
     HdDisplayStyle GetDisplayStyle() override
     {
-#if MAYA_APP_VERSION >= 2019
         MStatus           status;
         MFnDependencyNode node(GetNode(), &status);
         if (ARCH_UNLIKELY(!status)) {
@@ -263,14 +256,10 @@ public:
         const auto smoothLevel
             = std::max(0, node.findPlug(MayaAttrs::mesh::smoothLevel, true).asInt());
         return { smoothLevel, false, false };
-#else
-        return { 0, false, false };
-#endif
     }
 
     PxOsdSubdivTags GetSubdivTags() override
     {
-#if MAYA_APP_VERSION >= 2019
         PxOsdSubdivTags tags;
         if (GetDisplayStyle().refineLevel < 1) {
             return tags;
@@ -332,9 +321,6 @@ public:
         tags.SetTriangleSubdivision(UsdGeomTokens->catmullClark);
 
         return tags;
-#else
-        return {};
-#endif
     }
 
     HdPrimvarDescriptorVector GetPrimvarDescriptors(HdInterpolation interpolation) override

--- a/lib/usd/hdMaya/delegates/delegate.h
+++ b/lib/usd/hdMaya/delegates/delegate.h
@@ -112,7 +112,6 @@ public:
     virtual bool SupportsUfeSelection() { return false; }
 #endif // WANT_UFE_BUILD
 
-#if MAYA_API_VERSION >= 20210000
     virtual void PopulateSelectionList(
         const HdxPickHitVector&          hits,
         const MHWRender::MSelectionInfo& selectInfo,
@@ -120,7 +119,6 @@ public:
         MPointArray&                     worldSpaceHitPts)
     {
     }
-#endif
 
     void SetLightsEnabled(const bool enabled) { _lightsEnabled = enabled; }
     bool GetLightsEnabled() { return _lightsEnabled; }

--- a/lib/usd/hdMaya/delegates/proxyDelegate.cpp
+++ b/lib/usd/hdMaya/delegates/proxyDelegate.cpp
@@ -139,7 +139,7 @@ void SetupPluginCallbacks()
 }
 
 #ifndef UFE_V2_FEATURES_AVAILABLE
-#if (MAYA_API_VERSION >= 20210000) && WANT_UFE_BUILD
+#if WANT_UFE_BUILD
 MGlobal::ListAdjustment GetListAdjustment()
 {
     // Keyboard modifiers can be queried from QApplication::keyboardModifiers()
@@ -327,7 +327,6 @@ bool HdMayaProxyDelegate::SupportsUfeSelection() { return MayaUsd::ufe::getUsdRu
 
 #endif // WANT_UFE_BUILD
 
-#if MAYA_API_VERSION >= 20210000
 void HdMayaProxyDelegate::PopulateSelectionList(
     const HdxPickHitVector&          hits,
     const MHWRender::MSelectionInfo& selectInfo,
@@ -429,6 +428,5 @@ void HdMayaProxyDelegate::PopulateSelectionList(
     }
 #endif // WANT_UFE_BUILD
 }
-#endif // MAYA_API_VERSION >= 20210000
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/usd/hdMaya/delegates/proxyDelegate.h
+++ b/lib/usd/hdMaya/delegates/proxyDelegate.h
@@ -66,13 +66,11 @@ public:
     bool SupportsUfeSelection() override;
 #endif // WANT_UFE_BUILD
 
-#if MAYA_API_VERSION >= 20210000
     void PopulateSelectionList(
         const HdxPickHitVector&          hits,
         const MHWRender::MSelectionInfo& selectInfo,
         MSelectionList&                  selectionList,
         MPointArray&                     worldSpaceHitPts) override;
-#endif
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/usd/hdMaya/delegates/sceneDelegate.cpp
+++ b/lib/usd/hdMaya/delegates/sceneDelegate.cpp
@@ -739,7 +739,6 @@ void HdMayaSceneDelegate::PopulateSelectedPaths(
         MFn::kShape);
 }
 
-#if MAYA_API_VERSION >= 20210000
 void HdMayaSceneDelegate::PopulateSelectionList(
     const HdxPickHitVector&          hits,
     const MHWRender::MSelectionInfo& selectInfo,
@@ -773,7 +772,6 @@ void HdMayaSceneDelegate::PopulateSelectionList(
             _shapeAdapters);
     }
 }
-#endif
 
 HdMeshTopology HdMayaSceneDelegate::GetMeshTopology(const SdfPath& id)
 {

--- a/lib/usd/hdMaya/delegates/sceneDelegate.h
+++ b/lib/usd/hdMaya/delegates/sceneDelegate.h
@@ -123,14 +123,12 @@ public:
         SdfPathVector&              selectedSdfPaths,
         const HdSelectionSharedPtr& selection) override;
 
-#if MAYA_API_VERSION >= 20210000
     HDMAYA_API
     void PopulateSelectionList(
         const HdxPickHitVector&          hits,
         const MHWRender::MSelectionInfo& selectInfo,
         MSelectionList&                  selectionList,
         MPointArray&                     worldSpaceHitPts) override;
-#endif
 
     bool GetEnableMaterials() const { return _enableMaterials; }
     void SetEnableMaterials(bool enable) { _enableMaterials = enable; }

--- a/lib/usd/translators/meshReader.cpp
+++ b/lib/usd/translators/meshReader.cpp
@@ -131,12 +131,8 @@ bool MayaUsdPrimReaderMesh::Read(UsdMayaPrimReaderContext& context)
     // assign invisible faces
     UsdMayaMeshReadUtils::assignInvisibleFaces(mesh, meshRead.meshObject());
 
-#if MAYA_API_VERSION >= 20220000
-
     // Read componentTags
     UsdMayaMeshReadUtils::createComponentTags(mesh, meshRead.meshObject());
-
-#endif
 
     // assign material
     assignMaterial(mesh, _GetArgs(), meshRead.meshObject(), &context);

--- a/lib/usd/translators/meshWriter.cpp
+++ b/lib/usd/translators/meshWriter.cpp
@@ -825,13 +825,9 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
             _GetSparseValueWriter());
     }
 
-#if MAYA_API_VERSION >= 20220000
-
     if (exportArgs.exportComponentTags) {
         UsdMayaMeshWriteUtils::exportComponentTags(primSchema, GetMayaObject());
     }
-
-#endif
 
     return true;
 }

--- a/lib/usd/translators/shading/CMakeLists.txt
+++ b/lib/usd/translators/shading/CMakeLists.txt
@@ -18,20 +18,14 @@ target_sources(${TARGET_NAME}
         usdReflectWriter.cpp
         usdUVTextureReader.cpp
         usdPrimvarReaderFloat3Reader.cpp
+        usdStandardSurfaceReader.cpp
+        usdStandardSurfaceWriter.cpp
 )
 
 if (BUILD_RFM_TRANSLATORS)
     target_sources(${TARGET_NAME}
         PRIVATE
             rfmShaderTranslation.cpp
-    )
-endif()
-
-if (MAYA_APP_VERSION VERSION_GREATER_EQUAL 2020)
-    target_sources(${TARGET_NAME}
-        PRIVATE
-            usdStandardSurfaceReader.cpp
-            usdStandardSurfaceWriter.cpp
     )
 endif()
 

--- a/lib/usd/ui/layerEditor/mayaCommandHook.cpp
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.cpp
@@ -236,11 +236,7 @@ void MayaCommandHook::selectPrimsWithSpec(UsdLayer usdLayer)
     script += R"PYTHON(
 # Ufe
 import ufe
-try:
-    from maya.internal.ufeSupport import ufeSelectCmd
-except ImportError:
-    # Maya 2019 and 2020 don't have ufeSupport plugin, so use fallback.
-    from ufeScripts import ufeSelectCmd
+from maya.internal.ufeSupport import ufeSelectCmd
 
 # create a selection list
 sn = ufe.Selection()

--- a/plugin/adsk/plugin/ProxyShape.cpp
+++ b/plugin/adsk/plugin/ProxyShape.cpp
@@ -65,9 +65,7 @@ void ProxyShape::postConstructor()
     }
 
     // Enable proxy accessor features for this proxy
-#if MAYA_API_VERSION >= 20210000
     enableProxyAccessor();
-#endif
 }
 
 } // namespace MAYAUSD_NS_DEF

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/StageCache.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/StageCache.cpp
@@ -22,14 +22,7 @@
 
 #include <maya/MProfiler.h>
 namespace {
-const int _stageCacheProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "StageCache",
-    "StageCache"
-#else
-    "StageCache"
-#endif
-);
+const int _stageCacheProfilerCategory = MProfiler::addCategory("StageCache", "StageCache");
 } // namespace
 
 namespace AL {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/AnimationTranslator.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/AnimationTranslator.cpp
@@ -27,7 +27,6 @@
 #include <maya/MItDependencyGraph.h>
 #include <maya/MMatrix.h>
 #include <maya/MNodeClass.h>
-#include <maya/MTypes.h> // For MAYA_APP_VERSION
 
 namespace AL {
 namespace usdmaya {
@@ -61,29 +60,20 @@ void AnimationTranslator::exportAnimation(const ExporterParams& params)
                 ///         maya::Dg
                 ///         usdmaya::Dg
                 ///         usdmaya::fileio::translator::Dg
-#if MAYA_APP_VERSION > 2019
                 translators::TransformTranslator::copyAttributeValue(
                     it->first, it->second, timeCode, params.m_mergeOffsetParentMatrix);
-#else
-                translators::DgNodeTranslator::copyAttributeValue(it->first, it->second, timeCode);
-#endif
             }
             for (auto it = startAttribScaled; it != endAttribScaled; ++it) {
                 /// \todo This feels wrong. Split the DgNodeTranslator class into 3 ...
                 ///         maya::Dg
                 ///         usdmaya::Dg
                 ///         usdmaya::fileio::translator::Dg
-#if MAYA_APP_VERSION > 2019
                 translators::TransformTranslator::copyAttributeValue(
                     it->first,
                     it->second.attr,
                     it->second.scale,
                     timeCode,
                     params.m_mergeOffsetParentMatrix);
-#else
-                translators::DgNodeTranslator::copyAttributeValue(
-                    it->first, it->second.attr, it->second.scale, timeCode);
-#endif
             }
             for (auto it = startTransformAttrib; it != endTransformAttrib; ++it) {
                 translators::TransformTranslator::copyAttributeValue(

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/Export.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/Export.cpp
@@ -39,7 +39,6 @@
 #include <maya/MNodeClass.h>
 #include <maya/MPlugArray.h>
 #include <maya/MSyntax.h>
-#include <maya/MTypes.h> // For MAYA_APP_VERSION
 
 namespace AL {
 namespace usdmaya {
@@ -1083,13 +1082,11 @@ MStatus ExportCommand::doIt(const MArgList& args)
             argData.getFlagArgument("mt", 0, m_params.m_mergeTransforms),
             "ALUSDExport: Unable to fetch \"merge transforms\" argument");
     }
-#if MAYA_APP_VERSION > 2019
     if (argData.isFlagSet("mom", &status)) {
         AL_MAYA_CHECK_ERROR(
             argData.getFlagArgument("mom", 0, m_params.m_mergeOffsetParentMatrix),
             "ALUSDExport: Unable to fetch \"merge offset parent matrix\" argument");
     }
-#endif
     if (argData.isFlagSet("nc", &status)) {
         bool option;
         argData.getFlagArgument("nc", 0, option);
@@ -1248,10 +1245,8 @@ MSyntax ExportCommand::createSyntax()
     AL_MAYA_CHECK_ERROR2(status, errorString);
     status = syntax.addFlag("-mt", "-mergeTransforms", MSyntax::kBoolean);
     AL_MAYA_CHECK_ERROR2(status, errorString);
-#if MAYA_APP_VERSION > 2019
     status = syntax.addFlag("-mom", "-mergeOffsetParentMatrix", MSyntax::kBoolean);
     AL_MAYA_CHECK_ERROR2(status, errorString);
-#endif
     status = syntax.addFlag("-ani", "-animation", MSyntax::kNoArg);
     AL_MAYA_CHECK_ERROR2(status, errorString);
     status = syntax.addFlag("-fr", "-frameRange", MSyntax::kDouble, MSyntax::kDouble);

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportParams.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportParams.h
@@ -23,7 +23,6 @@
 
 #include <maya/MSelectionList.h>
 #include <maya/MStringArray.h>
-#include <maya/MTypes.h> // For MAYA_APP_VERSION
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -54,11 +53,9 @@ struct ExporterParams
     bool m_mergeTransforms
         = true; ///< if true, shapes will be merged into their parent transforms in the exported
                 ///< data. If false, the transform and shape will be exported seperately
-#if MAYA_APP_VERSION > 2019
     bool m_mergeOffsetParentMatrix
         = false; ///< if true, offset parent matrix would be merged to produce local space matrix;
                  ///< if false, offset parent matrix would be exported separately in USD.
-#endif
     bool m_animation = false;        ///< if true, animation will be exported.
     bool m_useTimelineRange = false; ///< if true, then the export uses Maya's timeline range.
     bool m_filterSample = false; ///< if true, duplicate sample of attribute will be filtered out

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportTranslator.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportTranslator.cpp
@@ -54,9 +54,7 @@ MStatus ExportTranslator::writer(
     params.m_dynamicAttributes = options.getBool(kDynamicAttributes);
     params.m_duplicateInstances = options.getBool(kDuplicateInstances);
     params.m_mergeTransforms = options.getBool(kMergeTransforms);
-#if MAYA_APP_VERSION > 2019
     params.m_mergeOffsetParentMatrix = options.getBool(kMergeOffsetParentMatrix);
-#endif
     params.m_fileName = file.fullName();
     params.m_selected = mode == MPxFileTranslator::kExportActiveAccessMode;
     params.m_animation = options.getBool(kAnimation);

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/ExportTranslator.h
@@ -20,8 +20,6 @@
 #include <AL/usdmaya/Api.h>
 #include <AL/usdmaya/fileio/ExportParams.h>
 
-#include <maya/MTypes.h> // For MAYA_APP_VERSION
-
 namespace AL {
 namespace usdmaya {
 namespace fileio {
@@ -62,10 +60,8 @@ static constexpr const char* const kDuplicateInstances
     = "Duplicate Instances"; ///< export instances option name
 static constexpr const char* const kMergeTransforms
     = "Merge Transforms"; ///< export by merging transforms and shapes option name
-#if MAYA_APP_VERSION > 2019
 static constexpr const char* const kMergeOffsetParentMatrix
     = "Merge Offset Parent Matrix"; ///< export by merging offset parent matrix
-#endif
 static constexpr const char* const kAnimation = "Animation"; ///< export animation data option name
 static constexpr const char* const kUseTimelineRange
     = "Use Timeline Range"; ///< export using the timeline range option name
@@ -109,10 +105,8 @@ static MStatus specifyOptions(AL::maya::utils::FileTranslatorOptions& options)
         return MS::kFailure;
     if (!options.addBool(kMergeTransforms, defaultValues.m_mergeTransforms))
         return MS::kFailure;
-#if MAYA_APP_VERSION > 2019
     if (!options.addBool(kMergeOffsetParentMatrix, defaultValues.m_mergeOffsetParentMatrix))
         return MS::kFailure;
-#endif
     if (!options.addBool(kAnimation, defaultValues.m_animation))
         return MS::kFailure;
     if (!options.addBool(kUseTimelineRange, defaultValues.m_useTimelineRange))

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.cpp
@@ -48,7 +48,6 @@ namespace usdmaya {
 namespace fileio {
 namespace translators {
 
-#if MAYA_APP_VERSION > 2019
 //----------------------------------------------------------------------------------------------------------------------
 static const GfMatrix4d g_identityMatrix(1.0);
 static constexpr double g_tolerance = 1e-9;
@@ -193,8 +192,6 @@ bool extractOffsetMatrixComponent(const MPlug& attr, double* value)
 }
 
 } // namespace
-
-#endif
 
 //----------------------------------------------------------------------------------------------------------------------
 MObject TransformTranslator::m_inheritsTransform = MObject::kNullObj;
@@ -863,7 +860,6 @@ MStatus TransformTranslator::copyAttributes(
         // This adds an op to the stack so we should do it after ClearXformOpOrder():
         xformSchema.SetResetXformStack(!inheritsTransform);
 
-#if MAYA_APP_VERSION > 2019
         if (params.m_mergeOffsetParentMatrix
             && extractOffsetMatrixComponents(
                 from, translation, rotation, rotateOrder, scale, shear)) {
@@ -871,18 +867,13 @@ MStatus TransformTranslator::copyAttributes(
             transformAnimated
                 |= animationCheck(animTranslator, MPlug(from, MPxTransform::offsetParentMatrix));
         } else {
-#endif
-
             /// Retrieve the values directly from Maya
             getVec3(from, m_scale, (float*)&scale);
             getVec3(from, m_shear, (float*)&shear);
             getVec3(from, m_rotation, (float*)&rotation);
             getInt32(from, m_rotateOrder, rotateOrder);
             getVec3(from, m_translation, (double*)&translation);
-
-#if MAYA_APP_VERSION > 2019
         }
-#endif
 
         bool plugAnimated = animationCheck(animTranslator, MPlug(from, m_visible));
         if (plugAnimated || visible != defaultVisible) {
@@ -1030,7 +1021,6 @@ void TransformTranslator::copyAttributeValue(
     }
 }
 
-#if MAYA_APP_VERSION > 2019
 //----------------------------------------------------------------------------------------------------------------------
 void TransformTranslator::copyAttributeValue(
     const MPlug&       attr,
@@ -1104,8 +1094,6 @@ void TransformTranslator::copyAttributeValue(
 
     translators::DgNodeTranslator::copyAttributeValue(attr, usdAttr, scale, timeCode);
 }
-
-#endif
 
 //----------------------------------------------------------------------------------------------------------------------
 } // namespace translators

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TransformTranslator.h
@@ -24,8 +24,6 @@
 #include <pxr/usd/usdGeom/xform.h>
 #include <pxr/usd/usdGeom/xformCommonAPI.h>
 
-#include <maya/MTypes.h> // For MAYA_APP_VERSION
-
 #include <vector>
 
 namespace AL {
@@ -102,7 +100,6 @@ public:
         MObject&           attribute,
         double&            conversionFactor);
 
-#if MAYA_APP_VERSION > 2019
     /// \brief  helper method to copy attributes from the UsdPrim to the Maya node
     /// \param  attr the maya node to copy the data from
     /// \param  usdAttr the UsdPrim to copy the data to
@@ -128,7 +125,6 @@ public:
         float              scale,
         const UsdTimeCode& timeCode,
         bool               mergeOffsetMatrix);
-#endif
 
 private:
     static MStatus processMetaData(const UsdPrim& from, MObject& to, const ImporterParams& params);

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorBase.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorBase.cpp
@@ -26,14 +26,8 @@
 
 #include <maya/MProfiler.h>
 namespace {
-const int _translatorProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "TranslatorManufacture",
-    "TranslatorManufacture"
-#else
-    "TranslatorManufacture"
-#endif
-);
+const int _translatorProfilerCategory
+    = MProfiler::addCategory("TranslatorManufacture", "TranslatorManufacture");
 } // namespace
 
 namespace AL {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.cpp
@@ -25,14 +25,8 @@
 #include <string>
 
 namespace {
-const int _translatorContextProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "TranslatorContext",
-    "TranslatorContext"
-#else
-    "TranslatorContext"
-#endif
-);
+const int _translatorContextProfilerCategory
+    = MProfiler::addCategory("TranslatorContext", "TranslatorContext");
 
 bool isDescendantPath(const SdfPathSet& affectedPaths, const SdfPath& path)
 {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp
@@ -39,14 +39,7 @@
 #include <vector>
 
 namespace {
-const int _enginProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "GLEngine",
-    "GLEngine"
-#else
-    "GLEngine"
-#endif
-);
+const int _enginProfilerCategory = MProfiler::addCategory("GLEngine", "GLEngine");
 } // namespace
 
 namespace AL {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.cpp
@@ -40,14 +40,7 @@
 #include <mutex>
 
 namespace {
-const int _layerManagerProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "LayerManager",
-    "LayerManager"
-#else
-    "LayerManager"
-#endif
-);
+const int _layerManagerProfilerCategory = MProfiler::addCategory("LayerManager", "LayerManager");
 
 MObjectHandle theLayerManagerHandle;
 

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -74,14 +74,8 @@ typedef void (
 const char* ProxyShape::s_selectionMaskName = "al_ProxyShape";
 
 namespace {
-const int _proxyShapeProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "AL_usdmaya_ProxyShape",
-    "AL_usdmaya_ProxyShape"
-#else
-    "AL_usdmaya_ProxyShape"
-#endif
-);
+const int _proxyShapeProfilerCategory
+    = MProfiler::addCategory("AL_usdmaya_ProxyShape", "AL_usdmaya_ProxyShape");
 
 //----------------------------------------------------------------------------------------------------------------------
 /// \brief Verify given Maya node is still valid.
@@ -1499,9 +1493,7 @@ void ProxyShape::postConstructor()
     MPlug(thisMObject(), m_visibleInReflections).setValue(true);
     MPlug(thisMObject(), m_visibleInRefractions).setValue(true);
 
-#if MAYA_API_VERSION >= 20210000
     enableProxyAccessor();
-#endif
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeSelection.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeSelection.cpp
@@ -31,14 +31,8 @@ namespace usdmaya {
 namespace nodes {
 namespace {
 
-const int _proxyShapeSelectionProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "AL_usdmaya_ProxyShape_selection",
-    "AL_usdmaya_ProxyShape_selection"
-#else
-    "AL_usdmaya_ProxyShape_selection"
-#endif
-);
+const int _proxyShapeSelectionProfilerCategory
+    = MProfiler::addCategory("AL_usdmaya_ProxyShape_selection", "AL_usdmaya_ProxyShape_selection");
 
 typedef void (
     *proxy_function_prototype)(void* userData, AL::usdmaya::nodes::ProxyShape* proxyInstance);

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Scope.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Scope.cpp
@@ -101,14 +101,7 @@ MStatus Scope::initialise()
             AL_MAYA_CHECK_ERROR(attributeAffects(inAttr, rotatePivotTranslate), errorString);
             AL_MAYA_CHECK_ERROR(attributeAffects(inAttr, scalePivot), errorString);
             AL_MAYA_CHECK_ERROR(attributeAffects(inAttr, scalePivotTranslate), errorString);
-            // Maya 2018 (checked 2018.2 and 2018.3) has a bug where, if any loaded plugin has an
-            // MPxTransform subclass that has ANY attribute that connected to rotateAxis, it will
-            // cause the rotateAxis to evaluate INCORRECTLY, even on the BASE transform class! See
-            // this gist for full reproduction details:
-            //   https://gist.github.com/elrond79/f9ddb277da3eab2948d27ddb1f84aba0
-#if MAYA_API_VERSION >= 20180600
             AL_MAYA_CHECK_ERROR(attributeAffects(inAttr, rotateAxis), errorString);
-#endif
             AL_MAYA_CHECK_ERROR(attributeAffects(inAttr, matrix), errorString);
             AL_MAYA_CHECK_ERROR(attributeAffects(inAttr, worldMatrix), errorString);
             AL_MAYA_CHECK_ERROR(attributeAffects(inAttr, inverseMatrix), errorString);

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Scope.h
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Scope.h
@@ -49,15 +49,9 @@ namespace nodes {
 /// \ingroup nodes
 //----------------------------------------------------------------------------------------------------------------------
 
-#if MAYA_API_VERSION >= 20190200 && MAYA_API_VERSION < 20200000
-class Scope
-    : public MPxTransform_BoundingBox
-    , public AL::maya::utils::NodeHelper
-#else
 class Scope
     : public MPxTransform
     , public AL::maya::utils::NodeHelper
-#endif
 {
 public:
     Scope();

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Transform.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/Transform.cpp
@@ -31,14 +31,7 @@
 #include <maya/MTime.h>
 
 namespace {
-const int _transformProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "Transform",
-    "Transform"
-#else
-    "Transform"
-#endif
-);
+const int _transformProfilerCategory = MProfiler::addCategory("Transform", "Transform");
 } // namespace
 
 namespace {
@@ -175,14 +168,7 @@ MStatus Transform::initialise()
             AL_MAYA_CHECK_ERROR(attributeAffects(inAttr, rotatePivotTranslate), errorString);
             AL_MAYA_CHECK_ERROR(attributeAffects(inAttr, scalePivot), errorString);
             AL_MAYA_CHECK_ERROR(attributeAffects(inAttr, scalePivotTranslate), errorString);
-            // Maya 2018 (checked 2018.2 and 2018.3) has a bug where, if any loaded plugin has an
-            // MPxTransform subclass that has ANY attribute that connected to rotateAxis, it will
-            // cause the rotateAxis to evaluate INCORRECTLY, even on the BASE transform class! See
-            // this gist for full reproduction details:
-            //   https://gist.github.com/elrond79/f9ddb277da3eab2948d27ddb1f84aba0
-#if MAYA_API_VERSION >= 20180600
             AL_MAYA_CHECK_ERROR(attributeAffects(inAttr, rotateAxis), errorString);
-#endif
             AL_MAYA_CHECK_ERROR(attributeAffects(inAttr, matrix), errorString);
             AL_MAYA_CHECK_ERROR(attributeAffects(inAttr, worldMatrix), errorString);
             AL_MAYA_CHECK_ERROR(attributeAffects(inAttr, inverseMatrix), errorString);

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
@@ -31,14 +31,8 @@
 #define AL_USDMAYA_XFORM_COMP_EPSILON 1e-7
 
 namespace {
-const int _transformationMatrixProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "TransformationMatrix",
-    "TransformationMatrix"
-#else
-    "TransformationMatrix"
-#endif
-);
+const int _transformationMatrixProfilerCategory
+    = MProfiler::addCategory("TransformationMatrix", "TransformationMatrix");
 } // namespace
 
 PXR_NAMESPACE_USING_DIRECTIVE

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/PrimFilter.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/PrimFilter.cpp
@@ -20,14 +20,7 @@
 
 #include <maya/MProfiler.h>
 namespace {
-const int _primFilterProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "PrimFIlter",
-    "PrimFIlter"
-#else
-    "PrimFIlter"
-#endif
-);
+const int _primFilterProfilerCategory = MProfiler::addCategory("PrimFIlter", "PrimFIlter");
 } // namespace
 
 namespace AL {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/ProxyShapeMetaData.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/ProxyShapeMetaData.cpp
@@ -24,14 +24,8 @@
 
 #include <maya/MProfiler.h>
 namespace {
-const int _proxyShapeMetadataProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "AL_usdmaya_ProxyShape_selection",
-    "AL_usdmaya_ProxyShape_selection"
-#else
-    "AL_usdmaya_ProxyShape_selection"
-#endif
-);
+const int _proxyShapeMetadataProfilerCategory
+    = MProfiler::addCategory("AL_usdmaya_ProxyShape_selection", "AL_usdmaya_ProxyShape_selection");
 } // namespace
 
 namespace AL {

--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/ProxyShapeVariantFallbacks.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/nodes/proxy/ProxyShapeVariantFallbacks.cpp
@@ -22,13 +22,8 @@
 #include <maya/MProfiler.h>
 namespace {
 const int _proxyShapeVariantFallbacksProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
     "AL_usdmaya_ProxyShape_variant_fallbacks",
-    "AL_usdmaya_ProxyShape_variant_fallbacks"
-#else
-    "AL_usdmaya_ProxyShape_variant_fallbacks"
-#endif
-);
+    "AL_usdmaya_ProxyShape_variant_fallbacks");
 } // namespace
 
 namespace AL {

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/test_translators_TransformTranslator.cpp
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/test_translators_TransformTranslator.cpp
@@ -26,7 +26,6 @@
 #include <maya/MFnDagNode.h>
 #include <maya/MObjectArray.h>
 #include <maya/MObjectHandle.h>
-#include <maya/MTypes.h> // For MAYA_APP_VERSION
 
 using AL::maya::test::compareNodes;
 using AL::maya::test::randomAnimatedNode;
@@ -501,7 +500,6 @@ TEST(translators_TranformTranslator, worldSpaceGroupsExport)
     ASSERT_TRUE(stage->GetPrimAtPath(SdfPath("/C/X2/Y3/cube1")));
 }
 
-#if MAYA_APP_VERSION > 2019
 TEST(translators_TranformTranslator, withOffsetParentMatrix)
 {
     MFileIO::newFile(true);
@@ -851,5 +849,3 @@ TEST(translators_TranformTranslator, withOffsetParentMatrix)
         EXPECT_NEAR(1.0, worldMatrix[3][3], 1e-5);
     }
 }
-
-#endif

--- a/plugin/al/translators/Camera.cpp
+++ b/plugin/al/translators/Camera.cpp
@@ -34,14 +34,7 @@
 #include <maya/MTime.h>
 
 namespace {
-const int _cameraProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "Camera",
-    "Camera"
-#else
-    "Camera"
-#endif
-);
+const int _cameraProfilerCategory = MProfiler::addCategory("Camera", "Camera");
 } // namespace
 
 namespace AL {

--- a/plugin/al/translators/MayaReference.cpp
+++ b/plugin/al/translators/MayaReference.cpp
@@ -42,14 +42,7 @@
 #include <maya/MSelectionList.h>
 
 namespace {
-const int _mayaReferenceProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "MayaReference",
-    "MayaReference"
-#else
-    "MayaReference"
-#endif
-);
+const int _mayaReferenceProfilerCategory = MProfiler::addCategory("MayaReference", "MayaReference");
 } // namespace
 
 namespace AL {

--- a/plugin/al/translators/Mesh.cpp
+++ b/plugin/al/translators/Mesh.cpp
@@ -41,14 +41,7 @@
 #include <maya/MVectorArray.h>
 
 namespace {
-const int _meshProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "Mesh",
-    "Mesh"
-#else
-    "Mesh"
-#endif
-);
+const int _meshProfilerCategory = MProfiler::addCategory("Mesh", "Mesh");
 } // namespace
 
 namespace AL {

--- a/plugin/al/translators/NurbsCurve.cpp
+++ b/plugin/al/translators/NurbsCurve.cpp
@@ -37,14 +37,7 @@
 #include <maya/MStatus.h>
 
 namespace {
-const int _nurbsCurveProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "NurbsCurve",
-    "NurbsCurve"
-#else
-    "NurbsCurve"
-#endif
-);
+const int _nurbsCurveProfilerCategory = MProfiler::addCategory("NurbsCurve", "NurbsCurve");
 } // namespace
 
 namespace AL {

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/AnimationTranslator.cpp
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/AnimationTranslator.cpp
@@ -30,14 +30,8 @@
 
 #include <iostream>
 namespace {
-const int _animationTranslatorProfilerCategory = MProfiler::addCategory(
-#if MAYA_API_VERSION >= 20190000
-    "AnimationTranslator",
-    "AnimationTranslator"
-#else
-    "AnimationTranslator"
-#endif
-);
+const int _animationTranslatorProfilerCategory
+    = MProfiler::addCategory("AnimationTranslator", "AnimationTranslator");
 } // namespace
 
 namespace AL {
@@ -286,11 +280,8 @@ MStatus AnimationCheckTransformAttributes::initialise()
     AL_MAYA_CHECK_ERROR(status, errorString);
     m_commonTransformAttributes[12] = transformNodeClass.attribute("rotateOrder", &status);
     AL_MAYA_CHECK_ERROR(status, errorString);
-
-#if MAYA_APP_VERSION > 2019
     m_commonTransformAttributes[13] = transformNodeClass.attribute("offsetParentMatrix", &status);
     AL_MAYA_CHECK_ERROR(status, errorString);
-#endif
 
     m_inheritTransformAttribute = transformNodeClass.attribute("inheritsTransform", &status);
     AL_MAYA_CHECK_ERROR(status, errorString);

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/AnimationTranslator.h
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/AnimationTranslator.h
@@ -310,11 +310,7 @@ protected:
 class AnimationCheckTransformAttributes
 {
 private:
-#if MAYA_APP_VERSION > 2019
     constexpr static int transformAttributesCount { 14 };
-#else
-    constexpr static int transformAttributesCount { 13 };
-#endif
 
 public:
     AL_USDMAYA_UTILS_PUBLIC

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -6,7 +6,7 @@ set(TEST_SCRIPT_FILES
     testMayaUsdCacheId.py
 )
 
-if (UFE_FOUND AND MAYA_APP_VERSION VERSION_GREATER 2020)
+if (UFE_FOUND)
     list(APPEND TEST_SCRIPT_FILES
         testMayaUsdDirtyScene.py
         testMayaUsdProxyAccessor.py

--- a/test/lib/mayaUsd/fileio/CMakeLists.txt
+++ b/test/lib/mayaUsd/fileio/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_SCRIPT_FILES
+    testComponentTags.py
     testPrimReader.py
     testPrimWriter.py
     testExportChaser.py
@@ -11,11 +12,6 @@ set(TEST_SCRIPT_FILES
     # will be skipped if not found (probably because BUILD_PXR_PLUGIN is off).
     testSchemaApiAdaptor.py
 )
-if (MAYA_APP_VERSION VERSION_GREATER_EQUAL 2022)
-    list(APPEND TEST_SCRIPT_FILES
-        testComponentTags.py
-    )
-endif()
 
 if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
     list(APPEND TEST_SCRIPT_FILES

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
@@ -17,11 +17,6 @@ if(CMAKE_UFE_V2_FEATURES_AVAILABLE)
         testVP2RenderDelegatePrimPath.py
         testVP2RenderDelegateUSDPreviewSurface.py
         testVP2RenderDelegateConsolidation.py
-    )
-endif()
-
-if (MAYA_APP_VERSION VERSION_GREATER_EQUAL 2022)
-    list(APPEND TEST_SCRIPT_FILES
         testVP2RenderDelegatePerInstanceInheritedData.py
         testVP2RenderDelegateBasisCurves.py
         testVP2RenderDelegateDrawModes.py
@@ -29,12 +24,10 @@ if (MAYA_APP_VERSION VERSION_GREATER_EQUAL 2022)
     )
 endif()
 
-if (MAYA_APP_VERSION VERSION_GREATER_EQUAL 2022)
-    if (CMAKE_UFE_V2_FEATURES_AVAILABLE)
-        list(APPEND TEST_SCRIPT_FILES
-            testVP2RenderDelegateUsdCamera.py
-        )
-    endif()
+if (CMAKE_UFE_V2_FEATURES_AVAILABLE)
+    list(APPEND TEST_SCRIPT_FILES
+        testVP2RenderDelegateUsdCamera.py
+    )
 endif()
 
 if (MAYA_APP_VERSION VERSION_GREATER 2022)

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -198,42 +198,39 @@ mayaUsd_add_test(testUsdImportChaser
 )
 set_property(TEST testUsdImportChaser APPEND PROPERTY LABELS translators)
 
-# Test using standardSurface, which was introduced in Maya 2020.
-if (MAYA_APP_VERSION VERSION_GREATER_EQUAL 2020)
-    set(CUSTOM_TEST_SCRIPT_FILES
-        testUsdExportCustomConverter.template.py
-        testUsdImportCustomConverter.template.py
+set(CUSTOM_TEST_SCRIPT_FILES
+    testUsdExportCustomConverter.template.py
+    testUsdImportCustomConverter.template.py
+)
+set(PLUGIN_TYPES
+    Maya
+    USD
+)
+foreach(template_script ${CUSTOM_TEST_SCRIPT_FILES})
+    string(REGEX REPLACE "\\.template.py" ".py" script
+            "${template_script}")
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/${template_script}"
+        "${CMAKE_CURRENT_BINARY_DIR}/${script}"
+        @ONLY
     )
-    set(PLUGIN_TYPES
-        Maya
-        USD
-    )
-    foreach(template_script ${CUSTOM_TEST_SCRIPT_FILES})
-        string(REGEX REPLACE "\\.template.py" ".py" script
-              "${template_script}")
-        configure_file(
-            "${CMAKE_CURRENT_SOURCE_DIR}/${template_script}"
-            "${CMAKE_CURRENT_BINARY_DIR}/${script}"
-            @ONLY
-        )
 
-        foreach(plugin_type ${PLUGIN_TYPES})
-            mayaUsd_get_unittest_target(module ${script})
-            set(target "${module}-${plugin_type}")
-            mayaUsd_add_test(${target}
-                PYTHON_MODULE ${module}
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                ENV
-                    "MAYA_PLUG_IN_PATH=${CMAKE_CURRENT_BINARY_DIR}/../plugin"
-                    "${PXR_OVERRIDE_PLUGINPATH_NAME}=${CMAKE_CURRENT_BINARY_DIR}/../plugin/${plugin_type}"
-                    "INPUT_PATH=${CMAKE_CURRENT_SOURCE_DIR}"
-                    "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
-                    "USD_FORCE_DEFAULT_MATERIALS_SCOPE_NAME=1"
-                    )
-            set_property(TEST ${target} APPEND PROPERTY LABELS translators)
-        endforeach()
+    foreach(plugin_type ${PLUGIN_TYPES})
+        mayaUsd_get_unittest_target(module ${script})
+        set(target "${module}-${plugin_type}")
+        mayaUsd_add_test(${target}
+            PYTHON_MODULE ${module}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            ENV
+                "MAYA_PLUG_IN_PATH=${CMAKE_CURRENT_BINARY_DIR}/../plugin"
+                "${PXR_OVERRIDE_PLUGINPATH_NAME}=${CMAKE_CURRENT_BINARY_DIR}/../plugin/${plugin_type}"
+                "INPUT_PATH=${CMAKE_CURRENT_SOURCE_DIR}"
+                "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
+                "USD_FORCE_DEFAULT_MATERIALS_SCOPE_NAME=1"
+                )
+        set_property(TEST ${target} APPEND PROPERTY LABELS translators)
     endforeach()
-endif()
+endforeach()
 
 # These import/export tests will work with older versions of Maya and USD.
 # However getting the test materials to appear in the Maya viewport will


### PR DESCRIPTION
#### MAYA-129259 - MayaUsd: drop support for Maya 2018/2019/2020 and Qt 5.6.1 & 5.12.5

**Commit 1:**
* cmake/doc changes to remove old Maya (2018/2019/2020) support.

**Commit 2:**
* Code change to remove older Maya (2018/2019/2020) support.