### PR TITLE
MAYA-102168 clear payloads

### DIFF
--- a/lib/mayaUsd/resources/scripts/CMakeLists.txt
+++ b/lib/mayaUsd/resources/scripts/CMakeLists.txt
@@ -6,6 +6,8 @@ list(APPEND scripts_src
     mayaUsdAddUSDReference.mel
     mayaUsdCacheMayaReference.mel
     mayaUsdCacheMayaReference.py
+    mayaUsdClearRefsOrPayloadsOptions.mel
+    mayaUsdClearRefsOrPayloadsOptions.py
     mayaUsdDuplicateAsUsdDataOptions.mel
     mayaUsdDuplicateAsUsdDataOptions.py
     mayaUsdMergeToUSDOptions.mel

--- a/lib/mayaUsd/resources/scripts/mayaUsdClearRefsOrPayloadsOptions.mel
+++ b/lib/mayaUsd/resources/scripts/mayaUsdClearRefsOrPayloadsOptions.mel
@@ -1,0 +1,25 @@
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//s
+
+// Many MEL commands take as argument a MEL procedure, not a Python function.
+//
+// All the following MEL proceduces serves to redirect to Python.
+
+global proc createClearRefsOrPayloadsOptionsDialog()
+{
+    python("import mayaUsdClearRefsOrPayloadsOptions; mayaUsdClearRefsOrPayloadsOptions._createClearRefsOrPayloadsOptionsDialog()");
+}
+

--- a/lib/mayaUsd/resources/scripts/mayaUsdClearRefsOrPayloadsOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdClearRefsOrPayloadsOptions.py
@@ -1,0 +1,188 @@
+#
+# Copyright 2023 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import maya.cmds as cmds
+import maya.mel as mel
+
+from mayaUsdLibRegisterStrings import getMayaUsdLibString
+import mayaUsdOptions
+
+from functools import partial
+
+kAllRefsCheckboxName = "allRefsCheckbox"
+kAllPayloadsCheckboxName = "allPayloadsCheckbox"
+
+_itemName = None
+
+def showClearRefsOrPayloadsOptions(itemName):
+    """
+    Shows the clear references or payloads options dialog.
+    """
+    global _itemName
+    _itemName = itemName
+    title = getMayaUsdLibString("kClearRefsOrPayloadsOptionsTitle")
+    userChoice = mel.eval('''layoutDialog -title "%s" -parent "MayaWindow" -uiScript createClearRefsOrPayloadsOptionsDialog;''' % title)
+
+    results = [userChoice]
+
+    options = getClearRefsOrPayloadsOptionsDict()
+    for optionName in ['references', 'payloads']:
+        if optionName in options and options[optionName]:
+            results.append(optionName)
+
+    return results
+
+
+def _createClearRefsOrPayloadsOptionsDialog():
+    """
+    Creates the clear references or payloads dialog UI.
+    """
+
+    # Same spacing as Maya option boxes.
+    spacer = 16
+    edge   = 12
+
+    # Use same height for buttons as in Maya option boxes.
+    buttonWidth = 100
+    buttonHeight = 26
+
+    windowLayout = cmds.setParent(query=True)
+
+    windowFormLayout = cmds.formLayout(parent=windowLayout)
+
+    controlsLayout = cmds.formLayout(parent=windowFormLayout)
+
+    cmds.setParent(controlsLayout)
+
+    global _itemName
+    messageLabel = cmds.text(label=getMayaUsdLibString("kClearRefsOrPayloadsOptionsMessage") % _itemName)
+
+    subLayout = cmds.columnLayout("ClearRefsOrPayloadsOptionsDialogSubLayout", adjustableColumn=True)
+
+    cmds.setParent(subLayout)
+
+    cmds.checkBox(kAllRefsCheckboxName, label=getMayaUsdLibString("kAllRefsLabel"), annotation=getMayaUsdLibString("kAllRefsTooltip"))
+    cmds.checkBox(kAllPayloadsCheckboxName, label=getMayaUsdLibString("kAllPayloadsLabel"), annotation=getMayaUsdLibString("kAllPayloadsTooltip"))
+
+    buttonsLayout = cmds.formLayout(parent=windowFormLayout)
+
+    clearCmd  = _acceptClearRefsOrPayloadsOptionsDialog
+    cancelCmd = _cancelClearRefsOrPayloadsOptionsDialog
+    clearButton  = cmds.button(label=getMayaUsdLibString("kClearButton"),  width=buttonWidth, height=buttonHeight, command=clearCmd)
+    cancelButton = cmds.button(label=getMayaUsdLibString("kCancelButton"), width=buttonWidth, height=buttonHeight, command=cancelCmd)
+
+    cmds.formLayout(buttonsLayout, edit=True,
+        attachForm=[
+            (cancelButton,   "bottom", edge),
+            (cancelButton,   "right",  edge),
+            (clearButton,    "bottom", edge),
+        ],
+        attachControl=[
+            (clearButton,    "right", spacer, cancelButton),
+        ])
+
+    cmds.formLayout(controlsLayout, edit=True,
+        attachForm=[
+            (messageLabel,   "top",   edge),
+            (messageLabel,   "left",  edge),
+            (messageLabel,   "right", edge),
+            (subLayout,      "left",  edge),
+            (subLayout,      "right", edge),
+        ],
+        attachControl=[
+            (subLayout,    "top", spacer, messageLabel),
+        ])
+
+    cmds.formLayout(windowFormLayout, edit=True,
+        attachForm=[
+            (controlsLayout, 'top',      0),
+            (controlsLayout, 'left',     0),
+            (controlsLayout, 'right',    0),
+            
+            (buttonsLayout,  'left',     0),
+            (buttonsLayout,  'right',    0),
+            (buttonsLayout,  'bottom',   0),
+        ],
+        attachControl=[
+            (controlsLayout, 'bottom',   edge, buttonsLayout)
+        ])
+    
+    _fillClearRefsOrPayloadsOptionsDialog()
+
+
+def _fillClearRefsOrPayloadsOptionsDialog():
+    """
+    Fills the clear references or payloads options dialog UI elements with the current options.
+    """
+    options = getClearRefsOrPayloadsOptionsDict()
+    cmds.checkBox(kAllRefsCheckboxName, edit=True, value=options['references'])
+    cmds.checkBox(kAllPayloadsCheckboxName, edit=True, value=options['payloads'])
+
+
+def _acceptClearRefsOrPayloadsOptionsDialog(data=None):
+    """
+    Reacts to the clear references or payloads options dialog being OK'ed by the user.
+    """
+    options = {
+        'references' : bool(cmds.checkBox(kAllRefsCheckboxName, query=True, value=True)),
+        'payloads'   : bool(cmds.checkBox(kAllPayloadsCheckboxName, query=True, value=True)),
+    }
+    setClearRefsOrPayloadsOptionsDict(options)
+    cmds.layoutDialog(dismiss='Clear')
+
+
+def _cancelClearRefsOrPayloadsOptionsDialog(data=None):
+    """
+    Reacts to the clear references or payloads options dialog being closed by the user.
+    """
+    cmds.layoutDialog(dismiss='dismiss')
+
+
+###########################################################
+#
+# Option var handling below.
+
+def _getClearRefsOrPayloadsOptionsVarName():
+    """
+    Retrieves the option var name under which the clear references or payloads options are kept.
+    """
+    return "mayaUsd_ClearRefsOrPayloadsOptions"
+
+def getDefaultClearRefsOrPayloadsOptionsDict():
+    """
+    Retrieves the default clear references or payloads options dictionary.
+    """
+    return {
+        "references": True,
+        "payloads":   True,
+    }
+
+def getClearRefsOrPayloadsOptionsDict():
+    """
+    Retrieves the current clear references or payloads options as a dictionary.
+    """
+    return mayaUsdOptions.getOptionsDict(
+        _getClearRefsOrPayloadsOptionsVarName(),
+        getDefaultClearRefsOrPayloadsOptionsDict())
+
+def setClearRefsOrPayloadsOptionsDict(options):
+    """
+    Sets the current clear references or payloads options from teh given dictionary.
+    """
+    mayaUsdOptions.setOptionsDict(
+        _getClearRefsOrPayloadsOptionsVarName(),
+        options)
+

--- a/lib/mayaUsd/resources/scripts/mayaUsdClearRefsOrPayloadsOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdClearRefsOrPayloadsOptions.py
@@ -52,8 +52,8 @@ def _createClearRefsOrPayloadsOptionsDialog():
     """
 
     # Same spacing as Maya option boxes.
-    spacer = 16
-    edge   = 12
+    spacer = 8
+    edge   = 6
 
     # Use same height for buttons as in Maya option boxes.
     buttonWidth = 100
@@ -180,7 +180,7 @@ def getClearRefsOrPayloadsOptionsDict():
 
 def setClearRefsOrPayloadsOptionsDict(options):
     """
-    Sets the current clear references or payloads options from teh given dictionary.
+    Sets the current clear references or payloads options from the given dictionary.
     """
     mayaUsdOptions.setOptionsDict(
         _getClearRefsOrPayloadsOptionsVarName(),

--- a/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
@@ -78,7 +78,7 @@ def mayaUsdLibRegisterStrings():
     register('kAllRefsLabel', 'All References')
     register('kAllRefsTooltip', 'Clear all references on the prim.')
     register('kAllPayloadsLabel', 'All Payloads')
-    register('kAllPayloadsTooltip', 'Clearr all payloads on the prims.')
+    register('kAllPayloadsTooltip', 'Clear all payloads on the prims.')
 
     # mayaUsdMergeToUSDOptions.py
     register('kMergeToUSDOptionsTitle', 'Merge Maya Edits to USD Options')

--- a/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
@@ -70,6 +70,16 @@ def mayaUsdLibRegisterStrings():
     register('kTextVariant', 'Variant')
     register('kTextVariantToolTip','If selected, your Maya reference will be defined in a variant. This will enable your prim to\nhave 2 variants you can switch between in the Outliner; the Maya reference and its USD cache.')
 
+    # mayaUsdClearRefsOrPayloadsOptions.py
+    register('kClearRefsOrPayloadsOptionsTitle', 'Clear All USD References/Payloads')
+    register('kClearRefsOrPayloadsOptionsMessage', 'Clear all references/payloads on %s?')
+    register('kClearButton', 'Clear')
+    register('kCancelButton', 'Cancel')
+    register('kAllRefsLabel', 'All References')
+    register('kAllRefsTooltip', 'Clear all references on the prim.')
+    register('kAllPayloadsLabel', 'All Payloads')
+    register('kAllPayloadsTooltip', 'Clearr all payloads on the prims.')
+
     # mayaUsdMergeToUSDOptions.py
     register('kMergeToUSDOptionsTitle', 'Merge Maya Edits to USD Options')
     register('kMergeButton', 'Merge')

--- a/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdOptions.py
@@ -59,6 +59,7 @@ def getOptionsText(varName, defaultOptions):
     """
     Retrieves the current options as text with column-separated key/value pairs.
     If the options don't exist, return the default options in the same text format.
+    The given defualt options can be in text form or a dict.
     """
     if cmds.optionVar(exists=varName):
         return _cleanupOptionsText(cmds.optionVar(query=varName))
@@ -66,13 +67,31 @@ def getOptionsText(varName, defaultOptions):
         return _cleanupOptionsText(convertOptionsDictToText(defaultOptions))
     else:
         return _cleanupOptionsText(defaultOptions)
-    
+
+
+def getOptionsDict(varName, defaultOptions):
+    """
+    Retrieves the current options as a dictionary.
+    If the options don't exist, return the default options in the same text format.
+    The given defualt options can be in text form or a dict.
+    """
+    optionsText = getOptionsText(varName, defaultOptions)
+    return convertOptionsTextToDict(optionsText, defaultOptions)
+
 
 def setOptionsText(varName, optionsText):
     """
     Sets the current options as text with column-separated key/value pairs.
     """
     return cmds.optionVar(stringValue=(varName, optionsText))
+
+
+def setOptionsDict(varName, options):
+    """
+    Sets the current options as text by converting the given dictionary.
+    """
+    optionsText = convertOptionsDictToText(options)
+    setOptionsText(varName, optionsText)
 
 
 def convertOptionsDictToText(optionsDict):

--- a/plugin/adsk/scripts/mayaUsd_pluginUICreation.mel
+++ b/plugin/adsk/scripts/mayaUsd_pluginUICreation.mel
@@ -51,6 +51,7 @@ global proc mayaUsd_pluginUICreation()
         source "mayaUsdAddUSDReference.mel";
         source "mayaUsdCacheMayaReference.mel";
         source "mayaUsdMergeToUSDOptions.mel";
+        source "mayaUsdClearRefsOrPayloadsOptions.mel";
         source "mayaUsdDuplicateAsUsdDataOptions.mel";
     }
 }


### PR DESCRIPTION
- Add command to clear payloads.
- Make commands to clear refs and payloads be undoable.
- Improve Python options utility helpers functions to deal with dictionaries directly.
- Implement clear dialog UI in Python.
- Remember user choices between invocations.