### PR TITLE
EMSUSD-85 - As a user, I'd like my 'Merge as USD' edits to be specified as overs when authoring to a stronger layer

### DIFF
--- a/lib/usd/utils/MergePrims.cpp
+++ b/lib/usd/utils/MergePrims.cpp
@@ -935,15 +935,6 @@ bool mergeDiffPrims(
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-/// Create any missing parents as "over". Parents may be missing because we are targeting a
-/// different layer than where the destination prim is authored. The SdfCopySpec function does not
-/// automatically create the missing parent, unlike other functions like UsdStage::CreatePrim.
-void createMissingParents(const SdfLayerRefPtr& dstLayer, const SdfPath& dstPath)
-{
-    SdfJustCreatePrimInLayer(dstLayer, dstPath.GetParentPath());
-}
-
-//----------------------------------------------------------------------------------------------------------------------
 // Augment a USD SdfPath with the variants selections currently active at all levels.
 std::pair<SdfPath, UsdEditTarget> augmentPathWithVariants(
     const UsdStageRefPtr& stage,
@@ -1022,7 +1013,10 @@ bool mergePrims(
 
     UsdEditContext editCtx(dstStage, target);
 
-    createMissingParents(dstLayer, augmentedDstPath);
+    /// Create any missing prim in the dst hierarchy as "over". Prims may be missing because we are targeting a
+    /// different layer than where the destination prim is authored. The SdfCopySpec function does not
+    /// automatically create the missing parent, unlike other functions like UsdStage::CreatePrim.
+    SdfJustCreatePrimInLayer(dstLayer, augmentedDstPath);
 
     if (options.ignoreUpperLayerOpinions) {
         auto           tempStage = UsdStage::CreateInMemory();

--- a/lib/usd/utils/MergePrims.cpp
+++ b/lib/usd/utils/MergePrims.cpp
@@ -1013,9 +1013,10 @@ bool mergePrims(
 
     UsdEditContext editCtx(dstStage, target);
 
-    /// Create any missing prim in the dst hierarchy as "over". Prims may be missing because we are targeting a
-    /// different layer than where the destination prim is authored. The SdfCopySpec function does not
-    /// automatically create the missing parent, unlike other functions like UsdStage::CreatePrim.
+    /// Create any missing prim in the dst hierarchy as "over". Prims may be missing because we are
+    /// targeting a different layer than where the destination prim is authored. The SdfCopySpec
+    /// function does not automatically create the missing parent, unlike other functions like
+    /// UsdStage::CreatePrim.
     SdfJustCreatePrimInLayer(dstLayer, augmentedDstPath);
 
     if (options.ignoreUpperLayerOpinions) {

--- a/test/lib/mayaUsd/fileio/testMergeToUsd.py
+++ b/test/lib/mayaUsd/fileio/testMergeToUsd.py
@@ -298,6 +298,12 @@ class MergeToUsdTestCase(unittest.TestCase):
     
         assertVectorAlmostEqual(self, mayaValues, usdValues)
 
+        # Check that edits have been set as "overs"
+        primSpecA = layers[1].GetPrimAtPath("/A")
+        self.assertEqual(primSpecA.specifier, Sdf.SpecifierOver)
+        primSpecB = layers[1].GetPrimAtPath("/A/B")
+        self.assertEqual(primSpecB.specifier, Sdf.SpecifierOver)
+
     def testEquivalentTransformMergeToUsd(self):
         '''Merge edits on a USD transform back to USD when the new transform is equivalent.'''
 


### PR DESCRIPTION
Behaviour of the function mergePrims in MergePrims.cpp was changed: 
Before, the function SdfJustCreatePrimInLayer was called for the prim's parent. This way the required "overs" were created up to the prim's parent and therefore the prim itself was created as "def"
Now, we call SdfJustCreatePrimInLayer for the prim itself. This way we create all required "overs" including the prim itself, which is the right behaviour.