### PR TITLE
EMSUSD-109 allow textures to be relative

### DIFF
--- a/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
@@ -40,6 +40,7 @@ def mayaUsdLibRegisterStrings():
     register('kLabelUnusedTransformAttrs', 'Unused')
     register('kLabelMetadata', 'Metadata')
     register('kLabelAppliedSchemas', 'Applied Schemas')
+    register('kOpenImage', 'Open')
 
     # mayaUsdAddMayaReference.py
     register('kErrorGroupPrimExists', 'Group prim "^1s" already exists under "^2s". Choose prim name other than "^1s" to proceed.')

--- a/plugin/adsk/scripts/CMakeLists.txt
+++ b/plugin/adsk/scripts/CMakeLists.txt
@@ -10,6 +10,7 @@ list(APPEND scripts_src
     mayaUsd_createStageFromFile.mel
     mayaUsd_createStageWithNewLayer.py
     mayaUsd_createStageFromAsset.mel
+    mayaUsd_imageFileDialogs.mel
     mayaUsd_layerEditorFileDialogs.mel
     mayaUsd_fileOptions.mel
     mayaUsd_pluginUICreation.mel

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.py
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.py
@@ -46,3 +46,4 @@ def mayaUSDRegisterStrings():
     register("kResolvedPath", "Resolved Path:")
     register("kResolvedPathAnn", "This field indicates the resolved path of your chosen working directory for your USD file. Note: The resolved path for the file can vary for each individual as the file is handed off.")
     register("kCompositionArcOptions", "Composition Arc Options")
+    register("kPreview", "Preview")

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -272,6 +272,7 @@ proc initRuntimeCommands() {
 
     source "mayaUsd_createStageFromFile.mel";
     source "mayaUsd_layerEditorFileDialogs.mel";
+    source "mayaUsd_imageFileDialogs.mel";
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/plugin/adsk/scripts/mayaUsd_imageFileDialogs.mel
+++ b/plugin/adsk/scripts/mayaUsd_imageFileDialogs.mel
@@ -1,0 +1,43 @@
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+global proc mayaUsd_ImageFileRelative_UICreate(string $parent)
+{
+    // First create the scroll layout here and then call the python
+    // helper to add the rest of the UI.
+    setParent $parent;
+    string $layout = `scrollLayout -childResizable true`;
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdImageRelativeToEditTargetLayer.uiCreate('" + $layout + "')");
+}
+
+global proc mayaUsd_ImageFileRelative_UIInit(string $parent, string $filterType)
+{
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdImageRelativeToEditTargetLayer.uiInit('" + $parent + "', '" + $filterType + "')");
+}
+
+global proc mayaUsd_ImageFileRelative_UICommit(string $parent, string $selectedFile)
+{
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdImageRelativeToEditTargetLayer.uiCommit('" + $parent + "', '" + $selectedFile + "')");
+}
+
+global proc mayaUsd_ImageFileRelative_SelectionChanged(string $parent, string $selection)
+{
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdImageRelativeToEditTargetLayer.selectionChanged('" + $parent + "', '" + $selection + "')");
+}
+
+global proc mayaUsd_ImageFileRelative_FileTypeChanged(string $parent, string $newType)
+{
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdImageRelativeToEditTargetLayer.fileTypeChanged('" + $parent + "', '" + $newType + "')");
+}


### PR DESCRIPTION
- Added an Attribute Editor control template for image assets.
- Added a function to detect that a UFE attribute is an asset.
- Added MEL callback trampolines to Python for the image file dialog.
- Added a usdImageRelativeToEditTargetLayer class to handle the file dialog UI, reusing code for other relative path handling.
- Simplified the layout of the relative file options.
- Don't auto-add the USD extension when browsing for image files.
- Auto-show the image preview in the dialog.
- Select the "All Files" filter by default.