### PR TITLE
EMSUSD-101 Override primWriter

### DIFF
--- a/lib/mayaUsd/fileio/primWriter.h
+++ b/lib/mayaUsd/fileio/primWriter.h
@@ -77,7 +77,7 @@ public:
     /// A static function is expected for all writers and allows
     /// declaring how well this class can support the current context.
     MAYAUSD_CORE_PUBLIC
-    static ContextSupport CanImport(const UsdMayaJobExportArgs& emportArgs);
+    static ContextSupport CanImport(const UsdMayaJobExportArgs& exportArgs);
 
     MAYAUSD_CORE_PUBLIC
     virtual ~UsdMayaPrimWriter();

--- a/lib/mayaUsd/fileio/primWriter.h
+++ b/lib/mayaUsd/fileio/primWriter.h
@@ -78,7 +78,7 @@ public:
     /// declaring how well this class can support the current context.
     MAYAUSD_CORE_PUBLIC
     static ContextSupport
-    CanExport(const UsdMayaJobExportArgs& exportArgs, const MFnDependencyNode& exportNode);
+    CanExport(const UsdMayaJobExportArgs& exportArgs, const MObject& exportObj);
 
     MAYAUSD_CORE_PUBLIC
     virtual ~UsdMayaPrimWriter();

--- a/lib/mayaUsd/fileio/primWriter.h
+++ b/lib/mayaUsd/fileio/primWriter.h
@@ -61,6 +61,24 @@ public:
         const SdfPath&           usdPath,
         UsdMayaWriteJobContext&  jobCtx);
 
+    /// The level of support a writer can offer for a given context
+    ///
+    /// A basic writer that gives correct results across most contexts should
+    /// report `Fallback`, while a specialized writer that really shines in a
+    /// given context should report `Supported` when the context is right and
+    /// `Unsupported` if the context is not as expected.
+    enum class ContextSupport
+    {
+        Supported,
+        Fallback,
+        Unsupported
+    };
+
+    /// A static function is expected for all writers and allows
+    /// declaring how well this class can support the current context.
+    MAYAUSD_CORE_PUBLIC
+    static ContextSupport CanImport(const UsdMayaJobExportArgs& emportArgs);
+
     MAYAUSD_CORE_PUBLIC
     virtual ~UsdMayaPrimWriter();
 

--- a/lib/mayaUsd/fileio/primWriter.h
+++ b/lib/mayaUsd/fileio/primWriter.h
@@ -77,7 +77,8 @@ public:
     /// A static function is expected for all writers and allows
     /// declaring how well this class can support the current context.
     MAYAUSD_CORE_PUBLIC
-    static ContextSupport CanImport(const UsdMayaJobExportArgs& exportArgs);
+    static ContextSupport
+    CanExport(const UsdMayaJobExportArgs& exportArgs, const MFnDependencyNode& exportNode);
 
     MAYAUSD_CORE_PUBLIC
     virtual ~UsdMayaPrimWriter();

--- a/lib/mayaUsd/fileio/primWriterRegistry.cpp
+++ b/lib/mayaUsd/fileio/primWriterRegistry.cpp
@@ -182,7 +182,7 @@ UsdMayaPrimWriterRegistry::WriterFactoryFn UsdMayaPrimWriterRegistry::Find(
     // if nothing was found and nothing was registered, we at least put it in
     // the registry in case we encounter it again.
     TF_DEBUG(PXRUSDMAYA_REGISTRY)
-        .Msg("No usdMaya writer plugin for TfType %s. No maya plugin.\n", mayaTypeName);
+        .Msg("No usdMaya writer plugin for TfType %s. No maya plugin.\n", mayaTypeName.c_str());
     if (_reg.count(mayaTypeName) == 0) {
         // Nothing registered at all, remember that:
         _reg.insert(std::make_pair(

--- a/lib/mayaUsd/fileio/primWriterRegistry.cpp
+++ b/lib/mayaUsd/fileio/primWriterRegistry.cpp
@@ -179,8 +179,10 @@ UsdMayaPrimWriterRegistry::WriterFactoryFn UsdMayaPrimWriterRegistry::Find(
         return it->second._writer;
     }
 
-    // ideally something just registered itself.  if not, we at least put it in
+    // if nothing was found and nothing was registered, we at least put it in
     // the registry in case we encounter it again.
+    TF_DEBUG(PXRUSDMAYA_REGISTRY)
+        .Msg("No usdMaya writer plugin for TfType %s. No maya plugin.\n", mayaTypeName);
     if (_reg.count(mayaTypeName) == 0) {
         // Nothing registered at all, remember that:
         _reg.insert(std::make_pair(
@@ -196,7 +198,7 @@ UsdMayaPrimWriterRegistry::WriterFactoryFn UsdMayaPrimWriterRegistry::Find(
 }
 
 /* static */
-void UsdMayaPrimWriterRegistry::Poke(const std::string& mayaTypeName)
+void UsdMayaPrimWriterRegistry::CheckForWriterPlugin(const std::string& mayaTypeName)
 {
     TfRegistryManager::GetInstance().SubscribeTo<UsdMayaPrimWriterRegistry>();
 

--- a/lib/mayaUsd/fileio/primWriterRegistry.cpp
+++ b/lib/mayaUsd/fileio/primWriterRegistry.cpp
@@ -42,9 +42,73 @@ TF_DEFINE_PRIVATE_TOKENS(
 );
 // clang-format on
 
-typedef std::map<std::string, UsdMayaPrimWriterRegistry::WriterFactoryFn> _Registry;
-static _Registry                                                          _reg;
+namespace {
+struct _RegistryEntry
+{
+    UsdMayaPrimWriterRegistry::ContextPredicateFn _pred;
+    UsdMayaPrimWriterRegistry::WriterFactoryFn    _writer;
+    int                                           _index;
+};
+
+// typedef std::map<std::string, UsdMayaPrimWriterRegistry::WriterFactoryFn> _Registry;
+typedef std::unordered_multimap<std::string, _RegistryEntry> _Registry;
+static _Registry                                             _reg;
 static std::set<std::string> _mayaTypesThatDoNotCreatePrims;
+static int                                                   _indexCounter = 0;
+
+_Registry::const_iterator
+_Find(const std::string& mayaTypeName, const UsdMayaJobExportArgs& exportArgs)
+{
+    using ContextSupport = UsdMayaPrimWriter::ContextSupport;
+
+    _Registry::const_iterator ret = _reg.cend();
+    _Registry::const_iterator first, last;
+    std::tie(first, last) = _reg.equal_range(mayaTypeName);
+    while (first != last) {
+        ContextSupport support = first->second._pred(exportArgs);
+        // Look for a "Supported" reader. If no "Supported" reader is found, use a "Fallback" reader
+        if (support == ContextSupport::Supported) {
+            ret = first;
+            break;
+        } else if (support == ContextSupport::Fallback && ret == _reg.end()) {
+            ret = first;
+        }
+        ++first;
+    }
+
+    return ret;
+}
+
+} // namespace
+
+/* static */
+void UsdMayaPrimWriterRegistry::Register(
+    const std::string&                            mayaTypeName,
+    UsdMayaPrimWriterRegistry::ContextPredicateFn pred,
+    UsdMayaPrimWriterRegistry::WriterFactoryFn    fn,
+    bool                                          fromPython)
+{
+    TF_DEBUG(PXRUSDMAYA_REGISTRY)
+        .Msg("Registering UsdMayaPrimWriter for maya type %s.\n", mayaTypeName.c_str());
+
+    int index = _indexCounter++;
+    _reg.insert(std::make_pair(mayaTypeName, _RegistryEntry { pred, fn, index }));
+
+    // The unloader uses the index to know which entry to erase when there are
+    // more than one for the same mayaTypeName.
+    UsdMaya_RegistryHelper::AddUnloader(
+        [mayaTypeName, index]() {
+            _Registry::const_iterator it, itEnd;
+            std::tie(it, itEnd) = _reg.equal_range(mayaTypeName);
+            for (; it != itEnd; ++it) {
+                if (it->second._index == index) {
+                    _reg.erase(it);
+                    break;
+                }
+            }
+        },
+        fromPython);
+}
 
 /* static */
 void UsdMayaPrimWriterRegistry::Register(
@@ -55,14 +119,30 @@ void UsdMayaPrimWriterRegistry::Register(
     TF_DEBUG(PXRUSDMAYA_REGISTRY)
         .Msg("Registering UsdMayaPrimWriter for maya type %s.\n", mayaTypeName.c_str());
 
-    std::pair<_Registry::iterator, bool> insertStatus
-        = _reg.insert(std::make_pair(mayaTypeName, fn));
-    if (insertStatus.second) {
-        UsdMaya_RegistryHelper::AddUnloader(
-            [mayaTypeName]() { _reg.erase(mayaTypeName); }, fromPython);
-    } else {
-        TF_CODING_ERROR("Multiple writers for type %s", mayaTypeName.c_str());
-    }
+    int index = _indexCounter++;
+
+    // Use default ContextSupport if not specified
+    _reg.insert(std::make_pair(
+        mayaTypeName,
+        _RegistryEntry {
+            [](const UsdMayaJobExportArgs&) { return UsdMayaPrimWriter::ContextSupport::Fallback; },
+            fn,
+            index }));
+
+    // The unloader uses the index to know which entry to erase when there are
+    // more than one for the same mayaTypeName.
+    UsdMaya_RegistryHelper::AddUnloader(
+        [mayaTypeName, index]() {
+            _Registry::const_iterator it, itEnd;
+            std::tie(it, itEnd) = _reg.equal_range(mayaTypeName);
+            for (; it != itEnd; ++it) {
+                if (it->second._index == index) {
+                    _reg.erase(it);
+                    break;
+                }
+            }
+        },
+        fromPython);
 }
 
 /* static */
@@ -74,32 +154,41 @@ void UsdMayaPrimWriterRegistry::RegisterRaw(
 }
 
 /* static */
-UsdMayaPrimWriterRegistry::WriterFactoryFn
-UsdMayaPrimWriterRegistry::Find(const std::string& mayaTypeName)
+UsdMayaPrimWriterRegistry::WriterFactoryFn UsdMayaPrimWriterRegistry::Find(
+    const std::string&          mayaTypeName,
+    const UsdMayaJobExportArgs& exportArgs)
 {
     TfRegistryManager::GetInstance().SubscribeTo<UsdMayaPrimWriterRegistry>();
 
-    // unfortunately, usdTypeName is diff from the tfTypeName which we use to
-    // register.  do the conversion here.
-    WriterFactoryFn ret = nullptr;
-    if (TfMapLookup(_reg, mayaTypeName, &ret)) {
-        return ret;
+    _Registry::const_iterator it = _Find(mayaTypeName, exportArgs);
+
+    if (it != _reg.end()) {
+        return it->second._writer;
     }
 
     static const TfTokenVector SCOPE = { _tokens->UsdMaya, _tokens->PrimWriter };
     UsdMaya_RegistryHelper::FindAndLoadMayaPlug(SCOPE, mayaTypeName);
 
-    // ideally something just registered itself.  if not, we at least put it in
-    // the registry in case we encounter it again.
-    if (!TfMapLookup(_reg, mayaTypeName, &ret)) {
-        TF_DEBUG(PXRUSDMAYA_REGISTRY)
-            .Msg(
-                "No usdMaya writer plugin for maya type %s. No maya plugin found.\n",
-                mayaTypeName.c_str());
-        _reg[mayaTypeName] = nullptr;
+    it = _Find(mayaTypeName, exportArgs);
+
+    if (it != _reg.end()) {
+        return it->second._writer;
     }
 
-    return ret;
+    // ideally something just registered itself.  if not, we at least put it in
+    // the registry in case we encounter it again.
+    if (_reg.count(mayaTypeName) == 0) {
+        // Nothing registered at all, remember that:
+        _reg.insert(std::make_pair(
+            mayaTypeName,
+            _RegistryEntry { [](const UsdMayaJobExportArgs&) {
+                                return UsdMayaPrimWriter::ContextSupport::Fallback;
+                            },
+                             nullptr,
+                             -1 }));
+    }
+
+    return nullptr;
 }
 
 /* static */

--- a/lib/mayaUsd/fileio/primWriterRegistry.cpp
+++ b/lib/mayaUsd/fileio/primWriterRegistry.cpp
@@ -126,10 +126,11 @@ void UsdMayaPrimWriterRegistry::Register(
     // Use default ContextSupport if not specified
     _reg.insert(std::make_pair(
         mayaTypeName,
-        _RegistryEntry {
-            [](const UsdMayaJobExportArgs&, const MFnDependencyNode&) { return UsdMayaPrimWriter::ContextSupport::Fallback; },
-            fn,
-            index }));
+        _RegistryEntry { [](const UsdMayaJobExportArgs&, const MFnDependencyNode&) {
+                            return UsdMayaPrimWriter::ContextSupport::Fallback;
+                        },
+                         fn,
+                         index }));
 
     // The unloader uses the index to know which entry to erase when there are
     // more than one for the same mayaTypeName.

--- a/lib/mayaUsd/fileio/primWriterRegistry.cpp
+++ b/lib/mayaUsd/fileio/primWriterRegistry.cpp
@@ -59,7 +59,7 @@ static int                                                   _indexCounter = 0;
 _Registry::const_iterator _Find(
     const std::string&          mayaTypeName,
     const UsdMayaJobExportArgs& exportArgs,
-    const MObject&    exportObj)
+    const MObject&              exportObj)
 {
     using ContextSupport = UsdMayaPrimWriter::ContextSupport;
 

--- a/lib/mayaUsd/fileio/primWriterRegistry.h
+++ b/lib/mayaUsd/fileio/primWriterRegistry.h
@@ -79,12 +79,14 @@ struct UsdMayaPrimWriterRegistry
 
     /// Predicate function, i.e. a function that can tell the level of support
     /// the writer function will provide for a given set of export options.
-    using ContextPredicateFn = std::function<
-        UsdMayaPrimWriter::ContextSupport(const UsdMayaJobExportArgs&)>;
+    using ContextPredicateFn
+        = std::function<UsdMayaPrimWriter::ContextSupport(const UsdMayaJobExportArgs&)>;
 
-    // TODO: Write new brief
     /// \brief Register \p fn as a factory function providing a
     /// UsdMayaPrimWriter subclass that can be used to write \p mayaType.
+    /// Provide a supportability of the primWriter. Use "supported" to
+    /// override the default primWriter
+    ///
     /// If you can't provide a valid UsdMayaPrimWriter for the given arguments,
     /// return a null pointer from the factory function \p fn.
     ///
@@ -142,6 +144,10 @@ struct UsdMayaPrimWriterRegistry
     MAYAUSD_CORE_PUBLIC
     static WriterFactoryFn
     Find(const std::string& mayaTypeName, const UsdMayaJobExportArgs& exportArgs);
+
+    /// \brief Check for external primWriter for \p mayaTypeName.
+    MAYAUSD_CORE_PUBLIC
+    static void Poke(const std::string& mayaTypeName);
 
     /// \brief Registers a maya node type to *not* create a new prim.
     ///

--- a/lib/mayaUsd/fileio/primWriterRegistry.h
+++ b/lib/mayaUsd/fileio/primWriterRegistry.h
@@ -77,6 +77,37 @@ struct UsdMayaPrimWriterRegistry
     /// macro.
     typedef std::function<bool(const UsdMayaPrimWriterArgs&, UsdMayaPrimWriterContext*)> WriterFn;
 
+    /// Predicate function, i.e. a function that can tell the level of support
+    /// the writer function will provide for a given set of export options.
+    using ContextPredicateFn = std::function<
+        UsdMayaPrimWriter::ContextSupport(const UsdMayaJobExportArgs&)>;
+
+    // TODO: Write new brief
+    /// \brief Register \p fn as a factory function providing a
+    /// UsdMayaPrimWriter subclass that can be used to write \p mayaType.
+    /// If you can't provide a valid UsdMayaPrimWriter for the given arguments,
+    /// return a null pointer from the factory function \p fn.
+    ///
+    /// Example for registering a writer factory in your custom plugin:
+    /// \code{.cpp}
+    /// class MyWriter : public UsdMayaPrimWriter {
+    ///     static UsdMayaPrimWriterSharedPtr Create(
+    ///             const MFnDependencyNode& depNodeFn,
+    ///             const SdfPath& usdPath,
+    ///             UsdMayaWriteJobContext& jobCtx);
+    /// };
+    /// TF_REGISTRY_FUNCTION_WITH_TAG(UsdMayaPrimWriterRegistry, MyWriter) {
+    ///     UsdMayaPrimWriterRegistry::Register("myCustomMayaNode",
+    ///             MyWriter::Create);
+    /// }
+    /// \endcode
+    MAYAUSD_CORE_PUBLIC
+    static void Register(
+        const std::string& mayaType,
+        ContextPredicateFn pred,
+        WriterFactoryFn    fn,
+        bool               fromPython = false);
+
     /// \brief Register \p fn as a factory function providing a
     /// UsdMayaPrimWriter subclass that can be used to write \p mayaType.
     /// If you can't provide a valid UsdMayaPrimWriter for the given arguments,
@@ -109,7 +140,8 @@ struct UsdMayaPrimWriterRegistry
     ///
     /// If there is no writer plugin for \p mayaTypeName, returns nullptr.
     MAYAUSD_CORE_PUBLIC
-    static WriterFactoryFn Find(const std::string& mayaTypeName);
+    static WriterFactoryFn
+    Find(const std::string& mayaTypeName, const UsdMayaJobExportArgs& exportArgs);
 
     /// \brief Registers a maya node type to *not* create a new prim.
     ///

--- a/lib/mayaUsd/fileio/primWriterRegistry.h
+++ b/lib/mayaUsd/fileio/primWriterRegistry.h
@@ -80,7 +80,7 @@ struct UsdMayaPrimWriterRegistry
     /// Predicate function, i.e. a function that can tell the level of support
     /// the writer function will provide for a given set of export options.
     using ContextPredicateFn = std::function<
-        UsdMayaPrimWriter::ContextSupport(const UsdMayaJobExportArgs&, const MFnDependencyNode&)>;
+        UsdMayaPrimWriter::ContextSupport(const UsdMayaJobExportArgs&, const MObject&)>;
 
     /// \brief Register \p fn as a factory function providing a
     /// UsdMayaPrimWriter subclass that can be used to write \p mayaType.
@@ -145,7 +145,7 @@ struct UsdMayaPrimWriterRegistry
     static WriterFactoryFn Find(
         const std::string&          mayaTypeName,
         const UsdMayaJobExportArgs& exportArgs,
-        const MFnDependencyNode&    exportNode);
+        const MObject&    exportObj);
 
     /// \brief Check for external primWriter for \p mayaTypeName.
     MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/fileio/primWriterRegistry.h
+++ b/lib/mayaUsd/fileio/primWriterRegistry.h
@@ -149,7 +149,7 @@ struct UsdMayaPrimWriterRegistry
 
     /// \brief Check for external primWriter for \p mayaTypeName.
     MAYAUSD_CORE_PUBLIC
-    static void Poke(const std::string& mayaTypeName);
+    static void CheckForWriterPlugin(const std::string& mayaTypeName);
 
     /// \brief Registers a maya node type to *not* create a new prim.
     ///

--- a/lib/mayaUsd/fileio/primWriterRegistry.h
+++ b/lib/mayaUsd/fileio/primWriterRegistry.h
@@ -79,8 +79,8 @@ struct UsdMayaPrimWriterRegistry
 
     /// Predicate function, i.e. a function that can tell the level of support
     /// the writer function will provide for a given set of export options.
-    using ContextPredicateFn
-        = std::function<UsdMayaPrimWriter::ContextSupport(const UsdMayaJobExportArgs&)>;
+    using ContextPredicateFn = std::function<
+        UsdMayaPrimWriter::ContextSupport(const UsdMayaJobExportArgs&, const MFnDependencyNode&)>;
 
     /// \brief Register \p fn as a factory function providing a
     /// UsdMayaPrimWriter subclass that can be used to write \p mayaType.
@@ -142,8 +142,10 @@ struct UsdMayaPrimWriterRegistry
     ///
     /// If there is no writer plugin for \p mayaTypeName, returns nullptr.
     MAYAUSD_CORE_PUBLIC
-    static WriterFactoryFn
-    Find(const std::string& mayaTypeName, const UsdMayaJobExportArgs& exportArgs);
+    static WriterFactoryFn Find(
+        const std::string&          mayaTypeName,
+        const UsdMayaJobExportArgs& exportArgs,
+        const MFnDependencyNode&    exportNode);
 
     /// \brief Check for external primWriter for \p mayaTypeName.
     MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/fileio/primWriterRegistry.h
+++ b/lib/mayaUsd/fileio/primWriterRegistry.h
@@ -145,7 +145,7 @@ struct UsdMayaPrimWriterRegistry
     static WriterFactoryFn Find(
         const std::string&          mayaTypeName,
         const UsdMayaJobExportArgs& exportArgs,
-        const MObject&    exportObj);
+        const MObject&              exportObj);
 
     /// \brief Check for external primWriter for \p mayaTypeName.
     MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/fileio/shaderWriter.h
+++ b/lib/mayaUsd/fileio/shaderWriter.h
@@ -43,19 +43,6 @@ public:
         const SdfPath&           usdPath,
         UsdMayaWriteJobContext&  jobCtx);
 
-    /// The level of support a writer can offer for a given context
-    ///
-    /// A basic writer that gives correct results across most contexts should
-    /// report `Fallback`, while a specialized writer that really shines in a
-    /// given context should report `Supported` when the context is right and
-    /// `Unsupported` if the context is not as expected.
-    enum class ContextSupport
-    {
-        Supported,
-        Fallback,
-        Unsupported
-    };
-
     /// A static function is expected for all shader writers and allows
     /// declaring how well this class can support the current context.
     ///

--- a/lib/mayaUsd/fileio/shaderWriterRegistry.cpp
+++ b/lib/mayaUsd/fileio/shaderWriterRegistry.cpp
@@ -57,7 +57,7 @@ static int       _indexCounter = 0;
 
 _Registry::const_iterator _Find(const TfToken& usdInfoId, const UsdMayaJobExportArgs& exportArgs)
 {
-    using ContextSupport = UsdMayaShaderWriter::ContextSupport;
+    using ContextSupport = UsdMayaPrimWriter::ContextSupport;
 
     TfToken    conversion = exportArgs.convertMaterialsTo;
     const bool noFallback
@@ -141,7 +141,7 @@ UsdMayaShaderWriterRegistry::WriterFactoryFn UsdMayaShaderWriterRegistry::Find(
         _reg.insert(std::make_pair(
             mayaTypeName,
             _RegistryEntry { [](const UsdMayaJobExportArgs&) {
-                                return UsdMayaShaderWriter::ContextSupport::Fallback;
+                                return UsdMayaPrimWriter::ContextSupport::Fallback;
                             },
                              nullptr,
                              -1 }));

--- a/lib/mayaUsd/fileio/shaderWriterRegistry.h
+++ b/lib/mayaUsd/fileio/shaderWriterRegistry.h
@@ -84,7 +84,7 @@ struct UsdMayaShaderWriterRegistry
     /// Predicate function, i.e. a function that can tell the level of support
     /// the writer function will provide for a given set of export options.
     using ContextPredicateFn
-        = std::function<UsdMayaShaderWriter::ContextSupport(const UsdMayaJobExportArgs&)>;
+        = std::function<UsdMayaPrimWriter::ContextSupport(const UsdMayaJobExportArgs&)>;
 
     /// \brief Register \p fn as a factory function providing a
     /// UsdMayaShaderWriter subclass that can be used to write \p mayaType.

--- a/lib/mayaUsd/fileio/shading/symmetricShaderWriter.cpp
+++ b/lib/mayaUsd/fileio/shading/symmetricShaderWriter.cpp
@@ -67,7 +67,7 @@ void UsdMayaSymmetricShaderWriter::RegisterWriter(
 }
 
 /* static */
-UsdMayaShaderWriter::ContextSupport UsdMayaSymmetricShaderWriter::CanExport(
+UsdMayaPrimWriter::ContextSupport UsdMayaSymmetricShaderWriter::CanExport(
     const UsdMayaJobExportArgs& exportArgs,
     const TfToken&              materialConversionName)
 {

--- a/lib/mayaUsd/fileio/utils/adaptor.cpp
+++ b/lib/mayaUsd/fileio/utils/adaptor.cpp
@@ -158,7 +158,12 @@ TfType UsdMayaAdaptor::GetUsdType() const
     // The adaptor type mapping might be registered externally in a prim writer
     // plugin. This simply pokes the prim writer registry to load the prim
     // writer plugin in order to pull in the adaptor mapping.
-    UsdMayaPrimWriterRegistry::Find(depNode.typeName().asChar());
+    if (!_jobExportArgs) {
+        TF_CODING_ERROR("ExportArgs shouldn't be Null.");
+        return TfType();
+    }
+
+    UsdMayaPrimWriterRegistry::Find(depNode.typeName().asChar(), *_jobExportArgs);
     TfRegistryManager::GetInstance().SubscribeTo<UsdMayaAdaptor>();
 
     const auto iter = _schemaLookup.find(depNode.typeName().asChar());

--- a/lib/mayaUsd/fileio/utils/adaptor.cpp
+++ b/lib/mayaUsd/fileio/utils/adaptor.cpp
@@ -158,7 +158,7 @@ TfType UsdMayaAdaptor::GetUsdType() const
     // The adaptor type mapping might be registered externally in a prim writer
     // plugin. This simply pokes the prim writer registry to load the prim
     // writer plugin in order to pull in the adaptor mapping.
-    UsdMayaPrimWriterRegistry::Poke(depNode.typeName().asChar());
+    UsdMayaPrimWriterRegistry::CheckForWriterPlugin(depNode.typeName().asChar());
     TfRegistryManager::GetInstance().SubscribeTo<UsdMayaAdaptor>();
 
     const auto iter = _schemaLookup.find(depNode.typeName().asChar());

--- a/lib/mayaUsd/fileio/utils/adaptor.cpp
+++ b/lib/mayaUsd/fileio/utils/adaptor.cpp
@@ -158,12 +158,7 @@ TfType UsdMayaAdaptor::GetUsdType() const
     // The adaptor type mapping might be registered externally in a prim writer
     // plugin. This simply pokes the prim writer registry to load the prim
     // writer plugin in order to pull in the adaptor mapping.
-    if (!_jobExportArgs) {
-        TF_CODING_ERROR("ExportArgs shouldn't be Null.");
-        return TfType();
-    }
-
-    UsdMayaPrimWriterRegistry::Find(depNode.typeName().asChar(), *_jobExportArgs);
+    UsdMayaPrimWriterRegistry::Poke(depNode.typeName().asChar());
     TfRegistryManager::GetInstance().SubscribeTo<UsdMayaAdaptor>();
 
     const auto iter = _schemaLookup.find(depNode.typeName().asChar());

--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -565,7 +565,7 @@ UsdMayaWriteJobContext::_FindWriter(const MFnDependencyNode& mayaNode)
         = UsdMayaUtil::GetAllAncestorMayaNodeTypes(mayaNodeType);
     for (auto i = ancestorTypes.rbegin(); i != ancestorTypes.rend(); ++i) {
         if (UsdMayaPrimWriterRegistry::WriterFactoryFn primWriterFactory
-            = UsdMayaPrimWriterRegistry::Find(*i, mArgs, mayaNode)) {
+            = UsdMayaPrimWriterRegistry::Find(*i, mArgs, mayaNode.object())) {
             mWriterFactoryCache[mayaNodeType] = primWriterFactory;
             return primWriterFactory;
         }

--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -564,7 +564,7 @@ UsdMayaWriteJobContext::_FindWriter(const std::string& mayaNodeType)
         = UsdMayaUtil::GetAllAncestorMayaNodeTypes(mayaNodeType);
     for (auto i = ancestorTypes.rbegin(); i != ancestorTypes.rend(); ++i) {
         if (UsdMayaPrimWriterRegistry::WriterFactoryFn primWriterFactory
-            = UsdMayaPrimWriterRegistry::Find(*i)) {
+            = UsdMayaPrimWriterRegistry::Find(*i, mArgs)) {
             mWriterFactoryCache[mayaNodeType] = primWriterFactory;
             return primWriterFactory;
         }

--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -537,8 +537,7 @@ UsdMayaPrimWriterSharedPtr UsdMayaWriteJobContext::CreatePrimWriter(
     // This is either a DG node or a non-instanced DAG node, so try to look up
     // a writer plugin. We search through the node's type ancestors, working
     // backwards until we find a prim writer plugin.
-    const std::string mayaTypeName(depNodeFn.typeName().asChar());
-    if (UsdMayaPrimWriterRegistry::WriterFactoryFn primWriterFactory = _FindWriter(mayaTypeName)) {
+    if (UsdMayaPrimWriterRegistry::WriterFactoryFn primWriterFactory = _FindWriter(depNodeFn)) {
         if (UsdMayaPrimWriterSharedPtr primPtr = primWriterFactory(depNodeFn, writePath, *this)) {
             // We found a registered user prim writer that handles this node
             // type, so return now.
@@ -551,8 +550,10 @@ UsdMayaPrimWriterSharedPtr UsdMayaWriteJobContext::CreatePrimWriter(
 }
 
 UsdMayaPrimWriterRegistry::WriterFactoryFn
-UsdMayaWriteJobContext::_FindWriter(const std::string& mayaNodeType)
+UsdMayaWriteJobContext::_FindWriter(const MFnDependencyNode& mayaNode)
 {
+    const std::string mayaNodeType(mayaNode.typeName().asChar());
+
     // Check if type is already cached locally.
     auto iter = mWriterFactoryCache.find(mayaNodeType);
     if (iter != mWriterFactoryCache.end()) {
@@ -564,7 +565,7 @@ UsdMayaWriteJobContext::_FindWriter(const std::string& mayaNodeType)
         = UsdMayaUtil::GetAllAncestorMayaNodeTypes(mayaNodeType);
     for (auto i = ancestorTypes.rbegin(); i != ancestorTypes.rend(); ++i) {
         if (UsdMayaPrimWriterRegistry::WriterFactoryFn primWriterFactory
-            = UsdMayaPrimWriterRegistry::Find(*i, mArgs)) {
+            = UsdMayaPrimWriterRegistry::Find(*i, mArgs, mayaNode)) {
             mWriterFactoryCache[mayaNodeType] = primWriterFactory;
             return primWriterFactory;
         }

--- a/lib/mayaUsd/fileio/writeJobContext.h
+++ b/lib/mayaUsd/fileio/writeJobContext.h
@@ -186,7 +186,7 @@ private:
         std::vector<UsdMayaPrimWriterSharedPtr>::const_iterator* end) const;
 
     /// Prim writer search with ancestor type resolution behavior.
-    UsdMayaPrimWriterRegistry::WriterFactoryFn _FindWriter(const std::string& mayaNodeType);
+    UsdMayaPrimWriterRegistry::WriterFactoryFn _FindWriter(const MFnDependencyNode& mayaNode);
 
     struct MObjectHandleComp
     {

--- a/lib/mayaUsd/python/wrapPrimWriter.cpp
+++ b/lib/mayaUsd/python/wrapPrimWriter.cpp
@@ -233,7 +233,7 @@ public:
         Register(boost::python::object cl, const std::string& mayaTypeName, bool& updated)
         {
             size_t classIndex = RegisterPythonObject(cl, GetKey(cl, mayaTypeName));
-            updated = classIndex == UsdMayaPythonObjectRegistry::UPDATED;
+            updated = (classIndex == UsdMayaPythonObjectRegistry::UPDATED);
             // Return a new factory function:
             return FactoryFnWrapper { classIndex };
         }
@@ -265,6 +265,9 @@ public:
         bool             updated = false;
         FactoryFnWrapper fn = FactoryFnWrapper::Register(cl, mayaTypeName, updated);
         if (!updated) {
+
+            // fn is used twice because the register function will handle both
+            // CanExport and FactoryFn
             UsdMayaPrimWriterRegistry::Register(mayaTypeName, fn, fn, true);
         }
     }

--- a/lib/mayaUsd/python/wrapPrimWriter.cpp
+++ b/lib/mayaUsd/python/wrapPrimWriter.cpp
@@ -215,11 +215,15 @@ public:
                 // Prototype was unregistered
                 return UsdMayaPrimWriter::ContextSupport::Unsupported;
             }
-            TfPyLock              pyLock;
-            boost::python::object CanExport = pyClass.attr("CanExport");
-            PyObject*             callable = CanExport.ptr();
-            auto                  res = boost::python::call<int>(callable, exportArgs, exportObj);
-            return UsdMayaPrimWriter::ContextSupport(res);
+            TfPyLock pyLock;
+            if (PyObject_HasAttrString(pyClass.ptr(), "CanExport")) {
+                boost::python::object CanExport = pyClass.attr("CanExport");
+                PyObject*             callable = CanExport.ptr();
+                auto res = boost::python::call<int>(callable, exportArgs, exportObj);
+                return UsdMayaPrimWriter::ContextSupport(res);
+            } else {
+                return UsdMayaPrimWriter::ContextSupport::Fallback;
+            }
         }
 
         // Create a new wrapper for a Python class that is seen for the first time for a given

--- a/lib/mayaUsd/python/wrapPrimWriter.cpp
+++ b/lib/mayaUsd/python/wrapPrimWriter.cpp
@@ -209,7 +209,7 @@ public:
         UsdMayaPrimWriter::ContextSupport
         operator()(const UsdMayaJobExportArgs& exportArgs, const MObject& exportObj)
         {
-            
+
             boost::python::object pyClass = GetPythonObject(_classIndex);
             if (!pyClass) {
                 // Prototype was unregistered
@@ -219,7 +219,7 @@ public:
             boost::python::object CanExport = pyClass.attr("CanExport");
             PyObject*             callable = CanExport.ptr();
             auto                  res = boost::python::call<int>(callable, exportArgs, exportObj);
-            return UsdMayaPrimWriter::ContextSupport(res);            
+            return UsdMayaPrimWriter::ContextSupport(res);
         }
 
         // Create a new wrapper for a Python class that is seen for the first time for a given

--- a/lib/mayaUsd/python/wrapPrimWriter.cpp
+++ b/lib/mayaUsd/python/wrapPrimWriter.cpp
@@ -206,20 +206,32 @@ public:
             return sptr;
         }
 
+        UsdMayaPrimWriter::ContextSupport
+        operator()(const UsdMayaJobExportArgs& exportArgs, const MObject& exportObj)
+        {
+            
+            boost::python::object pyClass = GetPythonObject(_classIndex);
+            if (!pyClass) {
+                // Prototype was unregistered
+                return UsdMayaPrimWriter::ContextSupport::Unsupported;
+            }
+            TfPyLock              pyLock;
+            boost::python::object CanExport = pyClass.attr("CanExport");
+            PyObject*             callable = CanExport.ptr();
+            auto                  res = boost::python::call<int>(callable, exportArgs, exportObj);
+            return UsdMayaPrimWriter::ContextSupport(res);            
+        }
+
         // Create a new wrapper for a Python class that is seen for the first time for a given
         // purpose. If we already have a registration for this purpose: update the class to
         // allow the previously issued factory function to use it.
-        static UsdMayaPrimWriterRegistry::WriterFactoryFn
-        Register(boost::python::object cl, const std::string& mayaTypeName)
+        static FactoryFnWrapper
+        Register(boost::python::object cl, const std::string& mayaTypeName, bool& updated)
         {
             size_t classIndex = RegisterPythonObject(cl, GetKey(cl, mayaTypeName));
-            if (classIndex != UsdMayaPythonObjectRegistry::UPDATED) {
-                // Return a new factory function:
-                return FactoryFnWrapper { classIndex };
-            } else {
-                // We already registered a factory function for this purpose:
-                return nullptr;
-            }
+            updated = classIndex == UsdMayaPythonObjectRegistry::UPDATED;
+            // Return a new factory function:
+            return FactoryFnWrapper { classIndex };
         }
 
         // Unregister a class for a given purpose. This will cause the associated factory
@@ -246,10 +258,10 @@ public:
 
     static void Register(boost::python::object cl, const std::string& mayaTypeName)
     {
-        UsdMayaPrimWriterRegistry::WriterFactoryFn fn
-            = FactoryFnWrapper::Register(cl, mayaTypeName);
-        if (fn) {
-            UsdMayaPrimWriterRegistry::Register(mayaTypeName, fn, true);
+        bool             updated = false;
+        FactoryFnWrapper fn = FactoryFnWrapper::Register(cl, mayaTypeName, updated);
+        if (!updated) {
+            UsdMayaPrimWriterRegistry::Register(mayaTypeName, fn, fn, true);
         }
     }
 
@@ -349,18 +361,18 @@ public:
         }
 
         // We can have multiple function objects, this one apapts the CanImport function:
-        UsdMayaShaderWriter::ContextSupport operator()(const UsdMayaJobExportArgs& exportArgs)
+        UsdMayaPrimWriter::ContextSupport operator()(const UsdMayaJobExportArgs& exportArgs)
         {
             boost::python::object pyClass = GetPythonObject(_classIndex);
             if (!pyClass) {
                 // Prototype was unregistered
-                return UsdMayaShaderWriter::ContextSupport::Unsupported;
+                return UsdMayaPrimWriter::ContextSupport::Unsupported;
             }
             TfPyLock              pyLock;
             boost::python::object CanExport = pyClass.attr("CanExport");
             PyObject*             callable = CanExport.ptr();
             auto                  res = boost::python::call<int>(callable, exportArgs);
-            return UsdMayaShaderWriter::ContextSupport(res);
+            return UsdMayaPrimWriter::ContextSupport(res);
         }
 
         // Create a new wrapper for a Python class that is seen for the first time for a given
@@ -598,11 +610,24 @@ void wrapJobExportArgs()
         .staticmethod("GetDefaultMaterialsScopeName");
 }
 
+TF_REGISTRY_FUNCTION(TfEnum)
+{
+    TF_ADD_ENUM_NAME(UsdMayaPrimWriter::ContextSupport::Supported, "Supported");
+    TF_ADD_ENUM_NAME(UsdMayaPrimWriter::ContextSupport::Fallback, "Fallback");
+    TF_ADD_ENUM_NAME(UsdMayaPrimWriter::ContextSupport::Unsupported, "Unsupported");
+}
+
 void wrapPrimWriter()
 {
-    boost::python::class_<PrimWriterWrapper<>, boost::noncopyable>(
-        "PrimWriter", boost::python::no_init)
-        .def("__init__", make_constructor(&PrimWriterWrapper<>::New))
+
+    boost::python::class_<PrimWriterWrapper<>, boost::noncopyable> c(
+        "PrimWriter", boost::python::no_init);
+
+    boost::python::scope s(c);
+
+    TfPyWrapEnum<UsdMayaPrimWriter::ContextSupport>();
+
+    c.def("__init__", make_constructor(&PrimWriterWrapper<>::New))
         .def(
             "PostExport",
             &PrimWriterWrapper<>::PostExport,
@@ -658,13 +683,6 @@ void wrapPrimWriter()
         .staticmethod("Unregister");
 }
 
-TF_REGISTRY_FUNCTION(TfEnum)
-{
-    TF_ADD_ENUM_NAME(UsdMayaShaderWriter::ContextSupport::Supported, "Supported");
-    TF_ADD_ENUM_NAME(UsdMayaShaderWriter::ContextSupport::Fallback, "Fallback");
-    TF_ADD_ENUM_NAME(UsdMayaShaderWriter::ContextSupport::Unsupported, "Unsupported");
-}
-
 //----------------------------------------------------------------------------------------------------------------------
 void wrapShaderWriter()
 {
@@ -673,8 +691,6 @@ void wrapShaderWriter()
             c("ShaderWriter", boost::python::no_init);
 
     boost::python::scope s(c);
-
-    TfPyWrapEnum<UsdMayaShaderWriter::ContextSupport>();
 
     c.def("__init__", make_constructor(&ShaderWriterWrapper::New))
         .def(

--- a/lib/usd/pxrUsdPreviewSurface/usdPreviewSurfaceWriter.cpp
+++ b/lib/usd/pxrUsdPreviewSurface/usdPreviewSurfaceWriter.cpp
@@ -135,7 +135,7 @@ void _ValidateNormalMap(const MPlug& shadingNodePlug)
 
 } // namespace
 
-UsdMayaShaderWriter::ContextSupport
+UsdMayaPrimWriter::ContextSupport
 PxrMayaUsdPreviewSurface_Writer::CanExport(const UsdMayaJobExportArgs& exportArgs)
 {
     if (exportArgs.convertMaterialsTo == UsdImagingTokens->UsdPreviewSurface) {

--- a/lib/usd/translators/shading/mtlxBaseWriter.cpp
+++ b/lib/usd/translators/shading/mtlxBaseWriter.cpp
@@ -75,7 +75,7 @@ REGISTER_SHADING_MODE_EXPORT_MATERIAL_CONVERSION(
     TrMtlxTokens->niceName,
     TrMtlxTokens->exportDescription);
 
-UsdMayaShaderWriter::ContextSupport
+UsdMayaPrimWriter::ContextSupport
 MtlxUsd_BaseWriter::CanExport(const UsdMayaJobExportArgs& exportArgs)
 {
     return exportArgs.convertMaterialsTo == TrMtlxTokens->conversionName

--- a/lib/usd/translators/shading/mtlxSymmetricShaderWriter.cpp
+++ b/lib/usd/translators/shading/mtlxSymmetricShaderWriter.cpp
@@ -146,7 +146,7 @@ void MtlxUsd_SymmetricShaderWriter::RegisterWriter(
 }
 
 /* static */
-UsdMayaShaderWriter::ContextSupport
+UsdMayaPrimWriter::ContextSupport
 MtlxUsd_SymmetricShaderWriter::CanExport(const UsdMayaJobExportArgs& exportArgs)
 {
     if (exportArgs.convertMaterialsTo == TrMtlxTokens->conversionName) {

--- a/lib/usd/translators/shading/usdDisplacementShaderWriter.cpp
+++ b/lib/usd/translators/shading/usdDisplacementShaderWriter.cpp
@@ -152,7 +152,7 @@ void PxrUsdTranslators_DisplacementShaderWriter::Write(const UsdTimeCode& usdTim
 }
 
 /* static */
-UsdMayaShaderWriter::ContextSupport
+UsdMayaPrimWriter::ContextSupport
 PxrUsdTranslators_DisplacementShaderWriter::CanExport(const UsdMayaJobExportArgs& exportArgs)
 {
     if (exportArgs.convertMaterialsTo == UsdImagingTokens->UsdPreviewSurface) {

--- a/lib/usd/translators/shading/usdFileTextureWriter.cpp
+++ b/lib/usd/translators/shading/usdFileTextureWriter.cpp
@@ -115,7 +115,7 @@ TF_DEFINE_PRIVATE_TOKENS(
 );
 // clang-format on
 
-UsdMayaShaderWriter::ContextSupport
+UsdMayaPrimWriter::ContextSupport
 PxrUsdTranslators_FileTextureWriter::CanExport(const UsdMayaJobExportArgs& exportArgs)
 {
     if (exportArgs.convertMaterialsTo == UsdImagingTokens->UsdPreviewSurface) {

--- a/lib/usd/translators/shading/usdMaterialWriter.cpp
+++ b/lib/usd/translators/shading/usdMaterialWriter.cpp
@@ -51,7 +51,7 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-UsdMayaShaderWriter::ContextSupport
+UsdMayaPrimWriter::ContextSupport
 PxrUsdTranslators_MaterialWriter::CanExport(const UsdMayaJobExportArgs& exportArgs)
 {
     if (exportArgs.convertMaterialsTo == UsdImagingTokens->UsdPreviewSurface) {

--- a/test/lib/mayaUsd/fileio/testPrimWriter.py
+++ b/test/lib/mayaUsd/fileio/testPrimWriter.py
@@ -49,6 +49,9 @@ class primWriterTest(mayaUsdLib.PrimWriter):
         self._SetUsdPrim(usdPrim)
         primWriterTest.InitCalled = True
 
+    def CanExport(cls, exportArgs, exportObj=None):
+        return mayaUsdLib.PrimWriter.ContextSupport.Supported
+
     def Write(self, usdTime):
         depNodeFn = OpenMaya.MFnDependencyNode(self.GetMayaObject())
         plg = depNodeFn.findPlug('inMesh', True)

--- a/test/lib/mayaUsd/fileio/testPrimWriter.py
+++ b/test/lib/mayaUsd/fileio/testPrimWriter.py
@@ -32,6 +32,7 @@ class primWriterTest(mayaUsdLib.PrimWriter):
     InitCalled = False
     WriteCalled = False
     PostExportCalled = False
+    CanExportCalled = False
 
     def __init__(self, *args, **kwargs):
         super(primWriterTest, self).__init__(*args, **kwargs)
@@ -51,6 +52,7 @@ class primWriterTest(mayaUsdLib.PrimWriter):
 
     @classmethod
     def CanExport(cls, exportArgs, exportObj=None):
+        primWriterTest.CanExportCalled = True
         return mayaUsdLib.PrimWriter.ContextSupport.Supported
 
     def Write(self, usdTime):
@@ -92,6 +94,7 @@ class testReadWriteUtils(unittest.TestCase):
             shadingMode='none')
 
         self.assertTrue(primWriterTest.InitCalled)
+        self.assertTrue(primWriterTest.CanExportCalled)
         self.assertTrue(primWriterTest.WriteCalled)
         self.assertTrue(primWriterTest.PostExportCalled)
 

--- a/test/lib/mayaUsd/fileio/testPrimWriter.py
+++ b/test/lib/mayaUsd/fileio/testPrimWriter.py
@@ -49,6 +49,7 @@ class primWriterTest(mayaUsdLib.PrimWriter):
         self._SetUsdPrim(usdPrim)
         primWriterTest.InitCalled = True
 
+    @classmethod
     def CanExport(cls, exportArgs, exportObj=None):
         return mayaUsdLib.PrimWriter.ContextSupport.Supported
 

--- a/test/lib/mayaUsd/fileio/testShaderWriter.py
+++ b/test/lib/mayaUsd/fileio/testShaderWriter.py
@@ -35,7 +35,7 @@ class shaderWriterTest(mayaUsdLib.ShaderWriter):
     @classmethod
     def CanExport(cls, exportArgs):
         shaderWriterTest.CanExportCalled = True
-        return mayaUsdLib.ShaderWriter.ContextSupport.Supported
+        return mayaUsdLib.PrimWriter.ContextSupport.Supported
 
     def Write(self, usdTime):
         shaderWriterTest.WriteCalledCount += 1


### PR DESCRIPTION
- Add `CanExport` function to primWriter for overriding default primWriter
- Overload the Register function for backward support
- Add `Poke `function for cases when only wants to check for plugin register but not really find a primWriter