### PR TITLE
Fixed a compile error when UFE_SCENE_SEGMENT_SUPPORT isn't available.

### DIFF
--- a/lib/mayaUsd/utils/trieVisitor.h
+++ b/lib/mayaUsd/utils/trieVisitor.h
@@ -18,7 +18,9 @@
 
 #include <mayaUsd/base/api.h>
 
+#if UFE_SCENE_SEGMENT_SUPPORT
 #include <ufe/sceneSegmentHandler.h>
+#endif
 #include <ufe/trie.h>
 
 #include <functional>
@@ -84,14 +86,18 @@ inline void TrieVisitor<T>::visit(
         if (nodeComp) {
             if (parentPath.empty()) {
                 nodePath = Ufe::Path(Ufe::PathSegment(nodeComp, ufe::getMayaRunTimeId(), '|'));
-            } else if (Ufe::SceneSegmentHandler::isGateway(parentPath)) {
+            } 
+        #if UFE_SCENE_SEGMENT_SUPPORT
+            else if (Ufe::SceneSegmentHandler::isGateway(parentPath)) {
                 if (parentPath.runTimeId() == ufe::getUsdRunTimeId()) {
                     nodePath
                         = parentPath + Ufe::PathSegment(nodeComp, ufe::getMayaRunTimeId(), '|');
                 } else {
                     nodePath = parentPath + Ufe::PathSegment(nodeComp, ufe::getUsdRunTimeId(), '/');
-                }
-            } else {
+                }            
+            }
+        #endif
+            else {
                 nodePath = parentPath + nodeComp;
             }
         }


### PR DESCRIPTION
I'm not sure if this is the correct fix, but there is a compile error when the header file "ufe/sceneSegmentHandler.h" isn't available. I'm assuming it's because our studio is using Maya 2023 and this feature is available in the next version.