### PR TITLE
Include pxr header

### DIFF
--- a/lib/mayaUsd/base/api.h
+++ b/lib/mayaUsd/base/api.h
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 #include <pxr/base/arch/export.h>
+#include <pxr/pxr.h>
 
 // clang-format off
 #if defined _WIN32 || defined __CYGWIN__


### PR DESCRIPTION
This was getting picked up implicitly via the include in pxr/base/arch/defines.h but that is getting removed in usd 23.08