### PR TITLE
LOOKDEVX-1547 - Allow introspecting UsdAttribute UFE class

### DIFF
--- a/lib/mayaUsd/ufe/UsdAttribute.h
+++ b/lib/mayaUsd/ufe/UsdAttribute.h
@@ -106,7 +106,7 @@ namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
 //! \brief Internal helper class to implement the pure virtual methods from Ufe::Attribute.
-class UsdAttribute
+class MAYAUSD_CORE_PUBLIC UsdAttribute
 {
 public:
     UsdAttribute(UsdAttributeHolder::UPtr&& attrHolder);

--- a/lib/mayaUsd/ufe/UsdShaderAttributeHolder.cpp
+++ b/lib/mayaUsd/ufe/UsdShaderAttributeHolder.cpp
@@ -78,9 +78,16 @@ std::string UsdShaderAttributeHolder::isEditAllowedMsg() const
 
 std::string UsdShaderAttributeHolder::defaultValue() const
 {
+    // TODO: Add a PXR_VERSION if a fix is introduced in OpenUSD.
     if (_sdrProp->GetType() == PXR_NS::SdfValueTypeNames->Matrix3d.GetAsToken()) {
-        // There is no Matrix3d type in Sdr, so the MaterialX default value is not kept
-        return "0,0,0,0,0,0,0,0,0";
+        std::string val = UsdShaderAttributeDef(_sdrProp).defaultValue();
+        if (val.empty()) {
+            // There is no Matrix3d type in Sdr, so the MaterialX default value is not kept
+            return "0,0,0,0,0,0,0,0,0";
+        }
+        // But if https://github.com/PixarAnimationStudios/OpenUSD/issues/2523 gets fixed
+        // then return that value:
+        return val;
     }
 #if PXR_VERSION < 2205
     if (_sdrProp->GetType() == PXR_NS::SdfValueTypeNames->Bool.GetAsToken()) {

--- a/lib/mayaUsd/ufe/UsdShaderAttributeHolder.cpp
+++ b/lib/mayaUsd/ufe/UsdShaderAttributeHolder.cpp
@@ -80,7 +80,7 @@ std::string UsdShaderAttributeHolder::defaultValue() const
 {
     // TODO: Add a PXR_VERSION if a fix is introduced in OpenUSD.
     if (_sdrProp->GetType() == PXR_NS::SdfValueTypeNames->Matrix3d.GetAsToken()) {
-        std::string val = UsdShaderAttributeDef(_sdrProp).defaultValue();
+        const std::string val = UsdShaderAttributeDef(_sdrProp).defaultValue();
         if (val.empty()) {
             // There is no Matrix3d type in Sdr, so the MaterialX default value is not kept
             return "0,0,0,0,0,0,0,0,0";

--- a/test/lib/ufe/testAttribute.py
+++ b/test/lib/ufe/testAttribute.py
@@ -22,7 +22,7 @@ import ufeUtils
 import testUtils
 import usdUtils
 
-from pxr import Usd, UsdGeom, Vt, Gf, UsdLux, UsdUI
+from pxr import Usd, UsdGeom, Vt, Gf, UsdLux, UsdUI, Sdr
 from pxr import UsdShade
 
 from maya import cmds
@@ -40,6 +40,11 @@ import os
 import random
 import unittest
 
+def UsdHasDefaultForMatrix33():
+    r = Sdr.Registry()
+    n = r.GetNodeByIdentifier("ND_add_matrix33")
+    i = n.GetShaderInput("in1")
+    return i.GetDefaultValue() is not None
 
 class TestObserver(ufe.Observer):
     def __init__(self):
@@ -1856,10 +1861,10 @@ class AttributeTestCase(unittest.TestCase):
         newVector3 = ufe.Vector3f(0.2, 0.4, 0.6)
         origVector4 = ufe.Vector4f(0.0, 0.0, 0.0, 0.0)
         newVector4 = ufe.Vector4f(0.2, 0.4, 0.6, 0.8)
-        # Default Matrix33 should be identity, but USD does not store a default value for that type.
-        # Requires same fix as Boolean in pxr/usd/usdMtlx/parser.cpp
-        #   See: https://github.com/PixarAnimationStudios/USD/pull/1789
-        origMatrix3 = ufe.Matrix3d([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+        if UsdHasDefaultForMatrix33():
+            origMatrix3 = ufe.Matrix3d([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        else:
+            origMatrix3 = ufe.Matrix3d([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
         newMatrix3 = ufe.Matrix3d([[2, 4, 6], [7, 5, 3], [1, 2, 3]])
         origMatrix4 = ufe.Matrix4d([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
         newMatrix4 = ufe.Matrix4d([[1, 2, 1, 1], [0, 1, 0, 1], [2, 3, 4, 1], [1, 1, 1, 1]])


### PR DESCRIPTION
Allows a downstream client to access the USD data wrapped in a UFE Attribute class.

Also updates core and tests in case MaterialX starts remembering default values for matrix33 inputs.