### PR TITLE
EMSUSD-77 - Newly created USD Lights can't cast shadows

### DIFF
--- a/lib/mayaUsd/ufe/UsdLight.cpp
+++ b/lib/mayaUsd/ufe/UsdLight.cpp
@@ -173,11 +173,12 @@ Ufe::Color3f UsdLight::color() const { return getLightColor(prim()); }
 bool getLightShadowEnable(const UsdPrim& prim)
 {
     const UsdLuxShadowAPI      shadowAPI(prim);
-    const PXR_NS::UsdAttribute lightAttribute = shadowAPI.GetShadowEnableAttr();
+    PXR_NS::UsdAttribute lightAttribute = shadowAPI.GetShadowEnableAttr();
 
     if (!lightAttribute) {
         // If the shadow enable attribute is not created yet, create one here
-        shadowAPI.CreateShadowEnableAttr(VtValue(true));
+        lightAttribute = shadowAPI.CreateShadowEnableAttr(VtValue(true));
+        return true;
     }
 
     bool val = false;
@@ -210,11 +211,11 @@ bool UsdLight::shadowEnable() const { return getLightShadowEnable(prim()); }
 Ufe::Color3f getLightShadowColor(const UsdPrim& prim)
 {
     const UsdLuxShadowAPI      shadowAPI(prim);
-    const PXR_NS::UsdAttribute lightAttribute = shadowAPI.GetShadowColorAttr();
+    PXR_NS::UsdAttribute lightAttribute = shadowAPI.GetShadowColorAttr();
 
     if (!lightAttribute) {
         // If the shadow color attribute is not created yet, create one here
-        shadowAPI.CreateShadowColorAttr();
+        lightAttribute = shadowAPI.CreateShadowColorAttr();
     }
 
     GfVec3f val(0.f, 0.f, 0.f);

--- a/lib/mayaUsd/ufe/UsdLight.cpp
+++ b/lib/mayaUsd/ufe/UsdLight.cpp
@@ -175,6 +175,11 @@ bool getLightShadowEnable(const UsdPrim& prim)
     const UsdLuxShadowAPI      shadowAPI(prim);
     const PXR_NS::UsdAttribute lightAttribute = shadowAPI.GetShadowEnableAttr();
 
+    if (!lightAttribute) {
+        // If the shadow enable attribute is not created yet, create one here
+        shadowAPI.CreateShadowEnableAttr(VtValue(true));
+    }
+
     bool val = false;
     lightAttribute.Get(&val);
     return val;
@@ -187,9 +192,6 @@ void setLightShadowEnable(const UsdPrim& prim, bool attrVal)
 
     if (lightAttribute) {
         lightAttribute.Set(attrVal);
-    } else {
-        const PXR_NS::UsdAttribute shadowAttribute = shadowAPI.CreateShadowEnableAttr();
-        shadowAttribute.Set(attrVal);
     }
 }
 
@@ -209,6 +211,11 @@ Ufe::Color3f getLightShadowColor(const UsdPrim& prim)
 {
     const UsdLuxShadowAPI      shadowAPI(prim);
     const PXR_NS::UsdAttribute lightAttribute = shadowAPI.GetShadowColorAttr();
+
+    if (!lightAttribute) {
+        // If the shadow color attribute is not created yet, create one here
+        shadowAPI.CreateShadowColorAttr();
+    }
 
     GfVec3f val(0.f, 0.f, 0.f);
     lightAttribute.Get(&val);

--- a/lib/mayaUsd/ufe/UsdLight.cpp
+++ b/lib/mayaUsd/ufe/UsdLight.cpp
@@ -172,8 +172,8 @@ Ufe::Color3f UsdLight::color() const { return getLightColor(prim()); }
 
 bool getLightShadowEnable(const UsdPrim& prim)
 {
-    const UsdLuxShadowAPI      shadowAPI(prim);
-    PXR_NS::UsdAttribute lightAttribute = shadowAPI.GetShadowEnableAttr();
+    const UsdLuxShadowAPI shadowAPI(prim);
+    PXR_NS::UsdAttribute  lightAttribute = shadowAPI.GetShadowEnableAttr();
 
     if (!lightAttribute) {
         // If the shadow enable attribute is not created yet, create one here
@@ -210,8 +210,8 @@ bool UsdLight::shadowEnable() const { return getLightShadowEnable(prim()); }
 
 Ufe::Color3f getLightShadowColor(const UsdPrim& prim)
 {
-    const UsdLuxShadowAPI      shadowAPI(prim);
-    PXR_NS::UsdAttribute lightAttribute = shadowAPI.GetShadowColorAttr();
+    const UsdLuxShadowAPI shadowAPI(prim);
+    PXR_NS::UsdAttribute  lightAttribute = shadowAPI.GetShadowColorAttr();
 
     if (!lightAttribute) {
         // If the shadow color attribute is not created yet, create one here

--- a/lib/mayaUsd/ufe/UsdLight.cpp
+++ b/lib/mayaUsd/ufe/UsdLight.cpp
@@ -185,7 +185,12 @@ void setLightShadowEnable(const UsdPrim& prim, bool attrVal)
     const UsdLuxShadowAPI      shadowAPI(prim);
     const PXR_NS::UsdAttribute lightAttribute = shadowAPI.GetShadowEnableAttr();
 
-    lightAttribute.Set(attrVal);
+    if (lightAttribute) {
+        lightAttribute.Set(attrVal);
+    } else {
+        const PXR_NS::UsdAttribute shadowAttribute = shadowAPI.CreateShadowEnableAttr();
+        shadowAttribute.Set(attrVal);
+    }
 }
 
 Ufe::Light::ShadowEnableUndoableCommand::Ptr UsdLight::shadowEnableCmd(bool se)

--- a/lib/mayaUsd/ufe/UsdLightHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdLightHandler.cpp
@@ -46,10 +46,7 @@ Ufe::Light::Ptr UsdLightHandler::light(const Ufe::SceneItem::Ptr& item) const
     if (!lightSchema)
         return nullptr;
 
-    UsdLight::Ptr usdLight = UsdLight::create(usdItem);
-    usdLight->shadowEnable(true);
-
-    return usdLight;
+    return UsdLight::create(usdItem);
 }
 
 } // namespace ufe

--- a/lib/mayaUsd/ufe/UsdLightHandler.cpp
+++ b/lib/mayaUsd/ufe/UsdLightHandler.cpp
@@ -46,7 +46,10 @@ Ufe::Light::Ptr UsdLightHandler::light(const Ufe::SceneItem::Ptr& item) const
     if (!lightSchema)
         return nullptr;
 
-    return UsdLight::create(usdItem);
+    UsdLight::Ptr usdLight = UsdLight::create(usdItem);
+    usdLight->shadowEnable(true);
+
+    return usdLight;
 }
 
 } // namespace ufe


### PR DESCRIPTION
Create USD light from USD will cause the bug. The root cause is that those shadow attributes are never added to the USD created lights. So create Shadow attributes at first query if the attribute is not created