### PR TITLE
EMSUSD-256 allow Maya ref to be relative to the layer.

### DIFF
--- a/lib/mayaUsd/resources/scripts/mayaUsdAddMayaReference.mel
+++ b/lib/mayaUsd/resources/scripts/mayaUsdAddMayaReference.mel
@@ -92,7 +92,7 @@ proc fileOptionsTabPage(string $tabLayout)
     string $topForm = `columnLayout -rowSpacing 5 actionOptionsForm`;
 
     setParent $topForm;
-    frameLayout -label `getMayaUsdLibString("kMayaRefDescription")` -height 170 -mw $gOptionBoxTemplateDescriptionMarginWidth;
+    frameLayout -label `getMayaUsdLibString("kMayaRefDescription")` -height 170 -mw $gOptionBoxTemplateDescriptionMarginWidth -collapsable 0;
     columnLayout;
     text -align "left" -wordWrap true -height 80 -label `getMayaUsdLibString("kMayaRefAddToUSDDescription1")`;
     text -align "left" -wordWrap true -height 50 -label `getMayaUsdLibString("kMayaRefAddToUSDDescription2")`;
@@ -100,6 +100,8 @@ proc fileOptionsTabPage(string $tabLayout)
     setParent $topForm;
     frameLayout -label `getMayaUsdLibString("kMayaRefUsdOptions")`;
     string $widgetColumn = `columnLayout usdOptionsLayout`;
+
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdMayaRefRelativeToEditTargetLayer.uiCreateFields()");
 
     textFieldGrp
         -label `getMayaUsdLibString("kMayaRefMayaRefPrimName")`
@@ -592,8 +594,10 @@ proc usdMayaRef_setupDefineInVariant()
 }
 
 // Adapted from fileOptions.mel:fileOptionsSetup().
-proc fileOptionsSetup(string $parent, int $forceFactorySettings, string $chosenFileType)
+proc fileOptionsSetup(string $parent, int $forceFactorySettings, string $filterType)
 {
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdMayaRefRelativeToEditTargetLayer.uiInit(r'''" + $parent + "''', r'''" + $filterType + "''')");
+
     global string $gUsdMayaReferenceUfePath;
 
     string $action = "Reference";
@@ -670,8 +674,8 @@ proc fileOptionsSetup(string $parent, int $forceFactorySettings, string $chosenF
 
     fo_changeReferenceNamespaceOption( $action );
 
-    string $fileType = ("" == $chosenFileType) ? 
-        `optionVar -q defaultFileReferenceType` : $chosenFileType;
+    string $fileType = ("" == $filterType) ? 
+        `optionVar -q defaultFileReferenceType` : $filterType;
 
     int $userPrefix = 0;
     string $usePrefixOptionVar = "referenceOptionsUseRenamePrefix";
@@ -774,6 +778,8 @@ proc string makeNamespaceNameFromFileName(string $fileName)
 global proc addMayaReferenceToUsdUiCb(string $parent, string $selectedFile)
 {
     setParent $parent;
+
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdMayaRefRelativeToEditTargetLayer.uiCommit(r'''" + $parent + "''', r'''" + $selectedFile + "''')");
 
     string $action = "Reference";
 
@@ -1060,10 +1066,17 @@ global proc string addMayaReferenceToUsd(string $ufePath)
 
     int $autoEditAsMayaData = `optionVar -query usdMayaReferenceEditAsMayaDat`;
     
-    // No need to actually create the Maya reference node: pulling on the
+    string $filePath = $file[0];
+    int $requireRelative = (`optionVar -exists mayaUsd_MakePathRelativeToEditTargetLayer` && `optionVar -query mayaUsd_MakePathRelativeToEditTargetLayer`);
+    if ($requireRelative) {
+        string $relativeTo = `python("import mayaUsd_USDRootFileRelative as murel; murel.usdFileRelative.getRelativeFilePathRoot()")`;
+        $filePath = `python("import mayaUsd.lib as mayaUsdLib; mayaUsdLib.Util.getPathRelativeToDirectory(r'''" + $filePath + "''', r'''" + $relativeTo + "''')")`;
+    }
+    $filePath = fromNativePath($filePath);
+
+    // No need to actually create the Maya reference node: edit-as-Maya on the
     // Maya reference prim will create the Maya reference node.
     // Create the Maya reference prim under its parent.
-    string $filePath = fromNativePath($file[0]);
     string $ns = computeNamespace($filePath);
     string $pyCmdArgs = `format -s $ufePath -s $filePath -s $ns -s $gUsdMayaReferencePrimName "'^1s', '^2s', '^3s', '^4s'"`;
     if ($useGroup)

--- a/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.mel
+++ b/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.mel
@@ -31,7 +31,7 @@ global proc mayaUsdLibRegisterStrings()
     register("kMayaRefCacheToUSDDescription2", "<p><b>Note:</b> When authoring the exported USD cache back into a current USD hierarchy, an edit will be made on the targeted layer. The cache file will be added as a USD reference, defined either in a variant or prim.</p>");
     register("kMayaRefAddToUSDDescription1", "<p>Add a Maya reference to a USD prim to enable working with original Maya data in your USD scene. Select a Maya scene file to add as a reference. Once a Maya reference file is added, a Maya transform node will appear in the Outliner at your selected prim, containing your newly added Maya reference. Use this dialog to build out the scope of your Maya reference.</p>");
     register("kMayaRefAddToUSDDescription2", "<p><b>Tip:</b> Define your Maya Reference in a USD variant. This will enable your prim to have 2 variants you can switch between in the Outliner; the Maya reference and its USD cache.</p>");
-    register("kMayaRefUsdOptions", "USD Options");
+    register("kMayaRefUsdOptions", "Author Maya Reference File to USD");
     register("kMayaRefMayaRefPrimName", "Maya Reference Prim Name:");
     register("kMayaRefGroup", "Group");
     register("kMayaRefPrimName", "Prim Name:");

--- a/lib/mayaUsd/ufe/MayaUsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/MayaUsdContextOps.cpp
@@ -155,7 +155,9 @@ const std::string getTargetLayerFilePath(const UsdPrim& prim)
 
 bool _prepareUSDReferenceTargetLayer(const UsdPrim& prim)
 {
-    return UsdMayaUtilFileSystem::prepareLayerSaveUILayer(getCurrentTargetLayer(prim), false);
+    static const bool useSceneFileForRoot = false;
+    return UsdMayaUtilFileSystem::prepareLayerSaveUILayer(
+        getCurrentTargetLayer(prim), useSceneFileForRoot);
 }
 
 // Ask SDF for all supported extensions:
@@ -616,6 +618,9 @@ Ufe::UndoableCommand::Ptr MayaUsdContextOps::doOpCmd(const ItemPath& itemPath)
         WaitCursor wait;
         MGlobal::executeCommand(script, /* display = */ true, /* undoable = */ true);
     } else if (itemPath[0] == kAddMayaReferenceItem) {
+        if (!_prepareUSDReferenceTargetLayer(prim()))
+            return nullptr;
+
         MString script;
         script.format("addMayaReferenceToUsd \"^1s\"", Ufe::PathString::string(path()).c_str());
         MString result = MGlobal::executeCommandStringResult(


### PR DESCRIPTION
- Prepare the current edit target before showing the file dialog.
- Make the function used for this preparatio clearer by naming the flag passed to disable the option for using the scene file as the relative root. When making things relative to the edit target, we don't want to accidentlly use the scene as the root when no saved layer exist.
- Make the code creating the dialog for Maya ref use the code to make the path relative.
- Change the label of the seperator in the file dialog.
- Refactor the common Python code to avoid passing around some options and at teh same time make the function override have the same parameters. Having the same paarmeters is necessary since differnt classes will end-up calling different functions with the same parameters.
- Split the code that create the relative path UI in two: one to setup the layout, one for the UI elements.
- This was necessary because the dialog for the Maya ref already setup the layout.
- Create new class for Maya ref relative UI.