### PR TITLE
 EMSUSD-259 relative Maya ref cache

### DIFF
--- a/lib/mayaUsd/base/tokens.h
+++ b/lib/mayaUsd/base/tokens.h
@@ -134,8 +134,10 @@ TF_DECLARE_PUBLIC_TOKENS(MayaUsdTokens, MAYAUSD_CORE_PUBLIC, MAYA_USD_GENERIC_TO
     ((Xform, "Xform"))                                  \
     /* Default USD file format for cache             */ \
     ((DefaultUSDFormat, "defaultUSDFormat"))            \
-    /* Destination layer for caching                 */ \
+    /* Destination layer absolute path for caching   */ \
     ((DestinationLayerPath, "rn_layer"))                \
+    /* If cache will be converted to a relative path */ \
+    ((RelativePath, "rn_relativePath"))                 \
     /* Destination prim for caching                  */ \
     ((DestinationPrimName, "rn_primName"))              \
     /* If reference added as an append or preprend   */ \

--- a/lib/mayaUsd/resources/ae/usdschemabase/custom_image_control.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/custom_image_control.py
@@ -16,6 +16,7 @@
 import mayaUsd.lib as mayaUsdLib
 from mayaUsdLibRegisterStrings import getMayaUsdLibString
 import mayaUsd_USDRootFileRelative as murel
+import mayaUsdUtils
 
 import maya.cmds as cmds
 import maya.mel as mel
@@ -173,19 +174,8 @@ class ImageCustomControl(object):
         return cmds.optionVar(exists=opVarName) and cmds.optionVar(query=opVarName)
 
     @staticmethod
-    def getCurrentTargetLayerDir(prim):
-        stage = prim.GetStage()
-        if not stage:
-            return None
-        layer = stage.GetEditTarget().GetLayer()
-        if not layer:
-            return ''
-        layerFileName = layer.realPath
-        return os.path.dirname(layerFileName)
-
-    @staticmethod
     def prepareRelativeDir(prim):
-        layerDirName = ImageCustomControl.getCurrentTargetLayerDir(prim)
+        layerDirName = mayaUsdUtils.getCurrentTargetLayerDir(prim)
         murel.usdFileRelative.setRelativeFilePathRoot(layerDirName)
 
 

--- a/lib/mayaUsd/resources/scripts/cacheToUsd.py
+++ b/lib/mayaUsd/resources/scripts/cacheToUsd.py
@@ -40,7 +40,8 @@ def getDefaultCacheCreationOptions():
 
 def createCacheCreationOptions(exportOptions, cacheFile, cachePrimName,
                             payloadOrReference, listEditType,
-                            variantSetName = None, variantName = None):
+                            variantSetName = None, variantName = None,
+                            relativePath=False):
     """
     Creates the dict containing the export options and the cache-to-USD options.
     """
@@ -50,6 +51,7 @@ def createCacheCreationOptions(exportOptions, cacheFile, cachePrimName,
     userArgs = mayaUsd.lib.Util.getDictionaryFromEncodedOptions(exportOptions)
     
     userArgs['rn_layer']              = cacheFile
+    userArgs['rn_relativePath']       = 1 if relativePath else 0
     userArgs['rn_primName']           = cachePrimName
     userArgs['rn_defineInVariant']    = defineInVariant
     userArgs['rn_payloadOrReference'] = payloadOrReference

--- a/lib/mayaUsd/resources/scripts/mayaUsdAddMayaReference.mel
+++ b/lib/mayaUsd/resources/scripts/mayaUsdAddMayaReference.mel
@@ -101,7 +101,7 @@ proc fileOptionsTabPage(string $tabLayout)
     frameLayout -label `getMayaUsdLibString("kMayaRefUsdOptions")`;
     string $widgetColumn = `columnLayout usdOptionsLayout`;
 
-    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdMayaRefRelativeToEditTargetLayer.uiCreateFields()");
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdMayaRefRelativeToEditTargetLayer.uiCreateFields(True)");
 
     textFieldGrp
         -label `getMayaUsdLibString("kMayaRefMayaRefPrimName")`

--- a/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdCacheMayaReference.py
@@ -24,6 +24,7 @@ from mayaUsdLibRegisterStrings import getMayaUsdLibString
 import mayaUsdUtils
 import mayaUsdMayaReferenceUtils as mayaRefUtils
 import mayaUsdOptions
+import mayaUsd_USDRootFileRelative as murel
 
 from pxr import Sdf, Tf
 
@@ -195,13 +196,16 @@ def fileOptionsTabPage(tabLayout):
 
     optBoxMarginWidth = mel.eval('global int $gOptionBoxTemplateDescriptionMarginWidth; $gOptionBoxTemplateDescriptionMarginWidth += 0')
     cmds.setParent(topForm)
+    
     cmds.frameLayout(label=getMayaUsdLibString("kMayaRefDescription"), mw=optBoxMarginWidth, height=160, collapsable=False)
     cmds.columnLayout()
     cmds.text(align="left", wordWrap=True, height=70, label=getMayaUsdLibString("kMayaRefCacheToUSDDescription1"))
     cmds.text(align="left", wordWrap=True, height=50, label=getMayaUsdLibString("kMayaRefCacheToUSDDescription2"))
-
+   
     cmds.setParent(topForm)
     cmds.frameLayout(label=getMayaUsdLibString("kCacheMayaRefOptions"))
+
+    murel.usdFileRelativeToEditTargetLayer.uiCreateFields(True)
 
     # USD file option controls will be parented under this layout.
     # resultCallback not called on "post", is therefore an empty string.
@@ -248,6 +252,8 @@ def cacheInitUi(parent, filterType):
     Fills the cache-to-USD UI.
     Called by the fileDialog command via the MEL mayaUsdCacheMayaReference_cacheInitUi function.
     """
+    murel.usdFileRelativeToEditTargetLayer.uiInit(parent, filterType)
+
     optionsDict = cacheToUsd.loadCacheCreationOptions()
 
     cmds.setParent(parent)
@@ -306,6 +312,11 @@ def cacheCommitUi(parent, selectedFile):
     """
     # Read data to set up cache.
 
+    murel.usdFileRelativeToEditTargetLayer.uiCommit(parent, selectedFile)
+
+    optionVarName = "mayaUsd_MakePathRelativeToEditTargetLayer"
+    requireRelative = cmds.optionVar(exists=optionVarName) and cmds.optionVar(query=optionVarName)
+
     # The following call will set _cacheExportOptions.  Initial settings not
     # accessed on "query", is therefore an empty string.
     mel.eval('mayaUsdTranslatorExport("fileOptionsScroll", "query={exportOpts}", "", "mayaUsdCacheMayaReference_setCacheOptions")'.format(exportOpts=kTranslatorExportOptions))
@@ -328,17 +339,24 @@ def cacheCommitUi(parent, selectedFile):
 
     userArgs = cacheToUsd.createCacheCreationOptions(
         getCacheExportOptions(), selectedFile, primName, compositionArc,
-        listEditType, variantSetName, variantName)
+        listEditType, variantSetName, variantName, requireRelative)
 
     cacheToUsd.saveCacheCreationOptions(userArgs)
     mayaUsdUtils.saveLastUsedUSDDialogFileFilter(mayaUsdUtils.getUserSelectedUSDDialogFileFilter())
 
-
-    # Call push.
-    if not mayaUsd.lib.PrimUpdaterManager.mergeToUsd(_mayaRefDagPath, userArgs):
-        errorMsgFormat = getMayaUsdLibString('kErrorCacheToUsdFailed')
-        errorMsg = cmds.format(errorMsgFormat, stringArg=(_mayaRefDagPath))
-        cmds.error(errorMsg)
+    # Call merge-to-USD.
+    #
+    # Note: the undo item are captured in the undo item list below and then
+    #       thrown away because during the merge-to-USD operation, the Maya
+    #       reference is unloaded which unconditionally flushes the undo queue.
+    #       This prevents undoing back, so there is no point trying to create
+    #       an undo in the Maya undo queue. We still need to capture the undo
+    #       items to avoid leaving them behind.
+    with mayaUsd.lib.OpUndoItemList():
+        if not mayaUsd.lib.PrimUpdaterManager.mergeToUsd(_mayaRefDagPath, userArgs):
+            errorMsgFormat = getMayaUsdLibString('kErrorCacheToUsdFailed')
+            errorMsg = cmds.format(errorMsgFormat, stringArg=(_mayaRefDagPath))
+            cmds.error(errorMsg)
 
 
 def fileTypeChangedUi(parent, fileType):
@@ -365,6 +383,9 @@ def cacheDialog(dagPath, pulledMayaRefPrim, _):
     
     _mayaRefDagPath = dagPath
     _pulledMayaRefPrim = pulledMayaRefPrim
+
+    layerDirName = mayaUsdUtils.getCurrentTargetLayerDir(pulledMayaRefPrim)
+    murel.usdFileRelativeToEditTargetLayer.setRelativeFilePathRoot(layerDirName)
 
     ok = getMayaUsdLibString('kCacheMayaRefCache')
     fileFilter = mayaUsdUtils.getUSDDialogFileFilters(False)

--- a/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
@@ -56,7 +56,7 @@ def mayaUsdLibRegisterStrings():
     register('kCacheFileWillAppear', 'Cache file will\nappear on parent\nprim:')
     register('kCacheMayaRefCache', 'Cache')
     register('kCacheMayaRefOptions', 'Cache File Options')
-    register('kCacheMayaRefUsdHierarchy', 'Author Cache File to USD Hierarchy')
+    register('kCacheMayaRefUsdHierarchy', 'Author Cache File to USD')
     register('kCaptionCacheToUsd', 'Cache to USD')
     register('kErrorCacheToUsdFailed', 'Cache to USD failed for "^1s".')
     register('kMenuAppend', 'Append')

--- a/lib/mayaUsd/resources/scripts/mayaUsdUtils.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdUtils.py
@@ -23,6 +23,7 @@ import maya.cmds as cmds
 import mayaUsd
 
 import ufe
+import os.path
 
 def getPulledInfo(dagPath):
     """
@@ -75,6 +76,23 @@ def isPulledMayaReference(dagPath):
 
     _, _, _, prim = getPulledInfo(dagPath)
     return prim and prim.GetTypeName() == 'MayaReference'
+
+
+def getCurrentTargetLayerDir(prim):
+    """
+    Retrieve the edit target of the stage of the given prim and return the
+    folder that contains the targeted layer.
+
+    Returns an empty string for invalid prim, unsaved layers, etc.
+    """
+    stage = prim.GetStage()
+    if not stage:
+        return ''
+    layer = stage.GetEditTarget().GetLayer()
+    if not layer:
+        return ''
+    layerFileName = layer.realPath
+    return os.path.dirname(layerFileName)
 
 
 def getMonoFormatFileFilterLabels(includeCompressed = True):

--- a/lib/mayaUsd/ufe/MayaUsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/MayaUsdContextOps.cpp
@@ -21,6 +21,7 @@
 #endif
 #include <mayaUsd/ufe/UsdUndoMaterialCommands.h>
 #include <mayaUsd/ufe/Utils.h>
+#include <mayaUsd/utils/layers.h>
 #include <mayaUsd/utils/util.h>
 #include <mayaUsd/utils/utilFileSystem.h>
 
@@ -135,29 +136,11 @@ public:
 };
 #endif
 
-const PXR_NS::SdfLayerHandle getCurrentTargetLayer(const UsdPrim& prim)
-{
-    auto stage = prim.GetStage();
-    if (!stage)
-        return {};
-
-    return stage->GetEditTarget().GetLayer();
-}
-
-const std::string getTargetLayerFilePath(const UsdPrim& prim)
-{
-    auto layer = getCurrentTargetLayer(prim);
-    if (!layer)
-        return {};
-
-    return layer->GetRealPath();
-}
-
 bool _prepareUSDReferenceTargetLayer(const UsdPrim& prim)
 {
     static const bool useSceneFileForRoot = false;
     return UsdMayaUtilFileSystem::prepareLayerSaveUILayer(
-        getCurrentTargetLayer(prim), useSceneFileForRoot);
+        UsdUfe::getCurrentTargetLayer(prim), useSceneFileForRoot);
 }
 
 // Ask SDF for all supported extensions:
@@ -223,8 +206,7 @@ makeUSDReferenceFilePathRelativeIfRequested(const std::string& filePath, const U
     if (!UsdMayaUtilFileSystem::requireUsdPathsRelativeToEditTargetLayer())
         return filePath;
 
-    const std::string layerDirPath = UsdMayaUtilFileSystem::getDir(getTargetLayerFilePath(prim));
-
+    const std::string layerDirPath = MayaUsd::getTargetLayerFolder(prim);
     auto relativePathAndSuccess = UsdMayaUtilFileSystem::makePathRelativeTo(filePath, layerDirPath);
 
     if (!relativePathAndSuccess.second) {

--- a/lib/mayaUsd/utils/layers.cpp
+++ b/lib/mayaUsd/utils/layers.cpp
@@ -15,3 +15,21 @@
 //
 
 #include "layers.h"
+
+#include <mayaUsd/utils/utilFileSystem.h>
+
+#include <usdUfe/utils/layers.h>
+
+namespace MAYAUSD_NS_DEF {
+
+const std::string getTargetLayerFolder(const PXR_NS::UsdStagePtr& stage)
+{
+    return PXR_NS::UsdMayaUtilFileSystem::getDir(UsdUfe::getTargetLayerFilePath(stage));
+}
+
+const std::string getTargetLayerFolder(const PXR_NS::UsdPrim& prim)
+{
+    return PXR_NS::UsdMayaUtilFileSystem::getDir(UsdUfe::getTargetLayerFilePath(prim));
+}
+
+}

--- a/lib/mayaUsd/utils/layers.cpp
+++ b/lib/mayaUsd/utils/layers.cpp
@@ -32,4 +32,4 @@ const std::string getTargetLayerFolder(const PXR_NS::UsdPrim& prim)
     return PXR_NS::UsdMayaUtilFileSystem::getDir(UsdUfe::getTargetLayerFilePath(prim));
 }
 
-}
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/layers.h
+++ b/lib/mayaUsd/utils/layers.h
@@ -29,6 +29,16 @@ getAllSublayers(const std::vector<std::string>& parentLayerPaths, bool includePa
     return UsdUfe::getAllSublayers(parentLayerPaths, includeParents);
 }
 
+//! Return the folder of the layer of the current edit target of the stage, if any.
+//  If the stage is null, the returned path will be empty.
+MAYAUSD_CORE_PUBLIC
+const std::string getTargetLayerFolder(const PXR_NS::UsdStagePtr& stage);
+
+//! Return the folder of the layer of the current edit target of the prim, if any.
+//  If the prim is invalid, the returned path will be empty.
+MAYAUSD_CORE_PUBLIC
+const std::string getTargetLayerFolder(const PXR_NS::UsdPrim& prim);
+
 } // namespace MAYAUSD_NS_DEF
 
 #endif

--- a/lib/usd/translators/mayaReferenceEditRouter.md
+++ b/lib/usd/translators/mayaReferenceEditRouter.md
@@ -44,7 +44,8 @@ The input information received by the Maya Reference `edit router` are:
 
 - "prim" (std::string): the `SdfPath` of the USD Maya Reference that was edited. 
 - "defaultUSDFormat" (std::string): the USD file format used to create the cache.
-- "rn_layer" (std::string): the file path to the cache. A layer will be created there.
+- "rn_layer" (std::string): the absolute file path to the cache. A layer will be created there.
+- "rn_relativePath" (int): if the file path should be converted to be relative to the layer containing the reference. 0 or 1.
 - "rn_primName" (std::string): the name of the root prim of the cache.
 - "rn_listEditType" (std::string): how the reference is added: "Append" or "Prepend".
 - "rn_payloadOrReference" (std::string): type of ref: "Reference" or "Payload".

--- a/lib/usdUfe/utils/layers.cpp
+++ b/lib/usdUfe/utils/layers.cpp
@@ -377,4 +377,31 @@ SdfPrimSpecHandle getDefiningPrimSpec(const UsdPrim& prim)
     return {};
 }
 
+const SdfLayerHandle getCurrentTargetLayer(const UsdStagePtr& stage)
+{
+    if (!stage)
+        return {};
+
+    return stage->GetEditTarget().GetLayer();
+}
+
+const SdfLayerHandle getCurrentTargetLayer(const UsdPrim& prim)
+{
+    return getCurrentTargetLayer(prim.GetStage());
+}
+
+const std::string getTargetLayerFilePath(const UsdStagePtr& stage)
+{
+    auto layer = getCurrentTargetLayer(stage);
+    if (!layer)
+        return {};
+
+    return layer->GetRealPath();
+}
+
+const std::string getTargetLayerFilePath(const UsdPrim& prim)
+{
+    return getTargetLayerFilePath(prim.GetStage());
+}
+
 } // namespace USDUFE_NS_DEF

--- a/lib/usdUfe/utils/layers.h
+++ b/lib/usdUfe/utils/layers.h
@@ -206,6 +206,26 @@ PXR_NS::SdfPrimSpecHandleVector getDefiningPrimStack(const PXR_NS::UsdPrim& prim
 USDUFE_PUBLIC
 PXR_NS::SdfPrimSpecHandle getDefiningPrimSpec(const PXR_NS::UsdPrim& prim);
 
+//! Return the layer of the current edit target of the stage, if any.
+//  If the stage is null, the returned layer will be null.
+USDUFE_PUBLIC
+const PXR_NS::SdfLayerHandle getCurrentTargetLayer(const PXR_NS::UsdStagePtr& stage);
+
+//! Return the layer of the current edit target of the prim, if any.
+//  If the prim is invalid, the returned layer will be null.
+USDUFE_PUBLIC
+const PXR_NS::SdfLayerHandle getCurrentTargetLayer(const PXR_NS::UsdPrim& prim);
+
+//! Return the file path of the layer of the current edit target of the stage, if any.
+//  If the stage is null, the returned path will be empty.
+USDUFE_PUBLIC
+const std::string getTargetLayerFilePath(const PXR_NS::UsdStagePtr& stage);
+
+//! Return the file path of the layer of the current edit target of the prim, if any.
+//  If the prim is invalid, the returned path will be empty.
+USDUFE_PUBLIC
+const std::string getTargetLayerFilePath(const PXR_NS::UsdPrim& prim);
+
 } // namespace USDUFE_NS_DEF
 
 #endif // USDUFE_UTIL_LAYERS_H

--- a/test/lib/mayaUsd/fileio/testCacheToUsd.py
+++ b/test/lib/mayaUsd/fileio/testCacheToUsd.py
@@ -285,16 +285,13 @@ class CacheToUsdTestCase(unittest.TestCase):
         cachePrim = mayaUsd.ufe.ufePathToPrim(ufe.PathString.string(cacheItem.path()))
         query = Usd.PrimCompositionQuery(cachePrim)
         foundPayload = False
-        payloadLayer = None
         for arc in query.GetCompositionArcs():
             if arc.GetArcType() == Pcp.ArcTypePayload:
                 foundPayload = True
-                payloadLayer = arc.GetTargetLayer()
                 break
 
         self.assertTrue(foundPayload)
         self.assertTrue(cachePrim.HasAuthoredPayloads())
-        self.assertIsNotNone(payloadLayer)
 
         # If using relative path, verify the payload source is using
         # a relative file path.

--- a/test/lib/mayaUsd/fileio/testCacheToUsd.py
+++ b/test/lib/mayaUsd/fileio/testCacheToUsd.py
@@ -55,7 +55,12 @@ def createMayaRefPrimSiblingCache(testCase, cacheParent, cacheParentPathStr):
 
     # The sibling cache is a new child of its parent, thus the parent has no
     # variant data.
-    return (mayaRefPrim, None, None, None, None)
+    return [mayaRefPrim, None, None, None, None, False]
+
+def createMayaRefPrimSiblingCacheWithRelativePath(testCase, cacheParent, cacheParentPathStr):
+    options = createMayaRefPrimSiblingCache(testCase, cacheParent, cacheParentPathStr)
+    options[-1] = True
+    return options
 
 def checkSiblingCacheParent(testCase, cacheParentChildren, vs, vn):
     '''Verify the cache parent after caching in the sibling cache test case.'''
@@ -80,7 +85,12 @@ def createMayaRefPrimVariantCache(testCase, cacheParent, cacheParentPathStr):
     vs = refParent.GetVariantSets()
     variantSet = vs.GetVariantSet(variantSetName)
 
-    return (mayaRefPrim, variantSetName, variantSet, variantName, 'Cache')
+    return [mayaRefPrim, variantSetName, variantSet, variantName, 'Cache', False]
+
+def createMayaRefPrimVariantCacheWithRelativePath(testCase, cacheParent, cacheParentPathStr):
+    options = createMayaRefPrimVariantCache(testCase, cacheParent, cacheParentPathStr)
+    options[-1] = True
+    return options
 
 def checkVariantCacheParent(testCase, cacheParentChildren, variantSet, cacheVariantName):
     '''Verify the cache parent after caching in the variant cache test case.'''
@@ -107,7 +117,7 @@ class CacheToUsdTestCase(unittest.TestCase):
         standalone.uninitialize()
 
     def getCacheFileName(self):
-        return 'testCacheToUsd.usda'
+        return os.path.abspath('testCacheToUsd.usda')
 
     def removeCacheFile(self):
         '''
@@ -118,14 +128,30 @@ class CacheToUsdTestCase(unittest.TestCase):
         except:
             pass
 
+    def getRootLayerFileName(self):
+        return os.path.abspath('testCacheToUsdRootLayer.usda')
+
+    def removeRootLayerFile(self):
+        '''
+        Remove the root layer file if it exists. Ignore error if it does not exists.
+        '''
+        try:
+            os.remove(self.getRootLayerFileName())
+        except:
+            pass
+
     def setUp(self):
         # Start each test with a new scene with empty stage.
         cmds.file(new=True, force=True)
+
+        # Make sure the cache file is removed in case a previous test failed mid-way.
+        self.removeCacheFile()
+        self.removeRootLayerFile()
+
         import mayaUsd_createStageWithNewLayer
         self.proxyShapePathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
         self.stage = mayaUsd.lib.GetPrim(self.proxyShapePathStr).GetStage()
-        # Make sure the cache file is removed in case a previous test failed mid-way.
-        self.removeCacheFile()
+        self.stage.GetRootLayer().identifier = self.getRootLayerFileName()
 
     def tearDown(self):
         self.removeCacheFile()
@@ -147,7 +173,7 @@ class CacheToUsdTestCase(unittest.TestCase):
         cacheParentPathStr = self.proxyShapePathStr + ',/CacheParent'
         self.assertFalse(cacheParent.HasVariantSets())
 
-        (mayaRefPrim, variantSetName, variantSet, refVariantName, cacheVariantName) = \
+        (mayaRefPrim, variantSetName, variantSet, refVariantName, cacheVariantName, relativePath) = \
             createMayaRefPrimFn(self, cacheParent, cacheParentPathStr)
 
         # The Maya reference prim is a child of the cache parent.
@@ -214,7 +240,7 @@ class CacheToUsdTestCase(unittest.TestCase):
         # None.
         cacheOptions = cacheToUsd.createCacheCreationOptions(
             defaultExportOptions, cacheFile, cachePrimName,
-            payloadOrReference, listEditType, variantSetName, cacheVariantName)
+            payloadOrReference, listEditType, variantSetName, cacheVariantName, relativePath)
 
         # Before caching, the cache file does not exist.
         self.assertFalse(os.path.exists(cacheFile))
@@ -259,20 +285,48 @@ class CacheToUsdTestCase(unittest.TestCase):
         cachePrim = mayaUsd.ufe.ufePathToPrim(ufe.PathString.string(cacheItem.path()))
         query = Usd.PrimCompositionQuery(cachePrim)
         foundPayload = False
+        payloadLayer = None
         for arc in query.GetCompositionArcs():
             if arc.GetArcType() == Pcp.ArcTypePayload:
                 foundPayload = True
+                payloadLayer = arc.GetTargetLayer()
                 break
 
         self.assertTrue(foundPayload)
+        self.assertTrue(cachePrim.HasAuthoredPayloads())
+        self.assertIsNotNone(payloadLayer)
+
+        # If using relative path, verify the payload source is using
+        # a relative file path.
+        #
+        # Note: the reason we need to look at the raw contents of the
+        #       root layer is that no OpenUSD API allows us to peek
+        #       at the raw payload file path:
+        #
+        #       - UsdPayloads as returned by UsdPrim::GetPayloads() do not
+        #         allow to retrieve the individual payloads. The docs even
+        #         says so and advise to use UsdPrimCompositionQuery.
+        #       - UsdPrimCompositionQuery returns UsdPrimCompositionQueryArc
+        #         which don't give access to the file path, only to the
+        #         resolved SdfLayer.
+        #       - Due to the way layer caching works in OpenUSD, asking for
+        #         the layer identifier returns the absolute path.
+        if relativePath:
+            self.assertIn('payload = @testCacheToUsd.usda', self.stage.GetRootLayer().ExportToString())
 
         self.verifyCacheFileDefaultPrim(cacheFile, cachePrimName)
 
     def testCacheToUsdSibling(self):
         self.runTestCacheToUsd(createMayaRefPrimSiblingCache, checkSiblingCacheParent)
 
+    def testCacheToUsdSiblingWithRelativePath(self):
+        self.runTestCacheToUsd(createMayaRefPrimSiblingCacheWithRelativePath, checkSiblingCacheParent)
+
     def testCacheToUsdVariant(self):
         self.runTestCacheToUsd(createMayaRefPrimVariantCache, checkVariantCacheParent)
+
+    def testCacheToUsdVariantWithRelativePath(self):
+        self.runTestCacheToUsd(createMayaRefPrimVariantCacheWithRelativePath, checkVariantCacheParent)
 
     def testAutoEditAndCache(self):
         '''Test editing then caching a Maya Reference.
@@ -439,7 +493,7 @@ class CacheToUsdTestCase(unittest.TestCase):
         cacheParentPathStr = self.proxyShapePathStr + ',/CacheParent'
         self.assertFalse(cacheParent.HasVariantSets())
 
-        (mayaRefPrim, variantSetName, variantSet, refVariantName, cacheVariantName) = \
+        (mayaRefPrim, variantSetName, variantSet, refVariantName, cacheVariantName, relativePath) = \
             createMayaRefPrimFn(self, cacheParent, cacheParentPathStr)
 
         # Set an initial translation.
@@ -498,7 +552,7 @@ class CacheToUsdTestCase(unittest.TestCase):
 
         cacheOptions = cacheToUsd.createCacheCreationOptions(
             defaultExportOptions, cacheFile, cachePrimName,
-            payloadOrReference, listEditType, variantSetName, cacheVariantName)
+            payloadOrReference, listEditType, variantSetName, cacheVariantName, relativePath)
 
         # Before caching, the cache file does not exist.
         self.assertFalse(os.path.exists(cacheFile))


### PR DESCRIPTION
- Move the Python function getCurrentTargetLayerDir to the mayaUsdUtils file for reuse.
- Change section label to "Author Cache File to USD".
- Combine description text to improve the layout spacing.
- Add UI to make the cache file relative to the targeted layer.
- Add a new cache edit router parameter to control if the cache file is relative.
- Document the new edit router parameter in the user documentation.
- Modify the Python createCacheCreationOptions to allow specifying if we want relative paths.
- Pass the parameter when caching from the caching file dialog.
- Refactor C++ functions to get the edit target file path and folder to be reusable.
- Use the new C++ functions in the context menu and caching code.
- In the Maya reference edit router, add the cache payload or reference to the containing prim using the relative path if requested.
- Add unit tests to verify that relative cache work.
- Modify the existing unit tests to first save the root layer since we can only make the cache relative to the root layer if it the root layer has a file name.
