### PR TITLE
EMSUSD-263 export relative textures UI

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -529,6 +529,16 @@ bool pullCustomize(const PullImportPaths& importedPaths, const UsdMayaPrimUpdate
     return true;
 }
 
+// The user arguments might not contain the final output filename,
+// so fill the user args dictionary with the known output file name.
+void fillUserArgsFileIfEmpty(VtDictionary& userArgs, const std::string& fileName)
+{
+    if (userArgs.count(UsdMayaJobExportArgsTokens->file) == 0
+        || userArgs[UsdMayaJobExportArgsTokens->file].Get<std::string>() == "") {
+        userArgs[UsdMayaJobExportArgsTokens->file] = fileName;
+    }
+}
+
 //------------------------------------------------------------------------------
 //
 // Perform the export step of the merge to USD (first step).  Returns the
@@ -555,6 +565,8 @@ PushCustomizeSrc pushExport(
     VtDictionary userArgs = context.GetUserArgs();
 
     std::string fileName = srcLayer->GetIdentifier();
+
+    fillUserArgsFileIfEmpty(userArgs, fileName);
 
     MFnDagNode fnDag(mayaObject);
     MDagPath   dagPath;
@@ -1556,6 +1568,11 @@ bool PrimUpdaterManager::duplicate(
 
         auto ctxArgs = VtDictionaryOver(userArgs, UsdMayaJobExportArgs::GetDefaultDictionary());
 
+        const UsdStageRefPtr  dstStage = dstProxyShape->getUsdStage();
+        const SdfLayerHandle& layer = dstStage->GetEditTarget().GetLayer();
+        if (!layer->IsAnonymous())
+            fillUserArgsFileIfEmpty(ctxArgs, layer->GetIdentifier());
+
         // Record all USD modifications in an undo block and item.
         UsdUfe::UsdUndoBlock undoBlock(
             &UsdUndoableItemUndoItem::create("Duplicate USD data modifications"));
@@ -1564,7 +1581,6 @@ bool PrimUpdaterManager::duplicate(
         // We will only do copy between two data models, setting this in arguments
         // to configure the updater
         ctxArgs[UsdMayaPrimUpdaterArgsTokens->copyOperation] = true;
-        auto                      dstStage = dstProxyShape->getUsdStage();
         UsdMayaPrimUpdaterContext context(dstProxyShape->getTime(), dstStage, ctxArgs);
 
         // Export out to a temporary layer.

--- a/lib/mayaUsd/resources/scripts/cacheToUsd.py
+++ b/lib/mayaUsd/resources/scripts/cacheToUsd.py
@@ -49,7 +49,8 @@ def createCacheCreationOptions(exportOptions, cacheFile, cachePrimName,
     defineInVariant = 0 if variantSetName is None else 1
 
     userArgs = mayaUsd.lib.Util.getDictionaryFromEncodedOptions(exportOptions)
-    
+
+    userArgs['file']                  = cacheFile
     userArgs['rn_layer']              = cacheFile
     userArgs['rn_relativePath']       = 1 if relativePath else 0
     userArgs['rn_primName']           = cachePrimName

--- a/plugin/adsk/plugin/exportTranslator.cpp
+++ b/plugin/adsk/plugin/exportTranslator.cpp
@@ -69,6 +69,13 @@ MStatus UsdMayaExportTranslator::writer(
     if (status != MS::kSuccess)
         return status;
 
+    // The options might not contain the final output filename,
+    // so fill the user args dictionary with the known output file name.
+    if (userArgs.count(UsdMayaJobExportArgsTokens->file) == 0
+        || userArgs[UsdMayaJobExportArgsTokens->file].Get<std::string>() == "") {
+        userArgs[UsdMayaJobExportArgsTokens->file] = file.resolvedFullName().asChar();
+    }
+
     std::vector<double> timeSamples;
     UsdMayaJobExportArgs::GetDictionaryTimeSamples(userArgs, timeSamples);
     progressBar.advance();

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
@@ -190,6 +190,15 @@ global proc mayaUSDRegisterStrings()
     register("kExportSubdMethodNoLbl", "None (Polygonal Mesh)");
     register("kExportUVSetsAnn", "Exports Maya UV Sets as USD primvars.");
     register("kExportUVSetsLbl", "UV Sets");
+    register("kExportRelativeTexturesAnn",
+        "Choose whether your texture files are written as relative\n" +
+        "or absolute paths as you export them to USD. If you select\n" +
+        "Automatic, it will be chosen for you in the exported USD file\n" +
+        "based on what they currently are as Maya data.");
+    register("kExportRelativeTexturesAutomaticLbl", "Automatic");
+    register("kExportRelativeTexturesAbsoluteLbl", "Absolute");
+    register("kExportRelativeTexturesRelativeLbl", "Relative");
+    register("kExportRelativeTexturesLbl", "Texture File Paths:");
     register("kExportVisibilityAnn", "Exports Maya visibility attributes as USD metadata.");
     register("kExportVisibilityLbl", "Visibility");
 

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -679,9 +679,13 @@ global proc int mayaUsdTranslatorExport (string $parent,
                 }
 
                 optionMenuGrp -l `getMayaUsdString("kExportRelativeTexturesLbl")` -annotation `getMayaUsdString("kExportRelativeTexturesAnn")` exportRelativeTexturesPopup;
-                    menuItem -l `getMayaUsdString("kExportRelativeTexturesAutomaticLbl")` -ann "automatic";
-                    menuItem -l `getMayaUsdString("kExportRelativeTexturesAbsoluteLbl")` -ann "absolute";
-                    menuItem -l `getMayaUsdString("kExportRelativeTexturesRelativeLbl")` -ann "relative";
+                    string $lbl;
+                    $lbl = getMayaUsdString("kExportRelativeTexturesAutomaticLbl");
+                    menuItem -l $lbl -ann $lbl;
+                    $lbl = getMayaUsdString("kExportRelativeTexturesAbsoluteLbl");
+                    menuItem -l $lbl -ann $lbl;
+                    $lbl = getMayaUsdString("kExportRelativeTexturesRelativeLbl");
+                    menuItem -l $lbl -ann $lbl;
 
                 separator -style "none";
             setParent ..;

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -355,6 +355,7 @@ global proc mayaUsdTranslatorExport_EnableAllControls() {
             string $widgetName = $opt + "_ConvertMaterialsToCheckBox";
             checkBoxGrp -e -en 1 $widgetName;
         }
+        optionMenuGrp -e -en 1 exportRelativeTexturesPopup;
     }
 
     if (stringArrayContains("advanced", $sectionNames)) {
@@ -390,6 +391,8 @@ global proc mayaUsdTranslatorExport_SetFromOptions(string $currentOptions, int $
             tokenize($optionList[$index], "=", $optionBreakDown);
             if ($optionBreakDown[0] == "exportUVs") {
                 mayaUsdTranslatorExport_SetCheckbox($optionBreakDown[1], $enable, "exportUVsCheckBox");
+            } else if ($optionBreakDown[0] == "exportRelativeTextures") {
+                mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], $enable, "exportRelativeTexturesPopup");
             } else if ($optionBreakDown[0] == "exportSkels") {
                 mayaUsdTranslatorExport_SetOptionMenuByAnnotation($optionBreakDown[1], $enable, "skelsPopup");
             } else if ($optionBreakDown[0] == "exportSkin") {
@@ -674,7 +677,12 @@ global proc int mayaUsdTranslatorExport (string $parent,
                         -label "" -label1 $conversion -annotation $ann
                         $widgetName;
                 }
-                
+
+                optionMenuGrp -l `getMayaUsdString("kExportRelativeTexturesLbl")` -annotation `getMayaUsdString("kExportRelativeTexturesAnn")` exportRelativeTexturesPopup;
+                    menuItem -l `getMayaUsdString("kExportRelativeTexturesAutomaticLbl")` -ann "automatic";
+                    menuItem -l `getMayaUsdString("kExportRelativeTexturesAbsoluteLbl")` -ann "absolute";
+                    menuItem -l `getMayaUsdString("kExportRelativeTexturesRelativeLbl")` -ann "relative";
+
                 separator -style "none";
             setParent ..;
         }
@@ -774,6 +782,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
 
         if (stringArrayContains("materials", $sectionNames)) {
             $currentOptions = mayaUsdTranslatorExport_AppendConvertMaterialsTo($currentOptions, "convertMaterialsTo");
+            $currentOptions = mayaUsdTranslatorExport_AppendFromPopup($currentOptions, "exportRelativeTextures", "exportRelativeTexturesPopup");
         }
 
         if (stringArrayContains("advanced", $sectionNames)) {


### PR DESCRIPTION
- Add the option menu for relative textures in the export UI-builder.
- Add the code to fill and extract the selected option to and from the UI.
- Add the required labels and tool-tips.
- Fix the problem that the export code was never able to export relative paths when goign through the UI becuase the output file argument was never set in merge-to-USD, cache-to-USD and duplicate.