### PR TITLE
EMS-310 Usd Context Ops, fixed toggle visibility to used computed visibile + expose isRootChild as a DCC function.

### DIFF
--- a/lib/usdUfe/ufe/Global.cpp
+++ b/lib/usdUfe/ufe/Global.cpp
@@ -75,6 +75,8 @@ Ufe::Rtid initialize(
         UsdUfe::setIsAttributeLockedFn(dccFunctions.isAttributeLockedFn);
     if (dccFunctions.saveStageLoadRulesFn)
         UsdUfe::setSaveStageLoadRulesFn(dccFunctions.saveStageLoadRulesFn);
+    if (dccFunctions.isRootChildFn)
+        UsdUfe::setIsRootChildFn(dccFunctions.isRootChildFn);
 
     // Create a default stages subject if none is provided.
     if (nullptr == ss) {

--- a/lib/usdUfe/ufe/Global.h
+++ b/lib/usdUfe/ufe/Global.h
@@ -46,7 +46,7 @@ struct USDUFE_PUBLIC DCCFunctions
     // Optional: default values will be used if no function is supplied.
     IsAttributeLockedFn  isAttributeLockedFn = nullptr;
     SaveStageLoadRulesFn saveStageLoadRulesFn = nullptr;
-    IsRootChildFn isRootChildFn = nullptr;
+    IsRootChildFn        isRootChildFn = nullptr;
 };
 
 /*! Ufe runtime handlers used to initialize the plugin.

--- a/lib/usdUfe/ufe/Global.h
+++ b/lib/usdUfe/ufe/Global.h
@@ -46,6 +46,7 @@ struct USDUFE_PUBLIC DCCFunctions
     // Optional: default values will be used if no function is supplied.
     IsAttributeLockedFn  isAttributeLockedFn = nullptr;
     SaveStageLoadRulesFn saveStageLoadRulesFn = nullptr;
+    IsRootChildFn isRootChildFn = nullptr;
 };
 
 /*! Ufe runtime handlers used to initialize the plugin.

--- a/lib/usdUfe/ufe/UsdContextOps.cpp
+++ b/lib/usdUfe/ufe/UsdContextOps.cpp
@@ -295,12 +295,14 @@ Ufe::ContextOps::Items UsdContextOps::getItems(const Ufe::ContextOps::ItemPath& 
             if (object3dHndlr) {
                 auto object3d = object3dHndlr->object3d(sceneItem());
                 if (object3d) {
-                    // Don't actually use UsdObject3d::visibility() - it looks at the authored visibility
-                    // attribute. Instead, compute the effective visibility to decide on the label to use.
+                    // Don't actually use UsdObject3d::visibility() - it looks at the authored
+                    // visibility attribute. Instead, compute the effective visibility to decide on
+                    // the label to use.
                     const auto imageable = UsdGeomImageable(prim());
-                    const auto visibility = imageable.ComputeVisibility() != UsdGeomTokens->invisible;
+                    const auto visibility
+                        = imageable.ComputeVisibility() != UsdGeomTokens->invisible;
                     const auto label = visibility ? std::string(kUSDMakeInvisibleLabel)
-                        : std::string(kUSDMakeVisibleLabel);
+                                                  : std::string(kUSDMakeVisibleLabel);
                     items.emplace_back(kUSDToggleVisibilityItem, label);
                 }
             }

--- a/lib/usdUfe/ufe/Utils.h
+++ b/lib/usdUfe/ufe/Utils.h
@@ -44,6 +44,7 @@ typedef PXR_NS::UsdPrim (*UfePathToPrimFn)(const Ufe::Path&);
 typedef PXR_NS::UsdTimeCode (*TimeAccessorFn)(const Ufe::Path&);
 typedef bool (*IsAttributeLockedFn)(const PXR_NS::UsdAttribute& attr, std::string* errMsg);
 typedef void (*SaveStageLoadRulesFn)(const PXR_NS::UsdStageRefPtr&);
+typedef bool (*IsRootChildFn)(const Ufe::Path& path);
 
 //------------------------------------------------------------------------------
 // Helper functions
@@ -137,8 +138,21 @@ void saveStageLoadRules(const PXR_NS::UsdStageRefPtr& stage);
 USDUFE_PUBLIC
 int ufePathToInstanceIndex(const Ufe::Path& path, PXR_NS::UsdPrim* prim = nullptr);
 
+//! Set the DCC specific "isRootChild" test function.
+//! Use of this function is optional, if one is not supplied then
+//! a default implementation of isRootChild is used..
+USDUFE_PUBLIC
+void setIsRootChildFn(IsRootChildFn fn);
+
+//! Returns true if the path corresponds to an item at the root of a runtime.
+//! Implementation can be set by the DCC.
 USDUFE_PUBLIC
 bool isRootChild(const Ufe::Path& path);
+
+//! Default isRootChild() implementation. Assumes 2 segments. Will report a root child
+//! if the second segment has a single component.
+USDUFE_PUBLIC
+bool isRootChildDefault(const Ufe::Path& path);
 
 //! Split the source name into a base name and a numerical suffix (set to
 //! 1 if absent).  Increment the numerical suffix until name is unique.


### PR DESCRIPTION
1. Fixed usdUfe context ops to toggle the visibility. The visibility we want to toggle is the _computed_ visibility, not the authored visibility.

2. Exposed isRootChild as a an optional DCC function. Previous behavior kept as default (assumes more than one UFE runtime active, i.e. the maya case).