### PR TITLE
EMSUSD-121 - Use display color when texture mode is disabled

### DIFF
--- a/lib/mayaUsd/base/tokens.h
+++ b/lib/mayaUsd/base/tokens.h
@@ -68,7 +68,9 @@ PXR_NAMESPACE_OPEN_SCOPE
     /* Notice that only newly opened USD stage would be affected.   */ \
     ((DisableAsyncTextureLoading, "mayaUsd_DisableAsyncTextureLoading")) \
     /* option var to remember if the stage in the layer editor is pinned. */ \
-    ((PinLayerEditorStage, "mayaUsd_PinLayerEditorStage"))
+    ((PinLayerEditorStage, "mayaUsd_PinLayerEditorStage")) \
+    /* option var to remember if use display color when texture mode off */ \
+    ((ShowDisplayColorTextureOff, "mayaUsd_ShowDisplayColorTextureOff"))
 // clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(MayaUsdOptionVars, MAYAUSD_CORE_PUBLIC, MAYA_USD_OPTIONVAR_TOKENS);

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -891,9 +891,9 @@ void HdVP2Mesh::Sync(
 
         auto addRequiredPrimvars = [&](const SdfPath& materialId) {
             TfTokenVector requiredPrimvars;
-            // Only load textures when texture mode is selected
             if (!_GetMaterialPrimvars(renderIndex, materialId, requiredPrimvars)
                 || !(reprToken == HdReprTokens->smoothHull)) {
+                // debug
                 requiredPrimvars = sFallbackShaderPrimvars;
             }
 
@@ -1747,13 +1747,14 @@ void HdVP2Mesh::_UpdateDrawItem(
             const HdVP2Material* material = static_cast<const HdVP2Material*>(
                 renderIndex.GetSprim(HdPrimTypeTokens->material, materialId));
 
+            //if (material && (reprToken == HdReprTokens->smoothHull)) {
             if (material) {
                 const HdCullStyle           cullStyle = GetCullStyle(sceneDelegate);
                 MHWRender::MShaderInstance* shader = material->GetSurfaceShader(
                     _GetMaterialNetworkToken(reprToken), cullStyle == HdCullStyleBack);
 
                 // If untextured mode is selected, check if the material has base color
-                if (reprToken == HdVP2ReprTokens->smoothHullUntextured) {
+                if (reprToken == HdVP2ReprTokens->smoothHullUntextured){
                     MStringArray parameters;
                     shader->parameterList(parameters);
                     const bool hasColor = parameters.indexOf("base_color") != -1
@@ -1762,8 +1763,8 @@ void HdVP2Mesh::_UpdateDrawItem(
                     // if not, use the fallback shader, which will use the display color
                     if (!hasColor)
                         drawItemData._shaderIsFallback = true;
-                } else if (
-                    shader != nullptr
+                }
+                else if (shader != nullptr
                     && (shader != drawItemData._shader || shader != stateToCommit._shader)) {
                     drawItemData._shader = shader;
                     drawItemData._shaderIsFallback = false;

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -22,6 +22,7 @@
 #include "render_delegate.h"
 #include "tokens.h"
 
+#include <mayaUsd/base/tokens.h>
 #include <mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h>
 #include <mayaUsd/utils/colorSpace.h>
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -893,7 +893,6 @@ void HdVP2Mesh::Sync(
             TfTokenVector requiredPrimvars;
             if (!_GetMaterialPrimvars(renderIndex, materialId, requiredPrimvars)
                 || !(reprToken == HdReprTokens->smoothHull)) {
-                // debug
                 requiredPrimvars = sFallbackShaderPrimvars;
             }
 
@@ -1747,24 +1746,12 @@ void HdVP2Mesh::_UpdateDrawItem(
             const HdVP2Material* material = static_cast<const HdVP2Material*>(
                 renderIndex.GetSprim(HdPrimTypeTokens->material, materialId));
 
-            //if (material && (reprToken == HdReprTokens->smoothHull)) {
-            if (material) {
+            if (material && (reprToken == HdReprTokens->smoothHull)) {
+                //debug
                 const HdCullStyle           cullStyle = GetCullStyle(sceneDelegate);
                 MHWRender::MShaderInstance* shader = material->GetSurfaceShader(
                     _GetMaterialNetworkToken(reprToken), cullStyle == HdCullStyleBack);
-
-                // If untextured mode is selected, check if the material has base color
-                if (reprToken == HdVP2ReprTokens->smoothHullUntextured){
-                    MStringArray parameters;
-                    shader->parameterList(parameters);
-                    const bool hasColor = parameters.indexOf("base_color") != -1
-                        || parameters.indexOf("diffuseColor") != -1
-                        || parameters.indexOf("color") != -1;
-                    // if not, use the fallback shader, which will use the display color
-                    if (!hasColor)
-                        drawItemData._shaderIsFallback = true;
-                }
-                else if (shader != nullptr
+                if (shader != nullptr
                     && (shader != drawItemData._shader || shader != stateToCommit._shader)) {
                     drawItemData._shader = shader;
                     drawItemData._shaderIsFallback = false;

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -891,7 +891,8 @@ void HdVP2Mesh::Sync(
 
         auto addRequiredPrimvars = [&](const SdfPath& materialId) {
             TfTokenVector requiredPrimvars;
-            if (!_GetMaterialPrimvars(renderIndex, materialId, requiredPrimvars)) {
+            if (!_GetMaterialPrimvars(renderIndex, materialId, requiredPrimvars)
+                || !(reprToken == HdReprTokens->smoothHull)) {
                 requiredPrimvars = sFallbackShaderPrimvars;
             }
 
@@ -1745,7 +1746,8 @@ void HdVP2Mesh::_UpdateDrawItem(
             const HdVP2Material* material = static_cast<const HdVP2Material*>(
                 renderIndex.GetSprim(HdPrimTypeTokens->material, materialId));
 
-            if (material) {
+            if (material && (reprToken == HdReprTokens->smoothHull)) {
+                //debug
                 const HdCullStyle           cullStyle = GetCullStyle(sceneDelegate);
                 MHWRender::MShaderInstance* shader = material->GetSurfaceShader(
                     _GetMaterialNetworkToken(reprToken), cullStyle == HdCullStyleBack);

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -891,9 +891,9 @@ void HdVP2Mesh::Sync(
 
         auto addRequiredPrimvars = [&](const SdfPath& materialId) {
             TfTokenVector requiredPrimvars;
+            // Only load textures when texture mode is selected
             if (!_GetMaterialPrimvars(renderIndex, materialId, requiredPrimvars)
                 || !(reprToken == HdReprTokens->smoothHull)) {
-                // debug
                 requiredPrimvars = sFallbackShaderPrimvars;
             }
 
@@ -1747,14 +1747,13 @@ void HdVP2Mesh::_UpdateDrawItem(
             const HdVP2Material* material = static_cast<const HdVP2Material*>(
                 renderIndex.GetSprim(HdPrimTypeTokens->material, materialId));
 
-            //if (material && (reprToken == HdReprTokens->smoothHull)) {
             if (material) {
                 const HdCullStyle           cullStyle = GetCullStyle(sceneDelegate);
                 MHWRender::MShaderInstance* shader = material->GetSurfaceShader(
                     _GetMaterialNetworkToken(reprToken), cullStyle == HdCullStyleBack);
 
                 // If untextured mode is selected, check if the material has base color
-                if (reprToken == HdVP2ReprTokens->smoothHullUntextured){
+                if (reprToken == HdVP2ReprTokens->smoothHullUntextured) {
                     MStringArray parameters;
                     shader->parameterList(parameters);
                     const bool hasColor = parameters.indexOf("base_color") != -1
@@ -1763,8 +1762,8 @@ void HdVP2Mesh::_UpdateDrawItem(
                     // if not, use the fallback shader, which will use the display color
                     if (!hasColor)
                         drawItemData._shaderIsFallback = true;
-                }
-                else if (shader != nullptr
+                } else if (
+                    shader != nullptr
                     && (shader != drawItemData._shader || shader != stateToCommit._shader)) {
                     drawItemData._shader = shader;
                     drawItemData._shaderIsFallback = false;

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -891,8 +891,7 @@ void HdVP2Mesh::Sync(
 
         auto addRequiredPrimvars = [&](const SdfPath& materialId) {
             TfTokenVector requiredPrimvars;
-            if (!_GetMaterialPrimvars(renderIndex, materialId, requiredPrimvars)
-                || !(reprToken == HdReprTokens->smoothHull)) {
+            if (!_GetMaterialPrimvars(renderIndex, materialId, requiredPrimvars)) {
                 requiredPrimvars = sFallbackShaderPrimvars;
             }
 
@@ -1746,8 +1745,7 @@ void HdVP2Mesh::_UpdateDrawItem(
             const HdVP2Material* material = static_cast<const HdVP2Material*>(
                 renderIndex.GetSprim(HdPrimTypeTokens->material, materialId));
 
-            if (material && (reprToken == HdReprTokens->smoothHull)) {
-                //debug
+            if (material) {
                 const HdCullStyle           cullStyle = GetCullStyle(sceneDelegate);
                 MHWRender::MShaderInstance* shader = material->GetSurfaceShader(
                     _GetMaterialNetworkToken(reprToken), cullStyle == HdCullStyleBack);

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
@@ -21,7 +21,6 @@
 #include "meshViewportCompute.h"
 #include "primvarInfo.h"
 
-#include <mayaUsd/base/tokens.h>
 #include <mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h>
 
 #include <pxr/imaging/hd/mesh.h>

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.h
@@ -21,6 +21,7 @@
 #include "meshViewportCompute.h"
 #include "primvarInfo.h"
 
+#include <mayaUsd/base/tokens.h>
 #include <mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h>
 
 #include <pxr/imaging/hd/mesh.h>

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -661,6 +661,13 @@ void ProxyRenderDelegate::_InitRenderDelegate()
 {
     TF_VERIFY(_proxyShapeData->ProxyShape());
 
+    // Initialize the optionVar ShowDisplayColorTextureOff, which will decide if display color will
+    // be used when untextured mode is selected
+    const MString optionVarName(MayaUsdOptionVars->ShowDisplayColorTextureOff.GetText());
+    if (!MGlobal::optionVarExists(optionVarName)) {
+        MGlobal::setOptionVarValue(optionVarName, 0);
+    }
+
     // No need to run all the checks if we got till the end
     if (_isInitialized())
         return;


### PR DESCRIPTION
- Added optionVar "mayaUsd_ShowDisplayColorTextureOff" to toggle display mode
- The optionVar will be add to user Pref once the feature is ready. 
- To view the change in real time, run `ogs -reset`. This command will be added to the user pref call as well, so the user can see the difference when toggle the optionVar