### PR TITLE
EMSUSD-535 - "Edit as Maya Data" options dialog overwrites import UI

### DIFF
--- a/plugin/adsk/scripts/USDMenuProc.mel
+++ b/plugin/adsk/scripts/USDMenuProc.mel
@@ -214,7 +214,6 @@ global proc mayaUsdMenu_EditAsMayaDataOptions(string $obj)
     string $layout = getOptionBox();
     setParent $layout;
 
-    setUITemplate -pushTemplate DefaultTemplate;
     setOptionBoxTitle(getMayaUsdString("kEditAsMayaDataOptions"));
 
     string $optionsString = ";readAnimData=1";
@@ -222,8 +221,8 @@ global proc mayaUsdMenu_EditAsMayaDataOptions(string $obj)
         $optionsString = `optionVar -query usdMaya_EditAsMayaDataOptions`;
     }
 
-    string $optionsFrame = `frameLayout -collapsable false -labelVisible false -marginHeight 10 -borderVisible false editAsMayaDataOptionsFrame`;
-    mayaUsdTranslatorImport ($optionsFrame, "post", $optionsString, "mayaUsdMenu_EditAsMayaDataOptionsCallback");
+    string $optionsScroll = `scrollLayout -cr true editAsMayaDataOptionsFrame`;
+    mayaUsdTranslatorImport ($optionsScroll, "post", $optionsString, "mayaUsdMenu_EditAsMayaDataOptionsCallback");
 
     string $applyCloseBtn = getOptionBoxApplyAndCloseBtn();
     button -edit -label `getMayaUsdString("kEditAsMayaData")`


### PR DESCRIPTION
- Make Edit-As-Maya-Data UI scrollable 
- Prevents opening Edit-As-Maya-Data overwriting the style of Import UI
- Edit-As-Maya UI **Before**: 
![image](https://github.com/Autodesk/maya-usd/assets/127771016/91fd2d8f-ad70-4e50-b2d5-09e185160e68)

- **After**:  ![image](https://github.com/Autodesk/maya-usd/assets/127771016/d5d2a175-3ee1-414f-b1f2-1b636a581a9c)

-  Import UI after opening "Edit as Maya". Before: 
![image](https://github.com/Autodesk/maya-usd/assets/127771016/8c5669b9-f36a-4ec6-bdbd-c6bf2a9b84bf)

- After: 
![image](https://github.com/Autodesk/maya-usd/assets/127771016/e1756500-8d33-48f7-9585-7f31df63da70)
