### PR TITLE
Enable MaterialX support in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if(APPLE)
     option(BUILD_UB2 "Build Universal Binary 2 (UB2) Intel64+arm64" OFF)
 endif()
 set(BUILD_WITH_PYTHON_3_VERSION 3.7 CACHE STRING "The version of Python 3 to build with")
-option(CMAKE_WANT_MATERIALX_BUILD "Enable building with MaterialX (experimental)." OFF)
+option(CMAKE_WANT_MATERIALX_BUILD "Enable building with MaterialX." ON)
 option(CMAKE_WANT_VALIDATE_UNDO_ITEM "Enable validating undo items list." OFF)
 
 option(BUILD_WITH_QT_6 "Build with QT 6." OFF)

--- a/build.py
+++ b/build.py
@@ -379,6 +379,8 @@ def BuildAndInstall(context, buildArgs, stages):
             extraArgs.append('-DCMAKE_WANT_MATERIALX_BUILD=ON')
             extraArgs.append('-DCMAKE_PREFIX_PATH="{materialxLocation}"'
                              .format(materialxLocation=context.pxrUsdLocation))
+        else:
+            extraArgs.append('-DCMAKE_WANT_MATERIALX_BUILD=OFF')
 
         # Many people on Windows may not have python with the 
         # debugging symbol (python27_d.lib) installed, this is the common case.


### PR DESCRIPTION
Following the move to enable MaterialX as default introduced in PR #2979, this enables the same option for people building using CMake directly.