### PR TITLE
connect Maya Time to USD Imaging SceneIndex

### DIFF
--- a/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
+++ b/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
@@ -65,6 +65,7 @@
 #include <maya/MObjectHandle.h>
 #include <maya/MSelectionList.h>
 #include <maya/MString.h>
+#include <maya/MEventMessage.h>
 #include <ufe/rtid.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -282,9 +283,13 @@ MayaUsdProxyShapeSceneIndex::MayaUsdProxyShapeSceneIndex(
     TfWeakPtr<MayaUsdProxyShapeSceneIndex> ptr(this);
     TfNotice::Register(ptr, &MayaUsdProxyShapeSceneIndex::StageSet);
     TfNotice::Register(ptr, &MayaUsdProxyShapeSceneIndex::ObjectsChanged);
+
+    _timeChangeCallbackId = MEventMessage::addEventCallback("timeChanged", onTimeChanged, this);
 }
 
-MayaUsdProxyShapeSceneIndex::~MayaUsdProxyShapeSceneIndex() { }
+MayaUsdProxyShapeSceneIndex::~MayaUsdProxyShapeSceneIndex() {
+    MMessage::removeCallback(_timeChangeCallbackId);
+}
 
 MayaUsdProxyShapeSceneIndexRefPtr MayaUsdProxyShapeSceneIndex::New(
     MayaUsdProxyShapeBase*                 proxyShape,
@@ -294,6 +299,22 @@ MayaUsdProxyShapeSceneIndexRefPtr MayaUsdProxyShapeSceneIndex::New(
     // Create the proxy shape scene index which populates the stage
     return TfCreateRefPtr(new MayaUsdProxyShapeSceneIndex(
         sceneIndexChainLastElement, usdImagingStageSceneIndex, proxyShape));
+}
+
+void MayaUsdProxyShapeSceneIndex::onTimeChanged(void* data)
+{
+    auto* instance = reinterpret_cast<MayaUsdProxyShapeSceneIndex*>(data);
+    if (!TF_VERIFY(instance)) {
+        return;
+    }
+    instance->UpdateTime();
+}
+
+void MayaUsdProxyShapeSceneIndex::UpdateTime()
+{
+    if (_usdImagingStageSceneIndex && _proxyShape) {
+        _usdImagingStageSceneIndex->SetTime(_proxyShape->getTime());
+    }
 }
 
 Ufe::Path MayaUsdProxyShapeSceneIndex::InterpretRprimPath(
@@ -339,6 +360,8 @@ void MayaUsdProxyShapeSceneIndex::Populate()
 #endif
                 _populated = true;
             }
+            // Set the initial time
+            UpdateTime();
         }
     }
 }

--- a/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
+++ b/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
@@ -61,11 +61,11 @@
 #endif
 #endif
 
+#include <maya/MEventMessage.h>
 #include <maya/MObject.h>
 #include <maya/MObjectHandle.h>
 #include <maya/MSelectionList.h>
 #include <maya/MString.h>
-#include <maya/MEventMessage.h>
 #include <ufe/rtid.h>
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
+++ b/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
@@ -287,7 +287,8 @@ MayaUsdProxyShapeSceneIndex::MayaUsdProxyShapeSceneIndex(
     _timeChangeCallbackId = MEventMessage::addEventCallback("timeChanged", onTimeChanged, this);
 }
 
-MayaUsdProxyShapeSceneIndex::~MayaUsdProxyShapeSceneIndex() {
+MayaUsdProxyShapeSceneIndex::~MayaUsdProxyShapeSceneIndex()
+{
     MMessage::removeCallback(_timeChangeCallbackId);
 }
 

--- a/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.h
+++ b/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.h
@@ -31,9 +31,8 @@
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usdImaging/usdImaging/stageSceneIndex.h>
 
-#include <ufe/path.h>
-
 #include <maya/MMessage.h>
+#include <ufe/path.h>
 
 #include <memory>
 

--- a/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.h
+++ b/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.h
@@ -33,6 +33,8 @@
 
 #include <ufe/path.h>
 
+#include <maya/MMessage.h>
+
 #include <memory>
 
 //////////////////////////////////////////////////////////////// MayaUsdProxyShapeSceneIndexPlugin
@@ -92,6 +94,8 @@ public:
 
     virtual ~MayaUsdProxyShapeSceneIndex();
 
+    void UpdateTime();
+
 private:
     void ObjectsChanged(const MayaUsdProxyStageObjectsChangedNotice& notice);
 
@@ -113,9 +117,12 @@ protected:
         const HdSceneIndexObserver::DirtiedPrimEntries& entries) override final;
 
 private:
+    static void onTimeChanged(void* data);
+
     UsdImagingStageSceneIndexRefPtr _usdImagingStageSceneIndex;
     MayaUsdProxyShapeBase*          _proxyShape { nullptr };
     std::atomic_bool                _populated { false };
+    MCallbackId                     _timeChangeCallbackId;
 };
 } // namespace MAYAUSD_NS_DEF
 


### PR DESCRIPTION
To support USD Animation, like SceneDelegate, we need to set Time to SceneIndex for Hydra Viewport.
To do that, we add changes below:

1.React on the Maya timeChanged event.
2.Set current Time from proxy node to USDImagingStageSceneIndex on initialization or time was changed