### PR TITLE
EMSUSD-282 - MayaUsd: build with Qt directly from Maya devkit/runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ endif()
 
 if(DEFINED QT_LOCATION)
     if(NOT DEFINED QT_VERSION)
-		if(BUILD_WITH_QT_6)
+        if(BUILD_WITH_QT_6)
 			set(QT_VERSION "6.5")
         else() # Maya 2022, 2023, 2024
             set(QT_VERSION "5.15")
@@ -164,19 +164,41 @@ if(DEFINED QT_LOCATION)
         message(STATUS "Setting Qt version to Qt ${QT_VERSION}")
     endif()
     set(CMAKE_PREFIX_PATH "${QT_LOCATION}")
+
 	if(BUILD_WITH_QT_6)
 		find_package(Qt6 ${QT_VERSION} COMPONENTS Core Gui Widgets REQUIRED)
-		if(Qt6_FOUND)
-			message(STATUS "Building with Qt ${QT_VERSION} features enabled.")
-		endif()
 	else()
 		find_package(Qt5 ${QT_VERSION} COMPONENTS Core Gui Widgets REQUIRED)
-		if(Qt5_FOUND)
-			message(STATUS "Building with Qt ${QT_VERSION} features enabled.")
-		endif()
 	endif()
+    if(Qt5_FOUND OR Qt6_FOUND)
+        message(STATUS "Found Qt in custom location, building with Qt ${QT_VERSION} features enabled.")
+        set(Qt_FOUND TRUE)
+    else()
+        message(WARNING "Could not find Qt in custom location: ${QT_LOCATION}. Building with Qt features will be disabled.")
+    endif()
 else()
-    message(STATUS "QT_LOCATION not set. Building Qt features will be disabled.")
+    # First look for Qt6 in the Maya devkit.
+    # The Qt6 archive in the Maya devkit contains everything needed for the normal cmake find_package.
+    set(CMAKE_PREFIX_PATH "${MAYA_DEVKIT_LOCATION}/Qt")
+    find_package(Qt6 6.5 COMPONENTS Core Gui Widgets QUIET)
+    if (Qt6_FOUND)
+        message(STATUS "Found Qt6 in Maya devkit, building with Qt ${Qt6_VERSION} features enabled.")
+        set(BUILD_WITH_QT_6 ON)
+        set(Qt_FOUND TRUE)
+    else()
+        # If we didn't find Qt6 in Maya devkit, search again, but for Qt5 this time.
+        # Minimum version required is 5.15 (Maya 2022/2023/2024).
+        # This will find Qt in the Maya devkit using a custom find package.
+        # So the version will match Maya we are building for.
+        find_package(Maya_Qt 5.15 COMPONENTS Core Gui Widgets QUIET)
+        if (Maya_Qt_FOUND)
+            message(STATUS "Found Qt5 in Maya devkit, building with Qt ${MAYA_QT_VERSION} features enabled.")
+            set(BUILD_WITH_QT_6 OFF)
+            set(Qt_FOUND TRUE)
+        else()
+            message(WARNING "Could not find Qt in Maya devkit directory: ${MAYA_DEVKIT_LOCATION}. Building with Qt features will be disabled.")
+        endif()
+    endif()
 endif()
 
 #------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,6 @@ set(BUILD_WITH_PYTHON_3_VERSION 3.7 CACHE STRING "The version of Python 3 to bui
 option(CMAKE_WANT_MATERIALX_BUILD "Enable building with MaterialX." ON)
 option(CMAKE_WANT_VALIDATE_UNDO_ITEM "Enable validating undo items list." OFF)
 
-option(BUILD_WITH_QT_6 "Build with QT 6." OFF)
-
 set(PXR_OVERRIDE_PLUGINPATH_NAME PXR_PLUGINPATH_NAME
     CACHE STRING "Name of env var USD searches to find plugins")
 
@@ -154,51 +152,39 @@ if(TARGET hdMtlx)
     endif()
 endif()
 
-if(DEFINED QT_LOCATION)
-    if(NOT DEFINED QT_VERSION)
-        if(BUILD_WITH_QT_6)
-			set(QT_VERSION "6.5")
-        else() # Maya 2022, 2023, 2024
-            set(QT_VERSION "5.15")
-        endif()
-        message(STATUS "Setting Qt version to Qt ${QT_VERSION}")
-    endif()
-    set(CMAKE_PREFIX_PATH "${QT_LOCATION}")
-
-	if(BUILD_WITH_QT_6)
-		find_package(Qt6 ${QT_VERSION} COMPONENTS Core Gui Widgets REQUIRED)
-	else()
-		find_package(Qt5 ${QT_VERSION} COMPONENTS Core Gui Widgets REQUIRED)
-	endif()
-    if(Qt5_FOUND OR Qt6_FOUND)
-        message(STATUS "Found Qt in custom location, building with Qt ${QT_VERSION} features enabled.")
-        set(Qt_FOUND TRUE)
-    else()
-        message(WARNING "Could not find Qt in custom location: ${QT_LOCATION}. Building with Qt features will be disabled.")
-    endif()
-else()
+if(MAYA_APP_VERSION VERSION_GREATER 2024)
     # First look for Qt6 in the Maya devkit.
     # The Qt6 archive in the Maya devkit contains everything needed for the normal cmake find_package.
     set(CMAKE_PREFIX_PATH "${MAYA_DEVKIT_LOCATION}/Qt")
     find_package(Qt6 6.5 COMPONENTS Core Gui Widgets QUIET)
-    if (Qt6_FOUND)
-        message(STATUS "Found Qt6 in Maya devkit, building with Qt ${Qt6_VERSION} features enabled.")
-        set(BUILD_WITH_QT_6 ON)
+endif()
+if (Qt6_FOUND)
+    message(STATUS "Found Qt6 in Maya devkit, building with Qt ${Qt6_VERSION} features enabled.")
+    set(Qt_FOUND TRUE)
+else()
+    # If we didn't find Qt6 in Maya devkit, search again, but for Qt5 this time.
+    # Minimum version required is 5.15 (Maya 2022/2023/2024).
+    # This will find Qt in the Maya devkit using a custom find package.
+    # So the version will match Maya we are building for.
+    find_package(Maya_Qt 5.15 COMPONENTS Core Gui Widgets QUIET)
+    if (Maya_Qt_FOUND)
+        message(STATUS "Found Qt5 in Maya devkit, building with Qt ${MAYA_QT_VERSION} features enabled.")
         set(Qt_FOUND TRUE)
+    endif()
+endif()
+    
+if(NOT Qt_FOUND)
+    message(SEND_ERROR "Could not find Qt in Maya devkit directory: ${MAYA_DEVKIT_LOCATION}.")
+    if(MAYA_APP_VERSION VERSION_GREATER 2024)
+        message(STATUS "  You must extract Qt.tar.gz")
     else()
-        # If we didn't find Qt6 in Maya devkit, search again, but for Qt5 this time.
-        # Minimum version required is 5.15 (Maya 2022/2023/2024).
-        # This will find Qt in the Maya devkit using a custom find package.
-        # So the version will match Maya we are building for.
-        find_package(Maya_Qt 5.15 COMPONENTS Core Gui Widgets QUIET)
-        if (Maya_Qt_FOUND)
-            message(STATUS "Found Qt5 in Maya devkit, building with Qt ${MAYA_QT_VERSION} features enabled.")
-            set(BUILD_WITH_QT_6 OFF)
-            set(Qt_FOUND TRUE)
+        if (IS_WINDOWS)
+            message(STATUS "  In Maya devkit you must extract include/qt_5.15.2_vc14-include.zip")
         else()
-            message(WARNING "Could not find Qt in Maya devkit directory: ${MAYA_DEVKIT_LOCATION}. Building with Qt features will be disabled.")
+            message(STATUS "  In Maya devkit you must extract include/qt_5.15.2-include.tar.gz")
         endif()
     endif()
+    message(FATAL_ERROR "Cannot build MayaUsd without Qt.")
 endif()
 
 #------------------------------------------------------------------------------

--- a/build.py
+++ b/build.py
@@ -393,8 +393,8 @@ def SetupMayaQt(context):
             return not os.path.realpath(os.path.abspath(os.path.join(base, path))).startswith(base)
         def isBadLink(info, base):
             # Links are interpreted relative to the directory containing the link.
-            tip = os.path.realpath(os.path.abspath(os.path.join(base, dirname(info.name))))
-            return _badpath(info.linkname, base=tip)
+            tip = os.path.realpath(os.path.abspath(os.path.join(base, os.path.dirname(info.name))))
+            return isBadPath(info.linkname, base=tip)
 
         base = os.path.realpath(os.path.abspath('.'))
         result = []

--- a/build.py
+++ b/build.py
@@ -672,9 +672,7 @@ class InstallContext:
 
         # DEPRECATED: Qt Location
         if args.qt_location:
-            PrintError("--qt-location flag is deprecated as Qt is found automatically in Maya devkit.")
-            PrintError("If you want to use custom Qt, use flag: --build-args=-DQT_LOCATION=<dir>")
-            sys.exit(1)
+            PrintWarning("--qt-location flag is deprecated as Qt is found automatically in Maya devkit.")
 
         # MaterialX
         self.materialxEnabled = args.build_materialx

--- a/cmake/modules/FindMaya_Qt.cmake
+++ b/cmake/modules/FindMaya_Qt.cmake
@@ -1,0 +1,190 @@
+# Module to find Qt in Maya devkit.
+#
+# This module searches for the necessary Qt files in the Maya devkit.
+#
+# It relies on Maya being found first: find_package(Maya)
+# as it uses variables set there.
+#
+# Variables that will be defined:
+#    Maya_Qt_FOUND                  Defined if Qt has been found
+#    Qt{$QT_MAJOR_VERSION}_FOUND    Defined if Qt has been found
+#    MAYA_QT_INC_DIR                The include folder where Qt header files can be found
+#    QT_MOC_EXECUTABLE              Path to Qt moc executable
+#    QT_UIC_EXECUTABLE              Path to Qt uic executable
+#    QT_RCC_EXECUTABLE              Path to Qt rcc executable
+#    MAYA_QT_VERSION                The version of Qt in the Maya devkit
+#
+
+# List of directories to search for Maya Qt headers/libraries/executables.
+set(MAYA_DIRS_TO_SEARCH
+    ${MAYA_DEVKIT_LOCATION}
+    $ENV{MAYA_DEVKIT_LOCATION}
+    ${MAYA_LOCATION}
+    $ENV{MAYA_LOCATION}
+)
+
+# Find the directory paths to the Qt headers (using the input components list).
+foreach(MAYA_DIR_TO_SEARCH ${MAYA_DIRS_TO_SEARCH})
+    file(TO_CMAKE_PATH ${MAYA_DIR_TO_SEARCH} qt_root_dir)
+
+    # Make sure we can find the header files for each Qt component.
+    set(Maya_Qt_Headers_FOUND TRUE)  # Assume we will find them all.
+    foreach(Maya_Qt_Component ${Maya_Qt_FIND_COMPONENTS})
+        string(TOUPPER ${Maya_Qt_Component} MAYA_QT_COMPONENT)
+        string(TOLOWER ${Maya_Qt_Component} maya_qt_component)
+        unset(MAYA_QT_VERSION_FILE)
+        file(GLOB_RECURSE MAYA_QT_VERSION_FILE "${qt_root_dir}/include/*/qt${maya_qt_component}version.h")
+        if (NOT MAYA_QT_VERSION_FILE)
+            set(Maya_Qt_Headers_FOUND FALSE)
+            break()     # We could not find the headers in this search path (try the next).
+        endif()
+        # Get the include directory for this component.
+        get_filename_component(MAYA_QT_${MAYA_QT_COMPONENT}_DIR ${MAYA_QT_VERSION_FILE} DIRECTORY)
+    endforeach()
+
+    if (Maya_Qt_Headers_FOUND AND MAYA_QT_${MAYA_QT_COMPONENT}_DIR)
+        # Get the base Qt include path (we can simply use the last component found as they are
+        # all in the same base path).
+        get_filename_component(MAYA_QT_INC_DIR ${MAYA_QT_${MAYA_QT_COMPONENT}_DIR} DIRECTORY)
+        break() # We found all the headers in this search path.
+    endif()
+endforeach()
+
+# Find Qt utilities.
+set(Maya_Qt_Utilities "moc;uic;rcc")
+foreach(Maya_Qt_Utility ${Maya_Qt_Utilities})
+    string(TOUPPER ${Maya_Qt_Utility} MAYA_QT_UTILITY)
+    find_program(QT_${MAYA_QT_UTILITY}_EXECUTABLE
+        NAMES
+            ${Maya_Qt_Utility}
+        PATHS
+            ${MAYA_DEVKIT_LOCATION}
+            $ENV{MAYA_DEVKIT_LOCATION}
+            ${MAYA_LOCATION}
+            $ENV{MAYA_LOCATION}
+            ${MAYA_BASE_DIR}
+        PATH_SUFFIXES
+            devkit/bin
+            bin
+        NO_DEFAULT_PATH
+        DOC
+            "Maya Qt utility"
+    )
+endforeach()
+
+if (QT_UIC_EXECUTABLE)
+    # Get the Qt version based on UIC
+    execute_process(COMMAND ${QT_UIC_EXECUTABLE} "--version" OUTPUT_VARIABLE QT_UIC_VERSION)
+    STRING(REPLACE "." " " QT_UIC_VERSION ${QT_UIC_VERSION})
+    STRING(REPLACE " " ";" QT_UIC_VERSION ${QT_UIC_VERSION})
+    LIST(GET QT_UIC_VERSION 1 QT_VERSION_MAJOR)
+    LIST(GET QT_UIC_VERSION 2 QT_VERSION_MINOR)
+    LIST(GET QT_UIC_VERSION 3 QT_PATCH_LEVEL)
+    set(MAYA_QT_VERSION ${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}.${QT_PATCH_LEVEL})
+    add_executable(Qt${QT_VERSION_MAJOR}::uic IMPORTED GLOBAL)
+    set_target_properties(Qt${QT_VERSION_MAJOR}::uic PROPERTIES IMPORTED_LOCATION ${QT_UIC_EXECUTABLE})
+endif()
+
+if (QT_MOC_EXECUTABLE)
+    add_executable(Qt${QT_VERSION_MAJOR}::moc IMPORTED GLOBAL)
+    set_target_properties(Qt${QT_VERSION_MAJOR}::moc PROPERTIES IMPORTED_LOCATION ${QT_MOC_EXECUTABLE})
+endif()
+
+if (QT_RCC_EXECUTABLE)
+    add_executable(Qt${QT_VERSION_MAJOR}::rcc IMPORTED GLOBAL)
+    set_target_properties(Qt${QT_VERSION_MAJOR}::rcc PROPERTIES IMPORTED_LOCATION ${QT_RCC_EXECUTABLE})
+endif()
+
+# Find the Maya Qt libraries (using the input components list).
+foreach(Maya_Qt_LIB ${Maya_Qt_FIND_COMPONENTS})
+    string(TOUPPER ${Maya_Qt_LIB} MAYA_QT_LIB)
+    set(QT_NAME_TO_FIND "Qt${QT_VERSION_MAJOR}${Maya_Qt_LIB}")
+    if (CMAKE_BUILD_TYPE MATCHES "Debug")
+        # When in debug we sometimes need to modify the names.
+        if (IS_WINDOWS)
+            string(APPEND QT_NAME_TO_FIND "d")         # extra 'd' at end
+        elseif (IS_MACOSX)
+            string(APPEND QT_NAME_TO_FIND "_debug")    # extra '_debug' at end
+        endif()
+    endif()
+    find_library(MAYA_QT${MAYA_QT_LIB}_LIBRARY
+        NAMES
+            ${QT_NAME_TO_FIND}
+        PATHS
+            ${MAYA_LIBRARY_DIR}
+        NO_DEFAULT_PATH
+        DOC
+            "Maya Qt library"
+    )
+    if (MAYA_QT${MAYA_QT_LIB}_LIBRARY)
+        # Add each Qt library and set the target properties.
+        set(__target_name "Qt${QT_VERSION_MAJOR}::${Maya_Qt_LIB}")
+        add_library(${__target_name} SHARED IMPORTED GLOBAL)
+        set_target_properties(${__target_name} PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${MAYA_QT_${MAYA_QT_LIB}_DIR};${MAYA_QT_INC_DIR}")
+        set_target_properties(${__target_name} PROPERTIES IMPORTED_CONFIGURATIONS RELEASE) # RELEASE? 
+        set_target_properties(${__target_name} PROPERTIES IMPORTED_LOCATION "${MAYA_QT${MAYA_QT_LIB}_LIBRARY}")
+        if(IS_WINDOWS)
+            set_target_properties(${__target_name} PROPERTIES IMPORTED_IMPLIB "${MAYA_QT${MAYA_QT_LIB}_LIBRARY}")
+            set_target_properties(${__target_name} PROPERTIES INTERFACE_LINK_LIBRARIES "${__target_name}")
+        endif()
+        if(${QT_VERSION_MAJOR} VERSION_EQUAL 6)
+            # Add extra compile options required for Qt6.
+            set_target_properties(${__target_name} PROPERTIES
+                INTERFACE_COMPILE_FEATURES "cxx_std_17")   # Comes from Qt6::Platform
+            if (IS_WINDOWS)
+                # Comes from Qt6::Platform
+                set_target_properties(${__target_name} PROPERTIES
+                    INTERFACE_COMPILE_OPTIONS  "\$<\$<COMPILE_LANGUAGE:CXX>:/Zc:__cplusplus;/permissive->")
+            endif()
+        endif()
+
+        # Add a versionless target.
+        set(__versionless_target_name "Qt::${Maya_Qt_LIB}")
+        if (TARGET ${__target_name} AND NOT TARGET ${__versionless_target_name})
+            add_library(${__versionless_target_name} INTERFACE IMPORTED)
+            set_target_properties(${__versionless_target_name} PROPERTIES INTERFACE_LINK_LIBRARIES ${__target_name})
+        endif()
+    endif()
+endforeach()
+
+# Set the Qt library dependencies (special cases we know about).
+if (IS_LINUX AND TARGET Qt${QT_VERSION_MAJOR}::Core)
+    set_property(TARGET Qt${QT_VERSION_MAJOR}::Core APPEND PROPERTY INTERFACE_COMPILE_OPTIONS -fPIC)
+    set_property(TARGET Qt${QT_VERSION_MAJOR}::Core PROPERTY INTERFACE_COMPILE_FEATURES cxx_decltype)
+endif()
+if (TARGET Qt${QT_VERSION_MAJOR}::Widgets)
+    set_target_properties(Qt${QT_VERSION_MAJOR}::Widgets PROPERTIES INTERFACE_LINK_LIBRARIES "Qt${QT_VERSION_MAJOR}::Gui;Qt${QT_VERSION_MAJOR}::Core")
+endif()
+if (TARGET Qt${QT_VERSION_MAJOR}::Gui)
+    set_target_properties(Qt${QT_VERSION_MAJOR}::Gui PROPERTIES INTERFACE_LINK_LIBRARIES "Qt${QT_VERSION_MAJOR}::Core")
+endif()
+
+# Handle the QUIETLY and REQUIRED arguments and set UFE_FOUND to TRUE if
+# all listed variables are TRUE.
+include(FindPackageHandleStandardArgs)
+
+list(APPEND Maya_QtRequiredVars "MAYA_QT_INC_DIR" "QT_MOC_EXECUTABLE" "QT_UIC_EXECUTABLE" "QT_RCC_EXECUTABLE")
+foreach(Maya_Qt_LIB ${Maya_Qt_FIND_COMPONENTS})
+    string(TOUPPER ${Maya_Qt_LIB} MAYA_QT_LIB)
+    list(APPEND Maya_QtRequiredVars "MAYA_QT${MAYA_QT_LIB}_LIBRARY")
+endforeach()
+
+find_package_handle_standard_args(Maya_Qt
+    REQUIRED_VARS
+        ${Maya_QtRequiredVars}
+    VERSION_VAR
+        MAYA_QT_VERSION
+)
+
+if (Maya_Qt_FOUND)
+    set(Qt${QT_VERSION_MAJOR}_FOUND TRUE)
+    message(STATUS "Using Maya Qt version ${MAYA_QT_VERSION}")
+    message(STATUS "  Qt include path  : ${MAYA_QT_INC_DIR}")
+    message(STATUS "  moc executable   : ${QT_MOC_EXECUTABLE}")
+    message(STATUS "  uic executable   : ${QT_UIC_EXECUTABLE}")
+    message(STATUS "  rcc executable   : ${QT_RCC_EXECUTABLE}")
+    foreach(Maya_Qt_LIB ${Maya_Qt_FIND_COMPONENTS})
+        string(TOUPPER ${Maya_Qt_LIB} MAYA_QT_LIB)
+        message(STATUS "  Qt ${Maya_Qt_LIB} library: ${MAYA_QT${MAYA_QT_LIB}_LIBRARY}")
+    endforeach()
+endif()

--- a/lib/mayaUsd/CMakeLists.txt
+++ b/lib/mayaUsd/CMakeLists.txt
@@ -49,7 +49,7 @@ target_compile_definitions(${PROJECT_NAME}
         $<$<BOOL:${IS_LINUX}>:GL_GLEXT_PROTOTYPES>
         $<$<BOOL:${IS_LINUX}>:GLX_GLXEXT_PROTOTYPES>
         $<$<BOOL:${CMAKE_WANT_MATERIALX_BUILD}>:WANT_MATERIALX_BUILD>
-		$<$<OR:$<BOOL:${Qt5_FOUND}>,$<BOOL:${Qt6_FOUND}>>:WANT_QT_BUILD>
+		$<$<BOOL:${Qt_FOUND}>:WANT_QT_BUILD>
         $<$<BOOL:${BUILD_HDMAYA}>:BUILD_HDMAYA>
 
         # this flag is needed when building maya-usd in Maya

--- a/lib/usd/CMakeLists.txt
+++ b/lib/usd/CMakeLists.txt
@@ -23,7 +23,7 @@ add_subdirectory(schemas)
 
 add_subdirectory(utils)
 
-if(Qt5_FOUND OR Qt6_FOUND)
+if(Qt_FOUND)
     add_subdirectory(ui)
 endif()
 

--- a/lib/usd/ui/CMakeLists.txt
+++ b/lib/usd/ui/CMakeLists.txt
@@ -47,11 +47,7 @@ target_compile_definitions(${PROJECT_NAME}
 
 # QT_NO_KEYWORDS prevents Qt from defining the foreach, signals, slots and emit macros.
 # this avoids overlap between Qt macros and boost, and enforces using Q_ macros.
-if (Qt6_FOUND)
-	set_target_properties(Qt6::Core PROPERTIES INTERFACE_COMPILE_DEFINITIONS QT_NO_KEYWORDS)
-else()
-	set_target_properties(Qt5::Core PROPERTIES INTERFACE_COMPILE_DEFINITIONS QT_NO_KEYWORDS)
-endif()
+set_target_properties(Qt::Core PROPERTIES INTERFACE_COMPILE_DEFINITIONS QT_NO_KEYWORDS)
 
 mayaUsd_compile_config(${PROJECT_NAME})
 
@@ -62,9 +58,9 @@ target_link_libraries(${PROJECT_NAME}
     PUBLIC
         mayaUsd
     PRIVATE
-		$<IF:$<BOOL:${Qt6_FOUND}>,Qt6::Core,Qt5::Core>
-		$<IF:$<BOOL:${Qt6_FOUND}>,Qt6::Gui,Qt5::Gui>
-		$<IF:$<BOOL:${Qt6_FOUND}>,Qt6::Widgets,Qt5::Widgets>
+		Qt::Core
+		Qt::Gui
+		Qt::Widgets
 )
 
 # -----------------------------------------------------------------------------

--- a/lib/usd/ui/importDialogDemo/CMakeLists.txt
+++ b/lib/usd/ui/importDialogDemo/CMakeLists.txt
@@ -40,9 +40,9 @@ mayaUsd_compile_config(${PROJECT_NAME})
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
         mayaUsdUI
-		$<IF:$<BOOL:${Qt6_FOUND}>,Qt6::Core,Qt5::Core>
-		$<IF:$<BOOL:${Qt6_FOUND}>,Qt6::Gui,Qt5::Gui>
-		$<IF:$<BOOL:${Qt6_FOUND}>,Qt6::Widgets,Qt5::Widgets>
+		Qt::Core
+		Qt::Gui
+		Qt::Widgets
 )
 
 if (IS_LINUX)

--- a/plugin/adsk/plugin/CMakeLists.txt
+++ b/plugin/adsk/plugin/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 target_compile_definitions(${TARGET_NAME}
     PRIVATE
         MAYAUSD_PLUGIN_EXPORT
-        $<$<OR:$<BOOL:${Qt5_FOUND}>,$<BOOL:${Qt6_FOUND}>>:WANT_QT_BUILD>
+		$<$<BOOL:${Qt_FOUND}>:WANT_QT_BUILD>
 )
 
 if(DEFINED MAYAUSD_VERSION)
@@ -77,7 +77,7 @@ target_link_libraries(${TARGET_NAME}
         basePxrUsdPreviewSurface
 )
 
-if (Qt5_FOUND OR Qt6_FOUND)
+if (Qt_FOUND)
     target_link_libraries(${TARGET_NAME}
         PRIVATE
             mayaUsdUI


### PR DESCRIPTION
#### EMSUSD-282 - MayaUsd: build with Qt directly from Maya devkit/runtime
* New logic in build.py (during configure stage) to "setup Maya Qt" by looking for Qt headers in Maya devkit. If not found, extract either just the header from "qt*-include.zip" for Qt5 or the entire zipfile for Qt6.
* Deprecated the "--qt-location" flag from build.py.
* New cmake module "FindMaya_Qt" used for Qt5.
* Use versionless Qt targets.

This will solve issue #1070 by finding and building with Qt from Maya devkit for all supported versions of Maya.