### PR TITLE
EMSUSD-311 fix load sub-layer file preview.

### DIFF
--- a/lib/mayaUsd/utils/utilFileSystem.cpp
+++ b/lib/mayaUsd/utils/utilFileSystem.cpp
@@ -148,6 +148,9 @@ std::string UsdMayaUtilFileSystem::getLayerFileDir(const PXR_NS::SdfLayerHandle&
         return std::string();
 
     const std::string layerFileName = layer->GetRealPath();
+    if (layerFileName.empty())
+        return std::string();
+
     return UsdMayaUtilFileSystem::getDir(layerFileName);
 }
 
@@ -258,12 +261,21 @@ std::string UsdMayaUtilFileSystem::getPathRelativeToLayerFile(
         return fileName;
 
     const std::string layerDirPath = getLayerFileDir(layer);
-    auto              relativePathAndSuccess = makePathRelativeTo(fileName, layerDirPath);
+    if (layerDirPath.empty()) {
+        TF_WARN(
+            "File name (%s) cannot be resolved as relative since its parent layer is not saved,"
+            " using the absolute path instead.",
+            fileName.c_str());
+
+        return fileName;
+    }
+
+    auto relativePathAndSuccess = makePathRelativeTo(fileName, layerDirPath);
 
     if (!relativePathAndSuccess.second) {
         TF_WARN(
             "File name (%s) cannot be resolved as relative to its parent layer directory (%s), "
-            "using the absolute path.",
+            "using the absolute path instead.",
             fileName.c_str(),
             layerDirPath.c_str());
     }

--- a/lib/usd/ui/layerEditor/loadLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/loadLayersDialog.cpp
@@ -274,10 +274,6 @@ std::string LoadLayersDialog::findDirectoryToUse(const std::string& rowText) con
             item = item->parentLayerItem();
         }
     }
-    if (path.empty()) {
-        path = QDir::currentPath().toStdString()
-            + "/"; // USD is loading from current working directory when no path is specified.
-    }
 
     if (!path.empty()) {
         QFileInfo fileInfo(QString::fromStdString(path));

--- a/plugin/adsk/scripts/mayaUsd_USDRootFileRelative.py
+++ b/plugin/adsk/scripts/mayaUsd_USDRootFileRelative.py
@@ -233,29 +233,35 @@ class usdFileRelative(object):
     def updateFilePathPreviewFields(cls, makePathRelative=None):
         if not cls._haveRelativePathFields:
             return
+
+        if not cls._canBeRelative:
+            return
+
         if makePathRelative == None:
             makePathRelative = cls._checkBoxClass.get(cls.kMakePathRelativeCheckBox)
 
-        if cls._canBeRelative and makePathRelative:
-            # If the accept button is disabled it means there is no valid input in the file
-            # name edit field.
-            selFiles = cls._fileDialog.selectedFiles() if cls._fileDialog and cls._acceptButton and cls._acceptButton.isEnabled() else None
-            selectedFile = selFiles[0] if selFiles else ''
+        if not makePathRelative:
+            return
 
-            if cls._ensureUsdExtension:
-                # Make sure the file path has a valid USD extension. This is NOT done by the fileDialog so
-                # the user is free to enter any extension they want. The layer editor code will then verify
-                # (and fix if needed) the file path before saving. We do the same here for preview.
-                unresolvedPath = mayaUsdLib.Util.ensureUSDFileExtension(selectedFile) if selectedFile else ''
-            else:
-                unresolvedPath = selectedFile
-                
-            relativePath = ''
-            if unresolvedPath and cls._relativeToDir:
-                relativePath = mayaUsdLib.Util.getPathRelativeToDirectory(unresolvedPath, cls._relativeToDir)
-            elif unresolvedPath and cls._relativeToScene:
-                relativePath = mayaUsdLib.Util.getPathRelativeToMayaSceneFile(unresolvedPath)
-            cmds.textFieldGrp(cls.kUnresolvedPathTextField, edit=True, text=relativePath)
+        # If the accept button is disabled it means there is no valid input in the file
+        # name edit field.
+        selFiles = cls._fileDialog.selectedFiles() if cls._fileDialog and cls._acceptButton and cls._acceptButton.isEnabled() else None
+        selectedFile = selFiles[0] if selFiles else ''
+
+        if cls._ensureUsdExtension:
+            # Make sure the file path has a valid USD extension. This is NOT done by the fileDialog so
+            # the user is free to enter any extension they want. The layer editor code will then verify
+            # (and fix if needed) the file path before saving. We do the same here for preview.
+            unresolvedPath = mayaUsdLib.Util.ensureUSDFileExtension(selectedFile) if selectedFile else ''
+        else:
+            unresolvedPath = selectedFile
+            
+        relativePath = ''
+        if unresolvedPath and cls._relativeToDir:
+            relativePath = mayaUsdLib.Util.getPathRelativeToDirectory(unresolvedPath, cls._relativeToDir)
+        elif unresolvedPath and cls._relativeToScene:
+            relativePath = mayaUsdLib.Util.getPathRelativeToMayaSceneFile(unresolvedPath)
+        cmds.textFieldGrp(cls.kUnresolvedPathTextField, edit=True, text=relativePath)
 
     @classmethod
     def selectionChanged(cls, parentLayout, selection):
@@ -322,6 +328,7 @@ class usdSubLayerFileRelative(usdFileRelative):
         Note: the function takes an unused filterType argument to be compatible
               with the dialog2 command API.
         '''
+        cls.setRelativeFilePathRoot(parentLayerPath)
         cls._relativeToDir = parentLayerPath
         # If the parent layer is not saved, then the checkbox and label should be disabled.
         cls._canBeRelative = bool(cls._relativeToDir)

--- a/plugin/adsk/scripts/mayaUsd_layerEditorFileDialogs.mel
+++ b/plugin/adsk/scripts/mayaUsd_layerEditorFileDialogs.mel
@@ -173,6 +173,16 @@ global proc UsdLayerEditor_LoadLayersFileDialogOptions_UICommit(string $parent, 
     python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdSubLayerFileRelative.uiCommit('" + $parent + "', '" + $selectedFile + "')");
 }
 
+global proc UsdLayerEditor_LoadLayersFileDialogOptions_SelectionChanged(string $parent, string $selection)
+{
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdSubLayerFileRelative.selectionChanged('" + $parent + "', '" + $selection + "')");
+}
+
+global proc UsdLayerEditor_LoadLayersFileDialogOptions_FileTypeChanged(string $parent, string $newType)
+{
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdSubLayerFileRelative.fileTypeChanged('" + $parent + "', '" + $newType + "')");
+}
+
 global proc string[] UsdLayerEditor_LoadLayersFileDialog(string $title, string $folder)
 {
     global string $gLayerParentPathUsdLayerEditorSaveFileDialog;
@@ -189,6 +199,8 @@ global proc string[] UsdLayerEditor_LoadLayersFileDialog(string $title, string $
             -optionsUICreate "UsdLayerEditor_LoadLayersFileDialogOptions_UICreate"
             -optionsUIInit "UsdLayerEditor_LoadLayersFileDialogOptions_UIInit"
             -optionsUICommit2 "UsdLayerEditor_LoadLayersFileDialogOptions_UICommit"
+            -fileTypeChanged "UsdLayerEditor_LoadLayersFileDialogOptions_FileTypeChanged"
+            -selectionChanged "UsdLayerEditor_LoadLayersFileDialogOptions_SelectionChanged"
             -startingDirectory $folder
             `;
 


### PR DESCRIPTION
- Fix helper functions when the layer folder is empty.
- Don't use the current directory when there is no file path.
- Register the necessary callbacks.
- Simplified code logic in Python relative file code to be more linear.