### PR TITLE
EMSUSD-596 - AE: broken templates on older maya versions

### DIFF
--- a/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
@@ -902,7 +902,8 @@ class AETemplate(object):
         return False
 
     def isImageAttribute(self, attrName):
-        if self.attrS.attributeType(attrName) != ufe.Attribute.kFilename:
+        kFilenameAttr = ufe.Attribute.kFilename if hasattr(ufe.Attribute, "kFilename") else 'Filename'
+        if self.attrS.attributeType(attrName) != kFilenameAttr:
             return False
         attr = self.prim.GetAttribute(attrName)
         if not attr:


### PR DESCRIPTION
#### EMSUSD-596 - AE: broken templates on older maya versions
* Fix for broken template with different Ufe versions.