### PR TITLE
EMSUSD-533 - Incremental naming doesn't take zero into consideration

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -1605,7 +1605,7 @@ bool PrimUpdaterManager::duplicate(
 
         // Make the destination root path unique.
         SdfPath     dstParentPath = dstParentPrim.GetPath();
-        std::string dstChildName = ufe::uniqueChildName(dstParentPrim, srcRootPath.GetName());
+        std::string dstChildName = UsdUfe::uniqueChildName(dstParentPrim, srcRootPath.GetName());
         SdfPath     dstRootPath = dstParentPath.AppendChild(TfToken(dstChildName));
         progressBar.advance();
 

--- a/lib/mayaUsd/ufe/Global.cpp
+++ b/lib/mayaUsd/ufe/Global.cpp
@@ -164,6 +164,7 @@ MStatus initialize()
     dccFunctions.timeAccessorFn = MayaUsd::ufe::getTime;
     dccFunctions.isAttributeLockedFn = MayaUsd::Editability::isAttributeLocked;
     dccFunctions.saveStageLoadRulesFn = MayaUsd::MayaUsdProxyShapeStageExtraData::saveLoadRules;
+    dccFunctions.uniqueChildNameFn = MayaUsd::ufe::uniqueChildNameMayaStandard;
 
     // Replace the Maya hierarchy handler with ours.
     auto& runTimeMgr = Ufe::RunTimeMgr::instance();

--- a/lib/mayaUsd/ufe/UsdAttributes.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributes.cpp
@@ -338,7 +338,7 @@ UsdAttributes::getUniqueAttrName(const UsdSceneItem::Ptr& item, const std::strin
             attributeNames.insert(PXR_NS::TfToken(attributeName));
         }
 
-        return uniqueName(attributeNames, attrName);
+        return UsdUfe::uniqueName(attributeNames, attrName);
     }
     return attrName;
 }

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -162,13 +162,13 @@ std::string uniqueChildNameMayaStandard(const PXR_NS::UsdPrim& usdParent, const 
 
         std::string             childBaseName;
         std::pair<TfToken, int> largestMatching("", -1);
-        for (const auto child : allChildrenNames) {
+        for (const auto& child : allChildrenNames) {
             // While iterating thru all the children look for ones that match
             // the base name of the input. When we find one check its numerical
             // suffix and store the greatest one.
             splitNumericalSuffix(child.GetString(), childBaseName, suffix);
             if (baseName == childBaseName) {
-                int suffixValue = std::stoi(suffix);
+                int suffixValue = !suffix.empty() ? std::stoi(suffix) : 0;
                 if (suffixValue > largestMatching.second) {
                     largestMatching = std::make_pair(child, suffixValue);
                 }

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -159,9 +159,10 @@ std::string uniqueChildNameMayaStandard(const PXR_NS::UsdPrim& usdParent, const 
         // that to all the sibling names.
         std::string baseName, suffix;
         splitNumericalSuffix(childName, baseName, suffix);
+        int suffixValue = !suffix.empty() ? std::stoi(suffix) : 0;
 
-        std::string             childBaseName;
-        std::pair<TfToken, int> largestMatching("", -1);
+        std::string                 childBaseName;
+        std::pair<std::string, int> largestMatching(childName, suffixValue);
         for (const auto& child : allChildrenNames) {
             // While iterating thru all the children look for ones that match
             // the base name of the input. When we find one check its numerical
@@ -170,7 +171,7 @@ std::string uniqueChildNameMayaStandard(const PXR_NS::UsdPrim& usdParent, const 
             if (baseName == childBaseName) {
                 int suffixValue = !suffix.empty() ? std::stoi(suffix) : 0;
                 if (suffixValue > largestMatching.second) {
-                    largestMatching = std::make_pair(child, suffixValue);
+                    largestMatching = std::make_pair(child.GetString(), suffixValue);
                 }
             }
         }

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -154,8 +154,7 @@ std::string uniqueChildNameMayaStandard(const PXR_NS::UsdPrim& usdParent, const 
     // Example: with siblings Capsule001 & Capsule006, duplicating Capsule001
     //          will set new unique name to Capsule007.
     std::string childName { name };
-    if (allChildrenNames.find(TfToken(childName)) != allChildrenNames.end())
-    {
+    if (allChildrenNames.find(TfToken(childName)) != allChildrenNames.end()) {
         // Get the base name (removing the numerical suffix) so that we can compare
         // that to all the sibling names.
         std::string baseName, suffix;
@@ -163,8 +162,7 @@ std::string uniqueChildNameMayaStandard(const PXR_NS::UsdPrim& usdParent, const 
 
         std::string             childBaseName;
         std::pair<TfToken, int> largestMatching("", -1);
-        for (const auto child : allChildrenNames)
-        {
+        for (const auto child : allChildrenNames) {
             // While iterating thru all the children look for ones that match
             // the base name of the input. When we find one check its numerical
             // suffix and store the greatest one.

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -137,6 +137,54 @@ createSiblingSceneItem(const Ufe::Path& ufeSrcPath, const std::string& siblingNa
     return UsdSceneItem::create(ufeSiblingPath, ufePathToPrim(ufeSiblingPath));
 }
 
+std::string uniqueChildNameMayaStandard(const PXR_NS::UsdPrim& usdParent, const std::string& name)
+{
+    if (!usdParent.IsValid())
+        return std::string();
+
+    // See uniqueChildNameDefault() in lib\usdUfe\ufe\Utils.cpp for details.
+    TfToken::HashSet allChildrenNames;
+    for (auto child : usdParent.GetFilteredChildren(
+             UsdTraverseInstanceProxies(UsdPrimIsDefined && !UsdPrimIsAbstract))) {
+        allChildrenNames.insert(child.GetName());
+    }
+
+    // When setting unique name Maya will look at the numerical suffix of all
+    // matching names and set the unique name to +1 on the greatest suffix.
+    // Example: with siblings Capsule001 & Capsule006, duplicating Capsule001
+    //          will set new unique name to Capsule007.
+    std::string childName { name };
+    if (allChildrenNames.find(TfToken(childName)) != allChildrenNames.end())
+    {
+        // Get the base name (removing the numerical suffix) so that we can compare
+        // that to all the sibling names.
+        std::string baseName, suffix;
+        splitNumericalSuffix(childName, baseName, suffix);
+
+        std::string             childBaseName;
+        std::pair<TfToken, int> largestMatching("", -1);
+        for (const auto child : allChildrenNames)
+        {
+            // While iterating thru all the children look for ones that match
+            // the base name of the input. When we find one check its numerical
+            // suffix and store the greatest one.
+            splitNumericalSuffix(child.GetString(), childBaseName, suffix);
+            if (baseName == childBaseName) {
+                int suffixValue = std::stoi(suffix);
+                if (suffixValue > largestMatching.second) {
+                    largestMatching = std::make_pair(child, suffixValue);
+                }
+            }
+        }
+
+        // By sending in the largest matching name (instead of the input name)
+        // the unique name function will increment its numerical suffix by 1
+        // and thus it will be unique and follow Maya naming standard.
+        childName = uniqueName(allChildrenNames, largestMatching.first);
+    }
+    return childName;
+}
+
 bool isAGatewayType(const std::string& mayaNodeType)
 {
     // If we've seen this node type before, return the cached value.

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -73,15 +73,9 @@ MAYAUSD_CORE_PUBLIC
 UsdSceneItem::Ptr
 createSiblingSceneItem(const Ufe::Path& ufeSrcPath, const std::string& siblingName);
 
-inline std::string uniqueName(const PXR_NS::TfToken::HashSet& existingNames, std::string srcName)
-{
-    return UsdUfe::uniqueName(existingNames, srcName);
-}
-
-inline std::string uniqueChildName(const PXR_NS::UsdPrim& parent, const std::string& name)
-{
-    return UsdUfe::uniqueChildName(parent, name);
-}
+//! Returns a unique child name following the Maya standard naming rules.
+MAYAUSD_CORE_PUBLIC
+std::string uniqueChildNameMayaStandard(const PXR_NS::UsdPrim& usdParent, const std::string& name);
 
 //! Return if a Maya node type is derived from the gateway node type.
 MAYAUSD_CORE_PUBLIC

--- a/lib/usdUfe/python/wrapUtils.cpp
+++ b/lib/usdUfe/python/wrapUtils.cpp
@@ -31,8 +31,8 @@
 #include <boost/python.hpp>
 #include <boost/python/def.hpp>
 
-#include <vector>
 #include <string>
+#include <vector>
 
 using namespace boost::python;
 

--- a/lib/usdUfe/python/wrapUtils.cpp
+++ b/lib/usdUfe/python/wrapUtils.cpp
@@ -31,6 +31,7 @@
 #include <boost/python.hpp>
 #include <boost/python/def.hpp>
 
+#include <vector>
 #include <string>
 
 using namespace boost::python;
@@ -54,9 +55,10 @@ std::string _usdPathToUfePathSegment(
     return UsdUfe::usdPathToUfePathSegment(usdPath, instanceIndex).string();
 }
 
-std::string _uniqueChildName(const PXR_NS::UsdPrim& parent, const std::string& name)
+std::string _uniqueName(const std::vector<std::string>& existingNames, std::string srcName)
 {
-    return UsdUfe::uniqueChildName(parent, name);
+    PXR_NS::TfToken::HashSet existingNamesSet(existingNames.begin(), existingNames.end());
+    return UsdUfe::uniqueName(existingNamesSet, srcName);
 }
 
 std::string _stripInstanceIndexFromUfePath(const std::string& ufePathString)
@@ -73,11 +75,6 @@ PXR_NS::UsdPrim _ufePathToPrim(const std::string& ufePathString)
 int _ufePathToInstanceIndex(const std::string& ufePathString)
 {
     return UsdUfe::ufePathToInstanceIndex(Ufe::PathString::path(ufePathString));
-}
-
-bool _isEditTargetLayerModifiable(const PXR_NS::UsdStageWeakPtr stage)
-{
-    return UsdUfe::isEditTargetLayerModifiable(stage);
 }
 
 PXR_NS::UsdTimeCode _getTime(const std::string& pathStr)
@@ -104,11 +101,12 @@ void wrapUtils()
     def("usdPathToUfePathSegment",
         _usdPathToUfePathSegment,
         (arg("usdPath"), arg("instanceIndex") = PXR_NS::UsdImagingDelegate::ALL_INSTANCES));
-    def("uniqueChildName", _uniqueChildName);
+    def("uniqueName", _uniqueName);
+    def("uniqueChildName", UsdUfe::uniqueChildName);
     def("stripInstanceIndexFromUfePath", _stripInstanceIndexFromUfePath, (arg("ufePathString")));
     def("ufePathToPrim", _ufePathToPrim);
     def("ufePathToInstanceIndex", _ufePathToInstanceIndex);
-    def("isEditTargetLayerModifiable", _isEditTargetLayerModifiable);
+    def("isEditTargetLayerModifiable", UsdUfe::isEditTargetLayerModifiable);
     def("getTime", _getTime);
     def("isAttributeEditAllowed", _isAttributeEditAllowed);
 }

--- a/lib/usdUfe/python/wrapUtils.cpp
+++ b/lib/usdUfe/python/wrapUtils.cpp
@@ -57,7 +57,10 @@ std::string _usdPathToUfePathSegment(
 
 std::string _uniqueName(const std::vector<std::string>& existingNames, std::string srcName)
 {
-    PXR_NS::TfToken::HashSet existingNamesSet(existingNames.begin(), existingNames.end());
+    PXR_NS::TfToken::HashSet existingNamesSet;
+    for (const auto& n : existingNames) {
+        existingNamesSet.insert(PXR_NS::TfToken(n));
+    }
     return UsdUfe::uniqueName(existingNamesSet, srcName);
 }
 
@@ -75,6 +78,11 @@ PXR_NS::UsdPrim _ufePathToPrim(const std::string& ufePathString)
 int _ufePathToInstanceIndex(const std::string& ufePathString)
 {
     return UsdUfe::ufePathToInstanceIndex(Ufe::PathString::path(ufePathString));
+}
+
+bool _isEditTargetLayerModifiable(const PXR_NS::UsdStageWeakPtr stage)
+{
+    return UsdUfe::isEditTargetLayerModifiable(stage);
 }
 
 PXR_NS::UsdTimeCode _getTime(const std::string& pathStr)
@@ -106,7 +114,7 @@ void wrapUtils()
     def("stripInstanceIndexFromUfePath", _stripInstanceIndexFromUfePath, (arg("ufePathString")));
     def("ufePathToPrim", _ufePathToPrim);
     def("ufePathToInstanceIndex", _ufePathToInstanceIndex);
-    def("isEditTargetLayerModifiable", UsdUfe::isEditTargetLayerModifiable);
+    def("isEditTargetLayerModifiable", _isEditTargetLayerModifiable);
     def("getTime", _getTime);
     def("isAttributeEditAllowed", _isAttributeEditAllowed);
 }

--- a/lib/usdUfe/ufe/Global.cpp
+++ b/lib/usdUfe/ufe/Global.cpp
@@ -77,6 +77,8 @@ Ufe::Rtid initialize(
         UsdUfe::setSaveStageLoadRulesFn(dccFunctions.saveStageLoadRulesFn);
     if (dccFunctions.isRootChildFn)
         UsdUfe::setIsRootChildFn(dccFunctions.isRootChildFn);
+    if (dccFunctions.uniqueChildNameFn)
+        UsdUfe::setUniqueChildNameFn(dccFunctions.uniqueChildNameFn);
 
     // Create a default stages subject if none is provided.
     if (nullptr == ss) {

--- a/lib/usdUfe/ufe/Global.h
+++ b/lib/usdUfe/ufe/Global.h
@@ -47,6 +47,7 @@ struct USDUFE_PUBLIC DCCFunctions
     IsAttributeLockedFn  isAttributeLockedFn = nullptr;
     SaveStageLoadRulesFn saveStageLoadRulesFn = nullptr;
     IsRootChildFn        isRootChildFn = nullptr;
+    UniqueChildNameFn    uniqueChildNameFn = nullptr;
 };
 
 /*! Ufe runtime handlers used to initialize the plugin.

--- a/lib/usdUfe/ufe/Utils.cpp
+++ b/lib/usdUfe/ufe/Utils.cpp
@@ -284,7 +284,7 @@ bool splitNumericalSuffix(const std::string srcName, std::string& base, std::str
     // Compiled regular expression to find a numerical suffix to a path component.
     // It searches for any number of characters followed by a single non-numeric,
     // then one or more digits at end of string.
-    std::regex  re("(.*)([^0-9])([0-9]+)$");
+    std::regex re("(.*)([^0-9])([0-9]+)$");
     base = srcName;
     std::smatch match;
     if (std::regex_match(srcName, match, re)) {

--- a/lib/usdUfe/ufe/Utils.cpp
+++ b/lib/usdUfe/ufe/Utils.cpp
@@ -311,7 +311,10 @@ std::string uniqueName(const TfToken::HashSet& existingNames, std::string srcNam
     suffixStr = std::string(lenSuffix - std::min(lenSuffix, suffixStr.length()), '0') + suffixStr;
     std::string dstName = base + suffixStr;
     while (existingNames.count(TfToken(dstName)) > 0) {
-        dstName = base + std::to_string(++suffix);
+        suffixStr = std::to_string(++suffix);
+        suffixStr
+            = std::string(lenSuffix - std::min(lenSuffix, suffixStr.length()), '0') + suffixStr;
+        dstName = base + suffixStr;
     }
     return dstName;
 }

--- a/lib/usdUfe/ufe/Utils.h
+++ b/lib/usdUfe/ufe/Utils.h
@@ -45,6 +45,7 @@ typedef PXR_NS::UsdTimeCode (*TimeAccessorFn)(const Ufe::Path&);
 typedef bool (*IsAttributeLockedFn)(const PXR_NS::UsdAttribute& attr, std::string* errMsg);
 typedef void (*SaveStageLoadRulesFn)(const PXR_NS::UsdStageRefPtr&);
 typedef bool (*IsRootChildFn)(const Ufe::Path& path);
+typedef std::string (*UniqueChildNameFn)(const PXR_NS::UsdPrim& usdParent, const std::string& name);
 
 //------------------------------------------------------------------------------
 // Helper functions
@@ -140,7 +141,7 @@ int ufePathToInstanceIndex(const Ufe::Path& path, PXR_NS::UsdPrim* prim = nullpt
 
 //! Set the DCC specific "isRootChild" test function.
 //! Use of this function is optional, if one is not supplied then
-//! a default implementation of isRootChild is used..
+//! a default implementation of isRootChild is used.
 USDUFE_PUBLIC
 void setIsRootChildFn(IsRootChildFn fn);
 
@@ -154,14 +155,30 @@ bool isRootChild(const Ufe::Path& path);
 USDUFE_PUBLIC
 bool isRootChildDefault(const Ufe::Path& path);
 
+//! Split the input source name <p srcName> into a base name <p base> and a
+//! numerical suffix (if present) <p suffix>.
+//! Returns true when numerical suffix was found, otherwise false.
+USDUFE_PUBLIC
+bool splitNumericalSuffix(const std::string srcName, std::string& base, std::string& suffix);
+
 //! Split the source name into a base name and a numerical suffix (set to
 //! 1 if absent).  Increment the numerical suffix until name is unique.
 USDUFE_PUBLIC
 std::string uniqueName(const PXR_NS::TfToken::HashSet& existingNames, std::string srcName);
 
+//! Set the DCC specific "uniqueChildName" function.
+//! Use of this function is optional, if one is not supplied then
+//! a default implementation of uniqueChildName is used.
+USDUFE_PUBLIC
+void setUniqueChildNameFn(UniqueChildNameFn fn);
+
 //! Return a unique child name.
 USDUFE_PUBLIC
-std::string uniqueChildName(const PXR_NS::UsdPrim& parent, const std::string& name);
+std::string uniqueChildName(const PXR_NS::UsdPrim& usdParent, const std::string& name);
+
+//! Default uniqueChildName() implementation. Uses all the prim's children.
+USDUFE_PUBLIC
+std::string uniqueChildNameDefault(const PXR_NS::UsdPrim& parent, const std::string& name);
 
 //! Send notification for data model changes
 template <class T>

--- a/test/lib/ufe/testContextOps.py
+++ b/test/lib/ufe/testContextOps.py
@@ -919,13 +919,15 @@ class ContextOpsTestCase(unittest.TestCase):
         assert ufe.Hierarchy.createItem(ufe.PathString.path(expectedPath))
 
         # Case 6: A non-scope object named "mtl" exists and a scope named "mtl2" exists.
-        # The new material should get created in a new scope named "mtl1".
+        # The new material should get created in a new scope named "mtl3".
+        # This follows normal Maya naming standard where it increments the largest numerical
+        # suffix (even if there are gaps).
         proxyShape = createProxyShape()
         proxyShapePath = ufe.PathString.string(proxyShape.path())
         addNewPrim(proxyShape, "Def", materialsScopeName)
         addNewPrim(proxyShape, "Scope", materialsScopeName + "2")
         createMaterial(proxyShape)
-        expectedPath = proxyShapePath + ",/" + materialsScopeName + "1/" + materialName
+        expectedPath = proxyShapePath + ",/" + materialsScopeName + "3/" + materialName
         assert ufe.Hierarchy.createItem(ufe.PathString.path(expectedPath))
 
         # Case 7: A non-scope object named "mtl" exists and a scope named "mtlBingBong" exists.
@@ -948,8 +950,11 @@ class ContextOpsTestCase(unittest.TestCase):
         for scopeNamePostfix in scopeNamePostfixes:
             addNewPrim(proxyShape, "Scope", materialsScopeName + scopeNamePostfix)
 
+        # Again here follow the normal Maya naming standard which increments the largest
+        # numerical suffix (1337).
         createMaterial(proxyShape)
-        expectedPath = proxyShapePath + ",/" + materialsScopeName + "1/" + materialName
+        expectedPath = proxyShapePath + ",/" + materialsScopeName + "1338/" + materialName
+        print(expectedPath)
         assert ufe.Hierarchy.createItem(ufe.PathString.path(expectedPath))
 
         # Case 9: Multiple non-scope object named "mtl", "mtl1", ..., "mtl3" exists and multiple 
@@ -967,7 +972,7 @@ class ContextOpsTestCase(unittest.TestCase):
             addNewPrim(proxyShape, "Scope", materialsScopeName + scopeNamePostfix)
 
         createMaterial(proxyShape)
-        expectedPath = proxyShapePath + ",/" + materialsScopeName + "4/" + materialName
+        expectedPath = proxyShapePath + ",/" + materialsScopeName + "1338/" + materialName
         assert ufe.Hierarchy.createItem(ufe.PathString.path(expectedPath))
 
         # Case 10: Multiple non-scope object named "mtl", "mtl1", ..., "mtl3" exists and multiple 

--- a/test/lib/ufe/testDuplicateCmd.py
+++ b/test/lib/ufe/testDuplicateCmd.py
@@ -45,7 +45,7 @@ def firstSubLayer(context, routingData):
     routingData['layer'] = prim.GetStage().GetRootLayer().subLayerPaths[0]
 
 class DuplicateCmdTestCase(unittest.TestCase):
-    '''Verify the Maya delete command, for multiple runtimes.
+    '''Verify the Maya duplicate command, for multiple runtimes.
 
     UFE Feature : SceneItemOps
     Maya Feature : duplicate
@@ -646,7 +646,85 @@ class DuplicateCmdTestCase(unittest.TestCase):
         rootLayerText = rootLayer.ExportToString()
         self.assertNotIn('"Geom"', rootLayerText)
         self.assertNotIn('Mesh', rootLayerText)
-    
+
+    def testDuplicateUniqueName(self):
+        '''Test the duplicate of prims and ensure the new name follows Maya
+        unique new name standard.'''
+
+        cmds.file(new=True, force=True)
+        import mayaUsd_createStageWithNewLayer
+
+        psPathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        stage = mayaUsd.lib.GetPrim(psPathStr).GetStage()
+        stage.DefinePrim('/Xform1', 'Xform')
+        stage.DefinePrim('/Xform1/Cone1', 'Cone')
+
+        # Duplicate the 'Cone1' - new object should be 'Cone2'
+        newObj = cmds.duplicate(psPathStr + ',/Xform1/Cone1')
+        newObjItem = ufe.Hierarchy.createItem(ufe.PathString.path(newObj[0]))
+        self.assertEqual(newObjItem.nodeName(), 'Cone2')
+
+        # Rename the new 'Cone2' to 'Cone5' and then duplicate 'Cone1'.
+        # New prim should be named 'Cone6'. When finding unique name Maya
+        # will look at all nodes that match base name and increment the largest
+        # one (even if there are gaps in numbering).
+        cmds.rename(psPathStr + ',/Xform1/Cone2', 'Cone5')
+        newObj = cmds.duplicate(psPathStr + ',/Xform1/Cone1')
+        newObjItem = ufe.Hierarchy.createItem(ufe.PathString.path(newObj[0]))
+        self.assertEqual(newObjItem.nodeName(), 'Cone6')
+
+        # Rename the new 'Cone6' to 'Cone006' and then duplicate 'Cone1'.
+        # New prim should be named 'Cone007'. This is because we increment
+        # the sibling with the greatest numerical suffix (which is Capsule006).
+        cmds.rename(psPathStr + ',/Xform1/Cone6', 'Cone006')
+        newObj = cmds.duplicate(psPathStr + ',/Xform1/Cone1')
+        newObjItem = ufe.Hierarchy.createItem(ufe.PathString.path(newObj[0]))
+        self.assertEqual(newObjItem.nodeName(), 'Cone007')
+
+        # Start again, this time prim has 0's in name.
+        cmds.file(new=True, force=True)
+        psPathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        stage = mayaUsd.lib.GetPrim(psPathStr).GetStage()
+        stage.DefinePrim('/Xform1', 'Xform')
+        stage.DefinePrim('/Xform1/Cone001', 'Cone')
+
+        # Duplicate the 'Cone001' - new object should be 'Cone002'
+        newObj = cmds.duplicate(psPathStr + ',/Xform1/Cone001')
+        newObjItem = ufe.Hierarchy.createItem(ufe.PathString.path(newObj[0]))
+        self.assertEqual(newObjItem.nodeName(), 'Cone002')
+
+        # Rename the new 'Cone002' to 'Cone005' and then duplicate 'Cone001'.
+        # New prim should be named 'Cone006'. When finding unique name Maya
+        # will look at all nodes that match base name and increment the largest
+        # one (even if there are gaps in numbering).
+        cmds.rename(psPathStr + ',/Xform1/Cone002', 'Cone005')
+        newObj = cmds.duplicate(psPathStr + ',/Xform1/Cone001')
+        newObjItem = ufe.Hierarchy.createItem(ufe.PathString.path(newObj[0]))
+        self.assertEqual(newObjItem.nodeName(), 'Cone006')
+
+        # Start again, this time with mix of numerical suffix lengths.
+        cmds.file(new=True, force=True)
+        psPathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        stage = mayaUsd.lib.GetPrim(psPathStr).GetStage()
+        stage.DefinePrim('/Xform1', 'Xform')
+        stage.DefinePrim('/Xform1/Cone1', 'Cone')
+
+        # Duplicate the 'Cone1' - new object should be 'Cone2'
+        newObj = cmds.duplicate(psPathStr + ',/Xform1/Cone1')
+        newObjItem = ufe.Hierarchy.createItem(ufe.PathString.path(newObj[0]))
+        self.assertEqual(newObjItem.nodeName(), 'Cone2')
+
+        # Rename the new 'Cone2' to 'Cone001' and then duplicate 'Cone1.
+        # New prim name should be 'Cone2'
+        cmds.rename(psPathStr + ',/Xform1/Cone2', 'Cone001')
+        newObj = cmds.duplicate(psPathStr + ',/Xform1/Cone1')
+        newObjItem = ufe.Hierarchy.createItem(ufe.PathString.path(newObj[0]))
+        self.assertEqual(newObjItem.nodeName(), 'Cone2')
+
+        # Duplicate 'Cone001', new prim name should be 'Cone3'.
+        newObj = cmds.duplicate(psPathStr + ',/Xform1/Cone001')
+        newObjItem = ufe.Hierarchy.createItem(ufe.PathString.path(newObj[0]))
+        self.assertEqual(newObjItem.nodeName(), 'Cone3')
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/ufe/testPythonWrappers.py
+++ b/test/lib/ufe/testPythonWrappers.py
@@ -25,6 +25,7 @@ import mayaUsd
 
 from maya import cmds
 from maya import standalone
+from pxr import Usd
 
 import ufe
 
@@ -82,28 +83,71 @@ class PythonWrappersTestCase(unittest.TestCase):
 
         # Test the maya-usd ufePathToPrim() wrapper.
         mayaUsdStage.DefinePrim("/Capsule1", "Capsule")
-        if ufeUtils.ufeFeatureSetVersion() >= 2:
-            capsulePrim = mayaUsd.ufe.ufePathToPrim('%s,/Capsule1' % proxyShape)
-        else:
-            capsulePrim = mayaUsd.ufe.ufePathToPrim('|world%s,/Capsule1' % proxyShape)
+        capsulePrim = mayaUsd.ufe.ufePathToPrim('%s,/Capsule1' % proxyShape)
         self.assertIsNotNone(capsulePrim)
 
-        if ufeUtils.ufeFeatureSetVersion() >= 2:
-            # Test the maya-usd getPrimFromRawItem() wrapper.
-            capsulePath = proxyShapePath + usdUtils.createUfePathSegment('/Capsule1')
-            capsuleItem = ufe.Hierarchy.createItem(capsulePath)
-            rawItem = capsuleItem.getRawAddress()
-            capsulePrim2 = mayaUsd.ufe.getPrimFromRawItem(rawItem)
-            self.assertIsNotNone(capsulePrim2)
-            self.assertEqual(capsulePrim, capsulePrim2)
+        # Test maya-usd usdPathToUfePathSegment wrapper.
+        ufePath = mayaUsd.ufe.usdPathToUfePathSegment('/Capsule1')
+        self.assertEqual(ufePath, str(usdUtils.createUfePathSegment('/Capsule1')))
 
-            # Test the maya-usd getNodeTypeFromRawItem() wrapper.
-            nodeType = mayaUsd.ufe.getNodeTypeFromRawItem(rawItem)
-            self.assertIsNotNone(nodeType)
+        # Test the uniqueName wrapper.
+        # Note: param1 = list of existing children names.
+        #       param2 = source name that you want made unique
+        #       return = unique name from input source name
+        newName = mayaUsd.ufe.uniqueName([], 'Capsule')
+        self.assertEqual(newName, 'Capsule1')
+        newName = mayaUsd.ufe.uniqueName([], 'Capsule1')
+        self.assertEqual(newName, 'Capsule2')
+        newName = mayaUsd.ufe.uniqueName(['Cone1'], 'Capsule1')
+        self.assertEqual(newName, 'Capsule2')
+        newName = mayaUsd.ufe.uniqueName(['Capsule1'], 'Capsule1')
+        self.assertEqual(newName, 'Capsule2')
+        newName = mayaUsd.ufe.uniqueName(['Capsule1', 'Capsule5'], 'Capsule1')
+        self.assertEqual(newName, 'Capsule2')
+        newName = mayaUsd.ufe.uniqueName(['Capsule001'], 'Capsule001')
+        self.assertEqual(newName, 'Capsule002')
+        newName = mayaUsd.ufe.uniqueName(['Capsule001', 'Capsule002'], 'Capsule001')
+        self.assertEqual(newName, 'Capsule003')
+        newName = mayaUsd.ufe.uniqueName(['Capsule001', 'Capsule005'], 'Capsule001')
+        self.assertEqual(newName, 'Capsule002')
 
-            # Test the maya-usd getNodeNameFromRawItem() wrapper.
-            nodeName = mayaUsd.ufe.getNodeNameFromRawItem(rawItem)
-            self.assertIsNotNone(nodeName)
+        # Test uniqueChildName wrapper.
+        newName = mayaUsd.ufe.uniqueChildName(capsulePrim, 'Cone1')
+        self.assertEqual(newName, 'Cone1')
+        mayaUsdStage.DefinePrim("/Capsule1/Cone1", "Cone")
+        newName = mayaUsd.ufe.uniqueChildName(capsulePrim, 'Cone1')
+        self.assertEqual(newName, 'Cone2')
+        mayaUsdStage.DefinePrim("/Capsule1/Sphere001", "Sphere")
+        newName = mayaUsd.ufe.uniqueChildName(capsulePrim, 'Sphere001')
+        self.assertEqual(newName, 'Sphere002')
+
+        # stripInstanceIndexFromUfePath/ufePathToInstanceIndex wrappers are tested
+        # by testPointInstances.
+
+        # isEditTargetLayerModifiable wrapper is tested by testBlockedLayerEdit.
+
+        # Test the getTime wrapper.
+        cmds.currentTime(10)
+        t = mayaUsd.ufe.getTime(stagePath)
+        self.assertEqual(t, Usd.TimeCode(10))
+
+        # isAttributeEditAllowed wrapper is tested by testAttribute.
+
+        # Test the maya-usd getPrimFromRawItem() wrapper.
+        capsulePath = proxyShapePath + usdUtils.createUfePathSegment('/Capsule1')
+        capsuleItem = ufe.Hierarchy.createItem(capsulePath)
+        rawItem = capsuleItem.getRawAddress()
+        capsulePrim2 = mayaUsd.ufe.getPrimFromRawItem(rawItem)
+        self.assertIsNotNone(capsulePrim2)
+        self.assertEqual(capsulePrim, capsulePrim2)
+
+        # Test the maya-usd getNodeTypeFromRawItem() wrapper.
+        nodeType = mayaUsd.ufe.getNodeTypeFromRawItem(rawItem)
+        self.assertIsNotNone(nodeType)
+
+        # Test the maya-usd getNodeNameFromRawItem() wrapper.
+        nodeName = mayaUsd.ufe.getNodeNameFromRawItem(rawItem)
+        self.assertIsNotNone(nodeName)
 
         # Test the maya-usd runtime id wrappers.
         mayaRtid = mayaUsd.ufe.getMayaRunTimeId()
@@ -118,9 +162,9 @@ class PythonWrappersTestCase(unittest.TestCase):
         # a worker thread.
         cmds.file(new=True, force=True)
 
-    # In Maya 2020 and 2022, undo does not restore the stage.  To be
+    # In Maya 2022, undo does not restore the stage.  To be
     # investigated as needed.
-    @unittest.skipUnless((mayaUtils.mayaMajorVersion() == 2023) or mayaUtils.previewReleaseVersion() >= 139, 'Only supported in Maya 2023 or greater.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() == 2023, 'Only supported in Maya 2023 or greater.')
     def testGetAllStages(self):
         cmds.file(new=True, force=True)
 


### PR DESCRIPTION
#### EMSUSD-533 - Incremental naming doesn't take zero into consideration
* Added optional DCC function for uniqueChildName() and override the UsdUfe one with Maya version: uniqueChildNameMayaStandard().
* Split out numerical suffix handling in UsdUfe::uniqueName() into separate helper function.
* When creating new unique name take into account length of numerical suffix (when padded with 0's).
* Added new unit tests to testDuplicateCmd to test all these naming rules.