### PR TITLE
EMSUSD-59 make error messages more clear

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -2242,27 +2242,35 @@ void HdVP2Mesh::_UpdateDrawItem(
                 MHWRender::MVertexBufferArray vertexBuffers;
 
                 std::set<TfToken> addedPrimvars;
-                auto              addPrimvar =
-                    [primvarInfo, &vertexBuffers, &addedPrimvars, isBBoxItem, &sharedBBoxGeom](
-                        const TfToken& p) {
-                        auto entry = primvarInfo->find(p);
-                        if (entry == primvarInfo->cend()) {
-                            // No primvar by that name.
-                            return;
+                auto              addPrimvar = [primvarInfo,
+                                   &vertexBuffers,
+                                   &addedPrimvars,
+                                   isBBoxItem,
+                                   &sharedBBoxGeom,
+                                   &renderItem](const TfToken& p) {
+                    auto entry = primvarInfo->find(p);
+                    if (entry == primvarInfo->cend()) {
+                        // No primvar by that name.
+                        return;
+                    }
+                    MHWRender::MVertexBuffer* primvarBuffer = nullptr;
+                    if (isBBoxItem && p == HdTokens->points) {
+                        primvarBuffer = const_cast<MHWRender::MVertexBuffer*>(
+                            sharedBBoxGeom.GetPositionBuffer());
+                    } else {
+                        primvarBuffer = entry->second->_buffer.get();
+                    }
+                    if (primvarBuffer) { // this filters out the separate color & alpha entries
+                        MStatus result = vertexBuffers.addBuffer(p.GetText(), primvarBuffer);
+                        if (result != MStatus::kSuccess) {
+                            TF_WARN(
+                                "Could not create primvar [%s] buffer for [%s].",
+                                p.GetText(),
+                                renderItem->name().asChar());
                         }
-                        MHWRender::MVertexBuffer* primvarBuffer = nullptr;
-                        if (isBBoxItem && p == HdTokens->points) {
-                            primvarBuffer = const_cast<MHWRender::MVertexBuffer*>(
-                                sharedBBoxGeom.GetPositionBuffer());
-                        } else {
-                            primvarBuffer = entry->second->_buffer.get();
-                        }
-                        if (primvarBuffer) { // this filters out the separate color & alpha entries
-                            MStatus result = vertexBuffers.addBuffer(p.GetText(), primvarBuffer);
-                            TF_VERIFY(result == MStatus::kSuccess);
-                        }
-                        addedPrimvars.insert(p);
-                    };
+                    }
+                    addedPrimvars.insert(p);
+                };
 
                 // Points and normals always are at the beginning of vertex requirements:
                 addPrimvar(HdTokens->points);
@@ -2288,7 +2296,11 @@ void HdVP2Mesh::_UpdateDrawItem(
                 // - Trigger consolidation/instancing update.
                 result = drawScene.setGeometryForRenderItem(
                     *renderItem, vertexBuffers, *indexBuffer, stateToCommit._boundingBox);
-                TF_VERIFY(result == MStatus::kSuccess);
+                if (result != MStatus::kSuccess) {
+                    TF_WARN(
+                        "Could not create OGS geometry for [%s], maybe it has no geometry?",
+                        renderItem->name().asChar());
+                }
             }
 
             // Important, update instance transforms after setting geometry on render items!
@@ -2306,12 +2318,20 @@ void HdVP2Mesh::_UpdateDrawItem(
                             // VP2 defines instance ID of the first instance to be 1.
                             result = drawScene.updateInstanceTransform(
                                 *renderItem, i + 1, (*stateToCommit._instanceTransforms)[i]);
-                            TF_VERIFY(result == MStatus::kSuccess);
+                            if (result != MStatus::kSuccess) {
+                                TF_WARN(
+                                    "Could not update the instance transform for [%s].",
+                                    renderItem->name().asChar());
+                            }
                         }
                     } else {
                         result = drawScene.setInstanceTransformArray(
                             *renderItem, *stateToCommit._instanceTransforms);
-                        TF_VERIFY(result == MStatus::kSuccess);
+                        if (result != MStatus::kSuccess) {
+                            TF_WARN(
+                                "Could not update the instance transform for [%s].",
+                                renderItem->name().asChar());
+                        }
                     }
                 }
 
@@ -2323,13 +2343,21 @@ void HdVP2Mesh::_UpdateDrawItem(
                         *renderItem,
                         stateToCommit._instanceColorParam,
                         *stateToCommit._instanceColors);
-                    TF_VERIFY(result == MStatus::kSuccess);
+                    if (result != MStatus::kSuccess) {
+                        TF_WARN(
+                            "Could not set the instance color for [%s].",
+                            renderItem->name().asChar());
+                    }
                 }
             } else if (newInstanceCount >= 1) {
                 if (stateToCommit._instanceTransforms) {
                     result = drawScene.setInstanceTransformArray(
                         *renderItem, *stateToCommit._instanceTransforms);
-                    TF_VERIFY(result == MStatus::kSuccess);
+                    if (result != MStatus::kSuccess) {
+                        TF_WARN(
+                            "Could not update the instance transform for [%s].",
+                            renderItem->name().asChar());
+                    }
                 }
 
                 if (stateToCommit._instanceColors && stateToCommit._instanceColors->length() > 0) {
@@ -2340,7 +2368,11 @@ void HdVP2Mesh::_UpdateDrawItem(
                         *renderItem,
                         stateToCommit._instanceColorParam,
                         *stateToCommit._instanceColors);
-                    TF_VERIFY(result == MStatus::kSuccess);
+                    if (result != MStatus::kSuccess) {
+                        TF_WARN(
+                            "Could not set the instance color for [%s].",
+                            renderItem->name().asChar());
+                    }
                 }
 
                 stateToCommit._renderItemData._usingInstancedDraw = true;

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -1228,7 +1228,9 @@ void ProxyRenderDelegate::update(MSubSceneContainer& container, const MFrameCont
     if (selectionInfo) {
         bool oldSnapToSelectedObjects = _snapToSelectedObjects;
         _snapToSelectedObjects = selectionInfo->snapToActive(&status);
-        TF_VERIFY(status == MStatus::kSuccess);
+        if (status != MStatus::kSuccess) {
+            TF_WARN("Could not snap selected object.");
+        }
         if (_snapToSelectedObjects != oldSnapToSelectedObjects) {
             _selectionModeChanged = true;
         }


### PR DESCRIPTION
Some error checking logging was confusing for the user. Some failures were reported as the cryptic: "Failed verification: ' result == MStatus::kSuccess '".  This leads users to think we are reporting a success. (Technically we were reporting failure to succeed, but the message was worded confusingly.)

Change those failure verification messages to use explicit warning messages instead. This provides clearer failure diagnostics.