### PR TITLE
Add versioning to tests that use UsdSkelPackedJointAnimation 

### DIFF
--- a/test/lib/mayaUsd/utils/testMaterialCommands.py
+++ b/test/lib/mayaUsd/utils/testMaterialCommands.py
@@ -149,6 +149,8 @@ class testMaterialCommands(unittest.TestCase):
         self.assertEqual(cmds.mayaUsdMaterialBindings("|stage|stageShape,/SkelAnimation1", canAssignMaterialToNodeType=True), False)
         self.assertEqual(cmds.mayaUsdMaterialBindings("|stage|stageShape,/SkelBindingAPI1", canAssignMaterialToNodeType=True), False)
         self.assertEqual(cmds.mayaUsdMaterialBindings("|stage|stageShape,/SkelBlendShape1", canAssignMaterialToNodeType=True), False)
+        if usdVersion <= (0, 23, 8):
+            self.assertEqual(cmds.mayaUsdMaterialBindings("|stage|stageShape,/SkelPackedJointAnimation1", canAssignMaterialToNodeType=True), False)
         self.assertEqual(cmds.mayaUsdMaterialBindings("|stage|stageShape,/SkelRoot1", canAssignMaterialToNodeType=True), False)
         self.assertEqual(cmds.mayaUsdMaterialBindings("|stage|stageShape,/Skeleton1", canAssignMaterialToNodeType=True), False)
 

--- a/test/lib/mayaUsd/utils/testMaterialCommands.py
+++ b/test/lib/mayaUsd/utils/testMaterialCommands.py
@@ -149,7 +149,6 @@ class testMaterialCommands(unittest.TestCase):
         self.assertEqual(cmds.mayaUsdMaterialBindings("|stage|stageShape,/SkelAnimation1", canAssignMaterialToNodeType=True), False)
         self.assertEqual(cmds.mayaUsdMaterialBindings("|stage|stageShape,/SkelBindingAPI1", canAssignMaterialToNodeType=True), False)
         self.assertEqual(cmds.mayaUsdMaterialBindings("|stage|stageShape,/SkelBlendShape1", canAssignMaterialToNodeType=True), False)
-        self.assertEqual(cmds.mayaUsdMaterialBindings("|stage|stageShape,/SkelPackedJointAnimation1", canAssignMaterialToNodeType=True), False)
         self.assertEqual(cmds.mayaUsdMaterialBindings("|stage|stageShape,/SkelRoot1", canAssignMaterialToNodeType=True), False)
         self.assertEqual(cmds.mayaUsdMaterialBindings("|stage|stageShape,/Skeleton1", canAssignMaterialToNodeType=True), False)
 

--- a/test/lib/ufe/testUIIcons.py
+++ b/test/lib/ufe/testUIIcons.py
@@ -115,7 +115,6 @@ class UIIconsTestCase(unittest.TestCase):
             ('NurbsCurves',             'out_USD_UsdGeomCurves.png'),
             ('NurbsPatch',              'out_USD_NurbsPatch.png'),
             ('OpenVDBAsset',            'out_USD_UsdGeomXformable.png'),
-            ('PackedJointAnimation',    'out_USD_SkelAnimation.png'),
             ('PluginLight',             'out_USD_PluginLight.png'),
             ('PluginLightFilter',       'out_USD_LightFilter.png'),
             ('PointInstancer',          'out_USD_PointInstancer.png'),

--- a/test/lib/ufe/testUIIcons.py
+++ b/test/lib/ufe/testUIIcons.py
@@ -146,6 +146,10 @@ class UIIconsTestCase(unittest.TestCase):
                 ('PhysicsScene',            'out_USD_UsdTyped.png'),
                 ('PhysicsSphericalJoint',   'out_USD_UsdTyped.png')
             ])
+        if usdVer <= (0, 23, 8):
+            primTypes.extend([
+                ('PackedJointAnimation',    'out_USD_SkelAnimation.png')
+            ])
 
         # Special case for node types which are in an AL schema.
         # They aren't available when compiling without the AL plugin.

--- a/test/testSamples/material/materialAssignment.usda
+++ b/test/testSamples/material/materialAssignment.usda
@@ -266,10 +266,6 @@ def SkelBlendShape "SkelBlendShape1"
 {
 }
 
-def SkelPackedJointAnimation "SkelPackedJointAnimation1" 
-{
-}
-
 def SkelRoot "SkelRoot1" 
 {
 }

--- a/test/testSamples/material/materialAssignment.usda
+++ b/test/testSamples/material/materialAssignment.usda
@@ -266,6 +266,10 @@ def SkelBlendShape "SkelBlendShape1"
 {
 }
 
+def SkelPackedJointAnimation "SkelPackedJointAnimation1" 
+{
+}
+
 def SkelRoot "SkelRoot1" 
 {
 }


### PR DESCRIPTION
UsdSkelPackedJointAnimation is deprecated and can safely be removed from tests