### PR TITLE
EMSUSD-277 fix lost muted anonymous layers

### DIFF
--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -618,9 +618,9 @@ public:
             restoreSelection();
         }
 
-        // we perfer not holding to pointers needlessly, but we need to hold on to the layer if we
-        // mute it otherwise usd will let go of it and its modifications, and any dirty children
-        // will also be lost
+        // We prefer not holding to pointers needlessly, but we need to hold on
+        // to the muted layer. OpenUSD let go of muted layers, so anonymous
+        // layers and any dirty children would be lost if not explicitly held on.
         addMutedLayer(layer);
         return true;
     }
@@ -640,7 +640,7 @@ public:
             stage->MuteLayer(layer->GetIdentifier());
         }
 
-        // we can release the pointer
+        // We can release the now unmuted layers.
         removeMutedLayer(layer);
         return true;
     }

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -17,6 +17,7 @@
 #include "layerEditorCommand.h"
 
 #include <mayaUsd/ufe/Global.h>
+#include <mayaUsd/utils/layerMuting.h>
 #include <mayaUsd/utils/query.h>
 #include <mayaUsd/utils/utilFileSystem.h>
 
@@ -620,7 +621,7 @@ public:
         // we perfer not holding to pointers needlessly, but we need to hold on to the layer if we
         // mute it otherwise usd will let go of it and its modifications, and any dirty children
         // will also be lost
-        _mutedLayer = layer;
+        addMutedLayer(layer);
         return true;
     }
 
@@ -638,8 +639,9 @@ public:
             saveSelection();
             stage->MuteLayer(layer->GetIdentifier());
         }
+
         // we can release the pointer
-        _mutedLayer = nullptr;
+        removeMutedLayer(layer);
         return true;
     }
 
@@ -683,8 +685,7 @@ private:
         globalSn->replaceWith(UsdUfe::recreateDescendants(_savedSn, path));
     }
 
-    Ufe::Selection         _savedSn;
-    PXR_NS::SdfLayerRefPtr _mutedLayer;
+    Ufe::Selection _savedSn;
 };
 
 // We assume the indexes given to the command are the original indexes

--- a/lib/mayaUsd/utils/layerMuting.h
+++ b/lib/mayaUsd/utils/layerMuting.h
@@ -19,6 +19,7 @@
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
 
+#include <pxr/usd/sdf/layer.h>
 #include <pxr/usd/usd/stage.h>
 
 namespace MAYAUSD_NS_DEF {
@@ -46,6 +47,29 @@ copyLayerMutingToAttribute(const PXR_NS::UsdStage& stage, MayaUsdProxyShapeBase&
 MAYAUSD_CORE_PUBLIC
 MStatus
 copyLayerMutingFromAttribute(const MayaUsdProxyShapeBase& proxyShape, PXR_NS::UsdStage& stage);
+
+// OpenUSD forget everything about muted layers. The OpenUSD documentation for
+// the MuteLayer function says:
+//
+//    Note that muting a layer will cause this stage to release all references
+//    to that layer. If no other client is holding on to references to that
+//    layer, it will be unloaded.In this case, if there are unsaved edits to
+//    the muted layer, those edits are lost.
+//
+//    Since anonymous layers are not serialized, muting an anonymous layer will
+//    cause that layer and its contents to be lost in this case.
+//
+// So we need to hold on to muted layers. We do this in a private global list
+// of muted layers. That list gets cleared when a new Maya scene is created.
+
+MAYAUSD_CORE_PUBLIC
+void addMutedLayer(const PXR_NS::SdfLayerRefPtr& layer);
+
+MAYAUSD_CORE_PUBLIC
+void removeMutedLayer(const PXR_NS::SdfLayerRefPtr& layer);
+
+MAYAUSD_CORE_PUBLIC
+void forgetMutedLayers();
 
 } // namespace MAYAUSD_NS_DEF
 

--- a/test/lib/mayaUsd/fileio/testAddMayaReference.py
+++ b/test/lib/mayaUsd/fileio/testAddMayaReference.py
@@ -23,9 +23,10 @@ import mayaUtils
 import ufeUtils
 import usdUtils
 
-from pxr import Tf, Usd, Kind
+from pxr import Tf, Usd, Kind, Sdf
 
 from maya import cmds
+import maya.mel as mel
 from maya import standalone
 from maya.api import OpenMaya as om
 
@@ -286,6 +287,66 @@ class AddMayaReferenceTestCase(unittest.TestCase):
         # This functionality requires the orphaned nodes manager.
         if os.getenv('HAS_ORPHANED_NODES_MANAGER', '0') >= '1':
             self.assertTrue(mayaRefPrim.IsActive())
+
+
+    def testEditAndDiscardMayaRefWithMutedLayer(self):
+        '''
+        Test editing then discarding a Maya Reference when an anonymous
+        has been muted does not lose the muted layer.
+
+        Add a Maya Reference using auto-edit, create a new layer, mute it,
+        then discard the edits. Verify the muted layer still exists.
+        '''
+        kDefaultPrimName = mayaRefUtils.defaultMayaReferencePrimName()
+
+        # Create a new layer, and mute it. Make sure not to keep a reference
+        # to it to verify it does not get lost later. Use the layer editor
+        # command to mute it, as it is the one responsible to hold onto the
+        # anonymous layer.
+        anonLayer = usdUtils.addNewLayerToStage(self.stage, anonymous=True)
+        anonLayerId = anonLayer.identifier
+        mel.eval('mayaUsdLayerEditor -edit -muteLayer 1 "%s" "%s"' % (self.proxyShapePathStr, anonLayerId))
+        anonLayer = None
+
+        # Since this is a brand new prim, it should not have variant sets.
+        primTestDefault = self.stage.DefinePrim('/Test_Default', 'Xform')
+        primPathStr = self.proxyShapePathStr + ',/Test_Default'
+        self.assertFalse(primTestDefault.HasVariantSets())
+
+        mayaRefPrim = mayaUsdAddMayaReference.createMayaReferencePrim(
+            primPathStr,
+            self.mayaSceneStr,
+            self.kDefaultNamespace,
+            mayaAutoEdit=True)
+
+        # The prim should not have any variant set.
+        self.assertFalse(primTestDefault.HasVariantSets())
+
+        # Verify that a Maya Reference prim was created.
+        self.assertTrue(mayaRefPrim.IsValid())
+        self.assertEqual(str(mayaRefPrim.GetName()), kDefaultPrimName)
+        self.assertEqual(mayaRefPrim, primTestDefault.GetChild(kDefaultPrimName))
+        self.assertTrue(mayaRefPrim.GetPrimTypeInfo().GetTypeName(), 'MayaReference')
+
+        attr = mayaRefPrim.GetAttribute('mayaAutoEdit')
+        self.assertTrue(attr.IsValid())
+        self.assertEqual(attr.Get(), True)
+
+        # Discard Maya edits.
+        aMayaItem = ufe.GlobalSelection.get().front()
+        aMayaPath = aMayaItem.path()
+        aMayaPathStr = ufe.PathString.string(aMayaPath)
+        with mayaUsd.lib.OpUndoItemList():
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.discardEdits(aMayaPathStr))
+        
+        # Verify that the auto-edit has been turned off
+        attr = mayaRefPrim.GetAttribute('mayaAutoEdit')
+        self.assertTrue(attr.IsValid())
+        self.assertEqual(attr.Get(), False)
+
+        # Verify that the muted layer stil exists.
+        layerIdentifiers = [layer.identifier for layer in Sdf.Layer.GetLoadedLayers()]
+        self.assertIn(anonLayerId, layerIdentifiers)
 
 
     def testEditAndMergeMayaRef(self):

--- a/test/testUtils/usdUtils.py
+++ b/test/testUtils/usdUtils.py
@@ -210,7 +210,46 @@ def createDuoXformScene():
             aXlateOp, aXlation, aUsdUfePathStr, aUsdUfePath, aUsdItem,
             bXlateOp, bXlation, bUsdUfePathStr, bUsdUfePath, bUsdItem)
 
-def createLayeredStage(layersCount = 3):
+def addNewLayersToLayer(parentLayer, layersCount=1, anonymous=False):
+    '''
+    Create multiple new layers under the given layer.
+    Return the list of new layers.
+    '''
+    createdLayers = []
+    for i in range(layersCount):
+        if anonymous:
+            newLayer = Sdf.Layer.CreateAnonymous()
+        else:
+            newLayerName = 'Layer_%d' % (i+1)
+            usdFormat = Sdf.FileFormat.FindByExtension('usd')
+            newLayer = Sdf.Layer.New(usdFormat, newLayerName)
+        parentLayer.subLayerPaths.append(newLayer.identifier)
+        createdLayers.append(newLayer)
+        parentLayer = newLayer
+    return createdLayers
+
+def addNewLayerToLayer(parentLayer, anonymous=False):
+    '''
+    Create a new layer under the given layer.
+    Return the new layer.
+    '''
+    return addNewLayersToLayer(parentLayer, 1, anonymous)[0]
+
+def addNewLayersToStage(stage, layersCount=1, anonymous=False):
+    '''
+    Create multiple new layers under the root layer of a stage.
+    Return the list of new layers.
+    '''
+    return addNewLayersToLayer(stage.GetRootLayer(), layersCount, anonymous)
+
+def addNewLayerToStage(stage, anonymous=False):
+    '''
+    Create a new layer under the root layer of a stage.
+    Return the new layer.
+    '''
+    return addNewLayersToStage(stage, 1, anonymous)[0]
+
+def createLayeredStage(layersCount = 3, anonymous=False):
     '''Create a stage with multiple layers, by default 3 extra layers:
 
     Returns a tuple of:
@@ -222,15 +261,8 @@ def createLayeredStage(layersCount = 3):
     (psPathStr, psPath, ps) = createSimpleStage()
 
     stage = mayaUsd.lib.GetPrim(psPathStr).GetStage()
-    layer = stage.GetRootLayer()
-    layers = [layer]
-    for i in range(layersCount):
-        newLayerName = 'Layer_%d' % (i+1)
-        usdFormat = Sdf.FileFormat.FindByExtension('usd')
-        newLayer = Sdf.Layer.New(usdFormat, newLayerName)
-        layer.subLayerPaths.append(newLayer.identifier)
-        layer = newLayer
-        layers.append(layer)
+    rootLayer = stage.GetRootLayer()
+    layers = [rootLayer] + addNewLayersToLayer(rootLayer, layersCount, anonymous)
 
     return (psPathStr, psPath, ps, layers)
 


### PR DESCRIPTION
- Add a global functionality to hold onto muted layers.
- This is to work around the fact that OpenUSD will not keep muted layers in memory.
- Make sure to clean up the list of muted layers when a new Maya scene is created.
- Use the muted layer holder in the MuteLayer command.
- The base class of the command was trying to hold onto layer, but when the undo stack is cleared, so would be the anonymous layers.
- In particular, when unloading a Maya Reference, Maya always clears the undo stack.
- Add a test that check if muted anonymous layers are lost when editing a Maya Reference.
- The test fails without my fix, works with it.
- Improved test helper functions to enable creating anonymous sub-layers.