### PR TITLE
EMSUSD-612 - Update topo node list

### DIFF
--- a/test/testSamples/MaterialX/ShadedPyramid.usda
+++ b/test/testSamples/MaterialX/ShadedPyramid.usda
@@ -71,10 +71,17 @@ def Mesh "pPyramid1" (
                 {
                     uniform token info:id = "ND_standard_surface_surfaceshader"
                     float inputs:base = 1
-                    color3f inputs:base_color = (0, 1, 0)
+                    color3f inputs:base_color.connect = </pPyramid1/mtl/standardSurface2SG/MaterialX/red.outputs:out>
                     float inputs:specular = 1
                     float inputs:specular_roughness = 0.2
                     token outputs:out
+                }
+
+                def Shader "red"
+                {
+                    uniform token info:id = "ND_dot_color3"
+                    color3f inputs:in = (0, 1, 0)
+                    color3f outputs:out
                 }
             }
         }


### PR DESCRIPTION
The MaterialX topological node list was in need of an update:

For MaterialX 1.38.7:

"dot" nodes are now topological.
    Via https://github.com/AcademySoftwareFoundation/MaterialX/pull/1152

For upcoming MaterialX 1.38.8:

"dot" node no longer elided (except for filenames) "switch" node no longer elided
    Via https://github.com/AcademySoftwareFoundation/MaterialX/pull/1522