### PR TITLE
HYDRA-496: Fix for crash on new scene with a USD Stage inside the Maya scene

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeStageExtraData.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeStageExtraData.cpp
@@ -94,7 +94,7 @@ MStatus MayaUsdProxyShapeStageExtraData::finalize()
     return status;
 }
 
-bool MayaUsdProxyShapeStageExtraData::containsProxyShapeData(MayaUsdProxyShapeBase& proxyShape)
+bool MayaUsdProxyShapeStageExtraData::containsProxyShape(MayaUsdProxyShapeBase& proxyShape)
 {
     auto it = getTrackedProxyShapes().find(&proxyShape);
     return it != getTrackedProxyShapes().end() ? true : false;

--- a/lib/mayaUsd/nodes/proxyShapeStageExtraData.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeStageExtraData.cpp
@@ -97,7 +97,7 @@ MStatus MayaUsdProxyShapeStageExtraData::finalize()
 bool MayaUsdProxyShapeStageExtraData::containsProxyShape(MayaUsdProxyShapeBase& proxyShape)
 {
     auto it = getTrackedProxyShapes().find(&proxyShape);
-    return it != getTrackedProxyShapes().end() ? true : false;
+    return it != getTrackedProxyShapes().end();
 }
 
 /* static */

--- a/lib/mayaUsd/nodes/proxyShapeStageExtraData.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeStageExtraData.cpp
@@ -94,6 +94,7 @@ MStatus MayaUsdProxyShapeStageExtraData::finalize()
     return status;
 }
 
+/* static */
 bool MayaUsdProxyShapeStageExtraData::containsProxyShape(MayaUsdProxyShapeBase& proxyShape)
 {
     auto it = getTrackedProxyShapes().find(&proxyShape);

--- a/lib/mayaUsd/nodes/proxyShapeStageExtraData.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeStageExtraData.cpp
@@ -94,6 +94,11 @@ MStatus MayaUsdProxyShapeStageExtraData::finalize()
     return status;
 }
 
+bool MayaUsdProxyShapeStageExtraData::containsProxyShapeData(MayaUsdProxyShapeBase& proxyShape)
+{
+    return getTrackedProxyShapes().count(&proxyShape) ? true : false;
+}
+
 /* static */
 void MayaUsdProxyShapeStageExtraData::addProxyShape(MayaUsdProxyShapeBase& proxyShape)
 {

--- a/lib/mayaUsd/nodes/proxyShapeStageExtraData.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeStageExtraData.cpp
@@ -96,7 +96,8 @@ MStatus MayaUsdProxyShapeStageExtraData::finalize()
 
 bool MayaUsdProxyShapeStageExtraData::containsProxyShapeData(MayaUsdProxyShapeBase& proxyShape)
 {
-    return getTrackedProxyShapes().count(&proxyShape) ? true : false;
+    auto it = getTrackedProxyShapes().find(&proxyShape);
+    return it != getTrackedProxyShapes().end() ? true : false;
 }
 
 /* static */

--- a/lib/mayaUsd/nodes/proxyShapeStageExtraData.h
+++ b/lib/mayaUsd/nodes/proxyShapeStageExtraData.h
@@ -60,6 +60,7 @@ public:
     MAYAUSD_CORE_PUBLIC
     static void saveAllStageData();
 
+    /// \brief verify if the proxyshape requested is still valid
     MAYAUSD_CORE_PUBLIC
     static bool containsProxyShape(MayaUsdProxyShapeBase& proxyShape);
 

--- a/lib/mayaUsd/nodes/proxyShapeStageExtraData.h
+++ b/lib/mayaUsd/nodes/proxyShapeStageExtraData.h
@@ -60,6 +60,9 @@ public:
     MAYAUSD_CORE_PUBLIC
     static void saveAllStageData();
 
+    MAYAUSD_CORE_PUBLIC
+    static bool containsProxyShapeData(MayaUsdProxyShapeBase& proxyShape);
+
     /// \brief save load rules of tracked proxy shapes.
     MAYAUSD_CORE_PUBLIC
     static void saveAllLoadRules();

--- a/lib/mayaUsd/nodes/proxyShapeStageExtraData.h
+++ b/lib/mayaUsd/nodes/proxyShapeStageExtraData.h
@@ -61,7 +61,7 @@ public:
     static void saveAllStageData();
 
     MAYAUSD_CORE_PUBLIC
-    static bool containsProxyShapeData(MayaUsdProxyShapeBase& proxyShape);
+    static bool containsProxyShape(MayaUsdProxyShapeBase& proxyShape);
 
     /// \brief save load rules of tracked proxy shapes.
     MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
+++ b/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
@@ -18,9 +18,9 @@
 
 #if PXR_VERSION >= 2211
 
+#include <mayaUsd/nodes/proxyShapeStageExtraData.h>
 #include <mayaUsd/ufe/Global.h>
 #include <mayaUsd/ufe/Utils.h>
-#include <mayaUsd/nodes/proxyShapeStageExtraData.h>
 
 #include <usdUfe/ufe/Utils.h>
 
@@ -192,7 +192,7 @@ HdSceneIndexBaseRefPtr MayaUsdProxyShapeMayaNodeSceneIndexPlugin::_AppendSceneIn
             sceneIndex = HdFlatteningSceneIndex::New(sceneIndex, flatteningInputArgs);
             sceneIndex = UsdImagingDrawModeSceneIndex::New(sceneIndex, /* inputArgs = */ nullptr);
 #else
-            //#For USD 23.08 and later, HD_API_VERSION=54 in USD 23.08
+            // #For USD 23.08 and later, HD_API_VERSION=54 in USD 23.08
             static const bool _displayUnloadedPrimsWithBounds = true;
 
             HdContainerDataSourceHandle const stageInputArgs = HdRetainedContainerDataSource::New(

--- a/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
+++ b/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
@@ -314,7 +314,7 @@ void MayaUsdProxyShapeSceneIndex::onTimeChanged(void* data)
 
 bool MayaUsdProxyShapeSceneIndex::isProxyShapeValid()
 {
-    return MayaUsdProxyShapeStageExtraData::containsProxyShapeData(*_proxyShape);
+    return MayaUsdProxyShapeStageExtraData::containsProxyShape(*_proxyShape);
 }
 
 void MayaUsdProxyShapeSceneIndex::UpdateTime()

--- a/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
+++ b/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
@@ -20,6 +20,7 @@
 
 #include <mayaUsd/ufe/Global.h>
 #include <mayaUsd/ufe/Utils.h>
+#include <mayaUsd/nodes/proxyShapeStageExtraData.h>
 
 #include <usdUfe/ufe/Utils.h>
 
@@ -311,9 +312,14 @@ void MayaUsdProxyShapeSceneIndex::onTimeChanged(void* data)
     instance->UpdateTime();
 }
 
+bool MayaUsdProxyShapeSceneIndex::isProxyShapeValid()
+{
+    return MayaUsdProxyShapeStageExtraData::containsProxyShapeData(*_proxyShape);
+}
+
 void MayaUsdProxyShapeSceneIndex::UpdateTime()
 {
-    if (_usdImagingStageSceneIndex && _proxyShape) {
+    if (_usdImagingStageSceneIndex && _proxyShape && isProxyShapeValid()) {
         _usdImagingStageSceneIndex->SetTime(_proxyShape->getTime());
     }
 }

--- a/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.h
+++ b/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.h
@@ -101,6 +101,7 @@ private:
     void StageSet(const MayaUsdProxyStageSetNotice& notice);
 
     bool isProxyShapeValid();
+
     void Populate();
 
 protected:

--- a/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.h
+++ b/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.h
@@ -100,6 +100,7 @@ private:
 
     void StageSet(const MayaUsdProxyStageSetNotice& notice);
 
+    bool isProxyShapeValid();
     void Populate();
 
 protected:


### PR DESCRIPTION
Maya crashes when the MayaUsdProxyShapeSceneIndex tries to access MayaUsdProxyShape which is no longer valid.  This event happens for example in the case seen here in the reivew code to set time on the USD Stage. In this situation a Maya callback registered for "timechanged" event was also triggered on "New Scene" event but the USD and Hydra resources were deleted by then on which the callback tried to set the time and hence the crash.

The fix involves adding new API to MayaUsdProxyShapeStageExtraData which is a container of sorts for MayaUsdProxyShapeBase. The API allows to check if the proxy shape requested is valid.