### PR TITLE
LOOKDEVX-1912 - Append 1 to new prim name only if not ending with digit.

### DIFF
--- a/lib/usdUfe/ufe/UsdUndoAddNewPrimCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoAddNewPrimCommand.cpp
@@ -58,8 +58,14 @@ UsdUndoAddNewPrimCommand::UsdUndoAddNewPrimCommand(
     auto dagSegment = segments[0];
     _stage = usdSceneItem->prim().GetStage();
     if (_stage) {
+
+        std::string base, suffixStr;
+
         // Append the parent path and the requested name into a full ufe path.
-        _newUfePath = appendToPath(ufePath, name + '1');
+        // Append a '1' to new primitives names if the name does not end with a digit.
+        _newUfePath = splitNumericalSuffix(name, base, suffixStr)
+            ? appendToPath(ufePath, name)
+            : appendToPath(ufePath, name + '1');
 
         // Ensure the requested name is unique.
         auto newPrimName

--- a/test/lib/ufe/testContextOps.py
+++ b/test/lib/ufe/testContextOps.py
@@ -1141,7 +1141,7 @@ class ContextOpsTestCase(unittest.TestCase):
 
         self.assertTrue(shaderAttrs.hasAttribute("info:id"))
         self.assertEqual(shaderAttrs.attribute("info:id").get(), shaderName)
-        self.assertEqual(ufe.PathString.string(shaderItem.path()), "|stage1|stageShape1,/Material1/Red11")
+        self.assertEqual(ufe.PathString.string(shaderItem.path()), "|stage1|stageShape1,/Material1/Red1")
         materialHier = ufe.Hierarchy.hierarchy(materialItem)
         self.assertTrue(materialHier.hasChildren())
 


### PR DESCRIPTION
This PR is part of JIRA ticket [LOOKDEVX-1912](https://jira.autodesk.com/browse/LOOKDEVX-1912): we append a '1' to new primitives names if the name does not end with a digit.