### PR TITLE
EMSUSD-623 use project folder by default

### DIFF
--- a/lib/mayaUsd/utils/utilFileSystem.cpp
+++ b/lib/mayaUsd/utils/utilFileSystem.cpp
@@ -302,7 +302,13 @@ bool UsdMayaUtilFileSystem::prepareLayerSaveUILayer(const std::string& relativeA
     const char* script = "import mayaUsd_USDRootFileRelative as murel\n"
                          "murel.usdFileRelative.setRelativeFilePathRoot(r'''%s''')";
 
-    const std::string commandString = TfStringPrintf(script, relativeAnchor.c_str());
+    std::string anchor = relativeAnchor;
+    if (anchor.empty()) {
+        anchor = UsdMayaUtil::GetCurrentMayaWorkspacePath().asChar();
+        anchor = ghc::filesystem::path(anchor).string();
+    }
+
+    const std::string commandString = TfStringPrintf(script, anchor.c_str());
     return MGlobal::executePythonCommand(commandString.c_str());
 }
 

--- a/lib/usd/ui/layerEditor/loadLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/loadLayersDialog.cpp
@@ -24,6 +24,7 @@
 #include "qtUtils.h"
 #include "stringResources.h"
 
+#include <mayaUsd/utils/util.h>
 #include <mayaUsd/utils/utilFileSystem.h>
 
 #include <maya/MQtUtil.h>
@@ -273,6 +274,10 @@ std::string LoadLayersDialog::findDirectoryToUse(const std::string& rowText) con
             }
             item = item->parentLayerItem();
         }
+    }
+
+    if (path.empty()) {
+        path = UsdMayaUtil::GetCurrentMayaWorkspacePath().asChar();
     }
 
     if (!path.empty()) {


### PR DESCRIPTION
When no parent layer exists, use the project folder by default instead of the current directory.