### PR TITLE
EMSUSD-623 edit as Maya multiple variants

### DIFF
--- a/lib/mayaUsd/fileio/orphanedNodesManager.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.cpp
@@ -20,6 +20,7 @@
 #include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/ufe/Global.h>
 #include <mayaUsd/ufe/Utils.h>
+#include <mayaUsd/utils/variants.h>
 
 #include <usdUfe/ufe/UsdSceneItem.h>
 
@@ -27,6 +28,7 @@
 #include <pxr/usd/usd/editContext.h>
 
 #include <maya/MFnDagNode.h>
+#include <maya/MGlobal.h>
 #include <maya/MPlug.h>
 #include <ufe/hierarchy.h>
 #include <ufe/sceneSegmentHandler.h>
@@ -62,7 +64,7 @@ OrphanedNodesManager::Memento& OrphanedNodesManager::Memento::operator=(Memento&
     return *this;
 }
 
-Ufe::Trie<OrphanedNodesManager::PullVariantInfo> OrphanedNodesManager::Memento::release()
+OrphanedNodesManager::PulledPrims OrphanedNodesManager::Memento::release()
 {
     return std::move(_pulledPrims);
 }
@@ -74,10 +76,11 @@ Ufe::Trie<OrphanedNodesManager::PullVariantInfo> OrphanedNodesManager::Memento::
 namespace {
 
 using PullVariantInfo = OrphanedNodesManager::PullVariantInfo;
+using PullVariantInfos = OrphanedNodesManager::PullVariantInfos;
 using VariantSetDescriptor = OrphanedNodesManager::VariantSetDescriptor;
 using VariantSelection = OrphanedNodesManager::VariantSelection;
 using PulledPrims = OrphanedNodesManager::PulledPrims;
-using PulledPrimNode = Ufe::TrieNode<PullVariantInfo>;
+using PulledPrimNode = OrphanedNodesManager::PulledPrimNode;
 
 Ufe::PathSegment::Components trieNodeToPathComponents(PulledPrimNode::Ptr trieNode);
 Ufe::Path                    trieNodeToPulledPrimUfePath(PulledPrimNode::Ptr trieNode);
@@ -102,11 +105,13 @@ void renameVariantInfo(
 {
     // Note: TrieNode has no non-const data() function, so to modify the
     //       data we must make a copy, modify the copy and call setData().
-    PullVariantInfo newVariantInfo = trieNode->data();
+    PullVariantInfos newVariantInfos = trieNode->data();
 
-    renameVariantDescriptors(newVariantInfo.variantSetDescriptors, oldPath, newPath);
+    for (auto& info : newVariantInfos) {
+        renameVariantDescriptors(info.variantSetDescriptors, oldPath, newPath);
+    }
 
-    trieNode->setData(newVariantInfo);
+    trieNode->setData(newVariantInfos);
 }
 
 void renamePullInformation(
@@ -141,8 +146,10 @@ void renamePullInformation(
         }
     }
 
-    const MDagPath& mayaPath = trieNode->data().editedAsMayaRoot;
-    TF_VERIFY(writePullInformation(pulledPath, mayaPath));
+    for (const PullVariantInfo& info : trieNode->data()) {
+        const MDagPath& mayaPath = info.editedAsMayaRoot;
+        TF_VERIFY(writePullInformation(pulledPath, mayaPath));
+    }
 }
 
 void recursiveRename(
@@ -206,21 +213,49 @@ OrphanedNodesManager::OrphanedNodesManager()
 {
 }
 
+bool OrphanedNodesManager::has(const Ufe::Path& pulledPath, const MDagPath& editedAsMayaRoot) const
+{
+    PulledPrimNode::Ptr node = _pulledPrims.find(pulledPath);
+    if (!node)
+        return false;
+
+    const PullVariantInfos& infos = node->data();
+    for (const PullVariantInfo& info : infos)
+        if (info.editedAsMayaRoot == editedAsMayaRoot)
+            return true;
+
+    return false;
+}
+
+bool OrphanedNodesManager::has(const Ufe::Path& pulledPath) const
+{
+    PulledPrimNode::Ptr node = _pulledPrims.find(pulledPath);
+    if (!node)
+        return false;
+
+    // We store a list of (path, list of (variant set, variant set selection)),
+    // for all ancestors, starting at closest ancestor.
+    auto ancestorPath = pulledPath.pop();
+    auto vsd = variantSetDescriptors(ancestorPath);
+
+    const PullVariantInfos& infos = node->data();
+    for (const PullVariantInfo& info : infos)
+        if (info.variantSetDescriptors == vsd)
+            return true;
+
+    return false;
+}
+
 void OrphanedNodesManager::add(const Ufe::Path& pulledPath, const MDagPath& editedAsMayaRoot)
 {
     // Adding a node twice to the orphan manager is idem-potent. The manager was already
-    // racking that node.
-    if (_pulledPrims.containsDescendantInclusive(pulledPath))
+    // tracking that node.
+    if (_pulledPrims.containsDescendant(pulledPath))
         return;
 
-    // Add the edited-as-Maya root to our pulled prims prefix tree.  Also add the full
-    // configuration of variant set selections for each ancestor, up to the USD
-    // pseudo-root.  Variants on the pulled path itself are ignored, as once
-    // pulled into Maya they cannot be changed.
-    if (_pulledPrims.containsDescendantInclusive(pulledPath)) {
-        TF_WARN("Trying to edit-as-Maya a descendant of an already edited prim.");
+    if (has(pulledPath, editedAsMayaRoot))
         return;
-    }
+
     if (pulledPath.runTimeId() != MayaUsd::ufe::getUsdRunTimeId()) {
         TF_WARN("Trying to monitor a non-USD node for edit-as-Maya orphaning.");
         return;
@@ -231,25 +266,36 @@ void OrphanedNodesManager::add(const Ufe::Path& pulledPath, const MDagPath& edit
     auto ancestorPath = pulledPath.pop();
     auto vsd = variantSetDescriptors(ancestorPath);
 
-    _pulledPrims.add(pulledPath, PullVariantInfo(editedAsMayaRoot, vsd));
-}
-
-OrphanedNodesManager::Memento OrphanedNodesManager::remove(const Ufe::Path& pulledPath)
-{
-    Memento oldPulledPrims(preserve());
-    TF_VERIFY(_pulledPrims.remove(pulledPath) != nullptr);
-    return oldPulledPrims;
-}
-
-const PullVariantInfo& OrphanedNodesManager::get(const Ufe::Path& pulledPath) const
-{
-    const auto infoNode = _pulledPrims.find(pulledPath);
-    if (!infoNode || !infoNode->hasData()) {
-        static const PullVariantInfo empty;
-        return empty;
+    PulledPrimNode::Ptr node = _pulledPrims.find(pulledPath);
+    if (node) {
+        PullVariantInfos infos = node->data();
+        infos.emplace_back(PullVariantInfo(editedAsMayaRoot, vsd));
+        node->setData(infos);
+    } else {
+        _pulledPrims.add(pulledPath, { PullVariantInfo(editedAsMayaRoot, vsd) });
     }
+}
 
-    return infoNode->data();
+OrphanedNodesManager::Memento
+OrphanedNodesManager::remove(const Ufe::Path& pulledPath, const MDagPath& editedAsMayaRoot)
+{
+    Memento             oldPulledPrims(preserve());
+    PulledPrimNode::Ptr node = _pulledPrims.find(pulledPath);
+    if (node) {
+        PullVariantInfos infos = node->data();
+        for (size_t i = infos.size() - 1; i != size_t(0) - size_t(1); --i) {
+            if (infos[i].editedAsMayaRoot == editedAsMayaRoot) {
+                infos.erase(infos.begin() + i);
+            }
+        }
+
+        if (infos.size() > 0) {
+            node->setData(infos);
+        } else {
+            _pulledPrims.remove(pulledPath);
+        }
+    }
+    return oldPulledPrims;
 }
 
 void OrphanedNodesManager::operator()(const Ufe::Notification& n)
@@ -345,62 +391,53 @@ void OrphanedNodesManager::handleOp(const Ufe::SceneCompositeNotification::Op& o
             return;
         }
 
-        auto parentHier = Ufe::Hierarchy::hierarchy(parentItem);
-        if (!parentHier->hasChildren()) {
+        // USD sends resync changes (UFE subtree invalidate) on the
+        // pseudo-root itself.  Since the pseudo-root has no payload or
+        // variant, ignore these.
+        auto parentUsdItem = std::dynamic_pointer_cast<UsdUfe::UsdSceneItem>(parentItem);
+        if (!parentUsdItem) {
+            return;
+        }
+
+        // On variant switch, given a pulled prim, the session layer will
+        // have path-based USD overs for pull information and active
+        // (false) for that prim in the session layer.  If a prim child
+        // brought in by variant switching has the same name as that of the
+        // pulled prim in a previous variant, the overs will apply to to
+        // the new prim, which would then get a path mapping, which is
+        // inappropriate.  Read children using the USD API, including
+        // inactive children (since pulled prims are inactivated), to
+        // support a variant switch to variant child with the same name.
+        auto parentPrim = parentUsdItem->prim();
+        bool foundChild { false };
+        for (const auto& child :
+                parentPrim.GetFilteredChildren(UsdPrimIsDefined && !UsdPrimIsAbstract)) {
+            auto childPath = parentItem->path().popSegment();
+            childPath
+                = childPath
+                + Ufe::PathSegment(
+                        child.GetPath().GetAsString(), MayaUsd::ufe::getUsdRunTimeId(), '/');
+
+            auto ancestorNode = _pulledPrims.node(childPath);
+            // If there is no ancestor node in the trie, this means that
+            // the new hierarchy is completely different from the one when
+            // the pull occurred, which means that the pulled object must
+            // stay hidden.
+            if (!ancestorNode)
+                continue;
+
+            foundChild = true;
+            recursiveSwitch(ancestorNode, childPath);
+        }
+
+        // Following a subtree invalidate, if none of the now-valid
+        // children appear in the trie, means that we've switched to a
+        // different variant or it was a payload that got unloaded,
+        // so everything below that path should be hidden.
+        if (!foundChild) {
             auto ancestorNode = _pulledPrims.node(op.path);
             if (ancestorNode) {
                 recursiveSetOrphaned(ancestorNode, true);
-            }
-            return;
-        } else {
-            // On variant switch, given a pulled prim, the session layer will
-            // have path-based USD overs for pull information and active
-            // (false) for that prim in the session layer.  If a prim child
-            // brought in by variant switching has the same name as that of the
-            // pulled prim in a previous variant, the overs will apply to to
-            // the new prim, which would then get a path mapping, which is
-            // inappropriate.  Read children using the USD API, including
-            // inactive children (since pulled prims are inactivated), to
-            // support a variant switch to variant child with the same name.
-
-            auto parentUsdItem = std::dynamic_pointer_cast<UsdUfe::UsdSceneItem>(parentItem);
-            if (!parentUsdItem) {
-                // USD sends resync changes (UFE subtree invalidate) on the
-                // pseudo-root itself.  Since the pseudo-root has no payload or
-                // variant, ignore these.
-                TF_VERIFY(parentItem->path().nbSegments() == 1);
-                return;
-            }
-            auto parentPrim = parentUsdItem->prim();
-            bool foundChild { false };
-            for (const auto& child :
-                 parentPrim.GetFilteredChildren(UsdPrimIsDefined && !UsdPrimIsAbstract)) {
-                auto childPath = parentItem->path().popSegment();
-                childPath
-                    = childPath
-                    + Ufe::PathSegment(
-                          child.GetPath().GetAsString(), MayaUsd::ufe::getUsdRunTimeId(), '/');
-
-                auto ancestorNode = _pulledPrims.node(childPath);
-                // If there is no ancestor node in the trie, this means that
-                // the new hierarchy is completely different from the one when
-                // the pull occurred, which means that the pulled object must
-                // stay hidden.
-                if (!ancestorNode)
-                    continue;
-
-                foundChild = true;
-                recursiveSwitch(ancestorNode, childPath);
-            }
-            if (!foundChild) {
-                // Following a subtree invalidate, if none of the now-valid
-                // children appear in the trie, means that we've switched to a
-                // different variant, and everything below that path should be
-                // hidden.
-                auto ancestorNode = _pulledPrims.node(op.path);
-                if (ancestorNode) {
-                    recursiveSetOrphaned(ancestorNode, true);
-                }
             }
         }
     } break;
@@ -429,7 +466,8 @@ OrphanedNodesManager::Memento OrphanedNodesManager::preserve() const
 
 void OrphanedNodesManager::restore(Memento&& previous) { _pulledPrims = previous.release(); }
 
-bool OrphanedNodesManager::isOrphaned(const Ufe::Path& pulledPath) const
+bool OrphanedNodesManager::isOrphaned(const Ufe::Path& pulledPath, const MDagPath& editedAsMayaRoot)
+    const
 {
     auto trieNode = _pulledPrims.node(pulledPath);
     if (!trieNode) {
@@ -442,15 +480,29 @@ bool OrphanedNodesManager::isOrphaned(const Ufe::Path& pulledPath) const
         return false;
     }
 
-    const PullVariantInfo& variantInfo = trieNode->data();
+    const std::vector<PullVariantInfo>& variantInfos = trieNode->data();
 
-    // If the pull parent is visible, the pulled path is not orphaned.
-    MDagPath pullParentPath = variantInfo.editedAsMayaRoot;
-    pullParentPath.pop();
+    for (const PullVariantInfo& variantInfo : variantInfos) {
 
-    MFnDagNode fn(pullParentPath);
-    auto       visibilityPlug = fn.findPlug("visibility", /* tryNetworked */ true);
-    return !visibilityPlug.asBool();
+        if (!(variantInfo.editedAsMayaRoot == editedAsMayaRoot)) {
+            // TODO DEBUG REMOVE
+            TF_STATUS(
+                "Recorded Maya root does not match: %s 1= %s",
+                variantInfo.editedAsMayaRoot.fullPathName().asChar(),
+                editedAsMayaRoot.fullPathName().asChar());
+            continue;
+        }
+
+        // If the pull parent is visible, the pulled path is not orphaned.
+        MDagPath pullParentPath = editedAsMayaRoot;
+        pullParentPath.pop();
+
+        MFnDagNode fn(pullParentPath);
+        auto       visibilityPlug = fn.findPlug("visibility", /* tryNetworked */ true);
+        return !visibilityPlug.asBool();
+    }
+
+    return false;
 }
 
 namespace {
@@ -525,10 +577,21 @@ MStatus setNodeVisibility(const MDagPath& dagPath, bool visibility)
 /* static */
 bool OrphanedNodesManager::setOrphaned(const PulledPrimNode::Ptr& trieNode, bool orphaned)
 {
-    TF_VERIFY(trieNode->hasData());
+    if (!trieNode->hasData())
+        return true;
 
-    const PullVariantInfo& variantInfo = trieNode->data();
+    for (const PullVariantInfo& variantInfo : trieNode->data())
+        setOrphaned(trieNode, variantInfo, orphaned);
 
+    return true;
+}
+
+/* static */
+bool OrphanedNodesManager::setOrphaned(
+    const PulledPrimNode::Ptr& trieNode,
+    const PullVariantInfo&     variantInfo,
+    bool                       orphaned)
+{
     // Note: the change to USD data must be done *after* changes to Maya data because
     //       the outliner reacts to UFE notifications received following the USD edits
     //       to rebuild the node tree and the Maya node we want to hide must have been
@@ -537,23 +600,56 @@ bool OrphanedNodesManager::setOrphaned(const PulledPrimNode::Ptr& trieNode, bool
     pullParentPath.pop();
     CHECK_MSTATUS_AND_RETURN(setNodeVisibility(pullParentPath, !orphaned), false);
 
-    const Ufe::Path pulledPrimPath = trieNodeToPulledPrimUfePath(trieNode);
-
     // Note: if we are called due to the user deleting the stage, then the pulled prim
     //       path will be invalid and trying to add or remove information on it will
     //       fail, and cause spurious warnings in the script editor, so avoid it.
-    if (!pulledPrimPath.empty()) {
-        if (orphaned) {
-            removePulledPrimMetadata(pulledPrimPath);
-            removeExcludeFromRendering(pulledPrimPath);
-        } else {
-            writePulledPrimMetadata(pulledPrimPath, variantInfo.editedAsMayaRoot);
-            addExcludeFromRendering(pulledPrimPath);
+    const Ufe::Path pulledPrimPath = trieNodeToPulledPrimUfePath(trieNode);
+    if (pulledPrimPath.empty())
+        return true;
+
+    // Note: if we are called due to the user deleting the stage, then the stage
+    //       will be invalid, don't treat this as an error.
+    UsdStagePtr stage = getStage(pulledPrimPath);
+    if (!stage)
+        return true;
+
+    const PXR_NS::SdfLayerHandle& sessionLayer = stage->GetSessionLayer();
+    UsdEditTarget                 editTarget(sessionLayer);
+    std::string                   variantsNames;
+
+    for (const VariantSetDescriptor& varDesc : variantInfo.variantSetDescriptors) {
+        const Ufe::Path& ufePath = varDesc.path;
+        for (const VariantSelection& varSel : varDesc.variantSelections) {
+            const std::string& variant = varSel.variantSetName;
+            const std::string& selection = varSel.variantSelection;
+
+            variantsNames.append(" ");
+            variantsNames.append(variant);
+            variantsNames.append("=");
+            variantsNames.append(selection);
+
+            const SdfPath variantPath = MayaUsd::getVariantPath(ufePath, variant, selection);
+            editTarget = editTarget.ComposeOver(
+                PXR_NS::UsdEditTarget::ForLocalDirectVariant(sessionLayer, variantPath));
         }
     }
 
+    if (orphaned) {
+        removePulledPrimMetadata(pulledPrimPath, editTarget);
+        removeExcludeFromRendering(pulledPrimPath, editTarget);
+    } else {
+        writePulledPrimMetadata(pulledPrimPath, variantInfo.editedAsMayaRoot, editTarget);
+        addExcludeFromRendering(pulledPrimPath, editTarget);
+    }
+
+    TF_WARN(
+        "Edited-as-Maya prim \"%s\" (variants:%s) %s.",
+        pulledPrimPath.string().c_str(),
+        variantsNames.c_str(),
+        orphaned ? "was orphaned and is now hidden" : "no longer orphaned and is now shown");
+
     return true;
-}
+} // namespace MAYAUSD_NS_DEF
 
 /* static */
 void OrphanedNodesManager::recursiveSetOrphaned(const PulledPrimNode::Ptr& trieNode, bool orphaned)
@@ -592,11 +688,14 @@ void OrphanedNodesManager::recursiveSwitch(
         // tree state don't match, the pulled node must be made invisible.
         // Inactivation must not be considered, as the USD pulled node is made
         // inactive on pull, to avoid rendering it.
-        const auto& originalDesc = trieNode->data().variantSetDescriptors;
-        const auto  currentDesc = variantSetDescriptors(ufePath.pop());
-        const bool  variantSetsMatch = (originalDesc == currentDesc);
-        const bool  orphaned = (pulledNode && !variantSetsMatch);
-        TF_VERIFY(setOrphaned(trieNode, orphaned));
+        const auto             currentDesc = variantSetDescriptors(ufePath.pop());
+        const PullVariantInfos infos = trieNode->data();
+        for (const PullVariantInfo& variantInfo : infos) {
+            const auto& originalDesc = variantInfo.variantSetDescriptors;
+            const bool  variantSetsMatch = (originalDesc == currentDesc);
+            const bool  orphaned = (pulledNode && !variantSetsMatch);
+            TF_VERIFY(setOrphaned(trieNode, variantInfo, orphaned));
+        }
     } else {
         const bool isGatewayToUsd = Ufe::SceneSegmentHandler::isGateway(ufePath);
         for (const auto& c : trieNode->childrenComponents()) {
@@ -626,8 +725,10 @@ OrphanedNodesManager::variantSetDescriptors(const Ufe::Path& p)
         auto ancestor = Ufe::Hierarchy::createItem(path);
         auto usdAncestor = std::static_pointer_cast<UsdUfe::UsdSceneItem>(ancestor);
         auto variantSets = usdAncestor->prim().GetVariantSets();
+        auto setNames = variantSets.GetNames();
+        std::sort(setNames.begin(), setNames.end());
         std::list<VariantSelection> vs;
-        for (const auto& vsn : variantSets.GetNames()) {
+        for (const auto& vsn : setNames) {
             vs.emplace_back(vsn, variantSets.GetVariantSelection(vsn));
         }
         vsd.emplace_back(path, vs);

--- a/lib/mayaUsd/fileio/orphanedNodesManager.h
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.h
@@ -96,6 +96,10 @@ public:
         std::list<VariantSetDescriptor> variantSetDescriptors;
     };
 
+    using PullVariantInfos = std::vector<PullVariantInfo>;
+    using PulledPrims = Ufe::Trie<PullVariantInfos>;
+    using PulledPrimNode = Ufe::TrieNode<PullVariantInfos>;
+
     /// \brief Entire state of the OrphanedNodesManager at a point in time, used for undo/redo.
     class MAYAUSD_CORE_PUBLIC Memento
     {
@@ -117,11 +121,11 @@ public:
         // Private, for opacity.
         friend class OrphanedNodesManager;
 
-        Memento(Ufe::Trie<PullVariantInfo>&& pulledPrims);
+        Memento(PulledPrims&& pulledPrims);
 
-        Ufe::Trie<PullVariantInfo> release();
+        PulledPrims release();
 
-        Ufe::Trie<PullVariantInfo> _pulledPrims;
+        PulledPrims _pulledPrims;
     };
 
     // Construct an empty orphan manager.
@@ -135,14 +139,17 @@ public:
     // Asserts that the pulled path is not in the trie.
     void add(const Ufe::Path& pulledPath, const MDagPath& editedAsMayaRoot);
 
+    // Verify if the pulled path and the root of the generated
+    // Maya nodes to the trie of pulled prims are alredy tracked.
+    bool has(const Ufe::Path& pulledPath, const MDagPath& editedAsMayaRoot) const;
+
+    // Verify if the pulled path with its current variant set is alredy tracked.
+    bool has(const Ufe::Path& pulledPath) const;
+
     // Remove the pulled path from the trie of pulled prims.  Asserts that the
     // path is in the trie.  Returns a memento (see Memento Pattern) for undo
     // purposes, to be used as argument to restore().
-    Memento remove(const Ufe::Path& pulledPath);
-
-    // Retrieve the variant information of a pulled prim.
-    // Returns an empty info if the prim was not tracked by the orphan manager.
-    const PullVariantInfo& get(const Ufe::Path& pulledPath) const;
+    Memento remove(const Ufe::Path& pulledPath, const MDagPath& editedAsMayaRoot);
 
     // Preserve the trie of pulled prims into a memento.
     Memento preserve() const;
@@ -158,10 +165,8 @@ public:
 
     // Return whether the Dag hierarchy corresponding to the pulled path is
     // orphaned.
-    bool isOrphaned(const Ufe::Path& pulledPath) const;
+    bool isOrphaned(const Ufe::Path& pulledPath, const MDagPath& editedAsMayaRoot) const;
 
-    using PulledPrims = Ufe::Trie<PullVariantInfo>;
-    using PulledPrimNode = Ufe::TrieNode<PullVariantInfo>;
     const PulledPrims& getPulledPrims() const { return _pulledPrims; }
 
 private:
@@ -171,6 +176,10 @@ private:
     static void recursiveSwitch(const PulledPrimNode::Ptr& trieNode, const Ufe::Path& ufePath);
 
     static bool setOrphaned(const PulledPrimNode::Ptr& trieNode, bool orphaned);
+    static bool setOrphaned(
+        const PulledPrimNode::Ptr& trieNode,
+        const PullVariantInfo&     variantInfo,
+        bool                       orphaned);
 
     // Member function to access private nested classes.
     static std::list<VariantSetDescriptor> variantSetDescriptors(const Ufe::Path& path);

--- a/lib/mayaUsd/fileio/orphanedNodesManagerIO.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManagerIO.cpp
@@ -49,6 +49,20 @@ namespace {
 //                       ],
 //                   },
 //                ],
+//                "more pull info": [
+//                   {
+//                      "editedAsMayaRoot": "DAG-path-of-root-of-generated-Maya-data"
+//                      "variantSetDescriptors": [
+//                         {
+//                            "path": "UFE-path-of-one-ancestor",
+//                            "variantSelections": [
+//                               [ "variant-set-1-name", "variant-set-1-selection" ],
+//                               [ "variant-set-2-name", "variant-set-2-selection" ],
+//                            ],
+//                         },
+//                      ],
+//                   },
+//                ],
 //             },
 //          },
 //       },
@@ -59,6 +73,7 @@ namespace {
 
 static const std::string ufeComponentPrefix = "/";
 static const std::string pullInfoJsonKey = "pull info";
+static const std::string morePullInfoJsonKey = "more pull info";
 static const std::string editedAsMayaRootJsonKey = "editedAsMayaRoot";
 static const std::string variantSetDescriptorsJsonKey = "variantSetDescriptors";
 static const std::string pathJsonKey = "path";
@@ -74,8 +89,9 @@ using VariantSelection = OrphanedNodesManager::VariantSelection;
 using VariantSetDesc = OrphanedNodesManager::VariantSetDescriptor;
 using VariantSetDescList = std::list<VariantSetDesc>;
 using PullVariantInfo = OrphanedNodesManager::PullVariantInfo;
-using PullInfoTrie = Ufe::Trie<PullVariantInfo>;
-using PullInfoTrieNode = Ufe::TrieNode<PullVariantInfo>;
+using PullVariantInfos = std::vector<PullVariantInfo>;
+using PullInfoTrie = OrphanedNodesManager::PulledPrims;
+using PullInfoTrieNode = OrphanedNodesManager::PulledPrimNode;
 using Memento = OrphanedNodesManager::Memento;
 
 ////////////////////////////////////////////////////////////////////////////
@@ -90,6 +106,7 @@ PXR_NS::JsArray  convertToArray(const VariantSelection& variantSel);
 PXR_NS::JsObject convertToObject(const VariantSetDesc& variantDesc);
 PXR_NS::JsArray  convertToArray(const std::list<VariantSetDesc>& allVariantDesc);
 PXR_NS::JsObject convertToObject(const PullVariantInfo& pullInfo);
+PXR_NS::JsObject convertToObject(const PullVariantInfos& pullInfos);
 PXR_NS::JsObject convertToObject(const PullInfoTrieNode::Ptr& pullInfoNode);
 PXR_NS::JsObject convertToObject(const PullInfoTrie& allPulledInfo);
 
@@ -97,6 +114,7 @@ VariantSelection   convertToVariantSelection(const PXR_NS::JsArray& variantSelJs
 VariantSetDesc     convertToVariantSetDescriptor(const PXR_NS::JsObject& variantDescJson);
 VariantSetDescList convertToVariantSetDescList(const PXR_NS::JsArray& allVariantDescJson);
 PullVariantInfo    convertToPullVariantInfo(const PXR_NS::JsObject& pullInfoJson);
+PullVariantInfos   convertToPullVariantInfos(const PXR_NS::JsObject& pullInfoJson);
 void         convertToPullInfoTrieNodePtr(const PXR_NS::JsObject&, PullInfoTrieNode::Ptr intoRoot);
 PullInfoTrie convertToPullInfoTrie(const PXR_NS::JsObject& allPulledInfoJson);
 
@@ -199,6 +217,44 @@ PullVariantInfo convertToPullVariantInfo(const PXR_NS::JsObject& pullInfoJson)
     return pullInfo;
 }
 
+PXR_NS::JsObject convertToObject(const PullVariantInfos& pullInfos)
+{
+    PXR_NS::JsObject pullInfoJson;
+
+    if (pullInfos.size() > 0) {
+        pullInfoJson = convertToObject(pullInfos[0]);
+    }
+
+    if (pullInfos.size() > 1) {
+        PXR_NS::JsArray morePullInfoJson;
+        for (size_t i = 1; i < pullInfos.size(); ++i) {
+            PXR_NS::JsObject moreInfoJson = convertToObject(pullInfos[i]);
+            morePullInfoJson.emplace_back(moreInfoJson);
+        }
+        pullInfoJson[morePullInfoJsonKey] = morePullInfoJson;
+    }
+
+    return pullInfoJson;
+}
+
+PullVariantInfos convertToPullVariantInfos(const PXR_NS::JsObject& pullInfoJson)
+{
+    PullVariantInfos pullInfos;
+
+    if (pullInfoJson.count(editedAsMayaRootJsonKey)) {
+        pullInfos.emplace_back(convertToPullVariantInfo(pullInfoJson));
+    }
+
+    if (pullInfoJson.count(morePullInfoJsonKey)) {
+        PXR_NS::JsArray morePullInfoJson
+            = convertToArray(convertJsonKeyToValue(pullInfoJson, morePullInfoJsonKey));
+        for (const PXR_NS::JsValue& value : morePullInfoJson) {
+            pullInfos.emplace_back(convertToPullVariantInfo(convertToObject(value)));
+        }
+    }
+    return pullInfos;
+}
+
 PXR_NS::JsObject convertToObject(const PullInfoTrieNode::Ptr& pullInfoNodePtr)
 {
     if (!pullInfoNodePtr)
@@ -208,7 +264,7 @@ PXR_NS::JsObject convertToObject(const PullInfoTrieNode::Ptr& pullInfoNodePtr)
 
     PXR_NS::JsObject pullInfoNodeJson;
 
-    if (pullInfoNode.hasData()) {
+    if (pullInfoNode.hasData() && pullInfoNode.data().size() > 0) {
         pullInfoNodeJson[pullInfoJsonKey] = convertToObject(pullInfoNode.data());
     }
 
@@ -232,7 +288,7 @@ void convertToPullInfoTrieNodePtr(
         if (key.size() <= 0) {
             continue;
         } else if (key == pullInfoJsonKey) {
-            intoRoot->setData(convertToPullVariantInfo(convertToObject(value)));
+            intoRoot->setData(convertToPullVariantInfos(convertToObject(value)));
 
         } else if (key[0] == '/') {
             PullInfoTrieNode::Ptr child = std::make_shared<PullInfoTrieNode>(key.substr(1));

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -119,12 +119,18 @@ SdfPath makeDstPath(const SdfPath& dstRootParentPath, const SdfPath& srcPath)
     auto relativeSrcPath = srcPath.MakeRelativePath(SdfPath::AbsoluteRootPath());
     return dstRootParentPath.AppendPath(relativeSrcPath);
 }
+}
 
 //------------------------------------------------------------------------------
 //
 // Verify if the given prim under the given UFE path is an ancestor of an already edited prim.
-bool hasEditedDescendant(const Ufe::Path& ufeQueryPath)
+bool PrimUpdaterManager::hasEditedDescendant(const Ufe::Path& ufeQueryPath) const
 {
+#ifdef HAS_ORPHANED_NODES_MANAGER
+    if (_orphanedNodesManager->has(ufeQueryPath))
+        return true;
+#endif
+
     MObject pullSetObj;
     auto    status = UsdMayaUtil::GetMObjectByName(kPullSetName, pullSetObj);
     if (status != MStatus::kSuccess)
@@ -142,6 +148,18 @@ bool hasEditedDescendant(const Ufe::Path& ufeQueryPath)
         if (!readPullInformation(pulledDagPath, pulledUfePath))
             continue;
 
+#ifdef HAS_ORPHANED_NODES_MANAGER
+        // If the alread-edited node is orphaned, don't take it into consideration.
+        //
+        // TODO: should we cancel its edit? Might not be possible if not available
+        //       due to being dectuvated or in another variant...
+        if (_orphanedNodesManager) {
+            if (_orphanedNodesManager->isOrphaned(pulledUfePath, pulledDagPath)) {
+                continue;
+            }
+        }
+#endif
+
         if (pulledUfePath.startsWith(ufeQueryPath))
             return true;
     }
@@ -149,6 +167,7 @@ bool hasEditedDescendant(const Ufe::Path& ufeQueryPath)
     return false;
 }
 
+namespace {
 //------------------------------------------------------------------------------
 //
 // The UFE path is to the pulled prim, and the Dag path is the corresponding
@@ -198,22 +217,18 @@ bool writeAllPullInformation(const Ufe::Path& ufePulledPath, const MDagPath& edi
 //
 void removeAllPullInformation(const Ufe::Path& ufePulledPath)
 {
-    UsdPrim     pulledPrim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
-    UsdStagePtr stage = pulledPrim.GetStage();
-    if (!stage)
-        return;
-
     MayaUsd::ProgressBarScope progressBar(1);
-    removePulledPrimMetadata(stage, pulledPrim);
+    removePulledPrimMetadata(ufePulledPath);
     progressBar.advance();
 
-    // Session layer cleanup
-    auto                          rootPrims = stage->GetSessionLayer()->GetRootPrims();
-    MayaUsd::ProgressBarLoopScope rootPrimsLoop(rootPrims.size());
-    for (const SdfPrimSpecHandle& rootPrimSpec : rootPrims) {
-        stage->GetSessionLayer()->RemovePrimIfInert(rootPrimSpec);
-        rootPrimsLoop.loopAdvance();
-    }
+    // TODO DEBUG PUT BACK
+    // // Session layer cleanup
+    // auto                          rootPrims = stage->GetSessionLayer()->GetRootPrims();
+    // MayaUsd::ProgressBarLoopScope rootPrimsLoop(rootPrims.size());
+    // for (const SdfPrimSpecHandle& rootPrimSpec : rootPrims) {
+    //     stage->GetSessionLayer()->RemovePrimIfInert(rootPrimSpec);
+    //     rootPrimsLoop.loopAdvance();
+    // }
 }
 
 //------------------------------------------------------------------------------
@@ -865,7 +880,7 @@ public:
 
     bool undo() override
     {
-        _orphanedNodesManager->remove(_pulledPath);
+        _orphanedNodesManager->remove(_pulledPath, _editedAsMayaRoot);
         return true;
     }
 
@@ -888,13 +903,14 @@ public:
     // the global undo list.
     static bool execute(
         const std::shared_ptr<OrphanedNodesManager>& orphanedNodesManager,
-        const Ufe::Path&                             pulledPath)
+        const Ufe::Path&                             pulledPath,
+        const MDagPath&                              editedAsMayaRoot)
     {
         // Get the global undo list.
         auto& undoInfo = OpUndoItemList::instance();
 
-        auto item
-            = std::make_unique<RemovePullVariantInfoUndoItem>(orphanedNodesManager, pulledPath);
+        auto item = std::make_unique<RemovePullVariantInfoUndoItem>(
+            orphanedNodesManager, pulledPath, editedAsMayaRoot);
         if (!item->redo()) {
             return false;
         }
@@ -906,10 +922,12 @@ public:
 
     RemovePullVariantInfoUndoItem(
         const std::shared_ptr<OrphanedNodesManager>& orphanedNodesManager,
-        const Ufe::Path&                             pulledPath)
+        const Ufe::Path&                             pulledPath,
+        const MDagPath&                              editedAsMayaRoot)
         : OpUndoItem(std::string("Remove pull path ") + Ufe::PathString::string(pulledPath))
         , _orphanedNodesManager(orphanedNodesManager)
         , _pulledPath(pulledPath)
+        , _editedAsMayaRoot(editedAsMayaRoot)
     {
     }
 
@@ -921,13 +939,14 @@ public:
 
     bool redo() override
     {
-        _memento = _orphanedNodesManager->remove(_pulledPath);
+        _memento = _orphanedNodesManager->remove(_pulledPath, _editedAsMayaRoot);
         return true;
     }
 
 private:
     const std::shared_ptr<OrphanedNodesManager> _orphanedNodesManager;
     const Ufe::Path                             _pulledPath;
+    const MDagPath                              _editedAsMayaRoot;
 
     // Created by redo().
     OrphanedNodesManager::Memento _memento;
@@ -990,7 +1009,7 @@ bool PrimUpdaterManager::mergeToUsd(
         VtDictionaryIsHolding<std::string>(userArgs, MayaUsdEditRoutingTokens->DestinationPrimName)
             ? "Caching to USD"
             : "Merging to USD");
-    MayaUsd::ProgressBarScope progressBar(11, progStr);
+    MayaUsd::ProgressBarScope progressBar(10, progStr);
     PushPullScope             scopeIt(_inPushPull);
 
     auto ctxArgs = VtDictionaryOver(userArgs, UsdMayaJobExportArgs::GetDefaultDictionary());
@@ -1056,7 +1075,8 @@ bool PrimUpdaterManager::mergeToUsd(
     // thinking the Maya data shoudl be shown again...
 #ifdef HAS_ORPHANED_NODES_MANAGER
     if (_orphanedNodesManager) {
-        if (!TF_VERIFY(RemovePullVariantInfoUndoItem::execute(_orphanedNodesManager, pulledPath))) {
+        if (!TF_VERIFY(RemovePullVariantInfoUndoItem::execute(
+                _orphanedNodesManager, pulledPath, mayaDagPath))) {
             return false;
         }
     }
@@ -1091,15 +1111,7 @@ bool PrimUpdaterManager::mergeToUsd(
             TF_WARN("Cannot re-enable original USD data in viewport rendering.");
             return false;
         }
-    }
-    progressBar.advance();
 
-    if (!pushCustomize(pulledPath, pushCustomizeSrc, context)) {
-        return false;
-    }
-    progressBar.advance();
-
-    if (!isCopy) {
         if (!FunctionUndoItem::execute(
                 "Merge to Maya pull info removal",
                 [pulledPath]() {
@@ -1112,6 +1124,11 @@ bool PrimUpdaterManager::mergeToUsd(
             TF_WARN("Cannot remove pull information metadata.");
             return false;
         }
+    }
+    progressBar.advance();
+
+    if (!pushCustomize(pulledPath, pushCustomizeSrc, context)) {
+        return false;
     }
     progressBar.advance();
 
@@ -1161,7 +1178,6 @@ bool PrimUpdaterManager::mergeToUsd(
 bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& userArgs)
 {
     if (hasEditedDescendant(path)) {
-        TF_WARN("Cannot edit an ancestor of an already edited node.");
         return false;
     }
 
@@ -1294,7 +1310,7 @@ bool PrimUpdaterManager::discardEdits(const MDagPath& dagPath)
     auto usdPrim = MayaUsd::ufe::ufePathToPrim(pulledPath);
 
 #ifdef HAS_ORPHANED_NODES_MANAGER
-    auto ret = _orphanedNodesManager->isOrphaned(pulledPath)
+    auto ret = _orphanedNodesManager->isOrphaned(pulledPath, dagPath)
         ? discardOrphanedEdits(dagPath, pulledPath)
         : discardPrimEdits(pulledPath);
 #else
@@ -1373,7 +1389,8 @@ bool PrimUpdaterManager::discardPrimEdits(const Ufe::Path& pulledPath)
 
 #ifdef HAS_ORPHANED_NODES_MANAGER
     if (_orphanedNodesManager) {
-        if (!TF_VERIFY(RemovePullVariantInfoUndoItem::execute(_orphanedNodesManager, pulledPath))) {
+        if (!TF_VERIFY(RemovePullVariantInfoUndoItem::execute(
+                _orphanedNodesManager, pulledPath, mayaDagPath))) {
             return false;
         }
     }
@@ -1434,6 +1451,15 @@ bool PrimUpdaterManager::discardOrphanedEdits(const MDagPath& dagPath, const Ufe
     auto pullParent = dagPath;
     pullParent.pop();
 
+#ifdef HAS_ORPHANED_NODES_MANAGER
+    if (_orphanedNodesManager) {
+        if (!TF_VERIFY(RemovePullVariantInfoUndoItem::execute(
+                _orphanedNodesManager, pulledPath, dagPath))) {
+            return false;
+        }
+    }
+#endif
+
     if (!LockNodesUndoItem::lock("Discard orphaned edits node unlocking", pullParent, false)) {
         return false;
     }
@@ -1461,14 +1487,6 @@ bool PrimUpdaterManager::discardOrphanedEdits(const MDagPath& dagPath, const Ufe
         updater->discardEdits();
         toApplyOnLoop.loopAdvance();
     }
-
-#ifdef HAS_ORPHANED_NODES_MANAGER
-    if (_orphanedNodesManager) {
-        if (!TF_VERIFY(RemovePullVariantInfoUndoItem::execute(_orphanedNodesManager, pulledPath))) {
-            return false;
-        }
-    }
-#endif
 
     if (!TF_VERIFY(removePullParent(pullParent, pulledPath))) {
         return false;
@@ -1883,12 +1901,12 @@ PrimUpdaterManager::PulledPrimPaths PrimUpdaterManager::getPulledPrimPaths() con
         return pulledPaths;
 
     const OrphanedNodesManager::PulledPrims& pulledPrims = _orphanedNodesManager->getPulledPrims();
-    MayaUsd::TrieVisitor<OrphanedNodesManager::PullVariantInfo>::visit(
+    MayaUsd::TrieVisitor<OrphanedNodesManager::PullVariantInfos>::visit(
         pulledPrims,
-        [&pulledPaths](
-            const Ufe::Path&                                            path,
-            const Ufe::TrieNode<OrphanedNodesManager::PullVariantInfo>& node) {
-            pulledPaths.emplace_back(path, node.data().editedAsMayaRoot);
+        [&pulledPaths](const Ufe::Path& path, const OrphanedNodesManager::PulledPrimNode &node) {
+            for (const OrphanedNodesManager::PullVariantInfo& info : node.data()) {
+                pulledPaths.emplace_back(path, info.editedAsMayaRoot);
+            }
         });
 
 #endif

--- a/lib/mayaUsd/fileio/primUpdaterManager.h
+++ b/lib/mayaUsd/fileio/primUpdaterManager.h
@@ -114,8 +114,11 @@ private:
     //! Create the pull parent and set it into the prim updater context.
     MDagPath setupPullParent(const Ufe::Path& pulledPath, VtDictionary& args);
 
-    //! Record pull information for the pulled path, for inspection on
-    //! scene changes.
+    //! Verify if the given prim at the given UFE path is an ancestor of an already edited prim.
+    bool hasEditedDescendant(const Ufe::Path& ufeQueryPath) const;
+
+//! Record pull information for the pulled path, for inspection on
+//! scene changes.
 #ifdef HAS_ORPHANED_NODES_MANAGER
     // Maya file new or open callback.  Member function to access other private
     // member functions.

--- a/lib/mayaUsd/fileio/pullInformation.h
+++ b/lib/mayaUsd/fileio/pullInformation.h
@@ -19,6 +19,7 @@
 #include <mayaUsd/base/api.h>
 
 #include <pxr/pxr.h>
+#include <pxr/usd/usd/editTarget.h>
 #include <pxr/usd/usd/prim.h>
 
 #include <maya/MDagPath.h>
@@ -27,6 +28,11 @@
 UFE_NS_DEF { class Path; }
 
 namespace MAYAUSD_NS_DEF {
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Helper functions to write, read and remove edited-as-Maya (pull)
+// information set on the Maya DAG node.
 
 /// @brief Write on the Maya node the information necessary later-on to merge
 ///        the USD prim that is edited as Maya.
@@ -37,26 +43,75 @@ bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& edited
 ///        that is edited as Maya.
 MAYAUSD_CORE_PUBLIC
 bool readPullInformation(const PXR_NS::UsdPrim& prim, std::string& dagPathStr);
+
 MAYAUSD_CORE_PUBLIC
 bool readPullInformation(const PXR_NS::UsdPrim& prim, Ufe::SceneItem::Ptr& dagPathItem);
+
 MAYAUSD_CORE_PUBLIC
 bool readPullInformation(const Ufe::Path& ufePath, MDagPath& dagPath);
+
 MAYAUSD_CORE_PUBLIC
 bool readPullInformation(const MDagPath& dagpath, Ufe::Path& ufePath);
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Helper functions to write, read and remove edited-as-Maya (pull)
+// information set on the edited USD prim.
 
 /// @brief Write on the USD prim the information necessary later-on to merge
 ///        the USD prim that is edited as Maya.
 MAYAUSD_CORE_PUBLIC
 bool writePulledPrimMetadata(const Ufe::Path& ufePulledPath, const MDagPath& editedRoot);
+
+/// @brief Write on the Maya node the information necessary later-on to merge
+///        the USD prim that is edited as Maya, in the given edit target.
+MAYAUSD_CORE_PUBLIC
+bool writePulledPrimMetadata(
+    const Ufe::Path&             ufePulledPath,
+    const MDagPath&              editedRoot,
+    const PXR_NS::UsdEditTarget& editTarget);
+
+/// @brief Write on the USD prim the information necessary later-on to merge
+///        the USD prim that is edited as Maya.
 MAYAUSD_CORE_PUBLIC
 bool writePulledPrimMetadata(PXR_NS::UsdPrim& pulledPrim, const MDagPath& editedRoot);
+
+/// @brief Write on the Maya node the information necessary later-on to merge
+///        the USD prim that is edited as Maya, in the given edit target.
+MAYAUSD_CORE_PUBLIC
+bool writePulledPrimMetadata(
+    PXR_NS::UsdPrim&             pulledPrim,
+    const MDagPath&              editedAsMayaRoot,
+    const PXR_NS::UsdEditTarget& editTarget);
 
 /// @brief Remove from the USD prim the information necessary to merge the USD prim
 ///        that was edited as Maya.
 MAYAUSD_CORE_PUBLIC
 void removePulledPrimMetadata(const Ufe::Path& ufePulledPath);
+
+/// @brief Remove from the USD prim the information necessary to merge the USD prim
+///        that was edited as Maya, .
+MAYAUSD_CORE_PUBLIC
+void removePulledPrimMetadata(
+    const Ufe::Path&             ufePulledPath,
+    const PXR_NS::UsdEditTarget& editTarget);
+
+/// @brief Remove from the USD prim the information necessary to merge the USD prim
+///        that was edited as Maya.
 MAYAUSD_CORE_PUBLIC
 void removePulledPrimMetadata(const PXR_NS::UsdStagePtr& stage, PXR_NS::UsdPrim& prim);
+
+/// @brief Remove from the USD prim the information necessary to merge the USD prim
+///        that was edited as Maya, in the given edit target.
+MAYAUSD_CORE_PUBLIC
+void removePulledPrimMetadata(
+    const PXR_NS::UsdStagePtr&   stage,
+    PXR_NS::UsdPrim&             prim,
+    const PXR_NS::UsdEditTarget& editTarget);
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Helper functions to hide and show the edited prim.
 
 /// @brief Hide the USD prim that is edited as Maya.
 ///        This is done so that the USD prim and edited Maya data are not superposed
@@ -64,10 +119,24 @@ void removePulledPrimMetadata(const PXR_NS::UsdStagePtr& stage, PXR_NS::UsdPrim&
 MAYAUSD_CORE_PUBLIC
 bool addExcludeFromRendering(const Ufe::Path& ufePulledPath);
 
+MAYAUSD_CORE_PUBLIC
+bool addExcludeFromRendering(
+    const Ufe::Path&             ufePulledPath,
+    const PXR_NS::UsdEditTarget& editTarget);
+
 /// @brief Show again the USD prim that was edited as Maya.
 ///        This is done once the Maya data is meged into USD and removed from the scene.
 MAYAUSD_CORE_PUBLIC
 bool removeExcludeFromRendering(const Ufe::Path& ufePulledPath);
+
+MAYAUSD_CORE_PUBLIC
+bool removeExcludeFromRendering(
+    const Ufe::Path&             ufePulledPath,
+    const PXR_NS::UsdEditTarget& editTarget);
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Helper functions to check if a prim is already edited-as-Maya.
 
 /// @brief Verify if the edited as Maya nodes corresponding to the given prim is orphaned.
 MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.h
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.h
@@ -48,7 +48,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 struct UsdMayaTranslatorMayaReference
 {
     MAYAUSD_CORE_PUBLIC
-    static MStatus LoadMayaReference(
+    static MStatus CreateMayaReference(
         const UsdPrim& prim,
         MObject&       parent,
         MString&       mayaReferencePath,
@@ -60,18 +60,6 @@ struct UsdMayaTranslatorMayaReference
 
     MAYAUSD_CORE_PUBLIC
     static MStatus update(const UsdPrim& prim, MObject parent);
-
-private:
-    static MString namespaceFromPrim(const UsdPrim& prim);
-    static MString getUniqueRefNodeName(
-        const UsdPrim&      prim,
-        const MFnDagNode&   parentDag,
-        const MFnReference& refDependNode);
-    static MStatus connectReferenceAssociatedNode(MFnDagNode& dagNode, MFnReference& refNode);
-
-    static const TfToken m_namespaceName;
-    static const TfToken m_referenceName;
-    static const TfToken m_mergeNamespacesOnClash;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/utils/variants.cpp
+++ b/lib/mayaUsd/utils/variants.cpp
@@ -15,6 +15,12 @@
 //
 #include "variants.h"
 
+#include <mayaUsd/ufe/Global.h>
+
+#include <pxr/base/tf/stringUtils.h>
+#include <pxr/usd/pcp/node.h>
+#include <pxr/usd/pcp/primIndex.h>
+#include <pxr/usd/usd/editTarget.h>
 #include <pxr/usd/usd/stage.h>
 
 /// General utility functions for variants
@@ -57,6 +63,49 @@ void applyToAllVariants(
     // the function even in the absence of vairants, call it now.
     if (includeNonVariant && !atLeastOneVariant)
         func();
+}
+
+PXR_NS::UsdEditTarget
+getEditTargetForVariants(const PXR_NS::UsdPrim& prim, const PXR_NS::SdfLayerHandle& layer)
+{
+    PXR_NS::UsdEditTarget editTarget(layer);
+
+    // TODO DEBUG REMOVE
+    std::vector<std::string> variantPaths;
+
+    for (const PXR_NS::SdfPath& p : prim.GetPath().GetAncestorsRange()) {
+        PXR_NS::UsdPrim          ancestor = prim.GetStage()->GetPrimAtPath(p);
+        PXR_NS::UsdVariantSets   variantSets = ancestor.GetVariantSets();
+        std::vector<std::string> setNames = variantSets.GetNames();
+        for (const std::string& setName : setNames) {
+            PXR_NS::UsdVariantSet variant = variantSets.GetVariantSet(setName);
+            std::string selection = variant.GetVariantSelection();
+            variantPaths.emplace_back(setName + std::string("=") + selection);
+            editTarget = editTarget.ComposeOver(variant.GetVariantEditTarget(layer));
+        }
+    }
+
+    // TODO DEBUG REMOVE
+    using namespace PXR_NS;
+    TF_STATUS(
+        "edit target for variants for %s: %s",
+        prim.GetPath().GetText(),
+        PXR_NS::TfStringJoin(variantPaths).c_str());
+
+    return editTarget;
+}
+
+PXR_NS::SdfPath getVariantPath(
+    const Ufe::Path&   path,
+    const std::string& variantSetName,
+    const std::string& variantSelection)
+{
+    if (path.runTimeId() != MayaUsd::ufe::getUsdRunTimeId())
+        return {};
+
+    const Ufe::Path::Segments& segments = path.getSegments();
+    PXR_NS::SdfPath            primPath(segments.back().string());
+    return primPath.AppendVariantSelection(variantSetName, variantSelection);
 }
 
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/variants.h
+++ b/lib/mayaUsd/utils/variants.h
@@ -18,9 +18,12 @@
 
 #include <mayaUsd/base/api.h>
 
+#include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/editContext.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/variantSets.h>
+
+#include <ufe/path.h>
 
 #include <functional>
 #include <string>
@@ -71,6 +74,24 @@ private:
     PXR_NS::UsdVariantSet _variantSet;
     std::string           _variant;
 };
+
+/*! \brief Creates an edit target for all variants that might affect the given prim.
+
+           Note that this includes variants on ancestors that affect this prim. To find
+           those ancestor variant is the main prupose of this function. For prim-specific
+           variant selections, OpenUSD already provides a built-in function on UsdPrim.
+ */
+MAYAUSD_CORE_PUBLIC
+PXR_NS::UsdEditTarget
+getEditTargetForVariants(const PXR_NS::UsdPrim& prim, const PXR_NS::SdfLayerHandle& layer);
+
+/*! \brief Creates an USD variant path for the given UFE path and variant selection.
+ */
+MAYAUSD_CORE_PUBLIC
+PXR_NS::SdfPath getVariantPath(
+    const Ufe::Path&   path,
+    const std::string& variantSetName,
+    const std::string& variantSelection);
 
 } // namespace MAYAUSD_NS_DEF
 

--- a/test/lib/mayaUsd/fileio/testAddMayaReference.py
+++ b/test/lib/mayaUsd/fileio/testAddMayaReference.py
@@ -371,6 +371,8 @@ class AddMayaReferenceTestCase(unittest.TestCase):
             self.kDefaultNamespace,
             variantSet=(variantSetName, variantName),
             mayaAutoEdit=True)
+        mayaRefPrimPath = mayaRefPrim.GetPath()
+        stage = mayaRefPrim.GetStage()
 
         # The prim should have a variant set.
         self.assertTrue(primTestDefault.HasVariantSets())
@@ -408,16 +410,22 @@ class AddMayaReferenceTestCase(unittest.TestCase):
             self.assertTrue(mayaUsd.lib.PrimUpdaterManager.mergeToUsd(aMayaPathStr, cacheOptions))
 
         # Verify the cache variant is active and the prim
-        # is active.
+        # is not accessible since we are in the cache variant.
         self.assertTrue(primTestDefault.HasVariantSets())
         vs = primTestDefault.GetVariantSets()
         variantSet = vs.GetVariantSet(variantSetName)
         self.assertEqual(variantSet.GetVariantSelection(), cacheVariantName)
-        self.assertTrue(mayaRefPrim.IsActive())
+        # Note: we must fetch the prim again because when switching variant,
+        #       the prim became invalid.
+        mayaRefPrim = stage.GetPrimAtPath(mayaRefPrimPath)
+        self.assertFalse(mayaRefPrim)
 
         # Switch to Maya Ref variant and verify that the auto-edit is
         # still on and the prim is now inactive.
         variantSet.SetVariantSelection(variantName)
+        # Note: we must fetch the prim again because when switching variant,
+        #       the prim became invalid.
+        mayaRefPrim = stage.GetPrimAtPath(mayaRefPrimPath)
         self.assertFalse(mayaRefPrim.IsActive())
         attr = mayaRefPrim.GetAttribute('mayaAutoEdit')
         self.assertTrue(attr.IsValid())

--- a/test/lib/mayaUsd/fileio/testCacheToUsd.py
+++ b/test/lib/mayaUsd/fileio/testCacheToUsd.py
@@ -492,6 +492,7 @@ class CacheToUsdTestCase(unittest.TestCase):
 
         (mayaRefPrim, variantSetName, variantSet, refVariantName, cacheVariantName, relativePath) = \
             createMayaRefPrimFn(self, cacheParent, cacheParentPathStr)
+        mayaRefPrimPath = mayaRefPrim.GetPath()
 
         # Set an initial translation.
         editTarget = self.stage.GetEditTarget()
@@ -564,12 +565,13 @@ class CacheToUsdTestCase(unittest.TestCase):
         checkCacheParentFn(self, cacheParentChildren, variantSet, cacheVariantName)
 
         # Maya reference prim should now have the updated transformation.
-        editTarget = self.stage.GetEditTarget()
-        if variantSet:
-            variantSet.SetVariantSelection('Rig')
-            editTarget = variantSet.GetVariantEditTarget(editTarget.GetLayer())
+        if variantSetName:
+            cacheParent.GetVariantSet(variantSetName).SetVariantSelection('Rig')
 
         with Usd.EditContext(self.stage, editTarget):
+            # Note: must refetch the ref prim because it became invalid when
+            #       it got deactivated during edit.
+            mayaRefPrim = self.stage.GetPrimAtPath(mayaRefPrimPath)
             xformable = UsdGeom.Xformable(mayaRefPrim)
             ops = xformable.GetOrderedXformOps()
             self.assertEqual(len(ops), 1)

--- a/test/lib/mayaUsd/fileio/testEditAsMaya.py
+++ b/test/lib/mayaUsd/fileio/testEditAsMaya.py
@@ -433,7 +433,7 @@ class EditAsMayaTestCase(unittest.TestCase):
 
         self.assertFalse(stage.GetSessionLayer().empty)
 
-        kPullPrimMetadataKey = "Maya:Pull:DagPath"
+        kPullPrimMetadataKey = "Maya:PullVariant:DagPath"
         self.assertEqual(prim.GetCustomDataByKey(kPullPrimMetadataKey), "|__mayaUsd__|AParent|A")
 
         # Discard Maya edits, but there is nothing to discard.


### PR DESCRIPTION
This change adds support to edit-as-Maya a prim that is under a variant, with
each variation having a different Maya reference. That is, a single prim can
now be edited-as-Maya multiple times in parallel. This required major changes
on how those edited prim are tracked.

Edit-as-Maya authors data in the session layer related to the edited prim.
Previously, this data was authored outside any variant, which caused problems
when a prim had multiple variants. Now these data are authored inside the same
variant as the prim itself.

Additional helper functions:
- Add the getEditTargetForVariants function helper function to create the USD edit target targeting all the variants that affect a given prim.
- Add variant-specific pull info metadata in the pull-info helper functions.

Change to the orphan manager:
- Use the variant-targeting helper function when authoring the Maya reference custom attribute that holds the name of the Maya reference node.
- Support having multiple entries for a given UFE path.
- To differentiate between entries, the corresponding root Maya DAG path must be given in all functions to figure out which version of the prim we are dealing with.
- Fortunately, all callers always have on hand the DAG path of the root Maya node.
- Change all implementation function to iterate over these variations.
- Change the orphaned nodes serialization to support the extra data.
- Make the serialization format backward compatible by special-casing the usual case of having a single variation at a given edited UFE path.
- Add a log to tell the user when an edited prim is orphaned.

Changes to the prim updater manager:
- Ignore edited prim that are orphaned when determining if a prim has edited descendants.
- Adapt to changes to the orphaned manager by passing the Maya DAG path to the root of the edited nodes.

Changes to Maya reference translator (importer from USD to Maya):
- Use the variant-targeting helper function when authoring the pulled-prim metadata.
- Make many functions be purely in the implementation instead of declared private in the class.
- This allows better hiding of the implementation.
- This was also necessary to make the function callable from internal implementation functions.
- Renamed LoadMayaReference to CreateMayaReference to better reflect what the function does.
- Split the long update function into multiple function for clarity.
- When trying to reuse Maya reference nodes, verify that the referenced file is the one that was expected.
- This allows two prim with the same USD path but different references to work alongside each other.
- This happens when one prim with two variants each contain a Maya reference.
- Add more comments in the code to explain what is going on.
- Add a log to tell the user when a reference does not have the expected file path.