### PR TITLE
EMSUSD-287 - Setup preference section

### DIFF
--- a/lib/mayaUsd/resources/ae/usdschemabase/custom_image_control.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/custom_image_control.py
@@ -170,7 +170,7 @@ class ImageCustomControl(object):
 
     @staticmethod
     def wantRelativeFileName():
-        opVarName = "mayaUsd_MakePathRelativeToEditTargetLayer"
+        opVarName = "mayaUsd_MakePathRelativeToImageEditTargetLayer"
         return cmds.optionVar(exists=opVarName) and cmds.optionVar(query=opVarName)
 
     @staticmethod

--- a/lib/usd/ui/layerEditor/layerEditorWidget.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.cpp
@@ -79,59 +79,6 @@ void setupDefaultMenu(SessionState* in_sessionState, QMainWindow* in_parent)
         action->setCheckable(true);
         action->setChecked(in_sessionState->autoHideSessionLayer());
 
-        auto usdSaveMenu = optionMenu->addMenu(
-            StringResources::getAsQString(StringResources::kUsdSaveFileFormat));
-
-        // Add the save confirm existing file save checkbox
-        static const MString kConfirmExistingFileSave
-            = MayaUsdOptionVars->ConfirmExistingFileSave.GetText();
-        auto confirmExistingFileSaveAct = optionMenu->addAction(
-            StringResources::getAsQString(StringResources::kConfirmExistFileSave));
-
-        confirmExistingFileSaveAct->setCheckable(true);
-
-        QObject::connect(confirmExistingFileSaveAct, &QAction::toggled, in_parent, [](bool enable) {
-            MGlobal::setOptionVarValue(kConfirmExistingFileSave, enable);
-        });
-
-        if (MGlobal::optionVarExists(kConfirmExistingFileSave)) {
-            confirmExistingFileSaveAct->setChecked(
-                MGlobal::optionVarIntValue(kConfirmExistingFileSave) != 0);
-        } else {
-            confirmExistingFileSaveAct->setChecked(true);
-        }
-
-        auto formatGroup = new QActionGroup(usdSaveMenu);
-        formatGroup->setExclusive(true);
-        auto formatBinary
-            = formatGroup->addAction(StringResources::getAsQString(StringResources::kBinary));
-        auto formatAscii
-            = formatGroup->addAction(StringResources::getAsQString(StringResources::kAscii));
-        auto grpAnn = StringResources::getAsQString(StringResources::kSaveLayerUsdFileFormatAnn);
-        auto grpSbm = StringResources::getAsQString(StringResources::kSaveLayerUsdFileFormatSbm);
-        formatBinary->setCheckable(true);
-        formatBinary->setData(1);
-        formatBinary->setToolTip(grpAnn);
-        formatBinary->setStatusTip(grpSbm);
-        formatAscii->setCheckable(true);
-        formatAscii->setData(0);
-        formatAscii->setToolTip(grpAnn);
-        formatAscii->setStatusTip(grpSbm);
-        usdSaveMenu->addAction(formatBinary);
-        usdSaveMenu->addAction(formatAscii);
-        bool isBinary = true;
-
-        static const MString kSaveLayerFormatBinaryOption(
-            MayaUsdOptionVars->SaveLayerFormatArgBinaryOption.GetText());
-        if (MGlobal::optionVarExists(kSaveLayerFormatBinaryOption)) {
-            isBinary = MGlobal::optionVarIntValue(kSaveLayerFormatBinaryOption) != 0;
-        }
-        isBinary ? formatBinary->setChecked(true) : formatAscii->setChecked(true);
-        auto onFileFormatChanged = [=](QAction* action) {
-            MGlobal::setOptionVarValue(kSaveLayerFormatBinaryOption, action->data().toInt());
-        };
-        QObject::connect(formatGroup, &QActionGroup::triggered, in_parent, onFileFormatChanged);
-
         auto helpMenu = menuBar->addMenu(StringResources::getAsQString(StringResources::kHelp));
         helpMenu->addAction(
             StringResources::getAsQString(StringResources::kHelpOnUSDLayerEditor),

--- a/lib/usd/ui/layerEditor/stringResources.h
+++ b/lib/usd/ui/layerEditor/stringResources.h
@@ -49,10 +49,7 @@ MStringResourceId create(const char* key, const char* value);
 
 const auto kAddNewLayer                  { create("kAddNewLayer", "Add a New Layer") };
 const auto kAddSublayer                  { create("kAddSublayer", "Add sublayer") };
-const auto kAscii                        { create("kAscii", "ASCII") };
 const auto kAutoHideSessionLayer         { create("kAutoHideSessionLayer", "Auto-Hide Session Layer") };
-const auto kBinary                       { create("kBinary", "Binary") };
-const auto kConfirmExistFileSave         { create("kConfirmExistFileSave", "Confirm Save of Existing Files") };
 const auto kConvertToRelativePath        { create("kConvertToRelativePath", "Convert to Relative Path") };
 const auto kCancel                       { create("kCancel", "Cancel") };
 const auto kCreate                       { create("kCreate", "Create") };
@@ -90,7 +87,6 @@ const auto kToSaveTheStageSaveFiles      { create("kToSaveTheStageSaveFiles", "T
 const auto kUsedInStagesTooltip          { create("kUsedInStagesTooltip", "<b>Used in Stages</b>: ") };
 
 const auto kSetLayerAsTargetLayerTooltip { create("kSetLayerAsTargetLayerTooltip", "Set layer as target layer. Edits are added to the target layer.") };
-const auto kUsdSaveFileFormat            { create("kUsdSaveFileFormat", "Save .usd File Format") };
 const auto kUsdLayerIdentifier           { create("kUsdLayerIdentifier", "USD Layer identifier: ^1s") };
 const auto kUsdStage                     { create("kUsdStage", "USD Stage:") };
 const auto kPinUsdStageTooltip           { create("kPinUsdStage", "When unpinned, follow the USD stage selected in the outliner.") };
@@ -102,9 +98,6 @@ const auto kSaveAnonymousConfirmOverwriteTitle { create("kSaveAnonymousConfirmOv
 const auto kSaveAnonymousConfirmOverwrite { create("kSaveAnonymousConfirmOverwrite", "^1s file(s) already exist and will be overwritten.  Do you want to continue?")};
 const auto kSaveAnonymousIdenticalFilesTitle { create("kSaveAnonymousIdenticalFilesTitle", "Identical Names Error")};
 const auto kSaveAnonymousIdenticalFiles { create("kSaveAnonymousIdenticalFiles", "^1s files have identical file names and prevent correct saving.  Please select different file names for each layer. Here is the list of identical file names:<br>")};
-
-const auto kSaveLayerUsdFileFormatAnn    { create("kSaveLayerUsdFileFormatAnn", "Select whether the .usd file is written out in binary or ASCII. You can save a file in .usdc (binary) or .usda (ASCII) format. Manually entering a file name with an extension overrides the selection in this drop-down menu.") };
-const auto kSaveLayerUsdFileFormatSbm    { create("kSaveLayerUsdFileFormatSbm", "Select whether the .usd file is written out in binary or ASCII") };
 
 const auto kBatchSaveAllRelative { create("kBatchSaveAllRelative", "Convert All to Relative Paths")};
 const auto kBatchSaveRelativeToScene { create("kBatchSaveRelativeToScene", "Relative to Scene File")};

--- a/plugin/adsk/scripts/CMakeLists.txt
+++ b/plugin/adsk/scripts/CMakeLists.txt
@@ -17,6 +17,7 @@ list(APPEND scripts_src
     mayaUsd_pluginUIDeletion.mel
     mayaUsd_pluginBatchLoad.mel
     mayaUsd_pluginBatchUnload.mel
+    mayaUsd_preferenceTab.mel
     mayaUsd_selectionUtils.py
     mayaUsd_USDRootFileRelative.py
     usdFileSaveOptions.mel

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
@@ -243,6 +243,28 @@ global proc mayaUSDRegisterStrings()
     register("kMayaRefDuplicateAsUsdDataDiv", "Stages");
     register("kMayaRefDuplicateAsUsdDataOptions", "Options...");
 
+    // All strings for the USD Global Preferences:
+    register("kUSDPreferences", "USD: USD Preferences");
+    register("KSavingUSDFiles", "Save USD Files");
+    register("kdotusdFileFormat", ".usd File Format:");
+    register("kAscii", "ASCII");
+    register("kBinary", "Binary");
+    register("kSaveLayerUsdFileFormatAnn", "Select whether the .usd file is written out in binary or ASCII. You can save a file in .usdc (binary) or .usda (ASCII) format. Manually entering a file name with an extension overrides the selection in this preference.");
+    register("kSaveLayerUsdFileFormatSbm", "Select whether the .usd file is written out in binary or ASCII");
+    register("kConfirmExistFileSave", "Confirm Save of Existing Files");
+    register("kSavingMayaSceneFiles", "Save Maya Scene Files");
+    register("kSaveFileRelatively", "Save Files Relatively");
+    register("kAllRelativeToggle", "All files");
+    register("kAllRelativeToggleAnn", "When on, all of your files will be saved as relative paths.");
+    register("kRootLayersRelativeToSceneFile", "USD root layers");
+    register("kRootLayersRelativeToSceneFileAnn", "When on, your USD root layer file will be saved relatively to your Maya scene file.");
+    register("kSubLayersRelativeToParentLayer", "Sublayers");
+    register("kSubLayersRelativeToParentLayerAnn", "When on, all sublayers will be saved relatively to their parent layers.");
+    register("kReferencesRelativeToEditTargetLayer", "References/Payloads");
+    register("kReferencesRelativeToEditTargetLayerAnn", "When on, any references or payloads will be saved relatively to their respective edit target layer.");
+    register("kFileDependenciesRelativeToEditTargetLayer", "File dependencies");
+    register("kFileDependenciesRelativeToEditTargetLayerAnn", "When on, any file dependencies, such as textures or Maya references will be saved relatively to their respective edit target layer.");
+
     // Register the strings from the python equivalent register function.
     // Note: the strings from both the MEL and python register can be loaded
     //       by either MEL or python. They all get registered together under

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.py
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.py
@@ -40,6 +40,8 @@ def mayaUSDRegisterStrings():
     register("kMakePathRelativeToSceneFileAnn", "Path will be relative to your Maya scene file.")
     register("kMakePathRelativeToEditTargetLayer", "Make Path Relative to Edit Target Layer Directory")
     register("kMakePathRelativeToEditTargetLayerAnn", "Enable to activate relative pathing to your current edit target layer's directory.\nIf this option is disabled, verify that your target layer is not anonymous and save it to disk.")
+    register("kMakePathRelativeToImageEditTargetLayer", "Make Path Relative to Edit Target Layer Directory")
+    register("kMakePathRelativeToImageEditTargetLayerAnn", "Enable to activate relative pathing to your current edit target layer's directory.\nIf this option is disabled, verify that your target layer is not anonymous and save it to disk.")
     register("kMakePathRelativeToParentLayer", "Make Path Relative to Parent Layer Directory")
     register("kMakePathRelativeToParentLayerAnn", "Enable to activate relative pathing to your current parent layer's directory.\nIf this option is disabled, verify that your parent layer is not anonymous and save it to disk.")
     register("kUnresolvedPath", "Path Preview:")

--- a/plugin/adsk/scripts/mayaUsd_USDRootFileRelative.py
+++ b/plugin/adsk/scripts/mayaUsd_USDRootFileRelative.py
@@ -440,6 +440,9 @@ class usdImageRelativeToEditTargetLayer(usdFileRelativeToEditTargetLayer):
     '''
     Helper class to create the UI for image optionally relative to a layer file.
     '''
+
+    kRelativeToWhat = 'ImageEditTargetLayer'
+
     @classmethod
     def uiInit(cls, parentLayout, filterType):
         '''

--- a/plugin/adsk/scripts/mayaUsd_pluginUICreation.mel
+++ b/plugin/adsk/scripts/mayaUsd_pluginUICreation.mel
@@ -24,6 +24,16 @@ global proc mayaUsd_pluginUICreation()
     source "mayaUsdMenu.mel";
     mayaUsdMenu_loadui;
 
+    source "mayaUsd_preferenceTab.mel";
+    addCustomPrefsTab("mayaUsd_PrefCreateTab",
+                      "mayaUsd_PrefCreateFrameLayout",
+                      "mayaUsd_PrefUpdate",
+                      "mayaUsd_PrefHoldState",
+                      "mayaUsd_PrefSetOptVarsToDefault",
+                      `getMayaUsdString("kUSDPreferences")`,
+                      "USD");
+    mayaUsd_PrefInitOptionVars(false);
+
     source "mayaUsd_fileOptions.mel";
 
     // Set the default USD attributes we want to display

--- a/plugin/adsk/scripts/mayaUsd_pluginUIDeletion.mel
+++ b/plugin/adsk/scripts/mayaUsd_pluginUIDeletion.mel
@@ -6,5 +6,9 @@ global proc mayaUsd_pluginUIDeletion()
     // we do attempt to load it when this plugin gets loaded.  It is a utility
     // plugin that we depend on, but so could others so we will leave it alone.
 
+
+    // Unregister the Preferences tab.
+    deleteCustomPrefsTab("mayaUsd_PrefCreateTab");
+
     mayaUsdMenu_unloadui();
 }

--- a/plugin/adsk/scripts/mayaUsd_preferenceTab.mel
+++ b/plugin/adsk/scripts/mayaUsd_preferenceTab.mel
@@ -1,0 +1,415 @@
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// USD Preferences section in Maya preferences
+
+global proc mayaUsd_PrefSaveMayaSceneFilesChanged()
+{
+	int $saveOption = 1;
+	if (`radioButtonGrp -exists usdPrefSaveMayaSceneFiles`) {
+		$saveOption = `radioButtonGrp -q -select usdPrefSaveMayaSceneFiles`;
+		optionVar -iv mayaUsd_SerializedUsdEditsLocation $saveOption;
+	}
+	if (`text -exists usdPrefSaveOptions2GBWarning`) {
+		string $t = ($saveOption == 2) ? `getMayaUsdString("kSaveOption2GBWarning")` : "";
+		text -e -label $t usdPrefSaveOptions2GBWarning;
+	}
+	if (`checkBoxGrp -exists usdPrefSaveAskMe`) {
+		int $v = `checkBoxGrp -q -v1 usdPrefSaveAskMe`;
+		optionVar -iv mayaUsd_SerializedUsdEditsLocationPrompt $v;
+	}
+}
+
+global proc mayaUsd_PrefFileFormatChanged()
+{
+	if (`radioButtonGrp -exists usdPrefSaveFileFormat`) {
+		string $saveLayerFormatArgBinaryOptionPref = `python("import mayaUsd.lib as mlib; mlib.OptionVarTokens.SaveLayerFormatArgBinaryOption")`;
+		int $sel = `radioButtonGrp -q -select usdPrefSaveFileFormat`;
+		optionVar -iv $saveLayerFormatArgBinaryOptionPref ($sel == 1);	// Button 1 is binary
+	}
+	if (`checkBoxGrp -exists usdPrefConfirmExistFileSave`) {
+		string $confirmExistingFileSaveOptionPref = `python("import mayaUsd.lib as mlib; mlib.OptionVarTokens.ConfirmExistingFileSave")`;
+		int $v = `checkBoxGrp -q -v1 usdPrefConfirmExistFileSave`;
+		optionVar -iv $confirmExistingFileSaveOptionPref $v;
+	}
+}
+
+global proc mayaUsd_PrefAllRelative(int $v)
+{
+	// When true, check all the relative checkboxes.
+	// When false, uncheck all the relative checkboxes.
+	checkBoxGrp -e -v1 $v usdPrefRootLayerRelativeToSceneFile;
+	checkBoxGrp -e -v1 $v usdPrefSubLayersRelativeToParentLayer;
+	checkBoxGrp -e -v1 $v usdPrefRefererencesRelativeToEditTargetLayer;
+	checkBoxGrp -e -v1 $v usdPrefFileDependenciesRelativeToEditTargetLayer;
+
+	mayaUsd_PrefRelativeToChanged();
+}
+
+global proc mayaUsd_PrefRelativeToChanged()
+{
+	int $checkAll = true;
+	if (`checkBoxGrp -exists usdPrefRootLayerRelativeToSceneFile`) {
+		int $v = `checkBoxGrp -q -v1 usdPrefRootLayerRelativeToSceneFile`;
+		optionVar -iv mayaUsd_MakePathRelativeToSceneFile $v;
+		if ($v == false) $checkAll = false;
+	}
+	if (`checkBoxGrp -exists usdPrefSubLayersRelativeToParentLayer`) {
+		int $v = `checkBoxGrp -q -v1 usdPrefSubLayersRelativeToParentLayer`;
+		optionVar -iv mayaUsd_MakePathRelativeToParentLayer $v;
+		if ($v == false) $checkAll = false;
+	}
+	if (`checkBoxGrp -exists usdPrefRefererencesRelativeToEditTargetLayer`) {
+		int $v = `checkBoxGrp -q -v1 usdPrefRefererencesRelativeToEditTargetLayer`;
+		optionVar -iv mayaUsd_MakePathRelativeToEditTargetLayer $v;
+		if ($v == false) $checkAll = false;
+	}
+	if (`checkBoxGrp -exists usdPrefFileDependenciesRelativeToEditTargetLayer`) {
+		int $v = `checkBoxGrp -q -v1 usdPrefFileDependenciesRelativeToEditTargetLayer`;
+		optionVar -iv mayaUsd_MakePathRelativeToImageEditTargetLayer $v;
+		if ($v == false) $checkAll = false;
+	}
+
+	// If any of the relative checkboxes get unchecked, also uncheck the
+	// 'Create relative paths for all' checkbox
+	if (`checkBoxGrp -exists usdPrefAllRelativeToggle`) {
+		checkBoxGrp -e -v1 $checkAll usdPrefAllRelativeToggle;
+	}
+}
+
+global proc mayaUsd_PrefInitOptionVars(int $forceFactoryDefault)
+{
+	string $saveLayerFormatArgBinaryOptionPref = `python("import mayaUsd.lib as mlib; mlib.OptionVarTokens.SaveLayerFormatArgBinaryOption")`;
+	string $confirmExistingFileSaveOptionPref = `python("import mayaUsd.lib as mlib; mlib.OptionVarTokens.ConfirmExistingFileSave")`;
+
+	int $mjv = `about -majorVersion`;
+	if ($mjv <= 2022) {
+		if ($forceFactoryDefault || !`optionVar -exists mayaUsd_SerializedUsdEditsLocation`) {
+			optionVar -intValue mayaUsd_SerializedUsdEditsLocation 1;
+		}
+		if ($forceFactoryDefault || !`optionVar -exists mayaUsd_SerializedUsdEditsLocationPrompt`) {
+			optionVar -intValue mayaUsd_SerializedUsdEditsLocationPrompt 1;
+		}
+
+		if ($forceFactoryDefault || !`optionVar -exists $saveLayerFormatArgBinaryOptionPref`) {
+			optionVar -intValue $saveLayerFormatArgBinaryOptionPref true;
+		}
+		if ($forceFactoryDefault || !`optionVar -exists $confirmExistingFileSaveOptionPref`) {
+			optionVar -intValue $confirmExistingFileSaveOptionPref true;
+		}
+
+		if ($forceFactoryDefault || !`optionVar -exists mayaUsd_MakePathRelativeToSceneFile`) {
+			optionVar -intValue mayaUsd_MakePathRelativeToSceneFile false;
+		}
+		if ($forceFactoryDefault || !`optionVar -exists mayaUsd_MakePathRelativeToParentLayer`) {
+			optionVar -intValue mayaUsd_MakePathRelativeToParentLayer false;
+		}
+		if ($forceFactoryDefault || !`optionVar -exists mayaUsd_MakePathRelativeToEditTargetLayer`) {
+			optionVar -intValue mayaUsd_MakePathRelativeToEditTargetLayer false;
+		}
+		if ($forceFactoryDefault || !`optionVar -exists mayaUsd_MakePathRelativeToImageEditTargetLayer`) {
+			optionVar -intValue mayaUsd_MakePathRelativeToImageEditTargetLayer false;
+		}
+
+	} else {
+		optionVar -init $forceFactoryDefault -category "MayaUsd"
+			-intValue mayaUsd_SerializedUsdEditsLocation 1
+			-intValue mayaUsd_SerializedUsdEditsLocationPrompt 1
+		;
+
+		optionVar -init $forceFactoryDefault -category "MayaUsd"
+			-iv $saveLayerFormatArgBinaryOptionPref true
+			-iv $confirmExistingFileSaveOptionPref true
+		;
+
+		optionVar -init $forceFactoryDefault -category "MayaUsd"
+			-iv mayaUsd_MakePathRelativeToSceneFile false
+			-iv mayaUsd_MakePathRelativeToParentLayer false
+			-iv mayaUsd_MakePathRelativeToEditTargetLayer false
+			-iv mayaUsd_MakePathRelativeToImageEditTargetLayer false
+		;
+	}
+}
+
+global proc mayaUsd_PrefCreateTab()
+{
+	global string $gPreferenceWindow;
+	setParent $gPreferenceWindow;
+	string $parent = "mayaUsd_PrefLayout";
+
+	// Check to see if this has been created already.
+	if (`columnLayout -q -numberOfChildren $parent` > 0) {
+		mayaUsd_PrefUpdate();
+		return;
+	}
+
+	// Create the UI.
+	setParent $parent;
+	setUITemplate -pushTemplate prefsTemplate;
+
+	// This is used to force the width to fill the window.
+	separator -style "none" -h 1;
+
+	setParent $parent;
+	frameLayout -label `getMayaUsdString("kSavingMayaSceneFiles")`;
+		string $colLay = `columnLayout -adj true`;
+
+		radioButtonGrp
+			-vertical
+			-nrb 3
+			-select 1	// Default -> save Maya & USD
+			-label ""
+			-label1      `getMayaUsdString("kSaveOption1")`
+			-annotation1 `getMayaUsdString("kSaveOptionAnn1")`
+			-label2      `getMayaUsdString("kSaveOption2")`
+			-annotation2 `getMayaUsdString("kSaveOptionAnn2")`
+			-label3      `getMayaUsdString("kSaveOption3")`
+			-annotation3 `getMayaUsdString("kSaveOptionAnn3")`
+			-onCommand mayaUsd_PrefSaveMayaSceneFilesChanged
+			usdPrefSaveMayaSceneFiles;
+
+		rowLayout -nc 2 -cat 2 "left" 0 -cw2 142 310;
+		text -label "";
+		text -label "" usdPrefSaveOptions2GBWarning;
+		setParent $colLay;
+
+		checkBoxGrp
+			-ncb 1
+			-label ""
+			-label1 `getMayaUsdString("kSaveOptionAsk")`
+			-ann `getMayaUsdString("kSaveOptionAskAnn")`
+			-v1 true	// Default -> checked
+			-changeCommand mayaUsd_PrefSaveMayaSceneFilesChanged
+			usdPrefSaveAskMe;
+
+	setParent $parent;
+	frameLayout -label `getMayaUsdString("KSavingUSDFiles")`;
+		columnLayout -adj true;
+		radioButtonGrp
+			-nrb 2
+			-label `getMayaUsdString("kdotusdFileFormat")`
+			-label1 `getMayaUsdString("kBinary")`
+			-label2 `getMayaUsdString("kAscii")`
+			-select 1	// Default -> Binary
+			-onCommand mayaUsd_PrefFileFormatChanged
+			usdPrefSaveFileFormat;
+		checkBoxGrp
+			-ncb 1
+			-label ""
+			-label1 `getMayaUsdString("kConfirmExistFileSave")`
+			-v1 true	// Default -> checked
+			-changeCommand mayaUsd_PrefFileFormatChanged
+			usdPrefConfirmExistFileSave;
+
+	setParent $parent;
+	frameLayout -label `getMayaUsdString("kSaveFileRelatively")`;
+		columnLayout -adj true;
+		checkBoxGrp
+			-ncb 1
+			-label ""
+			-label1 `getMayaUsdString("kAllRelativeToggle")`
+			-ann `getMayaUsdString("kAllRelativeToggleAnn")`
+			-v1 false	// default -> not checked
+			-changeCommand "mayaUsd_PrefAllRelative(#1)"
+			usdPrefAllRelativeToggle;
+		checkBoxGrp
+			-ncb 1
+			-label ""
+			-label1 `getMayaUsdString("kRootLayersRelativeToSceneFile")`
+			-ann `getMayaUsdString("kRootLayersRelativeToSceneFileAnn")`
+			-v1 false	// default -> not checked
+			-changeCommand mayaUsd_PrefRelativeToChanged
+			usdPrefRootLayerRelativeToSceneFile;
+		checkBoxGrp
+			-ncb 1
+			-label ""
+			-label1 `getMayaUsdString("kSubLayersRelativeToParentLayer")`
+			-ann `getMayaUsdString("kSubLayersRelativeToParentLayerAnn")`
+			-v1 false	// default -> not checked
+			-changeCommand mayaUsd_PrefRelativeToChanged
+			usdPrefSubLayersRelativeToParentLayer;
+		checkBoxGrp
+			-ncb 1
+			-label ""
+			-label1 `getMayaUsdString("kReferencesRelativeToEditTargetLayer")`
+			-ann `getMayaUsdString("kReferencesRelativeToEditTargetLayerAnn")`
+			-v1 false	// default -> not checked
+			-changeCommand mayaUsd_PrefRelativeToChanged
+			usdPrefRefererencesRelativeToEditTargetLayer;
+		checkBoxGrp
+			-ncb 1
+			-label ""
+			-label1 `getMayaUsdString("kFileDependenciesRelativeToEditTargetLayer")`
+			-ann `getMayaUsdString("kFileDependenciesRelativeToEditTargetLayerAnn")`
+			-v1 false	// default -> not checked
+			-changeCommand mayaUsd_PrefRelativeToChanged
+			usdPrefFileDependenciesRelativeToEditTargetLayer;
+
+	setUITemplate -popTemplate;
+
+	mayaUsd_PrefUpdate();
+}
+
+global proc mayaUsd_PrefCreateFrameLayout()
+{
+	frameLayout -labelVisible false -borderVisible false -marginWidth 10 -marginHeight 10;
+	columnLayout -adj true mayaUsd_PrefLayout;
+}
+
+global proc mayaUsd_PrefUpdate()
+{
+	global string $gPreferenceWindow;
+	setParent $gPreferenceWindow;
+	string $parent = "mayaUsd_PrefLayout";
+	
+	if (`columnLayout -q -numberOfChildren $parent` == 0) {
+		return;
+	}
+
+	setParent $parent;
+
+	if (`optionVar -exists mayaUsd_SerializedUsdEditsLocation`) {
+		int $saveOption = `optionVar -q mayaUsd_SerializedUsdEditsLocation`;
+		radioButtonGrp -e -select $saveOption usdPrefSaveMayaSceneFiles;
+
+		string $t = ($saveOption == 2) ? `getMayaUsdString("kSaveOption2GBWarning")` : "";
+		text -e -label $t usdPrefSaveOptions2GBWarning;
+	}
+
+	if (`optionVar -exists mayaUsd_SerializedUsdEditsLocationPrompt`) {
+		int $v = `optionVar -q mayaUsd_SerializedUsdEditsLocationPrompt`;
+		checkBoxGrp -e -v1 $v usdPrefSaveAskMe;
+	}
+
+	string $saveLayerFormatArgBinaryOptionPref = `python("import mayaUsd.lib as mlib; mlib.OptionVarTokens.SaveLayerFormatArgBinaryOption")`;
+	if (`optionVar -exists $saveLayerFormatArgBinaryOptionPref`) {
+		int $isBinary = `optionVar -q $saveLayerFormatArgBinaryOptionPref`;
+		radioButtonGrp -e -select ($isBinary ? 1 : 2) usdPrefSaveFileFormat;
+	}
+
+	string $confirmExistingFileSaveOptionPref = `python("import mayaUsd.lib as mlib; mlib.OptionVarTokens.ConfirmExistingFileSave")`;
+	if (`optionVar -exists $confirmExistingFileSaveOptionPref`) {
+		checkBoxGrp -e -v1
+			`optionVar -q $confirmExistingFileSaveOptionPref`
+			usdPrefConfirmExistFileSave;
+	}
+
+	int $checkAll = true;
+	if (`optionVar -exists "mayaUsd_MakePathRelativeToSceneFile"`) {
+		int $v = `optionVar -q "mayaUsd_MakePathRelativeToSceneFile"`;
+		checkBoxGrp -e -v1 $v usdPrefRootLayerRelativeToSceneFile;
+		if ($v == false) $checkAll = false;
+	}
+
+	if (`optionVar -exists "mayaUsd_MakePathRelativeToParentLayer"`) {
+		int $v = `optionVar -q "mayaUsd_MakePathRelativeToParentLayer"`;
+		checkBoxGrp -e -v1 $v usdPrefSubLayersRelativeToParentLayer;
+		if ($v == false) $checkAll = false;
+	}
+
+	if (`optionVar -exists "mayaUsd_MakePathRelativeToEditTargetLayer"`) {
+		int $v = `optionVar -q "mayaUsd_MakePathRelativeToEditTargetLayer"`;
+		checkBoxGrp -e -v1 $v usdPrefRefererencesRelativeToEditTargetLayer;
+		if ($v == false) $checkAll = false;
+	}
+
+	if (`optionVar -exists "mayaUsd_MakePathRelativeToImageEditTargetLayer"`) {
+		int $v = `optionVar -q "mayaUsd_MakePathRelativeToImageEditTargetLayer"`;
+		checkBoxGrp -e -v1 $v usdPrefFileDependenciesRelativeToEditTargetLayer;
+		if ($v == false) $checkAll = false;
+	}
+
+	// If any of the relative checkboxes get unchecked, also uncheck the
+	// 'Create relative paths for all' checkbox
+	checkBoxGrp -e -v1 $checkAll usdPrefAllRelativeToggle;
+}
+
+global proc mayaUsd_PrefHoldState(string $mode)
+{
+	mayaUsd_PrefSaveMayaSceneFilesChanged();
+	mayaUsd_PrefFileFormatChanged();
+	mayaUsd_PrefRelativeToChanged();
+
+	string $saveLayerFormatArgBinaryOptionPref = `python("import mayaUsd.lib as mlib; mlib.OptionVarTokens.SaveLayerFormatArgBinaryOption")`;
+	string $confirmExistingFileSaveOptionPref = `python("import mayaUsd.lib as mlib; mlib.OptionVarTokens.ConfirmExistingFileSave")`;
+
+	string $prefOptionVars[] = {
+		"mayaUsd_SerializedUsdEditsLocation",
+		"mayaUsd_SerializedUsdEditsLocationPrompt",
+		$saveLayerFormatArgBinaryOptionPref,
+		$confirmExistingFileSaveOptionPref,
+		"mayaUsd_MakePathRelativeToSceneFile",
+		"mayaUsd_MakePathRelativeToParentLayer",
+		"mayaUsd_MakePathRelativeToEditTargetLayer",
+		"mayaUsd_MakePathRelativeToImageEditTargetLayer"
+	};
+	prefsHoldOptionVars($prefOptionVars, $mode); 
+
+	if ($mode == "remove") {
+		// Finalize preference changes into MayaUsd.
+	}
+
+	global string $gPreferenceWindow;
+	if (`window -exists $gPreferenceWindow`) {
+		setParent mayaUsd_PrefLayout;
+
+		if (`radioButtonGrp -exists usdPrefSaveMayaSceneFiles`) {
+			radioButtonGrp -e -select
+				`optionVar -q mayaUsd_SerializedUsdEditsLocation`
+				usdPrefSaveMayaSceneFiles;
+		}
+		if (`checkBoxGrp -exists usdPrefSaveAskMe`) {
+			checkBoxGrp -e -v1
+				`optionVar -q mayaUsd_SerializedUsdEditsLocationPrompt`
+				usdPrefSaveAskMe;
+		}
+
+		if (`radioButtonGrp -exists usdPrefSaveFileFormat`) {
+			int $isBinary = `optionVar -q $saveLayerFormatArgBinaryOptionPref`;
+			radioButtonGrp -e -select ($isBinary ? 1 : 2) usdPrefSaveFileFormat;
+		}
+		if (`checkBoxGrp -exists usdPrefConfirmExistFileSave`) {
+			checkBoxGrp -e -v1
+				`optionVar -q $confirmExistingFileSaveOptionPref`
+				usdPrefConfirmExistFileSave;
+		}
+
+		if (`checkBoxGrp -exists usdPrefRootLayerRelativeToSceneFile`) {
+			checkBoxGrp -e -v1
+				`optionVar -q mayaUsd_MakePathRelativeToSceneFile`
+				usdPrefRootLayerRelativeToSceneFile;
+		}
+		if (`checkBoxGrp -exists usdPrefSubLayersRelativeToParentLayer`) {
+			checkBoxGrp -e -v1
+				`optionVar -q mayaUsd_MakePathRelativeToParentLayer`
+				usdPrefSubLayersRelativeToParentLayer;
+		}
+		if (`checkBoxGrp -exists usdPrefRefererencesRelativeToEditTargetLayer`) {
+			checkBoxGrp -e -v1
+				`optionVar -q mayaUsd_MakePathRelativeToEditTargetLayer`
+				usdPrefRefererencesRelativeToEditTargetLayer;
+		}
+		if (`checkBoxGrp -exists usdPrefFileDependenciesRelativeToEditTargetLayer`) {
+			checkBoxGrp -e -v1
+				`optionVar -q mayaUsd_MakePathRelativeToImageEditTargetLayer`
+				usdPrefFileDependenciesRelativeToEditTargetLayer;
+		}
+	}
+}
+
+global proc mayaUsd_PrefSetOptVarsToDefault()
+{
+	mayaUsd_PrefInitOptionVars(true);
+}

--- a/plugin/adsk/scripts/usdFileSaveOptions.mel
+++ b/plugin/adsk/scripts/usdFileSaveOptions.mel
@@ -15,11 +15,19 @@
 
 proc setOptionVars(int $forceFactorySettings)
 {
-    if ($forceFactorySettings || !`optionVar -exists mayaUsd_SerializedUsdEditsLocation`)
-        optionVar -intValue mayaUsd_SerializedUsdEditsLocation 1;
+    int $mjv = `about -majorVersion`;
+    if ($mjv <= 2022) {
+        if ($forceFactorySettings || !`optionVar -exists mayaUsd_SerializedUsdEditsLocation`)
+            optionVar -intValue mayaUsd_SerializedUsdEditsLocation 1;
 
-    if ($forceFactorySettings || !`optionVar -exists mayaUsd_SerializedUsdEditsLocationPrompt`)
-        optionVar -intValue mayaUsd_SerializedUsdEditsLocationPrompt 1;
+        if ($forceFactorySettings || !`optionVar -exists mayaUsd_SerializedUsdEditsLocationPrompt`)
+            optionVar -intValue mayaUsd_SerializedUsdEditsLocationPrompt 1;
+    } else {
+        optionVar -init $forceFactorySettings -category "MayaUsd"
+            -intValue mayaUsd_SerializedUsdEditsLocation 1
+            -intValue mayaUsd_SerializedUsdEditsLocationPrompt 1
+        ;
+    }
 }
 
 global proc saveOptionsAndCloseUSDSaveOptionDialog(string $parent)


### PR DESCRIPTION
#### EMSUSD-287 - USD preference section
* New MEL file "mayaUsd_preferenceTab.mel" containing the USD preference dialog code. Added when mayaUsdPlugin is loaded.
* Removed "saving usd files" options from LayerEditor and move them to USD preferences.
* New optionVar for Image relative.
* For LE bulk saveas, set the initial state of relative checkboxes from optionVars.
* In LE fixed initial dialog size.