### PR TITLE
EMSUSD-490 Fixes outerliner not refreshing when performing a UsdUndoVisibleCommand

### DIFF
--- a/lib/usdUfe/ufe/StagesSubject.cpp
+++ b/lib/usdUfe/ufe/StagesSubject.cpp
@@ -162,6 +162,12 @@ void sendAttributeChanged(
         }
     } break;
     case AttributeChangeType::kRemoved: {
+        // Special case when Undoing a visibility change, the notice.GetChangedInfoOnlyPaths()
+        // does not contain the change, hence handling visibility notification in re-synch path.
+        if (changedToken == UsdGeomTokens->visibility) {
+            Ufe::VisibilityChanged vis(ufePath);
+            notifyWithoutExceptions<Ufe::Object3d>(vis);
+        }
         notifyWithoutExceptions<Ufe::Attributes>(
             Ufe::AttributeRemoved(ufePath, changedToken.GetString()));
     } break;
@@ -395,12 +401,7 @@ void StagesSubject::stageChanged(
                     notifyWithoutExceptions<Ufe::Transform3d>(ufePath);
                 }
             }
-            // Special case when Undoing a visibility change, the notice.GetChangedInfoOnlyPaths()
-            // does not contain the change, hence handling visibility notification in re-synch path.
-            if (changedPath.GetNameToken() == UsdGeomTokens->visibility) {
-                Ufe::VisibilityChanged vis(ufePath);
-                notifyWithoutExceptions<Ufe::Object3d>(vis);
-            }
+
             processAttributeChanges(ufePath, changedPath, it.base()->second);
 
             // No further processing for this prim property path is required.

--- a/lib/usdUfe/ufe/StagesSubject.cpp
+++ b/lib/usdUfe/ufe/StagesSubject.cpp
@@ -384,7 +384,7 @@ void StagesSubject::stageChanged(
         const auto& changedPath = *it;
         if (changedPath.IsPrimPropertyPath()) {
             // Special case to detect when an xformop is added or removed from a prim.
-            // We need to send some notifs so DCC can update (such as on undo
+            // We need to send some notifications so DCC can update (such as on undo
             // to move the transform manipulator back to original position).
             const TfToken nameToken = changedPath.GetNameToken();
             auto          usdPrimPathStr = changedPath.GetPrimPath().GetString();
@@ -395,7 +395,14 @@ void StagesSubject::stageChanged(
                     notifyWithoutExceptions<Ufe::Transform3d>(ufePath);
                 }
             }
+            // Special case when Undoing a visibility change, the notice.GetChangedInfoOnlyPaths() does not 
+            // contain the change, hence handling visibility notification in re-synch path.
+            if (changedPath.GetNameToken() == UsdGeomTokens->visibility) {
+                Ufe::VisibilityChanged vis(ufePath);
+                notifyWithoutExceptions<Ufe::Object3d>(vis);
+            }
             processAttributeChanges(ufePath, changedPath, it.base()->second);
+            
             // No further processing for this prim property path is required.
             continue;
         }

--- a/lib/usdUfe/ufe/StagesSubject.cpp
+++ b/lib/usdUfe/ufe/StagesSubject.cpp
@@ -395,14 +395,14 @@ void StagesSubject::stageChanged(
                     notifyWithoutExceptions<Ufe::Transform3d>(ufePath);
                 }
             }
-            // Special case when Undoing a visibility change, the notice.GetChangedInfoOnlyPaths() does not 
-            // contain the change, hence handling visibility notification in re-synch path.
+            // Special case when Undoing a visibility change, the notice.GetChangedInfoOnlyPaths()
+            // does not contain the change, hence handling visibility notification in re-synch path.
             if (changedPath.GetNameToken() == UsdGeomTokens->visibility) {
                 Ufe::VisibilityChanged vis(ufePath);
                 notifyWithoutExceptions<Ufe::Object3d>(vis);
             }
             processAttributeChanges(ufePath, changedPath, it.base()->second);
-            
+
             // No further processing for this prim property path is required.
             continue;
         }


### PR DESCRIPTION
When undoing a visibility command, UsdNotice::ObjectsChanged does not produce a path for Info Change but still generates a path for Re-sync Change which has the Visibility token. The special case is added to refresh when in the latter path. 