### PR TITLE
EMSUSD-623 edit as Maya multiple variants

### DIFF
--- a/lib/mayaUsd/fileio/orphanedNodesManager.h
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.h
@@ -96,6 +96,10 @@ public:
         std::list<VariantSetDescriptor> variantSetDescriptors;
     };
 
+    using PullVariantInfos = std::vector<PullVariantInfo>;
+    using PulledPrims = Ufe::Trie<PullVariantInfos>;
+    using PulledPrimNode = Ufe::TrieNode<PullVariantInfos>;
+
     /// \brief Entire state of the OrphanedNodesManager at a point in time, used for undo/redo.
     class MAYAUSD_CORE_PUBLIC Memento
     {
@@ -117,11 +121,11 @@ public:
         // Private, for opacity.
         friend class OrphanedNodesManager;
 
-        Memento(Ufe::Trie<PullVariantInfo>&& pulledPrims);
+        Memento(PulledPrims&& pulledPrims);
 
-        Ufe::Trie<PullVariantInfo> release();
+        PulledPrims release();
 
-        Ufe::Trie<PullVariantInfo> _pulledPrims;
+        PulledPrims _pulledPrims;
     };
 
     // Construct an empty orphan manager.
@@ -135,14 +139,17 @@ public:
     // Asserts that the pulled path is not in the trie.
     void add(const Ufe::Path& pulledPath, const MDagPath& editedAsMayaRoot);
 
+    // Verify if the pulled path and the root of the generated
+    // Maya nodes to the trie of pulled prims are alredy tracked.
+    bool has(const Ufe::Path& pulledPath, const MDagPath& editedAsMayaRoot) const;
+
+    // Verify if the pulled path with its current variant set is alredy tracked.
+    bool has(const Ufe::Path& pulledPath) const;
+
     // Remove the pulled path from the trie of pulled prims.  Asserts that the
     // path is in the trie.  Returns a memento (see Memento Pattern) for undo
     // purposes, to be used as argument to restore().
-    Memento remove(const Ufe::Path& pulledPath);
-
-    // Retrieve the variant information of a pulled prim.
-    // Returns an empty info if the prim was not tracked by the orphan manager.
-    const PullVariantInfo& get(const Ufe::Path& pulledPath) const;
+    Memento remove(const Ufe::Path& pulledPath, const MDagPath& editedAsMayaRoot);
 
     // Preserve the trie of pulled prims into a memento.
     Memento preserve() const;
@@ -158,10 +165,8 @@ public:
 
     // Return whether the Dag hierarchy corresponding to the pulled path is
     // orphaned.
-    bool isOrphaned(const Ufe::Path& pulledPath) const;
+    bool isOrphaned(const Ufe::Path& pulledPath, const MDagPath& editedAsMayaRoot) const;
 
-    using PulledPrims = Ufe::Trie<PullVariantInfo>;
-    using PulledPrimNode = Ufe::TrieNode<PullVariantInfo>;
     const PulledPrims& getPulledPrims() const { return _pulledPrims; }
 
 private:
@@ -171,6 +176,10 @@ private:
     static void recursiveSwitch(const PulledPrimNode::Ptr& trieNode, const Ufe::Path& ufePath);
 
     static bool setOrphaned(const PulledPrimNode::Ptr& trieNode, bool orphaned);
+    static bool setOrphaned(
+        const PulledPrimNode::Ptr& trieNode,
+        const PullVariantInfo&     variantInfo,
+        bool                       orphaned);
 
     // Member function to access private nested classes.
     static std::list<VariantSetDescriptor> variantSetDescriptors(const Ufe::Path& path);

--- a/lib/mayaUsd/fileio/orphanedNodesManagerIO.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManagerIO.cpp
@@ -49,6 +49,20 @@ namespace {
 //                       ],
 //                   },
 //                ],
+//                "more pull info": [
+//                   {
+//                      "editedAsMayaRoot": "DAG-path-of-root-of-generated-Maya-data"
+//                      "variantSetDescriptors": [
+//                         {
+//                            "path": "UFE-path-of-one-ancestor",
+//                            "variantSelections": [
+//                               [ "variant-set-1-name", "variant-set-1-selection" ],
+//                               [ "variant-set-2-name", "variant-set-2-selection" ],
+//                            ],
+//                         },
+//                      ],
+//                   },
+//                ],
 //             },
 //          },
 //       },
@@ -59,6 +73,7 @@ namespace {
 
 static const std::string ufeComponentPrefix = "/";
 static const std::string pullInfoJsonKey = "pull info";
+static const std::string morePullInfoJsonKey = "more pull info";
 static const std::string editedAsMayaRootJsonKey = "editedAsMayaRoot";
 static const std::string variantSetDescriptorsJsonKey = "variantSetDescriptors";
 static const std::string pathJsonKey = "path";
@@ -74,8 +89,9 @@ using VariantSelection = OrphanedNodesManager::VariantSelection;
 using VariantSetDesc = OrphanedNodesManager::VariantSetDescriptor;
 using VariantSetDescList = std::list<VariantSetDesc>;
 using PullVariantInfo = OrphanedNodesManager::PullVariantInfo;
-using PullInfoTrie = Ufe::Trie<PullVariantInfo>;
-using PullInfoTrieNode = Ufe::TrieNode<PullVariantInfo>;
+using PullVariantInfos = std::vector<PullVariantInfo>;
+using PullInfoTrie = OrphanedNodesManager::PulledPrims;
+using PullInfoTrieNode = OrphanedNodesManager::PulledPrimNode;
 using Memento = OrphanedNodesManager::Memento;
 
 ////////////////////////////////////////////////////////////////////////////
@@ -90,6 +106,7 @@ PXR_NS::JsArray  convertToArray(const VariantSelection& variantSel);
 PXR_NS::JsObject convertToObject(const VariantSetDesc& variantDesc);
 PXR_NS::JsArray  convertToArray(const std::list<VariantSetDesc>& allVariantDesc);
 PXR_NS::JsObject convertToObject(const PullVariantInfo& pullInfo);
+PXR_NS::JsObject convertToObject(const PullVariantInfos& pullInfos);
 PXR_NS::JsObject convertToObject(const PullInfoTrieNode::Ptr& pullInfoNode);
 PXR_NS::JsObject convertToObject(const PullInfoTrie& allPulledInfo);
 
@@ -97,6 +114,7 @@ VariantSelection   convertToVariantSelection(const PXR_NS::JsArray& variantSelJs
 VariantSetDesc     convertToVariantSetDescriptor(const PXR_NS::JsObject& variantDescJson);
 VariantSetDescList convertToVariantSetDescList(const PXR_NS::JsArray& allVariantDescJson);
 PullVariantInfo    convertToPullVariantInfo(const PXR_NS::JsObject& pullInfoJson);
+PullVariantInfos   convertToPullVariantInfos(const PXR_NS::JsObject& pullInfoJson);
 void         convertToPullInfoTrieNodePtr(const PXR_NS::JsObject&, PullInfoTrieNode::Ptr intoRoot);
 PullInfoTrie convertToPullInfoTrie(const PXR_NS::JsObject& allPulledInfoJson);
 
@@ -199,6 +217,44 @@ PullVariantInfo convertToPullVariantInfo(const PXR_NS::JsObject& pullInfoJson)
     return pullInfo;
 }
 
+PXR_NS::JsObject convertToObject(const PullVariantInfos& pullInfos)
+{
+    PXR_NS::JsObject pullInfoJson;
+
+    if (pullInfos.size() > 0) {
+        pullInfoJson = convertToObject(pullInfos[0]);
+    }
+
+    if (pullInfos.size() > 1) {
+        PXR_NS::JsArray morePullInfoJson;
+        for (size_t i = 1; i < pullInfos.size(); ++i) {
+            PXR_NS::JsObject moreInfoJson = convertToObject(pullInfos[i]);
+            morePullInfoJson.emplace_back(moreInfoJson);
+        }
+        pullInfoJson[morePullInfoJsonKey] = morePullInfoJson;
+    }
+
+    return pullInfoJson;
+}
+
+PullVariantInfos convertToPullVariantInfos(const PXR_NS::JsObject& pullInfoJson)
+{
+    PullVariantInfos pullInfos;
+
+    if (pullInfoJson.count(editedAsMayaRootJsonKey)) {
+        pullInfos.emplace_back(convertToPullVariantInfo(pullInfoJson));
+    }
+
+    if (pullInfoJson.count(morePullInfoJsonKey)) {
+        PXR_NS::JsArray morePullInfoJson
+            = convertToArray(convertJsonKeyToValue(pullInfoJson, morePullInfoJsonKey));
+        for (const PXR_NS::JsValue& value : morePullInfoJson) {
+            pullInfos.emplace_back(convertToPullVariantInfo(convertToObject(value)));
+        }
+    }
+    return pullInfos;
+}
+
 PXR_NS::JsObject convertToObject(const PullInfoTrieNode::Ptr& pullInfoNodePtr)
 {
     if (!pullInfoNodePtr)
@@ -208,7 +264,7 @@ PXR_NS::JsObject convertToObject(const PullInfoTrieNode::Ptr& pullInfoNodePtr)
 
     PXR_NS::JsObject pullInfoNodeJson;
 
-    if (pullInfoNode.hasData()) {
+    if (pullInfoNode.hasData() && pullInfoNode.data().size() > 0) {
         pullInfoNodeJson[pullInfoJsonKey] = convertToObject(pullInfoNode.data());
     }
 
@@ -232,7 +288,7 @@ void convertToPullInfoTrieNodePtr(
         if (key.size() <= 0) {
             continue;
         } else if (key == pullInfoJsonKey) {
-            intoRoot->setData(convertToPullVariantInfo(convertToObject(value)));
+            intoRoot->setData(convertToPullVariantInfos(convertToObject(value)));
 
         } else if (key[0] == '/') {
             PullInfoTrieNode::Ptr child = std::make_shared<PullInfoTrieNode>(key.substr(1));

--- a/lib/mayaUsd/fileio/primUpdaterManager.h
+++ b/lib/mayaUsd/fileio/primUpdaterManager.h
@@ -114,8 +114,11 @@ private:
     //! Create the pull parent and set it into the prim updater context.
     MDagPath setupPullParent(const Ufe::Path& pulledPath, VtDictionary& args);
 
-    //! Record pull information for the pulled path, for inspection on
-    //! scene changes.
+    //! Verify if the given prim at the given UFE path is an ancestor of an already edited prim.
+    bool hasEditedDescendant(const Ufe::Path& ufeQueryPath) const;
+
+//! Record pull information for the pulled path, for inspection on
+//! scene changes.
 #ifdef HAS_ORPHANED_NODES_MANAGER
     // Maya file new or open callback.  Member function to access other private
     // member functions.

--- a/lib/mayaUsd/fileio/pullInformation.cpp
+++ b/lib/mayaUsd/fileio/pullInformation.cpp
@@ -18,6 +18,7 @@
 
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/utils/primActivation.h>
+#include <mayaUsd/utils/variants.h>
 
 #include <usdUfe/utils/usdUtils.h>
 
@@ -38,8 +39,14 @@ namespace MAYAUSD_NS_DEF {
 
 namespace {
 
-// Metadata key used to store pull information on a prim
+// Metadata key used to store pull information on a prim.
+//
+// Note: we have two versions, because historically we did not author
+//       the metadata inside variants. To support backward compatibility
+//       we need to read from both, starting with the newer, variant-specific
+//       one.
 const PXR_NS::TfToken kPullPrimMetadataKey("Maya:Pull:DagPath");
+const PXR_NS::TfToken kPullPrimVariantMetadataKey("Maya:PullVariant:DagPath");
 
 // Metadata key used to store pull information on a DG node
 const MString kPullDGMetadataKey("Pull_UfePath");
@@ -53,7 +60,12 @@ const MString kPullDGMetadataKey("Pull_UfePath");
 
 bool readPullInformation(const PXR_NS::UsdPrim& prim, std::string& dagPathStr)
 {
-    auto value = prim.GetCustomDataByKey(kPullPrimMetadataKey);
+    PXR_NS::VtValue value = prim.GetCustomDataByKey(kPullPrimVariantMetadataKey);
+    if (!value.IsEmpty() && value.CanCast<std::string>()) {
+        dagPathStr = value.Get<std::string>();
+        return !dagPathStr.empty();
+    }
+    value = prim.GetCustomDataByKey(kPullPrimMetadataKey);
     if (!value.IsEmpty() && value.CanCast<std::string>()) {
         dagPathStr = value.Get<std::string>();
         return !dagPathStr.empty();
@@ -139,21 +151,47 @@ bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& edited
 
 bool writePulledPrimMetadata(const Ufe::Path& ufePulledPath, const MDagPath& editedAsMayaRoot)
 {
+    return writePulledPrimMetadata(ufePulledPath, editedAsMayaRoot, PXR_NS::UsdEditTarget());
+}
+
+bool writePulledPrimMetadata(
+    const Ufe::Path&             ufePulledPath,
+    const MDagPath&              editedAsMayaRoot,
+    const PXR_NS::UsdEditTarget& editTarget)
+{
     auto pulledPrim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
     if (!pulledPrim)
         return false;
-    return writePulledPrimMetadata(pulledPrim, editedAsMayaRoot);
+
+    return writePulledPrimMetadata(pulledPrim, editedAsMayaRoot, editTarget);
 }
 
 bool writePulledPrimMetadata(PXR_NS::UsdPrim& pulledPrim, const MDagPath& editedAsMayaRoot)
+{
+    return writePulledPrimMetadata(pulledPrim, editedAsMayaRoot, PXR_NS::UsdEditTarget());
+}
+
+bool writePulledPrimMetadata(
+    PXR_NS::UsdPrim&             pulledPrim,
+    const MDagPath&              editedAsMayaRoot,
+    const PXR_NS::UsdEditTarget& editTarget)
 {
     auto stage = pulledPrim.GetStage();
     if (!stage)
         return false;
 
-    PXR_NS::UsdEditContext editContext(stage, stage->GetSessionLayer());
-    PXR_NS::VtValue        value(editedAsMayaRoot.fullPathName().asChar());
-    return pulledPrim.SetMetadataByDictKey(SdfFieldKeys->CustomData, kPullPrimMetadataKey, value);
+    // If the edit target is null, then target the exact set of variants under
+    // which the USD prim lives to set the custom metadata. That way if multiple
+    // prims with the same name but under different variants exists, they won't
+    // step on each other's data.
+    const PXR_NS::UsdEditContext editContext(
+        stage,
+        editTarget.IsNull() ? getEditTargetForVariants(pulledPrim, stage->GetSessionLayer())
+                            : editTarget);
+
+    const PXR_NS::VtValue value(editedAsMayaRoot.fullPathName().asChar());
+    return pulledPrim.SetMetadataByDictKey(
+        SdfFieldKeys->CustomData, kPullPrimVariantMetadataKey, value);
 }
 
 //------------------------------------------------------------------------------
@@ -163,20 +201,60 @@ bool writePulledPrimMetadata(PXR_NS::UsdPrim& pulledPrim, const MDagPath& edited
 
 void removePulledPrimMetadata(const Ufe::Path& ufePulledPath)
 {
+    removePulledPrimMetadata(ufePulledPath, PXR_NS::UsdEditTarget());
+}
+
+void removePulledPrimMetadata(
+    const Ufe::Path&             ufePulledPath,
+    const PXR_NS::UsdEditTarget& editTarget)
+{
     PXR_NS::UsdPrim prim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
-    if (!prim.IsValid())
+    if (!prim.IsValid()) {
+        TF_WARN(
+            "Could not find prim to remove pulled prim metadata on %s.",
+            ufePulledPath.string().c_str());
         return;
+    }
 
     PXR_NS::UsdStagePtr stage = prim.GetStage();
     if (!stage)
         return;
-    removePulledPrimMetadata(stage, prim);
+
+    removePulledPrimMetadata(stage, prim, editTarget);
 }
 
-void removePulledPrimMetadata(const PXR_NS::UsdStagePtr& stage, PXR_NS::UsdPrim& prim)
+void removePulledPrimMetadata(const PXR_NS::UsdStagePtr& stage, PXR_NS::UsdPrim& pulledPrim)
 {
-    PXR_NS::UsdEditContext editContext(stage, stage->GetSessionLayer());
-    prim.ClearCustomDataByKey(kPullPrimMetadataKey);
+    removePulledPrimMetadata(stage, pulledPrim, PXR_NS::UsdEditTarget());
+}
+
+void removePulledPrimMetadata(
+    const PXR_NS::UsdStagePtr&   stage,
+    PXR_NS::UsdPrim&             pulledPrim,
+    const PXR_NS::UsdEditTarget& editTarget)
+{
+    // Note: this is the old prim data that was not variant-specific,
+    //       so it is removed without using the edit target.
+    pulledPrim.ClearCustomDataByKey(kPullPrimMetadataKey);
+
+    // If the edit target is null, then target the exact set of variants
+    // under which the USD prim lives to clear the custom metadata. That
+    // way if multiple prims with the same name but under  different
+    // variants exists, they won't step on each other's data.
+    {
+        const PXR_NS::UsdEditContext editContext(
+            stage,
+            editTarget.IsNull() ? getEditTargetForVariants(pulledPrim, stage->GetSessionLayer())
+                                : editTarget);
+
+        pulledPrim.ClearCustomDataByKey(kPullPrimVariantMetadataKey);
+    }
+
+    // Session layer cleanup.
+    auto rootPrims = stage->GetSessionLayer()->GetRootPrims();
+    for (const SdfPrimSpecHandle& rootPrimSpec : rootPrims) {
+        stage->GetSessionLayer()->RemovePrimIfInert(rootPrimSpec);
+    }
 }
 
 //------------------------------------------------------------------------------
@@ -186,6 +264,15 @@ void removePulledPrimMetadata(const PXR_NS::UsdStagePtr& stage, PXR_NS::UsdPrim&
 // in the viewport.
 
 bool addExcludeFromRendering(const Ufe::Path& ufePulledPath)
+{
+    // Note: passing an invalid edit target will write the exclusion
+    //       in the active variants in the session layer.
+    return addExcludeFromRendering(ufePulledPath, PXR_NS::UsdEditTarget());
+}
+
+bool addExcludeFromRendering(
+    const Ufe::Path&             ufePulledPath,
+    const PXR_NS::UsdEditTarget& editTarget)
 {
     // Note: must make sure the prim is accessible by activating all its ancestors.
     PrimActivation activation(ufePulledPath);
@@ -198,9 +285,20 @@ bool addExcludeFromRendering(const Ufe::Path& ufePulledPath)
     if (!stage)
         return false;
 
-    PXR_NS::UsdEditContext editContext(stage, stage->GetSessionLayer());
-    if (!prim.SetActive(false))
-        return false;
+    // Receiving an invalid edit target means that we write the exclusion
+    // in the active variants in the session layer.
+    if (editTarget.IsNull()) {
+        const PXR_NS::SdfLayerHandle layer = stage->GetSessionLayer();
+        const PXR_NS::UsdEditTarget  editTarget = getEditTargetForVariants(prim, layer);
+
+        PXR_NS::UsdEditContext editContext(stage, stage->GetSessionLayer());
+        if (!prim.SetActive(false))
+            return false;
+    } else {
+        PXR_NS::UsdEditContext editContext(stage, editTarget);
+        if (!prim.SetActive(false))
+            return false;
+    }
 
     return true;
 }
@@ -211,6 +309,15 @@ bool addExcludeFromRendering(const Ufe::Path& ufePulledPath)
 // This is done once the Maya data is meged into USD and removed from the scene.
 
 bool removeExcludeFromRendering(const Ufe::Path& ufePulledPath)
+{
+    // Note: passing an invalid edit target will remove the exclusion
+    //       from the active variants in the session layer.
+    return removeExcludeFromRendering(ufePulledPath, PXR_NS::UsdEditTarget());
+}
+
+bool removeExcludeFromRendering(
+    const Ufe::Path&             ufePulledPath,
+    const PXR_NS::UsdEditTarget& editTarget)
 {
     // Note: must make sure the prim is accessible by activating all its ancestors.
     PrimActivation activation(ufePulledPath);
@@ -229,15 +336,30 @@ bool removeExcludeFromRendering(const Ufe::Path& ufePulledPath)
         return false;
 
     PXR_NS::SdfLayerHandle sessionLayer = stage->GetSessionLayer();
-    PXR_NS::UsdEditContext editContext(stage, sessionLayer);
-
-    // Cleanup the field and potentially empty over
-    if (!prim.ClearActive())
+    if (!sessionLayer)
         return false;
 
-    PXR_NS::SdfPrimSpecHandle primSpec = UsdUfe::getPrimSpecAtEditTarget(prim);
-    if (sessionLayer && primSpec)
-        sessionLayer->ScheduleRemoveIfInert(primSpec.GetSpec());
+    auto clearActive = [&stage, &sessionLayer, &prim](const PXR_NS::UsdEditTarget& editTarget) {
+        PXR_NS::UsdEditContext editContext(stage, editTarget);
+
+        // Cleanup the field and potentially empty over
+        prim.ClearActive();
+
+        PXR_NS::SdfPrimSpecHandle primSpec = UsdUfe::getPrimSpecAtEditTarget(prim);
+        if (primSpec)
+            sessionLayer->ScheduleRemoveIfInert(primSpec.GetSpec());
+    };
+
+    // Note: older version of MayaUSD wrote the exclusion outside all variants,
+    //       so for backward compatibility, we always try to remove it from there.
+    clearActive(PXR_NS::UsdEditTarget(sessionLayer));
+
+    // Remove the exclusion in the correct variants, if any.
+    if (editTarget.IsNull()) {
+        clearActive(getEditTargetForVariants(prim, sessionLayer));
+    } else {
+        clearActive(editTarget);
+    }
 
     return true;
 }

--- a/lib/mayaUsd/fileio/pullInformation.h
+++ b/lib/mayaUsd/fileio/pullInformation.h
@@ -19,6 +19,7 @@
 #include <mayaUsd/base/api.h>
 
 #include <pxr/pxr.h>
+#include <pxr/usd/usd/editTarget.h>
 #include <pxr/usd/usd/prim.h>
 
 #include <maya/MDagPath.h>
@@ -27,6 +28,11 @@
 UFE_NS_DEF { class Path; }
 
 namespace MAYAUSD_NS_DEF {
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Helper functions to write, read and remove edited-as-Maya (pull)
+// information set on the Maya DAG node.
 
 /// @brief Write on the Maya node the information necessary later-on to merge
 ///        the USD prim that is edited as Maya.
@@ -37,26 +43,75 @@ bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& edited
 ///        that is edited as Maya.
 MAYAUSD_CORE_PUBLIC
 bool readPullInformation(const PXR_NS::UsdPrim& prim, std::string& dagPathStr);
+
 MAYAUSD_CORE_PUBLIC
 bool readPullInformation(const PXR_NS::UsdPrim& prim, Ufe::SceneItem::Ptr& dagPathItem);
+
 MAYAUSD_CORE_PUBLIC
 bool readPullInformation(const Ufe::Path& ufePath, MDagPath& dagPath);
+
 MAYAUSD_CORE_PUBLIC
 bool readPullInformation(const MDagPath& dagpath, Ufe::Path& ufePath);
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Helper functions to write, read and remove edited-as-Maya (pull)
+// information set on the edited USD prim.
 
 /// @brief Write on the USD prim the information necessary later-on to merge
 ///        the USD prim that is edited as Maya.
 MAYAUSD_CORE_PUBLIC
 bool writePulledPrimMetadata(const Ufe::Path& ufePulledPath, const MDagPath& editedRoot);
+
+/// @brief Write on the Maya node the information necessary later-on to merge
+///        the USD prim that is edited as Maya, in the given edit target.
+MAYAUSD_CORE_PUBLIC
+bool writePulledPrimMetadata(
+    const Ufe::Path&             ufePulledPath,
+    const MDagPath&              editedRoot,
+    const PXR_NS::UsdEditTarget& editTarget);
+
+/// @brief Write on the USD prim the information necessary later-on to merge
+///        the USD prim that is edited as Maya.
 MAYAUSD_CORE_PUBLIC
 bool writePulledPrimMetadata(PXR_NS::UsdPrim& pulledPrim, const MDagPath& editedRoot);
+
+/// @brief Write on the Maya node the information necessary later-on to merge
+///        the USD prim that is edited as Maya, in the given edit target.
+MAYAUSD_CORE_PUBLIC
+bool writePulledPrimMetadata(
+    PXR_NS::UsdPrim&             pulledPrim,
+    const MDagPath&              editedAsMayaRoot,
+    const PXR_NS::UsdEditTarget& editTarget);
 
 /// @brief Remove from the USD prim the information necessary to merge the USD prim
 ///        that was edited as Maya.
 MAYAUSD_CORE_PUBLIC
 void removePulledPrimMetadata(const Ufe::Path& ufePulledPath);
+
+/// @brief Remove from the USD prim the information necessary to merge the USD prim
+///        that was edited as Maya, .
+MAYAUSD_CORE_PUBLIC
+void removePulledPrimMetadata(
+    const Ufe::Path&             ufePulledPath,
+    const PXR_NS::UsdEditTarget& editTarget);
+
+/// @brief Remove from the USD prim the information necessary to merge the USD prim
+///        that was edited as Maya.
 MAYAUSD_CORE_PUBLIC
 void removePulledPrimMetadata(const PXR_NS::UsdStagePtr& stage, PXR_NS::UsdPrim& prim);
+
+/// @brief Remove from the USD prim the information necessary to merge the USD prim
+///        that was edited as Maya, in the given edit target.
+MAYAUSD_CORE_PUBLIC
+void removePulledPrimMetadata(
+    const PXR_NS::UsdStagePtr&   stage,
+    PXR_NS::UsdPrim&             prim,
+    const PXR_NS::UsdEditTarget& editTarget);
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Helper functions to hide and show the edited prim.
 
 /// @brief Hide the USD prim that is edited as Maya.
 ///        This is done so that the USD prim and edited Maya data are not superposed
@@ -64,10 +119,24 @@ void removePulledPrimMetadata(const PXR_NS::UsdStagePtr& stage, PXR_NS::UsdPrim&
 MAYAUSD_CORE_PUBLIC
 bool addExcludeFromRendering(const Ufe::Path& ufePulledPath);
 
+MAYAUSD_CORE_PUBLIC
+bool addExcludeFromRendering(
+    const Ufe::Path&             ufePulledPath,
+    const PXR_NS::UsdEditTarget& editTarget);
+
 /// @brief Show again the USD prim that was edited as Maya.
 ///        This is done once the Maya data is meged into USD and removed from the scene.
 MAYAUSD_CORE_PUBLIC
 bool removeExcludeFromRendering(const Ufe::Path& ufePulledPath);
+
+MAYAUSD_CORE_PUBLIC
+bool removeExcludeFromRendering(
+    const Ufe::Path&             ufePulledPath,
+    const PXR_NS::UsdEditTarget& editTarget);
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Helper functions to check if a prim is already edited-as-Maya.
 
 /// @brief Verify if the edited as Maya nodes corresponding to the given prim is orphaned.
 MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
@@ -34,6 +34,7 @@
 #include <mayaUsd/base/debugCodes.h>
 #include <mayaUsd/undo/OpUndoItems.h>
 #include <mayaUsd/utils/util.h>
+#include <mayaUsd/utils/variants.h>
 
 #include <pxr/base/tf/getenv.h>
 
@@ -157,6 +158,17 @@ const TfToken MayaReferenceNodeName("MayaReferenceNodeName");
 
 MStatus setMayaRefCustomAttribute(const UsdPrim& prim, const MFnReference& refDependNode)
 {
+    PXR_NS::UsdStagePtr stage = prim.GetStage();
+    if (!stage)
+        return MS::kFailure;
+
+    // Target the exact set of variants under which the USD prim lives to set
+    // the custom metadata. That way if multiple prims with the same name but
+    // under different variants exists, they won't step on each other's data.
+    const PXR_NS::SdfLayerHandle layer = stage->GetSessionLayer();
+    const PXR_NS::UsdEditTarget  editTarget = MayaUsd::getEditTargetForVariants(prim, layer);
+    const PXR_NS::UsdEditContext editContext(stage, editTarget);
+
     // Always have to try to create the attribute to make sure it is in the prim scope and not
     // inherited. If it was already created, it will be used.
     UsdAttribute attr = prim.CreateAttribute(MayaReferenceNodeName, SdfValueTypeNames->String);
@@ -170,22 +182,19 @@ MString GetMayaRefCustomAttribute(const UsdPrim& prim)
 {
     UsdAttribute attr = prim.GetAttribute(MayaReferenceNodeName);
     if (!attr)
-        return MString();
+        return {};
 
     VtValue value;
     attr.Get(&value);
 
-    // Check if attribute was directly on prim or inherited.
-    auto resInfo = attr.GetResolveInfo();
-    bool isAttributeOnPrim = resInfo.GetNode().GetPath() == prim.GetPath();
-    if (!isAttributeOnPrim)
-        return MString();
-
     // Check if the attribute type is correct.
-    if (value.GetType() != SdfValueTypeNames->String.GetType())
-        return MString();
+    if (value.IsEmpty())
+        return {};
 
-    return MString(value.Get<std::string>().c_str());
+    if (!value.CanCast<std::string>())
+        return {};
+
+    return value.Get<std::string>().c_str();
 }
 
 MStatus LoadOrUnloadMayaReferenceWithUndo(const MObject& referenceObject, bool load)
@@ -216,18 +225,15 @@ MStatus UnloadMayaReferenceWithUndo(const MObject& referenceObject)
     return LoadOrUnloadMayaReferenceWithUndo(referenceObject, false);
 }
 
-} // namespace
-
-const TfToken UsdMayaTranslatorMayaReference::m_namespaceName = TfToken("mayaNamespace");
-const TfToken UsdMayaTranslatorMayaReference::m_referenceName = TfToken("mayaReference");
-const TfToken UsdMayaTranslatorMayaReference::m_mergeNamespacesOnClash
-    = TfToken("mergeNamespacesOnClash");
+const TfToken namespaceNamePrimAttrName = TfToken("mayaNamespace");
+const TfToken referenceNameAttrName = TfToken("mayaReference");
+const TfToken mergeNamespacesOnClashAttrName = TfToken("mergeNamespacesOnClash");
 
 // Get the namespace attribute from prim
-MString UsdMayaTranslatorMayaReference::namespaceFromPrim(const UsdPrim& prim)
+MString namespaceFromPrim(const UsdPrim& prim)
 {
     std::string ns;
-    if (UsdAttribute namespaceAttribute = prim.GetAttribute(m_namespaceName)) {
+    if (UsdAttribute namespaceAttribute = prim.GetAttribute(namespaceNamePrimAttrName)) {
         TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
             .Msg(
                 "MayaReferenceLogic::update Checking namespace on prim \"%s\".\n",
@@ -247,7 +253,7 @@ MString UsdMayaTranslatorMayaReference::namespaceFromPrim(const UsdPrim& prim)
     return MString(ns.c_str(), ns.size());
 }
 
-MString UsdMayaTranslatorMayaReference::getUniqueRefNodeName(
+MString getUniqueRefNodeName(
     const UsdPrim&      prim,
     const MFnDagNode&   parentDag,
     const MFnReference& refDependNode)
@@ -279,7 +285,11 @@ MString UsdMayaTranslatorMayaReference::getUniqueRefNodeName(
     return uniqueRefNodeName;
 }
 
-MStatus UsdMayaTranslatorMayaReference::LoadMayaReference(
+} // namespace
+
+static MStatus connectReferenceAssociatedNode(MFnDagNode& dagNode, MFnReference& refNode);
+
+MStatus UsdMayaTranslatorMayaReference::CreateMayaReference(
     const UsdPrim& prim,
     MObject&       parent,
     MString&       mayaReferencePath,
@@ -287,7 +297,7 @@ MStatus UsdMayaTranslatorMayaReference::LoadMayaReference(
     bool           mergeNamespacesOnClash)
 {
     TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
-        .Msg("MayaReferenceLogic::LoadMayaReference prim=%s\n", prim.GetPath().GetText());
+        .Msg("MayaReferenceLogic::CreateMayaReference prim=%s\n", prim.GetPath().GetText());
     MStatus status;
 
     MFnDagNode parentDag(parent, &status);
@@ -334,7 +344,7 @@ MStatus UsdMayaTranslatorMayaReference::LoadMayaReference(
 
     TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
         .Msg(
-            "MayaReferenceLogic::LoadMayaReference prim=%s execute \"%s\"\n",
+            "MayaReferenceLogic::CreateMayaReference prim=%s execute \"%s\"\n",
             prim.GetPath().GetText(),
             referenceCommand.asChar());
     status = MGlobal::executeCommand(referenceCommand, createdNodes);
@@ -398,9 +408,7 @@ MStatus UsdMayaTranslatorMayaReference::UnloadMayaReference(const MObject& paren
     return status;
 }
 
-MStatus UsdMayaTranslatorMayaReference::connectReferenceAssociatedNode(
-    MFnDagNode&   dagNode,
-    MFnReference& refNode)
+static MStatus connectReferenceAssociatedNode(MFnDagNode& dagNode, MFnReference& refNode)
 {
     MPlug srcPlug(dagNode.object(), getMessageAttr());
     /*
@@ -433,60 +441,39 @@ MStatus UsdMayaTranslatorMayaReference::connectReferenceAssociatedNode(
     return result;
 }
 
-MStatus UsdMayaTranslatorMayaReference::update(const UsdPrim& prim, MObject parent)
+static MObject findConnectedMayaReference(MObject& parent)
 {
-    MStatus      status;
-    SdfAssetPath mayaReferenceAssetPath;
-    // Check to see if we have a valid Maya reference node name
-    UsdAttribute mayaReferenceNodeName = prim.GetAttribute(m_referenceName);
-    mayaReferenceNodeName.Get(&mayaReferenceAssetPath);
-    MString mayaReferencePath(mayaReferenceAssetPath.GetResolvedPath().c_str());
-
-    // The resolved path is empty if the maya reference is a full path.
-    if (!mayaReferencePath.length()) {
-        mayaReferencePath = mayaReferenceAssetPath.GetAssetPath().c_str();
-    }
-
-    // If the path is still empty return, there is no reference to import
-    if (!mayaReferencePath.length()) {
-        return MS::kFailure;
-    }
-    MFileObject fileObj;
-    fileObj.setRawFullName(mayaReferencePath);
-    mayaReferencePath = fileObj.resolvedFullName();
-
-    TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
-        .Msg(
-            "MayaReferenceLogic::update Looking for attribute on \"%s\".\"%s\"\n",
-            prim.GetTypeName().GetText(),
-            m_namespaceName.GetText());
-
-    MFnDagNode parentDag(parent, &status);
-    CHECK_MSTATUS_AND_RETURN_IT(status);
-
-    // Get required namespace attribute from prim
-    MString     rigNamespaceM = namespaceFromPrim(prim);
-    std::string rigNamespace = rigNamespaceM.asChar();
-
-    MObject refNode;
-
-    // First, see if a reference is already attached
+    MStatus           status;
     MFnDependencyNode fnParent(parent, &status);
-    if (status) {
-        MPlug      messagePlug(fnParent.object(), getMessageAttr());
-        MPlugArray referencePlugs;
+    if (!status)
+        return {};
+
+    MPlugArray referencePlugs;
+    {
+        MPlug messagePlug(fnParent.object(), getMessageAttr());
         messagePlug.connectedTo(referencePlugs, false, true);
-        for (uint32_t i = 0, n = referencePlugs.length(); i < n; ++i) {
-            MObject temp = referencePlugs[i].node();
-            if (temp.hasFn(MFn::kReference)) {
-                refNode = temp;
-            }
-        }
     }
 
-    // Check to see whether we have previously created a reference node for this
-    // prim.  If so, we can just reuse it.
-    //
+    for (uint32_t i = 0, n = referencePlugs.length(); i < n; ++i) {
+        MObject temp = referencePlugs[i].node();
+        if (!temp.hasFn(MFn::kReference))
+            continue;
+        return temp;
+    }
+
+    return {};
+}
+
+static bool isSameFileName(const MString& found, const MString& expected)
+{
+    return ghc::filesystem::path(found.asChar()) == ghc::filesystem::path(expected.asChar());
+}
+
+static MObject findExistingMayaReference(
+    const UsdPrim& prim,
+    MFnDagNode&    parentDag,
+    const MString& expectedRefFilePath)
+{
     // Notes for the legacy ref-naming scheme:
     //
     // The check is based on comparing the prim's full path and the name of the
@@ -512,33 +499,126 @@ MStatus UsdMayaTranslatorMayaReference::update(const UsdPrim& prim, MObject pare
     const bool    useLegacyScheme = useLegacyMayaRefNaming(prim);
     const MString expectedRefName
         = useLegacyScheme ? refNameFromPath(parentDag) : GetMayaRefCustomAttribute(prim);
-    if (refNode.isNull() && expectedRefName.length() > 0) {
-        for (MItDependencyNodes refIter(MFn::kReference); !refIter.isDone(); refIter.next()) {
-            MObject      tempRefNode = refIter.item();
-            MFnReference tempRefFn(tempRefNode);
-            if (!tempRefFn.isFromReferencedFile()) {
-                if (expectedRefName == tempRefFn.name()) {
-                    // Reconnect the reference node's `associatedNode` attr before
-                    // loading it, since the previous connection may be gone.
-                    connectReferenceAssociatedNode(parentDag, tempRefFn);
-                    refNode = tempRefNode;
+    if (expectedRefName.length() <= 0) {
+#ifdef MAYAUSD_DEBUG_MAYA_REFERENCE_LOCATION
+        TF_WARN("No Maya custom ref attribute for %s", prim.GetPath().GetText());
+#endif
+        return {};
+    }
 
-                    if (!useLegacyScheme) {
-                        // On reconnect, the  Maya reference node is renamed to match
-                        // the prim.
-                        MString uniqueRefNodeName
-                            = getUniqueRefNodeName(prim, parentDag, tempRefFn);
-                        tempRefFn.setName(uniqueRefNodeName);
+    for (MItDependencyNodes refIter(MFn::kReference); !refIter.isDone(); refIter.next()) {
+        MObject      tempObj = refIter.item();
+        MFnReference tempRefFn(tempObj);
 
-                        status = setMayaRefCustomAttribute(prim, tempRefFn);
-                        CHECK_MSTATUS_AND_RETURN_IT(status);
-                    }
+        // Only take into consideration reference nodes that are directly in
+        // the Maya scene file, not nodes that may be inside other referenced
+        // files.
+        if (tempRefFn.isFromReferencedFile())
+            continue;
 
-                    // Found a matching Maya reference node, stop searching.
-                    break;
-                }
+        // If the reference is not named as we expected, then even if it would
+        // refer to the same file we don't use it: it may belong to another stage
+        // or to the user.
+        const bool hasMatchingName = (expectedRefName == tempRefFn.name());
+#ifdef MAYAUSD_DEBUG_MAYA_REFERENCE_LOCATION
+        TF_WARN(
+            "Found Maya reference with %s name (%s != %s)",
+            hasMatchingName ? "matching" : "non-matching",
+            expectedRefName.asChar(),
+            tempRefFn.name().asChar());
+#endif
+        if (!hasMatchingName)
+            continue;
+
+        // If the reference is not to the expected referenced file, don't use it.
+        // It might be because two prims with the same name, which can happen when
+        // they are under different USD variants, result in the same reference node
+        // name but are referencing two different files. For example, it could be
+        // that the user wants to switch between two referenced rigs by switching
+        // between two variants.
+        const bool    resolvedName = true;
+        const bool    includePath = false; // Weirdly, false means we get full path!
+        const bool    includeCopy = false;
+        const MString refFilePath = tempRefFn.fileName(resolvedName, includePath, includeCopy);
+        if (!isSameFileName(refFilePath, expectedRefFilePath)) {
+#ifdef MAYAUSD_DEBUG_MAYA_REFERENCE_LOCATION
+            TF_WARN(
+                "Maya reference node [%s] does not refer to the expected file: "
+                "expected [%s], found [%s].",
+                expectedRefName.asChar(),
+                expectedRefFilePath.asChar(),
+                refFilePath.asChar());
+#endif
+            continue;
+        }
+
+        // If we get here, we have found the desired reference node.
+        // Reconnect the reference node's `associatedNode` attr before
+        // loading it, since the previous connection may be gone.
+        connectReferenceAssociatedNode(parentDag, tempRefFn);
+
+        if (!useLegacyScheme) {
+            // On reconnect, rename the Maya reference node to match the prim.
+            MString uniqueRefNodeName = getUniqueRefNodeName(prim, parentDag, tempRefFn);
+            tempRefFn.setName(uniqueRefNodeName);
+
+            if (!setMayaRefCustomAttribute(prim, tempRefFn)) {
+                TF_WARN(
+                    "The custom prim attribute used to track the Maya reference %s could not be "
+                    "updated.",
+                    prim.GetPath().GetText());
             }
         }
+
+        // Found a matching Maya reference node, stop searching.
+        return tempObj;
+    }
+
+    return {};
+}
+
+MStatus UsdMayaTranslatorMayaReference::update(const UsdPrim& prim, MObject parent)
+{
+    MStatus      status;
+    SdfAssetPath mayaReferenceAssetPath;
+    // Check to see if we have a valid Maya reference node name
+    UsdAttribute mayaReferenceNodeName = prim.GetAttribute(referenceNameAttrName);
+    mayaReferenceNodeName.Get(&mayaReferenceAssetPath);
+    MString mayaReferencePath(mayaReferenceAssetPath.GetResolvedPath().c_str());
+
+    // The resolved path is empty if the maya reference is a full path.
+    if (!mayaReferencePath.length()) {
+        mayaReferencePath = mayaReferenceAssetPath.GetAssetPath().c_str();
+    }
+
+    // If the path is still empty return, there is no reference to import
+    if (!mayaReferencePath.length()) {
+        return MS::kFailure;
+    }
+    MFileObject fileObj;
+    fileObj.setRawFullName(mayaReferencePath);
+    mayaReferencePath = fileObj.resolvedFullName();
+
+    TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
+        .Msg(
+            "MayaReferenceLogic::update Looking for attribute on \"%s\".\"%s\"\n",
+            prim.GetTypeName().GetText(),
+            namespaceNamePrimAttrName.GetText());
+
+    MFnDagNode parentDag(parent, &status);
+    CHECK_MSTATUS_AND_RETURN_IT(status);
+
+    // Get required namespace attribute from prim
+    MString     rigNamespaceM = namespaceFromPrim(prim);
+    std::string rigNamespace = rigNamespaceM.asChar();
+
+    // First, see if a reference is already attached
+    MObject refNode = findConnectedMayaReference(parent);
+
+    // Check to see whether we have previously created a reference node for this
+    // prim.  If so, we can just reuse it.
+    if (refNode.isNull()) {
+        refNode = findExistingMayaReference(prim, parentDag, mayaReferencePath);
     }
 
     // If no reference found, we'll need to create it. This may be the first time we are
@@ -546,11 +626,11 @@ MStatus UsdMayaTranslatorMayaReference::update(const UsdPrim& prim, MObject pare
     if (refNode.isNull()) {
         bool mergeNamespacesOnClash = false;
         if (UsdAttribute mergeNamespacesOnClashAttribute
-            = prim.GetAttribute(m_mergeNamespacesOnClash)) {
+            = prim.GetAttribute(mergeNamespacesOnClashAttrName)) {
             mergeNamespacesOnClashAttribute.Get(&mergeNamespacesOnClash);
         }
 
-        return LoadMayaReference(
+        return CreateMayaReference(
             prim, parent, mayaReferencePath, rigNamespaceM, mergeNamespacesOnClash);
     }
 

--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.h
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.h
@@ -48,7 +48,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 struct UsdMayaTranslatorMayaReference
 {
     MAYAUSD_CORE_PUBLIC
-    static MStatus LoadMayaReference(
+    static MStatus CreateMayaReference(
         const UsdPrim& prim,
         MObject&       parent,
         MString&       mayaReferencePath,
@@ -60,18 +60,6 @@ struct UsdMayaTranslatorMayaReference
 
     MAYAUSD_CORE_PUBLIC
     static MStatus update(const UsdPrim& prim, MObject parent);
-
-private:
-    static MString namespaceFromPrim(const UsdPrim& prim);
-    static MString getUniqueRefNodeName(
-        const UsdPrim&      prim,
-        const MFnDagNode&   parentDag,
-        const MFnReference& refDependNode);
-    static MStatus connectReferenceAssociatedNode(MFnDagNode& dagNode, MFnReference& refNode);
-
-    static const TfToken m_namespaceName;
-    static const TfToken m_referenceName;
-    static const TfToken m_mergeNamespacesOnClash;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/utils/variants.cpp
+++ b/lib/mayaUsd/utils/variants.cpp
@@ -15,6 +15,12 @@
 //
 #include "variants.h"
 
+#include <mayaUsd/ufe/Global.h>
+
+#include <pxr/base/tf/stringUtils.h>
+#include <pxr/usd/pcp/node.h>
+#include <pxr/usd/pcp/primIndex.h>
+#include <pxr/usd/usd/editTarget.h>
 #include <pxr/usd/usd/stage.h>
 
 /// General utility functions for variants
@@ -57,6 +63,53 @@ void applyToAllVariants(
     // the function even in the absence of vairants, call it now.
     if (includeNonVariant && !atLeastOneVariant)
         func();
+}
+
+PXR_NS::UsdEditTarget
+getEditTargetForVariants(const PXR_NS::UsdPrim& prim, const PXR_NS::SdfLayerHandle& layer)
+{
+    PXR_NS::UsdEditTarget editTarget(layer);
+
+#ifdef MAYAUSD_DEBUG_EDIT_TARGET_FOR_VARIANTS
+    std::vector<std::string> variantPaths;
+#endif
+
+    for (const PXR_NS::SdfPath& p : prim.GetPath().GetAncestorsRange()) {
+        PXR_NS::UsdPrim          ancestor = prim.GetStage()->GetPrimAtPath(p);
+        PXR_NS::UsdVariantSets   variantSets = ancestor.GetVariantSets();
+        std::vector<std::string> setNames = variantSets.GetNames();
+        for (const std::string& setName : setNames) {
+            PXR_NS::UsdVariantSet variant = variantSets.GetVariantSet(setName);
+            const std::string     selection = variant.GetVariantSelection();
+#ifdef MAYAUSD_DEBUG_EDIT_TARGET_FOR_VARIANTS
+            variantPaths.emplace_back(setName + std::string("=") + selection);
+#endif
+            editTarget = editTarget.ComposeOver(variant.GetVariantEditTarget(layer));
+        }
+    }
+
+#ifdef MAYAUSD_DEBUG_EDIT_TARGET_FOR_VARIANTS
+    using namespace PXR_NS;
+    TF_STATUS(
+        "edit target for variants for %s: %s",
+        prim.GetPath().GetText(),
+        PXR_NS::TfStringJoin(variantPaths).c_str());
+#endif
+
+    return editTarget;
+}
+
+PXR_NS::SdfPath getVariantPath(
+    const Ufe::Path&   path,
+    const std::string& variantSetName,
+    const std::string& variantSelection)
+{
+    if (path.runTimeId() != MayaUsd::ufe::getUsdRunTimeId())
+        return {};
+
+    const Ufe::Path::Segments& segments = path.getSegments();
+    PXR_NS::SdfPath            primPath(segments.back().string());
+    return primPath.AppendVariantSelection(variantSetName, variantSelection);
 }
 
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/variants.h
+++ b/lib/mayaUsd/utils/variants.h
@@ -18,9 +18,12 @@
 
 #include <mayaUsd/base/api.h>
 
+#include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/editContext.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/variantSets.h>
+
+#include <ufe/path.h>
 
 #include <functional>
 #include <string>
@@ -71,6 +74,24 @@ private:
     PXR_NS::UsdVariantSet _variantSet;
     std::string           _variant;
 };
+
+/*! \brief Creates an edit target for all variants that might affect the given prim.
+
+           Note that this includes variants on ancestors that affect this prim. To find
+           those ancestor variant is the main prupose of this function. For prim-specific
+           variant selections, OpenUSD already provides a built-in function on UsdPrim.
+ */
+MAYAUSD_CORE_PUBLIC
+PXR_NS::UsdEditTarget
+getEditTargetForVariants(const PXR_NS::UsdPrim& prim, const PXR_NS::SdfLayerHandle& layer);
+
+/*! \brief Creates an USD variant path for the given UFE path and variant selection.
+ */
+MAYAUSD_CORE_PUBLIC
+PXR_NS::SdfPath getVariantPath(
+    const Ufe::Path&   path,
+    const std::string& variantSetName,
+    const std::string& variantSelection);
 
 } // namespace MAYAUSD_NS_DEF
 

--- a/test/lib/mayaUsd/fileio/testAddMayaReference.py
+++ b/test/lib/mayaUsd/fileio/testAddMayaReference.py
@@ -371,6 +371,8 @@ class AddMayaReferenceTestCase(unittest.TestCase):
             self.kDefaultNamespace,
             variantSet=(variantSetName, variantName),
             mayaAutoEdit=True)
+        mayaRefPrimPath = mayaRefPrim.GetPath()
+        stage = mayaRefPrim.GetStage()
 
         # The prim should have a variant set.
         self.assertTrue(primTestDefault.HasVariantSets())
@@ -408,16 +410,22 @@ class AddMayaReferenceTestCase(unittest.TestCase):
             self.assertTrue(mayaUsd.lib.PrimUpdaterManager.mergeToUsd(aMayaPathStr, cacheOptions))
 
         # Verify the cache variant is active and the prim
-        # is active.
+        # is not accessible since we are in the cache variant.
         self.assertTrue(primTestDefault.HasVariantSets())
         vs = primTestDefault.GetVariantSets()
         variantSet = vs.GetVariantSet(variantSetName)
         self.assertEqual(variantSet.GetVariantSelection(), cacheVariantName)
-        self.assertTrue(mayaRefPrim.IsActive())
+        # Note: we must fetch the prim again because when switching variant,
+        #       the prim became invalid.
+        mayaRefPrim = stage.GetPrimAtPath(mayaRefPrimPath)
+        self.assertFalse(mayaRefPrim)
 
         # Switch to Maya Ref variant and verify that the auto-edit is
         # still on and the prim is now inactive.
         variantSet.SetVariantSelection(variantName)
+        # Note: we must fetch the prim again because when switching variant,
+        #       the prim became invalid.
+        mayaRefPrim = stage.GetPrimAtPath(mayaRefPrimPath)
         self.assertFalse(mayaRefPrim.IsActive())
         attr = mayaRefPrim.GetAttribute('mayaAutoEdit')
         self.assertTrue(attr.IsValid())

--- a/test/lib/mayaUsd/fileio/testCacheToUsd.py
+++ b/test/lib/mayaUsd/fileio/testCacheToUsd.py
@@ -492,6 +492,7 @@ class CacheToUsdTestCase(unittest.TestCase):
 
         (mayaRefPrim, variantSetName, variantSet, refVariantName, cacheVariantName, relativePath) = \
             createMayaRefPrimFn(self, cacheParent, cacheParentPathStr)
+        mayaRefPrimPath = mayaRefPrim.GetPath()
 
         # Set an initial translation.
         editTarget = self.stage.GetEditTarget()
@@ -564,12 +565,13 @@ class CacheToUsdTestCase(unittest.TestCase):
         checkCacheParentFn(self, cacheParentChildren, variantSet, cacheVariantName)
 
         # Maya reference prim should now have the updated transformation.
-        editTarget = self.stage.GetEditTarget()
-        if variantSet:
-            variantSet.SetVariantSelection('Rig')
-            editTarget = variantSet.GetVariantEditTarget(editTarget.GetLayer())
+        if variantSetName:
+            cacheParent.GetVariantSet(variantSetName).SetVariantSelection('Rig')
 
         with Usd.EditContext(self.stage, editTarget):
+            # Note: must refetch the ref prim because it became invalid when
+            #       it got deactivated during edit.
+            mayaRefPrim = self.stage.GetPrimAtPath(mayaRefPrimPath)
             xformable = UsdGeom.Xformable(mayaRefPrim)
             ops = xformable.GetOrderedXformOps()
             self.assertEqual(len(ops), 1)

--- a/test/lib/mayaUsd/fileio/testEditAsMaya.py
+++ b/test/lib/mayaUsd/fileio/testEditAsMaya.py
@@ -433,7 +433,7 @@ class EditAsMayaTestCase(unittest.TestCase):
 
         self.assertFalse(stage.GetSessionLayer().empty)
 
-        kPullPrimMetadataKey = "Maya:Pull:DagPath"
+        kPullPrimMetadataKey = "Maya:PullVariant:DagPath"
         self.assertEqual(prim.GetCustomDataByKey(kPullPrimMetadataKey), "|__mayaUsd__|AParent|A")
 
         # Discard Maya edits, but there is nothing to discard.


### PR DESCRIPTION
This change adds support to edit-as-Maya a prim that is under a variant, with each variation having a different Maya reference. That is, a single prim can now be edited-as-Maya multiple times in parallel. This required major changes on how those edited prim are tracked.

Edit-as-Maya authors data in the session layer related to the edited prim. Previously, this data was authored outside any variant, which caused problems when a prim had multiple variants. Now these data are authored inside the same variant as the prim itself.

Add overloads of the helper functions to write and remove pull information and metadata. The overloads take and explicit USD edit target. These are necessary because when the orphaned node manager tries to remove or write the information, the stage might not be in the current state of variants might not be the same as when the prim was initially edited-as-Maya. So we must use the cache variant selection information instead to build the correct target.

Additional variant-related helper functions:
- Add the getEditTargetForVariants function helper function to create the USD edit target targeting all the variants that affect a given prim.
- Ensure getEditTargetForVariants works in more complex scenarios spanning payloads and references.
- Add the getVariantPath helper function to create a USD path containing a variant selection.

Additional pull information helper functions:
- Add variant-specific pull info metadata in the pull-info helper functions.
- Add overloads of the pull information helper functions, taking an explicit edit target.
- Refactor the existing overload to call the new functions.
- Warn when we fail to remove pull information.

Change to the orphan manager:
- Use the variant-targeting helper function when authoring the Maya reference custom attribute that holds the name of the Maya reference node.
- Support having multiple entries for a given UFE path.
- To differentiate between entries, the corresponding root Maya DAG path must be given in all functions to figure out which version of the prim we are dealing with.
- Fortunately, all callers always have on hand the DAG path of the root Maya node.
- Change all implementation function to iterate over these variations.
- Change the orphaned nodes serialization to support the extra data.
- Make the serialization format backward compatible by special-casing the usual case of having a single variation at a given edited UFE path.
- Add a log to tell the user when an edited prim is orphaned.
- Add a has function in the orphaned node manager to check if a prim is already edited.
- Use it to avoid editing a prim variant twice.
- Added debug log to be removed later.
- Refactor the orphaned node manager to use the helper passing an explicit edit target.
- Make the orphaned node manager build an explicit USD edit target for the exact variant selections that were active when the prim was edited.
- Fix how the orphaned manager handles notifications to determine orphans.
- In particular, handle deactvated prims correctly: when switching variants, the order of the consequences is not deterministic, so the handling must not assume that edited prims are active.

Changes to the prim updater manager:
- Ignore edited prim that are orphaned when determining if a prim has edited descendants.
- Adapt to changes to the orphaned manager by passing the Maya DAG path to the root of the edited nodes.
- When merging to USD, when removing the pull information, use the helper function.
- Remove the pull information before calling the prim updaters since they might change the active variant.

Changes to Maya reference translator (importer from USD to Maya):
- Use the variant-targeting helper function when authoring the pulled-prim metadata.
- Make many functions be purely in the implementation instead of declared private in the class.
- This allows better hiding of the implementation.
- This was also necessary to make the function callable from internal implementation functions.
- Renamed LoadMayaReference to CreateMayaReference to better reflect what the function does.
- Split the long update function into multiple function for clarity.
- When trying to reuse Maya reference nodes, verify that the referenced file is the one that was expected.
- This allows two prim with the same USD path but different references to work alongside each other.
- This happens when one prim with two variants each contain a Maya reference.
- Add more comments in the code to explain what is going on.
- Add a log to tell the user when a reference does not have the expected file path.

Fix unit tests:
- Some tests were re-using prims that had become invalid and needed to be fetched again.
- Some tests were checking if prims were accessible when they should not, since merging a Maya reference with variants change to those variants.
- It used to work because there were some left-overs in the session layer.