### PR TITLE
EMSUSD-623 edit as Maya multiple variants

### DIFF
--- a/lib/mayaUsd/fileio/orphanedNodesManager.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.cpp
@@ -62,7 +62,7 @@ OrphanedNodesManager::Memento& OrphanedNodesManager::Memento::operator=(Memento&
     return *this;
 }
 
-Ufe::Trie<OrphanedNodesManager::PullVariantInfo> OrphanedNodesManager::Memento::release()
+OrphanedNodesManager::PulledPrims OrphanedNodesManager::Memento::release()
 {
     return std::move(_pulledPrims);
 }
@@ -74,10 +74,11 @@ Ufe::Trie<OrphanedNodesManager::PullVariantInfo> OrphanedNodesManager::Memento::
 namespace {
 
 using PullVariantInfo = OrphanedNodesManager::PullVariantInfo;
+using PullVariantInfos = OrphanedNodesManager::PullVariantInfos;
 using VariantSetDescriptor = OrphanedNodesManager::VariantSetDescriptor;
 using VariantSelection = OrphanedNodesManager::VariantSelection;
 using PulledPrims = OrphanedNodesManager::PulledPrims;
-using PulledPrimNode = Ufe::TrieNode<PullVariantInfo>;
+using PulledPrimNode = OrphanedNodesManager::PulledPrimNode;
 
 Ufe::PathSegment::Components trieNodeToPathComponents(PulledPrimNode::Ptr trieNode);
 Ufe::Path                    trieNodeToPulledPrimUfePath(PulledPrimNode::Ptr trieNode);
@@ -102,11 +103,13 @@ void renameVariantInfo(
 {
     // Note: TrieNode has no non-const data() function, so to modify the
     //       data we must make a copy, modify the copy and call setData().
-    PullVariantInfo newVariantInfo = trieNode->data();
+    PullVariantInfos newVariantInfos = trieNode->data();
 
-    renameVariantDescriptors(newVariantInfo.variantSetDescriptors, oldPath, newPath);
+    for (auto& info : newVariantInfos) {
+        renameVariantDescriptors(info.variantSetDescriptors, oldPath, newPath);
+    }
 
-    trieNode->setData(newVariantInfo);
+    trieNode->setData(newVariantInfos);
 }
 
 void renamePullInformation(
@@ -141,8 +144,10 @@ void renamePullInformation(
         }
     }
 
-    const MDagPath& mayaPath = trieNode->data().editedAsMayaRoot;
-    TF_VERIFY(writePullInformation(pulledPath, mayaPath));
+    for (const PullVariantInfo& info : trieNode->data()) {
+        const MDagPath& mayaPath = info.editedAsMayaRoot;
+        TF_VERIFY(writePullInformation(pulledPath, mayaPath));
+    }
 }
 
 void recursiveRename(
@@ -206,21 +211,49 @@ OrphanedNodesManager::OrphanedNodesManager()
 {
 }
 
+bool OrphanedNodesManager::has(const Ufe::Path& pulledPath, const MDagPath& editedAsMayaRoot) const
+{
+    PulledPrimNode::Ptr node = _pulledPrims.find(pulledPath);
+    if (!node)
+        return false;
+
+    const PullVariantInfos& infos = node->data();
+    for (const PullVariantInfo& info : infos)
+        if (info.editedAsMayaRoot == editedAsMayaRoot)
+            return true;
+
+    return false;
+}
+
+bool OrphanedNodesManager::has(const Ufe::Path& pulledPath) const
+{
+    PulledPrimNode::Ptr node = _pulledPrims.find(pulledPath);
+    if (!node)
+        return false;
+
+    // We store a list of (path, list of (variant set, variant set selection)),
+    // for all ancestors, starting at closest ancestor.
+    auto ancestorPath = pulledPath.pop();
+    auto vsd = variantSetDescriptors(ancestorPath);
+
+    const PullVariantInfos& infos = node->data();
+    for (const PullVariantInfo& info : infos)
+        if (info.variantSetDescriptors == vsd)
+            return true;
+
+    return false;
+}
+
 void OrphanedNodesManager::add(const Ufe::Path& pulledPath, const MDagPath& editedAsMayaRoot)
 {
     // Adding a node twice to the orphan manager is idem-potent. The manager was already
-    // racking that node.
-    if (_pulledPrims.containsDescendantInclusive(pulledPath))
+    // tracking that node.
+    if (_pulledPrims.containsDescendant(pulledPath))
         return;
 
-    // Add the edited-as-Maya root to our pulled prims prefix tree.  Also add the full
-    // configuration of variant set selections for each ancestor, up to the USD
-    // pseudo-root.  Variants on the pulled path itself are ignored, as once
-    // pulled into Maya they cannot be changed.
-    if (_pulledPrims.containsDescendantInclusive(pulledPath)) {
-        TF_WARN("Trying to edit-as-Maya a descendant of an already edited prim.");
+    if (has(pulledPath, editedAsMayaRoot))
         return;
-    }
+
     if (pulledPath.runTimeId() != MayaUsd::ufe::getUsdRunTimeId()) {
         TF_WARN("Trying to monitor a non-USD node for edit-as-Maya orphaning.");
         return;
@@ -231,25 +264,36 @@ void OrphanedNodesManager::add(const Ufe::Path& pulledPath, const MDagPath& edit
     auto ancestorPath = pulledPath.pop();
     auto vsd = variantSetDescriptors(ancestorPath);
 
-    _pulledPrims.add(pulledPath, PullVariantInfo(editedAsMayaRoot, vsd));
-}
-
-OrphanedNodesManager::Memento OrphanedNodesManager::remove(const Ufe::Path& pulledPath)
-{
-    Memento oldPulledPrims(preserve());
-    TF_VERIFY(_pulledPrims.remove(pulledPath) != nullptr);
-    return oldPulledPrims;
-}
-
-const PullVariantInfo& OrphanedNodesManager::get(const Ufe::Path& pulledPath) const
-{
-    const auto infoNode = _pulledPrims.find(pulledPath);
-    if (!infoNode || !infoNode->hasData()) {
-        static const PullVariantInfo empty;
-        return empty;
+    PulledPrimNode::Ptr node = _pulledPrims.find(pulledPath);
+    if (node) {
+        PullVariantInfos infos = node->data();
+        infos.emplace_back(PullVariantInfo(editedAsMayaRoot, vsd));
+        node->setData(infos);
+    } else {
+        _pulledPrims.add(pulledPath, { PullVariantInfo(editedAsMayaRoot, vsd) });
     }
+}
 
-    return infoNode->data();
+OrphanedNodesManager::Memento
+OrphanedNodesManager::remove(const Ufe::Path& pulledPath, const MDagPath& editedAsMayaRoot)
+{
+    Memento             oldPulledPrims(preserve());
+    PulledPrimNode::Ptr node = _pulledPrims.find(pulledPath);
+    if (node) {
+        PullVariantInfos infos = node->data();
+        for (size_t i = infos.size() - 1; i != size_t(0) - size_t(1); --i) {
+            if (infos[i].editedAsMayaRoot == editedAsMayaRoot) {
+                infos.erase(infos.begin() + i);
+            }
+        }
+
+        if (infos.size() > 0) {
+            node->setData(infos);
+        } else {
+            _pulledPrims.remove(pulledPath);
+        }
+    }
+    return oldPulledPrims;
 }
 
 void OrphanedNodesManager::operator()(const Ufe::Notification& n)
@@ -310,7 +354,8 @@ void OrphanedNodesManager::handleOp(const Ufe::SceneCompositeNotification::Op& o
         // point.  It may be an internal node, without data.
         auto ancestorNode = _pulledPrims.node(op.path);
         TF_VERIFY(ancestorNode);
-        recursiveSwitch(ancestorNode, op.path);
+        recursiveSwitch(ancestorNode, op.path, true);
+        recursiveSwitch(ancestorNode, op.path, false);
     } break;
     case Ufe::SceneCompositeNotification::OpType::ObjectDelete: {
         // The following cases will generate object delete:
@@ -345,62 +390,53 @@ void OrphanedNodesManager::handleOp(const Ufe::SceneCompositeNotification::Op& o
             return;
         }
 
-        auto parentHier = Ufe::Hierarchy::hierarchy(parentItem);
-        if (!parentHier->hasChildren()) {
+        // USD sends resync changes (UFE subtree invalidate) on the
+        // pseudo-root itself.  Since the pseudo-root has no payload or
+        // variant, ignore these.
+        auto parentUsdItem = std::dynamic_pointer_cast<UsdUfe::UsdSceneItem>(parentItem);
+        if (!parentUsdItem) {
+            return;
+        }
+
+        // On variant switch, given a pulled prim, the session layer will
+        // have path-based USD overs for pull information and active
+        // (false) for that prim in the session layer.  If a prim child
+        // brought in by variant switching has the same name as that of the
+        // pulled prim in a previous variant, the overs will apply to to
+        // the new prim, which would then get a path mapping, which is
+        // inappropriate.  Read children using the USD API, including
+        // inactive children (since pulled prims are inactivated), to
+        // support a variant switch to variant child with the same name.
+        auto parentPrim = parentUsdItem->prim();
+        bool foundChild { false };
+        for (const auto& child :
+             parentPrim.GetFilteredChildren(UsdPrimIsDefined && !UsdPrimIsAbstract)) {
+            auto childPath = parentItem->path().popSegment();
+            childPath = childPath
+                + Ufe::PathSegment(
+                            child.GetPath().GetAsString(), MayaUsd::ufe::getUsdRunTimeId(), '/');
+
+            auto ancestorNode = _pulledPrims.node(childPath);
+            // If there is no ancestor node in the trie, this means that
+            // the new hierarchy is completely different from the one when
+            // the pull occurred, which means that the pulled object must
+            // stay hidden.
+            if (!ancestorNode)
+                continue;
+
+            foundChild = true;
+            recursiveSwitch(ancestorNode, childPath, true);
+            recursiveSwitch(ancestorNode, childPath, false);
+        }
+
+        // Following a subtree invalidate, if none of the now-valid
+        // children appear in the trie, means that we've switched to a
+        // different variant or it was a payload that got unloaded,
+        // so everything below that path should be hidden.
+        if (!foundChild) {
             auto ancestorNode = _pulledPrims.node(op.path);
             if (ancestorNode) {
                 recursiveSetOrphaned(ancestorNode, true);
-            }
-            return;
-        } else {
-            // On variant switch, given a pulled prim, the session layer will
-            // have path-based USD overs for pull information and active
-            // (false) for that prim in the session layer.  If a prim child
-            // brought in by variant switching has the same name as that of the
-            // pulled prim in a previous variant, the overs will apply to to
-            // the new prim, which would then get a path mapping, which is
-            // inappropriate.  Read children using the USD API, including
-            // inactive children (since pulled prims are inactivated), to
-            // support a variant switch to variant child with the same name.
-
-            auto parentUsdItem = std::dynamic_pointer_cast<UsdUfe::UsdSceneItem>(parentItem);
-            if (!parentUsdItem) {
-                // USD sends resync changes (UFE subtree invalidate) on the
-                // pseudo-root itself.  Since the pseudo-root has no payload or
-                // variant, ignore these.
-                TF_VERIFY(parentItem->path().nbSegments() == 1);
-                return;
-            }
-            auto parentPrim = parentUsdItem->prim();
-            bool foundChild { false };
-            for (const auto& child :
-                 parentPrim.GetFilteredChildren(UsdPrimIsDefined && !UsdPrimIsAbstract)) {
-                auto childPath = parentItem->path().popSegment();
-                childPath
-                    = childPath
-                    + Ufe::PathSegment(
-                          child.GetPath().GetAsString(), MayaUsd::ufe::getUsdRunTimeId(), '/');
-
-                auto ancestorNode = _pulledPrims.node(childPath);
-                // If there is no ancestor node in the trie, this means that
-                // the new hierarchy is completely different from the one when
-                // the pull occurred, which means that the pulled object must
-                // stay hidden.
-                if (!ancestorNode)
-                    continue;
-
-                foundChild = true;
-                recursiveSwitch(ancestorNode, childPath);
-            }
-            if (!foundChild) {
-                // Following a subtree invalidate, if none of the now-valid
-                // children appear in the trie, means that we've switched to a
-                // different variant, and everything below that path should be
-                // hidden.
-                auto ancestorNode = _pulledPrims.node(op.path);
-                if (ancestorNode) {
-                    recursiveSetOrphaned(ancestorNode, true);
-                }
             }
         }
     } break;
@@ -429,7 +465,8 @@ OrphanedNodesManager::Memento OrphanedNodesManager::preserve() const
 
 void OrphanedNodesManager::restore(Memento&& previous) { _pulledPrims = previous.release(); }
 
-bool OrphanedNodesManager::isOrphaned(const Ufe::Path& pulledPath) const
+bool OrphanedNodesManager::isOrphaned(const Ufe::Path& pulledPath, const MDagPath& editedAsMayaRoot)
+    const
 {
     auto trieNode = _pulledPrims.node(pulledPath);
     if (!trieNode) {
@@ -442,15 +479,24 @@ bool OrphanedNodesManager::isOrphaned(const Ufe::Path& pulledPath) const
         return false;
     }
 
-    const PullVariantInfo& variantInfo = trieNode->data();
+    const std::vector<PullVariantInfo>& variantInfos = trieNode->data();
 
-    // If the pull parent is visible, the pulled path is not orphaned.
-    MDagPath pullParentPath = variantInfo.editedAsMayaRoot;
-    pullParentPath.pop();
+    for (const PullVariantInfo& variantInfo : variantInfos) {
 
-    MFnDagNode fn(pullParentPath);
-    auto       visibilityPlug = fn.findPlug("visibility", /* tryNetworked */ true);
-    return !visibilityPlug.asBool();
+        if (!(variantInfo.editedAsMayaRoot == editedAsMayaRoot)) {
+            continue;
+        }
+
+        // If the pull parent is visible, the pulled path is not orphaned.
+        MDagPath pullParentPath = editedAsMayaRoot;
+        pullParentPath.pop();
+
+        MFnDagNode fn(pullParentPath);
+        auto       visibilityPlug = fn.findPlug("visibility", /* tryNetworked */ true);
+        return !visibilityPlug.asBool();
+    }
+
+    return false;
 }
 
 namespace {
@@ -525,10 +571,21 @@ MStatus setNodeVisibility(const MDagPath& dagPath, bool visibility)
 /* static */
 bool OrphanedNodesManager::setOrphaned(const PulledPrimNode::Ptr& trieNode, bool orphaned)
 {
-    TF_VERIFY(trieNode->hasData());
+    if (!trieNode->hasData())
+        return true;
 
-    const PullVariantInfo& variantInfo = trieNode->data();
+    for (const PullVariantInfo& variantInfo : trieNode->data())
+        setOrphaned(trieNode, variantInfo, orphaned);
 
+    return true;
+}
+
+/* static */
+bool OrphanedNodesManager::setOrphaned(
+    const PulledPrimNode::Ptr& trieNode,
+    const PullVariantInfo&     variantInfo,
+    bool                       orphaned)
+{
     // Note: the change to USD data must be done *after* changes to Maya data because
     //       the outliner reacts to UFE notifications received following the USD edits
     //       to rebuild the node tree and the Maya node we want to hide must have been
@@ -537,23 +594,34 @@ bool OrphanedNodesManager::setOrphaned(const PulledPrimNode::Ptr& trieNode, bool
     pullParentPath.pop();
     CHECK_MSTATUS_AND_RETURN(setNodeVisibility(pullParentPath, !orphaned), false);
 
-    const Ufe::Path pulledPrimPath = trieNodeToPulledPrimUfePath(trieNode);
-
     // Note: if we are called due to the user deleting the stage, then the pulled prim
     //       path will be invalid and trying to add or remove information on it will
     //       fail, and cause spurious warnings in the script editor, so avoid it.
-    if (!pulledPrimPath.empty()) {
-        if (orphaned) {
-            removePulledPrimMetadata(pulledPrimPath);
-            removeExcludeFromRendering(pulledPrimPath);
-        } else {
-            writePulledPrimMetadata(pulledPrimPath, variantInfo.editedAsMayaRoot);
-            addExcludeFromRendering(pulledPrimPath);
-        }
+    const Ufe::Path pulledPrimPath = trieNodeToPulledPrimUfePath(trieNode);
+    if (pulledPrimPath.empty())
+        return true;
+
+    // Note: if we are called due to the user deleting the stage, then the stage
+    //       will be invalid, don't treat this as an error.
+    UsdStagePtr stage = getStage(pulledPrimPath);
+    if (!stage)
+        return true;
+
+    if (orphaned) {
+        removePulledPrimMetadata(pulledPrimPath);
+        removeExcludeFromRendering(pulledPrimPath);
+    } else {
+        writePulledPrimMetadata(pulledPrimPath, variantInfo.editedAsMayaRoot);
+        addExcludeFromRendering(pulledPrimPath);
     }
 
+    TF_STATUS(
+        "Edited-as-Maya prim \"%s\" %s.",
+        pulledPrimPath.string().c_str(),
+        orphaned ? "was orphaned and is now hidden" : "no longer orphaned and is now shown");
+
     return true;
-}
+} // namespace MAYAUSD_NS_DEF
 
 /* static */
 void OrphanedNodesManager::recursiveSetOrphaned(const PulledPrimNode::Ptr& trieNode, bool orphaned)
@@ -574,7 +642,8 @@ void OrphanedNodesManager::recursiveSetOrphaned(const PulledPrimNode::Ptr& trieN
 /* static */
 void OrphanedNodesManager::recursiveSwitch(
     const PulledPrimNode::Ptr& trieNode,
-    const Ufe::Path&           ufePath)
+    const Ufe::Path&           ufePath,
+    const bool                 processOrphans)
 {
     // We know in our case that a trie node with data can't have children,
     // since descendants of a pulled prim can't be pulled.  A trie node with
@@ -592,11 +661,15 @@ void OrphanedNodesManager::recursiveSwitch(
         // tree state don't match, the pulled node must be made invisible.
         // Inactivation must not be considered, as the USD pulled node is made
         // inactive on pull, to avoid rendering it.
-        const auto& originalDesc = trieNode->data().variantSetDescriptors;
-        const auto  currentDesc = variantSetDescriptors(ufePath.pop());
-        const bool  variantSetsMatch = (originalDesc == currentDesc);
-        const bool  orphaned = (pulledNode && !variantSetsMatch);
-        TF_VERIFY(setOrphaned(trieNode, orphaned));
+        const auto             currentDesc = variantSetDescriptors(ufePath.pop());
+        const PullVariantInfos infos = trieNode->data();
+        for (const PullVariantInfo& variantInfo : infos) {
+            const auto& originalDesc = variantInfo.variantSetDescriptors;
+            const bool  variantSetsMatch = (originalDesc == currentDesc);
+            const bool  orphaned = (pulledNode && !variantSetsMatch);
+            if (processOrphans == orphaned)
+                TF_VERIFY(setOrphaned(trieNode, variantInfo, orphaned));
+        }
     } else {
         const bool isGatewayToUsd = Ufe::SceneSegmentHandler::isGateway(ufePath);
         for (const auto& c : trieNode->childrenComponents()) {
@@ -606,10 +679,10 @@ void OrphanedNodesManager::recursiveSwitch(
                 // component stored in the trie. When crossing runtimes, we
                 // need to create a segment instead with the new runtime ID.
                 if (!isGatewayToUsd) {
-                    recursiveSwitch(childTrieNode, ufePath + c);
+                    recursiveSwitch(childTrieNode, ufePath + c, processOrphans);
                 } else {
                     Ufe::PathSegment childSegment(c, ufe::getUsdRunTimeId(), '/');
-                    recursiveSwitch(childTrieNode, ufePath + childSegment);
+                    recursiveSwitch(childTrieNode, ufePath + childSegment, processOrphans);
                 }
             }
         }
@@ -626,8 +699,10 @@ OrphanedNodesManager::variantSetDescriptors(const Ufe::Path& p)
         auto ancestor = Ufe::Hierarchy::createItem(path);
         auto usdAncestor = std::static_pointer_cast<UsdUfe::UsdSceneItem>(ancestor);
         auto variantSets = usdAncestor->prim().GetVariantSets();
+        auto setNames = variantSets.GetNames();
+        std::sort(setNames.begin(), setNames.end());
         std::list<VariantSelection> vs;
-        for (const auto& vsn : variantSets.GetNames()) {
+        for (const auto& vsn : setNames) {
             vs.emplace_back(vsn, variantSets.GetVariantSelection(vsn));
         }
         vsd.emplace_back(path, vs);

--- a/lib/mayaUsd/fileio/orphanedNodesManagerIO.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManagerIO.cpp
@@ -49,6 +49,20 @@ namespace {
 //                       ],
 //                   },
 //                ],
+//                "more pull info": [
+//                   {
+//                      "editedAsMayaRoot": "DAG-path-of-root-of-generated-Maya-data"
+//                      "variantSetDescriptors": [
+//                         {
+//                            "path": "UFE-path-of-one-ancestor",
+//                            "variantSelections": [
+//                               [ "variant-set-1-name", "variant-set-1-selection" ],
+//                               [ "variant-set-2-name", "variant-set-2-selection" ],
+//                            ],
+//                         },
+//                      ],
+//                   },
+//                ],
 //             },
 //          },
 //       },
@@ -59,6 +73,7 @@ namespace {
 
 static const std::string ufeComponentPrefix = "/";
 static const std::string pullInfoJsonKey = "pull info";
+static const std::string morePullInfoJsonKey = "more pull info";
 static const std::string editedAsMayaRootJsonKey = "editedAsMayaRoot";
 static const std::string variantSetDescriptorsJsonKey = "variantSetDescriptors";
 static const std::string pathJsonKey = "path";
@@ -74,8 +89,9 @@ using VariantSelection = OrphanedNodesManager::VariantSelection;
 using VariantSetDesc = OrphanedNodesManager::VariantSetDescriptor;
 using VariantSetDescList = std::list<VariantSetDesc>;
 using PullVariantInfo = OrphanedNodesManager::PullVariantInfo;
-using PullInfoTrie = Ufe::Trie<PullVariantInfo>;
-using PullInfoTrieNode = Ufe::TrieNode<PullVariantInfo>;
+using PullVariantInfos = std::vector<PullVariantInfo>;
+using PullInfoTrie = OrphanedNodesManager::PulledPrims;
+using PullInfoTrieNode = OrphanedNodesManager::PulledPrimNode;
 using Memento = OrphanedNodesManager::Memento;
 
 ////////////////////////////////////////////////////////////////////////////
@@ -90,6 +106,7 @@ PXR_NS::JsArray  convertToArray(const VariantSelection& variantSel);
 PXR_NS::JsObject convertToObject(const VariantSetDesc& variantDesc);
 PXR_NS::JsArray  convertToArray(const std::list<VariantSetDesc>& allVariantDesc);
 PXR_NS::JsObject convertToObject(const PullVariantInfo& pullInfo);
+PXR_NS::JsObject convertToObject(const PullVariantInfos& pullInfos);
 PXR_NS::JsObject convertToObject(const PullInfoTrieNode::Ptr& pullInfoNode);
 PXR_NS::JsObject convertToObject(const PullInfoTrie& allPulledInfo);
 
@@ -97,6 +114,7 @@ VariantSelection   convertToVariantSelection(const PXR_NS::JsArray& variantSelJs
 VariantSetDesc     convertToVariantSetDescriptor(const PXR_NS::JsObject& variantDescJson);
 VariantSetDescList convertToVariantSetDescList(const PXR_NS::JsArray& allVariantDescJson);
 PullVariantInfo    convertToPullVariantInfo(const PXR_NS::JsObject& pullInfoJson);
+PullVariantInfos   convertToPullVariantInfos(const PXR_NS::JsObject& pullInfoJson);
 void         convertToPullInfoTrieNodePtr(const PXR_NS::JsObject&, PullInfoTrieNode::Ptr intoRoot);
 PullInfoTrie convertToPullInfoTrie(const PXR_NS::JsObject& allPulledInfoJson);
 
@@ -199,6 +217,44 @@ PullVariantInfo convertToPullVariantInfo(const PXR_NS::JsObject& pullInfoJson)
     return pullInfo;
 }
 
+PXR_NS::JsObject convertToObject(const PullVariantInfos& pullInfos)
+{
+    PXR_NS::JsObject pullInfoJson;
+
+    if (pullInfos.size() > 0) {
+        pullInfoJson = convertToObject(pullInfos[0]);
+    }
+
+    if (pullInfos.size() > 1) {
+        PXR_NS::JsArray morePullInfoJson;
+        for (size_t i = 1; i < pullInfos.size(); ++i) {
+            PXR_NS::JsObject moreInfoJson = convertToObject(pullInfos[i]);
+            morePullInfoJson.emplace_back(moreInfoJson);
+        }
+        pullInfoJson[morePullInfoJsonKey] = morePullInfoJson;
+    }
+
+    return pullInfoJson;
+}
+
+PullVariantInfos convertToPullVariantInfos(const PXR_NS::JsObject& pullInfoJson)
+{
+    PullVariantInfos pullInfos;
+
+    if (pullInfoJson.count(editedAsMayaRootJsonKey)) {
+        pullInfos.emplace_back(convertToPullVariantInfo(pullInfoJson));
+    }
+
+    if (pullInfoJson.count(morePullInfoJsonKey)) {
+        PXR_NS::JsArray morePullInfoJson
+            = convertToArray(convertJsonKeyToValue(pullInfoJson, morePullInfoJsonKey));
+        for (const PXR_NS::JsValue& value : morePullInfoJson) {
+            pullInfos.emplace_back(convertToPullVariantInfo(convertToObject(value)));
+        }
+    }
+    return pullInfos;
+}
+
 PXR_NS::JsObject convertToObject(const PullInfoTrieNode::Ptr& pullInfoNodePtr)
 {
     if (!pullInfoNodePtr)
@@ -208,7 +264,7 @@ PXR_NS::JsObject convertToObject(const PullInfoTrieNode::Ptr& pullInfoNodePtr)
 
     PXR_NS::JsObject pullInfoNodeJson;
 
-    if (pullInfoNode.hasData()) {
+    if (pullInfoNode.hasData() && pullInfoNode.data().size() > 0) {
         pullInfoNodeJson[pullInfoJsonKey] = convertToObject(pullInfoNode.data());
     }
 
@@ -232,7 +288,7 @@ void convertToPullInfoTrieNodePtr(
         if (key.size() <= 0) {
             continue;
         } else if (key == pullInfoJsonKey) {
-            intoRoot->setData(convertToPullVariantInfo(convertToObject(value)));
+            intoRoot->setData(convertToPullVariantInfos(convertToObject(value)));
 
         } else if (key[0] == '/') {
             PullInfoTrieNode::Ptr child = std::make_shared<PullInfoTrieNode>(key.substr(1));

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -119,12 +119,18 @@ SdfPath makeDstPath(const SdfPath& dstRootParentPath, const SdfPath& srcPath)
     auto relativeSrcPath = srcPath.MakeRelativePath(SdfPath::AbsoluteRootPath());
     return dstRootParentPath.AppendPath(relativeSrcPath);
 }
+} // namespace
 
 //------------------------------------------------------------------------------
 //
 // Verify if the given prim under the given UFE path is an ancestor of an already edited prim.
-bool hasEditedDescendant(const Ufe::Path& ufeQueryPath)
+bool PrimUpdaterManager::hasEditedDescendant(const Ufe::Path& ufeQueryPath) const
 {
+#ifdef HAS_ORPHANED_NODES_MANAGER
+    if (_orphanedNodesManager->has(ufeQueryPath))
+        return true;
+#endif
+
     MObject pullSetObj;
     auto    status = UsdMayaUtil::GetMObjectByName(kPullSetName, pullSetObj);
     if (status != MStatus::kSuccess)
@@ -142,6 +148,15 @@ bool hasEditedDescendant(const Ufe::Path& ufeQueryPath)
         if (!readPullInformation(pulledDagPath, pulledUfePath))
             continue;
 
+#ifdef HAS_ORPHANED_NODES_MANAGER
+        // If the alread-edited node is orphaned, don't take it into consideration.
+        if (_orphanedNodesManager) {
+            if (_orphanedNodesManager->isOrphaned(pulledUfePath, pulledDagPath)) {
+                continue;
+            }
+        }
+#endif
+
         if (pulledUfePath.startsWith(ufeQueryPath))
             return true;
     }
@@ -149,6 +164,7 @@ bool hasEditedDescendant(const Ufe::Path& ufeQueryPath)
     return false;
 }
 
+namespace {
 //------------------------------------------------------------------------------
 //
 // The UFE path is to the pulled prim, and the Dag path is the corresponding
@@ -198,22 +214,9 @@ bool writeAllPullInformation(const Ufe::Path& ufePulledPath, const MDagPath& edi
 //
 void removeAllPullInformation(const Ufe::Path& ufePulledPath)
 {
-    UsdPrim     pulledPrim = MayaUsd::ufe::ufePathToPrim(ufePulledPath);
-    UsdStagePtr stage = pulledPrim.GetStage();
-    if (!stage)
-        return;
-
     MayaUsd::ProgressBarScope progressBar(1);
-    removePulledPrimMetadata(stage, pulledPrim);
+    removePulledPrimMetadata(ufePulledPath);
     progressBar.advance();
-
-    // Session layer cleanup
-    auto                          rootPrims = stage->GetSessionLayer()->GetRootPrims();
-    MayaUsd::ProgressBarLoopScope rootPrimsLoop(rootPrims.size());
-    for (const SdfPrimSpecHandle& rootPrimSpec : rootPrims) {
-        stage->GetSessionLayer()->RemovePrimIfInert(rootPrimSpec);
-        rootPrimsLoop.loopAdvance();
-    }
 }
 
 //------------------------------------------------------------------------------
@@ -865,7 +868,7 @@ public:
 
     bool undo() override
     {
-        _orphanedNodesManager->remove(_pulledPath);
+        _orphanedNodesManager->remove(_pulledPath, _editedAsMayaRoot);
         return true;
     }
 
@@ -888,13 +891,14 @@ public:
     // the global undo list.
     static bool execute(
         const std::shared_ptr<OrphanedNodesManager>& orphanedNodesManager,
-        const Ufe::Path&                             pulledPath)
+        const Ufe::Path&                             pulledPath,
+        const MDagPath&                              editedAsMayaRoot)
     {
         // Get the global undo list.
         auto& undoInfo = OpUndoItemList::instance();
 
-        auto item
-            = std::make_unique<RemovePullVariantInfoUndoItem>(orphanedNodesManager, pulledPath);
+        auto item = std::make_unique<RemovePullVariantInfoUndoItem>(
+            orphanedNodesManager, pulledPath, editedAsMayaRoot);
         if (!item->redo()) {
             return false;
         }
@@ -906,10 +910,12 @@ public:
 
     RemovePullVariantInfoUndoItem(
         const std::shared_ptr<OrphanedNodesManager>& orphanedNodesManager,
-        const Ufe::Path&                             pulledPath)
+        const Ufe::Path&                             pulledPath,
+        const MDagPath&                              editedAsMayaRoot)
         : OpUndoItem(std::string("Remove pull path ") + Ufe::PathString::string(pulledPath))
         , _orphanedNodesManager(orphanedNodesManager)
         , _pulledPath(pulledPath)
+        , _editedAsMayaRoot(editedAsMayaRoot)
     {
     }
 
@@ -921,13 +927,14 @@ public:
 
     bool redo() override
     {
-        _memento = _orphanedNodesManager->remove(_pulledPath);
+        _memento = _orphanedNodesManager->remove(_pulledPath, _editedAsMayaRoot);
         return true;
     }
 
 private:
     const std::shared_ptr<OrphanedNodesManager> _orphanedNodesManager;
     const Ufe::Path                             _pulledPath;
+    const MDagPath                              _editedAsMayaRoot;
 
     // Created by redo().
     OrphanedNodesManager::Memento _memento;
@@ -1056,7 +1063,8 @@ bool PrimUpdaterManager::mergeToUsd(
     // thinking the Maya data shoudl be shown again...
 #ifdef HAS_ORPHANED_NODES_MANAGER
     if (_orphanedNodesManager) {
-        if (!TF_VERIFY(RemovePullVariantInfoUndoItem::execute(_orphanedNodesManager, pulledPath))) {
+        if (!TF_VERIFY(RemovePullVariantInfoUndoItem::execute(
+                _orphanedNodesManager, pulledPath, mayaDagPath))) {
             return false;
         }
     }
@@ -1161,7 +1169,7 @@ bool PrimUpdaterManager::mergeToUsd(
 bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& userArgs)
 {
     if (hasEditedDescendant(path)) {
-        TF_WARN("Cannot edit an ancestor of an already edited node.");
+        TF_WARN("Cannot edit an ancestor (%s) of an already edited node.", path.string().c_str());
         return false;
     }
 
@@ -1294,7 +1302,7 @@ bool PrimUpdaterManager::discardEdits(const MDagPath& dagPath)
     auto usdPrim = MayaUsd::ufe::ufePathToPrim(pulledPath);
 
 #ifdef HAS_ORPHANED_NODES_MANAGER
-    auto ret = _orphanedNodesManager->isOrphaned(pulledPath)
+    auto ret = _orphanedNodesManager->isOrphaned(pulledPath, dagPath)
         ? discardOrphanedEdits(dagPath, pulledPath)
         : discardPrimEdits(pulledPath);
 #else
@@ -1373,7 +1381,8 @@ bool PrimUpdaterManager::discardPrimEdits(const Ufe::Path& pulledPath)
 
 #ifdef HAS_ORPHANED_NODES_MANAGER
     if (_orphanedNodesManager) {
-        if (!TF_VERIFY(RemovePullVariantInfoUndoItem::execute(_orphanedNodesManager, pulledPath))) {
+        if (!TF_VERIFY(RemovePullVariantInfoUndoItem::execute(
+                _orphanedNodesManager, pulledPath, mayaDagPath))) {
             return false;
         }
     }
@@ -1464,7 +1473,8 @@ bool PrimUpdaterManager::discardOrphanedEdits(const MDagPath& dagPath, const Ufe
 
 #ifdef HAS_ORPHANED_NODES_MANAGER
     if (_orphanedNodesManager) {
-        if (!TF_VERIFY(RemovePullVariantInfoUndoItem::execute(_orphanedNodesManager, pulledPath))) {
+        if (!TF_VERIFY(RemovePullVariantInfoUndoItem::execute(
+                _orphanedNodesManager, pulledPath, dagPath))) {
             return false;
         }
     }
@@ -1883,12 +1893,12 @@ PrimUpdaterManager::PulledPrimPaths PrimUpdaterManager::getPulledPrimPaths() con
         return pulledPaths;
 
     const OrphanedNodesManager::PulledPrims& pulledPrims = _orphanedNodesManager->getPulledPrims();
-    MayaUsd::TrieVisitor<OrphanedNodesManager::PullVariantInfo>::visit(
+    MayaUsd::TrieVisitor<OrphanedNodesManager::PullVariantInfos>::visit(
         pulledPrims,
-        [&pulledPaths](
-            const Ufe::Path&                                            path,
-            const Ufe::TrieNode<OrphanedNodesManager::PullVariantInfo>& node) {
-            pulledPaths.emplace_back(path, node.data().editedAsMayaRoot);
+        [&pulledPaths](const Ufe::Path& path, const OrphanedNodesManager::PulledPrimNode& node) {
+            for (const OrphanedNodesManager::PullVariantInfo& info : node.data()) {
+                pulledPaths.emplace_back(path, info.editedAsMayaRoot);
+            }
         });
 
 #endif

--- a/lib/mayaUsd/fileio/primUpdaterManager.h
+++ b/lib/mayaUsd/fileio/primUpdaterManager.h
@@ -114,8 +114,11 @@ private:
     //! Create the pull parent and set it into the prim updater context.
     MDagPath setupPullParent(const Ufe::Path& pulledPath, VtDictionary& args);
 
-    //! Record pull information for the pulled path, for inspection on
-    //! scene changes.
+    //! Verify if the given prim at the given UFE path is an ancestor of an already edited prim.
+    bool hasEditedDescendant(const Ufe::Path& ufeQueryPath) const;
+
+//! Record pull information for the pulled path, for inspection on
+//! scene changes.
 #ifdef HAS_ORPHANED_NODES_MANAGER
     // Maya file new or open callback.  Member function to access other private
     // member functions.

--- a/lib/mayaUsd/fileio/pullInformation.h
+++ b/lib/mayaUsd/fileio/pullInformation.h
@@ -28,6 +28,11 @@ UFE_NS_DEF { class Path; }
 
 namespace MAYAUSD_NS_DEF {
 
+////////////////////////////////////////////////////////////////////////////
+//
+// Helper functions to write, read and remove edited-as-Maya (pull)
+// information set on the Maya DAG node.
+
 /// @brief Write on the Maya node the information necessary later-on to merge
 ///        the USD prim that is edited as Maya.
 MAYAUSD_CORE_PUBLIC
@@ -37,17 +42,28 @@ bool writePullInformation(const Ufe::Path& ufePulledPath, const MDagPath& edited
 ///        that is edited as Maya.
 MAYAUSD_CORE_PUBLIC
 bool readPullInformation(const PXR_NS::UsdPrim& prim, std::string& dagPathStr);
+
 MAYAUSD_CORE_PUBLIC
 bool readPullInformation(const PXR_NS::UsdPrim& prim, Ufe::SceneItem::Ptr& dagPathItem);
+
 MAYAUSD_CORE_PUBLIC
 bool readPullInformation(const Ufe::Path& ufePath, MDagPath& dagPath);
+
 MAYAUSD_CORE_PUBLIC
 bool readPullInformation(const MDagPath& dagpath, Ufe::Path& ufePath);
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Helper functions to write, read and remove edited-as-Maya (pull)
+// information set on the edited USD prim.
 
 /// @brief Write on the USD prim the information necessary later-on to merge
 ///        the USD prim that is edited as Maya.
 MAYAUSD_CORE_PUBLIC
 bool writePulledPrimMetadata(const Ufe::Path& ufePulledPath, const MDagPath& editedRoot);
+
+/// @brief Write on the USD prim the information necessary later-on to merge
+///        the USD prim that is edited as Maya.
 MAYAUSD_CORE_PUBLIC
 bool writePulledPrimMetadata(PXR_NS::UsdPrim& pulledPrim, const MDagPath& editedRoot);
 
@@ -55,8 +71,15 @@ bool writePulledPrimMetadata(PXR_NS::UsdPrim& pulledPrim, const MDagPath& edited
 ///        that was edited as Maya.
 MAYAUSD_CORE_PUBLIC
 void removePulledPrimMetadata(const Ufe::Path& ufePulledPath);
+
+/// @brief Remove from the USD prim the information necessary to merge the USD prim
+///        that was edited as Maya.
 MAYAUSD_CORE_PUBLIC
 void removePulledPrimMetadata(const PXR_NS::UsdStagePtr& stage, PXR_NS::UsdPrim& prim);
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Helper functions to hide and show the edited prim.
 
 /// @brief Hide the USD prim that is edited as Maya.
 ///        This is done so that the USD prim and edited Maya data are not superposed
@@ -68,6 +91,10 @@ bool addExcludeFromRendering(const Ufe::Path& ufePulledPath);
 ///        This is done once the Maya data is meged into USD and removed from the scene.
 MAYAUSD_CORE_PUBLIC
 bool removeExcludeFromRendering(const Ufe::Path& ufePulledPath);
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Helper functions to check if a prim is already edited-as-Maya.
 
 /// @brief Verify if the edited as Maya nodes corresponding to the given prim is orphaned.
 MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.cpp
@@ -36,6 +36,7 @@
 #include <mayaUsd/utils/util.h>
 
 #include <pxr/base/tf/getenv.h>
+#include <pxr/usd/usd/editContext.h>
 
 #include <maya/MDGModifier.h>
 #include <maya/MFileIO.h>
@@ -157,6 +158,12 @@ const TfToken MayaReferenceNodeName("MayaReferenceNodeName");
 
 MStatus setMayaRefCustomAttribute(const UsdPrim& prim, const MFnReference& refDependNode)
 {
+    PXR_NS::UsdStagePtr stage = prim.GetStage();
+    if (!stage)
+        return MS::kFailure;
+
+    const PXR_NS::UsdEditContext editContext(stage, stage->GetSessionLayer());
+
     // Always have to try to create the attribute to make sure it is in the prim scope and not
     // inherited. If it was already created, it will be used.
     UsdAttribute attr = prim.CreateAttribute(MayaReferenceNodeName, SdfValueTypeNames->String);
@@ -175,17 +182,14 @@ MString GetMayaRefCustomAttribute(const UsdPrim& prim)
     VtValue value;
     attr.Get(&value);
 
-    // Check if attribute was directly on prim or inherited.
-    auto resInfo = attr.GetResolveInfo();
-    bool isAttributeOnPrim = resInfo.GetNode().GetPath() == prim.GetPath();
-    if (!isAttributeOnPrim)
-        return MString();
-
     // Check if the attribute type is correct.
-    if (value.GetType() != SdfValueTypeNames->String.GetType())
+    if (value.IsEmpty())
         return MString();
 
-    return MString(value.Get<std::string>().c_str());
+    if (!value.CanCast<std::string>())
+        return MString();
+
+    return value.Get<std::string>().c_str();
 }
 
 MStatus LoadOrUnloadMayaReferenceWithUndo(const MObject& referenceObject, bool load)
@@ -216,18 +220,15 @@ MStatus UnloadMayaReferenceWithUndo(const MObject& referenceObject)
     return LoadOrUnloadMayaReferenceWithUndo(referenceObject, false);
 }
 
-} // namespace
-
-const TfToken UsdMayaTranslatorMayaReference::m_namespaceName = TfToken("mayaNamespace");
-const TfToken UsdMayaTranslatorMayaReference::m_referenceName = TfToken("mayaReference");
-const TfToken UsdMayaTranslatorMayaReference::m_mergeNamespacesOnClash
-    = TfToken("mergeNamespacesOnClash");
+const TfToken namespaceNamePrimAttrName = TfToken("mayaNamespace");
+const TfToken referenceNameAttrName = TfToken("mayaReference");
+const TfToken mergeNamespacesOnClashAttrName = TfToken("mergeNamespacesOnClash");
 
 // Get the namespace attribute from prim
-MString UsdMayaTranslatorMayaReference::namespaceFromPrim(const UsdPrim& prim)
+MString namespaceFromPrim(const UsdPrim& prim)
 {
     std::string ns;
-    if (UsdAttribute namespaceAttribute = prim.GetAttribute(m_namespaceName)) {
+    if (UsdAttribute namespaceAttribute = prim.GetAttribute(namespaceNamePrimAttrName)) {
         TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
             .Msg(
                 "MayaReferenceLogic::update Checking namespace on prim \"%s\".\n",
@@ -247,7 +248,7 @@ MString UsdMayaTranslatorMayaReference::namespaceFromPrim(const UsdPrim& prim)
     return MString(ns.c_str(), ns.size());
 }
 
-MString UsdMayaTranslatorMayaReference::getUniqueRefNodeName(
+MString getUniqueRefNodeName(
     const UsdPrim&      prim,
     const MFnDagNode&   parentDag,
     const MFnReference& refDependNode)
@@ -279,7 +280,11 @@ MString UsdMayaTranslatorMayaReference::getUniqueRefNodeName(
     return uniqueRefNodeName;
 }
 
-MStatus UsdMayaTranslatorMayaReference::LoadMayaReference(
+} // namespace
+
+static MStatus connectReferenceAssociatedNode(MFnDagNode& dagNode, MFnReference& refNode);
+
+MStatus UsdMayaTranslatorMayaReference::CreateMayaReference(
     const UsdPrim& prim,
     MObject&       parent,
     MString&       mayaReferencePath,
@@ -287,7 +292,7 @@ MStatus UsdMayaTranslatorMayaReference::LoadMayaReference(
     bool           mergeNamespacesOnClash)
 {
     TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
-        .Msg("MayaReferenceLogic::LoadMayaReference prim=%s\n", prim.GetPath().GetText());
+        .Msg("MayaReferenceLogic::CreateMayaReference prim=%s\n", prim.GetPath().GetText());
     MStatus status;
 
     MFnDagNode parentDag(parent, &status);
@@ -334,7 +339,7 @@ MStatus UsdMayaTranslatorMayaReference::LoadMayaReference(
 
     TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
         .Msg(
-            "MayaReferenceLogic::LoadMayaReference prim=%s execute \"%s\"\n",
+            "MayaReferenceLogic::CreateMayaReference prim=%s execute \"%s\"\n",
             prim.GetPath().GetText(),
             referenceCommand.asChar());
     status = MGlobal::executeCommand(referenceCommand, createdNodes);
@@ -398,9 +403,7 @@ MStatus UsdMayaTranslatorMayaReference::UnloadMayaReference(const MObject& paren
     return status;
 }
 
-MStatus UsdMayaTranslatorMayaReference::connectReferenceAssociatedNode(
-    MFnDagNode&   dagNode,
-    MFnReference& refNode)
+static MStatus connectReferenceAssociatedNode(MFnDagNode& dagNode, MFnReference& refNode)
 {
     MPlug srcPlug(dagNode.object(), getMessageAttr());
     /*
@@ -433,60 +436,39 @@ MStatus UsdMayaTranslatorMayaReference::connectReferenceAssociatedNode(
     return result;
 }
 
-MStatus UsdMayaTranslatorMayaReference::update(const UsdPrim& prim, MObject parent)
+static MObject findConnectedMayaReference(MObject& parent)
 {
-    MStatus      status;
-    SdfAssetPath mayaReferenceAssetPath;
-    // Check to see if we have a valid Maya reference node name
-    UsdAttribute mayaReferenceNodeName = prim.GetAttribute(m_referenceName);
-    mayaReferenceNodeName.Get(&mayaReferenceAssetPath);
-    MString mayaReferencePath(mayaReferenceAssetPath.GetResolvedPath().c_str());
-
-    // The resolved path is empty if the maya reference is a full path.
-    if (!mayaReferencePath.length()) {
-        mayaReferencePath = mayaReferenceAssetPath.GetAssetPath().c_str();
-    }
-
-    // If the path is still empty return, there is no reference to import
-    if (!mayaReferencePath.length()) {
-        return MS::kFailure;
-    }
-    MFileObject fileObj;
-    fileObj.setRawFullName(mayaReferencePath);
-    mayaReferencePath = fileObj.resolvedFullName();
-
-    TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
-        .Msg(
-            "MayaReferenceLogic::update Looking for attribute on \"%s\".\"%s\"\n",
-            prim.GetTypeName().GetText(),
-            m_namespaceName.GetText());
-
-    MFnDagNode parentDag(parent, &status);
-    CHECK_MSTATUS_AND_RETURN_IT(status);
-
-    // Get required namespace attribute from prim
-    MString     rigNamespaceM = namespaceFromPrim(prim);
-    std::string rigNamespace = rigNamespaceM.asChar();
-
-    MObject refNode;
-
-    // First, see if a reference is already attached
+    MStatus           status;
     MFnDependencyNode fnParent(parent, &status);
-    if (status) {
-        MPlug      messagePlug(fnParent.object(), getMessageAttr());
-        MPlugArray referencePlugs;
+    if (!status)
+        return {};
+
+    MPlugArray referencePlugs;
+    {
+        MPlug messagePlug(fnParent.object(), getMessageAttr());
         messagePlug.connectedTo(referencePlugs, false, true);
-        for (uint32_t i = 0, n = referencePlugs.length(); i < n; ++i) {
-            MObject temp = referencePlugs[i].node();
-            if (temp.hasFn(MFn::kReference)) {
-                refNode = temp;
-            }
-        }
     }
 
-    // Check to see whether we have previously created a reference node for this
-    // prim.  If so, we can just reuse it.
-    //
+    for (uint32_t i = 0, n = referencePlugs.length(); i < n; ++i) {
+        MObject temp = referencePlugs[i].node();
+        if (!temp.hasFn(MFn::kReference))
+            continue;
+        return temp;
+    }
+
+    return {};
+}
+
+static bool isSameFileName(const MString& found, const MString& expected)
+{
+    return ghc::filesystem::path(found.asChar()) == ghc::filesystem::path(expected.asChar());
+}
+
+static MObject findExistingMayaReference(
+    const UsdPrim& prim,
+    MFnDagNode&    parentDag,
+    const MString& expectedRefFilePath)
+{
     // Notes for the legacy ref-naming scheme:
     //
     // The check is based on comparing the prim's full path and the name of the
@@ -512,33 +494,126 @@ MStatus UsdMayaTranslatorMayaReference::update(const UsdPrim& prim, MObject pare
     const bool    useLegacyScheme = useLegacyMayaRefNaming(prim);
     const MString expectedRefName
         = useLegacyScheme ? refNameFromPath(parentDag) : GetMayaRefCustomAttribute(prim);
-    if (refNode.isNull() && expectedRefName.length() > 0) {
-        for (MItDependencyNodes refIter(MFn::kReference); !refIter.isDone(); refIter.next()) {
-            MObject      tempRefNode = refIter.item();
-            MFnReference tempRefFn(tempRefNode);
-            if (!tempRefFn.isFromReferencedFile()) {
-                if (expectedRefName == tempRefFn.name()) {
-                    // Reconnect the reference node's `associatedNode` attr before
-                    // loading it, since the previous connection may be gone.
-                    connectReferenceAssociatedNode(parentDag, tempRefFn);
-                    refNode = tempRefNode;
+    if (expectedRefName.length() <= 0) {
+#ifdef MAYAUSD_DEBUG_MAYA_REFERENCE_LOCATION
+        TF_WARN("No Maya custom ref attribute for %s", prim.GetPath().GetText());
+#endif
+        return {};
+    }
 
-                    if (!useLegacyScheme) {
-                        // On reconnect, the  Maya reference node is renamed to match
-                        // the prim.
-                        MString uniqueRefNodeName
-                            = getUniqueRefNodeName(prim, parentDag, tempRefFn);
-                        tempRefFn.setName(uniqueRefNodeName);
+    for (MItDependencyNodes refIter(MFn::kReference); !refIter.isDone(); refIter.next()) {
+        MObject      tempObj = refIter.item();
+        MFnReference tempRefFn(tempObj);
 
-                        status = setMayaRefCustomAttribute(prim, tempRefFn);
-                        CHECK_MSTATUS_AND_RETURN_IT(status);
-                    }
+        // Only take into consideration reference nodes that are directly in
+        // the Maya scene file, not nodes that may be inside other referenced
+        // files.
+        if (tempRefFn.isFromReferencedFile())
+            continue;
 
-                    // Found a matching Maya reference node, stop searching.
-                    break;
-                }
+        // If the reference is not named as we expected, then even if it would
+        // refer to the same file we don't use it: it may belong to another stage
+        // or to the user.
+        const bool hasMatchingName = (expectedRefName == tempRefFn.name());
+#ifdef MAYAUSD_DEBUG_MAYA_REFERENCE_LOCATION
+        TF_WARN(
+            "Found Maya reference with %s name (%s != %s)",
+            hasMatchingName ? "matching" : "non-matching",
+            expectedRefName.asChar(),
+            tempRefFn.name().asChar());
+#endif
+        if (!hasMatchingName)
+            continue;
+
+        // If the reference is not to the expected referenced file, don't use it.
+        // It might be because two prims with the same name, which can happen when
+        // they are under different USD variants, result in the same reference node
+        // name but are referencing two different files. For example, it could be
+        // that the user wants to switch between two referenced rigs by switching
+        // between two variants.
+        const bool    resolvedName = true;
+        const bool    includePath = false; // Weirdly, false means we get full path!
+        const bool    includeCopy = false;
+        const MString refFilePath = tempRefFn.fileName(resolvedName, includePath, includeCopy);
+        if (!isSameFileName(refFilePath, expectedRefFilePath)) {
+#ifdef MAYAUSD_DEBUG_MAYA_REFERENCE_LOCATION
+            TF_WARN(
+                "Maya reference node [%s] does not refer to the expected file: "
+                "expected [%s], found [%s].",
+                expectedRefName.asChar(),
+                expectedRefFilePath.asChar(),
+                refFilePath.asChar());
+#endif
+            continue;
+        }
+
+        // If we get here, we have found the desired reference node.
+        // Reconnect the reference node's `associatedNode` attr before
+        // loading it, since the previous connection may be gone.
+        connectReferenceAssociatedNode(parentDag, tempRefFn);
+
+        if (!useLegacyScheme) {
+            // On reconnect, rename the Maya reference node to match the prim.
+            MString uniqueRefNodeName = getUniqueRefNodeName(prim, parentDag, tempRefFn);
+            tempRefFn.setName(uniqueRefNodeName);
+
+            if (!setMayaRefCustomAttribute(prim, tempRefFn)) {
+                TF_WARN(
+                    "The custom prim attribute used to track the Maya reference %s could not be "
+                    "updated.",
+                    prim.GetPath().GetText());
             }
         }
+
+        // Found a matching Maya reference node, stop searching.
+        return tempObj;
+    }
+
+    return {};
+}
+
+MStatus UsdMayaTranslatorMayaReference::update(const UsdPrim& prim, MObject parent)
+{
+    MStatus      status;
+    SdfAssetPath mayaReferenceAssetPath;
+    // Check to see if we have a valid Maya reference node name
+    UsdAttribute mayaReferenceNodeName = prim.GetAttribute(referenceNameAttrName);
+    mayaReferenceNodeName.Get(&mayaReferenceAssetPath);
+    MString mayaReferencePath(mayaReferenceAssetPath.GetResolvedPath().c_str());
+
+    // The resolved path is empty if the maya reference is a full path.
+    if (!mayaReferencePath.length()) {
+        mayaReferencePath = mayaReferenceAssetPath.GetAssetPath().c_str();
+    }
+
+    // If the path is still empty return, there is no reference to import
+    if (!mayaReferencePath.length()) {
+        return MS::kFailure;
+    }
+    MFileObject fileObj;
+    fileObj.setRawFullName(mayaReferencePath);
+    mayaReferencePath = fileObj.resolvedFullName();
+
+    TF_DEBUG(PXRUSDMAYA_TRANSLATORS)
+        .Msg(
+            "MayaReferenceLogic::update Looking for attribute on \"%s\".\"%s\"\n",
+            prim.GetTypeName().GetText(),
+            namespaceNamePrimAttrName.GetText());
+
+    MFnDagNode parentDag(parent, &status);
+    CHECK_MSTATUS_AND_RETURN_IT(status);
+
+    // Get required namespace attribute from prim
+    MString     rigNamespaceM = namespaceFromPrim(prim);
+    std::string rigNamespace = rigNamespaceM.asChar();
+
+    // First, see if a reference is already attached
+    MObject refNode = findConnectedMayaReference(parent);
+
+    // Check to see whether we have previously created a reference node for this
+    // prim.  If so, we can just reuse it.
+    if (refNode.isNull()) {
+        refNode = findExistingMayaReference(prim, parentDag, mayaReferencePath);
     }
 
     // If no reference found, we'll need to create it. This may be the first time we are
@@ -546,11 +621,11 @@ MStatus UsdMayaTranslatorMayaReference::update(const UsdPrim& prim, MObject pare
     if (refNode.isNull()) {
         bool mergeNamespacesOnClash = false;
         if (UsdAttribute mergeNamespacesOnClashAttribute
-            = prim.GetAttribute(m_mergeNamespacesOnClash)) {
+            = prim.GetAttribute(mergeNamespacesOnClashAttrName)) {
             mergeNamespacesOnClashAttribute.Get(&mergeNamespacesOnClash);
         }
 
-        return LoadMayaReference(
+        return CreateMayaReference(
             prim, parent, mayaReferencePath, rigNamespaceM, mergeNamespacesOnClash);
     }
 

--- a/lib/mayaUsd/fileio/translators/translatorMayaReference.h
+++ b/lib/mayaUsd/fileio/translators/translatorMayaReference.h
@@ -48,7 +48,7 @@ PXR_NAMESPACE_OPEN_SCOPE
 struct UsdMayaTranslatorMayaReference
 {
     MAYAUSD_CORE_PUBLIC
-    static MStatus LoadMayaReference(
+    static MStatus CreateMayaReference(
         const UsdPrim& prim,
         MObject&       parent,
         MString&       mayaReferencePath,
@@ -60,18 +60,6 @@ struct UsdMayaTranslatorMayaReference
 
     MAYAUSD_CORE_PUBLIC
     static MStatus update(const UsdPrim& prim, MObject parent);
-
-private:
-    static MString namespaceFromPrim(const UsdPrim& prim);
-    static MString getUniqueRefNodeName(
-        const UsdPrim&      prim,
-        const MFnDagNode&   parentDag,
-        const MFnReference& refDependNode);
-    static MStatus connectReferenceAssociatedNode(MFnDagNode& dagNode, MFnReference& refNode);
-
-    static const TfToken m_namespaceName;
-    static const TfToken m_referenceName;
-    static const TfToken m_mergeNamespacesOnClash;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/utils/variants.cpp
+++ b/lib/mayaUsd/utils/variants.cpp
@@ -74,19 +74,19 @@ getEditTargetForVariants(const PXR_NS::UsdPrim& prim, const PXR_NS::SdfLayerHand
     std::vector<std::string> variantPaths;
 #endif
 
-//     for (const PXR_NS::SdfPath& p : prim.GetPath().GetAncestorsRange()) {
-//         PXR_NS::UsdPrim          ancestor = prim.GetStage()->GetPrimAtPath(p);
-//         PXR_NS::UsdVariantSets   variantSets = ancestor.GetVariantSets();
-//         std::vector<std::string> setNames = variantSets.GetNames();
-//         for (const std::string& setName : setNames) {
-//             PXR_NS::UsdVariantSet variant = variantSets.GetVariantSet(setName);
-//             const std::string     selection = variant.GetVariantSelection();
-// #ifdef MAYAUSD_DEBUG_EDIT_TARGET_FOR_VARIANTS
-//             variantPaths.emplace_back(setName + std::string("=") + selection);
-// #endif
-//             editTarget = editTarget.ComposeOver(variant.GetVariantEditTarget(layer));
-//         }
-//     }
+    for (const PXR_NS::SdfPath& p : prim.GetPath().GetAncestorsRange()) {
+        PXR_NS::UsdPrim          ancestor = prim.GetStage()->GetPrimAtPath(p);
+        PXR_NS::UsdVariantSets   variantSets = ancestor.GetVariantSets();
+        std::vector<std::string> setNames = variantSets.GetNames();
+        for (const std::string& setName : setNames) {
+            PXR_NS::UsdVariantSet variant = variantSets.GetVariantSet(setName);
+            const std::string     selection = variant.GetVariantSelection();
+#ifdef MAYAUSD_DEBUG_EDIT_TARGET_FOR_VARIANTS
+            variantPaths.emplace_back(setName + std::string("=") + selection);
+#endif
+            editTarget = editTarget.ComposeOver(variant.GetVariantEditTarget(layer));
+        }
+    }
 
 #ifdef MAYAUSD_DEBUG_EDIT_TARGET_FOR_VARIANTS
     using namespace PXR_NS;

--- a/lib/mayaUsd/utils/variants.h
+++ b/lib/mayaUsd/utils/variants.h
@@ -18,9 +18,12 @@
 
 #include <mayaUsd/base/api.h>
 
+#include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/editContext.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/variantSets.h>
+
+#include <ufe/path.h>
 
 #include <functional>
 #include <string>
@@ -71,6 +74,24 @@ private:
     PXR_NS::UsdVariantSet _variantSet;
     std::string           _variant;
 };
+
+/*! \brief Creates an edit target for all variants that might affect the given prim.
+
+           Note that this includes variants on ancestors that affect this prim. To find
+           those ancestor variant is the main prupose of this function. For prim-specific
+           variant selections, OpenUSD already provides a built-in function on UsdPrim.
+ */
+MAYAUSD_CORE_PUBLIC
+PXR_NS::UsdEditTarget
+getEditTargetForVariants(const PXR_NS::UsdPrim& prim, const PXR_NS::SdfLayerHandle& layer);
+
+/*! \brief Creates an USD variant path for the given UFE path and variant selection.
+ */
+MAYAUSD_CORE_PUBLIC
+PXR_NS::SdfPath getVariantPath(
+    const Ufe::Path&   path,
+    const std::string& variantSetName,
+    const std::string& variantSelection);
 
 } // namespace MAYAUSD_NS_DEF
 

--- a/test/lib/mayaUsd/fileio/testAddMayaReference.py
+++ b/test/lib/mayaUsd/fileio/testAddMayaReference.py
@@ -413,7 +413,7 @@ class AddMayaReferenceTestCase(unittest.TestCase):
         vs = primTestDefault.GetVariantSets()
         variantSet = vs.GetVariantSet(variantSetName)
         self.assertEqual(variantSet.GetVariantSelection(), cacheVariantName)
-        self.assertTrue(mayaRefPrim.IsActive())
+        self.assertTrue(mayaRefPrim)
 
         # Switch to Maya Ref variant and verify that the auto-edit is
         # still on and the prim is now inactive.

--- a/test/lib/mayaUsd/fileio/testCacheToUsd.py
+++ b/test/lib/mayaUsd/fileio/testCacheToUsd.py
@@ -564,10 +564,8 @@ class CacheToUsdTestCase(unittest.TestCase):
         checkCacheParentFn(self, cacheParentChildren, variantSet, cacheVariantName)
 
         # Maya reference prim should now have the updated transformation.
-        editTarget = self.stage.GetEditTarget()
-        if variantSet:
-            variantSet.SetVariantSelection('Rig')
-            editTarget = variantSet.GetVariantEditTarget(editTarget.GetLayer())
+        if variantSetName:
+            cacheParent.GetVariantSet(variantSetName).SetVariantSelection('Rig')
 
         with Usd.EditContext(self.stage, editTarget):
             xformable = UsdGeom.Xformable(mayaRefPrim)


### PR DESCRIPTION
This change adds support to edit-as-Maya a prim that is under a variant, with each variation having a different Maya reference. That is, a single prim can now be edited-as-Maya multiple times in parallel. This required some changes on how those edited prim are tracked.

Edit-as-Maya authors data in the session layer related to the edited prim. Previously, when edited-as-Maya were orphaned or ceased to be, the order in which they were processed was random. This caused two prims with the same name but in different variants to potentially clobber each other's data. Now we process new orphans first, then new non-orphans second. This allows new non-orphans to write their data without it being wiped out by an orphan.

Additional variant-related helper functions:
- Add the getEditTargetForVariants function helper function to create the USD edit target targeting all the variants that affect a given prim.
- Ensure getEditTargetForVariants works in more complex scenarios spanning payloads and references.
- Add the getVariantPath helper function to create a USD path containing a variant selection.

Additional pull information helper functions:
- Warn when we fail to remove pull information.

Change to the orphan manager:
- Support having multiple entries for a given UFE path.
- To differentiate between entries, the corresponding root Maya DAG path must be given in all functions to figure out which version of the prim we are dealing with.
- Fortunately, all callers always have on hand the DAG path of the root Maya node.
- Change all implementation function to iterate over these variations.
- Change the orphaned nodes serialization to support the extra data.
- Make the serialization format backward compatible by special-casing the usual case of having a single variation at a given edited UFE path.
- Add a log to tell the user when an edited prim is orphaned.
- Add a has function in the orphaned node manager to check if a prim is already edited.
- Use it to avoid editing a prim variant twice.
- Fix how the orphaned manager handles notifications to determine orphans.
- In particular, handle deactvated prims correctly: when switching variants, the order of the consequences is not deterministic, so the handling must not assume that edited prims are active.
- Make the orphan manager handle orphans in two passes: first the new orphans, second the ones that are no longer orphans.
- This way, non-orphans can write their metadata and it won't be deleted by orphans of the same name.

Changes to the prim updater manager:
- Ignore edited prim that are orphaned when determining if a prim has edited descendants.
- Adapt to changes to the orphaned manager by passing the Maya DAG path to the root of the edited nodes.
- When merging to USD, when removing the pull information, use the helper function.

Changes to Maya reference translator (importer from USD to Maya):
- Make many functions be purely in the implementation instead of declared private in the class.
- This allows better hiding of the implementation.
- This was also necessary to make the function callable from internal implementation functions.
- Renamed LoadMayaReference to CreateMayaReference to better reflect what the function does.
- Split the long update function into multiple function for clarity.
- When trying to reuse Maya reference nodes, verify that the referenced file is the one that was expected.
- This allows two prim with the same USD path but different references to work alongside each other.
- This happens when one prim with two variants each contain a Maya reference.
- Add more comments in the code to explain what is going on.
- Add a log to tell the user when a reference does not have the expected file path.

EMSUSD-623 minimize changes from base branch.