### PR TITLE
EMSUSD-489 fix reparenting crash

### DIFF
--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -119,6 +119,9 @@ public:
         // transform3d() returns a whole-object interface, which may include
         // other transform ops.
         auto t3d = Ufe::Transform3d::editTransform3d(sceneItem());
+        if (!TF_VERIFY(t3d)) {
+            return;
+        }
         t3d->setMatrix(_newM);
     }
 

--- a/lib/usdUfe/utils/layers.h
+++ b/lib/usdUfe/utils/layers.h
@@ -90,24 +90,26 @@ void enforceMutedLayer(const PXR_NS::UsdPrim& prim, const char* command);
  *
  * @param prim The prim to be modified.
  * @param func The function to be applied.
+ * @return the number of prim specs that were affected.
  */
 
 using PrimSpecFunc = std::function<void(const PXR_NS::UsdPrim&, const PXR_NS::SdfPrimSpecHandle&)>;
 
 USDUFE_PUBLIC
-void applyToAllPrimSpecs(const PXR_NS::UsdPrim& prim, const PrimSpecFunc& func);
+int applyToAllPrimSpecs(const PXR_NS::UsdPrim& prim, const PrimSpecFunc& func);
 
 /**
  * Apply the given function to all the layers that have an opinion about the given prim.
  *
  * @param prim The prim to be modified.
  * @param func The function to be applied.
+ * @return the number of layers that were affected.
  */
 
 using PrimLayerFunc = std::function<void(const PXR_NS::UsdPrim&, const PXR_NS::SdfLayerRefPtr&)>;
 
 USDUFE_PUBLIC
-void applyToAllLayersWithOpinions(const PXR_NS::UsdPrim& prim, PrimLayerFunc& func);
+int applyToAllLayersWithOpinions(const PXR_NS::UsdPrim& prim, PrimLayerFunc& func);
 
 /**
  * Apply the given function to some of the layers that have an opinion about the given prim.
@@ -116,10 +118,11 @@ void applyToAllLayersWithOpinions(const PXR_NS::UsdPrim& prim, PrimLayerFunc& fu
  * @param prim The prim to be modified.
  * @param layers The set of layers that can be affected if they contain an opinion.
  * @param func The function to be applied.
+ * @return the number of layers that were affected.
  */
 
 USDUFE_PUBLIC
-void applyToSomeLayersWithOpinions(
+int applyToSomeLayersWithOpinions(
     const PXR_NS::UsdPrim&                  prim,
     const std::set<PXR_NS::SdfLayerRefPtr>& layers,
     PrimLayerFunc&                          func);

--- a/test/lib/ufe/testParentCmd.py
+++ b/test/lib/ufe/testParentCmd.py
@@ -25,7 +25,7 @@ from usdUtils import filterUsdStr
 
 import mayaUsd.ufe
 
-from pxr import UsdGeom, Vt, Gf, Sdf
+from pxr import UsdGeom, Vt, Gf, Sdf, Usd
 
 from maya import cmds
 from maya import standalone
@@ -274,6 +274,19 @@ class ParentCmdTestCase(unittest.TestCase):
 
         cylChildren = cylHier.children()
         self.assertEqual(len(cylChildren), 1)
+
+    def testParentRelativeLayer(self):
+        '''
+        Test that parenting in sub-layer that are loaded in relative mode works.
+        '''
+        usdFileName = testUtils.getTestScene('relativeSubLayer', 'root.usda')
+        shapeNode, stage = mayaUtils.createProxyFromFile(usdFileName)
+        self.assertEqual(len(stage.GetRootLayer().subLayerPaths), 1)
+        sublayer = Sdf.Layer.FindRelativeToLayer(stage.GetRootLayer(), stage.GetRootLayer().subLayerPaths[0])
+        with Usd.EditContext(stage, sublayer):
+            cmds.parent(shapeNode + ',/group/geo', shapeNode + ',/group/other')
+        movedCube = stage.GetPrimAtPath('/group/other/geo/cube')
+        self.assertTrue(movedCube)
 
     @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'Requires Maya fixes only available in Maya 2023 or greater.')
     def testParentAbsoluteSingleMatrixOp(self):

--- a/test/testSamples/relativeSubLayer/root.usda
+++ b/test/testSamples/relativeSubLayer/root.usda
@@ -1,0 +1,14 @@
+#usda 1.0
+(
+    subLayers = [
+        @sublayer.usda@,
+    ]
+)
+
+# With sub-layer, the hierarchy is group/geo/cube and group/other
+def Xform "group" (
+    kind = "component"
+)
+{
+}
+

--- a/test/testSamples/relativeSubLayer/sublayer.usda
+++ b/test/testSamples/relativeSubLayer/sublayer.usda
@@ -1,0 +1,27 @@
+#usda 1.0
+
+over Xform "group" (
+    kind = "component"
+)
+{
+    double3 xformOp:translate = (5.8646097315075165, 0, 2.156596612263078)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    def Xform "geo"
+    {
+        def Mesh "cube"
+        {
+            float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+            point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5)]
+            color3f[] primvars:displayColor = [(0.4, 0.4, 0.4)]
+            uniform token subdivisionScheme = "none"
+        }
+    }
+
+   def Xform "other"
+   {
+   }
+}
+


### PR DESCRIPTION
There were multiple problems that triggered each others to cause a crash when using relative sub-layers. The problems were:
- The relative sub-layer was not found.
- This cause the code that applies the reparenting to all layers to do no work.
- This would cause the prim to vanish.
- This would cause the transform command to crash because it did not check that the scene item was valid.

The corrections done are:
- Fix the getAllSubLayers helper function to use FindRelativeToLayer to find sub-layers, in case they are relative to their parent. Otherwise it would fail to find sub-layers.
- Modify the applyToAllPrimSpecs, applyToAllLayersWithOpinions and applyToSomeLayersWithOpinions helper functions to return the number of layers that were affected.
- This allows the caller to detect if no action was taken at all, indicating that an expected action failed.
- Make the UsdSetMatrix4dUndoableCmd UFE command not crash when the scene item is not found.
- Make the insert-child UFE command detect if the move to the new parent did no work at all and report an error instead of marching on and deleting the old location.
- Otherwise, the prim would not be at the new location and would be deleted from its old location, so it owuld vanish.

Add a unit test that try to reparent a prim in a relative sub-layer. It failed without the fixes, now it works.