### PR TITLE
EMSUSD-549 Fixes unneeded nodes getting exported on materials

### DIFF
--- a/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
@@ -94,8 +94,7 @@ private:
         const SdfPath&                         parentPath,
         const UsdMayaShadingModeExportContext& context,
         _NodeHandleToShaderWriterMap&          shaderWriterMap,
-        bool                                   createIfMissing = true
-    )
+        bool                                   createIfMissing = true)
     {
         if (depNode.hasFn(MFn::kShadingEngine)) {
             // depNode is the material itself, so we don't need to create a

--- a/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
@@ -93,7 +93,9 @@ private:
         const MObject&                         depNode,
         const SdfPath&                         parentPath,
         const UsdMayaShadingModeExportContext& context,
-        _NodeHandleToShaderWriterMap&          shaderWriterMap)
+        _NodeHandleToShaderWriterMap&          shaderWriterMap,
+        bool                                   createIfMissing = true
+    )
     {
         if (depNode.hasFn(MFn::kShadingEngine)) {
             // depNode is the material itself, so we don't need to create a
@@ -112,6 +114,10 @@ private:
             // We've already created a shader writer for this node, so just
             // return it.
             return iter->second;
+        }
+
+        if (!createIfMissing) {
+            return nullptr;
         }
 
         // No shader writer exists for this node yet, so create one.
@@ -180,7 +186,7 @@ private:
             rootPlugCopy,
             MFn::kInvalid,
             MItDependencyGraph::Direction::kUpstream,
-            MItDependencyGraph::Traversal::kDepthFirst,
+            MItDependencyGraph::Traversal::kBreadthFirst,
             MItDependencyGraph::Level::kPlugLevel,
             &status);
         if (status != MS::kSuccess) {
@@ -255,7 +261,7 @@ private:
                 }
 
                 auto dstShaderInfo = _GetExportedShaderForNode(
-                    dstPlug.node(), materialExportPath, context, shaderWriterMap);
+                    dstPlug.node(), materialExportPath, context, shaderWriterMap, false);
                 if (!dstShaderInfo) {
                     continue;
                 }

--- a/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
@@ -283,7 +283,7 @@ private:
                 }
 
                 bool allowedNode = false;
-                for (unsigned int j = 0; j < allowedNodes.length(); ++j) { 
+                for (unsigned int j = 0; j < allowedNodes.length(); ++j) {
                     if (dstPlug.node() == allowedNodes[j]) {
                         allowedNode = true;
                         break;


### PR DESCRIPTION
When exporting prims to USD that have Lambert materials , some extra nodes were being exported that would later cause a crash due to the mismatch between input nodes and uv sets. This fixes the issue by changing to depth first when traversing the node graph and only exporting nodes that are supposed to be part of the graph.
