### PR TITLE
EMSUSD-636 always use the same folder to load layers

### DIFF
--- a/plugin/adsk/scripts/mayaUsd_layerEditorFileDialogs.mel
+++ b/plugin/adsk/scripts/mayaUsd_layerEditorFileDialogs.mel
@@ -15,6 +15,7 @@
 
 // global used to store parent layer's directory to be used in usdRootFileRelative.uiInit
 global string $gLayerParentPathUsdLayerEditorSaveFileDialog = "";
+global string $gLayerParentPathUsdLayerEditorLoadFileDialog = "";
 
 ///////////////////////////////////////////////////////////
 //
@@ -164,12 +165,14 @@ global proc UsdLayerEditor_LoadLayersFileDialogOptions_UICreate(string $parent)
 
 global proc UsdLayerEditor_LoadLayersFileDialogOptions_UIInit(string $parent, string $filterType)
 {
-    global string $gLayerParentPathUsdLayerEditorSaveFileDialog;
-    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdSubLayerFileRelative.uiInit('" + $parent + "', '" + $filterType + "',  '" + $gLayerParentPathUsdLayerEditorSaveFileDialog + "')");
+    global string $gLayerParentPathUsdLayerEditorLoadFileDialog;
+    python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdSubLayerFileRelative.uiInit('" + $parent + "', '" + $filterType + "',  '" + $gLayerParentPathUsdLayerEditorLoadFileDialog + "')");
 }
 
 global proc UsdLayerEditor_LoadLayersFileDialogOptions_UICommit(string $parent, string $selectedFile)
 {
+    optionVar -stringValue usdMayaLoadLayersFolder $selectedFile;
+
     python("import mayaUsd_USDRootFileRelative as murel\nmurel.usdSubLayerFileRelative.uiCommit('" + $parent + "', '" + $selectedFile + "')");
 }
 
@@ -185,8 +188,12 @@ global proc UsdLayerEditor_LoadLayersFileDialogOptions_FileTypeChanged(string $p
 
 global proc string[] UsdLayerEditor_LoadLayersFileDialog(string $title, string $folder)
 {
-    global string $gLayerParentPathUsdLayerEditorSaveFileDialog;
-    $gLayerParentPathUsdLayerEditorSaveFileDialog = $folder;
+    global string $gLayerParentPathUsdLayerEditorLoadFileDialog;
+    if (`optionVar -exists usdMayaLoadLayersFolder`) {
+        $gLayerParentPathUsdLayerEditorLoadFileDialog = `optionVar -q usdMayaLoadLayersFolder`;
+    } else {
+        $gLayerParentPathUsdLayerEditorLoadFileDialog = $folder;
+    }
     
     string $fileFilter = python("from mayaUsdUtils import getUSDDialogFileFilters; getUSDDialogFileFilters(False)");
     $okCaption = getMayaUsdString("kLoad");
@@ -201,7 +208,7 @@ global proc string[] UsdLayerEditor_LoadLayersFileDialog(string $title, string $
             -optionsUICommit2 "UsdLayerEditor_LoadLayersFileDialogOptions_UICommit"
             -fileTypeChanged "UsdLayerEditor_LoadLayersFileDialogOptions_FileTypeChanged"
             -selectionChanged "UsdLayerEditor_LoadLayersFileDialogOptions_SelectionChanged"
-            -startingDirectory $folder
+            -startingDirectory $gLayerParentPathUsdLayerEditorLoadFileDialog
             `;
 
     return $result;


### PR DESCRIPTION
No matter whatthe  parent layer is, always use the last folder where a layer was loaded. (Unless no layer was ever loaded by the user, of course.)