### PR TITLE
Explicitly set UpAxis in tests

### DIFF
--- a/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateDisplayLayers.py
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateDisplayLayers.py
@@ -42,6 +42,10 @@ class testVP2RenderDelegateDisplayLayers(imageUtils.ImageDiffingTestCase):
 
     @classmethod
     def setUpClass(cls):
+        # The baselines assume Y-up, so make sure Maya is configured
+        # that way too.
+        cmds.upAxis(axis='y')
+
         inputPath = fixturesUtils.setUpClass(__file__,
             initializeStandalone=False, loadPlugin=False)
 

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateUSDPreviewSurface.py
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateUSDPreviewSurface.py
@@ -39,6 +39,10 @@ class testVP2RenderDelegateUSDPreviewSurface(imageUtils.ImageDiffingTestCase):
 
     @classmethod
     def setUpClass(cls):
+        # The baselines assume Y-up, so make sure Maya is configured
+        # that way too.
+        cmds.upAxis(axis='y')
+
         input_path = fixturesUtils.setUpClass(
             __file__, initializeStandalone=False, loadPlugin=False
         )


### PR DESCRIPTION
Certain baselines assume Y-up. Explicitly set this so tests pass in various environments