### PR TITLE
EMSUSD-632 prevent root metadata changes when not targeting root

### DIFF
--- a/lib/usdUfe/python/wrapCommands.cpp
+++ b/lib/usdUfe/python/wrapCommands.cpp
@@ -15,9 +15,11 @@
 //
 #include <usdUfe/ufe/UsdUndoAddPayloadCommand.h>
 #include <usdUfe/ufe/UsdUndoAddReferenceCommand.h>
+#include <usdUfe/ufe/UsdUndoClearDefaultPrimCommand.h>
 #include <usdUfe/ufe/UsdUndoClearPayloadsCommand.h>
 #include <usdUfe/ufe/UsdUndoClearReferencesCommand.h>
 #include <usdUfe/ufe/UsdUndoPayloadCommand.h>
+#include <usdUfe/ufe/UsdUndoSetDefaultPrimCommand.h>
 #include <usdUfe/ufe/UsdUndoToggleActiveCommand.h>
 #include <usdUfe/ufe/UsdUndoToggleInstanceableCommand.h>
 
@@ -71,10 +73,37 @@ UsdUfe::UsdUndoUnloadPayloadCommand* UnloadPayloadCommandInit(const PXR_NS::UsdP
     return new UsdUfe::UsdUndoUnloadPayloadCommand(prim);
 }
 
+UsdUfe::UsdUndoClearDefaultPrimCommand*
+ClearDefaultPrimCommandInit(const PXR_NS::UsdStageRefPtr& stage)
+{
+    return new UsdUfe::UsdUndoClearDefaultPrimCommand(stage);
+}
+
+UsdUfe::UsdUndoSetDefaultPrimCommand* SetDefaultPrimCommandInit(const PXR_NS::UsdPrim& prim)
+{
+    return new UsdUfe::UsdUndoSetDefaultPrimCommand(prim);
+}
+
 } // namespace
 
 void wrapCommands()
 {
+    {
+        using This = UsdUfe::UsdUndoClearDefaultPrimCommand;
+        class_<This, boost::noncopyable>("ClearDefaultPrimCommand", no_init)
+            .def("__init__", make_constructor(ClearDefaultPrimCommandInit))
+            .def("execute", &UsdUfe::UsdUndoClearDefaultPrimCommand::execute)
+            .def("undo", &UsdUfe::UsdUndoClearDefaultPrimCommand::undo)
+            .def("redo", &UsdUfe::UsdUndoClearDefaultPrimCommand::redo);
+    }
+    {
+        using This = UsdUfe::UsdUndoSetDefaultPrimCommand;
+        class_<This, boost::noncopyable>("SetDefaultPrimCommand", no_init)
+            .def("__init__", make_constructor(SetDefaultPrimCommandInit))
+            .def("execute", &UsdUfe::UsdUndoSetDefaultPrimCommand::execute)
+            .def("undo", &UsdUfe::UsdUndoSetDefaultPrimCommand::undo)
+            .def("redo", &UsdUfe::UsdUndoSetDefaultPrimCommand::redo);
+    }
     {
         using This = UsdUfe::UsdUndoAddPayloadCommand;
         class_<This, boost::noncopyable>("AddPayloadCommand", no_init)

--- a/lib/usdUfe/ufe/UsdUndoClearDefaultPrimCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoClearDefaultPrimCommand.cpp
@@ -27,7 +27,12 @@ namespace USDUFE_NS_DEF {
 
 UsdUndoClearDefaultPrimCommand::UsdUndoClearDefaultPrimCommand(const UsdPrim& prim)
     : Ufe::UndoableCommand()
-    , _prim(prim)
+    , _stage(prim.GetStage())
+{
+}
+
+UsdUndoClearDefaultPrimCommand::UsdUndoClearDefaultPrimCommand(const PXR_NS::UsdStageRefPtr& stage)
+    : _stage(stage)
 {
 }
 
@@ -35,16 +40,15 @@ UsdUndoClearDefaultPrimCommand::~UsdUndoClearDefaultPrimCommand() { }
 
 void UsdUndoClearDefaultPrimCommand::execute()
 {
-    const PXR_NS::UsdStageRefPtr stage = _prim.GetStage();
-    if (!stage)
+    if (!_stage)
         return;
 
     // Check if the default prim can be cleared.
-    applyRootLayerMetadataRestriction(stage, "clear default prim");
+    applyRootLayerMetadataRestriction(_stage, "clear default prim");
 
     // Clear the stage's default prim.
     UsdUndoBlock undoBlock(&_undoableItem);
-    stage->ClearDefaultPrim();
+    _stage->ClearDefaultPrim();
 }
 
 void UsdUndoClearDefaultPrimCommand::redo() { _undoableItem.redo(); }

--- a/lib/usdUfe/ufe/UsdUndoClearDefaultPrimCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoClearDefaultPrimCommand.cpp
@@ -35,19 +35,15 @@ UsdUndoClearDefaultPrimCommand::~UsdUndoClearDefaultPrimCommand() { }
 
 void UsdUndoClearDefaultPrimCommand::execute()
 {
-    UsdUndoBlock undoBlock(&_undoableItem);
-
-    PXR_NS::UsdStageWeakPtr stage = _prim.GetStage();
-
-    // Check if the layer selected is the root layer.
-    if (!UsdUfe::isRootLayer(stage)) {
-        TF_WARN(
-            "Stage metadata [defaultPrim] can only be modified when the root layer is targeted "
-            "[%s]",
-            stage->GetRootLayer()->GetDisplayName().c_str());
+    const PXR_NS::UsdStageRefPtr stage = _prim.GetStage();
+    if (!stage)
         return;
-    }
+
+    // Check if the default prim can be cleared.
+    applyRootLayerMetadataRestriction(stage, "clear default prim");
+
     // Clear the stage's default prim.
+    UsdUndoBlock undoBlock(&_undoableItem);
     stage->ClearDefaultPrim();
 }
 

--- a/lib/usdUfe/ufe/UsdUndoClearDefaultPrimCommand.h
+++ b/lib/usdUfe/ufe/UsdUndoClearDefaultPrimCommand.h
@@ -30,6 +30,7 @@ class USDUFE_PUBLIC UsdUndoClearDefaultPrimCommand : public Ufe::UndoableCommand
 public:
     // Public for std::make_shared() access, use create() instead.
     UsdUndoClearDefaultPrimCommand(const PXR_NS::UsdPrim& prim);
+    UsdUndoClearDefaultPrimCommand(const PXR_NS::UsdStageRefPtr& stage);
     ~UsdUndoClearDefaultPrimCommand() override;
 
     // Delete the copy/move constructors assignment operators.
@@ -38,12 +39,12 @@ public:
     UsdUndoClearDefaultPrimCommand(UsdUndoClearDefaultPrimCommand&&) = delete;
     UsdUndoClearDefaultPrimCommand& operator=(UsdUndoClearDefaultPrimCommand&&) = delete;
 
-private:
     void execute() override;
     void undo() override;
     void redo() override;
 
-    PXR_NS::UsdPrim _prim;
+private:
+    PXR_NS::UsdStageRefPtr _stage;
 
     UsdUndoableItem _undoableItem;
 

--- a/lib/usdUfe/ufe/UsdUndoSetDefaultPrimCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoSetDefaultPrimCommand.cpp
@@ -35,18 +35,15 @@ UsdUndoSetDefaultPrimCommand::~UsdUndoSetDefaultPrimCommand() { }
 
 void UsdUndoSetDefaultPrimCommand::execute()
 {
-    UsdUndoBlock            undoBlock(&_undoableItem);
-    PXR_NS::UsdStageWeakPtr stage = _prim.GetStage();
-
-    // Check if the layer selected is the root layer.
-    if (!UsdUfe::isRootLayer(stage)) {
-        TF_WARN(
-            "Stage metadata [defaultPrim] can only be modified when the root layer is targeted "
-            "[%s]",
-            stage->GetRootLayer()->GetDisplayName().c_str());
+    const PXR_NS::UsdStageRefPtr stage = _prim.GetStage();
+    if (!stage)
         return;
-    }
+
+    // Check if the default prim can be set.
+    applyRootLayerMetadataRestriction(stage, "set default prim");
+
     // Set the stage's default prim to the given prim.
+    UsdUndoBlock undoBlock(&_undoableItem);
     stage->SetDefaultPrim(_prim);
 }
 

--- a/lib/usdUfe/ufe/UsdUndoSetDefaultPrimCommand.h
+++ b/lib/usdUfe/ufe/UsdUndoSetDefaultPrimCommand.h
@@ -38,11 +38,11 @@ public:
     UsdUndoSetDefaultPrimCommand(UsdUndoSetDefaultPrimCommand&&) = delete;
     UsdUndoSetDefaultPrimCommand& operator=(UsdUndoSetDefaultPrimCommand&&) = delete;
 
-private:
     void execute() override;
     void undo() override;
     void redo() override;
 
+private:
     PXR_NS::UsdPrim _prim;
 
     UsdUndoableItem _undoableItem;

--- a/lib/usdUfe/ufe/Utils.h
+++ b/lib/usdUfe/ufe/Utils.h
@@ -264,6 +264,16 @@ bool applyCommandRestrictionNoThrow(
     const std::string&     commandName,
     bool                   allowStronger = false);
 
+//! Apply restriction rules for root layer metadata on the given prim
+USDUFE_PUBLIC
+void applyRootLayerMetadataRestriction(const PXR_NS::UsdPrim& prim, const std::string& commandName);
+
+//! Apply restriction rules for root layer metadata on the given stage
+USDUFE_PUBLIC
+void applyRootLayerMetadataRestriction(
+    const PXR_NS::UsdStageRefPtr& stage,
+    const std::string&            commandName);
+
 //! Check if the edit target in the stage is allowed to be changed.
 //! \return True, if the edit target layer in the stage is allowed to be changed
 USDUFE_PUBLIC
@@ -274,8 +284,5 @@ bool isEditTargetLayerModifiable(
 //! Combine two UFE bounding boxes.
 USDUFE_PUBLIC
 Ufe::BBox3d combineUfeBBox(const Ufe::BBox3d& ufeBBox1, const Ufe::BBox3d& ufeBBox2);
-
-USDUFE_PUBLIC
-bool isRootLayer(const PXR_NS::UsdStageWeakPtr prim);
 
 } // namespace USDUFE_NS_DEF

--- a/plugin/adsk/scripts/AETemplateHelpers.py
+++ b/plugin/adsk/scripts/AETemplateHelpers.py
@@ -68,7 +68,7 @@ def SetDefaultPrim(proxyShape, primName):
         return True
     except Exception as e:
         # Note: we do want to tell the user why the set or clear failed.
-        OpenMaya.MGlobal.displayError((str(e)))
+        OpenMaya.MGlobal.displayError(str(e))
         return False
     
 def GetRootLayerName(proxyShape):

--- a/plugin/adsk/scripts/AETemplateHelpers.py
+++ b/plugin/adsk/scripts/AETemplateHelpers.py
@@ -1,7 +1,8 @@
-import functools
 import os.path
 import maya.cmds as cmds
-import ufe
+import maya.api.OpenMaya as OpenMaya
+import maya.internal.ufeSupport.ufeCmdWrapper as ufeCmd
+import usdUfe
 import mayaUsd.ufe
 import mayaUsd.lib as mayaUsdLib
 import re
@@ -13,10 +14,12 @@ def debugMessage(msg):
     if DEBUG:
         print(msg)
 
+__naturalOrderRE = re.compile(r'([0-9]+)')
+
 def GetAllRootPrimNamesNaturalOrder(proxyShape):
     # Custom comparator key
     def natural_key(item):
-        return [int(s) if s.isdigit() else s.lower() for s in re.split(r'([0-9]+)', item)]
+        return [int(s) if s.isdigit() else s.lower() for s in __naturalOrderRE.split(item)]
     try:
         proxyStage = mayaUsd.ufe.getStage(proxyShape)
         primNames = []
@@ -47,19 +50,26 @@ def GetDefaultPrimName(proxyShape):
 def SetDefaultPrim(proxyShape, primName):
     try:
         proxyStage = mayaUsd.ufe.getStage(proxyShape)
-        if(not primName):
-           proxyStage.ClearDefaultPrim()
-        defautlPrim = None
-        if proxyStage:
-            for prim in proxyStage.TraverseAll():
-                if(primName == prim.GetName()):
-                    defautlPrim = prim
-        if defautlPrim:
-            proxyStage.SetDefaultPrim(defautlPrim)
+        if not proxyStage:
+            return False
+
+        cmd = None
+        if not primName:
+            cmd = usdUfe.ClearDefaultPrimCommand(proxyStage)
+        else:
+            defaultPrim = proxyStage.GetPrimAtPath('/' + primName)
+            if defaultPrim:
+                cmd = usdUfe.SetDefaultPrimCommand(defaultPrim)
+
+        if cmd is None:
+            return False
+        
+        ufeCmd.execute(cmd)
+        return True
     except Exception as e:
-        debugMessage('SetDefaultPrim() - Error: %s' % str(e))
-        pass
-    return ''
+        # Note: we do want to tell the user why the set or clear failed.
+        OpenMaya.MGlobal.displayError((str(e)))
+        return False
     
 def GetRootLayerName(proxyShape):
     try:

--- a/plugin/adsk/scripts/AEmayaUsdProxyShapeBaseTemplate.mel
+++ b/plugin/adsk/scripts/AEmayaUsdProxyShapeBaseTemplate.mel
@@ -20,10 +20,17 @@ global proc string AEmayaUsdProxyShapeInfoChanged(string $input)
 
     // Call python helpers to get the info we want to display.
     string $rootLayer   = `python("import AETemplateHelpers; AETemplateHelpers.GetRootLayerName('" + $fullNodeName + "')")`;
-    string $defaultPrim = `python("import AETemplateHelpers; AETemplateHelpers.GetDefaultPrimName('" + $fullNodeName + "')")`;
-    string $allRootPrims[] = `python("import AETemplateHelpers; AETemplateHelpers.GetAllRootPrimNamesNaturalOrder('" + $fullNodeName + "')")`;
 
     textFieldGrp -edit -text $rootLayer mayaUsdProxyShapeRootLayer;
+    mayaUsd_DefaultPrimInit($fullNodeName);
+
+    return $fullNodeName;
+}
+
+global proc mayaUsd_DefaultPrimInit(string $fullNodeName)
+{
+    string $defaultPrim = `python("import AETemplateHelpers; AETemplateHelpers.GetDefaultPrimName('" + $fullNodeName + "')")`;
+    string $allRootPrims[] = `python("import AETemplateHelpers; AETemplateHelpers.GetAllRootPrimNamesNaturalOrder('" + $fullNodeName + "')")`;
 
     optionMenuGrp -edit -deleteAllItems -changeCommand ("mayaUsd_DefaultPrimChanged(\"" + $fullNodeName + "\"\)") mayaUsdProxyShapeDefaultPrim;
     string $menuName = `optionMenuGrp -q -fullPathName mayaUsdProxyShapeDefaultPrim`;
@@ -43,14 +50,17 @@ global proc string AEmayaUsdProxyShapeInfoChanged(string $input)
         $index = 1;
     }
     optionMenuGrp -e -select $index mayaUsdProxyShapeDefaultPrim;
-
-    return $fullNodeName;
 }
 
 global proc mayaUsd_DefaultPrimChanged(string $fullNodeName)
 {
     string $primName = `optionMenuGrp -q -value mayaUsdProxyShapeDefaultPrim`;
-    python("import AETemplateHelpers; AETemplateHelpers.SetDefaultPrim('" + $fullNodeName + "', primName ='" + $primName + "')");
+    int $result = `python("import AETemplateHelpers; AETemplateHelpers.SetDefaultPrim('" + $fullNodeName + "', primName ='" + $primName + "')")`;
+    // On failure, we re-initialize the UI since the command failed
+    // and thus we need to restore the previous UI state.
+    if ($result == 0) {
+        mayaUsd_DefaultPrimInit($fullNodeName);
+    }
 }
 
 global proc AEmayaUsdProxyShapeInfoReplace(string $input)

--- a/test/lib/ufe/CMakeLists.txt
+++ b/test/lib/ufe/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TEST_SCRIPT_FILES
     testChildFilter.py
     testComboCmd.py
     testContextOps.py
+    testDefaultPrimCmds.py
     testDuplicateCmd.py
     testEditRouting.py
     testGroupCmd.py

--- a/test/lib/ufe/testDefaultPrimCmds.py
+++ b/test/lib/ufe/testDefaultPrimCmds.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright 2020 Autodesk
+# Copyright 2023 Autodesk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,20 +19,14 @@
 import fixturesUtils
 import mayaUtils
 import testUtils
-from testUtils import assertVectorAlmostEqual, assertVectorNotAlmostEqual
-import usdUtils
-from usdUtils import filterUsdStr
 
-import mayaUsd.ufe
-
-from pxr import UsdGeom, Vt, Gf, Sdf, Usd
+from pxr import Sdf
 
 from maya import cmds
 from maya import standalone
 
 import ufe
 
-import os
 import unittest
 
 class DefaultPrimCmdsTestCase(unittest.TestCase):

--- a/test/lib/ufe/testDefaultPrimCmds.py
+++ b/test/lib/ufe/testDefaultPrimCmds.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2020 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import fixturesUtils
+import mayaUtils
+import testUtils
+from testUtils import assertVectorAlmostEqual, assertVectorNotAlmostEqual
+import usdUtils
+from usdUtils import filterUsdStr
+
+import mayaUsd.ufe
+
+from pxr import UsdGeom, Vt, Gf, Sdf, Usd
+
+from maya import cmds
+from maya import standalone
+
+import ufe
+
+import os
+import unittest
+
+class DefaultPrimCmdsTestCase(unittest.TestCase):
+
+    pluginsLoaded = False
+
+    @classmethod
+    def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
+        if not cls.pluginsLoaded:
+            cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        cmds.file(new=True, force=True)
+        standalone.uninitialize()
+
+    def setUp(self):
+        # Load plugins
+        self.assertTrue(self.pluginsLoaded)
+
+    def testClearDefaultPrim(self):
+        '''
+        Verify that we can clear the default prim.
+        '''
+        cmds.file(new=True, force=True)
+        testFile = testUtils.getTestScene('defaultPrimInSub', 'root.usda')
+        shapeNode, stage = mayaUtils.createProxyFromFile(testFile)
+
+        capsulePathStr = '|stage|stageShape,/Capsule1'
+        capsulePath = ufe.PathString.path(capsulePathStr)
+        capsuleItem = ufe.Hierarchy.createItem(capsulePath)
+        self.assertIsNotNone(capsuleItem)
+        
+        contextOps = ufe.ContextOps.contextOps(capsuleItem)
+        contextOps.doOp(['Clear Default Prim'])
+
+        self.assertFalse(stage.GetDefaultPrim())
+
+    def testSetDefaultPrimRestriction(self):
+        '''
+        Verify that we can set the default prim.
+        '''
+        cmds.file(new=True, force=True)
+        testFile = testUtils.getTestScene('defaultPrimInSub', 'root.usda')
+        shapeNode, stage = mayaUtils.createProxyFromFile(testFile)
+
+        x1 = stage.DefinePrim('/Xform1', 'Xform')
+        self.assertIsNotNone(x1)
+        x1PathStr = '|stage|stageShape,/Xform1'
+        x1Path = ufe.PathString.path(x1PathStr)
+        x1Item = ufe.Hierarchy.createItem(x1Path)
+        self.assertIsNotNone(x1Item)
+
+        x1Prim = stage.GetPrimAtPath('/Xform1')
+        self.assertIsNotNone(x1Prim)
+        self.assertIsTrue(x1Prim)
+        
+        contextOps = ufe.ContextOps.contextOps(x1Item)
+        contextOps.doOp(['Set as Default Prim'])
+
+        self.assertEqual(stage.GetDefaultPrim(), x1Prim)
+
+    def testClearDefaultPrimRestriction(self):
+        '''
+        Verify that we cannot clear the default prim
+        when not targeting the root layer.
+        '''
+        cmds.file(new=True, force=True)
+        testFile = testUtils.getTestScene('defaultPrimInSub', 'root.usda')
+        shapeNode, stage = mayaUtils.createProxyFromFile(testFile)
+
+        layer = Sdf.Layer.FindRelativeToLayer(stage.GetRootLayer(), stage.GetRootLayer().subLayerPaths[0])
+        self.assertIsNotNone(layer)
+        stage.SetEditTarget(layer)
+        self.assertEqual(stage.GetEditTarget().GetLayer(), layer)
+
+        capsulePathStr = '|stage|stageShape,/Capsule1'
+        capsulePath = ufe.PathString.path(capsulePathStr)
+        capsuleItem = ufe.Hierarchy.createItem(capsulePath)
+        self.assertIsNotNone(capsuleItem)
+        
+        contextOps = ufe.ContextOps.contextOps(capsuleItem)
+        with self.assertRaises(RuntimeError):
+            contextOps.doOp(['Clear Default Prim'])
+
+    def testSetDefaultPrimRestriction(self):
+        '''
+        Verify that we cannot set the default prim
+        when not targeting the root layer.
+        '''
+        cmds.file(new=True, force=True)
+        testFile = testUtils.getTestScene('defaultPrimInSub', 'root.usda')
+        shapeNode, stage = mayaUtils.createProxyFromFile(testFile)
+
+        layer = Sdf.Layer.FindRelativeToLayer(stage.GetRootLayer(), stage.GetRootLayer().subLayerPaths[0])
+        self.assertIsNotNone(layer)
+        stage.SetEditTarget(layer)
+        self.assertEqual(stage.GetEditTarget().GetLayer(), layer)
+
+        x1 = stage.DefinePrim('/Xform1', 'Xform')
+        self.assertIsNotNone(x1)
+        x1PathStr = '|stage|stageShape,/Xform1'
+        x1Path = ufe.PathString.path(x1PathStr)
+        x1Item = ufe.Hierarchy.createItem(x1Path)
+        self.assertIsNotNone(x1Item)
+        
+        contextOps = ufe.ContextOps.contextOps(x1Item)
+        with self.assertRaises(RuntimeError):
+            contextOps.doOp(['Set as Default Prim'])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testGroupCmd.py
+++ b/test/lib/ufe/testGroupCmd.py
@@ -373,6 +373,30 @@ class GroupCmdTestCase(unittest.TestCase):
             stage.GetPrimAtPath("/Ball_set/Props/Ball_6"),
             stage.GetPrimAtPath("/Sphere1")])
 
+    def testGroupRestrictionDefaultPrim(self):
+        '''
+        Verify that a prim that is the default prim prevent
+        grouping that prim when not targeting the root layer.
+        '''
+        cmds.file(new=True, force=True)
+        testFile = testUtils.getTestScene('defaultPrimInSub', 'root.usda')
+        shapeNode, stage = mayaUtils.createProxyFromFile(testFile)
+
+        capsulePathStr = '|stage|stageShape,/Capsule1'
+
+        layer = Sdf.Layer.FindRelativeToLayer(stage.GetRootLayer(), stage.GetRootLayer().subLayerPaths[0])
+        self.assertIsNotNone(layer)
+        stage.SetEditTarget(layer)
+        self.assertEqual(stage.GetEditTarget().GetLayer(), layer)
+
+        capsuleItem = ufe.Hierarchy.createItem(ufe.PathString.path(capsulePathStr))
+        ufeSelection = ufe.GlobalSelection.get()
+        ufeSelection.clear()
+        ufeSelection.append(capsuleItem)
+
+        with self.assertRaises(RuntimeError):
+            cmds.group(name="newGroup")
+
     @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 3, 'testGroupAbsolute is only available in UFE v3 or greater.')
     def testGroupAbsolute(self):
         '''Verify -absolute flag.'''

--- a/test/lib/ufe/testParentCmd.py
+++ b/test/lib/ufe/testParentCmd.py
@@ -1057,6 +1057,29 @@ class ParentCmdTestCase(unittest.TestCase):
             cmds.parent("|Tree_usd|Tree_usdShape,/TreeBase/trunk",
                         "|Tree_usd|Tree_usdShape,/TreeBase/leavesXform/leaves")
 
+    def testParentRestrictionDefaultPrim(self):
+        '''
+        Verify that a prim that is the default prim prevent
+        parenting that prim when not targeting the root layer.
+        '''
+        cmds.file(new=True, force=True)
+        testFile = testUtils.getTestScene('defaultPrimInSub', 'root.usda')
+        shapeNode, stage = mayaUtils.createProxyFromFile(testFile)
+
+        capsulePathStr = '|stage|stageShape,/Capsule1'
+
+        layer = Sdf.Layer.FindRelativeToLayer(stage.GetRootLayer(), stage.GetRootLayer().subLayerPaths[0])
+        self.assertIsNotNone(layer)
+        stage.SetEditTarget(layer)
+        self.assertEqual(stage.GetEditTarget().GetLayer(), layer)
+
+        x1 = stage.DefinePrim('/Xform1', 'Xform')
+        self.assertIsNotNone(x1)
+        x1PathStr = '|stage|stageShape,/Xform1'
+        
+        with self.assertRaises(RuntimeError):
+            cmds.parent(capsulePathStr, x1PathStr)
+
     @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'Requires Maya fixes only available in Maya 2023 or greater.')
     def testParentShader(self):
         '''Shaders can only have NodeGraphs and Materials as parent.'''

--- a/test/lib/ufe/testRename.py
+++ b/test/lib/ufe/testRename.py
@@ -537,6 +537,28 @@ class RenameTestCase(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             cmds.rename("geo_renamed")
 
+    def testRenameRestrictionDefaultPrim(self):
+        '''
+        Verify that a prim that is the default prim prevent
+        renaming that prim when not targeting the root layer.
+        '''
+        cmds.file(new=True, force=True)
+        testFile = testUtils.getTestScene('defaultPrimInSub', 'root.usda')
+        shapeNode, stage = mayaUtils.createProxyFromFile(testFile)
+
+        capsulePath = ufe.PathString.path('|stage|stageShape,/Capsule1')
+        capsuleItem = ufe.Hierarchy.createItem(capsulePath)
+        self.assertIsNotNone(capsuleItem)
+        ufe.GlobalSelection.get().append(capsuleItem)
+
+        layer = Sdf.Layer.FindRelativeToLayer(stage.GetRootLayer(), stage.GetRootLayer().subLayerPaths[0])
+        self.assertIsNotNone(layer)
+        stage.SetEditTarget(layer)
+        self.assertEqual(stage.GetEditTarget().GetLayer(), layer)
+        
+        with self.assertRaises(RuntimeError):
+            cmds.rename("banana")
+
     def testRenameUniqueName(self):
         # open tree.ma scene in testSamples
         mayaUtils.openTreeScene()

--- a/test/testSamples/defaultPrimInSub/root.usda
+++ b/test/testSamples/defaultPrimInSub/root.usda
@@ -1,0 +1,8 @@
+#usda 1.0
+(
+    defaultPrim = "Capsule1"
+    subLayers = [
+        @sub.usda@
+    ]
+)
+

--- a/test/testSamples/defaultPrimInSub/sub.usda
+++ b/test/testSamples/defaultPrimInSub/sub.usda
@@ -1,0 +1,6 @@
+#usda 1.0
+
+def Capsule "Capsule1"
+{
+}
+


### PR DESCRIPTION
- Add a applyRootLayerMetadataRestriction helper function to enforce not modifying the root layer metadata when not targeting the root layer.
- The only restriction applied is about the default prim.
- Call it from within the applyCommandRestriction helper function.
- Call it from within the default prim commands.
- Add unit tests for the rename, parent and group default prim restrictions.
- Add tests for the default prim commands.
