### PR TITLE
EMSUSD-499 - Dirty layers don't get saved in Maya files

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -1586,7 +1586,13 @@ bool MayaUsdProxyShapeBase::isStageIncoming() const
         CHECK_MSTATUS_AND_RETURN(localStatus, false);
         const auto cacheId = UsdStageCache::Id::FromLongInt(cacheIdNum);
         const auto stageCached = cacheId.IsValid() && UsdUtilsStageCache::Get().Contains(cacheId);
-        if (stageCached) {
+
+        // Check what is the cache connected to
+        MStringArray result;
+        MGlobal::executeCommand(("listConnections -shapes on " + this->name()), result);
+
+        // The stage is only incoming if the cache is connected to a shape
+        if (stageCached && result.length()) {
             isIncomingStage = true;
         }
     }


### PR DESCRIPTION
For details and discussions please see this github issue: https://github.com/Autodesk/maya-usd/issues/3243

The idea is to check if the cache is actually connected (for example bifrost graph), if not this is not actually an incoming stage