### PR TITLE
EMSUSD-499 - Dirty layers don't get saved in Maya files

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -1589,7 +1589,7 @@ bool MayaUsdProxyShapeBase::isStageIncoming() const
 
         // Check what is the cache connected to
         MStringArray result;
-        MGlobal::executeCommand(("listConnections -shapes on " + this->name()), result);
+        MGlobal::executeCommand(("listConnections -t shape -shapes on " + this->name()), result);
 
         // The stage is only incoming if the cache is connected to a shape
         if (stageCached && result.length()) {


### PR DESCRIPTION
A fix for previous PR: https://github.com/Autodesk/maya-usd/pull/3402
Github issue: https://github.com/Autodesk/maya-usd/issues/3243

Adding `-t shape` to the command will exclude the "time" nodes but leave only Bifrost nodes.
Deleting the `else` part will not work because for Bifrost to save properly we will need to check for cache