### PR TITLE
EMSUSD-254 disable the default prim auto-filling.

### DIFF
--- a/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
@@ -73,9 +73,11 @@ def mayaUsdLibRegisterStrings():
     register('kTextVariant', 'Variant')
     register('kTextVariantToolTip','If selected, your Maya reference will be defined in a variant. This will enable your prim to\nhave 2 variants you can switch between in the Outliner; the Maya reference and its USD cache.')
 
-    register('kAddRefOrPayloadPrimPathToolTip', 'Specifying a prim path will make an explicit reference to a prim.\n' +
-                                        'If there is no default prim in your chosen reference, this field auto populates with the top level prim for you to reference in.\n' +
-                                        'If the field is left blank, no prim will be referenced.')
+    register('kAddRefOrPayloadPrimPathToolTip',
+        'Leave this field blank to use the default prim as your prim path (only viable if your file has a default prim).\n' +
+        'Specifying a prim path will make an explicit reference to a prim.\n' +
+        'If there is no default prim and no prim path is specified, no prim will be referenced.')
+    
     register('kAddRefOrPayloadPrimPathLabel', 'Prim Path')
     register('kAddRefOrPayloadPrimPathPlaceHolder', ' (Default Prim)')
     register('kAddRefOrPayloadPrimPathHelpLabel', 'Help on Select a Prim for Reference')

--- a/lib/mayaUsd/resources/scripts/mayaUsdMayaReferenceUtils.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdMayaReferenceUtils.py
@@ -173,8 +173,8 @@ def _resetReferencedPrim(*args):
 #             defPrim = layer.defaultPrim
 #     except Exception as ex:
 #         print(str(ex))
-    
-    return defPrim, rootPrim
+#
+#     return defPrim, rootPrim
 
 def _updateReferencedPrimBasedOnFile():
     """Update all UI related to the referenced prim based on the currently selected file."""
@@ -200,7 +200,7 @@ def _updateReferencedPrimBasedOnFile():
     # elif rootPrim:
     #     cmds.textFieldGrp('mayaUsdAddRefOrPayloadPrimPath', edit=True, text=rootPrim, placeholderText='')
     # else:
-    #     cmds.textFieldGrp('mayaUsdAddRefOrPayloadPrimPath', edit=True, text='', placeholderText='')
+    cmds.textFieldGrp('mayaUsdAddRefOrPayloadPrimPath', edit=True, text='', placeholderText='')
 
 def createUsdRefOrPayloadUI(uiForLoad=False):
     _setCurrentFilename(None)

--- a/lib/mayaUsd/resources/scripts/mayaUsdMayaReferenceUtils.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdMayaReferenceUtils.py
@@ -153,23 +153,26 @@ def _resetReferencedPrim(*args):
     """Reset the referenced prim UI"""
     _updateReferencedPrimBasedOnFile()
 
-def _getDefaultAndRootPrims(filename):
-    """Retrieve the default and first root prims of a USD file."""
-    defPrim, rootPrim = None, None
-    try:
-        layer = Sdf.Layer.FindOrOpen(filename)
-        if layer:
-            # Note: the root prims at the USD layer level are SdfPrimSpec,
-            #       so they are not SdfPath themselves nor prim. That is
-            #       why their path is retrieved via their path property.
-            #
-            #       The default prim is a pure token though, because it is
-            #       a metadata on the layer, so it can be used as-is.
-            rootPrims = layer.rootPrims
-            rootPrim = rootPrims[0].path if len(rootPrims) > 0 else None
-            defPrim = layer.defaultPrim
-    except Exception as ex:
-        print(str(ex))
+# Note: we are disabling the default prim filling due to the long delay when the USD
+#       file is very large.
+#
+# def _getDefaultAndRootPrims(filename):
+#     """Retrieve the default and first root prims of a USD file."""
+#     defPrim, rootPrim = None, None
+#     try:
+#         layer = Sdf.Layer.FindOrOpen(filename)
+#         if layer:
+#             # Note: the root prims at the USD layer level are SdfPrimSpec,
+#             #       so they are not SdfPath themselves nor prim. That is
+#             #       why their path is retrieved via their path property.
+#             #
+#             #       The default prim is a pure token though, because it is
+#             #       a metadata on the layer, so it can be used as-is.
+#             rootPrims = layer.rootPrims
+#             rootPrim = rootPrims[0].path if len(rootPrims) > 0 else None
+#             defPrim = layer.defaultPrim
+#     except Exception as ex:
+#         print(str(ex))
     
     return defPrim, rootPrim
 
@@ -187,14 +190,17 @@ def _updateReferencedPrimBasedOnFile():
     cmds.button('mayaUsdAddRefOrPayloadFilePathBrowser', edit=True, enable=True)
     cmds.symbolButton('mayaUsdAddRefOrPayloadFilePathReset', edit=True, enable=True)
 
-    defaultPrim, rootPrim = _getDefaultAndRootPrims(filename)
-    if defaultPrim:
-        placeHolder = defaultPrim + getMayaUsdLibString('kAddRefOrPayloadPrimPathPlaceHolder')
-        cmds.textFieldGrp('mayaUsdAddRefOrPayloadPrimPath', edit=True, text='', placeholderText=placeHolder)
-    elif rootPrim:
-        cmds.textFieldGrp('mayaUsdAddRefOrPayloadPrimPath', edit=True, text=rootPrim, placeholderText='')
-    else:
-        cmds.textFieldGrp('mayaUsdAddRefOrPayloadPrimPath', edit=True, text='', placeholderText='')
+    # Note: we are disabling the default prim filling due to the long delay when the USD
+    #       file is very large.
+    #
+    # defaultPrim, rootPrim = _getDefaultAndRootPrims(filename)
+    # if defaultPrim:
+    #     placeHolder = defaultPrim + getMayaUsdLibString('kAddRefOrPayloadPrimPathPlaceHolder')
+    #     cmds.textFieldGrp('mayaUsdAddRefOrPayloadPrimPath', edit=True, text='', placeholderText=placeHolder)
+    # elif rootPrim:
+    #     cmds.textFieldGrp('mayaUsdAddRefOrPayloadPrimPath', edit=True, text=rootPrim, placeholderText='')
+    # else:
+    #     cmds.textFieldGrp('mayaUsdAddRefOrPayloadPrimPath', edit=True, text='', placeholderText='')
 
 def createUsdRefOrPayloadUI(uiForLoad=False):
     _setCurrentFilename(None)


### PR DESCRIPTION
- Disable to code that auto-fills the prim path when creating a ref or payload.
- We are keeping the code because we think we likely will put it back in the next release under an advance option.
- Update the tooltip to be clearer and remove text about auto-filling.