### PR TITLE
EMSUSD-490 Fixes Redo Visibility Visual Update in Outliner

### DIFF
--- a/lib/usdUfe/ufe/StagesSubject.cpp
+++ b/lib/usdUfe/ufe/StagesSubject.cpp
@@ -157,13 +157,19 @@ void sendAttributeChanged(
                 notifyWithoutExceptions<Ufe::Camera>(ufePath);
             }
         } else {
+            // Special case when Redo-ing visibility change, the notice.GetChangedInfoOnlyPaths()
+            // does not contain the change, hence handling visibility notification in re-sync path.
+            if (changedToken == UsdGeomTokens->visibility) {
+                Ufe::VisibilityChanged vis(ufePath);
+                notifyWithoutExceptions<Ufe::Object3d>(vis);
+            }
             notifyWithoutExceptions<Ufe::Attributes>(
                 Ufe::AttributeAdded(ufePath, changedToken.GetString()));
         }
     } break;
     case AttributeChangeType::kRemoved: {
         // Special case when Undoing a visibility change, the notice.GetChangedInfoOnlyPaths()
-        // does not contain the change, hence handling visibility notification in re-synch path.
+        // does not contain the change, hence handling visibility notification in re-sync path.
         if (changedToken == UsdGeomTokens->visibility) {
             Ufe::VisibilityChanged vis(ufePath);
             notifyWithoutExceptions<Ufe::Object3d>(vis);

--- a/test/lib/ufe/testObject3d.py
+++ b/test/lib/ufe/testObject3d.py
@@ -306,15 +306,24 @@ class Object3dTestCase(unittest.TestCase):
         object3d.setVisibility(False)
         self.assertFalse(object3d.visibility())
 
-        # We should have got 'one' notification.
-        self.assertEqual(visObs.notifications(), 1)
+        # We should have got 'two' notifications. One for Add and one for ValueChange
+        # This occurs on the very first time the visibility token attribute is added.
+        self.assertEqual(visObs.notifications(), 2)
 
         # Make it visible.
         object3d.setVisibility(True)
         self.assertTrue(object3d.visibility())
 
-        # We should have got one more notification.
-        self.assertEqual(visObs.notifications(), 2)
+        # We should have got one more notification. Only for ValueChange
+        self.assertEqual(visObs.notifications(), 3)
+
+        # Make it visible.
+        object3d.setVisibility(False)
+        self.assertFalse(object3d.visibility())
+
+        # We should have got one more notification. Only for ValueChange
+        self.assertEqual(visObs.notifications(), 4)
+
 
         # Remove the observer.
         ufe.Object3d.removeObserver(visObs)

--- a/test/lib/ufe/testObject3d.py
+++ b/test/lib/ufe/testObject3d.py
@@ -306,24 +306,33 @@ class Object3dTestCase(unittest.TestCase):
         object3d.setVisibility(False)
         self.assertFalse(object3d.visibility())
 
-        # We should have got 'two' notifications. One for Add and one for ValueChange
-        # This occurs on the very first time the visibility token attribute is added.
-        self.assertEqual(visObs.notifications(), 2)
-
+        if (ufeUtils.ufeFeatureSetVersion() >= 4):
+            # We should have got 'two' notifications. One for Add and one for ValueChange
+            # This occurs on the very first time the visibility token attribute is added.
+            self.assertEqual(visObs.notifications(), 2)
+        else:
+            # We should have got one notification. Only for ValueChange
+            self.assertEqual(visObs.notifications(), 1)
+            
         # Make it visible.
         object3d.setVisibility(True)
         self.assertTrue(object3d.visibility())
 
         # We should have got one more notification. Only for ValueChange
-        self.assertEqual(visObs.notifications(), 3)
-
+        if (ufeUtils.ufeFeatureSetVersion() >= 4):
+            self.assertEqual(visObs.notifications(), 3)
+        else:
+            self.assertEqual(visObs.notifications(), 2)
+            
         # Make it visible.
         object3d.setVisibility(False)
         self.assertFalse(object3d.visibility())
 
         # We should have got one more notification. Only for ValueChange
-        self.assertEqual(visObs.notifications(), 4)
-
+        if (ufeUtils.ufeFeatureSetVersion() >= 4):
+            self.assertEqual(visObs.notifications(), 4)
+        else:
+            self.assertEqual(visObs.notifications(), 3)
 
         # Remove the observer.
         ufe.Object3d.removeObserver(visObs)


### PR DESCRIPTION
Previously we fixed the Undo command that wasn't triggering a visibility update on the Outliner.
This change is about fixing the Re-do which is a different attribute event.