### PR TITLE
EMSUSD-749 fix how stages are updated when saved

### DIFF
--- a/lib/mayaUsd/commands/abstractLayerEditorWindow.h
+++ b/lib/mayaUsd/commands/abstractLayerEditorWindow.h
@@ -96,6 +96,7 @@ public:
     virtual void printLayer() = 0;
     virtual void clearLayer() = 0;
     virtual void selectPrimsWithSpec() = 0;
+    virtual void updateLayerModel() = 0;
 
     virtual void selectProxyShape(const char* shapePath) = 0;
 };

--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -15,6 +15,7 @@
 //
 #include "layerManager.h"
 
+#include <mayaUsd/commands/abstractLayerEditorWindow.h>
 #include <mayaUsd/listeners/notice.h>
 #include <mayaUsd/listeners/proxyShapeNotice.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
@@ -254,6 +255,7 @@ private:
     void clearProxies();
     bool hasDirtyLayer() const;
     void refreshProxiesToSave();
+    void updateLayerManagers();
 
     std::map<std::string, SdfLayerRefPtr> _idToLayer;
     TfNotice::Key                         _onStageSetKey;
@@ -437,6 +439,21 @@ void LayerDatabase::clearProxies()
 {
     _proxiesToSave.clear();
     _internalProxiesToSave.clear();
+}
+
+void LayerDatabase::updateLayerManagers()
+{
+    auto creator = MayaUsd::AbstractLayerEditorCreator::instance();
+    if (!creator)
+        return;
+
+    for (const std::string& panelName : creator->getAllPanelNames()) {
+        AbstractLayerEditorWindow* window = creator->getWindow(panelName.c_str());
+        if (!window)
+            continue;
+
+        window->updateLayerModel();
+    }
 }
 
 bool LayerDatabase::hasDirtyLayer() const
@@ -646,6 +663,7 @@ bool LayerDatabase::saveUsd(bool isExport)
     }
 
     clearProxies();
+    updateLayerManagers();
     return (MayaUsd::kCompleted == result);
 }
 

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -821,7 +821,7 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
     bool isIncomingStage = false;
 
     // Note: we explicitly always load no payload initially and will load them
-    //       later on if requested. The reason is that there are otehr code elsewhere
+    //       later on if requested. The reason is that there are other code elsewhere
     //       that updates the stages. Those functions must find the same existing stages.
     //       Somewhat unfortunately, the OpenUSD API to open a stage only finds an existing
     //       stage if *all* parameters passed to open the stage match, including the initial

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -820,19 +820,25 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
 
     bool isIncomingStage = false;
 
-    // Compute the load set for the stage.
-    MDataHandle loadPayloadsHandle = dataBlock.inputValue(loadPayloadsAttr, &retValue);
-    CHECK_MSTATUS_AND_RETURN_IT(retValue);
-
-    UsdStage::InitialLoadSet loadSet = loadPayloadsHandle.asBool()
-        ? UsdStage::InitialLoadSet::LoadAll
-        : UsdStage::InitialLoadSet::LoadNone;
-
-    // If there is a dynamic attribute containing the exact load rules
-    // for payload, start by loading nothing. The correct payload will
-    // be loaded by the load rules.
-    if (hasLoadRulesAttribute(*this))
-        loadSet = UsdStage::InitialLoadSet::LoadNone;
+    // Note: we explicitly always load no payload initially and will load them
+    //       later on if requested. The reason is that there are otehr code elsewhere
+    //       that updates the stages. Those functions must find the same existing stages.
+    //       Somewhat unfortunately, the OpenUSD API to open a stage only finds an existing
+    //       stage if *all* parameters passed to open the stage match, including the initial
+    //       load set. In order to be consistent everywhere, we must always pass in the same
+    //       initial load set. Given that not loading payloads is the "lightest" version,
+    //       that is what we request.
+    //
+    //       Furthermore, for any statge that had its payload loaded or unloaded by the user
+    //       we keep the detailed load and unload state of all prims, so we would use the
+    //       load-none mode anyway and apply the detailed rules afterward, and this is
+    //       probably the common case for stages that actually contain payloads.
+    //
+    //       TODO: in the future, we need to provide a stage (and layer) internal manager
+    //             that would stand between MayaUSD and OpenUSD and manage stages and layers
+    //             and deal with consistent Open and other considerations, like updating stages
+    //             and layers when anonymous layers are saved to disk.
+    const UsdStage::InitialLoadSet loadSet = UsdStage::InitialLoadSet::LoadNone;
 
     // If inData has an incoming connection, then use it. Otherwise generate stage from the filepath
     if (!inDataHandle.data().isNull()) {
@@ -966,16 +972,9 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                     //       then UsdStage::Open will create the in-memory session layer for us,
                     //       just as we want.
                     if (sessionLayer) {
-                        sharedUsdStage = UsdStage::Open(
-                            rootLayer,
-                            sessionLayer,
-                            ArGetResolver().CreateDefaultContextForAsset(fileString),
-                            loadSet);
+                        sharedUsdStage = UsdStage::Open(rootLayer, sessionLayer, loadSet);
                     } else {
-                        sharedUsdStage = UsdStage::Open(
-                            rootLayer,
-                            ArGetResolver().CreateDefaultContextForAsset(fileString),
-                            loadSet);
+                        sharedUsdStage = UsdStage::Open(rootLayer, loadSet);
                     }
 
                     sharedUsdStage->SetEditTarget(
@@ -1072,8 +1071,24 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
     }
 
     if (finalUsdStage) {
+        // Compute the load set for the stage.
+        MDataHandle loadPayloadsHandle = dataBlock.inputValue(loadPayloadsAttr, &retValue);
+        CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+        // Apply the payload rules based on either the saved payload rules
+        // dynamic attribute containing the exact load rules for payload,
+        // or the load-payload attribute.
+        if (hasLoadRulesAttribute(*this)) {
+            copyLoadRulesFromAttribute(*this, *finalUsdStage);
+        } else {
+            if (loadPayloadsHandle.asBool()) {
+                finalUsdStage->Load(SdfPath("/"), UsdLoadPolicy::UsdLoadWithDescendants);
+            } else {
+                finalUsdStage->Unload(SdfPath("/"));
+            }
+        }
+
         primPath = finalUsdStage->GetPseudoRoot().GetPath();
-        copyLoadRulesFromAttribute(*this, *finalUsdStage);
         copyLayerMutingFromAttribute(*this, *finalUsdStage);
         if (!_targetLayer)
             _targetLayer = getTargetLayerFromAttribute(*this, *finalUsdStage);

--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -137,6 +137,9 @@ void updateAllCachedStageWithLayer(SdfLayerRefPtr originalLayer, const std::stri
         std::vector<UsdStageRefPtr> stages = cache.FindAllMatching(originalLayer);
         for (const auto& stage : stages) {
             auto sessionLayer = stage->GetSessionLayer();
+            // Note: See comments in lib\mayaUsd\nodes\proxyShapeBase.cpp, line 823
+            //       about requirements about matching UsdStage::Open() arguments to
+            //       find a stage.
             auto newStage = UsdStage::UsdStage::Open(
                 newLayer, sessionLayer, UsdStage::InitialLoadSet::LoadNone);
             newStage->SetLoadRules(stage->GetLoadRules());

--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -137,9 +137,9 @@ void updateAllCachedStageWithLayer(SdfLayerRefPtr originalLayer, const std::stri
         std::vector<UsdStageRefPtr> stages = cache.FindAllMatching(originalLayer);
         for (const auto& stage : stages) {
             auto sessionLayer = stage->GetSessionLayer();
-            // Note: See comments in lib\mayaUsd\nodes\proxyShapeBase.cpp, line 823
-            //       about requirements about matching UsdStage::Open() arguments to
-            //       find a stage.
+            // Note: See comments in lib\mayaUsd\nodes\proxyShapeBase.cpp, in the
+            //       function computeInStageDataCached() about requirements about
+            //       matching UsdStage::Open() arguments to find a stage.
             auto newStage = UsdStage::UsdStage::Open(
                 newLayer, sessionLayer, UsdStage::InitialLoadSet::LoadNone);
             newStage->SetLoadRules(stage->GetLoadRules());

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
@@ -192,6 +192,8 @@ void MayaLayerEditorWindow::addAnonymousSublayer()
     treeView()->callMethodOnSelection(name, &LayerTreeItem::addAnonymousSublayer);
 }
 
+void MayaLayerEditorWindow::updateLayerModel() { _sessionState.refreshCurrentStageEntry(); }
+
 void MayaLayerEditorWindow::addParentLayer()
 {
     QString name = "Add Parent Layer";

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.h
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.h
@@ -70,6 +70,7 @@ public:
     void printLayer() override;
     void clearLayer() override;
     void selectPrimsWithSpec() override;
+    void updateLayerModel() override;
 
     void selectProxyShape(const char* shapePath) override;
 

--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -184,11 +184,15 @@ void MayaSessionState::unregisterNotifications()
     TfNotice::Revoke(_stageResetNoticeKey);
 }
 
-void MayaSessionState::mayaUsdStageReset(const MayaUsdProxyStageSetNotice& notice)
+void MayaSessionState::refreshCurrentStageEntry()
 {
-    auto       shapePath = notice.GetShapePath();
+    refreshStageEntry(_currentStageEntry._proxyShapePath);
+}
+
+void MayaSessionState::refreshStageEntry(std::string const& proxyShapePath)
+{
     StageEntry entry;
-    if (getStageEntry(&entry, shapePath.c_str())) {
+    if (getStageEntry(&entry, proxyShapePath.c_str())) {
         if (entry._proxyShapePath == _currentStageEntry._proxyShapePath) {
             QTimer::singleShot(0, this, [this, entry]() {
                 mayaUsdStageResetCBOnIdle(entry);
@@ -198,6 +202,11 @@ void MayaSessionState::mayaUsdStageReset(const MayaUsdProxyStageSetNotice& notic
             QTimer::singleShot(0, this, [this, entry]() { mayaUsdStageResetCBOnIdle(entry); });
         }
     }
+}
+
+void MayaSessionState::mayaUsdStageReset(const MayaUsdProxyStageSetNotice& notice)
+{
+    refreshStageEntry(notice.GetShapePath());
 }
 
 void MayaSessionState::mayaUsdStageResetCBOnIdle(StageEntry const& entry)

--- a/lib/usd/ui/layerEditor/mayaSessionState.h
+++ b/lib/usd/ui/layerEditor/mayaSessionState.h
@@ -72,6 +72,9 @@ public:
     // in this case, the stage needs to be re-created on the new file
     void rootLayerPathChanged(std::string const& in_path) override;
 
+    void refreshCurrentStageEntry();
+    void refreshStageEntry(std::string const& proxyShapePath);
+
     std::string proxyShapePath() { return _currentStageEntry._proxyShapePath; }
 
 Q_SIGNALS:

--- a/test/lib/mayaUsd/nodes/testProxyShapeBase.py
+++ b/test/lib/mayaUsd/nodes/testProxyShapeBase.py
@@ -630,9 +630,11 @@ class testProxyShapeBase(unittest.TestCase):
         proxyShapePath = proxyShapes[0]
         stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
 
-        # check that the stage has no load rules
+        # check that the stage has a single load rule to laod everything.
         loadRules = stage.GetLoadRules()
-        self.assertEqual(len(loadRules.GetRules()), 0)
+        self.assertEqual(len(loadRules.GetRules()), 1)
+        self.assertEqual(loadRules.GetRules()[0][0], "/")
+        self.assertEqual(loadRules.GetRules()[0][1], loadRules.AllRule)
 
         # add a new rule to unload the room
         cmd = contextOps.doOpCmd(['Unload'])
@@ -642,9 +644,11 @@ class testProxyShapeBase(unittest.TestCase):
         # check that the expected load rules are on the stage.
         def check_load_rules(stage):
             loadRules = stage.GetLoadRules()
-            self.assertEqual(len(loadRules.GetRules()), 1)
-            self.assertEqual(loadRules.GetRules()[0][0], "/Room_set")
-            self.assertEqual(loadRules.GetRules()[0][1], loadRules.NoneRule)
+            self.assertEqual(len(loadRules.GetRules()), 2)
+            self.assertEqual(loadRules.GetRules()[0][0], "/")
+            self.assertEqual(loadRules.GetRules()[0][1], loadRules.AllRule)
+            self.assertEqual(loadRules.GetRules()[1][0], "/Room_set")
+            self.assertEqual(loadRules.GetRules()[1][1], loadRules.NoneRule)
 
         check_load_rules(stage)
 


### PR DESCRIPTION
The interaction between how the stage were initially open or created and how they were updated did not match. This caused the code that attempted to update the stage cache when saving anonymous layers to fail to achieve its goal. This led to the proxy shape next compute to fail to find the original session layer. This caused the information about edited-as-Maya prim to be lost. This resulted in the stage being in a weird state where a Maya reference prim was edited but the stage had forgotten about it.

Fix the code so that the way the stage os open in the proxy shape and in the function that update the stage cache match.

- Changed how the proxy shape open the USD stage by always initially not loading payloads.
- Also, do not pass an explicit resolver as it would affect which stage could be found in the cache.
- Document in the helper function that updates stage after saving anonymous layer to open the stages the same way.

We also needed to fix the layer manager UI update after save.

The previous code worked by happenstance of the order of indirect operations. In particular, it only worked if the proxy shape was recomputed at just the right time. Recomputing the proxy shape emitted a notice that refreshed the layer manager. For complex reasons, when there is an edited Maya reference, the order changes, which prevented the layer manager UI from updating with the latest data.

To avoid this reliance on the exact timing of when the proxy shape might get recomputed, an explicit call to refresh the underlying model of the layer manager is done when saving. Unfortunately, due to the complicated design of the layer manager, the underlying tree model and where the data is kept, multiple classes had to be modified to provide a path from the save code the the data model.

- Add functions on the MayaSessionState to refresh the current displayed stage layers.
- (The MayaSessionState is where the layer manager UI keeps its list of loaded USD stages... it really ough to be called LoadedStages instead... MayaSessionState is a combination of three meaningless words.)
- Add a updateLayerModel() abstract function to the AbstractLayerEditorWindow interface.
- Implement updateLayerModel() in MayaLayerEditorWindow by calling the refreshStageEntry() on the MayaSessionStage.
- Add a updateLayerManagers(0 helper function to the LayerDatabase used by the LayerManager (that is, the data holder, not the UI), to refresh all layer manager UI.
- Call it at the end of LayerDatabase::saveUsd(), which is where layers get saved.