### PR TITLE
LOOKDEVX-2124 - MaterialX Topo Handler

### DIFF
--- a/lib/mayaUsd/render/MaterialXGenOgsXml/CMakeLists.txt
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(${PROJECT_NAME}
         GlslOcioNodeImpl.cpp
         OgsFragment.cpp
         OgsXmlGenerator.cpp
+        ShaderGenUtil.cpp
         Nodes/SurfaceNodeMaya.cpp
         Nodes/TexcoordNodeMaya.cpp
         PugiXML/pugixml.cpp
@@ -18,6 +19,7 @@ set(HEADERS
     GlslOcioNodeImpl.h
     OgsFragment.h
     OgsXmlGenerator.h
+    ShaderGenUtil.h
 )
 
 # -----------------------------------------------------------------------------
@@ -64,6 +66,10 @@ mayaUsd_promoteHeaderList(HEADERS ${HEADERS} SUBDIR render/MaterialXGenOgsXml)
 # -----------------------------------------------------------------------------
 # install
 # -----------------------------------------------------------------------------
+
+install(FILES ${HEADERS}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}/render/MaterialXGenOgsXml
+)
 
 install(FILES ${NODE_DECLARATIONS}
     DESTINATION ${CMAKE_INSTALL_PREFIX}/libraries/adsk/maya

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
@@ -82,8 +82,10 @@ void fixupVertexDataInstance(ShaderStage& stage)
 
     static const std::string primvarParamSource
         = "vec([23]) [$](" + d(HW::T_IN_GEOMPROP) + "_[A-Za-z0-9_]+)";
-
-    static const std::regex primvarParamRegex(primvarParamSource.c_str());
+    static const std::regex  primvarParamRegex(primvarParamSource.c_str());
+    static const std::string texcoordParamSource
+        = "vec([23]) [$](" + d(HW::T_TEXCOORD) + "_[0-9]+)";
+    static const std::regex texcoordParamRegex(texcoordParamSource.c_str());
 
     // Find keywords:                                       (as text)
     //
@@ -94,16 +96,21 @@ void fixupVertexDataInstance(ShaderStage& stage)
     //  PIX_IN.(NAME)                                       PIX_IN.st
     //
 
-    static const std::string vdCleanupSource = "[$]" + d(HW::T_VERTEX_DATA_INSTANCE) + "[.][$]"
+    static const std::string vdCleanGeoSource = "[$]" + d(HW::T_VERTEX_DATA_INSTANCE) + "[.][$]"
         + d(HW::T_IN_GEOMPROP) + "_([A-Za-z0-9_]+)";
+    static const std::regex vdCleanGeoRegex(vdCleanGeoSource.c_str());
 
-    static const std::regex vdCleanupRegex(vdCleanupSource.c_str());
+    static const std::string vdCleanTexSource
+        = "[$]" + d(HW::T_VERTEX_DATA_INSTANCE) + "[.][$](" + d(HW::T_TEXCOORD) + "_[0-9]+)";
+    static const std::regex vdCleanTexRegex(vdCleanTexSource.c_str());
 
     std::string code = stage.getSourceCode();
     code = std::regex_replace(code, paramRegex, "vec3 unused_$1");
     code = std::regex_replace(code, vtxRegex, "$$$1( PIX_IN.$$$1 )");
     code = std::regex_replace(code, primvarParamRegex, "vec$1 unused_$2");
-    code = std::regex_replace(code, vdCleanupRegex, "PIX_IN.$1");
+    code = std::regex_replace(code, texcoordParamRegex, "vec$1 unused_$2");
+    code = std::regex_replace(code, vdCleanGeoRegex, "PIX_IN.$1");
+    code = std::regex_replace(code, vdCleanTexRegex, "PIX_IN.$1");
 
 #if MX_COMBINED_VERSION >= 13804
     stage.setSourceCode(code);

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/OgsFragment.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/OgsFragment.cpp
@@ -462,7 +462,7 @@ bool OgsFragment::isElementAShader() const
 
 bool OgsFragment::isTransparent() const
 {
-    return _glslShader && _glslShader->hasAttribute(mx::HW::ATTR_TRANSPARENT);
+    return isTransparentSurface(_element, mx::GlslShaderGenerator::TARGET);
 }
 
 mx::ImageSamplingProperties

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/OgsFragment.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/OgsFragment.h
@@ -4,6 +4,8 @@
 /// @file
 /// OGS fragment wrapper.
 
+#include <mayaUsd/base/api.h>
+
 #include <MaterialXCore/Document.h>
 #include <MaterialXGenShader/Shader.h>
 #include <MaterialXRender/ImageHandler.h>
@@ -16,7 +18,7 @@ namespace MaterialXMaya {
 /// and outputs and embedding source code in one or potentially multiple target
 /// shading languages (GLSL is the only such language currently supported).
 ///
-class OgsFragment
+class MAYAUSD_CORE_PUBLIC OgsFragment
 {
 public:
     /// Creates a local GLSL fragment generator

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/OgsXmlGenerator.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/OgsXmlGenerator.h
@@ -8,11 +8,13 @@
 
 /// @file
 /// OGS XML fragments generator
+#include <mayaUsd/base/api.h>
+
 #include <MaterialXGenShader/ShaderGenerator.h>
 
 MATERIALX_NAMESPACE_BEGIN
 
-class OgsXmlGenerator
+class MAYAUSD_CORE_PUBLIC OgsXmlGenerator
 {
 public:
     /// Generate OSG XML for the given shader fragments, output to the given stream.

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.cpp
@@ -1,0 +1,383 @@
+#include "ShaderGenUtil.h"
+
+#include <mayaUsd/render/MaterialXGenOgsXml/CombinedMaterialXVersion.h>
+
+#include <MaterialXCore/Document.h>
+
+#include <sstream>
+
+namespace MaterialXMaya {
+namespace ShaderGenUtil {
+
+namespace {
+const std::string SURFACEMATERIAL_CATEGORY("surfacematerial");
+const std::string SURFACESHADER_TYPE("surfaceshader");
+
+const std::set<std::string> _mtlxTopoNodeSet = {
+    // Topo affecting nodes due to object/model/world space parameter
+    "position",
+    "normal",
+    "tangent",
+    "bitangent",
+    // Topo affecting nodes due to channel index.
+    "texcoord",
+    // Color at vertices also affect topo, but we have not locked a naming scheme to go from index
+    // based to name based as we did for UV sets. We will mark them as topo-affecting, but there is
+    // nothing we can do to link them correctly to a primvar without specifying a naming scheme.
+    "geomcolor",
+    // Geompropvalue are the best way to reference a primvar by name. The primvar name is
+    // topo-affecting. Note that boolean and string are not supported by the GLSL codegen.
+    "geompropvalue",
+    // Swizzles are inlined into the codegen and affect topology.
+    "swizzle",
+    // Conversion nodes:
+    "convert",
+    // Constants: they get inlined in the source.
+    "constant",
+#if MX_COMBINED_VERSION < 13808
+    // Switch, unless all inputs are connected. Bug was fixed in 1.38.8.
+    "switch",
+#endif
+#if MX_COMBINED_VERSION == 13807
+    // Dot became topological in 1.38.7. Reverted in 1.38.8.
+    // Still topological for filename though.
+    "dot",
+#endif
+};
+} // namespace
+
+const std::string& TopoNeutralGraph::getMaterialName()
+{
+    // A material node is always the first node created and will be named N0
+    static const std::string kMaterialName("N0");
+    return kMaterialName;
+}
+
+TopoNeutralGraph::TopoNeutralGraph(const mx::ElementPtr& material)
+{
+    if (!material) {
+        throw mx::Exception("Invalid material element");
+    }
+    std::string message;
+    if (!material->validate(&message)) {
+        const std::string step("Error in original graph:\n");
+        throw mx::Exception(step + message);
+    }
+    _doc = mx::createDocument();
+
+    auto inputDoc = material->getDocument();
+
+    mx::NodePtr materialNode = material->asA<mx::Node>();
+    if (!materialNode) {
+        // We might handle standalone "Output" element at a later stage
+        throw mx::Exception("Material element is not a node.");
+    }
+
+    std::list<mx::NodePtr> nodesToTraverse;
+    mx::NodePtr            surfaceShader;
+    if (materialNode->getCategory() == SURFACEMATERIAL_CATEGORY) {
+        auto dupMaterial = cloneNode(*materialNode, *_doc);
+        auto surfaceInput = materialNode->getInput(SURFACESHADER_TYPE);
+        if (!surfaceInput || !surfaceInput->getConnectedNode()) {
+            throw mx::Exception("Unconnected material node.");
+        }
+        surfaceShader = surfaceInput->getConnectedNode();
+        if (!surfaceShader) {
+            throw mx::Exception("Unconnected material node.");
+        }
+        auto dupSurfaceShader = cloneNode(*surfaceShader, *_doc);
+        dupMaterial->addInput(SURFACESHADER_TYPE, SURFACESHADER_TYPE)
+            ->setConnectedNode(dupSurfaceShader);
+        nodesToTraverse.push_back(surfaceShader);
+    } else {
+        if (materialNode->getType() != SURFACESHADER_TYPE) {
+            throw mx::Exception("Material shader node is not a surfaceshader.");
+        }
+        auto dupMaterial = _doc->addMaterialNode("N" + std::to_string(_nodeIndex));
+        dupMaterial->setNodeDefString("ND_surfacematerial");
+        ++_nodeIndex;
+        surfaceShader = materialNode;
+        auto dupSurfaceShader = cloneNode(*materialNode, *_doc);
+        dupMaterial->addInput(SURFACESHADER_TYPE, SURFACESHADER_TYPE)
+            ->setConnectedNode(dupSurfaceShader);
+        nodesToTraverse.push_back(materialNode);
+    }
+
+    // Breadth-first traversal, in order of NodeDef attributes, to insure repeatability
+    while (!nodesToTraverse.empty()) {
+        const mx::Node& sourceNode = *nodesToTraverse.front();
+        nodesToTraverse.pop_front();
+
+        auto        destNodeIt = _nodeMap.find(sourceNode.getNamePath());
+        mx::NodePtr destNode;
+        if (destNodeIt != _nodeMap.end()) {
+            destNode = destNodeIt->second;
+        } else {
+            if (!_nodeGraph) {
+                _nodeGraph = _doc->addNodeGraph("NG0");
+            }
+            destNode = cloneNode(sourceNode, *_nodeGraph);
+        }
+
+        auto sourceNodeDef = sourceNode.getNodeDef();
+        if (!sourceNodeDef) {
+            throw mx::Exception("Could not find NodeDef.");
+        }
+
+        const bool isTopological = isTopologicalNodeDef(*sourceNodeDef);
+        for (const auto& defInput : sourceNodeDef->getActiveInputs()) {
+            auto sourceInput = sourceNode.getInput(defInput->getName());
+            if (!sourceInput) {
+                continue;
+            }
+
+            auto connectedNode = sourceInput->getConnectedNode();
+            if (connectedNode) {
+                auto        destConnectedIt = _nodeMap.find(connectedNode->getNamePath());
+                mx::NodePtr destConnectedNode;
+                if (destConnectedIt != _nodeMap.end()) {
+                    destConnectedNode = destConnectedIt->second;
+                } else {
+                    if (!_nodeGraph) {
+                        _nodeGraph = _doc->addNodeGraph("NG0");
+                    }
+                    destConnectedNode = cloneNode(*connectedNode, *_nodeGraph);
+                    nodesToTraverse.push_back(connectedNode);
+                }
+
+                const std::string channelInfo = gatherChannels(*sourceInput);
+                const std::string outputString = gatherOutput(*sourceInput);
+
+                if (sourceNode != *surfaceShader) {
+                    cloneConnection(
+                        *sourceInput, *destNode, destConnectedNode, channelInfo, outputString);
+                } else {
+                    cloneNodeGraphConnection(
+                        *sourceInput, *destNode, destConnectedNode, channelInfo, outputString);
+                }
+            } else if (isTopological) {
+                std::string valueString = sourceInput->getValueString();
+                if (valueString.empty()) {
+                    const auto interfaceInput = sourceInput->getInterfaceInput();
+                    if (interfaceInput) {
+                        valueString = interfaceInput->getValueString();
+                    }
+                }
+                if (!valueString.empty()) {
+                    auto destInput
+                        = destNode->addInput(sourceInput->getName(), sourceInput->getType());
+                    destInput->setValueString(valueString);
+                }
+            }
+        }
+    }
+}
+
+mx::NodePtr TopoNeutralGraph::cloneNode(const mx::Node& node, mx::GraphElement& container)
+{
+    auto destNode
+        = container.addNode(node.getCategory(), "N" + std::to_string(_nodeIndex), node.getType());
+    ++_nodeIndex;
+    _nodeMap.insert({ node.getNamePath(), destNode });
+    _nodeMap.insert({ node.getNamePath(), destNode });
+    _pathMap.insert({ destNode->getNamePath(), node.getNamePath() });
+    // Always be explicit on the NodeDef:
+    auto nodeDef = node.getNodeDef();
+    if (!nodeDef) {
+        throw mx::Exception("Ambiguous node is not fully resolvable");
+    }
+    destNode->setNodeDefString(nodeDef->getName());
+    return destNode;
+}
+
+const std::string& TopoNeutralGraph::getOriginalPath(const std::string& topoPath) const
+{
+    auto it = _pathMap.find(topoPath);
+    if (it == _pathMap.end()) {
+        throw mx::Exception("Could not find original path for " + topoPath);
+    }
+    return it->second;
+}
+
+bool TopoNeutralGraph::isTopologicalNodeDef(const mx::NodeDef& nodeDef)
+{
+    // This is where we need to remove all these hardcoded names and instead ask the shadergen about
+    // the info. Requires a shadergen that can tell if a node is topological (usually C++ nodes that
+    // have custom shader code that varies when input value varies)
+
+    // This is the hardcoded list for the GLSL shader generator:
+#if MX_COMBINED_VERSION >= 13807
+    // Dot filename is always topological to prevent creating extra OpenGL samplers in the
+    // generated OpenGL code.
+    if (nodeDef.getName() == "ND_dot_filename")
+        return true;
+#endif
+    return _mtlxTopoNodeSet.find(nodeDef.getNodeString()) != _mtlxTopoNodeSet.cend();
+}
+
+mx::DocumentPtr TopoNeutralGraph::getDocument() const { return _doc; }
+
+mx::OutputPtr
+TopoNeutralGraph::findNodeGraphOutput(const mx::Input& input, const std::string& outputName)
+{
+    auto sourceNode = input.getParent();
+    if (!sourceNode || !sourceNode->isA<mx::Node>()) {
+        return nullptr;
+    }
+
+    auto scope = sourceNode->getParent();
+    if (!scope || !scope->isA<mx::Document>()) {
+        return nullptr;
+    }
+
+    auto nodeGraph = scope->asA<mx::Document>()->getNodeGraph(input.getNodeGraphString());
+    if (!nodeGraph) {
+        return nullptr;
+    }
+
+    return nodeGraph->getOutput(outputName);
+}
+
+std::string TopoNeutralGraph::gatherChannels(const mx::Input& input)
+{
+    // The info we seek might be on the interface of a standalone NodeGraph:
+    const auto  interfaceInput = input.getInterfaceInput();
+    const auto& ngInput = interfaceInput ? *interfaceInput : input;
+
+    std::string channelInfo = ngInput.getChannels();
+
+    if (!ngInput.hasNodeGraphString()) {
+        if (ngInput.hasNodeName()) {
+            return channelInfo;
+        } else {
+            throw mx::Exception("We do not support standalone Output elements");
+        }
+    }
+
+    // See if we have extra channels on the NodeGraph output:
+    auto output = findNodeGraphOutput(ngInput, ngInput.getOutputString());
+    if (!output) {
+        throw mx::Exception("Could not find nodegraph");
+    }
+
+    const std::string outputChannels = output->getChannels();
+    if (outputChannels.empty()) {
+        return channelInfo;
+    } else if (channelInfo.empty()) {
+        return outputChannels;
+    }
+
+    // Here we must combine the channels.
+    std::string combinedChannels;
+    combinedChannels.reserve(channelInfo.size());
+
+    for (const char c : channelInfo) {
+        switch (c) {
+        case '0':
+        case '1': combinedChannels.push_back(c); break;
+        case 'r':
+        case 'x':
+            // We know from above the string is not empty.
+            combinedChannels.push_back(outputChannels[0]);
+            break;
+        case 'g':
+        case 'y':
+            if (outputChannels.size() < 2) {
+                throw mx::Exception("Missing channels in outputChannels");
+            }
+            combinedChannels.push_back(outputChannels[1]);
+            break;
+        case 'b':
+        case 'z':
+            if (outputChannels.size() < 3) {
+                throw mx::Exception("Missing channels in outputChannels");
+            }
+            combinedChannels.push_back(outputChannels[2]);
+            break;
+        case 'a':
+        case 'w':
+            if (outputChannels.size() < 4) {
+                throw mx::Exception("Missing channels in outputChannels");
+            }
+            combinedChannels.push_back(outputChannels[3]);
+            break;
+        default: throw mx::Exception("Invalid channel name");
+        }
+    }
+    return combinedChannels;
+}
+
+std::string TopoNeutralGraph::gatherOutput(const mx::Input& input)
+{
+    // The info we seek might be on the interface of a standalone NodeGraph:
+    const auto  interfaceInput = input.getInterfaceInput();
+    const auto& ngInput = interfaceInput ? *interfaceInput : input;
+
+    std::string outputString = ngInput.getOutputString();
+
+    if (!ngInput.hasNodeGraphString()) {
+        if (ngInput.hasNodeName()) {
+            return outputString;
+        } else {
+            throw mx::Exception("We do not support standalone Output elements");
+        }
+    }
+
+    // See if we have extra channels on the NodeGraph output:
+    auto output = findNodeGraphOutput(ngInput, ngInput.getOutputString());
+    if (!output) {
+        throw mx::Exception("Could not find nodegraph");
+    }
+
+    return output->getOutputString();
+}
+
+void TopoNeutralGraph::cloneConnection(
+    const mx::Input&   sourceInput,
+    mx::Node&          destNode,
+    mx::NodePtr&       destConnectedNode,
+    const std::string& channelInfo,
+    const std::string& output)
+{
+    auto destInput = destNode.addInput(sourceInput.getName(), sourceInput.getType());
+    destInput->setConnectedNode(destConnectedNode);
+    if (!channelInfo.empty()) {
+        destInput->setChannels(channelInfo);
+    }
+    if (!output.empty()) {
+        destInput->setOutputString(output);
+    }
+}
+
+void TopoNeutralGraph::cloneNodeGraphConnection(
+    const mx::Input&   sourceInput,
+    mx::Node&          destNode,
+    mx::NodePtr&       destConnectedNode,
+    const std::string& channelInfo,
+    const std::string& output)
+{
+    std::string outputKey = destConnectedNode->getName() + "(t)" + sourceInput.getType() + "(c)"
+        + channelInfo + "(o)" + output;
+    mx::OutputPtr graphOutput;
+    auto          outputIt = _outputMap.find(outputKey);
+    if (outputIt != _outputMap.end()) {
+        graphOutput = outputIt->second;
+    } else {
+        graphOutput
+            = _nodeGraph->addOutput("O" + std::to_string(_outputIndex), sourceInput.getType());
+        if (!channelInfo.empty()) {
+            graphOutput->setChannels(channelInfo);
+        }
+        if (!output.empty()) {
+            graphOutput->setOutputString(output);
+        }
+        ++_outputIndex;
+        _outputMap.insert({ outputKey, graphOutput });
+        graphOutput->setConnectedNode(destConnectedNode);
+        auto destInput = destNode.addInput(sourceInput.getName(), sourceInput.getType());
+        destInput->setConnectedOutput(graphOutput);
+    }
+}
+
+} // namespace ShaderGenUtil
+} // namespace MaterialXMaya

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.cpp
@@ -180,7 +180,6 @@ mx::NodePtr TopoNeutralGraph::cloneNode(const mx::Node& node, mx::GraphElement& 
         = container.addNode(node.getCategory(), "N" + std::to_string(_nodeIndex), node.getType());
     ++_nodeIndex;
     _nodeMap.insert({ node.getNamePath(), destNode });
-    _nodeMap.insert({ node.getNamePath(), destNode });
     _pathMap.insert({ destNode->getNamePath(), node.getNamePath() });
     // Always be explicit on the NodeDef:
     auto nodeDef = node.getNodeDef();

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.cpp
@@ -4,6 +4,7 @@
 
 #include <MaterialXCore/Document.h>
 
+#include <list>
 #include <sstream>
 
 namespace MaterialXMaya {

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.h
@@ -1,0 +1,76 @@
+#ifndef MATERIALX_MAYA_SHADERGENUTIL_H
+#define MATERIALX_MAYA_SHADERGENUTIL_H
+
+/// @file
+/// Helpers
+
+#include <mayaUsd/base/api.h>
+
+#include <MaterialXCore/Document.h>
+
+#include <map>
+
+namespace mx = MaterialX;
+namespace MaterialXMaya {
+namespace ShaderGenUtil {
+
+/// Topo-neutral graph duplicator. Creates a topologically neutral copy of a shading graph:
+
+class MAYAUSD_CORE_PUBLIC TopoNeutralGraph
+{
+public:
+    explicit TopoNeutralGraph(const mx::ElementPtr& material);
+    ~TopoNeutralGraph() = default;
+
+    TopoNeutralGraph() = delete;
+
+    TopoNeutralGraph(const TopoNeutralGraph&) = default;
+    TopoNeutralGraph& operator=(const TopoNeutralGraph&) = default;
+    TopoNeutralGraph(TopoNeutralGraph&&) = default;
+    TopoNeutralGraph& operator=(TopoNeutralGraph&&) = default;
+
+    static bool isTopologicalNodeDef(const mx::NodeDef& nodeDef);
+
+    mx::DocumentPtr           getDocument() const;
+    static const std::string& getMaterialName();
+    const std::string&        getOriginalPath(const std::string& topoPath) const;
+
+private:
+    mx::NodePtr   cloneNode(const mx::Node& node, mx::GraphElement& container);
+    mx::OutputPtr findNodeGraphOutput(const mx::Input& input, const std::string& outputName);
+    std::string   gatherChannels(const mx::Input& input);
+    std::string   gatherOutput(const mx::Input& input);
+    void          cloneConnection(
+                 const mx::Input&   sourceInput,
+                 mx::Node&          destNode,
+                 mx::NodePtr&       destConnectedNode,
+                 const std::string& channelInfo,
+                 const std::string& output);
+    void cloneNodeGraphConnection(
+        const mx::Input&   sourceInput,
+        mx::Node&          destNode,
+        mx::NodePtr&       destConnectedNode,
+        const std::string& channelInfo,
+        const std::string& output);
+
+    // The topo neutral document we are trying to create.
+    mx::DocumentPtr _doc;
+    // This topo neutral document will store all ancillary nodes in a NodeGraph
+    mx::NodeGraphPtr _nodeGraph;
+    // Since we anonymize the node names, we need a map from original name
+    // to the duplicated node.
+    using TNodeMap = std::map<std::string, mx::NodePtr>;
+    TNodeMap _nodeMap;
+    size_t   _nodeIndex = 0;
+    // We also make sure to create the minimal number of outputs on the NodeGraph.
+    using TOutputMap = std::map<std::string, mx::OutputPtr>;
+    TOutputMap _outputMap;
+    size_t     _outputIndex = 0;
+    // String mapping from topo path to original path:
+    std::unordered_map<std::string, std::string> _pathMap;
+};
+
+} // namespace ShaderGenUtil
+} // namespace MaterialXMaya
+
+#endif

--- a/test/lib/mayaUsd/utils/CMakeLists.txt
+++ b/test/lib/mayaUsd/utils/CMakeLists.txt
@@ -112,7 +112,7 @@ if(IS_WINDOWS)
         testSplitString.cpp
     )
 
-    if(CMAKE_WANT_MATERIALX_BUILD)
+    if(CMAKE_WANT_MATERIALX_BUILD AND PXR_VERSION GREATER_EQUAL 2211)
         add_mayaUsdLibUtils_test(
             test_ShaderGenUtils
             test_ShaderGenUtils.cpp

--- a/test/lib/mayaUsd/utils/CMakeLists.txt
+++ b/test/lib/mayaUsd/utils/CMakeLists.txt
@@ -111,4 +111,25 @@ if(IS_WINDOWS)
         testSplitString
         testSplitString.cpp
     )
+
+    if(CMAKE_WANT_MATERIALX_BUILD)
+        add_mayaUsdLibUtils_test(
+            test_ShaderGenUtils
+            test_ShaderGenUtils.cpp
+        )
+
+        target_compile_definitions(test_ShaderGenUtils
+        PRIVATE
+            MATERIALX_TEST_DATA="${CMAKE_CURRENT_SOURCE_DIR}/materialx_test_data"
+            MATERIALX_TEST_OUTPUT="${CMAKE_BINARY_DIR}/test/Temporary/test_ShaderGenUtils"
+        )
+
+        target_link_libraries(test_ShaderGenUtils
+        PRIVATE
+            usdMtlx
+            MaterialXCore
+            MaterialXFormat
+        )
+
+    endif()    
 endif()

--- a/test/lib/mayaUsd/utils/materialx_test_data/Channel1_topo.mtlx
+++ b/test/lib/mayaUsd/utils/materialx_test_data/Channel1_topo.mtlx
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+  <surfacematerial name="N0" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="N1" />
+  </surfacematerial>
+  <standard_surface name="N1" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base" type="float" output="O0" nodegraph="NG0" />
+  </standard_surface>
+  <nodegraph name="NG0">
+    <constant name="N2" type="color3" nodedef="ND_constant_color3">
+      <input name="value" type="color3" value="0.263273, 0.263273, 0.263273" />
+    </constant>
+    <output name="O0" type="float" channels="g" nodename="N2" />
+  </nodegraph>
+</materialx>

--- a/test/lib/mayaUsd/utils/materialx_test_data/Channel4_topo.mtlx
+++ b/test/lib/mayaUsd/utils/materialx_test_data/Channel4_topo.mtlx
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+  <surfacematerial name="N0" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="N1" />
+  </surfacematerial>
+  <standard_surface name="N1" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base" type="float" output="O0" nodegraph="NG0" />
+  </standard_surface>
+  <nodegraph name="NG0">
+    <constant name="N2" type="color3" nodedef="ND_constant_color3">
+      <input name="value" type="color3" value="0.263273, 0.263273, 0.263273" />
+    </constant>
+    <output name="O0" type="float" channels="r" nodename="N2" />
+  </nodegraph>
+</materialx>

--- a/test/lib/mayaUsd/utils/materialx_test_data/Interface2_topo.mtlx
+++ b/test/lib/mayaUsd/utils/materialx_test_data/Interface2_topo.mtlx
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+  <surfacematerial name="N0" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="N1" />
+  </surfacematerial>
+  <standard_surface name="N1" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base" type="float" output="O0" nodegraph="NG0" />
+  </standard_surface>
+  <nodegraph name="NG0">
+    <add name="N2" type="float" nodedef="ND_add_float">
+      <input name="in1" type="float" nodename="N3" />
+    </add>
+    <output name="O0" type="float" nodename="N2" />
+    <add name="N3" type="float" nodedef="ND_add_float">
+      <input name="in1" type="float" nodename="N4" channels="g" />
+    </add>
+    <constant name="N4" type="color3" nodedef="ND_constant_color3">
+      <input name="value" type="color3" value="0.263273, 0.263273, 0.263273" />
+    </constant>
+  </nodegraph>
+</materialx>

--- a/test/lib/mayaUsd/utils/materialx_test_data/MultiOut6_topo.mtlx
+++ b/test/lib/mayaUsd/utils/materialx_test_data/MultiOut6_topo.mtlx
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+  <surfacematerial name="N0" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="N1" />
+  </surfacematerial>
+  <standard_surface name="N1" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base_color" type="color3" output="O0" nodegraph="NG0" />
+  </standard_surface>
+  <nodegraph name="NG0">
+    <artistic_ior name="N2" type="multioutput" nodedef="ND_artistic_ior" />
+    <output name="O0" type="color3" output="ior" nodename="N2" />
+  </nodegraph>
+</materialx>

--- a/test/lib/mayaUsd/utils/materialx_test_data/topology_tests.mtlx
+++ b/test/lib/mayaUsd/utils/materialx_test_data/topology_tests.mtlx
@@ -1,0 +1,161 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+
+  <!-- Simple use of channels on output node -->
+  <nodegraph name="Ng1">
+    <constant name="constant" type="color3" nodedef="ND_constant_color3">
+      <input name="value" type="color3" value="0.263273, 0.263273, 0.263273" />
+    </constant>
+    <output name="float_output" type="float" nodename="constant" channels="g" />
+  </nodegraph>
+  <standard_surface name="Surf1" type="surfaceshader">
+    <input name="base" type="float" nodegraph="Ng1" output="float_output" />
+  </standard_surface>
+  <surfacematerial name="Channel1" type="material" topo="Channel1_topo.mtlx">
+    <input name="surfaceshader" type="surfaceshader" nodename="Surf1" />
+  </surfacematerial>
+
+  <!-- Simple use of channels on node outside of graph -->
+  <nodegraph name="Ng2">
+    <constant name="constant" type="color3" nodedef="ND_constant_color3">
+      <input name="value" type="color3" value="0.263273, 0.263273, 0.263273" />
+    </constant>
+    <output name="color3_output" type="color3" nodename="constant" />
+  </nodegraph>
+  <standard_surface name="Surf2" type="surfaceshader">
+    <input name="base" type="float" nodegraph="Ng2" output="color3_output" channels="g" />
+  </standard_surface>
+  <surfacematerial name="Channel2" type="material" topo="Channel1_topo.mtlx">
+    <input name="surfaceshader" type="surfaceshader" nodename="Surf2" />
+  </surfacematerial>
+
+  <!-- Devious use of a double channel to confuse the code -->
+  <nodegraph name="Ng3">
+    <constant name="constant" type="color3" nodedef="ND_constant_color3">
+      <input name="value" type="color3" value="0.263273, 0.263273, 0.263273" />
+    </constant>
+    <output name="color4_output" type="color4" nodename="constant" channels="rgb1" />
+  </nodegraph>
+  <standard_surface name="Surf3" type="surfaceshader">
+    <input name="base" type="float" nodegraph="Ng3" output="color4_output" channels="g" />
+  </standard_surface>
+  <surfacematerial name="Channel3" type="material" topo="Channel1_topo.mtlx">
+    <input name="surfaceshader" type="surfaceshader" nodename="Surf3" />
+  </surfacematerial>
+
+  <!-- Even worse use of a double channel to confuse the code. We expect final channel to be "r" -->
+  <nodegraph name="Ng4">
+    <constant name="constant" type="color3" nodedef="ND_constant_color3">
+      <input name="value" type="color3" value="0.263273, 0.263273, 0.263273" />
+    </constant>
+    <output name="color4_output" type="color4" nodename="constant" channels="rrrr" />
+  </nodegraph>
+  <standard_surface name="Surf4" type="surfaceshader">
+    <input name="base" type="float" nodegraph="Ng4" output="color4_output" channels="g" />
+  </standard_surface>
+  <surfacematerial name="Channel4" type="material" topo="Channel4_topo.mtlx">
+    <input name="surfaceshader" type="surfaceshader" nodename="Surf4" />
+  </surfacematerial>
+
+  <!-- Absence of a nodegraph does not influence flattened topology -->
+  <standard_surface name="Surf5" type="surfaceshader">
+    <input name="base" type="float" nodename="constant5" channels="g" />
+  </standard_surface>
+  <constant name="constant5" type="color3" nodedef="ND_constant_color3">
+    <input name="value" type="color3" value="0.263273, 0.263273, 0.263273" />
+  </constant>
+  <surfacematerial name="Channel5" type="material" topo="Channel1_topo.mtlx">
+    <input name="surfaceshader" type="surfaceshader" nodename="Surf5" />
+  </surfacematerial>
+
+  <!-- Multi-output test -->
+  <nodegraph name="Ng6">
+    <artistic_ior name="ior6" type="multioutput">
+      <input name="edge_color" type="color3" value="0.7, 0.4, 0.1" colorspace="lin_rec709" />
+    </artistic_ior>
+    <output name="ior_output" type="color3" nodename="ior6" output="ior" />
+  </nodegraph>
+  <standard_surface name="Surf6" type="surfaceshader">
+    <input name="base_color" type="color3" nodegraph="Ng6" output="ior_output" />
+  </standard_surface>
+  <surfacematerial name="MultiOut6" type="material" topo="MultiOut6_topo.mtlx">
+    <input name="surfaceshader" type="surfaceshader" nodename="Surf6" />
+  </surfacematerial>
+
+  <!-- Multi-output test no nodegraph -->
+  <artistic_ior name="ior7" type="multioutput">
+    <input name="edge_color" type="color3" value="0.7, 0.4, 0.1" colorspace="lin_rec709" />
+  </artistic_ior>
+  <standard_surface name="Surf7" type="surfaceshader">
+    <input name="base_color" type="color3" nodename="ior7" output="ior" />
+  </standard_surface>
+  <surfacematerial name="MultiOut7" type="material" topo="MultiOut6_topo.mtlx">
+    <input name="surfaceshader" type="surfaceshader" nodename="Surf7" />
+  </surfacematerial>
+
+  <!-- Constant value on interface -->
+  <nodegraph name="Ng8">
+    <input name="ng_const" type="color3" value="0.263273, 0.263273, 0.263273" /> 
+    <constant name="constant" type="color3" nodedef="ND_constant_color3">
+      <input name="value" type="color3" interfacename="ng_const" />
+    </constant>
+    <output name="float_output" type="float" nodename="constant" channels="g" />
+  </nodegraph>
+  <standard_surface name="Surf8" type="surfaceshader">
+    <input name="base" type="float" nodegraph="Ng8" output="float_output" />
+  </standard_surface>
+  <surfacematerial name="Interface1" type="material" topo="Channel1_topo.mtlx">
+    <input name="surfaceshader" type="surfaceshader" nodename="Surf8" />
+  </surfacematerial>
+
+  <!-- Chaining nodegraphs: -->
+  <nodegraph name="Ng9a">
+    <input name="ng_const" type="color3" value="0.263273, 0.263273, 0.263273" /> 
+    <constant name="constant" type="color3" nodedef="ND_constant_color3">
+      <input name="value" type="color3" interfacename="ng_const" />
+    </constant>
+    <output name="float_output" type="float" nodename="constant" channels="g" />
+  </nodegraph>
+  <add name="add9a" type="float" nodedef="ND_add_float">
+    <input name="in1" type="float" nodegraph="Ng9a" output="float_output" />
+  </add>
+  <nodegraph name="Ng9b">
+    <input name="ng_add" type="float" nodename="add9a" /> 
+    <add name="add9b" type="float" nodedef="ND_add_float">
+      <input name="in1" type="float" interfacename="ng_add" />
+    </add>
+    <output name="float_output" type="float" nodename="add9b" />
+  </nodegraph>
+  <standard_surface name="Surf9" type="surfaceshader">
+    <input name="base" type="float" nodegraph="Ng9b" output="float_output" />
+  </standard_surface>
+  <surfacematerial name="Interface2" type="material" topo="Interface2_topo.mtlx">
+    <input name="surfaceshader" type="surfaceshader" nodename="Surf9" />
+  </surfacematerial>
+
+  <!-- Chaining nodegraphs without intermediate node: -->
+  <nodegraph name="Ng10a">
+    <input name="ng_const" type="color3" value="0.263273, 0.263273, 0.263273" /> 
+    <constant name="constant" type="color3" nodedef="ND_constant_color3">
+      <input name="value" type="color3" interfacename="ng_const" />
+    </constant>
+    <add name="add10a" type="float" nodedef="ND_add_float">
+      <input name="in1" type="float" nodename="constant" channels="g" />
+    </add>
+    <output name="float_output" type="float" nodename="add10a" />
+  </nodegraph>
+  <nodegraph name="Ng10b">
+    <input name="ng_add" type="float" ndegraph="Ng10a" output="float_output" /> 
+    <add name="add10b" type="float" nodedef="ND_add_float">
+      <input name="in1" type="float" interfacename="ng_add" />
+    </add>
+    <output name="float_output" type="float" nodename="add10b" />
+  </nodegraph>
+  <standard_surface name="Surf10" type="surfaceshader">
+    <input name="base" type="float" nodegraph="Ng10b" output="float_output" />
+  </standard_surface>
+  <surfacematerial name="Interface3" type="material" topo="Interface2_topo.mtlx">
+    <input name="surfaceshader" type="surfaceshader" nodename="Surf10" />
+  </surfacematerial>
+
+</materialx>

--- a/test/lib/mayaUsd/utils/test_ShaderGenUtils.cpp
+++ b/test/lib/mayaUsd/utils/test_ShaderGenUtils.cpp
@@ -1,0 +1,74 @@
+#include <mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.h>
+
+#include <pxr/imaging/hdMtlx/hdMtlx.h>
+#include <pxr/usd/sdf/path.h>
+
+#include <maya/MGlobal.h>
+#include <maya/MString.h>
+
+#include <MaterialXCore/Document.h>
+#include <MaterialXFormat/File.h>
+#include <MaterialXFormat/Util.h>
+#include <MaterialXFormat/XmlIo.h>
+#include <MaterialXGenShader/Util.h>
+#include <gtest/gtest.h>
+
+#include <iostream>
+
+constexpr auto pythonDiff = R"D(
+import difflib
+import sys
+
+with open(r'^1s', 'r') as mxBaseline:
+    with open(r'^1s', 'r') as mxOutput:
+        diff = difflib.unified_diff(
+            mxBaseline.readlines(),
+            mxOutput.readlines(),
+            fromfile='baseline',
+            tofile='output',
+        )
+        [str(line) for line in diff]
+)D";
+
+TEST(ShaderGenUtils, topoChannels)
+{
+    auto testPath = mx::FilePath(MATERIALX_TEST_DATA);
+
+    auto library = mx::createDocument();
+    ASSERT_TRUE(library != nullptr);
+    auto searchPath = PXR_NS::HdMtlxSearchPaths();
+    mx::loadLibraries({}, searchPath, library);
+
+    auto doc = mx::createDocument();
+    doc->importLibrary(library);
+
+    const mx::XmlReadOptions readOptions;
+    mx::readFromXmlFile(doc, testPath / "topology_tests.mtlx", mx::EMPTY_STRING, &readOptions);
+
+    for (const mx::NodePtr& material : doc->getMaterialNodes()) {
+        if (material->getName() != "Interface2") {
+            continue;
+        }
+        auto topoNetwork = MaterialXMaya::ShaderGenUtil::TopoNeutralGraph(material);
+
+        const std::string& expectedFileName = material->getAttribute("topo");
+        ASSERT_FALSE(expectedFileName.empty());
+
+        auto baseline = mx::createDocument();
+        auto baselinePath = testPath / expectedFileName;
+        mx::readFromXmlFile(baseline, baselinePath, mx::EMPTY_STRING, &readOptions);
+
+        auto outputDoc = topoNetwork.getDocument();
+
+        if (*baseline != *outputDoc) {
+            const std::string baselineStr = mx::writeToXmlString(baseline);
+            const std::string outputStr = mx::writeToXmlString(outputDoc);
+            ASSERT_EQ(baselineStr, outputStr) << "While testing: " << material->getName()
+                                              << " against baseline " << expectedFileName;
+        }
+
+        outputDoc->importLibrary(library);
+        std::string message;
+        ASSERT_TRUE(outputDoc->validate(&message)) << message;
+    }
+}


### PR DESCRIPTION
Implements a topo neutral graph generator. This allows detecting that two native MaterialX shading graphs are topologically equivalent, generate universal shading code, and provide the right mapping to find the original node name corresponding to a renamed node.

Also adds proper exports to allow rebuilding the old MaterialX Maya surface node using this new functionnality. This also requires fixing the generated code to properly handle the "texcoord" nodes variables used in the shader.