### PR TITLE
EMSUSD-604 fix crash when duplicating a proxy shape

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.h
+++ b/lib/mayaUsd/nodes/layerManager.h
@@ -55,10 +55,10 @@ enum BatchSaveResult
  */
 struct StageSavingInfo
 {
-    MDagPath    dagPath;
-    UsdStagePtr stage;
-    bool        shareable = true;
-    bool        isIncoming = false;
+    MDagPath       dagPath;
+    UsdStageRefPtr stage;
+    bool           shareable = true;
+    bool           isIncoming = false;
 };
 
 /*! \brief Callback function to handle saving of Usd edits.  In a default build of the

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -546,6 +546,16 @@ void MayaUsdProxyShapeBase::enableProxyAccessor()
     _usdAccessor = ProxyAccessor::createAndRegister(*this);
 }
 
+void MayaUsdProxyShapeBase::renameCallback(MObject&, const MString&, void* clientData)
+{
+    auto proxyShape = static_cast<MayaUsdProxyShapeBase*>(clientData);
+    if (!proxyShape) {
+        return;
+    }
+
+    proxyShape->updateAncestorCallbacks();
+}
+
 void beforeSaveCallback(void* clientData)
 {
     auto proxyShape = static_cast<MayaUsdProxyShapeBase*>(clientData);
@@ -584,6 +594,11 @@ void MayaUsdProxyShapeBase::postConstructor()
     if (_preSaveCallbackId == 0) {
         _preSaveCallbackId
             = MSceneMessage::addCallback(MSceneMessage::kBeforeSave, beforeSaveCallback, this);
+    }
+
+    if (_renameCallbackId == 0) {
+        MObject obj = thisMObject();
+        _renameCallbackId = MNodeMessage::addNameChangedCallback(obj, renameCallback, this);
     }
 }
 
@@ -1958,6 +1973,11 @@ MayaUsdProxyShapeBase::~MayaUsdProxyShapeBase()
     if (_preSaveCallbackId != 0) {
         MMessage::removeCallback(_preSaveCallbackId);
         _preSaveCallbackId = 0;
+    }
+
+    if (_renameCallbackId != 0) {
+        MMessage::removeCallback(_renameCallbackId);
+        _renameCallbackId = 0;
     }
 
     clearAncestorCallbacks();

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -396,6 +396,8 @@ private:
     void _OnLayerMutingChanged(const UsdNotice::LayerMutingChanged& notice);
     void _OnStageEditTargetChanged(const UsdNotice::StageEditTargetChanged& notice);
 
+    static void renameCallback(MObject& node, const MString& str, void* clientData);
+
     UsdMayaStageNoticeListener _stageNoticeListener;
 
     std::map<UsdTimeCode, MBoundingBox> _boundingBoxCache;
@@ -442,6 +444,7 @@ private:
     bool                     _inAncestorCallback { false };
 
     MCallbackId _preSaveCallbackId { 0 };
+    MCallbackId _renameCallbackId { 0 };
 
 public:
     // Counter for the number of times compute is re-entered

--- a/test/lib/ufe/CMakeLists.txt
+++ b/test/lib/ufe/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TEST_SCRIPT_FILES
     testContextOps.py
     testDefaultPrimCmds.py
     testDuplicateCmd.py
+    testDuplicateProxyShape.py
     testEditRouting.py
     testGroupCmd.py
     testMatrices.py

--- a/test/lib/ufe/testDuplicateProxyShape.py
+++ b/test/lib/ufe/testDuplicateProxyShape.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2023 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import fixturesUtils
+import mayaUtils
+import mayaUsd
+
+from maya import cmds
+from maya import standalone
+
+import unittest
+
+class DuplicateProxyShapeTestCase(unittest.TestCase):
+    '''
+    Verify the Maya duplicate command when duplicating a proxy shape.
+    '''
+
+    pluginsLoaded = False
+
+    @classmethod
+    def setUpClass(cls):
+        '''
+        Setup the class, which will create an output folder and set
+        the current directory to it so we can write files.
+        '''
+        fixturesUtils.setUpClass(__file__, loadPlugin=False)
+
+        if not cls.pluginsLoaded:
+            cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def setUp(self):
+        '''
+        Called initially to set up the Maya test environment
+        '''
+        # Load plugins
+        self.assertTrue(self.pluginsLoaded)
+
+    def testDuplicate(self):
+        '''
+        Duplicate the Maya transform holding the MayaUSD proxy shape.
+        Verify that the new proxy shape has the expected content.
+        '''
+
+        # Initial setup: a new stage with a cone prim
+        proxyShapePathStr, usdStage = mayaUtils.createProxyAndStage()
+        proxyShapeParentPathStr = cmds.listRelatives(proxyShapePathStr, parent=1)[0]
+        self.assertTrue(proxyShapeParentPathStr)
+
+        conePrimPathStr = '/cone'
+        usdStage.DefinePrim(conePrimPathStr, 'Cone')
+
+        def verifyCone(stage):
+            conePrim = stage.GetPrimAtPath(conePrimPathStr)
+            self.assertIsNotNone(conePrim)
+            self.assertTrue(conePrim)
+
+        verifyCone(usdStage)
+
+        # Duplicate the Maya transform parent that is holding the proxy shape.
+        cmds.select(proxyShapePathStr)
+        duplicatedNodesPathStr = cmds.duplicate()
+
+        # Extract the new proxy shape parent path from the duplicate command results.
+        self.assertEqual(len(duplicatedNodesPathStr), 1)
+        newProxyShapeParentPathStr = duplicatedNodesPathStr[0]
+        self.assertTrue(proxyShapeParentPathStr)
+
+        # Verify there is a stage below the new proxy parent.
+        newProxyShapePathStr = proxyShapePathStr.replace(proxyShapeParentPathStr, newProxyShapeParentPathStr)
+        self.assertNotEqual(newProxyShapePathStr, proxyShapePathStr)
+
+        # Retrieve the new USD stage
+        newUsdStage = mayaUsd.lib.GetPrim(newProxyShapePathStr).GetStage()
+        self.assertTrue(newUsdStage)
+        verifyCone(newUsdStage)
+
+        cmds.undo()
+
+        verifyCone(usdStage)
+
+        cmds.redo()
+        verifyCone(usdStage)
+        verifyCone(newUsdStage)
+
+    def testNoModificationDuplicate(self):
+        '''
+        Duplicate the Maya transform holding the MayaUSD proxy shape
+        and immediately save. It used to crash. The stages need to not
+        be modified before saving to trigger the crash.
+        
+        Verify that it no longer crashes.
+        '''
+
+        # Initial setup: a new stage with a cone prim
+        proxyShapePathStr, usdStage = mayaUtils.createProxyAndStage()
+        proxyShapeParentPathStr = cmds.listRelatives(proxyShapePathStr, parent=1)[0]
+        self.assertTrue(proxyShapeParentPathStr)
+
+        # Duplicate the Maya transform parent that is holding the proxy shape.
+        cmds.select(proxyShapePathStr)
+        duplicatedNodesPathStr = cmds.duplicate()
+
+        # Extract the new proxy shape parent path from the duplicate command results.
+        self.assertEqual(len(duplicatedNodesPathStr), 1)
+        newProxyShapeParentPathStr = duplicatedNodesPathStr[0]
+        self.assertTrue(proxyShapeParentPathStr)
+
+        # Verify there is a stage below the new proxy parent.
+        newProxyShapePathStr = proxyShapePathStr.replace(proxyShapeParentPathStr, newProxyShapeParentPathStr)
+        self.assertNotEqual(newProxyShapePathStr, proxyShapePathStr)
+
+        # Retrieve the new USD stage
+        newUsdStage = mayaUsd.lib.GetPrim(newProxyShapePathStr).GetStage()
+        self.assertTrue(newUsdStage)
+
+        cmds.file(rename='DuplicateProxyShapeTest.ma')
+        cmds.file(save=True, force=True)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The crash occurred in deeply nested callbacks-within-callbacks. There were attributes being set which triggered dirtynes, which triggered computation, which triggered atribute updates, which triggered proxy accessor, etc. In the end, some code accessed the proxy shape Maya node while it was not in a valid state to be accessed.

The ultimate cause was that, surprinsingly, never during the duplication of a node does the node has its final name, in any of the usual callbacks. During the postConstruct callback, it doesn't have a name. During the copyInternal callback, it does not have a name. But the proxy shape wants to know its ownname when it registers some callbacks. The end-result was that during save, the node was discovering that it had a new name and it brought the house down.

The fix is to be notified about node naming and renaming as soon as they happen. As such, a callback when renamed is added that fixes the issue.

Also, discovered that the way the stage were held during saving was insecure because they used weak pointer that could become null. Use a referencing pointer instead to avoid losing stages mid-save.

Add a unit test for the crash condition.