### PR TITLE
Update helpTableMayaUSD

### DIFF
--- a/lib/mayaUsd/resources/helpTable/helpTableMayaUSD
+++ b/lib/mayaUsd/resources/helpTable/helpTableMayaUSD
@@ -2,8 +2,8 @@ UsdEditDuplicateAsMaya
 ?contextId=UsdEditDuplicateAsMaya
 UsdHierarchyView
 ?contextId=UsdHierarchyView
-UsdAddReferenceConfig 
-?contextId=UsdAddReferenceConfig 
+UsdAddReferenceConfig
+?contextId=UsdAddReferenceConfig
 UsdImportOptionsConfig
 ?contextId=UsdImportOptionsConfig
 UsdLayerEditor


### PR DESCRIPTION
fixing small issue with one extra space at the end of the help table item, causing the contextID not to be found.