### PR TITLE
Add missing include

### DIFF
--- a/lib/mayaUsd/fileio/primReaderRegistry.h
+++ b/lib/mayaUsd/fileio/primReaderRegistry.h
@@ -24,6 +24,7 @@
 #include <pxr/base/plug/registry.h>
 #include <pxr/base/tf/registryManager.h>
 #include <pxr/pxr.h>
+#include <pxr/usd/usd/schemaBase.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
 


### PR DESCRIPTION
This include is required for the Usd Type reader registry definition. The include was being picked up at the callsite