### PR TITLE
EMS-789 apply restrictions for activation and instanceable

### DIFF
--- a/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
@@ -20,6 +20,7 @@ import fnmatch
 from functools import partial
 import re
 import ufe
+import usdUfe
 import maya.mel as mel
 import maya.cmds as cmds
 import mayaUsd.ufe as mayaUsdUfe
@@ -221,11 +222,23 @@ class MetaDataCustomControl(object):
 
     def _onActiveChanged(self, value):
         with mayaUsdLib.UsdUndoBlock():
-            self.prim.SetActive(value)
+            try:
+                usdUfe.ToggleActiveCommand(self.prim).execute()
+            except Exception as ex:
+                # Note: the command might not work because there is a stronger
+                #       opinion, so update the checkbox.
+                cmds.checkBoxGrp(self.active, edit=True, value1=self.prim.IsActive())
+                cmds.error(str(ex))
 
     def _onInstanceableChanged(self, value):
         with mayaUsdLib.UsdUndoBlock():
-            self.prim.SetInstanceable(value)
+            try:
+                usdUfe.ToggleInstanceableCommand(self.prim).execute()
+            except Exception as ex:
+                # Note: the command might not work because there is a stronger
+                #       opinion, so update the checkbox.
+                cmds.checkBoxGrp(self.instan, edit=True, value1=self.prim.IsInstanceable())
+                cmds.error(str(ex))
 
 # Custom control for all array attribute.
 class ArrayCustomControl(object):

--- a/lib/usdUfe/ufe/UsdUndoToggleActiveCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoToggleActiveCommand.cpp
@@ -18,6 +18,8 @@
 
 #include "private/UfeNotifGuard.h"
 
+#include <usdUfe/ufe/Utils.h>
+
 namespace USDUFE_NS_DEF {
 
 UsdUndoToggleActiveCommand::UsdUndoToggleActiveCommand(const PXR_NS::UsdPrim& prim)
@@ -34,6 +36,14 @@ void UsdUndoToggleActiveCommand::executeImplementation()
     PXR_NS::UsdPrim prim = _stage->GetPrimAtPath(_primPath);
     if (!prim.IsValid())
         return;
+
+    std::string errMsg;
+    if (!UsdUfe::isPrimMetadataEditAllowed(
+            prim, PXR_NS::SdfFieldKeys->Active, PXR_NS::TfToken(), &errMsg)) {
+        // Note: we don't throw an exception because this would break bulk actions.
+        TF_RUNTIME_ERROR(errMsg);
+        return;
+    }
 
     UsdUfe::InAddOrDeleteOperation ad;
     prim.SetActive(!prim.IsActive());

--- a/lib/usdUfe/ufe/UsdUndoToggleInstanceableCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoToggleInstanceableCommand.cpp
@@ -16,6 +16,8 @@
 
 #include "UsdUndoToggleInstanceableCommand.h"
 
+#include <usdUfe/ufe/Utils.h>
+
 namespace USDUFE_NS_DEF {
 
 UsdUndoToggleInstanceableCommand::UsdUndoToggleInstanceableCommand(const PXR_NS::UsdPrim& prim)
@@ -32,6 +34,14 @@ void UsdUndoToggleInstanceableCommand::executeImplementation()
     PXR_NS::UsdPrim prim = _stage->GetPrimAtPath(_primPath);
     if (!prim.IsValid())
         return;
+
+    std::string errMsg;
+    if (!UsdUfe::isPrimMetadataEditAllowed(
+            prim, PXR_NS::SdfFieldKeys->Instanceable, PXR_NS::TfToken(), &errMsg)) {
+        // Note: we don't throw an exception because this would break bulk actions.
+        TF_RUNTIME_ERROR(errMsg);
+        return;
+    }
 
     prim.SetInstanceable(!prim.IsInstanceable());
 }


### PR DESCRIPTION
(This also covers EMSUSD-790.)

- Make the internal commands used to toggle activation or instanceable flag enfore edit restrictions.
- Make the corresponding code in the attribute editor also use these commands.
- Add unit tests for the new restrictions.