### PR TITLE
EMSUSD-603 - Errors when trying to cache a rig with merge transforms ON and namespaces OFF

### DIFF
--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -195,7 +195,8 @@ SdfPath UsdMayaWriteJobContext::ConvertDagToUsdPath(const MDagPath& dagPath) con
     // write to the parent (transform) path instead.
     MDagPath parentDag(dagPath);
     parentDag.pop();
-    if (IsMergedTransform(parentDag)) {
+
+    if (IsMergedTransform(parentDag) && UsdMayaUtil::isShape(dagPath)) {
         path = path.GetParentPath();
     }
 

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -1317,7 +1317,7 @@ MPlug UsdMayaUtil::FindChildPlugByName(const MPlug& plug, const MString& name)
 
 // XXX: see logic in UsdMayaTransformWriter.  It's unfortunate that this
 // logic is in 2 places.  we should merge.
-static bool _IsShape(const MDagPath& dagPath)
+bool UsdMayaUtil::isShape(const MDagPath& dagPath)
 {
     if (dagPath.hasFn(MFn::kTransform)) {
         return false;
@@ -1362,7 +1362,7 @@ SdfPath UsdMayaUtil::MDagPathToUsdPath(
     SdfPath usdPath
         = UsdMayaUtil::MayaNodeNameToSdfPath(dagPath.fullPathName().asChar(), stripNamespaces);
 
-    if (mergeTransformAndShape && _IsShape(dagPath)) {
+    if (mergeTransformAndShape && isShape(dagPath)) {
         usdPath = usdPath.GetParentPath();
     }
 

--- a/lib/mayaUsd/utils/util.h
+++ b/lib/mayaUsd/utils/util.h
@@ -690,6 +690,8 @@ void AddMayaExtents(
 MAYAUSD_CORE_PUBLIC
 SdrShaderNodePtrVec GetSurfaceShaderNodeDefs();
 
+bool isShape(const MDagPath& dagPath);
+
 } // namespace UsdMayaUtil
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/utils/util.h
+++ b/lib/mayaUsd/utils/util.h
@@ -690,6 +690,7 @@ void AddMayaExtents(
 MAYAUSD_CORE_PUBLIC
 SdrShaderNodePtrVec GetSurfaceShaderNodeDefs();
 
+MAYAUSD_CORE_PUBLIC
 bool isShape(const MDagPath& dagPath);
 
 } // namespace UsdMayaUtil

--- a/test/lib/mayaUsd/fileio/testCacheToUsd.py
+++ b/test/lib/mayaUsd/fileio/testCacheToUsd.py
@@ -471,8 +471,6 @@ class CacheToUsdTestCase(unittest.TestCase):
         value = xformOp.Get()
         self.assertIn("xformOp:translate", value)
         self.assertIn("xformOp:rotateXYZ", value)
-        self.assertIn("xformOp:translate:channel1", value)
-        self.assertIn("xformOp:rotateXYZ:channel1", value)
         
     def runTestMayaRefPrimTransform(self, createMayaRefPrimFn, checkCacheParentFn):
         '''


### PR DESCRIPTION
- The issue is caused by transforms merged to parent node, which will cause a mismatch between SDF and DAG paths and ultimately cause clashes. We should only write to the node's parent node when it a shape node.
- Removed the `channel1` part of the unity test because that attribute is created because of the bug above. I compared the cache to usd result to a normal export and the files matches (there's no `channel1 ` in normal export usd files)