### PR TITLE
LOOKDEVX-2260 - Add a third party naming convention for shader outliner icons

### DIFF
--- a/lib/mayaUsd/ufe/MayaUsdUIInfoHandler.cpp
+++ b/lib/mayaUsd/ufe/MayaUsdUIInfoHandler.cpp
@@ -15,8 +15,19 @@
 //
 #include "MayaUsdUIInfoHandler.h"
 
+#include <pxr/base/arch/fileSystem.h>
+#include <pxr/base/tf/getenv.h>
+#include <pxr/usd/ar/defaultResolverContext.h>
+#include <pxr/usd/ar/resolver.h>
+#include <pxr/usd/ar/resolverContextBinder.h>
+
 #include <maya/MDoubleArray.h>
 #include <maya/MGlobal.h>
+#include <ufe/nodeDef.h>
+#include <ufe/nodeDefHandler.h>
+#include <ufe/runTimeMgr.h>
+
+#include <algorithm>
 
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
@@ -86,6 +97,69 @@ UsdUfe::UsdUIInfoHandler::SupportedTypesMap MayaUsdUIInfoHandler::getSupportedIc
     };
     supportedTypes.insert(mayaSupportedTypes.begin(), mayaSupportedTypes.end());
     return supportedTypes;
+}
+
+Ufe::UIInfoHandler::Icon
+MayaUsdUIInfoHandler::treeViewIcon(const Ufe::SceneItem::Ptr& mayaItem) const
+{
+    Ufe::UIInfoHandler::Icon icon = Parent::treeViewIcon(mayaItem);
+
+    if (icon.baseIcon == "out_USD_Shader.png") {
+        // Naming convention for third party shader outliner icons:
+        //
+        //  We take the info:id of the shader and make it safe by replacing : with _.
+        //  Then we search the Maya icon paths for a PNG file with that name. If found we will use
+        //  it. Please note that files with _150 and _200 can also be provided for high DPI
+        //  displays.
+        //
+        //   For example an info:id of:
+        //       MyRenderer:nifty_surface
+        //   Will have this code search the full Maya icon path for a file named:
+        //       MyRenderer_nifty_surface.png
+        //   And will use it if found. At resolution 200%, the file:
+        //       MyRenderer_nifty_surface_200.png
+        //   Will alternatively be used if found.
+        //
+        const auto nodeDefHandler
+            = Ufe::RunTimeMgr::instance().nodeDefHandler(mayaItem->runTimeId());
+        if (!nodeDefHandler) {
+            return icon;
+        }
+        const auto nodeDef = nodeDefHandler->definition(mayaItem);
+        if (!nodeDef || nodeDef->type().empty()) {
+            return icon;
+        }
+
+        std::string iconName = nodeDef->type();
+        std::replace(iconName.begin(), iconName.end(), ':', '_');
+        iconName += ".png";
+
+        // Since this will be hitting the filesystem hard, mostly to find nothing, let's cache
+        // search results. Note that "XBMLANGPATH" is Maya specific, which is why the code is here
+        // and not in the base class.
+        static const auto iconContext = PXR_NS::ArDefaultResolverContext(
+            PXR_NS::TfStringSplit(PXR_NS::TfGetenv("XBMLANGPATH", ""), ARCH_PATH_LIST_SEP));
+
+        static std::unordered_map<std::string, bool> sSearchCache;
+        auto                                         cachedHit = sSearchCache.find(iconName);
+        if (cachedHit != sSearchCache.end()) {
+            if (cachedHit->second) {
+                icon.baseIcon = iconName;
+            }
+        } else {
+            // Would be better using MQtUtil::createPixmap, but this requires linking against
+            // QtCore.
+            PXR_NS::ArResolverContextBinder binder(iconContext);
+            if (!PXR_NS::ArGetResolver().Resolve(iconName).empty()) {
+                icon.baseIcon = iconName;
+                sSearchCache.insert({ iconName, true });
+            } else {
+                sSearchCache.insert({ iconName, false });
+            }
+        }
+    }
+
+    return icon;
 }
 
 } // namespace ufe

--- a/lib/mayaUsd/ufe/MayaUsdUIInfoHandler.cpp
+++ b/lib/mayaUsd/ufe/MayaUsdUIInfoHandler.cpp
@@ -206,10 +206,11 @@ MayaUsdUIInfoHandler::treeViewIcon(const Ufe::SceneItem::Ptr& mayaItem) const
         //
         //   For example an info:id of:
         //       MyRenderer:nifty_surface
-        //   Will have this code search the full Maya icon path for a file named:
-        //       MyRenderer_nifty_surface.png
+        //   On a USD runtime item will have this code search the full Maya icon path for a file
+        //   named:
+        //       out_USD_MyRenderer_nifty_surface.png
         //   And will use it if found. At resolution 200%, the file:
-        //       MyRenderer_nifty_surface_200.png
+        //       out_USD_MyRenderer_nifty_surface_200.png
         //   Will alternatively be used if found.
         //
         const auto nodeDefHandler
@@ -222,7 +223,9 @@ MayaUsdUIInfoHandler::treeViewIcon(const Ufe::SceneItem::Ptr& mayaItem) const
             return icon;
         }
 
-        std::string iconName = nodeDef->type();
+        constexpr auto outlinerPrefix = "out_";
+        const auto     runtimeName = Ufe::RunTimeMgr::instance().getName(mayaItem->runTimeId());
+        std::string    iconName = outlinerPrefix + runtimeName + "_" + nodeDef->type();
         std::replace(iconName.begin(), iconName.end(), ':', '_');
         iconName += ".png";
 

--- a/lib/mayaUsd/ufe/MayaUsdUIInfoHandler.cpp
+++ b/lib/mayaUsd/ufe/MayaUsdUIInfoHandler.cpp
@@ -121,28 +121,28 @@ public:
         // Since this will be hitting the filesystem hard, mostly to find nothing, let's cache
         // search results. Note that "XBMLANGPATH" is Maya specific, which is why the code is here
         // and not in the base class.
-        auto cachedHit = m_searchCache.find(iconName);
-        if (cachedHit != m_searchCache.end()) {
+        auto cachedHit = _searchCache.find(iconName);
+        if (cachedHit != _searchCache.end()) {
             return cachedHit->second;
         }
 
         // Would be better using MQtUtil::createPixmap, but this requires linking against
         // QtCore.
-        PXR_NS::ArResolverContextBinder binder(m_iconContext);
+        PXR_NS::ArResolverContextBinder binder(_iconContext);
         if (!PXR_NS::ArGetResolver().Resolve(iconName).empty()) {
-            m_searchCache.insert({ iconName, true });
+            _searchCache.insert({ iconName, true });
             return true;
         }
 
-        m_searchCache.insert({ iconName, false });
+        _searchCache.insert({ iconName, false });
         return false;
     }
 
     void ResetCache()
     {
-        m_iconContext = PXR_NS::ArDefaultResolverContext(
+        _iconContext = PXR_NS::ArDefaultResolverContext(
             PXR_NS::TfStringSplit(PXR_NS::TfGetenv("XBMLANGPATH", ""), ARCH_PATH_LIST_SEP));
-        m_searchCache.clear();
+        _searchCache.clear();
     }
 
     static void OnPluginStateChange(const MStringArray& /*strs*/, void* /*clientData*/)
@@ -152,17 +152,17 @@ public:
 
     void Terminate()
     {
-        if (m_pluginLoadCB) {
-            MMessage::removeCallback(m_pluginLoadCB);
-            m_pluginLoadCB = 0;
+        if (_pluginLoadCB) {
+            MMessage::removeCallback(_pluginLoadCB);
+            _pluginLoadCB = 0;
         }
-        if (m_pluginUnloadCB) {
-            MMessage::removeCallback(m_pluginUnloadCB);
-            m_pluginLoadCB = 0;
+        if (_pluginUnloadCB) {
+            MMessage::removeCallback(_pluginUnloadCB);
+            _pluginLoadCB = 0;
         }
-        if (m_beforeExitCB) {
-            MMessage::removeCallback(m_beforeExitCB);
-            m_beforeExitCB = 0;
+        if (_beforeExitCB) {
+            MMessage::removeCallback(_beforeExitCB);
+            _beforeExitCB = 0;
         }
     }
 
@@ -174,18 +174,18 @@ private:
         ResetCache();
 
         // Set up callback to notify of plugin load and unload
-        m_pluginLoadCB = MSceneMessage::addStringArrayCallback(
+        _pluginLoadCB = MSceneMessage::addStringArrayCallback(
             MSceneMessage::kAfterPluginLoad, OnPluginStateChange);
-        m_pluginUnloadCB = MSceneMessage::addStringArrayCallback(
+        _pluginUnloadCB = MSceneMessage::addStringArrayCallback(
             MSceneMessage::kAfterPluginUnload, OnPluginStateChange);
-        m_beforeExitCB = MSceneMessage::addCallback(MSceneMessage::kMayaExiting, OnTerminateCache);
+        _beforeExitCB = MSceneMessage::addCallback(MSceneMessage::kMayaExiting, OnTerminateCache);
     }
 
-    PXR_NS::ArDefaultResolverContext      m_iconContext;
-    std::unordered_map<std::string, bool> m_searchCache;
-    MCallbackId                           m_pluginLoadCB = 0;
-    MCallbackId                           m_pluginUnloadCB = 0;
-    MCallbackId                           m_beforeExitCB = 0;
+    PXR_NS::ArDefaultResolverContext      _iconContext;
+    std::unordered_map<std::string, bool> _searchCache;
+    MCallbackId                           _pluginLoadCB = 0;
+    MCallbackId                           _pluginUnloadCB = 0;
+    MCallbackId                           _beforeExitCB = 0;
 };
 } // namespace
 #endif

--- a/lib/mayaUsd/ufe/MayaUsdUIInfoHandler.h
+++ b/lib/mayaUsd/ufe/MayaUsdUIInfoHandler.h
@@ -46,6 +46,7 @@ public:
     static MayaUsdUIInfoHandler::Ptr create();
 
     UsdUfe::UsdUIInfoHandler::SupportedTypesMap getSupportedIconTypes() const override;
+    Ufe::UIInfoHandler::Icon treeViewIcon(const Ufe::SceneItem::Ptr& item) const override;
 
 private:
     void updateInvisibleColor();

--- a/lib/usdUfe/ufe/UsdUIInfoHandler.cpp
+++ b/lib/usdUfe/ufe/UsdUIInfoHandler.cpp
@@ -17,15 +17,9 @@
 
 #include <usdUfe/ufe/UsdSceneItem.h>
 
-#include <pxr/base/arch/fileSystem.h>
-#include <pxr/base/tf/getenv.h>
-#include <pxr/usd/ar/defaultResolverContext.h>
-#include <pxr/usd/ar/resolver.h>
-#include <pxr/usd/ar/resolverContextBinder.h>
 #include <pxr/usd/sdf/listOp.h> // SdfReferenceListOp/SdfPayloadListOp/SdfPathListOp
 #include <pxr/usd/sdf/schema.h> // SdfFieldKeys
 #include <pxr/usd/usd/variantSets.h>
-#include <pxr/usd/usdShade/shader.h>
 
 #include <map>
 #include <vector>
@@ -185,51 +179,6 @@ Ufe::UIInfoHandler::Icon UsdUIInfoHandler::treeViewIcon(const Ufe::SceneItem::Pt
                     icon.badgeIcon = "out_USD_CompArcBadge.png";
                     icon.pos = Ufe::UIInfoHandler::LowerRight;
                     break;
-                }
-            }
-        }
-    }
-
-    // Naming convention for third party shader outliner icons:
-    //
-    //  We take the info:id of the shader and make it safe by replacing : with _.
-    //  Then we search the Maya icon paths for a PNG file with that name. If found we will use it.
-    //  Please note that files with _150 and _200 can also be provided for high DPI displays.
-    //
-    //   For example an info:id of:
-    //       MyRenderer:nifty_surface
-    //   Will have this code search the full Maya icon path for a file named:
-    //       MyRenderer_nifty_surface.png
-    //   And will use it if found. At resolution 200%, the file:
-    //       MyRenderer_nifty_surface_200.png
-    //   Will alternatively be used if found.
-    //
-    if (auto shaderSchema = PXR_NS::UsdShadeShader(usdItem->prim())) {
-        static const auto iconContext = PXR_NS::ArDefaultResolverContext(
-            PXR_NS::TfStringSplit(PXR_NS::TfGetenv("XBMLANGPATH", ""), ARCH_PATH_LIST_SEP));
-        PXR_NS::TfToken shaderId;
-        shaderSchema.GetIdAttr().Get(&shaderId);
-        if (!shaderId.IsEmpty()) {
-            PXR_NS::ArResolverContextBinder binder(iconContext);
-
-            std::string iconName = shaderId.GetString();
-            std::replace(iconName.begin(), iconName.end(), ':', '_');
-            iconName += ".png";
-
-            // Since this will be hitting the filesystem hard, mostly to find nothing, let's cache
-            // search results.
-            static std::unordered_map<std::string, bool> sSearchCache;
-            auto                                         cachedHit = sSearchCache.find(iconName);
-            if (cachedHit != sSearchCache.end()) {
-                if (cachedHit->second) {
-                    icon.baseIcon = iconName;
-                }
-            } else {
-                if (!PXR_NS::ArGetResolver().Resolve(iconName).empty()) {
-                    icon.baseIcon = iconName;
-                    sSearchCache.insert({ iconName, true });
-                } else {
-                    sSearchCache.insert({ iconName, false });
                 }
             }
         }

--- a/lib/usdUfe/ufe/UsdUIInfoHandler.cpp
+++ b/lib/usdUfe/ufe/UsdUIInfoHandler.cpp
@@ -194,7 +194,7 @@ Ufe::UIInfoHandler::Icon UsdUIInfoHandler::treeViewIcon(const Ufe::SceneItem::Pt
     //
     //  We take the info:id of the shader and make it safe by replacing : with _.
     //  Then we search the Maya icon paths for a PNG file with that name. If found we will use it.
-    //  Please note that files with _150 ad _200 can also be provided for high DPI displays.
+    //  Please note that files with _150 and _200 can also be provided for high DPI displays.
     //
     //   For example an info:id of:
     //       MyRenderer:nifty_surface

--- a/lib/usdUfe/ufe/UsdUIInfoHandler.cpp
+++ b/lib/usdUfe/ufe/UsdUIInfoHandler.cpp
@@ -216,8 +216,21 @@ Ufe::UIInfoHandler::Icon UsdUIInfoHandler::treeViewIcon(const Ufe::SceneItem::Pt
             std::replace(iconName.begin(), iconName.end(), ':', '_');
             iconName += ".png";
 
-            if (!PXR_NS::ArGetResolver().Resolve(iconName).empty()) {
-                icon.baseIcon = iconName;
+            // Since this will be hitting the filesystem hard, mostly to find nothing, let's cache
+            // search results.
+            static std::unordered_map<std::string, bool> sSearchCache;
+            auto                                         cachedHit = sSearchCache.find(iconName);
+            if (cachedHit != sSearchCache.end()) {
+                if (cachedHit->second) {
+                    icon.baseIcon = iconName;
+                }
+            } else {
+                if (!PXR_NS::ArGetResolver().Resolve(iconName).empty()) {
+                    icon.baseIcon = iconName;
+                    sSearchCache.insert({ iconName, true });
+                } else {
+                    sSearchCache.insert({ iconName, false });
+                }
             }
         }
     }

--- a/lib/usdUfe/ufe/UsdUIInfoHandler.cpp
+++ b/lib/usdUfe/ufe/UsdUIInfoHandler.cpp
@@ -17,9 +17,15 @@
 
 #include <usdUfe/ufe/UsdSceneItem.h>
 
+#include <pxr/base/arch/fileSystem.h>
+#include <pxr/base/tf/getenv.h>
+#include <pxr/usd/ar/defaultResolverContext.h>
+#include <pxr/usd/ar/resolver.h>
+#include <pxr/usd/ar/resolverContextBinder.h>
 #include <pxr/usd/sdf/listOp.h> // SdfReferenceListOp/SdfPayloadListOp/SdfPathListOp
 #include <pxr/usd/sdf/schema.h> // SdfFieldKeys
 #include <pxr/usd/usd/variantSets.h>
+#include <pxr/usd/usdShade/shader.h>
 
 #include <map>
 #include <vector>
@@ -180,6 +186,38 @@ Ufe::UIInfoHandler::Icon UsdUIInfoHandler::treeViewIcon(const Ufe::SceneItem::Pt
                     icon.pos = Ufe::UIInfoHandler::LowerRight;
                     break;
                 }
+            }
+        }
+    }
+
+    // Naming convention for third party shader outliner icons:
+    //
+    //  We take the info:id of the shader and make it safe by replacing : with _.
+    //  Then we search the Maya icon paths for a PNG file with that name. If found we will use it.
+    //  Please note that files with _150 ad _200 can also be provided for high DPI displays.
+    //
+    //   For example an info:id of:
+    //       MyRenderer:nifty_surface
+    //   Will have this code search the full Maya icon path for a file named:
+    //       MyRenderer_nifty_surface.png
+    //   And will use it if found. At resolution 200%, the file:
+    //       MyRenderer_nifty_surface_200.png
+    //   Will alternatively be used if found.
+    //
+    if (auto shaderSchema = PXR_NS::UsdShadeShader(usdItem->prim())) {
+        static const auto iconContext = PXR_NS::ArDefaultResolverContext(
+            PXR_NS::TfStringSplit(PXR_NS::TfGetenv("XBMLANGPATH", ""), ARCH_PATH_LIST_SEP));
+        PXR_NS::TfToken shaderId;
+        shaderSchema.GetIdAttr().Get(&shaderId);
+        if (!shaderId.IsEmpty()) {
+            PXR_NS::ArResolverContextBinder binder(iconContext);
+
+            std::string iconName = shaderId.GetString();
+            std::replace(iconName.begin(), iconName.end(), ':', '_');
+            iconName += ".png";
+
+            if (!PXR_NS::ArGetResolver().Resolve(iconName).empty()) {
+                icon.baseIcon = iconName;
             }
         }
     }


### PR DESCRIPTION
Allows any renderer like Arnold, VRay, or RenderMan to provide outliner icons for their custom nodes.