### PR TITLE
Pr/deprecate boost optional for sdf copy spec

### DIFF
--- a/lib/usd/utils/MergePrims.cpp
+++ b/lib/usd/utils/MergePrims.cpp
@@ -456,17 +456,17 @@ bool isDataAtPathsModified(
 //----------------------------------------------------------------------------------------------------------------------
 /// Decides if we should merge a value.
 bool shouldMergeValue(
-    const MergeContext&       ctx,
-    SdfSpecType               specType,
-    const TfToken&            field,
-    const SdfLayerHandle&     srcLayer,
-    const SdfPath&            srcPath,
-    bool                      fieldInSrc,
-    const SdfLayerHandle&     dstLayer,
-    const SdfPath&            dstPath,
-    bool                      fieldInDst,
-#if PXR_VERSION >= 2311
-    std::optional<VtValue>*   valueToCopy)
+    const MergeContext&   ctx,
+    SdfSpecType           specType,
+    const TfToken&        field,
+    const SdfLayerHandle& srcLayer,
+    const SdfPath&        srcPath,
+    bool                  fieldInSrc,
+    const SdfLayerHandle& dstLayer,
+    const SdfPath&        dstPath,
+    bool                  fieldInDst,
+#if PXR_VERSION > 2311
+    std::optional<VtValue>* valueToCopy)
 #else
     boost::optional<VtValue>* valueToCopy)
 #endif
@@ -870,17 +870,17 @@ bool filterChildren(
 //----------------------------------------------------------------------------------------------------------------------
 /// Decides if we should merge children.
 bool shouldMergeChildren(
-    const MergeContext&       ctx,
-    const TfToken&            childrenField,
-    const SdfLayerHandle&     srcLayer,
-    const SdfPath&            srcPath,
-    bool                      fieldInSrc,
-    const SdfLayerHandle&     dstLayer,
-    const SdfPath&            dstPath,
-    bool                      fieldInDst,
-#if PXR_VERSION >= 2311
-    std::optional<VtValue>*   srcChildren,
-    std::optional<VtValue>*   dstChildren)
+    const MergeContext&   ctx,
+    const TfToken&        childrenField,
+    const SdfLayerHandle& srcLayer,
+    const SdfPath&        srcPath,
+    bool                  fieldInSrc,
+    const SdfLayerHandle& dstLayer,
+    const SdfPath&        dstPath,
+    bool                  fieldInDst,
+#if PXR_VERSION > 2311
+    std::optional<VtValue>* srcChildren,
+    std::optional<VtValue>* dstChildren)
 #else
     boost::optional<VtValue>* srcChildren,
     boost::optional<VtValue>* dstChildren)

--- a/lib/usd/utils/MergePrims.cpp
+++ b/lib/usd/utils/MergePrims.cpp
@@ -465,7 +465,11 @@ bool shouldMergeValue(
     const SdfLayerHandle&     dstLayer,
     const SdfPath&            dstPath,
     bool                      fieldInDst,
+#if PXR_VERSION >= 2311
+    std::optional<VtValue>*   valueToCopy)
+#else
     boost::optional<VtValue>* valueToCopy)
+#endif
 {
     const bool isCopiable = SdfShouldCopyValue(
         ctx.srcRootPath,
@@ -874,8 +878,13 @@ bool shouldMergeChildren(
     const SdfLayerHandle&     dstLayer,
     const SdfPath&            dstPath,
     bool                      fieldInDst,
+#if PXR_VERSION >= 2311
+    std::optional<VtValue>*   srcChildren,
+    std::optional<VtValue>*   dstChildren)
+#else
     boost::optional<VtValue>* srcChildren,
     boost::optional<VtValue>* dstChildren)
+#endif
 {
     const bool shouldMerge = SdfShouldCopyChildren(
         ctx.srcRootPath,


### PR DESCRIPTION
The USD team is phasing out usage of boost::optional. This updates the callsites for the upcoming switch in SdfCopySpec