### PR TITLE
EMSUSD-671 Remove the load payloads proxy shape attribute

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -474,18 +474,18 @@ MStatus MayaUsdProxyShapeBase::initialize()
     retValue = attributeAffects(primPathAttr, outStageCacheIdAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
-    retValue = attributeAffects(loadPayloadsAttr, inStageDataCachedAttr);
-    CHECK_MSTATUS_AND_RETURN_IT(retValue);
-    retValue = attributeAffects(loadPayloadsAttr, outStageDataAttr);
-    CHECK_MSTATUS_AND_RETURN_IT(retValue);
-    retValue = attributeAffects(loadPayloadsAttr, outStageCacheIdAttr);
-    CHECK_MSTATUS_AND_RETURN_IT(retValue);
-
     retValue = attributeAffects(shareStageAttr, inStageDataCachedAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
     retValue = attributeAffects(shareStageAttr, outStageDataAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
     retValue = attributeAffects(shareStageAttr, outStageCacheIdAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+    retValue = attributeAffects(loadPayloadsAttr, inStageDataCachedAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+    retValue = attributeAffects(loadPayloadsAttr, outStageDataAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+    retValue = attributeAffects(loadPayloadsAttr, outStageCacheIdAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
     retValue = attributeAffects(inStageDataAttr, inStageDataCachedAttr);
@@ -1104,8 +1104,8 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
         CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
         // Apply the payload rules based on either the saved payload rules
-        // dynamic attribute containing the exact load rules for payload.
-        // If no such attribute exists, load everything.
+        // dynamic attribute containing the exact load rules for payload,
+        // or the load-payload attribute.
         if (hasLoadRulesAttribute(*this)) {
             copyLoadRulesFromAttribute(*this, *finalUsdStage);
         } else {

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -141,6 +141,7 @@ MObject MayaUsdProxyShapeBase::filePathAttr;
 MObject MayaUsdProxyShapeBase::filePathRelativeAttr;
 MObject MayaUsdProxyShapeBase::primPathAttr;
 MObject MayaUsdProxyShapeBase::excludePrimPathsAttr;
+MObject MayaUsdProxyShapeBase::loadPayloadsAttr;
 MObject MayaUsdProxyShapeBase::shareStageAttr;
 MObject MayaUsdProxyShapeBase::timeAttr;
 MObject MayaUsdProxyShapeBase::complexityAttr;
@@ -276,6 +277,17 @@ MStatus MayaUsdProxyShapeBase::initialize()
     typedAttrFn.setAffectsAppearance(true);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
     retValue = addAttribute(excludePrimPathsAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+    loadPayloadsAttr
+        = numericAttrFn.create("loadPayloads", "lpl", MFnNumericData::kBoolean, 1.0, &retValue);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+    numericAttrFn.setKeyable(false);
+    numericAttrFn.setReadable(false);
+    numericAttrFn.setInternal(true);
+    numericAttrFn.setHidden(true);
+    numericAttrFn.setAffectsAppearance(true);
+    retValue = addAttribute(loadPayloadsAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
     shareStageAttr
@@ -460,6 +472,13 @@ MStatus MayaUsdProxyShapeBase::initialize()
     retValue = attributeAffects(primPathAttr, outStageDataAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
     retValue = attributeAffects(primPathAttr, outStageCacheIdAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+    retValue = attributeAffects(loadPayloadsAttr, inStageDataCachedAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+    retValue = attributeAffects(loadPayloadsAttr, outStageDataAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+    retValue = attributeAffects(loadPayloadsAttr, outStageCacheIdAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
     retValue = attributeAffects(shareStageAttr, inStageDataCachedAttr);
@@ -1081,13 +1100,20 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
 
     if (finalUsdStage) {
         // Compute the load set for the stage.
+        MDataHandle loadPayloadsHandle = dataBlock.inputValue(loadPayloadsAttr, &retValue);
+        CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
         // Apply the payload rules based on either the saved payload rules
         // dynamic attribute containing the exact load rules for payload.
         // If no such attribute exists, load everything.
         if (hasLoadRulesAttribute(*this)) {
             copyLoadRulesFromAttribute(*this, *finalUsdStage);
         } else {
-            finalUsdStage->Load(SdfPath("/"), UsdLoadPolicy::UsdLoadWithDescendants);
+            if (loadPayloadsHandle.asBool()) {
+                finalUsdStage->Load(SdfPath("/"), UsdLoadPolicy::UsdLoadWithDescendants);
+            } else {
+                finalUsdStage->Unload(SdfPath("/"));
+            }
         }
 
         primPath = finalUsdStage->GetPseudoRoot().GetPath();
@@ -1126,9 +1152,9 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
 UsdStageRefPtr MayaUsdProxyShapeBase::getUnsharedStage(UsdStage::InitialLoadSet loadSet)
 {
     // The unshared stages are *also* kept in a stage cache so that we can find them
-    // again when proxy shape attribute change. For example, if the payloads loading
-    // change, we want to find the same unshared stage, we don't want to lose edits,
-    // in particular in its session layer.
+    // again when proxy shape attribute change. For example, if the 'loadPayloads'
+    // attribute change, we want to find the same unshared stage, we don't want to lose
+    // edits, in particular in its session layer.
     //
     // We also need to be able to find them when switching a stage between non-shared
     // and shared, so that we can transfer the content of the session layer.
@@ -1636,6 +1662,7 @@ MStatus MayaUsdProxyShapeBase::preEvaluation(
             // All the plugs that affect outStageDataAttr
             evaluationNode.dirtyPlugExists(filePathAttr)
             || evaluationNode.dirtyPlugExists(primPathAttr)
+            || evaluationNode.dirtyPlugExists(loadPayloadsAttr)
             || evaluationNode.dirtyPlugExists(shareStageAttr)
             || evaluationNode.dirtyPlugExists(inStageDataAttr)
             || evaluationNode.dirtyPlugExists(stageCacheIdAttr)) {
@@ -1689,8 +1716,8 @@ MStatus MayaUsdProxyShapeBase::setDependentsDirty(const MPlug& plug, MPlugArray&
     } else if (
         plug == outStageDataAttr ||
         // All the plugs that affect outStageDataAttr
-        plug == filePathAttr || plug == primPathAttr || plug == shareStageAttr
-        || plug == inStageDataAttr || plug == stageCacheIdAttr) {
+        plug == filePathAttr || plug == primPathAttr || plug == loadPayloadsAttr
+        || plug == shareStageAttr || plug == inStageDataAttr || plug == stageCacheIdAttr) {
         _IncreaseUsdStageVersion();
         MayaUsdProxyStageInvalidateNotice(*this).Send();
     }

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -91,8 +91,6 @@ public:
     MAYAUSD_CORE_PUBLIC
     static MObject excludePrimPathsAttr;
     MAYAUSD_CORE_PUBLIC
-    static MObject loadPayloadsAttr;
-    MAYAUSD_CORE_PUBLIC
     static MObject shareStageAttr;
     MAYAUSD_CORE_PUBLIC
     static MObject timeAttr;

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -91,6 +91,8 @@ public:
     MAYAUSD_CORE_PUBLIC
     static MObject excludePrimPathsAttr;
     MAYAUSD_CORE_PUBLIC
+    static MObject loadPayloadsAttr;
+    MAYAUSD_CORE_PUBLIC
     static MObject shareStageAttr;
     MAYAUSD_CORE_PUBLIC
     static MObject timeAttr;

--- a/lib/mayaUsd/python/CMakeLists.txt
+++ b/lib/mayaUsd/python/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(${PYTHON_TARGET_NAME}
         wrapColorSpace.cpp
         wrapConverter.cpp
         wrapDiagnosticDelegate.cpp
+        wrapLoadRules.cpp
         wrapMeshWriteUtils.cpp
         wrapOpUndoItem.cpp
         wrapQuery.cpp

--- a/lib/mayaUsd/python/module.cpp
+++ b/lib/mayaUsd/python/module.cpp
@@ -30,6 +30,7 @@ TF_WRAP_MODULE
     TF_WRAP(Converter);
     TF_WRAP(ConverterArgs);
     TF_WRAP(DiagnosticDelegate);
+    TF_WRAP(LoadRules);
     TF_WRAP(MeshWriteUtils);
 #ifdef UFE_V3_FEATURES_AVAILABLE
     TF_WRAP(PrimUpdater);

--- a/lib/mayaUsd/python/wrapLoadRules.cpp
+++ b/lib/mayaUsd/python/wrapLoadRules.cpp
@@ -1,0 +1,55 @@
+//
+// Copyright 2023 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include <mayaUsd/utils/loadRules.h>
+#include <mayaUsd/utils/util.h>
+
+#include <pxr/base/tf/pyResultConversions.h>
+
+#include <boost/python/def.hpp>
+
+using namespace boost::python;
+
+namespace {
+
+bool setLoadRules(const std::string& shapeName, bool loadAllPayloads)
+{
+    MObject shapeObj;
+    UsdMayaUtil::GetMObjectByName(shapeName, shapeObj);
+    return MayaUsd::setLoadRulesAttribute(shapeObj, loadAllPayloads);
+}
+
+bool isLoadingAll(const std::string& shapeName)
+{
+    MObject shapeObj;
+    UsdMayaUtil::GetMObjectByName(shapeName, shapeObj);
+
+    PXR_NS::UsdStageLoadRules rules;
+    MStatus                   status = MayaUsd::getLoadRulesFromAttribute(shapeObj, rules);
+
+    // Note: when there are no load rules set, we load all payloads.
+    if (!status)
+        return true;
+
+    return rules.IsLoadedWithAllDescendants(PXR_NS::SdfPath("/"));
+}
+
+} // namespace
+
+void wrapLoadRules()
+{
+    def("setLoadRulesAttribute", setLoadRules);
+    def("isLoadingAllPaylaods", isLoadingAll);
+}

--- a/lib/mayaUsd/utils/loadRules.h
+++ b/lib/mayaUsd/utils/loadRules.h
@@ -22,6 +22,7 @@
 #include <pxr/usd/usd/stage.h>
 
 #include <maya/MApiNamespace.h>
+#include <maya/MObject.h>
 
 namespace MAYAUSD_NS_DEF {
 
@@ -42,6 +43,21 @@ MAYAUSD_CORE_PUBLIC
 MStatus copyLoadRulesFromAttribute(
     const PXR_NS::MayaUsdProxyShapeBase& proxyShape,
     PXR_NS::UsdStage&                    stage);
+
+/*! \brief get the load rules from data in a dynamic attribute on the object.
+ */
+MAYAUSD_CORE_PUBLIC
+MStatus getLoadRulesFromAttribute(const MObject& proxyObj, PXR_NS::UsdStageLoadRules& rules);
+
+/*! \brief set the load rules to load-all or unload-all in a dynamic attribute on the object.
+           Used to set the initial load rules when creating a proxy shape.
+ */
+MAYAUSD_CORE_PUBLIC
+MStatus
+setLoadRulesAttribute(const PXR_NS::MayaUsdProxyShapeBase& proxyShape, bool loadAllPayloads);
+
+MAYAUSD_CORE_PUBLIC
+MStatus setLoadRulesAttribute(const MObject& proxyObj, bool loadAllPayloads);
 
 } // namespace MAYAUSD_NS_DEF
 

--- a/lib/usdUfe/utils/loadRules.h
+++ b/lib/usdUfe/utils/loadRules.h
@@ -50,6 +50,11 @@ std::string convertLoadRulesToText(const PXR_NS::UsdStage& stage);
 USDUFE_PUBLIC
 void setLoadRulesFromText(PXR_NS::UsdStage& stage, const std::string& text);
 
+/*! \brief set the stage load rules if they are different from the current ones.
+ */
+USDUFE_PUBLIC
+void setLoadRules(PXR_NS::UsdStage& stage, const PXR_NS::UsdStageLoadRules& newLoadRules);
+
 /*! \brief convert the load rules to a text format.
  */
 USDUFE_PUBLIC

--- a/lib/usdUfe/utils/loadRulesText.cpp
+++ b/lib/usdUfe/utils/loadRulesText.cpp
@@ -27,7 +27,11 @@ std::string convertLoadRulesToText(const PXR_NS::UsdStage& stage)
 
 void setLoadRulesFromText(PXR_NS::UsdStage& stage, const std::string& text)
 {
-    const auto newLoadRules = createLoadRulesFromText(text);
+    setLoadRules(stage, createLoadRulesFromText(text));
+}
+
+void setLoadRules(PXR_NS::UsdStage& stage, const PXR_NS::UsdStageLoadRules& newLoadRules)
+{
     if (stage.GetLoadRules() != newLoadRules)
         stage.SetLoadRules(newLoadRules);
 }

--- a/plugin/adsk/scripts/AETemplateHelpers.py
+++ b/plugin/adsk/scripts/AETemplateHelpers.py
@@ -183,7 +183,7 @@ def ProxyShapeFilePathChanged(filePathAttr, newFilePath=None):
             #       in that case.
             primPath = cmds.getAttr(stageName+'.primPath') or ''
             excludedPrimPaths = cmds.getAttr(stageName+'.excludePrimPaths') or ''
-            loadPayloads = cmds.getAttr(stageName+'.loadPayloads') or 0
+            loadPayloads = mayaUsdLib.isLoadingAllPaylaods(stageName)
 
             cmds.optionVar(stringValue=('stageFromFile_primPath', primPath))
             cmds.optionVar(stringValue=('stageFromFile_excludePrimPath', excludedPrimPaths))
@@ -214,11 +214,13 @@ def ProxyShapeFilePathChanged(filePathAttr, newFilePath=None):
                 excludedPrimPaths = cmds.optionVar(query='stageFromFile_excludePrimPath')
                 loadPayloads = cmds.optionVar(query='stageFromFile_loadPayloads')
 
+                # Note: load rules must be the first thing set so the stage gets loaded in teh correct state right away.
+                mayaUsdLib.setLoadRulesAttribute(stageName, loadPayloads)
+
                 cmds.setAttr(filePathAttr, usdFileToLoad, type='string')
                 cmds.setAttr(filePathAttr+"Relative", requireRelative)
                 cmds.setAttr(stageName+'.primPath', primPath, type="string")
                 cmds.setAttr(stageName+'.excludePrimPaths', excludedPrimPaths, type="string")
-                cmds.setAttr(stageName+'.loadPayloads', loadPayloads)
 
                 return True
         elif newFilePath is not None:

--- a/plugin/adsk/scripts/mayaUsd_createStageFromFile.mel
+++ b/plugin/adsk/scripts/mayaUsd_createStageFromFile.mel
@@ -23,8 +23,8 @@ proc setOptionVars(int $forceFactorySettings)
         optionVar -stringValue stageFromFile_excludePrimPath "";
     }
 
-    if ($forceFactorySettings || !`optionVar -exists stageFromFile_loadPayloads`) {
-        optionVar -intValue stageFromFile_loadPayloads 1;
+    if ($forceFactorySettings || !`optionVar -exists stageFromFile_loadAllPayloads`) {
+        optionVar -intValue stageFromFile_loadAllPayloads 1;
     }
 }
 
@@ -81,7 +81,7 @@ global proc string stageFromFile_UISetup(string $parent)
     checkBoxGrp -l `getMayaUsdString("kLoadPayloads")` 
         -ann `getMayaUsdString("kLoadPayloadsAnn")`
         -sbm `getMayaUsdString("kLoadPayloadsSbm")`
-        loadPayloadsCheckBox;
+        loadAllPayloadsCheckBox;
 
     frameLayout -label `getMayaUsdString("kLabelStageDisplay")` -parent $frame -collapsable false;
     textFieldGrp -l `getMayaUsdString("kPrimPath")` 
@@ -107,12 +107,12 @@ global proc stageFromFile_UIInit(string $parent, string $filterType)
 
     string $ppath = `optionVar -q stageFromFile_primPath`;
     string $exppath = `optionVar -q stageFromFile_excludePrimPath`;
-    int $loadp = `optionVar -q stageFromFile_loadPayloads`;
+    int $loadp = `optionVar -q stageFromFile_loadAllPayloads`;
 
     setParent $parent;
     textFieldGrp -e -text $ppath primPathField;
     textFieldGrp -e -text $exppath excludePrimPathField;
-    checkBoxGrp -e -value1 $loadp loadPayloadsCheckBox;
+    checkBoxGrp -e -value1 $loadp loadAllPayloadsCheckBox;
 }
 
 global proc stageFromFile_UICommit(string $parent)
@@ -127,8 +127,8 @@ global proc stageFromFile_UICommit(string $parent)
         (`textFieldGrp -q -text  primPathField`);
     optionVar -stringValue stageFromFile_excludePrimPath
         (`textFieldGrp -q -text  excludePrimPathField`);
-    optionVar -intValue stageFromFile_loadPayloads
-        (`checkBoxGrp -q -value1 loadPayloadsCheckBox`);
+    optionVar -intValue stageFromFile_loadAllPayloads
+        (`checkBoxGrp -q -value1 loadAllPayloadsCheckBox`);
 }
 
 proc string doCreateStage(string $fileName)
@@ -140,7 +140,11 @@ proc string doCreateStage(string $fileName)
 
     string $ppath = `optionVar -q stageFromFile_primPath`;
     string $exppath = `optionVar -q stageFromFile_excludePrimPath`;
-    int $loadp = `optionVar -q stageFromFile_loadPayloads`;
+    int $loadp = `optionVar -q stageFromFile_loadAllPayloads`;
+    string $loadpStr = "True";
+    if ($loadp == 0) {
+        $loadpStr = "False";
+    }
 
     string $fileNameToSave = $fileName;
     int $requireRelative = (`optionVar -exists mayaUsd_MakePathRelativeToSceneFile` && `optionVar -query mayaUsd_MakePathRelativeToSceneFile`);
@@ -149,11 +153,12 @@ proc string doCreateStage(string $fileName)
     }
 
     string $shapeNode = `createNode "mayaUsdProxyShape" -skipSelect -name ($baseName+"Shape")`;
+    // Note: load rules must be the first thing set so the stage gets loaded in teh correct state right away.
+    python("import mayaUsd.lib as mayaUsdLib; mayaUsdLib.setLoadRulesAttribute('" + $shapeNode + "', " + $loadpStr + ")");
     setAttr -type "string" ($shapeNode+".filePath") $fileNameToSave;
     setAttr ($shapeNode+".filePathRelative") $requireRelative;
     setAttr -type "string" ($shapeNode+".primPath") $ppath;
     setAttr -type "string" ($shapeNode+".excludePrimPaths") $exppath;
-    setAttr ($shapeNode+".loadPayloads") $loadp;
     connectAttr time1.outTime ($shapeNode+".time");
     select -r $shapeNode;
     string $fullPath[] = `ls -l $shapeNode`;

--- a/test/lib/mayaUsd/nodes/testProxyShapeBase.py
+++ b/test/lib/mayaUsd/nodes/testProxyShapeBase.py
@@ -574,10 +574,10 @@ class testProxyShapeBase(unittest.TestCase):
         # verify that the prim exists.
         self._verifyPrim()
 
-        # Set an attribute on the proxy shape. Here we set the loadPayloads.
+        # Set an attribute on the proxy shape. Here we set the shareStage.
         # It was already set, this only triggers a Maya node recompute.
         _, proxyShapePath = self._getStage()
-        cmds.setAttr('{}.{}'.format(proxyShapePath,"loadPayloads"), True)
+        cmds.setAttr('{}.{}'.format(proxyShapePath,"shareStage"), True)
 
         # Verify that we did not lose the data on the root layer.
         self._verifyPrim()


### PR DESCRIPTION
Instead, we will always use the existing payload rules dynamic attribute.

- Remove the "loadPayloads" attribute from the proxy shape.
- Add Python binding to new functions to set and retrieve if all payloads are loaded or not.
- Split-up existing load-rules helper functions to give more fined-grained access to the saved load rules in order to support the Python API.
- Use the new Python helper functions when creating or loading a stage.
- Adjust one unit test.