### PR TITLE
EMSUSD-756 allow parenting under a stronger layer

### DIFF
--- a/lib/usdUfe/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoInsertChildCommand.cpp
@@ -130,7 +130,10 @@ UsdUndoInsertChildCommand::UsdUndoInsertChildCommand(
 
     // Apply restriction rules
     UsdUfe::applyCommandRestriction(childPrim, "reparent");
-    UsdUfe::applyCommandRestriction(parentPrim, "reparent");
+    // Note: the parent is only receiving the prim, so it can be declared
+    //       in a weaker layer.
+    const bool allowStronger = true;
+    UsdUfe::applyCommandRestriction(parentPrim, "reparent", allowStronger);
 }
 
 UsdUndoInsertChildCommand::~UsdUndoInsertChildCommand() { }


### PR DESCRIPTION
Adjust the parenting UFE command to allow parenting under a prim defined in a lower layer.

Add a unit test to validate the fix. Failed before the fix, now works.