### PR TITLE
HYDRA-764 : Fix instanceable prims not rendered in Hydra

### DIFF
--- a/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
+++ b/lib/mayaUsd/sceneIndex/proxyShapeSceneIndexPlugin.cpp
@@ -397,7 +397,7 @@ HdSceneIndexPrim MayaUsdProxyShapeSceneIndex::GetPrim(const SdfPath& primPath) c
 
 SdfPathVector MayaUsdProxyShapeSceneIndex::GetChildPrimPaths(const SdfPath& primPath) const
 {
-    return _usdImagingStageSceneIndex->GetChildPrimPaths(primPath);
+    return _GetInputSceneIndex()->GetChildPrimPaths(primPath);
 }
 
 void MayaUsdProxyShapeSceneIndex::_PrimsAdded(


### PR DESCRIPTION
This PR fixes instanceable prims not being rendered in MayaHydra. The issue was due to the `MayaUsdProxyShapeSceneIndex::GetChildPrimPaths()` method not using its input scene index and instead skipping over to directly using the stage scene index, which made it so that the work done by the UsdImagingNiPrototypePropagatingSceneIndex was not carried over to the following scene indices. For reference, the scene index hierarchy looks something like this : 
```
MayaUsdProxyShapeSceneIndex
|__...
   |__UsdImagingNiPrototypePropagatingSceneIndex
      |__...
         |__UsdImagingStageSceneIndex
```