### PR TITLE
EMSUSD-181: Tooltips are not formatted correctly

### DIFF
--- a/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
@@ -15,6 +15,7 @@
 
 from .custom_image_control import customImageControlCreator
 from .attribute_custom_control import getNiceAttributeName
+from .attribute_custom_control import cleanAndFormatTooltip
 from .attribute_custom_control import AttributeCustomControl
 
 import collections
@@ -294,7 +295,7 @@ class ArrayCustomControl(AttributeCustomControl):
                 # See comment in ConnectionsCustomControl below for why nc=5.
                 rl = cmds.rowLayout(nc=5, adj=3)
                 with LayoutManager(rl):
-                    cmds.text(nameTxt, al='right', label=attrLabel, annotation=attr.GetDocumentation())
+                    cmds.text(nameTxt, al='right', label=attrLabel, annotation=cleanAndFormatTooltip(attr.GetDocumentation()))
                     cmds.textField(attrTypeFld, editable=False, text=typeNameStr, font='obliqueLabelFont', width=singleWidgetWidth*1.5)
 
                 if hasAEPopupMenu:
@@ -360,7 +361,7 @@ class ConnectionsCustomControl(AttributeCustomControl):
             # remain at a given width.
             rl = cmds.rowLayout(nc=5, adj=3)
             with LayoutManager(rl):
-                cmds.text(nameTxt, al='right', label=attrLabel, annotation=attr.GetDocumentation())
+                cmds.text(nameTxt, al='right', label=attrLabel, annotation=cleanAndFormatTooltip(attr.GetDocumentation()))
                 cmds.textField(attrTypeFld, editable=False, text=attrType, backgroundColor=[0.945, 0.945, 0.647], font='obliqueLabelFont', width=singleWidgetWidth*1.5)
 
                 # Add a menu item for each connection.
@@ -433,7 +434,7 @@ def arrayCustomControlCreator(aeTemplate, c):
 def defaultControlCreator(aeTemplate, c):
     ufeAttr = aeTemplate.attrS.attribute(c)
     uiLabel = getNiceAttributeName(ufeAttr, c) if aeTemplate.useNiceName else c
-    cmds.editorTemplate(addControl=[c], label=uiLabel)
+    cmds.editorTemplate(addControl=[c], label=uiLabel, annotation=cleanAndFormatTooltip(ufeAttr.getDocumentation()))
     return None
 
 class AEShaderLayout(object):

--- a/lib/mayaUsd/resources/ae/usdschemabase/attribute_custom_control.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/attribute_custom_control.py
@@ -32,6 +32,14 @@ def getNiceAttributeName(ufeAttr, attrName):
         attrName = str(ufeAttr.getMetadata("uiname"))
     return mayaUsd.lib.Util.prettifyName(attrName)
 
+def cleanAndFormatTooltip(s):
+    # Remove leading/trailing whitespace and replace newlines.
+    lines = s.splitlines()
+    stripped = [line.strip() for line in lines]
+    cleaned = '<br>'.join(stripped)
+
+    # Don't allow the tooltip to word-wrap.
+    return "<p style='white-space:pre'>" + cleaned + '</p>'
 
 class AttributeCustomControl(object):
     '''
@@ -55,4 +63,3 @@ class AttributeCustomControl(object):
         Return the label to be used in the UI for the attribute set on this object.
         '''
         return self.getAttributeUILabel(self.ufeAttr, self.attrName)
-    

--- a/lib/mayaUsd/resources/ae/usdschemabase/custom_enum_control.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/custom_enum_control.py
@@ -14,6 +14,7 @@
 #
 
 from .attribute_custom_control import AttributeCustomControl
+from .attribute_custom_control import cleanAndFormatTooltip
 
 import ufe
 import mayaUsd.ufe as mayaUsdUfe
@@ -32,7 +33,7 @@ class CustomEnumControl(AttributeCustomControl):
     def onCreate(self, *args):
         # Create the control.
         attrLabel = self.getUILabel()
-        self.uiControl = cmds.optionMenuGrp(label=attrLabel)
+        self.uiControl = cmds.optionMenuGrp(label=attrLabel, annotation=cleanAndFormatTooltip(self.ufeAttr.getDocumentation()))
         attributes.AEPopupMenu(self.uiControl, self.ufeAttr)
 
         # Add the menu items.

--- a/lib/mayaUsd/resources/ae/usdschemabase/custom_image_control.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/custom_image_control.py
@@ -14,6 +14,7 @@
 #
 
 from .attribute_custom_control import AttributeCustomControl
+from .attribute_custom_control import cleanAndFormatTooltip
 
 import mayaUsd.lib as mayaUsdLib
 from mayaUsdLibRegisterStrings import getMayaUsdLibString
@@ -51,7 +52,7 @@ class ImageCustomControl(AttributeCustomControl):
         createdControl = cmds.rowLayout(nc=3)
         self.controlName = createdControl
         with LayoutManager(createdControl):
-            cmds.text(label=attrUIName)
+            cmds.text(label=attrUIName, annotation=cleanAndFormatTooltip(ufeAttr.getDocumentation()))
             cmds.textField(ImageCustomControl.filenameField)
             cmds.symbolButton("browser", image="navButtonBrowse.png")
 


### PR DESCRIPTION
#### EMSUSD-181: Tooltips are not formatted correctly
* Use tooltip cleaning method similiar to UsdView to remove leading whitespace from multi-line doc strings.
* Added tooltips to all attributes.