### PR TITLE
EMSUSD-804 duplicate-to-USD support relationship targets

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
@@ -131,7 +131,9 @@ void UsdUndoDuplicateCommand::execute()
         isFirst = false;
     }
 
-    extras.finalize(MayaUsd::ufe::stagePath(stage), &path, &_usdDstPath);
+    MayaUsd::ufe::ReplicateExtrasToUSD::RenamedPaths renamed;
+    renamed[path] = _usdDstPath;
+    extras.finalize(MayaUsd::ufe::stagePath(stage), renamed);
 }
 
 void UsdUndoDuplicateCommand::undo()

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -883,18 +883,20 @@ void ReplicateExtrasToUSD::initRecursive(const Ufe::SceneItem::Ptr& item) const
 #endif
 }
 
-void ReplicateExtrasToUSD::finalize(
-    const Ufe::Path&       stagePath,
-    const PXR_NS::SdfPath* oldPrefix,
-    const PXR_NS::SdfPath* newPrefix) const
+void ReplicateExtrasToUSD::finalize(const Ufe::Path& stagePath, const RenamedPaths& renamed) const
 {
 #ifdef MAYA_HAS_DISPLAY_LAYER_API
     // Replicate display layer membership
     for (const auto& entry : _primToLayerMap) {
         if (entry.second.hasFn(MFn::kDisplayLayer)) {
             auto usdPrimPath = entry.first;
-            if (oldPrefix && newPrefix) {
-                usdPrimPath = usdPrimPath.ReplacePrefix(*oldPrefix, *newPrefix);
+            for (const auto& oldAndNew : renamed) {
+                const PXR_NS::SdfPath& oldPrefix = oldAndNew.first;
+                if (!usdPrimPath.HasPrefix(oldPrefix))
+                    continue;
+
+                const PXR_NS::SdfPath& newPrefix = oldAndNew.second;
+                usdPrimPath = usdPrimPath.ReplacePrefix(oldPrefix, newPrefix);
             }
 
             auto                primPath = UsdUfe::usdPathToUfePathSegment(usdPrimPath);

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -206,10 +206,8 @@ public:
 
     // Finalizes the replication operation to the USD stage defined by 'stagePath'
     // with a possibility to rename the old usd prefix to a new one
-    void finalize(
-        const Ufe::Path&       stagePath,
-        const PXR_NS::SdfPath* oldPrefix = nullptr,
-        const PXR_NS::SdfPath* newPrefix = nullptr) const;
+    using RenamedPaths = std::map<PXR_NS::SdfPath, PXR_NS::SdfPath>;
+    void finalize(const Ufe::Path& stagePath, const RenamedPaths& renamed) const;
 
 private:
     mutable std::map<PXR_NS::SdfPath, MObject> _primToLayerMap;

--- a/lib/usdUfe/ufe/Utils.cpp
+++ b/lib/usdUfe/ufe/Utils.cpp
@@ -368,6 +368,17 @@ std::string uniqueChildNameDefault(const UsdPrim& usdParent, const std::string& 
     return childName;
 }
 
+SdfPath uniqueChildPath(const UsdStage& stage, const SdfPath& path)
+{
+    const UsdPrim     parentPrim = stage.GetPrimAtPath(path.GetParentPath());
+    const std::string originalName = path.GetName();
+    const std::string uniqueName = uniqueChildName(parentPrim, originalName);
+    if (uniqueName == originalName)
+        return path;
+
+    return path.ReplaceName(TfToken(uniqueName));
+}
+
 namespace {
 
 bool allowedInStrongerLayer(

--- a/lib/usdUfe/ufe/Utils.h
+++ b/lib/usdUfe/ufe/Utils.h
@@ -187,6 +187,10 @@ std::string uniqueChildName(const PXR_NS::UsdPrim& usdParent, const std::string&
 USDUFE_PUBLIC
 std::string uniqueChildNameDefault(const PXR_NS::UsdPrim& parent, const std::string& name);
 
+//! Return a unique SdfPath by looking at existing siblings under the path's parent.
+USDUFE_PUBLIC
+PXR_NS::SdfPath uniqueChildPath(const PXR_NS::UsdStage& stage, const PXR_NS::SdfPath& path);
+
 //! Send notification for data model changes
 template <class T>
 void sendNotification(const Ufe::SceneItem::Ptr& item, const Ufe::Path& previousPath)


### PR DESCRIPTION
The goal is to solve problems with duplicating Maya node to USD when using the Arnold configuration. The main problem is that Arnold authors the materials used by the prim corresponding to the duplicated Maya node outside of the USD prim. The duplicate code was expecting to copy a single prim and its children.

To solve this, we add code to follow relationships and connections inside the new prim and also copy the targets of these relationships and connections.

Improve the traverseLayer function:
- Avoid infinite recursion by tracking which path have already been traversed.
- Correctly traverse relationships and not stop at first non-prim item.
- It worked for the original use case (prim updater) because that use case always pruned the traversal under each prim, avoiding traversal of non-prim "prim spec". That was hiding the fact the function did not work as expected.

Improve some helper code:
- Add uniqueChildPath helper function to make a SdfPath unique in its parent.
- Make the finalize function of ReplicateExtrasToUSD handle more than one renamed paths.

Support copying relationship and connection targets:
- Make the duplicate-to-USD function also copy the prims that are targeted by the copied prim in its relationships and connections.
- Do this recursively, so that if the targeted prim also targets other prims, those will be included.
- Adjust the targets to take into account renamed prims.
- Keep track of which prims have already been copied to avoid copying them again.