### PR TITLE
Add explicit boost/optional include

### DIFF
--- a/lib/mayaUsd/fileio/shaderReader.h
+++ b/lib/mayaUsd/fileio/shaderReader.h
@@ -25,6 +25,8 @@
 #include <maya/MObject.h>
 #include <maya/MPlug.h>
 
+#include <boost/optional.hpp>
+
 #include <memory>
 
 PXR_NAMESPACE_OPEN_SCOPE


### PR DESCRIPTION
This was implicitly included via sdf/allowed.h, but has been removed from that header.