### PR TITLE
EMSUSD-840 expand and collapse all layer items

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeView.h
+++ b/lib/usd/ui/layerEditor/layerTreeView.h
@@ -111,7 +111,13 @@ protected:
     void onModelAboutToBeReset();
     void onModelReset();
     void onItemDoubleClicked(const QModelIndex& index);
+    void onExpanded(const QModelIndex& index);
+    void onCollapsed(const QModelIndex& index);
     void onMuteLayerButtonPushed();
+
+    bool shouldExpandOrCollapseAll() const;
+    void expandChildren(const QModelIndex& index);
+    void collapseChildren(const QModelIndex& index);
 
     // delayed signal to select a layer on idle
     void selectLayerRquest(const QModelIndex& index);


### PR DESCRIPTION
When holding shift while clicking the expand or collapse button, expand or collapse all items in the layer editor.