### PR TITLE
EMSUSD-838 new layers collapsed

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeView.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeView.cpp
@@ -172,7 +172,7 @@ void LayerViewMemento::restore(LayerTreeView& view, LayerTreeModel& model)
         if (!item)
             continue;
 
-        bool expanded = true;
+        bool expanded = false;
 
         PXR_NS::SdfLayerRefPtr layer = item->layer();
         if (layer) {


### PR DESCRIPTION
New layer items in the Layer Editor are now in the collapsed state by default when found for the first time, instead of expanded by default.