### PR TITLE
EMSUSD-134 unit test for parent to selection

### DIFF
--- a/test/lib/ufe/testParentCmd.py
+++ b/test/lib/ufe/testParentCmd.py
@@ -811,6 +811,51 @@ class ParentCmdTestCase(unittest.TestCase):
 
         checkParentDone()
 
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() > 2025, 'Requires Maya fixes only available in Maya greater than 2025.')
+    def testParentToSelection(self):
+        '''
+        Test that the parent command with a single argument will parent to the selection.
+        '''
+        # Create scene items for the cube and the cylinder.
+        shapeSegment = mayaUtils.createUfePathSegment(
+            "|mayaUsdProxy1|mayaUsdProxyShape1")
+        
+        cylinderPath = ufe.Path(
+            [shapeSegment, usdUtils.createUfePathSegment("/cylinderXform")])
+        cylinderItem = ufe.Hierarchy.createItem(cylinderPath)
+
+        def verifyInitialSetup():
+            '''Verify that the cube is not a child of the cylinder.'''
+            cylHier = ufe.Hierarchy.hierarchy(cylinderItem)
+            cylChildren = cylHier.children()
+            self.assertEqual(len(cylChildren), 1)
+            self.assertNotIn("cubeXform", childrenNames(cylChildren))
+
+        verifyInitialSetup()
+
+        # Parent cube to cylinder by passing the cube but not the cylinder
+        # while the cylinder is selected.
+        cmds.select("|mayaUsdProxy1|mayaUsdProxyShape1,/cylinderXform")
+        cmds.parent("|mayaUsdProxy1|mayaUsdProxyShape1,/cubeXform")
+
+        def verifyCubeUnderCylinder():
+            '''Verify that the cube is under the cylinder.'''
+            cylHier = ufe.Hierarchy.hierarchy(cylinderItem)
+            cylChildren = cylHier.children()
+            self.assertEqual(len(cylChildren), 2)
+            self.assertIn("cubeXform", childrenNames(cylChildren))
+
+        # Confirm that the cube is now a child of the cylinder.
+        verifyCubeUnderCylinder()
+
+        # Undo: the cube is no longer a child of the cylinder.
+        cmds.undo()
+        verifyInitialSetup()
+
+        # Redo: the cube is again a child of the cylinder.
+        cmds.redo()
+        verifyCubeUnderCylinder()
+
     def testParentToProxyShape(self):
 
         # Load a file with a USD hierarchy at least 2-levels deep.

--- a/test/lib/ufe/testParentCmd.py
+++ b/test/lib/ufe/testParentCmd.py
@@ -811,7 +811,7 @@ class ParentCmdTestCase(unittest.TestCase):
 
         checkParentDone()
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() > 2025, 'Requires Maya fixes only available in Maya greater than 2025.')
+    @unittest.skipUnless(mayaUtils.ufeSupportFixLevel() >= 8, 'Requires parent command fix in Maya.')
     def testParentToSelection(self):
         '''
         Test that the parent command with a single argument will parent to the selection.


### PR DESCRIPTION
Verify that the parent command with a single argument wil parent to the selection. Only works in future Maya versions.