### PR TITLE
EMSUSD-958 : [github 3560] CXX ABI detection is broken

### DIFF
--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -478,7 +478,7 @@ if(IS_LINUX AND MAYA_Foundation_LIBRARY)
     # If yes, then MayaUsd MUST also be built with new ABI.
     execute_process(
         COMMAND
-            nm "${MAYA_Foundation_LIBRARY}"
+            nm -D "${MAYA_Foundation_LIBRARY}"
         COMMAND
             grep findVariableReplacement
         COMMAND


### PR DESCRIPTION
#### EMSUSD-958 : [github 3560] CXX ABI detection is broken
* When using Linux nm utility need "-D" flag for dynamic symbols