### PR TITLE
EMSUSD-65 wait cursor during long VP2 updates

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -540,6 +540,8 @@ bool _DrawItemFilterPredicate(const SdfPath& rprimID, const void* predicateParam
 }
 #endif
 
+bool _longDurationRendering = false;
+
 } // namespace
 
 //! \brief  Draw classification used during plugin load to register in VP2
@@ -1202,6 +1204,8 @@ void ProxyRenderDelegate::_Execute(const MHWRender::MFrameContext& frameContext)
     }
 }
 
+void ProxyRenderDelegate::setLongDurationRendering() { _longDurationRendering = true; }
+
 //! \brief  Main update entry from subscene override.
 void ProxyRenderDelegate::update(MSubSceneContainer& container, const MFrameContext& frameContext)
 {
@@ -1213,6 +1217,16 @@ void ProxyRenderDelegate::update(MSubSceneContainer& container, const MFrameCont
     // Without a proxy shape we can't do anything
     if (_proxyShapeData->ProxyShape() == nullptr)
         return;
+
+    // If the rendering was flagged as possibly taking a long time,
+    // show the wait cursor.
+    //
+    // Note: using the wait cursor sets the long duration flag,
+    //       so reset the flag after setting up the cursor, otherwise
+    //       once one rendering would be long-duration, all of them
+    //       would be flagged afterward.
+    WaitCursor waitCursor(_longDurationRendering);
+    _longDurationRendering = false;
 
 #ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
     const MSelectionInfo* selectionInfo = frameContext.getSelectionInfo();

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -256,6 +256,8 @@ public:
     bool SnapToPoints() const;
 #endif
 
+    static void setLongDurationRendering();
+
 private:
     ProxyRenderDelegate(const ProxyRenderDelegate&) = delete;
     ProxyRenderDelegate& operator=(const ProxyRenderDelegate&) = delete;

--- a/lib/mayaUsd/ufe/Global.cpp
+++ b/lib/mayaUsd/ufe/Global.cpp
@@ -18,6 +18,7 @@
 #include "private/UfeNotifGuard.h"
 
 #include <mayaUsd/nodes/proxyShapeStageExtraData.h>
+#include <mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h>
 #include <mayaUsd/ufe/MayaStagesSubject.h>
 #include <mayaUsd/ufe/MayaUsdContextOpsHandler.h>
 #include <mayaUsd/ufe/MayaUsdObject3dHandler.h>
@@ -108,7 +109,11 @@ MCallbackId gExitingCbId = 0;
 // Subject singleton for observation of all USD stages.
 MayaUsd::ufe::MayaStagesSubject::RefPtr g_StagesSubject;
 
-void mayaStartWaitCursor() { MGlobal::executeCommand("waitCursor -state 1"); }
+void mayaStartWaitCursor()
+{
+    ProxyRenderDelegate::setLongDurationRendering();
+    MGlobal::executeCommand("waitCursor -state 1");
+}
 
 void mayaStopWaitCursor() { MGlobal::executeCommand("waitCursor -state 0"); }
 

--- a/lib/usdUfe/ufe/Utils.h
+++ b/lib/usdUfe/ufe/Utils.h
@@ -319,8 +319,27 @@ void stopWaitCursor();
 //! Start and stop the wait cursor in the constructor and destructor.
 struct USDUFE_PUBLIC WaitCursor
 {
-    WaitCursor() { startWaitCursor(); }
-    ~WaitCursor() { stopWaitCursor(); }
+    //! Show the wait cursor if the showCursor flag is true.
+    WaitCursor(bool showCursor = true)
+        : _showCursor(showCursor)
+    {
+        if (_showCursor)
+            startWaitCursor();
+    }
+
+    //! Stop the wait cursor if the showCursor flag is true.
+    ~WaitCursor()
+    {
+        if (_showCursor)
+            stopWaitCursor();
+    }
+
+    WaitCursor(const WaitCursor&) = delete;
+    WaitCursor(WaitCursor&&) = delete;
+    WaitCursor& operator=(const WaitCursor&) = delete;
+    WaitCursor& operator=(WaitCursor&&) = delete;
+
+    const bool _showCursor;
 };
 
 } // namespace USDUFE_NS_DEF


### PR DESCRIPTION
When a command may trigger a long viewport update, set a flag so that the proxy render delegate shows the wait cursor while it is updating the viewport data. We make the assumption that long-duration commands will generally cause long-duration viewport updates. This is done via the already-existing LongDurationCommand base class and wait cursor functions.

- Modify the WaitCursor helper class to take a flag to control if the cursor is shown or not.
- This allows conditionally showing the wait cursor based on a condition.
- Add a function to tell the render delegate that it should expect its update to take a long time.
- Make the wait cursor function used by long-duration commands tell the render delegate to expect a long update.