### PR TITLE
LOOKDEVX-2403 - Allow creating custom types at NodeGraph boundaries

### DIFF
--- a/lib/mayaUsd/ufe/UsdAttribute.cpp
+++ b/lib/mayaUsd/ufe/UsdAttribute.cpp
@@ -477,6 +477,12 @@ UsdAttributeGeneric::create(const UsdSceneItem::Ptr& item, UsdAttributeHolder::U
 
 std::string UsdAttributeGeneric::nativeType() const { return UsdAttribute::nativeType(); }
 
+const std::string& UsdAttributeGeneric::nativeSdrTypeMetadata()
+{
+    static const auto kMetadataName = std::string { "nativeSdrType" };
+    return kMetadataName;
+}
+
 #ifdef UFE_V4_FEATURES_AVAILABLE
 //------------------------------------------------------------------------------
 // UsdAttributeFilename:

--- a/lib/mayaUsd/ufe/UsdAttribute.h
+++ b/lib/mayaUsd/ufe/UsdAttribute.h
@@ -192,6 +192,10 @@ public:
 
     // Ufe::AttributeGeneric overrides
     std::string nativeType() const override;
+
+    // Metadata used when creating a dynamic attribute on NodeGraph/Material boundaries that
+    // remembers the native type of a generic shader property.
+    static const std::string& nativeSdrTypeMetadata();
 }; // UsdAttributeGeneric
 
 #ifdef UFE_V4_FEATURES_AVAILABLE

--- a/lib/mayaUsd/ufe/UsdAttributeHolder.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributeHolder.cpp
@@ -141,6 +141,7 @@ std::string UsdAttributeHolder::defaultValue() const { return std::string(); }
 
 std::string UsdAttributeHolder::nativeType() const
 {
+#ifdef UFE_V3_FEATURES_AVAILABLE
     if (usdAttributeType() == SdfValueTypeNames->Token && PXR_NS::UsdShadeNodeGraph(usdPrim())) {
         // We might have saved the Sdr native type as metadata:
         if (PXR_NS::UsdShadeInput::IsInput(_usdAttr)
@@ -151,7 +152,7 @@ std::string UsdAttributeHolder::nativeType() const
             }
         }
     }
-
+#endif
     return usdAttributeType().GetType().GetTypeName();
 }
 

--- a/lib/mayaUsd/ufe/UsdAttributeHolder.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributeHolder.cpp
@@ -141,6 +141,17 @@ std::string UsdAttributeHolder::defaultValue() const { return std::string(); }
 
 std::string UsdAttributeHolder::nativeType() const
 {
+    if (usdAttributeType() == SdfValueTypeNames->Token && PXR_NS::UsdShadeNodeGraph(usdPrim())) {
+        // We might have saved the Sdr native type as metadata:
+        if (PXR_NS::UsdShadeInput::IsInput(_usdAttr)
+            || PXR_NS::UsdShadeOutput::IsOutput(_usdAttr)) {
+            const auto metaValue = getMetadata(UsdAttributeGeneric::nativeSdrTypeMetadata());
+            if (!metaValue.empty() && metaValue.isType<std::string>()) {
+                return metaValue.get<std::string>();
+            }
+        }
+    }
+
     return usdAttributeType().GetType().GetTypeName();
 }
 

--- a/lib/mayaUsd/ufe/UsdAttributes.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributes.cpp
@@ -373,9 +373,21 @@ Ufe::Attribute::Ptr UsdAttributes::doAddAttribute(
                 }
             }
             // Fallback to creating a nodegraph output.
-            connectApi.CreateOutput(baseNameAndType.first, ufeTypeToUsd(type));
+            auto usdType = ufeTypeToUsd(type);
+            auto output = connectApi.CreateOutput(
+                baseNameAndType.first, usdType ? usdType : SdfValueTypeNames->Token);
+            if (!usdType) {
+                output.SetSdrMetadataByKey(
+                    TfToken(UsdAttributeGeneric::nativeSdrTypeMetadata()), type);
+            }
         } else if (baseNameAndType.second == PXR_NS::UsdShadeAttributeType::Input) {
-            connectApi.CreateInput(baseNameAndType.first, ufeTypeToUsd(type));
+            auto usdType = ufeTypeToUsd(type);
+            auto input = connectApi.CreateInput(
+                baseNameAndType.first, usdType ? usdType : SdfValueTypeNames->Token);
+            if (!usdType) {
+                input.SetSdrMetadataByKey(
+                    TfToken(UsdAttributeGeneric::nativeSdrTypeMetadata()), type);
+            }
         }
     }
 


### PR DESCRIPTION
When creating NodeGraph/Material inputs and outputs, allow passing the native type as a string instead of "Generic" when creating a port that can only be wrapped in UFE as an UfeAttributeGeneric.

This allows LookdevX to display the expected port type when promoting ports on inner nodes.