### PR TITLE
EMSUSD-964 - Layer Editor's "Revert to File" menu item is renamed to "Reload"

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -450,8 +450,9 @@ void LayerTreeItem::saveAnonymousLayer()
 }
 void LayerTreeItem::discardEdits()
 {
-    if (isAnonymous()) {
+    if (isAnonymous() || !isDirty()) {
         // according to MAYA-104336, we don't prompt for confirmation for anonymous layers
+        // according to EMSUSD-964, we don't prompt for confirmation if the layer is not dirty
         commandHook()->discardEdits(layer());
     } else {
         MString title;

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
@@ -53,7 +53,7 @@ global proc mayaUSDRegisterStrings()
     register("kMenuAddSublayer", "Add Sublayer");
     register("kMenuAddParentLayer", "Add Parent Layer");
     register("kMenuClear", "Clear");
-    register("kMenuRevertToFile", "Revert to File");
+    register("kMenuReload", "Reload");
     register("kMenuLayerEditor", "USD Layer Editor");
     register("kContextMenuLayerEditor", "USD Layer Editor...");
     register("kMenuLayerEditorAnn", "Organize and edit USD data in layers");

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -885,9 +885,9 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
     }
 
     if (!$isAnonymousLayer) {
-        $label = getMayaUsdString("kMenuRevertToFile");
+        $label = getMayaUsdString("kMenuReload");
         $cmd = makeCommand($panelName, "discardEdits");
-        $enabled = $needsSaving;
+        $enabled = true;
         menuItem -label $label -enable $enabled -c $cmd;
     }
 


### PR DESCRIPTION
Layer Editor's "Revert to File" menu item is renamed to "Reload"

Additionally, The action no longer requires the layer to be dirty and the menu item is shown as long as the layer is not an anonymous layer.