### PR TITLE
EMSUSD-804 fix copying node with Arnold material.

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -1778,8 +1778,13 @@ bool PrimUpdaterManager::duplicate(
 
         // Note: copyFn can append new items in pathsToCopy, so do not optimize
         //       comparing to the size of the container nor use iterators.
+        //
+        //       For the same reason, the pathsToCopy container can be resized
+        //       and its value moved to a new memory location, so that it why
+        //       the path we pass to the traverseLayer function is taken by value.
         for (size_t i = 0; i < pathsToCopy.size(); ++i) {
-            traverseLayer(srcLayer, pathsToCopy[i], copyFn);
+            const SdfPath srcPath = pathsToCopy[i];
+            traverseLayer(srcLayer, srcPath, copyFn);
         }
         progressBar.advance();
 

--- a/lib/mayaUsd/utils/traverseLayer.cpp
+++ b/lib/mayaUsd/utils/traverseLayer.cpp
@@ -55,14 +55,14 @@ using AlreadyTraversedPaths = std::set<SdfPath>;
 
 void _traverseLayer(
     const SdfLayerHandle&           layer,
-    const SdfPath&                  path,
+    const SdfPath                   path,
     AlreadyTraversedPaths&          traversed,
     const MayaUsd::TraverseLayerFn& fn);
 
 template <typename ChildPolicy>
 void TraverseChildren(
     const SdfLayerHandle&           layer,
-    const SdfPath&                  path,
+    const SdfPath                   path,
     AlreadyTraversedPaths&          traversed,
     const MayaUsd::TraverseLayerFn& fn)
 {
@@ -77,7 +77,7 @@ void TraverseChildren(
 
 void _traverseLayer(
     const SdfLayerHandle&           layer,
-    const SdfPath&                  path,
+    const SdfPath                   path,
     AlreadyTraversedPaths&          traversed,
     const MayaUsd::TraverseLayerFn& fn)
 {

--- a/lib/mayaUsd/utils/traverseLayer.cpp
+++ b/lib/mayaUsd/utils/traverseLayer.cpp
@@ -55,14 +55,14 @@ using AlreadyTraversedPaths = std::set<SdfPath>;
 
 void _traverseLayer(
     const SdfLayerHandle&           layer,
-    const SdfPath                   path,
+    const SdfPath&                  path,
     AlreadyTraversedPaths&          traversed,
     const MayaUsd::TraverseLayerFn& fn);
 
 template <typename ChildPolicy>
 void TraverseChildren(
     const SdfLayerHandle&           layer,
-    const SdfPath                   path,
+    const SdfPath&                  path,
     AlreadyTraversedPaths&          traversed,
     const MayaUsd::TraverseLayerFn& fn)
 {
@@ -77,7 +77,7 @@ void TraverseChildren(
 
 void _traverseLayer(
     const SdfLayerHandle&           layer,
-    const SdfPath                   path,
+    const SdfPath&                  path,
     AlreadyTraversedPaths&          traversed,
     const MayaUsd::TraverseLayerFn& fn)
 {


### PR DESCRIPTION
The code was not creating the necessary missing parent prims and was not detecting relationships correctly, among other smaller things.

- Add a helper to create the missing parent prims, trying to replicate the same prim type found in the temporary source stage, without actually copying those prims.
- Add a lot of debug logging to help investigate issues with duplicate-to-USD.
- Keep track of each prim that gets brought in by each prim that gets copied, recursively, so that we copy all necessary prims.
- Keep recursing into prims that have already been copied indirectly via SdfCopySpec so that their relationships can be detected too.
- This happens for example if one copies a Maya sphere than contained a Maya cube.
- Correctly detect relationships. The old way was detecting relational attributes...