### PR TITLE
EMSUSD-972 refactor duplication code

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -30,6 +30,7 @@
 #include <mayaUsd/ufe/Global.h>
 #include <mayaUsd/undo/OpUndoItemMuting.h>
 #include <mayaUsd/undo/OpUndoItems.h>
+#include <mayaUsd/utils/copyLayerPrims.h>
 #include <mayaUsd/utils/dynamicAttribute.h>
 #include <mayaUsd/utils/progressBarScope.h>
 #include <mayaUsd/utils/traverseLayer.h>
@@ -1517,60 +1518,6 @@ void PrimUpdaterManager::discardPullSetIfEmpty()
     }
 }
 
-static void replicateMissingAncestors(
-    const UsdStageRefPtr& srcStage,
-    SdfPath               srcPath,
-    const UsdStageRefPtr& dstStage,
-    SdfPath               dstPath)
-{
-    // List f prims to be created. The last prim should be created
-    // first, (it will be the highest in the hierarchy)
-    std::vector<std::pair<SdfPath, SdfPath>> toBeCreated;
-
-    while (true) {
-        // If we reach the top of the hierarchy, stop.
-        srcPath = srcPath.GetParentPath();
-        if (srcPath.IsEmpty() || srcPath.IsAbsoluteRootPath())
-            break;
-
-        // If we reach the top of the hierarchy, stop.
-        dstPath = dstPath.GetParentPath();
-        if (dstPath.IsEmpty() || dstPath.IsAbsoluteRootPath())
-            break;
-
-        // If the destination prim already exists, stop.
-        UsdPrim dstPrim = dstStage->GetPrimAtPath(dstPath);
-        if (dstPrim) {
-#ifdef PRIM_UPDATER_MANAGER_DEBUG_DUPLICATE_PRIM
-            std::string ancestorFoundMsg
-                = TfStringPrintf("The ancestor %s exists", dstPath.GetAsString().c_str());
-            MGlobal::displayInfo(ancestorFoundMsg.c_str());
-#endif
-            break;
-        }
-
-#ifdef PRIM_UPDATER_MANAGER_DEBUG_DUPLICATE_PRIM
-        std::string ancestorNeededMsg
-            = TfStringPrintf("The ancestor %s needs to be created", dstPath.GetAsString().c_str());
-        MGlobal::displayInfo(ancestorNeededMsg.c_str());
-#endif
-        toBeCreated.emplace_back(srcPath, dstPath);
-    }
-
-    const auto end = toBeCreated.rend();
-    for (auto iter = toBeCreated.rbegin(); iter != end; ++iter) {
-        const SdfPath& srcPath = iter->first;
-        const SdfPath& dstPath = iter->second;
-
-        // try to reproduce the same prim type, if we can.
-        TfToken primType;
-        if (UsdPrim srcPrim = srcStage->GetPrimAtPath(srcPath))
-            primType = srcPrim.GetTypeName();
-
-        dstStage->DefinePrim(dstPath, primType);
-    }
-}
-
 bool PrimUpdaterManager::duplicate(
     const Ufe::Path&    srcPath,
     const Ufe::Path&    dstPath,
@@ -1661,12 +1608,6 @@ bool PrimUpdaterManager::duplicate(
         const auto& editTarget = dstStage->GetEditTarget();
         const auto& dstLayer = editTarget.GetLayer();
 
-#ifdef PRIM_UPDATER_MANAGER_DEBUG_DUPLICATE_PRIM
-        std::string layerContentsMsg;
-        if (srcLayer->ExportToString(&layerContentsMsg))
-            MGlobal::displayInfo(layerContentsMsg.c_str());
-#endif
-
         // Validate that the destination parent prim is valid.
         UsdPrim dstParentPrim = MayaUsd::ufe::ufePathToPrim(dstPath);
         if (!dstParentPrim.IsValid()) {
@@ -1674,221 +1615,26 @@ bool PrimUpdaterManager::duplicate(
         }
         progressBar.advance();
 
-        // Traverse the temporary layer starting from the source root path
-        // and copy all prims, including the ones targeted by relationships.
-
+        // We need the parent path of the source and destination to
+        // fixup the paths of the source prims we copy to their
+        // destination paths.
         const SdfPath srcParentPath = srcRootPath.GetParentPath();
         const SdfPath dstParentPath = dstParentPrim.GetPath();
 
-        // This contains the list of paths that have to be copied.
-        // Initially, it only contains the source path, but we add
-        // the destination of relationships to the list so to copy
-        // all related prims.
-        std::vector<SdfPath> pathsToCopy;
-        pathsToCopy.push_back(srcRootPath);
+        CopyLayerPrimsOptions options;
+        options.progressBar = &progressBar;
 
-        // This contains the set of path that have alredy been copied.
-        // Used to avoid copying a prim that has already been copied.
-        std::set<SdfPath> copiedPaths;
+        CopyLayerPrimsResult copyResult = copyLayerPrims(
+            srcStage,
+            srcLayer,
+            srcParentPath,
+            dstStage,
+            dstLayer,
+            dstParentPath,
+            { srcRootPath },
+            options);
 
-        // This contains a map of the original destination SdfPath to
-        // renamed destination SdfPath. Used after the copy is done to
-        // rename relationships to a prim that was renamed.
-        MayaUsd::ufe::ReplicateExtrasToUSD::RenamedPaths renamedPaths;
-
-        // Note: returning false means to prune traversing children.
-        auto copyFn = [&srcStage,
-                       &srcLayer,
-                       &srcParentPath,
-                       &dstLayer,
-                       &dstParentPath,
-                       &pathsToCopy,
-                       &copiedPaths,
-                       &renamedPaths,
-                       &dstStage](const SdfPath& srcPath) -> bool {
-            // Check if the path is a relationship target path. If so, we need to copy
-            // the target since it is used by the prim containing this relationship.
-            if (srcPath.IsTargetPath()) {
-                const SdfPath& targetPath = srcPath.GetTargetPath();
-                if (!targetPath.IsEmpty()) {
-#ifdef PRIM_UPDATER_MANAGER_DEBUG_DUPLICATE_PRIM
-                    std::string moreToCopyMsg = TfStringPrintf(
-                        "Adding %s to be copied due to target in %s",
-                        targetPath.GetAsString().c_str(),
-                        srcPath.GetAsString().c_str());
-                    MGlobal::displayInfo(moreToCopyMsg.c_str());
-#endif
-                    pathsToCopy.emplace_back(targetPath);
-                }
-                return true;
-            }
-
-            // We only copy prims, not any other type of specs, like attributes etc.
-            // Copying the prim will copy its attributes, etc.
-            if (!srcPath.IsPrimPath()) {
-#ifdef PRIM_UPDATER_MANAGER_DEBUG_DUPLICATE_PRIM
-                std::string notPrimMsg
-                    = TfStringPrintf("Path %s is not a prim path", srcPath.GetAsString().c_str());
-                MGlobal::displayInfo(notPrimMsg.c_str());
-#endif
-                return true;
-            }
-
-            for (const SdfPath& alreadyDone : copiedPaths) {
-                if (srcPath.HasPrefix(alreadyDone)) {
-#ifdef PRIM_UPDATER_MANAGER_DEBUG_DUPLICATE_PRIM
-                    std::string alreadyMsg = TfStringPrintf(
-                        "Already copied source prim %s, skipping additional copies",
-                        srcPath.GetAsString().c_str());
-                    MGlobal::displayInfo(alreadyMsg.c_str());
-#endif
-                    // Note: we must not prevent traversing children otherwise we will
-                    //       not process relationships.
-                    return true;
-                }
-            }
-
-            copiedPaths.insert(srcPath);
-
-            // Make the destination path unique.
-            const SdfPath origDstPath = srcPath.ReplacePrefix(srcParentPath, dstParentPath);
-
-            // Make sure parent prims exists in the destination.
-            replicateMissingAncestors(srcStage, srcPath, dstStage, origDstPath);
-
-            const SdfPath dstPath = UsdUfe::uniqueChildPath(*dstStage, origDstPath);
-            if (dstPath != origDstPath) {
-                renamedPaths[origDstPath] = dstPath;
-            }
-
-            const std::string copyingMsg = TfStringPrintf(
-                "Copying source prim %s to destination prim %s",
-                srcPath.GetAsString().c_str(),
-                dstPath.GetAsString().c_str());
-            MGlobal::displayInfo(copyingMsg.c_str());
-
-            if (!SdfCopySpec(srcLayer, srcPath, dstLayer, dstPath)) {
-                const std::string errMsg
-                    = TfStringPrintf("could not copy to %s", dstPath.GetAsString().c_str()).c_str();
-                throw std::runtime_error(errMsg);
-            }
-
-            return true;
-        };
-
-        // Note: copyFn can append new items in pathsToCopy, so do not optimize
-        //       comparing to the size of the container nor use iterators.
-        //
-        //       For the same reason, the pathsToCopy container can be resized
-        //       and its value moved to a new memory location, so that it why
-        //       the path we pass to the traverseLayer function is taken by value.
-        for (size_t i = 0; i < pathsToCopy.size(); ++i) {
-            const SdfPath srcPath = pathsToCopy[i];
-            traverseLayer(srcLayer, srcPath, copyFn);
-        }
-        progressBar.advance();
-
-        // Traverse again the destination prims and adjust the relationships
-        // to take into account renamed prims.
-        auto renameRelFn = [&renamedPaths, &dstStage](const SdfPath& layerSpecPath) -> bool {
-            // We're only interested in relationship target paths
-            if (!layerSpecPath.IsTargetPath())
-                return true;
-
-            // Adjust all targets that were referring to prims that were renamed.
-            SdfPath targetPath = layerSpecPath.GetTargetPath();
-#ifdef PRIM_UPDATER_MANAGER_DEBUG_DUPLICATE_PRIM
-            std::string targetVerifyingMsg = TfStringPrintf(
-                "Verifying renaming for %s target path", targetPath.GetAsString().c_str());
-            MGlobal::displayInfo(targetVerifyingMsg.c_str());
-#endif
-            for (const auto& oldAndNew : renamedPaths) {
-                // If the relationship was not targeting this renamed path, skip.
-                const SdfPath& oldPath = oldAndNew.first;
-                if (!targetPath.HasPrefix(oldPath))
-                    continue;
-
-                const SdfPath& newPath = oldAndNew.second;
-
-                // Determine if we have a relationship target or an attribute connection.
-                // Note: the parent path of a relationship target path is the relationship.
-                const SdfPath primPath = layerSpecPath.GetPrimOrPrimVariantSelectionPath();
-                UsdPrim       prim = dstStage->GetPrimAtPath(primPath);
-                const SdfPath targetingPath = layerSpecPath.GetParentPath();
-
-#ifdef PRIM_UPDATER_MANAGER_DEBUG_DUPLICATE_PRIM
-                std::string containingPrimMsg = TfStringPrintf(
-                    "Prim %s containg targeting property %s",
-                    primPath.GetAsString().c_str(),
-                    targetingPath.GetAsString().c_str());
-                MGlobal::displayInfo(containingPrimMsg.c_str());
-#endif
-
-                // Note: we could *almost* use a UsdProperty, which is the base class of
-                //       both UsdRelationship and UsdAttribute. It has a _GetTargets()
-                //       functions... but it is protected! How unfortunate... So instead
-                //       we have two almost identical branches.
-                UsdRelationship rel = prim.GetRelationshipAtPath(targetingPath);
-                if (rel) {
-                    // Modify all targets that were using the old path to now use the new path.
-                    SdfPathVector targets;
-                    rel.GetTargets(&targets);
-                    for (auto& target : targets) {
-                        if (!target.HasPrefix(oldPath))
-                            continue;
-                        SdfPath newTarget = target.ReplacePrefix(oldPath, newPath);
-
-#ifdef PRIM_UPDATER_MANAGER_DEBUG_DUPLICATE_PRIM
-                        std::string renamingMsg = TfStringPrintf(
-                            "Renaming relationship %s to %s",
-                            target.GetAsString().c_str(),
-                            newTarget.GetAsString().c_str());
-                        MGlobal::displayInfo(renamingMsg.c_str());
-#endif
-                        target = newTarget;
-                    }
-                    rel.SetTargets(targets);
-                } else {
-                    // Retrieve the attribute so we can modify its targets.
-                    UsdAttribute attr = prim.GetAttributeAtPath(targetingPath);
-                    if (attr) {
-                        // Modify all targets that were using the old path to now use the new path.
-                        SdfPathVector targets;
-                        attr.GetConnections(&targets);
-                        for (auto& target : targets) {
-                            if (!target.HasPrefix(oldPath))
-                                continue;
-
-                            SdfPath newTarget = target.ReplacePrefix(oldPath, newPath);
-
-#ifdef PRIM_UPDATER_MANAGER_DEBUG_DUPLICATE_PRIM
-                            std::string renamingMsg = TfStringPrintf(
-                                "Renaming attribute connection %s to %s",
-                                target.GetAsString().c_str(),
-                                newTarget.GetAsString().c_str());
-                            MGlobal::displayInfo(renamingMsg.c_str());
-#endif
-                            target = newTarget;
-                        }
-                        attr.SetConnections(targets);
-                    }
-                }
-            }
-
-            return true;
-        };
-
-        progressBar.addSteps(copiedPaths.size());
-        for (const SdfPath& path : copiedPaths) {
-            if (renamedPaths.count(path)) {
-                traverseLayer(dstLayer, renamedPaths[path], renameRelFn);
-            } else {
-                traverseLayer(dstLayer, path, renameRelFn);
-            }
-            progressBar.advance();
-        }
-
-        context._pushExtras.finalize(MayaUsd::ufe::stagePath(dstStage), renamedPaths);
+        context._pushExtras.finalize(MayaUsd::ufe::stagePath(dstStage), copyResult.renamedPaths);
 
         auto ufeItem = Ufe::Hierarchy::createItem(dstPath);
         if (TF_VERIFY(ufeItem)) {

--- a/lib/mayaUsd/python/CMakeLists.txt
+++ b/lib/mayaUsd/python/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(${PYTHON_TARGET_NAME}
         wrapBlockSceneModificationContext.cpp
         wrapColorSpace.cpp
         wrapConverter.cpp
+        wrapCopyLayerPrims.cpp
         wrapDiagnosticDelegate.cpp
         wrapLoadRules.cpp
         wrapMeshWriteUtils.cpp

--- a/lib/mayaUsd/python/module.cpp
+++ b/lib/mayaUsd/python/module.cpp
@@ -29,6 +29,7 @@ TF_WRAP_MODULE
     TF_WRAP(ColorSpace);
     TF_WRAP(Converter);
     TF_WRAP(ConverterArgs);
+    TF_WRAP(CopyLayerPrims);
     TF_WRAP(DiagnosticDelegate);
     TF_WRAP(LoadRules);
     TF_WRAP(MeshWriteUtils);

--- a/lib/mayaUsd/python/wrapCopyLayerPrims.cpp
+++ b/lib/mayaUsd/python/wrapCopyLayerPrims.cpp
@@ -1,0 +1,91 @@
+//
+// Copyright 2024 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include <mayaUsd/utils/copyLayerPrims.h>
+
+#include <pxr/base/tf/pyResultConversions.h>
+
+#include <boost/python/def.hpp>
+
+using namespace boost::python;
+
+namespace {
+
+// Note: due to a limitation of boost::python, we cannot pass shared-pointer
+//       between Python and C++. See this stack overflow answer for an explanation:
+//       https://stackoverflow.com/questions/20825662/boost-python-argument-types-did-not-match-c-signature
+//
+//       That is why stages and layers are passed by raw C++ references and a
+//       smart pointer is created on-the-fly. Otherwise, the stage you pass it
+//       in Python would become invalid during the call.
+std::map<PXR_NS::SdfPath, PXR_NS::SdfPath> _copyLayerPrims(
+    PXR_NS::UsdStage&                   srcStage,
+    PXR_NS::SdfLayer&                   srcLayer,
+    const PXR_NS::SdfPath&              srcParentPath,
+    PXR_NS::UsdStage&                   dstStage,
+    PXR_NS::SdfLayer&                   dstLayer,
+    const PXR_NS::SdfPath&              dstParentPath,
+    const std::vector<PXR_NS::SdfPath>& primsToCopy,
+    const bool                          followRelationships)
+{
+    MayaUsd::CopyLayerPrimsOptions options;
+    options.followRelationships = followRelationships;
+
+    PXR_NS::UsdStageRefPtr srcStagePtr(&srcStage);
+    PXR_NS::SdfLayerRefPtr srcLayerPtr(&srcLayer);
+    PXR_NS::UsdStageRefPtr dstStagePtr(&dstStage);
+    PXR_NS::SdfLayerRefPtr dstLayerPtr(&dstLayer);
+
+    MayaUsd::CopyLayerPrimsResult result = MayaUsd::copyLayerPrims(
+        srcStagePtr,
+        srcLayerPtr,
+        srcParentPath,
+        dstStagePtr,
+        dstLayerPtr,
+        dstParentPath,
+        primsToCopy,
+        options);
+
+    return result.copiedPaths;
+}
+
+std::map<PXR_NS::SdfPath, PXR_NS::SdfPath> _copyLayerPrim(
+    PXR_NS::UsdStage&      srcStage,
+    PXR_NS::SdfLayer&      srcLayer,
+    const PXR_NS::SdfPath& srcParentPath,
+    PXR_NS::UsdStage&      dstStage,
+    PXR_NS::SdfLayer&      dstLayer,
+    const PXR_NS::SdfPath& dstParentPath,
+    const PXR_NS::SdfPath& primToCopy,
+    const bool             followRelationships)
+{
+    return _copyLayerPrims(
+        srcStage,
+        srcLayer,
+        srcParentPath,
+        dstStage,
+        dstLayer,
+        dstParentPath,
+        { primToCopy },
+        followRelationships);
+}
+
+} // namespace
+
+void wrapCopyLayerPrims()
+{
+    def("copyLayerPrim", _copyLayerPrim);
+    def("copyLayerPrims", _copyLayerPrims);
+}

--- a/lib/mayaUsd/utils/CMakeLists.txt
+++ b/lib/mayaUsd/utils/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(${PROJECT_NAME}
         blockSceneModificationContext.cpp
         colorSpace.cpp
         converter.cpp
+        copyLayerPrims.cpp
         customLayerData.cpp
         diagnosticDelegate.cpp
         dynamicAttribute.cpp
@@ -36,6 +37,7 @@ set(HEADERS
     colorSpace.h
     customLayerData.h
     converter.h
+    copyLayerPrims.h
     diagnosticDelegate.h
     dynamicAttribute.h
     editability.h

--- a/lib/mayaUsd/utils/copyLayerPrims.cpp
+++ b/lib/mayaUsd/utils/copyLayerPrims.cpp
@@ -1,0 +1,466 @@
+//
+// Copyright 2024 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "copyLayerPrims.h"
+
+#include <mayaUsd/utils/traverseLayer.h>
+
+#include <pxr/usd/sdf/copyUtils.h>
+
+#include <maya/MGlobal.h>
+
+using namespace PXR_NS;
+
+namespace {
+
+// Debugging helpers to log message to help diagnose problems.
+//#define DEBUG_COPY_LAYER_PRIMS
+
+#ifdef DEBUG_COPY_LAYER_PRIMS
+
+void logDebug(const std::string& msg) { MGlobal::displayInfo(msg.c_str()); }
+#define DEBUG_LOG_COPY_LAYER_PRIMS(X) logDebug(X)
+
+#else
+
+#define DEBUG_LOG_COPY_LAYER_PRIMS(X)
+
+#endif
+
+// Wrappers for the optional progress bar, to avoid having to check if it
+// is null everywhere in the code.
+
+void addProgressSteps(const MayaUsd::CopyLayerPrimsOptions& options, int steps)
+{
+    if (!options.progressBar)
+        return;
+
+    options.progressBar->addSteps(steps);
+}
+
+void advanceProgress(const MayaUsd::CopyLayerPrimsOptions& options)
+{
+    if (!options.progressBar)
+        return;
+
+    options.progressBar->advance();
+}
+
+// Replicate missing ancestor prims of the given destination prim
+// by mimicking those that were found in the source.
+
+void replicateMissingAncestors(
+    const UsdStageRefPtr& srcStage,
+    SdfPath               srcPath,
+    const UsdStageRefPtr& dstStage,
+    SdfPath               dstPath)
+{
+    // List of prims to be created. The last prim should be created
+    // first. (It will be the highest in the hierarchy.)
+    std::vector<std::pair<SdfPath, SdfPath>> toBeCreated;
+
+    while (true) {
+        // If we reach the top of the hierarchy, stop.
+        srcPath = srcPath.GetParentPath();
+        if (srcPath.IsEmpty() || srcPath.IsAbsoluteRootPath())
+            break;
+
+        // If we reach the top of the hierarchy, stop.
+        dstPath = dstPath.GetParentPath();
+        if (dstPath.IsEmpty() || dstPath.IsAbsoluteRootPath())
+            break;
+
+        // If the destination prim already exists, stop.
+        UsdPrim dstPrim = dstStage->GetPrimAtPath(dstPath);
+        if (dstPrim) {
+            DEBUG_LOG_COPY_LAYER_PRIMS(
+                TfStringPrintf("The ancestor %s exists", dstPath.GetAsString().c_str()));
+            break;
+        }
+
+        DEBUG_LOG_COPY_LAYER_PRIMS(
+            TfStringPrintf("The ancestor %s needs to be created", dstPath.GetAsString().c_str()));
+        toBeCreated.emplace_back(srcPath, dstPath);
+    }
+
+    const auto end = toBeCreated.rend();
+    for (auto iter = toBeCreated.rbegin(); iter != end; ++iter) {
+        const SdfPath& srcPath = iter->first;
+        const SdfPath& dstPath = iter->second;
+
+        // Try to reproduce the same prim type, if we can.
+        TfToken primType;
+        if (UsdPrim srcPrim = srcStage->GetPrimAtPath(srcPath))
+            primType = srcPrim.GetTypeName();
+
+        dstStage->DefinePrim(dstPath, primType);
+    }
+}
+
+// Verify if the given path needs to be renamed and rename it if needed.
+void renamePath(SdfPath& pathToVerify, const MayaUsd::CopyLayerPrimsResult& result)
+{
+    for (const auto& oldAndNew : result.renamedPaths) {
+        // If the relationship was not targeting this renamed path, skip.
+        const SdfPath& oldPath = oldAndNew.first;
+        if (!pathToVerify.HasPrefix(oldPath))
+            continue;
+
+        const SdfPath& newPath = oldAndNew.second;
+        SdfPath        renamedPath = pathToVerify.ReplacePrefix(oldPath, newPath);
+
+        DEBUG_LOG_COPY_LAYER_PRIMS(TfStringPrintf(
+            "Renaming path %s to %s",
+            pathToVerify.GetAsString().c_str(),
+            renamedPath.GetAsString().c_str()));
+
+        pathToVerify = renamedPath;
+
+        // Note: each path must only be renamed once. Otherwise, if there
+        //       is a chain of renaming 1 -> 2 -> 3, etc, all paths would
+        //       get renamed to the end of the chain, instead of their one
+        //       true renamed path.
+        //
+        //       For example:
+        //
+        //       Let's say we copied a1 and a2 and suppose the destination
+        //       already contained a1. Then a1 will become a2 and a2 will
+        //       become a3 in the destination.
+        //
+        //       When verifying the path a1 we want to correctly rename it to
+        //       the path a2, but then avoid renaming it again to a3. That is
+        //       why we interrupt renaming at the first renaming.
+        break;
+    }
+}
+
+// Prim hierarchy traverser (a function called for every SdfSpec starting
+// from a prim to be copied, recursively) that copies each prim encountered
+// and optionally adds the targets of relationships to the list of other paths
+// to also be copied.
+//
+// Note: returning false means to prune traversing children.
+bool copyTraverser(
+    const UsdStageRefPtr&                 srcStage,
+    const SdfLayerRefPtr&                 srcLayer,
+    const SdfPath&                        srcParentPath,
+    const UsdStageRefPtr&                 dstStage,
+    const SdfLayerRefPtr&                 dstLayer,
+    const SdfPath&                        dstParentPath,
+    std::vector<SdfPath>&                 otherPathsToCopy,
+    const MayaUsd::CopyLayerPrimsOptions& options,
+    const SdfPath&                        pathToCopy,
+    MayaUsd::CopyLayerPrimsResult&        result)
+{
+    // Check if the path is a relationship target path. If so, we optionally copy
+    // the target since it is used by the prim containing this relationship.
+    if (pathToCopy.IsTargetPath()) {
+        if (options.followRelationships) {
+            const SdfPath& targetPath = pathToCopy.GetTargetPath();
+            if (!targetPath.IsEmpty()) {
+                DEBUG_LOG_COPY_LAYER_PRIMS(TfStringPrintf(
+                    "Adding %s to be copied due to target in %s",
+                    targetPath.GetAsString().c_str(),
+                    pathToCopy.GetAsString().c_str()));
+
+                otherPathsToCopy.emplace_back(targetPath);
+                addProgressSteps(options, 1);
+            }
+        }
+        return true;
+    }
+
+    // We only copy prims, not any other type of specs, like attributes etc.
+    // Copying the prim will copy its attributes, etc.
+    if (!pathToCopy.IsPrimPath()) {
+        DEBUG_LOG_COPY_LAYER_PRIMS(
+            TfStringPrintf("Path %s is not a prim path", pathToCopy.GetAsString().c_str()));
+        return true;
+    }
+
+    for (const auto& srcAndDest : result.copiedPaths) {
+        const SdfPath& alreadyDone = srcAndDest.first;
+        if (pathToCopy.HasPrefix(alreadyDone)) {
+            DEBUG_LOG_COPY_LAYER_PRIMS(TfStringPrintf(
+                "Already copied source prim %s, skipping additional copies",
+                pathToCopy.GetAsString().c_str()));
+
+            // Note: it may have been copied indirectly, in that case it will not
+            //       have been added to the list copied paths, so we want to add
+            //       it to the list of copied paths now. It's important that it be
+            //       added because the list of copied prims is used to post-process
+            //       the copy by the callers. For example, we post-process it to
+            //       handle display layers.
+            if (result.copiedPaths.count(pathToCopy) == 0) {
+                SdfPath dstPath = pathToCopy.ReplacePrefix(srcParentPath, dstParentPath);
+                // Verify if the prim that contained this prim was renamed.
+                renamePath(dstPath, result);
+                result.copiedPaths[pathToCopy] = dstPath;
+            }
+
+            // Note: we must not prevent traversing children otherwise we will
+            //       not process relationships.
+            return true;
+        }
+    }
+
+    // Make the destination path unique and make sure parent prims
+    // exists in the destination.
+    const SdfPath origDstPath = pathToCopy.ReplacePrefix(srcParentPath, dstParentPath);
+    replicateMissingAncestors(srcStage, pathToCopy, dstStage, origDstPath);
+    const SdfPath dstPath = UsdUfe::uniqueChildPath(*dstStage, origDstPath);
+
+    // Record the copy and the potential renaming.
+    result.copiedPaths[pathToCopy] = dstPath;
+    if (dstPath != origDstPath)
+        result.renamedPaths[origDstPath] = dstPath;
+
+    const std::string copyingMsg = TfStringPrintf(
+        "Copying source prim %s to destination prim %s",
+        pathToCopy.GetAsString().c_str(),
+        dstPath.GetAsString().c_str());
+    MGlobal::displayInfo(copyingMsg.c_str());
+
+    // Now perform the actual copy.
+    if (!SdfCopySpec(srcLayer, pathToCopy, dstLayer, dstPath)) {
+        const std::string errMsg
+            = TfStringPrintf("could not copy to %s", dstPath.GetAsString().c_str()).c_str();
+        throw std::runtime_error(errMsg);
+    }
+
+    return true;
+}
+
+// Function to create a copy traverser functor that can take
+// a single argument: the path to process. Used to create the
+// function that can be called by the traverseLayer function.
+auto makeCopyTraverser(
+    const UsdStageRefPtr&                 srcStage,
+    const SdfLayerRefPtr&                 srcLayer,
+    const SdfPath&                        srcParentPath,
+    const UsdStageRefPtr&                 dstStage,
+    const SdfLayerRefPtr&                 dstLayer,
+    const SdfPath&                        dstParentPath,
+    std::vector<SdfPath>&                 otherPathsToCopy,
+    const MayaUsd::CopyLayerPrimsOptions& options,
+    MayaUsd::CopyLayerPrimsResult&        result)
+{
+    auto copyFn = [&srcStage,
+                   &srcLayer,
+                   &srcParentPath,
+                   &dstStage,
+                   &dstLayer,
+                   &dstParentPath,
+                   &otherPathsToCopy,
+                   &options,
+                   &result](const SdfPath& pathToCopy) -> bool {
+        return copyTraverser(
+            srcStage,
+            srcLayer,
+            srcParentPath,
+            dstStage,
+            dstLayer,
+            dstParentPath,
+            otherPathsToCopy,
+            options,
+            pathToCopy,
+            result);
+    };
+    return copyFn;
+}
+
+// Prim hierarchy traverser (a function called for every SdfSpec starting
+// from a prim to be copied, recursively) that finds every targeting paths.
+bool findTargetingPathsTraverser(
+    const UsdStageRefPtr& dstStage,
+    const SdfPath&        layerSpecPath,
+    std::set<SdfPath>&    targetingPaths)
+{
+    // We're only interested in targeting paths.
+    if (!layerSpecPath.IsTargetPath())
+        return true;
+
+    SdfPath targetPath = layerSpecPath.GetTargetPath();
+
+    if (targetingPaths.count(layerSpecPath))
+        return true;
+
+    DEBUG_LOG_COPY_LAYER_PRIMS(
+        TfStringPrintf("Found targeting property %s", layerSpecPath.GetAsString().c_str()));
+
+    targetingPaths.insert(layerSpecPath);
+
+    return true;
+}
+
+// Function to create a find-targeting-path traverser functor that can take
+// a single argument: the path to process. Used to create the function that
+// can be called by the traverseLayer function.
+auto makeFindTargetingPathsTraverser(
+    const UsdStageRefPtr& dstStage,
+    std::set<SdfPath>&    targetingPaths)
+{
+    auto findTargetingFn = [&dstStage, &targetingPaths](const SdfPath& layerSpecPath) -> bool {
+        return findTargetingPathsTraverser(dstStage, layerSpecPath, targetingPaths);
+    };
+    return findTargetingFn;
+}
+
+// Verify if each target needs to be renamed and rename them if needed.
+void renameTargets(SdfPathVector& targets, const MayaUsd::CopyLayerPrimsResult& result)
+{
+    for (auto& target : targets) {
+        renamePath(target, result);
+    }
+}
+
+// Verify if the targets of the given targeting path need to be renamed based on
+// the known list of renamed prims and rename them if needed.
+void renameTargetingPath(
+    const UsdStageRefPtr&                dstStage,
+    const SdfPath&                       layerSpecPath,
+    const MayaUsd::CopyLayerPrimsResult& result)
+{
+    // We're only interested in targeting paths.
+    if (!layerSpecPath.IsTargetPath())
+        return;
+
+#ifdef DEBUG_COPY_LAYER_PRIMS
+    SdfPath targetPath = layerSpecPath.GetTargetPath();
+    DEBUG_LOG_COPY_LAYER_PRIMS(
+        TfStringPrintf("Verifying renaming for %s target path", targetPath.GetAsString().c_str()));
+#endif
+
+    // Determine if we have a relationship target or an attribute connection.
+    // Note: the parent path of a targeting path is the relationship or connection.
+    const SdfPath primPath = layerSpecPath.GetPrimOrPrimVariantSelectionPath();
+    UsdPrim       prim = dstStage->GetPrimAtPath(primPath);
+    const SdfPath targetingPath = layerSpecPath.GetParentPath();
+
+    DEBUG_LOG_COPY_LAYER_PRIMS(TfStringPrintf(
+        "Prim %s containing targeting property %s",
+        primPath.GetAsString().c_str(),
+        targetingPath.GetAsString().c_str()));
+
+    // Adjust all targets that were referring to prims that were renamed.
+    //
+    // Note: we could *almost* use a UsdProperty, which is the base class of
+    //       both UsdRelationship and UsdAttribute. It has a _GetTargets()
+    //       function... but this function is protected! How unfortunate...
+    //       So instead we have two almost identical branches.
+    UsdRelationship rel = prim.GetRelationshipAtPath(targetingPath);
+    if (rel) {
+        // Modify all targets that were using the old path to now use the new path.
+        SdfPathVector targets;
+        rel.GetTargets(&targets);
+        renameTargets(targets, result);
+        rel.SetTargets(targets);
+    } else {
+        // Retrieve the attribute so we can modify its targets.
+        UsdAttribute attr = prim.GetAttributeAtPath(targetingPath);
+        if (attr) {
+            // Modify all targets that were using the old path to now use the new path.
+            SdfPathVector targets;
+            attr.GetConnections(&targets);
+            renameTargets(targets, result);
+            attr.SetConnections(targets);
+        }
+    }
+}
+
+} // namespace
+
+namespace MAYAUSD_NS_DEF {
+
+CopyLayerPrimsResult copyLayerPrims(
+    const UsdStageRefPtr&        srcStage,
+    const SdfLayerRefPtr&        srcLayer,
+    const SdfPath&               srcParentPath,
+    const UsdStageRefPtr&        dstStage,
+    const SdfLayerRefPtr&        dstLayer,
+    const SdfPath&               dstParentPath,
+    const std::vector<SdfPath>&  primsToCopy,
+    const CopyLayerPrimsOptions& options)
+{
+    CopyLayerPrimsResult result;
+
+#ifdef DEBUG_COPY_LAYER_PRIMS
+    std::string layerContentsMsg;
+    if (srcLayer->ExportToString(&layerContentsMsg))
+        DEBUG_LOG_COPY_LAYER_PRIMS(layerContentsMsg.c_str());
+#endif
+
+    // This contains the list of paths that have to be copied.
+    // Initially, it only contains the given source paths,
+    // but we optionally add the destination of relationships
+    // and connections to the list, to copy the related prims.
+    std::vector<SdfPath> otherPathsToCopy = primsToCopy;
+
+    auto copyFn = makeCopyTraverser(
+        srcStage,
+        srcLayer,
+        srcParentPath,
+        dstStage,
+        dstLayer,
+        dstParentPath,
+        otherPathsToCopy,
+        options,
+        result);
+
+    // Traverse the temporary layer starting from the source root path
+    // and copy all prims, optionally including the ones targeted by relationships.
+    //
+    // Note: copyFn can append new items in otherPathsToCopy, so do not optimize
+    //       comparing to the size of the container nor use iterators.
+    //
+    //       For the same reason, the otherPathsToCopy container can be resized
+    //       and its value moved to a new memory location, so that is why
+    //       the path we pass to the traverseLayer function is taken by value.
+    addProgressSteps(options, otherPathsToCopy.size());
+    for (size_t i = 0; i < otherPathsToCopy.size(); ++i) {
+        const SdfPath srcPath = otherPathsToCopy[i];
+        traverseLayer(srcLayer, srcPath, copyFn);
+        advanceProgress(options);
+    }
+
+    // Traverse again the destination prims to find all targeting properties
+    // so that we can rename their targets if necessary.
+    std::set<SdfPath> targetingPaths;
+
+    auto findTargetingsFn = makeFindTargetingPathsTraverser(dstStage, targetingPaths);
+
+    addProgressSteps(options, result.copiedPaths.size());
+    for (const auto& srcAndDest : result.copiedPaths) {
+        const SdfPath& dstPath = srcAndDest.second;
+        traverseLayer(dstLayer, dstPath, findTargetingsFn);
+        advanceProgress(options);
+    }
+
+    DEBUG_LOG_COPY_LAYER_PRIMS(
+        TfStringPrintf("Found %d targeting path.", int(targetingPaths.size())));
+
+    // Rename each target of the given list of targeting paths when they need
+    // to be renamed based on the known list of renamed prims.
+    addProgressSteps(options, targetingPaths.size());
+    for (const SdfPath& layerSpecPath : targetingPaths) {
+        renameTargetingPath(dstStage, layerSpecPath, result);
+        advanceProgress(options);
+    }
+
+    return result;
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/copyLayerPrims.h
+++ b/lib/mayaUsd/utils/copyLayerPrims.h
@@ -1,0 +1,75 @@
+//
+// Copyright 2024 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_COPY_LAYER_PRIMS_H
+#define MAYAUSD_COPY_LAYER_PRIMS_H
+
+#include <mayaUsd/base/api.h>
+#include <mayaUsd/ufe/Utils.h>
+#include <mayaUsd/utils/progressBarScope.h>
+
+#include <pxr/usd/sdf/layer.h>
+#include <pxr/usd/sdf/path.h>
+#include <pxr/usd/usd/stage.h>
+
+#include <map>
+#include <vector>
+
+namespace MAYAUSD_NS_DEF {
+
+//! Options for the copyLayerPrims function.
+struct CopyLayerPrimsOptions
+{
+    // The relationships and connections of the prims will be followed
+    // and the targets of the relations will also get copied.
+    bool followRelationships = true;
+
+    // Optional progress bar.
+    MayaUsd::ProgressBarScope* progressBar = nullptr;
+};
+
+//! The result of the copyLayerPrims function.
+struct CopyLayerPrimsResult
+{
+    // Map of copied source paths to destination paths.
+    std::map<PXR_NS::SdfPath, PXR_NS::SdfPath> copiedPaths;
+
+    // A map of the original destination SdfPath to
+    // renamed destination SdfPath. Used after the copy is done to
+    // rename relationships to a prim that was renamed.
+    // Also used by some callers to handle display layer.
+    MayaUsd::ufe::ReplicateExtrasToUSD::RenamedPaths renamedPaths;
+};
+
+//! \brief copy the given list of paths from the source layer to the target layer.
+//!
+//!        Only copies the prims from the single given layer, and thus assumes
+//!        that all needed information is in that single layer. The typical use case
+//!        is to copy from a temporary exported layer to a destination.
+//!
+MAYAUSD_CORE_PUBLIC
+CopyLayerPrimsResult copyLayerPrims(
+    const PXR_NS::UsdStageRefPtr&       srcStage,
+    const PXR_NS::SdfLayerRefPtr&       srcLayer,
+    const PXR_NS::SdfPath&              srcParentPath,
+    const PXR_NS::UsdStageRefPtr&       dstStage,
+    const PXR_NS::SdfLayerRefPtr&       dstLayer,
+    const PXR_NS::SdfPath&              dstParentPath,
+    const std::vector<PXR_NS::SdfPath>& primsToCopy,
+    const CopyLayerPrimsOptions&        options);
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif

--- a/test/lib/mayaUsd/fileio/CMakeLists.txt
+++ b/test/lib/mayaUsd/fileio/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SCRIPT_FILES
     testComponentTags.py
+    testCopyLayerPrims.py
     testPrimReader.py
     testPrimWriter.py
     testExportChaser.py

--- a/test/lib/mayaUsd/fileio/testCopyLayerPrims.py
+++ b/test/lib/mayaUsd/fileio/testCopyLayerPrims.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2024 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import fixturesUtils
+import testUtils
+import mayaUsd_createStageWithNewLayer
+
+import mayaUsd.lib
+
+import mayaUtils
+import mayaUsd.ufe
+
+from pxr import Usd, Sdf
+
+from maya import cmds
+from maya import standalone
+from maya.api import OpenMaya as om
+
+import ufe
+
+import unittest
+
+import os
+
+class CopyLayerPrimsTestCase(unittest.TestCase):
+    '''
+    Test the copyLayerPrims utility function, used in duplicate-to-USD.
+    '''
+
+    pluginsLoaded = False
+
+    @classmethod
+    def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
+        if not cls.pluginsLoaded:
+            cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def setUp(self):
+        cmds.file(new=True, force=True)
+
+    def _createStageAndLayer(self):
+        '''Create and return an in-memory stage and its root layer.'''
+        stage = Usd.Stage.CreateInMemory()
+        self.assertIsNotNone(stage)
+        layer = stage.GetRootLayer()
+        self.assertIsNotNone(layer)
+        return stage, layer
+    
+    def _createPrims(self, stage, srcPathAndTypes):
+        '''Prims to be created. Might not necessarily all be copied.'''
+        for srcPath, typeName in srcPathAndTypes.items():
+            prim = stage.DefinePrim(Sdf.Path(srcPath), typeName)
+            self.assertTrue(prim, 'Expected to create prim %s with type %s' % (srcPath, typeName))
+
+    def _createRelationships(self, stage, relations):
+        '''Creates the relationships described in the map (dict) of source to target.'''
+        for srcPath, dstPath in relations.items():
+            srcPrim = stage.GetPrimAtPath(Sdf.Path(srcPath))
+            rel = srcPrim.CreateRelationship('arrow')
+            rel.AddTarget(Sdf.Path(dstPath))
+
+    def _createStageLayerAndPrims(self, srcPathAndTypes):
+        '''Create and return an in-memory stage and its root layer and creates prims.'''
+        stage, layer = self._createStageAndLayer()
+        for srcPath, typeName in srcPathAndTypes.items():
+            prim = stage.DefinePrim(Sdf.Path(srcPath), typeName)
+            self.assertTrue(prim, 'Expected to create prim %s with type %s' % (srcPath, typeName))
+        return stage, layer
+    
+    def _verifyDestinationPrims(self, stage, copiedPrims, srcPathAndTypes, expected):
+        '''Verify that the expected prims were created.'''
+        self.assertIsNotNone(copiedPrims)
+        self.assertEqual(len(copiedPrims), len(expected))
+        for srcPath, expectedDstPath in expected.items():
+            self.assertIn(srcPath, srcPathAndTypes)
+            self.assertIn(Sdf.Path(srcPath), copiedPrims)
+            
+            dstPath = copiedPrims[Sdf.Path(srcPath)]
+            self.assertEqual(dstPath, Sdf.Path(expectedDstPath))
+
+            dstPrim = stage.GetPrimAtPath(dstPath)
+            self.assertTrue(dstPrim)
+            self.assertEqual(dstPrim.GetTypeName(), srcPathAndTypes[srcPath])
+
+    def _verifyDestinationRelTargets(self, stage, expected):
+        '''Verify that the relationships have the expected targets.'''
+        for dstPath, expectedTarget in expected.items():
+            dstPrim = stage.GetPrimAtPath(Sdf.Path(dstPath))
+            self.assertTrue(dstPrim)
+            rel = dstPrim.GetRelationship('arrow')
+            self.assertIsNotNone(rel)
+            self.assertTrue(rel)
+            targets = rel.GetTargets()
+            self.assertIn(Sdf.Path(expectedTarget), targets)
+
+    def testCopyLayerPrimsSimple(self):
+        '''Copy a layer containing a cube.'''
+
+        # Prims to be created. Might not necessarily all be copied
+        srcPrims = {
+            "/hello":   "Cube",
+            "/ignored": "Capsule",
+        }
+
+        # Map of destination prim path indexed by the corresponding source path.
+        expectedDstPrims = {
+            "/hello" : "/hello",
+        }
+
+        # Create the source stage, layer and prims.
+        srcStage, srcLayer = self._createStageLayerAndPrims(srcPrims)
+
+        # Create the destination stage and layer.
+        dstStage, dstLayer = self._createStageAndLayer()
+
+        # Copy the desired prims for the test.
+        toCopy = [Sdf.Path("/hello")]
+        srcParentPath = Sdf.Path("/")
+        dstParentPath = Sdf.Path("/")
+        followRelationships = True
+        copiedPrims = mayaUsd.lib.copyLayerPrims(srcStage, srcLayer, srcParentPath,
+                                                dstStage, dstLayer, dstParentPath,
+                                                toCopy, followRelationships)
+        
+        # Verify the results.
+        self._verifyDestinationPrims(dstStage, copiedPrims, srcPrims, expectedDstPrims)
+
+    def testCopyLayerPrimsWithRelation(self):
+        '''Copy a layer containing a cube. May or may not follow the relation to the sphere.'''
+
+        # Prims to be created. Might not necessarily all be copied
+        srcPrims = {
+            "/hello":   "Cube",
+            "/ignored": "Capsule",
+            "/related": "Sphere",
+        }
+
+        # Map of source to target relationships.
+        relationships = {
+            "/hello": "/related",
+        }
+
+        # Map of destination prim path indexed by the corresponding source path.
+        # One map when relationships are followed, one when not.
+        expectedDstForFollow = {
+            True: {
+                "/hello" :  "/hello",
+                "/related": "/related"
+            },
+            False: {
+                "/hello" :  "/hello",
+            }
+        }
+
+        # Map of relationship targets indexed by the destination path that
+        # containing the targeting 'arrow' relationship.
+        expectedTargetsForFollow = {
+            True: {
+                "/hello" :  "/related",
+            },
+            False: {},
+        }
+
+        # Create the source stage, layer and prims.
+        srcStage, srcLayer = self._createStageLayerAndPrims(srcPrims)
+        self._createRelationships(srcStage, relationships)
+
+        toCopy = [Sdf.Path("/hello")]
+        srcParentPath = Sdf.Path("/")
+        dstParentPath = Sdf.Path("/")
+
+        for followRelationships in [True, False]:
+            # Create the destination stage and layer.
+            dstStage, dstLayer = self._createStageAndLayer()
+
+            # Copy the desired prims for the test.
+            copiedPrims = mayaUsd.lib.copyLayerPrims(srcStage, srcLayer, srcParentPath,
+                                                    dstStage, dstLayer, dstParentPath,
+                                                    toCopy, followRelationships)
+            
+            # Verify the results.
+            expectedDstPrims = expectedDstForFollow[followRelationships]
+            self._verifyDestinationPrims(dstStage, copiedPrims, srcPrims, expectedDstPrims)
+
+            expectedDstTargets = expectedTargetsForFollow[followRelationships]
+            self._verifyDestinationRelTargets(dstStage, expectedDstTargets)
+
+    def testCopyLayerPrimsNested(self):
+        '''Copy a layer containing a cube and a nexted cone.'''
+
+        # Prims to be created. Might not necessarily all be copied
+        srcPrims = {
+            "/hello":       "Cube",
+            "/hello/bye":   "Cone",
+            "/ignored": "Capsule",
+        }
+
+        # Map of destination prim path indexed by the corresponding source path.
+        expectedDstPrims = {
+            "/hello" :      "/hello",
+            "/hello/bye" :  "/hello/bye",
+        }
+
+        # Create the source stage, layer and prims.
+        srcStage, srcLayer = self._createStageLayerAndPrims(srcPrims)
+
+        # Create the destination stage and layer.
+        dstStage, dstLayer = self._createStageAndLayer()
+
+        # Copy the desired prims for the test.
+        toCopy = Sdf.Path("/hello")
+        srcParentPath = Sdf.Path("/")
+        dstParentPath = Sdf.Path("/")
+        followRelationships = True
+        copiedPrims = mayaUsd.lib.copyLayerPrim(srcStage, srcLayer, srcParentPath,
+                                                dstStage, dstLayer, dstParentPath,
+                                                toCopy, followRelationships)
+        
+        # Verify the results.
+        self._verifyDestinationPrims(dstStage, copiedPrims, srcPrims, expectedDstPrims)
+
+    def testCopyLayerPrimsNestedLower(self):
+        '''Copy a layer containing a cube and a nexted cone under a non-root destination prim.'''
+
+        # Prims to be created. Might not necessarily all be copied
+        srcPrims = {
+            "/hello":       "Cube",
+            "/hello/bye":   "Cone",
+            "/ignored": "Capsule",
+        }
+
+        # Map of destination prim path indexed by the corresponding source path.
+        expectedDstPrims = {
+            "/hello" :      "/there/hello",
+            "/hello/bye" :  "/there/hello/bye",
+        }
+
+        # Create the source stage, layer and prims.
+        srcStage, srcLayer = self._createStageLayerAndPrims(srcPrims)
+
+        # Create the destination stage, layer and destination prim.
+        dstStage, dstLayer = self._createStageAndLayer()
+        dstStage.DefinePrim("/there")
+
+        # Copy the desired prims for the test.
+        toCopy = Sdf.Path("/hello")
+        srcParentPath = Sdf.Path("/")
+        dstParentPath = Sdf.Path("/there")
+        followRelationships = True
+        copiedPrims = mayaUsd.lib.copyLayerPrim(srcStage, srcLayer, srcParentPath,
+                                                dstStage, dstLayer, dstParentPath,
+                                                toCopy, followRelationships)
+        
+        # Verify the results.
+        self._verifyDestinationPrims(dstStage, copiedPrims, srcPrims, expectedDstPrims)
+
+    def testCopyLayerPrimsNestedToLowerWithRelation(self):
+        '''
+        Copy a layer containing a cube and a nexted cone under a non-root destination prim.
+        There is also a relationship that may or may not be followed depending on options.
+        '''
+
+        # Prims to be created. Might not necessarily all be copied
+        srcPrims = {
+            "/hello":       "Cube",
+            "/hello/bye":   "Cone",
+            "/ignored":     "Capsule",
+            "/related":     "Sphere",
+        }
+
+        # Map of source to target relationships.
+        relationships = {
+            "/hello": "/related",
+        }
+
+        # Map of destination prim path indexed by the corresponding source path.
+        # One map when relationships are followed, one when not.
+        expectedDstForFollow = {
+            True: {
+                "/hello" :      "/there/hello",
+                "/hello/bye" :  "/there/hello/bye",
+                "/related":     "/there/related"
+            },
+            False: {
+                "/hello" :      "/there/hello",
+                "/hello/bye" :  "/there/hello/bye",
+            }
+        }
+
+        # Map of relationship targets indexed by the destination path that
+        # containing the targeting 'arrow' relationship.
+        expectedTargetsForFollow = {
+            True: {
+                "/there/hello" :    "/related",
+            },
+            False: {},
+        }
+
+        # Create the source stage, layer and prims.
+        srcStage, srcLayer = self._createStageLayerAndPrims(srcPrims)
+        self._createRelationships(srcStage, relationships)
+
+        toCopy = [Sdf.Path("/hello")]
+        srcParentPath = Sdf.Path("/")
+        dstParentPath = Sdf.Path("/there")
+
+        for followRelationships in [True, False]:
+            # Create the destination stage, layer and destination prim.
+            dstStage, dstLayer = self._createStageAndLayer()
+            dstStage.DefinePrim("/there")
+
+            # Copy the desired prims for the test.
+            copiedPrims = mayaUsd.lib.copyLayerPrims(srcStage, srcLayer, srcParentPath,
+                                                    dstStage, dstLayer, dstParentPath,
+                                                    toCopy, followRelationships)
+            
+            # Verify the results.
+            expectedDstPrims = expectedDstForFollow[followRelationships]
+            self._verifyDestinationPrims(dstStage, copiedPrims, srcPrims, expectedDstPrims)
+            
+            expectedDstTargets = expectedTargetsForFollow[followRelationships]
+            self._verifyDestinationRelTargets(dstStage, expectedDstTargets)
+
+    def testCopyLayerPrimsChainedRenaming(self):
+        '''
+        Copy a layer containing three nested prims, each with a reltion to a prim with
+        a name ending with an increasing digit, which will collide in the destination.
+
+        This will create a chain of renaming:
+            r1 will be renamed to r2
+            r2 will be renamed to r3
+            r3 will be renamed to r4
+
+        When handling the renamed relationship target, the test verifies that the target
+        only follow one level of renaming. Meaning the correct result we expect is that
+        r1 is now r2, r2 -> r3 and r4 -> r4. If the code were wrong and applied all renaming
+        mappings to all relationships, all targets would incorrectly end-up pointing to r4.
+        '''
+
+        # Prims to be created. Might not necessarily all be copied
+        srcPrims = {
+            "/a":           "Cube",
+            "/a/b":         "Cube",
+            "/a/b/c":       "Cube",
+            "/ignored":     "Capsule",
+            "/r1":          "Cone",
+            "/r2":          "Capsule",
+            "/r3":          "Sphere",
+        }
+
+        # Map of source to target relationships.
+        #
+        # Note: due to the order of traversal, the relationships of the lowest
+        #       prims are copied first, so to create the chain of renaming, we
+        #       need to have r1 be in the lowest prim, not the highest.
+        relationships = {
+            "/a":       "/r3",
+            "/a/b":     "/r2",
+            "/a/b/c":   "/r1",
+        }
+
+        # Map of destination prim path indexed by the corresponding source path.
+        expectedDstPrims = {
+            "/a" :      "/a",
+            "/a/b" :    "/a/b",
+            "/a/b/c":   "/a/b/c",
+            "/r1":      "/r2",
+            "/r2":      "/r3",
+            "/r3":      "/r4",
+        }
+
+        # Map of relationship targets indexed by the destination path that
+        # containing the targeting 'arrow' relationship.
+        expectedDstTargets = {
+            "/a" :      "/r4",
+            "/a/b" :    "/r3",
+            "/a/b/c":   "/r2",
+        }
+
+        # Create the source stage, layer and prims.
+        srcStage, srcLayer = self._createStageLayerAndPrims(srcPrims)
+        self._createRelationships(srcStage, relationships)
+
+        toCopy = [Sdf.Path("/a")]
+        srcParentPath = Sdf.Path("/")
+        dstParentPath = Sdf.Path("/")
+        followRelationships = True
+
+        # Create the destination stage, layer and a prim that will collide
+        # with a relationship target, which will trigger the chain of renaming.
+        dstStage, dstLayer = self._createStageAndLayer()
+        dstStage.DefinePrim("/r1")
+
+        # Copy the desired prims for the test.
+        copiedPrims = mayaUsd.lib.copyLayerPrims(srcStage, srcLayer, srcParentPath,
+                                                 dstStage, dstLayer, dstParentPath,
+                                                 toCopy, followRelationships)
+        
+        # Verify the results.
+        self._verifyDestinationPrims(dstStage, copiedPrims, srcPrims, expectedDstPrims)
+        self._verifyDestinationRelTargets(dstStage, expectedDstTargets)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The goal is to make the duplication more testable.

Some scenarios would require the Arnold plugin to be present and we want to avoid depending on it. So instead, the code refactor split the duplication into finer-grained functions that can be tested by using custom-made temporary layers to reproduce the behavior of Arnold.

The refactor also makes the code clearer and more correct by having smaller functions. Multiple subtle problems were discovered and fixed with this strategy, related to complex cases of renaming and inter-prim relationships.

- Move code to copy temporary prims to a layer out of PrimUpdaterManager.
- This makes the code testable with pre-fabricated temp layers to test specific scenarios.
- This also lighten a bit the prim updater manager source code, which is very large.
- (More code should be refactored out of it in the future to make it simpler and more testable.)
- Fix copyLayerPrims to report all copied prims, even b=nested ones.
- This is important for display layers and renaming.
- Add Python wrapper for copyLayerPrims to allow testing.
- Add explanation to the Python wrapper why stage and layer are not passed by pointers.
- Write multiple unit tests of increasing complexities.
- Add unit tests for optionally copying relationships targets.
- Improve the renaming handling to avoid renaming chains.
- Improve renaming handling to avoid modifying the prim hierarchy while we are traversing it, otherwise the traversal becomes unpredictable and elements could be processed twice.
- Clearly explain in comments the pitfalls of rename chains.
- Add relationship targets verification to the unit tests.