### PR TITLE
EMSUSD-988 Maya node observer classes

### DIFF
--- a/lib/mayaUsd/utils/CMakeLists.txt
+++ b/lib/mayaUsd/utils/CMakeLists.txt
@@ -16,6 +16,8 @@ target_sources(${PROJECT_NAME}
         layers.cpp
         loadRulesAttribute.cpp
         mayaEditRouter.cpp
+        mayaNodeObserver.cpp
+        mayaNodeTypeObserver.cpp
         query.cpp
         plugRegistryHelper.cpp
         primActivation.cpp
@@ -47,6 +49,8 @@ set(HEADERS
     layers.h
     loadRules.h
     mayaEditRouter.h
+    mayaNodeObserver.h
+    mayaNodeTypeObserver.h
     query.h
     plugRegistryHelper.h
     primActivation.h

--- a/lib/mayaUsd/utils/mayaNodeObserver.cpp
+++ b/lib/mayaUsd/utils/mayaNodeObserver.cpp
@@ -1,0 +1,271 @@
+//
+// Copyright 2024 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "mayaNodeObserver.h"
+
+#include <maya/MDagMessage.h>
+#include <maya/MDagPathArray.h>
+#include <maya/MFnDependencyNode.h>
+#include <maya/MNodeMessage.h>
+
+namespace MAYAUSD_NS_DEF {
+
+////////////////////////////////////////////////////////////////////////////
+//
+// External listener called when Maya notifications are received.
+// Default implementation is to do nothing.
+
+void MayaNodeObserver::Listener::processNodeRenamed(
+    MObject& /*observedNode*/,
+    const MString& /*str*/)
+{
+}
+void MayaNodeObserver::Listener::processParentAdded(
+    MObject& /*observedNode*/,
+    MDagPath& /*child*/,
+    MDagPath& /*parent*/)
+{
+}
+void MayaNodeObserver::Listener::processPlugDirty(
+    MObject& observedNode,
+    MObject& /*dirtiedNode*/,
+    MPlug& /*plug*/,
+    bool /*pathChanged*/)
+{
+}
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Constructor and destructor.
+
+MayaNodeObserver::MayaNodeObserver() { }
+
+MayaNodeObserver::~MayaNodeObserver() { stopObserving(); }
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Observation begin and end.
+
+void MayaNodeObserver::startObserving(const MObject& observedNode)
+{
+    stopObserving();
+
+    _observedNode = observedNode;
+
+    updateRenameCallback();
+    updateAncestorCallbacks();
+    updateDagPathCallbacks();
+}
+
+void MayaNodeObserver::stopObserving()
+{
+    removeRenameCallback();
+    removeDagPathCallbacks();
+    removeAncestorCallbacks();
+
+    _observedNode = MObject();
+}
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Listener management.
+
+void MayaNodeObserver::addListener(Listener& listener)
+{
+    // Start tracking and calling the given listener.
+    _listeners.insert(&listener);
+}
+
+void MayaNodeObserver::removeListener(Listener& listener)
+{
+    // Stop tracking and calling the given listener.
+    _listeners.erase(&listener);
+}
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Maya callback helpers.
+
+/* static */
+void MayaNodeObserver::removeCallbackIds(std::vector<MCallbackId>& callbackIds)
+{
+    for (MCallbackId id : callbackIds)
+        removeCallbackId(id);
+    callbackIds.clear();
+}
+
+/* static */
+void MayaNodeObserver::removeCallbackId(MCallbackId& callbackId)
+{
+    MMessage::removeCallback(callbackId);
+    callbackId = 0;
+}
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Maya callbacks registration and cleanup.
+
+void MayaNodeObserver::updateRenameCallback()
+{
+    removeRenameCallback();
+    _renameCallbackId
+        = MNodeMessage::addNameChangedCallback(_observedNode, processNodeRenamed, this);
+}
+
+void MayaNodeObserver::removeRenameCallback() { removeCallbackId(_renameCallbackId); }
+
+void MayaNodeObserver::updateDagPathCallbacks()
+{
+    removeDagPathCallbacks();
+
+    MDagPathArray dags;
+    if (MDagPath::getAllPathsTo(_observedNode, dags)) {
+        const auto numDags = dags.length();
+        for (auto i = decltype(numDags) { 0 }; i < numDags; ++i) {
+            MDagPath& dag = dags[i];
+            for (; dag.length() > 0; dag.pop()) {
+                MObject obj = dag.node();
+                if (obj == MObject::kNullObj)
+                    continue;
+                _parentAddedCallbackIds.push_back(
+                    MDagMessage::addParentAddedDagPathCallback(dag, processParentAdded, this));
+            }
+        }
+    }
+}
+
+void MayaNodeObserver::removeDagPathCallbacks() { removeCallbackIds(_parentAddedCallbackIds); }
+
+void MayaNodeObserver::updateAncestorCallbacks()
+{
+    removeAncestorCallbacks();
+
+    // Add our own callback
+    _ancestorCallbackIds.push_back(
+        MNodeMessage::addNodeDirtyPlugCallback(_observedNode, processPlugDirty, this));
+
+    // Remember the path for which we are accumulating the listener
+    MDagPath ancestorPath;
+    MDagPath::getAPathTo(_observedNode, ancestorPath);
+    _ancestorCallbacksPath = ancestorPath.fullPathName();
+
+    // Add listener for all the ancestors
+    for (ancestorPath.pop(); ancestorPath.isValid() && ancestorPath.length() > 0;
+         ancestorPath.pop()) {
+        MObject ancestorObj = ancestorPath.node();
+        _ancestorCallbackIds.push_back(
+            MNodeMessage::addNodeDirtyPlugCallback(ancestorObj, processPlugDirty, this));
+    }
+}
+
+void MayaNodeObserver::removeAncestorCallbacks() { removeCallbackIds(_ancestorCallbackIds); }
+
+void MayaNodeObserver::updateAllNameRelatedCallbacks()
+{
+    updateAncestorCallbacks();
+    updateDagPathCallbacks();
+}
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Maya callbacks processing and forwarding to listeners.
+
+namespace {
+
+template <typename T> struct AutoValueRestore
+{
+    AutoValueRestore(T& value, T newValue)
+        : _value(value)
+        , _oldValue(value)
+    {
+        value = newValue;
+    }
+
+    ~AutoValueRestore() { _value = _oldValue; }
+
+    T&      _value;
+    const T _oldValue;
+};
+
+} // namespace
+
+/* static */
+void MayaNodeObserver::processPlugDirty(MObject& node, MPlug& plug, void* clientData)
+{
+    auto self = static_cast<MayaNodeObserver*>(clientData);
+    if (!self)
+        return;
+
+    // This prevents recursion.
+    if (self->_inAncestorCallback)
+        return;
+
+    AutoValueRestore<bool> restoreInAncestor(self->_inAncestorCallback, true);
+
+    // If the observed node's path has changed, update ancestor listener
+    // and the DAG listener.
+    MDagPath currentPath;
+    MDagPath::getAPathTo(self->_observedNode, currentPath);
+    const bool pathChanged = (currentPath.fullPathName() != self->_ancestorCallbacksPath);
+    if (pathChanged)
+        self->updateAllNameRelatedCallbacks();
+
+    // Note: we make a copy of the set of listeners in case calling
+    //       a listener adds or remove listeners.
+    const auto cachedListeners = self->_listeners;
+    for (Listener* cb : cachedListeners)
+        cb->processPlugDirty(self->_observedNode, node, plug, pathChanged);
+}
+
+/* static */
+void MayaNodeObserver::processNodeRenamed(MObject& node, const MString& oldName, void* clientData)
+{
+    auto self = static_cast<MayaNodeObserver*>(clientData);
+    if (!self)
+        return;
+
+    // Nodes only have a proper DAG path once renamed.
+    // So, on rename, we update the listener.
+    self->updateAllNameRelatedCallbacks();
+
+    // Note: we make a copy of the set of listeners in case calling
+    //       a listener adds or remove listeners.
+    const auto cachedListeners = self->_listeners;
+    for (Listener* cb : cachedListeners)
+        cb->processNodeRenamed(node, oldName);
+}
+
+/* static */
+void MayaNodeObserver::processParentAdded(
+    MDagPath& childPath,
+    MDagPath& parentPath,
+    void*     clientData)
+{
+    auto self = static_cast<MayaNodeObserver*>(clientData);
+    if (!self)
+        return;
+
+    // Reparented, so listen to new hierarchy.
+    self->updateAllNameRelatedCallbacks();
+
+    // Note: we make a copy of the set of listeners in case calling
+    //       a listener adds or remove listeners.
+    const auto cachedListeners = self->_listeners;
+    for (Listener* cb : cachedListeners)
+        cb->processParentAdded(self->_observedNode, childPath, parentPath);
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/mayaNodeObserver.h
+++ b/lib/mayaUsd/utils/mayaNodeObserver.h
@@ -1,0 +1,121 @@
+//
+// Copyright 2024 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_MAYA_NODE_OBSERVER_H
+#define MAYAUSD_MAYA_NODE_OBSERVER_H
+
+#include <mayaUsd/base/api.h>
+
+#include <maya/MDagPath.h>
+#include <maya/MMessage.h>
+#include <maya/MObject.h>
+#include <maya/MPlug.h>
+#include <maya/MString.h>
+
+#include <set>
+#include <vector>
+
+namespace MAYAUSD_NS_DEF {
+
+//! Observer for a single Maya node that receives notifications when the node is renamed,
+//  reparented, or any of its ancestor is renamed or reparented.
+//
+// It forwards those notifications to listerners.
+class MayaNodeObserver
+{
+public:
+    //! Listener triggered by the observation.
+    struct MAYAUSD_CORE_PUBLIC Listener
+    {
+        //! Called when a given particular node is renamed.
+        virtual void processNodeRenamed(MObject& observedNode, const MString& str);
+        //! Called when a parent is added anywhere in the hierarchy of a given particular node.
+        virtual void processParentAdded(MObject& observedNode, MDagPath& child, MDagPath& parent);
+        //! Called when a plug is dirtied anywhere in the hierarchy of a given particular node.
+        virtual void processPlugDirty(
+            MObject& observedNode,
+            MObject& dirtiedNode,
+            MPlug&   plug,
+            bool     pathChanged);
+    };
+
+    //! Create a Maya node observer. To start observing the node, call startObserving().
+    MAYAUSD_CORE_PUBLIC
+    MayaNodeObserver();
+
+    MAYAUSD_CORE_PUBLIC
+    ~MayaNodeObserver();
+
+    //! Start observing the given node. Ends observing any previous observed node.
+    MAYAUSD_CORE_PUBLIC
+    void startObserving(const MObject& observedNode);
+
+    //! Stop observing the given node.
+    MAYAUSD_CORE_PUBLIC
+    void stopObserving();
+
+    //! Add a listener to be called when the node changes.
+    //
+    //  The caller is responsible to ensure the listener is valid
+    //  until removed.
+    MAYAUSD_CORE_PUBLIC
+    void addListener(Listener& listener);
+
+    //! Remove a listener.
+    MAYAUSD_CORE_PUBLIC
+    void removeListener(Listener& listener);
+
+    //! Remove all listener in the given vector of listener and clear the vector.
+    MAYAUSD_CORE_PUBLIC
+    static void removeCallbackIds(std::vector<MCallbackId>& callbackIds);
+
+    //! Remove the given callback and clear it, make it an invalid callback ID.
+    MAYAUSD_CORE_PUBLIC
+    static void removeCallbackId(MCallbackId& callbackId);
+
+private:
+    MayaNodeObserver(const MayaNodeObserver&) = delete;
+    MayaNodeObserver& operator=(const MayaNodeObserver&) = delete;
+
+    void updateRenameCallback();
+    void removeRenameCallback();
+
+    void updateAncestorCallbacks();
+    void removeAncestorCallbacks();
+
+    void updateDagPathCallbacks();
+    void removeDagPathCallbacks();
+
+    void updateAllNameRelatedCallbacks();
+
+    static void processNodeRenamed(MObject& observedNode, const MString& str, void* clientData);
+    static void processParentAdded(MDagPath& child, MDagPath& parent, void* clientData);
+    static void processPlugDirty(MObject& dirtiedNode, MPlug& plug, void* clientData);
+
+    MObject _observedNode;
+
+    MCallbackId              _renameCallbackId = 0;
+    std::vector<MCallbackId> _parentAddedCallbackIds;
+    std::vector<MCallbackId> _ancestorCallbackIds;
+
+    MString _ancestorCallbacksPath;
+    bool    _inAncestorCallback = false;
+
+    std::set<Listener*> _listeners;
+};
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif

--- a/lib/mayaUsd/utils/mayaNodeTypeObserver.cpp
+++ b/lib/mayaUsd/utils/mayaNodeTypeObserver.cpp
@@ -1,0 +1,165 @@
+//
+// Copyright 2024 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "mayaNodeTypeObserver.h"
+
+#include <mayaUsd/base/debugCodes.h>
+
+#include <maya/MDGMessage.h>
+
+namespace MAYAUSD_NS_DEF {
+
+////////////////////////////////////////////////////////////////////////////
+//
+// External listener called when Maya notifications are received.
+// Default implementation is to do nothing.
+
+void MayaNodeTypeObserver::Listener::processNodeAdded(MObject& /*node*/) { }
+void MayaNodeTypeObserver::Listener::processNodeRemoved(MObject& /*node*/) { }
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Constructor and destructor.
+
+MayaNodeTypeObserver::MayaNodeTypeObserver(const MString& nodeTypeName)
+    : _nodeTypeName(nodeTypeName)
+{
+    updateNodeAddedRemovedCallbacks();
+}
+
+MayaNodeTypeObserver::~MayaNodeTypeObserver()
+{
+    // Stop listening to Maya notifications.
+    removeNodeAddedRemovedCallbacks();
+}
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Listener management.
+
+void MayaNodeTypeObserver::addTypeListener(Listener& listener)
+{
+    // Start tracking and calling the given node type listener.
+    _listeners.insert(&listener);
+}
+
+void MayaNodeTypeObserver::removeTypeListener(Listener& listener)
+{
+    // Stop tracking and calling the given node type listener.
+    _listeners.erase(&listener);
+}
+
+void MayaNodeTypeObserver::addNodeListener(MayaNodeObserver::Listener& listener)
+{
+    for (auto& handleAndObserver : _observedNodes)
+        handleAndObserver.second.addListener(listener);
+}
+
+void MayaNodeTypeObserver::removeNodeListener(MayaNodeObserver::Listener& listener)
+{
+    for (auto& handleAndObserver : _observedNodes)
+        handleAndObserver.second.removeListener(listener);
+}
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Manual observed node management.
+
+MayaNodeObserver* MayaNodeTypeObserver::addObservedNode(const MObject& node)
+{
+    MObjectHandle handle(node);
+    auto          iter = _observedNodes.find(handle);
+    if (iter != _observedNodes.end())
+        return &(iter->second);
+
+    MayaNodeObserver& observer = _observedNodes[handle];
+    observer.startObserving(node);
+    return &observer;
+}
+
+void MayaNodeTypeObserver::removeObservedNode(const MObject& node)
+{
+    MObjectHandle handle(node);
+    _observedNodes.erase(handle);
+}
+
+MayaNodeObserver* MayaNodeTypeObserver::getNodeObserver(const MObject& node)
+{
+    MObjectHandle handle(node);
+    auto          iter = _observedNodes.find(handle);
+    if (iter == _observedNodes.end())
+        return nullptr;
+
+    return &(iter->second);
+}
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Maya listener registration and cleanup.
+
+void MayaNodeTypeObserver::updateNodeAddedRemovedCallbacks()
+{
+    removeNodeAddedRemovedCallbacks();
+
+    _nodeAddedRemovedCallbackIds.push_back(
+        MDGMessage::addNodeAddedCallback(processNodeAdded, _nodeTypeName, this));
+
+    _nodeAddedRemovedCallbackIds.push_back(
+        MDGMessage::addNodeRemovedCallback(processNodeRemoved, _nodeTypeName, this));
+}
+
+void MayaNodeTypeObserver::removeNodeAddedRemovedCallbacks()
+{
+    MayaNodeObserver::removeCallbackIds(_nodeAddedRemovedCallbackIds);
+}
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Maya listener processing and forwarding.
+
+/* static */
+void MayaNodeTypeObserver::processNodeAdded(MObject& node, void* clientData)
+{
+    auto self = static_cast<MayaNodeTypeObserver*>(clientData);
+    if (!self)
+        return;
+
+    self->addObservedNode(node);
+
+    // Note: we make a copy of the set of listeners in case calling
+    //       a listener adds or remove listeners.
+    const auto cachedListeners = self->_listeners;
+    for (Listener* cb : cachedListeners)
+        cb->processNodeAdded(node);
+}
+
+/* static */
+void MayaNodeTypeObserver::processNodeRemoved(MObject& node, void* clientData)
+{
+    auto self = static_cast<MayaNodeTypeObserver*>(clientData);
+    if (!self)
+        return;
+
+    // Note: we make a copy of the set of listeners in case calling
+    //       a listener adds or remove listeners.
+    const auto cachedListeners = self->_listeners;
+    for (Listener* cb : cachedListeners)
+        cb->processNodeRemoved(node);
+
+    self->removeObservedNode(node);
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/mayaNodeTypeObserver.h
+++ b/lib/mayaUsd/utils/mayaNodeTypeObserver.h
@@ -1,0 +1,121 @@
+//
+// Copyright 2024 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_MAYA_NODE_TYPE_OBSERVER_H
+#define MAYAUSD_MAYA_NODE_TYPE_OBSERVER_H
+
+#include <mayaUsd/base/api.h>
+#include <mayaUsd/utils/mayaNodeObserver.h>
+
+#include <maya/MFnDependencyNode.h>
+#include <maya/MObjectHandle.h>
+
+#include <memory>
+#include <unordered_map>
+
+namespace MAYAUSD_NS_DEF {
+
+//! Observer for a given type of Maya node. Receives notifications when
+//  an instance of that node type is added or removed and start observing
+//  that node for renaming, etc with a MayaNodeObserver.
+//
+// It forwards those notifications to listerners.
+class MayaNodeTypeObserver
+{
+public:
+    //! Listener triggered by the observation.
+    struct MAYAUSD_CORE_PUBLIC Listener
+    {
+        //! Called when any node of the observed type is added to the Maya scene.
+        virtual void processNodeAdded(MObject& node);
+        //! Called when any node of the observed type is removed from the Maya scene.
+        virtual void processNodeRemoved(MObject& node);
+    };
+
+    //! Create a Maya node type observer for the given node type.
+    MAYAUSD_CORE_PUBLIC
+    MayaNodeTypeObserver(const MString& nodeTypeName);
+    MAYAUSD_CORE_PUBLIC
+    ~MayaNodeTypeObserver();
+
+    //! Add a node type listener to be called when the node changes.
+    //
+    //  The caller is responsible to ensure the listener is valid
+    //  until removed.
+    MAYAUSD_CORE_PUBLIC
+    void addTypeListener(Listener& listener);
+
+    //! Remove a node type listener.
+    MAYAUSD_CORE_PUBLIC
+    void removeTypeListener(Listener& listener);
+
+    //! Add a node listener to all observed nodes.
+    //
+    //  Useful to initially setup to receive listener from nodes
+    //  that may have already been added before a listener is ready.
+    MAYAUSD_CORE_PUBLIC
+    void addNodeListener(MayaNodeObserver::Listener& listener);
+
+    //! Remove a node listener from all observed nodes.
+    MAYAUSD_CORE_PUBLIC
+    void removeNodeListener(MayaNodeObserver::Listener& listener);
+
+    //! Add a node of the observed type to be observed.
+    //  Return the node observer associated with the node.
+    //  We trust the caller to only pass nodes of the correct type.
+    //
+    // Adding a node multipe times is safe, extra aditions are do nothing.
+    //
+    //  Used so that the C++ class of the node type can manually add
+    //  node instances as early as they are created, if needed.
+    MAYAUSD_CORE_PUBLIC
+    MayaNodeObserver* addObservedNode(const MObject& node);
+
+    //! Remove a node of the observed type tono longer be observed.
+    //  We trust the caller to only pass nodes of the correct type.
+    //
+    //  Used so that the C++ class of the node type can manually remove
+    //  node instances as early as they are destroyed, if needed.
+    MAYAUSD_CORE_PUBLIC
+    void removeObservedNode(const MObject& node);
+
+    //! Retrieve the node observer for the given node, if any.
+    //  Return null if the node is not being observed by this instance.
+    MAYAUSD_CORE_PUBLIC
+    MayaNodeObserver* getNodeObserver(const MObject& node);
+
+private:
+    void updateNodeAddedRemovedCallbacks();
+    void removeNodeAddedRemovedCallbacks();
+
+    static void processNodeAdded(MObject& node, void* clientData);
+    static void processNodeRemoved(MObject& node, void* clientData);
+
+    struct ObjectHandleHasher
+    {
+        unsigned long operator()(const MObjectHandle& handle) const { return handle.hashCode(); }
+    };
+
+    using ObservedNodeMap = std::unordered_map<MObjectHandle, MayaNodeObserver, ObjectHandleHasher>;
+
+    MString                  _nodeTypeName;
+    ObservedNodeMap          _observedNodes;
+    std::vector<MCallbackId> _nodeAddedRemovedCallbackIds;
+    std::set<Listener*>      _listeners;
+};
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif


### PR DESCRIPTION
Add new classes to observe Maya nodes of a given type or a given Maya node. The observer forward changes to registered listeners. The goal is to standardize how a node is observed and to share the notification between multiple listeners.

This will be used by multiple classes in a subsequent pull request: MayaUsdProxyShapeBase, UsdStageMap and MayaSessionState.

The MayaNodeTypeObserver allows listening to new nodes being created or removed. The MayaNodeObserver allows listening to the node being renamed or reparented. Many use cases need to track the DAG path, UFE path or USD path of objects, mostly the USD stage itself.