### PR TITLE
EMSUSD-957 - Call CanExport() per object instead of per export

### DIFF
--- a/lib/mayaUsd/fileio/primWriterRegistry.cpp
+++ b/lib/mayaUsd/fileio/primWriterRegistry.cpp
@@ -84,6 +84,12 @@ _Registry::const_iterator _Find(
 } // namespace
 
 /* static */
+bool UsdMayaPrimWriterRegistry::HasMultipleWriters(const std::string& mayaTypeName)
+{
+    return _reg.count(mayaTypeName) > 1;
+}
+
+/* static */
 void UsdMayaPrimWriterRegistry::Register(
     const std::string&                            mayaTypeName,
     UsdMayaPrimWriterRegistry::ContextPredicateFn pred,

--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -590,8 +590,11 @@ UsdMayaWriteJobContext::_FindWriter(const MFnDependencyNode& mayaNode)
     const std::string mayaNodeType(mayaNode.typeName().asChar());
 
     // Check if type is already cached locally.
+    // If this type has multiple writers, we need to call CanExport again to determine which writer
+    // to use
     auto iter = mWriterFactoryCache.find(mayaNodeType);
-    if (iter != mWriterFactoryCache.end()) {
+    if (iter != mWriterFactoryCache.end()
+        && !UsdMayaPrimWriterRegistry::HasMultipleWriters(mayaNodeType)) {
         return iter->second;
     }
 


### PR DESCRIPTION
https://github.com/Autodesk/maya-usd/issues/3502

What MayaUsd used to do is using a map to remember if a primWriter has been used for this maya object type. However, with our _CanExport()_ feature available, the user may want to inspect each object and see which writer to use, so call Find() to inspect and find the best primWriter to use if there are multiple primWriters available for this maya object type
