### PR TITLE
EMSUSD-987 undo edit prototype

### DIFF
--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -676,6 +676,7 @@ bool UsdMaya_ReadJob::_DoImport(UsdPrimRange& rootRange, const UsdPrim& usdRootP
                     }
                 }
                 deletePrototypeMod.deleteNode(prototypeObject, false);
+                mNewNodeRegistry.erase(prototypePath.GetString());
             }
             prototypesLoop.loopAdvance();
         }


### PR DESCRIPTION
Editing as Maya an instanced object and then undoing the edit-as-Maya would crash. That was because when editing an instance, Maya nodes were briefly created for the prototype, registered as newly-created nodes, then immediately deleted. When undoing, the undo was trying to delete those non-existing nodes.

Fix by removing the deleted node from the map of created Maya nodes.