### PR TITLE
EMSUSD-1001 lost muted layer

### DIFF
--- a/test/lib/mayaUsd/fileio/CMakeLists.txt
+++ b/test/lib/mayaUsd/fileio/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TEST_SCRIPT_FILES
     testImportWithNamespace.py
     testJobContextRegistry.py
     testDisplayLayerSaveRestore.py
+    testSaveMutedAnonLayer.py
 
     # Once of the tests in this file requires UsdMaya (from the Pixar plugin). That test
     # will be skipped if not found (probably because BUILD_PXR_PLUGIN is off).

--- a/test/lib/mayaUsd/fileio/testSaveMutedAnonLayer.py
+++ b/test/lib/mayaUsd/fileio/testSaveMutedAnonLayer.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2022 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import fixturesUtils
+
+from maya import cmds
+from maya import standalone
+
+import mayaUtils
+import mayaUsd
+import mayaUsd_createStageWithNewLayer
+
+import usdUtils
+
+from pxr import Usd, Sdf
+
+import unittest
+
+class SaveMutedLayerTest(unittest.TestCase):
+    '''
+    Test saving muted layers and reloading the scene to verify they are not lost.
+    '''
+
+    pluginsLoaded = False
+
+    @classmethod
+    def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
+        if not cls.pluginsLoaded:
+            cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def setUp(self):
+        cmds.file(new=True, force=True)
+
+    def testSaveMutedAnonLayer(self):
+        # Create a stage with a sub-layer.
+        psPathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        stage = mayaUsd.lib.GetPrim(psPathStr).GetStage()
+        rootLayer = stage.GetRootLayer()
+        subLayer = usdUtils.addNewLayerToLayer(rootLayer, anonymous=True)
+
+        # Add a prim in the root and in the sub-layer.
+        with Usd.EditContext(stage, Usd.EditTarget(rootLayer)):
+            stage.DefinePrim('/InRoot', 'Sphere')
+
+        with Usd.EditContext(stage, Usd.EditTarget(subLayer)):
+            stage.DefinePrim('/InSub', 'Cube')
+
+        def verifyPrims(stage):
+            inRoot = stage.GetPrimAtPath("/InRoot")
+            self.assertTrue(inRoot)
+            inRoot = None
+            inSub = stage.GetPrimAtPath("/InSub")
+            self.assertTrue(inSub)
+            inSub = None
+
+        verifyPrims(stage)
+
+        # Mute the sub-layer.
+        stage.MuteLayer(subLayer.identifier)
+
+        # Save the file. Make sure the edit will go to the Maya file.
+        tempMayaFile = 'saveMutedAnonLayer.ma'
+        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 2))
+        cmds.file(rename=tempMayaFile)
+        cmds.file(save=True, force=True, type='mayaAscii')
+
+        # Clear and reopen the file.
+        stage = None
+        rootLayer = None
+        subLayer = None
+        cmds.file(new=True, force=True)
+        cmds.file(tempMayaFile, open=True)
+
+        # Retrieve the stage, root and sub-layer.
+        stage = mayaUsd.lib.GetPrim(psPathStr).GetStage()
+        rootLayer = stage.GetRootLayer()
+        self.assertEqual(len(rootLayer.subLayerPaths), 1)
+        subLayerPath = rootLayer.subLayerPaths[0]
+        self.assertIsNotNone(subLayerPath)
+        self.assertTrue(subLayerPath)
+        subLayer = Sdf.Layer.FindRelativeToLayer(rootLayer,subLayerPath)
+        self.assertIsNotNone(subLayer)
+
+        # Verify the two objects are still present.
+        stage.UnmuteLayer(subLayer.identifier)
+        verifyPrims(stage)

--- a/test/lib/mayaUsd/fileio/testSaveMutedAnonLayer.py
+++ b/test/lib/mayaUsd/fileio/testSaveMutedAnonLayer.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright 2022 Autodesk
+# Copyright 2024 Autodesk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/lib/mayaUsd/fileio/testSaveMutedAnonLayer.py
+++ b/test/lib/mayaUsd/fileio/testSaveMutedAnonLayer.py
@@ -99,7 +99,7 @@ class SaveMutedLayerTest(unittest.TestCase):
         subLayerPath = rootLayer.subLayerPaths[0]
         self.assertIsNotNone(subLayerPath)
         self.assertTrue(subLayerPath)
-        subLayer = Sdf.Layer.FindRelativeToLayer(rootLayer,subLayerPath)
+        subLayer = Sdf.Layer.Find(subLayerPath)
         self.assertIsNotNone(subLayer)
 
         # Verify the two objects are still present.


### PR DESCRIPTION
Fix that muted anonymous layers are lost when saved within the Maya scene file. The culprit was that UsdStage::GetLayerStack() did not return muted layers. The new code use an alternative method to retrieve the list of layers.