### PR TITLE
EMSUSD-1000 - Implement new Hierarchy Cmd.

### DIFF
--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
@@ -251,6 +251,18 @@ ProxyShapeHierarchy::insertChild(const Ufe::SceneItem::Ptr& child, const Ufe::Sc
     return insertChildCommand->insertedChild();
 }
 
+Ufe::InsertChildCommand::Ptr
+ProxyShapeHierarchy::appendChildVerifyRestrictionsCmd(const Ufe::SceneItem::Ptr& child)
+{
+    const auto childCmd = appendChildCmd(child);
+
+    if (childCmd && isConnected(downcast(child))) {
+        throw std::runtime_error("The node you're trying to move has connections.");
+    }
+
+    return childCmd;
+}
+
 #ifdef UFE_V3_FEATURES_AVAILABLE
 Ufe::SceneItem::Ptr ProxyShapeHierarchy::createGroup(const Ufe::PathComponent& name) const
 {

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
@@ -78,6 +78,8 @@ public:
     insertChild(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
     Ufe::InsertChildCommand::Ptr
     insertChildCmd(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
+    Ufe::InsertChildCommand::Ptr
+    appendChildVerifyRestrictionsCmd(const Ufe::SceneItem::Ptr& child) override;
 
     Ufe::UndoableCommand::Ptr reorderCmd(const Ufe::SceneItemList& orderedList) const override;
 

--- a/lib/mayaUsd/ufe/PulledObjectHierarchy.cpp
+++ b/lib/mayaUsd/ufe/PulledObjectHierarchy.cpp
@@ -81,6 +81,13 @@ Ufe::InsertChildCommand::Ptr PulledObjectHierarchy::insertChildCmd(
     return nullptr;
 }
 
+Ufe::InsertChildCommand::Ptr
+PulledObjectHierarchy::appendChildVerifyRestrictionsCmd(const Ufe::SceneItem::Ptr& child)
+{
+    TF_CODING_ERROR("Illegal call to unimplemented %s", __func__);
+    return nullptr;
+}
+
 Ufe::SceneItem::Ptr
 PulledObjectHierarchy::insertChild(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos)
 {

--- a/lib/mayaUsd/ufe/PulledObjectHierarchy.h
+++ b/lib/mayaUsd/ufe/PulledObjectHierarchy.h
@@ -74,6 +74,8 @@ public:
     insertChild(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
     Ufe::InsertChildCommand::Ptr
     insertChildCmd(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
+    Ufe::InsertChildCommand::Ptr
+    appendChildVerifyRestrictionsCmd(const Ufe::SceneItem::Ptr& child) override;
 
     Ufe::UndoableCommand::Ptr reorderCmd(const Ufe::SceneItemList& orderedList) const override;
 

--- a/lib/mayaUsd/ufe/UsdAttributes.cpp
+++ b/lib/mayaUsd/ufe/UsdAttributes.cpp
@@ -446,7 +446,7 @@ static void removeSrcAttrConnections(PXR_NS::UsdPrim& prim, const PXR_NS::UsdAtt
     for (const auto& attribute : prim.GetAttributes()) {
         PXR_NS::UsdAttribute dstUsdAttr = attribute.As<PXR_NS::UsdAttribute>();
 
-        if (MayaUsd::ufe::isConnected(srcUsdAttr, dstUsdAttr)) {
+        if (isConnected(srcUsdAttr, dstUsdAttr)) {
             UsdShadeConnectableAPI::DisconnectSource(dstUsdAttr, srcUsdAttr);
             // Check if we can remove the property.
             if (MayaUsd::ufe::canRemoveDstProperty(dstUsdAttr)) {

--- a/lib/mayaUsd/ufe/UsdUndoConnectionCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoConnectionCommands.cpp
@@ -22,6 +22,7 @@
 #include <mayaUsd/ufe/UsdConnections.h>
 #include <mayaUsd/ufe/Utils.h>
 
+#include <usdUfe/ufe/Utils.h>
 #include <usdUfe/ufe/UsdSceneItem.h>
 #include <usdUfe/undo/UsdUndoBlock.h>
 #include <usdUfe/utils/usdUtils.h>
@@ -155,7 +156,7 @@ void UsdUndoCreateConnectionCommand::execute()
         return;
     }
 
-    if (MayaUsd::ufe::isConnected(srcUsdAttr->usdAttribute(), dstUsdAttr->usdAttribute())) {
+    if (isConnected(srcUsdAttr->usdAttribute(), dstUsdAttr->usdAttribute())) {
         return;
     }
 
@@ -287,7 +288,7 @@ void UsdUndoDeleteConnectionCommand::execute()
     UsdAttribute* dstUsdAttr = usdAttrFromUfeAttr(dstAttr);
 
     if (!srcUsdAttr || !dstUsdAttr
-        || !MayaUsd::ufe::isConnected(srcUsdAttr->usdAttribute(), dstUsdAttr->usdAttribute())) {
+        || !isConnected(srcUsdAttr->usdAttribute(), dstUsdAttr->usdAttribute())) {
         return;
     }
 #if PXR_VERSION < 2302

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -347,20 +347,6 @@ TfTokenVector getProxyShapePurposes(const Ufe::Path& path)
     return purposes;
 }
 
-bool isConnected(const PXR_NS::UsdAttribute& srcUsdAttr, const PXR_NS::UsdAttribute& dstUsdAttr)
-{
-    PXR_NS::SdfPathVector connectedAttrs;
-    dstUsdAttr.GetConnections(&connectedAttrs);
-
-    for (PXR_NS::SdfPath path : connectedAttrs) {
-        if (path == srcUsdAttr.GetPath()) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 bool canRemoveSrcProperty(const PXR_NS::UsdAttribute& srcAttr)
 {
 

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -116,11 +116,6 @@ PXR_NS::UsdTimeCode getTime(const Ufe::Path& path);
 MAYAUSD_CORE_PUBLIC
 PXR_NS::TfTokenVector getProxyShapePurposes(const Ufe::Path& path);
 
-//! Check if the src and dst attributes are connected.
-//! \return True, if they are connected.
-MAYAUSD_CORE_PUBLIC
-bool isConnected(const PXR_NS::UsdAttribute& srcUsdAttr, const PXR_NS::UsdAttribute& dstUsdAttr);
-
 //! Check if a source connection property is allowed to be removed.
 //! \return True, if the property can be removed.
 MAYAUSD_CORE_PUBLIC

--- a/lib/usdUfe/ufe/UsdHierarchy.cpp
+++ b/lib/usdUfe/ufe/UsdHierarchy.cpp
@@ -257,6 +257,19 @@ UsdHierarchy::insertChildCmd(const Ufe::SceneItem::Ptr& child, const Ufe::SceneI
     return UsdUndoInsertChildCommand::create(fItem, downcast(child), downcast(pos));
 }
 
+Ufe::InsertChildCommand::Ptr
+UsdHierarchy::appendChildVerifyRestrictionsCmd(const Ufe::SceneItem::Ptr& child)
+{
+    const auto childCmd = appendChildCmd(child);
+
+    if (childCmd && isConnected(downcast(child))) {
+        throw std::runtime_error("The node you're trying to move has connections.");
+    }
+
+    return childCmd;
+}
+
+
 Ufe::SceneItem::Ptr
 UsdHierarchy::insertChild(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos)
 {

--- a/lib/usdUfe/ufe/UsdHierarchy.h
+++ b/lib/usdUfe/ufe/UsdHierarchy.h
@@ -84,6 +84,8 @@ public:
     insertChild(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
     Ufe::InsertChildCommand::Ptr
     insertChildCmd(const Ufe::SceneItem::Ptr& child, const Ufe::SceneItem::Ptr& pos) override;
+    Ufe::InsertChildCommand::Ptr
+    appendChildVerifyRestrictionsCmd(const Ufe::SceneItem::Ptr& child) override;
 
     Ufe::UndoableCommand::Ptr reorderCmd(const Ufe::SceneItemList& orderedList) const override;
 

--- a/lib/usdUfe/ufe/Utils.h
+++ b/lib/usdUfe/ufe/Utils.h
@@ -304,6 +304,16 @@ bool isEditTargetLayerModifiable(
 USDUFE_PUBLIC
 Ufe::BBox3d combineUfeBBox(const Ufe::BBox3d& ufeBBox1, const Ufe::BBox3d& ufeBBox2);
 
+//! Check if the src and dst attributes are connected.
+//! \return True, if they are connected.
+USDUFE_PUBLIC
+bool isConnected(const PXR_NS::UsdAttribute& srcUsdAttr, const PXR_NS::UsdAttribute& dstUsdAttr);
+
+//! Check if the usdItem is connected (i.e. if there are in or out connections).
+//! \return True, if it is connected.
+USDUFE_PUBLIC
+bool isConnected(const UsdSceneItem::Ptr& usdItem);
+
 //! Set both the start and stop wait cursor functions.
 USDUFE_PUBLIC
 void setWaitCursorFns(WaitCursorFn startFn, WaitCursorFn stopFn);


### PR DESCRIPTION
**Notes:** Implementing the new cmd added in [UFE PR](https://git.autodesk.com/media-and-entertainment/ufe/pull/375).
Marking this as a Draft PR as we will need it for next Maya release since it is breaking the Hierarchy interface by adding a new command. Pushing it to not lose progress and be ready to jump on it for the next release.
[related JIRA ticket
](https://jira.autodesk.com/browse/EMSUSD-1000)
The new command will allow us to not drop connected items in the Outliner. Please refer to the related [story ticket](https://jira.autodesk.com/browse/LOOKDEVX-1545) for more details.