### PR TITLE
EMSUSD-1007 fix layers not muted on reload

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -248,6 +248,8 @@ public:
 
     SdfLayerHandle findLayer(std::string identifier) const;
 
+    LayerManager::LayerNameMap getLayerNameMap() const;
+
 private:
     void registerCallbacks();
     void unregisterCallbacks();
@@ -1099,6 +1101,19 @@ void LayerDatabase::cleanUpNewScene(void*)
     LayerDatabase::removeManagerNode();
 }
 
+LayerManager::LayerNameMap LayerDatabase::getLayerNameMap() const
+{
+    LayerManager::LayerNameMap nameMap;
+    for (const auto& idAndLayer : _idToLayer) {
+        const std::string& layerName = idAndLayer.first;
+        const std::string& currentName = idAndLayer.second->GetIdentifier();
+        if (currentName != layerName) {
+            nameMap[layerName] = currentName;
+        }
+    }
+    return nameMap;
+}
+
 bool LayerDatabase::remapSubLayerPaths(SdfLayerHandle parentLayer)
 {
     bool                     modifiedPaths = false;
@@ -1352,6 +1367,16 @@ SdfLayerHandle LayerManager::findLayer(std::string identifier)
     LayerDatabase::loadLayersPostRead(nullptr);
 
     return LayerDatabase::instance().findLayer(identifier);
+}
+
+/* static */
+LayerManager::LayerNameMap LayerManager::getLayerNameMap()
+{
+    std::lock_guard<std::recursive_mutex> lock(findNodeMutex);
+
+    LayerDatabase::loadLayersPostRead(nullptr);
+
+    return LayerDatabase::instance().getLayerNameMap();
 }
 
 /* static */

--- a/lib/mayaUsd/nodes/layerManager.h
+++ b/lib/mayaUsd/nodes/layerManager.h
@@ -129,6 +129,9 @@ public:
     */
     static SdfLayerHandle findLayer(std::string identifier);
 
+    using LayerNameMap = std::map<std::string, std::string>;
+    static LayerNameMap getLayerNameMap();
+
     static const MString typeName;
     static const MTypeId typeId;
 

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -806,6 +806,8 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
     UsdStageRefPtr finalUsdStage;
     SdfPath        primPath;
 
+    LayerNameMap layerNameMap = MayaUsd::LayerManager::getLayerNameMap();
+
     MDataHandle inDataHandle = dataBlock.inputValue(inStageDataAttr, &retValue);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
@@ -1122,7 +1124,7 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
         }
 
         primPath = finalUsdStage->GetPseudoRoot().GetPath();
-        copyLayerMutingFromAttribute(*this, *finalUsdStage);
+        copyLayerMutingFromAttribute(*this, layerNameMap, *finalUsdStage);
         if (!_targetLayer)
             _targetLayer = getTargetLayerFromAttribute(*this, *finalUsdStage);
         updateShareMode(sharedUsdStage, unsharedUsdStage, loadSet);

--- a/lib/mayaUsd/utils/layerMuting.h
+++ b/lib/mayaUsd/utils/layerMuting.h
@@ -42,11 +42,18 @@ MAYAUSD_CORE_PUBLIC
 MStatus
 copyLayerMutingToAttribute(const PXR_NS::UsdStage& stage, MayaUsdProxyShapeBase& proxyShape);
 
+/*! Map the original layer name when the scene was saved to the current layer name.
+    Layer renaming happens when anonymous layers are saved within the Maya scene file.
+*/
+using LayerNameMap = std::map<std::string, std::string>;
+
 /*! \brief set the stage layers muting from data in the corresponding attribute of the proxy shape.
  */
 MAYAUSD_CORE_PUBLIC
-MStatus
-copyLayerMutingFromAttribute(const MayaUsdProxyShapeBase& proxyShape, PXR_NS::UsdStage& stage);
+MStatus copyLayerMutingFromAttribute(
+    const MayaUsdProxyShapeBase& proxyShape,
+    const LayerNameMap&          nameMap,
+    PXR_NS::UsdStage&            stage);
 
 // OpenUSD forget everything about muted layers. The OpenUSD documentation for
 // the MuteLayer function says:

--- a/test/lib/mayaUsd/fileio/testSaveMutedAnonLayer.py
+++ b/test/lib/mayaUsd/fileio/testSaveMutedAnonLayer.py
@@ -102,6 +102,9 @@ class SaveMutedLayerTest(unittest.TestCase):
         subLayer = Sdf.Layer.Find(subLayerPath)
         self.assertIsNotNone(subLayer)
 
+        # Verify the layer was reloaded as muted.
+        self.assertTrue(stage.IsLayerMuted(subLayerPath))
+
         # Verify the two objects are still present.
         stage.UnmuteLayer(subLayer.identifier)
         verifyPrims(stage)


### PR DESCRIPTION
- Allow retrieving a mapping of renamed layers from the LayerManager Maya node that keeps track of USD layers saved inside a Maya scene.
- Pass that map of layer names to the function that restore layer muting.
- Make sure muted layers are not lost by adding them to the set of retained muted layers.
- This is especially important for anonymous layers, as nothing else refer to them.