### PR TITLE
Maya is no longer using a Preview Release number

### DIFF
--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -12,7 +12,6 @@
 # MAYA_API_VERSION    Maya API version (6-8 digits) - defined in MTypes.h
 # MAYA_APP_VERSION    Maya app version (4 digits) - either from MTypes.h or first 4 digits of MAYA_API_VERSION
 # MAYA_LIGHTAPI_VERSION Maya light API version (1 or 2 or 3)
-# MAYA_PREVIEW_RELEASE_VERSION Preview Release number (3 or more digits) in preview releases, 0 in official releases
 #
 # Cache variables:
 # MAYA_HAS_DEFAULT_MATERIAL_API Presence of a default material API on MRenderItem.
@@ -258,15 +257,6 @@ if(MAYA_INCLUDE_DIRS AND EXISTS "${MAYA_INCLUDE_DIR}/maya/MTypes.h")
         string(REGEX MATCHALL "[0-9]+" MAYA_APP_VERSION ${MAYA_APP_VERSION})
     else()
         string(SUBSTRING ${MAYA_API_VERSION} "0" "4" MAYA_APP_VERSION)
-    endif()
-endif()
-
-if(MAYA_INCLUDE_DIRS AND EXISTS "${MAYA_INCLUDE_DIR}/maya/MDefines.h")
-    file(STRINGS ${MAYA_INCLUDE_DIR}/maya/MDefines.h MAYA_PREVIEW_RELEASE_VERSION REGEX "#define MAYA_PREVIEW_RELEASE_VERSION.*$")
-    if(MAYA_PREVIEW_RELEASE_VERSION)
-        string(REGEX MATCHALL "[0-9]+" MAYA_PREVIEW_RELEASE_VERSION ${MAYA_PREVIEW_RELEASE_VERSION})
-    else()
-        set(MAYA_PREVIEW_RELEASE_VERSION 0)
     endif()
 endif()
 

--- a/test/testUtils/mayaUtils.py
+++ b/test/testUtils/mayaUtils.py
@@ -31,12 +31,9 @@ import ufe
 import ufeUtils, testUtils
 
 import os
-import re
 import sys
 
 mayaSeparator = "|"
-
-prRe = re.compile('Preview Release ([0-9]+)')
 
 def loadPlugin(pluginName):
     """ 
@@ -249,43 +246,6 @@ def createSingleSphereMayaScene(directory=None):
     cmds.file(rename=tempMayaFile)
     cmds.file(save=True, force=True, type='mayaAscii')
     return tempMayaFile
-
-def previewReleaseVersion():
-    '''Return the Maya Preview Release version.
-
-    If the version of Maya is 2019, returns 98 (no longer supported).
-
-    If the version of Maya is 2020, returns 110 (no longer supported).
-
-    If the version of Maya is 2022, returns 122.
-
-    If the version of Maya is 2023, returns 132.
-
-    If the version of Maya is 2024, returns 142.
-
-    If the version of Maya is current and is not a Preview Release, returns
-    sys.maxsize (a very large number).  If the environment variable
-    MAYA_PREVIEW_RELEASE_VERSION_OVERRIDE is defined, return its value instead.
-    '''
-
-    if 'MAYA_PREVIEW_RELEASE_VERSION_OVERRIDE' in os.environ:
-        return int(os.environ['MAYA_PREVIEW_RELEASE_VERSION_OVERRIDE'])
-
-    majorVersion = int(cmds.about(majorVersion=True))
-    if majorVersion == 2019:
-        return 98
-    elif majorVersion == 2020:
-        return 110
-    elif majorVersion == 2022:
-        return 122
-    elif majorVersion == 2023:
-        return 132
-    elif majorVersion == 2024:
-        return 142
-
-    match = prRe.match(cmds.about(v=True))
-
-    return int(match.group(1)) if match else sys.maxsize
 
 def mayaMajorVersion():
     return int(cmds.about(majorVersion=True))


### PR DESCRIPTION
Remove code (currently not used) that detected this.