### PR TITLE
Update github actions to node20 (node16 is out of support)

### DIFF
--- a/.github/workflows/maya-usd-new-issues.yml
+++ b/.github/workflows/maya-usd-new-issues.yml
@@ -7,9 +7,8 @@ jobs:
   move-triage-card:
     runs-on: ubuntu-latest
     steps:
-      - uses: alex-page/github-project-automation-plus@v0.8.3
-      # Aug 2023: Update from v0.3.0 to v0.8.3 which uses node16.
-      #           node12 is out of support.
+      - uses: alex-page/github-project-automation-plus@v0.9.0
+      # Feb 2024: Update v0.9.0 which uses node20 (node16 is out of support).
         with:
           project: Issue Triage
           column: Needs triage

--- a/.github/workflows/maya-usd-preflight-launcher.yml
+++ b/.github/workflows/maya-usd-preflight-launcher.yml
@@ -15,9 +15,9 @@ jobs:
       # Start clang format by assigning pull-request to yourself.
       if: ${{ github.event.assignee.login == github.event.pull_request.user.login }}
       steps:
-      # Aug 2023: Update from v2 to v3 which uses node16 (node12 is out of support).
-      - uses: actions/checkout@v3
-      - uses: DoozyX/clang-format-lint-action@v0.16.2
+      # Feb 2024: Update from v3 to v4 which uses node20 (node16 is out of support).
+      - uses: actions/checkout@v4
+      - uses: DoozyX/clang-format-lint-action@v0.17
         with:
           source: '.'
           clangFormatVersion: 10
@@ -33,7 +33,7 @@ jobs:
 
         # Build start info will be committed here when the remote build is launched
         - name: Setup transfer repo
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
           with:
             repository: ecp-maya-devops-adsk/log-transfer
             ref: transfer
@@ -77,8 +77,8 @@ jobs:
 
         # Upload files related to this build
         - name: Upload files in transfer directory as artifacts
-          # Aug 2023: Update from v2 to v3 which uses node16 (node12 is out of support).
-          uses: actions/upload-artifact@v3
+          # Feb 2024: Update from v3 to v4 which uses node20 (node16 is out of support).
+          uses: actions/upload-artifact@v4
           with:
             name: build logs
             path: "transfer/${{ github.run_id }}_${{ github.run_number }}_*"


### PR DESCRIPTION
I noticed this in the checks after running a preflight:
![image](https://github.com/Autodesk/maya-usd/assets/23455376/3365d08c-c92a-43a5-9cdd-017bcd44e6e4)

For details as to why see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

I updated this in the past from Node12 to Node16 in #3291 