### PR TITLE
EMSUSD-1016 - Link against mayaUsdAPI to preload it for other plugins

### DIFF
--- a/plugin/adsk/plugin/CMakeLists.txt
+++ b/plugin/adsk/plugin/CMakeLists.txt
@@ -89,6 +89,16 @@ else()
     )
 endif()
 
+# The mayaUsd plugin does need the mayaUsdAPI library. However, other plugins that
+# depend on it have no way of locating it currently at runtime, so it has to be
+# preloaded.
+if(IS_MACOSX OR IS_LINUX)
+    target_link_libraries(${TARGET_NAME}
+        PRIVATE
+            mayaUsdAPI
+    )
+endif()
+
 # -----------------------------------------------------------------------------
 # properties
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
The mayaUsdAPI library is not directly needed by the mayaUsd plugin. However, there is no way currently for other plugins that need it to know where to locate it on mac/linux through rpaths. By linking it it will be preloaded like the other dynamic libs.