### PR TITLE
EMSUSD-708 fix performance of instanceable prims

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -910,12 +910,12 @@ void HdVP2BasisCurves::_UpdateDrawItem(
         if (0 == instanceCount) {
             instancerWithNoInstances = true;
         } else {
+            const SdfPathVector usdPaths = drawScene.GetScenePrimPaths(id, instanceCount);
             stateToCommit._instanceTransforms->setLength(instanceCount);
             for (unsigned int i = 0; i < instanceCount; ++i) {
                 transforms[i].Get(instanceMatrix.matrix);
                 (*stateToCommit._instanceTransforms)[i] = worldMatrix * instanceMatrix;
-                stateToCommit._ufeIdentifiers.append(
-                    drawScene.GetScenePrimPath(GetId(), i).GetString().c_str());
+                stateToCommit._ufeIdentifiers.append(usdPaths[i].GetString().c_str());
             }
 
             // If the item is used for both regular draw and selection highlight,

--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
@@ -808,9 +808,12 @@ void MayaUsdRPrim::_SyncDisplayLayerModesInstanced(SdfPath const& id, unsigned i
     _requiredModFlagsBitset.reset();
     if (_useInstancedDisplayLayerModes) {
         _displayLayerModesInstanced.resize(instanceCount);
+
+        const SdfPathVector usdPaths = drawScene.GetScenePrimPaths(id, instanceCount);
+
         for (unsigned int usdInstanceId = 0; usdInstanceId < instanceCount; usdInstanceId++) {
-            auto  usdPath = drawScene.GetScenePrimPath(id, usdInstanceId);
-            auto& displayLayerModes = _displayLayerModesInstanced[usdInstanceId];
+            auto&          displayLayerModes = _displayLayerModesInstanced[usdInstanceId];
+            const SdfPath& usdPath = usdPaths[usdInstanceId];
             _PopulateDisplayLayerModes(usdPath, displayLayerModes, drawScene);
 
             if (displayLayerModes._reprOverride == kBBox) {

--- a/lib/mayaUsd/render/vp2RenderDelegate/points.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/points.cpp
@@ -607,12 +607,12 @@ void HdVP2Points::_UpdateDrawItem(
         if (0 == instanceCount) {
             instancerWithNoInstances = true;
         } else {
+            const SdfPathVector usdPaths = drawScene.GetScenePrimPaths(id, instanceCount);
             stateToCommit._instanceTransforms->setLength(instanceCount);
             for (unsigned int i = 0; i < instanceCount; ++i) {
                 transforms[i].Get(instanceMatrix.matrix);
                 (*stateToCommit._instanceTransforms)[i] = worldMatrix * instanceMatrix;
-                stateToCommit._ufeIdentifiers.append(
-                    drawScene.GetScenePrimPath(GetId(), i).GetString().c_str());
+                stateToCommit._ufeIdentifiers.append(usdPaths[i].GetString().c_str());
             }
 
             // If the item is used for both regular draw and selection highlight,

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -159,6 +159,9 @@ public:
     SdfPath GetScenePrimPath(const SdfPath& rprimId, int instanceIndex) const;
 #endif
 
+    SdfPathVector GetScenePrimPaths(const SdfPath& rprimId, std::vector<int> instanceIndexes) const;
+    SdfPathVector GetScenePrimPaths(const SdfPath& rprimId, unsigned int instanceCount) const;
+
     MAYAUSD_CORE_PUBLIC
     void SelectionChanged();
 


### PR DESCRIPTION
Call the Usdimaging function to retrieve all instance prim path at once instead of one-by-one, which optimizes many internal details.

- Use the same faster code in a few other similar places.
- Add a convenience function to retrieve all the prim paths when the instance ID are consecutive.
- Use it in a few places.