### PR TITLE
EMSUSD-1003 Keep Maya Ref valid after saving

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -26,6 +26,7 @@
 #endif
 #include <mayaUsd/fileio/primUpdaterRegistry.h>
 #include <mayaUsd/fileio/utils/writeUtil.h>
+#include <mayaUsd/nodes/layerManager.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/ufe/Global.h>
 #include <mayaUsd/undo/OpUndoItemMuting.h>
@@ -1657,6 +1658,10 @@ void PrimUpdaterManager::onProxyContentChanged(
     const MayaUsdProxyStageObjectsChangedNotice& proxyNotice)
 {
     if (_inPushPull) {
+        return;
+    }
+
+    if (LayerManager::isSaving()) {
         return;
     }
 

--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -250,6 +250,8 @@ public:
 
     LayerManager::LayerNameMap getLayerNameMap() const;
 
+    static bool isSaving() { return _isSavingMayaFile; }
+
 private:
     void registerCallbacks();
     void unregisterCallbacks();
@@ -1408,5 +1410,8 @@ std::string LayerManager::getSelectedStage()
     LayerDatabase::loadLayersPostRead(nullptr);
     return LayerDatabase::instance().getSelectedStage();
 }
+
+/* static */
+bool LayerManager::isSaving() { return LayerDatabase::isSaving(); }
 
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/nodes/layerManager.h
+++ b/lib/mayaUsd/nodes/layerManager.h
@@ -132,6 +132,9 @@ public:
     using LayerNameMap = std::map<std::string, std::string>;
     static LayerNameMap getLayerNameMap();
 
+    //! \brief returns true if the layer manager is currently saving files.
+    static bool isSaving();
+
     static const MString typeName;
     static const MTypeId typeId;
 


### PR DESCRIPTION
Avoid starting to edit-as-Maya in the middle of saving because some of the state necessary to keep track of the edit would not make it to the saved file.