### PR TITLE
EMSUSD-998 better universal manip undo redo

### DIFF
--- a/lib/mayaUsd/ufe/UsdSetXformOpUndoableCommandBase.cpp
+++ b/lib/mayaUsd/ufe/UsdSetXformOpUndoableCommandBase.cpp
@@ -28,61 +28,124 @@ void warnUnimplemented(const char* msg) { TF_WARN("Illegal call to unimplemented
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
-template <typename T>
-UsdSetXformOpUndoableCommandBase<T>::UsdSetXformOpUndoableCommandBase(
+UsdSetXformOpUndoableCommandBase::UsdSetXformOpUndoableCommandBase(
+    const PXR_NS::VtValue&     value,
+    const Ufe::Path&           path,
+    const PXR_NS::UsdTimeCode& writeTime)
+    : Ufe::SetVector3dUndoableCommand(path)
+    , _writeTime(writeTime)
+    , _newOpValue(value)
+    , _isPrepared(false)
+    , _canUpdateValue(true)
+    , _opCreated(false)
+{
+}
+
+UsdSetXformOpUndoableCommandBase::UsdSetXformOpUndoableCommandBase(
     const Ufe::Path&   path,
     const UsdTimeCode& writeTime)
-    : Ufe::SetVector3dUndoableCommand(path)
-    , _readTime(getTime(path)) // Always read from proxy shape time.
-    , _writeTime(writeTime)
+    : UsdSetXformOpUndoableCommandBase({}, path, writeTime)
 {
 }
 
-template <typename T> void UsdSetXformOpUndoableCommandBase<T>::execute()
+void UsdSetXformOpUndoableCommandBase::execute()
 {
-    warnUnimplemented("UsdSetXformOpUndoableCommandBase::execute()");
+    // Create the attribute and cache the initial value,
+    // if this is the first time we're executed, or redo
+    // the attribute creation.
+    recreateOpIfNeeded();
+
+    // Set the new value.
+    prepareAndSet(_newOpValue);
+    _canUpdateValue = true;
 }
 
-template <typename T> void UsdSetXformOpUndoableCommandBase<T>::undo()
+void UsdSetXformOpUndoableCommandBase::undo()
 {
-    if (_state == kInitial) {
-        // Spurious call from Maya, ignore.
-        _state = kInitialUndoCalled;
+    // If the command was never called at all, do nothing.
+    // Maya can start by calling undo.
+    if (!_isPrepared)
         return;
-    }
-    _undoableItem.undo();
-    _state = kUndone;
+
+    // Restore the initial value and potentially remove the creatd attributes.
+    setValue(_initialOpValue, _writeTime);
+    removeOpIfNeeded();
+    _canUpdateValue = false;
 }
 
-template <typename T> void UsdSetXformOpUndoableCommandBase<T>::redo()
+void UsdSetXformOpUndoableCommandBase::redo()
 {
-    warnUnimplemented("UsdSetXformOpUndoableCommandBase::redo()");
+    // Redo the attribute creation if the attribute was already created
+    // but then undone.
+    recreateOpIfNeeded();
+
+    // Set the new value, potentially creating the attribute if it
+    // did not exists or caching the initial value if this is the
+    // first time the command is executed, redone or undone.
+    prepareAndSet(_newOpValue);
+    _canUpdateValue = true;
 }
 
-template <typename T> void UsdSetXformOpUndoableCommandBase<T>::handleSet(const T& v)
+void UsdSetXformOpUndoableCommandBase::updateNewValue(const VtValue& v)
 {
-    if (_state == kInitialUndoCalled) {
-        // Spurious call from Maya, ignore.  Otherwise, we set a value that
-        // is identical to the previous, the UsdUndoBlock does not capture
-        // any invertFunc's, and subsequent undo() calls undo nothing.
-        _state = kInitial;
-    } else if (_state == kInitial) {
-        UsdUndoBlock undoBlock(&_undoableItem);
-        setValue(v);
-        _state = kExecute;
-    } else if (_state == kExecute) {
-        setValue(v);
-    } else if (_state == kUndone) {
-        _undoableItem.redo();
-        _state = kRedone;
-    }
+    // Redo the attribute creation if the attribute was already created
+    // but then undone.
+    recreateOpIfNeeded();
+
+    // Update the value that will be set.
+    if (_canUpdateValue)
+        _newOpValue = v;
+
+    // Set the new value, potentially creating the attribute if it
+    // did not exists or caching the initial value if this is the
+    // first time the command is executed, redone or undone.
+    prepareAndSet(_newOpValue);
+    _canUpdateValue = true;
 }
 
-// Explicit instantiation for transform ops that can be set from matrices and
-// vectors.
-template class UsdSetXformOpUndoableCommandBase<GfVec3f>;
-template class UsdSetXformOpUndoableCommandBase<GfVec3d>;
-template class UsdSetXformOpUndoableCommandBase<GfMatrix4d>;
+void UsdSetXformOpUndoableCommandBase::prepareAndSet(const VtValue& v)
+{
+    if (v.IsEmpty())
+        return;
+
+    prepareOpIfNeeded();
+    setValue(v, _writeTime);
+}
+
+void UsdSetXformOpUndoableCommandBase::prepareOpIfNeeded()
+{
+    if (_isPrepared)
+        return;
+
+    createOpIfNeeded(_opCreationUndo);
+    _initialOpValue = getValue(_writeTime);
+    _isPrepared = true;
+    _opCreated = true;
+}
+
+void UsdSetXformOpUndoableCommandBase::recreateOpIfNeeded()
+{
+    if (!_isPrepared)
+        return;
+
+    if (_opCreated)
+        return;
+
+    _opCreationUndo.redo();
+    _opCreated = true;
+}
+
+void UsdSetXformOpUndoableCommandBase::removeOpIfNeeded()
+{
+    if (!_isPrepared)
+        return;
+
+    if (!_opCreated)
+        return;
+
+    _opCreationUndo.undo();
+    _opCreated = false;
+}
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.cpp
@@ -31,7 +31,7 @@ namespace ufe {
 
 namespace {
 
-class CommonAPITranslateUndoableCmd : public UsdSetXformOpUndoableCommandBase<GfVec3d>
+class CommonAPITranslateUndoableCmd : public UsdSetXformOpUndoableCommandBase
 {
 public:
     CommonAPITranslateUndoableCmd(const UsdSceneItem::Ptr& item, const UsdTimeCode& writeTime)
@@ -40,11 +40,31 @@ public:
     {
     }
 
-    void setValue(const GfVec3d& v) override { _commonAPI.SetTranslate(v, writeTime()); }
+    void createOpIfNeeded(UsdUndoableItem& undoableItem) override
+    {
+        UsdUndoBlock undoBlock(&undoableItem);
+        _commonAPI.CreateXformOps(UsdGeomXformCommonAPI::OpTranslate);
+    }
+
+    void setValue(const VtValue& v, const UsdTimeCode& writeTime) override
+    {
+        // Note: the value passed in is either the initial value returned
+        //       by the getValue function below or a new value passed to
+        //       the set function below. In both cases, we are guaranteed
+        //       that it will be a GfVec3d.
+        _commonAPI.SetTranslate(v.Get<GfVec3d>(), writeTime);
+    }
+
+    VtValue getValue(const UsdTimeCode& readTime) const override
+    {
+        GfVec3d translation;
+        _commonAPI.GetXformVectors(&translation, nullptr, nullptr, nullptr, nullptr, readTime);
+        return VtValue(translation);
+    }
 
     bool set(double x, double y, double z) override
     {
-        handleSet(GfVec3d(x, y, z));
+        updateNewValue(VtValue(GfVec3d(x, y, z)));
         return true;
     }
 
@@ -52,7 +72,7 @@ private:
     UsdGeomXformCommonAPI _commonAPI;
 };
 
-class CommonAPIRotateUndoableCmd : public UsdSetXformOpUndoableCommandBase<GfVec3f>
+class CommonAPIRotateUndoableCmd : public UsdSetXformOpUndoableCommandBase
 {
 public:
     CommonAPIRotateUndoableCmd(const UsdSceneItem::Ptr& item, const UsdTimeCode& writeTime)
@@ -61,14 +81,31 @@ public:
     {
     }
 
-    void setValue(const GfVec3f& v) override
+    void createOpIfNeeded(UsdUndoableItem& undoableItem) override
     {
-        _commonAPI.SetRotate(v, UsdGeomXformCommonAPI::RotationOrderXYZ, writeTime());
+        UsdUndoBlock undoBlock(&undoableItem);
+        _commonAPI.CreateXformOps(UsdGeomXformCommonAPI::OpRotate);
+    }
+
+    void setValue(const VtValue& v, const UsdTimeCode& writeTime) override
+    {
+        // Note: the value passed in is either the initial value returned
+        //       by the getValue function below or a new value passed to
+        //       the set function below. In both cases, we are guaranteed
+        //       that it will be a GfVec3f.
+        _commonAPI.SetRotate(v.Get<GfVec3f>(), UsdGeomXformCommonAPI::RotationOrderXYZ, writeTime);
+    }
+
+    VtValue getValue(const UsdTimeCode& readTime) const override
+    {
+        GfVec3f rotation;
+        _commonAPI.GetXformVectors(nullptr, &rotation, nullptr, nullptr, nullptr, readTime);
+        return VtValue(rotation);
     }
 
     bool set(double x, double y, double z) override
     {
-        handleSet(GfVec3f(x, y, z));
+        updateNewValue(VtValue(GfVec3f(x, y, z)));
         return true;
     }
 
@@ -76,7 +113,7 @@ private:
     UsdGeomXformCommonAPI _commonAPI;
 };
 
-class CommonAPIScaleUndoableCmd : public UsdSetXformOpUndoableCommandBase<GfVec3f>
+class CommonAPIScaleUndoableCmd : public UsdSetXformOpUndoableCommandBase
 {
 
 public:
@@ -86,11 +123,31 @@ public:
     {
     }
 
-    void setValue(const GfVec3f& v) override { _commonAPI.SetScale(v, writeTime()); }
+    void createOpIfNeeded(UsdUndoableItem& undoableItem) override
+    {
+        UsdUndoBlock undoBlock(&undoableItem);
+        _commonAPI.CreateXformOps(UsdGeomXformCommonAPI::OpScale);
+    }
+
+    void setValue(const VtValue& v, const UsdTimeCode& writeTime) override
+    {
+        // Note: the value passed in is either the initial value returned
+        //       by the getValue function below or a new value passed to
+        //       the set function below. In both cases, we are guaranteed
+        //       that it will be a GfVec3d.
+        _commonAPI.SetScale(v.Get<GfVec3f>(), writeTime);
+    }
+
+    VtValue getValue(const UsdTimeCode& readTime) const override
+    {
+        GfVec3f scale;
+        _commonAPI.GetXformVectors(nullptr, nullptr, &scale, nullptr, nullptr, readTime);
+        return VtValue(scale);
+    }
 
     bool set(double x, double y, double z) override
     {
-        handleSet(GfVec3f(x, y, z));
+        updateNewValue(VtValue(GfVec3f(x, y, z)));
         return true;
     }
 
@@ -98,7 +155,7 @@ private:
     UsdGeomXformCommonAPI _commonAPI;
 };
 
-class CommonAPIPivotUndoableCmd : public UsdSetXformOpUndoableCommandBase<GfVec3f>
+class CommonAPIPivotUndoableCmd : public UsdSetXformOpUndoableCommandBase
 {
 public:
     CommonAPIPivotUndoableCmd(const UsdSceneItem::Ptr& item, const UsdTimeCode& writeTime)
@@ -107,11 +164,31 @@ public:
     {
     }
 
-    void setValue(const GfVec3f& v) override { _commonAPI.SetPivot(v, writeTime()); }
+    void createOpIfNeeded(UsdUndoableItem& undoableItem) override
+    {
+        UsdUndoBlock undoBlock(&undoableItem);
+        _commonAPI.CreateXformOps(UsdGeomXformCommonAPI::OpPivot);
+    }
+
+    void setValue(const VtValue& v, const UsdTimeCode& writeTime) override
+    {
+        // Note: the value passed in is either the initial value returned
+        //       by the getValue function below or a new value passed to
+        //       the set function below. In both cases, we are guaranteed
+        //       that it will be a GfVec3f.
+        _commonAPI.SetPivot(v.Get<GfVec3f>(), writeTime);
+    }
+
+    VtValue getValue(const UsdTimeCode& readTime) const override
+    {
+        GfVec3f pivot;
+        _commonAPI.GetXformVectors(nullptr, nullptr, nullptr, &pivot, nullptr, readTime);
+        return VtValue(pivot);
+    }
 
     bool set(double x, double y, double z) override
     {
-        handleSet(GfVec3f(x, y, z));
+        updateNewValue(VtValue(GfVec3f(x, y, z)));
         return true;
     }
 

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.cpp
@@ -15,6 +15,7 @@
 //
 #include "UsdTransform3dMayaXformStack.h"
 
+#include "UsdSetXformOpUndoableCommandBase.h"
 #include "private/UfeNotifGuard.h"
 
 #include <mayaUsd/fileio/utils/xformStack.h>
@@ -39,7 +40,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 namespace {
 
 using BaseUndoableCommand = Ufe::BaseUndoableCommand;
-using OpFunc = std::function<UsdGeomXformOp(const BaseUndoableCommand&)>;
+using OpFunc = std::function<UsdGeomXformOp(const BaseUndoableCommand&, UsdUndoableItem&)>;
 
 using namespace MayaUsd::ufe;
 
@@ -189,141 +190,86 @@ createTransform3d(const Ufe::SceneItem::Ptr& item, NextTransform3dFn nextTransfo
 
 // Helper class to factor out common code for translate, rotate, scale
 // undoable commands.
-class UsdTRSUndoableCmdBase : public Ufe::SetVector3dUndoableCommand
+//
+// We must do a careful dance due to historic reasons and the way Maya handle
+// interactive commands:
+//
+//     - These commands can be wrapped inside other commands which may
+//       use their own UsdUndoBlock. In particular, we must not try to
+//       undo an attribute creation if it was not yet created.
+//
+//     - Maya can call undo and set-value before first executing the
+//       command. In particular, when using manipualtion tools, Maya
+//       will usually do loops of undo/set-value/execute, thus beginning
+//       by undoing a command that was never executed.
+//
+//     - As a general rule, when undoing, we want to remove any attributes
+//       that were created when first executed.
+//
+//     - When redoing some commands after an undo, Maya will update the
+//       value to be set with an incorrect value when operating in object
+//       space, which must be ignored.
+//
+// Those things are what the prepare-op/recreate-op/remove-op functions are
+// aimed to support. Also, we must only capture the initial value the first
+// time thevalue is modified, to support both the inital undo/set-value and
+// avoid losing the initial value on repeat set-value.
+class UsdTRSUndoableCmdBase : public UsdSetXformOpUndoableCommandBase
 {
-private:
-    const UsdTimeCode _writeTime;
-    VtValue           _newOpValue;
-    UsdGeomXformOp    _op;
-    OpFunc            _opFunc;
-    UsdUndoableItem   _undoableItem;
-
 public:
-    struct State
-    {
-        virtual void handleUndo(UsdTRSUndoableCmdBase*)
-        {
-            TF_CODING_ERROR(
-                "Illegal handleUndo() call in UsdTRSUndoableCmdBase for state '%s'.",
-                typeid(*this).name());
-        }
-        virtual void handleSet(UsdTRSUndoableCmdBase*, const VtValue&)
-        {
-            TF_CODING_ERROR(
-                "Illegal handleSet() call in UsdTRSUndoableCmdBase for state '%s'.",
-                typeid(*this).name());
-        }
-    };
-
-    struct InitialState : public State
-    {
-        void handleUndo(UsdTRSUndoableCmdBase* cmd) override
-        {
-            // Maya triggers an undo on command creation, ignore it.
-            cmd->_state = &UsdTRSUndoableCmdBase::_initialUndoCalledState;
-        }
-        void handleSet(UsdTRSUndoableCmdBase* cmd, const VtValue& v) override
-        {
-            // Add undoblock to capture edits
-            UsdUndoBlock undoBlock(&cmd->_undoableItem);
-
-            // Going from initial to executing / executed state, save value.
-            cmd->_op = cmd->_opFunc(*cmd);
-            cmd->setValue(v);
-            cmd->_state = &UsdTRSUndoableCmdBase::_executeState;
-        }
-    };
-
-    struct InitialUndoCalledState : public State
-    {
-        void handleSet(UsdTRSUndoableCmdBase* cmd, const VtValue&) override
-        {
-            // Maya triggers a redo on command creation, ignore it.
-            cmd->_state = &UsdTRSUndoableCmdBase::_initialState;
-        }
-    };
-
-    struct ExecuteState : public State
-    {
-        void handleUndo(UsdTRSUndoableCmdBase* cmd) override
-        {
-            // Undo
-            cmd->_undoableItem.undo();
-            cmd->_state = &UsdTRSUndoableCmdBase::_undoneState;
-        }
-        void handleSet(UsdTRSUndoableCmdBase* cmd, const VtValue& v) override { cmd->setValue(v); }
-    };
-
-    struct UndoneState : public State
-    {
-        void handleSet(UsdTRSUndoableCmdBase* cmd, const VtValue&) override
-        {
-            // Redo
-            cmd->_undoableItem.redo();
-            cmd->_state = &UsdTRSUndoableCmdBase::_redoneState;
-        }
-    };
-
-    struct RedoneState : public State
-    {
-        void handleUndo(UsdTRSUndoableCmdBase* cmd) override
-        {
-            // Undo
-            cmd->_undoableItem.undo();
-            cmd->_state = &UsdTRSUndoableCmdBase::_undoneState;
-        }
-        // The redone state should normally be reached only once manipulation
-        // is over, after undo, so setting new values in the redone state seems
-        // illogical.  However, during point snapping manipulation, within a
-        // single drag, the Maya move command repeatedly calls undo, then redo,
-        // setting new values after the redo.  Treat such events identically to
-        // the Execute state.
-        void handleSet(UsdTRSUndoableCmdBase* cmd, const VtValue& v) override { cmd->setValue(v); }
-    };
-
     UsdTRSUndoableCmdBase(
         const VtValue&     newOpValue,
         const Ufe::Path&   path,
         OpFunc             opFunc,
         const UsdTimeCode& writeTime)
-        : Ufe::SetVector3dUndoableCommand(path)
-        , _writeTime(writeTime)
-        , _newOpValue(newOpValue)
+        : UsdSetXformOpUndoableCommandBase(newOpValue, path, writeTime)
         , _op()
         , _opFunc(std::move(opFunc))
     {
     }
 
-    // Ufe::UndoableCommand overrides.
-    void execute() override { handleSet(_newOpValue); }
-    void undo() override { _state->handleUndo(this); }
-    void redo() override { handleSet(_newOpValue); }
-
-    void handleSet(const VtValue& v) { _state->handleSet(this, v); }
-
-    void setValue(const VtValue& v)
+protected:
+    void createOpIfNeeded(UsdUndoableItem& undoableItem) override
     {
-        auto attr = _op.GetAttr();
-        if (attr) {
-            _newOpValue = v;
-            _op.GetAttr().Set(v, _writeTime);
-        }
+        if (_op)
+            return;
+
+        _op = _opFunc(*this, undoableItem);
     }
 
-    static InitialState           _initialState;
-    static InitialUndoCalledState _initialUndoCalledState;
-    static ExecuteState           _executeState;
-    static UndoneState            _undoneState;
-    static RedoneState            _redoneState;
+    void setValue(const VtValue& v, const UsdTimeCode& writeTime) override
+    {
+        if (!_op)
+            return;
 
-    State* _state { &_initialState };
+        if (v.IsEmpty())
+            return;
+
+        auto attr = _op.GetAttr();
+        if (!attr)
+            return;
+
+        attr.Set(v, writeTime);
+    }
+
+    VtValue getValue(const UsdTimeCode& readTime) const override
+    {
+        if (!_op)
+            return {};
+
+        auto attr = _op.GetAttr();
+        if (!attr)
+            return {};
+
+        VtValue value;
+        attr.Get(&value, readTime);
+        return value;
+    }
+
+private:
+    UsdGeomXformOp _op;
+    OpFunc         _opFunc;
 };
-
-UsdTRSUndoableCmdBase::InitialState           UsdTRSUndoableCmdBase::_initialState;
-UsdTRSUndoableCmdBase::InitialUndoCalledState UsdTRSUndoableCmdBase::_initialUndoCalledState;
-UsdTRSUndoableCmdBase::ExecuteState           UsdTRSUndoableCmdBase::_executeState;
-UsdTRSUndoableCmdBase::UndoneState            UsdTRSUndoableCmdBase::_undoneState;
-UsdTRSUndoableCmdBase::RedoneState            UsdTRSUndoableCmdBase::_redoneState;
 
 // UsdRotatePivotTranslateUndoableCmd uses hard-coded USD common transform API
 // single pivot attribute name, not reusable.
@@ -344,7 +290,7 @@ public:
     {
         VtValue v;
         v = V(x, y, z);
-        handleSet(v);
+        updateNewValue(v);
         return true;
     }
 };
@@ -368,7 +314,7 @@ public:
     {
         VtValue v;
         v = _cvtRotXYZToAttr(x, y, z);
-        handleSet(v);
+        updateNewValue(v);
         return true;
     }
 
@@ -481,13 +427,15 @@ UsdTransform3dMayaXformStack::rotateCmd(double x, double y, double z)
 
     auto f = OpFunc(
         [attrName, opSuffix = getTRSOpSuffix(), setXformOpOrderFn = getXformOpOrderFn(), v](
-            const BaseUndoableCommand& cmd) {
+            const BaseUndoableCommand& cmd, UsdUndoableItem& undoableItem) {
             SceneItemHolder usdSceneItem(cmd);
 
             auto attr = getUsdPrimAttribute(usdSceneItem.item().prim(), attrName);
             if (attr) {
                 return UsdGeomXformOp(attr);
             } else {
+                UsdUndoBlock undoBlock(&undoableItem);
+
                 // Use notification guard, otherwise will generate one notification
                 // for the xform op add, and another for the reorder.
                 UsdUfe::InTransform3dChange guard(cmd.path());
@@ -497,7 +445,6 @@ UsdTransform3dMayaXformStack::rotateCmd(double x, double y, double z)
                 if (!r) {
                     throw std::runtime_error("Cannot add rotation transform operation");
                 }
-                r.Set(v);
                 if (!setXformOpOrderFn(xformable)) {
                     throw std::runtime_error("Cannot set rotation transform operation");
                 }
@@ -529,13 +476,15 @@ Ufe::ScaleUndoableCommand::Ptr UsdTransform3dMayaXformStack::scaleCmd(double x, 
     GfVec3f v(x, y, z);
     auto    f = OpFunc(
         [attrName, opSuffix = getTRSOpSuffix(), setXformOpOrderFn = getXformOpOrderFn(), v](
-            const BaseUndoableCommand& cmd) {
+            const BaseUndoableCommand& cmd, UsdUndoableItem& undoableItem) {
             SceneItemHolder usdSceneItem(cmd);
 
             auto attr = getUsdPrimAttribute(usdSceneItem.item().prim(), attrName);
             if (attr) {
                 return UsdGeomXformOp(attr);
             } else {
+                UsdUndoBlock undoBlock(&undoableItem);
+
                 UsdUfe::InTransform3dChange guard(cmd.path());
                 UsdGeomXformable            xformable(usdSceneItem.item().prim());
 
@@ -543,7 +492,6 @@ Ufe::ScaleUndoableCommand::Ptr UsdTransform3dMayaXformStack::scaleCmd(double x, 
                 if (!s) {
                     throw std::runtime_error("Cannot add scaling transform operation");
                 }
-                s.Set(v);
                 if (!setXformOpOrderFn(xformable)) {
                     throw std::runtime_error("Cannot set scaling transform operation");
                 }
@@ -642,20 +590,22 @@ Ufe::SetVector3dUndoableCommand::Ptr UsdTransform3dMayaXformStack::setVector3dCm
         // work around by calling in function body.  PPT, 11-Jan-2021.
         // [opSuffix, setXformOpOrderFn = getXformOpOrderFn(), v](const BaseUndoableCommand&
         // cmd) {
-        [attrName, opSuffix, setXformOpOrderFn, v](const BaseUndoableCommand& cmd) {
+        [attrName, opSuffix, setXformOpOrderFn, v](
+            const BaseUndoableCommand& cmd, UsdUndoableItem& undoableItem) {
             SceneItemHolder usdSceneItem(cmd);
 
             auto attr = getUsdPrimAttribute(usdSceneItem.item().prim(), attrName);
             if (attr) {
                 return UsdGeomXformOp(attr);
             } else {
+                UsdUndoBlock undoBlock(&undoableItem);
+
                 UsdUfe::InTransform3dChange guard(cmd.path());
                 UsdGeomXformable            xformable(usdSceneItem.item().prim());
                 auto op = xformable.AddTranslateOp(OpPrecision<V>::precision, opSuffix);
                 if (!op) {
                     throw std::runtime_error("Cannot add translation transform operation");
                 }
-                op.Set(v);
                 if (!setXformOpOrderFn(xformable)) {
                     throw std::runtime_error("Cannot set translation transform operation");
                 }
@@ -681,7 +631,7 @@ UsdTransform3dMayaXformStack::pivotCmd(const TfToken& pvtOpSuffix, double x, dou
 
     GfVec3f v(x, y, z);
     auto    f = OpFunc([pvtAttrName, pvtOpSuffix, setXformOpOrderFn = getXformOpOrderFn(), v](
-                        const BaseUndoableCommand& cmd) {
+                        const BaseUndoableCommand& cmd, UsdUndoableItem& undoableItem) {
         SceneItemHolder usdSceneItem(cmd);
 
         auto attr = usdSceneItem.item().prim().GetAttribute(pvtAttrName);
@@ -696,6 +646,8 @@ UsdTransform3dMayaXformStack::pivotCmd(const TfToken& pvtOpSuffix, double x, dou
             // its inverse is added --- this does not match the Maya transform
             // stack.  Use of SdfChangeBlock is discouraged when calling USD
             // APIs above Sdf, so use our own guard.
+
+            UsdUndoBlock                undoBlock(&undoableItem);
             UsdUfe::InTransform3dChange guard(cmd.path());
             UsdGeomXformable            xformable(usdSceneItem.item().prim());
             auto p = xformable.AddTranslateOp(UsdGeomXformOp::PrecisionFloat, pvtOpSuffix);
@@ -705,7 +657,6 @@ UsdTransform3dMayaXformStack::pivotCmd(const TfToken& pvtOpSuffix, double x, dou
             if (!(p && pInv)) {
                 throw std::runtime_error("Cannot add translation transform operation");
             }
-            p.Set(v);
             if (!setXformOpOrderFn(xformable)) {
                 throw std::runtime_error("Cannot set translation transform operation");
             }

--- a/test/lib/ufe/testTRSBase.py
+++ b/test/lib/ufe/testTRSBase.py
@@ -72,9 +72,9 @@ class TRSTestCaseBase(unittest.TestCase):
         # For a memento list of length n, n-1 redo operations sets us current.
         self.assertEqual(self.memento[0], self.snapshotRunTimeUFE())
         # Skip first
-        for m in self.memento[1:]:
+        for i in range(1, len(self.memento)):
             cmds.redo()
-            self.assertEqual(m, self.snapshotRunTimeUFE())
+            self.assertEqual(self.memento[i], self.snapshotRunTimeUFE(), 'Differing for memento %s of %s' % (i, len(self.memento)))
         
     def multiSelectRewindMemento(self, items):
         '''Undo through all items in memento.


### PR DESCRIPTION
Fix the complicated handling of undo and redo vs the universal manipulator. The code failed to do the right thing when half of the attributes are already existed or when more complex composite manipulations were done, for example when scaling with the universal manipulator.

We make the transformation commands more robust vs the ordering of calls to support all use cases. They still handle the bug related to object-space translation redo: when redoing an object-space translation, Maya passes in incorrect values to the command that must be ignored.

Apply fix to all transform commands. This way they all use the same pattern from UsdSetXformOpUndoableCommandBase to manage any order of calls to execute/set/undo/redo: use in the CommonAPI commands, matrix commands and Maya tranform-stack commands.