### PR TITLE
EMSUSD-872 - Adds the ability to System-lock a layer

### DIFF
--- a/lib/mayaUsd/commands/Readme.md
+++ b/lib/mayaUsd/commands/Readme.md
@@ -631,6 +631,7 @@ The purpose of this command is edit layers.
 | `-addAnonymous`     | `-aa`      | string         | Add an anonynous layer at the top of the stack, returns it |
 | `-insertSubPath`    | `-is`      | int string     | Insert a sub layer path at a given index |
 | `-muteLayer`        | `-mt`      | bool string    | Mute or unmute the named layer           |
+| `-lockLayer`        | `-lk`      | int string     | Lock, System-Lock or unlock a layer. `0` = Unlocked, `1` = Locked and `2` = System-Locked |
 | `-replaceSubPath`   | `-rp`      | string string  | Replaces a path in the layer stack       |
 | `-removeSubPath`    | `-rs`      | int string     | Remove a sub layer at a given index      |
 
@@ -660,6 +661,11 @@ The purpose of this command is to control the layer editor window.
 | `-layerIsMuted`         | `-mu`      | Query if the layer itself is muted            |
 | `-layerIsReadOnly`      | `-r`       | Query if the layer or any parent is read only |
 | `-muteLayer`            | `-mt`      | Toggle the muting of a layer                  |
+| `-layerAppearsLocked`   | `-al`      | Query if the layer's parent is locked         |
+| `-layerIsLocked`        | `-lo`      | Query if the layer itself is locked           |
+| `-layerAppearsSystemLocked` | `-as`      | Query if the layer's parent is system-locked  |
+| `-layerIsSystemLocked`  | `-ls`      | Query if the layer itself is system-locked    |
+| `-lockLayer`            | `-lk`      | Lock, System-Lock or unlock a layer. `0` = Unlocked, `1` = Locked and `2` = System-Locked |
 | `-layerNeedsSaving`     | `-ns`      | Query if the layer is dirty or anonymous      |
 | `-printLayer`           | `-pl`      | Print the layer to the script editor output   |
 | `-proxyShape`           | `-ps`      | Query the proxyShape path or sets the selected shape by its path. Takes the path as argument |

--- a/lib/mayaUsd/commands/abstractLayerEditorWindow.h
+++ b/lib/mayaUsd/commands/abstractLayerEditorWindow.h
@@ -85,6 +85,8 @@ public:
     virtual bool        layerIsMuted() = 0;
     virtual bool        layerAppearsLocked() = 0;
     virtual bool        layerIsLocked() = 0;
+    virtual bool        layerAppearsSystemLocked() = 0;
+    virtual bool        layerIsSystemLocked() = 0;
     virtual bool        layerIsReadOnly() = 0;
     virtual std::string proxyShapeName() const = 0;
 

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -60,8 +60,6 @@ const char kMuteLayerFlag[] = "mt";
 const char kMuteLayerFlagL[] = "muteLayer";
 const char kLockLayerFlag[] = "lk";
 const char kLockLayerFlagL[] = "lockLayer";
-const char kSystemLockLayerFlag[] = "sk";
-const char kSystemLockLayerFlagL[] = "SystemLockLayer";
 
 } // namespace
 

--- a/lib/mayaUsd/commands/layerEditorWindowCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorWindowCommand.cpp
@@ -45,6 +45,8 @@ DEF_FLAG(mu, layerIsMuted)
 DEF_FLAG(r, layerIsReadOnly)
 DEF_FLAG(al, layerAppearsLocked)
 DEF_FLAG(lo, layerIsLocked)
+DEF_FLAG(as, layerAppearsSystemLocked)
+DEF_FLAG(ls, layerIsSystemLocked)
 
 // edit flags
 DEF_FLAG(rs, removeSubLayer)
@@ -130,6 +132,8 @@ MSyntax LayerEditorWindowCommand::createSyntax()
     ADD_FLAG(layerIsReadOnly);
     ADD_FLAG(layerAppearsLocked);
     ADD_FLAG(layerIsLocked);
+    ADD_FLAG(layerAppearsSystemLocked);
+    ADD_FLAG(layerIsSystemLocked);
 
     ADD_FLAG(removeSubLayer);
     ADD_FLAG(saveEdits);
@@ -325,6 +329,8 @@ MStatus LayerEditorWindowCommand::handleQueries(
     HANDLE_Q_FLAG(layerIsReadOnly)
     HANDLE_Q_FLAG(layerAppearsLocked)
     HANDLE_Q_FLAG(layerIsLocked)
+    HANDLE_Q_FLAG(layerAppearsSystemLocked)
+    HANDLE_Q_FLAG(layerIsSystemLocked)
 
     if (argParser.isFlagSet(FLAG(proxyShape)) && argParser.isQuery()) {
         setResult(layerEditor->proxyShapeName().c_str());

--- a/lib/mayaUsd/utils/CMakeLists.txt
+++ b/lib/mayaUsd/utils/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(${PROJECT_NAME}
         dynamicAttribute.cpp
         editability.cpp
         json.cpp
+		layerLocking.cpp
         layerMuting.cpp
         layers.cpp
         loadRulesAttribute.cpp
@@ -45,6 +46,7 @@ set(HEADERS
     editability.h
     hash.h
     json.h
+	layerLocking.h
     layerMuting.h
     layers.h
     loadRules.h

--- a/lib/mayaUsd/utils/CMakeLists.txt
+++ b/lib/mayaUsd/utils/CMakeLists.txt
@@ -12,7 +12,7 @@ target_sources(${PROJECT_NAME}
         dynamicAttribute.cpp
         editability.cpp
         json.cpp
-		layerLocking.cpp
+        layerLocking.cpp
         layerMuting.cpp
         layers.cpp
         loadRulesAttribute.cpp
@@ -46,7 +46,7 @@ set(HEADERS
     editability.h
     hash.h
     json.h
-	layerLocking.h
+    layerLocking.h
     layerMuting.h
     layers.h
     loadRules.h

--- a/lib/mayaUsd/utils/layerLocking.cpp
+++ b/lib/mayaUsd/utils/layerLocking.cpp
@@ -1,0 +1,100 @@
+//
+// Copyright 2024 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "layerLocking.h"
+
+#include <mayaUsd/listeners/notice.h>
+
+#include <pxr/base/tf/weakBase.h>
+
+namespace MAYAUSD_NS_DEF {
+
+namespace {
+
+// Automatic reset of recorded locked layers when the Maya scene is reset.
+struct SceneResetListener : public PXR_NS::TfWeakBase
+{
+    SceneResetListener()
+    {
+        PXR_NS::TfWeakPtr<SceneResetListener> me(this);
+        PXR_NS::TfNotice::Register(me, &SceneResetListener::OnSceneReset);
+    }
+
+    void OnSceneReset(const UsdMayaSceneResetNotice&)
+    {
+        // Make sure we don't hold onto locked layers now that the
+        // Maya scene is reset.
+        forgetSystemLockedLayers();
+    }
+};
+
+// The set of locked layers.
+//
+// Kept in a function to avoid problem with the order of construction
+// of global variables in C++.
+using LockedLayers = std::set<PXR_NS::SdfLayerRefPtr>;
+LockedLayers& getLockedLayers()
+{
+    // Note: C++ guarantees correct multi-thread protection for static
+    //       variables initialization in functions.
+    static SceneResetListener onSceneResetListener;
+    static LockedLayers       layers;
+    return layers;
+}
+} // namespace
+
+void addSystemLockedLayer(const PXR_NS::SdfLayerRefPtr& layer)
+{
+    if (!layer)
+        return;
+
+    LockedLayers& layers = getLockedLayers();
+    auto          iter = layers.find(layer);
+    if (iter != layers.end()) {
+        return;
+    }
+    layers.insert(layer);
+}
+
+void removeSystemLockedLayer(const PXR_NS::SdfLayerRefPtr& layer)
+{
+    if (!layer)
+        return;
+
+    LockedLayers& layers = getLockedLayers();
+    layers.erase(layer);
+}
+
+bool isLayerSystemLocked(const PXR_NS::SdfLayerRefPtr& layer)
+{
+    if (!layer)
+        return false;
+
+    LockedLayers& layers = getLockedLayers();
+    auto          iter = layers.find(layer);
+    if (iter != layers.end()) {
+        return true;
+    }
+    return false;
+}
+
+void forgetSystemLockedLayers()
+{
+    LockedLayers& layers = getLockedLayers();
+    layers.clear();
+}
+
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/layerLocking.cpp
+++ b/lib/mayaUsd/utils/layerLocking.cpp
@@ -62,10 +62,6 @@ void addSystemLockedLayer(const PXR_NS::SdfLayerRefPtr& layer)
         return;
 
     LockedLayers& layers = getLockedLayers();
-    auto          iter = layers.find(layer);
-    if (iter != layers.end()) {
-        return;
-    }
     layers.insert(layer);
 }
 

--- a/lib/mayaUsd/utils/layerLocking.h
+++ b/lib/mayaUsd/utils/layerLocking.h
@@ -35,8 +35,8 @@ namespace MAYAUSD_NS_DEF {
 // stage-level state. So, we need to explicitly save the layer locked state.
 //
 // Additionally, there are multiple levels of locking defined for a layer
-//     1- A layer is locked if layer's permission to edit is set to false
-//     2- A layer is system locked by setting a layer's permission to edit
+//     1- A layer is "Locked" if layer's permission to edit is set to false
+//     2- A layer is "System-Locked" by setting a layer's permission to edit
 //        and a layer's permission to save both to false.
 //
 // However, the USD API for checking permissions is a result of the following
@@ -63,6 +63,13 @@ namespace MAYAUSD_NS_DEF {
 //
 // So we need to hold on to locked layers. We do this in a private global list
 // of locked layers. That list gets cleared when a new Maya scene is created.
+
+enum LayerLockType
+{
+    LayerLock_Unlocked,
+    LayerLock_Locked,
+    LayerLock_SystemLocked
+};
 
 /*! \brief Adds a layer to the system lock list
  */

--- a/lib/mayaUsd/utils/layerLocking.h
+++ b/lib/mayaUsd/utils/layerLocking.h
@@ -1,0 +1,89 @@
+//
+// Copyright 2024 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_LAYERLOCKING_H
+#define MAYAUSD_LAYERLOCKING_H
+
+#include <mayaUsd/base/api.h>
+#include <mayaUsd/nodes/proxyShapeBase.h>
+
+#include <pxr/usd/sdf/layer.h>
+#include <pxr/usd/usd/stage.h>
+
+namespace MAYAUSD_NS_DEF {
+
+// The lock state of a layer is stage-level data. As such, it is not saved
+// within the layer (i.e. in the USD files that have been staged.) The reason
+// behind this is that two stages could have different locked layers, a single
+// layer could be locked in one stage and not locked in another stage. So, the
+// locked state cannot be a layer-level data.
+//
+// Furthermore, stages in USD are not saved but are a pure run-time entity,
+// part of the hosting application. It is thus the host responsibility to save
+// stage-level state. So, we need to explicitly save the layer locked state.
+//
+// Additionally, there are multiple levels of locking defined for a layer
+//     1- A layer is locked if layer's permission to edit is set to false
+//     2- A layer is system locked by setting a layer's permission to edit
+//        and a layer's permission to save both to false.
+//
+// However, the USD API for checking permissions is a result of the following
+// conditions:
+//
+//     For permission to save to be True (SdfLayer::PermissionToSave()):
+//
+//     1- The layer must not be anonymous
+//     2- The layer must not be muted
+//     3- The layer must have write access to disk
+//     4- The internal _permissionToSave must be True
+//
+//     For permission to Edit (SdfLayer::PermissionToEdit()):
+//
+//     1- The layer must not be muted
+//     2- The internal _permissionToEdit must be True
+//
+// For this reason, the locked layer state needs to be managed inside Maya USD
+// to avoid receiving false positives for PermissionToSave and PermissionToEdit.
+//
+// We therefore save the lock state of layers.
+// OpenUSD forgets everything about layer permissions to save or edit as there are only applicable
+// to sessions
+//
+// So we need to hold on to locked layers. We do this in a private global list
+// of locked layers. That list gets cleared when a new Maya scene is created.
+
+/*! \brief Adds a layer to the system lock list
+ */
+MAYAUSD_CORE_PUBLIC
+void addSystemLockedLayer(const PXR_NS::SdfLayerRefPtr& layer);
+
+/*! \brief Removes a layer from the system lock list
+ */
+MAYAUSD_CORE_PUBLIC
+void removeSystemLockedLayer(const PXR_NS::SdfLayerRefPtr& layer);
+
+/*! \brief Checks if a layer is in the lock list.
+ */
+MAYAUSD_CORE_PUBLIC
+bool isLayerSystemLocked(const PXR_NS::SdfLayerRefPtr& layer);
+
+/*! \brief Clears the lock list
+ */
+MAYAUSD_CORE_PUBLIC
+void forgetSystemLockedLayers();
+
+} // namespace MAYAUSD_NS_DEF
+
+#endif

--- a/lib/usd/ui/layerEditor/abstractCommandHook.h
+++ b/lib/usd/ui/layerEditor/abstractCommandHook.h
@@ -19,6 +19,8 @@
 
 #include "pxr/usd/sdf/layer.h"
 
+#include <mayaUsd/utils/layerLocking.h>
+
 #include <pxr/usd/usd/stage.h>
 
 #include <QtCore/QString>
@@ -79,8 +81,8 @@ public:
     // mute or unmute the given layer
     virtual void muteSubLayer(UsdLayer usdLayer, bool muteIt) = 0;
 
-    // lock or unlock the given layer
-    virtual void lockSubLayer(UsdLayer usdLayer, bool lockIt, bool systemLock) = 0;
+    // Sets the lock state on a layer
+    virtual void lockSubLayer(UsdLayer usdLayer, MayaUsd::LayerLockType lockState) = 0;
 
     // starts a complex undo operation in the host app. Please use UndoContext class to safely
     // open/close

--- a/lib/usd/ui/layerEditor/abstractCommandHook.h
+++ b/lib/usd/ui/layerEditor/abstractCommandHook.h
@@ -80,7 +80,7 @@ public:
     virtual void muteSubLayer(UsdLayer usdLayer, bool muteIt) = 0;
 
     // lock or unlock the given layer
-    virtual void lockSubLayer(UsdLayer usdLayer, bool lockIt) = 0;
+    virtual void lockSubLayer(UsdLayer usdLayer, bool lockIt, bool systemLock) = 0;
 
     // starts a complex undo operation in the host app. Please use UndoContext class to safely
     // open/close

--- a/lib/usd/ui/layerEditor/layerEditorWidget.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.cpp
@@ -264,10 +264,10 @@ void LayerEditorWidget::updateButtons()
             if (layer->isSystemLocked()) {
                 count--;
             }
-            // Neither does any anonymous layer whose parent is system locked.
+            // Neither does any anonymous layer whose parent is locked or system-locked.
             // This is because saving an anonymous layer will cause
             // the parent layer to re-path the sub layer with a file name.
-            if (layer->isAnonymous() && layer->appearsSystemLocked()) {
+            if (layer->isAnonymous() && (layer->appearsLocked() || layer->appearsSystemLocked())) {
                 count--;
             }
         }

--- a/lib/usd/ui/layerEditor/layerEditorWidget.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.cpp
@@ -267,8 +267,7 @@ void LayerEditorWidget::updateButtons()
             // Neither does any anonymous layer whose parent is system locked.
             // This is because saving an anonymous layer will cause
             // the parent layer to re-path the sub layer with a file name.
-            if (layer->isAnonymous() && layer->appearsSystemLocked())
-            {
+            if (layer->isAnonymous() && layer->appearsSystemLocked()) {
                 count--;
             }
         }

--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -281,6 +281,8 @@ bool LayerTreeItem::isLocked() const { return _layer && _layer->PermissionToEdit
 
 bool LayerTreeItem::appearsLocked() const
 {
+    // Note: This is used to indicate that some of the actions
+    // cannot be performed on a layer whose parent is locked.
     auto item = parentLayerItem();
     if (item != nullptr) {
         return item->isLocked();
@@ -293,6 +295,8 @@ bool LayerTreeItem::isSystemLocked() const { return MayaUsd::isLayerSystemLocked
 
 bool LayerTreeItem::appearsSystemLocked() const
 {
+    // Note: This is used to indicate that some of the actions cannot
+    // be performed on a layer whose parent is system-locked.
     auto item = parentLayerItem();
     if (item != nullptr) {
         return item->isSystemLocked();

--- a/lib/usd/ui/layerEditor/layerTreeItem.h
+++ b/lib/usd/ui/layerEditor/layerTreeItem.h
@@ -138,6 +138,10 @@ public:
     bool isLocked() const;
     // check if this layer is locked
     bool appearsLocked() const;
+    // is the layer system locked?
+    bool isSystemLocked() const;
+    // check if this layer is system locked 
+    bool appearsSystemLocked() const;
 
     // used by draw delegate: returns how deep in the hierarchy we are
     int depth() const;

--- a/lib/usd/ui/layerEditor/layerTreeItem.h
+++ b/lib/usd/ui/layerEditor/layerTreeItem.h
@@ -140,7 +140,7 @@ public:
     bool appearsLocked() const;
     // is the layer system locked?
     bool isSystemLocked() const;
-    // check if this layer is system locked 
+    // check if this layer is system locked
     bool appearsSystemLocked() const;
 
     // used by draw delegate: returns how deep in the hierarchy we are

--- a/lib/usd/ui/layerEditor/layerTreeItem.h
+++ b/lib/usd/ui/layerEditor/layerTreeItem.h
@@ -136,11 +136,15 @@ public:
     bool isIncoming() const;
     // is the layer locked?
     bool isLocked() const;
-    // check if this layer is locked
+    // check if this layer appears locked. This means that the layer item itself
+    // may not be locked but by inference some of the action items of the layer
+    // can appear as locked if the parent is locked.
     bool appearsLocked() const;
     // is the layer system locked?
     bool isSystemLocked() const;
-    // check if this layer is system locked
+    // check if this layer appears system locked. This means that the layer item itself
+    // may not be system locked but by inference some of the action items of the layer
+    // can appear as locked if the parent is system locked.
     bool appearsSystemLocked() const;
 
     // used by draw delegate: returns how deep in the hierarchy we are

--- a/lib/usd/ui/layerEditor/layerTreeModel.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeModel.cpp
@@ -151,7 +151,7 @@ bool LayerTreeModel::canDropMimeData(
     }
 
     auto parentItem = layerItemFromIndex(parentIndex);
-    if (!parentItem || parentItem->isReadOnly()) {
+    if (!parentItem || parentItem->isReadOnly() || parentItem->isLocked()) {
         return false;
     }
 
@@ -194,7 +194,7 @@ bool LayerTreeModel::dropMimeData(
     }
 
     auto parentItem = layerItemFromIndex(parentIndex);
-    if (!parentItem || parentItem->isReadOnly()) {
+    if (!parentItem || parentItem->isReadOnly() || parentItem->isLocked()) {
         return false;
     }
 
@@ -235,7 +235,8 @@ bool LayerTreeModel::dropMimeData(
 
 void LayerTreeModel::setEditTarget(LayerTreeItem* item)
 {
-    if (!item->appearsMuted() && !item->isReadOnly()) {
+    if (!item->appearsMuted() && !item->isReadOnly() && !item->isLocked()
+        && !item->isSystemLocked()) {
         UndoContext context(_sessionState->commandHook(), "Set USD Edit Target Layer");
         context.hook()->setEditTarget(item->layer());
     }
@@ -481,8 +482,11 @@ void LayerTreeModel::saveStage(QWidget* in_parent)
     auto saveAllLayers = [this]() {
         const auto layers = getAllNeedsSavingLayers();
         for (auto layer : layers) {
-            if (!layer->isAnonymous())
-                layer->saveEditsNoPrompt();
+            if (!layer->isSystemLocked()) {
+                if (!layer->isAnonymous()) {
+                    layer->saveEditsNoPrompt();
+                }
+            }
         }
     };
 
@@ -570,7 +574,7 @@ void LayerTreeModel::toggleMuteLayer(LayerTreeItem* item, bool* forcedState)
 
 void LayerTreeModel::toggleLockLayer(LayerTreeItem* item, bool* forcedState /*= nullptr*/)
 {
-    if (item->isInvalidLayer() || item->isSessionLayer())
+    if (item->isInvalidLayer() || item->isSessionLayer() || item->isSystemLocked())
         return;
 
     if (forcedState) {
@@ -578,7 +582,7 @@ void LayerTreeModel::toggleLockLayer(LayerTreeItem* item, bool* forcedState /*= 
             return;
     }
 
-    _sessionState->commandHook()->lockSubLayer(item->layer(), !item->isLocked());
+    _sessionState->commandHook()->lockSubLayer(item->layer(), !item->isLocked(), false);
 }
 
 } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/layerTreeModel.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeModel.cpp
@@ -582,7 +582,10 @@ void LayerTreeModel::toggleLockLayer(LayerTreeItem* item, bool* forcedState /*= 
             return;
     }
 
-    _sessionState->commandHook()->lockSubLayer(item->layer(), !item->isLocked(), false);
+    MayaUsd::LayerLockType toggledLockType = item->isLocked()
+        ? MayaUsd::LayerLockType::LayerLock_Unlocked
+        : MayaUsd::LayerLockType::LayerLock_Locked;
+    _sessionState->commandHook()->lockSubLayer(item->layer(), toggledLockType);
 }
 
 } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/layerTreeView.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeView.cpp
@@ -541,7 +541,7 @@ void LayerTreeView::onMuteLayerButtonPushed()
 void LayerTreeView::onLockLayerButtonPushed()
 {
     auto item = currentLayerItem();
-    if (item) {
+    if (item && !item->isSystemLocked()) {
         item->parentModel()->toggleLockLayer(item);
     }
     // need to force redraw of everything otherwise redraw isn't right

--- a/lib/usd/ui/layerEditor/mayaCommandHook.cpp
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.cpp
@@ -210,19 +210,30 @@ void MayaCommandHook::muteSubLayer(UsdLayer usdLayer, bool muteIt)
     executeMel(cmd).asChar();
 }
 
-// lock or unlock the given layer
-void MayaCommandHook::lockSubLayer(UsdLayer usdLayer, bool lockIt, bool systemLock)
+// lock, system-lock or unlock the given layer
+void MayaCommandHook::lockSubLayer(UsdLayer usdLayer, MayaUsd::LayerLockType lockState)
 {
     std::string cmd;
     cmd = "mayaUsdLayerEditor -edit -lockLayer ";
     // 0 = Unlocked
     // 1 = Locked
     // 2 = System Locked
-    if (systemLock) {
-        cmd += "2";
-    } else {
-        cmd += lockIt ? "1" : "0";
+    switch (lockState) {
+    default:
+    case MayaUsd::LayerLockType::LayerLock_Unlocked: {
+        cmd += "0";
+        break;
     }
+    case MayaUsd::LayerLockType::LayerLock_Locked: {
+        cmd += "1";
+        break;
+    }
+    case MayaUsd::LayerLockType::LayerLock_SystemLocked: {
+        cmd += "2";
+        break;
+    }
+    }
+
     cmd += quote(proxyShapePath());
     cmd += quote(usdLayer->GetIdentifier());
     executeMel(cmd).asChar();

--- a/lib/usd/ui/layerEditor/mayaCommandHook.cpp
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.cpp
@@ -211,11 +211,18 @@ void MayaCommandHook::muteSubLayer(UsdLayer usdLayer, bool muteIt)
 }
 
 // lock or unlock the given layer
-void MayaCommandHook::lockSubLayer(UsdLayer usdLayer, bool lockIt)
+void MayaCommandHook::lockSubLayer(UsdLayer usdLayer, bool lockIt, bool systemLock)
 {
     std::string cmd;
     cmd = "mayaUsdLayerEditor -edit -lockLayer ";
-    cmd += lockIt ? "1" : "0";
+    // 0 = Unlocked
+    // 1 = Locked
+    // 2 = System Locked
+    if (systemLock) {
+        cmd += "2";
+    } else {
+        cmd += lockIt ? "1" : "0";
+    }
     cmd += quote(proxyShapePath());
     cmd += quote(usdLayer->GetIdentifier());
     executeMel(cmd).asChar();

--- a/lib/usd/ui/layerEditor/mayaCommandHook.h
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.h
@@ -61,8 +61,8 @@ public:
     // mute or unmute the given layer
     void muteSubLayer(UsdLayer usdLayer, bool muteIt) override;
 
-    // lock or unlock the given layer
-    void lockSubLayer(UsdLayer usdLayer, bool lockIt, bool systemLock) override;
+    // lock, system-lock or unlock the given layer
+    void lockSubLayer(UsdLayer usdLayer, MayaUsd::LayerLockType lockState) override;
 
     // starts a complex undo operation in the host app. Please use UndoContext class to safely
     // open/close

--- a/lib/usd/ui/layerEditor/mayaCommandHook.h
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.h
@@ -62,7 +62,7 @@ public:
     void muteSubLayer(UsdLayer usdLayer, bool muteIt) override;
 
     // lock or unlock the given layer
-    void lockSubLayer(UsdLayer usdLayer, bool lockIt) override;
+    void lockSubLayer(UsdLayer usdLayer, bool lockIt, bool systemLock) override;
 
     // starts a complex undo operation in the host app. Please use UndoContext class to safely
     // open/close

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
@@ -161,6 +161,8 @@ bool MayaLayerEditorWindow::layerIsMuted() { CALL_CURRENT_ITEM(isMuted); }
 bool MayaLayerEditorWindow::layerIsReadOnly() { CALL_CURRENT_ITEM(isReadOnly); }
 bool MayaLayerEditorWindow::layerAppearsLocked() { CALL_CURRENT_ITEM(appearsLocked); }
 bool MayaLayerEditorWindow::layerIsLocked() { CALL_CURRENT_ITEM(isLocked); }
+bool MayaLayerEditorWindow::layerAppearsSystemLocked() { CALL_CURRENT_ITEM(appearsSystemLocked); }
+bool MayaLayerEditorWindow::layerIsSystemLocked() { CALL_CURRENT_ITEM(isSystemLocked); }
 
 std::string MayaLayerEditorWindow::proxyShapeName() const
 {

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.h
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.h
@@ -61,6 +61,8 @@ public:
     std::string proxyShapeName() const override;
     bool        layerAppearsLocked() override;
     bool        layerIsLocked() override;
+    bool        layerAppearsSystemLocked() override;
+    bool        layerIsSystemLocked() override;
 
     void removeSubLayer() override;
     void saveEdits() override;

--- a/lib/usd/ui/layerEditor/stringResources.h
+++ b/lib/usd/ui/layerEditor/stringResources.h
@@ -65,6 +65,7 @@ const auto kLoadSublayers                { create("kLoadSublayers", "Load Sublay
 const auto kLayerPath                    { create("kLayerPath", "Layer Path:") };
 const auto kMuteUnmuteLayer              { create("kMuteUnmuteLayer", "Mute/unmute the layer. Muted layers are ignored by the stage.")};
 const auto kLockUnlockLayer              { create("kLockUnlockLayer", "Lock/unlock the layer. A locked layer cannot be edited.")};
+const auto kLayerIsSystemLocked          { create("kLayerIsSystemLocked", "This layer has been locked by the system or administrator and is not editable.\nContact your TD for access.")};
 const auto kNoLayers                     { create("kNoLayers", "No Layers") };
 const auto kNotUndoable                  { create("kNotUndoable", "You can not undo this action.") };
 const auto kOption                       { create("kOption", "Option") };

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -870,6 +870,8 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
     int $isReadOnly = `mayaUsdLayerEditorWindow -q -layerIsReadOnly $panelName`;
     int $appearsLocked = `mayaUsdLayerEditorWindow -q -layerAppearsLocked $panelName`;
     int $isLocked = `mayaUsdLayerEditorWindow -q -layerIsLocked $panelName`;
+    int $appearsSystemLocked = `mayaUsdLayerEditorWindow -q -layerAppearsSystemLocked $panelName`;
+    int $isSystemLocked = `mayaUsdLayerEditorWindow -q -layerIsSystemLocked $panelName`;
     int $isIncoming = `mayaUsdLayerEditorWindow -q -isIncomingLayer $panelName`;
     string $proxyShape = `mayaUsdLayerEditorWindow -q -proxyShape $panelName`;
 
@@ -881,7 +883,12 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
             $label = getMayaUsdString("kMenuSaveAs");
         else
             $label = getMayaUsdString("kMenuSaveEdits");
-        $enabled = $singleSelect && $needsSaving;
+        $enabled = $singleSelect && $needsSaving && !$isSystemLocked;
+        // An anonymous layer whose parent is locked or system locked cannot be saved
+        if ($isAnonymousLayer)
+            {
+                $enabled = $enabled && !$appearsLocked && !$appearsSystemLocked;
+            }
         $cmd = makeCommand($panelName, "saveEdits");
         menuItem -label $label -enable $enabled -c $cmd;
     }
@@ -897,17 +904,17 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
 
     $label = getMayaUsdString("kMenuAddSublayer");
     $cmd = makeCommand($panelName, "addAnonymousSublayer");
-    $enabled = $appearsMuted == 0 && !$isReadOnly;
+    $enabled = $appearsMuted == 0 && !$isReadOnly && !$isLocked && !$isSystemLocked;
     menuItem -label $label -enable $enabled -c $cmd;
 
     $label = getMayaUsdString("kMenuAddParentLayer");
     $cmd = makeCommand($panelName, "addParentLayer");
-    $enabled = $isSubLayer && $appearsMuted == 0 && !$isReadOnly;
+    $enabled = $isSubLayer && $appearsMuted == 0 && !$isReadOnly && !$appearsLocked && !$appearsSystemLocked;
     menuItem -label $label -enable $enabled -c $cmd;
 
     $label = getMayaUsdString("kMenuLoadSublayers");
     $cmd = makeCommand($panelName, "loadSubLayers");
-    $enabled = $singleSelect && !$appearsMuted && !$isReadOnly;
+    $enabled = $singleSelect && !$appearsMuted && !$isReadOnly && !$isLocked && !$isSystemLocked;
     menuItem -label $label -enable $enabled -c $cmd;
 
     menuItem -divider 1;
@@ -928,7 +935,7 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
         else
             $label = getMayaUsdString("kMenuLock");
         $cmd = makeCommand($panelName, "lockLayer");
-        $enabled = 1;
+        $enabled = !$isSystemLocked;
         menuItem -label $label -enable $enabled -c $cmd;
     }
 
@@ -973,13 +980,13 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
     if ($isSubLayer) {
         $label = getMayaUsdString("kMenuRemove");
         $cmd = makeCommand($panelName, "removeSubLayer");
-        $enabled = !$isReadOnly;
+        $enabled = !$isReadOnly && !$appearsLocked && !$appearsSystemLocked;
         menuItem -label $label -enable $enabled -c $cmd;
     }
 
 
     $label = getMayaUsdString("kMenuClear");
     $cmd = makeCommand($panelName, "clearLayer");
-    $enabled = !$isReadOnly;
+    $enabled = !$isReadOnly && !$isLocked && !$isSystemLocked;
     menuItem -label $label -enable $enabled -c $cmd;
 }

--- a/test/lib/testMayaUsdLayerEditorCommands.py
+++ b/test/lib/testMayaUsdLayerEditorCommands.py
@@ -545,14 +545,23 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
         subLayer = createLayer(0)
         self.assertTrue(subLayer.permissionToEdit)
         
-        mel.eval('mayaUsdLayerEditor -edit -lockLayer 1 "%s" "%s"' % (shapePath, subLayer.identifier))
+        # Locking a layer
+        cmds.mayaUsdLayerEditor(subLayer.identifier, edit=True, lockLayer=(1, shapePath))
         self.assertFalse(subLayer.permissionToEdit)
         cmds.undo()
         self.assertTrue(subLayer.permissionToEdit)
         cmds.redo()
         self.assertFalse(subLayer.permissionToEdit)
-        mel.eval('mayaUsdLayerEditor -edit -lockLayer 0 "%s" "%s"' % (shapePath, subLayer.identifier))
+        # Unlocking a layer
+        cmds.mayaUsdLayerEditor(subLayer.identifier, edit=True, lockLayer=(0, shapePath))
         self.assertTrue(subLayer.permissionToEdit)
+        # System locking a layer
+        cmds.mayaUsdLayerEditor(subLayer.identifier, edit=True, lockLayer=(2, shapePath))
+        self.assertFalse(subLayer.permissionToEdit)
+        self.assertFalse(subLayer.permissionToSave)
+        cmds.undo()
+        self.assertTrue(subLayer.permissionToEdit)
+        
         
     def testMuteLayer(self):
         """ test 'mayaUsdLayerEditor' command 'muteLayer' paramater """


### PR DESCRIPTION
The system lock is a severity of locking a layer where it cannot be undone using UI. It is meant to be controlled through script or programmatically to prevent a user from editing or saving a layer.

The locking can be performed using the mayaUsdLayerEditor command with the lockLayer parameter:
- `lockLayer 0` is unlocked 
- `lockLayer 1` is locked: Sets the PermissionToEdit to false
- `lockLayer 2` is system locked: Sets both the PermissionToEdit and PermissionToSave to false

Example of System Locking:
<img src="https://github.com/Autodesk/maya-usd/assets/123101715/1029fb20-8d61-41ba-a5da-adb3186f38ac" width="750"/>

In the above example:
- (1) asdf.usda is system locked, No Save, No Edit
- As a result of the system lock, the anonymous layers (2), (3) cannot be saved since saving them will cause a change in asdf.usda. The anonymous layers can still be edited.
- qwerty.usda changes can be saved since it doesn't affect the system locked parent.

<img src="https://github.com/Autodesk/maya-usd/assets/123101715/3e4e0951-5e2c-43a3-bf99-dab2512e1489" width="400"/>
<img src="https://github.com/Autodesk/maya-usd/assets/123101715/834cc796-270f-43e1-b94e-8c0733277d44" width="400"/>

Any Layer Editor operations that affect the locked parent are disabled on sublayers. This includes context menu operations.