### PR TITLE
EMSUSD-1017 Fix reverting multiple files

### DIFF
--- a/lib/usd/ui/layerEditor/abstractCommandHook.h
+++ b/lib/usd/ui/layerEditor/abstractCommandHook.h
@@ -105,8 +105,53 @@ public:
     // or has an owned root
     virtual bool isProxyShapeSharedStage(const std::string& proxyShapePath) = 0;
 
+    // Increase the count tracking if command executions are delayed.
+    void increaseDelayedCommands() { _delayCount += 1; }
+
+    // Decrease the count tracking if command executions are delayed.
+    void decreaseDelayedCommands()
+    {
+        _delayCount -= 1;
+        if (!areCommandsDelayed())
+            executeDelayedCommands();
+    }
+
+    // Verify if commands are currently delayed.
+    bool areCommandsDelayed() const { return _delayCount > 0; }
+
 protected:
+    virtual void executeDelayedCommands() = 0;
+
     SessionState* _sessionState;
+    int           _delayCount { 0 };
+};
+
+/**
+ * @brief When executing multiple commands, it may sometimes be necessary to delay.
+ *        the execution until all commands are issued. For example, when processing
+ *        multiple elements in the slection, but the command itself might change the
+ *        selection.
+ */
+class DelayAbstractCommandHook
+{
+public:
+    DelayAbstractCommandHook(AbstractCommandHook& hook)
+        : _hook(hook)
+    {
+        _hook.increaseDelayedCommands();
+    }
+
+    ~DelayAbstractCommandHook()
+    {
+        try {
+            _hook.decreaseDelayedCommands();
+        } catch (const std::exception&) {
+            // Ignore exceptions in destructor.
+        }
+    }
+
+private:
+    AbstractCommandHook& _hook;
 };
 
 class UndoContext

--- a/lib/usd/ui/layerEditor/layerTreeView.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeView.cpp
@@ -293,6 +293,8 @@ LayerItemVector LayerTreeView::getSelectedLayerItems() const
 
 void LayerTreeView::onAddParentLayer(const QString& undoName) const
 {
+    DelayAbstractCommandHook delayed(*_model->sessionState()->commandHook());
+
     auto selection = getSelectedLayerItems();
 
     CallMethodParams params;
@@ -322,6 +324,8 @@ void LayerTreeView::onAddParentLayer(const QString& undoName) const
 
 void LayerTreeView::onMuteLayer(const QString& undoName) const
 {
+    DelayAbstractCommandHook delayed(*_model->sessionState()->commandHook());
+
     auto selection = getSelectedLayerItems();
 
     CallMethodParams params;
@@ -339,6 +343,7 @@ void LayerTreeView::onMuteLayer(const QString& undoName) const
 
 void LayerTreeView::onLockLayer(const QString& undoName) const
 {
+    DelayAbstractCommandHook delayed(*_model->sessionState()->commandHook());
 
     auto selection = getSelectedLayerItems();
 
@@ -357,6 +362,8 @@ void LayerTreeView::onLockLayer(const QString& undoName) const
 
 void LayerTreeView::callMethodOnSelection(const QString& undoName, simpleLayerMethod method)
 {
+    DelayAbstractCommandHook delayed(*_model->sessionState()->commandHook());
+
     CallMethodParams params;
     auto             selection = getSelectedLayerItems();
     params.selection = &selection;
@@ -486,6 +493,8 @@ void LayerTreeView::mouseReleaseEvent(QMouseEvent* event)
 
 void LayerTreeView::keyPressEvent(QKeyEvent* event)
 {
+    DelayAbstractCommandHook delayed(*_model->sessionState()->commandHook());
+
     if (event->type() == QEvent::KeyPress) {
         if (event->key() == Qt::Key_Delete) {
             CallMethodParams params;

--- a/lib/usd/ui/layerEditor/mayaCommandHook.h
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.h
@@ -19,6 +19,8 @@
 
 #include "abstractCommandHook.h"
 
+#include <vector>
+
 namespace UsdLayerEditor {
 
 /**
@@ -87,6 +89,25 @@ public:
 
 protected:
     std::string proxyShapePath();
+
+    std::string executeMel(const std::string& commandString);
+    void        executePython(const std::string& commandString);
+
+    void executeDelayedCommands() override;
+
+    struct DelayedCommand
+    {
+        DelayedCommand(const std::string& cmd, bool isP)
+            : command(cmd)
+            , isPython(isP)
+        {
+        }
+
+        std::string command;
+        bool        isPython { false };
+    };
+
+    std::vector<DelayedCommand> _delayedCommands;
 };
 
 } // namespace UsdLayerEditor


### PR DESCRIPTION
When reverting multiple USD layers, reverting the first layer would trigger the UI to update, thus making the the element holding the other layers invalid before they were processed.

To avoid this, add a mechanism to delay the execution of commands in the command-hook so that all item can be processed before the first command is executed.

In the Maya implementation of the command hook, the MEL and Python commands are accumulated when the commands are delayed and executed once the delayed commands are triggered.