### PR TITLE
EMSUSD-873 - Adds write permission checks to layer system-locking

### DIFF
--- a/lib/mayaUsd/utils/layerLocking.h
+++ b/lib/mayaUsd/utils/layerLocking.h
@@ -66,7 +66,7 @@ namespace MAYAUSD_NS_DEF {
 
 enum LayerLockType
 {
-    LayerLock_Unlocked,
+    LayerLock_Unlocked = 0,
     LayerLock_Locked,
     LayerLock_SystemLocked
 };

--- a/lib/mayaUsd/utils/layers.h
+++ b/lib/mayaUsd/utils/layers.h
@@ -29,6 +29,11 @@ getAllSublayers(const std::vector<std::string>& parentLayerPaths, bool includePa
     return UsdUfe::getAllSublayers(parentLayerPaths, includeParents);
 }
 
+inline std::set<PXR_NS::SdfLayerRefPtr> getAllSublayerRefs(const PXR_NS::SdfLayerRefPtr& layer, bool includeTopLayer = false)
+{
+    return UsdUfe::getAllSublayerRefs(layer, includeTopLayer);
+}
+
 //! Return the folder of the layer of the current edit target of the stage, if any.
 //  If the stage is null, the returned path will be empty.
 MAYAUSD_CORE_PUBLIC

--- a/lib/usd/ui/layerEditor/abstractCommandHook.h
+++ b/lib/usd/ui/layerEditor/abstractCommandHook.h
@@ -84,6 +84,10 @@ public:
     // Sets the lock state on a layer
     virtual void lockSubLayer(UsdLayer usdLayer, MayaUsd::LayerLockType lockState) = 0;
 
+    // Checks if the file layer or its sublayers are accessible on disk, and updates the system-lock
+    // status.
+    virtual void refreshLayerSystemLock(UsdLayer usdLayer, bool refreshSubLayers = false) = 0;
+
     // starts a complex undo operation in the host app. Please use UndoContext class to safely
     // open/close
     virtual void openUndoBracket(const QString& name) = 0;
@@ -107,6 +111,9 @@ public:
 
 protected:
     SessionState* _sessionState;
+
+    // Checks if the file layer is accessible on disk, and updates the system-lock status accordingly.
+    virtual void _refreshLayerSystemLock(UsdLayer usdLayer) = 0;
 };
 
 class UndoContext

--- a/lib/usd/ui/layerEditor/layerTreeModel.h
+++ b/lib/usd/ui/layerEditor/layerTreeModel.h
@@ -139,7 +139,7 @@ protected:
 
     void rebuildModelOnIdle();
     bool _rebuildOnIdlePending = false;
-    void rebuildModel();
+    void rebuildModel(bool refreshLockState = false);
 
     void updateTargetLayer(InRebuildModel inRebuild);
 

--- a/lib/usd/ui/layerEditor/mayaCommandHook.h
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.h
@@ -64,6 +64,10 @@ public:
     // lock, system-lock or unlock the given layer
     void lockSubLayer(UsdLayer usdLayer, MayaUsd::LayerLockType lockState) override;
 
+    // Checks if the file layer or its sublayers are accessible on disk, and updates the system-lock
+    // status.
+    void refreshLayerSystemLock(UsdLayer usdLayer, bool refreshSubLayers = false) override;
+
     // starts a complex undo operation in the host app. Please use UndoContext class to safely
     // open/close
     void openUndoBracket(const QString& name) override;
@@ -87,6 +91,10 @@ public:
 
 protected:
     std::string proxyShapePath();
+
+    // Checks if the file layer or its sublayers are accessible on disk, and updates the system-lock
+    // status.
+    void _refreshLayerSystemLock(UsdLayer usdLayer) override;
 };
 
 } // namespace UsdLayerEditor

--- a/plugin/adsk/scripts/AETemplateHelpers.py
+++ b/plugin/adsk/scripts/AETemplateHelpers.py
@@ -3,6 +3,7 @@ import maya.cmds as cmds
 import maya.api.OpenMaya as OpenMaya
 import maya.internal.ufeSupport.ufeCmdWrapper as ufeCmd
 import usdUfe
+import mayaUsd
 import mayaUsd.ufe
 import mayaUsd.lib as mayaUsdLib
 import re
@@ -108,6 +109,16 @@ def GetStageFromProxyShapeAttr(attr):
     proxyStage = mayaUsd.ufe.getStage(fullStageName)
 
     return(stageName, proxyStage)
+
+def GetFullStageNameFromProxyShapeAttr(attr):
+    # Helper method which returns the full stage name
+    # First get the stage name from the input attribute.
+    stageName = attr.split('.')[0]
+    # Convert that into a long Maya path so we can get the USD stage.
+    res = cmds.ls(stageName, l=True)
+    fullStageName = res[0]
+    
+    return(fullStageName)
 
 def RequireUsdPathsRelativeToMayaSceneFile():
     opVarName = "mayaUsd_MakePathRelativeToSceneFile"
@@ -278,5 +289,11 @@ def ProxyShapeFilePathRefresh(filePathAttr):
                 if res == kYes:
                     debugMessage('  User confirmed reload action, calling UsdStage.Reload()')
                     proxyStage.Reload()
+        
+        # Refresh the system lock status of the stage and its sublayers
+        stageFilePath = cmds.getAttr(filePathAttr)
+        fullStageName = GetFullStageNameFromProxyShapeAttr(filePathAttr)
+        cmds.mayaUsdLayerEditor(stageFilePath, edit=True, refreshSystemLock=(fullStageName, True))
+        
     except Exception as e:
         debugMessage('ProxyShapeFilePathRefresh() - Error: %s' % str(e))


### PR DESCRIPTION
Some of the layer operations will refresh the system-lock based on the write permissions of those layers. The operations are as follows:

- When the user initiates a layer reload (through the context menu in the usd layer editor)
- When the user initiates a stage reload (through attribute editor)
- When the user loads a stage from a file.
- Anything that may cause a session stage change on the LayerTreeModel (including the case of stage reload).
- Using script (refreshSystemLock)

Note that:
- Anonymous layers are not checked for write permissions.
- The check is executed regardless of changes on disk. Only the write permissions are checked (as per design).
