### PR TITLE
EMSUSD-871 - Locked layer status persists between Maya sessions

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -120,6 +120,8 @@ public:
     static MObject rootLayerNameAttr;
     MAYAUSD_CORE_PUBLIC
     static MObject mutedLayersAttr;
+    MAYAUSD_CORE_PUBLIC
+    static MObject lockedLayersAttr;
 
     // Change counter attributes
     MAYAUSD_CORE_PUBLIC
@@ -212,6 +214,12 @@ public:
 
     MAYAUSD_CORE_PUBLIC
     MStatus setMutedLayers(const std::vector<std::string>& muted);
+
+    MAYAUSD_CORE_PUBLIC
+    std::vector<std::string> getLockedLayers() const;
+
+    MAYAUSD_CORE_PUBLIC
+    MStatus setLockedLayers(const std::vector<std::string>& locked);
 
     MAYAUSD_CORE_PUBLIC
     UsdTimeCode getTime() const override;

--- a/lib/mayaUsd/utils/layerLocking.cpp
+++ b/lib/mayaUsd/utils/layerLocking.cpp
@@ -30,15 +30,19 @@ namespace MAYAUSD_NS_DEF {
 
 MStatus copyLayerLockingToAttribute(MayaUsdProxyShapeBase* proxyShape)
 {
-    LockedLayers& lockedLayers = getLockedLayers();
+    if (proxyShape != nullptr) {
+        LockedLayers& lockedLayers = getLockedLayers();
 
-    std::vector<std::string> toAttribute;
-    toAttribute.reserve(lockedLayers.size());
+        std::vector<std::string> toAttribute;
+        toAttribute.reserve(lockedLayers.size());
 
-    for (auto layer : lockedLayers) {
-        toAttribute.emplace_back(layer->GetIdentifier());
+        for (auto layer : lockedLayers) {
+            toAttribute.emplace_back(layer->GetIdentifier());
+        }
+        return proxyShape->setLockedLayers(toAttribute);
+    } else {
+        return MStatus::kFailure;
     }
-    return proxyShape->setLockedLayers(toAttribute);
 }
 
 MStatus copyLayerLockingFromAttribute(

--- a/lib/mayaUsd/utils/layerLocking.cpp
+++ b/lib/mayaUsd/utils/layerLocking.cpp
@@ -17,12 +17,63 @@
 #include "layerLocking.h"
 
 #include <mayaUsd/listeners/notice.h>
+#include <mayaUsd/ufe/Global.h>
+#include <mayaUsd/ufe/Utils.h>
+#include <mayaUsd/utils/query.h>
+#include <mayaUsd/utils/util.h>
 
 #include <pxr/base/tf/weakBase.h>
 
+#include <ufe/path.h>
+
 namespace MAYAUSD_NS_DEF {
 
-namespace {
+MStatus copyLayerLockingToAttribute(MayaUsdProxyShapeBase* proxyShape)
+{
+    LockedLayers& lockedLayers = getLockedLayers();
+
+    std::vector<std::string> toAttribute;
+    toAttribute.reserve(lockedLayers.size());
+
+    for (auto layer : lockedLayers) {
+        toAttribute.emplace_back(layer->GetIdentifier());
+    }
+    return proxyShape->setLockedLayers(toAttribute);
+}
+
+MStatus copyLayerLockingFromAttribute(
+    const MayaUsdProxyShapeBase& proxyShape,
+    const LayerNameMap&          nameMap,
+    PXR_NS::UsdStage&            stage)
+{
+    std::vector<std::string> locked = proxyShape.getLockedLayers();
+
+    // Remap the locked layer names in case the layers were renamed when reloaded.
+    for (std::string& name : locked) {
+        auto iter = nameMap.find(name);
+        if (iter != nameMap.end()) {
+            name = iter->second;
+        }
+    }
+
+    // Add locked layers to the retained locked layer set to avoid losing them.
+    // This is necessary because USD only keeps layers in memory if at least one
+    // referencing pointer holds it, but locking in the stage makes the stage no
+    // longer reference the layer, so the layer would be lost otherwise.
+    //
+    // Use a set to accelerate lookup of locked layers.
+    PXR_NS::SdfLayerHandleVector layers = stage.GetLayerStack();
+    std::set<std::string>        lockedSet(locked.begin(), locked.end());
+    for (const auto& layer : layers) {
+        const auto iter = lockedSet.find(layer->GetIdentifier());
+        if (iter != lockedSet.end()) {
+            std::string emptyShapePath;
+            lockLayer(emptyShapePath, layer, LayerLockType::LayerLock_Locked, false);
+        }
+    }
+
+    return MS::kSuccess;
+}
 
 // Automatic reset of recorded locked layers when the Maya scene is reset.
 struct SceneResetListener : public PXR_NS::TfWeakBase
@@ -37,15 +88,66 @@ struct SceneResetListener : public PXR_NS::TfWeakBase
     {
         // Make sure we don't hold onto locked layers now that the
         // Maya scene is reset.
+        forgetLockedLayers();
         forgetSystemLockedLayers();
     }
 };
+
+void updateProxyShapeAttribute(const std::string proxyShapePath)
+{
+    if (!proxyShapePath.empty()) {
+        MayaUsdProxyShapeBase* proxyShape = UsdMayaUtil::GetProxyShapeByProxyName(proxyShapePath);
+        copyLayerLockingToAttribute(proxyShape);
+    }
+}
+
+void lockLayer(
+    std::string                   proxyShapePath,
+    const PXR_NS::SdfLayerRefPtr& layer,
+    LayerLockType                 locktype,
+    bool                          updateProxyShapeAttr /*= true */)
+{
+
+    switch (locktype) {
+    default:
+    case LayerLock_Unlocked: {
+        layer->SetPermissionToEdit(true);
+        layer->SetPermissionToSave(true);
+        removeLockedLayer(layer);
+        removeSystemLockedLayer(layer);
+        if (updateProxyShapeAttr) {
+            updateProxyShapeAttribute(proxyShapePath);
+        }
+        break;
+    }
+    case LayerLock_Locked: {
+        layer->SetPermissionToEdit(false);
+        layer->SetPermissionToSave(true);
+        addLockedLayer(layer);
+        removeSystemLockedLayer(layer);
+        if (updateProxyShapeAttr) {
+            updateProxyShapeAttribute(proxyShapePath);
+        }
+        break;
+    }
+    case LayerLock_SystemLocked: {
+        layer->SetPermissionToSave(false);
+        layer->SetPermissionToEdit(false);
+        addSystemLockedLayer(layer);
+        removeLockedLayer(layer);
+        if (updateProxyShapeAttr) {
+            updateProxyShapeAttribute(proxyShapePath);
+        }
+        break;
+    }
+    }
+}
 
 // The set of locked layers.
 //
 // Kept in a function to avoid problem with the order of construction
 // of global variables in C++.
-using LockedLayers = std::set<PXR_NS::SdfLayerRefPtr>;
+
 LockedLayers& getLockedLayers()
 {
     // Note: C++ guarantees correct multi-thread protection for static
@@ -54,9 +156,17 @@ LockedLayers& getLockedLayers()
     static LockedLayers       layers;
     return layers;
 }
-} // namespace
 
-void addSystemLockedLayer(const PXR_NS::SdfLayerRefPtr& layer)
+LockedLayers& getSystemLockedLayers()
+{
+    // Note: C++ guarantees correct multi-thread protection for static
+    //       variables initialization in functions.
+    static SceneResetListener onSceneResetListener;
+    static LockedLayers       layers;
+    return layers;
+}
+
+void addLockedLayer(const PXR_NS::SdfLayerRefPtr& layer)
 {
     if (!layer)
         return;
@@ -65,7 +175,7 @@ void addSystemLockedLayer(const PXR_NS::SdfLayerRefPtr& layer)
     layers.insert(layer);
 }
 
-void removeSystemLockedLayer(const PXR_NS::SdfLayerRefPtr& layer)
+void removeLockedLayer(const PXR_NS::SdfLayerRefPtr& layer)
 {
     if (!layer)
         return;
@@ -74,7 +184,7 @@ void removeSystemLockedLayer(const PXR_NS::SdfLayerRefPtr& layer)
     layers.erase(layer);
 }
 
-bool isLayerSystemLocked(const PXR_NS::SdfLayerRefPtr& layer)
+bool isLayerLocked(const PXR_NS::SdfLayerRefPtr& layer)
 {
     if (!layer)
         return false;
@@ -87,9 +197,46 @@ bool isLayerSystemLocked(const PXR_NS::SdfLayerRefPtr& layer)
     return false;
 }
 
-void forgetSystemLockedLayers()
+void forgetLockedLayers()
 {
     LockedLayers& layers = getLockedLayers();
+    layers.clear();
+}
+
+void addSystemLockedLayer(const PXR_NS::SdfLayerRefPtr& layer)
+{
+    if (!layer)
+        return;
+
+    LockedLayers& layers = getSystemLockedLayers();
+    layers.insert(layer);
+}
+
+void removeSystemLockedLayer(const PXR_NS::SdfLayerRefPtr& layer)
+{
+    if (!layer)
+        return;
+
+    LockedLayers& layers = getSystemLockedLayers();
+    layers.erase(layer);
+}
+
+bool isLayerSystemLocked(const PXR_NS::SdfLayerRefPtr& layer)
+{
+    if (!layer)
+        return false;
+
+    LockedLayers& layers = getSystemLockedLayers();
+    auto          iter = layers.find(layer);
+    if (iter != layers.end()) {
+        return true;
+    }
+    return false;
+}
+
+void forgetSystemLockedLayers()
+{
+    LockedLayers& layers = getSystemLockedLayers();
     layers.clear();
 }
 

--- a/lib/mayaUsd/utils/layerLocking.h
+++ b/lib/mayaUsd/utils/layerLocking.h
@@ -75,12 +75,6 @@ namespace MAYAUSD_NS_DEF {
  * attributes.
  */
 MAYAUSD_CORE_PUBLIC
-// MStatus
-// copyLayerLockingToAttribute(const PXR_NS::UsdStage& stage, MayaUsdProxyShapeBase& proxyShape);
-
-// MStatus
-// copyLayerLockingToAttribute(MayaUsdProxyShapeBase& proxyShape);
-
 MStatus copyLayerLockingToAttribute(MayaUsdProxyShapeBase* proxyShape);
 
 /*! Map the original layer name when the scene was saved to the current layer name.
@@ -113,8 +107,13 @@ void lockLayer(
     bool                          updateProxyShapeAttr = true);
 
 using LockedLayers = std::set<PXR_NS::SdfLayerRefPtr>;
+
+/*! \brief gets the list of locked layers
+ */
 MAYAUSD_CORE_PUBLIC LockedLayers& getLockedLayers();
 
+/*! \brief gets the list of system-locked layers
+ */
 MAYAUSD_CORE_PUBLIC LockedLayers& getSystemLockedLayers();
 
 /*! \brief Adds a layer to the lock list

--- a/lib/mayaUsd/utils/layerLocking.h
+++ b/lib/mayaUsd/utils/layerLocking.h
@@ -58,11 +58,43 @@ namespace MAYAUSD_NS_DEF {
 // to avoid receiving false positives for PermissionToSave and PermissionToEdit.
 //
 // We therefore save the lock state of layers.
-// OpenUSD forgets everything about layer permissions to save or edit as there are only applicable
-// to sessions
 //
-// So we need to hold on to locked layers. We do this in a private global list
-// of locked layers. That list gets cleared when a new Maya scene is created.
+// Since layer permissions are only applicable to sessions, we need to hold on to locked layers.
+// We do this in a private global list of locked layers. That list gets cleared when a new Maya
+// scene is created.
+//
+// When a layer's lock status changes by the user, we store the locked state in a proxy shape
+// attribute so that it can be retrieved when the Maya scene is loaded again.
+//
+// Note that only layers with the lock type LayerLock_Locked persist in the Maya scene file.
+// System locks are only script driven and temporary for the duration of the session and will
+// not survive from session to session.
+
+/*! \brief copy the stage layers locking in the corresponding attribute of the proxy shape.
+ * Note that only the Locked state persists as an attribute. We do not track SystemLocked in
+ * attributes.
+ */
+MAYAUSD_CORE_PUBLIC
+// MStatus
+// copyLayerLockingToAttribute(const PXR_NS::UsdStage& stage, MayaUsdProxyShapeBase& proxyShape);
+
+// MStatus
+// copyLayerLockingToAttribute(MayaUsdProxyShapeBase& proxyShape);
+
+MStatus copyLayerLockingToAttribute(MayaUsdProxyShapeBase* proxyShape);
+
+/*! Map the original layer name when the scene was saved to the current layer name.
+    Layer renaming happens when anonymous layers are saved within the Maya scene file.
+*/
+using LayerNameMap = std::map<std::string, std::string>;
+
+/*! \brief set the stage layers locking from data in the corresponding attribute of the proxy shape.
+ */
+MAYAUSD_CORE_PUBLIC
+MStatus copyLayerLockingFromAttribute(
+    const MayaUsdProxyShapeBase& proxyShape,
+    const LayerNameMap&          nameMap,
+    PXR_NS::UsdStage&            stage);
 
 enum LayerLockType
 {
@@ -70,6 +102,40 @@ enum LayerLockType
     LayerLock_Locked,
     LayerLock_SystemLocked
 };
+
+/*! \brief Sets the lock status on a layer
+ */
+MAYAUSD_CORE_PUBLIC
+void lockLayer(
+    std::string                   proxyShapePath,
+    const PXR_NS::SdfLayerRefPtr& layer,
+    LayerLockType                 locktype,
+    bool                          updateProxyShapeAttr = true);
+
+using LockedLayers = std::set<PXR_NS::SdfLayerRefPtr>;
+MAYAUSD_CORE_PUBLIC LockedLayers& getLockedLayers();
+
+MAYAUSD_CORE_PUBLIC LockedLayers& getSystemLockedLayers();
+
+/*! \brief Adds a layer to the lock list
+ */
+MAYAUSD_CORE_PUBLIC
+void addLockedLayer(const PXR_NS::SdfLayerRefPtr& layer);
+
+/*! \brief Removes a layer from the lock list
+ */
+MAYAUSD_CORE_PUBLIC
+void removeLockedLayer(const PXR_NS::SdfLayerRefPtr& layer);
+
+/*! \brief Checks if a layer is in the lock list.
+ */
+MAYAUSD_CORE_PUBLIC
+bool isLayerLocked(const PXR_NS::SdfLayerRefPtr& layer);
+
+/*! \brief Clears the lock list
+ */
+MAYAUSD_CORE_PUBLIC
+void forgetLockedLayers();
 
 /*! \brief Adds a layer to the system lock list
  */

--- a/test/lib/testMayaUsdLayerEditorCommands.py
+++ b/test/lib/testMayaUsdLayerEditorCommands.py
@@ -561,7 +561,23 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
         self.assertFalse(subLayer.permissionToSave)
         cmds.undo()
         self.assertTrue(subLayer.permissionToEdit)
-        
+   
+    def testLayerLockWritePermission(self):
+        # FileBacked Layer Write Permission
+        # 1- Loading the test scene
+        rootLayerPath = testUtils.getTestScene("layerLocking", "layerLocking.usda")
+        stage = Usd.Stage.Open(rootLayerPath)
+        topLayer = stage.GetRootLayer();
+        layerLockingShapes = cmds.ls(type="mayaUsdProxyShapeBase", long=True)
+        proxyShapePath = layerLockingShapes[0]
+        # 2- Setting a system lock on a layer loaded from a file
+        cmds.mayaUsdLayerEditor(topLayer.identifier, edit=True, lockLayer=(2, proxyShapePath))
+        self.assertFalse(topLayer.permissionToEdit)
+        self.assertFalse(topLayer.permissionToSave)
+        # 3- Refreshing the system lock should remove the lock if the file is writable
+        cmds.mayaUsdLayerEditor(topLayer.identifier, edit=True, refreshSystemLock=(proxyShapePath, 1))
+        self.assertTrue(topLayer.permissionToEdit)
+        self.assertTrue(topLayer.permissionToSave)
         
     def testMuteLayer(self):
         """ test 'mayaUsdLayerEditor' command 'muteLayer' paramater """

--- a/test/testSamples/layerLocking/layerLocking.usda
+++ b/test/testSamples/layerLocking/layerLocking.usda
@@ -1,0 +1,6 @@
+#usda 1.0
+
+def Cube "Cube1"
+{
+}
+


### PR DESCRIPTION
- If a layer has a LayerLock_Locked status, the status is saved into a proxy shape attribute named "lockedLayers" (brief name: lockla) and is stored in the maya file.
- Moved the core of locking mechanism into layerLocking .h and .cpp