### PR TITLE
EMSUSD-1087 - Fixes the issue where the lock state isn't applied from Maya file when the layer is both locked and muted.

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -1133,9 +1133,11 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
 
         primPath = finalUsdStage->GetPseudoRoot().GetPath();
 
-        copyLayerMutingFromAttribute(*this, layerNameMap, *finalUsdStage);
-
+        // EMSUSD-1087 Applying the lock permissions to layers should be done before the layer
+        // muting step as the layer identifiers change after muting
         copyLayerLockingFromAttribute(*this, layerNameMap, *finalUsdStage);
+
+        copyLayerMutingFromAttribute(*this, layerNameMap, *finalUsdStage);
 
         if (!_targetLayer)
             _targetLayer = getTargetLayerFromAttribute(*this, *finalUsdStage);

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -1134,7 +1134,7 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
         primPath = finalUsdStage->GetPseudoRoot().GetPath();
 
         // EMSUSD-1087 Applying the lock permissions to layers should be done before the layer
-        // muting step as the layer identifiers change after muting
+        // muting
         copyLayerLockingFromAttribute(*this, layerNameMap, *finalUsdStage);
 
         copyLayerMutingFromAttribute(*this, layerNameMap, *finalUsdStage);


### PR DESCRIPTION
Fixes the issue where the lock state isn't applied from Maya file when the layer is both locked and muted.