### PR TITLE
EMSUSD-1071 - Remember unknown color spaces

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/colorManagementPreferences.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/colorManagementPreferences.cpp
@@ -35,6 +35,16 @@ const MString& ColorManagementPreferences::RenderingSpaceName()
 
 const MString& ColorManagementPreferences::sRGBName() { return Get()._sRGBName; }
 
+bool ColorManagementPreferences::isUnknownColorSpace(const std::string& colorSpace)
+{
+    return Get()._unknownColorSpaces.count(colorSpace) > 0;
+}
+
+void ColorManagementPreferences::addUnknownColorSpace(const std::string& colorSpace)
+{
+    InternalGet()._unknownColorSpaces.insert(colorSpace);
+}
+
 std::string ColorManagementPreferences::getFileRule(const std::string& path)
 {
     MString colorRuleCmd;
@@ -136,6 +146,7 @@ void ColorManagementPreferences::Refresh()
             break;
         }
     }
+    _unknownColorSpaces.clear();
 }
 
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/render/vp2RenderDelegate/colorManagementPreferences.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/colorManagementPreferences.h
@@ -21,6 +21,7 @@
 #include <maya/MMessage.h>
 #include <maya/MString.h>
 
+#include <set>
 #include <vector>
 
 namespace MAYAUSD_NS_DEF {
@@ -50,6 +51,12 @@ public:
      */
     static const MString& sRGBName();
 
+    /*! \brief Prevent error spamming in the script editor by remembering failed requests
+               for a color management fragment.
+     */
+    static bool isUnknownColorSpace(const std::string& colorSpace);
+    static void addUnknownColorSpace(const std::string& colorSpace);
+
     /*! \brief  Returns the OCIO color space name according to config file rules.
 
         \param path The path of the file to be color managed.
@@ -73,6 +80,7 @@ private:
     bool                     _active = false;
     MString                  _renderingSpaceName;
     MString                  _sRGBName;
+    std::set<std::string>    _unknownColorSpaces;
     std::vector<MCallbackId> _mayaColorManagementCallbackIds;
 
     void Refresh();

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -1141,9 +1141,16 @@ void _AddColorManagementFragments(HdMaterialNetwork& net)
         }
 
         MString fragName, inputName, outputName;
-        MStatus status = fragmentManager->getColorManagementFragmentInfo(
-            colorSpace, fragName, inputName, outputName);
-        if (!status) {
+        if (!MayaUsd::ColorManagementPreferences::isUnknownColorSpace(colorSpace.asChar())) {
+            MStatus status = fragmentManager->getColorManagementFragmentInfo(
+                colorSpace, fragName, inputName, outputName);
+            if (!status) {
+                // Maya does not know about this color space. Remember that.
+                MayaUsd::ColorManagementPreferences::addUnknownColorSpace(colorSpace.asChar());
+                continue;
+            }
+        } else {
+            // Don't know how to handle that color space.
             continue;
         }
 
@@ -2700,14 +2707,19 @@ TfToken _RequiresColorManagement(
     }
 
     MString fragName, fragInput, fragOutput;
-    if (fragmentManager->getColorManagementFragmentInfo(
-            sourceColorSpace.c_str(), fragName, fragInput, fragOutput)) {
-        std::string untypedNodeDefId
-            = MaterialXMaya::OgsFragment::registerOCIOFragment(fragName.asChar());
-        if (!untypedNodeDefId.empty()) {
-            cmInputName = TfToken(fragInput.asChar());
-            cmOutputName = TfToken(fragOutput.asChar());
-            return TfToken((untypedNodeDefId + colorOutput->getType()));
+    if (!MayaUsd::ColorManagementPreferences::isUnknownColorSpace(sourceColorSpace)) {
+        if (fragmentManager->getColorManagementFragmentInfo(
+                sourceColorSpace.c_str(), fragName, fragInput, fragOutput)) {
+            std::string untypedNodeDefId
+                = MaterialXMaya::OgsFragment::registerOCIOFragment(fragName.asChar());
+            if (!untypedNodeDefId.empty()) {
+                cmInputName = TfToken(fragInput.asChar());
+                cmOutputName = TfToken(fragOutput.asChar());
+                return TfToken((untypedNodeDefId + colorOutput->getType()));
+            }
+        } else {
+            // Maya does not know about this color space. Remember that.
+            MayaUsd::ColorManagementPreferences::addUnknownColorSpace(sourceColorSpace);
         }
     }
 #else


### PR DESCRIPTION
This prevents spamming the error log with evey single image node using a unsupported color space.