### PR TITLE
Fix conflict in shaders with MaterialX 1.38.9

### DIFF
--- a/lib/mayaUsd/render/MaterialXGenOgsXml/libraries/1.38.3/mx_lighting_maya_v3.glsl
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/libraries/1.38.3/mx_lighting_maya_v3.glsl
@@ -8,7 +8,7 @@
 
 // https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch20.html
 // Section 20.4 Equation 13
-float mx_latlong_compute_lod(vec3 dir, float pdf, float maxMipLevel, int envSamples)
+float mx_latlong_compute_lod_adsk(vec3 dir, float pdf, float maxMipLevel, int envSamples)
 {
     const float MIP_LEVEL_OFFSET = 1.5;
     float effectiveMaxMipLevel = maxMipLevel - MIP_LEVEL_OFFSET;
@@ -54,7 +54,7 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, int distrib
         // Sample the environment light from the given direction.
         vec3 Lw = tangentToWorld * L;
         float pdf = mx_ggx_PDF(H, LdotH, roughness);
-        float lod = mx_latlong_compute_lod(Lw, pdf, float(mayaGetSpecularEnvironmentNumLOD() - 1), MX_NUM_FIS_SAMPLES);
+        float lod = mx_latlong_compute_lod_adsk(Lw, pdf, float(mayaGetSpecularEnvironmentNumLOD() - 1), MX_NUM_FIS_SAMPLES);
         vec3 sampleColor = mayaSampleSpecularEnvironmentAtLOD(Lw, lod);
 
         // Compute the Fresnel term.

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/libraries/1.38.7/mx_lighting_maya_v3.glsl
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/libraries/1.38.7/mx_lighting_maya_v3.glsl
@@ -7,7 +7,7 @@
 
 // https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch20.html
 // Section 20.4 Equation 13
-float mx_latlong_compute_lod(vec3 dir, float pdf, float maxMipLevel, int envSamples)
+float mx_latlong_compute_lod_adsk(vec3 dir, float pdf, float maxMipLevel, int envSamples)
 {
     const float MIP_LEVEL_OFFSET = 1.5;
     float effectiveMaxMipLevel = maxMipLevel - MIP_LEVEL_OFFSET;
@@ -53,7 +53,7 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distributio
         // Sample the environment light from the given direction.
         vec3 Lw = tangentToWorld * L;
         float pdf = mx_ggx_PDF(H, LdotH, alpha);
-        float lod = mx_latlong_compute_lod(Lw, pdf, float(mayaGetSpecularEnvironmentNumLOD() - 1), MX_NUM_FIS_SAMPLES);
+        float lod = mx_latlong_compute_lod_adsk(Lw, pdf, float(mayaGetSpecularEnvironmentNumLOD() - 1), MX_NUM_FIS_SAMPLES);
         vec3 sampleColor = mayaSampleSpecularEnvironmentAtLOD(Lw, lod);
 
         // Compute the Fresnel term.

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/libraries/mx_lighting_maya_v3.glsl
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/libraries/mx_lighting_maya_v3.glsl
@@ -7,7 +7,7 @@
 
 // https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch20.html
 // Section 20.4 Equation 13
-float mx_latlong_compute_lod(vec3 dir, float pdf, float maxMipLevel, int envSamples)
+float mx_latlong_compute_lod_adsk(vec3 dir, float pdf, float maxMipLevel, int envSamples)
 {
     const float MIP_LEVEL_OFFSET = 1.5;
     float effectiveMaxMipLevel = maxMipLevel - MIP_LEVEL_OFFSET;
@@ -52,7 +52,7 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distributio
         // Sample the environment light from the given direction.
         vec3 Lw = tangentToWorld * L;
         float pdf = mx_ggx_NDF(H, alpha) * G1V / (4.0 * NdotV);
-        float lod = mx_latlong_compute_lod(Lw, pdf, float(mayaGetSpecularEnvironmentNumLOD() - 1), MX_NUM_FIS_SAMPLES);
+        float lod = mx_latlong_compute_lod_adsk(Lw, pdf, float(mayaGetSpecularEnvironmentNumLOD() - 1), MX_NUM_FIS_SAMPLES);
         vec3 sampleColor = mayaSampleSpecularEnvironmentAtLOD(Lw, lod);
 
         // Compute the Fresnel term.


### PR DESCRIPTION
MaterialX 1.38.9 has incorporated this commit (https://github.com/AcademySoftwareFoundation/MaterialX/commit/eae062a038bcd8f8172b1725e93e35641dc73f61) that causes a conflict with a similar change that is inside Maya USD resulting in Pixel shader compilation errors;

```
ERROR: 0:1092: Function 'mx_latlong_compute_lod' redefines an existing function
```

This PR resolves that by renaming the Maya one to a non-conflicting name. This seemed easiest rather than trying to detect the MaterialX version and handling it accordingly.

Without this PR, Maya fails to generate any MaterialX based shaders.