### PR TITLE
EMSUSD-591: Remove lingering invalid prims after adding prim under prim that is deactivated

### DIFF
--- a/lib/usdUfe/ufe/UsdUndoAddNewPrimCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoAddNewPrimCommand.cpp
@@ -98,7 +98,7 @@ void UsdUndoAddNewPrimCommand::execute()
             TF_RUNTIME_ERROR("%s", errMsg.c_str());
         } else {
             UsdUfe::InAddOrDeleteOperation ad;
-            auto prim = _stage->DefinePrim(_primPath, _primToken);
+            auto                           prim = _stage->DefinePrim(_primPath, _primToken);
             if (!prim.IsValid()) {
                 TF_RUNTIME_ERROR("Failed to create new prim type: %s", _primToken.GetText());
                 _stage->RemovePrim(_primPath);

--- a/lib/usdUfe/ufe/UsdUndoAddNewPrimCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoAddNewPrimCommand.cpp
@@ -98,9 +98,11 @@ void UsdUndoAddNewPrimCommand::execute()
             TF_RUNTIME_ERROR("%s", errMsg.c_str());
         } else {
             UsdUfe::InAddOrDeleteOperation ad;
-            auto                           prim = _stage->DefinePrim(_primPath, _primToken);
-            if (!prim.IsValid())
+            auto prim = _stage->DefinePrim(_primPath, _primToken);
+            if (!prim.IsValid()) {
                 TF_RUNTIME_ERROR("Failed to create new prim type: %s", _primToken.GetText());
+                _stage->RemovePrim(_primPath);
+            }
         }
     }
 }


### PR DESCRIPTION
When the user tries to add a prim under a prim that is deactivated, they will see an error in the console such as:
```
Failed to create new prim type: Capsule
ValueError: Cannot append null item pointer to selection.
```
However, upon reactivating the prim that was deactivated, they will see that the prim was in fact added. This PR addresses this problem by removing the invalid prim that gets created in such a situation.