### PR TITLE
EMSUSD-1073 - Update for USD v24.03

### DIFF
--- a/lib/usd/utils/MergePrims.cpp
+++ b/lib/usd/utils/MergePrims.cpp
@@ -54,7 +54,7 @@ struct MergeLocation
 {
     const SdfLayerHandle& layer;
     const SdfPath&        path;
-    const TfToken&        field;
+    TfToken               field;
     bool                  fieldExists;
 };
 


### PR DESCRIPTION
When updating to USD v24.03 the test `testMergeToUsd.py` would segfault and crash. I found its because of a `const TkToken&` being stored in a struct which is then passed around. Not sure why with 24.03 this changed, but my suspicion was that token was being released elsewhere and this the ref in the struct not valid. There is no reason to store a ref in the struct. TfTokens are lightweight objects which are ref counted.