### PR TITLE
MAYA-133210: Dope Sheet : Error when right-click on channel set if USD plugin installed

### DIFF
--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -586,7 +586,9 @@ proc string getPulledUsdObject(string $dagObject) {
             // If there is no selection, try to fetch the item under the mouse in the outliner editor
             if (size($dagObject) == 0 || size(`ls -set $dagObject`) > 0) {
                 string $outliner = `getPanel -underPointer`;
-                $dagObject = `outlinerEditor -query -feedbackItemName $outliner`;
+                if (`outlinerEditor -exists $outliner`) {
+                    $dagObject = `outlinerEditor -query -feedbackItemName $outliner`;
+                }
             }
         }
         if (size(`ls -dagObjects $dagObject`) > 0) {


### PR DESCRIPTION
#### MAYA-133210: Dope Sheet : Error when right-click on channel set if USD plugin is installed
* When over the Dopesheet the panel type returned is not compatible with OutlinerEditor command.