### PR TITLE
LOOKDEVX-2358 - Fix image file attribute detection

### DIFF
--- a/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
@@ -963,6 +963,10 @@ class AETemplate(object):
         kFilenameAttr = ufe.Attribute.kFilename if hasattr(ufe.Attribute, "kFilename") else 'Filename'
         if self.attrS.attributeType(attrName) != kFilenameAttr:
             return False
+        shader = UsdShade.Shader(self.prim)
+        if shader and attrName.startswith("inputs:"):
+            # Shader attribute. The actual USD Attribute might not exist yet.
+            return True
         attr = self.prim.GetAttribute(attrName)
         if not attr:
             return False

--- a/lib/mayaUsdAPI/utils.cpp
+++ b/lib/mayaUsdAPI/utils.cpp
@@ -128,4 +128,14 @@ bool requireUsdPathsRelativeToEditTargetLayer()
     return PXR_NS::UsdMayaUtilFileSystem::requireUsdPathsRelativeToEditTargetLayer();
 }
 
+std::string handleAssetPathThatMaybeRelativeToLayer(
+    std::string                   fileName,
+    const std::string&            attrName,
+    const PXR_NS::SdfLayerHandle& layer,
+    const std::string&            optionVarName)
+{
+    return PXR_NS::UsdMayaUtilFileSystem::handleAssetPathThatMaybeRelativeToLayer(
+        fileName, attrName, layer, optionVarName);
+}
+
 } // End of namespace MAYAUSDAPI_NS_DEF

--- a/lib/mayaUsdAPI/utils.h
+++ b/lib/mayaUsdAPI/utils.h
@@ -111,6 +111,13 @@ makePathRelativeTo(const std::string& fileName, const std::string& relativeToDir
 MAYAUSD_API_PUBLIC
 bool requireUsdPathsRelativeToEditTargetLayer();
 
+MAYAUSD_API_PUBLIC
+std::string handleAssetPathThatMaybeRelativeToLayer(
+    std::string                   fileName,
+    const std::string&            attrName,
+    const PXR_NS::SdfLayerHandle& layer,
+    const std::string&            optionVarName);
+
 } // namespace MAYAUSDAPI_NS_DEF
 
 #endif // MAYAUSDAPI_UTILS_H


### PR DESCRIPTION
An image UsdShade node that never had its filename attribute set would fail the isImageAttribute test. Allow the image code since a filename in a shader is always an image.