### PR TITLE
Support EditRouter in delete command

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoDeleteCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDeleteCommand.cpp
@@ -17,8 +17,10 @@
 
 #include "private/UfeNotifGuard.h"
 
+#include <usdUfe/base/tokens.h>
 #include <usdUfe/ufe/Utils.h>
 #include <usdUfe/undo/UsdUndoBlock.h>
+#include <usdUfe/utils/editRouter.h>
 #include <usdUfe/utils/layers.h>
 #include <usdUfe/utils/usdUtils.h>
 
@@ -60,20 +62,38 @@ void UsdUndoDeleteCommand::execute()
     const auto& stage = _prim.GetStage();
     auto        targetPrimSpec = stage->GetEditTarget().GetPrimSpecForScenePath(_prim.GetPath());
 
-    if (UsdUfe::applyCommandRestrictionNoThrow(_prim, "delete")) {
+    PXR_NS::UsdEditTarget routingEditTarget
+        = getEditRouterEditTarget(UsdUfe::EditRoutingTokens->RouteDelete, _prim);
+
+    if (!UsdUfe::applyCommandRestrictionNoThrow(_prim, "delete", true))
+        return;
+
 #ifdef UFE_V4_FEATURES_AVAILABLE
-        UsdAttributes::removeAttributesConnections(_prim);
+    UsdAttributes::removeAttributesConnections(_prim);
 #endif
-        // Let removeAttributesConnections be run first as it will also cleanup
-        // attributes that were authored only to be the destination of a connection.
-        if (!UsdUfe::cleanReferencedPath(_prim)) {
-            const std::string error = TfStringPrintf(
-                "Failed to cleanup references to prim \"%s\".", _prim.GetPath().GetText());
+    // Let removeAttributesConnections be run first as it will also cleanup
+    // attributes that were authored only to be the destination of a connection.
+    if (!UsdUfe::cleanReferencedPath(_prim)) {
+        const std::string error = TfStringPrintf(
+            "Failed to cleanup references to prim \"%s\".", _prim.GetPath().GetText());
+        TF_WARN("%s", error.c_str());
+        throw std::runtime_error(error);
+    }
+
+    if (!routingEditTarget.IsNull()) {
+        PXR_NS::UsdEditContext ctx(stage, routingEditTarget);
+        if (!stage->RemovePrim(_prim.GetPath())) {
+            const std::string error
+                = TfStringPrintf("Failed to delete prim \"%s\".", _prim.GetPath().GetText());
             TF_WARN("%s", error.c_str());
             throw std::runtime_error(error);
         }
+    } else {
         PrimSpecFunc deleteFunc
             = [stage](const UsdPrim& prim, const SdfPrimSpecHandle& primSpec) -> void {
+            if (!primSpec)
+                return;
+
             PXR_NS::UsdEditContext ctx(stage, primSpec->GetLayer());
             if (!stage->RemovePrim(prim.GetPath())) {
                 const std::string error

--- a/lib/mayaUsd/ufe/UsdUndoDeleteCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDeleteCommand.cpp
@@ -65,9 +65,6 @@ void UsdUndoDeleteCommand::execute()
     PXR_NS::UsdEditTarget routingEditTarget
         = getEditRouterEditTarget(UsdUfe::EditRoutingTokens->RouteDelete, _prim);
 
-    if (!UsdUfe::applyCommandRestrictionNoThrow(_prim, "delete", true))
-        return;
-
 #ifdef UFE_V4_FEATURES_AVAILABLE
     UsdAttributes::removeAttributesConnections(_prim);
 #endif
@@ -82,6 +79,10 @@ void UsdUndoDeleteCommand::execute()
 
     if (!routingEditTarget.IsNull()) {
         PXR_NS::UsdEditContext ctx(stage, routingEditTarget);
+
+        if (!UsdUfe::applyCommandRestrictionNoThrow(_prim, "delete", true))
+            return;
+
         if (!stage->RemovePrim(_prim.GetPath())) {
             const std::string error
                 = TfStringPrintf("Failed to delete prim \"%s\".", _prim.GetPath().GetText());
@@ -89,6 +90,9 @@ void UsdUndoDeleteCommand::execute()
             throw std::runtime_error(error);
         }
     } else {
+        if (!UsdUfe::applyCommandRestrictionNoThrow(_prim, "delete"))
+            return;
+
         PrimSpecFunc deleteFunc
             = [stage](const UsdPrim& prim, const SdfPrimSpecHandle& primSpec) -> void {
             if (!primSpec)

--- a/lib/usdUfe/base/tokens.h
+++ b/lib/usdUfe/base/tokens.h
@@ -38,6 +38,7 @@ namespace USDUFE_NS_DEF {
     ((Operation, "operation"))                          \
     /* Stage received in the context of some router  */ \
     ((Stage, "stage"))                                  \
+    ((EditTarget, "editTarget"))                        \
                                                         \
     /* Routing operations                            */ \
                                                         \
@@ -45,6 +46,7 @@ namespace USDUFE_NS_DEF {
     ((RouteDuplicate, "duplicate"))                     \
     ((RouteVisibility, "visibility"))                   \
     ((RouteAttribute, "attribute"))                     \
+    ((RouteDelete, "delete"))                           \
                                                         \
 // clang-format on
 

--- a/lib/usdUfe/python/wrapEditRouter.cpp
+++ b/lib/usdUfe/python/wrapEditRouter.cpp
@@ -78,6 +78,8 @@ public:
             throw;
         }
 
+        // Extract keys and values individually so that we can extract
+        // PXR_NS::UsdEditTarget correctly from PXR_NS::TfPyObjWrapper.
         const boost::python::object items = dictObject.items();
         for (boost::python::ssize_t i = 0; i < len(items); ++i) {
 

--- a/lib/usdUfe/ufe/Utils.cpp
+++ b/lib/usdUfe/ufe/Utils.cpp
@@ -401,6 +401,9 @@ bool allowedInStrongerLayer(
         : stage->GetRootLayer();
 
     auto strongerLayer = getStrongerLayer(searchRoot, targetLayer, topLayer);
+
+    // This happens when the edit target layer is within the reference.
+    // In this cae, we return true to allow it to be edited.
     if (!strongerLayer) {
         return true;
     }

--- a/lib/usdUfe/ufe/Utils.cpp
+++ b/lib/usdUfe/ufe/Utils.cpp
@@ -400,7 +400,12 @@ bool allowedInStrongerLayer(
         ? stage->GetSessionLayer()
         : stage->GetRootLayer();
 
-    return getStrongerLayer(searchRoot, targetLayer, topLayer) == targetLayer;
+    auto strongerLayer = getStrongerLayer(searchRoot, targetLayer, topLayer);
+    if (!strongerLayer) {
+        return true;
+    }
+
+    return strongerLayer == targetLayer;
 }
 
 } // namespace

--- a/lib/usdUfe/utils/editRouter.cpp
+++ b/lib/usdUfe/utils/editRouter.cpp
@@ -213,4 +213,30 @@ getAttrEditRouterLayer(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attrN
     }
 }
 
+PXR_NS::UsdEditTarget
+getEditRouterEditTarget(const PXR_NS::TfToken& operation, const PXR_NS::UsdPrim& prim)
+{
+    const auto dstEditRouter = getEditRouter(operation);
+    if (!dstEditRouter) {
+        return PXR_NS::UsdEditTarget();
+    }
+
+    PXR_NS::VtDictionary context;
+    PXR_NS::VtDictionary routingData;
+    context[EditRoutingTokens->Prim] = PXR_NS::VtValue(prim);
+    context[EditRoutingTokens->Operation] = operation;
+    (*dstEditRouter)(context, routingData);
+
+    const auto found = routingData.find(EditRoutingTokens->EditTarget);
+
+    if (found != routingData.end()) {
+        const auto& value = found->second;
+        if (value.IsHolding<PXR_NS::UsdEditTarget>()) {
+            const auto editTarget = value.Get<PXR_NS::UsdEditTarget>();
+            return editTarget;
+        }
+    }
+    return PXR_NS::UsdEditTarget();
+}
+
 } // namespace USDUFE_NS_DEF

--- a/lib/usdUfe/utils/editRouter.h
+++ b/lib/usdUfe/utils/editRouter.h
@@ -86,6 +86,14 @@ USDUFE_PUBLIC
 PXR_NS::SdfLayerHandle
 getAttrEditRouterLayer(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attrName);
 
+// Utility function that returns a UsdEditTarget for the argument operation.
+// If no edit router exists for that operation, a null UsdEditTarget is returned.
+// The edit router is given the prim in the context with key "prim", and is
+// expected to return the UsdEditTarget which can be used to set edit target.
+USDUFE_PUBLIC
+PXR_NS::UsdEditTarget
+getEditRouterEditTarget(const PXR_NS::TfToken& operation, const PXR_NS::UsdPrim& prim);
+
 // Register an edit router for the argument operation.
 USDUFE_PUBLIC
 void registerEditRouter(const PXR_NS::TfToken& operation, const EditRouter::Ptr& editRouter);


### PR DESCRIPTION
Hi, in our pipeline, we have a tool in Maya to delete prims from a specified layer using USD's native API, and we are using the `delete` key as the hotkey to run the tool. In order the make the prim deletion behaviour consistent between our tool and in Maya viewport (so that users could hit the `delete` key either with the tool or viewport in focus and get the same result), we'd like to map the `delete` key in Maya to our prim deletion tool, but we learned that the `delete` key executed in viewport cannot be remapped and it has been reserved to Maya's `cmds.delete()` command which has its own logic to delete the selected prims from the layers retrieved based on its own logic. `cmds.delete()` calls `UsdUndoDeleteCommand` internally and it doesn't support `EditRouter` to get an edit target layer from users. 

We made these changes in our pipeline to be able to send an `UsdEditTarget` to `UsdUndoDeleteCommand`  via `EditRouter` so that a prim can be deleted in a layer we specify. By sending a `UsdEditTarget` object instead of a `SdfLayer`, clients have full control on how to construct a `UsdEditTarget`;  if it's constructed with a pcp node, it can delete prims defined in non-local layers, which is one of the main intentions of this update. 

The changes are:

- add `getEditRouterEditTarget` function in `EditRouter` to retrieve `UsdEditTarget`. 
- turn on `allowStronger` in `UsdUfe::applyCommandRestrictionNoThrow` to pass the check.
- add new `EditRouter` tokens for registering new `EditRouter` callback for deletion and retrieving `UsdEditTarget` from callbacks.
- update `wrapEditRouter` to be able to retrieve `UsdEditTarget` object from Python. 


