### PR TITLE
EMSUSD-1056 fix crash due to invalid shader

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -982,6 +982,12 @@ void HdVP2Mesh::Sync(
 
             for (size_t i = 0; i < numFaceVertexIndices; i++) {
                 const int sceneFaceVtxId = faceVertexIndices[i];
+
+                // Scene index is actually greater than anticipated, increase the buffer size.
+                if (size_t(sceneFaceVtxId) >= _meshSharedData->_sceneToRenderingFaceVtxIds.size()) {
+                    _meshSharedData->_sceneToRenderingFaceVtxIds.resize(sceneFaceVtxId + 1, -1);
+                }
+
                 _meshSharedData->_sceneToRenderingFaceVtxIds[sceneFaceVtxId]
                     = i; // could check if the existing value is -1, but it doesn't matter.
                          // we just need to map to a vertex in the position buffer that has

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -890,6 +890,12 @@ void ProxyRenderDelegate::_UpdateSceneDelegate()
     }
 }
 
+void ProxyRenderDelegate::_PopulateCleanup()
+{
+    // Get rid of shaders no longer in use.
+    HdVP2ShaderUniquePtr::cleanupDeadShaders();
+}
+
 InstancePrototypePath ProxyRenderDelegate::GetPathInPrototype(const SdfPath& id)
 {
     HdInstancerContext instancerContext;
@@ -1264,6 +1270,7 @@ void ProxyRenderDelegate::update(MSubSceneContainer& container, const MFrameCont
     if (_Populate()) {
         _UpdateSceneDelegate();
         _Execute(frameContext);
+        _PopulateCleanup();
     }
 
     _currentFrameContext = nullptr;

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -271,6 +271,7 @@ private:
     bool _Populate();
     void _UpdateSceneDelegate();
     void _Execute(const MHWRender::MFrameContext& frameContext);
+    void _PopulateCleanup();
 
     typedef std::pair<MColor, std::atomic<uint64_t>>  MColorCache;
     typedef std::pair<GfVec3f, std::atomic<uint64_t>> GfVec3fCache;

--- a/lib/mayaUsd/render/vp2RenderDelegate/shader.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/shader.cpp
@@ -17,18 +17,149 @@
 
 #include <pxr/base/tf/diagnostic.h>
 
+#include <maya/MGlobal.h>
+
+#include <mutex>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
-/*! \brief  Releases the reference to the shader owned by a smart pointer.
- */
-void HdVP2ShaderDeleter::operator()(MHWRender::MShaderInstance* shader)
+namespace {
+using DeadShaders = std::set<MHWRender::MShaderInstance*>;
+std::mutex deadShaderMutex;
+
+DeadShaders& getDeadShaders()
+{
+    static DeadShaders dead;
+    return dead;
+}
+
+void addDeadShader(MHWRender::MShaderInstance* shader)
+{
+    if (!shader)
+        return;
+
+    std::lock_guard<std::mutex> mutexGuard(deadShaderMutex);
+    getDeadShaders().insert(shader);
+}
+
+} // namespace
+
+void HdVP2ShaderUniquePtr::cleanupDeadShaders()
 {
     MRenderer* const renderer = MRenderer::theRenderer();
+    if (!renderer)
+        return;
 
-    const MShaderManager* const shaderMgr = renderer ? renderer->getShaderManager() : nullptr;
-    if (TF_VERIFY(shaderMgr)) {
-        shaderMgr->releaseShader(shader);
+    const MShaderManager* const shaderMgr = renderer->getShaderManager();
+    if (!shaderMgr)
+        return;
+
+    std::lock_guard<std::mutex> mutexGuard(deadShaderMutex);
+
+    for (MHWRender::MShaderInstance* shader : getDeadShaders()) {
+        if (shader)
+            shaderMgr->releaseShader(shader);
     }
+
+    getDeadShaders().clear();
+}
+
+HdVP2ShaderUniquePtr::HdVP2ShaderUniquePtr() { }
+
+HdVP2ShaderUniquePtr::HdVP2ShaderUniquePtr(MHWRender::MShaderInstance* shader) { reset(shader); }
+
+HdVP2ShaderUniquePtr::HdVP2ShaderUniquePtr(const HdVP2ShaderUniquePtr& other)
+{
+    if (!other._data)
+        return;
+
+    _data = other._data;
+    _data->_count.fetch_add(1);
+}
+
+HdVP2ShaderUniquePtr::HdVP2ShaderUniquePtr(HdVP2ShaderUniquePtr&& other)
+{
+    _data = other._data;
+    other._data = nullptr;
+}
+
+HdVP2ShaderUniquePtr::~HdVP2ShaderUniquePtr() { clear(); }
+
+HdVP2ShaderUniquePtr& HdVP2ShaderUniquePtr::operator=(const HdVP2ShaderUniquePtr& other)
+{
+    if (other._data == _data)
+        return *this;
+
+    if (_data && other._data && _data->_shader == other._data->_shader)
+        return *this;
+
+    clear();
+
+    if (!other._data)
+        return *this;
+
+    _data = other._data;
+    _data->_count.fetch_add(1);
+
+    return *this;
+}
+
+HdVP2ShaderUniquePtr& HdVP2ShaderUniquePtr::operator=(HdVP2ShaderUniquePtr&& other)
+{
+    if (other._data == _data)
+        return *this;
+
+    _data = other._data;
+    other._data = nullptr;
+
+    return *this;
+}
+
+MHWRender::MShaderInstance* HdVP2ShaderUniquePtr::operator->() const
+{
+    return _data ? _data->_shader : nullptr;
+}
+
+MHWRender::MShaderInstance* HdVP2ShaderUniquePtr::get() const
+{
+    return _data ? _data->_shader : nullptr;
+}
+
+HdVP2ShaderUniquePtr::operator bool() const
+{
+    return _data != nullptr && _data->_shader != nullptr;
+}
+
+void HdVP2ShaderUniquePtr::reset(MHWRender::MShaderInstance* shader)
+{
+    if (_data && _data->_shader == shader)
+        return;
+
+    clear();
+
+    if (!shader)
+        return;
+
+    _data = new Data;
+    _data->_count.fetch_add(1);
+    _data->_shader = shader;
+}
+
+void HdVP2ShaderUniquePtr::clear()
+{
+    if (!_data)
+        return;
+
+    const int prevCount = _data->_count.fetch_sub(1);
+    if (prevCount != 1)
+        return;
+
+    MHWRender::MShaderInstance* shader = _data->_shader;
+    addDeadShader(shader);
+
+    _data->_shader = nullptr;
+    delete _data;
+    _data = nullptr;
 }
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/render/vp2RenderDelegate/shader.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/shader.h
@@ -28,16 +28,36 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-/*! \brief  A deleter for MShaderInstance, for use with smart pointers.
- */
-struct HdVP2ShaderDeleter
+struct HdVP2ShaderUniquePtr
 {
-    void operator()(MHWRender::MShaderInstance*);
-};
+    HdVP2ShaderUniquePtr();
+    explicit HdVP2ShaderUniquePtr(MHWRender::MShaderInstance*);
+    HdVP2ShaderUniquePtr(const HdVP2ShaderUniquePtr&);
+    HdVP2ShaderUniquePtr(HdVP2ShaderUniquePtr&&);
 
-/*! \brief  A MShaderInstance owned by a std::unique_ptr.
- */
-using HdVP2ShaderUniquePtr = std::unique_ptr<MHWRender::MShaderInstance, HdVP2ShaderDeleter>;
+    ~HdVP2ShaderUniquePtr();
+
+    HdVP2ShaderUniquePtr& operator=(const HdVP2ShaderUniquePtr&);
+    HdVP2ShaderUniquePtr& operator=(HdVP2ShaderUniquePtr&&);
+
+    MHWRender::MShaderInstance* operator->() const;
+    MHWRender::MShaderInstance* get() const;
+    explicit                    operator bool() const;
+
+    void reset(MHWRender::MShaderInstance* shader);
+    void clear();
+
+    static void cleanupDeadShaders();
+
+private:
+    struct Data
+    {
+        std::atomic<int>            _count { 0 };
+        MHWRender::MShaderInstance* _shader { nullptr };
+    };
+
+    Data* _data { nullptr };
+};
 
 /*! \brief  Thread-safe cache of named shaders.
  */


### PR DESCRIPTION
The multi-threaded viewport update code would sometimes end-up using a shader that was no longer valid. Seems related to reference counting and multi-threading and reusing the same material on multiple (possibly instanced) meshes. Seems to be due to a race condition between multiple threads, the guarantee about multi-threaded in VP2 / OGS are not entirely clear.

Fix it by delaying releasing shaders until the entire update is done. We keep these unused shaders in a set. Each unused shader gets released at the end of the update.