### PR TITLE
EMSUSD-1180 Fix blendshape names

### DIFF
--- a/lib/usd/translators/meshWriter_BlendShapes.cpp
+++ b/lib/usd/translators/meshWriter_BlendShapes.cpp
@@ -677,10 +677,10 @@ MObject PxrUsdTranslators_MeshWriter::writeBlendShapeData(UsdGeomMesh& primSchem
                             MFnDagNode parentDagNode(dagNode.parent(0));
                             curTargetNameMStr
                                 = UsdMayaUtil::GetUniqueNameOfDagNode(parentDagNode.object());
-                            curTargetLongNameMStr = MString(curTargetNameMStr);
+                            curTargetLongNameMStr = curTargetNameMStr;
                         } else {
                             curTargetNameMStr = UsdMayaUtil::GetUniqueNameOfDagNode(targetMesh);
-                            curTargetLongNameMStr = MString(curTargetNameMStr);
+                            curTargetLongNameMStr = curTargetNameMStr;
                         }
                         // NOTE: (yliangsiew) Because UsdSkelBlendShape does not
                         // support animated targets (the `normalOffsets` and

--- a/lib/usd/translators/meshWriter_BlendShapes.cpp
+++ b/lib/usd/translators/meshWriter_BlendShapes.cpp
@@ -672,14 +672,15 @@ MObject PxrUsdTranslators_MeshWriter::writeBlendShapeData(UsdGeomMesh& primSchem
                     MString                   curTargetLongNameMStr;
                     if (!targetMesh.isNull()) {
                         MFnDagNode dagNode(targetMesh);
-                        MString nodeName;
-                        if(dagNode.parentCount() > 0) {
-                        	MFnDagNode parentDagNode(dagNode.parent(0));
-                        	curTargetNameMStr = UsdMayaUtil::GetUniqueNameOfDagNode(parentDagNode.object());
-                        	curTargetLongNameMStr = MString(curTargetNameMStr);
+                        MString    nodeName;
+                        if (dagNode.parentCount() > 0) {
+                            MFnDagNode parentDagNode(dagNode.parent(0));
+                            curTargetNameMStr
+                                = UsdMayaUtil::GetUniqueNameOfDagNode(parentDagNode.object());
+                            curTargetLongNameMStr = MString(curTargetNameMStr);
                         } else {
-                        	curTargetNameMStr = UsdMayaUtil::GetUniqueNameOfDagNode(targetMesh);
-                        	curTargetLongNameMStr = MString(curTargetNameMStr);
+                            curTargetNameMStr = UsdMayaUtil::GetUniqueNameOfDagNode(targetMesh);
+                            curTargetLongNameMStr = MString(curTargetNameMStr);
                         }
                         // NOTE: (yliangsiew) Because UsdSkelBlendShape does not
                         // support animated targets (the `normalOffsets` and

--- a/lib/usd/translators/meshWriter_BlendShapes.cpp
+++ b/lib/usd/translators/meshWriter_BlendShapes.cpp
@@ -48,7 +48,6 @@
 #include <maya/MStatus.h>
 
 #include <algorithm>
-#include <complex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -672,6 +671,16 @@ MObject PxrUsdTranslators_MeshWriter::writeBlendShapeData(UsdGeomMesh& primSchem
                     MString                   curTargetNameMStr;
                     MString                   curTargetLongNameMStr;
                     if (!targetMesh.isNull()) {
+                        MFnDagNode dagNode(targetMesh);
+                        MString nodeName;
+                        if(dagNode.parentCount() > 0) {
+                        	MFnDagNode parentDagNode(dagNode.parent(0));
+                        	curTargetNameMStr = UsdMayaUtil::GetUniqueNameOfDagNode(parentDagNode.object());
+                        	curTargetLongNameMStr = MString(curTargetNameMStr);
+                        } else {
+                        	curTargetNameMStr = UsdMayaUtil::GetUniqueNameOfDagNode(targetMesh);
+                        	curTargetLongNameMStr = MString(curTargetNameMStr);
+                        }
                         // NOTE: (yliangsiew) Because UsdSkelBlendShape does not
                         // support animated targets (the `normalOffsets` and
                         // `offsets` attributes are defined as uniforms), we cannot
@@ -684,11 +693,6 @@ MObject PxrUsdTranslators_MeshWriter::writeBlendShapeData(UsdGeomMesh& primSchem
                                 "connections first before attempting to export.");
                             return MObject::kNullObj;
                         }
-                        curTargetNameMStr = UsdMayaUtil::GetUniqueNameOfDagNode(targetMesh);
-                        curTargetLongNameMStr = MString(curTargetNameMStr);
-                        stat = mayaPrefixBlendShapeTargetNameForUSD(
-                            curTargetLongNameMStr, blendShapeInfo.blendShapeDeformer);
-                        CHECK_MSTATUS_AND_RETURN(stat, MObject::kNullObj);
                     } else {
                         MFnDependencyNode fnNode(blendShapeInfo.blendShapeDeformer, &stat);
                         CHECK_MSTATUS_AND_RETURN(stat, MObject::kNullObj);
@@ -719,10 +723,11 @@ MObject PxrUsdTranslators_MeshWriter::writeBlendShapeData(UsdGeomMesh& primSchem
                         // UsdSkelBlendShape stores _all_ the target names across the
                         // entire file in a single array for the animation samples.)
                         curTargetLongNameMStr = MString(curTargetNameMStr);
-                        stat = mayaPrefixBlendShapeTargetNameForUSD(
-                            curTargetLongNameMStr, blendShapeInfo.blendShapeDeformer);
-                        CHECK_MSTATUS_AND_RETURN(stat, MObject::kNullObj);
                     }
+
+                    stat = mayaPrefixBlendShapeTargetNameForUSD(
+                        curTargetLongNameMStr, blendShapeInfo.blendShapeDeformer);
+                    CHECK_MSTATUS_AND_RETURN(stat, MObject::kNullObj);
 
                     TF_VERIFY(curTargetNameMStr.length() != 0);
                     std::string curTargetName

--- a/test/lib/usd/translators/testUsdExportBlendshapes.py
+++ b/test/lib/usd/translators/testUsdExportBlendshapes.py
@@ -58,7 +58,7 @@ class TestUsdExportBlendshapes(unittest.TestCase):
         cmds.mayaUSDExport(f=temp_file, v=True, sl=True, ebs=True, skl="auto")
 
         stage = Usd.Stage.Open(temp_file)
-        prim = stage.GetPrimAtPath("/root/base/blendShape")
+        prim = stage.GetPrimAtPath("/root/base/blend")
         offsets = prim.GetAttribute("offsets").Get()
 
         for i, coords in enumerate(offsets):
@@ -68,7 +68,7 @@ class TestUsdExportBlendshapes(unittest.TestCase):
         """
         Sample BlendShape prim:
 
-        def BlendShape "blendShape"
+        def BlendShape "blend"
         {
             uniform vector3f[] normalOffsets = [(0, 0, 0), (0, 0, 0), (0, 0, 0)]
             uniform vector3f[] offsets = [(0, -0.25, 0), (0, -0.25, 0), (0, 0.25, 0)]


### PR DESCRIPTION
When exporting maya blendshapes to usd, it's used the name of the mesh shape. However, the Maya's shape editor lists the name of the parent node to drive the blendshape weights. 

This PR it's an improvement so that the default USD blendshapes are created with proper names.