### PR TITLE
EMSUSD-1149 prevent unlocking system-locked layer when unlocking parents

### DIFF
--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -1202,8 +1202,7 @@ MSyntax LayerEditorCommand::createSyntax()
     // parameter 2: refresh sub layers
     syntax.addFlag(
         kRefreshSystemLockFlag, kRefreshSystemLockFlagL, MSyntax::kString, MSyntax::kBoolean);
-    syntax.addFlag(
-        kSkipSystemLockedFlag, kSkipSystemLockedFlagL);
+    syntax.addFlag(kSkipSystemLockedFlag, kSkipSystemLockedFlagL);
 
     return syntax;
 }

--- a/lib/usd/ui/layerEditor/mayaCommandHook.cpp
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.cpp
@@ -208,6 +208,11 @@ void MayaCommandHook::lockLayer(
     MayaUsd::LayerLockType lockState,
     bool                   includeSubLayers)
 {
+    // Per design, we refuse to change the lock state of system-locked
+    // layers through the UI.
+    if (MayaUsd::isLayerSystemLocked(usdLayer))
+        return;
+
     std::string cmd;
     cmd = "mayaUsdLayerEditor -edit -lockLayer ";
     cmd += std::to_string(lockState);

--- a/lib/usd/ui/layerEditor/mayaCommandHook.cpp
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.cpp
@@ -214,7 +214,7 @@ void MayaCommandHook::lockLayer(
         return;
 
     std::string cmd;
-    cmd = "mayaUsdLayerEditor -edit -lockLayer ";
+    cmd = "mayaUsdLayerEditor -edit -skipSystemLocked -lockLayer ";
     cmd += std::to_string(lockState);
     cmd += includeSubLayers ? " 1" : " 0";
     cmd += quote(proxyShapePath());

--- a/test/lib/testMayaUsdLayerEditorCommands.py
+++ b/test/lib/testMayaUsdLayerEditorCommands.py
@@ -701,12 +701,13 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
 
         # Unlocking a system-locked layer recursively
         #
-        # Note: this *only* unlocks the layer itself because by design
-        #       we don't want to recursively unlock system-locked layers.
+        # Note: we use the flag to skip system-locked layer to *only* unlock
+        #       the layer itself because by design we don't want to recursively
+        #       unlock system-locked layers from the UI.
         #
         #       Otherwise, unlocking recursively inthe UI would unlock system
         #       layers, which is not something we want the user to do.
-        cmds.mayaUsdLayerEditor(subLayer1.identifier, edit=True, lockLayer=(0, 1, shapePath))
+        cmds.mayaUsdLayerEditor(subLayer1.identifier, edit=True, skipSystemLocked=True, lockLayer=(0, 1, shapePath))
         self.assertTrue(subLayer1.permissionToEdit)
         self.assertTrue(subLayer1.permissionToSave)
         self.assertFalse(subLayer1_1.permissionToEdit)
@@ -721,17 +722,17 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
         self.assertTrue(subLayer1.permissionToSave)
         self.assertFalse(subLayer1_1.permissionToEdit)
         self.assertFalse(subLayer1_1.permissionToSave)
+        cmds.undo()
 
-        # Now unlock the sub-layer. Otherwise, the other tests would fail
-        # since layers are kept in memory by USD during a session.
-        cmds.mayaUsdLayerEditor(subLayer1_1.identifier, edit=True, lockLayer=(0, 1, shapePath))
+        # Unlocking a system-locked layer recursively
+        cmds.mayaUsdLayerEditor(subLayer1.identifier, edit=True, lockLayer=(0, 1, shapePath))
         self.assertTrue(subLayer1.permissionToEdit)
         self.assertTrue(subLayer1.permissionToSave)
         self.assertTrue(subLayer1_1.permissionToEdit)
         self.assertTrue(subLayer1_1.permissionToSave)
         cmds.undo()
-        self.assertTrue(subLayer1.permissionToEdit)
-        self.assertTrue(subLayer1.permissionToSave)
+        self.assertFalse(subLayer1.permissionToEdit)
+        self.assertFalse(subLayer1.permissionToSave)
         self.assertFalse(subLayer1_1.permissionToEdit)
         self.assertFalse(subLayer1_1.permissionToSave)
         cmds.redo()

--- a/test/testSamples/layerLocking/layerLockingSubLayer.usda
+++ b/test/testSamples/layerLocking/layerLockingSubLayer.usda
@@ -1,2 +1,11 @@
 #usda 1.0
 
+(
+    subLayers = [
+        @layerLockingSubSubLayer.usda@
+    ]
+)
+
+def Sphere "Sphere1"
+{
+}

--- a/test/testSamples/layerLocking/layerLockingSubSubLayer.usda
+++ b/test/testSamples/layerLocking/layerLockingSubSubLayer.usda
@@ -1,0 +1,5 @@
+#usda 1.0
+
+def Cone "Cone1"
+{
+}


### PR DESCRIPTION
- When unlocking recursively, do not unlock sub-layers that are system-locked.
- Correctly check that the *request* was for system lock when undoing a lock command.
- Add more lock tests to cover more cases, like having sub-layers and system-locked layers.