### PR TITLE
EMSUSD-1193 hide unwanted export plugin options

### DIFF
--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -274,6 +274,15 @@ global proc mayaUsdTranslatorExport_MeshCB() {
     columnLayout -e -enable (`checkBoxGrp -q -v1 exportMeshesCheckBox` == 1) materialOptsCol;
 }
 
+proc string[] mayaUsdTranslatorExport_getContextLabels()
+{
+    // Make sure they are in alphabetical order when creatign the UI,
+    // otherwise they are in a semi-random order, probably based on plugin
+    // load order or other internal details.
+    string $contextLabels[] = `mayaUSDListJobContexts -export`;
+    return `sort $contextLabels`;
+}
+
 proc string mayaUsdTranslatorExport_getContextOptionsCheckBoxName(string $jobContext)
 {
     // Build the name of the checkbox used for a given plugin context configuration
@@ -301,16 +310,27 @@ proc string mayaUsdTranslatorExport_getContextOptionsButtonName(string $jobConte
 proc mayaUsdTranslatorExport_updateContextOptionButton(string $contextLabel, string $jobContext)
 {
     string $buttonName = mayaUsdTranslatorExport_getContextOptionsButtonName($jobContext);
-    iconTextButton -edit -visible `mayaUsdTranslatorExport_isContextOptionsUISupported($contextLabel)` $buttonName;
+    int $vis = `mayaUsdTranslatorExport_isContextOptionsUISupported($contextLabel)`;
+    iconTextButton -edit -visible $vis $buttonName;
 }
 
-proc string[] mayaUsdTranslatorExport_getContextLabels()
+proc string[] mayaUsdTranslatorExport_updateAllContextOptionButtons()
 {
-    // Make sure they are in alphabetical order when creatign the UI,
-    // otherwise they are in a semi-random order, probably based on plugin
-    // load order or other internal details.
-    string $contextLabels[] = `mayaUSDListJobContexts -export`;
-    return `sort $contextLabels`;
+    string $jobContexts[];
+
+    string $contextLabels[] = mayaUsdTranslatorExport_getContextLabels();
+    for ($contextLabel in $contextLabels) {
+        // Note: we verify that the enabled context actually exists. Might be redundant, but
+        //       initially the list of enabled context comes from the saved ones from a previous
+        //       Maya session and the list of loaded plugins might have changed.
+        string $jobContext = `mayaUSDListJobContexts -jobContext $contextLabel`;
+        if ($jobContext == "")
+            continue;
+        stringArrayInsertAtIndex(255, $jobContexts, $jobContext);
+        mayaUsdTranslatorExport_updateContextOptionButton($contextLabel, $jobContext);
+    }
+
+    return $jobContexts;
 }
 
 global string $_mayaUsdTranslatorExport_contextLabel;
@@ -477,15 +497,7 @@ proc mayaUsdTranslatorExport_fillContextOptionsUI(string $listOfJobContexts)
     // Note: we verify that the enabled context actually exists. Might be redundant, but
     //       initially the list of enabled context comes from the saved ones from a previous
     //       Maya session and the list of loaded plugins might have changed.
-    string $contextLabels[] = mayaUsdTranslatorExport_getContextLabels();
-    string $jobContexts[];
-    for ($contextLabel in $contextLabels) {
-        string $jobContext = `mayaUSDListJobContexts -jobContext $contextLabel`;
-        if ($jobContext == "")
-            continue;
-        stringArrayInsertAtIndex(255, $jobContexts, $jobContext);
-        mayaUsdTranslatorExport_updateContextOptionButton($contextLabel, $jobContext);
-    }
+    string $jobContexts[] = mayaUsdTranslatorExport_updateAllContextOptionButtons();
 
     string $enabledJobContexts[] = stringToStringArray($listOfJobContexts, ",");
     for ($enabledJobContext in $enabledJobContexts) {
@@ -857,7 +869,12 @@ global proc mayaUsdTranslatorExport_SetFromOptions(string $currentOptions, int $
 
         if ($listOfJobContexts != "" && $processJobContext == 1) {
             mayaUsdTranslatorExport_fillContextOptionsUI($listOfJobContexts);
+        } else {
+            // Note: this is necessary to correctly hide the export option button
+            //       if not supported by the plugin.
+            mayaUsdTranslatorExport_updateAllContextOptionButtons();
         }
+
         if ($processJobContext == 0 && $supportsMultiExport == 0) {
             mayaUsdTranslatorExport_DisableConvertMaterialsToCheckboxes();
         }

--- a/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
@@ -20,6 +20,15 @@
 //
 // Import context UI
 
+proc string[] mayaUsdTranslatorImport_getContextLabels()
+{
+    // Make sure they are in alphabetical order when creatign the UI,
+    // otherwise they are in a semi-random order, probably based on plugin
+    // load order or other internal details.
+    string $contextLabels[] = `mayaUSDListJobContexts -import`;
+    return `sort $contextLabels`;
+}
+
 proc string mayaUsdTranslatorImport_getContextOptionsCheckBoxName(string $jobContext)
 {
     // Build the name of the checkbox used for a given plugin context configuration
@@ -50,13 +59,23 @@ proc mayaUsdTranslatorImport_updateContextOptionButton(string $contextLabel, str
     iconTextButton -edit -visible `mayaUsdTranslatorImport_isContextOptionsUISupported($contextLabel)` $buttonName;
 }
 
-proc string[] mayaUsdTranslatorImport_getContextLabels()
+proc string[] mayaUsdTranslatorImport_updateAllContextOptionButtons()
 {
-    // Make sure they are in alphabetical order when creatign the UI,
-    // otherwise they are in a semi-random order, probably based on plugin
-    // load order or other internal details.
-    string $contextLabels[] = `mayaUSDListJobContexts -import`;
-    return `sort $contextLabels`;
+    string $jobContexts[];
+
+    string $contextLabels[] = mayaUsdTranslatorImport_getContextLabels();
+    for ($contextLabel in $contextLabels) {
+        // Note: we verify that the enabled context actually exists. Might be redundant, but
+        //       initially the list of enabled context comes from the saved ones from a previous
+        //       Maya session and the list of loaded plugins might have changed.
+        string $jobContext = `mayaUSDListJobContexts -jobContext $contextLabel`;
+        if ($jobContext == "")
+            continue;
+        stringArrayInsertAtIndex(255, $jobContexts, $jobContext);
+        mayaUsdTranslatorImport_updateContextOptionButton($contextLabel, $jobContext);
+    }
+
+    return $jobContexts;
 }
 
 global string $_mayaUsdTranslatorImport_contextLabel;
@@ -217,18 +236,7 @@ proc mayaUsdTranslatorImport_fillContextOptionsUI(string $listOfJobContexts)
         }
     }
 
-    // Note: we verify that the enabled context actually exists. Might be redundant, but
-    //       initially the list of enabled context comes from the saved ones from a previous
-    //       Maya session and the list of loaded plugins might have changed.
-    string $contextLabels[] = mayaUsdTranslatorImport_getContextLabels();
-    string $jobContexts[];
-    for ($contextLabel in $contextLabels) {
-        string $jobContext = `mayaUSDListJobContexts -jobContext $contextLabel`;
-        if ($jobContext == "")
-            continue;
-        stringArrayInsertAtIndex(255, $jobContexts, $jobContext);
-        mayaUsdTranslatorImport_updateContextOptionButton($contextLabel, $jobContext);
-    }
+    string $jobContexts[] = mayaUsdTranslatorImport_updateAllContextOptionButtons();
 
     string $enabledJobContexts[] = stringToStringArray($listOfJobContexts, ",");
     for ($enabledJobContext in $enabledJobContexts) {
@@ -407,6 +415,8 @@ global proc mayaUsdTranslatorImport_SetFromOptions(string $currentOptions, int $
         }
         if ($jobContext != "" && $processJobContext == 1) {
             mayaUsdTranslatorImport_fillContextOptionsUI($jobContext);
+        } else {
+            mayaUsdTranslatorImport_updateAllContextOptionButtons();
         }
     }
 }


### PR DESCRIPTION
When an export plugin has no option UI, the option button must not show up. When the plugin was disabled and nothing was exported, we got into a state where the option button would still show up.

- Add a function to update all option buttons of each export plugin.
- Call it when setting up the initial UI.
- Do the same fixes for teh import plugins.