### PR TITLE
EMSUSD-1067 allow deleting prims carrying a loaded payload

### DIFF
--- a/lib/usdUfe/ufe/Utils.cpp
+++ b/lib/usdUfe/ufe/Utils.cpp
@@ -543,11 +543,11 @@ void applyCommandRestriction(
             continue;
         }
 
-        // one reason for skipping the reference is to not clash
+        // one reason for skipping the references and payloads is to not clash
         // with the over that may be created in the stage's sessionLayer.
         // another reason is that one should be able to edit a referenced prim that
         // either as over/def as long as it has a primSpec in the selected edit target layer.
-        if (spec->HasReferences()) {
+        if (spec->HasReferences() || spec->HasPayloads()) {
             break;
         }
 

--- a/test/lib/ufe/testPayloadCommands.py
+++ b/test/lib/ufe/testPayloadCommands.py
@@ -144,7 +144,7 @@ class PayloadCommandsTestCase(unittest.TestCase):
         cmd.redo()
         self.assertTrue(prim.IsLoaded())
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() > 2022, 'Delete restriction on delete was only after Maya 2022.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'Delete restriction on delete requires Maya 2023 or greater.')
     def testDeletePrimContainingPayload(self):
         '''
         Test adding a payload to a prim, then deleting that prim.

--- a/test/lib/ufe/testPayloadCommands.py
+++ b/test/lib/ufe/testPayloadCommands.py
@@ -144,5 +144,30 @@ class PayloadCommandsTestCase(unittest.TestCase):
         cmd.redo()
         self.assertTrue(prim.IsLoaded())
 
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() > 2022, 'Delete restriction on delete was only after Maya 2022.')
+    def testDeletePrimContainingPayload(self):
+        '''
+        Test adding a payload to a prim, then deleting that prim.
+        '''
+        # Get the session layer
+        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
+
+        self.assertFalse(prim.HasPayload())
+
+        payloadFile = testUtils.getTestScene('twoSpheres', 'sphere.usda')
+        cmd = usdUfe.AddPayloadCommand(prim, payloadFile, True)
+        self.assertIsNotNone(cmd)
+
+        # Verify state after add payload
+        cmd.execute()
+        self.assertTrue(prim.HasPayload())
+        self.assertTrue(prim.IsLoaded())
+
+        # Delete the prim containing the payload. The payload should not block deletion.
+        cmds.delete("|stage1|stageShape1,/A")
+        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
+        self.assertFalse(prim)
+        
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/ufe/testReferenceCommands.py
+++ b/test/lib/ufe/testReferenceCommands.py
@@ -93,7 +93,7 @@ class ReferenceCommandsTestCase(unittest.TestCase):
         self.assertEqual(originalRootContents, filterUsdStr(self.stage.GetRootLayer().ExportToString()))
 
 
-    @unittest.skipUnless(mayaUtils.mayaMajorVersion() > 2022, 'Delete restriction on delete was only after Maya 2022.')
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'Delete restriction on delete requires Maya 2023 or greater.')
     def testDeletePrimContainingReference(self):
         '''
         Test adding a reference to a prim, then deleting that prim.

--- a/test/lib/ufe/testReferenceCommands.py
+++ b/test/lib/ufe/testReferenceCommands.py
@@ -93,5 +93,27 @@ class ReferenceCommandsTestCase(unittest.TestCase):
         self.assertEqual(originalRootContents, filterUsdStr(self.stage.GetRootLayer().ExportToString()))
 
 
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() > 2022, 'Delete restriction on delete was only after Maya 2022.')
+    def testDeletePrimContainingReference(self):
+        '''
+        Test adding a reference to a prim, then deleting that prim.
+        '''
+        # Get the session layer
+        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
+
+        self.assertFalse(prim.HasAuthoredReferences())
+
+        referencedFile = testUtils.getTestScene('twoSpheres', 'sphere.usda')
+        cmd = usdUfe.AddReferenceCommand(prim, referencedFile, True)
+
+        cmd.execute()
+        self.assertTrue(prim.HasAuthoredReferences())
+
+        # Delete the prim containing the reference. The ref should not block deletion.
+        cmds.delete("|stage1|stageShape1,/A")
+        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
+        self.assertFalse(prim)
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
- Apply the same logic as for references.
- Add test for deletion of a prim containing a payload or a ref.