### PR TITLE
EMSUSD-1142 layer editor icon scaling

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -32,8 +32,8 @@ LayerActionDefinitions LayerTreeItem::_actionButtons;
 
 static void createPixmapPair(const QString& name, QPixmap& normal, QPixmap& hover)
 {
-    normal = utils->createPNGResPixmap(utils->getDPIPixmapName(name));
-    hover = utils->createPNGResPixmap(utils->getDPIPixmapName(name + QString("_hover")));
+    normal = utils->createPNGResPixmap(name);
+    hover = utils->createPNGResPixmap(name + QString("_hover"));
 }
 
 const LayerActionDefinitions& LayerTreeItem::actionButtonsDefinition()

--- a/lib/usd/ui/layerEditor/layerTreeItemDelegate.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItemDelegate.cpp
@@ -88,10 +88,9 @@ LayerTreeItemDelegate::LayerTreeItemDelegate(LayerTreeView* in_parent)
     : QStyledItemDelegate(in_parent)
     , _treeView(in_parent)
 {
-    DISABLED_BACKGROUND_IMAGE = utils->createPNGResPixmap(
-        QString(":/UsdLayerEditor/") + QtUtils::getDPIPixmapName("striped"));
-    DISABLED_HIGHLIGHT_IMAGE = utils->createPNGResPixmap(
-        QString(":/UsdLayerEditor/") + QtUtils::getDPIPixmapName("striped_selected"));
+    DISABLED_BACKGROUND_IMAGE = utils->createPNGResPixmap(QString(":/UsdLayerEditor/striped"));
+    DISABLED_HIGHLIGHT_IMAGE
+        = utils->createPNGResPixmap(QString(":/UsdLayerEditor/striped_selected"));
     WARNING_IMAGE = utils->createPNGResPixmap("RS_warning");
 
     const char* targetOnPixmaps[3] { "target_on", "target_on_hover", "target_on_pressed" };

--- a/lib/usd/ui/layerEditor/qtUtils.cpp
+++ b/lib/usd/ui/layerEditor/qtUtils.cpp
@@ -35,6 +35,14 @@ QPixmap QtUtils::createPNGResPixmap(QString const& in_pixmapName, int width, int
     if (pixmapName.left(2) != resourcePrefix) {
         pixmapName = resourcePrefix + pixmapName;
     }
+
+    // Note: createPNGResPixmap calls QtUtils::createPNGResPixmap, but that is
+    //       *not* the function below but rather MayaQtUtils::createPixmap, since
+    //       these functions are virtual.
+    //
+    //       The MayaQtUtils version calls MQtUtil::createPixmap which calls
+    //       QmayaQtHelper::createPixmap which generates the scaled image name
+    //       by adding the _150 or _200 suffix as necessary.
     return createPixmap(pixmapName, width, height);
 }
 

--- a/lib/usd/ui/layerEditor/resources.qrc
+++ b/lib/usd/ui/layerEditor/resources.qrc
@@ -35,31 +35,31 @@
         <file alias="LE_import_layer_pressed_150.png">resources/import_layer_hover_150.png</file>
         <file alias="LE_import_layer_pressed_200.png">resources/import_layer_hover_200.png</file>
 
-        <file alias="LE_lock_off_100.png">resources/lock_off_100.png</file>
+        <file alias="LE_lock_off.png">resources/lock_off_100.png</file>
         <file alias="LE_lock_off_150.png">resources/lock_off_150.png</file>
         <file alias="LE_lock_off_200.png">resources/lock_off_200.png</file>
-        <file alias="LE_lock_off_hover_100.png">resources/lock_off_hover_100.png</file>
+        <file alias="LE_lock_off_hover.png">resources/lock_off_hover_100.png</file>
         <file alias="LE_lock_off_hover_150.png">resources/lock_off_hover_150.png</file>
         <file alias="LE_lock_off_hover_200.png">resources/lock_off_hover_200.png</file>
 
-        <file alias="LE_lock_on_100.png">resources/lock_on_100.png</file>
+        <file alias="LE_lock_on.png">resources/lock_on_100.png</file>
         <file alias="LE_lock_on_150.png">resources/lock_on_150.png</file>
         <file alias="LE_lock_on_200.png">resources/lock_on_200.png</file>
-        <file alias="LE_lock_on_hover_100.png">resources/lock_on_hover_100.png</file>
+        <file alias="LE_lock_on_hover.png">resources/lock_on_hover_100.png</file>
         <file alias="LE_lock_on_hover_150.png">resources/lock_on_hover_150.png</file>
         <file alias="LE_lock_on_hover_200.png">resources/lock_on_hover_200.png</file>
 
-        <file alias="LE_mute_off_100.png">resources/mute_off_100.png</file>
+        <file alias="LE_mute_off.png">resources/mute_off_100.png</file>
         <file alias="LE_mute_off_150.png">resources/mute_off_150.png</file>
         <file alias="LE_mute_off_200.png">resources/mute_off_200.png</file>
-        <file alias="LE_mute_off_hover_100.png">resources/mute_off_hover_100.png</file>
+        <file alias="LE_mute_off_hover.png">resources/mute_off_hover_100.png</file>
         <file alias="LE_mute_off_hover_150.png">resources/mute_off_hover_150.png</file>
         <file alias="LE_mute_off_hover_200.png">resources/mute_off_hover_200.png</file>
 
-        <file alias="LE_mute_on_100.png">resources/mute_on_100.png</file>
+        <file alias="LE_mute_on.png">resources/mute_on_100.png</file>
         <file alias="LE_mute_on_150.png">resources/mute_on_150.png</file>
         <file alias="LE_mute_on_200.png">resources/mute_on_200.png</file>
-        <file alias="LE_mute_on_hover_100.png">resources/mute_on_hover_100.png</file>
+        <file alias="LE_mute_on_hover.png">resources/mute_on_hover_100.png</file>
         <file alias="LE_mute_on_hover_150.png">resources/mute_on_hover_150.png</file>
         <file alias="LE_mute_on_hover_200.png">resources/mute_on_hover_200.png</file>
 
@@ -82,11 +82,11 @@
         <file alias="pin_on_pressed_150.png">resources/pin_off_hover_150.png</file>
         <file alias="pin_on_pressed_200.png">resources/pin_off_hover_200.png</file>
 
-        <file alias="striped_100.png">resources/striped_100.png</file>
+        <file alias="striped.png">resources/striped_100.png</file>
         <file alias="striped_150.png">resources/striped_150.png</file>
         <file alias="striped_200.png">resources/striped_200.png</file>
 
-        <file alias="striped_selected_100.png">resources/striped_selected_100.png</file>
+        <file alias="striped_selected.png">resources/striped_selected_100.png</file>
         <file alias="striped_selected_150.png">resources/striped_selected_150.png</file>
         <file alias="striped_selected_200.png">resources/striped_selected_200.png</file>
 


### PR DESCRIPTION
Correctly define the scaling icon and don't try to calculate the DPI in the plugin, let the pixmap creation do the maths. In that scheme, the default 100% scaling pixamp does not have a DPI suffix, so fix the resource names.