### PR TITLE
EMSUSD-1091 Save and restore non local edit target layer and anonymous layer

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -472,7 +472,7 @@ void LayerDatabase::updateLayerManagers()
 bool LayerDatabase::hasDirtyLayer() const
 {
     for (const auto& info : _proxiesToSave) {
-        SdfLayerHandleVector allLayers = info.stage->GetLayerStack(true);
+        SdfLayerHandleVector allLayers = info.stage->GetUsedLayers(true);
         for (auto layer : allLayers) {
             if (layer->IsDirty()) {
                 return true;
@@ -480,7 +480,7 @@ bool LayerDatabase::hasDirtyLayer() const
         }
     }
     for (const auto& info : _internalProxiesToSave) {
-        SdfLayerHandleVector allLayers = info.stage->GetLayerStack(true);
+        SdfLayerHandleVector allLayers = info.stage->GetUsedLayers(true);
         for (auto layer : allLayers) {
             if (layer->IsDirty()) {
                 return true;
@@ -530,7 +530,7 @@ bool LayerDatabase::getProxiesToSave(bool isExport, bool* hasAnyProxy)
                 // so we can put them back in the same spot). So doesn't matter if its incoming or
                 // not, we need to save.
                 if (!pShape->isShareableStage() || !pShape->isStageIncoming()) {
-                    SdfLayerHandleVector allLayers = stage->GetLayerStack(true);
+                    SdfLayerHandleVector allLayers = stage->GetUsedLayers(true);
                     for (auto layer : allLayers) {
                         if (layer->IsDirty()) {
                             StageSavingInfo info;
@@ -743,16 +743,19 @@ struct SaveStageToMayaResult
     bool _stageHasDirtyLayers { false };
 };
 
-static void saveLayersToMayaFile(
+template <typename T, typename IgnoreLayerFn>
+void saveLayersToMayaFile(
+    const T&&              allLayers,
+    const IgnoreLayerFn&&  ignoreLayerFn,
     MayaUsd::LayerManager* lm,
     MArrayDataBuilder&     builder,
     MayaUsdProxyShapeBase& proxyShape,
-    const SdfLayerHandle&  layer,
     SaveStageToMayaResult& result)
 {
-    bool includeTopLayer = true;
-    auto allLayers = UsdUfe::getAllSublayerRefs(layer, includeTopLayer);
     for (auto layer : allLayers) {
+        if (ignoreLayerFn(layer)) {
+            continue;
+        }
         addLayerToBuilder(
             lm,
             builder,
@@ -783,8 +786,43 @@ SaveStageToMayaResult saveStageToMayaFile(
     if (!pShape)
         return result;
 
-    saveLayersToMayaFile(lm, builder, *pShape, stage->GetSessionLayer(), result);
-    saveLayersToMayaFile(lm, builder, *pShape, stage->GetRootLayer(), result);
+    std::unordered_set<std::string> localLayerIds;
+
+    // Save session layer and its sublayers
+    saveLayersToMayaFile(
+        UsdUfe::getAllSublayerRefs(stage->GetSessionLayer(), true),
+        [&localLayerIds](const auto& layer) {
+            localLayerIds.emplace(layer->GetIdentifier());
+            return false;
+        },
+        lm,
+        builder,
+        *pShape,
+        result);
+
+    // Save root layer and its sublayers
+    saveLayersToMayaFile(
+        UsdUfe::getAllSublayerRefs(stage->GetRootLayer(), true),
+        [&localLayerIds](const auto& layer) {
+            localLayerIds.emplace(layer->GetIdentifier());
+            return false;
+        },
+        lm,
+        builder,
+        *pShape,
+        result);
+
+    // Save non local layers (reference layers and sub layers in reference layers),
+    // skip those have been saved previously from local stack
+    saveLayersToMayaFile(
+        stage->GetUsedLayers(true),
+        [&localLayerIds](const auto& layer) {
+            return localLayerIds.find(layer->GetIdentifier()) != localLayerIds.cend();
+        },
+        lm,
+        builder,
+        *pShape,
+        result);
 
     if (result._stageHasDirtyLayers) {
         setValueForAttr(
@@ -895,9 +933,10 @@ BatchSaveResult LayerDatabase::saveUsdToUsdFiles()
                     continue;
                 }
                 convertAnonymousLayers(pShape, mobj, info.stage);
-                SdfLayerHandleVector allLayers = info.stage->GetLayerStack(false);
+                const auto& sessionLayer = info.stage->GetSessionLayer();
+                const auto& allLayers = info.stage->GetUsedLayers(true);
                 for (auto layer : allLayers) {
-                    if (layer->PermissionToSave()) {
+                    if (layer != sessionLayer && layer->PermissionToSave()) {
                         if (!MayaUsd::utils::saveLayerWithFormat(layer)) {
                             MString errMsg;
                             MString layerName(layer->GetDisplayName().c_str());

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -1048,6 +1048,15 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
                         targetSession ? sharedUsdStage->GetSessionLayer()
                                       : sharedUsdStage->GetRootLayer());
                 }
+
+                // Update file path attribute to match the correct root layer id if it was anonymous
+                if (!fileString.empty() && SdfLayer::IsAnonymousLayerIdentifier(fileString)) {
+                    if (rootLayer->IsAnonymous() && rootLayer->GetIdentifier() != fileString) {
+                        MDataHandle outDataHandle = dataBlock.outputValue(filePathAttr, &retValue);
+                        CHECK_MSTATUS_AND_RETURN_IT(retValue);
+                        outDataHandle.set(MString(rootLayer->GetIdentifier().c_str()));
+                    }
+                }
             }
             // Reset only if the global variant fallbacks has been modified
             if (!fallbacks.empty()) {

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -1178,7 +1178,7 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
 
         UsdEditTarget editTarget;
         if (!_targetLayer) {
-            editTarget = getEditTargetFromAttribute(*this, *finalUsdStage);
+            editTarget = getEditTargetFromAttribute(*this, layerNameMap, *finalUsdStage);
             if (editTarget.IsValid()) {
                 _targetLayer = editTarget.GetLayer();
             }

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -1167,8 +1167,6 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
         // muting
         copyLayerLockingFromAttribute(*this, layerNameMap, *finalUsdStage);
 
-        copyLayerMutingFromAttribute(*this, layerNameMap, *finalUsdStage);
-
         UsdEditTarget editTarget;
         if (!_targetLayer) {
             editTarget = getEditTargetFromAttribute(*this, *finalUsdStage);
@@ -1194,6 +1192,11 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
         if (editTarget.IsValid()) {
             finalUsdStage->SetEditTarget(editTarget);
         }
+
+        // Note: muting layer needs to be done after setting edit target layer
+        //       because the target layer could be the muted layer itself,
+        //       or one of the nested layers of a muted layer
+        copyLayerMutingFromAttribute(*this, layerNameMap, *finalUsdStage);
     }
 
     // Set the outUsdStageData

--- a/lib/mayaUsd/utils/targetLayer.cpp
+++ b/lib/mayaUsd/utils/targetLayer.cpp
@@ -18,6 +18,8 @@
 
 #include "dynamicAttribute.h"
 
+#include <pxr/usd/pcp/layerStack.h>
+#include <pxr/usd/pcp/node.h>
 #include <pxr/usd/usd/editTarget.h>
 
 #include <maya/MCommandResult.h>
@@ -27,6 +29,54 @@
 #include <maya/MGlobal.h>
 #include <maya/MObject.h>
 #include <maya/MString.h>
+
+namespace {
+
+const char kTargetLayerAttrName[] = "usdStageTargetLayer";
+const char kTargetLayerPrimPathAttrName[] = "usdStageTargetLayerPrimPath";
+
+/// \brief Find prim node that matches given layer id
+PXR_NS::PcpNodeRef
+findPrimNode(const PXR_NS::PcpNodeRef& primNode, const std::string& targetLayerId)
+{
+    // We need to store and check current depth level first (BFS), this is to
+    // preserve the opinions from strong to week
+    std::vector<PXR_NS::PcpNodeRef> childNodes;
+    TF_FOR_ALL(child, primNode.GetChildrenRange())
+    {
+        // The prim node can't have a variant.
+        if (child->GetPath().ContainsPrimVariantSelection()) {
+            continue;
+        }
+        // Confirm that the primNode is a direct contributor to the root prim.
+        bool result = child->IsRootNode();
+        // Confirm we are looking at one of the composition arcs that could lead us to a prim
+        // instance and not some other contributor like a specializes or such.
+        if (!result) {
+            auto arcType = child->GetArcType();
+            result = (arcType == PcpArcTypeReference) || (arcType == PcpArcTypePayload)
+                || (arcType == PcpArcTypeVariant);
+        }
+
+        if (result) {
+            if (child->GetLayerStack()->GetIdentifier().rootLayer->GetIdentifier()
+                == targetLayerId) {
+                return *child;
+            }
+            childNodes.emplace_back(*child);
+        }
+    }
+
+    for (const auto& child : childNodes) {
+        auto childPrimNode = findPrimNode(child, targetLayerId);
+        if (childPrimNode) {
+            return childPrimNode;
+        }
+    }
+    return {};
+}
+
+} // namespace
 
 namespace MAYAUSD_NS_DEF {
 
@@ -53,7 +103,7 @@ PXR_NS::SdfLayerHandle getTargetLayerFromText(PXR_NS::UsdStage& stage, const MSt
         return {};
 
     const std::string layerId(text.asChar());
-    for (const auto& layer : stage.GetLayerStack())
+    for (const auto& layer : stage.GetUsedLayers())
         if (layer->GetIdentifier() == layerId)
             return layer;
 
@@ -70,32 +120,47 @@ bool setTargetLayerFromText(PXR_NS::UsdStage& stage, const MString& text)
     return true;
 }
 
-namespace {
-
-const char kTargetLayerAttrName[] = "usdStageTargetLayer";
-
-} // namespace
-
 MStatus copyTargetLayerToAttribute(const PXR_NS::UsdStage& stage, MayaUsdProxyShapeBase& proxyShape)
 {
     MObject proxyObj = proxyShape.thisMObject();
     if (proxyObj.isNull())
         return MS::kFailure;
 
+    MString     targetLayerText;
+    MString     targetLayerPrimPath;
+    const auto& editTarget = stage.GetEditTarget();
+    if (editTarget.IsValid()) {
+        const auto& editTargetLayer = editTarget.GetLayer();
+        targetLayerText = editTargetLayer->GetIdentifier().c_str();
+        if (!stage.HasLocalLayer(editTargetLayer)) {
+            const auto& pathMap(editTarget.GetMapFunction().GetSourceToTargetMap());
+            if (!pathMap.empty()) {
+                // Save the top most prim path as the reference prim path for this edit target,
+                // when restoring edit target , we will need a prim path to locate to
+                // this layer.
+                targetLayerPrimPath = pathMap.begin()->second.GetString().c_str();
+            }
+        }
+    }
+
     MFnDependencyNode depNode(proxyObj);
-    if (!hasDynamicAttribute(depNode, kTargetLayerAttrName))
-        createDynamicAttribute(depNode, kTargetLayerAttrName);
-
-    MString targetLayerText = convertTargetLayerToText(stage);
-
     // Don't set the attribute if it already has the same value to avoid
     // update loops.
     MString previousTargetLayerText;
     getDynamicAttribute(depNode, kTargetLayerAttrName, previousTargetLayerText);
-    if (previousTargetLayerText == targetLayerText)
+
+    MString previousTargetLayerPrimPathText;
+    getDynamicAttribute(depNode, kTargetLayerPrimPathAttrName, previousTargetLayerPrimPathText);
+
+    if (previousTargetLayerText == targetLayerText
+        && previousTargetLayerPrimPathText == targetLayerPrimPath)
         return MS::kSuccess;
 
+    // Create and set dynamic attribute only when needed
     MStatus status = setDynamicAttribute(depNode, kTargetLayerAttrName, targetLayerText);
+    if (status == MS::kSuccess && targetLayerPrimPath.length()) {
+        status = setDynamicAttribute(depNode, kTargetLayerPrimPathAttrName, targetLayerPrimPath);
+    }
 
     return status;
 }
@@ -128,6 +193,65 @@ copyTargetLayerFromAttribute(const MayaUsdProxyShapeBase& proxyShape, PXR_NS::Us
 {
     const MString targetLayerText = getTargetLayerFromAttribute(proxyShape);
     return setTargetLayerFromText(stage, targetLayerText) ? MS::kSuccess : MS::kNotFound;
+}
+
+PXR_NS::UsdEditTarget
+getEditTargetFromAttribute(const MayaUsdProxyShapeBase& proxyShape, PXR_NS::UsdStage& stage)
+{
+    MObject proxyObj = proxyShape.thisMObject();
+    if (proxyObj.isNull()) {
+        return {};
+    }
+
+    MFnDependencyNode depNode(proxyObj);
+    if (!hasDynamicAttribute(depNode, kTargetLayerAttrName)) {
+        return {};
+    }
+
+    MString targetLayerText;
+    if (getDynamicAttribute(depNode, kTargetLayerAttrName, targetLayerText) != MS::kSuccess) {
+        return {};
+    }
+
+    PXR_NS::SdfLayerHandle layer = getTargetLayerFromText(stage, targetLayerText);
+    if (stage.HasLocalLayer(layer)) {
+        // Exit early if the layer in local layer stack
+        return layer;
+    }
+
+    MString targetLayerPrimPathText;
+    if (hasDynamicAttribute(depNode, kTargetLayerPrimPathAttrName)) {
+        getDynamicAttribute(depNode, kTargetLayerPrimPathAttrName, targetLayerPrimPathText);
+    }
+
+    if (!targetLayerPrimPathText.length()) {
+        return {};
+    }
+
+    std::string layerId = layer->GetIdentifier();
+
+    auto prim = stage.GetPrimAtPath(PXR_NS::SdfPath(targetLayerPrimPathText.asChar()));
+    if (!prim) {
+        MGlobal::displayError(
+            MString("Failed to construct non local edit target from layer id \"") + layerId.c_str()
+            + "\", reference prim path does not exist");
+        return {};
+    }
+
+    PXR_NS::PcpNodeRef primNode = prim.GetPrimIndex().GetRootNode();
+    if (primNode.GetLayerStack()->GetIdentifier().rootLayer->GetIdentifier() != layerId) {
+        // Search target layer from children recursively
+        primNode = findPrimNode(primNode, layerId);
+    }
+
+    if (!primNode) {
+        MGlobal::displayError(
+            MString("Failed to construct non local edit target from layer id \"") + layerId.c_str()
+            + "\", cannot find reference prim path \"" + targetLayerPrimPathText + "\"");
+        return {};
+    }
+
+    return PXR_NS::UsdEditTarget(layer, primNode);
 }
 
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/targetLayer.cpp
+++ b/lib/mayaUsd/utils/targetLayer.cpp
@@ -214,6 +214,11 @@ getEditTargetFromAttribute(const MayaUsdProxyShapeBase& proxyShape, PXR_NS::UsdS
     }
 
     PXR_NS::SdfLayerHandle layer = getTargetLayerFromText(stage, targetLayerText);
+    if (!layer) {
+        // No layer found, either not accessible or missing
+        return {};
+    }
+
     if (stage.HasLocalLayer(layer)) {
         // Exit early if the layer in local layer stack
         return layer;

--- a/lib/mayaUsd/utils/targetLayer.h
+++ b/lib/mayaUsd/utils/targetLayer.h
@@ -43,10 +43,16 @@ namespace MAYAUSD_NS_DEF {
 MAYAUSD_CORE_PUBLIC
 MString convertTargetLayerToText(const PXR_NS::UsdStage& stage);
 
+/*! Map the original layer name when the scene was saved to the current layer name.
+    Layer renaming happens when anonymous layers are saved within the Maya scene file.
+*/
+using LayerNameMap = std::map<std::string, std::string>;
+
 /*! \brief get the target layer from a text format if it exists on the given stage.
  */
 MAYAUSD_CORE_PUBLIC
-PXR_NS::SdfLayerHandle getTargetLayerFromText(PXR_NS::UsdStage& stage, const MString& text);
+PXR_NS::SdfLayerHandle
+getTargetLayerFromText(const LayerNameMap& nameMap, PXR_NS::UsdStage& stage, const MString& text);
 
 /*! \brief set the stage target layer from a text format.
  */
@@ -62,8 +68,10 @@ MString getTargetLayerFromAttribute(const MayaUsdProxyShapeBase& proxyShape);
  * exists on the given stage.
  */
 MAYAUSD_CORE_PUBLIC
-PXR_NS::SdfLayerHandle
-getTargetLayerFromAttribute(const MayaUsdProxyShapeBase& proxyShape, PXR_NS::UsdStage& stage);
+PXR_NS::SdfLayerHandle getTargetLayerFromAttribute(
+    const MayaUsdProxyShapeBase& proxyShape,
+    const LayerNameMap&          nameMap,
+    PXR_NS::UsdStage&            stage);
 
 /*! \brief copy the stage target layer in the corresponding attribute of the proxy shape.
  */
@@ -81,8 +89,10 @@ copyTargetLayerFromAttribute(const MayaUsdProxyShapeBase& proxyShape, PXR_NS::Us
  * exists on the given stage, the edit target layer could be a local layer or non local layer.
  */
 MAYAUSD_CORE_PUBLIC
-PXR_NS::UsdEditTarget
-getEditTargetFromAttribute(const MayaUsdProxyShapeBase& proxyShape, PXR_NS::UsdStage& stage);
+PXR_NS::UsdEditTarget getEditTargetFromAttribute(
+    const MayaUsdProxyShapeBase& proxyShape,
+    const LayerNameMap&          nameMap,
+    PXR_NS::UsdStage&            stage);
 
 } // namespace MAYAUSD_NS_DEF
 

--- a/lib/mayaUsd/utils/targetLayer.h
+++ b/lib/mayaUsd/utils/targetLayer.h
@@ -20,6 +20,7 @@
 #include <mayaUsd/nodes/proxyShapeBase.h>
 
 #include <pxr/usd/sdf/layer.h>
+#include <pxr/usd/usd/editTarget.h>
 #include <pxr/usd/usd/stage.h>
 
 #include <maya/MApiNamespace.h>
@@ -75,6 +76,13 @@ copyTargetLayerToAttribute(const PXR_NS::UsdStage& stage, MayaUsdProxyShapeBase&
 MAYAUSD_CORE_PUBLIC
 MStatus
 copyTargetLayerFromAttribute(const MayaUsdProxyShapeBase& proxyShape, PXR_NS::UsdStage& stage);
+
+/*! \brief get the edit target from data in the corresponding attribute of the proxy shape if it
+ * exists on the given stage, the edit target layer could be a local layer or non local layer.
+ */
+MAYAUSD_CORE_PUBLIC
+PXR_NS::UsdEditTarget
+getEditTargetFromAttribute(const MayaUsdProxyShapeBase& proxyShape, PXR_NS::UsdStage& stage);
 
 } // namespace MAYAUSD_NS_DEF
 

--- a/test/lib/mayaUsd/fileio/CMakeLists.txt
+++ b/test/lib/mayaUsd/fileio/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TEST_SCRIPT_FILES
     testDisplayLayerSaveRestore.py
     testSaveMutedAnonLayer.py
     testSaveLockedAnonLayer.py
+    testNonLocalEditTargetLayer.py
 
     # Once of the tests in this file requires UsdMaya (from the Pixar plugin). That test
     # will be skipped if not found (probably because BUILD_PXR_PLUGIN is off).

--- a/test/lib/mayaUsd/fileio/NonLocalEditTargetLayerTest/nested_reference_geo.usda
+++ b/test/lib/mayaUsd/fileio/NonLocalEditTargetLayerTest/nested_reference_geo.usda
@@ -1,0 +1,12 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+)
+
+def Xform "root"{
+    def Xform "group"{
+        def Xform "sphere"
+        {
+        }
+    }
+}

--- a/test/lib/mayaUsd/fileio/NonLocalEditTargetLayerTest/outer_sub_layer.usda
+++ b/test/lib/mayaUsd/fileio/NonLocalEditTargetLayerTest/outer_sub_layer.usda
@@ -1,0 +1,10 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+)
+
+def Xform "root"  (
+    prepend references = @./reference_geo.usda@
+)
+{
+}

--- a/test/lib/mayaUsd/fileio/NonLocalEditTargetLayerTest/reference_geo.usda
+++ b/test/lib/mayaUsd/fileio/NonLocalEditTargetLayerTest/reference_geo.usda
@@ -1,0 +1,17 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+)
+
+def Xform "root"
+{
+    def Xform "group"
+    {
+        def Xform "sphere" (
+            kind = "component"
+            prepend references = @./nested_reference_geo.usda@
+        )
+        {
+        }
+    }
+}

--- a/test/lib/mayaUsd/fileio/NonLocalEditTargetLayerTest/root_layer.usda
+++ b/test/lib/mayaUsd/fileio/NonLocalEditTargetLayerTest/root_layer.usda
@@ -1,0 +1,11 @@
+#usda 1.0
+(
+    defaultPrim = "root"
+    subLayers = [
+        @./outer_sub_layer.usda@
+    ]
+)
+
+def "root"
+{
+}

--- a/test/lib/mayaUsd/fileio/testNonLocalEditTargetLayer.py
+++ b/test/lib/mayaUsd/fileio/testNonLocalEditTargetLayer.py
@@ -76,8 +76,7 @@ class NonLocalEditTargetLayer(unittest.TestCase):
         # For this particular case, the layer should be the deepest "nested_reference_geo.usda" layer
         targetLayer = primNode.layerStack.identifier.rootLayer
         self.assertTrue(targetLayer)
-        targetLayerId = targetLayer.identifier
-        self.assertEqual(targetLayerId, os.path.join(testDir, 'data', 'nested_reference_geo.usda'))
+        self.assertEqual(targetLayer.realPath, os.path.join(testDir, 'data', 'nested_reference_geo.usda'))
         # Verify target layer that it is **not** in stage layer stack
         self.assertNotIn(targetLayer, stage.GetLayerStack())
         # Verify current edit target layer is not the target layer
@@ -113,8 +112,8 @@ class NonLocalEditTargetLayer(unittest.TestCase):
         stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
         self.assertTrue(stage)
         # Verify edit target layer id
-        # The layer id should equal to the file path
-        self.assertEqual(stage.GetEditTarget().GetLayer().identifier, targetLayerPath)
+        # The layer real path should equal to the file path
+        self.assertEqual(stage.GetEditTarget().GetLayer().realPath, targetLayerPath)
 
         return stage
 

--- a/test/lib/mayaUsd/fileio/testNonLocalEditTargetLayer.py
+++ b/test/lib/mayaUsd/fileio/testNonLocalEditTargetLayer.py
@@ -55,152 +55,179 @@ class NonLocalEditTargetLayer(unittest.TestCase):
     def setUp(self):
         cmds.file(new=True, force=True)
 
-    def _runTestNonLocalEditTargetLayer(self, saveLocation):
+    def _prepareStage(self, testDir):
         # Localize the test data to the temp location to avoid
         # saving mode 1 (save all edits back to usd files) to write back changes
         # to original USD file, that would prevent from re-running the unit test
-        with testUtils.TemporaryDirectory(prefix='NonLocalEditTargetLayerTest', ignore_errors=True) as testDir:
-            shutil.copytree(self.testDataDir, os.path.join(testDir, 'data'))
+        shutil.copytree(self.testDataDir, os.path.join(testDir, 'data'))
 
-            rootLayerPath = os.path.join(testDir, 'data', 'root_layer.usda')
-            # create new stage
-            proxyShapePath, stage = mayaUtils.createProxyFromFile(rootLayerPath)
+        rootLayerPath = os.path.join(testDir, 'data', 'root_layer.usda')
+        # create new stage
+        proxyShapePath, stage = mayaUtils.createProxyFromFile(rootLayerPath)
 
-            # the "sphere" variant prim should be loaded
-            spherePrim = stage.GetPrimAtPath('/root/group/sphere/group/sphere')
-            self.assertTrue(spherePrim.IsValid())
-            prim = stage.GetPrimAtPath('/root/group/sphere/group')
-            self.assertTrue(spherePrim.IsValid())
-            # Find the nested pcp node
-            primNode = prim.GetPrimIndex().rootNode.children[0].children[0]
-            self.assertTrue(primNode)
-            # For this particular case, the layer should be the deepest "geo.usda" layer
-            targetLayer = primNode.layerStack.identifier.rootLayer
-            self.assertTrue(targetLayer)
-            targetLayerId = targetLayer.identifier
-            # Verify target layer that it is **not** in stage layer stack
-            self.assertNotIn(targetLayer, stage.GetLayerStack())
-            # Verify current edit target layer is not the target layer
-            self.assertNotEqual(stage.GetEditTarget().GetLayer(), targetLayer)
-            # Change edit target layer to the non-local edit target layer
-            stage.SetEditTarget(Usd.EditTarget(targetLayer, primNode))
-            # Verify edit target layer
-            self.assertEqual(stage.GetEditTarget().GetLayer(), targetLayer)
-            # Dirty the non-local edit target layer, the path in nested layer
-            # will be mapped like this on the stage level:
-            #    /root/group/sphere/group/newXform
-            newXform = Sdf.CreatePrimInLayer(targetLayer, '/root/group/newXform')
-            newXform.specifier = Sdf.SpecifierDef
-            newXform.typeName = 'Xform'
+        # the "sphere" variant prim should be loaded
+        spherePrim = stage.GetPrimAtPath('/root/group/sphere/group/sphere')
+        self.assertTrue(spherePrim.IsValid())
+        prim = stage.GetPrimAtPath('/root/group/sphere/group')
+        self.assertTrue(spherePrim.IsValid())
+        # Find the nested pcp node
+        primNode = prim.GetPrimIndex().rootNode.children[0].children[0]
+        self.assertTrue(primNode)
+        # For this particular case, the layer should be the deepest "nested_reference_geo.usda" layer
+        targetLayer = primNode.layerStack.identifier.rootLayer
+        self.assertTrue(targetLayer)
+        targetLayerId = targetLayer.identifier
+        self.assertEqual(targetLayerId, os.path.join(testDir, 'data', 'nested_reference_geo.usda'))
+        # Verify target layer that it is **not** in stage layer stack
+        self.assertNotIn(targetLayer, stage.GetLayerStack())
+        # Verify current edit target layer is not the target layer
+        self.assertNotEqual(stage.GetEditTarget().GetLayer(), targetLayer)
+        # Change edit target layer to the non-local edit target layer
+        stage.SetEditTarget(Usd.EditTarget(targetLayer, primNode))
+        # Verify edit target layer
+        self.assertEqual(stage.GetEditTarget().GetLayer(), targetLayer)
+        # Dirty the non-local edit target layer, the path in nested layer
+        # will be mapped like this on the stage level:
+        #    /root/group/sphere/group/newXform
+        newXform = Sdf.CreatePrimInLayer(targetLayer, '/root/group/newXform')
+        newXform.specifier = Sdf.SpecifierDef
+        newXform.typeName = 'Xform'
 
-            self.assertTrue(stage.GetPrimAtPath('/root/group/sphere/group/newXform'))
-            self.assertTrue(targetLayer.dirty)
+        self.assertTrue(stage.GetPrimAtPath('/root/group/sphere/group/newXform'))
+        self.assertTrue(targetLayer.dirty)
 
+        return proxyShapePath, stage
+
+    def _saveAndReopen(self, sceneName, testDir, saveLocation, proxyShapePath):
+        targetLayerPath = os.path.join(testDir, 'data', 'nested_reference_geo.usda')
+        # Save and reopen the maya file
+        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', saveLocation))
+        tempMayaFile = os.path.join(testDir, '{}.ma'.format(sceneName))
+        cmds.file(rename=tempMayaFile)
+        cmds.file(save=True, force=True, type='mayaAscii')
+
+        # Verify
+        cmds.file(force=True, new=True)
+        cmds.file(tempMayaFile, open=True, force=True)
+        self.assertTrue(cmds.ls(proxyShapePath))
+        stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
+        self.assertTrue(stage)
+        # Verify edit target layer id
+        # The layer id should equal to the file path
+        self.assertEqual(stage.GetEditTarget().GetLayer().identifier, targetLayerPath)
+
+        return stage
+
+    def _runTestUnmutedUnlocked(self, saveLocation):
+        '''
+        Test preserving non local edit target layer, parent of target layer is unmuted and unlocked.
+        '''
+        caseName = 'UnmutedUnlocked'
+        prefixDir = 'NonLocalEditTargetLayerTest_{}_{}'.format(saveLocation, caseName)
+        with testUtils.TemporaryDirectory(prefix=prefixDir, ignore_errors=True) as testDir:
+            proxyShapePath, _ = self._prepareStage(testDir)
+
+            # Case 1: no muting nor locking parent layer (nothing else to do here)
             # Save and reopen the maya file
-            cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', saveLocation))
+            stage = self._saveAndReopen(caseName, testDir, saveLocation, proxyShapePath)
 
-            # Case 1: no muting nor locking parent layer
-            tempMayaFile = os.path.join(testDir, 'SaveNonLocalEditTargetLayer.ma')
-            cmds.file(rename=tempMayaFile)
-            cmds.file(save=True, force=True, type='mayaAscii')
+            # Verify the prim that created in the edit target layer
+            self.assertTrue(stage.GetPrimAtPath('/root/group/sphere/group/newXform'))
+
+            # Verify the layer was reloaded but not muted nor locked
+            subLayer = Sdf.Layer.Find(os.path.join(testDir, 'data', 'outer_sub_layer.usda'))
+            self.assertIsNotNone(subLayer)
+            self.assertFalse(stage.IsLayerMuted(subLayer.identifier))
+            self.assertFalse(mayaUsd.lib.isLayerLocked(subLayer))
+
+            if saveLocation == 2:
+                # Saving mode 2 writes the dirty layers in Maya scene, thus the USD layers
+                # are still in *dirty* status after reopening
+                self.assertTrue(stage.GetEditTarget().GetLayer().dirty)
+
+    def _runTestUnmutedLocked(self, saveLocation):
+        '''
+        Test preserving non local edit target layer, parent of target layer is unmuted and locked.
+        '''
+        caseName = 'UnmutedLocked'
+        prefixDir = 'NonLocalEditTargetLayerTest_{}_{}'.format(saveLocation, caseName)
+        with testUtils.TemporaryDirectory(prefix=prefixDir, ignore_errors=True) as testDir:
+            proxyShapePath, stage = self._prepareStage(testDir)
 
             # Case 2: lock parent layer, no muting
             subLayerPath = os.path.join(testDir, 'data', 'outer_sub_layer.usda')
-            subLayer = Sdf.Find(subLayerPath)
+
+            subLayer = Sdf.Layer.Find(subLayerPath)
             self.assertIn(subLayer, stage.GetLayerStack())
             mayaUsd.lib.lockLayer(proxyShapePath, subLayer)
 
-            tempMayaFileParentLocked = os.path.join(testDir, 'SaveNonLocalEditTargetLayer_ParentLocked.ma')
-            cmds.file(rename=tempMayaFileParentLocked)
-            cmds.file(save=True, force=True, type='mayaAscii')
+            # Save and reopen the maya file
+            stage = self._saveAndReopen(caseName, testDir, saveLocation, proxyShapePath)
 
-            # Case 3: mute parent layer, no locking
-            subLayer = Sdf.Find(subLayerPath)
-            mayaUsd.lib.unlockLayer(proxyShapePath, subLayer)
-            stage.MuteLayer(subLayer.identifier)
-            tempMayaFileParentMuted = os.path.join(testDir, 'SaveNonLocalEditTargetLayer_ParentMuted.ma')
-            cmds.file(rename=tempMayaFileParentMuted)
-            cmds.file(save=True, force=True, type='mayaAscii')
-
-            # Case 4: mute and lock parent layer
-            stage.UnmuteLayer(subLayerPath)
-            subLayer = Sdf.Find(subLayerPath)
-            mayaUsd.lib.lockLayer(proxyShapePath, subLayer)
-            stage.MuteLayer(subLayer.identifier)
-            tempMayaFileParentMutedLocked = os.path.join(testDir, 'SaveNonLocalEditTargetLayer_ParentMutedLocked.ma')
-            cmds.file(rename=tempMayaFileParentMutedLocked)
-            cmds.file(save=True, force=True, type='mayaAscii')
-
-            # Verify case 1
-            cmds.file(force=True, new=True)
-            cmds.file(tempMayaFile, open=True, force=True)
-            self.assertTrue(cmds.ls(proxyShapePath))
-            stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
-            self.assertTrue(stage)
-            # Verify edit target layer id
-            self.assertEqual(stage.GetEditTarget().GetLayer().identifier, targetLayerId)
-            # Verify the prim that created in the edit target layer
-            self.assertTrue(stage.GetPrimAtPath('/root/group/sphere/group/newXform'))
-            subLayer = Sdf.Layer.FindOrOpen(subLayerPath)
-            self.assertIsNotNone(subLayer)
-            # Verify the layer was reloaded but not muted nor locked
-            self.assertFalse(stage.IsLayerMuted(subLayer.identifier))
-            self.assertFalse(mayaUsd.lib.isLayerLocked(subLayer))
-            if saveLocation == 2:
-                # Saving mode 2 writes the dirty layers in Maya scene, thus the USD layers
-                # are still in *dirty* status after reopening
-                self.assertTrue(stage.GetEditTarget().GetLayer().dirty)
-
-            # Verify case 2: parent layer locked
-            cmds.file(force=True, new=True)
-            cmds.file(tempMayaFileParentLocked, open=True, force=True)
-            self.assertTrue(cmds.ls(proxyShapePath))
-            stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
-            self.assertTrue(stage)
-            # Verify edit target layer id
-            self.assertEqual(stage.GetEditTarget().GetLayer().identifier, targetLayerId)
             # Parent layer locked, the prim is still accessible
             self.assertTrue(stage.GetPrimAtPath('/root/group/sphere/group/newXform'))
-            subLayer = Sdf.Layer.FindOrOpen(subLayerPath)
-            self.assertIsNotNone(subLayer)
             # Verify the layer was reloaded as locked and not muted
+            subLayer = Sdf.Layer.Find(os.path.join(testDir, 'data', 'outer_sub_layer.usda'))
+            self.assertIsNotNone(subLayer)
             self.assertFalse(stage.IsLayerMuted(subLayer.identifier))
             self.assertTrue(mayaUsd.lib.isLayerLocked(subLayer))
+
             if saveLocation == 2:
                 # Saving mode 2 writes the dirty layers in Maya scene, thus the USD layers
                 # are still in *dirty* status after reopening
                 self.assertTrue(stage.GetEditTarget().GetLayer().dirty)
 
-            # Verify case 3: parent layer muted
-            cmds.file(force=True, new=True)
-            cmds.file(tempMayaFileParentMuted, open=True, force=True)
-            self.assertTrue(cmds.ls(proxyShapePath))
-            stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
-            self.assertTrue(stage)
-            # Verify edit target layer id
-            self.assertEqual(stage.GetEditTarget().GetLayer().identifier, targetLayerId)
+    def _runTestMutedUnlocked(self, saveLocation):
+        '''
+        Test preserving non local edit target layer, parent of target layer is muted and unlocked.
+        '''
+        caseName = 'MutedUnlocked'
+        prefixDir = 'NonLocalEditTargetLayerTest_{}_{}'.format(saveLocation, caseName)
+        with testUtils.TemporaryDirectory(prefix=prefixDir, ignore_errors=True) as testDir:
+            proxyShapePath, stage = self._prepareStage(testDir)
+
+            # Case 3: mute parent layer, no locking
+            subLayerPath = os.path.join(testDir, 'data', 'outer_sub_layer.usda')
+            subLayer = Sdf.Layer.Find(subLayerPath)
+            stage.MuteLayer(subLayer.identifier)
+
+            # Save and reopen the maya file
+            stage = self._saveAndReopen(caseName, testDir, saveLocation, proxyShapePath)
+
             # Parent layer muted, the prim is not accessible
             self.assertFalse(stage.GetPrimAtPath('/root/group/sphere/group/newXform'))
-            subLayer = Sdf.Layer.FindOrOpen(subLayerPath)
-            self.assertIsNotNone(subLayer)
             # Verify the layer was reloaded as muted and not locked
-            self.assertTrue(stage.IsLayerMuted(subLayer.identifier))
-            self.assertFalse(mayaUsd.lib.isLayerLocked(subLayer))
+            self.assertIsNone(Sdf.Layer.Find(subLayerPath))
+            self.assertTrue(stage.IsLayerMuted(subLayerPath))
+            self.assertFalse(mayaUsd.lib.isLayerLocked(Sdf.Layer.FindOrOpen(subLayerPath)))
             # The dirty layer was muted before saving, the layer manager won't be able
             # to find the dirty layer (the nested layer) thus the content won't be saved.
             self.assertFalse(stage.GetEditTarget().GetLayer().dirty)
 
-            # Verify case 4: parent layer muted and locked
-            cmds.file(force=True, new=True)
-            cmds.file(tempMayaFileParentMutedLocked, open=True, force=True)
-            self.assertTrue(cmds.ls(proxyShapePath))
-            stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
-            self.assertTrue(stage)
-            # Verify edit target layer id
-            self.assertEqual(stage.GetEditTarget().GetLayer().identifier, targetLayerId)
+    def _runTestMutedLocked(self, saveLocation):
+        '''
+        Test preserving non local edit target layer, parent of target layer is muted and locked.
+        '''
+        caseName = 'MutedLocked'
+        prefixDir = 'NonLocalEditTargetLayerTest_{}_{}'.format(saveLocation, caseName)
+        with testUtils.TemporaryDirectory(prefix=prefixDir, ignore_errors=True) as testDir:
+            proxyShapePath, stage = self._prepareStage(testDir)
+
+            # Case 4: mute and lock parent layer
+            subLayerPath = os.path.join(testDir, 'data', 'outer_sub_layer.usda')
+
+            subLayer = Sdf.Layer.Find(subLayerPath)
+            mayaUsd.lib.lockLayer(proxyShapePath, subLayer)
+            stage.MuteLayer(subLayer.identifier)
+
+            # Save and reopen the maya file
+            stage = self._saveAndReopen(caseName, testDir, saveLocation, proxyShapePath)
+
             # Parent layer muted, the prim is not accessible
             self.assertFalse(stage.GetPrimAtPath('/root/group/sphere/group/newXform'))
-            subLayer = Sdf.Layer.FindOrOpen(subLayerPath)
+            # Note: MayaUSD inserts the locking layer in local layer stack to keep a reference of it
+            #       thus the layer can still be found even it had been muted
+            subLayer = Sdf.Layer.Find(subLayerPath)
             self.assertIsNotNone(subLayer)
             # Verify the layer was reloaded as muted
             self.assertTrue(stage.IsLayerMuted(subLayer.identifier))
@@ -210,17 +237,53 @@ class NonLocalEditTargetLayer(unittest.TestCase):
             # to find the dirty layer (the nested layer) thus the content won't be saved.
             self.assertFalse(stage.GetEditTarget().GetLayer().dirty)
 
-    def testNonLocalEditTargetLayerInUSD(self):
+    def testSaveInUSDUnmutedUnlocked(self):
         '''
-        Test saving and restoring non local edit target layer, dirty layers are saved in USD.
+        Test preserving non local edit target layer, save dirty layers in USD, parent of target layer is unmuted and unlocked.
         '''
-        self._runTestNonLocalEditTargetLayer(1)
+        self._runTestUnmutedUnlocked(1)
 
-    def testNonLocalEditTargetLayerInMaya(self):
+    def testSaveInUSDUnmutedLocked(self):
         '''
-        Test saving and restoring non local edit target layer, dirty layers are saved in Maya.
+        Test preserving non local edit target layer, save dirty layers in USD, parent of target layer is unmuted and locked.
         '''
-        self._runTestNonLocalEditTargetLayer(2)
+        self._runTestUnmutedLocked(1)
+
+    def testSaveInUSDMutedUnlocked(self):
+        '''
+        Test preserving non local edit target layer, save dirty layers in USD, parent of target layer is muted and unlocked.
+        '''
+        self._runTestMutedUnlocked(1)
+
+    def testSaveInUSDMutedLocked(self):
+        '''
+        Test preserving non local edit target layer, save dirty layers in USD, parent of target layer is muted and locked.
+        '''
+        self._runTestMutedLocked(1)
+
+    def testSaveInMayaUnmutedUnlocked(self):
+        '''
+        Test preserving non local edit target layer, save dirty layers in Maya, parent of target layer is unmuted and unlocked.
+        '''
+        self._runTestUnmutedUnlocked(2)
+
+    def testSaveInMayaUnmutedLocked(self):
+        '''
+        Test preserving non local edit target layer, save dirty layers in Maya, parent of target layer is unmuted and locked.
+        '''
+        self._runTestUnmutedLocked(2)
+
+    def testSaveInMayaMutedUnlocked(self):
+        '''
+        Test preserving non local edit target layer, save dirty layers in Maya, parent of target layer is muted and unlocked.
+        '''
+        self._runTestMutedUnlocked(2)
+
+    def testSaveInMayaMutedLocked(self):
+        '''
+        Test preserving non local edit target layer, save dirty layers in Maya, parent of target layer is muted and locked.
+        '''
+        self._runTestMutedLocked(2)
 
 
 if __name__ == '__main__':

--- a/test/lib/mayaUsd/fileio/testNonLocalEditTargetLayer.py
+++ b/test/lib/mayaUsd/fileio/testNonLocalEditTargetLayer.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2024 Animal Logic
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import unittest
+import shutil
+
+from pxr import Usd, Sdf
+
+from maya import cmds
+from maya import standalone
+
+import mayaUsd
+
+import fixturesUtils
+import testUtils
+import mayaUtils
+
+
+class NonLocalEditTargetLayer(unittest.TestCase):
+    '''
+    Test saving and restoring non local edit target layer.
+    '''
+
+    pluginsLoaded = False
+
+    @classmethod
+    def setUpClass(cls):
+        inputPath = fixturesUtils.setUpClass(__file__)
+
+        if not cls.pluginsLoaded:
+            cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+        cls.testDataDir = os.path.join(inputPath, 'NonLocalEditTargetLayerTest')
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def setUp(self):
+        cmds.file(new=True, force=True)
+
+    def _runTestNonLocalEditTargetLayer(self, saveLocation):
+        # Localize the test data to the temp location to avoid
+        # saving mode 1 (save all edits back to usd files) to write back changes
+        # to original USD file, that would prevent from re-running the unit test
+        with testUtils.TemporaryDirectory(prefix='NonLocalEditTargetLayerTest', ignore_errors=True) as testDir:
+            shutil.copytree(self.testDataDir, os.path.join(testDir, 'data'))
+
+            rootLayerPath = os.path.join(testDir, 'data', 'root_layer.usda')
+            # create new stage
+            proxyShapePath, stage = mayaUtils.createProxyFromFile(rootLayerPath)
+
+            # the "sphere" variant prim should be loaded
+            spherePrim = stage.GetPrimAtPath('/root/group/sphere/group/sphere')
+            self.assertTrue(spherePrim.IsValid())
+            prim = stage.GetPrimAtPath('/root/group/sphere/group')
+            self.assertTrue(spherePrim.IsValid())
+            # Find the nested pcp node
+            primNode = prim.GetPrimIndex().rootNode.children[0].children[0]
+            self.assertTrue(primNode)
+            # For this particular case, the layer should be the deepest "geo.usda" layer
+            targetLayer = primNode.layerStack.identifier.rootLayer
+            self.assertTrue(targetLayer)
+            targetLayerId = targetLayer.identifier
+            # Verify target layer that it is **not** in stage layer stack
+            self.assertNotIn(targetLayer, stage.GetLayerStack())
+            # Verify current edit target layer is not the target layer
+            self.assertNotEqual(stage.GetEditTarget().GetLayer(), targetLayer)
+            # Change edit target layer to the non-local edit target layer
+            stage.SetEditTarget(Usd.EditTarget(targetLayer, primNode))
+            # Verify edit target layer
+            self.assertEqual(stage.GetEditTarget().GetLayer(), targetLayer)
+            # Dirty the non-local edit target layer, the path in nested layer
+            # will be mapped like this on the stage level:
+            #    /root/group/sphere/group/newXform
+            newXform = Sdf.CreatePrimInLayer(targetLayer, '/root/group/newXform')
+            newXform.specifier = Sdf.SpecifierDef
+            newXform.typeName = 'Xform'
+
+            self.assertTrue(stage.GetPrimAtPath('/root/group/sphere/group/newXform'))
+            self.assertTrue(targetLayer.dirty)
+
+            # Save and reopen the maya file
+            cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', saveLocation))
+
+            tempMayaFile = os.path.join(testDir, 'SaveNonLocalEditTargetLayer.ma')
+            cmds.file(rename=tempMayaFile)
+            cmds.file(save=True, force=True, type='mayaAscii')
+
+            # Reopen the saved scene
+            cmds.file(force=True, new=True)
+            cmds.file(tempMayaFile, open=True, force=True)
+            self.assertTrue(cmds.ls(proxyShapePath))
+
+            stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
+            self.assertTrue(stage)
+
+            # Verify edit target layer id
+            self.assertEqual(stage.GetEditTarget().GetLayer().identifier, targetLayerId)
+
+            # Verify the prim that created in the edit target layer
+            self.assertTrue(stage.GetPrimAtPath('/root/group/sphere/group/newXform'))
+            return stage
+
+    def testNonLocalEditTargetLayerInUSD(self):
+        '''
+        Test saving and restoring non local edit target layer, dirty layers are saved in USD.
+        '''
+        self._runTestNonLocalEditTargetLayer(1)
+
+    def testNonLocalEditTargetLayerInMaya(self):
+        '''
+        Test saving and restoring non local edit target layer, dirty layers are saved in Maya.
+        '''
+        stage = self._runTestNonLocalEditTargetLayer(2)
+        # Saving mode 2 writes the dirty layers in Maya scene, thus the USD layers
+        # are still in *dirty* status after reopening
+        self.assertTrue(stage.GetEditTarget().GetLayer().dirty)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/mayaUsd/nodes/testProxyShapeBase.py
+++ b/test/lib/mayaUsd/nodes/testProxyShapeBase.py
@@ -756,6 +756,57 @@ class testProxyShapeBase(unittest.TestCase):
         self.assertListEqual(list(stage.GetRootLayer().subLayerPaths), [subLayer.identifier])
         verifyTargetLayer(stage)
 
+    def testStageAnonymousRootLayerInMaya(self):
+        '''
+        Verify that stage preserve the anonymous root layer of the stage when a scene is reloaded.
+        '''
+        # Create new scene
+        cmds.file(new=True, force=True)
+
+        # Prepare anonymous root layer
+        anonRootLayer = Sdf.Layer.CreateAnonymous()
+        anonRootLayerId = anonRootLayer.identifier
+        primSpec = Sdf.CreatePrimInLayer(anonRootLayer, '/root_xform')
+        primSpec.specifier = Sdf.SpecifierDef
+        primSpec.typeName = 'Xform'
+
+        # Create an empty proxy shape
+        mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        # Set root layer file path to the newly created anonymous layer
+        cmds.setAttr('|stage1|stageShape1.filePath', anonRootLayer.identifier, type='string')
+        filePath = cmds.getAttr('|stage1|stageShape1.filePath')
+        self.assertEqual(anonRootLayerId, filePath)
+
+        stage = mayaUsd.lib.GetPrim('|stage1|stageShape1').GetStage()
+        stage.SetEditTarget(stage.GetRootLayer())
+        self.assertTrue(stage.GetPrimAtPath('/root_xform'))
+
+        # Save and re-open
+        with testUtils.TemporaryDirectory(prefix='ProxyShapeBase') as testDir:
+            # Save the dirty layer along with Maya scene
+            cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 2))
+            tempMayaFile = os.path.join(testDir, 'AnonymousRootLayerTest.ma')
+            cmds.file(rename=tempMayaFile)
+            cmds.file(save=True, force=True)
+
+            # Save the Maya scene.
+            cmds.file(new=True, force=True)
+            cmds.file(tempMayaFile, open=True)
+
+            stage = mayaUsd.lib.GetPrim('|stage1|stageShape1').GetStage()
+            self.assertEqual(stage.GetRootLayer().identifier, stage.GetEditTarget().GetLayer().identifier)
+
+            # Verify the root layer has been recreated and content restored
+            self.assertTrue(stage.GetPrimAtPath('/root_xform'))
+
+            # Verify the .filePath attribute string
+            filePath = cmds.getAttr('|stage1|stageShape1.filePath')
+            self.assertTrue(Sdf.Layer.IsAnonymousLayerIdentifier(filePath))
+            self.assertEqual(stage.GetRootLayer().identifier, filePath)
+            self.assertNotEqual(anonRootLayerId, filePath)
+
+            cmds.file(new=True, force=True)
+
     def testSerializationShareStage(self):
         '''
         Verify share/unshare stage works with serialization and complex heirharchies

--- a/test/lib/mayaUsd/nodes/testProxyShapeBase.py
+++ b/test/lib/mayaUsd/nodes/testProxyShapeBase.py
@@ -756,6 +756,53 @@ class testProxyShapeBase(unittest.TestCase):
         self.assertListEqual(list(stage.GetRootLayer().subLayerPaths), [subLayer.identifier])
         verifyTargetLayer(stage)
 
+    def testStageAnonymousSubLayerAsTargetLayer(self):
+        '''
+        Verify that stage preserve the anonymous sub layer edit target layer when a scene is reloaded.
+        '''
+        # Create new scene
+        cmds.file(new=True, force=True)
+
+        # Create an empty scene
+        shapePath = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        stage = mayaUsd.lib.GetPrim(shapePath).GetStage()
+
+        stage.SetEditTarget(stage.GetSessionLayer())
+
+        # Add a sub-layer and target it.
+        subLayer = Sdf.Layer.CreateAnonymous()
+        stage.GetSessionLayer().subLayerPaths.append(subLayer.identifier)
+        stage.SetEditTarget(subLayer)
+
+        def verifyTargetLayer(stage):
+            self.assertNotEqual(stage.GetSessionLayer().identifier, stage.GetEditTarget().GetLayer().identifier)
+            self.assertNotEqual(stage.GetRootLayer().identifier, stage.GetEditTarget().GetLayer().identifier)
+
+        verifyTargetLayer(stage)
+
+        # Save and re-open
+        with testUtils.TemporaryDirectory(prefix='ProxyShapeBase') as testDir:
+            # Save the dirty layer along with Maya scene
+            cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 2))
+            tempMayaFile = os.path.join(testDir, 'StageAnonymousSubLayerAsTargetLayer.ma')
+            cmds.file(rename=tempMayaFile)
+            cmds.file(save=True, force=True)
+
+            # Save the Maya scene.
+            cmds.file(new=True, force=True)
+            cmds.file(tempMayaFile, open=True)
+
+            stage = mayaUsd.lib.GetPrim('|stage1|stageShape1').GetStage()
+            self.assertEqual(len(list(stage.GetSessionLayer().subLayerPaths)), 1)
+            verifyTargetLayer(stage)
+
+            subLayer = stage.GetSessionLayer().subLayerPaths[0]
+
+            self.assertTrue(Sdf.Layer.IsAnonymousLayerIdentifier(subLayer))
+            self.assertEqual(stage.GetEditTarget().GetLayer().identifier, subLayer)
+
+            cmds.file(new=True, force=True)
+
     def testStageAnonymousRootLayerInMaya(self):
         '''
         Verify that stage preserve the anonymous root layer of the stage when a scene is reloaded.


### PR DESCRIPTION
This PR aims to fix [issue-3637](https://github.com/Autodesk/maya-usd/issues/3637), the changes include three different but still highly related problems all together, I have split them to cover their own problems and added unit test accordingly:

- 0c28b99ab78ffa99d694c9f6d2df3481d2d292d3:
  -  Fixes the non local edit target layer issue by extending `stage->GetLayerStack()` to be `stage->GetUsedLayers()` to include reference layers and their sub layers which are not visible in local layer stack;
  - The main code to locate a non local layer when restoring is in [`copyTargetLayerToAttribute()`](https://github.com/Autodesk/maya-usd/commit/0c28b99ab78ffa99d694c9f6d2df3481d2d292d3#diff-3003792a8ba0c46971021e5768a07b291f62eae545db8b0ffda15b215e1f89faR123) and [`findPrimNode()`](https://github.com/Autodesk/maya-usd/commit/0c28b99ab78ffa99d694c9f6d2df3481d2d292d3#diff-3003792a8ba0c46971021e5768a07b291f62eae545db8b0ffda15b215e1f89faR40) functions in file `utils/targetLayer.cpp`, it has assumption that: if a non local edit target layer can be constructed by a PrimNode, there must be at least one valid prim path contributes to the final composition, which must be able to find it at the time when reopening, this is the reason the code serializes one reference prim path in [`copyTargetLayerToAttribute()` function at  `utils/targetLayer.cpp#L141`](https://github.com/Autodesk/maya-usd/commit/0c28b99ab78ffa99d694c9f6d2df3481d2d292d3#diff-3003792a8ba0c46971021e5768a07b291f62eae545db8b0ffda15b215e1f89faR141), and will need it to reconstruct the edit target in [`getEditTargetFromAttribute()` function at line 233](https://github.com/Autodesk/maya-usd/commit/0c28b99ab78ffa99d694c9f6d2df3481d2d292d3#diff-3003792a8ba0c46971021e5768a07b291f62eae545db8b0ffda15b215e1f89faR233).
  - We use this logic internally in our pipeline and it's been working fine for us for a few years, we haven't had other use cases to verify if this logic is also useful for other studios, that said, it's arguable a generic solution to fix this 'non local edit target layer' issue.
  - A unit test `test/lib/mayaUsd/fileio/testNonLocalEditTargetLayer.py` has been provided to demo the typical use case we have.
- 49d0435937b50c8a810bd7fa6e3a2758f60f4320:
  - Fixes the problem where the root layer was anonymous layer
  - The unit test [testStageAnonymousRootLayerInMaya](https://github.com/Autodesk/maya-usd/commit/49d0435937b50c8a810bd7fa6e3a2758f60f4320#diff-e10676769455b9e59ce01cd801bdd81a62aa99798308d3a9b31eb81346247956R759) demo-ed our use case in our pipeline that we usually configure and setup the stage (from a URI or in-memory) somewhere else, then we load the stage into Maya by creating the proxy shape and set the **.filePath** to visualize the content, this is why we have a root layer path point to an anonymous layer id. This commit 49d0435937b50c8a810bd7fa6e3a2758f60f4320 was trying to correct the **.filePath** attribute to be the newly created anonymous root layer.
- 06b157df4c14770c805f7e959561c7799d39c454:
  - This is kind of related to the anonymous root layer issue but it's a different case to address if edit target layer was an anonymous sub layer