### PR TITLE
EMSUSD-1092 fix layer editor refresh when reloading from AE

### DIFF
--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -1078,8 +1078,8 @@ private:
 
     void _notifySystemLockIsRefreshed()
     {
-        UsdUfe::UICallback::Ptr dstCallback = UsdUfe::getUICallback(TfToken("onRefreshSystemLock"));
-        if (!dstCallback)
+        auto dstCallbacks = UsdUfe::getUICallbacks(TfToken("onRefreshSystemLock"));
+        if (dstCallbacks.size() == 0)
             return;
 
         PXR_NS::VtDictionary callbackContext;
@@ -1095,7 +1095,8 @@ private:
         VtStringArray lockedArray(affectedLayers.begin(), affectedLayers.end());
         callbackData["affectedLayerIds"] = lockedArray;
 
-        (*dstCallback)(callbackContext, callbackData);
+        for (UsdUfe::UICallback::Ptr& dstCallback : dstCallbacks)
+            (*dstCallback)(callbackContext, callbackData);
     }
 
     UsdStageWeakPtr getStage()

--- a/lib/mayaUsd/python/__init__.py
+++ b/lib/mayaUsd/python/__init__.py
@@ -15,3 +15,4 @@ from usdUfe import restoreAllDefaultEditRouters
 from usdUfe import OperationEditRouterContext
 from usdUfe import AttributeEditRouterContext
 from usdUfe import registerUICallback
+from usdUfe import unregisterUICallback

--- a/lib/usd/ui/layerEditor/layerTreeView.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeView.cpp
@@ -54,6 +54,28 @@ void doCallMethodOnSelection(const CallMethodParams& params, simpleLayerMethod m
     }
 }
 
+class LayerTreeViewRefreshCallback : public UsdUfe::UICallback
+{
+public:
+    LayerTreeViewRefreshCallback(LayerTreeView* treeView)
+        : UICallback()
+        , _treeView(treeView)
+    {
+    }
+
+    void
+    operator()(const PXR_NS::VtDictionary& context, PXR_NS::VtDictionary& callbackData) override
+    {
+        if (!_treeView)
+            return;
+
+        _treeView->repaint();
+    }
+
+private:
+    LayerTreeView* _treeView;
+};
+
 } // namespace
 
 namespace UsdLayerEditor {
@@ -123,6 +145,17 @@ LayerTreeView::LayerTreeView(SessionState* in_sessionState, QWidget* in_parent)
         auto            lockAction = new QAction(lockActionInfo._name, this);
         connect(lockAction, &QAction::triggered, this, &LayerTreeView::onLockLayerButtonPushed);
         _actionButtons._staticActions.push_back(lockAction);
+    }
+
+    _refreshCallback = std::make_shared<LayerTreeViewRefreshCallback>(this);
+    UsdUfe::registerUICallback(PXR_NS::TfToken("onRefreshSystemLock"), _refreshCallback);
+}
+
+LayerTreeView::~LayerTreeView()
+{
+    if (_refreshCallback) {
+        UsdUfe::unregisterUICallback(PXR_NS::TfToken("onRefreshSystemLock"), _refreshCallback);
+        _refreshCallback.reset();
     }
 }
 

--- a/lib/usd/ui/layerEditor/layerTreeView.h
+++ b/lib/usd/ui/layerEditor/layerTreeView.h
@@ -20,6 +20,8 @@
 #include "layerTreeViewStyle.h"
 #include "sessionState.h"
 
+#include <usdUfe/utils/uiCallback.h>
+
 #include <QtCore/QPointer>
 #include <QtWidgets/QTreeView>
 
@@ -72,6 +74,7 @@ class LayerTreeView : public QTreeView
 public:
     typedef QTreeView PARENT_CLASS;
     LayerTreeView(SessionState* in_sessionState, QWidget* in_parent);
+    ~LayerTreeView() override;
 
     // get properly typed item
     LayerTreeItem* layerItemFromIndex(const QModelIndex& index) const;
@@ -131,6 +134,8 @@ protected:
     LayerTreeItemDelegate*   _delegate;
 
     std::unique_ptr<LayerViewMemento> _cachedModelState;
+
+    UsdUfe::UICallback::Ptr _refreshCallback;
 
     // the mute button area has a different implementation than
     // the target button. It is based on Maya's renderSetup

--- a/lib/usdUfe/utils/uiCallback.h
+++ b/lib/usdUfe/utils/uiCallback.h
@@ -43,16 +43,20 @@ public:
         = 0;
 };
 
-using UICallbacks
-    = PXR_NS::TfHashMap<PXR_NS::TfToken, UICallback::Ptr, PXR_NS::TfToken::HashFunctor>;
+using UICallbacks = PXR_NS::
+    TfHashMap<PXR_NS::TfToken, std::vector<UICallback::Ptr>, PXR_NS::TfToken::HashFunctor>;
 
-// Retrieve the callback for the argument operation.  If no such callbacks exits, a nullptr is
-// returned.
+// Retrieve the callbacks for the argument operation.
+// If no such callback exists, an empty vector is returned.
 USDUFE_PUBLIC
-UICallback::Ptr getUICallback(const PXR_NS::TfToken& operation);
+const std::vector<UICallback::Ptr>& getUICallbacks(const PXR_NS::TfToken& operation);
 
 // Register an callback for the argument operation.
 USDUFE_PUBLIC
 void registerUICallback(const PXR_NS::TfToken& operation, const UICallback::Ptr& uiCallback);
+
+// Unregister an callback for the argument operation.
+USDUFE_PUBLIC
+void unregisterUICallback(const PXR_NS::TfToken& operation, const UICallback::Ptr& uiCallback);
 
 } // namespace USDUFE_NS_DEF


### PR DESCRIPTION
- Support having multiple callbacks for a given UI callback.
- Support having multiple callbacks from Python.
- Support unregistering a callback.
- Register a UI callback for the onRefreshSystemLock"" notification in the layer view.
- Repaint when receiving that notification.