### PR TITLE
EMSUSD-1179 Fixed an issue exporting USD skel with new root option

### DIFF
--- a/lib/mayaUsd/fileio/translators/skelBindingsProcessor.cpp
+++ b/lib/mayaUsd/fileio/translators/skelBindingsProcessor.cpp
@@ -52,8 +52,11 @@ static UsdPrim _FindRootmostXformOrSkelRoot(const UsdStagePtr& stage, const SdfP
 /// already a SkelRoot, so no renaming was necessary (false).
 /// If an existing, common SkelRoot cannot be found for all paths, and if
 /// it's not possible to create one, returns an empty SdfPath.
-static SdfPath
-_VerifyOrMakeSkelRoot(const UsdStagePtr& stage, const SdfPath& path, const TfToken& config)
+static SdfPath _VerifyOrMakeSkelRoot(
+    const UsdStagePtr& stage,
+    const SdfPath&     path,
+    const TfToken&     config,
+    const SdfPath&     rootPrimPath)
 {
     if (config != UsdMayaJobExportArgsTokens->auto_
         && config != UsdMayaJobExportArgsTokens->explicit_) {
@@ -93,6 +96,9 @@ _VerifyOrMakeSkelRoot(const UsdStagePtr& stage, const SdfPath& path, const TfTok
             return root.GetPath();
         } else {
             if (path.IsRootPrimPath()) {
+                if (!rootPrimPath.IsEmpty()) {
+                    return SdfPath(rootPrimPath);
+                }
                 // This is the most common problem when we can't obtain a
                 // SkelRoot.
                 // Show a nice error with useful information about root prims.
@@ -127,12 +133,18 @@ void UsdMaya_SkelBindingsProcessor::MarkBindings(
     _bindingToSkelMap[path] = _Entry(skelPath, config);
 }
 
+void UsdMaya_SkelBindingsProcessor::SetRootPrimPath(const SdfPath& rootPrimPath)
+{
+    this->mRootPrimPath = rootPrimPath;
+}
+
 bool UsdMaya_SkelBindingsProcessor::_VerifyOrMakeSkelRoots(const UsdStagePtr& stage) const
 {
     bool success = true;
     for (const auto& pair : _bindingToSkelMap) {
         const _Entry& entry = pair.second;
-        SdfPath       skelRootPath = _VerifyOrMakeSkelRoot(stage, pair.first, entry.second);
+        SdfPath       skelRootPath
+            = _VerifyOrMakeSkelRoot(stage, pair.first, entry.second, mRootPrimPath);
         success = success && !skelRootPath.IsEmpty();
         if (!success) {
             return success;
@@ -149,7 +161,8 @@ bool UsdMaya_SkelBindingsProcessor::UpdateSkelRootsWithExtent(
     bool success = true;
     for (const auto& pair : _bindingToSkelMap) {
         const _Entry& entry = pair.second;
-        SdfPath       skelRootPath = _VerifyOrMakeSkelRoot(stage, pair.first, entry.second);
+        SdfPath       skelRootPath
+            = _VerifyOrMakeSkelRoot(stage, pair.first, entry.second, mRootPrimPath);
         success = success && !skelRootPath.IsEmpty();
         if (success) {
             UsdSkelRoot skelRoot = UsdSkelRoot::Get(stage, skelRootPath);

--- a/lib/mayaUsd/fileio/translators/skelBindingsProcessor.h
+++ b/lib/mayaUsd/fileio/translators/skelBindingsProcessor.h
@@ -25,7 +25,6 @@
 
 #include <maya/MDagPath.h>
 
-#include <set>
 #include <unordered_map>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -47,6 +46,9 @@ public:
     /// mark an invalid binding.
     void MarkBindings(const SdfPath& path, const SdfPath& skelPath, const TfToken& config);
 
+    /// Set the rootPrim path if defined by the user on export
+    void SetRootPrimPath(const SdfPath& rootPrimPath);
+
     /// Performs final processing for skel bindings.
     bool PostProcessSkelBindings(const UsdStagePtr& stage) const;
 
@@ -62,6 +64,8 @@ private:
     using _Entry = std::pair<SdfPath, TfToken>;
 
     std::unordered_map<SdfPath, _Entry, SdfPath::Hash> _bindingToSkelMap;
+
+    SdfPath mRootPrimPath;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/utils/jointWriteUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/jointWriteUtils.cpp
@@ -475,8 +475,15 @@ MObject UsdMayaJointUtil::writeSkinningData(
     }
 
     UsdMayaJointUtil::warnForPostDeformationTransform(usdPath, dagPath, skinCluster);
-
-    skelPath = UsdMayaJointUtil::getSkeletonPath(rootJoint, stripNamespaces);
+    auto jointRootPath = UsdMayaJointUtil::getSkeletonPath(rootJoint, stripNamespaces);
+    if (skelPath.IsEmpty()) {
+        skelPath = jointRootPath;
+    } else {
+        // SdfPath can only append relative path, so remove the '/' at the first index
+        const std::string jointRootPathString = jointRootPath.GetAsString();
+        skelPath = skelPath.AppendPath(
+            SdfPath { jointRootPathString.substr(1, jointRootPathString.size()) });
+    }
 
     // Export will create a Skeleton at the location corresponding to
     // the root joint. Configure this mesh to be bound to the same skel.

--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -695,6 +695,7 @@ void UsdMayaWriteJobContext::MarkSkelBindings(
     const TfToken& config)
 {
     _skelBindingsProcessor->MarkBindings(path, skelPath, config);
+    _skelBindingsProcessor->SetRootPrimPath(mRootPrimPath);
 }
 
 bool UsdMayaWriteJobContext::UpdateSkelBindingsWithExtent(

--- a/lib/usd/translators/jointWriter.cpp
+++ b/lib/usd/translators/jointWriter.cpp
@@ -87,8 +87,17 @@ PxrUsdTranslators_JointWriter::PxrUsdTranslators_JointWriter(
         return;
     }
 
-    SdfPath skelPath
+    SdfPath       skelPath = _GetExportArgs().rootPrim;
+    const SdfPath skeletonPath
         = UsdMayaJointUtil::getSkeletonPath(GetDagPath(), _GetExportArgs().stripNamespaces);
+    if (skelPath.IsEmpty()) {
+        skelPath = skeletonPath;
+    } else {
+        // SdfPath can only append relative path, so remove the '/' at the first index
+        const std::string skeletonPathString = skeletonPath.GetAsString();
+        skelPath = skelPath.AppendPath(
+            SdfPath { skeletonPathString.substr(1, skeletonPathString.size()) });
+    }
 
     _skel = UsdSkelSkeleton::Define(GetUsdStage(), skelPath);
     if (!TF_VERIFY(_skel)) {

--- a/lib/usd/translators/meshWriter.cpp
+++ b/lib/usd/translators/meshWriter.cpp
@@ -374,8 +374,8 @@ bool PxrUsdTranslators_MeshWriter::writeMeshAttrs(
             _skelInputMesh = MObject();
 
         } else {
-
-            SdfPath skelPath;
+            // Make sure to use the user's root prim if they selected when exporting
+            SdfPath skelPath = _GetExportArgs().rootPrim;
             _skelInputMesh = UsdMayaJointUtil::writeSkinningData(
                 primSchema,
                 GetUsdPath(),

--- a/test/lib/usd/translators/testUsdExportSkeleton.py
+++ b/test/lib/usd/translators/testUsdExportSkeleton.py
@@ -261,6 +261,32 @@ class testUsdExportSkeleton(unittest.TestCase):
             cmds.usdExport(mergeTransformAndShape=True, file=usdFile,
                            shadingMode='none', exportSkels='auto')
 
+    def testSkelExportWithNewRoot(self):
+        """
+        It is possible to export joints at scene root level if a new Xform root is created when exporting.
+        The new stage root will then be converted to a SkelRoot
+        """
+        mayaFile = os.path.join(self.inputPath, "UsdExportSkeletonTest", "UsdExportSkeletonAtSceneRoot.ma")
+        cmds.file(mayaFile, force=True, open=True)
+
+        usdFile = os.path.abspath('UsdExportSkeletonNewRootTest.usda')
+
+        cmds.usdExport(mergeTransformAndShape=True, file=usdFile, rootPrimType='xform', exportSkin='auto',
+            exportSkels="auto", rootPrim="testSkel", defaultPrim="testSkel")
+
+        stage = Usd.Stage.Open(usdFile)
+
+        skelRoot = UsdSkel.Root.Get(stage, '/testSkel')
+        self.assertTrue(skelRoot)
+
+        meshPrim = stage.GetPrimAtPath('/testSkel/pCube1')
+        self.assertTrue(meshPrim)
+
+        binding = UsdSkel.BindingAPI.Get(stage, meshPrim.GetPath())
+        self.assertTrue(binding)
+
+        skeleton = UsdSkel.Skeleton.Get(stage, '/testSkel/joint1')
+        self.assertTrue(skeleton.IsValid())
 
     def testSkelForSegfault(self):
         """


### PR DESCRIPTION
There's a issue when exporting USD Skel while creating a new root to the stage, the SkelRoot and Skeleton prim aren't properly created.
This PR fixes this issue allowing the user to not have to group all all elements of the scene under the same group. If the new root is a Xform, it will used that root prim to create the SkelRoot