### PR TITLE
EMSUSD-208 Material custom control for AE

### DIFF
--- a/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
@@ -41,6 +41,13 @@ def mayaUsdLibRegisterStrings():
     register('kLabelMetadata', 'Metadata')
     register('kLabelAppliedSchemas', 'Applied Schemas')
     register('kOpenImage', 'Open')
+    register('kLabelMaterial', 'Material')
+    register('kLabelAssignedMaterial', 'Assigned Material')
+    register('kLabelInheritedMaterial', 'Inherited Material')
+    register('kLabelInheritedFromPrim', 'Inherited from Prim')
+    register('kLabelInheriting', 'inheriting')
+    register('kTooltipInheritingOverDirect', 'This material is being over-ridden due to the strength setting on an ancestor')
+    register('kTooltipInheriting', 'This material is inherited from an ancestor')
 
     # mayaUsdAddMayaReference.py
     register('kErrorGroupPrimExists', 'Group prim "^1s" already exists under "^2s". Choose prim name other than "^1s" to proceed.')


### PR DESCRIPTION
- Added a new material custom control for the attribute editor (AE).
- It creates text fields for the material path, inherited material and ancestor prim path.
- If the material is directly on the prim, the inherited and ancestor fields are hidden.
- If the material is inherited, the material path is set to "inheriting".
- All fields are not editable.
- The direct or inherited material is found by using the ComputeBoundMaterial function from the USD material binding API.
- Added a button to go to the prim from which the material is inherited.
- Insert the material section after the "Mesh" or "Xformable" section, whichever comes first.
- Don't show the material section for materials themselves.