### PR TITLE
EMSUSD-209 graph the material in LookdevX

### DIFF
--- a/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
@@ -78,9 +78,16 @@ def _queueEditorRefresh():
 
 # Custom control, but does not have any UI. Instead we use
 # this control to be notified from UFE when any attribute has changed
-# so we can update the AE. This is to fix refresh issue
-# when transform is added to a prim.
+# so we can update the AE. 
 class UfeAttributesObserver(ufe.Observer):
+    _watchedAttrs = {
+        # This is to fix refresh issue when transform is added to a prim.
+        UsdGeom.Tokens.xformOpOrder,
+        # This is to fix refresh issue when an existing material is assigned
+        # to the prim when it already had a another material.
+        UsdShade.Tokens.materialBinding,
+    }
+
     def __init__(self, item):
         super(UfeAttributesObserver, self).__init__()
         self._item = item
@@ -91,7 +98,7 @@ class UfeAttributesObserver(ufe.Observer):
     def __call__(self, notification):
         refreshEditor = False
         if isinstance(notification, ufe.AttributeValueChanged):
-            if notification.name() == UsdGeom.Tokens.xformOpOrder:
+            if notification.name() in UfeAttributesObserver._watchedAttrs:
                 refreshEditor = True
         if hasattr(ufe, "AttributeAdded") and isinstance(notification, ufe.AttributeAdded):
             refreshEditor = True
@@ -126,6 +133,7 @@ class UfeConnectionChangedObserver(ufe.Observer):
     def onReplace(self, *args):
         # Nothing needed here since we don't create any UI.
         pass
+
 
 class MetaDataCustomControl(object):
     # Custom control for all prim metadata we want to display.

--- a/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
@@ -992,10 +992,10 @@ class AETemplate(object):
         if not mat:
             return
         layoutName = getMayaUsdLibString('kLabelMaterial')
-        collapse = True
+        collapse = False
         with ufeAeTemplate.Layout(self, layoutName, collapse):
             createdControl = MaterialCustomControl(self.item, self.prim, self.useNiceName)
-        self.defineCustom(createdControl)
+            self.defineCustom(createdControl)
 
     def suppressArrayAttribute(self):
         # Suppress all array attributes.

--- a/lib/mayaUsd/resources/ae/usdschemabase/material_custom_control.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/material_custom_control.py
@@ -253,6 +253,8 @@ class MaterialCustomControl(object):
             command = ''
         cmds.popupMenu(menu, edit=True, postMenuCommand=command)
 
+    # Note: the ignore1 and ignore2 parameters are the values provided by the MEL callback
+    #       specifying the menu and item being selected that we don't care about.
     @staticmethod
     def _fillGraphMenu(ignore1, ignore2, menu, ufePathStr):
         '''
@@ -283,6 +285,8 @@ class MaterialCustomControl(object):
                 command = partial(MaterialCustomControl._showInExistingTab, tabName=tabName, ufePathStr=ufePathStr)
                 cmds.menuItem(parent=menu, label=tabName, command=command)
 
+    # Note: the ignore parameter is the value provided by the MEL callback
+    #       specifying the item being selected that we don't care about.
     @staticmethod
     def _showInNewTab(ignore, ufePathStr):
         '''
@@ -293,6 +297,8 @@ class MaterialCustomControl(object):
         tabName = cmds.lookdevXGraph(openNewTab='USD')
         MaterialCustomControl._showInExistingTab(ignore, tabName=tabName, ufePathStr=ufePathStr)
 
+    # Note: the ignore parameter is the value provided by the MEL callback
+    #       specifying the item being selected that we don't care about.
     @staticmethod
     def _showInExistingTab(ignore, tabName, ufePathStr):
         '''

--- a/lib/mayaUsd/resources/ae/usdschemabase/material_custom_control.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/material_custom_control.py
@@ -254,7 +254,7 @@ class MaterialCustomControl(object):
         cmds.popupMenu(menu, edit=True, postMenuCommand=command)
 
     @staticmethod
-    def _fillGraphMenu(*args, menu=None, ufePathStr=None):
+    def _fillGraphMenu(ignore1, ignore2, menu, ufePathStr):
         '''
         Fill the popup menu with menu items for graphing materials when it gets shown to the user.
         '''
@@ -284,17 +284,17 @@ class MaterialCustomControl(object):
                 cmds.menuItem(parent=menu, label=tabName, command=command)
 
     @staticmethod
-    def _showInNewTab(*args, ufePathStr=None):
+    def _showInNewTab(ignore, ufePathStr):
         '''
         Show a material in a new LookdevX tab.
         '''
         if not ufePathStr:
             return
         tabName = cmds.lookdevXGraph(openNewTab='USD')
-        MaterialCustomControl._showInExistingTab(tabName=tabName, ufePathStr=ufePathStr)
+        MaterialCustomControl._showInExistingTab(ignore, tabName=tabName, ufePathStr=ufePathStr)
 
     @staticmethod
-    def _showInExistingTab(*args, tabName=None, ufePathStr=None):
+    def _showInExistingTab(ignore, tabName, ufePathStr):
         '''
         Show a material in a given existing LookdevX tab.
         '''

--- a/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
@@ -52,6 +52,7 @@ def mayaUsdLibRegisterStrings():
     register('kLabelWeakerMaterial', 'Weaker than descendants')
     register('kLabelStrongerMaterial', 'Stronger than descendants')
     register('kTooltipInheritedStrength', 'This setting cannot be changed on this prim due to the strength setting on an ancestor')
+    register('kLabelMaterialNewTab', 'New Tab...')
 
     # mayaUsdAddMayaReference.py
     register('kErrorGroupPrimExists', 'Group prim "^1s" already exists under "^2s". Choose prim name other than "^1s" to proceed.')

--- a/test/lib/testAttributeEditorTemplate.py
+++ b/test/lib/testAttributeEditorTemplate.py
@@ -201,11 +201,16 @@ class AttributeEditorTemplateTestCase(unittest.TestCase):
         self.assertTrue(cmds.formLayout(meshFormLayout, exists=True))
         startLayout = cmds.formLayout(meshFormLayout, query=True, fullPathName=True)
         self.assertIsNotNone(startLayout, 'Could not get full path for Mesh formLayout')
-        
+
+        # In the AE there is a formLayout for each USD prim type. We start
+        # by making sure we can find the one for the mesh.
+        materialFormLayout = self.searchForMayaControl(startLayout, cmds.frameLayout, 'Material')
+        self.assertIsNotNone(materialFormLayout, 'Could not find "Material" frameLayout')
+
         # We can now search for the control for the meterial.
-        assignedMaterialControl = self.searchForMayaControl(meshFormLayout, cmds.text, 'Assigned Material')
+        assignedMaterialControl = self.searchForMayaControl(materialFormLayout, cmds.text, 'Assigned Material')
         self.assertIsNotNone(assignedMaterialControl, 'Could not find the "Assigned Material" control')
-        strengthControl = self.searchForMayaControl(meshFormLayout, cmds.optionMenuGrp, 'Strength')
+        strengthControl = self.searchForMayaControl(materialFormLayout, cmds.optionMenuGrp, 'Strength')
         self.assertIsNotNone(strengthControl, 'Could not find the "Strength" control')
 
     def testAECustomImageControl(self):

--- a/test/lib/testAttributeEditorTemplate.py
+++ b/test/lib/testAttributeEditorTemplate.py
@@ -181,6 +181,32 @@ class AttributeEditorTemplateTestCase(unittest.TestCase):
         frameLayout = self.searchForMayaControl(startLayout, cmds.frameLayout, sectionName)
         self.assertIsNotNone(frameLayout, 'Could not find Extra Attributes frameLayout')
 
+    def testAECustomMaterialControl(self):
+        '''Simple test for the MaterialCustomControl in AE template.'''
+
+        cmds.file(new=True, force=True)
+        testFile = testUtils.getTestScene("MaterialX", "MayaSurfaces.usda")
+        shapeNode,shapeStage = mayaUtils.createProxyFromFile(testFile)
+
+        # Select this prim which has a custom material control attribute.
+        cmds.select('|stage|stageShape,/pCube1', r=True)
+
+        # Make sure the AE is visible.
+        import maya.mel
+        maya.mel.eval('openAEWindow')
+
+        # In the AE there is a formLayout for each USD prim type. We start
+        # by making sure we can find the one for the mesh.
+        meshFormLayout = self.attrEdFormLayoutName('Mesh')
+        self.assertTrue(cmds.formLayout(meshFormLayout, exists=True))
+        startLayout = cmds.formLayout(meshFormLayout, query=True, fullPathName=True)
+        self.assertIsNotNone(startLayout, 'Could not get full path for Mesh formLayout')
+        
+        # We can now search for the control for the meterial.
+        assignedMaterialControl = self.searchForMayaControl(meshFormLayout, cmds.text, 'Assigned Material')
+        self.assertIsNotNone(assignedMaterialControl, 'Could not find the "Assigned Material" control')
+        strengthControl = self.searchForMayaControl(meshFormLayout, cmds.optionMenuGrp, 'Strength')
+        self.assertIsNotNone(strengthControl, 'Could not find the "Strength" control')
 
     def testAECustomImageControl(self):
         '''Simple test for the customImageControlCreator in AE template.'''


### PR DESCRIPTION
- Detect if the LookdevX plugin is loaded. Everything else is turned off when not loaded.
- Add a button to graph the material in a LookdevX tab.
- Use a named tuple to hold text field info.
- Refactor the code to show buttons and update the associated commands.
- Use the lookdevXGraph command to open the tab.
- Add a utility function to build a UFE path from a USD path.
- Fixed that the AE would not update when assigning an existing material.
- Add a popup menu to the graph material buttons.
- Allow creating a new tab or re-using an existing tab.
- The material types is always USD since these are USD materials.