### PR TITLE
EMSUSD-1111 Edit routing for transform commands

### DIFF
--- a/lib/mayaUsd/ufe/UsdPointInstanceOrientationModifier.cpp
+++ b/lib/mayaUsd/ufe/UsdPointInstanceOrientationModifier.cpp
@@ -86,7 +86,7 @@ Ufe::Vector3d UsdPointInstanceOrientationModifier::convertValueToUfe(const GfQua
 }
 
 /* override */
-PXR_NS::UsdAttribute UsdPointInstanceOrientationModifier::_getAttribute() const
+PXR_NS::UsdAttribute UsdPointInstanceOrientationModifier::getAttribute() const
 {
     UsdGeomPointInstancer pointInstancer = getPointInstancer();
     if (!pointInstancer) {

--- a/lib/mayaUsd/ufe/UsdPointInstanceOrientationModifier.h
+++ b/lib/mayaUsd/ufe/UsdPointInstanceOrientationModifier.h
@@ -49,9 +49,9 @@ public:
 
     Batches& batches() override;
 
-protected:
-    PXR_NS::UsdAttribute _getAttribute() const override;
+    PXR_NS::UsdAttribute getAttribute() const override;
 
+protected:
     PXR_NS::UsdAttribute _createAttribute() override;
 };
 

--- a/lib/mayaUsd/ufe/UsdPointInstancePositionModifier.cpp
+++ b/lib/mayaUsd/ufe/UsdPointInstancePositionModifier.cpp
@@ -37,7 +37,7 @@ MAYAUSD_VERIFY_CLASS_VIRTUAL_DESTRUCTOR(UsdPointInstancePositionModifier);
 MAYAUSD_VERIFY_CLASS_NOT_MOVE_OR_COPY(UsdPointInstancePositionModifier);
 
 /* override */
-PXR_NS::UsdAttribute UsdPointInstancePositionModifier::_getAttribute() const
+PXR_NS::UsdAttribute UsdPointInstancePositionModifier::getAttribute() const
 {
     PXR_NS::UsdGeomPointInstancer pointInstancer = getPointInstancer();
     if (!pointInstancer) {

--- a/lib/mayaUsd/ufe/UsdPointInstancePositionModifier.h
+++ b/lib/mayaUsd/ufe/UsdPointInstancePositionModifier.h
@@ -58,9 +58,9 @@ public:
 
     Batches& batches() override;
 
-protected:
-    PXR_NS::UsdAttribute _getAttribute() const override;
+    PXR_NS::UsdAttribute getAttribute() const override;
 
+protected:
     PXR_NS::UsdAttribute _createAttribute() override;
 };
 

--- a/lib/mayaUsd/ufe/UsdPointInstanceScaleModifier.cpp
+++ b/lib/mayaUsd/ufe/UsdPointInstanceScaleModifier.cpp
@@ -37,7 +37,7 @@ MAYAUSD_VERIFY_CLASS_VIRTUAL_DESTRUCTOR(UsdPointInstanceScaleModifier);
 MAYAUSD_VERIFY_CLASS_NOT_MOVE_OR_COPY(UsdPointInstanceScaleModifier);
 
 /* override */
-PXR_NS::UsdAttribute UsdPointInstanceScaleModifier::_getAttribute() const
+PXR_NS::UsdAttribute UsdPointInstanceScaleModifier::getAttribute() const
 {
     PXR_NS::UsdGeomPointInstancer pointInstancer = getPointInstancer();
     if (!pointInstancer) {

--- a/lib/mayaUsd/ufe/UsdPointInstanceScaleModifier.h
+++ b/lib/mayaUsd/ufe/UsdPointInstanceScaleModifier.h
@@ -58,9 +58,9 @@ public:
 
     Batches& batches() override;
 
-protected:
-    PXR_NS::UsdAttribute _getAttribute() const override;
+    PXR_NS::UsdAttribute getAttribute() const override;
 
+protected:
     PXR_NS::UsdAttribute _createAttribute() override;
 };
 

--- a/lib/mayaUsd/ufe/UsdSetXformOpUndoableCommandBase.cpp
+++ b/lib/mayaUsd/ufe/UsdSetXformOpUndoableCommandBase.cpp
@@ -17,7 +17,9 @@
 
 #include <mayaUsd/ufe/Utils.h>
 
+#include <usdUfe/base/tokens.h>
 #include <usdUfe/undo/UsdUndoBlock.h>
+#include <usdUfe/utils/editRouterContext.h>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -48,6 +50,9 @@ UsdSetXformOpUndoableCommandBase::UsdSetXformOpUndoableCommandBase(
 
 void UsdSetXformOpUndoableCommandBase::execute()
 {
+    UsdUfe::OperationEditRouterContext editContext(
+        UsdUfe::EditRoutingTokens->RouteTransform, getPrim());
+
     // Create the attribute and cache the initial value,
     // if this is the first time we're executed, or redo
     // the attribute creation.
@@ -65,6 +70,9 @@ void UsdSetXformOpUndoableCommandBase::undo()
     if (!_isPrepared)
         return;
 
+    UsdUfe::OperationEditRouterContext editContext(
+        UsdUfe::EditRoutingTokens->RouteTransform, getPrim());
+
     // Restore the initial value and potentially remove the creatd attributes.
     setValue(_initialOpValue, _writeTime);
     removeOpIfNeeded();
@@ -73,6 +81,9 @@ void UsdSetXformOpUndoableCommandBase::undo()
 
 void UsdSetXformOpUndoableCommandBase::redo()
 {
+    UsdUfe::OperationEditRouterContext editContext(
+        UsdUfe::EditRoutingTokens->RouteTransform, getPrim());
+
     // Redo the attribute creation if the attribute was already created
     // but then undone.
     recreateOpIfNeeded();
@@ -82,6 +93,12 @@ void UsdSetXformOpUndoableCommandBase::redo()
     // first time the command is executed, redone or undone.
     prepareAndSet(_newOpValue);
     _canUpdateValue = true;
+}
+
+UsdPrim UsdSetXformOpUndoableCommandBase::getPrim() const
+{
+    // Convert the UFE path to the corresponding USD prim.
+    return UsdUfe::ufePathToPrim(path());
 }
 
 void UsdSetXformOpUndoableCommandBase::updateNewValue(const VtValue& v)

--- a/lib/mayaUsd/ufe/UsdSetXformOpUndoableCommandBase.h
+++ b/lib/mayaUsd/ufe/UsdSetXformOpUndoableCommandBase.h
@@ -20,6 +20,7 @@
 #include <usdUfe/undo/UsdUndoableItem.h>
 
 #include <pxr/base/vt/value.h>
+#include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/timeCode.h>
 
 #include <ufe/transform3dUndoableCommands.h>
@@ -72,6 +73,9 @@ public:
     void redo() override;
 
     PXR_NS::UsdTimeCode writeTime() const { return _writeTime; }
+
+    // Retrieve the USD prim affected by the command.
+    virtual PXR_NS::UsdPrim getPrim() const;
 
 protected:
     // Create the XformOp attributes if they do not exists.

--- a/lib/mayaUsd/ufe/UsdTransform3dBase.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dBase.h
@@ -37,7 +37,7 @@ namespace ufe {
 // could be changed to use the current time, using getTime(path()).
 
 class MAYAUSD_CORE_PUBLIC UsdTransform3dBase
-    : private UsdTransform3dReadImpl
+    : protected UsdTransform3dReadImpl
     , public Ufe::Transform3d
 {
 public:
@@ -77,6 +77,10 @@ public:
     Ufe::Matrix4d segmentInclusiveMatrix() const override;
     Ufe::Matrix4d segmentExclusiveMatrix() const override;
 
+protected:
+    // Check if the attribute edit is allowed inside the edit context.
+    bool isAttributeEditAllowed(const PXR_NS::TfToken attrName) const;
+    bool isAttributeEditAllowed(const PXR_NS::TfToken* attrNames, int count) const;
 }; // UsdTransform3dBase
 
 } // namespace ufe

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.cpp
@@ -308,37 +308,43 @@ Ufe::Vector3d UsdTransform3dMatrixOp::scale() const { return getScale(matrix());
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dMatrixOp::translateCmd(double x, double y, double z)
 {
-    if (!UsdUfe::isAttributeEditAllowed(prim(), TfToken("xformOp:translate"))) {
+    if (!isAttributeEditAllowed(TfToken("xformOp:translate")))
         return nullptr;
-    }
 
     return std::make_shared<MatrixOpTranslateUndoableCmd>(path(), _op, UsdTimeCode::Default());
 }
 
 Ufe::RotateUndoableCommand::Ptr UsdTransform3dMatrixOp::rotateCmd(double x, double y, double z)
 {
-    if (!UsdUfe::isAttributeEditAllowed(prim(), TfToken("xformOp:rotateXYZ"))) {
+    if (!isAttributeEditAllowed(TfToken("xformOp:rotateXYZ")))
         return nullptr;
-    }
 
     return std::make_shared<MatrixOpRotateUndoableCmd>(path(), _op, UsdTimeCode::Default());
 }
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3dMatrixOp::scaleCmd(double x, double y, double z)
 {
-    if (!UsdUfe::isAttributeEditAllowed(prim(), TfToken("xformOp:scale"))) {
+    if (!isAttributeEditAllowed(TfToken("xformOp:scale")))
         return nullptr;
-    }
 
     return std::make_shared<MatrixOpScaleUndoableCmd>(path(), _op, UsdTimeCode::Default());
 }
 
 Ufe::SetMatrix4dUndoableCommand::Ptr UsdTransform3dMatrixOp::setMatrixCmd(const Ufe::Matrix4d& m)
 {
+    if (!isAttributeEditAllowed(_op.GetName()))
+        return nullptr;
+
     return std::make_shared<UsdSetMatrix4dUndoableCmd>(path(), m);
 }
 
-void UsdTransform3dMatrixOp::setMatrix(const Ufe::Matrix4d& m) { _op.Set(toUsd(m)); }
+void UsdTransform3dMatrixOp::setMatrix(const Ufe::Matrix4d& m)
+{
+    if (!isAttributeEditAllowed(_op.GetName()))
+        return;
+
+    _op.Set(toUsd(m));
+}
 
 Ufe::Matrix4d UsdTransform3dMatrixOp::matrix() const
 {

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
@@ -115,8 +115,6 @@ protected:
 private:
     Ufe::TranslateUndoableCommand::Ptr
     pivotCmd(const PXR_NS::TfToken& pvtOpSuffix, double x, double y, double z);
-
-    bool isAttributeEditAllowed(const PXR_NS::TfToken attrName, std::string& errMsg) const;
 }; // UsdTransform3dMayaXformStack
 
 //! \brief Factory to create a UsdTransform3dMayaXformStack interface object.

--- a/lib/mayaUsd/ufe/UsdTransform3dPointInstance.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dPointInstance.h
@@ -60,6 +60,8 @@ public:
     Ufe::Matrix4d segmentExclusiveMatrix() const override;
 
 private:
+    bool isAttributeEditAllowed(const PXR_NS::UsdAttribute& attr) const;
+
     UsdPointInstancePositionModifier    _positionModifier;
     UsdPointInstanceOrientationModifier _orientationModifier;
     UsdPointInstanceScaleModifier       _scaleModifier;

--- a/lib/usdUfe/base/tokens.h
+++ b/lib/usdUfe/base/tokens.h
@@ -47,6 +47,7 @@ namespace USDUFE_NS_DEF {
     ((RouteVisibility, "visibility"))                   \
     ((RouteAttribute, "attribute"))                     \
     ((RouteDelete, "delete"))                           \
+    ((RouteTransform, "transform"))                     \
                                                         \
 // clang-format on
 

--- a/lib/usdUfe/python/wrapEditRouter.cpp
+++ b/lib/usdUfe/python/wrapEditRouter.cpp
@@ -34,13 +34,17 @@ std::string handlePythonException()
     PyObject* val = nullptr;
     PyObject* tb = nullptr;
     PyErr_Fetch(&exc, &val, &tb);
+    if (!exc)
+        return "unknown Python exception";
+
     handle<> hexc(exc);
     handle<> hval(allow_null(val));
     handle<> htb(allow_null(tb));
     object   traceback(import("traceback"));
     object   format_exception_only(traceback.attr("format_exception_only"));
-    object   formatted_list = format_exception_only(hexc, hval);
+    object   formatted_list = val ? format_exception_only(hexc, hval) : format_exception_only(hexc);
     object   formatted = str("\n").join(formatted_list);
+
     return extract<std::string>(formatted);
 }
 

--- a/test/lib/ufe/testEditRouting.py
+++ b/test/lib/ufe/testEditRouting.py
@@ -11,7 +11,9 @@ import os
 import unittest
 import usdUtils
 from pxr import UsdGeom
+from pxr import Gf
 from usdUtils import filterUsdStr
+import mayaUsd_createStageWithNewLayer
 
 
 #####################################################################
@@ -110,6 +112,7 @@ class CustomCompositeCmd(ufe.CompositeUndoableCommand):
 class EditRoutingTestCase(unittest.TestCase):
     '''Verify the Maya Edit Router for visibility.'''
     pluginsLoaded = False
+    EPSILON = 1e-3
 
     @classmethod
     def setUpClass(cls):
@@ -125,19 +128,22 @@ class EditRoutingTestCase(unittest.TestCase):
         self.assertTrue(self.pluginsLoaded)
 
         cmds.file(new=True, force=True)
-        import mayaUsd_createStageWithNewLayer
- 
-        # Create the following hierarchy:
+
+    def tearDown(self):
+        # Restore default edit routers.
+        mayaUsd.lib.restoreAllDefaultEditRouters()
+
+    def _prepareSimpleScene(self):
+         # Create the following hierarchy:
         #
         # proxy shape
         #  |_ A
         #  |_ B
         #
- 
         psPathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
-        stage = mayaUsd.lib.GetPrim(psPathStr).GetStage()
-        stage.DefinePrim('/A', 'Xform')
-        stage.DefinePrim('/B', 'Xform')
+        self.stage = mayaUsd.lib.GetPrim(psPathStr).GetStage()
+        self.stage.DefinePrim('/A', 'Xform')
+        self.stage.DefinePrim('/B', 'Xform')
  
         psPath = ufe.PathString.path(psPathStr)
         psPathSegment = psPath.segments[0]
@@ -145,47 +151,42 @@ class EditRoutingTestCase(unittest.TestCase):
         bPath = ufe.Path([psPathSegment, usdUtils.createUfePathSegment('/B')])
         self.a = ufe.Hierarchy.createItem(aPath)
         self.b = ufe.Hierarchy.createItem(bPath)
+
+        self.prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
+        self.sessionLayer = self.stage.GetSessionLayer()
  
         cmds.select(clear=True)
 
-    def tearDown(self):
-        # Restore default edit routers.
-        mayaUsd.lib.restoreAllDefaultEditRouters()
+        # Select /B
+        sn = ufe.GlobalSelection.get()
+        sn.clear()
+        sn.append(self.b)
 
     def _verifyEditRouterForCmd(self, operationName, cmdFunc, verifyFunc):
         '''
         Test edit router functionality for the given operation name, using the given command and verifier.
         The B xform will be in the global selection and is assumed to be affected by the command.
         '''
-
-        # Get the session layer
-        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
-        sessionLayer = prim.GetStage().GetSessionLayer()
- 
         # Check that the session layer is empty
-        self.assertTrue(sessionLayer.empty)
+        self.assertTrue(self.sessionLayer.empty)
  
         # Send visibility edits to the session layer.
         mayaUsd.lib.registerEditRouter(operationName, routeCmdToSessionLayer)
- 
-        # Select /B
-        sn = ufe.GlobalSelection.get()
-        sn.clear()
-        sn.append(self.b)
  
         # Affect B via the command
         cmdFunc()
 
         # Check that something was written to the session layer
-        self.assertIsNotNone(sessionLayer)
+        self.assertIsNotNone(self.sessionLayer)
 
         # Verify the command was routed.
-        verifyFunc(sessionLayer)
+        verifyFunc(self.sessionLayer)
 
     def testEditRouterForVisibilityCmd(self):
         '''
         Test edit router functionality for the set-visibility command.
         '''
+        self._prepareSimpleScene()
 
         def setVisibility():
             cmds.hide()
@@ -206,6 +207,7 @@ class EditRoutingTestCase(unittest.TestCase):
         '''
         Test edit router functionality for the duplicate command.
         '''
+        self._prepareSimpleScene()
 
         def duplicate():
             cmds.duplicate()
@@ -225,6 +227,7 @@ class EditRoutingTestCase(unittest.TestCase):
         '''
         Test edit router functionality for the parent command.
         '''
+        self._prepareSimpleScene()
 
         def group():
             cmds.group()
@@ -242,19 +245,203 @@ class EditRoutingTestCase(unittest.TestCase):
              
         self._verifyEditRouterForCmd('parent', group, verifyGroup)
 
+    def _verifyTransform(self, sessionLayer, attributeName):
+        self.assertIsNotNone(sessionLayer.GetPrimAtPath('/B'))
+
+        # Check that any visibility changes were written to the session layer
+        self.assertIsNotNone(sessionLayer.GetAttributeAtPath('/B.' + attributeName))
+
+    def testEditRouterForCommonAPITranslateCmd(self):
+        '''
+        Test edit router functionality for the common API translate commands.
+        '''
+        self._prepareSimpleScene()
+
+        def set():
+            cmds.move(0, 1, 2)
+
+        def verify(sessionLayer):
+            self._verifyTransform(sessionLayer, 'xformOp:translate')
+            
+        self._verifyEditRouterForCmd('transform', set, verify)
+
+    def testEditRouterForCommonAPIRotateCmd(self):
+        '''
+        Test edit router functionality for the common API rotate commands.
+        '''
+        self._prepareSimpleScene()
+
+        def set():
+            cmds.rotate(30, 10, 0)
+
+        def verify(sessionLayer):
+            self._verifyTransform(sessionLayer, 'xformOp:rotateXYZ')
+            
+        self._verifyEditRouterForCmd('transform', set, verify)
+
+    def testEditRouterForCommonAPIScaleCmd(self):
+        '''
+        Test edit router functionality for the common API scale commands.
+        '''
+        self._prepareSimpleScene()
+
+        def set():
+            cmds.scale(2, 2, 2)
+
+        def verify(sessionLayer):
+            self._verifyTransform(sessionLayer, 'xformOp:scale')
+            
+        self._verifyEditRouterForCmd('transform', set, verify)
+
+    def _preparePointInstanceScene(self):
+        '''
+        Prepare a stage with a point instance and an instance already selected.
+        Return the point instancer and the instance index.
+        '''
+        mayaUtils.openPointInstancesGrid14Scene()
+
+        # Create a UFE path to a PointInstancer prim with an instanceIndex on
+        # the end. This path uniquely identifies a specific point instance.
+        instanceIndex = 7
+
+        ufePath = ufe.Path([
+            mayaUtils.createUfePathSegment('|UsdProxy|UsdProxyShape'),
+            usdUtils.createUfePathSegment(
+                '/PointInstancerGrid/PointInstancer/%d' % instanceIndex)])
+        ufeItem = ufe.Hierarchy.createItem(ufePath)
+
+        # Select the point instance scene item.
+        globalSelection = ufe.GlobalSelection.get()
+        globalSelection.append(ufeItem)
+
+        # Get the PointInstancer prim for validating the values in USD.
+        ufePathString = ufe.PathString.string(ufePath)
+        self.prim = mayaUsd.ufe.ufePathToPrim(ufePathString)
+        self.stage = self.prim.GetStage()
+        self.sessionLayer = self.stage.GetSessionLayer()
+        pointInstancer = UsdGeom.PointInstancer(self.prim)
+        self.assertTrue(pointInstancer)
+
+        return pointInstancer, instanceIndex
+    
+    def testManipulatePointInstancePosition(self):
+        '''
+        Test that we can route point instance transation.
+        '''
+        pointInstancer, instanceIndex = self._preparePointInstanceScene()
+
+        def preValidate():
+            # The PointInstancer should have 14 authored positions initially.
+            positionsAttr = pointInstancer.GetPositionsAttr()
+            positions = positionsAttr.Get()
+            self.assertEqual(len(positions), 14)
+
+            # Validate the initial position before manipulating
+            position = positions[instanceIndex]
+            self.assertTrue(
+                Gf.IsClose(position, Gf.Vec3f(-4.5, 1.5, 0.0), self.EPSILON))
+
+        def set():
+            # Perfom a translate manipulation via the move command.
+            cmds.move(1.0, 2.0, 3.0, objectSpace=True, relative=True)
+
+        def verify(sessionLayer):
+            # Re-fetch the USD positions and check for the update.
+            positionsAttr = pointInstancer.GetPositionsAttr()
+            position = positionsAttr.Get()[instanceIndex]
+            self.assertTrue(
+                Gf.IsClose(position, Gf.Vec3f(-3.5, 3.5, 3.0), self.EPSILON))
+            
+            instancerPath = pointInstancer.GetPath()
+            self.assertIsNotNone(sessionLayer.GetPrimAtPath(instancerPath))
+            self.assertIsNotNone(sessionLayer.GetAttributeAtPath(str(instancerPath) + '.positions'))
+            
+        preValidate()
+        self._verifyEditRouterForCmd('transform', set, verify)
+        
+    def testManipulatePointInstanceOrientation(self):
+        '''
+        Test that we can route point instance rotation.
+        '''
+        pointInstancer, instanceIndex = self._preparePointInstanceScene()
+
+        def preValidate():
+            # The PointInstancer should not have any authored orientations
+            # initially.
+            orientationsAttr = pointInstancer.GetOrientationsAttr()
+            self.assertFalse(orientationsAttr.HasAuthoredValue())
+
+        def set():
+            # Perfom an orientation manipulation via the rotate command.
+            cmds.rotate(15.0, 30.0, 45.0, objectSpace=True, relative=True)
+
+        def verify(sessionLayer):
+            # The initial rotate should have filled out the orientations attribute.
+            orientationsAttr = pointInstancer.GetOrientationsAttr()
+            orientations = orientationsAttr.Get()
+            self.assertEqual(len(orientations), 14)
+
+            # Validate the rotated item.
+            orientation = orientations[instanceIndex]
+            self.assertTrue(
+                Gf.IsClose(orientation.real, 0.897461, self.EPSILON))
+            self.assertTrue(
+                Gf.IsClose(orientation.imaginary, Gf.Vec3h(0.01828, 0.2854, 0.335205), self.EPSILON))
+
+            instancerPath = pointInstancer.GetPath()
+            self.assertIsNotNone(sessionLayer.GetPrimAtPath(instancerPath))
+            self.assertIsNotNone(sessionLayer.GetAttributeAtPath(str(instancerPath) + '.orientations'))
+
+        preValidate()
+        self._verifyEditRouterForCmd('transform', set, verify)
+
+    def testManipulatePointInstanceScale(self):
+        '''
+        Test that we can route point instance transation.
+        '''
+        pointInstancer, instanceIndex = self._preparePointInstanceScene()
+
+        def preValidate():
+            # The PointInstancer should not have any authored scales initially.
+            scalesAttr = pointInstancer.GetScalesAttr()
+            self.assertFalse(scalesAttr.HasAuthoredValue())
+
+        def set():
+            # Perfom a scale manipulation via the scale command.
+            cmds.scale(1.0, 2.0, 3.0, objectSpace=True, relative=True)
+
+        def verify(sessionLayer):
+            # The initial scale should have filled out the scales attribute.
+            scalesAttr = pointInstancer.GetScalesAttr()
+            scales = scalesAttr.Get()
+            self.assertEqual(len(scales), 14)
+
+            # Validate the scaled item.
+            scale = scales[instanceIndex]
+            self.assertTrue(
+                Gf.IsClose(scale, Gf.Vec3f(1.0, 2.0, 3.0), self.EPSILON))
+
+            # The non-scaled items should all have identity scales.
+            for i in [idx for idx in range(14) if idx != instanceIndex]:
+                scale = scales[i]
+                self.assertTrue(
+                    Gf.IsClose(scale, Gf.Vec3f(1.0, 1.0, 1.0), self.EPSILON))
+
+            instancerPath = pointInstancer.GetPath()
+            self.assertIsNotNone(sessionLayer.GetPrimAtPath(instancerPath))
+            self.assertIsNotNone(sessionLayer.GetAttributeAtPath(str(instancerPath) + '.scales'))
+
+
+        preValidate()
+        self._verifyEditRouterForCmd('transform', set, verify)
+
     def testEditRouterForSetVisibility(self):
         '''
         Test edit router for the visibility attribute triggered
         via UFE Object3d's setVisibility function.
         '''
+        self._prepareSimpleScene()
 
-        # Get the session layer
-        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
-        sessionLayer = prim.GetStage().GetSessionLayer()
- 
-        # Check that the session layer is empty
-        self.assertTrue(sessionLayer.empty)
- 
         # Send visibility edits to the session layer.
         mayaUsd.lib.registerEditRouter('attribute', routeVisibilityAttribute)
  
@@ -263,15 +450,15 @@ class EditRoutingTestCase(unittest.TestCase):
         object3d.setVisibility(False)
  
         # Check that something was written to the session layer
-        self.assertIsNotNone(sessionLayer)
-        self.assertFalse(sessionLayer.empty)
-        self.assertIsNotNone(sessionLayer.GetPrimAtPath('/B'))
+        self.assertIsNotNone(self.sessionLayer)
+        self.assertFalse(self.sessionLayer.empty)
+        self.assertIsNotNone(self.sessionLayer.GetPrimAtPath('/B'))
  
         # Check that any visibility changes were written to the session layer
-        self.assertIsNotNone(sessionLayer.GetAttributeAtPath('/B.visibility').default)
+        self.assertIsNotNone(self.sessionLayer.GetAttributeAtPath('/B.visibility').default)
  
         # Check that correct visibility changes were written to the session layer
-        self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
+        self.assertEqual(filterUsdStr(self.sessionLayer.ExportToString()),
                          filterUsdStr('over "B"\n{\n    token visibility = "invisible"\n}'))
 
     def testEditRouterForAttributeVisibility(self):
@@ -279,14 +466,8 @@ class EditRoutingTestCase(unittest.TestCase):
         Test edit router for the visibility attribute triggered
          via UFE attribute's set function.
         '''
+        self._prepareSimpleScene()
 
-        # Get the session layer
-        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
-        sessionLayer = prim.GetStage().GetSessionLayer()
- 
-        # Check that the session layer is empty
-        self.assertTrue(sessionLayer.empty)
- 
         # Send visibility edits to the session layer.
         mayaUsd.lib.registerEditRouter('attribute', routeVisibilityAttribute)
  
@@ -296,15 +477,15 @@ class EditRoutingTestCase(unittest.TestCase):
         visibilityAttr.set(UsdGeom.Tokens.invisible)
  
         # Check that something was written to the session layer
-        self.assertIsNotNone(sessionLayer)
-        self.assertFalse(sessionLayer.empty)
-        self.assertIsNotNone(sessionLayer.GetPrimAtPath('/B'))
+        self.assertIsNotNone(self.sessionLayer)
+        self.assertFalse(self.sessionLayer.empty)
+        self.assertIsNotNone(self.sessionLayer.GetPrimAtPath('/B'))
  
         # Check that any visibility changes were written to the session layer
-        self.assertIsNotNone(sessionLayer.GetAttributeAtPath('/B.visibility').default)
+        self.assertIsNotNone(self.sessionLayer.GetAttributeAtPath('/B.visibility').default)
  
         # Check that correct visibility changes were written to the session layer
-        self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
+        self.assertEqual(filterUsdStr(self.sessionLayer.ExportToString()),
                          filterUsdStr('over "B"\n{\n    token visibility = "invisible"\n}'))
         
         # Check we are still allowed to set the attribute without
@@ -320,37 +501,27 @@ class EditRoutingTestCase(unittest.TestCase):
         using the given command and verifier.
         The B xform will be in the global selection and is assumed to be affected by the command.
         '''
-        # Get the session layer
-        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
-        stage = prim.GetStage()
-        sessionLayer = stage.GetSessionLayer()
- 
-        # Check that the session layer is empty
-        self.assertTrue(sessionLayer.empty)
+        self._prepareSimpleScene()
  
         # Prevent edits.
         mayaUsd.lib.registerEditRouter(operationName, preventCommandRouter)
- 
-        # Select /B
-        sn = ufe.GlobalSelection.get()
-        sn.clear()
-        sn.append(self.b)
  
         # try to affect B via the command, should be prevented
         with self.assertRaises(RuntimeError):
             cmdFunc()
  
         # Check that nothing was written to the session layer
-        self.assertIsNotNone(sessionLayer)
-        self.assertIsNone(sessionLayer.GetPrimAtPath('/B'))
+        self.assertIsNotNone(self.sessionLayer)
+        self.assertIsNone(self.sessionLayer.GetPrimAtPath('/B'))
  
         # Check that no changes were done in any layer
-        verifyFunc(stage)
+        verifyFunc(self.stage)
 
     def testPreventVisibilityCmd(self):
         '''
         Test edit router preventing a the visibility command by raising an exception.
         '''
+        self._prepareSimpleScene()
 
         def hide():
             cmds.hide()
@@ -366,6 +537,7 @@ class EditRoutingTestCase(unittest.TestCase):
         '''
         Test edit router preventing the duplicate command by raising an exception.
         '''
+        self._prepareSimpleScene()
 
         def duplicate():
             cmds.duplicate()
@@ -381,6 +553,7 @@ class EditRoutingTestCase(unittest.TestCase):
         '''
         Test edit router preventing the parent operation by raising an exception.
         '''
+        self._prepareSimpleScene()
 
         def group():
             cmds.group()
@@ -397,16 +570,10 @@ class EditRoutingTestCase(unittest.TestCase):
         Test that an edit router for a composite command prevent routing of sub-commands.
         The B xform will be in the global selection and is assumed to be affected by the command.
         '''
-        # Get the session layer
-        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
-        stage = prim.GetStage()
-        sessionLayer = stage.GetSessionLayer()
- 
-        # Check that the session layer is empty
-        self.assertTrue(sessionLayer.empty)
+        self._prepareSimpleScene()
 
         # Check to root layer only contains bare A and B xforms.
-        rootLayer = stage.GetRootLayer()
+        rootLayer = self.stage.GetRootLayer()
         self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
                          filterUsdStr('def Xform "A"\n{\n}\ndef Xform "B"\n{\n}'))
  
@@ -416,23 +583,18 @@ class EditRoutingTestCase(unittest.TestCase):
         mayaUsd.lib.registerEditRouter('visibility', routeCmdToSessionLayer)
         mayaUsd.lib.registerEditRouter('custom', routeCmdToRootLayer)
  
-        # Select /B
-        sn = ufe.GlobalSelection.get()
-        sn.clear()
-        sn.append(self.b)
- 
         # try to affect B via the command, should be prevented
-        compCmd = CustomCompositeCmd(prim, self.b)
+        compCmd = CustomCompositeCmd(self.prim, self.b)
         compCmd.execute()
  
         # Check that nothing was written to the session layer
-        self.assertIsNotNone(sessionLayer)
-        self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
+        self.assertIsNotNone(self.sessionLayer)
+        self.assertEqual(filterUsdStr(self.sessionLayer.ExportToString()),
                          '')
-        self.assertTrue(sessionLayer.empty)
+        self.assertTrue(self.sessionLayer.empty)
  
         # Check that visibility was written to the root layer
-        rootLayer = stage.GetRootLayer()
+        rootLayer = self.stage.GetRootLayer()
         self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
                          filterUsdStr('def Xform "A"\n{\n}\ndef Xform "B"\n{\n    token visibility = "invisible"\n}'))
 
@@ -441,36 +603,25 @@ class EditRoutingTestCase(unittest.TestCase):
         '''
         Test that a composite command with not edit router registered works as expected.
         '''
-        # Get the session layer
-        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
-        stage = prim.GetStage()
-        sessionLayer = stage.GetSessionLayer()
- 
-        # Check that the session layer is empty
-        self.assertTrue(sessionLayer.empty)
+        self._prepareSimpleScene()
 
         # Check to root layer only contains bare A and B xforms.
-        rootLayer = stage.GetRootLayer()
+        rootLayer = self.stage.GetRootLayer()
         self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
                          filterUsdStr('def Xform "A"\n{\n}\ndef Xform "B"\n{\n}'))
  
-        # Select /B
-        sn = ufe.GlobalSelection.get()
-        sn.clear()
-        sn.append(self.b)
- 
         # try to affect B via the command, should be prevented
-        compCmd = CustomCompositeCmd(prim, self.b)
+        compCmd = CustomCompositeCmd(self.prim, self.b)
         compCmd.execute()
  
         # Check that nothing was written to the session layer
-        self.assertIsNotNone(sessionLayer)
-        self.assertEqual(filterUsdStr(sessionLayer.ExportToString()),
+        self.assertIsNotNone(self.sessionLayer)
+        self.assertEqual(filterUsdStr(self.sessionLayer.ExportToString()),
                          '')
-        self.assertTrue(sessionLayer.empty)
+        self.assertTrue(self.sessionLayer.empty)
  
         # Check that visibility was written to the root layer
-        rootLayer = stage.GetRootLayer()
+        rootLayer = self.stage.GetRootLayer()
         self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
                          filterUsdStr('def Xform "A"\n{\n}\ndef Xform "B"\n{\n    token visibility = "invisible"\n}'))
 
@@ -479,32 +630,21 @@ class EditRoutingTestCase(unittest.TestCase):
         '''
         Test that an edit router for the group composite command routes all sub-commands.
         '''
-        # Get the session layer
-        prim = mayaUsd.ufe.ufePathToPrim("|stage1|stageShape1,/A")
-        stage = prim.GetStage()
-        sessionLayer = stage.GetSessionLayer()
- 
-        # Check that the session layer is empty
-        self.assertTrue(sessionLayer.empty)
+        self._prepareSimpleScene()
 
         # Check to root layer only contains bare A and B xforms.
-        rootLayer = stage.GetRootLayer()
+        rootLayer = self.stage.GetRootLayer()
         self.assertEqual(filterUsdStr(rootLayer.ExportToString()),
                          filterUsdStr('def Xform "A"\n{\n}\ndef Xform "B"\n{\n}'))
  
         # Route the group command to the session layer.
         mayaUsd.lib.registerEditRouter('group', routeCmdToSessionLayer)
  
-        # Select /B
-        sn = ufe.GlobalSelection.get()
-        sn.clear()
-        sn.append(self.b)
- 
         # Group
         cmds.group()
  
         # Check that everything was written to the session layer
-        self.assertIsNotNone(sessionLayer)
+        self.assertIsNotNone(self.sessionLayer)
         expectedContents = '''
             def Xform "group1" (
                 kind = "group"
@@ -525,7 +665,7 @@ class EditRoutingTestCase(unittest.TestCase):
             }
             '''
         self.maxDiff = None
-        self.assertEqual(filterUsdStr(sessionLayer.ExportToString()), filterUsdStr(expectedContents))
+        self.assertEqual(filterUsdStr(self.sessionLayer.ExportToString()), filterUsdStr(expectedContents))
  
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add helpers to support permissions and routing:
- Provide a helper function to check permission-to-edit in the base class of the USD implementation of the UFE 3D Transform interface.
- The helper ensures that the correct edit context is used when checking permissions.

Use helpers in transforms and commands:
- Use those helper functions to check for permission to edit in command creation.
- Use those helper functions to do the edits, in command execution.
- Add edit routing context in all transform-related edits function.
- This context queries and sets where the edits should be routed.
- In particular, it is used in the execute, undo, redo and set functions of the command base class.
- Properly check permissions for matrix commands.
- The common API, 3d Matrix Op, point instances and Maya Xform stack are done.

Permissions for point instance transform
- Make the getAttribute function of the point instance modifier base class be public.
- Same for its derived classes.
- Add helper function to check permission for point instances.
- Use it to check permissions for point instances.

Add unit tests for transform routing.