### PR TITLE
EMSUSD-1258 extend the delete cmd edit routing

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoDeleteCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDeleteCommand.cpp
@@ -80,7 +80,12 @@ void UsdUndoDeleteCommand::execute()
     if (!routingEditTarget.IsNull()) {
         PXR_NS::UsdEditContext ctx(stage, routingEditTarget);
 
-        if (!UsdUfe::applyCommandRestrictionNoThrow(_prim, "delete", true))
+        // Note: we allow stronger opinion when editing inside a reference or payload.
+        //       We detect this by the fact the ref/payload layer is non-local.
+        const bool isLocal = stage->HasLocalLayer(routingEditTarget.GetLayer());
+        const bool allowStronger = !isLocal;
+
+        if (!UsdUfe::applyCommandRestrictionNoThrow(_prim, "delete", allowStronger))
             return;
 
         if (!stage->RemovePrim(_prim.GetPath())) {


### PR DESCRIPTION
The new code for doing edit routing using an edit target directly was not supporting the usual use-case of providing the target by the layer identifier or layer handle.

It also always allowed stronger opinions, even though we only need it if the target is within a reference or payload.

This fixes both issues: delete can now be routed like other commands by ID or layer handle and will only allow stronger opinions when targeting a non-local layer.

Extending using an edit target directly in all other commands will be done separately in the future.