### PR TITLE
EMSUSD-1257 Fast Python routing

### DIFF
--- a/doc/EditRouting.md
+++ b/doc/EditRouting.md
@@ -166,6 +166,44 @@ import mayaUsd.lib
 mayaUsd.lib.restoreAllDefaultEditRouters()
 ```
 
+## Fast Edit Routing
+
+There is another way to route edits designed to make routing faster for the
+common simple case where a command should always be routed to the same layer.
+This is called fast edit routing. It is used by calling a different function
+to register the route: `registerStageLayerEditRouter`. This function takes
+the name of the operation to route, a stage and a layer and will route that
+operation to the given layer.
+
+The advantage is that it avoids creating temporary dictionaries to ask where
+to route the edits, is pure C++ code and thus is optimized even when used from
+Python. If you want to always route a given operation to the same layer for a
+given stage, that is the recommended way of doing it.
+
+Here is an example of routing the transform commands in Python using the fast
+edit routing:
+
+```Python
+import mayaUsd.lib
+
+def getStage():
+    '''
+    Here we hard-code the stage, but a more sphoisticated script
+    would select the stage using some mechanism, like UI or
+    based on notifications when a stage is created.
+    '''
+    psPathStr = "|stage1|stageShape1"
+    return mayaUsd.lib.GetPrim(psPathStr).GetStage()
+
+def getLayer(stage):
+    '''Here we route to the session layer, but any known layer could be used.'''
+    return stage.GetSessionLayer()
+
+stage = getStage()
+layer = getLayer(stage)
+mayaUsd.lib.registerStageLayerEditRouter('transform', stage, layer)
+```
+
 ## Canceling commands
 
 It is possible to prevent a command from executing instead of simply routing to

--- a/lib/mayaUsd/python/__init__.py
+++ b/lib/mayaUsd/python/__init__.py
@@ -10,6 +10,7 @@ del Tf
 # Import some of the names from the usdUfe module into this (mayaUsd.lib) module.
 # During the transition this helps by not having to update all the maya-usd tests.
 from usdUfe import registerEditRouter
+from usdUfe import registerStageLayerEditRouter
 from usdUfe import restoreDefaultEditRouter
 from usdUfe import restoreAllDefaultEditRouters
 from usdUfe import OperationEditRouterContext

--- a/lib/usdUfe/utils/editRouter.cpp
+++ b/lib/usdUfe/utils/editRouter.cpp
@@ -74,6 +74,47 @@ void CxxEditRouter::operator()(
     _cb(context, routingData);
 }
 
+void LayerPerStageEditRouter::setLayerForStage(
+    const PXR_NS::UsdStagePtr&    stage,
+    const PXR_NS::SdfLayerHandle& layer)
+{
+    if (!stage)
+        return;
+
+    if (!layer)
+        _stageToLayerMap.erase(stage);
+    else
+        _stageToLayerMap[stage] = layer;
+}
+
+PXR_NS::SdfLayerHandle
+LayerPerStageEditRouter::getLayerForStage(const PXR_NS::UsdStagePtr& stage) const
+{
+    auto layerIter = _stageToLayerMap.find(stage);
+    if (layerIter == _stageToLayerMap.end())
+        return nullptr;
+
+    return layerIter->second;
+}
+
+void LayerPerStageEditRouter::operator()(
+    const PXR_NS::VtDictionary& context,
+    PXR_NS::VtDictionary&       routingData)
+{
+    const auto primIter = context.find(EditRoutingTokens->Prim);
+    if (primIter == context.end())
+        return;
+
+    const auto& value = primIter->second;
+    if (!value.IsHolding<PXR_NS::UsdPrim>())
+        return;
+
+    UsdPrim prim = value.Get<PXR_NS::UsdPrim>();
+    auto    layer = getLayerForStage(prim.GetStage());
+    if (layer)
+        routingData[EditRoutingTokens->Layer] = layer;
+}
+
 void registerDefaultEditRouter(const PXR_NS::TfToken& operation, const EditRouter::Ptr& editRouter)
 {
     getRegisterdDefaultEditRouters()[operation] = editRouter;
@@ -103,6 +144,25 @@ EditRouters defaultEditRouters()
 void registerEditRouter(const PXR_NS::TfToken& operation, const EditRouter::Ptr& editRouter)
 {
     getRegisteredEditRouters()[operation] = editRouter;
+}
+
+void registerStageLayerEditRouter(
+    const PXR_NS::TfToken&        operation,
+    const PXR_NS::UsdStagePtr&    stage,
+    const PXR_NS::SdfLayerHandle& layer)
+{
+    if (!stage)
+        return;
+
+    auto router = getEditRouter(operation);
+    auto layerRouter = std::dynamic_pointer_cast<LayerPerStageEditRouter>(router);
+
+    if (!layerRouter) {
+        layerRouter = std::make_shared<LayerPerStageEditRouter>();
+        registerEditRouter(operation, layerRouter);
+    }
+
+    layerRouter->setLayerForStage(stage, layer);
 }
 
 bool restoreDefaultEditRouter(const PXR_NS::TfToken& operation)
@@ -165,6 +225,11 @@ getEditRouterLayer(const PXR_NS::TfToken& operation, const PXR_NS::UsdPrim& prim
     if (!dstEditRouter)
         return nullptr;
 
+    // Optimize the case where we have a per-stage layer routing.
+    // This avoid creating dictionaries just to pass and receive a value.
+    if (auto layerRouter = std::dynamic_pointer_cast<LayerPerStageEditRouter>(dstEditRouter))
+        return layerRouter->getLayerForStage(prim.GetStage());
+
     PXR_NS::VtDictionary context;
     PXR_NS::VtDictionary routingData;
     context[EditRoutingTokens->Prim] = PXR_NS::VtValue(prim);
@@ -188,6 +253,11 @@ getAttrEditRouterLayer(const PXR_NS::UsdPrim& prim, const PXR_NS::TfToken& attrN
     if (!dstEditRouter)
         return nullptr;
 
+    // Optimize the case where we have a per-stage layer routing.
+    // This avoid creating dictionaries just to pass and receive a value.
+    if (auto layerRouter = std::dynamic_pointer_cast<LayerPerStageEditRouter>(dstEditRouter))
+        return layerRouter->getLayerForStage(prim.GetStage());
+
     PXR_NS::VtDictionary context;
     PXR_NS::VtDictionary routingData;
     context[EditRoutingTokens->Prim] = PXR_NS::VtValue(prim);
@@ -207,9 +277,13 @@ PXR_NS::UsdEditTarget
 getEditRouterEditTarget(const PXR_NS::TfToken& operation, const PXR_NS::UsdPrim& prim)
 {
     const auto dstEditRouter = getEditRouter(operation);
-    if (!dstEditRouter) {
+    if (!dstEditRouter)
         return PXR_NS::UsdEditTarget();
-    }
+
+    // Optimize the case where we have a per-stage layer routing.
+    // This avoid creating dictionaries just to pass and receive a value.
+    if (auto layerRouter = std::dynamic_pointer_cast<LayerPerStageEditRouter>(dstEditRouter))
+        return layerRouter->getLayerForStage(prim.GetStage());
 
     PXR_NS::VtDictionary context;
     PXR_NS::VtDictionary routingData;


### PR DESCRIPTION
Add a C++ edit router that unconditionally route a command to a layer for a given stage. Expose this router to Python.

This allows a fast edit router even in Python. We avoid creating USD and Python dictionaries and just use the given layer for the command. This ensures that the routing is very efficient.

Updated the documentation.