### PR TITLE
EMSUSD-26 fix center pivot command

### DIFF
--- a/test/testSamples/pivot/cube-far-pivot.usda
+++ b/test/testSamples/pivot/cube-far-pivot.usda
@@ -1,0 +1,36 @@
+#usda 1.0
+(
+    defaultPrim = "Cube1"
+    endTimeCode = 12
+    framesPerSecond = 24
+    metersPerUnit = 0.01
+    startTimeCode = 12
+    timeCodesPerSecond = 24
+    upAxis = "Z"
+)
+
+def Mesh "Cube1" (
+    kind = "component"
+)
+{
+    uniform bool doubleSided = 1
+    float3[] extent = [(-5, -5, -5), (5, 5, 5)]
+    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+    int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+    point3f[] points = [(-5, -5, 5), (5, -5, 5), (-5, 5, 5), (5, 5, 5), (-5, 5, -5), (5, 5, -5), (-5, -5, -5), (5, -5, -5)]
+    color3f[] primvars:displayColor = [(0.13320851, 0.13320851, 0.13320851)] (
+        customData = {
+            dictionary Maya = {
+                bool generated = 1
+            }
+        }
+    )
+
+    double3 xformOp:translate = (0, 20, 0)
+    float3 xformOp:translate:pivot = (7, 7, 8)
+    float3 xformOp:translate:rotatePivot = (2, -3, -1)
+    float3 xformOp:translate:scalePivot = (2, -3, -1)
+    float3 xformOp:translate:scalePivotTranslate = (0, 0, 0)
+    uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "xformOp:translate:rotatePivot", "!invert!xformOp:translate:rotatePivot", "xformOp:translate:scalePivotTranslate", "xformOp:translate:scalePivot", "!invert!xformOp:translate:scalePivot", "!invert!xformOp:translate:pivot"]
+}
+


### PR DESCRIPTION
When there is a mix of Maya-style and USD-style pivot, handle the translate rotate pivot command differently.