### PR TITLE
EMSUSD-1260 fix rotation when prim already single-axis rotation

### DIFF
--- a/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.cpp
@@ -330,6 +330,8 @@ UsdTransform3dFallbackMayaXformStack::getOrderedOps() const
     return orderedOps;
 }
 
+bool UsdTransform3dFallbackMayaXformStack::isFallback() const { return true; }
+
 // segmentInclusiveMatrix() from UsdTransform3dBase is fine.
 
 Ufe::Matrix4d UsdTransform3dFallbackMayaXformStack::segmentExclusiveMatrix() const

--- a/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.h
@@ -78,6 +78,7 @@ public:
     Ufe::Matrix4d segmentExclusiveMatrix() const override;
 
 private:
+    bool                isFallback() const override;
     SetXformOpOrderFn   getXformOpOrderFn() const override;
     PXR_NS::TfToken     getOpSuffix(OpNdx ndx) const override;
     PXR_NS::TfToken     getTRSOpSuffix() const override;

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
@@ -95,6 +95,7 @@ public:
 protected:
     bool                        hasOp(OpNdx ndx) const;
     PXR_NS::UsdGeomXformOp      getOp(OpNdx ndx) const;
+    virtual bool                isFallback() const;
     virtual SetXformOpOrderFn   getXformOpOrderFn() const;
     virtual PXR_NS::TfToken     getOpSuffix(OpNdx ndx) const;
     virtual PXR_NS::TfToken     getTRSOpSuffix() const;


### PR DESCRIPTION
Force the prim to have a three-axis rotation when creating a rotation command.

The fallback transform implementation derives from the Maya one, but wants the old behavior of not changing how the ops work. So we add a virtual function to detect this.

Add a unit test that test the situation.