### PR TITLE
EMSUSD-1272 - CopyPaste: MayaUSD clipboard error messages when opening up preferences window

### DIFF
--- a/lib/usdUfe/python/CMakeLists.txt
+++ b/lib/usdUfe/python/CMakeLists.txt
@@ -26,12 +26,12 @@ target_sources(${PYTHON_TARGET_NAME}
 )
 
 if (UFE_CLIPBOARD_SUPPORT)
-    target_sources(${PROJECT_NAME}
+    target_sources(${PYTHON_TARGET_NAME}
         PRIVATE
             wrapClipboard.cpp
     )
 
-    target_compile_definitions(${PROJECT_NAME}
+    target_compile_definitions(${PYTHON_TARGET_NAME}
         PRIVATE
             UFE_CLIPBOARD_SUPPORT=1
     )

--- a/plugin/adsk/scripts/mayaUsd_preferenceTab.mel
+++ b/plugin/adsk/scripts/mayaUsd_preferenceTab.mel
@@ -46,8 +46,8 @@ global proc mayaUsd_PrefFileFormatChanged()
 	}
 
 	// Update the clipboard file format to match the format here.
-
-	if (`optionVar -exists $saveLayerFormatArgBinaryOptionPref`) {
+	int $haveClipboardSupport = `python("import mayaUsd.ufe as mufe; callable(getattr(mufe, 'setClipboardFileFormat', None))")`;
+	if ($haveClipboardSupport && `optionVar -exists $saveLayerFormatArgBinaryOptionPref`) {
 		int $isBinary = `optionVar -q $saveLayerFormatArgBinaryOptionPref`;
 		string $formatTag = $isBinary ? "usdc" : "usda";
 		python("import mayaUsd.ufe as mufe; mufe.setClipboardFileFormat('" + $formatTag + "')");

--- a/test/lib/ufe/testClipboard.py
+++ b/test/lib/ufe/testClipboard.py
@@ -52,6 +52,9 @@ class ClipboardHandlerTestCase(unittest.TestCase):
     def testClipboardCopyPaste(self):
         '''Basic test for the Clipboard copy/paste support.'''
 
+        # Verify that the method to set the clipboard format exists.
+        self.assertTrue(callable(getattr(mayaUsd.ufe, 'setClipboardFileFormat', None)))
+
         psPathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
         stage = mayaUsd.lib.GetPrim(psPathStr).GetStage()
         stage.DefinePrim('/Xform1', 'Xform')


### PR DESCRIPTION
#### EMSUSD-1272 - CopyPaste: MayaUSD clipboard error messages when opening up preferences window
* cmake mistake caused missing python binding