### PR TITLE
Add support for env var expansions in file node writers

### DIFF
--- a/lib/usd/translators/shading/mtlxFileTextureWriter.cpp
+++ b/lib/usd/translators/shading/mtlxFileTextureWriter.cpp
@@ -298,7 +298,7 @@ void MtlxUsd_FileWriter::Write(const UsdTimeCode& usdTime)
         return;
     }
 
-    // Resolve texture path à la file node
+    // Resolve texture path like a file node
     const MString exactTextureName = MRenderUtil::exactFileTextureName(
         rawTextureName,
         /* useFrameExt = */ false,

--- a/lib/usd/translators/shading/usdFileTextureWriter.cpp
+++ b/lib/usd/translators/shading/usdFileTextureWriter.cpp
@@ -271,7 +271,7 @@ void PxrUsdTranslators_FileTextureWriter::Write(const UsdTimeCode& usdTime)
         return;
     }
 
-    // Resolve texture path à la file node
+    // Resolve texture path like a file node
     const MString exactTextureName = MRenderUtil::exactFileTextureName(
         rawTextureName,
         /* useFrameExt = */ false,

--- a/lib/usd/translators/shading/usdFileTextureWriter.cpp
+++ b/lib/usd/translators/shading/usdFileTextureWriter.cpp
@@ -51,6 +51,7 @@
 #include <maya/MGlobal.h>
 #include <maya/MObject.h>
 #include <maya/MPlug.h>
+#include <maya/MRenderUtil.h>
 #include <maya/MStatus.h>
 #include <maya/MString.h>
 
@@ -265,9 +266,27 @@ void PxrUsdTranslators_FileTextureWriter::Write(const UsdTimeCode& usdTime)
         return;
     }
 
-    std::string fileTextureName(fileTextureNamePlug.asString(&status).asChar());
+    const MString rawTextureName = fileTextureNamePlug.asString(&status);
     if (status != MS::kSuccess) {
         return;
+    }
+
+    // Resolve texture path à la file node
+    const MString exactTextureName = MRenderUtil::exactFileTextureName(
+        rawTextureName,
+        /* useFrameExt = */ false,
+        /* currentFrameExt = */ MString(),
+        depNodeFn.absoluteName(),
+        &status);
+    if (status != MS::kSuccess) {
+        return;
+    }
+
+    std::string fileTextureName(exactTextureName.asChar(), exactTextureName.length());
+
+    // Fallback to raw name if maya resolution failed, eg file was not found
+    if (fileTextureName.empty()) {
+        fileTextureName.assign(rawTextureName.asChar(), rawTextureName.length());
     }
 
     const MPlug tilingAttr

--- a/test/lib/usd/translators/testUsdExportTexture.py
+++ b/test/lib/usd/translators/testUsdExportTexture.py
@@ -26,7 +26,9 @@ import os
 import unittest
 
 import fixturesUtils
+import testUtils
 
+PROJ_ENV_VAR_NAME = "_MAYA_USD_EXPORT_TEXTURE_TEST_PATH"
 
 class testUsdExportTexture(unittest.TestCase):
 
@@ -56,7 +58,7 @@ class testUsdExportTexture(unittest.TestCase):
             # We're removing the output file only to be nice, it is not mandatory.
             pass
 
-    def runTextureTest(self, relativeMode):
+    def runTextureTest(self, relativeMode, withEnvVar):
         projectFolder = os.path.join(self.inputPath, 'UsdExportTextureTest', 'rel_project')
         mayaScenePath = os.path.join(projectFolder, 'scenes', 'TextureTest.ma')
         cmds.file(mayaScenePath, force=True, open=True)
@@ -65,12 +67,16 @@ class testUsdExportTexture(unittest.TestCase):
         cmds.workspace(projectFolder, openWorkspace=True)
 
         # Prepare texture path to be part of the project folder.
-        texturePath = os.path.join(projectFolder, 'sourceimages', 'grid.png')
+        # build the absolute texturePath, with an env var if requested
+        textureRoot = f'${PROJ_ENV_VAR_NAME}' if withEnvVar else projectFolder
+        texturePath = os.path.join(textureRoot, 'sourceimages', 'grid.png')
         cmds.setAttr('file1.ftn', texturePath, edit=True, type='string')
 
-        # Export to USD.
+        # Export to USD, ensuring envvar is set if it is used by texture  path
         usdFilePath = self.getUsdFilePath()
-        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath, exportRelativeTextures=relativeMode)
+
+        with testUtils.TemporaryEnvironmentVariable(PROJ_ENV_VAR_NAME, projectFolder):
+            cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath, exportRelativeTextures=relativeMode)
 
         stage = Usd.Stage.Open(usdFilePath)
         self.assertTrue(stage, usdFilePath)
@@ -92,20 +98,41 @@ class testUsdExportTexture(unittest.TestCase):
         '''
         Test that texture can be exported with relative paths for textures.
         '''
-        self.runTextureTest('relative')
+        self.runTextureTest('relative', withEnvVar=False)
 
     def testExportAbsoluteTexture(self):
         '''
         Test that texture can be exported with absolute paths for textures.
         '''
-        self.runTextureTest('absolute')
+        self.runTextureTest('absolute', withEnvVar=False)
 
     def testExportAutomaticTexture(self):
         '''
         Test that texture can be exported with automatic reltive or absolute
         paths for textures.
         '''
-        self.runTextureTest('automatic')
+        self.runTextureTest('automatic', withEnvVar=False)
+
+    def testExportRelativeTextureWithEnvVar(self):
+        '''
+        Test that texture path with an environment variable expansion can be
+        exported with relative paths for textures.
+        '''
+        self.runTextureTest('relative', withEnvVar=True)
+
+    def testExportAbsoluteTextureWithEnvVar(self):
+        '''
+        Test that texture path with an environment variable expansion can be
+        exported with absolute paths for textures.
+        '''
+        self.runTextureTest('absolute', withEnvVar=True)
+
+    def testExportAutomaticTextureWithEnvVar(self):
+        '''
+        Test that texture path with an environment variable expansion can be
+        exported with automatic relative or absolute paths for textures.
+        '''
+        self.runTextureTest('automatic', withEnvVar=True)
 
 
 if __name__ == '__main__':

--- a/test/lib/usd/translators/testUsdExportTexture.py
+++ b/test/lib/usd/translators/testUsdExportTexture.py
@@ -68,7 +68,7 @@ class testUsdExportTexture(unittest.TestCase):
 
         # Prepare texture path to be part of the project folder.
         # build the absolute texturePath, with an env var if requested
-        textureRoot = f'${PROJ_ENV_VAR_NAME}' if withEnvVar else projectFolder
+        textureRoot = ('$' + PROJ_ENV_VAR_NAME) if withEnvVar else projectFolder
         texturePath = os.path.join(textureRoot, 'sourceimages', 'grid.png')
         cmds.setAttr('file1.ftn', texturePath, edit=True, type='string')
 

--- a/test/lib/usd/translators/testUsdExportTexture.py
+++ b/test/lib/usd/translators/testUsdExportTexture.py
@@ -94,6 +94,9 @@ class testUsdExportTexture(unittest.TestCase):
         self.assertEqual(os.path.isabs(exportedTexturePath.path), shouldBeAbsolute,
                          'The exported texture %s does not have the right relative mode' % exportedTexturePath)
 
+        self.assertTrue(os.path.exists(exportedTexturePath.resolvedPath),
+                        'The exported texture %s is not resolved by USD' % exportedTexturePath)
+
     def testExportRelativeTexture(self):
         '''
         Test that texture can be exported with relative paths for textures.


### PR DESCRIPTION
Fixes #3766 .

Adds support for environment variable expansions found in `file.fileTextureName` attributes at export, thanx to `MRenderUtil::exactFileTextureName`.

A more conservative surgical change would  be to use `MString::expandEnvironmentVariablesAndTilde`.  I opted for `exactFileTextureName` as it  aligns with file node logic, supporting other resolution options like `dirmap` and `MPxFileResolver` plugins, although it might introduce more side effects.
