### PR TITLE
LOOKDEVX-2903 - Update for a change in MaterialX 1.38.10

### DIFF
--- a/lib/mayaUsd/render/MaterialXGenOgsXml/OgsFragment.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/OgsFragment.cpp
@@ -419,13 +419,13 @@ OgsFragment::OgsFragment(mx::ElementPtr element, GLSL_GENERATOR_WRAPPER&& glslGe
             surfaceNode = surfaceInput->getConnectedNode();
         }
     }
-    std::string surfaceNodeName;
+    std::string           surfaceNodeName;
     std::set<std::string> surfaceInputNames;
     if (surfaceNode) {
         surfaceNodeName = surfaceNode->getName();
         const auto nodeDef = surfaceNode->getNodeDef();
         if (nodeDef) {
-            for (auto const& surfaceInput: nodeDef->getActiveInputs()) {
+            for (auto const& surfaceInput : nodeDef->getActiveInputs()) {
                 surfaceInputNames.insert(surfaceInput->getName());
             }
         }


### PR DESCRIPTION
Handle the case where a shader input has no path, yet is a valid parameter of that node. This is a behavior that was changed in MaterialX 1.38.10.