### PR TITLE
EMSUSD-1005 export materials without meshes

### DIFF
--- a/lib/mayaUsd/commands/baseExportCommand.cpp
+++ b/lib/mayaUsd/commands/baseExportCommand.cpp
@@ -431,8 +431,8 @@ MStatus MayaUSDExportCommand::doIt(const MArgList& args)
 
         const std::vector<double> timeSamples
             = UsdMayaWriteUtil::GetTimeSamples(timeInterval, frameSamples, frameStride);
-        UsdMayaJobExportArgs jobArgs
-            = UsdMayaJobExportArgs::CreateFromDictionary(userArgs, dagPaths, timeSamples);
+        UsdMayaJobExportArgs jobArgs = UsdMayaJobExportArgs::CreateFromDictionary(
+            userArgs, dagPaths, objSelList, timeSamples);
 
         std::unique_ptr<UsdMaya_WriteJob> writeJob = initializeWriteJob(jobArgs);
         if (!writeJob || !writeJob->Write(fileName, append)) {

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -280,7 +280,14 @@ struct UsdMayaJobExportArgs
     const std::string pythonPerFrameCallback;
     const std::string pythonPostCallback;
 
+    // List of object to export that are DAG objects.
     const UsdMayaUtil::MDagPathSet dagPaths;
+
+    // Full list of objects that were initially requested to be
+    // exported. Contains the DAG object and also non-DAG objects,
+    // like materials.
+    const MSelectionList fullObjectList;
+
     /// The time samples at which to export animated data; the times must be
     /// monotonically non-decreasing.
     /// An empty list of time samples means that no animated (time-sampled)
@@ -311,6 +318,7 @@ struct UsdMayaJobExportArgs
     static UsdMayaJobExportArgs CreateFromDictionary(
         const VtDictionary&             userArgs,
         const UsdMayaUtil::MDagPathSet& dagPaths,
+        const MSelectionList&           fullList,
         const std::vector<double>&      timeSamples = std::vector<double>());
 
     /// Fills a VtDictionary from the given text-encoded options.
@@ -346,11 +354,21 @@ struct UsdMayaJobExportArgs
     MAYAUSD_CORE_PUBLIC
     std::string GetResolvedFileName() const;
 
+    // Verify if meshes are exported. (i.e not excluded by excludeExportTypes)
+    bool isExportingMeshes() const;
+
+    // Verify if cameras are exported. (i.e not excluded by excludeExportTypes)
+    bool isExportingCameras() const;
+
+    // Verify if lights are exported. (i.e not excluded by excludeExportTypes)
+    bool isExportingLights() const;
+
 private:
     MAYAUSD_CORE_PUBLIC
     UsdMayaJobExportArgs(
         const VtDictionary&             userArgs,
         const UsdMayaUtil::MDagPathSet& dagPaths,
+        const MSelectionList&           fullList,
         const std::vector<double>&      timeSamples = std::vector<double>());
 };
 

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -578,7 +578,9 @@ PushCustomizeSrc pushExport(
     fnDag.getPath(dagPath);
 
     UsdMayaUtil::MDagPathSet dagPaths;
+    MSelectionList           fullObjectList;
     dagPaths.insert(dagPath);
+    fullObjectList.add(dagPath);
 
     std::vector<double> timeSamples;
     UsdMayaJobExportArgs::GetDictionaryTimeSamples(userArgs, timeSamples);
@@ -593,8 +595,8 @@ PushCustomizeSrc pushExport(
     // be merged too.
     userArgs[UsdMayaJobExportArgsTokens->exportMaterialUnderPrim] = true;
 
-    UsdMayaJobExportArgs jobArgs
-        = UsdMayaJobExportArgs::CreateFromDictionary(userArgs, dagPaths, timeSamples);
+    UsdMayaJobExportArgs jobArgs = UsdMayaJobExportArgs::CreateFromDictionary(
+        userArgs, dagPaths, fullObjectList, timeSamples);
     progressBar.advance();
 
     UsdMaya_WriteJob writeJob(jobArgs);

--- a/lib/mayaUsd/fileio/shading/shadingModePxrRis.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModePxrRis.cpp
@@ -275,9 +275,6 @@ private:
     {
         const UsdMayaShadingModeExportContext::AssignmentVector& assignments
             = context.GetAssignments();
-        if (assignments.empty()) {
-            return;
-        }
 
         UsdPrim materialPrim = context.MakeStandardMaterialPrim(assignments);
         context.BindStandardMaterialPrim(materialPrim, assignments, boundPrimPaths);

--- a/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeUseRegistry.cpp
@@ -367,9 +367,6 @@ private:
 
         const UsdMayaShadingModeExportContext::AssignmentVector& assignments
             = context.GetAssignments();
-        if (assignments.empty()) {
-            return;
-        }
 
         UsdPrim materialPrim = context.MakeStandardMaterialPrim(assignments, std::string());
         UsdShadeMaterial material(materialPrim);

--- a/lib/mayaUsd/fileio/writeJobContext.cpp
+++ b/lib/mayaUsd/fileio/writeJobContext.cpp
@@ -406,18 +406,15 @@ bool UsdMayaWriteJobContext::_NeedToTraverse(const MDagPath& curDag) const
 
         const std::string mayaTypeName(depFn.typeName().asChar());
 
-        if ((mArgs.excludeExportTypes.count(TfToken("Meshes")) != 0)
-            || (mArgs.excludeExportTypes.count(TfToken("meshes")) != 0)) {
+        if (!mArgs.isExportingMeshes()) {
             if (mayaTypeName == "mesh")
                 return false;
         }
-        if ((mArgs.excludeExportTypes.count(TfToken("Cameras")) != 0)
-            || (mArgs.excludeExportTypes.count(TfToken("camera")) != 0)) {
+        if (!mArgs.isExportingCameras()) {
             if (mayaTypeName.find("camera") != std::string::npos)
                 return false;
         }
-        if ((mArgs.excludeExportTypes.count(TfToken("Lights")) != 0)
-            || (mArgs.excludeExportTypes.count(TfToken("light")) != 0)) {
+        if (!mArgs.isExportingLights()) {
             if (mayaTypeName.find("Light") != std::string::npos)
                 return false;
         }

--- a/lib/mayaUsd/render/mayaToHydra/shadingModeExporter.cpp
+++ b/lib/mayaUsd/render/mayaToHydra/shadingModeExporter.cpp
@@ -129,7 +129,6 @@ public:
         SdfPathSet* const boundPrimPaths) override {
         const UsdMayaShadingModeExportContext::AssignmentVector& assignments =
             context.GetAssignments();
-        if (assignments.empty()) { return; }
 
         UsdPrim materialPrim = context.MakeStandardMaterialPrim(assignments);
         context.BindStandardMaterialPrim(materialPrim, assignments, boundPrimPaths);

--- a/plugin/adsk/plugin/exportTranslator.cpp
+++ b/plugin/adsk/plugin/exportTranslator.cpp
@@ -98,13 +98,16 @@ MStatus UsdMayaExportTranslator::writer(
     }
     GetFilteredSelectionToExport(exportSelected, objSelList, dagPaths);
 
-    if (dagPaths.empty()) {
-        TF_WARN("No DAG nodes to export. Skipping.");
-        return MS::kSuccess;
+    // Materials are not DAG objects, so they won't show up in the returned
+    // dagPaths, so we check the full object list instead.
+    if (objSelList.isEmpty()) {
+        TF_WARN("Nohting to export. Skipping.");
+        return MS::kFailure;
     }
     progressBar.advance();
 
-    auto jobArgs = UsdMayaJobExportArgs::CreateFromDictionary(userArgs, dagPaths, timeSamples);
+    auto jobArgs
+        = UsdMayaJobExportArgs::CreateFromDictionary(userArgs, dagPaths, objSelList, timeSamples);
     bool append = false;
     progressBar.advance();
 

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -318,15 +318,13 @@ global proc mayaUsdTranslatorExport_MeshCB() {
     mayaUsdTranslatorExport_updateDefaultPrimList();
     int $enable = `checkBoxGrp -q -v1 exportMeshesCheckBox`;
     columnLayout -e -enable $enable meshExportOptsCol;
-    columnLayout -e -enable $enable materialOptsCol2;
-    mayaUsdTranslatorExport_MaterialsCB();
 }
 
 global proc mayaUsdTranslatorExport_MaterialsCB() {
     if (`checkBoxGrp -exists exportMaterialsCheckBox` == 0)
         return;
     
-    int $enable = (`checkBoxGrp -q -v1 exportMeshesCheckBox` && `checkBoxGrp -q -v1 exportMaterialsCheckBox`);
+    int $enable = `checkBoxGrp -q -v1 exportMaterialsCheckBox`;
     mayaUsdTranslatorExport_updateDefaultPrimList();
     columnLayout -e -enable $enable materialOptsCol;
 }

--- a/plugin/adsk/scripts/mayaUsd_exportHelpers.py
+++ b/plugin/adsk/scripts/mayaUsd_exportHelpers.py
@@ -46,28 +46,39 @@ def updateDefaultPrimCandidates(excludeMesh, excludeLight, excludeCamera):
     return allItems
 
 def updateDefaultPrimCandidatesFromSelection(excludeMesh, excludeLight, excludeCamera):
+    def _getRelatives(item):
+        listInfo = cmds.listRelatives(i, fullPath=True)
+        if not listInfo:
+            return None
+        return listInfo[0]
+    
     allSelectedItems = cmds.ls(selection=True)
     allItems = set()
     for i in allSelectedItems:
-        path = cmds.listRelatives(i, fullPath=True)[0]
+        path = _getRelatives(i)
+        if not path:
+            continue
         root = path.split("|")[1]
         allItems.add(root)
 
     excludeSet = set()
+
+    def _addExclusions(nodeType):
+        nodes = cmds.ls(type=(nodeType), l=True)
+        for n in nodes:
+            path = _getRelatives(n)
+            if not path:
+                continue
+            excludeSet.add(path)
+
     if excludeMesh == "1":
-        meshes = cmds.ls(type=('mesh'), l=True)
-        for m in meshes:
-            excludeSet.add(cmds.listRelatives(m, parent=True)[0])
+        _addExclusions('mesh')
 
     if excludeLight == "1":
-        lights = cmds.ls(type=('light'), l=True)
-        for l in lights:
-            excludeSet.add(cmds.listRelatives(l, parent=True)[0])
+        _addExclusions('light')
     
     if excludeCamera == "1":
-        cameras = cmds.ls(type=('camera'), l=True)
-        for c in cameras:
-            excludeSet.add(cmds.listRelatives(c, parent=True)[0])
+        _addExclusions('camera')
 
     allItems = removeHiddenInOutliner(list(allItems - excludeSet))
     allItems.sort(key=natural_key)

--- a/plugin/pxr/maya/lib/usdMaya/exportTranslator.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/exportTranslator.cpp
@@ -77,7 +77,8 @@ MStatus UsdMayaExportTranslator::writer(
     std::vector<double> timeSamples;
     UsdMayaJobExportArgs::GetDictionaryTimeSamples(userArgs, timeSamples);
 
-    auto jobArgs = UsdMayaJobExportArgs::CreateFromDictionary(userArgs, dagPaths, timeSamples);
+    auto jobArgs
+        = UsdMayaJobExportArgs::CreateFromDictionary(userArgs, dagPaths, objSelList, timeSamples);
     bool append = false;
 
     UsdMaya_WriteJob writeJob(jobArgs);

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -249,6 +249,7 @@ endforeach()
 if (MAYA_APP_VERSION VERSION_GREATER 2022)
     set(MTLX_TEST_SCRIPT_FILES
         testUsdExportMaterialScope.py
+        testUsdExportMaterialsOnly.py
         testUsdExportMaterialX.py
         testUsdImportMaterialX.py
 		testUsdExportFannedOutFileNodesMaterial.py

--- a/test/lib/usd/translators/testUsdExportMaterialsOnly.py
+++ b/test/lib/usd/translators/testUsdExportMaterialsOnly.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env mayapy
+#
+# Copyright 2024 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pxr import Usd
+from pxr import UsdShade
+from pxr import Sdr
+
+from maya import cmds
+from maya import standalone
+
+import os
+import unittest
+
+import fixturesUtils
+
+
+class testUsdExportMaterialsOnly(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.inputPath = fixturesUtils.setUpClass(__file__)
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def _export(self, exportMeshes=False, selection=None):
+        '''
+        Export the Maya scene with or without meshes and restricted to the selection or not.
+        Then open the exported USD file.
+        '''
+        mayaFileName  = 'one-group.ma'
+        self._mayaFile = os.path.join(self.inputPath, 'UsdExportMaterialScopeTest', mayaFileName)
+        cmds.file(self._mayaFile, force=True, open=True)
+
+        if selection:
+            cmds.select(selection)
+
+        # Export to USD.
+        self._usdFilePath = os.path.abspath('MaterialsOnlyTest.usda')
+        cmds.mayaUSDExport(
+            mergeTransformAndShape=True,
+            file=self._usdFilePath,
+            shadingMode='useRegistry', 
+            convertMaterialsTo=['UsdPreviewSurface'],
+            materialsScopeName='Materials',
+            defaultPrim='top_group',
+            exportMaterials=True,
+            selection=bool(selection),
+            excludeExportTypes=[] if exportMeshes else ['Meshes'])
+
+        self._stage = Usd.Stage.Open(self._usdFilePath)
+
+    def _verifyMaterials(self, expectedMtlAndShaderPaths, expectPresent=True):
+        '''
+        Verify that the given materials and shaders are present or not.
+        '''
+        expectation = 'Expected to find' if expectPresent else 'Unexpected'
+        for expectedPath, shader in expectedMtlAndShaderPaths:
+            prim = self._stage.GetPrimAtPath(expectedPath)
+            self.assertEqual(bool(prim), expectPresent,
+                             '%s %s when exporting %s to %s' % (expectation, expectedPath, self._mayaFile, self._usdFilePath))
+            if not expectPresent or not shader:
+                continue
+            shader = self._stage.GetPrimAtPath('%s/%s' % (expectedPath, shader))
+            self.assertTrue(shader, 'Expected prim at %s to be a shader when exporting %s to %s' %  (expectedPath, self._mayaFile, self._usdFilePath))
+            shader = UsdShade.Shader(shader)
+            self.assertEqual(shader.GetIdAttr().Get(), 'UsdPreviewSurface')
+
+    def _verifyMeshes(self, expectedMeshesPaths, expectPresent=True):
+        '''
+        Verify that the given meshes are present or not.
+        '''
+        expectation = 'Expected to find' if expectPresent else 'Unexpected'
+        for expectedPath in expectedMeshesPaths:
+            prim = self._stage.GetPrimAtPath(expectedPath)
+            self.assertEqual(bool(prim), expectPresent,
+                             '%s %s when exporting %s to %s' % (expectation, expectedPath, self._mayaFile, self._usdFilePath))
+
+    def testStageOpens(self):
+        '''
+        Tests that the export can be done and that the USD stage can be opened successfully.
+        '''
+        self._export()
+        self.assertTrue(self._stage)
+
+    def testExportMeshesAndMaterials(self):
+        '''
+        Test that we can export meshes and materials and find both.
+        When exporting like this, only assigned materials are exported.
+        (Will change in the near future with a new export option.)
+        '''
+        self._export(exportMeshes=True)
+
+        expectedMtlAndShaderPaths = [
+            ('/top_group/Materials/standardSurface2SG', 'standardSurface2'),
+            ('/top_group/Materials/standardSurface3SG', 'standardSurface3'),
+            ('/top_group/Materials/standardSurface4SG', 'standardSurface4'),
+            ('/top_group/Materials/standardSurface5SG', 'standardSurface5'),
+        ]
+        self._verifyMaterials(expectedMtlAndShaderPaths)
+
+        expectedMeshPaths = [
+            '/top_group/group1/pSphere1',
+            '/top_group/group1/pCube1',
+            '/top_group/group2/pCone1',
+            '/top_group/pCylinder1',
+        ]
+        self._verifyMeshes(expectedMeshPaths, expectPresent=True)
+
+
+    def testExportSelectedMeshAndMaterial(self):
+        '''
+        Test that we can export one selected mesh and another material and find both.
+        '''
+        self._export(exportMeshes=True, selection=['pSphere1', 'standardSurface4'])
+
+        # Note: the material of the selected mesh is also exported.
+        expectedMtlAndShaderPaths = [
+            ('/top_group/Materials/standardSurface3SG', 'standardSurface3'),
+            ('/top_group/Materials/standardSurface4SG', 'standardSurface4'),
+        ]
+        self._verifyMaterials(expectedMtlAndShaderPaths)
+
+        excludedMtlAndShaderPaths = [
+            ('/top_group/Materials/standardSurface2SG', None),
+            ('/top_group/Materials/standardSurface5SG', None),
+        ]
+        self._verifyMaterials(excludedMtlAndShaderPaths, expectPresent=False)
+
+        expectedMeshPaths = [
+            '/top_group/group1/pSphere1',
+        ]
+        self._verifyMeshes(expectedMeshPaths, expectPresent=True)
+
+        excludedMeshPaths = [
+            '/top_group/group1/pCube1',
+            '/top_group/group2/pCone1',
+            '/top_group/pCylinder1',
+        ]
+        self._verifyMeshes(excludedMeshPaths, expectPresent=False)
+
+
+    def testExportMaterialsOnly(self):
+        '''
+        Test that we can export only materials.
+        In this case, all materials are exported, even if unused.
+        No mesh should be found in the exported file.
+        '''
+        self._export(exportMeshes=False)
+
+        expectedMtlAndShaderPaths = [
+            ('/top_group/Materials/initialShadingGroup', None),
+            ('/top_group/Materials/standardSurface2SG', 'standardSurface2'),
+            ('/top_group/Materials/standardSurface3SG', 'standardSurface3'),
+            ('/top_group/Materials/standardSurface4SG', 'standardSurface4'),
+            ('/top_group/Materials/standardSurface5SG', 'standardSurface5'),
+        ]
+        self._verifyMaterials(expectedMtlAndShaderPaths)
+
+        excludedMeshPaths = [
+            '/top_group/group1/pSphere1',
+            '/top_group/group1/pCube1',
+            '/top_group/group2/pCone1',
+            '/top_group/pCylinder1',
+        ]
+        self._verifyMeshes(excludedMeshPaths, expectPresent=False)
+
+    def testExportSelectedMaterialsOnly(self):
+        '''
+        Test that we can export only the selected materials.
+        In this case, all materials are exported, even if unused.
+        No mesh should be found in the exported file.
+        '''
+        self._export(exportMeshes=False, selection=['standardSurface2', 'standardSurface4'])
+
+        expectedMtlAndShaderPaths = [
+            ('/top_group/Materials/standardSurface2SG', 'standardSurface2'),
+            ('/top_group/Materials/standardSurface4SG', 'standardSurface4'),
+        ]
+        self._verifyMaterials(expectedMtlAndShaderPaths)
+
+        excludedMtlAndShaderPaths = [
+            ('/top_group/Materials/initialShadingGroup', None),
+            ('/top_group/Materials/standardSurface3SG', None),
+            ('/top_group/Materials/standardSurface5SG', None),
+        ]
+        self._verifyMaterials(excludedMtlAndShaderPaths, expectPresent=False)
+
+        excludedMeshPaths = [
+            '/top_group/group1/pSphere1',
+            '/top_group/group1/pCube1',
+            '/top_group/group2/pCone1',
+            '/top_group/pCylinder1',
+        ]
+        self._verifyMeshes(excludedMeshPaths, expectPresent=False)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
- Add the full list of Maya objects that were selected in the export job export arguments.
- Pass the full object list when creating the UsdMayaJobExportArgs in the base export command, prim updater manager and export translator.
- In specific material exporter, don't skip if the assignments are empty, since we are now exporting materials independently of meshes.
- Avoid errors when filling the default prim UI since some objects in the selections might not be DAG objects.
- Don't disable exporting materials UI when meshes are disabled since they are now independent.
- Add isExportingMeshes, isExportingCameras and isExportingLights functions to UsdMayaJobExportArgs.
- Use them instead of custom code during export.
- When exporting selected, only include materials that are selected or used by a mesh.
- When exporting all and mesh export is enabled, only export materials used by meshes.
- When exporting all and mesh export is disabled, export all materials.
- Test exporting materials with and without meshes.
- Test exporting selection with and without meshes.