### PR TITLE
EMSUSD-1122 - As a user, I'd like to copy and then paste a prim as a sibling

### DIFF
--- a/lib/usdUfe/ufe/UsdClipboard.cpp
+++ b/lib/usdUfe/ufe/UsdClipboard.cpp
@@ -21,12 +21,42 @@
 #include <pxr/usd/usd/usdcFileFormat.h>
 #include <pxr/usd/usdShade/connectableAPI.h>
 
+#include <ufe/globalSelection.h>
+#include <ufe/observableSelection.h>
+#include <ufe/observer.h>
+#include <ufe/selectionNotification.h>
+
 #if (__cplusplus < 201703L)
 #error "Compiling ClipboardHandler requires C++17"
 #endif
 #include <filesystem> // Requires C++17
 
 namespace USDUFE_NS_DEF {
+
+// TufeSelectionObserver
+//
+class UsdClipboard::TufeSelectionObserver : public Ufe::Observer
+{
+public:
+    TufeSelectionObserver(UsdClipboard& cb)
+        : Ufe::Observer()
+        , _clipboard(cb)
+    {
+    }
+
+    void operator()(const Ufe::Notification& notif)
+    {
+        // EMSUSD-1122 - As a user, I'd like to copy and then paste a prim as a sibling
+        // If the selection hasn't changed between the copy and the paste, then we'll
+        // paste into the parent of each destination parent item.
+        if (dynamic_cast<const Ufe::SelectionChanged*>(&notif)) {
+            _clipboard.ufeSelectionChanged();
+        }
+    }
+
+private:
+    UsdClipboard& _clipboard;
+};
 
 // Ensure that UsdClipboard is properly setup.
 static_assert(!std::is_copy_constructible<UsdClipboard>::value);
@@ -56,6 +86,8 @@ void UsdClipboard::setClipboardData(const PXR_NS::UsdStageWeakPtr& clipboardData
         throw std::runtime_error(error);
     }
 
+    setPasteAsSibling();
+
     // Unload the stage, otherwise when we try to set and get the next clipboard data we end up with
     // the old stage.
     clipboardData->Unload();
@@ -80,6 +112,19 @@ PXR_NS::UsdStageWeakPtr UsdClipboard::getClipboardData()
     clipboardStage->Reload();
 
     return clipboardStage;
+}
+
+void UsdClipboard::setPasteAsSibling()
+{
+    // Create a Ufe selection observer. If the selection changes after
+    // the copy or paste (not from the paste command itself though) we'll
+    // paste as sibling, rather than into paste target.
+    // This mimics the duplicate behavior.
+    if (!_ufeSelObserver) {
+        _ufeSelObserver = std::make_shared<TufeSelectionObserver>(*this);
+        Ufe::GlobalSelection::get()->addObserver(_ufeSelObserver);
+        _pasteAsSibling = true;
+    }
 }
 
 void UsdClipboard::setClipboardPath(const std::string& clipboardPath)
@@ -115,5 +160,16 @@ void UsdClipboard::cleanClipboardStageCache()
 }
 
 void UsdClipboard::removeClipboardFile() { std::filesystem::remove(_clipboardFilePath); }
+
+void UsdClipboard::ufeSelectionChanged()
+{
+    if (!_inSelectionGuard) {
+        // Any ufe selection changed event that occurs between the copy and paste (that didn't
+        // come from the paste itself) means that the user has selected what they want to be
+        // the paste target.
+        _pasteAsSibling = false;
+        _ufeSelObserver.reset();
+    }
+}
 
 } // namespace USDUFE_NS_DEF

--- a/lib/usdUfe/ufe/UsdClipboard.h
+++ b/lib/usdUfe/ufe/UsdClipboard.h
@@ -52,6 +52,10 @@ public:
     //! \return The clipboard data (aka the clipboard stage).
     PXR_NS::UsdStageWeakPtr getClipboardData();
 
+    //! \brief Should we paste the prims as a sibling of the copy?
+    bool pasteAsSibling() const { return _pasteAsSibling; }
+    void setPasteAsSibling();
+
     //! \brief Set the clipboard path, i.e. where the .usd should be exported and read from.
     //! \note The filename "UsdUfeClipboard.usd" will be appended to the input path.
     //! \param clipboardPath The new clipboard path.
@@ -84,6 +88,18 @@ private:
 
     //! \brief Remove the clipboard file by deleting it.
     void removeClipboardFile();
+
+    // When true, we paste as a sibling of copy rather than into the target.
+    bool _pasteAsSibling { true };
+
+    // Ufe selection changed observer. Used for paste as sibling detection.
+    class TufeSelectionObserver;
+    std::shared_ptr<TufeSelectionObserver> _ufeSelObserver;
+
+    // Keep track of selection changes after the copy command.
+    friend class UsdPasteClipboardCommandWithSelection;
+    bool _inSelectionGuard { false };
+    void ufeSelectionChanged();
 };
 
 } // namespace USDUFE_NS_DEF

--- a/lib/usdUfe/ufe/UsdClipboardCommands.cpp
+++ b/lib/usdUfe/ufe/UsdClipboardCommands.cpp
@@ -31,6 +31,7 @@
 #include <ufe/observableSelection.h>
 #include <ufe/runTimeMgr.h>
 #include <ufe/sceneItemOps.h>
+#include <ufe/selectionUndoableCommands.h>
 
 namespace {
 
@@ -320,9 +321,12 @@ void UsdCutClipboardCommand::execute()
     const auto& sceneItemOpsHandler
         = Ufe::RunTimeMgr::instance().sceneItemOpsHandler(UsdUfe::getUsdRunTimeId());
 
-    // Step 2. Delete the selected items.
+    auto ufeSn = Ufe::GlobalSelection::get();
+
+    // Step 2. Deselect then delete the selected items.
     for (auto&& item : _selection) {
         if (auto usdItem = downcast(item)) {
+            Ufe::SelectionRemoveItem::createAndExecute(ufeSn, item);
             sceneItemOpsHandler->sceneItemOps(usdItem)->deleteItem();
         }
     }
@@ -331,6 +335,13 @@ void UsdCutClipboardCommand::execute()
 void UsdCutClipboardCommand::undo() { _undoableItem.undo(); }
 
 void UsdCutClipboardCommand::redo() { _undoableItem.redo(); }
+
+Ufe::Selection getNewSelectionFromCommand(const UsdCutClipboardCommand& cmd)
+{
+    // Just keep the same selection (the cut items were already removed).
+    Ufe::Selection sel(*Ufe::GlobalSelection::get());
+    return sel;
+}
 
 // Ensure that UsdPasteClipboardCommand is properly setup.
 static_assert(std::is_base_of<Ufe::UndoableCommand, UsdPasteClipboardCommand>::value);
@@ -440,6 +451,12 @@ void UsdPasteClipboardCommand::execute()
         }
     };
 
+    // EMSUSD-1122 - As a user, I'd like to copy and then paste a prim as a sibling
+    // If the selection hasn't changed between the copy and the paste, then we'll
+    // paste into the parent of each destination parent item.
+    // Note: for now only applies to regular prims (not the materials or shaders).
+    bool pasteAsSibling = _clipboard->pasteAsSibling();
+
     for (const auto& dstParentItem : _dstParentItems) {
         Ufe::PasteClipboardCommand::PasteInfo pasteInfo;
         pasteInfo.pasteTarget = dstParentItem->path();
@@ -480,18 +497,60 @@ void UsdPasteClipboardCommand::execute()
         }
 
         if (!clipboardPrims.empty()) {
-            auto duplicateCmd
-                = UsdUndoDuplicateSelectionCommand::create(clipboardPrims, dstParentItem);
-            duplicateCmd->execute();
-            appendToVector(duplicateCmd->targetItems(), pasteInfo.successfulPastes);
-            auto tmpTargetItems = duplicateCmd->targetItems();
-            _targetItems.insert(_targetItems.end(), tmpTargetItems.begin(), tmpTargetItems.end());
-            _itemsToSelect.insert(
-                _itemsToSelect.end(), tmpTargetItems.begin(), tmpTargetItems.end());
+            UsdSceneItem::Ptr pasteTarget = dstParentItem;
+            if (pasteAsSibling) {
+                auto hier = Ufe::Hierarchy::hierarchy(dstParentItem);
+                auto parentItem = hier ? hier->parent() : nullptr;
+                auto newPasteTarget = downcast(parentItem);
+                if (newPasteTarget) {
+                    pasteTarget = newPasteTarget;
+                } else {
+                    pasteAsSibling = false;
+                }
+            }
+
+            // When pasting as sibling we have changed the paste target to the parent
+            // which means we might have the same parent as one of the other paste targets.
+            // We don't want to paste twice to that same parent.
+            bool skipThisTarget = false;
+            for (const auto& prevPasteInto : _pasteInfos) {
+                if (prevPasteInto.pasteTarget == pasteTarget->path()) {
+                    skipThisTarget = true;
+                    break;
+                }
+            }
+
+            if (!skipThisTarget) {
+                // When pasting as sibling we'll use an extra paste info since
+                // the paste target is different.
+                Ufe::PasteClipboardCommand::PasteInfo extraPasteInfo;
+                if (pasteAsSibling)
+                    extraPasteInfo.pasteTarget = pasteTarget->path();
+
+                auto duplicateCmd
+                    = UsdUndoDuplicateSelectionCommand::create(clipboardPrims, pasteTarget);
+                duplicateCmd->execute();
+                appendToVector(
+                    duplicateCmd->targetItems(),
+                    pasteAsSibling ? extraPasteInfo.successfulPastes : pasteInfo.successfulPastes);
+                auto tmpTargetItems = duplicateCmd->targetItems();
+                _targetItems.insert(
+                    _targetItems.end(), tmpTargetItems.begin(), tmpTargetItems.end());
+                _itemsToSelect.insert(
+                    _itemsToSelect.end(), tmpTargetItems.begin(), tmpTargetItems.end());
+
+                if (pasteAsSibling) {
+                    _pasteInfos.push_back(std::move(extraPasteInfo));
+                }
+            }
         }
 
         // Add the paste info.
         _pasteInfos.push_back(std::move(pasteInfo));
+    }
+
+    if (!pasteAsSibling) {
+        _clipboard->setPasteAsSibling();
     }
 
     // Remove ClipboardMetadata.
@@ -520,4 +579,5 @@ Ufe::Selection getNewSelectionFromCommand(const UsdPasteClipboardCommand& cmd)
     }
     return newSelection;
 }
+
 } // namespace USDUFE_NS_DEF

--- a/lib/usdUfe/ufe/UsdClipboardCommands.h
+++ b/lib/usdUfe/ufe/UsdClipboardCommands.h
@@ -91,6 +91,10 @@ private:
 
 }; // UsdCutClipboardCommand
 
+//! \brief Retrieve the desired selection after the command has executed.
+//         \see UsdUndoSelectAfterCommand.
+Ufe::Selection USDUFE_PUBLIC getNewSelectionFromCommand(const UsdCutClipboardCommand& cmd);
+
 //! \brief Command to paste the USD prims from the clipboard.
 class USDUFE_PUBLIC UsdPasteClipboardCommand : public Ufe::PasteClipboardCommand
 {
@@ -138,6 +142,7 @@ private:
     Ufe::SceneItemList _itemsToSelect;
 
     // The cmd gets the clipboard data when executed.
+    friend class UsdPasteClipboardCommandWithSelection;
     UsdClipboard::Ptr _clipboard;
 
     // The info messages for the pasted items.


### PR DESCRIPTION
#### EMSUSD-1122 - As a user, I'd like to copy and then paste a prim as a sibling
* Added selection observer to UsdClipboard to track when to reset the "paste as sibling".
* Fixed bug with cut command which wasn't removing the cut item from selection. Added unit test for this.
* New logic in paste command (for regular prims only) to paste as a sibling of the copy rather than into the paste target if the selection wasn't changed between copy and paste.
* Overrode the paste command execute to set a selection guard since the paste command selects newly pasted prims.
* New unit test for pasting multiple times to test paste as sibling.