### PR TITLE
EMSUSD-1196 material scope as default prim

### DIFF
--- a/lib/mayaUsd/fileio/functorPrimWriter.cpp
+++ b/lib/mayaUsd/fileio/functorPrimWriter.cpp
@@ -56,8 +56,7 @@ void UsdMaya_FunctorPrimWriter::Write(const UsdTimeCode& usdTime)
     const UsdMayaPrimWriterArgs args(
         GetDagPath(),
         _GetExportArgs().exportRefsAsInstanceable,
-        _GetExportArgs().excludeExportTypes,
-        _GetExportArgs().defaultPrim);
+        _GetExportArgs().excludeExportTypes);
 
     UsdMayaPrimWriterContext ctx(usdTime, GetUsdPath(), GetUsdStage());
 

--- a/lib/mayaUsd/fileio/jobs/writeJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/writeJob.cpp
@@ -490,12 +490,6 @@ bool UsdMaya_WriteJob::_FinishWriting()
 {
     MayaUsd::ProgressBarScope progressBar(7);
 
-    // Note: we must prune empty groups before retrieving the list
-    //       of root prims, otherwise we will use prims that will be
-    //       subsequently deleted.
-    _PruneEmpties();
-    progressBar.advance();
-
     UsdPrimSiblingRange usdRootPrims = mJobCtx.mStage->GetPseudoRoot().GetChildren();
 
     // Write Variants (to first root prim path)
@@ -583,6 +577,9 @@ bool UsdMaya_WriteJob::_FinishWriting()
     }
 
     _PostCallback();
+    progressBar.advance();
+
+    _PruneEmpties();
     progressBar.advance();
 
     TF_STATUS("Saving stage");

--- a/lib/mayaUsd/fileio/primWriterArgs.cpp
+++ b/lib/mayaUsd/fileio/primWriterArgs.cpp
@@ -24,12 +24,10 @@ PXR_NAMESPACE_OPEN_SCOPE
 UsdMayaPrimWriterArgs::UsdMayaPrimWriterArgs(
     const MDagPath&     dagPath,
     const bool          exportRefsAsInstanceable,
-    const TfToken::Set& excludeExportTypes,
-    const std::string&  defaultPrim)
+    const TfToken::Set& excludeExportTypes)
     : _dagPath(dagPath)
     , _exportRefsAsInstanceable(exportRefsAsInstanceable)
     , _excludeExportTypes(excludeExportTypes)
-    , _defaultPrim(defaultPrim)
 {
 }
 

--- a/lib/mayaUsd/fileio/primWriterArgs.h
+++ b/lib/mayaUsd/fileio/primWriterArgs.h
@@ -41,8 +41,7 @@ public:
     UsdMayaPrimWriterArgs(
         const MDagPath&     dagPath,
         const bool          exportRefsAsInstanceable,
-        const TfToken::Set& excludeExportTypes,
-        const std::string&  defaultPrim);
+        const TfToken::Set& excludeExportTypes);
 
     /// \brief returns the MObject that should be exported.
     MAYAUSD_CORE_PUBLIC
@@ -71,7 +70,6 @@ private:
     MDagPath     _dagPath;
     bool         _exportRefsAsInstanceable;
     TfToken::Set _excludeExportTypes;
-    std::string  _defaultPrim;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
@@ -395,7 +395,7 @@ static UsdPrim _GetMaterialParent(
     if (shaderExportLocation.IsEmpty())
         shaderExportLocation = SdfPath::AbsoluteRootPath();
 
-    if (!defaultPrim.empty())
+    if (!defaultPrim.empty() && defaultPrim != materialsScopeName)
         shaderExportLocation = shaderExportLocation.AppendChild(TfToken(defaultPrim));
 
     if (!materialsScopeName.IsEmpty())

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -217,19 +217,23 @@ global proc mayaUsdTranslatorExport_setDefaultPrim(string $defaultPrimName) {
     if (`optionMenuGrp -exists exportDefaultPrim` == 0){
         return;
     }
-    if ((`checkBoxGrp -exists exportMeshesCheckBox` == 0)||(`checkBoxGrp -exists exportLightsCheckBox` == 0)||(`checkBoxGrp -exists exportCamerasCheckBox` == 0)){
-        return;
-    }
     // set the default prim if it's available
     catchQuiet(`optionMenuGrp -e -value $defaultPrimName exportDefaultPrim`);
 }
 
+proc int mayaUsdTranslatorExport_isCheckBoxOn(string $cbName)
+{
+    if (`checkBoxGrp -exists $cbName` == 0)
+        return 0;
+    
+    if (`checkBoxGrp -q -v1 $cbName` == 0)
+        return 0;
+
+    return 1;
+}
+
 global proc mayaUsdTranslatorExport_updateDefaultPrimList() {
     if (`optionMenuGrp -exists exportDefaultPrim` == 0){
-        return;
-    }
-
-    if ((`checkBoxGrp -exists exportMeshesCheckBox` == 0)||(`checkBoxGrp -exists exportLightsCheckBox` == 0)||(`checkBoxGrp -exists exportCamerasCheckBox` == 0)){
         return;
     }
 
@@ -247,9 +251,9 @@ global proc mayaUsdTranslatorExport_updateDefaultPrimList() {
         }
     }
 
-    int $excludeMesh = (`checkBoxGrp -q -v1 exportMeshesCheckBox` == 0);
-    int $excludeLight = (`checkBoxGrp -q -v1 exportLightsCheckBox` == 0);
-    int $excludeCamera = (`checkBoxGrp -q -v1 exportCamerasCheckBox` == 0);
+    int $excludeMesh = (mayaUsdTranslatorExport_isCheckBoxOn("exportMeshesCheckBox") == 0);
+    int $excludeLight = (mayaUsdTranslatorExport_isCheckBoxOn("exportLightsCheckBox") == 0);
+    int $excludeCamera = (mayaUsdTranslatorExport_isCheckBoxOn("exportCamerasCheckBox") == 0);
 
     string $allItems[];
     global int $exportAll;
@@ -258,6 +262,15 @@ global proc mayaUsdTranslatorExport_updateDefaultPrimList() {
 
     } else{
         $allItems = `python("import mayaUsd_exportHelpers; mayaUsd_exportHelpers.updateDefaultPrimCandidatesFromSelection('" + $excludeMesh + "','" + $excludeLight + "', '" + $excludeCamera +"')")`;
+    }
+
+    // Note: we only add the material scope if meshes are *not* listed.
+    int $includeMaterials = ($excludeMesh != 0) && (mayaUsdTranslatorExport_isCheckBoxOn("exportMaterialsCheckBox") != 0);
+    if ($includeMaterials) {
+        string $materialScopeName = `python("import mayaUsd_exportHelpers; mayaUsd_exportHelpers.getDefaultMaterialScopeName()")`;
+        if (size($materialScopeName) > 0) {
+            stringArrayInsertAtIndex(255, $allItems, $materialScopeName);
+        }
     }
 
     for($item in $allItems){
@@ -272,6 +285,9 @@ global proc mayaUsdTranslatorExport_updateDefaultPrimList() {
 
 }
 
+// This is called to update the default prim drop-down with the
+// explicit root prim name entered by the user. If the explicit
+// name is empty, we fill teh default prim menu as usual.
 proc updateDefaultPrimOptionMenu(string $rootPrim) {
     if (`optionMenuGrp -exists exportDefaultPrim` == 0){
         return;

--- a/plugin/adsk/scripts/mayaUsd_exportHelpers.py
+++ b/plugin/adsk/scripts/mayaUsd_exportHelpers.py
@@ -1,4 +1,5 @@
 import maya.cmds as cmds
+import mayaUsd.lib
 import re
 from mayaUSDRegisterStrings import getMayaUsdString
 
@@ -83,3 +84,9 @@ def updateDefaultPrimCandidatesFromSelection(excludeMesh, excludeLight, excludeC
     allItems = removeHiddenInOutliner(list(allItems - excludeSet))
     allItems.sort(key=natural_key)
     return allItems
+
+def getDefaultMaterialScopeName():
+    '''
+    Retrieve the default material scope name.
+    '''
+    return  mayaUsd.lib.JobExportArgs.GetDefaultMaterialsScopeName()

--- a/test/lib/mayaUsd/fileio/testComponentTags.py
+++ b/test/lib/mayaUsd/fileio/testComponentTags.py
@@ -51,6 +51,7 @@ class testComponentTags(unittest.TestCase):
         cmds.mayaUSDExport(mergeTransformAndShape=True,
             file=usdFilePath,
             shadingMode='none',
+            defaultPrim='pSphere1',
             exportComponentTags=True)
 
         cmds.file(new=True, force=True)
@@ -74,6 +75,7 @@ class testComponentTags(unittest.TestCase):
         cmds.mayaUSDExport(mergeTransformAndShape=True,
             file=usdFilePath,
             shadingMode='none',
+            defaultPrim='pSphere1',
             exportComponentTags=False)
 
         cmds.file(new=True, force=True)

--- a/test/lib/mayaUsd/fileio/testSchemaApiAdaptor.py
+++ b/test/lib/mayaUsd/fileio/testSchemaApiAdaptor.py
@@ -413,7 +413,7 @@ class testSchemaApiAdaptor(unittest.TestCase):
         schemasToExport = ["PhysicsMassAPI", "PhysicsRigidBodyAPI"]
         # Export, with Bullet:
         usdFilePath = os.path.abspath('UsdExportSchemaApiTest_WithBullet.usda')
-        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
+        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath, defaultPrim='pSphere1',
                            apiSchema=schemasToExport, frameRange=(1, 10))
 
         # Check that Physics API schemas did get exported:

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawColors.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeDrawColors.py
@@ -73,7 +73,7 @@ class testProxyShapeDrawColors(imageUtils.ImageDiffingTestCase):
         x = self._PlaneWithColor((0.55, 0.55, 0.55))
         cmds.select(x)
         usdFile = os.path.join(self._testDir, 'plane.usd')
-        cmds.mayaUSDExport(file=usdFile, selection=True, shadingMode='none',
+        cmds.mayaUSDExport(file=usdFile, selection=True, shadingMode='none', defaultPrim='pPlane1',
             exportDisplayColor=True)
         proxyShape = cmds.createNode('mayaUsdProxyShape', name='usdProxyShape')
         proxyTransform = cmds.listRelatives(proxyShape, parent=True,

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateMaterialX.py
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateMaterialX.py
@@ -232,7 +232,7 @@ class testVP2RenderDelegateMaterialX(imageUtils.ImageDiffingTestCase):
         cmds.rotate(-90, 0, 0, 'persp')
         self.assertSnapshotClose('place2dTextureShowcase_Maya_render.png', 960, 960)
         usdFilePath = os.path.join(self._testDir, "place2dTextureShowcase.usda")
-        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
+        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath, defaultPrim='locator1',
             shadingMode='useRegistry', convertMaterialsTo=['MaterialX'],
             materialsScopeName='Materials')
         xform, shape = mayaUtils.createProxyFromFile(usdFilePath)
@@ -261,7 +261,7 @@ class testVP2RenderDelegateMaterialX(imageUtils.ImageDiffingTestCase):
         cmds.rotate(-90, 0, 0, 'persp')
         self.assertSnapshotClose('mtlxNodesShowcase_Maya_render.png', 960, 960)
         usdFilePath = os.path.join(self._testDir, "mtlxNodesShowcase.usda")
-        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
+        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath, defaultPrim='locator1',
             shadingMode='useRegistry', convertMaterialsTo=['MaterialX'],
             materialsScopeName='Materials')
         xform, shape = mayaUtils.createProxyFromFile(usdFilePath)
@@ -410,12 +410,12 @@ class testVP2RenderDelegateMaterialX(imageUtils.ImageDiffingTestCase):
             cmds.setAttr(file_node + ".defaultColor", 0.5, 0.25, 0.125, type="double3")
 
         usdFilePath = os.path.join(self._testDir, "explicit_ocio_usd.usda")
-        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
+        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath, defaultPrim='pPlane1',
             shadingMode='useRegistry', convertMaterialsTo=['UsdPreviewSurface'],
             materialsScopeName='mtl')
 
         mtlxFilePath = os.path.join(self._testDir, "explicit_ocio_mtlx.usda")
-        cmds.mayaUSDExport(mergeTransformAndShape=True, file=mtlxFilePath,
+        cmds.mayaUSDExport(mergeTransformAndShape=True, file=mtlxFilePath, defaultPrim='pPlane1',
             shadingMode='useRegistry', convertMaterialsTo=['MaterialX'],
             materialsScopeName='mtl')
 

--- a/test/lib/usd/translators/testUsdExportDefaultPrim.py
+++ b/test/lib/usd/translators/testUsdExportDefaultPrim.py
@@ -38,31 +38,75 @@ class testUsdExportMesh(unittest.TestCase):
     def tearDownClass(cls):
         standalone.uninitialize()
 
-    def testExportDefaultPrim(self):
-        cmds.file(self.testFile, force=True, open=True)
-        usdFile = os.path.abspath('UsdExportDefaultPrim.usda')
+    def testExportMeshDefaultPrim(self):
+        '''Export to USD with a mesh set as the default prim.'''
+        usdFile = os.path.abspath('UsdExportMeshDefaultPrim.usda')
 
         cmds.usdExport(mergeTransformAndShape=True, file=usdFile,
             shadingMode='none', defaultPrim='pSphere1')
         
         stage = Usd.Stage.Open(usdFile)
-        self.assertEqual(stage.GetDefaultPrim().GetName(), 'pSphere1')
+        defaultPrim = stage.GetDefaultPrim()
+        self.assertTrue(defaultPrim)
+        self.assertEqual(defaultPrim.GetName(), 'pSphere1')
 
-        cmds.file(self.testFile, force=True, open=True)
+    def testExportLightDefaultPrim(self):
+        '''Export to USD with a light set as the default prim.'''
+        usdFile = os.path.abspath('UsdExportLightDefaultPrim.usda')
+
         cmds.usdExport(mergeTransformAndShape=True, file=usdFile,
             shadingMode='none', defaultPrim='pointLight1')
         
         stage = Usd.Stage.Open(usdFile)
-        self.assertEqual(stage.GetDefaultPrim().GetName(), 'pointLight1')
+        defaultPrim = stage.GetDefaultPrim()
+        self.assertTrue(defaultPrim)
+        self.assertEqual(defaultPrim.GetName(), 'pointLight1')
 
-        # Test setting default prim with set parent scope on export
-        cmds.file(self.testFile, force=True, open=True)
-        usdFile = os.path.abspath('UsdExportDefaultPrim.usda')
+    def testExportRootScopeDefaultPrim(self):
+        '''Export to USD with a scope set as the default prim.'''
+        usdFile = os.path.abspath('UsdExportScopeDefaultPrim.usda')
         cmds.usdExport(mergeTransformAndShape=True, file=usdFile,
             shadingMode='none', rootPrim='testScope', defaultPrim = 'testScope')
         
         stage = Usd.Stage.Open(usdFile)
-        self.assertEqual(stage.GetDefaultPrim().GetName(), 'testScope')
+        defaultPrim = stage.GetDefaultPrim()
+        self.assertTrue(defaultPrim)
+        self.assertEqual(defaultPrim.GetName(), 'testScope')
+
+    def testExportNoDefaultPrim(self):
+        '''Export to USD with no default prim.'''
+        usdFile = os.path.abspath('UsdExportScopeDefaultPrim.usda')
+        cmds.usdExport(mergeTransformAndShape=True, file=usdFile,
+            shadingMode='none', defaultPrim=None)
+        
+        stage = Usd.Stage.Open(usdFile)
+        defaultPrim = stage.GetDefaultPrim()
+        self.assertFalse(defaultPrim)
+
+    def testExportMaterialScopeDefaultPrim(self):
+        '''Export to USD with no default prim.'''
+        usdFile = os.path.abspath('UsdExportMaterialScopeDefaultPrim.usda')
+        cmds.usdExport(mergeTransformAndShape=True, file=usdFile,
+            shadingMode='useRegistry', convertMaterialsTo=['UsdPreviewSurface'], defaultPrim='mtl')
+        
+        stage = Usd.Stage.Open(usdFile)
+        defaultPrim = stage.GetDefaultPrim()
+        self.assertTrue(defaultPrim)
+        self.assertEqual(defaultPrim.GetName(), 'mtl')
+        self.assertFalse(stage.GetPrimAtPath('/mtl/mtl'))
+
+    def testExportNoMeshMaterialScopeDefaultPrim(self):
+        '''Export to USD with no default prim.'''
+        usdFile = os.path.abspath('UsdExportNoMeshMaterialScopeDefaultPrim.usda')
+        cmds.usdExport(mergeTransformAndShape=True, file=usdFile,
+            shadingMode='useRegistry', convertMaterialsTo=['UsdPreviewSurface'], defaultPrim='mtl',
+            excludeExportTypes=['Meshes'])
+        
+        stage = Usd.Stage.Open(usdFile)
+        defaultPrim = stage.GetDefaultPrim()
+        self.assertTrue(defaultPrim)
+        self.assertEqual(defaultPrim.GetName(), 'mtl')
+        self.assertFalse(stage.GetPrimAtPath('/mtl/mtl'))
 
 
 if __name__ == '__main__':

--- a/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
+++ b/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
@@ -471,6 +471,7 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
             usd_path = os.path.abspath('CubeWithAssignedFaces_CB.usda')
             cmds.usdExport(mergeTransformAndShape=True,
                 file=usd_path,
+                defaultPrim='pCube1',
                 shadingMode='useRegistry',
                 exportDisplayColor=False,
                 exportCollectionBasedBindings=True,
@@ -479,6 +480,7 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
             usd_path = os.path.abspath('CubeWithAssignedFaces.usda')
             cmds.usdExport(mergeTransformAndShape=True,
                 file=usd_path,
+                defaultPrim='pCube1',
                 shadingMode='useRegistry',
                 exportDisplayColor=False,
                 exportComponentTags=True)
@@ -572,12 +574,12 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
         geomSubset = stage.GetPrimAtPath("/pCube1/left")
         geomSubset.GetAttribute("familyName").Set("materialBind")
         subsetBindAPI = UsdShade.MaterialBindingAPI.Apply(geomSubset.GetPrim())
-        subsetBindAPI.Bind(UsdShade.Material(stage.GetPrimAtPath("/Looks/blueFaceSG")))
+        subsetBindAPI.Bind(UsdShade.Material(stage.GetPrimAtPath("/pCube1/Looks/blueFaceSG")))
 
         meshBindAPI = UsdShade.MaterialBindingAPI(stage.GetPrimAtPath("/pCube1"))
         geomSubset = meshBindAPI.CreateMaterialBindSubset("newKidOnTheBlock", [1, 2], UsdGeom.Tokens.face)
         subsetBindAPI = UsdShade.MaterialBindingAPI.Apply(geomSubset.GetPrim())
-        subsetBindAPI.Bind(UsdShade.Material(stage.GetPrimAtPath("/Looks/redFaceSG")))
+        subsetBindAPI.Bind(UsdShade.Material(stage.GetPrimAtPath("/pCube1/Looks/redFaceSG")))
 
         # The "unassigned faced" were previously [1, 2, 3, 5]
         # We have assigned faces 1, 2, and 5 (left), so the only one remaining is 3:

--- a/test/lib/usd/translators/testUsdExportSchemaApi.py
+++ b/test/lib/usd/translators/testUsdExportSchemaApi.py
@@ -97,7 +97,7 @@ class testUsdExportSchemaApi(unittest.TestCase):
 
         cmds.polySphere(r=1)
         usdFilePath = os.path.abspath('UsdExportSchemaApiTestBasic.usda')
-        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath, 
+        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath, defaultPrim='pSphere1',
                            jobContext=["Larry", "Curly", "Moe"])
 
         self.assertFalse(mark.IsClean())
@@ -121,7 +121,7 @@ class testUsdExportSchemaApi(unittest.TestCase):
 
         cmds.polySphere(r=1)
         usdFilePath = os.path.abspath('UsdExportSchemaApiTestBasic.usda')
-        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath, 
+        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath, defaultPrim='pSphere1',
                            jobContext=["NullAPI", "Moe"])
 
         self.assertFalse(mark.IsClean())
@@ -236,7 +236,7 @@ class testUsdExportSchemaApi(unittest.TestCase):
 
         # Export, but without enabling Bullet:
         usdFilePath = os.path.abspath('UsdExportSchemaApiTest_NoBullet.usda')
-        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath)
+        cmds.mayaUSDExport(mergeTransformAndShape=True, defaultPrim='pSphere1', file=usdFilePath)
 
         # Check that there are no Physics API schemas exported:
         stage = Usd.Stage.Open(usdFilePath)
@@ -246,7 +246,7 @@ class testUsdExportSchemaApi(unittest.TestCase):
 
         # Export, with Bullet:
         usdFilePath = os.path.abspath('UsdExportSchemaApiTest_WithBullet.usda')
-        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
+        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath, defaultPrim='pSphere1',
                            jobContext=["Bullet"], frameRange=(1, 10))
 
         # Check that Physics API schemas did get exported:

--- a/test/lib/usd/translators/testUsdExportSkeleton.py
+++ b/test/lib/usd/translators/testUsdExportSkeleton.py
@@ -348,6 +348,7 @@ class testUsdExportSkeleton(unittest.TestCase):
                 "worldspace": True,
                 "stripNamespaces" : True,
                 "shadingMode":"none",
+                "defaultPrim":"jointsGrp",
                 "exportRoots":("jointsGrp",),
                 "exportSkels":"auto",
             }

--- a/test/lib/usd/translators/testUsdImportEulerFilter.py
+++ b/test/lib/usd/translators/testUsdImportEulerFilter.py
@@ -46,7 +46,7 @@ def build_skel_scene(out_file):
     cmds.setKeyframe('joint1.ry', v=-85.968, t=[1])
     cmds.setKeyframe('joint1.ry', v=-85.127, t=[2])
     
-    cmds.mayaUSDExport(file=out_file, skl='auto', skn='auto', fr=[1,2])
+    cmds.mayaUSDExport(file=out_file, skl='auto', skn='auto', fr=[1,2], defaultPrim='group')
     
     
 
@@ -60,7 +60,7 @@ def build_xform_scene(out_file):
     cmds.setKeyframe('pCube1.ry', v=-85.968, t=[1])
     cmds.setKeyframe('pCube1.ry', v=-85.127, t=[2])
 
-    cmds.mayaUSDExport(file=out_file, fr=[1,2])
+    cmds.mayaUSDExport(file=out_file, fr=[1,2], defaultPrim='pCube1')
 
 
 class testUsdImportEulerFilter(unittest.TestCase):

--- a/test/lib/usd/translators/testUsdImportExportSiteSpecificConfig.py
+++ b/test/lib/usd/translators/testUsdImportExportSiteSpecificConfig.py
@@ -84,7 +84,7 @@ class testSiteSpecificConfig(unittest.TestCase):
 
         # Export scene, which should use site-specific settings and trigger the chaser:
         usd_file_path = os.path.join(self.temp_dir, "SiteSpecificFile.usda")
-        cmds.mayaUSDExport(file=usd_file_path)
+        cmds.mayaUSDExport(file=usd_file_path, defaultPrim='pCube1')
 
         # Import scene, which should use site-specific settings and trigger the chaser:
         cmds.mayaUSDImport(file=usd_file_path)

--- a/test/lib/usd/translators/testUsdImportXforms.py
+++ b/test/lib/usd/translators/testUsdImportXforms.py
@@ -155,7 +155,7 @@ class testUsdImportXforms(unittest.TestCase):
         # Now write out a usd file with all our xforms...
         cmds.select(allNodes)
         usdPath = os.path.abspath('UsdImportMayaXformVariationsTest.usdc')
-        cmds.usdExport(selection=1, file=usdPath)
+        cmds.usdExport(selection=1, file=usdPath, defaultPrim='topPrim')
         
         # Now import, and make sure it round-trips as expected
         cmds.file(new=1, f=1)


### PR DESCRIPTION
- Prune empty group at the start of the finish step of export to avoid using a prim that will be deleted as a root prim.
- No longer set the first prim of the USD file as teh default prim when no default prim is specified.
- That was breaking the user's choice of not having any default prim.
- Users that depended on this behavior can use the "-defaultPrim" export flag to explicitly set the default prim instead of relying on the implicit behavior.
- Don't add the default prim name as a parent of the material scope when the material scope *is* the default prim.
- Add a Python helper to retrieve the default material scope name.
- Add the material scope name to the default-prim drop-down when meshes are off and materials are on.
- Remove unused default prim data member from UsdMayaPrimWriterArgs.
- Add unit tests.
- Fix unit tests that were failing due to export no longer always having a default prim by default. Fixed them by specifying the default prim during export.