### PR TITLE
Update googletest & gulrak (filesystem)

### DIFF
--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -26,7 +26,13 @@ macro(fetch_googletest)
         file(TO_CMAKE_PATH ${CMAKE_MAKE_PROGRAM} CMAKE_MAKE_PROGRAM)
 
         # Set some options used when compiling googletest.
-        set(CMAKE_CXX_STANDARD 11)
+
+        # USD updated to c++17 for USD v23.11
+        if(USD_VERSION VERSION_GREATER_EQUAL "0.23.11")
+            set(CMAKE_CXX_STANDARD 17)
+        else()
+            set(CMAKE_CXX_STANDARD 11)
+        endif()
         set(CMAKE_CXX_EXTENSIONS OFF)
         set(CMAKE_CXX_STANDARD_REQUIRED ON)
         if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/cmake/googletest_download.txt.in
+++ b/cmake/googletest_download.txt.in
@@ -14,6 +14,7 @@ ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   GIT_TAG           release-1.10.0
   GIT_CONFIG        advice.detachedHead=false
+  GIT_SHALLOW       TRUE
   SOURCE_DIR        "${GOOGLETEST_BUILD_ROOT}/googletest-src"
   BINARY_DIR        "${GOOGLETEST_BUILD_ROOT}/googletest-build"
   CMAKE_ARGS

--- a/cmake/gulrak.cmake
+++ b/cmake/gulrak.cmake
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Autodesk
+# Copyright 2024 Autodesk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 include(FetchContent)
 
-set(CONTENT_NAME gulrak)
-
 set(FETCHCONTENT_QUIET OFF)
 
 # GULRAK_SOURCE_DIR : Set this to the directory where you have cloned gulrak filesystem repo, 
@@ -26,23 +24,18 @@ if(DEFINED GULRAK_SOURCE_DIR)
     file(TO_CMAKE_PATH "${GULRAK_SOURCE_DIR}" GULRAK_SOURCE_DIR)
     message(STATUS "**** Building Gulrak From " ${GULRAK_SOURCE_DIR})
     FetchContent_Declare(
-        ${CONTENT_NAME}
+        gulrak
         URL ${GULRAK_SOURCE_DIR}
     )
 
-    string(TOUPPER ${CONTENT_NAME} UPPERGULARK)
-    mark_as_advanced(FETCHCONTENT_SOURCE_DIR_${UPPERGULARK})
+    mark_as_advanced(FETCHCONTENT_SOURCE_DIR_GULRAK)
     mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_${UPPERGULARK})
-
 else()
     message(STATUS "**** Building Gulrak From Github Repository.")
     FetchContent_Declare(
-        ${CONTENT_NAME}
-        GIT_REPOSITORY https://github.com/gulrak/filesystem.git
-        GIT_TAG        4e21ab305794f5309a1454b4ae82ab9a0f5e0d25
-        USES_TERMINAL_DOWNLOAD TRUE
-        GIT_CONFIG     advice.detachedHead=false
+        gulrak
+        URL https://github.com/gulrak/filesystem/archive/refs/tags/v1.5.14.zip
     )
 endif()
 
-FetchContent_MakeAvailable(${CONTENT_NAME})
+FetchContent_MakeAvailable(gulrak)

--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -59,8 +59,6 @@
 #include <maya/MStatus.h>
 #include <maya/MTime.h>
 
-#include <ghc/filesystem.hpp>
-
 #include <map>
 #include <string>
 #include <unordered_map>

--- a/lib/usd/translators/shading/mtlxFileTextureReader.cpp
+++ b/lib/usd/translators/shading/mtlxFileTextureReader.cpp
@@ -51,8 +51,6 @@
 #include <maya/MPlug.h>
 #include <maya/MStatus.h>
 
-#include <ghc/filesystem.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 class MtlxUsd_FileTextureReader : public MtlxUsd_BaseReader

--- a/lib/usd/translators/shading/mtlxFileTextureWriter.cpp
+++ b/lib/usd/translators/shading/mtlxFileTextureWriter.cpp
@@ -56,8 +56,6 @@
 #include <maya/MStatus.h>
 #include <maya/MString.h>
 
-#include <ghc/filesystem.hpp>
-
 #include <regex>
 
 PXR_NAMESPACE_OPEN_SCOPE

--- a/lib/usd/translators/shading/mtlxImageReader.cpp
+++ b/lib/usd/translators/shading/mtlxImageReader.cpp
@@ -52,8 +52,6 @@
 #include <maya/MPlug.h>
 #include <maya/MStatus.h>
 
-#include <ghc/filesystem.hpp>
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 class MtlxUsd_ImageReader : public MtlxUsd_BaseReader


### PR DESCRIPTION
* Set C++ version when building googletest and use shallow clone (no history is needed).
* Update gulrak version from 1.5.6 to 1.5.14.
* Remove unneeded filesystem include.