### PR TITLE
EMSUSD-1351 - MayaUsd: Code cleanup - No pragma once

### DIFF
--- a/lib/mayaUsd/base/mayaUsd.h.src
+++ b/lib/mayaUsd/base/mayaUsd.h.src
@@ -14,7 +14,8 @@
 // limitations under the License.
 //
 
-#pragma once
+#ifndef MAYAUSD_H
+#define MAYAUSD_H
 
 #define MAYAUSD_MAJOR_VERSION ${MAYAUSD_MAJOR_VERSION}
 #define MAYAUSD_MINOR_VERSION ${MAYAUSD_MINOR_VERSION}
@@ -87,3 +88,5 @@ static_assert(!std::is_move_constructible<TypeName>::value, \
               "Class should NOT be move constructible");    \
 static_assert(!std::is_move_assignable<TypeName>::value,    \
               "Class should NOT be move assignable");
+
+#endif // MAYAUSD_H

--- a/lib/mayaUsd/commands/PullPushCommands.h
+++ b/lib/mayaUsd/commands/PullPushCommands.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_PULLPUSHCOMMANDS_H
+#define MAYAUSD_PULLPUSHCOMMANDS_H
 
 #ifndef PXRUSDMAYA_PULLPUSHCOMMANDS_H
 #define PXRUSDMAYA_PULLPUSHCOMMANDS_H
@@ -183,3 +184,5 @@ private:
 } // namespace MAYAUSD_NS_DEF
 
 #endif /* PXRUSDMAYA_PULLPUSHCOMMANDS_H */
+
+#endif // MAYAUSD_PULLPUSHCOMMANDS_H

--- a/lib/mayaUsd/fileio/importData.h
+++ b/lib/mayaUsd/fileio/importData.h
@@ -14,7 +14,8 @@
 // limitations under the License.
 //
 
-#pragma once
+#ifndef MAYAUSD_IMPORTDATA_H
+#define MAYAUSD_IMPORTDATA_H
 
 #include <mayaUsd/base/api.h>
 
@@ -140,3 +141,5 @@ private:
 };
 
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_IMPORTDATA_H

--- a/lib/mayaUsd/fileio/orphanedNodesManager.h
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.h
@@ -14,7 +14,8 @@
 // limitations under the License.
 //
 
-#pragma once
+#ifndef MAYAUSD_ORPHANEDNODESMANAGER_H
+#define MAYAUSD_ORPHANEDNODESMANAGER_H
 
 #include <mayaUsd/base/api.h>
 
@@ -201,3 +202,5 @@ private:
 };
 
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_ORPHANEDNODESMANAGER_H

--- a/lib/mayaUsd/fileio/translators/translatorMesh.h
+++ b/lib/mayaUsd/fileio/translators/translatorMesh.h
@@ -16,7 +16,8 @@
 // Modifications copyright (C) 2020 Autodesk
 //
 
-#pragma once
+#ifndef MAYAUSD_TRANSLATORMESH_H
+#define MAYAUSD_TRANSLATORMESH_H
 
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/fileio/primReaderRegistry.h>
@@ -95,3 +96,5 @@ private:
 };
 
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_TRANSLATORMESH_H

--- a/lib/mayaUsd/fileio/utils/orphanedNodesManagerUtil.h
+++ b/lib/mayaUsd/fileio/utils/orphanedNodesManagerUtil.h
@@ -14,7 +14,8 @@
 // limitations under the License.
 //
 
-#pragma once
+#ifndef MAYAUSD_ORPHANEDNODESMANAGERUTIL_H
+#define MAYAUSD_ORPHANEDNODESMANAGERUTIL_H
 
 #include <mayaUsd/fileio/orphanedNodesManager.h>
 
@@ -52,3 +53,5 @@ void printOrphanedNodesManagerPullInfo(
 
 } // namespace utils
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_ORPHANEDNODESMANAGERUTIL_H

--- a/lib/mayaUsd/ufe/EditAsMayaCommand.h
+++ b/lib/mayaUsd/ufe/EditAsMayaCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_EDITASMAYACOMMAND_H
+#define MAYAUSD_EDITASMAYACOMMAND_H
 
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/undo/OpUndoItemList.h>
@@ -49,3 +50,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_EDITASMAYACOMMAND_H

--- a/lib/mayaUsd/ufe/Global.h
+++ b/lib/mayaUsd/ufe/Global.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_UFE_GLOBAL_H
+#define MAYAUSD_UFE_GLOBAL_H
 
 #include <mayaUsd/base/api.h>
 
@@ -44,3 +45,5 @@ Ufe::Rtid getMayaRunTimeId();
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_UFE_GLOBAL_H

--- a/lib/mayaUsd/ufe/MayaStagesSubject.h
+++ b/lib/mayaUsd/ufe/MayaStagesSubject.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_MAYASTAGESSUBJECT_H
+#define MAYAUSD_MAYASTAGESSUBJECT_H
 
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/listeners/proxyShapeNotice.h>
@@ -97,3 +98,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_MAYASTAGESSUBJECT_H

--- a/lib/mayaUsd/ufe/MayaUsdContextOps.h
+++ b/lib/mayaUsd/ufe/MayaUsdContextOps.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_MAYAUSDCONTEXTOPS_H
+#define MAYAUSD_MAYAUSDCONTEXTOPS_H
 
 #include <mayaUsd/base/api.h>
 
@@ -55,3 +56,5 @@ public:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_MAYAUSDCONTEXTOPS_H

--- a/lib/mayaUsd/ufe/MayaUsdContextOpsHandler.h
+++ b/lib/mayaUsd/ufe/MayaUsdContextOpsHandler.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_MAYAUSDCONTEXTOPSHANDLER_H
+#define MAYAUSD_MAYAUSDCONTEXTOPSHANDLER_H
 
 #include <mayaUsd/base/api.h>
 
@@ -39,3 +40,5 @@ public:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_MAYAUSDCONTEXTOPSHANDLER_H

--- a/lib/mayaUsd/ufe/MayaUsdHierarchy.h
+++ b/lib/mayaUsd/ufe/MayaUsdHierarchy.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_MAYAUSDHIERARCHY_H
+#define MAYAUSD_MAYAUSDHIERARCHY_H
 
 #include <mayaUsd/base/api.h>
 
@@ -58,3 +59,5 @@ bool mayaUsdHierarchyChildrenHook(
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_MAYAUSDHIERARCHY_H

--- a/lib/mayaUsd/ufe/MayaUsdHierarchyHandler.h
+++ b/lib/mayaUsd/ufe/MayaUsdHierarchyHandler.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_MAYAUSDHIERARCHYHANDLER_H
+#define MAYAUSD_MAYAUSDHIERARCHYHANDLER_H
 
 #include <mayaUsd/base/api.h>
 
@@ -43,3 +44,5 @@ public:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_MAYAUSDHIERARCHYHANDLER_H

--- a/lib/mayaUsd/ufe/MayaUsdObject3d.h
+++ b/lib/mayaUsd/ufe/MayaUsdObject3d.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_MAYAUSDOBJECT3D_H
+#define MAYAUSD_MAYAUSDOBJECT3D_H
 
 #include <mayaUsd/base/api.h>
 
@@ -46,3 +47,5 @@ public:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_MAYAUSDOBJECT3D_H

--- a/lib/mayaUsd/ufe/MayaUsdObject3dHandler.h
+++ b/lib/mayaUsd/ufe/MayaUsdObject3dHandler.h
@@ -12,7 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#pragma once
+#ifndef MAYAUSD_MAYAUSDOBJECT3DHANDLER_H
+#define MAYAUSD_MAYAUSDOBJECT3DHANDLER_H
 
 #include <mayaUsd/base/api.h>
 
@@ -42,3 +43,5 @@ public:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_MAYAUSDOBJECT3DHANDLER_H

--- a/lib/mayaUsd/ufe/MayaUsdRootChildHierarchy.h
+++ b/lib/mayaUsd/ufe/MayaUsdRootChildHierarchy.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_MAYAUSDROOTCHILDHIERARCHY_H
+#define MAYAUSD_MAYAUSDROOTCHILDHIERARCHY_H
 
 #include <mayaUsd/base/api.h>
 
@@ -48,3 +49,5 @@ protected:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_MAYAUSDROOTCHILDHIERARCHY_H

--- a/lib/mayaUsd/ufe/ProxyShapeCameraHandler.h
+++ b/lib/mayaUsd/ufe/ProxyShapeCameraHandler.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_PROXYSHAPECAMERAHANDLER_H
+#define MAYAUSD_PROXYSHAPECAMERAHANDLER_H
 
 #include <mayaUsd/base/api.h>
 
@@ -47,3 +48,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_PROXYSHAPECAMERAHANDLER_H

--- a/lib/mayaUsd/ufe/ProxyShapeContextOpsHandler.h
+++ b/lib/mayaUsd/ufe/ProxyShapeContextOpsHandler.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_PROXYSHAPECONTEXTOPSHANDLER_H
+#define MAYAUSD_PROXYSHAPECONTEXTOPSHANDLER_H
 
 #include <mayaUsd/base/api.h>
 
@@ -56,3 +57,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_PROXYSHAPECONTEXTOPSHANDLER_H

--- a/lib/mayaUsd/ufe/ProxyShapeHandler.h
+++ b/lib/mayaUsd/ufe/ProxyShapeHandler.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_PROXYSHAPEHANDLER_H
+#define MAYAUSD_PROXYSHAPEHANDLER_H
 
 #include <mayaUsd/base/api.h>
 
@@ -53,3 +54,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_PROXYSHAPEHANDLER_H

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_PROXYSHAPEHIERARCHY_H
+#define MAYAUSD_PROXYSHAPEHIERARCHY_H
 
 #include <mayaUsd/base/api.h>
 
@@ -96,3 +97,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_PROXYSHAPEHIERARCHY_H

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchyHandler.h
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchyHandler.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_PROXYSHAPEHIERARCHYHANDLER_H
+#define MAYAUSD_PROXYSHAPEHIERARCHYHANDLER_H
 
 #include <mayaUsd/base/api.h>
 
@@ -62,3 +63,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_PROXYSHAPEHIERARCHYHANDLER_H

--- a/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.h
+++ b/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_PROXYSHAPESCENESEGMENTHANDLER_H
+#define MAYAUSD_PROXYSHAPESCENESEGMENTHANDLER_H
 
 #include <mayaUsd/base/api.h>
 
@@ -56,3 +57,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_PROXYSHAPESCENESEGMENTHANDLER_H

--- a/lib/mayaUsd/ufe/PulledObjectHierarchy.h
+++ b/lib/mayaUsd/ufe/PulledObjectHierarchy.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_PULLEDOBJECTHIERARCHY_H
+#define MAYAUSD_PULLEDOBJECTHIERARCHY_H
 
 #include <mayaUsd/base/api.h>
 
@@ -82,3 +83,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_PULLEDOBJECTHIERARCHY_H

--- a/lib/mayaUsd/ufe/PulledObjectHierarchyHandler.h
+++ b/lib/mayaUsd/ufe/PulledObjectHierarchyHandler.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_PULLEDOBJECTHIERARCHYHANDLER_H
+#define MAYAUSD_PULLEDOBJECTHIERARCHYHANDLER_H
 
 #include <mayaUsd/base/api.h>
 
@@ -62,3 +63,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_PULLEDOBJECTHIERARCHYHANDLER_H

--- a/lib/mayaUsd/ufe/RotationUtils.h
+++ b/lib/mayaUsd/ufe/RotationUtils.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_ROTATIONUTILS_H
+#define MAYAUSD_ROTATIONUTILS_H
 
 #include <mayaUsd/mayaUsd.h>
 
@@ -120,3 +121,5 @@ inline Ufe::Vector3d fromZ(const PXR_NS::VtValue& value)
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_ROTATIONUTILS_H

--- a/lib/mayaUsd/ufe/UsdConnectionHandler.h
+++ b/lib/mayaUsd/ufe/UsdConnectionHandler.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDCONNECTIONHANDLER_H
+#define MAYAUSD_USDCONNECTIONHANDLER_H
 
 #include <mayaUsd/base/api.h>
 
@@ -62,3 +63,5 @@ protected:
 }; // UsdConnectionHandler
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDCONNECTIONHANDLER_H

--- a/lib/mayaUsd/ufe/UsdConnections.h
+++ b/lib/mayaUsd/ufe/UsdConnections.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDCONNECTIONS_H
+#define MAYAUSD_USDCONNECTIONS_H
 
 #include <mayaUsd/base/api.h>
 
@@ -44,3 +45,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDCONNECTIONS_H

--- a/lib/mayaUsd/ufe/UsdLight.h
+++ b/lib/mayaUsd/ufe/UsdLight.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDLIGHT_H
+#define MAYAUSD_USDLIGHT_H
 
 #include <mayaUsd/base/api.h>
 
@@ -157,3 +158,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDLIGHT_H

--- a/lib/mayaUsd/ufe/UsdLightHandler.h
+++ b/lib/mayaUsd/ufe/UsdLightHandler.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDLIGHTHANDLER_H
+#define MAYAUSD_USDLIGHTHANDLER_H
 
 #include <mayaUsd/base/api.h>
 
@@ -42,3 +43,5 @@ public:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDLIGHTHANDLER_H

--- a/lib/mayaUsd/ufe/UsdMaterial.h
+++ b/lib/mayaUsd/ufe/UsdMaterial.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDMATERIAL_H
+#define MAYAUSD_USDMATERIAL_H
 
 #include <mayaUsd/base/api.h>
 
@@ -53,3 +54,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDMATERIAL_H

--- a/lib/mayaUsd/ufe/UsdMaterialHandler.h
+++ b/lib/mayaUsd/ufe/UsdMaterialHandler.h
@@ -5,7 +5,8 @@
 // agreement provided at the time of installation or download, or which
 // otherwise accompanies this software in either electronic or hard copy form.
 // ===========================================================================
-#pragma once
+#ifndef MAYAUSD_USDMATERIALHANDLER_H
+#define MAYAUSD_USDMATERIALHANDLER_H
 
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/ufe/UsdMaterial.h>
@@ -38,3 +39,5 @@ public:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDMATERIALHANDLER_H

--- a/lib/mayaUsd/ufe/UsdRotatePivotTranslateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdRotatePivotTranslateUndoableCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDROTATEPIVOTTRANSLATEUNDOABLECOMMAND_H
+#define MAYAUSD_USDROTATEPIVOTTRANSLATEUNDOABLECOMMAND_H
 
 #include <mayaUsd/base/api.h>
 
@@ -73,3 +74,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDROTATEPIVOTTRANSLATEUNDOABLECOMMAND_H

--- a/lib/mayaUsd/ufe/UsdRotateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdRotateUndoableCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDROTATEUNDOABLECOMMAND_H
+#define MAYAUSD_USDROTATEUNDOABLECOMMAND_H
 
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/ufe/UsdTRSUndoableCommandBase.h>
@@ -71,3 +72,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDROTATEUNDOABLECOMMAND_H

--- a/lib/mayaUsd/ufe/UsdScaleUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdScaleUndoableCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDSCALEUNDOABLECOMMAND_H
+#define MAYAUSD_USDSCALEUNDOABLECOMMAND_H
 
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/ufe/UsdTRSUndoableCommandBase.h>
@@ -64,3 +65,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDSCALEUNDOABLECOMMAND_H

--- a/lib/mayaUsd/ufe/UsdSceneItemOps.h
+++ b/lib/mayaUsd/ufe/UsdSceneItemOps.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDSCENEITEMOPS_H
+#define MAYAUSD_USDSCENEITEMOPS_H
 
 #include <mayaUsd/base/api.h>
 
@@ -75,3 +76,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDSCENEITEMOPS_H

--- a/lib/mayaUsd/ufe/UsdSceneItemOpsHandler.h
+++ b/lib/mayaUsd/ufe/UsdSceneItemOpsHandler.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDSCENEITEMOPSHANDLER_H
+#define MAYAUSD_USDSCENEITEMOPSHANDLER_H
 
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/ufe/UsdSceneItemOps.h>
@@ -42,3 +43,5 @@ public:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDSCENEITEMOPSHANDLER_H

--- a/lib/mayaUsd/ufe/UsdSetXformOpUndoableCommandBase.h
+++ b/lib/mayaUsd/ufe/UsdSetXformOpUndoableCommandBase.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDSETXFORMOPUNDOABLECOMMANDBASE_H
+#define MAYAUSD_USDSETXFORMOPUNDOABLECOMMANDBASE_H
 
 #include <mayaUsd/base/api.h>
 
@@ -119,3 +120,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDSETXFORMOPUNDOABLECOMMANDBASE_H

--- a/lib/mayaUsd/ufe/UsdShaderNodeDef.h
+++ b/lib/mayaUsd/ufe/UsdShaderNodeDef.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDSHADERNODEDEF_H
+#define MAYAUSD_USDSHADERNODEDEF_H
 
 #include <mayaUsd/base/api.h>
 
@@ -154,3 +155,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDSHADERNODEDEF_H

--- a/lib/mayaUsd/ufe/UsdShaderNodeDefHandler.h
+++ b/lib/mayaUsd/ufe/UsdShaderNodeDefHandler.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDSHADERNODEDEFHANDLER_H
+#define MAYAUSD_USDSHADERNODEDEFHANDLER_H
 
 #include <mayaUsd/base/api.h>
 
@@ -58,3 +59,5 @@ public:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDSHADERNODEDEFHANDLER_H

--- a/lib/mayaUsd/ufe/UsdStageMap.h
+++ b/lib/mayaUsd/ufe/UsdStageMap.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDSTAGEMAP_H
+#define MAYAUSD_USDSTAGEMAP_H
 
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/utils/mayaNodeTypeObserver.h>
@@ -135,3 +136,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDSTAGEMAP_H

--- a/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
+++ b/lib/mayaUsd/ufe/UsdTRSUndoableCommandBase.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDTRSUNDOABLECOMMANDBASE_H
+#define MAYAUSD_USDTRSUNDOABLECOMMANDBASE_H
 
 #include <mayaUsd/base/api.h>
 
@@ -107,3 +108,5 @@ template <class T> struct MakeSharedEnabler : public T
 };
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDTRSUNDOABLECOMMANDBASE_H

--- a/lib/mayaUsd/ufe/UsdTransform3dBase.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dBase.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDTRANSFORM3DBASE_H
+#define MAYAUSD_USDTRANSFORM3DBASE_H
 
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/ufe/UsdTransform3dReadImpl.h>
@@ -88,3 +89,5 @@ protected:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDTRANSFORM3DBASE_H

--- a/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dCommonAPI.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDTRANSFORM3DCOMMONAPI_H
+#define MAYAUSD_USDTRANSFORM3DCOMMONAPI_H
 
 #include <mayaUsd/ufe/UsdTransform3dBase.h>
 
@@ -99,3 +100,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDTRANSFORM3DCOMMONAPI_H

--- a/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dFallbackMayaXformStack.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDTRANSFORM3DFALLBACKMAYAXFORMSTACK_H
+#define MAYAUSD_USDTRANSFORM3DFALLBACKMAYAXFORMSTACK_H
 
 #include <mayaUsd/ufe/UsdTransform3dMayaXformStack.h>
 
@@ -116,3 +117,5 @@ public:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDTRANSFORM3DFALLBACKMAYAXFORMSTACK_H

--- a/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dMatrixOp.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDTRANSFORM3DMATRIXOP_H
+#define MAYAUSD_USDTRANSFORM3DMATRIXOP_H
 
 #include <mayaUsd/ufe/UsdTransform3dBase.h>
 
@@ -99,3 +100,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDTRANSFORM3DMATRIXOP_H

--- a/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dMayaXformStack.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDTRANSFORM3DMAYAXFORMSTACK_H
+#define MAYAUSD_USDTRANSFORM3DMAYAXFORMSTACK_H
 
 #include <mayaUsd/ufe/UsdTransform3dBase.h>
 
@@ -148,3 +149,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDTRANSFORM3DMAYAXFORMSTACK_H

--- a/lib/mayaUsd/ufe/UsdTransform3dRead.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dRead.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDTRANSFORM3DREAD_H
+#define MAYAUSD_USDTRANSFORM3DREAD_H
 
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/ufe/UsdTransform3dReadImpl.h>
@@ -90,3 +91,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDTRANSFORM3DREAD_H

--- a/lib/mayaUsd/ufe/UsdTransform3dReadImpl.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dReadImpl.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDTRANSFORM3DREADIMPL_H
+#define MAYAUSD_USDTRANSFORM3DREADIMPL_H
 
 #include <mayaUsd/base/api.h>
 
@@ -60,3 +61,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDTRANSFORM3DREADIMPL_H

--- a/lib/mayaUsd/ufe/UsdTransform3dSetObjectMatrix.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dSetObjectMatrix.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDTRANSFORM3DSETOBJECTMATRIX_H
+#define MAYAUSD_USDTRANSFORM3DSETOBJECTMATRIX_H
 
 #include <mayaUsd/ufe/UsdTransform3dBase.h>
 
@@ -131,3 +132,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDTRANSFORM3DSETOBJECTMATRIX_H

--- a/lib/mayaUsd/ufe/UsdTransform3dUndoableCommands.h
+++ b/lib/mayaUsd/ufe/UsdTransform3dUndoableCommands.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDTRANSFORM3DUNDOABLECOMMANDS_H
+#define MAYAUSD_USDTRANSFORM3DUNDOABLECOMMANDS_H
 
 #include <mayaUsd/base/api.h>
 
@@ -52,3 +53,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDTRANSFORM3DUNDOABLECOMMANDS_H

--- a/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.h
+++ b/lib/mayaUsd/ufe/UsdTranslateUndoableCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDTRANSLATEUNDOABLECOMMAND_H
+#define MAYAUSD_USDTRANSLATEUNDOABLECOMMAND_H
 
 #include <mayaUsd/base/api.h>
 #include <mayaUsd/ufe/UsdTRSUndoableCommandBase.h>
@@ -66,3 +67,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDTRANSLATEUNDOABLECOMMAND_H

--- a/lib/mayaUsd/ufe/UsdUndoCreateFromNodeDefCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoCreateFromNodeDefCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDUNDOCREATEFROMNODEDEFCOMMAND_H
+#define MAYAUSD_USDUNDOCREATEFROMNODEDEFCOMMAND_H
 
 #include <mayaUsd/base/api.h>
 
@@ -68,3 +69,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDUNDOCREATEFROMNODEDEFCOMMAND_H

--- a/lib/mayaUsd/ufe/UsdUndoDeleteCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoDeleteCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDUNDODELETECOMMAND_H
+#define MAYAUSD_USDUNDODELETECOMMAND_H
 
 #include <mayaUsd/base/api.h>
 
@@ -53,3 +54,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDUNDODELETECOMMAND_H

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDUNDODUPLICATECOMMAND_H
+#define MAYAUSD_USDUNDODUPLICATECOMMAND_H
 
 #include <mayaUsd/base/api.h>
 
@@ -76,3 +77,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDUNDODUPLICATECOMMAND_H

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.h
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDUNDOMATERIALCOMMANDS_H
+#define MAYAUSD_USDUNDOMATERIALCOMMANDS_H
 
 #include <mayaUsd/base/api.h>
 
@@ -198,3 +199,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDUNDOMATERIALCOMMANDS_H

--- a/lib/mayaUsd/ufe/UsdUndoRenameCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoRenameCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_USDUNDORENAMECOMMAND_H
+#define MAYAUSD_USDUNDORENAMECOMMAND_H
 
 #include <mayaUsd/base/api.h>
 
@@ -67,3 +68,5 @@ private:
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDUNDORENAMECOMMAND_H

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_UFE_UTILS_H
+#define MAYAUSD_UFE_UTILS_H
 
 #include <mayaUsd/base/api.h>
 
@@ -194,3 +195,5 @@ Ufe::BBox3d getPulledPrimsBoundingBox(const Ufe::Path& path);
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_UFE_UTILS_H

--- a/lib/mayaUsd/ufe/XformOpUtils.h
+++ b/lib/mayaUsd/ufe/XformOpUtils.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MAYAUSD_UFE_XFORMOPUTILS_H
+#define MAYAUSD_UFE_XFORMOPUTILS_H
 
 #include <mayaUsd/mayaUsd.h>
 
@@ -69,3 +70,5 @@ void getTRS(const Ufe::Matrix4d& m, Ufe::Vector3d* t, Ufe::Vector3d* r, Ufe::Vec
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_UFE_XFORMOPUTILS_H

--- a/lib/mayaUsdAPI/mayaUsdAPI.h.src
+++ b/lib/mayaUsdAPI/mayaUsdAPI.h.src
@@ -14,7 +14,8 @@
 // limitations under the License.
 //
 
-#pragma once
+#ifndef MAYAUSDAPI_H
+#define MAYAUSDAPI_H
 
 #define MAYAUSDAPI_MAJOR_VERSION ${MAYAUSDAPI_MAJOR_VERSION}
 #define MAYAUSDAPI_MINOR_VERSION ${MAYAUSDAPI_MINOR_VERSION}
@@ -45,3 +46,5 @@ using namespace MAYAUSDAPI_VERSIONED_NS;
 #else
 #define MAYAUSDAPI_NS_DEF MAYAUSDAPI_VERSIONED_NS
 #endif
+
+#endif // MAYAUSDAPI_H

--- a/lib/usd/translators/shading/materialUpdater.h
+++ b/lib/usd/translators/shading/materialUpdater.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef MATERIALUPDATER_H
+#define MATERIALUPDATER_H
 
 #include <mayaUsd/fileio/primUpdater.h>
 
@@ -37,3 +38,5 @@ public:
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif // MATERIALUPDATER_H

--- a/lib/usdUfe/base/forwardDeclares.h
+++ b/lib/usdUfe/base/forwardDeclares.h
@@ -14,7 +14,8 @@
 // limitations under the License.
 //
 
-#pragma once
+#ifndef USDUFE_FORWARDDECLARES_H
+#define USDUFE_FORWARDDECLARES_H
 
 #include <usdUfe/base/api.h>
 
@@ -41,3 +42,5 @@ PXR_NAMESPACE_CLOSE_SCOPE
 namespace USDUFE_NS_DEF {
 typedef std::vector<PXR_NS::UsdPrim> UsdPrimVector;
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_FORWARDDECLARES_H

--- a/lib/usdUfe/base/usdUfe.h.src
+++ b/lib/usdUfe/base/usdUfe.h.src
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
+#ifndef USDUFE_H
+#define USDUFE_H
 
 #define USDUFE_MAJOR_VERSION ${USDUFE_MAJOR_VERSION}
 #define USDUFE_MINOR_VERSION ${USDUFE_MINOR_VERSION}
@@ -86,3 +87,5 @@ static_assert(!std::is_move_constructible<TypeName>::value, \
               "Class should NOT be move constructible");    \
 static_assert(!std::is_move_assignable<TypeName>::value,    \
               "Class should NOT be move assignable");
+
+#endif // USDUFE_H

--- a/lib/usdUfe/ufe/Global.h
+++ b/lib/usdUfe/ufe/Global.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_UFE_GLOBAL_H
+#define USDUFE_UFE_GLOBAL_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/ufe/StagesSubject.h>
@@ -127,3 +128,5 @@ USDUFE_PUBLIC
 Ufe::Rtid getUsdRunTimeId();
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_UFE_GLOBAL_H

--- a/lib/usdUfe/ufe/SetVariantSelectionCommand.h
+++ b/lib/usdUfe/ufe/SetVariantSelectionCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_SETVARIANTSELECTIONCOMMAND_H
+#define USDUFE_SETVARIANTSELECTIONCOMMAND_H
 
 #include <usdUfe/base/api.h>
 
@@ -62,3 +63,5 @@ private:
 };
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_SETVARIANTSELECTIONCOMMAND_H

--- a/lib/usdUfe/ufe/StagesSubject.h
+++ b/lib/usdUfe/ufe/StagesSubject.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_STAGESSUBJECT_H
+#define USDUFE_STAGESSUBJECT_H
 
 #include <usdUfe/base/api.h>
 
@@ -102,3 +103,5 @@ public:
 };
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_STAGESSUBJECT_H

--- a/lib/usdUfe/ufe/UfeVersionCompat.h
+++ b/lib/usdUfe/ufe/UfeVersionCompat.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_UFEVERSIONCOMPAT_H
+#define USDUFE_UFEVERSIONCOMPAT_H
 
 // Make sure ufe.h is included, if it hasn't been already.
 #include <ufe/ufe.h>
@@ -28,3 +29,5 @@
 #if !defined(UFE_V4_FEATURES_AVAILABLE) && !defined(UFE_V4)
 #define UFE_V4(...)
 #endif
+
+#endif // USDUFE_UFEVERSIONCOMPAT_H

--- a/lib/usdUfe/ufe/UsdAttribute.h
+++ b/lib/usdUfe/ufe/UsdAttribute.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDATTRIBUTE_H
+#define USDUFE_USDATTRIBUTE_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UsdAttributeHolder.h>
@@ -566,3 +567,5 @@ public:
 #endif
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDATTRIBUTE_H

--- a/lib/usdUfe/ufe/UsdAttributeHolder.h
+++ b/lib/usdUfe/ufe/UsdAttributeHolder.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDATTRIBUTEHOLDER_H
+#define USDUFE_USDATTRIBUTEHOLDER_H
 
 #include <usdUfe/base/api.h>
 
@@ -69,3 +70,5 @@ protected:
 }; // UsdAttributeHolder
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDATTRIBUTEHOLDER_H

--- a/lib/usdUfe/ufe/UsdAttributes.h
+++ b/lib/usdUfe/ufe/UsdAttributes.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDATTRIBUTES_H
+#define USDUFE_USDATTRIBUTES_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UsdAttribute.h>
@@ -97,3 +98,5 @@ private:
 }; // UsdAttributes
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDATTRIBUTES_H

--- a/lib/usdUfe/ufe/UsdAttributesHandler.h
+++ b/lib/usdUfe/ufe/UsdAttributesHandler.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDATTRIBUTESHANDLER_H
+#define USDUFE_USDATTRIBUTESHANDLER_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UsdAttributes.h>
@@ -42,3 +43,5 @@ private:
 }; // UsdAttributesHandler
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDATTRIBUTESHANDLER_H

--- a/lib/usdUfe/ufe/UsdCamera.h
+++ b/lib/usdUfe/ufe/UsdCamera.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDCAMERA_H
+#define USDUFE_USDCAMERA_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UsdSceneItem.h>
@@ -94,3 +95,5 @@ private:
 }; // UsdCamera
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDCAMERA_H

--- a/lib/usdUfe/ufe/UsdCameraHandler.h
+++ b/lib/usdUfe/ufe/UsdCameraHandler.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDCAMERAHANDLER_H
+#define USDUFE_USDCAMERAHANDLER_H
 
 #include <usdUfe/base/api.h>
 
@@ -49,3 +50,5 @@ public:
 }; // UsdCameraHandler
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDCAMERAHANDLER_H

--- a/lib/usdUfe/ufe/UsdContextOps.h
+++ b/lib/usdUfe/ufe/UsdContextOps.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDCONTEXTOPS_H
+#define USDUFE_USDCONTEXTOPS_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UsdSceneItem.h>
@@ -145,3 +146,5 @@ private:
 };
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDCONTEXTOPS_H

--- a/lib/usdUfe/ufe/UsdContextOpsHandler.h
+++ b/lib/usdUfe/ufe/UsdContextOpsHandler.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDCONTEXTOPSHANDLER_H
+#define USDUFE_USDCONTEXTOPSHANDLER_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UsdContextOps.h>
@@ -40,3 +41,5 @@ public:
 }; // UsdContextOpsHandler
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDCONTEXTOPSHANDLER_H

--- a/lib/usdUfe/ufe/UsdHierarchy.h
+++ b/lib/usdUfe/ufe/UsdHierarchy.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDHIERARCHY_H
+#define USDUFE_USDHIERARCHY_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UfeVersionCompat.h>
@@ -105,3 +106,5 @@ private:
 }; // UsdHierarchy
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDHIERARCHY_H

--- a/lib/usdUfe/ufe/UsdHierarchyHandler.h
+++ b/lib/usdUfe/ufe/UsdHierarchyHandler.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDHIERARCHYHANDLER_H
+#define USDUFE_USDHIERARCHYHANDLER_H
 
 #include <usdUfe/base/api.h>
 
@@ -48,3 +49,5 @@ public:
 }; // UsdHierarchyHandler
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDHIERARCHYHANDLER_H

--- a/lib/usdUfe/ufe/UsdObject3d.h
+++ b/lib/usdUfe/ufe/UsdObject3d.h
@@ -5,7 +5,8 @@
 // agreement provided at the time of installation or download, or which
 // otherwise accompanies this software in either electronic or hard copy form.
 // ===========================================================================
-#pragma once
+#ifndef USDUFE_USDOBJECT3D_H
+#define USDUFE_USDOBJECT3D_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UsdSceneItem.h>
@@ -66,3 +67,5 @@ private:
 }; // UsdObject3d
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDOBJECT3D_H

--- a/lib/usdUfe/ufe/UsdObject3dHandler.h
+++ b/lib/usdUfe/ufe/UsdObject3dHandler.h
@@ -5,7 +5,8 @@
 // agreement provided at the time of installation or download, or which
 // otherwise accompanies this software in either electronic or hard copy form.
 // ===========================================================================
-#pragma once
+#ifndef USDUFE_USDOBJECT3DHANDLER_H
+#define USDUFE_USDOBJECT3DHANDLER_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UsdObject3d.h>
@@ -39,3 +40,5 @@ public:
 }; // UsdObject3dHandler
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDOBJECT3DHANDLER_H

--- a/lib/usdUfe/ufe/UsdRootChildHierarchy.h
+++ b/lib/usdUfe/ufe/UsdRootChildHierarchy.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDROOTCHILDHIERARCHY_H
+#define USDUFE_USDROOTCHILDHIERARCHY_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UsdHierarchy.h>
@@ -43,3 +44,5 @@ public:
 }; // UsdRootChildHierarchy
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDROOTCHILDHIERARCHY_H

--- a/lib/usdUfe/ufe/UsdShaderAttributeDef.h
+++ b/lib/usdUfe/ufe/UsdShaderAttributeDef.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDSHADERATTRIBUTEDEF_H
+#define USDUFE_USDSHADERATTRIBUTEDEF_H
 
 #include <usdUfe/base/api.h>
 
@@ -67,3 +68,5 @@ private:
 }; // UsdShaderAttributeDef
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDSHADERATTRIBUTEDEF_H

--- a/lib/usdUfe/ufe/UsdShaderAttributeHolder.h
+++ b/lib/usdUfe/ufe/UsdShaderAttributeHolder.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDSHADERATTRIBUTEHOLDER_H
+#define USDUFE_USDSHADERATTRIBUTEHOLDER_H
 
 #include <usdUfe/ufe/UsdAttributeHolder.h>
 
@@ -75,3 +76,5 @@ private:
 }; // UsdShaderAttributeHolder
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDSHADERATTRIBUTEHOLDER_H

--- a/lib/usdUfe/ufe/UsdUndoClearDefaultPrimCommand.h
+++ b/lib/usdUfe/ufe/UsdUndoClearDefaultPrimCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDUNDOCLEARDEFAULTPRIMCOMMAND_H
+#define USDUFE_USDUNDOCLEARDEFAULTPRIMCOMMAND_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/undo/UsdUndoableItem.h>
@@ -46,3 +47,5 @@ private:
 }; // UsdUndoClearDefaultPrimCommand
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDUNDOCLEARDEFAULTPRIMCOMMAND_H

--- a/lib/usdUfe/ufe/UsdUndoCreateGroupCommand.h
+++ b/lib/usdUfe/ufe/UsdUndoCreateGroupCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDUNDOCREATEGROUPCOMMAND_H
+#define USDUFE_USDUNDOCREATEGROUPCOMMAND_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UsdSceneItem.h>
@@ -67,3 +68,5 @@ private:
 }; // UsdUndoCreateGroupCommand
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDUNDOCREATEGROUPCOMMAND_H

--- a/lib/usdUfe/ufe/UsdUndoInsertChildCommand.h
+++ b/lib/usdUfe/ufe/UsdUndoInsertChildCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDUNDOINSERTCHILDCOMMAND_H
+#define USDUFE_USDUNDOINSERTCHILDCOMMAND_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UfeVersionCompat.h>
@@ -72,3 +73,5 @@ private:
 }; // UsdUndoInsertChildCommand
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDUNDOINSERTCHILDCOMMAND_H

--- a/lib/usdUfe/ufe/UsdUndoLongDurationCommand.h
+++ b/lib/usdUfe/ufe/UsdUndoLongDurationCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDUNDOLONGDURATIONCOMMAND_H
+#define USDUFE_USDUNDOLONGDURATIONCOMMAND_H
 
 #include <usdUfe/base/api.h>
 
@@ -54,3 +55,5 @@ public:
 };
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDUNDOLONGDURATIONCOMMAND_H

--- a/lib/usdUfe/ufe/UsdUndoReorderCommand.h
+++ b/lib/usdUfe/ufe/UsdUndoReorderCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDUNDOREORDERCOMMAND_H
+#define USDUFE_USDUNDOREORDERCOMMAND_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/undo/UsdUndoableItem.h>
@@ -52,3 +53,5 @@ private:
 }; // UsdUndoReorderCommand
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDUNDOREORDERCOMMAND_H

--- a/lib/usdUfe/ufe/UsdUndoSetDefaultPrimCommand.h
+++ b/lib/usdUfe/ufe/UsdUndoSetDefaultPrimCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDUNDOSETDEFAULTPRIMCOMMAND_H
+#define USDUFE_USDUNDOSETDEFAULTPRIMCOMMAND_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/undo/UsdUndoableItem.h>
@@ -45,3 +46,5 @@ private:
 }; // UsdUndoSetDefaultPrimCommand
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDUNDOSETDEFAULTPRIMCOMMAND_H

--- a/lib/usdUfe/ufe/UsdUndoUngroupCommand.h
+++ b/lib/usdUfe/ufe/UsdUndoUngroupCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDUNDOUNGROUPCOMMAND_H
+#define USDUFE_USDUNDOUNGROUPCOMMAND_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UsdSceneItem.h>
@@ -49,3 +50,5 @@ private:
 }; // UsdUndoUngroupCommand
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDUNDOUNGROUPCOMMAND_H

--- a/lib/usdUfe/ufe/UsdUndoVisibleCommand.h
+++ b/lib/usdUfe/ufe/UsdUndoVisibleCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDUNDOVISIBLECOMMAND_H
+#define USDUFE_USDUNDOVISIBLECOMMAND_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/undo/UsdUndoableItem.h>
@@ -52,3 +53,5 @@ private:
 }; // UsdUndoVisibleCommand
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDUNDOVISIBLECOMMAND_H

--- a/lib/usdUfe/ufe/UsdUndoableCommand.h
+++ b/lib/usdUfe/ufe/UsdUndoableCommand.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_USDUNDOABLECOMMAND_H
+#define USDUFE_USDUNDOABLECOMMAND_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/undo/UsdUndoBlock.h>
@@ -206,3 +207,5 @@ private:
 };
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_USDUNDOABLECOMMAND_H

--- a/lib/usdUfe/ufe/Utils.h
+++ b/lib/usdUfe/ufe/Utils.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_UFE_UTILS_H
+#define USDUFE_UFE_UTILS_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UsdSceneItem.h>
@@ -421,3 +422,5 @@ USDUFE_PUBLIC
 UsdSceneItem::Ptr getParentMaterial(const UsdSceneItem::Ptr& item);
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_UFE_UTILS_H

--- a/lib/usdUfe/ufe/private/Utils.h
+++ b/lib/usdUfe/ufe/private/Utils.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_UFE_PRIVATE_UTILS_H
+#define USDUFE_UFE_PRIVATE_UTILS_H
 
 #include <usdUfe/base/api.h>
 
@@ -66,3 +67,5 @@ void rotatePivotTranslateOp(
     double           z);
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_UFE_PRIVATE_UTILS_H

--- a/lib/usdUfe/utils/ALHalf.h
+++ b/lib/usdUfe/utils/ALHalf.h
@@ -24,7 +24,8 @@
 ///         methods to convert between half/float and half/double using the F16C conversion
 ///         intrinsics. To enable HW conversions, pass the compiler flag -mf16c to clang or gcc.
 //----------------------------------------------------------------------------------------------------------------------
-#pragma once
+#ifndef USDUFE_ALHALF_H
+#define USDUFE_ALHALF_H
 
 #include <usdUfe/base/api.h>
 
@@ -246,3 +247,5 @@ inline GfHalf double2half_1f(const double f) { return GfHalf(float(f)); }
 #endif
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_ALHALF_H

--- a/lib/usdUfe/utils/SIMD.h
+++ b/lib/usdUfe/utils/SIMD.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_SIMD_H
+#define USDUFE_SIMD_H
 
 #ifdef _WIN32
 #define ALIGN16(X) __declspec(align(16)) X
@@ -558,3 +559,5 @@ inline f128 loadmask3f(const void* const ptr, size_t count)
 #endif
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_SIMD_H

--- a/lib/usdUfe/utils/diffCore.h
+++ b/lib/usdUfe/utils/diffCore.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_DIFFCORE_H
+#define USDUFE_DIFFCORE_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/utils/ALHalf.h>
@@ -498,3 +499,5 @@ bool compareRGBAArray(
 
 //----------------------------------------------------------------------------------------------------------------------
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_DIFFCORE_H

--- a/lib/usdUfe/utils/diffPrims.h
+++ b/lib/usdUfe/utils/diffPrims.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_DIFFPRIMS_H
+#define USDUFE_DIFFPRIMS_H
 
 #include <usdUfe/base/api.h>
 
@@ -357,3 +358,5 @@ template <class MAP> inline DiffResult computeOverallResult(const MAP& subResult
 }
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_DIFFPRIMS_H

--- a/lib/usdUfe/utils/editRouter.h
+++ b/lib/usdUfe/utils/editRouter.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_EDITROUTER_H
+#define USDUFE_EDITROUTER_H
 
 #include <usdUfe/base/api.h>
 
@@ -150,3 +151,5 @@ void registerDefaultEditRouter(const PXR_NS::TfToken&, const EditRouter::Ptr&);
 EditRouters defaultEditRouters();
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_EDITROUTER_H

--- a/lib/usdUfe/utils/editRouterContext.h
+++ b/lib/usdUfe/utils/editRouterContext.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_EDITROUTERCONTEXT_H
+#define USDUFE_EDITROUTERCONTEXT_H
 
 #include <usdUfe/base/api.h>
 
@@ -126,3 +127,5 @@ private:
 };
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_EDITROUTERCONTEXT_H

--- a/lib/usdUfe/utils/mergePrims.h
+++ b/lib/usdUfe/utils/mergePrims.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_MERGEPRIMS_H
+#define USDUFE_MERGEPRIMS_H
 
 #include <usdUfe/base/api.h>
 #include <usdUfe/utils/mergePrimsOptions.h>
@@ -56,3 +57,5 @@ bool mergePrims(
     const PXR_NS::SdfPath&        dstPath);
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_MERGEPRIMS_H

--- a/lib/usdUfe/utils/mergePrimsOptions.h
+++ b/lib/usdUfe/utils/mergePrimsOptions.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_MERGEPRIMSOPTIONS_H
+#define USDUFE_MERGEPRIMSOPTIONS_H
 
 #include <usdUfe/base/api.h>
 
@@ -203,3 +204,5 @@ PXR_NAMESPACE_USING_DIRECTIVE
 TF_DECLARE_PUBLIC_TOKENS(MergeOptionsTokens, USDUFE_PUBLIC, USDUFE_MERGE_OPTIONS_TOKENS);
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_MERGEPRIMSOPTIONS_H

--- a/lib/usdUfe/utils/uiCallback.h
+++ b/lib/usdUfe/utils/uiCallback.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef USDUFE_UICALLBACK_H
+#define USDUFE_UICALLBACK_H
 
 #include <usdUfe/base/api.h>
 
@@ -60,3 +61,5 @@ USDUFE_PUBLIC
 void unregisterUICallback(const PXR_NS::TfToken& operation, const UICallback::Ptr& uiCallback);
 
 } // namespace USDUFE_NS_DEF
+
+#endif // USDUFE_UICALLBACK_H

--- a/plugin/adsk/plugin/ProxyShape.h
+++ b/plugin/adsk/plugin/ProxyShape.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef ASDK_PLUGIN_PROXYSHAPE_H
+#define ASDK_PLUGIN_PROXYSHAPE_H
 
 #include "base/api.h"
 
@@ -53,3 +54,5 @@ private:
 };
 
 } // namespace MAYAUSD_NS_DEF
+
+#endif // ASDK_PLUGIN_PROXYSHAPE_H

--- a/plugin/adsk/plugin/ProxyShapeListener.h
+++ b/plugin/adsk/plugin/ProxyShapeListener.h
@@ -13,7 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef ASDK_PLUGIN_PROXYSHAPELISTENER_H
+#define ASDK_PLUGIN_PROXYSHAPELISTENER_H
 
 #include "base/api.h"
 
@@ -51,3 +52,5 @@ private:
 };
 
 } // namespace MAYAUSD_NS_DEF
+
+#endif // ASDK_PLUGIN_PROXYSHAPELISTENER_H

--- a/plugin/adsk/plugin/exportTranslator.h
+++ b/plugin/adsk/plugin/exportTranslator.h
@@ -14,7 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
+#ifndef ASDK_PLUGIN_EXPORTTRANSLATOR_H
+#define ASDK_PLUGIN_EXPORTTRANSLATOR_H
 
 #include "base/api.h"
 
@@ -74,3 +75,5 @@ private:
 };
 
 } // namespace MAYAUSD_NS_DEF
+
+#endif // ASDK_PLUGIN_EXPORTTRANSLATOR_H


### PR DESCRIPTION
#### EMSUSD-1351 - MayaUsd: Code cleanup
* Adhere to include guard (instead of "#pragma once") from our coding standard.