### PR TITLE
Explicitly setting legacyMaterialScope arg in tests

### DIFF
--- a/test/lib/usd/pxrUsdPreviewSurface/testPxrUsdPreviewSurfaceExport.py
+++ b/test/lib/usd/pxrUsdPreviewSurface/testPxrUsdPreviewSurfaceExport.py
@@ -48,7 +48,7 @@ class testPxrUsdPreviewSurfaceExport(unittest.TestCase):
 
         cmds.loadPlugin('mayaUsdPlugin', quiet=True)
         cmds.file(usdFilePath, force=True,
-                  options="shadingMode=useRegistry;mergeTransformAndShape=1",
+                  options="shadingMode=useRegistry;mergeTransformAndShape=1;legacyMaterialScope=0",
                   typ="USD Export", pr=True, ea=True)
 
         cmds.file(defaultExtensions=defaultExtSetting)

--- a/test/lib/usd/translators/testUsdExport8BitNormalMap.py
+++ b/test/lib/usd/translators/testUsdExport8BitNormalMap.py
@@ -100,7 +100,7 @@ class testExport8BitNormalMap(unittest.TestCase):
         build_test_scene(self.temp_dir)
 
         out_file = os.path.abspath('normalMapTest.usdc')
-        cmds.mayaUSDExport(file=out_file,)
+        cmds.mayaUSDExport(file=out_file,legacyMaterialScope=False)
         
         self.assertTrue(os.path.isfile(out_file))
 

--- a/test/lib/usd/translators/testUsdExportAssignedMaterials.py
+++ b/test/lib/usd/translators/testUsdExportAssignedMaterials.py
@@ -62,6 +62,7 @@ class testUsdExportAssignedMaterials(unittest.TestCase):
             defaultPrim='top_group',
             exportMaterials=True,
             exportAssignedMaterials=False,
+            legacyMaterialScope=False,
             selection=bool(selection),
             excludeExportTypes=[] if exportMeshes else ['Meshes'])
 

--- a/test/lib/usd/translators/testUsdExportCustomConverter.template.py
+++ b/test/lib/usd/translators/testUsdExportCustomConverter.template.py
@@ -70,7 +70,8 @@ class testUsdExportCustomConverter(unittest.TestCase):
         # plugin
         options = ["shadingMode=useRegistry",
                    "convertMaterialsTo=[maya]",
-                   "mergeTransformAndShape=1"]
+                   "mergeTransformAndShape=1",
+                   "legacyMaterialScope=0"]
 
         default_ext_setting = cmds.file(q=True, defaultExtensions=True)
         cmds.file(defaultExtensions=False)

--- a/test/lib/usd/translators/testUsdExportDefaultPrim.py
+++ b/test/lib/usd/translators/testUsdExportDefaultPrim.py
@@ -87,7 +87,8 @@ class testUsdExportMesh(unittest.TestCase):
         '''Export to USD with no default prim.'''
         usdFile = os.path.abspath('UsdExportMaterialScopeDefaultPrim.usda')
         cmds.usdExport(mergeTransformAndShape=True, file=usdFile,
-            shadingMode='useRegistry', convertMaterialsTo=['UsdPreviewSurface'], defaultPrim='mtl')
+            shadingMode='useRegistry', convertMaterialsTo=['UsdPreviewSurface'], defaultPrim='mtl',
+            legacyMaterialScope=False)
         
         stage = Usd.Stage.Open(usdFile)
         defaultPrim = stage.GetDefaultPrim()
@@ -100,7 +101,7 @@ class testUsdExportMesh(unittest.TestCase):
         usdFile = os.path.abspath('UsdExportNoMeshMaterialScopeDefaultPrim.usda')
         cmds.usdExport(mergeTransformAndShape=True, file=usdFile,
             shadingMode='useRegistry', convertMaterialsTo=['UsdPreviewSurface'], defaultPrim='mtl',
-            excludeExportTypes=['Meshes'])
+            excludeExportTypes=['Meshes'], legacyMaterialScope=False)
         
         stage = Usd.Stage.Open(usdFile)
         defaultPrim = stage.GetDefaultPrim()

--- a/test/lib/usd/translators/testUsdExportDisplacement.py
+++ b/test/lib/usd/translators/testUsdExportDisplacement.py
@@ -41,7 +41,7 @@ class testUsdExportDisplacementShaders(unittest.TestCase):
         usdFilePath = os.path.abspath('SimpleDisplacement.usda')
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
             shadingMode='useRegistry', convertMaterialsTo=['UsdPreviewSurface'],
-            materialsScopeName='Materials')
+            materialsScopeName='Materials', legacyMaterialScope=False)
 
         cls._stage = Usd.Stage.Open(usdFilePath)
 

--- a/test/lib/usd/translators/testUsdExportFannedOutFileNodesMaterial.py
+++ b/test/lib/usd/translators/testUsdExportFannedOutFileNodesMaterial.py
@@ -66,7 +66,7 @@ class testExportFannedOutFileNodesMaterial(unittest.TestCase):
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
             shadingMode='useRegistry', 
             convertMaterialsTo=['MaterialX', 'UsdPreviewSurface'],
-            materialsScopeName='Materials')
+            materialsScopeName='Materials', legacyMaterialScope=False)
 
         stage = Usd.Stage.Open(usdFilePath)
         self.assertTrue(stage)

--- a/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
+++ b/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
@@ -131,7 +131,8 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
         export_options = [
             "shadingMode=useRegistry",
             "convertMaterialsTo=[{}]".format(convertTo),
-            "mergeTransformAndShape=1"
+            "mergeTransformAndShape=1",
+            "legacyMaterialScope=0"
         ]
 
         cmds.file(usd_path, force=True,
@@ -413,7 +414,8 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
         cmds.usdExport(mergeTransformAndShape=True,
             file=usd_path,
             shadingMode='useRegistry',
-            exportDisplayColor=True)
+            exportDisplayColor=True,
+            legacyMaterialScope=False)
 
         # We expect 2 primvar readers, and 2 st transforms:
         stage = Usd.Stage.Open(usd_path)
@@ -474,14 +476,16 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
                 shadingMode='useRegistry',
                 exportDisplayColor=False,
                 exportCollectionBasedBindings=True,
-                exportComponentTags=True)
+                exportComponentTags=True,
+                legacyMaterialScope=False)
         else:
             usd_path = os.path.abspath('CubeWithAssignedFaces.usda')
             cmds.usdExport(mergeTransformAndShape=True,
                 file=usd_path,
                 shadingMode='useRegistry',
                 exportDisplayColor=False,
-                exportComponentTags=True)
+                exportComponentTags=True,
+                legacyMaterialScope=False)
 
         stage = Usd.Stage.Open(usd_path)
 
@@ -686,7 +690,8 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
         usd_path = os.path.abspath('OpacityRoundtripTest.usda')
         cmds.usdExport(mergeTransformAndShape=True,
                        file=usd_path,
-                       shadingMode='useRegistry')
+                       shadingMode='useRegistry',
+                       legacyMaterialScope=False)
 
         stage = Usd.Stage.Open(usd_path)
 

--- a/test/lib/usd/translators/testUsdExportImportUDIM.py
+++ b/test/lib/usd/translators/testUsdExportImportUDIM.py
@@ -52,7 +52,7 @@ class testUsdExportImportUDIM(unittest.TestCase):
         usd_file = os.path.abspath('UsdExportUDIMTest.usda')
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usd_file,
             shadingMode='useRegistry', convertMaterialsTo=['UsdPreviewSurface'],
-            materialsScopeName='Materials')
+            materialsScopeName='Materials', legacyMaterialScope=False)
 
         stage = Usd.Stage.Open(usd_file)
         self.assertTrue(stage)

--- a/test/lib/usd/translators/testUsdExportMaterialScope.py
+++ b/test/lib/usd/translators/testUsdExportMaterialScope.py
@@ -53,6 +53,7 @@ class testUsdExportMaterialScope(unittest.TestCase):
             shadingMode='useRegistry', 
             convertMaterialsTo=['UsdPreviewSurface'],
             materialsScopeName='Materials',
+            legacyMaterialScope=False,
             defaultPrim=defaultPrim)
 
         self._stage = Usd.Stage.Open(self._usdFilePath)

--- a/test/lib/usd/translators/testUsdExportMaterialsOnly.py
+++ b/test/lib/usd/translators/testUsdExportMaterialsOnly.py
@@ -59,6 +59,7 @@ class testUsdExportMaterialsOnly(unittest.TestCase):
             shadingMode='useRegistry', 
             convertMaterialsTo=['UsdPreviewSurface'],
             materialsScopeName='Materials',
+            legacyMaterialScope=False,
             defaultPrim='top_group',
             exportMaterials=True,
             selection=bool(selection),

--- a/test/lib/usd/translators/testUsdExportMultiMaterial.py
+++ b/test/lib/usd/translators/testUsdExportMultiMaterial.py
@@ -62,7 +62,8 @@ class testUsdExportMultiMaterial(unittest.TestCase):
             shadingMode='useRegistry', 
             convertMaterialsTo=['MaterialX', 'UsdPreviewSurface', 'rendermanForMaya'],
             materialsScopeName='Materials',
-            exportMaterials=exportMaterials)
+            exportMaterials=exportMaterials,
+            legacyMaterialScope=False)
 
         self._stage = Usd.Stage.Open(usdFilePath)
 
@@ -199,7 +200,8 @@ class testUsdExportMultiMaterial(unittest.TestCase):
             file=usd_path,
             shadingMode='useRegistry',
             convertMaterialsTo=['MaterialX', 'UsdPreviewSurface'],
-            materialsScopeName='Looks')
+            materialsScopeName='Looks',
+            legacyMaterialScope=False)
 
         # We expect 2 primvar readers, and 2 st transforms:
         stage = Usd.Stage.Open(usd_path)

--- a/test/lib/usd/translators/testUsdExportRfMShaders.py
+++ b/test/lib/usd/translators/testUsdExportRfMShaders.py
@@ -41,7 +41,7 @@ class testUsdExportRfMShaders(unittest.TestCase):
         usdFilePath = os.path.abspath('MarbleCube.usda')
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
             shadingMode='useRegistry', convertMaterialsTo=['rendermanForMaya'],
-            materialsScopeName='Materials')
+            materialsScopeName='Materials', legacyMaterialScope=False)
 
         cls._stage = Usd.Stage.Open(usdFilePath)
 

--- a/test/lib/usd/translators/testUsdExportRoots.py
+++ b/test/lib/usd/translators/testUsdExportRoots.py
@@ -64,6 +64,7 @@ class testUsdExportRoot(unittest.TestCase):
                 'file': usdFile,
                 'mergeTransformAndShape': True,
                 'shadingMode': 'useRegistry',
+                'legacyMaterialScope': False
             }
             if root:
                 kwargs['exportRoots'] = root
@@ -79,7 +80,7 @@ class testUsdExportRoot(unittest.TestCase):
                 'type': 'USD Export',
                 'f': 1,
             }
-            options = []
+            options = ['legacyMaterialScope=0']
             if root:
                 options.append('exportRoots={}'.format(','.join(root)))
             if worldspace:

--- a/test/lib/usd/translators/testUsdExportShadingInstanced.py
+++ b/test/lib/usd/translators/testUsdExportShadingInstanced.py
@@ -43,7 +43,8 @@ class testUsdExportShadingInstanced(unittest.TestCase):
                 materialsScopeName='Materials',
                 exportCollectionBasedBindings=True,
                 exportMaterialCollections=True,
-                materialCollectionsPath="/World")
+                materialCollectionsPath="/World",
+                legacyMaterialScope=False)
 
         cls._simpleStage = Usd.Stage.Open(usdFilePath)
 
@@ -57,7 +58,8 @@ class testUsdExportShadingInstanced(unittest.TestCase):
                 materialsScopeName='Materials',
                 exportCollectionBasedBindings=True,
                 exportMaterialCollections=True,
-                materialCollectionsPath="/World")
+                materialCollectionsPath="/World",
+                legacyMaterialScope=False)
 
         cls._nestedStage = Usd.Stage.Open(usdFilePath)
 

--- a/test/lib/usd/translators/testUsdExportShadingModePxrRis.py
+++ b/test/lib/usd/translators/testUsdExportShadingModePxrRis.py
@@ -39,7 +39,8 @@ class testUsdExportShadingModePxrRis(unittest.TestCase):
         # Export to USD.
         usdFilePath = os.path.abspath('MarbleCube.usda')
         cmds.usdExport(mergeTransformAndShape=True, file=usdFilePath,
-            shadingMode='pxrRis', materialsScopeName='Materials')
+            shadingMode='pxrRis', materialsScopeName='Materials',
+            legacyMaterialScope=False)
 
         cls._stage = Usd.Stage.Open(usdFilePath)
 

--- a/test/lib/usd/translators/testUsdExportTexture.py
+++ b/test/lib/usd/translators/testUsdExportTexture.py
@@ -77,7 +77,8 @@ class testUsdExportTexture(unittest.TestCase):
         usdFilePath = self.getUsdFilePath()
 
         with testUtils.TemporaryEnvironmentVariable(PROJ_ENV_VAR_NAME, projectFolder):
-            cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath, exportRelativeTextures=relativeMode)
+            cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath, 
+                exportRelativeTextures=relativeMode, legacyMaterialScope=False)
 
         stage = Usd.Stage.Open(usdFilePath)
         self.assertTrue(stage, usdFilePath)

--- a/test/lib/usd/translators/testUsdExportUVSetMappings.py
+++ b/test/lib/usd/translators/testUsdExportUVSetMappings.py
@@ -58,7 +58,8 @@ class testUsdExportUVSetMappings(unittest.TestCase):
         usdFilePath += ".usda"
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
             shadingMode='useRegistry', convertMaterialsTo=['UsdPreviewSurface'],
-            materialsScopeName='Materials', **extraOptions)
+            materialsScopeName='Materials', legacyMaterialScope=False,
+            **extraOptions)
 
         stage = Usd.Stage.Open(usdFilePath)
 
@@ -193,7 +194,8 @@ class testUsdExportUVSetMappings(unittest.TestCase):
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
                            shadingMode='useRegistry', convertMaterialsTo=['UsdPreviewSurface'],
                            preserveUVSetNames=False, remapUVSetsTo=[['','']], 
-                           materialsScopeName='Materials', selection=True)
+                           materialsScopeName='Materials', legacyMaterialScope=False,
+                           selection=True)
 
         stage = Usd.Stage.Open(usdFilePath)
 

--- a/test/lib/usd/translators/testUsdExportUVTransforms.py
+++ b/test/lib/usd/translators/testUsdExportUVTransforms.py
@@ -51,7 +51,7 @@ class testUsdExportUVTransforms(unittest.TestCase):
 
         usd_file_path = os.path.join(cls.temp_dir, "UsdExportUVTransforms.usda")
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usd_file_path,
-                           shadingMode='useRegistry')
+                           shadingMode='useRegistry', legacyMaterialScope=False)
 
         cls.stage = Usd.Stage.Open(usd_file_path)
 

--- a/test/lib/usd/translators/testUsdExportUsdPreviewSurface.py
+++ b/test/lib/usd/translators/testUsdExportUsdPreviewSurface.py
@@ -286,7 +286,8 @@ class testUsdExportUsdPreviewSurface(unittest.TestCase):
         cmds.file(maya_file, force=True, open=True)
         usd_file_path = os.path.join(self.temp_dir, "UsdPreviewSurfaceExportTest.usda")
         cmds.mayaUSDExport(
-            mergeTransformAndShape=True, file=usd_file_path, shadingMode="useRegistry"
+            mergeTransformAndShape=True, file=usd_file_path, 
+            legacyMaterialScope=False, shadingMode="useRegistry"
         )
 
         stage = Usd.Stage.Open(usd_file_path)
@@ -334,7 +335,8 @@ class testUsdExportUsdPreviewSurface(unittest.TestCase):
         cmds.file(maya_file, force=True, open=True)
         usd_file_path = os.path.join(self.temp_dir, "UsdPreviewSurfaceExportTest.usda")
         cmds.mayaUSDExport(
-            mergeTransformAndShape=True, file=usd_file_path, shadingMode="useRegistry"
+            mergeTransformAndShape=True, file=usd_file_path, 
+            legacyMaterialScope=False, shadingMode="useRegistry"
         )
 
         stage = Usd.Stage.Open(usd_file_path)

--- a/test/lib/usd/translators/testUsdExportUsdzPackage.py
+++ b/test/lib/usd/translators/testUsdExportUsdzPackage.py
@@ -49,7 +49,7 @@ class testUsdExportPackage(unittest.TestCase):
 
         # Write the file out
         path = os.path.join(self.temp_dir, 'testExportSelfContainedPackage.usdz')
-        cmds.mayaUSDExport(f=path, compatibility='appleArKit')
+        cmds.mayaUSDExport(f=path, compatibility='appleArKit', legacyMaterialScope=False)
 
         # Check with USD what the path to the texture is
         stage = Usd.Stage.Open(path)


### PR DESCRIPTION
This allows tests to pass within environments with specified default export behavior