### PR TITLE
EMSUSD-1359 Export of Maya skeleton as USD comes in as a stage in the wrong place.

### DIFF
--- a/lib/usd/translators/jointWriter.cpp
+++ b/lib/usd/translators/jointWriter.cpp
@@ -91,21 +91,6 @@ PxrUsdTranslators_JointWriter::PxrUsdTranslators_JointWriter(
     _usdPrim = _skel.GetPrim();
 }
 
-/// Whether the transform plugs on a transform node are animated.
-static bool _IsTransformNodeAnimated(const MDagPath& dagPath)
-{
-    MFnDependencyNode node(dagPath.node());
-    return UsdMayaUtil::isPlugAnimated(node.findPlug("translateX"))
-        || UsdMayaUtil::isPlugAnimated(node.findPlug("translateY"))
-        || UsdMayaUtil::isPlugAnimated(node.findPlug("translateZ"))
-        || UsdMayaUtil::isPlugAnimated(node.findPlug("rotateX"))
-        || UsdMayaUtil::isPlugAnimated(node.findPlug("rotateY"))
-        || UsdMayaUtil::isPlugAnimated(node.findPlug("rotateZ"))
-        || UsdMayaUtil::isPlugAnimated(node.findPlug("scaleX"))
-        || UsdMayaUtil::isPlugAnimated(node.findPlug("scaleY"))
-        || UsdMayaUtil::isPlugAnimated(node.findPlug("scaleZ"));
-}
-
 /// Gets the world-space rest transform for a single dag path.
 static GfMatrix4d _GetJointWorldBindTransform(const MDagPath& dagPath)
 {
@@ -270,49 +255,6 @@ bool _GetLocalTransformForDagPoseMember(
     return true;
 }
 
-/// Set local-space rest transform by converting from the world-space bind xforms.
-static bool
-_GetJointLocalRestTransformsFromBindTransforms(UsdSkelSkeleton& skel, VtMatrix4dArray& restXforms)
-{
-    auto bindXformsAttr = skel.GetBindTransformsAttr();
-    if (!bindXformsAttr) {
-        TF_WARN("skeleton was missing bind transforms attr: %s", skel.GetPath().GetText());
-        return false;
-    }
-    VtMatrix4dArray bindXforms;
-    if (!bindXformsAttr.Get(&bindXforms)) {
-        TF_WARN("error retrieving bind transforms: %s", skel.GetPath().GetText());
-        return false;
-    }
-
-    auto jointsAttr = skel.GetJointsAttr();
-    if (!jointsAttr) {
-        TF_WARN("skeleton was missing bind joints attr: %s", skel.GetPath().GetText());
-        return false;
-    }
-    VtTokenArray joints;
-    if (!jointsAttr.Get(&joints)) {
-        TF_WARN("error retrieving bind joints: %s", skel.GetPath().GetText());
-        return false;
-    }
-
-    auto restXformsAttr = skel.GetRestTransformsAttr();
-    if (!restXformsAttr) {
-        restXformsAttr = skel.CreateRestTransformsAttr();
-        if (!restXformsAttr) {
-            TF_WARN(
-                "skeleton had no rest transforms attr, and was unable to "
-                "create it: %s",
-                skel.GetPath().GetText());
-            return false;
-        }
-    }
-
-    UsdSkelTopology topology(joints);
-    restXforms.resize(bindXforms.size());
-    return UsdSkelComputeJointLocalTransforms(topology, bindXforms, restXforms);
-}
-
 /// Gets the world-space transform of \p dagPath at the current time.
 static GfMatrix4d _GetJointWorldTransform(const MDagPath& dagPath)
 {
@@ -388,14 +330,11 @@ static bool _GetJointLocalTransforms(
 /// (1) are moved from their rest poses or (2) have animation, if we are going
 /// to export animation.
 static void _GetAnimatedJoints(
-    const UsdSkelTopology&       topology,
     const VtTokenArray&          usdJointNames,
-    const MDagPath&              rootDagPath,
     const std::vector<MDagPath>& jointDagPaths,
     const VtMatrix4dArray&       restXforms,
     VtTokenArray*                animatedJointNames,
-    std::vector<MDagPath>*       animatedJointPaths,
-    bool                         exportingAnimation)
+    std::vector<MDagPath>*       animatedJointPaths)
 {
     if (!TF_VERIFY(usdJointNames.size() == jointDagPaths.size())) {
         return;
@@ -408,14 +347,6 @@ static void _GetAnimatedJoints(
         *animatedJointNames = usdJointNames;
         *animatedJointPaths = jointDagPaths;
         return;
-    }
-
-    VtMatrix4dArray localXforms;
-    if (!exportingAnimation) {
-        // Compute the current local xforms of all joints so we can decide
-        // whether or not they need to have a value encoded on the anim prim.
-        GfMatrix4d rootXform = _GetJointWorldTransform(rootDagPath);
-        _GetJointLocalTransforms(topology, jointDagPaths, rootXform, &localXforms);
     }
 
     // The resulting vector contains only animated joints or joints not
@@ -476,7 +407,8 @@ bool PxrUsdTranslators_JointWriter::_WriteRestState()
 
     // Create something reasonable for rest transforms
     VtMatrix4dArray restXforms;
-    if (_GetJointLocalRestTransformsFromBindTransforms(_skel, restXforms)) {
+    GfMatrix4d      rootXf = _GetJointWorldTransform(_jointHierarchyRootPath);
+    if (_GetJointLocalTransforms(_topology, _joints, rootXf, &restXforms)) {
         UsdMayaWriteUtil::SetAttribute(
             _skel.GetRestTransformsAttr(),
             restXforms,
@@ -487,15 +419,7 @@ bool PxrUsdTranslators_JointWriter::_WriteRestState()
     }
 
     VtTokenArray animJointNames;
-    _GetAnimatedJoints(
-        _topology,
-        skelJointNames,
-        GetDagPath(),
-        _joints,
-        restXforms,
-        &animJointNames,
-        &_animatedJoints,
-        !_GetExportArgs().timeSamples.empty());
+    _GetAnimatedJoints(skelJointNames, _joints, restXforms, &animJointNames, &_animatedJoints);
 
     if (haveUsdSkelXform) {
         _skelXformAttr = _skel.MakeMatrixXform();

--- a/lib/usd/translators/jointWriter.cpp
+++ b/lib/usd/translators/jointWriter.cpp
@@ -15,7 +15,6 @@
 //
 #include "jointWriter.h"
 
-#include <mayaUsd/base/debugCodes.h>
 #include <mayaUsd/fileio/primWriter.h>
 #include <mayaUsd/fileio/primWriterRegistry.h>
 #include <mayaUsd/fileio/translators/translatorSkel.h>
@@ -32,7 +31,6 @@
 #include <pxr/base/tf/token.h>
 #include <pxr/pxr.h>
 #include <pxr/usd/sdf/path.h>
-#include <pxr/usd/sdf/pathTable.h>
 #include <pxr/usd/usd/timeCode.h>
 #include <pxr/usd/usdGeom/xform.h>
 #include <pxr/usd/usdSkel/animation.h>
@@ -45,10 +43,8 @@
 #include <maya/MDagPath.h>
 #include <maya/MFnDependencyNode.h>
 #include <maya/MFnMatrixData.h>
-#include <maya/MFnSkinCluster.h>
 #include <maya/MFnTransform.h>
 #include <maya/MGlobal.h>
-#include <maya/MItDag.h>
 #include <maya/MMatrix.h>
 #include <maya/MPlug.h>
 #include <maya/MPlugArray.h>
@@ -388,22 +384,6 @@ static bool _GetJointLocalTransforms(
     return true;
 }
 
-/// Returns true if the joint's transform definitely matches its rest transform
-/// over all exported frames.
-static bool _JointMatchesRestPose(
-    size_t                 jointIdx,
-    const MDagPath&        dagPath,
-    const VtMatrix4dArray& xforms,
-    const VtMatrix4dArray& restXforms,
-    bool                   exportingAnimation)
-{
-    if (exportingAnimation && _IsTransformNodeAnimated(dagPath))
-        return false;
-    else if (jointIdx < xforms.size())
-        return GfIsClose(xforms[jointIdx], restXforms[jointIdx], 1e-8);
-    return false;
-}
-
 /// Given the list of USD joint names and dag paths, returns the joints that
 /// (1) are moved from their rest poses or (2) have animation, if we are going
 /// to export animation.
@@ -445,11 +425,8 @@ static void _GetAnimatedJoints(
         const TfToken&  jointName = usdJointNames[i];
         const MDagPath& dagPath = jointDagPaths[i];
 
-        if (!_JointMatchesRestPose(
-                i, jointDagPaths[i], localXforms, restXforms, exportingAnimation)) {
-            animatedJointNames->push_back(jointName);
-            animatedJointPaths->push_back(dagPath);
-        }
+        animatedJointNames->push_back(jointName);
+        animatedJointPaths->push_back(dagPath);
     }
 }
 

--- a/lib/usd/translators/jointWriter.cpp
+++ b/lib/usd/translators/jointWriter.cpp
@@ -408,6 +408,10 @@ bool PxrUsdTranslators_JointWriter::_WriteRestState()
     // Create something reasonable for rest transforms
     VtMatrix4dArray restXforms;
     GfMatrix4d      rootXf = _GetJointWorldTransform(_jointHierarchyRootPath);
+    // Setting the skel rest transform as the inverse of the current joint transform.
+    // The inverse of the bind pose would be the ideal scenario here, however joints without a bind
+    // pose or not linked to a skin cluster would have the identity and wouldn't be represented
+    // correctly.
     if (_GetJointLocalTransforms(_topology, _joints, rootXf, &restXforms)) {
         UsdMayaWriteUtil::SetAttribute(
             _skel.GetRestTransformsAttr(),

--- a/test/lib/usd/translators/testUsdExportSkeleton.py
+++ b/test/lib/usd/translators/testUsdExportSkeleton.py
@@ -165,8 +165,12 @@ class testUsdExportSkeleton(unittest.TestCase):
             Vt.Matrix4dArray([Gf.Matrix4d(1.0)]))
         self.assertEqual(skeleton.GetJointsAttr().Get(),
             Vt.TokenArray(['joint1']))
-        self.assertEqual(skeleton.GetRestTransformsAttr().Get(),
-            Vt.Matrix4dArray([Gf.Matrix4d(1.0)]))
+        self.assertEqual(
+            skeleton.GetRestTransformsAttr().Get(),
+            Vt.Matrix4dArray([
+                Gf.Matrix4d( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (5, 5, 0, 1) )
+            ])
+        )
 
         self.assertTrue(skeleton.GetPrim().HasAPI(UsdSkel.BindingAPI))
         skelBindingAPI = UsdSkel.BindingAPI(skeleton)
@@ -240,12 +244,12 @@ class testUsdExportSkeleton(unittest.TestCase):
         self.assertEqual(
             skeleton.GetRestTransformsAttr().Get(),
             Vt.Matrix4dArray([
-                Gf.Matrix4d( (-1, 0, 0, 0), (0, 1, 0, 0), (0, 0, -1, 0), (0, 0, 0, 1) ),
-                Gf.Matrix4d( (0, -1, 0, 0), (1, 0, 0, 0), (0, 0, 1, 0), (-3, 0, 0, 1) ),
-                Gf.Matrix4d( (1, 0, 0, 0), (0, 0, 1, 0), (0, -1, 0, 0), (0, 0, 2, 1) ),
-                Gf.Matrix4d( (1, 0, 0, 0), (0, 0, 1, 0), (0, -1, 0, 0), (0, 2, 0, 1) ),
+                Gf.Matrix4d((0.5000000000000001, 0, -0.8660254037844386, 0), (0, 1, 0, 0), (0.8660254037844386, 0, 0.5000000000000001, 0), (-8, 1, 7, 1)),
+                Gf.Matrix4d((1, 0, 0, 0), (2.7755575615628914e-17, 0.8660254037844387, 0.4999999999999999, 0), (0, -0.49999999999999994, 0.8660254037844388, 0), (-3, 0, 1.2300000000000004, 1)),
+                Gf.Matrix4d((0.7071067811865475, 0.7071067811865476, 2.7755575615628914e-17, 0), (-0.4999999999999999, 0.4999999999999999, 0.7071067811865475, 0), (0.5, -0.4999999999999999, 0.7071067811865475, 0), (-5.0000000000000036, 5, 13.000000000000004, 1)),
+                Gf.Matrix4d((0.9999999999999999, -5.551115123125783e-17, -1.3877787807814457e-17, 0), (5.551115123125783e-17, -2.7755575615628914e-17, 0.9999999999999998, 0), (5.551115123125783e-17, -1, 2.7755575615628914e-17, 0), (-1.7763568394002505e-15, 2, 4.440892098500626e-16, 1)),
             ])
-        )        
+        )
 
     def testSkelWithJointsAtSceneRoot(self):
         """
@@ -322,14 +326,14 @@ class testUsdExportSkeleton(unittest.TestCase):
         stage = Usd.Stage.Open(usdFile)
 
         skeleton = UsdSkel.Skeleton.Get(stage, '/joint_grp/joint1')
-        self.assertEqual(skeleton.GetRestTransformsAttr().Get(),
+        self.assertEqual(skeleton.GetBindTransformsAttr().Get(),
             Vt.Matrix4dArray(
                 # If we're not correlating using logical indices correctly, we may get this
                 # matrix in here somehwere (which we shouldn't):
                 # Gf.Matrix4d( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (777, 888, 999, 1) ),
                 [Gf.Matrix4d( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 2, 1) ),
-                 Gf.Matrix4d( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 3, 0, 1) ),
-                 Gf.Matrix4d( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (5, 0, 0, 1) )]))
+                 Gf.Matrix4d( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 3, 2, 1) ),
+                 Gf.Matrix4d( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (5, 3, 2, 1) )]))
     
     def testPartialSkeletonExport(self):
         """

--- a/test/lib/usd/translators/testUsdExportSkeleton.py
+++ b/test/lib/usd/translators/testUsdExportSkeleton.py
@@ -241,15 +241,19 @@ class testUsdExportSkeleton(unittest.TestCase):
             ])
         )
 
-        self.assertEqual(
-            skeleton.GetRestTransformsAttr().Get(),
-            Vt.Matrix4dArray([
+        expectedRestMatrix = Vt.Matrix4dArray([
                 Gf.Matrix4d((0.5000000000000001, 0, -0.8660254037844386, 0), (0, 1, 0, 0), (0.8660254037844386, 0, 0.5000000000000001, 0), (-8, 1, 7, 1)),
                 Gf.Matrix4d((1, 0, 0, 0), (2.7755575615628914e-17, 0.8660254037844387, 0.4999999999999999, 0), (0, -0.49999999999999994, 0.8660254037844388, 0), (-3, 0, 1.2300000000000004, 1)),
                 Gf.Matrix4d((0.7071067811865475, 0.7071067811865476, 2.7755575615628914e-17, 0), (-0.4999999999999999, 0.4999999999999999, 0.7071067811865475, 0), (0.5, -0.4999999999999999, 0.7071067811865475, 0), (-5.0000000000000036, 5, 13.000000000000004, 1)),
                 Gf.Matrix4d((0.9999999999999999, -5.551115123125783e-17, -1.3877787807814457e-17, 0), (5.551115123125783e-17, -2.7755575615628914e-17, 0.9999999999999998, 0), (5.551115123125783e-17, -1, 2.7755575615628914e-17, 0), (-1.7763568394002505e-15, 2, 4.440892098500626e-16, 1)),
             ])
-        )
+
+        actualRestMatrix = skeleton.GetRestTransformsAttr().Get()
+
+        self.assertTrue(Gf.IsClose(expectedRestMatrix[0], actualRestMatrix[0], 1e-5))
+        self.assertTrue(Gf.IsClose(expectedRestMatrix[1], actualRestMatrix[1], 1e-5))
+        self.assertTrue(Gf.IsClose(expectedRestMatrix[2], actualRestMatrix[2], 1e-5))
+        self.assertTrue(Gf.IsClose(expectedRestMatrix[3], actualRestMatrix[3], 1e-5))
 
     def testSkelWithJointsAtSceneRoot(self):
         """


### PR DESCRIPTION
We were exporting the rest transform as the inverse of the bind transform. 
This was causing issues for bones that weren't bound to any skin cluster.
With this pr, we will use the inverse of the joint's transform as the rest transform.
https://openusd.org/dev/api/_usd_skel__a_p_i__intro.html#UsdSkel_API_WritingSkels

This PR fixes #2857 and #3765 