### PR TITLE
LOOKDEVX-2937 - Fix diffuse lighting with aiAreaLight

### DIFF
--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/SurfaceNodeMaya.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/SurfaceNodeMaya.cpp
@@ -119,7 +119,7 @@ void SurfaceNodeMaya::emitLightLoop(
 
     shadergen.emitComment("Accumulate the light's contribution", stage);
     shadergen.emitLine(
-        outColor + " += lightShader.specularI * " + bsdf->getOutput()->getVariable() + ".response",
+        outColor + " += lightShader.diffuseI * " + bsdf->getOutput()->getVariable() + ".response",
         stage);
 
     shadergen.emitScopeEnd(stage);


### PR DESCRIPTION
This light is the only one that has a specular contribution that differs from the diffuse one, in order to create a fast square-shaped specular.

Problem is this is not a correct physical light and MaterialX expects lights to behave identically in th diffuse and specular domains.

So, we were already using the diffuse light direction at the top of the light loop, so the only change is to use the diffuseI multiplication factor at the bottom. This produces better results with aiAreaLight.