### PR TITLE
EMSUSD-1401 Write single metadata value

### DIFF
--- a/lib/usdUfe/ufe/UsdUndoClearSceneItemMetadataCommand.h
+++ b/lib/usdUfe/ufe/UsdUndoClearSceneItemMetadataCommand.h
@@ -45,7 +45,7 @@ public:
 private:
     const PXR_NS::UsdStageWeakPtr _stage;
     const PXR_NS::SdfPath         _primPath;
-    const PXR_NS::TfToken         _group;
+    const std::string             _group;
     const std::string             _key;
 };
 

--- a/lib/usdUfe/ufe/UsdUndoSetSceneItemMetadataCommand.h
+++ b/lib/usdUfe/ufe/UsdUndoSetSceneItemMetadataCommand.h
@@ -56,7 +56,7 @@ private:
 
     const PXR_NS::UsdStageWeakPtr _stage;
     const PXR_NS::SdfPath         _primPath;
-    const PXR_NS::TfToken         _group;
+    const std::string             _group;
     const std::string             _key;
     const Ufe::Value              _value;
 };


### PR DESCRIPTION
When setting or clearing custom metadata, only write or clear the single requested key. Do not rewrite the whole dictionary. Otherwise, writing a single value in a new USD layer would write all values in that layer.

- Modify the set and clear metadata group command to write or clear only the given key.
- This makes use of the fact the underlying USD function allows writing to a single key by passing a composite key made of the full path to the destination metadata.
- USD also composes metadata dictionaries in multiple layer correctly.
- Add unit tests that failed due to writing to multiple layers before the changes and now passes.