### PR TITLE
MAYA-131348 - Adapt to Maya Ufe world node change

### DIFF
--- a/lib/mayaUsd/commands/PullPushCommands.cpp
+++ b/lib/mayaUsd/commands/PullPushCommands.cpp
@@ -98,22 +98,42 @@ MSyntax createSyntaxWithUfeArgs(int paramCount)
 bool isPrimPath(const Ufe::Path& path) { return ufePathToPrim(path).IsValid(); }
 
 // Parse the indexed argument as text.
-MStatus parseTextArg(const MArgParser& argParser, int index, MString& outputText)
+MStatus parseTextArg(
+    const MArgParser& argParser,
+    int               index,
+    MString&          outputText,
+    const bool        allowEmpty = false)
 {
-    argParser.getCommandArgument(index, outputText);
-    if (outputText.length() <= 0)
+    MStatus st;
+    st = argParser.getCommandArgument(index, outputText);
+    CHECK_MSTATUS_AND_RETURN_IT(st);
+
+    // Note: when requested, we allow the outputText string to be empty
+    //       (input string to command was empty string). In that case
+    //       it will mean the Maya (hidden) world node.
+    if (!allowEmpty && outputText.length() <= 0)
         return MS::kNotFound;
 
     return MS::kSuccess;
 }
 
 // Parse the indexed argument as a UFE path.
-MStatus parseUfePathArg(const MArgParser& argParser, int index, Ufe::Path& outputPath)
+MStatus parseUfePathArg(
+    const MArgParser& argParser,
+    int               index,
+    Ufe::Path&        outputPath,
+    const bool        allowEmpty = false)
 {
     MString text;
-    MStatus status = parseTextArg(argParser, index, text);
-    if (MS::kSuccess != status)
-        return status;
+    MStatus status = parseTextArg(argParser, index, text, allowEmpty);
+    CHECK_MSTATUS_AND_RETURN_IT(status);
+
+    // Note: when requested we allow the Ufe outputPath to be empty
+    //       which will mean the Maya (hidden) world node.
+    if (allowEmpty && (text.length() == 0)) {
+        outputPath = Ufe::Path();
+        return MS::kSuccess;
+    }
 
     return parseArgAsUfePath(text, outputPath);
 }
@@ -122,13 +142,11 @@ MStatus parseDagPathArg(const MArgParser& argParser, int index, MDagPath& output
 {
     MString text;
     MStatus status = parseTextArg(argParser, index, text);
-    if (MS::kSuccess != status)
-        return status;
+    CHECK_MSTATUS_AND_RETURN_IT(status);
 
     MObject obj;
     status = PXR_NS::UsdMayaUtil::GetMObjectByName(text, obj);
-    if (status != MStatus::kSuccess)
-        return status;
+    CHECK_MSTATUS_AND_RETURN_IT(status);
 
     return MDagPath::getAPathTo(obj, outputDagPath);
 }
@@ -185,12 +203,10 @@ MStatus EditAsMayaCommand::doIt(const MArgList& argList)
 
     MStatus    status = MS::kSuccess;
     MArgParser argParser(syntax(), argList, &status);
-    if (status != MS::kSuccess)
-        return status;
+    CHECK_MSTATUS_AND_RETURN_IT(status);
 
     status = parseUfePathArg(argParser, 0, _path);
-    if (status != MS::kSuccess)
-        return reportError(status);
+    CHECK_MSTATUS_AND_RETURN_IT(status);
 
     if (!isPrimPath(_path))
         return reportError(MS::kInvalidParameter);
@@ -247,11 +263,7 @@ MStatus MergeToUsdCommand::doIt(const MArgList& argList)
 
     MStatus    status = MS::kSuccess;
     MArgParser argParser(syntax(), argList, &status);
-    if (status != MS::kSuccess)
-        return status;
-
-    if (status != MStatus::kSuccess)
-        return status;
+    CHECK_MSTATUS_AND_RETURN_IT(status);
 
     MDagPath dagPath;
     status = parseDagPathArg(argParser, 0, dagPath);
@@ -275,8 +287,7 @@ MStatus MergeToUsdCommand::doIt(const MArgList& argList)
     if (exportOptions.length() > 0) {
         status = PXR_NS::UsdMayaJobExportArgs::GetDictionaryFromEncodedOptions(
             exportOptions, &userArgs);
-        if (status != MS::kSuccess)
-            return status;
+        CHECK_MSTATUS_AND_RETURN_IT(status);
     }
 
     if (argData.isFlagSet(kIgnoreVariantsFlag)) {
@@ -338,8 +349,7 @@ MStatus DiscardEditsCommand::doIt(const MArgList& argList)
 
     MStatus    status = MS::kSuccess;
     MArgParser argParser(syntax(), argList, &status);
-    if (status != MS::kSuccess)
-        return status;
+    CHECK_MSTATUS_AND_RETURN_IT(status);
 
     MString nodeName;
     status = parseTextArg(argParser, 0, nodeName);
@@ -416,14 +426,13 @@ MStatus DuplicateCommand::doIt(const MArgList& argList)
 
     MStatus    status = MS::kSuccess;
     MArgParser argParser(syntax(), argList, &status);
-    if (status != MS::kSuccess)
-        return status;
+    CHECK_MSTATUS_AND_RETURN_IT(status);
 
     status = parseUfePathArg(argParser, 0, _srcPath);
     if (status != MS::kSuccess)
         return reportError(status);
 
-    status = parseUfePathArg(argParser, 1, _dstPath);
+    status = parseUfePathArg(argParser, 1, _dstPath, true /*allowEmpty*/);
     if (status != MS::kSuccess)
         return reportError(status);
 
@@ -435,8 +444,7 @@ MStatus DuplicateCommand::doIt(const MArgList& argList)
     if (exportOptions.length() > 0) {
         status = PXR_NS::UsdMayaJobExportArgs::GetDictionaryFromEncodedOptions(
             exportOptions, &userArgs);
-        if (status != MS::kSuccess)
-            return status;
+        CHECK_MSTATUS_AND_RETURN_IT(status);
     }
 
     // Scope the undo item recording so we can undo on failure.
@@ -455,12 +463,19 @@ MStatus DuplicateCommand::doIt(const MArgList& argList)
             // - Maya duplicate to USD: we always duplicate directly under the
             //   proxy shape, so add a single path component USD path segment.
             // - USD duplicate to Maya: no path segment to add.
-            Ufe::Path childPath = (_srcPath.runTimeId() == getMayaRunTimeId())
-                ?
+            Ufe::Path childPath;
+            if (_srcPath.runTimeId() == getMayaRunTimeId()) {
                 // Maya duplicate to USD
-                _dstPath + Ufe::PathSegment(_srcPath.back(), getUsdRunTimeId(), '/')
+                auto ps = Ufe::PathSegment(_srcPath.back(), getUsdRunTimeId(), '/');
+                childPath = _dstPath.empty() ? ps : _dstPath + ps;
+            } else {
                 // USD duplicate to Maya
-                : _dstPath + _srcPath.back();
+                if (_dstPath.empty()) {
+                    childPath = Ufe::PathString::path("|" + _srcPath.back().string());
+                } else {
+                    childPath = _dstPath + _srcPath.back();
+                }
+            }
 
             Ufe::Selection sn;
             sn.append(Ufe::Hierarchy::createItem(childPath));

--- a/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
+++ b/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
@@ -94,10 +94,13 @@ bool duplicate(
     const std::string&  dstUfePathString,
     const VtDictionary& userArgs = VtDictionary())
 {
-    Ufe::Path src = Ufe::PathString::path(srcUfePathString);
-    Ufe::Path dst = Ufe::PathString::path(dstUfePathString);
+    // Either input string is allowed to be null (but not both).
+    Ufe::Path src
+        = srcUfePathString.empty() ? Ufe::Path() : Ufe::PathString::path(srcUfePathString);
+    Ufe::Path dst
+        = dstUfePathString.empty() ? Ufe::Path() : Ufe::PathString::path(dstUfePathString);
 
-    if (src.empty() || dst.empty())
+    if (src.empty() && dst.empty())
         return false;
 
     return PrimUpdaterManager::getInstance().duplicate(src, dst, userArgs);

--- a/lib/mayaUsd/ufe/MayaUsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/MayaUsdContextOps.cpp
@@ -683,9 +683,10 @@ Ufe::UndoableCommand::Ptr MayaUsdContextOps::doOpCmd(const ItemPath& itemPath)
     } else if (itemPath[0] == kEditAsMayaOptionsItem) {
         executeEditAsMayaOptions(path());
     } else if (itemPath[0] == kDuplicateAsMayaItem) {
+        // Note: empty string for target means Maya (hidden) world node.
         MString script;
         script.format(
-            "^1s \"^2s\" \"|world\"",
+            "^1s \"^2s\" \"\"",
             DuplicateCommand::commandName,
             Ufe::PathString::string(path()).c_str());
         UsdUfe::WaitCursor wait;

--- a/lib/mayaUsd/ufe/UsdUndoCreateStageWithNewLayerCommand.h
+++ b/lib/mayaUsd/ufe/UsdUndoCreateStageWithNewLayerCommand.h
@@ -44,6 +44,9 @@ public:
     //! Since the proxy shape does not have a USD file associated (in the .filePath attribute), the
     //! proxy shape base will create an empty stage in memory. This will create the session and root
     //! layer as well.
+    //!
+    //! \param[in] parentItem Item to parent the new stage to, can be null in which case the
+    //!                       new stage gets parented under the Maya world node.
     static UsdUndoCreateStageWithNewLayerCommand::Ptr create(const Ufe::SceneItem::Ptr& parentItem);
 
     Ufe::SceneItem::Ptr sceneItem() const override;

--- a/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
@@ -37,6 +37,7 @@
 #include <ufe/log.h>
 #include <ufe/path.h>
 #include <ufe/pathSegment.h>
+#include <ufe/pathString.h>
 #include <ufe/scene.h>
 #include <ufe/sceneNotification.h>
 
@@ -123,7 +124,6 @@ void sendNotificationToAllStageProxies(
     const Ufe::Path&   srcPath,
     const Ufe::Path&   dstPath)
 {
-    const Ufe::Rtid mayaId = getMayaRunTimeId();
     for (const std::string& proxyName : ProxyShapeHandler::getAllNames()) {
         UsdStagePtr proxyStage = ProxyShapeHandler::dagPathToStage(proxyName);
         if (proxyStage != stage)
@@ -131,7 +131,8 @@ void sendNotificationToAllStageProxies(
 
         // For all the proxy shapes that are mapping the same stage, we need to fixup the
         // Ufe path since they have different Ufe Paths because it contains proxy shape name.
-        const Ufe::PathSegment proxySegment(std::string("|world") + proxyName, mayaId, '|');
+        auto proxyNamePath = Ufe::PathString::path(proxyName);
+        auto proxySegment = proxyNamePath.getSegments()[0];
 
         const Ufe::PathSegment& srcUsdSegment = srcPath.getSegments()[1];
         const Ufe::Path adjustedSrcPath(Ufe::Path::Segments({ proxySegment, srcUsdSegment }));

--- a/lib/mayaUsd/ufe/wrapUtils.cpp
+++ b/lib/mayaUsd/ufe/wrapUtils.cpp
@@ -93,8 +93,13 @@ PXR_NS::TfTokenVector _getProxyShapePurposes(const std::string& ufePathString)
 #ifdef UFE_V4_FEATURES_AVAILABLE
 std::string createStageWithNewLayer(const std::string& parentPathString)
 {
-    auto parentPath = Ufe::PathString::path(parentPathString);
-    auto parent = Ufe::Hierarchy::createItem(parentPath);
+    // Input path parent string is allowed to be empty in which case we'll
+    // parent the new stage to the Maya world node.
+    Ufe::SceneItem::Ptr parent;
+    if (!parentPathString.empty()) {
+        auto parentPath = Ufe::PathString::path(parentPathString);
+        parent = Ufe::Hierarchy::createItem(parentPath);
+    }
     auto command = MayaUsd::ufe::UsdUndoCreateStageWithNewLayerCommand::create(parent);
     if (!command) {
         return "";

--- a/lib/mayaUsdAPI/utils.h
+++ b/lib/mayaUsdAPI/utils.h
@@ -70,6 +70,9 @@ Ufe::UndoableCommand::Ptr createMaterialsScopeCommand(const Ufe::SceneItem::Ptr&
 
 /*! Returns a Ufe command that can create a new Usd stage with a new layer.
  *  The returned command is not executed; it is up to the caller to call execute().
+ *
+ * \param [in] parentItem Item to parent the new stage to, can be null in which case the
+ *                        new stage gets parented under the Maya world node.
  */
 MAYAUSD_API_PUBLIC
 Ufe::UndoableCommand::Ptr createStageWithNewLayerCommand(const Ufe::SceneItem::Ptr& parentItem);

--- a/plugin/adsk/scripts/mayaUsd_createStageWithNewLayer.py
+++ b/plugin/adsk/scripts/mayaUsd_createStageWithNewLayer.py
@@ -31,7 +31,8 @@ def createStageWithNewLayer():
     # (in the .filePath attribute), the proxy shape base will create an empty
     # stage in memory. This will create the session and root layer as well.
     if hasattr(mayaUsd, 'ufe') and hasattr(mayaUsd.ufe, 'createStageWithNewLayer'):
-        shapeNode = mayaUsd.ufe.createStageWithNewLayer('|world')
+        # Empty parent means parent to Maya world node.
+        shapeNode = mayaUsd.ufe.createStageWithNewLayer('')
         cmds.select(shapeNode, replace=True)
         return shapeNode
     else:

--- a/test/lib/mayaUsd/fileio/testDiscardEdits.py
+++ b/test/lib/mayaUsd/fileio/testDiscardEdits.py
@@ -281,7 +281,7 @@ class DiscardEditsTestCase(unittest.TestCase):
         mayaUtils.openAppleBiteScene()
 
         mayaPathSegment = mayaUtils.createUfePathSegment('|Asset_flattened_instancing_and_class_removed_usd|Asset_flattened_instancing_and_class_removed_usdShape')
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
         self.assertTrue(stage)
         
         usdPathSegment = usdUtils.createUfePathSegment('/apple/payload/geo/skin')

--- a/test/lib/mayaUsd/fileio/testDuplicateAs.py
+++ b/test/lib/mayaUsd/fileio/testDuplicateAs.py
@@ -71,7 +71,7 @@ class DuplicateAsTestCase(unittest.TestCase):
         # Duplicate USD data as Maya data, placing it under the root.
         with mayaUsd.lib.OpUndoItemList():
             self.assertTrue(mayaUsd.lib.PrimUpdaterManager.duplicate(
-                aUsdUfePathStr, '|world'))
+                aUsdUfePathStr, ''))
 
         # Should now have two transform nodes in the Maya scene: the path
         # components in the second segment of the aUsdItem and bUsdItem will
@@ -102,7 +102,7 @@ class DuplicateAsTestCase(unittest.TestCase):
         # Duplicate USD data as Maya data, placing it under the transform we created.
         with mayaUsd.lib.OpUndoItemList():
             self.assertTrue(mayaUsd.lib.PrimUpdaterManager.duplicate(
-                aUsdUfePathStr, '|world|'+ xformName))
+                aUsdUfePathStr, "|" + xformName))
 
         # Should now have two transform nodes in the Maya scene: the path
         # components in the second segment of the aUsdItem and bUsdItem will
@@ -131,7 +131,7 @@ class DuplicateAsTestCase(unittest.TestCase):
         previousSn = cmds.ls(sl=True, ufe=True, long=True)
 
         # Duplicate USD data as Maya data, placing it under the root.
-        cmds.mayaUsdDuplicate(aUsdUfePathStr, '|world')
+        cmds.mayaUsdDuplicate(aUsdUfePathStr, '')
 
         def verifyDuplicate():
             # Should now have two transform nodes in the Maya scene: the path

--- a/test/lib/mayaUsd/nodes/testLayerManagerSerialization.py
+++ b/test/lib/mayaUsd/nodes/testLayerManagerSerialization.py
@@ -260,7 +260,7 @@ class testLayerManagerSerialization(unittest.TestCase):
         proxyShape = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
         proxyShapePath = ufe.PathString.path(proxyShape)
 
-        stage = mayaUsd.ufe.getStage(str(proxyShapePath))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(proxyShapePath))
 
         newPrimPath = "/ChangeInRoot"
         stage.DefinePrim(newPrimPath, "xform")
@@ -290,7 +290,7 @@ class testLayerManagerSerialization(unittest.TestCase):
         proxyShape = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
         proxyShapePath = ufe.PathString.path(proxyShape)
 
-        stage = mayaUsd.ufe.getStage(str(proxyShapePath))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(proxyShapePath))
 
         newPrimPath = "/ChangeInRoot"
         stage.DefinePrim(newPrimPath, "xform")

--- a/test/lib/mayaUsd/nodes/testProxyShapeBase.py
+++ b/test/lib/mayaUsd/nodes/testProxyShapeBase.py
@@ -88,7 +88,7 @@ class testProxyShapeBase(unittest.TestCase):
         self.assertEqual(str(proxyShapeHier.children()[0].nodeName()), "Capsule1")
 
         # validate session name and anonymous tag name 
-        stage = mayaUsd.ufe.getStage(str(proxyShapePath))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(proxyShapePath))
         self.assertEqual(stage.GetLayerStack()[0], stage.GetSessionLayer())
         self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetRootLayer())
         self.assertEqual(True, "-session" in stage.GetSessionLayer().identifier)
@@ -122,7 +122,7 @@ class testProxyShapeBase(unittest.TestCase):
         self.assertEqual(childName, "Capsule1")
 
         # validate session name and anonymous tag name 
-        duplStage = mayaUsd.ufe.getStage(str(ufe.PathString.path('|stage2|stageShape2')))
+        duplStage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.PathString.path('|stage2|stageShape2')))
         self.assertEqual(duplStage.GetLayerStack()[0], duplStage.GetSessionLayer())
         self.assertEqual(duplStage.GetEditTarget().GetLayer(), duplStage.GetRootLayer())
         self.assertEqual(True, "-session" in duplStage.GetSessionLayer().identifier)
@@ -228,7 +228,7 @@ class testProxyShapeBase(unittest.TestCase):
         self.assertEqual(1, len(ufe.Hierarchy.hierarchy(treebaseItem).children()))
 
         # get the USD stage
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
 
         # by default edit target is set to the Rootlayer.
         self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetRootLayer())
@@ -259,7 +259,7 @@ class testProxyShapeBase(unittest.TestCase):
         self.assertEqual(childName, "TreeBase")
 
         # validate session name and anonymous tag name 
-        duplStage = mayaUsd.ufe.getStage(str(ufe.PathString.path('|Tree_usd1|Tree_usd1Shape')))
+        duplStage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.PathString.path('|Tree_usd1|Tree_usd1Shape')))
         self.assertEqual(duplStage.GetLayerStack()[0], duplStage.GetSessionLayer())
         self.assertEqual(duplStage.GetEditTarget().GetLayer(), duplStage.GetRootLayer())
         self.assertEqual(True, "-session" in duplStage.GetSessionLayer().identifier)

--- a/test/lib/mayaUsd/undo/testOpUndoItem.py
+++ b/test/lib/mayaUsd/undo/testOpUndoItem.py
@@ -60,7 +60,7 @@ class OpUndoItemTestCase(unittest.TestCase):
         # Without any means to capture undo items.
         with self.assertRaises(pxr.Tf.ErrorException):
             self.assertTrue(mayaUsd.lib.PrimUpdaterManager.duplicate(
-                aUsdUfePathStr, '|world'))
+                aUsdUfePathStr, ''))
 
     def testUndoItemWithRecorder(self):
         '''
@@ -84,7 +84,7 @@ class OpUndoItemTestCase(unittest.TestCase):
         # With an active list the undo item should be happy.
         with undoList:
             self.assertTrue(mayaUsd.lib.PrimUpdaterManager.duplicate(
-                aUsdUfePathStr, '|world'))
+                aUsdUfePathStr, ''))
 
 
 if __name__ == '__main__':

--- a/test/lib/mayaUsd/undo/testOpUndoItemList.py
+++ b/test/lib/mayaUsd/undo/testOpUndoItemList.py
@@ -63,7 +63,7 @@ class OpUndoItemListTestCase(unittest.TestCase):
         # Duplicate USD data as Maya data, placing it under the root.
         with undoList:
             self.assertTrue(mayaUsd.lib.PrimUpdaterManager.duplicate(
-                aUsdUfePathStr, '|world'))
+                aUsdUfePathStr, ''))
 
         # Verify the command worked and undo items were captured.
         def hasDuplicatedObjects():

--- a/test/lib/mayaUsd/undo/testUsdUndoManager.py
+++ b/test/lib/mayaUsd/undo/testUsdUndoManager.py
@@ -21,6 +21,7 @@ import maya.cmds as cmds
 
 from pxr import Tf, Usd, UsdGeom, Gf
 
+import ufe
 import mayaUsd.lib as mayaUsdLib
 import mayaUtils
 import ufeUtils
@@ -162,7 +163,7 @@ class TestUsdUndoManager(unittest.TestCase):
         self.assertEqual(cmds.undoInfo(q=True), 0)
         
         mayaPathSegment = mayaUtils.createUfePathSegment('|Tree_usd|Tree_usdShape')
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
         self.assertTrue(stage)
         self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetRootLayer())
         

--- a/test/lib/testMayaUsdCreateStageCommands.py
+++ b/test/lib/testMayaUsdCreateStageCommands.py
@@ -113,7 +113,7 @@ class MayaUsdCreateStageCommandsTestCase(unittest.TestCase):
         Create a stage with a new layer using the command exposed by a Python wrapper.
         '''
 
-        stageUfePathStr = mayaUsd.ufe.createStageWithNewLayer("|world")
+        stageUfePathStr = mayaUsd.ufe.createStageWithNewLayer("")
         self.assertIsNotNone(stageUfePathStr)
 
         stageUfePath = ufe.PathString.path(stageUfePathStr)

--- a/test/lib/ufe/testBatchOpsHandler.py
+++ b/test/lib/ufe/testBatchOpsHandler.py
@@ -141,12 +141,13 @@ class BatchOpsHandlerTestCase(unittest.TestCase):
 
         connections = connectionHandler.sourceConnections(dF3t.item)
         self.assertIsNotNone(connections)
-        conn = set(["{}.{} -> {}.{}".format(i.src.path, i.src.name, i.dst.path, i.dst.name) for i in connections.allConnections()])
+        conn = set(["{}.{} -> {}.{}".format(ufe.PathString.string(i.src.path), i.src.name,
+                                            ufe.PathString.string(i.dst.path), i.dst.name) for i in connections.allConnections()])
         wrongButExpected = {
             # Connections are pointing to the original file3 and place2dTexture3 nodes. We want them
             # to link with the new nodes instead
-            '|world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/file3.outputs:out -> |world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/file3_MayafileTexture1.inputs:inColor',
-            '|world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/place2dTexture3.outputs:out -> |world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/file3_MayafileTexture1.inputs:uvCoord'
+            '|stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/file3.outputs:out -> |stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/file3_MayafileTexture1.inputs:inColor',
+            '|stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/place2dTexture3.outputs:out -> |stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/file3_MayafileTexture1.inputs:uvCoord'
         }
         self.assertEqual(conn, wrongButExpected)
 
@@ -164,24 +165,28 @@ class BatchOpsHandlerTestCase(unittest.TestCase):
 
         expectedF3t = {
             # Connections are pointing to the new file4 and place2dTexture4 nodes.
-            '|world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/file4.outputs:out -> |world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/file3_MayafileTexture1.inputs:inColor',
-            '|world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/place2dTexture4.outputs:out -> |world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/file3_MayafileTexture1.inputs:uvCoord'
+            '|stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/file4.outputs:out -> |stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/file3_MayafileTexture1.inputs:inColor',
+            '|stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/place2dTexture4.outputs:out -> |stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/file3_MayafileTexture1.inputs:uvCoord'
         }
 
         def checkConnections1(self, cmd, f3Item, f3tItem, f3pItem, expectedF3t):
             connections = connectionHandler.sourceConnections(cmd.targetItem(f3tItem.path()))
             self.assertIsNotNone(connections)
-            conn = set(["{}.{} -> {}.{}".format(i.src.path, i.src.name, i.dst.path, i.dst.name) for i in connections.allConnections()])
+            conn = set(["{}.{} -> {}.{}".format(ufe.PathString.string(i.src.path), i.src.name,
+                                                ufe.PathString.string(i.dst.path), i.dst.name) for i in connections.allConnections()])
             self.assertEqual(conn, expectedF3t)
-            self.assertEqual(str(cmd.targetItem(f3Item.path()).path()), '|world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/file4')
-            self.assertEqual(str(cmd.targetItem(f3pItem.path()).path()), '|world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/place2dTexture4')
+            self.assertEqual(ufe.PathString.string(cmd.targetItem(f3Item.path()).path()),
+                             '|stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/file4')
+            self.assertEqual(ufe.PathString.string(cmd.targetItem(f3pItem.path()).path()),
+                             '|stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/place2dTexture4')
 
             connections = connectionHandler.sourceConnections(cmd.targetItem(f3pItem.path()))
             self.assertIsNotNone(connections)
-            conn = set(["{}.{} -> {}.{}".format(i.src.path, i.src.name, i.dst.path, i.dst.name) for i in connections.allConnections()])
+            conn = set(["{}.{} -> {}.{}".format(ufe.PathString.string(i.src.path), i.src.name,
+                                                ufe.PathString.string(i.dst.path), i.dst.name) for i in connections.allConnections()])
             expectedF3p = {
                 # Connection pointing to the original node graph.
-                '|world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG.inputs:file3:varname -> |world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/place2dTexture4.inputs:geomprop',
+                '|stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG.inputs:file3:varname -> |stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/place2dTexture4.inputs:geomprop',
             }
             self.assertEqual(conn, expectedF3p)
 
@@ -203,7 +208,8 @@ class BatchOpsHandlerTestCase(unittest.TestCase):
         def checkConnections2(self, cmd, f3tItem, f3pItem, expectedF3t):
             connections = connectionHandler.sourceConnections(cmd.targetItem(f3tItem.path()))
             self.assertIsNotNone(connections)
-            conn = set(["{}.{} -> {}.{}".format(i.src.path, i.src.name, i.dst.path, i.dst.name) for i in connections.allConnections()])
+            conn = set(["{}.{} -> {}.{}".format(ufe.PathString.string(i.src.path), i.src.name,
+                                                ufe.PathString.string(i.dst.path), i.dst.name) for i in connections.allConnections()])
             self.assertEqual(conn, expectedF3t)
 
             # The connection between the new place2dTexture and the original NodeGraph will be gone.
@@ -273,25 +279,29 @@ class BatchOpsHandlerTestCase(unittest.TestCase):
 
         expectedF3t = {
             # Connections are pointing to the new file4 and place2dTexture4 nodes.
-            '|world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/file4.outputs:out -> |world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/file3_MayafileTexture1.inputs:inColor',
-            '|world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/place2dTexture4.outputs:out -> |world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/file3_MayafileTexture1.inputs:uvCoord'
+            '|stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/file4.outputs:out -> |stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/file3_MayafileTexture1.inputs:inColor',
+            '|stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/place2dTexture4.outputs:out -> |stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/file3_MayafileTexture1.inputs:uvCoord'
         }
 
         def checkState1(self, expectedF3t):
             f3tDupItem, f3DupItem, f3pDupItem = tuple(ufe.GlobalSelection.get())
             connections = connectionHandler.sourceConnections(f3tDupItem)
             self.assertIsNotNone(connections)
-            conn = set(["{}.{} -> {}.{}".format(i.src.path, i.src.name, i.dst.path, i.dst.name) for i in connections.allConnections()])
+            conn = set(["{}.{} -> {}.{}".format(ufe.PathString.string(i.src.path), i.src.name,
+                                                ufe.PathString.string(i.dst.path), i.dst.name) for i in connections.allConnections()])
             self.assertEqual(conn, expectedF3t)
-            self.assertEqual(str(f3DupItem.path()), '|world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/file4')
-            self.assertEqual(str(f3pDupItem.path()), '|world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/place2dTexture4')
+            self.assertEqual(ufe.PathString.string(f3DupItem.path()),
+                             '|stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/file4')
+            self.assertEqual(ufe.PathString.string(f3pDupItem.path()),
+                             '|stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/place2dTexture4')
 
             connections = connectionHandler.sourceConnections(f3pDupItem)
             self.assertIsNotNone(connections)
-            conn = set(["{}.{} -> {}.{}".format(i.src.path, i.src.name, i.dst.path, i.dst.name) for i in connections.allConnections()])
+            conn = set(["{}.{} -> {}.{}".format(ufe.PathString.string(i.src.path), i.src.name,
+                                                ufe.PathString.string(i.dst.path), i.dst.name) for i in connections.allConnections()])
             expectedF3p = {
                 # Connection pointing to the original node graph.
-                '|world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG.inputs:file3:varname -> |world|stage|stageShape/mtl/ss3SG/MayaNG_ss3SG/place2dTexture4.inputs:geomprop',
+                '|stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG.inputs:file3:varname -> |stage|stageShape,/mtl/ss3SG/MayaNG_ss3SG/place2dTexture4.inputs:geomprop',
             }
             self.assertEqual(conn, expectedF3p)
 
@@ -311,7 +321,8 @@ class BatchOpsHandlerTestCase(unittest.TestCase):
             f3tDupItem, _, f3pDupItem = tuple(ufe.GlobalSelection.get())
             connections = connectionHandler.sourceConnections(f3tDupItem)
             self.assertIsNotNone(connections)
-            conn = set(["{}.{} -> {}.{}".format(i.src.path, i.src.name, i.dst.path, i.dst.name) for i in connections.allConnections()])
+            conn = set(["{}.{} -> {}.{}".format(ufe.PathString.string(i.src.path), i.src.name,
+                                                ufe.PathString.string(i.dst.path), i.dst.name) for i in connections.allConnections()])
             self.assertEqual(conn, expectedF3t)
 
             # The connection between the new place2dTexture and the original NodeGraph will be gone.

--- a/test/lib/ufe/testClipboard.py
+++ b/test/lib/ufe/testClipboard.py
@@ -330,7 +330,7 @@ class ClipboardHandlerTestCase(unittest.TestCase):
 
         # Get the stage
         mayaPathSegment = mayaUtils.createUfePathSegment('|Variant_usd|Variant_usdShape')
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
 
         # First check that we have a Variant.
         objectPrim = stage.GetPrimAtPath('/objects')

--- a/test/lib/ufe/testDeleteCmd.py
+++ b/test/lib/ufe/testDeleteCmd.py
@@ -115,7 +115,7 @@ class DeleteCmdTestCase(unittest.TestCase):
 
         # validate the default edit target to be the Rootlayer.
         mayaPathSegment = mayaUtils.createUfePathSegment('|Tree_usd|Tree_usdShape')
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
         self.assertTrue(stage)
         self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetRootLayer())
         
@@ -151,7 +151,7 @@ class DeleteCmdTestCase(unittest.TestCase):
 
         # validate the default edit target to be the Rootlayer.
         mayaPathSegment = mayaUtils.createUfePathSegment('|Tree_usd|Tree_usdShape')
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
         self.assertTrue(stage)
         self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetRootLayer())
         
@@ -190,7 +190,7 @@ class DeleteCmdTestCase(unittest.TestCase):
 
         # validate the default edit target to be the Rootlayer.
         mayaPathSegment = mayaUtils.createUfePathSegment('|Tree_usd|Tree_usdShape')
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
         self.assertTrue(stage)
         self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetRootLayer())
         
@@ -229,7 +229,7 @@ class DeleteCmdTestCase(unittest.TestCase):
 
         # retrieve the stage
         mayaPathSegment = mayaUtils.createUfePathSegment('|Tree_usd|Tree_usdShape')
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
         self.assertTrue(stage)
 
         newLayerName = 'Layer_1'
@@ -272,7 +272,7 @@ class DeleteCmdTestCase(unittest.TestCase):
 
         # validate the default edit target to be the Rootlayer.
         mayaPathSegment = mayaUtils.createUfePathSegment('|Variant_usd|Variant_usdShape')
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
         self.assertTrue(stage)
         self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetRootLayer())
         
@@ -305,7 +305,7 @@ class DeleteCmdTestCase(unittest.TestCase):
 
         # validate the default edit target to be the Rootlayer.
         mayaPathSegment = mayaUtils.createUfePathSegment('|Asset_flattened_instancing_and_class_removed_usd|Asset_flattened_instancing_and_class_removed_usdShape')
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
         self.assertTrue(stage)
         self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetRootLayer())
         
@@ -338,7 +338,7 @@ class DeleteCmdTestCase(unittest.TestCase):
 
         # add child defined on a new layer
         mayaPathSegment = mayaUtils.createUfePathSegment('|Tree_usd|Tree_usdShape')
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
         self.assertTrue(stage)
 
         newLayerName = 'Layer_1'
@@ -388,7 +388,7 @@ class DeleteCmdTestCase(unittest.TestCase):
 
         # add child defined on session layer
         mayaPathSegment = mayaUtils.createUfePathSegment('|Tree_usd|Tree_usdShape')
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
         self.assertTrue(stage)
         
         stage.SetEditTarget(stage.GetSessionLayer())
@@ -535,7 +535,7 @@ class DeleteCmdTestCase(unittest.TestCase):
 
         # validate the default edit target to be the Rootlayer.
         mayaPathSegment = mayaUtils.createUfePathSegment('|TreeRef_usd|TreeRef_usdShape')
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
         self.assertTrue(stage)
         self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetRootLayer())
         self.assertTrue(stage.GetPrimAtPath('/TreeBase/leaf_ref_1').HasAuthoredReferences())

--- a/test/lib/ufe/testGroupCmd.py
+++ b/test/lib/ufe/testGroupCmd.py
@@ -123,7 +123,7 @@ class GroupCmdTestCase(unittest.TestCase):
         self.assertEqual(len(parentChildrenPre), 6)
 
         # get the USD stage
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
 
         # set the edit target to balls.usda
         layer = stage.GetLayerStack()[1]
@@ -323,7 +323,7 @@ class GroupCmdTestCase(unittest.TestCase):
         ufeSelection.append(ball5Item)
 
         # get the USD stage
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
 
         # set the edit target to a new layer
         newLayerName = 'Layer_1'

--- a/test/lib/ufe/testLegacyDeleteCmd.py
+++ b/test/lib/ufe/testLegacyDeleteCmd.py
@@ -249,7 +249,7 @@ class DeleteCmdTestCase(unittest.TestCase):
             ball34PathString,
             "|transform1|proxyShape1,/Room_set/Props/Ball_34")
 
-        # Test that "|world" prefix is optional for multi-segment paths.
+        # Test that "|world" prefix is not required for multi-segment paths.
         ball35PathString = "|transform1|proxyShape1,/Room_set/Props/Ball_35"
 
         ufeObs.reset()

--- a/test/lib/ufe/testObject3d.py
+++ b/test/lib/ufe/testObject3d.py
@@ -360,7 +360,7 @@ class Object3dTestCase(unittest.TestCase):
         object3d = ufe.Object3d.object3d(capsuleItem)
 
         # stage / primSpec
-        stage = mayaUsd.ufe.getStage(str(proxyShapePath))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(proxyShapePath))
         primSpec = stage.GetEditTarget().GetPrimSpecForScenePath('/Capsule1');
 
         # initially capsuleItem should be visible.
@@ -428,7 +428,7 @@ class Object3dTestCase(unittest.TestCase):
         cylinderPrim = mayaUsd.ufe.ufePathToPrim(ufe.PathString.string(cylinderPath))
 
         # stage / primSpec
-        stage = mayaUsd.ufe.getStage(str(proxyShapePath))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(proxyShapePath))
         primSpecCapsule = stage.GetEditTarget().GetPrimSpecForScenePath('/Capsule1');
         primSpecCylinder = stage.GetEditTarget().GetPrimSpecForScenePath('/Cylinder1');
 

--- a/test/lib/ufe/testParentCmd.py
+++ b/test/lib/ufe/testParentCmd.py
@@ -113,7 +113,7 @@ class ParentCmdTestCase(unittest.TestCase):
         cylinderItem = ufe.Hierarchy.createItem(cylinderPath)
 
         # get the USD stage
-        stage = mayaUsd.ufe.getStage(str(shapeSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(shapeSegment)))
 
         # check GetLayerStack behavior
         self.assertEqual(stage.GetEditTarget().GetLayer(),
@@ -203,7 +203,7 @@ class ParentCmdTestCase(unittest.TestCase):
         cylinderItem = ufe.Hierarchy.createItem(cylinderPath)
 
         # get the USD stage
-        stage = mayaUsd.ufe.getStage(str(shapeSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(shapeSegment)))
 
         # check GetLayerStack behavior
         self.assertEqual(stage.GetEditTarget().GetLayer(),
@@ -312,7 +312,7 @@ class ParentCmdTestCase(unittest.TestCase):
         cylinderItem = ufe.Hierarchy.createItem(cylinderPath)
 
         # get the USD stage
-        stage = mayaUsd.ufe.getStage(str(shapeSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(shapeSegment)))
 
         # check GetLayerStack behavior
         self.assertEqual(stage.GetEditTarget().GetLayer(),
@@ -872,7 +872,7 @@ class ParentCmdTestCase(unittest.TestCase):
             sphereItem = ufe.Hierarchy.createItem(spherePath)
 
             # get the USD stage
-            stage = mayaUsd.ufe.getStage(str(shapeSegment))
+            stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(shapeSegment)))
 
             # check GetLayerStack behavior
             self.assertEqual(stage.GetEditTarget().GetLayer(),
@@ -957,7 +957,7 @@ class ParentCmdTestCase(unittest.TestCase):
             childrenPre = parent.children()
 
             # get the USD stage
-            stage = mayaUsd.ufe.getStage(str(shapeSegment))
+            stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(shapeSegment)))
 
             # check GetLayerStack behavior
             self.assertEqual(stage.GetEditTarget().GetLayer(),

--- a/test/lib/ufe/testPythonWrappers.py
+++ b/test/lib/ufe/testPythonWrappers.py
@@ -64,7 +64,7 @@ class PythonWrappersTestCase(unittest.TestCase):
         proxyShapePath = ufe.Path(mayaUtils.createUfePathSegment(proxyShape))
 
         # Test maya-usd getStage() wrapper.
-        mayaUsdStage = mayaUsd.ufe.getStage(str(proxyShapePath))
+        mayaUsdStage = mayaUsd.ufe.getStage(ufe.PathString.string(proxyShapePath))
         self.assertIsNotNone(mayaUsdStage)
 
         # Verify that this the stage returned from maya-usd wrapper
@@ -202,7 +202,7 @@ class PythonWrappersTestCase(unittest.TestCase):
             self.assertTrue(cmds.isConnected('time1.outTime', proxyShapePathString+'.time'))
 
         # Create a proxy shape under the world node.
-        proxy1PathString = mayaUsd.ufe.createStageWithNewLayer('|world')
+        proxy1PathString = mayaUsd.ufe.createStageWithNewLayer('')
         self.assertEqual('|stage1|stageShape1', proxy1PathString)
         verifyProxyShape(proxy1PathString)
         self.assertEqual(len(mayaUsd.ufe.getAllStages()), 1)

--- a/test/lib/ufe/testRename.py
+++ b/test/lib/ufe/testRename.py
@@ -115,18 +115,16 @@ class RenameTestCase(unittest.TestCase):
         usdSegment = usdUtils.createUfePathSegment("/Room_set/Props/Ball_35")
 
         ball35Path = ufe.Path([mayaSegment, usdSegment])
-        ball35PathStr = ','.join(
-            [str(segment) for segment in ball35Path.segments])
 
         # Because of difference in Python binding systems (pybind11 for UFE,
         # Boost Python for mayaUsd and USD), need to pass in strings to
         # mayaUsd functions.  Multi-segment UFE paths need to have
         # comma-separated segments.
-        def assertStageAndPrimAccess(proxyShapeSegment, primUfePathStr, primSegment):
+        def assertStageAndPrimAccess(proxyShapeSegment, primUfePath, primSegment):
             proxyShapePathStr = ufe.PathString.string(ufe.Path(proxyShapeSegment))
 
             stage     = mayaUsd.ufe.getStage(proxyShapePathStr)
-            prim      = mayaUsd.ufe.ufePathToPrim(primUfePathStr)
+            prim      = mayaUsd.ufe.ufePathToPrim(ufe.PathString.string(primUfePath))
             stagePath = mayaUsd.ufe.stagePath(stage)
 
             self.assertIsNotNone(stage)
@@ -134,7 +132,7 @@ class RenameTestCase(unittest.TestCase):
             self.assertTrue(prim.IsValid())
             self.assertEqual(str(prim.GetPath()), str(primSegment))
 
-        assertStageAndPrimAccess(mayaSegment, ball35PathStr, usdSegment)
+        assertStageAndPrimAccess(mayaSegment, ball35Path, usdSegment)
 
         # Rename the proxy shape node itself.  Stage and prim access should
         # still be valid, with the new path.
@@ -144,10 +142,8 @@ class RenameTestCase(unittest.TestCase):
         self.assertEqual(len(cmds.ls('potato')), 1)
 
         ball35Path = ufe.Path([mayaSegment, usdSegment])
-        ball35PathStr = ','.join(
-            [str(segment) for segment in ball35Path.segments])
 
-        assertStageAndPrimAccess(mayaSegment, ball35PathStr, usdSegment)
+        assertStageAndPrimAccess(mayaSegment, ball35Path, usdSegment)
 
     def testRename(self):
         '''
@@ -168,7 +164,7 @@ class RenameTestCase(unittest.TestCase):
         ufe.GlobalSelection.get().append(treebaseItem)
 
         # get the USD stage
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
 
         # by default edit target is set to the Rootlayer.
         self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetRootLayer())
@@ -235,7 +231,7 @@ class RenameTestCase(unittest.TestCase):
         ufe.GlobalSelection.get().append(cylinderItem)
 
         # get the USD stage
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
 
         # check GetLayerStack behavior
         self.assertEqual(stage.GetLayerStack()[0], stage.GetSessionLayer())
@@ -312,7 +308,7 @@ class RenameTestCase(unittest.TestCase):
 
         # Maya UFE segment and USD stage, needed in various places below.
         mayaPathSegment = mayaUtils.createUfePathSegment('|transform1|proxyShape1')
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
 
         # Setup the load rules:
         #     /Props is unloaded
@@ -405,7 +401,7 @@ class RenameTestCase(unittest.TestCase):
         ufe.GlobalSelection.get().append(ball35Item)
 
         # get the USD stage
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
 
         # check GetLayerStack behavior
         self.assertEqual(stage.GetLayerStack()[0], stage.GetSessionLayer())
@@ -481,7 +477,7 @@ class RenameTestCase(unittest.TestCase):
         ufe.GlobalSelection.get().append(getItem(oldName))
 
         # Get the USD stage
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
 
         # Add an opinion about the cylinder in the session layer
         stage.SetEditTarget(stage.GetSessionLayer())
@@ -530,7 +526,7 @@ class RenameTestCase(unittest.TestCase):
         ufe.GlobalSelection.get().append(geoItem)
 
         # get the USD stage
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
 
         # rename "/apple/payload/geo" to "/apple/payload/geo_renamed"
         # expect the exception happens
@@ -575,7 +571,7 @@ class RenameTestCase(unittest.TestCase):
         ufe.GlobalSelection.get().append(trunkItem)
 
         # get the USD stage
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
 
         # by default edit target is set to the Rootlayer.
         self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetRootLayer())
@@ -618,7 +614,7 @@ class RenameTestCase(unittest.TestCase):
         ufe.GlobalSelection.get().append(usdSphereItem)
 
         # get the USD stage
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
 
         # by default edit target is set to the Rootlayer.
         self.assertEqual(stage.GetEditTarget().GetLayer(), stage.GetRootLayer())
@@ -713,7 +709,7 @@ class RenameTestCase(unittest.TestCase):
         ufe.GlobalSelection.get().append(cylinderItem)
 
         # get the USD stage
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
 
         # set the edit target to the root layer
         stage.SetEditTarget(stage.GetRootLayer())
@@ -747,7 +743,7 @@ class RenameTestCase(unittest.TestCase):
 
         # stage
         mayaPathSegment = mayaUtils.createUfePathSegment('|Variant_usd|Variant_usdShape')
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
 
         # first check that we have a VariantSets
         objectPrim = stage.GetPrimAtPath('/objects')
@@ -809,7 +805,7 @@ class RenameTestCase(unittest.TestCase):
 
         # stage
         mayaPathSegment = mayaUtils.createUfePathSegment('|CompositionArcs_usd|CompositionArcs_usdShape')
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
 
         # first check for ArcType, nodePath values. I am only interested in the composition Arc other than "root".
         compQueryPrimA = CompositionQuery(stage.GetPrimAtPath('/objects/geos/cube_A'))

--- a/test/lib/ufe/testReorderCmd.py
+++ b/test/lib/ufe/testReorderCmd.py
@@ -160,7 +160,7 @@ class ReorderCmdTestCase(unittest.TestCase):
         '''
         # Get the USD stage
         mayaPathSegment = mayaUtils.createUfePathSegment('|Primitives_usd|Primitives_usdShape')
-        stage = mayaUsd.ufe.getStage(str(mayaPathSegment))
+        stage = mayaUsd.ufe.getStage(ufe.PathString.string(ufe.Path(mayaPathSegment)))
 
         # Some helper functions used during the test
         def getItem(name):


### PR DESCRIPTION
MAYA-131348 - Nothing prevents users from naming nodes "world", which breaks USD workflow

* Incorrect to create Ufe::Path for Maya (hidden) world node using Ufe::PathString::path().
* Let DuplicateCommand accept empty destination path which means Maya (hidden) world node.
* Let CreateStageWithNewLayer command accept null input parent which means Maya world node.
* Use ufe.PathString.string() instead of str()