### PR TITLE
EMSUSD-1389 save before export

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -652,7 +652,7 @@ bool LayerDatabase::saveUsd(bool isExport)
             result = kPartiallyCompleted;
             opt = MayaUsd::utils::kSaveToMayaSceneFile;
         } else if (_batchSaveDelegate && _proxiesToSave.size() > 0) {
-            result = _batchSaveDelegate(_proxiesToSave);
+            result = _batchSaveDelegate(_proxiesToSave, isExport);
         }
 
         // kAbort: we should abort and return false, which Maya will take as

--- a/lib/mayaUsd/nodes/layerManager.h
+++ b/lib/mayaUsd/nodes/layerManager.h
@@ -65,7 +65,8 @@ struct StageSavingInfo
     plugin a delegate will be installed that posts a UI dialog that provides an opportunity
     to choose file names and locations of all anonymous layers that need to be saved to disk.
  */
-using BatchSaveDelegate = std::function<BatchSaveResult(const std::vector<StageSavingInfo>&)>;
+using BatchSaveDelegate
+    = std::function<BatchSaveResult(const std::vector<StageSavingInfo>&, bool isExporting)>;
 
 /*! \brief Maya dependency node responsible for serializing unsaved Usd edits.
 

--- a/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.cpp
+++ b/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.cpp
@@ -32,8 +32,9 @@ void UsdLayerEditor::initialize()
     }
 }
 
-MayaUsd::BatchSaveResult
-UsdLayerEditor::batchSaveLayersUIDelegate(const std::vector<MayaUsd::StageSavingInfo>& infos)
+MayaUsd::BatchSaveResult UsdLayerEditor::batchSaveLayersUIDelegate(
+    const std::vector<MayaUsd::StageSavingInfo>& infos,
+    bool                                         isExporting)
 {
     if (MGlobal::kInteractive == MGlobal::mayaState()) {
         auto opt = MayaUsd::utils::serializeUsdEditsLocationOption();
@@ -59,7 +60,7 @@ UsdLayerEditor::batchSaveLayersUIDelegate(const std::vector<MayaUsd::StageSaving
             }
 
             if (showConfirmDgl) {
-                UsdLayerEditor::SaveLayersDialog dlg(nullptr, infos);
+                UsdLayerEditor::SaveLayersDialog dlg(nullptr, infos, isExporting);
 
                 // The SaveLayers dialog only handles choosing new names for anonymous layers and
                 // making sure that they are remapped correctly in either their parent layer or by

--- a/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.h
+++ b/lib/usd/ui/layerEditor/batchSaveLayersUIDelegate.h
@@ -36,7 +36,7 @@ void initialize();
 
 MAYAUSD_UI_PUBLIC
 MayaUsd::BatchSaveResult
-batchSaveLayersUIDelegate(const std::vector<MayaUsd::StageSavingInfo>& infos);
+batchSaveLayersUIDelegate(const std::vector<MayaUsd::StageSavingInfo>& infos, bool isExporting);
 
 } // namespace UsdLayerEditor
 

--- a/lib/usd/ui/layerEditor/layerTreeModel.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeModel.cpp
@@ -518,7 +518,8 @@ void LayerTreeModel::saveStage(QWidget* in_parent)
     }
 
     if (showConfirmDgl) {
-        SaveLayersDialog dlg(_sessionState, in_parent);
+        bool             isExporting = false;
+        SaveLayersDialog dlg(_sessionState, in_parent, isExporting);
         if (QDialog::Accepted == dlg.exec()) {
 
             if (!dlg.layersWithErrorPairs().isEmpty()) {

--- a/lib/usd/ui/layerEditor/saveLayersDialog.h
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.h
@@ -29,10 +29,13 @@ public:
     typedef std::unordered_multimap<SdfLayerRefPtr, std::string, TfHash> stageLayerMap;
 
     // Create dialog using single stage (from session state).
-    SaveLayersDialog(SessionState* in_sessionState, QWidget* in_parent);
+    SaveLayersDialog(SessionState* in_sessionState, QWidget* in_parent, bool isExporting);
 
     // Create dialog for bulk save using all provided proxy shapes and their owned stages.
-    SaveLayersDialog(QWidget* in_parent, const std::vector<MayaUsd::StageSavingInfo>& infos);
+    SaveLayersDialog(
+        QWidget*                                     in_parent,
+        const std::vector<MayaUsd::StageSavingInfo>& infos,
+        bool                                         isExporting);
 
     ~SaveLayersDialog();
 
@@ -88,6 +91,7 @@ private:
     stageLayerMap         _stageLayerMap;
     SessionState*         _sessionState;
     std::vector<QWidget*> _saveLayerPathRows;
+    bool                  _isExporting { false };
 };
 
 }; // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/stringResources.h
+++ b/lib/usd/ui/layerEditor/stringResources.h
@@ -83,9 +83,12 @@ const auto kSaveLayerWarnTitle           { create("kSaveLayerWarnTitle", "Save ^
 const auto kSaveLayerWarnMsg             { create("kSaveLayerWarnMsg", "Saving edits to ^1s will overwrite your file.") };
 const auto kSaveStage                    { create("kSaveStage", "Save Stage") };
 const auto kSaveStages                   { create("kSaveStages", "Save Stage(s)") };
+const auto kSaveStagesAndExport          { create("kSaveStagesAndExport", "Save Stage(s) and Export") };
 const auto kSaveXStages                  { create("kSaveXStages", "Save ^1s Stage(s)") };
 const auto kToSaveTheStageSaveAnonym     { create("kToSaveTheStageSaveAnonym", "To save the ^1s stage(s), save the following ^2s anonymous layer(s).") };
 const auto kToSaveTheStageSaveFiles      { create("kToSaveTheStageSaveFiles", "To save the ^1s stage(s), the following existing file(s) will be overwritten.") };
+const auto kToExportTheStageSaveAnonym   { create("kToExportTheStageSaveAnonym", "To export the ^1s stage(s), save the following ^2s anonymous layer(s).") };
+const auto kToExportTheStageSaveFiles    { create("kToExportTheStageSaveFiles", "To export the ^1s stage(s), the following existing file(s) will be overwritten.") };
 const auto kUsedInStagesTooltip          { create("kUsedInStagesTooltip", "<b>Used in Stages</b>: ") };
 
 const auto kSetLayerAsTargetLayerTooltip { create("kSetLayerAsTargetLayerTooltip", "Set layer as target layer. Edits are added to the target layer.") };


### PR DESCRIPTION
- Change the labels on headers and buttons when exporting.
- Propagate the fact we are exporting from the layer manager down to the UI.