### PR TITLE
Fixed accessing JobExportArgs TfToken arguments in Python

### DIFF
--- a/lib/mayaUsd/python/wrapPrimWriter.cpp
+++ b/lib/mayaUsd/python/wrapPrimWriter.cpp
@@ -543,8 +543,15 @@ void wrapJobExportArgs()
         .def_readonly("exportMaterialCollections", &UsdMayaJobExportArgs::exportMaterialCollections)
         .def_readonly("exportMeshUVs", &UsdMayaJobExportArgs::exportMeshUVs)
         .def_readonly("exportNurbsExplicitUV", &UsdMayaJobExportArgs::exportNurbsExplicitUV)
-        .def_readonly("exportRelativeTextures", &UsdMayaJobExportArgs::exportRelativeTextures)
-        .def_readonly("referenceObjectMode", &UsdMayaJobExportArgs::referenceObjectMode)
+        .add_property(
+            "exportRelativeTextures",
+            make_getter(
+                &UsdMayaJobExportArgs::exportRelativeTextures,
+                return_value_policy<return_by_value>()))
+        .add_property(
+            "referenceObjectMode",
+            make_getter(
+                &UsdMayaJobExportArgs::referenceObjectMode, return_value_policy<return_by_value>()))
         .def_readonly("exportRefsAsInstanceable", &UsdMayaJobExportArgs::exportRefsAsInstanceable)
         .def_readonly("exportSelected", &UsdMayaJobExportArgs::exportSelected)
         .add_property(

--- a/test/lib/mayaUsd/fileio/CMakeLists.txt
+++ b/test/lib/mayaUsd/fileio/CMakeLists.txt
@@ -52,6 +52,7 @@ foreach(script ${TEST_SCRIPT_FILES})
         ENV
             "UFE_PREVIEW_VERSION_NUM=${UFE_PREVIEW_VERSION_NUM}"
             "USD_FORCE_DEFAULT_MATERIALS_SCOPE_NAME=1"
+            "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
     )
 
     # Add a ctest label to these tests for easy filtering.
@@ -83,6 +84,7 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         ENV
             "${PXR_OVERRIDE_PLUGINPATH_NAME}=${CMAKE_CURRENT_SOURCE_DIR}/UsdCustomRigSchema/"
+            "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
     )
 endif()
 
@@ -95,11 +97,14 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             ENV
                 "HAS_ORPHANED_NODES_MANAGER=1"
+                "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
         )
     else()
         mayaUsd_add_test(${target}
             PYTHON_MODULE ${target}
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            ENV
+                "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
         )
     endif()
 
@@ -115,12 +120,15 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
             PYTHON_MODULE ${target}
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             ENV
-            "HAS_ORPHANED_NODES_MANAGER=1"
+                "HAS_ORPHANED_NODES_MANAGER=1"
+                "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
         )
     else()
         mayaUsd_add_test(${target}
             PYTHON_MODULE ${target}
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            ENV
+                "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
         )
     endif()
 

--- a/test/lib/mayaUsd/fileio/testExportChaser.py
+++ b/test/lib/mayaUsd/fileio/testExportChaser.py
@@ -34,6 +34,18 @@ class exportChaserTest(mayaUsdLib.ExportChaser):
     ChaserNames = set()
     ChaserArgs = {}
     ExportSelected = False
+    ShadingMode = None
+    ReferenceObjectMode = None
+    ExportRelativeTextures = None
+    Compatibility = None
+    DefaultMeshScheme = None
+    DefaultUSDFormat = None
+    ExportSkels = None
+    ExportSkin = None
+    MaterialsScopeName = None
+    RenderLayerMode = None
+    RootKind = None
+    GeomSidedness = None
 
     def __init__(self, factoryContext, *args, **kwargs):
         super(exportChaserTest, self).__init__(factoryContext, *args, **kwargs)
@@ -43,7 +55,18 @@ class exportChaserTest(mayaUsdLib.ExportChaser):
         exportChaserTest.DefaultPrim = factoryContext.GetJobArgs().defaultPrim
         exportChaserTest.RootPrim = factoryContext.GetJobArgs().rootPrim
         exportChaserTest.RootPrimType = factoryContext.GetJobArgs().rootPrimType
-
+        exportChaserTest.ShadingMode = factoryContext.GetJobArgs().shadingMode
+        exportChaserTest.ReferenceObjectMode = factoryContext.GetJobArgs().referenceObjectMode
+        exportChaserTest.ExportRelativeTextures = factoryContext.GetJobArgs().exportRelativeTextures
+        exportChaserTest.Compatibility = factoryContext.GetJobArgs().compatibility
+        exportChaserTest.DefaultMeshScheme = factoryContext.GetJobArgs().defaultMeshScheme
+        exportChaserTest.DefaultUSDFormat = factoryContext.GetJobArgs().defaultUSDFormat
+        exportChaserTest.ExportSkels = factoryContext.GetJobArgs().exportSkels
+        exportChaserTest.ExportSkin = factoryContext.GetJobArgs().exportSkin
+        exportChaserTest.MaterialsScopeName = factoryContext.GetJobArgs().materialsScopeName
+        exportChaserTest.RenderLayerMode = factoryContext.GetJobArgs().renderLayerMode
+        exportChaserTest.RootKind = factoryContext.GetJobArgs().rootKind
+        exportChaserTest.GeomSidedness = factoryContext.GetJobArgs().geomSidedness
 
     def ExportDefault(self):
         exportChaserTest.ExportDefaultCalled = True
@@ -120,6 +143,32 @@ class testExportChaser(unittest.TestCase):
         self.assertEqual(exportChaserTest.DefaultPrim,"testRootPrim")
         self.assertEqual(exportChaserTest.RootPrim, '/testRootPrim')
         self.assertEqual(exportChaserTest.RootPrimType, 'xform')
+
+        # test 'compatibility' argument explicitly, all other arguments
+        # remain default
+        usdzFilePath = os.path.join(self.temp_dir,'testExportChaser.usdz')
+        cmds.usdExport(mergeTransformAndShape=True,
+            file=usdzFilePath,
+            compatibility='appleArKit',  # Require to export as .usdz
+            chaser=['test'],
+            chaserArgs=[
+                ('test', 'foo', 'tball'),
+                ('test', 'bar', 'ometer'),
+            ])
+        self.assertEqual(exportChaserTest.Compatibility, 'appleArKit')
+        # Verify all other TfToken arguments can be accessed and are default values
+        self.assertEqual(exportChaserTest.ShadingMode, 'useRegistry')
+        self.assertEqual(exportChaserTest.ReferenceObjectMode, 'none')
+        self.assertEqual(exportChaserTest.ExportRelativeTextures, 'automatic')
+        self.assertEqual(exportChaserTest.DefaultMeshScheme, 'catmullClark')
+        self.assertEqual(exportChaserTest.DefaultUSDFormat, 'usdc')
+        self.assertEqual(exportChaserTest.ExportSkels, 'none')
+        self.assertEqual(exportChaserTest.ExportSkin, 'none')
+        self.assertEqual(exportChaserTest.MaterialsScopeName, 'Looks')
+        self.assertEqual(exportChaserTest.RenderLayerMode, 'defaultLayer')
+        self.assertEqual(exportChaserTest.RootKind, '')
+        self.assertEqual(exportChaserTest.GeomSidedness, 'derived')
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/mayaUsd/fileio/utils/CMakeLists.txt
+++ b/test/lib/mayaUsd/fileio/utils/CMakeLists.txt
@@ -8,6 +8,8 @@ foreach(script ${TEST_SCRIPT_FILES})
     mayaUsd_add_test(${target}
         PYTHON_MODULE ${target}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        ENV
+            "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
     )
 
     # Add a ctest label to these tests for easy filtering.

--- a/test/lib/mayaUsd/nodes/CMakeLists.txt
+++ b/test/lib/mayaUsd/nodes/CMakeLists.txt
@@ -10,6 +10,8 @@ foreach(script ${TEST_SCRIPT_FILES})
     mayaUsd_add_test(${target}
         PYTHON_MODULE ${target}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        ENV
+            "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
     )
 
     # Add a ctest label to these tests for easy filtering.
@@ -23,5 +25,6 @@ mayaUsd_add_test(testHdImagingShape
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     ENV
         "MAYAUSD_DISABLE_VP2_RENDER_DELEGATE=1"
+        "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
 )
 set_property(TEST testHdImagingShape APPEND PROPERTY LABELS nodes)

--- a/test/lib/mayaUsd/undo/CMakeLists.txt
+++ b/test/lib/mayaUsd/undo/CMakeLists.txt
@@ -18,6 +18,8 @@ foreach(script ${TEST_SCRIPT_FILES})
     mayaUsd_add_test(${target}
         PYTHON_MODULE ${target}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        ENV
+            "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
     )
 
     # Add a ctest label to these tests for easy filtering.

--- a/test/lib/mayaUsd/utils/CMakeLists.txt
+++ b/test/lib/mayaUsd/utils/CMakeLists.txt
@@ -24,6 +24,8 @@ foreach(script ${TEST_SCRIPT_FILES})
     mayaUsd_add_test(${target}
         PYTHON_MODULE ${target}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        ENV
+            "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
     )
 
     # Add a ctest label to these tests for easy filtering.
@@ -36,6 +38,8 @@ foreach(script ${INTERACTIVE_TEST_SCRIPT_FILES})
         INTERACTIVE
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         PYTHON_SCRIPT ${script}
+        ENV
+            "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
     )
 
     # Add a ctest label to these tests for easy filtering.

--- a/test/lib/mayaUsdAPI/CMakeLists.txt
+++ b/test/lib/mayaUsdAPI/CMakeLists.txt
@@ -8,6 +8,8 @@ foreach(script ${TEST_SCRIPT_FILES})
     mayaUsd_add_test(${target}
         PYTHON_MODULE ${target}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        ENV
+            "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
     )
 
     # Add a ctest label to these tests for easy filtering.

--- a/test/lib/ufe/CMakeLists.txt
+++ b/test/lib/ufe/CMakeLists.txt
@@ -179,6 +179,8 @@ foreach(script ${INTERACTIVE_TEST_SCRIPT_FILES})
         INTERACTIVE
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         PYTHON_SCRIPT ${script}
+        ENV
+            "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
     )
 
     # Add a ctest label to these tests for easy filtering.

--- a/test/lib/usd/pxrUsdPreviewSurface/CMakeLists.txt
+++ b/test/lib/usd/pxrUsdPreviewSurface/CMakeLists.txt
@@ -19,6 +19,7 @@ foreach(script ${TEST_SCRIPT_FILES})
         PYTHON_MODULE ${target}
         ENV
             "USD_FORCE_DEFAULT_MATERIALS_SCOPE_NAME=1"
+            "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
     )
     set_property(TEST ${target} APPEND PROPERTY LABELS usdPreviewSurface)
 endforeach()

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -125,6 +125,7 @@ foreach(script ${TEST_SCRIPT_FILES})
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         ENV
             "USD_FORCE_DEFAULT_MATERIALS_SCOPE_NAME=1"
+            "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
     )
 
     # Add a ctest label to these tests for easy filtering.
@@ -152,6 +153,8 @@ foreach(script ${TEST_SCRIPT_FILES_WITH_MATERIAL_SCOPE})
     mayaUsd_add_test(${target}
         PYTHON_MODULE ${target}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        ENV
+            "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
     )
 
     # Add a ctest label to these tests for easy filtering.
@@ -166,6 +169,7 @@ mayaUsd_add_test(testUsdExportUVSets
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     ENV
         "PIXMAYA_WRITE_UV_AS_FLOAT2=0"
+        "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
 )
 set_property(TEST testUsdExportUVSets APPEND PROPERTY LABELS translators)
 
@@ -174,6 +178,7 @@ mayaUsd_add_test(testUsdExportUVSetsFloat
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     ENV
         "PIXMAYA_WRITE_UV_AS_FLOAT2=1"
+        "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
 )
 set_property(TEST testUsdExportUVSetsFloat APPEND PROPERTY LABELS translators)
 
@@ -183,6 +188,7 @@ mayaUsd_add_test(testUsdExportUVSetMappings
     ENV
         "PIXMAYA_WRITE_UV_AS_FLOAT2=0"
         "MAYAUSD_PROVIDE_DEFAULT_TEXCOORD_PRIMVAR_NAME=1"
+        "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
 )
 set_property(TEST testUsdExportUVSetMappings APPEND PROPERTY LABELS translators)
 
@@ -191,6 +197,7 @@ mayaUsd_add_test(testUsdImportUVSets
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     ENV
         "PIXMAYA_READ_FLOAT2_AS_UV=0"
+        "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
 )
 set_property(TEST testUsdImportUVSets APPEND PROPERTY LABELS translators)
 
@@ -199,6 +206,7 @@ mayaUsd_add_test(testUsdImportUVSetsFloat
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     ENV
         "PIXMAYA_READ_FLOAT2_AS_UV=1"
+        "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
 )
 set_property(TEST testUsdImportUVSetsFloat APPEND PROPERTY LABELS translators)
 
@@ -208,6 +216,7 @@ mayaUsd_add_test(testUsdImportChaser
     ENV
         "MAYA_PLUG_IN_PATH=${CMAKE_CURRENT_BINARY_DIR}/../plugin"
         "${PXR_OVERRIDE_PLUGINPATH_NAME}=${CMAKE_CURRENT_BINARY_DIR}/../plugin"
+        "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
 )
 set_property(TEST testUsdImportChaser APPEND PROPERTY LABELS translators)
 
@@ -240,6 +249,7 @@ foreach(template_script ${CUSTOM_TEST_SCRIPT_FILES})
                 "INPUT_PATH=${CMAKE_CURRENT_SOURCE_DIR}"
                 "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}"
                 "USD_FORCE_DEFAULT_MATERIALS_SCOPE_NAME=1"
+                "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
                 )
         set_property(TEST ${target} APPEND PROPERTY LABELS translators)
     endforeach()
@@ -263,6 +273,8 @@ if (MAYA_APP_VERSION VERSION_GREATER 2022)
         mayaUsd_add_test(${target}
             PYTHON_MODULE ${target}
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            ENV
+                "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
         )
 
         # Add a ctest label to these tests for easy filtering.
@@ -273,6 +285,8 @@ if (MAYA_APP_VERSION VERSION_GREATER 2022)
         mayaUsd_add_test(testUsdExportMultiMaterial
             PYTHON_MODULE testUsdExportMultiMaterial
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            ENV
+                "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
         )
         set_property(TEST testUsdExportMultiMaterial APPEND PROPERTY LABELS translators)
     endif()
@@ -285,6 +299,7 @@ mayaUsd_add_test(testUsdMayaListShadingModesCommand
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     ENV
         "MAYA_PLUG_IN_PATH=${CMAKE_CURRENT_BINARY_DIR}/../plugin"
+        "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
 )
 set_property(TEST testUsdMayaListShadingModesCommand APPEND PROPERTY LABELS translators)
 
@@ -297,6 +312,7 @@ mayaUsd_add_test(testUsdExportSchemaApi
     ENV
         "MAYA_PLUG_IN_PATH=${CMAKE_CURRENT_BINARY_DIR}/../plugin"
         "${PXR_OVERRIDE_PLUGINPATH_NAME}=${CMAKE_CURRENT_BINARY_DIR}/../plugin/nullApiExporter"
+        "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
 )
 set_property(TEST testUsdExportSchemaApi APPEND PROPERTY LABELS translators)
 
@@ -305,6 +321,7 @@ mayaUsd_add_test(testUsdImportExportSiteSpecificConfig
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     ENV
         "${PXR_OVERRIDE_PLUGINPATH_NAME}=${CMAKE_CURRENT_BINARY_DIR}/../plugin/SiteSpecificConfig"
+        "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
 )
 set_property(TEST testUsdImportExportSiteSpecificConfig APPEND PROPERTY LABELS translators)
 
@@ -313,4 +330,5 @@ mayaUsd_add_test(testUsdExportEmptyXforms
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     ENV
         "${PXR_OVERRIDE_PLUGINPATH_NAME}=${CMAKE_CURRENT_BINARY_DIR}/../plugin/ExportEmptyConfig"
+        "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
 )


### PR DESCRIPTION
This PR fixes https://github.com/Autodesk/maya-usd/issues/3809 :
- Fixed accessing those TfToken type arguments in Python
- Extended unit test to cover other TfToken arguments

Note: Many other CMakeLists.txt files are also touched to align with other unit tests for the correct runtime env (`LD_LIBRARY_PATH`)