### PR TITLE
EMSUSD-1160 improve Maya pivot support

### DIFF
--- a/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.cpp
@@ -441,25 +441,25 @@ void UsdTransform3dMayaXformStack::convertToMayaPivotIfNeeded()
     }
 
     // Adjust possibly existing Maya rotate pivot by the common pivot.
+    // Note: must explicitly qualify the call to rotatePivot because
+    //       the overload on this class hides the other.
     {
         Ufe::Vector3d currentPivotValue = rotatePivot();
-        auto          cmd = rotatePivotCmd(
+        Ufe::Transform3d::rotatePivot(
             currentPivotValue.x() + commonPivotValue[0],
             currentPivotValue.y() + commonPivotValue[1],
             currentPivotValue.z() + commonPivotValue[2]);
-        if (cmd)
-            cmd->execute();
     }
 
     // Adjust possibly existing Maya scale pivot by the common pivot.
+    // Note: must explicitly qualify the call to scalePivot because
+    //       the overload on this class hides the other.
     {
         Ufe::Vector3d currentPivotValue = scalePivot();
-        auto          cmd = scalePivotCmd(
+        Ufe::Transform3d::scalePivot(
             currentPivotValue.x() + commonPivotValue[0],
             currentPivotValue.y() + commonPivotValue[1],
             currentPivotValue.z() + commonPivotValue[2]);
-        if (cmd)
-            cmd->execute();
     }
 }
 

--- a/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.cpp
@@ -374,9 +374,92 @@ MAYAUSD_VERIFY_CLASS_SETUP(UsdUfe::UsdTransform3dBase, UsdTransform3dMayaXformSt
 UsdTransform3dMayaXformStack::UsdTransform3dMayaXformStack(const UsdUfe::UsdSceneItem::Ptr& item)
     : UsdUfe::UsdTransform3dBase(item)
     , _xformable(prim())
+    , _needPivotConversion(isPivotConversionNeeded())
 {
     if (!TF_VERIFY(_xformable)) {
         throw std::runtime_error("Invalid scene item for transform stack");
+    }
+}
+
+bool UsdTransform3dMayaXformStack::isPivotConversionNeeded() const
+{
+    // Note: USD and Maya use different pivots: USD has a single pivot that is used
+    //       for both translation and scale, while Maya has separate ones. When working
+    //       in this Maya transform stack mode, the USD pivot affects the position of
+    //       the manipulators, so we need to convert it to a Maya-style pivot.
+    //       Otherwise, prim with USD-style pivot won't work with the "center pivot"
+    //       command. They would also not work well with the universal manipulator.
+    TfToken pivotName
+        = UsdGeomXformOp::GetOpName(UsdGeomXformOp::TypeTranslate, UsdGeomTokens->pivot);
+    auto pivotAttr = prim().GetAttribute(pivotName);
+    if (!pivotAttr)
+        return false;
+
+    if (!pivotAttr.HasAuthoredValue())
+        return false;
+
+    Ufe::Vector3d pivot = getVector3d<GfVec3f>(pivotName);
+    if (isAlmostZero(pivot))
+        return false;
+
+    return true;
+}
+
+void UsdTransform3dMayaXformStack::convertToMayaPivotIfNeeded()
+{
+    if (!_needPivotConversion)
+        return;
+
+    // Note: must reset flag immediately because we call functions that would trigger
+    //       conversion again, resulting in infinite recursion.
+    _needPivotConversion = false;
+
+    // Extract and clear the USD common pivot. The exiesting pivot can be authored
+    // with any precision, so we need to convert it if needed.
+    GfVec3f commonPivotValue;
+    {
+        TfToken pivotName
+            = UsdGeomXformOp::GetOpName(UsdGeomXformOp::TypeTranslate, UsdGeomTokens->pivot);
+        UsdAttribute pivotAttr = prim().GetAttribute(pivotName);
+
+        VtValue currentValue;
+        if (!pivotAttr.Get(&currentValue, getTime(path())))
+            return;
+
+        if (currentValue.IsHolding<GfVec3f>()) {
+            commonPivotValue = currentValue.UncheckedGet<GfVec3f>();
+        } else if (currentValue.IsHolding<GfVec3d>()) {
+            auto val = currentValue.UncheckedGet<GfVec3d>();
+            commonPivotValue.Set(val[0], val[1], val[2]);
+        } else if (currentValue.IsHolding<GfVec3h>()) {
+            auto val = currentValue.UncheckedGet<GfVec3h>();
+            commonPivotValue.Set(val[0], val[1], val[2]);
+        } else {
+            commonPivotValue.Set(0, 0, 0);
+        }
+        pivotAttr.Set(GfVec3f(0, 0, 0));
+    }
+
+    // Adjust possibly existing Maya rotate pivot by the common pivot.
+    {
+        Ufe::Vector3d currentPivotValue = rotatePivot();
+        auto          cmd = rotatePivotCmd(
+            currentPivotValue.x() + commonPivotValue[0],
+            currentPivotValue.y() + commonPivotValue[1],
+            currentPivotValue.z() + commonPivotValue[2]);
+        if (cmd)
+            cmd->execute();
+    }
+
+    // Adjust possibly existing Maya scale pivot by the common pivot.
+    {
+        Ufe::Vector3d currentPivotValue = scalePivot();
+        auto          cmd = scalePivotCmd(
+            currentPivotValue.x() + commonPivotValue[0],
+            currentPivotValue.y() + commonPivotValue[1],
+            currentPivotValue.z() + commonPivotValue[2]);
+        if (cmd)
+            cmd->execute();
     }
 }
 
@@ -438,6 +521,8 @@ bool UsdTransform3dMayaXformStack::isFallback() const { return false; }
 Ufe::RotateUndoableCommand::Ptr
 UsdTransform3dMayaXformStack::rotateCmd(double x, double y, double z)
 {
+    convertToMayaPivotIfNeeded();
+
     UsdGeomXformOp op;
     TfToken        attrName;
     bool           hasRotate = hasOp(NdxRotate);
@@ -506,6 +591,8 @@ UsdTransform3dMayaXformStack::rotateCmd(double x, double y, double z)
 
 Ufe::ScaleUndoableCommand::Ptr UsdTransform3dMayaXformStack::scaleCmd(double x, double y, double z)
 {
+    convertToMayaPivotIfNeeded();
+
     UsdGeomXformOp op;
     TfToken        attrName;
     if (hasOp(NdxScale)) {
@@ -552,49 +639,59 @@ Ufe::ScaleUndoableCommand::Ptr UsdTransform3dMayaXformStack::scaleCmd(double x, 
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dMayaXformStack::rotatePivotCmd(double x, double y, double z)
 {
+    convertToMayaPivotIfNeeded();
+
     return pivotCmd(getOpSuffix(NdxRotatePivot), x, y, z);
 }
 
 Ufe::Vector3d UsdTransform3dMayaXformStack::rotatePivot() const
 {
-    return getVector3d<GfVec3f>(
+    Ufe::Vector3d mayaPivot = getVector3d<GfVec3f>(
         UsdGeomXformOp::GetOpName(UsdGeomXformOp::TypeTranslate, getOpSuffix(NdxRotatePivot)));
+
+    if (_needPivotConversion) {
+        Ufe::Vector3d commonPivot = getVector3d<GfVec3f>(
+            UsdGeomXformOp::GetOpName(UsdGeomXformOp::TypeTranslate, UsdGeomTokens->pivot));
+
+        mayaPivot = Ufe::Vector3d(
+            commonPivot.x() + mayaPivot.x(),
+            commonPivot.y() + mayaPivot.y(),
+            commonPivot.z() + mayaPivot.z());
+    }
+
+    return mayaPivot;
 }
 
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dMayaXformStack::scalePivotCmd(double x, double y, double z)
 {
+    convertToMayaPivotIfNeeded();
+
     return pivotCmd(getOpSuffix(NdxScalePivot), x, y, z);
 }
 
 Ufe::Vector3d UsdTransform3dMayaXformStack::scalePivot() const
 {
-    return getVector3d<GfVec3f>(
+    Ufe::Vector3d mayaPivot = getVector3d<GfVec3f>(
         UsdGeomXformOp::GetOpName(UsdGeomXformOp::TypeTranslate, getOpSuffix(NdxScalePivot)));
+
+    if (_needPivotConversion) {
+        Ufe::Vector3d commonPivot = getVector3d<GfVec3f>(
+            UsdGeomXformOp::GetOpName(UsdGeomXformOp::TypeTranslate, UsdGeomTokens->pivot));
+
+        mayaPivot = Ufe::Vector3d(
+            commonPivot.x() + mayaPivot.x(),
+            commonPivot.y() + mayaPivot.y(),
+            commonPivot.z() + mayaPivot.z());
+    }
+
+    return mayaPivot;
 }
 
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dMayaXformStack::translateRotatePivotCmd(double x, double y, double z)
 {
-    // Note: USD and Maya use different pivots: USD has a single pivot that is used
-    //       for both translation and scale, while Maya has separate ones. When working
-    //       in this Maya transform stack mode, the USD pivot affects the position of
-    //       the manipulators, so we need to take it into account here.
-    //
-    //       Otherwise, prim with USD-style picot won't work with the "center pivot"
-    //       command.
-    TfToken commonPivotName
-        = UsdGeomXformOp::GetOpName(UsdGeomXformOp::TypeTranslate, UsdGeomTokens->pivot);
-    auto commonPivotAttr = prim().GetAttribute(commonPivotName);
-    if (commonPivotAttr && commonPivotAttr.HasAuthoredValue()) {
-        Ufe::Vector3d commonPivot = getVector3d<GfVec3f>(commonPivotName);
-        if (!isAlmostZero(commonPivot)) {
-            x = commonPivot.x() - x;
-            y = commonPivot.y() - y;
-            z = commonPivot.z() - z;
-            return setVector3dCmd(GfVec3f(x, y, z), commonPivotName);
-        }
-    }
+    convertToMayaPivotIfNeeded();
 
     auto opSuffix = getOpSuffix(NdxRotatePivotTranslate);
     auto attrName = UsdGeomXformOp::GetOpName(UsdGeomXformOp::TypeTranslate, opSuffix);
@@ -603,29 +700,15 @@ UsdTransform3dMayaXformStack::translateRotatePivotCmd(double x, double y, double
 
 Ufe::Vector3d UsdTransform3dMayaXformStack::rotatePivotTranslation() const
 {
-    // Note: USD and Maya use different pivots: USD has a single pivot that is used
-    //       for both translation and scale, while Maya has separate ones. When working
-    //       in this Maya transform stack mode, the USD pivot is only used to move the
-    //       position of the manipulators, by returning it as part of this function.
-    //
-    //       Interestingly, this is correct and enough to both display the manip at the
-    //       correct position in the viewport *and* give the correct results. That's
-    //       because USD internally will apply its pivot and the manip will give the
-    //       correct value when manipulating.
-    Ufe::Vector3d commonPivot = getVector3d<GfVec3f>(
-        UsdGeomXformOp::GetOpName(UsdGeomXformOp::TypeTranslate, UsdGeomTokens->pivot));
-    Ufe::Vector3d mayaPivot = getVector3d<GfVec3f>(UsdGeomXformOp::GetOpName(
+    return getVector3d<GfVec3f>(UsdGeomXformOp::GetOpName(
         UsdGeomXformOp::TypeTranslate, getOpSuffix(NdxRotatePivotTranslate)));
-    mayaPivot.set(
-        mayaPivot.x() + commonPivot.x(),
-        mayaPivot.y() + commonPivot.y(),
-        mayaPivot.z() + commonPivot.z());
-    return mayaPivot;
 }
 
 Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dMayaXformStack::translateScalePivotCmd(double x, double y, double z)
 {
+    convertToMayaPivotIfNeeded();
+
     auto opSuffix = getOpSuffix(NdxScalePivotTranslate);
     auto attrName = UsdGeomXformOp::GetOpName(UsdGeomXformOp::TypeTranslate, opSuffix);
     return setVector3dCmd(GfVec3f(x, y, z), attrName, opSuffix);
@@ -748,6 +831,8 @@ UsdTransform3dMayaXformStack::pivotCmd(const TfToken& pvtOpSuffix, double x, dou
 Ufe::SetMatrix4dUndoableCommand::Ptr
 UsdTransform3dMayaXformStack::setMatrixCmd(const Ufe::Matrix4d& m)
 {
+    convertToMayaPivotIfNeeded();
+
     // Note: UsdSetMatrix4dUndoableCommand uses separate calls to translate, rotate and scale,
     //       so check those 3 attributes.
     const TfToken attrs[]
@@ -865,11 +950,11 @@ Ufe::Transform3d::Ptr UsdTransform3dMayaXformStackHandler::editTransform3d(
     // MAYA-109190: Moved the IsInstanceProxy() check here since it was causing the
     // camera framing not properly be applied.
     //
-    // HS January 15, 2021: After speaking with Pierre, there is a more robust solution to move this
-    // check entirely from here.
+    // HS January 15, 2021: After speaking with Pierre, there is a more robust solution to move
+    // this check entirely from here.
 
-    // According to USD docs, editing scene description via instance proxies and their properties is
-    // not allowed.
+    // According to USD docs, editing scene description via instance proxies and their
+    // properties is not allowed.
     // https://graphics.pixar.com/usd/docs/api/_usd__page__scenegraph_instancing.html#Usd_ScenegraphInstancing_InstanceProxies
     auto usdItem = downcast(item);
     if (usdItem->prim().IsInstanceProxy()) {

--- a/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.h
+++ b/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.h
@@ -113,7 +113,11 @@ protected:
         const PXR_NS::TfToken& attrName,
         const PXR_NS::TfToken& opSuffix = PXR_NS::TfToken());
 
+    bool isPivotConversionNeeded() const;
+    void convertToMayaPivotIfNeeded();
+
     PXR_NS::UsdGeomXformable _xformable;
+    bool                     _needPivotConversion { false };
 
 private:
     Ufe::TranslateUndoableCommand::Ptr

--- a/test/lib/ufe/CMakeLists.txt
+++ b/test/lib/ufe/CMakeLists.txt
@@ -28,6 +28,7 @@ set(TEST_SCRIPT_FILES
     testRotateCmd.py
     testRotateCmdUndoRedo.py
     testRotatePivot.py
+    testPivotConversion.py
     testScaleCmd.py
     testSceneItem.py
     testSelection.py

--- a/test/lib/ufe/testCenterPivot.py
+++ b/test/lib/ufe/testCenterPivot.py
@@ -47,11 +47,6 @@ class CenterPivotTestCase(unittest.TestCase):
         self.assertTrue(self.pluginsLoaded)
 
 
-    def checkPos(self, m, p):
-        self.assertAlmostEqual(m[ndx(3,0)], p[0])
-        self.assertAlmostEqual(m[ndx(3,1)], p[1])
-        self.assertAlmostEqual(m[ndx(3,2)], p[2])
-
     def testCenterPivot(self):
         '''Verify the behavior Transform3d UFE pivot interface.
 
@@ -123,7 +118,7 @@ class CenterPivotTestCase(unittest.TestCase):
 
     def testCenterPivotWithUSDPivot(self):
         '''
-        Test centering the pivot when teh USD file has a USD-style pivot,
+        Test centering the pivot when the USD file has a USD-style pivot,
         not a Maya-style pivot.
 
         UFE Feature : Transform3d
@@ -174,7 +169,7 @@ class CenterPivotTestCase(unittest.TestCase):
 
         verifyCubeUSDPivots(
             [2., -3., -1.],     # translate rotate pivot
-            [7., 7., 8.],       # translate pivot (equivalent to translate rotate translate pivot)
+            [7., 7., 8.],       # USD translate pivot (equivalent to translate rotate translate pivot)
             [2., -3., -1.],     # translate scale pivot
             [0., 0., 0.]        # translate scale translate pivot
         )
@@ -187,11 +182,14 @@ class CenterPivotTestCase(unittest.TestCase):
             assertVectorAlmostEqual(self, cubeUfeT3d.scalePivot().vector,             tsPivot)
             assertVectorAlmostEqual(self, cubeUfeT3d.scalePivotTranslation().vector,  tstPivot)
 
+        # Note: when going through UFE, the USD translate pivot is added to the Maya
+        #       pivots (translate and scale). So the USD translate pivot that was verified
+        #       above to be [7., 7., 8.] is instead added to the other pivot values.
         verifyCubeUFEPivots(
-            [2., -3., -1.],     # translate rotate pivot
-            [7., 7., 8.],       # translate rotate translate pivot
-            [2., -3., -1.],     # translate scale pivot
-            [0., 0., 0.]        # translate scale translate pivot
+            [9., 4., 7.],     # translate rotate pivot
+            [0., 0., 0.],     # translate rotate translate pivot
+            [9., 4., 7.],     # translate scale pivot
+            [0., 0., 0.]      # translate scale translate pivot
         )
 
         # Select the prim.

--- a/test/lib/ufe/testPivotConversion.py
+++ b/test/lib/ufe/testPivotConversion.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2024 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import fixturesUtils
+import mayaUtils
+from testUtils import assertVectorAlmostEqual, getTestScene
+
+from maya import cmds
+from maya import standalone
+
+import ufe
+
+import unittest
+
+class PivotConversionTestCase(unittest.TestCase):
+    pluginsLoaded = False
+
+    @classmethod
+    def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
+        if not cls.pluginsLoaded:
+            cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def setUp(self):
+        ''' Called initially to set up the maya test environment '''
+        # Load plugins
+        self.assertTrue(self.pluginsLoaded)
+
+    def testUSDPivotConversion(self):
+        '''
+        Test that USD-style pivot gets converted to Maya-style pivots
+        when the pivot is modified.
+        '''
+        # Open the USD file containing the prim we want to affect.
+        testFile = getTestScene("pivot", "cube-usd-pivot.usda")
+        testDagPath, stage = mayaUtils.createProxyFromFile(testFile)
+        self.assertIsNotNone(stage)
+
+        # Retrieve the UFE item to the prim and the prim.
+        cubeUfePathString = testDagPath + ",/Cube1"
+        cubeUfePath = ufe.PathString.path(cubeUfePathString)
+        cubeUfeItem = ufe.Hierarchy.createItem(cubeUfePath)
+        self.assertIsNotNone(cubeUfeItem)
+        cubeUsdPrim = stage.GetPrimAtPath("/Cube1")
+        self.assertIsNotNone(cubeUsdPrim)
+
+        # Verify the cube overall position.
+        def verifyCubePosition():
+            cubeUfeT3d = ufe.Transform3d.transform3d(cubeUfeItem)
+            cubeUfeMtx = cubeUfeT3d.matrix()
+            flatMtx = []
+            for row in cubeUfeMtx.matrix:
+                flatMtx.extend(row)
+            assertVectorAlmostEqual(self, flatMtx, [ 1., 0., 0., 0.,
+                                                     0., 1., 0., 0.,
+                                                     0., 0., 1., 0.,
+                                                     0., 20., 0., 1.])
+            
+        def verifyCubeUSDPivots(usdPivot, mayaRotPivot, mayaScalePivot):
+            namesAndValues = [
+                ('xformOp:translate:pivot',                 usdPivot),
+                ('xformOp:translate:rotatePivot',           mayaRotPivot),
+                ('xformOp:translate:scalePivot',            mayaScalePivot),
+            ]
+            for name, value in namesAndValues:
+                if value is None:
+                    continue
+                usdAttr = cubeUsdPrim.GetAttribute(name)
+                self.assertIsNotNone(usdAttr)
+                assertVectorAlmostEqual(self, usdAttr.Get(), value)
+
+        def verifyCubeUFEPivots(mayaRotPivot, mayaScalePivot):
+            cubeUfeT3d = ufe.Transform3d.transform3d(cubeUfeItem)
+            assertVectorAlmostEqual(self, cubeUfeT3d.rotatePivot().vector,            mayaRotPivot)
+            assertVectorAlmostEqual(self, cubeUfeT3d.scalePivot().vector,             mayaScalePivot)
+
+        verifyCubePosition()
+
+        verifyCubeUSDPivots(
+            [7., 7., 8.],       # USD translate pivot
+            None,               # Maya rotate pivot
+            None                # Maya scale pivot
+        )
+
+        # Note: when going through UFE, the USD translate pivot is added to the Maya
+        #       pivots (translate and scale). So the USD translate pivot that was verified
+        #       above to be [7., 7., 8.] is instead added to the other pivot values.
+        verifyCubeUFEPivots(
+            [7., 7., 8.],     # Maya rotate pivot
+            [7., 7., 8.]      # Maya scale pivot
+        )
+
+        def modifyPivot():
+            cubeUfeT3d = ufe.Transform3d.transform3d(cubeUfeItem)
+            cmd = cubeUfeT3d.rotatePivotCmd(2., 2., 2.)
+            self.assertIsNotNone(cmd)
+            cmd.execute()
+
+        modifyPivot()
+
+        verifyCubePosition()
+
+        # Editing the Maya pivot converted the USD pivot to Maya pivots, so the USD
+        # pivot is now zero and its previous value is added to the Maya pivots.
+        # Since the command that we execute explivitly set the rotate pivot, the
+        # converted value was overwritten with this new value after the conversion.
+        verifyCubeUSDPivots(
+            [0., 0., 0.],       # USD translate pivot
+            [2., 2., 2.],       # Maya rotate pivot
+            [7., 7., 8.]        # Maya scale pivot
+        )
+
+        verifyCubeUFEPivots(
+            [2., 2., 2.],     # Maya rotate pivot
+            [7., 7., 8.]      # Maya scale pivot
+        )
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/testSamples/pivot/cube-usd-pivot.usda
+++ b/test/testSamples/pivot/cube-usd-pivot.usda
@@ -1,0 +1,24 @@
+#usda 1.0
+(
+    defaultPrim = "Cube1"
+    upAxis = "Z"
+)
+
+def Mesh "Cube1" (
+    kind = "component"
+)
+{
+    uniform bool doubleSided = 1
+    float3[] extent = [(-5, -5, -5), (5, 5, 5)]
+    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+    int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+    point3f[] points = [(-5, -5, 5), (5, -5, 5), (-5, 5, 5), (5, 5, 5), (-5, 5, -5), (5, 5, -5), (-5, -5, -5), (5, -5, -5)]
+    color3f[] primvars:displayColor = [(0.13320851, 0.13320851, 0.13320851)]
+
+    double3 xformOp:translate = (0, 20, 0)
+    float3 xformOp:rotateXYZ = (0, 0, 0)
+    float3 xformOp:scale = (1, 1, 1)
+    float3 xformOp:translate:pivot = (7, 7, 8)
+    uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot",  "xformOp:rotateXYZ", "xformOp:scale", "!invert!xformOp:translate:pivot"]
+}
+


### PR DESCRIPTION
Multiple tools require the use of Maya-style pivots. The difference between Maya-style and USD-style is that Maya has two separate pivots for rotation and scaling while USD has a single pivot for both. In addition, Maya has pivot-compensation attributes.

When there is already a USD-style pivot authored, we need to convert it to the Maya-style pivots when these tools try to modify the object. We detect that such a conversion is needed and adjust the values when they are read and do the conversion the first time a tools tries to write the values.

Fix center pivot test to take into account the new behaviour. Add new unit test for pivot conversion.