### PR TITLE
EMSUSD-1361 Same-name Python edit routers

### DIFF
--- a/lib/mayaUsd/python/__init__.py
+++ b/lib/mayaUsd/python/__init__.py
@@ -13,6 +13,7 @@ from usdUfe import registerEditRouter
 from usdUfe import registerStageLayerEditRouter
 from usdUfe import restoreDefaultEditRouter
 from usdUfe import restoreAllDefaultEditRouters
+from usdUfe import clearAllEditRouters
 from usdUfe import OperationEditRouterContext
 from usdUfe import AttributeEditRouterContext
 from usdUfe import registerUICallback

--- a/lib/mayaUsd/ufe/Global.cpp
+++ b/lib/mayaUsd/ufe/Global.cpp
@@ -431,6 +431,8 @@ MStatus finalize(bool exiting)
     g_MayaUIInfoHandler.reset();
 #endif
 
+    UsdUfe::clearAllEditRouters();
+
     MMessage::removeCallback(gExitingCbId);
 
     return MS::kSuccess;

--- a/lib/usdUfe/python/wrapEditRouter.cpp
+++ b/lib/usdUfe/python/wrapEditRouter.cpp
@@ -55,9 +55,16 @@ public:
     PyEditRouter(PyObject* pyCallable)
         : _pyCb(pyCallable)
     {
+        if (_pyCb)
+            Py_INCREF(_pyCb);
     }
 
-    ~PyEditRouter() override { }
+    ~PyEditRouter() override
+    {
+        PXR_NS::TfPyLock pyLock;
+        if (_pyCb)
+            Py_DECREF(_pyCb);
+    }
 
     void operator()(const PXR_NS::VtDictionary& context, PXR_NS::VtDictionary& routingData) override
     {
@@ -181,6 +188,8 @@ void wrapEditRouter()
     def("restoreDefaultEditRouter", &UsdUfe::restoreDefaultEditRouter);
 
     def("restoreAllDefaultEditRouters", &UsdUfe::restoreAllDefaultEditRouters);
+
+    def("clearAllEditRouters", &UsdUfe::clearAllEditRouters);
 
     using OpThis = UsdUfe::OperationEditRouterContext;
     class_<OpThis, boost::noncopyable>("OperationEditRouterContext", no_init)

--- a/lib/usdUfe/utils/editRouter.cpp
+++ b/lib/usdUfe/utils/editRouter.cpp
@@ -189,9 +189,11 @@ bool restoreDefaultEditRouter(const PXR_NS::TfToken& operation)
     return true;
 }
 
+void clearAllEditRouters() { getRegisteredEditRouters().clear(); }
+
 void restoreAllDefaultEditRouters()
 {
-    getRegisteredEditRouters().clear();
+    clearAllEditRouters();
 
     auto defaults = defaultEditRouters();
     for (const auto& entry : defaults) {

--- a/lib/usdUfe/utils/editRouter.h
+++ b/lib/usdUfe/utils/editRouter.h
@@ -147,6 +147,12 @@ void restoreAllDefaultEditRouters();
 USDUFE_PUBLIC
 void registerDefaultEditRouter(const PXR_NS::TfToken&, const EditRouter::Ptr&);
 
+// Clear all registered edit routers.
+// Mostly only used on exit to ensure edit routers are cleared to avoid order of destruction
+// problems.
+USDUFE_PUBLIC
+void clearAllEditRouters();
+
 // Return built-in default edit routers.
 EditRouters defaultEditRouters();
 


### PR DESCRIPTION
If two Python edit routers were written in the Maya script editor using the same function name, then the first one would no longer be held in memory and would crash when called. Fix this by increasing the Python reference count when registering and decreasing it when unregistering.

Make the cleanup of registered Python routers safer during exit. Make the clearAllEditRouters function accessible from Python.

Add a unit test to cover this problem.