### PR TITLE
Fix reparenting/renaming of pulled objects USD ancestor

### DIFF
--- a/lib/mayaUsd/fileio/utils/CMakeLists.txt
+++ b/lib/mayaUsd/fileio/utils/CMakeLists.txt
@@ -19,6 +19,7 @@ if(UFE_TRIE_NODE_HAS_CHILDREN_COMPONENTS_ACCESSOR)
     target_sources(${PROJECT_NAME}
         PRIVATE
             orphanedNodesManagerUtil.cpp
+            proxyAccessorUtil.cpp
     )
 endif()
 
@@ -38,6 +39,7 @@ set(HEADERS
 if(UFE_TRIE_NODE_HAS_CHILDREN_COMPONENTS_ACCESSOR)
     list(APPEND HEADERS
         orphanedNodesManagerUtil.h
+        proxyAccessorUtil.h
     )
 endif()
 

--- a/lib/mayaUsd/fileio/utils/proxyAccessorUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/proxyAccessorUtil.cpp
@@ -1,0 +1,74 @@
+//
+// Copyright 2024 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "proxyAccessorUtil.h"
+
+#include <mayaUsd/ufe/Utils.h>
+
+#include <maya/MString.h>
+#include <ufe/pathString.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace utils {
+
+MStatus ProxyAccessorUndoItem::parentPulledObject(
+    const std::string name,
+    const MDagPath&   pulledDagPath,
+    const Ufe::Path&  ufeParentPath,
+    bool              force)
+{
+    // The "child" is the node that will receive the computed parent
+    // transformation, in its offsetParentMatrix attribute.  We are using
+    // the pull parent for this purpose, so pop the path of the ufeChild to
+    // get to its pull parent.
+    const auto ufeChildPath = MayaUsd::ufe::dagPathToUfe(pulledDagPath).pop();
+
+    // Quick workaround to reuse some POC code - to rewrite later
+
+    // Communication to current proxyAccessor code is through the global selection.
+    // This is not logically necessary, and should be re-written to avoid going through
+    // the global selection.
+    static const MString kPyTrueLiteral("True");
+    static const MString kPyFalseLiteral("False");
+
+    MString pyCommand;
+    pyCommand.format(
+        "from mayaUsd.lib import proxyAccessor as pa\n"
+        "import maya.cmds as cmds\n"
+        "cmds.select('^1s', '^2s')\n"
+        "pa.parent(force=^3s)\n"
+        "cmds.select(clear=True)\n",
+        Ufe::PathString::string(ufeChildPath).c_str(),
+        Ufe::PathString::string(ufeParentPath).c_str(),
+        force ? kPyTrueLiteral : kPyFalseLiteral);
+
+    auto item = std::make_unique<ProxyAccessorUndoItem>(std::move(name));
+
+    CHECK_MSTATUS_AND_RETURN_IT(item->_modifier.pythonCommandToExecute(pyCommand));
+    CHECK_MSTATUS_AND_RETURN_IT(item->_modifier.doIt());
+
+    auto& undoInfo = OpUndoItemList::instance();
+    undoInfo.addItem(std::move(item));
+    return MS::kSuccess;
+}
+
+bool ProxyAccessorUndoItem::undo() { return _modifier.undoIt() == MS::kSuccess; }
+bool ProxyAccessorUndoItem::redo() { return _modifier.doIt() == MS::kSuccess; }
+
+ProxyAccessorUndoItem::~ProxyAccessorUndoItem() { }
+
+} // namespace utils
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/fileio/utils/proxyAccessorUtil.h
+++ b/lib/mayaUsd/fileio/utils/proxyAccessorUtil.h
@@ -1,0 +1,70 @@
+//
+// Copyright 2024 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef MAYAUSD_PROXYACCESSORUTIL_H
+#define MAYAUSD_PROXYACCESSORUTIL_H
+
+#include <mayaUsd/undo/OpUndoItemList.h>
+
+#include <maya/MDGModifier.h>
+#include <maya/MDagPath.h>
+#include <maya/MStatus.h>
+#include <ufe/path.h>
+
+#include <string>
+
+namespace MAYAUSD_NS_DEF {
+namespace utils {
+
+/// \brief OpUndoItem for proxyAccessor parenting.
+class ProxyAccessorUndoItem : public OpUndoItem
+{
+public:
+    /// \brief create proxy Accessor recorder and keep track of it in the global
+    /// undo item list. Parents the pulled maya object at \p pulledDagPath under
+    /// the UFE USD item at \p ufeParentPath.
+    /// If \p force is \c true, the pulled object will first be un-parented from
+    /// its current USD parent. Otherwise an error will occur if the child is
+    /// already parented to USD.
+    /// Returns \c MStatus::kSuccess if the parenting succeeded.
+    static MStatus parentPulledObject(
+        const std::string name,
+        const MDagPath&   pulledDagPath,
+        const Ufe::Path&  ufeParentPath,
+        bool              force = false);
+
+    /// \brief construct a proxy accessor recorder.
+    ProxyAccessorUndoItem(std::string name)
+        : OpUndoItem(std::move(name))
+    {
+    }
+
+    ~ProxyAccessorUndoItem() override;
+
+    /// \brief undo a single sub-operation.
+    bool undo() override;
+
+    /// \brief redo a single sub-operation.
+    bool redo() override;
+
+private:
+    MDGModifier _modifier;
+};
+
+} // namespace utils
+} // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_PROXYACCESSORUTIL_H

--- a/test/lib/mayaUsd/fileio/CMakeLists.txt
+++ b/test/lib/mayaUsd/fileio/CMakeLists.txt
@@ -18,7 +18,6 @@ set(TEST_SCRIPT_FILES
 
 if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
     list(APPEND TEST_SCRIPT_FILES
-        testEditAsMaya.py
         testEditAsMayaBBox.py
         testEditAsMayaDefaultValue.py
         testMergeToUsd.py
@@ -129,6 +128,34 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             ENV
                 "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
+        )
+    endif()
+
+    # Add a ctest label for easy filtering.
+    set_property(TEST ${target} APPEND PROPERTY LABELS fileio)
+endif()
+
+if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
+    mayaUsd_get_unittest_target(target testEditAsMaya.py)
+
+    if(UFE_TRIE_NODE_HAS_CHILDREN_COMPONENTS_ACCESSOR)
+        mayaUsd_add_test(${target}
+            PYTHON_MODULE ${target}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            ENV
+                "HAS_ORPHANED_NODES_MANAGER=1"
+                "UFE_PREVIEW_VERSION_NUM=${UFE_PREVIEW_VERSION_NUM}"
+                "USD_FORCE_DEFAULT_MATERIALS_SCOPE_NAME=1"
+                "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
+        )
+    else()
+        mayaUsd_add_test(${target}
+            PYTHON_MODULE ${target}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            ENV
+                "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
+                "UFE_PREVIEW_VERSION_NUM=${UFE_PREVIEW_VERSION_NUM}"
+                "USD_FORCE_DEFAULT_MATERIALS_SCOPE_NAME=1"
         )
     endif()
 

--- a/test/lib/mayaUsd/fileio/testEditAsMaya.py
+++ b/test/lib/mayaUsd/fileio/testEditAsMaya.py
@@ -18,7 +18,7 @@
 
 import fixturesUtils
 
-from usdUtils import createSimpleXformScene
+from usdUtils import createSimpleXformScene, createDuoXformScene
 
 from maya import OpenMaya as OM
 from maya import OpenMayaAnim as OMA
@@ -165,6 +165,65 @@ class EditAsMayaTestCase(unittest.TestCase):
             aMayaItem = ufe.GlobalSelection.get().front()
             aMayaPath = aMayaItem.path()
             self.assertTrue(mayaUsd.lib.PrimUpdaterManager.mergeToUsd(ufe.PathString.string(aMayaPath)))
+
+    @unittest.skipIf(os.getenv('HAS_ORPHANED_NODES_MANAGER', '0') != '1', 'Test only available when UFE supports the orphaned nodes manager')
+    def testReparentUsdAncestorOfEditAsMaya(self):
+        '''Test that reparenting an usd ancestor correctly updates the internal data.'''
+        def validateEditAsMayaMetadata(mayaItem, ufePathStr):
+            mayaPath = mayaItem.path()
+            self.assertEqual(mayaPath.nbSegments(), 1)
+            mayaToUsd = ufe.PathMappingHandler.pathMappingHandler(mayaItem)
+            fromHostUfePath = mayaToUsd.fromHost(mayaPath)
+            self.assertEqual(ufe.PathString.string(fromHostUfePath), ufePathStr)
+            dagPath = om.MSelectionList().add(ufe.PathString.string(mayaPath)).getDagPath(0)
+            pullUfePath = cmds.getAttr(str(dagPath) + ".Pull_UfePath")
+            self.assertEqual(pullUfePath, ufePathStr)
+            self.assertFalse(mayaUsd.lib.PrimUpdaterManager.canEditAsMaya(ufePathStr))
+
+        def verifyDagXformAndVis(dagPath, expectedXlation, expectedVis):
+            mXformMatrix = om.MTransformationMatrix(dagPath.inclusiveMatrix())
+            mXlation = mXformMatrix.translation(om.MSpace.kObject)
+            assertVectorAlmostEqual(self, mXlation, expectedXlation)
+            self.assertEqual(dagPath.isVisible(), expectedVis)
+
+        (ps,
+         aXlateOp, aUsdXlation, aUsdUfePathStr, _, _,
+         bXlateOp, bUsdXlation, bUsdUfePathStr, _, _) = createDuoXformScene()
+
+        proxyShapePathStr = ufe.PathString.string(ps.path())
+        stage = mayaUsd.ufe.getStage(proxyShapePathStr)
+        editedPrim = stage.DefinePrim("/A/Edited", "Xform")
+
+        with mayaUsd.lib.OpUndoItemList():
+            editedUfePathStr = "{},{}".format(proxyShapePathStr, editedPrim.GetPath())
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.canEditAsMaya(editedUfePathStr))
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.editAsMaya(editedUfePathStr))
+
+        editedMayaItem = ufe.GlobalSelection.get().front()
+        editedMayaPathStr = ufe.PathString.string(editedMayaItem.path())
+        editedDagPath = om.MSelectionList().add(editedMayaPathStr).getDagPath(0)
+
+        verifyDagXformAndVis(editedDagPath, aUsdXlation, True)
+        validateEditAsMayaMetadata(editedMayaItem, editedUfePathStr)
+
+        # Reparent /A under /B
+        cmds.parent(aUsdUfePathStr, bUsdUfePathStr)
+
+        # Make /B invisible and translate it.
+        bPrim = mayaUsd.ufe.ufePathToPrim(bUsdUfePathStr)
+        UsdGeom.Imageable(bPrim).CreateVisibilityAttr().Set(UsdGeom.Tokens.invisible)
+
+        bOffset = Gf.Vec3d(100, 100, 100)
+        bXlateOp.Set(bXlateOp.Get() + bOffset)
+
+        # After reparent "/A/Edited" xform is conserved and inherits b offset
+        # /B invisibility is also inherited.
+        verifyDagXformAndVis(editedDagPath, aUsdXlation + bOffset, False)
+        validateEditAsMayaMetadata(editedMayaItem, bUsdUfePathStr + "/A/Edited")
+
+        # Verify we can merge "Edited" Maya data after the reparent
+        with mayaUsd.lib.OpUndoItemList():
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.mergeToUsd(editedMayaPathStr))
 
     def testEditAsMayaPreserveUsdSkel(self):
         '''Test that edit does not change the usd skel prim data.'''

--- a/test/lib/mayaUsd/fileio/testEditAsMaya.py
+++ b/test/lib/mayaUsd/fileio/testEditAsMaya.py
@@ -122,6 +122,7 @@ class EditAsMayaTestCase(unittest.TestCase):
             self.assertTrue(mayaUsd.lib.PrimUpdaterManager.mergeToUsd(ufe.PathString.string(aMayaPath)))
 
     @unittest.skipIf(os.getenv('HAS_ORPHANED_NODES_MANAGER', '0') != '1', 'Test only available when UFE supports the orphaned nodes manager')
+    @unittest.skip("This test is failing at least with UVE v3 and v4; OrphanedNodesManager does not seem to support re-parenting a proxyShape ancestor.")
     def testReparentAncestorOfEditAsMaya(self):
         '''Test that reparenting an ancestor correctly updates the internal data.'''
 


### PR DESCRIPTION
Hello,

This PR addresses an issue where pulled Maya objects transform and visibility were disconnected from the USD stages after renaming or reparenting a USD ancestor of the pulled prim. Our artists very frequently have multiple pulled objects in the same stage while re-structuring the hierarchy.

Before this fix:
![beforeFixPullParentAncestor](https://github.com/user-attachments/assets/04bfffc3-f71a-4c07-8170-832cc77e71ea)

Ater this fix:
![afterFixPullParentAncestor](https://github.com/user-attachments/assets/a257c1ac-7e9c-477a-9a13-8004ee15e4df)

Changes included in this PR:

- Added the ability to cleanly reparent a DAG to a USD item using `mayaUsd.lib.proxyAccessor`, ensuring it does not leave disconnected proxyAccessor outputs, potentially accessing invalid prims: a25dcd60cb84981e69d2bb5f64a6625a3e45a59b and unit-test 415dcb653db407229cf07991a623c5379230326f.
- Small refactoring of `PrimUpdaterManager` to mutualize the `mayaUsd.lib.proxyAccessor.parent` python call: dc8956361e167de3ae292e36612665fab9d38ede.
- Added the proxyAccessor update in `OrphanedNodeManager`, following the `pullInformation` update: 2969283dc556eefe591182959870c97f0721018b.
- Modified CMake targets to define the `HAS_ORPHANED_NODES_MANAGER` env to add a unit test in testEditAsMaya.py. Disabled a failing test. It was failing without my changes with Maya2023 + USD-23.11 and Maya2024 + USD-23.11. The CMake/test changes: 243eecdec1bd768b5a800d2e4dff244e09cbad6b. The new test: 1a93630fc8942ab094a2d0181a613f0eb16b0fc6. 

--
Julien