### PR TITLE
EMSUSD-1463 - MayaUsd: 2026 Maya blessing is broken because of TBB change in Maya

### DIFF
--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -158,8 +158,7 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(USD
     REQUIRED_VARS
         PXR_USD_LOCATION
-        USD_INCLUDE_DIR
-        USD_LIBRARY_DIR
+        PXR_INCLUDE_DIRS
         USD_CONFIG_FILE
         USD_VERSION
         ADSK_USD_VERSION
@@ -170,8 +169,7 @@ find_package_handle_standard_args(USD
 
 if (USD_FOUND)
     # This will follow a message "-- Found USD: <path> ..."
-    message(STATUS "   USD include dir: ${USD_INCLUDE_DIR}")
-    message(STATUS "   USD library dir: ${USD_LIBRARY_DIR}")
+    message(STATUS "   USD include dirs: ${PXR_INCLUDE_DIRS}")
     if (USD_GENSCHEMA)
         message(STATUS "   usdGenSchema: ${USD_GENSCHEMA}")
     endif()

--- a/lib/mayaUsd/CMakeLists.txt
+++ b/lib/mayaUsd/CMakeLists.txt
@@ -219,10 +219,13 @@ mayaUsd_compile_config(${PROJECT_NAME})
 # include directories
 # -----------------------------------------------------------------------------
 target_include_directories(${PROJECT_NAME} 
-    PUBLIC
-        ${MAYA_INCLUDE_DIRS}
+    SYSTEM PUBLIC
         ${PXR_INCLUDE_DIRS}
+        ${MAYA_INCLUDE_DIRS}
         ${UFE_INCLUDE_DIR}
+)
+target_include_directories(${PROJECT_NAME} 
+    PUBLIC
         ${CMAKE_BINARY_DIR}/include
 )
 

--- a/lib/mayaUsdAPI/CMakeLists.txt
+++ b/lib/mayaUsdAPI/CMakeLists.txt
@@ -83,9 +83,10 @@ mayaUsd_promoteHeaderList(
 # -----------------------------------------------------------------------------
 target_include_directories(${PROJECT_NAME}
     PRIVATE
+        ${PXR_INCLUDE_DIRS}
         ${MAYA_INCLUDE_DIRS}
         ${CMAKE_BINARY_DIR}/include
-        )
+)
 
 # -----------------------------------------------------------------------------
 # link libraries

--- a/lib/mayaUsdAPI/python/CMakeLists.txt
+++ b/lib/mayaUsdAPI/python/CMakeLists.txt
@@ -47,9 +47,9 @@ mayaUsd_compile_config(${PYTHON_TARGET_NAME})
 # -----------------------------------------------------------------------------
 target_include_directories(${PROJECT_NAME} 
     PUBLIC
+        ${PXR_INCLUDE_DIRS}
         ${MAYA_INCLUDE_DIRS}
         ${UFE_INCLUDE_DIR}
-        ${PXR_INCLUDE_DIRS}
         ${CMAKE_BINARY_DIR}/include
 )
 

--- a/lib/usd/pxrUsdPreviewSurface/CMakeLists.txt
+++ b/lib/usd/pxrUsdPreviewSurface/CMakeLists.txt
@@ -62,6 +62,7 @@ mayaUsd_promoteHeaderList(
 # -----------------------------------------------------------------------------
 target_include_directories(${TARGET_NAME}
     PRIVATE
+        ${PXR_INCLUDE_DIRS}
         ${MAYA_INCLUDE_DIRS}
         ${CMAKE_BINARY_DIR}
 )

--- a/lib/usd/translators/CMakeLists.txt
+++ b/lib/usd/translators/CMakeLists.txt
@@ -67,6 +67,7 @@ mayaUsd_compile_config(${TARGET_NAME})
 # -----------------------------------------------------------------------------
 target_include_directories(${TARGET_NAME}
     PRIVATE
+        ${PXR_INCLUDE_DIRS}
         ${MAYA_INCLUDE_DIRS}
         ${CMAKE_BINARY_DIR}
 )

--- a/plugin/al/mayatest/AL/maya/test/CMakeLists.txt
+++ b/plugin/al/mayatest/AL/maya/test/CMakeLists.txt
@@ -41,8 +41,8 @@ target_include_directories(${MAYA_TEST_LIBRARY_NAME}
   PRIVATE
     ${MAYATEST_INCLUDE_LOCATION}
     ${GTEST_INCLUDE_DIRS}
+    ${PXR_INCLUDE_DIRS}
     ${MAYA_INCLUDE_DIRS}
-    ${USD_INCLUDE_DIR}
 )
 
 list(APPEND maya_test_headers

--- a/plugin/al/plugin/AL_USDMayaPlugin/CMakeLists.txt
+++ b/plugin/al/plugin/AL_USDMayaPlugin/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(${PXR_PACKAGE}
 
 target_include_directories(${PXR_PACKAGE}
     PRIVATE
+        ${PXR_INCLUDE_DIRS}
         ${MAYA_INCLUDE_DIRS}
         "../../lib/AL_USDMaya"
 )

--- a/plugin/al/plugin/AL_USDMayaTestPlugin/CMakeLists.txt
+++ b/plugin/al/plugin/AL_USDMayaTestPlugin/CMakeLists.txt
@@ -77,6 +77,7 @@ target_compile_definitions(${TARGET_NAME}
 target_include_directories(${TARGET_NAME}
     PRIVATE
         ${GTEST_INCLUDE_DIRS}
+        ${PXR_INCLUDE_DIRS}
         ${MAYA_INCLUDE_DIRS}
         "../../lib/AL_USDMaya"
         "../../schemas"

--- a/plugin/al/schemas/AL/usd/schemas/maya/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/maya/CMakeLists.txt
@@ -74,7 +74,7 @@ target_compile_definitions(AL_USDMayaSchemas
 
 target_include_directories(AL_USDMayaSchemas 
   PUBLIC
-    ${USD_INCLUDE_DIR}
+    ${PXR_INCLUDE_DIRS}
 )
 
 # Hamed 2019 

--- a/plugin/al/schemas/AL/usd/schemas/maya/tests/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/maya/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(${TARGET_NAME}
     PUBLIC
         ${PROJECT_SOURCE_DIR}/schemas
         ${GTEST_INCLUDE_DIRS}
-        ${USD_INCLUDE_DIR}
+        ${PXR_INCLUDE_DIRS}
 )
 
 target_link_libraries(${TARGET_NAME}

--- a/plugin/al/schemas/AL/usd/schemas/mayatest/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/mayatest/CMakeLists.txt
@@ -73,7 +73,7 @@ target_compile_definitions(AL_USDMayaSchemasTest
 
 target_include_directories(AL_USDMayaSchemasTest 
   PUBLIC
-    ${USD_INCLUDE_DIR}
+    ${PXR_INCLUDE_DIRS}
 )
 
 target_link_libraries(AL_USDMayaSchemasTest ${DEPENDANT_LIBRARIES})

--- a/plugin/al/usdmayautils/AL/usdmaya/utils/CMakeLists.txt
+++ b/plugin/al/usdmayautils/AL/usdmaya/utils/CMakeLists.txt
@@ -73,8 +73,12 @@ target_link_libraries(${USDMAYA_UTILS_LIBRARY_NAME}
 
 target_include_directories(${USDMAYA_UTILS_LIBRARY_NAME} 
     PUBLIC
-    ${USDMAYAUTILS_INCLUDE_LOCATION}
-    ${USD_INCLUDE_DIR}
+        ${USDMAYAUTILS_INCLUDE_LOCATION}
+)
+target_include_directories(${USDMAYA_UTILS_LIBRARY_NAME} 
+    SYSTEM PUBLIC
+        ${PXR_INCLUDE_DIRS}
+        ${MAYA_INCLUDE_DIRS}
 )
 
 # install the public headers

--- a/plugin/al/usdtransaction/AL/usd/transaction/CMakeLists.txt
+++ b/plugin/al/usdtransaction/AL/usd/transaction/CMakeLists.txt
@@ -52,7 +52,7 @@ target_compile_definitions(${USDTRANSACTION_LIBRARY_NAME}
 target_include_directories(${USDTRANSACTION_LIBRARY_NAME} 
   PUBLIC
     ${USDTRANSACTION_INCLUDE_LOCATION} 
-    ${USD_INCLUDE_DIR}
+    ${PXR_INCLUDE_DIRS}
 )
 
 target_link_libraries(${USDTRANSACTION_LIBRARY_NAME}
@@ -90,7 +90,7 @@ target_compile_definitions(${USDTRANSACTION_PYTHON_LIBRARY_NAME}
 target_include_directories(${USDTRANSACTION_PYTHON_LIBRARY_NAME} 
   PUBLIC
     ${USDTRANSACTION_INCLUDE_LOCATION} 
-    ${USD_INCLUDE_DIR}
+    ${PXR_INCLUDE_DIRS}
 )
 
 target_link_libraries(${USDTRANSACTION_PYTHON_LIBRARY_NAME}

--- a/plugin/al/usdtransaction/AL/usd/transaction/tests/CMakeLists.txt
+++ b/plugin/al/usdtransaction/AL/usd/transaction/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(${TARGET_NAME}
   PUBLIC
     ${GTEST_INCLUDE_DIRS}
     ${USDTRANSACTION_INCLUDE_LOCATION}
-    ${USD_INCLUDE_DIR}
+    ${PXR_INCLUDE_DIRS}
 )
 
 target_link_libraries(${TARGET_NAME}

--- a/plugin/pxr/maya/lib/usdMaya/CMakeLists.txt
+++ b/plugin/pxr/maya/lib/usdMaya/CMakeLists.txt
@@ -20,6 +20,7 @@ pxr_shared_library(${PXR_PACKAGE}
         ${UFE_LIBRARY}
 
     INCLUDE_DIRS
+        ${PXR_INCLUDE_DIRS}
         ${MAYA_INCLUDE_DIRS}
         ${UFE_INCLUDE_DIR}
 

--- a/plugin/pxr/maya/plugin/pxrUsd/CMakeLists.txt
+++ b/plugin/pxr/maya/plugin/pxrUsd/CMakeLists.txt
@@ -16,6 +16,7 @@ pxr_plugin(${PXR_PACKAGE}
         ${UFE_LIBRARY}
 
     INCLUDE_DIRS
+        ${PXR_INCLUDE_DIRS}
         ${MAYA_INCLUDE_DIRS}
         ${UFE_INCLUDE_DIR}
 

--- a/plugin/pxr/maya/plugin/pxrUsdPreviewSurface/CMakeLists.txt
+++ b/plugin/pxr/maya/plugin/pxrUsdPreviewSurface/CMakeLists.txt
@@ -11,6 +11,7 @@ pxr_plugin(${PXR_PACKAGE}
         ${MAYA_OpenMaya_LIBRARY}
 
     INCLUDE_DIRS
+        ${PXR_INCLUDE_DIRS}
         ${MAYA_INCLUDE_DIRS}
 
     CPPFILES


### PR DESCRIPTION
EMSUSD-1463 - MayaUsd: 2026 Maya blessing is broken because of TBB change in Maya

* Use PXR_INCLUDE_DIR from pxrConfig.cmake
* Because USD include path is set as system, make Maya include path a system one and put USD before Maya. Note: system paths always come after regular include paths.