### PR TITLE
EMSUSD-1357 material scope when no default prim given

### DIFF
--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -707,6 +707,7 @@ UsdMayaJobExportArgs::UsdMayaJobExportArgs(
     , dagPaths(dagPaths)
     , fullObjectList(fullList)
     , timeSamples(timeSamples)
+    , exportRoots(extractVector<std::string>(userArgs, UsdMayaJobExportArgsTokens->exportRoots))
     , rootMapFunction(PcpMapFunction::Create(
           _ExportRootsMap(
               userArgs,

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -270,7 +270,7 @@ struct UsdMayaJobExportArgs
     const TfToken::Set includeAPINames;
     const TfToken::Set jobContextNames;
     const TfToken::Set excludeExportTypes;
-    const std::string  defaultPrim;
+    std::string        defaultPrim;
 
     using ChaserArgs = std::map<std::string, std::string>;
     const std::vector<std::string>          chaserNames;
@@ -307,6 +307,7 @@ struct UsdMayaJobExportArgs
     // When using export roots feature we will leverage map function to
     // override the sdfpath generated from source DAG path. Will be empty
     // if export roots is not used.
+    const std::vector<std::string> exportRoots;
     const PcpMapFunction rootMapFunction;
 
     // Maya type ids to avoid exporting; these are EXACT types, the constructor will also add all

--- a/test/lib/mayaUsd/fileio/testSchemaApiAdaptor.py
+++ b/test/lib/mayaUsd/fileio/testSchemaApiAdaptor.py
@@ -414,7 +414,8 @@ class testSchemaApiAdaptor(unittest.TestCase):
         # Export, with Bullet:
         usdFilePath = os.path.abspath('UsdExportSchemaApiTest_WithBullet.usda')
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
-                           apiSchema=schemasToExport, frameRange=(1, 10))
+                           apiSchema=schemasToExport, frameRange=(1, 10),
+                           defaultPrim='pSphere1')
 
         # Check that Physics API schemas did get exported:
         stage = Usd.Stage.Open(usdFilePath)

--- a/test/lib/usd/pxrUsdPreviewSurface/testPxrUsdPreviewSurfaceExport.py
+++ b/test/lib/usd/pxrUsdPreviewSurface/testPxrUsdPreviewSurfaceExport.py
@@ -48,7 +48,7 @@ class testPxrUsdPreviewSurfaceExport(unittest.TestCase):
 
         cmds.loadPlugin('mayaUsdPlugin', quiet=True)
         cmds.file(usdFilePath, force=True,
-                  options="shadingMode=useRegistry;mergeTransformAndShape=1;legacyMaterialScope=0",
+                  options="shadingMode=useRegistry;mergeTransformAndShape=1;legacyMaterialScope=0;defaultPrim=None",
                   typ="USD Export", pr=True, ea=True)
 
         cmds.file(defaultExtensions=defaultExtSetting)

--- a/test/lib/usd/translators/testUsdExport8BitNormalMap.py
+++ b/test/lib/usd/translators/testUsdExport8BitNormalMap.py
@@ -100,7 +100,7 @@ class testExport8BitNormalMap(unittest.TestCase):
         build_test_scene(self.temp_dir)
 
         out_file = os.path.abspath('normalMapTest.usdc')
-        cmds.mayaUSDExport(file=out_file,legacyMaterialScope=False)
+        cmds.mayaUSDExport(file=out_file,legacyMaterialScope=False, defaultPrim="None")
         
         self.assertTrue(os.path.isfile(out_file))
 

--- a/test/lib/usd/translators/testUsdExportCustomConverter.template.py
+++ b/test/lib/usd/translators/testUsdExportCustomConverter.template.py
@@ -71,7 +71,8 @@ class testUsdExportCustomConverter(unittest.TestCase):
         options = ["shadingMode=useRegistry",
                    "convertMaterialsTo=[maya]",
                    "mergeTransformAndShape=1",
-                   "legacyMaterialScope=0"]
+                   "legacyMaterialScope=0",
+                   "defaultPrim=None"]
 
         default_ext_setting = cmds.file(q=True, defaultExtensions=True)
         cmds.file(defaultExtensions=False)

--- a/test/lib/usd/translators/testUsdExportDisplacement.py
+++ b/test/lib/usd/translators/testUsdExportDisplacement.py
@@ -41,7 +41,7 @@ class testUsdExportDisplacementShaders(unittest.TestCase):
         usdFilePath = os.path.abspath('SimpleDisplacement.usda')
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
             shadingMode='useRegistry', convertMaterialsTo=['UsdPreviewSurface'],
-            materialsScopeName='Materials', legacyMaterialScope=False)
+            materialsScopeName='Materials', legacyMaterialScope=False, defaultPrim="None")
 
         cls._stage = Usd.Stage.Open(usdFilePath)
 

--- a/test/lib/usd/translators/testUsdExportEmptyXforms.py
+++ b/test/lib/usd/translators/testUsdExportEmptyXforms.py
@@ -176,7 +176,7 @@ class testUsdExportEmptyXforms(unittest.TestCase):
 
         usdFilePath = os.path.abspath('UsdExportExcludeEmptyTest.usda')
         cmds.select('null1')
-        self._exportToUSD(usdFilePath, includeEmpties)
+        self._exportToUSD(usdFilePath, includeEmpties, defaultPrimPath="None")
         
         stage = Usd.Stage.Open(usdFilePath)
         self.assertTrue(stage)
@@ -193,7 +193,7 @@ class testUsdExportEmptyXforms(unittest.TestCase):
 
         usdFilePath = os.path.abspath('UsdExportExcludeEmptyTest.usda')
         cmds.select('null1')
-        self._exportToUSD(usdFilePath, includeEmpties)
+        self._exportToUSD(usdFilePath, includeEmpties, defaultPrimPath="None")
         
         stage = Usd.Stage.Open(usdFilePath)
         self.assertTrue(stage)

--- a/test/lib/usd/translators/testUsdExportFannedOutFileNodesMaterial.py
+++ b/test/lib/usd/translators/testUsdExportFannedOutFileNodesMaterial.py
@@ -66,7 +66,7 @@ class testExportFannedOutFileNodesMaterial(unittest.TestCase):
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
             shadingMode='useRegistry', 
             convertMaterialsTo=['MaterialX', 'UsdPreviewSurface'],
-            materialsScopeName='Materials', legacyMaterialScope=False)
+            materialsScopeName='Materials', legacyMaterialScope=False, defaultPrim="None")
 
         stage = Usd.Stage.Open(usdFilePath)
         self.assertTrue(stage)

--- a/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
+++ b/test/lib/usd/translators/testUsdExportImportRoundtripPreviewSurface.py
@@ -132,7 +132,8 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
             "shadingMode=useRegistry",
             "convertMaterialsTo=[{}]".format(convertTo),
             "mergeTransformAndShape=1",
-            "legacyMaterialScope=0"
+            "legacyMaterialScope=0",
+            "defaultPrim=None"
         ]
 
         cmds.file(usd_path, force=True,
@@ -415,7 +416,8 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
             file=usd_path,
             shadingMode='useRegistry',
             exportDisplayColor=True,
-            legacyMaterialScope=False)
+            legacyMaterialScope=False,
+            defaultPrim="None")
 
         # We expect 2 primvar readers, and 2 st transforms:
         stage = Usd.Stage.Open(usd_path)
@@ -477,7 +479,8 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
                 exportDisplayColor=False,
                 exportCollectionBasedBindings=True,
                 exportComponentTags=True,
-                legacyMaterialScope=False)
+                legacyMaterialScope=False,
+                defaultPrim='pCube1')
         else:
             usd_path = os.path.abspath('CubeWithAssignedFaces.usda')
             cmds.usdExport(mergeTransformAndShape=True,
@@ -485,7 +488,8 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
                 shadingMode='useRegistry',
                 exportDisplayColor=False,
                 exportComponentTags=True,
-                legacyMaterialScope=False)
+                legacyMaterialScope=False,
+                defaultPrim='pCube1')
 
         stage = Usd.Stage.Open(usd_path)
 
@@ -576,12 +580,12 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
         geomSubset = stage.GetPrimAtPath("/pCube1/left")
         geomSubset.GetAttribute("familyName").Set("materialBind")
         subsetBindAPI = UsdShade.MaterialBindingAPI.Apply(geomSubset.GetPrim())
-        subsetBindAPI.Bind(UsdShade.Material(stage.GetPrimAtPath("/Looks/blueFaceSG")))
+        subsetBindAPI.Bind(UsdShade.Material(stage.GetPrimAtPath("/pCube1/Looks/blueFaceSG")))
 
         meshBindAPI = UsdShade.MaterialBindingAPI(stage.GetPrimAtPath("/pCube1"))
         geomSubset = meshBindAPI.CreateMaterialBindSubset("newKidOnTheBlock", [1, 2], UsdGeom.Tokens.face)
         subsetBindAPI = UsdShade.MaterialBindingAPI.Apply(geomSubset.GetPrim())
-        subsetBindAPI.Bind(UsdShade.Material(stage.GetPrimAtPath("/Looks/redFaceSG")))
+        subsetBindAPI.Bind(UsdShade.Material(stage.GetPrimAtPath("/pCube1/Looks/redFaceSG")))
 
         # The "unassigned faced" were previously [1, 2, 3, 5]
         # We have assigned faces 1, 2, and 5 (left), so the only one remaining is 3:
@@ -691,7 +695,8 @@ class testUsdExportImportRoundtripPreviewSurface(unittest.TestCase):
         cmds.usdExport(mergeTransformAndShape=True,
                        file=usd_path,
                        shadingMode='useRegistry',
-                       legacyMaterialScope=False)
+                       legacyMaterialScope=False,
+                       defaultPrim='None')
 
         stage = Usd.Stage.Open(usd_path)
 

--- a/test/lib/usd/translators/testUsdExportImportUDIM.py
+++ b/test/lib/usd/translators/testUsdExportImportUDIM.py
@@ -52,7 +52,7 @@ class testUsdExportImportUDIM(unittest.TestCase):
         usd_file = os.path.abspath('UsdExportUDIMTest.usda')
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usd_file,
             shadingMode='useRegistry', convertMaterialsTo=['UsdPreviewSurface'],
-            materialsScopeName='Materials', legacyMaterialScope=False)
+            materialsScopeName='Materials', legacyMaterialScope=False, defaultPrim='None')
 
         stage = Usd.Stage.Open(usd_file)
         self.assertTrue(stage)

--- a/test/lib/usd/translators/testUsdExportMaterialScope.py
+++ b/test/lib/usd/translators/testUsdExportMaterialScope.py
@@ -41,7 +41,7 @@ class testUsdExportMaterialScope(unittest.TestCase):
     def tearDownClass(cls):
         standalone.uninitialize()
 
-    def _export(self, mayaFileName, defaultPrim=''):
+    def _export(self, mayaFileName, defaultPrim='None'):
         self._mayaFile = os.path.join(self.inputPath, 'UsdExportMaterialScopeTest', mayaFileName)
         cmds.file(self._mayaFile, force=True, open=True)
 

--- a/test/lib/usd/translators/testUsdExportMaterialX.py
+++ b/test/lib/usd/translators/testUsdExportMaterialX.py
@@ -146,7 +146,7 @@ class testUsdExportMaterialX(unittest.TestCase):
         usdFilePath = os.path.abspath('UsdExportMaterialXTest.usda')
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
             shadingMode='useRegistry', convertMaterialsTo=['MaterialX'],
-            materialsScopeName='Materials')
+            materialsScopeName='Materials', defaultPrim='None')
 
         stage = Usd.Stage.Open(usdFilePath)
         self.assertTrue(stage)
@@ -287,7 +287,7 @@ class testUsdExportMaterialX(unittest.TestCase):
         usdFilePath = os.path.abspath('MaterialX_decal.usda')
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
             shadingMode='useRegistry', convertMaterialsTo=['MaterialX'],
-            materialsScopeName='Materials')
+            materialsScopeName='Materials', defaultPrim='None')
 
         stage = Usd.Stage.Open(usdFilePath)
         self.assertTrue(stage)

--- a/test/lib/usd/translators/testUsdExportMultiMaterial.py
+++ b/test/lib/usd/translators/testUsdExportMultiMaterial.py
@@ -63,7 +63,8 @@ class testUsdExportMultiMaterial(unittest.TestCase):
             convertMaterialsTo=['MaterialX', 'UsdPreviewSurface', 'rendermanForMaya'],
             materialsScopeName='Materials',
             exportMaterials=exportMaterials,
-            legacyMaterialScope=False)
+            legacyMaterialScope=False,
+            defaultPrim='None')
 
         self._stage = Usd.Stage.Open(usdFilePath)
 
@@ -201,7 +202,8 @@ class testUsdExportMultiMaterial(unittest.TestCase):
             shadingMode='useRegistry',
             convertMaterialsTo=['MaterialX', 'UsdPreviewSurface'],
             materialsScopeName='Looks',
-            legacyMaterialScope=False)
+            legacyMaterialScope=False,
+            defaultPrim='None')
 
         # We expect 2 primvar readers, and 2 st transforms:
         stage = Usd.Stage.Open(usd_path)

--- a/test/lib/usd/translators/testUsdExportRfMShaders.py
+++ b/test/lib/usd/translators/testUsdExportRfMShaders.py
@@ -41,7 +41,8 @@ class testUsdExportRfMShaders(unittest.TestCase):
         usdFilePath = os.path.abspath('MarbleCube.usda')
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
             shadingMode='useRegistry', convertMaterialsTo=['rendermanForMaya'],
-            materialsScopeName='Materials', legacyMaterialScope=False)
+            materialsScopeName='Materials', legacyMaterialScope=False,
+            defaultPrim='None')
 
         cls._stage = Usd.Stage.Open(usdFilePath)
 

--- a/test/lib/usd/translators/testUsdExportRoots.py
+++ b/test/lib/usd/translators/testUsdExportRoots.py
@@ -64,7 +64,8 @@ class testUsdExportRoot(unittest.TestCase):
                 'file': usdFile,
                 'mergeTransformAndShape': True,
                 'shadingMode': 'useRegistry',
-                'legacyMaterialScope': False
+                'legacyMaterialScope': False,
+                'defaultPrim': 'None',
             }
             if root:
                 kwargs['exportRoots'] = root
@@ -80,7 +81,7 @@ class testUsdExportRoot(unittest.TestCase):
                 'type': 'USD Export',
                 'f': 1,
             }
-            options = ['legacyMaterialScope=0']
+            options = ['legacyMaterialScope=0', 'defaultPrim=None']
             if root:
                 options.append('exportRoots={}'.format(','.join(root)))
             if worldspace:

--- a/test/lib/usd/translators/testUsdExportSchemaApi.py
+++ b/test/lib/usd/translators/testUsdExportSchemaApi.py
@@ -247,7 +247,8 @@ class testUsdExportSchemaApi(unittest.TestCase):
         # Export, with Bullet:
         usdFilePath = os.path.abspath('UsdExportSchemaApiTest_WithBullet.usda')
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
-                           jobContext=["Bullet"], frameRange=(1, 10))
+                           jobContext=["Bullet"], frameRange=(1, 10),
+                           defaultPrim='pSphere1')
 
         # Check that Physics API schemas did get exported:
         stage = Usd.Stage.Open(usdFilePath)

--- a/test/lib/usd/translators/testUsdExportShadingInstanced.py
+++ b/test/lib/usd/translators/testUsdExportShadingInstanced.py
@@ -44,7 +44,8 @@ class testUsdExportShadingInstanced(unittest.TestCase):
                 exportCollectionBasedBindings=True,
                 exportMaterialCollections=True,
                 materialCollectionsPath="/World",
-                legacyMaterialScope=False)
+                legacyMaterialScope=False,
+                defaultPrim='None')
 
         cls._simpleStage = Usd.Stage.Open(usdFilePath)
 
@@ -59,7 +60,8 @@ class testUsdExportShadingInstanced(unittest.TestCase):
                 exportCollectionBasedBindings=True,
                 exportMaterialCollections=True,
                 materialCollectionsPath="/World",
-                legacyMaterialScope=False)
+                legacyMaterialScope=False,
+                defaultPrim='None')
 
         cls._nestedStage = Usd.Stage.Open(usdFilePath)
 

--- a/test/lib/usd/translators/testUsdExportShadingModePxrRis.py
+++ b/test/lib/usd/translators/testUsdExportShadingModePxrRis.py
@@ -40,7 +40,7 @@ class testUsdExportShadingModePxrRis(unittest.TestCase):
         usdFilePath = os.path.abspath('MarbleCube.usda')
         cmds.usdExport(mergeTransformAndShape=True, file=usdFilePath,
             shadingMode='pxrRis', materialsScopeName='Materials',
-            legacyMaterialScope=False)
+            legacyMaterialScope=False, defaultPrim='None')
 
         cls._stage = Usd.Stage.Open(usdFilePath)
 

--- a/test/lib/usd/translators/testUsdExportSkeleton.py
+++ b/test/lib/usd/translators/testUsdExportSkeleton.py
@@ -357,7 +357,7 @@ class testUsdExportSkeleton(unittest.TestCase):
                 "stripNamespaces" : True,
                 "shadingMode":"none",
                 "exportRoots":("jointsGrp",),
-                "exportSkels":"auto",
+                "exportSkels":"auto"
             }
             cmds.mayaUSDExport(**kwargs)
                 

--- a/test/lib/usd/translators/testUsdExportTexture.py
+++ b/test/lib/usd/translators/testUsdExportTexture.py
@@ -78,7 +78,8 @@ class testUsdExportTexture(unittest.TestCase):
 
         with testUtils.TemporaryEnvironmentVariable(PROJ_ENV_VAR_NAME, projectFolder):
             cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath, 
-                exportRelativeTextures=relativeMode, legacyMaterialScope=False)
+                exportRelativeTextures=relativeMode, legacyMaterialScope=False,
+                defaultPrim='None')
 
         stage = Usd.Stage.Open(usdFilePath)
         self.assertTrue(stage, usdFilePath)

--- a/test/lib/usd/translators/testUsdExportUVSetMappings.py
+++ b/test/lib/usd/translators/testUsdExportUVSetMappings.py
@@ -59,6 +59,7 @@ class testUsdExportUVSetMappings(unittest.TestCase):
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
             shadingMode='useRegistry', convertMaterialsTo=['UsdPreviewSurface'],
             materialsScopeName='Materials', legacyMaterialScope=False,
+            defaultPrim='None',
             **extraOptions)
 
         stage = Usd.Stage.Open(usdFilePath)
@@ -195,7 +196,7 @@ class testUsdExportUVSetMappings(unittest.TestCase):
                            shadingMode='useRegistry', convertMaterialsTo=['UsdPreviewSurface'],
                            preserveUVSetNames=False, remapUVSetsTo=[['','']], 
                            materialsScopeName='Materials', legacyMaterialScope=False,
-                           selection=True)
+                           defaultPrim='None', selection=True)
 
         stage = Usd.Stage.Open(usdFilePath)
 

--- a/test/lib/usd/translators/testUsdExportUVTransforms.py
+++ b/test/lib/usd/translators/testUsdExportUVTransforms.py
@@ -51,7 +51,8 @@ class testUsdExportUVTransforms(unittest.TestCase):
 
         usd_file_path = os.path.join(cls.temp_dir, "UsdExportUVTransforms.usda")
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usd_file_path,
-                           shadingMode='useRegistry', legacyMaterialScope=False)
+                           shadingMode='useRegistry', legacyMaterialScope=False,
+                           defaultPrim='None')
 
         cls.stage = Usd.Stage.Open(usd_file_path)
 

--- a/test/lib/usd/translators/testUsdExportUsdPreviewSurface.py
+++ b/test/lib/usd/translators/testUsdExportUsdPreviewSurface.py
@@ -287,7 +287,8 @@ class testUsdExportUsdPreviewSurface(unittest.TestCase):
         usd_file_path = os.path.join(self.temp_dir, "UsdPreviewSurfaceExportTest.usda")
         cmds.mayaUSDExport(
             mergeTransformAndShape=True, file=usd_file_path, 
-            legacyMaterialScope=False, shadingMode="useRegistry"
+            legacyMaterialScope=False, shadingMode="useRegistry",
+            defaultPrim='None'
         )
 
         stage = Usd.Stage.Open(usd_file_path)
@@ -336,7 +337,8 @@ class testUsdExportUsdPreviewSurface(unittest.TestCase):
         usd_file_path = os.path.join(self.temp_dir, "UsdPreviewSurfaceExportTest.usda")
         cmds.mayaUSDExport(
             mergeTransformAndShape=True, file=usd_file_path, 
-            legacyMaterialScope=False, shadingMode="useRegistry"
+            legacyMaterialScope=False, shadingMode="useRegistry",
+            defaultPrim='None'
         )
 
         stage = Usd.Stage.Open(usd_file_path)

--- a/test/lib/usd/translators/testUsdExportUsdzPackage.py
+++ b/test/lib/usd/translators/testUsdExportUsdzPackage.py
@@ -49,7 +49,7 @@ class testUsdExportPackage(unittest.TestCase):
 
         # Write the file out
         path = os.path.join(self.temp_dir, 'testExportSelfContainedPackage.usdz')
-        cmds.mayaUSDExport(f=path, compatibility='appleArKit', legacyMaterialScope=False)
+        cmds.mayaUSDExport(f=path, compatibility='appleArKit', legacyMaterialScope=False, defaultPrim='None')
 
         # Check with USD what the path to the texture is
         stage = Usd.Stage.Open(path)

--- a/test/testSamples/twoSpheres/sphere.usda
+++ b/test/testSamples/twoSpheres/sphere.usda
@@ -8,6 +8,10 @@ def Xform "sphereXform"
     double3 xformOp:translate = (10, 0, 0)
     uniform token[] xformOpOrder = ["xformOp:translate"]
 
+    def Xform "test"
+    {
+    }
+
     def Sphere "sphere"
     {
         float3[] extent = [(-2, -2, -2), (2, 2, 2)]


### PR DESCRIPTION
Change when the default prim is selected when the export job has no default prim explicitly given. It is now chosen at the beginning the export. This change allows the material scope to know that it must be placed under that default prim.

Fix all unit tests affected by the change to where the material scope is placed. Some tests are fixed by explicitly requested that no default prim be used, some are fixed by changing where the material scope is checked to be. These two variations allow testing the new behaviour without having to write new unit tests.