### PR TITLE
LOOKDEVX-3214 - Improve UI name generation

### DIFF
--- a/lib/mayaUsd/render/MaterialXGenOgsXml/libraries/lookdevKit.mtlx
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/libraries/lookdevKit.mtlx
@@ -21,7 +21,7 @@
   <!-- ======================================================================== -->
 
   <!-- colorCorrect -->
-  <nodedef name="LdkND_ColorCorrect_color4" node="LdkColorCorrect" nodegroup="adjustment" doc="Color correct from Maya LookdevKit" version="1.0" isdefaultversion="true">
+  <nodedef name="LdkND_ColorCorrect_color4" node="LdkColorCorrect" uiname="LookdevKit Color Correct" nodegroup="adjustment" doc="Color correct from Maya LookdevKit" version="1.0" isdefaultversion="true">
     <!-- Inputs -->
     <input name="inColor" type="color3" value="0.3, 0.3, 0.3" uiname="Color" uifolder="Inputs" />
     <input name="inAlpha" type="float" value="1.0" uiname="Alpha" uifolder="Inputs" />
@@ -56,7 +56,7 @@
   </nodedef>
 
   <!-- floatCorrect -->
-  <nodedef name="LdkND_FloatCorrect_float" node="LdkFloatCorrect" nodegroup="adjustment" doc="Float correct from Maya LookdevKit" version="1.0" isdefaultversion="true">
+  <nodedef name="LdkND_FloatCorrect_float" node="LdkFloatCorrect" uiname="LookdevKit Float Correct" nodegroup="adjustment" doc="Float correct from Maya LookdevKit" version="1.0" isdefaultversion="true">
     <!-- Inputs -->
     <input name="inFloat" type="float" value="1.0" uiname="Float" uifolder="Inputs" />
 

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/libraries/usd_utilities.mtlx
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/libraries/usd_utilities.mtlx
@@ -38,52 +38,52 @@
   </nodedef>
 
   <!-- Explicit color conversion while waiting for an OCIO-enabled MaterialX    -->
-  <nodedef name="MayaND_sRGBtoLinrec709_color3" node="sRGBtoLinrec709" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoLinrec709_color3" node="sRGBtoLinrec709" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color3" value="0, 0, 0" />
     <output name="out" type="color3" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoLinrec709_color4" node="sRGBtoLinrec709" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoLinrec709_color4" node="sRGBtoLinrec709" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color4" value="0, 0, 0, 1" />
     <output name="out" type="color4" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoACEScg_color3" node="sRGBtoACEScg" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoACEScg_color3" node="sRGBtoACEScg" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color3" value="0, 0, 0" />
     <output name="out" type="color3" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoACEScg_color4" node="sRGBtoACEScg" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoACEScg_color4" node="sRGBtoACEScg" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color4" value="0, 0, 0, 1" />
     <output name="out" type="color4" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoACES2065_color3" node="sRGBtoACES2065" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoACES2065_color3" node="sRGBtoACES2065" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color3" value="0, 0, 0" />
     <output name="out" type="color3" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoACES2065_color4" node="sRGBtoACES2065" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoACES2065_color4" node="sRGBtoACES2065" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color4" value="0, 0, 0, 1" />
     <output name="out" type="color4" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoLinDCIP3D65_color3" node="sRGBtoLinDCIP3D65" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoLinDCIP3D65_color3" node="sRGBtoLinDCIP3D65" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color3" value="0, 0, 0" />
     <output name="out" type="color3" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoLinDCIP3D65_color4" node="sRGBtoLinDCIP3D65" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoLinDCIP3D65_color4" node="sRGBtoLinDCIP3D65" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color4" value="0, 0, 0, 1" />
     <output name="out" type="color4" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoLinrec2020_color3" node="sRGBtoLinrec2020" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoLinrec2020_color3" node="sRGBtoLinrec2020" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color3" value="0, 0, 0" />
     <output name="out" type="color3" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoLinrec2020_color4" node="sRGBtoLinrec2020" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoLinrec2020_color4" node="sRGBtoLinrec2020" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color4" value="0, 0, 0, 1" />
     <output name="out" type="color4" />
   </nodedef>

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/libraries/usd_utilities.mtlx
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/libraries/usd_utilities.mtlx
@@ -22,7 +22,7 @@
 
   <!-- Node: texcoordtangents: Generate world tangents from derivatives of position
              and texcoord                                                       -->
-  <nodedef name="MayaND_texcoordtangents_vector3" node="texcoordtangents" nodegroup="math">
+  <nodedef name="MayaND_texcoordtangents_vector3" node="texcoordtangents" uiname="Tangents from Texture Coordinates" nodegroup="math">
     <input name="position" type="vector3" defaultgeomprop="Pworld" />
     <input name="normal" type="vector3" defaultgeomprop="Nworld" />
     <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
@@ -31,59 +31,59 @@
 
   <!-- Node: arbitrarytangents: Completely arbitrary tangent for when there is no
              texcoord space available                                           -->
-  <nodedef name="MayaND_arbitrarytangents_vector3" node="arbitrarytangents" nodegroup="math">
+  <nodedef name="MayaND_arbitrarytangents_vector3" node="arbitrarytangents" uiname="Arbitrary Tangents" nodegroup="math">
     <input name="position" type="vector3" defaultgeomprop="Pworld" />
     <input name="normal" type="vector3" defaultgeomprop="Nworld" />
     <output name="out" type="vector3" />
   </nodedef>
 
   <!-- Explicit color conversion while waiting for an OCIO-enabled MaterialX    -->
-  <nodedef name="MayaND_sRGBtoLinrec709_color3" node="sRGBtoLinrec709" ldx_hide="true" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoLinrec709_color3" node="sRGBtoLinrec709" uiname="sRGB to Linear Rec. 709" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color3" value="0, 0, 0" />
     <output name="out" type="color3" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoLinrec709_color4" node="sRGBtoLinrec709" ldx_hide="true" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoLinrec709_color4" node="sRGBtoLinrec709" uiname="sRGB to Linear Rec. 709" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color4" value="0, 0, 0, 1" />
     <output name="out" type="color4" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoACEScg_color3" node="sRGBtoACEScg" ldx_hide="true" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoACEScg_color3" node="sRGBtoACEScg" uiname="sRGB to ACEScg" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color3" value="0, 0, 0" />
     <output name="out" type="color3" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoACEScg_color4" node="sRGBtoACEScg" ldx_hide="true" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoACEScg_color4" node="sRGBtoACEScg" uiname="sRGB to ACEScg" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color4" value="0, 0, 0, 1" />
     <output name="out" type="color4" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoACES2065_color3" node="sRGBtoACES2065" ldx_hide="true" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoACES2065_color3" node="sRGBtoACES2065" uiname="sRGB to ACES 2065-1" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color3" value="0, 0, 0" />
     <output name="out" type="color3" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoACES2065_color4" node="sRGBtoACES2065" ldx_hide="true" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoACES2065_color4" node="sRGBtoACES2065" uiname="sRGB to ACES 2065-1" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color4" value="0, 0, 0, 1" />
     <output name="out" type="color4" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoLinDCIP3D65_color3" node="sRGBtoLinDCIP3D65" ldx_hide="true" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoLinDCIP3D65_color3" node="sRGBtoLinDCIP3D65" uiname="sRGB to Linear DCI-P3 D65" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color3" value="0, 0, 0" />
     <output name="out" type="color3" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoLinDCIP3D65_color4" node="sRGBtoLinDCIP3D65" ldx_hide="true" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoLinDCIP3D65_color4" node="sRGBtoLinDCIP3D65" uiname="sRGB to Linear DCI-P3 D65" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color4" value="0, 0, 0, 1" />
     <output name="out" type="color4" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoLinrec2020_color3" node="sRGBtoLinrec2020" ldx_hide="true" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoLinrec2020_color3" node="sRGBtoLinrec2020" uiname="sRGB to Linear Rec. 2020" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color3" value="0, 0, 0" />
     <output name="out" type="color3" />
   </nodedef>
 
-  <nodedef name="MayaND_sRGBtoLinrec2020_color4" node="sRGBtoLinrec2020" ldx_hide="true" nodegroup="adjustment">
+  <nodedef name="MayaND_sRGBtoLinrec2020_color4" node="sRGBtoLinrec2020" uiname="sRGB to Linear Rec. 2020" ldx_hide="true" nodegroup="adjustment">
     <input name="in" type="color4" value="0, 0, 0, 1" />
     <output name="out" type="color4" />
   </nodedef>

--- a/lib/mayaUsd/ufe/UsdShaderNodeDef.cpp
+++ b/lib/mayaUsd/ufe/UsdShaderNodeDef.cpp
@@ -290,7 +290,7 @@ static const MetadataMap _metaMap = {
     { UsdUfe::MetadataTokens->UIName.GetString(),
       [](const PXR_NS::SdrShaderNode& n) {
           std::string uiname;
-          if (!n.GetLabel().IsEmpty()) {
+          if (!n.GetLabel().IsEmpty() && n.GetLabel() != n.GetFamily()) {
               return n.GetLabel().GetString();
           }
           if (!n.GetFamily().IsEmpty() && !_isArnoldWithIssue1214(n)) {
@@ -298,7 +298,7 @@ static const MetadataMap _metaMap = {
           }
           return UsdUfe::prettifyName(n.GetName());
       } },
-    { "doc",
+    { UsdUfe::MetadataTokens->UIDoc,
       [](const PXR_NS::SdrShaderNode& n) {
           return !n.GetHelp().empty() ? n.GetHelp() : Ufe::Value();
       } },

--- a/lib/usdUfe/base/tokens.h
+++ b/lib/usdUfe/base/tokens.h
@@ -81,6 +81,9 @@ TF_DECLARE_PUBLIC_TOKENS(GenericTokens, USDUFE_PUBLIC, USDUFE_GENERIC_TOKENS);
     ((Autodesk, "Autodesk"))                             \
     /* Metadata for UI queries                        */ \
     ((UIName, "uiname"))                                 \
+    ((UIDoc, "doc"))                                     \
+    ((UIEnumLabels, "enum"))                             \
+    ((UIEnumValues, "enumvalues"))                       \
     ((UIFolder, "uifolder"))                             \
     ((UIMin, "uimin"))                                   \
     ((UIMax, "uimax"))                                   \

--- a/lib/usdUfe/ufe/StagesSubject.cpp
+++ b/lib/usdUfe/ufe/StagesSubject.cpp
@@ -15,6 +15,7 @@
 //
 #include "StagesSubject.h"
 
+#include <usdUfe/base/tokens.h>
 #include <usdUfe/ufe/Global.h>
 #include <usdUfe/ufe/UfeNotifGuard.h>
 #include <usdUfe/ufe/UfeVersionCompat.h>
@@ -338,6 +339,18 @@ void processAttributeChanges(
                         metadataKeys.insert(newMetadataKey);
                     }
                 }
+            } else if (infoChanged.first == SdfFieldKeys->AllowedTokens) {
+                sendMetadataChanged = true;
+                metadataKeys.insert(UsdUfe::MetadataTokens->UIEnumLabels);
+            } else if (infoChanged.first == SdfFieldKeys->Documentation) {
+                sendMetadataChanged = true;
+                metadataKeys.insert(UsdUfe::MetadataTokens->UIDoc);
+            } else if (infoChanged.first == SdfFieldKeys->DisplayGroup) {
+                sendMetadataChanged = true;
+                metadataKeys.insert(UsdUfe::MetadataTokens->UIFolder);
+            } else if (infoChanged.first == SdfFieldKeys->DisplayName) {
+                sendMetadataChanged = true;
+                metadataKeys.insert(UsdUfe::MetadataTokens->UIName);
             }
         }
     }

--- a/lib/usdUfe/ufe/UsdShaderAttributeDef.cpp
+++ b/lib/usdUfe/ufe/UsdShaderAttributeDef.cpp
@@ -79,7 +79,7 @@ static const MetadataMap _metaMap = {
           return !p.GetLabel().IsEmpty() ? p.GetLabel().GetString()
                                          : UsdUfe::prettifyName(p.GetName().GetString());
       } },
-    { "doc",
+    { UsdUfe::MetadataTokens->UIDoc,
       [](const PXR_NS::SdrShaderProperty& p) {
           return !p.GetHelp().empty() ? p.GetHelp() : Ufe::Value();
       } },
@@ -87,7 +87,7 @@ static const MetadataMap _metaMap = {
       [](const PXR_NS::SdrShaderProperty& p) {
           return !p.GetPage().IsEmpty() ? p.GetPage().GetString() : Ufe::Value();
       } },
-    { "enum",
+    { UsdUfe::MetadataTokens->UIEnumLabels,
       [](const PXR_NS::SdrShaderProperty& p) {
           std::string r;
           for (auto&& opt : p.GetOptions()) {
@@ -98,7 +98,7 @@ static const MetadataMap _metaMap = {
           }
           return !r.empty() ? r : Ufe::Value();
       } },
-    { "enumvalues",
+    { UsdUfe::MetadataTokens->UIEnumValues,
       [](const PXR_NS::SdrShaderProperty& p) {
           std::string r;
           for (auto&& opt : p.GetOptions()) {

--- a/lib/usdUfe/ufe/Utils.cpp
+++ b/lib/usdUfe/ufe/Utils.cpp
@@ -15,6 +15,7 @@
 //
 #include "Utils.h"
 
+#include <usdUfe/base/tokens.h>
 #include <usdUfe/ufe/Global.h>
 #include <usdUfe/ufe/UsdAttribute.h>
 #include <usdUfe/ufe/UsdAttributes.h>
@@ -605,7 +606,13 @@ Ufe::Attribute::Type usdTypeToUfe(const PXR_NS::UsdAttribute& usdAttr)
                 const auto portType = UsdShadeUtils::GetBaseNameAndType(usdAttr.GetName()).second;
                 if (portType == UsdShadeAttributeType::Input) {
                     const auto input = UsdShadeInput(usdAttr);
-                    if (!input.GetSdrMetadataByKey(TfToken("enum")).empty()) {
+                    if (!input.GetSdrMetadataByKey(UsdUfe::MetadataTokens->UIEnumLabels).empty()) {
+                        return Ufe::Attribute::kEnumString;
+                    }
+                    // Enum tokens can also be found at the Sdf level:
+                    auto sdfAttr
+                        = TfStatic_cast<SdfAttributeSpecHandle>(usdAttr.GetPropertyStack().front());
+                    if (sdfAttr->HasAllowedTokens()) {
                         return Ufe::Attribute::kEnumString;
                     }
                 }

--- a/lib/usdUfe/ufe/Utils.cpp
+++ b/lib/usdUfe/ufe/Utils.cpp
@@ -30,6 +30,7 @@
 #include <pxr/usd/pcp/layerStack.h>
 #include <pxr/usd/pcp/site.h>
 #include <pxr/usd/sdf/layer.h>
+#include <pxr/usd/sdf/schema.h>
 #include <pxr/usd/sdf/types.h>
 #include <pxr/usd/sdr/registry.h>
 #include <pxr/usd/sdr/shaderProperty.h>
@@ -610,9 +611,7 @@ Ufe::Attribute::Type usdTypeToUfe(const PXR_NS::UsdAttribute& usdAttr)
                         return Ufe::Attribute::kEnumString;
                     }
                     // Enum tokens can also be found at the Sdf level:
-                    auto sdfAttr
-                        = TfStatic_cast<SdfAttributeSpecHandle>(usdAttr.GetPropertyStack().front());
-                    if (sdfAttr->HasAllowedTokens()) {
+                    if (usdAttr.HasMetadata(SdfFieldKeys->AllowedTokens)) {
                         return Ufe::Attribute::kEnumString;
                     }
                 }

--- a/lib/usdUfe/utils/Utils.cpp
+++ b/lib/usdUfe/utils/Utils.cpp
@@ -24,6 +24,149 @@
 
 namespace USDUFE_NS_DEF {
 
+namespace {
+
+// This is an ugly and temporary solution to the lack of uiname metadata at the NodeDef level in
+// MaterialX. There is a PR in flight to add the needed uinames to the official MaterialX repository
+// (PR 1959), but it might take some time before it reaches MayaUSD via an updated USD build.
+std::string _getMaterialXUIName(const std::string& nodename)
+{
+    static const auto kUINames = std::unordered_map<std::string, std::string> {
+        { "LamaSSS", "Lama Subsurface Scattering" },
+        { "UsdPreviewSurface", "USD Preview Surface" },
+        { "UsdPrimvarReader", "USD Primvar Reader" },
+        { "UsdTransform2d", "USD Transform 2D" },
+        { "UsdUVTexture", "USD UV Texture" },
+        { "absorption_vdf", "Absorption VDF" },
+        { "absval", "Absolute Value" },
+        { "acescg_to_lin_rec709", "ACEScg to Linear Rec. 709" },
+        { "adobergb_to_lin_rec709", "Adobe RGB to Linear Rec. 709" },
+        { "ambientocclusion", "Ambient Occlusion" },
+        { "anisotropic_vdf", "Anisotropic VDF" },
+        { "arrayappend", "Array Append" },
+        { "artistic_ior", "Artistic IOR" },
+        { "burley_diffuse_bsdf", "Burley Diffuse BSDF" },
+        { "cellnoise2d", "2D Cellular Noise" },
+        { "cellnoise3d", "3D Cellular Noise" },
+        { "colorcorrect", "Color Correct" },
+        { "conductor_bsdf", "Conductor BSDF" },
+        { "conical_edf", "Conical EDF" },
+        { "creatematrix", "Create Matrix" },
+        { "crossproduct", "Cross Product" },
+        { "curveadjust", "Curve Adjust" },
+        { "dielectric_bsdf", "Dielectric BSDF" },
+        { "disjointover", "Disjoint Over" },
+        { "disney_brdf_2012", "Disney BRDF 2012" },
+        { "disney_bsdf_2015", "Disney BSDF 2015" },
+        { "dotproduct", "Dot Product" },
+        { "facingratio", "Facing Ratio" },
+        { "fractal3d", "3D Fractal Noise" },
+        { "g18_rec709_to_lin_rec709", "Gamma 1.8 Rec. 709 to Linear Rec. 709" },
+        { "g22_ap1_to_lin_rec709", "Gamma 2.2 AP1 to Linear Rec. 709" },
+        { "g22_rec709_to_lin_rec709", "Gamma 2.2 Rec. 709 to Linear Rec. 709" },
+        { "generalized_schlick_bsdf", "Generalized Schlick BSDF" },
+        { "generalized_schlick_edf", "Generalized Schlick EDF" },
+        { "geomcolor", "Geometric Color" },
+        { "geompropvalue", "Geometric Property Value" },
+        { "gltf_colorimage", "glTF Color Image" },
+        { "gltf_image", "glTF Image" },
+        { "gltf_iridescence_thickness", "glTF Iridescence Thickness" },
+        { "gltf_normalmap", "glTF Normal Map" },
+        { "gltf_pbr", "glTF PBR" },
+        { "heighttonormal", "Height to Normal" },
+        { "hsvadjust", "HSV Adjust" },
+        { "hsvtorgb", "HSV to RGB" },
+        { "ifequal", "If Equal" },
+        { "ifgreater", "If Greater" },
+        { "ifgreatereq", "If Greater or Equal" },
+        { "invertmatrix", "Invert Matrix" },
+        { "lin_adobergb_to_lin_rec709", "Linear Adobe RGB to Linear Rec. 709" },
+        { "lin_displayp3_to_lin_rec709", "Linear Display P3 to Linear Rec. 709" },
+        { "measured_edf", "Measured EDF" },
+        { "noise2d", "2D Perlin Noise" },
+        { "noise3d", "3D Perlin Noise" },
+        { "normalmap", "Normal Map" },
+        { "open_pbr_anisotropy", "OpenPBR Anisotropy" },
+        { "open_pbr_surface", "OpenPBR Surface" },
+        { "open_pbr_surface_to_standard_surface", "OpenPBR Surface to Standard Surface" },
+        { "oren_nayar_diffuse_bsdf", "Oren-Nayar Diffuse BSDF" },
+        { "place2d", "Place 2D" },
+        { "premult", "Premultiply" },
+        { "ramp4", "4-corner Bilinear Value Ramp" },
+        { "ramplr", "Left-to-right Bilinear Value Ramp" },
+        { "ramptb", "Top-to-bottom Bilinear Value Ramp" },
+        { "randomcolor", "Random Color" },
+        { "randomfloat", "Random Float" },
+        { "rec709_display_to_lin_rec709", "Rec. 709 Display to Linear Rec. 709" },
+        { "rgbtohsv", "RGB to HSV" },
+        { "rotate2d", "Rotate 2D" },
+        { "rotate3d", "Rotate 3D" },
+        { "safepower", "Safe Power" },
+        { "sheen_bsdf", "Sheen BSDF" },
+        { "smoothstep", "Smooth Step" },
+        { "splitlr", "Left-right Split Matte" },
+        { "splittb", "Top-bottom Split Matte" },
+        { "srgb_displayp3_to_lin_rec709", "sRGB Display P3 to Linear Rec. 709" },
+        { "srgb_texture_to_lin_rec709", "sRGB Texture to Linear Rec. 709" },
+        { "standard_surface_to_UsdPreviewSurface", "Standard Surface to USD Preview Surface" },
+        { "standard_surface_to_gltf_pbr", "Standard Surface to glTF PBR" },
+        { "standard_surface_to_open_pbr_surface", "Standard Surface to OpenPBR Surface" },
+        { "subsurface_bsdf", "Subsurface BSDF" },
+        { "surfacematerial", "Surface Material" },
+        { "texcoord", "Texture Coordinate" },
+        { "thin_film_bsdf", "Thin Film BSDF" },
+        { "tiledcircles", "Tiled Circles" },
+        { "tiledcloverleafs", "Tiled Cloverleafs" },
+        { "tiledhexagons", "Tiled Hexagons" },
+        { "tiledimage", "Tiled Image" },
+        { "transformmatrix", "Transform Matrix" },
+        { "transformnormal", "Transform Normal" },
+        { "transformpoint", "Transform Point" },
+        { "transformvector", "Transform Vector" },
+        { "translucent_bsdf", "Translucent BSDF" },
+        { "trianglewave", "Triangle Wave" },
+        { "triplanarprojection", "Tri-planar Projection" },
+        { "unifiednoise2d", "Unified 2D Noise" },
+        { "unifiednoise3d", "Unified 3D Noise" },
+        { "uniform_edf", "Uniform EDF" },
+        { "unpremult", "Unpremultiply" },
+        { "viewdirection", "View Direction" },
+        { "volumematerial", "Volume Material" },
+        { "worleynoise2d", "2D Worley (Voronoi) Noise" },
+        { "worleynoise3d", "3D Worley (Voronoi) Noise" },
+        // Those are category names associated with MaterialX:
+        { "bxdf", "BXDF" },
+        { "cmlib", "Color Transform" },
+        { "colortransform", "Color Transform" },
+        { "convolution2d", "Convolution 2D" },
+        { "nprlib", "NPR" },
+        { "pbr", "PBR" },
+        { "pbrlib", "PBR" },
+        { "procedural2d", "Procedural 2D" },
+        { "procedural3d", "Procedural 3D" },
+        { "stdlib", "Standard" },
+        { "texture2d", "Texture 2D" },
+        // These ones are from MayaUSD and also require manual expansion:
+        { "LdkColorCorrect", "LookdevKit Color Correct" },
+        { "LdkFloatCorrect", "LookdevKit Float Correct" },
+        { "texcoordtangents", "Tangents from Texture Coordinates" },
+        { "arbitrarytangents", "Arbitrary Tangents" },
+        { "sRGBtoLinrec709", "sRGB to Linear Rec. 709" },
+        { "sRGBtoACEScg", "sRGB to ACEScg" },
+        { "sRGBtoACES2065", "sRGB to ACES 2065-1" },
+        { "sRGBtoLinDCIP3D65", "sRGB to Linear DCI-P3 D65" },
+        { "sRGBtoLinrec2020", "sRGB to Linear Rec. 2020" },
+    };
+
+    const auto it = kUINames.find(nodename);
+    if (it != kUINames.end()) {
+        return it->second;
+    }
+    return {};
+}
+
+} // namespace
+
 std::string sanitizeName(const std::string& name)
 {
     return PXR_NS::TfStringReplace(name, ":", "_");
@@ -31,7 +174,13 @@ std::string sanitizeName(const std::string& name)
 
 std::string prettifyName(const std::string& name)
 {
-    std::string prettyName;
+    // First try our temporarily hardcoded list:
+    std::string prettyName = _getMaterialXUIName(name);
+
+    if (!prettyName.empty()) {
+        return prettyName;
+    }
+
     // Note: slightly over-reserve to account for additional spaces.
     prettyName.reserve(name.size() + 6);
     size_t nbChars = name.size();
@@ -62,23 +211,11 @@ std::string prettifyName(const std::string& name)
         }
     }
     // Manual substitutions for custom capitalisations. Will be searched as case-insensitive.
-    static const std::unordered_map<std::string, std::string> subs
-        = { { "usd", "USD" },
-            { "mtlx", "MaterialX" },
-            { "gltf", "glTF" },
-            { "pbr", "PBR" },
-            { "bsdf", "BSDF" },
-            { "brdf", "BRDF" },
-            { "edf", "EDF" },
-            { "vdf", "VDF" },
-            { "ior", "IOR" },
-            { "srgb", "sRGB" },
-            { "to", "to" },
-            { "pbrlib", "PBR Library" },
-            { "stdlib", "Standard Library" },
-            { "s rg bto", "sRGB to" },
-            { "ace scg", "ACEScg" },
-            { "Open Pbr", "OpenPBR" } };
+    static const std::unordered_map<std::string, std::string> subs = {
+        { "usd", "USD" },
+        { "mtlx", "MaterialX" },
+        { "lookdevx", "LookdevX" },
+    };
 
     static const auto subRegexes = []() {
         std::vector<std::pair<std::regex, std::string>> regexes;

--- a/lib/usdUfe/utils/Utils.cpp
+++ b/lib/usdUfe/utils/Utils.cpp
@@ -42,13 +42,16 @@ std::string prettifyName(const std::string& name)
             if ((i > 0 && (i < (nbChars - 1))
                  && (!std::isupper(name[i + 1]) && !std::isdigit(name[i + 1])))
                 || std::islower(name[i - 1])) {
-                prettyName += ' ';
+                if (prettyName.size() > 0 && prettyName.back() != ' ') {
+                    prettyName += ' ';
+                }
             }
             prettyName += nextLetter;
             capitalizeNext = false;
         } else if (name[i] == '_' || name[i] == ':') {
-            if (prettyName.size() > 0)
+            if (prettyName.size() > 0 && prettyName.back() != ' ') {
                 prettyName += " ";
+            }
             capitalizeNext = true;
         } else {
             if (capitalizeNext) {
@@ -62,8 +65,20 @@ std::string prettifyName(const std::string& name)
     static const std::unordered_map<std::string, std::string> subs
         = { { "usd", "USD" },
             { "mtlx", "MaterialX" },
-            { "gltf pbr", "glTF PBR" },
-            { "Open Pbr Surface", "OpenPBR Surface" } };
+            { "gltf", "glTF" },
+            { "pbr", "PBR" },
+            { "bsdf", "BSDF" },
+            { "brdf", "BRDF" },
+            { "edf", "EDF" },
+            { "vdf", "VDF" },
+            { "ior", "IOR" },
+            { "srgb", "sRGB" },
+            { "to", "to" },
+            { "pbrlib", "PBR Library" },
+            { "stdlib", "Standard Library" },
+            { "s rg bto", "sRGB to" },
+            { "ace scg", "ACEScg" },
+            { "Open Pbr", "OpenPBR" } };
 
     static const auto subRegexes = []() {
         std::vector<std::pair<std::regex, std::string>> regexes;

--- a/test/lib/testAttributeEditorTemplate.py
+++ b/test/lib/testAttributeEditorTemplate.py
@@ -353,10 +353,10 @@ class AttributeEditorTemplateTestCase(unittest.TestCase):
         self.assertIsNotNone(startLayout, 'Could not get full path for Shader formLayout')
         
         if mayaUtils.mayaMajorVersion() > 2024:
-            # We should have a frameLayout called 'Shader: Fractal3d' in the template.
+            # We should have a frameLayout called 'Shader: 3D Fractal Noise' in the template.
             # If there is a scripting error in the template, this layout will be missing.
-            frameLayout = self.searchForMayaControl(startLayout, cmds.frameLayout, 'Shader: Fractal3d')
-            self.assertIsNotNone(frameLayout, 'Could not find "Shader: Fractal3d" frameLayout')
+            frameLayout = self.searchForMayaControl(startLayout, cmds.frameLayout, 'Shader: 3D Fractal Noise')
+            self.assertIsNotNone(frameLayout, 'Could not find "Shader: 3D Fractal Noise" frameLayout')
             
             # We should also have an attribute called 'Amplitude' which has a connection.
             AmplitudeControl = self.searchForMayaControl(frameLayout, cmds.text, 'Amplitude')

--- a/test/lib/testAttributeEditorTemplate.py
+++ b/test/lib/testAttributeEditorTemplate.py
@@ -328,7 +328,7 @@ class AttributeEditorTemplateTestCase(unittest.TestCase):
         self.assertIsNotNone(frameLayout, 'Could not find "Alpha" frameLayout')
         
         # We should also have custom enum control for 'Inputs Alpha Mode'.
-        InputsAlphaModeControl = self.searchForMayaControl(frameLayout, cmds.text, 'Alpha  Mode')
+        InputsAlphaModeControl = self.searchForMayaControl(frameLayout, cmds.text, 'Alpha Mode')
         self.assertIsNotNone(InputsAlphaModeControl, 'Could not find gltf_pbr1 "Alpha Mode" control')
 
     def testAEConnectionsCustomControl(self):

--- a/test/lib/ufe/testAttribute.py
+++ b/test/lib/ufe/testAttribute.py
@@ -1637,9 +1637,10 @@ class AttributeTestCase(unittest.TestCase):
         runMetadataUndoRedo(float, 65.78, 0.567)
         runMetadataUndoRedo(str, 'New doc from command', 'New doc starting value')
 
-    @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 3, 'testMetadata is only available in UFE v3 or greater.')
+    @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 4, 'testUsdNativeMetadata is only available in UFE v4 or greater.')
     def testUsdNativeMetadata(self):
-        '''Test metadata that are native to USD.'''
+        '''Test metadata that are native to USD. 
+           Requires material assignment in context ops, which appeared in UFE v4'''
         cmds.file(new=True, force=True)
 
         # Create a capsule.
@@ -1730,7 +1731,7 @@ class AttributeTestCase(unittest.TestCase):
         self.assertTrue(materialUfeOutput.clearMetadata("uifolder"))
         self.assertTrue(materialUfeOutput.clearMetadata("uiname"))
 
-        # Make it worked:
+        # Make sure it worked:
         self.assertFalse(materialUsdOutput.HasAuthoredDocumentation())
         self.assertFalse(materialUsdOutput.HasMetadata('allowedTokens'))
         self.assertFalse(materialUsdOutput.HasAuthoredDisplayGroup())

--- a/test/lib/ufe/testAttribute.py
+++ b/test/lib/ufe/testAttribute.py
@@ -1912,7 +1912,7 @@ class AttributeTestCase(unittest.TestCase):
         materialItem = rootHier.children()[0]
         
         surfDef = ufe.NodeDef.definition(materialItem.runTimeId(), "ND_standard_surface_surfaceshader")
-        self.assertEqual(str(surfDef.getMetadata("uiname")), "standard_surface")
+        self.assertEqual(str(surfDef.getMetadata("uiname")), "Standard Surface")
         self.assertEqual(str(surfDef.getMetadata("doc")), "Autodesk standard surface shader")
 
         cmd = surfDef.createNodeCmd(materialItem, ufe.PathComponent("MySurf"))
@@ -1984,11 +1984,30 @@ class AttributeTestCase(unittest.TestCase):
         self.assertEqual(mayaUsdUfe.prettifyName("standardSurface"), "Standard Surface")
         self.assertEqual(mayaUsdUfe.prettifyName("USDPreviewSurface"), "USD Preview Surface")
         self.assertEqual(mayaUsdUfe.prettifyName("xformOp:rotateXYZ"), "Xform Op Rotate XYZ")
-        self.assertEqual(mayaUsdUfe.prettifyName("ior"), "Ior")
+        self.assertEqual(mayaUsdUfe.prettifyName("ior"), "IOR")
         self.assertEqual(mayaUsdUfe.prettifyName("IOR"), "IOR")
         self.assertEqual(mayaUsdUfe.prettifyName("specular_IOR"), "Specular IOR")
         self.assertEqual(mayaUsdUfe.prettifyName("HwPtexTexture"), "Hw Ptex Texture")
         self.assertEqual(mayaUsdUfe.prettifyName("fluid2D"), "Fluid2D")
+        # In "_to_USD" we have both an explicit "_" and a lower to upper case
+        # transition. This caused a double space to be inserted but is now fixed.
+        self.assertEqual(mayaUsdUfe.prettifyName("standard_surface_to_UsdPreviewSurface"), "Standard Surface to USD Preview Surface")
+        self.assertEqual(mayaUsdUfe.prettifyName("standard_surface_to_gltf_pbr"), "Standard Surface to glTF PBR")
+        self.assertEqual(mayaUsdUfe.prettifyName("artistic_ior"), "Artistic IOR")
+        self.assertEqual(mayaUsdUfe.prettifyName("stdlib"), "Standard Library")
+        self.assertEqual(mayaUsdUfe.prettifyName("pbrlib"), "PBR Library")
+        self.assertEqual(mayaUsdUfe.prettifyName("burley_diffuse_bsdf"), "Burley Diffuse BSDF")
+        self.assertEqual(mayaUsdUfe.prettifyName("uniform_edf"), "Uniform EDF")
+        self.assertEqual(mayaUsdUfe.prettifyName("anisotropic_vdf"), "Anisotropic VDF")
+        self.assertEqual(mayaUsdUfe.prettifyName("gltf_colorimage"), "glTF Colorimage")
+        self.assertEqual(mayaUsdUfe.prettifyName("disney_brdf_2012"), "Disney BRDF 2012")
+        self.assertEqual(mayaUsdUfe.prettifyName("open_pbr_surface"), "OpenPBR Surface")
+        self.assertEqual(mayaUsdUfe.prettifyName("open_pbr_anisotropy"), "OpenPBR Anisotropy")
+        # Using camelCase mixed with acronyms is the prettyfier worst scenario.
+        # We have one series of MaterialX nodes using this in MayaUSD.
+        self.assertEqual(mayaUsdUfe.prettifyName("sRGBtoACEScg"), "sRGB to ACEScg")
+        self.assertEqual(mayaUsdUfe.prettifyName("srgb_displayp3_to_lin_rec709"), "sRGB Displayp3 to Lin Rec709")
+        
         # This is as expected as we do not insert space on digit<->alpha transitions:
         self.assertEqual(mayaUsdUfe.prettifyName("Dx11Shader"), "Dx11Shader")
         # Explicit substitutions


### PR DESCRIPTION
- Prettify UI names provided by USD that are identical to the family name (for MaterialX shader nodes)
- Do more corrections in the prettifyName function based on observations on the MaterialX library
- Store known USD metadata using Sdf keys instead of Sdr metadata