### PR TITLE
MSVC 2022 compiler fixes + minor correction for older Hydra APIs

### DIFF
--- a/lib/mayaUsd/render/pxrUsdMayaGL/proxyDrawOverride.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/proxyDrawOverride.cpp
@@ -96,7 +96,7 @@ UsdMayaProxyDrawOverride::transform(const MDagPath& objPath, const MDagPath& cam
         GfMatrix4d rootXform(transform.matrix);
 
         MayaUsdProxyShapeBase* pShape = MayaUsdProxyShapeBase::GetShapeAtDagPath(objPath);
-        if (pShape and pShape->usdPrim().GetPath() != SdfPath::AbsoluteRootPath()) {
+        if (pShape && pShape->usdPrim().GetPath() != SdfPath::AbsoluteRootPath()) {
             // If we're not computing the transform of the root of the Usd
             // scene, apply the usdPrim transform from within the scene
             const UsdTimeCode timeCode = pShape->getTime();

--- a/lib/usd/hdMaya/adapters/dagAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/dagAdapter.cpp
@@ -106,7 +106,7 @@ void _InstancerNodeDirty(MObject& node, MPlug& plug, void* clientData)
 
 const auto _instancePrimvarDescriptors = HdPrimvarDescriptorVector { {
 #if HD_API_VERSION < 56
-    HdInstancerTokens->instanceTransform
+    HdInstancerTokens->instanceTransform,
 #else
     HdInstancerTokens->instanceTransforms,
 #endif

--- a/lib/usd/hdMaya/adapters/dagAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/dagAdapter.cpp
@@ -110,7 +110,7 @@ const auto _instancePrimvarDescriptors = HdPrimvarDescriptorVector { {
 #else
     HdInstancerTokens->instanceTransforms,
 #endif
-        HdInterpolationInstance,
+    HdInterpolationInstance,
     HdPrimvarRoleTokens->none } };
 
 } // namespace

--- a/plugin/pxr/maya/lib/usdMaya/translatorModelAssembly.cpp
+++ b/plugin/pxr/maya/lib/usdMaya/translatorModelAssembly.cpp
@@ -235,7 +235,7 @@ bool UsdMayaTranslatorModelAssembly::Create(
 
     if (!assemblyEdits.empty()) {
         std::vector<std::string> failedEdits;
-        const bool               needsLoadAndUnload = not prim.IsLoaded();
+        const bool               needsLoadAndUnload = !prim.IsLoaded();
 
         // the prim must be loaded in order to apply edits.
         if (needsLoadAndUnload) {


### PR DESCRIPTION
Hi, I just have some small fixes when compiling with MSVC 2022 and targetting an older Hydra API (USD 23.02).

First commit has the compiler fixes (changing operator notation `and` to `&&` and `not` to `!`) and the second commit has the comma fix for old hydra APIs.

I used these fixes for `release/v0.29.0` but I thought I'd target the `dev` branch for upstreaming.

Cheers