### PR TITLE
EMSUSD-1467 fix multi-layer parenting

### DIFF
--- a/lib/usdUfe/ufe/trf/UsdTransform3dUndoableCommands.cpp
+++ b/lib/usdUfe/ufe/trf/UsdTransform3dUndoableCommands.cpp
@@ -16,7 +16,9 @@
 
 #include "UsdTransform3dUndoableCommands.h"
 
+#include <usdUfe/base/tokens.h>
 #include <usdUfe/ufe/Utils.h>
+#include <usdUfe/utils/editRouterContext.h>
 
 #include <ufe/transform3d.h>
 
@@ -40,9 +42,13 @@ bool UsdSetMatrix4dUndoableCommand::set(const Ufe::Matrix4d&)
 
 void UsdSetMatrix4dUndoableCommand::executeImplementation()
 {
+    OperationEditRouterContext editContext(
+        EditRoutingTokens->RouteTransform, ufePathToPrim(path()));
+
     // transform3d() and editTransform3d() are equivalent for a normal Maya
     // transform stack, but not for a fallback Maya transform stack, and
     // both can be edited by this command.
+
     auto t3d = Ufe::Transform3d::editTransform3d(sceneItem());
     if (!TF_VERIFY(t3d)) {
         return;

--- a/lib/usdUfe/utils/editRouterContext.cpp
+++ b/lib/usdUfe/utils/editRouterContext.cpp
@@ -49,11 +49,10 @@ StackedEditRouterContext::~StackedEditRouterContext()
 
 const PXR_NS::SdfLayerHandle& StackedEditRouterContext::getLayer() const
 {
-    if (_layer)
-        return _layer;
-
-    if (const StackedEditRouterContext* ctx = GetStackPrevious())
-        return ctx->getLayer();
+    // Use the layer of the top-most edit router context that contains a layer.
+    for (const StackedEditRouterContext* ctx : GetStack())
+        if (ctx->_layer)
+            return ctx->_layer;
 
     static const PXR_NS::SdfLayerHandle empty;
     return empty;
@@ -61,11 +60,13 @@ const PXR_NS::SdfLayerHandle& StackedEditRouterContext::getLayer() const
 
 PXR_NS::UsdStagePtr StackedEditRouterContext::getStage() const
 {
-    if (_stage)
-        return _stage;
-
-    if (const StackedEditRouterContext* ctx = GetStackPrevious())
-        return ctx->getStage();
+    // Use the stage of the top-most edit router context that contains a layer.
+    //
+    // Note: *yes* we check the layer for the stage, it is the layer that can be
+    //       null or not.
+    for (const StackedEditRouterContext* ctx : GetStack())
+        if (ctx->_layer)
+            return ctx->_stage;
 
     return {};
 }

--- a/lib/usdUfe/utils/editRouterContext.h
+++ b/lib/usdUfe/utils/editRouterContext.h
@@ -1,4 +1,4 @@
-//
+    //
 // Copyright 2021 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The parenting code was not copying the data correctly. Changed to use the similar code as in the duplicate command. The duplicate command could not be used because the parenting command targets an arbitrary destination.

Added a unit test that exercises the case where a prim is in multiple layers and targeting the session layer. The old code would lose data.