### PR TITLE
EMSUSD-1432 duplicate materials without meshes

### DIFF
--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -361,12 +361,15 @@ struct UsdMayaJobExportArgs
     std::string GetResolvedFileName() const;
 
     // Verify if meshes are exported. (i.e not excluded by excludeExportTypes)
+    MAYAUSD_CORE_PUBLIC
     bool isExportingMeshes() const;
 
     // Verify if cameras are exported. (i.e not excluded by excludeExportTypes)
+    MAYAUSD_CORE_PUBLIC
     bool isExportingCameras() const;
 
     // Verify if lights are exported. (i.e not excluded by excludeExportTypes)
+    MAYAUSD_CORE_PUBLIC
     bool isExportingLights() const;
 
 private:

--- a/lib/mayaUsd/fileio/jobs/writeJob.h
+++ b/lib/mayaUsd/fileio/jobs/writeJob.h
@@ -55,6 +55,10 @@ public:
     MAYAUSD_CORE_PUBLIC
     const UsdMayaUtil::MDagPathMap<SdfPath>& GetDagPathToUsdPathMap() const;
 
+    // Retrieve all exported material paths.
+    MAYAUSD_CORE_PUBLIC
+    const std::vector<SdfPath>& GetMaterialPaths() { return mJobCtx.GetMaterialPaths(); }
+
 private:
     /// Begins constructing the USD stage, writing out the values at the default
     /// time. Returns \c true if the stage can be created successfully.

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -550,18 +550,27 @@ void fillUserArgsFileIfEmpty(VtDictionary& userArgs, const std::string& fileName
 // source SdfPath and SdfLayer for the next step, push customize.  The source
 // SdfPath will be empty on error.
 using UsdPathToDagPathMap = TfHashMap<SdfPath, MDagPath, SdfPath::Hash>;
-using UsdPathToDagPathMapPtr = std::shared_ptr<UsdPathToDagPathMap>;
-using PushCustomizeSrc
-    = std::tuple<SdfPath, UsdStageRefPtr, SdfLayerRefPtr, UsdPathToDagPathMapPtr>;
+struct PushExportResult
+{
 
-PushCustomizeSrc pushExport(const MObject& mayaObject, const UsdMayaPrimUpdaterContext& context)
+    SdfPath                              srcRootPath;
+    UsdStageRefPtr                       stage;
+    SdfLayerRefPtr                       layer;
+    std::shared_ptr<UsdPathToDagPathMap> usdToDag;
+    std::vector<SdfPath>                 materialPaths;
+};
+
+PushExportResult pushExport(const MObject& mayaObject, const UsdMayaPrimUpdaterContext& context)
 {
     MayaUsd::ProgressBarScope progressBar(3);
 
-    UsdStageRefPtr         srcStage = UsdStage::CreateInMemory();
-    SdfLayerRefPtr         srcLayer = srcStage->GetRootLayer();
-    UsdPathToDagPathMapPtr pathMapPtr;
-    auto pushCustomizeSrc = std::make_tuple(SdfPath(), srcStage, srcLayer, pathMapPtr);
+    UsdStageRefPtr srcStage = UsdStage::CreateInMemory();
+    SdfLayerRefPtr srcLayer = srcStage->GetRootLayer();
+
+    PushExportResult result;
+    result.srcRootPath = SdfPath();
+    result.stage = srcStage;
+    result.layer = srcLayer;
 
     // Copy to be able to add the export root.
     VtDictionary userArgs = context.GetUserArgs();
@@ -582,15 +591,26 @@ PushCustomizeSrc pushExport(const MObject& mayaObject, const UsdMayaPrimUpdaterC
     std::vector<double> timeSamples;
     UsdMayaJobExportArgs::GetDictionaryTimeSamples(userArgs, timeSamples);
 
-    // The pushed Dag node is the root of the export job.
-    std::vector<VtValue> rootPathString(
-        1, VtValue(std::string(dagPath.partialPathName().asChar())));
-    userArgs[UsdMayaJobExportArgsTokens->exportRoots] = rootPathString;
-
-    // This ensures the materials will be under the prim, so that
-    // when exported it is under the node being merged and will thus
-    // be merged too.
-    userArgs[UsdMayaJobExportArgsTokens->legacyMaterialScope] = true;
+    const bool isCopy = context.GetArgs()._copyOperation;
+    if (isCopy) {
+        // Make sure legacy material scope mode is off so that all materials
+        // will be placed under a single parent scope. This important for
+        // material-only duplication op, so that we have a single root node.
+        userArgs[UsdMayaJobExportArgsTokens->legacyMaterialScope] = false;
+        // Make sure we don't have any default prim, otherwise the materials
+        // would be put under it instead of as a root, which would be weird
+        // when doing material-only duplications.
+        userArgs[UsdMayaJobExportArgsTokens->defaultPrim] = "None";
+    } else {
+        // The pushed Dag node is the root of the export job.
+        std::vector<VtValue> rootPathString(
+            1, VtValue(std::string(dagPath.partialPathName().asChar())));
+        userArgs[UsdMayaJobExportArgsTokens->exportRoots] = rootPathString;
+        // Legacy mode ensures the materials will be under the prim, so that
+        // when exported it is under the node being merged and will thus
+        // be merged too.
+        userArgs[UsdMayaJobExportArgsTokens->legacyMaterialScope] = true;
+    }
 
     UsdMayaJobExportArgs jobArgs = UsdMayaJobExportArgs::CreateFromDictionary(
         userArgs, dagPaths, fullObjectList, timeSamples);
@@ -598,22 +618,27 @@ PushCustomizeSrc pushExport(const MObject& mayaObject, const UsdMayaPrimUpdaterC
 
     UsdMaya_WriteJob writeJob(jobArgs);
     if (!writeJob.Write(fileName, false /* append */)) {
-        return pushCustomizeSrc;
+        return result;
     }
     progressBar.advance();
 
-    std::get<SdfPath>(pushCustomizeSrc) = writeJob.MapDagPathToSdfPath(dagPath);
+    result.srcRootPath = writeJob.MapDagPathToSdfPath(dagPath);
+    if (result.srcRootPath.IsEmpty()) {
+        for (const SdfPath& matPath : writeJob.GetMaterialPaths()) {
+            result.srcRootPath = matPath.GetParentPath();
+            break;
+        }
+    }
 
     // Invert the Dag path to USD path map, to return it for prim updater use.
-    auto usdPathToDagPathMap = std::make_shared<UsdPathToDagPathMap>();
+    result.usdToDag = std::make_shared<UsdPathToDagPathMap>();
     for (const auto& v : writeJob.GetDagPathToUsdPathMap()) {
-        usdPathToDagPathMap->insert(UsdPathToDagPathMap::value_type(v.second, v.first));
+        result.usdToDag->insert(UsdPathToDagPathMap::value_type(v.second, v.first));
     }
 
-    std::get<UsdPathToDagPathMapPtr>(pushCustomizeSrc) = usdPathToDagPathMap;
     progressBar.advance();
 
-    return pushCustomizeSrc;
+    return result;
 }
 
 //------------------------------------------------------------------------------
@@ -715,13 +740,13 @@ UsdMayaPrimUpdaterSharedPtr createUpdater(
 // for each updater.
 bool pushCustomize(
     const Ufe::Path&                 ufePulledPath,
-    const PushCustomizeSrc&          src,
+    const PushExportResult&          exportResult,
     const UsdMayaPrimUpdaterContext& context)
 
 {
-    const auto& srcRootPath = std::get<SdfPath>(src);
-    const auto& srcLayer = std::get<SdfLayerRefPtr>(src);
-    const auto& srcStage = std::get<UsdStageRefPtr>(src);
+    const auto& srcRootPath = exportResult.srcRootPath;
+    const auto& srcLayer = exportResult.layer;
+    const auto& srcStage = exportResult.stage;
     if (srcRootPath.IsEmpty() || !srcLayer || !srcStage) {
         return false;
     }
@@ -1111,21 +1136,22 @@ bool PrimUpdaterManager::mergeToUsd(
     //    per-prim customization.
 
     // 1) Perform the export to the temporary layer.
-    auto pushCustomizeSrc = pushExport(depNodeFn.object(), context);
+    PushExportResult pushExportResult = pushExport(depNodeFn.object(), context);
     progressBar.advance();
 
-    const auto& srcDagPathMap = std::get<UsdPathToDagPathMapPtr>(pushCustomizeSrc);
-
-    if (TF_VERIFY(srcDagPathMap)) {
-        const auto& srcRootPath = std::get<SdfPath>(pushCustomizeSrc);
-        const auto  dstRootPath = getDstSdfPath(pulledPath, srcRootPath, isCopy);
-        processPushExtras(context._pushExtras, *srcDagPathMap, srcRootPath, dstRootPath);
+    if (TF_VERIFY(pushExportResult.usdToDag)) {
+        const auto dstRootPath = getDstSdfPath(pulledPath, pushExportResult.srcRootPath, isCopy);
+        processPushExtras(
+            context._pushExtras,
+            *pushExportResult.usdToDag,
+            pushExportResult.srcRootPath,
+            dstRootPath);
     }
 
     // 2) Traverse the in-memory layer, creating a prim updater for each prim,
     // and call Push for each updater.  Build a new context with the USD path
     // to Maya path mapping information.
-    context.SetUsdPathToDagPathMap(srcDagPathMap);
+    context.SetUsdPathToDagPathMap(pushExportResult.usdToDag);
 
     if (!isCopy) {
         if (!FunctionUndoItem::execute(
@@ -1141,7 +1167,7 @@ bool PrimUpdaterManager::mergeToUsd(
     }
     progressBar.advance();
 
-    if (!pushCustomize(pulledPath, pushCustomizeSrc, context)) {
+    if (!pushCustomize(pulledPath, pushExportResult, context)) {
         return false;
     }
     progressBar.advance();
@@ -1556,7 +1582,7 @@ void PrimUpdaterManager::discardPullSetIfEmpty()
     }
 }
 
-bool PrimUpdaterManager::duplicate(
+std::vector<Ufe::Path> PrimUpdaterManager::duplicate(
     const Ufe::Path&    srcPath,
     const Ufe::Path&    dstPath,
     const VtDictionary& userArgs)
@@ -1572,7 +1598,7 @@ bool PrimUpdaterManager::duplicate(
     if (srcProxyShape && dstProxyShape == nullptr) {
         auto srcPrim = MayaUsd::ufe::ufePathToPrim(srcPath);
         if (!srcPrim) {
-            return false;
+            return {};
         }
 
         MayaUsd::ProgressBarScope progressBar(3, "Duplicating to Maya Data");
@@ -1593,7 +1619,7 @@ bool PrimUpdaterManager::duplicate(
         if (!MayaUsd::ufe::isMayaWorldPath(dstPath) && !dstPath.empty()) {
             pullParentPath = MayaUsd::ufe::ufeToDagPath(dstPath);
             if (!pullParentPath.isValid()) {
-                return false;
+                return {};
             }
         }
         ctxArgs[kPullParentPathKey] = VtValue(std::string(pullParentPath.fullPathName().asChar()));
@@ -1603,20 +1629,24 @@ bool PrimUpdaterManager::duplicate(
         context._pullExtras.initRecursive(Ufe::Hierarchy::createItem(srcPath));
         progressBar.advance();
 
-        pullImport(srcPath, srcPrim, context);
+        PullImportPaths importedPaths = pullImport(srcPath, srcPrim, context);
         progressBar.advance();
 
         scopeIt.end();
         executeAdditionalCommands(context);
         progressBar.advance();
 
-        return true;
+        std::vector<Ufe::Path> dstPaths;
+        for (const auto& dagAndUfe : importedPaths)
+            dstPaths.push_back(MayaUsd::ufe::dagPathToUfe(dagAndUfe.first));
+
+        return dstPaths;
     }
     // Copy from DG to USD
     else if (srcProxyShape == nullptr && dstProxyShape) {
         MDagPath dagPath = PXR_NS::UsdMayaUtil::nameToDagPath(Ufe::PathString::string(srcPath));
         if (!dagPath.isValid()) {
-            return false;
+            return {};
         }
 
         MayaUsd::ProgressBarScope progressBar(6, "Duplicating to USD");
@@ -1643,36 +1673,34 @@ bool PrimUpdaterManager::duplicate(
         UsdMayaPrimUpdaterContext context(dstProxyShape->getTime(), dstStage, ctxArgs);
 
         // Export out to a temporary layer.
-        auto        pushExportOutput = pushExport(dagPath.node(), context);
-        const auto& srcRootPath = std::get<SdfPath>(pushExportOutput);
-        if (srcRootPath.IsEmpty()) {
-            return false;
+        PushExportResult pushExportResult = pushExport(dagPath.node(), context);
+        if (pushExportResult.srcRootPath.IsEmpty()) {
+            return {};
         }
         progressBar.advance();
 
         // Copy the temporary layer contents out to the proper destination.
-        const auto& srcStage = std::get<UsdStageRefPtr>(pushExportOutput);
-        const auto& srcLayer = std::get<SdfLayerRefPtr>(pushExportOutput);
+        const auto& srcStage = pushExportResult.stage;
+        const auto& srcLayer = pushExportResult.layer;
         const auto& editTarget = dstStage->GetEditTarget();
         const auto& dstLayer = editTarget.GetLayer();
 
         // Validate that the destination parent prim is valid.
         UsdPrim dstParentPrim = MayaUsd::ufe::ufePathToPrim(dstPath);
         if (!dstParentPrim.IsValid()) {
-            return false;
+            return {};
         }
         progressBar.advance();
 
         // We need the parent path of the source and destination to
         // fixup the paths of the source prims we copy to their
         // destination paths.
-        const SdfPath srcParentPath = srcRootPath.GetParentPath();
+        const SdfPath srcParentPath = pushExportResult.srcRootPath.GetParentPath();
         const SdfPath dstParentPath = dstParentPrim.GetPath();
 
-        const auto& srcPathMapPtr = std::get<UsdPathToDagPathMapPtr>(pushExportOutput);
-
-        if (TF_VERIFY(srcPathMapPtr)) {
-            processPushExtras(context._pushExtras, *srcPathMapPtr, srcParentPath, dstParentPath);
+        if (TF_VERIFY(pushExportResult.usdToDag)) {
+            processPushExtras(
+                context._pushExtras, *pushExportResult.usdToDag, srcParentPath, dstParentPath);
         }
 
         CopyLayerPrimsOptions options;
@@ -1685,7 +1713,7 @@ bool PrimUpdaterManager::duplicate(
             dstStage,
             dstLayer,
             dstParentPath,
-            { srcRootPath },
+            { pushExportResult.srcRootPath },
             options);
 
         context._pushExtras.finalize(MayaUsd::ufe::stagePath(dstStage), copyResult.renamedPaths);
@@ -1700,11 +1728,13 @@ bool PrimUpdaterManager::duplicate(
         executeAdditionalCommands(context);
         progressBar.advance();
 
-        return true;
+        const Ufe::PathSegment pathSegment
+            = UsdUfe::usdPathToUfePathSegment(pushExportResult.srcRootPath);
+        return { Ufe::Path(dstPath + pathSegment) };
     }
 
     // Copy operations to the same data model not supported here.
-    return false;
+    return {};
 }
 
 void PrimUpdaterManager::onProxyContentChanged(

--- a/lib/mayaUsd/fileio/primUpdaterManager.h
+++ b/lib/mayaUsd/fileio/primUpdaterManager.h
@@ -65,8 +65,9 @@ public:
     bool discardEdits(const MDagPath& dagPath);
 
     /// \brief Copy USD data into USD or Maya data.
+    /// \return list of destination paths.
     MAYAUSD_CORE_PUBLIC
-    bool duplicate(
+    std::vector<Ufe::Path> duplicate(
         const Ufe::Path&    srcPath,
         const Ufe::Path&    dstPath,
         const VtDictionary& userArgs = VtDictionary());

--- a/lib/mayaUsd/fileio/shading/shadingModeExporter.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporter.cpp
@@ -128,9 +128,12 @@ void UsdMayaShadingModeExporter::DoExport(
         SdfPathSet       boundPrimPaths;
         Export(context, &mat, &boundPrimPaths);
 
-        if (mat && !boundPrimPaths.empty()) {
+        if (mat) {
+            writeJobContext.AddMaterialPath(mat.GetPath());
             exportedMaterials.push_back(mat);
-            matAssignments.push_back(std::make_pair(_GetCollectionName(mat), boundPrimPaths));
+            if (!boundPrimPaths.empty()) {
+                matAssignments.push_back(std::make_pair(_GetCollectionName(mat), boundPrimPaths));
+            }
         }
         shadingEngineLoop.loopAdvance();
     }

--- a/lib/mayaUsd/fileio/writeJobContext.h
+++ b/lib/mayaUsd/fileio/writeJobContext.h
@@ -135,6 +135,12 @@ public:
         const VtVec3fArray& bbox,
         const UsdTimeCode&  timeSample);
 
+    // Add the path to an exported material.
+    void AddMaterialPath(const SdfPath& matPath) { _materialPaths.emplace_back(matPath); }
+
+    // Retrieve all exported material paths.
+    const std::vector<SdfPath>& GetMaterialPaths() { return _materialPaths; }
+
 protected:
     /// Opens the stage with the given \p filename for writing.
     /// If \p append is \c true, the file must already exist.
@@ -218,6 +224,8 @@ private:
     // some types not resolved by the UsdMayaPrimWriterRegistry will get
     // resolved in this map).
     std::map<std::string, UsdMayaPrimWriterRegistry::WriterFactoryFn> mWriterFactoryCache;
+
+    std::vector<SdfPath> _materialPaths;
 
     // UsdMaya_InstancedNodeWriter is in a separate file, but functions as
     // an internal helper for UsdMayaWriteJobContext.

--- a/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
+++ b/lib/mayaUsd/python/wrapPrimUpdaterManager.cpp
@@ -89,7 +89,7 @@ bool discardEdits(const std::string& nodeName)
     return PrimUpdaterManager::getInstance().discardEdits(dagPath);
 }
 
-bool duplicate(
+std::string duplicate(
     const std::string&  srcUfePathString,
     const std::string&  dstUfePathString,
     const VtDictionary& userArgs = VtDictionary())
@@ -101,9 +101,13 @@ bool duplicate(
         = dstUfePathString.empty() ? Ufe::Path() : Ufe::PathString::path(dstUfePathString);
 
     if (src.empty() && dst.empty())
-        return false;
+        return {};
 
-    return PrimUpdaterManager::getInstance().duplicate(src, dst, userArgs);
+    auto dstUfePaths = PrimUpdaterManager::getInstance().duplicate(src, dst, userArgs);
+    if (dstUfePaths.size() <= 0)
+        return {};
+
+    return Ufe::PathString::string(dstUfePaths[0]);
 }
 
 BOOST_PYTHON_FUNCTION_OVERLOADS(duplicate_overloads, duplicate, 2, 3)

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -18,7 +18,6 @@
 global string $gMayaUsdTranslatorExport_SectionNames[];
 global int $exportAll;
 global int $gMayaUsdTranslatorExport_useShadingRegistry = 1;
-global int $gMayaUsdTranslatorExport_MaterialsOnlyIfMeshes = 0;
 
 proc string stringRemoveSuffix(string $object, string $suffix)
 {
@@ -355,19 +354,6 @@ global proc mayaUsdTranslatorExport_MaterialsCB() {
         return;
     
     int $enable = `checkBoxGrp -q -v1 exportMaterialsCheckBox`;
-
-    // If materials export is linked to meshes export, then we disable
-    // all materials-related check-boxes when meshes are off. This is
-    // used in duplicate-to-USD to not duplicate materials without meshes.
-    global int $gMayaUsdTranslatorExport_MaterialsOnlyIfMeshes;
-    if ($gMayaUsdTranslatorExport_MaterialsOnlyIfMeshes) {
-        int $meshesEnable = `checkBoxGrp -q -v1 exportMeshesCheckBox`;
-        columnLayout -e -enable $meshesEnable materialOptsCol2;
-        columnLayout -e -enable $meshesEnable materialOptsCol;
-        if ($meshesEnable == 0) {
-            $enable = 0;
-        }
-    }
 
     mayaUsdTranslatorExport_updateDefaultPrimList();
     columnLayout -e -enable $enable materialOptsCol;
@@ -1103,7 +1089,6 @@ global proc int mayaUsdTranslatorExport (string $parent,
     // check for export option box window first, if it doesn't exist means user opened the main export window
     global string $gOptionBox;
     global int $exportAll;
-    global int $gMayaUsdTranslatorExport_MaterialsOnlyIfMeshes;
     
     if (`window -exists $gOptionBox`) {
         string $title = `window -query -title $gOptionBox`;
@@ -1146,10 +1131,8 @@ global proc int mayaUsdTranslatorExport (string $parent,
         // Adjust options related to which operation is being done:
         // export, duplicate-to-USD or merge=to-USD.
         int $canExportStagesAsRefs = 1;
-        $gMayaUsdTranslatorExport_MaterialsOnlyIfMeshes = 0;
         
         if (stringArrayContains("duplicate", $sectionNames)) {
-            $gMayaUsdTranslatorExport_MaterialsOnlyIfMeshes = 1;
             $canExportStagesAsRefs = 0;
         }
 

--- a/test/lib/mayaUsd/fileio/testDuplicateAs.py
+++ b/test/lib/mayaUsd/fileio/testDuplicateAs.py
@@ -370,7 +370,7 @@ class DuplicateAsTestCase(unittest.TestCase):
         cmds.mayaUsdDuplicate(cmds.ls(sphere, long=True)[0], psPathStr)
 
         # Verify that the copied sphere has a look (material) prim.
-        looksPrim = stage.GetPrimAtPath("/pSphere1/Looks")
+        looksPrim = stage.GetPrimAtPath("/Looks")
         self.assertTrue(looksPrim.IsValid())
 
         # Undo duplicate to USD.
@@ -382,6 +382,40 @@ class DuplicateAsTestCase(unittest.TestCase):
         # Verify that the copied sphere does not have a look (material) prim.
         looksPrim = stage.GetPrimAtPath("/pSphere1/Looks")
         self.assertFalse(looksPrim.IsValid())
+        looksPrim = stage.GetPrimAtPath("/Looks")
+        self.assertFalse(looksPrim.IsValid())
+
+
+    def testDuplicateWithoutMeshes(self):
+        '''Duplicate a Maya sphere without the meshes, only materials.'''
+
+        # Create a sphere.
+        sphere = cmds.polySphere(r=1)
+
+        # Create a stage to receive the USD duplicate.
+        psPathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        stage = mayaUsd.lib.GetPrim(psPathStr).GetStage()
+        
+        # Duplicate Maya data as USD data with meshes
+        cmds.mayaUsdDuplicate(cmds.ls(sphere, long=True)[0], psPathStr)
+
+        # Verify that the both the sphere and material were copied.
+        looksPrim = stage.GetPrimAtPath("/Looks")
+        self.assertTrue(looksPrim.IsValid())
+        spherePrim = stage.GetPrimAtPath("/pSphere1")
+        self.assertTrue(spherePrim.IsValid())
+
+        # Undo duplicate to USD.
+        cmds.undo()
+
+        # Duplicate Maya data as USD data without meshes
+        cmds.mayaUsdDuplicate(cmds.ls(sphere, long=True)[0], psPathStr, exportOptions='excludeExportTypes=[Mesh]')
+
+        # Verify that the material was copied but not the sphere.
+        looksPrim = stage.GetPrimAtPath("/Looks")
+        self.assertTrue(looksPrim.IsValid())
+        spherePrim = stage.GetPrimAtPath("/pSphere1")
+        self.assertFalse(spherePrim.IsValid())
 
 
     def testDuplicateUsingOptions(self):
@@ -423,7 +457,7 @@ class DuplicateAsTestCase(unittest.TestCase):
         cmds.mayaUsdDuplicate(cmds.ls(sphere, long=True)[0], psPathStr, exportOptions=modifiedDuplicateAsUsdDataOptions)
 
         # Verify that the copied sphere has a look (material) prim.
-        looksPrim = stage.GetPrimAtPath("/pSphere1/Looks")
+        looksPrim = stage.GetPrimAtPath("/Looks")
         self.assertTrue(looksPrim.IsValid())
 
         # Restore default options


### PR DESCRIPTION
- Keep track of the exported material paths in the write job and write job context.
- No longer disable material UI when not exporting meshes in duplicate mode.
- Add the exported material to the write job in the shading engine.
- Cleanup the result of the export in the prim updater manager.
- When copying to USD, make sure we don't use legacy mode and have no default prim.
- Make the duplicate command and function return the list of duplicated destinations.
- This fixes the problem that the destination of duplicating without meshes cannot be known in advance.
- Add unit test for duplication without meshes but with materials.