### PR TITLE
EMSUSD-1498 - Add fallback light type for unsupported lights

### DIFF
--- a/lib/mayaUsd/ufe/UsdLight.cpp
+++ b/lib/mayaUsd/ufe/UsdLight.cpp
@@ -102,7 +102,8 @@ Ufe::Light::Type UsdLight::type() const
                                                               : Ufe::Light::Point;
     }
 
-    return Ufe::Light::Invalid;
+    // In case of unknown light type, fallback to point light
+    return Ufe::Light::Point;
 }
 
 float getLightIntensity(const UsdPrim& prim)


### PR DESCRIPTION
Invalid light types will fall back to point like as shown below
![image](https://github.com/user-attachments/assets/4e978873-7192-4eed-9ac8-861513cde609)
