### PR TITLE
EMSUSD-1527 support selection in duplicate to USD

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -1657,6 +1657,10 @@ std::vector<Ufe::Path> PrimUpdaterManager::duplicate(
         //       on the root prim.
         ctxArgs[UsdMayaJobExportArgsTokens->disableModelKindProcessor] = true;
 
+        // Setting the export-selected flag will allow filtering materials so that
+        // only materials in the prim selected to be copied will be included.
+        ctxArgs[UsdMayaJobExportArgsTokens->exportSelected] = true;
+
         const UsdStageRefPtr  dstStage = dstProxyShape->getUsdStage();
         const SdfLayerHandle& layer = dstStage->GetEditTarget().GetLayer();
         if (!layer->IsAnonymous())
@@ -1705,6 +1709,7 @@ std::vector<Ufe::Path> PrimUpdaterManager::duplicate(
 
         CopyLayerPrimsOptions options;
         options.progressBar = &progressBar;
+        options.mergeScopes = true;
 
         CopyLayerPrimsResult copyResult = copyLayerPrims(
             srcStage,

--- a/lib/mayaUsd/utils/copyLayerPrims.h
+++ b/lib/mayaUsd/utils/copyLayerPrims.h
@@ -36,6 +36,11 @@ struct CopyLayerPrimsOptions
     // and the targets of the relations will also get copied.
     bool followRelationships = true;
 
+    // When enabled, if a scope collides with an existing scope, don't
+    // rename the scope, merge them instead. This allows copying multiple
+    // items under the same base tree without multiplying the tree branches.
+    bool mergeScopes = false;
+
     // Optional progress bar.
     MayaUsd::ProgressBarScope* progressBar = nullptr;
 };

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -667,17 +667,49 @@ global proc mayaUsdMenu_duplicateToUSD( string $proxy, string $obj )
     if (!hasPrimUpdater())
         return;
 
+    // Convert proxy to long form.
+    {
+        string $proxyLong[] = `ls -l $proxy`;
+        if (size($proxyLong) == 0)
+            return;
+        $proxy = $proxyLong[0];
+    }
+
+    string $bulkObjects[];
+
+    // Convert selection to long form.
+    string $sel[] = `ls -sl`;
+    for ($i = 0; $i < size($sel); $i++) {
+        string $objLong[] = `ls -l $sel[$i]`;
+        if (size($objLong))
+            $sel[$i] = $objLong[0];
+    }
+
     if (size($obj) == 0) {
-        string $sel[] = `ls -sl`;
-        if (size($sel)) {
-            $obj = $sel[0];
+        $bulkObjects = $sel;
+    } else {
+        // Convert object to long form.
+        {
+            string $objLong[] = `ls -l $obj`;
+            if (size($objLong))
+                $obj = $objLong[0];
+        }
+        int $found = 0;
+        for ($item in $sel) {
+            if ($item == $obj) {
+                $found = 1;
+            }
+        }
+        if ($found) {
+            $bulkObjects = $sel;
+        } else {
+            $bulkObjects = { $obj };
         }
     }
-    string $objLong[] = `ls -l $obj`;
-    string $proxyLong[] = `ls -l $proxy`;
-    if (size($objLong) && size($proxyLong)) {
+
+    for ($item in $bulkObjects) {
         string $exportOptions = `python("import mayaUsdDuplicateAsUsdDataOptions; import mayaUsdOptions; mayaUsdOptions.setAnimateOption('''" + $obj + "''', mayaUsdDuplicateAsUsdDataOptions.getDuplicateAsUsdDataOptionsText())")`;
-        mayaUsdDuplicate -exportOptions $exportOptions $objLong[0] $proxyLong[0];
+        mayaUsdDuplicate -exportOptions $exportOptions $item $proxy;
     }
 }
 


### PR DESCRIPTION
- Add an option to the copyLayerPrims function to merge the top USD scope instead of creating new ones.
- This allows copying multiple prims with a common root tree without adding new branch every time.
- This is useful when duplicating materials only because each one creates a "mtl" scope to contain itself. With this change, all material will be under a common "mtl" scope instead of having a different scope for each.
- Make use of that mode in the duplicate code. Also, make sure we set the export selected flag so that it only duplicate materials in the selected Maya nodes.
- Modify the duplicate menu handler to parse the whole selection if the clicked object is in the selection.
- Add a unit test.