### PR TITLE
Remove matrix multiply operator overloads that potentially lose

### DIFF
--- a/lib/usd/hdMaya/adapters/directionalLightAdapter.cpp
+++ b/lib/usd/hdMaya/adapters/directionalLightAdapter.cpp
@@ -50,7 +50,7 @@ public:
     {
         // Directional lights point toward -Z, but we need the opposite
         // for the position so the light acts as a directional light.
-        const auto direction = GfVec4f(0.0, 0.0, 1.0, 0.0) * GetTransform();
+        const GfVec4f direction(GfVec4f(0.0, 0.0, 1.0, 0.0) * GetTransform());
         light.SetHasShadow(true);
         light.SetPosition({ direction[0], direction[1], direction[2], 0.0f });
     }


### PR DESCRIPTION
precision

The overloads of the methods that take and return a GfVec3f can cause inadvertent loss of precision. This change updates call sites where the result of a call to one of these overloads now needs to be converted to GfVec3f. The advantage of requiring these conversions is that the loss of precision is explicit.