### PR TITLE
EMSUSD-1477 merge job context arguments with user arguments

### DIFF
--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -430,6 +430,111 @@ std::set<unsigned int> _FilteredTypeIds(const VtDictionary& userArgs)
     return result;
 }
 
+std::vector<VtValue>
+_MergeVectors(const std::vector<VtValue>& existingValues, const std::vector<VtValue>& newValues)
+{
+    std::vector<VtValue> resultValues = existingValues;
+
+    for (const VtValue& element : newValues) {
+        if (element.IsHolding<std::vector<VtValue>>()) {
+            // vector<vector<string>> is common for chaserArgs and shadingModes
+            auto findElement = [&element](const VtValue& a) {
+                return UsdUfe::compareValues(element, a) == UsdUfe::DiffResult::Same;
+            };
+            if (std::find_if(resultValues.begin(), resultValues.end(), findElement)
+                == resultValues.end()) {
+                resultValues.push_back(element);
+            }
+        } else {
+            if (std::find(resultValues.begin(), resultValues.end(), element)
+                == resultValues.end()) {
+                resultValues.push_back(element);
+            }
+        }
+    }
+
+    return resultValues;
+}
+
+bool _MergeVectors(
+    const VtValue& existingValue,
+    const VtValue& newValue,
+    VtValue&       resultValue,
+    bool           allowConflicts)
+{
+    if (!newValue.IsHolding<std::vector<VtValue>>()) {
+        return allowConflicts;
+    }
+
+    resultValue = _MergeVectors(
+        existingValue.UncheckedGet<std::vector<VtValue>>(),
+        newValue.UncheckedGet<std::vector<VtValue>>());
+
+    return true;
+}
+
+// Merge into the existing dictionary but does *not* over-write existing values.
+// Record the source name of new values in the given map.
+// (It maps value names to the dictionary name where they were initially found.)
+// Conflicting values will be reported and return false if conflicts are not allowed.
+// Conflicting values will be ignored if conflicts are allowed.
+bool _MergeDictionaries(
+    VtDictionary&                       existingDict,
+    std::map<std::string, std::string>& existingSourceNames,
+    const VtDictionary&                 newDict,
+    const std::string&                  newDictName,
+    bool                                allowConflicts)
+{
+    bool allMergeOK = true;
+
+    for (auto const& dictTuple : newDict) {
+        const std::string& valueName = dictTuple.first;
+        const VtValue&     newValue = dictTuple.second;
+
+        auto existingValueIter = existingDict.find(valueName);
+        if (existingValueIter == existingDict.end()) {
+            // New value, no need to merge of manage conflicts.
+            existingDict[valueName] = newValue;
+            existingSourceNames[valueName] = newDictName;
+            continue;
+        }
+
+        // We have already seen this argument from another jobContext. Look for conflicts:
+        const VtValue& existingValue = existingValueIter->second;
+
+        if (existingValue.IsHolding<std::vector<VtValue>>()) {
+            VtValue mergedValue;
+            if (_MergeVectors(existingValue, newValue, mergedValue, allowConflicts)) {
+                existingDict[valueName] = mergedValue;
+            } else if (!allowConflicts) {
+                // We have both an array and a scalar under the same argument name.
+                const std::string& existingDictName = existingSourceNames[valueName];
+                TF_RUNTIME_ERROR(TfStringPrintf(
+                    "Context '%s' and context '%s' do not agree on type of argument '%s'.",
+                    newDictName.c_str(),
+                    existingDictName.c_str(),
+                    valueName.c_str()));
+                allMergeOK = false;
+            }
+        } else {
+            // Scalar value already exists. Check for value conflicts:
+            if (existingValue != newValue) {
+                if (!allowConflicts) {
+                    const std::string& existingDictName = existingSourceNames[valueName];
+                    TF_RUNTIME_ERROR(TfStringPrintf(
+                        "Context '%s' and context '%s' do not agree on argument '%s'.",
+                        newDictName.c_str(),
+                        existingDictName.c_str(),
+                        valueName.c_str()));
+                    allMergeOK = false;
+                }
+            }
+        }
+    }
+
+    return allMergeOK;
+}
+
 // Merges all the jobContext arguments dictionaries found while exploring the jobContexts into a
 // single one. Also checks for conflicts and errors.
 //
@@ -440,14 +545,19 @@ std::set<unsigned int> _FilteredTypeIds(const VtDictionary& userArgs)
 // Outputs:
 // allContextArgs: dictionary of all extra jobContext arguments merged together.
 // return value: true if the merge was successful, false if a conflict or an error was detected.
-bool _MergeJobContexts(bool isExport, const VtDictionary& userArgs, VtDictionary& allContextArgs)
+bool _MergeJobContexts(
+    bool                                isExport,
+    const VtDictionary&                 userArgs,
+    std::map<std::string, std::string>& argInitialSource,
+    VtDictionary&                       allContextArgs)
 {
     // List of all argument dictionaries found while exploring jobContexts
     std::vector<VtDictionary> contextArgs;
 
     bool canMergeContexts = true;
 
-    // This first loop gathers all job context argument dictionaries found in the userArgs
+    // This first loop gathers all job context argument dictionaries found in the userArgs.
+    // The job context provides their desired arguments through their callback.
     const TfToken& jcKey = UsdMayaJobExportArgsTokens->jobContext;
     if (VtDictionaryIsHolding<std::vector<VtValue>>(userArgs, jcKey)) {
         for (const VtValue& v : VtDictionaryGet<std::vector<VtValue>>(userArgs, jcKey)) {
@@ -487,10 +597,6 @@ bool _MergeJobContexts(bool isExport, const VtDictionary& userArgs, VtDictionary
         }
     }
 
-    // Convenience map holding the jobContext that first introduces an argument to the final
-    // dictionary. Allows printing meaningful error messages.
-    std::map<std::string, std::string> argInitialSource;
-
     // Traverse argument dictionaries and look for merge conflicts while building the returned
     // allContextArgs.
     for (auto const& dict : contextArgs) {
@@ -498,68 +604,46 @@ bool _MergeJobContexts(bool isExport, const VtDictionary& userArgs, VtDictionary
         const std::string& sourceName = VtDictionaryGet<std::vector<VtValue>>(dict, jcKey)
                                             .front()
                                             .UncheckedGet<std::string>();
-        for (auto const& dictTuple : dict) {
-            const std::string& k = dictTuple.first;
-            const VtValue&     v = dictTuple.second;
 
-            auto allContextIt = allContextArgs.find(k);
-            if (allContextIt == allContextArgs.end()) {
-                // First time we see this argument. Store and remember source.
-                allContextArgs[k] = v;
-                argInitialSource[k] = sourceName;
-            } else {
-                // We have already seen this argument from another jobContext. Look for conflicts:
-                const VtValue& allContextValue = allContextIt->second;
-
-                if (allContextValue.IsHolding<std::vector<VtValue>>()) {
-                    if (v.IsHolding<std::vector<VtValue>>()) {
-                        // We merge arrays:
-                        std::vector<VtValue> mergedValues
-                            = allContextValue.UncheckedGet<std::vector<VtValue>>();
-                        for (const VtValue& element : v.UncheckedGet<std::vector<VtValue>>()) {
-                            if (element.IsHolding<std::vector<VtValue>>()) {
-                                // vector<vector<string>> is common for chaserArgs and shadingModes
-                                auto findElement = [&element](const VtValue& a) {
-                                    return UsdUfe::compareValues(element, a)
-                                        == UsdUfe::DiffResult::Same;
-                                };
-                                if (std::find_if(
-                                        mergedValues.begin(), mergedValues.end(), findElement)
-                                    == mergedValues.end()) {
-                                    mergedValues.push_back(element);
-                                }
-                            } else {
-                                if (std::find(mergedValues.begin(), mergedValues.end(), element)
-                                    == mergedValues.end()) {
-                                    mergedValues.push_back(element);
-                                }
-                            }
-                        }
-                        allContextArgs[k] = mergedValues;
-                    } else {
-                        // We have both an array and a scalar under the same argument name.
-                        TF_RUNTIME_ERROR(TfStringPrintf(
-                            "Context '%s' and context '%s' do not agree on type of argument '%s'.",
-                            sourceName.c_str(),
-                            argInitialSource[k].c_str(),
-                            k.c_str()));
-                        canMergeContexts = false;
-                    }
-                } else {
-                    // Scalar value already exists. Check for value conflicts:
-                    if (allContextValue != v) {
-                        TF_RUNTIME_ERROR(TfStringPrintf(
-                            "Context '%s' and context '%s' do not agree on argument '%s'.",
-                            sourceName.c_str(),
-                            argInitialSource[k].c_str(),
-                            k.c_str()));
-                        canMergeContexts = false;
-                    }
-                }
-            }
-        }
+        const bool allowConflicts = false;
+        if (!_MergeDictionaries(allContextArgs, argInitialSource, dict, sourceName, allowConflicts))
+            canMergeContexts = false;
     }
     return canMergeContexts;
+}
+
+VtDictionary
+_MergeAllArguments(bool isExport, const VtDictionary& userArgs, const VtDictionary& defaultsArgs)
+{
+    // This will contain user argumentss, default arguments and job-context arguments
+    // all merged together.
+    VtDictionary allArgs;
+
+    // Convenience map holding the job-context that first introduces an argument to the final
+    // dictionary. Allows printing meaningful error messages.
+    std::map<std::string, std::string> argSources;
+
+    // First we merge all job context arguments for all job contexts that were given in
+    // the "jobContext" entry of the user arguments dictionary.
+    if (!_MergeJobContexts(isExport, userArgs, argSources, allArgs)) {
+        MGlobal::displayWarning("Errors while processing job contexts. Using base options.");
+        return VtDictionaryOver(userArgs, defaultsArgs);
+    }
+
+    // We now merge user argument with the default values over the job-context arguments.
+    // The job-context values have priority and we allow conflicting values. (After all,
+    // one of the *goal* of the job context is to provide specific, different defaults
+    // for import/export options than the default options.)
+    const VtDictionary withDefaults = VtDictionaryOver(userArgs, defaultsArgs);
+    const std::string  userArgsName = "user arguments";
+
+    const bool allowConflicts = true;
+    if (!_MergeDictionaries(allArgs, argSources, withDefaults, userArgsName, allowConflicts)) {
+        MGlobal::displayWarning(
+            "Errors while merging job contexts with user arguments. Using base options.");
+    }
+
+    return allArgs;
 }
 
 bool _GetEncodedArg(const MString& option, std::string& argName, MString& argValue)
@@ -847,17 +931,10 @@ UsdMayaJobExportArgs UsdMayaJobExportArgs::CreateFromDictionary(
     const MSelectionList&           fullList,
     const std::vector<double>&      timeSamples)
 {
-    VtDictionary allUserArgs = VtDictionaryOver(userArgs, GetDefaultDictionary());
-    VtDictionary allContextArgs;
+    const bool         isExport = true;
+    const VtDictionary allArgs = _MergeAllArguments(isExport, userArgs, GetDefaultDictionary());
 
-    if (_MergeJobContexts(true, userArgs, allContextArgs)) {
-        allUserArgs = VtDictionaryOver(allContextArgs, allUserArgs);
-    } else {
-        MGlobal::displayWarning(
-            "Errors while processing export contexts. Using base export options.");
-    }
-
-    return UsdMayaJobExportArgs(allUserArgs, dagPaths, fullList, timeSamples);
+    return UsdMayaJobExportArgs(allArgs, dagPaths, fullList, timeSamples);
 }
 
 /* static */
@@ -1291,17 +1368,10 @@ UsdMayaJobImportArgs UsdMayaJobImportArgs::CreateFromDictionary(
     const bool          importWithProxyShapes,
     const GfInterval&   timeInterval)
 {
-    VtDictionary allUserArgs = VtDictionaryOver(userArgs, GetDefaultDictionary());
-    VtDictionary allContextArgs;
+    const bool         isExport = false;
+    const VtDictionary allArgs = _MergeAllArguments(isExport, userArgs, GetDefaultDictionary());
 
-    if (_MergeJobContexts(false, userArgs, allContextArgs)) {
-        allUserArgs = VtDictionaryOver(allContextArgs, allUserArgs);
-    } else {
-        MGlobal::displayWarning(
-            "Errors while processing import contexts. Using base import options.");
-    }
-
-    return UsdMayaJobImportArgs(allUserArgs, importWithProxyShapes, timeInterval);
+    return UsdMayaJobImportArgs(allArgs, importWithProxyShapes, timeInterval);
 }
 
 /* static */


### PR DESCRIPTION
The VRay plugin provides the chaser name by the user arguments instead of returning it in the plug-in job-context callback. (How they inject the chaser name in the arguments is still a mystery.)

The code used to overwrite such user arguments with the job-context arguments. (By calling VtDictionaryOver.) Now we instead merge the dictionaries with code refactored from the code used to merge job context arguments.

Do the same for the import context.