### PR TITLE
EMSUSD-1496 export stages as relative references

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -932,7 +932,8 @@ void LayerDatabase::convertAnonymousLayers(
         const bool wasTargetLayer = (stage->GetEditTarget().GetLayer() == root);
         PXR_NS::SdfFileFormat::FileFormatArguments args;
         std::string newFileName = MayaUsd::utils::generateUniqueFileName(proxyName);
-        if (UsdMayaUtilFileSystem::requireUsdPathsRelativeToMayaSceneFile()) {
+        const bool  isRelative = UsdMayaUtilFileSystem::requireUsdPathsRelativeToMayaSceneFile();
+        if (isRelative) {
             newFileName = UsdMayaUtilFileSystem::getPathRelativeToMayaSceneFile(newFileName);
         }
         if (!MayaUsd::utils::saveLayerWithFormat(root, newFileName)) {
@@ -944,7 +945,11 @@ void LayerDatabase::convertAnonymousLayers(
 
         SdfLayerRefPtr newLayer = SdfLayer::FindOrOpen(newFileName);
         MayaUsd::utils::setNewProxyPath(
-            pShape->name(), UsdMayaUtil::convert(newFileName), newLayer, wasTargetLayer);
+            pShape->name(),
+            UsdMayaUtil::convert(newFileName),
+            isRelative ? MayaUsd::utils::kProxyPathRelative : MayaUsd::utils::kProxyPathAbsolute,
+            newLayer,
+            wasTargetLayer);
     }
 
     SdfLayerHandle session = stage->GetSessionLayer();

--- a/lib/mayaUsd/utils/utilSerialization.h
+++ b/lib/mayaUsd/utils/utilSerialization.h
@@ -64,6 +64,33 @@ enum USDUnsavedEditsOption
 MAYAUSD_CORE_PUBLIC
 USDUnsavedEditsOption serializeUsdEditsLocationOption();
 
+/*! \brief Return if the relative-path plug is set to true on the proxy shape.
+ */
+MAYAUSD_CORE_PUBLIC
+bool isProxyShapePathRelative(MayaUsdProxyShapeBase& proxyShape);
+
+/*! \brief File path mode for the setNewProxyPath and isProxyPathModeRelative functions.
+ *         kProxyPathRelative makes the file path relative to the Maya scene.
+ *         kProxyPathAbsolute makes the file path absolute.
+ *         kProxyPathFollowProxyShape reads the relative-path plug of the proxy shape
+ *                                    to decide.
+ *         kProxyPathFollowOptionVar reads the mayaUsd_MakePathRelativeToSceneFile
+ *                                   options to decide.
+ */
+enum ProxyPathMode
+{
+    kProxyPathRelative,
+    kProxyPathAbsolute,
+    kProxyPathFollowProxyShape,
+    kProxyPathFollowOptionVar
+};
+
+/*! \brief Convert the proxy path mode into a boolean telling if the path should be relative.
+ *  \note the proxy node name is only required for the kProxyPathFollowProxyShape mode.
+ */
+MAYAUSD_CORE_PUBLIC
+bool isProxyPathModeRelative(ProxyPathMode proxyPathMode, const MString& proxyNodeName);
+
 /*! \brief Utility function to update the file path attribute on the proxy shape
     when an anonymous root layer gets exported to disk. Also optionally updates
     the target layer if the anonymous layer was the target layer.
@@ -72,6 +99,7 @@ MAYAUSD_CORE_PUBLIC
 void setNewProxyPath(
     const MString&        proxyNodeName,
     const MString&        newValue,
+    ProxyPathMode         proxyPathMode,
     const SdfLayerRefPtr& layer,
     bool                  isTargetLayer);
 

--- a/lib/usd/translators/stageWriter.cpp
+++ b/lib/usd/translators/stageWriter.cpp
@@ -23,6 +23,7 @@
 #include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/utils/util.h>
 #include <mayaUsd/utils/utilFileSystem.h>
+#include <mayaUsd/utils/utilSerialization.h>
 
 #include <pxr/base/gf/vec2f.h>
 #include <pxr/base/tf/diagnostic.h>
@@ -52,17 +53,6 @@ void reportWarning(const char* msg, const MDagPath& dagPath)
     MString formatted;
     formatted.format(msg, dagPath.fullPathName());
     MGlobal::displayWarning(formatted);
-}
-
-bool isProxyShapeRelative(MayaUsdProxyShapeBase& proxyShape)
-{
-    MStatus           status;
-    MFnDependencyNode depNode(proxyShape.thisMObject(), &status);
-    if (!status)
-        return false;
-
-    MPlug filePathRelativePlug = depNode.findPlug(MayaUsdProxyShapeBase::filePathRelativeAttr);
-    return filePathRelativePlug.asBool();
 }
 
 std::string getUsdRefIdentifier(const UsdStage& stage, const MDagPath& dagPath)
@@ -171,7 +161,7 @@ void PxrUsdTranslators_StageWriter::Write(const UsdTimeCode& usdTime)
         return;
     }
 
-    if (isProxyShapeRelative(*proxyShape)) {
+    if (MayaUsd::utils::isProxyShapePathRelative(*proxyShape)) {
         std::string baseDir = UsdMayaUtilFileSystem::getDir(_GetExportArgs().file);
         refIdentifier = UsdMayaUtilFileSystem::makePathRelativeTo(refIdentifier, baseDir).first;
     }

--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -406,7 +406,8 @@ void MayaSessionState::rootLayerPathChanged(std::string const& in_path)
     if (!_currentStageEntry._proxyShapePath.empty()) {
         MString proxyShape(_currentStageEntry._proxyShapePath.c_str());
         MString newValue(in_path.c_str());
-        MayaUsd::utils::setNewProxyPath(proxyShape, newValue, nullptr, false);
+        MayaUsd::utils::setNewProxyPath(
+            proxyShape, newValue, MayaUsd::utils::kProxyPathFollowProxyShape, nullptr, false);
     }
 }
 


### PR DESCRIPTION
The problem was that the fact that the stage root layer was a relative path was lost when saved mid-export. Change the code so that the knowledge of the user's choice is always correctly preserved. Then the exported stage can correctly detect that the file path is relative.

- Add a function to check if a proxy shape is holding the file path as relative.
- Modify the setNewProxyPath function to take a flag to control if the new path is relative or not, including optionally following the mode selected in a option var or in the proxy shape.
- Use that new parameter when saving anonymous layers based on the known information that is passed when saving that anonymous layer, in the saveAnonymousLayer function.
- Use that new parameter when converting anonymous layers to saved layers.
- Use that new parameter when handling notification that the root layer path changed.