### PR TITLE
LOOKDEVX-3222 - Expose hardcoded texture paths

### DIFF
--- a/lib/mayaUsd/render/MaterialXGenOgsXml/OgsFragment.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/OgsFragment.cpp
@@ -647,6 +647,14 @@ OgsFragment::OgsFragment(mx::ElementPtr element, GLSL_GENERATOR_WRAPPER&& glslGe
         for (size_t i = 0; i < uniforms.size(); ++i) {
             const mx::ShaderPort* const port = uniforms[i];
             if (!port->getNode()) {
+                if (port->getType()->getSemantic() == mx::TypeDesc::SEMANTIC_FILENAME) {
+                    // Might be an embedded texture. Retrieve the filename.
+                    std::string textureName
+                        = mx::OgsXmlGenerator::samplerToTextureName(port->getVariable());
+                    if (!textureName.empty() && !port->getPath().empty()) {
+                        _embeddedTextures[textureName] = port->getPath();
+                    }
+                }
                 continue;
             }
             std::string path = port->getPath();
@@ -692,6 +700,8 @@ const std::string& OgsFragment::getLightRigName() const { return _lightRigName; 
 const std::string& OgsFragment::getLightRigSource() const { return _lightRigSource; }
 
 const mx::StringMap& OgsFragment::getPathInputMap() const { return _pathInputMap; }
+
+const mx::StringMap& OgsFragment::getEmbeddedTextureMap() const { return _embeddedTextures; }
 
 bool OgsFragment::isElementAShader() const
 {

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/OgsFragment.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/OgsFragment.h
@@ -71,6 +71,9 @@ public:
     /// Maps XML element paths of MaterialX inputs to their names in the generated shader.
     const mx::StringMap& getPathInputMap() const;
 
+    /// Maps a generated shader texture input to its library path.
+    const mx::StringMap& getEmbeddedTextureMap() const;
+
     /// Return whether the element to render represents a surface shader graph
     /// as opposed to a texture graph.
     bool isElementAShader() const;
@@ -105,13 +108,14 @@ private:
     template <typename GLSL_GENERATOR_WRAPPER>
     OgsFragment(mx::ElementPtr, GLSL_GENERATOR_WRAPPER&&);
 
-    mx::ElementPtr _element;        ///< The MaterialX element.
-    std::string    _fragmentName;   ///< An automatically generated fragment name.
-    std::string    _fragmentSource; ///< The generated fragment source.
-    std::string    _lightRigName;   ///< An automatically generated light rig name.
-    std::string    _lightRigSource; ///< The generated light rig for surface fragments.
-    mx::StringMap  _pathInputMap;   ///< Maps MaterialX element paths to fragment input names.
-    mx::ShaderPtr  _glslShader;     ///< The MaterialX-generated GLSL shader.
+    mx::ElementPtr _element;          ///< The MaterialX element.
+    std::string    _fragmentName;     ///< An automatically generated fragment name.
+    std::string    _fragmentSource;   ///< The generated fragment source.
+    std::string    _lightRigName;     ///< An automatically generated light rig name.
+    std::string    _lightRigSource;   ///< The generated light rig for surface fragments.
+    mx::StringMap  _pathInputMap;     ///< Maps MaterialX element paths to fragment input names.
+    mx::StringMap  _embeddedTextures; ///< Maps texture entry points to library paths.
+    mx::ShaderPtr  _glslShader;       ///< The MaterialX-generated GLSL shader.
 };
 
 } // namespace MaterialXMaya

--- a/lib/mayaUsdAPI/render.cpp
+++ b/lib/mayaUsdAPI/render.cpp
@@ -115,6 +115,11 @@ const MaterialX::StringMap& OgsFragment::getPathInputMap() const
     return _imp->_ogsFragment.getPathInputMap();
 }
 
+const MaterialX::StringMap& OgsFragment::getEmbeddedTextureMap() const
+{
+    return _imp->_ogsFragment.getEmbeddedTextureMap();
+}
+
 std::string OgsFragment::getMatrix4Name(const std::string& matrix3Name)
 {
     return _imp->_ogsFragment.getMatrix4Name(matrix3Name);

--- a/lib/mayaUsdAPI/render.h
+++ b/lib/mayaUsdAPI/render.h
@@ -94,6 +94,7 @@ public:
     const std::string&          getFragmentSource() const;
     const std::string&          getFragmentName() const;
     const MaterialX::StringMap& getPathInputMap() const;
+    const MaterialX::StringMap& getEmbeddedTextureMap() const;
     std::string                 getMatrix4Name(const std::string& matrix3Name);
 
 private:


### PR DESCRIPTION
This will expose the MaterialX path of a library definition containing hardcoded image paths, allowing clients to fetch the relevant data required to populate those shader inputs.