### PR TITLE
EMSUSD-1629 fix copying grouped meshes

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -1734,8 +1734,21 @@ std::vector<Ufe::Path> PrimUpdaterManager::duplicate(
         executeAdditionalCommands(context);
         progressBar.advance();
 
-        const Ufe::PathSegment pathSegment
-            = UsdUfe::usdPathToUfePathSegment(pushExportResult.srcRootPath);
+        SdfPath finalUsdPath(pushExportResult.srcRootPath);
+        {
+            auto copiedIt = copyResult.copiedPaths.find(finalUsdPath);
+            if (copiedIt != copyResult.copiedPaths.end()) {
+                finalUsdPath = copiedIt->second;
+            }
+        }
+        {
+            auto renamedIt = copyResult.renamedPaths.find(finalUsdPath);
+            if (renamedIt != copyResult.renamedPaths.end()) {
+                finalUsdPath = renamedIt->second;
+            }
+        }
+
+        Ufe::PathSegment pathSegment = UsdUfe::usdPathToUfePathSegment(finalUsdPath);
         return { Ufe::Path(dstPath + pathSegment) };
     }
 

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -437,7 +437,7 @@ void ReplicateExtrasToUSD::finalize(const Ufe::Path& stagePath, const RenamedPat
     // Replicate display layer membership
     for (const auto& entry : _primToLayerMap) {
         if (entry.second.hasFn(MFn::kDisplayLayer)) {
-            auto usdPrimPath = entry.first;
+            SdfPath usdPrimPath = entry.first;
             for (const auto& oldAndNew : renamed) {
                 const PXR_NS::SdfPath& oldPrefix = oldAndNew.first;
                 if (!usdPrimPath.HasPrefix(oldPrefix))
@@ -446,6 +446,11 @@ void ReplicateExtrasToUSD::finalize(const Ufe::Path& stagePath, const RenamedPat
                 const PXR_NS::SdfPath& newPrefix = oldAndNew.second;
                 usdPrimPath = usdPrimPath.ReplacePrefix(oldPrefix, newPrefix);
             }
+
+            // Avoid trying to manipulate the virtual absolute root. It will trigger
+            // exceptions which can affect Python scripts and testing.
+            if (usdPrimPath.IsAbsoluteRootPath())
+                continue;
 
             auto                primPath = UsdUfe::usdPathToUfePathSegment(usdPrimPath);
             Ufe::Path::Segments segments { stagePath.getSegments()[0], primPath };

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -708,7 +708,7 @@ global proc mayaUsdMenu_duplicateToUSD( string $proxy, string $obj )
     }
 
     for ($item in $bulkObjects) {
-        string $exportOptions = `python("import mayaUsdDuplicateAsUsdDataOptions; import mayaUsdOptions; mayaUsdOptions.setAnimateOption('''" + $obj + "''', mayaUsdDuplicateAsUsdDataOptions.getDuplicateAsUsdDataOptionsText())")`;
+        string $exportOptions = `python("import mayaUsdDuplicateAsUsdDataOptions; import mayaUsdOptions; mayaUsdOptions.setAnimateOption('''" + $item + "''', mayaUsdDuplicateAsUsdDataOptions.getDuplicateAsUsdDataOptionsText())")`;
         mayaUsdDuplicate -exportOptions $exportOptions $item $proxy;
     }
 }

--- a/test/lib/mayaUsd/fileio/testDuplicateAs.py
+++ b/test/lib/mayaUsd/fileio/testDuplicateAs.py
@@ -446,6 +446,41 @@ class DuplicateAsTestCase(unittest.TestCase):
         self.assertTrue(conePrim.IsValid())
 
 
+    def testDuplicateGroupedSelection(self):
+        '''Duplicate a Maya sphere and cone both in a group and in selection by calling the MEL script used in the UI.'''
+
+        # Create a sphere.
+        sphere = cmds.polySphere(r=1)[0]
+        cone = cmds.polyCone(r=1)[0]
+
+        # Create a stage to receive the USD duplicate.
+        psPathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        stage = mayaUsd.lib.GetPrim(psPathStr).GetStage()
+
+        # Select both and group them
+        cmds.select(clear=True)
+        cmds.select(sphere, add=True)
+        cmds.select(cone, add=True)
+
+        cmds.group()
+
+        # Select both again
+        cmds.select(clear=True)
+        cmds.select(sphere, add=True)
+        cmds.select(cone, add=True)
+
+        # Duplicate Maya data as USD data, will use the selection.
+        mel.eval('''source mayaUsd_pluginUICreation.mel''')
+        mel.eval('''source mayaUsdMenu.mel''')
+        mel.eval('''mayaUsdMenu_duplicateToUSD("%s", "%s")''' % (psPathStr, sphere))
+
+        # Verify that the copied sphere has a look (material) prim.
+        spherePrim = stage.GetPrimAtPath("/%s" % sphere)
+        self.assertTrue(spherePrim.IsValid())
+        conePrim = stage.GetPrimAtPath("/%s" % cone)
+        self.assertTrue(conePrim.IsValid())
+
+
     def testDuplicateUsingOptions(self):
         '''Duplicate a Maya sphere using options to merge with or without materials.'''
 


### PR DESCRIPTION
- Return the correct path of the copied object from the duplicate function.
- Don't try to process the virtual root prim path.
- Prepare the correct export options.
- Add a unit test for duplicate grouped meshes.