### PR TITLE
EMSUSD-1610 layer manager flicker

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeModel.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeModel.cpp
@@ -300,7 +300,13 @@ void LayerTreeModel::rebuildModel(bool refreshLockState /*= false*/)
     _lastAskedAnonLayerNameSinceRebuild = 0;
 
     beginResetModel();
-    clear();
+
+    //  Note: do *not* call clear() here! Unfortunately, clear() itself calls,
+    //        beginResetModel() and endResetModel(). Qt does not detect the nested
+    //        begin/end/ So calling clear() would make the layer manager flicker
+    //        to be empty for a brief time.
+    if (rowCount() > 0)
+        removeRows(0, rowCount());
 
     if (_sessionState->isValid()) {
         auto rootLayer = _sessionState->stage()->GetRootLayer();

--- a/lib/usd/ui/layerEditor/layerTreeView.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeView.cpp
@@ -254,6 +254,13 @@ LayerViewMemento::LayerViewMemento(const LayerTreeView& view, const LayerTreeMod
 
 void LayerViewMemento::preserve(const LayerTreeView& view, const LayerTreeModel& model)
 {
+    if (QScrollBar* hsb = view.horizontalScrollBar()) {
+        _horizontalScrollbarPosition = hsb->value();
+    }
+    if (QScrollBar* vsb = view.verticalScrollBar()) {
+        _verticalScrollbarPosition = vsb->value();
+    }
+
     const LayerItemVector items = model.getAllItems();
     if (items.size() == 0)
         return;
@@ -296,6 +303,19 @@ void LayerViewMemento::restore(LayerTreeView& view, LayerTreeModel& model)
 
         view.setExpanded(item->index(), expanded);
     }
+
+    if (QScrollBar* hsb = view.horizontalScrollBar()) {
+        if (hsb->value() != _horizontalScrollbarPosition) {
+            hsb->setValue(_horizontalScrollbarPosition);
+            hsb->valueChanged(_horizontalScrollbarPosition);
+        }
+    }
+    if (QScrollBar* vsb = view.verticalScrollBar()) {
+        if (vsb->value() != _verticalScrollbarPosition) {
+            vsb->setValue(_verticalScrollbarPosition);
+            vsb->valueChanged(_verticalScrollbarPosition);
+        }
+    }
 }
 
 void LayerTreeView::onModelAboutToBeReset()
@@ -303,10 +323,13 @@ void LayerTreeView::onModelAboutToBeReset()
     if (!_model)
         return;
 
-    LayerViewMemento memento(*this, *_model);
-    if (memento.empty())
+    // Don't allow recursive saving of the tree view state.
+    // Could happen if notifications are sent in response
+    // to other notifications or Qt events.
+    if (_cachedModelState)
         return;
 
+    LayerViewMemento memento(*this, *_model);
     _cachedModelState = std::make_unique<LayerViewMemento>(std::move(memento));
 }
 
@@ -315,10 +338,12 @@ void LayerTreeView::onModelReset()
     if (!_model)
         return;
 
-    if (_cachedModelState)
+    if (_cachedModelState) {
         _cachedModelState->restore(*this, *_model);
-    else
+        _cachedModelState.reset();
+    } else {
         expandAll();
+    }
 }
 
 LayerItemVector LayerTreeView::getSelectedLayerItems() const

--- a/lib/usd/ui/layerEditor/layerTreeView.h
+++ b/lib/usd/ui/layerEditor/layerTreeView.h
@@ -65,6 +65,8 @@ private:
     };
 
     std::map<ItemId, ItemState> _itemsState;
+    int                         _horizontalScrollbarPosition { 0 };
+    int                         _verticalScrollbarPosition { 0 };
 };
 
 /**


### PR DESCRIPTION
- Don't use clear() to empty the layer tree model because it causes recursive Qt notifications.
- Remember the position of the scroll bars when updating the layer manager model.
- Don't allow recursive caching the layer manager state.
- Properly get rid of the cached state once restored.