### PR TITLE
EMSUSD-1619 fix removal on multiple layers

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeView.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeView.cpp
@@ -420,6 +420,11 @@ void LayerTreeView::callMethodOnSelection(const QString& undoName, simpleLayerMe
 {
     DelayAbstractCommandHook delayed(*_model->sessionState()->commandHook());
 
+    callMethodOnSelectionNoDelay(undoName, method);
+}
+
+void LayerTreeView::callMethodOnSelectionNoDelay(const QString& undoName, simpleLayerMethod method)
+{
     CallMethodParams params;
     auto             selection = getSelectedLayerItems();
     params.selection = &selection;

--- a/lib/usd/ui/layerEditor/layerTreeView.h
+++ b/lib/usd/ui/layerEditor/layerTreeView.h
@@ -100,6 +100,7 @@ public:
     // calls a given method on all items in the selection, with the given string as the undo chunk
     // name
     void callMethodOnSelection(const QString& undoName, simpleLayerMethod method);
+    void callMethodOnSelectionNoDelay(const QString& undoName, simpleLayerMethod method);
 
     // menu callbacks
     void onAddParentLayer(const QString& undoName) const;

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
@@ -173,7 +173,7 @@ std::string MayaLayerEditorWindow::proxyShapeName() const
 void MayaLayerEditorWindow::removeSubLayer()
 {
     QString name = "Remove";
-    treeView()->callMethodOnSelection(name, &LayerTreeItem::removeSubLayer);
+    treeView()->callMethodOnSelectionNoDelay(name, &LayerTreeItem::removeSubLayer);
 }
 
 void MayaLayerEditorWindow::saveEdits()


### PR DESCRIPTION
When removing multiple layers the removal must not be delayed. This is due to the low-level implementation of layer removal: it uses the parent layer and the index of the sub-layer to be removed instead of its name. When commands are delayed, the index would become incorrect. By not delaying command, the index is properly calculated.