### PR TITLE
Copy a test file for use in overwrite testing

### DIFF
--- a/test/lib/ufe/testReferenceCommands.py
+++ b/test/lib/ufe/testReferenceCommands.py
@@ -66,7 +66,7 @@ class ReferenceCommandsTestCase(unittest.TestCase):
 
         # paths to the files used in this test
         newFile = testUtils.getTestScene('twoSpheres', 'spherexform.usda')
-        oldFile = testUtils.getTestScene('twoSpheres', 'sphere.usda')
+        oldFile = testUtils.getTestScene('twoSpheres', 'sphere_ext.usda')
         bkFile  = testUtils.getTestScene('twoSpheres', 'sphere_bk.usda')
         refFile = testUtils.getTestScene('twoSpheres', 'spheres_ref.usda')
 

--- a/test/testSamples/twoSpheres/sphere_ext.usda
+++ b/test/testSamples/twoSpheres/sphere_ext.usda
@@ -1,0 +1,21 @@
+#usda 1.0
+(
+    defaultPrim = "sphereXform"
+)
+
+def Xform "sphereXform"
+{
+    double3 xformOp:translate = (10, 0, 0)
+    uniform token[] xformOpOrder = ["xformOp:translate"]
+
+    def Xform "test"
+    {
+    }
+
+    def Sphere "sphere"
+    {
+        float3[] extent = [(-2, -2, -2), (2, 2, 2)]
+        color3f[] primvars:displayColor = [(0, 1, 0)]
+        double radius = 2
+    }
+}

--- a/test/testSamples/twoSpheres/spheres_ref.usda
+++ b/test/testSamples/twoSpheres/spheres_ref.usda
@@ -4,7 +4,7 @@
 )
 
 def Xform "Xform1" (
-    prepend references = @sphere.usda@
+    prepend references = @sphere_ext.usda@
 )
 {
 }


### PR DESCRIPTION
Modifying a test file that is used in multiple tests is causing issues in our test framework. This change splits the file that is overwritten during the testReferenceCommands test to avoid corrupting other tests that are trying to use the same test file