### PR TITLE
EMSUSD-946 axis in import UI and command

### DIFF
--- a/README_DOC.md
+++ b/README_DOC.md
@@ -8,6 +8,7 @@
 + [Managing Translation (Import/Export) Options](lib/mayaUsd/fileio/doc/Managing_export_options_via_JobContext_in_Python.md)
 + [Example Import and Export Plugin in Python](tutorials/import-export-plugin/README.md)
 + [Example Import and Export Plugin in C++](tutorials/import-export-plugin-c++/README.md)
++ [Adding new import or export option](lib/mayaUsd/fileio/doc/How-to-add-new-option.md)
 + [SchemaAPI Translators](lib/mayaUsd/fileio/doc/SchemaAPI_Import_Export_in_Python.md)
 + [UFE Transform](lib/usdUfe/ufe/trf/UsdTransform3d.md)
 + [Undo/Redo Support](lib/mayaUsd/undo/README.md)

--- a/lib/mayaUsd/commands/Readme.md
+++ b/lib/mayaUsd/commands/Readme.md
@@ -53,6 +53,8 @@ Each base command class is documented in the following sections.
 | `-importUSDZTextures`         | `-itx`     | bool           | false                             | Imports textures from USDZ archives during import to disk. Can be used in conjuction with `-importUSDZTexturesFilePath` to specify an explicit directory to write imported textures to. If not specified, requires a Maya project to be set in the current context.  |
 | `-importUSDZTexturesFilePath` | `-itf`     | string         | none                              | Specifies an explicit directory to write imported textures to from a USDZ archive. Has no effect if `-importUSDZTextures` is not specified. |
 | `-importRelativeTextures`     | `-rtx`     | string         | none                              | Selects how textures filenames are generated: absolute, relative, automatic or none. When automatic, the filename is relative if the source filename of the texture being imported is relative. When none, the file path is left alone, for backward compatible behavior. |
+| `-upAxis`                     | `-upa`     | bool           | true                              | Enable changing axis on import. |
+| `-axisAndUnitMethod`          | `-aum`     | string         | rotateScale                       | Selects how the unit and axis are handled during import. |
 
 ### Return Value
 

--- a/lib/mayaUsd/commands/baseImportCommand.cpp
+++ b/lib/mayaUsd/commands/baseImportCommand.cpp
@@ -68,6 +68,12 @@ MSyntax MayaUSDImportCommand::createSyntax()
         kImportRelativeTexturesFlag,
         UsdMayaJobImportArgsTokens->importRelativeTextures.GetText(),
         MSyntax::kString);
+    syntax.addFlag(
+        kImportUpAxisFlag, UsdMayaJobImportArgsTokens->upAxis.GetText(), MSyntax::kBoolean);
+    syntax.addFlag(
+        kImportAxisAndUnitMethodFlag,
+        UsdMayaJobImportArgsTokens->axisAndUnitMethod.GetText(),
+        MSyntax::kString);
     syntax.addFlag(kMetadataFlag, UsdMayaJobImportArgsTokens->metadata.GetText(), MSyntax::kString);
     syntax.makeFlagMultiUse(kMetadataFlag);
     syntax.addFlag(

--- a/lib/mayaUsd/commands/baseImportCommand.h
+++ b/lib/mayaUsd/commands/baseImportCommand.h
@@ -46,6 +46,8 @@ public:
     static constexpr auto kImportUSDZTexturesFlag = "itx";
     static constexpr auto kImportUSDZTexturesFilePathFlag = "itf";
     static constexpr auto kImportRelativeTexturesFlag = "rtx";
+    static constexpr auto kImportUpAxisFlag = "upa";
+    static constexpr auto kImportAxisAndUnitMethodFlag = "aum";
     static constexpr auto kMetadataFlag = "md";
     static constexpr auto kApiSchemaFlag = "api";
     static constexpr auto kJobContextFlag = "jc";

--- a/lib/mayaUsd/fileio/doc/How-to-add-new-option.md
+++ b/lib/mayaUsd/fileio/doc/How-to-add-new-option.md
@@ -1,0 +1,46 @@
+# How to add a new option to import or export
+
+Search for an existing option in the code and do the same for the new option
+everywhere you find the old existing option. Use an existing option with a
+very unique name to avoid false matches.
+
+## Adding the option UI, command flag and import/export argument
+
+Usually, you will need to modify these places:
+
+- baseImportCommand.h: (or baseExportCommand.h)
+	- Add the short flag
+
+- baseImportCommand.cpp: (or baseExportCommand.cpp)
+	- Add the flag to the syntax
+
+- lib/mayaUsd/commands/Readme.md:
+	- Document the new flag
+
+- lib/mayaUsd/fileio/jobs/jobArgs.h:
+	- Add the token to the import or export tokens
+	- Add data item to the import or export struct
+
+- lib/mayaUsd/fileio/jobs/jobArgs.cpp:
+	- Handle parsing the flag in the constructor
+	- Add default value to GetDefaultDictionary
+	- Add the type to GetGuideDictionary
+	- Add writing the value to the operator<<
+
+- wrapPrimReader.cpp:
+	- Expose the option to Python
+
+- mayaUSDRegisterStrings.mel:
+	Add the new UI labels
+
+- mayaUsdTranslatorImport.mel: (or mayaUsdTranslatorExport.mel)
+	- Add new UI elements in mayaUsdTranslatorImport "post"
+	- Read the UI values in mayaUsdTranslatorImport "query"
+	- Add the UI in EnableAllControls
+	- Add filling the UI with data in SetFromOptions
+	- Maybe add some callback when UI valeu change when UI affect other UI.
+
+## Handling the option in code
+
+Afterward, modify the import/export code itself to handle the new option and
+add new behavior during the actual import or export.

--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -1344,6 +1344,14 @@ UsdMayaJobImportArgs::UsdMayaJobImportArgs(
             UsdMayaJobImportArgsTokens->absolute,
             UsdMayaJobImportArgsTokens->relative,
             UsdMayaJobImportArgsTokens->none }))
+    , axisAndUnitMethod(extractToken(
+          userArgs,
+          UsdMayaJobImportArgsTokens->axisAndUnitMethod,
+          UsdMayaJobImportArgsTokens->rotateScale,
+          { UsdMayaJobImportArgsTokens->rotateScale,
+            UsdMayaJobImportArgsTokens->addTransform,
+            UsdMayaJobImportArgsTokens->overwritePrefs }))
+    , upAxis(extractBoolean(userArgs, UsdMayaJobImportArgsTokens->upAxis))
     , importInstances(extractBoolean(userArgs, UsdMayaJobImportArgsTokens->importInstances))
     , useAsAnimationCache(extractBoolean(userArgs, UsdMayaJobImportArgsTokens->useAsAnimationCache))
     , importWithProxyShapes(importWithProxyShapes)
@@ -1432,6 +1440,9 @@ const VtDictionary& UsdMayaJobImportArgs::GetDefaultDictionary()
         d[UsdMayaJobImportArgsTokens->importUSDZTexturesFilePath] = "";
         d[UsdMayaJobImportArgsTokens->importRelativeTextures]
             = UsdMayaJobImportArgsTokens->none.GetString();
+        d[UsdMayaJobImportArgsTokens->axisAndUnitMethod]
+            = UsdMayaJobImportArgsTokens->rotateScale.GetString();
+        d[UsdMayaJobImportArgsTokens->upAxis] = true;
         d[UsdMayaJobImportArgsTokens->pullImportStage] = UsdStageRefPtr();
         d[UsdMayaJobImportArgsTokens->useAsAnimationCache] = false;
         d[UsdMayaJobImportArgsTokens->preserveTimeline] = false;
@@ -1514,6 +1525,8 @@ const VtDictionary& UsdMayaJobImportArgs::GetGuideDictionary()
         d[UsdMayaJobImportArgsTokens->importUSDZTextures] = _boolean;
         d[UsdMayaJobImportArgsTokens->importUSDZTexturesFilePath] = _string;
         d[UsdMayaJobImportArgsTokens->importRelativeTextures] = _string;
+        d[UsdMayaJobImportArgsTokens->axisAndUnitMethod] = _string;
+        d[UsdMayaJobImportArgsTokens->upAxis] = _boolean;
         d[UsdMayaJobImportArgsTokens->pullImportStage] = _usdStageRefPtr;
         d[UsdMayaJobImportArgsTokens->useAsAnimationCache] = _boolean;
         d[UsdMayaJobImportArgsTokens->preserveTimeline] = _boolean;
@@ -1604,6 +1617,8 @@ std::ostream& operator<<(std::ostream& out, const UsdMayaJobImportArgs& importAr
         << "importUSDZTextures: " << TfStringify(importArgs.importUSDZTextures) << std::endl
         << "importUSDZTexturesFilePath: " << TfStringify(importArgs.importUSDZTexturesFilePath)
         << "importRelativeTextures: " << TfStringify(importArgs.importRelativeTextures) << std::endl
+        << "axisAndUnitMethod: " << TfStringify(importArgs.axisAndUnitMethod) << std::endl
+        << "upAxis: " << TfStringify(importArgs.upAxis) << std::endl
         << "pullImportStage: " << TfStringify(importArgs.pullImportStage) << std::endl
         << std::endl
         << "timeInterval: " << importArgs.timeInterval << std::endl

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -174,6 +174,12 @@ TF_DECLARE_PUBLIC_TOKENS(
     (pullImportStage) \
     (preserveTimeline) \
     (remapUVSetsTo) \
+    (upAxis) \
+    (axisAndUnitMethod) \
+    /* values for axis and unit method */ \
+    (rotateScale) \
+    (addTransform) \
+    (overwritePrefs) \
     /* values for import relative textures */ \
     (automatic) \
     (absolute) \
@@ -403,6 +409,8 @@ struct UsdMayaJobImportArgs
     const std::string    importUSDZTexturesFilePath;
     const bool           importUSDZTextures;
     const std::string    importRelativeTextures;
+    const std::string    axisAndUnitMethod;
+    const bool           upAxis;
     const bool           importInstances;
     const bool           useAsAnimationCache;
     const bool           importWithProxyShapes;

--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -22,12 +22,14 @@
 #include <mayaUsd/fileio/utils/readUtil.h>
 #include <mayaUsd/nodes/stageNode.h>
 #include <mayaUsd/undo/OpUndoItemMuting.h>
+#include <mayaUsd/utils/dynamicAttribute.h>
 #include <mayaUsd/utils/progressBarScope.h>
 #include <mayaUsd/utils/stageCache.h>
 #include <mayaUsd/utils/util.h>
 #include <mayaUsd/utils/utilFileSystem.h>
 
 #include <pxr/base/tf/debug.h>
+#include <pxr/base/tf/stringUtils.h>
 #include <pxr/base/tf/token.h>
 #include <pxr/usd/sdf/fileFormat.h>
 #include <pxr/usd/sdf/layer.h>
@@ -36,7 +38,6 @@
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/primFlags.h>
 #include <pxr/usd/usd/primRange.h>
-#include <pxr/usd/usd/stage.h>
 #include <pxr/usd/usd/stageCacheContext.h>
 #include <pxr/usd/usd/timeCode.h>
 #include <pxr/usd/usd/variantSets.h>
@@ -53,6 +54,7 @@
 #include <maya/MDagPathArray.h>
 #include <maya/MDistance.h>
 #include <maya/MFnDependencyNode.h>
+#include <maya/MGlobal.h>
 #include <maya/MItDependencyGraph.h>
 #include <maya/MObject.h>
 #include <maya/MPlug.h>
@@ -196,7 +198,7 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
     // When we are called from PrimUpdaterManager we should already have
     // a computation scope. If we are called from elsewhere don't show any
     // progress bar here.
-    MayaUsd::ProgressBarScope progressBar(16);
+    MayaUsd::ProgressBarScope progressBar(17);
 
     // Do not use the global undo info recording system.
     // The read job Undo() / redo() functions will handle all operations.
@@ -480,9 +482,245 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
     }
     progressBar.advance();
 
+    _ConvertUpAxis(stage);
+    progressBar.advance();
+
     UsdMayaReadUtil::mapFileHashes.clear();
 
     return (status == MS::kSuccess);
+}
+
+static bool getMayaUpAxisZ() { return MGlobal::isZAxisUp(); }
+
+static bool getUSDUpAxisZ(const UsdStageRefPtr& stage)
+{
+    return UsdGeomGetStageUpAxis(stage) == UsdGeomTokens->z;
+}
+
+void UsdMaya_ReadJob::_ConvertUpAxis(const UsdStageRefPtr& stage)
+{
+    // If up-axis fixing is turned off, do nothing.
+    if (!mArgs.upAxis)
+        return;
+
+    // If up axis are the same in Maya and USD, do nothing.
+    const bool isMayaUpAxisZ = getMayaUpAxisZ();
+    const bool isUSDUpAxisUZ = getUSDUpAxisZ(stage);
+
+    if (isMayaUpAxisZ == isUSDUpAxisUZ)
+        return;
+
+    // Convert axis based on desired method.
+    const bool convertYtoZ = isMayaUpAxisZ;
+
+    bool success = false;
+
+    if (mArgs.axisAndUnitMethod == UsdMayaJobImportArgsTokens->rotateScale)
+        success = _ConvertUpAxisWithRotation(stage, convertYtoZ, false);
+    else if (mArgs.axisAndUnitMethod == UsdMayaJobImportArgsTokens->addTransform)
+        success = _ConvertUpAxisWithRotation(stage, convertYtoZ, true);
+    else if (mArgs.axisAndUnitMethod == UsdMayaJobImportArgsTokens->overwritePrefs)
+        success = _ConvertUpAxisByChangingMayPrefs(convertYtoZ);
+    else
+        TF_WARN(
+            "Unknown method of converting the USD up axis to Maya: %s",
+            mArgs.axisAndUnitMethod.c_str());
+
+    if (success)
+        MGlobal::displayInfo("Mismatching axis have been converted for accurate orientation.");
+}
+
+// Construct list of top level DAG nodes.
+static std::vector<MDagPath> _findAllRootDagNodePaths(
+    const UsdMayaPrimReaderContext::ObjectRegistry& newNodes,
+    const MDagPath&                                 rootPath)
+{
+    std::vector<MDagPath> rootNodePaths;
+
+    for (auto& it : newNodes) {
+        // Do not process the root DAG path, which was not part of the import.
+        if (it.second == rootPath.node())
+            continue;
+
+        // Note: if it is not a DAG node, then it is a DG node and we don't
+        //       need to process it.
+        MStatus    dagStatus;
+        MFnDagNode dagFn(it.second, &dagStatus);
+        if (dagStatus != MS::kSuccess)
+            continue;
+
+        MDagPathArray paths;
+        dagFn.getAllPaths(paths);
+        for (const MDagPath& path : paths) {
+            if (path.length() == 1) {
+                rootNodePaths.emplace_back(path);
+            }
+        }
+    }
+
+    return rootNodePaths;
+}
+
+static std::vector<std::string> _convertDagPathToNames(const std::vector<MDagPath>& dagNodePaths)
+{
+    std::vector<std::string> dagNodeNames;
+
+    dagNodeNames.reserve(dagNodePaths.size());
+    for (const MDagPath& path : dagNodePaths)
+        dagNodeNames.emplace_back(path.fullPathName().asChar());
+
+    return dagNodeNames;
+}
+
+static std::string _cleanMayaNodeName(const std::string& name)
+{
+    std::string cleaned(name);
+    for (char& c : cleaned) {
+        if (!std::isalpha(c) && !std::isdigit(c))
+            c = '_';
+    }
+    return cleaned;
+}
+
+static void
+_addOrignalUpAxisAttribute(const std::vector<MDagPath>& dagNodePaths, bool convertUsdYtoMayaZ)
+{
+    // Note: if we're converting from Y to Z, then the original up axis was Y, otherwise Z.
+    const MString originalUpAxis = convertUsdYtoMayaZ ? "Y" : "Z";
+    const MString attrName = "OriginalUSDUpAxis";
+    for (const MDagPath& dagPath : dagNodePaths) {
+        MFnDependencyNode depNode(dagPath.node());
+        MayaUsd::setDynamicAttribute(depNode, attrName, originalUpAxis);
+    }
+}
+
+bool UsdMaya_ReadJob::_ConvertUpAxisWithRotation(
+    const UsdStageRefPtr& stage,
+    bool                  convertUsdYtoMayaZ,
+    bool                  keepParentGroup)
+{
+    std::vector<MDagPath> dagNodePaths
+        = _findAllRootDagNodePaths(mNewNodeRegistry, mMayaRootDagPath);
+    if (dagNodePaths.size() <= 0)
+        return true;
+
+    std::vector<std::string> dagNodeNames = _convertDagPathToNames(dagNodePaths);
+
+    std::string fullScript;
+
+    // The rules for the group name are:
+    //
+    //    - If there is a single root object, use that object name + _converted
+    //    - Otherwise use the import file name + _converted
+    std::string groupName;
+    {
+        if (dagNodeNames.size() == 1) {
+            groupName = dagNodeNames[0];
+            if (TfStringContains(groupName, "|")) {
+                groupName = TfStringGetSuffix(groupName, '|');
+            }
+        } else {
+            groupName = TfGetBaseName(mImportData.filename());
+        }
+
+        static const char groupNameSuffix[] = "_converted";
+        groupName = _cleanMayaNodeName(groupName);
+        groupName = groupName + groupNameSuffix;
+    }
+
+    // Group all root node under a new group:
+    //
+    //    - Use -name to force the desired group name
+    //    - Use -absolute to keep the grouped node world positions
+    //    - Use -parent if the import was done under a given Maya node
+    //    - Use -world to create the group under the root ofthe scene
+    //      if the import was done at the root of the scene
+    //    - Capture the new group name in a MEL variable called $groupName
+
+    {
+        std::string groupCmd;
+
+        // Note: for the group commands, the node names must be separated  by, literally, " ",
+        //       so that they form a space-separated serie of quoted names.
+        static const char nodeNameSeparator[] = "\" \"";
+        std::string       joinedDAGNodeNames = TfStringJoin(dagNodeNames, nodeNameSeparator);
+
+        if (mMayaRootDagPath.node() != MObject::kNullObj) {
+            static const char groupUnderParentCmdFormat[]
+                = "string $groupName = `group -name \"%s\" -absolute -parent \"%s\" \"%s\"`;";
+            std::string rootName = mMayaRootDagPath.fullPathName().asChar();
+            groupCmd = TfStringPrintf(
+                groupUnderParentCmdFormat,
+                groupName.c_str(),
+                joinedDAGNodeNames.c_str(),
+                rootName.c_str());
+        } else {
+            static const char groupUnderWorldCmdFormat[]
+                = "string $groupName = `group -name \"%s\" -absolute -world \"%s\"`;";
+            groupCmd = TfStringPrintf(
+                groupUnderWorldCmdFormat, groupName.c_str(), joinedDAGNodeNames.c_str());
+        }
+
+        fullScript += groupCmd;
+    }
+
+    // Rotate the group to align with the desired axis.
+    //
+    //    - Use relative rotation since we want to rotate the group as it is already positioned
+    //    - Use -euler to make teh angle be relative to the current angle
+    //    - Use forceOrderXYZ to force  the rotation to be relative to world
+    //    - Use -pivot to make sure we are rotating relative to the origin
+    //      (The group is positioned at the center of all sub-object, so we need to specify the
+    //      pivot)
+    {
+        static const char rotationCmdFormat[]
+            = "rotate -relative -euler -pivot 0 0 0 -forceOrderXYZ %d 0 0 $groupName;";
+        const int   angleYtoZ = 90;
+        const int   angleZtoY = -90;
+        std::string rotationCmd
+            = TfStringPrintf(rotationCmdFormat, convertUsdYtoMayaZ ? angleYtoZ : angleZtoY);
+        fullScript += rotationCmd;
+    }
+
+    if (!keepParentGroup) {
+        static const char ungroupCmdFormat[] = "ungroup -absolute \"%s\";";
+        std::string       ungroupCmd = TfStringPrintf(ungroupCmdFormat, groupName.c_str());
+        fullScript += ungroupCmd;
+    }
+
+    if (!MGlobal::executeCommand(fullScript.c_str())) {
+        MGlobal::displayWarning("Failed to add a transform to convert the up-axis to align "
+                                "the USD data with Maya up-axis.");
+        return false;
+    }
+
+    if (keepParentGroup) {
+        MDagPath groupDagPath;
+        {
+            MSelectionList sel;
+            sel.add(groupName.c_str());
+            sel.getDagPath(0, groupDagPath);
+        }
+        _addOrignalUpAxisAttribute({ groupDagPath }, convertUsdYtoMayaZ);
+    } else {
+        _addOrignalUpAxisAttribute(dagNodePaths, convertUsdYtoMayaZ);
+    }
+
+    return true;
+}
+
+bool UsdMaya_ReadJob::_ConvertUpAxisByChangingMayPrefs(const bool convertUsdYtoMayaZ)
+{
+    const bool    rotateView = true;
+    const MStatus status
+        = convertUsdYtoMayaZ ? MGlobal::setYAxisUp(rotateView) : MGlobal::setZAxisUp(rotateView);
+    if (!status) {
+        MGlobal::displayWarning(
+            "Failed to change the Maya up-axis preferences to match USD data up-axis.");
+        return false;
+    }
+
+    return true;
 }
 
 bool UsdMaya_ReadJob::DoImport(UsdPrimRange& rootRange, const UsdPrim& usdRootPrim)
@@ -561,6 +799,9 @@ void UsdMaya_ReadJob::_DoImportInstanceIt(
     const SdfPath prototypePath = prototype.GetPath();
     MObject       prototypeObject = readCtx.GetMayaNode(prototypePath, false);
     if (prototypeObject == MObject::kNullObj) {
+        // Note: we are not passing the primReaderMap to _ImportPrototype because
+        //       _ImportPrototype does its own prim range loop and immediate post-visit
+        //       on the prims of the prototype.
         _ImportPrototype(prototype, usdRootPrim, readCtx);
         prototypeObject = readCtx.GetMayaNode(prototypePath, false);
         if (prototypeObject == MObject::kNullObj) {
@@ -602,26 +843,12 @@ void UsdMaya_ReadJob::_ImportPrototype(
     const UsdPrim&            usdRootPrim,
     UsdMayaPrimReaderContext& readCtx)
 {
-    _PrimReaderMap     primReaderMap;
     const UsdPrimRange range = UsdPrimRange::PreAndPostVisit(prototype);
-    for (auto primIt = range.begin(); primIt != range.end(); ++primIt) {
-        const UsdPrim&           prim = *primIt;
-        UsdMayaPrimReaderContext readCtx(&mNewNodeRegistry);
-        readCtx.SetTimeSampleMultiplier(mTimeSampleMultiplier);
-        if (prim.IsInstance()) {
-            _DoImportInstanceIt(primIt, usdRootPrim, readCtx, primReaderMap);
-        } else {
-            _DoImportPrimIt(primIt, usdRootPrim, readCtx, primReaderMap);
-        }
-    }
+    _ImportPrimRange(range, usdRootPrim);
 }
 
-bool UsdMaya_ReadJob::_DoImport(UsdPrimRange& rootRange, const UsdPrim& usdRootPrim)
+bool UsdMaya_ReadJob::_DoImport(const UsdPrimRange& rootRange, const UsdPrim& usdRootPrim)
 {
-    const bool buildInstances = mArgs.importInstances;
-
-    MayaUsd::ProgressBarScope progressBar(0);
-
     // We want both pre- and post- visit iterations over the prims in this
     // method. To do so, iterate over all the root prims of the input range,
     // and create new PrimRanges to iterate over their subtrees.
@@ -629,58 +856,70 @@ bool UsdMaya_ReadJob::_DoImport(UsdPrimRange& rootRange, const UsdPrim& usdRootP
         const UsdPrim& rootPrim = *rootIt;
         rootIt.PruneChildren();
 
-        _PrimReaderMap     primReaderMap;
-        const UsdPrimRange range = buildInstances
+        const UsdPrimRange range = mArgs.importInstances
             ? UsdPrimRange::PreAndPostVisit(rootPrim)
             : UsdPrimRange::PreAndPostVisit(
                 rootPrim, UsdTraverseInstanceProxies(UsdPrimAllPrimsPredicate));
-
-        const int                     loopSize = std::distance(range.begin(), range.end());
-        MayaUsd::ProgressBarLoopScope instanceLoop(loopSize);
-        for (auto primIt = range.begin(); primIt != range.end(); ++primIt) {
-            const UsdPrim&           prim = *primIt;
-            UsdMayaPrimReaderContext readCtx(&mNewNodeRegistry);
-            readCtx.SetTimeSampleMultiplier(mTimeSampleMultiplier);
-
-            if (buildInstances && prim.IsInstance()) {
-                _DoImportInstanceIt(primIt, usdRootPrim, readCtx, primReaderMap);
-            } else {
-                _DoImportPrimIt(primIt, usdRootPrim, readCtx, primReaderMap);
-            }
-            instanceLoop.loopAdvance();
-        }
+        _ImportPrimRange(range, usdRootPrim);
     }
 
-    if (buildInstances) {
-        progressBar.addSteps(1);
+    return _CleanupPrototypes(usdRootPrim);
+}
 
-        MDGModifier              deletePrototypeMod;
+void UsdMaya_ReadJob::_ImportPrimRange(const UsdPrimRange& range, const UsdPrim& usdRootPrim)
+{
+    const int                     loopSize = std::distance(range.begin(), range.end());
+    MayaUsd::ProgressBarLoopScope instanceLoop(loopSize);
+
+    _PrimReaderMap primReaderMap;
+
+    for (auto primIt = range.begin(); primIt != range.end(); ++primIt) {
+        const UsdPrim&           prim = *primIt;
         UsdMayaPrimReaderContext readCtx(&mNewNodeRegistry);
         readCtx.SetTimeSampleMultiplier(mTimeSampleMultiplier);
 
-        auto                          prototypes = usdRootPrim.GetStage()->GetPrototypes();
-        const int                     loopSize = prototypes.size();
-        MayaUsd::ProgressBarLoopScope prototypesLoop(loopSize);
-        for (const auto& prototype : prototypes) {
-
-            const SdfPath prototypePath = prototype.GetPath();
-            MObject       prototypeObject = readCtx.GetMayaNode(prototypePath, false);
-            if (prototypeObject != MObject::kNullObj) {
-                MStatus    status;
-                MFnDagNode prototypeNode(prototypeObject, &status);
-                if (status) {
-                    while (prototypeNode.childCount()) {
-                        prototypeNode.removeChildAt(prototypeNode.childCount() - 1);
-                    }
-                }
-                deletePrototypeMod.deleteNode(prototypeObject, false);
-                mNewNodeRegistry.erase(prototypePath.GetString());
-            }
-            prototypesLoop.loopAdvance();
+        if (mArgs.importInstances && prim.IsInstance()) {
+            _DoImportInstanceIt(primIt, usdRootPrim, readCtx, primReaderMap);
+        } else {
+            _DoImportPrimIt(primIt, usdRootPrim, readCtx, primReaderMap);
         }
-        deletePrototypeMod.doIt();
-        progressBar.advance();
+        instanceLoop.loopAdvance();
     }
+}
+
+bool UsdMaya_ReadJob::_CleanupPrototypes(const UsdPrim& usdRootPrim)
+{
+    if (!mArgs.importInstances)
+        return true;
+
+    MayaUsd::ProgressBarScope progressBar(1);
+
+    MDGModifier              deletePrototypeMod;
+    UsdMayaPrimReaderContext readCtx(&mNewNodeRegistry);
+    readCtx.SetTimeSampleMultiplier(mTimeSampleMultiplier);
+
+    auto                          prototypes = usdRootPrim.GetStage()->GetPrototypes();
+    const int                     loopSize = prototypes.size();
+    MayaUsd::ProgressBarLoopScope prototypesLoop(loopSize);
+    for (const auto& prototype : prototypes) {
+
+        const SdfPath prototypePath = prototype.GetPath();
+        MObject       prototypeObject = readCtx.GetMayaNode(prototypePath, false);
+        if (prototypeObject != MObject::kNullObj) {
+            MStatus    status;
+            MFnDagNode prototypeNode(prototypeObject, &status);
+            if (status) {
+                while (prototypeNode.childCount()) {
+                    prototypeNode.removeChildAt(prototypeNode.childCount() - 1);
+                }
+            }
+            deletePrototypeMod.deleteNode(prototypeObject, false);
+            mNewNodeRegistry.erase(prototypePath.GetString());
+        }
+        prototypesLoop.loopAdvance();
+    }
+    deletePrototypeMod.doIt();
+    progressBar.advance();
 
     return true;
 }

--- a/lib/mayaUsd/fileio/jobs/readJob.h
+++ b/lib/mayaUsd/fileio/jobs/readJob.h
@@ -25,6 +25,7 @@
 #include <pxr/pxr.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/primRange.h>
+#include <pxr/usd/usd/stage.h>
 
 #include <maya/MDagModifier.h>
 #include <maya/MDagPath.h>
@@ -92,8 +93,7 @@ protected:
 
     // Engine method for DoImport().  Covers the functionality of a regular
     // usdImport.
-    MAYAUSD_CORE_PUBLIC
-    bool _DoImport(UsdPrimRange& range, const UsdPrim& usdRootPrim);
+    bool _DoImport(const UsdPrimRange& range, const UsdPrim& usdRootPrim);
 
     // Hook for derived classes to perform processing before import.
     // Method in this class is a no-op.
@@ -112,24 +112,41 @@ protected:
     MDagPath                                 mMayaRootDagPath;
 
 private:
+
+    // Import a range of prims. called by _DoImport and _ImportPrototype
+    void _ImportPrimRange(const UsdPrimRange& range, const UsdPrim& usdRootPrim);
+
+    // Delete the temporary prototypes once all instances are setup.
+    bool _CleanupPrototypes(const UsdPrim& usdRootPrim);
+
+    // Import a non-instance prim.
     void _DoImportPrimIt(
         UsdPrimRange::iterator&   primIt,
         const UsdPrim&            usdRootPrim,
         UsdMayaPrimReaderContext& readCtx,
         _PrimReaderMap&           primReaders);
 
+    // Import an instance prim. Will create the prototype if needed.
     void _DoImportInstanceIt(
         UsdPrimRange::iterator&   primIt,
         const UsdPrim&            usdRootPrim,
         UsdMayaPrimReaderContext& readCtx,
         _PrimReaderMap&           primReaders);
 
+    // Import a prototype to be used by instances.
     void _ImportPrototype(
         const UsdPrim&            prototype,
         const UsdPrim&            usdRootPrim,
         UsdMayaPrimReaderContext& readCtx);
 
     double _setTimeSampleMultiplierFrom(const double layerFPS);
+
+    void _ConvertUpAxis(const UsdStageRefPtr& stage);
+    bool _ConvertUpAxisWithRotation(
+        const UsdStageRefPtr& stage,
+        bool                  convertUsdYtoMayaZ,
+        bool                  keepParentGroup);
+    bool _ConvertUpAxisByChangingMayPrefs(const bool convertUsdYtoMayaZ);
 
     // Data
     MDagModifier mDagModifierUndo;

--- a/lib/mayaUsd/python/wrapPrimReader.cpp
+++ b/lib/mayaUsd/python/wrapPrimReader.cpp
@@ -473,6 +473,8 @@ void wrapJobImportArgs()
         .def_readonly(
             "importUSDZTexturesFilePath", &UsdMayaJobImportArgs::importUSDZTexturesFilePath)
         .def_readonly("importRelativeTextures", &UsdMayaJobImportArgs::importRelativeTextures)
+        .def_readonly("axisAndUnitMethod", &UsdMayaJobImportArgs::axisAndUnitMethod)
+        .def_readonly("upAxis", &UsdMayaJobImportArgs::upAxis)
         .def_readonly("importWithProxyShapes", &UsdMayaJobImportArgs::importWithProxyShapes)
         .add_property(
             "includeAPINames",

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
@@ -273,6 +273,22 @@ global proc mayaUSDRegisterStrings()
                                        "Plug-ins may have extra settings you can adjust.");
     register("kImportPluginConfigButtonAnn", "Options");
 
+    register("kImportAxisAndUnit", "Axis & Unit Conversion");
+    register("kImportUpAxis", "Up Axis");
+    register("kImportUpAxisAnn", "If selected, when an up axis mismatch is detected\n" +
+                                 "between the imported data and your scene preferences,\n" +
+                                 "an automatic correction will be performed.");
+    register("kImportAxisAndUnitMethod", "Method");
+    // Note: initial <b> is used to force Qt to render the text as HTML.
+    register("kImportAxisAndUnitMethodAnn", "<b></b>Select the method for axis/unit conversions.<br/>" +
+                                            "<br/>" +
+                                            "<b>Rotate/Scale</b>: Rotate/Scale the stage.<br/>" +
+                                            "<b>Add Parent Transform</b>: Rotate/Scale all objects within the imported data as a group<br/>" +
+                                            "<b>Overwrite Maya Preferences</b>: Update Maya's axis/unit preferences based on the imported data.");
+    register("kImportAxisAndUnitRotateScale", "Rotate/Scale");
+    register("kImportAxisAndUnitAddTransform", "Add Parent Transform");
+    register("kImportAxisAndUnitOverwritePrefs", "Overwrite Maya Preferences");
+
     register("kMayaDiscardEdits", "Discard Maya Edits");
     register("kMayaRefDiscardEdits", "Cancel Editing as Maya Data");
     register("kMayaRefDuplicateAsUsdData", "Duplicate As USD Data");

--- a/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
@@ -373,6 +373,9 @@ global proc mayaUsdTranslatorImport_EnableAllControls() {
 
     intFieldGrp -e -en1 1 -en2 1 mayaUsdTranslator_CustomFrameRange;
 
+    checkBoxGrp -e -en 1 mayaUsdTranslator_ImportUpAxisCheckBox;
+    optionMenuGrp -e -en 1 mayaUsdTranslator_ImportkImportAxisAndUnitMethodMenu;
+
     mayaUsdTranslatorImport_enableContextOptions();
 }
 
@@ -404,6 +407,10 @@ global proc mayaUsdTranslatorImport_SetFromOptions(string $currentOptions, int $
             } else if ($optionBreakDown[0] == "endTime") {
                 int $endTime = $optionBreakDown[1];
                 intFieldGrp -e -value2 $endTime -en2 $enable mayaUsdTranslator_CustomFrameRange;
+            } else if ($optionBreakDown[0] == "upAxis") {
+                mayaUsdTranslatorImport_SetCheckBoxGrp($optionBreakDown[1], $enable, "mayaUsdTranslator_ImportUpAxisCheckBox");
+            } else if ($optionBreakDown[0] == "axisAndUnitMethod") {
+                mayaUsdTranslatorImport_SetOptionMenuByAnnotation($optionBreakDown[1], $enable, "mayaUsdTranslator_ImportkImportAxisAndUnitMethodMenu");
             } else if ($optionBreakDown[0] == "useCustomFrameRange") {
                 mayaUsdTranslatorImport_SetCheckBoxGrp($optionBreakDown[1], $enable, "mayaUsdTranslator_CustomFrameRangeCheckBox");
                 mayaUsdTranslatorImport_AnimationCB();
@@ -574,6 +581,14 @@ global proc int mayaUsdTranslatorImport (string $parent,
             separator -style "none";
             checkBoxGrp -label "" -label1 `getMayaUsdString("kImportToInstanceOpt")` -cw 1 $cw1 -value1 1 -ann `getMayaUsdString("kImportToInstanceAnn")` mayaUsdTranslator_ImportInstancesCheckBox;
             separator -style "none";
+
+            frameLayout -label `getMayaUsdString("kImportAxisAndUnit")` axisAndUnitFrameLayout;
+                checkBoxGrp -label "" -label1 `getMayaUsdString("kImportUpAxis")` -cw 1 $cw1 -value1 1 -ann `getMayaUsdString("kImportUpAxisAnn")` mayaUsdTranslator_ImportUpAxisCheckBox;
+                optionMenuGrp -l `getMayaUsdString("kImportAxisAndUnitMethod")` -cw 1 $cw1 -ann `getMayaUsdString("kImportAxisAndUnitMethodAnn")` mayaUsdTranslator_ImportkImportAxisAndUnitMethodMenu;
+                    menuItem -l `getMayaUsdString("kImportAxisAndUnitRotateScale")` -ann "rotateScale";
+                    menuItem -l `getMayaUsdString("kImportAxisAndUnitAddTransform")` -ann "addTransform";
+                    menuItem -l `getMayaUsdString("kImportAxisAndUnitOverwritePrefs")` -ann "overwritePrefs";
+            setParent ..;
         setParent ..;
 
         // Now set to current settings.
@@ -604,6 +619,10 @@ global proc int mayaUsdTranslatorImport (string $parent,
         $currentOptions = mayaUsdTranslatorImport_queryContextOptionsUI($currentOptions, "jobContext");
         $currentOptions = mayaUsdTranslatorImport_AppendFromCheckBoxGrp($currentOptions, "importInstances", "mayaUsdTranslator_ImportInstancesCheckBox");
 
+        if (!$forEditAsMaya) {
+            $currentOptions = mayaUsdTranslatorImport_AppendFromCheckBoxGrp($currentOptions, "upAxis", "mayaUsdTranslator_ImportUpAxisCheckBox");
+            $currentOptions = mayaUsdTranslatorImport_AppendFromPopup($currentOptions, "axisAndUnitMethod", "mayaUsdTranslator_ImportkImportAxisAndUnitMethodMenu");
+        }
         eval($resultCallback+" \""+$currentOptions+"\"");
         $bResult = 1;
 

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -87,6 +87,7 @@ set(TEST_SCRIPT_FILES
     testUsdImportUSDZTextures.py
     testUsdExportImportRoundtripPreviewSurface.py
     testUsdImportSkeleton.py
+    testUsdImportUpAxis.py
     testUsdImportXforms.py
     testUsdImportXformAnim.py
     testUsdImportEulerFilter.py

--- a/test/lib/usd/translators/UsdImportUpAxisTests/UpAxisY.usda
+++ b/test/lib/usd/translators/UsdImportUpAxisTests/UpAxisY.usda
@@ -1,0 +1,20 @@
+#usda 1.0
+(
+    defaultPrim = "RootPrim"
+    metersPerUnit = 0.01
+    upAxis = "Y"
+)
+
+def Xform "RootPrim"
+{
+    def Mesh "SimpleMesh"
+    {
+        uniform bool doubleSided = 1
+        float3[] extent = [(-1, -1, 0), (1, 1, 0)]
+        int[] faceVertexCounts = [3]
+        int[] faceVertexIndices = [0, 1, 2]
+        point3f[] points = [(-1, -1, 0), (1, -1, 0), (0, 1, 0)]
+        color3f[] primvars:displayColor = [(0.2, 0, 0)]
+    }
+}
+

--- a/test/lib/usd/translators/testUsdImportUpAxis.py
+++ b/test/lib/usd/translators/testUsdImportUpAxis.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env mayapy
+#
+# Copyright 2024 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import maya.api.OpenMaya as om
+import os
+import unittest
+from math import radians
+
+from maya import cmds
+from maya import standalone
+
+from pxr import Gf
+
+import fixturesUtils
+
+def _GetMayaTransform(transformName):
+    '''Retrieve the transformation matrix of a Maya node.'''
+    selectionList = om.MSelectionList()
+    selectionList.add(transformName)
+    node = selectionList.getDependNode(0)
+    return om.MFnTransform(node)
+
+def _GetMayaMatrix(transformName):
+    '''Retrieve the three XYZ local rotation angles of a Maya node.'''
+    mayaTransform = _GetMayaTransform(transformName)
+    transformation = mayaTransform.transformation()
+    return transformation.asMatrix()
+
+def _GetRotationFromMatrix(matrix):
+    return om.MTransformationMatrix(matrix).rotation()
+
+def _GetMayaRotation(transformName):
+    return _GetRotationFromMatrix(_GetMayaMatrix(transformName))
+
+class testUsdImportUpAxis(unittest.TestCase):
+    """Test for modifying the up-axis when importing."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._path = fixturesUtils.setUpClass(__file__)
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def setUp(self):
+        """Clear the scene"""
+        cmds.file(f=True, new=True)
+        cmds.upAxis(axis='z')
+
+    def testImportChangeMayaPrefs(self):
+        """Test importing and changing the Maya up-axis preference."""
+        usd_file = os.path.join(self._path, "UsdImportUpAxisTests", "UpAxisY.usda")
+
+        cmds.mayaUSDImport(file=usd_file,
+                           primPath="/",
+                           upAxis=1,
+                           axisAndUnitMethod='overwritePrefs')
+        
+        expectedAxis = 'y'
+        actualAxis = cmds.upAxis(query=True, axis=True)
+        self.assertEqual(actualAxis, expectedAxis)
+
+    def testImportRotateGroup(self):
+        """Test importing and adding a group to hold the rotation."""
+        usd_file = os.path.join(self._path, "UsdImportUpAxisTests", "UpAxisY.usda")
+
+        cmds.mayaUSDImport(file=usd_file,
+                           primPath="/",
+                           upAxis=1,
+                           axisAndUnitMethod='addTransform')
+        
+        expectedAxis = 'z'
+        actualAxis = cmds.upAxis(query=True, axis=True)
+        self.assertEqual(actualAxis, expectedAxis)
+
+        rootNodes = cmds.ls('RootPrim_converted')
+        self.assertEqual(len(rootNodes), 1)
+
+        EPSILON = 1e-3
+
+        expectedRotation = _GetRotationFromMatrix(
+            om.MEulerRotation(radians(90.), radians(0.), radians(0.)).asMatrix())
+        actualRotation = _GetMayaRotation(rootNodes[0])
+        self.assertTrue(actualRotation.isEquivalent(expectedRotation))
+
+        self.assertEqual(cmds.getAttr('%s.OriginalUSDUpAxis' % rootNodes[0]), 'Y')
+
+    def testImportRotateRootNodes(self):
+        """Test importing and rotating the root nodes."""
+        usd_file = os.path.join(self._path, "UsdImportUpAxisTests", "UpAxisY.usda")
+
+        cmds.mayaUSDImport(file=usd_file,
+                           primPath="/",
+                           upAxis=1,
+                           axisAndUnitMethod='scaleRotate')
+        
+        expectedAxis = 'z'
+        actualAxis = cmds.upAxis(query=True, axis=True)
+        self.assertEqual(actualAxis, expectedAxis)
+
+        rootNodes = cmds.ls('RootPrim')
+        self.assertEqual(len(rootNodes), 1)
+
+        EPSILON = 1e-3
+
+        expectedRotation = _GetRotationFromMatrix(
+            om.MEulerRotation(radians(90.), radians(0.), radians(0.)).asMatrix())
+        actualRotation = _GetMayaRotation(rootNodes[0])
+        self.assertTrue(actualRotation.isEquivalent(expectedRotation))
+
+        self.assertEqual(cmds.getAttr('%s.OriginalUSDUpAxis' % rootNodes[0]), 'Y')
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
- Add -upAxis (-upa) and -axisAndUnitMethod (-aum) flags to the base import command.
- Document the new flags in the import command read-me file.
- Add upAxis and axisAndUnitMethod tokens to the import job args tokens.
- Add the rotateScale, addTransform and overwritePrefs tokens to the import job args token.
- Add the upAxis and axisAndUnitMethod data to the UsdMayaJobImportArgs structure.
- Handle parsing the new user args to build the UsdMayaJobImportArgs.
- Expose the upAxis and axisAndUnitMethod data to Python.
- Add the new UI related to upAxis and axisAndUnitMethod in the import UI.
- Add documentation about how to add a new import or export option.

Implement import rotation
- Add axis conversion helper to the UsdMaya_ReadJob class.
- Determine the Maya up-axis and USD up-axis.
- Do nothing if they match.
- Do nothing if the user requested to leave things as-is.
- Otherwise either change the Maya prefs or rotate the root imported objects.
- When rotating objects, group them under a group and rotate the group.
- The ungroup them if the user did not want to keep the group.
- Report success or failure of axis conversion.

Cleanup import code by refactoring into smaller functions to avoid code duplication.

Add unit tests for all three methods.