### PR TITLE
USD 24.11 adds explicit schemaIdentifier fields

### DIFF
--- a/lib/usd/schemas/plugInfo.json.in
+++ b/lib/usd/schemas/plugInfo.json.in
@@ -14,6 +14,7 @@
                         "bases": [
                             "UsdGeomXformable"
                         ],
+                        "schemaIdentifier": "ALMayaReference",
                         "schemaKind": "concreteTyped"
                     },
                     "MayaUsd_SchemasALMayaReference": {
@@ -24,6 +25,7 @@
                         "bases": [
                             "MayaUsd_SchemasMayaReference"
                         ],
+                        "schemaIdentifier": "MayaReference",
                         "schemaKind": "concreteTyped"
                     }
                 }

--- a/test/lib/mayaUsd/fileio/UsdCustomRigSchema/plugInfo.json
+++ b/test/lib/mayaUsd/fileio/UsdCustomRigSchema/plugInfo.json
@@ -14,6 +14,7 @@
                         "bases": [
                             "UsdTyped"
                         ], 
+                        "schemaIdentifier": "CustomRig", 
                         "schemaKind": "concreteTyped"
                     }
                 }


### PR DESCRIPTION
This still allows aliases as identifiers as a backup