### PR TITLE
EMSUSD-1654 Fixed Test a typo in testLight's testUsdVolumeLights

### DIFF
--- a/test/lib/ufe/testLight.py
+++ b/test/lib/ufe/testLight.py
@@ -291,7 +291,7 @@ class LightTestCase(unittest.TestCase):
         if (hasattr(ufe, "Light_v5_5")):
             ufeCylinderLight = ufe.Light_v5_5.light(cylinderlightItem)
         else:
-            ufeCylinderLight = ufe.light.light(cylinderlightItem)
+            ufeCylinderLight = ufe.Light.light(cylinderlightItem)
         usdCylinderLight = usdUtils.getPrimFromSceneItem(cylinderlightItem)
         self._TestCylinderLight(ufeCylinderLight, usdCylinderLight)
 


### PR DESCRIPTION
EMSUSD-1654 Fixed Test a typo in testLight's testUsdVolumeLights that causes the test to fail when there's no `Light_v5_5` attribute defined.