### PR TITLE
EMSUSD-1555 Duplicating a Physical Sky to USD using Arnold options is missing data

### DIFF
--- a/lib/mayaUsd/fileio/chaser/exportChaser.cpp
+++ b/lib/mayaUsd/fileio/chaser/exportChaser.cpp
@@ -35,4 +35,14 @@ bool UsdMayaExportChaser::PostExport()
     return true;
 }
 
+void UsdMayaExportChaser::RegisterExtraPrimsPaths(const std::vector<SdfPath>& extraPrimPaths)
+{
+    _extraPrimsPaths.insert(_extraPrimsPaths.end(), extraPrimPaths.begin(), extraPrimPaths.end());
+}
+
+const std::vector<SdfPath>& UsdMayaExportChaser::GetExtraPrimsPaths() const
+{
+    return _extraPrimsPaths;
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/chaser/exportChaser.h
+++ b/lib/mayaUsd/fileio/chaser/exportChaser.h
@@ -21,6 +21,7 @@
 #include <pxr/base/tf/declarePtrs.h>
 #include <pxr/base/tf/refPtr.h>
 #include <pxr/pxr.h>
+#include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/timeCode.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -69,6 +70,20 @@ public:
     /// Returning false will terminate the whole export.
     MAYAUSD_CORE_PUBLIC
     virtual bool PostExport();
+
+    /// Optional helper method to cache the given path array in the chaser.
+    /// The cached array is used internally to track any extra prim created by the chasers.
+    /// For example: when duplicating Maya data to USD we'll internally ask the chaser for those.
+    MAYAUSD_CORE_PUBLIC
+    virtual void RegisterExtraPrimsPaths(const std::vector<SdfPath>& extraPrimPaths);
+
+    /// Get the array of extra prim paths set by the chaser.
+    /// Returns the array of cached prim paths.
+    MAYAUSD_CORE_PUBLIC
+    virtual const std::vector<SdfPath>& GetExtraPrimsPaths() const;
+
+private:
+    std::vector<SdfPath> _extraPrimsPaths;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -729,6 +729,7 @@ UsdMayaJobExportArgs::UsdMayaJobExportArgs(
     , ignoreWarnings(extractBoolean(userArgs, UsdMayaJobExportArgsTokens->ignoreWarnings))
     , includeEmptyTransforms(
           extractBoolean(userArgs, UsdMayaJobExportArgsTokens->includeEmptyTransforms))
+    , isDuplicating(extractBoolean(userArgs, UsdMayaJobExportArgsTokens->isDuplicating))
     , materialCollectionsPath(
           extractAbsolutePath(userArgs, UsdMayaJobExportArgsTokens->materialCollectionsPath))
     , materialsScopeName(_GetMaterialsScopeName(
@@ -840,7 +841,7 @@ std::ostream& operator<<(std::ostream& out, const UsdMayaJobExportArgs& exportAr
         << "file: " << exportArgs.file << std::endl
         << "ignoreWarnings: " << TfStringify(exportArgs.ignoreWarnings) << std::endl
         << "includeEmptyTransforms: " << TfStringify(exportArgs.includeEmptyTransforms)
-        << std::endl;
+        << "isDuplicating: " << TfStringify(exportArgs.isDuplicating) << std::endl;
     out << "includeAPINames (" << exportArgs.includeAPINames.size() << ")" << std::endl;
     for (const std::string& includeAPIName : exportArgs.includeAPINames) {
         out << "    " << includeAPIName << std::endl;
@@ -1124,6 +1125,7 @@ const VtDictionary& UsdMayaJobExportArgs::GetDefaultDictionary()
         d[UsdMayaJobExportArgsTokens->filterTypes] = std::vector<VtValue>();
         d[UsdMayaJobExportArgsTokens->ignoreWarnings] = false;
         d[UsdMayaJobExportArgsTokens->includeEmptyTransforms] = true;
+        d[UsdMayaJobExportArgsTokens->isDuplicating] = false;
         d[UsdMayaJobExportArgsTokens->kind] = std::string();
         d[UsdMayaJobExportArgsTokens->disableModelKindProcessor] = false;
         d[UsdMayaJobExportArgsTokens->materialCollectionsPath] = std::string();
@@ -1228,6 +1230,7 @@ const VtDictionary& UsdMayaJobExportArgs::GetGuideDictionary()
         d[UsdMayaJobExportArgsTokens->filterTypes] = _stringVector;
         d[UsdMayaJobExportArgsTokens->ignoreWarnings] = _boolean;
         d[UsdMayaJobExportArgsTokens->includeEmptyTransforms] = _boolean;
+        d[UsdMayaJobExportArgsTokens->isDuplicating] = _boolean;
         d[UsdMayaJobExportArgsTokens->kind] = _string;
         d[UsdMayaJobExportArgsTokens->disableModelKindProcessor] = _boolean;
         d[UsdMayaJobExportArgsTokens->materialCollectionsPath] = _string;

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -93,6 +93,7 @@ TF_DECLARE_PUBLIC_TOKENS(
     (filterTypes) \
     (ignoreWarnings) \
     (includeEmptyTransforms) \
+    (isDuplicating) \
     (kind) \
     (disableModelKindProcessor) \
     (materialCollectionsPath) \
@@ -232,6 +233,7 @@ struct UsdMayaJobExportArgs
     const std::string file;
     const bool        ignoreWarnings;
     const bool        includeEmptyTransforms;
+    const bool        isDuplicating;
 
     /// If this is not empty, then a set of collections are exported on the
     /// prim pointed to by the path, each representing the collection of

--- a/lib/mayaUsd/fileio/jobs/writeJob.h
+++ b/lib/mayaUsd/fileio/jobs/writeJob.h
@@ -59,6 +59,10 @@ public:
     MAYAUSD_CORE_PUBLIC
     const std::vector<SdfPath>& GetMaterialPaths() { return mJobCtx.GetMaterialPaths(); }
 
+    // Cached prims paths from chasers
+    MAYAUSD_CORE_PUBLIC
+    const std::vector<SdfPath>& GetExtraPrimsPaths() { return _extrasPrimsPaths; }
+
 private:
     /// Begins constructing the USD stage, writing out the values at the default
     /// time. Returns \c true if the stage can be created successfully.
@@ -101,6 +105,9 @@ private:
     MObjectArray mRenderLayerObjs;
 
     UsdMayaUtil::MDagPathMap<SdfPath> mDagPathToUsdPathMap;
+
+    // Array to track any extra prims created chasers
+    std::vector<SdfPath> _extrasPrimsPaths;
 
     // Currently only used if stripNamespaces is on, to ensure we don't have clashes
     TfHashMap<SdfPath, MDagPath, SdfPath::Hash> mUsdPathToDagPathMap;

--- a/lib/mayaUsd/python/wrapExportChaser.cpp
+++ b/lib/mayaUsd/python/wrapExportChaser.cpp
@@ -176,6 +176,16 @@ void wrapExportChaser()
         .def("ExportDefault", &This::ExportDefault, &ExportChaserWrapper::default_ExportDefault)
         .def("ExportFrame", &This::ExportFrame, &ExportChaserWrapper::default_ExportFrame)
         .def("PostExport", &This::PostExport, &ExportChaserWrapper::default_PostExport)
+        .def(
+            "RegisterExtraPrimsPaths",
+            &This::RegisterExtraPrimsPaths,
+            boost::python::arg("extraPrimPaths"),
+            "Method to cache the path for any extra prim path created by the chaser.")
+        .def(
+            "GetExtraPrimsPaths",
+            &This::GetExtraPrimsPaths,
+            boost::python::return_internal_reference<>(),
+            "Get the array of the currently cached extra paths.")
         .def("Register", &ExportChaserWrapper::Register)
         .staticmethod("Register")
         .def("Unregister", &ExportChaserWrapper::Unregister)

--- a/lib/mayaUsd/python/wrapPrimWriter.cpp
+++ b/lib/mayaUsd/python/wrapPrimWriter.cpp
@@ -574,6 +574,7 @@ void wrapJobExportArgs()
                 &UsdMayaJobExportArgs::geomSidedness, return_value_policy<return_by_value>()))
         .def_readonly("ignoreWarnings", &UsdMayaJobExportArgs::ignoreWarnings)
         .def_readonly("includeEmptyTransforms", &UsdMayaJobExportArgs::includeEmptyTransforms)
+        .def_readonly("isDuplicating", &UsdMayaJobExportArgs::isDuplicating)
         .add_property(
             "includeAPINames",
             make_getter(


### PR DESCRIPTION
When "Duplicate as Usd data" is select from the context ops menu on a maya object, we only translate to Usd the selected maya object.
This can be a problem when there are extra prims created by a chaser, for example. Those would be discarded.

With those changes, we allow the users to register the path for those extra prims created so that it can be queried when merging the maya object into Usd.