### PR TITLE
EMSUSD-947 units conversion for USD import

### DIFF
--- a/lib/mayaUsd/commands/Readme.md
+++ b/lib/mayaUsd/commands/Readme.md
@@ -54,6 +54,7 @@ Each base command class is documented in the following sections.
 | `-importUSDZTexturesFilePath` | `-itf`     | string         | none                              | Specifies an explicit directory to write imported textures to from a USDZ archive. Has no effect if `-importUSDZTextures` is not specified. |
 | `-importRelativeTextures`     | `-rtx`     | string         | none                              | Selects how textures filenames are generated: absolute, relative, automatic or none. When automatic, the filename is relative if the source filename of the texture being imported is relative. When none, the file path is left alone, for backward compatible behavior. |
 | `-upAxis`                     | `-upa`     | bool           | true                              | Enable changing axis on import. |
+| `-unit`                       | `-unt`     | bool           | true                              | Enable changing units on import. |
 | `-axisAndUnitMethod`          | `-aum`     | string         | rotateScale                       | Selects how the unit and axis are handled during import. |
 
 ### Return Value

--- a/lib/mayaUsd/commands/baseImportCommand.cpp
+++ b/lib/mayaUsd/commands/baseImportCommand.cpp
@@ -70,6 +70,7 @@ MSyntax MayaUSDImportCommand::createSyntax()
         MSyntax::kString);
     syntax.addFlag(
         kImportUpAxisFlag, UsdMayaJobImportArgsTokens->upAxis.GetText(), MSyntax::kBoolean);
+    syntax.addFlag(kImportUnitFlag, UsdMayaJobImportArgsTokens->unit.GetText(), MSyntax::kBoolean);
     syntax.addFlag(
         kImportAxisAndUnitMethodFlag,
         UsdMayaJobImportArgsTokens->axisAndUnitMethod.GetText(),

--- a/lib/mayaUsd/commands/baseImportCommand.h
+++ b/lib/mayaUsd/commands/baseImportCommand.h
@@ -47,6 +47,7 @@ public:
     static constexpr auto kImportUSDZTexturesFilePathFlag = "itf";
     static constexpr auto kImportRelativeTexturesFlag = "rtx";
     static constexpr auto kImportUpAxisFlag = "upa";
+    static constexpr auto kImportUnitFlag = "unt";
     static constexpr auto kImportAxisAndUnitMethodFlag = "aum";
     static constexpr auto kMetadataFlag = "md";
     static constexpr auto kApiSchemaFlag = "api";

--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -1382,6 +1382,7 @@ UsdMayaJobImportArgs::UsdMayaJobImportArgs(
             UsdMayaJobImportArgsTokens->addTransform,
             UsdMayaJobImportArgsTokens->overwritePrefs }))
     , upAxis(extractBoolean(userArgs, UsdMayaJobImportArgsTokens->upAxis))
+    , unit(extractBoolean(userArgs, UsdMayaJobImportArgsTokens->unit))
     , importInstances(extractBoolean(userArgs, UsdMayaJobImportArgsTokens->importInstances))
     , useAsAnimationCache(extractBoolean(userArgs, UsdMayaJobImportArgsTokens->useAsAnimationCache))
     , importWithProxyShapes(importWithProxyShapes)
@@ -1473,6 +1474,7 @@ const VtDictionary& UsdMayaJobImportArgs::GetDefaultDictionary()
         d[UsdMayaJobImportArgsTokens->axisAndUnitMethod]
             = UsdMayaJobImportArgsTokens->rotateScale.GetString();
         d[UsdMayaJobImportArgsTokens->upAxis] = true;
+        d[UsdMayaJobImportArgsTokens->unit] = true;
         d[UsdMayaJobImportArgsTokens->pullImportStage] = UsdStageRefPtr();
         d[UsdMayaJobImportArgsTokens->useAsAnimationCache] = false;
         d[UsdMayaJobImportArgsTokens->preserveTimeline] = false;
@@ -1557,6 +1559,7 @@ const VtDictionary& UsdMayaJobImportArgs::GetGuideDictionary()
         d[UsdMayaJobImportArgsTokens->importRelativeTextures] = _string;
         d[UsdMayaJobImportArgsTokens->axisAndUnitMethod] = _string;
         d[UsdMayaJobImportArgsTokens->upAxis] = _boolean;
+        d[UsdMayaJobImportArgsTokens->unit] = _boolean;
         d[UsdMayaJobImportArgsTokens->pullImportStage] = _usdStageRefPtr;
         d[UsdMayaJobImportArgsTokens->useAsAnimationCache] = _boolean;
         d[UsdMayaJobImportArgsTokens->preserveTimeline] = _boolean;
@@ -1649,6 +1652,7 @@ std::ostream& operator<<(std::ostream& out, const UsdMayaJobImportArgs& importAr
         << "importRelativeTextures: " << TfStringify(importArgs.importRelativeTextures) << std::endl
         << "axisAndUnitMethod: " << TfStringify(importArgs.axisAndUnitMethod) << std::endl
         << "upAxis: " << TfStringify(importArgs.upAxis) << std::endl
+        << "unit: " << TfStringify(importArgs.unit) << std::endl
         << "pullImportStage: " << TfStringify(importArgs.pullImportStage) << std::endl
         << std::endl
         << "timeInterval: " << importArgs.timeInterval << std::endl

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -197,6 +197,7 @@ TF_DECLARE_PUBLIC_TOKENS(
     (preserveTimeline) \
     (remapUVSetsTo) \
     (upAxis) \
+    (unit) \
     (axisAndUnitMethod) \
     /* values for axis and unit method */ \
     (rotateScale) \
@@ -436,6 +437,7 @@ struct UsdMayaJobImportArgs
     const std::string    importRelativeTextures;
     const std::string    axisAndUnitMethod;
     const bool           upAxis;
+    const bool           unit;
     const bool           importInstances;
     const bool           useAsAnimationCache;
     const bool           importWithProxyShapes;

--- a/lib/mayaUsd/fileio/jobs/readJob.h
+++ b/lib/mayaUsd/fileio/jobs/readJob.h
@@ -141,12 +141,25 @@ private:
 
     double _setTimeSampleMultiplierFrom(const double layerFPS);
 
-    void _ConvertUpAxis(const UsdStageRefPtr& stage);
-    bool _ConvertUpAxisWithRotation(
+    struct ConversionInfo
+    {
+        bool isMayaUpAxisZ { false };
+        bool isUSDUpAxisUZ { false };
+        bool needUpAxisConversion { false };
+
+        double mayaMetersPerUnit = { 0.01 };
+        double usdMetersPerUnit = { 0.01 };
+        bool   needUnitsConversion = { false };
+    };
+
+    void _ConvertUpAxisAndUnits(const UsdStageRefPtr& stage);
+    void _ConvertUpAxisAndUnitsByModifyingData(
         const UsdStageRefPtr& stage,
-        bool                  convertUsdYtoMayaZ,
+        const ConversionInfo& conversion,
         bool                  keepParentGroup);
-    bool _ConvertUpAxisByChangingMayPrefs(const bool convertUsdYtoMayaZ);
+    void _ConvertUpAxisAndUnitsByChangingMayaPrefs(
+        const UsdStageRefPtr& stage,
+        const ConversionInfo& conversion);
 
     // Data
     MDagModifier mDagModifierUndo;

--- a/lib/mayaUsd/fileio/jobs/writeJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/writeJob.cpp
@@ -493,8 +493,6 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
     _autoAxisAndUnitsChanger = std::make_unique<AutoUpAxisAndUnitsChanger>(
         mJobCtx.mStage, mJobCtx.mArgs.upAxis, mJobCtx.mArgs.unit);
 
-    // TODO: handle mJobCtx.mArgs.unit
-
     // Set the customLayerData on the layer
     if (!mJobCtx.mArgs.customLayerData.empty()) {
         mJobCtx.mStage->GetRootLayer()->SetCustomLayerData(mJobCtx.mArgs.customLayerData);

--- a/lib/mayaUsd/python/wrapPrimReader.cpp
+++ b/lib/mayaUsd/python/wrapPrimReader.cpp
@@ -475,6 +475,7 @@ void wrapJobImportArgs()
         .def_readonly("importRelativeTextures", &UsdMayaJobImportArgs::importRelativeTextures)
         .def_readonly("axisAndUnitMethod", &UsdMayaJobImportArgs::axisAndUnitMethod)
         .def_readonly("upAxis", &UsdMayaJobImportArgs::upAxis)
+        .def_readonly("unit", &UsdMayaJobImportArgs::unit)
         .def_readonly("importWithProxyShapes", &UsdMayaJobImportArgs::importWithProxyShapes)
         .add_property(
             "includeAPINames",

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -148,6 +148,20 @@ double UsdMayaUtil::ConvertMDistanceUnitToUsdGeomLinearUnit(const MDistance::Uni
     }
 }
 
+MString UsdMayaUtil::ConvertMDistanceUnitToText(const MDistance::Unit mdistanceUnit)
+{
+    static std::map<MDistance::Unit, const char*> unitsConversionMap
+        = { { MDistance::kMillimeters, "mm" }, { MDistance::kCentimeters, "cm" },
+            { MDistance::kMeters, "m" },       { MDistance::kKilometers, "km" },
+            { MDistance::kInches, "inch" },    { MDistance::kFeet, "foot" },
+            { MDistance::kYards, "yard" },     { MDistance::kMiles, "mile" } };
+
+    const auto iter = unitsConversionMap.find(mdistanceUnit);
+    if (iter == unitsConversionMap.end())
+        return "cm";
+    return iter->second;
+}
+
 MDistance::Unit UsdMayaUtil::ConvertUsdGeomLinearUnitToMDistanceUnit(const double linearUnit)
 {
     if (UsdGeomLinearUnitsAre(linearUnit, UsdGeomLinearUnits::millimeters)) {
@@ -175,8 +189,7 @@ MDistance::Unit UsdMayaUtil::ConvertUsdGeomLinearUnitToMDistanceUnit(const doubl
         return MDistance::kMiles;
     }
 
-    TF_CODING_ERROR("Invalid UsdGeomLinearUnit %f. Assuming centimeters", linearUnit);
-    return MDistance::kCentimeters;
+    return MDistance::kInvalid;
 }
 
 double UsdMayaUtil::GetExportDistanceConversionScalar(const double metersPerUnit)

--- a/lib/mayaUsd/utils/util.h
+++ b/lib/mayaUsd/utils/util.h
@@ -152,6 +152,11 @@ double ConvertMDistanceUnitToUsdGeomLinearUnit(const MDistance::Unit mdistanceUn
 MAYAUSD_CORE_PUBLIC
 MDistance::Unit ConvertUsdGeomLinearUnitToMDistanceUnit(const double linearUnit);
 
+/// Convert the given \p mdistanceYnit into its text representation suitable
+/// to be used with the currentUnit MEL command. Invalid units return "cm".
+MAYAUSD_CORE_PUBLIC
+MString ConvertMDistanceUnitToText(const MDistance::Unit mdistanceUnit);
+
 /// Returns a scaling value from Maya's internal units to the specified \p metersPerUnit
 MAYAUSD_CORE_PUBLIC
 double GetExportDistanceConversionScalar(const double metersPerUnit);

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.mel
@@ -305,6 +305,10 @@ global proc mayaUSDRegisterStrings()
     register("kImportUpAxisAnn", "If selected, when an up axis mismatch is detected\n" +
                                  "between the imported data and your scene preferences,\n" +
                                  "an automatic correction will be performed.");
+    register("kImportUnit", "Unit");
+    register("kImportUnitAnn", "If selected, when a unit mismatch is detected\n" +
+                                 "between the imported data and your scene preferences,\n" +
+                                 "an automatic correction will be performed.");
     register("kImportAxisAndUnitMethod", "Method");
     // Note: initial <b> is used to force Qt to render the text as HTML.
     register("kImportAxisAndUnitMethodAnn", "<b></b>Select the method for axis/unit conversions.<br/>" +

--- a/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorImport.mel
@@ -374,6 +374,7 @@ global proc mayaUsdTranslatorImport_EnableAllControls() {
     intFieldGrp -e -en1 1 -en2 1 mayaUsdTranslator_CustomFrameRange;
 
     checkBoxGrp -e -en 1 mayaUsdTranslator_ImportUpAxisCheckBox;
+    checkBoxGrp -e -en 1 mayaUsdTranslator_ImportUnitCheckBox;
     optionMenuGrp -e -en 1 mayaUsdTranslator_ImportkImportAxisAndUnitMethodMenu;
 
     mayaUsdTranslatorImport_enableContextOptions();
@@ -409,6 +410,8 @@ global proc mayaUsdTranslatorImport_SetFromOptions(string $currentOptions, int $
                 intFieldGrp -e -value2 $endTime -en2 $enable mayaUsdTranslator_CustomFrameRange;
             } else if ($optionBreakDown[0] == "upAxis") {
                 mayaUsdTranslatorImport_SetCheckBoxGrp($optionBreakDown[1], $enable, "mayaUsdTranslator_ImportUpAxisCheckBox");
+            } else if ($optionBreakDown[0] == "unit") {
+                mayaUsdTranslatorImport_SetCheckBoxGrp($optionBreakDown[1], $enable, "mayaUsdTranslator_ImportUnitCheckBox");
             } else if ($optionBreakDown[0] == "axisAndUnitMethod") {
                 mayaUsdTranslatorImport_SetOptionMenuByAnnotation($optionBreakDown[1], $enable, "mayaUsdTranslator_ImportkImportAxisAndUnitMethodMenu");
             } else if ($optionBreakDown[0] == "useCustomFrameRange") {
@@ -584,6 +587,7 @@ global proc int mayaUsdTranslatorImport (string $parent,
 
             frameLayout -label `getMayaUsdString("kImportAxisAndUnit")` axisAndUnitFrameLayout;
                 checkBoxGrp -label "" -label1 `getMayaUsdString("kImportUpAxis")` -cw 1 $cw1 -value1 1 -ann `getMayaUsdString("kImportUpAxisAnn")` mayaUsdTranslator_ImportUpAxisCheckBox;
+                checkBoxGrp -label "" -label1 `getMayaUsdString("kImportUnit")` -cw 1 $cw1 -value1 1 -ann `getMayaUsdString("kImportUnitAnn")` mayaUsdTranslator_ImportUnitCheckBox;
                 optionMenuGrp -l `getMayaUsdString("kImportAxisAndUnitMethod")` -cw 1 $cw1 -ann `getMayaUsdString("kImportAxisAndUnitMethodAnn")` mayaUsdTranslator_ImportkImportAxisAndUnitMethodMenu;
                     menuItem -l `getMayaUsdString("kImportAxisAndUnitRotateScale")` -ann "rotateScale";
                     menuItem -l `getMayaUsdString("kImportAxisAndUnitAddTransform")` -ann "addTransform";
@@ -621,6 +625,7 @@ global proc int mayaUsdTranslatorImport (string $parent,
 
         if (!$forEditAsMaya) {
             $currentOptions = mayaUsdTranslatorImport_AppendFromCheckBoxGrp($currentOptions, "upAxis", "mayaUsdTranslator_ImportUpAxisCheckBox");
+            $currentOptions = mayaUsdTranslatorImport_AppendFromCheckBoxGrp($currentOptions, "unit", "mayaUsdTranslator_ImportUnitCheckBox");
             $currentOptions = mayaUsdTranslatorImport_AppendFromPopup($currentOptions, "axisAndUnitMethod", "mayaUsdTranslator_ImportkImportAxisAndUnitMethodMenu");
         }
         eval($resultCallback+" \""+$currentOptions+"\"");

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -89,6 +89,7 @@ set(TEST_SCRIPT_FILES
     testUsdImportUSDZTextures.py
     testUsdExportImportRoundtripPreviewSurface.py
     testUsdImportSkeleton.py
+    testUsdImportUnits.py
     testUsdImportUpAxis.py
     testUsdImportXforms.py
     testUsdImportXformAnim.py

--- a/test/lib/usd/translators/UsdImportUnitsTests/UnitsMillimeters.usda
+++ b/test/lib/usd/translators/UsdImportUnitsTests/UnitsMillimeters.usda
@@ -1,0 +1,20 @@
+#usda 1.0
+(
+    defaultPrim = "RootPrim"
+    metersPerUnit = 0.001
+    upAxis = "Y"
+)
+
+def Xform "RootPrim"
+{
+    def Mesh "SimpleMesh"
+    {
+        uniform bool doubleSided = 1
+        float3[] extent = [(-1, -1, 0), (1, 1, 0)]
+        int[] faceVertexCounts = [3]
+        int[] faceVertexIndices = [0, 1, 2]
+        point3f[] points = [(-1, -1, 0), (1, -1, 0), (0, 1, 0)]
+        color3f[] primvars:displayColor = [(0.2, 0, 0)]
+    }
+}
+

--- a/test/lib/usd/translators/testUsdImportUnits.py
+++ b/test/lib/usd/translators/testUsdImportUnits.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env mayapy
+#
+# Copyright 2024 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import maya.api.OpenMaya as om
+import os
+import unittest
+
+from maya import cmds
+from maya import standalone
+
+from pxr import Gf
+
+import fixturesUtils
+
+
+def _GetMayaTransform(transformName):
+    '''Retrieve the Maya SDK transformation API (MFnTransform) of a Maya node.'''
+    selectionList = om.MSelectionList()
+    selectionList.add(transformName)
+    node = selectionList.getDependNode(0)
+    return om.MFnTransform(node)
+
+def _GetMayaMatrix(transformName):
+    '''Retrieve the transformation matrix (MMatrix) of a Maya node.'''
+    mayaTransform = _GetMayaTransform(transformName)
+    transformation = mayaTransform.transformation()
+    return transformation.asMatrix()
+
+def _GetScalingFromMatrix(matrix):
+    '''Extract the scaling from a Maya matrix.'''
+    return om.MTransformationMatrix(matrix).scale(om.MSpace.kObject)
+
+def _GetMayaScaling(transformName):
+    '''Extract the scaling from a Maya node.'''
+    return _GetScalingFromMatrix(_GetMayaMatrix(transformName))
+
+
+class testUsdImportUpAxis(unittest.TestCase):
+    """Test for modifying the up-axis when importing."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._path = fixturesUtils.setUpClass(__file__)
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def setUp(self):
+        """Clear the scene"""
+        cmds.file(f=True, new=True)
+        # Make sure up-axis is Y like in teh USD file.
+        cmds.upAxis(axis='y')
+        # Make sure the units are centimeters.
+        cmds.currentUnit(linear='cm')
+
+    @unittest.skip('Preference is changed on idle, so we cannot get the new settings in a test.')
+    def testImportChangeMayaPrefs(self):
+        """Test importing and changing the Maya unit preference."""
+        usd_file = os.path.join(self._path, "UsdImportUnitsTests", "UnitsMillimeters.usda")
+
+        cmds.mayaUSDImport(file=usd_file,
+                           primPath="/",
+                           unit=1,
+                           axisAndUnitMethod='overwritePrefs')
+
+        cmds.sleep
+
+        # Preference should have been changed.
+        expectedUnits = 'mm'
+        actualUnits = cmds.currentUnit(query=True, linear=True)
+        self.assertEqual(actualUnits, expectedUnits)
+
+    def testImportScaleGroup(self):
+        """Test importing and adding a group to hold the scaling."""
+        usd_file = os.path.join(self._path, "UsdImportUnitsTests", "UnitsMillimeters.usda")
+
+        cmds.mayaUSDImport(file=usd_file,
+                           primPath="/",
+                           unit=1,
+                           axisAndUnitMethod='addTransform')
+        
+        # Preference should have been left alone.
+        expectedUnits = 'cm'
+        actualUnits = cmds.currentUnit(query=True, linear=True)
+        self.assertEqual(actualUnits, expectedUnits)
+
+        rootNodes = cmds.ls('RootPrim_converted')
+        self.assertEqual(len(rootNodes), 1)
+
+        EPSILON = 1e-6
+
+        expectedScaling = [0.1, 0.1, 0.1]
+        actualScaling = _GetMayaScaling(rootNodes[0])
+        self.assertTrue(Gf.IsClose(actualScaling, expectedScaling, EPSILON))
+
+        self.assertEqual(cmds.getAttr('%s.OriginalUSDMetersPerUnit' % rootNodes[0]), '0.001')
+
+    def testImportScaleRootNodes(self):
+        """Test importing and scaling the root nodes."""
+        usd_file = os.path.join(self._path, "UsdImportUnitsTests", "UnitsMillimeters.usda")
+
+        cmds.mayaUSDImport(file=usd_file,
+                           primPath="/",
+                           unit=1,
+                           axisAndUnitMethod='scaleRotate')
+        
+        # Preference should have been left alone.
+        expectedUnits = 'cm'
+        actualUnits = cmds.currentUnit(query=True, linear=True)
+        self.assertEqual(actualUnits, expectedUnits)
+
+        rootNodes = cmds.ls('RootPrim')
+        self.assertEqual(len(rootNodes), 1)
+
+        EPSILON = 1e-6
+
+        expectedScaling = [0.1, 0.1, 0.1]
+        actualScaling = _GetMayaScaling(rootNodes[0])
+        self.assertTrue(Gf.IsClose(actualScaling, expectedScaling, EPSILON))
+
+        self.assertEqual(cmds.getAttr('%s.OriginalUSDMetersPerUnit' % rootNodes[0]), '0.001')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
- Add -unit (-unt) option to the import command.
- Document it.
- Add unit option to the job import argument structure.
- Parse the unit option.
- Expose it to Python.
- Add check-box UI to the import UI.
- Add private structure to the import read job class to hold all conversion info.
- Remove old warning about unit conversion not being implemented.
- Refactor the code for up-axis conversion to also handle the units conversion.
- Change prefs for units if requested and needed.
- Add unit tests.