### PR TITLE
LOOKDEVX-2640 - Fix compilation error when using geomcolor nodes

### DIFF
--- a/lib/mayaUsd/render/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
@@ -114,6 +114,19 @@ void fixupVertexDataInstance(ShaderStage& stage)
         = "[$]" + d(HW::T_VERTEX_DATA_INSTANCE) + "[.][$](" + d(HW::T_TEXCOORD) + "_[0-9]+)";
     static const std::regex vdCleanTexRegex(vdCleanTexSource.c_str());
 
+    // Find keywords:                                (as text)
+    //
+    //  HW::T_VERTEX_DATA_INSTANCE.(T_COLOR_INDEX)   $vd.$color_0;
+    //
+    // And replace with:
+    //
+    //  (T_COLOR_INDEX)                              color_0;
+    //
+
+    static const std::string vdCleanColorSource
+        = "[$]" + d(HW::T_VERTEX_DATA_INSTANCE) + "[.][$](" + d(HW::T_COLOR) + "_[0-9]+)";
+    static const std::regex vdCleanColorRegex(vdCleanColorSource.c_str());
+
     std::string code = stage.getSourceCode();
     code = std::regex_replace(code, paramRegex, "vec3 unused_$1");
     code = std::regex_replace(code, vtxRegex, "$$$1( PIX_IN.$$$1 )");
@@ -121,6 +134,7 @@ void fixupVertexDataInstance(ShaderStage& stage)
     code = std::regex_replace(code, texcoordParamRegex, "vec$1 unused_$2");
     code = std::regex_replace(code, vdCleanGeoRegex, "PIX_IN.$1");
     code = std::regex_replace(code, vdCleanTexRegex, "PIX_IN.$1");
+    code = std::regex_replace(code, vdCleanColorRegex, "$1");
 
 #if MX_COMBINED_VERSION >= 13804
     stage.setSourceCode(code);

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/OgsXmlGenerator.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/OgsXmlGenerator.cpp
@@ -77,7 +77,7 @@ static const std::unordered_map<string, const pugi::char_t*> OGS_SEMANTICS_MAP =
 
 static const vector<std::pair<string, const pugi::char_t*>> OGS_SEMANTICS_PREFIX_MAP
     = { { "texcoord_", "mayaUvCoordSemantic" },
-        { "color_", "colorset" },
+        { "color_", "fcolor" },
         { "i_geomprop_", "mayaUvCoordSemantic" } };
 
 namespace OgsParameterFlags {


### PR DESCRIPTION
Does not affect USD since geompropvalue should be used instead for accessing vertex color streams.