### PR TITLE
EMSUSD-1700 make up-axis and units attribute visible

### DIFF
--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -572,10 +572,12 @@ static std::string _cleanMayaNodeName(const std::string& name)
 static void _addOrignalUpAxisAttribute(const std::vector<MDagPath>& dagNodePaths, bool isUSDUpAxisZ)
 {
     const MString originalUpAxis = isUSDUpAxisZ ? "Z" : "Y";
-    const MString attrName = "OriginalUSDUpAxis";
+    const MString attrName = "OriginalUpAxis";
     for (const MDagPath& dagPath : dagNodePaths) {
         MFnDependencyNode depNode(dagPath.node());
-        MayaUsd::setDynamicAttribute(depNode, attrName, originalUpAxis);
+        using namespace MayaUsd;
+        const auto flags = DynamicAttrFlags::kDefaults & ~DynamicAttrFlags::kHidden;
+        MayaUsd::setDynamicAttribute(depNode, attrName, originalUpAxis, flags);
     }
 }
 
@@ -584,10 +586,12 @@ _addOrignalUnitsAttribute(const std::vector<MDagPath>& dagNodePaths, double usdM
 {
     MString originalUnits;
     originalUnits.set(usdMetersPerUnit);
-    const MString attrName = "OriginalUSDMetersPerUnit";
+    const MString attrName = "OriginalMetersPerUnit";
     for (const MDagPath& dagPath : dagNodePaths) {
         MFnDependencyNode depNode(dagPath.node());
-        MayaUsd::setDynamicAttribute(depNode, attrName, originalUnits);
+        using namespace MayaUsd;
+        const auto flags = DynamicAttrFlags::kDefaults & ~DynamicAttrFlags::kHidden;
+        MayaUsd::setDynamicAttribute(depNode, attrName, originalUnits, flags);
     }
 }
 

--- a/lib/mayaUsd/utils/dynamicAttribute.cpp
+++ b/lib/mayaUsd/utils/dynamicAttribute.cpp
@@ -29,19 +29,27 @@ bool hasDynamicAttribute(const MFnDependencyNode& depNode, const MString& attrNa
     return depNode.hasAttribute(attrName);
 }
 
-MStatus createDynamicAttribute(MFnDependencyNode& depNode, const MString& attrName)
+MStatus createDynamicAttribute(
+    MFnDependencyNode&     depNode,
+    const MString&         attrName,
+    const DynamicAttrFlags flags)
 {
     MStatus status;
 
-    MFnTypedAttribute typedAttrFn;
-    MObject attr = typedAttrFn.create(attrName, "", MFnData::kString, MObject::kNullObj, &status);
+    MFnTypedAttribute attrFn;
+    MObject attr = attrFn.create(attrName, "", MFnData::kString, MObject::kNullObj, &status);
     CHECK_MSTATUS_AND_RETURN_IT(status);
 
-    typedAttrFn.setReadable(true);
-    typedAttrFn.setWritable(true);
-    typedAttrFn.setHidden(true);
-    typedAttrFn.setKeyable(false);
-    typedAttrFn.setStorable(true);
+    attrFn.setAffectsAppearance(isFlagSet(flags, DynamicAttrFlags::kAppearance) ? true : false);
+    attrFn.setCached(isFlagSet(flags, DynamicAttrFlags::kCached) ? true : false);
+    attrFn.setConnectable(isFlagSet(flags, DynamicAttrFlags::kConnectable) ? true : false);
+    attrFn.setUsedAsFilename(isFlagSet(flags, DynamicAttrFlags::kFilename) ? true : false);
+    attrFn.setHidden(isFlagSet(flags, DynamicAttrFlags::kHidden) ? true : false);
+    attrFn.setKeyable(isFlagSet(flags, DynamicAttrFlags::kKeyable) ? true : false);
+    attrFn.setReadable(isFlagSet(flags, DynamicAttrFlags::kReadable) ? true : false);
+    attrFn.setStorable(isFlagSet(flags, DynamicAttrFlags::kStorable) ? true : false);
+    attrFn.setAffectsWorldSpace(isFlagSet(flags, DynamicAttrFlags::kWorldspace) ? true : false);
+    attrFn.setWritable(isFlagSet(flags, DynamicAttrFlags::kWritable) ? true : false);
 
     status = depNode.addAttribute(attr);
     return status;
@@ -59,13 +67,16 @@ getDynamicAttribute(const MFnDependencyNode& depNode, const MString& attrName, M
     return status;
 }
 
-MStatus
-setDynamicAttribute(MFnDependencyNode& depNode, const MString& attrName, const MString& value)
+MStatus setDynamicAttribute(
+    MFnDependencyNode&     depNode,
+    const MString&         attrName,
+    const MString&         value,
+    const DynamicAttrFlags flags)
 {
     MStatus status = MS::kSuccess;
 
     if (!depNode.hasAttribute(attrName)) {
-        status = createDynamicAttribute(depNode, attrName);
+        status = createDynamicAttribute(depNode, attrName, flags);
         CHECK_MSTATUS_AND_RETURN_IT(status);
     }
 

--- a/lib/mayaUsd/utils/dynamicAttribute.cpp
+++ b/lib/mayaUsd/utils/dynamicAttribute.cpp
@@ -40,16 +40,16 @@ MStatus createDynamicAttribute(
     MObject attr = attrFn.create(attrName, "", MFnData::kString, MObject::kNullObj, &status);
     CHECK_MSTATUS_AND_RETURN_IT(status);
 
-    attrFn.setAffectsAppearance(isFlagSet(flags, DynamicAttrFlags::kAppearance) ? true : false);
-    attrFn.setCached(isFlagSet(flags, DynamicAttrFlags::kCached) ? true : false);
-    attrFn.setConnectable(isFlagSet(flags, DynamicAttrFlags::kConnectable) ? true : false);
-    attrFn.setUsedAsFilename(isFlagSet(flags, DynamicAttrFlags::kFilename) ? true : false);
-    attrFn.setHidden(isFlagSet(flags, DynamicAttrFlags::kHidden) ? true : false);
-    attrFn.setKeyable(isFlagSet(flags, DynamicAttrFlags::kKeyable) ? true : false);
-    attrFn.setReadable(isFlagSet(flags, DynamicAttrFlags::kReadable) ? true : false);
-    attrFn.setStorable(isFlagSet(flags, DynamicAttrFlags::kStorable) ? true : false);
-    attrFn.setAffectsWorldSpace(isFlagSet(flags, DynamicAttrFlags::kWorldspace) ? true : false);
-    attrFn.setWritable(isFlagSet(flags, DynamicAttrFlags::kWritable) ? true : false);
+    attrFn.setAffectsAppearance(isFlagSet(flags, DynamicAttrFlags::kAppearance));
+    attrFn.setCached(isFlagSet(flags, DynamicAttrFlags::kCached));
+    attrFn.setConnectable(isFlagSet(flags, DynamicAttrFlags::kConnectable));
+    attrFn.setUsedAsFilename(isFlagSet(flags, DynamicAttrFlags::kFilename));
+    attrFn.setHidden(isFlagSet(flags, DynamicAttrFlags::kHidden));
+    attrFn.setKeyable(isFlagSet(flags, DynamicAttrFlags::kKeyable));
+    attrFn.setReadable(isFlagSet(flags, DynamicAttrFlags::kReadable));
+    attrFn.setStorable(isFlagSet(flags, DynamicAttrFlags::kStorable));
+    attrFn.setAffectsWorldSpace(isFlagSet(flags, DynamicAttrFlags::kWorldspace));
+    attrFn.setWritable(isFlagSet(flags, DynamicAttrFlags::kWritable));
 
     status = depNode.addAttribute(attr);
     return status;

--- a/lib/mayaUsd/utils/dynamicAttribute.h
+++ b/lib/mayaUsd/utils/dynamicAttribute.h
@@ -22,6 +22,59 @@
 
 namespace MAYAUSD_NS_DEF {
 
+/*! \brief flags used to create the dynamic attribute.
+ **        By default it is readable, writable, storable and hidden.
+ */
+enum class DynamicAttrFlags : unsigned
+{
+    kNone = 0,
+
+    kAppearance = 1 << 0,
+    kCached = 1 << 1,
+    kConnectable = 1 << 2,
+    kFilename = 1 << 3,
+    kHidden = 1 << 4,
+    kKeyable = 1 << 5,
+    kReadable = 1 << 6,
+    kStorable = 1 << 7,
+    kWorldspace = 1 << 8,
+    kWritable = 1 << 9,
+
+    kDefaults = kReadable | kWritable | kHidden | kStorable,
+
+    kAll = unsigned(-1)
+};
+
+MAYAUSD_CORE_PUBLIC
+inline DynamicAttrFlags operator|(const DynamicAttrFlags lhs, const DynamicAttrFlags rhs)
+{
+    return DynamicAttrFlags(unsigned(lhs) | unsigned(rhs));
+}
+
+MAYAUSD_CORE_PUBLIC
+inline DynamicAttrFlags operator&(const DynamicAttrFlags lhs, const DynamicAttrFlags rhs)
+{
+    return DynamicAttrFlags(unsigned(lhs) & unsigned(rhs));
+}
+
+MAYAUSD_CORE_PUBLIC
+inline DynamicAttrFlags operator^(const DynamicAttrFlags lhs, const DynamicAttrFlags rhs)
+{
+    return DynamicAttrFlags(unsigned(lhs) ^ unsigned(rhs));
+}
+
+MAYAUSD_CORE_PUBLIC
+inline DynamicAttrFlags operator~(const DynamicAttrFlags flags)
+{
+    return DynamicAttrFlags(unsigned(DynamicAttrFlags::kAll) & ~unsigned(flags));
+}
+
+MAYAUSD_CORE_PUBLIC
+inline bool isFlagSet(const DynamicAttrFlags lhs, const DynamicAttrFlags rhs)
+{
+    return unsigned(lhs & rhs) != 0;
+}
+
 /*! \brief verify if the named dynamic attribute is present on the Maya node.
  */
 MAYAUSD_CORE_PUBLIC
@@ -30,7 +83,10 @@ bool hasDynamicAttribute(const MFnDependencyNode& depNode, const MString& attrNa
 /*! \brief create the named dynamic attribute on the Maya node.
  */
 MAYAUSD_CORE_PUBLIC
-MStatus createDynamicAttribute(MFnDependencyNode& depNode, const MString& attrName);
+MStatus createDynamicAttribute(
+    MFnDependencyNode&     depNode,
+    const MString&         attrName,
+    const DynamicAttrFlags flags = DynamicAttrFlags::kDefaults);
 
 /*! \brief get the string value of the named dynamic attribute from the Maya node.
  */
@@ -41,8 +97,11 @@ getDynamicAttribute(const MFnDependencyNode& depNode, const MString& attrName, M
 /*! \brief set the named dynamic attribute to the given string value on the Maya node.
  */
 MAYAUSD_CORE_PUBLIC
-MStatus
-setDynamicAttribute(MFnDependencyNode& depNode, const MString& attrName, const MString& value);
+MStatus setDynamicAttribute(
+    MFnDependencyNode&     depNode,
+    const MString&         attrName,
+    const MString&         value,
+    const DynamicAttrFlags flags = DynamicAttrFlags::kDefaults);
 
 } // namespace MAYAUSD_NS_DEF
 

--- a/test/lib/usd/translators/testUsdImportUnits.py
+++ b/test/lib/usd/translators/testUsdImportUnits.py
@@ -108,7 +108,7 @@ class testUsdImportUpAxis(unittest.TestCase):
         actualScaling = _GetMayaScaling(rootNodes[0])
         self.assertTrue(Gf.IsClose(actualScaling, expectedScaling, EPSILON))
 
-        self.assertEqual(cmds.getAttr('%s.OriginalUSDMetersPerUnit' % rootNodes[0]), '0.001')
+        self.assertEqual(cmds.getAttr('%s.OriginalMetersPerUnit' % rootNodes[0]), '0.001')
 
     def testImportScaleRootNodes(self):
         """Test importing and scaling the root nodes."""
@@ -133,7 +133,7 @@ class testUsdImportUpAxis(unittest.TestCase):
         actualScaling = _GetMayaScaling(rootNodes[0])
         self.assertTrue(Gf.IsClose(actualScaling, expectedScaling, EPSILON))
 
-        self.assertEqual(cmds.getAttr('%s.OriginalUSDMetersPerUnit' % rootNodes[0]), '0.001')
+        self.assertEqual(cmds.getAttr('%s.OriginalMetersPerUnit' % rootNodes[0]), '0.001')
 
 
 if __name__ == '__main__':

--- a/test/lib/usd/translators/testUsdImportUpAxis.py
+++ b/test/lib/usd/translators/testUsdImportUpAxis.py
@@ -98,7 +98,7 @@ class testUsdImportUpAxis(unittest.TestCase):
         actualRotation = _GetMayaRotation(rootNodes[0])
         self.assertTrue(actualRotation.isEquivalent(expectedRotation))
 
-        self.assertEqual(cmds.getAttr('%s.OriginalUSDUpAxis' % rootNodes[0]), 'Y')
+        self.assertEqual(cmds.getAttr('%s.OriginalUpAxis' % rootNodes[0]), 'Y')
 
     def testImportRotateRootNodes(self):
         """Test importing and rotating the root nodes."""
@@ -123,7 +123,7 @@ class testUsdImportUpAxis(unittest.TestCase):
         actualRotation = _GetMayaRotation(rootNodes[0])
         self.assertTrue(actualRotation.isEquivalent(expectedRotation))
 
-        self.assertEqual(cmds.getAttr('%s.OriginalUSDUpAxis' % rootNodes[0]), 'Y')
+        self.assertEqual(cmds.getAttr('%s.OriginalUpAxis' % rootNodes[0]), 'Y')
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
- Change the dynamic attribute APi to allow controlling the attribute flags.
- Make the up-axis and units attributes be visible.