### PR TITLE
Disable upAxis translation on import/export in tests

### DIFF
--- a/test/lib/mayaUsd/fileio/testDuplicateAs.py
+++ b/test/lib/mayaUsd/fileio/testDuplicateAs.py
@@ -71,7 +71,7 @@ class DuplicateAsTestCase(unittest.TestCase):
         # Duplicate USD data as Maya data, placing it under the root.
         with mayaUsd.lib.OpUndoItemList():
             self.assertTrue(mayaUsd.lib.PrimUpdaterManager.duplicate(
-                aUsdUfePathStr, ''))
+                aUsdUfePathStr, '', {'upAxis': False}))
 
         # Should now have two transform nodes in the Maya scene: the path
         # components in the second segment of the aUsdItem and bUsdItem will
@@ -131,7 +131,7 @@ class DuplicateAsTestCase(unittest.TestCase):
         previousSn = cmds.ls(sl=True, ufe=True, long=True)
 
         # Duplicate USD data as Maya data, placing it under the root.
-        cmds.mayaUsdDuplicate(aUsdUfePathStr, '')
+        cmds.mayaUsdDuplicate(aUsdUfePathStr, '', exportOptions='upAxis=0')
 
         def verifyDuplicate():
             # Should now have two transform nodes in the Maya scene: the path

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateUSDPreviewSurface.py
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateUSDPreviewSurface.py
@@ -238,7 +238,8 @@ class testVP2RenderDelegateUSDPreviewSurface(imageUtils.ImageDiffingTestCase):
         testFile = testUtils.getTestScene("UsdPreviewSurface", "DisplayColorCube.usda")
         options = ["shadingMode=[[useRegistry,UsdPreviewSurface]]",
                    "primPath=/",
-                   "preferredMaterial=none"]
+                   "preferredMaterial=none",
+                   "upAxis=0"]
         cmds.file(testFile, i=True, type="USD Import",
                   ignoreVersion=True, ra=True, mergeNamespacesOnClash=False,
                   namespace="Test", pr=True, importTimeRange="combine",

--- a/test/lib/usd/translators/testUsdImportXformAnim.py
+++ b/test/lib/usd/translators/testUsdImportXformAnim.py
@@ -31,7 +31,7 @@ class testUsdImportXformAnim(unittest.TestCase):
     def _LoadUsd(self):
         # Import the USD file.
         usdFilePath = os.path.join(self.inputPath, "UsdImportXformAnimTest", "Mesh.usda")
-        cmds.usdImport(file=usdFilePath, readAnimData=False)
+        cmds.usdImport(file=usdFilePath, readAnimData=False, upAxis=False)
         self.stage = Usd.Stage.Open(usdFilePath)
         self.assertTrue(self.stage)
 


### PR DESCRIPTION
Pixar's configuration will use Z-up for USD stages by default, but Maya defaults to Y-up. This was causing objects to get rotated on import/export, which caused test failures. Disable this translation for these tests