### PR TITLE
EMSUSD-1682 assign material to lock layer

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
@@ -653,40 +653,55 @@ Ufe::SceneItem::Ptr UsdUndoCreateMaterialsScopeCommand::sceneItem() const { retu
 
 void UsdUndoCreateMaterialsScopeCommand::execute()
 {
+    try {
+        if (!doExecute()) {
+            markAsFailed();
+        }
+    } catch (std::exception&) {
+        markAsFailed();
+        throw;
+    }
+}
+
+bool UsdUndoCreateMaterialsScopeCommand::doExecute()
+{
+    if (_insertedChild || !_parentItem) {
+        return true;
+    }
+
     UsdUfe::InAddOrDeleteOperation ad;
 
     UsdUfe::UsdUndoBlock undoBlock(&_undoableItem);
-
-    if (_insertedChild || !_parentItem) {
-        return;
-    }
 
     // The AddNewPrimCommand automatically appends a "1" to the name, so it cannot create a
     // scope with the desired name directly. Create a scope and rename it afterwards.
     auto createScopeCmd
         = UsdUfe::UsdUndoAddNewPrimCommand::create(_parentItem, "ScopeName", "Scope");
     if (!createScopeCmd) {
-        markAsFailed();
-        return;
+        return false;
     }
     createScopeCmd->execute();
 
     auto scopeItem = downcast(createScopeCmd->sceneItem());
+    if (!scopeItem || scopeItem->path().empty()) {
+        return false;
+    }
+
     auto materialsScopeName = UsdMayaJobExportArgs::GetDefaultMaterialsScopeName();
     auto renameCmd = UsdUndoRenameCommand::create(scopeItem, materialsScopeName);
     if (!renameCmd) {
-        markAsFailed();
-        return;
+        return false;
     }
     renameCmd->execute();
 
     scopeItem = renameCmd->renamedItem();
     if (!scopeItem || scopeItem->path().empty()) {
-        markAsFailed();
-        return;
+        return false;
     }
 
     _insertedChild = scopeItem;
+
+    return true;
 }
 
 void UsdUndoCreateMaterialsScopeCommand::undo()

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.h
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.h
@@ -189,6 +189,7 @@ public:
     void redo() override;
 
 private:
+    bool doExecute();
     void markAsFailed();
 
     UsdUfe::UsdSceneItem::Ptr _parentItem;

--- a/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoRenameCommand.cpp
@@ -80,8 +80,11 @@ UsdUndoRenameCommand::UsdUndoRenameCommand(
 #endif
     , _ufeSrcItem(srcItem)
     , _ufeDstItem(nullptr)
-    , _stage(_ufeSrcItem->prim().GetStage())
+    , _stage(_ufeSrcItem ? _ufeSrcItem->prim().GetStage() : PXR_NS::UsdStageWeakPtr())
 {
+    if (!_stage)
+        return;
+
     const UsdPrim prim = _stage->GetPrimAtPath(_ufeSrcItem->prim().GetPath());
 
     UsdUfe::applyCommandRestriction(prim, "rename");


### PR DESCRIPTION
Fix crash when trying to assigned a material to a prim in a locked layer. The code was failing to check for null in a critical place.

- Check for null item or stage when renaming prim.
- Check for null after creating a scope.
- Properly sequence undo vs undo-block when the execution fails.
- Add a unit test to verify the crash fix.