### PR TITLE
EMSUSD-1613 clean session layer when undoing add prim

### DIFF
--- a/lib/usdUfe/ufe/UsdUndoAddNewPrimCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoAddNewPrimCommand.cpp
@@ -102,6 +102,7 @@ void UsdUndoAddNewPrimCommand::undo()
     UsdUfe::InAddOrDeleteOperation ad;
 
     _undoableItem.undo();
+    removeSessionLeftOvers(_stage, _primPath, &_undoableItem);
 }
 
 void UsdUndoAddNewPrimCommand::redo()

--- a/lib/usdUfe/ufe/Utils.h
+++ b/lib/usdUfe/ufe/Utils.h
@@ -50,6 +50,7 @@ UFE_NS_DEF
 namespace USDUFE_NS_DEF {
 
 class UsdAttribute;
+class UsdUndoableItem;
 
 // DCC specific accessor functions.
 typedef PXR_NS::UsdStageWeakPtr (*StageAccessorFn)(const Ufe::Path&);
@@ -466,6 +467,15 @@ const char* getTransform3dMatrixOpName();
 //! \note the prefix-less name is only filled when returning true.
 USDUFE_PUBLIC
 bool isSessionLayerGroupMetadata(const std::string& groupName, std::string* adjustedGroupName);
+
+//! Remove data left behind in the session layer for the given prim path in the given stage
+//! and store the undos as extra undos in the given undo items.
+USDUFE_PUBLIC
+void removeSessionLeftOvers(
+    const PXR_NS::UsdStageRefPtr& stage,
+    const PXR_NS::SdfPath&        primPath,
+    UsdUndoableItem*              undoableItem,
+    bool                          extraEdits = true);
 
 } // namespace USDUFE_NS_DEF
 

--- a/lib/usdUfe/undo/UsdUndoBlock.cpp
+++ b/lib/usdUfe/undo/UsdUndoBlock.cpp
@@ -23,8 +23,9 @@ USDUFE_VERIFY_CLASS_NOT_MOVE_OR_COPY(UsdUndoBlock);
 
 uint32_t UsdUndoBlock::_undoBlockDepth { 0 };
 
-UsdUndoBlock::UsdUndoBlock(UsdUndoableItem* undoItem)
+UsdUndoBlock::UsdUndoBlock(UsdUndoableItem* undoItem, bool extraEdits)
     : _undoItem(undoItem)
+    , _extraEdits(extraEdits)
 {
     // TfDebug::Enable(USDUFE_UNDOSTACK);
 
@@ -40,7 +41,7 @@ UsdUndoBlock::~UsdUndoBlock()
 
     if ((nullptr != _undoItem) && (_undoBlockDepth == 0)) {
         // transfer edits
-        UsdUfe::UsdUndoManagerAccessor::transferEdits(*_undoItem);
+        UsdUfe::UsdUndoManagerAccessor::transferEdits(*_undoItem, _extraEdits);
 
         TF_DEBUG_MSG(USDUFE_UNDOSTACK, "Undoable Item adopted the new edits.\n");
     }

--- a/lib/usdUfe/undo/UsdUndoBlock.h
+++ b/lib/usdUfe/undo/UsdUndoBlock.h
@@ -35,7 +35,12 @@ TF_DECLARE_WEAK_AND_REF_PTRS(UsdUndoManager);
 class USDUFE_PUBLIC UsdUndoBlock
 {
 public:
-    UsdUndoBlock(UsdUndoableItem* undoItem);
+    /// @brief Create an undo block that will capture all undo into the given undo item.
+    /// @param undoItem the item to receive the undos.
+    /// @param extraEdits if true, the undos are added the item, even if the item already contained
+    /// undos.
+    ///                   Otherwise, any undos that were already in the items are discarded.
+    UsdUndoBlock(UsdUndoableItem* undoItem, bool extraEdits = false);
     virtual ~UsdUndoBlock();
 
     USDUFE_DISALLOW_COPY_MOVE_AND_ASSIGNMENT(UsdUndoBlock);
@@ -46,6 +51,7 @@ private:
     static uint32_t _undoBlockDepth;
 
     UsdUndoableItem* _undoItem;
+    bool             _extraEdits;
 };
 
 } // namespace USDUFE_NS_DEF

--- a/lib/usdUfe/undo/UsdUndoManager.cpp
+++ b/lib/usdUfe/undo/UsdUndoManager.cpp
@@ -53,10 +53,16 @@ void UsdUndoManager::addInverse(UsdUndoableItem::InvertFunc func)
     _invertFuncs.emplace_back(func);
 }
 
-void UsdUndoManager::transferEdits(UsdUndoableItem& undoableItem)
+void UsdUndoManager::transferEdits(UsdUndoableItem& undoableItem, bool extraEdits)
 {
     // transfer the edits
-    undoableItem._invertFuncs = std::move(_invertFuncs);
+    if (extraEdits) {
+        undoableItem._invertFuncs.insert(
+            undoableItem._invertFuncs.begin(), _invertFuncs.begin(), _invertFuncs.end());
+        _invertFuncs.clear();
+    } else {
+        undoableItem._invertFuncs = std::move(_invertFuncs);
+    }
 }
 
 } // namespace USDUFE_NS_DEF

--- a/lib/usdUfe/undo/UsdUndoManager.h
+++ b/lib/usdUfe/undo/UsdUndoManager.h
@@ -54,7 +54,7 @@ private:
     ~UsdUndoManager() = default;
 
     void addInverse(UsdUndoableItem::InvertFunc func);
-    void transferEdits(UsdUndoableItem& undoableItem);
+    void transferEdits(UsdUndoableItem& undoableItem, bool extraEdits);
 
 private:
     UsdUndoableItem::InvertFuncs _invertFuncs;
@@ -76,10 +76,10 @@ public:
         auto& undoManager = UsdUfe::UsdUndoManager::instance();
         undoManager.addInverse(func);
     }
-    static void transferEdits(UsdUndoableItem& undoableItem)
+    static void transferEdits(UsdUndoableItem& undoableItem, bool extraEdits = false)
     {
         auto& undoManager = UsdUfe::UsdUndoManager::instance();
-        undoManager.transferEdits(undoableItem);
+        undoManager.transferEdits(undoableItem, extraEdits);
     }
 };
 


### PR DESCRIPTION
- Refactor the USD undo block and undo manager to support extending an undo item with new undos.
- Add a helper function to cleanup the session layer of a given prim data, capturing the removal in an undo item.
- Make the add-prim command use the session clean-up helper.
- Add unit test.