### PR TITLE
EMSUSD-1718 automatically close prefs when changing units

### DIFF
--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -756,7 +756,15 @@ void UsdMaya_ReadJob::_ConvertUpAxisAndUnitsByChangingMayaPrefs(
         } else {
             const MString mayaUnitText = UsdMayaUtil::ConvertMDistanceUnitToText(mayaUnit);
             MString       changeUnitsCmd;
-            changeUnitsCmd.format("currentUnit -linear ^1s;", mayaUnitText);
+            changeUnitsCmd.format(
+                "global string $gPreferenceWindow;\n"
+                "if (`window -query -exists $gPreferenceWindow`) {\n"
+                "    if (`window -query -visible $gPreferenceWindow`) {\n"
+                "        window -edit -visible off $gPreferenceWindow;\n"
+                "    }\n"
+                "}\n"
+                "currentUnit -linear ^1s;",
+                mayaUnitText);
 
             // Note: we *must* execute the units change on-idle because the import process
             //       saves and restores all units! If we change it now, the change would be lost.

--- a/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
+++ b/lib/mayaUsd/resources/scripts/mayaUsdLibRegisterStrings.py
@@ -133,6 +133,13 @@ def mayaUsdLibRegisterStrings():
     register("kStageConversionUnknownMethod", "Unknown stage conversion method: %s")
     register("kStageConversionSuccessful", "Mismatching axis/unit have been converted for accurate scale.")
 
+    # readJob.cpp
+    register("kAboutToChangePrefs", "The USD import is about to change the Maya preferences.\n" +
+                                    "Save your changes in the preferences window?")
+    register("kAboutToChangePrefsTitle", "Save Preferences")
+    register("kSavePrefsChange", "Save Preferences")
+    register("kDiscardPrefsChange", "Discard Preferences")
+
 
 def registerPluginResource(pluginId, stringId, resourceStr):
     '''See registerPluginResource.mel in Maya.


### PR DESCRIPTION
When the USD import needs to change the Maya units preferences, we need to close the preferences window, otherwise it will overwrite the preferences when closed.