### PR TITLE
EMSUSD-1222 no metadata on read-only layers

### DIFF
--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -365,6 +365,10 @@ void setLayerUpAxisAndUnits(const SdfLayerRefPtr& layer)
     if (!layer)
         return;
 
+    // Don't try to author the metadata on non-editable layers.
+    if (!layer->PermissionToEdit())
+        return;
+
     const PXR_NS::TfToken upAxis
         = MGlobal::isZAxisUp() ? PXR_NS::UsdGeomTokens->z : PXR_NS::UsdGeomTokens->y;
     const double metersPerUnit


### PR DESCRIPTION
Don't try to set the units and up-axis metadata on layers that are not editable.