### PR TITLE
Adds support for defaultgeomprop values on nodegraph inputs.

### DIFF
--- a/lib/mayaUsd/render/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
@@ -254,6 +254,7 @@ ShaderPtr GlslFragmentGenerator::createShader(
     ElementPtr    element,
     GenContext&   context) const
 {
+#if MX_COMBINED_VERSION >= 13810
     // Create the root shader graph
     ShaderGraphPtr graph = MayaShaderGraph::create(nullptr, name, element, context);
     ShaderPtr      shader = std::make_shared<Shader>(name, graph);
@@ -457,10 +458,18 @@ ShaderPtr GlslFragmentGenerator::createShader(
         // Flag the shader as being transparent.
         shader->setAttribute(HW::ATTR_TRANSPARENT);
     }
+#else
+    ShaderPtr    shader = GlslShaderGenerator::createShader(name, element, context);
+    ShaderGraph& graph = shader->getGraph();
+#endif
     ShaderStage& pixelStage = shader->getStage(Stage::PIXEL);
 
     // Add uniforms for environment lighting.
+#if MX_COMBINED_VERSION >= 13810
     if (requiresLighting(*graph) && OgsXmlGenerator::useLightAPI() < 2) {
+#else
+    if (requiresLighting(graph) && OgsXmlGenerator::useLightAPI() < 2) {
+#endif
         VariableBlock& psPrivateUniforms = pixelStage.getUniformBlock(HW::PUBLIC_UNIFORMS);
         psPrivateUniforms.add(
             Type::COLOR3, LIGHT_LOOP_RESULT, Value::createValue(Color3(0.0f, 0.0f, 0.0f)));

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
@@ -256,7 +256,7 @@ ShaderPtr GlslFragmentGenerator::createShader(
 {
     // Create the root shader graph
     ShaderGraphPtr graph = MayaShaderGraph::create(nullptr, name, element, context);
-    ShaderPtr shader = std::make_shared<Shader>(name, graph);
+    ShaderPtr      shader = std::make_shared<Shader>(name, graph);
 
     // Check if there are inputs with default geomprops assigned. In order to bind the
     // corresponding data to these inputs we insert geomprop nodes in the graph.
@@ -264,7 +264,7 @@ ShaderPtr GlslFragmentGenerator::createShader(
     for (ShaderGraphInputSocket* socket : graph->getInputSockets()) {
         if (!socket->getGeomProp().empty()) {
             ConstDocumentPtr doc = element->getDocument();
-            GeomPropDefPtr geomprop = doc->getGeomPropDef(socket->getGeomProp());
+            GeomPropDefPtr   geomprop = doc->getGeomPropDef(socket->getGeomProp());
             if (geomprop) {
                 // A default geomprop was assigned to this graph input.
                 // For all internal connections to this input, break the connection
@@ -292,10 +292,10 @@ ShaderPtr GlslFragmentGenerator::createShader(
     // Each Stage must have three types of uniform blocks:
     // Private, Public and Sampler blocks
     // Public uniforms are inputs that should be published in a user interface for user interaction,
-    // while private uniforms are internal variables needed by the system which should not be exposed in UI.
-    // So when creating these uniforms for a shader node, if the variable is user-facing it should go into the public block,
-    // and otherwise the private block.
-    // All texture based objects should be added to Sampler block
+    // while private uniforms are internal variables needed by the system which should not be
+    // exposed in UI. So when creating these uniforms for a shader node, if the variable is
+    // user-facing it should go into the public block, and otherwise the private block. All texture
+    // based objects should be added to Sampler block
 
     vs->createUniformBlock(HW::PRIVATE_UNIFORMS, "u_prv");
     vs->createUniformBlock(HW::PUBLIC_UNIFORMS, "u_pub");
@@ -308,7 +308,7 @@ ShaderPtr GlslFragmentGenerator::createShader(
     vsPrivateUniforms.add(Type::MATRIX44, HW::T_VIEW_PROJECTION_MATRIX);
 
     // Create pixel stage.
-    ShaderStagePtr ps = createStage(Stage::PIXEL, *shader);
+    ShaderStagePtr   ps = createStage(Stage::PIXEL, *shader);
     VariableBlockPtr psOutputs = ps->createOutputBlock(HW::PIXEL_OUTPUTS, "o_ps");
 
     // Create required Uniform blocks and any additonal blocks if needed.
@@ -328,7 +328,8 @@ ShaderPtr GlslFragmentGenerator::createShader(
     // Add uniforms for shadow map rendering.
     if (context.getOptions().hwShadowMap) {
         psPrivateUniforms->add(Type::FILENAME, HW::T_SHADOW_MAP);
-        psPrivateUniforms->add(Type::MATRIX44, HW::T_SHADOW_MATRIX, Value::createValue(Matrix44::IDENTITY));
+        psPrivateUniforms->add(
+            Type::MATRIX44, HW::T_SHADOW_MATRIX, Value::createValue(Matrix44::IDENTITY));
     }
 
     // Add inputs and uniforms for ambient occlusion.
@@ -340,22 +341,24 @@ ShaderPtr GlslFragmentGenerator::createShader(
     }
 
     // Add uniforms for environment lighting.
-    bool lighting = graph->hasClassification(ShaderNode::Classification::SHADER | ShaderNode::Classification::SURFACE) ||
-                    graph->hasClassification(ShaderNode::Classification::BSDF);
+    bool lighting = graph->hasClassification(
+                        ShaderNode::Classification::SHADER | ShaderNode::Classification::SURFACE)
+        || graph->hasClassification(ShaderNode::Classification::BSDF);
     if (lighting && context.getOptions().hwSpecularEnvironmentMethod != SPECULAR_ENVIRONMENT_NONE) {
         const Matrix44 yRotationPI = Matrix44::createScale(Vector3(-1, 1, -1));
         psPrivateUniforms->add(Type::MATRIX44, HW::T_ENV_MATRIX, Value::createValue(yRotationPI));
         psPrivateUniforms->add(Type::FILENAME, HW::T_ENV_RADIANCE);
         psPrivateUniforms->add(Type::FLOAT, HW::T_ENV_LIGHT_INTENSITY, Value::createValue(1.0f));
         psPrivateUniforms->add(Type::INTEGER, HW::T_ENV_RADIANCE_MIPS, Value::createValue<int>(1));
-        psPrivateUniforms->add(Type::INTEGER, HW::T_ENV_RADIANCE_SAMPLES, Value::createValue<int>(16));
+        psPrivateUniforms->add(
+            Type::INTEGER, HW::T_ENV_RADIANCE_SAMPLES, Value::createValue<int>(16));
         psPrivateUniforms->add(Type::FILENAME, HW::T_ENV_IRRADIANCE);
         psPrivateUniforms->add(Type::BOOLEAN, HW::T_REFRACTION_TWO_SIDED);
     }
 
     // Add uniforms for the directional albedo table.
-    if (context.getOptions().hwDirectionalAlbedoMethod == DIRECTIONAL_ALBEDO_TABLE ||
-        context.getOptions().hwWriteAlbedoTable) {
+    if (context.getOptions().hwDirectionalAlbedoMethod == DIRECTIONAL_ALBEDO_TABLE
+        || context.getOptions().hwWriteAlbedoTable) {
         psPrivateUniforms->add(Type::FILENAME, HW::T_ALBEDO_TABLE);
         psPrivateUniforms->add(Type::INTEGER, HW::T_ALBEDO_TABLE_SIZE, Value::createValue<int>(64));
     }
@@ -383,17 +386,20 @@ ShaderPtr GlslFragmentGenerator::createShader(
     // so copy name and variable from the graph output but set type to color4.
     // TODO: Improve this to support multiple outputs and other data types.
     ShaderGraphOutputSocket* outputSocket = graph->getOutputSocket();
-    ShaderPort* output = psOutputs->add(Type::COLOR4, outputSocket->getName());
+    ShaderPort*              output = psOutputs->add(Type::COLOR4, outputSocket->getName());
     output->setVariable(outputSocket->getVariable());
     output->setPath(outputSocket->getPath());
 
     // Create shader variables for all nodes that need this.
     createVariables(graph, context, *shader);
 
-    HwLightShadersPtr lightShaders = context.getUserData<HwLightShaders>(HW::USER_DATA_LIGHT_SHADERS);
+    HwLightShadersPtr lightShaders
+        = context.getUserData<HwLightShaders>(HW::USER_DATA_LIGHT_SHADERS);
 
     // For surface shaders we need light shaders
-    if (lightShaders && graph->hasClassification(ShaderNode::Classification::SHADER | ShaderNode::Classification::SURFACE)) {
+    if (lightShaders
+        && graph->hasClassification(
+            ShaderNode::Classification::SHADER | ShaderNode::Classification::SURFACE)) {
         // Create shader variables for all bound light shaders
         for (const auto& it : lightShaders->get()) {
             ShaderNode* node = it.second.get();
@@ -411,7 +417,7 @@ ShaderPtr GlslFragmentGenerator::createShader(
     vector<ShaderGraph*> graphStack = { graph.get() };
     if (lightShaders) {
         for (const auto& it : lightShaders->get()) {
-            ShaderNode* node = it.second.get();
+            ShaderNode*  node = it.second.get();
             ShaderGraph* lightGraph = node->getImplementation().getGraph();
             if (lightGraph) {
                 graphStack.push_back(lightGraph);
@@ -427,8 +433,10 @@ ShaderPtr GlslFragmentGenerator::createShader(
             if (node->hasClassification(ShaderNode::Classification::FILETEXTURE)) {
                 for (ShaderInput* input : node->getInputs()) {
                     if (!input->getConnection() && *input->getType() == *Type::FILENAME) {
-                        // Create the uniform using the filename type to make this uniform into a texture sampler.
-                        ShaderPort* filename = psPublicUniforms->add(Type::FILENAME, input->getVariable(), input->getValue());
+                        // Create the uniform using the filename type to make this uniform into a
+                        // texture sampler.
+                        ShaderPort* filename = psPublicUniforms->add(
+                            Type::FILENAME, input->getVariable(), input->getValue());
                         filename->setPath(input->getPath());
 
                         // Assing the uniform name to the input value

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.cpp
@@ -39,6 +39,7 @@ MayaShaderGraph::MayaShaderGraph(
     const ElementPtr&  element,
     GenContext&        context)
     : ShaderGraph(parent, name, element->getDocument(), context.getReservedWords())
+    , _shouldPropagateInputs(false)
 {
     ElementPtr root;
 
@@ -190,10 +191,11 @@ MayaShaderGraph::MayaShaderGraph(
     const NodeGraph&   nodeGraph,
     GenContext&        context)
     : ShaderGraph(
-        parent,
-        makeValidName(nodeGraph, context),
-        nodeGraph.getDocument(),
-        context.getReservedWords())
+          parent,
+          makeValidName(nodeGraph, context),
+          nodeGraph.getDocument(),
+          context.getReservedWords())
+    , _shouldPropagateInputs(true)
 {
     // Clear classification
     _classification = 0;
@@ -237,6 +239,10 @@ MayaShaderGraph::create(const ShaderGraph* parent, const NodeGraph& nodeGraph, G
 
 void MayaShaderGraph::addPropagatedInput(ShaderNode& node, string const& name)
 {
+    if (!_shouldPropagateInputs) {
+        return;
+    }
+
     auto* nodeInput = node.getInput(name);
     if (nodeInput) {
         auto* inputSocket = getInputSocket(name);

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.cpp
@@ -29,6 +29,7 @@ std::string makeValidName(const NodeGraph& nodeGraph, GenContext& context)
 
 } // namespace
 
+#if MX_COMBINED_VERSION >= 13810
 //
 // ShaderGraph methods
 //
@@ -182,6 +183,7 @@ MayaShaderGraph::MayaShaderGraph(
 
     finalize(context);
 }
+#endif
 
 MayaShaderGraph::MayaShaderGraph(
     const ShaderGraph* parent,
@@ -213,6 +215,7 @@ MayaShaderGraph::MayaShaderGraph(
 
 MayaShaderGraph::~MayaShaderGraph() = default;
 
+#if MX_COMBINED_VERSION >= 13810
 ShaderGraphPtr MayaShaderGraph::create(
     const ShaderGraph* parent,
     const string&      name,
@@ -222,6 +225,7 @@ ShaderGraphPtr MayaShaderGraph::create(
     ShaderGraphPtr graph = std::make_shared<MayaShaderGraph>(parent, name, element, context);
     return graph;
 }
+#endif
 
 ShaderGraphPtr
 MayaShaderGraph::create(const ShaderGraph* parent, const NodeGraph& nodeGraph, GenContext& context)
@@ -247,6 +251,7 @@ void MayaShaderGraph::addPropagatedInput(ShaderNode& node, string const& name)
 
 StringVec const& MayaShaderGraph::getPropagatedInputs() const { return _propagatedInputs; }
 
+#if MX_COMBINED_VERSION >= 13810
 void MayaShaderGraph::createConnectedNodes(
     const ElementPtr& downstreamElement,
     const ElementPtr& upstreamElement,
@@ -363,5 +368,6 @@ void MayaShaderGraph::addUpstreamDependencies(const Element& root, GenContext& c
             downstreamElement, upstreamElement, edge.getConnectingElement(), context);
     }
 }
+#endif
 
 MATERIALX_NAMESPACE_END

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.cpp
@@ -7,6 +7,8 @@
 
 #include <MaterialXGenShader/GenContext.h>
 #include <MaterialXGenShader/ShaderGenerator.h>
+#include <MaterialXGenShader/ShaderNode.h>
+#include <MaterialXGenShader/TypeDesc.h>
 
 MATERIALX_NAMESPACE_BEGIN
 
@@ -30,6 +32,153 @@ std::string makeValidName(const NodeGraph& nodeGraph, GenContext& context)
 //
 // ShaderGraph methods
 //
+MayaShaderGraph::MayaShaderGraph(
+    const ShaderGraph* parent,
+    const string&      name,
+    const ElementPtr&  element,
+    GenContext&        context)
+    : ShaderGraph(
+        parent,
+        name,
+        element->getDocument(),
+        context.getReservedWords())
+{
+    ElementPtr root;
+
+    if (element->isA<Output>()) {
+        OutputPtr output = element->asA<Output>();
+        ElementPtr outputParent = output->getParent();
+
+        InterfaceElementPtr interface;
+        if (outputParent->isA<NodeGraph>()) {
+            // A nodegraph output.
+            NodeGraphPtr nodeGraph = outputParent->asA<NodeGraph>();
+            NodeDefPtr nodeDef = nodeGraph->getNodeDef();
+            if (nodeDef) {
+                interface = nodeDef;
+            } else {
+                interface = nodeGraph;
+            }
+        } else if (outputParent->isA<Document>()) {
+            // A free floating output.
+            outputParent = output->getConnectedNode();
+            interface = outputParent ? outputParent->asA<InterfaceElement>() : nullptr;
+        }
+        if (!interface) {
+            throw ExceptionShaderGenError("Given output '" + output->getName() + "' has no interface valid for shader generation");
+        }
+
+        // Clear classification
+        _classification = 0;
+
+        // Create input sockets
+        addInputSockets(*interface, context);
+
+        // Create the given output socket
+        ShaderGraphOutputSocket* outputSocket = addOutputSocket(output->getName(), TypeDesc::get(output->getType()));
+        outputSocket->setPath(output->getNamePath());
+        const string& outputUnit = output->getUnit();
+        if (!outputUnit.empty()) {
+            outputSocket->setUnit(outputUnit);
+        }
+        const string& outputColorSpace = output->getColorSpace();
+        if (!outputColorSpace.empty()) {
+            outputSocket->setColorSpace(outputColorSpace);
+        }
+
+        // Start traversal from this output
+        root = output;
+    } else if (element->isA<Node>()) {
+        NodePtr node = element->asA<Node>();
+        NodeDefPtr nodeDef = node->getNodeDef();
+        if (!nodeDef) {
+            throw ExceptionShaderGenError("Could not find a nodedef for node '" + node->getName() + "'");
+        }
+
+        // Create input sockets
+        addInputSockets(*nodeDef, context);
+
+        // Create output sockets
+        addOutputSockets(*nodeDef);
+
+        // Create this shader node in the graph.
+        ShaderNodePtr newNode = ShaderNode::create(this, node->getName(), *nodeDef, context);
+        addNode(newNode);
+
+        // Share metadata.
+        setMetadata(newNode->getMetadata());
+
+        // Connect it to the graph outputs
+        for (size_t i = 0; i < newNode->numOutputs(); ++i) {
+            ShaderGraphOutputSocket* outputSocket = getOutputSocket(i);
+            outputSocket->makeConnection(newNode->getOutput(i));
+            outputSocket->setPath(node->getNamePath());
+        }
+
+        // Handle node input ports
+        for (const InputPtr& nodedefInput : nodeDef->getActiveInputs()) {
+            ShaderGraphInputSocket* inputSocket = getInputSocket(nodedefInput->getName());
+            ShaderInput* input = newNode->getInput(nodedefInput->getName());
+            if (!inputSocket || !input) {
+                throw ExceptionShaderGenError("Node input '" + nodedefInput->getName() + "' doesn't match an existing input on graph '" + getName() + "'");
+            }
+
+            // Copy data from node element to shadergen representation
+            InputPtr nodeInput = node->getInput(nodedefInput->getName());
+            if (nodeInput) {
+                ValuePtr value = nodeInput->getResolvedValue();
+                if (value) {
+                    const string& valueString = value->getValueString();
+                    std::pair<const TypeDesc*, ValuePtr> enumResult;
+                    const TypeDesc* type = TypeDesc::get(nodedefInput->getType());
+                    const string& enumNames = nodedefInput->getAttribute(ValueElement::ENUM_ATTRIBUTE);
+                    if (context.getShaderGenerator().getSyntax().remapEnumeration(valueString, type, enumNames, enumResult)) {
+                        inputSocket->setValue(enumResult.second);
+                    } else {
+                        inputSocket->setValue(value);
+                    }
+                }
+
+                input->setBindInput();
+                const string path = nodeInput->getNamePath();
+                if (!path.empty()) {
+                    inputSocket->setPath(path);
+                    input->setPath(path);
+                }
+                const string& unit = nodeInput->getUnit();
+                if (!unit.empty()) {
+                    inputSocket->setUnit(unit);
+                    input->setUnit(unit);
+                }
+                const string& colorSpace = nodeInput->getColorSpace();
+                if (!colorSpace.empty()) {
+                    inputSocket->setColorSpace(colorSpace);
+                    input->setColorSpace(colorSpace);
+                }
+            }
+
+            // Connect graph socket to the node input
+            inputSocket->makeConnection(input);
+
+            // Share metadata.
+            inputSocket->setMetadata(input->getMetadata());
+        }
+
+        // Apply color and unit transforms to each input.
+        applyInputTransforms(node, newNode, context);
+
+        // Set root for upstream dependency traversal
+        root = node;
+    }
+
+    // Traverse and create all dependencies upstream
+    if (root && context.getOptions().addUpstreamDependencies) {
+        addUpstreamDependencies(*root, context);
+    }
+
+    finalize(context);
+}
+
 MayaShaderGraph::MayaShaderGraph(
     const ShaderGraph* parent,
     const NodeGraph&   nodeGraph,
@@ -61,6 +210,13 @@ MayaShaderGraph::MayaShaderGraph(
 MayaShaderGraph::~MayaShaderGraph() = default;
 
 ShaderGraphPtr
+MayaShaderGraph::create(const ShaderGraph* parent, const string& name, ElementPtr element, GenContext& context)
+{
+    ShaderGraphPtr graph = std::make_shared<MayaShaderGraph>(parent, name, element, context);
+    return graph;
+}
+
+ShaderGraphPtr
 MayaShaderGraph::create(const ShaderGraph* parent, const NodeGraph& nodeGraph, GenContext& context)
 {
     ShaderGraphPtr graph = std::make_shared<MayaShaderGraph>(parent, nodeGraph, context);
@@ -83,5 +239,116 @@ void MayaShaderGraph::addPropagatedInput(ShaderNode& node, string const& name)
 }
 
 StringVec const& MayaShaderGraph::getPropagatedInputs() const { return _propagatedInputs; }
+
+void MayaShaderGraph::createConnectedNodes(const ElementPtr& downstreamElement,
+                                           const ElementPtr& upstreamElement,
+                                           ElementPtr connectingElement,
+                                           GenContext& context)
+{
+    // Create the node if it doesn't exist.
+    NodePtr upstreamNode = upstreamElement->asA<Node>();
+    if (!upstreamNode) {
+        throw ExceptionShaderGenError("Upstream element to connect is not a node '" +
+                                      upstreamElement->getName() + "'");
+    }
+    const string& newNodeName = upstreamNode->getName();
+    ShaderNode* newNode = getNode(newNodeName);
+    if (!newNode) {
+        newNode = createNode(upstreamNode, context);
+    }
+
+    // Handle interface inputs with default geometric properties.
+    for (InputPtr activeInput : upstreamNode->getActiveInputs()) {
+        if (!activeInput->hasInterfaceName() || activeInput->getConnectedNode()) {
+            continue;
+        }
+
+        InputPtr graphInput = activeInput->getInterfaceInput();
+        if (graphInput && graphInput->hasDefaultGeomPropString()) {
+            ShaderInput* shaderInput = getNode(upstreamNode->getName())->getInput(activeInput->getName());
+            addDefaultGeomNode(shaderInput, *graphInput->getDefaultGeomProp(), context);
+        }
+    }
+
+    //
+    // Make connections
+    //
+
+    // Find the output to connect to.
+    if (!connectingElement && downstreamElement->isA<Output>()) {
+        // Edge case for having an output downstream but no connecting
+        // element (input) reported upstream. In this case we set the
+        // output itself as connecting element, which handles finding
+        // the nodedef output in case of a multioutput node upstream.
+        connectingElement = downstreamElement->asA<Output>();
+    }
+    OutputPtr nodeDefOutput = connectingElement ? upstreamNode->getNodeDefOutput(connectingElement) : nullptr;
+    ShaderOutput* output = nodeDefOutput ? newNode->getOutput(nodeDefOutput->getName()) : newNode->getOutput();
+    if (!output) {
+        throw ExceptionShaderGenError("Could not find an output named '" + (nodeDefOutput ? nodeDefOutput->getName() : string("out")) +
+                                      "' on upstream node '" + upstreamNode->getName() + "'");
+    }
+
+    // Check if it was a node downstream
+    NodePtr downstreamNode = downstreamElement->asA<Node>();
+    if (downstreamNode) {
+        // We have a node downstream
+        ShaderNode* downstream = getNode(downstreamNode->getName());
+        if (downstream && connectingElement) {
+            ShaderInput* input = downstream->getInput(connectingElement->getName());
+            if (!input) {
+                throw ExceptionShaderGenError("Could not find an input named '" + connectingElement->getName() +
+                                              "' on downstream node '" + downstream->getName() + "'");
+            }
+            input->makeConnection(output);
+        } else {
+            throw ExceptionShaderGenError("Could not find downstream node ' " + downstreamNode->getName() + "'");
+        }
+    } else {
+        // Not a node, then it must be an output
+        ShaderGraphOutputSocket* outputSocket = getOutputSocket(downstreamElement->getName());
+        if (outputSocket) {
+            outputSocket->makeConnection(output);
+        }
+    }
+}
+
+void MayaShaderGraph::addUpstreamDependencies(const Element& root, GenContext& context)
+{
+    std::set<ElementPtr> processedOutputs;
+
+    for (Edge edge : root.traverseGraph()) {
+        ElementPtr upstreamElement = edge.getUpstreamElement();
+        if (!upstreamElement) {
+            continue;
+        }
+
+        ElementPtr downstreamElement = edge.getDownstreamElement();
+
+        // Early out if downstream element is an output that
+        // we have already processed. This might happen since
+        // we perform jumps over output elements below.
+        if (processedOutputs.count(downstreamElement)) {
+            continue;
+        }
+
+        // If upstream is an output jump to the actual node connected to the output.
+        if (upstreamElement->isA<Output>()) {
+            // Record this output so we don't process it again when it
+            // shows up as a downstream element in the next iteration.
+            processedOutputs.insert(upstreamElement);
+
+            upstreamElement = upstreamElement->asA<Output>()->getConnectedNode();
+            if (!upstreamElement) {
+                continue;
+            }
+        }
+
+        createConnectedNodes(downstreamElement,
+                             upstreamElement,
+                             edge.getConnectingElement(),
+                             context);
+    }
+}
 
 MATERIALX_NAMESPACE_END

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.cpp
@@ -191,10 +191,10 @@ MayaShaderGraph::MayaShaderGraph(
     const NodeGraph&   nodeGraph,
     GenContext&        context)
     : ShaderGraph(
-          parent,
-          makeValidName(nodeGraph, context),
-          nodeGraph.getDocument(),
-          context.getReservedWords())
+        parent,
+        makeValidName(nodeGraph, context),
+        nodeGraph.getDocument(),
+        context.getReservedWords())
     , _shouldPropagateInputs(true)
 {
     // Clear classification

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.cpp
@@ -188,10 +188,10 @@ MayaShaderGraph::MayaShaderGraph(
     const NodeGraph&   nodeGraph,
     GenContext&        context)
     : ShaderGraph(
-          parent,
-          makeValidName(nodeGraph, context),
-          nodeGraph.getDocument(),
-          context.getReservedWords())
+        parent,
+        makeValidName(nodeGraph, context),
+        nodeGraph.getDocument(),
+        context.getReservedWords())
 {
     // Clear classification
     _classification = 0;

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.cpp
@@ -37,23 +37,19 @@ MayaShaderGraph::MayaShaderGraph(
     const string&      name,
     const ElementPtr&  element,
     GenContext&        context)
-    : ShaderGraph(
-        parent,
-        name,
-        element->getDocument(),
-        context.getReservedWords())
+    : ShaderGraph(parent, name, element->getDocument(), context.getReservedWords())
 {
     ElementPtr root;
 
     if (element->isA<Output>()) {
-        OutputPtr output = element->asA<Output>();
+        OutputPtr  output = element->asA<Output>();
         ElementPtr outputParent = output->getParent();
 
         InterfaceElementPtr interface;
         if (outputParent->isA<NodeGraph>()) {
             // A nodegraph output.
             NodeGraphPtr nodeGraph = outputParent->asA<NodeGraph>();
-            NodeDefPtr nodeDef = nodeGraph->getNodeDef();
+            NodeDefPtr   nodeDef = nodeGraph->getNodeDef();
             if (nodeDef) {
                 interface = nodeDef;
             } else {
@@ -65,7 +61,9 @@ MayaShaderGraph::MayaShaderGraph(
             interface = outputParent ? outputParent->asA<InterfaceElement>() : nullptr;
         }
         if (!interface) {
-            throw ExceptionShaderGenError("Given output '" + output->getName() + "' has no interface valid for shader generation");
+            throw ExceptionShaderGenError(
+                "Given output '" + output->getName()
+                + "' has no interface valid for shader generation");
         }
 
         // Clear classification
@@ -75,7 +73,8 @@ MayaShaderGraph::MayaShaderGraph(
         addInputSockets(*interface, context);
 
         // Create the given output socket
-        ShaderGraphOutputSocket* outputSocket = addOutputSocket(output->getName(), TypeDesc::get(output->getType()));
+        ShaderGraphOutputSocket* outputSocket
+            = addOutputSocket(output->getName(), TypeDesc::get(output->getType()));
         outputSocket->setPath(output->getNamePath());
         const string& outputUnit = output->getUnit();
         if (!outputUnit.empty()) {
@@ -89,10 +88,11 @@ MayaShaderGraph::MayaShaderGraph(
         // Start traversal from this output
         root = output;
     } else if (element->isA<Node>()) {
-        NodePtr node = element->asA<Node>();
+        NodePtr    node = element->asA<Node>();
         NodeDefPtr nodeDef = node->getNodeDef();
         if (!nodeDef) {
-            throw ExceptionShaderGenError("Could not find a nodedef for node '" + node->getName() + "'");
+            throw ExceptionShaderGenError(
+                "Could not find a nodedef for node '" + node->getName() + "'");
         }
 
         // Create input sockets
@@ -118,9 +118,11 @@ MayaShaderGraph::MayaShaderGraph(
         // Handle node input ports
         for (const InputPtr& nodedefInput : nodeDef->getActiveInputs()) {
             ShaderGraphInputSocket* inputSocket = getInputSocket(nodedefInput->getName());
-            ShaderInput* input = newNode->getInput(nodedefInput->getName());
+            ShaderInput*            input = newNode->getInput(nodedefInput->getName());
             if (!inputSocket || !input) {
-                throw ExceptionShaderGenError("Node input '" + nodedefInput->getName() + "' doesn't match an existing input on graph '" + getName() + "'");
+                throw ExceptionShaderGenError(
+                    "Node input '" + nodedefInput->getName()
+                    + "' doesn't match an existing input on graph '" + getName() + "'");
             }
 
             // Copy data from node element to shadergen representation
@@ -128,11 +130,13 @@ MayaShaderGraph::MayaShaderGraph(
             if (nodeInput) {
                 ValuePtr value = nodeInput->getResolvedValue();
                 if (value) {
-                    const string& valueString = value->getValueString();
+                    const string&                        valueString = value->getValueString();
                     std::pair<const TypeDesc*, ValuePtr> enumResult;
                     const TypeDesc* type = TypeDesc::get(nodedefInput->getType());
-                    const string& enumNames = nodedefInput->getAttribute(ValueElement::ENUM_ATTRIBUTE);
-                    if (context.getShaderGenerator().getSyntax().remapEnumeration(valueString, type, enumNames, enumResult)) {
+                    const string&   enumNames
+                        = nodedefInput->getAttribute(ValueElement::ENUM_ATTRIBUTE);
+                    if (context.getShaderGenerator().getSyntax().remapEnumeration(
+                            valueString, type, enumNames, enumResult)) {
                         inputSocket->setValue(enumResult.second);
                     } else {
                         inputSocket->setValue(value);
@@ -184,10 +188,10 @@ MayaShaderGraph::MayaShaderGraph(
     const NodeGraph&   nodeGraph,
     GenContext&        context)
     : ShaderGraph(
-        parent,
-        makeValidName(nodeGraph, context),
-        nodeGraph.getDocument(),
-        context.getReservedWords())
+          parent,
+          makeValidName(nodeGraph, context),
+          nodeGraph.getDocument(),
+          context.getReservedWords())
 {
     // Clear classification
     _classification = 0;
@@ -209,8 +213,11 @@ MayaShaderGraph::MayaShaderGraph(
 
 MayaShaderGraph::~MayaShaderGraph() = default;
 
-ShaderGraphPtr
-MayaShaderGraph::create(const ShaderGraph* parent, const string& name, ElementPtr element, GenContext& context)
+ShaderGraphPtr MayaShaderGraph::create(
+    const ShaderGraph* parent,
+    const string&      name,
+    ElementPtr         element,
+    GenContext&        context)
 {
     ShaderGraphPtr graph = std::make_shared<MayaShaderGraph>(parent, name, element, context);
     return graph;
@@ -240,19 +247,20 @@ void MayaShaderGraph::addPropagatedInput(ShaderNode& node, string const& name)
 
 StringVec const& MayaShaderGraph::getPropagatedInputs() const { return _propagatedInputs; }
 
-void MayaShaderGraph::createConnectedNodes(const ElementPtr& downstreamElement,
-                                           const ElementPtr& upstreamElement,
-                                           ElementPtr connectingElement,
-                                           GenContext& context)
+void MayaShaderGraph::createConnectedNodes(
+    const ElementPtr& downstreamElement,
+    const ElementPtr& upstreamElement,
+    ElementPtr        connectingElement,
+    GenContext&       context)
 {
     // Create the node if it doesn't exist.
     NodePtr upstreamNode = upstreamElement->asA<Node>();
     if (!upstreamNode) {
-        throw ExceptionShaderGenError("Upstream element to connect is not a node '" +
-                                      upstreamElement->getName() + "'");
+        throw ExceptionShaderGenError(
+            "Upstream element to connect is not a node '" + upstreamElement->getName() + "'");
     }
     const string& newNodeName = upstreamNode->getName();
-    ShaderNode* newNode = getNode(newNodeName);
+    ShaderNode*   newNode = getNode(newNodeName);
     if (!newNode) {
         newNode = createNode(upstreamNode, context);
     }
@@ -265,7 +273,8 @@ void MayaShaderGraph::createConnectedNodes(const ElementPtr& downstreamElement,
 
         InputPtr graphInput = activeInput->getInterfaceInput();
         if (graphInput && graphInput->hasDefaultGeomPropString()) {
-            ShaderInput* shaderInput = getNode(upstreamNode->getName())->getInput(activeInput->getName());
+            ShaderInput* shaderInput
+                = getNode(upstreamNode->getName())->getInput(activeInput->getName());
             addDefaultGeomNode(shaderInput, *graphInput->getDefaultGeomProp(), context);
         }
     }
@@ -282,11 +291,15 @@ void MayaShaderGraph::createConnectedNodes(const ElementPtr& downstreamElement,
         // the nodedef output in case of a multioutput node upstream.
         connectingElement = downstreamElement->asA<Output>();
     }
-    OutputPtr nodeDefOutput = connectingElement ? upstreamNode->getNodeDefOutput(connectingElement) : nullptr;
-    ShaderOutput* output = nodeDefOutput ? newNode->getOutput(nodeDefOutput->getName()) : newNode->getOutput();
+    OutputPtr nodeDefOutput
+        = connectingElement ? upstreamNode->getNodeDefOutput(connectingElement) : nullptr;
+    ShaderOutput* output
+        = nodeDefOutput ? newNode->getOutput(nodeDefOutput->getName()) : newNode->getOutput();
     if (!output) {
-        throw ExceptionShaderGenError("Could not find an output named '" + (nodeDefOutput ? nodeDefOutput->getName() : string("out")) +
-                                      "' on upstream node '" + upstreamNode->getName() + "'");
+        throw ExceptionShaderGenError(
+            "Could not find an output named '"
+            + (nodeDefOutput ? nodeDefOutput->getName() : string("out")) + "' on upstream node '"
+            + upstreamNode->getName() + "'");
     }
 
     // Check if it was a node downstream
@@ -297,12 +310,14 @@ void MayaShaderGraph::createConnectedNodes(const ElementPtr& downstreamElement,
         if (downstream && connectingElement) {
             ShaderInput* input = downstream->getInput(connectingElement->getName());
             if (!input) {
-                throw ExceptionShaderGenError("Could not find an input named '" + connectingElement->getName() +
-                                              "' on downstream node '" + downstream->getName() + "'");
+                throw ExceptionShaderGenError(
+                    "Could not find an input named '" + connectingElement->getName()
+                    + "' on downstream node '" + downstream->getName() + "'");
             }
             input->makeConnection(output);
         } else {
-            throw ExceptionShaderGenError("Could not find downstream node ' " + downstreamNode->getName() + "'");
+            throw ExceptionShaderGenError(
+                "Could not find downstream node ' " + downstreamNode->getName() + "'");
         }
     } else {
         // Not a node, then it must be an output
@@ -344,10 +359,8 @@ void MayaShaderGraph::addUpstreamDependencies(const Element& root, GenContext& c
             }
         }
 
-        createConnectedNodes(downstreamElement,
-                             upstreamElement,
-                             edge.getConnectingElement(),
-                             context);
+        createConnectedNodes(
+            downstreamElement, upstreamElement, edge.getConnectingElement(), context);
     }
 }
 

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.h
@@ -9,6 +9,8 @@
 /// @file
 /// Shader graph class
 
+#include <mayaUsd/render/MaterialXGenOgsXml/CombinedMaterialXVersion.h>
+
 #include <MaterialXGenShader/ShaderGraph.h>
 
 MATERIALX_NAMESPACE_BEGIN
@@ -19,21 +21,25 @@ class MayaShaderGraph : public ShaderGraph
 {
 public:
     /// Constructor
+#if MX_COMBINED_VERSION >= 13810
     MayaShaderGraph(
         const ShaderGraph* parent,
         const string&      name,
         const ElementPtr&  element,
         GenContext&        context);
+#endif
     /// Constructor.
     MayaShaderGraph(const ShaderGraph* parent, const NodeGraph& nodeGraph, GenContext& context);
 
     /// Desctructor.
     virtual ~MayaShaderGraph();
 
+#if MX_COMBINED_VERSION >= 13810
     /// Create a new shader graph from an element.
     /// Supported elements are outputs and shader nodes.
     static ShaderGraphPtr
     create(const ShaderGraph* parent, const string& name, ElementPtr element, GenContext& context);
+#endif
 
     /// Create a new shader graph from a nodegraph.
     static ShaderGraphPtr
@@ -44,6 +50,7 @@ public:
     StringVec const& getPropagatedInputs() const;
 
 protected:
+#if MX_COMBINED_VERSION >= 13810
     /// Create node connections corresponding to the connection between a pair of elements.
     /// @param downstreamElement Element representing the node to connect to.
     /// @param upstreamElement Element representing the node to connect from
@@ -60,6 +67,7 @@ protected:
     /// The traversal is done in the context of a material, if given, to include
     /// bind input elements in the traversal.
     void addUpstreamDependencies(const Element& root, GenContext& context);
+#endif
 
     StringVec _propagatedInputs;
 };

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.h
@@ -18,11 +18,18 @@ MATERIALX_NAMESPACE_BEGIN
 class MayaShaderGraph : public ShaderGraph
 {
 public:
+    /// Constructor
+    MayaShaderGraph(const ShaderGraph* parent, const string& name, const ElementPtr& element, GenContext& context);
     /// Constructor.
     MayaShaderGraph(const ShaderGraph* parent, const NodeGraph& nodeGraph, GenContext& context);
 
     /// Desctructor.
     virtual ~MayaShaderGraph();
+
+    /// Create a new shader graph from an element.
+    /// Supported elements are outputs and shader nodes.
+    static ShaderGraphPtr create(const ShaderGraph* parent, const string& name, ElementPtr element,
+                                 GenContext& context);
 
     /// Create a new shader graph from a nodegraph.
     static ShaderGraphPtr
@@ -33,6 +40,21 @@ public:
     StringVec const& getPropagatedInputs() const;
 
 protected:
+    /// Create node connections corresponding to the connection between a pair of elements.
+    /// @param downstreamElement Element representing the node to connect to.
+    /// @param upstreamElement Element representing the node to connect from
+    /// @param connectingElement If non-null, specifies the element on on the downstream node to connect to.
+    /// @param context Context for generation.
+    void createConnectedNodes(const ElementPtr& downstreamElement,
+                              const ElementPtr& upstreamElement,
+                              ElementPtr connectingElement,
+                              GenContext& context);
+
+    /// Traverse from the given root element and add all dependencies upstream.
+    /// The traversal is done in the context of a material, if given, to include
+    /// bind input elements in the traversal.
+    void addUpstreamDependencies(const Element& root, GenContext& context);
+
     StringVec _propagatedInputs;
 };
 

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.h
@@ -19,7 +19,11 @@ class MayaShaderGraph : public ShaderGraph
 {
 public:
     /// Constructor
-    MayaShaderGraph(const ShaderGraph* parent, const string& name, const ElementPtr& element, GenContext& context);
+    MayaShaderGraph(
+        const ShaderGraph* parent,
+        const string&      name,
+        const ElementPtr&  element,
+        GenContext&        context);
     /// Constructor.
     MayaShaderGraph(const ShaderGraph* parent, const NodeGraph& nodeGraph, GenContext& context);
 
@@ -28,8 +32,8 @@ public:
 
     /// Create a new shader graph from an element.
     /// Supported elements are outputs and shader nodes.
-    static ShaderGraphPtr create(const ShaderGraph* parent, const string& name, ElementPtr element,
-                                 GenContext& context);
+    static ShaderGraphPtr
+    create(const ShaderGraph* parent, const string& name, ElementPtr element, GenContext& context);
 
     /// Create a new shader graph from a nodegraph.
     static ShaderGraphPtr
@@ -43,12 +47,14 @@ protected:
     /// Create node connections corresponding to the connection between a pair of elements.
     /// @param downstreamElement Element representing the node to connect to.
     /// @param upstreamElement Element representing the node to connect from
-    /// @param connectingElement If non-null, specifies the element on on the downstream node to connect to.
+    /// @param connectingElement If non-null, specifies the element on on the downstream node to
+    /// connect to.
     /// @param context Context for generation.
-    void createConnectedNodes(const ElementPtr& downstreamElement,
-                              const ElementPtr& upstreamElement,
-                              ElementPtr connectingElement,
-                              GenContext& context);
+    void createConnectedNodes(
+        const ElementPtr& downstreamElement,
+        const ElementPtr& upstreamElement,
+        ElementPtr        connectingElement,
+        GenContext&       context);
 
     /// Traverse from the given root element and add all dependencies upstream.
     /// The traversal is done in the context of a material, if given, to include

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.h
@@ -70,6 +70,7 @@ protected:
 #endif
 
     StringVec _propagatedInputs;
+    bool      _shouldPropagateInputs;
 };
 
 MATERIALX_NAMESPACE_END


### PR DESCRIPTION
This PR is an attempt to back port the following MaterialX PR for MayaUsd: https://github.com/AcademySoftwareFoundation/MaterialX/pull/2076.

This PR makes it possible to have defaultgeomprop values on nodegraph inputs as opposed to only on nodedef inputs.