### PR TITLE
EMSUSD-1630: Support custom callback for primitives AE template

### DIFF
--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -1078,8 +1078,7 @@ private:
 
     void _notifySystemLockIsRefreshed()
     {
-        auto dstCallbacks = UsdUfe::getUICallbacks(TfToken("onRefreshSystemLock"));
-        if (dstCallbacks.size() == 0)
+        if (!UsdUfe::isUICallbackRegistered(TfToken("onRefreshSystemLock")))
             return;
 
         PXR_NS::VtDictionary callbackContext;
@@ -1095,8 +1094,7 @@ private:
         VtStringArray lockedArray(affectedLayers.begin(), affectedLayers.end());
         callbackData["affectedLayerIds"] = lockedArray;
 
-        for (UsdUfe::UICallback::Ptr& dstCallback : dstCallbacks)
-            (*dstCallback)(callbackContext, callbackData);
+        UsdUfe::triggerUICallback(TfToken("onRefreshSystemLock"), callbackContext, callbackData);
     }
 
     UsdStageWeakPtr getStage()

--- a/lib/mayaUsd/python/__init__.py
+++ b/lib/mayaUsd/python/__init__.py
@@ -16,5 +16,6 @@ from usdUfe import restoreAllDefaultEditRouters
 from usdUfe import clearAllEditRouters
 from usdUfe import OperationEditRouterContext
 from usdUfe import AttributeEditRouterContext
+from usdUfe import triggerUICallback
 from usdUfe import registerUICallback
 from usdUfe import unregisterUICallback

--- a/lib/mayaUsd/resources/ae/usdschemabase/attributeCustomControl.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/attributeCustomControl.py
@@ -61,9 +61,9 @@ def getNiceAttributeName(ufeAttr, attrName):
             tempName = fn(ufeAttr, attrName)
             if tempName:
                 attrName = tempName
-    except:
+    except Exception as ex:
         # Do not let any of the callback failures affect our template.
-        pass
+        print('Failed to call AE nice naming callback for %s: %s' % (attrName, ex))
 
     # Finally use our internal MayaUsd nice naming function.
     return mayaUsdUfe.prettifyName(attrName)

--- a/lib/usdUfe/python/wrapUICallback.cpp
+++ b/lib/usdUfe/python/wrapUICallback.cpp
@@ -109,9 +109,9 @@ PXR_NS::VtDictionary _triggerUICallback(
     // Need to copy the input data into non-const reference to call C++ version.
     // This allows the python callback function to modify the data which we then
     // return to the triggering function.
-    // 
+    //
     // Trying to use "PXR_NS::VtDictionary& cbData" results in python error:
-    // 
+    //
     // Python argument types in usdUfe._usdUfe.triggerUICallback(str, dict, dict)
     // did not match C++ signature:
     //     triggerUICallback(

--- a/lib/usdUfe/ufe/UsdContextOps.cpp
+++ b/lib/usdUfe/ufe/UsdContextOps.cpp
@@ -748,6 +748,7 @@ UsdContextOps::SchemaNameMap UsdContextOps::getSchemaPluginNiceNames() const
         { "usdSkel", "Skeleton" },
         { "usdUI", "UI" },
         { "usdVol", "Volumes" },
+        { "usdArnold", "Arnold" }
     };
     // clang-format on
     return schemaPluginNiceNames;

--- a/lib/usdUfe/utils/uiCallback.cpp
+++ b/lib/usdUfe/utils/uiCallback.cpp
@@ -71,7 +71,7 @@ void triggerUICallback(
     PXR_NS::VtDictionary&       data)
 {
     UICallbacks& uiCallbacks = getRegisteredUICallbacks();
-    auto foundCallback = uiCallbacks.find(operation);
+    auto         foundCallback = uiCallbacks.find(operation);
     if (foundCallback != uiCallbacks.end()) {
         for (auto& cb : foundCallback->second) {
             (*cb)(context, data);

--- a/lib/usdUfe/utils/uiCallback.h
+++ b/lib/usdUfe/utils/uiCallback.h
@@ -18,12 +18,10 @@
 
 #include <usdUfe/base/api.h>
 
-#include <pxr/base/tf/hashmap.h>
+#include <pxr/base/tf/token.h>
 #include <pxr/base/vt/dictionary.h>
 #include <pxr/usd/sdf/types.h>
-#include <pxr/usd/usd/prim.h>
 
-#include <functional>
 #include <memory>
 
 namespace USDUFE_NS_DEF {
@@ -44,14 +42,6 @@ public:
         = 0;
 };
 
-using UICallbacks = PXR_NS::
-    TfHashMap<PXR_NS::TfToken, std::vector<UICallback::Ptr>, PXR_NS::TfToken::HashFunctor>;
-
-// Retrieve the callbacks for the argument operation.
-// If no such callback exists, an empty vector is returned.
-USDUFE_PUBLIC
-const std::vector<UICallback::Ptr>& getUICallbacks(const PXR_NS::TfToken& operation);
-
 // Register an callback for the argument operation.
 USDUFE_PUBLIC
 void registerUICallback(const PXR_NS::TfToken& operation, const UICallback::Ptr& uiCallback);
@@ -59,6 +49,17 @@ void registerUICallback(const PXR_NS::TfToken& operation, const UICallback::Ptr&
 // Unregister an callback for the argument operation.
 USDUFE_PUBLIC
 void unregisterUICallback(const PXR_NS::TfToken& operation, const UICallback::Ptr& uiCallback);
+
+// Is there a callback registered for the argument operation?
+USDUFE_PUBLIC
+bool isUICallbackRegistered(const PXR_NS::TfToken& operation);
+
+// Trigger the callback(s) for the argument operation with the callback context and data.
+USDUFE_PUBLIC
+void triggerUICallback(
+    const PXR_NS::TfToken&      operation,
+    const PXR_NS::VtDictionary& context,
+    PXR_NS::VtDictionary&       data);
 
 } // namespace USDUFE_NS_DEF
 


### PR DESCRIPTION
#### EMSUSD-1630: Support custom callback for primitives AE template
* Added new `triggerUICallback` function and removed `getUICallbacks`
* Updated AE doc on how to use new AE custom callback.
* New custom callback section in AE template giving clients ability to add to AE template.
* New attribute nice name callback to give clients ability to inject function into attribute nice name.