### PR TITLE
EMSUSD-1724 add support for decimeters in export

### DIFF
--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -764,6 +764,7 @@ UsdMayaJobExportArgs::UsdMayaJobExportArgs(
             UsdMayaJobExportArgsTokens->um,
             UsdMayaJobExportArgsTokens->mm,
             UsdMayaJobExportArgsTokens->cm,
+            UsdMayaJobExportArgsTokens->dm,
             UsdMayaJobExportArgsTokens->m,
             UsdMayaJobExportArgsTokens->km,
             UsdMayaJobExportArgsTokens->lightyear,

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -140,6 +140,7 @@ TF_DECLARE_PUBLIC_TOKENS(
     (um) \
     (mm) \
     (cm) \
+    (dm) \
     (m) \
     (km) \
     (lightyear) \

--- a/lib/mayaUsd/fileio/jobs/writeJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/writeJob.cpp
@@ -129,6 +129,8 @@ private:
                 { UsdMayaJobExportArgsTokens->um, UsdGeomLinearUnits::micrometers },
                 { UsdMayaJobExportArgsTokens->mm, UsdGeomLinearUnits::millimeters },
                 { UsdMayaJobExportArgsTokens->cm, UsdGeomLinearUnits::centimeters },
+                // Note: there is no official USD decimeter units, we have to roll our own.
+                { UsdMayaJobExportArgsTokens->dm, 0.1 },
                 { UsdMayaJobExportArgsTokens->m, UsdGeomLinearUnits::meters },
                 { UsdMayaJobExportArgsTokens->km, UsdGeomLinearUnits::kilometers },
                 { UsdMayaJobExportArgsTokens->lightyear, UsdGeomLinearUnits::lightYears },

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.py
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.py
@@ -283,6 +283,7 @@ __mayaUSDStringResources = {
     "kExportUnitMayaPrefsLbl": "Use Maya Preferences",
     "kExportUnitMillimeterLbl": "Millimeter",
     "kExportUnitCentimeterLbl": "Centimeter",
+    "kExportUnitDecimeterLbl": "Decimeter",
     "kExportUnitMeterLbl": "Meter",
     "kExportUnitKilometerLbl": "Kilometer",
     "kExportUnitInchLbl": "Inch",

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -1351,6 +1351,7 @@ global proc int mayaUsdTranslatorExport (string $parent,
                             menuItem -divider on;
                             menuItem -l `getMayaUsdString("kExportUnitMillimeterLbl")` -ann "mm";
                             menuItem -l `getMayaUsdString("kExportUnitCentimeterLbl")` -ann "cm";
+                            menuItem -l `getMayaUsdString("kExportUnitDecimeterLbl")` -ann "dm";
                             menuItem -l `getMayaUsdString("kExportUnitMeterLbl")` -ann "m";
                             menuItem -l `getMayaUsdString("kExportUnitKilometerLbl")` -ann "km";
                             menuItem -divider on;

--- a/test/lib/usd/translators/testUsdExportUnits.py
+++ b/test/lib/usd/translators/testUsdExportUnits.py
@@ -110,29 +110,69 @@ class testUsdExportUnits(unittest.TestCase):
             ('xformOp:translate', (0., 0., 30.)),
             ('xformOp:scale', (10., 10., 10.))])
 
-    def testExportUnitsDifferentUnits(self):
+    def testExportUnitsNanometers(self):
+        """Test exporting and forcing units of nanometers, different from Maya prefs."""
+        self._runTestExportUnitsDifferentUnits('nm', 1e-9)
+
+    def testExportUnitsMicrometers(self):
+        """Test exporting and forcing units of micrometers, different from Maya prefs."""
+        self._runTestExportUnitsDifferentUnits('um', 1e-6)
+
+    def testExportUnitsMillimeters(self):
+        """Test exporting and forcing units of millimeters, different from Maya prefs."""
+        self._runTestExportUnitsDifferentUnits('mm', 1e-3)
+
+    def testExportUnitsDecimeters(self):
+        """Test exporting and forcing units of decimeters, different from Maya prefs."""
+        self._runTestExportUnitsDifferentUnits('dm', 1e-1)
+
+    def testExportUnitsMeters(self):
+        """Test exporting and forcing units of meters, different from Maya prefs."""
+        self._runTestExportUnitsDifferentUnits('m', 1.)
+
+    def testExportUnitsKilometers(self):
         """Test exporting and forcing units of kilometers, different from Maya prefs."""
+        self._runTestExportUnitsDifferentUnits('km', 1000.)
+
+    def testExportUnitsInches(self):
+        """Test exporting and forcing units of inches, different from Maya prefs."""
+        self._runTestExportUnitsDifferentUnits('inch', 0.0254)
+
+    def testExportUnitsFeet(self):
+        """Test exporting and forcing units of feet, different from Maya prefs."""
+        self._runTestExportUnitsDifferentUnits('foot', 0.3048)
+
+    def testExportUnitsYards(self):
+        """Test exporting and forcing units of yards, different from Maya prefs."""
+        self._runTestExportUnitsDifferentUnits('yard', 0.9144)
+
+    def testExportUnitsMiles(self):
+        """Test exporting and forcing units of miles, different from Maya prefs."""
+        self._runTestExportUnitsDifferentUnits('mile', 1609.344)
+
+    def _runTestExportUnitsDifferentUnits(self, unitName, expectedMetersPerUnit):
+        """Test exporting and forcing units, different from Maya prefs."""
         cmds.polySphere()
         cmds.move(0, 0, 3, relative=True)
 
         usdFile = os.path.abspath('UsdExportUnits_DifferentY.usda')
         cmds.mayaUSDExport(file=usdFile,
                            shadingMode='none',
-                           unit='km')
+                           unit=unitName)
         
         stage = Usd.Stage.Open(usdFile)
         self.assertTrue(stage.HasAuthoredMetadata('metersPerUnit'))
 
-        expectedMetersPerUnit = 1000.
         actualMetersPerUnit = UsdGeom.GetStageMetersPerUnit(stage)
-        self.assertEqual(actualMetersPerUnit, expectedMetersPerUnit)
+        self.assertAlmostEqual(actualMetersPerUnit, expectedMetersPerUnit)
 
         spherePrim = stage.GetPrimAtPath('/pSphere1')
         self.assertTrue(spherePrim)
 
+        expectedScale = 0.01 / expectedMetersPerUnit
         transformUtils.assertPrimXforms(self, spherePrim, [
-            ('xformOp:translate', (0., 0., 0.00003)),
-            ('xformOp:scale', (0.00001, 0.00001, 0.00001))])
+            ('xformOp:translate', (0., 0., 3 * expectedScale)),
+            ('xformOp:scale', (expectedScale, expectedScale, expectedScale))])
 
 
 if __name__ == '__main__':

--- a/test/testUtils/transformUtils.py
+++ b/test/testUtils/transformUtils.py
@@ -51,7 +51,7 @@ def assertPrimXforms(test, prim, xforms):
             ('xformOp:scale', (10., 10., 10.))
         ]
     '''
-    EPSILON = 1e-6
+    EPSILON = 1e-5
     xformOpOrder = prim.GetAttribute('xformOpOrder').Get()
     test.assertEqual(len(xformOpOrder), len(xforms))
     for name, value in xforms:


### PR DESCRIPTION
- Add "dm" in the supported units in the export command.
- Add a Decimeters entry in the drop-down menu for units in export.
- Add unit tests for all export units.
- Adjust precision of comparison because comparison would fail for feet.