### PR TITLE
Fix crash in Attribute Editor when renaming a prim with pulled descendants

### DIFF
--- a/lib/mayaUsd/fileio/orphanedNodesManager.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.cpp
@@ -36,7 +36,7 @@
 #include <ufe/trie.imp.h>
 
 // Workaround to avoid a crash that occurs when the Attribute Editor is visible
-// and displaying a USD prim that is being renamed, while we are updating proxyAccessor 
+// and displaying a USD prim that is being renamed, while we are updating proxyAccessor
 // connections for its descendant pulled objects.
 #define MAYA_USD_AE_CRASH_ON_RENAME_WORKAROUND
 

--- a/lib/mayaUsd/fileio/orphanedNodesManager.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.cpp
@@ -29,10 +29,16 @@
 #include <pxr/usd/usd/editContext.h>
 
 #include <maya/MFnDagNode.h>
+#include <maya/MGlobal.h>
 #include <maya/MPlug.h>
 #include <ufe/hierarchy.h>
 #include <ufe/sceneSegmentHandler.h>
 #include <ufe/trie.imp.h>
+
+// Workaround to avoid a crash that occurs when the Attribute Editor is visible
+// and displaying a USD prim that is being renamed, while we are updating proxyAccessor 
+// connections for its descendant pulled objects.
+#define MAYA_USD_AE_CRASH_ON_RENAME_WORKAROUND
 
 // For Tf diagnostics macros.
 PXR_NAMESPACE_USING_DIRECTIVE
@@ -163,8 +169,22 @@ void renamePulledObject(
     for (const PullVariantInfo& info : trieNode->data()) {
         const MDagPath& mayaPath = info.editedAsMayaRoot;
         TF_VERIFY(writePullInformation(pulledPath, mayaPath));
-        if (usdPathChanged) {
-            TF_VERIFY(reparentPulledObject(mayaPath, pulledPath.pop()));
+        if (usdPathChanged && mayaPath.isValid()) {
+#ifdef MAYA_USD_AE_CRASH_ON_RENAME_WORKAROUND
+            // Update the proxyAccessor connections on idle to avoid a crash when
+            // attribute editor is visible and showing the ancestor USD prim beeing renamed.
+            if (MGlobal::mayaState() == MGlobal::kInteractive) {
+                using ReparentArgs = std::pair<MDagPath, Ufe::Path>;
+                MGlobal::executeTaskOnIdle(
+                    [](void* data) {
+                        const auto* args = static_cast<ReparentArgs*>(data);
+                        TF_VERIFY(reparentPulledObject(args->first, args->second));
+                        delete args;
+                    },
+                    new ReparentArgs(mayaPath, pulledPath.pop()));
+            } else
+#endif
+                TF_VERIFY(reparentPulledObject(mayaPath, pulledPath.pop()));
         }
     }
 }

--- a/lib/mayaUsd/fileio/utils/proxyAccessorUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/proxyAccessorUtil.cpp
@@ -37,20 +37,13 @@ MStatus ProxyAccessorUndoItem::parentPulledObject(
     const auto ufeChildPath = MayaUsd::ufe::dagPathToUfe(pulledDagPath).pop();
 
     // Quick workaround to reuse some POC code - to rewrite later
-
-    // Communication to current proxyAccessor code is through the global selection.
-    // This is not logically necessary, and should be re-written to avoid going through
-    // the global selection.
     static const MString kPyTrueLiteral("True");
     static const MString kPyFalseLiteral("False");
 
     MString pyCommand;
     pyCommand.format(
         "from mayaUsd.lib import proxyAccessor as pa\n"
-        "import maya.cmds as cmds\n"
-        "cmds.select('^1s', '^2s')\n"
-        "pa.parent(force=^3s)\n"
-        "cmds.select(clear=True)\n",
+        "pa.parent('^1s', '^2s', force=^3s)\n",
         Ufe::PathString::string(ufeChildPath).c_str(),
         Ufe::PathString::string(ufeParentPath).c_str(),
         force ? kPyTrueLiteral : kPyFalseLiteral);

--- a/lib/mayaUsd/nodes/proxyAccessor.py
+++ b/lib/mayaUsd/nodes/proxyAccessor.py
@@ -325,7 +325,7 @@ def parentItems(ufeChildren, ufeParent, connect=True):
         # Cannot use 'visibility' here because it's already used by orphan manager
         connectParentChildAttr(parentVisibilityAttr, childDagPath, 'lodVisibility', connect)
 
-def __parent(*ufeItemPathStrings, doParenting=True, forceUnparenting=False):
+def __parent(doParenting, forceUnparenting, *ufeItemPathStrings):
    if ufeItemPathStrings:
       ufeSelectionList = [_createUfeSceneItem(pStr) for pStr in ufeItemPathStrings]
    else:
@@ -347,11 +347,13 @@ def __parent(*ufeItemPathStrings, doParenting=True, forceUnparenting=False):
    
    parentItems(ufeChildren, ufeParent, doParenting)
 
-def parent(*ufeItemPathStrings, force=False):
-    __parent(*ufeItemPathStrings, doParenting=True, forceUnparenting=force)
+def parent(*ufeItemPathStrings, **kwargs):
+    # Use **kwargs instead of keyword-only arguments after varargs for python2 compat.
+    forceUnparenting = kwargs.get('force', False)
+    __parent(True, forceUnparenting, *ufeItemPathStrings)
 
 def unparent(*ufeItemPathStrings):
-    __parent(*ufeItemPathStrings, doParenting=False)
+    __parent(False, False, *ufeItemPathStrings)
 
 def connectItems(ufeObjectSrc, ufeObjectDst, attrToConnect):
     connectMayaToUsd = isUfeUsdPath(ufeObjectDst)


### PR DESCRIPTION
This PR addresses a crash that occurs when renaming a USD prim with descendant prims edited as Maya, while the Attribute Editor is visible and displaying the prim being renamed. I observed the issue on Maya 2023 and 2025 on Linux. It occurs since PR #3861.

The crash can be reproduced using this [maya scene](https://github.com/user-attachments/files/17546929/crash_ae_on_ufe_rename.zip). To trigger the issue, open the AE, select and rename a prim such as `/Root1`. This should result in a hard crash within `TPSdatabase::doRebuild`, typically producing the following stack trace:
```
  TPSdataNode::typeName(bool) const
  TPSdatabase::generateUI(QLayout*, TPSdataNode*, bool)
  TPSdatabase::generateUI(QLayout*, TdependNode*, bool)
  TPSdatabase::doRebuild(Tevent const&)
  /usr/autodesk/maya2025/lib/libSharedUI.so(+0x3cae17) [0x7f694dc14e17]
  TeventHandler::doIdles()
  /usr/autodesk/maya2025/lib/libExtensionLayer.so(+0x33ccf5) [0x7f6947411cf5]
  QObject::event(QEvent*)
  QApplicationPrivate::notify_helper(QObject*, QEvent*)
  /usr/autodesk/maya2025/lib/libExtensionLayer.so(+0x3271a3) [0x7f69473fc1a3]
  QCoreApplication::notifyInternal2(QObject*, QEvent*)
  QTimerInfoList::activateTimers()
  /usr/autodesk/maya2025/lib/libQt6Core.so.6(+0x3e36ac) [0x7f69440bb6ac]
  g_main_context_dispatch
  /lib64/libglib-2.0.so.0(+0x4dea8) [0x7f6926a24ea8]
  g_main_context_iteration
  QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>)
  QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>)
  QCoreApplication::exec()
  Tapplication::start()
  /usr/autodesk/maya2025/bin/maya.bin() [0x41ba3e]
  /usr/autodesk/maya2025/bin/maya.bin() [0x416b60]
  __libc_start_main
  /usr/autodesk/maya2025/bin/maya.bin() [0x41a1ce]
```

While investigating the cause of the crash, I simplified the context and was able to reproduce it using the following script. It triggers the crash by disconnecting a `proxyAccessor` output during `Ufe::ObjectRename`, which is a subset of the operations performed by OrphanedNodesManager on rename since PR #3861.

```python
import ufe
from maya import cmds, mel

# Open the test scene
cmds.file("crash_ae_on_ufe_rename.ma", open=True, force=True)

# Add observer
class CrashyObserver(ufe.Observer):
    def __call__(self, notif):
        if isinstance(notif, ufe.ObjectRename):
            for dest in cmds.connectionInfo("stageShape1.AP__Root1_combinedVisibility", dfs=True):
                cmds.disconnectAttr("stageShape1.AP__Root1_combinedVisibility", dest)

obs = CrashyObserver()
ufe.Scene.addObserver(obs)

# Select the prim to rename and ensure the AE is shown
cmds.select("|stage1|stageShape1,/Root1")
mel.eval('showEditor("|stage1|stageShape1,/Root1")')

# Wait and rename the prim. Maya shoud crash.
cmds.rename("NewRoot1")
```

I could not find the root cause of this crash within the maya-usd codebase. The issue may lie on the Maya or UFE side, related to the timing of AE updates and Ufe::ObjectRename events. The workaround proposed in this PR defers the proxyAccessor connection updates, having them occur at a more appropriate time for the AE, preventing the crash.

#### Included Changes:

- Modified `mayaUsd.lib.proxyAccessor` `parent` and `unparent` functions to accept an optional list of UFE children and parent paths: jufrantz/maya-usd@7bf2b98.
- Thanks to this, `OrphanedNodesManager` does not alter Maya's selection when updating `proxyAccessor` connections: jufrantz/maya-usd@008b0da.
- Updated `OrphanedNodesManager` to execute `ProxyAccessorUndoItem::parentPulledObject` on idle to avoid the crash. This change is enclosed within a `#ifdef` scope, making it easier to remove if a better fix becomes available: jufrantz/maya-usd@776e65d

