### PR TITLE
EMSUSD-1455 no save during export

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -228,7 +228,6 @@ public:
     static void           prepareForSaveCheck(bool*, void*);
     static void           cleanupForSave(void*);
     static void           prepareForExportCheck(bool*, void*);
-    static void           cleanupForExport(void*);
     static void           prepareForWriteCheck(bool*, bool);
     static void           cleanupForWrite();
     static void           loadLayersPostRead(const MFnReference* fromReference = nullptr);
@@ -339,8 +338,6 @@ void LayerDatabase::registerCallbacks()
             = MSceneMessage::addCallback(MSceneMessage::kAfterSave, LayerDatabase::cleanupForSave);
         preExportCallbackId = MSceneMessage::addCallback(
             MSceneMessage::kBeforeExportCheck, LayerDatabase::prepareForExportCheck);
-        postExportCallbackId = MSceneMessage::addCallback(
-            MSceneMessage::kAfterExport, LayerDatabase::cleanupForExport);
         postNewCallbackId
             = MSceneMessage::addCallback(MSceneMessage::kAfterNew, LayerDatabase::cleanUpNewScene);
         preOpenCallbackId = MSceneMessage::addCallback(
@@ -409,17 +406,76 @@ void LayerDatabase::cleanupForSave(void*)
     cleanupForWrite();
 }
 
-void LayerDatabase::prepareForExportCheck(bool* retCode, void*)
+namespace {
+
+MString formatProxyShapeWarning(const char* message, const StageSavingInfo& info)
 {
-    // This is called during a Maya notification callback, so no undo supported.
-    OpUndoItemMuting muting;
-    prepareForWriteCheck(retCode, true);
+    MString text;
+    text.format(message, info.dagPath.partialPathName());
+    return text;
 }
 
-void LayerDatabase::cleanupForExport(void*)
+// Handle a dirty stage during export as USD.
+void handleDirtyStageDuringExport(const StageSavingInfo& info)
 {
-    // This is call by Maya when the Maya save has finished.
-    cleanupForWrite();
+    if (!info.stage)
+        return;
+
+    const UsdUfe::StageDirtyState dirty = UsdUfe::isStageDirty(*info.stage);
+    if (dirty == UsdUfe::StageDirtyState::Clean)
+        return;
+
+    if (info.stage->GetRootLayer()->IsAnonymous()) {
+        MGlobal::displayWarning(formatProxyShapeWarning(
+            "A reference to ^1s could not be exported because the root layer is anonymous."
+            " To include this stage, you will need to save the anonymous root layer to disk"
+            " and re-export the scene.",
+            info));
+        return;
+    }
+
+    if (dirty == UsdUfe::StageDirtyState::DirtyRootLayers) {
+        MGlobal::displayWarning(formatProxyShapeWarning(
+            "^1s may not appear in the exported scene exactly as it appears in the scene"
+            " because there are layers that have not been saved to disk. Saving those"
+            " layers in the layer editor may be needed.",
+            info));
+        return;
+    }
+
+    if (dirty == UsdUfe::StageDirtyState::DirtySessionLayers) {
+        MGlobal::displayWarning(formatProxyShapeWarning(
+            "^1s may not appear in the exported scene exactly as it appears in the scene"
+            " because there are opinions in the session layer which are not propagated"
+            " into the USD files.",
+            info));
+        return;
+    }
+}
+
+} // namespace
+
+void LayerDatabase::prepareForExportCheck(bool* retCode, void*)
+{
+    *retCode = true;
+
+    // This is called during a Maya notification callback, so no undo supported.
+    OpUndoItemMuting muting;
+
+    auto& layerDB = LayerDatabase::instance();
+
+    bool       hasAnyProxy = false;
+    const bool isExport = true;
+    if (!layerDB.getProxiesToSave(isExport, &hasAnyProxy))
+        return;
+
+    for (const StageSavingInfo& info : layerDB._proxiesToSave)
+        handleDirtyStageDuringExport(info);
+
+    for (const auto& info : layerDB._internalProxiesToSave)
+        handleDirtyStageDuringExport(info);
+
+    layerDB.clearProxies();
 }
 
 void LayerDatabase::prepareForWriteCheck(bool* retCode, bool isExport)
@@ -486,19 +542,15 @@ void LayerDatabase::updateLayerManagers()
 bool LayerDatabase::hasDirtyLayer() const
 {
     for (const auto& info : _proxiesToSave) {
-        SdfLayerHandleVector allLayers = info.stage->GetUsedLayers(true);
-        for (auto layer : allLayers) {
-            if (layer->IsDirty()) {
-                return true;
-            }
+        const UsdUfe::StageDirtyState dirty = UsdUfe::isStageDirty(*info.stage);
+        if (dirty != UsdUfe::StageDirtyState::Clean) {
+            return true;
         }
     }
     for (const auto& info : _internalProxiesToSave) {
-        SdfLayerHandleVector allLayers = info.stage->GetUsedLayers(true);
-        for (auto layer : allLayers) {
-            if (layer->IsDirty()) {
-                return true;
-            }
+        const UsdUfe::StageDirtyState dirty = UsdUfe::isStageDirty(*info.stage);
+        if (dirty != UsdUfe::StageDirtyState::Clean) {
+            return true;
         }
     }
     return false;

--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -422,7 +422,7 @@ void handleDirtyStageDuringExport(const StageSavingInfo& info)
         return;
 
     const UsdUfe::StageDirtyState dirty = UsdUfe::isStageDirty(*info.stage);
-    if (dirty == UsdUfe::StageDirtyState::Clean)
+    if (dirty == UsdUfe::StageDirtyState::kClean)
         return;
 
     if (info.stage->GetRootLayer()->IsAnonymous()) {
@@ -434,7 +434,7 @@ void handleDirtyStageDuringExport(const StageSavingInfo& info)
         return;
     }
 
-    if (dirty == UsdUfe::StageDirtyState::DirtyRootLayers) {
+    if (dirty == UsdUfe::StageDirtyState::kDirtyRootLayers) {
         MGlobal::displayWarning(formatProxyShapeWarning(
             "^1s may not appear in the exported scene exactly as it appears in the scene"
             " because there are layers that have not been saved to disk. Saving those"
@@ -443,7 +443,7 @@ void handleDirtyStageDuringExport(const StageSavingInfo& info)
         return;
     }
 
-    if (dirty == UsdUfe::StageDirtyState::DirtySessionLayers) {
+    if (dirty == UsdUfe::StageDirtyState::kDirtySessionLayers) {
         MGlobal::displayWarning(formatProxyShapeWarning(
             "^1s may not appear in the exported scene exactly as it appears in the scene"
             " because there are opinions in the session layer which are not propagated"
@@ -543,13 +543,13 @@ bool LayerDatabase::hasDirtyLayer() const
 {
     for (const auto& info : _proxiesToSave) {
         const UsdUfe::StageDirtyState dirty = UsdUfe::isStageDirty(*info.stage);
-        if (dirty != UsdUfe::StageDirtyState::Clean) {
+        if (dirty != UsdUfe::StageDirtyState::kClean) {
             return true;
         }
     }
     for (const auto& info : _internalProxiesToSave) {
         const UsdUfe::StageDirtyState dirty = UsdUfe::isStageDirty(*info.stage);
-        if (dirty != UsdUfe::StageDirtyState::Clean) {
+        if (dirty != UsdUfe::StageDirtyState::kClean) {
             return true;
         }
     }

--- a/lib/usdUfe/utils/layers.cpp
+++ b/lib/usdUfe/utils/layers.cpp
@@ -99,13 +99,13 @@ StageDirtyState isStageDirty(const PXR_NS::UsdStage& stage)
             continue;
 
         if (rootLayers.count(layer))
-            return StageDirtyState::DirtyRootLayers;
+            return StageDirtyState::kDirtyRootLayers;
 
         if (sessionLayers.count(layer))
-            return StageDirtyState::DirtySessionLayers;
+            return StageDirtyState::kDirtySessionLayers;
     }
 
-    return StageDirtyState::Clean;
+    return StageDirtyState::kClean;
 }
 
 bool hasMutedLayer(const PXR_NS::UsdPrim& prim)

--- a/lib/usdUfe/utils/layers.h
+++ b/lib/usdUfe/utils/layers.h
@@ -152,9 +152,9 @@ bool isSessionLayer(
 // Verify if a stage has any dirty layer.
 enum class StageDirtyState : int
 {
-    Clean,
-    DirtyRootLayers,
-    DirtySessionLayers
+    kClean,
+    kDirtyRootLayers,
+    kDirtySessionLayers
 };
 
 /**

--- a/lib/usdUfe/utils/layers.h
+++ b/lib/usdUfe/utils/layers.h
@@ -149,6 +149,23 @@ bool isSessionLayer(
     const PXR_NS::SdfLayerHandle&           layer,
     const std::set<PXR_NS::SdfLayerRefPtr>& sessionLayers);
 
+// Verify if a stage has any dirty layer.
+enum class StageDirtyState : int
+{
+    Clean,
+    DirtyRootLayers,
+    DirtySessionLayers
+};
+
+/**
+ * Verify if a stage is dirty.
+ *
+ * @param stage the stage to verify.
+ */
+
+USDUFE_PUBLIC
+StageDirtyState isStageDirty(const PXR_NS::UsdStage& stage);
+
 /**
  * Get which of the two given layers is the strongest under the given root layer hierarchy.
  *

--- a/test/lib/usd/translators/UsdExportStagesAsRefsTest/sceneWithStage.ma
+++ b/test/lib/usd/translators/UsdExportStagesAsRefsTest/sceneWithStage.ma
@@ -2,12 +2,13 @@
 //Name: sceneWithStage.ma
 //Last modified: Wed, Jun 26, 2024 04:41:34 PM
 //Codeset: 1252
+requires maya "2019ff01";
 requires -nodeType "mayaUsdLayerManager" -nodeType "mayaUsdProxyShape" -dataType "pxrUsdStageData"
 		 "mayaUsdPlugin" "0.30.0";
 currentUnit -l centimeter -a degree -t film;
 fileInfo "application" "maya";
-fileInfo "product" "Maya 2022";
-fileInfo "version" "Preview Release 123";
+fileInfo "product" "Maya 2019";
+fileInfo "version" "Preview Release 96";
 fileInfo "cutIdentifier" "202102250315-aee19a710d";
 fileInfo "osv" "Windows 7 Enterprise v (Build: 7601)";
 fileInfo "UUID" "898E14B2-4E8B-50E7-E532-F0A9C06435D9";

--- a/test/lib/usd/translators/UsdExportStagesAsRefsTest/sceneWithStage.ma
+++ b/test/lib/usd/translators/UsdExportStagesAsRefsTest/sceneWithStage.ma
@@ -2,13 +2,13 @@
 //Name: sceneWithStage.ma
 //Last modified: Wed, Jun 26, 2024 04:41:34 PM
 //Codeset: 1252
-requires maya "2019ff01";
+requires maya "2022";
 requires -nodeType "mayaUsdLayerManager" -nodeType "mayaUsdProxyShape" -dataType "pxrUsdStageData"
 		 "mayaUsdPlugin" "0.30.0";
 currentUnit -l centimeter -a degree -t film;
 fileInfo "application" "maya";
-fileInfo "product" "Maya 2019";
-fileInfo "version" "Preview Release 96";
+fileInfo "product" "Maya 2022";
+fileInfo "version" "2022";
 fileInfo "cutIdentifier" "202102250315-aee19a710d";
 fileInfo "osv" "Windows 7 Enterprise v (Build: 7601)";
 fileInfo "UUID" "898E14B2-4E8B-50E7-E532-F0A9C06435D9";


### PR DESCRIPTION
- Add an helper function to check if a stage is dirty.
- Do not save dirty layers when exporting to USD.
- Instead, warn about anonymous or dirty stages.
- Add a unit test.