### PR TITLE
EMSUSD-1722 fix node origin detection

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -114,20 +114,23 @@ MStatus disconnectCompoundArrayPlug(MPlug arrayPlug)
     return dgmod.doIt();
 }
 
-/// @brief Verify if the given node is either from the given reference, if that is not null,
-///        or from the main Maya scene if the reference is null.
+/// @brief Verify if the given node is from a reference.
 static bool
-isNodeFromDesiredOrigin(const MFnReference* fromReference, const MFnDependencyNode& node)
+isNodeFromDesiredOrigin(const MFnDependencyNode& node, MayaUsdProxyShapeBase* forProxyShape)
 {
-    if (fromReference) {
-        return fromReference->containsNodeExactly(node.object());
-    } else {
-        return !node.isFromReferencedFile();
-    }
+    const bool proxyIsFromReference
+        = (forProxyShape && MFnDependencyNode(forProxyShape->thisMObject()).isFromReferencedFile());
+    return node.isFromReferencedFile() == proxyIsFromReference;
 }
 
-MayaUsd::LayerManager* findNode(const MFnReference* fromReference = nullptr)
+MayaUsd::LayerManager* findNode(MayaUsdProxyShapeBase* forProxyShape)
 {
+    if (forProxyShape) {
+        if (MayaUsd::LayerManager* layerManager = forProxyShape->getLayerManager()) {
+            return layerManager;
+        }
+    }
+
     // Check for cached layer manager before searching
     MFnDependencyNode fn;
     if (layerManagerHandle.isValid() && layerManagerHandle.isAlive()) {
@@ -143,7 +146,7 @@ MayaUsd::LayerManager* findNode(const MFnReference* fromReference = nullptr)
         MObject mobj = iter.item();
         fn.setObject(mobj);
         if (fn.typeId() == MayaUsd::LayerManager::typeId) {
-            if (isNodeFromDesiredOrigin(fromReference, fn)) {
+            if (isNodeFromDesiredOrigin(fn, forProxyShape)) {
                 layerManagerHandle = mobj;
                 return static_cast<MayaUsd::LayerManager*>(fn.userNode());
             }
@@ -152,9 +155,9 @@ MayaUsd::LayerManager* findNode(const MFnReference* fromReference = nullptr)
     return nullptr;
 }
 
-MayaUsd::LayerManager* findOrCreateNode(const MFnReference* fromReference = nullptr)
+MayaUsd::LayerManager* findOrCreateNode(MayaUsdProxyShapeBase* forProxyShape)
 {
-    MayaUsd::LayerManager* lm = findNode(fromReference);
+    MayaUsd::LayerManager* lm = findNode(forProxyShape);
     if (!lm) {
         MDGModifier& modifier = MayaUsd::MDGModifierUndoItem::create("Node find or creation");
         MObject      manager = modifier.createNode(MayaUsd::LayerManager::typeId);
@@ -230,10 +233,12 @@ public:
     static void           prepareForExportCheck(bool*, void*);
     static void           prepareForWriteCheck(bool*, bool);
     static void           cleanupForWrite();
-    static void           loadLayersPostRead(const MFnReference* fromReference = nullptr);
+    static void           loadLayersPostRead(MayaUsdProxyShapeBase* forProxyShape);
     static void           cleanUpNewScene(void*);
     static void           clearManagerNode(MayaUsd::LayerManager* lm);
-    static void           removeManagerNode(MayaUsd::LayerManager* lm = nullptr);
+    static void           removeManagerNode(
+                  MayaUsd::LayerManager* lm = nullptr,
+                  MayaUsdProxyShapeBase* forProxyShape = nullptr);
 
     bool getProxiesToSave(bool isExport, bool* hasAnyProxy);
     bool saveInteractionRequired();
@@ -249,7 +254,7 @@ public:
     std::string getSelectedStage() const;
 
     bool saveLayerManagerSelectedStage();
-    bool loadLayerManagerSelectedStage();
+    bool loadLayerManagerSelectedStage(MayaUsdProxyShapeBase* forProxyShape);
 
     SdfLayerHandle findLayer(std::string identifier) const;
 
@@ -506,8 +511,11 @@ void LayerDatabase::prepareForWriteCheck(bool* retCode, bool isExport)
         *retCode = true;
     }
 
+    // Note: for now we only save USD change made in stage in the main
+    //       Maya scene. We don't save changes made to stages in Maya
+    //       references.
     if (!hasAnyProxy)
-        removeManagerNode(nullptr);
+        removeManagerNode(nullptr, nullptr);
 }
 
 void LayerDatabase::cleanupForWrite()
@@ -666,7 +674,10 @@ std::string LayerDatabase::getSelectedStage() const { return _selectedStage; }
 
 bool LayerDatabase::saveLayerManagerSelectedStage()
 {
-    MayaUsd::LayerManager* lm = findOrCreateNode();
+    // Note: for now we only save USD change made in stage in the main
+    //       Maya scene. We don't save changes made to stages in Maya
+    //       references.
+    MayaUsd::LayerManager* lm = findOrCreateNode(nullptr);
     if (!lm)
         return false;
 
@@ -691,9 +702,9 @@ bool LayerDatabase::saveLayerManagerSelectedStage()
     return true;
 }
 
-bool LayerDatabase::loadLayerManagerSelectedStage()
+bool LayerDatabase::loadLayerManagerSelectedStage(MayaUsdProxyShapeBase* forProxyShape)
 {
-    MayaUsd::LayerManager* lm = findNode();
+    MayaUsd::LayerManager* lm = findNode(forProxyShape);
     if (!lm)
         return false;
 
@@ -852,6 +863,8 @@ SaveStageToMayaResult saveStageToMayaFile(
     if (!pShape)
         return result;
 
+    pShape->setLayerManager(nullptr);
+
     std::unordered_set<std::string> localLayerIds;
 
     // Save session layer and its sublayers
@@ -902,14 +915,19 @@ SaveStageToMayaResult saveStageToMayaFile(
             stage->GetRootLayer()->GetIdentifier());
     }
 
+    pShape->setLayerManager(lm);
+
     result._saveSuceeded = true;
     return result;
 }
 
 SaveStageToMayaResult saveStageToMayaFile(const MObject& proxyNode, UsdStageRefPtr stage)
 {
+    // Note: for now we only save USD change made in stage in the main
+    //       Maya scene. We don't save changes made to stages in Maya
+    //       references.
     SaveStageToMayaResult  result;
-    MayaUsd::LayerManager* lm = findOrCreateNode();
+    MayaUsd::LayerManager* lm = findOrCreateNode(nullptr);
     if (!lm)
         return result;
 
@@ -930,7 +948,10 @@ SaveStageToMayaResult saveStageToMayaFile(const MObject& proxyNode, UsdStageRefP
 
 BatchSaveResult LayerDatabase::saveUsdToMayaFile()
 {
-    MayaUsd::LayerManager* lm = findOrCreateNode();
+    // Note: for now we only save USD change made in stage in the main
+    //       Maya scene. We don't save changes made to stages in Maya
+    //       references.
+    MayaUsd::LayerManager* lm = findOrCreateNode(nullptr);
     if (!lm) {
         return MayaUsd::kNotHandled;
     }
@@ -1077,7 +1098,10 @@ void LayerDatabase::convertAnonymousLayers(
 
 void LayerDatabase::saveUsdLayerToMayaFile(SdfLayerRefPtr layer, bool asAnonymous)
 {
-    MayaUsd::LayerManager* lm = findOrCreateNode();
+    // Note: for now we only save USD change made in stage in the main
+    //       Maya scene. We don't save changes made to stages in Maya
+    //       references.
+    MayaUsd::LayerManager* lm = findOrCreateNode(nullptr);
     if (!lm)
         return;
 
@@ -1094,9 +1118,9 @@ void LayerDatabase::saveUsdLayerToMayaFile(SdfLayerRefPtr layer, bool asAnonymou
     dataBlock.setClean(lm->layers);
 }
 
-void LayerDatabase::loadLayersPostRead(const MFnReference* fromReference)
+void LayerDatabase::loadLayersPostRead(MayaUsdProxyShapeBase* forProxyShape)
 {
-    MayaUsd::LayerManager* lm = findNode(fromReference);
+    MayaUsd::LayerManager* lm = findNode(forProxyShape);
     if (!lm)
         return;
 
@@ -1127,7 +1151,7 @@ void LayerDatabase::loadLayersPostRead(const MFnReference* fromReference)
         identifierVal = idPlug.asString(MDGContext::fsNormal, &status).asChar();
         if (identifierVal.empty()) {
             MGlobal::displayError(
-                MString("Error - plug ") + idPlug.partialName(true) + "had empty identifier");
+                MString("Error - plug ") + idPlug.partialName(true) + " had empty identifier");
             continue;
         }
 
@@ -1209,10 +1233,10 @@ void LayerDatabase::loadLayersPostRead(const MFnReference* fromReference)
         }
     }
 
-    LayerDatabase::instance().loadLayerManagerSelectedStage();
+    LayerDatabase::instance().loadLayerManagerSelectedStage(forProxyShape);
 
     if (!_isSavingMayaFile)
-        removeManagerNode(lm);
+        removeManagerNode(lm, forProxyShape);
 
     for (auto it = createdLayers.begin(); it != createdLayers.end(); ++it) {
         SdfLayerHandle lh = (*it);
@@ -1332,10 +1356,12 @@ void LayerDatabase::clearManagerNode(MayaUsd::LayerManager* lm)
     dataBlock.setClean(lm->layers);
 }
 
-void LayerDatabase::removeManagerNode(MayaUsd::LayerManager* lm)
+void LayerDatabase::removeManagerNode(
+    MayaUsd::LayerManager* lm,
+    MayaUsdProxyShapeBase* forProxyShape)
 {
     if (!lm) {
-        lm = findNode();
+        lm = findNode(forProxyShape);
     }
     if (!lm) {
         return;
@@ -1485,21 +1511,21 @@ LayerManager::LayerManager()
 LayerManager::~LayerManager() { }
 
 /* static */
-SdfLayerHandle LayerManager::findLayer(std::string identifier, const MFnReference* fromReference)
+SdfLayerHandle LayerManager::findLayer(std::string identifier, MayaUsdProxyShapeBase* forProxyShape)
 {
     std::lock_guard<std::recursive_mutex> lock(findNodeMutex);
 
-    LayerDatabase::loadLayersPostRead(fromReference);
+    LayerDatabase::loadLayersPostRead(forProxyShape);
 
     return LayerDatabase::instance().findLayer(identifier);
 }
 
 /* static */
-LayerManager::LayerNameMap LayerManager::getLayerNameMap(const MFnReference* fromReference)
+LayerManager::LayerNameMap LayerManager::getLayerNameMap(MayaUsdProxyShapeBase* forProxyShape)
 {
     std::lock_guard<std::recursive_mutex> lock(findNodeMutex);
 
-    LayerDatabase::loadLayersPostRead(fromReference);
+    LayerDatabase::loadLayersPostRead(forProxyShape);
 
     return LayerDatabase::instance().getLayerNameMap();
 }
@@ -1528,9 +1554,9 @@ void LayerManager::setSelectedStage(const std::string& stage)
 }
 
 /* static */
-std::string LayerManager::getSelectedStage()
+std::string LayerManager::getSelectedStage(MayaUsdProxyShapeBase* forProxyShape)
 {
-    LayerDatabase::loadLayersPostRead();
+    LayerDatabase::loadLayersPostRead(forProxyShape);
     return LayerDatabase::instance().getSelectedStage();
 }
 

--- a/lib/mayaUsd/nodes/layerManager.h
+++ b/lib/mayaUsd/nodes/layerManager.h
@@ -17,6 +17,7 @@
 #define MAYA_USD_LAYER_MANAGER
 
 #include <mayaUsd/base/api.h>
+#include <mayaUsd/nodes/proxyShapeBase.h>
 
 #include <pxr/base/tf/notice.h>
 #include <pxr/pxr.h>
@@ -122,7 +123,7 @@ public:
     //! \brief set the stage that is currently selected in the layer manager.
     static void setSelectedStage(const std::string& stage);
     //! \brief get the stage that should be selected in the layer manager.
-    static std::string getSelectedStage();
+    static std::string getSelectedStage(PXR_NS::MayaUsdProxyShapeBase* forProxyShape);
 
     /*! \brief  Supported Proxy Shapes should call this to possibly retrieve their Root and Session
        layers before calling Sdf::FindOrOpen.  If a handle is found and returned then it will be the
@@ -130,10 +131,10 @@ public:
        used to initialize the Proxy Shape in a call to UsdStage::Open().
     */
     static SdfLayerHandle
-    findLayer(std::string identifier, const MFnReference* fromReference = nullptr);
+    findLayer(std::string identifier, PXR_NS::MayaUsdProxyShapeBase* forProxyShape);
 
     using LayerNameMap = std::map<std::string, std::string>;
-    static LayerNameMap getLayerNameMap(const MFnReference* fromReference = nullptr);
+    static LayerNameMap getLayerNameMap(PXR_NS::MayaUsdProxyShapeBase* forProxyShape);
 
     //! \brief returns true if the layer manager is currently saving files.
     static bool isSaving();

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -103,6 +103,7 @@
 #include <maya/MStatus.h>
 #include <maya/MString.h>
 #include <maya/MTime.h>
+#include <maya/MUuid.h>
 #include <maya/MViewport2Renderer.h>
 #include <ufe/path.h>
 #include <ufe/pathString.h>
@@ -169,6 +170,7 @@ MObject MayaUsdProxyShapeBase::outTimeAttr;
 MObject MayaUsdProxyShapeBase::outStageDataAttr;
 MObject MayaUsdProxyShapeBase::outStageCacheIdAttr;
 MObject MayaUsdProxyShapeBase::variantFallbacksAttr;
+MObject MayaUsdProxyShapeBase::layerManagerAttr;
 
 namespace {
 // utility function to extract the tag name from an anonymous layer.
@@ -479,6 +481,19 @@ MStatus MayaUsdProxyShapeBase::initialize()
     retValue = addAttribute(lockedLayersAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
+    layerManagerAttr = typedAttrFn.create(
+        "layerManager", "lymgr", MFnData::kString, MObject::kNullObj, &retValue);
+    typedAttrFn.setStorable(true);
+    typedAttrFn.setWritable(true);
+    typedAttrFn.setReadable(true);
+    typedAttrFn.setInternal(true);
+    typedAttrFn.setHidden(true);
+    typedAttrFn.setDisconnectBehavior(MFnNumericAttribute::kReset); // on disconnect, reset to Null
+    typedAttrFn.setAffectsAppearance(false);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+    retValue = addAttribute(layerManagerAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
     //
     // add attribute dependencies
     //
@@ -537,6 +552,9 @@ MStatus MayaUsdProxyShapeBase::initialize()
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
     retValue = attributeAffects(variantFallbacksAttr, outStageDataAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+    retValue = attributeAffects(layerManagerAttr, outStageDataAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
     return retValue;
@@ -684,37 +702,12 @@ MStatus MayaUsdProxyShapeBase::compute(const MPlug& plug, MDataBlock& dataBlock)
     return MS::kUnknownParameter;
 }
 
-/// Return either the Maya reference scene containing the node or nullptr to mean the
-/// main Maya scene.
-static std::unique_ptr<MFnReference> getProxyNodeOrigin(const MayaUsdProxyShapeBase& proxyShape)
-{
-    MObject proxyShapeNode(proxyShape.thisMObject());
-
-    MStringArray referenceFileNames;
-    MFileIO::getReferences(referenceFileNames);
-    for (unsigned int rfni = 0; rfni < referenceFileNames.length(); ++rfni) {
-        MSelectionList selectionList;
-        selectionList.add(referenceFileNames[rfni]);
-        MObject referenceObject;
-        selectionList.getDependNode(0, referenceObject);
-        MFnReference mayaRef(referenceObject);
-
-        if (mayaRef.containsNode(proxyShapeNode)) {
-            return std::make_unique<MFnReference>(referenceObject);
-        }
-    }
-
-    return {};
-}
-
 /* virtual */
 SdfLayerRefPtr MayaUsdProxyShapeBase::computeRootLayer(MDataBlock& dataBlock, const std::string&)
 {
     if (LayerManager::supportedNodeType(MPxNode::typeId())) {
-        auto                rootLayerName = dataBlock.inputValue(rootLayerNameAttr).asString();
-        auto                mayaRef = getProxyNodeOrigin(*this);
-        const MFnReference* fromReference = mayaRef ? mayaRef.get() : nullptr;
-        return LayerManager::findLayer(UsdMayaUtil::convert(rootLayerName), fromReference);
+        const MString rootLayerName = dataBlock.inputValue(rootLayerNameAttr).asString();
+        return LayerManager::findLayer(UsdMayaUtil::convert(rootLayerName), this);
     } else {
         return nullptr;
     }
@@ -725,9 +718,7 @@ SdfLayerRefPtr MayaUsdProxyShapeBase::computeSessionLayer(MDataBlock& dataBlock)
 {
     if (LayerManager::supportedNodeType(MPxNode::typeId())) {
         auto sessionLayerName = dataBlock.inputValue(sessionLayerNameAttr).asString();
-        auto mayaRef = getProxyNodeOrigin(*this);
-        const MFnReference* fromReference = mayaRef ? mayaRef.get() : nullptr;
-        return LayerManager::findLayer(UsdMayaUtil::convert(sessionLayerName), fromReference);
+        return LayerManager::findLayer(UsdMayaUtil::convert(sessionLayerName), this);
     } else {
         return nullptr;
     }
@@ -851,9 +842,7 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
     UsdStageRefPtr finalUsdStage;
     SdfPath        primPath;
 
-    auto                  mayaRef = getProxyNodeOrigin(*this);
-    const MFnReference*   fromReference = mayaRef ? mayaRef.get() : nullptr;
-    MayaUsd::LayerNameMap layerNameMap = LayerManager::getLayerNameMap(fromReference);
+    MayaUsd::LayerNameMap layerNameMap = LayerManager::getLayerNameMap(this);
 
     MDataHandle inDataHandle = dataBlock.inputValue(inStageDataAttr, &retValue);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
@@ -873,7 +862,7 @@ MStatus MayaUsdProxyShapeBase::computeInStageDataCached(MDataBlock& dataBlock)
             VtArray<std::string> updatedReferences;
             for (const auto& identifier : referencedLayers) {
                 // Update the identifier reference in the customer layer data
-                auto layer = LayerManager::findLayer(identifier, fromReference);
+                auto layer = LayerManager::findLayer(identifier, this);
                 if (layer) {
                     updatedReferences.push_back(layer->GetIdentifier());
                 }
@@ -1988,6 +1977,54 @@ void MayaUsdProxyShapeBase::getDrawPurposeToggles(
 {
     MDataBlock dataBlock = const_cast<MayaUsdProxyShapeBase*>(this)->forceCache();
     _GetDrawPurposeToggles(dataBlock, drawRenderPurpose, drawProxyPurpose, drawGuidePurpose);
+}
+
+MayaUsd::LayerManager* MayaUsdProxyShapeBase::getLayerManager()
+{
+    MStatus localStatus;
+
+    MDataBlock  dataBlock = forceCache();
+    MDataHandle layerManagerData = dataBlock.inputValue(layerManagerAttr, &localStatus);
+    CHECK_MSTATUS_AND_RETURN(localStatus, nullptr);
+
+    if (layerManagerData.asString().length() <= 0)
+        return nullptr;
+
+    MUuid layerManagerUuid(layerManagerData.asString(), &localStatus);
+    CHECK_MSTATUS_AND_RETURN(localStatus, nullptr);
+
+    MSelectionList selection;
+    localStatus = selection.add(layerManagerUuid);
+    CHECK_MSTATUS_AND_RETURN(localStatus, nullptr);
+
+    MObject layerManagerObj;
+    localStatus = selection.getDependNode(0, layerManagerObj);
+    CHECK_MSTATUS_AND_RETURN(localStatus, nullptr);
+
+    MFnDependencyNode depNode;
+    if (!depNode.setObject(layerManagerObj))
+        return nullptr;
+
+    if (LayerManager* layerManager = dynamic_cast<LayerManager*>(depNode.userNode()))
+        return layerManager;
+
+    return nullptr;
+}
+
+void MayaUsdProxyShapeBase::setLayerManager(MayaUsd::LayerManager* layerManager)
+{
+    MStatus localStatus;
+
+    MPlug layerManagerPlug
+        = MFnDependencyNode(thisMObject()).findPlug(layerManagerAttr, false, &localStatus);
+    CHECK_MSTATUS(localStatus);
+
+    if (layerManager) {
+        MFnDependencyNode layerManagerDepNode(layerManager->thisMObject());
+        layerManagerPlug.setString(layerManagerDepNode.uuid().asString());
+    } else {
+        layerManagerPlug.setString("");
+    }
 }
 
 SdfPath MayaUsdProxyShapeBase::getPrimPath() const

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -52,6 +52,10 @@ UFE_NS_DEF { class Path; }
 #include <mayaUsd/utils/mayaNodeObserver.h>
 #include <mayaUsd/utils/mayaNodeTypeObserver.h>
 
+namespace MAYAUSD_NS_DEF {
+class LayerManager;
+}
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 // clang-format off
@@ -139,6 +143,9 @@ public:
 
     MAYAUSD_CORE_PUBLIC
     static MObject variantFallbacksAttr;
+
+    MAYAUSD_CORE_PUBLIC
+    static MObject layerManagerAttr;
 
     /// Delegate function for computing the closest point and surface normal
     /// on the proxy shape to a given ray.
@@ -309,6 +316,14 @@ public:
     /// Returns the observer for all proxy shapes instance.
     MAYAUSD_CORE_PUBLIC
     static MayaUsd::MayaNodeTypeObserver& getProxyShapesObserver();
+
+    /// Retrieve the layer manager that is connected to this proxy shape,
+    /// if any.
+    MAYAUSD_CORE_PUBLIC
+    MayaUsd::LayerManager* getLayerManager();
+
+    MAYAUSD_CORE_PUBLIC
+    void setLayerManager(MayaUsd::LayerManager* lm);
 
 protected:
     MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -2584,3 +2584,10 @@ SdrShaderNodePtrVec UsdMayaUtil::GetSurfaceShaderNodeDefs()
 
     return surfaceShaderNodeDefs;
 }
+
+bool UsdMayaUtil::isNodeInReference(const MObject& node, const MString& referenceFileName)
+{
+    MSelectionList nodes;
+    MFileIO::getReferenceNodes(referenceFileName, nodes);
+    return nodes.hasItem(node);
+}

--- a/lib/mayaUsd/utils/util.h
+++ b/lib/mayaUsd/utils/util.h
@@ -698,6 +698,10 @@ SdrShaderNodePtrVec GetSurfaceShaderNodeDefs();
 MAYAUSD_CORE_PUBLIC
 bool isShape(const MDagPath& dagPath);
 
+/// Verify if the given Maya node is from the given Maya reference.
+MAYAUSD_CORE_PUBLIC
+bool isNodeInReference(const MObject& node, const MString& referenceFileName);
+
 } // namespace UsdMayaUtil
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/test/lib/testMayaUsdCreateStageInMayaRef.py
+++ b/test/lib/testMayaUsdCreateStageInMayaRef.py
@@ -20,16 +20,58 @@ import unittest
 import os.path
 
 import fixturesUtils
-from ufeUtils import ufeFeatureSetVersion
 
 from maya import cmds
 from maya import OpenMaya as om
 from maya import standalone
-import maya.mel as mel
 
 import mayaUsd.lib
 import mayaUsd.ufe
 import mayaUsd_createStageWithNewLayer
+
+from pxr import Sdf
+
+
+# Note: for some reason, when Maya processes file path for Maya references,
+#       it really does not like backward slashes on Windows. So make sure
+#       all paths use forward slashes.
+
+def createCubeUsdFile(root_path):
+    cmds.file(new=True, force=True)
+    cmds.polyCube(name="cube1")
+    usd_cube_file = os.path.join(root_path, "cube.usd").replace('\\', '/')
+    cmds.file(usd_cube_file, exportAll=True, force=True, type="USD Export")
+    return usd_cube_file
+
+def createMayaSceneWithStageWithUsdRef(root_path, usd_cube_file):
+    # Create a Maya scene with a reference to the usd scene
+    cmds.file(new=True, force=True)# Create USD stage
+    proxy_shape = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+    stage = mayaUsd.lib.GetPrim(proxy_shape).GetStage()
+
+    # Add the reference
+    usd_cube_path = "/usd_cube"
+    ref_prim = stage.DefinePrim(usd_cube_path)
+    ref_prim.GetReferences().AddReference(usd_cube_file)
+
+    maya_with_usd_ref = os.path.join(root_path, "maya_with_usd_ref.ma").replace('\\', '/')
+    # Save the scene
+    SAVE_USD_TO_MAYA_SCENE = 2
+    cmds.optionVar(iv=("mayaUsd_SerializedUsdEditsLocation", SAVE_USD_TO_MAYA_SCENE))
+    om.MFileIO.saveAs(maya_with_usd_ref, "mayaAscii")
+    return proxy_shape, usd_cube_path, maya_with_usd_ref
+
+def createMayaSceneWithMayaRef(root_path, maya_with_usd_ref, namespace):
+    # Reference the Maya scene in a new scene
+    maya_with_maya_ref = os.path.join(root_path, "maya_with_maya_ref.ma").replace('\\', '/')
+    cmds.file(new=True, force=True)
+    ref_file = cmds.file(maya_with_usd_ref, reference=True, namespace=namespace)
+
+def saveAndOpenMayaSceneWithMayaRef(root_path):
+    maya_with_maya_ref = os.path.join(root_path, "maya_with_maya_ref.ma").replace('\\', '/')
+    om.MFileIO.saveAs(maya_with_maya_ref, "mayaAscii")
+    cmds.file(new=True, force=True)
+    cmds.file(maya_with_maya_ref, open=True)
 
 
 class MayaUsdCreateStageInMayaRefTestCase(unittest.TestCase):
@@ -40,7 +82,6 @@ class MayaUsdCreateStageInMayaRefTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         fixturesUtils.setUpClass(__file__)
-        cmds.loadPlugin('mayaUsdPlugin')
 
     @classmethod
     def tearDownClass(cls):
@@ -52,52 +93,23 @@ class MayaUsdCreateStageInMayaRefTestCase(unittest.TestCase):
         '''
         testDir = os.path.join(os.path.abspath('.'),'testMayaUsdCreateStageInMayaRef')
 
-        # Note: for some reason, when Maya processes file path for Maya references,
-        #       it really does not like backward slashes on Windows. So make sure
-        #       all paths use forward slashes.
-        usd_cube_scene = os.path.join(testDir, "cube.usd").replace('\\', '/')
-        maya_with_usd_ref = os.path.join(testDir, "maya_with_usd_ref.ma").replace('\\', '/')
-        maya_with_maya_ref = os.path.join(testDir, "maya_with_maya_ref.ma").replace('\\', '/')
+        usd_cube_file = createCubeUsdFile(testDir)
+        proxy_shape, usd_cube_path, maya_with_usd_ref = createMayaSceneWithStageWithUsdRef(testDir, usd_cube_file)
+        namespace = "my_ref"
+        createMayaSceneWithMayaRef(testDir, maya_with_usd_ref, namespace)
 
-        # Create a USD scene with a cube
-        cmds.file(new=True, force=True)
-        cmds.polyCube(name="cube1")
-        USD_EXPORT_SETTING = 1
-        cmds.optionVar(iv=("mayaUsd_SerializedUsdEditsLocation", USD_EXPORT_SETTING))
-        cmds.file(usd_cube_scene, exportAll=True, force=True, type="USD Export")
-
-        # Create a Maya scene with an empty USD stage 
-        cmds.file(new=True, force=True)
-        proxy_shape = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
-        stage = mayaUsd.lib.GetPrim(proxy_shape).GetStage()
-        self.assertTrue(stage)
-
-        # Add a reference to the usd scene with the cube
-        usdCubePath = "/usd_cube"
-        ref_prim = stage.DefinePrim(usdCubePath)
-        self.assertTrue(ref_prim)
-        ref_prim.GetReferences().AddReference(usd_cube_scene)
-
-        # Save the scene
-        cmds.optionVar(iv=("mayaUsd_SerializedUsdEditsLocation", USD_EXPORT_SETTING))
-        om.MFileIO.saveAs(maya_with_usd_ref, "mayaAscii")
-
-        # Make sure we don't retain references to USD data.
-        stage = None
-        ref_prim = None
-
-        # Reference the Maya scene in a new scene
-        namespace = 'my_ref'
-        cmds.file(new=True, force=True)
-        cmds.file(maya_with_usd_ref, reference=True, namespace=namespace)
-        om.MFileIO.saveAs(maya_with_maya_ref, "mayaAscii")
-        
-        cmds.file(new=True, force=True)
-        cmds.file(maya_with_maya_ref, open=True)
+        # To debug the test, it can be useful to save the top Maya scene.
+        # saveAndOpenMayaSceneWithMayaRef(testDir)
 
         proxy_shape_in_ref = proxy_shape.replace('|', '|%s:' % namespace)
 
         stage = mayaUsd.lib.GetPrim(proxy_shape_in_ref).GetStage()
         self.assertTrue(stage)
-        ref_prim = stage.DefinePrim(usdCubePath)
+        self.assertTrue(Sdf.Layer.IsAnonymousLayerIdentifier(stage.GetRootLayer().identifier))
+        self.assertTrue(Sdf.Layer.IsAnonymousLayerIdentifier(stage.GetSessionLayer().identifier))
+        ref_prim = stage.GetPrimAtPath(usd_cube_path)
         self.assertTrue(ref_prim)
+
+
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals())


### PR DESCRIPTION
- Pass the proxy node to the layer manager so it can determine which layer manager corresponds to the proxy node.
- We keep track of the association by connecting a new proxy shape attribute to the layer manager so that we can traverse the connection to find the layer manager.
- Fix a crash in MayaSessionState when the proxy shape has been deleted before the on-idle callback is run.
- This can happen in scripts that creates scene, a stage and clear the scene in one go, before an on-idle callback is run.
- Make the test more similar to the script in the ticket.