### PR TITLE
EMSUSD-1570 add a class-prims filter to USD UFE

### DIFF
--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -148,6 +148,14 @@ if (UFE_SCENE_SEGMENT_HANDLER_ROOT_PATH)
     )
 endif()
 
+if (NOT MAYA_APP_VERSION VERSION_GREATER 2025)
+    target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+        MAYAUSD_NEED_OUTLINER_FILTER_FIX=1
+    )
+endif()
+
+
 if(CMAKE_UFE_V4_FEATURES_AVAILABLE)
     target_sources(${PROJECT_NAME}
         PRIVATE

--- a/lib/mayaUsd/ufe/MayaUsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/MayaUsdContextOps.cpp
@@ -403,8 +403,10 @@ Ufe::ContextOps::Items MayaUsdContextOps::getItems(const Ufe::ContextOps::ItemPa
 #endif
 
 #ifdef UFE_V3_FEATURES_AVAILABLE
+        const bool isClassPrim = prim().IsAbstract();
         const bool isMayaRef = (prim().GetTypeName() == TfToken("MayaReference"));
-        if (!_isAGatewayType && PrimUpdaterManager::getInstance().canEditAsMaya(path())) {
+        if (!isClassPrim && !_isAGatewayType
+            && PrimUpdaterManager::getInstance().canEditAsMaya(path())) {
             items.emplace_back(kEditAsMayaItem, kEditAsMayaLabel, kEditAsMayaImage);
 
             Ufe::ContextItem item(kEditAsMayaOptionsItem, kEditAsMayaOptionsLabel);
@@ -416,7 +418,7 @@ Ufe::ContextOps::Items MayaUsdContextOps::getItems(const Ufe::ContextOps::ItemPa
                 items.emplace_back(kDuplicateAsMayaItem, kDuplicateAsMayaLabel);
             }
         }
-        if (!isMayaRef) {
+        if (!isMayaRef && !isClassPrim) {
             items.emplace_back(kAddMayaReferenceItem, kAddMayaReferenceLabel);
         }
         items.emplace_back(Ufe::ContextItem::kSeparator);

--- a/lib/mayaUsd/ufe/MayaUsdHierarchyHandler.cpp
+++ b/lib/mayaUsd/ufe/MayaUsdHierarchyHandler.cpp
@@ -22,6 +22,9 @@
 #include <usdUfe/ufe/UsdSceneItem.h>
 #include <usdUfe/ufe/Utils.h>
 
+#include <maya/MGlobal.h>
+#include <maya/MString.h>
+
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
@@ -49,6 +52,90 @@ Ufe::Hierarchy::Ptr MayaUsdHierarchyHandler::hierarchy(const Ufe::SceneItem::Ptr
     }
     return MayaUsdHierarchy::create(usdItem);
 }
+
+#ifdef MAYAUSD_NEED_OUTLINER_FILTER_FIX
+
+static std::map<std::string, bool> fsCachedFilterValues = {
+    { "InactivePrims", true },
+    { "ClassPrims", false },
+};
+
+// This flag prevents infinite recursion.
+static std::atomic<bool> hasPendingFilterDefaultsUpdate(false);
+
+static void updateFilterDefaults()
+{
+    // This script finds a valid outiner panel that has valid UFE filters
+    // settings. Calling this script call to the outlinerEditor command
+    // triggers a call to UFE childFilter function, which would cause an
+    // infinite recursion if we did not protect against it.
+    static const char outlinerScriptTemplate[] = R"MEL(
+        proc string _getUSDFilterValue() {
+            string $outliners[] = `getPanel -type "outlinerPanel"`;
+            for ($index = 0; $index < size($outliners); $index++) {
+                string $outliner = $outliners[$index];
+                string $value = `outlinerEditor -query -ufeFilter "USD" "^1s" -ufeFilterValue $outliner`;
+                if (size($value) > 0) {
+                    return $value;
+                }
+            }
+            return "";
+        }
+        _getUSDFilterValue()
+        )MEL";
+
+    try {
+        for (auto& nameAndValue : fsCachedFilterValues) {
+            MString script;
+            script.format(outlinerScriptTemplate, nameAndValue.first.c_str());
+            const MString value = MGlobal::executeCommandStringResult(script);
+            if (value.length() > 0 && value.isInt()) {
+                nameAndValue.second = (value.asInt() != 0);
+            }
+        }
+    } catch (const std::exception&) {
+        // Ignore exceptions in callbacks.
+    }
+
+    // Allow another filter update in the future.
+    hasPendingFilterDefaultsUpdate = false;
+}
+
+static void triggerUpdateFilterDefaults()
+{
+    // Don't trigger an update if there is already one pending.
+    if (hasPendingFilterDefaultsUpdate)
+        return;
+
+    // Mark that an update will be pending.
+    hasPendingFilterDefaultsUpdate = true;
+
+    updateFilterDefaults();
+}
+
+Ufe::Hierarchy::ChildFilter MayaUsdHierarchyHandler::childFilter() const
+{
+    Ufe::Hierarchy::ChildFilter filters = UsdUfe::UsdHierarchyHandler::childFilter();
+    for (Ufe::ChildFilterFlag& filter : filters) {
+        const auto iter = fsCachedFilterValues.find(filter.name);
+        if (iter != fsCachedFilterValues.end()) {
+            filter.value = fsCachedFilterValues[filter.name];
+        }
+    }
+
+    triggerUpdateFilterDefaults();
+
+    return filters;
+}
+
+#else
+
+Ufe::Hierarchy::ChildFilter MayaUsdHierarchyHandler::childFilter() const
+{
+    return UsdUfe::UsdHierarchyHandler::childFilter();
+}
+
+#endif
 
 } // namespace ufe
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/MayaUsdHierarchyHandler.h
+++ b/lib/mayaUsd/ufe/MayaUsdHierarchyHandler.h
@@ -39,7 +39,9 @@ public:
     static MayaUsdHierarchyHandler::Ptr create();
 
     // UsdHierarchyHandler overrides
-    Ufe::Hierarchy::Ptr hierarchy(const Ufe::SceneItem::Ptr& item) const override;
+    Ufe::Hierarchy::Ptr         hierarchy(const Ufe::SceneItem::Ptr& item) const override;
+    Ufe::Hierarchy::ChildFilter childFilter() const override;
+
 }; // MayaUsdHierarchyHandler
 
 } // namespace ufe

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchy.cpp
@@ -186,18 +186,8 @@ Ufe::SceneItemList ProxyShapeHierarchy::filteredChildren(const ChildFilter& chil
     if (!rootPrim.IsValid())
         return Ufe::SceneItemList();
 
-    // Note: for now the only child filter flag we support is "Inactive Prims".
-    //       See UsdHierarchyHandler::childFilter()
-    if ((childFilter.size() == 1) && (childFilter.front().name == "InactivePrims")) {
-        // See uniqueChildName() for explanation of USD filter predicate.
-        const bool             showInactive = childFilter.front().value;
-        Usd_PrimFlagsPredicate flags
-            = showInactive ? UsdPrimIsDefined && !UsdPrimIsAbstract : kMayaUsdPrimDefaultPredicate;
-        return createUFEChildList(getUSDFilteredChildren(rootPrim, flags), !showInactive);
-    }
-
-    UFE_LOG("Unknown child filter");
-    return Ufe::SceneItemList();
+    Usd_PrimFlagsPredicate flags = UsdUfe::getUsdPredicate(childFilter);
+    return createUFEChildList(getUSDFilteredChildren(rootPrim, flags), false);
 }
 
 // Return UFE child list from input USD child list.

--- a/lib/usdUfe/ufe/UsdContextOps.cpp
+++ b/lib/usdUfe/ufe/UsdContextOps.cpp
@@ -329,6 +329,8 @@ Ufe::ContextOps::Items UsdContextOps::getItems(const Ufe::ContextOps::ItemPath& 
 
     Ufe::ContextOps::Items items;
     if (itemPath.empty()) {
+        const bool isClassPrim = prim().IsAbstract();
+
         if (!_isAGatewayType) {
             // Working set management (load and unload):
             const auto itemLabelPairs = _computeLoadAndUnloadItems(prim());
@@ -363,10 +365,12 @@ Ufe::ContextOps::Items UsdContextOps::getItems(const Ufe::ContextOps::ItemPath& 
             // Default Prim:
             //     - If the prim is the default prim, add clearing the default prim
             //     - Otherwise, if the prim is a root prim, add set default prim
-            if (prim().GetStage()->GetDefaultPrim() == prim()) {
-                items.emplace_back(kUSDClearDefaultPrim, kUSDClearDefaultPrim);
-            } else if (prim().GetPath().IsRootPrimPath()) {
-                items.emplace_back(kUSDSetAsDefaultPrim, kUSDSetAsDefaultPrim);
+            if (!isClassPrim) {
+                if (prim().GetStage()->GetDefaultPrim() == prim()) {
+                    items.emplace_back(kUSDClearDefaultPrim, kUSDClearDefaultPrim);
+                } else if (prim().GetPath().IsRootPrimPath()) {
+                    items.emplace_back(kUSDSetAsDefaultPrim, kUSDSetAsDefaultPrim);
+                }
             }
 
             // Prim active state:

--- a/lib/usdUfe/ufe/UsdHierarchy.cpp
+++ b/lib/usdUfe/ufe/UsdHierarchy.cpp
@@ -189,18 +189,8 @@ Ufe::SceneItemList UsdHierarchy::children() const
 
 Ufe::SceneItemList UsdHierarchy::filteredChildren(const ChildFilter& childFilter) const
 {
-    // Note: for now the only child filter flag we support is "Inactive Prims".
-    //       See UsdHierarchyHandler::childFilter()
-    if ((childFilter.size() == 1) && (childFilter.front().name == "InactivePrims")) {
-        // See uniqueChildName() for explanation of USD filter predicate.
-        const bool             showInactive = childFilter.front().value;
-        Usd_PrimFlagsPredicate flags
-            = showInactive ? UsdPrimIsDefined && !UsdPrimIsAbstract : kUsdUfePrimDefaultPredicate;
-        return createUFEChildList(getUSDFilteredChildren(_item, flags), !showInactive);
-    }
-
-    UFE_LOG("Unknown child filter");
-    return Ufe::SceneItemList();
+    Usd_PrimFlagsPredicate flags = UsdUfe::getUsdPredicate(childFilter);
+    return createUFEChildList(getUSDFilteredChildren(_item, flags), false);
 }
 
 bool UsdHierarchy::childrenHook(

--- a/lib/usdUfe/ufe/UsdHierarchyHandler.cpp
+++ b/lib/usdUfe/ufe/UsdHierarchyHandler.cpp
@@ -58,6 +58,7 @@ Ufe::Hierarchy::ChildFilter UsdHierarchyHandler::childFilter() const
 {
     Ufe::Hierarchy::ChildFilter childFilters;
     childFilters.emplace_back("InactivePrims", "Inactive Prims", true);
+    childFilters.emplace_back("ClassPrims", "Class Prims", false);
     return childFilters;
 }
 

--- a/lib/usdUfe/ufe/Utils.cpp
+++ b/lib/usdUfe/ufe/Utils.cpp
@@ -1523,4 +1523,36 @@ void removeSessionLeftOvers(
     stage->RemovePrim(primPath);
 }
 
+Usd_PrimFlagsPredicate getUsdPredicate(const Ufe::Hierarchy::ChildFilter& childFilter)
+{
+    // Note: for now the only child filter flags we support are "Inactive Prims"
+    //       and "Class Prims".
+    //       See UsdHierarchyHandler::childFilter()
+
+    bool showInactive = false;
+    bool showClass = false;
+
+    for (const Ufe::ChildFilterFlag& filter : childFilter) {
+        if (filter.name == "InactivePrims") {
+            showInactive = filter.value;
+        } else if (filter.name == "ClassPrims") {
+            showClass = filter.value;
+        }
+    }
+
+    // Note: unfortunately, the way the USD predicate are implemented,
+    //       we cannot use && on a Usd_PrimFlagsPredicate, only on a
+    //       Usd_Term or a Usd_PrimFlagsConjunction.
+
+    auto predicate = Usd_PrimFlagsConjunction(Usd_Term(UsdPrimIsDefined));
+
+    if (!showInactive)
+        predicate &= UsdPrimIsActive;
+
+    if (!showClass)
+        predicate &= !UsdPrimIsAbstract;
+
+    return predicate;
+}
+
 } // namespace USDUFE_NS_DEF

--- a/lib/usdUfe/ufe/Utils.h
+++ b/lib/usdUfe/ufe/Utils.h
@@ -22,10 +22,12 @@
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usd/sdr/shaderNode.h>
 #include <pxr/usd/usd/attribute.h>
+#include <pxr/usd/usd/primFlags.h>
 #include <pxr/usd/usd/stage.h>
 #include <pxr/usdImaging/usdImaging/delegate.h>
 
 #include <ufe/attribute.h>
+#include <ufe/hierarchy.h>
 #include <ufe/path.h>
 #include <ufe/scene.h>
 #include <ufe/types.h>
@@ -476,6 +478,12 @@ void removeSessionLeftOvers(
     const PXR_NS::SdfPath&        primPath,
     UsdUndoableItem*              undoableItem,
     bool                          extraEdits = true);
+
+//! Return the USD prims predicate for the given UFE child filter.
+//! Note: an empty filter or unknown filter will filter out everything.
+//!       Yes, that means no-filter actually means filter everything out.
+USDUFE_PUBLIC
+PXR_NS::Usd_PrimFlagsPredicate getUsdPredicate(const Ufe::Hierarchy::ChildFilter& childFilter);
 
 } // namespace USDUFE_NS_DEF
 

--- a/test/testSamples/classPrims/class-prims.usda
+++ b/test/testSamples/classPrims/class-prims.usda
@@ -1,0 +1,39 @@
+#usda 1.0
+(
+    metersPerUnit = 0.01
+    upAxis = "Y"
+)
+
+def Xform "top"
+{
+    def Cone "active_cone"
+    {
+        double3 xformOp:translate = (-5.624157828991091, 0, -5.283505766735125)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    def Cube "active_cube"
+    {
+        double3 xformOp:translate = (-5.905612502078963, 0, 4.50852128164777)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    def Cylinder "inactive_cylinder" (
+        active = false
+    )
+    {
+        double3 xformOp:translate = (5.058637937703114, 0, -5.308671155580967)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    class "active_class"
+    {
+    }
+
+    class "inactive_class" (
+        active = false
+    )
+    {
+    }
+}
+


### PR DESCRIPTION
- Add a getUsdPredicate helper function to UsdUfe to create the USD predicate corresponding to a list of UFE filters.
- Add the "Class Prims" filter to the list of USD filters in the hierarchy handler.
- Use the helper to create the USD predicate.
- Rely on the USD predicate having a correct predicate for inactive prim instead of using an explicit flag.
- Adjust the context menu for class prims.
- Add a unit test for the class prims filter.

Work around the problem that Maya does not correctly handle UFE filters. Maya only handles one UFE filter. If there are more than one filters, only one is handled.

To work around this issue, we manually ask the outliner what are the desired settings and use these settings as the default values for the filters. When the outliner fails to handle multiple filters, it will end-up using the default values, which will be the desired values.