### PR TITLE
EMSUSD-1777 namespace in USD default prim export argument

### DIFF
--- a/lib/mayaUsd/fileio/jobs/writeJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/writeJob.cpp
@@ -398,6 +398,12 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
         }
     }
 
+    if (!mJobCtx.mArgs.defaultPrim.empty()) {
+        mJobCtx.mArgs.defaultPrim = UsdMayaUtil::MayaNodeNameToSdfPath(
+                                        mJobCtx.mArgs.defaultPrim, mJobCtx.mArgs.stripNamespaces)
+                                        .GetString();
+    }
+
     // Check for DAG nodes that are a child of an already specified DAG node to export
     // if that's the case, report the issue and skip the export
     UsdMayaUtil::MDagPathSet::const_iterator m, n;

--- a/test/lib/usd/translators/testUsdExportDefaultPrim.py
+++ b/test/lib/usd/translators/testUsdExportDefaultPrim.py
@@ -50,6 +50,23 @@ class testUsdExportMesh(unittest.TestCase):
         self.assertTrue(defaultPrim)
         self.assertEqual(defaultPrim.GetName(), 'pSphere1')
 
+    def testExportNamespaceDefaultPrim(self):
+        '''Export to USD with a mesh inside a Maya namespace set as the default prim.'''
+        cmds.namespace(add="hello")
+        cmds.namespace(setNamespace=":hello")
+        cubeNames = cmds.polyCube()
+        self.assertEqual(len(cubeNames), 2)
+
+        usdFile = os.path.abspath('UsdExportNamespaceDefaultPrim.usda')
+
+        cmds.usdExport(mergeTransformAndShape=True, file=usdFile,
+            shadingMode='none', defaultPrim=cubeNames[0])
+        
+        stage = Usd.Stage.Open(usdFile)
+        defaultPrim = stage.GetDefaultPrim()
+        self.assertTrue(defaultPrim)
+        self.assertEqual(defaultPrim.GetName(), 'hello_pCube1')
+
     def testExportLightDefaultPrim(self):
         '''Export to USD with a light set as the default prim.'''
         usdFile = os.path.abspath('UsdExportLightDefaultPrim.usda')


### PR DESCRIPTION
Properly filter the default prim argument to convert it in the same way we convert DAG paths while exporting.

Add a unit test to cover exporting a mesh inside a namespace and set as the default prim.