### PR TITLE
EMSUSD-1745 fix export roots when no default prim is specified

### DIFF
--- a/lib/mayaUsd/fileio/jobs/writeJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/writeJob.cpp
@@ -399,9 +399,8 @@ bool UsdMaya_WriteJob::_BeginWriting(const std::string& fileName, bool append)
     }
 
     if (!mJobCtx.mArgs.defaultPrim.empty()) {
-        mJobCtx.mArgs.defaultPrim = UsdMayaUtil::MayaNodeNameToSdfPath(
-                                        mJobCtx.mArgs.defaultPrim, mJobCtx.mArgs.stripNamespaces)
-                                        .GetString();
+        mJobCtx.mArgs.defaultPrim = UsdMayaUtil::MayaNodeNameToPrimName(
+            mJobCtx.mArgs.defaultPrim, mJobCtx.mArgs.stripNamespaces);
     }
 
     // Check for DAG nodes that are a child of an already specified DAG node to export

--- a/lib/mayaUsd/utils/util.cpp
+++ b/lib/mayaUsd/utils/util.cpp
@@ -1348,6 +1348,15 @@ bool UsdMayaUtil::isShape(const MDagPath& dagPath)
     return (numberOfShapesDirectlyBelow == 1);
 }
 
+std::string
+UsdMayaUtil::MayaNodeNameToPrimName(const std::string& nodeName, const bool stripNamespaces)
+{
+    // Note: When not found, rfind returns std::string::npos.
+    //       npos == -1, so npos+1 is zero, so it always works.
+    const std::string::size_type pos = nodeName.rfind('|');
+    return MayaNodeNameToSdfPath(nodeName.substr(pos + 1), stripNamespaces).GetString();
+}
+
 SdfPath UsdMayaUtil::MayaNodeNameToSdfPath(const std::string& nodeName, const bool stripNamespaces)
 {
     std::string pathString = nodeName;

--- a/lib/mayaUsd/utils/util.h
+++ b/lib/mayaUsd/utils/util.h
@@ -409,6 +409,15 @@ MPlug FindChildPlugByName(const MPlug& plug, const MString& name);
 MAYAUSD_CORE_PUBLIC
 SdfPath MayaNodeNameToSdfPath(const std::string& nodeName, const bool stripNamespaces);
 
+/// Converts the given Maya node name or DAG path \p nodeName into a prim name.
+///
+/// This will strip any DAG path, so there is only the final part after the final '|'.
+/// Then it will be sanitized such that it is a valid USD prim name.
+/// This means it will replace Maya's namespace delimiter (':') with
+/// underscores ('_').
+MAYAUSD_CORE_PUBLIC
+std::string MayaNodeNameToPrimName(const std::string& nodeName, const bool stripNamespaces);
+
 /// Converts the given Maya MDagPath \p dagPath into an SdfPath.
 ///
 /// If \p mergeTransformAndShape and the dagPath is a shapeNode, it will return

--- a/test/lib/usd/translators/testUsdExportDefaultPrim.py
+++ b/test/lib/usd/translators/testUsdExportDefaultPrim.py
@@ -55,6 +55,7 @@ class testUsdExportMesh(unittest.TestCase):
         cmds.namespace(add="hello")
         cmds.namespace(setNamespace=":hello")
         cubeNames = cmds.polyCube()
+        cmds.namespace(setNamespace=":")
         self.assertEqual(len(cubeNames), 2)
 
         usdFile = os.path.abspath('UsdExportNamespaceDefaultPrim.usda')
@@ -66,6 +67,20 @@ class testUsdExportMesh(unittest.TestCase):
         defaultPrim = stage.GetDefaultPrim()
         self.assertTrue(defaultPrim)
         self.assertEqual(defaultPrim.GetName(), 'hello_pCube1')
+
+    def testExportRootsNoDefaultPrim(self):
+        '''Export to USD with the export roots argument and no default prim should select a root as default.'''
+        cubeNames = cmds.polyCube()
+        self.assertEqual(len(cubeNames), 2)
+
+        usdFile = os.path.abspath('UsdExportRootsNoDefaultPrim.usda')
+        cmds.usdExport(mergeTransformAndShape=True, file=usdFile,
+            shadingMode='none', exportRoots=['|' + cubeNames[0]])
+
+        stage = Usd.Stage.Open(usdFile)
+        defaultPrim = stage.GetDefaultPrim()
+        self.assertTrue(defaultPrim)
+        self.assertEqual(defaultPrim.GetName(), cubeNames[0])
 
     def testExportLightDefaultPrim(self):
         '''Export to USD with a light set as the default prim.'''


### PR DESCRIPTION
- Add a helper function to convert a DAG path to a valid prim name.
- Properly create the default prim name using that function.
- Add a unit test for the export roots without default prim case.