### PR TITLE
EMSUSD-1490 make group names more unique

### DIFF
--- a/lib/usdUfe/ufe/UsdUndoCreateGroupCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoCreateGroupCommand.cpp
@@ -17,6 +17,7 @@
 
 #include <usdUfe/ufe/UsdUndoAddNewPrimCommand.h>
 #include <usdUfe/ufe/UsdUndoSetKindCommand.h>
+#include <usdUfe/ufe/Utils.h>
 
 #include <pxr/usd/kind/registry.h>
 #include <pxr/usd/usd/modelAPI.h>
@@ -72,7 +73,9 @@ Ufe::SceneItem::Ptr UsdUndoCreateGroupCommand::insertedChild() const { return _g
 
 void UsdUndoCreateGroupCommand::execute()
 {
-    auto addPrimCmd = UsdUndoAddNewPrimCommand::create(_parentItem, _name.string(), "Xform");
+    std::string newPrimName
+        = UsdUfe::relativelyUniqueName(_parentItem->prim(), _name.string() + '1');
+    auto addPrimCmd = UsdUndoAddNewPrimCommand::create(_parentItem, newPrimName, "Xform");
     _groupCompositeCmd->append(addPrimCmd);
     addPrimCmd->execute();
 

--- a/lib/usdUfe/ufe/Utils.h
+++ b/lib/usdUfe/ufe/Utils.h
@@ -199,6 +199,12 @@ void setUniqueChildNameFn(UniqueChildNameFn fn);
 USDUFE_PUBLIC
 std::string uniqueChildName(const PXR_NS::UsdPrim& usdParent, const std::string& name);
 
+//! Return a relatively unique prim name.
+//! That is, make some effort so that the name is unique relative to other prims
+//! "around" it, like ancestors and some descendants.
+USDUFE_PUBLIC
+std::string relativelyUniqueName(const PXR_NS::UsdPrim& usdParent, const std::string& name);
+
 //! Default uniqueChildName() implementation. Uses all the prim's children.
 USDUFE_PUBLIC
 std::string uniqueChildNameDefault(const PXR_NS::UsdPrim& parent, const std::string& name);

--- a/test/lib/ufe/testGroupCmd.py
+++ b/test/lib/ufe/testGroupCmd.py
@@ -1115,6 +1115,28 @@ class GroupCmdTestCase(unittest.TestCase):
         self.assertTrue(stage.GetPrimAtPath('/A/ball'))
         self.assertFalse(stage.GetPrimAtPath('/A/group1/ball'))
         
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() >= 2023, 'Requires that the group command returns the group name.')
+    def testGroupNested(self):
+        '''Verify grouping of a leaf node repeatedly.'''
+
+        cmds.file(new=True, force=True)
+        import mayaUsd_createStageWithNewLayer
+
+        proxyShapePathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        stage = mayaUsd.lib.GetPrim(proxyShapePathStr).GetStage()
+        self.assertTrue(stage)
+
+        # create a sphere
+        stage.DefinePrim('/ball', 'Sphere')
+        groupName = cmds.group('%s,/ball' % proxyShapePathStr)
+
+        groupNames = { groupName }
+
+        for _ in range(10):
+            groupName = cmds.group('%s,/%s' % (proxyShapePathStr, groupName))
+            self.assertNotIn(groupName, groupNames)
+            groupNames.add(groupName)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/lib/ufe/testUngroupCmd.py
+++ b/test/lib/ufe/testUngroupCmd.py
@@ -310,13 +310,13 @@ class UngroupCmdTestCase(unittest.TestCase):
         self.assertEqual([x for x in self.stage.Traverse()],
             [self.stage.GetPrimAtPath("/Sphere1"),
             self.stage.GetPrimAtPath("/group1"),
-            self.stage.GetPrimAtPath("/group1/group1"),
-            self.stage.GetPrimAtPath("/group1/group1/Sphere2"),
-            self.stage.GetPrimAtPath("/group1/group1/Sphere3"),
-            self.stage.GetPrimAtPath("/group1/group1/Sphere4")])
+            self.stage.GetPrimAtPath("/group1/group2"),
+            self.stage.GetPrimAtPath("/group1/group2/Sphere2"),
+            self.stage.GetPrimAtPath("/group1/group2/Sphere3"),
+            self.stage.GetPrimAtPath("/group1/group2/Sphere4")])
 
         # remove /group1/group1 from the hierarchy with the -world flag
-        cmds.ungroup("{},/group1/group1".format(self.proxyShapePathStr), world=True)
+        cmds.ungroup("{},/group1/group2".format(self.proxyShapePathStr), world=True)
 
         # verify the paths after ungroup
         self.assertEqual([x for x in self.stage.Traverse()],


### PR DESCRIPTION
When grouping USD items, make the group name more unique vs other existing group names. This avoid having a chain of group with names almost all the same.

We don't do this for other prims, because too much code, especially unit tests related to materials, assume that the names will have specific pattern.

- Add a new utility function is UsdUfe to make a name relatively unique.
- Use that function to prepare the group name.
- Add a new unit test.
- Adjust a ungroup unit test that assumed things about the group name.