### PR TITLE
EMSUSD-1625 - Disable EditAsMaya for cylinder, disk and dome light

### DIFF
--- a/lib/usd/translators/lightReader.cpp
+++ b/lib/usd/translators/lightReader.cpp
@@ -26,6 +26,12 @@ TF_DEFINE_ENV_SETTING(
     false,
     "Whether to import UsdLux as Renderman-for-Maya lights.");
 
+// Unregister the light readers for cylinder, disk and dome lights
+// As for now those lights are not supported by import/export to Maya
+// This will also disable edit as maya
+// User can register a custom light reader for those lights if needed
+
+/*
 PXRUSDMAYA_DEFINE_READER(UsdLuxCylinderLight, args, context)
 {
     if (TfGetEnvSetting(MAYAUSD_IMPORT_RFM_LIGHTS)) {
@@ -42,20 +48,21 @@ PXRUSDMAYA_DEFINE_READER(UsdLuxDiskLight, args, context)
     return false;
 }
 
-PXRUSDMAYA_DEFINE_READER(UsdLuxDistantLight, args, context)
-{
-    if (TfGetEnvSetting(MAYAUSD_IMPORT_RFM_LIGHTS)) {
-        return UsdMayaTranslatorRfMLight::Read(args, context);
-    }
-    return UsdMayaTranslatorLight::Read(args, context);
-}
-
 PXRUSDMAYA_DEFINE_READER(UsdLuxDomeLight, args, context)
 {
     if (TfGetEnvSetting(MAYAUSD_IMPORT_RFM_LIGHTS)) {
         return UsdMayaTranslatorRfMLight::Read(args, context);
     }
     return false;
+}
+*/
+
+PXRUSDMAYA_DEFINE_READER(UsdLuxDistantLight, args, context)
+{
+    if (TfGetEnvSetting(MAYAUSD_IMPORT_RFM_LIGHTS)) {
+        return UsdMayaTranslatorRfMLight::Read(args, context);
+    }
+    return UsdMayaTranslatorLight::Read(args, context);
 }
 
 PXRUSDMAYA_DEFINE_READER(UsdLuxGeometryLight, args, context)


### PR DESCRIPTION
As discussed, disable the editAsMaya for now instead of writing light reader/writers
