### PR TITLE
Fix crashes when saving layers to USD files in specific edge cases.

### DIFF
--- a/lib/mayaUsd/utils/utilSerialization.cpp
+++ b/lib/mayaUsd/utils/utilSerialization.cpp
@@ -407,7 +407,12 @@ bool saveLayerWithFormat(
         }
     }
 
-    updateAllCachedStageWithLayer(layer, filePath);
+    // Update all known stage caches if the layer was saved to a new file path.
+    // Skip this step when the layer's file path hasn't changed to avoid unnecessary stage
+    // recompositions.
+    if (!requestedFilePath.empty()) {
+        updateAllCachedStageWithLayer(layer, filePath);
+    }
 
     return true;
 }

--- a/lib/usdUfe/utils/layers.cpp
+++ b/lib/usdUfe/utils/layers.cpp
@@ -95,7 +95,7 @@ StageDirtyState isStageDirty(const PXR_NS::UsdStage& stage)
 
     SdfLayerHandleVector allLayers = stage.GetUsedLayers(true);
     for (auto layer : allLayers) {
-        if (!layer->IsDirty())
+        if (!TF_VERIFY(layer) || !layer->IsDirty())
             continue;
 
         if (rootLayers.count(layer))


### PR DESCRIPTION
This addresses a crash encountered in production assets since maya-usd v0.30.0. The crash occurs during the save to USD operation, it is triggered by dereferencing a null `SdfLayerHandle` returned by `UsdStage::GetUsedLayers(true)` in `LayerDatabase::saveUsdToMayaFile`. Maya outputs this error:
```
maya.bin crashed. FATAL ERROR: attempted member lookup on NULL TfWeakPtr<SdfLayer>  
```

Upon investigation, the crash is linked to the presence of USD value clips using auto-generated manifest layers in the stage. The auto-generated manifest layer - returned by GetUsedLayers(true) - becomes null after a stage recomposition. This recomposition is triggered midway through the "save loop" within `MayaUsd::utils::saveLayerWithFormat`, as the stage cache is updated to reflect potential layer path changes.

Unfortunately, the issue occurs with very complex production scenes that I cannot share, and I have not been able to reproduce it with simpler scenes yet.

##### Included changes

- Avoid unnecessary stage recomposition in saveLayerWithFormat when the root layer's path did not change. This reduces related instability.
- Verify layers returned by `UsdStage::GetUsedLayers()`, even though null layers are not expected, to handle edge cases like this gracefully.
