### PR TITLE
Fix AE extra attribute section.

### DIFF
--- a/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
@@ -331,11 +331,11 @@ class AETemplate(object):
                     createdControl = controlCreator(self, attrName)
                     if createdControl:
                         self.defineCustom(createdControl, attrName)
-                        self.addedAttrs.add(attrName)
                         break
                 except Exception as ex:
                     # Do not let one custom control failure affect others.
                     print('Failed to create control %s: %s' % (attrName, ex))
+            self.addedAttrs.add(attrName)
 
     def suppress(self, attrName):
         cmds.editorTemplate(suppress=attrName)
@@ -491,7 +491,7 @@ class AETemplate(object):
         # long as the suppressed attributes are suppressed by suppress(self, control).
         # This function will keep all suppressed attributes into a list which will be use
         # by addControls(). So any suppressed attributes in extraAttrs will be ignored later.
-        extraAttrs = [attr for attr in self.attrS.attributeNames if attr not in self.addedAttrs]
+        extraAttrs = [attr for attr in self.attrS.attributeNames if attr not in self.addedAttrs and attr not in self.suppressedAttrs]
         sectionName = mel.eval("uiRes(\"s_TPStemplateStrings.rExtraAttributes\");")
         self.createSection(sectionName, extraAttrs, collapse)
 


### PR DESCRIPTION
A previous change broke which attributes are added to the extra attributes section. That is because the default function to create an attribute UI returns None and was interpreted as no UI being created.

This is a unfortunate consequence of the design: the return value is interpreted as success or failure of creating a UI and then, on success, custom callbacks are connected to that UI. But for the default fallback, those callbacks must not be added, so it returns None, which was interpreted as failure. Given that it is the final fallback, that had no consequences, but a code change made registering the attribute as being handled was no longer done properly.

Restore the old code, which was adding the attribute to the list of known, handled attributes. Also, don't add suppressed attributes in the extra attribute section.