### PR TITLE
LayerManager: Prevent unintended overwriting of unmodified USD layers at Maya save.

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -1022,7 +1022,8 @@ BatchSaveResult LayerDatabase::saveUsdToUsdFiles()
                 const auto& allLayers = info.stage->GetUsedLayers(true);
                 for (auto layer : allLayers) {
                     if (TF_VERIFY(layer)) {
-                        if (layer != sessionLayer && layer->PermissionToSave()) {
+                        if (layer != sessionLayer && layer->PermissionToSave()
+                            && layer->IsDirty()) {
                             if (!MayaUsd::utils::saveLayerWithFormat(layer)) {
                                 MString errMsg;
                                 MString layerName(layer->GetDisplayName().c_str());


### PR DESCRIPTION
The `MayaUsd::utils::saveLayerWithFormat` function uses two approaches to save USD data, depending on the layer file format:

- **Matching file format:**
If the layer file's format matches the user's preferences, the function calls `SdfLayer::Save()`. By default, Save() does not overwrite the file unless the layer has been modified.

- **Mismatched file format:**
If the file format differs from the user's preferences, the function uses `SdfLayer::Export()` to save the layer to the file. Unlike Save(), Export() always writes to the file, even if the layer hasn’t been modified in memory, potentially overwriting more recent changes on disk.

With this PR, `LayerDatabase::saveUsdToUsdFiles` now performs a "dirty" check to ensure that only modified layers are saved (exported). This change is particularly important in the context of Maya saves. Since Maya-usd v0.30, all layers used by the stage - including referenced layers - are considered during save. Large assembled stages may involve thousands of files in varying formats, this check is crucial to prevent unintended overwrites and data loss.

Additionally, this logic now better aligns with `LayerDatabase::saveUsdToMayaFile`.

A downside is that forcing a file format change during a save without modifications is no longer straightforward, but this is a minor concern compared to preventing data loss.
