### PR TITLE
EMSUSD-968 shorter nice names

### DIFF
--- a/lib/usdUfe/utils/Utils.cpp
+++ b/lib/usdUfe/utils/Utils.cpp
@@ -216,6 +216,9 @@ std::string prettifyName(const std::string& name)
         { "usd", "USD" },
         { "mtlx", "MaterialX" },
         { "lookdevx", "LookdevX" },
+        { "Ui Nodegraph Node", "Ui" },
+        { "Translate Scale Pivot", "Scale Pivot" },
+        { "Translate Rotate Pivot", "Rotate Pivot" },
     };
 
     static const auto subRegexes = []() {


### PR DESCRIPTION
- Ui Nodegraph Node -> Ui
Example: Ui Nodegraph Node Pos -> Ui Pos
Justification: the section is already titled Node Graph Node
- Translate Scale/Rotate Pivot -> Scale/Rotate Pivot
Example: Translate Scale Pivot -> Scale Pivot
Justification: pivot are always translations, no need to say it, it is implicit in being a pivot.
- Translate Scale/Rotate Pivot Translate -> Rotate/Scale Pivot Translate
Example: Translate Scale Pivot Translate -> Scale Pivot Translate
