### PR TITLE
MAYA-133671 - Add textured mode handling to topo grapher

### DIFF
--- a/lib/mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.cpp
@@ -1,6 +1,7 @@
 #include "ShaderGenUtil.h"
 
 #include "LobePruner.h"
+#include "MaterialXCore/Types.h"
 
 #include <mayaUsd/render/MaterialXGenOgsXml/CombinedMaterialXVersion.h>
 
@@ -151,9 +152,15 @@ void TopoNeutralGraph::computeGraph(const mx::ElementPtr& material, bool texture
 
             // In textured mode we traverse everything, but in untextured mode we only traverse PBR
             // level connections.
-            static const auto isPbrType
-                = [](const auto& t) { return t == "BSDF" || t == "EDF" || t == "surfaceshader"; };
-            if (!textured && !isPbrType(sourceInput->getType())) {
+            static const auto kPbrConnectionTypes
+                = std::set<std::string> { mx::BSDF_TYPE_STRING,
+                                          mx::EDF_TYPE_STRING,
+                                          mx::VDF_TYPE_STRING,
+                                          mx::SURFACE_SHADER_TYPE_STRING,
+                                          mx::DISPLACEMENT_SHADER_TYPE_STRING,
+                                          mx::VOLUME_SHADER_TYPE_STRING };
+
+            if (!textured && kPbrConnectionTypes.count(sourceInput->getType()) == 0) {
                 connectedNode = nullptr;
             }
 

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.cpp
@@ -152,13 +152,16 @@ void TopoNeutralGraph::computeGraph(const mx::ElementPtr& material, bool texture
 
             // In textured mode we traverse everything, but in untextured mode we only traverse PBR
             // level connections.
-            static const auto kPbrConnectionTypes
-                = std::set<std::string> { mx::BSDF_TYPE_STRING,
-                                          mx::EDF_TYPE_STRING,
-                                          mx::VDF_TYPE_STRING,
-                                          mx::SURFACE_SHADER_TYPE_STRING,
-                                          mx::DISPLACEMENT_SHADER_TYPE_STRING,
-                                          mx::VOLUME_SHADER_TYPE_STRING };
+            static const auto kPbrConnectionTypes = std::set<std::string>
+            {
+#if MX_COMBINED_VERSION >= 13807
+                mx::BSDF_TYPE_STRING, mx::EDF_TYPE_STRING, mx::VDF_TYPE_STRING,
+#else
+                "BSDF", "EDF", "VDF",
+#endif
+                    mx::SURFACE_SHADER_TYPE_STRING, mx::DISPLACEMENT_SHADER_TYPE_STRING,
+                    mx::VOLUME_SHADER_TYPE_STRING
+            };
 
             if (!textured && kPbrConnectionTypes.count(sourceInput->getType()) == 0) {
                 connectedNode = nullptr;

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.h
@@ -20,9 +20,34 @@ namespace ShaderGenUtil {
 class MAYAUSD_CORE_PUBLIC TopoNeutralGraph
 {
 public:
+    /*! Creates a barebones TopoNeutralGraph that will process the provided material and generate a
+     * topo neutral version of it.
+     * @param[in] material the material to process
+     */
     explicit TopoNeutralGraph(const mx::ElementPtr& material);
-    TopoNeutralGraph(const mx::ElementPtr& material, const LobePruner::Ptr& library);
-    TopoNeutralGraph(const mx::ElementPtr& material, const LobePruner::Ptr& library, bool textured);
+
+    /*! Creates a TopoNeutralGraph that will process the provided material and generate a topo
+     * neutral version of it. It will also substitute lobe pruned categories if a LobePruner is
+     * provided.
+     * @param[in] material the material to process
+     * @param[in] lobePruner an instance of a LobePruner. These are usually singletons that
+     * accumulate pruned NodeDefs
+     */
+    TopoNeutralGraph(const mx::ElementPtr& material, const LobePruner::Ptr& lobePruner);
+
+    /*! Creates a TopoNeutralGraph that will process the provided material and generate a topo
+     * neutral version of it. It will also substitute lobe pruned categories if a LobePruner is
+     * provided.
+     * @param[in] material the material to process
+     * @param[in] lobePruner an instance of a LobePruner. These are usually singletons that
+     * accumulate pruned NodeDefs
+     * @param[in] textured is true if the full material is to be processed. When false, we will
+     * generate an untextured topo neutral material instead
+     */
+    TopoNeutralGraph(
+        const mx::ElementPtr&  material,
+        const LobePruner::Ptr& lobePruner,
+        bool                   textured);
     ~TopoNeutralGraph() = default;
 
     TopoNeutralGraph() = delete;

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/ShaderGenUtil.h
@@ -21,7 +21,8 @@ class MAYAUSD_CORE_PUBLIC TopoNeutralGraph
 {
 public:
     explicit TopoNeutralGraph(const mx::ElementPtr& material);
-    explicit TopoNeutralGraph(const mx::ElementPtr& material, const LobePruner::Ptr& library);
+    TopoNeutralGraph(const mx::ElementPtr& material, const LobePruner::Ptr& library);
+    TopoNeutralGraph(const mx::ElementPtr& material, const LobePruner::Ptr& library, bool textured);
     ~TopoNeutralGraph() = default;
 
     TopoNeutralGraph() = delete;
@@ -57,7 +58,7 @@ public:
     mx::NodeGraphPtr& getNodeGraph();
 
 protected:
-    void          computeGraph(const mx::ElementPtr& material);
+    void          computeGraph(const mx::ElementPtr& material, bool textured);
     mx::NodePtr   cloneNode(const mx::Node& node, mx::GraphElement& container);
     mx::OutputPtr findNodeGraphOutput(const mx::Input& input, const std::string& outputName);
     std::string   gatherChannels(const mx::Input& input);

--- a/lib/mayaUsdAPI/render.cpp
+++ b/lib/mayaUsdAPI/render.cpp
@@ -169,6 +169,14 @@ struct TopoNeutralGraphImpl
     {
     }
 
+    TopoNeutralGraphImpl(
+        const MaterialX::ElementPtr& material,
+        const LobePruner::Ptr&       lobePruner,
+        bool                         textured)
+        : _topoGraph(material, lobePruner->_imp->_lobePruner, textured)
+    {
+    }
+
     MaterialXMaya::ShaderGenUtil::TopoNeutralGraph _topoGraph;
 };
 
@@ -181,6 +189,14 @@ TopoNeutralGraph::TopoNeutralGraph(
     const MaterialX::ElementPtr& material,
     const LobePruner::Ptr&       lobePruner)
     : _imp(new TopoNeutralGraphImpl(material, lobePruner))
+{
+}
+
+TopoNeutralGraph::TopoNeutralGraph(
+    const MaterialX::ElementPtr& material,
+    const LobePruner::Ptr&       lobePruner,
+    bool                         textured)
+    : _imp(new TopoNeutralGraphImpl(material, lobePruner, textured))
 {
 }
 

--- a/lib/mayaUsdAPI/render.h
+++ b/lib/mayaUsdAPI/render.h
@@ -145,11 +145,33 @@ private:
 class MAYAUSD_API_PUBLIC TopoNeutralGraph
 {
 public:
-    TopoNeutralGraph(const MaterialX::ElementPtr&);
-    TopoNeutralGraph(const MaterialX::ElementPtr&, const LobePruner::Ptr& lobePruner);
+    /*! Creates a barebones TopoNeutralGraph that will process the provided material and generate a
+     * topo neutral version of it.
+     * @param[in] material the material to process
+     */
+    TopoNeutralGraph(const MaterialX::ElementPtr& material);
+
+    /*! Creates a TopoNeutralGraph that will process the provided material and generate a topo
+     * neutral version of it. It will also substitute lobe pruned categories if a LobePruner is
+     * provided.
+     * @param[in] material the material to process
+     * @param[in] lobePruner an instance of a LobePruner. These are usually singletons that
+     * accumulate pruned NodeDefs
+     */
+    TopoNeutralGraph(const MaterialX::ElementPtr& material, const LobePruner::Ptr& lobePruner);
+
+    /*! Creates a TopoNeutralGraph that will process the provided material and generate a topo
+     * neutral version of it. It will also substitute lobe pruned categories if a LobePruner is
+     * provided.
+     * @param[in] material the material to process
+     * @param[in] lobePruner an instance of a LobePruner. These are usually singletons that
+     * accumulate pruned NodeDefs
+     * @param[in] textured is true if the full material is to be processed. When false, we will
+     * generate an untextured topo neutral material instead
+     */
     TopoNeutralGraph(
         const MaterialX::ElementPtr& material,
-        const LobePruner::Ptr&       library,
+        const LobePruner::Ptr&       lobePruner,
         bool                         textured);
     ~TopoNeutralGraph();
 

--- a/lib/mayaUsdAPI/render.h
+++ b/lib/mayaUsdAPI/render.h
@@ -147,6 +147,10 @@ class MAYAUSD_API_PUBLIC TopoNeutralGraph
 public:
     TopoNeutralGraph(const MaterialX::ElementPtr&);
     TopoNeutralGraph(const MaterialX::ElementPtr&, const LobePruner::Ptr& lobePruner);
+    TopoNeutralGraph(
+        const MaterialX::ElementPtr& material,
+        const LobePruner::Ptr&       library,
+        bool                         textured);
     ~TopoNeutralGraph();
 
     MaterialX::NodeGraphPtr nodeGraph();


### PR DESCRIPTION
Allows quickly reducing a graph to only a surface for when the viewport is in "untextured" mode.