### PR TITLE
Update change processing code

### DIFF
--- a/lib/usdUfe/ufe/StagesSubject.cpp
+++ b/lib/usdUfe/ufe/StagesSubject.cpp
@@ -533,6 +533,9 @@ void StagesSubject::stageChanged(
                 // removed, we need to trigger a subtree invalidation.  This is
                 // necessary in order to prevent stale items from being kept in
                 // the global selection set.
+                // Note: at the point of this notif the prim is not valid anymore
+                // and thus we cannot create a scene item to simply remove
+                // the item from selection list.
                 if (!InAddOrDeleteOperation::inAddOrDeleteOperation()) {
                     auto       parentPath = changedPath.GetParentPath();
                     const auto parentUfePath = parentPath == SdfPath::AbsoluteRootPath()

--- a/lib/usdUfe/ufe/StagesSubject.cpp
+++ b/lib/usdUfe/ufe/StagesSubject.cpp
@@ -13,9 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+#include "StagesSubject.h"
+
 #include <usdUfe/base/tokens.h>
 #include <usdUfe/ufe/Global.h>
-#include <usdUfe/ufe/StagesSubject.h>
 #include <usdUfe/ufe/UfeNotifGuard.h>
 #include <usdUfe/ufe/UfeVersionCompat.h>
 #include <usdUfe/ufe/UsdCamera.h>


### PR DESCRIPTION
This handles the case where we receive a prim deleted message outside of a maya command, which results in the removal of a selected prim. In this case, we trigger a subtree invalidated notice so that the global selection list will be updated.