### PR TITLE
Fix UsdMayaPrimWriter and UsdMayaPrimReader Python Wrappings

### DIFF
--- a/lib/mayaUsd/python/wrapPrimReader.cpp
+++ b/lib/mayaUsd/python/wrapPrimReader.cpp
@@ -38,7 +38,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 template <typename T = UsdMayaPrimReader>
 class PrimReaderWrapper
     : public T
-    , public TfPyPolymorphic<UsdMayaPrimReader>
+    , public TfPyPolymorphic<T>
 {
 public:
     typedef PrimReaderWrapper This;
@@ -580,7 +580,7 @@ void wrapShaderReader()
 
     typedef UsdMayaShaderReader This;
 
-    class_<ShaderReaderWrapper, bases<PrimReaderWrapper<>>, PXR_BOOST_PYTHON_NAMESPACE::noncopyable>
+    class_<ShaderReaderWrapper, bases<UsdMayaPrimReader>, PXR_BOOST_PYTHON_NAMESPACE::noncopyable>
         c("ShaderReader", no_init);
 
     scope s(c);

--- a/lib/mayaUsd/python/wrapPrimWriter.cpp
+++ b/lib/mayaUsd/python/wrapPrimWriter.cpp
@@ -38,7 +38,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 template <typename T = UsdMayaPrimWriter>
 class PrimWriterWrapper
     : public T
-    , public TfPyPolymorphic<UsdMayaPrimWriter>
+    , public TfPyPolymorphic<T>
 {
 public:
     typedef PrimWriterWrapper This;
@@ -99,7 +99,7 @@ public:
     const SdfPathVector& default_GetModelPaths() const { return base_t::GetModelPaths(); }
     const SdfPathVector& GetModelPaths() const override
     {
-        if (Override o = GetOverride("GetModelPaths")) {
+        if (TfPyOverride o = this->GetOverride("GetModelPaths")) {
             auto res = std::function<PXR_BOOST_PYTHON_NAMESPACE::object()>(
                 TfPyCall<PXR_BOOST_PYTHON_NAMESPACE::object>(o))();
             if (res) {
@@ -131,7 +131,7 @@ public:
     }
     const UsdMayaUtil::MDagPathMap<SdfPath>& GetDagToUsdPathMapping() const override
     {
-        if (Override o = GetOverride("GetDagToUsdPathMapping")) {
+        if (TfPyOverride o = this->GetOverride("GetDagToUsdPathMapping")) {
             auto res = std::function<PXR_BOOST_PYTHON_NAMESPACE::object()>(
                 TfPyCall<PXR_BOOST_PYTHON_NAMESPACE::object>(o))();
             if (res) {
@@ -735,7 +735,7 @@ void wrapShaderWriter()
 {
     PXR_BOOST_PYTHON_NAMESPACE::class_<
         ShaderWriterWrapper,
-        PXR_BOOST_PYTHON_NAMESPACE::bases<PrimWriterWrapper<>>,
+        PXR_BOOST_PYTHON_NAMESPACE::bases<UsdMayaPrimWriter>,
         PXR_BOOST_PYTHON_NAMESPACE::noncopyable>
         c("ShaderWriter", PXR_BOOST_PYTHON_NAMESPACE::no_init);
 


### PR DESCRIPTION
The PrimReaderWrapper<T> and PrimWriterWrapper<T> helper classes ignored the template parameter when deriving from TfPyPolymorphic. This caused unexpected duplicate entries in boost::python's type conversion table. boost::python silently accepted this, but the new pxr_boost::python in OpenUSD 24.11 flagged this with an assert in debug mode.

The wrappings for ShaderReaderWrapper and ShaderWriterWrapper incorrectly specified PrimReaderWrapper<> and PrimWriterWrapper<> as their bases. For example, this meant that passing an instance of a ShaderReader to a a Python-wrapped C++ function that takes a UsdMayaPrimReader would fail. This doesn't show up in practice since clients aren't expected to create their own instances of these types but it seemed good to fix anyway.