### PR TITLE
EMSUSD-1949 better support for grouping prims with references

### DIFF
--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -131,6 +131,13 @@ if (USD_INCLUDE_DIR AND EXISTS "${USD_INCLUDE_DIR}/pxr/imaging/hd/changeTracker.
     endif()
 endif()
 
+# See if USD changetracker has instance count.
+set(USD_HAS_NAMESPACE_EDIT FALSE CACHE INTERNAL "USD.NamespaceEdit")
+if (USD_INCLUDE_DIR AND EXISTS "${USD_INCLUDE_DIR}/pxr/usd/sdf/namespaceEdit.h")
+    set(USD_HAS_NAMESPACE_EDIT TRUE CACHE INTERNAL "USD.NamespaceEdit")
+    message(STATUS "USD has namespace edit")
+endif()
+
 # See if MaterialX shaders with color4 inputs exist natively in Sdr:
 # Not yet in a tagged USD version: https://github.com/PixarAnimationStudios/USD/pull/1894
 set(USD_HAS_COLOR4_SDR_SUPPORT FALSE CACHE INTERNAL "USD.Sdr.PropertyTypes.Color4")

--- a/lib/usdUfe/CMakeLists.txt
+++ b/lib/usdUfe/CMakeLists.txt
@@ -56,6 +56,14 @@ if (USD_HAS_COLOR4_SDR_SUPPORT)
     )
 endif()
 
+message(STATUS "USD_HAS_NAMESPACE_EDIT is ${USD_HAS_NAMESPACE_EDIT}")
+if (USD_HAS_NAMESPACE_EDIT)
+    target_compile_definitions(${PROJECT_NAME}
+        PRIVATE
+        USD_HAS_NAMESPACE_EDIT=1
+    )
+endif()
+
 message(STATUS "MAYA_HAS_DISPLAY_LAYER_API is ${MAYA_HAS_DISPLAY_LAYER_API}")
 if (MAYA_HAS_DISPLAY_LAYER_API)
     target_compile_definitions(${PROJECT_NAME}


### PR DESCRIPTION
If a prims has a reference the normal reparent algorithm would flatten the reference. In the frequent case where the prim only has opinion on a single layer and grouping in the same layer, we can instead rename the prim. This requires support for namespace edits in USD.

- Detect this common case and use namespace edits when available.
- Add a unit test to validate this.