### PR TITLE
EMSUSD-1519 refactor collection UI

### DIFF
--- a/lib/mayaUsd/resources/ae/CMakeLists.txt
+++ b/lib/mayaUsd/resources/ae/CMakeLists.txt
@@ -63,12 +63,26 @@ if(MAYA_APP_VERSION VERSION_GREATER_EQUAL 2023)
         ${MAYAUSD_SHARED_COMPONENTS}/common/filteredStringListModel.py
         ${MAYAUSD_SHARED_COMPONENTS}/common/filteredStringListView.py
         ${MAYAUSD_SHARED_COMPONENTS}/common/host.py
-        ${MAYAUSD_SHARED_COMPONENTS}/common/list.py
+        ${MAYAUSD_SHARED_COMPONENTS}/common/stringListPanel.py
         ${MAYAUSD_SHARED_COMPONENTS}/common/persistentStorage.py
         ${MAYAUSD_SHARED_COMPONENTS}/common/resizable.py
         ${MAYAUSD_SHARED_COMPONENTS}/common/theme.py
         ${MAYAUSD_SHARED_COMPONENTS}/common/menuButton.py
         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python/usd_shared_components/common/
+    )
+
+    install(FILES
+        ${MAYAUSD_SHARED_COMPONENTS}/data/__init__.py
+        ${MAYAUSD_SHARED_COMPONENTS}/data/collectionData.py
+        ${MAYAUSD_SHARED_COMPONENTS}/data/stringListData.py
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python/usd_shared_components/data/
+    )
+
+    install(FILES
+        ${MAYAUSD_SHARED_COMPONENTS}/usdData/__init__.py
+        ${MAYAUSD_SHARED_COMPONENTS}/usdData/usdCollectionData.py
+        ${MAYAUSD_SHARED_COMPONENTS}/usdData/usdCollectionStringListData.py
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python/usd_shared_components/usdData/
     )
 
     set(LIB_ICONS

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/includeExcludeWidget.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/includeExcludeWidget.py
@@ -117,11 +117,17 @@ class IncludeExcludeWidget(QWidget):
             self._include.cbIncludeAll.setChecked(incAll)
 
     def onAddToIncludePrimClicked(self):
-        items = self._collData.pick("Add Include Objects")
+        stage = self._collData.getStage()
+        if not stage:
+            return
+        items = Host.instance().pick(stage, "Add Include Objects")
         self._collData.getIncludeData().addStrings(items)
 
     def onAddToExcludePrimClicked(self):
-        items = self._collData.pick("Add Exclude Objects")
+        stage = self._collData.getStage()
+        if not stage:
+            return
+        items = Host.instance().pick(stage, "Add Exclude Objects")
         self._collData.getExcludeData().addStrings(items)
 
     def onRemoveSelectionFromInclude(self):

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/widget.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/widget.py
@@ -1,6 +1,7 @@
 from .includeExcludeWidget import IncludeExcludeWidget
 from .expressionWidget import ExpressionWidget
 from ..common.theme import Theme
+from ..usdData.usdCollectionData import UsdCollectionData
 
 try:
     from PySide6.QtCore import QEvent, QObject, Qt, Slot  # type: ignore
@@ -37,19 +38,12 @@ class CollectionWidget(QWidget):
 
         self._collection: Usd.CollectionAPI = collection
         self._prim: Usd.Prim = prim
+        self._collData = UsdCollectionData(prim, collection)
 
         mainLayout = QVBoxLayout()
         mainLayout.setContentsMargins(0, 0, 0, 0)
 
-        self._includeExcludeWidget = IncludeExcludeWidget(prim, collection, self)
-
-        # this is used to avoid infinite loop when updating the UI
-        self._updatingUI: bool = False
-
-        # register to the object changed notification
-        self._noticeKey = Tf.Notice.Register(
-            Usd.Notice.ObjectsChanged, self.onObjectsChanged, self._prim.GetStage()
-        )
+        self._includeExcludeWidget = IncludeExcludeWidget(self._collData, self)
 
         self._tabWidget = None
 
@@ -60,12 +54,8 @@ class CollectionWidget(QWidget):
             self._tabWidget.currentChanged.connect(self.onTabChanged)
             self._tabWidget.setDocumentMode(True)
 
-            self._expressionWidget = ExpressionWidget(
-                collection, self._tabWidget, self.onExpressionChanged
-            )
-            self._tabWidget.addTab(
-                self._includeExcludeWidget, QIcon(), "Include/Exclude"
-            )
+            self._expressionWidget = ExpressionWidget(self._collData, self._tabWidget, self.onExpressionChanged)
+            self._tabWidget.addTab(self._includeExcludeWidget, QIcon(), "Include/Exclude")
             self._tabWidget.addTab(self._expressionWidget, QIcon(), "Expression")
 
             offset: int = Theme.instance().uiScaled(4)
@@ -80,21 +70,6 @@ class CollectionWidget(QWidget):
 
         self.setLayout(mainLayout)
 
-    def updateUI(self):
-        self._updatingUI = True
-        self._includeExcludeWidget.updateUI()
-        self._updatingUI = False
-
-    def onObjectsChanged(self, notice, sender):
-        # TODO: check if the collection was actually touched by this change!
-        if not self._updatingUI:
-            self.updateUI()
-
-    @Slot()
-    def cleanup(self):
-        # unregister from the object changed notification
-        self._noticeKey.Revoke()
-
     if Usd.GetVersion() >= (0, 23, 11):
 
         def onTabChanged(self, index):
@@ -103,12 +78,12 @@ class CollectionWidget(QWidget):
 
         def onExpressionChanged(self):
             updateIncludeAll = (
-                len(self._includeExcludeWidget.getIncludedItems()) == 0
-                and len(self._includeExcludeWidget.getIncludedItems()) == 0
-                and self._includeExcludeWidget.getIncludeAll()
+                len(self._collData._includes.getStrings()) == 0
+                and len(self._collData._includes.getStrings()) == 0
+                and self._collData.includesAll()
             )
             if updateIncludeAll:
-                self._includeExcludeWidget.setIncludeAll(False)
+                self._collData.setIncludeAll(False)
                 print(
                     '"Include All" has been disabled for the expression to take effect.'
                 )

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/filteredStringListView.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/filteredStringListView.py
@@ -36,10 +36,10 @@ except:
     from PySide2.QtWidgets import QListView, QStyledItemDelegate, QStyleOptionViewItem  # type: ignore
 
 
-kNoObjectFoundLabel = "No objects found"
-kDragObjectsHereLabel = "Drag objects here"
-kPickObjectsLabel = "Click '+' to add"
-kDragOrPickObjectsLabel = "Drag objects here or click '+' to add"
+NO_OBJECTS_FOUND_LABEL = "No objects found"
+DRAG_OBJECTS_HERE_LABEL = "Drag objects here"
+PICK_OBJECTS_LABEL = "Click '+' to add"
+DRAG_OR_PICK_OBJECTS_LABEL = "Drag objects here or click '+' to add"
 
 
 class FilteredStringListView(QListView):
@@ -99,14 +99,14 @@ class FilteredStringListView(QListView):
             return
 
         if model.isFilteredEmpty():
-            self._paintPlaceHolder(kNoObjectFoundLabel)
+            self._paintPlaceHolder(NO_OBJECTS_FOUND_LABEL)
         elif model.rowCount() == 0:
             if Host.instance().canDrop and Host.instance().canPick:
-                self._paintPlaceHolder(kDragOrPickObjectsLabel)
+                self._paintPlaceHolder(DRAG_OR_PICK_OBJECTS_LABEL)
             elif Host.instance().canDrop:
-                self._paintPlaceHolder(kDragObjectsHereLabel)
+                self._paintPlaceHolder(DRAG_OBJECTS_HERE_LABEL)
             elif Host.instance().canPick:
-                self._paintPlaceHolder(kPickObjectsLabel)
+                self._paintPlaceHolder(PICK_OBJECTS_LABEL)
 
     def selectedItems(self) -> Sequence[str]:
         return [str(index.data(Qt.DisplayRole)) for index in self.selectedIndexes()]
@@ -118,9 +118,6 @@ class FilteredStringListView(QListView):
         painter = QPainter(self.viewport())
         theme = Theme.instance()
         painter.setPen(theme.palette.colorPlaceHolderText)
-        font: QFont = painter.font()
-        font.setPixelSize(theme.uiScaled(18))
-        painter.setFont(font)
         painter.drawText(self.rect(), Qt.AlignCenter, placeHolderText)
 
 class DragAndDropEventFilter(QObject):

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/theme.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/theme.py
@@ -49,6 +49,7 @@ class Theme(object):
         def __init__(self):
             super(Theme.Palette, self)
             self.colorResizeBorderActive: QColor = QColor(0x5285a6)
+            self.colorPlaceHolderText = QColor(128, 128, 128)
 
             pal = QPallette = QPalette()
             self.colorPlaceHolderText = pal.color(QPalette.ColorRole.WindowText)

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/data/__init__.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/data/__init__.py
@@ -1,0 +1,1 @@
+# Shared common data components for USD plugins for 3dsMax and Maya

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/data/collectionData.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/data/collectionData.py
@@ -13,19 +13,13 @@ class CollectionData(QObject):
     def __init__(self):
         super().__init__()
 
-    # Item picking
-
-    def canPick(self) -> bool:
-        '''
-        Return if there is a UI to pick items.
-        '''
-        return False
+    # USD Stage information
     
-    def pick(self) -> Sequence[AnyStr]:
+    def getStage(self):
         '''
-        Pick items and return the sequnce of picked items.
+        Returns the USD stage in which the collection lives.
         '''
-        return []
+        return None
 
     # Include and exclude
 

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/data/collectionData.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/data/collectionData.py
@@ -1,0 +1,80 @@
+from typing import AnyStr, Sequence
+
+from .stringListData import StringListData
+
+try:
+    from PySide6.QtCore import QObject, Signal  # type: ignore
+except ImportError:
+    from PySide2.QtCore import QObject, Signal  # type: ignore
+
+class CollectionData(QObject):
+    dataChanged = Signal()
+
+    def __init__(self):
+        super().__init__()
+
+    # Item picking
+
+    def canPick(self) -> bool:
+        '''
+        Return if there is a UI to pick items.
+        '''
+        return False
+    
+    def pick(self) -> Sequence[AnyStr]:
+        '''
+        Pick items and return the sequnce of picked items.
+        '''
+        return []
+
+    # Include and exclude
+
+    def includesAll(self) -> bool:
+        '''
+        Verify if the collection includes all by default.
+        '''
+        return False
+    
+    def setIncludeAll(self, state: bool):
+        '''
+        Sets if the collection should include all items by default.
+        '''
+        pass
+    
+    def getIncludeData(self) -> StringListData:
+        '''
+        Returns the included items string list.
+        '''
+        return None
+
+    def getExcludeData(self) -> StringListData:
+        '''
+        Returns the excluded items string list.
+        '''
+        return None
+
+    # Expression
+
+    def getExpansionRule(self):
+        '''
+        Returns expansion rule as a USD token.
+        '''
+        return None
+    
+    def setExpansionRule(self, rule):
+        '''
+        Sets the expansion rule as a USD token.
+        '''
+        pass
+
+    def getMembershipExpression(self) -> AnyStr:
+        '''
+        Returns the membership expression as text.
+        '''
+        return None
+    
+    def setMembershipExpression(self, textExpression: AnyStr):
+        '''
+        Set the textual membership expression.
+        '''
+        pass

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/data/stringListData.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/data/stringListData.py
@@ -1,0 +1,53 @@
+from typing import AnyStr, Sequence
+
+try:
+    from PySide6.QtCore import QObject, Signal  # type: ignore
+except ImportError:
+    from PySide2.QtCore import QObject, Signal  # type: ignore
+
+class StringListData(QObject):
+
+    dataChanged = Signal()
+
+    def __init__(self):
+        super().__init__()
+
+    # Functions to be implemented by sub-class
+
+    def getStrings(self) -> Sequence[AnyStr]:
+        '''
+        Retrieve the full list of all text strings.
+        '''
+        return []
+
+    def addStrings(self, items: Sequence[AnyStr]):
+        '''
+        Add the given strings to the model.
+        '''
+        pass
+
+    def removeStrings(self, items: Sequence[AnyStr]):
+        '''
+        Remove the given strings from the model.
+        '''
+        pass
+
+    def _isValidString(self, s) -> AnyStr:
+        '''
+        Validates if the string is valid and possibly alter it to make it valid
+        or conform to the expected format or value. Return None if invalid.
+        '''
+        return None
+
+    # Function provided to help using this class, call
+    # other functions above.
+
+    def addMultiLineStrings(self, multiLineText):
+        items = []
+        for text in multiLineText.split("\n"):
+            text = self._isValidString(text)
+            if text is None:
+                continue
+            items.append(text)
+
+        self.addStrings(items)

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/__init__.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/__init__.py
@@ -1,0 +1,1 @@
+# Shared common USD data components for USD plugins for 3dsMax and Maya

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/usdCollectionData.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/usdCollectionData.py
@@ -1,0 +1,153 @@
+from typing import AnyStr, Sequence
+from ..data.collectionData import CollectionData
+from .usdCollectionStringListData import CollectionStringListData
+from ..common.host import Host
+
+from pxr import Sdf, Tf, Usd
+
+class UsdCollectionData(CollectionData):
+    def __init__(self, prim: Usd.Prim, collection: Usd.CollectionAPI):
+        super().__init__()
+        self._includes = CollectionStringListData(collection, True)
+        self._excludes = CollectionStringListData(collection, False)
+        self._noticeKey = None
+        self.setCollection(prim, collection)
+
+    def __del__(self):
+        # Note: base class does not have a __del__ so we don't call super() for it.
+        self._untrackCollectionNotifications()
+
+    def setCollection(self, prim: Usd.Prim, collection: Usd.CollectionAPI):
+        '''
+        Update which collecton on which prim is held by this data class.
+        '''
+        self._prim = prim
+        self._collection = collection
+
+        self._includes.setCollection(collection)
+        self._excludes.setCollection(collection)
+
+        self._untrackCollectionNotifications()
+        self._trackCollectionNotifications()
+        self._onObjectsChanged(None, None)
+
+    def _trackCollectionNotifications(self):
+        '''
+        Register with the USD object changed notification, which gets
+        converted to the class's dataChanged signal (and to each
+        CollectionStringListData dataChanged signal)
+        '''
+        self._noticeKey = Tf.Notice.Register(
+            Usd.Notice.ObjectsChanged, self._onObjectsChanged, self._prim.GetStage())
+
+    def _untrackCollectionNotifications(self):
+        '''
+        Stop receiving USD notifications for the prim and collection.
+        '''
+        if self._noticeKey is None:
+            return
+        self._noticeKey.Revoke()
+        self._noticeKey = None
+
+    def _onObjectsChanged(self, notice, sender):
+        # TODO: check if the collection was actually touched by this change!
+        self.dataChanged.emit()
+        self._includes.dataChanged.emit()
+        self._excludes.dataChanged.emit()
+
+    # Item picking
+
+    def canPick(self) -> bool:
+        '''
+        Return if there is a UI to pick items.
+        '''
+        return False
+    
+    def pick(self, dialogTitle) -> Sequence[AnyStr]:
+        '''
+        Pick items and return the sequnce of picked items.
+        '''
+        # TODO: move host functionality in sub-class of this class, overriding pick.
+        prims: Sequence[Usd.Prim] = Host.instance().pick(self._prim.GetStage(), dialogTitle=dialogTitle)
+        if prims is None:
+            return
+        items = []
+        for prim in prims:
+            items.append(prim.GetPath())
+        return items
+
+    # Include and exclude
+
+    def includesAll(self) -> bool:
+        '''
+        Verify if the collection includes all by default.
+        '''
+        includeRootAttribute = self._collection.GetIncludeRootAttr()
+        return includeRootAttribute.Get()
+
+    def setIncludeAll(self, state: bool):
+        '''
+        Sets if the collection should include all items by default.
+        '''
+        if self.includesAll() == state:
+            return
+        includeRootAttribute = self._collection.GetIncludeRootAttr()
+        includeRootAttribute.Set(state)
+    
+    def getIncludeData(self) -> CollectionStringListData:
+        '''
+        Returns the included items string list.
+        '''
+        return self._includes
+
+    def getExcludeData(self) -> CollectionStringListData:
+        '''
+        Returns the excluded items string list.
+        '''
+        return self._excludes
+
+    # Expression
+
+    def getExpansionRule(self):
+        '''
+        Returns expansion rule as a USD token.
+        '''
+        return self._collection.GetExpansionRuleAttr().Get()
+
+    def setExpansionRule(self, rule):
+        '''
+        Sets the expansion rule as a USD token.
+        '''
+        if rule == self.getExpansionRule():
+            return
+        self._collection.CreateExpansionRuleAttr(rule)
+
+    def getMembershipExpression(self) -> AnyStr:
+        '''
+        Returns the membership expression as text.
+        '''
+        usdExpressionAttr = self._collection.GetMembershipExpressionAttr().Get()
+        if usdExpressionAttr is None:
+            return None
+        return usdExpressionAttr.GetText()
+    
+    def setMembershipExpression(self, textExpression: AnyStr):
+        '''
+        Set the textual membership expression.
+        '''
+        usdExpression = ""
+        usdExpressionAttr = self._collection.GetMembershipExpressionAttr().Get()
+        if usdExpressionAttr != None:
+            usdExpression = usdExpressionAttr.GetText()
+
+        textExpression = self._expressionText.toPlainText()
+        if usdExpression != textExpression:
+            # assign default value if text is empty
+            if textExpression == "":
+                self._collection.CreateMembershipExpressionAttr()
+            else:
+                self._collection.CreateMembershipExpressionAttr(Sdf.PathExpression(textExpression))
+
+            if self._expressionCallback != None:
+                self._expressionCallback()
+

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/usdCollectionData.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/usdCollectionData.py
@@ -55,26 +55,15 @@ class UsdCollectionData(CollectionData):
         self._includes.dataChanged.emit()
         self._excludes.dataChanged.emit()
 
-    # Item picking
-
-    def canPick(self) -> bool:
-        '''
-        Return if there is a UI to pick items.
-        '''
-        return False
+    # USD Stage information
     
-    def pick(self, dialogTitle) -> Sequence[AnyStr]:
+    def getStage(self):
         '''
-        Pick items and return the sequnce of picked items.
+        Returns the USD stage in which the collection lives.
         '''
-        # TODO: move host functionality in sub-class of this class, overriding pick.
-        prims: Sequence[Usd.Prim] = Host.instance().pick(self._prim.GetStage(), dialogTitle=dialogTitle)
-        if prims is None:
-            return
-        items = []
-        for prim in prims:
-            items.append(prim.GetPath())
-        return items
+        if not self._prim:
+            return None
+        return self._prim.GetStage()
 
     # Include and exclude
 
@@ -82,6 +71,8 @@ class UsdCollectionData(CollectionData):
         '''
         Verify if the collection includes all by default.
         '''
+        if not self._collection:
+            return False
         includeRootAttribute = self._collection.GetIncludeRootAttr()
         return includeRootAttribute.Get()
 
@@ -90,6 +81,8 @@ class UsdCollectionData(CollectionData):
         Sets if the collection should include all items by default.
         '''
         if self.includesAll() == state:
+            return
+        if not self._collection:
             return
         includeRootAttribute = self._collection.GetIncludeRootAttr()
         includeRootAttribute.Set(state)
@@ -112,6 +105,8 @@ class UsdCollectionData(CollectionData):
         '''
         Returns expansion rule as a USD token.
         '''
+        if not self._collection:
+            return ""
         return self._collection.GetExpansionRuleAttr().Get()
 
     def setExpansionRule(self, rule):
@@ -120,12 +115,17 @@ class UsdCollectionData(CollectionData):
         '''
         if rule == self.getExpansionRule():
             return
+        if not self._collection:
+            return
         self._collection.CreateExpansionRuleAttr(rule)
 
     def getMembershipExpression(self) -> AnyStr:
         '''
         Returns the membership expression as text.
         '''
+        if not self._collection:
+            return None
+        
         usdExpressionAttr = self._collection.GetMembershipExpressionAttr().Get()
         if usdExpressionAttr is None:
             return None
@@ -135,6 +135,9 @@ class UsdCollectionData(CollectionData):
         '''
         Set the textual membership expression.
         '''
+        if not self._collection:
+            return
+        
         usdExpression = ""
         usdExpressionAttr = self._collection.GetMembershipExpressionAttr().Get()
         if usdExpressionAttr != None:

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/usdCollectionStringListData.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/usdCollectionStringListData.py
@@ -1,0 +1,81 @@
+from ..data.stringListData import StringListData
+
+from typing import AnyStr, Sequence
+from pxr import Sdf
+
+class CollectionStringListData(StringListData):
+    def __init__(self, collection, isInclude: bool):
+        super().__init__()
+        self._isInclude = isInclude
+        self.setCollection(collection)
+
+    def setCollection(self, collection):
+        '''
+        Sets which USD collection is held by this data class.
+        '''
+        self._collection = collection
+
+    def getStrings(self) -> Sequence[AnyStr]:
+        '''
+        Retrieve the full list of all text strings.
+        '''
+        items = []
+        if self._collection is None:
+            return items
+
+        if self._isInclude:
+            targets = self._collection.GetIncludesRel().GetTargets()
+        else:
+            targets = self._collection.GetExcludesRel().GetTargets()
+            
+        for p in targets:
+            items.append(p.pathString)
+        return items
+
+    def addStrings(self, items: Sequence[AnyStr]):
+        '''
+        Add the given strings to the model.
+        '''
+        if self._collection is None:
+            return
+        # Use a SdfChangeBlock to group all updates in a single USD recomposition.
+        with Sdf.ChangeBlock():
+            if self._isInclude:
+                for path in items:
+                    self._collection.GetIncludesRel().AddTarget(Sdf.Path(path))
+            else:
+                for path in items:
+                    self._collection.GetExcludesRel().AddTarget(Sdf.Path(path))
+
+    def removeStrings(self, items: Sequence[AnyStr]):
+        '''
+        Remove the given strings from the model.
+        '''
+        with Sdf.ChangeBlock():
+            if self._isInclude:
+                for item in items:
+                    self._collection.GetIncludesRel().RemoveTarget(Sdf.Path(item))
+            else:
+                for item in items:
+                    self._collection.GetExcludesRel().RemoveTarget(Sdf.Path(item))
+
+    def _isValidString(self, text) -> AnyStr:
+        '''
+        Validates if the string is valid and possibly alter it to make it valid
+        or conform to the expected format or value. Return None if invalid.
+        '''
+        # We probably received the UFE path, which contains a Maya path and
+        # a USD (Sdf) path separated by a comma. Extract the USD path.
+        if "," in text:
+            text = text.split(",")[1]
+        if not Sdf.Path.IsValidPathString(text):
+            return None
+
+        stage = self._collection.GetPrim().GetStage()
+        prim = stage.GetPrimAtPath(Sdf.Path(text))
+
+        if not prim or not prim.IsValid():
+            # TODO: maybe report a warning...? Would it be really useful?
+            return None
+
+        return text

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/usdCollectionStringListData.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/usdCollectionStringListData.py
@@ -38,6 +38,7 @@ class CollectionStringListData(StringListData):
         '''
         if self._collection is None:
             return
+        
         # Use a SdfChangeBlock to group all updates in a single USD recomposition.
         with Sdf.ChangeBlock():
             if self._isInclude:
@@ -51,6 +52,9 @@ class CollectionStringListData(StringListData):
         '''
         Remove the given strings from the model.
         '''
+        if self._collection is None:
+            return
+        
         with Sdf.ChangeBlock():
             if self._isInclude:
                 for item in items:
@@ -66,6 +70,9 @@ class CollectionStringListData(StringListData):
         '''
         # We probably received the UFE path, which contains a Maya path and
         # a USD (Sdf) path separated by a comma. Extract the USD path.
+        if self._collection is None:
+            return None
+
         if "," in text:
             text = text.split(",")[1]
         if not Sdf.Path.IsValidPathString(text):


### PR DESCRIPTION
Separate data from UI:
- Add data and usdData modules.
- Add collectionData and stringData to the data module as abstract interface to read and modify collection data.
- Add usdCollectionData and usdCollectionStringListData to usdData, for USD implementation.
- This also avoids business logic referring to UI labels and such.
- This also automatically updates the data source for the UI since the model is the data source.
- Allow setting the collection on the usdCollectionData.
- Fix the default value for the include-all flag.
- Still need to derive a Maya implementation to host picking and undo/redo.
- Make all UI use the collectionData and stringListData classes to hold and modify data instead of having business logic in UI.

Refactor UI code:
- Rename list.py to stringListPanel.py to avoid clashing with Python's list type.
- Removed all update and updateUI functions and flags and listen to dataChanged signals instead.
- Moved drag-and-drop event filter to string list view.
- Don't stop adding dropped item just because one is invalid.
- Move dropped item conversion and validation to the data class.

Small UI fixes:
- Fix selection mode of list views.
- Fixed issues with the check box callback getting the wrong state.
- Add include-all checkbox tooltip.
- Made the color and font size for the filtered list view come from the Theme.
- Removed place holder label and use paint event instead to both paint "no object found" and "drop stuff here".