### PR TITLE
EMSUSD-1971 Make job context UI registeration be order-neutral

### DIFF
--- a/lib/mayaUsd/fileio/jobContextRegistry.cpp
+++ b/lib/mayaUsd/fileio/jobContextRegistry.cpp
@@ -62,34 +62,39 @@ void UsdMayaJobContextRegistry::RegisterExportJobContext(
     bool               fromPython)
 {
     TF_DEBUG(PXRUSDMAYA_REGISTRY).Msg("Registering export job context %s.\n", jobContext.c_str());
+
     TfToken     key(jobContext);
-    ContextInfo newInfo { key, TfToken(niceName), TfToken(description), enablerFct, {}, {} };
-    auto        itFound = _jobContextReg.find(newInfo);
+    ContextInfo newInfo { key, TfToken(niceName), TfToken(description) };
+    newInfo.exportEnablerCallback = enablerFct;
+
+    auto itFound = _jobContextReg.find(newInfo);
     if (itFound == _jobContextReg.end()) {
         _jobContextReg.insert(newInfo);
         UsdMaya_RegistryHelper::AddUnloader(
-            [key]() {
-                ContextInfo toErase { key, {}, {}, {}, {}, {} };
-                _jobContextReg.erase(toErase);
-            },
-            fromPython);
+            [key]() { _jobContextReg.erase(ContextInfo { key }); }, fromPython);
     } else {
-        if (!itFound->exportEnablerCallback) {
-            if (niceName != itFound->niceName) {
-                TF_CODING_ERROR(
-                    "Export enabler has differing nice name: %s != %s",
-                    niceName.c_str(),
-                    itFound->niceName.GetText());
-            }
-            // Fill the export part:
-            ContextInfo updatedInfo(*itFound);
-            updatedInfo.exportDescription = TfToken(description);
-            updatedInfo.exportEnablerCallback = enablerFct;
-            _jobContextReg.erase(updatedInfo);
-            _jobContextReg.insert(updatedInfo);
-        } else {
+        if (itFound->exportEnablerCallback) {
             TF_CODING_ERROR("Multiple enablers for export job context %s", jobContext.c_str());
         }
+
+        if (itFound->niceName.size() > 0 && niceName != itFound->niceName) {
+            TF_CODING_ERROR(
+                "Export enabler has differing nice name: %s != %s",
+                niceName.c_str(),
+                itFound->niceName.GetText());
+        }
+
+        // Note: the container for the plugin info is a set so it cannot be modified.
+        //       We need to copy the entry, modify the copy, remove the old entry and
+        //       insert the newly updated entry.
+        ContextInfo updatedInfo(*itFound);
+        if (niceName.size() > 0)
+            updatedInfo.niceName = TfToken(niceName);
+        if (description.size() > 0)
+            updatedInfo.exportDescription = TfToken(description);
+        updatedInfo.exportEnablerCallback = enablerFct;
+        _jobContextReg.erase(updatedInfo);
+        _jobContextReg.insert(updatedInfo);
     }
 }
 
@@ -98,22 +103,27 @@ void UsdMayaJobContextRegistry::SetExportOptionsUI(
     UIFn               uiFct,
     bool               fromPython)
 {
-    const ContextInfo key { TfToken(jobContext), {}, {}, {}, {}, {} };
-    auto              iter = _jobContextReg.find(key);
-    if (iter == _jobContextReg.end()) {
-        TF_CODING_ERROR("Export job context %s does not exists", jobContext.c_str());
-        return;
+    TF_DEBUG(PXRUSDMAYA_REGISTRY).Msg("Adding export job context %s UI.\n", jobContext.c_str());
+
+    TfToken     key(jobContext);
+    ContextInfo newInfo { key };
+    newInfo.exportUICallback = uiFct;
+
+    auto itFound = _jobContextReg.find(newInfo);
+    if (itFound == _jobContextReg.end()) {
+        _jobContextReg.insert(newInfo);
+        UsdMaya_RegistryHelper::AddUnloader(
+            [key]() { _jobContextReg.erase(ContextInfo { key }); }, fromPython);
+    } else {
+        // Note: the container for the plugin info is a set so it cannot be modified.
+        //       We need to copy the entry, modify the copy, remove the old entry and
+        //       insert the newly updated entry.
+
+        ContextInfo updatedInfo(*itFound);
+        updatedInfo.exportUICallback = uiFct;
+        _jobContextReg.erase(itFound);
+        _jobContextReg.insert(updatedInfo);
     }
-
-    // Note: the container for the plugin info is a set so it cannot be modified.
-    //       We need to copy the entry, modify the copy, remove the old entry and
-    //       insert the newly updated entry.
-
-    ContextInfo updatedInfo(*iter);
-    updatedInfo.exportUICallback = uiFct;
-    UsdMaya_RegistryHelper::AddUnloader([key]() { _jobContextReg.erase(key); }, fromPython);
-    _jobContextReg.erase(iter);
-    _jobContextReg.insert(updatedInfo);
 }
 
 void UsdMayaJobContextRegistry::RegisterImportJobContext(
@@ -124,9 +134,12 @@ void UsdMayaJobContextRegistry::RegisterImportJobContext(
     bool               fromPython)
 {
     TF_DEBUG(PXRUSDMAYA_REGISTRY).Msg("Registering import job context %s.\n", jobContext.c_str());
+
     TfToken     key(jobContext);
-    ContextInfo newInfo { key, TfToken(niceName), {}, {}, TfToken(description), enablerFct };
-    auto        itFound = _jobContextReg.find(newInfo);
+    ContextInfo newInfo { key, TfToken(niceName), {}, {}, {}, TfToken(description) };
+    newInfo.importEnablerCallback = enablerFct;
+
+    auto itFound = _jobContextReg.find(newInfo);
     if (itFound == _jobContextReg.end()) {
         _jobContextReg.insert(newInfo);
         UsdMaya_RegistryHelper::AddUnloader(
@@ -136,22 +149,29 @@ void UsdMayaJobContextRegistry::RegisterImportJobContext(
             },
             fromPython);
     } else {
-        if (!itFound->importEnablerCallback) {
-            if (niceName != itFound->niceName) {
-                TF_CODING_ERROR(
-                    "Import enabler has differing nice name: %s != %s",
-                    niceName.c_str(),
-                    itFound->niceName.GetText());
-            }
-            // Fill the import part:
-            ContextInfo updatedInfo(*itFound);
-            updatedInfo.importDescription = TfToken(description);
-            updatedInfo.importEnablerCallback = enablerFct;
-            _jobContextReg.erase(updatedInfo);
-            _jobContextReg.insert(updatedInfo);
-        } else {
+        if (itFound->importEnablerCallback) {
             TF_CODING_ERROR("Multiple enablers for import job context %s", jobContext.c_str());
         }
+
+        if (itFound->niceName.size() > 0 && niceName.size() > 0 && niceName != itFound->niceName) {
+            TF_CODING_ERROR(
+                "Import enabler has differing nice name: %s != %s",
+                niceName.c_str(),
+                itFound->niceName.GetText());
+        }
+
+        // Note: the container for the plugin info is a set so it cannot be modified.
+        //       We need to copy the entry, modify the copy, remove the old entry and
+        //       insert the newly updated entry.
+
+        ContextInfo updatedInfo(*itFound);
+        if (niceName.size() > 0)
+            updatedInfo.niceName = TfToken(niceName);
+        if (description.size() > 0)
+            updatedInfo.importDescription = TfToken(description);
+        updatedInfo.importEnablerCallback = enablerFct;
+        _jobContextReg.erase(updatedInfo);
+        _jobContextReg.insert(updatedInfo);
     }
 }
 
@@ -160,22 +180,27 @@ void UsdMayaJobContextRegistry::SetImportOptionsUI(
     UIFn               uiFct,
     bool               fromPython)
 {
-    const ContextInfo key { TfToken(jobContext), {}, {}, {}, {}, {} };
-    auto              iter = _jobContextReg.find(key);
-    if (iter == _jobContextReg.end()) {
-        TF_CODING_ERROR("Import job context %s does not exist", jobContext.c_str());
-        return;
+    TF_DEBUG(PXRUSDMAYA_REGISTRY).Msg("Adding import job context %s UI.\n", jobContext.c_str());
+
+    TfToken     key(jobContext);
+    ContextInfo newInfo { key, {}, {}, {}, {}, {}, {}, uiFct };
+    newInfo.importUICallback = uiFct;
+
+    auto itFound = _jobContextReg.find(newInfo);
+    if (itFound == _jobContextReg.end()) {
+        _jobContextReg.insert(newInfo);
+        UsdMaya_RegistryHelper::AddUnloader(
+            [key]() { _jobContextReg.erase(ContextInfo { key }); }, fromPython);
+    } else {
+        // Note: the container for the plugin info is a set so it cannot be modified.
+        //       We need to copy the entry, modify the copy, remove the old entry and
+        //       insert the newly updated entry.
+
+        ContextInfo updatedInfo(*itFound);
+        updatedInfo.importUICallback = uiFct;
+        _jobContextReg.erase(itFound);
+        _jobContextReg.insert(updatedInfo);
     }
-
-    // Note: the container for the plugin info is a set so it cannot be modified.
-    //       We need to copy the entry, modify the copy, remove the old entry and
-    //       insert the newly updated entry.
-
-    ContextInfo updatedInfo(*iter);
-    updatedInfo.importUICallback = uiFct;
-    UsdMaya_RegistryHelper::AddUnloader([key]() { _jobContextReg.erase(key); }, fromPython);
-    _jobContextReg.erase(iter);
-    _jobContextReg.insert(updatedInfo);
 }
 
 TfTokenVector UsdMayaJobContextRegistry::_ListJobContexts()

--- a/lib/mayaUsd/fileio/jobContextRegistry.h
+++ b/lib/mayaUsd/fileio/jobContextRegistry.h
@@ -104,24 +104,6 @@ public:
         TfToken   importDescription;
         EnablerFn importEnablerCallback;
         UIFn      importUICallback;
-
-        ContextInfo() = default;
-
-        ContextInfo(
-            const TfToken& jc,
-            const TfToken& nn,
-            const TfToken& edsc,
-            EnablerFn      eef,
-            const TfToken& idsc,
-            EnablerFn      ief)
-            : jobContext(jc)
-            , niceName(nn)
-            , exportDescription(edsc)
-            , exportEnablerCallback(eef)
-            , importDescription(idsc)
-            , importEnablerCallback(ief)
-        {
-        }
     };
 
     /// Gets the conversion information associated with \p jobContext on export and import

--- a/test/lib/usd/plugin/nullApiExporter.cpp
+++ b/test/lib/usd/plugin/nullApiExporter.cpp
@@ -102,17 +102,6 @@ REGISTER_EXPORT_JOB_CONTEXT_FCT(
     return extraArgs;
 }
 
-REGISTER_EXPORT_JOB_CONTEXT_FCT(
-    Curly,
-    "Curly's special",
-    "Test coverage of error handling part deux")
-{
-    VtDictionary extraArgs;
-    // Incorrect type:
-    extraArgs[UsdMayaJobExportArgsTokens->apiSchema] = VtValue(std::string("testApi"));
-    return extraArgs;
-}
-
 REGISTER_EXPORT_JOB_CONTEXT_UI_FCT(Curly)
 {
     VtDictionary forcedSettings;
@@ -127,6 +116,17 @@ REGISTER_EXPORT_JOB_CONTEXT_UI_FCT(Curly)
     }
 
     return forcedSettings;
+}
+
+REGISTER_EXPORT_JOB_CONTEXT_FCT(
+    Curly,
+    "Curly's special",
+    "Test coverage of error handling part deux")
+{
+    VtDictionary extraArgs;
+    // Incorrect type:
+    extraArgs[UsdMayaJobExportArgsTokens->apiSchema] = VtValue(std::string("testApi"));
+    return extraArgs;
 }
 
 REGISTER_EXPORT_JOB_CONTEXT_FCT(Moe, "Moe's special", "Test coverage of error handling part funf")


### PR DESCRIPTION
- Change the job context registration macro to be order-independent.
- Change unit test to verify that the macro are order-neutral by registering UI first.