### PR TITLE
EMSUSD-2000 - Do not contaminate HdStorm libraries with lobe pruning

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -341,10 +341,10 @@ struct _MaterialXData
     {
         try {
             _mtlxSearchPath = HdMtlxSearchPaths();
-#if PXR_VERSION > 2311
-            _mtlxLibrary = HdMtlxStdLibraries();
-#else
             _mtlxLibrary = mx::createDocument();
+#if PXR_VERSION > 2311
+            _mtlxLibrary->importLibrary(HdMtlxStdLibraries());
+#else
             mx::loadLibraries({}, _mtlxSearchPath, _mtlxLibrary);
 #endif
 


### PR DESCRIPTION
MayaUSD should use a copy of the HdStorm MaterialX library in order to optimize it without affecting any Storm based render delegate.