### PR TITLE
EMSUSD-0 bring light linking changes from the shared repo

### DIFF
--- a/lib/mayaUsd/resources/ae/CMakeLists.txt
+++ b/lib/mayaUsd/resources/ae/CMakeLists.txt
@@ -83,6 +83,7 @@ if(MAYA_APP_VERSION VERSION_GREATER_EQUAL 2023)
         ${MAYAUSD_SHARED_COMPONENTS}/usdData/__init__.py
         ${MAYAUSD_SHARED_COMPONENTS}/usdData/usdCollectionData.py
         ${MAYAUSD_SHARED_COMPONENTS}/usdData/usdCollectionStringListData.py
+        ${MAYAUSD_SHARED_COMPONENTS}/usdData/validator.py
         DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python/usd_shared_components/usdData/
     )
 

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/widget.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/widget.py
@@ -37,8 +37,6 @@ class CollectionWidget(QWidget):
     ):
         super(CollectionWidget, self).__init__(parent)
 
-        self._collection: Usd.CollectionAPI = collection
-        self._prim: Usd.Prim = prim
         self._collData = Host.instance().createCollectionData(prim, collection)
 
         mainLayout = QVBoxLayout()
@@ -54,7 +52,7 @@ class CollectionWidget(QWidget):
             self._tabWidget.currentChanged.connect(self.onTabChanged)
             self._tabWidget.setDocumentMode(True)
 
-            self._expressionWidget = ExpressionWidget(self._collData, self._tabWidget, self.onExpressionChanged)
+            self._expressionWidget = ExpressionWidget(self._collData, self._tabWidget)
             self._tabWidget.addTab(self._includeExcludeWidget, QIcon(), "Include/Exclude")
             self._tabWidget.addTab(self._expressionWidget, QIcon(), "Expression")
 
@@ -71,24 +69,10 @@ class CollectionWidget(QWidget):
         self.setLayout(mainLayout)
 
     def setCollection(self, prim: Usd.Prim = None, collection: Usd.CollectionAPI = None):
-        self._collection = collection
-        self._prim = prim
-        self._collData = UsdCollectionData(prim, collection)
+        self._collData.setCollection(prim, collection)
 
     if Usd.GetVersion() >= (0, 23, 11):
 
         def onTabChanged(self, index):
             self._includeExcludeWidget.update()
             self._expressionWidget.update()
-
-        def onExpressionChanged(self):
-            updateIncludeAll = (
-                len(self._collData._includes.getStrings()) == 0
-                and len(self._collData._includes.getStrings()) == 0
-                and self._collData.includesAll()
-            )
-            if updateIncludeAll:
-                self._collData.setIncludeAll(False)
-                print(
-                    '"Include All" has been disabled for the expression to take effect.'
-                )

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/filteredStringListView.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/filteredStringListView.py
@@ -19,7 +19,6 @@ try:
     from PySide6.QtWidgets import (  # type: ignore
         QLabel,
         QListView,
-        QStyledItemDelegate,
         QStyleOptionViewItem
     )
 except:
@@ -34,7 +33,7 @@ except:
         Signal,
     )
     from PySide2.QtGui import QPainter, QPaintEvent, QFont  # type: ignore
-    from PySide2.QtWidgets import QLabel, QListView, QStyledItemDelegate, QStyleOptionViewItem  # type: ignore
+    from PySide2.QtWidgets import QLabel, QListView, QStyleOptionViewItem  # type: ignore
 
 
 NO_OBJECTS_FOUND_LABEL = "No objects found"
@@ -46,28 +45,6 @@ DRAG_OR_PICK_OBJECTS_LABEL = "Drag objects here or click '+' to add"
 class FilteredStringListView(QListView):
 
     itemSelectionChanged = Signal()
-
-    class Delegate(QStyledItemDelegate):
-        def __init__(self, model: QStringListModel, parent=None):
-            super(FilteredStringListView.Delegate, self).__init__(parent)
-            self._model = model
-
-        def sizeHint(
-            self,
-            option: QStyleOptionViewItem,
-            index: Union[QModelIndex, QPersistentModelIndex],
-        ):
-            s: int = Theme.instance().uiScaled(24)
-            return QSize(s, s)
-
-        def paint(
-            self,
-            painter: QPainter,
-            option: QStyleOptionViewItem,
-            index: Union[QModelIndex, QPersistentModelIndex],
-        ):
-            s: str = self._model.data(index, Qt.DisplayRole)
-            Theme.instance().paintStringListEntry(painter, option.rect, s)
 
     def __init__(self, data: StringListData, headerTitle: str = "", parent=None):
         super(FilteredStringListView, self).__init__(parent)

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/stringListPanel.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/stringListPanel.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     from PySide2.QtCore import QRect, Qt  # type: ignore
     from PySide2.QtGui import QPainter  # type: ignore
-    from PySide2.QtWidgets import QCheckBox, QHBoxLayout, QVBoxLayout, QStyle, QStyleOptionHeaderV2, QStylePainter, QWidget  # type: ignore
+    from PySide2.QtWidgets import QCheckBox, QHBoxLayout, QVBoxLayout, QStyle, QStyleOptionHeader as QStyleOptionHeaderV2, QStylePainter, QWidget  # type: ignore
 
 # TODO: support I8N
 kIncludeAllLabel = "Include all"

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/theme.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/theme.py
@@ -152,9 +152,3 @@ class Theme(object):
         """
 
         return self.uiScaled(2)
-
-    def paintList(self, widget: QWidget, updateRect: QRect, state: State):
-        raise RuntimeError("Needs to be implemented in derived class")
-
-    def paintStringListEntry(self, painter: QPainter, rect: QRect, string: str):
-        raise RuntimeError("Needs to be implemented in derived class")

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/data/collectionData.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/data/collectionData.py
@@ -29,11 +29,13 @@ class CollectionData(QObject):
         '''
         return False
     
-    def setIncludeAll(self, state: bool):
+    def setIncludeAll(self, state: bool) -> bool:
         '''
         Sets if the collection should include all items by default.
+        Return True if successfully set.
+        Return False if already set to the same value.
         '''
-        pass
+        return False
     
     def getIncludeData(self) -> StringListData:
         '''
@@ -47,11 +49,13 @@ class CollectionData(QObject):
         '''
         return None
 
-    def removeAllIncludeExclude(self):
+    def removeAllIncludeExclude(self) -> bool:
         '''
         Remove all included and excluded items.
+        Return True if successfully removed.
+        Return False if already empty.
         '''
-        pass
+        return False
 
     # Expression
 
@@ -61,11 +65,13 @@ class CollectionData(QObject):
         '''
         return None
     
-    def setExpansionRule(self, rule):
+    def setExpansionRule(self, rule) -> bool:
         '''
         Sets the expansion rule as a USD token.
+        Return True if successfully set.
+        Return False if already set to the same value.
         '''
-        pass
+        return False
 
     def getMembershipExpression(self) -> AnyStr:
         '''
@@ -73,8 +79,10 @@ class CollectionData(QObject):
         '''
         return None
     
-    def setMembershipExpression(self, textExpression: AnyStr):
+    def setMembershipExpression(self, textExpression: AnyStr) -> bool:
         '''
         Set the textual membership expression.
+        Return True if successfully set.
+        Return False if already set to the same value.
         '''
-        pass
+        return False

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/data/stringListData.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/data/stringListData.py
@@ -20,17 +20,20 @@ class StringListData(QObject):
         '''
         return []
 
-    def addStrings(self, items: Sequence[AnyStr]):
+    def addStrings(self, items: Sequence[AnyStr]) -> bool:
         '''
         Add the given strings to the model.
+        Return True if successfully added.
         '''
-        pass
+        return False
 
-    def removeStrings(self, items: Sequence[AnyStr]):
+    def removeStrings(self, items: Sequence[AnyStr]) -> bool:
         '''
         Remove the given strings from the model.
+        Return True if successfully removed.
+        Return False if already empty.
         '''
-        pass
+        return False
 
     def _isValidString(self, s) -> AnyStr:
         '''

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/validator.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/validator.py
@@ -1,0 +1,30 @@
+from typing import Callable
+
+def validatePrim(defaultReturnValue = None) -> Callable:
+    '''
+    Validate that the prim kept in the data is still valid.
+    If invalid, we will report the error and return the given
+    defaultReturnValue.
+    '''
+    def validator(func: Callable) -> Callable:
+        def wrapper(self, *args, **kwargs):
+            if not self._prim or not self._prim.IsValid():
+                return defaultReturnValue
+            return func(self, *args, **kwargs)
+        return wrapper
+    return validator
+
+def validateCollection(defaultReturnValue = None) -> Callable:
+    '''
+    Validate that the prim and collection kept in the data is still valid.
+    If invalid, we will report the error and return the given
+    defaultReturnValue.
+    '''
+    def validator(func: Callable) -> Callable:
+        def wrapper(self, *args, **kwargs):
+            if not self._prim or not self._collection or not self._prim.IsValid():
+                return defaultReturnValue
+            return func(self, *args, **kwargs)
+        return wrapper
+    return validator
+


### PR DESCRIPTION
- Fix setting a new prim and collection on an existing collection widget.
- Remove obsolete list item delegate and unused painters from the list view widget.
- Remove unused painter function from the Theme class.
- Make the data setter return true or False if the data was set or not.
- (This will potentially make possible to not add an undo for do-nothing actions.)
- Add validation of the prim and collection to avoid printing stack traces to the user.
- Update the check condition to change include all.
- Don't change focus of the expression widget on enter.
- Don't allow pasting text with formatting (bold, etc)
- Making the resizing of the list widgets more robust.
- Added an error message when setting the expression causes an exception.
- Avoid submitting the expression when it has not changed, to avoid bad interactions with undo/redo.
- Move the business logic of resetting teh include-all flaginto the data
  class, wher eit belongs.
- This avoids confusingly having two undo items when setting the
  expression the first time.
- Also avoids having yet another "magic" callback in the UI code that
  would know about the business logic instead of being pure UI.