### PR TITLE
EMSUSD-2095 multiple small UI fixes

### DIFF
--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/filteredStringListView.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/filteredStringListView.py
@@ -72,13 +72,11 @@ class FilteredStringListView(QListView):
 
         self.setCursor(Qt.ArrowCursor)
 
-        DragAndDropEventFilter(self, data)
+        DragAndDropAndDeleteEventFilter(self, data)
 
         self.selectionModel().selectionChanged.connect(self.itemSelectionChanged)
 
     def paintEvent(self, event: QPaintEvent):
-        painter = QPainter(self)
-        painter.fillRect(event.rect(), Theme.instance().palette.colorListBorder)
         super(FilteredStringListView, self).paintEvent(event)
 
         model = self.model()
@@ -110,7 +108,7 @@ class FilteredStringListView(QListView):
     def hasSelectedItems(self) -> bool:
         return bool(self.selectionModel().hasSelection())
 
-class DragAndDropEventFilter(QObject):
+class DragAndDropAndDeleteEventFilter(QObject):
     def __init__(self, widget, data: StringListData):
         super().__init__(widget)
         self._collData = data
@@ -128,5 +126,10 @@ class DragAndDropEventFilter(QObject):
         elif event.type() == QEvent.DragMove:
             event.acceptProposedAction()
             return True
+        elif event.type() == QEvent.KeyPress:
+            # These are to prevent deleting the overall DCC selection when
+            # an item in the listview is selected.
+            if event.key() == Qt.Key_Delete or event.key() == Qt.Key_Backspace:
+                return True
 
         return super().eventFilter(obj, event)

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/usdCollectionStringListData.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/usdCollectionStringListData.py
@@ -38,6 +38,8 @@ class CollectionStringListData(StringListData):
         Add the given strings to the model.
         '''
         # Use a SdfChangeBlock to group all updates in a single USD recomposition.
+        existingItems = set(self.getStrings())
+        items = set(items).difference(existingItems)
         with Sdf.ChangeBlock():
             if self._isInclude:
                 for path in items:


### PR DESCRIPTION
- Don't draw rectangle in list paint event that cause error output.
- Don't let the delete and backspace key events out of the list view to avoid deleting the DCC selection. (What is selected in the Maya outliner.)
- Don't add items that are already present.
- Fix invalid expression error message.
- Make use of the Host reportMesage function to report errors and info.
- Default to the expression tab if only expressions are used.