### PR TITLE
HYDRA-1347 : Fix double texture loading when using Hydra

### DIFF
--- a/lib/mayaUsd/render/mayaToHydra/utils.h
+++ b/lib/mayaUsd/render/mayaToHydra/utils.h
@@ -20,9 +20,6 @@
 #include <pxr/imaging/hd/renderDelegate.h>
 #include <pxr/pxr.h>
 
-#include <maya/MFrameContext.h>
-#include <maya/MString.h>
-
 #include <string>
 #include <vector>
 
@@ -49,27 +46,6 @@ using MtohRendererDescriptionVector = std::vector<MtohRendererDescription>;
 // Map from MtohRendererDescription::rendererName to it's a HdRenderSettingDescriptorList
 using MtohRendererSettings
     = std::unordered_map<TfToken, HdRenderSettingDescriptorList, TfToken::HashFunctor>;
-
-// Defining these in header so don't need to link to use
-inline bool IsMtohRenderOverrideName(const MString& overrideName)
-{
-    // See if the override is an mtoh one - ie, it starts with the right prefix
-
-    // VS2017 msvc didn't accept this as a constexpr
-    const auto prefixLen = strlen(MTOH_RENDER_OVERRIDE_PREFIX);
-    if (overrideName.length() < prefixLen) {
-        return false;
-    }
-
-    return overrideName.substring(0, prefixLen - 1) == MTOH_RENDER_OVERRIDE_PREFIX;
-}
-
-inline bool IsMtohRenderOverride(const MHWRender::MFrameContext& frameContext)
-{
-    MHWRender::MFrameContext::RenderOverrideInformation overrideInfo;
-    frameContext.getRenderOverrideInformation(overrideInfo);
-    return IsMtohRenderOverrideName(overrideInfo.overrideName);
-}
 
 std::string                          MtohGetRendererPluginDisplayName(const TfToken& id);
 const MtohRendererDescriptionVector& MtohGetRendererDescriptions();

--- a/lib/mayaUsd/render/px_vp20/utils.cpp
+++ b/lib/mayaUsd/render/px_vp20/utils.cpp
@@ -988,8 +988,7 @@ bool px_vp20Utils::HasHydraRenderOverride(const MHWRender::MFrameContext& frameC
         const auto prefixLength = std::strlen(prefix);
         if (overrideInfo.overrideName.length() < prefixLength) {
             continue;
-        }
-        else if (overrideInfo.overrideName.substring(0, prefixLength - 1) == prefix) {
+        } else if (overrideInfo.overrideName.substring(0, prefixLength - 1) == prefix) {
             return true;
         }
     }

--- a/lib/mayaUsd/render/px_vp20/utils.cpp
+++ b/lib/mayaUsd/render/px_vp20/utils.cpp
@@ -978,7 +978,7 @@ bool px_vp20Utils::HasHydraRenderOverride(const MHWRender::MFrameContext& frameC
     MHWRender::MFrameContext::RenderOverrideInformation overrideInfo;
     frameContext.getRenderOverrideInformation(overrideInfo);
 
-    if (overrideInfo.overrideName.isEmpty()) {
+    if (overrideInfo.overrideName.length() == 0U) {
         // No render override, avoid checking for prefixes
         return false;
     }

--- a/lib/mayaUsd/render/px_vp20/utils.cpp
+++ b/lib/mayaUsd/render/px_vp20/utils.cpp
@@ -965,6 +965,39 @@ void px_vp20Utils::OutputDisplayStatusToStream(
     }
 }
 
+/* static */
+bool px_vp20Utils::HasHydraRenderOverride(const MHWRender::MFrameContext& frameContext)
+{
+    static const auto HYDRA_RENDER_OVERRIDE_PREFIXES = {
+#if defined(BUILD_HDMAYA)
+        "mtohRenderOverride_",
+#endif
+        "mayaHydraRenderOverride_",
+    };
+
+    MHWRender::MFrameContext::RenderOverrideInformation overrideInfo;
+    frameContext.getRenderOverrideInformation(overrideInfo);
+
+    if (overrideInfo.overrideName.isEmpty()) {
+        // No render override, avoid checking for prefixes
+        return false;
+    }
+
+    // Loop over the prefixes to see if the render override name has one
+    for (const auto& prefix : HYDRA_RENDER_OVERRIDE_PREFIXES) {
+        const auto prefixLength = std::strlen(prefix);
+        if (overrideInfo.overrideName.length() < prefixLength) {
+            continue;
+        }
+        else if (overrideInfo.overrideName.substring(0, prefixLength - 1) == prefix) {
+            return true;
+        }
+    }
+
+    // No matching prefix found; this is not a Hydra-based render override
+    return false;
+}
+
 GLUniformBufferBindingsSaver::GLUniformBufferBindingsSaver()
 {
     for (size_t i = 0u; i < _uniformBufferBindings.size(); ++i) {

--- a/lib/mayaUsd/render/px_vp20/utils.h
+++ b/lib/mayaUsd/render/px_vp20/utils.h
@@ -114,6 +114,11 @@ public:
     static void
     OutputDisplayStatusToStream(const MHWRender::DisplayStatus displayStatus, std::ostream& stream);
 
+    // Returns true if the frameContext has a render override and it's a Hydra-based one.
+    // Returns false otherwise.
+    MAYAUSD_CORE_PUBLIC
+    static bool HasHydraRenderOverride(const MHWRender::MFrameContext& frameContext);
+
 private:
     px_vp20Utils() = delete;
     ~px_vp20Utils() = delete;

--- a/lib/mayaUsd/render/pxrUsdMayaGL/proxyDrawOverride.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/proxyDrawOverride.cpp
@@ -202,14 +202,11 @@ MUserData* UsdMayaProxyDrawOverride::prepareForDraw(
         return nullptr;
     }
 
-#if defined(BUILD_HDMAYA)
-    // If the current viewport renderer is an mtoh one, skip this update, as
-    // mtoh already has special handling for proxy shapes, and we don't want to
-    // build out a render index we don't need
-    if (IsMtohRenderOverride(frameContext)) {
+    // Hydra-based render overrides already take care of USD data,
+    // so avoid duplicating the effort.
+    if (px_vp20Utils::HasHydraRenderOverride(frameContext)) {
         return nullptr;
     }
-#endif
 
     MayaUsdProxyShapeBase* shape = MayaUsdProxyShapeBase::GetShapeAtDagPath(objPath);
     if (!shape) {

--- a/lib/mayaUsd/render/pxrUsdMayaGL/proxyDrawOverride.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/proxyDrawOverride.cpp
@@ -252,6 +252,12 @@ bool UsdMayaProxyDrawOverride::userSelect(
         MProfiler::kColorE_L2,
         "USD Proxy Shape userSelect() (Viewport 2.0)");
 
+    // Hydra-based render overrides already take care of USD data,
+    // so avoid duplicating the effort.
+    if (px_vp20Utils::HasHydraRenderOverride(context)) {
+        return false;
+    }
+
     M3dView    view;
     const bool hasView = px_vp20Utils::GetViewFromDrawContext(context, view);
     if (hasView && !view.pluginObjectDisplay(MayaUsdProxyShapeBase::displayFilterName)) {

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -24,6 +24,7 @@
 #include <mayaUsd/base/tokens.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/nodes/stageData.h>
+#include <mayaUsd/render/px_vp20/utils.h>
 #include <mayaUsd/utils/diagnosticDelegate.h>
 #include <mayaUsd/utils/selectability.h>
 
@@ -607,14 +608,12 @@ bool ProxyRenderDelegate::requiresUpdate(
     const MSubSceneContainer& container,
     const MFrameContext&      frameContext) const
 {
-#if defined(BUILD_HDMAYA)
-    // If the current viewport renderer is an mtoh one, skip this update, as
-    // mtoh already has special handling for proxy shapes, and we don't want to
-    // build out a render index we don't need
-    if (IsMtohRenderOverride(frameContext)) {
+    // Hydra-based render overrides already take care of USD data,
+    // so avoid duplicating the effort.
+    if (px_vp20Utils::HasHydraRenderOverride(frameContext)) {
         return false;
     }
-#endif
+
     return true;
 }
 


### PR DESCRIPTION
This PR skips MayaUsd handling of USD data when Hydra is being used, to avoid unnecessary processing and data loading. The change essentially rehabilitates an existing fix, but also updates it for the new MayaHydra render override prefix.

The changes will only take effect in viewports using MayaHydra; this should address the concerns raised in the previous attempt at solving this issue : https://github.com/Autodesk/maya-usd/pull/4060#issuecomment-2579789457. We only block rendering and selection, as they are both handled by MayaHydra.

I ran MayaHydra unit tests and all passed (except `testMaterialXOnNative` as I did not have LookdevX installed). 