### PR TITLE
EMSUSD-2132 fix collections for Maya 2023

### DIFF
--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/validator.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/validator.py
@@ -10,7 +10,10 @@ def validatePrim(defaultReturnValue = None) -> Callable:
         def wrapper(self, *args, **kwargs):
             if not self._prim or not self._prim.IsValid():
                 return defaultReturnValue
-            return func(self, *args, **kwargs)
+            try:
+                return func(self, *args, **kwargs)
+            except Exception:
+                return defaultReturnValue
         return wrapper
     return validator
 
@@ -24,7 +27,10 @@ def validateCollection(defaultReturnValue = None) -> Callable:
         def wrapper(self, *args, **kwargs):
             if not self._prim or not self._collection or not self._prim.IsValid():
                 return defaultReturnValue
-            return func(self, *args, **kwargs)
+            try:
+                return func(self, *args, **kwargs)
+            except Exception:
+                return defaultReturnValue
         return wrapper
     return validator
 

--- a/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
@@ -535,7 +535,7 @@ class AETemplate(object):
                     if usdVer < (0, 22, 3):
                         namespace = Usd.SchemaRegistry().GetPropertyNamespacePrefix(typeName)
                         prefix = namespace + ":" + instanceName + ":"
-                        attrList = [prefix + i for i in attrList]
+                        attrList = [namespace + ":" + instanceName] + [prefix + i for i in attrList]
 
                     typeName = instanceName + typeName
                 else:


### PR DESCRIPTION
- Make the validator function decorator catch the exceptions raised within the USD collection data classes to handle the case where the USD version does not support some API.
- Make the special code used to handle multi-apply schemas in USD prior to 22.3 correctly list the collection attribute itself.