### PR TITLE
EMSUSD-1674 fi warning icon not disappearing

### DIFF
--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/expressionWidget.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/expressionWidget.py
@@ -77,7 +77,7 @@ class ExpressionWidget(QWidget):
         self._selectBtn.setEnabled(bool(text))
 
         isConflicted = self._collData.hasDataConflict()
-        self._warningWidget.setVisible(isConflicted)
+        self._warningWidget.setConflicted(isConflicted)
         self._warningSeparator.setVisible(isConflicted)
 
     def _onSelectItemsClicked(self):

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/includeExcludeWidget.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/includeExcludeWidget.py
@@ -174,11 +174,11 @@ class IncludeExcludeWidget(QWidget):
             self._include.cbIncludeAll.setChecked(incAll)
         self.onListSelectionChanged()
 
-        wasConflicted = self._warningWidget.isVisible()
+        wasConflicted = self._warningWidget.isConflicted()
         isConflicted = self._collData.hasDataConflict()
+        self._warningWidget.setConflicted(isConflicted)
+        self._warningSeparator.setVisible(isConflicted)
         if wasConflicted != isConflicted:
-            self._warningWidget.setVisible(isConflicted)
-            self._warningSeparator.setVisible(isConflicted)
             if isConflicted:
                 from ..common.host import Host, MessageType
                 Host.instance().reportMessage(CONFLICT_WARNING_MSG, MessageType.WARNING)

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/warningWidget.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/warningWidget.py
@@ -18,8 +18,16 @@ class WarningWidget(QToolButton):
 
     def __init__(self, parentWidget=None):
         super(WarningWidget, self).__init__(parentWidget)
+        self._conflicted = False
         self.setToolTip(CONFLICT_WARNING_TOOLTIP)
         self.setIcon(Theme.instance().icon("warning"))
         self.setVisible(False)
         self.setStyleSheet("""
             QToolButton { border: 0px; }""")
+
+    def isConflicted(self) -> bool:
+        return self._conflicted
+    
+    def setConflicted(self, isConflicted: bool):
+        self._conflicted = isConflicted
+        self.setVisible(isConflicted)


### PR DESCRIPTION
Was trusting the icon visibility as being equal to the conflicted state, but when the UI is not visible on-screen, the the icon might be invisible due to not be on-screen rather than due to being hidden. So we now keep an explicit flag instead.