### PR TITLE
EMSUSD-2111 support the collection UI in Maya 2023.

### DIFF
--- a/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
@@ -341,8 +341,7 @@ class AETemplate(object):
         cmds.editorTemplate(suppress=attrName)
         self.suppressedAttrs.append(attrName)
 
-    @staticmethod
-    def defineCustom(customObj, attrs=[]):
+    def defineCustom(self, customObj, attrs=[]):
         create = lambda *args : customObj.onCreate(args)
         replace = lambda *args : customObj.onReplace(args)
         cmds.editorTemplate(attrs, callCustom=[create, replace])
@@ -536,6 +535,8 @@ class AETemplate(object):
                         namespace = Usd.SchemaRegistry().GetPropertyNamespacePrefix(typeName)
                         prefix = namespace + ":" + instanceName + ":"
                         attrList = [namespace + ":" + instanceName] + [prefix + i for i in attrList]
+                    elif usdVer <= (0, 22, 11):
+                        attrList = [schema] + attrList
 
                     typeName = instanceName + typeName
                 else:


### PR DESCRIPTION
- Python 3.9 treat static methods vs self differently than newer Python version.
- USD 22.11 did not list the base collection schema in the list of attributes.