### PR TITLE
Deprecating enableIdRender UsdImagingGLRenderParams

### DIFF
--- a/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
+++ b/lib/mayaUsd/render/pxrUsdMayaGL/sceneDelegate.cpp
@@ -565,7 +565,6 @@ HdTaskSharedPtrVector PxrMayaHdSceneDelegate::GetRenderTasks(
         renderSetupTaskParams.viewport = _viewport;
 
         // Set the parameters that are constant for all draws.
-        renderSetupTaskParams.enableIdRender = false;
         renderSetupTaskParams.alphaThreshold = 0.1f;
         renderSetupTaskParams.enableSceneMaterials = true;
         renderSetupTaskParams.depthBiasUseDefault = true;


### PR DESCRIPTION
This settings has been removed in favor of using the primId AOV