### PR TITLE
MTOA-2265 duplicate material to USD with Arnold

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -590,9 +590,19 @@ PushExportResult pushExport(const MObject& mayaObject, const UsdMayaPrimUpdaterC
     progressBar.advance();
 
     result.srcRootPath = writeJob.MapDagPathToSdfPath(dagPath);
+
+    // If there are no correspondences, it may be due to the fact the
+    // source DAG node was excluded from the export.  In this case, try
+    // to find a material or extra prim to use as the source root path.
     if (result.srcRootPath.IsEmpty()) {
         for (const SdfPath& matPath : writeJob.GetMaterialPaths()) {
             result.srcRootPath = matPath.GetParentPath();
+            break;
+        }
+    }
+    if (result.srcRootPath.IsEmpty()) {
+        for (const SdfPath& extraPath : result.extraPrimsPaths) {
+            result.srcRootPath = extraPath;
             break;
         }
     }


### PR DESCRIPTION
If there are no entries corresponding to the source DAG path in the map, try to use one of the extra prims as the source root path.