### PR TITLE
EMSUSD-2171 Fix multiple collection UI issues

### DIFF
--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/expressionWidget.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/expressionWidget.py
@@ -41,6 +41,7 @@ class ExpressionWidget(QWidget):
         self._selectBtn.setIcon(Theme.instance().icon("selector"))
         self._selectBtn.setEnabled(False)
         self._selectBtn.clicked.connect(self._onSelectItemsClicked)
+        theme.themeMenuButton(self._selectBtn, False)
         menuLayout.addWidget(self._selectBtn)
 
         menuLayout.addStretch(1)

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/includeExcludeWidget.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/includeExcludeWidget.py
@@ -117,6 +117,7 @@ class IncludeExcludeWidget(QWidget):
         self._selectBtn.setIcon(Theme.instance().icon("selector"))
         self._selectBtn.setEnabled(False)
         self._selectBtn.clicked.connect(self._onSelectItemsClicked)
+        theme.themeMenuButton(self._selectBtn, False)
 
         self._warningWidget = WarningWidget(headerWidget)
         self._warningSeparator = QFrame()

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/includeExcludeWidget.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/includeExcludeWidget.py
@@ -206,7 +206,7 @@ class IncludeExcludeWidget(QWidget):
 
     def _hasValidSelection(self, stringList: StringListData) -> bool:
         for item in Host.instance().getSelectionAsText():
-            if stringList.convertToCollectionString(item):
+            if stringList.convertToCollectionString(item)[0]:
                 return True
         return False
     

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/filteredStringListModel.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/filteredStringListModel.py
@@ -5,11 +5,13 @@ try:
     from PySide6.QtCore import (
         QStringListModel,
         Signal,
+        Qt
     )
 except:
     from PySide2.QtCore import (
         QStringListModel,
         Signal,
+        Qt
     )
 
 
@@ -59,6 +61,20 @@ class FilteredStringListModel(QStringListModel):
                 return False
             index = newIndex + len(filter)
         return True
+    
+    def setData(self, index, value, role):
+        if role == Qt.DisplayRole or role ==  Qt.ItemDataRole:
+            oldValue = self.data(index, role)
+            value = value.strip()
+            if value:
+                self._collData.replaceStrings(oldValue, value)
+        return super(QStringListModel, self).setData(index, value, role)
+
+    def flags(self, index):
+        '''
+        Return the flags for the given index.
+        '''
+        return super(FilteredStringListModel, self).flags(index) | Qt.ItemFlag.ItemIsEditable
 
     def isFilteredEmpty(self):
         '''

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/data/stringListData.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/data/stringListData.py
@@ -1,4 +1,4 @@
-from typing import AnyStr, Sequence
+from typing import AnyStr, Sequence, Tuple
 
 try:
     from PySide6.QtCore import QObject, Signal  # type: ignore
@@ -49,7 +49,7 @@ class StringListData(QObject):
         '''
         return False
 
-    def convertToCollectionString(self, s) -> AnyStr:
+    def convertToCollectionString(self, s) -> Tuple[AnyStr, AnyStr]:
         '''
         Validates if the string is valid and possibly alter it to make it valid
         or conform to the expected format or value. Return None if invalid.
@@ -75,14 +75,14 @@ class StringListData(QObject):
 
     def _splitMultiLineStrings(self, multiLineText):
         items = []
-        reportedError = False
+        reportedError = set()
         for text in multiLineText.split("\n"):
-            text = self.convertToCollectionString(text)
+            text, error = self.convertToCollectionString(text)
             if not text:
-                if not reportedError:
-                    reportedError = True
+                if error not in reportedError:
+                    reportedError.add(error)
                     from ..common.host import Host
-                    Host.instance().reportMessage("Only objects in the same stage as the collection can be added.")
+                    Host.instance().reportMessage(error)
                 continue
             items.append(text)
 

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/validator.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/validator.py
@@ -12,7 +12,7 @@ def validatePrim(defaultReturnValue = None) -> Callable:
                 return defaultReturnValue
             try:
                 return func(self, *args, **kwargs)
-            except Exception:
+            except AttributeError:
                 return defaultReturnValue
         return wrapper
     return validator
@@ -29,7 +29,7 @@ def validateCollection(defaultReturnValue = None) -> Callable:
                 return defaultReturnValue
             try:
                 return func(self, *args, **kwargs)
-            except Exception:
+            except AttributeError:
                 return defaultReturnValue
         return wrapper
     return validator


### PR DESCRIPTION
Also addresses: EMSUSD-2168, EMSUSD-2169, EMSUSD-2171, EMSUSD-2167, EMSUSD-2151

Fix validation error:
- Make the convertToCollectionString return the cause of any error.
- Make the validator only handle the attribute error exception caused by the absence of expression support in old USD, not all exceptions.

Fix list editor:
- Replace ad-hoc code with QCompleter and QItemDelegate to edit the list items.
- This fixes multiple interaction bugs.
- Mark the filtered string list model items as being editable.
- Make sure the list view gets focus after edit.
- Make sure the new item can be added before deleting the old item in replaceStrings.
- Simplify how the stage prims are gathered for suggestions.