### PR TITLE
EMSUSD-1783 support append export of animated values

### DIFF
--- a/lib/mayaUsd/fileio/transformWriter.h
+++ b/lib/mayaUsd/fileio/transformWriter.h
@@ -152,6 +152,9 @@ private:
         const bool              writeAnim,
         const bool              worldspace);
 
+    static UsdGeomXformOp
+    findXformOp(const UsdGeomXformable& usdXformable, const _AnimChannel& animChan);
+
     void _WriteChannelsXformOps(const UsdGeomXformable& usdXForm);
 
     std::vector<_AnimChannel> _animChannels;

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_SCRIPT_FILES
     testUsdExport8BitNormalMap.py
     testUsdExportAnimation.py
+    testUsdExportAppendAnim.py
     testUsdExportAsClip.py
     testUsdExportBindTransform.py
     testUsdExportBlendshapes.py

--- a/test/lib/usd/translators/testUsdExportAppendAnim.py
+++ b/test/lib/usd/translators/testUsdExportAppendAnim.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env mayapy
+#
+# Copyright 2025 Autodesk, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import unittest
+
+from pxr import Usd
+
+from maya import cmds
+from maya import standalone
+
+import fixturesUtils
+
+class testUsdExportAppendAnim(unittest.TestCase):
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    @classmethod
+    def setUpClass(cls):
+        inputPath = fixturesUtils.setUpClass(__file__)
+
+    def _ExportFrame(self, usdFilePath, frame):
+        cmds.usdExport(mergeTransformAndShape=True,
+            file=usdFilePath,
+            exportComponentTags=False,
+            exportMaterials=False,
+            frameRange=(frame, frame),
+            append=bool(frame > 1))
+
+
+    def _AssertTimeSamples(self, stage, primName, expectedSamples):
+        cube = stage.GetPrimAtPath('/' + primName)
+        attr = cube.GetAttribute('xformOp:translate')
+        timeSamples = attr.GetTimeSamples()
+        self.assertEqual(timeSamples, expectedSamples)
+
+    def testAppendAnim(self):
+        '''
+        Tests exporting a cube with animation, appending to the same file.
+        Verify that all animation frames are in the same XformOp, not in
+        separate channel XformOps.
+        '''
+        cube = cmds.polyCube(w=2, h=2, d=2, sx=1, sy=1, sz=1)[0]
+        cmds.setKeyframe(cube + ".t")
+        cmds.currentTime(20)
+        cmds.setAttr(cube + ".translateX", 10)
+        cmds.setKeyframe(cube + ".t")
+
+        usdFilePath = os.path.abspath('UsdExportAppendAnimTest.usda')
+        for frame in range(1, 5):
+            self._ExportFrame(usdFilePath, frame)
+
+        stage = Usd.Stage.Open(usdFilePath)
+        self.assertTrue(stage)
+    
+        self._AssertTimeSamples(stage, cube, [1.0, 2.0, 3.0, 4.0])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/usd/translators/testUsdExportRoots.py
+++ b/test/lib/usd/translators/testUsdExportRoots.py
@@ -236,10 +236,8 @@ class testUsdExportRoot(unittest.TestCase):
             self.assertNotPrim(stage, '/OtherMid')
             self.assertPrim(stage, '/Mid/OtherLowest', 'Xform')
             transformUtils.assertStagePrimXforms(self, stage, '/Mid', [
-                ('xformOp:translate', (2., 0., 0.)),
-                ('xformOp:rotateXYZ', (45., 0., 0.)),
-                ('xformOp:translate:channel1', (0., 2., 0.)),
-                ('xformOp:rotateXYZ:channel1', (0., 0., 45.))])
+                ('xformOp:translate', (2., 2., 0.)),
+                ('xformOp:rotateXYZ', (45., 0., 45.))])
             transformUtils.assertStagePrimXforms(self, stage, '/Mid/Cube', [
                 ('xformOp:translate', (0., 0., 3.)),
                 ('xformOp:rotateXYZ', (0., 45., 0.))])
@@ -317,12 +315,8 @@ class testUsdExportRoot(unittest.TestCase):
             self.assertNotPrim(stage, '/OtherMid')
             self.assertNotPrim(stage, '/OtherLowest')
             transformUtils.assertStagePrimXforms(self, stage, '/Cube', [
-                ('xformOp:translate', (2., 0., 0.)),
-                ('xformOp:rotateXYZ', (45., 0., 0.)),
-                ('xformOp:translate:channel1', (0., 2., 0.)),
-                ('xformOp:rotateXYZ:channel1', (0., 0., 45.)),
-                ('xformOp:translate:channel2', (0., 0., 3.)),
-                ('xformOp:rotateXYZ:channel2', (0., 45., 0.))])
+                ('xformOp:translate', (2., 2., 3.)),
+                ('xformOp:rotateXYZ', (45., 45., 45.))])
         self.doExportImportTest(validator, root='Cube', worldspace=True)
 
     def testExportRoot_rootCube_selTop(self):

--- a/test/testUtils/transformUtils.py
+++ b/test/testUtils/transformUtils.py
@@ -58,7 +58,7 @@ def assertPrimXforms(test, prim, xforms):
         test.assertEqual(xformOpOrder[0], name)
         attr = prim.GetAttribute(name)
         test.assertIsNotNone(attr)
-        test.assertTrue(Gf.IsClose(attr.Get(), value, EPSILON))
+        test.assertTrue(Gf.IsClose(attr.Get(), value, EPSILON), "For %s Expected: %s, Got: %s" % (name, value, attr.Get()))
         # Chop off the first xofrm op for the next loop.
         xformOpOrder = xformOpOrder[1:]
 


### PR DESCRIPTION
- Combine values from multiple sources instead of creating new transform data channels when a transformation op already exists.
- This allows appending new animated values to an existing USD file.
- This also avoid breaking rig and skeleton which can combine multiple values when controlling a joint.
- Add a unit test for append-mode export with multiple animation frames.
- Adjust one unit test that expected additional transform channel: now it gets all values in the same normal transform op.
- Improve the error message for the unit test transform comparison helper function.