### PR TITLE
PrimUpdaterManager: Avoid spurious `allowTopologyMod` reference edits

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -223,7 +223,7 @@ void removeAllPullInformation(const Ufe::Path& ufePulledPath)
 //------------------------------------------------------------------------------
 //
 // Turn on the mesh flag to allow topological modifications.
-bool allowTopologyModifications(MDagPath& root)
+bool allowTopologyModificationsAfterLockNodes(MDagPath& root)
 {
     MDGModifier& dgMod = MDGModifierUndoItem::create("Allow topology modifications");
 
@@ -231,10 +231,12 @@ bool allowTopologyModifications(MDagPath& root)
     dagIt.reset(root, MItDag::kDepthFirst, MFn::kMesh);
     for (; !dagIt.isDone(); dagIt.next()) {
         MFnDependencyNode depNode(dagIt.item());
-        MPlug             topoPlug = depNode.findPlug("allowTopologyMod");
-        if (topoPlug.isNull())
-            continue;
-        dgMod.newPlugValueBool(topoPlug, true);
+        if (LockNodesUndoItem::isLockable(depNode)) {
+            MPlug topoPlug = depNode.findPlug("allowTopologyMod");
+            if (topoPlug.isNull())
+                continue;
+            dgMod.newPlugValueBool(topoPlug, true);
+        }
     }
 
     return dgMod.doIt();
@@ -1276,7 +1278,7 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
             return false;
 
         // Allow editing topology, which gets turned of by locking.
-        if (!allowTopologyModifications(pullParentPath))
+        if (!allowTopologyModificationsAfterLockNodes(pullParentPath))
             return false;
     }
     progressBar.advance();

--- a/lib/mayaUsd/undo/OpUndoItems.cpp
+++ b/lib/mayaUsd/undo/OpUndoItems.cpp
@@ -531,6 +531,9 @@ bool UfeCommandUndoItem::redo()
 
 namespace {
 
+//! Returns whether the given node might be locked by LockNodesUndoItem.
+bool isLockableNode(const MFnDependencyNode& node) { return !node.isFromReferencedFile(); }
+
 //! Lock or unlock hierarchy starting at given root.
 void lockNodes(const MDagPath& root, bool state)
 {
@@ -538,7 +541,7 @@ void lockNodes(const MDagPath& root, bool state)
     dagIt.reset(root);
     for (; !dagIt.isDone(); dagIt.next()) {
         MFnDependencyNode node(dagIt.currentItem());
-        if (node.isFromReferencedFile()) {
+        if (!isLockableNode(node)) {
             dagIt.prune();
             continue;
         }
@@ -547,6 +550,8 @@ void lockNodes(const MDagPath& root, bool state)
 }
 
 } // namespace
+
+bool LockNodesUndoItem::isLockable(const MFnDependencyNode& node) { return isLockableNode(node); }
 
 LockNodesUndoItem::LockNodesUndoItem(const std::string name, const MDagPath& root, bool lock)
     : OpUndoItem(std::move(name))

--- a/lib/mayaUsd/undo/OpUndoItems.h
+++ b/lib/mayaUsd/undo/OpUndoItems.h
@@ -541,6 +541,10 @@ private:
 class LockNodesUndoItem : public OpUndoItem
 {
 public:
+    /// \brief returns whether the given node might be locked by a lock node item.
+    MAYAUSD_CORE_PUBLIC
+    static bool isLockable(const MFnDependencyNode& node);
+
     /// \brief create and execute a lock node undo item and keep track of it.
     MAYAUSD_CORE_PUBLIC
     static bool


### PR DESCRIPTION
When editing as Maya a `mayaReference` prim, we noticed that `allowTopologyMod` attributes were being force-enabled on all referenced meshes, cluttering the reference edits list and preventing these attributes from being disabled up-front if needed. 

This PR skips these forced edits unless allowTopologyMod was really disabled by the preceding LockNodeUndoItems execution.