### PR TITLE
Add "mayaUsdSetSelectedLayers" and "mayaUsdGetSelectedLayers" layer editor hooks

### DIFF
--- a/lib/usd/ui/layerEditor/CMakeLists.txt
+++ b/lib/usd/ui/layerEditor/CMakeLists.txt
@@ -22,6 +22,10 @@ target_sources(${PROJECT_NAME}
         generatedIconButton.cpp
         layerEditorWidget.cpp
         layerEditorWidget.h
+        layerEditorWidgetManager.cpp
+        layerEditorWidgetManager.h
+        layerEditorCommands.cpp
+        layerEditorCommands.h
         layerTreeItem.cpp
         layerTreeItem.h
         layerTreeItemDelegate.cpp
@@ -70,6 +74,7 @@ target_link_libraries(${PROJECT_NAME}
 # -----------------------------------------------------------------------------
 set(HEADERS
     batchSaveLayersUIDelegate.h
+    layerEditorCommands.h
 )
 
 mayaUsd_promoteHeaderList( 

--- a/lib/usd/ui/layerEditor/layerEditorCommands.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorCommands.cpp
@@ -14,14 +14,15 @@
 // limitations under the License.
 //
 
-#include "layerEditorWidgetManager.h"
 #include "layerEditorCommands.h"
 
-#include <pxr/pxr.h>
-#include <pxr/base/tf/diagnosticLite.h>
+#include "layerEditorWidgetManager.h"
 
-#include <maya/MSyntax.h>
+#include <pxr/base/tf/diagnosticLite.h>
+#include <pxr/pxr.h>
+
 #include <maya/MArgParser.h>
+#include <maya/MSyntax.h>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -43,9 +44,8 @@ MStatus GetSelectedWidgetLayersMpxCommand::doIt(const MArgList& args)
 {
     MStatus status(MS::kSuccess);
 
-    std::vector<std::string> layers
-        = LayerEditorWidgetManager::getInstance()->getSelectedLayers();
-    MStringArray results;
+    std::vector<std::string> layers = LayerEditorWidgetManager::getInstance()->getSelectedLayers();
+    MStringArray             results;
     for (int i = 0; i < layers.size(); i++) {
         results.append(layers[i].c_str());
     }
@@ -85,7 +85,7 @@ MStatus SetSelectedWidgetLayersMpxCommand::parse(const MString& layersString)
 
 MStatus SetSelectedWidgetLayersMpxCommand::doIt(const MArgList& args)
 {
-    MStatus status(MS::kSuccess);
+    MStatus    status(MS::kSuccess);
     MArgParser argData(syntax(), args, &status);
 
     if (argData.isFlagSet("l", &status)) {

--- a/lib/usd/ui/layerEditor/layerEditorCommands.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorCommands.cpp
@@ -1,0 +1,105 @@
+//
+// Copyright 2025 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "layerEditorWidgetManager.h"
+#include "layerEditorCommands.h"
+
+#include <pxr/pxr.h>
+#include <pxr/base/tf/diagnosticLite.h>
+
+#include <maya/MSyntax.h>
+#include <maya/MArgParser.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace UsdLayerEditor {
+const MString GetSelectedWidgetLayersMpxCommand::commandName("mayaUsdGetSelectedLayers");
+
+void* GetSelectedWidgetLayersMpxCommand::creator()
+{
+    return static_cast<MPxCommand*>(new GetSelectedWidgetLayersMpxCommand());
+}
+
+MSyntax GetSelectedWidgetLayersMpxCommand::createSyntax()
+{
+    MSyntax syntax;
+    return syntax;
+}
+
+MStatus GetSelectedWidgetLayersMpxCommand::doIt(const MArgList& args)
+{
+    MStatus status(MS::kSuccess);
+
+    std::vector<std::string> layers
+        = LayerEditorWidgetManager::getInstance()->getSelectedLayers();
+    MStringArray results;
+    for (int i = 0; i < layers.size(); i++) {
+        results.append(layers[i].c_str());
+    }
+    setResult(results);
+    return status;
+};
+
+const MString SetSelectedWidgetLayersMpxCommand::commandName("mayaUsdSetSelectedLayers");
+
+void* SetSelectedWidgetLayersMpxCommand::creator()
+{
+    return static_cast<MPxCommand*>(new SetSelectedWidgetLayersMpxCommand());
+}
+
+MSyntax SetSelectedWidgetLayersMpxCommand::createSyntax()
+{
+    MSyntax syntax;
+    syntax.addFlag(kLayersFlag, kLayersFlagLong, MSyntax::kString);
+    return syntax;
+}
+
+MStatus SetSelectedWidgetLayersMpxCommand::parse(const MString& layersString)
+{
+    MStatus status = MS::kSuccess;
+
+    if (layersString.length() > 0) {
+        int i, length;
+        MStringArray layersList;
+        layersString.split(';', layersList); // break out all the layers
+
+        length = layersList.length();
+        for (i = 0; i < length; ++i) {
+            layers.emplace_back(layersList[i].asChar());
+        }
+    }
+    return status;
+}
+
+MStatus SetSelectedWidgetLayersMpxCommand::doIt(const MArgList& args)
+{
+    MStatus status(MS::kSuccess);
+    MArgParser argData(syntax(), args, &status);
+
+    if (argData.isFlagSet("l", &status)) {
+        MString layersString;
+        argData.getFlagArgument(kLayersFlag, 0, layersString);
+        parse(layersString);
+    } else {
+        TF_RUNTIME_ERROR("-layers not specified.");
+        return MS::kFailure;
+    }
+
+    LayerEditorWidgetManager::getInstance()->selectLayers(layers);
+
+    return status;
+};
+} // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/layerEditorCommands.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorCommands.cpp
@@ -46,8 +46,8 @@ MStatus GetSelectedWidgetLayersMpxCommand::doIt(const MArgList& args)
 
     std::vector<std::string> layers = LayerEditorWidgetManager::getInstance()->getSelectedLayers();
     MStringArray             results;
-    for (int i = 0; i < layers.size(); i++) {
-        results.append(layers[i].c_str());
+    for (const auto& layer : layers) {
+        results.append(layer.c_str());
     }
     setResult(results);
     return status;
@@ -75,8 +75,8 @@ MStatus SetSelectedWidgetLayersMpxCommand::parse(const MString& layersString)
         MStringArray layersList;
         layersString.split(';', layersList); // break out all the layers
 
-        int length = layersList.length();
-        for (int i = 0; i < length; ++i) {
+        unsigned int length = layersList.length();
+        for (unsigned int i = 0; i < length; ++i) {
             layers.emplace_back(layersList[i].asChar());
         }
     }

--- a/lib/usd/ui/layerEditor/layerEditorCommands.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorCommands.cpp
@@ -77,7 +77,7 @@ MStatus SetSelectedWidgetLayersMpxCommand::parse(const MString& layersString)
 
         unsigned int length = layersList.length();
         for (unsigned int i = 0; i < length; ++i) {
-            layers.emplace_back(layersList[i].asChar());
+            _layers.emplace_back(layersList[i].asChar());
         }
     }
     return status;
@@ -97,7 +97,7 @@ MStatus SetSelectedWidgetLayersMpxCommand::doIt(const MArgList& args)
         return MS::kFailure;
     }
 
-    LayerEditorWidgetManager::getInstance()->selectLayers(layers);
+    LayerEditorWidgetManager::getInstance()->selectLayers(_layers);
 
     return status;
 };

--- a/lib/usd/ui/layerEditor/layerEditorCommands.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorCommands.cpp
@@ -22,8 +22,8 @@
 #include <pxr/pxr.h>
 
 #include <maya/MArgParser.h>
-#include <maya/MSyntax.h>
 #include <maya/MStringArray.h>
+#include <maya/MSyntax.h>
 
 namespace UsdLayerEditor {
 const MString GetSelectedWidgetLayersMpxCommand::commandName("mayaUsdGetSelectedLayers");

--- a/lib/usd/ui/layerEditor/layerEditorCommands.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorCommands.cpp
@@ -23,8 +23,7 @@
 
 #include <maya/MArgParser.h>
 #include <maya/MSyntax.h>
-
-PXR_NAMESPACE_USING_DIRECTIVE
+#include <maya/MStringArray.h>
 
 namespace UsdLayerEditor {
 const MString GetSelectedWidgetLayersMpxCommand::commandName("mayaUsdGetSelectedLayers");
@@ -85,6 +84,8 @@ MStatus SetSelectedWidgetLayersMpxCommand::parse(const MString& layersString)
 
 MStatus SetSelectedWidgetLayersMpxCommand::doIt(const MArgList& args)
 {
+    PXR_NAMESPACE_USING_DIRECTIVE
+
     MStatus    status(MS::kSuccess);
     MArgParser argData(syntax(), args, &status);
 

--- a/lib/usd/ui/layerEditor/layerEditorCommands.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorCommands.cpp
@@ -72,12 +72,11 @@ MStatus SetSelectedWidgetLayersMpxCommand::parse(const MString& layersString)
     MStatus status = MS::kSuccess;
 
     if (layersString.length() > 0) {
-        int i, length;
         MStringArray layersList;
         layersString.split(';', layersList); // break out all the layers
 
-        length = layersList.length();
-        for (i = 0; i < length; ++i) {
+        int length = layersList.length();
+        for (int i = 0; i < length; ++i) {
             layers.emplace_back(layersList[i].asChar());
         }
     }

--- a/lib/usd/ui/layerEditor/layerEditorCommands.h
+++ b/lib/usd/ui/layerEditor/layerEditorCommands.h
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
 
 #include <mayaUsdUI/ui/api.h>
 
@@ -61,7 +60,7 @@ public:
     MStatus parse(const MString& layersString);
 
 private:
-    std::vector<std::string> layers;
+    std::vector<std::string> _layers;
     static constexpr auto    kLayersFlag = "l";
     static constexpr auto    kLayersFlagLong = "layers";
 };

--- a/lib/usd/ui/layerEditor/layerEditorCommands.h
+++ b/lib/usd/ui/layerEditor/layerEditorCommands.h
@@ -19,6 +19,8 @@
 
 #include <maya/MPxCommand.h>
 
+#include <vector>
+
 namespace UsdLayerEditor {
 
 /**

--- a/lib/usd/ui/layerEditor/layerEditorCommands.h
+++ b/lib/usd/ui/layerEditor/layerEditorCommands.h
@@ -1,0 +1,67 @@
+//
+// Copyright 2025 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <mayaUsdUI/ui/api.h>
+
+#include <maya/MPxCommand.h>
+
+
+namespace UsdLayerEditor {
+
+    /**
+     * @brief Class that defines the "mayaUsdGetSelectedLayers" MEL command.
+     *
+     * This command allows the user to query the selected layers (i.e. selected rows)
+     * in the layer editor widget.
+     **/
+    class MAYAUSD_UI_PUBLIC GetSelectedWidgetLayersMpxCommand : public MPxCommand
+    {
+    public:
+        // plugin registration requirements
+        static const MString commandName;
+        static void* creator();
+        static MSyntax    createSyntax();
+
+        MStatus doIt(const MArgList& args) override;
+        bool    isUndoable() const override { return false; }
+    };
+
+    /**
+     * @brief Class that defines the "mayaUsdSetSelectedLayers -l 'layer_id_1;layer_id_2" MEL command.
+     *
+     * This command allows the user to set the selected layers (i.e. selected rows)
+     * in the layer editor widget.
+     **/
+    class MAYAUSD_UI_PUBLIC SetSelectedWidgetLayersMpxCommand : public MPxCommand
+    {
+    public:
+        // plugin registration requirements
+        static const MString commandName;
+        static void*         creator();
+        static MSyntax       createSyntax();
+
+        MStatus doIt(const MArgList& args) override;
+        bool    isUndoable() const override { return false; }
+
+        MStatus parse(const MString& layersString);
+    private:
+        std::vector<std::string> layers;
+        static constexpr auto    kLayersFlag = "l";
+        static constexpr auto    kLayersFlagLong = "layers";
+    };
+
+} // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/layerEditorCommands.h
+++ b/lib/usd/ui/layerEditor/layerEditorCommands.h
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+#ifndef LAYER_EDITOR_COMMANDS_H
+#define LAYER_EDITOR_COMMANDS_H
 
 #include <mayaUsdUI/ui/api.h>
 
@@ -66,3 +68,5 @@ private:
 };
 
 } // namespace UsdLayerEditor
+
+#endif //LAYER_EDITOR_COMMANDS_H

--- a/lib/usd/ui/layerEditor/layerEditorCommands.h
+++ b/lib/usd/ui/layerEditor/layerEditorCommands.h
@@ -19,49 +19,49 @@
 
 #include <maya/MPxCommand.h>
 
-
 namespace UsdLayerEditor {
 
-    /**
-     * @brief Class that defines the "mayaUsdGetSelectedLayers" MEL command.
-     *
-     * This command allows the user to query the selected layers (i.e. selected rows)
-     * in the layer editor widget.
-     **/
-    class MAYAUSD_UI_PUBLIC GetSelectedWidgetLayersMpxCommand : public MPxCommand
-    {
-    public:
-        // plugin registration requirements
-        static const MString commandName;
-        static void* creator();
-        static MSyntax    createSyntax();
+/**
+ * @brief Class that defines the "mayaUsdGetSelectedLayers" MEL command.
+ *
+ * This command allows the user to query the selected layers (i.e. selected rows)
+ * in the layer editor widget.
+ **/
+class MAYAUSD_UI_PUBLIC GetSelectedWidgetLayersMpxCommand : public MPxCommand
+{
+public:
+    // plugin registration requirements
+    static const MString commandName;
+    static void*         creator();
+    static MSyntax       createSyntax();
 
-        MStatus doIt(const MArgList& args) override;
-        bool    isUndoable() const override { return false; }
-    };
+    MStatus doIt(const MArgList& args) override;
+    bool    isUndoable() const override { return false; }
+};
 
-    /**
-     * @brief Class that defines the "mayaUsdSetSelectedLayers -l 'layer_id_1;layer_id_2" MEL command.
-     *
-     * This command allows the user to set the selected layers (i.e. selected rows)
-     * in the layer editor widget.
-     **/
-    class MAYAUSD_UI_PUBLIC SetSelectedWidgetLayersMpxCommand : public MPxCommand
-    {
-    public:
-        // plugin registration requirements
-        static const MString commandName;
-        static void*         creator();
-        static MSyntax       createSyntax();
+/**
+ * @brief Class that defines the "mayaUsdSetSelectedLayers -l 'layer_id_1;layer_id_2" MEL command.
+ *
+ * This command allows the user to set the selected layers (i.e. selected rows)
+ * in the layer editor widget.
+ **/
+class MAYAUSD_UI_PUBLIC SetSelectedWidgetLayersMpxCommand : public MPxCommand
+{
+public:
+    // plugin registration requirements
+    static const MString commandName;
+    static void*         creator();
+    static MSyntax       createSyntax();
 
-        MStatus doIt(const MArgList& args) override;
-        bool    isUndoable() const override { return false; }
+    MStatus doIt(const MArgList& args) override;
+    bool    isUndoable() const override { return false; }
 
-        MStatus parse(const MString& layersString);
-    private:
-        std::vector<std::string> layers;
-        static constexpr auto    kLayersFlag = "l";
-        static constexpr auto    kLayersFlagLong = "layers";
-    };
+    MStatus parse(const MString& layersString);
+
+private:
+    std::vector<std::string> layers;
+    static constexpr auto    kLayersFlag = "l";
+    static constexpr auto    kLayersFlagLong = "layers";
+};
 
 } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/layerEditorCommands.h
+++ b/lib/usd/ui/layerEditor/layerEditorCommands.h
@@ -69,4 +69,4 @@ private:
 
 } // namespace UsdLayerEditor
 
-#endif //LAYER_EDITOR_COMMANDS_H
+#endif // LAYER_EDITOR_COMMANDS_H

--- a/lib/usd/ui/layerEditor/layerEditorWidget.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.cpp
@@ -16,9 +16,9 @@
 
 #include "layerEditorWidget.h"
 
-#include "layerEditorWidgetManager.h"
 #include "abstractCommandHook.h"
 #include "dirtyLayersCountBadge.h"
+#include "layerEditorWidgetManager.h"
 #include "layerTreeModel.h"
 #include "layerTreeView.h"
 #include "qtUtils.h"
@@ -40,6 +40,7 @@
 #endif
 
 #include <usdUfe/ufe/Utils.h>
+
 #include <QtWidgets/QGraphicsOpacityEffect>
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QMainWindow>

--- a/lib/usd/ui/layerEditor/layerEditorWidget.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.cpp
@@ -368,7 +368,6 @@ void LayerEditorWidget::onLoadLayersButtonClicked()
         layerTreeItem = model->layerItemFromIndex(selection[0]);
     }
     layerTreeItem->loadSubLayers(this);
-    layerTreeItem->loadSubLayers(this);
 }
 
 void LayerEditorWidget::onSaveStageButtonClicked() { _treeView->layerTreeModel()->saveStage(this); }

--- a/lib/usd/ui/layerEditor/layerEditorWidget.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.cpp
@@ -16,6 +16,7 @@
 
 #include "layerEditorWidget.h"
 
+#include "layerEditorWidgetManager.h"
 #include "abstractCommandHook.h"
 #include "dirtyLayersCountBadge.h"
 #include "layerTreeModel.h"
@@ -38,6 +39,7 @@
 #include <QtWidgets/QActionGroup>
 #endif
 
+#include <usdUfe/ufe/Utils.h>
 #include <QtWidgets/QGraphicsOpacityEffect>
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QMainWindow>
@@ -53,6 +55,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 namespace {
 
 using namespace UsdLayerEditor;
+class LayerEditorWidgetManager;
 
 // create the default menus on the parent QMainWindow
 void setupDefaultMenu(SessionState* in_sessionState, QMainWindow* in_parent)
@@ -97,6 +100,8 @@ LayerEditorWidget::LayerEditorWidget(SessionState& in_sessionState, QMainWindow*
 {
     setupLayout();
     ::setupDefaultMenu(&in_sessionState, in_parent);
+    auto layerEditorManager = LayerEditorWidgetManager::getInstance();
+    layerEditorManager->setWidget(this);
 }
 
 // helper for setupLayout
@@ -149,6 +154,13 @@ QLayout* LayerEditorWidget::setupLayout_toolbar()
         &QItemSelectionModel::selectionChanged,
         this,
         &LayerEditorWidget::updateNewLayerButton);
+
+    // send callback notification to usdufe when selection changes
+    connect(
+        _treeView->selectionModel(),
+        &QItemSelectionModel::selectionChanged,
+        this,
+        &LayerEditorWidget::onSelectionChanged);
 
     _buttons._loadLayer = addHIGButton(
         ":/UsdLayerEditor/LE_import_layer",
@@ -346,9 +358,9 @@ void LayerEditorWidget::onNewLayerButtonClicked()
 
 void LayerEditorWidget::onLoadLayersButtonClicked()
 {
-    auto           model = _treeView->layerTreeModel();
-    auto           selectionModel = _treeView->selectionModel();
-    auto           selection = selectionModel->selectedRows();
+    const auto     model = _treeView->layerTreeModel();
+    const auto     selectionModel = _treeView->selectionModel();
+    const auto     selection = selectionModel->selectedRows();
     LayerTreeItem* layerTreeItem;
     if (selection.size() == 0) {
         layerTreeItem = model->layerItemFromIndex(model->rootLayerIndex());
@@ -356,8 +368,64 @@ void LayerEditorWidget::onLoadLayersButtonClicked()
         layerTreeItem = model->layerItemFromIndex(selection[0]);
     }
     layerTreeItem->loadSubLayers(this);
+    layerTreeItem->loadSubLayers(this);
 }
 
 void LayerEditorWidget::onSaveStageButtonClicked() { _treeView->layerTreeModel()->saveStage(this); }
+
+void LayerEditorWidget::onSelectionChanged(
+    const QItemSelection& selected,
+    const QItemSelection& deselected)
+{
+    if (!UsdUfe::isUICallbackRegistered(TfToken("onLayerEditorSelectionChanged"))) {
+        return;
+    }
+
+    const std::vector<std::string> selectedLayerIDs = getSelectedLayers();
+
+    PXR_NS::VtDictionary callbackContext;
+    callbackContext["objectPath"]
+        = PXR_NS::VtValue(UsdUfe::stagePath(_sessionState.stageEntry()._stage).string().c_str());
+    PXR_NS::VtDictionary callbackData;
+
+    VtStringArray layerIds(selectedLayerIDs.begin(), selectedLayerIDs.end());
+    callbackData["layerIds"] = layerIds;
+
+    UsdUfe::triggerUICallback(
+        TfToken("onLayerEditorSelectionChanged"), callbackContext, callbackData);
+}
+
+std::vector<std::string> LayerEditorWidget::getSelectedLayers()
+{
+    const auto               model = _treeView->layerTreeModel();
+    const auto               selectionModel = _treeView->selectionModel();
+    const auto               selection = selectionModel->selectedRows();
+    std::vector<std::string> selectedLayerIDs;
+    for (int i = 0; i < selection.size(); ++i) {
+        selectedLayerIDs.emplace_back(
+            model->layerItemFromIndex(selection[i])->layer()->GetIdentifier());
+    }
+
+    return selectedLayerIDs;
+}
+
+void LayerEditorWidget::selectLayers(const std::vector<std::string>& layerIdentifiers)
+{
+    const auto model = _treeView->layerTreeModel();
+    const auto selectionModel = _treeView->selectionModel();
+
+    // clear selection first
+    selectionModel->clearSelection();
+
+    // apply selection if layer exists in stage
+    for (const auto& layerId : layerIdentifiers) {
+        const auto sdfLayer = SdfLayer::Find(layerId);
+        if (sdfLayer) {
+            if (const auto item = model->findUSDLayerItem(sdfLayer)) {
+                selectionModel->select(item->index(), QItemSelectionModel::Select);
+            }
+        }
+    }
+}
 
 } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/layerEditorWidget.h
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.h
@@ -53,7 +53,7 @@ public Q_SLOTS:
     void updateButtonsOnIdle();
 
 public:
-    LayerTreeView* layerTree() { return _treeView.data(); }
+    LayerTreeView*           layerTree() { return _treeView.data(); }
     std::vector<std::string> getSelectedLayers();
     void                     selectLayers(const std::vector<std::string>& layerIdentifiers);
 

--- a/lib/usd/ui/layerEditor/layerEditorWidget.h
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.h
@@ -54,6 +54,8 @@ public Q_SLOTS:
 
 public:
     LayerTreeView* layerTree() { return _treeView.data(); }
+    std::vector<std::string> getSelectedLayers();
+    void                     selectLayers(const std::vector<std::string>& layerIdentifiers);
 
 protected:
     void          setupLayout();
@@ -68,6 +70,8 @@ protected:
     } _buttons;
     void updateNewLayerButton();
     void updateButtons();
+
+    void onSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
 
     QPointer<LayerTreeView> _treeView;
 

--- a/lib/usd/ui/layerEditor/layerEditorWidgetManager.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidgetManager.cpp
@@ -15,6 +15,7 @@
 //
 
 #include "layerEditorWidgetManager.h"
+
 #include "layerEditorWidget.h"
 
 #include <maya/MSyntax.h>
@@ -23,52 +24,51 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace UsdLayerEditor {
 
-    std::unique_ptr<LayerEditorWidgetManager> LayerEditorWidgetManager::instance;
+std::unique_ptr<LayerEditorWidgetManager> LayerEditorWidgetManager::instance;
 
-    LayerEditorWidgetManager::LayerEditorWidgetManager()
-        : layerWidgetInstance(nullptr)
-    {
+LayerEditorWidgetManager::LayerEditorWidgetManager()
+    : layerWidgetInstance(nullptr)
+{
+}
+
+LayerEditorWidgetManager* LayerEditorWidgetManager::getInstance()
+{
+    if (!instance) {
+        instance = std::unique_ptr<LayerEditorWidgetManager>(new LayerEditorWidgetManager);
+    }
+    return instance.get();
+}
+
+void LayerEditorWidgetManager::setWidget(LayerEditorWidget* widget)
+{
+    if (layerWidgetInstance != nullptr) {
+        TF_WARN("LayerEditorWidgetManager already has a LayerEditorWidget set. Overriding "
+                "previously set widget.");
+    }
+    layerWidgetInstance = widget;
+}
+
+std::vector<std::string> LayerEditorWidgetManager::getSelectedLayers()
+{
+    std::vector<std::string> selLayers;
+    if (layerWidgetInstance) {
+        selLayers = layerWidgetInstance->getSelectedLayers();
+    } else {
+        TF_CODING_ERROR(
+            "No LayerEditorWidget set in the LayerEditorWidgetManager. No layers to retrieve.");
     }
 
-    LayerEditorWidgetManager* LayerEditorWidgetManager::getInstance()
-    {
-        if (!instance) {
-            instance = std::unique_ptr<LayerEditorWidgetManager>(new LayerEditorWidgetManager);
-        }
-        return instance.get();
+    return selLayers;
+}
+
+void LayerEditorWidgetManager::selectLayers(std::vector<std::string> layerIds)
+{
+    if (layerWidgetInstance) {
+        layerWidgetInstance->selectLayers(layerIds);
+    } else {
+        TF_CODING_ERROR(
+            "No LayerEditorWidget set in the LayerEditorWidgetManager. Layers cannot be selected.");
     }
+}
 
-    void LayerEditorWidgetManager::setWidget(LayerEditorWidget* widget)
-    {
-        if (layerWidgetInstance != nullptr) {
-            TF_WARN("LayerEditorWidgetManager already has a LayerEditorWidget set. Overriding previously set widget.");
-        }
-        layerWidgetInstance = widget;
-    }
-
-    std::vector<std::string> LayerEditorWidgetManager::getSelectedLayers()
-    {
-        std::vector<std::string> selLayers;
-        if (layerWidgetInstance) {
-            selLayers = layerWidgetInstance->getSelectedLayers();
-        }
-        else {
-            TF_CODING_ERROR(
-                "No LayerEditorWidget set in the LayerEditorWidgetManager. No layers to retrieve.");
-        }
-
-        return selLayers;
-    }
-
-    void LayerEditorWidgetManager::selectLayers(std::vector<std::string> layerIds)
-    {
-        if (layerWidgetInstance) {
-            layerWidgetInstance->selectLayers(layerIds);
-        }
-        else {
-            TF_CODING_ERROR(
-                "No LayerEditorWidget set in the LayerEditorWidgetManager. Layers cannot be selected.");
-        }
-    }
-
-    } // namespace UsdLayerEditor
+} // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/layerEditorWidgetManager.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidgetManager.cpp
@@ -1,0 +1,74 @@
+//
+// Copyright 2025 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "layerEditorWidgetManager.h"
+#include "layerEditorWidget.h"
+
+#include <maya/MSyntax.h>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace UsdLayerEditor {
+
+    std::unique_ptr<LayerEditorWidgetManager> LayerEditorWidgetManager::instance;
+
+    LayerEditorWidgetManager::LayerEditorWidgetManager()
+        : layerWidgetInstance(nullptr)
+    {
+    }
+
+    LayerEditorWidgetManager* LayerEditorWidgetManager::getInstance()
+    {
+        if (!instance) {
+            instance = std::unique_ptr<LayerEditorWidgetManager>(new LayerEditorWidgetManager);
+        }
+        return instance.get();
+    }
+
+    void LayerEditorWidgetManager::setWidget(LayerEditorWidget* widget)
+    {
+        if (layerWidgetInstance != nullptr) {
+            TF_WARN("LayerEditorWidgetManager already has a LayerEditorWidget set. Overriding previously set widget.");
+        }
+        layerWidgetInstance = widget;
+    }
+
+    std::vector<std::string> LayerEditorWidgetManager::getSelectedLayers()
+    {
+        std::vector<std::string> selLayers;
+        if (layerWidgetInstance) {
+            selLayers = layerWidgetInstance->getSelectedLayers();
+        }
+        else {
+            TF_CODING_ERROR(
+                "No LayerEditorWidget set in the LayerEditorWidgetManager. No layers to retrieve.");
+        }
+
+        return selLayers;
+    }
+
+    void LayerEditorWidgetManager::selectLayers(std::vector<std::string> layerIds)
+    {
+        if (layerWidgetInstance) {
+            layerWidgetInstance->selectLayers(layerIds);
+        }
+        else {
+            TF_CODING_ERROR(
+                "No LayerEditorWidget set in the LayerEditorWidgetManager. Layers cannot be selected.");
+        }
+    }
+
+    } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/layerEditorWidgetManager.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidgetManager.cpp
@@ -18,13 +18,9 @@
 
 #include "layerEditorWidget.h"
 
-#include <maya/MSyntax.h>
-
-PXR_NAMESPACE_USING_DIRECTIVE
-
 namespace UsdLayerEditor {
 
-std::unique_ptr<LayerEditorWidgetManager> LayerEditorWidgetManager::_instance;
+std::unique_ptr<LayerEditorWidgetManager> LayerEditorWidgetManager::instance;
 
 LayerEditorWidgetManager::LayerEditorWidgetManager()
     : _layerWidgetInstance(nullptr)
@@ -33,10 +29,10 @@ LayerEditorWidgetManager::LayerEditorWidgetManager()
 
 LayerEditorWidgetManager* LayerEditorWidgetManager::getInstance()
 {
-    if (!_instance) {
-        _instance = std::unique_ptr<LayerEditorWidgetManager>(new LayerEditorWidgetManager);
+    if (!instance) {
+        instance = std::unique_ptr<LayerEditorWidgetManager>(new LayerEditorWidgetManager);
     }
-    return _instance.get();
+    return instance.get();
 }
 
 void LayerEditorWidgetManager::setWidget(LayerEditorWidget* widget)

--- a/lib/usd/ui/layerEditor/layerEditorWidgetManager.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidgetManager.cpp
@@ -24,35 +24,35 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace UsdLayerEditor {
 
-std::unique_ptr<LayerEditorWidgetManager> LayerEditorWidgetManager::instance;
+std::unique_ptr<LayerEditorWidgetManager> LayerEditorWidgetManager::_instance;
 
 LayerEditorWidgetManager::LayerEditorWidgetManager()
-    : layerWidgetInstance(nullptr)
+    : _layerWidgetInstance(nullptr)
 {
 }
 
 LayerEditorWidgetManager* LayerEditorWidgetManager::getInstance()
 {
-    if (!instance) {
-        instance = std::unique_ptr<LayerEditorWidgetManager>(new LayerEditorWidgetManager);
+    if (!_instance) {
+        _instance = std::unique_ptr<LayerEditorWidgetManager>(new LayerEditorWidgetManager);
     }
-    return instance.get();
+    return _instance.get();
 }
 
 void LayerEditorWidgetManager::setWidget(LayerEditorWidget* widget)
 {
-    if (layerWidgetInstance != nullptr) {
+    if (_layerWidgetInstance != nullptr) {
         TF_WARN("LayerEditorWidgetManager already has a LayerEditorWidget set. Overriding "
                 "previously set widget.");
     }
-    layerWidgetInstance = widget;
+    _layerWidgetInstance = widget;
 }
 
 std::vector<std::string> LayerEditorWidgetManager::getSelectedLayers()
 {
     std::vector<std::string> selLayers;
-    if (layerWidgetInstance) {
-        selLayers = layerWidgetInstance->getSelectedLayers();
+    if (_layerWidgetInstance) {
+        selLayers = _layerWidgetInstance->getSelectedLayers();
     } else {
         TF_CODING_ERROR(
             "No LayerEditorWidget set in the LayerEditorWidgetManager. No layers to retrieve.");
@@ -63,8 +63,8 @@ std::vector<std::string> LayerEditorWidgetManager::getSelectedLayers()
 
 void LayerEditorWidgetManager::selectLayers(std::vector<std::string> layerIds)
 {
-    if (layerWidgetInstance) {
-        layerWidgetInstance->selectLayers(layerIds);
+    if (_layerWidgetInstance) {
+        _layerWidgetInstance->selectLayers(layerIds);
     } else {
         TF_CODING_ERROR(
             "No LayerEditorWidget set in the LayerEditorWidgetManager. Layers cannot be selected.");

--- a/lib/usd/ui/layerEditor/layerEditorWidgetManager.h
+++ b/lib/usd/ui/layerEditor/layerEditorWidgetManager.h
@@ -41,8 +41,8 @@ public:
 private:
     LayerEditorWidgetManager();
 
-    QPointer<LayerEditorWidget>                      layerWidgetInstance;
-    static std::unique_ptr<LayerEditorWidgetManager> instance;
+    QPointer<LayerEditorWidget>                      _layerWidgetInstance;
+    static std::unique_ptr<LayerEditorWidgetManager> _instance;
 };
 
 } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/layerEditorWidgetManager.h
+++ b/lib/usd/ui/layerEditor/layerEditorWidgetManager.h
@@ -46,4 +46,4 @@ private:
 
 } // namespace UsdLayerEditor
 
-#endif //LAYER_EDITOR_WIDGETMANAGER_H
+#endif // LAYER_EDITOR_WIDGETMANAGER_H

--- a/lib/usd/ui/layerEditor/layerEditorWidgetManager.h
+++ b/lib/usd/ui/layerEditor/layerEditorWidgetManager.h
@@ -1,0 +1,48 @@
+//
+// Copyright 2025 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <QtCore/QPointer>
+
+#include <maya/MStringArray.h>
+
+
+namespace UsdLayerEditor {
+    class LayerEditorWidget;
+
+    /**
+     * @brief Lightweight LayerEditorWidget manager class, created to have an minimal interface between dll boundaries
+     * (in particular, for the _UsdLayerEditor project's code that creates python bindings for accessing data in the widget)
+     **/
+    class LayerEditorWidgetManager
+    {
+    public:
+        ~LayerEditorWidgetManager() = default;
+
+        static LayerEditorWidgetManager* getInstance();
+        void                             setWidget(LayerEditorWidget* widget);
+
+        std::vector<std::string> getSelectedLayers();
+        void               selectLayers(std::vector<std::string> layerIds);
+
+    private:
+        LayerEditorWidgetManager();
+
+        QPointer<LayerEditorWidget>      layerWidgetInstance;
+        static std::unique_ptr<LayerEditorWidgetManager> instance;
+    };
+
+} // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/layerEditorWidgetManager.h
+++ b/lib/usd/ui/layerEditor/layerEditorWidgetManager.h
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#pragma once
-
-#include <maya/MStringArray.h>
-
 #include <QtCore/QPointer>
 
 namespace UsdLayerEditor {
@@ -42,7 +38,7 @@ private:
     LayerEditorWidgetManager();
 
     QPointer<LayerEditorWidget>                      _layerWidgetInstance;
-    static std::unique_ptr<LayerEditorWidgetManager> _instance;
+    static std::unique_ptr<LayerEditorWidgetManager> instance;
 };
 
 } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/layerEditorWidgetManager.h
+++ b/lib/usd/ui/layerEditor/layerEditorWidgetManager.h
@@ -13,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+#ifndef LAYER_EDITOR_WIDGETMANAGER_H
+#define LAYER_EDITOR_WIDGETMANAGER_H
+
 #include <QtCore/QPointer>
 
 namespace UsdLayerEditor {
@@ -42,3 +45,5 @@ private:
 };
 
 } // namespace UsdLayerEditor
+
+#endif //LAYER_EDITOR_WIDGETMANAGER_H

--- a/lib/usd/ui/layerEditor/layerEditorWidgetManager.h
+++ b/lib/usd/ui/layerEditor/layerEditorWidgetManager.h
@@ -15,34 +15,34 @@
 //
 #pragma once
 
-#include <QtCore/QPointer>
-
 #include <maya/MStringArray.h>
 
+#include <QtCore/QPointer>
 
 namespace UsdLayerEditor {
-    class LayerEditorWidget;
+class LayerEditorWidget;
 
-    /**
-     * @brief Lightweight LayerEditorWidget manager class, created to have an minimal interface between dll boundaries
-     * (in particular, for the _UsdLayerEditor project's code that creates python bindings for accessing data in the widget)
-     **/
-    class LayerEditorWidgetManager
-    {
-    public:
-        ~LayerEditorWidgetManager() = default;
+/**
+ * @brief Lightweight LayerEditorWidget manager class, created to have an minimal interface between
+ *dll boundaries (in particular, for the _UsdLayerEditor project's code that creates python bindings
+ *for accessing data in the widget)
+ **/
+class LayerEditorWidgetManager
+{
+public:
+    ~LayerEditorWidgetManager() = default;
 
-        static LayerEditorWidgetManager* getInstance();
-        void                             setWidget(LayerEditorWidget* widget);
+    static LayerEditorWidgetManager* getInstance();
+    void                             setWidget(LayerEditorWidget* widget);
 
-        std::vector<std::string> getSelectedLayers();
-        void               selectLayers(std::vector<std::string> layerIds);
+    std::vector<std::string> getSelectedLayers();
+    void                     selectLayers(std::vector<std::string> layerIds);
 
-    private:
-        LayerEditorWidgetManager();
+private:
+    LayerEditorWidgetManager();
 
-        QPointer<LayerEditorWidget>      layerWidgetInstance;
-        static std::unique_ptr<LayerEditorWidgetManager> instance;
-    };
+    QPointer<LayerEditorWidget>                      layerWidgetInstance;
+    static std::unique_ptr<LayerEditorWidgetManager> instance;
+};
 
 } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/layerTreeModel.h
+++ b/lib/usd/ui/layerEditor/layerTreeModel.h
@@ -113,6 +113,8 @@ public:
     // for debugging
     void forceRefresh() { rebuildModelOnIdle(); }
 
+    LayerTreeItem* findUSDLayerItem(const PXR_NS::SdfLayerRefPtr& usdLayer) const;
+
 Q_SIGNALS:
     void selectLayerSignal(const QModelIndex&);
 
@@ -142,8 +144,6 @@ protected:
     void rebuildModel(bool refreshLockState = false);
 
     void updateTargetLayer(InRebuildModel inRebuild);
-
-    LayerTreeItem* findUSDLayerItem(const PXR_NS::SdfLayerRefPtr& usdLayer) const;
 };
 
 } // namespace UsdLayerEditor

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -385,6 +385,8 @@ MStatus uninitializePlugin(MObject obj)
     deregisterCommandCheck<MayaUsd::ADSKMayaUSDImportCommand>(plugin);
     deregisterCommandCheck<MayaUsd::EditTargetCommand>(plugin);
     deregisterCommandCheck<MayaUsd::LayerEditorCommand>(plugin);
+    deregisterCommandCheck<UsdLayerEditor::GetSelectedWidgetLayersMpxCommand>(plugin);
+    deregisterCommandCheck<UsdLayerEditor::SetSelectedWidgetLayersMpxCommand>(plugin);
     deregisterCommandCheck<MayaUsd::SchemaCommand>(plugin);
     deregisterCommandCheck<MayaUsd::MayaUsdInfoCommand>(plugin);
 #if defined(WANT_QT_BUILD)

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -75,6 +75,7 @@
 #if defined(WANT_QT_BUILD)
 #include <mayaUsdUI/ui/USDImportDialogCmd.h>
 #include <mayaUsdUI/ui/initStringResources.h>
+#include <mayaUsdUI/ui/layerEditorCommands.h>
 #endif
 
 #ifdef UFE_V3_FEATURES_AVAILABLE
@@ -181,6 +182,8 @@ MStatus initializePlugin(MObject obj)
     registerCommandCheck<MayaUsd::ADSKMayaUSDImportCommand>(plugin);
     registerCommandCheck<MayaUsd::EditTargetCommand>(plugin);
     registerCommandCheck<MayaUsd::LayerEditorCommand>(plugin);
+    registerCommandCheck<UsdLayerEditor::GetSelectedWidgetLayersMpxCommand>(plugin);
+    registerCommandCheck<UsdLayerEditor::SetSelectedWidgetLayersMpxCommand>(plugin);
     registerCommandCheck<MayaUsd::SchemaCommand>(plugin);
     registerCommandCheck<MayaUsd::MayaUsdInfoCommand>(plugin);
 #if defined(WANT_QT_BUILD)


### PR DESCRIPTION
Add "mayaUsdSetSelectedLayers" and "mayaUsdGetSelectedLayers" layer editor hooks.

Also add a new usdUfe ui notification: "onLayerEditorSelectionChanged"

Note the Manager class does not do much, but it was needed on the 3dsMax to be able to decouple the QT from the python boost wrappers, otherwise boost python was complaining about QT classes not being fully defined in Python.Boost.