### PR TITLE
EMSUSD-2199 - Fixes a performance issue regarding findGatwayItems() / cameras

### DIFF
--- a/lib/mayaUsd/ufe/UsdStageMap.h
+++ b/lib/mayaUsd/ufe/UsdStageMap.h
@@ -28,6 +28,7 @@
 #include <ufe/path.h>
 
 #include <unordered_map>
+#include <vector>
 
 // Pending rework of mayaUsd namespaces, MayaUsdProxyShapeBase is in the Pixar
 // namespace.  PPT, 9-Mar-2021.
@@ -82,6 +83,12 @@ public:
 
     //! Return all the USD stages.
     StageSet allStages();
+
+    //! Return all the USD stage paths.
+    std::vector<Ufe::Path> allStagesPaths();
+
+    //! Returns true if the a stage with the given path exists, returns false otherwise.
+    bool isInStagesCache(const Ufe::Path& path);
 
     //! Set the stage map as dirty. It will be cleared immediately, but
     //! only repopulated when stage info is requested.

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -100,6 +100,13 @@ Ufe::Path stagePath(UsdStageWeakPtr stage) { return UsdStageMap::getInstance().p
 
 TfHashSet<UsdStageWeakPtr, TfHash> getAllStages() { return UsdStageMap::getInstance().allStages(); }
 
+std::vector<Ufe::Path> getAllStagesPaths() { return UsdStageMap::getInstance().allStagesPaths(); }
+
+bool isInStagesCache(const Ufe::Path& path)
+{
+    return UsdStageMap::getInstance().isInStagesCache(path);
+}
+
 UsdPrim ufePathToPrim(const Ufe::Path& path)
 {
     // When called we do not make any assumption on whether or not the

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -35,6 +35,7 @@
 #include <ufe/types.h>
 
 #include <cstring> // memcpy
+#include <vector>
 
 UFE_NS_DEF
 {
@@ -64,6 +65,14 @@ Ufe::Path stagePath(PXR_NS::UsdStageWeakPtr stage);
 //! Return all the USD stages.
 MAYAUSD_CORE_PUBLIC
 PXR_NS::TfHashSet<PXR_NS::UsdStageWeakPtr, PXR_NS::TfHash> getAllStages();
+
+//! Return all the USD stages' paths without rebuilding the stage list.
+MAYAUSD_CORE_PUBLIC
+std::vector<Ufe::Path> getAllStagesPaths();
+
+//! Returns true if the a stage with the given path exists, returns false otherwise.
+MAYAUSD_CORE_PUBLIC
+bool isInStagesCache(const Ufe::Path& path);
 
 //! Return the USD prim corresponding to the argument UFE path.
 MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -66,7 +66,7 @@ Ufe::Path stagePath(PXR_NS::UsdStageWeakPtr stage);
 MAYAUSD_CORE_PUBLIC
 PXR_NS::TfHashSet<PXR_NS::UsdStageWeakPtr, PXR_NS::TfHash> getAllStages();
 
-//! Return all the USD stages' paths without rebuilding the stage list.
+//! Return all the USD stages' paths.
 MAYAUSD_CORE_PUBLIC
 std::vector<Ufe::Path> getAllStagesPaths();
 

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateCameras.py
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateCameras.py
@@ -26,6 +26,7 @@ from mayaUsd import ufe as mayaUsdUfe
 
 from maya import cmds
 
+import unittest
 import ufe
 import os
 
@@ -123,6 +124,7 @@ class testVP2RenderDelegateCameras(imageUtils.ImageDiffingTestCase):
         ufeItem = ufe.Hierarchy.createItem(ufePath)
         return ufeItem
 
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() > 2025, 'Requires Maya fixes only available after Maya 2025.')
     def testCameras(self):
         self._StartTest('RenderCameras')
 


### PR DESCRIPTION
EMSUSD-2199 - Fixes a performance issue regarding findGatwayItems() / cameras

This change addresses some of the performance issues mentioned in https://github.com/Autodesk/maya-usd/issues/4125

- Created methods to check / get the list of stages without having to re-generate / update the stage map cache.
- Added an early out in findGatwayItems to avoid unnecessary looping.
