### PR TITLE
EMSUSD-2222: Duplicating a ProxyStage and hiding the dup causes crash

### DIFF
--- a/lib/mayaUsd/nodes/proxyAccessor.h
+++ b/lib/mayaUsd/nodes/proxyAccessor.h
@@ -97,9 +97,14 @@ public:
 
         auto accessor = Owner(new ProxyAccessor(stageProvider));
 
-        // add hidden attribute to force compute when USD changes
+        // When creating the node, we need to add hidden attribute to
+        // force compute when USD changes.
+        // When duplicating a node it will already have this attribute.
         MFnDependencyNode fnDep(node.thisMObject());
-        {
+
+        if (fnDep.hasAttribute("forceCompute")) {
+            accessor->_forceCompute = fnDep.attribute("forceCompute");
+        } else {
             MFnNumericAttribute attr;
 
             accessor->_forceCompute

--- a/test/lib/testMayaUsdProxyAccessor.py
+++ b/test/lib/testMayaUsdProxyAccessor.py
@@ -1235,3 +1235,20 @@ class MayaUsdProxyAccessorTestCase(unittest.TestCase):
         with CachingScope(self) as thisScope:
             thisScope.verifyScopeSetup()
             self.validateRecursiveCompute(thisScope)
+
+    def testDuplicatedProxyShape(self):
+        """
+        Validate that duplicated proxy shape is working correctly.
+        EMSUSD-2222: [Github #4142] Duplicating a ProxyStage and hiding the duplicate causes Maya to Crash
+        """
+        cmds.file(new=True, force=True)
+
+        # Create an empty proxy shape and duplicate it.
+        proxyShape,_ = createProxyAndStage()
+        cmds.select(proxyShape)
+        duplicatedProxyShape = cmds.duplicate()
+
+        # Before the fix the proxy accessor on the duplicated proxy shape had
+        # and invalid attribute pointer for the attribute forceCompute which
+        # would cause a crash when hiding the duplicated proxy shape.
+        cmds.hide(duplicatedProxyShape)


### PR DESCRIPTION
EMSUSD-2222: [Github #4142] Duplicating a ProxyStage and hiding the duplicate causes Maya to Crash

* When duplicating the node we don't need to create the forceCompute attribute (the dup'd node will already have it from original).