### PR TITLE
Check that the stagePath points to a valid Ufe item

### DIFF
--- a/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeSceneSegmentHandler.cpp
@@ -51,7 +51,9 @@ void findUsdGatewayItems(const Ufe::Path& path, Ufe::Selection& result)
         // gateway nodes. If path itself is a gateway node it should not be included
         // in the results.
         if (stagePath.startsWith(path) && stagePath != path) {
-            result.append(Ufe::Hierarchy::createItem(stagePath));
+            if (auto item = Ufe::Hierarchy::createItem(stagePath)) {
+                result.append(item);
+            }
         }
     }
 }


### PR DESCRIPTION
This prevents a hang we are experiencing when duplicating a ProxyShape. During the duplication process, a path with a ':' prefix is found in 'allStagesPaths' but this does not correspond to a valid scene item. A simple null check prevents the issue