### PR TITLE
EMSUSD-2232 - Avoids rebuilding cache when trying to getProxyShape

### DIFF
--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -273,8 +273,8 @@ MayaUsdProxyShapeBase* getProxyShape(const Ufe::Path& path)
     if (!TF_VERIFY(!path.empty())) {
         return nullptr;
     }
-
-    return UsdStageMap::getInstance().proxyShapeNode(path);
+    const bool rebuildCacheIfNeeded = false;
+    return UsdStageMap::getInstance().proxyShapeNode(path, rebuildCacheIfNeeded);
 }
 
 SdfPath getProxyShapePrimPath(const Ufe::Path& path)

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -273,8 +273,15 @@ MayaUsdProxyShapeBase* getProxyShape(const Ufe::Path& path)
     if (!TF_VERIFY(!path.empty())) {
         return nullptr;
     }
-    const bool rebuildCacheIfNeeded = false;
-    return UsdStageMap::getInstance().proxyShapeNode(path, rebuildCacheIfNeeded);
+    const bool             rebuildCacheIfNeeded = false;
+    MayaUsdProxyShapeBase* result
+        = UsdStageMap::getInstance().proxyShapeNode(path, rebuildCacheIfNeeded);
+    if (result == nullptr) {
+        // If no proxy shape was found without rebuilding the cache, try rebuilding the cache.
+        return UsdStageMap::getInstance().proxyShapeNode(path);
+    } else {
+        return result;
+    }
 }
 
 SdfPath getProxyShapePrimPath(const Ufe::Path& path)
@@ -384,8 +391,8 @@ void ReplicateExtrasFromUSD::processItem(const Ufe::Path& path, const MObject& m
             displayLayer.add(dagPath);
 
             // In case display layer membership was removed from the USD prim that we are
-            // replicating, we want to restore it here to make sure that the prim will stay in its
-            // display layer on DiscardEdits
+            // replicating, we want to restore it here to make sure that the prim will stay in
+            // its display layer on DiscardEdits
             displayLayer.add(Ufe::PathString::string(path).c_str());
         }
     }


### PR DESCRIPTION
This update the getProxyShape() util function to avoid rebuilding cache by default.