### PR TITLE
EMSUSD-2265 : Mtlx-USD export should add ND_geompropvalue node to the image node during convertion

### DIFF
--- a/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
@@ -715,7 +715,6 @@ public:
                     selList.getPlug(0, uvNamePlug);
 
                     MFnMesh meshFn(uvNamePlug.node());
-                    MGlobal::displayInfo(meshFn.name());
                     TfToken shapeName(meshFn.name().asChar());
                     if (!exportedShapes.count(shapeName)) {
                         continue;

--- a/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
@@ -593,7 +593,8 @@ public:
     _UVMappingManager(
         const UsdShadeMaterial&                                  material,
         const UsdMayaShadingModeExportContext::AssignmentVector& assignmentsToBind,
-        const UsdMayaJobExportArgs&                              exportArgs)
+        const UsdMayaJobExportArgs&                              exportArgs,
+        const std::string&                                       materialType)
         : _material(material)
         , _exportArgs(exportArgs)
     {
@@ -652,57 +653,92 @@ public:
         }
 
         // Ask Maya about UV linkage:
-
         for (size_t i = 0; i < _nodesWithUVInput.size(); ++i) {
             const TfToken& nodeName = _nodesWithUVInput[i];
-            MString        uvLinkCmd;
-            uvLinkCmd.format(
-                "stringArrayToString(`uvLink -q -t \"^1s\"`, \" \");", nodeName.GetText());
-            std::string uvLinkResult = MGlobal::executeCommandStringResult(uvLinkCmd).asChar();
-            const std::vector<std::string> uvSets = TfStringTokenize(uvLinkResult);
-            // If there are not UV sets, then the node has no valid UV input we must remove it.
-            // Otherwise, assumptions in the code below won't be satisfied.
-            if (uvSets.empty()) {
-                TF_WARN(
-                    "Could not determine the UV link of the UV input of the node \"%s\".",
-                    nodeName.GetText());
-                _nodesWithUVInput.erase(_nodesWithUVInput.begin() + i);
-                --i;
-                continue;
-            }
 
-            for (std::string uvSetRef : uvSets) {
-                // NOTE: If the mesh shape has the same name as the transform, then we will get a
-                //       complete path like
-                //           |mesh|mesh.uvSet[0].uvSetName
-                //       the best way to prevent confusion is to move to the object model
-                //       immediately and process from there.
-                MSelectionList selList;
-                selList.add(uvSetRef.c_str());
-                MPlug uvNamePlug;
-                selList.getPlug(0, uvNamePlug);
+            // The MaterialXSurfaceShader does not support the uvLink command for now.
+            // LookDevX is only looking at the first UV set, do the same here.
+            if (materialType == "MaterialXSurfaceShader") {
+                for (const auto& iter : assignmentsToBind) {
+                    MObject shapeObj = iter.shapeObj.object();
+                    MStatus status;
+                    // Create an MFnMesh to work with the mesh object
+                    MFnMesh meshFn(shapeObj, &status);
+                    if (!status) {
+                        TF_WARN(
+                            "Failed to initialize MFnMesh for shape object \"%s\".", iter.shapeName);
+                        continue;
+                    }
+                    // Get the UV set names
+                    MStringArray uvSetNames;
+                    status = meshFn.getUVSetNames(uvSetNames);
+                    if (!status || uvSetNames.length() == 0) {
+                        TF_WARN(
+                            "Failed to get UV set names for shape object \"%s\".",
+                            iter.shapeName);
+                        continue;
+                    }
 
-                MFnMesh meshFn(uvNamePlug.node());
+                    // UV Renaming based on options
+                    MString uvSetName = UsdMayaWriteUtil::UVSetExportedName(
+                        uvSetNames, _exportArgs.preserveUVSetNames, _exportArgs.remapUVSetsTo, 0);
 
-                TfToken shapeName(meshFn.name().asChar());
-                if (!exportedShapes.count(shapeName)) {
+                    _shapeNameToUVNames[iter.shapeName].push_back(
+                        TfToken(uvSetName.asChar()));
+                }
+            } else {
+                MString uvLinkCmd;
+                uvLinkCmd.format(
+                    "stringArrayToString(`uvLink -q -t \"^1s\"`, \" \");", nodeName.GetText());
+                std::string uvLinkResult = MGlobal::executeCommandStringResult(uvLinkCmd).asChar();
+                std::vector<std::string> uvSets = TfStringTokenize(uvLinkResult);
+                // If there are not UV sets, then the node has no valid UV input we must remove it.
+                // Otherwise, assumptions in the code below won't be satisfied.
+                if (uvSets.empty()) {
+                    TF_WARN(
+                        "Could not determine the UV link of the UV input of the node \"%s\".",
+                        nodeName.GetText());
+                    _nodesWithUVInput.erase(_nodesWithUVInput.begin() + i);
+                    --i;
                     continue;
                 }
 
-                MString uvSetName = uvNamePlug.asString();
+                for (std::string uvSetRef : uvSets) {
+                    // NOTE: If the mesh shape has the same name as the transform, then we will get
+                    //       a complete path like
+                    //           |mesh|mesh.uvSet[0].uvSetName
+                    //       the best way to prevent confusion is to move to the object model
+                    //       immediately and process from there.
+                    MSelectionList selList;
+                    selList.add(uvSetRef.c_str());
+                    MPlug uvNamePlug;
+                    selList.getPlug(0, uvNamePlug);
 
-                // UV set renaming still exists. See if the UV was renamed:
-                MStringArray uvSets;
-                meshFn.getUVSetNames(uvSets);
-                for (unsigned int i = 0; i < uvSets.length(); i++) {
-                    if (uvSets[i] == uvSetName) {
-                        uvSetName = UsdMayaWriteUtil::UVSetExportedName(
-                            uvSets, _exportArgs.preserveUVSetNames, _exportArgs.remapUVSetsTo, i);
-                        break;
+                    MFnMesh meshFn(uvNamePlug.node());
+                    MGlobal::displayInfo(meshFn.name());
+                    TfToken shapeName(meshFn.name().asChar());
+                    if (!exportedShapes.count(shapeName)) {
+                        continue;
                     }
-                }
 
-                _shapeNameToUVNames[shapeName].push_back(TfToken(uvSetName.asChar()));
+                    MString uvSetName = uvNamePlug.asString();
+
+                    // UV set renaming still exists. See if the UV was renamed:
+                    MStringArray uvSets;
+                    meshFn.getUVSetNames(uvSets);
+                    for (unsigned int i = 0; i < uvSets.length(); i++) {
+                        if (uvSets[i] == uvSetName) {
+                            uvSetName = UsdMayaWriteUtil::UVSetExportedName(
+                                uvSets,
+                                _exportArgs.preserveUVSetNames,
+                                _exportArgs.remapUVSetsTo,
+                                i);
+                            break;
+                        }
+                    }
+
+                    _shapeNameToUVNames[shapeName].push_back(TfToken(uvSetName.asChar()));
+                }
             }
         }
 
@@ -979,7 +1015,11 @@ void UsdMayaShadingModeExportContext::BindStandardMaterialPrim(
         return;
     }
 
-    _UVMappingManager uvMappingManager(material, assignmentsToBind, GetExportArgs());
+    _UVMappingManager uvMappingManager(
+        material,
+        assignmentsToBind,
+        GetExportArgs(),
+        MFnDependencyNode(GetSurfaceShader()).typeName().asChar());
 
     UsdStageRefPtr stage = GetUsdStage();
     TfToken        materialNameToken(materialPrim.GetName());

--- a/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
@@ -667,7 +667,7 @@ public:
                     if (!status) {
                         TF_WARN(
                             "Failed to initialize MFnMesh for shape object \"%s\".",
-                            iter.shapeName);
+                            iter.shapeName.GetText());
                         continue;
                     }
                     // Get the UV set names
@@ -675,7 +675,8 @@ public:
                     status = meshFn.getUVSetNames(uvSetNames);
                     if (!status || uvSetNames.length() == 0) {
                         TF_WARN(
-                            "Failed to get UV set names for shape object \"%s\".", iter.shapeName);
+                            "Failed to get UV set names for shape object \"%s\".",
+                            iter.shapeName.GetText());
                         continue;
                     }
 

--- a/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
+++ b/lib/mayaUsd/fileio/shading/shadingModeExporterContext.cpp
@@ -666,7 +666,8 @@ public:
                     MFnMesh meshFn(shapeObj, &status);
                     if (!status) {
                         TF_WARN(
-                            "Failed to initialize MFnMesh for shape object \"%s\".", iter.shapeName);
+                            "Failed to initialize MFnMesh for shape object \"%s\".",
+                            iter.shapeName);
                         continue;
                     }
                     // Get the UV set names
@@ -674,8 +675,7 @@ public:
                     status = meshFn.getUVSetNames(uvSetNames);
                     if (!status || uvSetNames.length() == 0) {
                         TF_WARN(
-                            "Failed to get UV set names for shape object \"%s\".",
-                            iter.shapeName);
+                            "Failed to get UV set names for shape object \"%s\".", iter.shapeName);
                         continue;
                     }
 
@@ -683,8 +683,7 @@ public:
                     MString uvSetName = UsdMayaWriteUtil::UVSetExportedName(
                         uvSetNames, _exportArgs.preserveUVSetNames, _exportArgs.remapUVSetsTo, 0);
 
-                    _shapeNameToUVNames[iter.shapeName].push_back(
-                        TfToken(uvSetName.asChar()));
+                    _shapeNameToUVNames[iter.shapeName].push_back(TfToken(uvSetName.asChar()));
                 }
             } else {
                 MString uvLinkCmd;

--- a/lib/usd/translators/shading/mtlxMaterialXSurfaceShaderWriter.cpp
+++ b/lib/usd/translators/shading/mtlxMaterialXSurfaceShaderWriter.cpp
@@ -419,7 +419,7 @@ void _ExposeGeomPropAttributeToMaterial(
         .ConnectToSource(geompropShaderOutput);
 }
 
-// Adds a geompromvalue node to the USD stage, if needed, based on a MaterialX
+// Adds a geompromvalue node to the USD stage if needed, this is intended to be used on image nodes.
 void _AddGeompropValueNode(
     const MaterialX::NodePtr& node,
     const UsdStagePtr&        stage,

--- a/lib/usd/translators/shading/mtlxMaterialXSurfaceShaderWriter.cpp
+++ b/lib/usd/translators/shading/mtlxMaterialXSurfaceShaderWriter.cpp
@@ -537,8 +537,7 @@ void _AddNode(
         = _GetNodeWithGeompropInputFromLib();
     // Special case for Nodes that contains a defaultgeomprop attribute set to UV0.
     // A geompropvalue node might be needed.
-    if (geompropValueNodes.find(node->getCategory())
-        != geompropValueNodes.end()) {
+    if (geompropValueNodes.find(node->getCategory()) != geompropValueNodes.end()) {
         _AddGeompropValueNode(node, stage, parentPath, shader);
     }
 }

--- a/lib/usd/translators/shading/mtlxMaterialXSurfaceShaderWriter.cpp
+++ b/lib/usd/translators/shading/mtlxMaterialXSurfaceShaderWriter.cpp
@@ -203,7 +203,7 @@ void _ConnectToNode(
     if (!connectedNode) {
         TF_WARN(
             "Can't find node '%s' connected to input '%s' on node '%s'",
-            input->getNodeName(),
+            input->getNodeName().c_str(),
             input->getName().c_str(),
             input->getParent()->getName().c_str());
         return;
@@ -427,7 +427,8 @@ void _AddGeompropValueNode(
     UsdShadeShader&           imageShader)
 {
     MaterialX::NodePtr connectedNode;
-    TfToken inputName(TfStringPrintf("%s:%s", node->getName(), _GetVarnameName().GetText()));
+    TfToken            inputName(
+        TfStringPrintf("%s:%s", node->getName().c_str(), _GetVarnameName().GetText()));
     if (auto textCoordInput = node->getInput(TrMtlxTokens->texcoord.GetString())) {
         connectedNode = textCoordInput->getConnectedNode();
     }
@@ -446,7 +447,7 @@ void _AddGeompropValueNode(
             = stage->GetPrimAtPath(parentPath.AppendPath(SdfPath(connectedNode->getName())));
         if (!TF_VERIFY(
                 geompropPrim,
-                "Could not find geompropvalue prim at path \"s\"",
+                "Could not find geompropvalue prim at path '%s'",
                 geompropPrim.GetPath().GetText())) {
             return;
         }

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -102,6 +102,13 @@ set(TEST_SCRIPT_FILES
     testUsdMayaAdaptorUndoRedo.py
 )
 
+if(MAYA_APP_VERSION VERSION_GREATER_EQUAL 2025)
+    list(APPEND TEST_SCRIPT_FILES
+        # This test requires the LookdevX plugin and loads it manually
+        testUsdExportMaterialXSurfaceShader.py
+    )
+endif()
+
 if(BUILD_PXR_PLUGIN)
     # This test uses the file "UsdExportUVTransforms.ma" which
     # requires the plugin "pxrUsdPreviewSurface" that is built by the

--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -102,12 +102,12 @@ set(TEST_SCRIPT_FILES
     testUsdMayaAdaptorUndoRedo.py
 )
 
-if(MAYA_APP_VERSION VERSION_GREATER_EQUAL 2025)
-    list(APPEND TEST_SCRIPT_FILES
-        # This test requires the LookdevX plugin and loads it manually
-        testUsdExportMaterialXSurfaceShader.py
-    )
-endif()
+# This test is disabled by default since it requires the LookdevX plugin
+#if(MAYA_APP_VERSION VERSION_GREATER_EQUAL 2025)
+#    list(APPEND TEST_SCRIPT_FILES        
+#        testUsdExportMaterialXSurfaceShader.py
+#    )
+#endif()
 
 if(BUILD_PXR_PLUGIN)
     # This test uses the file "UsdExportUVTransforms.ma" which

--- a/test/lib/usd/translators/UsdExportMaterialXSurfaceShader/ImageWithoutGeomProp.mtlx
+++ b/test/lib/usd/translators/UsdExportMaterialXSurfaceShader/ImageWithoutGeomProp.mtlx
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <nodegraph name="NG_ImageWithoutGeomProp">
+    <tiledimage name="image_color" type="color3">
+      <input name="file" type="filename" value="../textures/RGB.png" colorspace="srgb_texture" />
+      <input name="uvtiling" type="vector2" value="4.0, 4.0" />
+    </tiledimage>
+    <tiledimage name="image_roughness" type="float">
+      <input name="file" type="filename" value="../textures/Mono.png" />
+      <input name="uvtiling" type="vector2" value="4.0, 4.0" />
+    </tiledimage>
+    <output name="out_color" type="color3" nodename="image_color" />
+    <output name="out_roughness" type="float" nodename="image_roughness" />
+  </nodegraph>
+  <standard_surface name="SR_ImageWithoutGeomProp" type="surfaceshader">
+    <input name="base" type="float" value="1" />
+    <input name="base_color" type="color3" nodegraph="NG_ImageWithoutGeomProp" output="out_color" />
+    <input name="specular" type="float" value="0.4" />
+    <input name="specular_roughness" type="float" nodegraph="NG_ImageWithoutGeomProp" output="out_roughness" />
+  </standard_surface>
+  <surfacematerial name="ImageWithoutGeomProp" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_ImageWithoutGeomProp" />
+  </surfacematerial>
+</materialx>

--- a/test/lib/usd/translators/testUsdExportMaterialXSurfaceShader.py
+++ b/test/lib/usd/translators/testUsdExportMaterialXSurfaceShader.py
@@ -46,7 +46,7 @@ class testUsdExportMaterialXSurfaceShader(unittest.TestCase):
 
         cmds.file(f=True, new=True)
 
-        mtlxFile = os.path.join("D:\\Dev\\maya\\maya-usd\\test\\lib\\usd\\translators", 'UsdExportMaterialXSurfaceShader',
+        mtlxFile = os.path.join(self._inputPath, 'UsdExportMaterialXSurfaceShader',
             'MaterialXStackExport.mtlx')
 
         stackName = mel.eval("createNode materialxStack")

--- a/test/lib/usd/translators/testUsdExportMaterialXSurfaceShader.py
+++ b/test/lib/usd/translators/testUsdExportMaterialXSurfaceShader.py
@@ -20,16 +20,10 @@ from pxr import Sdf
 from pxr import Sdr
 from pxr import UsdShade
 
-from maya import cmds
 from maya import standalone
-
 import maya.cmds as cmds
 import maya.mel as mel
 import ufe
-
-import mayaUsd.lib as mayaUsdLib
-
-import maya.api.OpenMaya as om
 
 import os
 import unittest
@@ -40,6 +34,8 @@ class testUsdExportMaterialXSurfaceShader(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        # The materialxStack node is available in the LookdevX plugin.
+        cmds.loadPlugin("LookdevXMaya", quiet=True)
         cls._inputPath = fixturesUtils.setUpClass(__file__)
 
     @classmethod
@@ -50,7 +46,7 @@ class testUsdExportMaterialXSurfaceShader(unittest.TestCase):
 
         cmds.file(f=True, new=True)
 
-        mtlxFile = os.path.join(self._inputPath, 'UsdExportMaterialXSurfaceShader',
+        mtlxFile = os.path.join("D:\\Dev\\maya\\maya-usd\\test\\lib\\usd\\translators", 'UsdExportMaterialXSurfaceShader',
             'MaterialXStackExport.mtlx')
 
         stackName = mel.eval("createNode materialxStack")
@@ -70,12 +66,11 @@ class testUsdExportMaterialXSurfaceShader(unittest.TestCase):
         usdFilePath = os.path.abspath('MaterialXStackExport.usda')
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
             shadingMode='useRegistry', convertMaterialsTo=['MaterialX'],
-            materialsScopeName='Materials', defaultPrim='None')
+            defaultPrim='None')
 
         stage = Usd.Stage.Open(usdFilePath)
         self.assertTrue(stage)
-
-        prim = stage.GetPrimAtPath("/Materials/Standard_Surface1SG")
+        prim = stage.GetPrimAtPath("/Looks/Standard_Surface1SG")
         self.assertTrue(prim)
         material = UsdShade.Material(prim)
         self.assertTrue(material)
@@ -113,15 +108,15 @@ class testUsdExportMaterialXSurfaceShader(unittest.TestCase):
         nodeGraph = UsdShade.NodeGraph(nodeGraphPrim)
         # Validate the Checkerboard Shader
         checkboardPrim = nodeGraph.GetOutput('out').GetConnectedSources()[0][0].source.GetPrim()
-        self.assertEqual(checkboardPrim.GetName(), 'checkboard1')
+        self.assertEqual(checkboardPrim.GetName(), 'checkerboard1')
         self.assertEqual(checkboardPrim.GetAttribute('info:id').Get(), 'ND_checkerboard_color3')
 
     def testExportMultiOutput(self):
 
         cmds.file(f=True, new=True)
 
-        mtlxFile = os.path.join(self._inputPath, 'Multioutput.mtlx',
-            'MaterialXStackExport.mtlx')
+        mtlxFile = os.path.join(self._inputPath, 'UsdExportMaterialXSurfaceShader',
+            'MultiOutput.mtlx')
 
         stackName = mel.eval("createNode materialxStack")
         stackPathString = mel.eval("ls -l " + stackName)[0]
@@ -140,12 +135,12 @@ class testUsdExportMaterialXSurfaceShader(unittest.TestCase):
         usdFilePath = os.path.abspath('Multioutput.usda')
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
             shadingMode='useRegistry', convertMaterialsTo=['MaterialX'],
-            materialsScopeName='Materials', defaultPrim='None')
+            defaultPrim='None')
 
         stage = Usd.Stage.Open(usdFilePath)
         self.assertTrue(stage)
 
-        prim = stage.GetPrimAtPath("/Materials/test_multi_out_matSG")
+        prim = stage.GetPrimAtPath("/Looks/test_multi_out_matSG")
         self.assertTrue(prim)
         material = UsdShade.Material(prim)
         self.assertTrue(material)
@@ -171,7 +166,7 @@ class testUsdExportMaterialXSurfaceShader(unittest.TestCase):
         iorExtractShader = UsdShade.Shader(iorExtractPrim)
         artisticiorPrim = iorExtractShader.GetInput('in').GetConnectedSources()[0][0].source.GetPrim()
         self.assertEqual(artisticiorPrim.GetName(), 'artistic_ior')
-        self.assertEqual(iorExtractPrim.GetAttribute('info:id').Get(), 'ND_artistic_ior')
+        self.assertEqual(artisticiorPrim.GetAttribute('info:id').Get(), 'ND_artistic_ior')
 
         # Validate the extinction output
         specularExtractPrim = nodeGraph.GetOutput('specular_output').GetConnectedSources()[0][0].source.GetPrim()
@@ -186,6 +181,74 @@ class testUsdExportMaterialXSurfaceShader(unittest.TestCase):
         self.assertEqual(outs[0].GetBaseName(), 'extinction')
         self.assertEqual(outs[1].GetBaseName(), 'ior')
         
+    def testExportImageWithoutGeomProp(self):
+        cmds.file(f=True, new=True)
+
+        mtlxFile = os.path.join(self._inputPath, 'UsdExportMaterialXSurfaceShader',
+            'ImageWithoutGeomProp.mtlx')
+
+        stackName = mel.eval("createNode materialxStack")
+        stackPathString = mel.eval("ls -l " + stackName)[0]
+        stackItem = ufe.Hierarchy.createItem(ufe.PathString.path(stackPathString))
+        stackHierarchy = ufe.Hierarchy.hierarchy(stackItem)
+        stackContextOps = ufe.ContextOps.contextOps(stackItem)
+        stackContextOps.doOp(['MxImportDocument', mtlxFile])
+        documentItem = stackHierarchy.children()[-1]
+        sphere = cmds.polySphere()
+        newUVSetName = "newUVSetName"
+        cmds.polyUVSet(sphere, rename=True, uvSet="map1", newUVSet=newUVSetName)
+        surfPathString = ufe.PathString.string(documentItem.path()) + "%ImageWithoutGeomProp"
+        cmds.select(sphere)
+        materialContextOps = ufe.ContextOps.contextOps(ufe.Hierarchy.createItem(ufe.PathString.path(surfPathString)))
+        materialContextOps.doOp(['Assign Material to Selection']) 
+
+        # Export to USD.
+        # preserveUVSetNames=True to validate that the UV set name are properly assigned by the _UVMappingManager
+        usdFilePath = os.path.abspath('ImageWithoutGeomProp.usda')
+        cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
+            shadingMode='useRegistry', convertMaterialsTo=['MaterialX'],
+            defaultPrim='None', preserveUVSetNames=True)
+
+        stage = Usd.Stage.Open(usdFilePath)
+        self.assertTrue(stage)
+
+        prim = stage.GetPrimAtPath("/Looks/ImageWithoutGeomPropSG")
+        self.assertTrue(prim)
+        material = UsdShade.Material(prim)
+        self.assertTrue(material)
+
+        # Validate the inputs for image_color and image_roughness
+        image_color_input = material.GetInput("image_color:varname")
+        image_roughness_input = material.GetInput("image_roughness:varname")
+        self.assertEqual(image_color_input.GetAttr().Get(), newUVSetName)
+        self.assertEqual(image_roughness_input.GetAttr().Get(), newUVSetName)
+
+        #Get the NodeGraph and validate the inputs for image_color and image_roughness
+        nodeGraphPrim = stage.GetPrimAtPath("/Looks/ImageWithoutGeomPropSG/NG_ImageWithoutGeomProp")
+        self.assertTrue(nodeGraphPrim)
+        nodeGraph = UsdShade.NodeGraph(nodeGraphPrim)
+        NG_image_color_input = nodeGraph.GetInput("image_color:varname")
+        NG_image_roughness_input = nodeGraph.GetInput("image_roughness:varname")
+        self.assertEqual(NG_image_color_input.GetConnectedSources()[0][0].source.GetPrim().GetName(), "ImageWithoutGeomPropSG")
+        self.assertEqual(NG_image_color_input.GetConnectedSources()[0][0].sourceName, "image_color:varname")
+
+        self.assertEqual(NG_image_roughness_input.GetConnectedSources()[0][0].source.GetPrim().GetName(), "ImageWithoutGeomPropSG")
+        self.assertEqual(NG_image_roughness_input.GetConnectedSources()[0][0].sourceName, "image_roughness:varname")
+
+        # Validate the geompropvalue shader that were created by the export
+        geomPropColorPrim = stage.GetPrimAtPath("/Looks/ImageWithoutGeomPropSG/NG_ImageWithoutGeomProp/geompropvalue_image_color")
+        self.assertTrue(geomPropColorPrim)
+        geomPropColorShader = UsdShade.Shader(geomPropColorPrim)
+        geomColorInput = geomPropColorShader.GetInput("geomprop")
+        self.assertEqual(geomColorInput.GetConnectedSources()[0][0].source.GetPrim().GetName(), "NG_ImageWithoutGeomProp")
+        self.assertEqual(geomColorInput.GetConnectedSources()[0][0].sourceName, "image_color:varname")
+
+        geomPropRoughnesPrim = stage.GetPrimAtPath("/Looks/ImageWithoutGeomPropSG/NG_ImageWithoutGeomProp/geompropvalue_image_roughness")
+        self.assertTrue(geomPropColorPrim)
+        geomPropRoughnesShader = UsdShade.Shader(geomPropRoughnesPrim)
+        geomRoughnessInput = geomPropRoughnesShader.GetInput("geomprop")
+        self.assertEqual(geomRoughnessInput.GetConnectedSources()[0][0].source.GetPrim().GetName(), "NG_ImageWithoutGeomProp")
+        self.assertEqual(geomRoughnessInput.GetConnectedSources()[0][0].sourceName, "image_roughness:varname")
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Add geomprop node when exporting MaterialX containing images not connected to a geomprop node.
Surface up the texcoord attribute to the material to allow the _UVMappingManager to connect the proper UV channel.