### PR TITLE
Fixes for building with QT_DISABLE_DEPRECATED_BEFORE

### DIFF
--- a/lib/usd/ui/importDialog/ItemDelegate.cpp
+++ b/lib/usd/ui/importDialog/ItemDelegate.cpp
@@ -256,7 +256,7 @@ QLayout* VariantsEditorWidget::createVariantSet(
     QComboBox* cb = new QComboBox;
 
     ItemDelegate* id = const_cast<ItemDelegate*>(itemDelegate);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#if QT_DISABLE_DEPRECATED_BEFORE || QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     connect(
         cb,
         static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::textActivated),

--- a/lib/usd/ui/importDialog/USDImportDialog.cpp
+++ b/lib/usd/ui/importDialog/USDImportDialog.cpp
@@ -63,7 +63,7 @@ USDImportDialog::USDImportDialog(
             _rootPrimPath = defPrim.GetPath().GetAsString();
     }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#if QT_DISABLE_DEPRECATED_BEFORE || QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     int minW = _uiView->nbPrimsInScopeLabel->fontMetrics().horizontalAdvance("12345");
 #else
     int minW = _uiView->nbPrimsInScopeLabel->fontMetrics().width("12345");

--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -207,7 +207,7 @@ void LayerTreeItem::fetchData(RebuildChildren in_rebuild, RecursionDetector* in_
 QVariant LayerTreeItem::data(int role) const
 {
     switch (role) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#if QT_DISABLE_DEPRECATED_BEFORE || QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     case Qt::ForegroundRole: return QColor(200, 200, 200);
 #else
     case Qt::TextColorRole: return QColor(200, 200, 200);

--- a/lib/usd/ui/layerEditor/layerTreeItemDelegate.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItemDelegate.cpp
@@ -255,7 +255,7 @@ void LayerTreeItemDelegate::paint_drawArrow(QPainter* painter, const ItemPaintCo
 
 void LayerTreeItemDelegate::paint_drawText(QPainter* painter, const ItemPaintContext& ctx) const
 {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#if QT_DISABLE_DEPRECATED_BEFORE || QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QColor penColor = ctx.item->data(Qt::ForegroundRole).value<QColor>();
 #else
     QColor penColor = ctx.item->data(Qt::TextColorRole).value<QColor>();

--- a/lib/usd/ui/layerEditor/layerTreeViewStyle.h
+++ b/lib/usd/ui/layerEditor/layerTreeViewStyle.h
@@ -157,7 +157,7 @@ protected:
         const override
     {
         if (hint == QStyle::SH_Slider_AbsoluteSetButtons) {
-#if QT_DISABLE_DEPRECATED_BEFOR || QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#if QT_DISABLE_DEPRECATED_BEFORE || QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
             return Qt::LeftButton | Qt::MiddleButton | Qt::RightButton;
 #else
             return Qt::LeftButton | Qt::MidButton | Qt::RightButton;

--- a/lib/usd/ui/layerEditor/layerTreeViewStyle.h
+++ b/lib/usd/ui/layerEditor/layerTreeViewStyle.h
@@ -157,7 +157,7 @@ protected:
         const override
     {
         if (hint == QStyle::SH_Slider_AbsoluteSetButtons) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#if QT_DISABLE_DEPRECATED_BEFOR || QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
             return Qt::LeftButton | Qt::MiddleButton | Qt::RightButton;
 #else
             return Qt::LeftButton | Qt::MidButton | Qt::RightButton;


### PR DESCRIPTION
        The maya_open_source Qt code already has version checks for Qt 6,
        but we need to follow the v6 branch when we are building with 5.15
        deprecation turned on. Adding this define to the checks as a minimal
        way to get this to compile internally with deprecation turned on,
        without changing the code in a way that makes it hard to merge
        updates from upstream.