### PR TITLE
EMSUSD-2524 : Crash if the file port is promoted to the top level of the graph

### DIFF
--- a/lib/usd/translators/shading/mtlxMaterialXSurfaceShaderWriter.cpp
+++ b/lib/usd/translators/shading/mtlxMaterialXSurfaceShaderWriter.cpp
@@ -141,11 +141,12 @@ bool _TypeSupportsColorSpace(const MaterialX::InputPtr& mxElem, const Ufe::Path&
     bool colorImageNode = false;
     if (type == "filename") {
         // verify the output is color3 or color4
-        auto node = mxElem->getParent()->asA<MaterialX::Node>();
-        if (auto parentNodeDef = _GetNodeDef(node, ufePath)) {
-            for (const MaterialX::OutputPtr& output : parentNodeDef->getOutputs()) {
-                const std::string& type = output->getType();
-                colorImageNode |= type == "color3" || type == "color4";
+        if (auto node = mxElem->getParent()->asA<MaterialX::Node>()) {
+            if (auto parentNodeDef = _GetNodeDef(node, ufePath)) {
+                for (const MaterialX::OutputPtr& output : parentNodeDef->getOutputs()) {
+                    const std::string& type = output->getType();
+                    colorImageNode |= type == "color3" || type == "color4";
+                }
             }
         }
     }


### PR DESCRIPTION
Fix crash : the input might not always be part of a node.