### PR TITLE
Added usdSkelImaging dependency

### DIFF
--- a/lib/mayaUsd/CMakeLists.txt
+++ b/lib/mayaUsd/CMakeLists.txt
@@ -250,6 +250,7 @@ target_link_libraries(${PROJECT_NAME}
         usdRi
         usdShade
         usdSkel
+	usdSkelImaging
         usdUtils
         usdUI
         vt


### PR DESCRIPTION
Adding dependency to usdSkelImaging. This change is mainly for Arnold team that rely on mayaUsd plugin to link against USD libraries.