### PR TITLE
LOOKDEVX-4467 - Move ProxyShapeLookdevHandler to MayaUSD.

### DIFF
--- a/lib/lookdevXUsd/CMakeLists.txt
+++ b/lib/lookdevXUsd/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(${PROJECT_NAME} SHARED)
 target_sources(${PROJECT_NAME}
     PRIVATE
         LookdevXUsd.cpp
+        ProxyShapeLookdevHandler.cpp
         UsdCapabilityHandler.cpp
         UsdClipboardHandler.cpp
         UsdComponentConnections.cpp
@@ -53,6 +54,7 @@ target_sources(${PROJECT_NAME}
 set(HEADERS
     Export.h
     LookdevXUsd.h
+    ProxyShapeLookdevHandler.h
     UsdCapabilityHandler.h
     UsdClipboardHandler.h
     UsdComponentConnections.h

--- a/lib/lookdevXUsd/LookdevXUsd.cpp
+++ b/lib/lookdevXUsd/LookdevXUsd.cpp
@@ -10,6 +10,7 @@
 //*****************************************************************************
 #include "LookdevXUsd.h"
 
+#include "ProxyShapeLookdevHandler.h"
 #include "UsdCapabilityHandler.h"
 #include "UsdClipboardHandler.h"
 #include "UsdDebugHandler.h"
@@ -35,7 +36,10 @@ namespace
 
 // Runtime ids (default 0 is invalid).
 Ufe::Rtid mayaUsdRuntimeId = 0;
+Ufe::Rtid mayaRuntimeId = 0;
+
 Ufe::SceneItemOpsHandler::Ptr mayaUsdSceneItemOpsHandler;
+LookdevXUfe::LookdevHandler::Ptr mayaLookdevHandler;
 
 } // namespace
 
@@ -43,6 +47,7 @@ namespace LookdevXUsd
 {
 
 constexpr auto kMayaUsdRuntimeName = "USD";
+constexpr auto kMayaRuntimeName = "Maya-DG";
 
 void initialize()
 {
@@ -50,6 +55,7 @@ void initialize()
     try
     {
         mayaUsdRuntimeId = Ufe::RunTimeMgr::instance().getId(kMayaUsdRuntimeName);
+        mayaRuntimeId = Ufe::RunTimeMgr::instance().getId(kMayaRuntimeName);
     }
     catch (const std::exception&)
     {
@@ -78,6 +84,10 @@ void initialize()
     mayaUsdSceneItemOpsHandler = Ufe::RunTimeMgr::instance().sceneItemOpsHandler(mayaUsdRuntimeId);
     Ufe::RunTimeMgr::instance().setSceneItemOpsHandler(
         mayaUsdRuntimeId, LookdevXUsd::UsdSceneItemOpsHandler::create(mayaUsdSceneItemOpsHandler));
+
+    mayaLookdevHandler = LookdevXUfe::LookdevHandler::get(mayaRuntimeId);
+    Ufe::RunTimeMgr::instance().registerHandler(mayaRuntimeId, ProxyShapeLookdevHandler::id,
+        ProxyShapeLookdevHandler::create(mayaLookdevHandler));
 
     // Force loading the Sdr library to preload the source of the NodeLibrary on the USD side. This will load the Arnold
     // DLL if it is in the USD paths and initialize it for its nodes, which should result in a slight delay.
@@ -117,6 +127,13 @@ void uninitialize()
         runTimeMgr.setSceneItemOpsHandler(mayaUsdRuntimeId, mayaUsdSceneItemOpsHandler);
     }
     mayaUsdSceneItemOpsHandler.reset();
+
+    // Unregister the decorated Maya handlers and restore the original ones.
+    Ufe::RunTimeMgr::instance().unregisterHandler(mayaUsdRuntimeId, ProxyShapeLookdevHandler::id);
+    if (runTimeMgr.hasId(mayaRuntimeId) && mayaLookdevHandler) {
+      Ufe::RunTimeMgr::instance().registerHandler( mayaRuntimeId, ProxyShapeLookdevHandler::id, mayaLookdevHandler);
+    }
+    mayaLookdevHandler.reset();
 }
 
 } // namespace LookdevXUsd

--- a/lib/lookdevXUsd/ProxyShapeLookdevHandler.cpp
+++ b/lib/lookdevXUsd/ProxyShapeLookdevHandler.cpp
@@ -12,6 +12,8 @@
 
 #include <mayaUsdAPI/utils.h>
 
+#include <ufe/hierarchy.h>
+
 namespace LookdevXUsd
 {
 
@@ -83,7 +85,7 @@ bool ProxyShapeLookdevHandler::isLookdevContainerImpl(const Ufe::SceneItem::Ptr&
 }
 
 MayaUsdCreateLookdevEnvironmentCommand::MayaUsdCreateLookdevEnvironmentCommand(Ufe::Path ancestor)
-    : m_ancestor(std::move(ancestor)), m_materialParent(nullptr),
+    : m_ancestor(std::move(ancestor)),
       m_cmds(std::make_shared<Ufe::CompositeUndoableCommand>())
 {
 }
@@ -95,7 +97,7 @@ MayaUsdCreateLookdevEnvironmentCommand::Ptr MayaUsdCreateLookdevEnvironmentComma
 
 Ufe::SceneItem::Ptr MayaUsdCreateLookdevEnvironmentCommand::sceneItem() const
 {
-    return m_materialParent;
+    return Ufe::Hierarchy::createItem(m_materialParent);
 }
 
 void MayaUsdCreateLookdevEnvironmentCommand::execute()
@@ -176,7 +178,7 @@ bool MayaUsdCreateLookdevEnvironmentCommand::executeCommand()
         return false;
     }
     m_cmds->append(createMaterialsScopeCmd);
-    m_materialParent = materialsScope;
+    m_materialParent = materialsScope->path();
 
     return true;
 }
@@ -186,7 +188,7 @@ void MayaUsdCreateLookdevEnvironmentCommand::undo()
     if (m_cmds)
     {
         m_cmds->undo();
-        m_materialParent.reset();
+        m_materialParent = {};
     }
 }
 

--- a/lib/lookdevXUsd/ProxyShapeLookdevHandler.cpp
+++ b/lib/lookdevXUsd/ProxyShapeLookdevHandler.cpp
@@ -1,0 +1,201 @@
+//*****************************************************************************
+// Copyright (c) 2025 Autodesk, Inc.
+// All rights reserved.
+//
+// These coded instructions, statements, and computer programs contain
+// unpublished proprietary information written by Autodesk, Inc. and are
+// protected by Federal copyright law. They may not be disclosed to third
+// parties or copied or duplicated in any form, in whole or in part, without
+// the prior written consent of Autodesk, Inc.
+//*****************************************************************************
+#include "ProxyShapeLookdevHandler.h"
+
+#include <mayaUsdAPI/utils.h>
+
+namespace LookdevXUsd
+{
+
+ProxyShapeLookdevHandler::ProxyShapeLookdevHandler(LookdevXUfe::LookdevHandler::Ptr previousHandler)
+    : m_previousHandler(std::move(previousHandler))
+{
+}
+
+/*static*/
+ProxyShapeLookdevHandler::Ptr ProxyShapeLookdevHandler::create(const LookdevXUfe::LookdevHandler::Ptr& previousHandler)
+{
+    return std::make_shared<ProxyShapeLookdevHandler>(previousHandler);
+}
+
+//------------------------------------------------------------------------------
+// ProxyShapeLookdevHandler overrides
+//------------------------------------------------------------------------------
+
+Ufe::SceneItemResultUndoableCommand::Ptr ProxyShapeLookdevHandler::createLookdevContainerCmdImpl(
+    const Ufe::SceneItem::Ptr& parent, const Ufe::PathComponent& name) const
+{
+    // Check if parent is a proxy shape.
+    if (!parent || !MayaUsdAPI::isAGatewayType(parent->nodeType()))
+    {
+        return m_previousHandler ? m_previousHandler->createLookdevContainerCmdImpl(parent, name) : nullptr;
+    }
+
+    // Treat proxy shapes in the same way as every other USD item.
+    auto parentItem = MayaUsdAPI::createUsdSceneItem(parent->path(), MayaUsdAPI::ufePathToPrim(parent->path()));
+    if (!parentItem || !MayaUsdAPI::getPrimForUsdSceneItem(parentItem).IsValid())
+    {
+        return nullptr;
+    }
+
+    return MayaUsdAPI::createAddNewPrimCommand(parentItem, name.string(), "Material");
+}
+
+Ufe::SceneItemResultUndoableCommand::Ptr ProxyShapeLookdevHandler::createLookdevContainerCmdImpl(
+    const Ufe::SceneItem::Ptr& parent, const Ufe::NodeDef::Ptr& nodeDef) const
+{
+    // The underlying command MayaUsd::ufe::UsdUndoAddNewMaterialCommand currently doesn't work for the proxy shape.
+    // Pass to the previous handler.
+    return m_previousHandler ? m_previousHandler->createLookdevContainerCmdImpl(parent, nodeDef) : nullptr;
+}
+
+Ufe::SceneItemResultUndoableCommand::Ptr ProxyShapeLookdevHandler::createLookdevEnvironmentCmdImpl(
+    const Ufe::SceneItem::Ptr& ancestor, Ufe::Rtid targetRunTimeId) const
+{
+    // This handler is only aware of gateways from Maya to USD.
+    if (!ancestor || ancestor->runTimeId() != MayaUsdAPI::getMayaRunTimeId() ||
+        targetRunTimeId != MayaUsdAPI::getUsdRunTimeId())
+    {
+        return m_previousHandler ? m_previousHandler->createLookdevEnvironmentCmdImpl(ancestor, targetRunTimeId)
+                                 : nullptr;
+    }
+
+    return MayaUsdCreateLookdevEnvironmentCommand::create(ancestor->path());
+}
+
+bool ProxyShapeLookdevHandler::isLookdevContainerImpl(const Ufe::SceneItem::Ptr& item) const
+{
+    // If item is not a proxy shape, pass to the previous handler.
+    if (!item || !MayaUsdAPI::isAGatewayType(item->nodeType()))
+    {
+        return m_previousHandler ? m_previousHandler->isLookdevContainerImpl(item) : false;
+    }
+
+    return item->nodeType() == "Material";
+}
+
+MayaUsdCreateLookdevEnvironmentCommand::MayaUsdCreateLookdevEnvironmentCommand(Ufe::Path ancestor)
+    : m_ancestor(std::move(ancestor)), m_materialParent(nullptr),
+      m_cmds(std::make_shared<Ufe::CompositeUndoableCommand>())
+{
+}
+
+MayaUsdCreateLookdevEnvironmentCommand::Ptr MayaUsdCreateLookdevEnvironmentCommand::create(const Ufe::Path& ancestor)
+{
+    return std::make_shared<MayaUsdCreateLookdevEnvironmentCommand>(ancestor);
+}
+
+Ufe::SceneItem::Ptr MayaUsdCreateLookdevEnvironmentCommand::sceneItem() const
+{
+    return m_materialParent;
+}
+
+void MayaUsdCreateLookdevEnvironmentCommand::execute()
+{
+    bool success = executeCommand();
+    if (!success)
+    {
+        m_cmds->undo();
+        m_cmds.reset();
+    }
+}
+
+bool MayaUsdCreateLookdevEnvironmentCommand::executeCommand()
+{
+    auto ancestor = Ufe::Hierarchy::createItem(m_ancestor);
+
+    if (!ancestor || ancestor->runTimeId() != MayaUsdAPI::getMayaRunTimeId())
+    {
+        return false;
+    }
+
+    // Check if m_ancestor is a proxy shape or the transform of a proxy shape.
+    Ufe::SceneItem::Ptr proxyShape = nullptr;
+    if (MayaUsdAPI::isAGatewayType(ancestor->nodeType()))
+    {
+        proxyShape = ancestor;
+    }
+    else
+    {
+        Ufe::Hierarchy::Ptr hierarchy = Ufe::Hierarchy::hierarchy(ancestor);
+        if (hierarchy && hierarchy->children().size() == 1)
+        {
+            auto child = hierarchy->children().back();
+            if (child && MayaUsdAPI::isAGatewayType(child->nodeType()))
+            {
+                proxyShape = child;
+            }
+        }
+    }
+
+    // If not, create a new proxy shape.
+    if (!proxyShape)
+    {
+        auto createProxyCommand = std::dynamic_pointer_cast<Ufe::SceneItemResultUndoableCommand>(
+            MayaUsdAPI::createStageWithNewLayerCommand(ancestor));
+        if (!createProxyCommand)
+        {
+            return false;
+        }
+
+        createProxyCommand->execute();
+        proxyShape = createProxyCommand->sceneItem();
+        if (!proxyShape)
+        {
+            return false;
+        }
+        m_cmds->append(createProxyCommand);
+    }
+
+    // Create a materials scope under the proxy shape.
+    auto proxyShapeItem =
+        MayaUsdAPI::createUsdSceneItem(proxyShape->path(), MayaUsdAPI::ufePathToPrim(proxyShape->path()));
+    if (!proxyShapeItem || !MayaUsdAPI::getPrimForUsdSceneItem(proxyShapeItem).IsValid())
+    {
+        return false;
+    }
+    auto createMaterialsScopeCmd = std::dynamic_pointer_cast<Ufe::SceneItemResultUndoableCommand>(
+        MayaUsdAPI::createMaterialsScopeCommand(proxyShapeItem));
+    if (!createMaterialsScopeCmd)
+    {
+        return false;
+    }
+    createMaterialsScopeCmd->execute();
+
+    auto materialsScope = createMaterialsScopeCmd->sceneItem();
+    if (!materialsScope)
+    {
+        return false;
+    }
+    m_cmds->append(createMaterialsScopeCmd);
+    m_materialParent = materialsScope;
+
+    return true;
+}
+
+void MayaUsdCreateLookdevEnvironmentCommand::undo()
+{
+    if (m_cmds)
+    {
+        m_cmds->undo();
+        m_materialParent.reset();
+    }
+}
+
+void MayaUsdCreateLookdevEnvironmentCommand::redo()
+{
+    if (m_cmds)
+    {
+        m_cmds->redo();
+    }
+}
+
+} // namespace LookdevXUsd

--- a/lib/lookdevXUsd/ProxyShapeLookdevHandler.h
+++ b/lib/lookdevXUsd/ProxyShapeLookdevHandler.h
@@ -1,0 +1,88 @@
+//*****************************************************************************
+// Copyright (c) 2025 Autodesk, Inc.
+// All rights reserved.
+//
+// These coded instructions, statements, and computer programs contain
+// unpublished proprietary information written by Autodesk, Inc. and are
+// protected by Federal copyright law. They may not be disclosed to third
+// parties or copied or duplicated in any form, in whole or in part, without
+// the prior written consent of Autodesk, Inc.
+//*****************************************************************************
+#pragma once
+
+#include <LookdevXUfe/LookdevHandler.h>
+
+#include <ufe/undoableCommand.h>
+
+namespace LookdevXUsd
+{
+
+//! \brief Maya run-time Lookdev handler. Used to deal with MayaUsdProxyShape items.
+class ProxyShapeLookdevHandler : public LookdevXUfe::LookdevHandler
+{
+public:
+    using Ptr = std::shared_ptr<ProxyShapeLookdevHandler>;
+
+    explicit ProxyShapeLookdevHandler(LookdevXUfe::LookdevHandler::Ptr previousHandler);
+    ~ProxyShapeLookdevHandler() override = default;
+
+    //@{
+    //! Delete the copy/move constructors assignment operators.
+    ProxyShapeLookdevHandler(const ProxyShapeLookdevHandler&) = delete;
+    ProxyShapeLookdevHandler& operator=(const ProxyShapeLookdevHandler&) = delete;
+    ProxyShapeLookdevHandler(ProxyShapeLookdevHandler&&) = delete;
+    ProxyShapeLookdevHandler& operator=(ProxyShapeLookdevHandler&&) = delete;
+    //@}
+
+    //! Create a ProxyShapeLookdevHandler.
+    static ProxyShapeLookdevHandler::Ptr create(const LookdevXUfe::LookdevHandler::Ptr& previousHandler);
+
+    [[nodiscard]] Ufe::SceneItemResultUndoableCommand::Ptr createLookdevContainerCmdImpl(
+        const Ufe::SceneItem::Ptr& parent, const Ufe::PathComponent& name) const override;
+    [[nodiscard]] Ufe::SceneItemResultUndoableCommand::Ptr createLookdevContainerCmdImpl(
+        const Ufe::SceneItem::Ptr& parent, const Ufe::NodeDef::Ptr& nodeDef) const override;
+    [[nodiscard]] Ufe::SceneItemResultUndoableCommand::Ptr createLookdevEnvironmentCmdImpl(
+        const Ufe::SceneItem::Ptr& ancestor, Ufe::Rtid targetRunTimeId) const override;
+    [[nodiscard]] bool isLookdevContainerImpl(const Ufe::SceneItem::Ptr& item) const override;
+
+private:
+    LookdevXUfe::LookdevHandler::Ptr m_previousHandler;
+}; // ProxyShapeLookdevHandler
+
+class MayaUsdCreateLookdevEnvironmentCommand : public Ufe::SceneItemResultUndoableCommand
+{
+public:
+    using Ptr = std::shared_ptr<MayaUsdCreateLookdevEnvironmentCommand>;
+
+    explicit MayaUsdCreateLookdevEnvironmentCommand(Ufe::Path ancestor);
+    ~MayaUsdCreateLookdevEnvironmentCommand() override = default;
+
+    // Delete the copy/move constructors assignment operators.
+    MayaUsdCreateLookdevEnvironmentCommand(const MayaUsdCreateLookdevEnvironmentCommand&) = delete;
+    MayaUsdCreateLookdevEnvironmentCommand& operator=(const MayaUsdCreateLookdevEnvironmentCommand&) = delete;
+    MayaUsdCreateLookdevEnvironmentCommand(MayaUsdCreateLookdevEnvironmentCommand&&) = delete;
+    MayaUsdCreateLookdevEnvironmentCommand& operator=(MayaUsdCreateLookdevEnvironmentCommand&&) = delete;
+
+    //! Create a MayaUsdCreateLookdevEnvironmentCommand that finds or creates an item under \p ancestor that can serve
+    //! as a parent of a material.
+    //! - If \p ancestor is a Maya object, a new USD stage will be created under it and a materials scope will be
+    //!   created within the new stage.
+    //! - If \p ancestor is a USD stage, a materials scope will be created under it.
+    //! - If \p ancestor already contains a materials scope, the existing scope will be returned.
+    static MayaUsdCreateLookdevEnvironmentCommand::Ptr create(const Ufe::Path& ancestor);
+
+    [[nodiscard]] Ufe::SceneItem::Ptr sceneItem() const override;
+
+    void execute() override;
+    void undo() override;
+    void redo() override;
+
+private:
+    bool executeCommand();
+
+    Ufe::Path m_ancestor;
+    Ufe::SceneItem::Ptr m_materialParent;
+    std::shared_ptr<Ufe::CompositeUndoableCommand> m_cmds;
+}; // MayaUsdCreateLookdevEnvironmentCommand
+
+} // namespace LookdevXUsd

--- a/lib/lookdevXUsd/ProxyShapeLookdevHandler.h
+++ b/lib/lookdevXUsd/ProxyShapeLookdevHandler.h
@@ -81,7 +81,7 @@ private:
     bool executeCommand();
 
     Ufe::Path m_ancestor;
-    Ufe::SceneItem::Ptr m_materialParent;
+    Ufe::Path m_materialParent;
     std::shared_ptr<Ufe::CompositeUndoableCommand> m_cmds;
 }; // MayaUsdCreateLookdevEnvironmentCommand
 

--- a/lib/lookdevXUsd/UsdMaterialHandler.cpp
+++ b/lib/lookdevXUsd/UsdMaterialHandler.cpp
@@ -47,7 +47,7 @@ LookdevXUfe::Material::Ptr UsdMaterialHandler::material(const Ufe::SceneItem::Pt
     // Test if this item is imageable or a geom subset. If not, then we cannot create a material
     // interface for it, which is a valid case (such as for a material node type).
     const auto prim = MayaUsdAPI::getPrimForUsdSceneItem(item);
-    if (!PXR_NS::UsdGeomImageable(prim) && !prim.IsA<UsdGeomSubset>())
+    if (!UsdGeomImageable(prim) && !prim.IsA<UsdGeomSubset>())
     {
         return nullptr;
     }

--- a/lib/lookdevXUsd/UsdMaterialHandler.cpp
+++ b/lib/lookdevXUsd/UsdMaterialHandler.cpp
@@ -17,6 +17,7 @@
 
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/usd/usdGeom/imageable.h>
+#include <pxr/usd/usdGeom/subset.h>
 #include <pxr/usd/usdShade/material.h>
 
 namespace LookdevXUsd
@@ -39,6 +40,14 @@ LookdevXUfe::Material::Ptr UsdMaterialHandler::material(const Ufe::SceneItem::Pt
     using namespace PXR_NS;
 
     if (!TF_VERIFY(MayaUsdAPI::isUsdSceneItem(item), "Invalid item\n"))
+    {
+        return nullptr;
+    }
+
+    // Test if this item is imageable or a geom subset. If not, then we cannot create a material
+    // interface for it, which is a valid case (such as for a material node type).
+    const auto prim = MayaUsdAPI::getPrimForUsdSceneItem(item);
+    if (!PXR_NS::UsdGeomImageable(prim) && !prim.IsA<UsdGeomSubset>())
     {
         return nullptr;
     }

--- a/lib/lookdevXUsd/UsdMaterialHandler.cpp
+++ b/lib/lookdevXUsd/UsdMaterialHandler.cpp
@@ -43,14 +43,6 @@ LookdevXUfe::Material::Ptr UsdMaterialHandler::material(const Ufe::SceneItem::Pt
         return nullptr;
     }
 
-    // Test if this item is imageable. If not, then we cannot create a material
-    // interface for it, which is a valid case (such as for a material node type).
-    PXR_NS::UsdGeomImageable primSchema(MayaUsdAPI::getPrimForUsdSceneItem(item));
-    if (!primSchema)
-    {
-        return nullptr;
-    }
-
     return UsdMaterial::create(item);
 }
 

--- a/lib/lookdevXUsd/UsdMaterialHandler.cpp
+++ b/lib/lookdevXUsd/UsdMaterialHandler.cpp
@@ -47,7 +47,7 @@ LookdevXUfe::Material::Ptr UsdMaterialHandler::material(const Ufe::SceneItem::Pt
     // Test if this item is imageable or a geom subset. If not, then we cannot create a material
     // interface for it, which is a valid case (such as for a material node type).
     const auto prim = MayaUsdAPI::getPrimForUsdSceneItem(item);
-    if (!UsdGeomImageable(prim) && !prim.IsA<UsdGeomSubset>())
+    if (!PXR_NS::UsdGeomImageable(prim) && !prim.IsA<PXR_NS::UsdGeomSubset>())
     {
         return nullptr;
     }


### PR DESCRIPTION
To decouple form USD, LookkdevX wants to move out any remaining USD dependencies. 

This PR moves the `ProxyShapeLookdevHandler` and its associated command `MayaUsdCreateLookdevEnvironmentCommand` to MayaUSD. This was missed when moving LookdevXUsd to MayaUSD: The `ProxyShapeLookdevHandler` is registered against the Maya runtime and, thus, resided in a different folder.

Unfortunately, there are no Python bindings for the `LookdevXUfe::LookdevHandler` yet, so I'm not sure if the test can be moved over right now. I logged another ticket to add bindings and move the test. 

This PR also makes a small change to `LookdevXUfe::UsdMaterialHandler`. See comment below.