### PR TITLE
Recognize new default sRGB color space name

### DIFF
--- a/test/lib/usd/translators/testUsdExportUsdPreviewSurface.py
+++ b/test/lib/usd/translators/testUsdExportUsdPreviewSurface.py
@@ -189,7 +189,7 @@ class testUsdExportUsdPreviewSurface(unittest.TestCase):
 
         # This file node should have stayed "sRGB":
         if not ignoreColorSpaceFileRules:
-            self.assertEqual(cmds.getAttr(file_node + ".colorSpace"), "sRGB")
+            self.assertIn(cmds.getAttr(file_node + ".colorSpace"), ["sRGB", "sRGB Encoded Rec.709 (sRGB)"])
 
         cmds.defaultNavigation(
             createNew=True, destination="%s.roughness" % shading_node


### PR DESCRIPTION
Maya OCIO default now has "sRGB Encoded Rec.709 (sRGB)" as default color space for sRGB textures.