### PR TITLE
EMSUSD-2578: Material prims break AE on Maya 2023 / 2022

### DIFF
--- a/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
@@ -422,6 +422,9 @@ class AETemplate(object):
                     if self.attrS.attribute(item):
                         self.addControls([item])
     def isRamp(self):
+        if not hasattr(ufe, "NodeDefHandler"):
+            return False
+
         runTimeMgr = ufe.RunTimeMgr.instance()
         nodeDefHandler = runTimeMgr.nodeDefHandler(self.item.runTimeId())
         nodeDef = nodeDefHandler.definition(self.item)


### PR DESCRIPTION
#### EMSUSD-2578: Material prims break AE on Maya 2023 / 2022
* NodeDefHandler was only added in Ufe v4