### PR TITLE
Anim spline, fix vertical aperture incorrect unit.

### DIFF
--- a/lib/usd/translators/cameraWriter.cpp
+++ b/lib/usd/translators/cameraWriter.cpp
@@ -167,7 +167,7 @@ bool PxrUsdTranslators_CameraWriter::writeCameraSplinesAttrs(UsdGeomCamera& prim
             cameraPrim,
             "verticalFilmAperture",
             HdCameraTokens->verticalAperture,
-            UsdMayaUtil::kMillimetersPerCentimeter);
+            UsdMayaUtil::ConvertInchesToMM(1));
 
         if (camFn.shakeEnabled()) {
             std::function shakeLambda = [](float apertureOffset, float shakeOffset) {

--- a/test/lib/usd/translators/testUsdExportCameraAttrSpline.py
+++ b/test/lib/usd/translators/testUsdExportCameraAttrSpline.py
@@ -145,7 +145,7 @@ class testUsdExportCameraAttrSpline(unittest.TestCase):
 
         verticalApertureAttr = usdCamera.GetPrim().GetAttribute('verticalAperture')
         verticalAperture = verticalApertureAttr.Get()
-        self.assertTrue(Gf.IsClose(verticalAperture, 9.4488, self.EPSILON))
+        self.assertTrue(Gf.IsClose(verticalAperture, 23.999952, self.EPSILON))
 
     @unittest.skipUnless(Usd.GetVersion() >= (0, 24, 11), 'Splines are only supported in USD 0.24.11 and later')
     def testExportOrthographicAttributes(self):


### PR DESCRIPTION
Convert vertical aperture from inches to mm. Previous conversion was incorrect.