### PR TITLE
API doc is no longer included schema's "doc" field

### DIFF
--- a/test/lib/ufe/testAttribute.py
+++ b/test/lib/ufe/testAttribute.py
@@ -1607,15 +1607,10 @@ class AttributeTestCase(unittest.TestCase):
         # Test for non-existing metdata.
         self.assertFalse(attr.hasMetadata('NotAMetadata'))
 
-        # Verify that this attribute has documentation metadata.
-        self.assertTrue(attr.hasMetadata('documentation'))
-        md = attr.getMetadata('documentation')
-        self.assertIsNotNone(md)
-        self.assertIsNotNone(str(md))
-
         # Store this original documentation metadata value for testing of the clear.
         # Note: USD doc has some fallback values, so clearing doc might not actually
         #       set it to empty.
+        md = attr.getMetadata('documentation')
         origDocMD = str(md)
 
         # Change the metadata and make sure it changed

--- a/test/lib/ufe/testAttribute.py
+++ b/test/lib/ufe/testAttribute.py
@@ -1613,6 +1613,15 @@ class AttributeTestCase(unittest.TestCase):
         md = attr.getMetadata('documentation')
         origDocMD = str(md)
 
+        # Verify that this attribute has documentation metadata.
+        # The use of the documentation field in schema prim/property definitions
+        # to store API doc has been deprecated, so only verify on older versions
+        # of USD
+        if Usd.GetVersion() <= (0, 25, 5):
+            self.assertTrue(attr.hasMetadata('documentation'))
+            self.assertIsNotNone(md)
+            self.assertIsNotNone(origDocMD)
+
         # Change the metadata and make sure it changed
         self.assertTrue(attr.setMetadata('documentation', 'New doc'))
         self.assertTrue(attr.hasMetadata('documentation'))


### PR DESCRIPTION
The assertion that the doc metadata should exist is no longer valid