### PR TITLE
EMSUSD-2648/2648 - UsdUfe: move delete and rename commands from MayaUsd

### DIFF
--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(${PROJECT_NAME}
         MayaUsdObject3d.cpp
         MayaUsdObject3dHandler.cpp
         MayaUsdUIInfoHandler.cpp
+        MayaUsdUndoRenameCommand.cpp
         ProxyShapeContextOpsHandler.cpp
         ProxyShapeHandler.cpp
         ProxyShapeHierarchy.cpp
@@ -18,10 +19,8 @@ target_sources(${PROJECT_NAME}
         UsdSceneItemOpsHandler.cpp
         UsdStageMap.cpp
         UsdUIUfeObserver.cpp
-        UsdUndoDeleteCommand.cpp
         UsdUndoDuplicateCommand.cpp
         UsdUndoMaterialCommands.cpp
-        UsdUndoRenameCommand.cpp
         Utils.cpp
         moduleDeps.cpp
 )
@@ -192,6 +191,7 @@ set(HEADERS
     MayaUsdObject3d.h
     MayaUsdObject3dHandler.h
     MayaUsdUIInfoHandler.h
+    MayaUsdUndoRenameCommand.h
     ProxyShapeContextOpsHandler.h
     ProxyShapeHandler.h
     ProxyShapeHierarchy.h
@@ -200,10 +200,8 @@ set(HEADERS
     UsdSceneItemOpsHandler.h
     UsdStageMap.h
     UsdUIUfeObserver.h
-    UsdUndoDeleteCommand.h
     UsdUndoDuplicateCommand.h
     UsdUndoMaterialCommands.h
-    UsdUndoRenameCommand.h
     Utils.h
 )
 

--- a/lib/mayaUsd/ufe/MayaUsdUndoRenameCommand.cpp
+++ b/lib/mayaUsd/ufe/MayaUsdUndoRenameCommand.cpp
@@ -1,0 +1,77 @@
+//
+// Copyright 2025 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "MayaUsdUndoRenameCommand.h"
+
+#include <mayaUsd/ufe/Global.h>
+#include <mayaUsd/ufe/ProxyShapeHandler.h>
+#include <mayaUsd/ufe/Utils.h>
+
+#include <usdUfe/ufe/Utils.h>
+
+#include <ufe/pathSegment.h>
+#include <ufe/pathString.h>
+#include <ufe/sceneNotification.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+// Ensure that MayaUsdUndoRenameCommand is properly setup.
+MAYAUSD_VERIFY_CLASS_SETUP(UsdUfe::UsdUndoRenameCommand, MayaUsdUndoRenameCommand);
+
+MayaUsdUndoRenameCommand::MayaUsdUndoRenameCommand(
+    const UsdUfe::UsdSceneItem::Ptr& srcItem,
+    const Ufe::PathComponent&        newName)
+    : UsdUfe::UsdUndoRenameCommand(srcItem, newName)
+{
+}
+
+UsdUfe::UsdUndoRenameCommand::Ptr MayaUsdUndoRenameCommand::create(
+    const UsdUfe::UsdSceneItem::Ptr& srcItem,
+    const Ufe::PathComponent&        newName)
+{
+    return std::make_shared<MayaUsdUndoRenameCommand>(srcItem, newName);
+}
+
+void MayaUsdUndoRenameCommand::sendRenameNotification(
+    const PXR_NS::UsdStagePtr& stage,
+    const PXR_NS::UsdPrim&     prim,
+    const Ufe::Path&           srcPath,
+    const Ufe::Path&           dstPath)
+{
+    for (const std::string& proxyName : ProxyShapeHandler::getAllNames()) {
+        PXR_NS::UsdStagePtr proxyStage = ProxyShapeHandler::dagPathToStage(proxyName);
+        if (proxyStage != stage)
+            continue;
+
+        // For all the proxy shapes that are mapping the same stage, we need to fixup the
+        // Ufe path since they have different Ufe Paths because it contains proxy shape name.
+        auto proxyNamePath = Ufe::PathString::path(proxyName);
+        auto proxySegment = proxyNamePath.getSegments()[0];
+
+        const Ufe::PathSegment& srcUsdSegment = srcPath.getSegments()[1];
+        const Ufe::Path adjustedSrcPath(Ufe::Path::Segments({ proxySegment, srcUsdSegment }));
+
+        const Ufe::PathSegment& dstUsdSegment = dstPath.getSegments()[1];
+        const Ufe::Path adjustedDstPath(Ufe::Path::Segments({ proxySegment, dstUsdSegment }));
+
+        auto newItem = UsdUfe::UsdSceneItem::create(adjustedDstPath, prim);
+
+        UsdUfe::sendNotification<Ufe::ObjectRename>(newItem, adjustedSrcPath);
+    }
+}
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/MayaUsdUndoRenameCommand.h
+++ b/lib/mayaUsd/ufe/MayaUsdUndoRenameCommand.h
@@ -1,0 +1,51 @@
+//
+// Copyright 2025 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_USDUNDORENAMECOMMAND_H
+#define MAYAUSD_USDUNDORENAMECOMMAND_H
+
+#include <mayaUsd/base/api.h>
+
+#include <usdUfe/ufe/UsdUndoRenameCommand.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+//! \brief MayaUsdUndoRenameCommand
+class MAYAUSD_CORE_PUBLIC MayaUsdUndoRenameCommand : public UsdUfe::UsdUndoRenameCommand
+{
+public:
+    MayaUsdUndoRenameCommand(
+        const UsdUfe::UsdSceneItem::Ptr& srcItem,
+        const Ufe::PathComponent&        newName);
+
+    MAYAUSD_DISALLOW_COPY_MOVE_AND_ASSIGNMENT(MayaUsdUndoRenameCommand);
+
+    //! Create a MayaUsdUndoRenameCommand from a USD scene item and UFE pathcomponent.
+    static UsdUndoRenameCommand::Ptr
+    create(const UsdUfe::UsdSceneItem::Ptr& srcItem, const Ufe::PathComponent& newName);
+
+    void sendRenameNotification(
+        const PXR_NS::UsdStagePtr& stage,
+        const PXR_NS::UsdPrim&     prim,
+        const Ufe::Path&           srcPath,
+        const Ufe::Path&           dstPath) override;
+
+}; // MayaUsdUndoRenameCommand
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDUNDORENAMECOMMAND_H

--- a/lib/mayaUsd/ufe/UsdSceneItemOps.cpp
+++ b/lib/mayaUsd/ufe/UsdSceneItemOps.cpp
@@ -15,10 +15,11 @@
 //
 #include "UsdSceneItemOps.h"
 
-#include <mayaUsd/ufe/UsdUndoDeleteCommand.h>
+#include <mayaUsd/ufe/MayaUsdUndoRenameCommand.h>
 #include <mayaUsd/ufe/UsdUndoDuplicateCommand.h>
-#include <mayaUsd/ufe/UsdUndoRenameCommand.h>
 #include <mayaUsd/ufe/Utils.h>
+
+#include <usdUfe/ufe/UsdUndoDeleteCommand.h>
 
 #include <maya/MGlobal.h>
 
@@ -52,13 +53,13 @@ Ufe::SceneItem::Ptr UsdSceneItemOps::sceneItem() const { return _item; }
 #ifdef UFE_V4_FEATURES_AVAILABLE
 Ufe::UndoableCommand::Ptr UsdSceneItemOps::deleteItemCmdNoExecute()
 {
-    return UsdUndoDeleteCommand::create(prim());
+    return UsdUfe::UsdUndoDeleteCommand::create(prim());
 }
 #endif
 
 Ufe::UndoableCommand::Ptr UsdSceneItemOps::deleteItemCmd()
 {
-    auto deleteCmd = UsdUndoDeleteCommand::create(prim());
+    auto deleteCmd = UsdUfe::UsdUndoDeleteCommand::create(prim());
     deleteCmd->execute();
     return deleteCmd;
 }
@@ -66,7 +67,7 @@ Ufe::UndoableCommand::Ptr UsdSceneItemOps::deleteItemCmd()
 bool UsdSceneItemOps::deleteItem()
 {
     if (prim()) {
-        auto deleteCmd = UsdUndoDeleteCommand::create(prim());
+        auto deleteCmd = UsdUfe::UsdUndoDeleteCommand::create(prim());
         deleteCmd->execute();
         return true;
     }
@@ -98,20 +99,20 @@ Ufe::SceneItem::Ptr UsdSceneItemOps::duplicateItem()
 Ufe::SceneItemResultUndoableCommand::Ptr
 UsdSceneItemOps::renameItemCmdNoExecute(const Ufe::PathComponent& newName)
 {
-    return UsdUndoRenameCommand::create(_item, newName);
+    return MayaUsdUndoRenameCommand::create(_item, newName);
 }
 #endif
 
 Ufe::Rename UsdSceneItemOps::renameItemCmd(const Ufe::PathComponent& newName)
 {
-    auto renameCmd = UsdUndoRenameCommand::create(_item, newName);
+    auto renameCmd = MayaUsdUndoRenameCommand::create(_item, newName);
     renameCmd->execute();
     return Ufe::Rename(renameCmd->renamedItem(), renameCmd);
 }
 
 Ufe::SceneItem::Ptr UsdSceneItemOps::renameItem(const Ufe::PathComponent& newName)
 {
-    auto renameCmd = UsdUndoRenameCommand::create(_item, newName);
+    auto renameCmd = MayaUsdUndoRenameCommand::create(_item, newName);
     renameCmd->execute();
     return renameCmd->renamedItem();
 }

--- a/lib/mayaUsd/ufe/UsdUndoCreateStageWithNewLayerCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoCreateStageWithNewLayerCommand.cpp
@@ -15,7 +15,6 @@
 //
 #include "UsdUndoCreateStageWithNewLayerCommand.h"
 
-#include <mayaUsd/ufe/UsdUndoRenameCommand.h>
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/undo/OpUndoItemRecorder.h>
 #include <mayaUsd/undo/OpUndoItems.h>

--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
@@ -21,6 +21,7 @@
 
 #include <usdUfe/base/tokens.h>
 #include <usdUfe/ufe/UfeNotifGuard.h>
+#include <usdUfe/ufe/Utils.h>
 #include <usdUfe/undo/UsdUndoBlock.h>
 #include <usdUfe/utils/editRouter.h>
 #include <usdUfe/utils/editRouterContext.h>
@@ -79,7 +80,7 @@ UsdUndoDuplicateCommand::create(const UsdUfe::UsdSceneItem::Ptr& srcItem)
 
 UsdUfe::UsdSceneItem::Ptr UsdUndoDuplicateCommand::duplicatedItem() const
 {
-    return createSiblingSceneItem(_ufeSrcPath, _usdDstPath.GetElementString());
+    return UsdUfe::createSiblingSceneItem(_ufeSrcPath, _usdDstPath.GetElementString());
 }
 
 void UsdUndoDuplicateCommand::execute()

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
@@ -16,7 +16,7 @@
 #include "UsdUndoMaterialCommands.h"
 
 #include <mayaUsd/fileio/jobs/jobArgs.h>
-#include <mayaUsd/ufe/UsdUndoRenameCommand.h>
+#include <mayaUsd/ufe/MayaUsdUndoRenameCommand.h>
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/utils/util.h>
 
@@ -704,7 +704,7 @@ bool UsdUndoCreateMaterialsScopeCommand::doExecute()
     }
 
     auto materialsScopeName = UsdMayaJobExportArgs::GetDefaultMaterialsScopeName();
-    auto renameCmd = UsdUndoRenameCommand::create(scopeItem, materialsScopeName);
+    auto renameCmd = MayaUsdUndoRenameCommand::create(scopeItem, materialsScopeName);
     if (!renameCmd) {
         return false;
     }

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -135,13 +135,6 @@ UsdPrim ufePathToPrim(const Ufe::Path& path)
         : stage->GetPrimAtPath(SdfPath(segments[1].string()).GetPrimPath());
 }
 
-UsdUfe::UsdSceneItem::Ptr
-createSiblingSceneItem(const Ufe::Path& ufeSrcPath, const std::string& siblingName)
-{
-    auto ufeSiblingPath = ufeSrcPath.sibling(Ufe::PathComponent(siblingName));
-    return UsdUfe::UsdSceneItem::create(ufeSiblingPath, ufePathToPrim(ufeSiblingPath));
-}
-
 std::string uniqueChildNameMayaStandard(const PXR_NS::UsdPrim& usdParent, const std::string& name)
 {
     if (!usdParent.IsValid())

--- a/lib/mayaUsd/ufe/Utils.h
+++ b/lib/mayaUsd/ufe/Utils.h
@@ -78,10 +78,6 @@ bool isInStagesCache(const Ufe::Path& path);
 MAYAUSD_CORE_PUBLIC
 PXR_NS::UsdPrim ufePathToPrim(const Ufe::Path& path);
 
-MAYAUSD_CORE_PUBLIC
-UsdUfe::UsdSceneItem::Ptr
-createSiblingSceneItem(const Ufe::Path& ufeSrcPath, const std::string& siblingName);
-
 //! Returns a unique child name following the Maya standard naming rules.
 MAYAUSD_CORE_PUBLIC
 std::string uniqueChildNameMayaStandard(const PXR_NS::UsdPrim& usdParent, const std::string& name);

--- a/lib/usdUfe/ufe/CMakeLists.txt
+++ b/lib/usdUfe/ufe/CMakeLists.txt
@@ -30,10 +30,12 @@ target_sources(${PROJECT_NAME}
         UsdUndoClearPayloadsCommand.cpp
         UsdUndoClearReferencesCommand.cpp
         UsdUndoCreateGroupCommand.cpp
+        UsdUndoDeleteCommand.cpp
         UsdUndoInsertChildCommand.cpp
         UsdUndoLongDurationCommand.cpp
         UsdUndoPayloadCommand.cpp
         UsdUndoReloadRefCommand.cpp
+        UsdUndoRenameCommand.cpp
         UsdUndoReorderCommand.cpp
         UsdUndoSelectAfterCommand.cpp
         UsdUndoSetKindCommand.cpp
@@ -156,10 +158,12 @@ set(HEADERS
     UsdUndoClearPayloadsCommand.h
     UsdUndoClearReferencesCommand.h
     UsdUndoCreateGroupCommand.h
+    UsdUndoDeleteCommand.h
     UsdUndoInsertChildCommand.h
     UsdUndoLongDurationCommand.h
     UsdUndoPayloadCommand.h
     UsdUndoReloadRefCommand.h
+    UsdUndoRenameCommand.h
     UsdUndoReorderCommand.h
     UsdUndoSelectAfterCommand.h
     UsdUndoSetKindCommand.h

--- a/lib/usdUfe/ufe/UsdUndoDeleteCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoDeleteCommand.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Autodesk
+// Copyright 2015 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,10 +30,9 @@
 #include <usdUfe/ufe/UsdAttributes.h>
 #endif
 
-namespace MAYAUSD_NS_DEF {
-namespace ufe {
+namespace USDUFE_NS_DEF {
 
-MAYAUSD_VERIFY_CLASS_SETUP(Ufe::UndoableCommand, UsdUndoDeleteCommand);
+USDUFE_VERIFY_CLASS_SETUP(Ufe::UndoableCommand, UsdUndoDeleteCommand);
 
 UsdUndoDeleteCommand::UsdUndoDeleteCommand(const PXR_NS::UsdPrim& prim)
     : Ufe::UndoableCommand()
@@ -131,5 +130,4 @@ void UsdUndoDeleteCommand::redo()
     _undoableItem.redo();
 }
 
-} // namespace ufe
-} // namespace MAYAUSD_NS_DEF
+} // namespace USDUFE_NS_DEF

--- a/lib/usdUfe/ufe/UsdUndoDeleteCommand.h
+++ b/lib/usdUfe/ufe/UsdUndoDeleteCommand.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Autodesk
+// Copyright 2015 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#ifndef MAYAUSD_USDUNDODELETECOMMAND_H
-#define MAYAUSD_USDUNDODELETECOMMAND_H
+#ifndef USDUFE_USDUNDODELETECOMMAND_H
+#define USDUFE_USDUNDODELETECOMMAND_H
 
-#include <mayaUsd/base/api.h>
-
+#include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UfeVersionCompat.h>
 #include <usdUfe/ufe/UsdSceneItem.h>
 #include <usdUfe/undo/UsdUndoableItem.h>
@@ -26,18 +25,17 @@
 
 #include <ufe/undoableCommand.h>
 
-namespace MAYAUSD_NS_DEF {
-namespace ufe {
+namespace USDUFE_NS_DEF {
 
 //! \brief UsdUndoDeleteCommand
-class MAYAUSD_CORE_PUBLIC UsdUndoDeleteCommand : public Ufe::UndoableCommand
+class USDUFE_PUBLIC UsdUndoDeleteCommand : public Ufe::UndoableCommand
 {
 public:
     typedef std::shared_ptr<UsdUndoDeleteCommand> Ptr;
 
     UsdUndoDeleteCommand(const PXR_NS::UsdPrim& prim);
 
-    MAYAUSD_DISALLOW_COPY_MOVE_AND_ASSIGNMENT(UsdUndoDeleteCommand);
+    USDUFE_DISALLOW_COPY_MOVE_AND_ASSIGNMENT(UsdUndoDeleteCommand);
 
     //! Create a UsdUndoDeleteCommand from a USD prim.
     static UsdUndoDeleteCommand::Ptr create(const PXR_NS::UsdPrim& prim);
@@ -52,7 +50,6 @@ private:
 
 }; // UsdUndoDeleteCommand
 
-} // namespace ufe
-} // namespace MAYAUSD_NS_DEF
+} // namespace USDUFE_NS_DEF
 
-#endif // MAYAUSD_USDUNDODELETECOMMAND_H
+#endif // USDUFE_USDUNDODELETECOMMAND_H

--- a/lib/usdUfe/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoInsertChildCommand.cpp
@@ -315,7 +315,7 @@ void UsdUndoInsertChildCommand::execute()
         // Create a new segment if parent and child are in different run-times.
         // parenting a USD node to the proxy shape node implies two different run-times
         auto cRtId = _ufeSrcPath.runTimeId();
-        if (_ufeParentPath.runTimeId() == cRtId) {
+        if ((_ufeParentPath.runTimeId() == cRtId) && (_ufeParentPath.nbSegments() > 1)) {
             _ufeDstPath = _ufeParentPath + childName;
         } else {
             auto cSep = _ufeSrcPath.getSegments().back().separator();

--- a/lib/usdUfe/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoInsertChildCommand.cpp
@@ -314,6 +314,9 @@ void UsdUndoInsertChildCommand::execute()
 
         // Create a new segment if parent and child are in different run-times.
         // parenting a USD node to the proxy shape node implies two different run-times
+        // Contrary to MayaUsd, MaxUsd uses 2 segments using the USD RtId. The first
+        // segment maps to the pseudo-root prim. In Maya or Max - the segment containing
+        // the actual prim path is never the first.
         auto cRtId = _ufeSrcPath.runTimeId();
         if ((_ufeParentPath.runTimeId() == cRtId) && (_ufeParentPath.nbSegments() > 1)) {
             _ufeDstPath = _ufeParentPath + childName;

--- a/lib/usdUfe/ufe/UsdUndoRenameCommand.h
+++ b/lib/usdUfe/ufe/UsdUndoRenameCommand.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Autodesk
+// Copyright 2025 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,26 +13,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#ifndef MAYAUSD_USDUNDORENAMECOMMAND_H
-#define MAYAUSD_USDUNDORENAMECOMMAND_H
+#ifndef USDUFE_USDUNDORENAMECOMMAND_H
+#define USDUFE_USDUNDORENAMECOMMAND_H
 
-#include <mayaUsd/base/api.h>
-
+#include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UfeVersionCompat.h>
 #include <usdUfe/ufe/UsdSceneItem.h>
+
+#include <pxr/usd/usd/prim.h>
+#include <pxr/usd/usd/stage.h>
 
 #include <ufe/path.h>
 #include <ufe/pathComponent.h>
 #include <ufe/undoableCommand.h>
 
-namespace MAYAUSD_NS_DEF {
-namespace ufe {
+namespace USDUFE_NS_DEF {
 
 //! \brief UsdUndoRenameCommand
 #ifdef UFE_V4_FEATURES_AVAILABLE
-class MAYAUSD_CORE_PUBLIC UsdUndoRenameCommand : public Ufe::SceneItemResultUndoableCommand
+class USDUFE_PUBLIC UsdUndoRenameCommand : public Ufe::SceneItemResultUndoableCommand
 #else
-class MAYAUSD_CORE_PUBLIC UsdUndoRenameCommand : public Ufe::UndoableCommand
+class USDUFE_PUBLIC UsdUndoRenameCommand : public Ufe::UndoableCommand
 #endif
 {
 public:
@@ -42,7 +43,7 @@ public:
         const UsdUfe::UsdSceneItem::Ptr& srcItem,
         const Ufe::PathComponent&        newName);
 
-    MAYAUSD_DISALLOW_COPY_MOVE_AND_ASSIGNMENT(UsdUndoRenameCommand);
+    USDUFE_DISALLOW_COPY_MOVE_AND_ASSIGNMENT(UsdUndoRenameCommand);
 
     //! Create a UsdUndoRenameCommand from a USD scene item and UFE pathcomponent.
     static UsdUndoRenameCommand::Ptr
@@ -51,9 +52,23 @@ public:
     UsdUfe::UsdSceneItem::Ptr renamedItem() const;
     UFE_V4(Ufe::SceneItem::Ptr sceneItem() const override { return renamedItem(); })
 
+    virtual void sendRenameNotification(
+        const PXR_NS::UsdStagePtr& stage,
+        const PXR_NS::UsdPrim&     prim,
+        const Ufe::Path&           srcPath,
+        const Ufe::Path&           dstPath);
+
 private:
     void renameRedo();
     void renameUndo();
+
+    void renameHelper(
+        const PXR_NS::UsdStagePtr&       stage,
+        const UsdUfe::UsdSceneItem::Ptr& ufeSrcItem,
+        const Ufe::Path&                 srcPath,
+        UsdUfe::UsdSceneItem::Ptr&       ufeDstItem,
+        const Ufe::Path&                 dstPath,
+        const std::string&               newName);
 
     void undo() override;
     void redo() override;
@@ -66,7 +81,6 @@ private:
 
 }; // UsdUndoRenameCommand
 
-} // namespace ufe
-} // namespace MAYAUSD_NS_DEF
+} // namespace USDUFE_NS_DEF
 
-#endif // MAYAUSD_USDUNDORENAMECOMMAND_H
+#endif // USDUFE_USDUNDORENAMECOMMAND_H

--- a/lib/usdUfe/ufe/Utils.cpp
+++ b/lib/usdUfe/ufe/Utils.cpp
@@ -230,6 +230,13 @@ UsdPrim ufePathToPrim(const Ufe::Path& path)
     return gUfePathToPrimFn(path);
 }
 
+UsdSceneItem::Ptr
+createSiblingSceneItem(const Ufe::Path& ufeSrcPath, const std::string& siblingName)
+{
+    auto ufeSiblingPath = ufeSrcPath.sibling(Ufe::PathComponent(siblingName));
+    return UsdSceneItem::create(ufeSiblingPath, ufePathToPrim(ufeSiblingPath));
+}
+
 void setTimeAccessorFn(TimeAccessorFn fn)
 {
     if (nullptr == fn) {

--- a/lib/usdUfe/ufe/Utils.h
+++ b/lib/usdUfe/ufe/Utils.h
@@ -118,6 +118,10 @@ void setUfePathToPrimFn(UfePathToPrimFn fn);
 USDUFE_PUBLIC
 PXR_NS::UsdPrim ufePathToPrim(const Ufe::Path& path);
 
+USDUFE_PUBLIC
+UsdSceneItem::Ptr
+createSiblingSceneItem(const Ufe::Path& ufeSrcPath, const std::string& siblingName);
+
 //! Set the DCC specific time accessor function.
 //! It cannot be empty.
 //! \excpection std::invalid_argument if fn is empty.


### PR DESCRIPTION
#### EMSUSD-2648 - UsdUfe: move UsdUndoDeleteCommand from MayaUsd
#### EMSUSD-2649 - UsdUfe: move UsdUndoRenameCommand from MayaUsd
* Moved these two commands from MayaUsd to UsdUfe.
* Created MayaUsdUndoRenameCommand to overload virtual method for sending Ufe rename notif.
* Moved helper function createSiblingSceneItem().