### PR TITLE
Updates for MaterialX 1.39.4

### DIFF
--- a/lib/mayaUsd/render/MaterialXGenOgsXml/GlslOcioNodeImpl.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/GlslOcioNodeImpl.h
@@ -22,13 +22,22 @@
 
 #include <MaterialXGenGlsl/GlslShaderGenerator.h>
 
+#include <mayaUsd/render/MaterialXGenOgsXml/CombinedMaterialXVersion.h>
+
 MATERIALX_NAMESPACE_BEGIN
 
 /// GLSL OCIO node implementation. Takes a Maya OCIO shader fragment and
 /// makes it compatible with the shadergen
-class GlslOcioNodeImpl : public GlslImplementation
+class GlslOcioNodeImpl
+#if MX_COMBINED_VERSION >= 13904
+ : public HwImplementation
+#else
+ : public GlslImplementation
+#endif
 {
 public:
+
+
     static ShaderNodeImplPtr create();
 
     void

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/GlslOcioNodeImpl.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/GlslOcioNodeImpl.h
@@ -20,9 +20,9 @@
 /// @file
 /// GLSL OCIO node implementation
 
-#include <MaterialXGenGlsl/GlslShaderGenerator.h>
-
 #include <mayaUsd/render/MaterialXGenOgsXml/CombinedMaterialXVersion.h>
+
+#include <MaterialXGenGlsl/GlslShaderGenerator.h>
 
 MATERIALX_NAMESPACE_BEGIN
 
@@ -30,14 +30,12 @@ MATERIALX_NAMESPACE_BEGIN
 /// makes it compatible with the shadergen
 class GlslOcioNodeImpl
 #if MX_COMBINED_VERSION >= 13904
- : public HwImplementation
+    : public HwImplementation
 #else
- : public GlslImplementation
+    : public GlslImplementation
 #endif
 {
 public:
-
-
     static ShaderNodeImplPtr create();
 
     void

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaTransformVectorNodeGlsl.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaTransformVectorNodeGlsl.h
@@ -8,10 +8,17 @@
 
 #include <MaterialXGenGlsl/GlslShaderGenerator.h>
 
+#include <mayaUsd/render/MaterialXGenOgsXml/CombinedMaterialXVersion.h>
+
 MATERIALX_NAMESPACE_BEGIN
 
 /// TransformVector node implementation for GLSL
-class MayaTransformVectorNodeGlsl : public GlslImplementation
+class MayaTransformVectorNodeGlsl
+#if MX_COMBINED_VERSION >= 13904
+ : public HwImplementation
+#else
+ : public GlslImplementation
+#endif
 {
 public:
     static ShaderNodeImplPtr create();

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaTransformVectorNodeGlsl.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaTransformVectorNodeGlsl.h
@@ -6,18 +6,18 @@
 #ifndef MATERIALX_MAYATRANSFORMVECTORNODEGLSL_H
 #define MATERIALX_MAYATRANSFORMVECTORNODEGLSL_H
 
-#include <MaterialXGenGlsl/GlslShaderGenerator.h>
-
 #include <mayaUsd/render/MaterialXGenOgsXml/CombinedMaterialXVersion.h>
+
+#include <MaterialXGenGlsl/GlslShaderGenerator.h>
 
 MATERIALX_NAMESPACE_BEGIN
 
 /// TransformVector node implementation for GLSL
 class MayaTransformVectorNodeGlsl
 #if MX_COMBINED_VERSION >= 13904
- : public HwImplementation
+    : public HwImplementation
 #else
- : public GlslImplementation
+    : public GlslImplementation
 #endif
 {
 public:

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/TexcoordNodeMaya.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/TexcoordNodeMaya.h
@@ -8,11 +8,18 @@
 
 #include <MaterialXGenGlsl/GlslShaderGenerator.h>
 
+#include <mayaUsd/render/MaterialXGenOgsXml/CombinedMaterialXVersion.h>
+
 MATERIALX_NAMESPACE_BEGIN
 
 /// Re-implementation of an index-based texcood node into a geompropvalue using standard USD primvar
 /// names
-class TexcoordNodeGlslMaya : public GlslImplementation
+class TexcoordNodeGlslMaya
+#if MX_COMBINED_VERSION >= 13904
+ : public HwImplementation
+#else
+ : public GlslImplementation
+#endif
 {
 public:
     static ShaderNodeImplPtr create();

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/TexcoordNodeMaya.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/TexcoordNodeMaya.h
@@ -6,9 +6,9 @@
 #ifndef MATERIALX_TEXCOORDNODEGLSLMAYA_H
 #define MATERIALX_TEXCOORDNODEGLSLMAYA_H
 
-#include <MaterialXGenGlsl/GlslShaderGenerator.h>
-
 #include <mayaUsd/render/MaterialXGenOgsXml/CombinedMaterialXVersion.h>
+
+#include <MaterialXGenGlsl/GlslShaderGenerator.h>
 
 MATERIALX_NAMESPACE_BEGIN
 
@@ -16,9 +16,9 @@ MATERIALX_NAMESPACE_BEGIN
 /// names
 class TexcoordNodeGlslMaya
 #if MX_COMBINED_VERSION >= 13904
- : public HwImplementation
+    : public HwImplementation
 #else
- : public GlslImplementation
+    : public GlslImplementation
 #endif
 {
 public:


### PR DESCRIPTION
Fixes API broken by removing GlslImplementation class in MaterialX PR 2409