### PR TITLE
Bracket code backported from MaterialX 1.39.X

### DIFF
--- a/lib/mayaUsd/render/MaterialXGenOgsXml/CMakeLists.txt
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/CMakeLists.txt
@@ -35,6 +35,16 @@ target_sources(${PROJECT_NAME}
         Nodes/MayaHwImageNode.cpp
         Nodes/MayaCompoundNode.cpp
         Nodes/MayaShaderGraph.cpp
+    )
+endif()
+
+if(MaterialX_VERSION VERSION_GREATER_EQUAL "1.38.8" AND MaterialX_VERSION VERSION_LESS "1.39.0")
+target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+    FIX_DUPLICATE_INCLUDED_SHADER_CODE
+    )
+target_sources(${PROJECT_NAME} 
+    PRIVATE
         Nodes/MayaSourceCodeNode.cpp
     )
 endif()

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/GlslFragmentGenerator.cpp
@@ -17,6 +17,8 @@
 #ifdef FIX_NODEGRAPH_UDIM_SCALE_OFFSET
 #include "Nodes/MayaCompoundNode.h"
 #include "Nodes/MayaHwImageNode.h"
+#endif
+#ifdef FIX_DUPLICATE_INCLUDED_SHADER_CODE
 #include "Nodes/MayaSourceCodeNode.h"
 #endif
 #ifdef USD_HAS_BACKPORTED_MX39_OPENPBR
@@ -292,7 +294,7 @@ ShaderPtr GlslFragmentGenerator::createShader(
     ElementPtr    element,
     GenContext&   context) const
 {
-#if MX_COMBINED_VERSION >= 13810
+#if MX_COMBINED_VERSION >= 13810 && MX_COMBINED_VERSION < 13903
     // Create the root shader graph
     ShaderGraphPtr graph = MayaShaderGraph::create(nullptr, name, element, context);
     ShaderPtr      shader = std::make_shared<Shader>(name, graph);
@@ -507,7 +509,7 @@ ShaderPtr GlslFragmentGenerator::createShader(
     ShaderStage& pixelStage = shader->getStage(Stage::PIXEL);
 
     // Add uniforms for environment lighting.
-#if MX_COMBINED_VERSION >= 13810
+#if MX_COMBINED_VERSION >= 13810 && MX_COMBINED_VERSION < 13903
     if (requiresLighting(*graph) && OgsXmlGenerator::useLightAPI() < 2) {
 #else
     if (requiresLighting(graph) && OgsXmlGenerator::useLightAPI() < 2) {
@@ -1036,13 +1038,10 @@ GlslFragmentGenerator::getImplementation(const NodeDef& nodedef, GenContext& con
         context.addNodeImplementation(name, impl);
 
         return impl;
+#ifdef FIX_DUPLICATE_INCLUDED_SHADER_CODE
     } else if (
         implElement->isA<Implementation>() && !_implFactory.classRegistered(name)
-#if MX_COMBINED_VERSION < 13900
         && !outputType->isClosure()) {
-#else
-        && !outputType.isClosure()) {
-#endif
         // Backporting 1.39 fix done in
         //  https://github.com/AcademySoftwareFoundation/MaterialX/pull/1754
         impl = MayaSourceCodeNode::create();
@@ -1052,6 +1051,7 @@ GlslFragmentGenerator::getImplementation(const NodeDef& nodedef, GenContext& con
         context.addNodeImplementation(name, impl);
 
         return impl;
+#endif
 #ifdef USD_HAS_BACKPORTED_MX39_OPENPBR
     } else if (
         implElement->getName() == "IM_dielectric_tf_bsdf_genglsl"

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.cpp
@@ -29,7 +29,7 @@ std::string makeValidName(const NodeGraph& nodeGraph, GenContext& context)
 
 } // namespace
 
-#if MX_COMBINED_VERSION >= 13810
+#if MX_COMBINED_VERSION >= 13810 && MX_COMBINED_VERSION < 13903
 //
 // ShaderGraph methods
 //
@@ -213,7 +213,9 @@ MayaShaderGraph::MayaShaderGraph(
         makeValidName(nodeGraph, context),
         nodeGraph.getDocument(),
         context.getReservedWords())
+#if MX_COMBINED_VERSION >= 13810 && MX_COMBINED_VERSION < 13903
     , _shouldPropagateInputs(true)
+#endif
 {
     // Clear classification
     _classification = 0;
@@ -239,7 +241,7 @@ MayaShaderGraph::MayaShaderGraph(
 
 MayaShaderGraph::~MayaShaderGraph() = default;
 
-#if MX_COMBINED_VERSION >= 13810
+#if MX_COMBINED_VERSION >= 13810 && MX_COMBINED_VERSION < 13903
 ShaderGraphPtr MayaShaderGraph::create(
     const ShaderGraph* parent,
     const string&      name,
@@ -261,9 +263,11 @@ MayaShaderGraph::create(const ShaderGraph* parent, const NodeGraph& nodeGraph, G
 
 void MayaShaderGraph::addPropagatedInput(ShaderNode& node, string const& name)
 {
+#if MX_COMBINED_VERSION >= 13810 && MX_COMBINED_VERSION < 13903
     if (!_shouldPropagateInputs) {
         return;
     }
+#endif
 
     auto* nodeInput = node.getInput(name);
     if (nodeInput) {
@@ -279,7 +283,7 @@ void MayaShaderGraph::addPropagatedInput(ShaderNode& node, string const& name)
 
 StringVec const& MayaShaderGraph::getPropagatedInputs() const { return _propagatedInputs; }
 
-#if MX_COMBINED_VERSION >= 13810
+#if MX_COMBINED_VERSION >= 13810 && MX_COMBINED_VERSION < 13903
 void MayaShaderGraph::createConnectedNodes(
     const ElementPtr& downstreamElement,
     const ElementPtr& upstreamElement,

--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.h
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaShaderGraph.h
@@ -21,7 +21,7 @@ class MayaShaderGraph : public ShaderGraph
 {
 public:
     /// Constructor
-#if MX_COMBINED_VERSION >= 13810
+#if MX_COMBINED_VERSION >= 13810 && MX_COMBINED_VERSION < 13903
     MayaShaderGraph(
         const ShaderGraph* parent,
         const string&      name,
@@ -34,7 +34,7 @@ public:
     /// Desctructor.
     virtual ~MayaShaderGraph();
 
-#if MX_COMBINED_VERSION >= 13810
+#if MX_COMBINED_VERSION >= 13810 && MX_COMBINED_VERSION < 13903
     /// Create a new shader graph from an element.
     /// Supported elements are outputs and shader nodes.
     static ShaderGraphPtr
@@ -50,7 +50,7 @@ public:
     StringVec const& getPropagatedInputs() const;
 
 protected:
-#if MX_COMBINED_VERSION >= 13810
+#if MX_COMBINED_VERSION >= 13810 && MX_COMBINED_VERSION < 13903
     /// Create node connections corresponding to the connection between a pair of elements.
     /// @param downstreamElement Element representing the node to connect to.
     /// @param upstreamElement Element representing the node to connect from
@@ -70,7 +70,9 @@ protected:
 #endif
 
     StringVec _propagatedInputs;
-    bool      _shouldPropagateInputs;
+#if MX_COMBINED_VERSION >= 13810 && MX_COMBINED_VERSION < 13903
+    bool _shouldPropagateInputs;
+#endif
 };
 
 MATERIALX_NAMESPACE_END

--- a/test/lib/mayaUsd/utils/test_ShaderGenUtils.cpp
+++ b/test/lib/mayaUsd/utils/test_ShaderGenUtils.cpp
@@ -201,8 +201,14 @@ TEST(ShaderGenUtils, lobePruner)
     input->setValueString("1.0");
     optimizedNodeDef = lobePruner->getOptimizedNodeDef(*node);
     ASSERT_TRUE(optimizedNodeDef);
+#if MX_COMBINED_VERSION < 13904
     // Now have a 1 for subsurface since we can also optimize the 1 value for mix nodes.
     ASSERT_EQ(optimizedNodeDef->getNodeString(), "standard_surface_x0000x00x010");
+#else
+    // Starting at 1.39.4 we have an X for subsurface since standard surface no longer uses a mix
+    // node. See https://github.com/AcademySoftwareFoundation/MaterialX/pull/2483
+    ASSERT_EQ(optimizedNodeDef->getNodeString(), "standard_surface_x0000x00x0x0");
+#endif
 
     PXR_NS::HdMaterialNode2 usdNode;
     usdNode.nodeTypeId = PXR_NS::TfToken("ND_standard_surface_surfaceshader");

--- a/test/lib/usd/translators/testUsdExportMaterialX.py
+++ b/test/lib/usd/translators/testUsdExportMaterialX.py
@@ -182,7 +182,12 @@ class testUsdExportMaterialX(unittest.TestCase):
                          "ND_standard_surface_surfaceshader")
         mxNode = Sdr.Registry().GetShaderNodeByIdentifier("ND_standard_surface_surfaceshader")
         if mxNode:
-            self.assertEqual(outputName, mxNode.GetShaderOutputNames()[0])
+            if hasattr(mxNode, "GetShaderOutputNames"):
+                # Use modern SdrShader interface introduced in 25.05
+                self.assertEqual(outputName, mxNode.GetShaderOutputNames()[0])
+            else:
+                # Use deprecated NdrShader interface removed in 25.08
+                self.assertEqual(outputName, mxNode.GetOutputNames()[0])
 
         # With a connected file texture on base_color going to baseColor on the
         # nodegraph:

--- a/test/lib/usd/translators/testUsdExportMaterialX.py
+++ b/test/lib/usd/translators/testUsdExportMaterialX.py
@@ -182,7 +182,7 @@ class testUsdExportMaterialX(unittest.TestCase):
                          "ND_standard_surface_surfaceshader")
         mxNode = Sdr.Registry().GetShaderNodeByIdentifier("ND_standard_surface_surfaceshader")
         if mxNode:
-            self.assertEqual(outputName, mxNode.GetOutputNames()[0])
+            self.assertEqual(outputName, mxNode.GetShaderOutputNames()[0])
 
         # With a connected file texture on base_color going to baseColor on the
         # nodegraph:


### PR DESCRIPTION
The code should stop being active if we are using the version they were backported from.

Targets 2 backports: PR #3968 and PR #3795.

Also fix some unit test failures that could happen with USD 25.08 and MaterialX 1.39.4.