### PR TITLE
EMSUSD-2306 fix reparent in the session layer

### DIFF
--- a/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoDuplicateCommand.cpp
@@ -134,6 +134,9 @@ void UsdUndoDuplicateCommand::execute()
         const bool isInSession = UsdUfe::isSessionLayer(layer, sessionLayers);
         const auto targetLayer = isInSession ? layer : _dstLayer;
 
+        if (isInSession)
+            SdfJustCreatePrimInLayer(targetLayer, _usdDstPath);
+
         const bool result = (isFirst || isInSession)
             ? SdfCopySpec(layer, path, targetLayer, _usdDstPath)
             : UsdUfe::mergePrims(stage, layer, path, stage, targetLayer, _usdDstPath, options);

--- a/lib/usdUfe/ufe/UsdUndoDuplicateCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoDuplicateCommand.cpp
@@ -147,6 +147,9 @@ void UsdUndoDuplicateCommand::execute()
         const bool isInSession = UsdUfe::isSessionLayer(layer, sessionLayers);
         const auto targetLayer = isInSession ? layer : dstLayer;
 
+        if (isInSession)
+            SdfJustCreatePrimInLayer(targetLayer, _usdDstPath);
+
         const bool result = (isFirst || isInSession)
             ? SdfCopySpec(layer, localPath, targetLayer, _usdDstPath)
             : UsdUfe::mergePrims(stage, layer, localPath, _dstStage, targetLayer, _usdDstPath);

--- a/lib/usdUfe/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoInsertChildCommand.cpp
@@ -254,6 +254,9 @@ static void doInsertion(
         const bool isInSession = UsdUfe::isSessionLayer(layer, sessionLayers);
         const auto targetLayer = isInSession ? layer : dstLayer;
 
+        if (isInSession)
+            SdfJustCreatePrimInLayer(targetLayer, dstUsdPath);
+
         const bool result = (isFirst || isInSession)
             ? SdfCopySpec(layer, path, targetLayer, dstUsdPath)
             : UsdUfe::mergePrims(stage, layer, path, stage, targetLayer, dstUsdPath, options);

--- a/test/lib/ufe/testParentCmd.py
+++ b/test/lib/ufe/testParentCmd.py
@@ -1244,11 +1244,15 @@ class ParentCmdTestCase(unittest.TestCase):
 
         verifySessionData(rootCapsuleUSDPath)
 
+        self.assertIsNone(sessionLayer.GetPrimAtPath(xformName))
+
         with Usd.EditContext(stage, stage.GetRootLayer()):
             cmds.parent(rootCapsuleUFEPath, xformUFEPathStr)
 
         newRootCapsuleUSDPath = xformName + rootCapsuleUSDPath
         self.assertTrue(stage.GetPrimAtPath(newRootCapsuleUSDPath))
+
+        self.assertIsNotNone(sessionLayer.GetPrimAtPath(xformName))
 
         # This is the key bit: the session data should still be there.
         verifySessionData(newRootCapsuleUSDPath)


### PR DESCRIPTION
Handle the case where the target path was not yet defined in the session layer.