### PR TITLE
vp2RenderDelegate: Ensure the intended TBB version is picked

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.cpp
@@ -48,11 +48,7 @@ std::string _GetResourcePath(const std::string& resource)
     return path;
 }
 
-template <typename F>
-class LambdaTask
-#ifndef ONETBB_SPEC_VERSION
-    : public tbb::task
-#endif
+template <typename F> class LambdaTask
 {
 public:
     LambdaTask(const F& func)
@@ -60,28 +56,15 @@ public:
     {
     }
 
-#ifdef ONETBB_SPEC_VERSION
     void operator()() const { _func(); }
-#else
-private:
-    tbb::task* execute()
-    {
-        _func();
-        return nullptr;
-    }
-#endif
 
     F _func;
 };
 
 template <typename F> void EnqueueLambdaTask(const F& f)
 {
-#ifdef ONETBB_SPEC_VERSION
     tbb::task_arena ta;
     ta.enqueue(LambdaTask<F>(f));
-#else
-    tbb::task::enqueue(*new (tbb::task::allocate_root()) LambdaTask<F>(f));
-#endif
 }
 } // namespace
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/meshViewportCompute.h
@@ -112,22 +112,7 @@
 #include <opensubdiv/version.h>
 #endif
 
-#if defined(__has_include)
-#if __has_include(<tbb/tbb_stddef.h>)
-    // Not OneTBB case - we need this because Maya and Usd can have different TBB
-    // versions and both are in include paths.
-#else
-#if __has_include(<tbb/version.h>)
-#include <tbb/version.h>
-#endif
-#endif
-#endif
-
-#ifdef ONETBB_SPEC_VERSION
 #include <tbb/task_arena.h>
-#else
-#include <tbb/task.h>
-#endif
 
 #include <fstream>
 #include <streambuf>

--- a/lib/mayaUsd/render/vp2RenderDelegate/taskCommit.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/taskCommit.h
@@ -18,17 +18,6 @@
 
 #include <tbb/tbb_allocator.h>
 
-#if defined(__has_include)
-#if __has_include(<tbb/tbb_stddef.h>)
-// Not OneTBB case - we need this because Maya and Usd can have different TBB
-// versions and both are in include paths.
-#else
-#if __has_include(<tbb/version.h>)
-#include <tbb/version.h>
-#endif
-#endif
-#endif
-
 PXR_NAMESPACE_OPEN_SCOPE
 
 /*! \brief  Base commit task class
@@ -71,11 +60,7 @@ public:
     //! Release the memory using same allocator by calling destroy method.
     void destroy() override
     {
-#ifdef ONETBB_SPEC_VERSION
         this->~HdVP2TaskCommitBody<Body>();
-#else
-        my_allocator_type().destroy(this);
-#endif
         my_allocator_type().deallocate(this, 1);
     }
 


### PR DESCRIPTION
A legacy system-wide TBB installation can sneak into the default include paths (this happens in our build environment); even on a Maya 2026 build `__has_include(<tbb/tbb_stddef.h>)` would then be true, and could cause the onetbb code paths to be skipped, and bring symbols from the older tbb.

This change unconditionally use the modern TBB API, which works with TBB 2020+ and meets Maya 2022+ requirements.
- `tbb::task_arena::enqueue` exists in TBB 2020+ should behave the same as onetbb.
- `tbb::allocator<T>::destroy()` correctly calls the standard destructor in TBB 2020+.

This was not a functional issue yet. `<tbb/version.h>` was already included transitively through pxr headers (which pull in `<tbb/blocked_range.h>`), implicitly defining `ONETBB_SPEC_VERSION`. We verified this with OpenUSD v25.05.

The commit simply makes the code simpler and more robust against future OpenUSD/onetbb changes, regardless of which other TBB headers are visible at compile time. 