### PR TITLE
Always enable testUsdExportRenderLayerMode.

### DIFF
--- a/test/lib/usd/translators/CMakeLists.txt
+++ b/test/lib/usd/translators/CMakeLists.txt
@@ -37,11 +37,6 @@ set(TEST_SCRIPT_FILES
     # PPT, 17-Jun-20.
     testUsdExportParticles.py
     testUsdExportPref.py
-
-    # Following test runs only in legacy render layer mode, otherwise skipped.
-    # Legacy render layers are deprecated, and should not be used.
-    # To avoid skipping and run in legacy render layer mode,
-    # export MAYA_ENABLE_LEGACY_RENDER_LAYERS=1
     testUsdExportRenderLayerMode.py
 
     # # XXX: This test is disabled by default since it requires the RenderMan for Maya plugin.

--- a/test/lib/usd/translators/testUsdExportRenderLayerMode.py
+++ b/test/lib/usd/translators/testUsdExportRenderLayerMode.py
@@ -29,17 +29,13 @@ from maya import OpenMayaRender as OMR
 
 import fixturesUtils
 
-# Initialize Maya standalone mode early, since we call cmds.mayaHasRenderSetup()
-# in a decorator on the test class, which will be evaluated *before*
-# setUpClass() is called.
-standalone.initialize('usd')
-
-@unittest.skipIf(cmds.mayaHasRenderSetup(), "USD render layer functionality can only be tested with Maya set to legacy render layer mode.")
 class testUsdExportRenderLayerMode(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
         cls.inputPath = fixturesUtils.setUpClass(__file__)
+        # USD render layer functionality can only be tested with Maya set to legacy render layer mode.
+        cmds.mayaHasRenderSetup(e=True, enableCurrentSession=False)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
While working on #4279, I noticed late that `testUsdExportRenderLayerMode` is disabled in the Maya versions we test, unless MAYA_ENABLE_LEGACY_RENDER_LAYERS is explicitly set.

I propose to enable the test by default to ensure CI coverage of the `-renderLayerMode` export option, in case some studios still rely on this feature with Maya’s `Legacy Render Layers` option enabled.
