### PR TITLE
EMSUSD-2748: Extract UsdSceneItemOps to the USDUFE lib

### DIFF
--- a/lib/mayaUsd/ufe/CMakeLists.txt
+++ b/lib/mayaUsd/ufe/CMakeLists.txt
@@ -9,14 +9,14 @@ target_sources(${PROJECT_NAME}
         MayaUsdContextOpsHandler.cpp
         MayaUsdObject3d.cpp
         MayaUsdObject3dHandler.cpp
+        MayaUsdSceneItemOps.cpp
+        MayaUsdSceneItemOpsHandler.cpp
         MayaUsdUIInfoHandler.cpp
         MayaUsdUndoRenameCommand.cpp
         ProxyShapeContextOpsHandler.cpp
         ProxyShapeHandler.cpp
         ProxyShapeHierarchy.cpp
         ProxyShapeHierarchyHandler.cpp
-        UsdSceneItemOps.cpp
-        UsdSceneItemOpsHandler.cpp
         UsdStageMap.cpp
         UsdUIUfeObserver.cpp
         UsdUndoDuplicateCommand.cpp
@@ -190,14 +190,14 @@ set(HEADERS
     MayaUsdContextOpsHandler.h
     MayaUsdObject3d.h
     MayaUsdObject3dHandler.h
+    MayaUsdSceneItemOps.h
+    MayaUsdSceneItemOpsHandler.h
     MayaUsdUIInfoHandler.h
     MayaUsdUndoRenameCommand.h
     ProxyShapeContextOpsHandler.h
     ProxyShapeHandler.h
     ProxyShapeHierarchy.h
     ProxyShapeHierarchyHandler.h
-    UsdSceneItemOps.h
-    UsdSceneItemOpsHandler.h
     UsdStageMap.h
     UsdUIUfeObserver.h
     UsdUndoDuplicateCommand.h

--- a/lib/mayaUsd/ufe/Global.cpp
+++ b/lib/mayaUsd/ufe/Global.cpp
@@ -21,11 +21,11 @@
 #include <mayaUsd/ufe/MayaStagesSubject.h>
 #include <mayaUsd/ufe/MayaUsdContextOpsHandler.h>
 #include <mayaUsd/ufe/MayaUsdObject3dHandler.h>
+#include <mayaUsd/ufe/MayaUsdSceneItemOpsHandler.h>
 #include <mayaUsd/ufe/MayaUsdUIInfoHandler.h>
 #include <mayaUsd/ufe/ProxyShapeContextOpsHandler.h>
 #include <mayaUsd/ufe/ProxyShapeHandler.h>
 #include <mayaUsd/ufe/ProxyShapeHierarchyHandler.h>
-#include <mayaUsd/ufe/UsdSceneItemOpsHandler.h>
 #include <mayaUsd/ufe/UsdUIUfeObserver.h>
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/ufe/trf/UsdTransform3dFallbackMayaXformStack.h>
@@ -244,7 +244,7 @@ MStatus initialize()
 #ifdef UFE_V3_FEATURES_AVAILABLE
     usdUfeHandlers.hierarchyHandler = MayaUsdHierarchyHandler::create();
 #endif
-    handlers.sceneItemOpsHandler = UsdSceneItemOpsHandler::create();
+    usdUfeHandlers.sceneItemOpsHandler = MayaUsdSceneItemOpsHandler::create();
     usdUfeHandlers.object3dHandler = MayaUsdObject3dHandler::create();
     usdUfeHandlers.contextOpsHandler = MayaUsdContextOpsHandler::create();
     usdUfeHandlers.uiInfoHandler = MayaUsdUIInfoHandler::create();

--- a/lib/mayaUsd/ufe/MayaUsdSceneItemOps.cpp
+++ b/lib/mayaUsd/ufe/MayaUsdSceneItemOps.cpp
@@ -1,0 +1,71 @@
+//
+// Copyright 2019 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "MayaUsdSceneItemOps.h"
+
+#include <mayaUsd/ufe/MayaUsdUndoRenameCommand.h>
+#include <mayaUsd/ufe/UsdUndoDuplicateCommand.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+MAYAUSD_VERIFY_CLASS_SETUP(UsdUfe::UsdSceneItemOps, MayaUsdSceneItemOps);
+
+MayaUsdSceneItemOps::MayaUsdSceneItemOps(const UsdUfe::UsdSceneItem::Ptr& item)
+    : UsdUfe::UsdSceneItemOps(item)
+{
+}
+
+/*static*/
+MayaUsdSceneItemOps::Ptr MayaUsdSceneItemOps::create(const UsdUfe::UsdSceneItem::Ptr& item)
+{
+    return std::make_shared<MayaUsdSceneItemOps>(item);
+}
+
+//------------------------------------------------------------------------------
+// Ufe::SceneItemOps overrides
+//------------------------------------------------------------------------------
+
+#ifdef UFE_V4_FEATURES_AVAILABLE
+Ufe::SceneItemResultUndoableCommand::Ptr MayaUsdSceneItemOps::duplicateItemCmdNoExecute()
+{
+    return UsdUndoDuplicateCommand::create(usdSceneItem());
+}
+#endif
+
+Ufe::Duplicate MayaUsdSceneItemOps::duplicateItemCmd()
+{
+    auto duplicateCmd = UsdUndoDuplicateCommand::create(usdSceneItem());
+    duplicateCmd->execute();
+    return Ufe::Duplicate(duplicateCmd->duplicatedItem(), duplicateCmd);
+}
+
+#ifdef UFE_V4_FEATURES_AVAILABLE
+Ufe::SceneItemResultUndoableCommand::Ptr
+MayaUsdSceneItemOps::renameItemCmdNoExecute(const Ufe::PathComponent& newName)
+{
+    return MayaUsdUndoRenameCommand::create(usdSceneItem(), newName);
+}
+#endif
+
+Ufe::Rename MayaUsdSceneItemOps::renameItemCmd(const Ufe::PathComponent& newName)
+{
+    auto renameCmd = MayaUsdUndoRenameCommand::create(usdSceneItem(), newName);
+    renameCmd->execute();
+    return Ufe::Rename(renameCmd->renamedItem(), renameCmd);
+}
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/ufe/MayaUsdSceneItemOps.h
+++ b/lib/mayaUsd/ufe/MayaUsdSceneItemOps.h
@@ -1,0 +1,55 @@
+//
+// Copyright 2019 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_USDSCENEITEMOPS_H
+#define MAYAUSD_USDSCENEITEMOPS_H
+
+#include <mayaUsd/base/api.h>
+
+#include <usdUfe/ufe/UsdSceneItemOps.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+//! \brief Interface for scene item operations.
+class MAYAUSD_CORE_PUBLIC MayaUsdSceneItemOps : public UsdUfe::UsdSceneItemOps
+{
+public:
+    typedef std::shared_ptr<MayaUsdSceneItemOps> Ptr;
+
+    MayaUsdSceneItemOps(const UsdUfe::UsdSceneItem::Ptr& item);
+
+    MAYAUSD_DISALLOW_COPY_MOVE_AND_ASSIGNMENT(MayaUsdSceneItemOps);
+
+    //! Create a MayaUsdSceneItemOps.
+    static MayaUsdSceneItemOps::Ptr create(const UsdUfe::UsdSceneItem::Ptr& item);
+
+    //@{
+    // Ufe::SceneItemOps overrides
+    Ufe::Duplicate duplicateItemCmd() override;
+#ifdef UFE_V4_FEATURES_AVAILABLE
+    Ufe::SceneItemResultUndoableCommand::Ptr duplicateItemCmdNoExecute() override;
+    Ufe::SceneItemResultUndoableCommand::Ptr
+    renameItemCmdNoExecute(const Ufe::PathComponent& newName) override;
+#endif
+    Ufe::Rename renameItemCmd(const Ufe::PathComponent& newName) override;
+    //@}
+
+}; // MayaUsdSceneItemOps
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDSCENEITEMOPS_H

--- a/lib/mayaUsd/ufe/MayaUsdSceneItemOpsHandler.cpp
+++ b/lib/mayaUsd/ufe/MayaUsdSceneItemOpsHandler.cpp
@@ -13,32 +13,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "UsdSceneItemOpsHandler.h"
+#include "MayaUsdSceneItemOpsHandler.h"
 
+#include <mayaUsd/ufe/MayaUsdSceneItemOps.h>
 #include <mayaUsd/ufe/Utils.h>
 
 namespace MAYAUSD_NS_DEF {
 namespace ufe {
 
-MAYAUSD_VERIFY_CLASS_SETUP(Ufe::SceneItemOpsHandler, UsdSceneItemOpsHandler);
+MAYAUSD_VERIFY_CLASS_SETUP(UsdUfe::UsdSceneItemOpsHandler, MayaUsdSceneItemOpsHandler);
 
 /*static*/
-UsdSceneItemOpsHandler::Ptr UsdSceneItemOpsHandler::create()
+MayaUsdSceneItemOpsHandler::Ptr MayaUsdSceneItemOpsHandler::create()
 {
-    return std::make_shared<UsdSceneItemOpsHandler>();
+    return std::make_shared<MayaUsdSceneItemOpsHandler>();
 }
 
 //------------------------------------------------------------------------------
 // Ufe::SceneItemOpsHandler overrides
 //------------------------------------------------------------------------------
 
-Ufe::SceneItemOps::Ptr UsdSceneItemOpsHandler::sceneItemOps(const Ufe::SceneItem::Ptr& item) const
+Ufe::SceneItemOps::Ptr
+MayaUsdSceneItemOpsHandler::sceneItemOps(const Ufe::SceneItem::Ptr& item) const
 {
     auto usdItem = downcast(item);
 #if !defined(NDEBUG)
     assert(usdItem);
 #endif
-    return UsdSceneItemOps::create(usdItem);
+    return MayaUsdSceneItemOps::create(usdItem);
 }
 
 } // namespace ufe

--- a/lib/mayaUsd/ufe/MayaUsdSceneItemOpsHandler.h
+++ b/lib/mayaUsd/ufe/MayaUsdSceneItemOpsHandler.h
@@ -1,0 +1,46 @@
+//
+// Copyright 2019 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSD_USDSCENEITEMOPSHANDLER_H
+#define MAYAUSD_USDSCENEITEMOPSHANDLER_H
+
+#include <mayaUsd/base/api.h>
+
+#include <usdUfe/ufe/UsdSceneItemOpsHandler.h>
+
+namespace MAYAUSD_NS_DEF {
+namespace ufe {
+
+//! \brief Interface to create a MayaUsdSceneItemOps interface object.
+class MAYAUSD_CORE_PUBLIC MayaUsdSceneItemOpsHandler : public UsdUfe::UsdSceneItemOpsHandler
+{
+public:
+    typedef std::shared_ptr<UsdSceneItemOpsHandler> Ptr;
+
+    MayaUsdSceneItemOpsHandler() = default;
+
+    MAYAUSD_DISALLOW_COPY_MOVE_AND_ASSIGNMENT(MayaUsdSceneItemOpsHandler);
+
+    //! Create a MayaUsdSceneItemOpsHandler.
+    static MayaUsdSceneItemOpsHandler::Ptr create();
+
+    // Ufe::SceneItemOpsHandler overrides
+    Ufe::SceneItemOps::Ptr sceneItemOps(const Ufe::SceneItem::Ptr& item) const override;
+}; // MayaUsdSceneItemOpsHandler
+
+} // namespace ufe
+} // namespace MAYAUSD_NS_DEF
+
+#endif // MAYAUSD_USDSCENEITEMOPSHANDLER_H

--- a/lib/mayaUsdAPI/ufeHandlers.cpp
+++ b/lib/mayaUsdAPI/ufeHandlers.cpp
@@ -16,7 +16,7 @@
 
 #include "ufeHandlers.h"
 
-#include <mayaUsd/ufe/UsdSceneItemOpsHandler.h>
+#include <mayaUsd/ufe/MayaUsdSceneItemOpsHandler.h>
 
 #include <usdUfe/ufe/UsdHierarchyHandler.h>
 
@@ -47,7 +47,7 @@ Ufe::NodeDefHandler::Ptr createUsdShaderNodeDefHandler()
 
 Ufe::SceneItemOpsHandler::Ptr createUsdSceneItemOpsHandler()
 {
-    return MayaUsd::ufe::UsdSceneItemOpsHandler::create();
+    return MayaUsd::ufe::MayaUsdSceneItemOpsHandler::create();
 }
 
 Ufe::HierarchyHandler::Ptr createUsdHierarchyHandler()

--- a/lib/usdUfe/ufe/CMakeLists.txt
+++ b/lib/usdUfe/ufe/CMakeLists.txt
@@ -22,6 +22,8 @@ target_sources(${PROJECT_NAME}
         UsdObject3dHandler.cpp
         UsdRootChildHierarchy.cpp
         UsdSceneItem.cpp
+        UsdSceneItemOps.cpp
+        UsdSceneItemOpsHandler.cpp
         UsdUIInfoHandler.cpp
         UsdUndoAddNewPrimCommand.cpp
         UsdUndoAddPayloadCommand.cpp
@@ -157,6 +159,8 @@ set(HEADERS
     UsdObject3dHandler.h
     UsdRootChildHierarchy.h
     UsdSceneItem.h
+    UsdSceneItemOps.h
+    UsdSceneItemOpsHandler.h
     UsdUIInfoHandler.h
     UsdUndoAddNewPrimCommand.h
     UsdUndoAddPayloadCommand.h

--- a/lib/usdUfe/ufe/Global.cpp
+++ b/lib/usdUfe/ufe/Global.cpp
@@ -20,6 +20,7 @@
 #include <usdUfe/ufe/UsdContextOpsHandler.h>
 #include <usdUfe/ufe/UsdHierarchyHandler.h>
 #include <usdUfe/ufe/UsdObject3dHandler.h>
+#include <usdUfe/ufe/UsdSceneItemOpsHandler.h>
 #include <usdUfe/ufe/UsdUIInfoHandler.h>
 #include <usdUfe/ufe/trf/UsdTransform3dCommonAPI.h>
 #include <usdUfe/ufe/trf/UsdTransform3dMatrixOp.h>
@@ -112,6 +113,9 @@ Ufe::Rtid initialize(
         = handlers.attributesHandler ? handlers.attributesHandler : UsdAttributesHandler::create();
     rtHandlers.hierarchyHandler
         = handlers.hierarchyHandler ? handlers.hierarchyHandler : UsdHierarchyHandler::create();
+    rtHandlers.sceneItemOpsHandler = handlers.sceneItemOpsHandler
+        ? handlers.sceneItemOpsHandler
+        : UsdSceneItemOpsHandler::create();
     rtHandlers.object3dHandler
         = handlers.object3dHandler ? handlers.object3dHandler : UsdObject3dHandler::create();
     rtHandlers.contextOpsHandler

--- a/lib/usdUfe/ufe/Global.h
+++ b/lib/usdUfe/ufe/Global.h
@@ -29,6 +29,7 @@
 #include <ufe/hierarchyHandler.h>
 #include <ufe/object3dHandler.h>
 #include <ufe/rtid.h>
+#include <ufe/sceneItemOpsHandler.h>
 #include <ufe/transform3dHandler.h>
 #include <ufe/uiInfoHandler.h>
 
@@ -78,9 +79,9 @@ struct USDUFE_PUBLIC DCCFunctions
 struct USDUFE_PUBLIC Handlers
 {
     // Ufe v1 handlers
-    Ufe::HierarchyHandler::Ptr   hierarchyHandler;
-    Ufe::Transform3dHandler::Ptr transform3dHandler;
-    //     Ufe::SceneItemOpsHandler::Ptr sceneItemOpsHandler;
+    Ufe::HierarchyHandler::Ptr    hierarchyHandler;
+    Ufe::Transform3dHandler::Ptr  transform3dHandler;
+    Ufe::SceneItemOpsHandler::Ptr sceneItemOpsHandler;
 
     // Ufe v2 handlers
     Ufe::AttributesHandler::Ptr attributesHandler;

--- a/lib/usdUfe/ufe/UsdSceneItemOps.h
+++ b/lib/usdUfe/ufe/UsdSceneItemOps.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Autodesk
+// Copyright 2025 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#ifndef MAYAUSD_USDSCENEITEMOPS_H
-#define MAYAUSD_USDSCENEITEMOPS_H
+#ifndef USD_USDSCENEITEMOPS_H
+#define USD_USDSCENEITEMOPS_H
 
-#include <mayaUsd/base/api.h>
-
+#include <usdUfe/base/api.h>
 #include <usdUfe/ufe/UsdSceneItem.h>
 
 #include <pxr/usd/usd/prim.h>
@@ -25,23 +24,22 @@
 #include <ufe/path.h>
 #include <ufe/sceneItemOps.h>
 
-namespace MAYAUSD_NS_DEF {
-namespace ufe {
+namespace USDUFE_NS_DEF {
 
 //! \brief Interface for scene item operations.
-class MAYAUSD_CORE_PUBLIC UsdSceneItemOps : public Ufe::SceneItemOps
+class USDUFE_PUBLIC UsdSceneItemOps : public Ufe::SceneItemOps
 {
 public:
     typedef std::shared_ptr<UsdSceneItemOps> Ptr;
 
-    UsdSceneItemOps(const UsdUfe::UsdSceneItem::Ptr& item);
+    UsdSceneItemOps(const UsdSceneItem::Ptr& item);
 
-    MAYAUSD_DISALLOW_COPY_MOVE_AND_ASSIGNMENT(UsdSceneItemOps);
+    USDUFE_DISALLOW_COPY_MOVE_AND_ASSIGNMENT(UsdSceneItemOps);
 
     //! Create a UsdSceneItemOps.
-    static UsdSceneItemOps::Ptr create(const UsdUfe::UsdSceneItem::Ptr& item);
+    static UsdSceneItemOps::Ptr create(const UsdSceneItem::Ptr& item);
 
-    void                   setItem(const UsdUfe::UsdSceneItem::Ptr& item);
+    void                   setItem(const UsdSceneItem::Ptr& item);
     const Ufe::Path&       path() const;
     inline PXR_NS::UsdPrim prim() const
     {
@@ -51,6 +49,7 @@ public:
         else
             return PXR_NS::UsdPrim();
     }
+    UsdSceneItem::Ptr usdSceneItem() const { return _item; }
 
     //@{
     // Ufe::SceneItemOps overrides
@@ -70,11 +69,10 @@ public:
     //@}
 
 private:
-    UsdUfe::UsdSceneItem::Ptr _item;
+    UsdSceneItem::Ptr _item;
 
 }; // UsdSceneItemOps
 
-} // namespace ufe
-} // namespace MAYAUSD_NS_DEF
+} // namespace USDUFE_NS_DEF
 
-#endif // MAYAUSD_USDSCENEITEMOPS_H
+#endif // USD_USDSCENEITEMOPS_H

--- a/lib/usdUfe/ufe/UsdSceneItemOpsHandler.cpp
+++ b/lib/usdUfe/ufe/UsdSceneItemOpsHandler.cpp
@@ -1,0 +1,43 @@
+//
+// Copyright 2025 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "UsdSceneItemOpsHandler.h"
+
+#include <usdUfe/ufe/Utils.h>
+
+namespace USDUFE_NS_DEF {
+
+USDUFE_VERIFY_CLASS_SETUP(Ufe::SceneItemOpsHandler, UsdSceneItemOpsHandler);
+
+/*static*/
+UsdSceneItemOpsHandler::Ptr UsdSceneItemOpsHandler::create()
+{
+    return std::make_shared<UsdSceneItemOpsHandler>();
+}
+
+//------------------------------------------------------------------------------
+// Ufe::SceneItemOpsHandler overrides
+//------------------------------------------------------------------------------
+
+Ufe::SceneItemOps::Ptr UsdSceneItemOpsHandler::sceneItemOps(const Ufe::SceneItem::Ptr& item) const
+{
+    auto usdItem = downcast(item);
+#if !defined(NDEBUG)
+    assert(usdItem);
+#endif
+    return UsdSceneItemOps::create(usdItem);
+}
+
+} // namespace USDUFE_NS_DEF

--- a/lib/usdUfe/ufe/UsdSceneItemOpsHandler.h
+++ b/lib/usdUfe/ufe/UsdSceneItemOpsHandler.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Autodesk
+// Copyright 2025 Autodesk
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,26 +13,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#ifndef MAYAUSD_USDSCENEITEMOPSHANDLER_H
-#define MAYAUSD_USDSCENEITEMOPSHANDLER_H
+#ifndef USD_USDSCENEITEMOPSHANDLER_H
+#define USD_USDSCENEITEMOPSHANDLER_H
 
-#include <mayaUsd/base/api.h>
-#include <mayaUsd/ufe/UsdSceneItemOps.h>
+#include <usdUfe/base/api.h>
+#include <usdUfe/ufe/UsdSceneItemOps.h>
 
 #include <ufe/sceneItemOpsHandler.h>
 
-namespace MAYAUSD_NS_DEF {
-namespace ufe {
+namespace USDUFE_NS_DEF {
 
 //! \brief Interface to create a UsdSceneItemOps interface object.
-class MAYAUSD_CORE_PUBLIC UsdSceneItemOpsHandler : public Ufe::SceneItemOpsHandler
+class USDUFE_PUBLIC UsdSceneItemOpsHandler : public Ufe::SceneItemOpsHandler
 {
 public:
     typedef std::shared_ptr<UsdSceneItemOpsHandler> Ptr;
 
     UsdSceneItemOpsHandler() = default;
 
-    MAYAUSD_DISALLOW_COPY_MOVE_AND_ASSIGNMENT(UsdSceneItemOpsHandler);
+    USDUFE_DISALLOW_COPY_MOVE_AND_ASSIGNMENT(UsdSceneItemOpsHandler);
 
     //! Create a UsdSceneItemOpsHandler.
     static UsdSceneItemOpsHandler::Ptr create();
@@ -41,7 +40,6 @@ public:
     Ufe::SceneItemOps::Ptr sceneItemOps(const Ufe::SceneItem::Ptr& item) const override;
 }; // UsdSceneItemOpsHandler
 
-} // namespace ufe
-} // namespace MAYAUSD_NS_DEF
+} // namespace USDUFE_NS_DEF
 
-#endif // MAYAUSD_USDSCENEITEMOPSHANDLER_H
+#endif // USD_USDSCENEITEMOPSHANDLER_H


### PR DESCRIPTION
#### EMSUSD-2748: Extract UsdSceneItemOps to the USDUFE lib
* Moved UsdSceneItemOps and UsdSceneItemOpsHandler from maya-usd to UsdUfe. Created MayaUsd versions which derive from UsdUfe ones.
* Added sceneItemOpsHandler to UsdUfe::Handlers. If UsdUfe is passed one, register that, otherwise create the UsdUfe one UsdSceneItemOpsHandler and register it.