### PR TITLE
EMSUSD-2783 - Adds an envionment variable to disable layer auto targeting

### DIFF
--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -29,6 +29,7 @@
 #include <usdUfe/utils/uiCallback.h>
 
 #include <pxr/base/tf/diagnostic.h>
+#include <pxr/base/tf/envSetting.h>
 
 #include <maya/MArgList.h>
 #include <maya/MArgParser.h>
@@ -43,16 +44,6 @@
 
 #include <cstddef>
 #include <string>
-
-// Disables updateEditTarget's functionality is set.
-// Areas that will be affected are:
-// - Mute layer
-// - Lock layer
-// - System lock layer
-TF_DEFINE_ENV_SETTING(
-    MAYAUSD_LAYEREDITOR_DISABLE_AUTOTARGET,
-    false,
-    "When set, disables auto retargeting of layers based on the file and permission status.");
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -80,6 +71,15 @@ const char kSkipSystemLockedFlagL[] = "skipSystemLocked";
 const char kRefreshSystemLockFlag[] = "rl";
 const char kRefreshSystemLockFlagL[] = "refreshSystemLock";
 
+// Disables updateEditTarget's functionality is set.
+// Areas that will be affected are:
+// - Mute layer
+// - Lock layer
+// - System lock layer
+TF_DEFINE_ENV_SETTING(
+    MAYAUSD_LAYEREDITOR_DISABLE_AUTOTARGET,
+    false,
+    "When set, disables auto retargeting of layers based on the file and permission status.");
 } // namespace
 
 namespace MAYAUSD_NS_DEF {

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -44,6 +44,16 @@
 #include <cstddef>
 #include <string>
 
+// Disables updateEditTarget's functionality is set.
+// Areas that will be affected are:
+// - Mute layer
+// - Lock layer
+// - System lock layer
+TF_DEFINE_ENV_SETTING(
+    MAYAUSD_LAYEREDITOR_DISABLE_AUTOTARGET,
+    false,
+    "When set, disables auto retargeting of layers based on the file and permission status.");
+
 PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace {
@@ -133,9 +143,15 @@ void BaseCmd::holdOntoSubLayers(SdfLayerHandle layer)
     }
 }
 
-// Set the edit target to Session layer if no other layers are modifiable
+// Set the edit target to Session layer if no other layers are modifiable,
+// unless the user has disabled this feature with an env var.
 void BaseCmd::updateEditTarget(const PXR_NS::UsdStageWeakPtr stage)
 {
+    //// User-controlled environment variable to disable automatic target change.
+    if (TfGetEnvSetting(MAYAUSD_LAYEREDITOR_DISABLE_AUTOTARGET)) {
+        return;
+    }
+
     if (!stage)
         return;
 


### PR DESCRIPTION
Areas that will be affected by setting the `MAYAUSD_LAYEREDITOR_DISABLE_AUTOTARGET` env variable are:

- Mute layer
- Lock layer
- System lock layer