### PR TITLE
EMSUSD-2810 - Integrate USD v25.08 into ecg-maya-usd builds

### DIFF
--- a/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/wrapTranslatorBase.cpp
+++ b/plugin/al/lib/AL_USDMaya/AL/usdmaya/fileio/translators/wrapTranslatorBase.cpp
@@ -104,16 +104,26 @@ public:
     std::size_t generateUniqueKey(const UsdPrim& prim) const override
     {
         if (Override o = GetOverride("generateUniqueKey")) {
+            // Acquire Python lock before making any Python calls
+            TfPyLock pyLock;
+
+            // Call the Python function with proper exception handling
             auto res = std::function<PXR_BOOST_PYTHON_NAMESPACE::object(const UsdPrim&)>(
                 TfPyCall<PXR_BOOST_PYTHON_NAMESPACE::object>(o))(prim);
-            if (!res) {
+
+            // Check if the result is valid (not None or null)
+            if (!res || res.is_none()) {
                 return 0;
             }
-            TfPyLock                                         pyLock;
+
             PXR_BOOST_PYTHON_NAMESPACE::str                  strObj(res);
             PXR_BOOST_PYTHON_NAMESPACE::extract<std::string> strValue(strObj);
             if (strValue.check()) {
-                return std::hash<std::string> {}(strValue);
+                std::string keyStr = strValue();
+                // Ensure we don't hash empty strings
+                if (!keyStr.empty()) {
+                    return std::hash<std::string> {}(keyStr);
+                }
             }
         }
         return 0;
@@ -155,6 +165,7 @@ public:
         // "import" is a python keyword so python's override will be called
         // "importObject" instead
         if (Override o = GetOverride("importObject")) {
+            TfPyLock pyLock;
             MDagPath path;
             MDagPath::getAPathTo(parent, path);
 
@@ -170,7 +181,8 @@ public:
     MStatus postImport(const UsdPrim& prim) override
     {
         if (Override o = GetOverride("postImport")) {
-            auto res = std::function<bool(const UsdPrim&)>(TfPyCall<bool>(o))(prim);
+            TfPyLock pyLock;
+            auto     res = std::function<bool(const UsdPrim&)>(TfPyCall<bool>(o))(prim);
             return res ? MS::kSuccess : MS::kFailure;
         }
         return MS::kSuccess;
@@ -233,6 +245,7 @@ public:
         std::string name(dagPath.fullPathName().asChar());
         // pass a dagPath name and dictionary of params to the python method
         if (Override o = GetOverride("exportObject")) {
+            TfPyLock pyLock;
             return std::function<UsdPrim(
                 UsdStageRefPtr, const char*, SdfPath, PXR_BOOST_PYTHON_NAMESPACE::dict)>(
                 TfPyCall<UsdPrim>(o))(stage, name.c_str(), usdPath, pyParams);

--- a/plugin/al/lib/AL_USDMaya/CMakeLists.txt
+++ b/plugin/al/lib/AL_USDMaya/CMakeLists.txt
@@ -289,7 +289,7 @@ install(FILES
 )
 install(CODE
     "file(WRITE \"${CMAKE_CURRENT_BINARY_DIR}/lib/python/AL/__init__.py\"
-    \"try:\n\t__import__('pkg_resources').declare_namespace(__name__)\nexcept:\n\tfrom pkgutil import extend_path\n\t__path__ = extend_path(__path__, __name__)\")"
+    \"from pkgutil import extend_path\n__path__ = extend_path(__path__, __name__)\n\")"
 )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/python/AL/__init__.py
     DESTINATION ${AL_INSTALL_PREFIX}/lib/python/AL

--- a/plugin/al/schemas/AL/usd/schemas/maya/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/maya/CMakeLists.txt
@@ -174,7 +174,7 @@ if(${listCount} STRGREATER 1)
       string(REPLACE ";" "/" currentPath "${currentPath}")
       file(WRITE
         ${CMAKE_BINARY_DIR}/${currentPath}/__init__.py
-        "try:\n\t__import__('pkg_resources').declare_namespace(__name__)\nexcept:\n\tfrom pkgutil import extend_path\n\t__path__ = extend_path(__path__, __name__)\n"
+        "from pkgutil import extend_path\n__path__ = extend_path(__path__, __name__)\n"
       )
     endforeach(i)
 endif()

--- a/plugin/al/schemas/AL/usd/schemas/mayatest/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/mayatest/CMakeLists.txt
@@ -159,7 +159,7 @@ if(${listCount} STRGREATER 1)
       string(REPLACE ";" "/" currentPath "${currentPath}")
       file(WRITE
         ${CMAKE_BINARY_DIR}/${currentPath}/__init__.py
-        "try:\n\t__import__('pkg_resources').declare_namespace(__name__)\nexcept:\n\tfrom pkgutil import extend_path\n\t__path__ = extend_path(__path__, __name__)\n"
+        "from pkgutil import extend_path\n__path__ = extend_path(__path__, __name__)\n"
       )
     endforeach(i)
 endif()

--- a/plugin/al/usdtransaction/AL/__init__.py
+++ b/plugin/al/usdtransaction/AL/__init__.py
@@ -1,4 +1,2 @@
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except:
-    pass
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/plugin/al/usdtransaction/AL/usd/__init__.py
+++ b/plugin/al/usdtransaction/AL/usd/__init__.py
@@ -1,4 +1,2 @@
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except:
-    pass
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/plugin/pxr/cmake/macros/Public.cmake
+++ b/plugin/pxr/cmake/macros/Public.cmake
@@ -171,7 +171,7 @@ function(pxr_setup_python)
     # see UsdMaya module inside pxr subdirectory
     _get_install_dir(lib/python/pxr installPrefix)
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/__init__.py"
-    "try:\n  __import__('pkg_resources').declare_namespace(__name__)\nexcept:\n  from pkgutil import extend_path\n  __path__ = extend_path(__path__, __name__)\n")
+    "from pkgutil import extend_path\n__path__ = extend_path(__path__, __name__)\n")
 	execute_process(COMMAND ${Python_EXECUTABLE} -m compileall ${CMAKE_CURRENT_BINARY_DIR}/__init__.py)
     install(
         FILES

--- a/test/lib/mayaUsd/fileio/testCacheToUsd.py
+++ b/test/lib/mayaUsd/fileio/testCacheToUsd.py
@@ -313,7 +313,7 @@ class CacheToUsdTestCase(unittest.TestCase):
         if relativePath:
             if self.stage.GetRootLayer().anonymous:
                 self.assertNotIn('payload = @testCacheToUsd.usda', self.stage.GetRootLayer().ExportToString())
-                self.assertRegexpMatches(self.stage.GetRootLayer().ExportToString(), 'payload = @.*testCacheToUsd.usda')
+                self.assertRegex(self.stage.GetRootLayer().ExportToString(), 'payload = @.*testCacheToUsd.usda')
                 self.makeRootLayerNotAnonymous()
                 mayaUsd.lib.Util.updatePostponedRelativePaths(self.stage.GetRootLayer())
                 

--- a/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
+++ b/test/lib/mayaUsd/utils/testDiagnosticDelegate.py
@@ -35,12 +35,6 @@ class testDiagnosticDelegate(unittest.TestCase):
     def setUpClass(cls):
         fixturesUtils.setUpClass(__file__)
 
-        # Deprecated since version 3.2: assertRegexpMatches and assertRaisesRegexp
-        # have been renamed to assertRegex() and assertRaisesRegex()
-        if sys.version_info.major < 3 or sys.version_info.minor < 2:
-            cls.assertRegex = cls.assertRegexpMatches
-            cls.assertRaisesRegex = cls.assertRaisesRegexp
-
     @classmethod
     def tearDownClass(cls):
         standalone.uninitialize()

--- a/test/lib/usd/translators/testUsdExportStripNamespaces.py
+++ b/test/lib/usd/translators/testUsdExportStripNamespaces.py
@@ -35,12 +35,6 @@ class testUsdExportStripNamespaces(unittest.TestCase):
     def setUpClass(cls):
         fixturesUtils.setUpClass(__file__)
 
-        # Deprecated since version 3.2: assertRegexpMatches and assertRaisesRegexp
-        # have been renamed to assertRegex() and assertRaisesRegex()
-        if sys.version_info.major < 3 or sys.version_info.minor < 2:
-            cls.assertRegex = cls.assertRegexpMatches
-            cls.assertRaisesRegex = cls.assertRaisesRegexp
-
     @classmethod
     def tearDownClass(cls):
         standalone.uninitialize()


### PR DESCRIPTION
#### EMSUSD-2810 - Integrate USD v25.08 into ecg-maya-usd builds
* Fix crash with python object lifetime.
* Remove old python2 'pkg_resources.declare_namespace' and replace with 'pkgutil.extend_path'.
* Replace renamed python function assertRegexpMatches with assertRegex.