### PR TITLE
EMSUSD-2810 - Integrate USD v25.08 into ecg-maya-usd builds

### DIFF
--- a/lib/usd/schemas/CMakeLists.txt
+++ b/lib/usd/schemas/CMakeLists.txt
@@ -136,7 +136,7 @@ execute_process(COMMAND
                 RESULT_VARIABLE
                     usdgen_res
 )
-if(usdgen_res)
+if(usdgen_res EQUAL 1)
     message(FATAL_ERROR "Schemas generation failed")
 endif()
 

--- a/plugin/al/schemas/AL/usd/schemas/maya/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/maya/CMakeLists.txt
@@ -45,7 +45,7 @@ execute_process(
     RESULT_VARIABLE
         usdgen_res
 )
-if(usdgen_res)
+if(usdgen_res EQUAL 1)
     message(FATAL_ERROR "Schemas generation failed")
 endif()
 

--- a/plugin/al/schemas/AL/usd/schemas/mayatest/CMakeLists.txt
+++ b/plugin/al/schemas/AL/usd/schemas/mayatest/CMakeLists.txt
@@ -45,7 +45,7 @@ execute_process(
     RESULT_VARIABLE
         usdgen_res
 )
-if(usdgen_res)
+if(usdgen_res EQUAL 1)
     message(FATAL_ERROR "Schemas generation failed")
 endif()
 

--- a/test/lib/mayaUsd/fileio/CMakeLists.txt
+++ b/test/lib/mayaUsd/fileio/CMakeLists.txt
@@ -89,7 +89,7 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
                         usdgen_res
     )
 
-    if(usdgen_res)
+    if(usdgen_res EQUAL 1)
         message(FATAL_ERROR "Schemas generation failed")
     endif()
 


### PR DESCRIPTION
#### EMSUSD-2810 - Integrate USD v25.08 into ecg-maya-usd builds
* Fix for a problem that occurs when importing Usd into a debug python. When exiting python an exception occurs during the cleanup coming from _usd_d.pyd

#### DESCRIPTION
When importing the Usd python modules into a debug python there is an access violation error that occurs when exiting python during the cleanup of USD global static variables with the `usd` python module. Partial callstack (from Windows):
```
python313_d.dll!00007ff9f907d8ca()
_usd_d.pyd!00007ff9c1d52988()
_usd_d.pyd!00007ff9c1d73b31()
_usd_d.pyd!00007ff9c1d73ad4()
_usd_d.pyd!00007ff9c2247632()
```
The `%ERRORLEVEL%` is set to `-1073741819` which is a padded `0xC0000005` which is a familiar value for access violation exception. That matches the return result from running `usdGenSchema` in cmake using `execute_process`:
` Schemas generation failed with return code: Access violation`

The temp fix which I've done in this PR is to test the return value when running usdGenSchema for an error code from usdGenSchema itself which calls `sys.exit(1)` if there is any error. The previous code just tested if the return result contained anything. Which it did contain the string `Access violation` which came from python and not the usdGenSchema script.