### PR TITLE
EMSUSD-2798: Usd v22.11 Usd.PrimDefinition doesn't have method called GetAttributeDefinition

### DIFF
--- a/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
@@ -577,7 +577,8 @@ class AETemplate(object):
             else:
                 schemaPrimDef   = Usd.SchemaRegistry().FindAppliedAPIPrimDefinition(typeName)
                 attrList = schemaPrimDef.GetPropertyNames()
-                attrList = [name for name in attrList if schemaPrimDef.GetAttributeDefinition(name)]
+                if hasattr(schemaPrimDef, 'GetAttributeDefinition'):
+                    attrList = [name for name in attrList if schemaPrimDef.GetAttributeDefinition(name)]
                 if isMultipleApplyAPISchema:
                     instanceName = typeAndInstance[1]
                     attrList = [name.replace('__INSTANCE_NAME__', instanceName) for name in attrList]


### PR DESCRIPTION
#### EMSUSD-2798: Usd v22.11 Usd.PrimDefinition doesn't have method called GetAttributeDefinition
* Fix AE template for older USD version