### PR TITLE
Fix custom rig test

### DIFF
--- a/test/lib/mayaUsd/fileio/testCustomRig.py
+++ b/test/lib/mayaUsd/fileio/testCustomRig.py
@@ -321,7 +321,7 @@ class testCustomRig(unittest.TestCase):
 
         layer = stage.GetRootLayer()
         layer.ImportFromString(
-        ''' #sdf 1
+            USD_HEADER + '''
             (
                 defaultPrim = "bobs"
             )


### PR DESCRIPTION
New test was not using the fix for 25.8 for importing layer from text strings.