### PR TITLE
Include tbb12 library for LookdevXUfe on Windows-Maya2026.0 only

### DIFF
--- a/cmake/modules/FindLookdevXUfe.cmake
+++ b/cmake/modules/FindLookdevXUfe.cmake
@@ -66,6 +66,32 @@ find_library(LookdevXUfe_LIBRARY
     NO_DEFAULT_PATH
 )
 
+# For Windows-Maya2026.0, the LookdevXUfe lib depends on tbb12
+# We are inserting tbb12 lib into LookdevXUfe_LIBRARY
+if(IS_WINDOWS AND MAYA_API_VERSION VERSION_EQUAL 20260000)
+    find_library(TBB12_LIBRARY
+        NAMES
+            tbb12
+        HINTS
+            $ENV{LOOKDEVXUFE_LIB_ROOT}
+            ${LOOKDEVXUFE_LIB_ROOT}
+            ${MAYA_DEVKIT_LOCATION}
+            $ENV{MAYA_DEVKIT_LOCATION}
+            ${MAYA_LOCATION}
+            $ENV{MAYA_LOCATION}
+            ${MAYA_BASE_DIR}
+        PATHS
+            ${UFE_LIBRARY_DIR}
+        PATH_SUFFIXES
+            devkit/ufe/extensions/lookdevXUfe/lib
+            lib/
+        DOC
+            "tbb12 library"
+        NO_DEFAULT_PATH
+    )
+    set(LookdevXUfe_LIBRARY ${LookdevXUfe_LIBRARY} ${TBB12_LIBRARY})
+endif()
+
 # Handle the QUIETLY and REQUIRED arguments and set LookdevXUfe_FOUND to TRUE if
 # all listed variables are TRUE.
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
**Overview**

Add support for tbb12 library dependency on Windows for Maya 2026.0 Only to prevent a crash: LINK : fatal error LNK1104: cannot open file 'tbb12.lib'.

**The problem**

I was trying to compile MayaUSD for Windows 11 - Maya 2026.0 and I face this error during compilation:
`LINK : fatal error LNK1104: cannot open file 'tbb12.lib' [C:\Users\raphael.jouretz\tmp\MayaUSD-0.33.0-complied\build\RelWithDebInfo\lib\lookdevXUsd\lookdevXUsd.vcxproj]`

After some investigation, I noticed that **devkitBase\devkit\ufe\extensions\lookdevXUfe\lib** is the only 2026 version that contains an extra dependency: **tbb12.lib**. Other 2026.X and OS do not have that lib.
See https://aps.autodesk.com/developer/overview/maya -> `Download SDKs 2019–2026 for Windows` -> `Maya 2026 win64 DevKit`.

**The fix**

lookdevXUsd will complain that it does not find tbb12.lib, so we need to add that extra lib in the target link libraries. Currently it contains ${LookdevXUfe_LIBRARY} https://github.com/Autodesk/maya-usd/blob/d1fb61847a534cd3fff953ff068da372c61fc6b1/lib/lookdevXUsd/CMakeLists.txt#L134 which points to LookdevXUfe_1_0.lib only. In order to not be too intrusive for other builds, my fix will replace the single value of ${LookdevXUfe_LIBRARY} by a list containing both LookdevXUfe_1_0.lib and ttb12.lib. It would have been better to rename it to ${LookdevXUfe_LIBRARIES} but as I am suspecting that dependency was not expected, this quick fix is good enough.

I am creating this MR in order to keep track so other people who face the same problem have a quick fix. Not sure if we need to patch the official branch as it should not be a problem for future versions/other OSs.