### PR TITLE
EMSUSD-2959 Blendshape data for blendshapes breaks on import from USD file

### DIFF
--- a/lib/mayaUsd/fileio/translators/translatorBlendShape.cpp
+++ b/lib/mayaUsd/fileio/translators/translatorBlendShape.cpp
@@ -44,6 +44,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <map>
 #include <utility>
 #include <vector>
 
@@ -276,16 +277,16 @@ bool UsdMayaTranslatorBlendShape::Read(const UsdPrim& meshPrim, UsdMayaPrimReade
 
         const std::vector<UsdSkelInbetweenShape> inBetweens = blendShape.GetInbetweens();
         if (!inBetweens.empty()) {
+            // Create a mapping from index value to original position
+            std::map<int, unsigned int> indexToOriginalPos;
+            for (unsigned int i = 0; i < indicesIntArray.length(); ++i) {
+                indexToOriginalPos[indicesIntArray[i]] = i;
+            }
+
             // Create a mapping from sorted position to original position
             std::vector<unsigned int> sortedToOriginalPos(indexDeltaPairs.size());
             for (unsigned int i = 0; i < indexDeltaPairs.size(); ++i) {
-                int sortedIdx = sortedIndices[i];
-                for (unsigned int j = 0; j < indicesIntArray.length(); ++j) {
-                    if (indicesIntArray[j] == sortedIdx) {
-                        sortedToOriginalPos[i] = j;
-                        break;
-                    }
-                }
+                sortedToOriginalPos[i] = indexToOriginalPos[sortedIndices[i]];
             }
 
             for (const auto& inBetween : inBetweens) {

--- a/test/lib/usd/translators/UsdImportSkeleton/morpher_box.usd
+++ b/test/lib/usd/translators/UsdImportSkeleton/morpher_box.usd
@@ -71,6 +71,7 @@ def SkelRoot "root"
                 weight = -1
             )
             uniform vector3f[] offsets = [(0, 0, 0), (0, 0, 0), (0, 0, 0), (0, 0, 0), (-5, -5, 0), (5, -5, 0), (-5, 5, 0), (5, 5, 0)]
+            uniform int[] pointIndices = [0, 1, 2, 3, 4, 6, 7, 5]
         }
     }
 

--- a/test/lib/usd/translators/testUsdImportBlendShapes.py
+++ b/test/lib/usd/translators/testUsdImportBlendShapes.py
@@ -16,15 +16,12 @@
 #
 
 import unittest, os
-from pxr import Gf, Usd, UsdSkel
+from pxr import Usd, UsdSkel
 
 from maya import cmds
 from maya import standalone
 
-import maya.api.OpenMaya as OM
-
 import fixturesUtils
-
 
 class testUsdImportBlendShapes(unittest.TestCase):
 
@@ -68,6 +65,7 @@ class testUsdImportBlendShapes(unittest.TestCase):
 
         self.assertEqual(cmds.nodeType("b1_Deformer"), "blendShape")
 
+        # Test blend shape weights at different time codes
         cmds.currentTime(0)
         self.assertEqual(sorted(cmds.getAttr("b1_Deformer.weight")[0]), [-1.0])
         cmds.currentTime(3)
@@ -76,6 +74,71 @@ class testUsdImportBlendShapes(unittest.TestCase):
         self.assertEqual(sorted(cmds.getAttr("b1_Deformer.weight")[0]), [0.15625])
         cmds.currentTime(8)
         self.assertEqual(sorted(cmds.getAttr("b1_Deformer.weight")[0]), [1.0])
+
+        # Expected deltas from the USD file:
+        expectedDeltas = {
+            0: (0, 0, 0),
+            1: (0, 0, 0),
+            2: (0, 0, 0),
+            3: (0, 0, 0),
+            4: (-5, -5, 0),
+            5: (5, 5, 0),   # Note: USD has this at index 5
+            6: (5, -5, 0),   # Note: USD has this at index 6
+            7: (-5, 5, 0)    # Note: USD has this at index 7
+        }
+        
+        # Find the target group and item - weight 1.0 maps to item 6000
+        targetGroupIndex = 0
+        targetItemIndex = 6000
+        
+        # The deltas are stored as MFnPointArrayData in inputPointsTarget
+        pointsTargetAttr = f"b1_Deformer.inputTarget[0].inputTargetGroup[{targetGroupIndex}].inputTargetItem[{targetItemIndex}].inputPointsTarget"
+        componentsTargetAttr = f"b1_Deformer.inputTarget[0].inputTargetGroup[{targetGroupIndex}].inputTargetItem[{targetItemIndex}].inputComponentsTarget"
+        
+        # Get the component indices (which vertices are affected)
+        self.assertTrue(cmds.objExists(componentsTargetAttr), "inputComponentsTarget attribute should exist")
+        
+        # Get the points (deltas) - this returns a flat list of coordinates
+        self.assertTrue(cmds.objExists(pointsTargetAttr), "inputPointsTarget attribute should exist")
+
+        # pointsData is a list of tuples: [(x1, y1, z1, w1), (x2, y2, z2, w2), ...]
+        pointsData = cmds.getAttr(pointsTargetAttr)
+
+        self.assertEqual(len(pointsData), 8, f"Expected 8 deltas, but got {len(pointsData)}")
+
+        # The sorted indices from the USD file (after sorting by the C++ code)
+        sortedIndices = [0, 1, 2, 3, 4, 5, 6, 7]
+
+        # Now match indices with deltas
+        actualDeltas = {}
+        foundNonZeroVertices = set()
+
+        for i, vertexIndex in enumerate(sortedIndices):
+            if i < len(pointsData):
+                deltaX = pointsData[i][0]
+                deltaY = pointsData[i][1]
+                deltaZ = pointsData[i][2]
+                
+                actualDeltas[vertexIndex] = (deltaX, deltaY, deltaZ)
+                
+                # Check if this is a non-zero delta
+                if abs(deltaX) > 0.0001 or abs(deltaY) > 0.0001 or abs(deltaZ) > 0.0001:
+                    foundNonZeroVertices.add(vertexIndex)
+                
+                # Check against expected delta
+                if vertexIndex in expectedDeltas:
+                    expectedDelta = expectedDeltas[vertexIndex]
+                    self.assertAlmostEqual(deltaX, expectedDelta[0], places=4,
+                                           msg=f"Vertex {vertexIndex} delta X mismatch: expected {expectedDelta[0]}, got {deltaX}")
+                    self.assertAlmostEqual(deltaY, expectedDelta[1], places=4,
+                                           msg=f"Vertex {vertexIndex} delta Y mismatch: expected {expectedDelta[1]}, got {deltaY}")
+                    self.assertAlmostEqual(deltaZ, expectedDelta[2], places=4,
+                                           msg=f"Vertex {vertexIndex} delta Z mismatch: expected {expectedDelta[2]}, got {deltaZ}")
+        
+        # Verify that the non-zero deltas are present (vertices 4, 5, 6, 7 should have deltas)
+        nonZeroDeltaVertices = {4, 5, 6, 7}
+        self.assertEqual(foundNonZeroVertices, nonZeroDeltaVertices,
+                         f"Non-zero delta vertices don't match expected set. Found: {foundNonZeroVertices}, Expected: {nonZeroDeltaVertices}. All deltas found: {actualDeltas}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes a regression when importing blendshapes with non-sorted indices. 
`MFnSingleIndexedComponent` used in for indexing the blendshapes sorts the indices by default. This PR makes sure the indices are sorted prior to created that component so that we can match the indices with the corresponding blendshape.