### PR TITLE
EMSUSD-2820 proxy accessor target layer

### DIFF
--- a/lib/mayaUsd/nodes/proxyAccessor.h
+++ b/lib/mayaUsd/nodes/proxyAccessor.h
@@ -140,10 +140,14 @@ public:
        Once completed, all output accessor plugs will be provided with data. \note   Call from
        MPxNode::compute()
      */
-    static MStatus compute(const Owner& accessor, const MPlug& plug, MDataBlock& dataBlock)
+    static MStatus compute(
+        const Owner&   accessor,
+        const MPlug&   plug,
+        MDataBlock&    dataBlock,
+        const MString& targetLayer)
     {
         if (accessor)
-            return accessor->compute(plug, dataBlock);
+            return accessor->compute(plug, dataBlock, targetLayer);
         else
             return MStatus::kFailure;
     }
@@ -175,10 +179,14 @@ public:
     /*! \brief  Update USD state to match what is stored in evaluation cache (when cached
        playback is on) \note   Call from MPxNode::postEvaluation()
      */
-    static MStatus syncCache(const Owner& accessor, const MObject& node, MDataBlock& dataBlock)
+    static MStatus syncCache(
+        const Owner&   accessor,
+        const MObject& node,
+        MDataBlock&    dataBlock,
+        const MString& targetLayer)
     {
         if (accessor && !accessor->inCompute())
-            return accessor->syncCache(node, dataBlock);
+            return accessor->syncCache(node, dataBlock, targetLayer);
         else
             return MStatus::kFailure;
     }
@@ -227,7 +235,7 @@ private:
     //! \brief  Notification from MPxNode to insert accessor plugs dependencies
     MStatus addDependentsDirty(const MPlug& plug, MPlugArray& plugArray);
     //! \brief  Notification from MPxNode to compute accessor plugs.
-    MStatus compute(const MPlug& plug, MDataBlock& dataBlock);
+    MStatus compute(const MPlug& plug, MDataBlock& dataBlock, const MString& targetLayer);
     //! \brief  Using acceleration structure, do computation of a given accessor input plug.
     MStatus computeInput(
         Item&                outputItemToCompute,
@@ -248,7 +256,7 @@ private:
        invalidate the cache. In order to keep USD state in sync with what was stored in
        evaluation cache, we leverage postEvaluation notification.
     */
-    MStatus syncCache(const MObject& node, MDataBlock& dataBlock);
+    MStatus syncCache(const MObject& node, MDataBlock& dataBlock, const MString& targetLayer);
 
     //! \brief  Something in USD changed and we may have to set it on plugs.
     MStatus stageChanged(const MObject& node, const UsdNotice::ObjectsChanged& notice);

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -688,7 +688,7 @@ MStatus MayaUsdProxyShapeBase::compute(const MPlug& plug, MDataBlock& dataBlock)
         return computeInStageDataCached(dataBlock);
     } else if (plug == outTimeAttr) {
         auto retStatus = computeOutputTime(dataBlock);
-        ProxyAccessor::compute(_usdAccessor, plug, dataBlock);
+        ProxyAccessor::compute(_usdAccessor, plug, dataBlock, _proxyAccessorLayer);
         return retStatus;
     } else if (plug == outStageDataAttr) {
         auto ret = computeOutStageData(dataBlock);
@@ -696,7 +696,7 @@ MStatus MayaUsdProxyShapeBase::compute(const MPlug& plug, MDataBlock& dataBlock)
     } else if (plug == outStageCacheIdAttr) {
         return computeOutStageCacheId(dataBlock);
     } else if (plug.isDynamic()) {
-        return ProxyAccessor::compute(_usdAccessor, plug, dataBlock);
+        return ProxyAccessor::compute(_usdAccessor, plug, dataBlock, _proxyAccessorLayer);
     }
 
     return MS::kUnknownParameter;
@@ -1788,7 +1788,7 @@ MStatus MayaUsdProxyShapeBase::postEvaluation(
 
     if (context.isNormal() && evalType == PostEvaluationEnum::kEvaluatedDirectly) {
         MDataBlock dataBlock = forceCache();
-        ProxyAccessor::syncCache(_usdAccessor, thisMObject(), dataBlock);
+        ProxyAccessor::syncCache(_usdAccessor, thisMObject(), dataBlock, _proxyAccessorLayer);
     }
 
     return MPxSurfaceShape::postEvaluation(context, evaluationNode, evalType);

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -382,6 +382,9 @@ protected:
     MAYAUSD_CORE_PUBLIC
     void copyInternalData(MPxNode* srcNode) override;
 
+    MAYAUSD_CORE_PUBLIC
+    void setProxyAccessorLayer(const MString& layer) { _proxyAccessorLayer = layer; }
+
 private:
     // The possible the shared mode of the stage.
     // The 'Unknown' mode is when the proxy shape is created and has not yet been computed.
@@ -466,6 +469,13 @@ private:
     // transferred to this variable on the first compute. Afterward, when the edit
     // target is changed, this gets updated via a notification listener.
     SdfLayerRefPtr _targetLayer;
+
+    // The layer to be used by the proxy accessor. Can be one of:
+    //     empty: use the session layer (default)
+    //     "session": use the session layer
+    //     "target": use the current edit target
+    //     A layer ID: use that layer if it exists, otherwise use the session layer
+    MString _proxyAccessorLayer;
 
     // We need to keep track of unshared sublayers (otherwise they get removed)
     std::vector<SdfLayerRefPtr> _unsharedStageRootSublayers;

--- a/plugin/adsk/plugin/ProxyShape.cpp
+++ b/plugin/adsk/plugin/ProxyShape.cpp
@@ -19,6 +19,10 @@
 #include <mayaUsd/nodes/proxyShapePlugin.h>
 #include <mayaUsd/utils/util.h>
 
+#include <maya/MDataBlock.h>
+#include <maya/MEvaluationNode.h>
+#include <maya/MFnTypedAttribute.h>
+
 namespace MAYAUSD_NS_DEF {
 
 // ========================================================
@@ -28,6 +32,9 @@ const MTypeId MAYAUSD_PROXYSHAPE_ID(0x58000095);
 const MTypeId ProxyShape::typeId(MayaUsd::MAYAUSD_PROXYSHAPE_ID);
 const MString ProxyShape::typeName("mayaUsdProxyShape");
 
+MObject            ProxyShape::proxyAccessorLayerAttr;
+static const char* kProxyAccessorLayerAttrName = "proxyAccessorLayer";
+
 /* static */
 void* ProxyShape::creator() { return new ProxyShape(); }
 
@@ -35,6 +42,17 @@ void* ProxyShape::creator() { return new ProxyShape(); }
 MStatus ProxyShape::initialize()
 {
     MStatus retValue = inheritAttributesFrom(MayaUsdProxyShapeBase::typeName);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+    MFnTypedAttribute typedAttrFn;
+
+    proxyAccessorLayerAttr = typedAttrFn.create(
+        kProxyAccessorLayerAttrName, "pala", MFnData::kString, MObject::kNullObj, &retValue);
+    typedAttrFn.setStorable(true);
+    typedAttrFn.setWritable(true);
+    typedAttrFn.setReadable(true);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+    retValue = addAttribute(proxyAccessorLayerAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
     return retValue;
@@ -66,6 +84,24 @@ void ProxyShape::postConstructor()
 
     // Enable proxy accessor features for this proxy
     enableProxyAccessor();
+}
+
+MStatus ProxyShape::preEvaluation(const MDGContext& context, const MEvaluationNode& evaluationNode)
+{
+    _verifyProxyAccessorLayer = true;
+    return MayaUsdProxyShapeBase::preEvaluation(context, evaluationNode);
+}
+
+MStatus ProxyShape::compute(const MPlug& plug, MDataBlock& dataBlock)
+{
+    if (_verifyProxyAccessorLayer) {
+        if (plug == outTimeAttr || plug.isDynamic()) {
+            const MString layerName = dataBlock.inputValue(proxyAccessorLayerAttr).asString();
+            setProxyAccessorLayer(layerName);
+            _verifyProxyAccessorLayer = false;
+        }
+    }
+    return MayaUsdProxyShapeBase::compute(plug, dataBlock);
 }
 
 } // namespace MAYAUSD_NS_DEF

--- a/plugin/adsk/plugin/ProxyShape.h
+++ b/plugin/adsk/plugin/ProxyShape.h
@@ -38,10 +38,17 @@ public:
     static const MString typeName;
 
     MAYAUSD_PLUGIN_PUBLIC
+    static MObject proxyAccessorLayerAttr;
+
+    MAYAUSD_PLUGIN_PUBLIC
     static void* creator();
 
     MAYAUSD_PLUGIN_PUBLIC
     static MStatus initialize();
+
+    MStatus
+            preEvaluation(const MDGContext& context, const MEvaluationNode& evaluationNode) override;
+    MStatus compute(const MPlug& plug, MDataBlock& dataBlock) override;
 
     void postConstructor() override;
 
@@ -51,6 +58,9 @@ private:
     ProxyShape(const ProxyShape&);
     ~ProxyShape() override;
     ProxyShape& operator=(const ProxyShape&);
+
+    // Flag to only update the target once per evaluation.
+    bool _verifyProxyAccessorLayer { false };
 };
 
 } // namespace MAYAUSD_NS_DEF

--- a/test/lib/testMayaUsdProxyAccessor.py
+++ b/test/lib/testMayaUsdProxyAccessor.py
@@ -192,14 +192,35 @@ class MayaUsdProxyAccessorTestCase(unittest.TestCase):
         v1 = cmds.getAttr('{}.{}'.format(nodeDagPath,worldMatrixPlugSphere))
         self.assertVectorAlmostEqual(v1, [0.0, 0.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 5.0, 5.0, 1.0])
 
-    def validateInput(self, cachingScope):
+    def validateInput(self, cachingScope, targetLayer):
         """
         Validate that accessor can write data to the stage and it's propagated correctly to:
         - output plugs
         - UFE interfaces
         """
         nodeDagPath, stage = createProxyFromFile(self.testAnimatedHierarchyUsdFile)
-        
+
+        def verifySessionLayer(expectEmpty):
+            lines = stage.GetSessionLayer().ExportToString().split('\n')
+            lines = [line for line in lines if line.strip() and not line.strip().startswith('#')]
+            if expectEmpty:
+                self.assertFalse(lines)
+            else:
+                self.assertTrue(lines)
+
+        verifySessionLayer(expectEmpty=True)
+
+        if targetLayer:
+            if targetLayer == 'root':
+                layerName = stage.GetRootLayer().identifier
+            elif targetLayer == 'target':
+                layerName = 'target'
+            elif targetLayer == 'session':
+                layerName = 'session'
+            else:
+                layerName = targetLayer
+            cmds.setAttr("{}.proxyAccessorLayer".format(nodeDagPath), layerName, type="string")
+
         # Get UFE items
         ufeItemParent = createUfeSceneItem(nodeDagPath,'/ParentA')
         ufeItemSphere = createUfeSceneItem(nodeDagPath,'/ParentA/Sphere')
@@ -238,6 +259,8 @@ class MayaUsdProxyAccessorTestCase(unittest.TestCase):
         v2 = ufeTransform3dCube.segmentInclusiveMatrix()
         self.assertVectorAlmostEqual(v1, [0.0, 0.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 10.0, 10.0, 15.0, 1.0])
         self.assertMatrixAlmostEqual(v2.matrix, [[0.0, 0.0, -1.0, 0.0], [0.0, 1.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0], [5.0, 10.0, 10.0, 1.0]])
+
+        verifySessionLayer(expectEmpty=bool(targetLayer and targetLayer != 'session'))
 
     def validateParentingDagObjectUnderUsdPrim(self, cachingScope):
         """
@@ -990,7 +1013,7 @@ class MayaUsdProxyAccessorTestCase(unittest.TestCase):
             thisScope.verifyScopeSetup()
             self.validateTransformedOutput(thisScope)
     
-    def testInput_NoCaching(self):
+    def testInput_NoCaching_SessionLayer(self):
         """
         The that accessor can write data to the stage and it's propagated correctly to:
         - output plugs
@@ -1000,9 +1023,21 @@ class MayaUsdProxyAccessorTestCase(unittest.TestCase):
         cmds.file(new=True, force=True)
         with NonCachingScope(self) as thisScope:
             thisScope.verifyScopeSetup()
-            self.validateInput(thisScope)
+            self.validateInput(thisScope, "")
   
-    def testInput_Caching(self):
+    def testInput_NoCaching_TargetLayer(self):
+        """
+        The that accessor can write data to the stage and it's propagated correctly to:
+        - output plugs
+        - UFE interfaces
+        Cached playback is disabled in this test.
+        """
+        cmds.file(new=True, force=True)
+        with NonCachingScope(self) as thisScope:
+            thisScope.verifyScopeSetup()
+            self.validateInput(thisScope, "target")
+  
+    def testInput_Caching_SessionLayer(self):
         """
         The that accessor can write data to the stage and it's propagated correctly to:
         - output plugs
@@ -1012,7 +1047,19 @@ class MayaUsdProxyAccessorTestCase(unittest.TestCase):
         cmds.file(new=True, force=True)
         with CachingScope(self) as thisScope:
             thisScope.verifyScopeSetup()
-            self.validateInput(thisScope)
+            self.validateInput(thisScope, 'session')
+        
+    def testInput_Caching_RootLayer(self):
+        """
+        The that accessor can write data to the stage and it's propagated correctly to:
+        - output plugs
+        - UFE interfaces
+        Cached playback is ENABLED in this test.
+        """
+        cmds.file(new=True, force=True)
+        with CachingScope(self) as thisScope:
+            thisScope.verifyScopeSetup()
+            self.validateInput(thisScope, 'root')
         
     def testParentingDagObjectUnderUsdPrim_NoCaching(self):
         """


### PR DESCRIPTION
The goal is to fix an issue reported by ILM in that the proxy accessor always writes its data to the session layer and ignored the edit target. The new code defaults to this old behavior, but allows using the current edit target or setting an explicit layer to target.

- Added a `proxyAccessorLayer` (`pala`) attribute on the MayaUSD proxy shape.
- This attribute controls which layer is targeted by the proxy accessor.
- If empty: use the session layer (default).
- If "session": use the session layer.
- If "target": use the current edit target of the stage.
- If a layer ID: use that layer if it exists, otherwise use the session layer.
- Added a `_proxyAccessorLayer` data member to the `MayaUsdProxyShapeBase` class, filled by the attribute value during compute.
- Use that value when calling into the `ProxyAccessor` class.
- Modified the `ProxyAccessor` functions to accept the layer name and pass it to its private `ComputeContext` class.
- Modified the `ComputeContext` functions to accept the layer name and set the edit target as described above.
- Added some unit tests.