### PR TITLE
EMSUSD-2969 bake export unit

### DIFF
--- a/lib/mayaUsd/fileio/jobs/writeJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/writeJob.cpp
@@ -283,7 +283,11 @@ private:
             //    - Capture the new group name in a MEL variable called $groupName
             "string $groupName = `group -absolute -world $rootNodeNames`;\n";
 
-        static const char scriptSuffix[] = // Ungroup while preserving the rotation.
+        static const char scriptSuffix[] =
+            // Apply the transformations to avoid accumulating transforms on ungroup.
+            "makeIdentity -apply true -rotate true -scale true -normal 0 -preserveNormals true "
+            "$groupName;\n"
+            // Ungroup while preserving the rotation.
             "ungroup -absolute $groupName;\n"
             // Restore the selection.
             "select -replace $selection;\n";

--- a/test/lib/usd/translators/testUsdExportUnits.py
+++ b/test/lib/usd/translators/testUsdExportUnits.py
@@ -107,8 +107,10 @@ class testUsdExportUnits(unittest.TestCase):
         self.assertTrue(spherePrim)
 
         transformUtils.assertPrimXforms(self, spherePrim, [
-            ('xformOp:translate', (0., 0., 30.)),
-            ('xformOp:scale', (10., 10., 10.))])
+            ('xformOp:translate', (0., 0., 3.)),
+            ('xformOp:translate:pivot', (0., 0., 27.)),
+            ('!invert!xformOp:translate:pivot', None),
+        ])
 
     def testExportUnitsNanometers(self):
         """Test exporting and forcing units of nanometers, different from Maya prefs."""
@@ -171,8 +173,10 @@ class testUsdExportUnits(unittest.TestCase):
 
         expectedScale = 0.01 / expectedMetersPerUnit
         transformUtils.assertPrimXforms(self, spherePrim, [
-            ('xformOp:translate', (0., 0., 3 * expectedScale)),
-            ('xformOp:scale', (expectedScale, expectedScale, expectedScale))])
+            ('xformOp:translate', (0., 0., 3.)),
+            ('xformOp:translate:pivot', (0., 0., 3 * expectedScale - 3.)),
+            ('!invert!xformOp:translate:pivot', None),
+        ])
 
 
 if __name__ == '__main__':

--- a/test/lib/usd/translators/testUsdExportUpAxis.py
+++ b/test/lib/usd/translators/testUsdExportUpAxis.py
@@ -100,8 +100,10 @@ class testUsdExportUpAxis(unittest.TestCase):
         self.assertTrue(spherePrim)
 
         transformUtils.assertPrimXforms(self, spherePrim, [
-            ('xformOp:translate', (0., 3., 0.)),
-            ('xformOp:rotateXYZ', (-90., 0., 0.))])
+            ('xformOp:translate', (0., 0., 3.)),
+            ('xformOp:translate:pivot', (0., 3., -3.)),
+            ('!invert!xformOp:translate:pivot', None),
+        ])
 
 
 if __name__ == '__main__':

--- a/test/testUtils/transformUtils.py
+++ b/test/testUtils/transformUtils.py
@@ -53,12 +53,14 @@ def assertPrimXforms(test, prim, xforms):
     '''
     EPSILON = 1e-5
     xformOpOrder = prim.GetAttribute('xformOpOrder').Get()
-    test.assertEqual(len(xformOpOrder), len(xforms))
+    test.assertEqual(len(xformOpOrder), len(xforms), "%s != %s" % (xformOpOrder, xforms))
     for name, value in xforms:
         test.assertEqual(xformOpOrder[0], name)
-        attr = prim.GetAttribute(name)
-        test.assertIsNotNone(attr)
-        test.assertTrue(Gf.IsClose(attr.Get(), value, EPSILON))
+        if value is not None:
+            attr = prim.GetAttribute(name)
+            test.assertIsNotNone(attr, "Attribute %s not found on prim %s" % (name, prim.GetPath()))
+            attrValue = attr.Get()
+            test.assertTrue(Gf.IsClose(attrValue, value, EPSILON), "%s does not match: %s != %s" % (name, attrValue, value))
         # Chop off the first xofrm op for the next loop.
         xformOpOrder = xformOpOrder[1:]
 


### PR DESCRIPTION
When exporting with the `-unit` or `-upAxis` flags, bake the scaling and rotation into the vertices positions instead of having a global rotation or scaling on the root nodes. That is the preferred way user want to work.

In particular, adding transformations (scaling or rotation) on the root nodes clashes with other USD layers that studio want to put on top. Those layer may come from other sources. So baking the position is preferred as it does not affect other layers that are composed over the exported data.