### PR TITLE
EMSUSDC-257 Transfer over session layer content when we save.

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeModel.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeModel.cpp
@@ -633,7 +633,8 @@ void LayerTreeModel::saveStage(QWidget* in_parent)
                     MDagPath newProxyShapePath;
                     MDagPath::getAPathTo(proxyNode, newProxyShapePath);
 
-                    // Save the old session layer content before swapping the root, which will create a new stage.
+                    // Save the old session layer content before swapping the root, which will
+                    // create a new stage.
                     auto oldSessionLayer = _sessionState->stage()->GetSessionLayer();
 
                     // Set the updated root file path


### PR DESCRIPTION
Upon initial saving of components we were loosing the contents of the session layer, and in effect, a new stage is re-created. This was causing us to loose the variant selection - amongst other possible things.