### PR TITLE
EMSUSD-2999 - add label when no search paths are in a context data group

### DIFF
--- a/lib/usd/ui/assetResolver/USDAssetResolverSettingsWidget.cpp
+++ b/lib/usd/ui/assetResolver/USDAssetResolverSettingsWidget.cpp
@@ -75,7 +75,7 @@ public:
         viewport()->update(r);
     }
 
-    void paintEvent(QPaintEvent* e)
+    void paintEvent(QPaintEvent* e) override
     {
         QListView::paintEvent(e);
         if (model() && model()->rowCount(rootIndex()) > 0)


### PR DESCRIPTION
## Goal
EMSUSD-2999 -  add label when no search paths are in a context data group

## Description
Fix missing "No paths" message in environment list and user paths list when empty.