### PR TITLE
Remove needless USD context menu separator

### DIFF
--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -816,7 +816,6 @@ proc mayaUsdMenu_addCommonUsdContextMenuItems(string $obj, string $insertAfter)
         string $proxyShapes[] = `ls -type mayaUsdProxyShape`;
 		string $mayaVersion = getMayaMajorVersion();
 		$usdContextMenu = `menuItem -label "USD" -subMenu true -insertAfter $insertAfter -version $mayaVersion -image "USD_generic.png"`;
-        menuItem -divider true;
 
 		// Conditionally add "Duplicate as USD Data" submenu if there are proxy shapes
 		if (size($proxyShapes) > 0) {


### PR DESCRIPTION
Daniel noticed this extra seperator at the top : 

<img width="299" height="82" alt="image" src="https://github.com/user-attachments/assets/ecf1bfbf-ad81-473a-abf8-1051a3f2aa0a" />

After fix : 

<img width="518" height="90" alt="image" src="https://github.com/user-attachments/assets/5c0e23be-370d-4dbe-a639-3d79e31aa25a" />