### PR TITLE
EMSUSD-3016 save edits for component

### DIFF
--- a/lib/usd/ui/layerEditor/layerEditorWidget.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.cpp
@@ -399,13 +399,13 @@ void LayerEditorWidget::onNewLayerButtonClicked()
     }
 
     if (addToRoot) {
-        layerTreeItem->addAnonymousSublayer();
+        layerTreeItem->addAnonymousSublayer(_treeView);
     } else {
         // add a sibling to the selection
         UndoContext context(_sessionState.commandHook(), "Add Anonymous Layer");
         auto        parentItem = layerTreeItem->parentLayerItem();
         int         rowToInsert = layerTreeItem->row();
-        auto        newLayer = parentItem->addAnonymousSublayerAndReturn();
+        auto        newLayer = parentItem->addAnonymousSublayerAndReturn(_treeView);
         // move it to the right place, if it's not top
         if (rowToInsert > 0) {
             context.hook()->removeSubLayerPath(parentItem->layer(), newLayer->GetIdentifier());

--- a/lib/usd/ui/layerEditor/layerTreeItem.h
+++ b/lib/usd/ui/layerEditor/layerTreeItem.h
@@ -183,17 +183,17 @@ public:
     LayerItemVector childrenVector() const;
 
     // menu callbacks
-    void removeSubLayer();
-    void saveEdits();
-    void saveEditsNoPrompt();
-    void discardEdits();
+    void removeSubLayer(QWidget* in_parent);
+    void saveEdits(QWidget* in_parent);
+    void saveEditsNoPrompt(QWidget* in_parent);
+    void discardEdits(QWidget* in_parent);
 
     // there are two addAnonymousSubLayer , because the menu needs all method to be void
-    void                   addAnonymousSublayer();
-    PXR_NS::SdfLayerRefPtr addAnonymousSublayerAndReturn();
+    void                   addAnonymousSublayer(QWidget* in_parent);
+    PXR_NS::SdfLayerRefPtr addAnonymousSublayerAndReturn(QWidget* in_parent);
     void                   loadSubLayers(QWidget* in_parent);
-    void                   printLayer();
-    void                   clearLayer();
+    void                   printLayer(QWidget* in_parent);
+    void                   clearLayer(QWidget* in_parent);
 
     // delegate Action API for command buttons
     void getActionButton(LayerActionType actionType, LayerActionInfo& out_info) const;
@@ -220,7 +220,7 @@ protected:
 protected:
     void populateChildren(RecursionDetector* in_recursionDetector);
     // helper to save anon layers called by saveEdits()
-    void saveAnonymousLayer();
+    void saveAnonymousLayer(QWidget* in_parent);
 
 private:
     bool sublayerOfShared() const;

--- a/lib/usd/ui/layerEditor/layerTreeModel.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeModel.cpp
@@ -508,7 +508,7 @@ LayerTreeModel::getAllAnonymousLayers(const LayerTreeItem* item /* = nullptr*/) 
 
 void LayerTreeModel::saveStage(QWidget* in_parent)
 {
-    auto saveAllLayers = [this]() {
+    auto saveAllLayers = [this, in_parent]() {
         // Special case for components created by the component creator. Only the component creator
         // knows how to save a component properly.
         if (MayaUsd::ComponentUtils::isAdskUsdComponent(
@@ -522,7 +522,7 @@ void LayerTreeModel::saveStage(QWidget* in_parent)
         for (auto layer : layers) {
             if (!layer->isSystemLocked()) {
                 if (!layer->isAnonymous()) {
-                    layer->saveEditsNoPrompt();
+                    layer->saveEditsNoPrompt(in_parent);
                 }
             }
         }
@@ -566,6 +566,7 @@ void LayerTreeModel::saveStage(QWidget* in_parent)
                 MGlobal::displayError(resultMsg);
 
                 warningDialog(
+                    in_parent,
                     StringResources::getAsQString(StringResources::kSaveAnonymousLayersErrorsTitle),
                     StringResources::getAsQString(StringResources::kSaveAnonymousLayersErrorsMsg));
             } else {

--- a/lib/usd/ui/layerEditor/layerTreeView.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeView.cpp
@@ -41,15 +41,18 @@ struct CallMethodParams
 namespace {
 QColor BLACK_BACKGROUND(55, 55, 55);
 
-typedef void (LayerTreeItem::*simpleLayerMethod)();
+typedef void (LayerTreeItem::*simpleLayerMethod)(QWidget* parent);
 
-void doCallMethodOnSelection(const CallMethodParams& params, simpleLayerMethod method)
+void doCallMethodOnSelection(
+    const CallMethodParams& params,
+    simpleLayerMethod       method,
+    QWidget*                in_parent)
 {
     if (params.selection->size() > 0) {
         UndoContext context(params.commandHook, params.name);
 
         for (auto item : *params.selection) {
-            (item->*method)();
+            (item->*method)(in_parent);
         }
     }
 }
@@ -201,7 +204,7 @@ void LayerTreeView::onItemDoubleClicked(const QModelIndex& index)
     if (layerTreeItem->isSystemLocked() || layerTreeItem->appearsSystemLocked())
         return;
 
-    layerTreeItem->saveEdits();
+    layerTreeItem->saveEdits(this);
 }
 
 bool LayerTreeView::shouldExpandOrCollapseAll() const
@@ -506,7 +509,7 @@ void LayerTreeView::callMethodOnSelectionNoDelay(const QString& undoName, simple
     params.selection = &selection;
     params.commandHook = _model->sessionState()->commandHook();
     params.name = undoName;
-    doCallMethodOnSelection(params, method);
+    doCallMethodOnSelection(params, method, this);
 }
 
 void LayerTreeView::paintEvent(QPaintEvent* event)
@@ -614,7 +617,7 @@ void LayerTreeView::keyPressEvent(QKeyEvent* event)
             params.selection = &selection;
             params.commandHook = _model->sessionState()->commandHook();
             params.name = "Remove";
-            doCallMethodOnSelection(params, &LayerTreeItem::removeSubLayer);
+            doCallMethodOnSelection(params, &LayerTreeItem::removeSubLayer, this);
             return;
         } else if (event->key() == Qt::Key_R) {
             _model->forceRefresh();

--- a/lib/usd/ui/layerEditor/layerTreeView.h
+++ b/lib/usd/ui/layerEditor/layerTreeView.h
@@ -40,7 +40,7 @@ class LayerTreeView;
 class SessionState;
 
 typedef std::vector<LayerTreeItem*> LayerItemVector;
-typedef void (LayerTreeItem::*simpleLayerMethod)();
+typedef void (LayerTreeItem::*simpleLayerMethod)(QWidget* in_parent);
 
 /**
  * @brief State of the layer tree view and layer model.

--- a/lib/usd/ui/layerEditor/pathChecker.cpp
+++ b/lib/usd/ui/layerEditor/pathChecker.cpp
@@ -78,7 +78,9 @@ bool checkPathRecursive(
                 pathToCheck.c_str());
             message = MQtUtil::toQString(tmp);
         }
-        warningDialog(in_errorTitle, message);
+        // TODO: fix to have a valid parent widget.
+        QWidget* parent = nullptr;
+        warningDialog(parent, in_errorTitle, message);
         return false;
     }
 
@@ -161,7 +163,9 @@ bool checkIfPathIsSafeToAdd(
     msg.format(
         StringResources::getAsMString(StringResources::kErrorCannotAddPathTwice),
         in_pathToAdd.c_str());
-    warningDialog(in_errorTitle, MQtUtil::toQString(msg));
+    // TODO: fix to have a valid parent widget.
+    QWidget* parent = nullptr;
+    warningDialog(parent, in_errorTitle, MQtUtil::toQString(msg));
     return false;
 }
 

--- a/lib/usd/ui/layerEditor/saveLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.cpp
@@ -1016,6 +1016,7 @@ bool SaveLayersDialog::okToSave()
             StringResources::getAsMString(StringResources::kSaveAnonymousIdenticalFiles), count);
 
         warningDialog(
+            this,
             StringResources::getAsQString(StringResources::kSaveAnonymousIdenticalFilesTitle),
             MQtUtil::toQString(errorMsg),
             &identicalFiles,
@@ -1032,6 +1033,7 @@ bool SaveLayersDialog::okToSave()
             StringResources::getAsMString(StringResources::kSaveAnonymousConfirmOverwrite), count);
 
         return (confirmDialog(
+            this,
             StringResources::getAsQString(StringResources::kSaveAnonymousConfirmOverwriteTitle),
             MQtUtil::toQString(confirmMsg),
             &existingFiles,

--- a/lib/usd/ui/layerEditor/warningDialogs.cpp
+++ b/lib/usd/ui/layerEditor/warningDialogs.cpp
@@ -40,13 +40,14 @@ namespace UsdLayerEditor {
 
 bool confirmDialog_internal(
     bool               okCancel,
+    QWidget*           parent,
     const QString&     title,
     const QString&     message,
     const QStringList* bulletList,
     const QString*     okButtonText,
     QMessageBox::Icon  icon)
 {
-    QMessageBox msgBox;
+    QMessageBox msgBox(parent);
     // there is no title bar text on mac, instead it's bold text
     if (IS_MAC_OS)
         msgBox.setText(title);
@@ -88,23 +89,25 @@ bool confirmDialog_internal(
 }
 
 bool confirmDialog(
+    QWidget*           parent,
     const QString&     title,
     const QString&     message,
     const QStringList* bulletList,
     const QString*     okButtonText,
     QMessageBox::Icon  icon)
 {
-    return confirmDialog_internal(true, title, message, bulletList, okButtonText, icon);
+    return confirmDialog_internal(true, parent, title, message, bulletList, okButtonText, icon);
 }
 
 // create a warning dialog, with an optional bullet list
 void warningDialog(
+    QWidget*           parent,
     const QString&     title,
     const QString&     message,
     const QStringList* bulletList,
     QMessageBox::Icon  icon)
 {
-    confirmDialog_internal(false, title, message, bulletList, nullptr, icon);
+    confirmDialog_internal(false, parent, title, message, bulletList, nullptr, icon);
 }
 
 } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/warningDialogs.h
+++ b/lib/usd/ui/layerEditor/warningDialogs.h
@@ -28,6 +28,7 @@ namespace UsdLayerEditor {
 
 // create a confirmation dialog, with an optional bullet list of stuff like layer names
 bool confirmDialog(
+    QWidget*           parent,
     const QString&     title,
     const QString&     message,
     const QStringList* bulletList = nullptr,
@@ -36,6 +37,7 @@ bool confirmDialog(
 
 // create a dialog with a single OK button, with an optional bullet list
 void warningDialog(
+    QWidget*           parent,
     const QString&     title,
     const QString&     message,
     const QStringList* bulletList = nullptr,


### PR DESCRIPTION
When using the Save Edits menu on the layer items, detect component and reuse the tree model saveStage handling of component.

Locate dialogs on parent:
- Modified the `confirmDialog` and `warningDialog` function to take the parent widget.
- Added  `in_parent` parameter to various layer tree item methods to allow positioning the dialogs over the correct window.
- Previously, various dialogs would pop up under other windows, because no parent widget were provided.
- Modified the `simpleLayerMethod` typedef to take a parent QWidget pointer.
- Modified the `LayerTreeView` to call layer tree item methods with itself as the parent.
- Adapted various other places that were calling those methods.
- Modified various calls showing dialogs to use the parent widget.