### PR TITLE
Update README files to link to the correct maya-hydra repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ We take security serious at Autodesk and the same goes for our open source contr
 + [Maya Reference Edit Router](lib/usd/translators/mayaReferenceEditRouter.md)
 + [Layer Locking](doc/LayerLocking.md)
 + [Attribute Editor (AE) Template](lib/mayaUsd/resources/ae/usdschemabase/Attribute-Editor-Template-Doc.md)
-+ [Hydra For Maya](https://github.com/Autodesk/maya-usd/blob/release/maya-hydra/lib/mayaHydra/README.md)
++ [Hydra for Maya](https://github.com/Autodesk/maya-hydra/blob/dev/README.md)
 
 ## Additional Information
 

--- a/README_DOC.md
+++ b/README_DOC.md
@@ -14,7 +14,7 @@
 + [Undo/Redo Support](lib/mayaUsd/undo/README.md)
 + [MaterialX](doc/MaterialX.md)
 + [MaterialX Code Gen](lib/mayaUsd/render/MaterialXGenOgsXml/README.md)
-+ [Hydra For Maya](https://github.com/Autodesk/maya-usd/blob/release/maya-hydra/lib/mayaHydra/README.md)
++ [Hydra for Maya](https://github.com/Autodesk/maya-hydra/blob/dev/README.md)
 + [Layer Saving](lib/mayaUsd/nodes/Layer_Saving_Docs.md)
 + [Maya Reference Edit Router](lib/usd/translators/mayaReferenceEditRouter.md)
 + [Layer Locking](doc/LayerLocking.md)


### PR DESCRIPTION
Old link was still pointing to a very old branch in the maya-usd repo instead to the maya-hydra repo.