### PR TITLE
EMSUSD-3019 better fix to scene load fix.

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.h
+++ b/lib/mayaUsd/nodes/layerManager.h
@@ -151,7 +151,6 @@ public:
     static MObject serialized;
     static MObject anonymous;
     static MObject selectedStage;
-    static MObject layerManagerReady;
 
 protected:
     LayerManager();

--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -171,7 +171,7 @@ MObject MayaUsdProxyShapeBase::outStageDataAttr;
 MObject MayaUsdProxyShapeBase::outStageCacheIdAttr;
 MObject MayaUsdProxyShapeBase::variantFallbacksAttr;
 MObject MayaUsdProxyShapeBase::layerManagerAttr;
-MObject MayaUsdProxyShapeBase::layerManagerReadyAttr;
+MObject MayaUsdProxyShapeBase::recomputeLayersAttr;
 
 namespace {
 // utility function to extract the tag name from an anonymous layer.
@@ -495,14 +495,14 @@ MStatus MayaUsdProxyShapeBase::initialize()
     retValue = addAttribute(layerManagerAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
-    layerManagerReadyAttr = numericAttrFn.create(
-        "layerManagerReady", "lmr", MFnNumericData::kBoolean, false, &retValue);
+    recomputeLayersAttr
+        = numericAttrFn.create("recomputeLayers", "rcpl", MFnNumericData::kInt64, 0, &retValue);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
     numericAttrFn.setCached(true);
     numericAttrFn.setReadable(true);
     numericAttrFn.setStorable(true);
     numericAttrFn.setHidden(true);
-    retValue = addAttribute(layerManagerReadyAttr);
+    retValue = addAttribute(recomputeLayersAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
     //
@@ -568,9 +568,9 @@ MStatus MayaUsdProxyShapeBase::initialize()
     retValue = attributeAffects(layerManagerAttr, outStageDataAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
-    retValue = attributeAffects(layerManagerReadyAttr, outStageDataAttr);
+    retValue = attributeAffects(recomputeLayersAttr, outStageDataAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
-    retValue = attributeAffects(layerManagerReadyAttr, inStageDataCachedAttr);
+    retValue = attributeAffects(recomputeLayersAttr, inStageDataCachedAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
     return retValue;

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -146,8 +146,9 @@ public:
 
     MAYAUSD_CORE_PUBLIC
     static MObject layerManagerAttr;
+
     MAYAUSD_CORE_PUBLIC
-    static MObject layerManagerReadyAttr;
+    static MObject recomputeLayersAttr;
 
     /// Delegate function for computing the closest point and surface normal
     /// on the proxy shape to a given ray.

--- a/lib/mayaUsd/ufe/MayaStagesSubject.cpp
+++ b/lib/mayaUsd/ufe/MayaStagesSubject.cpp
@@ -176,10 +176,6 @@ void MayaStagesSubject::setupListeners()
     // Handle re-entrant onStageSet
     bool expectedState = false;
     if (stageSetGuardCount.compare_exchange_strong(expectedState, true)) {
-        // We should have no listeners and stage map is dirty.
-        TF_VERIFY(UsdStageMap::getInstance().isDirty());
-        TF_VERIFY(_stageListeners.empty());
-
         auto me = PXR_NS::TfCreateWeakPtr(this);
         for (auto stage : ProxyShapeHandler::getAllStages()) {
             NoticeKeys noticeKeys;


### PR DESCRIPTION
Better fix for the problem of restoring layers saved in the layer manager. This fix is better for existing scenes. Instead of relying on a connection to trigger a compute, just re-compute all proxy shapes when the scene load ends.

- Added a "recomputeLayers" attribute to trigger a proxy shape compute.
- Removed the layer manager ready attributes.
- Removed the connection between the layer manager and the proxy shape.
- Now trigger a recompute on all proxy shape at the end of the load.
- This makes the fix also support existing Maya scenes.
- Update saving/loading docs