### PR TITLE
EMSUSD-3040 fix auto-save

### DIFF
--- a/lib/usdUfe/utils/layers.cpp
+++ b/lib/usdUfe/utils/layers.cpp
@@ -32,10 +32,14 @@ void getAllSublayers(
     std::set<SdfLayerRefPtr>* layerRefs)
 {
     std::deque<SdfLayerRefPtr> processing;
+    std::set<SdfLayerRefPtr>   processed;
     processing.push_back(layer);
     while (!processing.empty()) {
         auto layerToProcess = processing.front();
         processing.pop_front();
+        if (processed.find(layerToProcess) != processed.end())
+            continue;
+        processed.insert(layerToProcess);
         SdfSubLayerProxy sublayerPaths = layerToProcess->GetSubLayerPaths();
         for (auto path : sublayerPaths) {
             SdfLayerRefPtr sublayer = SdfLayer::FindRelativeToLayer(layerToProcess, path);


### PR DESCRIPTION
- Allow once again to save leyers in the Maya scene during export.
- Necessary to make Maya auto-save work.
- Added protection against an infinite loop. Should not happen, but it did and locked-up Maya.