### PR TITLE
EMSUSDC-319 EMSUSDC-317 - env search paths management fixes

### DIFF
--- a/lib/usd/ui/assetResolver/PreferencesManagement.cpp
+++ b/lib/usd/ui/assetResolver/PreferencesManagement.cpp
@@ -158,8 +158,9 @@ void ApplyUsdPreferences(
                      && envIt < userIt /* 'env' appears before 'user' */)
                     || (!newOptions.IsUsingUserSearchPathsFirst()
                         && envIt > userIt /* 'env' appears after 'user' */)) {
-                // Reorder user paths and environment paths context data
-                std::swap(*envIt, *userIt);
+                    // Reorder user paths and environment paths context data
+                    std::swap(*envIt, *userIt);
+                }
             }
         }
 


### PR DESCRIPTION
* fixing env search path evaluation order is not respected with respect to user search paths
* fixing env search path enable/disable state not properly taken into account