### PR TITLE
EMSUSD-321 Make sure we dont always popup the save dialog for components

### DIFF
--- a/lib/usd/ui/layerEditor/saveLayersDialog.cpp
+++ b/lib/usd/ui/layerEditor/saveLayersDialog.cpp
@@ -461,7 +461,8 @@ SaveLayersDialog::SaveLayersDialog(
         std::string proxyPath = info.dagPath.fullPathName().asChar();
 
         // Check if this stage is a component stage
-        if (MayaUsd::ComponentUtils::shouldDisplayComponentInitialSaveDialog(info.stage, proxyPath)) {
+        if (MayaUsd::ComponentUtils::shouldDisplayComponentInitialSaveDialog(
+                info.stage, proxyPath)) {
             _componentStageInfos.push_back(info);
             // Component stages are saved via the component system, skip layer collection
             continue;


### PR DESCRIPTION
Was populating the windows for previously saved component, which was wrong. This worked form the layer editor window. For previously saved components we just want to do the regular thing, as we do for any ''normal'' stage, i.e. show the dirty layers.

Max validated this on his side with me giving him a fixed mayaUsdUI.dll  