### PR TITLE
EMSUSD-1397 fixMaya scene with Maya refs

### DIFF
--- a/lib/lookdevXUsd/ProxyShapeLookdevHandler.cpp
+++ b/lib/lookdevXUsd/ProxyShapeLookdevHandler.cpp
@@ -14,6 +14,8 @@
 
 #include <ufe/hierarchy.h>
 
+#include <usdUfe/ufe/Utils.h>
+
 namespace LookdevXUsd
 {
 
@@ -36,7 +38,7 @@ Ufe::SceneItemResultUndoableCommand::Ptr ProxyShapeLookdevHandler::createLookdev
     const Ufe::SceneItem::Ptr& parent, const Ufe::PathComponent& name) const
 {
     // Check if parent is a proxy shape.
-    if (!parent || !MayaUsdAPI::isAGatewayType(parent->nodeType()))
+    if (!parent || !MayaUsdAPI::isAGatewayType(UsdUfe::getSceneItemNodeType(parent)))
     {
         return m_previousHandler ? m_previousHandler->createLookdevContainerCmdImpl(parent, name) : nullptr;
     }
@@ -76,12 +78,12 @@ Ufe::SceneItemResultUndoableCommand::Ptr ProxyShapeLookdevHandler::createLookdev
 bool ProxyShapeLookdevHandler::isLookdevContainerImpl(const Ufe::SceneItem::Ptr& item) const
 {
     // If item is not a proxy shape, pass to the previous handler.
-    if (!item || !MayaUsdAPI::isAGatewayType(item->nodeType()))
+    if (!item || !MayaUsdAPI::isAGatewayType(UsdUfe::getSceneItemNodeType(item)))
     {
         return m_previousHandler ? m_previousHandler->isLookdevContainerImpl(item) : false;
     }
 
-    return item->nodeType() == "Material";
+    return UsdUfe::getSceneItemNodeType(item) == "Material";
 }
 
 MayaUsdCreateLookdevEnvironmentCommand::MayaUsdCreateLookdevEnvironmentCommand(Ufe::Path ancestor)
@@ -121,17 +123,17 @@ bool MayaUsdCreateLookdevEnvironmentCommand::executeCommand()
 
     // Check if m_ancestor is a proxy shape or the transform of a proxy shape.
     Ufe::SceneItem::Ptr proxyShape = nullptr;
-    if (MayaUsdAPI::isAGatewayType(ancestor->nodeType()))
+    if (MayaUsdAPI::isAGatewayType(UsdUfe::getSceneItemNodeType(ancestor)))
     {
         proxyShape = ancestor;
     }
     else
     {
         Ufe::Hierarchy::Ptr hierarchy = Ufe::Hierarchy::hierarchy(ancestor);
-        if (hierarchy && hierarchy->children().size() == 1)
+        if (hierarchy && UsdUfe::getHierarchyChildren(hierarchy).size() == 1)
         {
-            auto child = hierarchy->children().back();
-            if (child && MayaUsdAPI::isAGatewayType(child->nodeType()))
+            auto child = UsdUfe::getHierarchyChildren(hierarchy).back();
+            if (child && MayaUsdAPI::isAGatewayType(UsdUfe::getSceneItemNodeType(child)))
             {
                 proxyShape = child;
             }

--- a/lib/lookdevXUsd/UsdLookdevHandler.cpp
+++ b/lib/lookdevXUsd/UsdLookdevHandler.cpp
@@ -14,6 +14,8 @@
 
 #include <mayaUsdAPI/utils.h>
 
+#include <usdUfe/ufe/Utils.h>
+
 namespace
 {
 
@@ -131,7 +133,7 @@ Ufe::SceneItemResultUndoableCommand::Ptr UsdLookdevHandler::createLookdevEnviron
 
 bool UsdLookdevHandler::isLookdevContainerImpl(const Ufe::SceneItem::Ptr& item) const
 {
-    return item->nodeType() == "Material";
+    return UsdUfe::getSceneItemNodeType(item) == "Material";
 }
 
 } // namespace LookdevXUsd

--- a/lib/lookdevXUsd/UsdMaterialHandler.cpp
+++ b/lib/lookdevXUsd/UsdMaterialHandler.cpp
@@ -16,6 +16,8 @@
 
 #include <mayaUsdAPI/utils.h>
 
+#include <usdUfe/ufe/Utils.h>
+
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/base/tf/staticTokens.h>
 #include <pxr/usd/usdGeom/imageable.h>
@@ -59,9 +61,17 @@ LookdevXUfe::Material::Ptr UsdMaterialHandler::material(const Ufe::SceneItem::Pt
 Ufe::SceneItemResultUndoableCommand::Ptr UsdMaterialHandler::createBackdropCmdImpl(const Ufe::SceneItem::Ptr& parent,
                                                                                    const Ufe::PathComponent& name) const
 {
-    if (!MayaUsdAPI::isUsdSceneItem(parent) || (parent->nodeType() != "NodeGraph" && parent->nodeType() != "Material"))
+    if (!MayaUsdAPI::isUsdSceneItem(parent))
     {
         return nullptr;
+    }
+
+    {
+        const std::string nodeType = UsdUfe::getSceneItemNodeType(parent);
+        if (nodeType != "NodeGraph" && nodeType != "Material")
+        {
+            return nullptr;
+        }
     }
 
     return MayaUsdAPI::createAddNewPrimCommand(parent, name.string(), "Backdrop");
@@ -91,22 +101,22 @@ LookdevXUfe::ValidationLog::Ptr UsdMaterialHandler::validateMaterial(const Ufe::
 
 bool UsdMaterialHandler::isBackdropImpl(const Ufe::SceneItem::Ptr& item) const
 {
-    return item->nodeType() == "Backdrop";
+    return UsdUfe::getSceneItemNodeType(item) == "Backdrop";
 }
 
 bool UsdMaterialHandler::isNodeGraphImpl(const Ufe::SceneItem::Ptr& item) const
 {
-    return item->nodeType() == "NodeGraph";
+    return UsdUfe::getSceneItemNodeType(item) == "NodeGraph";
 }
 
 bool UsdMaterialHandler::isMaterialImpl(const Ufe::SceneItem::Ptr& item) const
 {
-    return item->nodeType() == "Material";
+    return UsdUfe::getSceneItemNodeType(item) == "Material";
 }
 
 bool UsdMaterialHandler::isShaderImpl(const Ufe::SceneItem::Ptr& item) const
 {
-    return item->nodeType() == "Shader";
+    return UsdUfe::getSceneItemNodeType(item) == "Shader";
 }
 
 bool UsdMaterialHandler::allowedInNodeGraph(const std::string& /*nodeDefType*/) const

--- a/lib/lookdevXUsd/UsdMxVersionUpgrade.cpp
+++ b/lib/lookdevXUsd/UsdMxVersionUpgrade.cpp
@@ -335,7 +335,7 @@ Ufe::Path _getMaterialPath(const Ufe::Path& materialPath)
 
     auto sceneItem = Ufe::Hierarchy::createItem(materialPath);
 
-    while (sceneItem && sceneItem->nodeType() != _tokens->Material) {
+    while (sceneItem && UsdUfe::getSceneItemNodeType(sceneItem) != _tokens->Material) {
         auto hierarchy = Ufe::Hierarchy::hierarchy(sceneItem);
         sceneItem = hierarchy->parent();
     }

--- a/lib/lookdevXUsd/UsdSoloingHandler.cpp
+++ b/lib/lookdevXUsd/UsdSoloingHandler.cpp
@@ -33,6 +33,8 @@
 #include <mayaUsdAPI/undo.h>
 #include <mayaUsdAPI/utils.h>
 
+#include <usdUfe/ufe/Utils.h>
+
 #include <memory>
 
 using namespace LookdevXUfe;
@@ -96,7 +98,7 @@ void processSoloingPrimChildren(const Ufe::SceneItem::Ptr& parent,
         return;
     }
 
-    for (const auto& child : Ufe::Hierarchy::hierarchy(parent)->children())
+    for (const auto& child : UsdUfe::getHierarchyChildren(Ufe::Hierarchy::hierarchy(parent)))
     {
         if (getMetadata(child, kSoloingItem) == "true")
         {

--- a/lib/mayaUsd/ufe/Global.cpp
+++ b/lib/mayaUsd/ufe/Global.cpp
@@ -93,6 +93,7 @@
 #include <usdUfe/ufe/UsdClipboardHandler.h>
 #endif
 
+#include <maya/MFileIO.h>
 #include <maya/MGlobal.h>
 #include <maya/MSceneMessage.h>
 #include <ufe/hierarchyHandler.h>
@@ -134,6 +135,12 @@ void mayaStartWaitCursor()
 }
 
 void mayaStopWaitCursor() { MGlobal::executeCommand("waitCursor -state 0"); }
+
+bool mayaIsSceneLoading()
+{
+    return MFileIO::isReadingFile() || MFileIO::isOpeningFile() || MFileIO::isNewingFile()
+        || MFileIO::isImportingFile() || MFileIO::isReferencingFile();
+}
 
 // Note: MayaUsd::ufe::getStage takes two parameters, so wrap it in a function taking only one.
 PXR_NS::UsdStageWeakPtr mayaGetStage(const Ufe::Path& path) { return MayaUsd::ufe::getStage(path); }
@@ -218,6 +225,7 @@ MStatus initialize()
     dccFunctions.defaultMaterialScopeNameFn = defaultMaterialsScopeName;
     dccFunctions.extractTRSFn = MayaUsd::ufe::extractTRS;
     dccFunctions.transform3dMatrixOpNameFn = getTransform3dMatrixOpName;
+    dccFunctions.isLoadingSceneFn = mayaIsSceneLoading;
 
     // Replace the Maya hierarchy handler with ours.
     auto& runTimeMgr = Ufe::RunTimeMgr::instance();

--- a/lib/mayaUsd/ufe/ProxyShapeCameraHandler.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeCameraHandler.cpp
@@ -62,7 +62,7 @@ Ufe::Camera::Ptr ProxyShapeCameraHandler::camera(const Ufe::SceneItem::Ptr& item
 Ufe::Selection ProxyShapeCameraHandler::find_(const Ufe::Path& path) const
 {
     Ufe::SceneItem::Ptr item = Ufe::Hierarchy::createItem(path);
-    if (item && isAGatewayType(item->nodeType())) {
+    if (item && isAGatewayType(UsdUfe::getSceneItemNodeType(item))) {
         // path is a path to a proxyShape node.
         // Get the UsdStage for this proxy shape node and search it for cameras
         PXR_NS::UsdStageWeakPtr stage = getStage(path);

--- a/lib/mayaUsd/ufe/ProxyShapeContextOpsHandler.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeContextOpsHandler.cpp
@@ -47,7 +47,7 @@ ProxyShapeContextOpsHandler::create(const Ufe::ContextOpsHandler::Ptr& mayaConte
 
 Ufe::ContextOps::Ptr ProxyShapeContextOpsHandler::contextOps(const Ufe::SceneItem::Ptr& item) const
 {
-    if (isAGatewayType(item->nodeType())) {
+    if (isAGatewayType(UsdUfe::getSceneItemNodeType(item))) {
         // UsdContextOps expects a UsdSceneItem which wraps a prim, so
         // create one using the pseudo-root and our own path.
         PXR_NS::UsdStageWeakPtr stage = getStage(item->path());

--- a/lib/mayaUsd/ufe/ProxyShapeHierarchyHandler.cpp
+++ b/lib/mayaUsd/ufe/ProxyShapeHierarchyHandler.cpp
@@ -46,7 +46,7 @@ ProxyShapeHierarchyHandler::create(const Ufe::HierarchyHandler::Ptr& mayaHierarc
 
 Ufe::Hierarchy::Ptr ProxyShapeHierarchyHandler::hierarchy(const Ufe::SceneItem::Ptr& item) const
 {
-    if (isAGatewayType(item->nodeType())) {
+    if (isAGatewayType(UsdUfe::getSceneItemNodeType(item))) {
         return ProxyShapeHierarchy::create(_mayaHierarchyHandler, item);
     } else {
         return _mayaHierarchyHandler->hierarchy(item);

--- a/lib/mayaUsd/ufe/PulledObjectHierarchy.cpp
+++ b/lib/mayaUsd/ufe/PulledObjectHierarchy.cpp
@@ -15,6 +15,8 @@
 //
 #include "PulledObjectHierarchy.h"
 
+#include <usdUfe/ufe/Utils.h>
+
 #include <pxr/base/tf/diagnostic.h>
 
 // Needed because of TF_CODING_ERROR
@@ -63,7 +65,10 @@ bool PulledObjectHierarchy::hasFilteredChildren(const ChildFilter& childFilter) 
 
 bool PulledObjectHierarchy::hasChildren() const { return _mayaHierarchy->hasChildren(); }
 
-Ufe::SceneItemList PulledObjectHierarchy::children() const { return _mayaHierarchy->children(); }
+Ufe::SceneItemList PulledObjectHierarchy::children() const
+{
+    return UsdUfe::getHierarchyChildren(_mayaHierarchy);
+}
 
 Ufe::SceneItemList PulledObjectHierarchy::filteredChildren(const ChildFilter& childFilter) const
 {

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
@@ -130,13 +130,13 @@ Ufe::SceneItem::Ptr getMaterialsScope(const Ufe::Path& parentPath)
     std::string scopeName = scopeNamePrefix;
     auto        hasName
         = [&scopeName](const Ufe::SceneItem::Ptr& item) { return item->nodeName() == scopeName; };
-    Ufe::SceneItemList children = parentHierarchy->children();
+    Ufe::SceneItemList children = UsdUfe::getHierarchyChildren(parentHierarchy);
     for (size_t i = 1;; ++i) {
         auto childrenIterator = std::find_if(children.begin(), children.end(), hasName);
         if (childrenIterator == children.end()) {
             return nullptr;
         }
-        if ((*childrenIterator)->nodeType() == "Scope") {
+        if (UsdUfe::getSceneItemNodeType(*childrenIterator) == "Scope") {
             return *childrenIterator;
         }
 
@@ -173,8 +173,8 @@ bool _BindMaterialCompatiblePrim(const UsdPrim& usdPrim)
 #ifdef UFE_V4_FEATURES_AVAILABLE
 bool isDefPrim(const Ufe::SceneItem::Ptr& sceneItem)
 {
-    const auto canonicalName
-        = TfType::Find<UsdSchemaBase>().FindDerivedByName(sceneItem->nodeType().c_str());
+    const auto canonicalName = TfType::Find<UsdSchemaBase>().FindDerivedByName(
+        UsdUfe::getSceneItemNodeType(sceneItem).c_str());
     if (canonicalName.IsUnknown()) {
         return true;
     }

--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -353,7 +353,7 @@ void ReplicateExtrasFromUSD::initRecursive(Ufe::SceneItem::Ptr ufeItem) const
     auto hier = Ufe::Hierarchy::hierarchy(ufeItem);
     if (hier) {
         // Go through the entire hierarchy
-        for (auto child : hier->children()) {
+        for (auto child : UsdUfe::getHierarchyChildren(hier)) {
             initRecursive(child);
         }
     }
@@ -415,7 +415,7 @@ void ReplicateExtrasToUSD::initRecursive(const Ufe::SceneItem::Ptr& item) const
     auto hier = Ufe::Hierarchy::hierarchy(item);
     if (hier) {
         // Go through the entire hierarchy.
-        for (auto child : hier->children()) {
+        for (auto child : UsdUfe::getHierarchyChildren(hier)) {
             initRecursive(child);
         }
     }

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
@@ -324,7 +324,7 @@ static MayaUsdProxyShapeBase* getChildProxyShape(const Ufe::SceneItem::Ptr& item
         return nullptr;
 
     const bool rebuildCacheIfNeeded = false;
-    for (const auto& subItem : hierarchy->children()) {
+    for (const auto& subItem : UsdUfe::getHierarchyChildren(hierarchy)) {
         auto proxyShapePtr = MayaUsd::ufe::getProxyShape(subItem->path(), rebuildCacheIfNeeded);
         if (!proxyShapePtr)
             continue;

--- a/lib/usdUfe/ufe/Global.cpp
+++ b/lib/usdUfe/ufe/Global.cpp
@@ -85,6 +85,8 @@ Ufe::Rtid initialize(
     UsdUfe::setWaitCursorFns(dccFunctions.startWaitCursorFn, dccFunctions.stopWaitCursorFn);
 
     // Optional DCC specific functions.
+    if (dccFunctions.isLoadingSceneFn)
+        UsdUfe::setIsLoadingSceneFn(dccFunctions.isLoadingSceneFn);
     if (dccFunctions.isAttributeLockedFn)
         UsdUfe::setIsAttributeLockedFn(dccFunctions.isAttributeLockedFn);
     if (dccFunctions.saveStageLoadRulesFn)

--- a/lib/usdUfe/ufe/Global.h
+++ b/lib/usdUfe/ufe/Global.h
@@ -55,6 +55,7 @@ struct USDUFE_PUBLIC DCCFunctions
     TimeAccessorFn      timeAccessorFn = nullptr;
 
     // Optional: default values will be used if no function is supplied.
+    IsLoadingSceneFn           isLoadingSceneFn = nullptr;
     IsAttributeLockedFn        isAttributeLockedFn = nullptr;
     SaveStageLoadRulesFn       saveStageLoadRulesFn = nullptr;
     IsRootChildFn              isRootChildFn = nullptr;

--- a/lib/usdUfe/ufe/UsdClipboardCommands.cpp
+++ b/lib/usdUfe/ufe/UsdClipboardCommands.cpp
@@ -203,7 +203,7 @@ pasteItemsToNewMaterial(const UsdUfe::UsdSceneItem::Ptr& dstItem, Ufe::Selection
         auto       usdItem = UsdUfe::downcast(materialItem);
         const auto matHierarchy = Ufe::Hierarchy::hierarchy(materialItem);
         if (matHierarchy) {
-            for (auto& child : matHierarchy->children()) {
+            for (auto& child : UsdUfe::getHierarchyChildren(matHierarchy)) {
                 // If necessary, rename the child using the name in the metadata.
                 pastedItems.push_back(renameItemUsingMetadata(child));
             }

--- a/lib/usdUfe/ufe/UsdContextOps.cpp
+++ b/lib/usdUfe/ufe/UsdContextOps.cpp
@@ -277,12 +277,12 @@ void UsdContextOps::setItem(const UsdSceneItem::Ptr& item)
         if (auto globalSn = Ufe::GlobalSelection::get()) {
             if (globalSn->contains(item->path())) {
                 // Only keep the selected items that match the runtime of the context item.
-                _bulkType = _item->nodeType();
+                _bulkType = UsdUfe::getSceneItemNodeType(_item);
                 const auto usdId = _item->runTimeId();
                 for (auto&& selItem : *globalSn) {
                     if (selItem->runTimeId() == usdId) {
                         _bulkItems.append(selItem);
-                        if (selItem->nodeType() != _bulkType)
+                        if (UsdUfe::getSceneItemNodeType(selItem) != _bulkType)
                             _bulkType.clear();
                     }
                 }

--- a/lib/usdUfe/ufe/UsdUIInfoHandler.cpp
+++ b/lib/usdUfe/ufe/UsdUIInfoHandler.cpp
@@ -222,7 +222,7 @@ Ufe::UIInfoHandler::Icon UsdUIInfoHandler::treeViewIcon(const Ufe::SceneItem::Pt
 
     // If the node type ends with _ followed by a number, we strip the number.
     // This is to handle the case where we have a node type like "Capsule_1".
-    auto nodeType = item->nodeType();
+    std::string nodeType = UsdUfe::getSceneItemNodeType(item);
     if (nodeType.size() > 2 && nodeType[nodeType.size() - 2] == '_'
         && std::isdigit(nodeType[nodeType.size() - 1])) {
         nodeType = nodeType.substr(0, nodeType.size() - 2);

--- a/lib/usdUfe/ufe/Utils.cpp
+++ b/lib/usdUfe/ufe/Utils.cpp
@@ -117,6 +117,7 @@ UsdUfe::StageAccessorFn            gStageAccessorFn = nullptr;
 UsdUfe::StagePathAccessorFn        gStagePathAccessorFn = nullptr;
 UsdUfe::UfePathToPrimFn            gUfePathToPrimFn = nullptr;
 UsdUfe::TimeAccessorFn             gTimeAccessorFn = nullptr;
+UsdUfe::IsLoadingSceneFn           gIsLoadingSceneFn = nullptr;
 UsdUfe::IsAttributeLockedFn        gIsAttributeLockedFn = nullptr;
 UsdUfe::SaveStageLoadRulesFn       gSaveStageLoadRulesFn = nullptr;
 UsdUfe::IsRootChildFn              gIsRootChildFn = nullptr;
@@ -251,6 +252,21 @@ PXR_NS::UsdTimeCode getTime(const Ufe::Path& path)
     assert(gTimeAccessorFn != nullptr);
 #endif
     return gTimeAccessorFn(path);
+}
+
+void setIsLoadingSceneFn(IsLoadingSceneFn fn)
+{
+    // This function is allowed to be null in which case return default (false).
+    gIsLoadingSceneFn = fn;
+}
+
+bool isSceneLoading()
+{
+    // If we have (optional) scene loading function, use it.
+    // Otherwise return false.
+    if (gIsLoadingSceneFn)
+        return gIsLoadingSceneFn();
+    return false;
 }
 
 void setIsAttributeLockedFn(IsAttributeLockedFn fn)
@@ -468,6 +484,41 @@ std::string relativelyUniqueName(const UsdPrim& usdParent, const std::string& ba
     return childName;
 }
 
+std::string getSceneItemNodeType(const Ufe::SceneItem::Ptr& item)
+{
+    if (!item) {
+        return {};
+    }
+
+    if (isSceneLoading()) {
+        // During Maya scene load, querying the node type of a USD scene item
+        // may cause Maya to crash (EMSUSD-1397). These crashes are due to missing
+        // null pointer checks in UFE code, where they access Maya node that are
+        // invalid. So we return an empty string in that case.
+        return {};
+    }
+
+    return item->nodeType();
+}
+
+Ufe::SceneItemList getHierarchyChildren(const Ufe::Hierarchy::Ptr& hierarchy)
+{
+    if (!hierarchy) {
+        return {};
+    }
+
+    if (isSceneLoading()) {
+        // During Maya scene load, querying the children of a USD hierarchy may
+        // cause Maya to crash (EMSUSD-1397). These crashes are due to missing
+        // null pointer checks in UFE code, where they access Maya node that are
+        // invalid. So we return an empty list in that
+        // case.
+        return {};
+    }
+
+    return hierarchy->children();
+}
+
 bool isMaterialsScope(const Ufe::SceneItem::Ptr& item)
 {
     if (!item) {
@@ -475,7 +526,7 @@ bool isMaterialsScope(const Ufe::SceneItem::Ptr& item)
     }
 
     // Must be a scope.
-    if (item->nodeType() != "Scope") {
+    if (UsdUfe::getSceneItemNodeType(item) != "Scope") {
         return false;
     }
 
@@ -487,8 +538,8 @@ bool isMaterialsScope(const Ufe::SceneItem::Ptr& item)
     // Or with only materials inside
     auto scopeHierarchy = Ufe::Hierarchy::hierarchy(item);
     if (scopeHierarchy) {
-        for (auto&& child : scopeHierarchy->children()) {
-            if (child->nodeType() != "Material") {
+        for (auto&& child : UsdUfe::getHierarchyChildren(scopeHierarchy)) {
+            if (UsdUfe::getSceneItemNodeType(child) != "Material") {
                 // At least one non material
                 return false;
             }

--- a/lib/usdUfe/ufe/Utils.h
+++ b/lib/usdUfe/ufe/Utils.h
@@ -71,6 +71,7 @@ typedef std::string (*DefaultMaterialScopeNameFn)();
 typedef void (
     *ExtractTRSFn)(const Ufe::Matrix4d& m, Ufe::Vector3d* t, Ufe::Vector3d* r, Ufe::Vector3d* s);
 typedef const char* (*Transform3dMatrixOpNameFn)();
+typedef bool (*IsLoadingSceneFn)();
 
 //------------------------------------------------------------------------------
 // Helper functions
@@ -133,6 +134,17 @@ void setTimeAccessorFn(TimeAccessorFn fn);
 //! Get the time along the argument path.
 USDUFE_PUBLIC
 PXR_NS::UsdTimeCode getTime(const Ufe::Path& path);
+
+//! Set the DCC specific is-scene-loading test function.
+//! Use of this function is optional, if one is not supplied then
+//! a default test function will be used.
+USDUFE_PUBLIC
+void setIsLoadingSceneFn(IsLoadingSceneFn fn);
+
+//! Return whether the DCC is loading a scene.
+//! \return True if the DCC is currently loading a scene, otherwise false
+USDUFE_PUBLIC
+bool isSceneLoading();
 
 //! Set the DCC specific USD attribute is locked test function.
 //! Use of this function is optional, if one is not supplied then
@@ -222,6 +234,14 @@ PXR_NS::SdfPath uniqueChildPath(const PXR_NS::UsdStage& stage, const PXR_NS::Sdf
 
 USDUFE_PUBLIC
 Ufe::Path appendToUsdPath(const Ufe::Path& path, const std::string& name);
+
+//! Returns the node type of the \p item safely, avoiding problem during scene loads.
+USDUFE_PUBLIC
+std::string getSceneItemNodeType(const Ufe::SceneItem::Ptr& item);
+
+//! Returns the children of the \p hierarchy safely, avoiding problem during scene loads.
+USDUFE_PUBLIC
+Ufe::SceneItemList getHierarchyChildren(const Ufe::Hierarchy::Ptr& hierarchy);
 
 //! Returns true if \p item is a materials scope.
 USDUFE_PUBLIC

--- a/plugin/adsk/plugin/adskMaterialCommands.cpp
+++ b/plugin/adsk/plugin/adskMaterialCommands.cpp
@@ -231,8 +231,8 @@ static bool isNodeTypeInList(
     const std::vector<std::string>& nodeTypeList,
     bool                            checkAllAncestors)
 {
-    const auto canonicalName
-        = TfType::Find<UsdSchemaBase>().FindDerivedByName(sceneItem->nodeType().c_str());
+    const auto canonicalName = TfType::Find<UsdSchemaBase>().FindDerivedByName(
+        UsdUfe::getSceneItemNodeType(sceneItem).c_str());
 
     if (canonicalName.IsUnknown()) {
         return false;


### PR DESCRIPTION
When a maya scene contains Maya references to another Maya scene that contains a USD stage, Maya would crash on loading the scene.

This was due to a dialog opening in the idle of the scene load, which caused on-idle events to be processed. That ended-up accessing UFE items corresponding to maya nodes that were either not yet fully loaded or were deleted when the previous scene was torn down.

This is a bug in all versions of Maya.

Protect against the bug, we avoid accessing items during scene load.