### PR TITLE
EMSUSD-2726 fix getAllStages vs renaming node

### DIFF
--- a/lib/mayaUsd/ufe/UsdStageMap.cpp
+++ b/lib/mayaUsd/ufe/UsdStageMap.cpp
@@ -389,8 +389,13 @@ void UsdStageMap::processNodeAdded(MObject& node)
 
     MayaUsd::MayaNodeTypeObserver& shapeObserver = MayaUsdProxyShapeBase::getProxyShapesObserver();
     MayaNodeObserver*              observer = shapeObserver.addObservedNode(node);
-    if (observer)
+    if (observer) {
         observer->addListener(*this);
+        // Note: due to the timing of Maya notifications, the node gets added the the observer
+        //       right at creation, before it gets named and parented. This menas the obervations
+        //       were not setup for its parents, so we update the observer at this point.
+        observer->updateObserving();
+    }
 
     addProxyShapeNode(*proxyShape, node);
 }

--- a/lib/mayaUsd/utils/mayaNodeObserver.h
+++ b/lib/mayaUsd/utils/mayaNodeObserver.h
@@ -68,6 +68,10 @@ public:
     MAYAUSD_CORE_PUBLIC
     void stopObserving();
 
+    //! Update callbacks for the observed node.
+    MAYAUSD_CORE_PUBLIC
+    void updateObserving();
+
     //! Add a listener to be called when the node changes.
     //
     //  The caller is responsible to ensure the listener is valid
@@ -88,8 +92,8 @@ public:
     static void removeCallbackId(MCallbackId& callbackId);
 
 private:
-    void updateRenameCallback();
-    void removeRenameCallback();
+    void updateRenameCallbacks();
+    void removeRenameCallbacks();
 
     void updateAncestorCallbacks();
     void removeAncestorCallbacks();
@@ -105,7 +109,7 @@ private:
 
     MObject _observedNode;
 
-    MCallbackId              _renameCallbackId = 0;
+    std::vector<MCallbackId> _renameCallbackIds;
     std::vector<MCallbackId> _parentAddedCallbackIds;
     std::vector<MCallbackId> _ancestorCallbackIds;
 

--- a/test/lib/ufe/testPythonWrappers.py
+++ b/test/lib/ufe/testPythonWrappers.py
@@ -189,6 +189,21 @@ class PythonWrappersTestCase(unittest.TestCase):
 
         self.assertEqual(len(mayaUsd.ufe.getAllStages()), 1)
 
+    def testGetAllStagesAfterRename(self):
+        '''
+        Verify that after renaming an ancestor node, we can still find
+        the stage via getAllStages().
+        '''
+        cmds.file(new=True, force=True)
+
+        mayaUsdStage = cmds.createNode("mayaUsdProxyShape", name="myStage")
+        self.assertEqual(len(mayaUsd.ufe.getAllStages()), 1)
+
+        usdProxyNode = cmds.listRelatives(mayaUsdStage, parent=True, fullPath=True)
+        cmds.rename(usdProxyNode, 'foo')
+
+        self.assertEqual(len(mayaUsd.ufe.getAllStages()), 1)
+
     @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 4, 'Test for UFE v4 or later')
     def testCreateStageWithNewLayerBinding(self):
         cmds.file(new=True, force=True)


### PR DESCRIPTION
- Make sure to update the node observer callback when the node is added to the stage map.
- Improve the node observer to make sure we update what is observed when the node gets a name or a parent.
- In particular, the observer failed to track ancestor being renamed.
- Added a unit test for the reported bug.