### PR TITLE
ProxyAccessor: avoid some potential GIL deadlocks during compute

### DIFF
--- a/lib/mayaUsd/nodes/proxyAccessor.h
+++ b/lib/mayaUsd/nodes/proxyAccessor.h
@@ -238,6 +238,7 @@ private:
         Item&                outputItemToCompute,
         const UsdStageRefPtr stage,
         MDataBlock&          dataBlock,
+        const UsdEditTarget& targetLayer,
         const ConverterArgs& args);
     //! \brief  Using acceleration structure, do computation of a given accessor output plug.
     MStatus computeOutput(


### PR DESCRIPTION
This PR updates `ProxyAccessor::compute` so it no longer changes the stage edit target while compute is running.

### Included Changes

- Removed `UsdEditContext` usage from the compute path.
- Replaced `UsdAttribute::Set` calls with direct writes to the targeted layer through the `Sdf` API.

### Why

`ProxyAccessor::compute` can run on an `Evaluation Manager` worker thread when the graph is evaluated in parallel mode.

This can happen while evaluating a Python command (for example, `maya.cmds.mayaUSDExport`), in which case the calling main thread may hold the Python `Global Interpreter Lock`.

Changing the stage edit target emits `UsdNotice::StageEditTargetChanged`. If that notice is delivered to Python listeners, the worker thread must acquire the `GIL`. In parallel, the main thread is waiting for evaluation to finish while still holding the `GIL`, which will deadlock Maya.

Related issue: #4486

### Scope

This fix addresses the production cases we hit. In our case, `mayaUsdProxyShape` has no Maya inputs; it only outputs world `transforms` and `visibility` to pulled Maya nodes.

A similar issue can still surface when both are true:

- Maya inputs are connected to `ProxyAccessor`, so `ProxyAccessor::compute` still modifies the USD stage.
- Python listeners are registered in Maya for notices other than `StageEditTargetChanged` (`ObjectsChanged`, `StageContentsChanged`, `LayersDidChange`).
