### PR TITLE
LOOKDEVX-5412 - Deprecate ExtendedConnectionHandler.

### DIFF
--- a/cmake/modules/FindLookdevXUfe.cmake
+++ b/cmake/modules/FindLookdevXUfe.cmake
@@ -91,3 +91,10 @@ if(LookdevXUfe_VERSION VERSION_GREATER_EQUAL "2.0.0" OR
     set(LOOKDEVXUFE_HAS_LEGACY_MTLX_DETECTION TRUE CACHE INTERNAL "LegacyMxLookdevXUfe")
     message(STATUS "Maya has LookdevXUfe Legacy MaterialX handling")
 endif()
+
+# The ExtendedConnectionHandler and associated classes get removed from LookdevXUfe in UFE v8 / LookdevXUfe v3.
+set(LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER FALSE CACHE INTERNAL "LookdevXUfeHasExtendedConnectionHandler")
+if (LookdevXUfe_INCLUDE_DIR AND EXISTS "${LookdevXUfe_INCLUDE_DIR}/LookdevXUfe/ExtendedConnectionHandler.h")
+    set(LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER TRUE CACHE INTERNAL "LookdevXUfeHasExtendedConnectionHandler")
+    message(STATUS "Maya has LookdevXUfe ExtendedConnectionHandler")
+endif()

--- a/lib/lookdevXUsd/CMakeLists.txt
+++ b/lib/lookdevXUsd/CMakeLists.txt
@@ -27,12 +27,8 @@ target_sources(${PROJECT_NAME}
         ProxyShapeLookdevHandler.cpp
         UsdCapabilityHandler.cpp
         UsdClipboardHandler.cpp
-        UsdComponentConnections.cpp
-        UsdConnectionCommands.cpp
         UsdDebugHandler.cpp
-        UsdDeleteCommand.cpp
         UsdExtendedAttributeHandler.cpp
-        UsdExtendedConnectionHandler.cpp
         UsdFileHandler.cpp
         UsdHierarchy.cpp
         UsdHierarchyHandler.cpp
@@ -41,8 +37,6 @@ target_sources(${PROJECT_NAME}
         UsdMaterialCommands.cpp
         UsdMaterialHandler.cpp
         UsdMaterialValidator.cpp
-        UsdSceneItemOps.cpp
-        UsdSceneItemOpsHandler.cpp
         UsdSceneItemUI.cpp
         UsdSceneItemUIHandler.cpp
         UsdSoloingHandler.cpp
@@ -58,12 +52,8 @@ set(HEADERS
     ProxyShapeLookdevHandler.h
     UsdCapabilityHandler.h
     UsdClipboardHandler.h
-    UsdComponentConnections.h
-    UsdConnectionCommands.h
     UsdDebugHandler.h
-    UsdDeleteCommand.h
     UsdExtendedAttributeHandler.h
-    UsdExtendedConnectionHandler.h
     UsdFileHandler.h
     UsdHierarchy.h
     UsdHierarchyHandler.h
@@ -72,8 +62,6 @@ set(HEADERS
     UsdMaterialCommands.h
     UsdMaterialHandler.h
     UsdMaterialValidator.h
-    UsdSceneItemOps.h
-    UsdSceneItemOpsHandler.h
     UsdSceneItemUI.h
     UsdSceneItemUIHandler.h
     UsdSoloingHandler.h
@@ -128,6 +116,33 @@ if (LOOKDEVXUFE_HAS_LEGACY_MTLX_DETECTION)
     PRIVATE
         LOOKDEVXUFE_HAS_LEGACY_MTLX_DETECTION=1
         MaterialX_VERSION_STRING="${MaterialX_VERSION_MAJOR}.${MaterialX_VERSION_MINOR}"
+    )
+endif()
+
+# The ExtendedConnectionHandler and associated classes get removed from LookdevXUfe in UFE v8 / LookdevXUfe v3.
+if (LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER)
+    target_sources(${PROJECT_NAME}
+    PRIVATE
+        UsdComponentConnections.cpp
+        UsdConnectionCommands.cpp
+        UsdDeleteCommand.cpp
+        UsdExtendedConnectionHandler.cpp
+        UsdSceneItemOps.cpp
+        UsdSceneItemOpsHandler.cpp
+    )
+
+    list(APPEND HEADERS
+        UsdComponentConnections.h
+        UsdConnectionCommands.h
+        UsdDeleteCommand.h
+        UsdExtendedConnectionHandler.h
+        UsdSceneItemOps.h
+        UsdSceneItemOpsHandler.h
+    )
+
+    target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+        LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER=1
     )
 endif()
 

--- a/lib/lookdevXUsd/LookdevXUsd.cpp
+++ b/lib/lookdevXUsd/LookdevXUsd.cpp
@@ -15,7 +15,6 @@
 #include "UsdClipboardHandler.h"
 #include "UsdDebugHandler.h"
 #include "UsdExtendedAttributeHandler.h"
-#include "UsdExtendedConnectionHandler.h"
 #include "UsdFileHandler.h"
 #include "UsdHierarchyHandler.h"
 #include "UsdLookdevHandler.h"
@@ -31,6 +30,10 @@
 
 #include <pxr/usd/sdr/registry.h>
 
+#ifdef LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER
+#include "UsdExtendedConnectionHandler.h"
+#endif
+
 namespace
 {
 
@@ -38,7 +41,9 @@ namespace
 Ufe::Rtid mayaUsdRuntimeId = 0;
 Ufe::Rtid mayaRuntimeId = 0;
 
+#ifdef LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER
 Ufe::SceneItemOpsHandler::Ptr mayaUsdSceneItemOpsHandler;
+#endif
 LookdevXUfe::LookdevHandler::Ptr mayaLookdevHandler;
 
 } // namespace
@@ -71,19 +76,23 @@ void initialize()
                                                 UsdSceneItemUIHandler::create());
     Ufe::RunTimeMgr::instance().registerHandler(mayaUsdRuntimeId, UsdExtendedAttributeHandler::id,
                                                 UsdExtendedAttributeHandler::create());
-    Ufe::RunTimeMgr::instance().registerHandler(mayaUsdRuntimeId, UsdExtendedConnectionHandler::id,
-                                                UsdExtendedConnectionHandler::create());
     Ufe::RunTimeMgr::instance().registerHandler(mayaUsdRuntimeId, UsdCapabilityHandler::id,
                                                 UsdCapabilityHandler::create());
+#ifdef LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER
+    Ufe::RunTimeMgr::instance().registerHandler(mayaUsdRuntimeId, UsdExtendedConnectionHandler::id,
+                                                UsdExtendedConnectionHandler::create());
+#endif
 
     // Replacements/wrappers for existing handlers.
     UsdUINodeGraphNodeHandler::registerHandler(mayaUsdRuntimeId);
     UsdHierarchyHandler::registerHandler(mayaUsdRuntimeId);
     UsdClipboardHandler::registerHandler(mayaUsdRuntimeId);
 
+#ifdef LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER
     mayaUsdSceneItemOpsHandler = Ufe::RunTimeMgr::instance().sceneItemOpsHandler(mayaUsdRuntimeId);
     Ufe::RunTimeMgr::instance().setSceneItemOpsHandler(
         mayaUsdRuntimeId, LookdevXUsd::UsdSceneItemOpsHandler::create(mayaUsdSceneItemOpsHandler));
+#endif
 
     mayaLookdevHandler = LookdevXUfe::LookdevHandler::get(mayaRuntimeId);
     Ufe::RunTimeMgr::instance().registerHandler(mayaRuntimeId, ProxyShapeLookdevHandler::id,
@@ -113,7 +122,9 @@ void uninitialize()
     Ufe::RunTimeMgr::instance().unregisterHandler(mayaUsdRuntimeId, UsdFileHandler::id);
     Ufe::RunTimeMgr::instance().unregisterHandler(mayaUsdRuntimeId, UsdSceneItemUIHandler::id);
     Ufe::RunTimeMgr::instance().unregisterHandler(mayaUsdRuntimeId, UsdExtendedAttributeHandler::id);
+#ifdef LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER
     Ufe::RunTimeMgr::instance().unregisterHandler(mayaUsdRuntimeId, UsdExtendedConnectionHandler::id);
+#endif
     Ufe::RunTimeMgr::instance().unregisterHandler(mayaUsdRuntimeId, UsdCapabilityHandler::id);
 
     // Replacements/wrappers for existing handlers
@@ -123,10 +134,12 @@ void uninitialize()
 
     // Unregister the decorated MayaUsd handlers and restore the original ones.
     auto& runTimeMgr = Ufe::RunTimeMgr::instance();
+#ifdef LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER
     if (runTimeMgr.hasId(mayaUsdRuntimeId)) {
         runTimeMgr.setSceneItemOpsHandler(mayaUsdRuntimeId, mayaUsdSceneItemOpsHandler);
     }
     mayaUsdSceneItemOpsHandler.reset();
+#endif
 
     // Unregister the decorated Maya handlers and restore the original ones.
     Ufe::RunTimeMgr::instance().unregisterHandler(mayaRuntimeId, ProxyShapeLookdevHandler::id);

--- a/test/lib/LookdevXUfe/CMakeLists.txt
+++ b/test/lib/LookdevXUfe/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(TEST_SCRIPT_FILES
     testLdxCapabilityHandler.py
-    testLdxComponentConnections.py        
     testLdxConnection.py
     testLdxDebugHandler.py
     testLdxFileHandler.py
@@ -10,11 +9,17 @@ if (LOOKDEVXUFE_HAS_LEGACY_MTLX_DETECTION)
     list(APPEND TEST_SCRIPT_FILES testLdxMaterialXUpgrade.py)
 endif()
 
+if (LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER)
+    list(APPEND TEST_SCRIPT_FILES testLdxComponentConnections.py)
+endif()
+
 foreach(script ${TEST_SCRIPT_FILES})
     mayaUsd_get_unittest_target(target ${script})
     mayaUsd_add_test(${target}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         PYTHON_MODULE ${target}
+        ENV
+            "LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER=${LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER}"
     )
 
     # Add a ctest label to these tests for easy filtering.

--- a/test/lib/LookdevXUfe/testLdxConnection.py
+++ b/test/lib/LookdevXUfe/testLdxConnection.py
@@ -101,6 +101,7 @@ class LookdevXUfeConnectionTestCase(unittest.TestCase):
         for addSrcConnection in addSrcConnections.allConnections():
             self.assertFalse(lxufe.UfeUtils.isConnectionHidden(addSrcConnection))
 
+    @unittest.skipIf(os.getenv('LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER', 'NOT-FOUND') not in ('1', "TRUE"), 'Test only available if LookdevXUfe has ExtendedConnectionHandler')
     def test_GetAllExtendedConnections(self):
         self.loadUsdFile("extendedConnections.usda")
 
@@ -190,6 +191,7 @@ class LookdevXUfeConnectionTestCase(unittest.TestCase):
         add2SrcExtendedConnections = lxufe.UfeUtils.getSourceExtendedConnections(add2Item)
         verifyConnections(self, add2SrcExtendedConnections, 0, 0, 2)
 
+    @unittest.skipIf(os.getenv('LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER', 'NOT-FOUND') not in ('1', "TRUE"), 'Test only available if LookdevXUfe has ExtendedConnectionHandler')
     def test_IsInternalConnection(self):
         self.loadUsdFile("isInternalConnection.usda")
 


### PR DESCRIPTION
Deprecate the `ExtendedConnectionHandler` and related classes.