### PR TITLE
Remove the "both" UI option for animation type

### DIFF
--- a/lib/mayaUsd/fileio/jobs/jobArgs.cpp
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.cpp
@@ -812,7 +812,6 @@ UsdMayaJobExportArgs::UsdMayaJobExportArgs(
           {
               UsdMayaJobExportArgsTokens->timesamples,
               UsdMayaJobExportArgsTokens->curves,
-              UsdMayaJobExportArgsTokens->both,
           }))
     , disableModelKindProcessor(
           extractBoolean(userArgs, UsdMayaJobExportArgsTokens->disableModelKindProcessor))

--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -59,7 +59,6 @@ TF_DECLARE_PUBLIC_TOKENS(
     /* animationType values */ \
     (timesamples) \
     (curves) \
-    (both) \
     (startTime) \
     (endTime) \
     (frameStride) \

--- a/plugin/adsk/scripts/mayaUSDRegisterStrings.py
+++ b/plugin/adsk/scripts/mayaUSDRegisterStrings.py
@@ -176,8 +176,7 @@ __mayaUSDStringResources = {
     "kExportAnimationTypeLbl": "Type",
     "kExportAnimationTypeTimeSamplesLbl": "Time Samples",
     "kExportAnimationTypeCurvesLbl": "Animation Curves",
-    "kExportAnimationTypeBothLbl": "Both Samples and Curves",
-    "kExportAnimationTypeAnn": "Select how animations should be stored: Time Samples, Animation Curves, or both.\n" + 
+    "kExportAnimationTypeAnn": "Select how animations should be stored: Time Samples or Animation Curves.\n" + 
                                "Animation Curves are not fully supported. Where unsupported, the system falls back to Time Samples.",
     "kExportBlendShapesAnn": "Exports Maya Blend Shapes as USD blendshapes. Requires skeletons to be exported as well.",
     "kExportBlendShapesLbl": "Blend Shapes",

--- a/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
+++ b/plugin/adsk/scripts/mayaUsdTranslatorExport.mel
@@ -1314,7 +1314,6 @@ global proc int mayaUsdTranslatorExport (string $parent,
                         optionMenuGrp -l `getMayaUsdString("kExportAnimationTypeLbl")` -annotation `getMayaUsdString("kExportAnimationTypeAnn")` exportAnimationTypePopup;
                             menuItem -l `getMayaUsdString("kExportAnimationTypeTimeSamplesLbl")` -ann "timesamples";
                             menuItem -l `getMayaUsdString("kExportAnimationTypeCurvesLbl")` -ann "curves";
-                            menuItem -l `getMayaUsdString("kExportAnimationTypeBothLbl")` -ann "both";
                     }
 
                     rowLayout -numberOfColumns 2 -columnAttach 2 "left" 20;


### PR DESCRIPTION
Having an attribute authored with both time samples and curves is not the intended way to work in USD. 

When that happens, time samples will have higher priority and things like `attr.HasSpline()` will be false, even if the attribute has a spline authored to it. To avoid confusion, we are removing the option to write "both".