### PR TITLE
MtlxMaterialXSurfaceShaderWriter: fix build with Maya 2025 when using OpenUSD 25.02+

### DIFF
--- a/lib/usd/translators/shading/CMakeLists.txt
+++ b/lib/usd/translators/shading/CMakeLists.txt
@@ -94,6 +94,13 @@ if (USD_HAS_COLORSPACE_API_SUPPORT)
     )
 endif()
 
+if (UFE_HAS_COLOR_MANAGEMENT_HANDLER)
+    target_compile_definitions(${TARGET_NAME}
+    PRIVATE
+        UFE_HAS_COLOR_MANAGEMENT_HANDLER=1
+    )
+endif()
+
 if (LOOKDEVXUFE_HAS_LEGACY_MTLX_DETECTION)
     target_compile_definitions(${TARGET_NAME}
     PRIVATE

--- a/lib/usd/translators/shading/mtlxMaterialXSurfaceShaderWriter.cpp
+++ b/lib/usd/translators/shading/mtlxMaterialXSurfaceShaderWriter.cpp
@@ -53,9 +53,12 @@
 #include <ufe/runTimeMgr.h>
 
 #ifdef USD_HAS_COLORSPACE_API_SUPPORT
+
+#ifdef UFE_HAS_COLOR_MANAGEMENT_HANDLER
 #include <mayaUsd/ufe/Global.h>
 
 #include <ufe/colorManagementHandler.h>
+#endif
 
 #include <unordered_map>
 #endif
@@ -998,6 +1001,7 @@ TfToken MtlxMaterialXSurfaceShaderWriter::_GetValidUsdColorSpace(
     // Usd wants standard names from the ASWF color interchange WG.
     auto usdColorSpace = TfToken { mxColorSpace };
 
+#ifdef UFE_HAS_COLOR_MANAGEMENT_HANDLER
     if (!GfColorSpace::IsValid(usdColorSpace)) {
         const auto cmHandler
             = Ufe::ColorManagementHandler::colorManagementHandler(MayaUsd::ufe::getMayaRunTimeId());
@@ -1008,6 +1012,7 @@ TfToken MtlxMaterialXSurfaceShaderWriter::_GetValidUsdColorSpace(
             }
         }
     }
+#endif
 
     if (!GfColorSpace::IsValid(usdColorSpace)) {
         // We know how to map some common MaterialX color spaces to USD recognized ones:


### PR DESCRIPTION
The use of `Ufe::ColorManagementHandler` in `MtlxMaterialXSurfaceShaderWriter` was only guarded by `USD_HAS_COLORSPACE_API_SUPPORT` (OpenUSD 25.02+).

This change also guards it with `UFE_HAS_COLOR_MANAGEMENT_HANDLER` so builds succeed with Maya 2025.