### PR TITLE
Fix material assignment command for edit forwarding + scope under default prim when exists.

### DIFF
--- a/lib/lookdevXUsd/ProxyShapeLookdevHandler.cpp
+++ b/lib/lookdevXUsd/ProxyShapeLookdevHandler.cpp
@@ -159,15 +159,33 @@ bool MayaUsdCreateLookdevEnvironmentCommand::executeCommand()
         m_cmds->append(createProxyCommand);
     }
 
-    // Create a materials scope under the proxy shape.
+    // Create a materials scope, preferring the default prim as parent if one exists.
     auto proxyShapeItem =
         MayaUsdAPI::createUsdSceneItem(proxyShape->path(), MayaUsdAPI::ufePathToPrim(proxyShape->path()));
     if (!proxyShapeItem || !MayaUsdAPI::getPrimForUsdSceneItem(proxyShapeItem).IsValid())
     {
         return false;
     }
+
+    Ufe::SceneItem::Ptr scopeParentItem = proxyShapeItem;
+    auto stage = MayaUsdAPI::getStage(proxyShape->path());
+    if (stage && stage->HasDefaultPrim())
+    {
+        auto defaultPrim = stage->GetDefaultPrim();
+        if (defaultPrim.IsValid())
+        {
+            auto defaultPrimUfePath = MayaUsdAPI::stagePath(stage)
+                + MayaUsdAPI::usdPathToUfePathSegment(defaultPrim.GetPath());
+            auto defaultPrimItem = MayaUsdAPI::createUsdSceneItem(defaultPrimUfePath, defaultPrim);
+            if (defaultPrimItem)
+            {
+                scopeParentItem = defaultPrimItem;
+            }
+        }
+    }
+
     auto createMaterialsScopeCmd = std::dynamic_pointer_cast<Ufe::SceneItemResultUndoableCommand>(
-        MayaUsdAPI::createMaterialsScopeCommand(proxyShapeItem));
+        MayaUsdAPI::createMaterialsScopeCommand(scopeParentItem));
     if (!createMaterialsScopeCmd)
     {
         return false;

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
@@ -387,15 +387,14 @@ void UsdUndoAssignNewMaterialCommand::execute()
         //
 
         // If a default prim exists, have the mtl scope under it, otherwise, fallback to the root.
-        auto defaultPrim = stage->GetDefaultPrim();
+        auto      defaultPrim = stage->GetDefaultPrim();
         UsdPrim   rootPrim;
-        Ufe::Path ufePath; 
+        Ufe::Path ufePath;
         if (defaultPrim) {
-            ufePath = UsdUfe::stagePath(stage)
-                + UsdUfe::usdPathToUfePathSegment(defaultPrim.GetPath());        
+            ufePath
+                = UsdUfe::stagePath(stage) + UsdUfe::usdPathToUfePathSegment(defaultPrim.GetPath());
             rootPrim = defaultPrim;
-        }
-        else {
+        } else {
             ufePath = UsdUfe::stagePath(stage);
             rootPrim = stage->GetPseudoRoot();
         }

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
@@ -388,10 +388,19 @@ void UsdUndoAssignNewMaterialCommand::execute()
 
         // If a default prim exists, have the mtl scope under it, otherwise, fallback to the root.
         auto defaultPrim = stage->GetDefaultPrim();
-        auto root = defaultPrim ? defaultPrim : stage->GetPseudoRoot();
-        Ufe::Path ufePath
-            = UsdUfe::stagePath(root.GetStage()) + UsdUfe::usdPathToUfePathSegment(root.GetPath());
-        auto stageItem = UsdUfe::UsdSceneItem::create(ufePath, root);
+        UsdPrim   rootPrim;
+        Ufe::Path ufePath; 
+        if (defaultPrim) {
+            ufePath = UsdUfe::stagePath(stage)
+                + UsdUfe::usdPathToUfePathSegment(defaultPrim.GetPath());        
+            rootPrim = defaultPrim;
+        }
+        else {
+            ufePath = UsdUfe::stagePath(stage);
+            rootPrim = stage->GetPseudoRoot();
+        }
+
+        auto stageItem = UsdUfe::UsdSceneItem::create(ufePath, rootPrim);
 
         auto createMaterialsScopeCmd = UsdUndoCreateMaterialsScopeCommand::create(stageItem);
         if (!createMaterialsScopeCmd) {
@@ -524,10 +533,10 @@ void UsdUndoAssignNewMaterialCommand::execute()
 void UsdUndoAssignNewMaterialCommand::undo()
 {
     if (_cmds) {
-        _cmds->undo();
         for (int i = _undoItems.size() - 1; i >= 0; i--) {
             _undoItems[i].undo();
         }
+        _cmds->undo();
     }
 }
 
@@ -671,9 +680,9 @@ void UsdUndoAddNewMaterialCommand::execute()
 void UsdUndoAddNewMaterialCommand::undo()
 {
     if (_createMaterialCmd) {
+        _undoItem.undo();
         _createShaderCmd->undo();
         _createMaterialCmd->undo();
-        _undoItem.undo();
     }
 }
 

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
@@ -442,21 +442,20 @@ void UsdUndoAssignNewMaterialCommand::execute()
             return;
         }
 
-
         {
             UsdUfe::UsdUndoableItem item;
-            UsdUfe::UsdUndoBlock connectUndo { &item };
+            UsdUfe::UsdUndoBlock    connectUndo { &item };
 
             //
             // 4. Connect the Shader to the material:
             //
-            
+
             if (!connectShaderToMaterial(
                     createShaderCmd->insertedChild(), createMaterialCmd->newPrim(), _nodeId)) {
                 markAsFailed();
                 return;
             }
-            
+
 #if PXR_VERSION >= 2502
             // Store the MaterialX current version on the created prim.
             if (shaderNodeDef->GetSourceType() == "mtlx") {
@@ -620,13 +619,13 @@ void UsdUndoAddNewMaterialCommand::execute()
     }
 
     {
-        UsdUfe::UsdUndoBlock usdUndo { &_undoItem};
+        UsdUfe::UsdUndoBlock usdUndo { &_undoItem };
 
         //
         // Connect the Shader to the material, only for surfaces:
         //
-        
-        auto                 surfaces = UsdMayaUtil::GetSurfaceShaderNodeDefs();
+
+        auto surfaces = UsdMayaUtil::GetSurfaceShaderNodeDefs();
         if (std::find(surfaces.begin(), surfaces.end(), shaderNodeDef) != surfaces.end()) {
             if (!connectShaderToMaterial(
                     _createShaderCmd->insertedChild(), _createMaterialCmd->newPrim(), _nodeId)) {

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
@@ -399,9 +399,9 @@ void UsdUndoAssignNewMaterialCommand::execute()
             rootPrim = stage->GetPseudoRoot();
         }
 
-        auto stageItem = UsdUfe::UsdSceneItem::create(ufePath, rootPrim);
+        auto rootItem = UsdUfe::UsdSceneItem::create(ufePath, rootPrim);
 
-        auto createMaterialsScopeCmd = UsdUndoCreateMaterialsScopeCommand::create(stageItem);
+        auto createMaterialsScopeCmd = UsdUndoCreateMaterialsScopeCommand::create(rootItem);
         if (!createMaterialsScopeCmd) {
             markAsFailed();
             return;

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
@@ -19,6 +19,7 @@
 #include <mayaUsd/ufe/MayaUsdUndoRenameCommand.h>
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/utils/util.h>
+#include <mayaUsd/utils/utilComponentCreator.h>
 
 #include <usdUfe/ufe/UfeNotifGuard.h>
 #include <usdUfe/ufe/Utils.h>
@@ -363,8 +364,15 @@ void UsdUndoAssignNewMaterialCommand::execute()
         //
         // 1. Create the Scope "materials" if it does not exist:
         //
-        auto stageItem
-            = UsdUfe::UsdSceneItem::create(MayaUsd::ufe::stagePath(stage), stage->GetPseudoRoot());
+
+        auto defaultPrim = stage->GetDefaultPrim();
+        auto root = defaultPrim ? defaultPrim : stage->GetPseudoRoot();
+
+        Ufe::Path ufePath
+            = UsdUfe::stagePath(root.GetStage()) + UsdUfe::usdPathToUfePathSegment(root.GetPath());
+
+        auto stageItem = UsdUfe::UsdSceneItem::create(ufePath, root);
+
         auto createMaterialsScopeCmd = UsdUndoCreateMaterialsScopeCommand::create(stageItem);
         if (!createMaterialsScopeCmd) {
             markAsFailed();
@@ -416,17 +424,6 @@ void UsdUndoAssignNewMaterialCommand::execute()
             return;
         }
 
-#if PXR_VERSION >= 2502
-        // Store the MaterialX current version on the created prim.
-        if (shaderNodeDef->GetSourceType() == "mtlx") {
-            if (auto mtlxLibrary = UsdMtlxGetDocument("")) {
-                auto mtlxConfigAPI = UsdMtlxMaterialXConfigAPI::Apply(createMaterialCmd->newPrim());
-                auto mtlxVersionStr = mtlxLibrary->getVersionString();
-                mtlxConfigAPI.CreateConfigMtlxVersionAttr(VtValue(mtlxVersionStr));
-            }
-        }
-#endif
-
         //
         // 3. Create the Shader:
         //
@@ -445,13 +442,34 @@ void UsdUndoAssignNewMaterialCommand::execute()
             return;
         }
 
-        //
-        // 4. Connect the Shader to the material:
-        //
-        if (!connectShaderToMaterial(
-                createShaderCmd->insertedChild(), createMaterialCmd->newPrim(), _nodeId)) {
-            markAsFailed();
-            return;
+
+        {
+            UsdUfe::UsdUndoableItem item;
+            UsdUfe::UsdUndoBlock connectUndo { &item };
+
+            //
+            // 4. Connect the Shader to the material:
+            //
+            
+            if (!connectShaderToMaterial(
+                    createShaderCmd->insertedChild(), createMaterialCmd->newPrim(), _nodeId)) {
+                markAsFailed();
+                return;
+            }
+            
+#if PXR_VERSION >= 2502
+            // Store the MaterialX current version on the created prim.
+            if (shaderNodeDef->GetSourceType() == "mtlx") {
+                if (auto mtlxLibrary = UsdMtlxGetDocument("")) {
+                    auto mtlxConfigAPI
+                        = UsdMtlxMaterialXConfigAPI::Apply(createMaterialCmd->newPrim());
+                    auto mtlxVersionStr = mtlxLibrary->getVersionString();
+                    mtlxConfigAPI.CreateConfigMtlxVersionAttr(VtValue(mtlxVersionStr));
+                }
+            }
+#endif
+
+            _undoItems.push_back(item);
         }
 
         //
@@ -488,6 +506,9 @@ void UsdUndoAssignNewMaterialCommand::undo()
 {
     if (_cmds) {
         _cmds->undo();
+        for (int i = _undoItems.size() - 1; i >= 0; i--) {
+            _undoItems[i].undo();
+        }
     }
 }
 
@@ -495,23 +516,8 @@ void UsdUndoAssignNewMaterialCommand::redo()
 {
     if (_cmds) {
         _cmds->redo();
-
-        auto cmdsIt = _cmds->cmdsList().begin();
-        while (cmdsIt != _cmds->cmdsList().end()) {
-            // Find out all Material creation followed by a shader creation and reconnect the
-            // shader to the material. Don't assume any ordering.
-            auto addMaterialCmd
-                = std::dynamic_pointer_cast<UsdUfe::UsdUndoAddNewPrimCommand>(*cmdsIt++);
-            if (addMaterialCmd && addMaterialCmd->newPrim()
-                && UsdShadeMaterial(addMaterialCmd->newPrim())
-                && cmdsIt != _cmds->cmdsList().end()) {
-                auto addShaderCmd
-                    = std::dynamic_pointer_cast<UsdUndoCreateFromNodeDefCommand>(*cmdsIt++);
-                if (addShaderCmd) {
-                    connectShaderToMaterial(
-                        addShaderCmd->insertedChild(), addMaterialCmd->newPrim(), _nodeId);
-                }
-            }
+        for (int i = 0; i < _undoItems.size(); i++) {
+            _undoItems[i].redo();
         }
     }
 }
@@ -596,17 +602,6 @@ void UsdUndoAddNewMaterialCommand::execute()
         return;
     }
 
-#if PXR_VERSION >= 2502
-    // Store the MaterialX current version on the created prim.
-    if (shaderNodeDef->GetSourceType() == "mtlx") {
-        if (auto mtlxLibrary = UsdMtlxGetDocument("")) {
-            auto mtlxConfigAPI = UsdMtlxMaterialXConfigAPI::Apply(_createMaterialCmd->newPrim());
-            auto mtlxVersionStr = mtlxLibrary->getVersionString();
-            mtlxConfigAPI.CreateConfigMtlxVersionAttr(VtValue(mtlxVersionStr));
-        }
-    }
-#endif
-
     //
     // Create the Shader:
     //
@@ -624,16 +619,33 @@ void UsdUndoAddNewMaterialCommand::execute()
         return;
     }
 
-    //
-    // Connect the Shader to the material, only for surfaces:
-    //
-    auto surfaces = UsdMayaUtil::GetSurfaceShaderNodeDefs();
-    if (std::find(surfaces.begin(), surfaces.end(), shaderNodeDef) != surfaces.end()) {
-        if (!connectShaderToMaterial(
-                _createShaderCmd->insertedChild(), _createMaterialCmd->newPrim(), _nodeId)) {
-            markAsFailed();
-            return;
+    {
+        UsdUfe::UsdUndoBlock usdUndo { &_undoItem};
+
+        //
+        // Connect the Shader to the material, only for surfaces:
+        //
+        
+        auto                 surfaces = UsdMayaUtil::GetSurfaceShaderNodeDefs();
+        if (std::find(surfaces.begin(), surfaces.end(), shaderNodeDef) != surfaces.end()) {
+            if (!connectShaderToMaterial(
+                    _createShaderCmd->insertedChild(), _createMaterialCmd->newPrim(), _nodeId)) {
+                markAsFailed();
+                return;
+            }
         }
+
+#if PXR_VERSION >= 2502
+        // Store the MaterialX current version on the created prim.
+        if (shaderNodeDef->GetSourceType() == "mtlx") {
+            if (auto mtlxLibrary = UsdMtlxGetDocument("")) {
+                auto mtlxConfigAPI
+                    = UsdMtlxMaterialXConfigAPI::Apply(_createMaterialCmd->newPrim());
+                auto mtlxVersionStr = mtlxLibrary->getVersionString();
+                mtlxConfigAPI.CreateConfigMtlxVersionAttr(VtValue(mtlxVersionStr));
+            }
+        }
+#endif
     }
 }
 
@@ -642,6 +654,7 @@ void UsdUndoAddNewMaterialCommand::undo()
     if (_createMaterialCmd) {
         _createShaderCmd->undo();
         _createMaterialCmd->undo();
+        _undoItem.undo();
     }
 }
 
@@ -650,9 +663,7 @@ void UsdUndoAddNewMaterialCommand::redo()
     if (_createMaterialCmd) {
         _createMaterialCmd->redo();
         _createShaderCmd->redo();
-
-        connectShaderToMaterial(
-            _createShaderCmd->insertedChild(), _createMaterialCmd->newPrim(), _nodeId);
+        _undoItem.redo();
     }
 }
 
@@ -730,7 +741,18 @@ bool UsdUndoCreateMaterialsScopeCommand::doExecute()
         return false;
     }
 
-    auto materialsScopeName = UsdMayaJobExportArgs::GetDefaultMaterialsScopeName();
+    auto proxyShapePath
+        = MayaUsd::ufe::ufeToDagPath(MayaUsd::ufe::stagePath(_parentItem->prim().GetStage()));
+    std::string materialsScopeName;
+    if (proxyShapePath.isValid()) {
+        const std::string proxyPath = proxyShapePath.fullPathName().asChar();
+        if (MayaUsd::ComponentUtils::isAdskUsdComponent(proxyPath)) {
+            materialsScopeName = MayaUsd::ComponentUtils::getMaterialScopeName(proxyPath);
+        }
+    }
+    if (materialsScopeName.empty()) {
+        materialsScopeName = UsdMayaJobExportArgs::GetDefaultMaterialsScopeName();
+    }
     auto renameCmd = MayaUsdUndoRenameCommand::create(scopeItem, materialsScopeName);
     if (!renameCmd) {
         return false;

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
@@ -532,7 +532,7 @@ void UsdUndoAssignNewMaterialCommand::execute()
 void UsdUndoAssignNewMaterialCommand::undo()
 {
     if (_cmds) {
-        for (int i = _undoItems.size() - 1; i >= 0; i--) {
+        for (int i = static_cast<int>(_undoItems.size()) - 1; i >= 0; i--) {
             _undoItems[i].undo();
         }
         _cmds->undo();
@@ -543,7 +543,7 @@ void UsdUndoAssignNewMaterialCommand::redo()
 {
     if (_cmds) {
         _cmds->redo();
-        for (int i = 0; i < _undoItems.size(); i++) {
+        for (size_t i = 0; i < _undoItems.size(); i++) {
             _undoItems[i].redo();
         }
     }

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
@@ -109,6 +109,27 @@ bool connectShaderToMaterial(
     return true;
 }
 
+//! Returns the materials scope name to use for the stage containing \p parentPath.
+//! Uses the component-defined scope name when the stage is an Autodesk USD Component,
+//! otherwise falls back to the default export job args name.
+std::string resolveMaterialScopeName(const Ufe::Path& parentPath)
+{
+    const UsdStageWeakPtr stage = getStage(parentPath);
+    if (stage) {
+        auto proxyShapePath = MayaUsd::ufe::ufeToDagPath(MayaUsd::ufe::stagePath(stage));
+        if (proxyShapePath.isValid()) {
+            const std::string proxyPath = proxyShapePath.fullPathName().asChar();
+            if (MayaUsd::ComponentUtils::isAdskUsdComponent(proxyPath)) {
+                auto name = MayaUsd::ComponentUtils::getMaterialScopeName(proxyPath);
+                if (!name.empty()) {
+                    return name;
+                }
+            }
+        }
+    }
+    return UsdMayaJobExportArgs::GetDefaultMaterialsScopeName();
+}
+
 //! Searches the children of \p parentPath for a materials scope. Returns a null pointer if no
 //! materials scope is found.
 Ufe::SceneItem::Ptr getMaterialsScope(const Ufe::Path& parentPath)
@@ -127,7 +148,7 @@ Ufe::SceneItem::Ptr getMaterialsScope(const Ufe::Path& parentPath)
     // Usually the materials scope will simply have the default name (e.g. "mtl"). However, if
     // that name is used by a non-scope object, a number should be appended (e.g. "mtl1"). If
     // this name is not available either, increment the number until an available name is found.
-    std::string scopeNamePrefix = UsdMayaJobExportArgs::GetDefaultMaterialsScopeName();
+    std::string scopeNamePrefix = resolveMaterialScopeName(parentPath);
     std::string scopeName = scopeNamePrefix;
     auto        hasName
         = [&scopeName](const Ufe::SceneItem::Ptr& item) { return item->nodeName() == scopeName; };
@@ -740,19 +761,8 @@ bool UsdUndoCreateMaterialsScopeCommand::doExecute()
         return false;
     }
 
-    auto proxyShapePath
-        = MayaUsd::ufe::ufeToDagPath(MayaUsd::ufe::stagePath(_parentItem->prim().GetStage()));
-    std::string materialsScopeName;
-    if (proxyShapePath.isValid()) {
-        const std::string proxyPath = proxyShapePath.fullPathName().asChar();
-        if (MayaUsd::ComponentUtils::isAdskUsdComponent(proxyPath)) {
-            materialsScopeName = MayaUsd::ComponentUtils::getMaterialScopeName(proxyPath);
-        }
-    }
-    if (materialsScopeName.empty()) {
-        materialsScopeName = UsdMayaJobExportArgs::GetDefaultMaterialsScopeName();
-    }
-    auto renameCmd = MayaUsdUndoRenameCommand::create(scopeItem, materialsScopeName);
+    std::string materialsScopeName = resolveMaterialScopeName(_parentItem->path());
+    auto        renameCmd = MayaUsdUndoRenameCommand::create(scopeItem, materialsScopeName);
     if (!renameCmd) {
         return false;
     }

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.cpp
@@ -386,12 +386,11 @@ void UsdUndoAssignNewMaterialCommand::execute()
         // 1. Create the Scope "materials" if it does not exist:
         //
 
+        // If a default prim exists, have the mtl scope under it, otherwise, fallback to the root.
         auto defaultPrim = stage->GetDefaultPrim();
         auto root = defaultPrim ? defaultPrim : stage->GetPseudoRoot();
-
         Ufe::Path ufePath
             = UsdUfe::stagePath(root.GetStage()) + UsdUfe::usdPathToUfePathSegment(root.GetPath());
-
         auto stageItem = UsdUfe::UsdSceneItem::create(ufePath, root);
 
         auto createMaterialsScopeCmd = UsdUndoCreateMaterialsScopeCommand::create(stageItem);

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.h
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.h
@@ -168,7 +168,7 @@ private:
     UsdUfe::UsdUndoAddNewPrimCommand::Ptr _createMaterialCmd;
     UsdUndoCreateFromNodeDefCommand::Ptr  _createShaderCmd;
     // An extra undo item for operation that dont themselves run a full fledged command.
-    UsdUfe::UsdUndoableItem               _undoItem;
+    UsdUfe::UsdUndoableItem _undoItem;
 
 }; // UsdUndoAddNewMaterialCommand
 

--- a/lib/mayaUsd/ufe/UsdUndoMaterialCommands.h
+++ b/lib/mayaUsd/ufe/UsdUndoMaterialCommands.h
@@ -126,6 +126,9 @@ private:
     size_t                                         _createMaterialCmdIdx = -1;
     std::shared_ptr<Ufe::CompositeUndoableCommand> _cmds;
 
+    // Extra undo items for operations not running within full fledged commands.
+    std::vector<UsdUfe::UsdUndoableItem> _undoItems;
+
 }; // UsdUndoAssignNewMaterialCommand
 
 //! \brief UsdUndoAddNewMaterialCommand
@@ -164,6 +167,8 @@ private:
 
     UsdUfe::UsdUndoAddNewPrimCommand::Ptr _createMaterialCmd;
     UsdUndoCreateFromNodeDefCommand::Ptr  _createShaderCmd;
+    // An extra undo item for operation that dont themselves run a full fledged command.
+    UsdUfe::UsdUndoableItem               _undoItem;
 
 }; // UsdUndoAddNewMaterialCommand
 

--- a/lib/mayaUsd/utils/utilComponentCreator.cpp
+++ b/lib/mayaUsd/utils/utilComponentCreator.cpp
@@ -269,7 +269,7 @@ std::string getComponentOptionString(const std::string& proxyPath, const char* o
 {
     MString defCmd;
     defCmd.format(
-        "def _usd_cc_get_scope_name():\n"
+        "def _cc_get_option_str():\n"
         "    import mayaUsd.ufe\n"
         "    try:\n"
         "        from AdskUsdComponentCreator import ComponentDescription\n"
@@ -285,7 +285,7 @@ std::string getComponentOptionString(const std::string& proxyPath, const char* o
 
     if (MS::kSuccess == MGlobal::executePythonCommand(defCmd)) {
         MString result;
-        if (MS::kSuccess == MGlobal::executePythonCommand("_usd_cc_get_scope_name()", result)) {
+        if (MS::kSuccess == MGlobal::executePythonCommand("_cc_get_option_str()", result)) {
             return result.asUTF8();
         }
     }

--- a/lib/mayaUsd/utils/utilComponentCreator.cpp
+++ b/lib/mayaUsd/utils/utilComponentCreator.cpp
@@ -265,9 +265,7 @@ bool shouldDisplayComponentInitialSaveDialog(
 
 namespace {
 
-std::string getComponentOptionString(
-    const std::string& proxyPath,
-    const char*        optionsAttribute)
+std::string getComponentOptionString(const std::string& proxyPath, const char* optionsAttribute)
 {
     MString defCmd;
     defCmd.format(
@@ -287,8 +285,7 @@ std::string getComponentOptionString(
 
     if (MS::kSuccess == MGlobal::executePythonCommand(defCmd)) {
         MString result;
-        if (MS::kSuccess
-            == MGlobal::executePythonCommand("_usd_cc_get_scope_name()", result)) {
+        if (MS::kSuccess == MGlobal::executePythonCommand("_usd_cc_get_scope_name()", result)) {
             return result.asUTF8();
         }
     }

--- a/lib/mayaUsd/utils/utilComponentCreator.cpp
+++ b/lib/mayaUsd/utils/utilComponentCreator.cpp
@@ -263,5 +263,49 @@ bool shouldDisplayComponentInitialSaveDialog(
         UsdMayaUtil::convert(tempDir), stage->GetRootLayer()->GetRealPath());
 }
 
+namespace {
+
+std::string getComponentOptionString(
+    const std::string& proxyPath,
+    const char*        optionsAttribute)
+{
+    MString defCmd;
+    defCmd.format(
+        "def _usd_cc_get_scope_name():\n"
+        "    import mayaUsd.ufe\n"
+        "    try:\n"
+        "        from AdskUsdComponentCreator import ComponentDescription\n"
+        "    except ImportError:\n"
+        "        return ''\n"
+        "    proxyStage = mayaUsd.ufe.getStage('^1s')\n"
+        "    component_description = ComponentDescription.CreateFromStageMetadata(proxyStage)\n"
+        "    if not component_description:\n"
+        "        return ''\n"
+        "    return component_description.GetOptions().^2s\n",
+        proxyPath.c_str(),
+        optionsAttribute);
+
+    if (MS::kSuccess == MGlobal::executePythonCommand(defCmd)) {
+        MString result;
+        if (MS::kSuccess
+            == MGlobal::executePythonCommand("_usd_cc_get_scope_name()", result)) {
+            return result.asUTF8();
+        }
+    }
+    return {};
+}
+
+} // namespace
+
+std::string getMaterialScopeName(const std::string& proxyPath)
+{
+    return getComponentOptionString(proxyPath, "materials_scope_name");
+}
+
+std::string getMeshScopeName(const std::string& proxyPath)
+{
+    return getComponentOptionString(proxyPath, "meshes_scope_name");
+}
+
 } // namespace ComponentUtils
 } // namespace MAYAUSD_NS_DEF

--- a/lib/mayaUsd/utils/utilComponentCreator.h
+++ b/lib/mayaUsd/utils/utilComponentCreator.h
@@ -85,6 +85,16 @@ bool shouldDisplayComponentInitialSaveDialog(
     const PXR_NS::UsdStageRefPtr stage,
     const std::string&           proxyShapePath);
 
+/*! \brief Returns the name of the materials scope used in the component at the given path
+ */
+MAYAUSD_CORE_PUBLIC
+std::string getMaterialScopeName(const std::string& proxyPath);
+
+/*! \brief Returns the name of the mesh scope used in the component at the given path.
+ */
+MAYAUSD_CORE_PUBLIC
+std::string getMeshScopeName(const std::string& proxyPath);
+
 } // namespace ComponentUtils
 } // namespace MAYAUSD_NS_DEF
 

--- a/lib/usdUfe/undo/UsdUndoStateDelegate.cpp
+++ b/lib/usdUfe/undo/UsdUndoStateDelegate.cpp
@@ -117,7 +117,7 @@ void UsdUndoStateDelegate::invertCreateSpec(const SdfPath& path, bool inert)
 
     TF_DEBUG(USDUFE_UNDOSTATEDELEGATE).Msg("Inverting creating spec at '%s'\n", path.GetText());
 
-    // In principle this should never happen if everything every edit is properly undoable.
+    // In principle this should never happen if every edit is properly undoable.
     // There is a Maya issue with attributes edited using the slider from the attribute editor.
     // The attribute value is set continuously as the slider moves, but the command is only
     // created on drop. The problem is that the specs get created immediately, not within the

--- a/lib/usdUfe/undo/UsdUndoStateDelegate.cpp
+++ b/lib/usdUfe/undo/UsdUndoStateDelegate.cpp
@@ -117,6 +117,18 @@ void UsdUndoStateDelegate::invertCreateSpec(const SdfPath& path, bool inert)
 
     TF_DEBUG(USDUFE_UNDOSTATEDELEGATE).Msg("Inverting creating spec at '%s'\n", path.GetText());
 
+    // In principle this should never happen if everything every edit is properly undoable.
+    // There is a Maya issue with attributes edited using the slider from the attribute editor.
+    // The attribute value is set continuously as the slider moves, but the command is only
+    // created on drop. The problem is that the specs get created immediately, not within the
+    // command. And so the undo block only records the value changing, and misses the spec
+    // creations (the attribute and its hierarchy). Depending on what happens before and after,
+    // we can get into a situation where the forwarding operation tries to delete or edit things
+    // on the session layer that do not exist, raising errors.
+    if (!_layer->GetObjectAtPath(path)) {
+        _setMessageAlreadyShowed = false;
+        return;
+    }
     DeleteSpec(path, inert);
 
     _setMessageAlreadyShowed = false;


### PR DESCRIPTION
Update Add and Assign material commands to work with the component creator and edit forwarding. 
- Search for & Create the scope under the default prim if one exists.
- Make sure every operation is Undoable via the undoblock (setting mtl X version was not undoable, and the connection where done/undone manually)
