### PR TITLE
build: fix installation of `cxx17_legacy_support.h` and `pxr_python.h`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,9 +402,7 @@ set(TOP_HEADERS
 )
 
 mayaUsd_promoteHeaderList(HEADERS ${TOP_HEADERS} BASEDIR "NONE")
-install(FILES ${CMAKE_BINARY_DIR}/include/pxr_python.h
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/include
-)
-install(FILES ${CMAKE_BINARY_DIR}/include/cxx17_legacy_support.h
+
+install(FILES ${TOP_HEADERS}
     DESTINATION ${CMAKE_INSTALL_PREFIX}/include
 )


### PR DESCRIPTION
Fix installation of `cxx17_legacy_support.h` and `pxr_python.h` so installed headers without access to the source tree.

These two headers were previously installed from `${CMAKE_BINARY_DIR}/include`, where `mayaUsd_promoteHeaderList` generates wrapper headers like:
```c++
#pragma once
#include "/path/to/source/maya-usd/cxx17_legacy_support.h"
```

That include makes the installed package non-relocatable and unusable when the source checkout is not present.