### PR TITLE
vp2RenderDelegate: reduce textured material network resyncs

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -2343,8 +2343,11 @@ HdVP2Material::~HdVP2Material()
     }
 }
 
-void ConvertNetworkMapToUntextured(HdMaterialNetworkMap& networkMap)
+// Returns true when untextured conversion changes the network.
+// This means textured and untextured compiled networks must remain distinct.
+bool ConvertNetworkMapToUntextured(HdMaterialNetworkMap& networkMap)
 {
+    bool changed = false;
     for (auto& item : networkMap.map) {
         auto& network = item.second;
         auto  isInputNode = [&networkMap](const HdMaterialNode& node) {
@@ -2353,8 +2356,14 @@ void ConvertNetworkMapToUntextured(HdMaterialNetworkMap& networkMap)
         };
 
         auto eraseBegin = std::remove_if(network.nodes.begin(), network.nodes.end(), isInputNode);
-        network.nodes.erase(eraseBegin, network.nodes.end());
-        network.relationships.clear();
+        if (eraseBegin != network.nodes.end()) {
+            network.nodes.erase(eraseBegin, network.nodes.end());
+            changed = true;
+        }
+        if (!network.relationships.empty()) {
+            network.relationships.clear();
+            changed = true;
+        }
 #ifdef WANT_MATERIALX_BUILD
         // Raw MaterialX surface constructor node does not render. Replace with default
         // standard_surface:
@@ -2362,10 +2371,12 @@ void ConvertNetworkMapToUntextured(HdMaterialNetworkMap& networkMap)
             if (node.identifier == _mtlxTokens->ND_surface) {
                 node.identifier = _mtlxTokens->ND_standard_surface_surfaceshader;
                 node.parameters.clear();
+                changed = true;
             }
         }
 #endif
     }
+    return changed;
 }
 
 /*! \brief  Synchronize VP2 state with scene delegate state based on dirty bits
@@ -2375,7 +2386,10 @@ void HdVP2Material::Sync(
     HdRenderParam* /*renderParam*/,
     HdDirtyBits* dirtyBits)
 {
-    if (*dirtyBits & (HdMaterial::DirtyResource | HdMaterial::DirtyParams)) {
+    const HdDirtyBits materialDirtyBits
+        = *dirtyBits & (HdMaterial::DirtyResource | HdMaterial::DirtyParams);
+
+    if (materialDirtyBits != HdMaterial::Clean) {
         const SdfPath& id = GetId();
 
         MProfilingScope profilingScope(
@@ -2390,15 +2404,29 @@ void HdVP2Material::Sync(
             const HdMaterialNetworkMap& fullNetworkMap
                 = vtMatResource.UncheckedGet<HdMaterialNetworkMap>();
 
-            // untextured network is always synced
             HdMaterialNetworkMap untexturedNetworkMap = fullNetworkMap;
-            ConvertNetworkMapToUntextured(untexturedNetworkMap);
+            const bool didChangeUntextured = ConvertNetworkMapToUntextured(untexturedNetworkMap);
+
+            // If conversion changed the network, smoothHull must use kFull in textured mode;
+            // otherwise smoothHull can reuse kUntextured.
+            _texturedConfig = didChangeUntextured ? kFull : kUntextured;
+
+            // untextured network is always synced
             _compiledNetworks[kUntextured].Sync(sceneDelegate, untexturedNetworkMap);
 
-            // full network is synced only if required by display style
-            auto* const param = static_cast<HdVP2RenderParam*>(_renderDelegate->GetRenderParam());
-            if (param->GetDrawScene().NeedTexturedMaterials()) {
-                _compiledNetworks[kFull].Sync(sceneDelegate, fullNetworkMap);
+            // full network is synced only if it is distinct and required by display style
+            if (_texturedConfig == kFull) {
+                auto* const param
+                    = static_cast<HdVP2RenderParam*>(_renderDelegate->GetRenderParam());
+
+                if (param->GetDrawScene().NeedTexturedMaterials()) {
+                    _compiledNetworks[kFull].Sync(sceneDelegate, fullNetworkMap);
+                    _pendingFullNetworkDirtyBits = HdChangeTracker::Clean;
+                } else {
+                    // Textured display is currently off: do not sync kFull now.
+                    // Retain full network sprim dirtiness, replay it when textured is re-enabled.
+                    _pendingFullNetworkDirtyBits |= materialDirtyBits;
+                }
             }
         } else {
             TF_WARN(
@@ -4019,7 +4047,7 @@ MHWRender::MShaderInstance* HdVP2Material::CompiledNetwork::GetPointShader() con
 
 HdVP2Material::NetworkConfig HdVP2Material::_GetCompiledConfig(const TfToken& reprToken) const
 {
-    return (reprToken == HdReprTokens->smoothHull) ? kFull : kUntextured;
+    return (reprToken == HdReprTokens->smoothHull) ? _texturedConfig : kUntextured;
 }
 
 MHWRender::MShaderInstance*
@@ -4051,6 +4079,29 @@ void HdVP2Material::UnsubscribeFromMaterialUpdates(const SdfPath& rprimId)
     std::lock_guard<std::mutex> lock(_materialSubscriptionsMutex);
 
     _materialSubscriptions.erase(rprimId);
+}
+
+void HdVP2Material::TexturedDisplayModeEnabled(HdSceneDelegate* sceneDelegate)
+{
+    // If there is no distinct kFull network, deferred full-network replay is not needed.
+    if (_texturedConfig == kUntextured) {
+        return;
+    }
+
+    HdChangeTracker& changeTracker = sceneDelegate->GetRenderIndex().GetChangeTracker();
+
+    // Full network may be stale when coming from untextured display.
+    if (_pendingFullNetworkDirtyBits != HdChangeTracker::Clean) {
+        changeTracker.MarkSprimDirty(GetId(), _pendingFullNetworkDirtyBits);
+        _pendingFullNetworkDirtyBits = HdChangeTracker::Clean;
+    }
+
+    // Tell all the Rprims associated with this material to recompute primvars
+    // if the network changes.
+    std::lock_guard<std::mutex> lock(_materialSubscriptionsMutex);
+    for (const SdfPath& rprimId : _materialSubscriptions) {
+        changeTracker.MarkRprimDirty(rprimId, HdChangeTracker::DirtyMaterialId);
+    }
 }
 
 void HdVP2Material::MaterialChanged(HdSceneDelegate* sceneDelegate)

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.cpp
@@ -4087,21 +4087,15 @@ void HdVP2Material::TexturedDisplayModeEnabled(HdSceneDelegate* sceneDelegate)
     if (_texturedConfig == kUntextured) {
         return;
     }
-
-    HdChangeTracker& changeTracker = sceneDelegate->GetRenderIndex().GetChangeTracker();
-
     // Full network may be stale when coming from untextured display.
     if (_pendingFullNetworkDirtyBits != HdChangeTracker::Clean) {
+        HdChangeTracker& changeTracker = sceneDelegate->GetRenderIndex().GetChangeTracker();
         changeTracker.MarkSprimDirty(GetId(), _pendingFullNetworkDirtyBits);
         _pendingFullNetworkDirtyBits = HdChangeTracker::Clean;
     }
-
     // Tell all the Rprims associated with this material to recompute primvars
     // if the network changes.
-    std::lock_guard<std::mutex> lock(_materialSubscriptionsMutex);
-    for (const SdfPath& rprimId : _materialSubscriptions) {
-        changeTracker.MarkRprimDirty(rprimId, HdChangeTracker::DirtyMaterialId);
-    }
+    MaterialChanged(sceneDelegate);
 }
 
 void HdVP2Material::MaterialChanged(HdSceneDelegate* sceneDelegate)

--- a/lib/mayaUsd/render/vp2RenderDelegate/material.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/material.h
@@ -115,6 +115,9 @@ public:
     //! Trigger sync on all Rprims which are listening to changes on this material.
     void MaterialChanged(HdSceneDelegate* sceneDelegate);
 
+    //! Trigger sync on this material and subscribed Rprims when textured display is enabled.
+    void TexturedDisplayModeEnabled(HdSceneDelegate* sceneDelegate);
+
     class TextureLoadingTask;
     friend class TextureLoadingTask;
 
@@ -228,7 +231,14 @@ private:
     HdVP2RenderDelegate* const
         _renderDelegate; //!< VP2 render delegate for which this material was created
 
-    CompiledNetwork              _compiledNetworks[kNumNetworkConfigs];
+    CompiledNetwork _compiledNetworks[kNumNetworkConfigs];
+
+    //! smoothHull network selection: kFull when untextured networks differ, otherwise kUntextured.
+    NetworkConfig _texturedConfig = kFull;
+
+    //! Deferred dirtiness for kFull network, when textured display is off.
+    HdDirtyBits _pendingFullNetworkDirtyBits = 0;
+
     static HdVP2GlobalTextureMap _globalTextureMap; //!< Texture in use by all materials in MayaUSD
     HdVP2LocalTextureMap         _localTextureMap;  //!< Textures used by this material
 

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -1188,11 +1188,10 @@ void ProxyRenderDelegate::_Execute(const MHWRender::MFrameContext& frameContext)
             auto materials = _renderIndex->GetSprimSubtree(
                 HdPrimTypeTokens->material, SdfPath::AbsoluteRootPath());
             for (auto material : materials) {
-                changeTracker.MarkSprimDirty(material, HdMaterial::DirtyParams);
-                // Tell all the Rprims associated with this material to recompute primvars
                 HdVP2Material* vp2material = static_cast<HdVP2Material*>(
                     _renderIndex->GetSprim(HdPrimTypeTokens->material, material));
-                vp2material->MaterialChanged(_sceneDelegate.get());
+
+                vp2material->TexturedDisplayModeEnabled(_sceneDelegate.get());
             }
         }
 


### PR DESCRIPTION

In production scenes, our artists often use two viewports: one for interaction and one through the shot camera. These viewports frequently use different display modes (one textured, one untextured). In this setup, we see severe lag (multi-second stalls in some scenes) when the textured viewport refreshes after interaction in the non-textured viewport.

The main cost is in `ProxyRenderDelegate::_Execute(...)`, which triggers syncs for all material sprims and many rprims. In the production scene I am testing, this phase takes about 2 seconds.

This PR updates material invalidation and sync behavior based on viewport texture display mode, avoiding broad brute-force material updates. With this change, textured viewport refresh drops from ~2s to ~15ms in my test scene.

It reduces unnecessary resyncs by avoiding work on:
- `HdVP2Material` instances created from simple/untextured `HdMaterialNetworkMap` resources (single surface terminal), which are very common in large environments.
- `HdVP2Material::CompiledNetwork` objects that are already up to date from a previous `HdVP2Material::Sync`.

This is done by:
- Detecting when textured and untextured networks are equivalent, then syncing only one compiled network and avoiding unnecessary rprim `MaterialId` syncs.
- Deferring full-network dirty bits when networks differ and textured display is disabled.
- Applying only pending dirty bits when textured display is re-enabled, instead of dirtying all materials.

This should fix, or at least significantly improve #3832.
