### PR TITLE
Use fully qualified Qt enum names in Python

### DIFF
--- a/doc/codingGuidelines.md
+++ b/doc/codingGuidelines.md
@@ -299,8 +299,10 @@ We are adopting the [PEP-8](https://www.python.org/dev/peps/pep-0008) style for 
 
 [Pylint](https://www.pylint.org/) is recommended for automation.
 
+### Qt Enum Names
+Always use fully qualified enum names when accessing Qt enums in Python (e.g., `QtCore.Qt.AlignmentFlag.AlignLeft` instead of `QtCore.Qt.AlignLeft`). The shorter unqualified forms were deprecated in PyQt5/PySide2 and have been removed in PyQt6/PySide6, so using fully qualified names ensures forward compatibility.
 
-# Coding guidelines for CMake 
+# Coding guidelines for CMake
 ## Modern CMake
 1. Target Build and Usage requirements should be very clear.
 * build requirements ( everything that is needed to build the target )

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/expressionWidget.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/expressionWidget.py
@@ -48,19 +48,19 @@ class ExpressionWidget(QWidget):
 
         self._warningWidget = WarningWidget(menuWidget)
         self._warningSeparator = QFrame()
-        self._warningSeparator.setFrameShape(QFrame.VLine)
+        self._warningSeparator.setFrameShape(QFrame.Shape.VLine)
         self._warningSeparator.setMaximumHeight(Theme.instance().uiScaled(20))
         self._warningSeparator.setVisible(False)
         menuLayout.addWidget(self._warningWidget)
         menuLayout.addWidget(self._warningSeparator)
 
         menuLayout.addWidget(menuButton)
-        menuWidget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        menuWidget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
         self._expressionText = QTextEdit(self)
         self._expressionText.setLineWrapMode(QTextEdit.LineWrapMode.WidgetWidth)
         self._expressionText.setMinimumHeight(Theme.instance().uiScaled(80))
-        self._expressionText.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Ignored)
+        self._expressionText.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Ignored)
         self._expressionText.setPlaceholderText("Type an expression here...")
         self._expressionText.setAcceptRichText(False)
 
@@ -105,13 +105,13 @@ class ExpressionWidget(QWidget):
             self._expressionText.setPlainText(membershipExpression)
 
     def eventFilter(self, obj, event):
-        if event.type() == QEvent.KeyPress and obj is self._expressionText:
-            if event.key() == Qt.Key_Return or event.key() == Qt.Key_Enter:
+        if event.type() == QEvent.Type.KeyPress and obj is self._expressionText:
+            if event.key() == Qt.Key.Key_Return or event.key() == Qt.Key.Key_Enter:
                 self.submitExpression()
                 return True
         # For the case when they change prim without hitting enter;
         # or click somewhere else in the UI
-        elif event.type() == QEvent.FocusOut:
+        elif event.type() == QEvent.Type.FocusOut:
             self.submitExpression()
 
         return super().eventFilter(obj, event)

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/includeExcludeWidget.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/includeExcludeWidget.py
@@ -70,7 +70,7 @@ class IncludeExcludeWidget(QWidget):
         self._filterWidget.setClearButtonEnabled(True)
 
         separator = QFrame()
-        separator.setFrameShape(QFrame.VLine)
+        separator.setFrameShape(QFrame.Shape.VLine)
         separator.setMaximumHeight(Theme.instance().uiScaled(20))
 
         headerWidget = QWidget(self)
@@ -83,7 +83,7 @@ class IncludeExcludeWidget(QWidget):
         addBtn.setToolTip(theme.themeLabel(ADD_OBJECTS_TOOLTIP))
         addBtn.setStatusTip(theme.themeLabel(ADD_OBJECTS_TOOLTIP))
         addBtn.setIcon(theme.icon("add"))
-        addBtn.setPopupMode(QToolButton.InstantPopup)
+        addBtn.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         Theme.instance().themeMenuButton(addBtn, True)
         
         self._addBtnMenu = QMenu(addBtn)
@@ -100,7 +100,7 @@ class IncludeExcludeWidget(QWidget):
         self._deleteBtn.setToolTip(theme.themeLabel(REMOVE_OBJECTS_TOOLTIP))
         self._deleteBtn.setStatusTip(theme.themeLabel(REMOVE_OBJECTS_TOOLTIP))
         self._deleteBtn.setIcon(theme.icon("delete"))
-        self._deleteBtn.setPopupMode(QToolButton.InstantPopup)
+        self._deleteBtn.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         self._deleteBtn.setEnabled(False)
 
         self._deleteBtnMenu = QMenu(self._deleteBtn)
@@ -126,7 +126,7 @@ class IncludeExcludeWidget(QWidget):
         self._warningWidget = WarningWidget(headerWidget)
         self._warningWidget.setConflicted(self._collData.hasDataConflict())
         self._warningSeparator = QFrame()
-        self._warningSeparator.setFrameShape(QFrame.VLine)
+        self._warningSeparator.setFrameShape(QFrame.Shape.VLine)
         self._warningSeparator.setMaximumHeight(Theme.instance().uiScaled(20))
         self._warningSeparator.setVisible(False)
 
@@ -295,7 +295,7 @@ class IncludeExcludeWidget(QWidget):
         if includesSelected and excludeSelected:
             self._deleteBtn.setToolTip(theme.themeLabel(REMOVE_OBJECTS_TOOLTIP))
             self._deleteBtn.setStatusTip(theme.themeLabel(REMOVE_OBJECTS_TOOLTIP))
-            self._deleteBtn.setPopupMode(QToolButton.InstantPopup)
+            self._deleteBtn.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
             Theme.instance().themeMenuButton(self._deleteBtn, True)
         else:
             if includesSelected:
@@ -308,7 +308,7 @@ class IncludeExcludeWidget(QWidget):
                 self._deleteBtn.setStatusTip(theme.themeLabel(REMOVE_FROM_EXCLUDE_TOOLTIP))
                 self._deleteBtn.pressed.connect(self.onRemoveSelectionFromExclude)
                 self._deleteBtnPressedConnectedTo = self.onRemoveSelectionFromExclude
-            self._deleteBtn.setPopupMode(QToolButton.DelayedPopup)
+            self._deleteBtn.setPopupMode(QToolButton.ToolButtonPopupMode.DelayedPopup)
             Theme.instance().themeMenuButton(self._deleteBtn, False)
 
     def onIncludeAllToggle(self, checked: bool):

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/filteredStringListModel.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/filteredStringListModel.py
@@ -63,7 +63,7 @@ class FilteredStringListModel(QStringListModel):
         return True
     
     def setData(self, index, value, role):
-        if role == Qt.DisplayRole or role ==  Qt.ItemDataRole:
+        if role == Qt.ItemDataRole.DisplayRole or role ==  Qt.ItemDataRole:
             oldValue = self.data(index, role)
             value = value.strip()
             if value:

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/filteredStringListView.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/filteredStringListView.py
@@ -65,7 +65,7 @@ class FilteredStringDelegate(QItemDelegate):
         if editLine and self._listView:
             suggestions = self._listView.model()._collData.getSuggestions()
             self._completer = QCompleter(suggestions)
-            self._completer.setCaseSensitivity(Qt.CaseInsensitive)
+            self._completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
             self._completer.popup().setFrameStyle(QFrame.Shape.StyledPanel)
             itemDelegate = CompleterItemDelegate(self._completer)
             self._completer.popup().setItemDelegate(itemDelegate)
@@ -73,7 +73,7 @@ class FilteredStringDelegate(QItemDelegate):
         return editLine
 
     def setModelData(self, editor, model, index):
-        oldValue = model.data(index, Qt.DisplayRole)
+        oldValue = model.data(index, Qt.ItemDataRole.DisplayRole)
         newValue = editor.text().strip()
         if newValue:
             model._collData.replaceStrings(oldValue, newValue)
@@ -116,7 +116,7 @@ class FilteredStringListView(QListView):
         self.placeholder_label.setPalette(palette)
         self.placeholder_label.hide()
 
-        self.setCursor(Qt.ArrowCursor)
+        self.setCursor(Qt.CursorShape.ArrowCursor)
 
         DragAndDropAndDeleteEventFilter(self, data)
 
@@ -158,10 +158,10 @@ class FilteredStringListView(QListView):
             mimeData.setText("\n".join([index.data() for index in selectedIndexes]))
 
         drag.setMimeData(mimeData)
-        drag.exec(Qt.MoveAction)
+        drag.exec(Qt.DropAction.MoveAction)
 
     def selectedItems(self) -> Sequence[str]:
-        return [str(index.data(Qt.DisplayRole)) for index in self.selectedIndexes()]
+        return [str(index.data(Qt.ItemDataRole.DisplayRole)) for index in self.selectedIndexes()]
 
     def hasSelectedItems(self) -> bool:
         return bool(self.selectionModel().hasSelection())
@@ -176,7 +176,7 @@ class DragAndDropAndDeleteEventFilter(QObject):
         widget.setDropIndicatorShown(True)
 
     def eventFilter(self, obj: QObject, event: QEvent):
-        if event.type() == QEvent.Drop:
+        if event.type() == QEvent.Type.Drop:
             mime_data = event.mimeData()
             draggedItems = mime_data.text()
 
@@ -198,16 +198,16 @@ class DragAndDropAndDeleteEventFilter(QObject):
             self._collData.addMultiLineStrings(draggedItems)
 
             return True
-        elif event.type() == QEvent.DragEnter:
+        elif event.type() == QEvent.Type.DragEnter:
             event.acceptProposedAction()
             return True
-        elif event.type() == QEvent.DragMove:
+        elif event.type() == QEvent.Type.DragMove:
             event.acceptProposedAction()
             return True
-        elif event.type() == QEvent.KeyPress:
+        elif event.type() == QEvent.Type.KeyPress:
             # These are to prevent deleting the overall DCC selection when
             # an item in the listview is selected.
-            if event.key() == Qt.Key_Delete or event.key() == Qt.Key_Backspace:
+            if event.key() == Qt.Key.Key_Delete or event.key() == Qt.Key.Key_Backspace:
                 return True
 
         return super().eventFilter(obj, event)

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/menuButton.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/menuButton.py
@@ -10,9 +10,9 @@ class MenuButton(QToolButton):
     def __init__(self, menu: QMenu, parent: QWidget = None):
         super(MenuButton, self).__init__(parent)
         self.setIcon(Theme.instance().icon("menu"))
-        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         self.setMaximumWidth(Theme.instance().uiScaled(16))
-        self.setArrowType(Qt.NoArrow)
-        self.setPopupMode(QToolButton.InstantPopup)
+        self.setArrowType(Qt.ArrowType.NoArrow)
+        self.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
         Theme.instance().themeMenuButton(self, False)
         self.setMenu(menu)

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/persistentStorage.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/persistentStorage.py
@@ -26,7 +26,7 @@ class PersistentStorage(object):
         cls._instance = persistentStorage
 
     def _settings(self) -> QSettings:
-        return QSettings("settings.ini", QSettings.IniFormat)
+        return QSettings("settings.ini", QSettings.Format.IniFormat)
 
     def set(self, group: str, key: str, value: object):
         '''

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/resizable.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/resizable.py
@@ -26,16 +26,16 @@ class Resizable(QWidget):
             self._mousePressGlobalPosY: Union[int, None] = None
             self._resizeHandleMask: QRect = None
 
-            self.setWindowFlags(Qt.FramelessWindowHint)
-            self.setAttribute(Qt.WA_TranslucentBackground)
-            self.setAttribute(Qt.WA_NoSystemBackground)
-            self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+            self.setWindowFlags(Qt.WindowType.FramelessWindowHint)
+            self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+            self.setAttribute(Qt.WidgetAttribute.WA_NoSystemBackground)
+            self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
             self.setMinimumSize(
                 self.RESIZE_HANDLE_SIZE,
                 self.RESIZE_HANDLE_SIZE,
             )
             self.setMouseTracking(True)
-            self.setFocusPolicy(Qt.NoFocus)
+            self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
 
         def paintEvent(self, _):
             if self._active:
@@ -78,7 +78,7 @@ class Resizable(QWidget):
             self._active = value
             self._updateMask()
             self.update()
-            self.setCursor(Qt.SizeVerCursor if value else Qt.ArrowCursor)
+            self.setCursor(Qt.CursorShape.SizeVerCursor if value else Qt.CursorShape.ArrowCursor)
 
         def mouseMoveEvent(self, event):
             if self._mousePressGlobalPosY is not None:
@@ -130,12 +130,12 @@ class Resizable(QWidget):
     ):
         super(Resizable, self).__init__(parent)
 
-        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
         stackedLayout = QStackedLayout()
         stackedLayout.setContentsMargins(0, 0, 0, 0)
         stackedLayout.setSpacing(0)
-        stackedLayout.setStackingMode(QStackedLayout.StackAll)
+        stackedLayout.setStackingMode(QStackedLayout.StackingMode.StackAll)
 
         contentWidget = QWidget(self)
         self._contentLayout = QVBoxLayout(contentWidget)

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/stringListPanel.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/stringListPanel.py
@@ -93,16 +93,16 @@ class StringListPanel(QWidget):
             opt = QStyleOptionHeaderV2()
             opt.initFrom(self)
             opt.position = QStyleOptionHeaderV2.SectionPosition.Middle
-            opt.orientation = Qt.Horizontal
-            opt.state = QStyle.State_None | QStyle.State_Raised | QStyle.State_Horizontal
+            opt.orientation = Qt.Orientation.Horizontal
+            opt.state = QStyle.StateFlag.State_None | QStyle.StateFlag.State_Raised | QStyle.StateFlag.State_Horizontal
             opt.section = 0
             
             # adjust the rect to not draw the right border
             opt.rect.adjust(-1,0,1,0)
 
             if self.isEnabled():
-                opt.state |= QStyle.State_Enabled
+                opt.state |= QStyle.StateFlag.State_Enabled
             if self.isActiveWindow():
-                opt.state |= QStyle.State_Active
+                opt.state |= QStyle.StateFlag.State_Active
             opt.text = self._headerTitle
-            painter.drawControl(QStyle.CE_Header, opt)
+            painter.drawControl(QStyle.ControlElement.CE_Header, opt)

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/theme.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/common/theme.py
@@ -82,7 +82,7 @@ class Theme(object):
             theme = Theme.instance()
             for icon in icons:
                 svg_renderer = QtSvg.QSvgRenderer(os.path.join(iconFolder, icon))
-                image = QImage(theme.uiScaled(64), theme.uiScaled(64), QImage.Format_ARGB32)
+                image = QImage(theme.uiScaled(64), theme.uiScaled(64), QImage.Format.Format_ARGB32)
                 image.fill(0x00000000)
                 svg_renderer.render(QPainter(image))
                 pixmap = QPixmap.fromImage(image)
@@ -94,7 +94,7 @@ class Theme(object):
             icons = fnmatch.filter(os.listdir(iconFolder), f"{name}*.png")
             for icon in icons:
                 svg_renderer = QtSvg.QSvgRenderer(os.path.join(iconFolder, icon))
-                image = QImage(theme.uiScaled(64), theme.uiScaled(64), QImage.Format_ARGB32)
+                image = QImage(theme.uiScaled(64), theme.uiScaled(64), QImage.Format.Format_ARGB32)
                 image.fill(0x00000000)
                 svg_renderer.render(QPainter(image))
                 pixmap = QPixmap.fromImage(image)
@@ -108,7 +108,7 @@ class Theme(object):
     
     def themeTab(self, tab: QTabWidget):
         tab.setDocumentMode(True)
-        tab.tabBar().setCursor(Qt.ArrowCursor)
+        tab.tabBar().setCursor(Qt.CursorShape.ArrowCursor)
 
     def themeMenuButton(self, menuButton: QToolButton, showMenuIndicator: bool):
         if showMenuIndicator:
@@ -148,7 +148,7 @@ class Theme(object):
         """
 
         painter = QPainter(widget)
-        painter.setRenderHint(QPainter.Antialiasing, False)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, False)
         rect = widget.rect()
         rect.adjust(0, 0, 0, - self.resizableContentMargin())
         lineWidth: int = self.uiScaled(2)
@@ -158,8 +158,8 @@ class Theme(object):
             halfLineWidth = round(lineWidth / 2.0)
             rect.adjust(halfLineWidth, halfLineWidth, -halfLineWidth, -halfLineWidth)
 
-        painter.setPen(QPen(self.palette.colorResizeBorderActive, lineWidth, Qt.SolidLine, Qt.SquareCap, Qt.MiterJoin))
-        painter.setBrush(Qt.NoBrush)
+        painter.setPen(QPen(self.palette.colorResizeBorderActive, lineWidth, Qt.PenStyle.SolidLine, Qt.PenCapStyle.SquareCap, Qt.PenJoinStyle.MiterJoin))
+        painter.setBrush(Qt.BrushStyle.NoBrush)
         painter.drawRect(rect)
 
     def resizableActiveAreaSize(self) -> int:

--- a/plugin/adsk/scripts/mayaUsd_USDRootFileRelative.py
+++ b/plugin/adsk/scripts/mayaUsd_USDRootFileRelative.py
@@ -203,7 +203,7 @@ class usdFileRelative(object):
             # Find the accept button, so we can know when there is valid input in the file name edit field.
             buttonBox = maya_window.findChild(QDialogButtonBox, 'buttonBox')
             if buttonBox and cls._fileDialog:
-                btn = QDialogButtonBox.Open if (cls._fileDialog.acceptMode() == QFileDialog.AcceptOpen) else QDialogButtonBox.Save
+                btn = QDialogButtonBox.StandardButton.Open if (cls._fileDialog.acceptMode() == QFileDialog.AcceptMode.AcceptOpen) else QDialogButtonBox.StandardButton.Save
                 cls._acceptButton = buttonBox.button(btn)
 
             # Find the lookin combobox and connect to it so we know when user changes directories.

--- a/plugin/pxr/maya/lib/usdMaya/userExportedAttributesUI.py
+++ b/plugin/pxr/maya/lib/usdMaya/userExportedAttributesUI.py
@@ -458,17 +458,17 @@ class ExportedAttributesModel(QtCore.QAbstractTableModel):
                 'value in USD if the Maya node attribute stores it in double precision'
         ]
 
-        if role == QtCore.Qt.DisplayRole:
+        if role == QtCore.Qt.ItemDataRole.DisplayRole:
             return COLUMN_HEADERS[section]
-        elif role == QtCore.Qt.ToolTipRole:
+        elif role == QtCore.Qt.ItemDataRole.ToolTipRole:
             return COLUMN_TOOLTIPS[section]
 
         return None
 
-    def data(self, index, role=QtCore.Qt.DisplayRole):
+    def data(self, index, role=QtCore.Qt.ItemDataRole.DisplayRole):
         value = None
 
-        if not self._exportedAttrs or not index.isValid() or role != QtCore.Qt.DisplayRole:
+        if not self._exportedAttrs or not index.isValid() or role != QtCore.Qt.ItemDataRole.DisplayRole:
             return value
 
         row = index.row()
@@ -488,7 +488,7 @@ class ExportedAttributesModel(QtCore.QAbstractTableModel):
 
         return value
 
-    def setData(self, index, value, role=QtCore.Qt.EditRole):
+    def setData(self, index, value, role=QtCore.Qt.ItemDataRole.EditRole):
         if not self._exportedAttrs:
             return False
 
@@ -522,27 +522,27 @@ class ExportedAttributesModel(QtCore.QAbstractTableModel):
 
     def flags(self, index):
         if not index.isValid():
-            return QtCore.Qt.ItemIsDropEnabled
+            return QtCore.Qt.ItemFlag.ItemIsDropEnabled
 
-        itemFlags = (QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable)
+        itemFlags = (QtCore.Qt.ItemFlag.ItemIsEnabled | QtCore.Qt.ItemFlag.ItemIsSelectable)
 
         column = index.column()
         if column == ExportedAttributesModel.MAYA_ATTR_NAME_COLUMN:
-            itemFlags |= QtCore.Qt.ItemIsDragEnabled
+            itemFlags |= QtCore.Qt.ItemFlag.ItemIsDragEnabled
         elif (column == ExportedAttributesModel.USD_ATTR_TYPE_COLUMN or
                 column == ExportedAttributesModel.USD_ATTR_NAME_COLUMN):
-            itemFlags |= QtCore.Qt.ItemIsEditable
+            itemFlags |= QtCore.Qt.ItemFlag.ItemIsEditable
         elif column == ExportedAttributesModel.PRIMVAR_INTERPOLATION_COLUMN:
             # The primvar column is only editable if this is a primvar.
             exportedAttr = self._exportedAttrs[index.row()]
             if exportedAttr.usdAttrType == USD_ATTR_TYPE_PRIMVAR:
-                itemFlags |= QtCore.Qt.ItemIsEditable
+                itemFlags |= QtCore.Qt.ItemFlag.ItemIsEditable
         elif column == ExportedAttributesModel.DOUBLE_PRECISION_COLUMN:
             # The double-to-single precision column is only editable if the
             # Maya attribute stores double precision data.
             exportedAttr = self._exportedAttrs[index.row()]
             if _ShouldEnableDoublePrecisionEditor(exportedAttr.mayaAttrName):
-                itemFlags |= QtCore.Qt.ItemIsEditable
+                itemFlags |= QtCore.Qt.ItemFlag.ItemIsEditable
 
         return itemFlags
 
@@ -638,9 +638,9 @@ class AddAttributesModel(QStringListModel):
 
     def flags(self, index):
         if not index.isValid():
-            return QtCore.Qt.ItemIsDropEnabled
+            return QtCore.Qt.ItemFlag.ItemIsDropEnabled
 
-        return (QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable | QtCore.Qt.ItemIsDragEnabled)
+        return (QtCore.Qt.ItemFlag.ItemIsEnabled | QtCore.Qt.ItemFlag.ItemIsSelectable | QtCore.Qt.ItemFlag.ItemIsDragEnabled)
 
     def mimeTypes(self):
         return [ITEM_MIME_TYPE]
@@ -680,7 +680,7 @@ class AddAttributesView(QListView):
         super(AddAttributesView, self).__init__(parent=parent)
         self.setDragEnabled(True)
         self.setAcceptDrops(True)
-        self.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
 
     def dragEnterEvent(self, event):
         if event.source() == self:

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeLiveSurface.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeLiveSurface.py
@@ -95,8 +95,8 @@ class testProxyShapeLiveSurface(unittest.TestCase):
         cmds.setToolTo('CreatePolyTorusCtx')
 
         # Click in the center of the viewport widget.
-        QTest.mouseClick(self._viewWidget, QtCore.Qt.LeftButton,
-            QtCore.Qt.NoModifier, self._viewWidget.rect().center())
+        QTest.mouseClick(self._viewWidget, QtCore.Qt.MouseButton.LeftButton,
+            QtCore.Qt.KeyboardModifier.NoModifier, self._viewWidget.rect().center())
 
         # Find the torus (it should be called pTorus1).
         self.assertTrue(cmds.ls('pTorus1'))
@@ -123,8 +123,8 @@ class testProxyShapeLiveSurface(unittest.TestCase):
         cmds.setToolTo('CreatePolyConeCtx')
 
         # Click in the center of the viewport widget.
-        QTest.mouseClick(self._viewWidget, QtCore.Qt.LeftButton,
-            QtCore.Qt.NoModifier, self._viewWidget.rect().center())
+        QTest.mouseClick(self._viewWidget, QtCore.Qt.MouseButton.LeftButton,
+            QtCore.Qt.KeyboardModifier.NoModifier, self._viewWidget.rect().center())
 
         # Find the cone (it should be called pCone1).
         self.assertTrue(cmds.ls('pCone1'))

--- a/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeSelectionPerformance.py
+++ b/test/lib/mayaUsd/render/pxrUsdMayaGL/testProxyShapeSelectionPerformance.py
@@ -60,19 +60,19 @@ class testProxyShapeSelectionPerformance(unittest.TestCase):
 
     @staticmethod
     def _ClickInView(viewWidget, clickPosition,
-            keyboardModifier=QtCore.Qt.NoModifier):
+            keyboardModifier=QtCore.Qt.KeyboardModifier.NoModifier):
         clickPoint = QtCore.QPoint(clickPosition[0], clickPosition[1])
-        QTest.mouseClick(viewWidget, QtCore.Qt.LeftButton, keyboardModifier,
+        QTest.mouseClick(viewWidget, QtCore.Qt.MouseButton.LeftButton, keyboardModifier,
             clickPoint)
 
     @staticmethod
     def _SelectAreaInView(viewWidget, selectAreaRange,
-            keyboardModifier=QtCore.Qt.NoModifier):
+            keyboardModifier=QtCore.Qt.KeyboardModifier.NoModifier):
         pressPoint = QtCore.QPoint(selectAreaRange.min[0], selectAreaRange.min[1])
         releasePoint = QtCore.QPoint(selectAreaRange.max[0], selectAreaRange.max[1])
-        QTest.mousePress(viewWidget, QtCore.Qt.LeftButton, keyboardModifier,
+        QTest.mousePress(viewWidget, QtCore.Qt.MouseButton.LeftButton, keyboardModifier,
             pressPoint)
-        QTest.mouseRelease(viewWidget, QtCore.Qt.LeftButton, keyboardModifier,
+        QTest.mouseRelease(viewWidget, QtCore.Qt.MouseButton.LeftButton, keyboardModifier,
             releasePoint)
 
     @classmethod
@@ -302,7 +302,7 @@ class testProxyShapeSelectionPerformance(unittest.TestCase):
 
         with self._ProfileScope(profileScopeName):
             self._ClickInView(self._viewWidget, clickPosition,
-                keyboardModifier=QtCore.Qt.ShiftModifier)
+                keyboardModifier=QtCore.Qt.KeyboardModifier.ShiftModifier)
 
         self._WriteViewportImage(self._testName, 'selection_append_1')
 
@@ -313,7 +313,7 @@ class testProxyShapeSelectionPerformance(unittest.TestCase):
 
         with self._ProfileScope(profileScopeName):
             self._ClickInView(self._viewWidget, clickPosition,
-                keyboardModifier=QtCore.Qt.ShiftModifier)
+                keyboardModifier=QtCore.Qt.KeyboardModifier.ShiftModifier)
 
         self._WriteViewportImage(self._testName, 'selection_append_2')
 
@@ -324,7 +324,7 @@ class testProxyShapeSelectionPerformance(unittest.TestCase):
 
         with self._ProfileScope(profileScopeName):
             self._ClickInView(self._viewWidget, clickPosition,
-                keyboardModifier=QtCore.Qt.ShiftModifier)
+                keyboardModifier=QtCore.Qt.KeyboardModifier.ShiftModifier)
 
         self._WriteViewportImage(self._testName, 'selection_append_3')
 
@@ -335,7 +335,7 @@ class testProxyShapeSelectionPerformance(unittest.TestCase):
 
         with self._ProfileScope(profileScopeName):
             self._ClickInView(self._viewWidget, clickPosition,
-                keyboardModifier=QtCore.Qt.ShiftModifier)
+                keyboardModifier=QtCore.Qt.KeyboardModifier.ShiftModifier)
 
         self._WriteViewportImage(self._testName, 'selection_append_4')
 

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegatePointInstancesPickMode.py
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegatePointInstancesPickMode.py
@@ -103,8 +103,8 @@ class testVP2RenderDelegatePointInstancesPickMode(imageUtils.ImageDiffingTestCas
         view = OMUI.M3dView.active3dView()
         viewWidget = wrapInstance(int(view.widget()), QWidget)
 
-        QTest.mouseClick(viewWidget, QtCore.Qt.LeftButton,
-            QtCore.Qt.NoModifier, viewWidget.rect().center())
+        QTest.mouseClick(viewWidget, QtCore.Qt.MouseButton.LeftButton,
+            QtCore.Qt.KeyboardModifier.NoModifier, viewWidget.rect().center())
 
     def assertSnapshotClose(self, imageName):
         baselineImage = os.path.join(self._baselineDir, imageName)

--- a/test/lib/mayaUsd/utils/testUtilsSelectability.py
+++ b/test/lib/mayaUsd/utils/testUtilsSelectability.py
@@ -65,7 +65,7 @@ class testUtilsSelectability(unittest.TestCase):
         '''
         Helper that forces Maya to process events.
         '''
-        QtCore.QCoreApplication.processEvents(QtCore.QEventLoop.AllEvents, timeout)
+        QtCore.QCoreApplication.processEvents(QtCore.QEventLoop.ProcessEventsFlag.AllEvents, timeout)
 
     def _dragSelectActiveView(self):
         '''
@@ -77,11 +77,11 @@ class testUtilsSelectability(unittest.TestCase):
         viewWidget.update()
         self._processViewEvents()
 
-        QTest.mousePress(viewWidget, QtCore.Qt.LeftButton,
-                    QtCore.Qt.NoModifier, viewWidget.rect().topLeft() + QtCore.QPoint(1, 1))
+        QTest.mousePress(viewWidget, QtCore.Qt.MouseButton.LeftButton,
+                    QtCore.Qt.KeyboardModifier.NoModifier, viewWidget.rect().topLeft() + QtCore.QPoint(1, 1))
         QTest.mouseMove(viewWidget, viewWidget.rect().bottomRight() - QtCore.QPoint(1,1))
-        QTest.mouseRelease(viewWidget, QtCore.Qt.LeftButton,
-            QtCore.Qt.NoModifier, viewWidget.rect().bottomRight() - QtCore.QPoint(1, 1))
+        QTest.mouseRelease(viewWidget, QtCore.Qt.MouseButton.LeftButton,
+            QtCore.Qt.KeyboardModifier.NoModifier, viewWidget.rect().bottomRight() - QtCore.QPoint(1, 1))
 
     def _createLayer(self):
         '''

--- a/test/lib/mayaUsd/utils/testUtilsSelectabilityPointInstanceSelection.py
+++ b/test/lib/mayaUsd/utils/testUtilsSelectabilityPointInstanceSelection.py
@@ -108,7 +108,7 @@ class testUtilsSelectabilityPointInstanceSelection(unittest.TestCase):
         '''
         Helper that forces Maya to process events.
         '''
-        QtCore.QCoreApplication.processEvents(QtCore.QEventLoop.AllEvents, timeout)
+        QtCore.QCoreApplication.processEvents(QtCore.QEventLoop.ProcessEventsFlag.AllEvents, timeout)
 
     def _dragSelectActiveView(self):
         '''
@@ -120,11 +120,11 @@ class testUtilsSelectabilityPointInstanceSelection(unittest.TestCase):
         viewWidget.update()
         self._processViewEvents()
 
-        QTest.mousePress(viewWidget, QtCore.Qt.LeftButton,
-                    QtCore.Qt.NoModifier, viewWidget.rect().topLeft() + QtCore.QPoint(1, 1))
+        QTest.mousePress(viewWidget, QtCore.Qt.MouseButton.LeftButton,
+                    QtCore.Qt.KeyboardModifier.NoModifier, viewWidget.rect().topLeft() + QtCore.QPoint(1, 1))
         QTest.mouseMove(viewWidget, viewWidget.rect().bottomRight() - QtCore.QPoint(1,1))
-        QTest.mouseRelease(viewWidget, QtCore.Qt.LeftButton,
-            QtCore.Qt.NoModifier, viewWidget.rect().bottomRight() - QtCore.QPoint(1, 1))
+        QTest.mouseRelease(viewWidget, QtCore.Qt.MouseButton.LeftButton,
+            QtCore.Qt.KeyboardModifier.NoModifier, viewWidget.rect().bottomRight() - QtCore.QPoint(1, 1))
 
     @staticmethod
     def _GetUfePath(instanceIndex=-1):

--- a/tutorials/import-export-plugin/ExampleExportPlugin.py
+++ b/tutorials/import-export-plugin/ExampleExportPlugin.py
@@ -142,7 +142,7 @@ def showUi(jobContext, parentUIName, settings):
         container = QtW.QWidget()
         rowLayout.addWidget(container)
 
-        buttonBox = QtW.QDialogButtonBox(QtW.QDialogButtonBox.Ok | QtW.QDialogButtonBox.Cancel)
+        buttonBox = QtW.QDialogButtonBox(QtW.QDialogButtonBox.StandardButton.Ok | QtW.QDialogButtonBox.StandardButton.Cancel)
         rowLayout.addWidget(buttonBox)
 
         def accept():


### PR DESCRIPTION
PyQt6 and PySide6 expose C++ enums as Python `enum.Enum`s, dropping the shorter path that matches the namespace of the enum in C++. For instance, where `QtEvent::Type` values are non-scoped enums in C++, e.g. `QtEvent::Type { KeyPress }` is `QtEvent::KeyPress`. This was exposed in PyQt5/PySide2 as `QtEvent.KeyPress` _and_ `QtEvent.Type.KeyPress` in preparation for a switch to use Python enums. In PyQt6/PySide6 this enum member is only available as `QtEvent.Type.KeyPress`.

This change updates all Qt enum usage in Python to use the fully-qualified names, which is backwards-compatible with PyQt5/PySide2.