### PR TITLE
EMSUSD-3077 - Stitch Layers

### DIFF
--- a/lib/mayaUsd/commands/abstractLayerEditorWindow.h
+++ b/lib/mayaUsd/commands/abstractLayerEditorWindow.h
@@ -106,6 +106,7 @@ public:
     virtual void updateLayerModel() = 0;
     virtual void lockLayer() = 0;
     virtual void lockLayerAndSubLayers() = 0;
+    virtual void stitchLayers() = 0;
 
     virtual void                     selectProxyShape(const char* shapePath) = 0;
     virtual std::vector<std::string> getSelectedLayers() = 0;

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -796,8 +796,12 @@ public:
 class StitchLayers : public BackupLayerBase
 {
 public:
-    StitchLayers()
+    StitchLayers(
+        const std::vector<std::string>& layerIdentifiers,
+        const std::string&              newParentLayer)
         : BackupLayerBase(CmdId::kStitchLayers)
+        , _layerIdentifiersByStrength(layerIdentifiers)
+        , _proxyShapePath(newParentLayer)
     {
     }
 
@@ -806,19 +810,19 @@ public:
         if (_layerIdentifiersByStrength.empty())
             return true;
 
-        auto prim = UsdMayaQuery::GetPrim(_proxyShapePath.c_str());
+        const auto prim = UsdMayaQuery::GetPrim(_proxyShapePath.c_str());
         if (!prim.IsValid()) {
             TF_RUNTIME_ERROR("Invalid proxy shape path: %s", _proxyShapePath.c_str());
             return false;
         }
 
-        UsdStageWeakPtr stage = prim.GetStage();
+        const UsdStageWeakPtr stage = prim.GetStage();
         if (!stage) {
             TF_RUNTIME_ERROR("Cannot get stage for proxy shape: %s", _proxyShapePath.c_str());
             return false;
         }
 
-        SdfLayerHandleVector stageLayers = stage->GetLayerStack();
+        const SdfLayerHandleVector stageLayers = stage->GetLayerStack();
 
         // Sort the selected layers by their strength (strongest first).
         std::unordered_map<std::string, size_t> layerStrengthMap;
@@ -830,8 +834,8 @@ public:
             _layerIdentifiersByStrength.begin(),
             _layerIdentifiersByStrength.end(),
             [&layerStrengthMap](const std::string& a, const std::string& b) {
-                auto itA = layerStrengthMap.find(a);
-                auto itB = layerStrengthMap.find(b);
+                const auto itA = layerStrengthMap.find(a);
+                const auto itB = layerStrengthMap.find(b);
                 if (itA == layerStrengthMap.end()) {
                     TF_WARN("Layer '%s' not found in stage layer stack", a.c_str());
                     return false;
@@ -854,7 +858,7 @@ public:
             layersByStrength.push_back(layer);
         }
 
-        SdfLayerHandle strongestLayer = layersByStrength[0];
+        const SdfLayerHandle strongestLayer = layersByStrength[0];
 
         holdOntoSubLayers(strongestLayer);
 
@@ -882,7 +886,7 @@ public:
             const SdfLayerHandle& weakLayer = layersByStrength[i];
             const std::string     weakLayerId = weakLayer->GetIdentifier();
 
-            auto it = parentInfoByLayer.find(weakLayerId);
+            const auto& it = parentInfoByLayer.find(weakLayerId);
             if (it != parentInfoByLayer.end()) {
                 removalsByParent[it->second.first->GetIdentifier()].push_back(it->second.second);
             } else {
@@ -935,7 +939,7 @@ public:
 
             std::set<std::string> addedSublayerIds;
             for (const auto path : strongLayerSubLayers) {
-                auto existingLayer = SdfLayer::FindRelativeToLayer(strongestLayer, path);
+                const auto existingLayer = SdfLayer::FindRelativeToLayer(strongestLayer, path);
                 if (existingLayer) {
                     addedSublayerIds.insert(existingLayer->GetIdentifier());
                 }
@@ -943,7 +947,8 @@ public:
 
             for (const auto& subLayerList : movedSubLayers) {
                 for (const auto& subLayerPath : subLayerList) {
-                    auto subLayer = SdfLayer::FindRelativeToLayer(strongestLayer, subLayerPath);
+                    const auto subLayer
+                        = SdfLayer::FindRelativeToLayer(strongestLayer, subLayerPath);
                     if (subLayer
                         && addedSublayerIds.find(subLayer->GetIdentifier())
                             == addedSublayerIds.end()) {
@@ -961,7 +966,8 @@ public:
             bool anyRemoved = false;
             for (size_t i = 1; i < layersByStrength.size(); ++i) {
                 const std::string weakLayerId = layersByStrength[i]->GetIdentifier();
-                auto it = std::find(dedupedSubLayers.begin(), dedupedSubLayers.end(), weakLayerId);
+                const auto        it
+                    = std::find(dedupedSubLayers.begin(), dedupedSubLayers.end(), weakLayerId);
                 if (it != dedupedSubLayers.end()) {
                     dedupedSubLayers.erase(it);
                     anyRemoved = true;
@@ -971,7 +977,7 @@ public:
                 strongestLayer->SetSubLayerPaths(dedupedSubLayers);
 
             for (auto& entry : removalsByParent) {
-                auto parentLayer = SdfLayer::Find(entry.first);
+                const auto parentLayer = SdfLayer::Find(entry.first);
                 if (parentLayer) {
                     auto subLayerPaths = parentLayer->GetSubLayerPaths();
                     for (const auto& pathToRemove : entry.second) {
@@ -1010,13 +1016,13 @@ public:
         return true;
     }
 
-    std::vector<std::string> _layerIdentifiersByStrength;
-    std::string              _proxyShapePath;
 
 private:
     UsdUfe::UsdUndoableItem  _undoItem;
     std::vector<std::string> _cleanParentIds;
     std::vector<std::string> _cleanWeakLayerIds;
+    std::vector<std::string> _layerIdentifiersByStrength;
+    std::string              _proxyShapePath;
 };
 
 class MuteLayer : public BaseCmd
@@ -1719,7 +1725,7 @@ MStatus LayerEditorCommand::parseArgs(const MArgList& argList)
         }
         if (argParser.isFlagSet(kStitchLayersFlag)) {
             std::vector<std::string> layerIdentifiers;
-            auto                     layerCount = argParser.numberOfFlagUses(kStitchLayersFlag);
+            const auto               layerCount = argParser.numberOfFlagUses(kStitchLayersFlag);
             MString                  proxyShapeName;
 
             for (unsigned i = 0; i < layerCount; ++i) {
@@ -1729,20 +1735,19 @@ MStatus LayerEditorCommand::parseArgs(const MArgList& argList)
                 if (i == 0)
                     proxyShapeName = listOfArgs.asString(0);
 
-                MString layerIdentifier = listOfArgs.asString(1);
+                const MString layerIdentifier = listOfArgs.asString(1);
                 layerIdentifiers.push_back(layerIdentifier.asChar());
             }
 
-            UsdPrim prim = UsdMayaQuery::GetPrim(proxyShapeName.asChar());
+            const UsdPrim prim = UsdMayaQuery::GetPrim(proxyShapeName.asChar());
             if (prim == UsdPrim()) {
                 displayError(
                     MString("Invalid proxy shape \"") + MString(proxyShapeName.asChar()) + "\"");
                 return MS::kInvalidParameter;
             }
 
-            auto cmd = std::make_shared<Impl::StitchLayers>();
-            cmd->_layerIdentifiersByStrength = layerIdentifiers;
-            cmd->_proxyShapePath = proxyShapeName.asChar();
+            const auto cmd
+                = std::make_shared<Impl::StitchLayers>(layerIdentifiers, proxyShapeName.asChar());
 
             _subCommands.push_back(std::move(cmd));
         }

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -934,7 +934,8 @@ public:
             }
 
             // Add all collected subLayers to the strongest layer, preventing duplicates.
-            // They are added at the end (weakest position) to preserve relative strength.
+            // Non-selected weak subLayers are added to the end of the subPathList of the strongestLayer.
+            // Note: This means there are cases where relative strength is not fully preserved.
             auto strongLayerSubLayers = strongestLayer->GetSubLayerPaths();
 
             std::set<std::string> addedSublayerIds;

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -26,6 +26,9 @@
 #include <mayaUsd/utils/utilFileSystem.h>
 
 #include <usdUfe/ufe/Utils.h>
+#include <usdUfe/undo/UsdUndoBlock.h>
+#include <usdUfe/undo/UsdUndoManager.h>
+#include <usdUfe/undo/UsdUndoableItem.h>
 #include <usdUfe/utils/uiCallback.h>
 
 #include <pxr/base/tf/diagnostic.h>
@@ -34,6 +37,7 @@
 #include <pxr/usd/usd/flattenUtils.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usdUtils/stitch.h>
 
 #include <maya/MArgList.h>
 #include <maya/MArgParser.h>
@@ -46,8 +50,13 @@
 
 #include <ghc/filesystem.hpp>
 
+#include <algorithm>
 #include <cstddef>
+#include <map>
+#include <set>
 #include <string>
+#include <unordered_map>
+#include <utility>
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -76,6 +85,8 @@ const char kSkipSystemLockedFlag[] = "ssl";
 const char kSkipSystemLockedFlagL[] = "skipSystemLocked";
 const char kRefreshSystemLockFlag[] = "rl";
 const char kRefreshSystemLockFlagL[] = "refreshSystemLock";
+const char kStitchLayersFlag[] = "sl";
+const char kStitchLayersFlagL[] = "stitchLayers";
 
 // Disables updateEditTarget's functionality is set.
 // Areas that will be affected are:
@@ -104,7 +115,8 @@ enum class CmdId
     kAddAnonLayer,
     kMuteLayer,
     kLockLayer,
-    kRefreshSystemLock
+    kRefreshSystemLock,
+    kStitchLayers
 };
 
 class BaseCmd
@@ -122,7 +134,7 @@ public:
 
 protected:
     CmdId _cmdId;
-    // we need to hold on to dirty sublayers if we remove them
+    // we need to hold on to dirty subLayers if we remove them
     std::vector<PXR_NS::SdfLayerRefPtr> _subLayersRefs;
     void                                holdOntoSubLayers(SdfLayerHandle layer);
     void                                releaseSubLayers() { _subLayersRefs.clear(); }
@@ -672,32 +684,7 @@ public:
         return true;
     }
 
-private:
-    // Backup dirty layer to support undo and redo.
-    void backupLayer(SdfLayerHandle layer)
-    {
-        if (!layer)
-            return;
-
-        if (layer->IsDirty() || _cmdId == CmdId::kClearLayer) {
-            _backupLayer = SdfLayer::CreateAnonymous();
-            _backupLayer->TransferContent(layer);
-        }
-    }
-
-    void restoreLayer(SdfLayerHandle layer)
-    {
-        if (!layer)
-            return;
-
-        if (_backupLayer) {
-            layer->TransferContent(_backupLayer);
-            _backupLayer = nullptr;
-        } else {
-            layer->Reload();
-        }
-    }
-
+protected:
     // Backup and restore edit targets of stages that were targeting the sub-layers
     // of the cleared layer to support undo and redo.
     void backupEditTargets(SdfLayerHandle layer)
@@ -745,6 +732,32 @@ private:
         }
     }
 
+private:
+    // Backup dirty layer to support undo and redo.
+    void backupLayer(SdfLayerHandle layer)
+    {
+        if (!layer)
+            return;
+
+        if (layer->IsDirty() || _cmdId != CmdId::kDiscardEdit) {
+            _backupLayer = SdfLayer::CreateAnonymous();
+            _backupLayer->TransferContent(layer);
+        }
+    }
+
+    void restoreLayer(SdfLayerHandle layer)
+    {
+        if (!layer)
+            return;
+
+        if (_backupLayer) {
+            layer->TransferContent(_backupLayer);
+            _backupLayer = nullptr;
+        } else {
+            layer->Reload();
+        }
+    }
+
     // Edit targets that were made invalid after the layer was cleared.
     // The stages are kept with weak pointer to avoid forcing to stay valid.
     using EditTargetBackups = std::map<PXR_NS::UsdStagePtr, PXR_NS::UsdEditTarget>;
@@ -778,6 +791,232 @@ public:
         : BackupLayerBase(CmdId::kFlattenLayer)
     {
     }
+};
+
+class StitchLayers : public BackupLayerBase
+{
+public:
+    StitchLayers()
+        : BackupLayerBase(CmdId::kStitchLayers)
+    {
+    }
+
+    bool doIt(SdfLayerHandle /*targetLayer*/) override
+    {
+        if (_layerIdentifiersByStrength.empty())
+            return true;
+
+        auto prim = UsdMayaQuery::GetPrim(_proxyShapePath.c_str());
+        if (!prim.IsValid()) {
+            TF_RUNTIME_ERROR("Invalid proxy shape path: %s", _proxyShapePath.c_str());
+            return false;
+        }
+
+        UsdStageWeakPtr stage = prim.GetStage();
+        if (!stage) {
+            TF_RUNTIME_ERROR("Cannot get stage for proxy shape: %s", _proxyShapePath.c_str());
+            return false;
+        }
+
+        SdfLayerHandleVector stageLayers = stage->GetLayerStack();
+
+        // Sort the selected layers by their strength (strongest first).
+        std::unordered_map<std::string, size_t> layerStrengthMap;
+        layerStrengthMap.reserve(stageLayers.size());
+        for (size_t i = 0; i < stageLayers.size(); ++i)
+            layerStrengthMap[stageLayers[i]->GetIdentifier()] = i;
+
+        std::sort(
+            _layerIdentifiersByStrength.begin(),
+            _layerIdentifiersByStrength.end(),
+            [&layerStrengthMap](const std::string& a, const std::string& b) {
+                auto itA = layerStrengthMap.find(a);
+                auto itB = layerStrengthMap.find(b);
+                if (itA == layerStrengthMap.end()) {
+                    TF_WARN("Layer '%s' not found in stage layer stack", a.c_str());
+                    return false;
+                }
+                if (itB == layerStrengthMap.end()) {
+                    TF_WARN("Layer '%s' not found in stage layer stack", b.c_str());
+                    return true;
+                }
+                return itA->second < itB->second;
+            });
+
+        SdfLayerHandleVector layersByStrength;
+        layersByStrength.reserve(_layerIdentifiersByStrength.size());
+        for (const auto& layerIdentifier : _layerIdentifiersByStrength) {
+            auto layer = SdfLayer::FindOrOpen(layerIdentifier);
+            if (!layer) {
+                TF_RUNTIME_ERROR("Cannot find layer: %s", layerIdentifier.c_str());
+                return false;
+            }
+            layersByStrength.push_back(layer);
+        }
+
+        SdfLayerHandle strongestLayer = layersByStrength[0];
+
+        holdOntoSubLayers(strongestLayer);
+
+        // Keep a hold of references for all selected layers, needed for undo().
+        for (size_t i = 1; i < layersByStrength.size(); ++i)
+            _subLayersRefs.push_back(layersByStrength[i]);
+
+        std::map<std::string, std::pair<SdfLayerHandle, std::string>> parentInfoByLayer;
+        for (const auto& potentialParent : stageLayers) {
+            const std::vector<std::string>& subLayerPaths = potentialParent->GetSubLayerPaths();
+            for (size_t i = 0; i < subLayerPaths.size(); ++i) {
+                auto subLayer = SdfLayer::FindRelativeToLayer(potentialParent, subLayerPaths[i]);
+                if (subLayer) {
+                    parentInfoByLayer[subLayer->GetIdentifier()]
+                        = std::make_pair(potentialParent, subLayerPaths[i]);
+                }
+            }
+        }
+
+        // Multiple selected weak layers may share the same parent, so batch removals by parent
+        // to avoid calling SetSubLayerPaths more than once per parent layer.
+        std::map<std::string, std::vector<std::string>> removalsByParent;
+        _cleanWeakLayerIds.clear();
+        for (size_t i = 1; i < layersByStrength.size(); ++i) {
+            const SdfLayerHandle& weakLayer = layersByStrength[i];
+            const std::string     weakLayerId = weakLayer->GetIdentifier();
+
+            auto it = parentInfoByLayer.find(weakLayerId);
+            if (it != parentInfoByLayer.end()) {
+                removalsByParent[it->second.first->GetIdentifier()].push_back(it->second.second);
+            } else {
+                TF_WARN("Could not find parent for layer: %s", weakLayerId.c_str());
+            }
+
+            if (!weakLayer->IsDirty())
+                _cleanWeakLayerIds.push_back(weakLayerId);
+        }
+
+        _cleanParentIds.clear();
+        for (const auto& entry : removalsByParent) {
+            if (auto parentLayer = SdfLayer::Find(entry.first))
+                if (!parentLayer->IsDirty())
+                    _cleanParentIds.push_back(entry.first);
+        }
+
+        const std::string strongestLayerId = strongestLayer->GetIdentifier();
+        if (!strongestLayer->IsDirty()) {
+            auto it = std::find(_cleanParentIds.begin(), _cleanParentIds.end(), strongestLayerId);
+            if (it == _cleanParentIds.end())
+                _cleanParentIds.push_back(strongestLayerId);
+        }
+
+        UsdUfe::UsdUndoManager::instance().trackLayerStates(strongestLayer);
+        for (size_t i = 1; i < layersByStrength.size(); ++i)
+            UsdUfe::UsdUndoManager::instance().trackLayerStates(layersByStrength[i]);
+        for (const auto& entry : removalsByParent) {
+            auto parentLayer = SdfLayer::Find(entry.first);
+            if (parentLayer) {
+                UsdUfe::UsdUndoManager::instance().trackLayerStates(parentLayer);
+            }
+        }
+
+        {
+            UsdUfe::UsdUndoBlock undoBlock(&_undoItem);
+
+            std::vector<std::vector<std::string>> movedSubLayers;
+            movedSubLayers.reserve(layersByStrength.size() - 1);
+            for (size_t i = 1; i < layersByStrength.size(); ++i) {
+                const SdfLayerHandle& weakLayer = layersByStrength[i];
+                movedSubLayers.push_back(weakLayer->GetSubLayerPaths());
+                weakLayer->SetSubLayerPaths({});
+                UsdUtilsStitchLayers(strongestLayer, weakLayer);
+            }
+
+            // Add all collected subLayers to the strongest layer, preventing duplicates.
+            // They are added at the end (weakest position) to preserve relative strength.
+            auto strongLayerSubLayers = strongestLayer->GetSubLayerPaths();
+
+            std::set<std::string> addedSublayerIds;
+            for (const auto path : strongLayerSubLayers) {
+                auto existingLayer = SdfLayer::FindRelativeToLayer(strongestLayer, path);
+                if (existingLayer) {
+                    addedSublayerIds.insert(existingLayer->GetIdentifier());
+                }
+            }
+
+            for (const auto& subLayerList : movedSubLayers) {
+                for (const auto& subLayerPath : subLayerList) {
+                    auto subLayer = SdfLayer::FindRelativeToLayer(strongestLayer, subLayerPath);
+                    if (subLayer
+                        && addedSublayerIds.find(subLayer->GetIdentifier())
+                            == addedSublayerIds.end()) {
+                        strongLayerSubLayers.push_back(subLayerPath);
+                        addedSublayerIds.insert(subLayer->GetIdentifier());
+                    }
+                }
+            }
+
+            strongestLayer->SetSubLayerPaths(strongLayerSubLayers);
+
+            // Remove any selected weak layers from the strongest layer's sublayer list to prevent
+            // them from being both stitched (merged) and referenced as subLayers.
+            auto dedupedSubLayers = strongestLayer->GetSubLayerPaths();
+            bool anyRemoved = false;
+            for (size_t i = 1; i < layersByStrength.size(); ++i) {
+                const std::string weakLayerId = layersByStrength[i]->GetIdentifier();
+                auto it = std::find(dedupedSubLayers.begin(), dedupedSubLayers.end(), weakLayerId);
+                if (it != dedupedSubLayers.end()) {
+                    dedupedSubLayers.erase(it);
+                    anyRemoved = true;
+                }
+            }
+            if (anyRemoved)
+                strongestLayer->SetSubLayerPaths(dedupedSubLayers);
+
+            for (auto& entry : removalsByParent) {
+                auto parentLayer = SdfLayer::Find(entry.first);
+                if (parentLayer) {
+                    auto subLayerPaths = parentLayer->GetSubLayerPaths();
+                    for (const auto& pathToRemove : entry.second) {
+                        auto it
+                            = std::find(subLayerPaths.begin(), subLayerPaths.end(), pathToRemove);
+                        if (it != subLayerPaths.end())
+                            subLayerPaths.erase(it);
+                    }
+                    parentLayer->SetSubLayerPaths(subLayerPaths);
+                }
+            }
+        }
+
+        backupEditTargets(strongestLayer);
+
+        return true;
+    }
+
+    bool undoIt(SdfLayerHandle /*targetLayer*/) override
+    {
+        _undoItem.undo();
+
+        for (const auto& id : _cleanParentIds) {
+            if (auto layer = SdfLayer::Find(id))
+                layer->Reload();
+        }
+
+        for (const auto& id : _cleanWeakLayerIds) {
+            if (auto layer = SdfLayer::Find(id))
+                layer->Reload();
+        }
+
+        restoreEditTargets();
+        releaseSubLayers();
+
+        return true;
+    }
+
+    std::vector<std::string> _layerIdentifiersByStrength;
+    std::string              _proxyShapePath;
+
+private:
+    UsdUfe::UsdUndoableItem  _undoItem;
+    std::vector<std::string> _cleanParentIds;
+    std::vector<std::string> _cleanWeakLayerIds;
 };
 
 class MuteLayer : public BaseCmd
@@ -1088,7 +1327,7 @@ private:
         return std::string(" \"") + string + std::string("\"");
     }
 
-    // Checks if the file layer or its sublayers are accessible on disk, and adds the layer
+    // Checks if the file layer or its subLayer are accessible on disk, and adds the layer
     // to _layers along with the _lockCommands to updates the system-lock status.
     void _refreshLayerSystemLock(SdfLayerHandle usdLayer)
     {
@@ -1269,6 +1508,10 @@ MSyntax LayerEditorCommand::createSyntax()
     syntax.addFlag(
         kRefreshSystemLockFlag, kRefreshSystemLockFlagL, MSyntax::kString, MSyntax::kBoolean);
     syntax.addFlag(kSkipSystemLockedFlag, kSkipSystemLockedFlagL);
+    // parameter 1: proxy shape name
+    // parameter 2: layer identifier
+    syntax.addFlag(kStitchLayersFlag, kStitchLayersFlagL, MSyntax::kString, MSyntax::kString);
+    syntax.makeFlagMultiUse(kStitchLayersFlag);
 
     return syntax;
 }
@@ -1472,6 +1715,35 @@ MStatus LayerEditorCommand::parseArgs(const MArgList& argList)
             auto cmd = std::make_shared<Impl::RefreshSystemLockLayer>();
             cmd->_proxyShapePath = proxyShapeName.asChar();
             cmd->_refreshSubLayers = refreshSubLayers;
+            _subCommands.push_back(std::move(cmd));
+        }
+        if (argParser.isFlagSet(kStitchLayersFlag)) {
+            std::vector<std::string> layerIdentifiers;
+            auto                     layerCount = argParser.numberOfFlagUses(kStitchLayersFlag);
+            MString                  proxyShapeName;
+
+            for (unsigned i = 0; i < layerCount; ++i) {
+                MArgList listOfArgs;
+                argParser.getFlagArgumentList(kStitchLayersFlag, i, listOfArgs);
+
+                if (i == 0)
+                    proxyShapeName = listOfArgs.asString(0);
+
+                MString layerIdentifier = listOfArgs.asString(1);
+                layerIdentifiers.push_back(layerIdentifier.asChar());
+            }
+
+            UsdPrim prim = UsdMayaQuery::GetPrim(proxyShapeName.asChar());
+            if (prim == UsdPrim()) {
+                displayError(
+                    MString("Invalid proxy shape \"") + MString(proxyShapeName.asChar()) + "\"");
+                return MS::kInvalidParameter;
+            }
+
+            auto cmd = std::make_shared<Impl::StitchLayers>();
+            cmd->_layerIdentifiersByStrength = layerIdentifiers;
+            cmd->_proxyShapePath = proxyShapeName.asChar();
+
             _subCommands.push_back(std::move(cmd));
         }
     }

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -881,7 +881,6 @@ public:
         // Multiple selected weak layers may share the same parent, so batch removals by parent
         // to avoid calling SetSubLayerPaths more than once per parent layer.
         std::map<std::string, std::vector<std::string>> removalsByParent;
-        _cleanWeakLayerIds.clear();
         for (size_t i = 1; i < layersByStrength.size(); ++i) {
             const SdfLayerHandle& weakLayer = layersByStrength[i];
             const std::string     weakLayerId = weakLayer->GetIdentifier();
@@ -892,23 +891,6 @@ public:
             } else {
                 TF_WARN("Could not find parent for layer: %s", weakLayerId.c_str());
             }
-
-            if (!weakLayer->IsDirty())
-                _cleanWeakLayerIds.push_back(weakLayerId);
-        }
-
-        _cleanParentIds.clear();
-        for (const auto& entry : removalsByParent) {
-            if (auto parentLayer = SdfLayer::Find(entry.first))
-                if (!parentLayer->IsDirty())
-                    _cleanParentIds.push_back(entry.first);
-        }
-
-        const std::string strongestLayerId = strongestLayer->GetIdentifier();
-        if (!strongestLayer->IsDirty()) {
-            auto it = std::find(_cleanParentIds.begin(), _cleanParentIds.end(), strongestLayerId);
-            if (it == _cleanParentIds.end())
-                _cleanParentIds.push_back(strongestLayerId);
         }
 
         UsdUfe::UsdUndoManager::instance().trackLayerStates(strongestLayer);
@@ -1002,16 +984,6 @@ public:
     {
         _undoItem.undo();
 
-        for (const auto& id : _cleanParentIds) {
-            if (auto layer = SdfLayer::Find(id))
-                layer->Reload();
-        }
-
-        for (const auto& id : _cleanWeakLayerIds) {
-            if (auto layer = SdfLayer::Find(id))
-                layer->Reload();
-        }
-
         restoreEditTargets();
         releaseSubLayers();
 
@@ -1020,8 +992,6 @@ public:
 
 private:
     UsdUfe::UsdUndoableItem  _undoItem;
-    std::vector<std::string> _cleanParentIds;
-    std::vector<std::string> _cleanWeakLayerIds;
     std::vector<std::string> _layerIdentifiersByStrength;
     std::string              _proxyShapePath;
 };

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -934,8 +934,9 @@ public:
             }
 
             // Add all collected subLayers to the strongest layer, preventing duplicates.
-            // Non-selected weak subLayers are added to the end of the subPathList of the strongestLayer.
-            // Note: This means there are cases where relative strength is not fully preserved.
+            // Non-selected weak subLayers are added to the end of the subPathList of the
+            // strongestLayer. Note: This means there are cases where relative strength is not fully
+            // preserved.
             auto strongLayerSubLayers = strongestLayer->GetSubLayerPaths();
 
             std::set<std::string> addedSublayerIds;
@@ -1016,7 +1017,6 @@ public:
 
         return true;
     }
-
 
 private:
     UsdUfe::UsdUndoableItem  _undoItem;
@@ -1747,7 +1747,7 @@ MStatus LayerEditorCommand::parseArgs(const MArgList& argList)
                 return MS::kInvalidParameter;
             }
 
-            const auto cmd
+            auto cmd
                 = std::make_shared<Impl::StitchLayers>(layerIdentifiers, proxyShapeName.asChar());
 
             _subCommands.push_back(std::move(cmd));

--- a/lib/mayaUsd/commands/layerEditorWindowCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorWindowCommand.cpp
@@ -67,6 +67,7 @@ DEF_FLAG(ms, mergeWithSublayers)
 DEF_FLAG(sp, selectPrimsWithSpec)
 DEF_FLAG(lk, lockLayer)
 DEF_FLAG(la, lockLayerAndSubLayers)
+DEF_FLAG(st, stitchLayers)
 
 const MString WORKSPACE_CONTROL_NAME = "mayaUsdLayerEditor";
 } // namespace
@@ -158,6 +159,7 @@ MSyntax LayerEditorWindowCommand::createSyntax()
     ADD_FLAG(selectPrimsWithSpec);
     ADD_FLAG(lockLayer);
     ADD_FLAG(lockLayerAndSubLayers);
+    ADD_FLAG(stitchLayers);
 
     // editor name
     syntax.addArg(MSyntax::kString);
@@ -397,6 +399,7 @@ MStatus LayerEditorWindowCommand::handleEdits(
     HANDLE_E_FLAG(selectPrimsWithSpec, true)
     HANDLE_E_FLAG(lockLayer, true)
     HANDLE_E_FLAG(lockLayerAndSubLayers, true)
+    HANDLE_E_FLAG(stitchLayers, false)
 
     if (argParser.isFlagSet(FLAG(setSelectedLayers))) {
         if (notEdit) {

--- a/lib/usd/ui/layerEditor/abstractCommandHook.h
+++ b/lib/usd/ui/layerEditor/abstractCommandHook.h
@@ -94,6 +94,9 @@ public:
     // status.
     virtual void refreshLayerSystemLock(UsdLayer usdLayer, bool refreshSubLayers = false) = 0;
 
+    // merge multiple layers into the strongest layer, removing them from their parents
+    virtual void stitchLayers(const std::vector<PXR_NS::SdfLayerRefPtr>& layers) = 0;
+
     // starts a complex undo operation in the host app. Please use UndoContext class to safely
     // open/close
     virtual void openUndoBracket(const QString& name) = 0;

--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -644,7 +644,7 @@ void LayerTreeItem::clearLayer(QWidget* /*in_parent*/) { commandHook()->clearLay
 
 void LayerTreeItem::mergeWithSublayers(QWidget* /*in_parent*/)
 {
-    if (!_layer || isInvalidLayer())
+    if (!_layer || isInvalidLayer() || !hasSubLayers())
         return;
 
     commandHook()->flattenLayer(_layer);

--- a/lib/usd/ui/layerEditor/mayaCommandHook.cpp
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.cpp
@@ -253,7 +253,7 @@ void MayaCommandHook::stitchLayers(const std::vector<PXR_NS::SdfLayerRefPtr>& la
         return;
 
     std::string cmd = "mayaUsdLayerEditor -edit ";
-    std::string proxyShape = proxyShapePath();
+    const std::string proxyShape = proxyShapePath();
 
     for (const auto& layer : layers) {
         if (!layer)

--- a/lib/usd/ui/layerEditor/mayaCommandHook.cpp
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.cpp
@@ -247,6 +247,30 @@ void MayaCommandHook::refreshLayerSystemLock(UsdLayer usdLayer, bool refreshSubL
     executeMel(cmd);
 }
 
+void MayaCommandHook::stitchLayers(const std::vector<PXR_NS::SdfLayerRefPtr>& layers)
+{
+    if (layers.empty())
+        return;
+
+    std::string cmd = "mayaUsdLayerEditor -edit ";
+    std::string proxyShape = proxyShapePath();
+
+    for (const auto& layer : layers) {
+        if (!layer)
+            continue;
+
+        cmd += "-stitchLayers ";
+        cmd += quote(proxyShape);
+        cmd += " ";
+        cmd += quote(layer->GetIdentifier());
+        cmd += " ";
+    }
+
+    // Target layer isn't actually used, but needed for the command syntax.
+    cmd += quote(layers[0]->GetIdentifier());
+    executeMel(cmd);
+}
+
 // Help menu callback
 void MayaCommandHook::showLayerEditorHelp()
 {

--- a/lib/usd/ui/layerEditor/mayaCommandHook.cpp
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.cpp
@@ -252,7 +252,7 @@ void MayaCommandHook::stitchLayers(const std::vector<PXR_NS::SdfLayerRefPtr>& la
     if (layers.empty())
         return;
 
-    std::string cmd = "mayaUsdLayerEditor -edit ";
+    std::string       cmd = "mayaUsdLayerEditor -edit ";
     const std::string proxyShape = proxyShapePath();
 
     for (const auto& layer : layers) {

--- a/lib/usd/ui/layerEditor/mayaCommandHook.h
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.h
@@ -74,6 +74,9 @@ public:
     // status.
     void refreshLayerSystemLock(UsdLayer usdLayer, bool refreshSubLayers = false) override;
 
+    // merge multiple layers into the strongest layer, removing them from their parents
+    void stitchLayers(const std::vector<PXR_NS::SdfLayerRefPtr>& layers) override;
+
     // starts a complex undo operation in the host app. Please use UndoContext class to safely
     // open/close
     void openUndoBracket(const QString& name) override;

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
@@ -227,7 +227,7 @@ void MayaLayerEditorWindow::lockLayerAndSubLayers()
 
 void MayaLayerEditorWindow::stitchLayers()
 {
-    auto selectedItems = treeView()->getSelectedLayerItems();
+    const auto selectedItems = treeView()->getSelectedLayerItems();
 
     if (selectedItems.size() < 2)
         return;
@@ -235,11 +235,11 @@ void MayaLayerEditorWindow::stitchLayers()
     std::vector<PXR_NS::SdfLayerRefPtr> layers;
     layers.reserve(selectedItems.size());
 
-    for (auto item : selectedItems) {
+    for (const auto& item : selectedItems) {
         if (!item)
             continue;
 
-        auto layer = item->layer();
+        const auto layer = item->layer();
         if (!layer)
             continue;
 

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
@@ -225,6 +225,33 @@ void MayaLayerEditorWindow::lockLayerAndSubLayers()
     }
 }
 
+void MayaLayerEditorWindow::stitchLayers()
+{
+    auto selectedItems = treeView()->getSelectedLayerItems();
+
+    if (selectedItems.size() < 2)
+        return;
+
+    std::vector<PXR_NS::SdfLayerRefPtr> layers;
+    layers.reserve(selectedItems.size());
+
+    for (auto item : selectedItems) {
+        if (!item)
+            continue;
+
+        auto layer = item->layer();
+        if (!layer)
+            continue;
+
+        layers.push_back(layer);
+    }
+
+    if (layers.size() < 2)
+        return;
+
+    _sessionState.commandHook()->stitchLayers(layers);
+}
+
 void MayaLayerEditorWindow::addParentLayer()
 {
     QString name = "Add Parent Layer";

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.h
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.h
@@ -80,6 +80,7 @@ public:
     void updateLayerModel() override;
     void lockLayer() override;
     void lockLayerAndSubLayers() override;
+    void stitchLayers() override;
 
     void selectProxyShape(const char* shapePath) override;
 

--- a/lib/usd/ui/layerEditor/stringResources.h
+++ b/lib/usd/ui/layerEditor/stringResources.h
@@ -74,6 +74,7 @@ const auto kOption                       { create("kOption", "Option") };
 const auto kPathNotFound                 { create("kPathNotFound", "Path not found: ") };
 const auto kRealPath                     { create("kRealPath", "Real Path: ^1s") };
 const auto kRemoveSublayer               { create("kRemoveSublayer", "Remove sublayer") };
+const auto kMenuStitchLayers             { create("kMenuStitchLayers", "Merge Layers") };
 const auto kSave                         { create("kSave", "Save") };
 const auto kSaveAll                      { create("kSaveAll", "Save All") };
 const auto kSaveAllEditsInLayerStack     { create("kSaveAllEditsInLayerStack", "Save all edits in the Layer Stack")};

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -1097,7 +1097,7 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
     menuItem -label $label -enable $enabled -c $cmd;
 
     int $multiSelect = `mayaUsdLayerEditorWindow -q -selectionLength $panelName` > 1;
-    if ($multiSelect && $isSubLayer) {
+    if ($multiSelect && !$singleSelect) {
         $label = getMayaUsdString("kMenuStitchLayers");
         $cmd = makeCommand($panelName, "stitchLayers");
         $enabled = !$isReadOnly && !$appearsLocked && !$appearsSystemLocked && !$appearsMuted;

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -1096,6 +1096,14 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
     $enabled = $singleSelect && !$appearsMuted && !$isReadOnly && !$isLocked && !$isSystemLocked;
     menuItem -label $label -enable $enabled -c $cmd;
 
+    int $multiSelect = `mayaUsdLayerEditorWindow -q -selectionLength $panelName` > 1;
+    if ($multiSelect && $isSubLayer) {
+        $label = getMayaUsdString("kMenuStitchLayers");
+        $cmd = makeCommand($panelName, "stitchLayers");
+        $enabled = !$isReadOnly && !$appearsLocked && !$appearsSystemLocked && !$appearsMuted;
+        menuItem -label $label -enable $enabled -c $cmd;
+    }
+
     if ($hasSublayers) {
         $label = getMayaUsdString("kMenuMergeWithSublayers");
         $cmd = makeCommand($panelName, "mergeWithSublayers");

--- a/test/lib/testMayaUsdLayerEditorCommands.py
+++ b/test/lib/testMayaUsdLayerEditorCommands.py
@@ -1841,7 +1841,6 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
 
             self.assertFalse(cleanLayer.dirty, "Clean layer should remain clean after undo")
             self.assertTrue(dirtyLayer.dirty, "Dirty layer should remain dirty after undo")
-            self.assertFalse(rootLayer.dirty, "Root layer dirty state should be restored to pre-flatten state")
 
             # Verify disk still has the old value 15.0.
             dirtyLayer.Reload()

--- a/test/lib/testMayaUsdLayerEditorCommands.py
+++ b/test/lib/testMayaUsdLayerEditorCommands.py
@@ -1032,6 +1032,655 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
         cmds.file(mayaSceneFilePath, force=True, open=True)
         filePathRel = mayaUsd.lib.Util.getPathRelativeToMayaSceneFile(ballFilePath)
         self.assertEqual(filePathRel, 'top_layer.usda')
+
+    def testStitchLayers(self):
+        """Test 'mayaUsdLayerEditor' command 'stitchLayers' parameter"""
+
+        shapePath, stage = getCleanMayaStage()
+        rootLayer = stage.GetRootLayer()
+        rootLayerId = rootLayer.identifier
+
+        # Create a hierarchy of layers with content
+        # Root
+        #   Layer1 (selected, strongest)
+        #   Layer2 (selected)
+        #   Layer3 (seleted, weakest)
+
+        layer1Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer1")[0]
+        layer2Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer2")[0]
+        layer3Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer3")[0]
+        rootLayer.subLayerPaths.clear()
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[0, layer1Id]) # Strongest
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[1, layer2Id])
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[2, layer3Id]) # Weakest
+
+        layer1 = Sdf.Layer.Find(layer1Id)
+        layer2 = Sdf.Layer.Find(layer2Id)
+        layer3 = Sdf.Layer.Find(layer3Id)
+
+        with Sdf.ChangeBlock():
+            prim1 = Sdf.CreatePrimInLayer(layer1, '/Sphere')
+            prim1.SetInfo('typeName', 'Sphere')
+            attr1 = Sdf.AttributeSpec(prim1, 'color', Sdf.ValueTypeNames.String)
+            attr1.default = "red"
+
+        with Sdf.ChangeBlock():
+            prim2 = Sdf.CreatePrimInLayer(layer2, '/Sphere')
+            prim2.SetInfo('typeName', 'Sphere')
+            attr2 = Sdf.AttributeSpec(prim2, 'radius', Sdf.ValueTypeNames.Double)
+            attr2.default = 2.0
+
+        with Sdf.ChangeBlock():
+            prim3 = Sdf.CreatePrimInLayer(layer3, '/Sphere')
+            prim3.SetInfo('typeName', 'Sphere')
+            attr3 = Sdf.AttributeSpec(prim3, 'visible', Sdf.ValueTypeNames.Bool)
+            attr3.default = False
+
+        self.assertEqual(len(rootLayer.subLayerPaths), 3)
+        self.assertIn(layer1Id, rootLayer.subLayerPaths)
+        self.assertIn(layer2Id, rootLayer.subLayerPaths)
+        self.assertIn(layer3Id, rootLayer.subLayerPaths)
+
+        # Note: Order the layers are passed in does not matter, strongest receives all other layers.
+        cmds.mayaUsdLayerEditor(
+            rootLayerId, edit=True,
+            stitchLayers=((shapePath, layer2Id), (shapePath, layer1Id), (shapePath, layer3Id))
+        )
+
+        self.assertEqual(len(rootLayer.subLayerPaths), 1)
+        self.assertEqual(rootLayer.subLayerPaths[0], layer1Id)
+
+        stitchedPrim = layer1.GetPrimAtPath('/Sphere')
+        self.assertIsNotNone(stitchedPrim)
+
+        self.assertIsNotNone(stitchedPrim.properties.get('color'))
+        self.assertIsNotNone(stitchedPrim.properties.get('radius'))
+        self.assertIsNotNone(stitchedPrim.properties.get('visible'))
+
+        self.assertEqual(stitchedPrim.properties.get('color').default, "red")
+        self.assertEqual(stitchedPrim.properties.get('radius').default, 2.0)
+        self.assertEqual(stitchedPrim.properties.get('visible').default, False)
+
+        cmds.undo()
+
+        self.assertEqual(len(rootLayer.subLayerPaths), 3)
+        self.assertIn(layer1Id, rootLayer.subLayerPaths)
+        self.assertIn(layer2Id, rootLayer.subLayerPaths)
+        self.assertIn(layer3Id, rootLayer.subLayerPaths)
+
+        restoredPrim = layer1.GetPrimAtPath('/Sphere')
+        self.assertIsNotNone(restoredPrim.properties.get('color'))
+        self.assertIsNone(restoredPrim.properties.get('radius'))
+        self.assertIsNone(restoredPrim.properties.get('visible'))
+
+        cmds.redo()
+
+        self.assertEqual(len(rootLayer.subLayerPaths), 1)
+        self.assertEqual(rootLayer.subLayerPaths[0], layer1Id)
+
+        restitchedPrim = layer1.GetPrimAtPath('/Sphere')
+        self.assertIsNotNone(restitchedPrim.properties.get('color'))
+        self.assertIsNotNone(restitchedPrim.properties.get('radius'))
+        self.assertIsNotNone(restitchedPrim.properties.get('visible'))
+
+    def testStitchLayersWithEditTarget(self):
+        """ Test stitching layers when edit target is on a layer being stitched """
+
+        shapePath, stage = getCleanMayaStage()
+        rootLayer = stage.GetRootLayer()
+        rootLayerId = rootLayer.identifier
+
+        strongLayerId = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Strong")[0]
+        weakLayerId = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Weak")[0]
+        rootLayer.subLayerPaths.clear()
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[0, strongLayerId])
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[1, weakLayerId])
+
+        cmds.mayaUsdEditTarget(shapePath, edit=True, editTarget=weakLayerId)
+        self.assertEqual(stage.GetEditTarget().GetLayer().identifier, weakLayerId)
+
+        cmds.mayaUsdLayerEditor(
+            rootLayerId, edit=True,
+            stitchLayers=((shapePath, strongLayerId), (shapePath, weakLayerId))
+        )
+
+        currentTarget = stage.GetEditTarget().GetLayer().identifier
+        self.assertNotEqual(currentTarget, weakLayerId)
+
+        cmds.undo()
+        self.assertEqual(stage.GetEditTarget().GetLayer().identifier, weakLayerId)
+
+    def testStitchLayersPartialSelection(self):
+        """ Test stitching only some layers while leaving others untouched """
+
+        shapePath, stage = getCleanMayaStage()
+        rootLayer = stage.GetRootLayer()
+        rootLayerId = rootLayer.identifier
+
+        layer1Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer1")[0]
+        layer2Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer2")[0]
+        layer3Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer3")[0]
+        layer4Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer4")[0]
+        rootLayer.subLayerPaths.clear()
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[0, layer1Id])
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[1, layer2Id])
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[2, layer3Id])
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[3, layer4Id])
+
+        self.assertEqual(len(rootLayer.subLayerPaths), 4)
+
+        # Stitch only layer1 and layer3 (layer1 is stronger, so it receives layer3's content)
+        cmds.mayaUsdLayerEditor(
+            rootLayerId, edit=True,
+            stitchLayers=((shapePath, layer1Id), (shapePath, layer3Id))
+        )
+
+        self.assertEqual(len(rootLayer.subLayerPaths), 3)
+        self.assertIn(layer1Id, rootLayer.subLayerPaths)
+        self.assertIn(layer2Id, rootLayer.subLayerPaths)
+        self.assertNotIn(layer3Id, rootLayer.subLayerPaths)
+        self.assertIn(layer4Id, rootLayer.subLayerPaths)
+
+        cmds.undo()
+        self.assertEqual(len(rootLayer.subLayerPaths), 4)
+
+    def testStitchLayersHierarchical(self):
+        """ Test stitching layers in a hierarchical structure """
+        # Root
+        #   ParentLayer
+        #       ChildStrong (strongest)
+        #       ChildWeak (weakest)
+
+        shapePath, stage = getCleanMayaStage()
+        rootLayer = stage.GetRootLayer()
+        rootLayerId = rootLayer.identifier
+
+
+        parentLayerId = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Parent")[0]
+        parentLayer = Sdf.Layer.Find(parentLayerId)
+
+        childStrongId = cmds.mayaUsdLayerEditor(parentLayerId, edit=True, addAnonymous="ChildStrong")[0]
+        childWeakId = cmds.mayaUsdLayerEditor(parentLayerId, edit=True, addAnonymous="ChildWeak")[0]
+        parentLayer.subLayerPaths.clear()
+        cmds.mayaUsdLayerEditor(parentLayerId, edit=True, insertSubPath=[0, childStrongId])
+        cmds.mayaUsdLayerEditor(parentLayerId, edit=True, insertSubPath=[1, childWeakId])
+
+        childStrong = Sdf.Layer.Find(childStrongId)
+        childWeak = Sdf.Layer.Find(childWeakId)
+
+        with Sdf.ChangeBlock():
+            prim1 = Sdf.CreatePrimInLayer(childStrong, '/Cube')
+            prim1.SetInfo('typeName', 'Cube')
+            attr1 = Sdf.AttributeSpec(prim1, 'size', Sdf.ValueTypeNames.Double)
+            attr1.default = 1.0
+
+        with Sdf.ChangeBlock():
+            prim2 = Sdf.CreatePrimInLayer(childWeak, '/Cube')
+            prim2.SetInfo('typeName', 'Cube')
+            attr2 = Sdf.AttributeSpec(prim2, 'color', Sdf.ValueTypeNames.String)
+            attr2.default = "blue"
+
+        self.assertEqual(len(parentLayer.subLayerPaths), 2)
+
+        cmds.mayaUsdLayerEditor(
+            parentLayerId, edit=True,
+            stitchLayers=((shapePath, childStrongId), (shapePath, childWeakId))
+        )
+
+        self.assertEqual(len(parentLayer.subLayerPaths), 1)
+        self.assertEqual(parentLayer.subLayerPaths[0], childStrongId)
+
+        stitchedPrim = childStrong.GetPrimAtPath('/Cube')
+        self.assertIsNotNone(stitchedPrim.properties.get('size'))
+        self.assertIsNotNone(stitchedPrim.properties.get('color'))
+
+        cmds.undo()
+        self.assertEqual(len(parentLayer.subLayerPaths), 2)
+
+    def testStitchLayersInvalidInput(self):
+        """ Test error handling with invalid inputs """
+
+        shapePath, stage = getCleanMayaStage()
+        rootLayer = stage.GetRootLayer()
+        rootLayerId = rootLayer.identifier
+
+        layerId = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="ValidLayer")[0]
+
+        with self.assertRaises(RuntimeError):
+            cmds.mayaUsdLayerEditor(
+                rootLayerId, edit=True,
+                stitchLayers=(("invalidShape", layerId),)
+            )
+
+        with self.assertRaises(RuntimeError):
+            cmds.mayaUsdLayerEditor(
+                rootLayerId, edit=True,
+                stitchLayers=((shapePath, "nonExistentLayer.usda"),)
+            )
+
+    def testStitchLayersWithDirtyAnonymousLayers(self):
+        """ Test that dirty anonymous layers are properly held onto during stitch """
+
+        shapePath, stage = getCleanMayaStage()
+        rootLayer = stage.GetRootLayer()
+        rootLayerId = rootLayer.identifier
+
+        strongId = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Strong")[0]
+        weakId = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Weak")[0]
+
+        strong = Sdf.Layer.Find(strongId)
+        weak = Sdf.Layer.Find(weakId)
+
+        # Make layers dirty
+        with Sdf.ChangeBlock():
+            Sdf.CreatePrimInLayer(strong, '/StrongPrim')
+            Sdf.CreatePrimInLayer(weak, '/WeakPrim')
+
+        self.assertTrue(strong.dirty)
+        self.assertTrue(weak.dirty)
+
+        cmds.mayaUsdLayerEditor(
+            rootLayerId, edit=True,
+            stitchLayers=((shapePath, strongId), (shapePath, weakId))
+        )
+
+        cmds.undo()
+
+        self.assertEqual(len(rootLayer.subLayerPaths), 2)
+
+        restoredWeak = Sdf.Layer.Find(weakId)
+        self.assertIsNotNone(restoredWeak)
+        self.assertIsNotNone(restoredWeak.GetPrimAtPath('/WeakPrim'))
+
+    def testStitchLayersWithSingleSublayer(self):
+        """ Test basic sublayer movement when stitching parent with its child layer """
+        # Creates the following structure, stitches Parent1 and Layer2.
+        # Before:
+        # Root
+        #   Parent1 (selected, strongest)
+        #        Layer1
+        #        Layer2 (selected, weakest)
+        #           Sub1
+        #
+        # After:
+        # Root
+        #   Parent1 (has merged/stitched layer changes)
+        #        Layer1
+        #        Sub1
+
+        shapePath, stage = getCleanMayaStage()
+        rootLayer = stage.GetRootLayer()
+        rootLayerId = rootLayer.identifier
+
+        parent1Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Parent1")[0]
+        parent1Layer = Sdf.Layer.Find(parent1Id)
+
+        layer1Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer1")[0]
+        parent1Layer.subLayerPaths.append(layer1Id)
+        layer1Layer = Sdf.Layer.Find(layer1Id)
+
+        with Sdf.ChangeBlock():
+            prim1 = Sdf.CreatePrimInLayer(layer1Layer, '/Layer1Prim')
+            prim1.SetInfo('typeName', 'Sphere')
+
+        layer2Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer2")[0]
+        parent1Layer.subLayerPaths.append(layer2Id)
+        layer2Layer = Sdf.Layer.Find(layer2Id)
+
+        with Sdf.ChangeBlock():
+            prim2 = Sdf.CreatePrimInLayer(layer2Layer, '/Layer2Prim')
+            prim2.SetInfo('typeName', 'Cube')
+
+        sub1Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Sub1")[0]
+        layer2Layer.subLayerPaths.append(sub1Id)
+        sub1Layer = Sdf.Layer.Find(sub1Id)
+
+        with Sdf.ChangeBlock():
+            prim3 = Sdf.CreatePrimInLayer(sub1Layer, '/Sub1Prim')
+            prim3.SetInfo('typeName', 'Cone')
+
+        rootLayer.subLayerPaths.clear()
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[0, parent1Id])
+
+        self.assertEqual(len(rootLayer.subLayerPaths), 1)
+        self.assertEqual(rootLayer.subLayerPaths[0], parent1Id)
+        self.assertEqual(len(parent1Layer.subLayerPaths), 2)
+        self.assertEqual(len(layer2Layer.subLayerPaths), 1)
+
+        cmds.mayaUsdLayerEditor(
+            rootLayerId, edit=True,
+            stitchLayers=((shapePath, parent1Id), (shapePath, layer2Id))
+        )
+
+        self.assertEqual(len(rootLayer.subLayerPaths), 1)
+        self.assertEqual(rootLayer.subLayerPaths[0], parent1Id)
+
+        self.assertEqual(len(parent1Layer.subLayerPaths), 2,
+                        "Parent1 should have 2 sublayers after stitch")
+
+        firstSublayer = Sdf.Layer.FindRelativeToLayer(parent1Layer, parent1Layer.subLayerPaths[0])
+        self.assertIsNotNone(firstSublayer)
+        self.assertEqual(firstSublayer.identifier, layer1Id,
+                        "Layer1 should remain at position 0")
+
+        secondSublayer = Sdf.Layer.FindRelativeToLayer(parent1Layer, parent1Layer.subLayerPaths[1])
+        self.assertIsNotNone(secondSublayer)
+        self.assertEqual(secondSublayer.identifier, sub1Id,
+                        "Sub1 should be at position 1 (moved from Layer2)")
+
+        self.assertIsNotNone(parent1Layer.GetPrimAtPath('/Layer2Prim'),
+                            "Parent1 should have merged content from Layer2")
+
+        self.assertIsNotNone(layer1Layer.GetPrimAtPath('/Layer1Prim'))
+        self.assertIsNotNone(sub1Layer.GetPrimAtPath('/Sub1Prim'))
+
+        cmds.undo()
+
+        self.assertEqual(len(parent1Layer.subLayerPaths), 2)
+
+        restored1 = Sdf.Layer.FindRelativeToLayer(parent1Layer, parent1Layer.subLayerPaths[0])
+        self.assertEqual(restored1.identifier, layer1Id)
+
+        restored2 = Sdf.Layer.FindRelativeToLayer(parent1Layer, parent1Layer.subLayerPaths[1])
+        self.assertEqual(restored2.identifier, layer2Id)
+
+        restoredLayer2 = Sdf.Layer.Find(layer2Id)
+        self.assertEqual(len(restoredLayer2.subLayerPaths), 1)
+        restoredSub1 = Sdf.Layer.FindRelativeToLayer(restoredLayer2, restoredLayer2.subLayerPaths[0])
+        self.assertEqual(restoredSub1.identifier, sub1Id)
+
+        self.assertIsNone(parent1Layer.GetPrimAtPath('/Layer2Prim'),
+                         "Layer2's content should not be in Parent1 after undo")
+
+        cmds.redo()
+
+        self.assertEqual(len(parent1Layer.subLayerPaths), 2)
+        self.assertEqual(Sdf.Layer.FindRelativeToLayer(parent1Layer, parent1Layer.subLayerPaths[0]).identifier, layer1Id)
+        self.assertEqual(Sdf.Layer.FindRelativeToLayer(parent1Layer, parent1Layer.subLayerPaths[1]).identifier, sub1Id)
+
+    def testBatchStitch(self):
+        """ Test batch stitching (3+ layers) across parent hierarchies with sublayer movement"""
+        # Creates the following structure, stitches Sub1, Layer2, and Sub3.
+        # Before:
+        # Root
+        #   Parent1
+        #        Layer1
+        #           Sub1 (selected, strongest)
+        #   Parent2
+        #       Layer2 (selected)
+        #           Sub2
+        #           Sub3 (selected, weakest)
+        #               SubSub3
+        #
+        # After:
+        # Root
+        #   Parent1
+        #        Layer1
+        #           Sub1 (has merged/stitched changes from Layer2 and Sub3)
+        #               Sub2 (moved from Layer2)
+        #               SubSub3 (moved from Sub3)
+
+        shapePath, stage = getCleanMayaStage()
+        rootLayer = stage.GetRootLayer()
+        rootLayerId = rootLayer.identifier
+
+        parent1Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Parent1")[0]
+        layer1Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer1")[0]
+        sub1Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Sub1")[0]
+
+        parent1Layer = Sdf.Layer.Find(parent1Id)
+        layer1Layer = Sdf.Layer.Find(layer1Id)
+        sub1Layer = Sdf.Layer.Find(sub1Id)
+
+        parent1Layer.subLayerPaths.append(layer1Id)
+        layer1Layer.subLayerPaths.append(sub1Id)
+
+        with Sdf.ChangeBlock():
+            prim1 = Sdf.CreatePrimInLayer(sub1Layer, '/Sub1Prim')
+            prim1.SetInfo('typeName', 'Sphere')
+            attr1 = Sdf.AttributeSpec(prim1, 'color', Sdf.ValueTypeNames.String)
+            attr1.default = "red"
+
+        parent2Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Parent2")[0]
+        layer2Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer2")[0]
+        sub2Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Sub2")[0]
+        sub3Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Sub3")[0]
+        subSub3Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="SubSub3")[0]
+
+        parent2Layer = Sdf.Layer.Find(parent2Id)
+        layer2Layer = Sdf.Layer.Find(layer2Id)
+        sub2Layer = Sdf.Layer.Find(sub2Id)
+        sub3Layer = Sdf.Layer.Find(sub3Id)
+        subSub3Layer = Sdf.Layer.Find(subSub3Id)
+
+        parent2Layer.subLayerPaths.append(layer2Id)
+        layer2Layer.subLayerPaths.append(sub2Id)
+        layer2Layer.subLayerPaths.append(sub3Id)
+        sub3Layer.subLayerPaths.append(subSub3Id)
+
+        with Sdf.ChangeBlock():
+            prim2 = Sdf.CreatePrimInLayer(layer2Layer, '/Layer2Prim')
+            prim2.SetInfo('typeName', 'Cube')
+            attr2 = Sdf.AttributeSpec(prim2, 'size', Sdf.ValueTypeNames.Double)
+            attr2.default = 2.0
+
+        with Sdf.ChangeBlock():
+            prim3 = Sdf.CreatePrimInLayer(sub2Layer, '/Sub2Prim')
+            prim3.SetInfo('typeName', 'Cylinder')
+
+        with Sdf.ChangeBlock():
+            prim4 = Sdf.CreatePrimInLayer(sub3Layer, '/Sub3Prim')
+            prim4.SetInfo('typeName', 'Cone')
+
+        with Sdf.ChangeBlock():
+            prim5 = Sdf.CreatePrimInLayer(subSub3Layer, '/SubSub3Prim')
+            prim5.SetInfo('typeName', 'Torus')
+
+        rootLayer.subLayerPaths.clear()
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[0, parent1Id])
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[1, parent2Id])
+
+        self.assertEqual(len(rootLayer.subLayerPaths), 2)
+        self.assertEqual(len(parent1Layer.subLayerPaths), 1)
+        self.assertEqual(len(layer1Layer.subLayerPaths), 1)
+        self.assertEqual(len(parent2Layer.subLayerPaths), 1)
+        self.assertEqual(len(layer2Layer.subLayerPaths), 2)
+        self.assertEqual(len(sub3Layer.subLayerPaths), 1)
+
+        cmds.mayaUsdLayerEditor(
+            rootLayerId, edit=True,
+            stitchLayers=((shapePath, sub1Id), (shapePath, layer2Id), (shapePath, sub3Id))
+        )
+
+        self.assertEqual(len(parent2Layer.subLayerPaths), 0,
+                        "Layer2 should be removed from Parent2")
+
+        self.assertEqual(len(sub1Layer.subLayerPaths), 2,
+                        "Sub1 should have 2 sublayers (Sub2 and SubSub3)")
+
+        firstSub = Sdf.Layer.FindRelativeToLayer(sub1Layer, sub1Layer.subLayerPaths[0])
+        self.assertIsNotNone(firstSub)
+        self.assertEqual(firstSub.identifier, sub2Id,
+                        "Sub2 should be at position 0")
+
+        secondSub = Sdf.Layer.FindRelativeToLayer(sub1Layer, sub1Layer.subLayerPaths[1])
+        self.assertIsNotNone(secondSub)
+        self.assertEqual(secondSub.identifier, subSub3Id,
+                        "SubSub3 should be at position 1")
+
+        self.assertIsNotNone(sub1Layer.GetPrimAtPath('/Sub1Prim'),
+                            "Sub1 should have original content")
+        self.assertIsNotNone(sub1Layer.GetPrimAtPath('/Layer2Prim'),
+                            "Sub1 should have merged content from Layer2")
+        self.assertIsNotNone(sub1Layer.GetPrimAtPath('/Sub3Prim'),
+                            "Sub1 should have merged content from Sub3")
+
+        self.assertIsNotNone(sub2Layer.GetPrimAtPath('/Sub2Prim'))
+        self.assertIsNotNone(subSub3Layer.GetPrimAtPath('/SubSub3Prim'))
+
+        cmds.undo()
+
+        self.assertEqual(len(parent2Layer.subLayerPaths), 1,
+                        "After undo, Parent2 should have Layer2 again")
+        restoredLayer2Path = parent2Layer.subLayerPaths[0]
+        restoredLayer2 = Sdf.Layer.FindRelativeToLayer(parent2Layer, restoredLayer2Path)
+        self.assertIsNotNone(restoredLayer2)
+        self.assertEqual(restoredLayer2.identifier, layer2Id)
+
+        self.assertEqual(len(restoredLayer2.subLayerPaths), 2,
+                        "After undo, Layer2 should have 2 sublayers")
+
+        restoredSub2 = Sdf.Layer.FindRelativeToLayer(restoredLayer2, restoredLayer2.subLayerPaths[0])
+        self.assertIsNotNone(restoredSub2)
+        self.assertEqual(restoredSub2.identifier, sub2Id)
+
+        restoredSub3 = Sdf.Layer.FindRelativeToLayer(restoredLayer2, restoredLayer2.subLayerPaths[1])
+        self.assertIsNotNone(restoredSub3)
+        self.assertEqual(restoredSub3.identifier, sub3Id)
+
+        restoredSub3Layer = Sdf.Layer.Find(sub3Id)
+        self.assertEqual(len(restoredSub3Layer.subLayerPaths), 1)
+        restoredSubSub3 = Sdf.Layer.FindRelativeToLayer(restoredSub3Layer, restoredSub3Layer.subLayerPaths[0])
+        self.assertIsNotNone(restoredSubSub3)
+        self.assertEqual(restoredSubSub3.identifier, subSub3Id)
+
+        restoredSub1 = Sdf.Layer.Find(sub1Id)
+        self.assertEqual(len(restoredSub1.subLayerPaths), 0,
+                        "After undo, Sub1 should have no sublayers")
+
+        self.assertIsNotNone(restoredSub1.GetPrimAtPath('/Sub1Prim'))
+        self.assertIsNone(restoredSub1.GetPrimAtPath('/Layer2Prim'),
+                         "Layer2's content should not be in Sub1 after undo")
+        self.assertIsNone(restoredSub1.GetPrimAtPath('/Sub3Prim'),
+                         "Sub3's content should not be in Sub1 after undo")
+
+        cmds.redo()
+
+        self.assertEqual(len(parent2Layer.subLayerPaths), 0)
+        self.assertEqual(len(sub1Layer.subLayerPaths), 2)
+        self.assertIsNotNone(sub1Layer.GetPrimAtPath('/Layer2Prim'))
+        self.assertIsNotNone(sub1Layer.GetPrimAtPath('/Sub3Prim'))
+
+    def testSharedSublayers(self):
+        """ Creates the following structure, stitching Layer1 and Layer2. Ensures there is no duplicate of the SharedSubLayer. """
+        # Before:
+        # Root
+        #   Layer1 (selected, strongest)
+        #       SharedSublayer
+        #   Layer2 (selected, weakest)
+        #       SharedSublayer
+        #
+        # After:
+        # Root
+        #   Layer1 (has merged/stitched changes)
+        #       SharedSublayer
+
+        shapePath, stage = getCleanMayaStage()
+        rootLayer = stage.GetRootLayer()
+        rootLayerId = rootLayer.identifier
+
+        sharedSubId = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="SharedSublayer")[0]
+        sharedSubLayer = Sdf.Layer.Find(sharedSubId)
+
+        with Sdf.ChangeBlock():
+            prim = Sdf.CreatePrimInLayer(sharedSubLayer, '/SharedPrim')
+            prim.SetInfo('typeName', 'Sphere')
+            attr = Sdf.AttributeSpec(prim, 'radius', Sdf.ValueTypeNames.Double)
+            attr.default = 5.0
+
+        layer1Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer1")[0]
+        layer1Layer = Sdf.Layer.Find(layer1Id)
+        layer1Layer.subLayerPaths.append(sharedSubId)
+
+        with Sdf.ChangeBlock():
+            prim1 = Sdf.CreatePrimInLayer(layer1Layer, '/Layer1Prim')
+            prim1.SetInfo('typeName', 'Cube')
+            attr1 = Sdf.AttributeSpec(prim1, 'color', Sdf.ValueTypeNames.String)
+            attr1.default = "blue"
+
+        layer2Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer2")[0]
+        layer2Layer = Sdf.Layer.Find(layer2Id)
+        layer2Layer.subLayerPaths.append(sharedSubId)
+
+        with Sdf.ChangeBlock():
+            prim2 = Sdf.CreatePrimInLayer(layer2Layer, '/Layer2Prim')
+            prim2.SetInfo('typeName', 'Cone')
+            attr2 = Sdf.AttributeSpec(prim2, 'size', Sdf.ValueTypeNames.Double)
+            attr2.default = 3.0
+
+        rootLayer.subLayerPaths.clear()
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[0, layer1Id])
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[1, layer2Id])
+
+        self.assertEqual(len(layer1Layer.subLayerPaths), 1)
+        self.assertEqual(len(layer2Layer.subLayerPaths), 1)
+
+        layer1Sub = Sdf.Layer.FindRelativeToLayer(layer1Layer, layer1Layer.subLayerPaths[0])
+        layer2Sub = Sdf.Layer.FindRelativeToLayer(layer2Layer, layer2Layer.subLayerPaths[0])
+        self.assertEqual(layer1Sub.identifier, sharedSubId)
+        self.assertEqual(layer2Sub.identifier, sharedSubId)
+
+        cmds.mayaUsdLayerEditor(
+            rootLayerId, edit=True,
+            stitchLayers=((shapePath, layer1Id), (shapePath, layer2Id))
+        )
+
+        self.assertEqual(len(layer1Layer.subLayerPaths), 1,
+                        "SharedSublayer should appear only once in Layer1 (no duplicate)")
+
+        remainingSub = Sdf.Layer.FindRelativeToLayer(layer1Layer, layer1Layer.subLayerPaths[0])
+        self.assertIsNotNone(remainingSub)
+        self.assertEqual(remainingSub.identifier, sharedSubId,
+                        "The single sublayer should be SharedSublayer")
+
+        subLayerIds = []
+        for path in layer1Layer.subLayerPaths:
+            layer = Sdf.Layer.FindRelativeToLayer(layer1Layer, path)
+            if layer:
+                subLayerIds.append(layer.identifier)
+
+        self.assertEqual(len(subLayerIds), len(set(subLayerIds)),
+                        "No duplicate sublayer identifiers should exist")
+
+        sharedPrim = sharedSubLayer.GetPrimAtPath('/SharedPrim')
+        self.assertIsNotNone(sharedPrim)
+        self.assertEqual(sharedPrim.properties.get('radius').default, 5.0)
+
+        self.assertIsNotNone(layer1Layer.GetPrimAtPath('/Layer1Prim'))
+        self.assertIsNotNone(layer1Layer.GetPrimAtPath('/Layer2Prim'),
+                            "Layer1 should have merged content from Layer2")
+
+        self.assertEqual(len(rootLayer.subLayerPaths), 1)
+        self.assertEqual(rootLayer.subLayerPaths[0], layer1Id)
+
+        cmds.undo()
+
+        self.assertEqual(len(rootLayer.subLayerPaths), 2)
+        self.assertIn(layer1Id, rootLayer.subLayerPaths)
+        self.assertIn(layer2Id, rootLayer.subLayerPaths)
+
+        restoredLayer1 = Sdf.Layer.Find(layer1Id)
+        self.assertEqual(len(restoredLayer1.subLayerPaths), 1)
+        restoredLayer1Sub = Sdf.Layer.FindRelativeToLayer(restoredLayer1, restoredLayer1.subLayerPaths[0])
+        self.assertIsNotNone(restoredLayer1Sub)
+        self.assertEqual(restoredLayer1Sub.identifier, sharedSubId,
+                        "Layer1 should have SharedSublayer after undo")
+
+        restoredLayer2 = Sdf.Layer.Find(layer2Id)
+        self.assertEqual(len(restoredLayer2.subLayerPaths), 1)
+        restoredLayer2Sub = Sdf.Layer.FindRelativeToLayer(restoredLayer2, restoredLayer2.subLayerPaths[0])
+        self.assertIsNotNone(restoredLayer2Sub)
+        self.assertEqual(restoredLayer2Sub.identifier, sharedSubId,
+                        "Layer2 should have SharedSublayer restored after undo")
+
+        self.assertIsNone(restoredLayer1.GetPrimAtPath('/Layer2Prim'),
+                         "Layer2's content should not be in Layer1 after undo")
+
+        cmds.redo()
+
+        self.assertEqual(len(rootLayer.subLayerPaths), 1)
+        self.assertEqual(len(layer1Layer.subLayerPaths), 1)
+        self.assertIsNotNone(layer1Layer.GetPrimAtPath('/Layer2Prim'))
         
     def testMergeWithSublayers(self):
         """ test 'mayaUsdLayerEditor' command 'flatten' parameter to merge a layer with its sublayers """
@@ -1044,6 +1693,7 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
         #     Layer1Sub
         #   Layer2
         #     Layer2Sub
+
         layer1Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer1")[0]
         layer2Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer2")[0]
         layer1SubId = cmds.mayaUsdLayerEditor(layer1Id, edit=True, addAnonymous="Layer1Sub")[0]
@@ -1054,13 +1704,11 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
         layer1Sub = Sdf.Layer.Find(layer1SubId)
         layer2Sub = Sdf.Layer.Find(layer2SubId)
 
-        # Ball1 defined in Layer1Sub, transformed in Layer1
         ball1Spec = Sdf.PrimSpec(layer1Sub, "Ball1", Sdf.SpecifierDef, "Sphere")
         ball1OverSpec = Sdf.PrimSpec(layer1, "Ball1", Sdf.SpecifierOver)
         ball1Attr = Sdf.AttributeSpec(ball1OverSpec, "radius", Sdf.ValueTypeNames.Double)
         ball1Attr.default = 5.0
 
-        # Ball2 defined in Layer2Sub, transformed in Layer2
         ball2Spec = Sdf.PrimSpec(layer2Sub, "Ball2", Sdf.SpecifierDef, "Sphere")
         ball2OverSpec = Sdf.PrimSpec(layer2, "Ball2", Sdf.SpecifierOver)
         ball2Attr = Sdf.AttributeSpec(ball2OverSpec, "radius", Sdf.ValueTypeNames.Double)
@@ -1070,17 +1718,14 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
         self.assertEqual(len(layer2.subLayerPaths), 1)
         self.assertEqual(len(rootLayer.subLayerPaths), 2)
 
-        # Flatten Layer1 (merge Layer1Sub into Layer1)
         cmds.mayaUsdLayerEditor(layer1Id, edit=True, flatten=True)
         self.assertEqual(len(layer1.subLayerPaths), 0)
         self.assertIsNotNone(layer1.GetPrimAtPath("/Ball1"))
 
-        # Flatten Layer2 (merge Layer2Sub into Layer2)
         cmds.mayaUsdLayerEditor(layer2Id, edit=True, flatten=True)
         self.assertEqual(len(layer2.subLayerPaths), 0)
         self.assertIsNotNone(layer2.GetPrimAtPath("/Ball2"))
 
-        # Flatten Root (merge flattened Layer1 and Layer2 into Root)
         self.assertEqual(len(rootLayer.subLayerPaths), 2)
         cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, flatten=True)
         self.assertEqual(len(rootLayer.subLayerPaths), 0)
@@ -1159,11 +1804,9 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
             self.assertFalse(cleanLayer.dirty)
             self.assertTrue(dirtyLayer.dirty)
 
-            # Save root layer so it's clean before flatten.
             rootLayer.Save()
             self.assertFalse(rootLayer.dirty, "Root layer should be clean after save")
 
-            # Verify the in-memory value for dirty layer is 20, not the disk value of 15.
             self.assertEqual(dirtyLayer.GetPrimAtPath("/Ball3").attributes["radius"].default, 20.0)
 
             cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, flatten=True)
@@ -1193,7 +1836,6 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
             self.assertEqual(cleanLayer.GetPrimAtPath("/Ball2").attributes["radius"].default, 10.0)
             self.assertIsNotNone(dirtyLayer.GetPrimAtPath("/Ball3"))
 
-            # Dirty layer should have the in-memory value 20.0, not disk value.
             self.assertEqual(dirtyLayer.GetPrimAtPath("/Ball3").attributes["radius"].default, 20.0,
                            "Dirty layer should restore with in-memory changes, not clean disk version")
 


### PR DESCRIPTION
EMSUSD-3077: Stitch layers

Adds support for the stitch operation in USD, under the name Merge Layers. Includes unit tests and undo/redo support in the script editor.

In a previous PR, UsdUndoBlock was suggested as a way to backup the Stitch Operation, but TransferContent isn't supported by it. It is used for backing up the SetSubLayerPaths operation for undo(), and TransferContent is backed up by private member var snapshots.

Because of UsdUndoBlock not working for TransferContent, flatten remains within backupLayer, using the existing snapshot backup functionality. Stitch is in a new class StitchLayers which extends from BackupLayerBase as it utilizes only backupEditTargets() and restoreEditTargets() (moved to protected).

Also includes the following small flatten fixes ( for PR #4469 )
1. In layerEditorCommand.cpp, new line 742, there is a fix which applies to Flatten layers. The backup layer used to only occur for ClearLayer, but now works for Flatten as well. Does not affect Stitch. The logic of both backupLayer() and restoreLayer() has otherwise not changed.
2. In layerTreeItem.cpp new line 647, there is an added condition which prevents pointless flattens on layers without subLayers. (In  a bulk operation, a selection may not have any subLayers, a flatten call does nothing, but would still occur. 
![EMSUSD-3077_stitchLayersDemo](https://github.com/user-attachments/assets/bf0a4251-498a-4e0d-8aa8-053f07f82a9a)
