### PR TITLE
EMSUSDC-297 - Component Creator is not supported on Maya Creative

### DIFF
--- a/plugin/adsk/scripts/CMakeLists.txt
+++ b/plugin/adsk/scripts/CMakeLists.txt
@@ -13,6 +13,7 @@ list(APPEND scripts_src
     mayaUsd_createStageWithNewLayer.py
     mayaUsd_createStageFromAsset.mel
     mayaUsd_imageFileDialogs.mel
+    mayaUsd_initializeComponentCreator.py
     mayaUsd_layerEditorFileDialogs.mel
     mayaUsd_fileOptions.mel
     mayaUsd_pluginUICreation.mel

--- a/plugin/adsk/scripts/mayaUsd_initializeComponentCreator.py
+++ b/plugin/adsk/scripts/mayaUsd_initializeComponentCreator.py
@@ -1,0 +1,23 @@
+import os
+
+def initializeComponentCreator():
+    """
+    Look to see if the Component Creator Maya plugin is available and if so, do
+    nothing since the plugin will initialize itself. If not, try to initialize the
+    Component Creator directly.
+    """
+
+    haveCCPlugin = False
+    if 'MAYA_PLUG_IN_PATH' in os.environ:
+        pluginPath = os.environ['MAYA_PLUG_IN_PATH']
+        for pp in pluginPath.split(os.path.pathsep):
+            if os.path.exists(pp) and ('usd_component_creator.py'in os.listdir(pp)):
+                haveCCPlugin = True
+                break
+
+    if not haveCCPlugin:
+        try:
+            from usd_component_creator_plugin import initialize as initializeCC
+            initializeCC()
+        except:
+            print('Failed to initialize AdskUsdComponentCreator.')

--- a/plugin/adsk/scripts/mayaUsd_pluginUICreation.mel
+++ b/plugin/adsk/scripts/mayaUsd_pluginUICreation.mel
@@ -65,4 +65,10 @@ global proc mayaUsd_pluginUICreation()
         source "mayaUsdClearRefsOrPayloadsOptions.mel";
         source "mayaUsdDuplicateAsUsdDataOptions.mel";
     }
+
+    // Try and initialize the Component Creator. If the Component Creator is not available,
+    // it will fail gracefully and not cause any issues.
+    // The CC init code relies on MayaUsd being loaded, including menus which is why we
+    // try to initialize it here (last).
+    python("import mayaUsd_initializeComponentCreator; mayaUsd_initializeComponentCreator.initializeComponentCreator()");
 }

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -85,6 +85,11 @@ if (AdskUsdComponentCreator_FOUND)
         PYTHON_SCRIPT testAdskUsdComponentCreator.py
         ENV
             "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
+            # The earlier Component Creator installs had a Maya plugin to initialize the CC
+            # so we need to find the CC .mod file for the test.
+            # This can be removed once we integrate the update CC which removed the Maya plugin
+            # and we initialize the CC directly from MayaUsd. Having this MAYA_MODULE_PATH is
+            # okay after the CC update since this path won't exist and therefore will be ignored.
             "MAYA_MODULE_PATH=${CMAKE_INSTALL_PREFIX}/../AdskUsdComponentCreator"
             "PXR_OVERRIDE_PLUGINPATH_NAME=${CMAKE_INSTALL_PREFIX}/lib/usd"
     )

--- a/test/lib/testAdskUsdComponentCreator.py
+++ b/test/lib/testAdskUsdComponentCreator.py
@@ -26,16 +26,32 @@ import tempfile
 from maya import cmds
 
 import os
+import sys
 
 def _isCCAvailable():
-    if 'MAYA_MODULE_PATH' not in os.environ:
-        return False
-    for pp in os.environ['MAYA_MODULE_PATH'].split(os.path.pathsep):
-        if os.path.exists(pp) and 'usd_component_creator.mod' in os.listdir(pp):
-            return True
+    # Check to see if the AdskUsdComponentCreator exist in python path. If so it means
+    # we have the Component Creator installed with this MayaUsd.
+    for pp in sys.path:
+        if not os.path.exists(pp):
+            continue
+        with os.scandir(path=pp) as entries:
+            for entry in entries:
+                if entry.is_dir() and entry.name == 'AdskUsdComponentCreator':
+                    return True
     return False
 
+# The USD component creator Maya plugin will only be there in certain circumstances so
+# only try and load it if the CC Maya plugin actually exists.
+def haveMayaCCPlugin():
+    if 'MAYA_PLUG_IN_PATH' in os.environ:
+        pluginPath = os.environ['MAYA_PLUG_IN_PATH']
+        for pp in pluginPath.split(os.path.pathsep):
+            if os.path.exists(pp) and ('usd_component_creator.py' in os.listdir(pp)):
+                return True
+        return False
+
 _CC_AVAILABLE = _isCCAvailable()
+_HAVE_CC_MAYA_PLUGIN = haveMayaCCPlugin()
 
 class LoadComponentCreatorPluginTestCase(unittest.TestCase):
     """
@@ -47,16 +63,34 @@ class LoadComponentCreatorPluginTestCase(unittest.TestCase):
         fixturesUtils.readOnlySetUpClass(__file__, initializeStandalone=False)
 
     def testPluginLoadable(self):
+        forceTest = os.environ.get('MAYAUSD_FORCE_CC_TEST', '0') == '1'
         if not _CC_AVAILABLE:
-            forceTest = os.environ.get('MAYAUSD_FORCE_CC_TEST', '0') == '1'
             if forceTest:
-                self.fail('USD component creator plugin was not found but MAYAUSD_FORCE_CC_TEST is set. '
-                          'MAYA_MODULE_PATH={}'.format(os.environ.get('MAYA_MODULE_PATH', '')))
+                self.fail('AdskUsdComponentCreator was not found but MAYAUSD_FORCE_CC_TEST is set.')
             else:
-                self.skipTest('Could not find the USD component creator plugin')
+                self.skipTest('Could not find the AdskUsdComponentCreator.')
 
+        # Both cases rely on the MayaUsd plugin being loaded first.
         self.assertTrue(mayaUtils.loadPlugin('mayaUsdPlugin'))
-        self.assertTrue(mayaUtils.loadPlugin('usd_component_creator'))
+        if _HAVE_CC_MAYA_PLUGIN:
+            self.assertTrue(mayaUtils.loadPlugin('usd_component_creator'))
+        else:
+            # In Maya at startup the idle events are suspended during initialization to prevent
+            # plugins from being loaded before the UI is initialized.
+            #
+            # In an interactive test the startup command (for the test) is called before Maya
+            # resumes the idle event processing. So we need to force resume it here and flush
+            # the idle queue to ensure that the MayaUsd plugin UI Creation script is called
+            # which is where the Component Creator initialization is done.
+            #
+            cmds.flushIdleQueue(resume=True)
+            cmds.flushIdleQueue()
+
+            # The Component Creator Maya plugin was removed and replace with a direct CC
+            # initialization. We make sure CC was init correctly.
+            from usd_component_creator_plugin import is_initialized as is_initializedCC
+            is_cc_init = is_initializedCC()
+            self.assertTrue(is_cc_init, "Component Creator was not initialized but MAYAUSD_FORCE_CC_TEST is set.")
 
 
 class DuplicateToComponentTestCase(unittest.TestCase):
@@ -73,7 +107,12 @@ class DuplicateToComponentTestCase(unittest.TestCase):
         if not _CC_AVAILABLE:
             self.skipTest('Could not find the USD component creator plugin')
         mayaUtils.loadPlugin('mayaUsdPlugin')
-        mayaUtils.loadPlugin('usd_component_creator')
+        if _HAVE_CC_MAYA_PLUGIN:
+            mayaUtils.loadPlugin('usd_component_creator')
+        else:
+            # See comment in test above.
+            cmds.flushIdleQueue(resume=True)
+            cmds.flushIdleQueue()
         cmds.file(new=True, force=True)
 
     def _createComponent(self):


### PR DESCRIPTION
#### EMSUSDC-297 - Component Creator is not supported on Maya Creative
* New python script to initialize Component Creator (no Maya plugin). Call this script from MayaUsd plugin UI Creation script.
* Fix test to handle both cases: CC Maya plugin and init directly from MayaUsd.