### PR TITLE
Fix component reparent

### DIFF
--- a/lib/usdUfe/ufe/UsdUndoInsertChildCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoInsertChildCommand.cpp
@@ -354,9 +354,6 @@ void UsdUndoInsertChildCommand::execute()
     // to access the existing rules.
     preserveLoadRules(_ufeSrcPath, _usdSrcPath, _usdDstPath);
 
-    // Pause edit forwarding during the undo operation with RAII
-    const UsdUfe::EditForwardingGuard efPauser {};
-
     // We need to keep the generated item to be able to return it to the caller
     // via the insertedChild() member function.
     {
@@ -425,9 +422,6 @@ void UsdUndoInsertChildCommand::undo()
     // Note: the arguments passed are the opposite of those in execute and redo().
     preserveLoadRules(_ufeDstPath, _usdDstPath, _usdSrcPath);
 
-    // Pause edit forwarding during the undo operation with RAII
-    const UsdUfe::EditForwardingGuard efPauser {};
-
     _undoableItem.undo();
 
     // Note: the arguments passed are the opposite of those in execute and redo().
@@ -441,9 +435,6 @@ void UsdUndoInsertChildCommand::redo()
     // Load rules must be duplicated before the prim is moved to be able
     // to access the existing rules.
     preserveLoadRules(_ufeSrcPath, _usdSrcPath, _usdDstPath);
-
-    // Pause edit forwarding during the undo operation with RAII
-    const UsdUfe::EditForwardingGuard efPauser {};
 
     _undoableItem.redo();
 


### PR DESCRIPTION
We must not pause edit forwarding, because the reparent command outputs a flattened prim to the current edit target, and that needs to be forwarded.

I asked Anton to do this at review time, i thought, wrongly, that the reparenting was happening on the same source layer.