### PR TITLE
EMSUSD-3190 fix gcc 14 errors

### DIFF
--- a/cmake/compiler_config.cmake
+++ b/cmake/compiler_config.cmake
@@ -15,6 +15,7 @@ set(GNU_CLANG_FLAGS
     -Wno-deprecated
     -Wno-deprecated-declarations
     -Wno-unused-local-typedefs
+    -Wno-maybe-uninitialized
 )
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/cmake/compiler_config.cmake
+++ b/cmake/compiler_config.cmake
@@ -15,7 +15,6 @@ set(GNU_CLANG_FLAGS
     -Wno-deprecated
     -Wno-deprecated-declarations
     -Wno-unused-local-typedefs
-    -Wno-maybe-uninitialized
 )
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/lib/lookdevXUsd/UsdMaterialValidator.cpp
+++ b/lib/lookdevXUsd/UsdMaterialValidator.cpp
@@ -386,9 +386,9 @@ LookdevXUfe::AttributeComponentInfo UsdMaterialValidator::remapComponentConnecti
                     if (output)
                     {
 #if PXR_VERSION > 2408
-                        const auto& outputType = output->GetTypeAsSdfType().GetSdfType();
+                        const auto outputType = output->GetTypeAsSdfType().GetSdfType();
 #else
-                        const auto& outputType = output->GetTypeAsSdfType().first;
+                        const auto outputType = output->GetTypeAsSdfType().first;
 #endif
 
                         if (outputType == SdfValueTypeNames->Color3f || outputType == SdfValueTypeNames->Color4f)

--- a/lib/mayaUsd/CMakeLists.txt
+++ b/lib/mayaUsd/CMakeLists.txt
@@ -215,6 +215,19 @@ endif()
 
 mayaUsd_compile_config(${PROJECT_NAME})
 
+# This is to work around a warning that comes from OpenUSD VtValue header
+# in deeply templated code that end up swapping a value when removing data.
+# The data is being removed, so the warning is incorrect, but the compiler
+# cannot know that.
+if(IS_LINUX)
+    if(IS_GNU OR IS_CLANG)
+        target_compile_options(${PROJECT_NAME} 
+            PRIVATE
+                -Wno-maybe-uninitialized
+        )
+    endif()
+endif()
+
 # -----------------------------------------------------------------------------
 # include directories
 # -----------------------------------------------------------------------------

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -887,6 +887,9 @@ private:
 class RecordPullVariantInfoUndoItem : public MayaUsd::OpUndoItem
 {
 public:
+    // This avoids hiding the base class execute function.
+    using OpUndoItem::execute;
+
     // Add the path to the orphaned nodes manager, and add an undo entry onto
     // the global undo list.
     static bool execute(
@@ -942,6 +945,9 @@ private:
 class RemovePullVariantInfoUndoItem : public MayaUsd::OpUndoItem
 {
 public:
+    // This avoids hiding the base class execute function.
+    using OpUndoItem::execute;
+
     // Remove the path from the orphaned nodes manager, and add an entry onto
     // the global undo list.
     static bool execute(

--- a/lib/mayaUsd/undo/OpUndoItems.h
+++ b/lib/mayaUsd/undo/OpUndoItems.h
@@ -232,6 +232,9 @@ public:
     MAYAUSD_CORE_PUBLIC
     static bool execute(const std::string name, MString pythonDo, MString pythonUndo);
 
+    // This avoids hiding the base class execute function.
+    using OpUndoItem::execute;
+
     /// \brief create a python undo item.
     MAYAUSD_CORE_PUBLIC
     PythonUndoItem(const std::string name, MString pythonDo, MString pythonUndo);
@@ -292,6 +295,9 @@ public:
     MAYAUSD_CORE_PUBLIC
     static bool
     execute(const std::string name, std::function<bool()> redo, std::function<bool()> undo);
+
+    // This avoids hiding the base class execute function.
+    using OpUndoItem::execute;
 
     /// \brief create a function undo item.
     MAYAUSD_CORE_PUBLIC
@@ -489,6 +495,9 @@ public:
     MAYAUSD_CORE_PUBLIC
     static bool
     execute(const std::string& name, const std::shared_ptr<Ufe::UndoableCommand>& command);
+
+    // This avoids hiding the base class execute function.
+    using OpUndoItem::execute;
 
     /// \brief Keep track of a UFE command.
     MAYAUSD_CORE_PUBLIC


### PR DESCRIPTION
- Disabled a warning caused by an OpenUSD header.
- Fixed a c++ dangling reference.
- Fixed a base-class function being hidden by a sub-class.