### PR TITLE
MAYA-142796 Correctly report gateway on empty type

### DIFF
--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -187,6 +187,10 @@ std::string uniqueChildNameMayaStandard(
 
 bool isAGatewayType(const std::string& mayaNodeType)
 {
+    if (mayaNodeType.empty()) {
+        return false;
+    }
+
     // If we've seen this node type before, return the cached value.
     auto iter = g_GatewayType.find(mayaNodeType);
     if (iter != std::end(g_GatewayType)) {


### PR DESCRIPTION
I did not investigate much into why this only is an issue now... this code is very old and doesnt seem to have changed recently (?). Maybe something with how maya initializes? 

Anyway, the fix seems self evident.