### PR TITLE
UsdMaya_ReadJob: Avoid crash on invalid root variant prim name

### DIFF
--- a/lib/mayaUsd/fileio/jobs/readJob.cpp
+++ b/lib/mayaUsd/fileio/jobs/readJob.cpp
@@ -224,10 +224,15 @@ bool UsdMaya_ReadJob::Read(std::vector<MDagPath>* addedDagPaths)
     // Construct the variant opinion for the session layer.
     SdfLayerRefPtr sessionLayer = SdfLayer::CreateAnonymous();
     {
-        TfToken modelName = UsdUtilsGetModelNameFromRootLayer(rootLayer);
-        if (modelName != TfToken()) {
-            SdfVariantSelectionMap varSelsMap = mImportData.rootVariantSelections();
-            if (!modelName.IsEmpty()) {
+        const auto& varSelsMap = mImportData.rootVariantSelections();
+        if (!varSelsMap.empty()) {
+            const auto modelName = UsdUtilsGetModelNameFromRootLayer(rootLayer).GetString();
+            if (!SdfPrimSpec::IsValidName(modelName)) {
+                TF_WARN(
+                    "Could not determine a valid root prim for layer '%s'; "
+                    "ignoring the requested root variant selection(s).",
+                    rootLayer->GetDisplayName().c_str());
+            } else {
                 SdfPrimSpecHandle over
                     = SdfPrimSpec::New(sessionLayer, modelName, SdfSpecifierOver);
                 for (auto varSel : varSelsMap) {


### PR DESCRIPTION
Since maya-usd v0.35.0, `UsdMaya_ReadJob::Read` can crash when importing a layer:
- whose file path stem is not a valid prim spec name
- with no `defaultPrim`
- with no root prim specs

For example, importing file in [layer-with-hyphens.tar.gz](https://github.com/user-attachments/files/26148473/layer-with-hyphens.tar.gz) can crash.
```Python
maya.cmds.mayaUSDImport(file="layer-with-hyphens.usda", primPath="/")
```

In this case, `UsdMaya_ReadJob::Read` tries to author root variant selections on a prim name determined by `UsdUtilsGetModelNameFromRootLayer()`. When there is no `defaultPrim` or root prim, that function falls back to the layer file path stem. If that stem is not a valid prim spec name, `SdfPrimSpec::New()` fails and a null pointer is dereferenced.

Changes:
- guard against invalid `SdfPrimSpec` names and emit a warning
- skip creating the root prim spec when no root variant selection was requested