### PR TITLE
EMSUSD-3189: [GitHub #4521] 'Hide indices option' for the Display Layer Content

### DIFF
--- a/lib/mayaUsd/base/tokens.h
+++ b/lib/mayaUsd/base/tokens.h
@@ -80,6 +80,16 @@ PXR_NAMESPACE_OPEN_SCOPE
     ((AdskAssetResolverUserPathsFirst, "mayaUsd_AdskAssetResolverUserPathsFirst")) \
     /* option var to remember if only user paths are used in AdskAssetResolver */ \
     ((AdskAssetResolverUserPathsOnly, "mayaUsd_AdskAssetResolverUserPathsOnly")) \
+    /* option var to remember if the Layer Editor is show/hiding the Session Layer */ \
+    ((LayerEditorAutoHideSessionLayer, "MayaUSDLayerEditor_AutoHideSessionLayer")) \
+    /* option var to remember if the Layer Editor is displaying the layer contents */ \
+    ((LayerEditorDisplayLayerContents, "MayaUSDLayerEditor_DisplayLayerContents")) \
+    /* option var to remember if the Layer Editor contents is expanded to show all values or not */ \
+    ((LayerEditorExpandAllValues, "MayaUSDLayerEditor_DisplayLayerExpandAllValues")) \
+    /* option var to change the default array size limit for pseudoLayer output in Layer Contents */ \
+    ((LayerContentsArraySizeLimit, "MayaUSDLayerEditor_LayerContentsArraySizeLimit")) \
+    /* option var to change the default time sample size limit for pseudoLayer output in Layer Contents */ \
+    ((LayerContentsTimeSamplesSizeLimit, "MayaUSDLayerEditor_LayerContentsTimeSamplesSizeLimit")) \
 // clang-format on
 
 TF_DECLARE_PUBLIC_TOKENS(MayaUsdOptionVars, MAYAUSD_CORE_PUBLIC, MAYA_USD_OPTIONVAR_TOKENS);

--- a/lib/usd/ui/assetResolver/AssetResolverProjectChangeTracker.cpp
+++ b/lib/usd/ui/assetResolver/AssetResolverProjectChangeTracker.cpp
@@ -19,6 +19,9 @@
 #define MNoVersionString
 #include "AssetResolverUtils.h"
 
+#include <mayaUsd/base/tokens.h>
+#include <mayaUsd/utils/util.h>
+
 #include <maya/MCallbackIdArray.h>
 #include <maya/MGlobal.h>
 #include <maya/MString.h>
@@ -31,7 +34,7 @@ static MCallbackId _projectChangedId;
 void AssetResolverProjectChangeTracker::onProjectChanged(void* clientData)
 {
     const bool includeMayaProjectTokens
-        = MGlobal::optionVarIntValue("mayaUsd_AdskAssetResolverIncludeMayaToken");
+        = MGlobal::optionVarIntValue(UsdMayaUtil::convert(MayaUsdOptionVars->IncludeMayaTokenInAR));
     if (includeMayaProjectTokens)
         AssetResolverUtils::includeMayaProjectTokensInAdskAssetResolver();
 }

--- a/lib/usd/ui/assetResolver/PreferencesManagement.cpp
+++ b/lib/usd/ui/assetResolver/PreferencesManagement.cpp
@@ -18,6 +18,9 @@
 #include "AssetResolverUtils.h"
 #include "PreferencesApplicationHost.h"
 
+#include <mayaUsd/base/tokens.h>
+#include <mayaUsd/utils/util.h>
+
 #include <pxr/base/tf/stringUtils.h>
 
 #include <maya/MGlobal.h>
@@ -33,11 +36,16 @@ namespace MAYAUSD_NS_DEF {
 namespace PreferencesManagement {
 
 // Option variable names
-static const MString OPT_VAR_USE_PROJECT_TOKENS = "mayaUsd_AdskAssetResolverIncludeMayaToken";
-static const MString OPT_VAR_MAPPING_FILE = "mayaUsd_AdskAssetResolverMappingFile";
-static const MString OPT_VAR_USER_SEARCH_PATHS = "mayaUsd_AdskAssetResolverUserSearchPaths";
-static const MString OPT_VAR_USER_PATHS_FIRST = "mayaUsd_AdskAssetResolverUserPathsFirst";
-static const MString OPT_VAR_USER_PATHS_ONLY = "mayaUsd_AdskAssetResolverUserPathsOnly";
+static const MString OPT_VAR_USE_PROJECT_TOKENS
+    = UsdMayaUtil::convert(MayaUsdOptionVars->IncludeMayaTokenInAR);
+static const MString OPT_VAR_MAPPING_FILE
+    = UsdMayaUtil::convert(MayaUsdOptionVars->AdskAssetResolverMappingFile);
+static const MString OPT_VAR_USER_SEARCH_PATHS
+    = UsdMayaUtil::convert(MayaUsdOptionVars->AdskAssetResolverUserSearchPaths);
+static const MString OPT_VAR_USER_PATHS_FIRST
+    = UsdMayaUtil::convert(MayaUsdOptionVars->AdskAssetResolverUserPathsFirst);
+static const MString OPT_VAR_USER_PATHS_ONLY
+    = UsdMayaUtil::convert(MayaUsdOptionVars->AdskAssetResolverUserPathsOnly);
 
 pxr::VtDictionary LoadUsdPreferences()
 {

--- a/lib/usd/ui/layerEditor/layerContentsWidget.cpp
+++ b/lib/usd/ui/layerEditor/layerContentsWidget.cpp
@@ -15,10 +15,234 @@
 //
 #include "layerContentsWidget.h"
 
+#include "layerTreeModel.h"
 #include "stringResources.h"
 #include "usdSyntaxHighlighter.h"
 
+#include <mayaUsd/base/tokens.h>
+#include <mayaUsd/utils/util.h>
+
+#include <pxr/base/tf/patternMatcher.h>
+#include <pxr/base/tf/stringUtils.h>
+#include <pxr/usd/sdf/copyUtils.h>
+#include <pxr/usd/sdf/layer.h>
+#include <pxr/usd/sdf/primSpec.h>
+#include <pxr/usd/sdf/usdFileFormat.h>
+#include <pxr/usd/sdf/usdaFileFormat.h>
+
+#include <maya/MGlobal.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace UsdLayerEditor {
+
+namespace OutputType {
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+// clang-format off
+
+// This code was copied from Pixar OpenUSD's sdffilter.cpp, with some modifications to fit our use case.
+// I disabled the clang-format for this section to preserve the original formatting of the code, which makes
+// it easier to maintain when comparing to the original source.
+
+// A file format for the human readable "pseudoLayer" output.  We use this so
+// that the terse human-readable output we produce is not a valid layer nor may
+// be mistaken for one.
+class SdfFilterPseudoFileFormat : public SdfUsdaFileFormat
+{
+private:
+    SDF_FILE_FORMAT_FACTORY_ACCESS;
+
+public:
+    SdfFilterPseudoFileFormat(std::string description="<< human readable >>")
+        : SdfUsdaFileFormat(TfToken("pseudousda"),
+                            TfToken(description),
+                            SdfUsdFileFormatTokens->Target) {}
+private:
+
+    virtual ~SdfFilterPseudoFileFormat() {}
+};
+
+TF_REGISTRY_FUNCTION(TfType)
+{
+    SDF_DEFINE_FILE_FORMAT(SdfFilterPseudoFileFormat, SdfUsdaFileFormat);
+}
+
+// An enum representing the type of output to produce.
+enum OutputType {
+    OutputPseudoLayer,  // report as human readable text, as close to a
+                        // valid layer as possible
+    OutputLayer         // produce a valid layer as output.
+};
+
+// We use this structure to represent all the parameters for reporting. 
+struct ReportParams
+{
+    std::shared_ptr<TfPatternMatcher> pathMatcher;
+    std::shared_ptr<TfPatternMatcher> fieldMatcher;
+
+    // Default to the most human readable output (pseudoLayer) which is the only
+    // time we use ReportParams.
+    OutputType outputType = OutputType::OutputPseudoLayer;
+
+    int64_t arraySizeLimit = 8;
+    int64_t timeSamplesSizeLimit = 8;
+};
+
+// Find all the paths in layer that match, or all paths if matcher is null.
+std::vector<SdfPath>
+CollectMatchingSpecPaths(SdfLayerHandle const &layer,
+                         TfPatternMatcher const *matcher)
+{
+    std::vector<SdfPath> result;
+    layer->Traverse(SdfPath::AbsoluteRootPath(),
+                    [&result, &matcher](SdfPath const &path) {
+                        if (!matcher || matcher->Match(path.GetString()))
+                            result.push_back(path);
+                    });
+    return result;
+}
+
+// Closeness check with relative tolerance.
+bool IsClose(double a, double b, double tol)
+{
+    double absDiff = fabs(a-b);
+    return absDiff <= fabs(tol*a) || absDiff < fabs(tol*b);
+}
+
+// Get a suitable value for the report specified by p.  In particular, for
+// non-layer output, make a value that shows only array type & size for large
+// arrays.
+VtValue
+GetReportValue(VtValue const &value, ReportParams const &p)
+{
+    if (p.outputType != OutputLayer &&
+        p.arraySizeLimit >= 0 &&
+        value.IsArrayValued() &&
+        value.GetArraySize() > static_cast<uint64_t>(p.arraySizeLimit)) {
+        return VtValue(
+            SdfHumanReadableValue(
+                TfStringPrintf(
+                    "%s[%zu]",
+                    ArchGetDemangled(value.GetElementTypeid()).c_str(),
+                    value.GetArraySize())));
+    }
+    return value;
+}
+
+// Get a suitable value for timeSamples for the report specified by p.  In
+// particular, for non-layer output, make a value that shows number of samples
+// and their time range.
+VtValue
+GetReportTimeSamplesValue(SdfLayerHandle const &layer,
+                          SdfPath const &path, ReportParams const &p)
+{
+    auto times = layer->ListTimeSamplesForPath(path);
+    std::vector<double> selectedTimes;
+    selectedTimes.reserve(times.size());
+
+    selectedTimes.assign(times.begin(), times.end());
+
+    if (selectedTimes.empty())
+        return VtValue();
+
+    SdfTimeSampleMap result;
+    
+    VtValue val;
+    if (p.outputType != OutputLayer &&
+        p.timeSamplesSizeLimit >= 0 &&
+        selectedTimes.size() > static_cast<uint64_t>(p.timeSamplesSizeLimit)) {
+        return VtValue(
+            SdfHumanReadableValue(
+                TfStringPrintf("%zu samples in [%s, %s]",
+                               times.size(),
+                               TfStringify(*times.begin()).c_str(),
+                               TfStringify(*(--times.end())).c_str())
+                )
+            );
+    }
+    else {
+        for (auto time: selectedTimes) {
+            TF_VERIFY(layer->QueryTimeSample(path, time, &val));
+            result[time] = GetReportValue(val, p);
+        }
+    }
+    return VtValue(result);
+}
+
+// Get a suitable value for the report specified by p.  In particular, for
+// non-layer output, make a value that shows only array type & size for large
+// arrays or number of time samples and time range for large timeSamples.
+VtValue
+GetReportFieldValue(SdfLayerHandle const &layer,
+                           SdfPath const &path, TfToken const &field,
+                           ReportParams const &p)
+{
+    VtValue result;
+    // Handle timeSamples specially:
+    if (field == SdfFieldKeys->TimeSamples) {
+        result = GetReportTimeSamplesValue(layer, path, p);
+    } else {
+        TF_VERIFY(layer->HasField(path, field, &result));
+        result = GetReportValue(result, p);
+    }
+    return result;
+}
+
+// Utility function to filter a layer by the params p.  This copies fields,
+// replacing large arrays and timeSamples with human readable values if
+// appropriate, and skipping paths and fields that do not match the matchers in
+// p.
+void
+FilterLayer(SdfLayerHandle const &inLayer,
+            SdfLayerHandle const &outLayer,
+            ReportParams const &p)
+{
+    namespace ph = std::placeholders;
+    auto copyValueFn = [&p](
+        SdfSpecType specType, TfToken const &field,
+        SdfLayerHandle const &srcLayer, const SdfPath& srcPath, bool fieldInSrc,
+        const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool fieldInDst,
+        std::optional<VtValue> *valueToCopy) {
+
+        if (!p.fieldMatcher || p.fieldMatcher->Match(field.GetString())) {
+            *valueToCopy = GetReportFieldValue(
+                srcLayer, srcPath, field, p);
+            return !(*valueToCopy)->IsEmpty();
+        }
+        else {
+            return false;
+        }
+    };
+
+    std::vector<SdfPath> paths =
+        CollectMatchingSpecPaths(inLayer, p.pathMatcher.get());
+    for (auto const &path: paths) {
+        if (path == SdfPath::AbsoluteRootPath() ||
+            path.IsPrimOrPrimVariantSelectionPath()) {
+            SdfPrimSpecHandle outPrim = SdfCreatePrimInLayer(outLayer, path);
+            SdfCopySpec(inLayer, path, outLayer, path,
+                        copyValueFn,
+                        std::bind(SdfShouldCopyChildren,
+                                  std::cref(path), std::cref(path),
+                                  ph::_1, ph::_2, ph::_3, ph::_4, ph::_5,
+                                  ph::_6, ph::_7, ph::_8, ph::_9));
+        }
+    }
+}
+
+// clang-format on
+
+} // namespace OutputType
+
+struct SuspendUsdNotices
+{
+    SuspendUsdNotices() { LayerTreeModel::suspendUsdNotices(true); }
+    ~SuspendUsdNotices() { LayerTreeModel::suspendUsdNotices(false); }
+};
 
 LayerContentsWidget::LayerContentsWidget(QWidget* in_parent)
     : QWidget(in_parent)
@@ -49,7 +273,9 @@ void LayerContentsWidget::createUI()
     setLayout(mainLayout);
 }
 
-void LayerContentsWidget::setLayer(const PXR_NS::SdfLayerRefPtr in_layer)
+void LayerContentsWidget::setLayer(
+    const PXR_NS::SdfLayerRefPtr in_layer,
+    bool                         expandAllValues /*= false*/)
 {
     if (_layerContents) {
         // Always clear the contents first as an input layer of nullptr means clear.
@@ -61,12 +287,55 @@ void LayerContentsWidget::setLayer(const PXR_NS::SdfLayerRefPtr in_layer)
             std::string layerText;
             // Note: potentially slow operation for large layers.
             //       We could consider doing this in a worker thread if needed.
-            if (in_layer->ExportToString(&layerText)) {
+
+            bool layerExported { false };
+            if (!expandAllValues) {
+                layerExported = exportPseudoLayer(in_layer, layerText);
+            } else {
+                layerExported = in_layer->ExportToString(&layerText);
+            }
+
+            if (layerExported) {
                 _layerContents->setPlainText(QString::fromStdString(layerText));
                 _isEmpty = false;
             }
         }
     }
+}
+
+bool LayerContentsWidget::exportPseudoLayer(
+    const PXR_NS::SdfLayerRefPtr in_layer,
+    std::string&                 out_contents)
+{
+    // Suspend all notices while we do this, since the pseudo layer is not a real layer and may have
+    // fields that would trigger notices that we don't want which cause the LE to rebuild.
+    SuspendUsdNotices suspendNotices;
+
+    // Make the pseudo layer and copy into it, then export.
+    PXR_NS::SdfFileFormatConstRefPtr fmt;
+    OutputType::ReportParams         params;
+
+    // Check if the user wants to change any of the size limits.
+    bool exists { false };
+    int  opt = MGlobal::optionVarIntValue(
+        UsdMayaUtil::convert(MayaUsdOptionVars->LayerContentsArraySizeLimit), &exists);
+    if (exists) {
+        params.arraySizeLimit = opt;
+    }
+    opt = MGlobal::optionVarIntValue(
+        UsdMayaUtil::convert(MayaUsdOptionVars->LayerContentsTimeSamplesSizeLimit), &exists);
+    if (exists) {
+        params.timeSamplesSizeLimit = opt;
+    }
+
+    fmt = PXR_NS::TfCreateRefPtr(new OutputType::SdfFilterPseudoFileFormat(
+        PXR_NS::TfStringPrintf("from @%s@", in_layer->GetIdentifier().c_str())));
+    auto pseudoLayer = PXR_NS::SdfLayer::CreateAnonymous(".pseudousda", fmt);
+
+    // Generate the layer content.
+    OutputType::FilterLayer(in_layer, pseudoLayer, params);
+
+    return pseudoLayer->ExportToString(&out_contents);
 }
 
 void LayerContentsWidget::clear()

--- a/lib/usd/ui/layerEditor/layerContentsWidget.cpp
+++ b/lib/usd/ui/layerEditor/layerContentsWidget.cpp
@@ -19,16 +19,23 @@
 #include "stringResources.h"
 #include "usdSyntaxHighlighter.h"
 
+#include <cxx17_legacy_support.h>
 #include <mayaUsd/base/tokens.h>
 #include <mayaUsd/utils/util.h>
 
 #include <pxr/base/tf/patternMatcher.h>
 #include <pxr/base/tf/stringUtils.h>
+#include <pxr/base/vt/value.h>
 #include <pxr/usd/sdf/copyUtils.h>
 #include <pxr/usd/sdf/layer.h>
 #include <pxr/usd/sdf/primSpec.h>
+
+#if PXR_VERSION < 2508
+#include "pxr/usd/sdf/textFileFormat.h"
+#else
 #include <pxr/usd/sdf/usdFileFormat.h>
 #include <pxr/usd/sdf/usdaFileFormat.h>
+#endif
 
 #include <maya/MGlobal.h>
 
@@ -51,16 +58,23 @@ PXR_NAMESPACE_USING_DIRECTIVE
 // A file format for the human readable "pseudoLayer" output.  We use this so
 // that the terse human-readable output we produce is not a valid layer nor may
 // be mistaken for one.
-class SdfFilterPseudoFileFormat : public SdfUsdaFileFormat
+#if PXR_VERSION < 2508
+#define LCWBASEFILEFORMAT SdfTextFileFormat
+#define LCWBASEFILEFORMATTOKENS SdfTextFileFormatTokens
+#else
+#define LCWBASEFILEFORMAT SdfUsdaFileFormat
+#define LCWBASEFILEFORMATTOKENS SdfUsdFileFormatTokens
+#endif
+class SdfFilterPseudoFileFormat : public LCWBASEFILEFORMAT
 {
 private:
     SDF_FILE_FORMAT_FACTORY_ACCESS;
 
 public:
     SdfFilterPseudoFileFormat(std::string description="<< human readable >>")
-        : SdfUsdaFileFormat(TfToken("pseudousda"),
+        : LCWBASEFILEFORMAT(TfToken("pseudousda"),
                             TfToken(description),
-                            SdfUsdFileFormatTokens->Target) {}
+                            LCWBASEFILEFORMATTOKENS->Target) {}
 private:
 
     virtual ~SdfFilterPseudoFileFormat() {}
@@ -68,7 +82,7 @@ private:
 
 TF_REGISTRY_FUNCTION(TfType)
 {
-    SDF_DEFINE_FILE_FORMAT(SdfFilterPseudoFileFormat, SdfUsdaFileFormat);
+    SDF_DEFINE_FILE_FORMAT(SdfFilterPseudoFileFormat, LCWBASEFILEFORMAT);
 }
 
 // An enum representing the type of output to produce.
@@ -206,8 +220,12 @@ FilterLayer(SdfLayerHandle const &inLayer,
         SdfSpecType specType, TfToken const &field,
         SdfLayerHandle const &srcLayer, const SdfPath& srcPath, bool fieldInSrc,
         const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool fieldInDst,
-        std::optional<VtValue> *valueToCopy) {
-
+#if PXR_VERSION >= 2403
+        std::optional<VtValue> *valueToCopy)
+#else
+        boost::optional<VtValue> *valueToCopy)
+#endif
+    {
         if (!p.fieldMatcher || p.fieldMatcher->Match(field.GetString())) {
             *valueToCopy = GetReportFieldValue(
                 srcLayer, srcPath, field, p);

--- a/lib/usd/ui/layerEditor/layerContentsWidget.h
+++ b/lib/usd/ui/layerEditor/layerContentsWidget.h
@@ -40,13 +40,15 @@ public:
     LayerContentsWidget(QWidget* in_parent);
     ~LayerContentsWidget() override;
 
-    void setLayer(const PXR_NS::SdfLayerRefPtr);
+    void setLayer(const PXR_NS::SdfLayerRefPtr, bool expandAllValues = false);
 
     void clear();
     bool isEmpty() const { return _isEmpty; }
 
 private:
     void createUI();
+
+    bool exportPseudoLayer(const PXR_NS::SdfLayerRefPtr in_layer, std::string& out_contents);
 
     QPointer<QTextEdit>          _layerContents;
     QPointer<QSyntaxHighlighter> _syntaxHighlighter;

--- a/lib/usd/ui/layerEditor/layerEditorWidget.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.cpp
@@ -273,6 +273,8 @@ void LayerEditorWidget::setupDefaultMenu(QMainWindow* in_parent)
         _actions._autoHide->setCheckable(true);
         _actions._autoHide->setChecked(ss->autoHideSessionLayer());
 
+        optionMenu->addSeparator();
+
         _actions._displayLayerContents = optionMenu->addAction(
             StringResources::getAsQString(StringResources::kDisplayLayerContents));
         QObject::connect(
@@ -282,6 +284,18 @@ void LayerEditorWidget::setupDefaultMenu(QMainWindow* in_parent)
             &SessionState::setDisplayLayerContents);
         _actions._displayLayerContents->setCheckable(true);
         _actions._displayLayerContents->setChecked(ss->displayLayerContents());
+
+        _actions._displayLayerExpandAllValues = optionMenu->addAction(
+            StringResources::getAsQString(StringResources::kDisplayLayerExpandAllValues));
+        _actions._displayLayerExpandAllValues->setStatusTip(
+            StringResources::getAsQString(StringResources::kDisplayLayerExpandAllValuesTooltip));
+        QObject::connect(
+            _actions._displayLayerExpandAllValues,
+            &QAction::toggled,
+            ss,
+            &SessionState::setDisplayLayerExpandAllValues);
+        _actions._displayLayerExpandAllValues->setCheckable(true);
+        _actions._displayLayerExpandAllValues->setChecked(ss->diplayLayerExpandAllValues());
 
         auto helpMenu = menuBar->addMenu(StringResources::getAsQString(StringResources::kHelp));
         helpMenu->addAction(
@@ -496,7 +510,8 @@ void LayerEditorWidget::updateLayerContentsWidget()
         if (selection.size() == 1) {
             const auto model = _treeView->layerTreeModel();
             auto       layerTreeItem = model->layerItemFromIndex(selection[0]);
-            _layerContents->setLayer(layerTreeItem->layer());
+            _layerContents->setLayer(
+                layerTreeItem->layer(), _sessionState.diplayLayerExpandAllValues());
         } else {
             // If there is no selection or multiple items selected, clear the contents.
             _layerContents->setLayer(nullptr);

--- a/lib/usd/ui/layerEditor/layerEditorWidget.h
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.h
@@ -79,6 +79,7 @@ protected:
     {
         QAction* _autoHide { nullptr };
         QAction* _displayLayerContents { nullptr };
+        QAction* _displayLayerExpandAllValues { nullptr };
     } _actions;
     void updateNewLayerButton();
     void updateButtons();

--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -19,6 +19,7 @@
 #include "saveLayersDialog.h"
 #include "stringResources.h"
 
+#include <mayaUsd/base/tokens.h>
 #include <mayaUsd/nodes/layerManager.h>
 #include <mayaUsd/nodes/proxyShapeBase.h>
 #include <mayaUsd/nodes/usdPrimProvider.h>
@@ -45,8 +46,12 @@ PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace {
 MString PROXY_NODE_TYPE = "mayaUsdProxyShapeBase";
-MString AUTO_HIDE_OPTION_VAR = "MayaUSDLayerEditor_AutoHideSessionLayer";
-MString DISPLAY_LAYER_CONTENTS_OPTION_VAR = "MayaUSDLayerEditor_DisplayLayerContents";
+MString AUTO_HIDE_OPTION_VAR
+    = UsdMayaUtil::convert(MayaUsdOptionVars->LayerEditorAutoHideSessionLayer);
+MString DISPLAY_LAYER_CONTENTS_OPTION_VAR
+    = UsdMayaUtil::convert(MayaUsdOptionVars->LayerEditorDisplayLayerContents);
+MString DISPLAY_LAYER_EXPAND_ALL_VALUES_OPTION_VAR
+    = UsdMayaUtil::convert(MayaUsdOptionVars->LayerEditorExpandAllValues);
 } // namespace
 
 namespace UsdLayerEditor {
@@ -59,6 +64,10 @@ MayaSessionState::MayaSessionState()
     }
     if (MGlobal::optionVarExists(DISPLAY_LAYER_CONTENTS_OPTION_VAR)) {
         _displayLayerContents = MGlobal::optionVarIntValue(DISPLAY_LAYER_CONTENTS_OPTION_VAR) != 0;
+    }
+    if (MGlobal::optionVarExists(DISPLAY_LAYER_EXPAND_ALL_VALUES_OPTION_VAR)) {
+        _displayLayerExpandAllValues
+            = MGlobal::optionVarIntValue(DISPLAY_LAYER_EXPAND_ALL_VALUES_OPTION_VAR) != 0;
     }
 
     registerNotifications();
@@ -439,6 +448,13 @@ void MayaSessionState::setDisplayLayerContents(bool showIt)
     int value = showIt ? 1 : 0;
     MGlobal::setOptionVarValue(DISPLAY_LAYER_CONTENTS_OPTION_VAR, value);
     PARENT_CLASS::setDisplayLayerContents(showIt);
+}
+
+void MayaSessionState::setDisplayLayerExpandAllValues(bool expand)
+{
+    int value = expand ? 1 : 0;
+    MGlobal::setOptionVarValue(DISPLAY_LAYER_EXPAND_ALL_VALUES_OPTION_VAR, value);
+    PARENT_CLASS::setDisplayLayerExpandAllValues(expand);
 }
 
 void MayaSessionState::printLayer(const PXR_NS::SdfLayerRefPtr& layer) const

--- a/lib/usd/ui/layerEditor/mayaSessionState.h
+++ b/lib/usd/ui/layerEditor/mayaSessionState.h
@@ -51,9 +51,11 @@ public:
     ~MayaSessionState();
 
     // API implementation
-    void                    setStageEntry(StageEntry const& in_entry) override;
-    void                    setAutoHideSessionLayer(bool hide) override;
-    void                    setDisplayLayerContents(bool show) override;
+    void setStageEntry(StageEntry const& in_entry) override;
+    void setAutoHideSessionLayer(bool hide) override;
+    void setDisplayLayerContents(bool show) override;
+    void setDisplayLayerExpandAllValues(bool expand) override;
+
     AbstractCommandHook*    commandHook() override;
     std::vector<StageEntry> allStages() const override;
     // path to default load layer dialogs to

--- a/lib/usd/ui/layerEditor/sessionState.cpp
+++ b/lib/usd/ui/layerEditor/sessionState.cpp
@@ -29,6 +29,12 @@ void SessionState::setDisplayLayerContents(bool showIt)
     Q_EMIT showDisplayLayerContents(showIt);
 }
 
+void SessionState::setDisplayLayerExpandAllValues(bool expand)
+{
+    _displayLayerExpandAllValues = expand;
+    Q_EMIT showDisplayLayerContents(_displayLayerContents);
+}
+
 void SessionState::setStageEntry(StageEntry const& in_entry)
 {
     if (_currentStageEntry != in_entry) {

--- a/lib/usd/ui/layerEditor/sessionState.h
+++ b/lib/usd/ui/layerEditor/sessionState.h
@@ -76,10 +76,13 @@ public:
     };
 
     // properties
-    virtual bool                    autoHideSessionLayer() const { return _autoHideSessionLayer; }
-    virtual void                    setAutoHideSessionLayer(bool hide);
-    virtual bool                    displayLayerContents() const { return _displayLayerContents; }
-    virtual void                    setDisplayLayerContents(bool show);
+    virtual bool autoHideSessionLayer() const { return _autoHideSessionLayer; }
+    virtual void setAutoHideSessionLayer(bool hide);
+    virtual bool displayLayerContents() const { return _displayLayerContents; }
+    virtual void setDisplayLayerContents(bool show);
+    virtual bool diplayLayerExpandAllValues() const { return _displayLayerExpandAllValues; }
+    virtual void setDisplayLayerExpandAllValues(bool expand);
+
     PXR_NS::UsdStageRefPtr const&   stage() const { return _currentStageEntry._stage; }
     StageEntry const&               stageEntry() const { return _currentStageEntry; }
     PXR_NS::SdfLayerRefPtr          targetLayer() const;
@@ -119,8 +122,9 @@ Q_SIGNALS:
 
 protected:
     StageEntry _currentStageEntry;
-    bool       _autoHideSessionLayer = true;
-    bool       _displayLayerContents = true;
+    bool       _autoHideSessionLayer { true };
+    bool       _displayLayerContents { true };
+    bool       _displayLayerExpandAllValues { false };
 };
 
 } // namespace UsdLayerEditor

--- a/lib/usd/ui/layerEditor/stringResources.h
+++ b/lib/usd/ui/layerEditor/stringResources.h
@@ -52,6 +52,9 @@ const auto kAddSublayer                  { create("kAddSublayer", "Add sublayer"
 const auto kAutoHideSessionLayer         { create("kAutoHideSessionLayer", "Auto-Hide Session Layer") };
 const auto kDisplayLayerContents         { create("kDisplayLayerContents", "Display Layer Content") };
 const auto kDisplayLayerContentsEmpty    { create("kDisplayLayerContentsEmpty", "Select a single layer to display the contents.\n\nLarge layers may take longer to load.") };
+const auto kDisplayLayerExpandAllValues  { create("kDisplayLayerExpandAllValues", "Expand All Values") };
+const auto kDisplayLayerExpandAllValuesTooltip { create("kDisplayLayerExpandAllValuesTooltip",
+                                                        "Enable to display all array values and timeSamples in the layer content") };
 const auto kConvertToRelativePath        { create("kConvertToRelativePath", "Convert to Relative Path") };
 const auto kCancel                       { create("kCancel", "Cancel") };
 const auto kCreate                       { create("kCreate", "Create") };

--- a/plugin/adsk/plugin/plugin.cpp
+++ b/plugin/adsk/plugin/plugin.cpp
@@ -29,6 +29,7 @@
 #include "mayaUsdInfoCommand.h"
 
 #include <mayaUsd/base/api.h>
+#include <mayaUsd/base/tokens.h>
 #include <mayaUsd/commands/editTargetCommand.h>
 #include <mayaUsd/commands/layerEditorCommand.h>
 #include <mayaUsd/commands/layerEditorWindowCommand.h>
@@ -46,6 +47,7 @@
 #include <mayaUsd/undo/MayaUsdUndoBlock.h>
 #include <mayaUsd/utils/diagnosticDelegate.h>
 #include <mayaUsd/utils/undoHelperCommand.h>
+#include <mayaUsd/utils/util.h>
 
 #include <pxr/base/plug/plugin.h>
 #include <pxr/base/plug/registry.h>
@@ -434,7 +436,7 @@ MStatus initializePlugin(MObject obj)
 
         // Load Maya project tokens to AdskAssetResolver if the preference is enabled
         // This needs to be done after InitializeUsdPreferences()
-        static const MString IncludeMayaTokenInAR = "mayaUsd_AdskAssetResolverIncludeMayaToken";
+        auto IncludeMayaTokenInAR = UsdMayaUtil::convert(MayaUsdOptionVars->IncludeMayaTokenInAR);
         if (MGlobal::optionVarExists(IncludeMayaTokenInAR)
             && MGlobal::optionVarIntValue(IncludeMayaTokenInAR)) {
             MayaUsd::AssetResolverUtils::includeMayaProjectTokensInAdskAssetResolver();

--- a/test/lib/mayaUsd/fileio/testHideOrphanedNodes.py
+++ b/test/lib/mayaUsd/fileio/testHideOrphanedNodes.py
@@ -268,7 +268,7 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
         cMayaPathStr = mayaUsd.lib.PrimUpdaterManager.readPullInformation(cPrim)
         self.assertEqual(cMayaPathStr, '')
 
-        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 2))
+        cmds.optionVar(intValue=(mayaUsd.lib.OptionVarTokens.SerializedUsdEditsLocation, 2))
         filename = os.path.abspath("orphaned.ma")
         self._saveScene(filename)
         self._reloadScene(filename)

--- a/test/lib/mayaUsd/fileio/testNonLocalEditTargetLayer.py
+++ b/test/lib/mayaUsd/fileio/testNonLocalEditTargetLayer.py
@@ -104,7 +104,7 @@ class NonLocalEditTargetLayer(unittest.TestCase):
     def _saveAndReopen(self, sceneName, testDir, saveLocation, proxyShapePath):
         targetLayerPath = os.path.join(testDir, 'data', 'nested_reference_geo.usda')
         # Save and reopen the maya file
-        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', saveLocation))
+        cmds.optionVar(intValue=(mayaUsd.lib.OptionVarTokens.SerializedUsdEditsLocation, saveLocation))
         tempMayaFile = os.path.join(testDir, '{}.ma'.format(sceneName))
         cmds.file(rename=tempMayaFile)
         cmds.file(save=True, force=True, type='mayaAscii')

--- a/test/lib/mayaUsd/fileio/testSaveLockedAnonLayer.py
+++ b/test/lib/mayaUsd/fileio/testSaveLockedAnonLayer.py
@@ -93,7 +93,7 @@ class SaveLockedLayerTest(unittest.TestCase):
 
         # Save the file. Make sure the edit will go where requested by saveLocation.
         tempMayaFile = 'saveLockedAnonLayer.ma'
-        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', saveLocation))
+        cmds.optionVar(intValue=(mayaUsd.lib.OptionVarTokens.SerializedUsdEditsLocation, saveLocation))
         cmds.file(rename=tempMayaFile)
         cmds.file(save=True, force=True, type='mayaAscii')
 
@@ -164,7 +164,7 @@ class SaveLockedLayerTest(unittest.TestCase):
 
         # Save the file. Make sure the edit will go where requested by saveLocation.
         tempMayaFile = 'saveSystemLockedAnonLayer.ma'
-        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', saveLocation))
+        cmds.optionVar(intValue=(mayaUsd.lib.OptionVarTokens.SerializedUsdEditsLocation, saveLocation))
         cmds.file(rename=tempMayaFile)
         cmds.file(save=True, force=True, type='mayaAscii')
 

--- a/test/lib/mayaUsd/fileio/testSaveMixedLocations.py
+++ b/test/lib/mayaUsd/fileio/testSaveMixedLocations.py
@@ -108,7 +108,7 @@ class SaveMixedLocationsTest(unittest.TestCase):
         # saveLocation 1 means on-disk, 2 in the Maya scene.
         saveLocation = 2
         tempMayaFile = 'saveMixedLocationsTest.ma'
-        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', saveLocation))
+        cmds.optionVar(intValue=(mayaUsd.lib.OptionVarTokens.SerializedUsdEditsLocation, saveLocation))
         cmds.file(rename=tempMayaFile)
         cmds.file(save=True, force=True, type='mayaAscii')
 

--- a/test/lib/mayaUsd/fileio/testSaveMutedAnonLayer.py
+++ b/test/lib/mayaUsd/fileio/testSaveMutedAnonLayer.py
@@ -93,7 +93,7 @@ class SaveMutedLayerTest(unittest.TestCase):
 
         # Save the file. Make sure the edit will go where requested by saveLocation.
         tempMayaFile = 'saveMutedAnonLayer.ma'
-        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', saveLocation))
+        cmds.optionVar(intValue=(mayaUsd.lib.OptionVarTokens.SerializedUsdEditsLocation, saveLocation))
         cmds.file(rename=tempMayaFile)
         cmds.file(save=True, force=True, type='mayaAscii')
 

--- a/test/lib/mayaUsd/fileio/testSaveUpAxisAndUnits.py
+++ b/test/lib/mayaUsd/fileio/testSaveUpAxisAndUnits.py
@@ -92,7 +92,7 @@ class SaveUpAxisAndUnitsTest(unittest.TestCase):
         # saveLocation 1 means on-disk, 2 in the Maya scene.
         saveLocation = 1 if saveOnDisk else 2
         tempMayaFile = 'saveUpAxisAndUnitsTest.ma'
-        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', saveLocation))
+        cmds.optionVar(intValue=(mayaUsd.lib.OptionVarTokens.SerializedUsdEditsLocation, saveLocation))
         cmds.file(rename=tempMayaFile)
         cmds.file(save=True, force=True, type='mayaAscii')
 

--- a/test/lib/mayaUsd/nodes/testLayerManagerSerialization.py
+++ b/test/lib/mayaUsd/nodes/testLayerManagerSerialization.py
@@ -173,7 +173,7 @@ class testLayerManagerSerialization(unittest.TestCase):
         '''
         self.copyTestFilesAndMakeEdits()
 
-        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 2))
+        cmds.optionVar(intValue=(mayaUsdLib.OptionVarTokens.SerializedUsdEditsLocation, 2))
 
         cmds.file(save=True, force=True)
         cmds.file(new=True, force=True)
@@ -196,7 +196,7 @@ class testLayerManagerSerialization(unittest.TestCase):
         '''
         self.copyTestFilesAndMakeEdits()
 
-        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 1))
+        cmds.optionVar(intValue=(mayaUsdLib.OptionVarTokens.SerializedUsdEditsLocation, 1))
 
         cmds.file(save=True, force=True)
         cmds.file(new=True, force=True)
@@ -219,7 +219,7 @@ class testLayerManagerSerialization(unittest.TestCase):
         '''
         self.copyTestFilesAndMakeEdits()
 
-        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 3))
+        cmds.optionVar(intValue=(mayaUsdLib.OptionVarTokens.SerializedUsdEditsLocation, 3))
 
         cmds.file(save=True, force=True)
         cmds.file(new=True, force=True)
@@ -260,7 +260,7 @@ class testLayerManagerSerialization(unittest.TestCase):
         self.confirmStageHasTestEdits(stage, True, not muteRootSubLayer, not muteSessionLayer)
 
         # Save and reopen the maya file.
-        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', serializedUsdEditsLocation))
+        cmds.optionVar(intValue=(mayaUsdLib.OptionVarTokens.SerializedUsdEditsLocation, serializedUsdEditsLocation))
 
         cmds.file(save=True, force=True)
         cmds.file(new=True, force=True)
@@ -319,7 +319,7 @@ class testLayerManagerSerialization(unittest.TestCase):
         stage.DefinePrim(newSessionsPrimPath, "xform")
         self.assertTrue(stage.GetPrimAtPath(newSessionsPrimPath).IsValid())
 
-        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 2))
+        cmds.optionVar(intValue=(mayaUsdLib.OptionVarTokens.SerializedUsdEditsLocation, 2))
 
         cmds.file(save=True, force=True, type='mayaAscii')
         cmds.file(new=True, force=True)
@@ -351,7 +351,7 @@ class testLayerManagerSerialization(unittest.TestCase):
         stage.DefinePrim(newSessionsPrimPath, "xform")
         self.assertTrue(stage.GetPrimAtPath(newSessionsPrimPath).IsValid())
 
-        cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 1))
+        cmds.optionVar(intValue=(mayaUsdLib.OptionVarTokens.SerializedUsdEditsLocation, 1))
 
         msg = ("Session Layer before: " + stage.GetSessionLayer().identifier)
         stage = None

--- a/test/lib/mayaUsd/nodes/testProxyShapeBase.py
+++ b/test/lib/mayaUsd/nodes/testProxyShapeBase.py
@@ -31,6 +31,7 @@ import usdUtils, mayaUtils, ufeUtils, testUtils
 
 import ufe
 import mayaUsd.ufe
+from mayaUsd import lib as mayaUsdLib
 
 class testProxyShapeBase(unittest.TestCase):
 
@@ -472,7 +473,7 @@ class testProxyShapeBase(unittest.TestCase):
         Verify that setting the option var mayaUsd_ProxyTargetsSessionLayerOnOpen
         to 1 targets the session layer instead of the layer that was previously targeted.
         '''
-        cmds.optionVar(iv=["mayaUsd_ProxyTargetsSessionLayerOnOpen",  1])
+        cmds.optionVar(iv=[mayaUsdLib.OptionVarTokens.ProxyTargetsSessionLayerOnOpen,  1])
 
         try:
             # create new stage
@@ -490,7 +491,7 @@ class testProxyShapeBase(unittest.TestCase):
             self.assertTrue(stage)
             self.assertEqual(stage.GetSessionLayer().identifier, stage.GetEditTarget().GetLayer().identifier)
         finally:
-            cmds.optionVar(iv=["mayaUsd_ProxyTargetsSessionLayerOnOpen",  0])
+            cmds.optionVar(iv=[mayaUsdLib.OptionVarTokens.ProxyTargetsSessionLayerOnOpen,  0])
 
     def _saveStagePreserveLayerHelper(self, targetRoot, saveInMaya):
         '''
@@ -532,7 +533,7 @@ class testProxyShapeBase(unittest.TestCase):
             # Make sure layers are saved to the desired location (Maya or USD)
             # when the Maya scene is saved.
             location = 2 if saveInMaya else 1
-            cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', location))
+            cmds.optionVar(intValue=(mayaUsdLib.OptionVarTokens.SerializedUsdEditsLocation, location))
 
             # Save the stage.
             cmds.file(rename=tempMayaFile)
@@ -640,7 +641,7 @@ class testProxyShapeBase(unittest.TestCase):
             # Make sure layers are saved to the desired location
             # when the Maya scene is saved.
             saveInUSD = 1
-            cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', saveInUSD))
+            cmds.optionVar(intValue=(mayaUsdLib.OptionVarTokens.SerializedUsdEditsLocation, saveInUSD))
 
             # Save the stage.
             tempMayaFile = os.path.join(testDir, 'StageViaIdPreservedWhenSaved')
@@ -808,7 +809,7 @@ class testProxyShapeBase(unittest.TestCase):
         # Save and re-open
         with testUtils.TemporaryDirectory(prefix='ProxyShapeBase') as testDir:
             # Save the dirty layer along with Maya scene
-            cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 2))
+            cmds.optionVar(intValue=(mayaUsdLib.OptionVarTokens.SerializedUsdEditsLocation, 2))
             tempMayaFile = os.path.join(testDir, 'StageAnonymousSubLayerAsTargetLayer.ma')
             cmds.file(rename=tempMayaFile)
             cmds.file(save=True, force=True)
@@ -856,7 +857,7 @@ class testProxyShapeBase(unittest.TestCase):
         # Save and re-open
         with testUtils.TemporaryDirectory(prefix='ProxyShapeBase') as testDir:
             # Save the dirty layer along with Maya scene
-            cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 2))
+            cmds.optionVar(intValue=(mayaUsdLib.OptionVarTokens.SerializedUsdEditsLocation, 2))
             tempMayaFile = os.path.join(testDir, 'AnonymousRootLayerTest.ma')
             cmds.file(rename=tempMayaFile)
             cmds.file(save=True, force=True)
@@ -1129,7 +1130,7 @@ class testProxyShapeBase(unittest.TestCase):
 
             # Make sure to save USD back to Maya file, so that the USD test
             # file we loaded (from source folder) isn't modified.
-            cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 2))
+            cmds.optionVar(intValue=(mayaUsdLib.OptionVarTokens.SerializedUsdEditsLocation, 2))
 
             cmds.file(rename=pathToSave)
             cmds.file(save=True, force=True, type='mayaAscii')
@@ -1230,7 +1231,7 @@ class testProxyShapeBase(unittest.TestCase):
 
             # Make sure to save USD back to Maya file, so that the USD test
             # file we loaded (from source folder) isn't modified.
-            cmds.optionVar(intValue=('mayaUsd_SerializedUsdEditsLocation', 2))
+            cmds.optionVar(intValue=(mayaUsdLib.OptionVarTokens.SerializedUsdEditsLocation, 2))
 
             cmds.file(rename=pathToSave)
             cmds.file(save=True, force=True, type='mayaAscii')

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateTextureLoading.py
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateTextureLoading.py
@@ -23,6 +23,8 @@ import testUtils
 
 from maya import cmds
 
+from mayaUsd import lib as mayaUsdLib
+
 import os
 
 class testVP2RenderDelegateTextureLoading(imageUtils.ImageDiffingTestCase):
@@ -42,7 +44,7 @@ class testVP2RenderDelegateTextureLoading(imageUtils.ImageDiffingTestCase):
 
         cls._test_dir = os.path.abspath(".")
 
-        cls._optVarName = "mayaUsd_DisableAsyncTextureLoading"
+        cls._optVarName = mayaUsdLib.OptionVarTokens.DisableAsyncTextureLoading
         # Save optionVar preference
         cls._hasDisabledAsync = cmds.optionVar(exists=cls._optVarName)
         if cls._hasDisabledAsync:

--- a/test/lib/testMayaUsdCreateStageInMayaRef.py
+++ b/test/lib/testMayaUsdCreateStageInMayaRef.py
@@ -57,7 +57,7 @@ def createMayaSceneWithStageWithUsdRef(root_path, usd_cube_file):
     maya_with_usd_ref = os.path.join(root_path, "maya_with_usd_ref.ma").replace('\\', '/')
     # Save the scene
     SAVE_USD_TO_MAYA_SCENE = 2
-    cmds.optionVar(iv=("mayaUsd_SerializedUsdEditsLocation", SAVE_USD_TO_MAYA_SCENE))
+    cmds.optionVar(iv=(mayaUsd.lib.OptionVarTokens.SerializedUsdEditsLocation, SAVE_USD_TO_MAYA_SCENE))
     om.MFileIO.saveAs(maya_with_usd_ref, "mayaAscii")
     return proxy_shape, usd_cube_path, maya_with_usd_ref
 


### PR DESCRIPTION
#### EMSUSD-3189: [GitHub #4521] 'Hide indices option' for the Display Layer Content
* Added new option vars to remember layer content settings.
* Cleaned up C++ code and tests regarding optionVar tokens.
* Added pseudoLayer display using code from OpenUsd sdffilter.cpp
* New menu option "Expand All Values" off by default, so large arrays are truncated.