### PR TITLE
EMSUSD-3194 - Remove MayaUsdAPI dependency from LookdevXUsd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ endif()
 if (NOT PYTHONLIBS_FOUND)
     include(cmake/python.cmake)
 endif()
-message(STATUS "Build MayaUSD with Python3 = " ${BUILD_WITH_PYTHON_3})
+message(STATUS "Building with Python3 = " ${BUILD_WITH_PYTHON_3})
 message(STATUS "   PYTHON_INCLUDE_DIRS = ${PYTHON_INCLUDE_DIRS}")
 message(STATUS "   PYTHON_LIBRARIES    = ${PYTHON_LIBRARIES}")
 message(STATUS "   Python_EXECUTABLE   = ${Python_EXECUTABLE}")
@@ -228,30 +228,33 @@ if(BUILD_MAYAUSD_LIBRARY)
     endif()
 endif()
 
-if (NOT BUILD_ADSK_PLUGIN)
-        set(BUILD_LOOKDEVXUSD_LIBRARY OFF)
-endif()
-# Need LookdevXUfe/MayaUsdAPI when building LookdevXUsd.
+# Need LookdevXUfe when building LookdevXUsd.
 if(BUILD_LOOKDEVXUSD_LIBRARY)
-    if(NOT BUILD_MAYAUSDAPI_LIBRARY)
-        message(FATAL_ERROR "Building LookdevXUsd requires MayaUsdAPI.")
-    endif()
-
-    if(MAYA_APP_VERSION VERSION_GREATER 2025)
-        find_package(LookdevXUfe) # Optional component - if not found, disable LookdevXUsd.
+    if (Maya_FOUND)
+        if(MAYA_APP_VERSION VERSION_GREATER 2025)
+            find_package(LookdevXUfe) # Optional component - if not found, disable LookdevXUsd.
+        else()
+            set(BUILD_LOOKDEVXUSD_LIBRARY OFF)
+            message(WARNING "Disabling LookdevXUsd: it is not supported by Maya ${MAYA_APP_VERSION}.")
+        endif()
     else()
-        set(BUILD_LOOKDEVXUSD_LIBRARY OFF)
-        message(WARNING "Disabling LookdevXUsd: it is not supported by Maya ${MAYA_APP_VERSION}.")
+        find_package(LookdevXUfe) # Optional component - if not found, disable LookdevXUsd.
     endif()
     if (NOT LookdevXUfe_FOUND)
         set(BUILD_LOOKDEVXUSD_LIBRARY OFF)
-        message(WARNING "Disabling LookdevXUsd as LookdevXUfe was not found (in Maya devkit).")
+        if (Maya_FOUND)
+            message(WARNING "Disabling LookdevXUsd as LookdevXUfe was not found (in Maya devkit).")
+        else()
+            message(WARNING "Disabling LookdevXUsd as LookdevXUfe was not found (set LOOKDEVXUFE_INCLUDE_ROOT/LOOKDEVXUFE_LIB_ROOT).")
+        endif()
     endif()
 endif()
 
-find_package(AdskUsdComponentCreator)
-find_package(AdskUsdAssetResolver)
-find_package(AdskUsdEditForward)
+if(BUILD_MAYAUSD_LIBRARY)
+    find_package(AdskUsdComponentCreator)
+    find_package(AdskUsdAssetResolver)
+    find_package(AdskUsdEditForward)
+endif()
 
 #------------------------------------------------------------------------------
 # compiler configuration

--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -4,7 +4,7 @@
 # and related paths (scripts)
 #
 # Variables that will be defined:
-# MAYA_FOUND          Defined if a Maya installation has been detected
+# Maya_FOUND          Defined if a Maya installation has been detected
 # MAYA_EXECUTABLE     Path to Maya's executable
 # MAYA_<lib>_FOUND    Defined if <lib> has been found
 # MAYA_<lib>_LIBRARY  Path to <lib> library
@@ -510,7 +510,7 @@ if(IS_MACOSX AND MAYA_Foundation_LIBRARY)
     endif()
 endif()
 
-# handle the QUIETLY and REQUIRED arguments and set MAYA_FOUND to TRUE if
+# handle the QUIETLY and REQUIRED arguments and set Maya_FOUND to TRUE if
 # all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
 

--- a/lib/lookdevXUsd/CMakeLists.txt
+++ b/lib/lookdevXUsd/CMakeLists.txt
@@ -24,7 +24,6 @@ add_library(${PROJECT_NAME} SHARED)
 target_sources(${PROJECT_NAME}
     PRIVATE
         LookdevXUsd.cpp
-        ProxyShapeLookdevHandler.cpp
         UsdCapabilityHandler.cpp
         UsdClipboardHandler.cpp
         UsdDebugHandler.cpp
@@ -49,7 +48,6 @@ target_sources(${PROJECT_NAME}
 set(HEADERS
     Export.h
     LookdevXUsd.h
-    ProxyShapeLookdevHandler.h
     UsdCapabilityHandler.h
     UsdClipboardHandler.h
     UsdDebugHandler.h
@@ -71,6 +69,17 @@ set(HEADERS
     Utils.h
 )
 
+if (BUILD_MAYAUSDAPI_LIBRARY)
+    target_sources(${PROJECT_NAME}
+        PRIVATE
+            ProxyShapeLookdevHandler.cpp
+    )
+
+    list(APPEND HEADERS
+        ProxyShapeLookdevHandler.h
+    )
+endif()
+
 # -----------------------------------------------------------------------------
 # Compiler configuration
 # -----------------------------------------------------------------------------
@@ -86,6 +95,14 @@ target_compile_definitions(${PROJECT_NAME}
         # this flag is needed when building for Maya
         $<$<BOOL:${IS_WINDOWS}>:WIN32>
 )
+
+if (BUILD_MAYAUSDAPI_LIBRARY)
+    message(STATUS "Building LookdevXUsd with MayaUsdAPI support")
+    target_compile_definitions(${PROJECT_NAME}
+        PRIVATE
+            LDX_USD_USE_MAYAUSDAPI=1
+    )
+endif()
 
 mayaUsd_compile_config(${PROJECT_NAME})
 
@@ -154,7 +171,7 @@ target_link_libraries(${PROJECT_NAME}
         sdf
         sdr
         usdMtlx
-        mayaUsdAPI
+        $<$<BOOL:${BUILD_MAYAUSDAPI_LIBRARY}>:mayaUsdAPI>
     PRIVATE
         usd
         usdShade

--- a/lib/lookdevXUsd/CMakeLists.txt
+++ b/lib/lookdevXUsd/CMakeLists.txt
@@ -205,11 +205,10 @@ endif()
 # install
 # -----------------------------------------------------------------------------
 
-# TODO - do we need to install the headers?
-#install(FILES  ${HEADERS}
-#    DESTINATION 
-#        ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}
-#)
+install(FILES  ${HEADERS}
+    DESTINATION 
+        ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME}
+)
 
 install(TARGETS ${PROJECT_NAME}
     LIBRARY

--- a/lib/lookdevXUsd/LookdevXUsd.cpp
+++ b/lib/lookdevXUsd/LookdevXUsd.cpp
@@ -10,7 +10,9 @@
 //*****************************************************************************
 #include "LookdevXUsd.h"
 
+#ifdef LDX_USD_USE_MAYAUSDAPI
 #include "ProxyShapeLookdevHandler.h"
+#endif
 #include "UsdCapabilityHandler.h"
 #include "UsdClipboardHandler.h"
 #include "UsdDebugHandler.h"
@@ -24,6 +26,8 @@
 #include "UsdSoloingHandler.h"
 #include "UsdUINodeGraphNodeHandler.h"
 
+#include <usdUfe/ufe/Global.h>
+
 #include <ufe/handlerInterface.h>
 #include <ufe/rtid.h>
 #include <ufe/runTimeMgr.h>
@@ -33,70 +37,64 @@
 #ifdef LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER
 #include "UsdExtendedConnectionHandler.h"
 #endif
+#ifdef LDX_USD_USE_MAYAUSDAPI
+#include <mayaUsdAPI/utils.h>
+#endif
 
 namespace
 {
 
-// Runtime ids (default 0 is invalid).
-Ufe::Rtid mayaUsdRuntimeId = 0;
-Ufe::Rtid mayaRuntimeId = 0;
-
 #ifdef LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER
 Ufe::SceneItemOpsHandler::Ptr mayaUsdSceneItemOpsHandler;
 #endif
+#ifdef LDX_USD_USE_MAYAUSDAPI
 LookdevXUfe::LookdevHandler::Ptr mayaLookdevHandler;
+#endif
 
 } // namespace
 
 namespace LookdevXUsd
 {
 
-constexpr auto kMayaUsdRuntimeName = "USD";
-constexpr auto kMayaRuntimeName = "Maya-DG";
-
 void initialize()
 {
-    // New extension handlers.
-    try
-    {
-        mayaUsdRuntimeId = Ufe::RunTimeMgr::instance().getId(kMayaUsdRuntimeName);
-        mayaRuntimeId = Ufe::RunTimeMgr::instance().getId(kMayaRuntimeName);
-    }
-    catch (const std::exception&)
-    {
-        return;
-    }
+    auto & runTimeMgr = Ufe::RunTimeMgr::instance();
 
-    Ufe::RunTimeMgr::instance().registerHandler(mayaUsdRuntimeId, UsdDebugHandler::id, UsdDebugHandler::create());
-    Ufe::RunTimeMgr::instance().registerHandler(mayaUsdRuntimeId, UsdLookdevHandler::id, UsdLookdevHandler::create());
-    Ufe::RunTimeMgr::instance().registerHandler(mayaUsdRuntimeId, UsdMaterialHandler::id, UsdMaterialHandler::create());
-    Ufe::RunTimeMgr::instance().registerHandler(mayaUsdRuntimeId, UsdSoloingHandler::id, UsdSoloingHandler::create());
-    Ufe::RunTimeMgr::instance().registerHandler(mayaUsdRuntimeId, UsdFileHandler::id, UsdFileHandler::create());
-    Ufe::RunTimeMgr::instance().registerHandler(mayaUsdRuntimeId, UsdSceneItemUIHandler::id,
-                                                UsdSceneItemUIHandler::create());
-    Ufe::RunTimeMgr::instance().registerHandler(mayaUsdRuntimeId, UsdExtendedAttributeHandler::id,
-                                                UsdExtendedAttributeHandler::create());
-    Ufe::RunTimeMgr::instance().registerHandler(mayaUsdRuntimeId, UsdCapabilityHandler::id,
-                                                UsdCapabilityHandler::create());
+    // New extension handlers.
+    const auto usdRuntimeId = UsdUfe::getUsdRunTimeId();
+    runTimeMgr.registerHandler(usdRuntimeId, UsdDebugHandler::id, UsdDebugHandler::create());
+    runTimeMgr.registerHandler(usdRuntimeId, UsdLookdevHandler::id, UsdLookdevHandler::create());
+    runTimeMgr.registerHandler(usdRuntimeId, UsdMaterialHandler::id, UsdMaterialHandler::create());
+    runTimeMgr.registerHandler(usdRuntimeId, UsdSoloingHandler::id, UsdSoloingHandler::create());
+    runTimeMgr.registerHandler(usdRuntimeId, UsdFileHandler::id, UsdFileHandler::create());
+    runTimeMgr.registerHandler(usdRuntimeId, UsdSceneItemUIHandler::id,
+                                             UsdSceneItemUIHandler::create());
+    runTimeMgr.registerHandler(usdRuntimeId, UsdExtendedAttributeHandler::id,
+                                             UsdExtendedAttributeHandler::create());
+    runTimeMgr.registerHandler(usdRuntimeId, UsdCapabilityHandler::id,
+                                             UsdCapabilityHandler::create());
 #ifdef LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER
-    Ufe::RunTimeMgr::instance().registerHandler(mayaUsdRuntimeId, UsdExtendedConnectionHandler::id,
-                                                UsdExtendedConnectionHandler::create());
+    runTimeMgr.registerHandler(usdRuntimeId, UsdExtendedConnectionHandler::id,
+                                             UsdExtendedConnectionHandler::create());
 #endif
 
     // Replacements/wrappers for existing handlers.
-    UsdUINodeGraphNodeHandler::registerHandler(mayaUsdRuntimeId);
-    UsdHierarchyHandler::registerHandler(mayaUsdRuntimeId);
-    UsdClipboardHandler::registerHandler(mayaUsdRuntimeId);
+    UsdUINodeGraphNodeHandler::registerHandler(usdRuntimeId);
+    UsdHierarchyHandler::registerHandler(usdRuntimeId);
+    UsdClipboardHandler::registerHandler(usdRuntimeId);
 
 #ifdef LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER
-    mayaUsdSceneItemOpsHandler = Ufe::RunTimeMgr::instance().sceneItemOpsHandler(mayaUsdRuntimeId);
-    Ufe::RunTimeMgr::instance().setSceneItemOpsHandler(
-        mayaUsdRuntimeId, LookdevXUsd::UsdSceneItemOpsHandler::create(mayaUsdSceneItemOpsHandler));
+    mayaUsdSceneItemOpsHandler = runTimeMgr.sceneItemOpsHandler(usdRuntimeId);
+    runTimeMgr.setSceneItemOpsHandler(
+        usdRuntimeId, LookdevXUsd::UsdSceneItemOpsHandler::create(mayaUsdSceneItemOpsHandler));
 #endif
 
+#ifdef LDX_USD_USE_MAYAUSDAPI
+    auto mayaRuntimeId = MayaUsdAPI::getMayaRunTimeId();
     mayaLookdevHandler = LookdevXUfe::LookdevHandler::get(mayaRuntimeId);
-    Ufe::RunTimeMgr::instance().registerHandler(mayaRuntimeId, ProxyShapeLookdevHandler::id,
+    runTimeMgr.registerHandler(mayaRuntimeId, ProxyShapeLookdevHandler::id,
         ProxyShapeLookdevHandler::create(mayaLookdevHandler));
+#endif
 
     // Force loading the Sdr library to preload the source of the NodeLibrary on the USD side. This will load the Arnold
     // DLL if it is in the USD paths and initialize it for its nodes, which should result in a slight delay.
@@ -115,17 +113,19 @@ void initialize()
 void uninitialize()
 {
     // New extension handlers.
-    Ufe::RunTimeMgr::instance().unregisterHandler(mayaUsdRuntimeId, UsdDebugHandler::id);
-    Ufe::RunTimeMgr::instance().unregisterHandler(mayaUsdRuntimeId, UsdLookdevHandler::id);
-    Ufe::RunTimeMgr::instance().unregisterHandler(mayaUsdRuntimeId, UsdMaterialHandler::id);
-    Ufe::RunTimeMgr::instance().unregisterHandler(mayaUsdRuntimeId, UsdSoloingHandler::id);
-    Ufe::RunTimeMgr::instance().unregisterHandler(mayaUsdRuntimeId, UsdFileHandler::id);
-    Ufe::RunTimeMgr::instance().unregisterHandler(mayaUsdRuntimeId, UsdSceneItemUIHandler::id);
-    Ufe::RunTimeMgr::instance().unregisterHandler(mayaUsdRuntimeId, UsdExtendedAttributeHandler::id);
+    auto & runTimeMgr = Ufe::RunTimeMgr::instance();
+    const auto usdRuntimeId = UsdUfe::getUsdRunTimeId();
+    runTimeMgr.unregisterHandler(usdRuntimeId, UsdDebugHandler::id);
+    runTimeMgr.unregisterHandler(usdRuntimeId, UsdLookdevHandler::id);
+    runTimeMgr.unregisterHandler(usdRuntimeId, UsdMaterialHandler::id);
+    runTimeMgr.unregisterHandler(usdRuntimeId, UsdSoloingHandler::id);
+    runTimeMgr.unregisterHandler(usdRuntimeId, UsdFileHandler::id);
+    runTimeMgr.unregisterHandler(usdRuntimeId, UsdSceneItemUIHandler::id);
+    runTimeMgr.unregisterHandler(usdRuntimeId, UsdExtendedAttributeHandler::id);
 #ifdef LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER
-    Ufe::RunTimeMgr::instance().unregisterHandler(mayaUsdRuntimeId, UsdExtendedConnectionHandler::id);
+    runTimeMgr.unregisterHandler(usdRuntimeId, UsdExtendedConnectionHandler::id);
 #endif
-    Ufe::RunTimeMgr::instance().unregisterHandler(mayaUsdRuntimeId, UsdCapabilityHandler::id);
+    runTimeMgr.unregisterHandler(usdRuntimeId, UsdCapabilityHandler::id);
 
     // Replacements/wrappers for existing handlers
     UsdUINodeGraphNodeHandler::unregisterHandler();
@@ -133,20 +133,22 @@ void uninitialize()
     UsdClipboardHandler::unregisterHandler();
 
     // Unregister the decorated MayaUsd handlers and restore the original ones.
-    auto& runTimeMgr = Ufe::RunTimeMgr::instance();
 #ifdef LOOKDEVXUFE_HAS_EXTENDED_CONNECTION_HANDLER
-    if (runTimeMgr.hasId(mayaUsdRuntimeId)) {
-        runTimeMgr.setSceneItemOpsHandler(mayaUsdRuntimeId, mayaUsdSceneItemOpsHandler);
+    if (runTimeMgr.hasId(usdRuntimeId)) {
+        runTimeMgr.setSceneItemOpsHandler(usdRuntimeId, mayaUsdSceneItemOpsHandler);
     }
     mayaUsdSceneItemOpsHandler.reset();
 #endif
 
+#ifdef LDX_USD_USE_MAYAUSDAPI
     // Unregister the decorated Maya handlers and restore the original ones.
-    Ufe::RunTimeMgr::instance().unregisterHandler(mayaRuntimeId, ProxyShapeLookdevHandler::id);
+    auto mayaRuntimeId = MayaUsdAPI::getMayaRunTimeId();
+    runTimeMgr.unregisterHandler(mayaRuntimeId, ProxyShapeLookdevHandler::id);
     if (runTimeMgr.hasId(mayaRuntimeId) && mayaLookdevHandler) {
-      Ufe::RunTimeMgr::instance().registerHandler(mayaRuntimeId, ProxyShapeLookdevHandler::id, mayaLookdevHandler);
+        runTimeMgr.registerHandler(mayaRuntimeId, ProxyShapeLookdevHandler::id, mayaLookdevHandler);
     }
     mayaLookdevHandler.reset();
+#endif
 }
 
 } // namespace LookdevXUsd

--- a/lib/lookdevXUsd/ProxyShapeLookdevHandler.cpp
+++ b/lib/lookdevXUsd/ProxyShapeLookdevHandler.cpp
@@ -14,6 +14,9 @@
 
 #include <ufe/hierarchy.h>
 
+#include <usdUfe/ufe/Global.h>
+#include <usdUfe/ufe/UsdSceneItem.h>
+#include <usdUfe/ufe/UsdUndoAddNewPrimCommand.h>
 #include <usdUfe/ufe/Utils.h>
 
 namespace LookdevXUsd
@@ -44,13 +47,13 @@ Ufe::SceneItemResultUndoableCommand::Ptr ProxyShapeLookdevHandler::createLookdev
     }
 
     // Treat proxy shapes in the same way as every other USD item.
-    auto parentItem = MayaUsdAPI::createUsdSceneItem(parent->path(), MayaUsdAPI::ufePathToPrim(parent->path()));
-    if (!parentItem || !MayaUsdAPI::getPrimForUsdSceneItem(parentItem).IsValid())
+    auto parentItem = UsdUfe::UsdSceneItem::create(parent->path(), UsdUfe::ufePathToPrim(parent->path()));
+    if (!parentItem || !parentItem->prim().IsValid())
     {
         return nullptr;
     }
 
-    return MayaUsdAPI::createAddNewPrimCommand(parentItem, name.string(), "Material");
+    return UsdUfe::UsdUndoAddNewPrimCommand::create(parentItem, name.string(), "Material");
 }
 
 Ufe::SceneItemResultUndoableCommand::Ptr ProxyShapeLookdevHandler::createLookdevContainerCmdImpl(
@@ -66,7 +69,7 @@ Ufe::SceneItemResultUndoableCommand::Ptr ProxyShapeLookdevHandler::createLookdev
 {
     // This handler is only aware of gateways from Maya to USD.
     if (!ancestor || ancestor->runTimeId() != MayaUsdAPI::getMayaRunTimeId() ||
-        targetRunTimeId != MayaUsdAPI::getUsdRunTimeId())
+        targetRunTimeId != UsdUfe::getUsdRunTimeId())
     {
         return m_previousHandler ? m_previousHandler->createLookdevEnvironmentCmdImpl(ancestor, targetRunTimeId)
                                  : nullptr;
@@ -161,22 +164,22 @@ bool MayaUsdCreateLookdevEnvironmentCommand::executeCommand()
 
     // Create a materials scope, preferring the default prim as parent if one exists.
     auto proxyShapeItem =
-        MayaUsdAPI::createUsdSceneItem(proxyShape->path(), MayaUsdAPI::ufePathToPrim(proxyShape->path()));
-    if (!proxyShapeItem || !MayaUsdAPI::getPrimForUsdSceneItem(proxyShapeItem).IsValid())
+        UsdUfe::UsdSceneItem::create(proxyShape->path(), UsdUfe::ufePathToPrim(proxyShape->path()));
+    if (!proxyShapeItem || !proxyShapeItem->prim().IsValid())
     {
         return false;
     }
 
     Ufe::SceneItem::Ptr scopeParentItem = proxyShapeItem;
-    auto stage = MayaUsdAPI::getStage(proxyShape->path());
+    auto stage = UsdUfe::getStage(proxyShape->path());
     if (stage && stage->HasDefaultPrim())
     {
         auto defaultPrim = stage->GetDefaultPrim();
         if (defaultPrim.IsValid())
         {
-            auto defaultPrimUfePath = MayaUsdAPI::stagePath(stage)
-                + MayaUsdAPI::usdPathToUfePathSegment(defaultPrim.GetPath());
-            auto defaultPrimItem = MayaUsdAPI::createUsdSceneItem(defaultPrimUfePath, defaultPrim);
+            auto defaultPrimUfePath = UsdUfe::stagePath(stage)
+                + UsdUfe::usdPathToUfePathSegment(defaultPrim.GetPath());
+            auto defaultPrimItem = UsdUfe::UsdSceneItem::create(defaultPrimUfePath, defaultPrim);
             if (defaultPrimItem)
             {
                 scopeParentItem = defaultPrimItem;

--- a/lib/lookdevXUsd/UsdClipboardHandler.cpp
+++ b/lib/lookdevXUsd/UsdClipboardHandler.cpp
@@ -10,12 +10,12 @@
 //*****************************************************************************
 #include "UsdClipboardHandler.h"
 
+#include <usdUfe/ufe/UsdClipboardHandler.h>
+
 #include <pxr/usd/usdShade/material.h>
 #include <pxr/usd/usdShade/nodeGraph.h>
 
 #include <ufe/runTimeMgr.h>
-
-#include <mayaUsdAPI/clipboard.h>
 
 #include <filesystem>
 
@@ -96,7 +96,10 @@ Ufe::UndoableCommand::Ptr UsdClipboardHandler::pasteCmd_(const Ufe::Selection& p
 
 bool UsdClipboardHandler::hasMaterialToPasteImpl()
 {
-    return MayaUsdAPI::hasItemToPaste(m_wrappedClipboardHandler, &isMaterial);
+    if (auto usdClipboardHandler = std::dynamic_pointer_cast<UsdUfe::UsdClipboardHandler>(m_wrappedClipboardHandler)) {
+        return usdClipboardHandler->hasItemToPaste(&isMaterial);
+    }
+    return false;
 }
 
 bool UsdClipboardHandler::hasItemsToPaste_()
@@ -106,21 +109,30 @@ bool UsdClipboardHandler::hasItemsToPaste_()
 
 bool UsdClipboardHandler::hasNodeGraphsToPasteImpl()
 {
-    return MayaUsdAPI::hasItemToPaste(m_wrappedClipboardHandler, &isNodeGraph);
+    if (auto usdClipboardHandler = std::dynamic_pointer_cast<UsdUfe::UsdClipboardHandler>(m_wrappedClipboardHandler)) {
+        return usdClipboardHandler->hasItemToPaste(&isNodeGraph);
+    }
+    return false;
 }
 
 bool UsdClipboardHandler::hasNonMaterialToPasteImpl()
 {
-    return MayaUsdAPI::hasItemToPaste(m_wrappedClipboardHandler, &isNonMaterial);
+    if (auto usdClipboardHandler = std::dynamic_pointer_cast<UsdUfe::UsdClipboardHandler>(m_wrappedClipboardHandler)) {
+        return usdClipboardHandler->hasItemToPaste(&isNonMaterial);
+    }
+    return false;
 }
 
 void UsdClipboardHandler::setClipboardPath(const std::string& clipboardPath)
 {
-    auto tmpPath = std::filesystem::path(clipboardPath);
-    tmpPath.append(clipboardFileName);
-    tmpPath.replace_extension("usda");
-    MayaUsdAPI::setClipboardFilePath(m_wrappedClipboardHandler, tmpPath.string());
-    MayaUsdAPI::setClipboardFileFormat(m_wrappedClipboardHandler, "usda");
+    if (auto usdClipboardHandler = std::dynamic_pointer_cast<UsdUfe::UsdClipboardHandler>(m_wrappedClipboardHandler))
+    {
+        auto tmpPath = std::filesystem::path(clipboardPath);
+        tmpPath.append(clipboardFileName);
+        tmpPath.replace_extension("usda");
+        usdClipboardHandler->setClipboardFilePath(tmpPath.string());
+        usdClipboardHandler->setClipboardFileFormat("usda");
+    }
 }
 
 bool UsdClipboardHandler::canBeCut_(const Ufe::SceneItem::Ptr& item)

--- a/lib/lookdevXUsd/UsdConnectionCommands.cpp
+++ b/lib/lookdevXUsd/UsdConnectionCommands.cpp
@@ -11,6 +11,8 @@
 
 #include "UsdConnectionCommands.h"
 
+#include <usdUfe/undo/UsdUndoBlock.h>
+
 #include <LookdevXUfe/UfeUtils.h>
 
 namespace LookdevXUsd
@@ -58,7 +60,7 @@ UsdCreateConnectionCommand::Ptr UsdCreateConnectionCommand::create(const Ufe::At
 
 void UsdCreateConnectionCommand::execute()
 {
-    const MayaUsdAPI::UsdUndoBlock undoBlock(&m_undoableItem);
+    const UsdUfe::UsdUndoBlock undoBlock(&m_undoableItem);
 
     createConnection(*m_srcInfo, *m_dstInfo);
 }
@@ -104,7 +106,7 @@ UsdDeleteConnectionCommand::Ptr UsdDeleteConnectionCommand::create(const Ufe::At
 
 void UsdDeleteConnectionCommand::execute()
 {
-    const MayaUsdAPI::UsdUndoBlock undoBlock(&m_undoableItem);
+    const UsdUfe::UsdUndoBlock undoBlock(&m_undoableItem);
 
     deleteConnection(*m_srcInfo, *m_dstInfo);
 }

--- a/lib/lookdevXUsd/UsdConnectionCommands.h
+++ b/lib/lookdevXUsd/UsdConnectionCommands.h
@@ -18,7 +18,7 @@
 #include <LookdevXUfe/ExtendedConnection.h>
 #include <LookdevXUfe/UndoableCommand.h>
 
-#include <mayaUsdAPI/undo.h>
+#include <usdUfe/undo/UsdUndoableItem.h>
 
 namespace LookdevXUsd
 {
@@ -70,7 +70,7 @@ protected:
         const Ufe::Attribute::Ptr& attr) const override;
 
 private:
-    MayaUsdAPI::UsdUndoableItem m_undoableItem;
+    UsdUfe::UsdUndoableItem m_undoableItem;
 
     std::unique_ptr<LookdevXUfe::AttributeComponentInfo> m_srcInfo;
     std::unique_ptr<LookdevXUfe::AttributeComponentInfo> m_dstInfo;
@@ -110,7 +110,7 @@ protected:
         const Ufe::Attribute::Ptr& attr) const override;
 
 private:
-    MayaUsdAPI::UsdUndoableItem m_undoableItem;
+    UsdUfe::UsdUndoableItem m_undoableItem;
 
     std::unique_ptr<LookdevXUfe::AttributeComponentInfo> m_srcInfo;
     std::unique_ptr<LookdevXUfe::AttributeComponentInfo> m_dstInfo;

--- a/lib/lookdevXUsd/UsdDebugHandler.cpp
+++ b/lib/lookdevXUsd/UsdDebugHandler.cpp
@@ -14,7 +14,7 @@
 #include <pxr/usd/sdr/registry.h>
 #include <pxr/usd/usd/prim.h>
 
-#include <mayaUsdAPI/utils.h>
+#include <usdUfe/ufe/Utils.h>
 
 #include <any>
 
@@ -41,7 +41,8 @@ std::string UsdDebugHandler::dumpPrim(const PXR_NS::UsdPrim& prim)
 
 std::string UsdDebugHandler::exportToString(Ufe::SceneItem::Ptr sceneItem)
 {
-    auto prim = MayaUsdAPI::getPrimForUsdSceneItem(sceneItem);
+    auto usdItem = UsdUfe::downcast(sceneItem);
+    auto prim = usdItem ? usdItem->prim() : PXR_NS::UsdPrim();
     if (prim.IsValid())
     {
         return dumpPrim(prim);

--- a/lib/lookdevXUsd/UsdExtendedAttributeHandler.cpp
+++ b/lib/lookdevXUsd/UsdExtendedAttributeHandler.cpp
@@ -11,7 +11,8 @@
 
 #include "UsdExtendedAttributeHandler.h"
 
-#include <mayaUsdAPI/utils.h>
+#include <usdUfe/ufe/UsdSceneItem.h>
+#include <usdUfe/ufe/Utils.h>
 
 #include <pxr/base/tf/token.h>
 
@@ -25,9 +26,10 @@ UsdExtendedAttributeHandler::Ptr UsdExtendedAttributeHandler::create()
 
 bool UsdExtendedAttributeHandler::isAuthoredAttribute(const Ufe::Attribute::Ptr& attribute) const
 {
-    if (attribute && attribute->sceneItem() && MayaUsdAPI::isUsdSceneItem(attribute->sceneItem()))
+    auto usdItem = attribute ? UsdUfe::downcast(attribute->sceneItem()) : nullptr;
+    if (usdItem)
     {
-        auto prim = MayaUsdAPI::getPrimForUsdSceneItem(attribute->sceneItem());
+        auto prim = usdItem->prim();
         return prim.GetAttribute(PXR_NS::TfToken(attribute->name())).IsAuthored();
     }
     return false;

--- a/lib/lookdevXUsd/UsdFileHandler.cpp
+++ b/lib/lookdevXUsd/UsdFileHandler.cpp
@@ -10,24 +10,31 @@
 //*****************************************************************************
 #include "UsdFileHandler.h"
 
-#include <mayaUsdAPI/utils.h>
-
 #include <pxr/usd/usdShade/udimUtils.h>
+
+#include <usdUfe/ufe/UsdAttribute.h>
+#include <usdUfe/ufe/Global.h>
 
 #include <LookdevXUfe/UfeUtils.h>
 
 #include <algorithm>
+
+#ifdef LDX_USD_USE_MAYAUSDAPI
+#include <mayaUsdAPI/utils.h>
+#endif
 
 namespace LookdevXUsd
 {
 
 namespace
 {
+#ifdef LDX_USD_USE_MAYAUSDAPI
 std::string getRelativePath(const Ufe::AttributeFilename::Ptr& fnAttr, const std::string& path)
 {
-    if (fnAttr && fnAttr->sceneItem()->runTimeId() == MayaUsdAPI::getUsdRunTimeId())
+    if (fnAttr && fnAttr->sceneItem()->runTimeId() == UsdUfe::getUsdRunTimeId())
     {
-        auto stage = MayaUsdAPI::usdStage(fnAttr);
+        auto usdAttribute = std::dynamic_pointer_cast<UsdUfe::UsdAttribute>(fnAttr);
+        auto stage = usdAttribute ? usdAttribute->usdPrim().GetStage() : nullptr;
         if (stage && stage->GetEditTarget().GetLayer())
         {
             const std::string layerDirPath = MayaUsdAPI::getDir(stage->GetEditTarget().GetLayer()->GetRealPath());
@@ -42,6 +49,7 @@ std::string getRelativePath(const Ufe::AttributeFilename::Ptr& fnAttr, const std
     }
     return path;
 }
+#endif
 
 // From USD's materialParamsUtil.cpp:
 // We need to find the first layer that changes the value
@@ -69,15 +77,17 @@ UsdFileHandler::~UsdFileHandler() = default;
 
 std::string UsdFileHandler::getResolvedPath(const Ufe::AttributeFilename::Ptr& fnAttr) const
 {
-    if (fnAttr && fnAttr->sceneItem()->runTimeId() == MayaUsdAPI::getUsdRunTimeId())
+    if (fnAttr && fnAttr->sceneItem()->runTimeId() == UsdUfe::getUsdRunTimeId())
     {
-        auto attributeType = MayaUsdAPI::usdAttributeType(fnAttr);
+        auto usdAttribute = std::dynamic_pointer_cast<UsdUfe::UsdAttribute>(fnAttr);
+        auto attributeType = usdAttribute ? usdAttribute->usdAttributeType() : PXR_NS::SdfValueTypeName();
         if (attributeType == PXR_NS::SdfValueTypeNames->Asset)
         {
-            const auto prim = MayaUsdAPI::getPrimForUsdSceneItem(fnAttr->sceneItem());
+            auto usdAttrItem = UsdUfe::downcast(fnAttr->sceneItem());
+            auto prim = usdAttrItem ? usdAttrItem->prim() : PXR_NS::UsdPrim();
             const auto usdAttribute = prim.GetAttribute(PXR_NS::TfToken(fnAttr->name()));
             const auto attrQuery = PXR_NS::UsdAttributeQuery(usdAttribute);
-            const auto time = MayaUsdAPI::getTime(fnAttr->sceneItem()->path());
+            const auto time = UsdUfe::getTime(fnAttr->sceneItem()->path());
             PXR_NS::SdfAssetPath assetPath;
 
             if (attrQuery.Get(&assetPath, time))
@@ -113,17 +123,20 @@ Ufe::UndoableCommand::Ptr UsdFileHandler::convertPathToAbsoluteCmd(const Ufe::At
 
 Ufe::UndoableCommand::Ptr UsdFileHandler::convertPathToRelativeCmd(const Ufe::AttributeFilename::Ptr& fnAttr) const
 {
+#ifdef LDX_USD_USE_MAYAUSDAPI
     auto relativePath = getRelativePath(fnAttr, fnAttr->get());
     if (!relativePath.empty() && relativePath != fnAttr->get())
     {
         return fnAttr->setCmd(relativePath);
     }
+#endif
     return {};
 }
 
 Ufe::UndoableCommand::Ptr UsdFileHandler::setPreferredPathCmd(const Ufe::AttributeFilename::Ptr& fnAttr,
                                                               const std::string& path) const
 {
+#ifdef LDX_USD_USE_MAYAUSDAPI
     if (MayaUsdAPI::requireUsdPathsRelativeToEditTargetLayer())
     {
         auto relativePath = getRelativePath(fnAttr, path);
@@ -133,12 +146,14 @@ Ufe::UndoableCommand::Ptr UsdFileHandler::setPreferredPathCmd(const Ufe::Attribu
             return fnAttr->setCmd(LookdevXUfe::UfeUtils::insertUdimTagInFilename(relativePath));
         }
     }
+#endif
     return fnAttr->setCmd(LookdevXUfe::UfeUtils::insertUdimTagInFilename(path));
 }
 
 std::string UsdFileHandler::openFileDialog(const Ufe::AttributeFilename::Ptr& fnAttr) const
 {
-    if (fnAttr && fnAttr->sceneItem()->runTimeId() == MayaUsdAPI::getUsdRunTimeId())
+#ifdef LDX_USD_USE_MAYAUSDAPI
+    if (fnAttr && fnAttr->sceneItem()->runTimeId() == UsdUfe::getUsdRunTimeId())
     {
         auto fileHandler = LookdevXUfe::FileHandler::get(fnAttr->sceneItem()->path().popSegment().runTimeId());
         if (!fileHandler)
@@ -147,7 +162,9 @@ std::string UsdFileHandler::openFileDialog(const Ufe::AttributeFilename::Ptr& fn
         }
 
         std::string relativeRoot;
-        auto stage = MayaUsdAPI::usdStage(fnAttr);
+
+        auto usdAttribute = std::dynamic_pointer_cast<UsdUfe::UsdAttribute>(fnAttr);
+        auto stage = usdAttribute ? usdAttribute->usdPrim().GetStage() : nullptr;
         if (stage && stage->GetEditTarget().GetLayer())
         {
             relativeRoot = MayaUsdAPI::getDir(stage->GetEditTarget().GetLayer()->GetRealPath());
@@ -166,6 +183,7 @@ std::string UsdFileHandler::openFileDialog(const Ufe::AttributeFilename::Ptr& fn
 
         return pickedPath;
     }
+#endif
     return {};
 }
 } // namespace LookdevXUsd

--- a/lib/lookdevXUsd/UsdLookdevHandler.cpp
+++ b/lib/lookdevXUsd/UsdLookdevHandler.cpp
@@ -13,7 +13,7 @@
 #include "UsdMaterialCommands.h"
 
 #include <usdUfe/ufe/Global.h>
-#include <usdufe/ufe/UsdUndoAddNewPrimCommand.h>
+#include <usdUfe/ufe/UsdUndoAddNewPrimCommand.h>
 #include <usdUfe/ufe/Utils.h>
 
 #ifdef LDX_USD_USE_MAYAUSDAPI

--- a/lib/lookdevXUsd/UsdLookdevHandler.cpp
+++ b/lib/lookdevXUsd/UsdLookdevHandler.cpp
@@ -12,9 +12,13 @@
 
 #include "UsdMaterialCommands.h"
 
-#include <mayaUsdAPI/utils.h>
-
+#include <usdUfe/ufe/Global.h>
+#include <usdufe/ufe/UsdUndoAddNewPrimCommand.h>
 #include <usdUfe/ufe/Utils.h>
+
+#ifdef LDX_USD_USE_MAYAUSDAPI
+#include <mayaUsdAPI/utils.h>
+#endif
 
 namespace
 {
@@ -90,18 +94,23 @@ namespace LookdevXUsd
 Ufe::SceneItemResultUndoableCommand::Ptr UsdLookdevHandler::createLookdevContainerCmdImpl(
     const Ufe::SceneItem::Ptr& parent, const Ufe::PathComponent& name) const
 {
-    if (!MayaUsdAPI::isUsdSceneItem(parent) || !MayaUsdAPI::getPrimForUsdSceneItem(parent).IsValid())
+    auto usdParent = UsdUfe::downcast(parent);
+    auto prim = usdParent ? usdParent->prim() : PXR_NS::UsdPrim();
+    if (!prim.IsValid())
     {
         return nullptr;
     }
 
-    return MayaUsdAPI::createAddNewPrimCommand(parent, name.string(), "Material");
+    return UsdUfe::UsdUndoAddNewPrimCommand::create(usdParent, name.string(), "Material");
 }
 
 Ufe::SceneItemResultUndoableCommand::Ptr UsdLookdevHandler::createLookdevContainerCmdImpl(
     const Ufe::SceneItem::Ptr& parent, const Ufe::NodeDef::Ptr& nodeDef) const
 {
-    if (!MayaUsdAPI::isUsdSceneItem(parent) || !MayaUsdAPI::getPrimForUsdSceneItem(parent).IsValid())
+#ifdef LDX_USD_USE_MAYAUSDAPI
+    auto usdParent = UsdUfe::downcast(parent);
+    auto prim = usdParent ? usdParent->prim() : PXR_NS::UsdPrim();
+    if (!prim.IsValid())
     {
         return nullptr;
     }
@@ -118,12 +127,15 @@ Ufe::SceneItemResultUndoableCommand::Ptr UsdLookdevHandler::createLookdevContain
         return nullptr;
     }
     return WrapInsertChildCommand::create(cmd);
+#else
+    return nullptr;
+#endif
 }
 
 Ufe::SceneItemResultUndoableCommand::Ptr UsdLookdevHandler::createLookdevEnvironmentCmdImpl(
     const Ufe::SceneItem::Ptr& ancestor, Ufe::Rtid targetRunTimeId) const
 {
-    if (!MayaUsdAPI::isUsdSceneItem(ancestor) || targetRunTimeId != MayaUsdAPI::getUsdRunTimeId())
+    if (!UsdUfe::downcast(ancestor) || targetRunTimeId != UsdUfe::getUsdRunTimeId())
     {
         return nullptr;
     }

--- a/lib/lookdevXUsd/UsdMaterial.cpp
+++ b/lib/lookdevXUsd/UsdMaterial.cpp
@@ -10,7 +10,8 @@
 //*****************************************************************************
 #include "UsdMaterial.h"
 
-#include <mayaUsdAPI/utils.h>
+#include <usdUfe/ufe/UsdSceneItem.h>
+#include <usdUfe/ufe/Utils.h>
 
 #include <ufe/types.h>
 
@@ -47,7 +48,8 @@ std::vector<Ufe::SceneItem::Ptr> UsdMaterial::getMaterials() const
 
     std::vector<PXR_NS::UsdPrim> materialPrims;
 
-    const PXR_NS::UsdPrim& prim = MayaUsdAPI::getPrimForUsdSceneItem(m_item);
+    auto usdItem = UsdUfe::downcast(m_item);
+    const PXR_NS::UsdPrim& prim = usdItem ? usdItem->prim() : PXR_NS::UsdPrim();
     PXR_NS::UsdShadeMaterialBindingAPI bindingApi(prim);
 
     // 1. Simple case: A material is directly attached to our object.
@@ -74,7 +76,7 @@ std::vector<Ufe::SceneItem::Ptr> UsdMaterial::getMaterials() const
     for (auto& materialPrim : materialPrims)
     {
         const PXR_NS::SdfPath& materialSdfPath = materialPrim.GetPath();
-        const Ufe::Path materialUfePath = MayaUsdAPI::usdPathToUfePathSegment(materialSdfPath);
+        const Ufe::Path materialUfePath = UsdUfe::usdPathToUfePathSegment(materialSdfPath);
 
         // Construct a UFE path consisting of two segments:
         // 1. The path to the USD stage
@@ -89,7 +91,7 @@ std::vector<Ufe::SceneItem::Ptr> UsdMaterial::getMaterials() const
         const auto ufePath = Ufe::Path({stagePathSegments[0], materialPathSegments[0]});
 
         // Now we have the full path to the material's SceneItem.
-        materials.push_back(MayaUsdAPI::createUsdSceneItem(ufePath, materialPrim));
+        materials.push_back(UsdUfe::UsdSceneItem::create(ufePath, materialPrim));
     }
 
     return materials;
@@ -102,7 +104,8 @@ bool UsdMaterial::hasMaterial() const
         return false;
     }
 
-    const PXR_NS::UsdPrim& prim = MayaUsdAPI::getPrimForUsdSceneItem(m_item);
+    auto usdItem = UsdUfe::downcast(m_item);
+    const PXR_NS::UsdPrim& prim = usdItem ? usdItem->prim() : PXR_NS::UsdPrim();
     PXR_NS::UsdShadeMaterialBindingAPI bindingApi(prim);
 
     // 1. Simple case: A material is directly attached to our object.

--- a/lib/lookdevXUsd/UsdMaterialCommands.cpp
+++ b/lib/lookdevXUsd/UsdMaterialCommands.cpp
@@ -10,7 +10,11 @@
 //*****************************************************************************
 #include "UsdMaterialCommands.h"
 
+#include <usdUfe/ufe/Utils.h>
+
+#ifdef LDX_USD_USE_MAYAUSDAPI
 #include <mayaUsdAPI/utils.h>
+#endif
 
 namespace LookdevXUsd
 {
@@ -37,21 +41,25 @@ Ufe::SceneItem::Ptr UsdCreateMaterialParentCommand::sceneItem() const
 
 void UsdCreateMaterialParentCommand::execute()
 {
-    if (!m_ancestor || !MayaUsdAPI::getPrimForUsdSceneItem(m_ancestor).IsValid())
+    auto usdItem = UsdUfe::downcast(m_ancestor);
+    auto prim = usdItem ? usdItem->prim() : PXR_NS::UsdPrim();
+    if (!prim.IsValid())
     {
         return;
     }
 
     // If m_ancestor is a materials scope, it can be used as material parent.
-    if (MayaUsdAPI::isMaterialsScope(m_ancestor))
+    if (UsdUfe::isMaterialsScope(m_ancestor))
     {
         m_materialParent = m_ancestor;
         return;
     }
 
+#ifdef LDX_USD_USE_MAYAUSDAPI
     // Create a materials scope.
     m_cmd = std::dynamic_pointer_cast<Ufe::SceneItemResultUndoableCommand>(
         MayaUsdAPI::createMaterialsScopeCommand(m_ancestor));
+#endif
     if (!m_cmd)
     {
         return;

--- a/lib/lookdevXUsd/UsdMaterialHandler.cpp
+++ b/lib/lookdevXUsd/UsdMaterialHandler.cpp
@@ -14,8 +14,7 @@
 #include "UsdMaterialValidator.h"
 #include "UsdMxVersionUpgrade.h"
 
-#include <mayaUsdAPI/utils.h>
-
+#include <usdUfe/ufe/UsdUndoAddNewPrimCommand.h>
 #include <usdUfe/ufe/Utils.h>
 
 #include <pxr/base/tf/diagnostic.h>
@@ -42,14 +41,15 @@ LookdevXUfe::Material::Ptr UsdMaterialHandler::material(const Ufe::SceneItem::Pt
 {
     PXR_NAMESPACE_USING_DIRECTIVE
 
-    if (!TF_VERIFY(MayaUsdAPI::isUsdSceneItem(item), "Invalid item\n"))
+    if (!TF_VERIFY(UsdUfe::downcast(item), "Invalid item\n"))
     {
         return nullptr;
     }
 
     // Test if this item is imageable or a geom subset. If not, then we cannot create a material
     // interface for it, which is a valid case (such as for a material node type).
-    const auto prim = MayaUsdAPI::getPrimForUsdSceneItem(item);
+    auto usdItem = UsdUfe::downcast(item);
+    auto prim = usdItem ? usdItem->prim() : PXR_NS::UsdPrim();
     if (!UsdGeomImageable(prim) && !prim.IsA<UsdGeomSubset>())
     {
         return nullptr;
@@ -61,7 +61,8 @@ LookdevXUfe::Material::Ptr UsdMaterialHandler::material(const Ufe::SceneItem::Pt
 Ufe::SceneItemResultUndoableCommand::Ptr UsdMaterialHandler::createBackdropCmdImpl(const Ufe::SceneItem::Ptr& parent,
                                                                                    const Ufe::PathComponent& name) const
 {
-    if (!MayaUsdAPI::isUsdSceneItem(parent))
+    auto usdItem = UsdUfe::downcast(parent);
+    if (!usdItem)
     {
         return nullptr;
     }
@@ -74,23 +75,29 @@ Ufe::SceneItemResultUndoableCommand::Ptr UsdMaterialHandler::createBackdropCmdIm
         }
     }
 
-    return MayaUsdAPI::createAddNewPrimCommand(parent, name.string(), "Backdrop");
+    return UsdUfe::UsdUndoAddNewPrimCommand::create(usdItem, name.string(), "Backdrop");
 }
 
 Ufe::SceneItemResultUndoableCommand::Ptr UsdMaterialHandler::createNodeGraphCmdImpl(
     const Ufe::SceneItem::Ptr& parent, const Ufe::PathComponent& name) const
 {
-    return MayaUsdAPI::createAddNewPrimCommand(parent, name.string(), "NodeGraph");
+    auto usdItem = UsdUfe::downcast(parent);
+    if (!usdItem) {
+        return nullptr;
+    }
+    return UsdUfe::UsdUndoAddNewPrimCommand::create(usdItem, name.string(), "NodeGraph");
 }
 
 LookdevXUfe::ValidationLog::Ptr UsdMaterialHandler::validateMaterial(const Ufe::SceneItem::Ptr& material) const
 {
-    if (!MayaUsdAPI::isUsdSceneItem(material))
+    if (!UsdUfe::downcast(material))
     {
         return nullptr;
     }
 
-    auto materialPrim = PXR_NS::UsdShadeMaterial(MayaUsdAPI::getPrimForUsdSceneItem(material));
+    auto usdItem = UsdUfe::downcast(material);
+    auto prim = usdItem ? usdItem->prim() : PXR_NS::UsdPrim();
+    auto materialPrim = PXR_NS::UsdShadeMaterial(prim);
     if (!materialPrim)
     {
         return nullptr;

--- a/lib/lookdevXUsd/UsdMaterialValidator.cpp
+++ b/lib/lookdevXUsd/UsdMaterialValidator.cpp
@@ -11,7 +11,7 @@
 #include "UsdMaterialValidator.h"
 #include "Utils.h"
 
-#include <mayaUsdAPI/utils.h>
+#include <usdUfe/ufe/Utils.h>
 
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/base/tf/stringUtils.h>
@@ -474,8 +474,8 @@ void UsdMaterialValidator::validateComponentLocation(const LookdevXUfe::Attribut
 
 Ufe::Path UsdMaterialValidator::toUfe(const UsdStageWeakPtr& stage, const SdfPath& path)
 {
-    auto stagePath = MayaUsdAPI::stagePath(stage);
-    return Ufe::Path::Segments{stagePath.getSegments()[0], MayaUsdAPI::usdPathToUfePathSegment(path)};
+    auto stagePath = UsdUfe::stagePath(stage);
+    return Ufe::Path::Segments{stagePath.getSegments()[0], UsdUfe::usdPathToUfePathSegment(path)};
 }
 
 Ufe::Path UsdMaterialValidator::toUfe(const UsdPrim& prim)

--- a/lib/lookdevXUsd/UsdMxVersionUpgrade.cpp
+++ b/lib/lookdevXUsd/UsdMxVersionUpgrade.cpp
@@ -14,8 +14,6 @@
 
 #include "UsdMxVersionUpgrade.h"
 
-#include <mayaUsdAPI/utils.h>
-
 #include <pxr/base/gf/vec3f.h>
 #include <pxr/base/tf/diagnostic.h>
 #include <pxr/base/tf/staticTokens.h>
@@ -34,9 +32,9 @@
 
 #include <ufe/hierarchy.h>
 
+#include <usdUfe/ufe/UsdSceneItem.h>
 #include <usdUfe/ufe/Utils.h>
-
-#include <mayaUsdAPI/utils.h>
+#include <usdUfe/undo/UsdUndoBlock.h>
 
 #include <regex>
 #include <string>
@@ -932,8 +930,8 @@ std::optional<std::string> isLegacyShaderGraph(const Ufe::Path& materialPath)
         return std::nullopt;
     }
 
-    const auto materialItem = Ufe::Hierarchy::createItem(adjustedMaterialPath);
-    auto materialPrim = UsdShadeMaterial(MayaUsdAPI::getPrimForUsdSceneItem(materialItem));
+    const auto materialItem = UsdUfe::downcast(Ufe::Hierarchy::createItem(adjustedMaterialPath));
+    auto materialPrim = UsdShadeMaterial(materialItem ? materialItem->prim() : PXR_NS::UsdPrim());
     if (!materialPrim)
     {
         return std::nullopt;
@@ -944,8 +942,8 @@ std::optional<std::string> isLegacyShaderGraph(const Ufe::Path& materialPath)
 void UpgradeMaterial(const Ufe::Path& materialPath)
 {
     const auto adjustedMaterialPath = _getMaterialPath(materialPath);
-    const auto materialItem = Ufe::Hierarchy::createItem(adjustedMaterialPath);
-    auto materialPrim = UsdShadeMaterial(MayaUsdAPI::getPrimForUsdSceneItem(materialItem));
+    const auto materialItem = UsdUfe::downcast(Ufe::Hierarchy::createItem(adjustedMaterialPath));
+    auto materialPrim = UsdShadeMaterial(materialItem ? materialItem->prim() : UsdPrim());
     if (materialPrim && _isLegacyMaterial(materialPrim)) {
         _upgradeMaterial(materialPrim);
     }
@@ -969,10 +967,10 @@ UsdMxUpgradeMaterialCmd::~UsdMxUpgradeMaterialCmd() = default;
 void UsdMxUpgradeMaterialCmd::execute()
 {
     // I do hope the undo block is strong enough to track multi-layer changes because the upgrade process can go dig into a nested material layer and execute some changes there.
-    MayaUsdAPI::UsdUndoBlock undoBlock(&_undoableItem);
+    UsdUfe::UsdUndoBlock undoBlock(&_undoableItem);
 
-    const auto materialItem = Ufe::Hierarchy::createItem(_materialPath);
-    auto materialPrim = UsdShadeMaterial(MayaUsdAPI::getPrimForUsdSceneItem(materialItem));
+    const auto materialItem = UsdUfe::downcast(Ufe::Hierarchy::createItem(_materialPath));
+    auto materialPrim = UsdShadeMaterial(materialItem ? materialItem->prim() : UsdPrim());
     if (materialPrim && _isLegacyMaterial(materialPrim)) {
         _upgradeMaterial(materialPrim);
     }

--- a/lib/lookdevXUsd/UsdMxVersionUpgrade.h
+++ b/lib/lookdevXUsd/UsdMxVersionUpgrade.h
@@ -15,7 +15,7 @@
 
 #include "Export.h"
 
-#include <mayaUsdAPI/undo.h>
+#include <usdUfe/undo/UsdUndoableItem.h>
 
 #include <ufe/path.h>
 #include <ufe/undoableCommand.h>
@@ -58,8 +58,8 @@ public:
     UFE_V4(std::string commandString() const override { return "MaterialXUpgradeMaterial"; })
 
 private:
-    Ufe::Path                   _materialPath;
-    MayaUsdAPI::UsdUndoableItem _undoableItem;
+    Ufe::Path               _materialPath;
+    UsdUfe::UsdUndoableItem _undoableItem;
 };
 
 } // namespace LookdevXUsd::Version

--- a/lib/lookdevXUsd/UsdSceneItemOps.cpp
+++ b/lib/lookdevXUsd/UsdSceneItemOps.cpp
@@ -9,7 +9,8 @@
 #include "UsdSceneItemOps.h"
 #include "UsdDeleteCommand.h"
 
-#include <mayaUsdAPI/utils.h>
+#include <usdUfe/ufe/UsdSceneItem.h>
+#include <usdUfe/ufe/Utils.h>
 
 #include <pxr/base/tf/diagnostic.h>
 
@@ -53,11 +54,12 @@ Ufe::UndoableCommand::Ptr UsdSceneItemOps::deleteItemCmd()
 bool UsdSceneItemOps::deleteItem()
 {
     auto prim = [this]() {
-        if (!TF_VERIFY(MayaUsdAPI::isUsdSceneItem(m_wrappedMayaUsdSceneItemOps->sceneItem()), "Invalid item\n"))
+        if (!TF_VERIFY(UsdUfe::downcast(m_wrappedMayaUsdSceneItemOps->sceneItem()), "Invalid item\n"))
         {
             return PXR_NS::UsdPrim();
         }
-        return MayaUsdAPI::getPrimForUsdSceneItem(m_wrappedMayaUsdSceneItemOps->sceneItem());
+        auto usdItem = UsdUfe::downcast(m_wrappedMayaUsdSceneItemOps->sceneItem());
+        return usdItem ? usdItem->prim() : PXR_NS::UsdPrim();
     };
 
     // Same check as in MayaUsd::ufe::UsdSceneItemOps::deleteItem()

--- a/lib/lookdevXUsd/UsdSceneItemUI.cpp
+++ b/lib/lookdevXUsd/UsdSceneItemUI.cpp
@@ -10,17 +10,16 @@
 //*****************************************************************************
 
 #include "UsdSceneItemUI.h"
+
 #include <LookdevXUfe/SoloingHandler.h>
 #include <LookdevXUfe/UfeUtils.h>
 #include <LookdevXUfe/Utils.h>
-
-#include <mayaUsdAPI/utils.h>
 
 namespace
 {
 
 // For backwards compatibility for when we used usd prim hidden flag. Needs to be removed at some point.
-bool isLegacyHiddenItem(const Ufe::SceneItem::Ptr& item)
+bool isLegacyHiddenItem(const UsdUfe::UsdSceneItem::Ptr& item)
 {
     if (!item)
     {
@@ -31,17 +30,17 @@ bool isLegacyHiddenItem(const Ufe::SceneItem::Ptr& item)
     const auto isSeparateOrCombine =
         nodeDef ? LookdevXUfe::identifyComponentNode(nodeDef->type()) != LookdevXUfe::ComponentNodeType::eNone : false;
 
-    auto prim = MayaUsdAPI::getPrimForUsdSceneItem(item);
+    auto prim = item->prim();
     return (prim.IsValid() && prim.IsHidden()) &&
            (isSeparateOrCombine || (soloingHandler && soloingHandler->isSoloingItem(item)));
 }
 
-std::string getHiddenKeyMetadata(const Ufe::SceneItemPtr& item)
+std::string getHiddenKeyMetadata(const UsdUfe::UsdSceneItem::Ptr& item)
 {
     if (item)
     {
         // Short circuit the NodeDef handler. Works even if the LookdevX converter nodes are unavailable in Sdr.
-        auto usdShaderItem = PXR_NS::UsdShadeShader(MayaUsdAPI::getPrimForUsdSceneItem(item));
+        auto usdShaderItem = PXR_NS::UsdShadeShader(item->prim());
         if (usdShaderItem)
         {
             PXR_NS::TfToken mxNodeType;
@@ -60,17 +59,15 @@ std::string getHiddenKeyMetadata(const Ufe::SceneItemPtr& item)
 namespace LookdevXUsd
 {
 
-UsdSceneItemUI::UsdSceneItemUI(Ufe::SceneItem::Ptr item, const PXR_NS::UsdPrim& prim)
-    : m_item(std::move(item)), m_stage(prim.IsValid() ? prim.GetStage() : nullptr),
-      m_path(prim.IsValid() ? prim.GetPath() : PXR_NS::SdfPath())
+UsdSceneItemUI::UsdSceneItemUI(UsdUfe::UsdSceneItem::Ptr item)
+    : m_item(std::move(item))
 {
 }
 
 /*static*/
-UsdSceneItemUI::Ptr UsdSceneItemUI::create(const Ufe::SceneItem::Ptr& item)
+UsdSceneItemUI::Ptr UsdSceneItemUI::create(const UsdUfe::UsdSceneItem::Ptr& item)
 {
-    auto prim = MayaUsdAPI::getPrimForUsdSceneItem(item);
-    return std::make_shared<UsdSceneItemUI>(item, prim);
+    return std::make_shared<UsdSceneItemUI>(item);
 }
 
 //------------------------------------------------------------------------------

--- a/lib/lookdevXUsd/UsdSceneItemUI.h
+++ b/lib/lookdevXUsd/UsdSceneItemUI.h
@@ -17,6 +17,8 @@
 #include <pxr/usd/sdf/path.h>
 #include <pxr/usd/usd/stage.h>
 
+#include <usdUfe/ufe/UsdSceneItem.h>
+
 #include <ufe/sceneItem.h>
 
 namespace LookdevXUsd
@@ -31,7 +33,7 @@ class UsdSceneItemUI : public LookdevXUfe::SceneItemUI
 public:
     using Ptr = std::shared_ptr<UsdSceneItemUI>;
 
-    explicit UsdSceneItemUI(Ufe::SceneItem::Ptr item, const PXR_NS::UsdPrim& prim);
+    explicit UsdSceneItemUI(UsdUfe::UsdSceneItem::Ptr item);
     ~UsdSceneItemUI() override = default;
 
     // Delete the copy/move constructors assignment operators.
@@ -41,7 +43,7 @@ public:
     UsdSceneItemUI& operator=(UsdSceneItemUI&&) = delete;
 
     //! Create a UsdSceneItemUI.
-    static UsdSceneItemUI::Ptr create(const Ufe::SceneItem::Ptr& item);
+    static UsdSceneItemUI::Ptr create(const UsdUfe::UsdSceneItem::Ptr& item);
 
     // Ufe::SceneItemUI overrides
     Ufe::SceneItem::Ptr sceneItem() const override;
@@ -49,9 +51,7 @@ public:
     Ufe::UndoableCommand::Ptr setHiddenCmd(bool hidden) override;
 
 private:
-    Ufe::SceneItem::Ptr m_item;
-    const PXR_NS::UsdStageWeakPtr m_stage;
-    const PXR_NS::SdfPath m_path;
+    UsdUfe::UsdSceneItem::Ptr m_item;
 };
 
 } // namespace LookdevXUsd

--- a/lib/lookdevXUsd/UsdSceneItemUIHandler.cpp
+++ b/lib/lookdevXUsd/UsdSceneItemUIHandler.cpp
@@ -12,7 +12,7 @@
 #include "UsdSceneItemUIHandler.h"
 #include "UsdSceneItemUI.h"
 
-#include <mayaUsdAPI/utils.h>
+#include <usdUfe/ufe/Utils.h>
 
 namespace LookdevXUsd
 {
@@ -29,11 +29,12 @@ UsdSceneItemUIHandler::Ptr UsdSceneItemUIHandler::create()
 
 LookdevXUfe::SceneItemUI::Ptr UsdSceneItemUIHandler::sceneItemUI(const Ufe::SceneItem::Ptr& item) const
 {
+    auto usdItem = UsdUfe::downcast(item);
 #if !defined(NDEBUG)
-    assert(MayaUsdAPI::isUsdSceneItem(item));
+    assert(usdItem);
 #endif
 
-    return LookdevXUsd::UsdSceneItemUI::create(item);
+    return LookdevXUsd::UsdSceneItemUI::create(usdItem);
 }
 
 } // namespace LookdevXUsd

--- a/lib/lookdevXUsd/UsdSoloingHandler.cpp
+++ b/lib/lookdevXUsd/UsdSoloingHandler.cpp
@@ -30,10 +30,12 @@
 #include <pxr/usd/sdr/registry.h>
 #include <pxr/usd/sdr/shaderProperty.h>
 
-#include <mayaUsdAPI/undo.h>
-#include <mayaUsdAPI/utils.h>
-
+#include <usdUfe/ufe/Global.h>
+#include <usdUfe/ufe/UsdSceneItem.h>
+#include <usdUfe/ufe/UsdUndoAddNewPrimCommand.h>
 #include <usdUfe/ufe/Utils.h>
+#include <usdUfe/undo/UsdUndoableItem.h>
+#include <usdUfe/undo/UsdUndoBlock.h>
 
 #include <memory>
 
@@ -85,7 +87,7 @@ void setMetadata(const Ufe::SceneItem::Ptr& item, const std::string& key, const 
 
 Ufe::ConnectionHandler::Ptr getConnHandler()
 {
-    static auto connHandler = Ufe::RunTimeMgr::instance().connectionHandler(MayaUsdAPI::getUsdRunTimeId());
+    static auto connHandler = Ufe::RunTimeMgr::instance().connectionHandler(UsdUfe::getUsdRunTimeId());
     return connHandler;
 }
 
@@ -180,7 +182,7 @@ public:
         // the NodeDef. As you have noticed, it is currently impossible to Solo a native USD shader.
         const auto* mtlxShaderNodeDef =
             SdrRegistry::GetInstance().GetShaderNodeByIdentifier(TfToken(kMtlxStandardSurface));
-        const auto nodeDefHandler = Ufe::RunTimeMgr::instance().nodeDefHandler(MayaUsdAPI::getUsdRunTimeId());
+        const auto nodeDefHandler = Ufe::RunTimeMgr::instance().nodeDefHandler(UsdUfe::getUsdRunTimeId());
         if (mtlxShaderNodeDef)
         {
             const auto nodeDef = nodeDefHandler ? nodeDefHandler->definition(kMtlxStandardSurface) : nullptr;
@@ -463,7 +465,13 @@ private:
     {
         Ufe::NotificationGuard guard(Ufe::Scene::instance());
         // Use a noop compound as an intermediary node for holding soloing information.
-        auto cmd = MayaUsdAPI::createAddNewPrimCommand(parent, std::string(kSoloingTag), "NodeGraph");
+        auto usdParentItem = UsdUfe::downcast(parent);
+        if (!usdParentItem)
+        {
+            return;
+        }
+
+        auto cmd = UsdUfe::UsdUndoAddNewPrimCommand::create(usdParentItem, std::string(kSoloingTag), "NodeGraph");
         cmd->execute();
 
         auto compound = cmd->sceneItem();
@@ -529,7 +537,7 @@ public:
 
     void execute() override
     {
-        const MayaUsdAPI::UsdUndoBlock undoBlock(&m_undoableItem);
+        const UsdUfe::UsdUndoBlock undoBlock(&m_undoableItem);
 
         auto sessionLayer = m_item ? LookdevXUsdUtils::getSessionLayer(m_item) : nullptr;
         if (!sessionLayer)
@@ -545,9 +553,7 @@ public:
 
         m_soloedItem = getSoloedUsdItem(material);
 
-        auto prim = MayaUsdAPI::getPrimForUsdSceneItem(material);
-        auto stage = prim.GetStage();
-
+        auto stage = UsdUfe::getStage(material->path());
         {
             EditTargetGuard editTargetGuard(stage, sessionLayer);
 
@@ -586,7 +592,7 @@ private:
         }
     }
 
-    MayaUsdAPI::UsdUndoableItem m_undoableItem;
+    UsdUfe::UsdUndoableItem m_undoableItem;
 
     // Input item.
     Ufe::SceneItem::Ptr m_item;
@@ -623,11 +629,10 @@ public:
 
     void execute() override
     {
-        const MayaUsdAPI::UsdUndoBlock undoBlock(&m_undoableItem);
+        const UsdUfe::UsdUndoBlock undoBlock(&m_undoableItem);
 
         auto item = m_attr->sceneItem();
-        auto prim = MayaUsdAPI::getPrimForUsdSceneItem(item);
-        auto stage = prim.GetStage();
+        auto stage = UsdUfe::getStage(item->path());
         auto material = getParentUsdMaterial(item);
         auto sessionLayer = LookdevXUsdUtils::getSessionLayer(item);
 
@@ -690,7 +695,7 @@ public:
     }
 
 private:
-    MayaUsdAPI::UsdUndoableItem m_undoableItem;
+    UsdUfe::UsdUndoableItem m_undoableItem;
 
     // Input attribute to solo.
     Ufe::Attribute::Ptr m_attr;
@@ -801,8 +806,8 @@ public:
             // The user can attempt to connect other surface shaders to the material output while soloing is active.
             // In that case, the fake connection information needs to be updated.
 
-            const auto item = Ufe::Hierarchy::createItem(connNotif->path());
-            const auto prim = MayaUsdAPI::getPrimForUsdSceneItem(item);
+            const auto item = UsdUfe::downcast(Ufe::Hierarchy::createItem(connNotif->path()));
+            auto prim = item ? item->prim() : PXR_NS::UsdPrim();
             // Only applicable to material nodes.
             if (!item || !prim || prim.GetTypeName() != TfToken("Material"))
             {
@@ -964,7 +969,8 @@ bool UsdSoloingHandler::hasSoloedDescendant(const Ufe::SceneItem::Ptr& item) con
 
 Ufe::Attribute::Ptr UsdSoloingHandler::getSoloedAttribute(const Ufe::SceneItem::Ptr& item) const
 {
-    if (!MayaUsdAPI::isUsdSceneItem(item))
+    auto usdItem = UsdUfe::downcast(item);
+    if (!usdItem)
     {
         return nullptr;
     }
@@ -975,18 +981,19 @@ Ufe::Attribute::Ptr UsdSoloingHandler::getSoloedAttribute(const Ufe::SceneItem::
     // USD does not seem to track outgoing connections. Instead, a search is performed on the
     // incoming connections of soloing nodes until one is found that matches the input item.
     processSoloingPrimChildren(material, [&](const auto& child) {
-        auto prim = MayaUsdAPI::getPrimForUsdSceneItem(child);
+        auto usdChildItem = UsdUfe::downcast(child);
+        auto prim = usdChildItem ? usdChildItem->prim() : PXR_NS::UsdPrim();
         const UsdShadeConnectableAPI connectableAttrs(prim);
         for (const auto& input : connectableAttrs.GetInputs(false))
         {
             for (const auto& sourceInfo : input.GetConnectedSources())
             {
                 const auto connectedPrim = sourceInfo.source.GetPrim();
-                auto usdPrim = MayaUsdAPI::getPrimForUsdSceneItem(item);
+                auto usdPrim = usdItem->prim();
                 if (connectedPrim == usdPrim)
                 {
                     auto attrOut = sourceInfo.source.GetOutput(sourceInfo.sourceName);
-                    auto attrs = Ufe::Attributes::attributes(item);
+                    auto attrs = Ufe::Attributes::attributes(usdItem);
                     retval = attrs->attribute(attrOut.GetFullName());
                     return false;
                 }
@@ -1005,7 +1012,7 @@ bool UsdSoloingHandler::isSoloingItem(const Ufe::SceneItem::Ptr& item) const
 
 Ufe::Connection::Ptr UsdSoloingHandler::replacedConnection(const Ufe::SceneItem::Ptr& item) const
 {
-    if (!MayaUsdAPI::isUsdSceneItem(item))
+    if (!UsdUfe::downcast(item))
     {
         return nullptr;
     }

--- a/lib/lookdevXUsd/Utils.cpp
+++ b/lib/lookdevXUsd/Utils.cpp
@@ -12,7 +12,7 @@
 
 #include <LookdevXUfe/UfeUtils.h>
 
-#include <usdufe/ufe/Utils.h>
+#include <usdUfe/ufe/Utils.h>
 
 #include <ufe/attributes.h>
 #include <ufe/runTimeMgr.h>

--- a/lib/lookdevXUsd/Utils.cpp
+++ b/lib/lookdevXUsd/Utils.cpp
@@ -12,7 +12,7 @@
 
 #include <LookdevXUfe/UfeUtils.h>
 
-#include <mayaUsdAPI/utils.h>
+#include <usdufe/ufe/Utils.h>
 
 #include <ufe/attributes.h>
 #include <ufe/runTimeMgr.h>
@@ -24,12 +24,13 @@ namespace LookdevXUsdUtils
 {
 SdfLayerRefPtr getSessionLayer(const Ufe::SceneItem::Ptr& item)
 {
-    if (!item)
+    auto usdSceneItem = UsdUfe::downcast(item);
+    if (!usdSceneItem)
     {
         return {};
     }
 
-    auto prim = MayaUsdAPI::getPrimForUsdSceneItem(item);
+    auto prim = usdSceneItem->prim();
     auto sessionLayer = prim.GetStage()->GetSessionLayer();
     return sessionLayer;
 }


### PR DESCRIPTION
#### EMSUSD-3194 - Remove MayaUsdAPI dependency from LookdevXUsd
* Allow building LookdevXUsd as separate component from MayaUsd (requires UsdUfe).
* Optionally build LookdevXUsd with MayaUsdAPI only when building MayaUsd.
* ProxyShapeLookdevHandler requires MayaUsd.
* Replace MayaUsdAPI calls with UsdUfe ones.
* There is still some MayaUSDAPI dependency using conditional compilation (when building MayaUsd).