### PR TITLE
LayerManager: avoid side effects on exports that do not include proxyShapes.

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -575,7 +575,17 @@ void LayerDatabase::prepareForExportCheck(bool* retCode, void*)
     for (const auto& info : layerDB._internalProxiesToSave)
         handleDirtyStageDuringExport(info);
 
-    prepareForWriteCheck(retCode, true);
+    const auto currentExportType = MFileIO::exportType();
+    const bool mightWriteProxyShapes
+        = (currentExportType == MFileIO::kExportTypeAll
+           || currentExportType == MFileIO::kExportTypeSelected
+           || currentExportType == MFileIO::kExportTypeAsReference);
+
+    if (mightWriteProxyShapes) {
+        prepareForWriteCheck(retCode, true);
+    } else {
+        layerDB.clearProxies();
+    }
 }
 
 void LayerDatabase::cleanupForExport(void*)
@@ -668,7 +678,10 @@ bool LayerDatabase::getProxiesToSave(bool isExport, bool* hasAnyProxy)
     if (hasAnyProxy)
         *hasAnyProxy = false;
 
-    bool checkSelection = isExport && (MFileIO::kExportTypeSelected == MFileIO::exportType());
+    bool checkSelection = isExport
+        && ((MFileIO::kExportTypeSelected == MFileIO::exportType())
+            || (MFileIO::kExportTypeAsReference == MFileIO::exportType()));
+
     const Ufe::GlobalSelection::Ptr& ufeSelection = Ufe::GlobalSelection::get();
 
     clearProxies();


### PR DESCRIPTION
Before this change, prepareForExportCheck() always called prepareForWriteCheck(), regardless of the export mode.

As a result, export operations such as exporting reference edits to editMA files still ran the LayerManager write path even though no LayerManager data needed to be persisted. This could raise unnecessary maya-usd save dialogs and trigger unnecessary session layer serialization, which could later lead to avoidable stage recomposition when a proxyShape is recomputed.

