### PR TITLE
EMSUSDC-376 improve transform command undo

### DIFF
--- a/lib/mayaUsd/ufe/Global.cpp
+++ b/lib/mayaUsd/ufe/Global.cpp
@@ -145,6 +145,10 @@ bool mayaIsSceneLoading()
         || MFileIO::isImportingFile() || MFileIO::isReferencingFile();
 }
 
+bool mayaIsUndoing() { return MGlobal::isUndoing(); }
+
+bool mayaIsRedoing() { return MGlobal::isRedoing(); }
+
 // Note: MayaUsd::ufe::getStage takes two parameters, so wrap it in a function taking only one.
 PXR_NS::UsdStageWeakPtr mayaGetStage(const Ufe::Path& path) { return MayaUsd::ufe::getStage(path); }
 
@@ -292,6 +296,8 @@ MStatus initialize()
     dccFunctions.extractTRSFn = MayaUsd::ufe::extractTRS;
     dccFunctions.transform3dMatrixOpNameFn = getTransform3dMatrixOpName;
     dccFunctions.isLoadingSceneFn = mayaIsSceneLoading;
+    dccFunctions.isUndoingFn = mayaIsUndoing;
+    dccFunctions.isRedoingFn = mayaIsRedoing;
 #ifdef WANT_ADSKUSDEDITFORWARD_BUILD
     dccFunctions.pauseEditForwardingFn = mayaPauseEditForwarding;
 #endif

--- a/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.cpp
@@ -331,6 +331,16 @@ public:
     // Executes the command by setting the translation onto the transform op.
     bool set(double x, double y, double z) override
     {
+        // Note: Maya viewport manipulators call the set function for the initial changes
+        //       and for redo! Detect we're in an undo or redo and call undo and redo instead.
+        if (UsdUfe::isRedoing()) {
+            redo();
+            return true;
+        } else if (UsdUfe::isUndoing()) {
+            undo();
+            return true;
+        }
+
         TF_DEBUG_MSG(USDUFE_UNDOCMD, "Setting value\n");
 
         UsdUfe::OperationEditRouterContext editContext(
@@ -338,10 +348,7 @@ public:
 
         VtValue v;
         v = V(x, y, z);
-        {
-            UsdUfe::NoUsdUndoBlockGuard guard(true);
-            updateNewValue(v);
-        }
+        updateNewValue(v);
         return true;
     }
 };
@@ -363,6 +370,16 @@ public:
     // Executes the command by setting the rotation onto the transform op.
     bool set(double x, double y, double z) override
     {
+        // Note: Maya viewport manipulators call the set function for the initial changes
+        //       and for redo! Detect we're in an undo or redo and call undo and redo instead.
+        if (UsdUfe::isRedoing()) {
+            redo();
+            return true;
+        } else if (UsdUfe::isUndoing()) {
+            undo();
+            return true;
+        }
+
         TF_DEBUG_MSG(USDUFE_UNDOCMD, "Setting value\n");
 
         UsdUfe::OperationEditRouterContext editContext(
@@ -370,10 +387,7 @@ public:
 
         VtValue v;
         v = _cvtRotXYZToAttr(x, y, z);
-        {
-            UsdUfe::NoUsdUndoBlockGuard guard(true);
-            updateNewValue(v);
-        }
+        updateNewValue(v);
         return true;
     }
 

--- a/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.cpp
@@ -341,7 +341,7 @@ public:
             return true;
         }
 
-        TF_DEBUG_MSG(USDUFE_UNDOCMD, "Setting value\n");
+        TF_DEBUG_MSG(USDUFE_UNDOCMD, "Setting value %lf %lf %lf\n", x, y, z);
 
         UsdUfe::OperationEditRouterContext editContext(
             UsdUfe::EditRoutingTokens->RouteTransform, getPrim());
@@ -380,7 +380,7 @@ public:
             return true;
         }
 
-        TF_DEBUG_MSG(USDUFE_UNDOCMD, "Setting value\n");
+        TF_DEBUG_MSG(USDUFE_UNDOCMD, "Setting value %lf %lf %lf\n", x, y, z);
 
         UsdUfe::OperationEditRouterContext editContext(
             UsdUfe::EditRoutingTokens->RouteTransform, getPrim());

--- a/lib/usdUfe/ufe/Global.cpp
+++ b/lib/usdUfe/ufe/Global.cpp
@@ -89,6 +89,10 @@ Ufe::Rtid initialize(
     // Optional DCC specific functions.
     if (dccFunctions.isLoadingSceneFn)
         UsdUfe::setIsLoadingSceneFn(dccFunctions.isLoadingSceneFn);
+    if (dccFunctions.isUndoingFn)
+        UsdUfe::setIsUndoing(dccFunctions.isUndoingFn);
+    if (dccFunctions.isRedoingFn)
+        UsdUfe::setIsRedoing(dccFunctions.isRedoingFn);
     if (dccFunctions.isAttributeLockedFn)
         UsdUfe::setIsAttributeLockedFn(dccFunctions.isAttributeLockedFn);
     if (dccFunctions.saveStageLoadRulesFn)

--- a/lib/usdUfe/ufe/Global.h
+++ b/lib/usdUfe/ufe/Global.h
@@ -74,6 +74,8 @@ struct USDUFE_PUBLIC DCCFunctions
     WaitCursorFn                    startWaitCursorFn = nullptr;
     WaitCursorFn                    stopWaitCursorFn = nullptr;
     PauseEditForwardingFn           pauseEditForwardingFn = nullptr;
+    IsInUndoRedoFn                  isUndoingFn = nullptr;
+    IsInUndoRedoFn                  isRedoingFn = nullptr;
     IsComponentStageFn              isComponentStageFn = nullptr;
     GetComponentMaterialScopeNameFn getComponentMaterialScopeNameFn = nullptr;
     GetComponentMeshScopeNameFn     getComponentMeshScopeNameFn = nullptr;

--- a/lib/usdUfe/ufe/Utils.cpp
+++ b/lib/usdUfe/ufe/Utils.cpp
@@ -118,6 +118,8 @@ UsdUfe::StagePathAccessorFn             gStagePathAccessorFn = nullptr;
 UsdUfe::UfePathToPrimFn                 gUfePathToPrimFn = nullptr;
 UsdUfe::TimeAccessorFn                  gTimeAccessorFn = nullptr;
 UsdUfe::IsLoadingSceneFn                gIsLoadingSceneFn = nullptr;
+UsdUfe::IsInUndoRedoFn                  gIsUndoingFn = nullptr;
+UsdUfe::IsInUndoRedoFn                  gIsRedoingFn = nullptr;
 UsdUfe::IsAttributeLockedFn             gIsAttributeLockedFn = nullptr;
 UsdUfe::SaveStageLoadRulesFn            gSaveStageLoadRulesFn = nullptr;
 UsdUfe::IsRootChildFn                   gIsRootChildFn = nullptr;
@@ -271,6 +273,36 @@ bool isSceneLoading()
     // Otherwise return false.
     if (gIsLoadingSceneFn)
         return gIsLoadingSceneFn();
+    return false;
+}
+
+void setIsUndoing(IsInUndoRedoFn fn)
+{
+    // This function is allowed to be null in which case return default (false).
+    gIsUndoingFn = fn;
+}
+
+bool isUndoing()
+{
+    // If we have (optional) undoing function, use it.
+    // Otherwise return false.
+    if (gIsUndoingFn)
+        return gIsUndoingFn();
+    return false;
+}
+
+void setIsRedoing(IsInUndoRedoFn fn)
+{
+    // This function is allowed to be null in which case return default (false).
+    gIsRedoingFn = fn;
+}
+
+bool isRedoing()
+{
+    // If we have (optional) redoing function, use it.
+    // Otherwise return false.
+    if (gIsRedoingFn)
+        return gIsRedoingFn();
     return false;
 }
 

--- a/lib/usdUfe/ufe/Utils.h
+++ b/lib/usdUfe/ufe/Utils.h
@@ -77,6 +77,7 @@ typedef void (
 typedef const char* (*Transform3dMatrixOpNameFn)();
 typedef bool (*IsLoadingSceneFn)();
 typedef void (*PauseEditForwardingFn)(bool pause);
+typedef bool (*IsInUndoRedoFn)();
 typedef bool (*IsComponentStageFn)(const Ufe::Path&);
 typedef std::string (*GetComponentMaterialScopeNameFn)(const PXR_NS::UsdStageRefPtr&);
 typedef std::string (*GetComponentMeshScopeNameFn)(const PXR_NS::UsdStageRefPtr&);
@@ -157,6 +158,28 @@ void setIsLoadingSceneFn(IsLoadingSceneFn fn);
 //! \return True if the DCC is currently loading a scene, otherwise false
 USDUFE_PUBLIC
 bool isSceneLoading();
+
+//! Set the DCC specific is-undoing test function.
+//! Use of this function is optional, if one is not supplied then
+//! a default test function will be used.
+USDUFE_PUBLIC
+void setIsUndoing(IsInUndoRedoFn fn);
+
+//! Return whether the DCC is currently undoing commands.
+//! \return True if the DCC is currently undoing commands, otherwise false
+USDUFE_PUBLIC
+bool isUndoing();
+
+//! Set the DCC specific is-readoing test function.
+//! Use of this function is optional, if one is not supplied then
+//! a default test function will be used.
+USDUFE_PUBLIC
+void setIsRedoing(IsInUndoRedoFn fn);
+
+//! Return whether the DCC is currently redoing commands.
+//! \return True if the DCC is currently redoing commands, otherwise false
+USDUFE_PUBLIC
+bool isRedoing();
 
 //! Set the DCC specific USD attribute is locked test function.
 //! Use of this function is optional, if one is not supplied then

--- a/lib/usdUfe/ufe/trf/UsdSetXformOpUndoableCommandBase.cpp
+++ b/lib/usdUfe/ufe/trf/UsdSetXformOpUndoableCommandBase.cpp
@@ -75,12 +75,8 @@ void UsdSetXformOpUndoableCommandBase::undo()
 
     OperationEditRouterContext editContext(EditRoutingTokens->RouteTransform, getPrim());
 
-    // Note: the command never use a UsdUndpBlock when setting values.
-    NoUsdUndoBlockGuard guard(true);
-
-    // Restore the initial value and potentially remove the creatd attributes.
-    setValue(_initialOpValue, _writeTime);
-    removeOpIfNeeded();
+    _valueUndo.undo();
+    _opCreationUndo.undo();
     _canUpdateValue = false;
 }
 
@@ -90,17 +86,8 @@ void UsdSetXformOpUndoableCommandBase::redo()
 
     OperationEditRouterContext editContext(EditRoutingTokens->RouteTransform, getPrim());
 
-    // Note: the command never use a UsdUndpBlock when setting values.
-    NoUsdUndoBlockGuard guard(true);
-
-    // Redo the attribute creation if the attribute was already created
-    // but then undone.
-    recreateOpIfNeeded();
-
-    // Set the new value, potentially creating the attribute if it
-    // did not exists or caching the initial value if this is the
-    // first time the command is executed, redone or undone.
-    prepareAndSet(_newOpValue);
+    _opCreationUndo.redo();
+    _valueUndo.redo();
     _canUpdateValue = true;
 }
 
@@ -133,8 +120,8 @@ void UsdSetXformOpUndoableCommandBase::prepareAndSet(const VtValue& v)
         return;
 
     prepareOpIfNeeded();
-    // Note: the command never use a UsdUndpBlock when setting values.
-    NoUsdUndoBlockGuard guard(true);
+    _valueUndo.undo();
+    UsdUndoBlock undoBlock(&_valueUndo);
     setValue(v, _writeTime);
 }
 

--- a/lib/usdUfe/ufe/trf/UsdSetXformOpUndoableCommandBase.cpp
+++ b/lib/usdUfe/ufe/trf/UsdSetXformOpUndoableCommandBase.cpp
@@ -82,6 +82,16 @@ void UsdSetXformOpUndoableCommandBase::undo()
 
 void UsdSetXformOpUndoableCommandBase::redo()
 {
+    // Note: various Maya commands call this `redo` function instead of `execute`
+    //       in their `doIt` function.That's because many commands implement their
+    //       `doIt` by calling their `redoIt`. Then they end-up calling `redo` on
+    //       the UFE commands. Redirect to `execute` when we detect suck shenanigans,
+    //       because our `execute` capture undo info but our `redo` replays them.
+    if (!UsdUfe::isRedoing()) {
+        execute();
+        return;
+    }
+
     TF_DEBUG_MSG(USDUFE_UNDOCMD, "Redoing command\n");
 
     OperationEditRouterContext editContext(EditRoutingTokens->RouteTransform, getPrim());

--- a/lib/usdUfe/ufe/trf/UsdSetXformOpUndoableCommandBase.h
+++ b/lib/usdUfe/ufe/trf/UsdSetXformOpUndoableCommandBase.h
@@ -111,6 +111,7 @@ private:
     PXR_NS::VtValue           _initialOpValue;
     PXR_NS::VtValue           _newOpValue;
     UsdUndoableItem           _opCreationUndo;
+    UsdUndoableItem           _valueUndo;
     bool                      _isPrepared;
     bool                      _canUpdateValue;
     bool                      _opCreated;

--- a/lib/usdUfe/ufe/trf/UsdTransform3dCommonAPI.cpp
+++ b/lib/usdUfe/ufe/trf/UsdTransform3dCommonAPI.cpp
@@ -64,11 +64,18 @@ public:
 
     bool set(double x, double y, double z) override
     {
-        OperationEditRouterContext editContext(EditRoutingTokens->RouteTransform, getPrim());
-        {
-            UsdUfe::NoUsdUndoBlockGuard guard(true);
-            updateNewValue(VtValue(GfVec3d(x, y, z)));
+        // Note: Maya viewport manipulators call the set function for the initial changes
+        //       and for redo! Detect we're in an undo or redo and call undo and redo instead.
+        if (UsdUfe::isRedoing()) {
+            redo();
+            return true;
+        } else if (UsdUfe::isUndoing()) {
+            undo();
+            return true;
         }
+
+        OperationEditRouterContext editContext(EditRoutingTokens->RouteTransform, getPrim());
+        updateNewValue(VtValue(GfVec3d(x, y, z)));
         return true;
     }
 
@@ -111,11 +118,18 @@ public:
 
     bool set(double x, double y, double z) override
     {
-        OperationEditRouterContext editContext(EditRoutingTokens->RouteTransform, getPrim());
-        {
-            UsdUfe::NoUsdUndoBlockGuard guard(true);
-            updateNewValue(VtValue(GfVec3f(x, y, z)));
+        // Note: Maya viewport manipulators call the set function for the initial changes
+        //       and for redo! Detect we're in an undo or redo and call undo and redo instead.
+        if (UsdUfe::isRedoing()) {
+            redo();
+            return true;
+        } else if (UsdUfe::isUndoing()) {
+            undo();
+            return true;
         }
+
+        OperationEditRouterContext editContext(EditRoutingTokens->RouteTransform, getPrim());
+        updateNewValue(VtValue(GfVec3f(x, y, z)));
         return true;
     }
 
@@ -160,11 +174,18 @@ public:
 
     bool set(double x, double y, double z) override
     {
-        OperationEditRouterContext editContext(EditRoutingTokens->RouteTransform, getPrim());
-        {
-            UsdUfe::NoUsdUndoBlockGuard guard(true);
-            updateNewValue(VtValue(GfVec3f(x, y, z)));
+        // Note: Maya viewport manipulators call the set function for the initial changes
+        //       and for redo! Detect we're in an undo or redo and call undo and redo instead.
+        if (UsdUfe::isRedoing()) {
+            redo();
+            return true;
+        } else if (UsdUfe::isUndoing()) {
+            undo();
+            return true;
         }
+
+        OperationEditRouterContext editContext(EditRoutingTokens->RouteTransform, getPrim());
+        updateNewValue(VtValue(GfVec3f(x, y, z)));
         return true;
     }
 
@@ -209,11 +230,18 @@ public:
 
     bool set(double x, double y, double z) override
     {
-        OperationEditRouterContext editContext(EditRoutingTokens->RouteTransform, getPrim());
-        {
-            UsdUfe::NoUsdUndoBlockGuard guard(true);
-            updateNewValue(VtValue(GfVec3f(x, y, z)));
+        // Note: Maya viewport manipulators call the set function for the initial changes
+        //       and for redo! Detect we're in an undo or redo and call undo and redo instead.
+        if (UsdUfe::isRedoing()) {
+            redo();
+            return true;
+        } else if (UsdUfe::isUndoing()) {
+            undo();
+            return true;
         }
+
+        OperationEditRouterContext editContext(EditRoutingTokens->RouteTransform, getPrim());
+        updateNewValue(VtValue(GfVec3f(x, y, z)));
         return true;
     }
 

--- a/lib/usdUfe/ufe/trf/UsdTransform3dMatrixOp.cpp
+++ b/lib/usdUfe/ufe/trf/UsdTransform3dMatrixOp.cpp
@@ -187,13 +187,20 @@ public:
     // Executes the command by setting the translation onto the transform op.
     bool set(double x, double y, double z) override
     {
+        // Note: Maya viewport manipulators call the set function for the initial changes
+        //       and for redo! Detect we're in an undo or redo and call undo and redo instead.
+        if (UsdUfe::isRedoing()) {
+            redo();
+            return true;
+        } else if (UsdUfe::isUndoing()) {
+            undo();
+            return true;
+        }
+
         UsdUfe::OperationEditRouterContext editContext(
             UsdUfe::EditRoutingTokens->RouteTransform, getPrim());
-        {
-            UsdUfe::NoUsdUndoBlockGuard guard(true);
-            _opTransform.SetTranslateOnly(GfVec3d(x, y, z));
-            updateNewValue(VtValue(_opTransform));
-        }
+        _opTransform.SetTranslateOnly(GfVec3d(x, y, z));
+        updateNewValue(VtValue(_opTransform));
         return true;
     }
 
@@ -234,6 +241,16 @@ public:
     // Executes the command by setting the rotation onto the transform op.
     bool set(double x, double y, double z) override
     {
+        // Note: Maya viewport manipulators call the set function for the initial changes
+        //       and for redo! Detect we're in an undo or redo and call undo and redo instead.
+        if (UsdUfe::isRedoing()) {
+            redo();
+            return true;
+        } else if (UsdUfe::isUndoing()) {
+            undo();
+            return true;
+        }
+
         // Expect XYZ Euler angles in degrees.
         GfMatrix3d r(
             GfRotation(GfVec3d::XAxis(), x) * GfRotation(GfVec3d::YAxis(), y)
@@ -241,13 +258,10 @@ public:
 
         UsdUfe::OperationEditRouterContext editContext(
             UsdUfe::EditRoutingTokens->RouteTransform, getPrim());
-        {
-            UsdUfe::NoUsdUndoBlockGuard guard(true);
-            fU.SetRotate(r);
+        fU.SetRotate(r);
 
-            GfMatrix4d opTransform = (fS * fU).SetTranslateOnly(fT);
-            updateNewValue(VtValue(opTransform));
-        }
+        GfMatrix4d opTransform = (fS * fU).SetTranslateOnly(fT);
+        updateNewValue(VtValue(opTransform));
         return true;
     }
 
@@ -283,13 +297,20 @@ public:
     // Executes the command by setting the scale onto the transform op.
     bool set(double x, double y, double z) override
     {
+        // Note: Maya viewport manipulators call the set function for the initial changes
+        //       and for redo! Detect we're in an undo or redo and call undo and redo instead.
+        if (UsdUfe::isRedoing()) {
+            redo();
+            return true;
+        } else if (UsdUfe::isUndoing()) {
+            undo();
+            return true;
+        }
+
         GfMatrix4d opTransform = (GfMatrix4d(GfVec4d(x, y, z, 1.0)) * fU).SetTranslateOnly(fT);
         UsdUfe::OperationEditRouterContext editContext(
             UsdUfe::EditRoutingTokens->RouteTransform, getPrim());
-        {
-            UsdUfe::NoUsdUndoBlockGuard guard(true);
-            updateNewValue(VtValue(opTransform));
-        }
+        updateNewValue(VtValue(opTransform));
         return true;
     }
 

--- a/test/lib/testAdskUsdEditForwardXformOp.py
+++ b/test/lib/testAdskUsdEditForwardXformOp.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+import cmd
 import unittest
 
 from pxr import Sdf, Usd
@@ -24,6 +25,27 @@ import mayaUsd
 import fixturesUtils
 import mayaUtils
 import ufe
+
+
+class MayaManipEmulatorCommand(ufe.UndoableCommand):
+    '''
+    This is a simple command that mimics how Maya manipulator commands work.
+    '''
+    def __init__(self, trfCmd, x, y, z):
+        super(MayaManipEmulatorCommand, self).__init__()
+        self._trfCmd = trfCmd
+        self._x = x
+        self._y = y
+        self._z = z
+
+    def execute(self):
+        self._trfCmd.set(self._x, self._y, self._z)
+
+    def undo(self):
+        self._trfCmd.undo()
+
+    def redo(self):
+        self._trfCmd.redo()
 
 
 class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
@@ -101,12 +123,25 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
         then flush the idle queue to trigger continuous forwarding, and finally
         call the provided verify function to check the expected state after forwarding.
         '''
+        commandHolders = []
+
+        def executeCmds(ufeCmds):
+            for i in range(2):
+                cmds.undoInfo(openChunk=True)
+                cmd = cmdFunc(i  * 1, i * 2, i * 3)
+                commandHolders.append(cmd)
+                self.assertIsNotNone(cmd, "Expected command to be available")
+                ufe.UndoableCommandMgr.instance().executeCmd(cmd)
+                cmds.undoInfo(closeChunk=True)
+                # Edit forwarding happens on the next idle.
+                cmds.flushIdleQueue()
+
         def verifyDone():
             self.assertIsNotNone(self._testLayer.GetPrimAtPath(self._primPath))
             sessionLayerXformOp = self._sessionLayer.GetPropertyAtPath(xformOpPropPath)
-            self.assertIsNone(sessionLayerXformOp, "Expected original session-layer edit to be forwarded")
+            self.assertIsNone(sessionLayerXformOp, f"Expected original session-layer {xformOpPropPath} to be forwarded")
             testLayerXformOp = self._testLayer.GetPropertyAtPath(xformOpPropPath)
-            self.assertIsNotNone(testLayerXformOp, "Expected scale xformOp to be forwarded to TEST layer")
+            self.assertIsNotNone(testLayerXformOp, f"Expected {xformOpPropPath} to be forwarded to TEST layer")
         
         def verifyUndone(had_xform_already):
             self.assertIsNotNone(self._testLayer.GetPrimAtPath(self._primPath))
@@ -115,26 +150,15 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
             # sessionLayerXformOp = self._sessionLayer.GetPropertyAtPath(xformOpPropPath)
             # self.assertIsNone(sessionLayerXformOp, "Expected original session-layer edit to also be undone")
             testLayerXformOp = self._testLayer.GetPropertyAtPath(xformOpPropPath)
-            if had_xform_already:
-                self.assertIsNotNone(testLayerXformOp, "Expected property to be kept in TEST layer after undo")
-            else:
-                self.assertIsNone(testLayerXformOp, "Expected property to be removed from TEST layer after undo")
+            self.assertIsNone(testLayerXformOp, f"Expected {xformOpPropPath} to be removed from TEST layer after undo")
 
 
         # Translate the prim using UFE and onyl its set() function
         # which mimicks how Maya viewport manipulators work.
-        ufeCmds = cmdFunc()
+        executeCmds(cmdFunc)
         verifyDone()
 
-        # If the UFE command is using execute(), then the edit-forwarding will use
-        # a Maya command (undo chunk), so we must call cmds. If the UFE command is
-        # using set(), then we only undo the UFE command (as Maya would have done)
-        # a the edit-forwarding will be done *not* in a command, so we must *not*
-        # call cmds.undo.
-        if is_using_execute:
-            ufeCmds[1].undo()
-        else:
-            ufeCmds[1].set(1, 2, 3)
+        cmds.undo()
         cmds.flushIdleQueue()
         # Note: the was a UFE command before this one that also set the value,
         #       so after undo there is *still* a value that was forwarded by that
@@ -142,33 +166,17 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
         #       the second command, because the first command is still in effect.
         verifyDone()
 
-        # For the very first edit, the command always uses a UsdUndoBlock to capture
-        # the creation of the xformOp, so the edit-forwarding will always use a Maya
-        # command for the forwarding, so we must call cmds.undo to undo the forwarding,
-        if had_xform_already:
-            ufeCmds[0].undo()
-        else:
-            cmds.undo()
-            ufeCmds[0].undo()
+        cmds.undo()
         cmds.flushIdleQueue()
         verifyUndone(had_xform_already)
 
         # Redo should restore the forwarded state.
 
-        # For The first redo, The first command is always creating the xformOp,
-        # so we always call cmds.redo, but if using set(), we must also call
-        # the redo of the UFE command.
-        ufeCmds[0].redo()
-        if not had_xform_already:
-            cmds.redo()
+        cmds.redo()
         cmds.flushIdleQueue()
         verifyDone()
 
-        # For the second redo, if using execute(), then the edit forwarding will
-        # be done in a Maya command, so we must call cmds.redo, but if using set(),
-        # then the edit-forwarding will be done *not* in a command, so we must *not*
-        # call cmds.redo.
-        ufeCmds[1].redo()
+        cmds.redo()
         cmds.flushIdleQueue()
         verifyDone()
 
@@ -182,16 +190,9 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
         self._prepareStage()
         xformOpPropPath = self._primPath.AppendProperty('xformOp:translate')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.translateCmd()
-                self.assertIsNotNone(cmd, "Expected translateCmd to be available")
-                cmd.set(i * 1, i * 2, i * 3)
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.translateCmd()
+            return MayaManipEmulatorCommand(cmd, x, y, z)
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=False)
 
@@ -200,16 +201,9 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
         self._prepareStage()
         xformOpPropPath = self._primPath.AppendProperty('xformOp:translate')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.translateCmd(i * 1, i * 2, i * 3)
-                self.assertIsNotNone(cmd, "Expected translateCmd to be available")
-                cmd.execute()
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.translateCmd(x, y, z)
+            return cmd
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=True)
 
@@ -218,16 +212,10 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
         self._prepareStage()
         xformOpPropPath = self._primPath.AppendProperty('xformOp:scale')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.scaleCmd()
-                self.assertIsNotNone(cmd, "Expected scaleCmd to be available")
-                cmd.set(i * 1, i * 2, i * 3)
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.scaleCmd()
+            self.assertIsNotNone(cmd, "Expected scaleCmd to be available")
+            return MayaManipEmulatorCommand(cmd, x, y, z)
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=False)
 
@@ -236,16 +224,9 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
         self._prepareStage()
         xformOpPropPath = self._primPath.AppendProperty('xformOp:scale')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.scaleCmd(i * 1, i * 2, i * 3)
-                self.assertIsNotNone(cmd, "Expected scaleCmd to be available")
-                cmd.execute()
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.scaleCmd(x, y, z)
+            return cmd
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=True)
 
@@ -254,16 +235,11 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
         self._prepareStage()
         xformOpPropPath = self._primPath.AppendProperty('xformOp:rotateXYZ')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.rotateCmd()
-                self.assertIsNotNone(cmd, "Expected rotateCmd to be available")
-                cmd.set(i * 1, i * 2, i * 3)
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.rotateCmd()
+            self.assertIsNotNone(cmd, "Expected rotateCmd to be available")
+            cmd = MayaManipEmulatorCommand(cmd, x, y, z)
+            return cmd
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=False)
 
@@ -272,16 +248,9 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
         self._prepareStage()
         xformOpPropPath = self._primPath.AppendProperty('xformOp:rotateXYZ')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.rotateCmd(i * 1, i * 2, i * 3)
-                self.assertIsNotNone(cmd, "Expected rotateCmd to be available")
-                cmd.execute()
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.rotateCmd(x, y, z)
+            return cmd
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=True)
 
@@ -310,16 +279,11 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
 
         xformOpPropPath = self._primPath.AppendProperty('xformOp:translate')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.translateCmd()
-                self.assertIsNotNone(cmd, "Expected translateCmd to be available")
-                cmd.set(i * 1, i * 2, i * 3)
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.translateCmd()
+            self.assertIsNotNone(cmd, "Expected translateCmd to be available")
+            cmd = MayaManipEmulatorCommand(cmd, x, y, z)
+            return cmd
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=False, had_xform_already=True)
 
@@ -330,16 +294,9 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
 
         xformOpPropPath = self._primPath.AppendProperty('xformOp:translate')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.translateCmd(i * 1, i * 2, i * 3)
-                self.assertIsNotNone(cmd, "Expected translateCmd to be available")
-                cmd.execute()
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.translateCmd(x, y, z)
+            return cmd
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=True, had_xform_already=True)
 
@@ -350,16 +307,11 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
 
         xformOpPropPath = self._primPath.AppendProperty('xformOp:scale')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.scaleCmd()
-                self.assertIsNotNone(cmd, "Expected scaleCmd to be available")
-                cmd.set(i * 1, i * 2, i * 3)
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.scaleCmd()
+            self.assertIsNotNone(cmd, "Expected scaleCmd to be available")
+            cmd = MayaManipEmulatorCommand(cmd, x, y, z)
+            return cmd
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=False, had_xform_already=True)
 
@@ -370,16 +322,9 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
 
         xformOpPropPath = self._primPath.AppendProperty('xformOp:scale')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.scaleCmd(i * 1, i * 2, i * 3)
-                self.assertIsNotNone(cmd, "Expected scaleCmd to be available")
-                cmd.execute()
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd =  self._primUfe3d.scaleCmd(x, y, z)
+            return cmd
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=True, had_xform_already=True)
 
@@ -390,16 +335,11 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
 
         xformOpPropPath = self._primPath.AppendProperty('xformOp:rotateXYZ')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.rotateCmd()
-                self.assertIsNotNone(cmd, "Expected rotateCmd to be available")
-                cmd.set(i * 1, i * 2, i * 3)
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.rotateCmd()
+            self.assertIsNotNone(cmd, "Expected rotateCmd to be available")
+            cmd = MayaManipEmulatorCommand(cmd, x, y, z)
+            return cmd
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=False, had_xform_already=True)
 
@@ -410,16 +350,9 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
 
         xformOpPropPath = self._primPath.AppendProperty('xformOp:rotateXYZ')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.rotateCmd(i * 1, i * 2, i * 3)
-                self.assertIsNotNone(cmd, "Expected rotateCmd to be available")
-                cmd.execute()
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.rotateCmd(x, y, z)
+            return cmd
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=True, had_xform_already=True)
 
@@ -446,16 +379,11 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
 
         xformOpPropPath = self._primPath.AppendProperty('xformOp:translate')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.translateCmd()
-                self.assertIsNotNone(cmd, "Expected translateCmd to be available")
-                cmd.set(i * 1, i * 2, i * 3)
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.translateCmd()
+            self.assertIsNotNone(cmd, "Expected translateCmd to be available")
+            cmd = MayaManipEmulatorCommand(cmd, x, y, z)
+            return cmd
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=False, had_xform_already=True)
 
@@ -466,16 +394,9 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
 
         xformOpPropPath = self._primPath.AppendProperty('xformOp:translate')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.translateCmd(i * 1, i * 2, i * 3)
-                self.assertIsNotNone(cmd, "Expected translateCmd to be available")
-                cmd.execute()
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.translateCmd(x, y, z)
+            return cmd
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=True, had_xform_already=True)
 
@@ -486,16 +407,11 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
 
         xformOpPropPath = self._primPath.AppendProperty('xformOp:scale')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.scaleCmd()
-                self.assertIsNotNone(cmd, "Expected scaleCmd to be available")
-                cmd.set(i * 1, i * 2, i * 3)
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.scaleCmd()
+            self.assertIsNotNone(cmd, "Expected scaleCmd to be available")
+            cmd = MayaManipEmulatorCommand(cmd, x, y, z)
+            return cmd
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=False, had_xform_already=True)
 
@@ -506,16 +422,9 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
 
         xformOpPropPath = self._primPath.AppendProperty('xformOp:scale')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.scaleCmd(i * 1, i * 2, i * 3)
-                self.assertIsNotNone(cmd, "Expected scaleCmd to be available")
-                cmd.execute()
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.scaleCmd(x, y, z)
+            return cmd
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=True, had_xform_already=True)
 
@@ -526,16 +435,11 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
 
         xformOpPropPath = self._primPath.AppendProperty('xformOp:rotateXYZ')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.rotateCmd()
-                self.assertIsNotNone(cmd, "Expected rotateCmd to be available")
-                cmd.set(i * 1, i * 2, i * 3)
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.rotateCmd()
+            self.assertIsNotNone(cmd, "Expected rotateCmd to be available")
+            cmd = MayaManipEmulatorCommand(cmd, x, y, z)
+            return cmd
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=False, had_xform_already=True)
 
@@ -546,16 +450,9 @@ class AdskUsdEditForwardXformOpTestCase(unittest.TestCase):
 
         xformOpPropPath = self._primPath.AppendProperty('xformOp:rotateXYZ')
 
-        def cmdFunc():
-            ufeCmds = []
-            for i in range(2):
-                cmd = self._primUfe3d.rotateCmd(i * 1, i * 2, i * 3)
-                self.assertIsNotNone(cmd, "Expected rotateCmd to be available")
-                cmd.execute()
-                ufeCmds.append(cmd)
-                # Continuous forwarding happens on the next idle.
-                cmds.flushIdleQueue()
-            return ufeCmds
+        def cmdFunc(x, y, z):
+            cmd = self._primUfe3d.rotateCmd(x, y, z)
+            return cmd
 
         self._runEditForwarding(cmdFunc, xformOpPropPath, is_using_execute=True, had_xform_already=True)
 


### PR DESCRIPTION
Fix problems in undo/redo of transform commands and their interaction with how the Maya viewport uses them. This fixes problem with lost redo and crash with invalid layer data.

The lost redo were due to the redo of the first transform command that create the `xformOp` was re-triggering the edit-forwarding because the re-creation of the `xformOp` was using a `UsdUndoBlock` but the rest of the command redo did not. This made the edit-forwarding do its work in a command, which thus erased the other redoes.

- Added a `isUndoing` and `isRedoing` `UsdUfe` helper functions to detect if the DCC is currently undoing or redoing.
- Use these functions to detect that when the Maya viewport manipulator is calling set(0 on a UFE command, it is in reality undoing or redoing.

Improve the `UsdSetXformOpUndoableCommandBase` base class used for tarnsform command:
- Made the class have a separate set of undo items for the modification of values.
- Made the `prepareAndSet` function of that class use a `UsdUndoBlock` to capture the setting of values, so they can be undone.
- Use the `UsdUndoableItem` `undo` and `redo` functions in that class `undo` and `redo` functions instead of setting values.
- Removed the usage of the `NoUsdUndoBlockGuard` from all transform commands that derives from the base class since they now always use a `UsdUndoBlock`.

Improved the unit tests:
- Added a `MayaManipEmulatorCommand` that emulate how the Maya viewport manipulators use the UFE commands.
- In particular this enable us to have the UFE command and edit-forwarding command in one Maya command, like in Maya.
- This removes all the weird complicated logic and special-casing in the unit test.
- Now each unit test just provides which `xformOp` will be create and a function to create commands.