### PR TITLE
MayaUsdProxyShapeBase: invalidate stage on recomputeLayers attribute changes

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -508,7 +508,7 @@ MStatus MayaUsdProxyShapeBase::initialize()
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
     numericAttrFn.setCached(true);
     numericAttrFn.setReadable(true);
-    numericAttrFn.setStorable(true);
+    numericAttrFn.setStorable(false);
     numericAttrFn.setHidden(true);
     retValue = addAttribute(recomputeLayersAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
@@ -1809,7 +1809,8 @@ MStatus MayaUsdProxyShapeBase::preEvaluation(
             || evaluationNode.dirtyPlugExists(loadPayloadsAttr)
             || evaluationNode.dirtyPlugExists(shareStageAttr)
             || evaluationNode.dirtyPlugExists(inStageDataAttr)
-            || evaluationNode.dirtyPlugExists(stageCacheIdAttr)) {
+            || evaluationNode.dirtyPlugExists(stageCacheIdAttr)
+            || evaluationNode.dirtyPlugExists(recomputeLayersAttr)) {
             _IncreaseUsdStageVersion();
             MayaUsdProxyStageInvalidateNotice(*this).Send();
         }
@@ -1862,7 +1863,8 @@ MStatus MayaUsdProxyShapeBase::setDependentsDirty(const MPlug& plug, MPlugArray&
         plug == outStageDataAttr ||
         // All the plugs that affect outStageDataAttr
         plug == filePathAttr || plug == primPathAttr || plug == loadPayloadsAttr
-        || plug == shareStageAttr || plug == inStageDataAttr || plug == stageCacheIdAttr) {
+        || plug == shareStageAttr || plug == inStageDataAttr || plug == stageCacheIdAttr
+        || plug == recomputeLayersAttr) {
         _IncreaseUsdStageVersion();
         MayaUsdProxyStageInvalidateNotice(*this).Send();
     }


### PR DESCRIPTION
This PR is a targeted fix for one stale `UsdStageMap` scenario seen in production with `maya-usd v0.35.0`.

The crash occurs in workflows like the following:
- The scene contains `editAsMaya` DAGs, with incoming `ProxyAccessor` visibility connections from the proxyShape.
- The user performs a file write or export. In some reported cases, this was `maya.cmds.exportEdits`, which is unrelated to USD content itself.
- Later, the user reloads a Maya-only reference, unrelated to the USD stage.
- A subsequent proxyShape recompute crashes in the `ProxyAccessor` compute path.

```
  TdagObject::inRenderLayer(TdnRenderLayer const&, bool) const
  TdagObject::inRenderLayer(TdagPath const&, TdnRenderLayer*)
  TmultiPath::isVisible() const
  Autodesk::Maya::OpenMaya20260000::MDagPath::isVisible(Autodesk::Maya::OpenMaya20260000::MStatus*) const
  MayaUsd_v0::ProxyAccessor::computeOutput(MayaUsd_v0::ProxyAccessor::Item const&, Autodesk::Maya::OpenMaya20260000::MMatrix const&, pxrInternal_v0_25_8__pxrReserved__::TfRefPtr<pxrInternal_v0_25_8__pxrReserved__::UsdStage>, Autodesk::Maya::OpenMaya20260000::MDataBlock&, pxrInternal_v0_25_8__pxrReserved__::UsdGeomXformCache&, MayaUsd_v0::ConverterArgs const&)
  MayaUsd_v0::ProxyAccessor::compute(Autodesk::Maya::OpenMaya20260000::MPlug const&, Autodesk::Maya::OpenMaya20260000::MDataBlock&, bool)
  pxrInternal_v0_25_8__pxrReserved__::MayaUsdProxyShapeBase::compute(Autodesk::Maya::OpenMaya20260000::MPlug const&, Autodesk::Maya::OpenMaya20260000::MDataBlock&)
  MayaUsd_v0::ProxyShape::compute(Autodesk::Maya::OpenMaya20260000::MPlug const&, Autodesk::Maya::OpenMaya20260000::MDataBlock&)
  THsurfaceShape::computePlug(Tplug const&, TdataBlock&)
  TevaluationNode::evaluateDirtyPlugs(TdataBlockDG*, TevaluationNode::TdirtyPlugType)
  TevaluationNode::evaluate(em::SyncMessage const&)
  em::ParallelExecution::evaluateAndVisitChildren(em::EvaluationNode&)
  em::ParallelExecution::evaluateAndSchedule()
  /usr/autodesk/maya2026/lib/libEvaluationManager.so.1.1.27.0(+0x29b42) [0x7f5d24446b42]
  tbb::detail::r1::isolate_within_arena(tbb::detail::d1::delegate_base&, long)
  em::ParallelExecution::evaluateImplementation()
  em::EvaluationGraph::evaluate(bool)
  TevaluationManager::evaluate(TdgContext&, bool)
  /usr/autodesk/maya2026/lib/libDependEngine.so(+0x29070b) [0x7f5d2550c70b]
  TdependGraph::setTime(TanimTime const&, bool)
  [...]
```

The crash is caused by calling `MDagPath::isVisible()` on an invalid `MDagPath`.  That invalid path comes from a stale `UsdStageMap`, which does not yet reflect a new stage created after file I/O. In the scenario above, the export creates a new `LayerManager`, and the later reference reload triggers a proxyShape recompute by bumping the `recomputeLayers` attribute (see #4443 ).

This change makes `recomputeLayers` behave like the other proxyShape attributes that affect `outStageData`: it now sends `MayaUsdProxyStageInvalidateNotice` so that stage observers, such as `MayaStagesSubject`, can invalidate stage-related data like `UsdStageMap`, and restores the usual notification flow for this code path: first `StageInvalidate`, then `StageSet`.

I also included a small unrelated cleanup I came across while investigating this issue: making this attribute non-storable, since it is only used as a runtime trigger.

**Note**

While investigating this issue, we also tried cherry-picking #4491  which looked like a good candidate for the stale `UsdStageMap` problem. It effectively fixed the crash for us, but it also caused other issues on our side.

In some scenarios, the map can become incomplete when it is dirtied during its own rebuild. The sequence is:

- `UsdStageMap::rebuildIfDirty()` indirectly calls `MayaUsdProxyShapeBase::getUsdStage()`
- `getUsdStage()` pulls `outStageData`, which can trigger a compute
- `MayaUsdProxyShapeBase::computeOutStageData()` sends `MayaUsdProxyStageSetNotice`
-  `MayaStagesSubject` indirectly calls `UsdStageMap::setDirty()` on `MayaUsdProxyStageSetNotice` (since PR4491)
- `setDirty()` clears the map in the middle of `rebuildIfDirty()`, so previously processed entries are lost, `UsdStageMap` is incomplete.

I cannot provide a standalone reproduction for this yet, it is difficult to isolate. However, I hope the proposed change is clear from the context above.
