### PR TITLE
EMSUSDC-391 Filter out stale field data when restoring state

### DIFF
--- a/lib/usdUfe/undo/UsdUndoStateDelegate.cpp
+++ b/lib/usdUfe/undo/UsdUndoStateDelegate.cpp
@@ -65,6 +65,10 @@ public:
 
 namespace USDUFE_NS_DEF {
 
+uint32_t UsdUndoStateDelegate::_invertCount { 0 };
+
+void UsdUndoStateDelegate::notifyInvert() { ++_invertCount; }
+
 UsdUndoStateDelegate::UsdUndoStateDelegate()
     : _dirty(false)
     , _setMessageAlreadyShowed(false)
@@ -106,7 +110,60 @@ void UsdUndoStateDelegate::invertSetField(
     TF_DEBUG(USDUFE_UNDOSTATEDELEGATE)
         .Msg("Inverting set Field '%s' for Spec '%s'\n", fieldName.GetText(), path.GetText());
 
-    SetField(path, fieldName, inverse);
+    // New invert — clear stale tracking from the previous one.
+    if (_invertCount != _lastInvertCount) {
+        _deletedByUndoCreate.clear();
+        _lastInvertCount = _invertCount;
+    }
+
+    // Children list fields may reference specs that no longer exist.
+    //
+    //  Case 1 : child temporarily absent (undo of normal deletion):
+    //     Sequence: invertSetField(/parent, primChildren, [child])  -> child missing now
+    //               invertDeleteSpec(/parent/child)                  -> recreates child
+    //     The layer is only temporarily in a bad state, nothing special to do.
+    //
+    //  Case 2 : child permanently gone (undo of creation)
+    //     This case is only reproducible when the data on the layer no longer matches what is
+    //     expected by the invert functions, and can lead to a corrupt layer state causing crashes.
+    //     Sequence: invertCreateSpec(/root/geo)                     -> deletes geo
+    //               invertSetField(/root, primChildren, [geo])      -> missing geo
+    //     We need to filter out the bad children.
+    //
+    // To distinguish these two cases we keep track of the paths hit by invertCreateSpec() in
+    // _deletedByUndoCreate. It is reset for every inversion sequence.
+    VtValue filteredInverse = inverse;
+    if (!_deletedByUndoCreate.empty() && inverse.IsHolding<std::vector<TfToken>>()
+        && (fieldName == SdfChildrenKeys->PrimChildren
+            || fieldName == SdfChildrenKeys->PropertyChildren)) {
+        const auto&          nameList = inverse.UncheckedGet<std::vector<TfToken>>();
+        std::vector<TfToken> filteredList;
+        filteredList.reserve(nameList.size());
+        const bool isPrimChildren = (fieldName == SdfChildrenKeys->PrimChildren);
+        auto       layerData = _GetLayerData();
+        for (const TfToken& childName : nameList) {
+            const SdfPath childPath
+                = isPrimChildren ? path.AppendChild(childName) : path.AppendProperty(childName);
+            // If not in a normal delete scenario, and the child doesn't exist, filter it out,
+            // leaving a stale reference to it would corrupt the layer.
+            if (_deletedByUndoCreate.count(childPath) != 0 && !layerData->HasSpec(childPath)) {
+                TF_DEBUG(USDUFE_UNDOSTATEDELEGATE)
+                    .Msg(
+                        "invertSetField: filtering child '%s' (deleted by invertCreateSpec "
+                        "and absent from layer data) from field '%s' on '%s'\n",
+                        childName.GetText(),
+                        fieldName.GetText(),
+                        path.GetText());
+            } else {
+                filteredList.push_back(childName);
+            }
+        }
+        if (filteredList.size() != nameList.size()) {
+            filteredInverse = filteredList.empty() ? VtValue() : VtValue(std::move(filteredList));
+        }
+    }
+
+    SetField(path, fieldName, filteredInverse);
 
     _setMessageAlreadyShowed = false;
 }
@@ -130,6 +187,8 @@ void UsdUndoStateDelegate::invertCreateSpec(const SdfPath& path, bool inert)
         return;
     }
     DeleteSpec(path, inert);
+
+    _deletedByUndoCreate.insert(path);
 
     _setMessageAlreadyShowed = false;
 }
@@ -364,6 +423,8 @@ void UsdUndoStateDelegate::_OnCreateSpec(const SdfPath& path, SdfSpecType specTy
     if (!_layer) {
         return;
     }
+
+    _deletedByUndoCreate.erase(path);
 
     UsdUfe::UsdUndoManagerAccessor::addInverse(
         std::bind(&UsdUndoStateDelegate::invertCreateSpec, this, path, inert));

--- a/lib/usdUfe/undo/UsdUndoStateDelegate.h
+++ b/lib/usdUfe/undo/UsdUndoStateDelegate.h
@@ -25,6 +25,8 @@
 // convenient way to bring in other headers
 #include <pxr/usd/usd/prim.h>
 
+#include <unordered_set>
+
 PXR_NAMESPACE_USING_DIRECTIVE
 
 namespace USDUFE_NS_DEF {
@@ -46,6 +48,10 @@ public:
     ~UsdUndoStateDelegate() override;
 
     static UsdUndoStateDelegateRefPtr New();
+
+    /// Called at the start of each undo/redo replay. Increments _invertCount, useful
+    /// to manage any per-undo/redo state.
+    static void notifyInvert();
 
 private:
     void invertSetField(const SdfPath& path, const TfToken& fieldName, const VtValue& inverse);
@@ -127,6 +133,13 @@ private:
     SdfLayerHandle _layer;
     bool           _dirty;
     bool           _setMessageAlreadyShowed;
+
+    // Tracks specs deleted by invertCreateSpec during an undo/redo replay.
+    // See invertSetField() for a detailed explaination.
+    std::unordered_set<SdfPath, SdfPath::Hash> _deletedByUndoCreate;
+
+    uint32_t        _lastInvertCount { 0 };
+    static uint32_t _invertCount;
 };
 
 } // namespace USDUFE_NS_DEF

--- a/lib/usdUfe/undo/UsdUndoableItem.cpp
+++ b/lib/usdUfe/undo/UsdUndoableItem.cpp
@@ -17,6 +17,7 @@
 #include "UsdUndoableItem.h"
 
 #include <usdUfe/undo/UsdUndoBlock.h>
+#include <usdUfe/undo/UsdUndoStateDelegate.h>
 
 #include <pxr/usd/sdf/changeBlock.h>
 
@@ -32,6 +33,9 @@ void UsdUndoableItem::doInvert()
         TF_CODING_ERROR("Inversion during open edit block may result in corrupted undo "
                         "stack.");
     }
+
+    // Signal so that any per-invert tracking state can be updated.
+    UsdUndoStateDelegate::notifyInvert();
 
     UsdUndoBlock undoBlock(this);
 


### PR DESCRIPTION
This fixes the undo/redo crashes when editing components, when ''dragging'' attributes in the attr editor. 

When some edits are made outside of an undo block, and undo/redo is perfomed, the state is not always what is expected by the invert function, and restoring data can corrupt layers, leading to crashes on traversal later. The fix here is to find & remove stale info before it causes trouble.