### PR TITLE
EMSUSD-3210 Fix for Stitch/merge option 

### DIFF
--- a/lib/mayaUsd/commands/abstractLayerEditorWindow.h
+++ b/lib/mayaUsd/commands/abstractLayerEditorWindow.h
@@ -91,6 +91,7 @@ public:
     virtual bool        layerIsReadOnly() = 0;
     virtual bool        layerHasSubLayers() = 0;
     virtual bool        strongestLayerIsLocked() = 0;
+    virtual bool        selectionHasSessionAndNonSessionLayers() = 0;
     virtual std::string proxyShapeName(const bool fullPath = false) const = 0;
 
     virtual void removeSubLayer() = 0;

--- a/lib/mayaUsd/commands/abstractLayerEditorWindow.h
+++ b/lib/mayaUsd/commands/abstractLayerEditorWindow.h
@@ -90,6 +90,7 @@ public:
     virtual bool        layerIsSystemLocked() = 0;
     virtual bool        layerIsReadOnly() = 0;
     virtual bool        layerHasSubLayers() = 0;
+    virtual bool        strongestLayerIsLocked() = 0;
     virtual std::string proxyShapeName(const bool fullPath = false) const = 0;
 
     virtual void removeSubLayer() = 0;

--- a/lib/mayaUsd/commands/layerEditorWindowCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorWindowCommand.cpp
@@ -52,6 +52,7 @@ DEF_FLAG(lo, layerIsLocked)
 DEF_FLAG(as, layerAppearsSystemLocked)
 DEF_FLAG(ls, layerIsSystemLocked)
 DEF_FLAG(ll, layerHasSubLayers)
+DEF_FLAG(sk, strongestLayerIsLocked)
 
 // edit flags
 DEF_FLAG(rs, removeSubLayer)
@@ -145,6 +146,7 @@ MSyntax LayerEditorWindowCommand::createSyntax()
     ADD_FLAG(layerAppearsSystemLocked);
     ADD_FLAG(layerIsSystemLocked);
     ADD_FLAG(layerHasSubLayers);
+    ADD_FLAG(strongestLayerIsLocked);
 
     ADD_FLAG(removeSubLayer);
     ADD_FLAG(saveEdits);
@@ -338,6 +340,7 @@ MStatus LayerEditorWindowCommand::handleQueries(
     HANDLE_Q_FLAG(layerAppearsSystemLocked)
     HANDLE_Q_FLAG(layerIsSystemLocked)
     HANDLE_Q_FLAG(layerHasSubLayers)
+    HANDLE_Q_FLAG(strongestLayerIsLocked)
 
     // proxyShape flag is both create/query.
     if (argParser.isFlagSet(FLAG(proxyShape)) && argParser.isQuery()) {

--- a/lib/mayaUsd/commands/layerEditorWindowCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorWindowCommand.cpp
@@ -53,6 +53,7 @@ DEF_FLAG(as, layerAppearsSystemLocked)
 DEF_FLAG(ls, layerIsSystemLocked)
 DEF_FLAG(ll, layerHasSubLayers)
 DEF_FLAG(sk, strongestLayerIsLocked)
+DEF_FLAG(ss, selectionHasSessionAndNonSessionLayers)
 
 // edit flags
 DEF_FLAG(rs, removeSubLayer)
@@ -147,6 +148,7 @@ MSyntax LayerEditorWindowCommand::createSyntax()
     ADD_FLAG(layerIsSystemLocked);
     ADD_FLAG(layerHasSubLayers);
     ADD_FLAG(strongestLayerIsLocked);
+    ADD_FLAG(selectionHasSessionAndNonSessionLayers);
 
     ADD_FLAG(removeSubLayer);
     ADD_FLAG(saveEdits);
@@ -341,6 +343,7 @@ MStatus LayerEditorWindowCommand::handleQueries(
     HANDLE_Q_FLAG(layerIsSystemLocked)
     HANDLE_Q_FLAG(layerHasSubLayers)
     HANDLE_Q_FLAG(strongestLayerIsLocked)
+    HANDLE_Q_FLAG(selectionHasSessionAndNonSessionLayers)
 
     // proxyShape flag is both create/query.
     if (argParser.isFlagSet(FLAG(proxyShape)) && argParser.isQuery()) {

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
@@ -211,6 +211,12 @@ bool MayaLayerEditorWindow::selectionHasSessionAndNonSessionLayers()
     if (selectedItems.size() < 2)
         return false;
 
+    const UsdStageRefPtr stage = _sessionState.stage();
+    if (!stage)
+        return false;
+
+    const auto sessionLayers = UsdUfe::getAllSublayerRefs(stage->GetSessionLayer(), true);
+
     bool hasSessionLayerItem = false;
     bool hasNonSessionLayerItem = false;
 
@@ -218,18 +224,7 @@ bool MayaLayerEditorWindow::selectionHasSessionAndNonSessionLayers()
         if (!item)
             continue;
 
-        // Sub layers of a session layer are not marked as session layers, need to check if the
-        // strongest parent is a session layer.
-        bool inSessionHierarchy = item->isSessionLayer();
-        if (!inSessionHierarchy) {
-            LayerTreeItem* ancestor = item->parentLayerItem();
-            while (ancestor && ancestor->parentLayerItem()) {
-                ancestor = ancestor->parentLayerItem();
-            }
-            inSessionHierarchy = ancestor && ancestor->isSessionLayer();
-        }
-
-        if (inSessionHierarchy)
+        if (UsdUfe::isSessionLayer(item->layer(), sessionLayers))
             hasSessionLayerItem = true;
         else
             hasNonSessionLayerItem = true;

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
@@ -177,6 +177,30 @@ std::string MayaLayerEditorWindow::proxyShapeName(const bool fullPath) const
     return fullPath ? stageEntry._proxyShapePath : stageEntry._displayName;
 }
 
+bool MayaLayerEditorWindow::strongestLayerIsLocked()
+{
+    // selectedItems are ordered by order of selection, not by strength.
+    const LayerItemVector selectedItems = treeView()->getSelectedLayerItems();
+    if (selectedItems.size() < 2) {
+        return false;        
+    }
+
+    const UsdStageRefPtr stage = _sessionState.stage();
+    if (!stage)
+        return false;
+
+    // Finds strongest layer from selectedItems.
+    const SdfLayerHandleVector stageLayersByStrength = stage->GetLayerStack();
+    for (const auto& stageLayer : stageLayersByStrength) {
+        for (const auto* selectedItem : selectedItems) {
+            if (selectedItem && selectedItem->layer() == stageLayer)
+                return selectedItem->isLocked();
+        }
+    }
+
+    return false;
+}
+
 void MayaLayerEditorWindow::removeSubLayer()
 {
     QString name = "Remove";

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
@@ -182,7 +182,7 @@ bool MayaLayerEditorWindow::strongestLayerIsLocked()
     // selectedItems are ordered by order of selection, not by strength.
     const LayerItemVector selectedItems = treeView()->getSelectedLayerItems();
     if (selectedItems.size() < 2) {
-        return false;        
+        return false;
     }
 
     const UsdStageRefPtr stage = _sessionState.stage();
@@ -196,6 +196,42 @@ bool MayaLayerEditorWindow::strongestLayerIsLocked()
             if (selectedItem && selectedItem->layer() == stageLayer)
                 return selectedItem->isLocked();
         }
+    }
+
+    return false;
+}
+
+bool MayaLayerEditorWindow::selectionHasSessionAndNonSessionLayers()
+{
+    const LayerItemVector selectedItems = treeView()->getSelectedLayerItems();
+    if (selectedItems.size() < 2)
+        return false;
+
+    bool hasSessionLayerItem = false;
+    bool hasNonSessionLayerItem = false;
+
+    for (const auto* item : selectedItems) {
+        if (!item)
+            continue;
+
+        // Sub layers of a session layer are not marked as session layers, need to check if the
+        // strongest parent is a session layer.
+        bool inSessionHierarchy = item->isSessionLayer();
+        if (!inSessionHierarchy) {
+            LayerTreeItem* ancestor = item->parentLayerItem();
+            while (ancestor && ancestor->parentLayerItem()) {
+                ancestor = ancestor->parentLayerItem();
+            }
+            inSessionHierarchy = ancestor && ancestor->isSessionLayer();
+        }
+
+        if (inSessionHierarchy)
+            hasSessionLayerItem = true;
+        else
+            hasNonSessionLayerItem = true;
+
+        if (hasSessionLayerItem && hasNonSessionLayerItem)
+            return true;
     }
 
     return false;

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
@@ -181,7 +181,6 @@ std::string MayaLayerEditorWindow::proxyShapeName(const bool fullPath) const
 
 bool MayaLayerEditorWindow::strongestLayerIsLocked()
 {
-    // selectedItems are ordered by order of selection, not by strength.
     const LayerItemVector selectedItems = treeView()->getSelectedLayerItems();
     if (selectedItems.size() < 2) {
         return false;

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
@@ -191,7 +191,7 @@ bool MayaLayerEditorWindow::strongestLayerIsLocked()
         return false;
 
     // Finds strongest layer from selectedItems by folding over the selection.
-    SdfLayerHandle      strongestLayer;
+    SdfLayerHandle       strongestLayer;
     const LayerTreeItem* strongestItem = nullptr;
     for (const auto* item : selectedItems) {
         SdfLayerHandle layer = item->layer();

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.cpp
@@ -27,6 +27,8 @@
 
 #include <mayaUsd/utils/query.h>
 
+#include <usdUfe/utils/layers.h>
+
 #include <maya/MGlobal.h>
 #include <maya/MQtUtil.h>
 
@@ -189,16 +191,18 @@ bool MayaLayerEditorWindow::strongestLayerIsLocked()
     if (!stage)
         return false;
 
-    // Finds strongest layer from selectedItems.
-    const SdfLayerHandleVector stageLayersByStrength = stage->GetLayerStack();
-    for (const auto& stageLayer : stageLayersByStrength) {
-        for (const auto* selectedItem : selectedItems) {
-            if (selectedItem && selectedItem->layer() == stageLayer)
-                return selectedItem->isLocked();
+    // Finds strongest layer from selectedItems by folding over the selection.
+    SdfLayerHandle      strongestLayer;
+    const LayerTreeItem* strongestItem = nullptr;
+    for (const auto* item : selectedItems) {
+        SdfLayerHandle layer = item->layer();
+        if (!strongestLayer || UsdUfe::getStrongerLayer(stage, layer, strongestLayer) == layer) {
+            strongestLayer = layer;
+            strongestItem = item;
         }
     }
 
-    return false;
+    return strongestItem && strongestItem->isLocked();
 }
 
 bool MayaLayerEditorWindow::selectionHasSessionAndNonSessionLayers()

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.h
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.h
@@ -66,6 +66,7 @@ public:
     bool        layerIsSystemLocked() override;
     bool        layerHasSubLayers() override;
     bool        strongestLayerIsLocked() override;
+    bool        selectionHasSessionAndNonSessionLayers() override;
 
     void removeSubLayer() override;
     void saveEdits() override;

--- a/lib/usd/ui/layerEditor/mayaLayerEditorWindow.h
+++ b/lib/usd/ui/layerEditor/mayaLayerEditorWindow.h
@@ -65,6 +65,7 @@ public:
     bool        layerAppearsSystemLocked() override;
     bool        layerIsSystemLocked() override;
     bool        layerHasSubLayers() override;
+    bool        strongestLayerIsLocked() override;
 
     void removeSubLayer() override;
     void saveEdits() override;

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -1038,10 +1038,11 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
         return; // that's all we can support on invalid layers
     }
 
+    // Single selection flags
+    int $singleSelect = `mayaUsdLayerEditorWindow -q -selectionLength $panelName` == 1;
     int $isSessionLayer = `mayaUsdLayerEditorWindow -q -isSessionLayer $panelName`;
     int $isAnonymousLayer = `mayaUsdLayerEditorWindow -q -isAnonymousLayer $panelName`;
     int $needsSaving = `mayaUsdLayerEditorWindow -q -layerNeedsSaving $panelName`;
-    int $singleSelect = `mayaUsdLayerEditorWindow -q -selectionLength $panelName` == 1;
     int $appearsMuted = `mayaUsdLayerEditorWindow -q -layerAppearsMuted $panelName`;
     int $isSubLayer = `mayaUsdLayerEditorWindow -q -isSubLayer $panelName`;
     int $isMuted = `mayaUsdLayerEditorWindow -q -layerIsMuted $panelName`;
@@ -1052,9 +1053,12 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
     int $isSystemLocked = `mayaUsdLayerEditorWindow -q -layerIsSystemLocked $panelName`;
     int $isIncoming = `mayaUsdLayerEditorWindow -q -isIncomingLayer $panelName`;
     int $hasSublayers = `mayaUsdLayerEditorWindow -q -layerHasSubLayers $panelName`;
+    string $proxyShape = `mayaUsdLayerEditorWindow -q -proxyShape $panelName`;
+    
+    // Multi selection flags
     int $multiSelect = `mayaUsdLayerEditorWindow -q -selectionLength $panelName` > 1;
     int $strongestLayerIsLocked = `mayaUsdLayerEditorWindow -q -strongestLayerIsLocked $panelName`;
-    string $proxyShape = `mayaUsdLayerEditorWindow -q -proxyShape $panelName`;
+    int $hasSessionAndNonSessionLayers = `mayaUsdLayerEditorWindow -q -selectionHasSessionAndNonSessionLayers $panelName`;
 
     string $label;
     int $enabled;
@@ -1101,7 +1105,7 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
     if ($multiSelect && !$singleSelect) {
             $label = getMayaUsdString("kMenuStitchLayers");
             $cmd = makeCommand($panelName, "stitchLayers");
-            $enabled = !$isReadOnly && !$appearsLocked && !$appearsSystemLocked && !$appearsMuted && !$strongestLayerIsLocked;
+            $enabled = !$isReadOnly && !$appearsLocked && !$appearsSystemLocked && !$appearsMuted && !$strongestLayerIsLocked && !$hasSessionAndNonSessionLayers;
             menuItem -label $label -enable $enabled -c $cmd;
     }
 

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -1112,7 +1112,7 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
     if ($hasSublayers) {
         $label = getMayaUsdString("kMenuMergeWithSublayers");
         $cmd = makeCommand($panelName, "mergeWithSublayers");
-        $enabled = !$appearsMuted && !$isReadOnly && !$isLocked && !$isSystemLocked && !$strongestLayerIsLocked;
+        $enabled = !$appearsMuted && !$isReadOnly && !$isLocked && !$isSystemLocked;
         menuItem -label $label -enable $enabled -c $cmd;
     }
 

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -1052,6 +1052,8 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
     int $isSystemLocked = `mayaUsdLayerEditorWindow -q -layerIsSystemLocked $panelName`;
     int $isIncoming = `mayaUsdLayerEditorWindow -q -isIncomingLayer $panelName`;
     int $hasSublayers = `mayaUsdLayerEditorWindow -q -layerHasSubLayers $panelName`;
+    int $multiSelect = `mayaUsdLayerEditorWindow -q -selectionLength $panelName` > 1;
+    int $strongestLayerIsLocked = `mayaUsdLayerEditorWindow -q -strongestLayerIsLocked $panelName`;
     string $proxyShape = `mayaUsdLayerEditorWindow -q -proxyShape $panelName`;
 
     string $label;
@@ -1096,18 +1098,17 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
     $enabled = $singleSelect && !$appearsMuted && !$isReadOnly && !$isLocked && !$isSystemLocked;
     menuItem -label $label -enable $enabled -c $cmd;
 
-    int $multiSelect = `mayaUsdLayerEditorWindow -q -selectionLength $panelName` > 1;
     if ($multiSelect && !$singleSelect) {
-        $label = getMayaUsdString("kMenuStitchLayers");
-        $cmd = makeCommand($panelName, "stitchLayers");
-        $enabled = !$isReadOnly && !$appearsLocked && !$appearsSystemLocked && !$appearsMuted;
-        menuItem -label $label -enable $enabled -c $cmd;
+            $label = getMayaUsdString("kMenuStitchLayers");
+            $cmd = makeCommand($panelName, "stitchLayers");
+            $enabled = !$isReadOnly && !$appearsLocked && !$appearsSystemLocked && !$appearsMuted && !$strongestLayerIsLocked;
+            menuItem -label $label -enable $enabled -c $cmd;
     }
 
     if ($hasSublayers) {
         $label = getMayaUsdString("kMenuMergeWithSublayers");
         $cmd = makeCommand($panelName, "mergeWithSublayers");
-        $enabled = !$appearsMuted && !$isReadOnly && !$isLocked && !$isSystemLocked;
+        $enabled = !$appearsMuted && !$isReadOnly && !$isLocked && !$isSystemLocked && !$strongestLayerIsLocked;
         menuItem -label $label -enable $enabled -c $cmd;
     }
 


### PR DESCRIPTION
Fixes two issues by adding flags to deactivate merge layers in the following cases:
1. When the selection includes both session and non-session layers.
2. When the selections strongest layer is locked.

<img width="560" height="411" alt="image" src="https://github.com/user-attachments/assets/b79eb644-2801-4c9e-aee6-cefb5d72da7c" />
<img width="475" height="368" alt="image" src="https://github.com/user-attachments/assets/0fe7ff6d-5fa6-491a-a75a-3cc1aece0c38" />
