### PR TITLE
EMSUSDC-411 do not disturb redo

### DIFF
--- a/lib/usd/ui/layerEditor/mayaCommandHook.cpp
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.cpp
@@ -244,7 +244,7 @@ void MayaCommandHook::refreshLayerSystemLock(UsdLayer usdLayer, bool refreshSubL
     cmd += " ";
     cmd += std::to_string(refreshSubLayers);
     cmd += quote(usdLayer->GetIdentifier());
-    executeMel(cmd);
+    executeMel(cmd, false);
 }
 
 void MayaCommandHook::stitchLayers(const std::vector<PXR_NS::SdfLayerRefPtr>& layers)
@@ -310,10 +310,10 @@ bool MayaCommandHook::isProxyShapeSharedStage(const std::string& proxyShapePath)
     return getBooleanAttributeOnProxyShape(proxyShapePath, "shareStage");
 }
 
-std::string MayaCommandHook::executeMel(const std::string& commandString)
+std::string MayaCommandHook::executeMel(const std::string& commandString, bool undoable)
 {
     if (areCommandsDelayed()) {
-        _delayedCommands.push_back({ commandString, false });
+        _delayedCommands.push_back({ commandString, false, undoable });
     } else {
         // executes maya command with display and undo set to true so that it logs
         MStringArray result;
@@ -321,19 +321,19 @@ std::string MayaCommandHook::executeMel(const std::string& commandString)
             MString(commandString.c_str()),
             result,
             /*display*/ true,
-            /*undo*/ true);
+            /*undo*/ undoable);
         if (result.length() > 0)
             return result[0].asChar();
     }
     return "";
 }
 
-void MayaCommandHook::executePython(const std::string& commandString)
+void MayaCommandHook::executePython(const std::string& commandString, bool undoable)
 {
     if (areCommandsDelayed()) {
-        _delayedCommands.push_back({ commandString, true });
+        _delayedCommands.push_back({ commandString, true, undoable });
     } else {
-        MGlobal::executePythonCommand(commandString.c_str());
+        MGlobal::executePythonCommand(commandString.c_str(), /*display*/ false, undoable);
     }
 }
 
@@ -349,9 +349,9 @@ void MayaCommandHook::executeDelayedCommands()
 
     for (const auto& cmd : cmds) {
         if (cmd.isPython) {
-            executePython(cmd.command);
+            executePython(cmd.command, cmd.isUndoable);
         } else {
-            executeMel(cmd.command);
+            executeMel(cmd.command, cmd.isUndoable);
         }
     }
 }

--- a/lib/usd/ui/layerEditor/mayaCommandHook.h
+++ b/lib/usd/ui/layerEditor/mayaCommandHook.h
@@ -101,21 +101,23 @@ public:
 protected:
     std::string proxyShapePath();
 
-    std::string executeMel(const std::string& commandString);
-    void        executePython(const std::string& commandString);
+    std::string executeMel(const std::string& commandString, bool undoable = true);
+    void        executePython(const std::string& commandString, bool undoable = true);
 
     void executeDelayedCommands() override;
 
     struct DelayedCommand
     {
-        DelayedCommand(const std::string& cmd, bool isP)
+        DelayedCommand(const std::string& cmd, bool isP, bool allowUndo = true)
             : command(cmd)
             , isPython(isP)
+            , isUndoable(allowUndo)
         {
         }
 
         std::string command;
         bool        isPython { false };
+        bool        isUndoable { true };
     };
 
     std::vector<DelayedCommand> _delayedCommands;


### PR DESCRIPTION
Make the `refreshLayerSystemLock` not use undo. Refreshing data should not use undo/redo, it is merely refreshing the UI, not changing data.

This is particularly important to do because the refresh can be triggered by the effect of other commands. So when redoing these commands, we don't want the refresh to flush the redo stack, the the refresh must not be undoable.