### PR TITLE
EMSUSDC-376 fix matrix command undo/redo

### DIFF
--- a/lib/usdUfe/ufe/trf/UsdTransform3dUndoableCommands.cpp
+++ b/lib/usdUfe/ufe/trf/UsdTransform3dUndoableCommands.cpp
@@ -29,7 +29,7 @@ USDUFE_VERIFY_CLASS_SETUP(Ufe::SetMatrix4dUndoableCommand, UsdSetMatrix4dUndoabl
 UsdSetMatrix4dUndoableCommand::UsdSetMatrix4dUndoableCommand(
     const Ufe::Path&     path,
     const Ufe::Matrix4d& newM)
-    : UsdUndoableCommand<Ufe::SetMatrix4dUndoableCommand>(path)
+    : Ufe::SetMatrix4dUndoableCommand(path)
 {
     extractTRS(newM, &_newT, &_newR, &_newS);
 }
@@ -40,7 +40,7 @@ bool UsdSetMatrix4dUndoableCommand::set(const Ufe::Matrix4d&)
     return true;
 }
 
-void UsdSetMatrix4dUndoableCommand::executeImplementation()
+void UsdSetMatrix4dUndoableCommand::execute()
 {
     OperationEditRouterContext editContext(
         EditRoutingTokens->RouteTransform, ufePathToPrim(path()));
@@ -53,9 +53,25 @@ void UsdSetMatrix4dUndoableCommand::executeImplementation()
     if (!TF_VERIFY(t3d)) {
         return;
     }
-    t3d->translate(_newT.x(), _newT.y(), _newT.z());
-    t3d->rotate(_newR.x(), _newR.y(), _newR.z());
-    t3d->scale(_newS.x(), _newS.y(), _newS.z());
+    _compositeCmd = Ufe::CompositeUndoableCommand::create(
+        { t3d->translateCmd(_newT.x(), _newT.y(), _newT.z()),
+          t3d->rotateCmd(_newR.x(), _newR.y(), _newR.z()),
+          t3d->scaleCmd(_newS.x(), _newS.y(), _newS.z()) });
+    _compositeCmd->execute();
+}
+
+void UsdSetMatrix4dUndoableCommand::undo()
+{
+    if (_compositeCmd) {
+        _compositeCmd->undo();
+    }
+}
+
+void UsdSetMatrix4dUndoableCommand::redo()
+{
+    if (_compositeCmd) {
+        _compositeCmd->redo();
+    }
 }
 
 } // namespace USDUFE_NS_DEF

--- a/lib/usdUfe/ufe/trf/UsdTransform3dUndoableCommands.h
+++ b/lib/usdUfe/ufe/trf/UsdTransform3dUndoableCommands.h
@@ -29,8 +29,7 @@ namespace USDUFE_NS_DEF {
 // This class provides the implementation for Ufe::Transform3d::setMatrixCmd()
 // derived classes, with undo / redo support.
 //
-class USDUFE_PUBLIC UsdSetMatrix4dUndoableCommand
-    : public UsdUndoableCommand<Ufe::SetMatrix4dUndoableCommand>
+class USDUFE_PUBLIC UsdSetMatrix4dUndoableCommand : public Ufe::SetMatrix4dUndoableCommand
 {
 public:
     UsdSetMatrix4dUndoableCommand(const Ufe::Path& path, const Ufe::Matrix4d& newM);
@@ -39,14 +38,16 @@ public:
 
     // No-op: for example, Maya does not set matrices through interactive manipulation.
     bool set(const Ufe::Matrix4d&) override;
-
-protected:
-    void executeImplementation() override;
+    void execute() override;
+    void undo() override;
+    void redo() override;
 
 private:
     Ufe::Vector3d _newT;
     Ufe::Vector3d _newR;
     Ufe::Vector3d _newS;
+
+    std::shared_ptr<Ufe::CompositeUndoableCommand> _compositeCmd;
 };
 
 } // namespace USDUFE_NS_DEF


### PR DESCRIPTION
After changing the other command to use UsdUndoBlock, the matrix command was incorrect because it too used a UsdUndoBlock, but call translate/rotate/scale on the UFE `Transform3d` interface which created transform commands behind the scene.

Change the matrix command to no longer use a UsdUndoBlock and now contain a composite UFE command instead, which will contain the individual transform commands.