### PR TITLE
EMSUSD-3110 - Merge with Sublayers with locked layers error fix

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -644,7 +644,7 @@ void LayerTreeItem::clearLayer(QWidget* /*in_parent*/) { commandHook()->clearLay
 
 void LayerTreeItem::mergeWithSublayers(QWidget* /*in_parent*/)
 {
-    if (!_layer || isInvalidLayer() || !hasSubLayers())
+    if (!_layer || isInvalidLayer() || !hasSubLayers() || isLocked())
         return;
 
     commandHook()->flattenLayer(_layer);


### PR DESCRIPTION
This PR makes the Merge with Sublayers command run on layers which are not locked, ensuring the user doesn't see any errors in the script editor while the operation is applied to all unlocked layers.