### PR TITLE
EMSUSD-3220 - Update messaging for stitch with a locked parent layer. 

### DIFF
--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -911,7 +911,6 @@ public:
             for (size_t i = 1; i < layersByStrength.size(); ++i) {
                 const SdfLayerHandle& weakLayer = layersByStrength[i];
                 movedSubLayers.push_back(weakLayer->GetSubLayerPaths());
-                weakLayer->SetSubLayerPaths({});
                 UsdUtilsStitchLayers(strongestLayer, weakLayer);
             }
 
@@ -969,8 +968,15 @@ public:
                             = std::find(subLayerPaths.begin(), subLayerPaths.end(), pathToRemove);
                         if (it != subLayerPaths.end())
                             subLayerPaths.erase(it);
+                            
                     }
-                    parentLayer->SetSubLayerPaths(subLayerPaths);
+                    if (parentLayer && parentLayer->PermissionToEdit()) {
+                        parentLayer->SetSubLayerPaths(subLayerPaths);
+                    } else {
+                        TF_WARN(
+                            "Cannot update layer '%s' because it is locked.",
+                            strongestLayer->GetIdentifier().c_str());
+                    }
                 }
             }
         }

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -920,6 +920,7 @@ public:
             // preserved.
             auto strongLayerSubLayers = strongestLayer->GetSubLayerPaths();
 
+            // Creates a set of the added subLayers, prevent duplicates.
             std::set<std::string> addedSublayerIds;
             for (const auto path : strongLayerSubLayers) {
                 const auto existingLayer = SdfLayer::FindRelativeToLayer(strongestLayer, path);
@@ -928,6 +929,8 @@ public:
                 }
             }
 
+            // Adds any moved sub layers to the strong layers sub layers to prevent layers from
+            // being lost when the weak layer is deleted.
             for (const auto& subLayerList : movedSubLayers) {
                 for (const auto& subLayerPath : subLayerList) {
                     const auto subLayer
@@ -941,24 +944,19 @@ public:
                 }
             }
 
-            strongestLayer->SetSubLayerPaths(strongLayerSubLayers);
-
-            // Remove any selected weak layers from the strongest layer's sublayer list to prevent
+            // Remove any merged weak layers from the sublayer list before setting, to prevent
             // them from being both stitched (merged) and referenced as subLayers.
-            auto dedupedSubLayers = strongestLayer->GetSubLayerPaths();
-            bool anyRemoved = false;
             for (size_t i = 1; i < layersByStrength.size(); ++i) {
                 const std::string weakLayerId = layersByStrength[i]->GetIdentifier();
-                const auto        it
-                    = std::find(dedupedSubLayers.begin(), dedupedSubLayers.end(), weakLayerId);
-                if (it != dedupedSubLayers.end()) {
-                    dedupedSubLayers.erase(it);
-                    anyRemoved = true;
-                }
+                const auto        it = std::find(
+                    strongLayerSubLayers.begin(), strongLayerSubLayers.end(), weakLayerId);
+                if (it != strongLayerSubLayers.end())
+                    strongLayerSubLayers.erase(it);
             }
-            if (anyRemoved)
-                strongestLayer->SetSubLayerPaths(dedupedSubLayers);
 
+            strongestLayer->SetSubLayerPaths(strongLayerSubLayers);
+
+            // Removes the selected weak layers from their parents.
             for (auto& entry : removalsByParent) {
                 const auto parentLayer = SdfLayer::Find(entry.first);
                 if (parentLayer) {
@@ -968,7 +966,6 @@ public:
                             = std::find(subLayerPaths.begin(), subLayerPaths.end(), pathToRemove);
                         if (it != subLayerPaths.end())
                             subLayerPaths.erase(it);
-                            
                     }
                     if (parentLayer && parentLayer->PermissionToEdit()) {
                         parentLayer->SetSubLayerPaths(subLayerPaths);

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -1100,7 +1100,7 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
     if ($multiSelect && !$singleSelect) {
         $label = getMayaUsdString("kMenuStitchLayers");
         $cmd = makeCommand($panelName, "stitchLayers");
-        $enabled = !$isReadOnly && !$appearsLocked && !$appearsSystemLocked && !$appearsMuted;
+        $enabled = !$isReadOnly && !$isLocked && !$appearsSystemLocked && !$appearsMuted;
         menuItem -label $label -enable $enabled -c $cmd;
     }
 


### PR DESCRIPTION
This PR has 3 changes, with each change in its own commit.
1. Change the menu from showing the user the Merge Layers option on locked layers to showing it on layers that are unlocked with a locked parent.
2. Adds a warning message if the user merges a sublayer with a locked parent layer, as it cannot remove the sublayer from the parents sub layer list (not editable in a locked state). The sub layers contents are still transferred to the strongest layer, but the sub layer is not deleted.
3. Refactors the moving of sublayers code found after the Merge Layers operation to be clearer, adds comments. Behaviour has not changed. 

Demo below shows change number 2 
![EMSUSD-3220_demo](https://github.com/user-attachments/assets/24de1358-d2ef-4a3b-9531-cc37d08af284)
