### PR TITLE
EMSUSDC-413 fix trf command undo

### DIFF
--- a/lib/mayaUsd/editForward/MayaUsdEditForwardHost.cpp
+++ b/lib/mayaUsd/editForward/MayaUsdEditForwardHost.cpp
@@ -44,7 +44,8 @@ void MayaUsdEditForwardHost::ExecuteInCmd(std::function<void()> callback, bool i
     static MayaUsd::MayaUsdEditForwardCommand::Callbacks callbacks;
     const bool forwardEditsWithoutUsdUndoBlock = UsdUfe::NoUsdUndoBlockGuard::wantsForwarding();
     if (!forwardEditsWithoutUsdUndoBlock && !IsInUsdUndoBlock()) {
-        TF_DEBUG_MSG(USDUFE_UNDOCMD, "No forwarding: not in set command and not in undo block\n");
+        TF_DEBUG_INFO_MSG(
+            USDUFE_UNDOCMD, "No forwarding: not in set command and not in undo block\n");
         return;
     }
 
@@ -58,7 +59,7 @@ void MayaUsdEditForwardHost::ExecuteInCmd(std::function<void()> callback, bool i
     // before it gets added to the stack.
     if (IsInUsdUndoBlock()) {
         if (!forwardingOpenedUndoChunk) {
-            TF_DEBUG_MSG(USDUFE_UNDOCMD, "In undo block, opening undo chunk for forwarding\n");
+            TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "In undo block, opening undo chunk for forwarding\n");
             forwardingOpenedUndoChunk = true;
             MGlobal::executeCommand("undoInfo -openChunk");
         }
@@ -74,13 +75,13 @@ void MayaUsdEditForwardHost::ExecuteInCmd(std::function<void()> callback, bool i
             idleTaskQueued = false;
 
             if (forwardingOpenedUndoChunk) {
-                TF_DEBUG_MSG(USDUFE_UNDOCMD, "In undo block, forwarding using command\n");
+                TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "In undo block, forwarding using command\n");
                 auto cmd = MayaUsd::MayaUsdEditForwardCommand::create(std::move(callbacksCopy));
                 Ufe::UndoableCommandMgr::instance().executeCmd(cmd);
                 forwardingOpenedUndoChunk = false;
                 MGlobal::executeCommand("undoInfo -closeChunk");
             } else {
-                TF_DEBUG_MSG(USDUFE_UNDOCMD, "No undo block, forwarding directly\n");
+                TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "No undo block, forwarding directly\n");
                 for (const auto& cb : callbacksCopy) {
                     if (cb) {
                         cb();
@@ -112,7 +113,7 @@ bool MayaUsdEditForwardHost::IsEditForwardingPaused() const
     // does not use a UsdUndoBlock in its execute, set, undo and redo functions.
     // IOW, even undo and redo need to forwarded.
     if (UsdUfe::NoUsdUndoBlockGuard::wantsForwarding()) {
-        TF_DEBUG_MSG(USDUFE_UNDOCMD, "Forwarding is not paused: in transform set()\n");
+        TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "Forwarding is not paused: in transform set()\n");
         return false;
     }
 
@@ -120,11 +121,11 @@ bool MayaUsdEditForwardHost::IsEditForwardingPaused() const
     // This is because the UsdUndoBlock will correctly restore the data
     // and thus will not need to be forwarded.
     if (MGlobal::isUndoing() || MGlobal::isRedoing()) {
-        TF_DEBUG_MSG(USDUFE_UNDOCMD, "Forwarding is paused: in undo/redo, \n");
+        TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "Forwarding is paused: in undo/redo, \n");
         return true;
     }
 
-    TF_DEBUG_MSG(USDUFE_UNDOCMD, "Forwarding is not paused\n");
+    TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "Forwarding is not paused\n");
     return false;
 }
 

--- a/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.cpp
@@ -227,6 +227,27 @@ createTransform3d(const Ufe::SceneItem::Ptr& item, NextTransform3dFn nextTransfo
     return stackOps.empty() ? nextTransform3dFn() : UsdTransform3dMayaXformStack::create(usdItem);
 }
 
+std::string convertValueToString(const VtValue& v)
+{
+    std::string valueStr;
+    if (v.IsHolding<GfVec3d>()) {
+        GfVec3d vec = v.UncheckedGet<GfVec3d>();
+        valueStr = TfStringPrintf("%lf %lf %lf", vec[0], vec[1], vec[2]);
+    } else if (v.IsHolding<GfVec3f>()) {
+        GfVec3f vec = v.UncheckedGet<GfVec3f>();
+        valueStr = TfStringPrintf("%f %f %f", vec[0], vec[1], vec[2]);
+    } else if (v.IsHolding<float>()) {
+        float value = v.UncheckedGet<float>();
+        valueStr = TfStringPrintf("%f", value);
+    } else if (v.IsHolding<double>()) {
+        double value = v.UncheckedGet<double>();
+        valueStr = TfStringPrintf("%lf", value);
+    } else {
+        valueStr = v.GetTypeid().name();
+    }
+    return valueStr;
+}
+
 // Helper class to factor out common code for translate, rotate, scale
 // undoable commands.
 //
@@ -257,25 +278,31 @@ class UsdTRSUndoableCmdBase : public UsdUfe::UsdSetXformOpUndoableCommandBase
 {
 public:
     UsdTRSUndoableCmdBase(
+        const char*        opName,
         const VtValue&     newOpValue,
         const Ufe::Path&   path,
         GetOpFunc          getOpFunc,
         CreateOpFunc       createOpFunc,
         const UsdTimeCode& writeTime)
         : UsdUfe::UsdSetXformOpUndoableCommandBase(newOpValue, path, writeTime)
+        , _opName(opName)
         , _getOpFunc(std::move(getOpFunc))
         , _createOpFunc(std::move(createOpFunc))
     {
     }
 
+    std::string commandString() const override { return _opName; }
+
 protected:
     void createOpIfNeeded(UsdUfe::UsdUndoableItem& undoableItem) override
     {
         UsdGeomXformOp op = _getOpFunc(*this);
-        if (op)
+        if (op) {
+            TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "Already existing xformOp for %s\n", _opName);
             return;
+        }
 
-        TF_DEBUG_MSG(USDUFE_UNDOCMD, "Creating xformOp\n");
+        TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "Creating xformOp for %s\n", _opName);
         op = _createOpFunc(*this, undoableItem);
     }
 
@@ -285,33 +312,51 @@ protected:
         //       the undo/redo may have made the original xformOp invalid, so we need to
         //       get it again.
         UsdGeomXformOp op = _getOpFunc(*this);
-        if (!op)
+        if (!op) {
+            TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "Set %s value failed: no UsdGeomXformOp\n", _opName);
             return;
+        }
 
-        if (v.IsEmpty())
+        if (v.IsEmpty()) {
+            TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "Set %s value failed: value is empty\n", _opName);
             return;
+        }
 
         auto attr = op.GetAttr();
-        if (!attr)
+        if (!attr) {
+            TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "Set %s value failed: no attribute\n", _opName);
             return;
+        }
 
+        TF_DEBUG_INFO_MSG(
+            USDUFE_UNDOCMD, "Set %s value %s\n", _opName, convertValueToString(v).c_str());
         attr.Set(v, writeTime);
     }
 
     VtValue getValue(const UsdTimeCode& readTime) const override
     {
+
         UsdGeomXformOp op = _getOpFunc(*this);
-        if (!op)
+        if (!op) {
+            TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "Get %s value failed: no UsdGeomXformOp\n", _opName);
             return {};
+        }
 
         auto attr = op.GetAttr();
-        if (!attr)
+        if (!attr) {
+            TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "Get %s value failed: no attribute\n", _opName);
             return {};
+        }
 
         VtValue value;
         attr.Get(&value, readTime);
+        TF_DEBUG_INFO_MSG(
+            USDUFE_UNDOCMD, "Get %s value %s\n", _opName, convertValueToString(value).c_str());
         return value;
     }
+
+protected:
+    const char* _opName = nullptr;
 
 private:
     GetOpFunc    _getOpFunc;
@@ -326,12 +371,13 @@ template <class V> class UsdVecOpUndoableCmd : public UsdTRSUndoableCmdBase
 {
 public:
     UsdVecOpUndoableCmd(
+        const char*        opName,
         const V&           v,
         const Ufe::Path&   path,
         GetOpFunc          opFunc,
         CreateOpFunc       createOpFunc,
         const UsdTimeCode& writeTime)
-        : UsdTRSUndoableCmdBase(VtValue(v), path, opFunc, createOpFunc, writeTime)
+        : UsdTRSUndoableCmdBase(opName, VtValue(v), path, opFunc, createOpFunc, writeTime)
     {
     }
 
@@ -348,7 +394,7 @@ public:
             return true;
         }
 
-        TF_DEBUG_MSG(USDUFE_UNDOCMD, "Setting value %lf %lf %lf\n", x, y, z);
+        TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "About to set %s value %lf %lf %lf\n", _opName, x, y, z);
 
         UsdUfe::OperationEditRouterContext editContext(
             UsdUfe::EditRoutingTokens->RouteTransform, getPrim());
@@ -370,7 +416,7 @@ public:
         CreateOpFunc                                    createOpFunc,
         UsdTransform3dMayaXformStack::CvtRotXYZToAttrFn cvt,
         const UsdTimeCode&                              writeTime)
-        : UsdTRSUndoableCmdBase(VtValue(r), path, opFunc, createOpFunc, writeTime)
+        : UsdTRSUndoableCmdBase("rotate", VtValue(r), path, opFunc, createOpFunc, writeTime)
         , _cvtRotXYZToAttr(cvt)
     {
     }
@@ -388,7 +434,7 @@ public:
             return true;
         }
 
-        TF_DEBUG_MSG(USDUFE_UNDOCMD, "Setting value %lf %lf %lf\n", x, y, z);
+        TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "About to set %s value %lf %lf %lf\n", _opName, x, y, z);
 
         UsdUfe::OperationEditRouterContext editContext(
             UsdUfe::EditRoutingTokens->RouteTransform, getPrim());
@@ -564,6 +610,7 @@ Ufe::TranslateUndoableCommand::Ptr
 UsdTransform3dMayaXformStack::translateCmd(double x, double y, double z)
 {
     return setVector3dCmd(
+        "translate",
         GfVec3d(x, y, z),
         UsdGeomXformOp::GetOpName(UsdGeomXformOp::TypeTranslate, getTRSOpSuffix()),
         getTRSOpSuffix());
@@ -574,8 +621,8 @@ bool UsdTransform3dMayaXformStack::isFallback() const { return false; }
 static GetOpFunc getGetOpFunc(const TfToken& attrName)
 {
     return [attrName](const BaseUndoableCommand& cmd) {
-        auto usdSceneItem = SceneItemHolder(cmd);
-        auto attr = getUsdPrimAttribute(usdSceneItem.item().prim(), attrName);
+        SceneItemHolder usdSceneItem = SceneItemHolder(cmd);
+        UsdAttribute    attr = getUsdPrimAttribute(usdSceneItem.item().prim(), attrName);
         if (!attr) {
             return UsdGeomXformOp();
         }
@@ -699,7 +746,7 @@ Ufe::ScaleUndoableCommand::Ptr UsdTransform3dMayaXformStack::scaleCmd(double x, 
         "scaling");
 
     return std::make_shared<UsdVecOpUndoableCmd<GfVec3f>>(
-        v, path(), std::move(getOp), std::move(createOp), UsdTimeCode::Default());
+        "scale", v, path(), std::move(getOp), std::move(createOp), UsdTimeCode::Default());
 }
 
 Ufe::TranslateUndoableCommand::Ptr
@@ -707,7 +754,7 @@ UsdTransform3dMayaXformStack::rotatePivotCmd(double x, double y, double z)
 {
     convertToMayaPivotIfNeeded();
 
-    return pivotCmd(getOpSuffix(NdxRotatePivot), x, y, z);
+    return pivotCmd("rotate pivot", getOpSuffix(NdxRotatePivot), x, y, z);
 }
 
 Ufe::Vector3d UsdTransform3dMayaXformStack::rotatePivot() const
@@ -733,7 +780,7 @@ UsdTransform3dMayaXformStack::scalePivotCmd(double x, double y, double z)
 {
     convertToMayaPivotIfNeeded();
 
-    return pivotCmd(getOpSuffix(NdxScalePivot), x, y, z);
+    return pivotCmd("scale pivot", getOpSuffix(NdxScalePivot), x, y, z);
 }
 
 Ufe::Vector3d UsdTransform3dMayaXformStack::scalePivot() const
@@ -761,7 +808,7 @@ UsdTransform3dMayaXformStack::translateRotatePivotCmd(double x, double y, double
 
     auto opSuffix = getOpSuffix(NdxRotatePivotTranslate);
     auto attrName = UsdGeomXformOp::GetOpName(UsdGeomXformOp::TypeTranslate, opSuffix);
-    return setVector3dCmd(GfVec3f(x, y, z), attrName, opSuffix);
+    return setVector3dCmd("translate rotate pivot", GfVec3f(x, y, z), attrName, opSuffix);
 }
 
 Ufe::Vector3d UsdTransform3dMayaXformStack::rotatePivotTranslation() const
@@ -777,7 +824,7 @@ UsdTransform3dMayaXformStack::translateScalePivotCmd(double x, double y, double 
 
     auto opSuffix = getOpSuffix(NdxScalePivotTranslate);
     auto attrName = UsdGeomXformOp::GetOpName(UsdGeomXformOp::TypeTranslate, opSuffix);
-    return setVector3dCmd(GfVec3f(x, y, z), attrName, opSuffix);
+    return setVector3dCmd("translate scale pivot", GfVec3f(x, y, z), attrName, opSuffix);
 }
 
 Ufe::Vector3d UsdTransform3dMayaXformStack::scalePivotTranslation() const
@@ -802,6 +849,7 @@ Ufe::Vector3d UsdTransform3dMayaXformStack::getVector3d(const TfToken& attrName)
 
 template <class V>
 Ufe::SetVector3dUndoableCommand::Ptr UsdTransform3dMayaXformStack::setVector3dCmd(
+    const char*    opName,
     const V&       v,
     const TfToken& attrName,
     const TfToken& opSuffix)
@@ -822,11 +870,15 @@ Ufe::SetVector3dUndoableCommand::Ptr UsdTransform3dMayaXformStack::setVector3dCm
         "translation");
 
     return std::make_shared<UsdVecOpUndoableCmd<V>>(
-        v, path(), std::move(getOp), std::move(createOp), UsdTimeCode::Default());
+        opName, v, path(), std::move(getOp), std::move(createOp), UsdTimeCode::Default());
 }
 
-Ufe::TranslateUndoableCommand::Ptr
-UsdTransform3dMayaXformStack::pivotCmd(const TfToken& pvtOpSuffix, double x, double y, double z)
+Ufe::TranslateUndoableCommand::Ptr UsdTransform3dMayaXformStack::pivotCmd(
+    const char*    opName,
+    const TfToken& pvtOpSuffix,
+    double         x,
+    double         y,
+    double         z)
 {
     auto pvtAttrName = UsdGeomXformOp::GetOpName(UsdGeomXformOp::TypeTranslate, pvtOpSuffix);
 
@@ -847,7 +899,7 @@ UsdTransform3dMayaXformStack::pivotCmd(const TfToken& pvtOpSuffix, double x, dou
         true);
 
     return std::make_shared<UsdVecOpUndoableCmd<GfVec3f>>(
-        v, path(), std::move(getOp), std::move(createOp), UsdTimeCode::Default());
+        opName, v, path(), std::move(getOp), std::move(createOp), UsdTimeCode::Default());
 }
 
 Ufe::SetMatrix4dUndoableCommand::Ptr

--- a/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.cpp
@@ -227,27 +227,6 @@ createTransform3d(const Ufe::SceneItem::Ptr& item, NextTransform3dFn nextTransfo
     return stackOps.empty() ? nextTransform3dFn() : UsdTransform3dMayaXformStack::create(usdItem);
 }
 
-std::string convertValueToString(const VtValue& v)
-{
-    std::string valueStr;
-    if (v.IsHolding<GfVec3d>()) {
-        GfVec3d vec = v.UncheckedGet<GfVec3d>();
-        valueStr = TfStringPrintf("%lf %lf %lf", vec[0], vec[1], vec[2]);
-    } else if (v.IsHolding<GfVec3f>()) {
-        GfVec3f vec = v.UncheckedGet<GfVec3f>();
-        valueStr = TfStringPrintf("%f %f %f", vec[0], vec[1], vec[2]);
-    } else if (v.IsHolding<float>()) {
-        float value = v.UncheckedGet<float>();
-        valueStr = TfStringPrintf("%f", value);
-    } else if (v.IsHolding<double>()) {
-        double value = v.UncheckedGet<double>();
-        valueStr = TfStringPrintf("%lf", value);
-    } else {
-        valueStr = v.GetTypeid().name();
-    }
-    return valueStr;
-}
-
 // Helper class to factor out common code for translate, rotate, scale
 // undoable commands.
 //
@@ -356,6 +335,27 @@ protected:
     }
 
 protected:
+    static std::string convertValueToString(const VtValue& v)
+    {
+        std::string valueStr;
+        if (v.IsHolding<GfVec3d>()) {
+            GfVec3d vec = v.UncheckedGet<GfVec3d>();
+            valueStr = TfStringPrintf("%lf %lf %lf", vec[0], vec[1], vec[2]);
+        } else if (v.IsHolding<GfVec3f>()) {
+            GfVec3f vec = v.UncheckedGet<GfVec3f>();
+            valueStr = TfStringPrintf("%f %f %f", vec[0], vec[1], vec[2]);
+        } else if (v.IsHolding<float>()) {
+            float value = v.UncheckedGet<float>();
+            valueStr = TfStringPrintf("%f", value);
+        } else if (v.IsHolding<double>()) {
+            double value = v.UncheckedGet<double>();
+            valueStr = TfStringPrintf("%lf", value);
+        } else {
+            valueStr = v.GetTypeid().name();
+        }
+        return valueStr;
+    }
+
     const char* _opName = nullptr;
 
 private:

--- a/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.h
+++ b/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.h
@@ -109,6 +109,7 @@ protected:
 
     template <class V>
     Ufe::SetVector3dUndoableCommand::Ptr setVector3dCmd(
+        const char*            opName,
         const V&               v,
         const PXR_NS::TfToken& attrName,
         const PXR_NS::TfToken& opSuffix = PXR_NS::TfToken());
@@ -121,7 +122,7 @@ protected:
 
 private:
     Ufe::TranslateUndoableCommand::Ptr
-    pivotCmd(const PXR_NS::TfToken& pvtOpSuffix, double x, double y, double z);
+    pivotCmd(const char* opName, const PXR_NS::TfToken& pvtOpSuffix, double x, double y, double z);
 }; // UsdTransform3dMayaXformStack
 
 //! \brief Factory to create a UsdTransform3dMayaXformStack interface object.

--- a/lib/usdUfe/base/debugCodes.h
+++ b/lib/usdUfe/base/debugCodes.h
@@ -17,6 +17,7 @@
 #define USDUFE_DEBUGCODES_H
 
 #include <pxr/base/tf/debug.h>
+#include <pxr/base/tf/diagnostic.h>
 #include <pxr/pxr.h>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -28,6 +29,13 @@ TF_DEBUG_CODES(
     USDUFE_UNDOCMD
 );
 // clang-format on
+
+// Macro like TF_DEBUG_MSG, but for informational messages.
+#define TF_DEBUG_INFO_MSG(enumVal, ...)           \
+    if (!TfDebug::IsEnabled(enumVal)) /* empty */ \
+        ;                                         \
+    else                                          \
+        TF_STATUS(__VA_ARGS__)
 
 PXR_NAMESPACE_CLOSE_SCOPE
 

--- a/lib/usdUfe/base/debugCodes.h
+++ b/lib/usdUfe/base/debugCodes.h
@@ -31,6 +31,13 @@ TF_DEBUG_CODES(
 // clang-format on
 
 // Macro like TF_DEBUG_MSG, but for informational messages.
+// IOW, it output its messages to the same place as TF_STATUS while being controlled
+// by the same debug codes as TF_DEBUG_MSG. This is useful because the debug message
+// are output to the standard error output while the status message are handled by
+// the DCC diagnostic dellegate and are sent to a more appropriate place for the
+// user to see. For example, in Maya, the status message are sent to the script editor
+// which has nice feature like clearing, searching and identical-messages consolidation,
+// while the debug message are output in a featureless console.
 #define TF_DEBUG_INFO_MSG(enumVal, ...)           \
     if (!TfDebug::IsEnabled(enumVal)) /* empty */ \
         ;                                         \

--- a/lib/usdUfe/ufe/trf/UsdSetXformOpUndoableCommandBase.cpp
+++ b/lib/usdUfe/ufe/trf/UsdSetXformOpUndoableCommandBase.cpp
@@ -51,7 +51,7 @@ UsdSetXformOpUndoableCommandBase::UsdSetXformOpUndoableCommandBase(
 
 void UsdSetXformOpUndoableCommandBase::execute()
 {
-    TF_DEBUG_MSG(USDUFE_UNDOCMD, "Executing command\n");
+    TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "Executing %s command\n", commandString().c_str());
 
     OperationEditRouterContext editContext(EditRoutingTokens->RouteTransform, getPrim());
 
@@ -72,7 +72,7 @@ void UsdSetXformOpUndoableCommandBase::undo()
     if (!_isPrepared)
         return;
 
-    TF_DEBUG_MSG(USDUFE_UNDOCMD, "Undoing command\n");
+    TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "Undoing %s command\n", commandString().c_str());
 
     OperationEditRouterContext editContext(EditRoutingTokens->RouteTransform, getPrim());
 
@@ -87,7 +87,7 @@ void UsdSetXformOpUndoableCommandBase::undo()
         setValue(_initialOpValue, _writeTime);
     }
 
-    _opCreationUndo.undo();
+    removeOpIfNeeded();
     _canUpdateValue = false;
 }
 
@@ -103,11 +103,11 @@ void UsdSetXformOpUndoableCommandBase::redo()
         return;
     }
 
-    TF_DEBUG_MSG(USDUFE_UNDOCMD, "Redoing command\n");
+    TF_DEBUG_INFO_MSG(USDUFE_UNDOCMD, "Redoing %s command\n", commandString().c_str());
 
     OperationEditRouterContext editContext(EditRoutingTokens->RouteTransform, getPrim());
 
-    _opCreationUndo.redo();
+    recreateOpIfNeeded();
 
     {
         // Set the new value.


### PR DESCRIPTION
- Added a `TF_DEBUG_INFO_MSG` to log conditional debug messages to the normal Maya scripting console instead of the hard-to-find and unfriendly raw console.
- Converted the undo debug messages to use this new macro.
- Added more details to the debug output of transform commands.
- Changed `UsdSetXformOpUndoableCommandBase::undo` to correctly call `removeOpIfNeeded`. which correctly resets the flag that the op was added. This was the source of the bug.