### PR TITLE
Fix crash in USD stage map

### DIFF
--- a/lib/mayaUsd/ufe/UsdStageMap.cpp
+++ b/lib/mayaUsd/ufe/UsdStageMap.cpp
@@ -183,6 +183,10 @@ MObject UsdStageMap::proxyShape(const Ufe::Path& path, bool rebuildCacheIfNeeded
     if (MayaUsdProxyShapeBase::countProxyShapeInstances() == 0)
         return MObject();
 
+    // Protect against empty path as the code below assumes there is at least one segment.
+    if (path.empty())
+        return MObject();
+
     const bool wasRebuilt = rebuildIfDirty();
 
     const auto& singleSegmentPath

--- a/test/lib/ufe/CMakeLists.txt
+++ b/test/lib/ufe/CMakeLists.txt
@@ -13,6 +13,7 @@ set(TEST_SCRIPT_FILES
     testDuplicateProxyShape.py
     testEditRouting.py
     testPrimMetadataEditRouting.py
+    testGetStage.py
     testGroupCmd.py
     testMatrices.py
     testMayaPickwalk.py

--- a/test/lib/ufe/testGetStage.py
+++ b/test/lib/ufe/testGetStage.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2024 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import fixturesUtils
+import mayaUtils
+import mayaUsd
+import mayaUsd_createStageWithNewLayer
+
+from maya import standalone
+
+import ufe
+
+import unittest
+
+
+class GetStageTestCase(unittest.TestCase):
+    '''Verify GetStage interface.'''
+
+    pluginsLoaded = False
+
+    @classmethod
+    def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, loadPlugin=False)
+
+        if not cls.pluginsLoaded:
+            cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def setUp(self):
+        ''' Called initially to set up the maya test environment '''
+        self.assertTrue(self.pluginsLoaded)
+
+    def testGetStageEmptyPath(self):
+        '''Test getStage with an empty path.'''
+        stage = mayaUsd.ufe.getStage("")
+        self.assertIsNone(stage)
+
+    def testGetStage(self):
+        '''Test getStage for a valid stage path gives the same answer as GetPrim().GetStage().'''
+        psPathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        primStage = mayaUsd.lib.GetPrim(psPathStr).GetStage()
+        self.assertIsNotNone(primStage)
+        
+        stage = mayaUsd.ufe.getStage(psPathStr)
+        self.assertIsNotNone(stage)
+        self.assertEqual(stage, primStage)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/lib/ufe/testGetStage.py
+++ b/test/lib/ufe/testGetStage.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #
-# Copyright 2024 Autodesk
+# Copyright 2026 Autodesk
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,8 +22,6 @@ import mayaUsd
 import mayaUsd_createStageWithNewLayer
 
 from maya import standalone
-
-import ufe
 
 import unittest
 

--- a/test/lib/ufe/testGetStage.py
+++ b/test/lib/ufe/testGetStage.py
@@ -51,6 +51,7 @@ class GetStageTestCase(unittest.TestCase):
         stage = mayaUsd.ufe.getStage("")
         self.assertIsNone(stage)
 
+    @unittest.skipUnless(mayaUtils.mayaMajorVersion() > 2025, 'Crash on exit in Maya 2025 or earlier.')
     def testGetStage(self):
         '''Test getStage for a valid stage path gives the same answer as GetPrim().GetStage().'''
         psPathStr = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()


### PR DESCRIPTION
If an empty path is passed, the code would crash.
Verify that the path is not empty. Observed while creating a component, called from some code in Python.