### PR TITLE
EMSUSD-3661 Asset Resolver Path Preview

### DIFF
--- a/cmake/modules/FindAdskUsdAssetResolver.cmake
+++ b/cmake/modules/FindAdskUsdAssetResolver.cmake
@@ -49,7 +49,7 @@ find_library(ADSK_USD_ASSET_RESOLVER_LIBRARY
 )
 find_library(ADSK_USD_ASSET_RESOLVER_DIALOG_LIBRARY
     NAMES
-        AssetResolverWidgets
+        AssetResolverExtensions
     HINTS
         $ENV{ADSK_USD_ASSET_RESOLVER_ROOT_DIR}
         ${ADSK_USD_ASSET_RESOLVER_ROOT_DIR}

--- a/lib/usd/ui/assetResolver/AssetResolverApplicationHost.h
+++ b/lib/usd/ui/assetResolver/AssetResolverApplicationHost.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <AssetResolverWidgets/ApplicationHost.h>
+#include <AssetResolverExtensions/ApplicationHost.h>
 
 class AssetResolverApplicationHost : public Adsk::ApplicationHost
 {

--- a/lib/usd/ui/assetResolver/AssetResolverDialogCmd.cpp
+++ b/lib/usd/ui/assetResolver/AssetResolverDialogCmd.cpp
@@ -42,7 +42,7 @@
 
 #include <maya/MFnPlugin.h>
 
-#include <AssetResolverWidgets/PathDialog/PathDialog.h>
+#include <AssetResolverExtensions/PathDialog/PathDialog.h>
 #include <QtCore/QPointer>
 #include <QtGui/QCursor>
 #include <QtWidgets/QApplication>
@@ -80,8 +80,12 @@ MStatus AssetResolverDialogCmd::initialize(MFnPlugin& plugin)
 /*static*/
 MStatus AssetResolverDialogCmd::finalize(MFnPlugin& plugin)
 {
+    // Destroy the dialog synchronously here (rather than relying on deleteLater
+    // via close()) so that its captured functors, which point into this
+    // plugin's binary, cannot fire after the plugin is unloaded.
     if (g_assetResolverDialog) {
-        g_assetResolverDialog->close();
+        delete g_assetResolverDialog.data();
+        g_assetResolverDialog.clear();
     }
     return plugin.deregisterCommand(name);
 }
@@ -99,7 +103,19 @@ MStatus AssetResolverDialogCmd::doIt(const MArgList& args)
             QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
 
             g_assetResolverDialog = new Adsk::AssetResolverPathDialog(MQtUtil::mainWindow());
-            g_assetResolverDialog->setAttribute(Qt::WA_DeleteOnClose);
+            // Intentionally do NOT set Qt::WA_DeleteOnClose. That attribute
+            // schedules deletion via deleteLater(), which races with:
+            //   * the user reinvoking this command before the deferred delete
+            //     runs (g_assetResolverDialog is still non-null until ~QObject
+            //     actually starts, so we'd re-show a dialog that is queued for
+            //     destruction);
+            //   * pending events / signals on child widgets firing during
+            //     deferred destruction;
+            //   * plugin unload happening before the deferred delete runs,
+            //     leaving the captured functors below dangling.
+            // Instead we keep the dialog alive across closes (Qt's default
+            // closeEvent just hides it) and destroy it explicitly in
+            // finalize().
 
             g_assetResolverDialog->setGetStagesFunctor([]() {
                 auto allStages = ufe::UsdStageMap::getInstance().allStages();
@@ -113,9 +129,7 @@ MStatus AssetResolverDialogCmd::doIt(const MArgList& args)
                 return stages;
             });
 
-            QObject::connect(
-                g_assetResolverDialog,
-                &Adsk::AssetResolverPathDialog::settingsApplied,
+            g_assetResolverDialog->setSettingsAppliedFunctor(
                 PreferencesManagement::SaveUsdPreferences);
 
             QApplication::restoreOverrideCursor();

--- a/lib/usd/ui/assetResolver/AssetResolverUtils.cpp
+++ b/lib/usd/ui/assetResolver/AssetResolverUtils.cpp
@@ -25,7 +25,7 @@
 #include <AdskAssetResolver/AdskAssetResolver.h>
 #include <AdskAssetResolver/AssetResolverContextDataRegistry.h>
 #include <AdskAssetResolver/AssetResolverContextExtension.h>
-#include <AssetResolverWidgets/Settings/AssetResolverSettingsManagement.h>
+#include <AssetResolverExtensions/Settings/AssetResolverSettingsManagement.h>
 
 namespace MAYAUSD_NS_DEF {
 

--- a/lib/usd/ui/assetResolver/PreferencesManagement.cpp
+++ b/lib/usd/ui/assetResolver/PreferencesManagement.cpp
@@ -27,8 +27,8 @@
 #include <maya/MQtUtil.h>
 #include <maya/MString.h>
 
-#include <AssetResolverWidgets/Settings/AssetResolverSettings.h>
-#include <AssetResolverWidgets/Settings/AssetResolverSettingsManagement.h>
+#include <AssetResolverExtensions/Settings/AssetResolverSettings.h>
+#include <AssetResolverExtensions/Settings/AssetResolverSettingsManagement.h>
 
 #include <algorithm>
 

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -131,7 +131,7 @@ if (AdskUsdAssetResolver_FOUND)
 else()
     # If MAYAUSD_FORCE_AR_TEST is set to 1, fail the build when Asset Resolver is not found
     if (DEFINED ENV{MAYAUSD_FORCE_AR_TEST} AND "$ENV{MAYAUSD_FORCE_AR_TEST}" STREQUAL "1")
-        message(FATAL_ERROR "MAYAUSD_FORCE_AR_TEST is set to 1 but AdskAssetResolver was not found. ")
+        message(FATAL_ERROR "MAYAUSD_FORCE_AR_TEST is set to 1 but AdskUsdAssetResolver was not found. ")
     endif()
 endif()
 

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -110,6 +110,31 @@ else()
     endif()
 endif()
 
+if (AdskUsdAssetResolver_FOUND)
+    # Install a test to verify Asset Resolver integration works correctly.
+    set(ASSET_RESOLVER_TEST_SCRIPT_FILES
+        testAdskAssetResolver.py
+    )
+    foreach(script ${ASSET_RESOLVER_TEST_SCRIPT_FILES})
+        mayaUsd_get_unittest_target(target ${script})
+        mayaUsd_add_test(${target}
+            INTERACTIVE
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            PYTHON_SCRIPT ${script}
+            ENV
+                "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}:${PXR_USD_LOCATION}/lib"
+                "MAYA_PLUG_IN_PATH=${CMAKE_INSTALL_PREFIX}/lib/maya"
+                "PXR_OVERRIDE_PLUGINPATH_NAME=${CMAKE_INSTALL_PREFIX}/lib/usd"
+        )
+        set_property(TEST ${target} APPEND PROPERTY LABELS MayaUsd)
+    endforeach()
+else()
+    # If MAYAUSD_FORCE_AR_TEST is set to 1, fail the build when Asset Resolver is not found
+    if (DEFINED ENV{MAYAUSD_FORCE_AR_TEST} AND "$ENV{MAYAUSD_FORCE_AR_TEST}" STREQUAL "1")
+        message(FATAL_ERROR "MAYAUSD_FORCE_AR_TEST is set to 1 but AdskAssetResolver was not found. ")
+    endif()
+endif()
+
 foreach(script ${INTERACTIVE_TEST_SCRIPT_FILES})
     mayaUsd_get_unittest_target(target ${script})
     mayaUsd_add_test(${target}

--- a/test/lib/testAdskAssetResolver.py
+++ b/test/lib/testAdskAssetResolver.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2026 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+import os
+import time
+
+from pxr import Sdf, Usd
+from pxr import Ar as pxrAr
+import AdskAssetResolver as ar
+from maya import cmds
+import maya.utils
+import mayaUsd
+import fixturesUtils
+import mayaUtils
+import ufe
+from maya.internal.ufeSupport import ufeCmdWrapper as ufeCmd
+
+class AdskAssetResolverTestCase(unittest.TestCase):
+
+    pluginsLoaded = False
+
+    @classmethod
+    def setUpClass(cls):
+        fixturesUtils.readOnlySetUpClass(__file__, initializeStandalone=False)
+        # Ensure the idle queue is running so that MGlobal::executeTaskOnIdle
+        # callbacks fire when cmds.flushIdleQueue() is called (needed on Linux).
+        cmds.flushIdleQueue(resume=True)
+        # Ensure the queue is clear before starting the test so that undo stack is predictable,
+        # some idle jobs can append commands on the stack.
+        cmds.flushIdleQueue()
+        if not cls.pluginsLoaded:
+            cls.pluginsLoaded = mayaUtils.isMayaUsdPluginLoaded()
+                        
+    def setUp(self):
+        cmds.file(new=True, force=True)
+
+    def testAssetResolver(self):
+        adskResolver = pxrAr.GetUnderlyingResolver()
+        self.assertIsNotNone(adskResolver, "No underlying asset resolver was found")       
+        try:
+            # This is Autodesk Asset Resolver api. If it doesn't work, AR is not properly loaded.
+            version = ar.VersionInfo() 
+        except Exception as e:
+            self.fail(f"Autodesk Asset Resolver API not available or failed to load. {e}")
+
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals())
+    

--- a/test/lib/testAdskAssetResolver.py
+++ b/test/lib/testAdskAssetResolver.py
@@ -17,19 +17,11 @@
 #
 
 import unittest
-import os
-import time
-
-from pxr import Sdf, Usd
 from pxr import Ar as pxrAr
 import AdskAssetResolver as ar
 from maya import cmds
-import maya.utils
-import mayaUsd
 import fixturesUtils
 import mayaUtils
-import ufe
-from maya.internal.ufeSupport import ufeCmdWrapper as ufeCmd
 
 class AdskAssetResolverTestCase(unittest.TestCase):
 
@@ -55,7 +47,7 @@ class AdskAssetResolverTestCase(unittest.TestCase):
         self.assertIsNotNone(adskResolver, "No underlying asset resolver was found")       
         try:
             # This is Autodesk Asset Resolver api. If it doesn't work, AR is not properly loaded.
-            version = ar.VersionInfo() 
+            ar.VersionInfo() 
         except Exception as e:
             self.fail(f"Autodesk Asset Resolver API not available or failed to load. {e}")
 


### PR DESCRIPTION
- Uses the updated Asset Resolver `0.4.0-7` which contains Path Preview.
- Fixes a race condition on Asset Resolver dialog close
- Adds `MAYAUSD_FORCE_AR_TEST` env variable to check if including / building AR is expected.
- Added a test for the above variable to check basic AR api to ensure it exists and fail the test if it doesn't.
