### PR TITLE
EMSUSD-3695 fix visibility vs Edit-Forwarding

### DIFF
--- a/lib/mayaUsd/editForward/MayaUsdEditForwardHost.cpp
+++ b/lib/mayaUsd/editForward/MayaUsdEditForwardHost.cpp
@@ -22,7 +22,7 @@
 
 #include <usdUfe/base/debugCodes.h>
 #include <usdUfe/ufe/UsdUndoableCommand.h>
-#include <usdUfe/ufe/trf/Utils.h>
+#include <usdUfe/ufe/Utils.h>
 #include <usdUfe/undo/UsdUndoBlock.h>
 #include <usdUfe/undo/UsdUndoManager.h>
 

--- a/lib/usdUfe/ufe/UsdObject3d.cpp
+++ b/lib/usdUfe/ufe/UsdObject3d.cpp
@@ -17,7 +17,6 @@
 
 #include <usdUfe/ufe/UsdUndoVisibleCommand.h>
 #include <usdUfe/ufe/Utils.h>
-#include <usdUfe/ufe/trf/Utils.h>
 #include <usdUfe/utils/editRouter.h>
 #include <usdUfe/utils/editRouterContext.h>
 
@@ -116,6 +115,9 @@ void UsdObject3d::setVisibility(bool vis)
 {
     AttributeEditRouterContext ctx(_prim, PXR_NS::UsdGeomTokens->visibility);
 
+    // TODO: this is to make the visibility toggle command in Maya work with edit-forwarding.
+    //       The more long-term fix would be to make Maya use the UsdUndoVisibleCommand via
+    //       the setVisibleCmd function.
     NoUsdUndoBlockGuard guard(true);
 
     vis ? PXR_NS::UsdGeomImageable(_prim).MakeVisible()

--- a/lib/usdUfe/ufe/UsdObject3d.cpp
+++ b/lib/usdUfe/ufe/UsdObject3d.cpp
@@ -17,6 +17,7 @@
 
 #include <usdUfe/ufe/UsdUndoVisibleCommand.h>
 #include <usdUfe/ufe/Utils.h>
+#include <usdUfe/ufe/trf/Utils.h>
 #include <usdUfe/utils/editRouter.h>
 #include <usdUfe/utils/editRouterContext.h>
 
@@ -114,6 +115,8 @@ bool UsdObject3d::visibility() const
 void UsdObject3d::setVisibility(bool vis)
 {
     AttributeEditRouterContext ctx(_prim, PXR_NS::UsdGeomTokens->visibility);
+
+    NoUsdUndoBlockGuard guard(true);
 
     vis ? PXR_NS::UsdGeomImageable(_prim).MakeVisible()
         : PXR_NS::UsdGeomImageable(_prim).MakeInvisible();

--- a/lib/usdUfe/ufe/Utils.h
+++ b/lib/usdUfe/ufe/Utils.h
@@ -663,6 +663,35 @@ void removeSessionLeftOvers(
 USDUFE_PUBLIC
 PXR_NS::Usd_PrimFlagsPredicate getUsdPredicate(const Ufe::Hierarchy::ChildFilter& childFilter);
 
+//! Guard to set and reset a flag indicating that we are in a command
+//! that does not use a UsdUndoBlock but still wants edit-forwarding.
+class USDUFE_PUBLIC NoUsdUndoBlockGuard
+{
+public:
+    NoUsdUndoBlockGuard(bool noUsdUndoBlock)
+        : _noUsdUndoBlock(noUsdUndoBlock)
+    {
+        if (_noUsdUndoBlock)
+            _getGuardedFlag()++;
+    }
+    ~NoUsdUndoBlockGuard()
+    {
+        if (_noUsdUndoBlock)
+            _getGuardedFlag()--;
+    }
+
+    static bool wantsForwarding() { return _getGuardedFlag() > 0; }
+
+private:
+    static int& _getGuardedFlag()
+    {
+        static int flag = 0;
+        return flag;
+    }
+
+    bool _noUsdUndoBlock;
+};
+
 } // namespace USDUFE_NS_DEF
 
 #endif // USDUFE_UFE_UTILS_H

--- a/lib/usdUfe/ufe/trf/Utils.h
+++ b/lib/usdUfe/ufe/trf/Utils.h
@@ -54,35 +54,6 @@ void rotatePivotTranslateOp(
     double                 y,
     double                 z);
 
-//! Guard to set and reset a flag indicating that we are in a command
-//! that does not use a UsdUndoBlock but still wants edit-forwarding.
-class USDUFE_PUBLIC NoUsdUndoBlockGuard
-{
-public:
-    NoUsdUndoBlockGuard(bool noUsdUndoBlock)
-        : _noUsdUndoBlock(noUsdUndoBlock)
-    {
-        if (_noUsdUndoBlock)
-            _getGuardedFlag()++;
-    }
-    ~NoUsdUndoBlockGuard()
-    {
-        if (_noUsdUndoBlock)
-            _getGuardedFlag()--;
-    }
-
-    static bool wantsForwarding() { return _getGuardedFlag() > 0; }
-
-private:
-    static int& _getGuardedFlag()
-    {
-        static int flag = 0;
-        return flag;
-    }
-
-    bool _noUsdUndoBlock;
-};
-
 } // namespace USDUFE_NS_DEF
 
 #endif // USDUFE_UFE_TRF_UTILS_H


### PR DESCRIPTION
Make the `setVisibility` function tell the edit-forwarding that it should forward the change even though there are no `UsdUndoBlock` in use. This is necessary because visibility toggling in Maya uses a UFE command tht is internal to Maya and calls this function instead of creating the UFE visibility command provided by MayaUsd.