### PR TITLE
EMSUSD-3098 fix layer manager node crash

### DIFF
--- a/lib/mayaUsd/nodes/layerManager.cpp
+++ b/lib/mayaUsd/nodes/layerManager.cpp
@@ -64,6 +64,7 @@
 #include <maya/MItDag.h>
 #include <maya/MItDependencyNodes.h>
 #include <maya/MSceneMessage.h>
+#include <maya/MSelectionList.h>
 #include <ufe/globalSelection.h>
 #include <ufe/observableSelection.h>
 #include <ufe/selectionNotification.h>
@@ -1557,6 +1558,13 @@ void LayerDatabase::removeManagerNode(
     OpUndoItemMuting muting;
 
     clearManagerNode(lm);
+
+    // Remove the layer manager from the selection list if it's selected,
+    // otherwise Maya might crash in the future after we delete the node.
+    {
+        MObject lmObject = lm->thisMObject();
+        MGlobal::unselect(lmObject);
+    }
 
     MDGModifier& modifier = MDGModifierUndoItem::create("Manager node removal");
     modifier.deleteNode(lm->thisMObject());

--- a/test/lib/mayaUsd/nodes/testLayerManagerSerialization.py
+++ b/test/lib/mayaUsd/nodes/testLayerManagerSerialization.py
@@ -149,6 +149,21 @@ class testLayerManagerSerialization(unittest.TestCase):
         self.confirmStageHasTestEdits(
             stage, fileBackedSavedStatus, fileBackedSavedStatus, sessionSavedStatus)
 
+    def testCreateNodeAndSave(self):
+        """
+        Test that creating a node and saving the Maya scene does not crash.
+        """
+        cmds.createNode("mayaUsdLayerManager")
+
+        self._currentTestDir = tempfile.mkdtemp(prefix='testSaveWithoutStage')
+        try:
+            self._tempMayaFile = os.path.join(
+                self._currentTestDir, 'EmptySerializationTest.ma')
+            cmds.file(rename=self._tempMayaFile)
+            cmds.file(save=True, force=True, type='mayaAscii')
+        finally:
+            shutil.rmtree(self._currentTestDir)
+
     def testSaveWithoutStage(self):
         '''
         Verify that when saving a Maya scene, if no stage have been created then


### PR DESCRIPTION
EMSUSD-3098 - fix layer manager node crash

## Description
When Maya saves the scene, layer manager nodes get created by MayaUsd to preserve the anonymous layers and other info related to layers. Then the nodes get immediately deleted.

Users should not be creating MayaUsdLayerManager nodes, but we cannot prevent them.

The crash was not entirely due to the layer manager, but due to interaction with other parts of Maya. When the layer manager nodes are deleted during save, the code that deleted them did not remove them from the global selection. Normally, they should never be in the selection, but the `createNode` command automatically adds the created node to the selection. Surprisingly, the `MDGModifier` `deleteNode` does not remove the deleted node from the global selection! What caused the crash was that other code run during save was retrieving the global selection and was trying to use the deleted node.

The fix is to remove the node from the global selection before deleting it.