### PR TITLE
EMSUSD-3181 faster all-stages

### DIFF
--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -150,8 +150,8 @@ std::vector<SessionState::StageEntry> MayaSessionState::allStages() const
 {
     std::vector<StageEntry> stages;
 
-    // Iterate through all DAG nodes to find proxy shape nodes
-    MItDag dagIterator(MItDag::kBreadthFirst, MFn::kInvalid);
+    // Iterate through all shape DAG nodes to find proxy shape nodes
+    MItDag dagIterator(MItDag::kBreadthFirst, MFn::kPluginShape);
     for (; !dagIterator.isDone(); dagIterator.next()) {
         MObject    mobj = dagIterator.currentItem();
         MFnDagNode fnDagNode(mobj);
@@ -164,8 +164,14 @@ std::vector<SessionState::StageEntry> MayaSessionState::allStages() const
         // Check if this node is a proxy shape by type name
         MDagPath dagPath;
         dagIterator.getPath(dagPath);
-        MString shapePath = dagPath.fullPathName();
 
+        // Avoid instances of the same shape by only looking at the first instance (instance number
+        // 0)
+        if (dagPath.instanceNumber() != 0) {
+            continue;
+        }
+
+        MString    shapePath = dagPath.fullPathName();
         StageEntry entry;
         if (getStageEntry(&entry, shapePath)) {
             stages.push_back(entry);

--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -151,7 +151,7 @@ std::vector<SessionState::StageEntry> MayaSessionState::allStages() const
     std::vector<StageEntry> stages;
 
     // Iterate through all shape DAG nodes to find proxy shape nodes
-    MItDag dagIterator(MItDag::kBreadthFirst, MFn::kPluginShape);
+    MItDag dagIterator(MItDag::kDepthFirst, MFn::kPluginShape);
     for (; !dagIterator.isDone(); dagIterator.next()) {
         MObject    mobj = dagIterator.currentItem();
         MFnDagNode fnDagNode(mobj);

--- a/lib/usd/ui/layerEditor/mayaSessionState.cpp
+++ b/lib/usd/ui/layerEditor/mayaSessionState.cpp
@@ -36,6 +36,7 @@
 #include <maya/MFileIO.h>
 #include <maya/MFnDagNode.h>
 #include <maya/MGlobal.h>
+#include <maya/MItDag.h>
 #include <maya/MNodeMessage.h>
 #include <maya/MPxNode.h>
 #include <maya/MSceneMessage.h>
@@ -148,12 +149,25 @@ bool MayaSessionState::getStageEntry(StageEntry* out_stageEntry, const MString& 
 std::vector<SessionState::StageEntry> MayaSessionState::allStages() const
 {
     std::vector<StageEntry> stages;
-    MStringArray            shapes;
-    MGlobal::executeCommand(
-        MString("ls -long -type ") + PROXY_NODE_TYPE, shapes, /*display*/ false, /*undo*/ false);
-    StageEntry entry;
-    for (unsigned i = 0; i < shapes.length(); ++i) {
-        if (getStageEntry(&entry, shapes[i])) {
+
+    // Iterate through all DAG nodes to find proxy shape nodes
+    MItDag dagIterator(MItDag::kBreadthFirst, MFn::kInvalid);
+    for (; !dagIterator.isDone(); dagIterator.next()) {
+        MObject    mobj = dagIterator.currentItem();
+        MFnDagNode fnDagNode(mobj);
+
+        const PXR_NS::MayaUsdProxyShapeBase* proxyShape
+            = dynamic_cast<const PXR_NS::MayaUsdProxyShapeBase*>(fnDagNode.userNode());
+        if (!proxyShape)
+            continue;
+
+        // Check if this node is a proxy shape by type name
+        MDagPath dagPath;
+        dagIterator.getPath(dagPath);
+        MString shapePath = dagPath.fullPathName();
+
+        StageEntry entry;
+        if (getStageEntry(&entry, shapePath)) {
             stages.push_back(entry);
         }
     }

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
@@ -345,6 +345,9 @@ void StageSelectorWidget::selectionChanged()
     if (!ufeGlobalSelection)
         return;
 
+    std::vector<SessionState::StageEntry> allStages;
+    bool                                  allStagesFilled = false;
+
     // We will set the currently selected stage to be the stage of the first item
     // that is a USD item. So if multiple stages are selected, the first one wins.
     const Ufe::Selection& ufeSelection = *ufeGlobalSelection;
@@ -358,9 +361,14 @@ void StageSelectorWidget::selectionChanged()
             }
         }
 
+        if (!allStagesFilled) {
+            allStages = _sessionState->allStages();
+            allStagesFilled = true;
+        }
+
         MFnDagNode        dagNode(proxyShapePtr->thisMObject());
         const std::string id = dagNode.uuid().asString().asChar();
-        const int         index = getEntryIndexById(id, _sessionState->allStages());
+        const int         index = getEntryIndexById(id, allStages);
         if (index == -1)
             continue;
 


### PR DESCRIPTION
- Optimized the `allStages` function of the `MayaSessionState` c;lass by using a C++ iterator instead of the MEL `ls` command.
- Optimized the `selectionChanged` callback function of the `StageSelectorWidget` class to only call `allStages` once.
- Still avoid calling `allStages` if there is not proxy stage in the selection.