### PR TITLE
EMSUSD-3363 : support for External Camera

### DIFF
--- a/lib/mayaUsd/nodes/sceneRenderSettings.cpp
+++ b/lib/mayaUsd/nodes/sceneRenderSettings.cpp
@@ -14,41 +14,57 @@
 // limitations under the License.
 //
 
-// Registration site and public C++ surface for the UsdDefaultRenderSettings
-// settings node. Node type, callbacks and serialization are handled
-// generically by UsdSettingsNode and UsdSceneSettingsManager.
-
 #include <mayaUsd/nodes/sceneRenderSettings.h>
 #include <mayaUsd/nodes/usdSceneSettingsManager.h>
+#include <mayaUsd/nodes/usdSettingsNode.h>
+#include <mayaUsd/ufe/Utils.h>
 
 #include <pxr/base/tf/token.h>
 #include <pxr/usd/sdf/path.h>
+#include <pxr/usd/sdf/valueTypeName.h>
+#include <pxr/usd/usd/attribute.h>
+#include <pxr/usd/usd/relationship.h>
+#include <pxr/usd/usd/stage.h>
+#include <pxr/usd/usdGeom/camera.h>
 #include <pxr/usd/usdGeom/scope.h>
 #include <pxr/usd/usdRender/settings.h>
 
-#include <maya/MFnDependencyNode.h>
-#include <maya/MObject.h>
+#include <ufe/path.h>
+#include <ufe/pathString.h>
 
 #include <string>
 
 namespace {
 
-// Locked DG node name and UsdSceneSettingsManager lookup key.
-const std::string kRenderSettingsNodeName("UsdDefaultRenderSettings");
-
-// Stage metadata key for the SdfPath of the default render-settings prim.
+const std::string     kRenderSettingsNodeName("UsdDefaultRenderSettings");
 const PXR_NS::TfToken kRenderSettingsPrimPathToken("renderSettingsPrimPath");
 
-// Stage metadata key for the UFE path of the currently active settings prim.
-const PXR_NS::TfToken kActiveSettingsPathToken("activeSettingsPath");
+// UFE path to a camera that lives outside renderSettings's stage (Maya native
+// camera, or a camera in a different USD stage). Overrides the schema `camera`
+// relationship for active-camera selection when authored.
+const PXR_NS::TfToken kExternalCameraAttrName("adskUsd:externalCamera");
 
-// Static initializer ensures registration happens before
-// UsdSceneSettingsManager::onPluginInitialize(). When the plugin is already
-// running (sub-plugin load), registerSettingNode() creates the node directly.
+// Transform path (not shape) for end-user readability; Maya Hydra resolves to
+// the underlying camera shape when required.
+const std::string kDefaultExternalCameraUfePath("|persp");
+
+// Avoids the AE default name-splitting of "adskUsd:externalCamera".
+const std::string kExternalCameraDisplayName("External Camera");
+
+PXR_NS::UsdAttribute createExternalCameraAttr(const PXR_NS::UsdPrim& renderSettings)
+{
+    PXR_NS::UsdAttribute attr = renderSettings.CreateAttribute(
+        kExternalCameraAttrName, PXR_NS::SdfValueTypeNames->String, /*custom=*/true);
+    if (attr) {
+        attr.SetDisplayName(kExternalCameraDisplayName);
+    }
+    return attr;
+}
+
 // NOLINTNEXTLINE(cert-err58-cpp) -- intentional static initializer pattern
 const bool kRenderSettingsRegistered = []() {
     MayaUsd::UsdSceneSettingsManager::registerSettingNode(
-        kRenderSettingsNodeName, [](PXR_NS::UsdStageRefPtr stage) {
+        kRenderSettingsNodeName, [](PXR_NS::UsdStageRefPtr stage, MayaUsd::UsdSettingsNode& node) {
             if (!stage) {
                 return;
             }
@@ -60,19 +76,21 @@ const bool kRenderSettingsRegistered = []() {
 
             PXR_NS::UsdGeomScope::Define(stage, renderScopePath);
 
-            // Leave attributes un-authored so they fall back to schema defaults.
             PXR_NS::UsdRenderSettings renderSettings
                 = PXR_NS::UsdRenderSettings::Define(stage, renderSettingsPath);
             if (!renderSettings) {
                 return;
             }
 
+            createExternalCameraAttr(renderSettings.GetPrim()).Set(kDefaultExternalCameraUfePath);
+
             stage->SetMetadata(kRenderSettingsPrimPathToken, renderSettingsPath.GetString());
 
-            // Comma is the segment separator used by Ufe::PathString.
-            const std::string defaultActivePath
-                = kRenderSettingsNodeName + "," + renderSettingsPath.GetString();
-            stage->SetMetadata(kActiveSettingsPathToken, defaultActivePath);
+            // Skip when non-empty so a pre-populator user value is preserved.
+            if (node.activeSettingsPath().empty()) {
+                node.setActiveSettingsPath(
+                    kRenderSettingsNodeName + "," + renderSettingsPath.GetString());
+            }
         });
     return true;
 }();
@@ -84,12 +102,9 @@ namespace SceneRenderSettings {
 
 std::string find()
 {
-    MObject obj = MayaUsd::UsdSceneSettingsManager::find(kRenderSettingsNodeName);
-    if (obj.isNull()) {
-        return {};
-    }
-    MFnDependencyNode depFn(obj);
-    return depFn.name().asChar();
+    MayaUsd::UsdSettingsNode* node
+        = MayaUsd::UsdSceneSettingsManager::getNodeForNodeName(kRenderSettingsNodeName);
+    return node ? node->nodeName() : std::string();
 }
 
 PXR_NS::UsdStageRefPtr getUsdStage()
@@ -113,22 +128,80 @@ PXR_NS::UsdPrim getDefaultRenderSettingsPrim()
 
 std::string getActiveSettingPath()
 {
-    auto stage = MayaUsd::UsdSceneSettingsManager::getStage(kRenderSettingsNodeName);
-    if (!stage) {
+    MayaUsd::UsdSettingsNode* node
+        = MayaUsd::UsdSceneSettingsManager::getNodeForNodeName(kRenderSettingsNodeName);
+    if (!node) {
         return {};
     }
-    std::string path;
-    stage->GetMetadata(kActiveSettingsPathToken, &path);
-    return path;
+    // Force the populator to seed the default before reading.
+    node->getUsdStage();
+    return node->activeSettingsPath();
 }
 
 bool setActiveSettingPath(const std::string& ufePath)
 {
-    auto stage = MayaUsd::UsdSceneSettingsManager::getStage(kRenderSettingsNodeName);
-    if (!stage) {
+    MayaUsd::UsdSettingsNode* node
+        = MayaUsd::UsdSceneSettingsManager::getNodeForNodeName(kRenderSettingsNodeName);
+    if (!node) {
         return false;
     }
-    return stage->SetMetadata(kActiveSettingsPathToken, ufePath);
+    // Run the populator first so a later replay cannot overwrite this write.
+    node->getUsdStage();
+    return node->setActiveSettingsPath(ufePath);
+}
+
+const PXR_NS::TfToken& externalCameraAttrName() { return kExternalCameraAttrName; }
+
+bool setRenderSettingsCamera(
+    const PXR_NS::UsdPrim& renderSettings,
+    const std::string&     cameraUfePath)
+{
+    if (!renderSettings || !renderSettings.IsA<PXR_NS::UsdRenderSettings>()) {
+        return false;
+    }
+
+    // Try SdfPath against renderSettings's stage first (handles bare USD
+    // paths and prims on stages not reachable through any UFE gateway), then
+    // fall back to UFE for paths with a Maya gateway segment.
+    PXR_NS::UsdPrim resolvedPrim;
+    if (!cameraUfePath.empty()) {
+        if (PXR_NS::SdfPath::IsValidPathString(cameraUfePath)) {
+            const PXR_NS::SdfPath sdfPath(cameraUfePath);
+            if (sdfPath.IsAbsolutePath() && sdfPath.IsPrimPath()) {
+                resolvedPrim = renderSettings.GetStage()->GetPrimAtPath(sdfPath);
+            }
+        }
+        if (!resolvedPrim) {
+            try {
+                const Ufe::Path ufePath = Ufe::PathString::path(cameraUfePath);
+                resolvedPrim = MayaUsd::ufe::ufePathToPrim(ufePath);
+            } catch (const std::exception&) {
+            }
+        }
+    }
+
+    PXR_NS::UsdRenderSettings settingsSchema(renderSettings);
+    PXR_NS::UsdRelationship   cameraRel = settingsSchema.CreateCameraRel();
+
+    const bool resolvesToSameStageCamera = resolvedPrim && resolvedPrim.IsA<PXR_NS::UsdGeomCamera>()
+        && resolvedPrim.GetStage() == renderSettings.GetStage();
+
+    if (resolvesToSameStageCamera) {
+        if (!cameraRel.SetTargets({ resolvedPrim.GetPath() })) {
+            return false;
+        }
+        if (renderSettings.HasAttribute(kExternalCameraAttrName)) {
+            // RemoveProperty is non-const; UsdPrim is a value-type handle.
+            PXR_NS::UsdPrim mutablePrim = renderSettings;
+            mutablePrim.RemoveProperty(kExternalCameraAttrName);
+        }
+        return true;
+    }
+
+    cameraRel.SetTargets({});
+
+    PXR_NS::UsdAttribute externalCameraAttr = createExternalCameraAttr(renderSettings);
+    return externalCameraAttr && externalCameraAttr.Set(cameraUfePath);
 }
 
 } // namespace SceneRenderSettings

--- a/lib/mayaUsd/nodes/sceneRenderSettings.h
+++ b/lib/mayaUsd/nodes/sceneRenderSettings.h
@@ -45,8 +45,33 @@ MAYAUSD_CORE_PUBLIC PXR_NS::UsdPrim getDefaultRenderSettingsPrim();
 MAYAUSD_CORE_PUBLIC std::string getActiveSettingPath();
 
 //! Author the UFE path of the currently active settings prim. Returns false
-//! if the stage cannot be resolved or SetMetadata fails.
+//! if the singleton node is unavailable or the plug write fails.
 MAYAUSD_CORE_PUBLIC bool setActiveSettingPath(const std::string& ufePath);
+
+//! Name of the custom string attribute that records the UFE path of a camera
+//! that does not live on the same stage as the render-settings prim
+//! (e.g. a Maya native camera shape, or a camera in another USD stage).
+//! When this attribute is authored, it overrides the schema `camera`
+//! relationship for the purpose of selecting the active render camera.
+MAYAUSD_CORE_PUBLIC const PXR_NS::TfToken& externalCameraAttrName();
+
+//! Set the active camera for a UsdRenderSettings prim from a UFE path string.
+//!
+//! Resolution rule:
+//! - If `cameraUfePath` resolves to a UsdGeomCamera prim that lives on the
+//!   same stage as `renderSettings`, the schema `camera` relationship is set
+//!   to that prim and any previously authored `adskUsd:externalCamera`
+//!   attribute is removed.
+//! - Otherwise (Maya native camera, or a camera prim in a different stage),
+//!   the schema `camera` relationship targets are cleared and the UFE path
+//!   string is stored on the `adskUsd:externalCamera` attribute.
+//!
+//! \param renderSettings A valid prim of type UsdRenderSettings.
+//! \param cameraUfePath  UFE path string parseable by Ufe::PathString::path.
+//! \return true on success; false if the prim is invalid, not a
+//!         UsdRenderSettings, or the authoring operation fails.
+MAYAUSD_CORE_PUBLIC bool
+setRenderSettingsCamera(const PXR_NS::UsdPrim& renderSettings, const std::string& cameraUfePath);
 
 } // namespace SceneRenderSettings
 

--- a/lib/mayaUsd/nodes/usdSceneSettingsManager.cpp
+++ b/lib/mayaUsd/nodes/usdSceneSettingsManager.cpp
@@ -80,7 +80,8 @@ void UsdSceneSettingsManager::registerSettingNode(const std::string& nodeName, P
 /* static */
 void UsdSceneSettingsManager::callPopulator(
     const std::string&     nodeName,
-    PXR_NS::UsdStageRefPtr stage)
+    PXR_NS::UsdStageRefPtr stage,
+    UsdSettingsNode&       node)
 {
     // Centralize the stage null-guard here so individual populators do not
     // each have to repeat it. ensureStage may pass a null stage if
@@ -90,7 +91,7 @@ void UsdSceneSettingsManager::callPopulator(
     }
     auto it = registry().find(nodeName);
     if (it != registry().end() && it->second) {
-        it->second(stage);
+        it->second(stage, node);
     }
 }
 
@@ -152,20 +153,20 @@ PXR_NS::UsdStageRefPtr UsdSceneSettingsManager::getStage(const std::string& node
 /* static */
 PXR_NS::UsdStageRefPtr UsdSceneSettingsManager::getStageForNodeName(const std::string& nodeName)
 {
+    UsdSettingsNode* node = getNodeForNodeName(nodeName);
+    return node ? node->getUsdStage() : nullptr;
+}
+
+/* static */
+UsdSettingsNode* UsdSceneSettingsManager::getNodeForNodeName(const std::string& nodeName)
+{
     // Never create a node here. The instances map is keyed by DG node name
     // (see createNode) and is the authoritative source for managed nodes.
-    // The stage itself is materialized lazily on first access
-    // (UsdSettingsNode::ensureStage), which runs the populator and fires
-    // the stage observer hook.
     auto it = instances().find(nodeName);
     if (it == instances().end() || !it->second.isValid()) {
         return nullptr;
     }
-    UsdSettingsNode* node = nodeFromHandle(it->second);
-    if (!node) {
-        return nullptr;
-    }
-    return node->getUsdStage();
+    return nodeFromHandle(it->second);
 }
 
 /* static */

--- a/lib/mayaUsd/nodes/usdSceneSettingsManager.h
+++ b/lib/mayaUsd/nodes/usdSceneSettingsManager.h
@@ -43,8 +43,9 @@ namespace MAYAUSD_NS_DEF {
 class MAYAUSD_CORE_PUBLIC UsdSceneSettingsManager
 {
 public:
-    //! Seeds a managed node's USD stage with domain-specific content.
-    using Populator = std::function<void(PXR_NS::UsdStageRefPtr)>;
+    //! Seeds a managed node's USD stage and its node-level attributes (e.g.
+    //! the activeSettingsPath plug) with domain-specific content.
+    using Populator = std::function<void(PXR_NS::UsdStageRefPtr, UsdSettingsNode&)>;
 
     // -----------------------------------------------------------------------
     // Registration
@@ -54,9 +55,10 @@ public:
     //! initialized (sub-plugin load), the node is created immediately.
     static void registerSettingNode(const std::string& nodeName, Populator populate);
 
-    //! Invoke the populator for \p nodeName on \p stage. Called from
-    //! UsdSettingsNode::ensureStage().
-    static void callPopulator(const std::string& nodeName, PXR_NS::UsdStageRefPtr stage);
+    //! Invoke the populator for \p nodeName on \p stage and \p node. Called
+    //! from UsdSettingsNode::ensureStage() and ::deserializeFromAttributes().
+    static void
+    callPopulator(const std::string& nodeName, PXR_NS::UsdStageRefPtr stage, UsdSettingsNode& node);
 
     // -----------------------------------------------------------------------
     // Node access
@@ -73,6 +75,10 @@ public:
     //! torn-down names. The stage itself is still materialized lazily on first
     //! call (which runs the populator and fires the stage observer hook).
     static PXR_NS::UsdStageRefPtr getStageForNodeName(const std::string& nodeName);
+
+    //! Live UsdSettingsNode* for \p nodeName, or nullptr if none is tracked.
+    //! Does not create or materialize the stage.
+    static UsdSettingsNode* getNodeForNodeName(const std::string& nodeName);
 
     //! Reverse lookup: live MObject of the managed node whose stage matches
     //! \p stage, or a null MObject if none. Does NOT trigger lazy stage

--- a/lib/mayaUsd/nodes/usdSettingsNode.cpp
+++ b/lib/mayaUsd/nodes/usdSettingsNode.cpp
@@ -35,6 +35,7 @@ const MString UsdSettingsNode::typeName("UsdDefaultSettings");
 
 MObject UsdSettingsNode::serializedRootLayerAttr;
 MObject UsdSettingsNode::serializedSessionLayerAttr;
+MObject UsdSettingsNode::activeSettingsPathAttr;
 
 /* static */
 void* UsdSettingsNode::creator() { return new UsdSettingsNode(); }
@@ -72,6 +73,17 @@ MStatus UsdSettingsNode::initialize()
     status = addAttribute(serializedSessionLayerAttr);
     CHECK_MSTATUS_AND_RETURN_IT(status);
 
+    // UFE path of the currently active settings prim, persisted with the
+    // scene. Hidden/internal: reads/writes go through the typed accessors.
+    activeSettingsPathAttr = typedAttrFn.create(
+        "activeSettingsPath", "asp", MFnData::kString, defaultStringDataObj, &status);
+    CHECK_MSTATUS_AND_RETURN_IT(status);
+    typedAttrFn.setStorable(true);
+    typedAttrFn.setHidden(true);
+    typedAttrFn.setInternal(true);
+    status = addAttribute(activeSettingsPathAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(status);
+
     return status;
 }
 
@@ -92,6 +104,19 @@ std::string UsdSettingsNode::nodeName() const
 {
     MFnDependencyNode depFn(thisMObject());
     return depFn.name().asChar();
+}
+
+std::string UsdSettingsNode::activeSettingsPath() const
+{
+    MPlug plug(thisMObject(), activeSettingsPathAttr);
+    return plug.asString().asChar();
+}
+
+bool UsdSettingsNode::setActiveSettingsPath(const std::string& ufePath)
+{
+    MPlug   plug(thisMObject(), activeSettingsPathAttr);
+    MStatus status = plug.setString(MString(ufePath.c_str()));
+    return status == MS::kSuccess;
 }
 
 void UsdSettingsNode::ensureStage() const
@@ -118,7 +143,7 @@ void UsdSettingsNode::ensureStage() const
         return;
     }
 
-    UsdSceneSettingsManager::callPopulator(name, _stage);
+    UsdSceneSettingsManager::callPopulator(name, _stage, const_cast<UsdSettingsNode&>(*this));
 
     // Hook USD-notice observers (UFE notification flow) onto the freshly
     // created stage. Done after the populator so the initial population is
@@ -241,7 +266,7 @@ void UsdSettingsNode::deserializeFromAttributes()
     // empty layers to write). Run the populator so the resulting stage
     // matches what a freshly-created node would produce.
     if (rootStr.length() == 0 && sessionStr.length() == 0) {
-        UsdSceneSettingsManager::callPopulator(name, _stage);
+        UsdSceneSettingsManager::callPopulator(name, _stage, *this);
     }
 
     // Newly deserialized stage: re-hook USD-notice observers via the manager

--- a/lib/mayaUsd/nodes/usdSettingsNode.h
+++ b/lib/mayaUsd/nodes/usdSettingsNode.h
@@ -78,10 +78,10 @@ public:
     //! Unlike getUsdStage(), this does not trigger lazy creation.
     bool hasStage() const { return _stage != nullptr; }
 
-    //! UFE path of the currently active settings prim.
+    //! UFE path string of the currently active settings prim.
     std::string activeSettingsPath() const;
 
-    //! Author the UFE path of the currently active settings prim. Returns
+    //! Author the UFE path string of the currently active settings prim. Returns
     //! false on plug-write failure.
     bool setActiveSettingsPath(const std::string& ufePath);
 

--- a/lib/mayaUsd/nodes/usdSettingsNode.h
+++ b/lib/mayaUsd/nodes/usdSettingsNode.h
@@ -60,6 +60,7 @@ public:
     // Attributes
     static MObject serializedRootLayerAttr;
     static MObject serializedSessionLayerAttr;
+    static MObject activeSettingsPathAttr;
 
     static void*   creator();
     static MStatus initialize();
@@ -76,6 +77,13 @@ public:
     //! Return true if the internal stage has already been created.
     //! Unlike getUsdStage(), this does not trigger lazy creation.
     bool hasStage() const { return _stage != nullptr; }
+
+    //! UFE path of the currently active settings prim.
+    std::string activeSettingsPath() const;
+
+    //! Author the UFE path of the currently active settings prim. Returns
+    //! false on plug-write failure.
+    bool setActiveSettingsPath(const std::string& ufePath);
 
     // Serialization (called by UsdSceneSettingsManager scene callbacks)
     void serializeToAttributes();

--- a/lib/mayaUsd/python/wrapSceneRenderSettings.cpp
+++ b/lib/mayaUsd/python/wrapSceneRenderSettings.cpp
@@ -36,5 +36,11 @@ void wrapSceneRenderSettings()
         .def("getActiveRenderSettingsPath", &MayaUsd::SceneRenderSettings::getActiveSettingPath)
         .staticmethod("getActiveRenderSettingsPath")
         .def("setActiveRenderSettingsPath", &MayaUsd::SceneRenderSettings::setActiveSettingPath)
-        .staticmethod("setActiveRenderSettingsPath");
+        .staticmethod("setActiveRenderSettingsPath")
+        .def(
+            "externalCameraAttrName",
+            +[]() { return MayaUsd::SceneRenderSettings::externalCameraAttrName().GetString(); })
+        .staticmethod("externalCameraAttrName")
+        .def("setCamera", &MayaUsd::SceneRenderSettings::setRenderSettingsCamera)
+        .staticmethod("setCamera");
 }

--- a/lib/mayaUsd/utils/plugInfo.json
+++ b/lib/mayaUsd/utils/plugInfo.json
@@ -20,13 +20,6 @@
                         "type": "token",
                         "appliesTo": "properties",
                         "default": "off"
-                    },
-                    # UFE path of the currently active settings prim, authored on
-                    # the stage of a UsdSettingsNode (e.g. UsdDefaultRenderSettings).
-                    "activeSettingsPath": {
-                        "type": "string",
-                        "appliesTo": "layers",
-                        "default": ""
                     }
                 }
             },

--- a/lib/mayaUsdAPI/CMakeLists.txt
+++ b/lib/mayaUsdAPI/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(${PROJECT_NAME}
         proxyStage.cpp
         proxyShapeNotice.cpp
         render.cpp
+        sceneRenderSettings.cpp
         ufeHandlers.cpp
         undo.cpp
         utils.cpp
@@ -40,6 +41,7 @@ set(HEADERS
     ufeHandlers.h
     proxyShapeNotice.h
     render.h
+    sceneRenderSettings.h
     undo.h
     utils.h
 )

--- a/lib/mayaUsdAPI/CMakeLists.txt
+++ b/lib/mayaUsdAPI/CMakeLists.txt
@@ -27,7 +27,6 @@ target_sources(${PROJECT_NAME}
         proxyStage.cpp
         proxyShapeNotice.cpp
         render.cpp
-        sceneRenderSettings.cpp
         ufeHandlers.cpp
         undo.cpp
         utils.cpp
@@ -41,10 +40,20 @@ set(HEADERS
     ufeHandlers.h
     proxyShapeNotice.h
     render.h
-    sceneRenderSettings.h
     undo.h
     utils.h
 )
+
+# Requires UsdSettingsNode, only available on supported Maya versions.
+if(MAYA_HAS_USD_SETTINGS_NODES)
+    target_sources(${PROJECT_NAME}
+        PRIVATE
+            sceneRenderSettings.cpp
+    )
+    list(APPEND HEADERS
+        sceneRenderSettings.h
+    )
+endif()
 
 if (UFE_CLIPBOARD_SUPPORT)
     target_sources(${PROJECT_NAME}

--- a/lib/mayaUsdAPI/sceneRenderSettings.cpp
+++ b/lib/mayaUsdAPI/sceneRenderSettings.cpp
@@ -1,0 +1,27 @@
+//
+// Copyright 2026 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "sceneRenderSettings.h"
+
+#include <mayaUsd/nodes/sceneRenderSettings.h>
+
+namespace MAYAUSDAPI_NS_DEF {
+namespace SceneRenderSettings {
+
+PXR_NS::UsdStageRefPtr getUsdStage() { return MayaUsd::SceneRenderSettings::getUsdStage(); }
+
+} // namespace SceneRenderSettings
+} // namespace MAYAUSDAPI_NS_DEF

--- a/lib/mayaUsdAPI/sceneRenderSettings.cpp
+++ b/lib/mayaUsdAPI/sceneRenderSettings.cpp
@@ -23,5 +23,10 @@ namespace SceneRenderSettings {
 
 PXR_NS::UsdStageRefPtr getUsdStage() { return MayaUsd::SceneRenderSettings::getUsdStage(); }
 
+const PXR_NS::TfToken& externalCameraAttrName()
+{
+    return MayaUsd::SceneRenderSettings::externalCameraAttrName();
+}
+
 } // namespace SceneRenderSettings
 } // namespace MAYAUSDAPI_NS_DEF

--- a/lib/mayaUsdAPI/sceneRenderSettings.h
+++ b/lib/mayaUsdAPI/sceneRenderSettings.h
@@ -18,6 +18,7 @@
 
 #include <mayaUsdAPI/api.h>
 
+#include <pxr/base/tf/token.h>
 #include <pxr/pxr.h>
 #include <pxr/usd/usd/stage.h>
 
@@ -29,6 +30,10 @@ namespace SceneRenderSettings {
 
 //! \return the USD stage backing the render-settings singleton.
 MAYAUSD_API_PUBLIC PXR_NS::UsdStageRefPtr getUsdStage();
+
+//! \return the name of the custom attribute holding the UFE path of a
+//!         camera that lives outside the render-settings stage.
+MAYAUSD_API_PUBLIC const PXR_NS::TfToken& externalCameraAttrName();
 
 } // namespace SceneRenderSettings
 

--- a/lib/mayaUsdAPI/sceneRenderSettings.h
+++ b/lib/mayaUsdAPI/sceneRenderSettings.h
@@ -31,7 +31,7 @@ namespace SceneRenderSettings {
 //! \return the USD stage backing the render-settings singleton.
 MAYAUSD_API_PUBLIC PXR_NS::UsdStageRefPtr getUsdStage();
 
-//! \return the name of the custom attribute holding the UFE path of a
+//! \return the name of the custom attribute holding the UFE path string of a
 //!         camera that lives outside the render-settings stage.
 MAYAUSD_API_PUBLIC const PXR_NS::TfToken& externalCameraAttrName();
 

--- a/lib/mayaUsdAPI/sceneRenderSettings.h
+++ b/lib/mayaUsdAPI/sceneRenderSettings.h
@@ -1,0 +1,37 @@
+//
+// Copyright 2026 Autodesk
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef MAYAUSDAPI_SCENE_RENDER_SETTINGS_H
+#define MAYAUSDAPI_SCENE_RENDER_SETTINGS_H
+
+#include <mayaUsdAPI/api.h>
+
+#include <pxr/pxr.h>
+#include <pxr/usd/usd/stage.h>
+
+namespace MAYAUSDAPI_NS_DEF {
+
+//! Public accessors for the process-wide render-settings singleton
+//! (UsdDefaultRenderSettings).
+namespace SceneRenderSettings {
+
+//! \return the USD stage backing the render-settings singleton.
+MAYAUSD_API_PUBLIC PXR_NS::UsdStageRefPtr getUsdStage();
+
+} // namespace SceneRenderSettings
+
+} // namespace MAYAUSDAPI_NS_DEF
+
+#endif // MAYAUSDAPI_SCENE_RENDER_SETTINGS_H

--- a/test/lib/mayaUsd/nodes/testSceneRenderSettings.py
+++ b/test/lib/mayaUsd/nodes/testSceneRenderSettings.py
@@ -18,9 +18,10 @@
 from maya import cmds
 from maya import standalone
 
+import mayaUsd.lib as mayaUsdLib
 from mayaUsd.lib import UsdDefaultRenderSettings
 
-from pxr import Usd, UsdGeom, UsdRender
+from pxr import Sdf, Usd, UsdGeom, UsdRender
 
 import fixturesUtils
 
@@ -326,7 +327,7 @@ class testSceneRenderSettings(unittest.TestCase):
             shutil.rmtree(tmpDir, ignore_errors=True)
 
     # ------------------------------------------------------------------
-    # Active settings UFE path (stage metadata)
+    # Active settings UFE path
     # ------------------------------------------------------------------
 
     def testActiveSettingsPathDefault(self):
@@ -337,8 +338,8 @@ class testSceneRenderSettings(unittest.TestCase):
         self.assertIn(nodeName, activePath)
         self.assertIn('/Render/SceneRenderSettings', activePath)
 
-        stage = UsdDefaultRenderSettings.getUsdStage()
-        self.assertEqual(stage.GetMetadata('activeSettingsPath'), activePath)
+        self.assertEqual(
+            cmds.getAttr(nodeName + '.activeSettingsPath'), activePath)
 
     def testActiveSettingsPathSetter(self):
         '''Writing through the helper updates every read path.'''
@@ -348,8 +349,9 @@ class testSceneRenderSettings(unittest.TestCase):
 
         self.assertEqual(
             UsdDefaultRenderSettings.getActiveRenderSettingsPath(), newPath)
-        stage = UsdDefaultRenderSettings.getUsdStage()
-        self.assertEqual(stage.GetMetadata('activeSettingsPath'), newPath)
+        nodeName = UsdDefaultRenderSettings.find()
+        self.assertEqual(
+            cmds.getAttr(nodeName + '.activeSettingsPath'), newPath)
 
     def testActiveSettingsPathRoundTrip(self):
         '''A custom activeSettingsPath survives a save/open cycle.'''
@@ -419,6 +421,157 @@ class testSceneRenderSettings(unittest.TestCase):
                         "Locked node must keep its name after a rename attempt")
         self.assertEqual(uuidBefore, cmds.ls(nodeName, uuid=True)[0],
                          "Locked node must remain the same MObject after rename")
+
+
+    # ------------------------------------------------------------------
+    # External camera attribute (adskUsd:externalCamera)
+    # ------------------------------------------------------------------
+
+    EXTERNAL_CAMERA_ATTR = 'adskUsd:externalCamera'
+    DEFAULT_EXTERNAL_CAMERA = '|persp'
+
+    def _createUsdProxyWithCamera(self, cameraPrimPath='/cameras/cam1'):
+        '''Create a Maya proxy shape backed by an in-memory stage that
+        contains a UsdGeomCamera at cameraPrimPath. Returns
+        (proxyShapeNode, stage, cameraUfePath) where cameraUfePath is the
+        user-facing UFE form '|proxyParent|proxyShape,/prim'.'''
+        cmds.createNode('mayaUsdProxyShape', name='extCamProxyShape')
+        shapeNode = cmds.ls(sl=True, long=True)[0]
+        cmds.select(clear=True)
+        cmds.connectAttr('time1.outTime', '{}.time'.format(shapeNode))
+        stage = mayaUsdLib.GetPrim(shapeNode).GetStage()
+        UsdGeom.Camera.Define(stage, cameraPrimPath)
+        cameraUfePath = '{}{}'.format(shapeNode, cameraPrimPath)
+        return shapeNode, stage, cameraUfePath
+
+    def testExternalCameraDefaultValue(self):
+        '''The singleton's default render-settings prim is pre-populated with
+        adskUsd:externalCamera = "|persp" and has no schema camera
+        relationship targets.'''
+        prim = UsdDefaultRenderSettings.getDefaultRenderSettingsPrim()
+        self.assertTrue(prim.IsValid())
+
+        attr = prim.GetAttribute(self.EXTERNAL_CAMERA_ATTR)
+        self.assertTrue(attr.IsValid(),
+                        '%s should be authored on the default prim'
+                        % self.EXTERNAL_CAMERA_ATTR)
+        self.assertEqual(attr.Get(), self.DEFAULT_EXTERNAL_CAMERA)
+
+        cameraRel = UsdRender.Settings(prim).GetCameraRel()
+        self.assertEqual(cameraRel.GetTargets(), [])
+
+    def testExternalCameraAttrName(self):
+        '''The Python binding exposes the canonical attribute name.'''
+        self.assertEqual(UsdDefaultRenderSettings.externalCameraAttrName(),
+                         self.EXTERNAL_CAMERA_ATTR)
+
+    def testSetCameraSameStage(self):
+        '''Setting a camera on the same stage authors the schema relationship
+        and removes any pre-existing external-camera attribute.'''
+        stage = UsdDefaultRenderSettings.getUsdStage()
+        cameraPrim = UsdGeom.Camera.Define(stage, '/Render/Cam1').GetPrim()
+
+        prim = UsdDefaultRenderSettings.getDefaultRenderSettingsPrim()
+        self.assertTrue(prim.HasAttribute(self.EXTERNAL_CAMERA_ATTR))
+
+        self.assertTrue(
+            UsdDefaultRenderSettings.setCamera(prim, cameraPrim.GetPath().pathString))
+
+        self.assertFalse(
+            prim.HasAttribute(self.EXTERNAL_CAMERA_ATTR),
+            'External camera attribute should be removed when a same-stage '
+            'camera is set')
+        self.assertEqual(
+            UsdRender.Settings(prim).GetCameraRel().GetTargets(),
+            [Sdf.Path('/Render/Cam1')])
+
+    def testSetCameraMayaNative(self):
+        '''Setting a Maya native camera UFE path authors the external
+        attribute and clears the schema relationship targets.'''
+        stage = UsdDefaultRenderSettings.getUsdStage()
+        cameraPrim = UsdGeom.Camera.Define(stage, '/Render/Cam1').GetPrim()
+        prim = UsdDefaultRenderSettings.getDefaultRenderSettingsPrim()
+
+        # Seed the relationship so the assertion below confirms it is cleared
+        # by the subsequent setCamera call to a Maya-native path.
+        UsdDefaultRenderSettings.setCamera(prim, cameraPrim.GetPath().pathString)
+        self.assertEqual(
+            UsdRender.Settings(prim).GetCameraRel().GetTargets(),
+            [Sdf.Path('/Render/Cam1')])
+
+        self.assertTrue(
+            UsdDefaultRenderSettings.setCamera(prim, '|persp|perspShape'))
+
+        self.assertEqual(
+            UsdRender.Settings(prim).GetCameraRel().GetTargets(), [])
+        attr = prim.GetAttribute(self.EXTERNAL_CAMERA_ATTR)
+        self.assertTrue(attr.IsValid())
+        self.assertEqual(attr.Get(), '|persp|perspShape')
+
+    def testSetCameraDifferentStage(self):
+        '''A UsdGeomCamera on a different stage routes through the external
+        attribute, not the schema relationship.'''
+        proxyShape, _proxyStage, cameraUfePath = self._createUsdProxyWithCamera()
+
+        prim = UsdDefaultRenderSettings.getDefaultRenderSettingsPrim()
+        self.assertTrue(UsdDefaultRenderSettings.setCamera(prim, cameraUfePath))
+
+        self.assertEqual(
+            UsdRender.Settings(prim).GetCameraRel().GetTargets(), [])
+        attr = prim.GetAttribute(self.EXTERNAL_CAMERA_ATTR)
+        self.assertTrue(attr.IsValid())
+        self.assertEqual(attr.Get(), cameraUfePath)
+
+    def testSetCameraInvalidPrim(self):
+        '''Invalid prim or non-RenderSettings prim returns False.'''
+        invalidPrim = Usd.Prim()
+        self.assertFalse(
+            UsdDefaultRenderSettings.setCamera(invalidPrim, '|persp|perspShape'))
+
+        stage = UsdDefaultRenderSettings.getUsdStage()
+        nonSettings = UsdGeom.Xform.Define(stage, '/Render/NotSettings').GetPrim()
+        self.assertFalse(
+            UsdDefaultRenderSettings.setCamera(nonSettings, '|persp|perspShape'))
+
+    def testSetCameraRoundTrip(self):
+        '''An external camera value survives a save/open cycle.'''
+        prim = UsdDefaultRenderSettings.getDefaultRenderSettingsPrim()
+        customCameraPath = '|some|custom|cameraShape'
+        self.assertTrue(
+            UsdDefaultRenderSettings.setCamera(prim, customCameraPath))
+
+        tmpDir = tempfile.mkdtemp(prefix='testSceneRenderSettings_')
+        try:
+            tmpFile = os.path.join(tmpDir, 'externalCameraRoundTrip.ma')
+            cmds.file(rename=tmpFile)
+            cmds.file(save=True, type='mayaAscii')
+            cmds.file(new=True, force=True)
+            cmds.file(tmpFile, open=True, force=True)
+
+            primAfter = UsdDefaultRenderSettings.getDefaultRenderSettingsPrim()
+            attr = primAfter.GetAttribute(self.EXTERNAL_CAMERA_ATTR)
+            self.assertTrue(attr.IsValid())
+            self.assertEqual(attr.Get(), customCameraPath)
+        finally:
+            cmds.file(new=True, force=True)
+            shutil.rmtree(tmpDir, ignore_errors=True)
+
+    def testExternalCameraDefaultRestoredOnFileNew(self):
+        '''File > New restores the populator-authored default value, even
+        after a prior override on the singleton's prim.'''
+        prim = UsdDefaultRenderSettings.getDefaultRenderSettingsPrim()
+        self.assertTrue(
+            UsdDefaultRenderSettings.setCamera(prim, '|some|other|cameraShape'))
+        self.assertEqual(
+            prim.GetAttribute(self.EXTERNAL_CAMERA_ATTR).Get(),
+            '|some|other|cameraShape')
+
+        cmds.file(new=True, force=True)
+
+        primAfter = UsdDefaultRenderSettings.getDefaultRenderSettingsPrim()
+        self.assertEqual(
+            primAfter.GetAttribute(self.EXTERNAL_CAMERA_ATTR).Get(),
+            self.DEFAULT_EXTERNAL_CAMERA)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Move the var storing the active settings from Stage MetaData to an attritube on the Maya Node.
Support for External Camera.
Minimal public API for the SceneRenderSettings.