### PR TITLE
EMSUSD-3714 - Add option to build arm64 only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,12 +130,12 @@ if (BUILD_MAYAUSD_LIBRARY)
     find_package(Maya 2022 REQUIRED)
 endif()
 
-if(APPLE)
+if(Maya_FOUND AND APPLE)
     if(BUILD_ARM64 AND NOT (MAYA_MACOSX_BUILT_WITH_ARM64 OR MAYA_MACOSX_BUILT_WITH_UB2))
         # When forcing arm64 only build, Maya can be either arm64 or UB2.
-        message(FATAL_ERROR "Building MayaUsd with Arm64, but Maya was NOT built with arm64 (or UB2)")
+        message(FATAL_ERROR "Building MayaUsd with arm64, but Maya was NOT built with arm64 (or UB2)")
     elseif(BUILD_UB2 AND NOT MAYA_MACOSX_BUILT_WITH_UB2)
-        message(FATAL_ERROR "Building MayaUSD with UB2, but Maya was NOT built with UB2")
+        message(FATAL_ERROR "Building MayaUsd with UB2, but Maya was NOT built with UB2")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,8 @@ option(BUILD_STRICT_MODE "Enforce all warnings as errors." ON)
 option(BUILD_SHARED_LIBS "Build libraries as shared or static." ON)
 option(BUILD_WITH_PYTHON_3 "Build with python 3." OFF)
 if(APPLE)
-    option(BUILD_UB2 "Build Universal Binary 2 (UB2) Intel64+arm64" OFF)
+    option(BUILD_UB2 "Build Universal Binary 2 (UB2) Intel64+arm64" ON) # Min Maya supported is 2024 which is UB2
+    option(BUILD_ARM64 "Build arm64 only" OFF)                          # Either arm or UB2 can be built, but not both.
 endif()
 set(BUILD_WITH_PYTHON_3_VERSION 3.7 CACHE STRING "The version of Python 3 to build with")
 option(CMAKE_WANT_MATERIALX_BUILD "Enable building with MaterialX." ON)
@@ -84,14 +85,28 @@ set(MAYAUSD_CUT_ID "DEVBLD" CACHE STRING "MayaUsd cut-id corresponding to this b
 # Avoid noisy install messages
 set(CMAKE_INSTALL_MESSAGE "NEVER")
 
+#------------------------------------------------------------------------------
+# Apple architectures and deployment targets
+#------------------------------------------------------------------------------
 if(APPLE)
+    # If both BUILD_UB2 and BUILD_ARM64 were specified, throw error.
+    if(BUILD_UB2 AND BUILD_ARM64)
+        message(FATAL_ERROR "BUILD_UB2 and BUILD_ARM64 are mutually exclusive, specify either one or neither.")
+    endif()
+
     if(BUILD_UB2)
         message(STATUS "Building with Universal Binary 2")
         set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
-        set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0)
+        set(DEFAULT_OSX_DEPLOYMENT_TARGET 11.0)
+    elseif(BUILD_ARM64)
+        set(CMAKE_OSX_ARCHITECTURES "arm64")
+        set(DEFAULT_OSX_DEPLOYMENT_TARGET 14.0)
     else()
         set(CMAKE_OSX_ARCHITECTURES "x86_64")
-        set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14)
+        set(DEFAULT_OSX_DEPLOYMENT_TARGET 10.14)
+    endif()
+    if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
+        set(CMAKE_OSX_DEPLOYMENT_TARGET ${DEFAULT_OSX_DEPLOYMENT_TARGET})
     endif()
 endif()
 
@@ -115,8 +130,13 @@ if (BUILD_MAYAUSD_LIBRARY)
     find_package(Maya 2022 REQUIRED)
 endif()
 
-if(APPLE AND BUILD_UB2 AND NOT MAYA_MACOSX_BUILT_WITH_UB2)
-    message(WARNING  "Maya was NOT built with Universal Binary 2")
+if(APPLE)
+    if(BUILD_ARM64 AND NOT (MAYA_MACOSX_BUILT_WITH_ARM64 OR MAYA_MACOSX_BUILT_WITH_UB2))
+        # When forcing arm64 only build, Maya can be either arm64 or UB2.
+        message(FATAL_ERROR "Building MayaUsd with Arm64, but Maya was NOT built with arm64 (or UB2)")
+    elseif(BUILD_UB2 AND NOT MAYA_MACOSX_BUILT_WITH_UB2)
+        message(FATAL_ERROR "Building MayaUSD with UB2, but Maya was NOT built with UB2")
+    endif()
 endif()
 
 if (BUILD_MAYAUSD_LIBRARY)

--- a/cmake/compiler_config.cmake
+++ b/cmake/compiler_config.cmake
@@ -15,7 +15,6 @@ set(GNU_CLANG_FLAGS
     -Wno-unused-local-typedefs
 )
 
-
 if(IS_GNU)
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14)
         # This is to work around a warning that comes from OpenUSD VtValue header

--- a/cmake/compiler_config.cmake
+++ b/cmake/compiler_config.cmake
@@ -6,8 +6,6 @@ set(GNU_CLANG_FLAGS
     -Wall
     $<$<BOOL:${BUILD_STRICT_MODE}>:-Werror>
     $<$<CONFIG:DEBUG>:-fstack-check>
-    # optimization
-    -msse4.2
     # According to gcc help, -Og should be the optimization level of choice.
     # It is a better choice that default -O0 for producing debuggable code.
     $<$<CONFIG:DEBUG>:-Og>
@@ -16,6 +14,7 @@ set(GNU_CLANG_FLAGS
     -Wno-deprecated-declarations
     -Wno-unused-local-typedefs
 )
+
 
 if(IS_GNU)
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14)
@@ -28,12 +27,25 @@ if(IS_GNU)
                 $<$<STREQUAL:${CMAKE_BUILD_TYPE},Debug>:-Wno-uninitialized>
         )
     endif()
+    list(APPEND GNU_CLANG_FLAGS
+        # optimization
+        -msse4.2
+    )
 endif()
 
 if (IS_CLANG)
     list(APPEND GNU_CLANG_FLAGS
             -Wrange-loop-analysis
     )
+    # The flag -msse4.2 tells the compiler to use Intel-specific "Streaming SIMD Extensions."
+    # Because ARM-based processors (like the Apple M-series) do not support SSE, the compiler ignores the flag.
+    # That will cause build error since we have warnings as errors on.
+    if(NOT BUILD_ARM64)
+        list(APPEND GNU_CLANG_FLAGS
+            # optimization
+            -msse4.2
+        )
+    endif()
 endif()
 
 set(MSVC_FLAGS

--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -32,6 +32,7 @@
 # MAYA_CAMERA_GIZMO_SUPPORT Support for drawing Ufe cameras and lights in the viewport.
 # MAYA_LINUX_BUILT_WITH_CXX11_ABI Maya Linux was built with new cxx11 ABI.
 # MAYA_MACOSX_BUILT_WITH_UB2 Maya OSX was built with Universal Binary 2.
+# MAYA_MACOSX_BUILT_WITH_ARM64 Maya OSX was built with arm64 only.
 
 #=============================================================================
 # Copyright 2011-2012 Francisco Requena <frarees@gmail.com>
@@ -495,9 +496,8 @@ if(IS_LINUX AND MAYA_Foundation_LIBRARY)
 endif()
 
 set(MAYA_MACOSX_BUILT_WITH_UB2 FALSE CACHE INTERNAL "MayaMacOSXBuiltWithUB2")
+set(MAYA_MACOSX_BUILT_WITH_ARM64 FALSE CACHE INTERNAL "MayaMacOSXBuiltWithArm64")
 if(IS_MACOSX AND MAYA_Foundation_LIBRARY)
-    # Determine if Maya (on OSX) was built with Universal Binary 2 (x86_64 & arm64).
-    # If yes, then MayaUsd can be built with either: Intel, Arm or both.
     execute_process(
         COMMAND
             lipo -archs "${MAYA_Foundation_LIBRARY}"
@@ -505,13 +505,19 @@ if(IS_MACOSX AND MAYA_Foundation_LIBRARY)
             ${MAYA_LIBRARY_DIR}
         OUTPUT_VARIABLE
             maya_lipo_output)
-    string(REGEX MATCHALL "(x86_64|arm64)" maya_ub2_match ${maya_lipo_output})
-    if (maya_ub2_match)
-        list(FIND maya_ub2_match "x86_64" ub2_index1)
-        list(FIND maya_ub2_match "arm64" ub2_index2)
-        if((NOT (${ub2_index1} STREQUAL "-1")) AND (NOT (${ub2_index2} STREQUAL "-1")))
+    string(REGEX MATCHALL "(x86_64|arm64)" maya_arch_match ${maya_lipo_output})
+    if (maya_arch_match)
+        list(FIND maya_arch_match "x86_64" x86_index1)
+        list(FIND maya_arch_match "arm64" arm64_index2)
+        # Determine if Maya (on OSX) was built with Universal Binary 2 (x86_64 & arm64).
+        # If yes, then MayaUsd can be built with either: Intel, Arm or both.
+        if((NOT (${x86_index1} STREQUAL "-1")) AND (NOT (${arm64_index2} STREQUAL "-1")))
             set(MAYA_MACOSX_BUILT_WITH_UB2 TRUE CACHE INTERNAL "MayaMacOSXBuiltWithUB2")
             message(STATUS "MacOSX: Maya was built with Universal Binary 2 (x86_64/arm64)")
+        # Determine if Maya (on OSX) was built with Arm64 only. If yes, then MayaUsd MUST be built with Arm64.
+        elseif(NOT (${arm64_index2} STREQUAL "-1"))
+            set(MAYA_MACOSX_BUILT_WITH_ARM64 TRUE CACHE INTERNAL "MayaMacOSXBuiltWithArm64")
+            message(STATUS "MacOSX: Maya was built with Arm64 only")
         endif()
     endif()
 endif()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -302,8 +302,8 @@ function(get_external_project_default_values out_var)
     external_project_conditional_define(CMAKE_BUILD_TYPE)
     external_project_conditional_define(CMAKE_MAKE_PROGRAM)
 
-    if(BUILD_UB2)
-        # UB2 builds require this flag
+    if(APPLE)
+        # OSX builds require these flags
         external_project_conditional_define(CMAKE_OSX_ARCHITECTURES)
         external_project_conditional_define(CMAKE_OSX_DEPLOYMENT_TARGET)
     endif()

--- a/doc/build.md
+++ b/doc/build.md
@@ -137,8 +137,8 @@ BUILD_TESTS                 | builds all unit tests.                            
 BUILD_STRICT_MODE           | enforces all warnings as errors.                           | ON
 BUILD_WITH_PYTHON_3         | build with python 3.                                       | OFF
 BUILD_SHARED_LIBS           | build libraries as shared or static.                       | ON
-BUILD_UB2                   | build Universal binary 2 (UB2) Intel64+arm64 (OSX only)    | ON
-BUILD_ARM64                 | build arm64 architecture (OSX only)                        | OFF
+BUILD_UB2                   | build Universal binary 2 (UB2) Intel64+arm64 (OSX only)<br><b>note</b>: mutually exclusive with BUILD_ARM64 | ON
+BUILD_ARM64                 | build arm64 architecture (OSX only)<br><b>note</b>: mutually exclusive with BUILD_UB2 | OFF
 CMAKE_WANT_MATERIALX_BUILD  | enable building with MaterialX (experimental).             | OFF
 
 ##### Stages

--- a/doc/build.md
+++ b/doc/build.md
@@ -135,9 +135,10 @@ BUILD_HDMAYA                | builds the legacy Maya-To-Hydra plugin and scene d
 BUILD_RFM_TRANSLATORS       | builds translators for RenderMan for Maya shaders.         | ON
 BUILD_TESTS                 | builds all unit tests.                                     | ON
 BUILD_STRICT_MODE           | enforces all warnings as errors.                           | ON
-BUILD_WITH_PYTHON_3			| build with python 3.										 | OFF
-BUILD_SHARED_LIBS			| build libraries as shared or static.						 | ON
-BUILD_UB2                   | build universal binary 2 (UB2) Intel64+arm64 (apple only)  | OFF
+BUILD_WITH_PYTHON_3         | build with python 3.                                       | OFF
+BUILD_SHARED_LIBS           | build libraries as shared or static.                       | ON
+BUILD_UB2                   | build Universal binary 2 (UB2) Intel64+arm64 (OSX only)    | ON
+BUILD_ARM64                 | build arm64 architecture (OSX only)                        | OFF
 CMAKE_WANT_MATERIALX_BUILD  | enable building with MaterialX (experimental).             | OFF
 
 ##### Stages


### PR DESCRIPTION
#### EMSUSD-3714 - Add option to build arm64 only
* Make UB2 default and add new option to build only arm64.
* Added detection if Maya was built arm64 only.
* Remove -msse compiler flag for arm64 (not needed), but issues warning.