### PR TITLE
OrphanedNodesManager: Avoid Python exception on stale pulled prims

### DIFF
--- a/lib/mayaUsd/fileio/orphanedNodesManager.cpp
+++ b/lib/mayaUsd/fileio/orphanedNodesManager.cpp
@@ -691,7 +691,7 @@ void OrphanedNodesManager::recursiveSwitch(
         TF_VERIFY(trieNode->empty());
 
         auto pulledNode = MayaUsd::ufe::downcast(Ufe::Hierarchy::createItem(ufePath));
-        if (!TF_VERIFY(pulledNode)) {
+        if (pulledNode == nullptr) {
             return;
         }
 
@@ -703,10 +703,9 @@ void OrphanedNodesManager::recursiveSwitch(
         const PullVariantInfos infos = trieNode->data();
         for (const PullVariantInfo& variantInfo : infos) {
             const auto& originalDesc = variantInfo.variantSetDescriptors;
-            const bool  variantSetsMatch = (originalDesc == currentDesc);
-            const bool  orphaned = (pulledNode && !variantSetsMatch);
-            if (processOrphans == orphaned)
-                TF_VERIFY(setOrphaned(trieNode, variantInfo, orphaned));
+            const bool  orphanedByVariant = (originalDesc != currentDesc);
+            if (processOrphans == orphanedByVariant)
+                TF_VERIFY(setOrphaned(trieNode, variantInfo, orphanedByVariant));
         }
     } else {
         const bool isGatewayToUsd = Ufe::SceneSegmentHandler::isGateway(ufePath);

--- a/test/lib/mayaUsd/fileio/testHideOrphanedNodes.py
+++ b/test/lib/mayaUsd/fileio/testHideOrphanedNodes.py
@@ -401,5 +401,23 @@ class HideOrphanedNodesTestCase(unittest.TestCase):
         cmds.undo()
         self.assertTrue(pullParentVisibilityPlug[self.cPathStr].asBool())
 
+    def testStructuralEditAfterInactiveAncestor(self):
+        with mayaUsd.lib.OpUndoItemList():
+            self.assertTrue(mayaUsd.lib.PrimUpdaterManager.editAsMaya(self.cPathStr))
+
+        cPrim = mayaUsd.ufe.ufePathToPrim(self.cPathStr)
+        aPrim = cPrim.GetParent().GetParent()
+
+        # Make the pulled path stale: /A/B/C is no longer composed because /A is inactive.
+        aPrim.SetActive(False)
+
+        # A structural USD change used to raise a pxr.Tf.ErrorException from OrphanedNodesManager::recursiveSwitch(),
+        # because UFE could no longer create an item for the uncomposed pulled prim /A/B/C.
+        try:
+            aPrim.GetVariantSets().AddVariantSet("testVariantSet").AddVariant("testVariant")
+        except Exception as exc:
+            self.fail("An unwanted exception was raised: {}".format(exc))
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
This fixes an issue seen when a prim is edited as Maya, then one of its ancestors is deactivated without first discarding the descendant edit.

In that state, `MayaUsd::OrphanedNodesManager` still tracks the pulled prim path, but that path can no longer be resolved to a prim or UFE item. A later structural change on an ancestor can make the manager revisit the stale path. Previously, this hit `TF_VERIFY(pulledNode)`, which propagated to Python as a `pxr.Tf.ErrorException` during an otherwise unrelated USD API call.

This change simply avoids the `TF_VERIFY` for this currently possible scenario.
I also added a regression test to cover it.

Example repro:

```python
from maya import cmds
import mayaUsd.ufe

proxy_path = mayaUsd.ufe.createStageWithNewLayer("")
stage = mayaUsd.ufe.getStage(proxy_path)

ancestor = stage.DefinePrim("/A", "Xform")

# Create a descendant prim and edit it as Maya.
stage.DefinePrim("/A/B", "Xform")
cmds.mayaUsdEditAsMaya(proxy_path + ",/A/B")

# Make the pulled path stale: /A/B is no longer composed because /A is inactive.
ancestor.SetActive(False)

# Make a structural USD edit on the inactive ancestor.
# This used to raise pxr.Tf.ErrorException and interrupt subsequent code.
ancestor.GetVariantSets().AddVariantSet("foo").AddVariant("bar")
```