### PR TITLE
EMSUSD-2801 renaming prim in reference

### DIFF
--- a/lib/usdUfe/ufe/UsdUndoRenameCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoRenameCommand.cpp
@@ -239,6 +239,17 @@ void UsdUndoRenameCommand::renameHelper(
     // the renamed scene item is a "sibling" of its original name.
     ufeDstItem = createSiblingSceneItem(srcPath, newName);
 
+    // Verify the destination item is valid: the rename could have failed
+    // if there were any issues with the underlying layers.
+    if (!ufeDstItem || !ufeDstItem->prim().IsValid()) {
+        const std::string error = TfStringPrintf(
+            "Failed to rename prim \"%s\" to \"%s\"",
+            srcPath.string().c_str(),
+            dstPath.string().c_str());
+        TF_WARN("%s.", error.c_str());
+        throw std::runtime_error(error);
+    }
+
     // update stage's default prim
     if (ufeSrcItem->prim().GetPath() == defaultPrimPath) {
         stage->SetDefaultPrim(ufeDstItem->prim());

--- a/test/lib/ufe/testRename.py
+++ b/test/lib/ufe/testRename.py
@@ -764,6 +764,31 @@ class RenameTestCase(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             cmds.rename("banana")
 
+    def testRenameNonLocalPrim(self):
+        '''
+        Verify that a prim in a reference cannot be renamed.
+        '''
+        cmds.file(new=True, force=True)
+        testFile = testUtils.getTestScene('cubeRef', 'cube-root.usda')
+        shapeNode, stage = mayaUtils.createProxyFromFile(testFile)
+
+        cubePath = ufe.PathString.path(shapeNode + ',/RootPrim/PrimWithRef/CubeMesh')
+        cubeItem = ufe.Hierarchy.createItem(cubePath)
+        self.assertIsNotNone(cubeItem)
+        ufe.GlobalSelection.get().append(cubeItem)
+
+        sessionLayer = stage.GetSessionLayer()
+        self.assertIsNotNone(sessionLayer)
+        stage.SetEditTarget(sessionLayer)
+        self.assertEqual(stage.GetEditTarget().GetLayer(), sessionLayer)
+        
+        with self.assertRaises(RuntimeError):
+            try:
+                cmds.rename("banana")
+            except RuntimeError as e:
+                self.assertIn("Failed to rename prim", str(e))
+                raise
+
     def testRenameUniqueName(self):
         # open tree.ma scene in testSamples
         mayaUtils.openTreeScene()


### PR DESCRIPTION
- Detect that the renamed failed by detecting that the UFE destination item is invalid.
- Added a unit test.