### PR TITLE
Default RenderSettings node : fix for loading the MayaUSD plugin during file load.

### DIFF
--- a/lib/mayaUsd/nodes/usdSceneSettingsManager.cpp
+++ b/lib/mayaUsd/nodes/usdSceneSettingsManager.cpp
@@ -248,7 +248,7 @@ void UsdSceneSettingsManager::onPluginInitialize()
     // create nodes for all registered node names now.
     //
     // Skip when the plugin is loaded mid-file-read (via a "requires" statement
-    // in the .ma file). In that case the file's createNode commands have not run
+    // in the Maya file). In that case the file's createNode commands have not run
     // yet; pre-creating the node here would take the canonical name and cause
     // Maya to rename the file's version, orphaning its serialized attribute data.
     // onAfterOpen will handle creation and deserialization once the file is done.

--- a/lib/mayaUsd/nodes/usdSceneSettingsManager.cpp
+++ b/lib/mayaUsd/nodes/usdSceneSettingsManager.cpp
@@ -19,6 +19,7 @@
 #include <mayaUsd/utils/blockSceneModificationContext.h>
 
 #include <maya/MDGModifier.h>
+#include <maya/MFileIO.h>
 #include <maya/MFnDependencyNode.h>
 #include <maya/MGlobal.h>
 #include <maya/MItDependencyNodes.h>
@@ -234,7 +235,7 @@ void UsdSceneSettingsManager::onPluginInitialize()
     CHECK_MSTATUS(status);
 
     afterOpenCbId = MSceneMessage::addCallback(
-        MSceneMessage::kAfterSceneReadAndRecordEdits, onAfterOpen, nullptr, &status);
+        MSceneMessage::kAfterOpen, onAfterOpen, nullptr, &status);
     CHECK_MSTATUS(status);
 
     beforeSaveCbId
@@ -245,8 +246,16 @@ void UsdSceneSettingsManager::onPluginInitialize()
 
     // kAfterNew does not fire for the default scene present at Maya startup;
     // create nodes for all registered node names now.
-    for (const auto& [nodeName, populate] : registry()) {
-        findOrCreate(nodeName);
+    //
+    // Skip when the plugin is loaded mid-file-read (via a "requires" statement
+    // in the .ma file). In that case the file's createNode commands have not run
+    // yet; pre-creating the node here would take the canonical name and cause
+    // Maya to rename the file's version, orphaning its serialized attribute data.
+    // onAfterOpen will handle creation and deserialization once the file is done.
+    if (!MFileIO::isReadingFile()) {
+        for (const auto& [nodeName, populate] : registry()) {
+            findOrCreate(nodeName);
+        }
     }
 }
 
@@ -387,13 +396,9 @@ void UsdSceneSettingsManager::onAfterOpen(void* /*clientData*/)
     // Rebuild the instance map from what was actually loaded from the file.
     rebuildInstancesFromScene();
 
-    // Deserialize each found node, but only when the stage is not yet live.
-    // kAfterSceneReadAndRecordEdits fires for File > Open, Import, and Reference;
-    // skipping nodes whose stage already exists avoids clobbering live data when
-    // the trigger is an Import or Reference rather than a fresh Open.
     for (const auto& [nodeName, handle] : instances()) {
         UsdSettingsNode* node = nodeFromHandle(handle);
-        if (node && !node->hasStage()) {
+        if (node) {
             node->deserializeFromAttributes();
         }
     }

--- a/lib/mayaUsd/nodes/usdSceneSettingsManager.cpp
+++ b/lib/mayaUsd/nodes/usdSceneSettingsManager.cpp
@@ -234,8 +234,8 @@ void UsdSceneSettingsManager::onPluginInitialize()
         = MSceneMessage::addCallback(MSceneMessage::kAfterNew, onAfterNew, nullptr, &status);
     CHECK_MSTATUS(status);
 
-    afterOpenCbId = MSceneMessage::addCallback(
-        MSceneMessage::kAfterOpen, onAfterOpen, nullptr, &status);
+    afterOpenCbId
+        = MSceneMessage::addCallback(MSceneMessage::kAfterOpen, onAfterOpen, nullptr, &status);
     CHECK_MSTATUS(status);
 
     beforeSaveCbId


### PR DESCRIPTION
- .ma file is opened → Maya reads requires mayaUsdPlugin → plugin loads mid-read
- onPluginInitialize() immediately calls findOrCreate("UsdDefaultRenderSettings") → creates a locked empty node before the file's createNode runs
- Maya reads createNode UsdDefaultSettings -n "UsdDefaultRenderSettings" → name taken and locked → Maya renames it to UsdDefaultRenderSettings1
- All setAttr commands (the serialized USD layers) are written to UsdDefaultRenderSettings1