### PR TITLE
EMSUSD-3706 correctly handle locked layers when merging layers

### DIFF
--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -827,47 +827,58 @@ public:
         const SdfLayerHandleVector stageLayers = stage->GetLayerStack();
 
         // Sort the selected layers by their strength (strongest first).
-        std::unordered_map<std::string, size_t> layerStrengthMap;
-        layerStrengthMap.reserve(stageLayers.size());
-        for (size_t i = 0; i < stageLayers.size(); ++i)
-            layerStrengthMap[stageLayers[i]->GetIdentifier()] = i;
+        {
+            std::unordered_map<std::string, size_t> layerStrengthMap;
+            layerStrengthMap.reserve(stageLayers.size());
+            for (size_t i = 0; i < stageLayers.size(); ++i)
+                layerStrengthMap[stageLayers[i]->GetIdentifier()] = i;
 
-        std::sort(
-            _layerIdentifiersByStrength.begin(),
-            _layerIdentifiersByStrength.end(),
-            [&layerStrengthMap](const std::string& a, const std::string& b) {
-                const auto itA = layerStrengthMap.find(a);
-                const auto itB = layerStrengthMap.find(b);
-                if (itA == layerStrengthMap.end()) {
-                    TF_WARN("Layer '%s' not found in stage layer stack", a.c_str());
+            std::sort(
+                _layerIdentifiersByStrength.begin(),
+                _layerIdentifiersByStrength.end(),
+                [&layerStrengthMap](const std::string& a, const std::string& b) {
+                    const auto itA = layerStrengthMap.find(a);
+                    const auto itB = layerStrengthMap.find(b);
+                    if (itA == layerStrengthMap.end()) {
+                        TF_WARN("Layer '%s' not found in stage layer stack", a.c_str());
+                        return false;
+                    }
+                    if (itB == layerStrengthMap.end()) {
+                        TF_WARN("Layer '%s' not found in stage layer stack", b.c_str());
+                        return true;
+                    }
+                    return itA->second < itB->second;
+                });
+        }
+
+        // We will analyze locked layers before doing any modification,
+        // report all problem and abort the command if any layer is locked.
+        bool hasProblems = false;
+
+        // Convert the list of layer identifier to a list of layer handles.
+        SdfLayerHandleVector layersByStrength;
+        {
+            layersByStrength.reserve(_layerIdentifiersByStrength.size());
+            for (const auto& layerIdentifier : _layerIdentifiersByStrength) {
+                auto layer = SdfLayer::FindOrOpen(layerIdentifier);
+                if (!layer) {
+                    TF_RUNTIME_ERROR("Cannot find layer: %s", layerIdentifier.c_str());
                     return false;
                 }
-                if (itB == layerStrengthMap.end()) {
-                    TF_WARN("Layer '%s' not found in stage layer stack", b.c_str());
-                    return true;
+                if (!layer->PermissionToEdit()) {
+                    TF_WARN(
+                        "Cannot update layer '%s' because it is locked.",
+                        layer->GetDisplayName().c_str());
+                    hasProblems = true;
                 }
-                return itA->second < itB->second;
-            });
-
-        SdfLayerHandleVector layersByStrength;
-        layersByStrength.reserve(_layerIdentifiersByStrength.size());
-        for (const auto& layerIdentifier : _layerIdentifiersByStrength) {
-            auto layer = SdfLayer::FindOrOpen(layerIdentifier);
-            if (!layer) {
-                TF_RUNTIME_ERROR("Cannot find layer: %s", layerIdentifier.c_str());
-                return false;
+                layersByStrength.push_back(layer);
             }
-            layersByStrength.push_back(layer);
         }
 
         const SdfLayerHandle strongestLayer = layersByStrength[0];
 
-        holdOntoSubLayers(strongestLayer);
-
-        // Keep a hold of references for all selected layers, needed for undo().
-        for (size_t i = 1; i < layersByStrength.size(); ++i)
-            _subLayersRefs.push_back(layersByStrength[i]);
-
+        // Create a map from layer identifier to its parent layer and subLayerPath,
+        // to be used for stitching and removals.
         std::map<std::string, std::pair<SdfLayerHandle, std::string>> parentInfoByLayer;
         for (const auto& potentialParent : stageLayers) {
             const std::vector<std::string>& subLayerPaths = potentialParent->GetSubLayerPaths();
@@ -883,17 +894,44 @@ public:
         // Multiple selected weak layers may share the same parent, so batch removals by parent
         // to avoid calling SetSubLayerPaths more than once per parent layer.
         std::map<std::string, std::vector<std::string>> removalsByParent;
-        for (size_t i = 1; i < layersByStrength.size(); ++i) {
-            const SdfLayerHandle& weakLayer = layersByStrength[i];
-            const std::string     weakLayerId = weakLayer->GetIdentifier();
+        {
+            for (size_t i = 1; i < layersByStrength.size(); ++i) {
+                const SdfLayerHandle& weakLayer = layersByStrength[i];
+                const std::string     weakLayerId = weakLayer->GetIdentifier();
 
-            const auto& it = parentInfoByLayer.find(weakLayerId);
-            if (it != parentInfoByLayer.end()) {
-                removalsByParent[it->second.first->GetIdentifier()].push_back(it->second.second);
-            } else {
-                TF_WARN("Could not find parent for layer: %s", weakLayerId.c_str());
+                const auto& it = parentInfoByLayer.find(weakLayerId);
+                if (it == parentInfoByLayer.end()) {
+                    TF_WARN(
+                        "Could not find parent for layer: %s", weakLayer->GetDisplayName().c_str());
+                    hasProblems = true;
+                    continue;
+                }
+
+                SdfLayerHandle parenttLayer = it->second.first;
+                if (!parenttLayer->PermissionToEdit()) {
+                    TF_WARN(
+                        "Cannot update layer '%s' because its parent '%s' is locked.",
+                        weakLayer->GetDisplayName().c_str(),
+                        parenttLayer->GetDisplayName().c_str());
+                    hasProblems = true;
+                    continue;
+                }
+
+                auto parentLayerId = parenttLayer->GetIdentifier();
+                auto removeLayerPath = it->second.second;
+                removalsByParent[parentLayerId].push_back(removeLayerPath);
             }
         }
+
+        if (hasProblems) {
+            return false;
+        }
+
+        holdOntoSubLayers(strongestLayer);
+
+        // Keep a hold of references for all selected layers, needed for undo().
+        for (size_t i = 1; i < layersByStrength.size(); ++i)
+            _subLayersRefs.push_back(layersByStrength[i]);
 
         UsdUfe::UsdUndoManager::instance().trackLayerStates(strongestLayer);
         for (size_t i = 1; i < layersByStrength.size(); ++i)
@@ -961,22 +999,16 @@ public:
             // Removes the selected weak layers from their parents.
             for (auto& entry : removalsByParent) {
                 const auto parentLayer = SdfLayer::Find(entry.first);
-                if (parentLayer) {
-                    auto subLayerPaths = parentLayer->GetSubLayerPaths();
-                    for (const auto& pathToRemove : entry.second) {
-                        auto it
-                            = std::find(subLayerPaths.begin(), subLayerPaths.end(), pathToRemove);
-                        if (it != subLayerPaths.end())
-                            subLayerPaths.erase(it);
-                    }
-                    if (parentLayer && parentLayer->PermissionToEdit()) {
-                        parentLayer->SetSubLayerPaths(subLayerPaths);
-                    } else {
-                        TF_WARN(
-                            "Cannot update layer '%s' because it is locked.",
-                            strongestLayer->GetIdentifier().c_str());
-                    }
+                if (!parentLayer)
+                    continue;
+
+                auto subLayerPaths = parentLayer->GetSubLayerPaths();
+                for (const auto& pathToRemove : entry.second) {
+                    auto it = std::find(subLayerPaths.begin(), subLayerPaths.end(), pathToRemove);
+                    if (it != subLayerPaths.end())
+                        subLayerPaths.erase(it);
                 }
+                parentLayer->SetSubLayerPaths(subLayerPaths);
             }
         }
 

--- a/test/lib/testMayaUsdLayerEditorCommands.py
+++ b/test/lib/testMayaUsdLayerEditorCommands.py
@@ -1150,6 +1150,45 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
         cmds.undo()
         self.assertEqual(stage.GetEditTarget().GetLayer().identifier, weakLayerId)
 
+    def testStitchLayersWithLockedParentLayer(self):
+        """ Test stitching fails when one selected layer is under a locked parent layer """
+
+        shapePath, stage = getCleanMayaStage()
+        rootLayer = stage.GetRootLayer()
+        rootLayerId = rootLayer.identifier
+
+        layer1Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer1")[0]
+        layer2Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer2")[0]
+        layer3Id = cmds.mayaUsdLayerEditor(layer2Id, edit=True, addAnonymous="Layer3")[0]
+
+        rootLayer.subLayerPaths.clear()
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[0, layer1Id])
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[1, layer2Id])
+
+        layer1 = Sdf.Layer.Find(layer1Id)
+        layer2 = Sdf.Layer.Find(layer2Id)
+        layer3 = Sdf.Layer.Find(layer3Id)
+
+        with Sdf.ChangeBlock():
+            prim = Sdf.CreatePrimInLayer(layer3, '/Cube')
+            prim.SetInfo('typeName', 'Cube')
+
+        self.assertIsNotNone(layer3.GetPrimAtPath('/Cube'))
+        self.assertIsNone(layer1.GetPrimAtPath('/Cube'))
+
+        cmds.mayaUsdLayerEditor(layer2Id, edit=True, lockLayer=(1, 0, shapePath))
+        self.assertFalse(layer2.permissionToEdit)
+
+
+        with self.assertRaises(RuntimeError):
+            cmds.mayaUsdLayerEditor(
+                rootLayerId, edit=True,
+                stitchLayers=((shapePath, layer1Id), (shapePath, layer3Id))
+            )
+
+        self.assertIsNotNone(layer3.GetPrimAtPath('/Cube'))
+        self.assertIsNone(layer1.GetPrimAtPath('/Cube'))
+
     def testStitchLayersPartialSelection(self):
         """ Test stitching only some layers while leaving others untouched """
 


### PR DESCRIPTION
- Reorganised the layer editor stitch command to validate everything before proceeding.
- Detect that all layers that will be affected are not locked.
- Added a unit test for that.