### PR TITLE
Layer Editor: Fix variable expression sublayer evaluation

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -26,6 +26,9 @@
 #include <maya/MQtUtil.h>
 
 #if PXR_VERSION >= 2308
+#include <pxr/usd/pcp/expressionVariables.h>
+#include <pxr/usd/pcp/layerStack.h>
+#include <pxr/usd/pcp/primIndex.h>
 #include <pxr/usd/sdf/variableExpression.h>
 #endif
 
@@ -145,31 +148,24 @@ void LayerTreeItem::populateChildren(RecursionDetector* recursionDetector)
 
     for (auto const path : subPaths) {
 #if PXR_VERSION >= 2308
-        // Resolve any variable expressions in the path using the stage's expression variables
+        // Resolve any variable expressions in the path using the stage's expression variables,
+        // composed from root and session layer variables.
         std::string resolvedPath = path;
         if (_stage && SdfVariableExpression::IsExpression(path)) {
-            auto resolveExprVarsFromLayer =
-                [](SdfVariableExpression& varExpr, SdfLayerRefPtr fromLayer, std::string& outPath) {
-                    if (fromLayer && fromLayer->HasExpressionVariables()) {
-                        auto expressionVars = fromLayer->GetExpressionVariables();
-                        auto result = varExpr.Evaluate(expressionVars);
-                        if (result.errors.empty() && !result.value.IsEmpty()) {
-                            outPath = result.value.UncheckedGet<std::string>();
-                        }
-                    }
-                };
+            const auto& stageRootLayerStack
+                = _stage->GetPseudoRoot().GetPrimIndex().GetRootNode().GetLayerStack();
 
-            SdfVariableExpression varExpr(path);
-            // Get the root layer's expression variables for resolution context
-            auto rootLayer = _stage->GetRootLayer();
-            resolveExprVarsFromLayer(varExpr, rootLayer, resolvedPath);
+            if (stageRootLayerStack) {
+                const auto& expressionVars
+                    = stageRootLayerStack->GetExpressionVariables().GetVariables();
 
-            // Expression variables are composed across session layer and root
-            // layer of a stage. So we do another pass with the session layer
-            // to override/set the resolvedPath in case it is present in the
-            // session layer
-            auto sessionLayer = _stage->GetSessionLayer();
-            resolveExprVarsFromLayer(varExpr, sessionLayer, resolvedPath);
+                const auto result
+                    = SdfVariableExpression(path).EvaluateTyped<std::string>(expressionVars);
+
+                if (result.errors.empty() && !result.value.IsEmpty()) {
+                    resolvedPath = result.value.UncheckedGet<std::string>();
+                }
+            }
         }
 
         std::string actualPath = SdfComputeAssetPathRelativeToLayer(_layer, resolvedPath);

--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -152,7 +152,7 @@ void LayerTreeItem::populateChildren(RecursionDetector* recursionDetector)
         // composed from root and session layer variables.
         std::string resolvedPath = path;
         if (_stage && SdfVariableExpression::IsExpression(path)) {
-            const auto& stageRootLayerStack
+            const auto stageRootLayerStack
                 = _stage->GetPseudoRoot().GetPrimIndex().GetRootNode().GetLayerStack();
 
             if (stageRootLayerStack) {


### PR DESCRIPTION
Resolve sublayer paths using the composed expression variables from the stage, instead of evaluating with root and session layer variables in two separate passes. This better matches how the USD stage internally composes variables and evaluates expressions.

For example, given a stage composed of this root layer:
```
#usda 1.0
(
    expressionVariables = {
        string SUBLAYER_PATH = "./resolved_sublayer.usda"
    }
    subLayers = [
        @`if(${SUBLAYER_ENABLED}, ${SUBLAYER_PATH})`@
    ]
)
```

and this session layer:
```
#usda 1.0
(
    expressionVariables = {
        bool SUBLAYER_ENABLED = 1
    }
)
```

Previously, the USD stage could resolve this sublayer, but the editor could not evaluate the same expression and showed it as unresolved:
<img width="767" height="191" alt="layer_editor_before_pr" src="https://github.com/user-attachments/assets/2439f3c5-28ec-4e39-a61c-756e9ab876cc" />


Now, the resolved sublayer is displayed correctly in the tree:
<img width="769" height="196" alt="layer_editor_after_pr" src="https://github.com/user-attachments/assets/73702c2c-6281-4f01-81fa-5a7c500cf2bf" />



