### PR TITLE
UsdUfe: Fix edit restrictions with variable expresssion layers

### DIFF
--- a/lib/usdUfe/ufe/Utils.cpp
+++ b/lib/usdUfe/ufe/Utils.cpp
@@ -947,8 +947,7 @@ bool allowedInStrongerLayer(
             return false;
     }
 
-    // This happens when the edit target layer is within the reference.
-    // In this case, we return true to allow it to be edited.
+    // Allow edits when the target layer is non-local, such as in a referenced layer.
     return true;
 }
 

--- a/lib/usdUfe/ufe/Utils.cpp
+++ b/lib/usdUfe/ufe/Utils.cpp
@@ -922,10 +922,11 @@ Ufe::Attribute::Ptr attrFromUfeAttrInfo(const Ufe::AttributeInfo& attrInfo)
 namespace {
 
 bool allowedInStrongerLayer(
-    const UsdPrim&                          prim,
-    const SdfPrimSpecHandleVector&          primStack,
-    const std::set<PXR_NS::SdfLayerRefPtr>& sessionLayers,
-    bool                                    allowStronger)
+    const UsdPrim&                       prim,
+    const SdfPrimSpecHandleVector&       primStack,
+    SdfLayerHandleVector::const_iterator stageLayersBegin,
+    SdfLayerHandleVector::const_iterator stageLayersEnd,
+    bool                                 allowStronger)
 {
     // If the flag to allow edits in a stronger layer if off, then it is not allowed.
     if (!allowStronger)
@@ -936,19 +937,19 @@ bool allowedInStrongerLayer(
     auto targetLayer = stage->GetEditTarget().GetLayer();
     auto topLayer = primStack.front()->GetLayer();
 
-    const SdfLayerHandle searchRoot = isSessionLayer(targetLayer, sessionLayers)
-        ? stage->GetSessionLayer()
-        : stage->GetRootLayer();
-
-    auto strongerLayer = getStrongerLayer(searchRoot, targetLayer, topLayer);
-
-    // This happens when the edit target layer is within the reference.
-    // In this cae, we return true to allow it to be edited.
-    if (!strongerLayer) {
+    if (targetLayer == topLayer)
         return true;
+
+    for (auto it = stageLayersBegin; it != stageLayersEnd; ++it) {
+        if (*it == targetLayer)
+            return true;
+        if (*it == topLayer)
+            return false;
     }
 
-    return strongerLayer == targetLayer;
+    // This happens when the edit target layer is within the reference.
+    // In this case, we return true to allow it to be edited.
+    return true;
 }
 
 } // namespace
@@ -1049,11 +1050,30 @@ void applyCommandRestriction(
     }
 
     const auto stage = prim.GetStage();
-    auto       targetLayer = stage->GetEditTarget().GetLayer();
+    const auto targetLayer = stage->GetEditTarget().GetLayer();
+    const auto stageLayers = stage->GetLayerStack();
 
-    const bool includeTopLayer = true;
-    const auto sessionLayers = getAllSublayerRefs(stage->GetSessionLayer(), includeTopLayer);
-    const bool isTargetingSession = isSessionLayer(targetLayer, sessionLayers);
+    // session layers are always stronger/first in the stage layers stack.
+    const auto sessionLayersEnd
+        = std::find(stageLayers.begin(), stageLayers.end(), stage->GetRootLayer());
+
+    if (!TF_VERIFY(sessionLayersEnd != stageLayers.end())) {
+        throw std::runtime_error(
+            "Cannot apply command restriction: root layer was not found in the stage layer stack.");
+    }
+    auto isInSessionStack = [&stageLayers, &sessionLayersEnd](const SdfLayerHandle& layer) {
+        return std::find(stageLayers.begin(), sessionLayersEnd, layer) != sessionLayersEnd;
+    };
+
+    // Only take session layer opinions into consideration when the target itself
+    // is a session layer or a sub-layer of session.
+    //
+    // We isolate session / non-session this way because these opinions are owned
+    // by the application and we don't want to block the user commands and user
+    // data due to them.
+    const bool isTargetingSession = isInSessionStack(targetLayer);
+    const auto restrictedLayersBegin = isTargetingSession ? stageLayers.begin() : sessionLayersEnd;
+    const auto restrictedLayersEnd = isTargetingSession ? sessionLayersEnd : stageLayers.end();
 
     auto        primSpec = getPrimSpecAtEditTarget(prim);
     auto        primStack = prim.GetPrimStack();
@@ -1069,14 +1089,9 @@ void applyCommandRestriction(
 
     // iterate over the prim stack, starting at the highest-priority layer.
     for (const auto& spec : primStack) {
-        // Only take session layers opinions into consideration when the target itself
-        // is a session layer (top a sub-layer of session).
-        //
-        // We isolate session / non-session this way because these opinions
-        // are owned by the application and we don't want to block the user
-        // commands and user data due to them.
+        // Ignore session or non-session opinions outside the layer stack selected above.
         const auto layer = spec->GetLayer();
-        if (isSessionLayer(layer, sessionLayers) != isTargetingSession)
+        if (isInSessionStack(layer) != isTargetingSession)
             continue;
 
         const auto& layerName = layer->GetDisplayName();
@@ -1120,7 +1135,8 @@ void applyCommandRestriction(
     UsdPrimCompositionQuery query(prim);
     for (const auto& compQueryArc : query.GetCompositionArcs()) {
         if (!primSpec && PcpArcTypeVariant == compQueryArc.GetArcType()) {
-            if (allowedInStrongerLayer(prim, primStack, sessionLayers, allowStronger))
+            if (allowedInStrongerLayer(
+                    prim, primStack, restrictedLayersBegin, restrictedLayersEnd, allowStronger))
                 return;
             std::string err = TfStringPrintf(
                 "Cannot %s [%s] because it is defined inside the variant composition arc %s",
@@ -1132,7 +1148,8 @@ void applyCommandRestriction(
     }
 
     if (!layerDisplayName.empty()) {
-        if (allowedInStrongerLayer(prim, primStack, sessionLayers, allowStronger))
+        if (allowedInStrongerLayer(
+                prim, primStack, restrictedLayersBegin, restrictedLayersEnd, allowStronger))
             return;
         std::string formattedInstructions
             = TfStringPrintf(instructions.c_str(), layerDisplayName.c_str());

--- a/lib/usdUfe/utils/layers.cpp
+++ b/lib/usdUfe/utils/layers.cpp
@@ -203,9 +203,10 @@ bool isSessionLayer(const SdfLayerHandle& layer, const std::set<SdfLayerRefPtr>&
 }
 
 SdfLayerHandle getStrongerLayer(
-    const SdfLayerHandle& root,
+    const UsdStagePtr&    stage,
     const SdfLayerHandle& layer1,
-    const SdfLayerHandle& layer2)
+    const SdfLayerHandle& layer2,
+    bool                  compareSessionLayers)
 {
     if (layer1 == layer2)
         return layer1;
@@ -216,48 +217,14 @@ SdfLayerHandle getStrongerLayer(
     if (!layer2)
         return layer1;
 
-    if (root == layer1)
-        return layer1;
-
-    if (root == layer2)
-        return layer2;
-
-    for (auto path : root->GetSubLayerPaths()) {
-        SdfLayerRefPtr subLayer = SdfLayer::FindRelativeToLayer(root, path);
-        if (!subLayer)
-            continue;
-
-        SdfLayerHandle stronger = getStrongerLayer(subLayer, layer1, layer2);
-        if (!stronger)
-            continue;
-
-        return stronger;
+    for (const auto& layer : stage->GetLayerStack(compareSessionLayers)) {
+        if (layer == layer1)
+            return layer1;
+        if (layer == layer2)
+            return layer2;
     }
 
     return SdfLayerHandle();
-}
-
-SdfLayerHandle getStrongerLayer(
-    const UsdStagePtr&    stage,
-    const SdfLayerHandle& layer1,
-    const SdfLayerHandle& layer2,
-    bool                  compareSessionLayers)
-{
-    if (compareSessionLayers) {
-        // Session Layer is the strongest in the stage, so check its hierarchy first
-        // when enabled.
-        auto strongerLayer = getStrongerLayer(stage->GetSessionLayer(), layer1, layer2);
-        if (strongerLayer == layer1) {
-            return layer1;
-        } else if (strongerLayer == layer2) {
-            return layer2;
-        }
-    }
-
-    // Only verify the stage's general layer hierarchy. Do not check the session
-    // layer hierarchy because we don't want to let opinions that are owned by
-    // the application interfere with the user commands.
-    return getStrongerLayer(stage->GetRootLayer(), layer1, layer2);
 }
 
 SdfPrimSpecHandleVector

--- a/lib/usdUfe/utils/layers.h
+++ b/lib/usdUfe/utils/layers.h
@@ -167,23 +167,9 @@ USDUFE_PUBLIC
 StageDirtyState isStageDirty(const PXR_NS::UsdStage& stage);
 
 /**
- * Get which of the two given layers is the strongest under the given root layer hierarchy.
+ * Get which of the two given layers is the strongest in the stage layer stack.
  *
- * @param root The root layer that will determine which is stronger.
- * @param layer1 one of the layers to be compared.
- * @param layer2 one of the layers to be compared.
- */
-
-USDUFE_PUBLIC
-PXR_NS::SdfLayerHandle getStrongerLayer(
-    const PXR_NS::SdfLayerHandle& root,
-    const PXR_NS::SdfLayerHandle& layer1,
-    const PXR_NS::SdfLayerHandle& layer2);
-
-/**
- * Get which of the two given layers is the strongest under the given stage root layer hierarchy.
- *
- * @param stage The stage with the root layer that will determine which is stronger.
+ * @param stage The stage that will determine which is stronger.
  * @param layer1 one of the layers to be compared.
  * @param layer2 one of the layers to be compared.
  * @param compareSessionLayers if true, also search the session layer. False by default.

--- a/test/lib/ufe/testAttribute.py
+++ b/test/lib/ufe/testAttribute.py
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+from contextlib import contextmanager
+
 import fixturesUtils
 import mayaUtils
 import ufeUtils
@@ -1870,6 +1872,87 @@ class AttributeTestCase(unittest.TestCase):
 
         # axisAttrUsd is not allowed to change since there is an opinion in a stronger layer
         self.assertFalse(mayaUsdUfe.isAttributeEditAllowed(axisAttrUsd))
+
+    @unittest.skipUnless(Usd.GetVersion() >= (0, 23, 8), 'Variable expressions in sublayers requires OpenUSD version 23.08 and above')
+    def testAttributeBlockingWithExpressionVariableSubLayer(self):
+        '''
+        Authoring attribute(s) in weaker layer(s) are not permitted if there exist opinion(s)
+        in stronger layer(s), even when sublayer paths are expression based.
+        '''
+        cmds.file(new=True, force=True)
+
+        psPathStr, strongLayer, varLayer, weakLayer = usdUtils.createStageWithExpressionVariableSubLayer()
+        stage = mayaUsd.ufe.getStage(psPathStr)
+        rootLayer = stage.GetRootLayer()
+
+        contextOps = ufe.ContextOps.contextOps(
+            ufe.Hierarchy.createItem(ufe.PathString.path(psPathStr))
+        )
+
+        # create a prim. This creates the primSpec in the strong layer.
+        cmds.mayaUsdEditTarget(psPathStr, edit=True, editTarget=weakLayer.identifier)
+        contextOps.doOp(['Add New Prim', 'Capsule'])
+
+        capsulePrim = stage.GetPrimAtPath('/Capsule1')
+        self.assertTrue(capsulePrim)
+
+        radiusAttrUsd = capsulePrim.GetAttribute('radius')
+        self.assertTrue(radiusAttrUsd)
+
+        @contextmanager
+        def temporaryRadiusValueInLayer(layer, radius):
+            with Usd.EditContext(stage, stage.GetEditTargetForLocalLayer(layer)):
+                radiusAttrUsd.Set(radius)
+                yield
+                radiusAttrUsd.Clear()
+                self.assertFalse(radiusAttrUsd.HasAuthoredValue())
+
+        def verifyRestriction(subLayer, editAllowed):
+            with Usd.EditContext(stage, stage.GetEditTargetForLocalLayer(subLayer)):
+                self.assertEqual(mayaUsdUfe.isAttributeEditAllowed(radiusAttrUsd), editAllowed)
+
+        # authoring new attribute edit is expected to be allowed anywhere.
+        for layer in stage.GetLayerStack():
+            verifyRestriction(layer, editAllowed=True)
+
+        # author a value in the weaker layer.
+        with temporaryRadiusValueInLayer(weakLayer, 20):
+            # we can author in this layer and all stronger layers.
+            verifyRestriction(stage.GetSessionLayer(), editAllowed=True)
+            verifyRestriction(rootLayer, editAllowed=True)
+            verifyRestriction(strongLayer, editAllowed=True)
+            verifyRestriction(varLayer, editAllowed=True)
+            verifyRestriction(weakLayer, editAllowed=True)
+
+        # author a value in the variable layer.
+        with temporaryRadiusValueInLayer(varLayer, 20):
+            # we can author in this layer and all stronger layers.
+            verifyRestriction(stage.GetSessionLayer(), editAllowed=True)
+            verifyRestriction(rootLayer, editAllowed=True)
+            verifyRestriction(strongLayer, editAllowed=True)
+            verifyRestriction(varLayer, editAllowed=True)
+            # we can not author in all weaker layers.
+            verifyRestriction(weakLayer, editAllowed=False)
+
+        # author a value in the strong layer.
+        with temporaryRadiusValueInLayer(strongLayer, 20):
+            # we can author in this layer and all stronger layers.
+            verifyRestriction(stage.GetSessionLayer(), editAllowed=True)
+            verifyRestriction(rootLayer, editAllowed=True)
+            verifyRestriction(strongLayer, editAllowed=True)
+            # we can not author in all weaker layers.
+            verifyRestriction(varLayer, editAllowed=False)
+            verifyRestriction(weakLayer, editAllowed=False)
+
+        # author a value in the root layer.
+        with temporaryRadiusValueInLayer(rootLayer, 20):
+            # we can author in this layer and all stronger layers.
+            verifyRestriction(stage.GetSessionLayer(), editAllowed=True)
+            verifyRestriction(rootLayer, editAllowed=True)
+            # we can not author in all weaker layers.
+            verifyRestriction(strongLayer, editAllowed=False)
+            verifyRestriction(varLayer, editAllowed=False)
+            verifyRestriction(weakLayer, editAllowed=False)
 
     def testTransformationAttributeBlocking(self):
         '''Authoring transformation attribute(s) in weaker layer(s) are not permitted if there exist opinion(s) in stronger layer(s).'''

--- a/test/lib/ufe/testAttribute.py
+++ b/test/lib/ufe/testAttribute.py
@@ -23,8 +23,9 @@ import mayaUtils
 import ufeUtils
 import testUtils
 import usdUtils
+import usdUfe
 
-from pxr import Usd, UsdGeom, Vt, Gf, UsdLux, UsdUI, Sdr
+from pxr import Usd, UsdGeom, Vt, Gf, UsdLux, UsdUI, Sdr, Tf, Kind, Sdf
 from pxr import UsdShade
 
 from maya import cmds
@@ -1953,6 +1954,70 @@ class AttributeTestCase(unittest.TestCase):
             verifyRestriction(strongLayer, editAllowed=False)
             verifyRestriction(varLayer, editAllowed=False)
             verifyRestriction(weakLayer, editAllowed=False)
+
+    @unittest.skipUnless(Usd.GetVersion() >= (0, 23, 8), 'Variable expressions in sublayers requires OpenUSD version 23.08 and above')
+    def testPrimMetadataBlockingWithExpressionVariableSubLayer(self):
+        '''
+        Authoring metadata in weaker layer(s) is not permitted when stronger
+        opinion(s) exist, even when sublayer paths are expression based.
+        '''
+        # author a layer stack using stage expression variables.
+        psPathStr, strongLayer, varLayer, weakLayer = usdUtils.createStageWithExpressionVariableSubLayer()
+
+        stage = mayaUsd.ufe.getStage(psPathStr)
+        rootLayer = stage.GetRootLayer()
+
+        prim = stage.DefinePrim('/Xf', 'Xform')
+
+        @contextmanager
+        def temporaryKindInLayer(layer, kind):
+            primSpec = Sdf.CreatePrimInLayer(layer, prim.GetPath())
+            oldKind = primSpec.kind
+            primSpec.kind = kind
+
+            yield
+
+            if oldKind:
+                primSpec.kind = oldKind
+            else:
+                primSpec.ClearKind()
+
+        def verifyRestriction(targetLayer, kind, editAllowed):
+            with Usd.EditContext(stage, stage.GetEditTargetForLocalLayer(targetLayer)):
+                ufeCmd = usdUfe.SetKindCommand(prim, kind)
+                try:
+                    ufeCmd.execute()
+                except Tf.ErrorException:
+                    didRaise = True
+                else:
+                    didRaise = False
+                    ufeCmd.undo()
+
+            self.assertNotEqual(didRaise, editAllowed)
+
+        with temporaryKindInLayer(weakLayer, Kind.Tokens.model):
+            verifyRestriction(weakLayer, Kind.Tokens.group, editAllowed=True)
+            verifyRestriction(varLayer, Kind.Tokens.group, editAllowed=True)
+            verifyRestriction(strongLayer, Kind.Tokens.group, editAllowed=True)
+            verifyRestriction(rootLayer, Kind.Tokens.group, editAllowed=True)
+
+        with temporaryKindInLayer(varLayer, Kind.Tokens.model):
+            verifyRestriction(weakLayer, Kind.Tokens.group, editAllowed=False)
+            verifyRestriction(varLayer, Kind.Tokens.group, editAllowed=True)
+            verifyRestriction(strongLayer, Kind.Tokens.group, editAllowed=True)
+            verifyRestriction(rootLayer, Kind.Tokens.group, editAllowed=True)
+
+        with temporaryKindInLayer(strongLayer, Kind.Tokens.model):
+            verifyRestriction(weakLayer, Kind.Tokens.group, editAllowed=False)
+            verifyRestriction(varLayer, Kind.Tokens.group, editAllowed=False)
+            verifyRestriction(strongLayer, Kind.Tokens.group, editAllowed=True)
+            verifyRestriction(rootLayer, Kind.Tokens.group, editAllowed=True)
+
+        with temporaryKindInLayer(rootLayer, Kind.Tokens.model):
+            verifyRestriction(weakLayer, Kind.Tokens.group, editAllowed=False)
+            verifyRestriction(varLayer, Kind.Tokens.group, editAllowed=False)
+            verifyRestriction(strongLayer, Kind.Tokens.group, editAllowed=False)
+            verifyRestriction(rootLayer, Kind.Tokens.group, editAllowed=True)
 
     def testTransformationAttributeBlocking(self):
         '''Authoring transformation attribute(s) in weaker layer(s) are not permitted if there exist opinion(s) in stronger layer(s).'''

--- a/test/lib/ufe/testDeleteCmd.py
+++ b/test/lib/ufe/testDeleteCmd.py
@@ -376,6 +376,41 @@ class DeleteCmdTestCase(unittest.TestCase):
         self.assertTrue(stage.GetPrimAtPath('/TreeBase/trunk'))
         self.assertTrue(stage.GetPrimAtPath('/TreeBase/newChild'))
 
+    @unittest.skipUnless(Usd.GetVersion() >= (0, 23, 8), 'Variable expressions in sublayers requires OpenUSD version 23.08 and above')
+    def testDeleteRestrictionWithExpressionVariableSubLayer(self):
+        '''
+        Test delete restriction - we don't allow removal of a prim from a weaker
+        layer when the prim is in the stronger layer.
+        With sub layer paths using expression variables.
+        '''
+        psPathStr, _, varLayer, weakLayer = usdUtils.createStageWithExpressionVariableSubLayer()
+        stage = mayaUsd.ufe.getStage(psPathStr)
+
+        stage.SetEditTarget(varLayer)
+        stage.DefinePrim('/A', 'Xform')
+        self.assertTrue(stage.GetPrimAtPath('/A'))
+
+        ufeObs = TestObserver()
+        ufe.Scene.addObserver(ufeObs)
+
+        # not allowed from the weaker layer.
+        stage.SetEditTarget(weakLayer)
+        cmds.delete(psPathStr + ',/A')
+
+        self.assertEqual(ufeObs.nbDeleteNotif(), 0)
+        self.assertTrue(stage.GetPrimAtPath('/A'))
+        self.assertFalse(weakLayer.GetPrimAtPath('/A'))
+
+        # allowed from the layer that owns the prim spec.
+        ufeObs.reset()
+
+        stage.SetEditTarget(varLayer)
+        cmds.delete(psPathStr + ',/A')
+
+        self.assertEqual(ufeObs.nbDeleteNotif(), 1)
+        self.assertFalse(stage.GetPrimAtPath('/A'))
+        self.assertFalse(varLayer.GetPrimAtPath('/A'))
+
     def testDeleteRestrictionHierarchyWithChildrenInSessionLayer(self):
         '''Test delete restriction - we *do* allow removal of a prim with child/children defined in the session layer'''
 

--- a/test/lib/ufe/testPrimMetadataEditRouting.py
+++ b/test/lib/ufe/testPrimMetadataEditRouting.py
@@ -2,10 +2,9 @@
 
 import os
 import unittest
-from contextlib import contextmanager
 
 from maya import cmds, standalone
-from pxr import Sdf, Usd, Tf, Kind
+from pxr import Sdf, Usd
 import ufe
 
 import mayaUsd.lib
@@ -371,72 +370,6 @@ class PrimMetadataEditRoutingTestCase(unittest.TestCase):
             lambda item: usdUfe.SetKindCommand(primFromSceneItem(item), 'group'),
             lambda spec: self.assertEqual(spec.kind, 'group'),
         )
-
-    @unittest.skipUnless(
-        Usd.GetVersion() >= (0, 23, 8),
-        'Variable expressions in sublayers requires OpenUSD version 23.08 and above')
-    def testEditRestrictionWithExpressionVariableSubLayer(self):
-        '''
-        Authoring metadata in weaker layer(s) is not permitted when stronger
-        opinion(s) exist, even when sublayer paths are expression based.
-        '''
-        # author a layer stack using stage expression variables.
-        psPathStr, strongLayer, varLayer, weakLayer = usdUtils.createStageWithExpressionVariableSubLayer()
-
-        stage = mayaUsd.ufe.getStage(psPathStr)
-        rootLayer = stage.GetRootLayer()
-
-        prim = stage.DefinePrim('/Xf', 'Xform')
-
-        @contextmanager
-        def temporaryKindInLayer(layer, kind):
-            primSpec = Sdf.CreatePrimInLayer(layer, prim.GetPath())
-            oldKind = primSpec.kind
-            primSpec.kind = kind
-
-            yield
-
-            if oldKind:
-                primSpec.kind = oldKind
-            else:
-                primSpec.ClearKind()
-
-        def verifyRestriction(targetLayer, kind, expectedAllowed):
-            with Usd.EditContext(stage, stage.GetEditTargetForLocalLayer(targetLayer)):
-                ufeCmd = usdUfe.SetKindCommand(prim, kind)
-                try:
-                    ufeCmd.execute()
-                except Tf.ErrorException:
-                    didRaise = True
-                else:
-                    didRaise = False
-                    ufeCmd.undo()
-
-            self.assertNotEqual(didRaise, expectedAllowed)
-
-        with temporaryKindInLayer(weakLayer, Kind.Tokens.model):
-            verifyRestriction(weakLayer, Kind.Tokens.group, expectedAllowed=True)
-            verifyRestriction(varLayer, Kind.Tokens.group, expectedAllowed=True)
-            verifyRestriction(strongLayer, Kind.Tokens.group, expectedAllowed=True)
-            verifyRestriction(rootLayer, Kind.Tokens.group, expectedAllowed=True)
-
-        with temporaryKindInLayer(varLayer, Kind.Tokens.model):
-            verifyRestriction(weakLayer, Kind.Tokens.group, expectedAllowed=False)
-            verifyRestriction(varLayer, Kind.Tokens.group, expectedAllowed=True)
-            verifyRestriction(strongLayer, Kind.Tokens.group, expectedAllowed=True)
-            verifyRestriction(rootLayer, Kind.Tokens.group, expectedAllowed=True)
-
-        with temporaryKindInLayer(strongLayer, Kind.Tokens.model):
-            verifyRestriction(weakLayer, Kind.Tokens.group, expectedAllowed=False)
-            verifyRestriction(varLayer, Kind.Tokens.group, expectedAllowed=False)
-            verifyRestriction(strongLayer, Kind.Tokens.group, expectedAllowed=True)
-            verifyRestriction(rootLayer, Kind.Tokens.group, expectedAllowed=True)
-
-        with temporaryKindInLayer(rootLayer, Kind.Tokens.model):
-            verifyRestriction(weakLayer, Kind.Tokens.group, expectedAllowed=False)
-            verifyRestriction(varLayer, Kind.Tokens.group, expectedAllowed=False)
-            verifyRestriction(strongLayer, Kind.Tokens.group, expectedAllowed=False)
-            verifyRestriction(rootLayer, Kind.Tokens.group, expectedAllowed=True)
 
     def testEditRouterForAddReference(self):
         '''

--- a/test/lib/ufe/testPrimMetadataEditRouting.py
+++ b/test/lib/ufe/testPrimMetadataEditRouting.py
@@ -2,9 +2,10 @@
 
 import os
 import unittest
+from contextlib import contextmanager
 
 from maya import cmds, standalone
-from pxr import Sdf, Usd
+from pxr import Sdf, Usd, Tf, Kind
 import ufe
 
 import mayaUsd.lib
@@ -370,6 +371,72 @@ class PrimMetadataEditRoutingTestCase(unittest.TestCase):
             lambda item: usdUfe.SetKindCommand(primFromSceneItem(item), 'group'),
             lambda spec: self.assertEqual(spec.kind, 'group'),
         )
+
+    @unittest.skipUnless(
+        Usd.GetVersion() >= (0, 23, 8),
+        'Variable expressions in sublayers requires OpenUSD version 23.08 and above')
+    def testEditRestrictionWithExpressionVariableSubLayer(self):
+        '''
+        Authoring metadata in weaker layer(s) is not permitted when stronger
+        opinion(s) exist, even when sublayer paths are expression based.
+        '''
+        # author a layer stack using stage expression variables.
+        psPathStr, strongLayer, varLayer, weakLayer = usdUtils.createStageWithExpressionVariableSubLayer()
+
+        stage = mayaUsd.ufe.getStage(psPathStr)
+        rootLayer = stage.GetRootLayer()
+
+        prim = stage.DefinePrim('/Xf', 'Xform')
+
+        @contextmanager
+        def temporaryKindInLayer(layer, kind):
+            primSpec = Sdf.CreatePrimInLayer(layer, prim.GetPath())
+            oldKind = primSpec.kind
+            primSpec.kind = kind
+
+            yield
+
+            if oldKind:
+                primSpec.kind = oldKind
+            else:
+                primSpec.ClearKind()
+
+        def verifyRestriction(targetLayer, kind, expectedAllowed):
+            with Usd.EditContext(stage, stage.GetEditTargetForLocalLayer(targetLayer)):
+                ufeCmd = usdUfe.SetKindCommand(prim, kind)
+                try:
+                    ufeCmd.execute()
+                except Tf.ErrorException:
+                    didRaise = True
+                else:
+                    didRaise = False
+                    ufeCmd.undo()
+
+            self.assertNotEqual(didRaise, expectedAllowed)
+
+        with temporaryKindInLayer(weakLayer, Kind.Tokens.model):
+            verifyRestriction(weakLayer, Kind.Tokens.group, expectedAllowed=True)
+            verifyRestriction(varLayer, Kind.Tokens.group, expectedAllowed=True)
+            verifyRestriction(strongLayer, Kind.Tokens.group, expectedAllowed=True)
+            verifyRestriction(rootLayer, Kind.Tokens.group, expectedAllowed=True)
+
+        with temporaryKindInLayer(varLayer, Kind.Tokens.model):
+            verifyRestriction(weakLayer, Kind.Tokens.group, expectedAllowed=False)
+            verifyRestriction(varLayer, Kind.Tokens.group, expectedAllowed=True)
+            verifyRestriction(strongLayer, Kind.Tokens.group, expectedAllowed=True)
+            verifyRestriction(rootLayer, Kind.Tokens.group, expectedAllowed=True)
+
+        with temporaryKindInLayer(strongLayer, Kind.Tokens.model):
+            verifyRestriction(weakLayer, Kind.Tokens.group, expectedAllowed=False)
+            verifyRestriction(varLayer, Kind.Tokens.group, expectedAllowed=False)
+            verifyRestriction(strongLayer, Kind.Tokens.group, expectedAllowed=True)
+            verifyRestriction(rootLayer, Kind.Tokens.group, expectedAllowed=True)
+
+        with temporaryKindInLayer(rootLayer, Kind.Tokens.model):
+            verifyRestriction(weakLayer, Kind.Tokens.group, expectedAllowed=False)
+            verifyRestriction(varLayer, Kind.Tokens.group, expectedAllowed=False)
+            verifyRestriction(strongLayer, Kind.Tokens.group, expectedAllowed=False)
+            verifyRestriction(rootLayer, Kind.Tokens.group, expectedAllowed=True)
 
     def testEditRouterForAddReference(self):
         '''

--- a/test/testUtils/usdUtils.py
+++ b/test/testUtils/usdUtils.py
@@ -150,6 +150,31 @@ def createSimpleXformScene():
             aXlateOp, aXlation, aUsdUfePathStr, aUsdUfePath, aUsdItem,
             bXlateOp, bXlation, bUsdUfePathStr, bUsdUfePath, bUsdItem)
 
+
+def createStageWithExpressionVariableSubLayer():
+    '''
+    Create a simple scene with subLayers, one is using an expression variable.
+    Sublayers are returned in strength order.
+    '''
+    psPathStr, _, _ = createSimpleStage()
+
+    strongLayer = Sdf.Layer.CreateAnonymous('strong.usda')
+    varLayer = Sdf.Layer.CreateAnonymous('variable.usda')
+    weakLayer = Sdf.Layer.CreateAnonymous('weak.usda')
+
+    stage = mayaUsd.ufe.getStage(psPathStr)
+
+    stage.GetSessionLayer().expressionVariables = {
+        'VAR': varLayer.identifier,
+    }
+    stage.GetRootLayer().subLayerPaths = [
+        strongLayer.identifier,
+        '`${VAR}`',
+        weakLayer.identifier,
+    ]
+    return (psPathStr, strongLayer, varLayer, weakLayer)
+
+
 def createDuoXformSceneInCurrentLayer(psPathStr, ps):
     '''Create a simple scene in the current stage and layer with a trivial hierarchy:
 
@@ -268,5 +293,4 @@ def filterUsdStr(usdSceneStr):
     nonBlankLines = filter(None, [l.strip() for l in usdSceneStr.splitlines()])
     finalLines = [l for l in nonBlankLines if not l.startswith('#')]
     return '\n'.join(finalLines)
-
 


### PR DESCRIPTION
This PR fixes UFE edit restriction behavior when stage-local layers use variable-expression sublayer paths.

It updates the layer strength checks used by:
- `delete`, `reparent`, and `reorder` UFE commands through `UsdUfe::applyCommandRestriction` (13917effa3775f2d7355e2de721218fb6d1fe82e).
- UFE commands that edit prim metadata through `UsdUfe::isPrimMetadataEditAllowed` / `UsdUfe::getStrongerLayer` (dd9685e54c5690f88e75760afe86e22705cc1cc4)

These code paths were previously comparing sublayer strength by manually traversing and resolving the sublayer tree. That manual resolution did not evaluate sublayer paths variable expression, and could therefore compare layer strength incorrectly.

The updated implementations use `UsdStage::GetLayerStack` instead, which provides the stage-local layers in strength order with expression variables already evaluated by USD.

This should also make the behavior more consistent for muted layers. Those are not part of the stage layer stack, but the previous manual traversal could still resolve them and treat them as stronger, e.g. when those layers were edited and held by maya-usd.

I added unit tests for the `delete` command (7539b76b86672fea4ca36177ff377cbb8cc54ec0) and prim metadata edit restrictions (5c6e031d211d073714e007ccc76ea67f82cb3a58) with expression-variable sublayer paths. I also added a test for attribute edit restrictions (f2f5337d1e11337a5bc14d0e2230846878d360da), even though that path was already behaving correctly, to improve coverage .

I removed the `UsdUfe::getStrongerLayer` overload that only took a root layer (dd9685e54c5690f88e75760afe86e22705cc1cc4). It is no longer used in the repo, and cannot behave correctly without stage context. If this public API is still wanted, we could probably add a replacement overload with a stage arg.