### PR TITLE
EMSUSD-3680 optimize layer tree model rebuilds

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeItem.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeItem.cpp
@@ -205,6 +205,35 @@ LayerItemVector LayerTreeItem::childrenVector() const
     return result;
 }
 
+bool LayerTreeItem::isIdenticalItem(const LayerTreeItem* other) const
+{
+    if (!other) {
+        return false;
+    }
+
+    if (this == other) {
+        return true;
+    }
+
+    if (layer() != other->layer()) {
+        return false;
+    }
+
+    auto myChildren = childrenVector();
+    auto otherChildren = other->childrenVector();
+    if (myChildren.size() != otherChildren.size()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < myChildren.size(); i++) {
+        if (!myChildren[i]->isIdenticalItem(otherChildren[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 // recursively update the target layer data member. Meant to be called from invisibleRoot
 void LayerTreeItem::updateTargetLayerRecursive(const PXR_NS::SdfLayerRefPtr& newTargetLayer)
 {

--- a/lib/usd/ui/layerEditor/layerTreeItem.h
+++ b/lib/usd/ui/layerEditor/layerTreeItem.h
@@ -182,6 +182,9 @@ public:
     // allows c++ iteration of children
     LayerItemVector childrenVector() const;
 
+    // Check if this item and its children are identical.
+    bool isIdenticalItem(const LayerTreeItem* other) const;
+
     // menu callbacks
     void removeSubLayer(QWidget* in_parent);
     void saveEdits(QWidget* in_parent);

--- a/lib/usd/ui/layerEditor/layerTreeModel.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeModel.cpp
@@ -378,7 +378,7 @@ void LayerTreeModel::rebuildModel(bool refreshLockState /*= false*/)
     const bool sessionIdentical = (!newSessionItem && !oldSessionItem)
         || (newSessionItem && newSessionItem->isIdenticalItem(oldSessionItem));
 
-    if (rootIdentical && sessionIdentical) {
+    if (!refreshLockState && rootIdentical && sessionIdentical) {
         return;
     }
 

--- a/lib/usd/ui/layerEditor/layerTreeModel.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeModel.cpp
@@ -353,11 +353,9 @@ void LayerTreeModel::rebuildModel(bool refreshLockState /*= false*/)
         }
     }
 
-    LayerTreeItem* newSessionItem = nullptr;
-    LayerTreeItem* newRootItem = nullptr;
-
+    std::unique_ptr<LayerTreeItem> newSessionItem;
     if (showSessionLayer) {
-        newSessionItem = new LayerTreeItem(
+        newSessionItem = std::make_unique<LayerTreeItem>(
             sessionLayer,
             _sessionState->stage(),
             LayerType::SessionLayer,
@@ -367,7 +365,7 @@ void LayerTreeModel::rebuildModel(bool refreshLockState /*= false*/)
             &sharedLayers);
     }
 
-    newRootItem = new LayerTreeItem(
+    std::unique_ptr<LayerTreeItem> newRootItem = std::make_unique<LayerTreeItem>(
         rootLayer,
         _sessionState->stage(),
         LayerType::RootLayer,
@@ -377,7 +375,8 @@ void LayerTreeModel::rebuildModel(bool refreshLockState /*= false*/)
         &sharedLayers);
 
     const bool rootIdentical = newRootItem->isIdenticalItem(oldRootItem);
-    const bool sessionIdentical = newSessionItem && newSessionItem->isIdenticalItem(oldSessionItem);
+    const bool sessionIdentical = (!newSessionItem && !oldSessionItem)
+        || (newSessionItem && newSessionItem->isIdenticalItem(oldSessionItem));
 
     if (rootIdentical && sessionIdentical) {
         return;
@@ -393,10 +392,10 @@ void LayerTreeModel::rebuildModel(bool refreshLockState /*= false*/)
         removeRows(0, rowCount());
 
     if (newSessionItem) {
-        appendRow(newSessionItem);
+        appendRow(newSessionItem.release());
     }
 
-    appendRow(newRootItem);
+    appendRow(newRootItem.release());
 
     updateTargetLayer(InRebuildModel::Yes);
 

--- a/lib/usd/ui/layerEditor/layerTreeModel.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeModel.cpp
@@ -303,6 +303,86 @@ void LayerTreeModel::rebuildModel(bool refreshLockState /*= false*/)
     _rebuildOnIdlePending = false;
     _lastAskedAnonLayerNameSinceRebuild = 0;
 
+    if (!_sessionState->isValid()) {
+        if (rowCount() > 0) {
+            // Note: clear() calls beginResetModel and endResetModel for us.
+            clear();
+        }
+        return;
+    }
+
+    auto rootLayer = _sessionState->stage()->GetRootLayer();
+    auto sessionLayer = _sessionState->stage()->GetSessionLayer();
+    bool showSessionLayer = true;
+    if (_sessionState->autoHideSessionLayer()) {
+        showSessionLayer = sessionLayer->IsDirty() || sessionLayer == _sessionState->targetLayer();
+    }
+
+    std::set<std::string> sharedLayers;
+    auto                  sharedStage = _sessionState->commandHook()->isProxyShapeSharedStage(
+        _sessionState->stageEntry()._proxyShapePath);
+    if (!sharedStage) {
+        auto layers = MayaUsd::CustomLayerData::getStringArray(
+            rootLayer, MayaUsdMetadata->ReferencedLayers);
+        std::vector<std::string> layerIds;
+        std::move(layers.begin(), layers.end(), inserter(layerIds, layerIds.begin()));
+        sharedLayers = MayaUsd::getAllSublayers(layerIds, true);
+    }
+
+    std::set<std::string> incomingLayers;
+    if (_sessionState->commandHook()->isProxyShapeStageIncoming(
+            _sessionState->stageEntry()._proxyShapePath)) {
+        if (!sharedStage) {
+            incomingLayers = sharedLayers;
+        } else {
+            std::vector<std::string> layerIds;
+            layerIds.push_back(rootLayer->GetIdentifier());
+            incomingLayers = MayaUsd::getAllSublayers(layerIds, true);
+        }
+    }
+
+    LayerTreeItem* oldSessionItem = nullptr;
+    LayerTreeItem* oldRootItem = nullptr;
+
+    if (rowCount() > 0) {
+        if (rowCount() > 1) {
+            oldSessionItem = dynamic_cast<LayerTreeItem*>(invisibleRootItem()->child(0));
+            oldRootItem = dynamic_cast<LayerTreeItem*>(invisibleRootItem()->child(1));
+        } else {
+            oldRootItem = dynamic_cast<LayerTreeItem*>(invisibleRootItem()->child(0));
+        }
+    }
+
+    LayerTreeItem* newSessionItem = nullptr;
+    LayerTreeItem* newRootItem = nullptr;
+
+    if (showSessionLayer) {
+        newSessionItem = new LayerTreeItem(
+            sessionLayer,
+            _sessionState->stage(),
+            LayerType::SessionLayer,
+            "",
+            &incomingLayers,
+            sharedStage,
+            &sharedLayers);
+    }
+
+    newRootItem = new LayerTreeItem(
+        rootLayer,
+        _sessionState->stage(),
+        LayerType::RootLayer,
+        "",
+        &incomingLayers,
+        sharedStage,
+        &sharedLayers);
+
+    const bool rootIdentical = newRootItem->isIdenticalItem(oldRootItem);
+    const bool sessionIdentical = newSessionItem && newSessionItem->isIdenticalItem(oldSessionItem);
+
+    if (rootIdentical && sessionIdentical) {
+        return;
+    }
+
     beginResetModel();
 
     //  Note: do *not* call clear() here! Unfortunately, clear() itself calls,
@@ -312,64 +392,17 @@ void LayerTreeModel::rebuildModel(bool refreshLockState /*= false*/)
     if (rowCount() > 0)
         removeRows(0, rowCount());
 
-    if (_sessionState->isValid()) {
-        auto rootLayer = _sessionState->stage()->GetRootLayer();
-        bool showSessionLayer = true;
-        auto sessionLayer = _sessionState->stage()->GetSessionLayer();
-        if (_sessionState->autoHideSessionLayer()) {
-            showSessionLayer
-                = sessionLayer->IsDirty() || sessionLayer == _sessionState->targetLayer();
-        }
+    if (newSessionItem) {
+        appendRow(newSessionItem);
+    }
 
-        std::set<std::string> sharedLayers;
-        auto                  sharedStage = _sessionState->commandHook()->isProxyShapeSharedStage(
-            _sessionState->stageEntry()._proxyShapePath);
-        if (!sharedStage) {
-            auto layers = MayaUsd::CustomLayerData::getStringArray(
-                rootLayer, MayaUsdMetadata->ReferencedLayers);
-            std::vector<std::string> layerIds;
-            std::move(layers.begin(), layers.end(), inserter(layerIds, layerIds.begin()));
-            sharedLayers = MayaUsd::getAllSublayers(layerIds, true);
-        }
+    appendRow(newRootItem);
 
-        std::set<std::string> incomingLayers;
-        if (_sessionState->commandHook()->isProxyShapeStageIncoming(
-                _sessionState->stageEntry()._proxyShapePath)) {
-            if (!sharedStage) {
-                incomingLayers = sharedLayers;
-            } else {
-                std::vector<std::string> layerIds;
-                layerIds.push_back(rootLayer->GetIdentifier());
-                incomingLayers = MayaUsd::getAllSublayers(layerIds, true);
-            }
-        }
+    updateTargetLayer(InRebuildModel::Yes);
 
-        if (showSessionLayer) {
-            appendRow(new LayerTreeItem(
-                sessionLayer,
-                _sessionState->stage(),
-                LayerType::SessionLayer,
-                "",
-                &incomingLayers,
-                sharedStage,
-                &sharedLayers));
-        }
-
-        appendRow(new LayerTreeItem(
-            rootLayer,
-            _sessionState->stage(),
-            LayerType::RootLayer,
-            "",
-            &incomingLayers,
-            sharedStage,
-            &sharedLayers));
-
-        updateTargetLayer(InRebuildModel::Yes);
-
-        if (refreshLockState) {
-            bool refreshSubLayers = true;
-            _sessionState->commandHook()->refreshLayerSystemLock(rootLayer, refreshSubLayers);
-        }
+    if (refreshLockState) {
+        bool refreshSubLayers = true;
+        _sessionState->commandHook()->refreshLayerSystemLock(rootLayer, refreshSubLayers);
     }
 
     endResetModel();


### PR DESCRIPTION
The problem was that every change to any prim triggers a `LayersDidChangeSentPerLayer` notification from USD. The `LayerTreeModel` uses that notification to trigger rebuilding itself in case the change was inserting or removing a child layer. That causes repeat model building when data changes, for example when dragging prims in the viewport. This would cause the layer editor UI to rebuild itself constantly.

Optimized the code to detect that the layers have not changed and not reset the model.

- Added a `isIdenticalItem` function to the LayerTreeItem class.
- Optimized the `rebuildModel` function of `LayerTreeModel` to not reset the model if the layers have not changed.
- Done by comparing old a new items, if identical, don't reset the model.
- This avoids redrawing a rebuilding the `LayerTreeWidget` of the layer editor.