### PR TITLE
EMSUSD-3749 prevent merging session and non-session

### DIFF
--- a/plugin/adsk/scripts/CMakeLists.txt
+++ b/plugin/adsk/scripts/CMakeLists.txt
@@ -15,6 +15,7 @@ list(APPEND scripts_src
     mayaUsd_imageFileDialogs.mel
     mayaUsd_initializeComponentCreator.py
     mayaUsd_layerEditorFileDialogs.mel
+    mayaUsd_layerUtils.py
     mayaUsd_fileOptions.mel
     mayaUsd_pluginUICreation.mel
     mayaUsd_pluginUIDeletion.mel

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -1065,10 +1065,10 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
         return; // that's all we can support on invalid layers
     }
 
+
     int $isSessionLayer = `mayaUsdLayerEditorWindow -q -isSessionLayer $panelName`;
     int $isAnonymousLayer = `mayaUsdLayerEditorWindow -q -isAnonymousLayer $panelName`;
     int $needsSaving = `mayaUsdLayerEditorWindow -q -layerNeedsSaving $panelName`;
-    int $singleSelect = `mayaUsdLayerEditorWindow -q -selectionLength $panelName` == 1;
     int $appearsMuted = `mayaUsdLayerEditorWindow -q -layerAppearsMuted $panelName`;
     int $isSubLayer = `mayaUsdLayerEditorWindow -q -isSubLayer $panelName`;
     int $isMuted = `mayaUsdLayerEditorWindow -q -layerIsMuted $panelName`;
@@ -1080,6 +1080,12 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
     int $isIncoming = `mayaUsdLayerEditorWindow -q -isIncomingLayer $panelName`;
     int $hasSublayers = `mayaUsdLayerEditorWindow -q -layerHasSubLayers $panelName`;
     string $proxyShape = `mayaUsdLayerEditorWindow -q -proxyShape $panelName`;
+
+    int $selectedCount = `mayaUsdLayerEditorWindow -q -selectionLength $panelName`;
+    int $singleSelect = ($selectedCount == 1);
+    int $multiSelect = ($selectedCount > 1);
+    int $hasSessionInSel = `python("import mayaUsd_layerUtils; mayaUsd_layerUtils.isSessionInLayerEditorSelection('" + $panelName + "')")`;
+    int $hasNonSessionInSel = `python("import mayaUsd_layerUtils; mayaUsd_layerUtils.isNonSessionInLayerEditorSelection('" + $panelName + "')")`;
 
     string $label;
     int $enabled;
@@ -1123,8 +1129,7 @@ global proc mayaUsdMenu_layerEditorContextMenu(string $panelName) {
     $enabled = $singleSelect && !$appearsMuted && !$isReadOnly && !$isLocked && !$isSystemLocked;
     menuItem -label $label -enable $enabled -c $cmd;
 
-    int $multiSelect = `mayaUsdLayerEditorWindow -q -selectionLength $panelName` > 1;
-    if ($multiSelect && !$singleSelect) {
+    if ($multiSelect && !($hasSessionInSel && $hasNonSessionInSel)) {
         $label = getMayaUsdString("kMenuStitchLayers");
         $cmd = makeCommand($panelName, "stitchLayers");
         $enabled = !$isReadOnly && !$isLocked && !$appearsSystemLocked && !$appearsMuted;

--- a/plugin/adsk/scripts/mayaUsd_layerUtils.py
+++ b/plugin/adsk/scripts/mayaUsd_layerUtils.py
@@ -37,7 +37,7 @@ def _getAllSessionLayerIds(stage):
         layer = todo.pop()
         sessionLayerIds.add(layer.identifier)
         for subLayerId in layer.subLayerPaths:
-            subLayer = Sdf.Layer.Find(subLayerId)
+            subLayer = Sdf.Layer.FindRelativeToLayer(layer, subLayerId)
             todo.append(subLayer)
     return sessionLayerIds
 
@@ -52,8 +52,7 @@ def isSessionInLayerEditorSelection(panelName):
 
     layerIds = getlayerEditorLayerIds(panelName)
     for layerId in layerIds:
-        layer = Sdf.Layer.Find(layerId)
-        if layer and layer.identifier in sessionLayers:
+        if layerId in sessionLayers:
             return True
     return False
 
@@ -68,7 +67,6 @@ def isNonSessionInLayerEditorSelection(panelName):
 
     layerIds = getlayerEditorLayerIds(panelName)
     for layerId in layerIds:
-        layer = Sdf.Layer.Find(layerId)
-        if layer and layer.identifier not in sessionLayers:
+        if layerId not in sessionLayers:
             return True
     return False

--- a/plugin/adsk/scripts/mayaUsd_layerUtils.py
+++ b/plugin/adsk/scripts/mayaUsd_layerUtils.py
@@ -1,0 +1,74 @@
+from pxr import Sdf
+from maya import cmds
+import mayaUsd
+
+
+def getlayerEditorLayerIds(panelName):
+    '''Returns the list of layer ids for the selected layers in the layer editor. Returns an empty list if the panel name is invalid.'''
+    if not panelName:
+        return []
+    return cmds.mayaUsdLayerEditorWindow(panelName, query=True, getSelectedLayers=True)
+
+
+def getLayerEditorProxyShape(panelName):
+    '''Returns the proxy shape path for the given layer editor panel. Returns an empty string if the panel name is invalid.'''
+    if not panelName:
+        return ""
+    return cmds.mayaUsdLayerEditorWindow(panelName, query=True, proxyShape=True)
+
+
+def getLayerEditorStage(panelName):
+    '''Returns the stage for the given layer editor panel. Returns None if the panel name is invalid or the proxy shape does not have a stage.'''
+    proxyShapePath = getLayerEditorProxyShape(panelName)
+    if not proxyShapePath:
+        return None
+    stage = mayaUsd.lib.GetPrim(proxyShapePath).GetStage()
+    return stage
+
+
+def _getAllSessionLayerIds(stage):
+    '''Returns a list of all session layer ids for the given stage.'''
+    if not stage:
+        return set()
+    sessionLayer = stage.GetSessionLayer()
+    todo = [sessionLayer]
+    sessionLayerIds = set()
+    while todo:
+        layer = todo.pop()
+        sessionLayerIds.add(layer.identifier)
+        for subLayerId in layer.subLayerPaths:
+            subLayer = Sdf.Layer.Find(subLayerId)
+            todo.append(subLayer)
+    return sessionLayerIds
+
+
+def isSessionInLayerEditorSelection(panelName):
+    '''Returns true if the panel is valid and any of the selected layers in the layer editor are session layers.'''
+    stage = getLayerEditorStage(panelName)
+    if not stage:
+        return False
+
+    sessionLayers = _getAllSessionLayerIds(stage)
+
+    layerIds = getlayerEditorLayerIds(panelName)
+    for layerId in layerIds:
+        layer = Sdf.Layer.Find(layerId)
+        if layer and layer.identifier in sessionLayers:
+            return True
+    return False
+
+
+def isNonSessionInLayerEditorSelection(panelName):
+    '''Returns true if the panel is valid and any of the selected layers in the layer editor are non-session layers.'''
+    stage = getLayerEditorStage(panelName)
+    if not stage:
+        return False
+
+    sessionLayers = _getAllSessionLayerIds(stage)
+
+    layerIds = getlayerEditorLayerIds(panelName)
+    for layerId in layerIds:
+        layer = Sdf.Layer.Find(layerId)
+        if layer and layer.identifier not in sessionLayers:
+            return True
+    return False


### PR DESCRIPTION
- Added Python helper functions to check if the layer editor selection contain session or non-session layers.
- Use them when creating the menu to avoid merging session and non-session layers.