### PR TITLE
EMSUSD-3709 ill-formed sdfpath warning

### DIFF
--- a/lib/mayaUsd/ufe/Utils.cpp
+++ b/lib/mayaUsd/ufe/Utils.cpp
@@ -174,9 +174,19 @@ UsdPrim ufePathToPrim(const Ufe::Path& path)
     // If there is only a single segment in the path, it must point to the
     // proxy shape, otherwise we would not have retrieved a valid stage.
     // The second path segment is the USD path.
-    return (segments.size() == 1u)
-        ? stage->GetPseudoRoot()
-        : stage->GetPrimAtPath(SdfPath(segments[1].string()).GetPrimPath());
+    if (segments.size() == 1u) {
+        return stage->GetPseudoRoot();
+    }
+
+    // If the USD path is empty, return the root. UfeSegment::string does not return a leading
+    // separator...!
+    std::string primPathStr = segments[1].string();
+    if (primPathStr.empty()) {
+        return stage->GetPseudoRoot();
+    }
+
+    // Note: we call GetPrimPath in case the path is to a property or relationship, etc.
+    return stage->GetPrimAtPath(SdfPath(primPathStr).GetPrimPath());
 }
 
 std::string uniqueChildNameMayaStandard(


### PR DESCRIPTION
Passing an empty text string to the SdfPath constructor causes  that warning to be emitted. Prevent it by detecting an empty path string and returning the USD psuedo-root in that case. Note that the path is not "really" empty, just that it contains just the "/" which gets parsed as an empty UFE segment. This happens when USD sends notification about the stage pseudo root.