### PR TITLE
Fixing component editing issue caused by the new EF fallback rule.

### DIFF
--- a/lib/mayaUsd/editForward/MayaUsdEditForwardHost.cpp
+++ b/lib/mayaUsd/editForward/MayaUsdEditForwardHost.cpp
@@ -292,7 +292,10 @@ std::vector<AdskUsdEditForward::RuleDef::Ptr> MayaUsdEditForwardController::GetR
     // Start with any rules authored on the stage (read from root layer custom data).
     auto rules = AdskUsdEditForward::StageRuleProvider::GetRules();
 
-    if (_fallbackTarget) {
+    // No rule for a session-layer fallback: session->session moves nothing.
+    const bool hasNonSessionFallback
+        = _fallbackTarget && _stage && _fallbackTarget != _stage->GetSessionLayer();
+    if (hasNonSessionFallback) {
         // Append an in-memory catch-all rule targeting the fallback layer.
         // Appended last so any user-authored rules take precedence.
         static const std::string kFallbackRuleId = "maya_ef_fallback_rule";

--- a/test/lib/testAdskUsdEditForwardLayerEditor.py
+++ b/test/lib/testAdskUsdEditForwardLayerEditor.py
@@ -529,5 +529,39 @@ class EditForwardLayerEditorTestCase(unittest.TestCase):
             "Got: {}".format(stage.GetEditTarget().GetLayer().identifier))
 
 
+    def testActivateEFOnSessionLayerTargetNoFallbackRule(self):
+        """Activating EF while the edit target is the session layer stores the session layer as
+        the fallback (so the API can report it). With the target being the session layer, nothing
+        should be forwarded or removed, and the edits should stay on the session layer."""
+        shapeNodePath, stage, layerA, layerB = self._createStageWithSublayers()
+        sessionLayer = stage.GetSessionLayer()
+
+        # Set the edit target to the session layer before activating EF.
+        cmds.mayaUsdEditTarget(shapeNodePath, edit=True, editTarget=sessionLayer.identifier)
+        self.assertEqual(stage.GetEditTarget().GetLayer(), sessionLayer)
+
+        # Activate EF with a rule that won't match edits, so they fall through to the fallback.
+        self._writeRules(stage.GetRootLayer(), inputExpr='/NoMatch.*')
+        self.assertEqual(stage.GetEditTarget().GetLayer(), sessionLayer)
+        self.assertEqual(
+            cmds.mayaUsdEditTarget(shapeNodePath, query=True, editTarget=True)[0],
+            sessionLayer.identifier,
+            "When EF seeds from the session layer, query must report the session layer")
+
+        # Edits must remain on the session layer.
+        shapeItem = ufe.Hierarchy.createItem(ufe.PathString.path(shapeNodePath))
+        contextOps = ufe.ContextOps.contextOps(shapeItem)
+        ufeCmd.execute(contextOps.doOpCmd(['Add New Prim', 'Xform']))
+        cmds.flushIdleQueue()
+
+        primPath = Sdf.Path('/Xform1')
+        self.assertIsNotNone(
+            sessionLayer.GetPrimAtPath(primPath),
+            "With a session-layer fallback (no rule), edits must stay on the session layer")
+        self.assertIsNone(
+            layerA.GetPrimAtPath(primPath),
+            "With a session-layer fallback (no rule), edits must not reach layerA")
+
+
 if __name__ == '__main__':
     fixturesUtils.runTests(globals())


### PR DESCRIPTION
In components, the root layer is locked, this auto-targets the session layer. There are rules setup on components, so we fall in "edit forward mode". A fallback rule is created, and because the target is the session layer, the fallback target is the session layer. 

When an edit happens on the session layer, src = session, target = session. The edit is forwarded onto itself and then deleted in the source... so we loose the edit. Fix in maya-usd is to just not use a fallback rule if the target is the session layer. I will also do a change in the EF component so that nothing is forwarded in case source layer == target layer.