### PR TITLE
EMSUSD-3785 fix merging layer with locked parents

### DIFF
--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -977,7 +977,7 @@ public:
 
             // Creates a set of the added subLayers, prevent duplicates.
             std::set<std::string> addedSublayerIds;
-            for (const auto& path : strongLayerSubLayers) {
+            for (const auto path : strongLayerSubLayers) {
                 const auto existingLayer = SdfLayer::FindRelativeToLayer(strongestLayer, path);
                 if (existingLayer) {
                     addedSublayerIds.insert(existingLayer->GetIdentifier());

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -852,7 +852,7 @@ public:
         }
 
         // We will analyze locked layers before doing any modification,
-        // report all problem and abort the command if any layer is locked.
+        // report all problem and abort the command if all layers are locked.
         bool hasProblems = false;
 
         // Convert the list of layer identifier to a list of layer handles.

--- a/lib/mayaUsd/commands/layerEditorCommand.cpp
+++ b/lib/mayaUsd/commands/layerEditorCommand.cpp
@@ -865,17 +865,22 @@ public:
                     TF_RUNTIME_ERROR("Cannot find layer: %s", layerIdentifier.c_str());
                     return false;
                 }
-                if (!layer->PermissionToEdit()) {
-                    TF_WARN(
-                        "Cannot update layer '%s' because it is locked.",
-                        layer->GetDisplayName().c_str());
-                    hasProblems = true;
-                }
                 layersByStrength.push_back(layer);
             }
         }
 
+        if (layersByStrength.empty()) {
+            TF_RUNTIME_ERROR("No valid layer found to stitch");
+            return false;
+        }
+
         const SdfLayerHandle strongestLayer = layersByStrength[0];
+        if (!strongestLayer->PermissionToEdit()) {
+            TF_WARN(
+                "Cannot merge into layer '%s' because it is locked.",
+                strongestLayer->GetDisplayName().c_str());
+            hasProblems = true;
+        }
 
         // Create a map from layer identifier to its parent layer and subLayerPath,
         // to be used for stitching and removals.
@@ -891,10 +896,14 @@ public:
             }
         }
 
-        // Multiple selected weak layers may share the same parent, so batch removals by parent
-        // to avoid calling SetSubLayerPaths more than once per parent layer.
+        // Filter the layers to be merged, only keeping those that have unlocked parents.
+        //
+        // Keep a map of parent layers to their removed children because multiple
+        // selected weak layers may share the same parent, so batch removals by
+        // parent to avoid calling SetSubLayerPaths more than once per parent layer.
         std::map<std::string, std::vector<std::string>> removalsByParent;
         {
+            SdfLayerHandleVector layersToBeMergedAndRemoved;
             for (size_t i = 1; i < layersByStrength.size(); ++i) {
                 const SdfLayerHandle& weakLayer = layersByStrength[i];
                 const std::string     weakLayerId = weakLayer->GetIdentifier();
@@ -910,32 +919,39 @@ public:
                 SdfLayerHandle parenttLayer = it->second.first;
                 if (!parenttLayer->PermissionToEdit()) {
                     TF_WARN(
-                        "Cannot update layer '%s' because its parent '%s' is locked.",
+                        "Cannot merge layer '%s' because its parent '%s' is locked.",
                         weakLayer->GetDisplayName().c_str(),
                         parenttLayer->GetDisplayName().c_str());
-                    hasProblems = true;
                     continue;
                 }
 
                 auto parentLayerId = parenttLayer->GetIdentifier();
                 auto removeLayerPath = it->second.second;
+                layersToBeMergedAndRemoved.push_back(weakLayer);
                 removalsByParent[parentLayerId].push_back(removeLayerPath);
             }
+            layersByStrength.swap(layersToBeMergedAndRemoved);
         }
 
         if (hasProblems) {
             return false;
         }
 
+        // Recheck if there are now no layer to merege from.
+        if (layersByStrength.empty()) {
+            TF_RUNTIME_ERROR("No valid layer found to stitch");
+            return false;
+        }
+
         holdOntoSubLayers(strongestLayer);
 
         // Keep a hold of references for all selected layers, needed for undo().
-        for (size_t i = 1; i < layersByStrength.size(); ++i)
-            _subLayersRefs.push_back(layersByStrength[i]);
+        for (auto& layer : layersByStrength)
+            _subLayersRefs.push_back(layer);
 
         UsdUfe::UsdUndoManager::instance().trackLayerStates(strongestLayer);
-        for (size_t i = 1; i < layersByStrength.size(); ++i)
-            UsdUfe::UsdUndoManager::instance().trackLayerStates(layersByStrength[i]);
+        for (auto& layer : layersByStrength)
+            UsdUfe::UsdUndoManager::instance().trackLayerStates(layer);
         for (const auto& entry : removalsByParent) {
             auto parentLayer = SdfLayer::Find(entry.first);
             if (parentLayer) {
@@ -947,9 +963,8 @@ public:
             UsdUfe::UsdUndoBlock undoBlock(&_undoItem);
 
             std::vector<std::vector<std::string>> movedSubLayers;
-            movedSubLayers.reserve(layersByStrength.size() - 1);
-            for (size_t i = 1; i < layersByStrength.size(); ++i) {
-                const SdfLayerHandle& weakLayer = layersByStrength[i];
+            movedSubLayers.reserve(layersByStrength.size());
+            for (auto& weakLayer : layersByStrength) {
                 movedSubLayers.push_back(weakLayer->GetSubLayerPaths());
                 UsdUtilsStitchLayers(strongestLayer, weakLayer);
             }
@@ -962,7 +977,7 @@ public:
 
             // Creates a set of the added subLayers, prevent duplicates.
             std::set<std::string> addedSublayerIds;
-            for (const auto path : strongLayerSubLayers) {
+            for (const auto& path : strongLayerSubLayers) {
                 const auto existingLayer = SdfLayer::FindRelativeToLayer(strongestLayer, path);
                 if (existingLayer) {
                     addedSublayerIds.insert(existingLayer->GetIdentifier());
@@ -986,8 +1001,8 @@ public:
 
             // Remove any merged weak layers from the sublayer list before setting, to prevent
             // them from being both stitched (merged) and referenced as subLayers.
-            for (size_t i = 1; i < layersByStrength.size(); ++i) {
-                const std::string weakLayerId = layersByStrength[i]->GetIdentifier();
+            for (const auto& weakLayer : layersByStrength) {
+                const std::string weakLayerId = weakLayer->GetIdentifier();
                 const auto        it = std::find(
                     strongLayerSubLayers.begin(), strongLayerSubLayers.end(), weakLayerId);
                 if (it != strongLayerSubLayers.end())

--- a/test/lib/testMayaUsdLayerEditorCommands.py
+++ b/test/lib/testMayaUsdLayerEditorCommands.py
@@ -1192,7 +1192,7 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
         self.assertIsNone(layer1.GetPrimAtPath('/Cube'))
 
     def testStitchMultiLayersWithLockedParentLayer(self):
-        """ Test stitching succeeds when there is multiple layers to be merged and one is under a locked parent layer """
+        """ Test stitching succeeds when there are multiple layers to be merged and one is under a locked parent layer """
 
         shapePath, stage = getCleanMayaStage()
         rootLayer = stage.GetRootLayer()

--- a/test/lib/testMayaUsdLayerEditorCommands.py
+++ b/test/lib/testMayaUsdLayerEditorCommands.py
@@ -1151,7 +1151,7 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
         self.assertEqual(stage.GetEditTarget().GetLayer().identifier, weakLayerId)
 
     def testStitchLayersWithLockedParentLayer(self):
-        """ Test stitching fails when one selected layer is under a locked parent layer """
+        """ Test stitching fails when there is only one layer to be merged and it is under a locked parent layer """
 
         shapePath, stage = getCleanMayaStage()
         rootLayer = stage.GetRootLayer()
@@ -1186,8 +1186,59 @@ class MayaUsdLayerEditorCommandsTestCase(unittest.TestCase):
                 stitchLayers=((shapePath, layer1Id), (shapePath, layer3Id))
             )
 
+        self.assertIn(layer3Id, layer2.subLayerPaths)
+        
         self.assertIsNotNone(layer3.GetPrimAtPath('/Cube'))
         self.assertIsNone(layer1.GetPrimAtPath('/Cube'))
+
+    def testStitchMultiLayersWithLockedParentLayer(self):
+        """ Test stitching succeeds when there is multiple layers to be merged and one is under a locked parent layer """
+
+        shapePath, stage = getCleanMayaStage()
+        rootLayer = stage.GetRootLayer()
+        rootLayerId = rootLayer.identifier
+
+        layer1Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer1")[0]
+        layer2Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer2")[0]
+        layer4Id = cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, addAnonymous="Layer4")[0]
+        layer3Id = cmds.mayaUsdLayerEditor(layer2Id, edit=True, addAnonymous="Layer3")[0]
+
+        rootLayer.subLayerPaths.clear()
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[0, layer1Id])
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[1, layer2Id])
+        cmds.mayaUsdLayerEditor(rootLayer.identifier, edit=True, insertSubPath=[2, layer4Id])
+
+        layer1 = Sdf.Layer.Find(layer1Id)
+        layer2 = Sdf.Layer.Find(layer2Id)
+        layer3 = Sdf.Layer.Find(layer3Id)
+        layer4 = Sdf.Layer.Find(layer4Id)
+
+        with Sdf.ChangeBlock():
+            prim = Sdf.CreatePrimInLayer(layer3, '/Cube')
+            prim.SetInfo('typeName', 'Cube')
+            prim = Sdf.CreatePrimInLayer(layer4, '/Cone')
+            prim.SetInfo('typeName', 'Cone')
+
+        self.assertIsNotNone(layer3.GetPrimAtPath('/Cube'))
+        self.assertIsNone(layer1.GetPrimAtPath('/Cube'))
+
+        self.assertIsNotNone(layer4.GetPrimAtPath('/Cone'))
+        self.assertIsNone(layer1.GetPrimAtPath('/Cone'))
+
+        cmds.mayaUsdLayerEditor(layer2Id, edit=True, lockLayer=(1, 0, shapePath))
+        self.assertFalse(layer2.permissionToEdit)
+
+        cmds.mayaUsdLayerEditor(
+            rootLayerId, edit=True,
+            stitchLayers=((shapePath, layer1Id), (shapePath, layer3Id), (shapePath, layer4Id))
+        )
+
+        self.assertIsNotNone(layer3.GetPrimAtPath('/Cube'))
+        self.assertIsNone(layer1.GetPrimAtPath('/Cube'))
+        self.assertIsNotNone(layer1.GetPrimAtPath('/Cone'))
+
+        self.assertIn(layer3Id, layer2.subLayerPaths)
+        self.assertNotIn(layer4Id, rootLayer.subLayerPaths)
 
     def testStitchLayersPartialSelection(self):
         """ Test stitching only some layers while leaving others untouched """


### PR DESCRIPTION
- Locked layers are allowed to be merged into other layers.
- Only fail if all layers have their parent locked.
- Allow merging even if one of many layers cannot be merged.
- Changed the warnings text.
- Added new unit test for the case where only one layer cannot be merged.