### PR TITLE
UsdUfe: Fix installation of Utils.h

### DIFF
--- a/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.cpp
+++ b/lib/mayaUsd/ufe/trf/UsdTransform3dMayaXformStack.cpp
@@ -25,7 +25,6 @@
 #include <usdUfe/ufe/Utils.h>
 #include <usdUfe/ufe/trf/UsdSetXformOpUndoableCommandBase.h>
 #include <usdUfe/ufe/trf/UsdTransform3dUndoableCommands.h>
-#include <usdUfe/ufe/trf/Utils.h>
 #include <usdUfe/undo/UsdUndoBlock.h>
 #include <usdUfe/undo/UsdUndoableItem.h>
 #include <usdUfe/utils/editRouterContext.h>

--- a/lib/usdUfe/ufe/CMakeLists.txt
+++ b/lib/usdUfe/ufe/CMakeLists.txt
@@ -221,7 +221,6 @@ set(HEADERS
     UsdUndoClearDefaultPrimCommand.h
     UsdUndoableCommand.h
     Utils.h
-    trf/Utils.h
 )
 
 if(CMAKE_UFE_V3_FEATURES_AVAILABLE)

--- a/lib/usdUfe/ufe/UsdUndoRenameCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoRenameCommand.cpp
@@ -17,7 +17,6 @@
 
 #include <usdUfe/ufe/UfeNotifGuard.h>
 #include <usdUfe/ufe/Utils.h>
-#include <usdUfe/ufe/trf/Utils.h>
 #include <usdUfe/undo/UsdUndoBlock.h>
 #include <usdUfe/undo/UsdUndoableItem.h>
 #include <usdUfe/utils/layers.h>

--- a/lib/usdUfe/ufe/trf/UsdSetXformOpUndoableCommandBase.cpp
+++ b/lib/usdUfe/ufe/trf/UsdSetXformOpUndoableCommandBase.cpp
@@ -15,10 +15,11 @@
 //
 #include "UsdSetXformOpUndoableCommandBase.h"
 
+#include "Utils.h"
+
 #include <usdUfe/base/debugCodes.h>
 #include <usdUfe/base/tokens.h>
 #include <usdUfe/ufe/Utils.h>
-#include <usdUfe/ufe/trf/Utils.h>
 #include <usdUfe/undo/UsdUndoBlock.h>
 #include <usdUfe/utils/editRouterContext.h>
 

--- a/lib/usdUfe/ufe/trf/UsdTransform3dCommonAPI.cpp
+++ b/lib/usdUfe/ufe/trf/UsdTransform3dCommonAPI.cpp
@@ -15,11 +15,12 @@
 //
 #include "UsdTransform3dCommonAPI.h"
 
+#include "Utils.h"
+
 #include <usdUfe/base/tokens.h>
 #include <usdUfe/ufe/Utils.h>
 #include <usdUfe/ufe/trf/UsdSetXformOpUndoableCommandBase.h>
 #include <usdUfe/ufe/trf/UsdTransform3dUndoableCommands.h>
-#include <usdUfe/ufe/trf/Utils.h>
 #include <usdUfe/utils/editRouterContext.h>
 
 #include <pxr/base/tf/stringUtils.h>

--- a/lib/usdUfe/ufe/trf/UsdTransform3dMatrixOp.cpp
+++ b/lib/usdUfe/ufe/trf/UsdTransform3dMatrixOp.cpp
@@ -15,13 +15,14 @@
 //
 #include "UsdTransform3dMatrixOp.h"
 
+#include "Utils.h"
+
 #include <usdUfe/base/tokens.h>
 #include <usdUfe/ufe/UsdSceneItem.h>
 #include <usdUfe/ufe/UsdUndoableCommand.h>
 #include <usdUfe/ufe/Utils.h>
 #include <usdUfe/ufe/trf/UsdSetXformOpUndoableCommandBase.h>
 #include <usdUfe/ufe/trf/UsdTransform3dSetObjectMatrix.h>
-#include <usdUfe/ufe/trf/Utils.h>
 #include <usdUfe/ufe/trf/XformOpUtils.h>
 #include <usdUfe/undo/UsdUndoBlock.h>
 #include <usdUfe/undo/UsdUndoableItem.h>


### PR DESCRIPTION
Fixes an install collision between:
- `lib/usdUfe/ufe/Utils.h`
- `lib/usdUfe/ufe/trf/Utils.h`

Both headers were being installed from `lib/usdUfe/ufe/CMakeLists.txt` into the same destination directory, the trf header overwrote the public ufe/Utils.h.

`lib/usdUfe/ufe/trf/Utils.h` is only used by implementation files in `lib/usdUfe/ufe/trf`. This change stops promoting/installing that private helper header and switches the remaining includes to local form.