### PR TITLE
vp2RenderDelegate: fix dangling-reference warning with GCC14

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp
@@ -717,7 +717,7 @@ void MayaUsdRPrim::_ProcessDisplayLayerModes(
     }
 
     if (useRGBColors.asBool()) {
-        auto          colorRGBHolder = UsdMayaUtil::GetPlugDataHandle(colorRGB);
+        const auto    colorRGBHolder = UsdMayaUtil::GetPlugDataHandle(colorRGB);
         const float3& rgbColor = colorRGBHolder->GetDataHandle().asFloat3();
         displayLayerModes._wireframeColorIndex = -1;
         displayLayerModes._wireframeColorRGBA

--- a/lib/mayaUsd/utils/util.h
+++ b/lib/mayaUsd/utils/util.h
@@ -115,7 +115,9 @@ public:
     MAYAUSD_CORE_PUBLIC
     static TfRefPtr<MDataHandleHolder> New(const MPlug& plug);
     MAYAUSD_CORE_PUBLIC
-    MDataHandle GetDataHandle() { return _dataHandle; }
+    const MDataHandle& GetDataHandle() const { return _dataHandle; }
+    MAYAUSD_CORE_PUBLIC
+    MDataHandle& GetDataHandle() { return _dataHandle; }
 
 private:
     MDataHandleHolder(const MPlug& plug, MDataHandle dataHandle);


### PR DESCRIPTION
Fixes this warning/error detected with GCC14:

```
maya-usd/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp:721:23: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
  721 |         const float3& rgbColor = colorRGBHolder->GetDataHandle().asFloat3();
      |                       ^~~~~~~~
/maya-usd/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp:721:74: note: the temporary was destroyed at the end of the full expression ‘pxrInternal_v0_24_11__pxrReserved__::UsdMayaUtil::MDataHandleHolder::GetDataHandle()().Autodesk::Maya::OpenMaya20260000::MDataHandle::asFloat3()’
  721 |         const float3& rgbColor = colorRGBHolder->GetDataHandle().asFloat3();
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~  
```