### PR TITLE
EMSUSD-3774 - Investigate shader node metadata difference causing test failure

### DIFF
--- a/test/lib/ufe/testShaderNodeDef.py
+++ b/test/lib/ufe/testShaderNodeDef.py
@@ -179,10 +179,26 @@ class ShaderNodeDefTestCase(unittest.TestCase):
         nodeDef = nodeDefHandler.definition("ND_add_float")
         output = nodeDef.output("out")
 
-        # TODO - figure out why the value has changed in 26.03 (to boolean True or string "1").
-        # EMSUSD-3774 - Investigate shader node metadata difference causing test failure
         if Usd.GetVersion() < (0, 26, 3):
             self.assertEqual(output.getMetadata("__SDR__defaultinput"), ufe.Value("in1"))
+        else:
+            # EMSUSD-3774 - Investigate shader node metadata difference causing test failure
+            #
+            # For ND_add_float, MaterialX defines the output with defaultinput="in1": when the node
+            # is disabled/bypassed, pass through input in1 (the first operand of the add).
+            #
+            # UsdMtlx copies the MaterialX output attribute straight into SDR metadata.
+            # So the source data is still the string "in1".
+            #
+            # In USD 25.11, maya-usd reads property metadata from the legacy string map.
+            # That path returns the raw stored string "in1".
+            #
+            # Starting in OpenUSD 26.03, Pixar added strongly typed metadata via SdrShaderPropertyMetadata.
+            # For __SDR__defaultinput, the registered type is bool, not string:
+            #   {SdrPropertyMetadata->DefaultInput, _LegacyStringToBool}
+            #   Thus: "in1" is not "0" / "false" / "f", so it becomes true.
+            #
+            self.assertEqual(output.getMetadata("__SDR__defaultinput"), ufe.Value(True))
 
     @unittest.skipUnless(ufeUtils.ufeFeatureSetVersion() >= 4, 'nodeDefHandler is only available in UFE V4 or greater')
     def testNodeCreation(self):


### PR DESCRIPTION
#### EMSUSD-3774 - Investigate shader node metadata difference causing test failure
* Starting in OpenUSD 26.03, Pixar added strongly typed metadata via SdrShaderPropertyMetadata. For __SDR__defaultinput, the registered type is bool, not string: {SdrPropertyMetadata->DefaultInput, _LegacyStringToBool}