### PR TITLE
Fix undefined vtValueToUfeValue when UFE_SCENEITEM_HAS_METADATA is no…

### DIFF
--- a/lib/usdUfe/ufe/UsdShaderAttributeDef.cpp
+++ b/lib/usdUfe/ufe/UsdShaderAttributeDef.cpp
@@ -31,6 +31,7 @@
 #include <pxr/usd/sdr/shaderProperty.h>
 
 #include <map>
+#include <sstream>
 #include <vector>
 
 namespace USDUFE_NS_DEF {
@@ -63,7 +64,13 @@ Ufe::Value getUsdShaderMetaData(const USD_SHADER& shader, const PXR_NS::TfToken&
     const auto& metadata = shader.GetMetadataObject();
     if (metadata.HasItem(key)) {
         auto vtValue = metadata.GetItemValue(key);
+#ifdef UFE_SCENEITEM_HAS_METADATA
         return vtValueToUfeValue(vtValue);
+#else
+        std::stringstream ss;
+        ss << vtValue;
+        return Ufe::Value(ss.str());
+#endif
     }
 #else
 #if PXR_VERSION >= 2505

--- a/lib/usdUfe/ufe/UsdShaderAttributeDef.cpp
+++ b/lib/usdUfe/ufe/UsdShaderAttributeDef.cpp
@@ -31,7 +31,6 @@
 #include <pxr/usd/sdr/shaderProperty.h>
 
 #include <map>
-#include <sstream>
 #include <vector>
 
 namespace USDUFE_NS_DEF {
@@ -64,13 +63,7 @@ Ufe::Value getUsdShaderMetaData(const USD_SHADER& shader, const PXR_NS::TfToken&
     const auto& metadata = shader.GetMetadataObject();
     if (metadata.HasItem(key)) {
         auto vtValue = metadata.GetItemValue(key);
-#ifdef UFE_SCENEITEM_HAS_METADATA
         return vtValueToUfeValue(vtValue);
-#else
-        std::stringstream ss;
-        ss << vtValue;
-        return Ufe::Value(ss.str());
-#endif
     }
 #else
 #if PXR_VERSION >= 2505

--- a/lib/usdUfe/ufe/Utils.cpp
+++ b/lib/usdUfe/ufe/Utils.cpp
@@ -62,7 +62,7 @@ PXR_NAMESPACE_USING_DIRECTIVE
 namespace {
 
 constexpr auto kIllegalUFEPath = "Illegal UFE run-time path %s.";
-#ifdef UFE_SCENEITEM_HAS_METADATA
+#ifdef UFE_V3_FEATURES_AVAILABLE
 constexpr auto kErrorMsgInvalidValueType = "Unexpected Ufe::Value type";
 #endif
 
@@ -1670,7 +1670,7 @@ PXR_NS::VtValue convertUfeVectorToUsd(const Ufe::Value& ufeValue)
 }
 #endif
 
-#ifdef UFE_SCENEITEM_HAS_METADATA
+#ifdef UFE_V3_FEATURES_AVAILABLE
 PXR_NS::VtValue ufeValueToVtValue(const Ufe::Value& ufeValue)
 {
     PXR_NS::VtValue usdValue;


### PR DESCRIPTION
…t defined

The PXR_VERSION >= 2603 code path in getUsdShaderMetaData() unconditionally calls vtValueToUfeValue(), but that function is only defined when UFE_SCENEITEM_HAS_METADATA is set. This causes an undefined symbol linker error when building with latest USD against a Maya/UFE version that doesn't have SceneItem::getMetadata (e.g., Maya 2024). The fallback behavior matches the pattern used elsewhere