### PR TITLE
EMSUSD-3823 fix layer content refresh

### DIFF
--- a/lib/usd/ui/layerEditor/layerEditorWidget.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.cpp
@@ -145,6 +145,13 @@ QLayout* LayerEditorWidget::setupLayout_toolbar()
         this,
         &LayerEditorWidget::onLazyUpdateLayerContents);
 
+    // update layer contents widget on selected layer data change
+    connect(
+        _treeView->layerTreeModel(),
+        &LayerTreeModel::selectedLayerDataChangedSignal,
+        this,
+        &LayerEditorWidget::onLazyUpdateLayerContents);
+
     _buttons._loadLayer = addHIGButton(
         ":/UsdLayerEditor/import_layer",
         StringResources::getAsQString(StringResources::kLoadExistingLayer),

--- a/lib/usd/ui/layerEditor/layerTreeModel.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeModel.cpp
@@ -294,11 +294,12 @@ void LayerTreeModel::setSessionState(SessionState* in_sessionState)
         this,
         &LayerTreeModel::autoHideSessionLayerChanged);
 
-    rebuildModelOnIdle();
+    rebuildModelOnIdle(true);
 }
 
-void LayerTreeModel::rebuildModelOnIdle()
+void LayerTreeModel::rebuildModelOnIdle(bool dataChanged)
 {
+    _selectedLayerDataChanged |= dataChanged;
     if (!_rebuildOnIdlePending) {
         _rebuildOnIdlePending = true;
         QTimer::singleShot(0, this, [this]() {
@@ -312,6 +313,11 @@ void LayerTreeModel::rebuildModel(bool refreshLockState /*= false*/)
 {
     _rebuildOnIdlePending = false;
     _lastAskedAnonLayerNameSinceRebuild = 0;
+
+    if (_selectedLayerDataChanged) {
+        Q_EMIT selectedLayerDataChangedSignal();
+        _selectedLayerDataChanged = false;
+    }
 
     if (!_sessionState->isValid()) {
         if (rowCount() > 0) {
@@ -472,7 +478,7 @@ void LayerTreeModel::usd_layerChanged(SdfNotice::LayersDidChangeSentPerLayer con
 {
     // experienced crashes in python prototype  For now, rebuild everything
     if (!_blockUsdNotices)
-        rebuildModelOnIdle();
+        rebuildModelOnIdle(true);
 }
 
 // notification from USD

--- a/lib/usd/ui/layerEditor/layerTreeModel.h
+++ b/lib/usd/ui/layerEditor/layerTreeModel.h
@@ -124,6 +124,7 @@ public:
 
 Q_SIGNALS:
     void selectLayerSignal(const QModelIndex&);
+    void selectedLayerDataChangedSignal();
 
 protected:
     // slots
@@ -149,8 +150,9 @@ protected:
 
     mutable int _lastAskedAnonLayerNameSinceRebuild = 0;
 
-    void rebuildModelOnIdle();
+    void rebuildModelOnIdle(bool dataChanged = false);
     bool _rebuildOnIdlePending = false;
+    bool _selectedLayerDataChanged = false;
     void rebuildModel(bool refreshLockState = false);
 
     void updateTargetLayer(InRebuildModel inRebuild);


### PR DESCRIPTION
The layer contents widget was only refreshed on Qt selection changed signal.  The layer model optimization  broke the refresh because it now avoid rebuilding the model if the layer tree has not changed. Before this optimization , any change to data in the layer, for example moving a prim, would trigger a full tree  model rebuild, which indirectly emitted a selection change signal.

Fix:
- Add a specific signal when data change.
- Now, when the model receives a layer data change signal, it tells the model-rebuild function that it is being called due to internal layer data change.
- The model rebuilding emit the new signal.
- This reuse the on-idle behavior to limit signal traffic, avoiding emitting the signal constantly.
- Make the layer editor widget listen to this signal and update the contents.