### PR TITLE
EMSUSD-3870 - MAYA Integration : Fix lib name for RenderSetup

### DIFF
--- a/cmake/modules/FindAdskUsdRenderSetup.cmake
+++ b/cmake/modules/FindAdskUsdRenderSetup.cmake
@@ -13,7 +13,7 @@ message(STATUS "Finding Autodesk USD Render Setup")
 
 find_path(ADSK_USD_RENDER_SETUP_INCLUDE_DIR
     NAMES
-        RenderSetup/RenderSetupVersion.h
+        AdskUsdRenderSetup/AdskUsdRenderSetupVersion.h
     HINTS
         $ENV{ADSK_USD_RENDER_SETUP_ROOT_DIR}
         ${ADSK_USD_RENDER_SETUP_ROOT_DIR}
@@ -29,7 +29,7 @@ find_path(ADSK_USD_RENDER_SETUP_INCLUDE_DIR
 
 find_library(ADSK_USD_RENDER_SETUP_LIBRARY
     NAMES
-        RenderSetup
+        AdskUsdRenderSetup
     HINTS
         $ENV{ADSK_USD_RENDER_SETUP_ROOT_DIR}
         ${ADSK_USD_RENDER_SETUP_ROOT_DIR}
@@ -44,9 +44,10 @@ find_library(ADSK_USD_RENDER_SETUP_LIBRARY
 # Render Setup version
 
 if(ADSK_USD_RENDER_SETUP_INCLUDE_DIR)
+    set(adsk_rs_version_header "${ADSK_USD_RENDER_SETUP_INCLUDE_DIR}/AdskUsdRenderSetup/AdskUsdRenderSetupVersion.h")
     file(
         STRINGS
-        ${ADSK_USD_RENDER_SETUP_INCLUDE_DIR}/RenderSetup/RenderSetupVersion.h
+        ${adsk_rs_version_header}
         ADSK_USD_RENDER_SETUP_VERSION
         REGEX "define RENDER_SETUP_VERSION .*")
     if(ADSK_USD_RENDER_SETUP_VERSION)

--- a/lib/usd/ui/renderSetup/mayaEditCommitter.h
+++ b/lib/usd/ui/renderSetup/mayaEditCommitter.h
@@ -19,9 +19,9 @@
 
 #include <pxr/usd/usd/stage.h>
 
+#include <AdskUsdRenderSetup/HostStage.h>
+#include <AdskUsdRenderSetup/IEditCommitter.h>
 #include <QtCore/QObject>
-#include <RenderSetup/HostStage.h>
-#include <RenderSetup/IEditCommitter.h>
 
 #include <functional>
 #include <string>

--- a/lib/usd/ui/renderSetup/renderSetupWindowCmd.cpp
+++ b/lib/usd/ui/renderSetup/renderSetupWindowCmd.cpp
@@ -18,7 +18,6 @@
 #include "mayaEditCommitter.h"
 
 #include <mayaUsd/nodes/proxyShapeBase.h>
-#include <mayaUsd/nodes/usdSceneSettingsManager.h>
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/utils/mayaNodeTypeObserver.h>
 
@@ -34,23 +33,29 @@
 #include <maya/MSceneMessage.h>
 #include <maya/MSyntax.h>
 
+#include <AdskUsdRenderSetup/RenderSetupWidget.h>
 #include <QtCore/QPointer>
 #include <QtCore/QTimer>
 #include <QtGui/QAction>
 #include <QtWidgets/QMainWindow>
 #include <QtWidgets/QMenuBar>
 #include <QtWidgets/QVBoxLayout>
-#include <RenderSetup/RenderSetupWidget.h>
 
 #include <algorithm>
 #include <vector>
+
+#ifdef MAYA_HAS_USD_SETTINGS_NODES
+#include <mayaUsd/nodes/usdSceneSettingsManager.h>
+#endif
 
 namespace MAYAUSD_NS_DEF {
 
 class RenderSetupWindow;
 
-const MString     RenderSetupWindowCmd::commandName("mayaUsdRenderSetupWindow");
+const MString RenderSetupWindowCmd::commandName("mayaUsdRenderSetupWindow");
+#ifdef MAYA_HAS_USD_SETTINGS_NODES
 const std::string kUSDRenderSettingsNodeName("UsdDefaultRenderSettings");
+#endif
 
 namespace {
 constexpr auto kReloadFlag = "-rl";

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -113,7 +113,7 @@ else()
 endif()
 
 if (AdskUsdRenderSetup_FOUND)
-    mayaUsd_get_unittest_target(target testUsdRenderSetup.py)
+    mayaUsd_get_unittest_target(target testAdskUsdRenderSetup.py)
     mayaUsd_add_test(${target}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         PYTHON_MODULE ${target}

--- a/test/lib/testAdskUsdRenderSetup.py
+++ b/test/lib/testAdskUsdRenderSetup.py
@@ -21,6 +21,8 @@ import unittest
 import maya.cmds as cmds
 import maya.mel as mel
 
+from mayaUsd.lib import UsdDefaultRenderSettings
+
 class VerifyUsdRenderSetupTestCase(unittest.TestCase):
     """ Test the Usd Render Setup. """
 
@@ -33,3 +35,19 @@ class VerifyUsdRenderSetupTestCase(unittest.TestCase):
     def testWindowCommandExists(self):
         # Verify that the render setup window command exists, which indicates that the render setup UI is available.
         self.assertTrue(mel.eval('exists mayaUsdRenderSetupWindow'))
+
+    def testPythonBindings(self):
+        # Verify that we can load the python bindings and call at least one method.
+        try:
+            import AdskUsdRenderSetup as rs
+        except ImportError as e:
+            self.fail(f"Failed to import my_module: {e}")
+
+        self.assertEqual(rs.__name__, 'AdskUsdRenderSetup')
+        self.assertTrue(rs.__version_info__ >= (0, 0, 1))
+
+        stage = UsdDefaultRenderSettings.getUsdStage()
+        self.assertIsNotNone(rs.GetAllRenderSettingsPaths(stage))
+
+        prim = rs.GetActiveRenderSettings(stage)
+        self.assertTrue(prim)


### PR DESCRIPTION
#### EMSUSD-3870 - MAYA Integration : Fix lib name for RenderSetup
* Adapt to name changes in RenderSetup shared component.
* Added missing ifdef to guard when not building with RS.
* Rename RS test to be consistent with other shared component tests.
* Update RS test to test python bindings.