### PR TITLE
EMSUSD-3880 Optimizes Multi-stage loading performance

### DIFF
--- a/lib/usd/ui/layerEditor/layerTreeModel.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeModel.cpp
@@ -297,13 +297,17 @@ void LayerTreeModel::setSessionState(SessionState* in_sessionState)
     rebuildModelOnIdle(true);
 }
 
-void LayerTreeModel::rebuildModelOnIdle(bool dataChanged)
+void LayerTreeModel::rebuildModelOnIdle(bool dataChanged, bool refreshLockState)
 {
+    // Coalesce rebuilds within one event-loop turn into a single rebuild. Accumulate
+    // the strongest request across coalesced callers (data-changed and lock-refresh).
     _selectedLayerDataChanged |= dataChanged;
+    _rebuildOnIdleRefreshLockState = _rebuildOnIdleRefreshLockState || refreshLockState;
     if (!_rebuildOnIdlePending) {
         _rebuildOnIdlePending = true;
         QTimer::singleShot(0, this, [this]() {
-            bool refreshLockState = false;
+            const bool refreshLockState = _rebuildOnIdleRefreshLockState;
+            _rebuildOnIdleRefreshLockState = false;
             this->rebuildModel(refreshLockState);
         });
     }
@@ -527,8 +531,9 @@ void LayerTreeModel::usd_layerDirtinessChanged(
 // called from SessionState::currentStageChangedSignal
 void LayerTreeModel::sessionStageChanged()
 {
-    bool refreshLockState = true;
-    rebuildModel(refreshLockState);
+    // Coalesce: a burst of stage changes collapses into one rebuild instead of
+    // rebuilding synchronously on every change.
+    rebuildModelOnIdle(/*dataChanged*/ false, /*refreshLockState*/ true);
 }
 
 // called from SessionState::autoHideSessionLayerSignal

--- a/lib/usd/ui/layerEditor/layerTreeModel.h
+++ b/lib/usd/ui/layerEditor/layerTreeModel.h
@@ -150,9 +150,10 @@ protected:
 
     mutable int _lastAskedAnonLayerNameSinceRebuild = 0;
 
-    void rebuildModelOnIdle(bool dataChanged = false);
+    void rebuildModelOnIdle(bool dataChanged = false, bool refreshLockState = false);
     bool _rebuildOnIdlePending = false;
     bool _selectedLayerDataChanged = false;
+    bool _rebuildOnIdleRefreshLockState = false;
     void rebuildModel(bool refreshLockState = false);
 
     void updateTargetLayer(InRebuildModel inRebuild);

--- a/lib/usd/ui/layerEditor/layerTreeView.cpp
+++ b/lib/usd/ui/layerEditor/layerTreeView.cpp
@@ -25,6 +25,7 @@
 #include <maya/MGlobal.h>
 #include <maya/MQtUtil.h>
 
+#include <QtCore/QTimer>
 #include <QtGui/QColor>
 #include <QtGui/QCursor>
 #include <QtWidgets/QMenu>
@@ -140,7 +141,7 @@ LayerTreeView::LayerTreeView(SessionState* in_sessionState, QWidget* in_parent)
         _model->sessionState(),
         &SessionState::stageListChangedSignal,
         this,
-        &LayerTreeView::updateFromSessionState);
+        &LayerTreeView::updateFromSessionStateOnIdle);
 
     auto buttonDefinitions = LayerTreeItem::actionButtonsDefinition();
     auto muteActionIter = buttonDefinitions.find(LayerActionType::Mute);
@@ -349,6 +350,19 @@ void LayerViewMemento::restore(LayerTreeView& view, LayerTreeModel& model)
             vsb->setValue(_verticalScrollbarPosition);
             vsb->valueChanged(_verticalScrollbarPosition);
         }
+    }
+}
+
+// Coalesce a burst of stageListChangedSignal notifications into a single refresh
+// (updateFromSessionState re-scans all stages, so avoid doing it per stage).
+void LayerTreeView::updateFromSessionStateOnIdle()
+{
+    if (!_updateFromSessionStatePending) {
+        _updateFromSessionStatePending = true;
+        QTimer::singleShot(0, this, [this]() {
+            _updateFromSessionStatePending = false;
+            updateFromSessionState();
+        });
     }
 }
 

--- a/lib/usd/ui/layerEditor/layerTreeView.h
+++ b/lib/usd/ui/layerEditor/layerTreeView.h
@@ -147,6 +147,9 @@ protected:
 
     // Updates the _cachedModelState using stage data from the session
     void updateFromSessionState();
+    // Coalesced updateFromSessionState (one refresh per event-loop turn).
+    void updateFromSessionStateOnIdle();
+    bool _updateFromSessionStatePending { false };
 
     LayerTreeViewStyle       _treeViewStyle;
     QPointer<LayerTreeModel> _model;

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
@@ -36,6 +36,7 @@
 #include <ufe/selectionNotification.h>
 
 #include <QtCore/QSignalBlocker>
+#include <QtCore/QTimer>
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QLabel>
 
@@ -43,27 +44,17 @@ Q_DECLARE_METATYPE(UsdLayerEditor::SessionState::StageEntry);
 
 namespace {
 
-int getEntryIndexById(
-    const std::string&                                           id,
-    std::vector<UsdLayerEditor::SessionState::StageEntry> const& stages)
+// Find the combo index whose stored StageEntry matches id, or -1. Used instead of
+// SessionState::allStages() (a full DAG scan) so per-stage handlers stay O(combo).
+int comboIndexById(const QComboBox* dropDown, const std::string& id)
 {
-    auto it = std::find_if(
-        stages.begin(), stages.end(), [&id](UsdLayerEditor::SessionState::StageEntry stageEntry) {
-            return (id == stageEntry._id);
-        });
-
-    if (it != stages.end()) {
-        return std::distance(stages.begin(), it);
+    for (int i = 0, count = dropDown->count(); i < count; ++i) {
+        const auto entry = dropDown->itemData(i).value<UsdLayerEditor::SessionState::StageEntry>();
+        if (entry._id == id) {
+            return i;
+        }
     }
-
     return -1;
-}
-
-int getEntryIndexById(
-    UsdLayerEditor::SessionState::StageEntry const&              entry,
-    std::vector<UsdLayerEditor::SessionState::StageEntry> const& stages)
-{
-    return getEntryIndexById(entry._id, stages);
 }
 
 bool loadStagePinnedOption()
@@ -241,7 +232,7 @@ void StageSelectorWidget::setSessionState(SessionState* in_sessionState)
         _sessionState,
         &SessionState::stageListChangedSignal,
         this,
-        &StageSelectorWidget::updateFromSessionState);
+        &StageSelectorWidget::updateFromSessionStateOnIdle);
     connect(
         _sessionState,
         &SessionState::currentStageChangedSignal,
@@ -269,6 +260,23 @@ SessionState::StageEntry const StageSelectorWidget::selectedStage()
 
     return SessionState::StageEntry();
 }
+// Coalesce a burst of stageListChangedSignal notifications into a single dropdown
+// rebuild (last requested selection wins). Avoids a per-stage rebuild + DAG scan.
+void StageSelectorWidget::updateFromSessionStateOnIdle(
+    SessionState::StageEntry const& entryToSelect)
+{
+    _pendingSelectEntry = entryToSelect;
+    if (!_updateFromSessionStatePending) {
+        _updateFromSessionStatePending = true;
+        QTimer::singleShot(0, this, [this]() {
+            _updateFromSessionStatePending = false;
+            const SessionState::StageEntry entry = _pendingSelectEntry;
+            _pendingSelectEntry = SessionState::StageEntry();
+            updateFromSessionState(entry);
+        });
+    }
+}
+
 // repopulates the combo based on the session stage list
 void StageSelectorWidget::updateFromSessionState(SessionState::StageEntry const& entryToSelect)
 {
@@ -326,9 +334,6 @@ void StageSelectorWidget::selectionChanged()
     if (!ufeGlobalSelection)
         return;
 
-    std::vector<SessionState::StageEntry> allStages;
-    bool                                  allStagesFilled = false;
-
     // We will set the currently selected stage to be the stage of the first item
     // that is a USD item. So if multiple stages are selected, the first one wins.
     const Ufe::Selection& ufeSelection = *ufeGlobalSelection;
@@ -337,14 +342,9 @@ void StageSelectorWidget::selectionChanged()
         if (!proxyShapePtr)
             continue;
 
-        if (!allStagesFilled) {
-            allStages = _sessionState->allStages();
-            allStagesFilled = true;
-        }
-
         MFnDagNode        dagNode(proxyShapePtr->thisMObject());
         const std::string id = dagNode.uuid().asString().asChar();
-        const int         index = getEntryIndexById(id, allStages);
+        const int         index = comboIndexById(_dropDown, id);
         if (index == -1)
             continue;
 
@@ -393,7 +393,7 @@ void StageSelectorWidget::updateContentButton()
 void StageSelectorWidget::sessionStageChanged()
 {
     if (!_internalChange) {
-        auto index = getEntryIndexById(_sessionState->stageEntry(), _sessionState->allStages());
+        auto index = comboIndexById(_dropDown, _sessionState->stageEntry()._id);
         if (index != -1) {
             QSignalBlocker blocker(_dropDown);
             _dropDown->setCurrentIndex(index);
@@ -403,7 +403,7 @@ void StageSelectorWidget::sessionStageChanged()
 
 void StageSelectorWidget::stageRenamed(SessionState::StageEntry const& renamedEntry)
 {
-    auto index = getEntryIndexById(renamedEntry, _sessionState->allStages());
+    auto index = comboIndexById(_dropDown, renamedEntry._id);
     if (index != -1) {
         _dropDown->setItemText(index, renamedEntry._displayName.c_str());
         _dropDown->setItemData(index, QVariant::fromValue(renamedEntry));
@@ -412,18 +412,10 @@ void StageSelectorWidget::stageRenamed(SessionState::StageEntry const& renamedEn
 
 void StageSelectorWidget::stageReset(SessionState::StageEntry const& entry)
 {
-    // Individual combo box entries have a short display name and a reference to a stage,
-    // which is not a unique combination.  By construction the combo box indices do line
-    // up with the SessionState StageEntry vector though, so in the case of resetting
-    // a proxy we will find the matching full proxy path in that vector and use its index
-    // to update the combo box.
-    auto count = _dropDown->count();
-    if (count <= 0) {
-        return;
-    }
-
-    auto index = getEntryIndexById(entry, _sessionState->allStages());
-    if (index >= 0 && index < count) {
+    // Refresh only the matching combo item's data, matched locally by id, instead
+    // of SessionState::allStages() (a full DAG scan) — this fires O(N) times.
+    const int index = comboIndexById(_dropDown, entry._id);
+    if (index != -1) {
         _dropDown->setItemData(index, QVariant::fromValue(entry));
     }
 }

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.cpp
@@ -49,8 +49,12 @@ namespace {
 int comboIndexById(const QComboBox* dropDown, const std::string& id)
 {
     for (int i = 0, count = dropDown->count(); i < count; ++i) {
-        const auto entry = dropDown->itemData(i).value<UsdLayerEditor::SessionState::StageEntry>();
-        if (entry._id == id) {
+        // Bind itemData() to a named QVariant so value<>() uses the const-lvalue
+        // overload. Calling value<>() directly on the returned rvalue selects the
+        // move overload, which move-constructs StageEntry and trips a spurious
+        // -Werror=array-bounds under GCC.
+        const QVariant data = dropDown->itemData(i);
+        if (data.value<UsdLayerEditor::SessionState::StageEntry>()._id == id) {
             return i;
         }
     }

--- a/lib/usd/ui/layerEditor/stageSelectorWidget.h
+++ b/lib/usd/ui/layerEditor/stageSelectorWidget.h
@@ -49,6 +49,9 @@ protected:
     // slot:
     void updateFromSessionState(
         SessionState::StageEntry const& entryToSelect = SessionState::StageEntry());
+    // Coalesced updateFromSessionState (one dropdown rebuild per event-loop turn).
+    void updateFromSessionStateOnIdle(
+        SessionState::StageEntry const& entryToSelect = SessionState::StageEntry());
     void stageRenamed(SessionState::StageEntry const& renamedEntry);
     void stageReset(SessionState::StageEntry const& entry);
     void sessionStageChanged();
@@ -64,6 +67,10 @@ private:
     QPushButton*  _collapseContent { nullptr };
     bool          _internalChange { false }; // for notifications
     bool          _pinStageSelection { true };
+
+    // Coalescing state for updateFromSessionStateOnIdle().
+    bool                     _updateFromSessionStatePending { false };
+    SessionState::StageEntry _pendingSelectEntry;
 };
 
 } // namespace UsdLayerEditor


### PR DESCRIPTION
EMSUSD-3880 Optimizes Multi-stage loading performance 

While the Layer Editor is open, loading many USD stages at once was O(N^2): each per-stage notification (stage set, current-stage change, proxy add/remove, selection change) triggered a full model rebuild, combo-box rebuild, or a full-DAG-scan allStages() lookup — once per stage. This coalesces those reactions and removes the per-stage scans, all within the Layer Editor.

Changes:
- `LayerTreeModel::sessionStageChanged` now defers through the coalesced `rebuildModelOnIdle` instead of rebuilding synchronously on every stage
  change; the lock-state refresh is preserved by threading it through the idle rebuild (rebuildModelOnIdle now takes a refreshLockState arg
  alongside dev's dataChanged arg).
- `StageSelectorWidget::updateFromSessionState` is now coalesced: a burst of `stageListChangedSignal` notifications collapses into a single combo  rebuild (last requested selection wins). LayerTreeView::updateFromSessionState is likewise coalesced into a  single refresh per event-loop turn.
- Replaced the `allStages()` (full Maya DAG scan) index lookups in `selectionChanged` / `sessionStageChanged` / `stageRenamed` / `stageReset` with a local combo lookup by id (comboIndexById), since the combo already holds the stage entries. Removed the now-unused `getEntryIndexById` helpers.
  
Impact (500-stage bulk load, Layer Editor open): ~44s -> ~12s (~3.5x);
Layer-Editor self-time ~31s -> ~65ms. The remaining cost is core UsdStageMap / ProxyShapeHandler quadratic work, independent of the Layer Editor, tracked separately.