### PR TITLE
MayaUsdProxyShapeBase: add ability to disable UFE selection per proxy shape

### DIFF
--- a/lib/mayaUsd/nodes/proxyShapeBase.cpp
+++ b/lib/mayaUsd/nodes/proxyShapeBase.cpp
@@ -169,6 +169,7 @@ MObject MayaUsdProxyShapeBase::sessionLayerNameAttr;
 MObject MayaUsdProxyShapeBase::rootLayerNameAttr;
 MObject MayaUsdProxyShapeBase::mutedLayersAttr;
 MObject MayaUsdProxyShapeBase::lockedLayersAttr;
+MObject MayaUsdProxyShapeBase::enableUfeSelectionAttr;
 // Change counter attributes
 MObject MayaUsdProxyShapeBase::updateCounterAttr;
 MObject MayaUsdProxyShapeBase::resyncCounterAttr;
@@ -405,6 +406,17 @@ MStatus MayaUsdProxyShapeBase::initialize()
     typedAttrFn.setInternal(true);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
     retValue = addAttribute(variantFallbacksAttr);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+
+    enableUfeSelectionAttr = numericAttrFn.create(
+        "enableUfeSelection", "eus", MFnNumericData::kBoolean, 1.0, &retValue);
+    CHECK_MSTATUS_AND_RETURN_IT(retValue);
+    numericAttrFn.setReadable(true);
+    numericAttrFn.setWritable(true);
+    numericAttrFn.setKeyable(false);
+    numericAttrFn.setStorable(true);
+    numericAttrFn.setInternal(true);
+    retValue = addAttribute(enableUfeSelectionAttr);
     CHECK_MSTATUS_AND_RETURN_IT(retValue);
 
     // outputs
@@ -670,6 +682,20 @@ void MayaUsdProxyShapeBase::postConstructor()
 }
 
 /* virtual */
+bool MayaUsdProxyShapeBase::setInternalValue(const MPlug& plug, const MDataHandle& handle)
+{
+    bool retVal = true;
+
+    if (plug == enableUfeSelectionAttr) {
+        _enableUfeSelectionAttrValue = handle.asBool();
+    } else {
+        retVal = MPxSurfaceShape::setInternalValue(plug, handle);
+    }
+
+    return retVal;
+}
+
+/* virtual */
 bool MayaUsdProxyShapeBase::getInternalValue(const MPlug& plug, MDataHandle& handle)
 {
     bool retVal = true;
@@ -678,6 +704,8 @@ bool MayaUsdProxyShapeBase::getInternalValue(const MPlug& plug, MDataHandle& han
         handle.set(_UsdStageUpdateCounter);
     } else if (plug == resyncCounterAttr) {
         handle.set(_UsdStageResyncCounter);
+    } else if (plug == enableUfeSelectionAttr) {
+        handle.set(_enableUfeSelectionAttrValue);
     } else {
         retVal = MPxSurfaceShape::getInternalValue(plug, handle);
     }

--- a/lib/mayaUsd/nodes/proxyShapeBase.h
+++ b/lib/mayaUsd/nodes/proxyShapeBase.h
@@ -133,6 +133,9 @@ public:
     MAYAUSD_CORE_PUBLIC
     static MObject lockedLayersAttr;
 
+    MAYAUSD_CORE_PUBLIC
+    static MObject enableUfeSelectionAttr;
+
     // Change counter attributes
     MAYAUSD_CORE_PUBLIC
     static MObject updateCounterAttr;
@@ -196,6 +199,8 @@ public:
 
     MAYAUSD_CORE_PUBLIC
     void postConstructor() override;
+    MAYAUSD_CORE_PUBLIC
+    bool setInternalValue(const MPlug&, const MDataHandle&) override;
     MAYAUSD_CORE_PUBLIC
     bool getInternalValue(const MPlug&, MDataHandle&) override;
     MAYAUSD_CORE_PUBLIC
@@ -316,7 +321,7 @@ public:
     /// hierarchy to be selected independently when using the Viewport 2.0
     /// render delegate.
     ///
-    /// UFE/subpath selection must be enabled or disabled when constructing
+    /// UFE/subpath selection can be enabled or disabled when constructing
     /// the proxy shape. This is primarily intended as a mechanism for
     /// UsdMayaProxyShape to disable UFE/subpath selection. Most of the
     /// usage of pxrUsdProxyShape nodes is when they are brought in by
@@ -324,7 +329,15 @@ public:
     /// pxrUsdReferenceAssembly nodes. In that case, they are intended to
     /// be read-only proxies, and any edits to prims within the hierarchy
     /// should be represented as assembly edits.
-    bool isUfeSelectionEnabled() const { return _isUfeSelectionEnabled; }
+    ///
+    /// Also, the UFE selection can be disabled per-shape by setting the
+    /// enableUfeSelection attribute to off. This attribute can only
+    /// restrict selection further: if construction already hard-disabled
+    /// UFE selection (above), the attribute cannot turn it back on.
+    bool isUfeSelectionEnabled() const
+    {
+        return _isUfeSelectionEnabled && _enableUfeSelectionAttrValue;
+    }
 
     MAYAUSD_CORE_PUBLIC
     bool isShareableStage() const;
@@ -480,6 +493,9 @@ private:
 
     // Whether or not the proxy shape has enabled UFE/subpath selection
     const bool _isUfeSelectionEnabled;
+
+    // Whether or not the `enableUfeSelection` attribute has enabled UFE/subpath selection.
+    bool _enableUfeSelectionAttrValue = true;
 
     // Track the shared mode of the stage as seen in the last compute.
     // Starts off as Unknown when the proxy shape is first created.


### PR DESCRIPTION
This PR adds the ability to disable UFE selection of prims through the viewport, per proxy shape.

This is controlled by a new `enableUfeSelection` boolean attribute on `mayaUsdProxyShapeBase`, defaulting to `true`. Its value is only honored if the proxyShape type didn't already hard-disable UFE selection at construction, so `pxrUsdProxyShape` remains permanently non-UFE-selectable, as before.

This attribute is not exposed in the AE's main sections, it's intended as an advanced/expert setting rather than an everyday, user-facing setting.
