### PR TITLE
Explicitly set args that may be overridden via plugin

### DIFF
--- a/test/lib/usd/translators/testUsdExportEmptyXforms.py
+++ b/test/lib/usd/translators/testUsdExportEmptyXforms.py
@@ -139,7 +139,10 @@ class testUsdExportEmptyXforms(unittest.TestCase):
         '''
         Export to USD, either including or excluding empty Xforms.
         '''
-        cmds.usdExport(file=filename, includeEmptyTransforms=includeEmpties, defaultPrim=defaultPrimPath)
+        cmds.usdExport(file=filename, includeEmptyTransforms=includeEmpties,
+                       defaultPrim=defaultPrimPath, legacyMaterialScope=False,
+                       materialsScopeName='mtl',
+                       chaser=["AddPayloadOrRefChaser"])
 
     def _verifyPrims(self, stage, present = [], absent = []):
         '''

--- a/test/lib/usd/translators/testUsdExportEmptyXforms.py
+++ b/test/lib/usd/translators/testUsdExportEmptyXforms.py
@@ -139,10 +139,7 @@ class testUsdExportEmptyXforms(unittest.TestCase):
         '''
         Export to USD, either including or excluding empty Xforms.
         '''
-        cmds.usdExport(file=filename, includeEmptyTransforms=includeEmpties,
-                       defaultPrim=defaultPrimPath, legacyMaterialScope=False,
-                       materialsScopeName='mtl',
-                       chaser=["AddPayloadOrRefChaser"])
+        cmds.usdExport(file=filename, includeEmptyTransforms=includeEmpties, defaultPrim=defaultPrimPath)
 
     def _verifyPrims(self, stage, present = [], absent = []):
         '''

--- a/test/lib/usd/translators/testUsdExportMaterialX.py
+++ b/test/lib/usd/translators/testUsdExportMaterialX.py
@@ -146,7 +146,8 @@ class testUsdExportMaterialX(unittest.TestCase):
         usdFilePath = os.path.abspath('UsdExportMaterialXTest.usda')
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
             shadingMode='useRegistry', convertMaterialsTo=['MaterialX'],
-            materialsScopeName='Materials', defaultPrim='None')
+            materialsScopeName='Materials', legacyMaterialScope=False,
+            defaultPrim='None')
 
         stage = Usd.Stage.Open(usdFilePath)
         self.assertTrue(stage)
@@ -292,7 +293,8 @@ class testUsdExportMaterialX(unittest.TestCase):
         usdFilePath = os.path.abspath('MaterialX_decal.usda')
         cmds.mayaUSDExport(mergeTransformAndShape=True, file=usdFilePath,
             shadingMode='useRegistry', convertMaterialsTo=['MaterialX'],
-            materialsScopeName='Materials', defaultPrim='None')
+            materialsScopeName='Materials', legacyMaterialScope=False,
+            defaultPrim='None')
 
         stage = Usd.Stage.Open(usdFilePath)
         self.assertTrue(stage)


### PR DESCRIPTION
Explicitly set some arguments that are overridden in Pixar's runtime environment