### PR TITLE
Add missing ShaderStage.h include for MaterialX 1.39.5

### DIFF
--- a/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaSourceCodeNode.cpp
+++ b/lib/mayaUsd/render/MaterialXGenOgsXml/Nodes/MayaSourceCodeNode.cpp
@@ -6,6 +6,7 @@
 #include "MayaSourceCodeNode.h"
 
 #include <MaterialXGenShader/HwShaderGenerator.h>
+#include <MaterialXGenShader/ShaderStage.h>
 
 MATERIALX_NAMESPACE_BEGIN
 


### PR DESCRIPTION
In MaterialX 1.39.5, HwShaderGenerator.h no longer transitively includes ShaderStage.h, which provides DEFINE_SHADER_STAGE and Stage::PIXEL. Add the explicit include to fix the build.