### PR TITLE
Clear attenuation for directional lights in batch renderer

### DIFF
--- a/lib/mayaUsd/render/px_vp20/utils.cpp
+++ b/lib/mayaUsd/render/px_vp20/utils.cpp
@@ -602,6 +602,9 @@ px_vp20Utils::GetLightingContextFromDrawContext(const MHWRender::MDrawContext& c
             if (!viewDirectionAlongNegZ) {
                 lightDirection[2u] = 1.0f;
             }
+
+            // Directional lights don't have attenuation.
+            lightAttenuation = GfVec3f(0.0f);
         }
 
         if (lightNumPositions == 0u && !lightHasDirection) {


### PR DESCRIPTION
Directional lights don't have attenuation, but we were setting (1, 0, 0), indicating constant attenuation. This bumped against a Hydra bug where attenuation was used to determine whether a light was directional. Ensure directional lights have attenuation = (0, 0, 0).