### PR TITLE
Fix unit scaling of skeleton bind and rest transforms

### DIFF
--- a/lib/mayaUsd/fileio/utils/writeUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/writeUtil.cpp
@@ -1369,6 +1369,10 @@ bool UsdMayaWriteUtil::SetScaledAttribute(
     const UsdTimeCode          time,
     FlexibleSparseValueWriter* valueWriter)
 {
+    if (!value) {
+        return false;
+    }
+
     if (scale != 1.0) {
         *value = ScaleMatrix(*value, scale);
     }
@@ -1383,6 +1387,10 @@ bool UsdMayaWriteUtil::SetScaledAttribute(
     const UsdTimeCode          time,
     FlexibleSparseValueWriter* valueWriter)
 {
+    if (!value) {
+        return false;
+    }
+
     if (scale != 1.0) {
         for (GfMatrix4d& matrix : *value) {
             matrix.SetTranslateOnly(matrix.ExtractTranslation() * scale);

--- a/lib/mayaUsd/fileio/utils/writeUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/writeUtil.cpp
@@ -1361,4 +1361,34 @@ bool UsdMayaWriteUtil::SetScaledAttribute(
     return SetAttribute(attr, ScaleMatrices(value, scale), time, valueWriter);
 }
 
+// static
+bool UsdMayaWriteUtil::SetScaledAttribute(
+    const UsdAttribute&        attr,
+    GfMatrix4d*                value,
+    const double               scale,
+    const UsdTimeCode          time,
+    FlexibleSparseValueWriter* valueWriter)
+{
+    if (scale != 1.0) {
+        *value = ScaleMatrix(*value, scale);
+    }
+    return SetAttribute(attr, value, time, valueWriter);
+}
+
+// static
+bool UsdMayaWriteUtil::SetScaledAttribute(
+    const UsdAttribute&        attr,
+    VtMatrix4dArray*           value,
+    const double               scale,
+    const UsdTimeCode          time,
+    FlexibleSparseValueWriter* valueWriter)
+{
+    if (scale != 1.0) {
+        for (GfMatrix4d& matrix : *value) {
+            matrix.SetTranslateOnly(matrix.ExtractTranslation() * scale);
+        }
+    }
+    return SetAttribute(attr, value, time, valueWriter);
+}
+
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/utils/writeUtil.h
+++ b/lib/mayaUsd/fileio/utils/writeUtil.h
@@ -336,12 +336,12 @@ struct UsdMayaWriteUtil
         const UsdTimeCode          time = UsdTimeCode::Default(),
         FlexibleSparseValueWriter* valueWriter = nullptr)
     {
-        if (scale == 1.0) {
-            return SetAttribute(attr, value, time, valueWriter);
+        if (scale != 1.0) {
+            T scaledValue(value * scale);
+            return valueWriter ? valueWriter->SetAttribute(attr, VtValue(scaledValue), time)
+                               : attr.Set(scaledValue, time);
         }
-        T scaledValue(value * scale);
-        return valueWriter ? valueWriter->SetAttribute(attr, VtValue(scaledValue), time)
-                           : attr.Set(scaledValue, time);
+        return SetAttribute(attr, value, time, valueWriter);
     }
 
     MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/fileio/utils/writeUtil.h
+++ b/lib/mayaUsd/fileio/utils/writeUtil.h
@@ -336,8 +336,12 @@ struct UsdMayaWriteUtil
         const UsdTimeCode          time = UsdTimeCode::Default(),
         FlexibleSparseValueWriter* valueWriter = nullptr)
     {
-        return valueWriter ? valueWriter->SetAttribute(attr, VtValue(T(value * scale)), time)
-                           : attr.Set(value, time);
+        if (scale == 1.0) {
+            return SetAttribute(attr, value, time, valueWriter);
+        }
+        T scaledValue(value * scale);
+        return valueWriter ? valueWriter->SetAttribute(attr, VtValue(scaledValue), time)
+                           : attr.Set(scaledValue, time);
     }
 
     MAYAUSD_CORE_PUBLIC
@@ -358,6 +362,28 @@ struct UsdMayaWriteUtil
     static bool SetScaledAttribute(
         const UsdAttribute&        attr,
         const VtMatrix4dArray&     value,
+        const double               scale,
+        const UsdTimeCode          time = UsdTimeCode::Default(),
+        FlexibleSparseValueWriter* valueWriter = nullptr);
+
+    /// \overload
+    /// Matrix values passed by pointer must scale like the matrix overloads
+    /// above (translation only). Without these overloads, resolution selects
+    /// the generic pointer template below, which multiplies every matrix
+    /// component by the scale, including the rotation block and the
+    /// homogeneous corner.
+    MAYAUSD_CORE_PUBLIC
+    static bool SetScaledAttribute(
+        const UsdAttribute&        attr,
+        GfMatrix4d*                value,
+        const double               scale,
+        const UsdTimeCode          time = UsdTimeCode::Default(),
+        FlexibleSparseValueWriter* valueWriter = nullptr);
+
+    MAYAUSD_CORE_PUBLIC
+    static bool SetScaledAttribute(
+        const UsdAttribute&        attr,
+        VtMatrix4dArray*           value,
         const double               scale,
         const UsdTimeCode          time = UsdTimeCode::Default(),
         FlexibleSparseValueWriter* valueWriter = nullptr);

--- a/test/lib/usd/translators/testUsdExportUnitsSkeleton.py
+++ b/test/lib/usd/translators/testUsdExportUnitsSkeleton.py
@@ -69,13 +69,16 @@ class testUsdExportUnitsSkeleton(unittest.TestCase):
         expectedScale = 0.01 / expectedMetersPerUnit
         EPSILON = expectedScale * 1e-5
 
+        # Unit conversion must scale only the translation row of bind/rest
+        # matrices; the rotation block and the homogeneous corner (w == 1)
+        # are unit-independent.
         skeleton = UsdSkel.Skeleton.Get(stage, '/cubeRig/skel/joint1')
         bindTrfs = skeleton.GetBindTransformsAttr().Get()
         self.assertEqual(len(bindTrfs), 1)
         self.assertTrue(
             Gf.IsClose(
                 bindTrfs[0],
-                Gf.Matrix4d(1.0 * expectedScale),
+                Gf.Matrix4d(1.0),
                 EPSILON
             )
         )
@@ -87,10 +90,10 @@ class testUsdExportUnitsSkeleton(unittest.TestCase):
             Gf.IsClose(
                 restTrfs[0],
                 Gf.Matrix4d(
-                    (1 * expectedScale, 0, 0, 0),
-                    (0, 1 * expectedScale, 0, 0),
-                    (0, 0, 1 * expectedScale, 0),
-                    (5 * expectedScale, 5 * expectedScale, 0, 1 * expectedScale)
+                    (1, 0, 0, 0),
+                    (0, 1, 0, 0),
+                    (0, 0, 1, 0),
+                    (5 * expectedScale, 5 * expectedScale, 0, 1)
                 ),
                 EPSILON
             )


### PR DESCRIPTION
## Description

Fixes #4652 (Usd Skeleton export with 'unit' flag still broken; previously
reported as #4377).

Exporting a skinned mesh with a unit conversion (e.g. `-unit m` from a
centimeter scene) produces corrupted skinning: the deformed geometry appears
scrambled/exploded because `Skeleton.bindTransforms` and
`Skeleton.restTransforms` are multiplied **component-wise** by the unit
factor. The rotation block gets scaled and the homogeneous corner ends up at
the factor instead of 1, while everything else in the file (points, xformOps,
`SkelAnimation.translations`, `geomBindTransform`, blend shape offsets) is
converted correctly. Skinning then mixes correctly-converted joint animation
with corrupted inverse bind matrices.

Exported with `-unit m` from a cm scene (joint at (10, 20, 5) cm), before this
fix:

```usda
uniform matrix4d[] bindTransforms = [
    ( (0.01, 0, 0, 0), (0, 0.01, 0, 0), (0, 0, 0.01, 0), (0.1, 0.2, 0.05, 0.01) )
]
```

Expected (only the translation row converts; rotation and w are
unit-independent):

```usda
uniform matrix4d[] bindTransforms = [
    ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0.1, 0.2, 0.05, 1) )
]
```

### Root cause

`UsdMayaWriteUtil::SetScaledAttribute` has matrix overloads that correctly
scale only the translation (via `ScaleMatrix` / `ScaleMatrices`), but they
take the value by **const reference**. `PxrUsdTranslators_JointWriter`
passes `&bindXforms` / `&restXforms` by **pointer** (to use the data-stealing
`VtValue::Take` path), so overload resolution selects the generic pointer
template instead, which computes `*value * scale` — an element-wise scalar
multiply of every matrix component.

These two call sites are the only matrix data passed by pointer; all other
pointer call sites (`points`, `extent`, `curveWidths`, ...) are vector or
scalar arrays, for which the generic template is correct.

### Fix

- `writeUtil.h` / `writeUtil.cpp`: add `GfMatrix4d*` and `VtMatrix4dArray*`
  overloads of `SetScaledAttribute` that scale the translation row only and
  keep the pointer/`VtValue::Take` semantics. Being non-template exact
  matches, they win overload resolution at the existing call sites — no
  writer changes needed.
- `writeUtil.h`: the by-value generic template ignored `scale` in its
  no-`valueWriter` branch (`attr.Set(value, time)` wrote the unscaled
  value); it now scales in both branches and short-circuits on
  `scale == 1.0` like the other overloads.
- `testUsdExportUnitsSkeleton.py`: the test asserted the corrupted matrices
  (whole matrix times the factor, `w == factor`). Expectations now verify
  unit-independent rotation, `w == 1`, and translation-only conversion,
  across all the existing unit variants (nm → mile).

### How this was validated

- Repro: 3-joint chain offset from the origin, skinned cylinder + a bound
  cube with a non-identity `geomBindTransform`, animated over 10 frames;
  exported with `-unit cm` / `m` / `mm` and diffed attribute-by-attribute.
- With the fix, `UsdSkel`-computed skinned points of the `-unit m` export
  match the cm reference exactly (max deviation 0.0 across meshes and
  frames); before the fix they deviated by orders of magnitude.
- Corrected `testUsdExportUnitsSkeleton.py` passes against a build of this
  branch (Maya 2025.3, USD 23.11, Windows 11) and fails against the previous
  behavior.

## Checklist notes

- No public API removed; two exported overloads added to
  `UsdMayaWriteUtil`.
- Behavior change is limited to exports using a unit conversion
  (`-unit` / `-metersPerUnit` different from the Maya scene unit) with
  `exportSkels` enabled.
- Downstream note for reviewers: any pipeline that post-processed these
  corrupted matrices can detect fixed files by `w == 1`.

---

*This fix was developed with the help of [Claude Code](https://claude.com/claude-code).*
*Feel free to make any changes to this pull request*
