### PR TITLE
Fix various EF dialog issues.

### DIFF
--- a/lib/usd/ui/editForward/editForwardDialog.cpp
+++ b/lib/usd/ui/editForward/editForwardDialog.cpp
@@ -89,7 +89,9 @@ EditForwardDialog::EditForwardDialog(const QString& title, QWidget* parent)
 
     // Tell Maya to treat this as a Maya-managed window. This is the same
     // mechanism Maya uses internally to keep its own dialogs from going behind
-    // the main window. This should not be combined with other flags.
+    // the main window. 
+    // Per Maya dev guidance these two calls should be applied alone, without
+    // combining with any other Qt window flags.
     setWindowFlags(Qt::Window);
     setProperty("saveWindowPref", QVariant::fromValue(true));
 

--- a/lib/usd/ui/editForward/editForwardDialog.cpp
+++ b/lib/usd/ui/editForward/editForwardDialog.cpp
@@ -36,6 +36,7 @@
 #include <AdskUsdEditForwardUi/StageEntry.h>
 #include <QtCore/QPointer>
 #include <QtCore/QTimer>
+#include <QtCore/QVariant>
 #include <QtWidgets/QVBoxLayout>
 
 #include <vector>
@@ -79,10 +80,17 @@ struct SelectionObserver : Ufe::Observer
 } // namespace
 
 EditForwardDialog::EditForwardDialog(const QString& title, QWidget* parent)
-    : QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint)
+    : QDialog(parent)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowTitle(title);
+
+    // Tell Maya to treat this as a Maya-managed window. This is the same
+    // mechanism Maya uses internally to keep its own dialogs from going behind
+    // the main window. This should not be combined with other flags.
+    setWindowFlags(Qt::Window);
+    setProperty("saveWindowPref", QVariant::fromValue(true));
+
     resize(
         static_cast<int>(MQtUtil::dpiScale(1250.0f)), static_cast<int>(MQtUtil::dpiScale(1000.0f)));
 

--- a/lib/usd/ui/editForward/editForwardDialog.cpp
+++ b/lib/usd/ui/editForward/editForwardDialog.cpp
@@ -89,7 +89,7 @@ EditForwardDialog::EditForwardDialog(const QString& title, QWidget* parent)
 
     // Tell Maya to treat this as a Maya-managed window. This is the same
     // mechanism Maya uses internally to keep its own dialogs from going behind
-    // the main window. 
+    // the main window.
     // Per Maya dev guidance these two calls should be applied alone, without
     // combining with any other Qt window flags.
     setWindowFlags(Qt::Window);

--- a/lib/usd/ui/editForward/editForwardDialog.cpp
+++ b/lib/usd/ui/editForward/editForwardDialog.cpp
@@ -84,15 +84,14 @@ EditForwardDialog::EditForwardDialog(const QString& title, QWidget* parent)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowTitle(title);
+    // Maya keys saved window preferences off the object name.
+    setObjectName("EditForwardConfigDialog");
 
     // Tell Maya to treat this as a Maya-managed window. This is the same
     // mechanism Maya uses internally to keep its own dialogs from going behind
     // the main window. This should not be combined with other flags.
     setWindowFlags(Qt::Window);
     setProperty("saveWindowPref", QVariant::fromValue(true));
-
-    resize(
-        static_cast<int>(MQtUtil::dpiScale(1250.0f)), static_cast<int>(MQtUtil::dpiScale(1000.0f)));
 
     _forwardWidget = new AdskUsdEditForwardUi::ForwardWidget(this);
     _forwardWidget->setSourceLayerDefault(
@@ -133,6 +132,12 @@ EditForwardDialog::~EditForwardDialog()
     if (ufeSelection && _selectionObserver) {
         ufeSelection->removeObserver(_selectionObserver);
     }
+}
+
+QSize EditForwardDialog::sizeHint() const
+{
+    return QSize(
+        static_cast<int>(MQtUtil::dpiScale(1250.0f)), static_cast<int>(MQtUtil::dpiScale(1000.0f)));
 }
 
 void EditForwardDialog::processNodeAdded(MObject& /*node*/)

--- a/lib/usd/ui/editForward/editForwardDialog.h
+++ b/lib/usd/ui/editForward/editForwardDialog.h
@@ -23,6 +23,7 @@
 #include <maya/MMessage.h>
 #include <ufe/observer.h>
 
+#include <QtCore/QSize>
 #include <QtWidgets/QDialog>
 
 #include <memory>
@@ -45,6 +46,11 @@ public:
 
     void handleSelectionChanged();
     void setActiveStage(PXR_NS::UsdStageRefPtr const& stage);
+
+    // Default size, used only when no geometry has been restored or set by the
+    // user. Deliberately not a resize() in the constructor, which would
+    // override the position and size Maya restores via saveWindowPref.
+    QSize sizeHint() const override;
 
 private:
     void refreshStages();

--- a/lib/usd/ui/editForward/editForwardDialog.h
+++ b/lib/usd/ui/editForward/editForwardDialog.h
@@ -47,9 +47,6 @@ public:
     void handleSelectionChanged();
     void setActiveStage(PXR_NS::UsdStageRefPtr const& stage);
 
-    // Default size, used only when no geometry has been restored or set by the
-    // user. Deliberately not a resize() in the constructor, which would
-    // override the position and size Maya restores via saveWindowPref.
     QSize sizeHint() const override;
 
 private:

--- a/lib/usd/ui/layerEditor/layerEditorWidget.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.cpp
@@ -178,8 +178,7 @@ QLayout* LayerEditorWidget::setupLayout_toolbar()
     _buttons._toggleEFButton = new QPushButton();
     _buttons._toggleEFButton->setFlat(true);
     _buttons._toggleEFButton->setFixedSize(buttonSize, buttonSize);
-    _buttons._toggleEFButton->setToolTip(
-        StringResources::getAsQString(StringResources::kToggleEditForwarding));
+    // Tooltip reflects the current edit forwarding state; set by updateButtons().
     _buttons._toggleEFButton->setObjectName("LayerEditorToggleEFButton");
     toolbar->addWidget(_buttons._toggleEFButton, 0, buttonAlignment);
     connect(
@@ -524,9 +523,13 @@ void LayerEditorWidget::updateButtons()
     _updateButtonsOnIdle = false;
 
 #ifdef WANT_ADSK_USD_EDIT_FORWARD_BUILD
-    // Update the EF toolbar button icon to reflect the current edit forwarding active state.
+    // Update the EF toolbar button icon and tooltip to reflect the current edit forwarding
+    // active state.
     if (_buttons._toggleEFButton) {
         const bool efActive = _sessionState.isEditForwardMode();
+        _buttons._toggleEFButton->setToolTip(StringResources::getAsQString(
+            efActive ? StringResources::kEditForwardingTooltipEnabled
+                     : StringResources::kEditForwardingTooltipDisabled));
         const auto baseName = efActive ? ":/UsdLayerEditor/ef_on" : ":/UsdLayerEditor/ef_default";
         _buttons._toggleEFButton->setStyleSheet(
             QString("QPushButton { padding: %1px; background-image: url(%2); "

--- a/lib/usd/ui/layerEditor/layerEditorWidget.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.cpp
@@ -751,7 +751,12 @@ void LayerEditorWidget::openEditForwardDialog()
             (_editForwardDialog->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
     }
 
-    _editForwardDialog->show();
+    // Only show() a dialog that is actually hidden. Showing a saveWindowPref
+    // window re-applies its stored position, which would move an already-open
+    // dialog away from where the user last dragged it.
+    if (!_editForwardDialog->isVisible()) {
+        _editForwardDialog->show();
+    }
     _editForwardDialog->raise();
     _editForwardDialog->activateWindow();
 }

--- a/lib/usd/ui/layerEditor/layerEditorWidget.cpp
+++ b/lib/usd/ui/layerEditor/layerEditorWidget.cpp
@@ -733,22 +733,27 @@ void LayerEditorWidget::onSplitterMoved(int pos, int index)
 void LayerEditorWidget::openEditForwardDialog()
 {
     auto* ss = &_sessionState;
-    if (_editForwardDialog) {
-        _editForwardDialog->show();
-        _editForwardDialog->raise();
-        _editForwardDialog->activateWindow();
-        return;
+    if (!_editForwardDialog) {
+        _editForwardDialog = new UsdEditForwardConfig::EditForwardDialog(
+            StringResources::getAsQString(StringResources::kConfigureEditForwardingTitle),
+            MQtUtil::mainWindow());
+        // While the layer editor is open, follow its current stage.
+        QObject::connect(ss, &SessionState::currentStageChangedSignal, this, [this, ss]() {
+            if (_editForwardDialog) {
+                _editForwardDialog->setActiveStage(ss->stage());
+            }
+        });
     }
-    _editForwardDialog = new UsdEditForwardConfig::EditForwardDialog(
-        StringResources::getAsQString(StringResources::kConfigureEditForwardingTitle),
-        MQtUtil::mainWindow());
-    // While the layer editor is open, follow its current stage.
-    QObject::connect(ss, &SessionState::currentStageChangedSignal, this, [this, ss]() {
-        if (_editForwardDialog) {
-            _editForwardDialog->setActiveStage(ss->stage());
-        }
-    });
+
+    // If the dialog was previously minimized, restore it before showing.
+    if (_editForwardDialog->isMinimized()) {
+        _editForwardDialog->setWindowState(
+            (_editForwardDialog->windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
+    }
+
     _editForwardDialog->show();
+    _editForwardDialog->raise();
+    _editForwardDialog->activateWindow();
 }
 
 #endif // WANT_ADSK_USD_EDIT_FORWARD_BUILD

--- a/lib/usd/ui/layerEditor/stringResources.h
+++ b/lib/usd/ui/layerEditor/stringResources.h
@@ -55,8 +55,8 @@ const auto kDisplayLayerContentsEmpty    { create("kDisplayLayerContentsEmpty", 
 #ifdef WANT_ADSK_USD_EDIT_FORWARD_BUILD
 const auto kToggleEditForwarding         { create("kToggleEditForwarding", "Toggle Edit Forwarding") };
 const auto kEchoEditForwarding           { create("kEchoEditForwarding", "Echo Edit Forwarding in Script Editor") };
-const auto kConfigureEditForwarding      { create("kConfigureEditForwarding", "Configure Edit Forwarding...") };
-const auto kConfigureEditForwardingTitle { create("kConfigureEditForwardingTitle", "Configure Edit Forwarding") };
+const auto kConfigureEditForwarding      { create("kConfigureEditForwarding", "Edit Forwarding Configuration") };
+const auto kConfigureEditForwardingTitle { create("kConfigureEditForwardingTitle", "USD Edit Forwarding Configuration") };
 #endif
 const auto kDisplayLayerExpandAllValues  { create("kDisplayLayerExpandAllValues", "Expand All Values") };
 const auto kDisplayLayerExpandAllValuesTooltip { create("kDisplayLayerExpandAllValuesTooltip",

--- a/lib/usd/ui/layerEditor/stringResources.h
+++ b/lib/usd/ui/layerEditor/stringResources.h
@@ -53,7 +53,16 @@ const auto kAutoHideSessionLayer         { create("kAutoHideSessionLayer", "Auto
 const auto kDisplayLayerContents         { create("kDisplayLayerContents", "Display Layer Content") };
 const auto kDisplayLayerContentsEmpty    { create("kDisplayLayerContentsEmpty", "Select a single layer to display the contents.\n\nLarge layers may take longer to load.") };
 #ifdef WANT_ADSK_USD_EDIT_FORWARD_BUILD
-const auto kToggleEditForwarding         { create("kToggleEditForwarding", "Toggle Edit Forwarding") };
+const auto kEditForwardingTooltipEnabled { create("kEditForwardingTooltipEnabled",
+                                                  "Edit Forwarding (enabled)\n"
+                                                  "When enabled, forwards scene edits to layers by rule. Unmatched edits go to the current target layer.\n"
+                                                  "When disabled, all edits go to the current target layer.\n\n"
+                                                  "Click to open configuration.") };
+const auto kEditForwardingTooltipDisabled { create("kEditForwardingTooltipDisabled",
+                                                   "Edit Forwarding (disabled)\n"
+                                                   "When enabled, forwards scene edits to layers by rule. Unmatched edits go to the current target layer.\n"
+                                                   "When disabled, all edits go to the current target layer.\n\n"
+                                                   "Click to open configuration.") };
 const auto kEchoEditForwarding           { create("kEchoEditForwarding", "Echo Edit Forwarding in Script Editor") };
 const auto kConfigureEditForwarding      { create("kConfigureEditForwarding", "Edit Forwarding Configuration") };
 const auto kConfigureEditForwardingTitle { create("kConfigureEditForwardingTitle", "USD Edit Forwarding Configuration") };


### PR DESCRIPTION
Adresses several small issues with the Usd Edit Forward configuration dialog.

https://autodesk.atlassian.net/browse/EMSUSD-3907 menu / windows titles
- Fix the menu entry and window title strings to match design.

https://autodesk.atlassian.net/browse/EMSUSD-3936 windows goes behind maya on macOs
- Fixed an issue where on OSX losing focus on the Edit Forward configuration dialog would push it "behind" the maya application.

https://autodesk.atlassian.net/browse/EMSUSD-3940 position/size lost on toggle open/close
- Fixed an issue where the edit forward dialog position and size configured by users was not preserved withing a maya session.

https://autodesk.atlassian.net/browse/EMSUSD-3904
- Fixed EF config button tooltips to match design