### PR TITLE
EMSUSD-3260 collection-based material-binding support

### DIFF
--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/expressionRulesMenu.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/collection/expressionRulesMenu.py
@@ -14,6 +14,8 @@ EXPAND_PRIMS_MENU_OPTION = "Expand Prims"
 EXPAND_PRIMS_PROPERTIES_MENU_OPTION = "Expand Prims and Properties"
 EXPLICIT_ONLY_MENU_OPTION = "Explicit Only"
 INCLUDE_EXCLUDE_LABEL = "Include/Exclude"
+ASSIGN_MATERIAL_LABEL = "Assign Material"
+UNASSIGN_MATERIAL_LABEL = "Unassign Material"
 REMOVE_ALL_LABEL = "Remove All"
 CLEAR_OPINIONS_LABEL = "Clear Opinions from Target Layer"
 PRINT_PRIMS_LABEL = "Print Prims to Script Editor"
@@ -28,16 +30,22 @@ class ExpressionMenu(QMenu):
 
         theme = Theme.instance()
 
+        self._assignMaterialAction = QAction(theme.themeLabel(ASSIGN_MATERIAL_LABEL), self)
+        self._unassignMaterialAction = QAction(theme.themeLabel(UNASSIGN_MATERIAL_LABEL), self)
         self._removeAllAction = QAction(theme.themeLabel(REMOVE_ALL_LABEL), self)
         self._clearOpinionsAction = QAction(theme.themeLabel(CLEAR_OPINIONS_LABEL), self)
         self._printPrimsAction = QAction(theme.themeLabel(PRINT_PRIMS_LABEL), self)
         self._copyCollectionPathAction = QAction(theme.themeLabel(COPY_COLLECTION_PATH_LABEL), self)
         self._helpAction = QAction(theme.themeLabel(HELP_LABEL), self)
 
+        self.addActions([self._assignMaterialAction, self._unassignMaterialAction])
+        self.addSeparator()
         self.addActions([self._removeAllAction, self._clearOpinionsAction])
         self.addSeparator()
         self.addActions([self._printPrimsAction, self._copyCollectionPathAction])
 
+        self._assignMaterialAction.triggered.connect(self._onAssignMaterial)
+        self._unassignMaterialAction.triggered.connect(self._onUnassignMaterial)
         self._removeAllAction.triggered.connect(self._onRemoveAll)
         self._clearOpinionsAction.triggered.connect(self._onClearOpinions)
         self._printPrimsAction.triggered.connect(self._onPrintPrims)
@@ -71,6 +79,16 @@ class ExpressionMenu(QMenu):
             self.expandPrimsPropertiesAction.setChecked(True)
         elif usdExpansionRule == Usd.Tokens.explicitOnly:
             self.explicitOnlyAction.setChecked(True)
+
+        hasMaterialBinding = self._collData.hasMaterialBinding()
+        self._assignMaterialAction.setVisible(not hasMaterialBinding)
+        self._unassignMaterialAction.setVisible(hasMaterialBinding)
+
+    def _onAssignMaterial(self):
+        self._collData.createMaterialBinding()
+
+    def _onUnassignMaterial(self):
+        self._collData.removeMaterialBinding()
 
     def _onRemoveAll(self):
         self._collData.removeAllIncludeExclude()

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/data/collectionData.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/data/collectionData.py
@@ -84,6 +84,31 @@ class CollectionData(QObject):
         '''
         return None
 
+    # Collection material binding
+
+    def hasMaterialBinding(self) -> bool:
+        '''
+        Verify if the collection has a collection-based material binding.
+        '''
+        return False
+
+    def createMaterialBinding(self) -> bool:
+        '''
+        Create an (initially unbound) collection-based material binding for
+        this collection so that it can be edited.
+        Return True if successfully created.
+        Return False if a binding already exists.
+        '''
+        return False
+
+    def removeMaterialBinding(self) -> bool:
+        '''
+        Remove the collection-based material binding for this collection.
+        Return True if successfully removed.
+        Return False if there was no binding to remove.
+        '''
+        return False
+
     # Expression
 
     def getExpansionRule(self):

--- a/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/usdCollectionData.py
+++ b/lib/mayaUsd/resources/ae/usd-shared-components/src/python/usdSharedComponents/usdData/usdCollectionData.py
@@ -3,7 +3,7 @@ from ..data.collectionData import CollectionData
 from .usdCollectionStringListData import CollectionStringListData
 from .validator import validatePrim, validateCollection
 
-from pxr import Sdf, Tf, Usd
+from pxr import Sdf, Tf, Usd, UsdShade
 
 
 PRINT_PRIMS_MSG = "{count} prims included in collection {collName} on {primName}:"
@@ -176,6 +176,63 @@ class UsdCollectionData(CollectionData):
         Clear all opinions about the collection.
         '''
         self._collection.ResetCollection()
+        return True
+
+    # Collection material binding
+
+    _materialBindingPurposes = [UsdShade.Tokens.allPurpose, UsdShade.Tokens.preview, UsdShade.Tokens.full]
+
+    def _getCollectionBindingRel(self, purpose):
+        '''
+        Returns the collection-based material binding relationship for this
+        collection and the given purpose, if authored, or an invalid
+        relationship otherwise.
+        '''
+        matAPI = UsdShade.MaterialBindingAPI(self._prim)
+        return matAPI.GetCollectionBindingRel(self._collection.GetName(), purpose)
+
+    @validateCollection(False)
+    def hasMaterialBinding(self) -> bool:
+        '''
+        Verify if the collection has a collection-based material binding.
+        '''
+        for purpose in self._materialBindingPurposes:
+            if self._getCollectionBindingRel(purpose):
+                return True
+        return False
+
+    @validateCollection(False)
+    def createMaterialBinding(self) -> bool:
+        '''
+        Create an (initially unbound) collection-based material binding for
+        this collection so that it can be edited.
+        '''
+        if self.hasMaterialBinding():
+            return False
+
+        bindingName = self._collection.GetName()
+        collectionPath = Usd.CollectionAPI.GetNamedCollectionPath(self._prim, bindingName)
+
+        # Note: there is no "Create" accessor for a collection binding relationship.
+        #       GetCollectionBindingRel() returns a (possibly still-unauthored) handle
+        #       that SetTargets() will author on demand.
+        matAPI = UsdShade.MaterialBindingAPI.Apply(self._prim)
+        bindingRel = matAPI.GetCollectionBindingRel(bindingName, UsdShade.Tokens.allPurpose)
+        bindingRel.SetTargets([collectionPath])
+        return True
+
+    @validateCollection(False)
+    def removeMaterialBinding(self) -> bool:
+        '''
+        Remove the collection-based material binding for this collection.
+        '''
+        if not self.hasMaterialBinding():
+            return False
+
+        for purpose in self._materialBindingPurposes:
+            bindingRel = self._getCollectionBindingRel(purpose)
+            if bindingRel:
+                self._prim.RemoveProperty(bindingRel.GetName())
         return True
 
     # Expression

--- a/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/ae_template.py
@@ -19,7 +19,7 @@ from .attributeCustomControl import getNiceAttributeName
 from .attributeCustomControl import cleanAndFormatTooltip
 from .connectionsCustomControl import ConnectionsCustomControl
 from .displayCustomControl import DisplayCustomControl
-from .materialCustomControl import MaterialCustomControl
+from .materialCustomControl import MaterialCustomControl, CollectionMaterialCustomControl
 from .metadataCustomControl import MetadataCustomControl
 from .assetInfoCustomControl import AssetInfoCustomControl
 from .relationshipCustomControl import RelationshipCustomControl
@@ -75,7 +75,7 @@ class AETemplate(object):
         # Get the UFE Attributes interface for this scene item.
         self.attrs = ufe.Attributes.attributes(self.item)
         self.addedAttrs = set()
-        self.suppressedAttrs = []
+        self.suppressedAttrs = set()
         self.hasConnectionObserver = False
 
         self.showArrayAttributes = False
@@ -177,9 +177,7 @@ class AETemplate(object):
             for controlCreator in AETemplate._controlCreators:
                 # Control can suppress attributes in the creator function
                 # so we check for supression at each loop
-                if attrName in self.suppressedAttrs:
-                    break
-                if attrName in self.addedAttrs:
+                if self.isAttrAlreadyHandled(attrName):
                     break
 
                 try:
@@ -194,7 +192,16 @@ class AETemplate(object):
 
     def suppress(self, attrName):
         cmds.editorTemplate(suppress=attrName)
-        self.suppressedAttrs.append(attrName)
+        self.suppressedAttrs.add(attrName)
+
+    def isSuppressedAttr(self, attrName):
+        return attrName in self.suppressedAttrs
+
+    def isAddedAttr(self, attrName):
+        return attrName in self.addedAttrs
+
+    def isAttrAlreadyHandled(self, attrName):
+        return self.isSuppressedAttr(attrName) or self.isAddedAttr(attrName)
 
     def defineCustom(self, customObj, attrs=[]):
         create = lambda *args : customObj.onCreate(args)
@@ -205,9 +212,7 @@ class AETemplate(object):
         # We create the section named "layoutName" if at least one
         # of the attributes from the input list exists.
         for attr in attrList:
-            if attr in self.suppressedAttrs:
-                continue
-            if attr in self.addedAttrs:
+            if self.isAttrAlreadyHandled(attr):
                 continue
             if self.attrs.hasAttribute(attr):
                 with ufeAeTemplate.Layout(self, layoutName, collapse):
@@ -387,7 +392,7 @@ class AETemplate(object):
         extraAttrs = []
         otherSchemaAttrs = {item for values in schemasAttributes.values() for item in values}
         for attr in self.attrs.attributeNames:
-            if attr in self.addedAttrs or attr in self.suppressedAttrs or attr in otherSchemaAttrs:
+            if self.isAttrAlreadyHandled(attr) or attr in otherSchemaAttrs:
                 continue
             extraAttrs.append(attr)
         sectionName = mel.eval("uiRes(\"s_TPStemplateStrings.rExtraAttributes\");")
@@ -402,6 +407,49 @@ class AETemplate(object):
             nameMap[attr] = name.title()
         with ufeAeTemplate.Layout(self, sectionName, collapse=collapse):
             self.addControls(attrs, nameMap=nameMap)
+
+    def createCollectionSection(self, sectionName, attrs, schemasAttributes, collapse, typeName):
+        '''
+        Create the section for a named CollectionAPI instance, then, if that
+        collection has a collection-based material binding authored on it, add
+        a sibling section right underneath to edit that binding.
+        '''
+        self.createSection(sectionName, attrs, schemasAttributes, collapse)
+
+        collectionApiSuffix = 'CollectionAPI'
+        if not typeName.endswith(collectionApiSuffix):
+            return
+        instanceName = typeName[:-len(collectionApiSuffix)]
+        if not instanceName:
+            return
+
+        self.createCollectionMaterialBindingSection(instanceName)
+
+    def createCollectionMaterialBindingSection(self, instanceName):
+        '''
+        If the named collection has a collection-based material binding
+        authored on the prim, create a section to edit it and suppress the
+        underlying attributes so they do not also appear in Extra Attributes.
+        '''
+        if not CollectionMaterialCustomControl.hasCollectionMaterial(self.prim, instanceName):
+            return
+
+        matAPI = UsdShade.MaterialBindingAPI(self.prim)
+        authoredRelNames = []
+        for purpose in [UsdShade.Tokens.allPurpose, UsdShade.Tokens.preview, UsdShade.Tokens.full]:
+            bindingRel = matAPI.GetCollectionBindingRel(instanceName, purpose)
+            if bindingRel:
+                authoredRelNames.append(bindingRel.GetName())
+
+        layoutName = '%s Collection Material' % instanceName
+        with ufeAeTemplate.Layout(self, layoutName, collapse=False):
+            createdControl = CollectionMaterialCustomControl(self.item, self.prim, instanceName, self.useNiceName)
+            usdNoticeControl = UsdNoticeListener(self.prim, [createdControl])
+            self.defineCustom(createdControl)
+            self.defineCustom(usdNoticeControl)
+
+        for relName in authoredRelNames:
+            self.suppress(relName)
 
     def findAppliedSchemas(self):
         # loop on all applied schemas and store all those
@@ -604,6 +652,10 @@ class AETemplate(object):
         def addMatSection():
             if not self.addedMaterialSection:
                 self.addedMaterialSection = True
+                # Note: collection sections are handled first because if there are *only*
+                #       collection-based material bindings, we want to show those only 
+                #       and not the material section.
+                self.createAllCollectionMaterialBindingSections()
                 self.createMaterialAttributeSection()
 
         # Function that determines if a section should be expanded.
@@ -632,6 +684,7 @@ class AETemplate(object):
             'assetInfo': self.createAssetInfoSection,
             'metadata': self.createMetadataSection,
             ".*AccessibilityAPI": self.createAccessibilitySection,
+            ".*CollectionAPI": self.createCollectionSection,
         }
 
         # We only want the attributes appearing once so if the prim 
@@ -647,14 +700,18 @@ class AETemplate(object):
             attrs = schemasAttributes[typeName]
             sectionName = self.sectionNameFromSchema(typeName)
             collapse = not isSectionOpen(sectionName)
+            creator = self.createSection
+            isCollectionSchema = False
             for pattern, value in customAttributes.items():
                 if re.fullmatch(pattern, typeName):
                     creator = value
+                    isCollectionSchema = (pattern == ".*CollectionAPI")
                     break
-            else:
-                creator = self.createSection
 
-            creator(sectionName, attrs, schemasAttributes, collapse)
+            if isCollectionSchema:
+                creator(sectionName, attrs, schemasAttributes, collapse, typeName)
+            else:
+                creator(sectionName, attrs, schemasAttributes, collapse)
 
             if sectionName == primTypeName:
                 addMatSection()
@@ -663,7 +720,10 @@ class AETemplate(object):
         addMatSection()        
 
     def createMaterialAttributeSection(self):
-        if not MaterialCustomControl.hasMaterial(self.prim):
+        for rel in MaterialCustomControl.findMaterialRelationships(self.prim):
+            if not self.isAttrAlreadyHandled(rel.GetName()):
+                break
+        else:
             return
         layoutName = getMayaUsdLibString('kLabelMaterial')
         with ufeAeTemplate.Layout(self, layoutName, collapse=False):
@@ -671,6 +731,14 @@ class AETemplate(object):
             usdNoticeControl = UsdNoticeListener(self.prim, [createdControl])
             self.defineCustom(createdControl)
             self.defineCustom(usdNoticeControl)
+
+    def createAllCollectionMaterialBindingSections(self):
+        collectionBindings = CollectionMaterialCustomControl.findCollectionMaterials(self.prim)
+        for instanceName, rel in collectionBindings.items():
+            if self.isAttrAlreadyHandled(rel.GetName()):
+                continue
+            self.createCollectionMaterialBindingSection(instanceName)
+            self.addedAttrs.add(rel.GetName())
 
     def suppressArrayAttribute(self):
         # Suppress all array attributes.

--- a/lib/mayaUsd/resources/ae/usdschemabase/collectionMayaHost.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/collectionMayaHost.py
@@ -8,8 +8,10 @@ from usd_shared_components.usdData.usdCollectionStringListData import Collection
 from maya.api.OpenMaya import MPxCommand, MFnPlugin, MGlobal, MSyntax, MArgDatabase
 import mayaUsd.lib
 import mayaUsd.ufe
+import maya.internal.ufeSupport.ufeCmdWrapper as ufeCmdWrapper
 import maya.mel as mel
 import maya.cmds as cmds
+import ufe
 
 from pxr import Usd
 from typing import AnyStr, Sequence, Tuple
@@ -303,6 +305,35 @@ class MayaCollectionData(UsdCollectionData):
     def setMembershipExpression(self, textExpression: AnyStr):
         with _UsdUndoBlockContext(_SetMembershipExpressionCommand.commandName):
             super().setMembershipExpression(textExpression)
+
+    # Collection material binding
+
+    def _getUfePathString(self) -> str:
+        '''
+        Build the UFE path string for the prim held by this collection data,
+        without requiring a pre-existing UFE scene item.
+        '''
+        stagePathStr = mayaUsd.ufe.stagePath(self._prim.GetStage())
+        mayaSegment = ufe.PathString.path(stagePathStr).segments[0]
+        usdSegment = ufe.PathSegment(str(self._prim.GetPath()), mayaUsd.ufe.getUsdRunTimeId(), '/')
+        return ufe.PathString.string(ufe.Path([mayaSegment, usdSegment]))
+
+    def createMaterialBinding(self) -> bool:
+        if self.hasMaterialBinding():
+            return False
+        cmd = mayaUsd.ufe.CreateCollectionMaterialBindingCommand(
+            self._getUfePathString(), self._collection.GetName())
+        ufeCmdWrapper.execute(cmd)
+        return True
+
+    def removeMaterialBinding(self) -> bool:
+        if not self.hasMaterialBinding():
+            return False
+        # Note: the bool overload removes all purposes of the binding at once.
+        cmd = mayaUsd.ufe.UnbindCollectionMaterialCommand(
+            self._getUfePathString(), self._collection.GetName(), True)
+        ufeCmdWrapper.execute(cmd)
+        return True
 
 
 class MayaStringListData(CollectionStringListData):

--- a/lib/mayaUsd/resources/ae/usdschemabase/materialCustomControl.py
+++ b/lib/mayaUsd/resources/ae/usdschemabase/materialCustomControl.py
@@ -22,7 +22,7 @@ import mayaUsd.ufe
 import mayaUsdUtils
 import maya.internal.ufeSupport.ufeCmdWrapper as ufeCmdWrapper
 
-from pxr import UsdShade
+from pxr import Sdf, Usd, UsdShade
 
 import maya.mel as mel
 import maya.cmds as cmds
@@ -55,15 +55,16 @@ class MaterialCustomControl(object):
     TextField = collections.namedtuple('TextField', ['layout', 'field', 'gotoButton', 'graphButton','graphMenu'])
 
     @staticmethod
-    def hasMaterial(prim):
+    def findMaterialRelationships(prim):
         if not UsdShade.MaterialBindingAPI.CanApply(prim):
-            return False
+            return []
+        relationships = []
         matAPI = UsdShade.MaterialBindingAPI(prim)
         for purpose in [UsdShade.Tokens.allPurpose, UsdShade.Tokens.preview, UsdShade.Tokens.full]:
-            mat, _ = matAPI.ComputeBoundMaterial(purpose)
-            if mat:
-                return True
-        return False
+            mat, rel = matAPI.ComputeBoundMaterial(purpose)
+            if mat and rel:
+                relationships.append(rel)
+        return relationships
     
     def __init__(self, item, prim, useNiceName):
         super(MaterialCustomControl, self).__init__()
@@ -173,13 +174,27 @@ class MaterialCustomControl(object):
 
         return MaterialCustomControl.TextField(rowLayout, textField, gotoButton, graphButton, graphMenu)
 
+    def _makeBindCommand(self, ufePath, value, purpose):
+        '''
+        Create the command used to bind the given material path for the given purpose.
+        Overridden by subclasses supporting other kinds of material bindings.
+        '''
+        return mayaUsd.ufe.BindMaterialCommand(ufePath, value, purpose)
+
+    def _makeUnbindCommand(self, ufePath, purpose):
+        '''
+        Create the command used to unbind the material for the given purpose.
+        Overridden by subclasses supporting other kinds of material bindings.
+        '''
+        return mayaUsd.ufe.UnbindMaterialCommand(ufePath, purpose)
+
     def _setMaterialPurposeBinding(self, purpose, value):
         try:
             ufePath = ufe.PathString.string(self.item.path())
             if value:
-                cmd = mayaUsd.ufe.BindMaterialCommand(ufePath, value, purpose)
+                cmd = self._makeBindCommand(ufePath, value, purpose)
             else:
-                cmd = mayaUsd.ufe.UnbindMaterialCommand(ufePath, purpose)
+                cmd = self._makeUnbindCommand(ufePath, purpose)
             ufeCmdWrapper.execute(cmd)
         except Exception as e:
             cmds.warning(f'Error executing material command: {e}', noContext=True)
@@ -222,6 +237,13 @@ class MaterialCustomControl(object):
         
         return cmds.popupMenu(parent=graphButton, button=True)
     
+    def _makeStrengthCommand(self, ufePath, strength, affectAllPurposes):
+        '''
+        Create the command used to set the material binding strength.
+        Overridden by subclasses supporting other kinds of material bindings.
+        '''
+        return mayaUsd.ufe.SetMaterialBindingStrengthCommand(ufePath, strength, affectAllPurposes)
+
     def _createDropDownField(self, longName, uiNameRes, elementsRes):
         '''
         Create a disabled drop-down menu with the given elements.
@@ -231,11 +253,11 @@ class MaterialCustomControl(object):
             try:
                 if value not in MaterialCustomControl.strengthTokens:
                     return
-                
+
                 ufePath = ufe.PathString.string(self.item.path())
                 strength = MaterialCustomControl.strengthTokens[value]
                 affectAllPurposes = True
-                cmd = mayaUsd.ufe.SetMaterialBindingStrengthCommand(ufePath, strength, affectAllPurposes)
+                cmd = self._makeStrengthCommand(ufePath, strength, affectAllPurposes)
                 ufeCmdWrapper.execute(cmd)
 
                 # Force update of all children in the VP2 delegate.
@@ -260,32 +282,55 @@ class MaterialCustomControl(object):
         # that case we don't need to update our controls since none will change.
         pass
 
+    def _getBoundMaterialInfo(self, purpose):
+        '''
+        Returns the (mat, matRel, directBinding) info used to fill the UI for the given
+        purpose. Overridden by subclasses supporting other kinds of material bindings.
+        '''
+        matAPI = UsdShade.MaterialBindingAPI(self.prim)
+        # Note: ComputeBoundMaterial returns a UsdShade.Material and a UsdRelationship
+        #       even if none is bound. The UsdShade.Material and the UsdRelationship
+        #       will be empty instance. For example, UsdShade.Material.GetPath() would
+        #       return an empty path.
+        mat, matRel = matAPI.ComputeBoundMaterial(purpose)
+        directBinding = matAPI.GetDirectBinding(purpose)
+        return mat, matRel, directBinding
+
+    def _getStrengthBindingRel(self):
+        '''
+        Returns the relationship used to read/write the binding strength.
+        Overridden by subclasses supporting other kinds of material bindings.
+        '''
+        matAPI = UsdShade.MaterialBindingAPI(self.prim)
+        directBinding = matAPI.GetDirectBinding(UsdShade.Tokens.allPurpose)
+        return directBinding.GetBindingRel() if directBinding else None
+
+    def _isInheritingMaterial(self):
+        '''
+        Verify if the default-purpose material is inherited from an ancestor prim.
+        Overridden by subclasses supporting other kinds of material bindings.
+        '''
+        matAPI = UsdShade.MaterialBindingAPI(self.prim)
+        _, defaultMatRel = matAPI.ComputeBoundMaterial(UsdShade.Tokens.allPurpose)
+        return bool(defaultMatRel.GetPrim() != self.prim)
+
     def refresh(self):
         '''
         Fill the UI with the material data.
         '''
-        matAPI = UsdShade.MaterialBindingAPI(self.prim)
-
         for purpose in [UsdShade.Tokens.allPurpose, UsdShade.Tokens.preview, UsdShade.Tokens.full]:
-            # Note: ComputeBoundMaterial returns a UsdShade.Material and a UsdRelationship
-            #       even if none is bound. The UsdShade.Material and the UsdRelationship 
-            #       will be empty instance. For example, UsdShade.Material.GetPath() would
-            #       return an empty path.
-            mat, matRel = matAPI.ComputeBoundMaterial(purpose)
-            directBinding = matAPI.GetDirectBinding(purpose)
+            mat, matRel, directBinding = self._getBoundMaterialInfo(purpose)
             self._fillUIForPurpose(purpose, mat, matRel, directBinding)
 
-        _, defaultMatRel = matAPI.ComputeBoundMaterial(UsdShade.Tokens.allPurpose)
-        isInheriting = bool(defaultMatRel.GetPrim() != self.prim)
+        bindingRel = self._getStrengthBindingRel()
+        isInheriting = self._isInheritingMaterial()
+        self._fillStrengthValue(bindingRel, isInheriting)
 
-        defaultDirectBinding = matAPI.GetDirectBinding(UsdShade.Tokens.allPurpose)
-        self._fillStrengthValue(defaultDirectBinding, isInheriting)
-
-    def _fillStrengthValue(self, directBinding, isInheriting):
+    def _fillStrengthValue(self, bindingRel, isInheriting):
 
         if isInheriting:
             strengthEnabled = False
-            strengthVisible = bool(directBinding)
+            strengthVisible = bool(bindingRel)
             strengthAnnotation = getMayaUsdLibString('kTooltipInheritedStrength')
         else:
             strengthEnabled = True
@@ -293,9 +338,8 @@ class MaterialCustomControl(object):
             strengthAnnotation = getMayaUsdLibString('kLabelMaterialStrength')
 
         # Note: USD TfToken are automatically represented as strings in Python by the USD Python API.
-        if directBinding:
-            directRel = directBinding.GetBindingRel()
-            bindingStrengthToken = UsdShade.MaterialBindingAPI.GetMaterialBindingStrength(directRel)
+        if bindingRel:
+            bindingStrengthToken = UsdShade.MaterialBindingAPI.GetMaterialBindingStrength(bindingRel)
         else:
             bindingStrengthToken = 'weakerThanDescendants'
 
@@ -454,4 +498,100 @@ class MaterialCustomControl(object):
             self.item.path().segments[0],
             ufe.PathSegment(usdPath, mayaUsd.ufe.getUsdRunTimeId(), '/')])
         return ufe.PathString.string(ufePath)
+
+
+class _MaterialPathHolder:
+    '''
+    Minimal adapter exposing the subset of UsdShade.MaterialBindingAPI.DirectBinding's
+    interface used by MaterialCustomControl._fillUIForPurpose(), backed by a plain
+    material path instead of a resolved direct binding.
+    '''
+    def __init__(self, materialPath):
+        self._materialPath = materialPath
+
+    def __bool__(self):
+        return bool(self._materialPath)
+
+    def GetMaterialPath(self):
+        return self._materialPath
+
+
+class CollectionMaterialCustomControl(MaterialCustomControl):
+    '''
+    Custom control to display and edit a collection-based material binding, i.e.
+    a material bound to every member of a named collection on the prim, instead
+    of a material bound directly to the prim itself.
+    '''
+
+    def __init__(self, item, prim, bindingName, useNiceName):
+        super(CollectionMaterialCustomControl, self).__init__(item, prim, useNiceName)
+        self.bindingName = bindingName
+
+    @staticmethod
+    def hasCollectionMaterial(prim, bindingName):
+        '''
+        Verify if the prim has a collection-based material binding for the
+        given (collection instance) binding name, for any purpose.
+        '''
+        matAPI = UsdShade.MaterialBindingAPI(prim)
+        for purpose in [UsdShade.Tokens.allPurpose, UsdShade.Tokens.preview, UsdShade.Tokens.full]:
+            if matAPI.GetCollectionBindingRel(bindingName, purpose):
+                return True
+        return False
+
+    @staticmethod
+    def findCollectionMaterials(prim):
+        '''
+        Find all collection-based material bindings on the given prim,
+        returning a dictionary of binding names to their corresponding binding relationship.
+        '''
+        collectionBindings = {}
+        matAPI = UsdShade.MaterialBindingAPI(prim)
+        for purpose in [UsdShade.Tokens.allPurpose, UsdShade.Tokens.preview, UsdShade.Tokens.full]:
+            bindings = matAPI.GetCollectionBindings(purpose)
+            for binding in bindings:
+                if not binding:
+                    continue
+                collectionBindings[binding.GetCollection().GetName()] = binding.GetBindingRel()
+        return collectionBindings
+
+    def _getBoundMaterialInfo(self, purpose):
+        '''
+        A collection-based binding authored directly on this prim is never
+        "inherited" the way a direct binding can be, so we always report the
+        binding relationship as belonging to this prim -- editable, possibly
+        empty -- rather than trying to compute an ancestor-inherited value.
+        '''
+        matAPI = UsdShade.MaterialBindingAPI(self.prim)
+        bindingRel = matAPI.GetCollectionBindingRel(self.bindingName, purpose)
+
+        matPath = Sdf.Path.emptyPath
+        if bindingRel:
+            collectionPath = Usd.CollectionAPI.GetNamedCollectionPath(self.prim, self.bindingName)
+            for target in bindingRel.GetTargets():
+                if target != collectionPath:
+                    matPath = target
+                    break
+
+        mat = UsdShade.Material(self.prim.GetStage().GetPrimAtPath(matPath)) if matPath else UsdShade.Material()
+        directBinding = _MaterialPathHolder(matPath)
+        return mat, bindingRel, directBinding
+
+    def _getStrengthBindingRel(self):
+        matAPI = UsdShade.MaterialBindingAPI(self.prim)
+        return matAPI.GetCollectionBindingRel(self.bindingName, UsdShade.Tokens.allPurpose)
+
+    def _isInheritingMaterial(self):
+        # Collection-based bindings authored on this prim are never inherited.
+        return False
+
+    def _makeBindCommand(self, ufePath, value, purpose):
+        return mayaUsd.ufe.BindCollectionMaterialCommand(ufePath, value, self.bindingName, purpose)
+
+    def _makeUnbindCommand(self, ufePath, purpose):
+        return mayaUsd.ufe.UnbindCollectionMaterialCommand(ufePath, self.bindingName, purpose)
+
+    def _makeStrengthCommand(self, ufePath, strength, affectAllPurposes):
+        return mayaUsd.ufe.SetMaterialBindingStrengthCommand(
+            ufePath, strength, affectAllPurposes, self.bindingName)
 

--- a/lib/usdUfe/python/wrapCommands.cpp
+++ b/lib/usdUfe/python/wrapCommands.cpp
@@ -155,6 +155,73 @@ UsdUfe::SetMaterialBindingStrengthCommand* SetBindingStrengthAffectAllPurposesCo
         Ufe::PathString::path(primUfePathStr), PXR_NS::TfToken(strength), unassignAll);
 }
 
+UsdUfe::SetMaterialBindingStrengthCommand* SetCollectionBindingStrengthCommandInit(
+    const std::string& primUfePathStr,
+    const std::string& strength,
+    const std::string& purpose,
+    const std::string& bindingName)
+{
+    return new UsdUfe::SetMaterialBindingStrengthCommand(
+        Ufe::PathString::path(primUfePathStr),
+        PXR_NS::TfToken(strength),
+        PXR_NS::TfToken(purpose),
+        PXR_NS::TfToken(bindingName));
+}
+
+UsdUfe::SetMaterialBindingStrengthCommand* SetCollectionBindingStrengthAffectAllPurposesCommandInit(
+    const std::string& primUfePathStr,
+    const std::string& strength,
+    bool               unassignAll,
+    const std::string& bindingName)
+{
+    return new UsdUfe::SetMaterialBindingStrengthCommand(
+        Ufe::PathString::path(primUfePathStr),
+        PXR_NS::TfToken(strength),
+        unassignAll,
+        PXR_NS::TfToken(bindingName));
+}
+
+UsdUfe::CreateCollectionMaterialBindingUndoableCommand* CreateCollectionMaterialBindingCommandInit(
+    const std::string& primUfePathStr,
+    const std::string& bindingName)
+{
+    return new UsdUfe::CreateCollectionMaterialBindingUndoableCommand(
+        Ufe::PathString::path(primUfePathStr), PXR_NS::TfToken(bindingName));
+}
+
+UsdUfe::BindCollectionMaterialUndoableCommand* BindCollectionMaterialCommandInit(
+    const std::string& primUfePathStr,
+    const std::string& matPathStr,
+    const std::string& bindingName,
+    const std::string& purpose)
+{
+    return new UsdUfe::BindCollectionMaterialUndoableCommand(
+        Ufe::PathString::path(primUfePathStr),
+        PXR_NS::SdfPath(matPathStr),
+        PXR_NS::TfToken(bindingName),
+        PXR_NS::TfToken(purpose));
+}
+
+UsdUfe::UnbindCollectionMaterialUndoableCommand* UnbindCollectionMaterialCommandInit(
+    const std::string& primUfePathStr,
+    const std::string& bindingName,
+    const std::string& purpose)
+{
+    return new UsdUfe::UnbindCollectionMaterialUndoableCommand(
+        Ufe::PathString::path(primUfePathStr),
+        PXR_NS::TfToken(bindingName),
+        PXR_NS::TfToken(purpose));
+}
+
+UsdUfe::UnbindCollectionMaterialUndoableCommand* UnbindAllCollectionMaterialCommandInit(
+    const std::string& primUfePathStr,
+    const std::string& bindingName,
+    bool               unassignAll)
+{
+    return new UsdUfe::UnbindCollectionMaterialUndoableCommand(
+        Ufe::PathString::path(primUfePathStr), PXR_NS::TfToken(bindingName), unassignAll);
+}
+
 } // namespace
 
 void wrapCommands()
@@ -332,6 +399,47 @@ void wrapCommands()
             "SetMaterialBindingStrengthCommand", no_init)
             .def("__init__", make_constructor(SetBindingStrengthCommandInit))
             .def("__init__", make_constructor(SetBindingStrengthAffectAllPurposesCommandInit))
+            .def("__init__", make_constructor(SetCollectionBindingStrengthCommandInit))
+            .def(
+                "__init__",
+                make_constructor(SetCollectionBindingStrengthAffectAllPurposesCommandInit))
+            .def("execute", &This::execute)
+#ifdef UFE_V4_FEATURES_AVAILABLE
+            .def("commandString", &This::commandString)
+#endif
+            .def("undo", &This::undo)
+            .def("redo", &This::redo);
+    }
+    {
+        using This = UsdUfe::CreateCollectionMaterialBindingUndoableCommand;
+        class_<This, PXR_BOOST_PYTHON_NAMESPACE::noncopyable>(
+            "CreateCollectionMaterialBindingCommand", no_init)
+            .def("__init__", make_constructor(CreateCollectionMaterialBindingCommandInit))
+            .def("execute", &This::execute)
+#ifdef UFE_V4_FEATURES_AVAILABLE
+            .def("commandString", &This::commandString)
+#endif
+            .def("undo", &This::undo)
+            .def("redo", &This::redo);
+    }
+    {
+        using This = UsdUfe::BindCollectionMaterialUndoableCommand;
+        class_<This, PXR_BOOST_PYTHON_NAMESPACE::noncopyable>(
+            "BindCollectionMaterialCommand", no_init)
+            .def("__init__", make_constructor(BindCollectionMaterialCommandInit))
+            .def("execute", &This::execute)
+#ifdef UFE_V4_FEATURES_AVAILABLE
+            .def("commandString", &This::commandString)
+#endif
+            .def("undo", &This::undo)
+            .def("redo", &This::redo);
+    }
+    {
+        using This = UsdUfe::UnbindCollectionMaterialUndoableCommand;
+        class_<This, PXR_BOOST_PYTHON_NAMESPACE::noncopyable>(
+            "UnbindCollectionMaterialCommand", no_init)
+            .def("__init__", make_constructor(UnbindCollectionMaterialCommandInit))
+            .def("__init__", make_constructor(UnbindAllCollectionMaterialCommandInit))
             .def("execute", &This::execute)
 #ifdef UFE_V4_FEATURES_AVAILABLE
             .def("commandString", &This::commandString)

--- a/lib/usdUfe/ufe/UsdUndoMaterialCommands.cpp
+++ b/lib/usdUfe/ufe/UsdUndoMaterialCommands.cpp
@@ -24,6 +24,7 @@
 
 #include <pxr/usd/sdr/registry.h>
 #include <pxr/usd/sdr/shaderProperty.h>
+#include <pxr/usd/usd/collectionAPI.h>
 #include <pxr/usd/usd/prim.h>
 #include <pxr/usd/usdGeom/scope.h>
 #include <pxr/usd/usdUtils/pipeline.h>
@@ -374,13 +375,225 @@ void UnbindMaterialUndoableCommand::execute()
 
 const std::string UnbindMaterialUndoableCommand::commandName("Unassign Material");
 
+CreateCollectionMaterialBindingUndoableCommand::CreateCollectionMaterialBindingUndoableCommand(
+    Ufe::Path      primPath,
+    const TfToken& bindingName)
+    : _primPath(std::move(primPath))
+    , _bindingName(bindingName)
+{
+    auto prim = ufePathToPrim(_primPath);
+    if (!prim.IsValid()) {
+        std::string err = TfStringPrintf(
+            "Invalid primitive path [%s]. Can not create collection material binding.",
+            Ufe::PathString::string(_primPath).c_str());
+        throw std::runtime_error(err);
+    }
+    if (!_BindMaterialCompatiblePrim(prim)) {
+        std::string err = TfStringPrintf(
+            "Invalid primitive type for binding [%s]. Can not create collection material binding.",
+            Ufe::PathString::string(_primPath).c_str());
+        throw std::runtime_error(err);
+    }
+    if (_bindingName.IsEmpty() || !UsdCollectionAPI::Get(prim, _bindingName)) {
+        std::string err = TfStringPrintf(
+            "Invalid collection name [%s]. Can not create collection material binding.",
+            _bindingName.GetText());
+        throw std::runtime_error(err);
+    }
+}
+
+void CreateCollectionMaterialBindingUndoableCommand::undo() { _undoableItem.undo(); }
+
+void CreateCollectionMaterialBindingUndoableCommand::redo() { _undoableItem.redo(); }
+
+void CreateCollectionMaterialBindingUndoableCommand::execute()
+{
+    auto prim = ufePathToPrim(_primPath);
+
+    // Edit routing is done by a user-provided implementation that can raise exceptions.
+    UsdUfe::AttributeEditRouterContext ctx(prim, UsdShadeTokens->materialBinding);
+
+    UsdUfe::UsdUndoBlock undoBlock(&_undoableItem);
+
+    auto collection = UsdCollectionAPI::Get(prim, _bindingName);
+    if (!collection) {
+        return;
+    }
+
+    // Note: there is no "Create" accessor for a collection binding relationship.
+    //       GetCollectionBindingRel() returns a (possibly still-unauthored) handle
+    //       that SetTargets() will author on demand.
+    auto            bindingAPI = UsdShadeMaterialBindingAPI::Apply(prim);
+    UsdRelationship bindingRel
+        = bindingAPI.GetCollectionBindingRel(_bindingName, UsdShadeTokens->allPurpose);
+    bindingRel.SetTargets({ UsdCollectionAPI::GetNamedCollectionPath(prim, _bindingName) });
+}
+
+const std::string CreateCollectionMaterialBindingUndoableCommand::commandName(
+    "Create Collection Material Binding");
+
+BindCollectionMaterialUndoableCommand::BindCollectionMaterialUndoableCommand(
+    Ufe::Path      primPath,
+    const SdfPath& materialPath,
+    const TfToken& bindingName,
+    const TfToken& purpose)
+    : _primPath(std::move(primPath))
+    , _materialPath(materialPath)
+    , _bindingName(bindingName)
+    , _purpose(purpose.IsEmpty() ? UsdShadeTokens->allPurpose : purpose)
+{
+    auto prim = ufePathToPrim(_primPath);
+    if (!prim.IsValid()) {
+        std::string err = TfStringPrintf(
+            "Invalid primitive path [%s]. Can not bind collection material.",
+            Ufe::PathString::string(_primPath).c_str());
+        throw std::runtime_error(err);
+    }
+    if (!_BindMaterialCompatiblePrim(prim)) {
+        std::string err = TfStringPrintf(
+            "Invalid primitive type for binding [%s]. Can not bind collection material.",
+            Ufe::PathString::string(_primPath).c_str());
+        throw std::runtime_error(err);
+    }
+    if (_materialPath.IsEmpty()
+        || !UsdShadeMaterial(prim.GetStage()->GetPrimAtPath(_materialPath))) {
+        std::string err = TfStringPrintf(
+            "Invalid material path [%s]. Can not bind collection material.",
+            _materialPath.GetAsString().c_str());
+        throw std::runtime_error(err);
+    }
+    if (_bindingName.IsEmpty() || !UsdCollectionAPI::Get(prim, _bindingName)) {
+        std::string err = TfStringPrintf(
+            "Invalid collection name [%s]. Can not bind collection material.",
+            _bindingName.GetText());
+        throw std::runtime_error(err);
+    }
+}
+
+void BindCollectionMaterialUndoableCommand::undo() { _undoableItem.undo(); }
+
+void BindCollectionMaterialUndoableCommand::redo() { _undoableItem.redo(); }
+
+void BindCollectionMaterialUndoableCommand::execute()
+{
+    // All validations were done in the CTOR: proceed.
+    auto prim = ufePathToPrim(_primPath);
+
+    // Edit routing is done by a user-provided implementation that can raise exceptions.
+    UsdUfe::AttributeEditRouterContext ctx(prim, UsdShadeTokens->materialBinding);
+
+    UsdUfe::UsdUndoBlock undoBlock(&_undoableItem);
+
+    auto bindingAPI = UsdShadeMaterialBindingAPI::Apply(prim);
+
+    const UsdRelationship collectionRel
+        = bindingAPI.GetCollectionBindingRel(_bindingName, _purpose);
+    const TfToken strength = collectionRel
+        ? UsdShadeMaterialBindingAPI::GetMaterialBindingStrength(collectionRel)
+        : UsdShadeTokens->fallbackStrength;
+
+    enforceMaterialBindingEditRestriction(collectionRel);
+
+    auto             collection = UsdCollectionAPI::Get(prim, _bindingName);
+    UsdShadeMaterial material(prim.GetStage()->GetPrimAtPath(_materialPath));
+    bindingAPI.Bind(collection, material, _bindingName, strength, _purpose);
+}
+
+const std::string BindCollectionMaterialUndoableCommand::commandName("Bind Collection Material");
+
+UnbindCollectionMaterialUndoableCommand::UnbindCollectionMaterialUndoableCommand(
+    Ufe::Path      primPath,
+    const TfToken& bindingName,
+    const TfToken& purpose)
+    : _primPath(std::move(primPath))
+    , _bindingName(bindingName)
+    , _purpose(purpose.IsEmpty() ? UsdShadeTokens->allPurpose : purpose)
+{
+    validatePrimPath();
+}
+
+UnbindCollectionMaterialUndoableCommand::UnbindCollectionMaterialUndoableCommand(
+    Ufe::Path      primPath,
+    const TfToken& bindingName,
+    bool           unassignAll)
+    : _primPath(std::move(primPath))
+    , _bindingName(bindingName)
+    , _purpose(UsdShadeTokens->allPurpose)
+    , _unassignAll(unassignAll)
+{
+    validatePrimPath();
+}
+
+void UnbindCollectionMaterialUndoableCommand::validatePrimPath() const
+{
+    if (_primPath.empty() || !ufePathToPrim(_primPath).IsValid()) {
+        std::string err = TfStringPrintf(
+            "Invalid primitive path [%s]. Can not unbind collection material.",
+            Ufe::PathString::string(_primPath).c_str());
+        throw std::runtime_error(err);
+    }
+}
+
+UnbindCollectionMaterialUndoableCommand::~UnbindCollectionMaterialUndoableCommand() { }
+
+void UnbindCollectionMaterialUndoableCommand::undo() { _undoableItem.undo(); }
+
+void UnbindCollectionMaterialUndoableCommand::redo() { _undoableItem.redo(); }
+
+void UnbindCollectionMaterialUndoableCommand::execute()
+{
+    auto prim = ufePathToPrim(_primPath);
+
+    // Edit routing is done by a user-provided implementation that can raise exceptions.
+    UsdUfe::AttributeEditRouterContext ctx(prim, UsdShadeTokens->materialBinding);
+
+    UsdUfe::UsdUndoBlock undoBlock(&_undoableItem);
+
+    auto bindingAPI = UsdShadeMaterialBindingAPI(prim);
+    if (!bindingAPI) {
+        return;
+    }
+
+    std::vector<TfToken> purposes;
+    if (_unassignAll) {
+        purposes.push_back(UsdShadeTokens->allPurpose);
+        purposes.push_back(UsdShadeTokens->preview);
+        purposes.push_back(UsdShadeTokens->full);
+    } else {
+        purposes.push_back(_purpose);
+    }
+
+    // Enforce editing restrictions and gather the relationships to remove before
+    // doing any work.
+    std::vector<UsdRelationship> relsToRemove;
+    for (const TfToken& purpose : purposes) {
+        const UsdRelationship rel = bindingAPI.GetCollectionBindingRel(_bindingName, purpose);
+        if (!rel)
+            continue;
+        enforceMaterialBindingEditRestriction(rel);
+        relsToRemove.push_back(rel);
+    }
+
+    // Note: we remove the property entirely (not just its targets) so that the
+    //       collection material binding attribute -- and any AE section built
+    //       from its presence -- disappears entirely.
+    for (const UsdRelationship& rel : relsToRemove) {
+        prim.RemoveProperty(rel.GetName());
+    }
+}
+
+const std::string
+    UnbindCollectionMaterialUndoableCommand::commandName("Unbind Collection Material");
+
 SetMaterialBindingStrengthCommand::SetMaterialBindingStrengthCommand(
     Ufe::Path              primPath,
     const PXR_NS::TfToken& strength,
-    const TfToken&         purpose)
+    const TfToken&         purpose,
+    const TfToken&         bindingName)
     : _primPath(std::move(primPath))
     , _purpose(purpose.IsEmpty() ? UsdShadeTokens->allPurpose : purpose)
     , _strength(strength)
+    , _bindingName(bindingName)
 {
     validatePrimPath();
 }
@@ -388,11 +601,13 @@ SetMaterialBindingStrengthCommand::SetMaterialBindingStrengthCommand(
 SetMaterialBindingStrengthCommand::SetMaterialBindingStrengthCommand(
     Ufe::Path              primPath,
     const PXR_NS::TfToken& strength,
-    bool                   unassignAll)
+    bool                   unassignAll,
+    const TfToken&         bindingName)
     : _primPath(std::move(primPath))
     , _purpose(UsdShadeTokens->allPurpose)
     , _strength(strength)
     , _affectAllPurposes(unassignAll)
+    , _bindingName(bindingName)
 {
     validatePrimPath();
 }
@@ -438,20 +653,25 @@ void SetMaterialBindingStrengthCommand::execute()
         purposes.push_back(_purpose);
     }
 
+    auto getRel = [&bindingAPI, this](const TfToken& purpose) {
+        return _bindingName.IsEmpty() ? bindingAPI.GetDirectBindingRel(purpose)
+                                      : bindingAPI.GetCollectionBindingRel(_bindingName, purpose);
+    };
+
     for (const TfToken& purpose : purposes) {
-        const UsdRelationship directRel = bindingAPI.GetDirectBindingRel(purpose);
-        if (!directRel)
+        const UsdRelationship rel = getRel(purpose);
+        if (!rel)
             continue;
 
-        enforceMaterialStrengthEditRestriction(directRel);
+        enforceMaterialStrengthEditRestriction(rel);
     }
 
     for (const TfToken& purpose : purposes) {
-        const UsdRelationship directRel = bindingAPI.GetDirectBindingRel(purpose);
-        if (!directRel)
+        const UsdRelationship rel = getRel(purpose);
+        if (!rel)
             continue;
 
-        UsdShadeMaterialBindingAPI::SetMaterialBindingStrength(directRel, _strength);
+        UsdShadeMaterialBindingAPI::SetMaterialBindingStrength(rel, _strength);
     }
 }
 

--- a/lib/usdUfe/ufe/UsdUndoMaterialCommands.h
+++ b/lib/usdUfe/ufe/UsdUndoMaterialCommands.h
@@ -104,11 +104,13 @@ public:
     SetMaterialBindingStrengthCommand(
         Ufe::Path              primPath,
         const PXR_NS::TfToken& strength,
-        const PXR_NS::TfToken& purpose);
+        const PXR_NS::TfToken& purpose,
+        const PXR_NS::TfToken& bindingName = PXR_NS::TfToken());
     SetMaterialBindingStrengthCommand(
         Ufe::Path              primPath,
         const PXR_NS::TfToken& strength,
-        bool                   affectAllPurposes);
+        bool                   affectAllPurposes,
+        const PXR_NS::TfToken& bindingName = PXR_NS::TfToken());
     ~SetMaterialBindingStrengthCommand() override;
 
     USDUFE_DISALLOW_COPY_MOVE_AND_ASSIGNMENT(SetMaterialBindingStrengthCommand);
@@ -125,6 +127,94 @@ private:
     PXR_NS::TfToken         _purpose;
     PXR_NS::TfToken         _strength;
     bool                    _affectAllPurposes = false;
+    PXR_NS::TfToken         _bindingName;
+    UsdUfe::UsdUndoableItem _undoableItem;
+};
+
+//! \brief CreateCollectionMaterialBindingUndoableCommand
+//! Authors an (initially unbound) collection-based material binding relationship
+//! for the named collection so that it can subsequently be edited/bound.
+class USDUFE_PUBLIC CreateCollectionMaterialBindingUndoableCommand : public Ufe::UndoableCommand
+{
+public:
+    static const std::string commandName;
+
+    CreateCollectionMaterialBindingUndoableCommand(
+        Ufe::Path              primPath,
+        const PXR_NS::TfToken& bindingName);
+
+    USDUFE_DISALLOW_COPY_MOVE_AND_ASSIGNMENT(CreateCollectionMaterialBindingUndoableCommand);
+
+    void execute() override;
+    void undo() override;
+    void redo() override;
+    UFE_V4(std::string commandString() const override { return "CreateCollectionMaterialBinding"; })
+
+private:
+    Ufe::Path               _primPath;
+    PXR_NS::TfToken         _bindingName;
+    UsdUfe::UsdUndoableItem _undoableItem;
+};
+
+//! \brief BindCollectionMaterialUndoableCommand
+class USDUFE_PUBLIC BindCollectionMaterialUndoableCommand : public Ufe::UndoableCommand
+{
+public:
+    static const std::string commandName;
+
+    BindCollectionMaterialUndoableCommand(
+        Ufe::Path              primPath,
+        const PXR_NS::SdfPath& materialPath,
+        const PXR_NS::TfToken& bindingName,
+        const PXR_NS::TfToken& purpose);
+
+    USDUFE_DISALLOW_COPY_MOVE_AND_ASSIGNMENT(BindCollectionMaterialUndoableCommand);
+
+    void execute() override;
+    void undo() override;
+    void redo() override;
+    UFE_V4(std::string commandString() const override { return "BindCollectionMaterial"; })
+
+private:
+    Ufe::Path               _primPath;
+    PXR_NS::SdfPath         _materialPath;
+    PXR_NS::TfToken         _bindingName;
+    PXR_NS::TfToken         _purpose;
+    UsdUfe::UsdUndoableItem _undoableItem;
+};
+
+//! \brief UnbindCollectionMaterialUndoableCommand
+//! Removes one purpose, or all purposes, of a collection-based material binding
+//! for the named collection.
+class USDUFE_PUBLIC UnbindCollectionMaterialUndoableCommand : public Ufe::UndoableCommand
+{
+public:
+    static const std::string commandName;
+
+    UnbindCollectionMaterialUndoableCommand(
+        Ufe::Path              primPath,
+        const PXR_NS::TfToken& bindingName,
+        const PXR_NS::TfToken& purpose);
+    UnbindCollectionMaterialUndoableCommand(
+        Ufe::Path              primPath,
+        const PXR_NS::TfToken& bindingName,
+        bool                   unassignAll);
+    ~UnbindCollectionMaterialUndoableCommand() override;
+
+    USDUFE_DISALLOW_COPY_MOVE_AND_ASSIGNMENT(UnbindCollectionMaterialUndoableCommand);
+
+    void execute() override;
+    void undo() override;
+    void redo() override;
+    UFE_V4(std::string commandString() const override { return "UnbindCollectionMaterial"; })
+
+private:
+    void validatePrimPath() const;
+
+    Ufe::Path               _primPath;
+    PXR_NS::TfToken         _bindingName;
+    PXR_NS::TfToken         _purpose;
+    bool                    _unassignAll = false;
     UsdUfe::UsdUndoableItem _undoableItem;
 };
 

--- a/test/lib/testAttributeEditorTemplate.py
+++ b/test/lib/testAttributeEditorTemplate.py
@@ -340,6 +340,54 @@ class AttributeEditorTemplateTestCase(unittest.TestCase):
         strengthControl = self.searchForMayaControl(materialFormLayout, cmds.optionMenuGrp, 'Strength')
         self.assertIsNotNone(strengthControl, 'Could not find the "Strength" control')
 
+    def testAECustomCollectionMaterialControl(self):
+        '''Simple test for the CollectionMaterialCustomControl in AE template.'''
+
+        cmds.file(new=True, force=True)
+
+        proxyShape = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+        proxyShapePath = ufe.PathString.path(proxyShape)
+        proxyShapeItem = ufe.Hierarchy.createItem(proxyShapePath)
+
+        # Create an Xform prim and give it a named collection.
+        proxyShapeContextOps = ufe.ContextOps.contextOps(proxyShapeItem)
+        proxyShapeContextOps.doOp(['Add New Prim', 'Xform'])
+        fullPrimPath = proxyShape + ",/Xform1"
+        cmds.select(fullPrimPath, r=True)
+
+        from pxr import Usd, UsdShade
+        usdPrim = mayaUsd.ufe.ufePathToPrim(fullPrimPath)
+        stage = usdPrim.GetStage()
+        UsdShade.Material.Define(stage, '/mtl/Material1')
+
+        collectionName = 'myColl'
+        Usd.CollectionAPI.Apply(usdPrim, collectionName)
+
+        # Author the (initially unbound) collection material binding, which is
+        # what the "Assign Material" menu item does, so the AE section appears.
+        cmd = mayaUsd.ufe.CreateCollectionMaterialBindingCommand(fullPrimPath, collectionName)
+        cmd.execute()
+
+        # Make sure the AE is visible.
+        import maya.mel
+        maya.mel.eval('openAEWindow')
+
+        xformFormLayout = self.attrEdFormLayoutName('Xform')
+        self.assertTrue(cmds.formLayout(xformFormLayout, exists=True))
+        startLayout = cmds.formLayout(xformFormLayout, query=True, fullPathName=True)
+        self.assertIsNotNone(startLayout, 'Could not get full path for Xform formLayout')
+
+        collectionMaterialLayout = self.findExpandedFrameLayout(
+            startLayout, '%s Collection Material' % collectionName, fullPrimPath)
+        self.assertIsNotNone(
+            collectionMaterialLayout,
+            'Could not find "%s Collection Material" frameLayout' % collectionName)
+
+        assignedMaterialControl = self.searchForMayaControl(collectionMaterialLayout, cmds.text, 'Default')
+        self.assertIsNotNone(assignedMaterialControl, 'Could not find the "Default" control')
+        strengthControl = self.searchForMayaControl(collectionMaterialLayout, cmds.optionMenuGrp, 'Strength')
+        self.assertIsNotNone(strengthControl, 'Could not find the "Strength" control')
+
     def testAECustomImageControl(self):
         '''Simple test for the customImageControlCreator in AE template.'''
         cmds.file(new=True, force=True)

--- a/test/lib/ufe/testMaterialBindingCommands.py
+++ b/test/lib/ufe/testMaterialBindingCommands.py
@@ -26,7 +26,7 @@ import ufe
 import unittest
 import usdUtils
 
-from pxr import UsdShade
+from pxr import Usd, UsdShade
 
 #####################################################################
 #
@@ -38,6 +38,9 @@ class MaterialBindingCommandsTestCase(unittest.TestCase):
         - BindMaterialCommand
         - UnbindMaterialCommand
         - SetMaterialBindingStrengthCommand
+        - CreateCollectionMaterialBindingCommand
+        - BindCollectionMaterialCommand
+        - UnbindCollectionMaterialCommand
     '''
 
     pluginsLoaded = False
@@ -94,16 +97,38 @@ class MaterialBindingCommandsTestCase(unittest.TestCase):
         self.preview = UsdShade.Tokens.preview
         self.full = UsdShade.Tokens.full
 
+        self.collectionName = 'myColl'
+        Usd.CollectionAPI.Apply(self.aPrim, self.collectionName)
+
         cmds.select(clear=True)
 
     def _directBinding(self, prim, purpose=''):
         purpose = purpose if purpose else self.allPurpose
         return UsdShade.MaterialBindingAPI(prim).GetDirectBinding(purpose)
-    
+
     def verifyBinding(self, prim, purpose, expectedMaterialPathStr):
         purpose = purpose if purpose else self.allPurpose
         binding = self._directBinding(prim, purpose)
         self.assertEqual(binding.GetMaterialPath().pathString, expectedMaterialPathStr)
+
+    def _collectionBindingRel(self, prim, bindingName, purpose=''):
+        purpose = purpose if purpose else self.allPurpose
+        return UsdShade.MaterialBindingAPI(prim).GetCollectionBindingRel(bindingName, purpose)
+
+    def _collectionBindingMaterialPath(self, prim, bindingName, purpose=''):
+        rel = self._collectionBindingRel(prim, bindingName, purpose)
+        if not rel:
+            return ''
+        collectionPath = Usd.CollectionAPI.GetNamedCollectionPath(prim, bindingName)
+        for target in rel.GetTargets():
+            if target != collectionPath:
+                return target.pathString
+        return ''
+
+    def verifyCollectionBinding(self, prim, bindingName, purpose, expectedMaterialPathStr):
+        self.assertEqual(
+            self._collectionBindingMaterialPath(prim, bindingName, purpose),
+            expectedMaterialPathStr)
 
     #####################################################################
     # BindMaterialCommand
@@ -394,6 +419,260 @@ class MaterialBindingCommandsTestCase(unittest.TestCase):
             self.aPathStr, UsdShade.Tokens.strongerThanDescendants, '')
         with self.assertRaises(RuntimeError):
             cmd.execute()
+
+    #####################################################################
+    # CreateCollectionMaterialBindingCommand
+
+    def testCreateCollectionMaterialBindingCommand(self):
+        '''
+        Creating a collection material binding authors an (initially unbound)
+        allPurpose collection binding relationship targeting the collection.
+        '''
+        self.assertFalse(self._collectionBindingRel(self.aPrim, self.collectionName))
+
+        cmd = usdUfe.CreateCollectionMaterialBindingCommand(self.aPathStr, self.collectionName)
+        cmd.execute()
+        self.assertTrue(self._collectionBindingRel(self.aPrim, self.collectionName))
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.allPurpose, '')
+
+        cmd.undo()
+        self.assertFalse(self._collectionBindingRel(self.aPrim, self.collectionName))
+
+        cmd.redo()
+        self.assertTrue(self._collectionBindingRel(self.aPrim, self.collectionName))
+
+    def testCreateCollectionMaterialBindingCommandInvalidCollection(self):
+        '''
+        Constructing the command with a name that is not an existing collection
+        on the prim should raise.
+        '''
+        self.assertRaises(
+            RuntimeError,
+            usdUfe.CreateCollectionMaterialBindingCommand, self.aPathStr, 'noSuchCollection')
+
+    def testCreateCollectionMaterialBindingCommandInvalidPrim(self):
+        '''
+        Constructing the command with an invalid prim path should raise.
+        '''
+        badPathStr = self.aPathStr + '_NoSuchPrim'
+        self.assertRaises(
+            RuntimeError,
+            usdUfe.CreateCollectionMaterialBindingCommand, badPathStr, self.collectionName)
+
+    #####################################################################
+    # BindCollectionMaterialCommand
+
+    def testBindCollectionMaterialCommandAllPurpose(self):
+        '''
+        Bind a material to a named collection using the default (all purpose) binding.
+        '''
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.allPurpose, '')
+
+        cmd = usdUfe.BindCollectionMaterialCommand(
+            self.aPathStr, self.mat1PathStr, self.collectionName, '')
+        cmd.execute()
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.allPurpose, self.mat1PathStr)
+
+        cmd.undo()
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.allPurpose, '')
+
+        cmd.redo()
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.allPurpose, self.mat1PathStr)
+
+    def testBindCollectionMaterialCommandWithPurpose(self):
+        '''
+        Bind a material to a named collection under a specific purpose only.
+        '''
+        cmd = usdUfe.BindCollectionMaterialCommand(
+            self.aPathStr, self.mat1PathStr, self.collectionName, self.preview)
+        cmd.execute()
+
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.allPurpose, '')
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.preview, self.mat1PathStr)
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.full, '')
+
+        cmd.undo()
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.preview, '')
+
+        cmd.redo()
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.preview, self.mat1PathStr)
+
+    def testBindCollectionMaterialCommandRebind(self):
+        '''
+        Binding a second material under a purpose that is already bound should
+        retarget the existing binding relationship instead of creating a new one.
+        '''
+        cmd1 = usdUfe.BindCollectionMaterialCommand(
+            self.aPathStr, self.mat1PathStr, self.collectionName, '')
+        cmd1.execute()
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.allPurpose, self.mat1PathStr)
+
+        cmd2 = usdUfe.BindCollectionMaterialCommand(
+            self.aPathStr, self.mat2PathStr, self.collectionName, '')
+        cmd2.execute()
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.allPurpose, self.mat2PathStr)
+
+        cmd2.undo()
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.allPurpose, self.mat1PathStr)
+
+        cmd2.redo()
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.allPurpose, self.mat2PathStr)
+
+    def testBindCollectionMaterialCommandInvalidPrim(self):
+        '''
+        Constructing a BindCollectionMaterialCommand with an invalid prim path should raise.
+        '''
+        badPathStr = self.aPathStr + '_NoSuchPrim'
+        self.assertRaises(
+            RuntimeError,
+            usdUfe.BindCollectionMaterialCommand,
+            badPathStr, self.mat1PathStr, self.collectionName, '')
+
+    def testBindCollectionMaterialCommandInvalidMaterial(self):
+        '''
+        Constructing a BindCollectionMaterialCommand with an invalid material path should raise.
+        '''
+        self.assertRaises(
+            RuntimeError,
+            usdUfe.BindCollectionMaterialCommand,
+            self.aPathStr, '/mtl/NoSuchMaterial', self.collectionName, '')
+
+    def testBindCollectionMaterialCommandInvalidCollection(self):
+        '''
+        Constructing a BindCollectionMaterialCommand with a name that is not an
+        existing collection on the prim should raise.
+        '''
+        self.assertRaises(
+            RuntimeError,
+            usdUfe.BindCollectionMaterialCommand,
+            self.aPathStr, self.mat1PathStr, 'noSuchCollection', '')
+
+    #####################################################################
+    # UnbindCollectionMaterialCommand
+
+    def testUnbindCollectionMaterialCommandOnePurpose(self):
+        '''
+        Unbind a collection material binding under a single purpose.
+        '''
+        bindCmd = usdUfe.BindCollectionMaterialCommand(
+            self.aPathStr, self.mat1PathStr, self.collectionName, '')
+        bindCmd.execute()
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.allPurpose, self.mat1PathStr)
+
+        unbindCmd = usdUfe.UnbindCollectionMaterialCommand(self.aPathStr, self.collectionName, '')
+        unbindCmd.execute()
+        self.assertFalse(self._collectionBindingRel(self.aPrim, self.collectionName, self.allPurpose))
+
+        unbindCmd.undo()
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.allPurpose, self.mat1PathStr)
+
+        unbindCmd.redo()
+        self.assertFalse(self._collectionBindingRel(self.aPrim, self.collectionName, self.allPurpose))
+
+    def testUnbindCollectionMaterialCommandUnassignAll(self):
+        '''
+        Unbind all purposes of a collection material binding at once.
+        '''
+        bindAllCmd = usdUfe.BindCollectionMaterialCommand(
+            self.aPathStr, self.mat1PathStr, self.collectionName, '')
+        bindAllCmd.execute()
+        bindPreviewCmd = usdUfe.BindCollectionMaterialCommand(
+            self.aPathStr, self.mat2PathStr, self.collectionName, self.preview)
+        bindPreviewCmd.execute()
+
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.allPurpose, self.mat1PathStr)
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.preview, self.mat2PathStr)
+
+        unbindCmd = usdUfe.UnbindCollectionMaterialCommand(self.aPathStr, self.collectionName, True)
+        unbindCmd.execute()
+        self.assertFalse(self._collectionBindingRel(self.aPrim, self.collectionName, self.allPurpose))
+        self.assertFalse(self._collectionBindingRel(self.aPrim, self.collectionName, self.preview))
+
+        unbindCmd.undo()
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.allPurpose, self.mat1PathStr)
+        self.verifyCollectionBinding(self.aPrim, self.collectionName, self.preview, self.mat2PathStr)
+
+        unbindCmd.redo()
+        self.assertFalse(self._collectionBindingRel(self.aPrim, self.collectionName, self.allPurpose))
+        self.assertFalse(self._collectionBindingRel(self.aPrim, self.collectionName, self.preview))
+
+    def testUnbindCollectionMaterialCommandInvalidPrim(self):
+        '''
+        Constructing an UnbindCollectionMaterialCommand with an invalid prim path should raise.
+        '''
+        badPathStr = self.aPathStr + '_NoSuchPrim'
+        self.assertRaises(
+            RuntimeError,
+            usdUfe.UnbindCollectionMaterialCommand, badPathStr, self.collectionName, '')
+        self.assertRaises(
+            RuntimeError,
+            usdUfe.UnbindCollectionMaterialCommand, badPathStr, self.collectionName, True)
+
+    #####################################################################
+    # SetMaterialBindingStrengthCommand (collection binding)
+
+    def testSetMaterialBindingStrengthCollectionOnePurpose(self):
+        '''
+        Change the binding strength of a single purpose's collection binding.
+        '''
+        bindCmd = usdUfe.BindCollectionMaterialCommand(
+            self.aPathStr, self.mat1PathStr, self.collectionName, '')
+        bindCmd.execute()
+
+        bindingRel = self._collectionBindingRel(self.aPrim, self.collectionName, self.allPurpose)
+        originalStrength = UsdShade.MaterialBindingAPI.GetMaterialBindingStrength(bindingRel)
+
+        strengthCmd = usdUfe.SetMaterialBindingStrengthCommand(
+            self.aPathStr, UsdShade.Tokens.strongerThanDescendants, '', self.collectionName)
+        strengthCmd.execute()
+        self.assertEqual(
+            UsdShade.MaterialBindingAPI.GetMaterialBindingStrength(bindingRel),
+            UsdShade.Tokens.strongerThanDescendants)
+
+        strengthCmd.undo()
+        self.assertEqual(
+            UsdShade.MaterialBindingAPI.GetMaterialBindingStrength(bindingRel),
+            originalStrength)
+
+        strengthCmd.redo()
+        self.assertEqual(
+            UsdShade.MaterialBindingAPI.GetMaterialBindingStrength(bindingRel),
+            UsdShade.Tokens.strongerThanDescendants)
+
+    def testSetMaterialBindingStrengthCollectionAllPurposes(self):
+        '''
+        Change the binding strength of all bound purposes of a collection
+        binding at once.
+        '''
+        bindAllCmd = usdUfe.BindCollectionMaterialCommand(
+            self.aPathStr, self.mat1PathStr, self.collectionName, '')
+        bindAllCmd.execute()
+        bindPreviewCmd = usdUfe.BindCollectionMaterialCommand(
+            self.aPathStr, self.mat2PathStr, self.collectionName, self.preview)
+        bindPreviewCmd.execute()
+
+        allPurposeRel = self._collectionBindingRel(self.aPrim, self.collectionName, self.allPurpose)
+        previewRel = self._collectionBindingRel(self.aPrim, self.collectionName, self.preview)
+
+        strengthCmd = usdUfe.SetMaterialBindingStrengthCommand(
+            self.aPathStr, UsdShade.Tokens.strongerThanDescendants, True, self.collectionName)
+        strengthCmd.execute()
+        self.assertEqual(
+            UsdShade.MaterialBindingAPI.GetMaterialBindingStrength(allPurposeRel),
+            UsdShade.Tokens.strongerThanDescendants)
+        self.assertEqual(
+            UsdShade.MaterialBindingAPI.GetMaterialBindingStrength(previewRel),
+            UsdShade.Tokens.strongerThanDescendants)
+
+        strengthCmd.undo()
+
+        strengthCmd.redo()
+        self.assertEqual(
+            UsdShade.MaterialBindingAPI.GetMaterialBindingStrength(allPurposeRel),
+            UsdShade.Tokens.strongerThanDescendants)
+        self.assertEqual(
+            UsdShade.MaterialBindingAPI.GetMaterialBindingStrength(previewRel),
+            UsdShade.Tokens.strongerThanDescendants)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adding support for  collection-based material assignment in the attribute editor (AE).

Added support for collection-base material bindings to the collection widget:
- Added `hasMaterialBinding`, `createMaterialBinding` and `removeMaterialBinding` function to the `CollectionData` interface.
- Implemented those functions in `UsdCollectionData`.
- Implemented those function in `MayaCollectionData` to use commands for undo/redo.
- Added two new menu items to the collection widget menu: "Assign Material" and "Unassign Material".

Modified the AE UI building:
- Modified `AETemplate` to detect USD collections with corresponding material binding and make sure both UI sections are next to each other.

Modified `MaterialCustomControl` to support collection-base material bindings:
- Refactored implementation details into their own functions so that the differences between direct binding and collection bindings can be abstracted away.
- Added `CollectionMaterialCustomControl` sub-class that implements all the functions for collection-based material bindings.

Added UFE commands to manipulate collection-based material bindings with undo/redo:
- Added `CreateCollectionMaterialBindingUndoableCommand`.
- Added `BindCollectionMaterialUndoableCommand` .
- Added `UnbindCollectionMaterialUndoableCommand`.
- Modified `SetMaterialBindingStrengthCommand` to support collection-based bindings.
- Wrapped the commands in Python.

Added unit tests.