### PR TITLE
LOOKDEVX-5908 - Make UsdLookdevHandler independent of mayaUsdAPI.

### DIFF
--- a/lib/lookdevXUsd/UsdLookdevHandler.cpp
+++ b/lib/lookdevXUsd/UsdLookdevHandler.cpp
@@ -14,11 +14,8 @@
 
 #include <usdUfe/ufe/Global.h>
 #include <usdUfe/ufe/UsdUndoAddNewPrimCommand.h>
+#include <usdUfe/ufe/UsdUndoMaterialCommands.h>
 #include <usdUfe/ufe/Utils.h>
-
-#ifdef LDX_USD_USE_MAYAUSDAPI
-#include <mayaUsdAPI/utils.h>
-#endif
 
 namespace
 {
@@ -107,7 +104,6 @@ Ufe::SceneItemResultUndoableCommand::Ptr UsdLookdevHandler::createLookdevContain
 Ufe::SceneItemResultUndoableCommand::Ptr UsdLookdevHandler::createLookdevContainerCmdImpl(
     const Ufe::SceneItem::Ptr& parent, const Ufe::NodeDef::Ptr& nodeDef) const
 {
-#ifdef LDX_USD_USE_MAYAUSDAPI
     auto usdParent = UsdUfe::downcast(parent);
     auto prim = usdParent ? usdParent->prim() : PXR_NS::UsdPrim();
     if (!prim.IsValid())
@@ -120,16 +116,12 @@ Ufe::SceneItemResultUndoableCommand::Ptr UsdLookdevHandler::createLookdevContain
         return nullptr;
     }
 
-    auto cmd =
-        std::dynamic_pointer_cast<Ufe::InsertChildCommand>(MayaUsdAPI::addNewMaterialCommand(parent, nodeDef->type()));
+    auto cmd = UsdUfe::UsdUndoAddNewMaterialCommand::create(usdParent, nodeDef->type());
     if (!cmd)
     {
         return nullptr;
     }
     return WrapInsertChildCommand::create(cmd);
-#else
-    return nullptr;
-#endif
 }
 
 Ufe::SceneItemResultUndoableCommand::Ptr UsdLookdevHandler::createLookdevEnvironmentCmdImpl(

--- a/lib/lookdevXUsd/UsdMaterialCommands.cpp
+++ b/lib/lookdevXUsd/UsdMaterialCommands.cpp
@@ -10,11 +10,8 @@
 //*****************************************************************************
 #include "UsdMaterialCommands.h"
 
+#include <usdUfe/ufe/UsdUndoMaterialCommands.h>
 #include <usdUfe/ufe/Utils.h>
-
-#ifdef LDX_USD_USE_MAYAUSDAPI
-#include <mayaUsdAPI/utils.h>
-#endif
 
 namespace LookdevXUsd
 {
@@ -55,11 +52,8 @@ void UsdCreateMaterialParentCommand::execute()
         return;
     }
 
-#ifdef LDX_USD_USE_MAYAUSDAPI
     // Create a materials scope.
-    m_cmd = std::dynamic_pointer_cast<Ufe::SceneItemResultUndoableCommand>(
-        MayaUsdAPI::createMaterialsScopeCommand(m_ancestor));
-#endif
+    m_cmd = UsdUfe::UsdUndoCreateMaterialsScopeCommand::create(usdItem);
     if (!m_cmd)
     {
         return;


### PR DESCRIPTION
Since `UsdUndoMaterialCommands.h` has been moved to UsdUfe in #4584, some more dependencies of LookdevXUsd on mayaUsdAPI can be resolved now.