### PR TITLE
Fix worldspace export baking ancestor transforms twice

### DIFF
--- a/lib/mayaUsd/fileio/transformWriter.cpp
+++ b/lib/mayaUsd/fileio/transformWriter.cpp
@@ -727,13 +727,40 @@ void UsdMayaTransformWriter::_WriteChannelsXformOps(const UsdGeomXformable& usdX
     }
 }
 
-static bool
-needsWorldspaceTransform(const UsdMayaJobExportArgs& exportArgs, const MFnTransform& iTrans)
+// True when the node at the specified dagPath has no exported parent. It will appear as a
+// top-level prim in the USD file, with nothing above it carrying a transform.
+static bool becomesTopLevelPrim(const UsdMayaWriteJobContext& jobCtx, const MDagPath& dagPath)
 {
-    if (!exportArgs.worldspace)
+    MDagPath parentPath = dagPath;
+
+    const bool isParentedToWorld = parentPath.pop() != MStatus::kSuccess || !parentPath.isValid()
+        || parentPath.length() == 0u;
+    if (isParentedToWorld) {
+        // No Maya parent: the node exports as a top-level prim.
+        return true;
+    }
+
+    const SdfPath parentUsdPath = jobCtx.ConvertDagToUsdPath(parentPath);
+    // An empty path means the export roots exclude the parent, so the node becomes top-level.
+    return parentUsdPath.IsEmpty();
+}
+
+static bool
+needsWorldspaceTransform(const UsdMayaWriteJobContext& jobCtx, const MFnTransform& iTrans)
+{
+    if (!jobCtx.GetArgs().worldspace)
         return false;
 
-    return exportArgs.dagPaths.count(iTrans.dagPath()) > 0;
+    MStatus        status;
+    const MDagPath dagPath = iTrans.dagPath(&status);
+    if (status != MStatus::kSuccess || !dagPath.isValid()) {
+        // Without a DAG path the ancestors are unknown; keep the local-space transform.
+        return false;
+    }
+
+    // Bake the unexported ancestor transforms only into top-level prims of the file: an exported
+    // ancestor already carries its transform in the file, and baking it too would apply it twice.
+    return becomesTopLevelPrim(jobCtx, dagPath);
 }
 
 UsdMayaTransformWriter::UsdMayaTransformWriter(
@@ -755,7 +782,7 @@ UsdMayaTransformWriter::UsdMayaTransformWriter(
         const MFnTransform transFn(GetDagPath());
         // Create a vector of _AnimChannels based on the Maya transformation
         // ordering
-        const bool worldspace = needsWorldspaceTransform(_writeJobCtx.GetArgs(), transFn);
+        const bool worldspace = needsWorldspaceTransform(_writeJobCtx, transFn);
         _PushTransformStack(
             GetDagPath(), transFn, primSchema, !_GetExportArgs().timeSamples.empty(), worldspace);
         _WriteChannelsXformOps(primSchema);

--- a/test/lib/usd/translators/testUsdExportRoots.py
+++ b/test/lib/usd/translators/testUsdExportRoots.py
@@ -245,6 +245,25 @@ class testUsdExportRoot(unittest.TestCase):
                 ('xformOp:rotateXYZ', (0., 45., 0.))])
         self.doExportImportTest(validator, root='Mid', worldspace=True)
 
+    def testExportRoot_rootMid_selCube_worldspace(self):
+        # The bake must land on /Mid, the root prim of the file, never on the selected /Mid/Cube:
+        # /Mid and its transform stay in the file, so baking the ancestors onto the deeper
+        # selection would apply Mid's transform twice.
+        def validator(stage):
+            self.assertPrim(stage, '/Mid/Cube', 'Mesh')
+            self.assertNotPrim(stage, '/Top')
+            self.assertNotPrim(stage, '/OtherTop')
+            self.assertNotPrim(stage, '/OtherMid')
+            transformUtils.assertStagePrimXforms(self, stage, '/Mid', [
+                ('xformOp:translate', (2., 0., 0.)),
+                ('xformOp:rotateXYZ', (45., 0., 0.)),
+                ('xformOp:translate:channel1', (0., 2., 0.)),
+                ('xformOp:rotateXYZ:channel1', (0., 0., 45.))])
+            transformUtils.assertStagePrimXforms(self, stage, '/Mid/Cube', [
+                ('xformOp:translate', (0., 0., 3.)),
+                ('xformOp:rotateXYZ', (0., 45., 0.))])
+        self.doExportImportTest(validator, root='Mid', selection='Cube', worldspace=True)
+
     def testExportRoot_rootMid_selTop(self):
         def validator(stage):
             self.assertPrim(stage, '/Mid/Cube', 'Mesh')
@@ -324,6 +343,25 @@ class testUsdExportRoot(unittest.TestCase):
                 ('xformOp:translate:channel2', (0., 0., 3.)),
                 ('xformOp:rotateXYZ:channel2', (0., 45., 0.))])
         self.doExportImportTest(validator, root='Cube', worldspace=True)
+
+    def testExportRoot_rootCube_selCube_worldspace(self):
+        # The selected node is itself the export root: it becomes the file's root prim, so it
+        # must keep the full worldspace bake of its (unexported) ancestors.
+        def validator(stage):
+            self.assertPrim(stage, '/Cube', 'Mesh')
+            self.assertNotPrim(stage, '/Top')
+            self.assertNotPrim(stage, '/Mid')
+            self.assertNotPrim(stage, '/OtherTop')
+            self.assertNotPrim(stage, '/OtherMid')
+            self.assertNotPrim(stage, '/OtherLowest')
+            transformUtils.assertStagePrimXforms(self, stage, '/Cube', [
+                ('xformOp:translate', (2., 0., 0.)),
+                ('xformOp:rotateXYZ', (45., 0., 0.)),
+                ('xformOp:translate:channel1', (0., 2., 0.)),
+                ('xformOp:rotateXYZ:channel1', (0., 0., 45.)),
+                ('xformOp:translate:channel2', (0., 0., 3.)),
+                ('xformOp:rotateXYZ:channel2', (0., 45., 0.))])
+        self.doExportImportTest(validator, root='Cube', selection='Cube', worldspace=True)
 
     def testExportRoot_rootCube_selTop(self):
         def validator(stage):


### PR DESCRIPTION
## Problem

Exporting with `-worldspace` produces wrong transforms when the selected
objects have ancestors that are also exported. This happens in two common
setups:

- `-exportSelected` with `-exportRoots` pointing at an ancestor of the
  selection.
- `-exportSelected` with a node deep in a hierarchy (its parents are
  always exported with their transforms).

In both cases the ancestor transforms end up in the file twice. They are
written on the ancestor prims, and they are also baked into the xform ops
of every selected prim. When the file is composed, the objects move twice
as far, scale twice, and so on.

<img width="2112" height="997" alt="image" src="https://github.com/user-attachments/assets/537f1d71-419b-449c-90e1-ab0b941dccc9" />

### Repro

```python
# group1 at translate (5, 0, 0), pCube1 under it at translate (0, 2, 0)
cmds.select("pCube1")
cmds.mayaUSDExport(file=path, selection=True, worldspace=True)
```

The cube lands at world position (10, 2, 0) instead of (5, 2, 0).

## Cause

`needsWorldspaceTransform` in `transformWriter.cpp` enables the ancestor
bake for every transform found in the export selection (`dagPaths`). That
is only correct when the selected node becomes a root prim of the file.
The existing worldspace tests only cover exports without a selection,
where `dagPaths` happens to hold the export roots, so the problem never
showed up there.

## Fix

Bake the ancestor chain only into prims that become top-level prims of
the exported file. A prim is top-level when its Maya parent maps to no
prim in the export, either because the node sits under the Maya world
root or because the export roots exclude its parent.

This matches what the existing `selNone` worldspace tests in
`testUsdExportRoots.py` already assert: the bake lands on the export
root itself, and prims below it keep their local transforms.

As a side effect, transforms above a non-top-level export root are now
captured on the export root prim instead of being double-applied below
it.

## Tests

Two new cases in `testUsdExportRoots.py`:

- `testExportRoot_rootMid_selCube_worldspace` — export root above the
  selection. Fails without the fix (double transform), passes with it.
- `testExportRoot_rootCube_selCube_worldspace` — the selected node is
  itself the export root. Guards that the bake stays where it is needed.

All existing `testUsdExportRoots` and `testUsdExportRootsAndRootPrim`
cases pass unchanged.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)