### PR TITLE
EMSUSD-3660 create USD ref at stage root

### DIFF
--- a/lib/mayaUsd/ufe/MayaUsdContextOps.cpp
+++ b/lib/mayaUsd/ufe/MayaUsdContextOps.cpp
@@ -80,6 +80,10 @@ static constexpr char kUSDLayerEditorLabel[] = "USD Layer Editor";
 static constexpr char kAssetResolverDialogItem[] = "Asset Resolver Dialog";
 static constexpr char kAssetResolverDialogLabel[] = "USD Path Editor";
 #endif
+// Top-level "USD" submenu shown on the stage/gateway context menu, grouping the
+// USD Layer Editor, USD Path Editor and Add Reference... items together.
+static constexpr char kUSDMenuItem[] = "USD";
+static constexpr char kUSDMenuLabel[] = "USD";
 #endif
 static const std::string kUSDLayerEditorImage { "USD_generic.png" };
 #ifdef UFE_V3_FEATURES_AVAILABLE
@@ -118,6 +122,8 @@ const constexpr char  kReloadReferenceLabel[] = "Reload";
 const constexpr char  kReloadReferenceItem[] = "Reload";
 static constexpr char kUSDReferenceItem[] = "Reference";
 static constexpr char kUSDReferenceLabel[] = "Reference";
+static constexpr char kAddReferenceItem[] = "AddReference";
+static constexpr char kAddReferenceLabel[] = "Add Reference...";
 
 // Copied from UsdUfe::UsdContextOps
 static constexpr char kUSDAddNewPrimItem[] = "Add New Prim";
@@ -324,6 +330,39 @@ makeUSDReferenceFilePathRelativeIfRequested(const std::string& filePath, const U
     return relativePathAndSuccess.first;
 }
 
+// Prompt for a USD file, then create a new Def prim under parentPrim (named after the
+// picked file) and add the file as a reference or payload on that new prim. Used both by
+// the prim-level "Reference > Add..." item and the stage-root "Add Reference..." item.
+Ufe::UndoableCommand::Ptr _addReferenceToNewPrimCmd(const UsdPrim& parentPrim)
+{
+    if (!_prepareUSDReferenceTargetLayer(parentPrim))
+        return nullptr;
+
+    MString fileRef
+        = MGlobal::executeCommandStringResult(_selectUSDFileScript("Add USD Reference"));
+    if (fileRef.length() == 0)
+        return nullptr;
+
+    const std::string path
+        = makeUSDReferenceFilePathRelativeIfRequested(UsdMayaUtil::convert(fileRef), parentPrim);
+    if (path.empty())
+        return nullptr;
+
+    // Derive the new prim name from the referenced filename stem.
+    std::string stem = path;
+    UsdMayaUtilFileSystem::pathStripPath(stem);
+    UsdMayaUtilFileSystem::pathRemoveExtension(stem);
+    const std::string newPrimName = TfMakeValidIdentifier(stem);
+
+    const std::string refPrimPath = UsdMayaUtilFileSystem::getReferencedPrimPath();
+    const bool        asRef = UsdMayaUtilFileSystem::wantReferenceCompositionArc();
+    const bool        prepend = UsdMayaUtilFileSystem::wantPrependCompositionArc();
+    const bool        preload = !asRef && UsdMayaUtilFileSystem::wantPayloadLoaded();
+
+    return std::make_shared<UsdUfe::UsdUndoAddRefOrPayloadToNewPrimCommand>(
+        parentPrim, newPrimName, path, refPrimPath, prepend, !asRef, preload);
+}
+
 #ifdef UFE_V4_FEATURES_AVAILABLE
 void addNewMaterialItems(const Ufe::ContextOps::ItemPath& itemPath, Ufe::ContextOps::Items& items)
 {
@@ -515,17 +554,15 @@ Ufe::ContextOps::Items MayaUsdContextOps::getItems(const Ufe::ContextOps::ItemPa
             items.emplace_back(Ufe::ContextItem::kSeparator);
         }
 #ifdef WANT_QT_BUILD
-        // Top-level item - USD Layer editor (for all context op types).
         // Only available when building with Qt enabled.
-        items.emplace_back(kUSDLayerEditorItem, kUSDLayerEditorLabel, kUSDLayerEditorImage);
-#if defined(WANT_ADSK_USD_ASSET_RESOLVER_BUILD)
-        // Top-level item - USD Path Editor (Asset Resolver dialog).
-        // Only shown on the stage root (gateway type), since the dialog
-        // operates at the stage / resolver level rather than on a specific prim.
         if (_isAGatewayType) {
-            items.emplace_back(kAssetResolverDialogItem, kAssetResolverDialogLabel);
+            // Stage root: group all USD-level items (Layer Editor, Path Editor, Add
+            // Reference...) under a single "USD" submenu.
+            items.emplace_back(kUSDMenuItem, kUSDMenuLabel, Ufe::ContextItem::kHasChildren);
+        } else {
+            // Top-level item - USD Layer editor (for prim-level context menus).
+            items.emplace_back(kUSDLayerEditorItem, kUSDLayerEditorLabel, kUSDLayerEditorImage);
         }
-#endif
 #endif
 
 #ifdef UFE_V3_FEATURES_AVAILABLE
@@ -667,6 +704,15 @@ Ufe::ContextOps::Items MayaUsdContextOps::getItems(const Ufe::ContextOps::ItemPa
                 items.emplace_back(kClearAllRefsOrPayloadsItem, kClearAllRefsOrPayloadsLabel);
             }
         }
+#ifdef WANT_QT_BUILD
+        else if (itemPath[0] == kUSDMenuItem) {
+            items.emplace_back(kUSDLayerEditorItem, kUSDLayerEditorLabel, kUSDLayerEditorImage);
+#if defined(WANT_ADSK_USD_ASSET_RESOLVER_BUILD)
+            items.emplace_back(kAssetResolverDialogItem, kAssetResolverDialogLabel);
+#endif
+            items.emplace_back(kAddReferenceItem, kAddReferenceLabel);
+        }
+#endif
     } // Top-level items
     return items;
 }
@@ -768,51 +814,39 @@ Ufe::UndoableCommand::Ptr MayaUsdContextOps::doOpCmd(const ItemPath& itemPath)
         script.format("mayaUsdLayerEditorWindow -proxyShape ^1s mayaUsdLayerEditor", shapePath);
         MGlobal::executeCommand(script);
         return nullptr;
-    }
+    } else if (itemPath.size() == 2u && itemPath[0] == kUSDMenuItem) {
+        // Stage root "USD" submenu.
+        if (itemPath[1] == kUSDLayerEditorItem) {
+            auto       ufePath = ufe::stagePath(prim().GetStage());
+            const auto dagPath = MayaUsd::ufe::ufeToDagPath(ufePath);
+            auto       shapePath = dagPath.fullPathName();
+
+            MString script;
+            script.format("mayaUsdLayerEditorWindow -proxyShape ^1s mayaUsdLayerEditor", shapePath);
+            MGlobal::executeCommand(script);
+        }
 #if defined(WANT_ADSK_USD_ASSET_RESOLVER_BUILD)
-    if (itemPath[0] == kAssetResolverDialogItem) {
-        // Passing the selected stage to the asset resolver dialog
-        auto       ufePath = ufe::stagePath(prim().GetStage());
-        const auto dagPath = MayaUsd::ufe::ufeToDagPath(ufePath);
-        auto       shapePath = dagPath.fullPathName();
-        // Open the Asset Resolver dialog (paths tab).
-        MString script;
-        script.format("assetResolverDialog -tab \"paths\" -proxyShape \"^1s\"", shapePath);
-        MGlobal::executeCommand(script, /* display = */ true, /* undoable = */ false);
+        else if (itemPath[1] == kAssetResolverDialogItem) {
+            // Passing the selected stage to the asset resolver dialog
+            auto       ufePath = ufe::stagePath(prim().GetStage());
+            const auto dagPath = MayaUsd::ufe::ufeToDagPath(ufePath);
+            auto       shapePath = dagPath.fullPathName();
+            // Open the Asset Resolver dialog (paths tab).
+            MString script;
+            script.format("assetResolverDialog -tab \"paths\" -proxyShape \"^1s\"", shapePath);
+            MGlobal::executeCommand(script, /* display = */ true, /* undoable = */ false);
+        }
+#endif
+        else if (itemPath[1] == kAddReferenceItem) {
+            return _addReferenceToNewPrimCmd(prim());
+        }
         return nullptr;
     }
-#endif
 #endif
 
     if (itemPath.size() == 2u && itemPath[0] == kUSDReferenceItem) {
         if (itemPath[1] == kAddRefToNewPrimItem) {
-            if (!_prepareUSDReferenceTargetLayer(prim()))
-                return nullptr;
-
-            MString fileRef
-                = MGlobal::executeCommandStringResult(_selectUSDFileScript("Add USD Reference"));
-            if (fileRef.length() == 0)
-                return nullptr;
-
-            const std::string path = makeUSDReferenceFilePathRelativeIfRequested(
-                UsdMayaUtil::convert(fileRef), prim());
-            if (path.empty())
-                return nullptr;
-
-            // Derive the new prim name from the referenced filename stem.
-            std::string stem = path;
-            UsdMayaUtilFileSystem::pathStripPath(stem);
-            UsdMayaUtilFileSystem::pathRemoveExtension(stem);
-            const std::string newPrimName = TfMakeValidIdentifier(stem);
-
-            const std::string refPrimPath = UsdMayaUtilFileSystem::getReferencedPrimPath();
-            const bool        asRef = UsdMayaUtilFileSystem::wantReferenceCompositionArc();
-            const bool        prepend = UsdMayaUtilFileSystem::wantPrependCompositionArc();
-            const bool        preload = !asRef && UsdMayaUtilFileSystem::wantPayloadLoaded();
-
-            return std::make_shared<UsdUfe::UsdUndoAddRefOrPayloadToNewPrimCommand>(
-                prim(), newPrimName, path, refPrimPath, prepend, !asRef, preload);
-
+            return _addReferenceToNewPrimCmd(prim());
         } else if (itemPath[1] == kAddRefOrPayloadItem) {
             if (!_prepareUSDReferenceTargetLayer(prim()))
                 return nullptr;

--- a/lib/usdUfe/ufe/UsdUndoAddRefOrPayloadToNewPrimCommand.cpp
+++ b/lib/usdUfe/ufe/UsdUndoAddRefOrPayloadToNewPrimCommand.cpp
@@ -55,8 +55,9 @@ void UsdUndoAddRefOrPayloadToNewPrimCommand::execute()
         return;
 
     // Build a scene item for the parent prim so we can reuse the existing create-prim command.
-    const Ufe::Path parentPath
-        = stagePath(_parentPrim.GetStage()) + usdPathToUfePathSegment(_parentPrim.GetPath());
+    const Ufe::Path parentPath = _parentPrim.IsPseudoRoot()
+        ? stagePath(_parentPrim.GetStage())
+        : stagePath(_parentPrim.GetStage()) + usdPathToUfePathSegment(_parentPrim.GetPath());
     auto parentItem = UsdSceneItem::create(parentPath, _parentPrim);
 
     // Create a typeless "def" (its type composes through the arc added next).

--- a/plugin/adsk/scripts/mayaUsdMenu.mel
+++ b/plugin/adsk/scripts/mayaUsdMenu.mel
@@ -905,16 +905,17 @@ proc mayaUsdMenu_addStageGatewayContextMenuItems(string $proxyShape)
         return;
     }
     string $shapePath = `longNameOf $proxyShape`;
-    string $insertAfter = "";
+    string $mayaVersion = getMayaMajorVersion();
+
+    string $usdDivider = `menuItem -divider true -insertAfter ""`;
+    string $usdContextMenu = `menuItem -label "USD" -subMenu true -insertAfter "" -version $mayaVersion -image "USD_generic.png"`;
 
     if (`exists mayaUsdLayerEditorWindow`) {
         string $command = "mayaUsdLayerEditorWindow -proxyShape \"" + $shapePath + "\" mayaUsdLayerEditor";
         string $layerEditorLabel = `getMayaUsdString("kContextMenuLayerEditor")`;
-        menuItem -divider true -insertAfter "";
-        $insertAfter = `menuItem -enableCommandRepeat false
+        menuItem -enableCommandRepeat false
             -label $layerEditorLabel
-            -insertAfter ""
-            -command $command openUsdLayerEditor`;
+            -command $command openUsdLayerEditor;
     }
 
     if (`exists assetResolverDialog`) {
@@ -922,8 +923,16 @@ proc mayaUsdMenu_addStageGatewayContextMenuItems(string $proxyShape)
         string $pathEditorLabel = `getMayaUsdString("kContextMenuPathEditor")`;
         menuItem -enableCommandRepeat false
             -label $pathEditorLabel
-            -insertAfter $insertAfter
             -command $command;
+    }
+
+    // Reset the menu parent back to the outliner context menu.
+    setParent -menu ..;
+
+    // Remove the USD submenu (and its divider) if neither item was available to add.
+    if (`menu -q -numberOfItems $usdContextMenu` == 0) {
+        deleteUI -mi $usdContextMenu;
+        deleteUI -mi $usdDivider;
     }
 }
 

--- a/test/lib/ufe/testContextOps.py
+++ b/test/lib/ufe/testContextOps.py
@@ -798,6 +798,39 @@ class ContextOpsTestCase(unittest.TestCase):
         cmd.undo()
         self.assertFalse(sessionLayer.GetPrimAtPath(xformPath))
 
+    def testGatewayUSDMenu(self):
+        '''
+        Test that the stage/gateway context menu groups the USD-specific items
+        (USD Layer Editor, USD Path Editor, Add Reference...) under a single
+        top-level "USD" submenu, instead of listing them flat like a prim's
+        context menu does.
+        '''
+        cmds.file(new=True, force=True)
+
+        # Create a proxy shape with empty stage to start with.
+        proxyShape = mayaUsd_createStageWithNewLayer.createStageWithNewLayer()
+
+        # Create a ContextOps interface for the proxy shape (gateway item).
+        proxyShapePath = ufe.Path([mayaUtils.createUfePathSegment(proxyShape)])
+        proxyShapeItem = ufe.Hierarchy.createItem(proxyShapePath)
+        contextOps = ufe.ContextOps.contextOps(proxyShapeItem)
+
+        topLevelItems = [c.item for c in contextOps.getItems([])]
+
+        # The "USD" submenu replaces the flat top-level items on the gateway.
+        self.assertIn('USD', topLevelItems)
+        self.assertNotIn('USD Layer Editor', topLevelItems)
+        self.assertNotIn('Asset Resolver Dialog', topLevelItems)
+
+        # The "Reference" submenu (used on prims) is not shown on the stage root.
+        self.assertNotIn('Reference', topLevelItems)
+
+        # The "USD" submenu should contain the USD Layer Editor and the new
+        # single-click "Add Reference..." item.
+        usdMenuItems = [c.item for c in contextOps.getItems(['USD'])]
+        self.assertIn('USD Layer Editor', usdMenuItems)
+        self.assertIn('AddReference', usdMenuItems)
+
     def testAddNewPrimInWeakerLayer(self):
         cmds.file(new=True, force=True)
 

--- a/test/lib/ufe/testReferenceCommands.py
+++ b/test/lib/ufe/testReferenceCommands.py
@@ -174,6 +174,40 @@ class ReferenceCommandsTestCase(unittest.TestCase):
         self.assertEqual(str(newPrim.GetTypeName()), 'Xform')
 
 
+    def testAddReferenceToNewPrimCommandAtStageRoot(self):
+        '''
+        Test the "add reference to a new prim" command when the parent is the
+        stage's pseudo-root: the new prim should be created directly under the
+        stage root, not nested under some mis-derived parent path.
+        '''
+        parentPrim = self.stage.GetPseudoRoot()
+        originalRootContents = filterUsdStr(self.stage.GetRootLayer().ExportToString())
+
+        referencedFile = testUtils.getTestScene('twoSpheres', 'sphere.usda')
+
+        newPrimPathStr = "|stage1|stageShape1,/sphere1"
+
+        # Arguments: parentPrim, newPrimName, filePath, primPath, prepend, isPayload, preload
+        cmd = usdUfe.AddRefOrPayloadToNewPrimCommand(
+            parentPrim, 'sphere', referencedFile, '', True, False, False)
+
+        cmd.execute()
+        newPrim = mayaUsd.ufe.ufePathToPrim(newPrimPathStr)
+        self.assertTrue(newPrim.IsValid())
+        self.assertTrue(newPrim.HasAuthoredReferences())
+        self.assertEqual(str(newPrim.GetTypeName()), 'Xform')
+
+        cmd.undo()
+        self.assertFalse(mayaUsd.ufe.ufePathToPrim(newPrimPathStr).IsValid())
+        self.assertEqual(originalRootContents, filterUsdStr(self.stage.GetRootLayer().ExportToString()))
+
+        cmd.redo()
+        newPrim = mayaUsd.ufe.ufePathToPrim(newPrimPathStr)
+        self.assertTrue(newPrim.IsValid())
+        self.assertTrue(newPrim.HasAuthoredReferences())
+        self.assertEqual(str(newPrim.GetTypeName()), 'Xform')
+
+
     def testAddPayloadToNewPrimCommand(self):
         '''
         Test the "add payload to a new prim" variant of the command: it creates a


### PR DESCRIPTION
- Added new menu item in context op handler. The stage proxy shape context menu now shows a "USD" submenu (Layer Editor, Path Editor, "Add Reference...".
- Proxy shape transform node's Outliner context menu now nests "USD Layer Editor" and "USD Path Editor" under a "USD" submenu (with cleanup if neither item is available).
- Added support to create a USD reference at the stage root in `UsdUndoAddRefOrPayloadToNewPrimCommand`.
- Added unit test.