### PR TITLE
EMSUSD-4036 Implement refresh locked layers

### DIFF
--- a/lib/mayaUsd/listeners/notice.cpp
+++ b/lib/mayaUsd/listeners/notice.cpp
@@ -171,6 +171,15 @@ void UsdMayaExitNotice::RemoveListener()
     }
 }
 
+TF_INSTANTIATE_TYPE(UsdMayaLayerLockChangedNotice, TfType::CONCRETE, TF_1_PARENT(TfNotice));
+
+UsdMayaLayerLockChangedNotice::UsdMayaLayerLockChangedNotice(const SdfLayerRefPtr& layer)
+    : _layer(layer)
+{
+}
+
+const SdfLayerRefPtr& UsdMayaLayerLockChangedNotice::GetLayer() const { return _layer; }
+
 UsdMaya_AssemblyInstancerNoticeBase::UsdMaya_AssemblyInstancerNoticeBase(
     const MObject& assembly,
     const MObject& instancer)

--- a/lib/mayaUsd/listeners/notice.h
+++ b/lib/mayaUsd/listeners/notice.h
@@ -19,6 +19,7 @@
 #include <mayaUsd/base/api.h>
 
 #include <pxr/base/tf/notice.h>
+#include <pxr/usd/sdf/layer.h>
 
 #include <maya/MMessage.h>
 #include <maya/MObject.h>
@@ -88,6 +89,21 @@ public:
 
 private:
     static MCallbackId _beforeExitCallbackId;
+};
+
+/// Notice sent when the lock state of a layer changed during a Maya session.
+class UsdMayaLayerLockChangedNotice : public TfNotice
+{
+public:
+    MAYAUSD_CORE_PUBLIC
+    explicit UsdMayaLayerLockChangedNotice(const SdfLayerRefPtr& layer);
+
+    /// \return The layer whose lock state changed.
+    MAYAUSD_CORE_PUBLIC
+    const SdfLayerRefPtr& GetLayer() const;
+
+private:
+    SdfLayerRefPtr _layer;
 };
 
 class UsdMaya_AssemblyInstancerNoticeBase : public TfNotice

--- a/lib/mayaUsd/utils/layerLocking.cpp
+++ b/lib/mayaUsd/utils/layerLocking.cpp
@@ -105,12 +105,26 @@ void updateProxyShapeAttribute(const std::string proxyShapePath)
     }
 }
 
+// Derive the lock state of a layer from the lock registries.
+LayerLockType currentLockType(const PXR_NS::SdfLayerRefPtr& layer)
+{
+    if (isLayerSystemLocked(layer)) {
+        return LayerLock_SystemLocked;
+    }
+    if (isLayerLocked(layer)) {
+        return LayerLock_Locked;
+    }
+    return LayerLock_Unlocked;
+}
+
 void lockLayer(
     std::string                   proxyShapePath,
     const PXR_NS::SdfLayerRefPtr& layer,
     LayerLockType                 locktype,
     bool                          updateProxyShapeAttr /*= true */)
 {
+    // Only fires on a real transition.
+    const LayerLockType previousLockType = currentLockType(layer);
 
     switch (locktype) {
     default:
@@ -144,6 +158,13 @@ void lockLayer(
         }
         break;
     }
+    }
+
+    // Compare against the registries rather than against `locktype` so an
+    // unrecognized value (which the switch treats as Unlocked) is handled the
+    // same way the switch handled it.
+    if (currentLockType(layer) != previousLockType) {
+        PXR_NS::UsdMayaLayerLockChangedNotice(layer).Send();
     }
 }
 

--- a/lib/mayaUsd/utils/layerLocking.cpp
+++ b/lib/mayaUsd/utils/layerLocking.cpp
@@ -105,12 +105,26 @@ void updateProxyShapeAttribute(const std::string proxyShapePath)
     }
 }
 
+// Derive the lock state of a layer from the lock registries.
+static LayerLockType currentLockType(const PXR_NS::SdfLayerRefPtr& layer)
+{
+    if (isLayerSystemLocked(layer)) {
+        return LayerLock_SystemLocked;
+    }
+    if (isLayerLocked(layer)) {
+        return LayerLock_Locked;
+    }
+    return LayerLock_Unlocked;
+}
+
 void lockLayer(
     std::string                   proxyShapePath,
     const PXR_NS::SdfLayerRefPtr& layer,
     LayerLockType                 locktype,
     bool                          updateProxyShapeAttr /*= true */)
 {
+    // Only fires on a real transition.
+    const LayerLockType previousLockType = currentLockType(layer);
 
     switch (locktype) {
     default:
@@ -144,6 +158,13 @@ void lockLayer(
         }
         break;
     }
+    }
+
+    // Compare against the registries rather than against `locktype` so an
+    // unrecognized value (which the switch treats as Unlocked) is handled the
+    // same way the switch handled it.
+    if (currentLockType(layer) != previousLockType) {
+        PXR_NS::UsdMayaLayerLockChangedNotice(layer).Send();
     }
 }
 

--- a/lib/usd/ui/debugTools/CompositionEditorCmd.cpp
+++ b/lib/usd/ui/debugTools/CompositionEditorCmd.cpp
@@ -15,12 +15,16 @@
 //
 #include "CompositionEditorCmd.h"
 
+#include <mayaUsd/listeners/notice.h>
 #include <mayaUsd/ufe/Utils.h>
 #include <mayaUsd/undo/MayaUsdUndoBlock.h>
 #include <mayaUsdUI/ui/undoChunkUtils.h>
 
 #include <usdUfe/undo/UsdUndoManager.h>
 
+#include <pxr/base/tf/notice.h>
+#include <pxr/base/tf/weakBase.h>
+#include <pxr/base/tf/weakPtr.h>
 #include <pxr/usd/sdf/layer.h>
 #include <pxr/usd/usd/prim.h>
 
@@ -101,14 +105,34 @@ public:
     }
 };
 
-class MayaCompositionEditorHost : public Adsk::UsdDebug::ApplicationHost
+class MayaCompositionEditorHost;
+MayaCompositionEditorHost* g_compositionEditorHost = nullptr;
+
+// TfWeakBase is a secondary base so the Qt metaobject machinery still sees
+// QObject (through ApplicationHost) as the first base, which Qt requires.
+class MayaCompositionEditorHost
+    : public Adsk::UsdDebug::ApplicationHost
+    , public PXR_NS::TfWeakBase
 {
 public:
     static void ensureInstalled()
     {
-        static MayaCompositionEditorHost* s_instance = nullptr;
-        if (!s_instance) {
-            s_instance = new MayaCompositionEditorHost();
+        if (!g_compositionEditorHost) {
+            g_compositionEditorHost = new MayaCompositionEditorHost();
+        }
+        // The host outlives a plugin unload, so a previous finalize() may have
+        // revoked the listener. Re-arm it, otherwise the lock refresh would
+        // silently stop working after an unload/reload cycle.
+        g_compositionEditorHost->registerLayerLockListener();
+    }
+
+    // Stop feeding the widget lock notifications. Called from the command's
+    // finalize() so a plugin unload cannot leave TfNotice holding a callback
+    // into code that is about to be unloaded.
+    static void stopListening()
+    {
+        if (g_compositionEditorHost) {
+            g_compositionEditorHost->revokeLayerLockListener();
         }
     }
 
@@ -175,11 +199,38 @@ public:
 protected:
     MayaCompositionEditorHost() { injectInstance(this); }
 
+    // Locking a layer authors nothing. Relay Maya's lock notice as the host signal the
+    // widget listens on, which makes it re-read the composition.
+    void registerLayerLockListener()
+    {
+        if (_layerLockNoticeKey.IsValid()) {
+            return;
+        }
+        PXR_NS::TfWeakPtr<MayaCompositionEditorHost> me(this);
+        _layerLockNoticeKey
+            = PXR_NS::TfNotice::Register(me, &MayaCompositionEditorHost::onLayerLockChanged);
+    }
+
+    void onLayerLockChanged(const PXR_NS::UsdMayaLayerLockChangedNotice&)
+    {
+        Q_EMIT layerLockStateChanged();
+    }
+
+    void revokeLayerLockListener()
+    {
+        if (_layerLockNoticeKey.IsValid()) {
+            PXR_NS::TfNotice::Revoke(_layerLockNoticeKey);
+        }
+    }
+
     static MString optionVarName(const QString& group, const QString& key)
     {
         const QString name = QStringLiteral("mayaUsd_CompositionEditor_%1_%2").arg(group, key);
         return MString(name.toUtf8().constData());
     }
+
+private:
+    PXR_NS::TfNotice::Key _layerLockNoticeKey;
 };
 
 bool workspaceControlExists()
@@ -228,6 +279,8 @@ MStatus CompositionEditorCmd::initialize(MFnPlugin& plugin)
 /*static*/
 MStatus CompositionEditorCmd::finalize(MFnPlugin& plugin)
 {
+    MayaCompositionEditorHost::stopListening();
+
     if (g_selectionObserver) {
         if (auto sel = Ufe::GlobalSelection::get()) {
             sel->removeObserver(g_selectionObserver);


### PR DESCRIPTION
Refresh the debug tools view to show proper locked layers when they are done from the layer editor in maya usd.