### PR TITLE
EMSUSD-4033 - Improve object selection in large stages

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -2715,6 +2715,15 @@ MHWRender::MRenderItem* HdVP2Mesh::_CreateSelectionHighlightRenderItem(const MSt
     renderItem->setSelectionMask(MSelectionMask());
     _InitRenderItemCommon(renderItem);
 
+    // Keep the selection-highlight overlay out of VP2 consolidation. This item is a
+    // decoration that is only enabled while its prim is selected, so consolidating it
+    // provides no draw-call benefit in the common case. More importantly, when the
+    // whole proxy shape is selected every prim's highlight item enables at once; if
+    // these participate in consolidation, OGS breaks and rebuilds consolidation across
+    // the entire stage (observed as a multi-second stall on large stages). Leaving them
+    // unconsolidated draws them individually and preserves the exact highlight visual.
+    _SetWantConsolidation(*renderItem, false);
+
     renderItem->setObjectTypeExclusionFlag(MHWRender::MFrameContext::kExcludeMeshes);
 
     return renderItem;


### PR DESCRIPTION
By default, most common render items participate in consolidation https://github.com/Autodesk/maya-usd/blob/fe05f54eadf0f2d4c2244042ece14a9d399061a2/lib/mayaUsd/render/vp2RenderDelegate/mayaPrimCommon.cpp#L457 

This change excludes the highlights. This makes it very quick to highlight items, but with the trade off of slower movement in very large scenes. However it is justified as the non consolidation slowdown is acceptable. The highlight selection is a common user interaction and can easily freeze the DCC for a dozen seconds. Now that is reduced to only a second or two.

For small to medium sized stages, the actions are instant.