### PR TITLE
Fixing bad override after rename in the Render Setup component.

### DIFF
--- a/lib/usd/ui/renderSetup/rendering/mayaBatchRenderHandler.h
+++ b/lib/usd/ui/renderSetup/rendering/mayaBatchRenderHandler.h
@@ -38,7 +38,7 @@ public:
     ~MayaBatchRenderHandler() = default;
 
     std::string name() const override { return std::string(kName); }
-    std::string label() const override { return std::string(kLabel); }
+    std::string displayName() const override { return std::string(kLabel); }
 
     bool isAsync() const override { return true; }
 

--- a/lib/usd/ui/renderSetup/rendering/mayaRenderCurrentFrameHandler.h
+++ b/lib/usd/ui/renderSetup/rendering/mayaRenderCurrentFrameHandler.h
@@ -38,7 +38,7 @@ public:
     ~MayaRenderCurrentFrameHandler() = default;
 
     std::string name() const override { return std::string(kName); }
-    std::string label() const override { return std::string(kLabel); }
+    std::string displayName() const override { return std::string(kLabel); }
 
     bool isAsync() const override { return false; }
 


### PR DESCRIPTION
The render setup component was update and included this rename. Preflights apparently missed this and a pull request was merged with this bad override.