### PR TITLE
Fix UV shell connectivity when importing non-indexed faceVarying UVs

### DIFF
--- a/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
@@ -24,9 +24,11 @@
 #include <mayaUsd/utils/json.h>
 #include <mayaUsd/utils/util.h>
 
+#include <pxr/base/gf/vec2f.h>
 #include <pxr/base/gf/vec3f.h>
 #include <pxr/base/js/json.h>
 #include <pxr/base/tf/diagnostic.h>
+#include <pxr/base/tf/hash.h>
 #include <pxr/base/tf/staticTokens.h>
 #include <pxr/base/tf/token.h>
 #include <pxr/base/vt/array.h>
@@ -56,6 +58,9 @@
 #include <maya/MSelectionList.h>
 #include <maya/MStatus.h>
 #include <maya/MUintArray.h>
+
+#include <unordered_map>
+#include <utility>
 
 PXR_NAMESPACE_OPEN_SCOPE
 
@@ -245,6 +250,39 @@ bool isPrimitiveLeftHanded(const UsdGeomMesh& mesh)
     return orientation == UsdGeomTokens->leftHanded;
 }
 
+// A non-indexed face-varying primvar carries no UV sharing information, so
+// importing it 1:1 would put every face in its own UV shell. Weld values that
+// are equal on the same mesh vertex into a single UV, which restores the
+// connectivity between adjacent faces without fusing UV islands that merely
+// overlap in UV space.
+void weldNonIndexedUVs(const UsdGeomMesh& mesh, VtVec2fArray& uvValues, VtIntArray& uvIndices)
+{
+    VtIntArray faceVertexIndices;
+    if (!mesh.GetFaceVertexIndicesAttr().Get(&faceVertexIndices, UsdTimeCode::EarliestTime())
+        || faceVertexIndices.size() != uvValues.size()) {
+        return;
+    }
+
+    VtVec2fArray uniqueValues;
+    uniqueValues.reserve(uvValues.size());
+    uvIndices.resize(uvValues.size());
+
+    std::unordered_map<std::pair<int, GfVec2f>, int, TfHash> valueIds;
+    valueIds.reserve(uvValues.size());
+
+    for (size_t i = 0u; i < uvValues.size(); ++i) {
+        auto inserted = valueIds.emplace(
+            std::make_pair(faceVertexIndices[i], uvValues[i]),
+            static_cast<int>(uniqueValues.size()));
+        if (inserted.second) {
+            uniqueValues.push_back(uvValues[i]);
+        }
+        uvIndices[i] = inserted.first->second;
+    }
+
+    uvValues = uniqueValues;
+}
+
 bool assignUVSetPrimvarToMesh(
     const UsdGeomMesh&                        mesh,
     const UsdGeomPrimvar&                     primvar,
@@ -302,12 +340,33 @@ bool assignUVSetPrimvarToMesh(
     MString currentSet = meshFn.currentUVSetName();
     meshFn.setCurrentUVSetName(currentSet);
 
+    const int      unauthoredValuesIndex = primvar.GetUnauthoredValuesIndex();
+    const TfToken& interpolation = primvar.GetInterpolation();
+
+    VtIntArray assignmentIndices;
+    primvar.GetIndices(&assignmentIndices, UsdTimeCode::EarliestTime());
+    if (!assignmentIndices.empty()) {
+        if (unauthoredValuesIndex >= 0) {
+            // Since the unauthored value gets removed below, we need to fix up
+            // the assignment indices to replace any index equal to the
+            // unauthored value index with -1, and decrement any index that was
+            // after the unauthored value index by 1.
+            for (int& index : assignmentIndices) {
+                if (index == unauthoredValuesIndex) {
+                    index = -1;
+                } else if (index > unauthoredValuesIndex) {
+                    index -= 1;
+                }
+            }
+        }
+    } else if (interpolation == UsdGeomTokens->faceVarying && unauthoredValuesIndex < 0) {
+        weldNonIndexedUVs(mesh, uvValues, assignmentIndices);
+    }
+
     // Set the UVs on the mesh from the values we collected out of the primvar.
     // We'll check whether there is an unauthored value in the primvar and skip
     // it if so to ensure that we don't import it into Maya where it has no
     // meaning.
-    const int unauthoredValuesIndex = primvar.GetUnauthoredValuesIndex();
-
     MFloatArray uCoords;
     MFloatArray vCoords;
 
@@ -327,25 +386,6 @@ bool assignUVSetPrimvarToMesh(
             meshFn.fullPathName().asChar());
         return false;
     }
-
-    VtIntArray assignmentIndices;
-    if (primvar.GetIndices(&assignmentIndices, UsdTimeCode::EarliestTime())) {
-        if (unauthoredValuesIndex >= 0) {
-            // Since the unauthored value was removed above, we need to fix up
-            // the assignment indices to replace any index equal to the
-            // unauthored value index with -1, and decrement any index that was
-            // after the unauthored value index by 1.
-            for (int& index : assignmentIndices) {
-                if (index == unauthoredValuesIndex) {
-                    index = -1;
-                } else if (index > unauthoredValuesIndex) {
-                    index -= 1;
-                }
-            }
-        }
-    }
-
-    const TfToken& interpolation = primvar.GetInterpolation();
 
     // Build an array of value assignments for each face vertex in the mesh.
     // Any assignments left as -1 will not be assigned a value.

--- a/test/lib/usd/translators/UsdImportUVSetsFloatTest/UsdImportUVSetsTest_Float.usda
+++ b/test/lib/usd/translators/UsdImportUVSetsFloatTest/UsdImportUVSetsTest_Float.usda
@@ -37,6 +37,35 @@ def Xform "UsdImportUVSetsTest" (
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]
             }
 
+            def Mesh "NonIndexedUVSetCube"
+            {
+                float3[] extent = [(-5, -5, 0), (5, 5, 10)]
+                int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+                int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+                point3f[] points = [(-5, -5, 10), (5, -5, 10), (-5, 5, 10), (5, 5, 10), (-5, 5, 0), (5, 5, 0), (-5, -5, 0), (5, -5, 0)]
+                texCoord2f[] primvars:st = [(0.375, 0), (0.625, 0), (0.625, 0.25), (0.375, 0.25), (0.375, 0.25), (0.625, 0.25), (0.625, 0.5), (0.375, 0.5), (0.375, 0.5), (0.625, 0.5), (0.625, 0.75), (0.375, 0.75), (0.375, 0.75), (0.625, 0.75), (0.625, 1), (0.375, 1), (0.625, 0), (0.875, 0), (0.875, 0.25), (0.625, 0.25), (0.125, 0), (0.375, 0), (0.375, 0.25), (0.125, 0.25)] (
+                    interpolation = "faceVarying"
+                )
+                double3 xformOp:translate = (0, 100, 0)
+                float3 xformOp:translate:pivot = (0, 0, 5)
+                uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]
+            }
+
+            def Mesh "LeftHandedNonIndexedUVSetCube"
+            {
+                float3[] extent = [(-5, -5, 0), (5, 5, 10)]
+                int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+                int[] faceVertexIndices = [2, 3, 1, 0, 4, 5, 3, 2, 6, 7, 5, 4, 0, 1, 7, 6, 3, 5, 7, 1, 4, 2, 0, 6]
+                uniform token orientation = "leftHanded"
+                point3f[] points = [(-5, -5, 10), (5, -5, 10), (-5, 5, 10), (5, 5, 10), (-5, 5, 0), (5, 5, 0), (-5, -5, 0), (5, -5, 0)]
+                texCoord2f[] primvars:st = [(0.375, 0.25), (0.625, 0.25), (0.625, 0), (0.375, 0), (0.375, 0.5), (0.625, 0.5), (0.625, 0.25), (0.375, 0.25), (0.375, 0.75), (0.625, 0.75), (0.625, 0.5), (0.375, 0.5), (0.375, 1), (0.625, 1), (0.625, 0.75), (0.375, 0.75), (0.625, 0.25), (0.875, 0.25), (0.875, 0), (0.625, 0), (0.125, 0.25), (0.375, 0.25), (0.375, 0), (0.125, 0)] (
+                    interpolation = "faceVarying"
+                )
+                double3 xformOp:translate = (0, 120, 0)
+                float3 xformOp:translate:pivot = (0, 0, 5)
+                uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]
+            }
+
             def Mesh "Map1UVSetCube"
             {
                 float3[] extent = [(-5, -5, 0), (5, 5, 10)]

--- a/test/lib/usd/translators/UsdImportUVSetsTest/UsdImportUVSetsTest.usda
+++ b/test/lib/usd/translators/UsdImportUVSetsTest/UsdImportUVSetsTest.usda
@@ -37,6 +37,35 @@ def Xform "UsdImportUVSetsTest" (
                 uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]
             }
 
+            def Mesh "NonIndexedUVSetCube"
+            {
+                float3[] extent = [(-5, -5, 0), (5, 5, 10)]
+                int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+                int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+                point3f[] points = [(-5, -5, 10), (5, -5, 10), (-5, 5, 10), (5, 5, 10), (-5, 5, 0), (5, 5, 0), (-5, -5, 0), (5, -5, 0)]
+                texCoord2f[] primvars:st = [(0.375, 0), (0.625, 0), (0.625, 0.25), (0.375, 0.25), (0.375, 0.25), (0.625, 0.25), (0.625, 0.5), (0.375, 0.5), (0.375, 0.5), (0.625, 0.5), (0.625, 0.75), (0.375, 0.75), (0.375, 0.75), (0.625, 0.75), (0.625, 1), (0.375, 1), (0.625, 0), (0.875, 0), (0.875, 0.25), (0.625, 0.25), (0.125, 0), (0.375, 0), (0.375, 0.25), (0.125, 0.25)] (
+                    interpolation = "faceVarying"
+                )
+                double3 xformOp:translate = (0, 100, 0)
+                float3 xformOp:translate:pivot = (0, 0, 5)
+                uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]
+            }
+
+            def Mesh "LeftHandedNonIndexedUVSetCube"
+            {
+                float3[] extent = [(-5, -5, 0), (5, 5, 10)]
+                int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+                int[] faceVertexIndices = [2, 3, 1, 0, 4, 5, 3, 2, 6, 7, 5, 4, 0, 1, 7, 6, 3, 5, 7, 1, 4, 2, 0, 6]
+                uniform token orientation = "leftHanded"
+                point3f[] points = [(-5, -5, 10), (5, -5, 10), (-5, 5, 10), (5, 5, 10), (-5, 5, 0), (5, 5, 0), (-5, -5, 0), (5, -5, 0)]
+                texCoord2f[] primvars:st = [(0.375, 0.25), (0.625, 0.25), (0.625, 0), (0.375, 0), (0.375, 0.5), (0.625, 0.5), (0.625, 0.25), (0.375, 0.25), (0.375, 0.75), (0.625, 0.75), (0.625, 0.5), (0.375, 0.5), (0.375, 1), (0.625, 1), (0.625, 0.75), (0.375, 0.75), (0.625, 0.25), (0.875, 0.25), (0.875, 0), (0.625, 0), (0.125, 0.25), (0.375, 0.25), (0.375, 0), (0.125, 0)] (
+                    interpolation = "faceVarying"
+                )
+                double3 xformOp:translate = (0, 120, 0)
+                float3 xformOp:translate:pivot = (0, 0, 5)
+                uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:translate:pivot", "!invert!xformOp:translate:pivot"]
+            }
+
             def Mesh "Map1UVSetCube"
             {
                 float3[] extent = [(-5, -5, 0), (5, 5, 10)]

--- a/test/lib/usd/translators/testUsdImportUVSets.py
+++ b/test/lib/usd/translators/testUsdImportUVSets.py
@@ -139,6 +139,87 @@ class testUsdImportUVSets(unittest.TestCase):
         self._AssertUVSet(mayaCubeMesh, "st", expectedValues,
             expectedNumValues=14, expectedNumUVShells=1)
 
+    def testImportNonIndexedUVSet(self):
+        """
+        Tests that a USD cube mesh with a non-indexed faceVarying UV set
+        (named 'st' in USD) gets imported with UV values welded per mesh
+        vertex so that UV connectivity between faces is preserved.
+        """
+        mayaCubeMesh = testUsdImportUVSets._GetMayaMesh('NonIndexedUVSetCubeShape')
+
+        # These are the default UV values for a regular Maya polycube.
+        expectedValues = {
+            0: Gf.Vec2f(0.375, 0.0),
+            1: Gf.Vec2f(0.625, 0.0),
+            2: Gf.Vec2f(0.625, 0.25),
+            3: Gf.Vec2f(0.375, 0.25),
+            4: Gf.Vec2f(0.375, 0.25),
+            5: Gf.Vec2f(0.625, 0.25),
+            6: Gf.Vec2f(0.625, 0.5),
+            7: Gf.Vec2f(0.375, 0.5),
+            8: Gf.Vec2f(0.375, 0.5),
+            9: Gf.Vec2f(0.625, 0.5),
+            10: Gf.Vec2f(0.625, 0.75),
+            11: Gf.Vec2f(0.375, 0.75),
+            12: Gf.Vec2f(0.375, 0.75),
+            13: Gf.Vec2f(0.625, 0.75),
+            14: Gf.Vec2f(0.625, 1.0),
+            15: Gf.Vec2f(0.375, 1.0),
+            16: Gf.Vec2f(0.625, 0.0),
+            17: Gf.Vec2f(0.875, 0.0),
+            18: Gf.Vec2f(0.875, 0.25),
+            19: Gf.Vec2f(0.625, 0.25),
+            20: Gf.Vec2f(0.125, 0.0),
+            21: Gf.Vec2f(0.375, 0.0),
+            22: Gf.Vec2f(0.375, 0.25),
+            23: Gf.Vec2f(0.125, 0.25)
+        }
+
+        self._AssertUVSet(mayaCubeMesh, "st", expectedValues,
+            expectedNumValues=14, expectedNumUVShells=1)
+
+    def testImportLeftHandedNonIndexedUVSet(self):
+        """
+        Tests that a left-handed USD cube mesh with a non-indexed faceVarying
+        UV set gets imported with UV values welded per mesh vertex, matching
+        the equivalent right-handed cube after the winding order is reversed.
+        """
+        mayaCubeMesh = testUsdImportUVSets._GetMayaMesh(
+            'LeftHandedNonIndexedUVSetCubeShape')
+
+        # After the left-handed winding order is reversed on import, the Maya
+        # mesh matches the right-handed cube, so the expected values are the
+        # same as for NonIndexedUVSetCube.
+        expectedValues = {
+            0: Gf.Vec2f(0.375, 0.0),
+            1: Gf.Vec2f(0.625, 0.0),
+            2: Gf.Vec2f(0.625, 0.25),
+            3: Gf.Vec2f(0.375, 0.25),
+            4: Gf.Vec2f(0.375, 0.25),
+            5: Gf.Vec2f(0.625, 0.25),
+            6: Gf.Vec2f(0.625, 0.5),
+            7: Gf.Vec2f(0.375, 0.5),
+            8: Gf.Vec2f(0.375, 0.5),
+            9: Gf.Vec2f(0.625, 0.5),
+            10: Gf.Vec2f(0.625, 0.75),
+            11: Gf.Vec2f(0.375, 0.75),
+            12: Gf.Vec2f(0.375, 0.75),
+            13: Gf.Vec2f(0.625, 0.75),
+            14: Gf.Vec2f(0.625, 1.0),
+            15: Gf.Vec2f(0.375, 1.0),
+            16: Gf.Vec2f(0.625, 0.0),
+            17: Gf.Vec2f(0.875, 0.0),
+            18: Gf.Vec2f(0.875, 0.25),
+            19: Gf.Vec2f(0.625, 0.25),
+            20: Gf.Vec2f(0.125, 0.0),
+            21: Gf.Vec2f(0.375, 0.0),
+            22: Gf.Vec2f(0.375, 0.25),
+            23: Gf.Vec2f(0.125, 0.25)
+        }
+
+        self._AssertUVSet(mayaCubeMesh, "st", expectedValues,
+            expectedNumValues=14, expectedNumUVShells=1)
+
     def testImportMap1UVSet(self):
         """
         Tests that a USD cube mesh with the Maya default values for the default


### PR DESCRIPTION
### Problem

When a mesh has a faceVarying UV primvar **without** authored indices (`primvars:st` but no `primvars:st:indices` — common for USD written by other DCCs), the importer creates one Maya UV per face vertex with no sharing.

The imported UV values themselves are correct, but no UVs are shared between neighboring faces, so every face becomes its own UV shell. A cube that should import with 14 UVs in a single shell instead imports with 24 UVs in 6 shells, and the layout falls apart into individual faces as soon as the UVs are edited.

The same data imports correctly when authored *with* indices, so whether an asset arrived intact depended on how the exporting application chose to write its UVs.

<img width="1321" height="722" alt="maya_uv_report_01" src="https://github.com/user-attachments/assets/5210d4b8-9bf5-4921-9fcd-e883914013ab" />

### Fix

In `assignUVSetPrimvarToMesh`, when a faceVarying UV primvar has no authored indices, weld values that are equal **on the same mesh vertex** into a single shared UV and synthesize the assignment indices. Welding per vertex restores connectivity between adjacent faces without fusing UV islands that merely overlap in UV space (e.g. stacked/mirrored shells). The result is identical to what an indexed export of the same data would produce.

Indexed primvars, other interpolations, and the left-handed winding reversal are untouched.

### Tests

Added a right-handed and a left-handed cube with non-indexed faceVarying UVs to the `UsdImportUVSetsTest` fixtures (both variants), with new cases in `testUsdImportUVSets.py` asserting values, UV count (14), and shell count (1). All existing UV set, mesh, and color set import tests pass.