### PR TITLE
Fix unstable NodeGraph order when exporting with multiple materialConversions

### DIFF
--- a/lib/mayaUsd/fileio/jobs/jobArgs.h
+++ b/lib/mayaUsd/fileio/jobs/jobArgs.h
@@ -298,25 +298,25 @@ struct UsdMayaJobExportArgs
 
     /// This is the path of the USD prim under which *all* prims will be
     /// authored.
-    const SdfPath      parentScope; // Deprecated, use rootPrim instead.
-    const SdfPath      rootPrim;
-    const TfToken      rootPrimType;
-    const TfToken      upAxis;
-    const TfToken      unit;
-    const TfToken      renderLayerMode;
-    const TfToken      rootKind;
-    const TfToken      animationType;
-    const bool         disableModelKindProcessor;
-    const TfToken      shadingMode;
-    TfToken            convertMaterialsTo; // Can not be const, iteration variable.
-    const TfToken::Set allMaterialConversions;
-    const bool         verbose;
-    const bool         staticSingleSample;
-    const TfToken      geomSidedness;
-    const TfToken::Set includeAPINames;
-    const TfToken::Set jobContextNames;
-    const TfToken::Set excludeExportTypes;
-    std::string        defaultPrim;
+    const SdfPath           parentScope; // Deprecated, use rootPrim instead.
+    const SdfPath           rootPrim;
+    const TfToken           rootPrimType;
+    const TfToken           upAxis;
+    const TfToken           unit;
+    const TfToken           renderLayerMode;
+    const TfToken           rootKind;
+    const TfToken           animationType;
+    const bool              disableModelKindProcessor;
+    const TfToken           shadingMode;
+    TfToken                 convertMaterialsTo; // Can not be const, iteration variable.
+    const std::set<TfToken> allMaterialConversions;
+    const bool              verbose;
+    const bool              staticSingleSample;
+    const TfToken           geomSidedness;
+    const std::set<TfToken> includeAPINames;
+    const std::set<TfToken> jobContextNames;
+    const std::set<TfToken> excludeExportTypes;
+    std::string             defaultPrim;
 
     // Accessibility Info
     std::string accessibilityLabel;
@@ -436,12 +436,12 @@ std::ostream& operator<<(std::ostream& out, const UsdMayaJobExportArgs& exportAr
 
 struct UsdMayaJobImportArgs
 {
-    const TfToken      assemblyRep;
-    const TfToken::Set excludePrimvarNames;
-    const TfToken::Set excludePrimvarNamespaces;
-    const TfToken::Set includeAPINames;
-    const TfToken::Set jobContextNames;
-    const TfToken::Set includeMetadataKeys;
+    const TfToken           assemblyRep;
+    const std::set<TfToken> excludePrimvarNames;
+    const std::set<TfToken> excludePrimvarNamespaces;
+    const std::set<TfToken> includeAPINames;
+    const std::set<TfToken> jobContextNames;
+    const std::set<TfToken> includeMetadataKeys;
     struct ShadingMode
     {
         TfToken mode;

--- a/lib/mayaUsd/fileio/primReaderArgs.cpp
+++ b/lib/mayaUsd/fileio/primReaderArgs.cpp
@@ -28,22 +28,22 @@ const UsdPrim& UsdMayaPrimReaderArgs::GetUsdPrim() const { return _prim; }
 
 GfInterval UsdMayaPrimReaderArgs::GetTimeInterval() const { return _jobArgs.timeInterval; }
 
-const TfToken::Set& UsdMayaPrimReaderArgs::GetIncludeMetadataKeys() const
+const std::set<TfToken>& UsdMayaPrimReaderArgs::GetIncludeMetadataKeys() const
 {
     return _jobArgs.includeMetadataKeys;
 }
 
-const TfToken::Set& UsdMayaPrimReaderArgs::GetIncludeAPINames() const
+const std::set<TfToken>& UsdMayaPrimReaderArgs::GetIncludeAPINames() const
 {
     return _jobArgs.includeAPINames;
 }
 
-const TfToken::Set& UsdMayaPrimReaderArgs::GetExcludePrimvarNames() const
+const std::set<TfToken>& UsdMayaPrimReaderArgs::GetExcludePrimvarNames() const
 {
     return _jobArgs.excludePrimvarNames;
 }
 
-const TfToken::Set& UsdMayaPrimReaderArgs::GetExcludePrimvarNamespaces() const
+const std::set<TfToken>& UsdMayaPrimReaderArgs::GetExcludePrimvarNamespaces() const
 {
     return _jobArgs.excludePrimvarNamespaces;
 }

--- a/lib/mayaUsd/fileio/primReaderArgs.h
+++ b/lib/mayaUsd/fileio/primReaderArgs.h
@@ -23,6 +23,8 @@
 #include <pxr/pxr.h>
 #include <pxr/usd/usd/prim.h>
 
+#include <set>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 /// \class UsdMayaPrimReaderArgs
@@ -52,15 +54,15 @@ public:
     GfInterval GetTimeInterval() const;
 
     MAYAUSD_CORE_PUBLIC
-    const TfToken::Set& GetIncludeMetadataKeys() const;
+    const std::set<TfToken>& GetIncludeMetadataKeys() const;
     MAYAUSD_CORE_PUBLIC
-    const TfToken::Set& GetIncludeAPINames() const;
+    const std::set<TfToken>& GetIncludeAPINames() const;
 
     MAYAUSD_CORE_PUBLIC
-    const TfToken::Set& GetExcludePrimvarNames() const;
+    const std::set<TfToken>& GetExcludePrimvarNames() const;
 
     MAYAUSD_CORE_PUBLIC
-    const TfToken::Set& GetExcludePrimvarNamespaces() const;
+    const std::set<TfToken>& GetExcludePrimvarNamespaces() const;
 
     MAYAUSD_CORE_PUBLIC
     bool GetUseAsAnimationCache() const;

--- a/lib/mayaUsd/fileio/primWriterArgs.cpp
+++ b/lib/mayaUsd/fileio/primWriterArgs.cpp
@@ -22,9 +22,9 @@
 PXR_NAMESPACE_OPEN_SCOPE
 
 UsdMayaPrimWriterArgs::UsdMayaPrimWriterArgs(
-    const MDagPath&     dagPath,
-    const bool          exportRefsAsInstanceable,
-    const TfToken::Set& excludeExportTypes)
+    const MDagPath&          dagPath,
+    const bool               exportRefsAsInstanceable,
+    const std::set<TfToken>& excludeExportTypes)
     : _dagPath(dagPath)
     , _exportRefsAsInstanceable(exportRefsAsInstanceable)
     , _excludeExportTypes(excludeExportTypes)

--- a/lib/mayaUsd/fileio/primWriterArgs.h
+++ b/lib/mayaUsd/fileio/primWriterArgs.h
@@ -25,6 +25,8 @@
 #include <maya/MDagPath.h>
 #include <maya/MObject.h>
 
+#include <set>
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 /// \class UsdMayaPrimWriterArgs
@@ -39,9 +41,9 @@ class UsdMayaPrimWriterArgs
 public:
     MAYAUSD_CORE_PUBLIC
     UsdMayaPrimWriterArgs(
-        const MDagPath&     dagPath,
-        const bool          exportRefsAsInstanceable,
-        const TfToken::Set& excludeExportTypes);
+        const MDagPath&          dagPath,
+        const bool               exportRefsAsInstanceable,
+        const std::set<TfToken>& excludeExportTypes);
 
     /// \brief returns the MObject that should be exported.
     MAYAUSD_CORE_PUBLIC
@@ -67,9 +69,9 @@ public:
     /// \}
 
 private:
-    MDagPath     _dagPath;
-    bool         _exportRefsAsInstanceable;
-    TfToken::Set _excludeExportTypes;
+    MDagPath          _dagPath;
+    bool              _exportRefsAsInstanceable;
+    std::set<TfToken> _excludeExportTypes;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.cpp
@@ -698,8 +698,8 @@ void UsdMayaMeshReadUtils::setEmitNormalsTag(MFnMesh& meshFn, const bool emitNor
 void UsdMayaMeshReadUtils::assignPrimvarsToMesh(
     const UsdGeomMesh&                        mesh,
     const MObject&                            meshObj,
-    const TfToken::Set&                       excludePrimvarSet,
-    const TfToken::Set&                       excludePrivarNamespaceSet,
+    const std::set<TfToken>&                  excludePrimvarSet,
+    const std::set<TfToken>&                  excludePrivarNamespaceSet,
     const std::map<std::string, std::string>& uvSetNameRemappings)
 {
     if (meshObj.apiType() != MFn::kMesh) {

--- a/lib/mayaUsd/fileio/utils/meshReadUtils.h
+++ b/lib/mayaUsd/fileio/utils/meshReadUtils.h
@@ -33,6 +33,7 @@
 #include <maya/MObject.h>
 #include <maya/MString.h>
 
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -82,8 +83,8 @@ MAYAUSD_CORE_PUBLIC
 void assignPrimvarsToMesh(
     const UsdGeomMesh&                        mesh,
     const MObject&                            meshObj,
-    const TfToken::Set&                       excludePrimvarSet,
-    const TfToken::Set&                       excludePrimvarNamespaceSet,
+    const std::set<TfToken>&                  excludePrimvarSet,
+    const std::set<TfToken>&                  excludePrimvarNamespaceSet,
     const std::map<std::string, std::string>& uvSetNameRemappings);
 
 MAYAUSD_CORE_PUBLIC

--- a/lib/mayaUsd/fileio/utils/readUtil.cpp
+++ b/lib/mayaUsd/fileio/utils/readUtil.cpp
@@ -855,9 +855,9 @@ void UsdMayaReadUtil::SetMayaAttrKeyableState(
 }
 
 bool UsdMayaReadUtil::ReadMetadataFromPrim(
-    const TfToken::Set& includeMetadataKeys,
-    const UsdPrim&      prim,
-    const MObject&      mayaObject)
+    const std::set<TfToken>& includeMetadataKeys,
+    const UsdPrim&           prim,
+    const MObject&           mayaObject)
 {
     UsdMayaAdaptor adaptor(mayaObject);
     if (!adaptor) {
@@ -882,9 +882,9 @@ bool UsdMayaReadUtil::ReadMetadataFromPrim(
 }
 
 bool UsdMayaReadUtil::ReadAPISchemaAttributesFromPrim(
-    const TfToken::Set& includeAPINames,
-    const UsdPrim&      prim,
-    const MObject&      mayaObject)
+    const std::set<TfToken>& includeAPINames,
+    const UsdPrim&           prim,
+    const MObject&           mayaObject)
 {
     UsdMayaAdaptor adaptor(mayaObject);
     if (!adaptor) {

--- a/lib/mayaUsd/fileio/utils/readUtil.h
+++ b/lib/mayaUsd/fileio/utils/readUtil.h
@@ -27,6 +27,7 @@
 #include <maya/MObject.h>
 #include <maya/MPlug.h>
 
+#include <set>
 #include <string>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -152,9 +153,9 @@ struct UsdMayaReadUtil
     /// Returns true if successful (even if there was nothing to import).
     MAYAUSD_CORE_PUBLIC
     static bool ReadMetadataFromPrim(
-        const TfToken::Set& includeMetadataKeys,
-        const UsdPrim&      prim,
-        const MObject&      mayaObject);
+        const std::set<TfToken>& includeMetadataKeys,
+        const UsdPrim&           prim,
+        const MObject&           mayaObject);
 
     /// Reads the attributes from the non-excluded schemas applied to \p prim,
     /// and uses adaptors to write them onto attributes of \p mayaObject.
@@ -163,9 +164,9 @@ struct UsdMayaReadUtil
     /// function, then this function won't recognize it.
     MAYAUSD_CORE_PUBLIC
     static bool ReadAPISchemaAttributesFromPrim(
-        const TfToken::Set& includeAPINames,
-        const UsdPrim&      prim,
-        const MObject&      mayaObject);
+        const std::set<TfToken>& includeAPINames,
+        const UsdPrim&           prim,
+        const MObject&           mayaObject);
 
     /// Iterate on all newly created Maya objects in \p readCtx to see if they can receive one of
     /// the API schemas found on the currently processed UsdPrim found in \p args.

--- a/lib/mayaUsd/utils/utilDictionary.cpp
+++ b/lib/mayaUsd/utils/utilDictionary.cpp
@@ -127,11 +127,11 @@ SdfPath extractAbsolutePath(const VtDictionary& userArgs, const TfToken& key)
 }
 
 /// Convenience function that takes the result of extractVector and converts it to a
-/// TfToken::Set.
-TfToken::Set extractTokenSet(const VtDictionary& userArgs, const TfToken& key)
+/// std::set<TfToken>.
+std::set<TfToken> extractTokenSet(const VtDictionary& userArgs, const TfToken& key)
 {
     const std::vector<std::string> vec = extractVector<std::string>(userArgs, key);
-    TfToken::Set                   result;
+    std::set<TfToken>              result;
     for (const std::string& s : vec) {
         result.insert(TfToken(s));
     }

--- a/lib/mayaUsd/utils/utilDictionary.h
+++ b/lib/mayaUsd/utils/utilDictionary.h
@@ -25,6 +25,7 @@
 #include <pxr/usd/usd/property.h>
 #include <pxr/usd/usd/stage.h>
 
+#include <set>
 #include <vector>
 
 namespace MAYAUSD_NS_DEF {
@@ -75,9 +76,9 @@ MAYAUSD_CORE_PUBLIC std::vector<T>
                     extractVector(const PXR_NS::VtDictionary& userArgs, const PXR_NS::TfToken& key);
 
 /// \brief Convenience function that takes the result of extractVector and converts it to a
-/// TfToken::Set.
+/// std::set<TfToken>.
 MAYAUSD_CORE_PUBLIC
-PXR_NS::TfToken::Set
+std::set<PXR_NS::TfToken>
 extractTokenSet(const PXR_NS::VtDictionary& userArgs, const PXR_NS::TfToken& key);
 
 // Implementation of the templated function declared above.


### PR DESCRIPTION
This fixes the unstable order of exported NodeGraphs when using multiple materialConversions. This was creating spurious diffs on our USD layers, preventing our asset manager from deduplicating file versions.

The issue was caused by `UsdMayaJobExportArgs::allMaterialConversions` being a `TfToken::Set`, which uses an arbitrary memory-address-based order (cf. [TfTokenFastArbitraryLessThan](https://openusd.org/dev/api/struct_tf_token_fast_arbitrary_less_than.html#details)). `UseRegistryShadingModeExporter::Export()` iterates over `allMaterialConversions` to export each nodeGraph, leading to unstable prim order.

This PR turns all the import/export `TfToken::Set` args into `std::set<TfToken>`, so we can keep using the same `MayaUsd::DictUtils::extractTokenSet`. I also believe this is better suited for these variables, which are of a reasonable size and aren't used in performance-critical code. This leads to a few API signature changes. If preferred, I can make a more surgical change that addresses only the material ordering.
