### PR TITLE
EMSUSD-4085 remove change block from committer

### DIFF
--- a/lib/usd/ui/renderSetup/mayaEditCommitter.cpp
+++ b/lib/usd/ui/renderSetup/mayaEditCommitter.cpp
@@ -52,7 +52,6 @@ void MayaEditCommitter::commit(const std::string& undoLabel, std::function<void(
     const MayaUsdUI::UndoChunkGuard undoChunkGuard(undoLabel);
     MayaUsd::MayaUsdUndoBlock       block;
     {
-        PXR_NS::SdfChangeBlock changeBlock;
         doEdit();
     }
 }


### PR DESCRIPTION
The `SdfChangeBlock` delays stage recomposition. This prevents USD-level API from working correctly. For example, `DefinePrim` fails because it does not see the prim it just created. `SdfChangeBlock`should be used by the code doing the work when they deem it safe, knowing exactly which API they are using. `Sdf`-level API are safe, `Usd` are not.