### PR TITLE
fileio: Fix discovery of PrimReader/PrimWriter override plugins

### DIFF
--- a/lib/mayaUsd/fileio/primReaderRegistry.cpp
+++ b/lib/mayaUsd/fileio/primReaderRegistry.cpp
@@ -163,12 +163,16 @@ UsdMayaPrimReaderRegistry::ReaderFactoryFn UsdMayaPrimReaderRegistry::Find(
 
     // unfortunately, usdTypeName is diff from the tfTypeName which we use to
     // register.  do the conversion here.
-    TfType          tfType = PlugRegistry::FindDerivedTypeByName<UsdSchemaBase>(usdTypeName);
-    std::string     typeNameStr = tfType.GetTypeName();
-    TfToken         typeName(typeNameStr);
-    ReaderFactoryFn ret = nullptr;
+    const TfType       tfType = PlugRegistry::FindDerivedTypeByName<UsdSchemaBase>(usdTypeName);
+    const std::string& typeNameStr = tfType.GetTypeName();
+    const TfToken      typeName(typeNameStr);
 
-    if (_reg.count(typeName) == 0) {
+    // Search the plugins once per type and even if the type is already registered.
+    // Multiple readers can be registered for the same type and the others may come from
+    // unloaded plugins.
+    static TfToken::Set typesTriedForPlugins;
+
+    if (typesTriedForPlugins.insert(typeName).second) {
         static const TfTokenVector SCOPE = { _tokens->UsdMaya, _tokens->PrimReader };
         UsdMaya_RegistryHelper::FindAndLoadMayaPlug(SCOPE, typeNameStr);
     }

--- a/lib/mayaUsd/fileio/primWriterRegistry.cpp
+++ b/lib/mayaUsd/fileio/primWriterRegistry.cpp
@@ -29,6 +29,7 @@
 
 #include <map>
 #include <string>
+#include <unordered_set>
 #include <utility>
 
 PXR_NAMESPACE_OPEN_SCOPE
@@ -168,18 +169,9 @@ UsdMayaPrimWriterRegistry::WriterFactoryFn UsdMayaPrimWriterRegistry::Find(
     const UsdMayaJobExportArgs& exportArgs,
     const MObject&              exportObj)
 {
-    TfRegistryManager::GetInstance().SubscribeTo<UsdMayaPrimWriterRegistry>();
+    CheckForWriterPlugin(mayaTypeName);
 
     _Registry::const_iterator it = _Find(mayaTypeName, exportArgs, exportObj);
-
-    if (it != _reg.end()) {
-        return it->second._writer;
-    }
-
-    static const TfTokenVector SCOPE = { _tokens->UsdMaya, _tokens->PrimWriter };
-    UsdMaya_RegistryHelper::FindAndLoadMayaPlug(SCOPE, mayaTypeName);
-
-    it = _Find(mayaTypeName, exportArgs, exportObj);
 
     if (it != _reg.end()) {
         return it->second._writer;
@@ -208,11 +200,12 @@ void UsdMayaPrimWriterRegistry::CheckForWriterPlugin(const std::string& mayaType
 {
     TfRegistryManager::GetInstance().SubscribeTo<UsdMayaPrimWriterRegistry>();
 
-    _Registry::const_iterator first, last;
-    std::tie(first, last) = _reg.equal_range(mayaTypeName);
+    // Search the plugins once per type and even if the type is already registered.
+    // Multiple writers can be registered for the same type and the others may come from
+    // unloaded plugins.
+    static std::unordered_set<std::string> mayaTypesTriedForPlugins;
 
-    if (first == last) {
-        // If the type name is not currently in our registry, check for plugin registry
+    if (mayaTypesTriedForPlugins.insert(mayaTypeName).second) {
         static const TfTokenVector SCOPE = { _tokens->UsdMaya, _tokens->PrimWriter };
         UsdMaya_RegistryHelper::FindAndLoadMayaPlug(SCOPE, mayaTypeName);
     }

--- a/test/lib/mayaUsd/fileio/CMakeLists.txt
+++ b/test/lib/mayaUsd/fileio/CMakeLists.txt
@@ -181,4 +181,29 @@ if(CMAKE_UFE_V3_FEATURES_AVAILABLE)
     set_property(TEST ${target} APPEND PROPERTY LABELS fileio)
 endif()
 
+
+set(TEST_DUMMY_TRANSLATORS_PLUGIN_FILES
+    dummyXformReaderPlugin.py
+    dummyLocatorWriterPlugin.py
+    plugInfo.json
+)
+
+foreach(file ${TEST_DUMMY_TRANSLATORS_PLUGIN_FILES})
+    file(COPY ${file} DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/UsdDummyPrimTranslators")
+endforeach()
+
+mayaUsd_get_unittest_target(target testPrimTranslatorPlugins.py)
+
+mayaUsd_add_test(${target}
+    PYTHON_MODULE ${target}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    ENV
+        "MAYA_PLUG_IN_PATH=${CMAKE_CURRENT_BINARY_DIR}/UsdDummyPrimTranslators"
+        "${PXR_OVERRIDE_PLUGINPATH_NAME}=${CMAKE_CURRENT_BINARY_DIR}/UsdDummyPrimTranslators"
+        "LD_LIBRARY_PATH=${ADDITIONAL_LD_LIBRARY_PATH}"
+)
+
+set_property(TEST ${target} APPEND PROPERTY LABELS fileio)
+
+
 add_subdirectory(utils)

--- a/test/lib/mayaUsd/fileio/dummyLocatorWriterPlugin.py
+++ b/test/lib/mayaUsd/fileio/dummyLocatorWriterPlugin.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+#
+# Copyright 2026 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import maya.api.OpenMaya
+import mayaUsd.lib
+
+
+def maya_useNewAPI():
+    pass
+
+
+class DummyLocatorWriter(mayaUsd.lib.PrimWriter):
+    """
+    Dummy locator PrimWriter.
+    It is used to verify plugin discovery and loading, and writes noting.
+    """
+    @classmethod
+    def CanExport(cls, exportArgs, exportObj=None):
+        return mayaUsd.lib.PrimWriter.ContextSupport.Unsupported
+
+
+def initializePlugin(mobject):
+    maya.api.OpenMaya.MFnPlugin(mobject, 'Autodesk', '1.0', 'Any')
+    mayaUsd.lib.PrimWriter.Register(DummyLocatorWriter, 'locator')
+
+
+def uninitializePlugin(mobject):
+    maya.api.OpenMaya.MFnPlugin(mobject, 'Autodesk', '1.0', 'Any')

--- a/test/lib/mayaUsd/fileio/dummyXformReaderPlugin.py
+++ b/test/lib/mayaUsd/fileio/dummyXformReaderPlugin.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+#
+# Copyright 2026 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import maya.api.OpenMaya
+import mayaUsd.lib
+
+
+def maya_useNewAPI():
+    pass
+
+
+class DummyXformReader(mayaUsd.lib.PrimReader):
+    """
+    Dummy UsdGeomXform PrimReader.
+    It is used to verify plugin discovery and loading, and reads noting.
+    """
+    @classmethod
+    def CanImport(cls, importArgs, importPrim):
+        return mayaUsd.lib.PrimReader.ContextSupport.Unsupported
+
+    def Read(self, context):
+        return False
+
+
+def initializePlugin(mobject):
+    maya.api.OpenMaya.MFnPlugin(mobject, 'Autodesk', '1.0', 'Any')
+    mayaUsd.lib.PrimReader.Register(DummyXformReader, 'UsdGeomXform')
+
+
+def uninitializePlugin(mobject):
+    maya.api.OpenMaya.MFnPlugin(mobject, 'Autodesk', '1.0', 'Any')

--- a/test/lib/mayaUsd/fileio/plugInfo.json
+++ b/test/lib/mayaUsd/fileio/plugInfo.json
@@ -1,0 +1,20 @@
+{
+  "Plugins": [
+    {
+      "Info": {
+        "UsdMaya": {
+          "PrimReader": {
+            "mayaPlugin": "dummyXformReaderPlugin",
+            "providesTranslator": [ "UsdGeomXform" ]
+          },
+          "PrimWriter": {
+            "mayaPlugin": "dummyLocatorWriterPlugin",
+            "providesTranslator": [ "locator" ]
+          }
+        }
+      },
+      "Name": "dummyPrimTranslators",
+      "Type": "resource"
+    }
+  ]
+}

--- a/test/lib/mayaUsd/fileio/testPrimTranslatorPlugins.py
+++ b/test/lib/mayaUsd/fileio/testPrimTranslatorPlugins.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env mayapy
+#
+# Copyright 2026 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from maya import cmds
+from maya import standalone
+
+from pxr import Plug, Sdf, Usd
+
+import fixturesUtils
+
+
+class testPrimTranslatorPlugins(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        fixturesUtils.setUpClass(__file__)
+
+    @classmethod
+    def tearDownClass(cls):
+        standalone.uninitialize()
+
+    def setUp(self):
+        cmds.file(new=True, force=True)
+
+    def _assertMayaPluginLoaded(self, pluginName, expected):
+        self.assertEqual(
+            bool(cmds.pluginInfo(pluginName, q=True, loaded=True)), expected,
+            "pluginInfo('%s', loaded=True)" % pluginName)
+
+    def _preloadMayaUsdTranslators(self):
+        plugin = Plug.Registry().GetPluginWithName('mayaUsd_Translators')
+        self.assertIsNotNone(plugin, 'mayaUsd_Translators')
+        plugin.Load()
+        self.assertTrue(plugin.isLoaded)
+
+    def testMultiplePrimReaderPlugin(self):
+        """Test if a prim reader plugin is loaded even when there is already a reader for this type."""
+
+        # Ensure the plugin providing the default mayaUsd translatorsis loaded,
+        # so that 'UsdGeomXform' already has a reader registered.
+        self._preloadMayaUsdTranslators()
+
+        srcStage = Usd.Stage.CreateInMemory()
+        prim = srcStage.DefinePrim("/Test", "Xform")
+        srcStage.SetDefaultPrim(prim)
+
+        # 'UsdGeomXform' already has a reader registered. dummyXformReaderPlugin declares a reader
+        # for it in its plugInfo.json and must still be discovered and loaded.
+
+        self._assertMayaPluginLoaded('dummyXformReaderPlugin', False)
+        cmds.mayaUSDImport(f=srcStage.GetRootLayer().identifier)
+        self._assertMayaPluginLoaded('dummyXformReaderPlugin', True)
+
+        # After an explicit unload the plugin is not discovered and loaded again.
+        cmds.unloadPlugin('dummyXformReaderPlugin')
+        self._assertMayaPluginLoaded('dummyXformReaderPlugin', False)
+
+        cmds.mayaUSDImport(f=srcStage.GetRootLayer().identifier)
+        self._assertMayaPluginLoaded('dummyXformReaderPlugin', False)
+
+    def testMultiplePrimWriterPlugin(self):
+        """Test if a prim writer plugin is loaded even when there is already a writer for this type."""
+
+        # Ensure the plugin providing the default mayaUsd translatorsis loaded,
+        # so that 'locator' already has a writer registered.
+        self._preloadMayaUsdTranslators()
+
+        dstLayer = Sdf.Layer.CreateAnonymous()
+        locator = cmds.spaceLocator()
+
+        # 'locator' already has a writer registered. dummyLocatorWriterPlugin declares a writer
+        # for it in its plugInfo.json and must still be discovered and loaded.
+
+        self._assertMayaPluginLoaded('dummyLocatorWriterPlugin', False)
+        cmds.mayaUSDExport(locator, file=dstLayer.identifier)
+        self._assertMayaPluginLoaded('dummyLocatorWriterPlugin', True)
+
+        # After an explicit unload the plugin is not discovered and loaded again.
+        cmds.unloadPlugin('dummyLocatorWriterPlugin')
+        self._assertMayaPluginLoaded('dummyLocatorWriterPlugin', False)
+
+        cmds.mayaUSDExport(locator, file=dstLayer.identifier)
+        self._assertMayaPluginLoaded('dummyLocatorWriterPlugin', False)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
When a PrimReader or a PrimWriter was already registered for a type, for instance by the `mayaUsd_Translators` plugin, which `mayaUsdPlugin` preloads, the registry stopped searching for plugins for that type. Plugins declaring a reader or writer override were then never discovered, so the override mechanism could not be used from a plugin unless that plugin was loaded explicitly.

#### Changes:

- `UsdMayaPrimReaderRegistry::Find` now searches the plugins once per type, at most once for the whole session (c92f6c4311e285d3e543355ddcac1718af5ddbb0).
- `UsdMayaPrimWriterRegistry::CheckForWriterPlugin` now searches the plugins once per type, at most once for the whole session (1b1c566e286174d5cc128ecadd07e98f0fa33c87).
- `UsdMayaPrimWriterRegistry::Find` now delegates the search to `CheckForWriterPlugin` (1b1c566e286174d5cc128ecadd07e98f0fa33c87).
- Add unit tests to verify PrimReader/Writer override plugin discovery (f7e5069a1ac17266057c73b5070a50915265c2ae).

These changes have a side effect: if a plugin providing the last reader/writer for a type is explicitly unloaded, an import/export will no longer automatically re-load it. I personally prefer this behaviour: having unloaded a plugin explicitly, I would rather reload it explicitly too.
