### PR TITLE
PrimUpdaterManager: Call UsdMayaPrimUpdater::editAsMaya on the pulled prim subtree

### DIFF
--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -485,12 +485,18 @@ bool pullCustomize(const PullImportPaths& importedPaths, const UsdMayaPrimUpdate
         auto factory = std::get<UsdMayaPrimUpdaterRegistry::UpdaterFactoryFn>(registryItem);
         auto updater = factory(context, dgNodeFn, pulledUfePath);
 
-        // The failure of a single updater causes failure of the whole
-        // customization step.  This is a frequent difficulty for operations on
-        // multiple data, especially since we can't roll back the result of
-        // the execution of previous updaters.  Revisit this.  PPT, 15-Sep-2021.
-        if (!updater->editAsMaya()) {
-            return false;
+        if (!updater) {
+            TF_WARN(
+                "Could not create a prim updater for path %s during EditAsMaya(), skipping prim.",
+                pulledUfePath.string().c_str());
+        } else {
+            // The failure of a single updater causes failure of the whole
+            // customization step.  This is a frequent difficulty for operations on
+            // multiple data, especially since we can't roll back the result of
+            // the execution of previous updaters.  Revisit this.  PPT, 15-Sep-2021.
+            if (!updater->editAsMaya()) {
+                return false;
+            }
         }
         progressBar.advance();
     }

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -70,14 +70,6 @@
 using UpdaterFactoryFn = UsdMayaPrimUpdaterRegistry::UpdaterFactoryFn;
 using namespace MayaUsd;
 
-// Allow for use of MObjectHandle with std::unordered_map.
-namespace std {
-template <> struct hash<MObjectHandle>
-{
-    std::size_t operator()(const MObjectHandle& obj) const { return obj.hashCode(); }
-};
-} // namespace std
-
 namespace {
 
 const std::string kPullParentPathKey("Maya:Pull:ParentPath");
@@ -292,18 +284,27 @@ UsdMayaJobImportArgs CreateImportArgsForPullImport(const VtDictionary& basicUser
 // prim as the root of the USD hierarchy to be pulled.  The UFE path and
 // the prim refer to the same object: the prim is passed in as an
 // optimization to avoid an additional call to ufePathToPrim().
-using PullImportPaths = std::vector<std::pair<MDagPath, Ufe::Path>>;
-PullImportPaths pullImport(
+struct PullImportResult
+{
+    using NodeAndUfePaths = std::vector<std::pair<MObject, Ufe::Path>>;
+
+    // The topmost DAG nodes created by the import, in the order the read job created them.
+    std::vector<MDagPath> topDagPaths;
+
+    // The Maya node of each prim of the pulled subtree, with the prim's UFE path. Ancestors first.
+    NodeAndUfePaths allPulledPrimNodes;
+};
+PullImportResult pullImport(
     const Ufe::Path&                 ufePulledPath,
     const UsdPrim&                   pulledPrim,
     const UsdMayaPrimUpdaterContext& context)
 {
-    MayaUsd::ProgressBarScope progressBar(9);
+    MayaUsd::ProgressBarScope progressBar(7);
 
     std::string mFileName = context.GetUsdStage()->GetRootLayer()->GetIdentifier();
     if (mFileName.empty()) {
         TF_WARN("Nothing to edit: invalid layer.");
-        return PullImportPaths();
+        return {};
     }
     progressBar.advance();
 
@@ -337,7 +338,7 @@ PullImportPaths pullImport(
     bool success = readJob->Read(&addedDagPaths);
     if (!success || addedDagPaths.size() == 0) {
         TF_WARN("Nothing to edit in the selection.");
-        return PullImportPaths();
+        return {};
     }
     progressBar.advance();
 
@@ -363,7 +364,7 @@ PullImportPaths pullImport(
         if (!utils::ProxyAccessorUndoItem::parentPulledObject(
                 "Pull import proxy accessor parenting", addedDagPath, ufeParent)) {
             TF_WARN("Cannot parent pulled object.");
-            return PullImportPaths();
+            return {};
         }
         progressBar.advance();
 
@@ -394,7 +395,7 @@ PullImportPaths pullImport(
                     return true;
                 })) {
             TF_WARN("Cannot write pull information metadata.");
-            return PullImportPaths();
+            return {};
         }
         progressBar.advance();
 
@@ -406,44 +407,46 @@ PullImportPaths pullImport(
                     return true;
                 })) {
             TF_WARN("Cannot exclude original USD data from viewport rendering.");
-            return PullImportPaths();
+            return {};
         }
         progressBar.advance();
 
         if (!UfeSelectionUndoItem::select("Pull import select DAG node", addedDagPath)) {
             TF_WARN("Cannot select the pulled nodes.");
-            return PullImportPaths();
+            return {};
         }
     }
     progressBar.advance();
 
-    // Invert the new node registry, for MObject to Ufe::Path lookup.
-    using ObjToUfePath = std::unordered_map<MObjectHandle, Ufe::Path>;
-    ObjToUfePath objToUfePath;
-    const auto&  ps = ufePulledPath.getSegments()[0];
-    const auto   rtid = MayaUsd::ufe::getUsdRunTimeId();
-    for (const auto& v : readJob->GetNewNodeRegistry()) {
-        Ufe::Path::Segments s { ps, Ufe::PathSegment(v.first, rtid, '/') };
-        Ufe::Path           p(std::move(s));
-        objToUfePath.insert(ObjToUfePath::value_type(MObjectHandle(v.second), p));
+    // Collect the Maya node imported for each prim of the pulled subtree.
+    // The node registry cannot be used directly: some keys are not real prim paths.
+    const auto& ps = ufePulledPath.getSegments()[0];
+    const auto  rtid = MayaUsd::ufe::getUsdRunTimeId();
+    const auto& nodeRegistry = readJob->GetNewNodeRegistry();
 
-        context._pullExtras.processItem(p, v.second);
-    }
-    progressBar.advance();
+    PullImportResult::NodeAndUfePaths pulledPrimNodes;
+    pulledPrimNodes.reserve(nodeRegistry.size());
 
-    // For each added Dag path, get the UFE path of the pulled USD prim.
-    PullImportPaths pulledPaths;
-    pulledPaths.reserve(addedDagPaths.size());
-    for (const auto& dagPath : addedDagPaths) {
-        auto found = objToUfePath.find(MObjectHandle(dagPath.node()));
-        if (TF_VERIFY(found != objToUfePath.end())) {
-            pulledPaths.emplace_back(std::make_pair(dagPath, found->second));
+    // Widest prim predicate.
+    static const auto allInstancePredicate = UsdTraverseInstanceProxies(UsdPrimAllPrimsPredicate);
+
+    for (const UsdPrim& importedPrim : UsdPrimRange(pulledPrim, allInstancePredicate)) {
+        const auto  primPath = importedPrim.GetPath();
+        const auto& primPathString = primPath.GetString();
+        MObject     mayaObject;
+
+        if (TfMapLookup(nodeRegistry, primPathString, &mayaObject)) {
+            Ufe::Path::Segments s { ps, Ufe::PathSegment(primPathString, rtid, '/') };
+            Ufe::Path           p(std::move(s));
+
+            context._pullExtras.processItem(p, mayaObject);
+
+            pulledPrimNodes.emplace_back(mayaObject, std::move(p));
         }
     }
-    progressBar.advance();
 
     progressBar.advance();
-    return pulledPaths;
+    return { std::move(addedDagPaths), std::move(pulledPrimNodes) };
 }
 
 //------------------------------------------------------------------------------
@@ -466,20 +469,20 @@ UsdMayaPrimUpdaterRegistry::RegisterItem getUpdaterItem(const MFnDependencyNode&
 //------------------------------------------------------------------------------
 //
 // Perform the customization step of the pull (second step).
-bool pullCustomize(const PullImportPaths& importedPaths, const UsdMayaPrimUpdaterContext& context)
+bool pullCustomize(const PullImportResult& pullResult, const UsdMayaPrimUpdaterContext& context)
 {
     // The number of imported paths should (hopefully) never be so great
     // as to overwhelm the computation with progress bar updates.
-    MayaUsd::ProgressBarScope progressBar(importedPaths.size());
+    MayaUsd::ProgressBarScope progressBar(pullResult.allPulledPrimNodes.size());
 
     // Record all USD modifications in an undo block and item.
     UsdUfe::UsdUndoBlock undoBlock(
         &UsdUndoableItemUndoItem::create("Pull customize USD data modifications"));
 
-    for (const auto& importedPair : importedPaths) {
-        const auto&       dagPath = importedPair.first;
+    for (const auto& importedPair : pullResult.allPulledPrimNodes) {
+        const auto&       nodeObject = importedPair.first;
         const auto&       pulledUfePath = importedPair.second;
-        MFnDependencyNode dgNodeFn(dagPath.node());
+        MFnDependencyNode dgNodeFn(nodeObject);
 
         auto registryItem = getUpdaterItem(dgNodeFn);
         auto factory = std::get<UsdMayaPrimUpdaterRegistry::UpdaterFactoryFn>(registryItem);
@@ -1440,14 +1443,14 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
     //    each, for per-prim customization.
 
     // 1) Perform the import
-    PullImportPaths importedPaths = pullImport(path, pulledPrim, context);
-    if (importedPaths.empty()) {
+    PullImportResult pullResult = pullImport(path, pulledPrim, context);
+    if (pullResult.topDagPaths.empty()) {
         return false;
     }
     progressBar.advance();
 
     // 2) Iterate over all imported Dag paths.
-    if (!pullCustomize(importedPaths, context)) {
+    if (!pullCustomize(pullResult, context)) {
         TF_WARN("Failed to customize the edited nodes.");
         return false;
     }
@@ -1455,7 +1458,8 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
 
 #ifdef HAS_ORPHANED_NODES_MANAGER
     if (_orphanedNodesManager) {
-        RecordPullVariantInfoUndoItem::execute(_orphanedNodesManager, path, importedPaths[0].first);
+        RecordPullVariantInfoUndoItem::execute(
+            _orphanedNodesManager, path, pullResult.topDagPaths[0]);
     }
 #endif
 
@@ -1822,7 +1826,7 @@ std::vector<Ufe::Path> PrimUpdaterManager::duplicateToMaya(
     context._pullExtras.initRecursive(Ufe::Hierarchy::createItem(srcPath));
     progressBar.advance();
 
-    PullImportPaths importedPaths = pullImport(srcPath, srcPrim, context);
+    PullImportResult pullResult = pullImport(srcPath, srcPrim, context);
     progressBar.advance();
 
     scopeIt.end();
@@ -1830,8 +1834,8 @@ std::vector<Ufe::Path> PrimUpdaterManager::duplicateToMaya(
     progressBar.advance();
 
     std::vector<Ufe::Path> dstPaths;
-    for (const auto& dagAndUfe : importedPaths)
-        dstPaths.push_back(MayaUsd::ufe::dagPathToUfe(dagAndUfe.first));
+    for (const auto& dagPath : pullResult.topDagPaths)
+        dstPaths.push_back(MayaUsd::ufe::dagPathToUfe(dagPath));
 
     return dstPaths;
 }

--- a/lib/mayaUsd/fileio/primUpdaterManager.cpp
+++ b/lib/mayaUsd/fileio/primUpdaterManager.cpp
@@ -355,7 +355,7 @@ PullImportResult pullImport(
 
     const bool isCopy = context.GetArgs()._copyOperation;
     if (!isCopy) {
-        progressBar.addSteps(4);
+        progressBar.addSteps(3);
         // Since we haven't pulled yet, obtaining the parent is simple, and
         // doesn't require going through the Hierarchy interface, which can do
         // non-trivial work on pulled objects to get their parent.
@@ -395,18 +395,6 @@ PullImportResult pullImport(
                     return true;
                 })) {
             TF_WARN("Cannot write pull information metadata.");
-            return {};
-        }
-        progressBar.advance();
-
-        if (!FunctionUndoItem::execute(
-                "Pull import rendering exclusion",
-                [ufePulledPath]() { return addExcludeFromRendering(ufePulledPath); },
-                [ufePulledPath]() {
-                    removeExcludeFromRendering(ufePulledPath);
-                    return true;
-                })) {
-            TF_WARN("Cannot exclude original USD data from viewport rendering.");
             return {};
         }
         progressBar.advance();
@@ -1411,7 +1399,7 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
         return false;
     }
 
-    MayaUsd::ProgressBarScope progressBar(7, "Converting to Maya Data");
+    MayaUsd::ProgressBarScope progressBar(8, "Converting to Maya Data");
 
     PushPullScope scopeIt(_inPushPull);
 
@@ -1453,6 +1441,20 @@ bool PrimUpdaterManager::editAsMaya(const Ufe::Path& path, const VtDictionary& u
     if (!pullCustomize(pullResult, context)) {
         TF_WARN("Failed to customize the edited nodes.");
         return false;
+    }
+    progressBar.advance();
+
+    if (!updaterArgs._copyOperation) {
+        if (!FunctionUndoItem::execute(
+                "Edit as Maya rendering exclusion",
+                [path]() { return addExcludeFromRendering(path); },
+                [path]() {
+                    removeExcludeFromRendering(path);
+                    return true;
+                })) {
+            TF_WARN("Cannot exclude original USD data from viewport rendering.");
+            return false;
+        }
     }
     progressBar.advance();
 

--- a/test/lib/mayaUsd/fileio/testPrimUpdater.py
+++ b/test/lib/mayaUsd/fileio/testPrimUpdater.py
@@ -20,7 +20,7 @@ import mayaUsd.lib as mayaUsdLib
 from mayaUtils import setMayaTranslation
 from usdUtils import createSimpleXformScene
 
-from pxr import Usd
+from pxr import Usd, Sdf
 
 from maya import cmds
 from maya import standalone
@@ -52,10 +52,19 @@ class primUpdaterAdditionalCommand(ufe.UndoableCommand):
 class primUpdaterTest(mayaUsdLib.PrimUpdater):
     pushCopySpecsCalled = False
     discardEditsCalled = False
-    editAsMayaCalled = False
+    editAsMayaCalledPaths = []
     pushEndCalled = False
     gotValidContext = False
     additionalCmd = None
+
+    @classmethod
+    def cleanUp(cls):
+        cls.editAsMayaCalledPaths = []
+        cls.pushCopySpecsCalled = False
+        cls.discardEditsCalled = False
+        cls.pushEndCalled = False
+        cls.gotValidContext = False
+        cls.additionalCmd = None
 
     def __init__(self, *args, **kwargs):
         super(primUpdaterTest, self).__init__(*args, **kwargs)
@@ -65,7 +74,7 @@ class primUpdaterTest(mayaUsdLib.PrimUpdater):
         return super(primUpdaterTest, self).pushCopySpecs(srcStage, srcLayer, srcSdfPath, dstStage, dstLayer, dstSdfPath)
 
     def editAsMaya(self):
-        primUpdaterTest.editAsMayaCalled = True
+        primUpdaterTest.editAsMayaCalledPaths.append(self.getUsdPrim().GetPath())
         context = self.getContext()
         if context:
             primUpdaterTest.gotValidContext = True
@@ -89,17 +98,19 @@ class testPrimUpdater(unittest.TestCase):
     def setUpClass(cls):
         fixturesUtils.setUpClass(__file__)
         cls.temp_dir = os.path.abspath('.')
+        mayaUsdLib.PrimUpdater.Register(primUpdaterTest, "UsdGeomXform", "transform", primUpdaterTest.Supports.All.value) # primUpdaterTest.Supports.Push.value + primUpdaterTest.Supports.Clear.value + primUpdaterTest.Supports.AutoPull.value)
+
 
     @classmethod
     def tearDownClass(cls):
+        mayaUsdLib.PrimUpdater.Unregister(primUpdaterTest, "UsdGeomXform", "transform", primUpdaterTest.Supports.All.value)
         standalone.uninitialize()
 
     def setUp(self):
         cmds.file(new=True, force=True)
+        primUpdaterTest.cleanUp()
 
     def testSimplePrimUpdater(self):
-        mayaUsdLib.PrimUpdater.Register(primUpdaterTest, "UsdGeomXform", "transform", primUpdaterTest.Supports.All.value) # primUpdaterTest.Supports.Push.value + primUpdaterTest.Supports.Clear.value + primUpdaterTest.Supports.AutoPull.value)
-
         # Edit as Maya first time.
         (ps, xlateOp, usdXlation, aUsdUfePathStr, aUsdUfePath, aUsdItem, _, _, _, _, _) = createSimpleXformScene()
         with mayaUsdLib.OpUndoItemList():
@@ -126,7 +137,7 @@ class testPrimUpdater(unittest.TestCase):
         with mayaUsdLib.OpUndoItemList():
             self.assertTrue(mayaUsdLib.PrimUpdaterManager.mergeToUsd(aMayaPathStr))
 
-        self.assertTrue(primUpdaterTest.editAsMayaCalled)
+        self.assertTrue(primUpdaterTest.editAsMayaCalledPaths)
         self.assertTrue(primUpdaterTest.discardEditsCalled)
         self.assertTrue(primUpdaterTest.pushCopySpecsCalled)
         self.assertTrue(primUpdaterTest.pushEndCalled)
@@ -136,6 +147,20 @@ class testPrimUpdater(unittest.TestCase):
         # self.assertTrue(primUpdaterTest.additionalCmd.executeCalled)
         # self.assertFalse(primUpdaterTest.additionalCmd.undoCalled)
         # self.assertFalse(primUpdaterTest.additionalCmd.redoCalled)
+
+    def testPrimUpdaterEditAsMayaOnSubtree(self):
+        """Test that PrimUpdaterManager runs per-prim customization for imported prims in subtree"""
+        _, _, _, aUsdUfePathStr, _, _, _, _, _, _, _ = createSimpleXformScene()
+
+        # Edit /A as Maya/
+        with mayaUsdLib.OpUndoItemList():
+            self.assertTrue(mayaUsdLib.PrimUpdaterManager.editAsMaya(aUsdUfePathStr))
+
+        # Verify editAsMaya was called for the whole subtree, including /A/B.
+        self.assertSequenceEqual(
+            (Sdf.Path("/A"), Sdf.Path("/A/B")),
+            primUpdaterTest.editAsMayaCalledPaths
+        )
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
This PR changes `PrimUpdaterManager::editAsMaya` so that it calls the `UsdMayaPrimUpdater::editAsMaya` per-prim customization hook on the whole pulled prim subtree. Before, only the topmost pulled DAG path was customized.

We hit this with an in-house updater, but it also affects workflow with a built-in one: editing as Maya an ancestor of a `MayaReference` prim did not call `PxrUsdTranslators_MayaReferenceUpdater::editAsMaya()`, so its attribute specific locking never ran and the stand-in transform stayed fully editable.

This aligns `editAsMaya` with what the other actions already do: `mergeToUsd` calls `UsdMayaPrimUpdater::pushCopySpecs()` on all the prims exported to USD, and `discardEdits` calls `UsdMayaPrimUpdater::discardEdits()` on the whole pulled DAG hierarchy.

### Changes

- c2d844d2a: call the hook on every pulled prim.
- 53c6fd190: move the prim rendering exclusion out of `pullImport()` so that it runs after `pullCustomize()`. The subtree then stays composed while the hooks run, so a nested updater can reach its prim through `getUsdPrim()`. This mirrors `mergeToUsd`, which removes the exclusion before `pushCopySpecs()`.
- 612e1eb0c: guard against a null updater from the factory, as `pushCustomize()`  and `canEditAsMaya()` already do.
- 6864a97d6: unit test on a nested hierarchy.