### PR TITLE
vp2RenderDelegate: Fix rectangle selection when ufe selection is disabled

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/basisCurves.cpp
@@ -1026,7 +1026,7 @@ void HdVP2BasisCurves::_UpdateDrawItem(
         MSelectionMask selectionMask(MSelectionMask::kSelectNurbsCurves);
 
 #ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
-        if (!isBoundingBoxItem) {
+        if (!isBoundingBoxItem && drawScene.WantsSelectPointsForGravity()) {
             // Only unselected Rprims can be used for point snapping.
             if (_selectionStatus == kUnselected) {
                 selectionMask.addMask(MSelectionMask::kSelectPointsForGravity);

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -2196,7 +2196,7 @@ void HdVP2Mesh::_UpdateDrawItem(
         MSelectionMask selectionMask(MSelectionMask::kSelectMeshes);
 
 #ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
-        if (!isBBoxItem) {
+        if (!isBBoxItem && drawScene.WantsSelectPointsForGravity()) {
             bool shadedUnselectedInstances
                 = !isShadedSelectedInstanceItem && !GetInstancerId().IsEmpty();
             if (_selectionStatus == kUnselected || drawScene.SnapToSelectedObjects()

--- a/lib/mayaUsd/render/vp2RenderDelegate/points.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/points.cpp
@@ -715,7 +715,7 @@ void HdVP2Points::_UpdateDrawItem(
         MSelectionMask selectionMask(MSelectionMask::kSelectParticleShapes);
 
 #ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
-        if (!isBoundingBoxItem) {
+        if (!isBoundingBoxItem && drawScene.WantsSelectPointsForGravity()) {
             // Only unselected Rprims can be used for point snapping.
             if (_selectionStatus == kUnselected) {
                 selectionMask.addMask(MSelectionMask::kSelectPointsForGravity);

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.cpp
@@ -1116,9 +1116,31 @@ void ProxyRenderDelegate::_Execute(const MHWRender::MFrameContext& frameContext)
     _changeVersions.sync(changeTracker);
 
 #ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
-    if (_selectionModeChanged || (_selectionChanged && !inSelectionPass)
-        || forcePopulateSelection) {
-        _UpdateSelectionStates();
+    // kSelectPointsForGravity is what makes the renderItem compatible with point
+    // snapping, it has to be set during a point snapping render.
+    // But when Maya resolves a DAG selection given by getInstancedSelectionPath(), a hit
+    // on a render item with kSelectPointsForGravity flag will enforce a single selection,
+    // dropping the other objects caught by e.g. a rectangle selection.
+    // So we only set the flag on the render items during point snapping to avoid that.
+    bool wantsSelectPointsForGravity = _snapToPoints;
+
+    // With ufeSelection enabled, and when not pointSnapping, getInstancedSelectionPath()
+    // populates the maya selection directly through UFE, and kSelectPointsForGravity
+    // has no effect.
+    // In this case we can leave the flag set and avoid useless updates.
+    if (_proxyShapeData->ProxyShape() && _proxyShapeData->ProxyShape()->isUfeSelectionEnabled()) {
+        wantsSelectPointsForGravity = true;
+    }
+
+    bool wantsSelectPointsForGravityChanged = false;
+    if (wantsSelectPointsForGravity != _wantsSelectPointsForGravity) {
+        _wantsSelectPointsForGravity = wantsSelectPointsForGravity;
+        wantsSelectPointsForGravityChanged = true;
+    }
+
+    if (_selectionModeChanged || (_selectionChanged && !inSelectionPass) || forcePopulateSelection
+        || wantsSelectPointsForGravityChanged) {
+        _UpdateSelectionStates(/*dirtyAllRprims=*/wantsSelectPointsForGravityChanged);
         _selectionChanged = false;
         _selectionModeChanged = false;
     }
@@ -1801,23 +1823,22 @@ void ProxyRenderDelegate::_PopulateSelection()
 }
 
 /*! \brief  Notify selection change to rprims.
+    \param dirtyAllRprims  Mark every rprim dirty rather than only the selected ones.
+                           Also raised internally based on the display status.
  */
-void ProxyRenderDelegate::_UpdateSelectionStates()
+void ProxyRenderDelegate::_UpdateSelectionStates(bool dirtyAllRprims)
 {
     const MHWRender::DisplayStatus previousStatus = _displayStatus;
     _displayStatus = MHWRender::MGeometryUtilities::displayStatus(_proxyShapeData->ProxyDagPath());
 
-    SdfPathVector        rootPaths;
-    const SdfPathVector* dirtyPaths = nullptr;
+    SdfPathVector rootPaths;
 
     if (_displayStatus == MHWRender::kLead || _displayStatus == MHWRender::kActive) {
         if (_displayStatus != previousStatus) {
-            rootPaths.push_back(SdfPath::AbsoluteRootPath());
-            dirtyPaths = &_renderIndex->GetRprimIds();
+            dirtyAllRprims = true;
         }
     } else if (previousStatus == MHWRender::kLead || previousStatus == MHWRender::kActive) {
-        rootPaths.push_back(SdfPath::AbsoluteRootPath());
-        dirtyPaths = &_renderIndex->GetRprimIds();
+        dirtyAllRprims = true;
         _PopulateSelection();
     } else {
         // Append pre-update lead and active selection.
@@ -1830,14 +1851,15 @@ void ProxyRenderDelegate::_UpdateSelectionStates()
         // Append post-update lead and active selection.
         AppendSelectedPrimPaths(_leadSelection, rootPaths);
         AppendSelectedPrimPaths(_activeSelection, rootPaths);
+    }
 
-        dirtyPaths = &rootPaths;
+    if (dirtyAllRprims) {
+        rootPaths = { SdfPath::AbsoluteRootPath() };
     }
 
     if (!rootPaths.empty()) {
         // When the selection changes then we have to update all the selected render
         // items. Set a dirty flag on each of the rprims so they know what to update.
-        // Avoid trying to set dirty the absolute root as it is not a Rprim.
         HdDirtyBits dirtySelectionBits = MayaUsdRPrim::DirtySelectionHighlight;
 #ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
         // If the selection mode changes, for example into or out of point snapping,
@@ -1846,9 +1868,17 @@ void ProxyRenderDelegate::_UpdateSelectionStates()
             dirtySelectionBits |= MayaUsdRPrim::DirtySelectionMode;
 #endif
         HdChangeTracker& changeTracker = _renderIndex->GetChangeTracker();
-        for (auto path : *dirtyPaths) {
-            if (_renderIndex->HasRprim(path))
+
+        if (dirtyAllRprims) {
+            for (const auto& path : _renderIndex->GetRprimIds()) {
                 changeTracker.MarkRprimDirty(path, dirtySelectionBits);
+            }
+        } else {
+            // rootPaths selection may still reference paths that are no longer Rprims.
+            for (const auto& path : rootPaths) {
+                if (_renderIndex->HasRprim(path))
+                    changeTracker.MarkRprimDirty(path, dirtySelectionBits);
+            }
         }
 
         // now that the appropriate prims have been marked dirty trigger
@@ -2287,6 +2317,11 @@ UsdImagingDelegate* ProxyRenderDelegate::GetUsdImagingDelegate() const
 #ifdef MAYA_NEW_POINT_SNAPPING_SUPPORT
 bool ProxyRenderDelegate::SnapToSelectedObjects() const { return _snapToSelectedObjects; }
 bool ProxyRenderDelegate::SnapToPoints() const { return _snapToPoints; }
+
+bool ProxyRenderDelegate::WantsSelectPointsForGravity() const
+{
+    return _wantsSelectPointsForGravity;
+}
 #endif
 
 // ProxyShapeData

--- a/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
+++ b/lib/mayaUsd/render/vp2RenderDelegate/proxyRenderDelegate.h
@@ -257,6 +257,9 @@ public:
 
     MAYAUSD_CORE_PUBLIC
     bool SnapToPoints() const;
+
+    MAYAUSD_CORE_PUBLIC
+    bool WantsSelectPointsForGravity() const;
 #endif
 
     static void setLongDurationRendering();
@@ -278,7 +281,7 @@ private:
 
     bool   _isInitialized();
     void   _PopulateSelection();
-    void   _UpdateSelectionStates();
+    void   _UpdateSelectionStates(bool dirtyAllRprims = false);
     void   _UpdateRenderTags();
     void   _ClearRenderDelegate();
     MColor _GetDisplayColor(
@@ -392,6 +395,10 @@ private:
     bool _snapToSelectedObjects {
         false
     }; //!< Whether point snapping should snap to selected objects
+
+    bool _wantsSelectPointsForGravity {
+        true
+    }; //!< Whether the kSelectPointsForGravity flag should be set on the render items
 #endif
 
     std::mutex _mayaCommandEngineMutex;

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/CMakeLists.txt
@@ -23,6 +23,7 @@ if (MAYA_APP_VERSION VERSION_GREATER 2022)
     list(APPEND TEST_SCRIPT_FILES_LAMBERT
         testVP2RenderDelegateSelection.py
         testVP2RenderDelegateUsdSkel.py
+        testVP2RenderDelegateMarqueeSelection.py
     )
 endif()
 

--- a/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateMarqueeSelection.py
+++ b/test/lib/mayaUsd/render/vp2RenderDelegate/testVP2RenderDelegateMarqueeSelection.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env mayapy
+#
+# Copyright 2026 Autodesk
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from maya import cmds
+from maya.api import OpenMayaUI as OMUI
+
+import fixturesUtils
+
+import unittest
+
+import ufe
+import mayaUtils
+
+try:
+    from PySide2 import QtCore
+    from PySide2.QtWidgets import QWidget
+    from shiboken2 import wrapInstance
+except Exception:
+    from PySide6 import QtCore
+    from PySide6.QtWidgets import QWidget
+    from shiboken6 import wrapInstance
+
+import qtInputHelpers
+
+
+class testVP2RenderDelegateMarqueeSelection(unittest.TestCase):
+    """
+    Tests marquee selection behaviour with proxyShapes.
+    """
+    @classmethod
+    def setUpClass(cls):
+        fixturesUtils.setUpClass(__file__, initializeStandalone=False)
+
+    def setUp(self):
+        cmds.file(new=True, force=True)
+
+    def _processViewEvents(self, timeout=10):
+        '''
+        Helper that forces Maya to process events.
+        '''
+        QtCore.QCoreApplication.processEvents(QtCore.QEventLoop.ProcessEventsFlag.AllEvents, timeout)
+
+    def _dragSelectActiveView(self):
+        '''
+        Helper that drags-select (region-select) the whole viewport.
+        '''
+        view = OMUI.M3dView.active3dView()
+        viewWidget = wrapInstance(int(view.widget()), QWidget)
+
+        viewWidget.update()
+        self._processViewEvents()
+
+        top_left = viewWidget.rect().topLeft() + QtCore.QPoint(1, 1)
+        bottom_right = viewWidget.rect().bottomRight() - QtCore.QPoint(1, 1)
+        qtInputHelpers.send_mouse_drag(viewWidget, top_left, bottom_right)
+
+    def _createProxyWithCube(self, translation, enableUfeSelection):
+        '''
+        Create a proxy shape holding a single cube prim.
+        Returns the UFE path of what a viewport selection is expected to pick.
+        '''
+        proxyShape, stage = mayaUtils.createProxyAndStage()
+        stage.DefinePrim('/cube', 'Cube')
+
+        transform = cmds.listRelatives(proxyShape, parent=True, fullPath=True)[0]
+        cmds.xform(transform, translation=translation)
+        cmds.setAttr(f'{proxyShape}.enableUfeSelection', enableUfeSelection)
+
+        return f'{proxyShape},/cube' if enableUfeSelection else transform
+
+    def _createMultipleProxiesWithCube(self, enableUfeSelection, translateY=0.0):
+        '''
+        Create three proxy shapes side by side, on the given row.
+        Returns the UFE paths of what a viewport selection is expected to pick.
+        '''
+        return [
+            self._createProxyWithCube((translateX, translateY, 0), enableUfeSelection)
+            for translateX in (-4.0, 0.0, 4.0)
+        ]
+
+    def _verifyMarqueeSelectsEveryUfePath(self, expectedUfePaths):
+        '''
+        Marquee-select the whole viewport and compare the global selection with the expected paths.
+        '''
+        globalSel = ufe.GlobalSelection.get()
+        globalSel.clear()
+
+        cmds.viewFit(all=True)
+        self._processViewEvents()
+        self._dragSelectActiveView()
+
+        selected = [ufe.PathString.string(item.path()) for item in globalSel]
+        self.assertEqual(sorted(selected), sorted(expectedUfePaths))
+
+    def testMarqueeSelectsEveryProxyShape(self):
+        '''
+        A rectangle over several proxy shapes must select them all.
+        It used to select only one proxyShape with ufeSelectionEnabled turned off.
+        '''
+        selectable = self._createMultipleProxiesWithCube(enableUfeSelection=False)
+
+        self._verifyMarqueeSelectsEveryUfePath(selectable)
+
+    def testMarqueeSelectsEveryUfePrim(self):
+        '''
+        A rectangle over proxyShapes with ufeSelectionEnabled turned on must select
+        all the prims.
+        '''
+        selectable = self._createMultipleProxiesWithCube(enableUfeSelection=True)
+
+        self._verifyMarqueeSelectsEveryUfePath(selectable)
+
+    def testMarqueeSelectsMixedItems(self):
+        '''
+        A rectangle over proxyShapes in both ufeSelection modes and a native Maya mesh
+        must select them all.
+        '''
+        selectable = self._createMultipleProxiesWithCube(
+            enableUfeSelection=False, translateY=-2.0)
+
+        selectable += self._createMultipleProxiesWithCube(
+            enableUfeSelection=True, translateY=2.0)
+
+        mayaCube = cmds.polyCube(name='mayaCube')[0]
+        cmds.setAttr(f'{mayaCube}.translateY', 8.0)
+        selectable.append(cmds.ls(mayaCube, long=True)[0])
+
+        self._verifyMarqueeSelectsEveryUfePath(selectable)
+
+
+if __name__ == '__main__':
+    fixturesUtils.runTests(globals())


### PR DESCRIPTION
This PR fixes issues with rectangle selection when a `mayaUsdProxyShape` has ufe selection disabled (through the new `enableUfeSelection` attribute, or with the `pxrUsdProxyShape` that hard-disables ufe selection).

- Before this change, only a single shape disabled could be selected in this case:

<img width="632" height="304" alt="vpRenderDelegate_marquee_selection_issue" src="https://github.com/user-attachments/assets/8e0832f2-0fa2-476d-aebe-d9cc49b19be1" />

- After this change:

<img width="632" height="304" alt="vpRenderDelegate_marquee_selection_fixed" src="https://github.com/user-attachments/assets/e5f90c7f-2073-4139-82fc-c2946da5c417" />

### Details

To make the renderItems compatible with point snapping, vp2RenderDelegate sets `MSelectionMask::kSelectPointsForGravity` on its render items.

But when Maya resolves a DAG selection given by `getInstancedSelectionPath()`, a hit on a render item with the `kSelectPointsForGravity` flag makes it enforce a single selection, dropping the other objects caught by e.g. a rectangle selection. This causes an issue when ufe selection is disabled as we let maya update the scene selection: we cannot select multiple shapes from the viewport when at least a proxyShape is caught by the user selection.

To fix this, this change ensures the flag is not set during the selection passes where it is harmful (non point snapping), and that it is set during the point snapping passes that need it.

With ufe selection enabled, and when not in pointSnapping, `getInstancedSelectionPath()` populates the maya selection directly through UFE, and `kSelectPointsForGravity` has no effect. In this case we always leave the flag set, which avoids useless updates that could add latency on each point snapping transition.

### Changes

- ce1ee9f8: ProxyRenderDelegate::_Execute now determines whether the flag is needed on the render items in the current rendering context. When that decision changes, it triggers an update, and the render items build their selection mask from that same value

- 5251449: add related unit-tests
