### PR TITLE
vp2RenderDelegate: Shorter render item names for geom subsets

### DIFF
--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -2656,14 +2656,8 @@ HdVP2DrawItem::RenderItemData& HdVP2Mesh::_CreateSmoothHullRenderItem(
     MSubSceneContainer& subSceneContainer,
     const HdGeomSubset* geomSubset) const
 {
-    MString itemName = name;
-    if (geomSubset) {
-        itemName += std::string(1, VP2_RENDER_DELEGATE_SEPARATOR).c_str();
-        itemName += geomSubset->id.GetString().c_str();
-    }
-
     MHWRender::MRenderItem* const renderItem = MHWRender::MRenderItem::Create(
-        itemName, MHWRender::MRenderItem::MaterialSceneItem, MHWRender::MGeometry::kTriangles);
+        name, MHWRender::MRenderItem::MaterialSceneItem, MHWRender::MGeometry::kTriangles);
 
     MHWRender::MGeometry::DrawMode drawMode = static_cast<MHWRender::MGeometry::DrawMode>(
         MHWRender::MGeometry::kShaded | MHWRender::MGeometry::kTextured);

--- a/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
+++ b/lib/mayaUsd/render/vp2RenderDelegate/mesh.cpp
@@ -1380,6 +1380,8 @@ void HdVP2Mesh::_CreateSmoothHullRenderItems(
     _meshSharedData->_faceIdToGeomSubsetId.clear();
     _meshSharedData->_faceIdToGeomSubsetId.resize(topology.GetNumFaces(), SdfPath::EmptyPath());
 
+    TfToken::Set usedSubsetSuffixes;
+
     // Create the geom subset render items, and fill in the face to subset item mapping for later
     // use.
     for (const auto& geomSubset : geomSubsets) {
@@ -1395,9 +1397,14 @@ void HdVP2Mesh::_CreateSmoothHullRenderItems(
         if (SdfPath::EmptyPath() == geomSubset.materialId)
             continue;
 
+        // We expect that subsets of a mesh are sibling prims, so their names are unique.
+        const auto& subsetItemSuffix = geomSubset.id.GetNameToken();
+        if (!TF_VERIFY(usedSubsetSuffixes.insert(subsetItemSuffix).second))
+            continue;
+
         MString renderItemName = drawItem.GetDrawItemName();
         renderItemName += std::string(1, VP2_RENDER_DELEGATE_SEPARATOR).c_str();
-        renderItemName += geomSubset.id.GetString().c_str();
+        renderItemName += subsetItemSuffix.GetText();
         _CreateSmoothHullRenderItem(
             renderItemName, drawItem, reprToken, subSceneContainer, &geomSubset);
 
@@ -2636,9 +2643,11 @@ MHWRender::MRenderItem* HdVP2Mesh::_CreateShadedSelectedInstancesItem(
     MSubSceneContainer& subSceneContainer,
     const HdGeomSubset* geomSubset) const
 {
+    // Suffixed with an illegal USD identifier, so it does not collide with a geom subset name.
     MString ssiName = name;
     ssiName += std::string(1, VP2_RENDER_DELEGATE_SEPARATOR).c_str();
-    ssiName += "shadedSelectedInstances";
+    ssiName += "<shadedSelectedInstances>";
+
     HdVP2DrawItem::RenderItemData& renderItemData
         = _CreateSmoothHullRenderItem(ssiName, drawItem, reprToken, subSceneContainer, geomSubset);
     renderItemData._shadedSelectedInstances = true;


### PR DESCRIPTION
This PR changes the internal naming of the render items representing mesh geom subsets, making them much shorter.
Mostly this helps profiling and debugging with more readable names, and it saves a little memory in large stages, with long prim paths and many geom subsets.

1) The geom subset path was added twice to the render item name, e.g.
`/Proxy_shape1_0x9e3de90/cube;DrawItem_0x1b0e0a70;/Proxy_shape1_0x9e3de90/cube/subset;/Proxy_stageShape1_0x9e3de90/cube/subset`
   The first commit 6835fed62d02c0d4a59ea84788f49cf90b610606 removes the extra suffixing in `HdVP2Mesh::_CreateSmoothHullRenderItem`, the name is already suffixed at the call site, the item becomes:
   `/Proxy_shape1_0x9e3de90/cube;DrawItem_0x1b0e0a70;/Proxy_shape1_0x9e3de90/cube/subset`
   
2) The full subset path is not needed, the suffix only has to distinguish the items of a single draw item, that is the subsets of one mesh, and those are unique because these subset prims are siblings.
   The second commit 0d4e36fe0980a205676ed18c5a5bf67744b2b291 uses the name token, the item becomes:
   `/Proxy_shape1_0x9e3de90/cube;DrawItem_0x1b0e0a70;subset`
   It also changes the name of the `shadedSelectedInstances` item so that it cannot collide with a subset:
   `/Proxy_shape1_0x9e3de90/cube;DrawItem_0x1b0e0a70;<shadedSelectedInstances>`

Nothing in the code base parses these names beyond the rprim id prefix extracted by `RenderItemToPrimPath()`.